### PR TITLE
Refactor logging/output contracts into clients base

### DIFF
--- a/docs/ABC_INDEX.md
+++ b/docs/ABC_INDEX.md
@@ -1,0 +1,8 @@
+# ABC Index
+
+- `LoggerAdapterABC` — contract `bioetl.clients.base.logging.contracts.LoggerAdapterABC`; default `bioetl.infrastructure.logging.factories.default_logger`; impl `bioetl.infrastructure.logging.impl.unified_logger.UnifiedLoggerImpl`.
+- `ProgressReporterABC` — contract `bioetl.clients.base.logging.contracts.ProgressReporterABC`; default `bioetl.infrastructure.logging.factories.default_progress_reporter`; impl `bioetl.infrastructure.logging.impl.progress_reporter.TqdmProgressReporterImpl`.
+- `TracerABC` — contract `bioetl.clients.base.logging.contracts.TracerABC`; infrastructure tracing implementations expected.
+- `WriterABC` — contract `bioetl.clients.base.output.contracts.WriterABC`; default `bioetl.infrastructure.output.factories.default_writer`; impls `bioetl.infrastructure.output.impl.csv_writer.CsvWriterImpl`, `bioetl.infrastructure.output.impl.parquet_writer.ParquetWriterImpl`.
+- `MetadataWriterABC` — contract `bioetl.clients.base.output.contracts.MetadataWriterABC`; default `bioetl.infrastructure.output.factories.default_metadata_writer`; impl `bioetl.infrastructure.output.impl.metadata_writer.MetadataWriterImpl`.
+- `QualityReportABC` — contract `bioetl.clients.base.output.contracts.QualityReportABC`; default `bioetl.infrastructure.output.factories.default_quality_reporter`; impl `bioetl.infrastructure.output.impl.quality_report.QualityReportImpl`.

--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -32,9 +32,9 @@ from bioetl.infrastructure.files.csv_record_source import (
     CsvRecordSourceImpl,
     IdListRecordSourceImpl,
 )
