### PR TITLE
Refactor provider registry initialization

### DIFF
--- a/src/bioetl/domain/provider_registry.py
+++ b/src/bioetl/domain/provider_registry.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterable, Protocol
 
 from bioetl.domain.errors import ProviderError
 from bioetl.domain.providers import ProviderDefinition, ProviderId
@@ -11,9 +11,13 @@ __all__ = [
     "ProviderNotRegisteredError",
     "ProviderRegistryError",
     "ProviderAlreadyRegisteredError",
+    "ProviderRegistryABC",
+    "MutableProviderRegistryABC",
+    "InMemoryProviderRegistry",
+    "get_provider_registry",
+    "register_provider",
     "get_provider",
     "list_providers",
-    "register_provider",
     "reset_provider_registry",
     "restore_provider_registry",
 ]
@@ -40,41 +44,92 @@ class ProviderAlreadyRegisteredError(ProviderRegistryError):
         super().__init__(provider, f"Provider '{provider}' already registered")
 
 
-_PROVIDERS: dict[ProviderId, ProviderDefinition] = {}
+class ProviderRegistryABC(Protocol):
+    """Port defining read access to provider definitions."""
+
+    def get_provider(self, provider_id: ProviderId) -> ProviderDefinition:
+        """Fetch provider definition by id."""
+
+    def list_providers(self) -> list[ProviderDefinition]:
+        """Return all registered provider definitions."""
+
+
+class MutableProviderRegistryABC(ProviderRegistryABC, Protocol):
+    """Mutable port for registering provider definitions."""
+
+    def register_provider(self, definition: ProviderDefinition) -> None:
+        """Register a provider definition."""
+
+    def reset_provider_registry(self) -> None:
+        """Clear registry content (used for tests)."""
+
+    def restore_provider_registry(self, definitions: Iterable[ProviderDefinition]) -> None:
+        """Restore registry from supplied definitions."""
+
+
+class InMemoryProviderRegistry(MutableProviderRegistryABC):
+    """In-memory implementation of provider registry."""
+
+    def __init__(self) -> None:
+        self._providers: dict[ProviderId, ProviderDefinition] = {}
+
+    def register_provider(self, definition: ProviderDefinition) -> None:
+        if definition.id in self._providers:
+            raise ProviderAlreadyRegisteredError(definition.id.value)
+        self._providers[definition.id] = definition
+
+    def get_provider(self, provider_id: ProviderId) -> ProviderDefinition:
+        try:
+            return self._providers[provider_id]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise ProviderNotRegisteredError(provider_id.value) from exc
+
+    def list_providers(self) -> list[ProviderDefinition]:
+        return list(self._providers.values())
+
+    def reset_provider_registry(self) -> None:
+        self._providers.clear()
+
+    def restore_provider_registry(self, definitions: Iterable[ProviderDefinition]) -> None:
+        self.reset_provider_registry()
+        for definition in definitions:
+            self._providers[definition.id] = definition
+
+
+_PROVIDERS = InMemoryProviderRegistry()
+
+
+def get_provider_registry() -> ProviderRegistryABC:
+    """Return global provider registry instance."""
+
+    return _PROVIDERS
 
 
 def register_provider(definition: ProviderDefinition) -> None:
-    """Register provider definition in the registry."""
+    """Register provider definition in the global registry."""
 
-    if definition.id in _PROVIDERS:
-        raise ProviderAlreadyRegisteredError(definition.id.value)
-    _PROVIDERS[definition.id] = definition
+    _PROVIDERS.register_provider(definition)
 
 
 def get_provider(provider_id: ProviderId) -> ProviderDefinition:
-    """Get provider definition by id."""
+    """Get provider definition by id from global registry."""
 
-    try:
-        return _PROVIDERS[provider_id]
-    except KeyError as exc:  # pragma: no cover - defensive
-        raise ProviderNotRegisteredError(provider_id.value) from exc
+    return _PROVIDERS.get_provider(provider_id)
 
 
 def list_providers() -> list[ProviderDefinition]:
