### PR TITLE
Refactor Chembl pipeline to use record sources and normalization DI

### DIFF
--- a/docs/ABC_INDEX.md
+++ b/docs/ABC_INDEX.md
@@ -1,0 +1,4 @@
+# ABC Index
+
+- `RecordSourceABC` → `bioetl.clients.records.contracts.RecordSourceABC` (default: `bioetl.clients.records.factories.default_record_source`)
+- `RecordNormalizationServiceABC` → `bioetl.clients.records.contracts.RecordNormalizationServiceABC` (default: `bioetl.clients.records.factories.default_normalization_service`)

--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -7,6 +7,10 @@ from bioetl.domain.schemas import register_schemas
 from bioetl.domain.schemas.registry import SchemaRegistry
 from bioetl.domain.transform.hash_service import HashService
 from bioetl.domain.validation.service import ValidationService
+from bioetl.clients.records.factories import (
+    default_normalization_service,
+    default_record_source,
+)
 from bioetl.infrastructure.clients.chembl.factories import (
     default_chembl_extraction_service,
 )
@@ -62,6 +66,18 @@ class PipelineContainer:
     def get_hash_service(self) -> HashService:
         """Get the hash service."""
         return HashService()
+
+    def get_record_source(self, extraction_service: Any, *, limit: int | None = None) -> Any:
+        """Get record source based on configuration."""
+        return default_record_source(
+            config=self.config,
+            extraction_service=extraction_service,
+            limit=limit,
+        )
+
+    def get_normalization_service(self) -> Any:
+        """Get record-level normalization service."""
+        return default_normalization_service(self.config)
 
 
 def build_pipeline_dependencies(config: PipelineConfig) -> PipelineContainer:

--- a/src/bioetl/application/pipelines/chembl/base.py
+++ b/src/bioetl/application/pipelines/chembl/base.py
@@ -1,31 +1,16 @@
 """
 Base pipeline implementation for ChEMBL data extraction.
 """
-from collections.abc import Iterator
 from typing import Any
 
-import pandas as pd
-
 from bioetl.application.pipelines.base import PipelineBase
-from bioetl.domain.contracts import ExtractionServiceABC
 from bioetl.domain.models import RunContext
+from bioetl.domain.records import NormalizationService, RawRecord, RecordSource
 from bioetl.domain.transform.hash_service import HashService
-from bioetl.domain.transform.impl.normalize import NormalizationService
 from bioetl.domain.validation.service import ValidationService
-from bioetl.infrastructure.config.models import (
-    ChemblSourceConfig,
-    PipelineConfig,
-)
+from bioetl.infrastructure.config.models import PipelineConfig
 from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
 from bioetl.infrastructure.output.unified_writer import UnifiedOutputWriter
