### PR TITLE
Add Chembl extraction port and client implementation

### DIFF
--- a/src/bioetl/application/pipelines/chembl/base.py
+++ b/src/bioetl/application/pipelines/chembl/base.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from bioetl.application.pipelines.base import PipelineBase
 from bioetl.application.pipelines.chembl.extractor import ChemblExtractorImpl
 from bioetl.application.pipelines.chembl.transformer import ChemblTransformerImpl
+from bioetl.domain.clients.ports.chembl_extraction_port import ChemblExtractionPort
 from bioetl.domain.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.domain.clients.base.output.contracts import OutputWriterABC
 from bioetl.domain.configs import PipelineConfig
-from bioetl.domain.contracts import ExtractionServiceABC
 from bioetl.domain.models import RunContext
 from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
 from bioetl.domain.record_source import RecordSource
@@ -28,7 +28,7 @@ class ChemblPipelineBase(PipelineBase):
         logger: LoggerAdapterABC,
         validation_service: ValidationService,
         output_writer: OutputWriterABC,
-        extraction_service: ExtractionServiceABC,
+        extraction_service: ChemblExtractionPort,
         hash_service: HashServiceABC,
         record_source: RecordSource | None = None,
         normalization_service: NormalizationServiceABC | None = None,

--- a/src/bioetl/application/pipelines/chembl/extractor.py
+++ b/src/bioetl/application/pipelines/chembl/extractor.py
@@ -8,9 +8,9 @@ from typing import Any, Iterable, cast
 import pandas as pd
 
 from bioetl.application.pipelines.contracts import ExtractorABC
+from bioetl.domain.clients.ports.chembl_extraction_port import ChemblExtractionPort
 from bioetl.domain.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.domain.configs import PipelineConfig
-from bioetl.domain.contracts import ExtractionServiceABC
 from bioetl.domain.record_source import ApiRecordSource, RecordSource
 from bioetl.domain.transform.contracts import NormalizationServiceABC
 from bioetl.infrastructure.config.models import ChemblSourceConfig, CsvInputOptions
