### PR TITLE
Add duplication and complexity CI workflow

### DIFF
--- a/.github/workflows/duplication-complexity.yml
+++ b/.github/workflows/duplication-complexity.yml
@@ -1,0 +1,52 @@
+name: Duplication and Complexity Checks
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+jobs:
+  duplication-complexity:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install radon xenon
+
+      - name: Prepare report directory
+        run: mkdir -p reports
+
+      - name: Generate Radon complexity reports
+        run: |
+          radon cc src tests -a -s > reports/radon_cc.txt
+          radon cc src tests -a -s -j > reports/radon_cc.json
+
+      - name: Enforce cyclomatic complexity threshold
+        run: xenon --max-absolute B --max-modules B --max-average B src tests
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Run jscpd for duplication detection
+        run: npx jscpd@latest --path src --path tests --threshold 5 --reporters "console,html,json" --output reports/jscpd
+
+      - name: Upload reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: duplication-complexity-reports
+          path: reports
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run duplication and cyclomatic complexity checks on src and tests
- enforce cyclomatic complexity not exceeding grade B (<=10) and duplication threshold of 5%
- publish radon and jscpd reports as build artifacts for review

## Testing
- not run (workflow file only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693335a2df34832b8c5fdf66b6d3af7e)