### PR TITLE
Refactor output writers with shared helper

### DIFF
--- a/src/bioetl/infrastructure/output/impl/base_writer.py
+++ b/src/bioetl/infrastructure/output/impl/base_writer.py
@@ -1,0 +1,60 @@
+"""
+Base helpers for writer implementations.
+"""
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+import pandas as pd
+
+from bioetl.infrastructure.output.column_order import apply_column_order
+from bioetl.infrastructure.output.contracts import WriteResult, WriterABC
+
+
+class BaseWriterImpl(WriterABC):
+    """Template for concrete writers with shared bookkeeping."""
+
+    def __init__(
+        self,
+        *,
+        atomic: bool,
+        checksum_fn: Callable[[Path], str] | None = None,
+    ) -> None:
+        self._atomic = atomic
+        self._checksum_fn = checksum_fn
+
+    @property
+    def atomic(self) -> bool:
+        return self._atomic
+
+    def write(
+        self,
+        df: pd.DataFrame,
+        path: Path,
+        *,
+        column_order: list[str] | None = None,
+    ) -> WriteResult:
+        start_time = time.monotonic()
+
+        df_to_write = apply_column_order(df, column_order)
+        self._write_frame(df_to_write, path)
+
+        duration = time.monotonic() - start_time
+        checksum = self._compute_checksum(path)
+
+        return WriteResult(
+            path=path,
+            row_count=len(df_to_write),
+            duration_sec=duration,
+            checksum=checksum,
+        )
+
+    def _compute_checksum(self, path: Path) -> str | None:
+        if self._checksum_fn is None:
+            return None
+        return self._checksum_fn(path)
+
+    def _write_frame(self, df: pd.DataFrame, path: Path) -> None:
+        raise NotImplementedError

--- a/src/bioetl/infrastructure/output/impl/csv_writer.py
+++ b/src/bioetl/infrastructure/output/impl/csv_writer.py
@@ -1,49 +1,27 @@
 """
 CSV Writer implementation.
 """
-import time
+from __future__ import annotations
+
 from pathlib import Path
 
 import pandas as pd
 
 from bioetl.infrastructure.files.checksum import compute_file_sha256
-from bioetl.infrastructure.output.column_order import apply_column_order
-from bioetl.infrastructure.output.contracts import WriterABC, WriteResult
+from bioetl.infrastructure.output.impl.base_writer import BaseWriterImpl
 
 
-class CsvWriterImpl(WriterABC):
+class CsvWriterImpl(BaseWriterImpl):
     """
     Запись CSV.
     Делегирует атомарность и хеширование внешнему фасаду.
     """
 
-    @property
-    def atomic(self) -> bool:
-        return False
+    def __init__(self) -> None:
+        super().__init__(atomic=False, checksum_fn=compute_file_sha256)
 
-    def write(
-        self,
-        df: pd.DataFrame,
-        path: Path,
-        *,
-        column_order: list[str] | None = None,
-    ) -> WriteResult:
-        start_time = time.monotonic()
-
-        df_to_write = apply_column_order(df, column_order)
-
-        df_to_write.to_csv(path, index=False, encoding="utf-8")
-
-        duration = time.monotonic() - start_time
-
-        checksum = compute_file_sha256(path)
-
-        return WriteResult(
-            path=path,
-            row_count=len(df_to_write),
-            duration_sec=duration,
-            checksum=checksum
-        )
+    def _write_frame(self, df: pd.DataFrame, path: Path) -> None:
+        df.to_csv(path, index=False, encoding="utf-8")
 
     def supports_format(self, fmt: str) -> bool:
         return fmt.lower() == "csv"

--- a/src/bioetl/infrastructure/output/impl/parquet_writer.py
+++ b/src/bioetl/infrastructure/output/impl/parquet_writer.py
@@ -1,42 +1,23 @@
-import time
+from __future__ import annotations
+
+from collections.abc import Callable
 from pathlib import Path
+
 import pandas as pd
 
-from bioetl.infrastructure.output.column_order import apply_column_order
-from bioetl.infrastructure.output.contracts import WriterABC, WriteResult
+from bioetl.infrastructure.output.impl.base_writer import BaseWriterImpl
 
 
-class ParquetWriterImpl(WriterABC):
+class ParquetWriterImpl(BaseWriterImpl):
     """
     Запись Parquet.
     """
 
-    @property
-    def atomic(self) -> bool:
-        return True
+    def __init__(self, *, checksum_fn: Callable[[Path], str] | None = None) -> None:
+        super().__init__(atomic=True, checksum_fn=checksum_fn)
 
-    def write(
-        self,
-        df: pd.DataFrame,
-        path: Path,
-        *,
-        column_order: list[str] | None = None,
-    ) -> WriteResult:
-        start_time = time.monotonic()
-
-        df_to_write = apply_column_order(df, column_order)
-
-        df_to_write.to_parquet(path, index=False)
-        
-        duration = time.monotonic() - start_time
-        
-        return WriteResult(
-            path=path,
-            row_count=len(df_to_write),
-            checksum="",
-            duration_sec=duration,
-        )
+    def _write_frame(self, df: pd.DataFrame, path: Path) -> None:
+        df.to_parquet(path, index=False)
 
     def supports_format(self, fmt: str) -> bool:
         return fmt.lower() == "parquet"
-


### PR DESCRIPTION
## Summary
- add BaseWriterImpl to encapsulate shared ordering, timing, and optional checksum logic
- refactor CSV and Parquet writers to delegate to the shared helper while keeping format-specific behavior
- extend writer tests to cover atomic flags, column ordering, row counting, and checksum delegation

## Testing
- pytest tests/bioetl/infrastructure/output/test_writers.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69340367d83c8324aa4b27f7fcf00747)