@@ -28,7 +28,7 @@ class ChemblExtractorImpl(ExtractorABC):
     def __init__(
         self,
         config: PipelineConfig,
-        extraction_service: ExtractionServiceABC,
+        extraction_service: ChemblExtractionPort,
         normalization_service: NormalizationServiceABC,
         logger: LoggerAdapterABC,
         record_source: RecordSource | None = None,

--- a/src/bioetl/domain/clients/ports/__init__.py
+++ b/src/bioetl/domain/clients/ports/__init__.py
@@ -1,0 +1,5 @@
+"""Domain ports for client-facing services."""
+
+from bioetl.domain.clients.ports.chembl_extraction_port import ChemblExtractionPort
+
+__all__ = ["ChemblExtractionPort"]

--- a/src/bioetl/domain/clients/ports/chembl_extraction_port.py
+++ b/src/bioetl/domain/clients/ports/chembl_extraction_port.py
@@ -1,0 +1,14 @@
+"""ChEMBL extraction port definitions."""
+
+from __future__ import annotations
+
+from abc import ABC
+
+from bioetl.domain.contracts import ExtractionServiceABC
+
+
+class ChemblExtractionPort(ExtractionServiceABC, ABC):
+    """Port contract for ChEMBL extraction services."""
+
+
+__all__ = ["ChemblExtractionPort"]

--- a/src/bioetl/infrastructure/chembl_client.py
+++ b/src/bioetl/infrastructure/chembl_client.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from bioetl.domain.clients.chembl.contracts import ChemblDataClientABC
+from bioetl.domain.clients.ports.chembl_extraction_port import ChemblExtractionPort
 from bioetl.domain.configs import ChemblSourceConfig
-from bioetl.domain.contracts import ExtractionServiceABC
 from bioetl.infrastructure.clients.chembl.factories import (
     default_chembl_client,
     default_chembl_extraction_service,
@@ -21,7 +21,7 @@ def create_client(config: ChemblSourceConfig) -> ChemblDataClientABC:
 
 def create_extraction_service(
     config: ChemblSourceConfig, *, client: ChemblDataClientABC | None = None
-) -> ExtractionServiceABC:
+) -> ChemblExtractionPort:
     """Create extraction service using provided or default ChEMBL client."""
 
     resolved_client = client or create_client(config)

--- a/src/bioetl/infrastructure/clients/chembl/__init__.py
+++ b/src/bioetl/infrastructure/clients/chembl/__init__.py
@@ -1,3 +1,7 @@
-"""
-ChEMBL client implementation.
-"""
+"""ChEMBL client implementations and factories."""
+
+from bioetl.infrastructure.clients.chembl.chembl_extraction_client_impl import (
+    ChemblExtractionClientImpl,
+)
+
+__all__ = ["ChemblExtractionClientImpl"]

--- a/src/bioetl/infrastructure/clients/chembl/chembl_extraction_client_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/chembl_extraction_client_impl.py
@@ -1,0 +1,19 @@
+"""Chembl extraction port implementation."""
+
+from __future__ import annotations
+
+from bioetl.domain.clients.chembl.contracts import ChemblDataClientABC
+from bioetl.domain.clients.ports.chembl_extraction_port import ChemblExtractionPort
+from bioetl.infrastructure.clients.chembl.impl.chembl_extraction_service_impl import (
+    ChemblExtractionServiceImpl,
+)
+
+
+class ChemblExtractionClientImpl(ChemblExtractionServiceImpl, ChemblExtractionPort):
+    """ChEMBL extraction client implementing the domain port."""
+
+    def __init__(self, client: ChemblDataClientABC, *, batch_size: int = 1000) -> None:
+        super().__init__(client=client, batch_size=batch_size)
+
+
+__all__ = ["ChemblExtractionClientImpl"]

--- a/src/bioetl/infrastructure/clients/chembl/factories.py
+++ b/src/bioetl/infrastructure/clients/chembl/factories.py
@@ -5,14 +5,14 @@ Factories for ChEMBL clients.
 from typing import Any
 
 from bioetl.domain.clients.chembl.contracts import ChemblDataClientABC
+from bioetl.domain.clients.ports.chembl_extraction_port import ChemblExtractionPort
 from bioetl.domain.configs import ChemblSourceConfig, ClientConfig
-from bioetl.domain.contracts import ExtractionServiceABC
 from bioetl.infrastructure.clients.base.impl.rate_limiter import (
     TokenBucketRateLimiterImpl,
 )
 from bioetl.infrastructure.clients.base.impl.unified_client import UnifiedAPIClient
-from bioetl.infrastructure.clients.chembl.impl.chembl_extraction_service_impl import (
-    ChemblExtractionServiceImpl,
+from bioetl.infrastructure.clients.chembl.chembl_extraction_client_impl import (
+    ChemblExtractionClientImpl,
 )
 from bioetl.infrastructure.clients.chembl.impl.http_client import (
     ChemblDataClientHTTPImpl,
@@ -85,7 +85,7 @@ def default_chembl_extraction_service(
     client_config: ClientConfig | None = None,
     *,
     client: ChemblDataClientABC | None = None,
-) -> ExtractionServiceABC:
+) -> ChemblExtractionPort:
     """
     Создает сервис экстракции ChEMBL.
 
@@ -100,7 +100,7 @@ def default_chembl_extraction_service(
     if client is None:
         client = default_chembl_client(config, client_config=client_config)
 
-    return ChemblExtractionServiceImpl(
+    return ChemblExtractionClientImpl(
         client=client,
         # Allow provider config to set batch_size while keeping a generous hard cap
         batch_size=config.resolve_effective_batch_size(hard_cap=1000),

--- a/src/bioetl/infrastructure/clients/chembl/provider.py
+++ b/src/bioetl/infrastructure/clients/chembl/provider.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from bioetl.domain.clients.chembl.contracts import ChemblDataClientABC
+from bioetl.domain.clients.ports.chembl_extraction_port import ChemblExtractionPort
 from bioetl.domain.configs import ChemblSourceConfig
-from bioetl.domain.contracts import ExtractionServiceABC
 from bioetl.domain.providers import ProviderComponents, ProviderDefinition, ProviderId
 from bioetl.domain.transform.contracts import (
     NormalizationConfigProvider,
@@ -20,7 +20,7 @@ from bioetl.infrastructure.transform.factories import default_normalization_serv
 class ChemblProviderComponents(
     ProviderComponents[
         ChemblDataClientABC,
-        ExtractionServiceABC,
+        ChemblExtractionPort,
         NormalizationServiceABC,
         object,
     ]
@@ -35,7 +35,7 @@ class ChemblProviderComponents(
         config: ChemblSourceConfig,
         *,
         client: ChemblDataClientABC | None = None,
-    ) -> ExtractionServiceABC:
+    ) -> ChemblExtractionPort:
         return create_extraction_service(config, client=client)
 
     def create_normalization_service(

--- a/tests/architecture/test_layer_dependencies.py
+++ b/tests/architecture/test_layer_dependencies.py
@@ -9,13 +9,6 @@ DOMAIN_ROOT = SOURCE_ROOT / "bioetl" / "domain"
 APPLICATION_ROOT = SOURCE_ROOT / "bioetl" / "application"
 INFRASTRUCTURE_ROOT = SOURCE_ROOT / "bioetl" / "infrastructure"
 
-APPLICATION_IMPL_ALLOWLIST: set[tuple[str, str]] = {
-    (
-        "src/bioetl/application/services/chembl_extraction.py",
-        "bioetl.infrastructure.clients.chembl.impl.chembl_extraction_service_impl",
-    ),
-}
-
 
 @dataclass(frozen=True)
 class ImportReference:
@@ -158,16 +151,7 @@ def test_application_avoids_infrastructure_implementations() -> None:
             if not reference.module.startswith("bioetl.infrastructure"):
                 continue
 
-            is_allowed = any(
-                file_path.as_posix() == allowed_path
-                and (
-                    reference.module == allowed_module
-                    or reference.module.startswith(f"{allowed_module}.")
-                )
-                for allowed_path, allowed_module in APPLICATION_IMPL_ALLOWLIST
-            )
-
-            if "impl" in reference.module.split(".") and not is_allowed:
+            if "impl" in reference.module.split("."):
                 violations.append(
                     _format_violation(
                         file_path,

--- a/tests/bioetl/application/pipelines/chembl/test_extraction.py
+++ b/tests/bioetl/application/pipelines/chembl/test_extraction.py
@@ -1,5 +1,5 @@
 """
-Tests for ChemblExtractionServiceImpl.
+Tests for ChemblExtractionClientImpl.
 """
 
 # pylint: disable=redefined-outer-name
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from bioetl.domain.clients.chembl.contracts import ChemblDataClientABC
-from bioetl.infrastructure.clients.chembl.impl import ChemblExtractionServiceImpl
+from bioetl.infrastructure.clients.chembl import ChemblExtractionClientImpl
 
 
 @pytest.fixture
@@ -19,8 +19,8 @@ def mock_client():
 
 @pytest.fixture
 def service(mock_client):
-    """ChemblExtractionServiceImpl instance with mock client."""
-    return ChemblExtractionServiceImpl(client=mock_client, batch_size=10)
+    """ChemblExtractionClientImpl instance with mock client."""
+    return ChemblExtractionClientImpl(client=mock_client, batch_size=10)
 
 
 def test_get_release_version(service, mock_client):

--- a/tests/bioetl/application/test_container.py
+++ b/tests/bioetl/application/test_container.py
@@ -155,9 +155,9 @@ def test_get_extraction_service_for_registered_providers() -> None:
     chembl_service = chembl_container.get_extraction_service()
     dummy_service = dummy_container.get_extraction_service()
 
-    from bioetl.infrastructure.clients.chembl.impl import ChemblExtractionServiceImpl
+    from bioetl.infrastructure.clients.chembl import ChemblExtractionClientImpl
 
-    assert isinstance(chembl_service, ChemblExtractionServiceImpl)
+    assert isinstance(chembl_service, ChemblExtractionClientImpl)
     assert dummy_service == ("dummy", "https://example.com/")
 
 

--- a/tests/bioetl/domain/test_container.py
+++ b/tests/bioetl/domain/test_container.py
@@ -155,9 +155,9 @@ def test_get_extraction_service_for_registered_providers() -> None:
     chembl_service = chembl_container.get_extraction_service()
     dummy_service = dummy_container.get_extraction_service()
 
-    from bioetl.infrastructure.clients.chembl.impl import ChemblExtractionServiceImpl
+    from bioetl.infrastructure.clients.chembl import ChemblExtractionClientImpl
 
-    assert isinstance(chembl_service, ChemblExtractionServiceImpl)
+    assert isinstance(chembl_service, ChemblExtractionClientImpl)
     assert dummy_service == ("dummy", "https://example.com/")
 
 

--- a/tests/bioetl/infrastructure/clients/chembl/test_factories.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_factories.py
@@ -8,7 +8,7 @@ from bioetl.infrastructure.clients.chembl.factories import (
     default_chembl_client,
     default_chembl_extraction_service,
 )
-from bioetl.infrastructure.clients.chembl.impl import ChemblExtractionServiceImpl
+from bioetl.infrastructure.clients.chembl import ChemblExtractionClientImpl
 from bioetl.infrastructure.clients.chembl.impl.http_client import (
     ChemblDataClientHTTPImpl,
 )
@@ -50,7 +50,7 @@ def test_default_chembl_extraction_service(source_config):
     """Test default extraction service factory."""
     source_config.batch_size = 50
     service = default_chembl_extraction_service(source_config)
-    assert isinstance(service, ChemblExtractionServiceImpl)
+    assert isinstance(service, ChemblExtractionClientImpl)
     assert isinstance(service.client, ChemblDataClientHTTPImpl)
     assert service.batch_size == 50
 

--- a/tests/golden/test_chembl_activity_golden.py
+++ b/tests/golden/test_chembl_activity_golden.py
@@ -13,7 +13,7 @@ import pytest
 from bioetl.application.config.runtime import build_runtime_config
 from bioetl.application.container import build_pipeline_dependencies
 from bioetl.application.pipelines.registry import get_pipeline_class
-from bioetl.infrastructure.clients.chembl.impl import ChemblExtractionServiceImpl
+from bioetl.infrastructure.clients.chembl import ChemblExtractionClientImpl
 from bioetl.infrastructure.clients.provider_registry_loader import (
     create_provider_loader,
 )
@@ -41,7 +41,7 @@ def test_chembl_activity_golden(tmp_path, monkeypatch):
         str(Path("tests/fixtures/configs").resolve()),
     )
     monkeypatch.setattr(
-        ChemblExtractionServiceImpl,
+        ChemblExtractionClientImpl,
         "get_release_version",
         lambda self: "chembl_golden",
     )

--- a/tests/integration/test_chembl_activity_pipeline_integration.py
+++ b/tests/integration/test_chembl_activity_pipeline_integration.py
@@ -11,7 +11,7 @@ import pytest
 from bioetl.application.config.runtime import build_runtime_config
 from bioetl.application.container import build_pipeline_dependencies
 from bioetl.application.pipelines.registry import get_pipeline_class
-from bioetl.infrastructure.clients.chembl.impl import ChemblExtractionServiceImpl
+from bioetl.infrastructure.clients.chembl import ChemblExtractionClientImpl
 from bioetl.infrastructure.clients.provider_registry_loader import (
     create_provider_loader,
 )
@@ -27,7 +27,7 @@ def test_chembl_activity_pipeline_smoke(tmp_path, monkeypatch):
         str(Path("tests/fixtures/configs").resolve()),
     )
     monkeypatch.setattr(
-        ChemblExtractionServiceImpl,
+        ChemblExtractionClientImpl,
         "get_release_version",
         lambda self: "chembl_integration",
     )

--- a/tests/integration/test_chembl_extraction_port_integration.py
+++ b/tests/integration/test_chembl_extraction_port_integration.py
@@ -1,0 +1,43 @@
+"""Integration test for the ChEMBL extraction port implementation."""
+
+from functools import partial
+from pathlib import Path
+
+import pytest
+
+from bioetl.application.config.runtime import build_runtime_config
+from bioetl.application.container import build_pipeline_dependencies
+from bioetl.domain.clients.ports.chembl_extraction_port import ChemblExtractionPort
+from bioetl.infrastructure.clients.chembl import ChemblExtractionClientImpl
+from bioetl.infrastructure.clients.provider_registry_loader import (
+    create_provider_loader,
+)
+
+
+@pytest.mark.integration
+def test_chembl_extraction_port_is_resolved(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Container wiring returns the ChEMBL extraction port implementation."""
+
+    monkeypatch.setenv(
+        "BIOETL_CONFIG_DIR", str(Path("tests/fixtures/configs").resolve())
+    )
+    monkeypatch.setattr(
+        ChemblExtractionClientImpl,
+        "get_release_version",
+        lambda self: "chembl_port_integration",
+    )
+
+    config = build_runtime_config(
+        config_path=Path("tests/fixtures/configs/chembl_activity_test.yaml"),
+        configs_root=Path("tests/fixtures/configs"),
+    )
+
+    provider_loader_factory = partial(create_provider_loader)
+    registry = provider_loader_factory().load_registry()
+    container = build_pipeline_dependencies(config, provider_registry=registry)
+
+    service = container.get_extraction_service()
+
+    assert isinstance(service, ChemblExtractionPort)
+    assert isinstance(service, ChemblExtractionClientImpl)
+    assert service.get_release_version() == "chembl_port_integration"

--- a/tests/integration/test_cli_run_integration.py
+++ b/tests/integration/test_cli_run_integration.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 from typer.testing import CliRunner
 
-from bioetl.infrastructure.clients.chembl.impl import ChemblExtractionServiceImpl
+from bioetl.infrastructure.clients.chembl import ChemblExtractionClientImpl
 from bioetl.interfaces.cli import app
 
 sys.modules.setdefault("tqdm", MagicMock())
@@ -23,7 +23,7 @@ def test_cli_run_dry_run_success(tmp_path, monkeypatch):
         str(Path("tests/fixtures/configs").resolve()),
     )
     monkeypatch.setattr(
-        ChemblExtractionServiceImpl,
+        ChemblExtractionClientImpl,
         "get_release_version",
         lambda self: "chembl_cli_integration",
     )


### PR DESCRIPTION
## Summary
- add ChemblExtractionPort and a ChemblExtractionClientImpl wrapper to expose the ChEMBL extraction contract
- wire Chembl factories, providers, and pipelines to the new port while removing the application-layer allowlist
- cover the new port with integration and unit test updates

## Testing
- pytest tests/architecture/test_layer_dependencies.py
- pytest tests/bioetl/infrastructure/clients/chembl/test_factories.py tests/bioetl/application/pipelines/chembl/test_extraction.py tests/integration/test_chembl_extraction_port_integration.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69346e8720548324ae333f30f5ccd64e)