### PR TITLE
Refactor container to use provider registry

### DIFF
--- a/src/bioetl/core/__init__.py
+++ b/src/bioetl/core/__init__.py
@@ -1,0 +1,5 @@
+"""Core abstractions for provider management and container composition."""
+
+__all__ = [
+    "providers",
+]

--- a/src/bioetl/core/provider_registry.py
+++ b/src/bioetl/core/provider_registry.py
@@ -1,0 +1,74 @@
+"""Typed registry for provider definitions."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from bioetl.core.providers import ProviderDefinition, ProviderId
+
+__all__ = [
+    "ProviderNotRegisteredError",
+    "ProviderRegistryError",
+    "ProviderAlreadyRegisteredError",
+    "get_provider",
+    "list_providers",
+    "register_provider",
+    "reset_provider_registry",
+    "restore_provider_registry",
+]
+
+
+class ProviderRegistryError(RuntimeError):
+    """Base class for provider registry errors."""
+
+
+class ProviderNotRegisteredError(ProviderRegistryError):
+    """Raised when provider is not registered in the registry."""
+
+
+class ProviderAlreadyRegisteredError(ProviderRegistryError):
+    """Raised when attempting to register a duplicate provider id."""
+
+
+_registry: dict[ProviderId, ProviderDefinition] = {}
+
+
+def register_provider(definition: ProviderDefinition) -> None:
+    """Register provider definition in the registry."""
+
+    if definition.id in _registry:
+        raise ProviderAlreadyRegisteredError(
+            f"Provider '{definition.id.value}' already registered"
+        )
+    _registry[definition.id] = definition
+
+
+def get_provider(provider_id: ProviderId) -> ProviderDefinition:
+    """Get provider definition by id."""
+
+    try:
+        return _registry[provider_id]
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise ProviderNotRegisteredError(
+            f"Provider '{provider_id.value}' is not registered"
+        ) from exc
+
+
+def list_providers() -> list[ProviderDefinition]:
+    """List all registered provider definitions."""
+
+    return list(_registry.values())
+
+
+def reset_provider_registry() -> None:
+    """Clear registry (intended for test isolation)."""
+
+    _registry.clear()
+
+
+def restore_provider_registry(definitions: Iterable[ProviderDefinition]) -> None:
+    """Restore registry to provided definitions (used in tests)."""
+
+    reset_provider_registry()
+    for definition in definitions:
+        _registry[definition.id] = definition

--- a/src/bioetl/core/providers.py
+++ b/src/bioetl/core/providers.py
@@ -1,0 +1,60 @@
+"""Provider abstractions and metadata definitions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol, TypeVar
+
+from pydantic import BaseModel
+
+ProviderConfigT = TypeVar("ProviderConfigT", bound="BaseProviderConfig")
+ProviderClientT = TypeVar("ProviderClientT")
+ExtractionServiceT = TypeVar("ExtractionServiceT")
+
+
+class ProviderId(str, Enum):
+    """Canonical provider identifiers following PIPE-002."""
+
+    CHEMBL = "chembl"
+    PUBCHEM = "pubchem"
+    UNIPROT = "uniprot"
+    PUBMED = "pubmed"
+
+
+class BaseProviderConfig(BaseModel):
+    """Base class for provider-specific configuration models."""
+
+    model_config = {
+        "extra": "forbid",
+    }
+
+
+class ProviderComponents(Protocol[ProviderConfigT, ProviderClientT, ExtractionServiceT]):
+    """Protocol describing provider component factories."""
+
+    def create_client(self, config: ProviderConfigT) -> ProviderClientT:
+        """Create provider client instance."""
+
+    def create_extraction_service(
+        self, client: ProviderClientT, config: ProviderConfigT
+    ) -> ExtractionServiceT:
+        """Create provider-specific extraction service."""
+
+
+@dataclass(frozen=True)
+class ProviderDefinition:
+    """Provider metadata and factory entry points."""
+
+    id: ProviderId
+    config_type: type[ProviderConfigT]
+    components: ProviderComponents[ProviderConfigT, ProviderClientT, ExtractionServiceT]
+    description: str | None = None
+
+
+__all__ = [
+    "BaseProviderConfig",
+    "ProviderComponents",
+    "ProviderDefinition",
+    "ProviderId",
+]

