### PR TITLE
Refactor provider registry loader

### DIFF
--- a/src/bioetl/application/config_loader.py
+++ b/src/bioetl/application/config_loader.py
@@ -9,7 +9,7 @@ import yaml
 from pydantic import ValidationError
 
 from bioetl.config.pipeline_config_schema import PipelineConfig
-from bioetl.config.provider_registry import (
+from bioetl.infrastructure.config.provider_registry_loader import (
     ProviderNotConfiguredError,
     ProviderRegistryError,
     ProviderRegistryFormatError,

--- a/src/bioetl/config/pipeline_config_schema.py
+++ b/src/bioetl/config/pipeline_config_schema.py
@@ -15,7 +15,10 @@ from pydantic import (
 )
 
 from bioetl.config.provider_config_schema import BaseProviderConfig, ProviderConfigUnion
-from bioetl.config.provider_registry import ProviderRegistryError, ensure_provider_known
+from bioetl.infrastructure.config.provider_registry_loader import (
+    ProviderRegistryError,
+    ensure_provider_known,
+)
 from bioetl.domain.transform.contracts import NormalizationConfigProvider
 
 

--- a/src/bioetl/config/provider_config_schema.py
+++ b/src/bioetl/config/provider_config_schema.py
@@ -14,7 +14,7 @@ from pydantic import (
 )
 from pydantic.types import NonNegativeInt
 
-from bioetl.config.provider_registry import (
+from bioetl.infrastructure.config.provider_registry_loader import (
     ProviderRegistryError,
     ensure_provider_known,
 )

--- a/src/bioetl/config/provider_registry.py
+++ b/src/bioetl/config/provider_registry.py
@@ -1,15 +1,16 @@
-"""Provider registry loader based on configuration YAML."""
+"""Provider registry contract delegating to infrastructure loader."""
 
 from __future__ import annotations
 
-from functools import lru_cache
-from pathlib import Path
-from typing import Any
-
-import yaml
-
-DEFAULT_CONFIGS_ROOT = Path("configs")
-DEFAULT_PROVIDERS_REGISTRY_PATH = DEFAULT_CONFIGS_ROOT / "providers.yaml"
+from bioetl.infrastructure.config.provider_registry_loader import (
+    DEFAULT_PROVIDERS_REGISTRY_PATH,
+    ProviderNotConfiguredError,
+    ProviderRegistryError,
+    ProviderRegistryFormatError,
+    ProviderRegistryNotFoundError,
+    clear_provider_registry_cache,
+    ensure_provider_known,
+)
 
 __all__ = [
     "DEFAULT_PROVIDERS_REGISTRY_PATH",
@@ -20,110 +21,3 @@ __all__ = [
     "clear_provider_registry_cache",
     "ensure_provider_known",
 ]
-
-
-class ProviderRegistryError(Exception):
-    """Base error for provider registry issues."""
-
-
-class ProviderRegistryNotFoundError(ProviderRegistryError):
-    """Registry file is missing."""
-
-    def __init__(self, registry_path: Path) -> None:
-        self.registry_path = registry_path
-        super().__init__(f"Providers registry not found: {registry_path}")
-
-
-class ProviderRegistryFormatError(ProviderRegistryError):
-    """Registry file has invalid structure."""
-
-    def __init__(self, registry_path: Path, message: str) -> None:
-        self.registry_path = registry_path
-        super().__init__(f"{registry_path}: {message}")
-
-
-class ProviderNotConfiguredError(ProviderRegistryError):
-    """Requested provider is absent in registry."""
-
-    def __init__(self, provider: str, registry_path: Path) -> None:
-        self.provider = provider
-        self.registry_path = registry_path
-        super().__init__(
-            f"Provider '{provider}' is not configured in registry {registry_path}"
-        )
-
-
-def ensure_provider_known(provider: str, *, registry_path: Path | None = None) -> str:
-    """Validate that provider exists in registry and return it back."""
-
-    path = registry_path or DEFAULT_PROVIDERS_REGISTRY_PATH
-    registry = _load_provider_registry(path)
-    if provider not in registry and provider not in _list_runtime_providers():
-        raise ProviderNotConfiguredError(provider, path)
-    return provider
-
-
-def clear_provider_registry_cache() -> None:
-    """Reset cached registry content (used in tests)."""
-
-    _load_provider_registry.cache_clear()
-
-
-def _read_registry_data(registry_path: Path) -> Any:
-    if not registry_path.exists():
-        raise ProviderRegistryNotFoundError(registry_path)
-
-    with registry_path.open("r", encoding="utf-8") as file:
-        return yaml.safe_load(file) or {}
-
-
-def _parse_registry_data(data: Any, registry_path: Path) -> set[str]:
-    if not isinstance(data, dict):
-        raise ProviderRegistryFormatError(registry_path, "YAML root must be a mapping")
-
-    providers = data.get("providers")
-    if providers is None:
-        return set()
-    if not isinstance(providers, list):
-        raise ProviderRegistryFormatError(
-            registry_path,
-            "'providers' must be a list",
-        )
-
-    return _collect_provider_ids(providers, registry_path)
-
-
-def _collect_provider_ids(providers: list[Any], registry_path: Path) -> set[str]:
-    registry: set[str] = set()
-    for provider in providers:
-        registry.add(_normalize_provider_entry(provider, registry_path))
-    return registry
-
-
-def _normalize_provider_entry(provider: Any, registry_path: Path) -> str:
-    if isinstance(provider, str):
-        return provider
-    if isinstance(provider, dict):
-        provider_id = provider.get("id")
-        if provider_id is None:
-            raise ProviderRegistryFormatError(
-                registry_path,
-                "Provider entry must have 'id' field",
-            )
-        return str(provider_id)
-    raise ProviderRegistryFormatError(
-        registry_path,
-        ("Provider entry must be string or dict, " f"got {type(provider).__name__}"),
-    )
-
-
-@lru_cache(maxsize=None)
-def _load_provider_registry(registry_path: Path) -> set[str]:
-    data: Any = _read_registry_data(registry_path)
-    return _parse_registry_data(data, registry_path)
-
-
-def _list_runtime_providers() -> set[str]:
-    from bioetl.domain.provider_registry import list_providers
-
-    return {definition.id.value for definition in list_providers()}

--- a/src/bioetl/infrastructure/config/provider_registry_loader.py
+++ b/src/bioetl/infrastructure/config/provider_registry_loader.py
@@ -1,0 +1,129 @@
+"""Infrastructure loader for provider registry configuration."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+DEFAULT_CONFIGS_ROOT = Path("configs")
+DEFAULT_PROVIDERS_REGISTRY_PATH = DEFAULT_CONFIGS_ROOT / "providers.yaml"
+
+__all__ = [
+    "DEFAULT_PROVIDERS_REGISTRY_PATH",
+    "ProviderNotConfiguredError",
+    "ProviderRegistryError",
+    "ProviderRegistryFormatError",
+    "ProviderRegistryNotFoundError",
+    "clear_provider_registry_cache",
+    "ensure_provider_known",
+]
+
+
+class ProviderRegistryError(Exception):
+    """Base error for provider registry issues."""
+
+
+class ProviderRegistryNotFoundError(ProviderRegistryError):
+    """Registry file is missing."""
+
+    def __init__(self, registry_path: Path) -> None:
+        self.registry_path = registry_path
+        super().__init__(f"Providers registry not found: {registry_path}")
+
+
+class ProviderRegistryFormatError(ProviderRegistryError):
+    """Registry file has invalid structure."""
+
+    def __init__(self, registry_path: Path, message: str) -> None:
+        self.registry_path = registry_path
+        super().__init__(f"{registry_path}: {message}")
+
+
+class ProviderNotConfiguredError(ProviderRegistryError):
+    """Requested provider is absent in registry."""
+
+    def __init__(self, provider: str, registry_path: Path) -> None:
+        self.provider = provider
+        self.registry_path = registry_path
+        super().__init__(
+            f"Provider '{provider}' is not configured in registry {registry_path}"
+        )
+
+
+def ensure_provider_known(provider: str, *, registry_path: Path | None = None) -> str:
+    """Validate that provider exists in registry and return it back."""
+
+    path = registry_path or DEFAULT_PROVIDERS_REGISTRY_PATH
+    registry = _load_provider_registry(path)
+    if provider not in registry and provider not in _list_runtime_providers():
+        raise ProviderNotConfiguredError(provider, path)
+    return provider
+
+
+def clear_provider_registry_cache() -> None:
+    """Reset cached registry content (used in tests)."""
+
+    _load_provider_registry.cache_clear()
+
+
+def _read_registry_data(registry_path: Path) -> Any:
+    if not registry_path.exists():
+        raise ProviderRegistryNotFoundError(registry_path)
+
+    with registry_path.open("r", encoding="utf-8") as file:
+        return yaml.safe_load(file) or {}
+
+
+def _parse_registry_data(data: Any, registry_path: Path) -> set[str]:
+    if not isinstance(data, dict):
+        raise ProviderRegistryFormatError(registry_path, "YAML root must be a mapping")
+
+    providers = data.get("providers")
+    if providers is None:
+        return set()
+    if not isinstance(providers, list):
+        raise ProviderRegistryFormatError(
+            registry_path,
+            "'providers' must be a list",
+        )
+
+    return _collect_provider_ids(providers, registry_path)
+
+
+def _collect_provider_ids(providers: list[Any], registry_path: Path) -> set[str]:
+    registry: set[str] = set()
+    for provider in providers:
+        registry.add(_normalize_provider_entry(provider, registry_path))
+    return registry
+
+
+def _normalize_provider_entry(provider: Any, registry_path: Path) -> str:
+    if isinstance(provider, str):
+        return provider
+    if isinstance(provider, dict):
+        provider_id = provider.get("id")
+        if provider_id is None:
+            raise ProviderRegistryFormatError(
+                registry_path,
+                "Provider entry must have 'id' field",
+            )
+        return str(provider_id)
+    raise ProviderRegistryFormatError(
+        registry_path,
+        ("Provider entry must be string or dict, " f"got {type(provider).__name__}"),
+    )
+
+
+@lru_cache(maxsize=None)
+def _load_provider_registry(registry_path: Path) -> set[str]:
+    data: Any = _read_registry_data(registry_path)
+    return _parse_registry_data(data, registry_path)
+
+
+def _list_runtime_providers() -> set[str]:
+    from bioetl.domain.provider_registry import list_providers
+
+    return {definition.id.value for definition in list_providers()}


### PR DESCRIPTION
## Summary
- add infrastructure provider registry loader handling YAML parsing and caching
- keep config provider registry module as thin alias to the infrastructure loader
- update modules to import provider registry validation from the new infrastructure path

## Testing
- pytest tests/bioetl/application/test_container_provider_registration.py (fails: PipelineContainer stub creation lacks `_register_providers` when bypassing `__init__`)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69342434ceb08324b89c24b9c8a317b3)