### PR TITLE
Add TTL-enabled file cache implementation

### DIFF
--- a/src/bioetl/infrastructure/clients/base/contracts.py
+++ b/src/bioetl/infrastructure/clients/base/contracts.py
@@ -121,11 +121,11 @@ class CacheABC(ABC, Generic[T]):
 
     @abstractmethod
     def get(self, key: str) -> T | None:
-        """Получает значение из кэша."""
+        """Получает значение из кэша или ``None``, если его нет или оно истекло."""
 
     @abstractmethod
     def set(self, key: str, value: T, ttl: int | None = None) -> None:
-        """Сохраняет значение в кэш."""
+        """Сохраняет значение в кэш с опциональным TTL в секундах."""
 
     @abstractmethod
     def invalidate(self, key: str) -> None:

--- a/src/bioetl/infrastructure/clients/base/impl/cache.py
+++ b/src/bioetl/infrastructure/clients/base/impl/cache.py
@@ -1,8 +1,23 @@
-from typing import Any, Generic, TypeVar
+from __future__ import annotations
+
+import hashlib
+import os
+import pickle
+import time
+from pathlib import Path
+from typing import Generic, TypeVar
 
 from bioetl.infrastructure.clients.base.contracts import CacheABC
 
 T = TypeVar("T")
+
+
+def _get_expiry_timestamp(ttl: int | None) -> float | None:
+    return time.time() + ttl if ttl is not None else None
+
+
+def _is_expired(expiry_timestamp: float | None) -> bool:
+    return expiry_timestamp is not None and expiry_timestamp <= time.time()
 
 
 class MemoryCacheImpl(CacheABC[T]):
@@ -11,14 +26,22 @@ class MemoryCacheImpl(CacheABC[T]):
     """
 
     def __init__(self) -> None:
-        self._store: dict[str, T] = {}
+        self._store: dict[str, tuple[T, float | None]] = {}
 
     def get(self, key: str) -> T | None:
-        return self._store.get(key)
+        value_with_expiry = self._store.get(key)
+        if value_with_expiry is None:
+            return None
+
+        value, expiry_timestamp = value_with_expiry
+        if _is_expired(expiry_timestamp):
+            self.invalidate(key)
+            return None
+
+        return value
 
     def set(self, key: str, value: T, ttl: int | None = None) -> None:
-        # TTL ignored in simple memory cache for now
-        self._store[key] = value
+        self._store[key] = (value, _get_expiry_timestamp(ttl))
 
     def invalidate(self, key: str) -> None:
         if key in self._store:
@@ -30,21 +53,53 @@ class MemoryCacheImpl(CacheABC[T]):
 
 class FileCacheImpl(CacheABC[T]):
     """
-    Файловый кэш (заглушка).
+    Файловый кэш с TTL.
     """
 
     def __init__(self, cache_dir: str) -> None:
-        self.cache_dir = cache_dir
+        self._cache_dir = Path(cache_dir)
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
 
     def get(self, key: str) -> T | None:
-        return None
+        cache_file = self._key_to_path(key)
+        if not cache_file.exists():
+            return None
+
+        try:
+            with cache_file.open("rb") as fh:
+                payload: tuple[T, float | None] = pickle.load(fh)
+        except (OSError, pickle.PickleError):
+            self.invalidate(key)
+            return None
+
+        value, expiry_timestamp = payload
+        if _is_expired(expiry_timestamp):
+            self.invalidate(key)
+            return None
+
+        return value
 
     def set(self, key: str, value: T, ttl: int | None = None) -> None:
-        pass
+        cache_file = self._key_to_path(key)
+        tmp_file = cache_file.with_suffix(cache_file.suffix + ".tmp")
+        payload: tuple[T, float | None] = (value, _get_expiry_timestamp(ttl))
+
+        with tmp_file.open("wb") as fh:
+            pickle.dump(payload, fh)
+
+        os.replace(tmp_file, cache_file)
 
     def invalidate(self, key: str) -> None:
-        pass
+        cache_file = self._key_to_path(key)
+        if cache_file.exists():
+            cache_file.unlink(missing_ok=True)
 
     def clear(self) -> None:
-        pass
+        for cache_file in self._cache_dir.glob("*.cache"):
+            cache_file.unlink(missing_ok=True)
+
+    def _key_to_path(self, key: str) -> Path:
+        digest = hashlib.sha256(key.encode("utf-8")).hexdigest()
+        safe_name = f"{digest}.cache"
+        return self._cache_dir / safe_name
 

--- a/tests/bioetl/infrastructure/clients/base/test_cache.py
+++ b/tests/bioetl/infrastructure/clients/base/test_cache.py
@@ -1,7 +1,10 @@
 """
 Tests for cache implementations.
 """
-from bioetl.infrastructure.clients.base.impl.cache import MemoryCacheImpl, FileCacheImpl
+import time
+from pathlib import Path
+
+from bioetl.infrastructure.clients.base.impl.cache import FileCacheImpl, MemoryCacheImpl
 
 
 def test_memory_cache():
@@ -17,11 +20,30 @@ def test_memory_cache():
     assert cache.get("k2") is None
 
 
-def test_file_cache():
-    """Test file cache operations (stub)."""
-    # Stub test
-    cache = FileCacheImpl("/tmp")
-    cache.set("k", 1)
+def test_memory_cache_ttl_expiration():
+    """Test TTL expiration in memory cache."""
+    cache = MemoryCacheImpl[int]()
+    cache.set("k", 10, ttl=1)
+    time.sleep(1.2)
     assert cache.get("k") is None
+
+
+def test_file_cache(tmp_path: Path):
+    """Test file cache operations."""
+    cache = FileCacheImpl(tmp_path)
+    cache.set("k", 1)
+    assert cache.get("k") == 1
     cache.invalidate("k")
+    assert cache.get("k") is None
+
+    cache.set("k2", 2)
     cache.clear()
+    assert cache.get("k2") is None
+
+
+def test_file_cache_ttl_expiration(tmp_path: Path):
+    """Test TTL expiration in file cache."""
+    cache = FileCacheImpl(tmp_path)
+    cache.set("k", 5, ttl=1)
+    time.sleep(1.2)
+    assert cache.get("k") is None


### PR DESCRIPTION
## Summary
- add TTL-aware in-memory cache entries with automatic expiration checks
- implement persistent file cache with atomic writes, hashed keys, and TTL support
- extend cache contract documentation and tests to cover expiration and disk storage operations

## Testing
- pytest tests/bioetl/infrastructure/clients/base/test_cache.py --cov-fail-under=0


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69319ccfb6608324a3e1781dd981954d)