### PR TITLE
Validate providers.yaml through pydantic schema

### DIFF
--- a/src/bioetl/infrastructure/config/provider_registry_loader.py
+++ b/src/bioetl/infrastructure/config/provider_registry_loader.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 DEFAULT_CONFIGS_ROOT = Path("configs")
 DEFAULT_PROVIDERS_REGISTRY_PATH = DEFAULT_CONFIGS_ROOT / "providers.yaml"
@@ -49,8 +50,31 @@ class ProviderNotConfiguredError(ProviderRegistryError):
         self.provider = provider
         self.registry_path = registry_path
         super().__init__(
-            f"Provider '{provider}' is not configured in registry {registry_path}"
+            (
+                "Provider '{provider}' is not configured in providers config "
+                "{registry_path}"
+            ).format(provider=provider, registry_path=registry_path)
         )
+
+
+class ProviderRegistryEntryModel(BaseModel):
+    """Single provider entry from providers.yaml."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    module: str
+    factory: str
+    active: bool = True
+    description: str | None = None
+
+
+class ProviderRegistryModel(BaseModel):
+    """Validated providers.yaml content."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    providers: list[ProviderRegistryEntryModel] = []
 
 
 def ensure_provider_known(provider: str, *, registry_path: Path | None = None) -> str:
@@ -62,11 +86,9 @@ def ensure_provider_known(provider: str, *, registry_path: Path | None = None) -
 
     path = registry_path or DEFAULT_PROVIDERS_REGISTRY_PATH
     registry = _load_provider_registry(path)
-    if provider in registry:
-        return provider
+    registered_ids = {entry.id for entry in registry.providers if entry.active}
 
-    # Разрешаем fallback на рантайм только когда используется дефолтный реестр
-    if registry_path is None and provider in _list_runtime_providers():
+    if provider in registered_ids:
         return provider
 
     raise ProviderNotConfiguredError(provider, path)
@@ -86,53 +108,10 @@ def _read_registry_data(registry_path: Path) -> Any:
         return yaml.safe_load(file) or {}
 
 
-def _parse_registry_data(data: Any, registry_path: Path) -> set[str]:
-    if not isinstance(data, dict):
-        raise ProviderRegistryFormatError(registry_path, "YAML root must be a mapping")
-
-    providers = data.get("providers")
-    if providers is None:
-        return set()
-    if not isinstance(providers, list):
-        raise ProviderRegistryFormatError(
-            registry_path,
-            "'providers' must be a list",
-        )
-
-    return _collect_provider_ids(providers, registry_path)
-
-
-def _collect_provider_ids(providers: list[Any], registry_path: Path) -> set[str]:
-    registry: set[str] = set()
-    for provider in providers:
-        registry.add(_normalize_provider_entry(provider, registry_path))
-    return registry
-
-
-def _normalize_provider_entry(provider: Any, registry_path: Path) -> str:
-    if isinstance(provider, str):
-        return provider
-    if isinstance(provider, dict):
-        provider_id = provider.get("id")
-        if provider_id is None:
-            raise ProviderRegistryFormatError(
-                registry_path,
-                "Provider entry must have 'id' field",
-            )
-        return str(provider_id)
-    raise ProviderRegistryFormatError(
-        registry_path,
-        ("Provider entry must be string or dict, " f"got {type(provider).__name__}"),
-    )
-
-
 @lru_cache(maxsize=None)
-def _load_provider_registry(registry_path: Path) -> set[str]:
+def _load_provider_registry(registry_path: Path) -> ProviderRegistryModel:
     data: Any = _read_registry_data(registry_path)
-    return _parse_registry_data(data, registry_path)
-
-
-def _list_runtime_providers() -> set[str]:
-    from bioetl.domain.provider_registry import list_providers
-
-    return {definition.id.value for definition in list_providers()}
+    try:
+        return ProviderRegistryModel.model_validate(data)
+    except ValidationError as exc:
+        raise ProviderRegistryFormatError(registry_path, exc.__str__()) from exc

