### PR TITLE
Support 10-character UniProt accessions

### DIFF
--- a/src/bioetl/domain/transform/custom_types.py
+++ b/src/bioetl/domain/transform/custom_types.py
@@ -101,7 +101,7 @@ def normalize_uniprot(value: Any) -> str | None:
 
     pattern_short = r"[A-NR-Z][0-9][A-Z][A-Z0-9]{2}[0-9]"
     pattern_pq = r"[OPQ][0-9][A-Z0-9]{3}[0-9]"
-    pattern_long = r"[A-NR-Z][0-9][A-Z][A-Z0-9]{5}[0-9]"
+    pattern_long = r"[A-NR-Z][0-9][A-Z][A-Z0-9]{2}[0-9][A-Z0-9]{3}[0-9]"
     if not re.fullmatch(f"(?:{pattern_pq}|{pattern_short}|{pattern_long})", accession):
         raise ValueError(f"Неверный UniProt ID: '{value}'")
     return accession

--- a/tests/bioetl/core/test_custom_types.py
+++ b/tests/bioetl/core/test_custom_types.py
@@ -156,6 +156,7 @@ class TestNormalizeUniprot:
             ("p12345", "P12345"),
             ("q9h0h5", "Q9H0H5"),
             ("B7ZC07", "B7ZC07"),
+            ("a0a023gpi8", "A0A023GPI8"),
             (None, None),
             (pd.NA, None),
         ],

--- a/tests/core/test_custom_types.py
+++ b/tests/core/test_custom_types.py
@@ -83,6 +83,7 @@ class TestIdentifierNormalizers:
 
     def test_normalize_uniprot(self):
         assert normalize_uniprot("p12345") == "P12345"
+        assert normalize_uniprot("A0A0B4J2D5") == "A0A0B4J2D5"
         with pytest.raises(ValueError):
             normalize_uniprot("invalid")
 


### PR DESCRIPTION
## Summary
- update UniProt normalization regex to accept 10-character accession formats
- extend UniProt normalization tests with 10-character examples

## Testing
- `PYTHONPATH=src pytest -q -c /dev/null tests/bioetl/core/test_custom_types.py tests/core/test_custom_types.py` *(fails: repository lacks pytest-cov plugin and default configuration could not be used; package import path unresolved when bypassing config)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f1d90fe208324be8952e7f6d3ef95)