### PR TITLE
Enforce import linter contract in CI

### DIFF
--- a/.github/workflows/import-linter.yml
+++ b/.github/workflows/import-linter.yml
@@ -81,10 +81,7 @@ jobs:
         run: pytest tests/architecture/test_layer_dependencies.py
 
       - name: Import Linter contract
-        continue-on-error: true
-        run: |
-          echo "Import Linter currently allowed to fail; set continue-on-error to false once violations are fixed."
-          lint-imports --config .importlinter
+        run: lint-imports --config .importlinter
 
   unit-tests:
     needs: lint


### PR DESCRIPTION
## Summary
- make the Import Linter step fail the architecture job instead of continuing on error
- run lint-imports using the committed .importlinter configuration without the previous placeholder message

## Testing
- not run (CI workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934576e19888324a69116b051e13ae9)