### PR TITLE
Add pipeline output regression tests

### DIFF
--- a/tests/golden/pipeline_outputs/__init__.py
+++ b/tests/golden/pipeline_outputs/__init__.py
@@ -1,0 +1,14 @@
+"""Golden records for pipeline output regression tests."""
+from .activity_chembl_golden import expected_activity_records
+from .assay_chembl_golden import expected_assay_records
+from .document_chembl_golden import expected_document_records
+from .target_chembl_golden import expected_target_records
+from .testitem_chembl_golden import expected_testitem_records
+
+__all__ = [
+    "expected_activity_records",
+    "expected_assay_records",
+    "expected_target_records",
+    "expected_document_records",
+    "expected_testitem_records",
+]

--- a/tests/golden/pipeline_outputs/activity_chembl_golden.py
+++ b/tests/golden/pipeline_outputs/activity_chembl_golden.py
@@ -1,0 +1,10 @@
+"""Golden snapshot for activity_chembl pipeline outputs."""
+from pathlib import Path
+
+from .utils import load_expected_records
+
+expected_activity_records = load_expected_records(
+    Path("data/output/activity/activity.csv"), sort_key="activity_id"
+)
+
+__all__ = ["expected_activity_records"]

--- a/tests/golden/pipeline_outputs/assay_chembl_golden.py
+++ b/tests/golden/pipeline_outputs/assay_chembl_golden.py
@@ -1,0 +1,10 @@
+"""Golden snapshot for assay_chembl pipeline outputs."""
+from pathlib import Path
+
+from .utils import load_expected_records
+
+expected_assay_records = load_expected_records(
+    Path("data/output/assay/assay.csv"), sort_key="assay_chembl_id"
+)
+
+__all__ = ["expected_assay_records"]

--- a/tests/golden/pipeline_outputs/document_chembl_golden.py
+++ b/tests/golden/pipeline_outputs/document_chembl_golden.py
@@ -1,0 +1,10 @@
+"""Golden snapshot for document_chembl pipeline outputs."""
+from pathlib import Path
+
+from .utils import load_expected_records
+
+expected_document_records = load_expected_records(
+    Path("data/output/document/document.csv"), sort_key="document_chembl_id"
+)
+
+__all__ = ["expected_document_records"]

--- a/tests/golden/pipeline_outputs/target_chembl_golden.py
+++ b/tests/golden/pipeline_outputs/target_chembl_golden.py
@@ -1,0 +1,10 @@
+"""Golden snapshot for target_chembl pipeline outputs."""
+from pathlib import Path
+
+from .utils import load_expected_records
+
+expected_target_records = load_expected_records(
+    Path("data/output/target/target.csv"), sort_key="target_chembl_id"
+)
+
+__all__ = ["expected_target_records"]

--- a/tests/golden/pipeline_outputs/testitem_chembl_golden.py
+++ b/tests/golden/pipeline_outputs/testitem_chembl_golden.py
@@ -1,0 +1,10 @@
+"""Golden snapshot for testitem_chembl pipeline outputs."""
+from pathlib import Path
+
+from .utils import load_expected_records
+
+expected_testitem_records = load_expected_records(
+    Path("data/output/testitem/testitem.csv"), sort_key="molecule_chembl_id"
+)
+
+__all__ = ["expected_testitem_records"]

