### PR TITLE
Refactor Chembl extraction service layering

### DIFF
--- a/src/bioetl.egg-info/SOURCES.txt
+++ b/src/bioetl.egg-info/SOURCES.txt
@@ -32,7 +32,7 @@ src/bioetl/application/pipelines/chembl/factories.py
 src/bioetl/application/pipelines/chembl/pipeline.py
 src/bioetl/application/pipelines/chembl/transformer.py
 src/bioetl/application/services/__init__.py
-src/bioetl/application/services/chembl_extraction.py
+src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
 src/bioetl/domain/__init__.py
 src/bioetl/domain/contracts.py
 src/bioetl/domain/enums.py

--- a/src/bioetl/application/config/pipeline_config_schema.py
+++ b/src/bioetl/application/config/pipeline_config_schema.py
@@ -17,6 +17,7 @@ from bioetl.infrastructure.config.provider_config_schema import (
     BaseProviderConfig,
     ProviderConfigUnion,
 )
+from bioetl.domain.transform.contracts import NormalizationConfigProvider
 
 
 class PaginationConfig(BaseModel):
@@ -193,6 +194,11 @@ class PipelineConfig(BaseModel):
     @property
     def entity_name(self) -> str:
         return self.entity
+
+    def as_normalization_config_provider(self) -> NormalizationConfigProvider:
+        """Return self to satisfy NormalizationConfigProvider protocol."""
+
+        return self
 
     def get_source_config(self, provider: str) -> BaseProviderConfig:
         if provider != self.provider:

--- a/src/bioetl/application/services/__init__.py
+++ b/src/bioetl/application/services/__init__.py
@@ -1,7 +1,3 @@
 """Application services - orchestration layer."""
 
-from bioetl.application.services.chembl_extraction import (
-    ChemblExtractionServiceImpl,
-)
-
-__all__ = ["ChemblExtractionServiceImpl"]
+__all__: list[str] = []

--- a/src/bioetl/infrastructure/chembl_client.py
+++ b/src/bioetl/infrastructure/chembl_client.py
@@ -1,7 +1,7 @@
 """Factories for constructing ChEMBL client stack."""
 from __future__ import annotations
 
-from bioetl.application.services.chembl_extraction import ChemblExtractionServiceImpl
+from bioetl.domain.contracts import ExtractionServiceABC
 from bioetl.domain.clients.chembl.contracts import ChemblDataClientABC
 from bioetl.infrastructure.clients.chembl.factories import (
     default_chembl_client,
@@ -20,7 +20,7 @@ def create_client(config: ChemblSourceConfig) -> ChemblDataClientABC:
 
 def create_extraction_service(
     config: ChemblSourceConfig, *, client: ChemblDataClientABC | None = None
-) -> ChemblExtractionServiceImpl:
+) -> ExtractionServiceABC:
     """Create extraction service using provided or default ChEMBL client."""
 
     resolved_client = client or create_client(config)

--- a/src/bioetl/infrastructure/clients/chembl/factories.py
+++ b/src/bioetl/infrastructure/clients/chembl/factories.py
@@ -3,14 +3,17 @@ Factories for ChEMBL clients.
 """
 from typing import Any
 
-from bioetl.application.services.chembl_extraction import ChemblExtractionServiceImpl
 from bioetl.domain.clients.chembl.contracts import ChemblDataClientABC
+from bioetl.domain.contracts import ExtractionServiceABC
 from bioetl.infrastructure.clients.base.impl.rate_limiter import (
     TokenBucketRateLimiterImpl,
 )
 from bioetl.infrastructure.clients.base.impl.unified_client import UnifiedAPIClient
 from bioetl.infrastructure.clients.chembl.impl.http_client import (
     ChemblDataClientHTTPImpl,
+)
+from bioetl.infrastructure.clients.chembl.impl.chembl_extraction_service_impl import (
+    ChemblExtractionServiceImpl,
 )
 from bioetl.infrastructure.clients.chembl.request_builder import (
     ChemblRequestBuilderImpl,
@@ -81,7 +84,7 @@ def default_chembl_extraction_service(
     client_config: ClientConfig | None = None,
     *,
     client: ChemblDataClientABC | None = None,
-) -> ChemblExtractionServiceImpl:
+) -> ExtractionServiceABC:
     """
     Создает сервис экстракции ChEMBL.
 

--- a/src/bioetl/infrastructure/clients/chembl/impl/__init__.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/__init__.py
@@ -2,3 +2,9 @@
 ChEMBL implementation details.
 """
 
+from bioetl.infrastructure.clients.chembl.impl.chembl_extraction_service_impl import (
+    ChemblExtractionServiceImpl,
+)
+
+__all__ = ["ChemblExtractionServiceImpl"]
+

--- a/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
@@ -1,8 +1,8 @@
 """
-ChEMBL Extraction Service.
+ChEMBL Extraction Service implementation for the infrastructure layer.
 
