### PR TITLE
Decouple domain ports from infrastructure factories

### DIFF
--- a/src/bioetl/domain/clients/base/logging/contracts.py
+++ b/src/bioetl/domain/clients/base/logging/contracts.py
@@ -13,8 +13,8 @@ class LoggerAdapterABC(ABC):
     """
     Интерфейс структурированного логгера.
 
-    Default factory: ``bioetl.infrastructure.logging.factories.default_logger``.
-    Implementations: ``UnifiedLoggerImpl``.
+    Реализация должна предоставляться инфраструктурой через DI-контейнер
+    по контракту доменного слоя.
     """
 
     @abstractmethod
@@ -42,9 +42,7 @@ class ProgressReporterABC(ABC):
     """
     Интерфейс отчетности о прогрессе.
 
-    Default factory:
-    ``bioetl.infrastructure.logging.factories.default_progress_reporter``.
-    Implementations: ``TqdmProgressReporterImpl``.
+    Реализация выбирается инфраструктурой и связывается с контейнером.
     """
 
     @abstractmethod
@@ -76,7 +74,7 @@ class TracerABC(ABC):
     """
     Интерфейс распределенной трассировки.
 
-    Implementations expected to be provided by infrastructure tracing backends.
+    Реализации предоставляются адаптерами инфраструктуры (трассировка).
     """
 
     @abstractmethod

--- a/src/bioetl/domain/clients/base/output/contracts.py
+++ b/src/bioetl/domain/clients/base/output/contracts.py
@@ -20,8 +20,7 @@ class WriterABC(ABC):
     """
     Запись данных в файл.
 
-    Default factory: ``bioetl.infrastructure.output.factories.default_writer``.
-    Implementations: ``CsvWriterImpl``, ``ParquetWriterImpl``.
+    Реализация предоставляется инфраструктурой через DI-контейнер.
     """
 
     @property
@@ -48,8 +47,7 @@ class MetadataWriterABC(ABC):
     """
     Запись метаданных и отчетов.
 
-    Default factory: ``bioetl.infrastructure.output.factories.default_metadata_writer``.
-    Implementations: ``MetadataWriterImpl``.
+    Реализация предоставляется инфраструктурой через DI-контейнер.
     """
 
     @abstractmethod
@@ -85,8 +83,7 @@ class OutputWriterABC(ABC):
     """
     Фасад для записи результатов пайплайна (данные + метаданные).
 
-    Default factory: ``bioetl.infrastructure.output.factories.default_output_writer``.
-    Implementations: ``UnifiedOutputWriter``.
+    Реализация предоставляется инфраструктурой через DI-контейнер.
     """
 
     @abstractmethod

--- a/src/bioetl/domain/observability/contracts.py
+++ b/src/bioetl/domain/observability/contracts.py
@@ -10,8 +10,7 @@ class LoggingPort(ABC):
     """
     Port describing structured logging operations.
 
-    Default factory: ``bioetl.infrastructure.observability.factories.default_logging_port``.
-    Implementations: ``StructuredLoggerImpl``.
+    Реализации предоставляются инфраструктурой и должны связываться через DI.
     """
 
     @abstractmethod
@@ -39,8 +38,7 @@ class TracingPort(ABC):
     """
     Port describing distributed tracing operations.
 
-    Default factory: ``bioetl.infrastructure.observability.factories.default_tracing_port``.
-    Implementations: ``TracingAdapterImpl``.
+    Инфраструктура должна предоставить адаптер трассировки и связать его через DI.
     """
 
     @abstractmethod

--- a/src/bioetl/domain/provider_registry.py
+++ b/src/bioetl/domain/provider_registry.py
@@ -15,11 +15,6 @@ __all__ = [
     "MutableProviderRegistryABC",
     "ProviderRegistryLoaderABC",
     "InMemoryProviderRegistry",
-    "register_provider",
-    "get_provider",
-    "list_providers",
-    "reset_provider_registry",
-    "restore_provider_registry",
 ]
 
 
@@ -116,31 +111,3 @@ class InMemoryProviderRegistry(MutableProviderRegistryABC):
             self._providers[definition.id] = definition
 
 
-_registry: MutableProviderRegistryABC = InMemoryProviderRegistry()
-
-
-def register_provider(definition: ProviderDefinition) -> None:
-    """Register provider definition in the default in-memory registry."""
-    _registry.register_provider(definition)
-
-
-def get_provider(provider_id: ProviderId) -> ProviderDefinition:
-    """Return provider definition by id from the default registry."""
-    return _registry.get_provider(provider_id)
-
-
-def list_providers() -> list[ProviderDefinition]:
-    """List provider definitions from the default registry."""
-    return _registry.list_providers()
-
-
-def reset_provider_registry() -> None:
-    """Clear default registry (utility for tests)."""
-    _registry.reset_provider_registry()
-
-
-def restore_provider_registry(
-    definitions: Iterable[ProviderDefinition],
-) -> None:
-    """Restore default registry from provided definitions."""
-    _registry.restore_provider_registry(definitions)

--- a/tests/bioetl/domain/test_provider_registry.py
+++ b/tests/bioetl/domain/test_provider_registry.py
@@ -1,18 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
 
 import pytest
 
 from bioetl.domain.provider_registry import (
+    InMemoryProviderRegistry,
     ProviderAlreadyRegisteredError,
     ProviderNotRegisteredError,
-    get_provider,
-    list_providers,
-    register_provider,
-    reset_provider_registry,
-    restore_provider_registry,
 )
 from bioetl.domain.providers import ProviderComponents, ProviderDefinition, ProviderId
 from bioetl.infrastructure.config.models import DummyProviderConfig
