### PR TITLE
Add YAML-based provider registry loader

### DIFF
--- a/configs/providers.example.yaml
+++ b/configs/providers.example.yaml
@@ -1,0 +1,11 @@
+providers:
+  - id: chembl
+    module: bioetl.infrastructure.clients.chembl.provider
+    factory: register_chembl_provider
+    active: true
+    description: "ChEMBL data provider"
+  - id: pubchem
+    module: bioetl.infrastructure.clients.pubchem.provider
+    factory: register_pubchem_provider
+    active: false
+    description: "PubChem provider (enable after implementation)"

--- a/configs/providers.yaml
+++ b/configs/providers.yaml
@@ -1,0 +1,6 @@
+providers:
+  - id: chembl
+    module: bioetl.infrastructure.clients.chembl.provider
+    factory: register_chembl_provider
+    active: true
+    description: "ChEMBL data provider"

--- a/docs/architecture/16-provider-registry-config.md
+++ b/docs/architecture/16-provider-registry-config.md
@@ -1,0 +1,44 @@
+# 16 Provider Registry Config
+
+## Purpose
+
+This note documents the YAML-driven provider registry that powers dynamic provider registration for BioETL. It explains the file format, validation rules, and the workflow for adding new providers.
+
+## Configuration file
+
+- Location: `configs/providers.yaml`
+- Format: YAML object with a `providers` array
+- Fields per entry:
+  - `id` *(required)* — provider identifier matching `ProviderId` (snake_case string)
+  - `module` *(required)* — fully-qualified Python module that exports the factory
+  - `factory` *(required)* — callable name that performs provider registration and returns `ProviderDefinition`
+  - `active` *(optional, default: true)* — toggle to enable/disable loading
+  - `description` *(optional)* — human-readable description for documentation
+
+### Example
+
+```yaml
+providers:
+  - id: chembl
+    module: bioetl.infrastructure.clients.chembl.provider
+    factory: register_chembl_provider
+    active: true
+    description: "ChEMBL data provider"
+```
+
+A reference sample is available at `configs/providers.example.yaml`.
+
+## Loader behavior
+
+- The loader validates the YAML via a Pydantic schema (extra fields are forbidden).
+- Disabled entries (`active: false`) are skipped with a debug log.
+- For each enabled entry the loader dynamically imports the module, resolves the factory, and executes it.
+- Failures to import modules, missing factories, or runtime exceptions are logged and do not stop other entries.
+- The factory return value must be a `ProviderDefinition`; otherwise the entry is skipped with an error log.
+
+## Adding a new provider
+
+1. Implement the provider components and registration factory (e.g., `register_<provider>_provider`).
+2. Ensure the provider identifier is declared in `ProviderId`.
+3. Add a new entry to `configs/providers.yaml` with `active: true` once the provider is ready.
+4. Commit the change along with any provider code and configuration updates.

--- a/src/bioetl/application/config_loader.py
+++ b/src/bioetl/application/config_loader.py
@@ -9,6 +9,7 @@ import yaml
 from pydantic import ValidationError
 
 from bioetl.config.pipeline_config_schema import PipelineConfig
+from bioetl.domain.providers import ProviderId
 from bioetl.domain.transform.merge import deep_merge
 
 CONFIGS_ROOT = Path("configs")
@@ -44,7 +45,7 @@ class UnknownProviderError(ConfigError):
         self.provider = provider
 
 
-SUPPORTED_PROVIDERS = {"chembl"}
+SUPPORTED_PROVIDERS = {provider.value for provider in ProviderId}
 
 
 def load_pipeline_config(


### PR DESCRIPTION
## Summary
- add YAML-driven provider registry configuration with example
- implement provider registry loader with pydantic validation and dynamic imports
- update pipeline container to use the loader and document the provider config format

## Testing
- python -m compileall src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69340d238a4083249c0adbaf7681b919)