### PR TITLE
Refactor pipeline transformers for hashing and metadata

### DIFF
--- a/src/bioetl/application/orchestrator.py
+++ b/src/bioetl/application/orchestrator.py
@@ -8,6 +8,13 @@ from bioetl.application.container import PipelineContainer, build_pipeline_depen
 from bioetl.application.pipelines.base import PipelineBase
 from bioetl.application.pipelines.registry import get_pipeline_class
 from bioetl.domain.models import RunResult
+from bioetl.domain.transform.transformers import (
+    DatabaseVersionTransformer,
+    FulldateTransformer,
+    HashColumnsTransformer,
+    IndexColumnTransformer,
+    TransformerChain,
+)
 from bioetl.infrastructure.config.models import PipelineConfig
 
 
@@ -53,6 +60,18 @@ class PipelineOrchestrator:
             hooks=hooks,
             error_policy=error_policy,
         )
+
+        post_transformer = TransformerChain(
+            [
+                HashColumnsTransformer(
+                    hash_service, self._config.hashing.business_key_fields
+                ),
+                IndexColumnTransformer(hash_service),
+                DatabaseVersionTransformer(hash_service, pipeline.get_version),
+                FulldateTransformer(hash_service),
+            ]
+        )
+        pipeline.set_post_transformer(post_transformer)
 
         pipeline.add_hooks(hooks)
         pipeline.set_error_policy(error_policy)

--- a/src/bioetl/application/pipelines/chembl/base.py
+++ b/src/bioetl/application/pipelines/chembl/base.py
@@ -12,6 +12,7 @@ from bioetl.domain.record_source import ApiRecordSource, RecordSource
 from bioetl.domain.contracts import ExtractionServiceABC
 from bioetl.domain.models import RunContext
 from bioetl.domain.transform.hash_service import HashService
+from bioetl.domain.transform.transformers import TransformerABC
 from bioetl.domain.validation.service import ValidationService
 from bioetl.infrastructure.config.models import PipelineConfig
 from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
@@ -33,6 +34,7 @@ class ChemblPipelineBase(PipelineBase):
         hash_service: HashService | None = None,
         hooks: list[PipelineHookABC] | None = None,
         error_policy: ErrorPolicyABC | None = None,
+        post_transformer: TransformerABC | None = None,
     ) -> None:
         super().__init__(
             config,
@@ -42,6 +44,7 @@ class ChemblPipelineBase(PipelineBase):
             hash_service,
             hooks,
             error_policy,
+            post_transformer,
         )
         self._extraction_service = extraction_service
         self._record_source = record_source or ApiRecordSource(

--- a/src/bioetl/domain/transform/__init__.py
+++ b/src/bioetl/domain/transform/__init__.py
@@ -2,3 +2,21 @@
 Data transformation logic.
 """
 
+from bioetl.domain.transform.transformers import (
+    DatabaseVersionTransformer,
+    FulldateTransformer,
+    HashColumnsTransformer,
+    IndexColumnTransformer,
+    TransformerABC,
+    TransformerChain,
+)
+
+__all__ = [
+    "TransformerABC",
+    "TransformerChain",
+    "HashColumnsTransformer",
+    "IndexColumnTransformer",
+    "DatabaseVersionTransformer",
+    "FulldateTransformer",
+]
+

--- a/src/bioetl/domain/transform/transformers.py
+++ b/src/bioetl/domain/transform/transformers.py
@@ -1,0 +1,99 @@
+"""
+Domain-level transformers used in pipelines.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Callable
+
+import pandas as pd
+
+from bioetl.domain.models import RunContext
+from bioetl.domain.transform.hash_service import HashService
+
+
+class TransformerABC(ABC):
+    """Базовый интерфейс для DataFrame-трансформеров."""
+
+    @abstractmethod
+    def apply(self, df: pd.DataFrame, context: RunContext | None = None) -> pd.DataFrame:
+        """Выполняет преобразование DataFrame."""
+
+
+class TransformerChain(TransformerABC):
+    """Комбинирует несколько трансформеров в последовательность."""
+
+    def __init__(self, transformers: list[TransformerABC]) -> None:
+        self._transformers = transformers
+
+    def apply(self, df: pd.DataFrame, context: RunContext | None = None) -> pd.DataFrame:
+        result = df
+        for transformer in self._transformers:
+            result = transformer.apply(result, context)
+        return result
+
+
+class HashColumnsTransformer(TransformerABC):
+    """Добавляет hash_business_key и hash_row."""
+
+    def __init__(
+        self, hash_service: HashService, business_key_fields: list[str] | None
+    ) -> None:
+        self._hash_service = hash_service
+        self._business_key_fields = business_key_fields or []
+
+    def apply(self, df: pd.DataFrame, context: RunContext | None = None) -> pd.DataFrame:
+        if df.empty:
+            return df.assign(hash_business_key=None, hash_row=None)
+
+        return self._hash_service.add_hash_columns(
+            df, business_key_cols=self._business_key_fields
+        )
+
+
+class IndexColumnTransformer(TransformerABC):
+    """Добавляет индексную колонку."""
+
+    def __init__(self, hash_service: HashService) -> None:
+        self._hash_service = hash_service
+
+    def apply(self, df: pd.DataFrame, context: RunContext | None = None) -> pd.DataFrame:
+        return self._hash_service.add_index_column(df)
+
+
+class DatabaseVersionTransformer(TransformerABC):
+    """Добавляет колонку с версией базы данных."""
+
+    def __init__(
+        self,
+        hash_service: HashService,
+        database_version_provider: Callable[[], str | None],
+    ) -> None:
+        self._hash_service = hash_service
+        self._database_version_provider = database_version_provider
+
+    def apply(self, df: pd.DataFrame, context: RunContext | None = None) -> pd.DataFrame:
+        version = self._database_version_provider()
+        if version is None:
+            return df
+        return self._hash_service.add_database_version_column(df, version)
+
+
+class FulldateTransformer(TransformerABC):
+    """Добавляет колонку extracted_at с таймстампом."""
+
+    def __init__(self, hash_service: HashService) -> None:
+        self._hash_service = hash_service
+
+    def apply(self, df: pd.DataFrame, context: RunContext | None = None) -> pd.DataFrame:
+        return self._hash_service.add_fulldate_column(df)
+
+
+__all__ = [
+    "TransformerABC",
+    "TransformerChain",
+    "HashColumnsTransformer",
+    "IndexColumnTransformer",
+    "DatabaseVersionTransformer",
+    "FulldateTransformer",
+]


### PR DESCRIPTION
## Summary
- introduce domain-level transformer abstractions for hashing, indexing, database version, and extracted-at columns
- inject transformer chains into pipelines through orchestrator composition instead of direct PipelineBase helpers
- update Chembl pipelines and tests to use new transformer interfaces

## Testing
- pytest tests/bioetl/application/pipelines/test_pipeline_base.py (fails: coverage threshold 85%)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69314db4b47483249e52e62dd1d09e08)