-
-
-def _chunk_list(data: list[Any], size: int) -> Iterator[list[Any]]:
-    """Yield successive chunks from data."""
-    for i in range(0, len(data), size):
-        yield data[i:i + size]
-
-
 class ChemblPipelineBase(PipelineBase):
     """
     Базовый класс для ChEMBL-пайплайнов.
@@ -48,7 +33,8 @@ class ChemblPipelineBase(PipelineBase):
         logger: LoggerAdapterABC,
         validation_service: ValidationService,
         output_writer: UnifiedOutputWriter,
-        extraction_service: ExtractionServiceABC,
+        record_source: RecordSource,
+        normalization_service: NormalizationService,
         hash_service: HashService | None = None,
     ) -> None:
         super().__init__(
@@ -58,147 +44,45 @@ class ChemblPipelineBase(PipelineBase):
             output_writer,
             hash_service,
         )
-        self._extraction_service = extraction_service
+        self._record_source = record_source
+        self._normalization_service = normalization_service
         self._chembl_release: str | None = None
-
-        # Initialize normalization service
-        self._normalization_service = NormalizationService(config)
 
     def get_version(self) -> str:
         """Возвращает версию релиза ChEMBL (например, 'chembl_34')."""
         if self._chembl_release is None:
-            self._chembl_release = (
-                self._extraction_service.get_release_version()
-            )
+            meta = self._record_source.metadata()
+            self._chembl_release = str(meta.get("chembl_release", "unknown"))
         return self._chembl_release
     
     # Alias for compatibility if needed elsewhere, but we use get_version now.
     def get_chembl_release(self) -> str:
         return self.get_version()
 
-    def _resolve_source_config(self) -> ChemblSourceConfig:
-        """Resolve and validate ChEMBL source configuration."""
-        config = self._config.get_source_config("chembl")
-        if not isinstance(config, ChemblSourceConfig):
-            raise TypeError("Expected ChemblSourceConfig")
-        return config
+    def extract(self, **kwargs: Any) -> list[RawRecord]:
+        """Итерирует записи из RecordSource и материализует в список."""
+        return list(self._record_source.iter_records())
 
-    def extract(self, **kwargs: Any) -> pd.DataFrame:
-        """
-        Generic extract with CSV input support.
-
-        If config.cli['input_file'] is provided:
-        - Full CSV data → returned as-is (with optional limit)
-        - ID-only CSV → fetches full records from API
-
-        Otherwise delegates to ChemblExtractionService.extract_all().
-        """
-        entity = self._config.entity_name
-        limit = kwargs.get("limit")
-        path = self._config.cli.get("input_file")
-
-        if path:
-            self._logger.info(f"Extracting {entity} from CSV: {path}")
-            return self._extract_from_csv(path, limit)
-
-        self._logger.info(f"Extracting {entity} from API...")
-        filters = self._config.pipeline.copy()
-        filters.update(kwargs)
-        return self._extraction_service.extract_all(entity, **filters)
-
-    def _extract_from_csv(
-        self, path: str, limit: int | None
-    ) -> pd.DataFrame:
-        """Handle CSV input (full data or ID-only)."""
-        id_col = self.ID_COLUMN
-        if not id_col:
-            raise ValueError(
-                f"{self.__class__.__name__} must define ID_COLUMN"
-            )
-
-        header = pd.read_csv(path, nrows=0)
-        if id_col not in header.columns:
-            raise ValueError(f"Input file {path} must contain '{id_col}'")
-
-        # Check for explicit config override
-        is_full_dataset = self._config.cli.get("input_full_dataset")
-
-        if is_full_dataset is None:
-            # Heuristic: <= 2 columns means it's likely just IDs
-            is_id_only = len(header.columns) <= 2
-            is_full_dataset = not is_id_only
-
-        if is_full_dataset:
-            self._logger.info("Using input CSV as full dataset")
-            df = pd.read_csv(path)
-            if limit:
-                df = df.head(limit)
-            return df
-
-        self._logger.info("Detected ID-only CSV, fetching from API...")
-        return self._fetch_by_ids(path, id_col, limit)
-
-    def _fetch_by_ids(
-        self, path: str, id_col: str, limit: int | None
-    ) -> pd.DataFrame:
-        """Fetch full records from API for IDs in CSV."""
-        df_ids = pd.read_csv(path, usecols=[id_col])
-        ids = df_ids[id_col].dropna().astype(str).tolist()
-
-        if limit:
-            ids = ids[:limit]
-
-        if not ids:
-            return pd.DataFrame()
-
-        source_config = self._resolve_source_config()
-        batch_size = source_config.resolve_effective_batch_size(
-            limit=limit, hard_cap=25
-        )
-
-        records: list[dict[str, Any]] = []
-        entity = self._config.entity_name
-
-        for batch_ids in _chunk_list(ids, batch_size):
-            response = self._request_batch(entity, batch_ids)
-            batch_records = self._extraction_service.parse_response(response)
-            # Serialize records using model to ensure format consistency (flattening, etc)
-            serialized_records = self._extraction_service.serialize_records(entity, batch_records)
-            records.extend(serialized_records)
-
-        return pd.DataFrame(records)
-
-    def _request_batch(
-        self, entity: str, batch_ids: list[str]
-    ) -> dict[str, Any]:
-        """Request a batch of records by IDs from the API."""
-        filter_key = self.API_FILTER_KEY
-        if not filter_key:
-            raise ValueError(
-                f"{self.__class__.__name__} must define API_FILTER_KEY"
-            )
-        return self._extraction_service.request_batch(
-            entity, batch_ids, filter_key
-        )
-
-    def transform(self, df: pd.DataFrame) -> pd.DataFrame:
+    def transform(self, data: Any) -> Any:
         """
         Цепочка трансформаций для ChEMBL:
