### PR TITLE
Directly register providers in pipeline container

### DIFF
--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -1,8 +1,6 @@
 """Dependency Injection Container for the application."""
 from pathlib import Path
 from typing import Any, Callable
-
-import bioetl.infrastructure.clients.chembl.provider  # noqa: F401 - ensure registration
 from bioetl.application.pipelines.hooks import ErrorPolicyABC, PipelineHookABC
 from bioetl.application.pipelines.hooks_impl import (
     FailFastErrorPolicyImpl,

--- a/tests/bioetl/application/test_container_provider_registration.py
+++ b/tests/bioetl/application/test_container_provider_registration.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import sys
+import types
+
+from bioetl.domain.provider_registry import (
+    get_provider,
+    list_providers,
+    reset_provider_registry,
+    restore_provider_registry,
+)
+from bioetl.domain.providers import ProviderId
+
+
+def _stub_tqdm_module() -> types.ModuleType:
+    module = types.ModuleType("tqdm")
+    module.tqdm = lambda *args, **kwargs: None
+    return module
+
+
+def test_register_providers_registers_chembl() -> None:
+    snapshot = list_providers()
+    try:
+        reset_provider_registry()
+        sys.modules.setdefault("tqdm", _stub_tqdm_module())
+
+        from bioetl.application.container import PipelineContainer
+
+        container = object.__new__(PipelineContainer)
+
+        container._register_providers()
+
+        provider = get_provider(ProviderId.CHEMBL)
+        assert provider.id == ProviderId.CHEMBL
+        assert ProviderId.CHEMBL in {definition.id for definition in list_providers()}
+    finally:
+        restore_provider_registry(snapshot)
+        sys.modules.pop("tqdm", None)


### PR DESCRIPTION
## Summary
- call explicit provider registration functions instead of relying on side-effect imports
- add a unit test verifying provider registration and lookup work without incidental imports

## Testing
- pytest tests/bioetl/application/test_container_provider_registration.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69331944c39c832ba1b6d4b6e911bc37)