### PR TITLE
Improve HTTP retry logging and metrics

### DIFF
--- a/src/bioetl/infrastructure/config/models.py
+++ b/src/bioetl/infrastructure/config/models.py
@@ -12,6 +12,7 @@ from bioetl.application.config.pipeline_config_schema import (
     LoggingConfig,
     NormalizationConfig,
     PaginationConfig,
+    PipelineConfig,
     QcConfig,
     StorageConfig,
 )
@@ -33,6 +34,7 @@ __all__ = [
     "LoggingConfig",
     "NormalizationConfig",
     "PaginationConfig",
+    "PipelineConfig",
     "QcConfig",
     "StorageConfig",
     "BaseProviderConfig",


### PR DESCRIPTION
## Summary
- log retry delays, reasons, and cumulative wait times with final success/failure records
- support optional metrics callbacks to count retries and failures
- export PipelineConfig alias and expand middleware tests to verify new logging

## Testing
- pytest tests/bioetl/infrastructure/clients/base/test_middleware.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69332c669868832485525605a8c299fb)