### PR TITLE
Register molecule schemas in registry

### DIFF
--- a/src/bioetl/domain/schemas/__init__.py
+++ b/src/bioetl/domain/schemas/__init__.py
@@ -5,12 +5,14 @@ Pandera Schemas.
 from bioetl.domain.schemas.chembl.activity import ActivitySchema
 from bioetl.domain.schemas.chembl.assay import AssaySchema
 from bioetl.domain.schemas.chembl.document import DocumentSchema
+from bioetl.domain.schemas.chembl.molecule import MoleculeSchema
 from bioetl.domain.schemas.chembl.target import TargetSchema
 from bioetl.domain.schemas.chembl.testitem import TestitemSchema
 from bioetl.domain.schemas.chembl.output_views import (
     ACTIVITY_OUTPUT_COLUMNS,
     ASSAY_OUTPUT_COLUMNS,
     DOCUMENT_OUTPUT_COLUMNS,
+    MOLECULE_OUTPUT_COLUMNS,
     TARGET_OUTPUT_COLUMNS,
     TESTITEM_OUTPUT_COLUMNS,
 )
@@ -31,6 +33,11 @@ def register_schemas(registry: SchemaProviderABC) -> None:
     registry.register("document_input", DocumentSchema)
     registry.register(
         "document_output", DocumentSchema, column_order=DOCUMENT_OUTPUT_COLUMNS
+    )
+    registry.register("molecule", MoleculeSchema)
+    registry.register("molecule_input", MoleculeSchema)
+    registry.register(
+        "molecule_output", MoleculeSchema, column_order=MOLECULE_OUTPUT_COLUMNS
     )
     registry.register("target", TargetSchema)
     registry.register("target_input", TargetSchema)


### PR DESCRIPTION
## Summary
- add Molecule schema imports to the shared schema registry module
- register molecule schemas for default, input, and output views with column ordering

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933efe56f188324b32761798e8ada0e)