### PR TITLE
Add QC reporting to unified output writer

### DIFF
--- a/docs/architecture/03-data-flow.md
+++ b/docs/architecture/03-data-flow.md
@@ -19,5 +19,5 @@
 2. ChemblClient извлекает данные по дескриптору (release, фильтры), пагинирует и передаёт батчи в ActivityTransformer.
 3. Transformer нормализует значения, считает `hash_business_key` и `hash_row`, сопоставляет TestItem/Target идентификаторы.
 4. ValidationService применяет ActivitySchema, формирует QC-отчёты и метрики валидации.
-5. UnifiedOutputWriter записывает таблицы в `tables/`, создаёт `meta.yaml`, QC-отчёты в `qc/` и контрольные суммы в `checksums/`.
+5. UnifiedOutputWriter записывает таблицы в `tables/`, создаёт `meta.yaml`, формирует `quality_report_table.csv` и `correlation_report_table.csv` атомарно и вычисляет контрольные суммы.
 6. finalize_run закрывает ресурсы клиента и публикует финальное состояние RunResult.

--- a/docs/guides/01-configuration.md
+++ b/docs/guides/01-configuration.md
@@ -46,6 +46,10 @@ pagination:
   limit: 1000
 hashing:
   business_key_fields: []
+qc:
+  enable_quality_report: true
+  enable_correlation_report: true
+  min_coverage: 0.85
 ```
 
 **Конфиг `configs/pipelines/chembl/activity.yaml`**:
@@ -60,6 +64,10 @@ hashing:
   business_key_fields:
     - activity_id
     - molecule_chembl_id
+qc:
+  enable_quality_report: true
+  enable_correlation_report: false
+  min_coverage: 0.9
 ```
 
 Пайплайн-секция может ссылаться на профиль `chembl_default` и одновременно задавать собственные поля (`entity_name`, `pipeline`, `hashing` и др.), которые будут объединены с настройками профиля при разрешении конфигурации.

--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -29,6 +29,7 @@ from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
 from bioetl.infrastructure.logging.factories import default_logger
 from bioetl.infrastructure.output.factories import (
     default_metadata_writer,
+    default_quality_reporter,
     default_writer,
 )
 from bioetl.infrastructure.output.unified_writer import UnifiedOutputWriter
@@ -75,7 +76,9 @@ class PipelineContainer:
         return UnifiedOutputWriter(
             writer=default_writer(),
             metadata_writer=default_metadata_writer(),
+            quality_reporter=default_quality_reporter(),
             config=self.config.determinism,
+            qc_config=self.config.qc,
         )
 
     def get_normalization_service(self) -> NormalizationService:

--- a/src/bioetl/infrastructure/output/contracts.py
+++ b/src/bioetl/infrastructure/output/contracts.py
@@ -55,3 +55,17 @@ class MetadataWriterABC(ABC):
     def generate_checksums(self, paths: list[Path]) -> dict[str, str]:
         """Генерирует контрольные суммы файлов."""
 
