### PR TITLE
Remove Chembl extraction service re-export from application layer

### DIFF
--- a/src/bioetl/application/services/__init__.py
+++ b/src/bioetl/application/services/__init__.py
@@ -1,5 +1,3 @@
 """Application services - orchestration layer."""
 
-from bioetl.application.services.chembl_extraction import ChemblExtractionServiceImpl
-
-__all__ = ["ChemblExtractionServiceImpl"]
+__all__: list[str] = []

--- a/src/bioetl/application/services/chembl_extraction.py
+++ b/src/bioetl/application/services/chembl_extraction.py
@@ -1,12 +1,3 @@
-"""
-Application-level entrypoint for ChEMBL extraction service.
+"""Application-level ChEMBL extraction service entrypoint placeholder."""
 
-Re-exports the infrastructure implementation to keep backward-compatible
-imports for pipelines and tests.
-"""
-
-from bioetl.infrastructure.clients.chembl.impl.chembl_extraction_service_impl import (
-    ChemblExtractionServiceImpl,
-)
-
-__all__ = ["ChemblExtractionServiceImpl"]
+# ChemblExtractionServiceImpl is no longer exposed at the application layer.

--- a/tests/bioetl/application/pipelines/chembl/test_extraction.py
+++ b/tests/bioetl/application/pipelines/chembl/test_extraction.py
@@ -7,10 +7,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from bioetl.application.services.chembl_extraction import (
-    ChemblExtractionServiceImpl,
-)
 from bioetl.domain.clients.chembl.contracts import ChemblDataClientABC
+from bioetl.infrastructure.clients.chembl.impl import ChemblExtractionServiceImpl
 
 
 @pytest.fixture

--- a/tests/bioetl/application/test_container.py
+++ b/tests/bioetl/application/test_container.py
@@ -160,9 +160,7 @@ def test_get_extraction_service_for_registered_providers() -> None:
     chembl_service = chembl_container.get_extraction_service()
     dummy_service = dummy_container.get_extraction_service()
 
-    from bioetl.application.services.chembl_extraction import (
-        ChemblExtractionServiceImpl,
-    )
+    from bioetl.infrastructure.clients.chembl.impl import ChemblExtractionServiceImpl
 
     assert isinstance(chembl_service, ChemblExtractionServiceImpl)
     assert dummy_service == ("dummy", "https://example.com/")

--- a/tests/bioetl/domain/test_container.py
+++ b/tests/bioetl/domain/test_container.py
@@ -162,9 +162,7 @@ def test_get_extraction_service_for_registered_providers() -> None:
     chembl_service = chembl_container.get_extraction_service()
     dummy_service = dummy_container.get_extraction_service()
 
-    from bioetl.application.services.chembl_extraction import (
-        ChemblExtractionServiceImpl,
-    )
+    from bioetl.infrastructure.clients.chembl.impl import ChemblExtractionServiceImpl
 
     assert isinstance(chembl_service, ChemblExtractionServiceImpl)
     assert dummy_service == ("dummy", "https://example.com/")

--- a/tests/bioetl/infrastructure/clients/chembl/test_factories.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_factories.py
@@ -4,13 +4,11 @@ Tests for ChEMBL factories.
 
 import pytest
 
-from bioetl.application.services.chembl_extraction import (
-    ChemblExtractionServiceImpl,
-)
 from bioetl.infrastructure.clients.chembl.factories import (
     default_chembl_client,
     default_chembl_extraction_service,
 )
+from bioetl.infrastructure.clients.chembl.impl import ChemblExtractionServiceImpl
 from bioetl.infrastructure.clients.chembl.impl.http_client import (
     ChemblDataClientHTTPImpl,
 )

--- a/tests/golden/test_chembl_activity_golden.py
+++ b/tests/golden/test_chembl_activity_golden.py
@@ -12,7 +12,7 @@ import pytest
 from bioetl.application.config.runtime import build_runtime_config
 from bioetl.application.container import build_pipeline_dependencies
 from bioetl.application.pipelines.registry import get_pipeline_class
-from bioetl.application.services.chembl_extraction import ChemblExtractionServiceImpl
+from bioetl.infrastructure.clients.chembl.impl import ChemblExtractionServiceImpl
 from bioetl.infrastructure.clients.provider_registry_loader import (
     load_provider_registry,
 )

--- a/tests/integration/test_chembl_activity_pipeline_integration.py
+++ b/tests/integration/test_chembl_activity_pipeline_integration.py
@@ -10,7 +10,7 @@ import pytest
 from bioetl.application.config.runtime import build_runtime_config
 from bioetl.application.container import build_pipeline_dependencies
 from bioetl.application.pipelines.registry import get_pipeline_class
-from bioetl.application.services.chembl_extraction import ChemblExtractionServiceImpl
+from bioetl.infrastructure.clients.chembl.impl import ChemblExtractionServiceImpl
 from bioetl.infrastructure.clients.provider_registry_loader import (
     load_provider_registry,
 )

--- a/tests/integration/test_cli_run_integration.py
+++ b/tests/integration/test_cli_run_integration.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 from typer.testing import CliRunner
 
-from bioetl.application.services.chembl_extraction import ChemblExtractionServiceImpl
+from bioetl.infrastructure.clients.chembl.impl import ChemblExtractionServiceImpl
 from bioetl.interfaces.cli import app
 
 sys.modules.setdefault("tqdm", MagicMock())


### PR DESCRIPTION
## Summary
- stop exposing ChemblExtractionServiceImpl from application services
- update tests to reference the infrastructure implementation directly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69345ee766848324842cb13570cabbcf)