### PR TITLE
Refactor metadata base builder

### DIFF
--- a/tests/bioetl/infrastructure/output/test_metadata_builder.py
+++ b/tests/bioetl/infrastructure/output/test_metadata_builder.py
@@ -11,6 +11,7 @@ import pytest
 from bioetl.domain.models import RunContext
 from bioetl.infrastructure.output.contracts import WriteResult
 from bioetl.infrastructure.output.metadata import (
+    build_base_metadata,
     build_dry_run_metadata,
     build_run_metadata,
 )
@@ -72,6 +73,32 @@ def test_build_dry_run_metadata(run_context):
     assert "files" not in meta
 
 
+def test_run_and_dry_run_share_base_fields(run_context):
+    """Run и dry-run должны совпадать по базовым полям и различаться по специфике."""
+    write_result = WriteResult(
+        path=Path("/tmp/out/test.csv"),
+        row_count=42,
+        duration_sec=1.0,
+        checksum="run-hash",
+    )
+
+    run_meta = build_run_metadata(run_context, write_result)
+    dry_run_meta = build_dry_run_metadata(run_context, row_count=42)
+
+    base_run_meta = build_base_metadata(run_context, row_count=42)
+
+    _assert_common_metadata_fields(run_meta, base_run_meta)
+    _assert_common_metadata_fields(dry_run_meta, base_run_meta)
+
+    assert "checksum" in run_meta
+    assert "files" in run_meta
+    assert "dry_run" not in run_meta
+
+    assert dry_run_meta["dry_run"] is True
+    assert "checksum" not in dry_run_meta
+    assert "files" not in dry_run_meta
+
+
 def _assert_metadata(
     meta: dict, write_result: WriteResult, run_context: RunContext
 ) -> None:
@@ -93,3 +120,8 @@ def _assert_checksums(meta: dict) -> None:
     assert meta["checksums"]["test.csv"] == "abc123hash"
     assert meta["checksums"]["quality_report_table.csv"] == "qc1"
     assert meta["qc_artifacts"]["quality_report_table.csv"]["checksum"] == "qc1"
+
+
+def _assert_common_metadata_fields(meta: dict, expected: dict) -> None:
+    for key, value in expected.items():
+        assert meta[key] == value


### PR DESCRIPTION
## Summary
- extract a shared base metadata builder to unify run and dry-run metadata
- preserve deterministic ordering for files and QC artifacts while adding shared context metadata
- extend unit tests to cover common and divergent fields between run and dry-run metadata

## Testing
- pytest tests/bioetl/infrastructure/output/test_metadata_builder.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934184bc92c8324b33a674fe65b2602)