--- a/src/bioetl/infrastructure/clients/chembl/provider.py
+++ b/src/bioetl/infrastructure/clients/chembl/provider.py
@@ -1,0 +1,57 @@
+"""ChEMBL provider components and registration."""
+
+from __future__ import annotations
+
+from bioetl.application.services.chembl_extraction import ChemblExtractionService
+from bioetl.core.provider_registry import (
+    ProviderAlreadyRegisteredError,
+    get_provider,
+    register_provider,
+)
+from bioetl.core.providers import (
+    ProviderComponents,
+    ProviderDefinition,
+    ProviderId,
+)
+from bioetl.infrastructure.clients.chembl.contracts import ChemblDataClientABC
+from bioetl.infrastructure.clients.chembl.factories import default_chembl_client
+from bioetl.infrastructure.config.models import ChemblSourceConfig
+
+
+class ChemblProviderComponents(
+    ProviderComponents[ChemblSourceConfig, ChemblDataClientABC, ChemblExtractionService]
+):
+    """Factory set for building ChEMBL provider components."""
+
+    def create_client(self, config: ChemblSourceConfig) -> ChemblDataClientABC:
+        return default_chembl_client(config)
+
+    def create_extraction_service(
+        self, client: ChemblDataClientABC, config: ChemblSourceConfig
+    ) -> ChemblExtractionService:
+        batch_size = config.resolve_effective_batch_size(hard_cap=1000)
+        return ChemblExtractionService(client=client, batch_size=batch_size)
+
+
+def register_chembl_provider() -> ProviderDefinition:
+    """Register ChEMBL provider in the global registry."""
+
+    definition = ProviderDefinition(
+        id=ProviderId.CHEMBL,
+        config_type=ChemblSourceConfig,
+        components=ChemblProviderComponents(),
+        description="ChEMBL data provider",
+    )
+    try:
+        register_provider(definition)
+    except ProviderAlreadyRegisteredError:
+        return get_provider(ProviderId.CHEMBL)
+    return definition
+
+
+register_chembl_provider()
+
+__all__ = [
+    "ChemblProviderComponents",
+    "register_chembl_provider",
+]

--- a/src/bioetl/infrastructure/config/models.py
+++ b/src/bioetl/infrastructure/config/models.py
@@ -1,7 +1,10 @@
 from pathlib import Path
 from typing import Annotated, Any, Literal, Optional
 
-from pydantic import BaseModel, Field, PositiveInt, field_validator, model_validator
+from pydantic import BaseModel, Field, PositiveInt, ValidationError, field_validator, model_validator
+
+from bioetl.core.provider_registry import get_provider
+from bioetl.core.providers import BaseProviderConfig, ProviderId
 
 
 class PaginationConfig(BaseModel):
@@ -61,7 +64,7 @@ class NormalizationConfig(BaseModel):
 # =============================================================================
 
 
-class SourceConfigBase(BaseModel):
+class SourceConfigBase(BaseProviderConfig):
     """
     Базовая конфигурация источника данных.
     Все провайдер-специфичные конфиги наследуют от неё.
@@ -96,7 +99,7 @@ class ChemblSourceConfig(SourceConfigBase):
     Конфигурация источника ChEMBL.
     Все параметры подключения на верхнем уровне (без вложенного 'parameters').
     """
-    provider: Literal["chembl"] = "chembl"
+    provider: ProviderId = ProviderId.CHEMBL
     base_url: str = "https://www.ebi.ac.uk/chembl/api/data"
     max_url_length: PositiveInt = 2000
 
@@ -133,7 +136,7 @@ class PipelineConfig(BaseModel):
     """
     Полная конфигурация пайплайна.
     """
-    provider: str
+    provider: ProviderId
     entity_name: str
     primary_key: Optional[str] = None  # Added to support custom PKs like assay_chembl_id
     input_mode: Literal["csv", "id_only", "auto_detect"] = "auto_detect"
@@ -153,24 +156,31 @@ class PipelineConfig(BaseModel):
     )
 
     # Sources configuration - keyed by provider name
