### PR TITLE
Adjust extraction services to return raw record lists

### DIFF
--- a/src/bioetl/domain/contracts.py
+++ b/src/bioetl/domain/contracts.py
@@ -6,11 +6,14 @@ allowing application layer to depend on abstractions rather than concrete
 implementations.
 """
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import pandas as pd
+if TYPE_CHECKING:  # pragma: no cover
+    from bioetl.domain.record_source import RawRecord
 
 
 class ExtractionServiceABC(ABC):
@@ -18,7 +21,7 @@ class ExtractionServiceABC(ABC):
     Abstract base class for data extraction services.
 
     Defines the contract for services that extract data from external sources
-    and return it as DataFrames.
+    and return raw record dictionaries.
     """
 
     @abstractmethod
@@ -31,7 +34,7 @@ class ExtractionServiceABC(ABC):
         """
 
     @abstractmethod
-    def extract_all(self, entity: str, **filters: Any) -> pd.DataFrame:
+    def extract_all(self, entity: str, **filters: Any) -> list[RawRecord]:
         """
         Extract all records for an entity with optional filters.
 
@@ -40,15 +43,15 @@ class ExtractionServiceABC(ABC):
             **filters: Provider-specific filters (e.g., limit, offset)
 
         Returns:
-            DataFrame containing extracted records
+            List of raw record dictionaries
         """
 
     @abstractmethod
     def iter_extract(
         self, entity: str, *, chunk_size: int | None = None, **filters: Any
-    ) -> Iterable[pd.DataFrame]:
+    ) -> Iterable[list[RawRecord]]:
         """
-        Stream records for an entity in DataFrame chunks.
+        Stream records for an entity in raw record batches.
 
         Args:
             entity: Entity name to extract (e.g., 'activity', 'assay')
@@ -56,7 +59,7 @@ class ExtractionServiceABC(ABC):
             **filters: Provider-specific filters (e.g., limit, offset)
 
         Returns:
-            Iterable of DataFrames with extracted records
+            Iterable of raw record lists
         """
 
     @abstractmethod

--- a/src/bioetl/domain/record_source.py
+++ b/src/bioetl/domain/record_source.py
@@ -53,9 +53,10 @@ class ApiRecordSource(RecordSource):
 
     def iter_records(self) -> Iterable[pd.DataFrame]:
         filters = dict(self._filters)
-        yield from self._extraction_service.iter_extract(
+        for raw_batch in self._extraction_service.iter_extract(
             self._entity, chunk_size=self._chunk_size, **filters
-        )
+        ):
+            yield pd.DataFrame(raw_batch)
 
 
 def _chunk_dataframe(


### PR DESCRIPTION
## Summary
- update extraction service contract to work with raw record lists instead of DataFrames
- modify ChEMBL extraction implementation to return raw record batches
- adapt API record source to build DataFrame chunks from raw record lists

## Testing
- python -m pytest tests/bioetl/domain/test_record_source.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69345e21e8548324826eb8509fc79c96)