### PR TITLE
Add deprecated config runtime facade

### DIFF
--- a/src/bioetl/config/__init__.py
+++ b/src/bioetl/config/__init__.py
@@ -1,9 +1,13 @@
 """
-Compatibility namespace for legacy imports.
+Deprecated compatibility facade for configuration helpers.
 
-Re-exports provider registry helpers from infrastructure layer.
+Новый код должен использовать ``bioetl.application.config.runtime``.
+Модуль сохранён, чтобы старые импорты продолжали работать без изменений.
 """
 
+from warnings import warn
+
+from bioetl.application.config.runtime import build_runtime_config as _build_runtime_config
 from bioetl.infrastructure.config.provider_registry_loader import (  # noqa: F401
     DEFAULT_PROVIDERS_REGISTRY_PATH,
     ProviderNotConfiguredError,
@@ -14,6 +18,19 @@ from bioetl.infrastructure.config.provider_registry_loader import (  # noqa: F40
     ensure_provider_known,
 )
 
+
+def build_runtime_config(*args, **kwargs):
+    """Deprecated: используйте ``bioetl.application.config.runtime``."""
+
+    warn(
+        "bioetl.config.build_runtime_config is deprecated; "
+        "use bioetl.application.config.runtime.build_runtime_config instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _build_runtime_config(*args, **kwargs)
+
+
 __all__ = [
     "provider_registry",
     "DEFAULT_PROVIDERS_REGISTRY_PATH",
@@ -23,4 +40,5 @@ __all__ = [
     "ProviderRegistryNotFoundError",
     "clear_provider_registry_cache",
     "ensure_provider_known",
+    "build_runtime_config",
 ]


### PR DESCRIPTION
## Summary
- add a deprecated compatibility facade in `bioetl.config` that forwards runtime config loading to the application layer
- retain provider registry compatibility exports while issuing a deprecation warning for the legacy entrypoint

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69345a72dbdc83249a9ce9426ced885c)