### PR TITLE
Refactor hashing service boundaries

### DIFF
--- a/docs/01-ABC/INDEX.md
+++ b/docs/01-ABC/INDEX.md
@@ -4,7 +4,7 @@
 - `NormalizationServiceABC` — `bioetl.domain.transform.contracts.NormalizationServiceABC`
   - Normalization service contract for DataFrame/record pipelines. Default factory: `bioetl.infrastructure.transform.factories.default_normalization_service`. Implementations: `NormalizationServiceImpl`, `ChemblNormalizationService`.
 - `HashServiceABC` — `bioetl.domain.transform.contracts.HashServiceABC`
-  - Facade for deterministic hash columns; default factory: `bioetl.infrastructure.transform.factories.default_hash_service`. Implementation: `HashServiceImpl`.
+  - Facade for deterministic hash columns; default factory: `bioetl.infrastructure.transform.factories.default_hash_service`. Implementation: `bioetl.infrastructure.transform.impl.hash_service_impl.HashServiceImpl`.
 - `ProviderRegistryABC` — `bioetl.domain.provider_registry.ProviderRegistryABC`
   - Read port for provider definitions consumed by orchestrator and containers.
 - `MutableProviderRegistryABC` — `bioetl.domain.provider_registry.MutableProviderRegistryABC`

--- a/docs/ABC_INDEX.md
+++ b/docs/ABC_INDEX.md
@@ -65,7 +65,7 @@
   - Хеширование строк.
 
 - `HashServiceABC` — `bioetl.domain.transform.contracts.HashServiceABC`
-  - Фасад для вычисления hash_row/hash_business_key и служебных колонок.
+  - Фасад для вычисления hash_row/hash_business_key и служебных колонок. Default factory: `bioetl.infrastructure.transform.factories.default_hash_service`. Implementation: `bioetl.infrastructure.transform.impl.hash_service_impl.HashServiceImpl`.
 
 - `NormalizationServiceABC` — `bioetl.domain.transform.contracts.NormalizationServiceABC`
   - Сервис нормализации данных в DataFrame. Обязательные операции: - normalize: нормализация единичной записи - normalize_fields: пакетная нормализация DataFrame по конфигурации - normalize_dataframe: совместимый алиас для normalize_fields - normalize_batch: пакетная нормализация чанка - normalize_series: нормализация столбца по конфигурации. Default factory: ``bioetl.infrastructure.transform.factories.default_normalization_service``. Implementations: ``NormalizationServiceImpl``, ``ChemblNormalizationService``.

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -15,7 +15,7 @@
 - реестр провайдеров (`domain.provider_registry`, `domain.providers`);
 - ошибки (`domain.errors`);
 - схемы (Pandera) и реестр схем (`domain.schemas.*`, `domain.schemas.registry`);
-- сервисы: валидация (`domain.validation.service`), нормализация (`infrastructure.transform.impl`), хеширование (`domain.transform.hash_service`), трансформеры/нормалайзеры (`domain.transform.*`);
+- сервисы: валидация (`domain.validation.service`), нормализация (`infrastructure.transform.impl`), хеширование (порт `domain.transform.contracts.HashServiceABC`, реализация `infrastructure.transform.impl.hash_service_impl`), трансформеры/нормалайзеры (`domain.transform.*`);
 - контракты пайплайнов (`domain.schemas.pipeline_contracts`).
 
 ## 3. Слой infrastructure

--- a/docs/architecture/diagrams/component/01-application-components.mmd
+++ b/docs/architecture/diagrams/component/01-application-components.mmd
@@ -29,7 +29,7 @@ class Application group;
 subgraph Domain["Domain Dependencies"]
     Validation["ValidationService\nbioetl.domain.validation.service"]:::componentSecondary
     Normalization["NormalizationServiceImpl\nbioetl.infrastructure.transform.impl.normalize"]:::componentSecondary
-    Hashing["HashService\nbioetl.domain.transform.hash_service"]:::componentSecondary
+    Hashing["HashServiceABC\nbioetl.domain.transform.contracts"]:::componentSecondary
     Transformers["TransformerChain\nHash/Index/Fulldate/DbVersion"]:::componentSecondary
     Contracts["PipelineSchemaContract\nbioetl.domain.schemas.pipeline_contracts"]:::componentSecondary
     Schemas["SchemaRegistry + PanderaValidator\nbioetl.domain.schemas.registry"]:::componentSecondary

--- a/docs/architecture/diagrams/component/02-domain-components.mmd
+++ b/docs/architecture/diagrams/component/02-domain-components.mmd
@@ -11,7 +11,7 @@ classDef group              fill:#e6ecef,stroke:#333,stroke-width:1.5px,color:#1
 subgraph Domain["Domain Layer"]
     Validation["ValidationService\nbioetl.domain.validation.service"]:::componentPrimary
     Normalization["NormalizationServiceImpl\nbioetl.infrastructure.transform.impl.normalize"]:::componentPrimary
