### PR TITLE
Ensure CSV writer uses atomic temp file and checksum

### DIFF
--- a/src/bioetl/infrastructure/output/impl/csv_writer.py
+++ b/src/bioetl/infrastructure/output/impl/csv_writer.py
@@ -1,3 +1,5 @@
+import hashlib
+import os
 import time
 from pathlib import Path
 import pandas as pd
@@ -16,19 +18,30 @@ class CsvWriterImpl(WriterABC):
 
     def write(self, df: pd.DataFrame, path: Path) -> WriteResult:
         start_time = time.monotonic()
-        
-        df.to_csv(path, index=False, encoding="utf-8")
-        
+
+        tmp_path = path.with_suffix(".tmp")
+
+        df.to_csv(tmp_path, index=False, encoding="utf-8")
+        os.replace(tmp_path, path)
+
+        checksum = self._compute_checksum(path)
+
         duration = time.monotonic() - start_time
-        
-        # Checksum calculation is done by UnifiedOutputWriter wrapper
+
         return WriteResult(
             path=path,
             row_count=len(df),
-            checksum="", 
+            checksum=checksum,
             duration_sec=duration,
         )
 
     def supports_format(self, fmt: str) -> bool:
         return fmt.lower() == "csv"
+
+    def _compute_checksum(self, path: Path) -> str:
+        sha256 = hashlib.sha256()
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(8192), b""):
+                sha256.update(chunk)
+        return sha256.hexdigest()
 


### PR DESCRIPTION
## Summary
- write CSV output to a temporary file and replace atomically while computing checksum
- update CSV writer tests to assert checksum and atomic temp-file usage

## Testing
- pytest tests/output/test_writers.py *(fails: ModuleNotFoundError: No module named 'pandas')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f002f7bb88324adc126dd7d4d026f)