+
+class QualityReportABC(ABC):
+    """Порт генератора QC-отчетов."""
+
+    @abstractmethod
+    def build_quality_report(
+        self, df: pd.DataFrame, *, min_coverage: float
+    ) -> pd.DataFrame:
+        """Строит таблицу покрытия и базовых метрик по колонкам."""
+
+    @abstractmethod
+    def build_correlation_report(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Строит корреляционную матрицу по числовым колонкам."""
+

--- a/src/bioetl/infrastructure/output/factories.py
+++ b/src/bioetl/infrastructure/output/factories.py
@@ -1,6 +1,11 @@
-from bioetl.infrastructure.output.contracts import MetadataWriterABC, WriterABC
+from bioetl.infrastructure.output.contracts import (
+    MetadataWriterABC,
+    QualityReportABC,
+    WriterABC,
+)
 from bioetl.infrastructure.output.impl.csv_writer import CsvWriterImpl
 from bioetl.infrastructure.output.impl.metadata_writer import MetadataWriterImpl
+from bioetl.infrastructure.output.impl.quality_report import QualityReportImpl
 
 
 def default_writer() -> WriterABC:
@@ -9,4 +14,8 @@ def default_writer() -> WriterABC:
 
 def default_metadata_writer() -> MetadataWriterABC:
     return MetadataWriterImpl()
+
+
+def default_quality_reporter() -> QualityReportABC:
+    return QualityReportImpl()
 

--- a/src/bioetl/infrastructure/output/impl/quality_report.py
+++ b/src/bioetl/infrastructure/output/impl/quality_report.py
@@ -1,0 +1,52 @@
+"""Quality report generator implementation."""
+from __future__ import annotations
+
+import pandas as pd
+
+from bioetl.infrastructure.output.contracts import QualityReportABC
+
+
+class QualityReportImpl(QualityReportABC):
+    """Генератор QC-отчетов на базе Pandas."""
+
+    def build_quality_report(
+        self, df: pd.DataFrame, *, min_coverage: float
+    ) -> pd.DataFrame:
+        row_count = len(df.index)
+        nulls = df.isnull().sum()
+        non_nulls = df.notnull().sum()
+        unique_counts = df.nunique(dropna=True)
+        coverage = non_nulls / row_count if row_count > 0 else 0.0
+
+        report = pd.DataFrame(
+            {
+                "column": df.columns,
+                "null_count": nulls.values,
+                "non_null_count": non_nulls.values,
+                "unique_count": unique_counts.values,
+                "dtype": df.dtypes.values.astype(str),
+                "coverage": coverage.values if hasattr(coverage, "values") else coverage,
+                "coverage_ok": (coverage >= min_coverage).values
+                if hasattr(coverage, "values")
+                else False,
+            }
+        )
+
+        return report.sort_values(by="column", ignore_index=True)
+
+    def build_correlation_report(self, df: pd.DataFrame) -> pd.DataFrame:
+        numeric_columns = sorted(
+            c for c in df.columns if pd.api.types.is_numeric_dtype(df[c])
+        )
+        if not numeric_columns:
+            return pd.DataFrame(columns=["column"])
+
+        numeric_df = df[numeric_columns].copy()
+        for column in numeric_columns:
+            if pd.api.types.is_bool_dtype(numeric_df[column]):
+                numeric_df[column] = numeric_df[column].astype(int)
+
+        correlation = numeric_df.corr(numeric_only=True)
+        correlation = correlation.loc[numeric_columns, numeric_columns]
+        correlation.insert(0, "column", correlation.index)
+        return correlation.reset_index(drop=True)

--- a/tests/bioetl/infrastructure/output/test_metadata_builder.py
+++ b/tests/bioetl/infrastructure/output/test_metadata_builder.py
@@ -35,7 +35,21 @@ def test_build_metadata(run_context):
         checksum="abc123hash"
     )
 
-    meta = build_run_metadata(run_context, write_result)
+    qc_artifacts = [
+        Path("/tmp/out/quality_report_table.csv"),
+        Path("/tmp/out/correlation_report_table.csv"),
+    ]
+    qc_checksums = {
+        "quality_report_table.csv": "qc1",
+        "correlation_report_table.csv": "qc2",
+    }
+
+    meta = build_run_metadata(
+        run_context,
+        write_result,
+        qc_artifacts=qc_artifacts,
+        qc_checksums=qc_checksums,
+    )
 
     assert meta["run_id"] == "test-run-123"
     assert meta["entity"] == "test_entity"
@@ -43,7 +57,14 @@ def test_build_metadata(run_context):
     assert meta["timestamp"] == "2023-01-01T12:00:00+00:00"
     assert meta["row_count"] == 100
     assert meta["checksum"] == "abc123hash"
-    assert meta["files"] == ["test.csv"]
+    assert meta["files"] == [
+        "correlation_report_table.csv",
+        "quality_report_table.csv",
+        "test.csv",
+    ]
+    assert meta["checksums"]["test.csv"] == "abc123hash"
+    assert meta["checksums"]["quality_report_table.csv"] == "qc1"
+    assert meta["qc_artifacts"]["quality_report_table.csv"]["checksum"] == "qc1"
     assert meta["extra_key"] == "extra_value"
 
 


### PR DESCRIPTION
## Summary
- add QualityReportABC with default implementation and wire into UnifiedOutputWriter
- generate quality and correlation QC tables atomically and include checksums in meta.yaml
- expose QC toggles in configuration docs and update integration/unit coverage

## Testing
- pytest tests/bioetl/infrastructure/output tests/integration/test_unified_writer_integration.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933ec4fa3a083249ca5850f149a543a)