### PR TITLE
Normalize PMID/PCID normalizers to return integers

### DIFF
--- a/src/bioetl/application/pipelines/chembl/document/run.py
+++ b/src/bioetl/application/pipelines/chembl/document/run.py
@@ -56,10 +56,10 @@ class ChemblDocumentPipeline(ChemblPipelineBase):
             if col in df.columns:
                 df[col] = pd.to_numeric(df[col], errors="coerce").astype("Int64")
 
-        # Convert pubmed_id to string (nullable)
+        # Convert pubmed_id to nullable integer
         if "pubmed_id" in df.columns:
             df["pubmed_id"] = df["pubmed_id"].apply(normalize_pmid)
-            df["pubmed_id"] = df["pubmed_id"].astype("string")
+            df["pubmed_id"] = df["pubmed_id"].astype("Int64")
 
         # Schema enforcement
         schema_columns = list(DocumentSchema.to_schema().columns.keys())

--- a/src/bioetl/domain/schemas/chembl/document.py
+++ b/src/bioetl/domain/schemas/chembl/document.py
@@ -41,9 +41,8 @@ class DocumentSchema(pa.DataFrameModel):
     patent_id: Series[str] = pa.Field(
         nullable=True, description="Идентификатор патента"
     )
-    pubmed_id: Series[str] = pa.Field(
+    pubmed_id: Series[int] = pa.Field(
         nullable=True,
-        str_matches=r"^\d+$",
         description="PubMed ID",
     )
     src_id: Series[float] = pa.Field(

--- a/src/bioetl/domain/transform/custom_types.py
+++ b/src/bioetl/domain/transform/custom_types.py
@@ -47,11 +47,11 @@ def normalize_chembl_id(value: Any) -> str | None:
     return f"CHEMBL{match.group(1)}"
 
 
-def normalize_pmid(value: Any) -> str | None:
-    """Normalize PubMed ID as numeric string."""
+def normalize_pmid(value: Any) -> int | None:
+    """Normalize PubMed ID as positive integer."""
     if _is_missing(value):
         return None
-    
+
     if isinstance(value, float):
         if value.is_integer():
             value = int(value)
@@ -59,22 +59,25 @@ def normalize_pmid(value: Any) -> str | None:
     if isinstance(value, int):
         if value <= 0:
             raise ValueError("PubMed ID должен быть положительным числом")
-        return str(value)
+        return value
 
     text = str(value).strip()
     if not text:
         return None
-    
+
     if text.endswith(".0") and text[:-2].isdigit():
         text = text[:-2]
 
     if not text.isdigit():
         raise ValueError(f"Неверный PubMed ID: '{value}'")
-    return text
+    parsed = int(text)
+    if parsed <= 0:
+        raise ValueError("PubMed ID должен быть положительным числом")
+    return parsed
 
 
-def normalize_pcid(value: Any) -> str | None:
-    """Normalize PubChem CID as numeric string."""
+def normalize_pcid(value: Any) -> int | None:
+    """Normalize PubChem CID as positive integer."""
     if _is_missing(value):
         return None
     text = str(value).strip().upper()
@@ -86,7 +89,10 @@ def normalize_pcid(value: Any) -> str | None:
         text = text[4:]
     if not text.isdigit():
         raise ValueError(f"Неверный PubChem CID: '{value}'")
-    return text
+    parsed = int(text)
+    if parsed <= 0:
+        raise ValueError("PubChem CID должен быть положительным числом")
+    return parsed
 
 
 def normalize_uniprot(value: Any) -> str | None:

--- a/tests/bioetl/core/test_custom_types.py
+++ b/tests/bioetl/core/test_custom_types.py
@@ -110,9 +110,9 @@ class TestNormalizePmid:
     @pytest.mark.parametrize(
         "value, expected",
         [
-            ("12345", "12345"),
-            (12345, "12345"),
-            (" 67890 ", "67890"),
+            ("12345", 12345),
+            (12345, 12345),
+            (" 67890 ", 67890),
             (None, None),
             (pd.NA, None),
         ],
@@ -133,9 +133,9 @@ class TestNormalizePcid:
     @pytest.mark.parametrize(
         "value, expected",
         [
-            ("CID987", "987"),
-            ("pcid123", "123"),
-            (" 456 ", "456"),
+            ("CID987", 987),
+            ("pcid123", 123),
+            (" 456 ", 456),
             (None, None),
             (pd.NA, None),
         ],
@@ -172,7 +172,7 @@ class TestNormalizeUniprot:
 class TestNormalizeArray:
     def test_normalizes_elements_and_types(self):
         result = normalize_array([" 123 ", 456, None], item_normalizer=normalize_pmid)
-        assert result == ["123", "456"]
+        assert result == [123, 456]
         assert isinstance(result, list)
 
     def test_handles_nested_records(self):
@@ -182,7 +182,7 @@ class TestNormalizeArray:
             None,
         ]
         result = normalize_array(values, item_normalizer=normalize_pmid)
-        assert result == [{"pmid": "123"}, {"pmid": "456"}]
+        assert result == [{"pmid": 123}, {"pmid": 456}]
 
     def test_raises_on_invalid_item(self):
         with pytest.raises(ValueError):
@@ -200,7 +200,7 @@ class TestNormalizeRecord:
     def test_normalizes_mapping_values(self):
         record = {"pmid": "123", "extra": None}
         result = normalize_record(record, value_normalizer=normalize_pmid)
-        assert result == {"pmid": "123"}
+        assert result == {"pmid": 123}
         assert isinstance(result, dict)
 
     def test_returns_none_for_empty_or_missing(self):

--- a/tests/core/test_custom_types.py
+++ b/tests/core/test_custom_types.py
@@ -72,12 +72,12 @@ class TestIdentifierNormalizers:
             normalize_chembl_id("CHEMBL12X")
 
     def test_normalize_pmid(self):
-        assert normalize_pmid("12345") == "12345"
+        assert normalize_pmid("12345") == 12345
         with pytest.raises(ValueError):
             normalize_pmid("pmid123")
 
     def test_normalize_pcid(self):
-        assert normalize_pcid("CID987") == "987"
+        assert normalize_pcid("CID987") == 987
         with pytest.raises(ValueError):
             normalize_pcid("CID98X")
 
@@ -98,7 +98,7 @@ class TestCollectionNormalizers:
 
     def test_normalize_record(self):
         result = normalize_record({"pmid": "123"}, value_normalizer=normalize_pmid)
-        assert result == {"pmid": "123"}
+        assert result == {"pmid": 123}
 
     def test_normalize_record_error(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- update PMID and PCID custom normalizers to return positive integers while keeping validation
- align Chembl document schema and pipeline transformation with integer pubmed IDs
- adjust unit tests to expect integer outputs for PMID/PCID normalization

## Testing
- pytest tests/bioetl/core/test_custom_types.py tests/core/test_custom_types.py *(fails: pytest-cov plugin unavailable in offline environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f1d9367348324973ef0913b7e3402)