### PR TITLE
Add custom identifier normalizers and integration

### DIFF
--- a/src/bioetl/core/__init__.py
+++ b/src/bioetl/core/__init__.py
@@ -8,6 +8,16 @@ from bioetl.domain.models import RunContext, RunResult
 from bioetl.application.pipelines.base import PipelineBase
 from bioetl.application.pipelines.stages import StageABC, StageResult
 from bioetl.core.container import PipelineContainer, build_pipeline_dependencies
+from bioetl.core.custom_types import (
+    CUSTOM_FIELD_NORMALIZERS,
+    normalize_array,
+    normalize_chembl_id,
+    normalize_doi,
+    normalize_pcid,
+    normalize_pmid,
+    normalize_record,
+    normalize_uniprot,
+)
 
 __all__ = [
     "ErrorAction",
@@ -20,4 +30,12 @@ __all__ = [
     "StageResult",
     "PipelineContainer",
     "build_pipeline_dependencies",
+    "CUSTOM_FIELD_NORMALIZERS",
+    "normalize_array",
+    "normalize_chembl_id",
+    "normalize_doi",
+    "normalize_pcid",
+    "normalize_pmid",
+    "normalize_record",
+    "normalize_uniprot",
 ]

--- a/src/bioetl/core/custom_types.py
+++ b/src/bioetl/core/custom_types.py
@@ -1,0 +1,187 @@
+"""Utility normalizers for domain-specific identifiers and records."""
+from __future__ import annotations
+
+import re
+from typing import Any, Callable, Iterable, Mapping, MutableMapping
+
+import pandas as pd
+
+
+def _is_missing(value: Any) -> bool:
+    if value is None:
+        return True
+    try:
+        return bool(pd.isna(value))
+    except (ValueError, TypeError):
+        return False
+
+
+def normalize_doi(value: Any) -> str | None:
+    """Normalize DOI to lowercase canonical form without prefixes."""
+    if _is_missing(value):
+        return None
+    if not isinstance(value, str):
+        raise ValueError("DOI должен быть строкой")
+
+    doi = value.strip().lower()
+    doi = re.sub(r"^(https?://)?(dx\.)?doi\.org/", "", doi)
+    if doi.startswith("doi:"):
+        doi = doi[4:]
+    if not doi:
+        return None
+    if not re.fullmatch(r"10\.\d{4,9}/.+", doi):
+        raise ValueError(f"Неверный формат DOI: '{value}'")
+    return doi
+
+
+def normalize_chembl_id(value: Any) -> str | None:
+    """Normalize ChEMBL ID ensuring prefix and numeric body."""
+    if _is_missing(value):
+        return None
+    text = str(value).strip().upper()
+    if not text:
+        return None
+    match = re.fullmatch(r"(?:CHEMBL)?(\d+)", text)
+    if not match:
+        raise ValueError(f"Неверный ChEMBL ID: '{value}'")
+    return f"CHEMBL{match.group(1)}"
+
+
+def normalize_pmid(value: Any) -> str | None:
+    """Normalize PubMed ID as numeric string."""
+    if _is_missing(value):
+        return None
+    if isinstance(value, int):
+        if value <= 0:
+            raise ValueError("PubMed ID должен быть положительным числом")
+        return str(value)
+    text = str(value).strip()
+    if not text:
+        return None
+    if not text.isdigit():
+        raise ValueError(f"Неверный PubMed ID: '{value}'")
+    return text
+
+
+def normalize_pcid(value: Any) -> str | None:
+    """Normalize PubChem CID as numeric string."""
+    if _is_missing(value):
+        return None
+    text = str(value).strip().upper()
+    if not text:
+        return None
+    if text.startswith("CID"):
+        text = text[3:]
+    if text.startswith("PCID"):
+        text = text[4:]
+    if not text.isdigit():
+        raise ValueError(f"Неверный PubChem CID: '{value}'")
+    return text
+
+
+def normalize_uniprot(value: Any) -> str | None:
+    """Normalize UniProt accession with strict format validation."""
+    if _is_missing(value):
+        return None
+    if not isinstance(value, str):
+        raise ValueError("UniProt ID должен быть строкой")
+    accession = value.strip().upper()
+    if not accession:
+        return None
+
+    pattern_short = r"[A-NR-Z][0-9][A-Z][A-Z0-9]{2}[0-9]"
+    pattern_pq = r"[OPQ][0-9][A-Z0-9]{3}[0-9]"
+    pattern_long = r"[A-NR-Z][0-9][A-Z][A-Z0-9]{5}[0-9]"
+    if not re.fullmatch(f"(?:{pattern_pq}|{pattern_short}|{pattern_long})", accession):
+        raise ValueError(f"Неверный UniProt ID: '{value}'")
+    return accession
+
+
+def normalize_array(
+    value: Any, *, item_normalizer: Callable[[Any], Any] | None = None
+) -> list[Any] | None:
+    """Normalize array-like value and its elements."""
+    if _is_missing(value):
+        return None
+    if not isinstance(value, (list, tuple)):
+        raise ValueError(
+            f"Ожидался список или кортеж для массива, получено {type(value).__name__}"
+        )
+
+    normalized: list[Any] = []
+    for idx, item in enumerate(value):
+        if _is_missing(item):
+            continue
+        if isinstance(item, dict):
+            try:
+                normalized_item = normalize_record(item, value_normalizer=item_normalizer)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Некорректный элемент словаря в массиве на позиции {idx}: {exc}"
+                ) from exc
+        else:
+            try:
+                normalized_item = item_normalizer(item) if item_normalizer else item
+            except ValueError as exc:
+                raise ValueError(
+                    f"Некорректный элемент массива на позиции {idx}: {exc}"
+                ) from exc
+        if not _is_missing(normalized_item):
+            normalized.append(normalized_item)
+
+    return normalized or None
+
+
+def normalize_record(
+    value: Any, *, value_normalizer: Callable[[Any], Any] | None = None
+) -> MutableMapping[str, Any] | None:
+    """Normalize mapping/dict values using provided normalizer."""
+    if _is_missing(value):
+        return None
+    if not isinstance(value, Mapping):
+        raise ValueError(
+            f"Ожидался словарь для object-поля, получено {type(value).__name__}"
+        )
+
+    normalized: MutableMapping[str, Any] = {}
+    for key, item in value.items():
+        if _is_missing(item):
+            continue
+        try:
+            normalized_value = value_normalizer(item) if value_normalizer else item
+        except ValueError as exc:
+            raise ValueError(
+                f"Некорректное значение в поле '{key}': {exc}"
+            ) from exc
+        if not _is_missing(normalized_value):
+            normalized[key] = normalized_value
+
+    return normalized or None
+
+
+CUSTOM_FIELD_NORMALIZERS: dict[str, Callable[[Any], Any]] = {
+    "doi": normalize_doi,
+    "doi_chembl": normalize_doi,
+    "document_chembl_id": normalize_chembl_id,
+    "assay_chembl_id": normalize_chembl_id,
+    "molecule_chembl_id": normalize_chembl_id,
+    "target_chembl_id": normalize_chembl_id,
+    "pubmed_id": normalize_pmid,
+    "pmid": normalize_pmid,
+    "pcid": normalize_pcid,
+    "pubchem_cid": normalize_pcid,
+    "uniprot_accession": normalize_uniprot,
+    "uniprot_id": normalize_uniprot,
+}
+
+
+__all__ = [
+    "CUSTOM_FIELD_NORMALIZERS",
+    "normalize_array",
+    "normalize_chembl_id",
+    "normalize_doi",
+    "normalize_pcid",
+    "normalize_pmid",
+    "normalize_record",
+    "normalize_uniprot",
+]

