### PR TITLE
Add metrics pipeline hook integration

### DIFF
--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -6,6 +6,7 @@ from typing import Any, Callable
 from bioetl.application.pipelines.hooks_impl import (
     FailFastErrorPolicyImpl,
     LoggingPipelineHookImpl,
+    MetricsPipelineHookImpl,
 )
 from bioetl.config.pipeline_config_schema import PipelineConfig
 from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
@@ -199,7 +200,14 @@ class PipelineContainer:
     def get_hooks(self) -> list[PipelineHookABC]:
         """Возвращает список хуков выполнения пайплайна."""
         if self._hooks is None:
-            self._hooks = [LoggingPipelineHookImpl(self.get_logger())]
+            self._hooks = [
+                LoggingPipelineHookImpl(self.get_logger()),
+                MetricsPipelineHookImpl(
+                    pipeline_id=self.config.id,
+                    provider=self._provider_id.value,
+                    entity_name=self.config.entity_name,
+                ),
+            ]
         return list(self._hooks)
 
     def get_error_policy(self) -> ErrorPolicyABC:

--- a/src/bioetl/application/pipelines/hooks_impl.py
+++ b/src/bioetl/application/pipelines/hooks_impl.py
@@ -9,6 +9,7 @@ from bioetl.domain.errors import PipelineStageError
 from bioetl.domain.models import StageResult
 from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
 from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
+from bioetl.infrastructure.observability import metrics
 
 
 class LoggingPipelineHookImpl(PipelineHookABC):
@@ -76,6 +77,39 @@ class ContinueOnErrorPolicyImpl(ErrorPolicyABC):
 
 __all__ = [
     "LoggingPipelineHookImpl",
+    "MetricsPipelineHookImpl",
     "FailFastErrorPolicyImpl",
     "ContinueOnErrorPolicyImpl",
 ]
+
+
+class MetricsPipelineHookImpl(PipelineHookABC):
+    """Хук, фиксирующий метрики завершения стадий."""
+
+    def __init__(self, *, pipeline_id: str, provider: str, entity_name: str) -> None:
+        self._pipeline_id = pipeline_id
+        self._provider = provider
+        self._entity_name = entity_name
+
+    def on_stage_start(self, stage: str, context: Any) -> None:  # noqa: ARG002
+        """Хук старта стадии не требует метрик."""
+
+    def on_stage_end(self, stage: str, result: StageResult) -> None:
+        outcome = "success" if result.success else "error"
+        metrics.STAGE_DURATION_SECONDS.labels(
+            pipeline=self._pipeline_id,
+            provider=self._provider,
+            entity=self._entity_name,
+            stage=stage,
+            outcome=outcome,
+        ).observe(result.duration_sec)
+        metrics.STAGE_TOTAL.labels(
+            pipeline=self._pipeline_id,
+            provider=self._provider,
+            entity=self._entity_name,
+            stage=stage,
+            outcome=outcome,
+        ).inc()
+
+    def on_error(self, stage: str, error: PipelineStageError) -> None:  # noqa: ARG002
+        """Метрики фиксируются в on_stage_end, поэтому обработка не требуется."""

--- a/tests/bioetl/application/pipelines/test_hooks_impl.py
+++ b/tests/bioetl/application/pipelines/test_hooks_impl.py
@@ -1,0 +1,98 @@
+from bioetl.application.pipelines.hooks_impl import MetricsPipelineHookImpl
+from bioetl.domain.models import StageResult
+from bioetl.infrastructure.observability import metrics
+from prometheus_client import Histogram
+
+
+def _histogram_stats(child: Histogram) -> tuple[float, float]:
+    samples = {
+        sample.name: sample.value
+        for sample in child._samples()
+        if sample.name in {"_sum", "_count"}
+    }
+    return samples["_sum"], samples["_count"]
+
+
+def _reset_metrics() -> None:
+    metrics.STAGE_DURATION_SECONDS._metrics.clear()
+    metrics.STAGE_TOTAL._metrics.clear()
+
+
+def test_metrics_hook_records_successful_stage() -> None:
+    _reset_metrics()
+    hook = MetricsPipelineHookImpl(
+        pipeline_id="pipeline-x",
+        provider="chembl",
+        entity_name="activity",
+    )
+    result = StageResult(
+        stage_name="extract",
+        success=True,
+        records_processed=5,
+        chunks_processed=1,
+        duration_sec=1.5,
+        errors=[],
+    )
+
+    hook.on_stage_end("extract", result)
+
+    histogram_child = metrics.STAGE_DURATION_SECONDS.labels(
+        pipeline="pipeline-x",
+        provider="chembl",
+        entity="activity",
+        stage="extract",
+        outcome="success",
+    )
+    counter_child = metrics.STAGE_TOTAL.labels(
+        pipeline="pipeline-x",
+        provider="chembl",
+        entity="activity",
+        stage="extract",
+        outcome="success",
+    )
+
+    duration_sum, duration_count = _histogram_stats(histogram_child)
+
+    assert duration_sum == 1.5
+    assert duration_count == 1.0
+    assert counter_child._value.get() == 1.0
+
+
+def test_metrics_hook_records_failed_stage() -> None:
+    _reset_metrics()
+    hook = MetricsPipelineHookImpl(
+        pipeline_id="pipeline-x",
+        provider="chembl",
+        entity_name="activity",
+    )
+    result = StageResult(
+        stage_name="validate",
+        success=False,
+        records_processed=0,
+        chunks_processed=0,
+        duration_sec=0.2,
+        errors=["boom"],
+    )
+
+    hook.on_stage_end("validate", result)
+
+    histogram_child = metrics.STAGE_DURATION_SECONDS.labels(
+        pipeline="pipeline-x",
+        provider="chembl",
+        entity="activity",
+        stage="validate",
+        outcome="error",
+    )
+    counter_child = metrics.STAGE_TOTAL.labels(
+        pipeline="pipeline-x",
+        provider="chembl",
+        entity="activity",
+        stage="validate",
+        outcome="error",
+    )
+
+    duration_sum, duration_count = _histogram_stats(histogram_child)
+
+    assert duration_sum == 0.2
+    assert duration_count == 1.0
+    assert counter_child._value.get() == 1.0


### PR DESCRIPTION
## Summary
- add MetricsPipelineHookImpl to record stage duration and totals
- wire metrics hook into pipeline container and rely on hook notifications instead of direct metric calls
- add unit tests covering success and failure metric recording

## Testing
- PYTHONPATH=src pytest tests/bioetl/application/pipelines/test_hooks_impl.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693417f3c4748324a266e71b5363d73c)