### PR TITLE
Add ingestion normalization service to Chembl pipelines

### DIFF
--- a/src/bioetl/application/pipelines/chembl/base.py
+++ b/src/bioetl/application/pipelines/chembl/base.py
@@ -8,9 +8,9 @@ import pandas as pd
 
 from bioetl.application.pipelines.base import PipelineBase
 from bioetl.domain.contracts import ExtractionServiceABC
+from bioetl.domain.ingestion.contracts import IngestionServiceABC
 from bioetl.domain.models import RunContext
 from bioetl.domain.transform.hash_service import HashService
-from bioetl.domain.transform.impl.normalize import NormalizationService
 from bioetl.domain.validation.service import ValidationService
 from bioetl.infrastructure.config.models import (
     ChemblSourceConfig,
@@ -49,6 +49,7 @@ class ChemblPipelineBase(PipelineBase):
         validation_service: ValidationService,
         output_writer: UnifiedOutputWriter,
         extraction_service: ExtractionServiceABC,
+        ingestion_service: IngestionServiceABC,
         hash_service: HashService | None = None,
     ) -> None:
         super().__init__(
@@ -60,9 +61,7 @@ class ChemblPipelineBase(PipelineBase):
         )
         self._extraction_service = extraction_service
         self._chembl_release: str | None = None
-
-        # Initialize normalization service
-        self._normalization_service = NormalizationService(config)
+        self._ingestion_service = ingestion_service
 
     def get_version(self) -> str:
         """Возвращает версию релиза ChEMBL (например, 'chembl_34')."""
@@ -189,51 +188,10 @@ class ChemblPipelineBase(PipelineBase):
         df = self.pre_transform(df)
         df = self._do_transform(df)
 
-        # Выполняем нормализацию (строки, числа, вложенные структуры)
-        df = self._normalization_service.normalize_fields(df)
-
-        # Приводим к схеме (добавляем отсутствующие колонки, упорядочиваем)
-        df = self._enforce_schema(df)
-
-        # Удаляем строки с NULL в обязательных колонках
-        df = self._drop_nulls_in_required_columns(df)
-
-        return df
-
-    def _drop_nulls_in_required_columns(self, df: pd.DataFrame) -> pd.DataFrame:
-        """
-        Удаляет строки, где обязательные (non-nullable) колонки содержат NULL.
-        Игнорирует генерируемые колонки (hash_row, hash_business_key),
-        так как они вычисляются позже.
-        """
-        entity = self._config.entity_name
-        schema_cls = self._validation_service.get_schema(entity)
-        schema = schema_cls.to_schema()
-
-        # Columns to ignore during this check because they are generated later
-        ignored_cols = {"hash_row", "hash_business_key", "index", "database_version", "extracted_at"}
-
-        required_cols = [
-            name
-            for name, col in schema.columns.items()
-            if not col.nullable
-            and name in df.columns
-            and name not in ignored_cols
-        ]
-
-        if not required_cols:
-            return df
-
-        initial_count = len(df)
-        df_clean = df.dropna(subset=required_cols)
-        dropped_count = initial_count - len(df_clean)
-
-        if dropped_count > 0:
-            self._logger.warning(
-                f"Dropped {dropped_count} rows with nulls in required columns: {required_cols}"
-            )
-
-        return df_clean
+        return self._ingestion_service.ingest(
+            df,
+            entity_name=self._config.entity_name,
+        )
 
     def pre_transform(self, df: pd.DataFrame) -> pd.DataFrame:
         """Хук для предварительной обработки (можно переопределить)."""
@@ -246,20 +204,6 @@ class ChemblPipelineBase(PipelineBase):
         Наследники могут переопределить или расширить.
         """
         return df
-
-    def _enforce_schema(self, df: pd.DataFrame) -> pd.DataFrame:
-        """
-        Приводит DataFrame к схеме: заполняет отсутствующие колонки None,
-        оставляет только колонки из схемы в правильном порядке.
-        """
-        entity = self._config.entity_name
-        schema_columns = self._validation_service.get_schema_columns(entity)
-
-        for col in schema_columns:
-            if col not in df.columns:
-                df[col] = None
-
-        return df[schema_columns]
 
     def _enrich_context(self, context: RunContext) -> None:
         """Добавляет chembl_release в метаданные контекста."""

--- a/src/bioetl/application/pipelines/chembl/pipeline.py
+++ b/src/bioetl/application/pipelines/chembl/pipeline.py
@@ -6,6 +6,7 @@ with a configurable generic implementation.
 """
 from bioetl.application.pipelines.chembl.base import ChemblPipelineBase
 from bioetl.domain.contracts import ExtractionServiceABC
