### PR TITLE
Align ChEMBL pipeline contracts with config IDs

### DIFF
--- a/src/bioetl/domain/schemas/__init__.py
+++ b/src/bioetl/domain/schemas/__init__.py
@@ -5,12 +5,14 @@ Pandera Schemas.
 from bioetl.domain.schemas.chembl.activity import ActivitySchema
 from bioetl.domain.schemas.chembl.assay import AssaySchema
 from bioetl.domain.schemas.chembl.document import DocumentSchema
+from bioetl.domain.schemas.chembl.molecule import MoleculeSchema
 from bioetl.domain.schemas.chembl.target import TargetSchema
 from bioetl.domain.schemas.chembl.testitem import TestitemSchema
 from bioetl.domain.schemas.chembl.output_views import (
     ACTIVITY_OUTPUT_COLUMNS,
     ASSAY_OUTPUT_COLUMNS,
     DOCUMENT_OUTPUT_COLUMNS,
+    MOLECULE_OUTPUT_COLUMNS,
     TARGET_OUTPUT_COLUMNS,
     TESTITEM_OUTPUT_COLUMNS,
 )
@@ -31,6 +33,11 @@ def register_schemas(registry: SchemaProviderABC) -> None:
     registry.register("document_input", DocumentSchema)
     registry.register(
         "document_output", DocumentSchema, column_order=DOCUMENT_OUTPUT_COLUMNS
+    )
+    registry.register("molecule", MoleculeSchema)
+    registry.register("molecule_input", MoleculeSchema)
+    registry.register(
+        "molecule_output", MoleculeSchema, column_order=MOLECULE_OUTPUT_COLUMNS
     )
     registry.register("target", TargetSchema)
     registry.register("target_input", TargetSchema)

--- a/src/bioetl/domain/schemas/pipeline_contracts.py
+++ b/src/bioetl/domain/schemas/pipeline_contracts.py
@@ -30,41 +30,41 @@ def _default_contract(code: str, entity: str | None) -> PipelineSchemaContract:
 
 
 PIPELINE_CONTRACTS: dict[str, PipelineSchemaContract] = {
-    "activity_chembl": PipelineSchemaContract(
-        pipeline_code="activity_chembl",
+    "chembl.activity": PipelineSchemaContract(
+        pipeline_code="chembl.activity",
         schema_out="activity",
         schema_in="activity_input",
         output_schema="activity_output",
     ),
-    "assay_chembl": PipelineSchemaContract(
-        pipeline_code="assay_chembl",
+    "chembl.assay": PipelineSchemaContract(
+        pipeline_code="chembl.assay",
         schema_out="assay",
         schema_in="assay_input",
         output_schema="assay_output",
     ),
-    "document_chembl": PipelineSchemaContract(
-        pipeline_code="document_chembl",
+    "chembl.document": PipelineSchemaContract(
+        pipeline_code="chembl.document",
         schema_out="document",
         schema_in="document_input",
         output_schema="document_output",
     ),
-    "target_chembl": PipelineSchemaContract(
-        pipeline_code="target_chembl",
+    "chembl.target": PipelineSchemaContract(
+        pipeline_code="chembl.target",
         schema_out="target",
         schema_in="target_input",
         output_schema="target_output",
     ),
-    "testitem_chembl": PipelineSchemaContract(
-        pipeline_code="testitem_chembl",
+    "chembl.testitem": PipelineSchemaContract(
+        pipeline_code="chembl.testitem",
         schema_out="testitem",
         schema_in="testitem_input",
         output_schema="testitem_output",
     ),
-    "molecule_chembl": PipelineSchemaContract(
-        pipeline_code="molecule_chembl",
-        schema_out="testitem",
-        schema_in="testitem_input",
-        output_schema="testitem_output",
+    "chembl.molecule": PipelineSchemaContract(
+        pipeline_code="chembl.molecule",
+        schema_out="molecule",
+        schema_in="molecule_input",
+        output_schema="molecule_output",
     ),
 }
 


### PR DESCRIPTION
## Summary
- align ChEMBL pipeline schema contracts with config IDs and correct input/output schema mappings
- register molecule schemas and output column order so validation and writes use the right schema metadata

## Testing
- python -m pytest tests/bioetl/domain/test_config_loader.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933f0a3734083248615937e7faac4ef)