### PR TITLE
Add pipeline schema contracts for chembl outputs

### DIFF
--- a/src/bioetl/application/pipelines/chembl/base.py
+++ b/src/bioetl/application/pipelines/chembl/base.py
@@ -96,8 +96,8 @@ class ChemblPipelineBase(PipelineBase):
         Игнорирует генерируемые колонки (hash_row, hash_business_key),
         так как они вычисляются позже.
         """
-        entity = self._config.entity_name
-        schema_cls = self._validation_service.get_schema(entity)
+        schema_name = self._schema_contract.schema_out
+        schema_cls = self._validation_service.get_schema(schema_name)
         schema = schema_cls.to_schema()
 
         ignored_cols = {
@@ -147,8 +147,8 @@ class ChemblPipelineBase(PipelineBase):
         Приводит DataFrame к схеме: заполняет отсутствующие колонки None,
         оставляет только колонки из схемы в правильном порядке.
         """
-        entity = self._config.entity_name
-        schema_columns = self._validation_service.get_schema_columns(entity)
+        schema_name = self._schema_contract.schema_out
+        schema_columns = self._validation_service.get_schema_columns(schema_name)
 
         for col in schema_columns:
             if col not in df.columns:

--- a/src/bioetl/domain/schemas/__init__.py
+++ b/src/bioetl/domain/schemas/__init__.py
@@ -7,13 +7,36 @@ from bioetl.domain.schemas.chembl.assay import AssaySchema
 from bioetl.domain.schemas.chembl.document import DocumentSchema
 from bioetl.domain.schemas.chembl.target import TargetSchema
 from bioetl.domain.schemas.chembl.testitem import TestitemSchema
+from bioetl.domain.schemas.chembl.output_views import (
+    ACTIVITY_OUTPUT_COLUMNS,
+    ASSAY_OUTPUT_COLUMNS,
+    DOCUMENT_OUTPUT_COLUMNS,
+    TARGET_OUTPUT_COLUMNS,
+    TESTITEM_OUTPUT_COLUMNS,
+)
 from bioetl.domain.validation.contracts import SchemaProviderABC
 
 
 def register_schemas(registry: SchemaProviderABC) -> None:
     """Register all schemas to the provided registry."""
     registry.register("activity", ActivitySchema)
+    registry.register("activity_input", ActivitySchema)
+    registry.register(
+        "activity_output", ActivitySchema, column_order=ACTIVITY_OUTPUT_COLUMNS
+    )
     registry.register("assay", AssaySchema)
+    registry.register("assay_input", AssaySchema)
+    registry.register("assay_output", AssaySchema, column_order=ASSAY_OUTPUT_COLUMNS)
     registry.register("document", DocumentSchema)
+    registry.register("document_input", DocumentSchema)
+    registry.register(
+        "document_output", DocumentSchema, column_order=DOCUMENT_OUTPUT_COLUMNS
+    )
     registry.register("target", TargetSchema)
+    registry.register("target_input", TargetSchema)
+    registry.register("target_output", TargetSchema, column_order=TARGET_OUTPUT_COLUMNS)
     registry.register("testitem", TestitemSchema)
+    registry.register("testitem_input", TestitemSchema)
+    registry.register(
+        "testitem_output", TestitemSchema, column_order=TESTITEM_OUTPUT_COLUMNS
+    )

--- a/src/bioetl/domain/schemas/chembl/output_views.py
+++ b/src/bioetl/domain/schemas/chembl/output_views.py
@@ -1,0 +1,42 @@
+"""Output column descriptors for ChEMBL schemas."""
+from __future__ import annotations
+
+from typing import Type
+
+import pandera.pandas as pa
+
+from bioetl.domain.schemas.chembl.activity import ActivitySchema
+from bioetl.domain.schemas.chembl.assay import AssaySchema
+from bioetl.domain.schemas.chembl.document import DocumentSchema
+from bioetl.domain.schemas.chembl.target import TargetSchema
+from bioetl.domain.schemas.chembl.testitem import TestitemSchema
+
+_OUTPUT_METADATA_COLUMNS = [
+    "hash_row",
+    "hash_business_key",
+    "index",
+    "database_version",
+    "extracted_at",
+]
+
+
+def _metadata_last(schema_cls: Type[pa.DataFrameModel]) -> list[str]:
+    columns = list(schema_cls.to_schema().columns.keys())
+    ordered = [col for col in columns if col not in _OUTPUT_METADATA_COLUMNS]
+    ordered.extend(col for col in _OUTPUT_METADATA_COLUMNS if col in columns)
+    return ordered
+
+
+ACTIVITY_OUTPUT_COLUMNS = _metadata_last(ActivitySchema)
+ASSAY_OUTPUT_COLUMNS = _metadata_last(AssaySchema)
+DOCUMENT_OUTPUT_COLUMNS = _metadata_last(DocumentSchema)
+TARGET_OUTPUT_COLUMNS = _metadata_last(TargetSchema)
+TESTITEM_OUTPUT_COLUMNS = _metadata_last(TestitemSchema)
+
+__all__ = [
+    "ACTIVITY_OUTPUT_COLUMNS",
+    "ASSAY_OUTPUT_COLUMNS",
+    "DOCUMENT_OUTPUT_COLUMNS",
+    "TARGET_OUTPUT_COLUMNS",
+    "TESTITEM_OUTPUT_COLUMNS",
+]