+from bioetl.domain.ingestion.contracts import IngestionServiceABC
 from bioetl.domain.transform.hash_service import HashService
 from bioetl.domain.validation.service import ValidationService
 from bioetl.infrastructure.config.models import PipelineConfig
@@ -26,6 +27,7 @@ class ChemblEntityPipeline(ChemblPipelineBase):
         validation_service: ValidationService,
         output_writer: UnifiedOutputWriter,
         extraction_service: ExtractionServiceABC,
+        ingestion_service: IngestionServiceABC,
         hash_service: HashService | None = None,
     ) -> None:
         super().__init__(
@@ -34,6 +36,7 @@ class ChemblEntityPipeline(ChemblPipelineBase):
             validation_service,
             output_writer,
             extraction_service,
+            ingestion_service,
             hash_service,
         )
 

--- a/src/bioetl/domain/ingestion/contracts.py
+++ b/src/bioetl/domain/ingestion/contracts.py
@@ -1,0 +1,16 @@
+"""Domain contracts for ingestion services."""
+
+from abc import ABC, abstractmethod
+
+import pandas as pd
+
+
+class IngestionServiceABC(ABC):
+    """Сервис приведения DataFrame к стандартизированному виду."""
+
+    @abstractmethod
+    def ingest(self, df: pd.DataFrame, *, entity_name: str) -> pd.DataFrame:
+        """
+        Выполняет нормализацию полей, приведение к схеме и очистку обязательных
+        колонок от NULL.
+        """

--- a/src/bioetl/infrastructure/ingestion/__init__.py
+++ b/src/bioetl/infrastructure/ingestion/__init__.py
@@ -1,0 +1,5 @@
+"""Ingestion service implementations."""
+
+from bioetl.infrastructure.ingestion.service import NormalizationIngestionService
+
+__all__ = ["NormalizationIngestionService"]

--- a/src/bioetl/infrastructure/ingestion/service.py
+++ b/src/bioetl/infrastructure/ingestion/service.py
@@ -1,0 +1,75 @@
+"""Ingestion service implementation based on normalization and schema rules."""
+
+from typing import Iterable
+
+import pandas as pd
+
+from bioetl.domain.ingestion.contracts import IngestionServiceABC
+from bioetl.domain.transform.impl.normalize import NormalizationService
+from bioetl.domain.validation.service import ValidationService
+from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
+
+
+class NormalizationIngestionService(IngestionServiceABC):
+    """Сервис нормализации и приведения данных к схеме."""
+
+    def __init__(
+        self,
+        normalization_service: NormalizationService,
+        validation_service: ValidationService,
+        logger: LoggerAdapterABC,
+    ) -> None:
+        self._normalization_service = normalization_service
+        self._validation_service = validation_service
+        self._logger = logger
+
+    def ingest(self, df: pd.DataFrame, *, entity_name: str) -> pd.DataFrame:
+        """Выполняет цепочку нормализации и очистки."""
+        df = self._normalization_service.normalize_fields(df)
+        df = self._enforce_schema(df, entity_name)
+        return self._drop_nulls_in_required_columns(df, entity_name)
+
+    def _enforce_schema(self, df: pd.DataFrame, entity_name: str) -> pd.DataFrame:
+        schema_columns = self._validation_service.get_schema_columns(entity_name)
+
+        for col in schema_columns:
+            if col not in df.columns:
+                df[col] = None
+
+        return df[schema_columns]
+
+    def _drop_nulls_in_required_columns(
+        self, df: pd.DataFrame, entity_name: str
+    ) -> pd.DataFrame:
+        schema_cls = self._validation_service.get_schema(entity_name)
+        schema = schema_cls.to_schema()
+
+        ignored_cols: set[str] = {
+            "hash_row",
+            "hash_business_key",
+            "index",
+            "database_version",
+            "extracted_at",
+        }
+
+        required_cols: Iterable[str] = [
+            name
+            for name, col in schema.columns.items()
+            if not col.nullable and name in df.columns and name not in ignored_cols
+        ]
+
+        if not required_cols:
+            return df
+
+        initial_count = len(df)
+        df_clean = df.dropna(subset=list(required_cols))
+        dropped_count = initial_count - len(df_clean)
+
+        if dropped_count > 0:
+            self._logger.warning(
+                "Dropped rows with nulls in required columns",
+                dropped_count=dropped_count,
+                required_columns=list(required_cols),
+            )
+
+        return df_clean

