### PR TITLE
Fix mermaid class diagram styling placement

### DIFF
--- a/docs/architecture/diagrams/class/client-architecture-three-layer.mmd
+++ b/docs/architecture/diagrams/class/client-architecture-three-layer.mmd
@@ -1,5 +1,11 @@
 classDiagram
 
+    %% Styling
+    classDef domainPrimary   fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px;
+    classDef domainSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px;
+    classDef interface       fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px;
+
+    %% Core Contracts
     class SourceClientABC {
         <<Interface>>
         +fetch_one(id)
@@ -48,7 +54,3 @@ classDiagram
     class SourceClientABC interface
     class RequestBuilderABC interface
     class ResponseParserABC interface
-
-classDef domainPrimary   fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px;
-classDef domainSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px;
-classDef interface       fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px;

--- a/docs/architecture/diagrams/class/pipeline-class-structure.mmd
+++ b/docs/architecture/diagrams/class/pipeline-class-structure.mmd
@@ -1,5 +1,10 @@
 classDiagram
 
+    %% Styling
+    classDef domainPrimary   fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px;
+    classDef domainSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px;
+    classDef interface       fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px;
+
     %% Core Abstractions
     class PipelineBase {
         <<Abstract>>
@@ -72,7 +77,7 @@ classDiagram
     PipelineBase o-- UnifiedOutputWriter : uses
     PipelineBase o-- PipelineHookABC : has many
     PipelineBase o-- ErrorPolicyABC : uses
-    
+
     ValidationService ..> PipelineBase : validates data
     HashService ..> PipelineBase : enriches data
     UnifiedOutputWriter ..> PipelineBase : persists data
@@ -84,8 +89,4 @@ classDiagram
     class UnifiedOutputWriter domainSecondary
     class PipelineHookABC interface
     class ErrorPolicyABC interface
-
-classDef domainPrimary   fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px;
-classDef domainSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px;
-classDef interface       fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px;
 


### PR DESCRIPTION
## Summary
- move Mermaid classDef styling blocks to the top of class diagrams for pipeline and client architecture
- keep styling scoped inside the diagrams to avoid parsing issues

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933f1a244648324b37207e68191bf7b)