### PR TITLE
Refactor ChEMBL normalization factory usage

### DIFF
--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -8,7 +8,6 @@ from bioetl.application.pipelines.hooks_impl import (
     LoggingPipelineHookImpl,
 )
 from bioetl.config.pipeline_config_schema import PipelineConfig
-from bioetl.domain.normalization_service import NormalizationService
 from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
 from bioetl.domain.provider_registry import get_provider
 from bioetl.domain.providers import ProviderDefinition, ProviderId
@@ -16,6 +15,7 @@ from bioetl.domain.record_source import ApiRecordSource, RecordSource
 from bioetl.domain.schemas import register_schemas
 from bioetl.domain.schemas.registry import SchemaRegistry
 from bioetl.domain.transform.hash_service import HashService
+from bioetl.domain.transform.contracts import NormalizationServiceABC
 from bioetl.domain.transform.transformers import (
     DatabaseVersionTransformer,
     FulldateTransformer,
@@ -90,7 +90,7 @@ class PipelineContainer:
             qc_config=self.config.qc,
         )
 
-    def get_normalization_service(self) -> NormalizationService:
+    def get_normalization_service(self) -> NormalizationServiceABC:
         """Create normalization service for the configured provider."""
 
         definition = self._get_provider_definition()

--- a/src/bioetl/application/pipelines/chembl/base.py
+++ b/src/bioetl/application/pipelines/chembl/base.py
@@ -8,14 +8,12 @@ from bioetl.application.pipelines.chembl.transformer import ChemblTransformerImp
 from bioetl.config.pipeline_config_schema import PipelineConfig
 from bioetl.domain.contracts import ExtractionServiceABC
 from bioetl.domain.models import RunContext
-from bioetl.domain.normalization_service import (
-    ChemblNormalizationService,
-    NormalizationService,
-)
 from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
 from bioetl.domain.record_source import RecordSource
 from bioetl.domain.schemas.pipeline_contracts import get_pipeline_contract
 from bioetl.domain.transform.hash_service import HashService
+from bioetl.domain.transform.contracts import NormalizationServiceABC
+from bioetl.domain.transform.factories import default_normalization_service
 from bioetl.domain.transform.transformers import TransformerABC
 from bioetl.domain.validation.service import ValidationService
 from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
@@ -34,7 +32,7 @@ class ChemblPipelineBase(PipelineBase):
         extraction_service: ExtractionServiceABC,
         hash_service: HashService,
         record_source: RecordSource | None = None,
-        normalization_service: NormalizationService | None = None,
+        normalization_service: NormalizationServiceABC | None = None,
         hooks: list[PipelineHookABC] | None = None,
         error_policy: ErrorPolicyABC | None = None,
         post_transformer: TransformerABC | None = None,
@@ -42,7 +40,7 @@ class ChemblPipelineBase(PipelineBase):
         self._extraction_service = extraction_service
         self._chembl_release: str | None = None
 