@@ -33,15 +28,12 @@ class DummyComponents(ProviderComponents):
         return resolved_client, config.provider
 
 
-@pytest.fixture(autouse=True)
-def _reset_registry() -> Any:
-    snapshot = list_providers()
-    yield
-    restore_provider_registry(snapshot)
+@pytest.fixture
+def registry() -> InMemoryProviderRegistry:
+    return InMemoryProviderRegistry()
 
 
-def test_register_and_get_provider() -> None:
-    reset_provider_registry()
+def test_register_and_get_provider(registry: InMemoryProviderRegistry) -> None:
     definition = ProviderDefinition(
         id=ProviderId.DUMMY,
         config_type=DummyProviderConfig,
@@ -49,27 +41,26 @@ def test_register_and_get_provider() -> None:
         description="Dummy provider for tests",
     )
 
-    register_provider(definition)
+    registry.register_provider(definition)
 
-    assert get_provider(ProviderId.DUMMY) == definition
-    assert list_providers() == [definition]
+    assert registry.get_provider(ProviderId.DUMMY) == definition
+    assert registry.list_providers() == [definition]
 
 
-def test_unknown_provider_raises() -> None:
-    reset_provider_registry()
-
+def test_unknown_provider_raises(registry: InMemoryProviderRegistry) -> None:
     with pytest.raises(ProviderNotRegisteredError):
-        get_provider(ProviderId.CHEMBL)
+        registry.get_provider(ProviderId.CHEMBL)
 
 
-def test_duplicate_registration_is_rejected() -> None:
-    reset_provider_registry()
+def test_duplicate_registration_is_rejected(
+    registry: InMemoryProviderRegistry,
+) -> None:
     definition = ProviderDefinition(
         id=ProviderId.DUMMY,
         config_type=DummyProviderConfig,
         components=DummyComponents(),
     )
-    register_provider(definition)
+    registry.register_provider(definition)
 
     with pytest.raises(ProviderAlreadyRegisteredError):
-        register_provider(definition)
+        registry.register_provider(definition)

--- a/tests/bioetl/domain/test_provider_registry_contract.py
+++ b/tests/bioetl/domain/test_provider_registry_contract.py
@@ -1,12 +1,8 @@
 import pytest
 
 from bioetl.domain.provider_registry import (
+    InMemoryProviderRegistry,
     ProviderAlreadyRegisteredError,
-    get_provider,
-    list_providers,
-    register_provider,
-    reset_provider_registry,
-    restore_provider_registry,
 )
 from bioetl.domain.providers import (
     BaseProviderConfig,
@@ -52,11 +48,9 @@ class DummyProviderComponents(
         return {"writer_config": config, "client": client}
 
 
-@pytest.fixture(autouse=True)
-def restore_registry_state() -> None:
-    original_definitions = list_providers()
-    yield
-    restore_provider_registry(original_definitions)
+@pytest.fixture
+def registry() -> InMemoryProviderRegistry:
+    return InMemoryProviderRegistry()
 
 
 @pytest.fixture
@@ -80,37 +74,37 @@ def chembl_provider_definition() -> ProviderDefinition:
 
 
 def test_register_and_get_provider(
+    registry: InMemoryProviderRegistry,
     dummy_provider_definition: ProviderDefinition,
 ) -> None:
-    reset_provider_registry()
+    registry.register_provider(dummy_provider_definition)
 
-    register_provider(dummy_provider_definition)
-
-    assert get_provider(dummy_provider_definition.id) is dummy_provider_definition
-    assert list_providers() == [dummy_provider_definition]
+    assert registry.get_provider(dummy_provider_definition.id) is dummy_provider_definition
+    assert registry.list_providers() == [dummy_provider_definition]
 
 
 def test_register_provider_duplicate(
+    registry: InMemoryProviderRegistry,
     dummy_provider_definition: ProviderDefinition,
 ) -> None:
-    reset_provider_registry()
-    register_provider(dummy_provider_definition)
+    registry.register_provider(dummy_provider_definition)
 
     with pytest.raises(ProviderAlreadyRegisteredError):
-        register_provider(dummy_provider_definition)
+        registry.register_provider(dummy_provider_definition)
 
 
 def test_reset_and_restore_provider_registry(
+    registry: InMemoryProviderRegistry,
     dummy_provider_definition: ProviderDefinition,
     chembl_provider_definition: ProviderDefinition,
 ) -> None:
     definitions = [dummy_provider_definition, chembl_provider_definition]
 
-    restore_provider_registry(definitions)
-    assert list_providers() == definitions
+    registry.restore_provider_registry(definitions)
+    assert registry.list_providers() == definitions
 
-    reset_provider_registry()
-    assert list_providers() == []
+    registry.reset_provider_registry()
+    assert registry.list_providers() == []
 
-    restore_provider_registry(definitions)
-    assert list_providers() == definitions
+    registry.restore_provider_registry(definitions)
+    assert registry.list_providers() == definitions


### PR DESCRIPTION
## Summary
- remove infrastructure-specific references from domain ports to keep observability and output contracts pure
- drop the implicit provider registry singleton and rely on explicit registry instances managed by DI
- update provider registry tests to use injected registries and reflect the new contract expectations

## Testing
- python -m pytest tests/bioetl/domain


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69349ef9e948832490b9ec3f58bb0dd0)