### PR TITLE
Support chunked DataFrame extraction and batch normalization

### DIFF
--- a/src/bioetl/domain/normalization_service.py
+++ b/src/bioetl/domain/normalization_service.py
@@ -27,6 +27,9 @@ class NormalizationService(Protocol):
     def normalize(self, raw: RawRecord) -> NormalizedRecord:
         """Normalize a single raw record."""
 
+    def normalize_batch(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Normalize a batch of raw records represented as a DataFrame."""
+
     def normalize_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
         """Normalize a DataFrame with ChEMBL field rules."""
 
@@ -86,6 +89,9 @@ class ChemblNormalizationService(NormalizationService):
             )
 
         return normalized_df
+
+    def normalize_batch(self, df: pd.DataFrame) -> pd.DataFrame:
+        return self.normalize_dataframe(df)
 
     def normalize_series(
         self, series: pd.Series, field_cfg: dict[str, Any]

--- a/tests/bioetl/application/pipelines/chembl/test_base.py
+++ b/tests/bioetl/application/pipelines/chembl/test_base.py
@@ -173,3 +173,67 @@ def test_transform_uses_batch_normalization(mock_dependencies_fixture):
     pd.testing.assert_frame_equal(
         result, normalization_service.normalize_dataframe.return_value
     )
+
+
+def test_extract_uses_dataframe_batches(mock_dependencies_fixture):
+    """Ensure extract works with dataframe chunks and batch normalization."""
+
+    class _ChunkRecordSource:
+        def __init__(self, df: pd.DataFrame):
+            self.df = df
+            self.calls = 0
+
+        def iter_records(self):
+            self.calls += 1
+            yield self.df
+
+    class _NormalizationStub:
+        def __init__(self) -> None:
+            self.batch_calls = 0
+            self.single_calls = 0
+
+        def normalize_batch(self, df: pd.DataFrame) -> pd.DataFrame:
+            self.batch_calls += 1
+            return df.assign(value=df["value"].str.upper())
+
+        def normalize(self, raw):  # pragma: no cover
+            self.single_calls += 1
+            return raw
+
+        def normalize_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:  # pragma: no cover
+            return df
+
+        def normalize_series(self, series, field_cfg):  # pragma: no cover
+            return series
+
+    raw_df = pd.DataFrame(
+        [
+            {"id": 1, "value": "a"},
+            {"id": 2, "value": "b"},
+        ]
+    )
+
+    record_source = _ChunkRecordSource(raw_df)
+    normalization_service = _NormalizationStub()
+    mock_dependencies_fixture["config"].pipeline = {}
+    mock_dependencies_fixture["config"].model_dump.return_value = {}
+
+    pipeline = ChemblPipelineBase(
+        config=mock_dependencies_fixture["config"],
+        logger=mock_dependencies_fixture["logger"],
+        validation_service=mock_dependencies_fixture["validation_service"],
+        output_writer=mock_dependencies_fixture["output_writer"],
+        extraction_service=mock_dependencies_fixture["extraction_service"],
+        record_source=record_source,
+        normalization_service=normalization_service,
+    )
+
+    result = pipeline.extract()
+
+    assert record_source.calls == 1
+    assert normalization_service.batch_calls == 1
+    assert normalization_service.single_calls == 0
+    pd.testing.assert_frame_equal(
+        result.reset_index(drop=True),
+        raw_df.assign(value=["A", "B"]),
+    )

--- a/tests/bioetl/domain/test_record_source.py
+++ b/tests/bioetl/domain/test_record_source.py
@@ -37,8 +37,10 @@ def test_in_memory_record_source_iterates_stably() -> None:
     first_pass = list(source.iter_records())
     second_pass = list(source.iter_records())
 
-    assert first_pass == records
-    assert second_pass == records
+    assert len(first_pass) == 1
+    assert len(second_pass) == 1
+    pd.testing.assert_frame_equal(first_pass[0], pd.DataFrame(records))
+    pd.testing.assert_frame_equal(second_pass[0], pd.DataFrame(records))
 
 
 def test_api_record_source_returns_serialized_records() -> None:
@@ -52,7 +54,11 @@ def test_api_record_source_returns_serialized_records() -> None:
     records = list(source.iter_records())
 
     assert extraction.called_with == {"entity": "activity", "limit": 1}
-    assert records == [
-        {"id": "1", "name": "alpha"},
-        {"id": "2", "name": "beta"},
-    ]
+    assert len(records) == 1
+    expected_df = pd.DataFrame(
+        [
+            {"id": "1", "name": "alpha"},
+            {"id": "2", "name": "beta"},
+        ]
+    )
+    pd.testing.assert_frame_equal(records[0].reset_index(drop=True), expected_df)


### PR DESCRIPTION
## Summary
- make record sources return DataFrame chunks instead of row dicts
- add batch normalization support and use it in ChemblPipelineBase.extract
- update tests to cover chunked extraction and batch normalization paths

## Testing
- pytest -q --disable-warnings --maxfail=1 --cov=src/bioetl --cov-report=term-missing --cov-fail-under=0 tests/bioetl/domain/test_record_source.py tests/bioetl/clients/test_csv_record_source.py tests/bioetl/application/pipelines/chembl/test_base.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931456f5d9883248060042525698851)