### PR TITLE
Generate ABC index from registry

### DIFF
--- a/docs/ABC_INDEX.md
+++ b/docs/ABC_INDEX.md
@@ -1,8 +1,71 @@
 # ABC Index
+<!-- generated -->
 
-- `LoggerAdapterABC` — contract `bioetl.clients.base.logging.contracts.LoggerAdapterABC`; default `bioetl.infrastructure.logging.factories.default_logger`; impl `bioetl.infrastructure.logging.impl.unified_logger.UnifiedLoggerImpl`.
-- `ProgressReporterABC` — contract `bioetl.clients.base.logging.contracts.ProgressReporterABC`; default `bioetl.infrastructure.logging.factories.default_progress_reporter`; impl `bioetl.infrastructure.logging.impl.progress_reporter.TqdmProgressReporterImpl`.
-- `TracerABC` — contract `bioetl.clients.base.logging.contracts.TracerABC`; infrastructure tracing implementations expected.
-- `WriterABC` — contract `bioetl.clients.base.output.contracts.WriterABC`; default `bioetl.infrastructure.output.factories.default_writer`; impls `bioetl.infrastructure.output.impl.csv_writer.CsvWriterImpl`, `bioetl.infrastructure.output.impl.parquet_writer.ParquetWriterImpl`.
-- `MetadataWriterABC` — contract `bioetl.clients.base.output.contracts.MetadataWriterABC`; default `bioetl.infrastructure.output.factories.default_metadata_writer`; impl `bioetl.infrastructure.output.impl.metadata_writer.MetadataWriterImpl`.
-- `QualityReportABC` — contract `bioetl.clients.base.output.contracts.QualityReportABC`; default `bioetl.infrastructure.output.factories.default_quality_reporter`; impl `bioetl.infrastructure.output.impl.quality_report.QualityReportImpl`.
+- `SourceClientABC` — `bioetl.domain.clients.base.contracts.SourceClientABC`
+  - Основной контракт клиента источника данных. Наследует доменный контракт DataClientABC.
+
+- `RequestBuilderABC` — `bioetl.domain.clients.base.contracts.RequestBuilderABC`
+  - Паттерн Builder для создания запросов.
+
+- `ResponseParserABC` — `bioetl.domain.clients.base.contracts.ResponseParserABC`
+  - Разбор ответов API.
+
+- `PaginatorABC` — `bioetl.domain.clients.base.contracts.PaginatorABC`
+  - Стратегия пагинации.
+
+- `RateLimiterABC` — `bioetl.domain.clients.base.contracts.RateLimiterABC`
+  - Ограничение частоты запросов.
+
+- `RetryPolicyABC` — `bioetl.domain.clients.base.contracts.RetryPolicyABC`
+  - Политика повторных попыток.
+
+- `CacheABC` — `bioetl.domain.clients.base.contracts.CacheABC`
+  - Интерфейс кэширования.
+
+- `SecretProviderABC` — `bioetl.domain.clients.base.contracts.SecretProviderABC`
+  - Поставщик секретов (env, vault).
+
+- `SideInputProviderABC` — `bioetl.domain.clients.base.contracts.SideInputProviderABC`
+  - Провайдер побочных данных (справочников).
+
+- `StageABC` — `bioetl.domain.pipelines.contracts.StageABC`
+  - Абстракция стадии пайплайна.
+
+- `PipelineHookABC` — `bioetl.domain.pipelines.contracts.PipelineHookABC`
+  - Хуки жизненного цикла пайплайна.
+
+- `ErrorPolicyABC` — `bioetl.domain.pipelines.contracts.ErrorPolicyABC`
+  - Политика обработки ошибок.
+
+- `CLICommandABC` — `bioetl.interfaces.cli.contracts.CLICommandABC`
+  - Интерфейс команды CLI.
+
+- `LoggerAdapterABC` — `bioetl.clients.base.logging.contracts.LoggerAdapterABC`
+  - Интерфейс структурированного логгера. Default factory: ``bioetl.infrastructure.logging.factories.default_logger``. Implementations: ``UnifiedLoggerImpl``.
+
+- `ProgressReporterABC` — `bioetl.clients.base.logging.contracts.ProgressReporterABC`
+  - Интерфейс отчетности о прогрессе. Default factory: ``bioetl.infrastructure.logging.factories.default_progress_reporter``. Implementations: ``TqdmProgressReporterImpl``.
+
+- `TracerABC` — `bioetl.clients.base.logging.contracts.TracerABC`
+  - Интерфейс распределенной трассировки. Implementations expected to be provided by infrastructure tracing backends.
+
+- `HasherABC` — `bioetl.domain.transform.contracts.HasherABC`
+  - Хеширование строк.
+
+- `NormalizationServiceABC` — `bioetl.domain.transform.contracts.NormalizationServiceABC`
+  - Сервис нормализации данных в DataFrame. Обязательные операции: - normalize: нормализация единичной записи - normalize_fields: пакетная нормализация DataFrame по конфигурации - normalize_dataframe: совместимый алиас для normalize_fields - normalize_batch: пакетная нормализация чанка - normalize_series: нормализация столбца по конфигурации
+
+- `ValidatorABC` — `bioetl.domain.validation.contracts.ValidatorABC`
+  - Валидация данных.
+
+- `SchemaProviderABC` — `bioetl.domain.validation.contracts.SchemaProviderABC`
+  - Провайдер схем данных.
+
+- `WriterABC` — `bioetl.clients.base.output.contracts.WriterABC`
+  - Запись данных в файл. Default factory: ``bioetl.infrastructure.output.factories.default_writer``. Implementations: ``CsvWriterImpl``, ``ParquetWriterImpl``.
+
+- `MetadataWriterABC` — `bioetl.clients.base.output.contracts.MetadataWriterABC`
+  - Запись метаданных и отчетов. Default factory: ``bioetl.infrastructure.output.factories.default_metadata_writer``. Implementations: ``MetadataWriterImpl``.
+
+- `QualityReportABC` — `bioetl.clients.base.output.contracts.QualityReportABC`
+  - Порт генератора QC-отчетов.