-        pre_transform → _do_transform → normalize_fields → enforce_schema
+        pre_transform → _do_transform → normalize → enforce_schema
         """
+        df = self._to_dataframe(data)
         df = self.pre_transform(df)
         df = self._do_transform(df)
 
-        # Выполняем нормализацию (строки, числа, вложенные структуры)
-        df = self._normalization_service.normalize_fields(df)
+        normalized_records = list(
+            self._normalization_service.normalize_many(
+                df.to_dict(orient="records")
+            )
+        )
 
-        # Приводим к схеме (добавляем отсутствующие колонки, упорядочиваем)
-        df = self._enforce_schema(df)
+        df_normalized = self._to_dataframe(normalized_records)
+        df_normalized = self._enforce_schema(df_normalized)
+        df_normalized = self._drop_nulls_in_required_columns(df_normalized)
 
-        # Удаляем строки с NULL в обязательных колонках
-        df = self._drop_nulls_in_required_columns(df)
-
-        return df
+        return df_normalized
 
     def _drop_nulls_in_required_columns(self, df: pd.DataFrame) -> pd.DataFrame:
         """

--- a/src/bioetl/application/pipelines/chembl/pipeline.py
+++ b/src/bioetl/application/pipelines/chembl/pipeline.py
@@ -5,7 +5,7 @@ Replaces specific pipeline implementations (Activity, Assay, etc.)
 with a configurable generic implementation.
 """
 from bioetl.application.pipelines.chembl.base import ChemblPipelineBase
-from bioetl.domain.contracts import ExtractionServiceABC
+from bioetl.domain.records import NormalizationService, RecordSource
 from bioetl.domain.transform.hash_service import HashService
 from bioetl.domain.validation.service import ValidationService
 from bioetl.infrastructure.config.models import PipelineConfig
@@ -25,7 +25,8 @@ class ChemblEntityPipeline(ChemblPipelineBase):
         logger: LoggerAdapterABC,
         validation_service: ValidationService,
         output_writer: UnifiedOutputWriter,
-        extraction_service: ExtractionServiceABC,
+        record_source: RecordSource,
+        normalization_service: NormalizationService,
         hash_service: HashService | None = None,
     ) -> None:
         super().__init__(
@@ -33,7 +34,8 @@ class ChemblEntityPipeline(ChemblPipelineBase):
             logger,
             validation_service,
             output_writer,
-            extraction_service,
+            record_source,
+            normalization_service,
             hash_service,
         )
 

--- a/src/bioetl/clients/chembl/impl/__init__.py
+++ b/src/bioetl/clients/chembl/impl/__init__.py
@@ -1,0 +1,7 @@
+"""ChEMBL-specific client implementations."""
+
+from bioetl.clients.chembl.impl.chembl_normalization_service import (
+    ChemblNormalizationServiceImpl,
+)
+
+__all__ = ["ChemblNormalizationServiceImpl"]

--- a/src/bioetl/clients/chembl/impl/chembl_normalization_service.py
+++ b/src/bioetl/clients/chembl/impl/chembl_normalization_service.py
@@ -1,0 +1,114 @@
+"""Record-level normalization for ChEMBL payloads."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, Callable
+
+import pandas as pd
+
+from bioetl.clients.records.contracts import RecordNormalizationServiceABC
+from bioetl.domain.records import NormalizedRecord, RawRecord
+from bioetl.domain.transform.impl.serializer import serialize_dict, serialize_list
+from bioetl.domain.transform.normalizers.registry import get_normalizer
+
+
+def _normalize_scalar(value: Any, mode: str = "default") -> Any:
+    if value is None:
+        return None
+
+    try:
+        if pd.isna(value):
+            return None
+    except ValueError:
+        pass
+
+    if isinstance(value, float):
+        return round(value, 3)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        val = value.strip()
+        if not val:
+            return None
+        if mode == "id":
+            return val.upper()
+        if mode == "sensitive":
+            return val
+        return val.lower()
+    return value
+
+
+class ChemblNormalizationServiceImpl(RecordNormalizationServiceABC):
+    """Normalize raw ChEMBL records to canonical shape."""
+
+    def __init__(
+        self,
+        *,
+        fields: list[dict[str, Any]],
+        case_sensitive_fields: list[str],
+        id_fields: list[str],
+    ) -> None:
+        self._fields = fields
+        self._case_sensitive_fields = set(case_sensitive_fields)
+        self._id_fields = set(id_fields)
+
+    def normalize(self, record: RawRecord) -> NormalizedRecord:
+        normalized: NormalizedRecord = dict(record)
+
+        for field_cfg in self._fields:
+            name = field_cfg["name"]
+            dtype = field_cfg.get("data_type")
+            mode = self._resolve_mode(name)
+
+            custom_normalizer = get_normalizer(name)
+            base_normalizer: Callable[[Any], Any] = (
+                custom_normalizer if custom_normalizer else lambda val: _normalize_scalar(val, mode)
+            )
+
+            value = record.get(name)
+            normalized[name] = self._normalize_value(
+                value=value, dtype=dtype, normalizer=base_normalizer, field_name=name
+            )
+
+        return normalized
+
+    def normalize_many(self, records: Iterable[RawRecord]) -> Iterable[NormalizedRecord]:
+        for record in records:
+            yield self.normalize(record)
+
+    def _normalize_value(
+        self,
+        *,
+        value: Any,
+        dtype: str | None,
+        normalizer: Callable[[Any], Any],
+        field_name: str,
+    ) -> Any:
+        if dtype in ("array", "object"):
+            if isinstance(value, dict):
+                return serialize_dict(value, value_normalizer=normalizer)
+            if isinstance(value, (list, tuple)):
+                return serialize_list(list(value), value_normalizer=normalizer)
+            return None
+
+        if dtype in ("string", "integer", "number", "float", "boolean"):
+            try:
+                return normalizer(value)
+            except ValueError as exc:  # pragma: no cover - defensive
+                raise ValueError(
+                    f"Normalization error for field '{field_name}': {exc}"
+                ) from exc
+
+        return value
+
+    def _resolve_mode(self, field_name: str) -> str:
+        if field_name in self._case_sensitive_fields:
+            return "sensitive"
+        if field_name in self._id_fields or field_name.endswith("_id"):
+            return "id"
+        if field_name.endswith("_chembl_id") or field_name.startswith("id_"):
+            return "id"
+        return "default"
+
+
+__all__ = ["ChemblNormalizationServiceImpl"]

