### PR TITLE
Refactor provider registry into domain layer

### DIFF
--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -2,8 +2,8 @@
 from typing import Any
 
 import bioetl.infrastructure.clients.chembl.provider  # noqa: F401 - ensure registration
-from bioetl.core.provider_registry import get_provider
-from bioetl.core.providers import ProviderId
+from bioetl.domain.provider_registry import get_provider
+from bioetl.domain.providers import ProviderId
 from bioetl.domain.schemas import register_schemas
 from bioetl.domain.schemas.registry import SchemaRegistry
 from bioetl.domain.transform.hash_service import HashService

--- a/src/bioetl/core/provider_registry.py
+++ b/src/bioetl/core/provider_registry.py
@@ -1,10 +1,15 @@
-"""Typed registry for provider definitions."""
+"""Typed registry for provider definitions (legacy path)."""
 
-from __future__ import annotations
-
-from typing import Iterable
-
-from bioetl.core.providers import ProviderDefinition, ProviderId
+from bioetl.domain.provider_registry import (  # noqa: F401
+    ProviderAlreadyRegisteredError,
+    ProviderNotRegisteredError,
+    ProviderRegistryError,
+    get_provider,
+    list_providers,
+    register_provider,
+    reset_provider_registry,
+    restore_provider_registry,
+)
 
 __all__ = [
     "ProviderNotRegisteredError",
@@ -16,59 +21,3 @@ __all__ = [
     "reset_provider_registry",
     "restore_provider_registry",
 ]
-
-
-class ProviderRegistryError(RuntimeError):
-    """Base class for provider registry errors."""
-
-
-class ProviderNotRegisteredError(ProviderRegistryError):
-    """Raised when provider is not registered in the registry."""
-
-
-class ProviderAlreadyRegisteredError(ProviderRegistryError):
-    """Raised when attempting to register a duplicate provider id."""
-
-
-_registry: dict[ProviderId, ProviderDefinition] = {}
-
-
-def register_provider(definition: ProviderDefinition) -> None:
-    """Register provider definition in the registry."""
-
-    if definition.id in _registry:
-        raise ProviderAlreadyRegisteredError(
-            f"Provider '{definition.id.value}' already registered"
-        )
-    _registry[definition.id] = definition
-
-
-def get_provider(provider_id: ProviderId) -> ProviderDefinition:
-    """Get provider definition by id."""
-
-    try:
-        return _registry[provider_id]
-    except KeyError as exc:  # pragma: no cover - defensive
-        raise ProviderNotRegisteredError(
-            f"Provider '{provider_id.value}' is not registered"
-        ) from exc
-
-
-def list_providers() -> list[ProviderDefinition]:
-    """List all registered provider definitions."""
-
-    return list(_registry.values())
-
-
-def reset_provider_registry() -> None:
-    """Clear registry (intended for test isolation)."""
-
-    _registry.clear()
-
-
-def restore_provider_registry(definitions: Iterable[ProviderDefinition]) -> None:
-    """Restore registry to provided definitions (used in tests)."""
-
-    reset_provider_registry()
-    for definition in definitions:
-        _registry[definition.id] = definition

--- a/src/bioetl/core/providers.py
+++ b/src/bioetl/core/providers.py
@@ -1,56 +1,11 @@
-"""Provider abstractions and metadata definitions."""
+"""Provider abstractions and metadata definitions (legacy path)."""
 
-from __future__ import annotations
-
-from dataclasses import dataclass
-from enum import Enum
-from typing import Protocol, TypeVar
-
-from pydantic import BaseModel
-
-ProviderConfigT = TypeVar("ProviderConfigT", bound="BaseProviderConfig")
-ProviderClientT = TypeVar("ProviderClientT")
-ExtractionServiceT = TypeVar("ExtractionServiceT")
-
-
-class ProviderId(str, Enum):
-    """Canonical provider identifiers following PIPE-002."""
-
-    CHEMBL = "chembl"
-    PUBCHEM = "pubchem"
-    UNIPROT = "uniprot"
-    PUBMED = "pubmed"
-
-
-class BaseProviderConfig(BaseModel):
-    """Base class for provider-specific configuration models."""
-
-    model_config = {
-        "extra": "forbid",
-    }
-
-
-class ProviderComponents(Protocol[ProviderConfigT, ProviderClientT, ExtractionServiceT]):
-    """Protocol describing provider component factories."""
-
-    def create_client(self, config: ProviderConfigT) -> ProviderClientT:
-        """Create provider client instance."""
-
-    def create_extraction_service(
-        self, client: ProviderClientT, config: ProviderConfigT
-    ) -> ExtractionServiceT:
-        """Create provider-specific extraction service."""
-
-
-@dataclass(frozen=True)
-class ProviderDefinition:
-    """Provider metadata and factory entry points."""
-
-    id: ProviderId
-    config_type: type[ProviderConfigT]
-    components: ProviderComponents[ProviderConfigT, ProviderClientT, ExtractionServiceT]
-    description: str | None = None
-
+from bioetl.domain.providers import (  # noqa: F401
+    BaseProviderConfig,
+    ProviderComponents,
+    ProviderDefinition,
+    ProviderId,
+)
 
 __all__ = [
     "BaseProviderConfig",

--- a/src/bioetl/domain/provider_registry.py
+++ b/src/bioetl/domain/provider_registry.py
@@ -1,0 +1,80 @@
+"""Registry for provider definitions."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from bioetl.domain.errors import ProviderError
+from bioetl.domain.providers import ProviderDefinition, ProviderId
+
+__all__ = [
+    "ProviderNotRegisteredError",
+    "ProviderRegistryError",
+    "ProviderAlreadyRegisteredError",
+    "get_provider",
+    "list_providers",
+    "register_provider",
+    "reset_provider_registry",
+    "restore_provider_registry",
+]
+
+
+class ProviderRegistryError(ProviderError):
+    """Base class for provider registry errors."""
+
+    def __init__(self, provider: str, message: str) -> None:
+        super().__init__(provider=provider, message=message)
+
+
+class ProviderNotRegisteredError(ProviderRegistryError):
+    """Raised when provider is not registered in the registry."""
+
+    def __init__(self, provider: str) -> None:
+        super().__init__(provider, f"Provider '{provider}' is not registered")
+
+
+class ProviderAlreadyRegisteredError(ProviderRegistryError):
+    """Raised when attempting to register a duplicate provider id."""
+
+    def __init__(self, provider: str) -> None:
+        super().__init__(provider, f"Provider '{provider}' already registered")
+
+
+_PROVIDERS: dict[ProviderId, ProviderDefinition] = {}
+
+
+def register_provider(definition: ProviderDefinition) -> None:
+    """Register provider definition in the registry."""
+
+    if definition.id in _PROVIDERS:
+        raise ProviderAlreadyRegisteredError(definition.id.value)
+    _PROVIDERS[definition.id] = definition
+
+
+def get_provider(provider_id: ProviderId) -> ProviderDefinition:
+    """Get provider definition by id."""
+
+    try:
+        return _PROVIDERS[provider_id]
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise ProviderNotRegisteredError(provider_id.value) from exc
+
+
+def list_providers() -> list[ProviderDefinition]:
+    """List all registered provider definitions."""
+
+    return list(_PROVIDERS.values())
+
+
+def reset_provider_registry() -> None:
+    """Clear registry (intended for test isolation)."""
+
+    _PROVIDERS.clear()
+
+
+def restore_provider_registry(definitions: Iterable[ProviderDefinition]) -> None:
+    """Restore registry to provided definitions (used in tests)."""
+
+    reset_provider_registry()
+    for definition in definitions:
+        _PROVIDERS[definition.id] = definition

--- a/src/bioetl/domain/providers.py
+++ b/src/bioetl/domain/providers.py
@@ -1,0 +1,62 @@
+"""Domain abstractions for provider metadata and factories."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol, TypeVar, runtime_checkable
+
+from pydantic import BaseModel
+
+ProviderConfigT = TypeVar("ProviderConfigT", bound="BaseProviderConfig")
+ProviderClientT = TypeVar("ProviderClientT")
+ExtractionServiceT = TypeVar("ExtractionServiceT")
+
+
+class ProviderId(str, Enum):
+    """Canonical provider identifiers following PIPE-002."""
+
+    CHEMBL = "chembl"
+    PUBCHEM = "pubchem"
+    UNIPROT = "uniprot"
+    PUBMED = "pubmed"
+    DUMMY = "dummy"
+
+
+class BaseProviderConfig(BaseModel):
+    """Base class for provider-specific configuration models."""
+
+    model_config = {
+        "extra": "forbid",
+    }
+
+
+@runtime_checkable
+class ProviderComponents(Protocol[ProviderConfigT, ProviderClientT, ExtractionServiceT]):
+    """Protocol describing provider component factories."""
+
+    def create_client(self, config: ProviderConfigT) -> ProviderClientT:
+        """Create provider client instance."""
+
+    def create_extraction_service(
+        self, client: ProviderClientT, config: ProviderConfigT
+    ) -> ExtractionServiceT:
+        """Create provider-specific extraction service."""
+
+
+@dataclass(frozen=True)
+class ProviderDefinition:
+    """Provider metadata and factory entry points."""
+
+    id: ProviderId
+    config_type: type[ProviderConfigT]
+    components: ProviderComponents[ProviderConfigT, ProviderClientT, ExtractionServiceT]
+    description: str | None = None
+
+
+__all__ = [
+    "BaseProviderConfig",
+    "ProviderComponents",
+    "ProviderDefinition",
+    "ProviderId",
+]

--- a/src/bioetl/infrastructure/clients/chembl/provider.py
+++ b/src/bioetl/infrastructure/clients/chembl/provider.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 from bioetl.application.services.chembl_extraction import ChemblExtractionService
-from bioetl.core.provider_registry import (
+from bioetl.domain.provider_registry import (
     ProviderAlreadyRegisteredError,
     get_provider,
     register_provider,
 )
-from bioetl.core.providers import (
+from bioetl.domain.providers import (
     ProviderComponents,
     ProviderDefinition,
     ProviderId,

--- a/src/bioetl/infrastructure/config/models.py
+++ b/src/bioetl/infrastructure/config/models.py
@@ -10,8 +10,8 @@ from typing import Annotated, Any, Literal, Optional
 
 from pydantic import BaseModel, Field, PositiveInt, ValidationError, field_validator, model_validator
 
-from bioetl.core.provider_registry import get_provider
-from bioetl.core.providers import BaseProviderConfig, ProviderId
+from bioetl.domain.provider_registry import get_provider
+from bioetl.domain.providers import BaseProviderConfig, ProviderId
 
 
 class PaginationConfig(BaseModel):

--- a/tests/bioetl/core/test_container.py
+++ b/tests/bioetl/core/test_container.py
@@ -9,12 +9,12 @@ from pydantic import ValidationError
 sys.modules.setdefault("tqdm", SimpleNamespace(tqdm=lambda *args: None))
 
 from bioetl.application.container import PipelineContainer  # noqa: E402
-from bioetl.core.provider_registry import (  # noqa: E402
+from bioetl.domain.provider_registry import (  # noqa: E402
     ProviderNotRegisteredError,
     list_providers,
     restore_provider_registry,
 )
-from bioetl.core.providers import ProviderId  # noqa: E402
+from bioetl.domain.providers import ProviderId  # noqa: E402
 from bioetl.infrastructure.clients.chembl.provider import (  # noqa: E402
     register_chembl_provider,
 )

--- a/tests/bioetl/core/test_provider_registry.py
+++ b/tests/bioetl/core/test_provider_registry.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import pytest
 
-from bioetl.core.provider_registry import (
+from bioetl.domain.provider_registry import (
     ProviderAlreadyRegisteredError,
     ProviderNotRegisteredError,
     get_provider,
@@ -14,7 +14,7 @@ from bioetl.core.provider_registry import (
     reset_provider_registry,
     restore_provider_registry,
 )
-from bioetl.core.providers import (
+from bioetl.domain.providers import (
     BaseProviderConfig,
     ProviderComponents,
     ProviderDefinition,

--- a/tests/bioetl/pipelines/chembl/test_extract_pipeline_errors.py
+++ b/tests/bioetl/pipelines/chembl/test_extract_pipeline_errors.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from bioetl.application.pipelines.chembl.pipeline import ChemblEntityPipeline
-from bioetl.core.providers import ProviderId
+from bioetl.domain.providers import ProviderId
 from bioetl.domain.contracts import ExtractionServiceABC
 from bioetl.domain.errors import ClientNetworkError, PipelineStageError
 from bioetl.infrastructure.config.models import PipelineConfig


### PR DESCRIPTION
## Summary
- add domain-level provider abstractions and registry definitions
- rewire the DI container and ChEMBL provider to resolve components through the registry
- update pipeline configuration and tests to consume the new provider modules

## Testing
- pytest tests/bioetl/core/test_provider_registry.py tests/bioetl/core/test_container.py tests/bioetl/pipelines/chembl/test_extract_pipeline_errors.py *(fails coverage gate: Required test coverage of 85% not reached)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930781179e8832492fda38be45a2c62)