### PR TITLE
Rename styleguide quick reference docs to kebab-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ BioETL is a data processing framework for acquiring, normalizing, and validating
 Проект следует строгим правилам именования, архитектуры и документации:
 
 - **Основные правила**: `.cursorrules` — правила для AI-ассистента и разработчиков
-- **Краткая сводка**: `docs/00-styleguide/RULES_QUICK_REFERENCE.md` — быстрый справочник
-- **Memories**: `docs/00-styleguide/MEMORIES.md` — ключевые правила для запоминания
+- **Краткая сводка**: `docs/00-styleguide/00-rules-quick-reference.md` — быстрый справочник
+- **Memories**: `docs/00-styleguide/00-memories.md` — ключевые правила для запоминания
 
 ## Документация
 

--- a/docs/00-styleguide/00-memories.md
+++ b/docs/00-styleguide/00-memories.md
@@ -1,4 +1,4 @@
-# Memories для проекта BioETL
+# 00 Memories для проекта BioETL
 
 Этот файл содержит ключевые правила и паттерны, которые должны быть запомнены при работе с проектом.
 
@@ -203,7 +203,7 @@ def write_atomic(path: Path, content: str) -> None:
 - `docs/00-styleguide/02-new-entity-naming-policy.md` — полная политика именования (regex, таблицы правил)
 - `docs/00-styleguide/03-python-code-style.md` — стиль Python кода (PEP 8, типы, mypy)
 - `docs/00-styleguide/10-documentation-standards.md` — стандарты документации (синхронизация, автогенерация)
-- `docs/00-styleguide/RULES_QUICK_REFERENCE.md` — краткая сводка для быстрого доступа
+- `docs/00-styleguide/00-rules-quick-reference.md` — краткая сводка для быстрого доступа
 
 ### Реестры и конфигурации
 - `src/bioetl/clients/base/abc_registry.yaml` — машинный реестр ABC (source of truth)

--- a/docs/00-styleguide/00-rules-quick-reference.md
+++ b/docs/00-styleguide/00-rules-quick-reference.md
@@ -1,4 +1,4 @@
-# Краткая сводка правил проекта (Quick Reference)
+# 00 Rules Quick Reference
 
 > **Примечание**: Это краткая сводка. Полные документы см. в `docs/styleguide/`
 


### PR DESCRIPTION
## Summary
- rename the styleguide memories and quick reference documents to kebab-case with numeric prefixes
- update references in the documentation to the new filenames

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e3c6eae908324bbaabc877799c9af)