### PR TITLE
Add run context factory fixture for writer tests

### DIFF
--- a/tests/bioetl/infrastructure/output/test_metadata_builder.py
+++ b/tests/bioetl/infrastructure/output/test_metadata_builder.py
@@ -16,20 +16,13 @@ from bioetl.infrastructure.output.metadata import (
 )
 
 
-@pytest.fixture
-def run_context():
-    """Fixture for RunContext."""
-    return RunContext(
+def test_build_metadata(run_context_factory):
+    """Test building metadata from WriteResult."""
+    run_context = run_context_factory(
         run_id="test-run-123",
-        entity_name="test_entity",
-        provider="chembl",
         started_at=datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
         metadata={"extra_key": "extra_value"},
     )
-
-
-def test_build_metadata(run_context):
-    """Test building metadata from WriteResult."""
     write_result = WriteResult(
         path=Path("/tmp/out/test.csv"),
         row_count=100,
@@ -57,8 +50,13 @@ def test_build_metadata(run_context):
     _assert_checksums(meta)
 
 
-def test_build_dry_run_metadata(run_context):
+def test_build_dry_run_metadata(run_context_factory):
     """Test building metadata for dry run."""
+    run_context = run_context_factory(
+        run_id="test-run-123",
+        started_at=datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        metadata={"extra_key": "extra_value"},
+    )
     meta = build_dry_run_metadata(run_context, row_count=50)
 
     assert meta["run_id"] == "test-run-123"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,9 @@ Pytest configuration and shared fixtures.
 
 import socket
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 from unittest.mock import MagicMock, Mock
 
 import pandas as pd
@@ -19,6 +20,7 @@ from bioetl.config.pipeline_config_schema import (
     StorageConfig,
 )
 from bioetl.domain.validation.service import ValidationService
+from bioetl.domain.models import RunContext
 from bioetl.infrastructure.config.models import ChemblSourceConfig
 from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
 from bioetl.infrastructure.output.unified_writer import UnifiedOutputWriter
@@ -133,6 +135,33 @@ def mock_output_writer():
 def sample_df():
     """Create a sample DataFrame."""
     return pd.DataFrame({"id": [1, 2, 3], "value": ["a", "b", "c"]})
+
+
+@pytest.fixture
+def run_context_factory():
+    """Factory fixture to build RunContext with optional overrides."""
+
+    def _factory(
+        run_id: str = "test-run",
+        entity_name: str = "test_entity",
+        provider: str = "chembl",
+        started_at: datetime | None = None,
+        metadata: dict[str, Any] | None = None,
+        config: dict[str, Any] | None = None,
+        dry_run: bool = False,
+    ) -> RunContext:
+        return RunContext(
+            run_id=run_id,
+            entity_name=entity_name,
+            provider=provider,
+            started_at=started_at
+            or datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            metadata=metadata or {},
+            config=config or {},
+            dry_run=dry_run,
+        )
+
+    return _factory
 
 
 @pytest.fixture

--- a/tests/integration/test_unified_writer_integration.py
+++ b/tests/integration/test_unified_writer_integration.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from pathlib import Path
 
 import pandas as pd
@@ -10,7 +9,6 @@ import pytest
 import yaml
 
 from bioetl.config.pipeline_config_schema import DeterminismConfig, QcConfig
-from bioetl.domain.models import RunContext
 from bioetl.infrastructure.files.atomic import AtomicFileOperation
 from bioetl.infrastructure.output.impl.csv_writer import CsvWriterImpl
 from bioetl.infrastructure.output.impl.metadata_writer import MetadataWriterImpl
@@ -19,7 +17,7 @@ from bioetl.infrastructure.output.unified_writer import UnifiedOutputWriter
 
 
 @pytest.mark.integration
-def test_unified_writer_writes_data_and_meta(tmp_path):
+def test_unified_writer_writes_data_and_meta(tmp_path, run_context_factory):
     df = pd.DataFrame({"value": [3, 1, 2], "id": [2, 3, 1]})
     config = DeterminismConfig(stable_sort=True)
     qc_config = QcConfig(enable_quality_report=True, enable_correlation_report=True)
@@ -28,11 +26,7 @@ def test_unified_writer_writes_data_and_meta(tmp_path):
     quality_reporter = QualityReportImpl()
     atomic_op, calls = _with_tracking_atomic()
 
-    run_context = RunContext(
-        run_id="test-run",
-        entity_name="test_entity",
-        provider="chembl",
-        started_at=datetime.now(timezone.utc),
+    run_context = run_context_factory(
         config={"hashing": {"business_key_fields": ["id"]}},
     )
 


### PR DESCRIPTION
## Summary
- add reusable run_context_factory fixture to build RunContext with common defaults
- update writer-related tests to use the shared factory instead of local fixtures
- align integration test context creation with the shared fixture

## Testing
- pytest tests/bioetl/infrastructure/output/test_metadata_builder.py tests/bioetl/infrastructure/output/test_unified_writer.py tests/integration/test_unified_writer_integration.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934184c6ef88324b62f24e5f79c8358)