### PR TITLE
Update pipeline running guide

### DIFF
--- a/docs/guides/00-running-pipelines.md
+++ b/docs/guides/00-running-pipelines.md
@@ -2,10 +2,16 @@
 
 ## Запуск через CLI
 
-- Один пайплайн: `bioetl run --pipeline chembl_activity --config configs/pipelines/chembl/activity.yaml`.
-- Несколько пайплайнов: указать несколько `--pipeline` или использовать групповой конфиг.
+- Одиночный запуск: `bioetl run --pipeline chembl_activity --config configs/pipelines/chembl/activity.yaml`.
 - Профили: `--profile dev` для ограниченных выборок, `--profile prod` для полноты и усиленных лимитов.
-- Доп. параметры: `--output-dir <path>`, `--dry-run` для проверки без записи, `--limit` для smoke-run.
+- Управление выводом: `--output-dir <path>` для смены директории артефактов.
+- Без записи: `--dry-run` для проверки конфигов и зависимостей без сохранения данных.
+- Ограничения выборки: `--limit <n>` для небольших прогонов и раннего обнаружения ошибок.
+
+### Smoke-test
+
+- Быстрый прогон: `bioetl run --pipeline chembl_activity --config configs/pipelines/chembl/activity.yaml --profile dev --limit 100`.
+- Комбинируйте с `--dry-run`, чтобы проверить доступность источников и целостность конфигурации без записи.
 
 ## Профили окружений
 


### PR DESCRIPTION
## Summary
- update the running pipelines guide with refreshed CLI instructions
- add smoke-test guidance for quick runs
- remove outdated mention of multi-pipeline flags

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f221aea188324b84c81ac6d47050b)