### PR TITLE
Update Chembl pipeline base reference in docs

### DIFF
--- a/docs/application/pipelines/chembl/00-index.md
+++ b/docs/application/pipelines/chembl/00-index.md
@@ -8,7 +8,7 @@
 - **Document** — агрегирует публикации и метаданные для ссылок на эксперименты.
 
 ## Общие принципы
-Все пайплайны наследуют `ChemblCommonPipeline`, используют единый `ChemblExtractionService` и общую конфигурацию (release, пагинация, лимиты). Доступны dry-run и QC-артефакты по умолчанию.
+Все пайплайны наследуют `ChemblPipelineBase` ([`src/bioetl/application/pipelines/chembl/base.py`](../../../../src/bioetl/application/pipelines/chembl/base.py)), используют единый `ChemblExtractionService` и общую конфигурацию (release, пагинация, лимиты). Доступны dry-run и QC-артефакты по умолчанию.
 
 ## Навигация по пайплайнам
 - Activity: `activity/00-activity-chembl-overview.md`


### PR DESCRIPTION
## Summary
- update the ChEMBL pipelines index to reference ChemblPipelineBase instead of ChemblCommonPipeline
- add a direct link to the ChemblPipelineBase source file for easier navigation

## Testing
- not run (documentation change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f222f85048324b528fad3e68abcb4)