--- a/src/bioetl/interfaces/cli/app.py
+++ b/src/bioetl/interfaces/cli/app.py
@@ -107,6 +107,9 @@ def run(
         output_writer = container.get_output_writer()
         extraction_service = container.get_extraction_service()
         hash_service = container.get_hash_service()
+        ingestion_service = container.get_ingestion_service(
+            logger, validation_service
+        )
 
         # 4. Run Pipeline
         pipeline = pipeline_cls(
@@ -115,6 +118,7 @@ def run(
             validation_service=validation_service,
             output_writer=output_writer,
             extraction_service=extraction_service,
+            ingestion_service=ingestion_service,
             hash_service=hash_service
         )
         

--- a/tests/pipelines/chembl/activity/test_extract.py
+++ b/tests/pipelines/chembl/activity/test_extract.py
@@ -55,6 +55,7 @@ def pipeline(mock_config, mock_extraction_service):
     logger = MagicMock()
     validation_service = MagicMock()
     output_writer = MagicMock()
+    ingestion_service = MagicMock()
 
     return ChemblEntityPipeline(
         config=mock_config,
@@ -62,6 +63,7 @@ def pipeline(mock_config, mock_extraction_service):
         validation_service=validation_service,
         output_writer=output_writer,
         extraction_service=mock_extraction_service,
+        ingestion_service=ingestion_service,
     )
 
 

--- a/tests/pipelines/chembl/document/test_document_pipeline.py
+++ b/tests/pipelines/chembl/document/test_document_pipeline.py
@@ -9,6 +9,8 @@ from bioetl.application.pipelines.chembl.pipeline import (
     ChemblEntityPipeline,
 )
 from bioetl.domain.schemas.chembl.document import DocumentSchema
+from bioetl.domain.transform.impl.normalize import NormalizationService
+from bioetl.infrastructure.ingestion import NormalizationIngestionService
 
 
 @pytest.fixture
@@ -36,6 +38,13 @@ def pipeline():
         DocumentSchema.to_schema().columns.keys()
     )
 
+    normalization_service = NormalizationService(config)
+    ingestion_service = NormalizationIngestionService(
+        normalization_service=normalization_service,
+        validation_service=validation_service,
+        logger=MagicMock(),
+    )
+
     # We need real normalization service logic or mocked?
     # ChemblPipelineBase initializes NormalizationService(config).
     # So we rely on that service working with our mock config.
@@ -46,6 +55,7 @@ def pipeline():
         validation_service=validation_service,
         output_writer=MagicMock(),
         extraction_service=MagicMock(),
+        ingestion_service=ingestion_service,
     )
 
 

--- a/tests/pipelines/chembl/target/test_target_pipeline.py
+++ b/tests/pipelines/chembl/target/test_target_pipeline.py
@@ -6,6 +6,8 @@ import pytest
 
 from bioetl.application.pipelines.chembl.pipeline import ChemblEntityPipeline
 from bioetl.domain.schemas.chembl.target import TargetSchema
+from bioetl.domain.transform.impl.normalize import NormalizationService
+from bioetl.infrastructure.ingestion import NormalizationIngestionService
 
 
 @pytest.fixture
@@ -24,12 +26,20 @@ def pipeline():
         TargetSchema.to_schema().columns.keys()
     )
 
+    normalization_service = NormalizationService(config)
+    ingestion_service = NormalizationIngestionService(
+        normalization_service=normalization_service,
+        validation_service=validation_service,
+        logger=MagicMock(),
+    )
+
     return ChemblEntityPipeline(
         config=config,
         logger=MagicMock(),
         validation_service=validation_service,
         output_writer=MagicMock(),
         extraction_service=MagicMock(),
+        ingestion_service=ingestion_service,
     )
 
 

--- a/tests/pipelines/chembl/test_base.py
+++ b/tests/pipelines/chembl/test_base.py
@@ -8,6 +8,8 @@ import pytest
 
 from bioetl.domain.models import RunContext
 from bioetl.application.pipelines.chembl.base import ChemblPipelineBase
+from bioetl.domain.transform.impl.normalize import NormalizationService
+from bioetl.infrastructure.ingestion import NormalizationIngestionService
 
 
 class ConcreteChemblPipeline(ChemblPipelineBase):
