### PR TITLE
Add shared column order helper and update writers

### DIFF
--- a/src/bioetl/infrastructure/output/column_order.py
+++ b/src/bioetl/infrastructure/output/column_order.py
@@ -1,0 +1,25 @@
+"""Column order helper utilities."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+__all__ = ["apply_column_order"]
+
+
+def apply_column_order(
+    df: pd.DataFrame, column_order: list[str] | None, *, fill_missing: bool = True
+) -> pd.DataFrame:
+    """Reorder dataframe columns and optionally fill missing ones with ``None``."""
+
+    if not column_order:
+        return df
+
+    df_prepared = df.copy()
+
+    if fill_missing:
+        for col in column_order:
+            if col not in df_prepared.columns:
+                df_prepared[col] = None
+
+    return df_prepared[column_order]

--- a/src/bioetl/infrastructure/output/impl/csv_writer.py
+++ b/src/bioetl/infrastructure/output/impl/csv_writer.py
@@ -6,6 +6,7 @@ import time
 from pathlib import Path
 import pandas as pd
 
+from bioetl.infrastructure.output.column_order import apply_column_order
 from bioetl.infrastructure.output.contracts import WriterABC, WriteResult
 
 
@@ -28,7 +29,7 @@ class CsvWriterImpl(WriterABC):
     ) -> WriteResult:
         start_time = time.monotonic()
 
-        df_to_write = self._apply_column_order(df, column_order)
+        df_to_write = apply_column_order(df, column_order)
 
         df_to_write.to_csv(path, index=False, encoding="utf-8")
 
@@ -48,16 +49,3 @@ class CsvWriterImpl(WriterABC):
 
     def supports_format(self, fmt: str) -> bool:
         return fmt.lower() == "csv"
-
-    def _apply_column_order(
-        self, df: pd.DataFrame, column_order: list[str] | None
-    ) -> pd.DataFrame:
-        if not column_order:
-            return df
-
-        df_to_write = df.copy()
-        for col in column_order:
-            if col not in df_to_write.columns:
-                df_to_write[col] = None
-
-        return df_to_write[column_order]

--- a/src/bioetl/infrastructure/output/impl/parquet_writer.py
+++ b/src/bioetl/infrastructure/output/impl/parquet_writer.py
@@ -2,6 +2,7 @@ import time
 from pathlib import Path
 import pandas as pd
 
+from bioetl.infrastructure.output.column_order import apply_column_order
 from bioetl.infrastructure.output.contracts import WriterABC, WriteResult
 
 
@@ -23,7 +24,7 @@ class ParquetWriterImpl(WriterABC):
     ) -> WriteResult:
         start_time = time.monotonic()
 
-        df_to_write = self._apply_column_order(df, column_order)
+        df_to_write = apply_column_order(df, column_order)
 
         df_to_write.to_parquet(path, index=False)
         
@@ -38,17 +39,4 @@ class ParquetWriterImpl(WriterABC):
 
     def supports_format(self, fmt: str) -> bool:
         return fmt.lower() == "parquet"
-
-    def _apply_column_order(
-        self, df: pd.DataFrame, column_order: list[str] | None
-    ) -> pd.DataFrame:
-        if not column_order:
-            return df
-
-        df_to_write = df.copy()
-        for col in column_order:
-            if col not in df_to_write.columns:
-                df_to_write[col] = None
-
-        return df_to_write[column_order]
 


### PR DESCRIPTION
## Summary
- add a reusable column order helper that fills missing columns
- switch CSV, Parquet, and Unified writers to use the shared helper
- expand writer tests to cover column ordering and missing column filling

## Testing
- pytest tests/bioetl/infrastructure/output -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933f51b67b083248c7c27f2c4f968a3)