### PR TITLE
Refactor metadata QC report generation

### DIFF
--- a/src/bioetl/infrastructure/output/contracts.py
+++ b/src/bioetl/infrastructure/output/contracts.py
@@ -48,7 +48,9 @@ class MetadataWriterABC(ABC):
         """Записывает метаданные (yaml)."""
 
     @abstractmethod
-    def write_qc_report(self, df: pd.DataFrame, path: Path) -> None:
+    def write_qc_report(
+        self, df: pd.DataFrame, path: Path, *, min_coverage: float | None = None
+    ) -> None:
         """Записывает отчет качества."""
 
     @abstractmethod

--- a/src/bioetl/infrastructure/output/impl/metadata_writer.py
+++ b/src/bioetl/infrastructure/output/impl/metadata_writer.py
@@ -1,9 +1,24 @@
 from pathlib import Path
+
 import pandas as pd
 import yaml
 
-from bioetl.infrastructure.output.contracts import MetadataWriterABC
+from bioetl.infrastructure.output.contracts import (
+    MetadataWriterABC,
+    QualityReportABC,
+)
+from bioetl.infrastructure.output.impl.quality_report import QualityReportImpl
 from bioetl.infrastructure.files.checksum import compute_files_sha256
+
+
+def build_quality_report_table(
+    df: pd.DataFrame,
+    *,
+    min_coverage: float,
+    quality_reporter: QualityReportABC | None = None,
+) -> pd.DataFrame:
+    reporter = quality_reporter or QualityReportImpl()
+    return reporter.build_quality_report(df, min_coverage=min_coverage)
 
 
 class MetadataWriterImpl(MetadataWriterABC):
@@ -11,18 +26,28 @@ class MetadataWriterImpl(MetadataWriterABC):
     Запись метаданных и QC отчетов.
     """
 
+    def __init__(
+        self,
+        quality_reporter: QualityReportABC | None = None,
+        *,
+        min_coverage: float = 0.85,
+    ) -> None:
+        self._quality_reporter = quality_reporter or QualityReportImpl()
+        self._min_coverage = min_coverage
+
     def write_meta(self, meta: dict, path: Path) -> None:
         with open(path, "w", encoding="utf-8") as f:
             yaml.dump(meta, f, sort_keys=True)
 
-    def write_qc_report(self, df: pd.DataFrame, path: Path) -> None:
-        # Simple QC report: count nulls, unique values
-        report = pd.DataFrame({
-            "column": df.columns,
-            "null_count": df.isnull().sum().values,
-            "unique_count": df.nunique().values,
-            "dtype": df.dtypes.values.astype(str)
-        })
+    def write_qc_report(
+        self, df: pd.DataFrame, path: Path, *, min_coverage: float | None = None
+    ) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        report = build_quality_report_table(
+            df,
+            min_coverage=min_coverage if min_coverage is not None else self._min_coverage,
+            quality_reporter=self._quality_reporter,
+        )
         report.to_csv(path, index=False)
 
     def generate_checksums(self, paths: list[Path]) -> dict[str, str]:


### PR DESCRIPTION
## Summary
- route metadata QC report creation through the shared quality reporter helper
- expose configurable coverage handling and consistent column set for QC tables
- add tests covering QC CSV format, coverage flags, and helper behavior

## Testing
- pytest tests/bioetl/infrastructure/output/test_writers.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69340369697c8324803a128928a58510)