### PR TITLE
Ensure ordered Pandera schemas for ChEMBL outputs

### DIFF
--- a/src/bioetl/domain/schemas/chembl/activity.py
+++ b/src/bioetl/domain/schemas/chembl/activity.py
@@ -51,6 +51,11 @@ OUTPUT_COLUMN_ORDER: list[str] = [
     "uo_units",
     "upper_value",
     "value",
+    "hash_row",
+    "hash_business_key",
+    "index",
+    "database_version",
+    "extracted_at",
 ]
 
 
@@ -114,3 +119,4 @@ class ActivitySchema(pa.DataFrameModel):
     class Config:
         strict = True
         coerce = True
+        ordered = True

--- a/src/bioetl/domain/schemas/chembl/assay.py
+++ b/src/bioetl/domain/schemas/chembl/assay.py
@@ -32,6 +32,11 @@ OUTPUT_COLUMN_ORDER: list[str] = [
     "target_chembl_id",
     "tissue_chembl_id",
     "variant_sequence",
+    "hash_row",
+    "hash_business_key",
+    "index",
+    "database_version",
+    "extracted_at",
 ]
 
 
@@ -77,3 +82,4 @@ class AssaySchema(pa.DataFrameModel):
     class Config:
         strict = True
         coerce = True
+        ordered = True

--- a/src/bioetl/domain/schemas/chembl/document.py
+++ b/src/bioetl/domain/schemas/chembl/document.py
@@ -25,6 +25,11 @@ OUTPUT_COLUMN_ORDER: list[str] = [
     "title",
     "volume",
     "year",
+    "hash_row",
+    "hash_business_key",
+    "index",
+    "database_version",
+    "extracted_at",
 ]
 
 
@@ -111,3 +116,4 @@ class DocumentSchema(pa.DataFrameModel):
 
         strict = True
         coerce = True
+        ordered = True

--- a/src/bioetl/domain/schemas/chembl/molecule.py
+++ b/src/bioetl/domain/schemas/chembl/molecule.py
@@ -39,6 +39,11 @@ OUTPUT_COLUMN_ORDER: list[str] = [
     "usan_year",
     "veterinary",
     "withdrawn_flag",
+    "hash_row",
+    "hash_business_key",
+    "index",
+    "database_version",
+    "extracted_at",
 ]
 
 
@@ -164,4 +169,5 @@ class MoleculeSchema(pa.DataFrameModel):
         """Pandera configuration."""
         strict = True
         coerce = True
+        ordered = True
 

--- a/src/bioetl/domain/schemas/chembl/target.py
+++ b/src/bioetl/domain/schemas/chembl/target.py
@@ -18,6 +18,11 @@ OUTPUT_COLUMN_ORDER: list[str] = [
     "target_components",
     "cross_references",
     "uniprot_id",
+    "hash_row",
+    "hash_business_key",
+    "index",
+    "database_version",
+    "extracted_at",
 ]
 
 
@@ -72,3 +77,4 @@ class TargetSchema(pa.DataFrameModel):
 
         strict = True
         coerce = True
+        ordered = True

--- a/src/bioetl/domain/schemas/chembl/testitem.py
+++ b/src/bioetl/domain/schemas/chembl/testitem.py
@@ -18,6 +18,11 @@ OUTPUT_COLUMN_ORDER: list[str] = [
     "cross_references",
     "pubchem_cid",
     "helm_notation",
+    "hash_row",
+    "hash_business_key",
+    "index",
+    "database_version",
+    "extracted_at",
 ]
 
 
@@ -87,3 +92,4 @@ class TestitemSchema(pa.DataFrameModel):
 
         strict = True
         coerce = True
+        ordered = True


### PR DESCRIPTION
## Summary
- add ordered flag to ChEMBL Pandera schemas to enforce column ordering
- align output column order constants with schema fields, including generated columns

## Testing
- PYTHONPATH=src python - <<'PY'
from bioetl.domain.schemas.chembl.activity import ActivitySchema, OUTPUT_COLUMN_ORDER as ACTIVITY_ORDER
from bioetl.domain.schemas.chembl.assay import AssaySchema, OUTPUT_COLUMN_ORDER as ASSAY_ORDER
from bioetl.domain.schemas.chembl.document import DocumentSchema, OUTPUT_COLUMN_ORDER as DOCUMENT_ORDER
from bioetl.domain.schemas.chembl.target import TargetSchema, OUTPUT_COLUMN_ORDER as TARGET_ORDER
from bioetl.domain.schemas.chembl.molecule import MoleculeSchema, OUTPUT_COLUMN_ORDER as MOLECULE_ORDER
from bioetl.domain.schemas.chembl.testitem import TestitemSchema, OUTPUT_COLUMN_ORDER as TESTITEM_ORDER

schemas = [
    ("activity", ActivitySchema, ACTIVITY_ORDER),
    ("assay", AssaySchema, ASSAY_ORDER),
    ("document", DocumentSchema, DOCUMENT_ORDER),
    ("target", TargetSchema, TARGET_ORDER),
    ("molecule", MoleculeSchema, MOLECULE_ORDER),
    ("testitem", TestitemSchema, TESTITEM_ORDER),
]

for name, schema_cls, expected in schemas:
    schema = schema_cls.to_schema()
    actual = list(schema.columns.keys())
    if actual != expected:
        raise SystemExit(f"{name} order mismatch: {actual} != {expected}")
    print(f"{name}: column order matches expected ({len(expected)} columns)")
    if not schema.ordered:
        raise SystemExit(f"{name} schema ordered flag is False")
PY


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933eb6293148324bd81110778df53fe)