-from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
+from bioetl.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.infrastructure.logging.factories import default_logger
-from bioetl.infrastructure.output.contracts import MetadataWriterABC
+from bioetl.clients.base.output.contracts import MetadataWriterABC
 from bioetl.infrastructure.output.factories import (
     default_metadata_writer,
     default_quality_reporter,

--- a/src/bioetl/application/pipelines/base.py
+++ b/src/bioetl/application/pipelines/base.py
@@ -23,8 +23,8 @@ from bioetl.domain.transform.factories import default_post_transformer
 from bioetl.domain.transform.hash_service import HashService
 from bioetl.domain.transform.transformers import TransformerABC
 from bioetl.domain.validation.service import ValidationService
-from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
-from bioetl.infrastructure.output.contracts import WriteResult
+from bioetl.clients.base.logging.contracts import LoggerAdapterABC
+from bioetl.clients.base.output.contracts import WriteResult
 from bioetl.infrastructure.output.metadata import (
     build_dry_run_metadata,
     build_run_metadata,

--- a/src/bioetl/application/pipelines/chembl/base.py
+++ b/src/bioetl/application/pipelines/chembl/base.py
@@ -16,7 +16,7 @@ from bioetl.domain.transform.factories import default_normalization_service
 from bioetl.domain.transform.hash_service import HashService
 from bioetl.domain.transform.transformers import TransformerABC
 from bioetl.domain.validation.service import ValidationService
-from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
+from bioetl.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.infrastructure.output.unified_writer import UnifiedOutputWriter
 
 

--- a/src/bioetl/application/pipelines/chembl/extractor.py
+++ b/src/bioetl/application/pipelines/chembl/extractor.py
@@ -16,7 +16,7 @@ from bioetl.infrastructure.files.csv_record_source import (
     CsvRecordSourceImpl,
     IdListRecordSourceImpl,
 )
-from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
+from bioetl.clients.base.logging.contracts import LoggerAdapterABC
 
 
 class ChemblExtractorImpl(ExtractorABC):

--- a/src/bioetl/application/pipelines/chembl/pipeline.py
+++ b/src/bioetl/application/pipelines/chembl/pipeline.py
@@ -13,7 +13,7 @@ from bioetl.domain.record_source import RecordSource
 from bioetl.domain.transform.contracts import NormalizationServiceABC
 from bioetl.domain.transform.hash_service import HashService
 from bioetl.domain.validation.service import ValidationService
-from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
+from bioetl.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.infrastructure.output.unified_writer import UnifiedOutputWriter
 
 

--- a/src/bioetl/application/pipelines/chembl/transformer.py
+++ b/src/bioetl/application/pipelines/chembl/transformer.py
@@ -9,7 +9,7 @@ from bioetl.domain.schemas.pipeline_contracts import PipelineSchemaContract
 from bioetl.domain.transform.contracts import NormalizationServiceABC
 from bioetl.domain.transform.transformers import TransformerABC
 from bioetl.domain.validation.service import ValidationService
-from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
+from bioetl.clients.base.logging.contracts import LoggerAdapterABC
 
 
 class ChemblTransformerImpl(TransformerABC):

--- a/src/bioetl/application/pipelines/contracts.py
+++ b/src/bioetl/application/pipelines/contracts.py
@@ -13,7 +13,7 @@ from bioetl.domain.transform.contracts import NormalizationServiceABC
 from bioetl.domain.transform.hash_service import HashService
 from bioetl.domain.transform.transformers import TransformerABC
 from bioetl.domain.validation.service import ValidationService
-from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
+from bioetl.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.infrastructure.output.unified_writer import UnifiedOutputWriter
 from bioetl.domain.record_source import RecordSource
 

--- a/src/bioetl/application/pipelines/error_policy_manager.py
+++ b/src/bioetl/application/pipelines/error_policy_manager.py
@@ -8,7 +8,7 @@ from bioetl.domain.errors import PipelineStageError
 from bioetl.domain.models import RunContext
 from bioetl.domain.pipelines.contracts import ErrorPolicyABC
 from bioetl.domain.providers import ProviderId
-from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
+from bioetl.clients.base.logging.contracts import LoggerAdapterABC
 
 
 class ErrorPolicyManager:

--- a/src/bioetl/application/pipelines/hooks_impl.py
+++ b/src/bioetl/application/pipelines/hooks_impl.py
@@ -8,7 +8,7 @@ from bioetl.domain.enums import ErrorAction
 from bioetl.domain.errors import PipelineStageError
 from bioetl.domain.models import StageResult
 from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
-from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
+from bioetl.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.infrastructure.observability import metrics
 
 

--- a/src/bioetl/application/pipelines/hooks_manager.py
+++ b/src/bioetl/application/pipelines/hooks_manager.py
@@ -6,7 +6,7 @@ from typing import Iterable
 from bioetl.domain.models import RunContext, StageResult
 from bioetl.domain.pipelines.contracts import PipelineHookABC
 from bioetl.domain.providers import ProviderId
-from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
+from bioetl.clients.base.logging.contracts import LoggerAdapterABC
 
 
 class HooksManager:

--- a/src/bioetl/clients/__init__.py
+++ b/src/bioetl/clients/__init__.py
@@ -1,0 +1,3 @@
+"""Client contracts and base definitions."""
+
+__all__ = []

--- a/src/bioetl/clients/base/__init__.py
+++ b/src/bioetl/clients/base/__init__.py
@@ -1,0 +1,3 @@
+"""Base client contracts."""
+
+__all__ = []

--- a/src/bioetl/clients/base/logging/__init__.py
+++ b/src/bioetl/clients/base/logging/__init__.py
@@ -1,0 +1,7 @@
+from bioetl.clients.base.logging.contracts import (
+    LoggerAdapterABC,
+    ProgressReporterABC,
+    TracerABC,
+)
+
+__all__ = ["LoggerAdapterABC", "ProgressReporterABC", "TracerABC"]

--- a/src/bioetl/clients/base/logging/contracts.py
+++ b/src/bioetl/clients/base/logging/contracts.py
@@ -6,6 +6,9 @@ from typing import Any, Iterator, Self
 class LoggerAdapterABC(ABC):
     """
     Интерфейс структурированного логгера.
+
+    Default factory: ``bioetl.infrastructure.logging.factories.default_logger``.
+    Implementations: ``UnifiedLoggerImpl``.
     """
 
     @abstractmethod
@@ -32,6 +35,9 @@ class LoggerAdapterABC(ABC):
 class ProgressReporterABC(ABC):
     """
     Интерфейс отчетности о прогрессе.
+
+    Default factory: ``bioetl.infrastructure.logging.factories.default_progress_reporter``.
+    Implementations: ``TqdmProgressReporterImpl``.
     """
 
     @abstractmethod
@@ -62,6 +68,8 @@ class ProgressReporterABC(ABC):
 class TracerABC(ABC):
     """
     Интерфейс распределенной трассировки.
+
+    Implementations expected to be provided by infrastructure tracing backends.
     """
 
     @abstractmethod
@@ -75,3 +83,10 @@ class TracerABC(ABC):
     @abstractmethod
     def inject_context(self, headers: dict[str, str]) -> None:
         """Внедряет контекст трассировки в заголовки."""
+
+
+__all__ = [
+    "LoggerAdapterABC",
+    "ProgressReporterABC",
+    "TracerABC",
+]

--- a/src/bioetl/clients/base/output/__init__.py
+++ b/src/bioetl/clients/base/output/__init__.py
@@ -1,0 +1,13 @@
+from bioetl.clients.base.output.contracts import (
+    MetadataWriterABC,
+    QualityReportABC,
+    WriteResult,
+    WriterABC,
+)
+
+__all__ = [
+    "WriteResult",
+    "WriterABC",
+    "MetadataWriterABC",
+    "QualityReportABC",
+]

--- a/src/bioetl/clients/base/output/contracts.py
+++ b/src/bioetl/clients/base/output/contracts.py
@@ -18,6 +18,9 @@ class WriteResult:
 class WriterABC(ABC):
     """
     Запись данных в файл.
+
+    Default factory: ``bioetl.infrastructure.output.factories.default_writer``.
+    Implementations: ``CsvWriterImpl``, ``ParquetWriterImpl``.
     """
 
     @property
@@ -43,6 +46,9 @@ class WriterABC(ABC):
 class MetadataWriterABC(ABC):
     """
     Запись метаданных и отчетов.
+
+    Default factory: ``bioetl.infrastructure.output.factories.default_metadata_writer``.
+    Implementations: ``MetadataWriterImpl``.
     """
 
     @abstractmethod
@@ -72,3 +78,11 @@ class QualityReportABC(ABC):
     @abstractmethod
     def build_correlation_report(self, df: pd.DataFrame) -> pd.DataFrame:
         """Строит корреляционную матрицу по числовым колонкам."""
+
+
+__all__ = [
+    "WriteResult",
+    "WriterABC",
+    "MetadataWriterABC",
+    "QualityReportABC",
+]

--- a/src/bioetl/infrastructure/clients/base/abc_impls.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_impls.yaml
@@ -48,3 +48,7 @@ MetadataWriterABC:
   implementations:
     Standard: bioetl.infrastructure.output.impl.metadata_writer.MetadataWriterImpl
 
+QualityReportABC:
+  default_factory: bioetl.infrastructure.output.factories.default_quality_reporter
+  implementations:
+    Default: bioetl.infrastructure.output.impl.quality_report.QualityReportImpl

--- a/src/bioetl/infrastructure/clients/base/abc_registry.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_registry.yaml
@@ -17,9 +17,9 @@ PipelineHookABC: bioetl.domain.pipelines.contracts.PipelineHookABC
 ErrorPolicyABC: bioetl.domain.pipelines.contracts.ErrorPolicyABC
 CLICommandABC: bioetl.interfaces.cli.contracts.CLICommandABC
 
-LoggerAdapterABC: bioetl.infrastructure.logging.contracts.LoggerAdapterABC
-ProgressReporterABC: bioetl.infrastructure.logging.contracts.ProgressReporterABC
-TracerABC: bioetl.infrastructure.logging.contracts.TracerABC
+LoggerAdapterABC: bioetl.clients.base.logging.contracts.LoggerAdapterABC
+ProgressReporterABC: bioetl.clients.base.logging.contracts.ProgressReporterABC
+TracerABC: bioetl.clients.base.logging.contracts.TracerABC
 
 HasherABC: bioetl.domain.transform.contracts.HasherABC
 NormalizationServiceABC: bioetl.domain.transform.contracts.NormalizationServiceABC
@@ -27,5 +27,6 @@ NormalizationServiceABC: bioetl.domain.transform.contracts.NormalizationServiceA
 ValidatorABC: bioetl.domain.validation.contracts.ValidatorABC
 SchemaProviderABC: bioetl.domain.validation.contracts.SchemaProviderABC
 
-WriterABC: bioetl.infrastructure.output.contracts.WriterABC
-MetadataWriterABC: bioetl.infrastructure.output.contracts.MetadataWriterABC
+WriterABC: bioetl.clients.base.output.contracts.WriterABC
+MetadataWriterABC: bioetl.clients.base.output.contracts.MetadataWriterABC
+QualityReportABC: bioetl.clients.base.output.contracts.QualityReportABC

--- a/src/bioetl/infrastructure/clients/provider_registry_loader.py
+++ b/src/bioetl/infrastructure/clients/provider_registry_loader.py
@@ -15,7 +15,7 @@ from bioetl.domain.provider_registry import (
     get_provider_registry,
 )
 from bioetl.domain.providers import ProviderDefinition, ProviderId
-from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
+from bioetl.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.infrastructure.logging.factories import default_logger
 
 DEFAULT_PROVIDERS_CONFIG_PATH = Path("configs/providers.yaml")

--- a/src/bioetl/infrastructure/files/csv_record_source.py
+++ b/src/bioetl/infrastructure/files/csv_record_source.py
@@ -11,7 +11,7 @@ import pandas as pd
 from bioetl.domain.configs import ChemblSourceConfig, CsvInputOptions
 from bioetl.domain.contracts import ExtractionServiceABC
 from bioetl.domain.record_source import RecordSource
-from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
+from bioetl.clients.base.logging.contracts import LoggerAdapterABC
 
 
 def _chunk_list(data: list[Any], size: int) -> Iterator[list[Any]]:

--- a/src/bioetl/infrastructure/logging/factories.py
+++ b/src/bioetl/infrastructure/logging/factories.py
@@ -1,6 +1,6 @@
 import structlog
 
-from bioetl.infrastructure.logging.contracts import (
+from bioetl.clients.base.logging.contracts import (
     LoggerAdapterABC,
     ProgressReporterABC,
 )

--- a/src/bioetl/infrastructure/logging/impl/progress_reporter.py
+++ b/src/bioetl/infrastructure/logging/impl/progress_reporter.py
@@ -1,6 +1,6 @@
 from tqdm import tqdm
 
-from bioetl.infrastructure.logging.contracts import ProgressReporterABC
+from bioetl.clients.base.logging.contracts import ProgressReporterABC
 
 
 class TqdmProgressReporterImpl(ProgressReporterABC):

--- a/src/bioetl/infrastructure/logging/impl/unified_logger.py
+++ b/src/bioetl/infrastructure/logging/impl/unified_logger.py
@@ -3,7 +3,7 @@ from typing import Any, Self
 import structlog
 from structlog.stdlib import BoundLogger
 
-from bioetl.infrastructure.logging.contracts import LoggerAdapterABC
+from bioetl.clients.base.logging.contracts import LoggerAdapterABC
 
 
 class UnifiedLoggerImpl(LoggerAdapterABC):

--- a/src/bioetl/infrastructure/output/factories.py
+++ b/src/bioetl/infrastructure/output/factories.py
@@ -1,4 +1,4 @@
-from bioetl.infrastructure.output.contracts import (
+from bioetl.clients.base.output.contracts import (
     MetadataWriterABC,
     QualityReportABC,
     WriterABC,

--- a/src/bioetl/infrastructure/output/impl/base_writer.py
+++ b/src/bioetl/infrastructure/output/impl/base_writer.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pandas as pd
 
 from bioetl.infrastructure.output.column_order import apply_column_order
-from bioetl.infrastructure.output.contracts import WriterABC, WriteResult
+from bioetl.clients.base.output.contracts import WriterABC, WriteResult
 
 
 class BaseWriterImpl(WriterABC):

--- a/src/bioetl/infrastructure/output/impl/metadata_writer.py
+++ b/src/bioetl/infrastructure/output/impl/metadata_writer.py
@@ -4,7 +4,7 @@ import pandas as pd
 import yaml
 
 from bioetl.infrastructure.files.checksum import compute_files_sha256
-from bioetl.infrastructure.output.contracts import (
+from bioetl.clients.base.output.contracts import (
     MetadataWriterABC,
     QualityReportABC,
 )

--- a/src/bioetl/infrastructure/output/impl/quality_report.py
+++ b/src/bioetl/infrastructure/output/impl/quality_report.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pandas as pd
 
-from bioetl.infrastructure.output.contracts import QualityReportABC
+from bioetl.clients.base.output.contracts import QualityReportABC
 
 
 class QualityReportImpl(QualityReportABC):

--- a/src/bioetl/infrastructure/output/metadata.py
+++ b/src/bioetl/infrastructure/output/metadata.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from bioetl.domain.configs import QcConfig
 from bioetl.domain.models import RunContext
-from bioetl.infrastructure.output.contracts import WriteResult
+from bioetl.clients.base.output.contracts import WriteResult
 
 
 def build_base_metadata(

--- a/src/bioetl/infrastructure/output/unified_writer.py
+++ b/src/bioetl/infrastructure/output/unified_writer.py
@@ -11,7 +11,7 @@ from bioetl.domain.models import RunContext
 from bioetl.infrastructure.files.atomic import AtomicFileOperation
 from bioetl.infrastructure.files.checksum import compute_file_sha256
 from bioetl.infrastructure.output.column_order import apply_column_order
-from bioetl.infrastructure.output.contracts import (
+from bioetl.clients.base.output.contracts import (
     MetadataWriterABC,
     QualityReportABC,
     WriterABC,


### PR DESCRIPTION
## Summary
- move logging and output ABCs into bioetl.clients.base modules with updated docstrings
- update application and infrastructure imports to use the new contract locations and keep default factories wiring
- refresh ABC registry/mapping files and add an ABC index entry for logging/output contracts

## Testing
- python -m compileall src/bioetl/clients src/bioetl/application src/bioetl/infrastructure

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693448216cb083248c77ef6d2624daf6)