-    """List all registered provider definitions."""
+    """List all registered provider definitions from global registry."""
 
-    return list(_PROVIDERS.values())
+    return _PROVIDERS.list_providers()
 
 
 def reset_provider_registry() -> None:
-    """Clear registry (intended for test isolation)."""
+    """Clear global registry (intended for test isolation)."""
 
-    _PROVIDERS.clear()
+    _PROVIDERS.reset_provider_registry()
 
 
 def restore_provider_registry(definitions: Iterable[ProviderDefinition]) -> None:
-    """Restore registry to provided definitions (used in tests)."""
+    """Restore global registry to provided definitions (used in tests)."""
 
-    reset_provider_registry()
-    for definition in definitions:
-        _PROVIDERS[definition.id] = definition
+    _PROVIDERS.restore_provider_registry(definitions)

--- a/src/bioetl/interfaces/cli/app.py
+++ b/src/bioetl/interfaces/cli/app.py
@@ -11,6 +11,9 @@ from bioetl.application.config_loader import load_pipeline_config_from_path
 from bioetl.application.orchestrator import PipelineOrchestrator
 from bioetl.application.pipelines.registry import PIPELINE_REGISTRY
 from bioetl.config.pipeline_config_schema import MetricsConfig, PipelineConfig
+from bioetl.infrastructure.clients.provider_registry_loader import (
+    load_provider_registry,
+)
 from bioetl.infrastructure.observability.server import start_metrics_server_once
 
 app = typer.Typer(
@@ -150,9 +153,13 @@ def run(
         )
         config = PipelineConfig(**config_payload)
         _start_metrics_exporter(config.metrics)
+        provider_registry = load_provider_registry(
+            config_path=base_dir / "providers.yaml"
+        )
         orchestrator = PipelineOrchestrator(
             pipeline_name=pipeline_name,
             config=config,
+            provider_registry=provider_registry,
         )
 
         console.print(f"[bold green]Starting pipeline: {pipeline_name}[/bold green]")

--- a/src/bioetl/interfaces/mq/handler.py
+++ b/src/bioetl/interfaces/mq/handler.py
@@ -7,6 +7,9 @@ from dataclasses import dataclass
 from bioetl.application.config_loader import load_pipeline_config
 from bioetl.application.orchestrator import PipelineOrchestrator
 from bioetl.domain.models import RunResult
+from bioetl.infrastructure.clients.provider_registry_loader import (
+    load_provider_registry,
+)
 
 
 @dataclass
@@ -37,8 +40,11 @@ class MQJobHandler:
         if not config.features.mq_interface_enabled:
             raise RuntimeError("MQ interface is disabled by configuration")
 
+        registry = load_provider_registry()
         orchestrator = PipelineOrchestrator(
-            pipeline_name=job.pipeline_name, config=config
+            pipeline_name=job.pipeline_name,
+            config=config,
+            provider_registry=registry,
         )
         return orchestrator.run_pipeline(dry_run=job.dry_run, limit=job.limit)
 

--- a/src/bioetl/interfaces/rest/server.py
+++ b/src/bioetl/interfaces/rest/server.py
@@ -10,6 +10,9 @@ from pydantic import BaseModel, Field
 from bioetl.application.config_loader import load_pipeline_config
 from bioetl.application.orchestrator import PipelineOrchestrator
 from bioetl.domain.models import RunResult
+from bioetl.infrastructure.clients.provider_registry_loader import (
+    load_provider_registry,
+)
 
 
 class PipelineRunRequest(BaseModel):
@@ -54,7 +57,12 @@ def _create_orchestrator(pipeline_name: str, profile: str) -> PipelineOrchestrat
             status_code=503,
             detail="REST interface is disabled by configuration",
         )
