### PR TITLE
Handle Retry-After in HTTP middleware retries

### DIFF
--- a/src/bioetl/infrastructure/config/models.py
+++ b/src/bioetl/infrastructure/config/models.py
@@ -12,6 +12,7 @@ from bioetl.application.config.pipeline_config_schema import (
     LoggingConfig,
     NormalizationConfig,
     PaginationConfig,
+    PipelineConfig,
     QcConfig,
     StorageConfig,
 )
@@ -33,6 +34,7 @@ __all__ = [
     "LoggingConfig",
     "NormalizationConfig",
     "PaginationConfig",
+    "PipelineConfig",
     "QcConfig",
     "StorageConfig",
     "BaseProviderConfig",


### PR DESCRIPTION
## Summary
- extract Retry-After headers from responses/errors to compute enforced retry delays
- combine Retry-After values with backoff using jitter capped by max_delay
- add retry timing tests for 429/503 responses and expose PipelineConfig for conftest import

## Testing
- PYTHONPATH=src pytest tests/bioetl/infrastructure/clients/base/test_middleware.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69332c594058832488385ac0348dba0a)