### PR TITLE
Handle scalar inputs in normalize_array

### DIFF
--- a/src/bioetl/domain/transform/custom_types.py
+++ b/src/bioetl/domain/transform/custom_types.py
@@ -113,13 +113,14 @@ def normalize_array(
     """Normalize array-like value and its elements."""
     if _is_missing(value):
         return None
-    if not isinstance(value, (list, tuple)):
-        raise ValueError(
-            f"Ожидался список или кортеж для массива, получено {type(value).__name__}"
-        )
+
+    if isinstance(value, (list, tuple)):
+        items: Iterable[Any] = value
+    else:
+        items = [value]
 
     normalized: list[Any] = []
-    for idx, item in enumerate(value):
+    for idx, item in enumerate(items):
         if _is_missing(item):
             continue
         if isinstance(item, dict):
@@ -139,7 +140,14 @@ def normalize_array(
         if not _is_missing(normalized_item):
             normalized.append(normalized_item)
 
-    return normalized or None
+    if normalized:
+        return normalized
+
+    if isinstance(value, (list, tuple)):
+        return []
+    if _is_missing(value):
+        return None
+    return []
 
 
 def normalize_record(

--- a/tests/bioetl/core/test_custom_types.py
+++ b/tests/bioetl/core/test_custom_types.py
@@ -48,7 +48,7 @@ if "tqdm" not in sys.modules:
     tqdm_module.tqdm = _noop_tqdm
     sys.modules["tqdm"] = tqdm_module
 
-from bioetl.core.custom_types import (
+from bioetl.domain.transform.custom_types import (
     CUSTOM_FIELD_NORMALIZERS,
     normalize_array,
     normalize_chembl_id,
@@ -188,12 +188,14 @@ class TestNormalizeArray:
         with pytest.raises(ValueError):
             normalize_array(["123", "invalid"], item_normalizer=normalize_pmid)
 
-    def test_raises_on_non_iterable(self):
-        with pytest.raises(ValueError):
-            normalize_array("not-a-list", item_normalizer=str)
+    def test_accepts_scalar_input(self):
+        assert normalize_array("123", item_normalizer=normalize_pmid) == ["123"]
+
+    def test_returns_empty_on_empty_scalar(self):
+        assert normalize_array("", item_normalizer=normalize_pmid) == []
 
     def test_returns_none_for_empty(self):
-        assert normalize_array([], item_normalizer=normalize_pmid) is None
+        assert normalize_array([], item_normalizer=normalize_pmid) == []
 
 
 class TestNormalizeRecord:

--- a/tests/core/test_custom_types.py
+++ b/tests/core/test_custom_types.py
@@ -88,13 +88,17 @@ class TestIdentifierNormalizers:
 
 
 class TestCollectionNormalizers:
+    def test_normalize_array_from_scalar(self):
+        result = normalize_array(" 10.1234/XYZ ", item_normalizer=normalize_doi)
+        assert result == ["10.1234/xyz"]
+
     def test_normalize_array_with_scalar(self):
         result = normalize_array([" 10.1234/XYZ "], item_normalizer=normalize_doi)
         assert result == ["10.1234/xyz"]
 
-    def test_normalize_array_error(self):
+    def test_normalize_array_keeps_invalid_item_errors(self):
         with pytest.raises(ValueError):
-            normalize_array("not-a-list", item_normalizer=str)
+            normalize_array(["10.1234/XYZ", "bad"], item_normalizer=normalize_doi)
 
     def test_normalize_record(self):
         result = normalize_record({"pmid": "123"}, value_normalizer=normalize_pmid)


### PR DESCRIPTION
## Summary
- allow normalize_array to wrap scalar inputs and return empty lists for empty values instead of raising
- extend array normalization tests to cover scalar handling and preserve invalid item checks

## Testing
- pytest --override-ini addopts= tests/core/test_custom_types.py
- pytest --override-ini addopts= tests/bioetl/core/test_custom_types.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f1d9bed148324b439f1139d7b9a37)