### PR TITLE
Refactor normalization service infrastructure

### DIFF
--- a/src/bioetl/domain/transform/impl/__init__.py
+++ b/src/bioetl/domain/transform/impl/__init__.py
@@ -3,11 +3,15 @@ Transform implementations.
 """
 
 from .hasher import HasherImpl
-from .normalize import NormalizationService, serialize_dict, serialize_list
+from .normalize import normalize_pubchem_cid, normalize_pubmed_id, normalize_scalar, normalize_uniprot_id
+from .serializer import serialize_dict, serialize_list
 
 __all__ = [
     "HasherImpl",
-    "NormalizationService",
+    "normalize_scalar",
+    "normalize_pubmed_id",
+    "normalize_pubchem_cid",
+    "normalize_uniprot_id",
     "serialize_dict",
     "serialize_list",
 ]

--- a/src/bioetl/domain/transform/impl/normalize.py
+++ b/src/bioetl/domain/transform/impl/normalize.py
@@ -2,27 +2,15 @@
 Normalization implementation for domain entities.
 """
 
-from typing import Any, Callable
+from typing import Any
 
 import pandas as pd
 
-from bioetl.domain.transform.contracts import (
-    NormalizationConfigProvider,
-    NormalizationServiceABC,
-)
-from bioetl.domain.transform.impl.base_normalizer import BaseNormalizationService
-from bioetl.domain.transform.impl.serializer import (
-    serialize_dict,
-    serialize_list,
-)
 from bioetl.domain.transform.normalizers import (
-    normalize_array,
     normalize_pcid,
     normalize_pmid,
-    normalize_record,
     normalize_uniprot,
 )
-from bioetl.domain.transform.normalizers.registry import get_normalizer
 
 # Aliases for backward compatibility or convenience
 normalize_pubmed_id = normalize_pmid
@@ -80,111 +68,11 @@ def _normalize_string_value(value: str, mode: str) -> str | None:
     return val.lower()
 
 
-class NormalizationService(NormalizationServiceABC, BaseNormalizationService):
-    """
-    Сервис нормализации данных.
-    Выполняет:
-    - Сериализацию вложенных структур (list/dict -> str)
-    - Нормализацию скалярных типов (float->round, str->trim/lower/upper)
-    """
+__all__ = [
+    "normalize_scalar",
+    "normalize_pubmed_id",
+    "normalize_pubchem_cid",
+    "normalize_uniprot_id",
+]
 
-    def __init__(self, config: NormalizationConfigProvider):
-        BaseNormalizationService.__init__(self, config, empty_value=pd.NA)
 
-    def normalize_fields(self, df: pd.DataFrame) -> pd.DataFrame:
-        """
-        Проходит по полям конфигурации и применяет нормализацию.
-        """
-        for field_cfg in self._config.fields:
-            name = field_cfg["name"]
-            dtype = field_cfg.get("data_type")
-
-            if name not in df.columns:
-                continue
-
-            mode = self._resolve_mode(name)
-            custom_normalizer = get_normalizer(name)
-
-            if custom_normalizer:
-                base_normalizer: Callable[[Any], Any] = custom_normalizer
-            else:
-
-                def _default_normalizer(val: Any, m=mode) -> Any:
-                    return normalize_scalar(val, mode=m)
-
-                base_normalizer = _default_normalizer
-
-            def _apply_value(
-                val: Any,
-                norm=base_normalizer,
-                field_name=name,
-                data_type=dtype,
-            ) -> Any:
-                try:
-                    return self._normalize_value(
-                        val,
-                        data_type,
-                        norm,
-                        field_name,
-                        allow_container_normalizer=True,
-                        serialize_with_value_normalizer=False,
-                    )
-                except ValueError as exc:
-                    raise ValueError(
-                        f"Ошибка нормализации поля '{field_name}': {exc}"
-                    ) from exc
-
-            df[name] = df[name].apply(_apply_value)
-
-            if dtype in ("array", "object"):
-                df[name] = df[name].astype("string").replace({pd.NA: None})
-
-        return df
-
-    def _normalize_container_item(
-        self, item: Any, normalizer: Callable[[Any], Any]
-    ) -> Any:
-        if isinstance(item, dict):
-            normalized_dict = normalize_record(item, value_normalizer=normalizer)
-            return normalized_dict if normalized_dict is not None else {}
-        return normalizer(item)
-
-    def _process_list(
-        self,
-        val: Any,
-        norm: Callable[[Any], Any],
-        field_name: str,
-        *,
-        serialize_with_value_normalizer: bool = False,
-    ) -> Any:
-        try:
-
-            def _smart_normalizer(item: Any) -> Any:
-                return self._normalize_container_item(item, norm)
-
-            normalized_list = normalize_array(
-                list(val), item_normalizer=_smart_normalizer
-            )
-        except ValueError as exc:
-            raise ValueError(
-                f"Ошибка нормализации списка в поле '{field_name}': {exc}"
-            ) from exc
-        if not normalized_list:
-            return pd.NA
-        return serialize_list(
-            normalized_list,
-            value_normalizer=norm if serialize_with_value_normalizer else None,
-        )
-
-    def _process_dict(
-        self, val: Any, norm: Callable[[Any], Any], field_name: str
-    ) -> Any:
-        try:
-            normalized_dict = normalize_record(val, value_normalizer=norm)
-        except ValueError as exc:
-            raise ValueError(
-                f"Ошибка нормализации записи в поле '{field_name}': {exc}"
-            ) from exc
-        if normalized_dict is None:
-            return pd.NA
-        return serialize_dict(normalized_dict)

