### PR TITLE
Split architecture checks into dedicated job

### DIFF
--- a/.github/workflows/import-linter.yml
+++ b/.github/workflows/import-linter.yml
@@ -37,6 +37,43 @@ jobs:
       - name: Mypy (strict-ish)
         run: mypy --config-file pyproject.toml src/bioetl
 
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[dev]
+
+      - name: Pytest
+        run: pytest
+
+  arch-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[dev]
+
       - name: Architecture guard (pytest)
         run: pytest tests/architecture/test_layer_dependencies.py
 


### PR DESCRIPTION
## Summary
- separate architecture contract checks into dedicated arch-tests job
- keep linting and main pytest runs in their own jobs to run in parallel

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693335a25c64832b8b5f819d86b96e34)