### PR TITLE
Add pipeline hooks and error policy plumbing

### DIFF
--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -4,6 +4,11 @@ from typing import Any
 
 import bioetl.infrastructure.clients.chembl.provider  # noqa: F401 - ensure registration
 from bioetl.clients.csv_record_source import CsvRecordSource, IdListRecordSource
+from bioetl.application.pipelines.hooks import ErrorPolicyABC, PipelineHookABC
+from bioetl.application.pipelines.hooks_impl import (
+    FailFastErrorPolicyImpl,
+    LoggingPipelineHookImpl,
+)
 from bioetl.core.provider_registry import get_provider
 from bioetl.core.providers import ProviderDefinition, ProviderId
 from bioetl.domain.normalization_service import ChemblNormalizationService, NormalizationService
@@ -36,6 +41,14 @@ class PipelineContainer:
     def get_logger(self) -> LoggerAdapterABC:
         """Get the configured logger."""
         return default_logger()
+
+    def get_hooks(self) -> list[PipelineHookABC]:
+        """Возвращает список хуков пайплайна."""
+        return [LoggingPipelineHookImpl(self.get_logger())]
+
+    def get_error_policy(self) -> ErrorPolicyABC:
+        """Возвращает политику обработки ошибок пайплайна."""
+        return FailFastErrorPolicyImpl()
 
     def get_validation_service(self) -> ValidationService:
         """Get the validation service with registered schemas."""

--- a/src/bioetl/application/orchestrator.py
+++ b/src/bioetl/application/orchestrator.py
@@ -38,6 +38,8 @@ class PipelineOrchestrator:
             extraction_service, limit=limit, logger=logger
         )
         hash_service = container.get_hash_service()
+        hooks = container.get_hooks()
+        error_policy = container.get_error_policy()
 
         return pipeline_cls(
             config=self._config,
@@ -48,6 +50,8 @@ class PipelineOrchestrator:
             record_source=record_source,
             normalization_service=normalization_service,
             hash_service=hash_service,
+            hooks=hooks,
+            error_policy=error_policy,
         )
 
     def run_pipeline(self, *, dry_run: bool = False, limit: int | None = None) -> RunResult:

--- a/src/bioetl/application/pipelines/chembl/base.py
+++ b/src/bioetl/application/pipelines/chembl/base.py
@@ -6,6 +6,7 @@ from typing import Any
 import pandas as pd
 
 from bioetl.application.pipelines.base import PipelineBase
+from bioetl.application.pipelines.hooks import ErrorPolicyABC, PipelineHookABC
 from bioetl.domain.normalization_service import ChemblNormalizationService, NormalizationService
 from bioetl.domain.record_source import ApiRecordSource, RecordSource
 from bioetl.domain.contracts import ExtractionServiceABC
@@ -30,6 +31,8 @@ class ChemblPipelineBase(PipelineBase):
         record_source: RecordSource | None = None,
         normalization_service: NormalizationService | None = None,
         hash_service: HashService | None = None,