--- a/src/bioetl/infrastructure/clients/base/abc_impls.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_impls.yaml
@@ -32,6 +32,11 @@ ValidatorABC:
   implementations:
     Pandera: bioetl.domain.validation.impl.pandera_validator.PanderaValidatorImpl
 
+NormalizationServiceABC:
+  default_factory: bioetl.infrastructure.transform.factories.default_normalization_service
+  implementations:
+    Default: bioetl.infrastructure.transform.impl.normalization_service_impl.NormalizationServiceImpl
+
 WriterABC:
   default_factory: bioetl.infrastructure.output.factories.default_writer
   implementations:

--- a/src/bioetl/infrastructure/transform/__init__.py
+++ b/src/bioetl/infrastructure/transform/__init__.py
@@ -1,0 +1,5 @@
+"""Transform infrastructure layer."""
+
+from bioetl.infrastructure.transform.factories import default_normalization_service
+
+__all__ = ["default_normalization_service"]

--- a/src/bioetl/infrastructure/transform/factories.py
+++ b/src/bioetl/infrastructure/transform/factories.py
@@ -1,0 +1,20 @@
+"""Factories for transform infrastructure components."""
+
+from bioetl.domain.transform.contracts import (
+    NormalizationConfigProvider,
+    NormalizationServiceABC,
+)
+from bioetl.infrastructure.transform.impl.normalization_service_impl import (
+    NormalizationServiceImpl,
+)
+
+
+def default_normalization_service(
+    config: NormalizationConfigProvider,
+) -> NormalizationServiceABC:
+    """Создает сервис нормализации по умолчанию."""
+
+    return NormalizationServiceImpl(config)
+
+
+__all__ = ["default_normalization_service"]

--- a/src/bioetl/infrastructure/transform/impl/__init__.py
+++ b/src/bioetl/infrastructure/transform/impl/__init__.py
@@ -1,0 +1,7 @@
+"""Concrete transform implementations."""
+
+from bioetl.infrastructure.transform.impl.normalization_service_impl import (
+    NormalizationServiceImpl,
+)
+
+__all__ = ["NormalizationServiceImpl"]

