### PR TITLE
Add OutputWriter abstraction for pipeline output

### DIFF
--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -12,6 +12,7 @@ from bioetl.application.pipelines.hooks_impl import (
 from bioetl.domain.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.domain.clients.base.output.contracts import (
     MetadataWriterABC,
+    OutputWriterABC,
     QualityReportABC,
     WriterABC,
 )
@@ -40,11 +41,11 @@ from bioetl.infrastructure.files.csv_record_source import (
 )
 from bioetl.infrastructure.logging.factories import default_logger
 from bioetl.infrastructure.output.factories import (
+    default_output_writer,
     default_metadata_writer,
     default_quality_reporter,
     default_writer,
 )
-from bioetl.infrastructure.output.unified_writer import UnifiedOutputWriter
 
 
 class PipelineContainer(PipelineContainerABC):
@@ -84,12 +85,12 @@ class PipelineContainer(PipelineContainerABC):
         self._post_transformer: TransformerABC | None = post_transformer
         self._provider_registry = provider_registry
         self._provider_registry_provider = provider_registry_provider
-        self._output_writer = UnifiedOutputWriter(
+        self._output_writer: OutputWriterABC = default_output_writer(
+            config=self._config.determinism,
+            qc_config=self._config.qc,
             writer=self._writer,
             metadata_writer=self._metadata_writer,
             quality_reporter=self._quality_reporter,
-            config=self._config.determinism,
-            qc_config=self._config.qc,
         )
         register_schemas(self._schema_registry)
 
@@ -105,7 +106,7 @@ class PipelineContainer(PipelineContainerABC):
         """Get the validation service with registered schemas."""
         return ValidationService(schema_provider=self._schema_registry)
 
-    def get_output_writer(self) -> UnifiedOutputWriter:
+    def get_output_writer(self) -> OutputWriterABC:
         """Get the unified output writer."""
         return self._output_writer
 

--- a/src/bioetl/application/pipelines/base.py
+++ b/src/bioetl/application/pipelines/base.py
@@ -31,7 +31,7 @@ from bioetl.infrastructure.output.metadata import (
 )
 
 if TYPE_CHECKING:
-    from bioetl.infrastructure.output.unified_writer import UnifiedOutputWriter
+    from bioetl.domain.clients.base.output.contracts import OutputWriterABC
 
 
 class PipelineBase(ABC):
@@ -49,7 +49,7 @@ class PipelineBase(ABC):
         config: PipelineConfig,
         logger: LoggerAdapterABC,
         validation_service: ValidationService,
-        output_writer: "UnifiedOutputWriter",
+        output_writer: "OutputWriterABC",
         hash_service: HashService,
         extractor: ExtractorABC | None = None,
         hooks: list[PipelineHookABC] | None = None,

--- a/src/bioetl/application/pipelines/chembl/base.py
+++ b/src/bioetl/application/pipelines/chembl/base.py
@@ -17,7 +17,7 @@ from bioetl.domain.transform.factories import default_normalization_service
 from bioetl.domain.transform.hash_service import HashService
 from bioetl.domain.transform.transformers import TransformerABC
 from bioetl.domain.validation.service import ValidationService
-from bioetl.infrastructure.output.unified_writer import UnifiedOutputWriter
+from bioetl.domain.clients.base.output.contracts import OutputWriterABC
 
 
 class ChemblPipelineBase(PipelineBase):
@@ -28,7 +28,7 @@ class ChemblPipelineBase(PipelineBase):
         config: PipelineConfig,
         logger: LoggerAdapterABC,
         validation_service: ValidationService,
-        output_writer: UnifiedOutputWriter,
+        output_writer: OutputWriterABC,
         extraction_service: ExtractionServiceABC,
         hash_service: HashService,
         record_source: RecordSource | None = None,

--- a/src/bioetl/application/pipelines/chembl/pipeline.py
+++ b/src/bioetl/application/pipelines/chembl/pipeline.py
@@ -14,7 +14,7 @@ from bioetl.domain.record_source import RecordSource
 from bioetl.domain.transform.contracts import NormalizationServiceABC
 from bioetl.domain.transform.hash_service import HashService
 from bioetl.domain.validation.service import ValidationService
-from bioetl.infrastructure.output.unified_writer import UnifiedOutputWriter
+from bioetl.domain.clients.base.output.contracts import OutputWriterABC
 
 
 class ChemblEntityPipeline(ChemblPipelineBase):
@@ -28,7 +28,7 @@ class ChemblEntityPipeline(ChemblPipelineBase):
         config: PipelineConfig,
         logger: LoggerAdapterABC,
         validation_service: ValidationService,
-        output_writer: UnifiedOutputWriter,
+        output_writer: OutputWriterABC,
         extraction_service: ExtractionServiceABC,
         hash_service: HashService,
         record_source: RecordSource | None = None,

--- a/src/bioetl/application/pipelines/contracts.py
+++ b/src/bioetl/application/pipelines/contracts.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Iterable
 import pandas as pd
 
 from bioetl.domain.clients.base.logging.contracts import LoggerAdapterABC
+from bioetl.domain.clients.base.output.contracts import OutputWriterABC
 from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
 from bioetl.domain.record_source import RecordSource
@@ -15,7 +16,6 @@ from bioetl.domain.transform.contracts import NormalizationServiceABC
 from bioetl.domain.transform.hash_service import HashService
 from bioetl.domain.transform.transformers import TransformerABC
 from bioetl.domain.validation.service import ValidationService
-from bioetl.infrastructure.output.unified_writer import UnifiedOutputWriter
 
 
 class ExtractorABC(ABC):
@@ -65,7 +65,7 @@ class PipelineContainerABC(ABC):
         """Return validation service bound to registered schemas."""
 
     @abstractmethod
-    def get_output_writer(self) -> UnifiedOutputWriter:
+    def get_output_writer(self) -> OutputWriterABC:
         """Return unified writer for data, metadata and QC outputs."""
 
     @abstractmethod

--- a/src/bioetl/domain/clients/base/output/contracts.py
+++ b/src/bioetl/domain/clients/base/output/contracts.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import pandas as pd
 
@@ -80,9 +81,31 @@ class QualityReportABC(ABC):
         """Строит корреляционную матрицу по числовым колонкам."""
 
 
+class OutputWriterABC(ABC):
+    """
+    Фасад для записи результатов пайплайна (данные + метаданные).
+
+    Default factory: ``bioetl.infrastructure.output.factories.default_output_writer``.
+    Implementations: ``UnifiedOutputWriter``.
+    """
+
+    @abstractmethod
+    def write_result(
+        self,
+        df: pd.DataFrame,
+        output_path: Path,
+        entity_name: str,
+        run_context: Any,
+        *,
+        column_order: list[str] | None = None,
+    ) -> WriteResult:
+        """Записывает результирующий DataFrame и сопутствующие артефакты, возвращая сведения о записи."""
+
+
 __all__ = [
     "WriteResult",
     "WriterABC",
     "MetadataWriterABC",
     "QualityReportABC",
+    "OutputWriterABC",
 ]

--- a/src/bioetl/infrastructure/output/factories.py
+++ b/src/bioetl/infrastructure/output/factories.py
@@ -1,11 +1,14 @@
 from bioetl.domain.clients.base.output.contracts import (
     MetadataWriterABC,
+    OutputWriterABC,
     QualityReportABC,
     WriterABC,
 )
+from bioetl.domain.configs import DeterminismConfig, QcConfig
 from bioetl.infrastructure.output.impl.csv_writer import CsvWriterImpl
 from bioetl.infrastructure.output.impl.metadata_writer import MetadataWriterImpl
 from bioetl.infrastructure.output.impl.quality_report import QualityReportImpl
+from bioetl.infrastructure.output.unified_writer import UnifiedOutputWriter
 
 
 def default_writer() -> WriterABC:
@@ -18,3 +21,20 @@ def default_metadata_writer() -> MetadataWriterABC:
 
 def default_quality_reporter() -> QualityReportABC:
     return QualityReportImpl()
+
+
+def default_output_writer(
+    *,
+    config: DeterminismConfig,
+    qc_config: QcConfig | None = None,
+    writer: WriterABC | None = None,
+    metadata_writer: MetadataWriterABC | None = None,
+    quality_reporter: QualityReportABC | None = None,
+) -> OutputWriterABC:
+    return UnifiedOutputWriter(
+        writer=writer or default_writer(),
+        metadata_writer=metadata_writer or default_metadata_writer(),
+        quality_reporter=quality_reporter or default_quality_reporter(),
+        config=config,
+        qc_config=qc_config,
+    )

--- a/src/bioetl/infrastructure/output/unified_writer.py
+++ b/src/bioetl/infrastructure/output/unified_writer.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from bioetl.domain.clients.base.output.contracts import (
     MetadataWriterABC,
+    OutputWriterABC,
     QualityReportABC,
     WriterABC,
     WriteResult,
@@ -20,7 +21,7 @@ from bioetl.infrastructure.output.column_order import apply_column_order
 from bioetl.infrastructure.output.metadata import build_run_metadata
 
 
-class UnifiedOutputWriter:
+class UnifiedOutputWriter(OutputWriterABC):
     """
     Фасад для записи результатов пайплайна.
 


### PR DESCRIPTION
## Summary
- add OutputWriterABC contract for unified pipeline output handling
- update pipeline base classes and contracts to depend on the new interface
- provide a default output writer factory and wire it through the application container

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69345f98195c8324a0dd757595d31a94)