-Orchestrates data extraction from ChEMBL API.
-Application-layer service that coordinates infrastructure components.
+Orchestrates data extraction from ChEMBL API using infrastructure clients and
+domain contracts.
 """
 from collections.abc import Iterable
 from typing import Any, Type
@@ -172,3 +172,6 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC):
         self, model_cls: Type[ChemblRecordModel], batch_records: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:
         return [model_cls(**batch_record).model_dump() for batch_record in batch_records]
+
+
+__all__ = ["ChemblExtractionServiceImpl"]

--- a/src/bioetl/infrastructure/clients/chembl/provider.py
+++ b/src/bioetl/infrastructure/clients/chembl/provider.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from bioetl.application.services.chembl_extraction import ChemblExtractionServiceImpl
 from bioetl.domain.normalization_service import ChemblNormalizationService
+from bioetl.domain.contracts import ExtractionServiceABC
 from bioetl.domain.provider_registry import (
     ProviderAlreadyRegisteredError,
     get_provider,
@@ -11,18 +11,18 @@ from bioetl.domain.provider_registry import (
 )
 from bioetl.domain.providers import ProviderComponents, ProviderDefinition, ProviderId
 from bioetl.domain.clients.chembl.contracts import ChemblDataClientABC
+from bioetl.domain.transform.contracts import NormalizationConfigProvider
 from bioetl.infrastructure.chembl_client import (
     create_client,
     create_extraction_service,
 )
-from bioetl.application.config.pipeline_config_schema import PipelineConfig
 from bioetl.infrastructure.config.models import ChemblSourceConfig
 
 
 class ChemblProviderComponents(
     ProviderComponents[
         ChemblDataClientABC,
-        ChemblExtractionServiceImpl,
+        ExtractionServiceABC,
         ChemblNormalizationService,
         object,
     ]
@@ -37,7 +37,7 @@ class ChemblProviderComponents(
         config: ChemblSourceConfig,
         *,
         client: ChemblDataClientABC | None = None,
-    ) -> ChemblExtractionServiceImpl:
+    ) -> ExtractionServiceABC:
         return create_extraction_service(config, client=client)
 
     def create_normalization_service(
@@ -45,11 +45,13 @@ class ChemblProviderComponents(
         config: ChemblSourceConfig,
         *,
         client: ChemblDataClientABC | None = None,
-        pipeline_config: PipelineConfig | None = None,
+        pipeline_config: NormalizationConfigProvider | None = None,
     ) -> ChemblNormalizationService:
         _ = client  # signature compatibility; normalization independent from client
         if pipeline_config is None:
-            raise ValueError("PipelineConfig is required to build normalization service")
+            raise ValueError(
+                "NormalizationConfigProvider is required to build normalization service"
+            )
         return ChemblNormalizationService(pipeline_config)
 
 

--- a/src/tools/debug_assay_fetch.py
+++ b/src/tools/debug_assay_fetch.py
@@ -9,7 +9,7 @@ src_path = os.path.abspath("src")
 sys.path.insert(0, src_path)
 
 from bioetl.interfaces.cli.app import app
-from bioetl.application.services.chembl_extraction import ChemblExtractionServiceImpl
+from bioetl.infrastructure.clients.chembl.impl import ChemblExtractionServiceImpl
 
 # Create output dir
 Path("data/output/assay").mkdir(parents=True, exist_ok=True)

--- a/src/tools/debug_assay_fetch_v2.py
+++ b/src/tools/debug_assay_fetch_v2.py
@@ -12,7 +12,7 @@ src_path = os.path.abspath("src")
 sys.path.insert(0, src_path)
 
 from bioetl.interfaces.cli.app import app
-from bioetl.application.services.chembl_extraction import ChemblExtractionServiceImpl
+from bioetl.infrastructure.clients.chembl.impl import ChemblExtractionServiceImpl
 
 # Create output dir
 Path("data/output/assay").mkdir(parents=True, exist_ok=True)

--- a/src/tools/run_cmd.py
+++ b/src/tools/run_cmd.py
@@ -14,7 +14,7 @@ try:
     import bioetl.application.container
     # print(f"Container module: {bioetl.application.container.__file__}")
     from bioetl.interfaces.cli.app import app
-    from bioetl.infrastructure.services.chembl_extraction import ChemblExtractionServiceImpl
+    from bioetl.infrastructure.clients.chembl.impl import ChemblExtractionServiceImpl
 except ImportError as e:
     print(f"ImportError: {e}")
     sys.exit(1)


### PR DESCRIPTION
## Summary
- move `ChemblExtractionServiceImpl` into the infrastructure chembl client implementations and wire factories to the domain extraction contract
- update chembl provider components to consume the normalization config protocol and avoid application-layer imports
- adjust PipelineConfig and tooling imports to satisfy the normalization protocol and new service location

## Testing
- python -m compileall src/bioetl/infrastructure/clients/chembl src/bioetl/application/config/pipeline_config_schema.py src/tools


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693405ed00ac83248b73126f57e727c7)