+        hooks: list[PipelineHookABC] | None = None,
+        error_policy: ErrorPolicyABC | None = None,
     ) -> None:
         super().__init__(
             config,
@@ -37,6 +40,8 @@ class ChemblPipelineBase(PipelineBase):
             validation_service,
             output_writer,
             hash_service,
+            hooks,
+            error_policy,
         )
         self._extraction_service = extraction_service
         self._record_source = record_source or ApiRecordSource(

--- a/src/bioetl/application/pipelines/chembl/pipeline.py
+++ b/src/bioetl/application/pipelines/chembl/pipeline.py
@@ -5,6 +5,7 @@ Replaces specific pipeline implementations (Activity, Assay, etc.)
 with a configurable generic implementation.
 """
 from bioetl.application.pipelines.chembl.base import ChemblPipelineBase
+from bioetl.application.pipelines.hooks import ErrorPolicyABC, PipelineHookABC
 from bioetl.domain.normalization_service import NormalizationService
 from bioetl.domain.record_source import RecordSource
 from bioetl.domain.contracts import ExtractionServiceABC
@@ -31,6 +32,8 @@ class ChemblEntityPipeline(ChemblPipelineBase):
         record_source: RecordSource | None = None,
         normalization_service: NormalizationService | None = None,
         hash_service: HashService | None = None,
+        hooks: list[PipelineHookABC] | None = None,
+        error_policy: ErrorPolicyABC | None = None,
     ) -> None:
         super().__init__(
             config,
@@ -41,6 +44,8 @@ class ChemblEntityPipeline(ChemblPipelineBase):
             record_source,
             normalization_service,
             hash_service,
+            hooks,
+            error_policy,
         )
 
         # Configure entity-specific constants from config

--- a/src/bioetl/application/pipelines/hooks_impl.py
+++ b/src/bioetl/application/pipelines/hooks_impl.py
@@ -1,0 +1,73 @@
+"""Реализации хуков и политик обработки ошибок пайплайна."""
+from __future__ import annotations
+
+from typing import Any
+
+from bioetl.application.pipelines.hooks import ErrorPolicyABC, PipelineHookABC
+from bioetl.domain.enums import ErrorAction
+from bioetl.domain.errors import PipelineStageError
+from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
+
+
+class LoggingPipelineHookImpl(PipelineHookABC):
+    """Хук, логирующий события жизненного цикла стадий."""
+
+    def __init__(self, logger: LoggerAdapterABC) -> None:
+        self._logger = logger
+
+    def on_stage_start(self, stage: str, context: Any) -> None:
+        self._logger.debug(
+            "Hook: stage started",
+            stage=stage,
+            run_id=getattr(context, "run_id", None),
+            provider=getattr(context, "provider", None),
+            entity=getattr(context, "entity_name", None),
+        )
+
+    def on_stage_end(self, stage: str, result: Any) -> None:  # StageResult duck type
+        self._logger.debug(
+            "Hook: stage finished",
+            stage=stage,
+            records=getattr(result, "records_processed", None),
+        )
+
+    def on_error(self, stage: str, error: PipelineStageError) -> None:
+        self._logger.error(
+            "Hook: stage error",
+            stage=stage,
+            attempt=error.attempt,
+            run_id=error.run_id,
+            error=str(error.cause) if error.cause else str(error),
+        )
+
+
+class FailFastErrorPolicyImpl(ErrorPolicyABC):
+    """Политика остановки пайплайна при первой ошибке."""
+
+    def handle(self, error: PipelineStageError, context: Any) -> ErrorAction:
+        return ErrorAction.FAIL
+
+    def should_retry(self, error: PipelineStageError) -> bool:
+        return False
+
+
+class ContinueOnErrorPolicyImpl(ErrorPolicyABC):
+    """Политика продолжения выполнения при ошибках стадий."""
+
+    def __init__(self, *, max_retries: int = 0) -> None:
+        self._max_retries = max_retries
+
+    def handle(self, error: PipelineStageError, context: Any) -> ErrorAction:
+        if self._max_retries > 0 and error.attempt <= self._max_retries:
+            return ErrorAction.RETRY
+        return ErrorAction.SKIP
+
+    def should_retry(self, error: PipelineStageError) -> bool:
+        return error.attempt <= self._max_retries
+
+
+__all__ = [
+    "LoggingPipelineHookImpl",
+    "FailFastErrorPolicyImpl",
+    "ContinueOnErrorPolicyImpl",
+]


### PR DESCRIPTION
## Summary
- add logging pipeline hook and continue/fail-fast error policy implementations
- expose hooks and error policy from the pipeline container and inject them into orchestrated pipelines
- extend pipeline base error handling and tests for skip/retry behavior

## Testing
- pytest tests/bioetl/application/pipelines/test_pipeline_base.py -q *(fails on coverage threshold configured in pytest.ini)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693149873cf08324b0d66d3c9665f7f5)