### PR TITLE
Refactor record sources to yield raw lists

### DIFF
--- a/src/bioetl/application/pipelines/chembl/extractor.py
+++ b/src/bioetl/application/pipelines/chembl/extractor.py
@@ -45,11 +45,14 @@ class ChemblExtractorImpl(ExtractorABC):
 
         remaining = limit
         for raw_chunk in self.record_source.iter_records():
-            working_chunk = raw_chunk
+            if remaining is not None and remaining <= 0:
+                break
+
+            chunk_records = raw_chunk
             if remaining is not None:
-                if remaining <= 0:
-                    break
-                working_chunk = raw_chunk.head(remaining)
+                chunk_records = raw_chunk[:remaining]
+
+            working_chunk = pd.DataFrame(chunk_records)
 
             normalized_chunk = self.normalization_service.normalize_batch(working_chunk)
 
@@ -57,6 +60,6 @@ class ChemblExtractorImpl(ExtractorABC):
                 yield normalized_chunk
 
             if remaining is not None:
-                remaining -= len(working_chunk)
+                remaining -= len(chunk_records)
                 if remaining <= 0:
                     break

--- a/tests/bioetl/application/pipelines/chembl/test_base.py
+++ b/tests/bioetl/application/pipelines/chembl/test_base.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=redefined-outer-name, unused-argument, protected-access
 from datetime import datetime, timezone
+from typing import cast
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -199,8 +200,8 @@ def test_extract_handles_dataframe_chunks(mock_dependencies_fixture):
     """Test that extract yields DataFrame chunks for further processing."""
     record_source = MagicMock()
     raw_chunks = [
-        pd.DataFrame([{"id": 1}, {"id": 2}]),
-        pd.DataFrame([{"id": 3}]),
+        [{"id": 1}, {"id": 2}],
+        [{"id": 3}],
     ]
     record_source.iter_records.return_value = raw_chunks
 
@@ -225,7 +226,11 @@ def test_extract_handles_dataframe_chunks(mock_dependencies_fixture):
     assert normalization_service.normalize_batch.call_count == 2
 
     expected = pd.concat(
-        [chunk.assign(processed=True) for chunk in raw_chunks], ignore_index=True
+        [
+            pd.DataFrame(chunk).assign(processed=True)
+            for chunk in cast(list[list[dict[str, int]]], raw_chunks)
+        ],
+        ignore_index=True,
     )
 
     pd.testing.assert_frame_equal(

--- a/tests/bioetl/domain/test_record_source.py
+++ b/tests/bioetl/domain/test_record_source.py
@@ -1,8 +1,6 @@
 from collections.abc import Iterable
 from typing import cast
 
-import pandas as pd
-
 from bioetl.domain.contracts import ExtractionServiceABC
 from bioetl.domain.record_source import ApiRecordSource, InMemoryRecordSource, RawRecord
 
@@ -11,26 +9,29 @@ class _DummyExtractionService:
     def __init__(self) -> None:
         self.called_with: dict[str, str] | None = None
 
-    def extract_all(self, entity: str, **filters: str) -> pd.DataFrame:  # type: ignore[override]
-        df_chunks = list(self.iter_extract(entity, **filters))
-        if not df_chunks:
-            return pd.DataFrame()
-        return pd.concat(df_chunks, ignore_index=True)
+    def extract_all(
+        self, entity: str, **filters: str
+    ) -> list[RawRecord]:  # type: ignore[override]
+        record_batches = list(self.iter_extract(entity, **filters))
+        flattened: list[RawRecord] = []
+        for batch in record_batches:
+            flattened.extend(batch)
+        return flattened
 
     def iter_extract(
         self, entity: str, *, chunk_size: int | None = None, **filters: str
-    ) -> Iterable[pd.DataFrame]:  # type: ignore[override]
+    ) -> Iterable[list[RawRecord]]:  # type: ignore[override]
         self.called_with = {"entity": entity, **filters, "chunk_size": chunk_size}
         records = [
             {"id": "1", "name": "alpha"},
             {"id": "2", "name": "beta"},
         ]
         if chunk_size is None or chunk_size <= 0:
-            yield pd.DataFrame(records)
+            yield records
             return
 
         for start in range(0, len(records), chunk_size):
-            yield pd.DataFrame(records[start : start + chunk_size])
+            yield records[start : start + chunk_size]
 
     def get_release_version(self) -> str:  # pragma: no cover
         return "v1"
@@ -60,8 +61,8 @@ def test_in_memory_record_source_iterates_stably() -> None:
     second_pass = list(source.iter_records())
 
     assert len(first_pass) == len(second_pass) == 1
-    pd.testing.assert_frame_equal(first_pass[0], pd.DataFrame(records))
-    pd.testing.assert_frame_equal(second_pass[0], pd.DataFrame(records))
+    assert first_pass[0] == records
+    assert second_pass[0] == records
 
 
 def test_api_record_source_returns_serialized_records() -> None:
@@ -80,10 +81,8 @@ def test_api_record_source_returns_serialized_records() -> None:
         "chunk_size": None,
     }
     assert len(records) == 1
-    expected_df = pd.DataFrame(
-        [
-            {"id": "1", "name": "alpha"},
-            {"id": "2", "name": "beta"},
-        ]
-    )
-    pd.testing.assert_frame_equal(records[0].reset_index(drop=True), expected_df)
+    expected_records = [
+        {"id": "1", "name": "alpha"},
+        {"id": "2", "name": "beta"},
+    ]
+    assert records[0] == expected_records


### PR DESCRIPTION
## Summary
- update RecordSource protocol and implementations to yield batches of raw record dictionaries instead of DataFrames
- adjust CSV record sources and Chembl extractor to operate on record lists, deferring DataFrame creation to the application layer
- refresh related tests to reflect the list-based record streaming behavior

## Testing
- python -m pytest tests/bioetl/domain/test_record_source.py tests/bioetl/infrastructure/files/test_csv_record_source.py tests/bioetl/application/pipelines/chembl/test_base.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69345ebe5f30832489198348e36906f7)