--- a/tests/documentation/test_abc_index.py
+++ b/tests/documentation/test_abc_index.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+REGISTRY_PATH = PROJECT_ROOT / "src/bioetl/infrastructure/clients/base/abc_registry.yaml"
+INDEX_PATH = PROJECT_ROOT / "docs/ABC_INDEX.md"
+
+
+def _load_registry_names() -> list[str]:
+    registry = yaml.safe_load(REGISTRY_PATH.read_text(encoding="utf-8"))
+    if not isinstance(registry, dict):
+        raise AssertionError("Registry must be a mapping of ABC names to targets")
+    return list(registry.keys())
+
+
+def _parse_index_names(text: str) -> set[str]:
+    pattern = re.compile(r"^- `([^`]+)`", flags=re.MULTILINE)
+    return set(pattern.findall(text))
+
+
+def test_registry_entries_are_listed_in_index() -> None:
+    registry_names = _load_registry_names()
+    index_text = INDEX_PATH.read_text(encoding="utf-8")
+    index_names = _parse_index_names(index_text)
+
+    missing = [name for name in registry_names if name not in index_names]
+    assert not missing, f"Missing ABCs in index: {', '.join(missing)}"
+
+
+def test_index_contains_generated_marker() -> None:
+    index_text = INDEX_PATH.read_text(encoding="utf-8")
+    assert "<!-- generated -->" in index_text

--- a/tools/generate_abc_index.py
+++ b/tools/generate_abc_index.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import importlib
+import inspect
+import os
+import sys
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = ROOT / "src"
+REGISTRY_PATH = ROOT / "src/bioetl/infrastructure/clients/base/abc_registry.yaml"
+OUTPUT_PATH = ROOT / "docs/ABC_INDEX.md"
+
+
+def load_registry(path: Path) -> dict[str, str]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("Registry YAML must contain a mapping of names to targets.")
+    return data
+
+
+def load_class(target: str) -> type:
+    module_name, class_name = target.rsplit(".", 1)
+    module = importlib.import_module(module_name)
+    try:
+        return getattr(module, class_name)
+    except AttributeError as exc:  # pragma: no cover - explicit failure path
+        raise ImportError(f"Class {class_name} not found in module {module_name}") from exc
+
+
+def normalize_docstring(docstring: str | None) -> str:
+    if not docstring:
+        return "No docstring available."
+    return " ".join(inspect.cleandoc(docstring).split())
+
+
+def build_lines(entries: Iterable[tuple[str, str, str]]) -> list[str]:
+    lines: list[str] = ["# ABC Index", "<!-- generated -->", ""]
+    for name, target, description in entries:
+        lines.append(f"- `{name}` — `{target}`")
+        lines.append(f"  - {description}")
+        lines.append("")
+    return lines
+
+
+def write_atomic(path: Path, content: str) -> None:
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(content, encoding="utf-8")
+    os.replace(tmp_path, path)
+
+
+def generate_index() -> None:
+    sys.path.insert(0, str(SRC_DIR))
+    registry = load_registry(REGISTRY_PATH)
+
+    entries: list[tuple[str, str, str]] = []
+    for name, target in registry.items():
+        cls = load_class(target)
+        description = normalize_docstring(cls.__doc__)
+        entries.append((name, target, description))
+
+    content = "\n".join(build_lines(entries)).rstrip() + "\n"
+    write_atomic(OUTPUT_PATH, content)
+
+
+if __name__ == "__main__":
+    generate_index()


### PR DESCRIPTION
## Summary
- add a generator utility to build docs/ABC_INDEX.md from the ABC registry
- regenerate the ABC index to include all registered interfaces with docstrings
- add a documentation test to ensure the index matches the registry and includes the generated marker

## Testing
- pytest tests/documentation/test_abc_index.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934544791148324b572d9a9a46e8448)