-    return PipelineOrchestrator(pipeline_name=pipeline_name, config=config)
+    registry = load_provider_registry()
+    return PipelineOrchestrator(
+        pipeline_name=pipeline_name,
+        config=config,
+        provider_registry=registry,
+    )
 
 
 def _run_pipeline_sync(

--- a/tests/golden/test_chembl_activity_golden.py
+++ b/tests/golden/test_chembl_activity_golden.py
@@ -14,6 +14,9 @@ from bioetl.application.container import build_pipeline_dependencies
 from bioetl.application.pipelines.registry import get_pipeline_class
 from bioetl.application.services.chembl_extraction import ChemblExtractionServiceImpl
 from bioetl.infrastructure.config.resolver import ConfigResolver
+from bioetl.infrastructure.clients.provider_registry_loader import (
+    load_provider_registry,
+)
 
 sys.modules.setdefault("tqdm", MagicMock())
 
@@ -48,7 +51,11 @@ def test_chembl_activity_golden(tmp_path, monkeypatch):
     config = resolver.resolve("chembl_activity_test.yaml")
     config.storage.output_path = str(tmp_path / "output")
 
-    container = build_pipeline_dependencies(config)
+    registry = load_provider_registry()
+    container = build_pipeline_dependencies(
+        config,
+        provider_registry=registry,
+    )
     pipeline_cls = get_pipeline_class("activity_chembl")
     pipeline = pipeline_cls(
         config=config,

--- a/tests/integration/test_background_run.py
+++ b/tests/integration/test_background_run.py
@@ -6,6 +6,9 @@ import pytest
 
 from bioetl.application.config_loader import load_pipeline_config_from_path
 from bioetl.application.orchestrator import PipelineOrchestrator
+from bioetl.infrastructure.clients.provider_registry_loader import (
+    load_provider_registry,
+)
 
 
 @pytest.mark.integration
@@ -24,7 +27,10 @@ def test_run_in_background_dry_run(tmp_path):
     )
     config_copy = config.__class__(**payload)
 
-    orchestrator = PipelineOrchestrator("activity_chembl", config_copy)
+    registry = load_provider_registry()
+    orchestrator = PipelineOrchestrator(
+        "activity_chembl", config_copy, provider_registry=registry
+    )
 
     future = orchestrator.run_in_background(dry_run=True, limit=5)
     result = future.result()

--- a/tests/integration/test_chembl_activity_pipeline_integration.py
+++ b/tests/integration/test_chembl_activity_pipeline_integration.py
@@ -12,6 +12,9 @@ from bioetl.application.container import build_pipeline_dependencies
 from bioetl.application.pipelines.registry import get_pipeline_class
 from bioetl.application.services.chembl_extraction import ChemblExtractionServiceImpl
 from bioetl.infrastructure.config.resolver import ConfigResolver
+from bioetl.infrastructure.clients.provider_registry_loader import (
+    load_provider_registry,
+)
 
 sys.modules.setdefault("tqdm", MagicMock())
 
@@ -33,7 +36,11 @@ def test_chembl_activity_pipeline_smoke(tmp_path, monkeypatch):
     config = resolver.resolve("chembl_activity_test.yaml")
     config.storage.output_path = str(tmp_path / "output")
 
-    container = build_pipeline_dependencies(config)
+    registry = load_provider_registry()
+    container = build_pipeline_dependencies(
+        config,
+        provider_registry=registry,
+    )
     pipeline_cls = get_pipeline_class("activity_chembl")
     pipeline = pipeline_cls(
         config=config,


### PR DESCRIPTION
## Summary
- introduce provider registry abstraction with injectable in-memory implementation
- add helper to load provider registry explicitly and inject it into pipeline containers and orchestrator entrypoints
- update CLI, REST/MQ handlers, and tests to initialize the provider registry before building containers

## Testing
- pytest tests/integration/test_background_run.py::test_run_in_background_dry_run -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69341e671dbc8324b2cc618924240d82)