-    Hashing["HashService\nbioetl.domain.transform.hash_service"]:::componentPrimary
+    Hashing["HashServiceABC\nbioetl.domain.transform.contracts"]:::componentPrimary
     Transformers["TransformerChain\nHash/Index/DbVersion/Fulldate"]:::componentSecondary
     Hasher["HasherImpl\ncanonical serializer"]:::componentSecondary
     Schemas["SchemaRegistry\nPipelineSchemaContract\nbioetl.domain.schemas.registry"]:::componentSecondary

--- a/src/bioetl/infrastructure/clients/base/abc_impls.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_impls.yaml
@@ -51,7 +51,7 @@ HasherABC:
 HashServiceABC:
   default_factory: bioetl.infrastructure.transform.factories.default_hash_service
   implementations:
-    Default: bioetl.domain.transform.hash_service.HashServiceImpl
+    Default: bioetl.infrastructure.transform.impl.hash_service_impl.HashServiceImpl
 
 WriterABC:
   default_factory: bioetl.infrastructure.output.factories.default_writer

--- a/src/bioetl/infrastructure/transform/factories.py
+++ b/src/bioetl/infrastructure/transform/factories.py
@@ -6,8 +6,8 @@ from bioetl.domain.transform.contracts import (
     NormalizationConfigProvider,
     NormalizationServiceABC,
 )
-from bioetl.domain.transform.hash_service import HashServiceImpl
 from bioetl.infrastructure.transform.impl.hasher import HasherImpl
+from bioetl.infrastructure.transform.impl.hash_service_impl import HashServiceImpl
 from bioetl.infrastructure.transform.impl.normalization_service_impl import (
     NormalizationServiceImpl,
 )

--- a/src/bioetl/infrastructure/transform/impl/__init__.py
+++ b/src/bioetl/infrastructure/transform/impl/__init__.py
@@ -1,8 +1,9 @@
 """Concrete transform implementations."""
 
+from bioetl.infrastructure.transform.impl.hash_service_impl import HashServiceImpl
 from bioetl.infrastructure.transform.impl.hasher import HasherImpl
 from bioetl.infrastructure.transform.impl.normalization_service_impl import (
     NormalizationServiceImpl,
 )
 
-__all__ = ["HasherImpl", "NormalizationServiceImpl"]
+__all__ = ["HasherImpl", "HashServiceImpl", "NormalizationServiceImpl"]

--- a/src/bioetl/infrastructure/transform/impl/hash_service_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/hash_service_impl.py
@@ -5,13 +5,11 @@ import pandas as pd
 
 from bioetl.domain.transform.contracts import HasherABC, HashServiceABC
 
-__all__ = ["HashService", "HashServiceImpl"]
+__all__ = ["HashServiceImpl"]
 
 
 class HashServiceImpl(HashServiceABC):
-    """
-    Реализация фасада хеш-сервиса.
-    """
+    """Реализация фасада хеш-сервиса."""
 
     def __init__(
         self,
@@ -95,7 +93,3 @@ class HashServiceImpl(HashServiceABC):
 
         self._index_counter = 0
         self._extracted_at = None
-
-
-# Alias for compatibility with existing imports/tests.
-HashService = HashServiceImpl

--- a/tests/architecture/test_layer_dependencies.py
+++ b/tests/architecture/test_layer_dependencies.py
@@ -9,13 +9,6 @@ DOMAIN_ROOT = SOURCE_ROOT / "bioetl" / "domain"
 APPLICATION_ROOT = SOURCE_ROOT / "bioetl" / "application"
 INFRASTRUCTURE_ROOT = SOURCE_ROOT / "bioetl" / "infrastructure"
 
-APPLICATION_IMPL_ALLOWLIST: set[tuple[str, str]] = {
-    (
-        "src/bioetl/application/services/chembl_extraction.py",
-        "bioetl.infrastructure.clients.chembl.impl.chembl_extraction_service_impl",
-    ),
-}
-
 
 @dataclass(frozen=True)
 class ImportReference:
@@ -158,16 +151,7 @@ def test_application_avoids_infrastructure_implementations() -> None:
             if not reference.module.startswith("bioetl.infrastructure"):
                 continue
 
-            is_allowed = any(
-                file_path.as_posix() == allowed_path
-                and (
-                    reference.module == allowed_module
-                    or reference.module.startswith(f"{allowed_module}.")
-                )
-                for allowed_path, allowed_module in APPLICATION_IMPL_ALLOWLIST
-            )
-
-            if "impl" in reference.module.split(".") and not is_allowed:
+            if "impl" in reference.module.split("."):
                 violations.append(
                     _format_violation(
                         file_path,


### PR DESCRIPTION
## Summary
- move hash service implementation from domain to infrastructure and update factories/registries
- refresh architecture docs and diagrams to reference the domain port and infrastructure impl
- tighten architecture test by removing application allowlist for infrastructure implementations

## Testing
- pytest tests/architecture/test_layer_dependencies.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69346e7e4a5883248529e8a81c41265b)