### PR TITLE
Refactor Chembl normalization pipeline

### DIFF
--- a/src/bioetl/application/pipelines/chembl/base.py
+++ b/src/bioetl/application/pipelines/chembl/base.py
@@ -1,13 +1,13 @@
 """Base pipeline implementation for ChEMBL data extraction."""
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any
 
 import pandas as pd
 
 from bioetl.application.pipelines.base import PipelineBase
 from bioetl.domain.normalization_service import ChemblNormalizationService, NormalizationService
-from bioetl.domain.record_source import ApiRecordSource, RawRecord, RecordSource
+from bioetl.domain.record_source import ApiRecordSource, RecordSource
 from bioetl.domain.contracts import ExtractionServiceABC
 from bioetl.domain.models import RunContext
 from bioetl.domain.transform.hash_service import HashService
@@ -77,13 +77,7 @@ class ChemblPipelineBase(PipelineBase):
         """
         df = self.pre_transform(df)
         df = self._do_transform(df)
-
-        records = [
-            self._normalization_service.normalize(cast(RawRecord, record))
-            for record in df.to_dict(orient="records")
-        ]
-
-        df = pd.DataFrame(records)
+        df = self._normalization_service.normalize_dataframe(df)
 
         df = self._enforce_schema(df)
         df = self._drop_nulls_in_required_columns(df)

--- a/src/bioetl/domain/normalization_service.py
+++ b/src/bioetl/domain/normalization_service.py
@@ -27,6 +27,14 @@ class NormalizationService(Protocol):
     def normalize(self, raw: RawRecord) -> NormalizedRecord:
         """Normalize a single raw record."""
 
+    def normalize_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Normalize a DataFrame with ChEMBL field rules."""
+
+    def normalize_series(
+        self, series: pd.Series, field_cfg: dict[str, Any]
+    ) -> pd.Series:
+        """Normalize a Series using field configuration."""
+
 
 class ChemblNormalizationService(NormalizationService):
     """Normalization service for ChEMBL records."""
@@ -64,6 +72,41 @@ class ChemblNormalizationService(NormalizationService):
                 normalized[key] = value
 
         return normalized
+
+    def normalize_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
+        normalized_df = df.copy()
+
+        for field_cfg in self._config.fields:
+            name = field_cfg.get("name")
+            if not name or name not in normalized_df.columns:
+                continue
+
+            normalized_df[name] = self.normalize_series(
+                normalized_df[name], field_cfg
+            )
+
+        return normalized_df
+
+    def normalize_series(
+        self, series: pd.Series, field_cfg: dict[str, Any]
+    ) -> pd.Series:
+        name = cast(str, field_cfg.get("name"))
+        dtype = field_cfg.get("data_type")
+        mode = self._resolve_mode(name)
+        custom_normalizer = normalize_impl.get_normalizer(name)
+
+        if custom_normalizer:
+            base_normalizer = custom_normalizer
+        else:
+            def _default_normalizer(val: Any, m=mode) -> Any:
+                return normalize_impl.normalize_scalar(val, mode=m)
+
+            base_normalizer = _default_normalizer
+
+        def _normalize_value_from_series(val: Any) -> Any:
+            return self._normalize_value(val, dtype, base_normalizer, name)
+
+        return series.apply(_normalize_value_from_series)
 
     def _resolve_mode(self, field_name: str) -> str:
         if field_name in self._config.normalization.case_sensitive_fields:


### PR DESCRIPTION
## Summary
- add DataFrame and Series normalization methods to ChemblNormalizationService and use them in pipeline transforms
- refactor ChemblPipelineBase.transform to batch-normalize data while keeping schema order and null handling intact
- extend normalization and pipeline tests to cover batch normalization across multiple rows

## Testing
- pytest -o addopts="" tests/bioetl/domain/test_normalization_service.py tests/bioetl/application/pipelines/chembl/test_base.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693143ef50308324b3ff59a0d1223b8c)