### PR TITLE
Refactor normalization services with shared base

### DIFF
--- a/src/bioetl/domain/normalization_service.py
+++ b/src/bioetl/domain/normalization_service.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 from bioetl.domain.record_source import RawRecord
 from bioetl.domain.transform.contracts import NormalizationConfigProvider
+from bioetl.domain.transform.impl.base_normalizer import BaseNormalizationService
 from bioetl.domain.transform.impl import normalize as normalize_impl
 from bioetl.domain.transform.normalizers import (
     normalize_array,
@@ -39,11 +40,11 @@ class NormalizationService(Protocol):
         """Normalize a Series using field configuration."""
 
 
-class ChemblNormalizationService(NormalizationService):
+class ChemblNormalizationService(BaseNormalizationService, NormalizationService):
     """Normalization service for ChEMBL records."""
 
     def __init__(self, config: NormalizationConfigProvider):
-        self._config = config
+        super().__init__(config)
 
     def normalize(self, raw: RawRecord) -> NormalizedRecord:
         normalized: dict[str, Any] = {}
@@ -67,7 +68,11 @@ class ChemblNormalizationService(NormalizationService):
 
             value = raw.get(name)
             normalized[name] = self._normalize_value(
-                value, dtype, base_normalizer, name
+                value,
+                dtype,
+                base_normalizer,
+                name,
+                allow_container_normalizer=True,
             )
 
         for key, value in raw.items():
@@ -110,76 +115,29 @@ class ChemblNormalizationService(NormalizationService):
             base_normalizer = _default_normalizer
 
         def _normalize_value_from_series(val: Any) -> Any:
-            # If custom normalizer exists and dtype is array, apply it to the whole list
             if custom_normalizer and dtype == "array" and isinstance(val, (list, tuple)):
                 normalized = custom_normalizer(val)
                 if normalized is None or not normalized:
                     return None
-                # Don't re-normalize values inside dicts - they're already normalized
-                # by the custom normalizer (e.g., normalize_target_components)
-                # Serialize the normalized list without additional normalization
                 return serialize_list(normalized, value_normalizer=None)
-            return self._normalize_value(val, dtype, base_normalizer, name)
+            return self._normalize_value(
+                val,
+                dtype,
+                base_normalizer,
+                name,
+                allow_container_normalizer=True,
+            )
 
         return series.apply(_normalize_value_from_series)
 
-    def _resolve_mode(self, field_name: str) -> str:
-        if field_name in self._config.normalization.case_sensitive_fields:
-            return "sensitive"
-        if self._is_id_field(field_name):
-            return "id"
-        return "default"
-
-    def _is_id_field(self, field_name: str) -> bool:
-        if field_name in self._config.normalization.id_fields:
-            return True
-        if field_name.endswith("_id") or field_name.endswith("_chembl_id"):
-            return True
-        if field_name.startswith("id_"):
-            return True
-        return False
-
-    def _normalize_value(
+    def _process_list(
         self,
         value: Any,
-        dtype: str | None,
         normalizer: Any,
         field_name: str,
+        *,
+        serialize_with_value_normalizer: bool = True,
     ) -> Any:
-        if value is None:
-            return None
-
-        if isinstance(value, (list, tuple, dict)):
-            pd_na = False
-        else:
-            try:
-                pd_na = pd.isna(value)
-            except ValueError:
-                pd_na = False
-
-        if pd_na:
-            return None
-
-        if dtype in ("array", "object"):
-            if isinstance(value, (list, tuple)):
-                return self._process_list(value, normalizer, field_name)
-            if isinstance(value, dict):
-                return self._process_dict(value, normalizer, field_name)
-
-        if dtype in ("string", "integer", "number", "float", "boolean"):
-            return self._apply_normalizer(value, normalizer, field_name)
-
-        return self._apply_normalizer(value, normalizer, field_name)
-
-    def _apply_normalizer(self, value: Any, normalizer: Any, field_name: str) -> Any:
-        try:
-            return normalizer(value)
-        except ValueError as exc:
-            raise ValueError(
-                f"Ошибка нормализации поля '{field_name}': {exc}"
-            ) from exc
-
-    def _process_list(self, value: Any, normalizer: Any, field_name: str) -> Any:
         try:
             normalized_list = normalize_array(
                 list(value),
@@ -194,12 +152,14 @@ class ChemblNormalizationService(NormalizationService):
 
         if not normalized_list:
             return None
-        # normalized_list contains already normalized dicts/items
-        # serialize_list will serialize them, and for dicts it will use value_normalizer
-        # to normalize scalar values inside dicts
-        return serialize_list(normalized_list, value_normalizer=normalizer)
+        return serialize_list(
+            normalized_list,
+            value_normalizer=normalizer if serialize_with_value_normalizer else None,
+        )
 
-    def _process_dict(self, value: Any, normalizer: Any, field_name: str) -> Any:
+    def _process_dict(
+        self, value: Any, normalizer: Any, field_name: str
+    ) -> Any:
         try:
             dict_value = cast(dict[str, Any], value)
             normalized_dict = normalize_record(
@@ -217,10 +177,7 @@ class ChemblNormalizationService(NormalizationService):
     def _normalize_container_item(self, item: Any, normalizer: Any) -> Any:
         if isinstance(item, dict):
             normalized_dict = normalize_record(
-                cast(dict[str, Any], item),
-                value_normalizer=normalizer,
+                cast(dict[str, Any], item), value_normalizer=normalizer
             )
-            # normalize_record returns None for empty dicts, but we need the dict for serialization
-            # Return empty dict instead of None to preserve structure
             return normalized_dict if normalized_dict is not None else {}
         return normalizer(item)

--- a/src/bioetl/domain/transform/impl/base_normalizer.py
+++ b/src/bioetl/domain/transform/impl/base_normalizer.py
@@ -1,0 +1,193 @@
+"""Shared helpers for normalization services."""
+from __future__ import annotations
+
+from typing import Any, Callable, cast
+
+import pandas as pd
+
+from bioetl.domain.transform.contracts import NormalizationConfigProvider
+from bioetl.domain.transform.impl.serializer import serialize_dict, serialize_list
+from bioetl.domain.transform.normalizers import normalize_array, normalize_record
+
+
+class BaseNormalizationService:
+    """Provide reusable normalization helpers for services."""
+
+    def __init__(self, config: NormalizationConfigProvider, empty_value: Any = None):
+        self._config = config
+        self._empty_value = empty_value
+
+    def _resolve_mode(self, field_name: str) -> str:
+        if field_name in self._config.normalization.case_sensitive_fields:
+            return "sensitive"
+        if self._is_id_field(field_name):
+            return "id"
+        return "default"
+
+    def _normalize_value(
+        self,
+        value: Any,
+        dtype: str | None,
+        normalizer: Callable[[Any], Any],
+        field_name: str,
+        *,
+        allow_container_normalizer: bool = False,
+        serialize_with_value_normalizer: bool = True,
+    ) -> Any:
+        if value is None:
+            return self._empty_value
+
+        if not isinstance(value, (list, tuple, dict)):
+            try:
+                if pd.isna(value):
+                    return self._empty_value
+            except ValueError:
+                pass
+
+        if dtype in ("array", "object"):
+            if isinstance(value, (list, tuple, dict)) and allow_container_normalizer:
+                handled, direct_result = self._apply_container_normalizer(
+                    value,
+                    normalizer,
+                    field_name,
+                    serialize_with_value_normalizer=serialize_with_value_normalizer,
+                )
+                if handled:
+                    return direct_result
+
+            if isinstance(value, (list, tuple)):
+                return self._process_list(
+                    value,
+                    normalizer,
+                    field_name,
+                    serialize_with_value_normalizer=serialize_with_value_normalizer,
+                )
+
+            if isinstance(value, dict):
+                return self._process_dict(value, normalizer, field_name)
+
+            normalized = self._apply_normalizer(value, normalizer, field_name)
+            if isinstance(normalized, (list, tuple, dict)):
+                return self._serialize_container_result(
+                    normalized,
+                    normalizer,
+                    serialize_with_value_normalizer=serialize_with_value_normalizer,
+                )
+            return normalized
+
+        return self._apply_normalizer(value, normalizer, field_name)
+
+    def _process_list(
+        self,
+        value: Any,
+        normalizer: Callable[[Any], Any],
+        field_name: str,
+        *,
+        serialize_with_value_normalizer: bool = True,
+    ) -> Any:
+        try:
+            normalized_list = normalize_array(
+                list(value),
+                item_normalizer=lambda item: self._normalize_container_item(
+                    item, normalizer
+                ),
+            )
+        except ValueError as exc:
+            raise ValueError(
+                f"Ошибка нормализации списка в поле '{field_name}': {exc}"
+            ) from exc
+
+        if not normalized_list:
+            return self._empty_value
+
+        return serialize_list(
+            normalized_list,
+            value_normalizer=normalizer if serialize_with_value_normalizer else None,
+        )
+
+    def _process_dict(
+        self, value: Any, normalizer: Callable[[Any], Any], field_name: str
+    ) -> Any:
+        try:
+            dict_value = cast(dict[str, Any], value)
+            normalized_dict = normalize_record(dict_value, value_normalizer=normalizer)
+        except ValueError as exc:
+            raise ValueError(
+                f"Ошибка нормализации записи в поле '{field_name}': {exc}"
+            ) from exc
+
+        if normalized_dict is None:
+            return self._empty_value
+
+        return serialize_dict(dict(normalized_dict))
+
+    def _apply_normalizer(
+        self, value: Any, normalizer: Callable[[Any], Any], field_name: str
+    ) -> Any:
+        try:
+            return normalizer(value)
+        except ValueError as exc:
+            raise ValueError(
+                f"Ошибка нормализации поля '{field_name}': {exc}"
+            ) from exc
+
+    def _apply_container_normalizer(
+        self,
+        value: Any,
+        normalizer: Callable[[Any], Any],
+        field_name: str,
+        *,
+        serialize_with_value_normalizer: bool = True,
+    ) -> tuple[bool, Any]:
+        try:
+            result = normalizer(value)
+        except (ValueError, TypeError):
+            return False, None
+
+        serialized = self._serialize_container_result(
+            result,
+            normalizer,
+            serialize_with_value_normalizer=serialize_with_value_normalizer,
+        )
+        return True, serialized
+
+    def _serialize_container_result(
+        self,
+        result: Any,
+        normalizer: Callable[[Any], Any],
+        *,
+        serialize_with_value_normalizer: bool = True,
+    ) -> Any:
+        if result is None or result is pd.NA:
+            return self._empty_value
+
+        if isinstance(result, (list, tuple)):
+            if not result:
+                return self._empty_value
+            return serialize_list(
+                list(result),
+                value_normalizer=normalizer if serialize_with_value_normalizer else None,
+            )
+
+        if isinstance(result, dict):
+            serialized_dict = serialize_dict(cast(dict[str, Any], result))
+            return self._empty_value if serialized_dict is pd.NA else serialized_dict
+
+        return str(result)
+
+    def _normalize_container_item(self, item: Any, normalizer: Callable[[Any], Any]) -> Any:
+        if isinstance(item, dict):
+            normalized_dict = normalize_record(
+                cast(dict[str, Any], item), value_normalizer=normalizer
+            )
+            return normalized_dict if normalized_dict is not None else {}
+        return normalizer(item)
+
+    def _is_id_field(self, field_name: str) -> bool:
+        if field_name in self._config.normalization.id_fields:
+            return True
+        if field_name.endswith("_id") or field_name.endswith("_chembl_id"):
+            return True
+        if field_name.startswith("id_"):
+            return True
+        return False

--- a/tests/bioetl/domain/test_normalization_service.py
+++ b/tests/bioetl/domain/test_normalization_service.py
@@ -18,6 +18,7 @@ class _ConfigStub:
         default_factory=lambda: [
             {"name": "name", "data_type": "string"},
             {"name": "activity_id", "data_type": "string"},
+            {"name": "assay_id", "data_type": "string"},
             {"name": "tags", "data_type": "array"},
             {"name": "metadata", "data_type": "object"},
             {"name": "label", "data_type": "string"},
@@ -27,12 +28,18 @@ class _ConfigStub:
 
 def test_chembl_normalization_service_normalizes_scalars_and_ids() -> None:
     service = ChemblNormalizationService(_ConfigStub())
-    raw = {"name": "  Alpha  ", "activity_id": "act1", "extra": "keep"}
+    raw = {
+        "name": "  Alpha  ",
+        "activity_id": "act1",
+        "assay_id": "ass1",
+        "extra": "keep",
+    }
 
     normalized = service.normalize(raw)
 
     assert normalized["name"] == "alpha"
     assert normalized["activity_id"] == "ACT1"
+    assert normalized["assay_id"] == "ASS1"
     assert normalized["extra"] == "keep"
 
 
@@ -49,6 +56,17 @@ def test_chembl_normalization_service_serializes_nested_values() -> None:
     assert normalized["tags"] == "a|b"
     assert normalized["metadata"] == "key:value"
     assert normalized["label"] == "MiXeD"
+
+
+def test_chembl_normalization_service_handles_empty_collections() -> None:
+    service = ChemblNormalizationService(_ConfigStub())
+    raw = {"tags": [], "metadata": {}, "label": "  NoChange "}
+
+    normalized = service.normalize(raw)
+
+    assert normalized["tags"] is None
+    assert normalized["metadata"] is None
+    assert normalized["label"] == "NoChange"
 
 
 def test_chembl_normalization_service_normalizes_dataframe_batch() -> None:


### PR DESCRIPTION
## Summary
- add a shared BaseNormalizationService to centralize normalization helpers
- refactor ChemblNormalizationService and transform NormalizationService to reuse the base logic and avoid duplication
- extend normalization tests for scalar/id handling, case-sensitive fields, and empty collections

## Testing
- pytest tests/bioetl/domain/test_normalization_service.py tests/bioetl/domain/transform/test_normalize.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69340363c3d8832483dc9999b151cf02)