### PR TITLE
Add compliance tests for architecture and project rules

### DIFF
--- a/tests/architecture/test_architecture_rules.py
+++ b/tests/architecture/test_architecture_rules.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import ast
+from collections import defaultdict
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+import yaml
+
+SRC_ROOT = Path("src")
+BIOETL_ROOT = SRC_ROOT / "bioetl"
+PIPELINES_ROOT = BIOETL_ROOT / "application" / "pipelines"
+DOC_PIPELINES_ROOT = Path("docs") / "application" / "pipelines"
+
+ALLOWED_LAYERS = {"domain", "application", "infrastructure", "interfaces"}
+STAGE_FILES = {"extract.py", "transform.py", "validate.py", "export.py"}
+ALLOWED_DUPLICATE_CLASSES = {
+    "ProviderRegistryError",
+    "ConfigError",
+    "ConfigValidationError",
+    "NormalizationServiceImpl",
+    "NormalizationConfig",
+    "Config",
+    "BaseProviderConfig",
+}
+ALLOWED_ABCS_WITHOUT_IMPL = {
+    "CLICommandABC",
+    "ErrorPolicyABC",
+    "MutableProviderRegistryABC",
+    "PaginatorABC",
+    "PipelineContainerABC",
+    "PipelineHookABC",
+    "ProviderRegistryABC",
+    "RequestBuilderABC",
+    "ResponseParserABC",
+    "SchemaProviderABC",
+    "SecretProviderABC",
+    "SideInputProviderABC",
+    "SourceClientABC",
+    "StageABC",
+    "TracerABC",
+}
+
+
+def _iter_python_files(root: Path) -> Iterable[Path]:
+    return (path for path in root.rglob("*.py") if path.is_file())
+
+
+def test_source_files_are_within_allowed_layers() -> None:
+    violations: list[str] = []
+
+    for path in _iter_python_files(BIOETL_ROOT):
+        relative = path.relative_to(BIOETL_ROOT)
+        parts = relative.parts
+        if len(parts) == 1 and parts[0] in {"__init__.py", "__main__.py"}:
+            continue
+
+        if not parts:
+            continue
+
+        layer = parts[0]
+        if layer not in ALLOWED_LAYERS:
+            violations.append(path.as_posix())
+
+    if violations:
+        pytest.fail(
+            "Found source files outside domain/application/infrastructure/interfaces:\n"
+            + "\n".join(sorted(violations))
+        )
+
+
+def test_domain_imports_avoid_infrastructure_and_io_clients() -> None:
+    forbidden_modules = {
+        "bioetl.infrastructure",
+        "requests",
+        "httpx",
+        "aiohttp",
+        "botocore",
+        "boto3",
+    }
+
+    violations: list[str] = []
+
+    for file_path in sorted((BIOETL_ROOT / "domain").rglob("*.py")):
+        tree = ast.parse(file_path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    for module in forbidden_modules:
+                        if alias.name.startswith(module):
+                            violations.append(f"{file_path}:{node.lineno}: import {alias.name}")
+            elif isinstance(node, ast.ImportFrom):
+                if node.module is None:
+                    continue
+                for module in forbidden_modules:
+                    if node.module.startswith(module):
+                        violations.append(
+                            f"{file_path}:{node.lineno}: from {node.module} import ..."
+                        )
+
+    if violations:
+        pytest.fail(
+            "Domain layer must not depend on infrastructure or IO clients:\n"
+            + "\n".join(sorted(set(violations)))
+        )
+
+
+@pytest.fixture(scope="module")
+def abc_registry() -> dict[str, str]:
+    registry_path = BIOETL_ROOT / "infrastructure" / "clients" / "base" / "abc_registry.yaml"
+    return yaml.safe_load(registry_path.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def abc_impls() -> dict[str, dict]:
+    impls_path = BIOETL_ROOT / "infrastructure" / "clients" / "base" / "abc_impls.yaml"
+    return yaml.safe_load(impls_path.read_text(encoding="utf-8"))
+
+
+def test_abcs_have_documented_implementations(
+    abc_registry: dict[str, str], abc_impls: dict[str, dict]
+) -> None:
+    missing_impl: list[str] = []
+    missing_files: list[str] = []
+
+    for name, target in abc_registry.items():
+        module_path, _ = target.rsplit(".", 1)
+        source_path = SRC_ROOT / Path(*module_path.split(".")).with_suffix(".py")
+        if not source_path.exists():
+            missing_files.append(source_path.as_posix())
+
+        impl_entry = abc_impls.get(name)
+        if not impl_entry or not impl_entry.get("implementations"):
+            if name in ALLOWED_ABCS_WITHOUT_IMPL:
+                continue
+            missing_impl.append(name)
+            continue
+
+        for impl_target in impl_entry["implementations"].values():
+            impl_module, _ = impl_target.rsplit(".", 1)
+            impl_path = SRC_ROOT / Path(*impl_module.split(".")).with_suffix(".py")
+            if not impl_path.exists():
+                missing_files.append(impl_path.as_posix())
+
+    if missing_impl:
+        pytest.fail(
+            "Implementations are missing for ABCs: " + ", ".join(sorted(set(missing_impl)))
+        )
+
+    if missing_files:
+        pytest.fail(
+            "Referenced modules are absent: " + ", ".join(sorted(set(missing_files)))
+        )
+
+
+def test_pipeline_docs_and_stage_structure() -> None:
+    violations: list[str] = []
+
+    for provider_dir in sorted(PIPELINES_ROOT.iterdir()):
+        if not provider_dir.is_dir() or provider_dir.name.startswith("__"):
+            continue
+
+        docs_dir = DOC_PIPELINES_ROOT / provider_dir.name
+        if not docs_dir.exists():
+            violations.append(
+                f"docs for provider '{provider_dir.name}' not found at {docs_dir}"
+            )
+        elif not (docs_dir / "00-index.md").exists():
+            violations.append(
+                f"docs/application/pipelines/{provider_dir.name}/00-index.md is missing"
+            )
+
+        entity_dirs = [d for d in provider_dir.iterdir() if d.is_dir() and not d.name.startswith("__")]
+        if not entity_dirs:
+            continue
+
+        for entity_dir in entity_dirs:
+            stage_files = {child.name for child in entity_dir.iterdir() if child.is_file()}
+            missing = [name for name in STAGE_FILES if name not in stage_files]
+            if missing:
+                violations.append(
+                    f"{entity_dir.as_posix()} is missing stage files: {', '.join(sorted(missing))}"
+                )
+
+    if violations:
+        pytest.fail("Pipeline structure violations:\n" + "\n".join(sorted(set(violations))))
+
+
+def test_no_untracked_duplicate_class_names() -> None:
+    class_locations: defaultdict[str, set[Path]] = defaultdict(set)
+
+    for path in _iter_python_files(BIOETL_ROOT):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef):
+                class_locations[node.name].add(path)
+
+    duplicates = {
+        name: {p.as_posix() for p in paths}
+        for name, paths in class_locations.items()
+        if len(paths) > 1 and name not in ALLOWED_DUPLICATE_CLASSES
+    }
+
+    if duplicates:
+        formatted = [f"{name}: {sorted(paths)}" for name, paths in sorted(duplicates.items())]
+        pytest.fail("Potential duplicate classes detected:\n" + "\n".join(formatted))

--- a/tests/progect_rules/test_project_rules.py
+++ b/tests/progect_rules/test_project_rules.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+import tomllib
+import yaml
+
+from bioetl.domain.configs import HashingConfig, NormalizationConfig
+from bioetl.infrastructure.config.provider_registry_loader import (
+    ProviderRegistryModel,
+    ProviderRegistryNotFoundError,
+    ProviderRegistryFormatError,
+    ProviderNotConfiguredError,
+    ensure_provider_known,
+)
+
+SRC_ROOT = Path("src")
+BIOETL_ROOT = SRC_ROOT / "bioetl"
+SCHEMAS_ROOT = BIOETL_ROOT / "domain" / "schemas" / "chembl"
+PYPROJECT = Path("pyproject.toml")
+
+MODULE_NAME_PATTERN = re.compile(r"^[a-z0-9_]+\.py$")
+CLASS_NAME_PATTERN = re.compile(r"^[A-Z][A-Za-z0-9]+$")
+FUNCTION_NAME_PATTERN = re.compile(r"^[a-z_][a-z0-9_]*$")
+
+
+@pytest.fixture(scope="module")
+def pyproject() -> dict:
+    return tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+
+
+def _iter_python_files(root: Path) -> Iterable[Path]:
+    return (path for path in root.rglob("*.py") if path.is_file())
+
+
+def test_style_tooling_is_configured(pyproject: dict) -> None:
+    tools = pyproject.get("tool", {})
+    missing = [name for name in ("black", "isort", "ruff") if name not in tools]
+    if missing:
+        pytest.fail(f"Missing formatter/linter configuration sections: {', '.join(missing)}")
+
+
+def test_mypy_strict_options_enabled(pyproject: dict) -> None:
+    mypy_cfg = pyproject.get("tool", {}).get("mypy", {})
+    required_flags = {
+        "disallow_untyped_defs": True,
+        "disallow_incomplete_defs": True,
+        "check_untyped_defs": True,
+        "no_implicit_optional": True,
+    }
+    missing = [key for key, expected in required_flags.items() if mypy_cfg.get(key) != expected]
+    if missing:
+        pytest.fail(
+            "Mypy strict configuration is incomplete for keys: " + ", ".join(sorted(missing))
+        )
+
+
+def test_abcs_from_registry_have_docstrings() -> None:
+    registry_path = BIOETL_ROOT / "infrastructure" / "clients" / "base" / "abc_registry.yaml"
+    registry = yaml.safe_load(registry_path.read_text(encoding="utf-8"))
+
+    missing: list[str] = []
+    for target in registry.values():
+        module_path, class_name = target.rsplit(".", 1)
+        source_path = SRC_ROOT / Path(*module_path.split(".")).with_suffix(".py")
+        if not source_path.exists():
+            continue
+
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef) and node.name == class_name:
+                if ast.get_docstring(node) is None:
+                    missing.append(target)
+                break
+
+    if missing:
+        pytest.fail("Missing docstrings for: " + ", ".join(sorted(missing)))
+
+
+def test_module_and_function_naming_conventions() -> None:
+    violations: list[str] = []
+
+    for path in _iter_python_files(BIOETL_ROOT):
+        filename = path.name
+        if filename not in {"__init__.py", "__main__.py"} and not MODULE_NAME_PATTERN.match(
+            filename
+        ):
+            violations.append(f"Invalid module name: {filename}")
+
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef):
+                if node.name.startswith("_"):
+                    continue
+                if not CLASS_NAME_PATTERN.match(node.name):
+                    violations.append(
+                        f"{path}:{node.lineno} class name '{node.name}' violates convention"
+                    )
+            if isinstance(node, ast.FunctionDef):
+                if node.name.startswith("_"):
+                    continue
+                if not FUNCTION_NAME_PATTERN.match(node.name):
+                    violations.append(
+                        f"{path}:{node.lineno} function name '{node.name}' violates snake_case"
+                    )
+
+    if violations:
+        pytest.fail("Naming convention violations:\n" + "\n".join(sorted(violations)))
+
+
+def test_no_builtin_print_calls_in_source() -> None:
+    offenders: list[str] = []
+
+    for path in _iter_python_files(BIOETL_ROOT):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                if node.func.id == "print":
+                    offenders.append(f"{path}:{node.lineno}")
+
+    if offenders:
+        pytest.fail("Use logging instead of print():\n" + "\n".join(offenders))
+
+
+def test_pandera_schemas_defined_for_entities() -> None:
+    violations: list[str] = []
+    allow_missing = {
+        (SCHEMAS_ROOT / "models.py").as_posix(),
+        (SCHEMAS_ROOT / "output_views.py").as_posix(),
+    }
+
+    for schema_file in sorted(SCHEMAS_ROOT.glob("*.py")):
+        if schema_file.name == "__init__.py":
+            continue
+
+        tree = ast.parse(schema_file.read_text(encoding="utf-8"))
+        schema_classes = [
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef)
+            and (
+                node.name.endswith("Schema")
+                or any(
+                    isinstance(base, ast.Attribute) and base.attr == "DataFrameModel"
+                    for base in node.bases
+                )
+                or any(
+                    isinstance(base, ast.Name) and base.id in {"DataFrameModel", "DataFrameSchema"}
+                    for base in node.bases
+                )
+            )
+        ]
+
+        if not schema_classes and schema_file.as_posix() not in allow_missing:
+            violations.append(schema_file.as_posix())
+
+    if violations:
+        pytest.fail("Missing Pandera schemas in files:\n" + "\n".join(violations))
+
+
+def test_configs_validate_against_models() -> None:
+    hashing_data = yaml.safe_load((Path("configs") / "hashing.yaml").read_text(encoding="utf-8"))
+    normalization_data = yaml.safe_load(
+        (Path("configs") / "normalization.yaml").read_text(encoding="utf-8")
+    )
+    providers_data = yaml.safe_load((Path("configs") / "providers.yaml").read_text(encoding="utf-8"))
+
+    HashingConfig.model_validate(hashing_data.get("hashing", {}))
+    NormalizationConfig.model_validate(normalization_data.get("normalization", {}))
+    ProviderRegistryModel.model_validate(providers_data)
+
+
+def test_provider_registry_fail_fast_on_unknown_provider() -> None:
+    registry_path = Path("configs") / "providers.yaml"
+
+    with pytest.raises(ProviderNotConfiguredError):
+        ensure_provider_known("nonexistent", registry_path=registry_path)
+
+    with pytest.raises(ProviderRegistryNotFoundError):
+        ensure_provider_known("chembl", registry_path=registry_path.parent / "missing.yaml")
+
+    with pytest.raises(ProviderRegistryFormatError):
+        bad_path = registry_path.parent / "_invalid_provider.yaml"
+        bad_path.write_text("providers: invalid", encoding="utf-8")
+        try:
+            ensure_provider_known("chembl", registry_path=bad_path)
+        finally:
+            bad_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- add architecture checks covering layer placement, domain imports, ABC registries, pipeline docs, and duplicate class detection
- add project governance tests for style tooling, naming conventions, Pandera schema presence, config validation, and provider registry fail-fast behavior

## Testing
- pytest tests/architecture tests/progect_rules -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69348a414bb883249f9f3f3aa67203db)