-        norm_service = normalization_service or ChemblNormalizationService(config)
+        norm_service = normalization_service or default_normalization_service(config)
 
         # Create Extractor
         extractor = ChemblExtractorImpl(

--- a/src/bioetl/application/pipelines/chembl/extractor.py
+++ b/src/bioetl/application/pipelines/chembl/extractor.py
@@ -10,8 +10,8 @@ import pandas as pd
 from bioetl.application.pipelines.contracts import ExtractorABC
 from bioetl.config.pipeline_config_schema import PipelineConfig
 from bioetl.domain.contracts import ExtractionServiceABC
-from bioetl.domain.normalization_service import NormalizationService
 from bioetl.domain.record_source import ApiRecordSource, RecordSource
+from bioetl.domain.transform.contracts import NormalizationServiceABC
 from bioetl.infrastructure.config.models import ChemblSourceConfig
 from bioetl.infrastructure.files.csv_record_source import (
     CsvRecordSourceImpl,
@@ -29,7 +29,7 @@ class ChemblExtractorImpl(ExtractorABC):
         self,
         config: PipelineConfig,
         extraction_service: ExtractionServiceABC,
-        normalization_service: NormalizationService,
+        normalization_service: NormalizationServiceABC,
         logger: LoggerAdapterABC,
         record_source: RecordSource | None = None,
     ) -> None:

--- a/src/bioetl/application/pipelines/chembl/pipeline.py
+++ b/src/bioetl/application/pipelines/chembl/pipeline.py
@@ -8,9 +8,9 @@ with a configurable generic implementation.
 from bioetl.application.pipelines.chembl.base import ChemblPipelineBase
 from bioetl.config.pipeline_config_schema import PipelineConfig
 from bioetl.domain.contracts import ExtractionServiceABC
-from bioetl.domain.normalization_service import NormalizationService
 from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
 from bioetl.domain.record_source import RecordSource
+from bioetl.domain.transform.contracts import NormalizationServiceABC
 from bioetl.domain.transform.hash_service import HashService
 from bioetl.domain.validation.service import ValidationService
 from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
@@ -32,7 +32,7 @@ class ChemblEntityPipeline(ChemblPipelineBase):
         extraction_service: ExtractionServiceABC,
         hash_service: HashService,
         record_source: RecordSource | None = None,
-        normalization_service: NormalizationService | None = None,
+        normalization_service: NormalizationServiceABC | None = None,
         hooks: list[PipelineHookABC] | None = None,
         error_policy: ErrorPolicyABC | None = None,
     ) -> None:

--- a/src/bioetl/application/pipelines/chembl/transformer.py
+++ b/src/bioetl/application/pipelines/chembl/transformer.py
@@ -5,8 +5,8 @@ ChEMBL data transformer implementation.
 import pandas as pd
 
 from bioetl.domain.models import RunContext
-from bioetl.domain.normalization_service import NormalizationService
 from bioetl.domain.schemas.pipeline_contracts import PipelineSchemaContract
+from bioetl.domain.transform.contracts import NormalizationServiceABC
 from bioetl.domain.transform.transformers import TransformerABC
 from bioetl.domain.validation.service import ValidationService
 from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
@@ -24,7 +24,7 @@ class ChemblTransformerImpl(TransformerABC):
         self,
         validation_service: ValidationService,
         schema_contract: PipelineSchemaContract,
-        normalization_service: NormalizationService,
+        normalization_service: NormalizationServiceABC,
         logger: LoggerAdapterABC,
     ) -> None:
         self.validation_service = validation_service

--- a/src/bioetl/domain/normalization_service.py
+++ b/src/bioetl/domain/normalization_service.py
@@ -7,7 +7,10 @@ from typing import Any, Protocol, TypedDict, cast
 import pandas as pd
 
 from bioetl.domain.record_source import RawRecord
-from bioetl.domain.transform.contracts import NormalizationConfigProvider
+from bioetl.domain.transform.contracts import (
+    NormalizationConfigProvider,
+    NormalizationServiceABC,
+)
 from bioetl.domain.transform.impl import normalize as normalize_impl
 from bioetl.domain.transform.impl.base_normalizer import BaseNormalizationService
 from bioetl.domain.transform.impl.serializer import serialize_dict, serialize_list
@@ -41,7 +44,9 @@ class NormalizationService(Protocol):
         """Normalize a Series using field configuration."""
 
 
-class ChemblNormalizationService(BaseNormalizationService, NormalizationService):
+class ChemblNormalizationService(
+    BaseNormalizationService, NormalizationServiceABC, NormalizationService
+):
     """Normalization service for ChEMBL records."""
 
     def __init__(self, config: NormalizationConfigProvider):
@@ -96,6 +101,9 @@ class ChemblNormalizationService(BaseNormalizationService, NormalizationService)
         return normalized_df
 
     def normalize_batch(self, df: pd.DataFrame) -> pd.DataFrame:
