### PR TITLE
Add batch checksum utility and reuse in writers

### DIFF
--- a/src/bioetl/infrastructure/files/checksum.py
+++ b/src/bioetl/infrastructure/files/checksum.py
@@ -14,3 +14,17 @@ def compute_file_sha256(path: Path) -> str:
             sha256.update(chunk)
     return sha256.hexdigest()
 
+
+def compute_files_sha256(paths: list[Path]) -> dict[str, str]:
+    """
+    Вычисляет SHA256 хеши нескольких файлов.
+
+    Отсутствующие файлы пропускаются.
+    """
+    checksums: dict[str, str] = {}
+    for path in paths:
+        if not path.exists():
+            continue
+        checksums[path.name] = compute_file_sha256(path)
+    return checksums
+

--- a/src/bioetl/infrastructure/output/impl/csv_writer.py
+++ b/src/bioetl/infrastructure/output/impl/csv_writer.py
@@ -1,11 +1,11 @@
 """
 CSV Writer implementation.
 """
-import hashlib
 import time
 from pathlib import Path
 import pandas as pd
 
+from bioetl.infrastructure.files.checksum import compute_file_sha256
 from bioetl.infrastructure.output.contracts import WriterABC, WriteResult
 
 
@@ -34,10 +34,7 @@ class CsvWriterImpl(WriterABC):
 
         duration = time.monotonic() - start_time
 
-        # Calculate checksum
-        sha256 = hashlib.sha256()
-        sha256.update(path.read_bytes())
-        checksum = sha256.hexdigest()
+        checksum = compute_file_sha256(path)
 
         return WriteResult(
             path=path,

--- a/src/bioetl/infrastructure/output/impl/metadata_writer.py
+++ b/src/bioetl/infrastructure/output/impl/metadata_writer.py
@@ -1,9 +1,9 @@
-import hashlib
 from pathlib import Path
 import pandas as pd
 import yaml
 
 from bioetl.infrastructure.output.contracts import MetadataWriterABC
+from bioetl.infrastructure.files.checksum import compute_files_sha256
 
 
 class MetadataWriterImpl(MetadataWriterABC):
@@ -26,14 +26,5 @@ class MetadataWriterImpl(MetadataWriterABC):
         report.to_csv(path, index=False)
 
     def generate_checksums(self, paths: list[Path]) -> dict[str, str]:
-        checksums = {}
-        for path in paths:
-            if not path.exists():
-                continue
-            sha256 = hashlib.sha256()
-            with open(path, "rb") as f:
-                for chunk in iter(lambda: f.read(8192), b""):
-                    sha256.update(chunk)
-            checksums[path.name] = sha256.hexdigest()
-        return checksums
+        return compute_files_sha256(paths)
 

--- a/tests/bioetl/infrastructure/files/test_checksum.py
+++ b/tests/bioetl/infrastructure/files/test_checksum.py
@@ -1,6 +1,6 @@
 import hashlib
 
-from bioetl.infrastructure.files.checksum import compute_file_sha256
+from bioetl.infrastructure.files.checksum import compute_file_sha256, compute_files_sha256
 
 
 def test_compute_sha256(tmp_path):
@@ -24,4 +24,26 @@ def test_compute_sha256_large_file(tmp_path):
     actual_hash = compute_file_sha256(test_file)
 
     assert actual_hash == expected_hash
+
+
+def test_compute_files_sha256(tmp_path):
+    file_one = tmp_path / "one.txt"
+    file_two = tmp_path / "two.txt"
+    missing_file = tmp_path / "missing.txt"
+
+    file_one.write_text("first", encoding="utf-8")
+    file_two.write_text("second", encoding="utf-8")
+
+    checksums = compute_files_sha256([file_one, file_two, missing_file])
+
+    assert checksums == {
+        file_one.name: hashlib.sha256(b"first").hexdigest(),
+        file_two.name: hashlib.sha256(b"second").hexdigest(),
+    }
+
+
+def test_compute_files_sha256_empty_list(tmp_path):
+    checksums = compute_files_sha256([])
+
+    assert checksums == {}
 


### PR DESCRIPTION
## Summary
- add batch SHA256 helper for multiple files and expose from checksum module
- reuse shared checksum utilities in CSV and metadata writers
- expand checksum tests to cover single and batch processing

## Testing
- pytest tests/bioetl/infrastructure/files/test_checksum.py tests/bioetl/infrastructure/output/test_writers.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933f51d6ff88324ab4c096df97ac093)