### PR TITLE
Add domain hash service and fix logging contracts

### DIFF
--- a/docs/ABC_INDEX.md
+++ b/docs/ABC_INDEX.md
@@ -55,11 +55,17 @@
 - `LoggerAdapterABC` — `bioetl.domain.clients.base.logging.contracts.LoggerAdapterABC`
   - Интерфейс структурированного логгера. Default factory: ``bioetl.infrastructure.logging.factories.default_logger``. Implementations: ``UnifiedLoggerImpl``.
 
+- `LoggingPort` — `bioetl.domain.observability.contracts.LoggingPort`
+  - Порт структурированного логгирования. Default factory: ``bioetl.infrastructure.observability.factories.default_logging_port``. Implementations: ``StructuredLoggerImpl``.
+
 - `ProgressReporterABC` — `bioetl.domain.clients.base.logging.contracts.ProgressReporterABC`
   - Интерфейс отчетности о прогрессе. Default factory: ``bioetl.infrastructure.logging.factories.default_progress_reporter``. Implementations: ``TqdmProgressReporterImpl``.
 
 - `TracerABC` — `bioetl.domain.clients.base.logging.contracts.TracerABC`
   - Интерфейс распределенной трассировки. Implementations expected to be provided by infrastructure tracing backends.
+
+- `TracingPort` — `bioetl.domain.observability.contracts.TracingPort`
+  - Порт для распределенной трассировки. Default factory: ``bioetl.infrastructure.observability.factories.default_tracing_port``. Implementations: ``TracingAdapterImpl``.
 
 - `HasherABC` — `bioetl.domain.transform.contracts.HasherABC`
   - Хеширование строк.

--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -23,6 +23,7 @@ from bioetl.domain.providers import ProviderDefinition, ProviderId
 from bioetl.domain.record_source import ApiRecordSource, RecordSource
 from bioetl.domain.schemas import register_schemas
 from bioetl.domain.schemas.registry import SchemaRegistry
+from bioetl.domain.transform.hash_service import HashService
 from bioetl.domain.transform.contracts import HashServiceABC, NormalizationServiceABC
 from bioetl.domain.transform.factories import default_post_transformer
 from bioetl.domain.transform.transformers import TransformerABC
@@ -39,7 +40,6 @@ from bioetl.infrastructure.output.factories import (
     default_quality_reporter,
     default_writer,
 )
-from bioetl.infrastructure.transform.factories import default_hash_service
 
 
 class PipelineContainer(PipelineContainerABC):
@@ -210,7 +210,7 @@ class PipelineContainer(PipelineContainerABC):
     def get_hash_service(self) -> HashServiceABC:
         """Get the hash service."""
         if self._hash_service is None:
