### PR TITLE
Rename ChEMBL activity stage docs

### DIFF
--- a/docs/02-pipelines/04-unified-output-writer.md
+++ b/docs/02-pipelines/04-unified-output-writer.md
@@ -104,6 +104,6 @@ JSON-файл с путями к артефактам и метаданными:
 
 - **RunArtifacts**: объект с путями к артефактам
 - **WriteResult**: результат операции записи
-- **ActivityWriter**: использует UnifiedOutputWriter для записи результатов (см. `docs/02-pipelines/chembl/activity/03-activity-chembl-write.md`)
+- **ActivityWriter**: использует UnifiedOutputWriter для записи результатов (см. `docs/02-pipelines/chembl/activity/03-activity-chembl-io.md`)
 - **SchemaRegistry**: используется для валидации данных перед записью (см. `docs/02-pipelines/05-schema-registry.md`)
 

--- a/docs/02-pipelines/chembl/14-chembl-client.md
+++ b/docs/02-pipelines/chembl/14-chembl-client.md
@@ -54,5 +54,5 @@ request = client.request_activity(ids=["CHEMBL123"], filters={"assay_type": "B"}
 - **ConfiguredHttpClient**: базовый класс унифицированного HTTP-клиента
 - **ChemblRequestBuilder**: построитель запросов для ChEMBL (см. `docs/02-pipelines/chembl/15-chembl-request-builder.md`)
 - **RequestsBackend**: HTTP-бэкенд на основе requests (см. `docs/02-pipelines/chembl/16-requests-backend.md`)
-- **ActivityExtractor**: использует клиент для извлечения данных (см. `docs/02-pipelines/chembl/activity/01-activity-chembl-extract.md`)
+- **ActivityExtractor**: использует клиент для извлечения данных (см. `docs/02-pipelines/chembl/activity/01-activity-chembl-extraction.md`)
 

--- a/docs/02-pipelines/chembl/INDEX.md
+++ b/docs/02-pipelines/chembl/INDEX.md
@@ -11,9 +11,9 @@
 ### Activity
 
 - [00 Activity ChEMBL Overview](../activity/00-activity-chembl-overview.md) — основной пайплайн для обработки данных биоактивности
-- [01 Activity ChEMBL Extract](../activity/01-activity-chembl-extract.md) — стадия извлечения данных
-- [02 Activity ChEMBL Transform](../activity/02-activity-chembl-transform.md) — стадия трансформации данных
-- [03 Activity ChEMBL Write](../activity/03-activity-chembl-write.md) — стадия записи результатов
+- [01 Activity ChEMBL Extraction](../activity/01-activity-chembl-extraction.md) — стадия извлечения данных
+- [02 Activity ChEMBL Transformation](../activity/02-activity-chembl-transformation.md) — стадия трансформации данных
+- [03 Activity ChEMBL IO](../activity/03-activity-chembl-io.md) — стадия записи результатов
 - [INDEX](../activity/INDEX.md) — полный индекс документации по Activity
 
 ### Assay

--- a/docs/02-pipelines/chembl/activity/00-activity-chembl-overview.md
+++ b/docs/02-pipelines/chembl/activity/00-activity-chembl-overview.md
@@ -104,9 +104,9 @@
 
 ## Related Components
 
-- **ActivityExtractor**: стадия извлечения данных (см. `01-activity-chembl-extract.md`)
-- **ActivityTransformer**: стадия трансформации данных (см. `02-activity-chembl-transform.md`)
-- **ActivityWriter**: стадия записи результатов (см. `03-activity-chembl-write.md`)
+- **ActivityExtractor**: стадия извлечения данных (см. `01-activity-chembl-extraction.md`)
+- **ActivityTransformer**: стадия трансформации данных (см. `02-activity-chembl-transformation.md`)
+- **ActivityWriter**: стадия записи результатов (см. `03-activity-chembl-io.md`)
 - **ActivityParser**: парсер ответов ChEMBL API (см. `04-activity-chembl-parser.md`)
 - **ActivityNormalizer**: нормализатор данных активности (см. `05-activity-chembl-normalizer.md`)
 - **ChemblClient**: REST-клиент для ChEMBL API (см. `docs/02-pipelines/01-base-external-data-client.md`)

--- a/docs/02-pipelines/chembl/activity/01-activity-chembl-extraction.md
+++ b/docs/02-pipelines/chembl/activity/01-activity-chembl-extraction.md
@@ -1,4 +1,4 @@
-# 01 Activity ChEMBL Extract
+# 01 Activity ChEMBL Extraction
 
 ## Описание
 

--- a/docs/02-pipelines/chembl/activity/02-activity-chembl-transformation.md
+++ b/docs/02-pipelines/chembl/activity/02-activity-chembl-transformation.md
@@ -1,4 +1,4 @@
-# 02 Activity ChEMBL Transform
+# 02 Activity ChEMBL Transformation
 
 ## Описание
 

--- a/docs/02-pipelines/chembl/activity/03-activity-chembl-io.md
+++ b/docs/02-pipelines/chembl/activity/03-activity-chembl-io.md
@@ -1,4 +1,4 @@
-# 03 Activity ChEMBL Write
+# 03 Activity ChEMBL IO
 
 ## Описание
 

--- a/docs/02-pipelines/chembl/activity/04-activity-chembl-parser.md
+++ b/docs/02-pipelines/chembl/activity/04-activity-chembl-parser.md
@@ -36,5 +36,5 @@
 ## Related Components
 
 - **ColumnMapping**: структура сопоставления колонок (см. `docs/02-pipelines/chembl/activity/11-activity-chembl-column-mapping.md`)
-- **ActivityExtractor**: использует парсер для преобразования ответов API (см. `docs/02-pipelines/chembl/activity/01-activity-chembl-extract.md`)
+- **ActivityExtractor**: использует парсер для преобразования ответов API (см. `docs/02-pipelines/chembl/activity/01-activity-chembl-extraction.md`)
 

--- a/docs/02-pipelines/chembl/activity/05-activity-chembl-normalizer.md
+++ b/docs/02-pipelines/chembl/activity/05-activity-chembl-normalizer.md
@@ -38,5 +38,5 @@
 
 - **BaseChemblNormalizer**: базовый нормализатор для ChEMBL (см. `docs/02-pipelines/chembl/activity/08-base-chembl-normalizer.md`)
 - **ColumnNormalizationSpec**: спецификация нормализации колонки (см. `docs/02-pipelines/chembl/activity/10-activity-chembl-column-spec.md`)
-- **ActivityTransformer**: использует нормализатор для трансформации данных (см. `docs/02-pipelines/chembl/activity/02-activity-chembl-transform.md`)
+- **ActivityTransformer**: использует нормализатор для трансформации данных (см. `docs/02-pipelines/chembl/activity/02-activity-chembl-transformation.md`)
 

--- a/docs/02-pipelines/chembl/activity/07-activity-chembl-descriptor.md
+++ b/docs/02-pipelines/chembl/activity/07-activity-chembl-descriptor.md
@@ -35,6 +35,6 @@
 ## Related Components
 
 - **BatchPlan**: план батчирования запросов (см. `docs/02-pipelines/chembl/activity/09-activity-chembl-batch-plan.md`)
-- **ActivityExtractor**: использует дескриптор для извлечения данных (см. `docs/02-pipelines/chembl/activity/01-activity-chembl-extract.md`)
+- **ActivityExtractor**: использует дескриптор для извлечения данных (см. `docs/02-pipelines/chembl/activity/01-activity-chembl-extraction.md`)
 - **ChemblActivityPipeline**: создаёт дескриптор через `build_descriptor()` (см. `docs/02-pipelines/chembl/activity/00-activity-chembl-overview.md`)
 

--- a/docs/02-pipelines/chembl/activity/09-activity-chembl-batch-plan.md
+++ b/docs/02-pipelines/chembl/activity/09-activity-chembl-batch-plan.md
@@ -35,5 +35,5 @@ batch_plan = BatchPlan(
 ## Related Components
 
 - **ChemblExtractionDescriptor**: содержит BatchPlan для управления извлечением (см. `docs/02-pipelines/chembl/activity/07-activity-chembl-descriptor.md`)
-- **ActivityExtractor**: использует BatchPlan для разбиения запросов на батчи (см. `docs/02-pipelines/chembl/activity/01-activity-chembl-extract.md`)
+- **ActivityExtractor**: использует BatchPlan для разбиения запросов на батчи (см. `docs/02-pipelines/chembl/activity/01-activity-chembl-extraction.md`)
 

--- a/docs/02-pipelines/chembl/activity/13-activity-chembl-artifacts.md
+++ b/docs/02-pipelines/chembl/activity/13-activity-chembl-artifacts.md
@@ -72,6 +72,6 @@
 
 ## Related Components
 
-- **ActivityWriter**: стадия записи результатов (см. `docs/02-pipelines/chembl/activity/03-activity-chembl-write.md`)
+- **ActivityWriter**: стадия записи результатов (см. `docs/02-pipelines/chembl/activity/03-activity-chembl-io.md`)
 - **UnifiedOutputWriter**: унифицированный writer для записи (см. `docs/02-pipelines/04-unified-output-writer.md`)
 

--- a/docs/02-pipelines/chembl/activity/INDEX.md
+++ b/docs/02-pipelines/chembl/activity/INDEX.md
@@ -8,9 +8,9 @@
 
 ## Стадии пайплайна
 
-- [01 Activity ChEMBL Extract](01-activity-chembl-extract.md) — стадия извлечения данных из ChEMBL API
-- [02 Activity ChEMBL Transform](02-activity-chembl-transform.md) — стадия трансформации и нормализации данных
-- [03 Activity ChEMBL Write](03-activity-chembl-write.md) — стадия записи результатов и генерации артефактов
+- [01 Activity ChEMBL Extraction](01-activity-chembl-extraction.md) — стадия извлечения данных из ChEMBL API
+- [02 Activity ChEMBL Transformation](02-activity-chembl-transformation.md) — стадия трансформации и нормализации данных
+- [03 Activity ChEMBL IO](03-activity-chembl-io.md) — стадия записи результатов и генерации артефактов
 
 ## Компоненты обработки данных
 


### PR DESCRIPTION
## Summary
- rename ChEMBL activity stage documentation files to new extraction/transformation/io names
- update headings and cross-references across pipeline docs and indices

## Testing
- not run (documentation changes only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e387eac5c8324a5a8bdbdbfada578)