--- a/src/bioetl/infrastructure/transform/impl/normalization_service_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/normalization_service_impl.py
@@ -1,0 +1,126 @@
+"""Infrastructure implementation of the normalization service."""
+
+from typing import Any, Callable
+
+import pandas as pd
+
+from bioetl.domain.transform.contracts import (
+    NormalizationConfigProvider,
+    NormalizationServiceABC,
+)
+from bioetl.domain.transform.impl.base_normalizer import BaseNormalizationService
+from bioetl.domain.transform.impl.serializer import serialize_dict, serialize_list
+from bioetl.domain.transform.impl.normalize import normalize_scalar
+from bioetl.domain.transform.normalizers import normalize_array, normalize_record
+from bioetl.domain.transform.normalizers.registry import get_normalizer
+
+
+class NormalizationServiceImpl(NormalizationServiceABC, BaseNormalizationService):
+    """
+    Сервис нормализации данных.
+    Выполняет:
+    - Сериализацию вложенных структур (list/dict -> str)
+    - Нормализацию скалярных типов (float->round, str->trim/lower/upper)
+    """
+
+    def __init__(self, config: NormalizationConfigProvider):
+        BaseNormalizationService.__init__(self, config, empty_value=pd.NA)
+
+    def normalize_fields(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Проходит по полям конфигурации и применяет нормализацию."""
+        for field_cfg in self._config.fields:
+            name = field_cfg["name"]
+            dtype = field_cfg.get("data_type")
+
+            if name not in df.columns:
+                continue
+
+            mode = self._resolve_mode(name)
+            custom_normalizer = get_normalizer(name)
+
+            if custom_normalizer:
+                base_normalizer: Callable[[Any], Any] = custom_normalizer
+            else:
+
+                def _default_normalizer(val: Any, m=mode) -> Any:
+                    return normalize_scalar(val, mode=m)
+
+                base_normalizer = _default_normalizer
+
+            def _apply_value(
+                val: Any,
+                norm=base_normalizer,
+                field_name=name,
+                data_type=dtype,
+            ) -> Any:
+                try:
+                    return self._normalize_value(
+                        val,
+                        data_type,
+                        norm,
+                        field_name,
+                        allow_container_normalizer=True,
+                        serialize_with_value_normalizer=False,
+                    )
+                except ValueError as exc:
+                    raise ValueError(
+                        f"Ошибка нормализации поля '{field_name}': {exc}"
+                    ) from exc
+
+            df[name] = df[name].apply(_apply_value)
+
+            if dtype in ("array", "object"):
+                df[name] = df[name].astype("string").replace({pd.NA: None})
+
+        return df
+
+    def _normalize_container_item(
+        self, item: Any, normalizer: Callable[[Any], Any]
+    ) -> Any:
+        if isinstance(item, dict):
+            normalized_dict = normalize_record(item, value_normalizer=normalizer)
+            return normalized_dict if normalized_dict is not None else {}
+        return normalizer(item)
+
+    def _process_list(
+        self,
+        val: Any,
+        norm: Callable[[Any], Any],
+        field_name: str,
+        *,
+        serialize_with_value_normalizer: bool = False,
+    ) -> Any:
+        try:
+
+            def _smart_normalizer(item: Any) -> Any:
+                return self._normalize_container_item(item, norm)
+
+            normalized_list = normalize_array(
+                list(val), item_normalizer=_smart_normalizer
+            )
+        except ValueError as exc:
+            raise ValueError(
+                f"Ошибка нормализации списка в поле '{field_name}': {exc}"
+            ) from exc
+        if not normalized_list:
+            return pd.NA
+        return serialize_list(
+            normalized_list,
+            value_normalizer=norm if serialize_with_value_normalizer else None,
+        )
+
+    def _process_dict(
+        self, val: Any, norm: Callable[[Any], Any], field_name: str
+    ) -> Any:
+        try:
+            normalized_dict = normalize_record(val, value_normalizer=norm)
+        except ValueError as exc:
+            raise ValueError(
+                f"Ошибка нормализации записи в поле '{field_name}': {exc}"
+            ) from exc
+        if normalized_dict is None:
+            return pd.NA
+        return serialize_dict(normalized_dict)
+
+
+__all__ = ["NormalizationServiceImpl"]


### PR DESCRIPTION
## Summary
- move the normalization service implementation to the infrastructure layer as NormalizationServiceImpl
- add a default_normalization_service factory and register it in abc_impls
- adjust domain helpers and tests to rely on the new factory and interface

## Testing
- pytest tests/bioetl/domain/transform/test_normalize.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693410edaa8883248f0b70f21a70c082)