--- a/tests/bioetl/application/test_container.py
+++ b/tests/bioetl/application/test_container.py
@@ -70,7 +70,20 @@ def _patch_provider_registry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     """
 
     providers_file = tmp_path / "providers.yaml"
-    providers_file.write_text("providers:\n  - chembl\n  - dummy\n", encoding="utf-8")
+    providers_file.write_text(
+        (
+            "providers:\n"
+            "  - id: chembl\n"
+            "    module: tests.dummy\n"
+            "    factory: create_chembl\n"
+            "    active: true\n"
+            "  - id: dummy\n"
+            "    module: tests.dummy\n"
+            "    factory: create_dummy\n"
+            "    active: true\n"
+        ),
+        encoding="utf-8",
+    )
     monkeypatch.setattr(
         config_provider_registry, "DEFAULT_PROVIDERS_REGISTRY_PATH", providers_file
     )

--- a/tests/bioetl/domain/test_config_loader.py
+++ b/tests/bioetl/domain/test_config_loader.py
@@ -100,7 +100,16 @@ def test_provider_registry_allows_known_provider(
 ) -> None:
     base_dir = tmp_path
     providers_file = base_dir / "providers.yaml"
-    providers_file.write_text("providers:\n  - chembl\n", encoding="utf-8")
+    providers_file.write_text(
+        (
+            "providers:\n"
+            "  - id: chembl\n"
+            "    module: tests.dummy\n"
+            "    factory: create_chembl\n"
+            "    active: true\n"
+        ),
+        encoding="utf-8",
+    )
 
     pipelines_root = base_dir / "pipelines"
     profiles_root = base_dir / "profiles"
@@ -144,7 +153,16 @@ def test_provider_registry_rejects_missing_provider(
 ) -> None:
     base_dir = tmp_path
     providers_file = base_dir / "providers.yaml"
-    providers_file.write_text("providers:\n  - dummy\n", encoding="utf-8")
+    providers_file.write_text(
+        (
+            "providers:\n"
+            "  - id: dummy\n"
+            "    module: tests.dummy\n"
+            "    factory: create_dummy\n"
+            "    active: true\n"
+        ),
+        encoding="utf-8",
+    )
 
     pipelines_root = base_dir / "pipelines"
     profiles_root = base_dir / "profiles"

--- a/tests/bioetl/domain/test_container.py
+++ b/tests/bioetl/domain/test_container.py
@@ -72,7 +72,20 @@ def _patch_provider_registry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     """
 
     providers_file = tmp_path / "providers.yaml"
-    providers_file.write_text("providers:\n  - chembl\n  - dummy\n", encoding="utf-8")
+    providers_file.write_text(
+        (
+            "providers:\n"
+            "  - id: chembl\n"
+            "    module: tests.dummy\n"
+            "    factory: create_chembl\n"
+            "    active: true\n"
+            "  - id: dummy\n"
+            "    module: tests.dummy\n"
+            "    factory: create_dummy\n"
+            "    active: true\n"
+        ),
+        encoding="utf-8",
+    )
     monkeypatch.setattr(
         config_provider_registry, "DEFAULT_PROVIDERS_REGISTRY_PATH", providers_file
     )

--- a/tests/bioetl/infrastructure/config/test_resolver.py
+++ b/tests/bioetl/infrastructure/config/test_resolver.py
@@ -25,7 +25,16 @@ def _reset_registry() -> None:
     clear_provider_registry_cache()
 
 
-def _write_providers(path: Path, content: str = "providers:\n  - chembl\n") -> None:
+def _write_providers(
+    path: Path,
+    content: str = (
+        "providers:\n"
+        "  - id: chembl\n"
+        "    module: tests.dummy\n"
+        "    factory: create_chembl\n"
+        "    active: true\n"
+    ),
+) -> None:
     path.write_text(content, encoding="utf-8")
 
 


### PR DESCRIPTION
## Summary
- validate providers.yaml using a pydantic schema instead of runtime registry fallback
- improve provider-not-configured error messaging and rely solely on config entries
- update tests and fixtures to use structured provider definitions

## Testing
- PYTHONPATH=src pytest tests/bioetl/infrastructure/config/test_resolver.py tests/bioetl/domain/test_config_loader.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69342d93632c832488b0fc4f5440bc92)