### PR TITLE
Move input path validation to loader

### DIFF
--- a/src/bioetl/application/config_loader.py
+++ b/src/bioetl/application/config_loader.py
@@ -98,6 +98,7 @@ def load_pipeline_config_from_path(
     _validate_provider(merged_config, path)
 
     merged_config = _transform_legacy_config(merged_config, path)
+    _validate_input_path_exists(merged_config, path)
 
     try:
         return PipelineConfig.model_validate(merged_config)
@@ -269,6 +270,18 @@ def _load_yaml(path: Path) -> dict[str, Any]:
     if not isinstance(data, dict):
         raise ConfigValidationError(path, "YAML root must be a mapping")
     return data
+
+
+def _validate_input_path_exists(config: dict[str, Any], config_path: Path) -> None:
+    input_path = config.get("input_path")
+    if input_path is None or input_path == "":
+        return
+
+    input_path_obj = Path(str(input_path))
+    if not input_path_obj.exists():
+        raise ConfigValidationError(config_path, f"Input path does not exist: {input_path}")
+
+    config["input_path"] = str(input_path_obj)
 
 
 __all__ = [

--- a/src/bioetl/config/pipeline_config_schema.py
+++ b/src/bioetl/config/pipeline_config_schema.py
@@ -243,8 +243,6 @@ class PipelineConfig(BaseModel):
         if value is None or value == "":
             return None
         path = Path(value)
-        if not path.exists():
-            raise ValueError(f"Input path does not exist: {value}")
         return str(path)
 
     @model_validator(mode="after")

--- a/tests/bioetl/domain/test_config_loader.py
+++ b/tests/bioetl/domain/test_config_loader.py
@@ -42,6 +42,30 @@ def test_missing_config_file_raises():
         load_pipeline_config_from_path(Path("tests/fixtures/configs/missing.yaml"))
 
 
+def test_load_pipeline_config_from_path_missing_input_path(tmp_path: Path) -> None:
+    config_path = tmp_path / "chembl_activity.yaml"
+    config_path.write_text(
+        """id: chembl.activity
+provider: chembl
+entity: activity
+input_mode: csv
+input_path: ./does_not_exist.csv
+output_path: /tmp/out
+batch_size: 5
+provider_config:
+  provider: chembl
+  base_url: https://www.ebi.ac.uk/chembl/api/data
+  timeout_sec: 30
+  max_retries: 3
+  rate_limit_per_sec: 10.0
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ConfigValidationError):
+        load_pipeline_config_from_path(config_path)
+
+
 def test_unknown_provider_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     pipelines_root = tmp_path / "pipelines"
     profiles_root = tmp_path / "profiles"


### PR DESCRIPTION
## Summary
- normalize input_path in the schema without enforcing filesystem existence
- add input path existence validation to the config loader before constructing PipelineConfig
- cover missing input path handling with a dedicated unit test

## Testing
- pytest tests/bioetl/domain/test_config_loader.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69342426cecc83249995f37ed9662b6a)