### PR TITLE
Implement chunked pipeline processing

### DIFF
--- a/src/bioetl/domain/enums.py
+++ b/src/bioetl/domain/enums.py
@@ -17,6 +17,7 @@ class StageResult:
     stage_name: str
     success: bool
     records_processed: int = 0
+    chunks_processed: int = 0
     duration_sec: float = 0.0
     errors: list[str] = field(default_factory=list)
 

--- a/src/bioetl/domain/models.py
+++ b/src/bioetl/domain/models.py
@@ -15,6 +15,7 @@ class StageResult:
     stage_name: str
     success: bool
     records_processed: int
+    chunks_processed: int
     duration_sec: float
     errors: list[str]
 

--- a/tests/bioetl/interfaces/cli/test_cli.py
+++ b/tests/bioetl/interfaces/cli/test_cli.py
@@ -68,7 +68,7 @@ def test_validate_config_success(mock_loader):
 
 @pytest.mark.unit
 @patch("bioetl.interfaces.cli.app.PipelineOrchestrator")
-@patch("bioetl.interfaces.cli.app.load_pipeline_config")
+@patch("bioetl.interfaces.cli.app.load_pipeline_config_from_path")
 def test_run_command(mock_loader, mock_orchestrator_cls):
     """Test the run command."""
     mock_orchestrator = MagicMock()
@@ -117,7 +117,7 @@ def test_smoke_run(mock_run):
 
 
 @pytest.mark.unit
-@patch("bioetl.interfaces.cli.app.load_pipeline_config")
+@patch("bioetl.interfaces.cli.app.load_pipeline_config_from_path")
 def test_run_config_not_found_explicit(mock_loader):
     """Test run command with explicit config that doesn't exist."""
     mock_loader.side_effect = FileNotFoundError("No such file or directory")
@@ -127,14 +127,12 @@ def test_run_config_not_found_explicit(mock_loader):
     )
 
     assert result.exit_code == 1
-    # The app catches exception and prints "Error: ..."
-    assert "Error:" in result.stdout
-    assert "No such file or directory" in result.stdout
+    assert "Config file not found" in result.stdout
 
 
 @pytest.mark.unit
 @patch("bioetl.interfaces.cli.app.PipelineOrchestrator")
-@patch("bioetl.interfaces.cli.app.load_pipeline_config")
+@patch("bioetl.interfaces.cli.app.load_pipeline_config_from_path")
 def test_run_with_limit_and_dry_run(
     mock_loader, mock_orchestrator_cls
 ):
@@ -176,7 +174,7 @@ def test_run_with_limit_and_dry_run(
 
 @pytest.mark.unit
 @patch("bioetl.interfaces.cli.app.PipelineOrchestrator")
-@patch("bioetl.interfaces.cli.app.load_pipeline_config")
+@patch("bioetl.interfaces.cli.app.load_pipeline_config_from_path")
 def test_run_pipeline_failure(mock_loader, mock_orchestrator_cls):
     """Test run command when pipeline fails."""
     mock_orchestrator = MagicMock()
@@ -207,7 +205,7 @@ def test_run_pipeline_failure(mock_loader, mock_orchestrator_cls):
 
 
 @pytest.mark.unit
-@patch("bioetl.interfaces.cli.app.load_pipeline_config")
+@patch("bioetl.interfaces.cli.app.load_pipeline_config_from_path")
 def test_run_exception(mock_loader):
     """Test run command unhandled exception."""
     mock_loader.side_effect = RuntimeError("Unexpected error")
@@ -221,7 +219,7 @@ def test_run_exception(mock_loader):
 
 @pytest.mark.unit
 @patch("bioetl.interfaces.cli.app.PipelineOrchestrator")
-@patch("bioetl.interfaces.cli.app.load_pipeline_config")
+@patch("bioetl.interfaces.cli.app.load_pipeline_config_from_path")
 def test_run_dry_run_pipeline_metadata(
     mock_loader,
     mock_orchestrator_cls,


### PR DESCRIPTION
## Summary
- add chunked pipeline execution with iter_chunks support and aggregate stage metrics
- persist hash and index state across chunks and stream ChEMBL records without full concatenation
- update CLI config resolution to honor provided paths and refresh tests for new behavior

## Testing
- pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69319cc233b08324a60641b0eb1ab56f)