### PR TITLE
Integrate pipeline hooks and error policies

### DIFF
--- a/src/bioetl/application/orchestrator.py
+++ b/src/bioetl/application/orchestrator.py
@@ -38,8 +38,10 @@ class PipelineOrchestrator:
             extraction_service, limit=limit, logger=logger
         )
         hash_service = container.get_hash_service()
+        hooks = container.get_hooks()
+        error_policy = container.get_error_policy()
 
-        return pipeline_cls(
+        pipeline = pipeline_cls(
             config=self._config,
             logger=logger,
             validation_service=validation_service,
@@ -49,6 +51,11 @@ class PipelineOrchestrator:
             normalization_service=normalization_service,
             hash_service=hash_service,
         )
+
+        pipeline.add_hooks(hooks)
+        pipeline.set_error_policy(error_policy)
+
+        return pipeline
 
     def run_pipeline(self, *, dry_run: bool = False, limit: int | None = None) -> RunResult:
         """Запускает пайплайн в текущем процессе."""

--- a/src/bioetl/application/pipelines/hooks_impl.py
+++ b/src/bioetl/application/pipelines/hooks_impl.py
@@ -1,0 +1,73 @@
+"""Реализации хуков и политик ошибок для пайплайна."""
+from __future__ import annotations
+
+from typing import Any
+
+from bioetl.application.pipelines.hooks import ErrorPolicyABC, PipelineHookABC
+from bioetl.domain.enums import ErrorAction
+from bioetl.domain.errors import PipelineStageError
+from bioetl.domain.models import StageResult
+from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
+
+
+class LoggingPipelineHook(PipelineHookABC):
+    """Хук, логирующий события стадий пайплайна."""
+
+    def __init__(self, logger: LoggerAdapterABC) -> None:
+        self._logger = logger
+
+    def on_stage_start(self, stage: str, context: Any) -> None:
+        self._logger.debug(
+            "Hook: stage start",
+            stage=stage,
+            run_id=context.run_id,
+            provider=context.provider,
+            entity=context.entity_name,
+        )
+
+    def on_stage_end(self, stage: str, result: StageResult) -> None:
+        self._logger.debug(
+            "Hook: stage end",
+            stage=stage,
+            success=result.success,
+            records=result.records_processed,
+            duration_sec=result.duration_sec,
+        )
+
+    def on_error(self, stage: str, error: PipelineStageError) -> None:
+        self._logger.error(
+            "Hook: stage error",
+            stage=stage,
+            run_id=error.run_id,
+            provider=error.provider,
+            entity=error.entity,
+            attempt=error.attempt,
+            error=str(error.cause) if error.cause else str(error),
+        )
+
+
+class StopOnErrorPolicyImpl(ErrorPolicyABC):
+    """Политика: останавливать пайплайн при первой ошибке."""
+
+    def handle(self, error: PipelineStageError, context: Any) -> ErrorAction:
+        return ErrorAction.FAIL
+
+    def should_retry(self, error: PipelineStageError) -> bool:  # noqa: ARG002 - интерфейс
+        return False
+
+
+class ContinueOnErrorPolicyImpl(ErrorPolicyABC):
+    """Политика: пропускать упавшую стадию и продолжать."""
+
+    def handle(self, error: PipelineStageError, context: Any) -> ErrorAction:
+        return ErrorAction.SKIP
+
+    def should_retry(self, error: PipelineStageError) -> bool:  # noqa: ARG002 - интерфейс
+        return False
+
+
+__all__ = [
+    "LoggingPipelineHook",
+    "StopOnErrorPolicyImpl",
+    "ContinueOnErrorPolicyImpl",
+]


### PR DESCRIPTION
## Summary
- add logging pipeline hook plus stop/continue error policy implementations for hook interfaces
- expose hooks and error policy through the pipeline container and wire them into the orchestrator
- extend pipeline base error handling for policy-driven skips and cover container wiring with tests

## Testing
- pytest tests/bioetl/core/test_container.py *(fails coverage gate: required 85% vs reported ~49%)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931495e0bc083249807741cb379912e)