### PR TITLE
Refactor column ordering handling in writers

### DIFF
--- a/src/bioetl/application/pipelines/base.py
+++ b/src/bioetl/application/pipelines/base.py
@@ -231,13 +231,13 @@ class PipelineBase(ABC):
         output_columns = self._validation_service.get_schema_columns(
             output_schema_name
         )
-        df = self._reindex_columns(df, output_columns)
 
         return self._output_writer.write_result(
             df=df,
             output_path=output_path,
             entity_name=self._config.entity_name,
             run_context=context,
+            column_order=output_columns,
         )
 
     # === Hooks ===
@@ -260,18 +260,6 @@ class PipelineBase(ABC):
         self._post_transformer = transformer
 
     # === Internal Methods ===
-    def _reindex_columns(self, df: pd.DataFrame, column_order: list[str]) -> pd.DataFrame:
-        """Добавляет отсутствующие колонки и упорядочивает DataFrame."""
-
-        if not column_order:
-            return df
-
-        for col in column_order:
-            if col not in df.columns:
-                df[col] = None
-
-        return df[column_order]
-
     def _notify_stage_start(self, stage: str, context: RunContext) -> None:
         self._stage_starts[stage] = datetime.now(timezone.utc)
         self._logger.info(

--- a/src/bioetl/infrastructure/output/contracts.py
+++ b/src/bioetl/infrastructure/output/contracts.py
@@ -24,8 +24,14 @@ class WriterABC(ABC):
         """Поддерживает ли атомарную запись."""
 
     @abstractmethod
-    def write(self, df: pd.DataFrame, path: Path) -> WriteResult:
-        """Записывает DataFrame."""
+    def write(
+        self,
+        df: pd.DataFrame,
+        path: Path,
+        *,
+        column_order: list[str] | None = None,
+    ) -> WriteResult:
+        """Записывает DataFrame с учетом порядка колонок."""
 
     @abstractmethod
     def supports_format(self, fmt: str) -> bool:

--- a/src/bioetl/infrastructure/output/impl/csv_writer.py
+++ b/src/bioetl/infrastructure/output/impl/csv_writer.py
@@ -19,10 +19,18 @@ class CsvWriterImpl(WriterABC):
     def atomic(self) -> bool:
         return False
 
-    def write(self, df: pd.DataFrame, path: Path) -> WriteResult:
+    def write(
+        self,
+        df: pd.DataFrame,
+        path: Path,
+        *,
+        column_order: list[str] | None = None,
+    ) -> WriteResult:
         start_time = time.monotonic()
 
-        df.to_csv(path, index=False, encoding="utf-8")
+        df_to_write = self._apply_column_order(df, column_order)
+
+        df_to_write.to_csv(path, index=False, encoding="utf-8")
 
         duration = time.monotonic() - start_time
 
@@ -33,10 +41,23 @@ class CsvWriterImpl(WriterABC):
 
         return WriteResult(
             path=path,
-            row_count=len(df),
+            row_count=len(df_to_write),
             duration_sec=duration,
             checksum=checksum
         )
 
     def supports_format(self, fmt: str) -> bool:
         return fmt.lower() == "csv"
+
+    def _apply_column_order(
+        self, df: pd.DataFrame, column_order: list[str] | None
+    ) -> pd.DataFrame:
+        if not column_order:
+            return df
+
+        df_to_write = df.copy()
+        for col in column_order:
+            if col not in df_to_write.columns:
+                df_to_write[col] = None
+
+        return df_to_write[column_order]

--- a/src/bioetl/infrastructure/output/impl/parquet_writer.py
+++ b/src/bioetl/infrastructure/output/impl/parquet_writer.py
@@ -14,20 +14,41 @@ class ParquetWriterImpl(WriterABC):
     def atomic(self) -> bool:
         return True
 
-    def write(self, df: pd.DataFrame, path: Path) -> WriteResult:
+    def write(
+        self,
+        df: pd.DataFrame,
+        path: Path,
+        *,
+        column_order: list[str] | None = None,
+    ) -> WriteResult:
         start_time = time.monotonic()
-        
-        df.to_parquet(path, index=False)
+
+        df_to_write = self._apply_column_order(df, column_order)
+
+        df_to_write.to_parquet(path, index=False)
         
         duration = time.monotonic() - start_time
         
         return WriteResult(
             path=path,
-            row_count=len(df),
-            checksum="", 
+            row_count=len(df_to_write),
+            checksum="",
             duration_sec=duration,
         )
 
     def supports_format(self, fmt: str) -> bool:
         return fmt.lower() == "parquet"
+
+    def _apply_column_order(
+        self, df: pd.DataFrame, column_order: list[str] | None
+    ) -> pd.DataFrame:
+        if not column_order:
+            return df
+
+        df_to_write = df.copy()
+        for col in column_order:
+            if col not in df_to_write.columns:
+                df_to_write[col] = None
+
+        return df_to_write[column_order]
 


### PR DESCRIPTION
## Summary
- move column alignment responsibility from pipelines to the output writer layer using schema column order
- extend writer contracts and implementations to accept column order before emitting data
- preserve stable sorting while respecting provided column ordering

## Testing
- python -m pytest tests/bioetl/application/pipelines/test_pipeline_base.py *(fails: coverage fail-under 85%)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69319c7fa65883249d5039916779a496)