### PR TITLE
Switch record sources to DataFrame chunks

### DIFF
--- a/src/bioetl/domain/normalization_service.py
+++ b/src/bioetl/domain/normalization_service.py
@@ -27,6 +27,9 @@ class NormalizationService(Protocol):
     def normalize(self, raw: RawRecord) -> NormalizedRecord:
         """Normalize a single raw record."""
 
+    def normalize_batch(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Normalize an entire DataFrame chunk."""
+
     def normalize_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
         """Normalize a DataFrame with ChEMBL field rules."""
 
@@ -72,6 +75,9 @@ class ChemblNormalizationService(NormalizationService):
                 normalized[key] = value
 
         return normalized
+
+    def normalize_batch(self, df: pd.DataFrame) -> pd.DataFrame:
+        return self.normalize_dataframe(df)
 
     def normalize_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
         normalized_df = df.copy()

--- a/src/bioetl/domain/record_source.py
+++ b/src/bioetl/domain/record_source.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any, Protocol, TypedDict
 
+import pandas as pd
+
 from bioetl.domain.contracts import ExtractionServiceABC
 
 
@@ -15,10 +17,10 @@ class RawRecord(TypedDict, total=False):
 
 
 class RecordSource(Protocol):
-    """Protocol for record sources."""
+    """Protocol for record sources returning DataFrame chunks."""
 
-    def iter_records(self) -> Iterable[RawRecord]:
-        """Return iterable over raw records."""
+    def iter_records(self) -> Iterable[pd.DataFrame]:
+        """Return iterable over raw record DataFrame chunks."""
 
 
 class InMemoryRecordSource(RecordSource):
@@ -27,8 +29,9 @@ class InMemoryRecordSource(RecordSource):
     def __init__(self, records: list[RawRecord]):
         self._records = list(records)
 
-    def iter_records(self) -> Iterable[RawRecord]:
-        return list(self._records)
+    def iter_records(self) -> Iterable[pd.DataFrame]:
+        df = pd.DataFrame(self._records)
+        return [df]
 
 
 class ApiRecordSource(RecordSource):
@@ -44,6 +47,6 @@ class ApiRecordSource(RecordSource):
         self._entity = entity
         self._filters = filters or {}
 
-    def iter_records(self) -> Iterable[RawRecord]:
+    def iter_records(self) -> Iterable[pd.DataFrame]:
         df = self._extraction_service.extract_all(self._entity, **self._filters)
-        return df.to_dict(orient="records")
+        return [df]

--- a/tests/bioetl/domain/test_record_source.py
+++ b/tests/bioetl/domain/test_record_source.py
@@ -37,8 +37,9 @@ def test_in_memory_record_source_iterates_stably() -> None:
     first_pass = list(source.iter_records())
     second_pass = list(source.iter_records())
 
-    assert first_pass == records
-    assert second_pass == records
+    assert len(first_pass) == len(second_pass) == 1
+    pd.testing.assert_frame_equal(first_pass[0], pd.DataFrame(records))
+    pd.testing.assert_frame_equal(second_pass[0], pd.DataFrame(records))
 
 
 def test_api_record_source_returns_serialized_records() -> None:
@@ -52,7 +53,11 @@ def test_api_record_source_returns_serialized_records() -> None:
     records = list(source.iter_records())
 
     assert extraction.called_with == {"entity": "activity", "limit": 1}
-    assert records == [
-        {"id": "1", "name": "alpha"},
-        {"id": "2", "name": "beta"},
-    ]
+    assert len(records) == 1
+    expected_df = pd.DataFrame(
+        [
+            {"id": "1", "name": "alpha"},
+            {"id": "2", "name": "beta"},
+        ]
+    )
+    pd.testing.assert_frame_equal(records[0], expected_df)


### PR DESCRIPTION
## Summary
- return pandas DataFrame chunks from record source implementations and add batch normalization support
- process chunked extraction in `ChemblPipelineBase.extract` while respecting limits
- update and extend tests for chunked record sources and batch extraction

## Testing
- pytest --no-cov tests/bioetl/domain/test_record_source.py tests/bioetl/clients/test_csv_record_source.py tests/bioetl/application/pipelines/chembl/test_base.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69314764fac48324ac1769132d866eb2)