### PR TITLE
Update ABC registry with pipeline container and provider entries

### DIFF
--- a/src/bioetl/infrastructure/clients/base/abc_registry.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_registry.yaml
@@ -12,10 +12,14 @@ CacheABC: bioetl.domain.clients.base.contracts.CacheABC
 SecretProviderABC: bioetl.domain.clients.base.contracts.SecretProviderABC
 SideInputProviderABC: bioetl.domain.clients.base.contracts.SideInputProviderABC
 
+PipelineContainerABC: bioetl.application.pipelines.contracts.PipelineContainerABC
 StageABC: bioetl.domain.pipelines.contracts.StageABC
 PipelineHookABC: bioetl.domain.pipelines.contracts.PipelineHookABC
 ErrorPolicyABC: bioetl.domain.pipelines.contracts.ErrorPolicyABC
 CLICommandABC: bioetl.interfaces.cli.contracts.CLICommandABC
+
+ProviderRegistryABC: bioetl.domain.provider_registry.ProviderRegistryABC
+MutableProviderRegistryABC: bioetl.domain.provider_registry.MutableProviderRegistryABC
 
 LoggerAdapterABC: bioetl.clients.base.logging.contracts.LoggerAdapterABC
 ProgressReporterABC: bioetl.clients.base.logging.contracts.ProgressReporterABC


### PR DESCRIPTION
## Summary
- register the pipeline container contract in the ABC registry
- add provider registry ABC and mutable variant mappings to the machine-readable registry

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693454435b1883249b482ce4d81ccf1a)