### PR TITLE
Add dry-run pipeline and CLI tests with shared fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,31 @@ def sample_df():
     })
 
 
+@pytest.fixture
+def pipeline_test_config(tmp_path_factory: pytest.TempPathFactory) -> PipelineConfig:
+    """Pipeline config for integration-style unit tests."""
+    output_dir = tmp_path_factory.mktemp("pipeline_output")
+    return PipelineConfig(
+        provider="test_provider",
+        entity_name="test_entity",
+        logging=LoggingConfig(level="DEBUG"),
+        storage=StorageConfig(output_path=str(output_dir)),
+        hashing=HashingConfig(business_key_fields=["id"]),
+        pipeline={},
+    )
+
+
+@pytest.fixture
+def small_pipeline_df() -> pd.DataFrame:
+    """Tiny dataset used for pipeline dry-run tests."""
+    return pd.DataFrame(
+        {
+            "id": [101, 202],
+            "value": ["alpha", "beta"],
+        }
+    )
+
+
 @pytest.fixture(autouse=True)
 def disable_network_calls(monkeypatch, request):
     """Block network access unless marked with 'network' or 'integration'."""


### PR DESCRIPTION
## Summary
- add reusable fixtures for pipeline config and small datasets in tests
- cover PipelineBase dry-run results with stage and metadata assertions
- add CLI dry-run test using CliRunner to verify stages and metadata propagation

## Testing
- `pytest tests/core/test_pipeline_base.py::test_pipeline_dry_run_metadata_and_stages tests/test_cli.py::test_run_dry_run_pipeline_metadata`
- `pytest` (fails: missing optional dependencies hypothesis/tqdm in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69305970aac88324bbe4f9b9a7dadee0)