@@ -34,12 +36,20 @@ def mock_dependencies_fixture():
     validation_service = MagicMock()
     validation_service.get_schema_columns.return_value = ["a", "transformed"]
 
+    normalization_service = NormalizationService(config)
+    ingestion_service = NormalizationIngestionService(
+        normalization_service=normalization_service,
+        validation_service=validation_service,
+        logger=MagicMock(),
+    )
+
     return {
         "config": config,
         "logger": MagicMock(),
         "validation_service": validation_service,
         "output_writer": MagicMock(),
         "extraction_service": MagicMock(),
+        "ingestion_service": ingestion_service,
     }
 
 
@@ -54,6 +64,7 @@ def pipeline_fixture(mock_dependencies_fixture):
         validation_service=mock_dependencies_fixture["validation_service"],
         output_writer=mock_dependencies_fixture["output_writer"],
         extraction_service=mock_dependencies_fixture["extraction_service"],
+        ingestion_service=mock_dependencies_fixture["ingestion_service"],
     )
 
 

--- a/tests/pipelines/chembl/test_config_resolution.py
+++ b/tests/pipelines/chembl/test_config_resolution.py
@@ -10,6 +10,7 @@ def dependencies():
         "validation_service": MagicMock(),
         "output_writer": MagicMock(),
         "extraction_service": MagicMock(),
+        "ingestion_service": MagicMock(),
         "hash_service": MagicMock(),
     }
 

--- a/tests/pipelines/chembl/test_pipelines_smoke.py
+++ b/tests/pipelines/chembl/test_pipelines_smoke.py
@@ -18,6 +18,7 @@ def common_dependencies():
         "validation_service": MagicMock(),
         "output_writer": MagicMock(),
         "extraction_service": MagicMock(),
+        "ingestion_service": MagicMock(),
     }
 
 
@@ -43,6 +44,7 @@ def test_pipeline_instantiation(pipeline_info, common_dependencies):
         validation_service=common_dependencies["validation_service"],
         output_writer=common_dependencies["output_writer"],
         extraction_service=common_dependencies["extraction_service"],
+        ingestion_service=common_dependencies["ingestion_service"],
     )
     
     assert pipeline.ID_COLUMN == id_col
@@ -53,5 +55,6 @@ def test_pipeline_instantiation(pipeline_info, common_dependencies):
         "id": [1],
         "chembl_release": [{"chembl_release": "34"}]
     })
+    pipeline._ingestion_service.ingest.side_effect = lambda df, **_: df
     result = pipeline.transform(df)
     assert isinstance(result, pd.DataFrame)

--- a/tests/pipelines/chembl/test_pk_resolution.py
+++ b/tests/pipelines/chembl/test_pk_resolution.py
@@ -10,6 +10,7 @@ def dependencies():
         "validation_service": MagicMock(),
         "output_writer": MagicMock(),
         "extraction_service": MagicMock(),
+        "ingestion_service": MagicMock(),
         "hash_service": MagicMock(),
     }
 

--- a/tests/pipelines/chembl/testitem/test_testitem_pipeline.py
+++ b/tests/pipelines/chembl/testitem/test_testitem_pipeline.py
@@ -8,6 +8,8 @@ from bioetl.application.pipelines.chembl.pipeline import (
     ChemblEntityPipeline,
 )
 from bioetl.domain.schemas.chembl.testitem import TestitemSchema
+from bioetl.domain.transform.impl.normalize import NormalizationService
+from bioetl.infrastructure.ingestion import NormalizationIngestionService
 
 
 @pytest.fixture
@@ -29,12 +31,20 @@ def pipeline():  # pylint: disable=redefined-outer-name
         TestitemSchema.to_schema().columns.keys()
     )
 
+    normalization_service = NormalizationService(config)
+    ingestion_service = NormalizationIngestionService(
+        normalization_service=normalization_service,
+        validation_service=validation_service,
+        logger=MagicMock(),
+    )
+
     return ChemblEntityPipeline(
         config=config,
         logger=MagicMock(),
         validation_service=validation_service,
         output_writer=MagicMock(),
         extraction_service=MagicMock(),
+        ingestion_service=ingestion_service,
     )
 
 


### PR DESCRIPTION
## Summary
- add ingestion service contracts and normalization-based implementation
- inject ingestion dependency into ChEMBL pipelines and CLI container
- update pipeline tests to use the new ingestion service

## Testing
- pytest tests/pipelines/chembl -q *(fails: coverage threshold 85% not met in partial run)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69305967e534832494ac1e382a7089fc)