### PR TITLE
Implement ChEMBL provider components factory

### DIFF
--- a/src/bioetl/infrastructure/chembl_client.py
+++ b/src/bioetl/infrastructure/chembl_client.py
@@ -1,0 +1,27 @@
+"""Factories for constructing ChEMBL client stack."""
+from __future__ import annotations
+
+from bioetl.application.services.chembl_extraction import ChemblExtractionService
+from bioetl.infrastructure.clients.chembl.contracts import ChemblDataClientABC
+from bioetl.infrastructure.clients.chembl.factories import (
+    default_chembl_client,
+    default_chembl_extraction_service,
+)
+from bioetl.infrastructure.config.models import ChemblSourceConfig
+
+__all__ = ["create_client", "create_extraction_service"]
+
+
+def create_client(config: ChemblSourceConfig) -> ChemblDataClientABC:
+    """Create a fully configured ChEMBL client from source config."""
+
+    return default_chembl_client(config)
+
+
+def create_extraction_service(
+    config: ChemblSourceConfig, *, client: ChemblDataClientABC | None = None
+) -> ChemblExtractionService:
+    """Create extraction service using provided or default ChEMBL client."""
+
+    resolved_client = client or create_client(config)
+    return default_chembl_extraction_service(config, client=resolved_client)

--- a/src/bioetl/infrastructure/clients/chembl/provider.py
+++ b/src/bioetl/infrastructure/clients/chembl/provider.py
@@ -13,11 +13,11 @@ from bioetl.core.providers import (
     ProviderDefinition,
     ProviderId,
 )
-from bioetl.infrastructure.clients.chembl.contracts import ChemblDataClientABC
-from bioetl.infrastructure.clients.chembl.factories import (
-    default_chembl_client,
-    default_chembl_extraction_service,
+from bioetl.infrastructure.chembl_client import (
+    create_client,
+    create_extraction_service,
 )
+from bioetl.infrastructure.clients.chembl.contracts import ChemblDataClientABC
 from bioetl.infrastructure.config.models import ChemblSourceConfig
 
 
@@ -27,12 +27,12 @@ class ChemblProviderComponents(
     """Factory set for building ChEMBL provider components."""
 
     def create_client(self, config: ChemblSourceConfig) -> ChemblDataClientABC:
-        return default_chembl_client(config)
+        return create_client(config)
 
     def create_extraction_service(
         self, client: ChemblDataClientABC, config: ChemblSourceConfig
     ) -> ChemblExtractionService:
-        return default_chembl_extraction_service(config, client=client)
+        return create_extraction_service(config, client=client)
 
 
 def register_chembl_provider() -> ProviderDefinition:
@@ -50,8 +50,6 @@ def register_chembl_provider() -> ProviderDefinition:
         return get_provider(ProviderId.CHEMBL)
     return definition
 
-
-register_chembl_provider()
 
 __all__ = [
     "ChemblProviderComponents",


### PR DESCRIPTION
## Summary
- add chembl_client helpers to create fully configured ChEMBL client and extraction service from source config
- route ChemblProviderComponents through the new helpers to keep provider setup consistent with ChemblSourceConfig
- rely on container initialization to register the ChEMBL provider instead of module import side effects

## Testing
- pytest tests/bioetl/infrastructure/clients/chembl/test_factories.py tests/bioetl/core/test_container.py *(fails: coverage threshold 85% not met in current suite)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69314bb3c5208324ae41bb4e1497d38c)