--- a/tests/golden/pipeline_outputs/utils.py
+++ b/tests/golden/pipeline_outputs/utils.py
@@ -1,0 +1,30 @@
+"""Utilities for loading golden pipeline outputs."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+_UNSTABLE_COLUMNS: set[str] = {
+    "hash_row",
+    "hash_business_key",
+    "index",
+    "database_version",
+    "extracted_at",
+}
+
+
+def load_expected_records(csv_path: Path, *, sort_key: str) -> list[dict[str, object]]:
+    """Load expected records from a CSV snapshot dropping unstable columns."""
+
+    df = pd.read_csv(csv_path)
+    df = df.drop(columns=[col for col in _UNSTABLE_COLUMNS if col in df.columns])
+    df = df.sort_values(by=sort_key).head(5)
+
+    return [
+        {key: (None if pd.isna(value) else value) for key, value in record.items()}
+        for record in df.to_dict(orient="records")
+    ]
+
+
+__all__ = ["load_expected_records"]

--- a/tests/test_pipeline_outputs.py
+++ b/tests/test_pipeline_outputs.py
@@ -1,0 +1,130 @@
+"""Regression tests for pipeline outputs across key ChEMBL entities."""
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from bioetl.application.config.runtime import build_runtime_config
+from bioetl.application.orchestrator import PipelineOrchestrator
+from bioetl.domain.errors import PipelineStageError
+from bioetl.infrastructure.clients.provider_registry_loader import (
+    load_provider_registry,
+)
+
+_PIPELINE_CASES = [
+    (
+        "activity_chembl",
+        "activity",
+        "tests.golden.pipeline_outputs.activity_chembl_golden",
+        "expected_activity_records",
+        "activity_id",
+    ),
+    (
+        "assay_chembl",
+        "assay",
+        "tests.golden.pipeline_outputs.assay_chembl_golden",
+        "expected_assay_records",
+        "assay_chembl_id",
+    ),
+    (
+        "target_chembl",
+        "target",
+        "tests.golden.pipeline_outputs.target_chembl_golden",
+        "expected_target_records",
+        "target_chembl_id",
+    ),
+    (
+        "document_chembl",
+        "document",
+        "tests.golden.pipeline_outputs.document_chembl_golden",
+        "expected_document_records",
+        "document_chembl_id",
+    ),
+    (
+        "testitem_chembl",
+        "testitem",
+        "tests.golden.pipeline_outputs.testitem_chembl_golden",
+        "expected_testitem_records",
+        "molecule_chembl_id",
+    ),
+]
+
+_UNSTABLE_COLUMNS = {
+    "hash_row",
+    "hash_business_key",
+    "index",
+    "database_version",
+    "extracted_at",
+}
+
+
+def _resolve_config_path(pipeline_name: str) -> Path:
+    entity, provider = pipeline_name.rsplit("_", 1)
+    return Path("configs") / "pipelines" / provider / f"{entity}.yaml"
+
+
+def _normalize_records(df: pd.DataFrame, *, sort_key: str) -> list[dict[str, Any]]:
+    cleaned = df.drop(columns=[col for col in _UNSTABLE_COLUMNS if col in df.columns])
+    records: list[dict[str, Any]] = []
+    for record in cleaned.to_dict(orient="records"):
+        normalized = {key: (None if pd.isna(value) else value) for key, value in record.items()}
+        records.append(normalized)
+    return sorted(records, key=lambda item: item.get(sort_key))
+
+
+@pytest.mark.parametrize(
+    "pipeline_name, entity_name, golden_module, expected_attr, sort_key",
+    _PIPELINE_CASES,
+)
+def test_pipeline_outputs(
+    tmp_path: Path,
+    pipeline_name: str,
+    entity_name: str,
+    golden_module: str,
+    expected_attr: str,
+    sort_key: str,
+) -> None:
+    config_path = _resolve_config_path(pipeline_name)
+    try:
+        config = build_runtime_config(
+            config_path=config_path,
+            configs_root=Path("configs"),
+        )
+    except Exception as exc:  # noqa: BLE001 - propagate as xfail for missing configs
+        pytest.xfail(f"Config unavailable for {pipeline_name}: {exc}")
+
+    output_dir = tmp_path / pipeline_name
+    output_dir.mkdir(parents=True, exist_ok=True)
+    config.output_path = str(output_dir)
+    config.storage.output_path = str(output_dir)
+
+    provider_registry = load_provider_registry(
+        config_path=Path("configs/providers.yaml")
+    )
+
+    orchestrator = PipelineOrchestrator(
+        pipeline_name, config, provider_registry=provider_registry
+    )
+    try:
+        run_result = orchestrator.run_pipeline(limit=5, dry_run=False)
+    except PipelineStageError as exc:
+        cause_text = str(exc.cause) if hasattr(exc, "cause") else ""
+        if "Network access disabled" in cause_text:
+            pytest.xfail(f"Network blocked for {pipeline_name}: {cause_text}")
+        raise
+    assert run_result.success, f"Pipeline {pipeline_name} failed: {run_result.error_message}"
+
+    output_csv = output_dir / f"{entity_name}.csv"
+    if not output_csv.exists():
+        pytest.fail(f"Output file not found: {output_csv}")
+
+    actual_records = _normalize_records(pd.read_csv(output_csv), sort_key=sort_key)
+
+    golden = importlib.import_module(golden_module)
+    expected_records = getattr(golden, expected_attr)
+
+    assert actual_records == expected_records


### PR DESCRIPTION
## Summary
- add parametrized regression test covering chembl pipeline outputs
- provide golden record loaders for activity, assay, target, document, and testitem entities
- normalize unstable fields and handle network-restricted environments

## Testing
- PYTHONPATH=src pytest tests/test_pipeline_outputs.py -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934601b75ac83249d447b13c525b56e)