### PR TITLE
Introduce observability ports for pipelines

### DIFF
--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -9,7 +9,6 @@ from bioetl.application.pipelines.hooks_impl import (
     LoggingPipelineHookImpl,
     MetricsPipelineHookImpl,
 )
-from bioetl.domain.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.domain.clients.base.output.contracts import (
     MetadataWriterABC,
     OutputWriterABC,
@@ -18,6 +17,7 @@ from bioetl.domain.clients.base.output.contracts import (
 )
 from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
+from bioetl.domain.observability import LoggingPort
 from bioetl.domain.provider_registry import ProviderRegistryABC
 from bioetl.domain.providers import ProviderDefinition, ProviderId
 from bioetl.domain.record_source import ApiRecordSource, RecordSource
@@ -32,7 +32,7 @@ from bioetl.infrastructure.files.csv_record_source import (
     CsvRecordSourceImpl,
     IdListRecordSourceImpl,
 )
-from bioetl.infrastructure.logging.factories import default_logger
+from bioetl.infrastructure.observability.factories import default_logging_port
 from bioetl.infrastructure.output.factories import (
     default_metadata_writer,
     default_output_writer,
@@ -51,7 +51,7 @@ class PipelineContainer(PipelineContainerABC):
         self,
         config: PipelineConfig,
         *,
-        logger: LoggerAdapterABC | None = None,
+        logger: LoggingPort | None = None,
         writer: WriterABC | None = None,
         metadata_writer: MetadataWriterABC | None = None,
         quality_reporter: QualityReportABC | None = None,
@@ -70,7 +70,7 @@ class PipelineContainer(PipelineContainerABC):
         self._validator_factory: ValidatorFactoryABC = (
             validator_factory or self._default_validator_factory()
         )
-        self._logger: LoggerAdapterABC = logger or default_logger()
+        self._logger: LoggingPort = logger or default_logging_port()
         self._writer: WriterABC = writer or default_writer()
         self._metadata_writer: MetadataWriterABC = (
             metadata_writer or default_metadata_writer()
@@ -101,7 +101,7 @@ class PipelineContainer(PipelineContainerABC):
     def config(self) -> PipelineConfig:
         return self._config
 
-    def get_logger(self) -> LoggerAdapterABC:
+    def get_logger(self) -> LoggingPort:
         """Get the configured logger."""
         return self._logger
 
@@ -138,7 +138,7 @@ class PipelineContainer(PipelineContainerABC):
         extraction_service: Any,
         *,
         limit: int | None = None,
-        logger: LoggerAdapterABC | None = None,
+        logger: LoggingPort | None = None,
     ) -> RecordSource:
         """Create record source based on pipeline input configuration."""
         mode = self._config.input_mode
@@ -284,7 +284,7 @@ class PipelineContainer(PipelineContainerABC):
 def build_pipeline_dependencies(
     config: PipelineConfig,
     *,
-    logger: LoggerAdapterABC | None = None,
+    logger: LoggingPort | None = None,
     writer: WriterABC | None = None,
     metadata_writer: MetadataWriterABC | None = None,
     quality_reporter: QualityReportABC | None = None,

--- a/src/bioetl/application/pipelines/base.py
+++ b/src/bioetl/application/pipelines/base.py
@@ -13,11 +13,11 @@ from bioetl.application.pipelines.contracts import ExtractorABC
 from bioetl.application.pipelines.error_policy_manager import ErrorPolicyManager
 from bioetl.application.pipelines.hooks_manager import HooksManager
 from bioetl.application.pipelines.stage_runner import StageRunner
-from bioetl.domain.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.domain.clients.base.output.contracts import WriteResult
 from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.errors import PipelineStageError
 from bioetl.domain.models import RunContext, RunResult, StageResult
+from bioetl.domain.observability import LoggingPort
 from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
 from bioetl.domain.providers import ProviderId
 from bioetl.domain.schemas.pipeline_contracts import get_pipeline_contract
@@ -47,7 +47,7 @@ class PipelineBase(ABC):
     def __init__(
         self,
         config: PipelineConfig,
-        logger: LoggerAdapterABC,
+        logger: LoggingPort,
         validation_service: ValidationService,
         output_writer: "OutputWriterABC",
         hash_service: HashServiceABC,

--- a/src/bioetl/application/pipelines/chembl/base.py
+++ b/src/bioetl/application/pipelines/chembl/base.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from bioetl.application.pipelines.base import PipelineBase
 from bioetl.application.pipelines.chembl.extractor import ChemblExtractorImpl
 from bioetl.application.pipelines.chembl.transformer import ChemblTransformerImpl
-from bioetl.domain.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.domain.clients.base.output.contracts import OutputWriterABC
 from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.contracts import ExtractionServiceABC
 from bioetl.domain.models import RunContext
+from bioetl.domain.observability import LoggingPort
 from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
 from bioetl.domain.record_source import RecordSource
 from bioetl.domain.schemas.pipeline_contracts import get_pipeline_contract
@@ -25,7 +25,7 @@ class ChemblPipelineBase(PipelineBase):
     def __init__(
         self,
         config: PipelineConfig,
-        logger: LoggerAdapterABC,
+        logger: LoggingPort,
         validation_service: ValidationService,
         output_writer: OutputWriterABC,
         extraction_service: ExtractionServiceABC,

--- a/src/bioetl/application/pipelines/chembl/extractor.py
+++ b/src/bioetl/application/pipelines/chembl/extractor.py
@@ -8,9 +8,9 @@ from typing import Any, Iterable, cast
 import pandas as pd
 
 from bioetl.application.pipelines.contracts import ExtractorABC
-from bioetl.domain.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.contracts import ExtractionServiceABC
+from bioetl.domain.observability import LoggingPort
 from bioetl.domain.record_source import ApiRecordSource, RecordSource
 from bioetl.domain.transform.contracts import NormalizationServiceABC
 from bioetl.infrastructure.config.models import ChemblSourceConfig, CsvInputOptions
@@ -30,7 +30,7 @@ class ChemblExtractorImpl(ExtractorABC):
         config: PipelineConfig,
         extraction_service: ExtractionServiceABC,
         normalization_service: NormalizationServiceABC,
-        logger: LoggerAdapterABC,
+        logger: LoggingPort,
         record_source: RecordSource | None = None,
     ) -> None:
         self.config = config

--- a/src/bioetl/application/pipelines/chembl/pipeline.py
+++ b/src/bioetl/application/pipelines/chembl/pipeline.py
@@ -6,10 +6,10 @@ with a configurable generic implementation.
 """
 
 from bioetl.application.pipelines.chembl.base import ChemblPipelineBase
-from bioetl.domain.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.domain.clients.base.output.contracts import OutputWriterABC
 from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.contracts import ExtractionServiceABC
+from bioetl.domain.observability import LoggingPort
 from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
 from bioetl.domain.record_source import RecordSource
 from bioetl.domain.transform.contracts import HashServiceABC, NormalizationServiceABC
@@ -25,7 +25,7 @@ class ChemblEntityPipeline(ChemblPipelineBase):
     def __init__(
         self,
         config: PipelineConfig,
-        logger: LoggerAdapterABC,
+        logger: LoggingPort,
         validation_service: ValidationService,
         output_writer: OutputWriterABC,
         extraction_service: ExtractionServiceABC,

--- a/src/bioetl/application/pipelines/chembl/transformer.py
+++ b/src/bioetl/application/pipelines/chembl/transformer.py
@@ -4,8 +4,8 @@ ChEMBL data transformer implementation.
 
 import pandas as pd
 
-from bioetl.domain.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.domain.models import RunContext
+from bioetl.domain.observability import LoggingPort
 from bioetl.domain.schemas.pipeline_contracts import PipelineSchemaContract
 from bioetl.domain.transform.contracts import NormalizationServiceABC
 from bioetl.domain.transform.transformers import TransformerABC
@@ -25,7 +25,7 @@ class ChemblTransformerImpl(TransformerABC):
         validation_service: ValidationService,
         schema_contract: PipelineSchemaContract,
         normalization_service: NormalizationServiceABC,
-        logger: LoggerAdapterABC,
+        logger: LoggingPort,
     ) -> None:
         self.validation_service = validation_service
         self.schema_contract = schema_contract

--- a/src/bioetl/application/pipelines/contracts.py
+++ b/src/bioetl/application/pipelines/contracts.py
@@ -7,10 +7,10 @@ from typing import Any, Callable, Iterable
 
 import pandas as pd
 
-from bioetl.domain.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.domain.clients.base.output.contracts import OutputWriterABC
 from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
+from bioetl.domain.observability import LoggingPort
 from bioetl.domain.record_source import RecordSource
 from bioetl.domain.transform.contracts import HashServiceABC, NormalizationServiceABC
 from bioetl.domain.transform.transformers import TransformerABC
@@ -56,7 +56,7 @@ class PipelineContainerABC(ABC):
         """Pipeline configuration associated with the container."""
 
     @abstractmethod
-    def get_logger(self) -> LoggerAdapterABC:
+    def get_logger(self) -> LoggingPort:
         """Return configured logger adapter for pipeline run."""
 
     @abstractmethod
@@ -81,7 +81,7 @@ class PipelineContainerABC(ABC):
         extraction_service: Any,
         *,
         limit: int | None = None,
-        logger: LoggerAdapterABC | None = None,
+        logger: LoggingPort | None = None,
     ) -> RecordSource:
         """Return record source for pipeline input according to config."""
 

--- a/src/bioetl/application/pipelines/error_policy_manager.py
+++ b/src/bioetl/application/pipelines/error_policy_manager.py
@@ -3,10 +3,10 @@
 from collections.abc import Callable
 
 from bioetl.application.pipelines.hooks_manager import HooksManager
-from bioetl.domain.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.domain.enums import ErrorAction
 from bioetl.domain.errors import PipelineStageError
 from bioetl.domain.models import RunContext
+from bioetl.domain.observability import LoggingPort
 from bioetl.domain.pipelines.contracts import ErrorPolicyABC
 from bioetl.domain.providers import ProviderId
 
@@ -19,7 +19,7 @@ class ErrorPolicyManager:
         *,
         error_policy: ErrorPolicyABC,
         hooks_manager: HooksManager,
-        logger: LoggerAdapterABC,
+        logger: LoggingPort,
         provider_id: ProviderId,
         entity_name: str,
         default_on_skip: Callable[[str], object],
@@ -128,7 +128,7 @@ class ErrorPolicyManager:
         self._last_error = None
         self._last_stage_action.clear()
 
-    def set_logger(self, logger: LoggerAdapterABC) -> None:
+    def set_logger(self, logger: LoggingPort) -> None:
         """Обновляет логгер для дальнейших сообщений."""
 
         self._logger = logger

--- a/src/bioetl/application/pipelines/hooks_impl.py
+++ b/src/bioetl/application/pipelines/hooks_impl.py
@@ -4,18 +4,18 @@ from __future__ import annotations
 
 from typing import Any
 
-from bioetl.domain.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.domain.enums import ErrorAction
 from bioetl.domain.errors import PipelineStageError
 from bioetl.domain.models import StageResult
 from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
+from bioetl.domain.observability import LoggingPort
 from bioetl.infrastructure.observability import metrics
 
 
 class LoggingPipelineHookImpl(PipelineHookABC):
     """Хук, логирующий события жизненного цикла стадий."""
 
-    def __init__(self, logger: LoggerAdapterABC) -> None:
+    def __init__(self, logger: LoggingPort) -> None:
         self._logger = logger
 
     def on_stage_start(self, stage: str, context: Any) -> None:

--- a/src/bioetl/application/pipelines/hooks_manager.py
+++ b/src/bioetl/application/pipelines/hooks_manager.py
@@ -3,9 +3,9 @@
 from datetime import datetime, timezone
 from typing import Iterable
 
-from bioetl.domain.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.domain.models import RunContext, StageResult
 from bioetl.domain.pipelines.contracts import PipelineHookABC
+from bioetl.domain.observability import LoggingPort
 from bioetl.domain.providers import ProviderId
 
 
@@ -15,7 +15,7 @@ class HooksManager:
     def __init__(
         self,
         *,
-        logger: LoggerAdapterABC,
+        logger: LoggingPort,
         provider_id: ProviderId,
         entity_name: str,
         hooks: Iterable[PipelineHookABC] | None = None,
@@ -90,7 +90,7 @@ class HooksManager:
 
         return self._stage_starts.get(stage)
 
-    def set_logger(self, logger: LoggerAdapterABC) -> None:
+    def set_logger(self, logger: LoggingPort) -> None:
         """Обновляет логгер для хуков."""
 
         self._logger = logger

--- a/src/bioetl/domain/observability/__init__.py
+++ b/src/bioetl/domain/observability/__init__.py
@@ -1,0 +1,6 @@
+from bioetl.domain.observability.contracts import LoggingPort, TracingPort
+
+__all__ = [
+    "LoggingPort",
+    "TracingPort",
+]

--- a/src/bioetl/domain/observability/contracts.py
+++ b/src/bioetl/domain/observability/contracts.py
@@ -1,0 +1,62 @@
+"""Observability ports for the domain layer."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Self
+
+
+class LoggingPort(ABC):
+    """
+    Port describing structured logging operations.
+
+    Default factory: ``bioetl.infrastructure.observability.factories.default_logging_port``.
+    Implementations: ``StructuredLoggerImpl``.
+    """
+
+    @abstractmethod
+    def info(self, msg: str, **ctx: Any) -> None:
+        """Log info message with structured context."""
+
+    @abstractmethod
+    def error(self, msg: str, **ctx: Any) -> None:
+        """Log error message with structured context."""
+
+    @abstractmethod
+    def debug(self, msg: str, **ctx: Any) -> None:
+        """Log debug message with structured context."""
+
+    @abstractmethod
+    def warning(self, msg: str, **ctx: Any) -> None:
+        """Log warning message with structured context."""
+
+    @abstractmethod
+    def bind(self, **ctx: Any) -> Self:
+        """Return logger instance with bound context."""
+
+
+class TracingPort(ABC):
+    """
+    Port describing distributed tracing operations.
+
+    Default factory: ``bioetl.infrastructure.observability.factories.default_tracing_port``.
+    Implementations: ``TracingAdapterImpl``.
+    """
+
+    @abstractmethod
+    def start_span(self, name: str) -> Any:
+        """Start a tracing span."""
+
+    @abstractmethod
+    def end_span(self, span: Any) -> None:
+        """Finish a tracing span."""
+
+    @abstractmethod
+    def inject_context(self, headers: dict[str, str]) -> None:
+        """Inject tracing context into headers."""
+
+
+__all__ = [
+    "LoggingPort",
+    "TracingPort",
+]

--- a/src/bioetl/infrastructure/clients/base/abc_impls.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_impls.yaml
@@ -27,10 +27,20 @@ LoggerAdapterABC:
   implementations:
     Unified: bioetl.infrastructure.logging.impl.unified_logger.UnifiedLoggerImpl
 
+LoggingPort:
+  default_factory: bioetl.infrastructure.observability.factories.default_logging_port
+  implementations:
+    Structured: bioetl.infrastructure.observability.adapters.StructuredLoggerImpl
+
 ProgressReporterABC:
   default_factory: bioetl.infrastructure.logging.factories.default_progress_reporter
   implementations:
     Tqdm: bioetl.infrastructure.logging.impl.progress_reporter.TqdmProgressReporterImpl
+
+TracingPort:
+  default_factory: bioetl.infrastructure.observability.factories.default_tracing_port
+  implementations:
+    Default: bioetl.infrastructure.observability.adapters.TracingAdapterImpl
 
 ValidatorABC:
   default_factory: bioetl.infrastructure.validation.factories.default_validator_factory

--- a/src/bioetl/infrastructure/clients/base/abc_registry.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_registry.yaml
@@ -25,6 +25,8 @@ MutableProviderRegistryABC: bioetl.domain.provider_registry.MutableProviderRegis
 LoggerAdapterABC: bioetl.domain.clients.base.logging.contracts.LoggerAdapterABC
 ProgressReporterABC: bioetl.domain.clients.base.logging.contracts.ProgressReporterABC
 TracerABC: bioetl.domain.clients.base.logging.contracts.TracerABC
+LoggingPort: bioetl.domain.observability.contracts.LoggingPort
+TracingPort: bioetl.domain.observability.contracts.TracingPort
 
 HasherABC: bioetl.domain.transform.contracts.HasherABC
 HashServiceABC: bioetl.domain.transform.contracts.HashServiceABC

--- a/src/bioetl/infrastructure/clients/provider_registry_loader.py
+++ b/src/bioetl/infrastructure/clients/provider_registry_loader.py
@@ -9,7 +9,7 @@ from typing import Any
 import yaml
 from pydantic import BaseModel, ConfigDict, ValidationError
 
-from bioetl.domain.clients.base.logging.contracts import LoggerAdapterABC
+from bioetl.domain.observability import LoggingPort
 from bioetl.domain.provider_registry import (
     InMemoryProviderRegistry,
     MutableProviderRegistryABC,
@@ -18,7 +18,7 @@ from bioetl.domain.provider_registry import (
 )
 from bioetl.domain.providers import ProviderDefinition, ProviderId
 from bioetl.infrastructure.clients.chembl.provider import register_chembl_provider
-from bioetl.infrastructure.logging.factories import default_logger
+from bioetl.infrastructure.observability.factories import default_logging_port
 
 DEFAULT_PROVIDERS_CONFIG_PATH = Path("configs/providers.yaml")
 
@@ -70,12 +70,12 @@ class ProviderLoaderImpl(ProviderRegistryLoaderABC):
         self,
         config_path: str | Path | None = None,
         *,
-        logger: LoggerAdapterABC | None = None,
+        logger: LoggingPort | None = None,
     ) -> None:
         self._config_path = (
             Path(config_path) if config_path else DEFAULT_PROVIDERS_CONFIG_PATH
         )
-        self._logger = logger or default_logger()
+        self._logger = logger or default_logging_port()
 
     def load(
         self,
@@ -202,7 +202,7 @@ class ProviderLoaderImpl(ProviderRegistryLoaderABC):
 def load_provider_registry(
     *,
     config_path: str | Path | None = None,
-    logger: LoggerAdapterABC | None = None,
+    logger: LoggingPort | None = None,
     registry: MutableProviderRegistryABC | None = None,
 ) -> MutableProviderRegistryABC:
     """Utility to load provider registry and return the populated instance."""
@@ -218,7 +218,7 @@ def load_provider_registry(
 def create_provider_loader(
     *,
     config_path: str | Path | None = None,
-    logger: LoggerAdapterABC | None = None,
+    logger: LoggingPort | None = None,
 ) -> ProviderRegistryLoaderABC:
     """Factory for ProviderLoaderProtocol implementations."""
 
@@ -231,7 +231,7 @@ ProviderRegistryLoader = ProviderLoaderImpl
 def default_provider_registry_loader(
     *,
     config_path: str | Path | None = None,
-    logger: LoggerAdapterABC | None = None,
+    logger: LoggingPort | None = None,
 ) -> ProviderRegistryLoaderABC:
     """Default factory for provider registry loader."""
 

--- a/src/bioetl/infrastructure/files/csv_record_source.py
+++ b/src/bioetl/infrastructure/files/csv_record_source.py
@@ -8,9 +8,9 @@ from typing import Any
 
 import pandas as pd
 
-from bioetl.domain.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.domain.configs import ChemblSourceConfig, CsvInputOptions
 from bioetl.domain.contracts import ExtractionServiceABC
+from bioetl.domain.observability import LoggingPort
 from bioetl.domain.record_source import RawRecord, RecordSource
 
 
@@ -27,7 +27,7 @@ class CsvRecordSourceImpl(RecordSource):
         input_path: Path,
         csv_options: dict[str, Any] | CsvInputOptions,
         limit: int | None,
-        logger: LoggerAdapterABC,
+        logger: LoggingPort,
         chunk_size: int | None = None,
     ) -> None:
         self._input_path = input_path
@@ -75,7 +75,7 @@ class IdListRecordSourceImpl(RecordSource):
         source_config: ChemblSourceConfig,
         entity: str,
         filter_key: str,
-        logger: LoggerAdapterABC,
+        logger: LoggingPort,
         chunk_size: int | None = None,
     ) -> None:
         if not id_column:

--- a/src/bioetl/infrastructure/logging/factories.py
+++ b/src/bioetl/infrastructure/logging/factories.py
@@ -1,28 +1,16 @@
-import structlog
-
-from bioetl.domain.clients.base.logging.contracts import (
-    LoggerAdapterABC,
-    ProgressReporterABC,
-)
+from bioetl.domain.clients.base.logging.contracts import ProgressReporterABC
+from bioetl.domain.observability import LoggingPort
 from bioetl.infrastructure.logging.impl.progress_reporter import (
     TqdmProgressReporterImpl,
 )
-from bioetl.infrastructure.logging.impl.unified_logger import UnifiedLoggerImpl
+from bioetl.infrastructure.observability.factories import default_logging_port
 
 
-def default_logger() -> LoggerAdapterABC:
+def default_logger() -> LoggingPort:
     """
     Создает и конфигурирует логгер по умолчанию.
     """
-    if not structlog.is_configured():
-        structlog.configure(
-            processors=[
-                structlog.processors.TimeStamper(fmt="iso"),
-                structlog.processors.JSONRenderer(),
-            ],
-            logger_factory=structlog.PrintLoggerFactory(),
-        )
-    return UnifiedLoggerImpl()
+    return default_logging_port()
 
 
 def default_progress_reporter() -> ProgressReporterABC:

--- a/src/bioetl/infrastructure/logging/impl/unified_logger.py
+++ b/src/bioetl/infrastructure/logging/impl/unified_logger.py
@@ -1,12 +1,14 @@
 from typing import Any, Self
 
+from typing import Any, Self
+
 import structlog
 from structlog.stdlib import BoundLogger
 
-from bioetl.domain.clients.base.logging.contracts import LoggerAdapterABC
+from bioetl.domain.observability import LoggingPort
 
 
-class UnifiedLoggerImpl(LoggerAdapterABC):
+class UnifiedLoggerImpl(LoggingPort):
     """
     Реализация логгера на основе structlog.
     """

--- a/src/bioetl/infrastructure/observability/__init__.py
+++ b/src/bioetl/infrastructure/observability/__init__.py
@@ -1,0 +1,15 @@
+from bioetl.infrastructure.observability.adapters import (
+    StructuredLoggerImpl,
+    TracingAdapterImpl,
+)
+from bioetl.infrastructure.observability.factories import (
+    default_logging_port,
+    default_tracing_port,
+)
+
+__all__ = [
+    "StructuredLoggerImpl",
+    "TracingAdapterImpl",
+    "default_logging_port",
+    "default_tracing_port",
+]

--- a/src/bioetl/infrastructure/observability/adapters.py
+++ b/src/bioetl/infrastructure/observability/adapters.py
@@ -1,0 +1,51 @@
+"""Infrastructure adapters for observability ports."""
+
+from __future__ import annotations
+
+from typing import Any, Self
+
+import structlog
+from structlog.stdlib import BoundLogger
+
+from bioetl.domain.observability import LoggingPort, TracingPort
+
+
+class StructuredLoggerImpl(LoggingPort):
+    """Structured logger adapter built on top of structlog."""
+
+    def __init__(self, logger: BoundLogger | None = None) -> None:
+        self._logger = logger or structlog.get_logger()
+
+    def info(self, msg: str, **ctx: Any) -> None:
+        self._logger.info(msg, **ctx)
+
+    def error(self, msg: str, **ctx: Any) -> None:
+        self._logger.error(msg, **ctx)
+
+    def debug(self, msg: str, **ctx: Any) -> None:
+        self._logger.debug(msg, **ctx)
+
+    def warning(self, msg: str, **ctx: Any) -> None:
+        self._logger.warning(msg, **ctx)
+
+    def bind(self, **ctx: Any) -> Self:
+        return self.__class__(self._logger.bind(**ctx))
+
+
+class TracingAdapterImpl(TracingPort):
+    """No-op tracing adapter placeholder for distributed tracing backends."""
+
+    def start_span(self, name: str) -> dict[str, str]:
+        return {"span": name}
+
+    def end_span(self, span: Any) -> None:  # pragma: no cover - no-op
+        _ = span
+
+    def inject_context(self, headers: dict[str, str]) -> None:  # pragma: no cover - no-op
+        headers.update({"trace": "noop"})
+
+
+__all__ = [
+    "StructuredLoggerImpl",
+    "TracingAdapterImpl",
+]

--- a/src/bioetl/infrastructure/observability/factories.py
+++ b/src/bioetl/infrastructure/observability/factories.py
@@ -1,0 +1,40 @@
+"""Factories for observability adapters."""
+
+from __future__ import annotations
+
+import structlog
+
+from bioetl.domain.observability import LoggingPort, TracingPort
+from bioetl.infrastructure.observability.adapters import (
+    StructuredLoggerImpl,
+    TracingAdapterImpl,
+)
+
+
+def _configure_structlog() -> None:
+    if structlog.is_configured():
+        return
+    structlog.configure(
+        processors=[
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.JSONRenderer(),
+        ],
+        logger_factory=structlog.PrintLoggerFactory(),
+    )
+
+
+def default_logging_port() -> LoggingPort:
+    """Create configured structured logger adapter."""
+    _configure_structlog()
+    return StructuredLoggerImpl()
+
+
+def default_tracing_port() -> TracingPort:
+    """Return tracing adapter implementation."""
+    return TracingAdapterImpl()
+
+
+__all__ = [
+    "default_logging_port",
+    "default_tracing_port",
+]

--- a/tests/bioetl/application/pipelines/chembl/activity/test_extract.py
+++ b/tests/bioetl/application/pipelines/chembl/activity/test_extract.py
@@ -11,7 +11,7 @@ import pytest
 from bioetl.application.pipelines.chembl.pipeline import (
     ChemblEntityPipeline,
 )
-from bioetl.domain.clients.base.logging.contracts import LoggerAdapterABC
+from bioetl.domain.observability import LoggingPort
 from bioetl.infrastructure.config.models import (
     ChemblSourceConfig,
     CsvInputOptions,
@@ -123,7 +123,7 @@ def test_extract_full_data_csv(pipeline, mock_extraction_service, tmp_path):
         input_path=csv_path,
         csv_options=pipeline._config.csv_options,
         limit=None,
-        logger=cast(LoggerAdapterABC, MagicMock()),
+        logger=cast(LoggingPort, MagicMock()),
     )
     pipeline._extractor.record_source = csv_record_source
 
@@ -157,7 +157,7 @@ def test_extract_ids_only_csv(
         source_config=source_config,
         entity="activity",
         filter_key="activity_id__in",
-        logger=cast(LoggerAdapterABC, MagicMock()),
+        logger=cast(LoggingPort, MagicMock()),
         chunk_size=None,
     )
     pipeline._extractor.record_source = id_list_record_source
@@ -217,7 +217,7 @@ def test_extract_batch_size_from_config(
         source_config=new_source_config,
         entity="activity",
         filter_key="activity_id__in",
-        logger=cast(LoggerAdapterABC, MagicMock()),
+        logger=cast(LoggingPort, MagicMock()),
         chunk_size=None,
     )
     pipeline._extractor.record_source = id_list_record_source
@@ -258,7 +258,7 @@ def test_extract_missing_column(
         source_config=source_config,
         entity="activity",
         filter_key="activity_id__in",
-        logger=cast(LoggerAdapterABC, MagicMock()),
+        logger=cast(LoggingPort, MagicMock()),
         chunk_size=None,
     )
     pipeline._extractor.record_source = id_list_record_source

--- a/tests/bioetl/application/test_logging_hook.py
+++ b/tests/bioetl/application/test_logging_hook.py
@@ -1,13 +1,14 @@
 from types import SimpleNamespace
+from types import SimpleNamespace
 from typing import Self
 
 from bioetl.application.pipelines.hooks_impl import LoggingPipelineHookImpl
-from bioetl.domain.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.domain.errors import PipelineStageError
 from bioetl.domain.models import StageResult
+from bioetl.domain.observability import LoggingPort
 
 
-class _DummyLogger(LoggerAdapterABC):
+class _DummyLogger(LoggingPort):
     def __init__(self) -> None:
         self.calls: list[tuple[str, str, dict[str, object]]] = []
 

--- a/tests/bioetl/infrastructure/files/test_csv_record_source.py
+++ b/tests/bioetl/infrastructure/files/test_csv_record_source.py
@@ -1,11 +1,14 @@
 from pathlib import Path
 from typing import cast
 
+from pathlib import Path
+from typing import cast
+
 import pandas as pd
 from pydantic import AnyHttpUrl
 
-from bioetl.domain.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.domain.contracts import ExtractionServiceABC
+from bioetl.domain.observability import LoggingPort
 from bioetl.infrastructure.config.models import (
     ChemblSourceConfig,
     CsvInputOptions,
@@ -37,8 +40,14 @@ class _StubExtractionService:
         return records
 
 
-class _DummyLogger:
+class _DummyLogger(LoggingPort):
     def info(self, *args, **kwargs):  # pragma: no cover
+        return None
+
+    def error(self, *args, **kwargs):  # pragma: no cover
+        return None
+
+    def debug(self, *args, **kwargs):  # pragma: no cover
         return None
 
     def warning(self, *args, **kwargs):  # pragma: no cover
@@ -58,7 +67,7 @@ def test_csv_record_source_reads_dataset(tmp_path: Path) -> None:
         input_path=csv_path,
         csv_options=CsvInputOptions(),
         limit=1,
-        logger=cast(LoggerAdapterABC, _DummyLogger()),
+        logger=cast(LoggingPort, _DummyLogger()),
     )
 
     chunks = list(source.iter_records())
@@ -92,7 +101,7 @@ def test_id_list_record_source_fetches_batches(tmp_path: Path) -> None:
         source_config=source_config,
         entity="activity",
         filter_key="activity_id__in",
-        logger=cast(LoggerAdapterABC, _DummyLogger()),
+        logger=cast(LoggingPort, _DummyLogger()),
     )
 
     records = list(source.iter_records())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,6 @@ import pandas as pd
 import pytest
 from pydantic import AnyHttpUrl
 
-from bioetl.domain.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.domain.configs import (
     ChemblSourceConfig,
     HashingConfig,
@@ -22,6 +21,7 @@ from bioetl.domain.configs import (
     StorageConfig,
 )
 from bioetl.domain.models import RunContext
+from bioetl.domain.observability import LoggingPort
 from bioetl.domain.validation.service import ValidationService
 from bioetl.infrastructure.output.unified_writer import UnifiedOutputWriter
 
@@ -108,7 +108,7 @@ def mock_config():
 @pytest.fixture
 def mock_logger():
     """Create a mock logger."""
-    logger = MagicMock(spec=LoggerAdapterABC)
+    logger = MagicMock(spec=LoggingPort)
     logger.bind.return_value = logger
     return logger
 

--- a/tests/integration/test_provider_registry_loader.py
+++ b/tests/integration/test_provider_registry_loader.py
@@ -8,9 +8,9 @@ from typing import Any, Callable
 import pytest
 import yaml
 
-from bioetl.domain.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.domain.configs import DummyProviderConfig
 from bioetl.domain.provider_registry import InMemoryProviderRegistry
+from bioetl.domain.observability import LoggingPort
 from bioetl.domain.providers import ProviderComponents, ProviderDefinition, ProviderId
 from bioetl.infrastructure.clients.provider_registry_loader import (
     ProviderRegistryLoader,
@@ -29,7 +29,7 @@ class DummyComponents(ProviderComponents):
         return resolved_client, config.provider
 
 
-class RecordingLogger(LoggerAdapterABC):
+class RecordingLogger(LoggingPort):
     def __init__(self) -> None:
         self.records: list[tuple[str, str, dict[str, Any]]] = []
 


### PR DESCRIPTION
## Summary
- add domain observability ports for logging and tracing plus structlog-based adapters
- update pipeline container and Chembl pipelines to consume logging via ports
- register new ports and adjust tests and provider utilities to use structured logging adapters

## Testing
- pytest tests/bioetl/application/test_logging_hook.py tests/bioetl/infrastructure/files/test_csv_record_source.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69346e94d0ec8324a38720f373b44ae2)