### PR TITLE
Introduce pipeline container ABC and update orchestrator typing

### DIFF
--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -8,6 +8,7 @@ from bioetl.application.pipelines.hooks_impl import (
     LoggingPipelineHookImpl,
     MetricsPipelineHookImpl,
 )
+from bioetl.application.pipelines.contracts import PipelineContainerABC
 from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
 from bioetl.domain.provider_registry import (
@@ -41,7 +42,7 @@ from bioetl.infrastructure.output.factories import (
 from bioetl.infrastructure.output.unified_writer import UnifiedOutputWriter
 
 
-class PipelineContainer:
+class PipelineContainer(PipelineContainerABC):
     """
     DI Container for pipeline dependencies.
     """
@@ -58,8 +59,8 @@ class PipelineContainer:
         provider_registry: ProviderRegistryABC | None = None,
         provider_registry_provider: Callable[[], ProviderRegistryABC] | None = None,
     ) -> None:
-        self.config = config
-        self._provider_id = ProviderId(self.config.provider)
+        self._config = config
+        self._provider_id = ProviderId(self._config.provider)
         self._schema_registry = SchemaRegistry()
         self._logger: LoggerAdapterABC | None = logger
         self._hooks: list[PipelineHookABC] | None = list(hooks) if hooks else None
@@ -69,6 +70,10 @@ class PipelineContainer:
         self._provider_registry = provider_registry
         self._provider_registry_provider = provider_registry_provider
         register_schemas(self._schema_registry)
+
+    @property
+    def config(self) -> PipelineConfig:
+        return self._config
 
     def get_logger(self) -> LoggerAdapterABC:
         """Get the configured logger."""
@@ -86,8 +91,8 @@ class PipelineContainer:
             writer=default_writer(),
             metadata_writer=default_metadata_writer(),
             quality_reporter=default_quality_reporter(),
-            config=self.config.determinism,
-            qc_config=self.config.qc,
+            config=self._config.determinism,
+            qc_config=self._config.qc,
         )
 
     def get_normalization_service(self) -> NormalizationServiceABC:
@@ -105,7 +110,7 @@ class PipelineContainer:
             raise ValueError(
                 f"Unsupported provider for normalization: {self._provider_id.value}"
             )
-        return factory(source_config, pipeline_config=self.config)
+        return factory(source_config, pipeline_config=self._config)
 
     def get_record_source(
         self,
@@ -115,8 +120,8 @@ class PipelineContainer:
         logger: LoggerAdapterABC | None = None,
     ) -> RecordSource:
         """Create record source based on pipeline input configuration."""
-        mode = self.config.input_mode
-        path = self.config.input_path
+        mode = self._config.input_mode
+        path = self._config.input_path
 
         if mode == "auto_detect" and path:
             mode = "csv"
@@ -128,7 +133,7 @@ class PipelineContainer:
                 raise ValueError("input_path is required for CSV mode")
             return CsvRecordSourceImpl(
                 input_path=Path(path),
-                csv_options=self.config.csv_options,
+                csv_options=self._config.csv_options,
                 limit=limit,
                 logger=effective_logger,
             )
@@ -143,24 +148,24 @@ class PipelineContainer:
             return IdListRecordSourceImpl(
                 input_path=Path(path),
                 id_column=id_column,
-                csv_options=self.config.csv_options,
+                csv_options=self._config.csv_options,
                 limit=limit,
                 extraction_service=extraction_service,
                 source_config=source_config,
-                entity=self.config.entity_name,
+                entity=self._config.entity_name,
                 filter_key=filter_key,
                 logger=effective_logger,
             )
 
-        filters = self.config.pipeline.copy()
+        filters = self._config.pipeline.copy()
         if limit is not None:
             filters["limit"] = limit
 
         return ApiRecordSource(
             extraction_service=extraction_service,
-            entity=self.config.entity_name,
+            entity=self._config.entity_name,
             filters=filters,
-            chunk_size=self.config.batch_size,
+            chunk_size=self._config.batch_size,
         )
 
     def get_extraction_service(self) -> Any:
@@ -186,7 +191,7 @@ class PipelineContainer:
         if self._post_transformer is None:
             self._post_transformer = default_post_transformer(
                 hash_service=self.get_hash_service(),
-                business_key_fields=self.config.hashing.business_key_fields,
+                business_key_fields=self._config.hashing.business_key_fields,
                 version_provider=version_provider,
             )
         return self._post_transformer
@@ -197,9 +202,9 @@ class PipelineContainer:
             self._hooks = [
                 LoggingPipelineHookImpl(self.get_logger()),
                 MetricsPipelineHookImpl(
-                    pipeline_id=self.config.id,
+                    pipeline_id=self._config.id,
                     provider=self._provider_id.value,
-                    entity_name=self.config.entity_name,
+                    entity_name=self._config.entity_name,
                 ),
             ]
         return list(self._hooks)
@@ -211,14 +216,14 @@ class PipelineContainer:
         return self._error_policy
 
     def _resolve_primary_key(self) -> str:
-        pk = self.config.primary_key
-        if not pk and self.config.pipeline and "primary_key" in self.config.pipeline:
-            pk = self.config.pipeline["primary_key"]
+        pk = self._config.primary_key
+        if not pk and self._config.pipeline and "primary_key" in self._config.pipeline:
+            pk = self._config.pipeline["primary_key"]
         if not pk:
-            pk = f"{self.config.entity_name}_id"
+            pk = f"{self._config.entity_name}_id"
         if not pk:
             raise ValueError(
-                f"Could not resolve primary key for entity '{self.config.entity_name}'"
+                f"Could not resolve primary key for entity '{self._config.entity_name}'"
             )
         return pk
 
@@ -235,7 +240,7 @@ class PipelineContainer:
         return self._provider_registry
 
     def _resolve_provider_config(self, definition: ProviderDefinition) -> Any:
-        source_config = self.config.get_source_config(self._provider_id.value)
+        source_config = self._config.get_source_config(self._provider_id.value)
         if not isinstance(source_config, definition.config_type):
             raise TypeError(
                 f"Expected config type {definition.config_type.__name__} for "
@@ -273,7 +278,7 @@ def build_pipeline_dependencies(
     post_transformer: TransformerABC | None = None,
     provider_registry: ProviderRegistryABC | None = None,
     provider_registry_provider: Callable[[], ProviderRegistryABC] | None = None,
-) -> PipelineContainer:
+) -> PipelineContainerABC:
     """Factory for the container."""
     return PipelineContainer(
         config,

--- a/src/bioetl/application/orchestrator.py
+++ b/src/bioetl/application/orchestrator.py
@@ -4,7 +4,8 @@ from concurrent.futures import Future, ProcessPoolExecutor
 from pathlib import Path
 from typing import Callable, cast
 
-from bioetl.application.container import PipelineContainer, build_pipeline_dependencies
+from bioetl.application.container import build_pipeline_dependencies
+from bioetl.application.pipelines.contracts import PipelineContainerABC
 from bioetl.application.pipelines.base import PipelineBase
 from bioetl.application.pipelines.registry import get_pipeline_class
 from bioetl.domain.configs import PipelineConfig
@@ -25,7 +26,7 @@ class PipelineOrchestrator:
         *,
         provider_registry: ProviderRegistryABC | None = None,
         provider_registry_provider: Callable[[], ProviderRegistryABC] | None = None,
-        container_factory: Callable[..., PipelineContainer] | None = None,
+        container_factory: Callable[..., PipelineContainerABC] | None = None,
     ) -> None:
         self._pipeline_name = pipeline_name
         self._config = config
@@ -36,7 +37,7 @@ class PipelineOrchestrator:
     def build_pipeline(self, *, limit: int | None = None) -> PipelineBase:
         """Создает экземпляр пайплайна с зависимостями."""
         pipeline_cls = get_pipeline_class(self._pipeline_name)