-    sources: dict[str, ChemblSourceConfig | dict[str, Any]] = Field(
+    sources: dict[str, BaseProviderConfig | dict[str, Any]] = Field(
         default_factory=dict
     )
 
-    def get_source_config(self, provider: str) -> SourceConfigBase:
+    def get_source_config(self, provider: ProviderId | str) -> SourceConfigBase:
         """
         Get typed source config for provider.
         Handles both dict and typed config objects.
         """
-        raw = self.sources.get(provider, {})
-        if isinstance(raw, SourceConfigBase):
-            return raw
+        provider_id = ProviderId(provider)
+        definition = get_provider(provider_id)
+        raw = self.sources.get(provider_id.value, {})
+        if isinstance(raw, BaseProviderConfig):
+            if isinstance(raw, definition.config_type):
+                return raw
+            return definition.config_type.model_validate(raw.model_dump())
 
-        # Parse dict into typed config
-        if provider == "chembl":
-            return ChemblSourceConfig(**raw)
+        if not isinstance(raw, dict):
+            raise TypeError("Source configuration must be a mapping")
 
-        raise ValueError(f"Unknown provider: {provider}")
+        try:
+            return definition.config_type.model_validate(raw)
+        except ValidationError:
+            # Re-raise to keep pydantic trace for callers
+            raise
 
     # Additional pipeline specific fields
     pipeline: dict[str, Any] = Field(default_factory=dict)

--- a/tests/bioetl/core/test_container.py
+++ b/tests/bioetl/core/test_container.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+sys.modules.setdefault("tqdm", SimpleNamespace(tqdm=lambda *args: None))
+
+from bioetl.application.container import PipelineContainer
+from bioetl.core.provider_registry import ProviderNotRegisteredError, list_providers, restore_provider_registry
+from bioetl.core.providers import ProviderId
+from bioetl.infrastructure.clients.chembl.provider import register_chembl_provider
+from bioetl.infrastructure.config.models import PipelineConfig
+
+
+@pytest.fixture(autouse=True)
+def _restore_registry() -> None:
+    snapshot = list_providers()
+    yield
+    restore_provider_registry(snapshot)
+
+
+def test_get_extraction_service_for_chembl() -> None:
+    register_chembl_provider()
+    container = PipelineContainer(
+        PipelineConfig(provider=ProviderId.CHEMBL, entity_name="activity", sources={})
+    )
+
+    service = container.get_extraction_service()
+
+    from bioetl.application.services.chembl_extraction import ChemblExtractionService
+
+    assert isinstance(service, ChemblExtractionService)
+
+
+def test_unknown_provider_raises() -> None:
+    container = PipelineContainer(
+        PipelineConfig(provider=ProviderId.PUBCHEM, entity_name="compound", sources={})
+    )
+
+    with pytest.raises(ProviderNotRegisteredError):
+        container.get_extraction_service()
+
+
+def test_config_validation_error_is_propagated() -> None:
+    register_chembl_provider()
+    container = PipelineContainer(
+        PipelineConfig(
+            provider=ProviderId.CHEMBL,
+            entity_name="activity",
+            sources={"chembl": {"max_url_length": 0}},
+        )
+    )
+
+    with pytest.raises(ValidationError):
+        container.get_extraction_service()

--- a/tests/bioetl/core/test_provider_registry.py
+++ b/tests/bioetl/core/test_provider_registry.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from bioetl.core.provider_registry import (
+    ProviderAlreadyRegisteredError,
+    ProviderNotRegisteredError,
+    get_provider,
+    list_providers,
+    register_provider,
+    reset_provider_registry,
+    restore_provider_registry,
+)
+from bioetl.core.providers import (
+    BaseProviderConfig,
+    ProviderComponents,
+    ProviderDefinition,
+    ProviderId,
+)
+
+
+class DummyConfig(BaseProviderConfig):
+    value: str = "payload"
+
+
+@dataclass(frozen=True)
+class DummyComponents(ProviderComponents[DummyConfig, str, str]):
+    def create_client(self, config: DummyConfig) -> str:
+        return f"client:{config.value}"
+
+    def create_extraction_service(self, client: str, config: DummyConfig) -> str:
+        return f"service:{client}:{config.value}"
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry() -> Any:
+    snapshot = list_providers()
+    yield
+    restore_provider_registry(snapshot)
+
+
+def test_register_and_get_provider() -> None:
+    reset_provider_registry()
+    definition = ProviderDefinition(
+        id=ProviderId.PUBCHEM,
+        config_type=DummyConfig,
+        components=DummyComponents(),
+        description="PubChem provider for tests",
+    )
+
+    register_provider(definition)
+
+    assert get_provider(ProviderId.PUBCHEM) == definition
+    assert list_providers() == [definition]
+
+
+def test_unknown_provider_raises() -> None:
+    reset_provider_registry()
+
+    with pytest.raises(ProviderNotRegisteredError):
+        get_provider(ProviderId.CHEMBL)
+
+
+def test_duplicate_registration_is_rejected() -> None:
+    reset_provider_registry()
+    definition = ProviderDefinition(
+        id=ProviderId.UNIPROT,
+        config_type=DummyConfig,
+        components=DummyComponents(),
+    )
+    register_provider(definition)
+
+    with pytest.raises(ProviderAlreadyRegisteredError):
+        register_provider(definition)


### PR DESCRIPTION
## Summary
- add typed provider abstractions and registry for dynamic provider resolution
- refactor the pipeline container to build clients and services from registry definitions
- implement Chembl provider registration and add unit tests for the registry and container

## Testing
- pytest tests/bioetl/core/test_provider_registry.py tests/bioetl/core/test_container.py --cov=src/bioetl/application/container.py --cov=src/bioetl/core (fails: coverage threshold 85% not met in current suite)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693062bd89788324b4a332e7834c57c8)