### PR TITLE
Add tests for client error handling

### DIFF
--- a/tests/bioetl/domain/test_errors.py
+++ b/tests/bioetl/domain/test_errors.py
@@ -1,6 +1,14 @@
 import pytest
 
-from bioetl.domain.errors import PipelineStageError
+from bioetl.domain.errors import (
+    BioetlError,
+    ClientError,
+    ClientNetworkError,
+    ClientRateLimitError,
+    ClientResponseError,
+    PipelineStageError,
+    ProviderError,
+)
 
 
 def test_pipeline_stage_error_properties() -> None:
@@ -39,3 +47,78 @@ def test_pipeline_stage_error_str_contains_context() -> None:
     assert "target" in message
     assert "validate" in message
     assert "run-456" in message
+
+
+@pytest.fixture
+def network_cause() -> Exception:
+    return ConnectionError("socket closed")
+
+
+def test_client_network_error_properties(network_cause: Exception) -> None:
+    error = ClientNetworkError(
+        provider="chembl",
+        message="connection failed",
+        endpoint="/ping",
+        cause=network_cause,
+    )
+
+    assert isinstance(error, ClientError)
+    assert isinstance(error, ProviderError)
+    assert isinstance(error, BioetlError)
+    assert error.provider == "chembl"
+    assert error.endpoint == "/ping"
+    assert error.status_code is None
+    assert error.cause is network_cause
+    assert "ClientNetworkError" in str(error)
+    assert "chembl" in str(error)
+    assert "/ping" in str(error)
+
+
+def test_client_rate_limit_error_properties() -> None:
+    cause = RuntimeError("too many requests")
+    error = ClientRateLimitError(
+        provider="chembl",
+        message="rate limited",
+        endpoint="/activities",
+        status_code=429,
+        cause=cause,
+    )
+
+    assert isinstance(error, ClientError)
+    assert isinstance(error, ProviderError)
+    assert isinstance(error, BioetlError)
+    assert error.provider == "chembl"
+    assert error.endpoint == "/activities"
+    assert error.status_code == 429
+    assert error.cause is cause
+    message = str(error)
+    assert "ClientRateLimitError" in message
+    assert "429" in message
+    assert "chembl" in message
+    assert "/activities" in message
+    assert "rate limited" in message
+
+
+def test_client_response_error_properties() -> None:
+    cause = ValueError("invalid body")
+    error = ClientResponseError(
+        provider="chembl",
+        message="unexpected response",
+        endpoint="/targets",
+        status_code=500,
+        cause=cause,
+    )
+
+    assert isinstance(error, ClientError)
+    assert isinstance(error, ProviderError)
+    assert isinstance(error, BioetlError)
+    assert error.provider == "chembl"
+    assert error.endpoint == "/targets"
+    assert error.status_code == 500
+    assert error.cause is cause
+    message = str(error)
+    assert "ClientResponseError" in message
+    assert "500" in message
+    assert "chembl" in message
+    assert "/targets" in message
+    assert "unexpected response" in message


### PR DESCRIPTION
## Summary
- add unit tests for client error subclasses covering inheritance, fields, and string formatting

## Testing
- pytest tests/bioetl/domain/test_errors.py (fails: coverage threshold 85%)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693149b309c88324a16787d15a02c7ca)