-            self._hash_service = default_hash_service()
+            self._hash_service = HashService()
         return self._hash_service
 
     def get_post_transformer(

--- a/src/bioetl/application/pipelines/chembl/base.py
+++ b/src/bioetl/application/pipelines/chembl/base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from bioetl.application.pipelines.base import PipelineBase
 from bioetl.application.pipelines.chembl.extractor import ChemblExtractorImpl
 from bioetl.application.pipelines.chembl.transformer import ChemblTransformerImpl
+from bioetl.domain.clients.ports import ChemblExtractionPort
 from bioetl.domain.clients.base.output.contracts import OutputWriterABC
 from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.models import RunContext

--- a/src/bioetl/application/pipelines/chembl/extractor.py
+++ b/src/bioetl/application/pipelines/chembl/extractor.py
@@ -7,6 +7,7 @@ from typing import Any, Iterable, cast
 
 import pandas as pd
 
+from bioetl.domain.clients.ports import ChemblExtractionPort
 from bioetl.application.pipelines.contracts import ExtractorABC
 from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.contracts import ExtractionServiceABC

--- a/src/bioetl/domain/transform/__init__.py
+++ b/src/bioetl/domain/transform/__init__.py
@@ -1,7 +1,6 @@
-"""
-Data transformation logic.
-"""
+"""Data transformation logic."""
 
+from bioetl.domain.transform.hash_service import HashService
 from bioetl.domain.transform.transformers import (
     DatabaseVersionTransformer,
     FulldateTransformer,
@@ -18,4 +17,5 @@ __all__ = [
     "IndexColumnTransformer",
     "DatabaseVersionTransformer",
     "FulldateTransformer",
+    "HashService",
 ]

--- a/src/bioetl/domain/transform/contracts.py
+++ b/src/bioetl/domain/transform/contracts.py
@@ -37,14 +37,13 @@ class NormalizationConfigProvider(Protocol):
 
 
 class HasherABC(ABC):
-    """
-    Хеширование строк.
-    """
+    """Хеширование строк."""
 
     @property
-    @abstractmethod
     def algorithm(self) -> str:
-        """Используемый алгоритм (sha256)."""
+        """Используемый алгоритм (по умолчанию blake2b_256)."""
+
+        return "blake2b_256"
 
     @abstractmethod
     def hash_row(self, row: pd.Series) -> str:

--- a/src/bioetl/domain/transform/hash_service.py
+++ b/src/bioetl/domain/transform/hash_service.py
@@ -1,0 +1,169 @@
+"""Доменный фасад для хеширования и служебных колонок."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import unicodedata
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, Callable, Iterable
+
+import pandas as pd
+
+from bioetl.domain.transform.contracts import HasherABC, HashServiceABC
+
+
+def _normalize_unicode(text: str) -> str:
+    """Нормализует строку в форму NFC."""
+
+    return unicodedata.normalize("NFC", text)
+
+
+def _format_float(value: float | Decimal) -> str:
+    """Форматирует число с плавающей точкой по спецификации %.15g."""
+
+    val = float(value)
+
+    if val in (float("inf"), float("-inf")) or val != val:
+        raise ValueError(f"Invalid float value for hashing: {value}")
+
+    return "%.15g" % val
+
+
+def _serialize_number(value: int | float | Decimal) -> str:
+    if isinstance(value, int) and not isinstance(value, bool):
+        return str(value)
+    return _format_float(value)
+
+
+def _serialize_string(text: str) -> str:
+    norm_str = _normalize_unicode(text)
+    return json.dumps(norm_str, ensure_ascii=False)
+
+
+def _serialize_sequence(items: Iterable[Any]) -> str:
+    serialized_items = [_serialize_canonical(item) for item in items]
+    return "[" + ",".join(serialized_items) + "]"
+
+
+def _serialize_mapping(obj: dict[str, Any]) -> str:
+    sorted_keys = sorted(obj.keys())
+    items = []
+    for key in sorted_keys:
+        if not isinstance(key, str):
+            raise TypeError(f"Dict keys must be strings, got {type(key)}")
+        key_str = json.dumps(_normalize_unicode(key), ensure_ascii=False)
+        val_str = _serialize_canonical(obj[key])
+        items.append(f"{key_str}:{val_str}")
+    return "{" + ",".join(items) + "}"
+
+
+def _serialize_canonical(obj: Any) -> str:
+    """Рекурсивно сериализует объект в каноническую JSON-строку."""
+
+    if obj is None:
+        return "null"
+    if isinstance(obj, bool):
+        return "true" if obj else "false"
+    if isinstance(obj, (int, float, Decimal)):
+        return _serialize_number(obj)
+    if isinstance(obj, str):
+        return _serialize_string(obj)
+    if isinstance(obj, (list, tuple)):
+        return _serialize_sequence(obj)
+    if isinstance(obj, dict):
+        return _serialize_mapping(obj)
+
+    raise TypeError(f"Type {type(obj)} not supported for canonical serialization")
+
+
+def _blake2b_hash_hex(data_bytes: bytes, digest_size: int = 32) -> str:
+    """Вычисляет BLAKE2b хеш в шестнадцатеричном представлении."""
+
+    return hashlib.blake2b(data_bytes, digest_size=digest_size).hexdigest()
+
+
+class _DefaultHasher(HasherABC):
+    """Доменная реализация HasherABC с канонической сериализацией."""
+
+    @property
+    def algorithm(self) -> str:
+        return "blake2b_256"
+
+    def hash_row(self, row: pd.Series) -> str:
+        record = row.to_dict()
+        serialized = _serialize_canonical(record)
+        return _blake2b_hash_hex(serialized.encode("utf-8"))
+
+    def hash_columns(self, df: pd.DataFrame, columns: list[str]) -> pd.Series:
+        if not columns:
+            return pd.Series([None] * len(df), index=df.index, dtype=object)
+
+        def _hash_vals(row: pd.Series) -> str | None:
+            values = [row.get(col) for col in columns]
+            serialized = _serialize_canonical(values)
+            return _blake2b_hash_hex(serialized.encode("utf-8"))
+
+        return df.apply(_hash_vals, axis=1)
+
+
+class HashService(HashServiceABC):
+    """Фасад для детерминированного хеширования и служебных колонок."""
+
+    def __init__(
+        self,
+        *,
+        hasher: HasherABC | None = None,
+        now_provider: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._hasher = hasher or _DefaultHasher()
+        self._index_counter = 0
+        self._now_provider = now_provider or (lambda: datetime.now(timezone.utc))
+        self._extracted_at: str | None = None
+
+    def add_hash_columns(
+        self, df: pd.DataFrame, business_key_cols: list[str] | None = None
+    ) -> pd.DataFrame:
+        df = df.copy()
+
+        if business_key_cols:
+            cols_to_hash = [c for c in business_key_cols if c in df.columns]
+            if cols_to_hash:
+                df["hash_business_key"] = self._hasher.hash_columns(df, cols_to_hash)
+            else:
+                df["hash_business_key"] = None
+        else:
+            df["hash_business_key"] = None
+
+        df["hash_row"] = df.apply(self._hasher.hash_row, axis=1)
+        return df
+
+    def add_index_column(self, df: pd.DataFrame) -> pd.DataFrame:
+        df = df.copy()
+        start_index = self._index_counter
+        end_index = start_index + len(df)
+        df["index"] = list(range(start_index, end_index))
+        self._index_counter = end_index
+        return df
+
+    def add_database_version_column(
+        self, df: pd.DataFrame, database_version: str
+    ) -> pd.DataFrame:
+        df = df.copy()
+        df["database_version"] = str(database_version)
+        return df
+
+    def add_fulldate_column(self, df: pd.DataFrame) -> pd.DataFrame:
+        df = df.copy()
+        if self._extracted_at is None:
+            self._extracted_at = self._now_provider().isoformat()
+        df["extracted_at"] = self._extracted_at
+        return df
+
+    def reset_state(self) -> None:
+        self._index_counter = 0
+        self._extracted_at = None
+
+
+__all__ = ["HashService"]

--- a/src/bioetl/infrastructure/logging/factories.py
+++ b/src/bioetl/infrastructure/logging/factories.py
@@ -1,16 +1,20 @@
+import structlog
+
 from bioetl.domain.clients.base.logging.contracts import ProgressReporterABC
 from bioetl.domain.observability import LoggingPort
 from bioetl.infrastructure.logging.impl.progress_reporter import (
     TqdmProgressReporterImpl,
 )
-from bioetl.infrastructure.observability.factories import default_logging_port
+from bioetl.infrastructure.logging.impl.unified_logger import UnifiedLoggerImpl
+from bioetl.infrastructure.observability import factories as observability_factories
 
 
 def default_logger() -> LoggingPort:
     """
     Создает и конфигурирует логгер по умолчанию.
     """
-    return default_logging_port()
+    observability_factories._configure_structlog()
+    return UnifiedLoggerImpl(logger=structlog.get_logger())
 
 
 def default_progress_reporter() -> ProgressReporterABC:

--- a/src/bioetl/infrastructure/logging/impl/unified_logger.py
+++ b/src/bioetl/infrastructure/logging/impl/unified_logger.py
@@ -1,17 +1,18 @@
-from typing import Any, Self
+"""Structlog-based unified logger implementation."""
+
+from __future__ import annotations
 
 from typing import Any, Self
 
 import structlog
 from structlog.stdlib import BoundLogger
 
+from bioetl.domain.clients.base.logging.contracts import LoggerAdapterABC
 from bioetl.domain.observability import LoggingPort
 
 
-class UnifiedLoggerImpl(LoggingPort):
-    """
-    Реализация логгера на основе structlog.
-    """
+class UnifiedLoggerImpl(LoggerAdapterABC, LoggingPort):
+    """Реализация структурированного логгера на базе structlog."""
 
     def __init__(self, logger: BoundLogger | None = None) -> None:
         self._logger = logger or structlog.get_logger()
@@ -30,3 +31,6 @@ class UnifiedLoggerImpl(LoggingPort):
 
     def bind(self, **ctx: Any) -> Self:
         return self.__class__(self._logger.bind(**ctx))
+
+
+__all__ = ["UnifiedLoggerImpl"]

--- a/src/bioetl/infrastructure/transform/impl/normalization_service_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/normalization_service_impl.py
@@ -9,11 +9,10 @@ from bioetl.domain.transform.contracts import (
     NormalizationServiceABC,
 )
 from bioetl.domain.transform.normalizers import normalize_array, normalize_record
-from bioetl.domain.transform.normalizers.registry import get_normalizer
 from bioetl.infrastructure.transform.impl.base_normalizer import (
     BaseNormalizationService,
 )
-from bioetl.infrastructure.transform.impl.normalize import normalize_scalar
+from bioetl.infrastructure.transform.impl import normalize
 from bioetl.infrastructure.transform.impl.serializer import (
     serialize_dict,
     serialize_list,
@@ -41,14 +40,14 @@ class NormalizationServiceImpl(NormalizationServiceABC, BaseNormalizationService
                 continue
 
             mode = self._resolve_mode(name)
-            custom_normalizer = get_normalizer(name)
+            custom_normalizer = normalize.get_normalizer(name)
 
             if custom_normalizer:
                 base_normalizer: Callable[[Any], Any] = custom_normalizer
             else:
 
                 def _default_normalizer(val: Any, m=mode) -> Any:
-                    return normalize_scalar(val, mode=m)
+                    return normalize.normalize_scalar(val, mode=m)
 
                 base_normalizer = _default_normalizer
 
@@ -89,14 +88,14 @@ class NormalizationServiceImpl(NormalizationServiceABC, BaseNormalizationService
 
             dtype = field_cfg.get("data_type")
             mode = self._resolve_mode(name)
-            custom_normalizer = get_normalizer(name)
+            custom_normalizer = normalize.get_normalizer(name)
 
             if custom_normalizer:
                 base_normalizer = custom_normalizer
             else:
 
                 def _default_normalizer(val: Any, m: str = mode) -> Any:
-                    return normalize_scalar(val, mode=m)
+                    return normalize.normalize_scalar(val, mode=m)
 
                 base_normalizer = _default_normalizer
 
@@ -140,14 +139,14 @@ class NormalizationServiceImpl(NormalizationServiceABC, BaseNormalizationService
         name = cast(str, field_cfg.get("name"))
         dtype = field_cfg.get("data_type")
         mode = self._resolve_mode(name)
-        custom_normalizer = get_normalizer(name)
+        custom_normalizer = normalize.get_normalizer(name)
 
         if custom_normalizer:
             base_normalizer = custom_normalizer
         else:
 
             def _default_normalizer(val: Any, m: str = mode) -> Any:
-                return normalize_scalar(val, mode=m)
+                return normalize.normalize_scalar(val, mode=m)
 
             base_normalizer = _default_normalizer
 


### PR DESCRIPTION
## Summary
- add a domain-level HashService with deterministic hashing helpers and wire it into the pipeline container
- align ChEMBL pipeline imports and normalization service to use patchable normalizer resolution
- update logging factories and implementations to satisfy LoggerAdapter contracts and document new observability ports

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693490bad05c83248cf36669c6f4ca46)