--- a/tests/core/test_custom_types.py
+++ b/tests/core/test_custom_types.py
@@ -1,0 +1,117 @@
+import sys
+import types
+
+import pytest
+
+
+if "structlog" not in sys.modules:
+    structlog_module = types.ModuleType("structlog")
+
+    class _BoundLogger:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def bind(self, **ctx):
+            return self
+
+        def info(self, *args, **kwargs):
+            return None
+
+        def error(self, *args, **kwargs):
+            return None
+
+        def debug(self, *args, **kwargs):
+            return None
+
+        def warning(self, *args, **kwargs):
+            return None
+
+    structlog_module.stdlib = types.SimpleNamespace(BoundLogger=_BoundLogger)
+    structlog_module.get_logger = lambda *args, **kwargs: _BoundLogger()
+    structlog_module.is_configured = lambda: True
+    structlog_module.configure = lambda **kwargs: None
+    structlog_module.processors = types.SimpleNamespace(
+        TimeStamper=lambda fmt=None: None, JSONRenderer=lambda: None
+    )
+    structlog_module.PrintLoggerFactory = lambda: None
+
+    sys.modules["structlog"] = structlog_module
+    sys.modules["structlog.stdlib"] = structlog_module.stdlib
+
+if "tqdm" not in sys.modules:
+    tqdm_module = types.ModuleType("tqdm")
+
+    def _noop_tqdm(*args, **kwargs):
+        return None
+
+    tqdm_module.tqdm = _noop_tqdm
+    sys.modules["tqdm"] = tqdm_module
+
+from bioetl.core.custom_types import (
+    CUSTOM_FIELD_NORMALIZERS,
+    normalize_array,
+    normalize_chembl_id,
+    normalize_doi,
+    normalize_pcid,
+    normalize_pmid,
+    normalize_record,
+    normalize_uniprot,
+)
+
+
+class TestIdentifierNormalizers:
+    def test_normalize_doi(self):
+        assert normalize_doi("https://doi.org/10.1000/ABC") == "10.1000/abc"
+        with pytest.raises(ValueError):
+            normalize_doi("not-a-doi")
+
+    def test_normalize_chembl(self):
+        assert normalize_chembl_id("chembl12") == "CHEMBL12"
+        assert normalize_chembl_id("12") == "CHEMBL12"
+        with pytest.raises(ValueError):
+            normalize_chembl_id("CHEMBL12X")
+
+    def test_normalize_pmid(self):
+        assert normalize_pmid("12345") == "12345"
+        with pytest.raises(ValueError):
+            normalize_pmid("pmid123")
+
+    def test_normalize_pcid(self):
+        assert normalize_pcid("CID987") == "987"
+        with pytest.raises(ValueError):
+            normalize_pcid("CID98X")
+
+    def test_normalize_uniprot(self):
+        assert normalize_uniprot("p12345") == "P12345"
+        with pytest.raises(ValueError):
+            normalize_uniprot("invalid")
+
+
+class TestCollectionNormalizers:
+    def test_normalize_array_with_scalar(self):
+        result = normalize_array([" 10.1234/XYZ "], item_normalizer=normalize_doi)
+        assert result == ["10.1234/xyz"]
+
+    def test_normalize_array_error(self):
+        with pytest.raises(ValueError):
+            normalize_array("not-a-list", item_normalizer=str)
+
+    def test_normalize_record(self):
+        result = normalize_record({"pmid": "123"}, value_normalizer=normalize_pmid)
+        assert result == {"pmid": "123"}
+
+    def test_normalize_record_error(self):
+        with pytest.raises(ValueError):
+            normalize_record([1, 2])
+
+
+def test_custom_field_normalizers_contains_expected_keys():
+    for key in [
+        "doi",
+        "doi_chembl",
+        "document_chembl_id",
+        "pubmed_id",
+        "pcid",
+        "uniprot_accession",
+    ]:
+        assert key in CUSTOM_FIELD_NORMALIZERS

