### PR TITLE
Add middleware and pipeline error coverage tests

### DIFF
--- a/src/bioetl/infrastructure/clients/base/middleware.py
+++ b/src/bioetl/infrastructure/clients/base/middleware.py
@@ -1,0 +1,92 @@
+"""HTTP middleware for client error handling and retries."""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Protocol
+
+from bioetl.domain.errors import (
+    ClientNetworkError,
+    ClientRateLimitError,
+    ClientResponseError,
+)
+from bioetl.infrastructure.clients.base.contracts import RetryPolicyABC
+
+
+class _HttpClient(Protocol):
+    def get(self, url: str) -> Any:  # pragma: no cover - Protocol definition
+        ...
+
+
+class HttpClientMiddleware:
+    """Обертка для HTTP-клиента с обработкой ошибок и ретраями."""
+
+    def __init__(
+        self,
+        provider: str,
+        http_client: _HttpClient,
+        retry_policy: RetryPolicyABC,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self._provider = provider
+        self._http_client = http_client
+        self._retry_policy = retry_policy
+        self._logger = logger or logging.getLogger(__name__)
+
+    def request(self, url: str) -> Any:
+        """Выполняет GET-запрос с обработкой сетевых и HTTP-ошибок."""
+
+        attempt = 1
+        while True:
+            try:
+                response = self._http_client.get(url)
+            except TimeoutError as exc:  # pragma: no cover - covered by tests
+                error = ClientNetworkError(
+                    provider=self._provider,
+                    endpoint=url,
+                    message=str(exc),
+                    cause=exc,
+                )
+            else:
+                status_code = getattr(response, "status_code", None)
+                if status_code == 429:
+                    error = ClientRateLimitError(
+                        provider=self._provider,
+                        endpoint=url,
+                        status_code=status_code,
+                        message="Rate limit exceeded",
+                    )
+                elif status_code is not None and status_code >= 500:
+                    error = ClientResponseError(
+                        provider=self._provider,
+                        endpoint=url,
+                        status_code=status_code,
+                        message="Server error",
+                    )
+                else:
+                    try:
+                        return response.json()
+                    except Exception as exc:  # pragma: no cover - defensive
+                        error = ClientResponseError(
+                            provider=self._provider,
+                            endpoint=url,
+                            status_code=status_code,
+                            message="Failed to parse response JSON",
+                            cause=exc,
+                        )
+
+            self._logger.warning(
+                "HTTP request failed",
+                extra={"attempt": attempt, "error_type": type(error).__name__},
+            )
+
+            if not self._retry_policy.should_retry(error, attempt):
+                raise error from error.cause
+
+            delay = self._retry_policy.get_delay(attempt)
+            self._logger.info(
+                "Retrying request", extra={"attempt": attempt + 1, "delay": delay}
+            )
+            time.sleep(delay)
+            attempt += 1
+

--- a/tests/bioetl/clients/test_middleware.py
+++ b/tests/bioetl/clients/test_middleware.py
@@ -1,0 +1,144 @@
+import logging
+from dataclasses import dataclass
+
+import pytest
+
+from bioetl.domain.errors import (
+    ClientNetworkError,
+    ClientRateLimitError,
+    ClientResponseError,
+)
+from bioetl.infrastructure.clients.base.middleware import HttpClientMiddleware
+
+
+@dataclass
+class _FakeResponse:
+    status_code: int
+    payload: dict
+
+    def json(self) -> dict:
+        return self.payload
+
+
+class _RetryPolicyStub:
+    def __init__(self, max_attempts: int = 3) -> None:
+        self.max_attempts = max_attempts
+        self.calls: list[tuple[Exception, int]] = []
+
+    def should_retry(self, error: Exception, attempt: int) -> bool:
+        self.calls.append((error, attempt))
+        return attempt < self.max_attempts
+
+    def get_delay(self, attempt: int) -> float:
+        return 0.0
+
+
+def test_success_request(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO)
+    response = _FakeResponse(status_code=200, payload={"ok": True})
+
+    class _Client:
+        def get(self, url: str) -> _FakeResponse:  # pragma: no cover - simple stub
+            return response
+
+    middleware = HttpClientMiddleware(
+        provider="chembl",
+        http_client=_Client(),
+        retry_policy=_RetryPolicyStub(),
+        logger=logging.getLogger("test_success"),
+    )
+
+    result = middleware.request("http://example.com")
+
+    assert result == {"ok": True}
+    assert "HTTP request failed" not in caplog.text
+
+
+def test_timeout_raises_network_error(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.WARNING)
+
+    class _Client:
+        def get(self, url: str) -> _FakeResponse:  # pragma: no cover - simple stub
+            raise TimeoutError("timeout")
+
+    middleware = HttpClientMiddleware(
+        provider="chembl",
+        http_client=_Client(),
+        retry_policy=_RetryPolicyStub(max_attempts=1),
+        logger=logging.getLogger("test_timeout"),
+    )
+
+    with pytest.raises(ClientNetworkError):
+        middleware.request("http://example.com")
+
+    assert "HTTP request failed" in caplog.text
+
+
+def test_rate_limit_error(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.WARNING)
+    response = _FakeResponse(status_code=429, payload={})
+
+    class _Client:
+        def get(self, url: str) -> _FakeResponse:  # pragma: no cover - simple stub
+            return response
+
+    middleware = HttpClientMiddleware(
+        provider="chembl",
+        http_client=_Client(),
+        retry_policy=_RetryPolicyStub(max_attempts=1),
+        logger=logging.getLogger("test_rate_limit"),
+    )
+
+    with pytest.raises(ClientRateLimitError):
+        middleware.request("http://example.com")
+
+    assert "HTTP request failed" in caplog.text
+
+
+def test_server_error(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.WARNING)
+    response = _FakeResponse(status_code=503, payload={})
+
+    class _Client:
+        def get(self, url: str) -> _FakeResponse:  # pragma: no cover - simple stub
+            return response
+
+    middleware = HttpClientMiddleware(
+        provider="chembl",
+        http_client=_Client(),
+        retry_policy=_RetryPolicyStub(max_attempts=1),
+        logger=logging.getLogger("test_server_error"),
+    )
+
+    with pytest.raises(ClientResponseError):
+        middleware.request("http://example.com")
+
+    assert "HTTP request failed" in caplog.text
+
+
+def test_retry_limit(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO)
+    policy = _RetryPolicyStub(max_attempts=2)
+
+    class _Client:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def get(self, url: str) -> _FakeResponse:  # pragma: no cover - simple stub
+            self.calls += 1
+            raise TimeoutError("timeout")
+
+    client = _Client()
+    middleware = HttpClientMiddleware(
+        provider="chembl",
+        http_client=client,
+        retry_policy=policy,
+        logger=logging.getLogger("test_retry"),
+    )
+
+    with pytest.raises(ClientNetworkError):
+        middleware.request("http://example.com")
+
+    assert client.calls == policy.max_attempts
+    assert len(policy.calls) == policy.max_attempts
+    assert "Retrying request" in caplog.text

--- a/tests/bioetl/core/test_errors.py
+++ b/tests/bioetl/core/test_errors.py
@@ -1,0 +1,41 @@
+import pytest
+
+from bioetl.domain.errors import PipelineStageError
+
+
+def test_pipeline_stage_error_properties() -> None:
+    cause = RuntimeError("boom")
+
+    error = PipelineStageError(
+        provider="chembl",
+        entity="activity",
+        stage="extract",
+        attempt=2,
+        run_id="run-123",
+        cause=cause,
+    )
+
+    assert error.provider == "chembl"
+    assert error.entity == "activity"
+    assert error.stage == "extract"
+    assert error.attempt == 2
+    assert error.run_id == "run-123"
+    assert error.cause is cause
+
+
+def test_pipeline_stage_error_str_contains_context() -> None:
+    error = PipelineStageError(
+        provider="chembl",
+        entity="target",
+        stage="validate",
+        attempt=1,
+        run_id="run-456",
+    )
+
+    message = str(error)
+
+    assert "PipelineStageError" in message
+    assert "chembl" in message
+    assert "target" in message
+    assert "validate" in message
+    assert "run-456" in message

--- a/tests/bioetl/pipelines/chembl/test_extract_pipeline_errors.py
+++ b/tests/bioetl/pipelines/chembl/test_extract_pipeline_errors.py
@@ -1,0 +1,79 @@
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from bioetl.application.pipelines.chembl.pipeline import ChemblEntityPipeline
+from bioetl.core.providers import ProviderId
+from bioetl.domain.contracts import ExtractionServiceABC
+from bioetl.domain.errors import ClientNetworkError, PipelineStageError
+from bioetl.infrastructure.config.models import PipelineConfig
+from bioetl.infrastructure.clients.chembl.provider import register_chembl_provider
+
+
+class _LoggerStub:
+    def __init__(self, logger) -> None:
+        self._logger = logger
+
+    def info(self, msg: str, **ctx):  # pragma: no cover - delegating
+        self._logger.info(msg, extra=ctx)
+
+    def error(self, msg: str, **ctx):  # pragma: no cover - delegating
+        self._logger.error(msg, extra=ctx)
+
+    def debug(self, msg: str, **ctx):  # pragma: no cover - delegating
+        self._logger.debug(msg, extra=ctx)
+
+    def warning(self, msg: str, **ctx):  # pragma: no cover - delegating
+        self._logger.warning(msg, extra=ctx)
+
+    def bind(self, **ctx):  # pragma: no cover - delegating
+        return self
+
+
+def test_extract_stage_wraps_client_error(caplog: pytest.LogCaptureFixture, tmp_path: Path) -> None:
+    caplog.set_level("ERROR")
+
+    register_chembl_provider()
+
+    config = PipelineConfig(
+        provider=ProviderId.CHEMBL,
+        entity_name="activity",
+        sources={"chembl": {}},
+    )
+
+    extraction_service = MagicMock(spec=ExtractionServiceABC)
+    extraction_service.extract_all.side_effect = ClientNetworkError(
+        provider="chembl", endpoint="/status", message="timeout"
+    )
+
+    validation_service = MagicMock()
+    validation_service.validate.side_effect = lambda df, entity_name=None: df
+
+    output_writer = MagicMock()
+
+    logger = _LoggerStub(logging.getLogger("pipeline-test"))
+
+    pipeline = ChemblEntityPipeline(
+        config=config,
+        logger=logger,
+        validation_service=validation_service,
+        output_writer=output_writer,
+        extraction_service=extraction_service,
+    )
+
+    with pytest.raises(PipelineStageError) as exc_info:
+        pipeline.run(output_path=tmp_path / "out.parquet")
+
+    error = exc_info.value
+
+    assert isinstance(error.cause, ClientNetworkError)
+    assert error.provider == "chembl"
+    assert error.entity == "activity"
+    assert error.stage == "extract"
+    assert error.attempt == 1
+
+    log_text = caplog.text
+    assert "Stage failed" in log_text
+    assert "Pipeline failed" in log_text


### PR DESCRIPTION
## Summary
- add HTTP client middleware to classify errors and apply retry logging
- cover PipelineStageError context and middleware error scenarios with targeted tests
- add integration-style test ensuring client errors are wrapped into pipeline stage errors and logged

## Testing
- pytest --cov=src/bioetl --cov-report=term-missing --cov-fail-under=0 tests/bioetl/core/test_errors.py tests/bioetl/clients/test_middleware.py tests/bioetl/pipelines/chembl/test_extract_pipeline_errors.py
- pytest (fails: missing dependency `hypothesis` and import name clash warning from existing test file)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69306771ddf48324bc00fdbc17a69be5)