--- a/src/bioetl/clients/records/__init__.py
+++ b/src/bioetl/clients/records/__init__.py
@@ -1,0 +1,17 @@
+"""Record source clients and normalization services."""
+
+from bioetl.clients.records.contracts import (
+    RecordNormalizationServiceABC,
+    RecordSourceABC,
+)
+from bioetl.clients.records.factories import (
+    default_normalization_service,
+    default_record_source,
+)
+
+__all__ = [
+    "RecordNormalizationServiceABC",
+    "RecordSourceABC",
+    "default_normalization_service",
+    "default_record_source",
+]

--- a/src/bioetl/clients/records/contracts.py
+++ b/src/bioetl/clients/records/contracts.py
@@ -1,0 +1,47 @@
+"""Contracts for record sources and normalization services."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterable, Iterator
+from typing import Any
+
+from bioetl.domain.records import NormalizationService, RawRecord
+
+
+class RecordSourceABC(ABC):
+    """
+    Abstract contract for record-level sources.
+
+    Provides streaming access to raw records along with optional metadata
+    (release versions, file paths, etc.).
+    Default factory: ``bioetl.clients.records.factories.default_record_source``
+    Implementations: ``CsvRecordSourceImpl``, ``IdOnlyRecordSourceImpl``
+    """
+
+    @abstractmethod
+    def iter_records(self) -> Iterator[RawRecord]:
+        """Return an iterator over raw records."""
+
+    @abstractmethod
+    def metadata(self) -> dict[str, Any]:
+        """Return source metadata for observability."""
+
+
+class RecordNormalizationServiceABC(NormalizationService, ABC):
+    """
+    Abstract contract for record-level normalization.
+
+    Default factory: ``bioetl.clients.records.factories.default_normalization_service``
+    Implementations: ``ChemblNormalizationServiceImpl``
+    """
+
+    @abstractmethod
+    def normalize(self, record: RawRecord) -> RawRecord:  # type: ignore[override]
+        """Normalize a single record."""
+
+    @abstractmethod
+    def normalize_many(self, records: Iterable[RawRecord]) -> Iterable[RawRecord]:  # type: ignore[override]
+        """Normalize multiple records preserving order."""
+
+
+__all__ = ["RecordSourceABC", "RecordNormalizationServiceABC"]

--- a/src/bioetl/clients/records/factories.py
+++ b/src/bioetl/clients/records/factories.py
@@ -1,0 +1,96 @@
+"""Default factories for record sources and normalization services."""
+from __future__ import annotations
+
+from typing import Any
+
+from bioetl.clients.records.contracts import (
+    RecordNormalizationServiceABC,
+    RecordSourceABC,
+)
+from bioetl.clients.records.impl.api_record_source import ChemblApiRecordSourceImpl
+from bioetl.clients.records.impl.csv_record_source import CsvRecordSourceImpl
+from bioetl.clients.records.impl.id_only_record_source import IdOnlyRecordSourceImpl
+from bioetl.clients.chembl.impl.chembl_normalization_service import (
+    ChemblNormalizationServiceImpl,
+)
+from bioetl.domain.contracts import ExtractionServiceABC
+from bioetl.domain.records import NormalizedRecord
+from bioetl.infrastructure.config.models import ChemblSourceConfig, PipelineConfig
+
+
+def _resolve_id_column(config: PipelineConfig) -> str:
+    explicit = config.primary_key
+    if not explicit and config.pipeline and "primary_key" in config.pipeline:
+        explicit = config.pipeline["primary_key"]
+    return explicit or f"{config.entity_name}_id"
+
+
+def default_record_source(
+    config: PipelineConfig,
+    extraction_service: ExtractionServiceABC,
+    *,
+    limit: int | None = None,
+) -> RecordSourceABC:
+    """Return the appropriate record source based on CLI configuration."""
+
+    input_path = config.cli.get("input_file")
+    id_column = _resolve_id_column(config)
+
+    if input_path:
+        header = CsvRecordSourceImpl.peek_columns(input_path)
+        is_full_dataset = config.cli.get("input_full_dataset")
+
+        if is_full_dataset is None:
+            is_full_dataset = len(header) > 2
+
+        if is_full_dataset:
+            return CsvRecordSourceImpl(path=input_path, limit=limit)
+
+        filter_key = f"{id_column}__in"
+        source_cfg = config.get_source_config("chembl")
+        if not isinstance(source_cfg, ChemblSourceConfig):
+            raise TypeError("Expected ChemblSourceConfig")
+
+        batch_size = source_cfg.resolve_effective_batch_size(
+            limit=limit, hard_cap=25
+        )
+
+        return IdOnlyRecordSourceImpl(
+            path=input_path,
+            id_column=id_column,
+            extraction_service=extraction_service,
+            entity=config.entity_name,
+            filter_key=filter_key,
+            batch_size=batch_size,
+        )
+
+    filters: dict[str, Any] = {}
+    if config.pipeline:
+        filters.update(config.pipeline)
+    return ChemblApiRecordSourceImpl(
+        extraction_service=extraction_service,
+        entity=config.entity_name,
+        filters=filters,
+        limit=limit,
+    )
+
+
+def default_normalization_service(
+    config: PipelineConfig,
+) -> RecordNormalizationServiceABC:
+    """Create default normalization service for record-level processing."""
+
+    fields = config.fields or []
+    normalization_cfg = config.normalization
+    return ChemblNormalizationServiceImpl(
+        fields=fields,
+        case_sensitive_fields=normalization_cfg.case_sensitive_fields,
+        id_fields=normalization_cfg.id_fields,
+    )
+
+
+__all__ = [
+    "default_record_source",
+    "default_normalization_service",
+    "NormalizedRecord",
+]

--- a/src/bioetl/clients/records/impl/__init__.py
+++ b/src/bioetl/clients/records/impl/__init__.py
@@ -1,0 +1,11 @@
+"""Implementations for record source clients."""
+
+from bioetl.clients.records.impl.api_record_source import ChemblApiRecordSourceImpl
+from bioetl.clients.records.impl.csv_record_source import CsvRecordSourceImpl
+from bioetl.clients.records.impl.id_only_record_source import IdOnlyRecordSourceImpl
+
+__all__ = [
+    "ChemblApiRecordSourceImpl",
+    "CsvRecordSourceImpl",
+    "IdOnlyRecordSourceImpl",
+]

--- a/src/bioetl/clients/records/impl/api_record_source.py
+++ b/src/bioetl/clients/records/impl/api_record_source.py
@@ -1,0 +1,53 @@
+"""API-backed record source for ChEMBL entities."""
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pandas as pd
+
+from bioetl.clients.records.contracts import RecordSourceABC
+from bioetl.domain.contracts import ExtractionServiceABC
+from bioetl.domain.records import RawRecord
+
+
+class ChemblApiRecordSourceImpl(RecordSourceABC):
+    """
+    Record source that fetches records directly from the ChEMBL API.
+
+    Uses the configured ``ExtractionServiceABC`` to fetch all records with
+    optional filters and returns them as an iterator of ``RawRecord``.
+    """
+
+    def __init__(
+        self,
+        extraction_service: ExtractionServiceABC,
+        entity: str,
+        filters: dict[str, Any] | None = None,
+        limit: int | None = None,
+    ) -> None:
+        self._extraction_service = extraction_service
+        self._entity = entity
+        self._filters = filters or {}
+        self._limit = limit
+        self._metadata: dict[str, Any] | None = None
+
+    def iter_records(self) -> Iterator[RawRecord]:
+        df = self._extraction_service.extract_all(self._entity, **self._filters)
+        if self._limit:
+            df = df.head(self._limit)
+        yield from df.to_dict(orient="records")
+
+    def metadata(self) -> dict[str, Any]:
+        if self._metadata is None:
+            version = self._extraction_service.get_release_version()
+            self._metadata = {
+                "chembl_release": version,
+                "entity": self._entity,
+                "filters": self._filters,
+                "limit": self._limit,
+            }
+        return self._metadata
+
+
+__all__ = ["ChemblApiRecordSourceImpl"]

--- a/src/bioetl/clients/records/impl/csv_record_source.py
+++ b/src/bioetl/clients/records/impl/csv_record_source.py
@@ -1,0 +1,40 @@
+"""CSV-backed record source implementation."""
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pandas as pd
+
+from bioetl.clients.records.contracts import RecordSourceABC
+from bioetl.domain.records import RawRecord
+
+
+class CsvRecordSourceImpl(RecordSourceABC):
+    """Read full records from a CSV file and stream as dictionaries."""
+
+    def __init__(self, path: str, *, limit: int | None = None) -> None:
+        self._path = path
+        self._limit = limit
+
+    @staticmethod
+    def peek_columns(path: str) -> list[str]:
+        """Read header columns without materializing the dataset."""
+        header = pd.read_csv(path, nrows=0)
+        return list(header.columns)
+
+    def iter_records(self) -> Iterator[RawRecord]:
+        df = pd.read_csv(self._path)
+        if self._limit:
+            df = df.head(self._limit)
+        yield from df.to_dict(orient="records")
+
+    def metadata(self) -> dict[str, Any]:
+        return {
+            "source": "csv",
+            "path": self._path,
+            "limit": self._limit,
+        }
+
+
+__all__ = ["CsvRecordSourceImpl"]

--- a/src/bioetl/clients/records/impl/id_only_record_source.py
+++ b/src/bioetl/clients/records/impl/id_only_record_source.py
@@ -1,0 +1,69 @@
+"""ID-only CSV adapter that enriches records via the extraction service."""
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pandas as pd
+
+from bioetl.clients.records.contracts import RecordSourceABC
+from bioetl.domain.contracts import ExtractionServiceABC
+from bioetl.domain.records import RawRecord
+
+
+def _chunk_list(data: list[Any], size: int) -> Iterator[list[Any]]:
+    for i in range(0, len(data), size):
+        yield data[i : i + size]
+
+
+class IdOnlyRecordSourceImpl(RecordSourceABC):
+    """Fetch full records for ID-only CSV inputs."""
+
+    def __init__(
+        self,
+        path: str,
+        id_column: str,
+        extraction_service: ExtractionServiceABC,
+        *,
+        entity: str,
+        filter_key: str,
+        batch_size: int,
+        limit: int | None = None,
+    ) -> None:
+        self._path = path
+        self._id_column = id_column
+        self._extraction_service = extraction_service
+        self._entity = entity
+        self._filter_key = filter_key
+        self._batch_size = batch_size
+        self._limit = limit
+
+    def iter_records(self) -> Iterator[RawRecord]:
+        ids_df = pd.read_csv(self._path, usecols=[self._id_column])
+        ids = ids_df[self._id_column].dropna().astype(str).tolist()
+        if self._limit:
+            ids = ids[: self._limit]
+
+        for batch in _chunk_list(ids, self._batch_size):
+            response = self._extraction_service.request_batch(
+                self._entity, batch, self._filter_key
+            )
+            parsed = self._extraction_service.parse_response(response)
+            serialized = self._extraction_service.serialize_records(
+                self._entity, parsed
+            )
+            for record in serialized:
+                yield record
+
+    def metadata(self) -> dict[str, Any]:
+        return {
+            "source": "id_only_csv",
+            "path": self._path,
+            "id_column": self._id_column,
+            "batch_size": self._batch_size,
+            "limit": self._limit,
+            "chembl_release": self._extraction_service.get_release_version(),
+        }
+
+
+__all__ = ["IdOnlyRecordSourceImpl"]

--- a/src/bioetl/domain/records.py
+++ b/src/bioetl/domain/records.py
@@ -1,0 +1,40 @@
+"""Record-level domain protocols and type aliases."""
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from typing import Any, Protocol, TypeAlias
+
+
+RawRecord: TypeAlias = dict[str, Any]
+"""Unnormalized record payload returned by sources."""
+
+NormalizedRecord: TypeAlias = dict[str, Any]
+"""Record payload after normalization and schema alignment."""
+
+
+class RecordSource(Protocol):
+    """Protocol for streaming raw records from an input source."""
+
+    def iter_records(self) -> Iterator[RawRecord]:
+        """Return an iterator yielding raw records."""
+
+    def metadata(self) -> dict[str, Any]:
+        """Return optional metadata about the source (release, path, etc.)."""
+
+
+class NormalizationService(Protocol):
+    """Protocol for record-level normalization."""
+
+    def normalize(self, record: RawRecord) -> NormalizedRecord:
+        """Normalize a single raw record to the canonical shape."""
+
+    def normalize_many(self, records: Iterable[RawRecord]) -> Iterable[NormalizedRecord]:
+        """Normalize multiple raw records preserving order."""
+
+
+__all__ = [
+    "RawRecord",
+    "NormalizedRecord",
+    "RecordSource",
+    "NormalizationService",
+]

--- a/src/bioetl/infrastructure/clients/base/abc_impls.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_impls.yaml
@@ -43,3 +43,15 @@ MetadataWriterABC:
   implementations:
     Standard: bioetl.infrastructure.output.impl.metadata_writer.MetadataWriterImpl
 
+RecordSourceABC:
+  default_factory: bioetl.clients.records.factories.default_record_source
+  implementations:
+    Csv: bioetl.clients.records.impl.csv_record_source.CsvRecordSourceImpl
+    IdOnlyCsv: bioetl.clients.records.impl.id_only_record_source.IdOnlyRecordSourceImpl
+    ChemblApi: bioetl.clients.records.impl.api_record_source.ChemblApiRecordSourceImpl
+
+RecordNormalizationServiceABC:
+  default_factory: bioetl.clients.records.factories.default_normalization_service
+  implementations:
+    Chembl: bioetl.clients.chembl.impl.chembl_normalization_service.ChemblNormalizationServiceImpl
+

--- a/src/bioetl/infrastructure/clients/base/abc_registry.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_registry.yaml
@@ -23,6 +23,8 @@ TracerABC: bioetl.infrastructure.logging.contracts.TracerABC
 
 HasherABC: bioetl.domain.transform.contracts.HasherABC
 NormalizationServiceABC: bioetl.domain.transform.contracts.NormalizationServiceABC
+RecordSourceABC: bioetl.clients.records.contracts.RecordSourceABC
+RecordNormalizationServiceABC: bioetl.clients.records.contracts.RecordNormalizationServiceABC
 
 ValidatorABC: bioetl.domain.validation.contracts.ValidatorABC
 SchemaProviderABC: bioetl.domain.validation.contracts.SchemaProviderABC

--- a/src/bioetl/interfaces/cli/app.py
+++ b/src/bioetl/interfaces/cli/app.py
@@ -101,12 +101,17 @@ def run(
 
         # 3. Instantiate Dependencies using Container
         container = build_pipeline_dependencies(config)
-        
+
         logger = container.get_logger()
         validation_service = container.get_validation_service()
         output_writer = container.get_output_writer()
         extraction_service = container.get_extraction_service()
         hash_service = container.get_hash_service()
+
+        record_source = container.get_record_source(
+            extraction_service, limit=limit
+        )
+        normalization_service = container.get_normalization_service()
 
         # 4. Run Pipeline
         pipeline = pipeline_cls(
@@ -114,7 +119,8 @@ def run(
             logger=logger,
             validation_service=validation_service,
             output_writer=output_writer,
-            extraction_service=extraction_service,
+            record_source=record_source,
+            normalization_service=normalization_service,
             hash_service=hash_service
         )
         


### PR DESCRIPTION
## Summary
- add record-level protocols plus CSV/API/ID-only record source adapters with default factories and registry entries
- implement Chembl normalization service for record-level processing and refactor Chembl pipeline to stream and normalize records without direct pandas imports
- extend the DI container and ABC index/registries to wire new services

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69305eab1bd883249aac9b78d4f27b72)