+        return self.normalize_dataframe(df)
+
+    def normalize_fields(self, df: pd.DataFrame) -> pd.DataFrame:
         return self.normalize_dataframe(df)
 
     def normalize_series(

--- a/src/bioetl/domain/providers.py
+++ b/src/bioetl/domain/providers.py
@@ -8,12 +8,12 @@ from typing import Generic, Protocol, TypeVar, runtime_checkable
 
 from pydantic import BaseModel, ConfigDict
 
-from bioetl.domain.normalization_service import NormalizationService
+from bioetl.domain.transform.contracts import NormalizationServiceABC
 
 ClientT_co = TypeVar("ClientT_co", covariant=True)
 ExtractionServiceT_co = TypeVar("ExtractionServiceT_co", covariant=True)
 NormalizationServiceT_co = TypeVar(
-    "NormalizationServiceT_co", bound=NormalizationService | None, covariant=True
+    "NormalizationServiceT_co", bound=NormalizationServiceABC | None, covariant=True
 )
 WriterT_co = TypeVar("WriterT_co", covariant=True)
 

--- a/src/bioetl/domain/transform/contracts.py
+++ b/src/bioetl/domain/transform/contracts.py
@@ -58,8 +58,31 @@ class HasherABC(ABC):
 class NormalizationServiceABC(ABC):
     """
     Сервис нормализации данных в DataFrame.
+
+    Обязательные операции:
+    - normalize: нормализация единичной записи
+    - normalize_fields: пакетная нормализация DataFrame по конфигурации
+    - normalize_dataframe: совместимый алиас для normalize_fields
+    - normalize_batch: пакетная нормализация чанка
+    - normalize_series: нормализация столбца по конфигурации
     """
+
+    @abstractmethod
+    def normalize(self, raw: pd.Series | dict[str, Any]) -> dict[str, Any]:
+        """Нормализует одиночную запись или Series."""
 
     @abstractmethod
     def normalize_fields(self, df: pd.DataFrame) -> pd.DataFrame:
         """Нормализует поля DataFrame согласно конфигурации."""
+
+    @abstractmethod
+    def normalize_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Алиас для normalize_fields для обратной совместимости."""
+
+    @abstractmethod
+    def normalize_batch(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Нормализует DataFrame чанками или целиком."""
+
+    @abstractmethod
+    def normalize_series(self, series: pd.Series, field_cfg: dict[str, Any]) -> pd.Series:
+        """Нормализует отдельную серию согласно полю конфигурации."""

--- a/src/bioetl/domain/transform/factories.py
+++ b/src/bioetl/domain/transform/factories.py
@@ -1,0 +1,17 @@
+"""Factory functions for transform services."""
+
+from bioetl.domain.transform.contracts import (
+    NormalizationConfigProvider,
+    NormalizationServiceABC,
+)
+from bioetl.domain.transform.impl import NormalizationServiceImpl
+
+__all__ = ["default_normalization_service"]
+
+
+def default_normalization_service(
+    config: NormalizationConfigProvider,
+) -> NormalizationServiceABC:
+    """Create default normalization service implementation."""
+
+    return NormalizationServiceImpl(config)

--- a/src/bioetl/domain/transform/impl/__init__.py
+++ b/src/bioetl/domain/transform/impl/__init__.py
@@ -3,11 +3,17 @@ Transform implementations.
 """
 
 from .hasher import HasherImpl
-from .normalize import NormalizationService, serialize_dict, serialize_list
+from .normalize import (
+    NormalizationService,
+    NormalizationServiceImpl,
+    serialize_dict,
+    serialize_list,
+)
 
 __all__ = [
     "HasherImpl",
     "NormalizationService",
+    "NormalizationServiceImpl",
     "serialize_dict",
     "serialize_list",
 ]

--- a/src/bioetl/infrastructure/clients/base/abc_impls.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_impls.yaml
@@ -32,6 +32,11 @@ ValidatorABC:
   implementations:
     Pandera: bioetl.domain.validation.impl.pandera_validator.PanderaValidatorImpl
 
+NormalizationServiceABC:
+  default_factory: bioetl.domain.transform.factories.default_normalization_service
+  implementations:
+    Chembl: bioetl.domain.normalization_service.ChemblNormalizationService
+
 WriterABC:
   default_factory: bioetl.infrastructure.output.factories.default_writer
   implementations:

--- a/src/bioetl/infrastructure/clients/chembl/provider.py
+++ b/src/bioetl/infrastructure/clients/chembl/provider.py
@@ -4,14 +4,17 @@ from __future__ import annotations
 
 from bioetl.domain.clients.chembl.contracts import ChemblDataClientABC
 from bioetl.domain.contracts import ExtractionServiceABC
-from bioetl.domain.normalization_service import ChemblNormalizationService
 from bioetl.domain.provider_registry import (
     ProviderAlreadyRegisteredError,
     get_provider,
     register_provider,
 )
 from bioetl.domain.providers import ProviderComponents, ProviderDefinition, ProviderId
-from bioetl.domain.transform.contracts import NormalizationConfigProvider
+from bioetl.domain.transform.contracts import (
+    NormalizationConfigProvider,
+    NormalizationServiceABC,
+)
+from bioetl.domain.transform.factories import default_normalization_service
 from bioetl.infrastructure.chembl_client import (
     create_client,
     create_extraction_service,
@@ -23,7 +26,7 @@ class ChemblProviderComponents(
     ProviderComponents[
         ChemblDataClientABC,
         ExtractionServiceABC,
-        ChemblNormalizationService,
+        NormalizationServiceABC,
         object,
     ]
 ):
@@ -46,13 +49,13 @@ class ChemblProviderComponents(
         *,
         client: ChemblDataClientABC | None = None,
         pipeline_config: NormalizationConfigProvider | None = None,
-    ) -> ChemblNormalizationService:
+    ) -> NormalizationServiceABC:
         _ = client  # signature compatibility; normalization independent from client
         if pipeline_config is None:
             raise ValueError(
                 "NormalizationConfigProvider is required to build normalization service"
             )
-        return ChemblNormalizationService(pipeline_config)
+        return default_normalization_service(pipeline_config)
 
 
 def register_chembl_provider() -> ProviderDefinition:

--- a/tests/bioetl/infrastructure/clients/chembl/test_provider.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_provider.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from bioetl.domain.transform.contracts import NormalizationServiceABC
+from bioetl.infrastructure.clients.chembl.provider import ChemblProviderComponents
+from bioetl.infrastructure.config.models import ChemblSourceConfig
+
+
+class _NormalizationServiceStub(NormalizationServiceABC):
+    def normalize(self, raw):
+        return {"raw": raw}
+
+    def normalize_fields(self, df):
+        return df
+
+    def normalize_dataframe(self, df):
+        return df
+
+    def normalize_batch(self, df):
+        return df
+
+    def normalize_series(self, series, field_cfg):
+        return series
+
+
+@pytest.fixture()
+def chembl_config() -> ChemblSourceConfig:
+    return ChemblSourceConfig(
+        base_url="https://example.com/api",
+        timeout_sec=30,
+        max_retries=1,
+        rate_limit_per_sec=1.0,
+    )
+
+
+def test_create_normalization_service_uses_factory(monkeypatch, chembl_config):
+    components = ChemblProviderComponents()
+    pipeline_config = SimpleNamespace(normalization={}, fields=[])
+    stub_service = _NormalizationServiceStub()
+
+    factory = MagicMock(return_value=stub_service)
+    monkeypatch.setattr(
+        "bioetl.infrastructure.clients.chembl.provider.default_normalization_service",
+        factory,
+    )
+
+    result = components.create_normalization_service(
+        chembl_config, pipeline_config=pipeline_config
+    )
+
+    assert result is stub_service
+    factory.assert_called_once_with(pipeline_config)
+
+
+def test_create_normalization_service_requires_pipeline_config(chembl_config):
+    components = ChemblProviderComponents()
+
+    with pytest.raises(ValueError):
+        components.create_normalization_service(chembl_config)


### PR DESCRIPTION
## Summary
- switch ChEMBL provider normalization to the NormalizationServiceABC interface via the default factory
- register the normalization service factory/implementation in the ABC registry and align pipelines to use it
- add coverage ensuring the provider builds normalization through the factory layer

## Testing
- pytest tests/bioetl/infrastructure/clients/chembl/test_provider.py tests/bioetl/domain/test_normalization_service.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693410e764fc832488b967f442fd9ed3)