--- a/tests/domain/transform/test_normalize.py
+++ b/tests/domain/transform/test_normalize.py
@@ -74,6 +74,7 @@ def test_normalizer_mixin_full():
         {"name": "num", "data_type": "float"},
         {"name": "nested_list", "data_type": "array"},
         {"name": "nested_obj", "data_type": "object"},
+        {"name": "doi", "data_type": "string"},
     ]
     config = MockConfig(fields)
     normalizer = MockNormalizer(config)
@@ -88,6 +89,7 @@ def test_normalizer_mixin_full():
             "num": [1.23456, 2.0],
             "nested_list": [["A", "B"], ["C"]],
             "nested_obj": [{"K": "V"}, {"X": "Y"}],
+            "doi": ["https://doi.org/10.1000/ABC", None],
         }
     )
 
@@ -106,3 +108,16 @@ def test_normalizer_mixin_full():
     # "A" -> "a", "K" -> "k", "V" -> "v"
     assert res["nested_list"].iloc[0] == "a|b"
     assert res["nested_obj"].iloc[0] == "K:v" # Keys preserve case, values normalized
+
+    # DOI normalized via custom normalizer
+    assert res["doi"].iloc[0] == "10.1000/abc"
+
+
+def test_normalizer_mixin_raises_on_invalid_custom_value():
+    config = MockConfig([{"name": "doi", "data_type": "string"}])
+    normalizer = MockNormalizer(config)
+
+    df = pd.DataFrame({"doi": ["invalid-doi"]})
+
+    with pytest.raises(ValueError):
+        normalizer.normalize_fields(df)


### PR DESCRIPTION
## Summary
- add dedicated normalizers for DOI, ChEMBL IDs, PubMed IDs, PubChem CIDs, UniProt accessions, arrays, and records
- integrate custom field normalizers into the normalization mixin with improved ID heuristics
- add tests covering identifier normalization behavior and error handling

## Testing
- pytest -o addopts='' tests/core/test_custom_types.py tests/domain/transform/test_normalize.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f071af51083248977cb847c09b1b9)