-        container = self._container_factory(
+        container: PipelineContainerABC = self._container_factory(
             self._config,
             provider_registry=self._provider_registry,
             provider_registry_provider=self._provider_registry_provider,

--- a/src/bioetl/application/pipelines/chembl/factories.py
+++ b/src/bioetl/application/pipelines/chembl/factories.py
@@ -2,11 +2,11 @@
 Factories for ChEMBL pipelines.
 """
 
-from bioetl.application.container import PipelineContainer
+from bioetl.application.pipelines.contracts import PipelineContainerABC
 from bioetl.application.pipelines.chembl.pipeline import ChemblEntityPipeline
 
 
-def create_chembl_pipeline(container: PipelineContainer) -> ChemblEntityPipeline:
+def create_chembl_pipeline(container: PipelineContainerABC) -> ChemblEntityPipeline:
     """
     Creates a ChEMBL entity pipeline using dependencies from container.
 

--- a/src/bioetl/application/pipelines/contracts.py
+++ b/src/bioetl/application/pipelines/contracts.py
@@ -3,9 +3,19 @@ Contracts for pipeline components.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable
 
 import pandas as pd
+
+from bioetl.domain.configs import PipelineConfig
+from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
+from bioetl.domain.transform.contracts import NormalizationServiceABC
+from bioetl.domain.transform.hash_service import HashService
+from bioetl.domain.transform.transformers import TransformerABC
+from bioetl.domain.validation.service import ValidationService
+from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
+from bioetl.infrastructure.output.unified_writer import UnifiedOutputWriter
+from bioetl.domain.record_source import RecordSource
 
 
 class ExtractorABC(ABC):
@@ -30,3 +40,73 @@ class LoaderABC(ABC):
         """
         Loads data to destination.
         """
+
+
+class PipelineContainerABC(ABC):
+    """
+    Dependency container contract for assembling pipelines.
+
+    Provides factories for core pipeline services, including logging, validation,
+    extraction, normalization, record sourcing, hashing, post-transformation,
+    hooks, and error handling.
+    """
+
+    @property
+    @abstractmethod
+    def config(self) -> PipelineConfig:
+        """Pipeline configuration associated with the container."""
+
+    @abstractmethod
+    def get_logger(self) -> LoggerAdapterABC:
+        """Return configured logger adapter for pipeline run."""
+
+    @abstractmethod
+    def get_validation_service(self) -> ValidationService:
+        """Return validation service bound to registered schemas."""
+
+    @abstractmethod
+    def get_output_writer(self) -> UnifiedOutputWriter:
+        """Return unified writer for data, metadata and QC outputs."""
+
+    @abstractmethod
+    def get_extraction_service(self) -> Any:
+        """Return extraction service for the configured provider."""
+
+    @abstractmethod
+    def get_normalization_service(self) -> NormalizationServiceABC:
+        """Return normalization service for the configured provider."""
+
+    @abstractmethod
+    def get_record_source(
+        self,
+        extraction_service: Any,
+        *,
+        limit: int | None = None,
+        logger: LoggerAdapterABC | None = None,
+    ) -> RecordSource:
+        """Return record source for pipeline input according to config."""
+
+    @abstractmethod
+    def get_hash_service(self) -> HashService:
+        """Return hash service used for checksum generation."""
+
+    @abstractmethod
+    def get_post_transformer(
+        self, *, version_provider: Callable[[], str] | None = None
+    ) -> TransformerABC:
+        """Return configured post-transformer chain."""
+
+    @abstractmethod
+    def get_hooks(self) -> list[PipelineHookABC]:
+        """Return pipeline execution hooks."""
+
+    @abstractmethod
+    def get_error_policy(self) -> ErrorPolicyABC:
+        """Return error handling policy for pipeline stages."""
+
+
+__all__ = [
+    "ExtractorABC",
+    "LoaderABC",
+    "PipelineContainerABC",
+]

--- a/tests/bioetl/application/test_pipeline_container_contract.py
+++ b/tests/bioetl/application/test_pipeline_container_contract.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from bioetl.application.container import PipelineContainer
+from bioetl.application.orchestrator import PipelineOrchestrator
+from bioetl.application.pipelines.contracts import PipelineContainerABC
+from bioetl.domain.configs import DummyProviderConfig, PipelineConfig
+
+
+class StubContainer(PipelineContainerABC):
+    def __init__(self, config: PipelineConfig) -> None:
+        self._config = config
+        self.record_source_calls: list[dict[str, Any]] = []
+        self.post_transformer_version: str | None = None
+
+    @property
+    def config(self) -> PipelineConfig:
+        return self._config
+
+    def get_logger(self) -> str:
+        return "logger"
+
+    def get_validation_service(self) -> str:
+        return "validation"
+
+    def get_output_writer(self) -> str:
+        return "writer"
+
+    def get_extraction_service(self) -> str:
+        return "extraction"
+
+    def get_normalization_service(self) -> str:
+        return "normalization"
+
+    def get_record_source(
+        self,
+        extraction_service: Any,
+        *,
+        limit: int | None = None,
+        logger: Any | None = None,
+    ) -> str:
+        self.record_source_calls.append({"limit": limit, "logger": logger})
+        return "record_source"
+
+    def get_hash_service(self) -> str:
+        return "hash"
+
+    def get_post_transformer(
+        self, *, version_provider: Callable[[], str] | None = None
+    ) -> str:
+        if version_provider:
+            self.post_transformer_version = version_provider()
+        return "post_transformer"
+
+    def get_hooks(self) -> list[str]:
+        return ["hook"]
+
+    def get_error_policy(self) -> str:
+        return "error_policy"
+
+
+class DummyPipeline:
+    def __init__(self, **deps: Any) -> None:
+        self.dependencies = deps
+        self.post_transformer: Any | None = None
+        self.hooks: list[Any] = []
+        self.error_policy: Any | None = None
+
+    def set_post_transformer(self, transformer: Any) -> None:
+        self.post_transformer = transformer
+
+    def add_hooks(self, hooks: list[Any]) -> None:
+        self.hooks.extend(hooks)
+
+    def set_error_policy(self, error_policy: Any) -> None:
+        self.error_policy = error_policy
+
+    def get_version(self) -> str:
+        return "pipeline-version"
+
+
+def _build_config() -> PipelineConfig:
+    return PipelineConfig(
+        id="dummy.entity",
+        provider="dummy",
+        entity="entity",
+        input_mode="auto_detect",
+        input_path=None,
+        output_path="/tmp/out",
+        batch_size=10,
+        provider_config=DummyProviderConfig(
+            base_url="https://example.com",  # type: ignore[arg-type]
+            timeout_sec=1,
+            max_retries=0,
+            rate_limit_per_sec=1.0,
+        ),
+    )
+
+
+def test_pipeline_container_satisfies_contract(monkeypatch: Any) -> None:
+    config = _build_config()
+    container = PipelineContainer(config)
+
+    assert isinstance(container, PipelineContainerABC)
+
+    stub_container = StubContainer(config)
+    monkeypatch.setattr(
+        "bioetl.application.orchestrator.get_pipeline_class", lambda _: DummyPipeline
+    )
+
+    orchestrator = PipelineOrchestrator(
+        "dummy.entity",
+        config,
+        container_factory=lambda *args, **kwargs: stub_container,
+    )
+
+    pipeline = orchestrator.build_pipeline(limit=5)
+
+    assert isinstance(pipeline, DummyPipeline)
+    assert pipeline.dependencies["logger"] == "logger"
+    assert pipeline.dependencies["validation_service"] == "validation"
+    assert pipeline.dependencies["output_writer"] == "writer"
+    assert pipeline.dependencies["extraction_service"] == "extraction"
+    assert pipeline.dependencies["normalization_service"] == "normalization"
+    assert pipeline.dependencies["record_source"] == "record_source"
+    assert pipeline.dependencies["hash_service"] == "hash"
+    assert pipeline.dependencies["hooks"] == ["hook"]
+    assert pipeline.dependencies["error_policy"] == "error_policy"
+    assert stub_container.record_source_calls == [{"limit": 5, "logger": "logger"}]
+    assert pipeline.post_transformer == "post_transformer"
+    assert stub_container.post_transformer_version == "pipeline-version"
+    assert pipeline.hooks == ["hook"]
+    assert pipeline.error_policy == "error_policy"


### PR DESCRIPTION
## Summary
- add PipelineContainerABC contract covering pipeline dependency factories
- implement the contract in PipelineContainer and adjust orchestrator and ChEMBL factory typing
- add a unit test demonstrating the contract and orchestrator substitution

## Testing
- python -m pytest tests/bioetl/application/test_pipeline_container_contract.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69344335dbf08324b9bbb682a9879e12)