### PR TITLE
Add explicit input source controls for Chembl pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Добавлены типизированные поля `input_mode`/`input_path`/`csv_options` для пайплайнов; `cli.input_file` автоматически мигрирует с предупреждением.
+- ChEMBL pipeline теперь выбирает источник записей явно (API/CSV/id-only) без колонковой эвристики; CLI умеет переопределять режим и CSV-опции.
+
 ### Removed
 - Удалена заглушка `assay_enrichment` из `ChemblSourceConfig`.
 - Помечены deprecated несуществующие клиенты (PubChem, PubMed, Crossref, UniProt, SemanticScholar) в документации.

--- a/configs/pipelines/chembl/activity.yaml
+++ b/configs/pipelines/chembl/activity.yaml
@@ -24,9 +24,11 @@ sources:
       enabled: false
       page_limit: 100
 
-cli:
-  input_file: data/input/activity.csv
-  input_full_dataset: false
+input_mode: id_only
+input_path: data/input/activity.csv
+csv_options:
+  delimiter: ","
+  header: true
 
 fields:
   - name: action_type

--- a/configs/pipelines/chembl/assay.yaml
+++ b/configs/pipelines/chembl/assay.yaml
@@ -20,9 +20,11 @@ sources:
     base_url: "https://www.ebi.ac.uk/chembl/api/data"
     max_url_length: 2000
 
-cli:
-  input_file: data/input/assay.csv
-  input_full_dataset: false
+input_mode: id_only
+input_path: data/input/assay.csv
+csv_options:
+  delimiter: ","
+  header: true
 
 fields:
   - name: aidx

--- a/configs/pipelines/chembl/document.yaml
+++ b/configs/pipelines/chembl/document.yaml
@@ -21,9 +21,11 @@ sources:
     base_url: "https://www.ebi.ac.uk/chembl/api/data"
     max_url_length: 2000
 
-cli:
-  input_file: data/input/document.csv
-  input_full_dataset: false
+input_mode: id_only
+input_path: data/input/document.csv
+csv_options:
+  delimiter: ","
+  header: true
 
 fields:
   - name: abstract

--- a/configs/pipelines/chembl/molecule.yaml
+++ b/configs/pipelines/chembl/molecule.yaml
@@ -20,9 +20,11 @@ sources:
     base_url: "https://www.ebi.ac.uk/chembl/api/data"
     max_url_length: 2000
 
-cli:
-  input_file: data/input/testitem.csv
-  input_full_dataset: false
+input_mode: id_only
+input_path: data/input/testitem.csv
+csv_options:
+  delimiter: ","
+  header: true
   
 fields:
   - name: atc_classifications

--- a/configs/pipelines/chembl/target.yaml
+++ b/configs/pipelines/chembl/target.yaml
@@ -20,9 +20,11 @@ sources:
     base_url: "https://www.ebi.ac.uk/chembl/api/data"
     max_url_length: 2000
 
-cli:
-  input_file: data/input/target.csv
-  input_full_dataset: false
+input_mode: id_only
+input_path: data/input/target.csv
+csv_options:
+  delimiter: ","
+  header: true
 
 fields:
   - name: target_chembl_id

--- a/configs/pipelines/chembl/testitem.yaml
+++ b/configs/pipelines/chembl/testitem.yaml
@@ -21,9 +21,11 @@ sources:
     base_url: "https://www.ebi.ac.uk/chembl/api/data"
     max_url_length: 2000
 
-cli:
-  input_file: data/input/testitem.csv
-  input_full_dataset: false
+input_mode: id_only
+input_path: data/input/testitem.csv
+csv_options:
+  delimiter: ","
+  header: true
   
 fields:
   - name: molecule_chembl_id

--- a/docs/application/pipelines/chembl/activity/00-activity-chembl-overview.md
+++ b/docs/application/pipelines/chembl/activity/00-activity-chembl-overview.md
@@ -15,7 +15,7 @@
 
 ## Особенности
 
-- **CSV input**: поддерживаются два сценария — загрузка полного CSV через `cli.input_file` и догрузка активностей из API по списку ID, прочитанному из CSV.
+- **CSV input**: explicit control via `input_mode` (`csv` for full dataset, `id_only` for ID lists) and `input_path`; `csv_options` configures delimiter/header without column heuristics.
 - **Хеширование**: хеши рассчитываются после нормализации; набор полей для бизнес-ключа задается в `hashing.business_key_fields`, что обеспечивает воспроизводимое устранение дублей.
 
 ## Конфигурация

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,7 @@ sys.modules.setdefault("tqdm", MagicMock())
 
 from bioetl.interfaces.cli import app
 from bioetl.application.pipelines.base import PipelineBase
+from bioetl.infrastructure.config.models import PipelineConfig
 
 runner = CliRunner()
 
@@ -38,10 +39,9 @@ def test_validate_config_missing():
 @patch("bioetl.interfaces.cli.app.ConfigResolver")
 def test_validate_config_success(mock_resolver):
     """Test validate-config success."""
-    mock_config = MagicMock()
-    mock_config.entity_name = "test"
-    mock_config.provider = "chembl"
-    mock_resolver.return_value.resolve.return_value = mock_config
+    mock_resolver.return_value.resolve.return_value = PipelineConfig(
+        provider="chembl", entity_name="test", sources={}
+    )
 
     # Create a dummy file so Path exists check passes if any
     with runner.isolated_filesystem():
@@ -66,8 +66,7 @@ def test_run_command(mock_build_deps, mock_resolver, mock_get_cls):
     )
     mock_get_cls.return_value = mock_pipeline_cls
 
-    mock_config = MagicMock()
-    mock_config.provider = "chembl"
+    mock_config = PipelineConfig(provider="chembl", entity_name="activity", sources={})
     mock_config.storage.output_path = "out"
     mock_resolver.return_value.resolve.return_value = mock_config
 
@@ -134,8 +133,7 @@ def test_run_with_limit_and_dry_run(
     )
     mock_get_cls.return_value = mock_pipeline_cls
 
-    mock_config = MagicMock()
-    mock_config.provider = "chembl"
+    mock_config = PipelineConfig(provider="chembl", entity_name="activity", sources={})
     mock_config.storage.output_path = "out"
     mock_resolver.return_value.resolve.return_value = mock_config
     mock_build_deps.return_value = MagicMock()
@@ -163,7 +161,9 @@ def test_run_pipeline_failure(mock_build_deps, mock_resolver, mock_get_cls):
     mock_pipeline_instance.run.return_value = MagicMock(success=False)
     mock_get_cls.return_value = mock_pipeline_cls
 
-    mock_resolver.return_value.resolve.return_value = MagicMock()
+    mock_resolver.return_value.resolve.return_value = PipelineConfig(
+        provider="chembl", entity_name="activity", sources={}
+    )
     mock_build_deps.return_value = MagicMock()
 
     with patch("pathlib.Path.exists", return_value=True):


### PR DESCRIPTION
## Summary
- add typed input_mode/input_path/csv_options with migration from legacy cli fields
- refactor ChemblPipelineBase extraction to explicit record sources and update CLI overrides
- update ChEMBL configs and docs to use the new input settings

## Testing
- python -m pytest tests/test_cli.py tests/pipelines/chembl/activity/test_extract.py (coverage gate fails locally)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69305f49bb488324928e957934bf2676)