### PR TITLE
Enforce ABC/Impl inheritance in architecture tests

### DIFF
--- a/src/bioetl/infrastructure/logging/impl/unified_logger.py
+++ b/src/bioetl/infrastructure/logging/impl/unified_logger.py
@@ -1,14 +1,13 @@
 from typing import Any, Self
 
-from typing import Any, Self
-
 import structlog
 from structlog.stdlib import BoundLogger
 
+from bioetl.domain.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.domain.observability import LoggingPort
 
 
-class UnifiedLoggerImpl(LoggingPort):
+class UnifiedLoggerImpl(LoggerAdapterABC, LoggingPort):
     """
     Реализация логгера на основе structlog.
     """


### PR DESCRIPTION
## Summary
- add an architectural test that checks registered implementations subclass their ABCs
- align UnifiedLoggerImpl with LoggerAdapterABC to satisfy the registry contract

## Testing
- pytest tests/architecture/test_architecture_rules.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693490bad05c83248cf36669c6f4ca46)