### PR TITLE
Refactor provider registry to domain layer

### DIFF
--- a/src/bioetl/application/pipelines/base.py
+++ b/src/bioetl/application/pipelines/base.py
@@ -7,11 +7,11 @@ from pathlib import Path
 from typing import Any, Callable, Iterable, TYPE_CHECKING
 import pandas as pd
 
-from bioetl.core.providers import ProviderId
 from bioetl.application.pipelines.hooks import ErrorPolicyABC, PipelineHookABC
 from bioetl.domain.enums import ErrorAction
 from bioetl.domain.errors import PipelineStageError
 from bioetl.domain.models import RunContext, RunResult, StageResult
+from bioetl.domain.providers import ProviderId
 from bioetl.domain.schemas.pipeline_contracts import get_pipeline_contract
 from bioetl.domain.transform.hash_service import HashService
 from bioetl.domain.transform.transformers import (

--- a/src/bioetl/core/provider_registry.py
+++ b/src/bioetl/core/provider_registry.py
@@ -1,11 +1,15 @@
-"""Registry for provider definitions."""
+"""Compatibility layer for provider registry APIs."""
 
-from __future__ import annotations
-
-from typing import Iterable
-
-from bioetl.core.providers import ProviderDefinition, ProviderId
-from bioetl.domain.errors import ProviderError
+from bioetl.domain.provider_registry import (
+    ProviderAlreadyRegisteredError,
+    ProviderNotRegisteredError,
+    ProviderRegistryError,
+    get_provider,
+    list_providers,
+    register_provider,
+    reset_provider_registry,
+    restore_provider_registry,
+)
 
 __all__ = [
     "ProviderNotRegisteredError",
@@ -17,64 +21,3 @@ __all__ = [
     "reset_provider_registry",
     "restore_provider_registry",
 ]
-
-
-class ProviderRegistryError(ProviderError):
-    """Base class for provider registry errors."""
-
-    def __init__(self, provider: str, message: str) -> None:
-        super().__init__(provider=provider, message=message)
-
-
-class ProviderNotRegisteredError(ProviderRegistryError):
-    """Raised when provider is not registered in the registry."""
-
-    def __init__(self, provider: str) -> None:
-        super().__init__(provider, f"Provider '{provider}' is not registered")
-
-
-class ProviderAlreadyRegisteredError(ProviderRegistryError):
-    """Raised when attempting to register a duplicate provider id."""
-
-    def __init__(self, provider: str) -> None:
-        super().__init__(provider, f"Provider '{provider}' already registered")
-
-
-_PROVIDERS: dict[ProviderId, ProviderDefinition] = {}
-
-
-def register_provider(definition: ProviderDefinition) -> None:
-    """Register provider definition in the registry."""
-
-    if definition.id in _PROVIDERS:
-        raise ProviderAlreadyRegisteredError(definition.id.value)
-    _PROVIDERS[definition.id] = definition
-
-
-def get_provider(provider_id: ProviderId) -> ProviderDefinition:
-    """Get provider definition by id."""
-
-    try:
-        return _PROVIDERS[provider_id]
-    except KeyError as exc:  # pragma: no cover - defensive
-        raise ProviderNotRegisteredError(provider_id.value) from exc
-
-
-def list_providers() -> list[ProviderDefinition]:
-    """List all registered provider definitions."""
-
-    return list(_PROVIDERS.values())
-
-
-def reset_provider_registry() -> None:
-    """Clear registry (intended for test isolation)."""
-
-    _PROVIDERS.clear()
-
-
-def restore_provider_registry(definitions: Iterable[ProviderDefinition]) -> None:
-    """Restore registry to provided definitions (used in tests)."""
-
-    reset_provider_registry()
-    for definition in definitions:
-        _PROVIDERS[definition.id] = definition

--- a/src/bioetl/core/providers.py
+++ b/src/bioetl/core/providers.py
@@ -1,49 +1,5 @@
-"""Provider domain abstractions and factories."""
+"""Compatibility layer for provider abstractions."""
 
-from __future__ import annotations
-
-from dataclasses import dataclass
-from enum import Enum
-from typing import Protocol, TypeVar, runtime_checkable
-
-from pydantic import BaseModel
-
-ProviderConfigT = TypeVar("ProviderConfigT", bound=BaseModel)
-ProviderClientT = TypeVar("ProviderClientT")
-ExtractionServiceT = TypeVar("ExtractionServiceT")
-
-
-class ProviderId(str, Enum):
-    """Canonical provider identifiers."""
-
-    CHEMBL = "chembl"
-    PUBCHEM = "pubchem"
-    UNIPROT = "uniprot"
-    PUBMED = "pubmed"
-    DUMMY = "dummy"
-
-
-@runtime_checkable
-class ProviderComponents(Protocol[ProviderConfigT, ProviderClientT, ExtractionServiceT]):
-    """Protocol describing provider component factories."""
-
-    def create_client(self, config: ProviderConfigT) -> ProviderClientT:
-        """Create provider client instance."""
-
-    def create_extraction_service(
-        self, client: ProviderClientT, config: ProviderConfigT
-    ) -> ExtractionServiceT:
-        """Create provider-specific extraction service."""
-
-
-@dataclass(frozen=True)
-class ProviderDefinition:
-    """Provider metadata and factory entry points."""
-
-    id: ProviderId
-    config_type: type[ProviderConfigT]
-    components: ProviderComponents[ProviderConfigT, ProviderClientT, ExtractionServiceT]
-    description: str | None = None
-
+from bioetl.domain.providers import ProviderComponents, ProviderDefinition, ProviderId
 
 __all__ = ["ProviderComponents", "ProviderDefinition", "ProviderId"]

--- a/src/bioetl/domain/provider_registry.py
+++ b/src/bioetl/domain/provider_registry.py
@@ -1,15 +1,10 @@
-"""Compatibility wrapper for provider registry."""
+"""Registry for provider definitions."""
+from __future__ import annotations
 
-from bioetl.core.provider_registry import (
-    ProviderAlreadyRegisteredError,
-    ProviderNotRegisteredError,
-    ProviderRegistryError,
-    get_provider,
-    list_providers,
-    register_provider,
-    reset_provider_registry,
-    restore_provider_registry,
-)
+from typing import Iterable
+
+from bioetl.domain.errors import ProviderError
+from bioetl.domain.providers import ProviderDefinition, ProviderId
 
 __all__ = [
     "ProviderNotRegisteredError",
@@ -21,3 +16,64 @@ __all__ = [
     "reset_provider_registry",
     "restore_provider_registry",
 ]
+
+
+class ProviderRegistryError(ProviderError):
+    """Base class for provider registry errors."""
+
+    def __init__(self, provider: str, message: str) -> None:
+        super().__init__(provider=provider, message=message)
+
+
+class ProviderNotRegisteredError(ProviderRegistryError):
+    """Raised when provider is not registered in the registry."""
+
+    def __init__(self, provider: str) -> None:
+        super().__init__(provider, f"Provider '{provider}' is not registered")
+
+
+class ProviderAlreadyRegisteredError(ProviderRegistryError):
+    """Raised when attempting to register a duplicate provider id."""
+
+    def __init__(self, provider: str) -> None:
+        super().__init__(provider, f"Provider '{provider}' already registered")
+
+
+_PROVIDERS: dict[ProviderId, ProviderDefinition] = {}
+
+
+def register_provider(definition: ProviderDefinition) -> None:
+    """Register provider definition in the registry."""
+
+    if definition.id in _PROVIDERS:
+        raise ProviderAlreadyRegisteredError(definition.id.value)
+    _PROVIDERS[definition.id] = definition
+
+
+def get_provider(provider_id: ProviderId) -> ProviderDefinition:
+    """Get provider definition by id."""
+
+    try:
+        return _PROVIDERS[provider_id]
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise ProviderNotRegisteredError(provider_id.value) from exc
+
+
+def list_providers() -> list[ProviderDefinition]:
+    """List all registered provider definitions."""
+
+    return list(_PROVIDERS.values())
+
+
+def reset_provider_registry() -> None:
+    """Clear registry (intended for test isolation)."""
+
+    _PROVIDERS.clear()
+
+
+def restore_provider_registry(definitions: Iterable[ProviderDefinition]) -> None:
+    """Restore registry to provided definitions (used in tests)."""
+
+    reset_provider_registry()
+    for definition in definitions:
+        _PROVIDERS[definition.id] = definition

--- a/src/bioetl/domain/providers.py
+++ b/src/bioetl/domain/providers.py
@@ -1,7 +1,64 @@
-"""Compatibility wrapper for provider domain types."""
+"""Provider domain abstractions and factories."""
+from __future__ import annotations
 
-from bioetl.core.providers import ProviderComponents, ProviderDefinition, ProviderId
-from bioetl.schemas.provider_config_schema import BaseProviderConfig
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict
+
+from bioetl.domain.normalization_service import NormalizationService
+
+
+class ProviderId(str, Enum):
+    """Canonical provider identifiers."""
+
+    CHEMBL = "chembl"
+    PUBCHEM = "pubchem"
+    UNIPROT = "uniprot"
+    PUBMED = "pubmed"
+    DUMMY = "dummy"
+
+
+class BaseProviderConfig(BaseModel):
+    """Base provider configuration model."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+@runtime_checkable
+class ProviderComponents(Protocol):
+    """Protocol describing provider component factories."""
+
+    def create_client(self, config: BaseProviderConfig):
+        """Create provider client instance."""
+
+    def create_extraction_service(self, client: object, config: BaseProviderConfig):
+        """Create provider-specific extraction service."""
+
+    # Optional factories
+    def create_normalization_service(
+        self,
+        config: BaseProviderConfig,
+        *,
+        client: object | None = None,
+        pipeline_config: object | None = None,
+    ) -> NormalizationService:  # pragma: no cover - optional
+        """Create provider-specific normalization service."""
+
+    def create_writer(self, config: BaseProviderConfig):  # pragma: no cover - optional
+        """Create provider-specific writer."""
+
+
+@dataclass(frozen=True)
+class ProviderDefinition:
+    """Provider metadata and factory entry points."""
+
+    id: ProviderId
+    config_type: type[BaseProviderConfig]
+    components: ProviderComponents
+    description: str | None = None
+
 
 __all__ = [
     "BaseProviderConfig",

--- a/src/bioetl/infrastructure/clients/chembl/provider.py
+++ b/src/bioetl/infrastructure/clients/chembl/provider.py
@@ -3,26 +3,23 @@
 from __future__ import annotations
 
 from bioetl.application.services.chembl_extraction import ChemblExtractionService
-from bioetl.core.provider_registry import (
+from bioetl.domain.normalization_service import ChemblNormalizationService
+from bioetl.domain.provider_registry import (
     ProviderAlreadyRegisteredError,
     get_provider,
     register_provider,
 )
-from bioetl.core.providers import (
-    ProviderComponents,
-    ProviderDefinition,
-    ProviderId,
-)
+from bioetl.domain.providers import ProviderComponents, ProviderDefinition, ProviderId
 from bioetl.infrastructure.chembl_client import (
     create_client,
     create_extraction_service,
 )
 from bioetl.infrastructure.clients.chembl.contracts import ChemblDataClientABC
-from bioetl.infrastructure.config.models import ChemblSourceConfig
+from bioetl.infrastructure.config.models import ChemblSourceConfig, PipelineConfig
 
 
 class ChemblProviderComponents(
-    ProviderComponents[ChemblSourceConfig, ChemblDataClientABC, ChemblExtractionService]
+    ProviderComponents
 ):
     """Factory set for building ChEMBL provider components."""
 
@@ -33,6 +30,19 @@ class ChemblProviderComponents(
         self, client: ChemblDataClientABC, config: ChemblSourceConfig
     ) -> ChemblExtractionService:
         return create_extraction_service(config, client=client)
+
+    def create_normalization_service(
+        self,
+        config: ChemblSourceConfig,
+        *,
+        pipeline_config: PipelineConfig | None = None,
+        client: ChemblDataClientABC | None = None,
+    ) -> ChemblNormalizationService:
+        _ = config  # keep signature explicit
+        effective_config = pipeline_config
+        if effective_config is None:
+            raise ValueError("PipelineConfig is required to build normalization service")
+        return ChemblNormalizationService(effective_config)
 
 
 def register_chembl_provider() -> ProviderDefinition:

--- a/src/bioetl/schemas/provider_config_schema.py
+++ b/src/bioetl/schemas/provider_config_schema.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 
 from typing import Annotated, Literal
 
-from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, PositiveFloat, PositiveInt
+from pydantic import AnyHttpUrl, ConfigDict, Field, PositiveFloat, PositiveInt
 from pydantic.types import NonNegativeInt
 
+from bioetl.domain.providers import BaseProviderConfig as ProviderConfigBase
 
-class BaseProviderConfig(BaseModel):
+
+class BaseProviderConfig(ProviderConfigBase):
     """Базовая строгая конфигурация провайдера."""
 
     provider: Literal["chembl", "pubchem", "uniprot", "dummy"]

--- a/tests/bioetl/domain/test_container.py
+++ b/tests/bioetl/domain/test_container.py
@@ -15,7 +15,7 @@ from bioetl.application.pipelines.hooks_impl import (
     FailFastErrorPolicyImpl,
     LoggingPipelineHookImpl,
 )
-from bioetl.core.provider_registry import (
+from bioetl.domain.provider_registry import (
     ProviderAlreadyRegisteredError,
     ProviderNotRegisteredError,
     list_providers,
@@ -23,15 +23,13 @@ from bioetl.core.provider_registry import (
     reset_provider_registry,
     restore_provider_registry,
 )
-from bioetl.core.providers import ProviderComponents, ProviderDefinition, ProviderId
+from bioetl.domain.providers import ProviderComponents, ProviderDefinition, ProviderId
 from bioetl.infrastructure.clients.chembl.provider import register_chembl_provider
 from bioetl.infrastructure.config.models import PipelineConfig
 from bioetl.schemas.provider_config_schema import ChemblSourceConfig, DummyProviderConfig
 
 
-class DummyComponents(
-    ProviderComponents[DummyProviderConfig, dict[str, str], tuple[str, str]]
-):
+class DummyComponents(ProviderComponents):
     def create_client(self, config: DummyProviderConfig) -> dict[str, str]:
         return {"provider": config.provider, "base_url": str(config.base_url)}
 

--- a/tests/bioetl/domain/test_provider_registry.py
+++ b/tests/bioetl/domain/test_provider_registry.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import pytest
 
-from bioetl.core.provider_registry import (
+from bioetl.domain.provider_registry import (
     ProviderAlreadyRegisteredError,
     ProviderNotRegisteredError,
     get_provider,
@@ -14,14 +14,12 @@ from bioetl.core.provider_registry import (
     reset_provider_registry,
     restore_provider_registry,
 )
-from bioetl.core.providers import ProviderComponents, ProviderDefinition, ProviderId
+from bioetl.domain.providers import ProviderComponents, ProviderDefinition, ProviderId
 from bioetl.schemas.provider_config_schema import DummyProviderConfig
 
 
 @dataclass(frozen=True)
-class DummyComponents(
-    ProviderComponents[DummyProviderConfig, dict[str, str], tuple[dict[str, str], str]]
-):
+class DummyComponents(ProviderComponents):
     def create_client(self, config: DummyProviderConfig) -> dict[str, str]:
         return {"base_url": str(config.base_url)}
 


### PR DESCRIPTION
## Summary
- move provider abstractions and registry into the domain layer and align provider configs
- refactor the pipeline container to resolve components via provider definitions without provider-specific branches
- register ChEMBL provider components including normalization factory and relocate provider registry tests

## Testing
- pytest --cov-fail-under=0 tests/bioetl/domain/test_provider_registry.py tests/bioetl/domain/test_container.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931a587caec832497b8526ba01b76a0)