### PR TITLE
Add circuit breaker controls to HTTP middleware

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -140,6 +140,7 @@ bioetl run new_entity_chembl --profile development --dry-run
 - `rate_limit`: ограничение запросов в секунду
 - `backoff_factor`: множитель для exponential backoff
 - `circuit_breaker_threshold`: порог срабатывания circuit breaker
+- `circuit_breaker_recovery_time`: время (секунды) удержания открытого circuit breaker перед повторной попыткой
 
 ### Секция `storage`
 - `output_path`: путь для финальных артефактов

--- a/configs/profiles/chembl_default.yaml
+++ b/configs/profiles/chembl_default.yaml
@@ -17,6 +17,7 @@ client:
   rate_limit: 10  # запросов в секунду
   backoff_factor: 2.0
   circuit_breaker_threshold: 5
+  circuit_breaker_recovery_time: 60.0
 
 # Общие пути хранения
 storage:

--- a/src/bioetl/infrastructure/clients/chembl/factories.py
+++ b/src/bioetl/infrastructure/clients/chembl/factories.py
@@ -41,6 +41,8 @@ def default_chembl_client(
         max_delay=options.get("max_delay", 30.0),
         backoff_factor=options.get("backoff_factor", 2.0),
         timeout=options.get("timeout", 30.0),
+        circuit_breaker_threshold=options.get("circuit_breaker_threshold", 5),
+        circuit_breaker_recovery_time=options.get("circuit_breaker_recovery_time", 60.0),
     )
 
     return ChemblDataClientHTTPImpl(

--- a/src/bioetl/schemas/pipeline_config_schema.py
+++ b/src/bioetl/schemas/pipeline_config_schema.py
@@ -31,6 +31,7 @@ class ClientConfig(BaseModel):
     rate_limit: float = 10.0
     backoff_factor: float = 2.0
     circuit_breaker_threshold: int = 5
+    circuit_breaker_recovery_time: float = 60.0
 
     model_config = ConfigDict(extra="forbid")
 


### PR DESCRIPTION
## Summary
- add circuit breaker state management to HttpClientMiddleware with logging and reset logic
- propagate circuit breaker configuration through client schemas, default profiles, and ChEMBL client factory
- cover the new circuit breaker behaviour with unit tests

## Testing
- pytest tests/bioetl/clients/test_middleware.py -q *(fails: coverage threshold 85% for unrelated modules)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693148b77e6083248be57ab3d39af2b3)