--- a/src/bioetl/domain/schemas/pipeline_contracts.py
+++ b/src/bioetl/domain/schemas/pipeline_contracts.py
@@ -1,0 +1,79 @@
+"""Pipeline schema contracts and registry."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PipelineSchemaContract:
+    """Описание схем для пайплайна."""
+
+    pipeline_code: str
+    schema_out: str
+    schema_in: str | None = None
+    output_schema: str | None = None
+
+    def get_output_schema(self) -> str:
+        """Возвращает схему для записи (fallback на schema_out)."""
+
+        return self.output_schema or self.schema_out
+
+
+def _default_contract(code: str, entity: str | None) -> PipelineSchemaContract:
+    schema_name = entity or code
+    return PipelineSchemaContract(
+        pipeline_code=code,
+        schema_out=schema_name,
+        schema_in=schema_name,
+        output_schema=schema_name,
+    )
+
+
+PIPELINE_CONTRACTS: dict[str, PipelineSchemaContract] = {
+    "activity_chembl": PipelineSchemaContract(
+        pipeline_code="activity_chembl",
+        schema_out="activity",
+        schema_in="activity_input",
+        output_schema="activity_output",
+    ),
+    "assay_chembl": PipelineSchemaContract(
+        pipeline_code="assay_chembl",
+        schema_out="assay",
+        schema_in="assay_input",
+        output_schema="assay_output",
+    ),
+    "document_chembl": PipelineSchemaContract(
+        pipeline_code="document_chembl",
+        schema_out="document",
+        schema_in="document_input",
+        output_schema="document_output",
+    ),
+    "target_chembl": PipelineSchemaContract(
+        pipeline_code="target_chembl",
+        schema_out="target",
+        schema_in="target_input",
+        output_schema="target_output",
+    ),
+    "testitem_chembl": PipelineSchemaContract(
+        pipeline_code="testitem_chembl",
+        schema_out="testitem",
+        schema_in="testitem_input",
+        output_schema="testitem_output",
+    ),
+    "molecule_chembl": PipelineSchemaContract(
+        pipeline_code="molecule_chembl",
+        schema_out="testitem",
+        schema_in="testitem_input",
+        output_schema="testitem_output",
+    ),
+}
+
+
+def get_pipeline_contract(
+    pipeline_code: str, *, default_entity: str | None = None
+) -> PipelineSchemaContract:
+    """Возвращает контракт схем для пайплайна."""
+
+    if pipeline_code in PIPELINE_CONTRACTS:
+        return PIPELINE_CONTRACTS[pipeline_code]
+    return _default_contract(pipeline_code, default_entity)

--- a/src/bioetl/domain/validation/contracts.py
+++ b/src/bioetl/domain/validation/contracts.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any
+
 import pandas as pd
 import pandera.pandas as pa
 
@@ -41,5 +42,15 @@ class SchemaProviderABC(ABC):
         """Возвращает список доступных схем."""
 
     @abstractmethod
-    def register(self, name: str, schema: type[pa.DataFrameModel]) -> None:
+    def get_schema_columns(self, name: str) -> list[str]:
+        """Возвращает порядок колонок для схемы."""
+
+    @abstractmethod
+    def register(
+        self,
+        name: str,
+        schema: type[pa.DataFrameModel],
+        *,
+        column_order: list[str] | None = None,
+    ) -> None:
         """Регистрирует новую схему."""

--- a/src/bioetl/domain/validation/service.py
+++ b/src/bioetl/domain/validation/service.py
@@ -20,8 +20,7 @@ class ValidationService:
 
     def get_schema_columns(self, entity_name: str) -> list[str]:
         """Get ordered list of column names for entity schema."""
-        schema_cls = self._schema_provider.get_schema(entity_name)
-        return list(schema_cls.to_schema().columns.keys())
+        return self._schema_provider.get_schema_columns(entity_name)
 
     def validate(self, df: pd.DataFrame, entity_name: str) -> pd.DataFrame:
         """

--- a/tests/bioetl/application/pipelines/chembl/activity/test_activity_pipeline.py
+++ b/tests/bioetl/application/pipelines/chembl/activity/test_activity_pipeline.py
@@ -12,6 +12,7 @@ from bioetl.domain.schemas.chembl.activity import ActivitySchema
 @pytest.fixture
 def pipeline():
     config = MagicMock()
+    config.id = "activity_chembl"
     config.entity_name = "activity"
     config.primary_key = "activity_id"
     config.model_dump.return_value = {}
@@ -93,9 +94,10 @@ def test_transform_drops_invalid_rows(pipeline):
         
     pipeline._validation_service.get_schema.return_value = MockSchema
     pipeline._validation_service.get_schema_columns.return_value = list(MockSchema.to_schema().columns.keys())
-    
+
     pipeline._normalization_service = MagicMock()
     pipeline._normalization_service.normalize_fields.side_effect = lambda x: x
+    pipeline._normalization_service.normalize.side_effect = lambda record: record
     
     df = pd.DataFrame({
         "required_col": ["A", None, "C"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,7 @@ def mock_validation_service():
     service = MagicMock(spec=ValidationService)
     # Default behavior: return df as is
     service.validate.side_effect = lambda df, **kwargs: df
+    service.get_schema_columns.return_value = []
     return service
 
 


### PR DESCRIPTION
## Summary
- add pipeline schema contract dataclass and register ChEMBL pipeline contracts
- extend schema registry to support input/output schema descriptors with explicit column order
- update pipelines to use schema contracts for validation and writer column ordering

## Testing
- pytest --cov-fail-under=0 tests/bioetl/application/pipelines/chembl/activity/test_activity_pipeline.py tests/bioetl/application/pipelines/test_pipeline_base.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693089de6f08832494632bd2a3fb8d7c)