### PR TITLE
Rename error policy facade and update references

### DIFF
--- a/docs/architecture/diagrams/class/11-pipeline-classes.mmd
+++ b/docs/architecture/diagrams/class/11-pipeline-classes.mmd
@@ -14,7 +14,7 @@ class ChemblTransformerImpl
 class ChemblExtractionServiceImpl
 class StageRunner
 class HooksManager
-class ErrorPolicyManager
+class ErrorPolicyFacade
 class RecordSource
 class ValidationService
 class NormalizationServiceABC
@@ -38,14 +38,14 @@ ChemblPipelineBase --> HashService
 ChemblPipelineBase --> UnifiedOutputWriter
 PipelineBase --> StageRunner
 PipelineBase --> HooksManager
-PipelineBase --> ErrorPolicyManager
+PipelineBase --> ErrorPolicyFacade
 PipelineBase --> TransformerABC : post_transformer
 PipelineBase --> ExtractorABC
 ChemblExtractorImpl --> ExtractionServiceABC
 ChemblExtractorImpl --> RecordSource
 ChemblTransformerImpl --> TransformerABC
 HooksManager --> PipelineHookABC
-ErrorPolicyManager --> ErrorPolicyABC
+ErrorPolicyFacade --> ErrorPolicyABC
 StageRunner --> HooksManager
-StageRunner --> ErrorPolicyManager
+StageRunner --> ErrorPolicyFacade
 

--- a/docs/architecture/diagrams/class/pipeline-class-structure.mmd
+++ b/docs/architecture/diagrams/class/pipeline-class-structure.mmd
@@ -16,7 +16,7 @@ classDiagram-v2
         +validate(df) DataFrame
         +write(df, path, context) WriteResult
         #_hooks_manager: HooksManager
-        #_error_policy_manager: ErrorPolicyManager
+        #_error_policy_facade: ErrorPolicyFacade
         #_stage_runner: StageRunner
         #_extractor: ExtractorABC
         #_transformer: TransformerABC
@@ -48,7 +48,7 @@ classDiagram-v2
         +reset()
     }
 
-    class ErrorPolicyManager {
+    class ErrorPolicyFacade {
         +execute(stage, context, fn, on_retry)
         +get_last_error_messages()
         +reset()
@@ -110,7 +110,7 @@ classDiagram-v2
     PipelineBase o-- HashService : uses
     PipelineBase o-- UnifiedOutputWriter : uses
     PipelineBase o-- HooksManager : uses
-    PipelineBase o-- ErrorPolicyManager : uses
+    PipelineBase o-- ErrorPolicyFacade : uses
     PipelineBase o-- StageRunner : uses
     PipelineBase o-- PipelineHookABC : has many
     PipelineBase o-- ErrorPolicyABC : uses
@@ -123,9 +123,9 @@ classDiagram-v2
     UnifiedOutputWriter ..> MetadataWriterABC : writes meta
     UnifiedOutputWriter ..> AtomicFileOperation : atomic IO
     HooksManager ..> PipelineHookABC : notifies
-    ErrorPolicyManager ..> ErrorPolicyABC : delegates
+    ErrorPolicyFacade ..> ErrorPolicyABC : delegates
     StageRunner ..> HooksManager : coordinates
-    StageRunner ..> ErrorPolicyManager
+    StageRunner ..> ErrorPolicyFacade
 
     ChemblPipelineBase o-- ChemblExtractorImpl : builds
     ChemblPipelineBase o-- ChemblTransformerImpl : builds
@@ -140,7 +140,7 @@ classDiagram-v2
     class UnifiedOutputWriter domainSecondary
     class StageRunner domainSecondary
     class HooksManager domainSecondary
-    class ErrorPolicyManager domainSecondary
+    class ErrorPolicyFacade domainSecondary
     class ChemblExtractorImpl domainSecondary
     class ChemblTransformerImpl domainSecondary
     class NormalizationServiceABC interface

--- a/docs/architecture/diagrams/component/01-application-components.mmd
+++ b/docs/architecture/diagrams/component/01-application-components.mmd
@@ -21,7 +21,7 @@ subgraph Application["Application Layer"]
     PipelineConfig["PipelineConfig\nconfig.pipeline_config_schema"]:::componentSecondary
     StageRunner["StageRunner\napplication.pipelines.stage_runner"]:::componentSecondary
     Hooks["Hooks (Logging + Metrics)\nLoggingPipelineHookImpl\nMetricsPipelineHookImpl"]:::componentSecondary
-    ErrorPolicy["ErrorPolicyManager\nFailFast/ContinueOnError"]:::componentSecondary
+    ErrorPolicy["ErrorPolicyFacade\nFailFast/ContinueOnError"]:::componentSecondary
     Pipelines["PipelineBase / ChemblPipelineBase /\nChemblEntityPipeline\napplication.pipelines.*"]:::componentSecondary
 end
 class Application group;

--- a/docs/architecture/diagrams/flow/project-package-structure.mmd
+++ b/docs/architecture/diagrams/flow/project-package-structure.mmd
@@ -24,7 +24,7 @@ subgraph Application["Application Layer"]
   Pipelines["PipelineBase / ChemblPipelineBase /\nChemblEntityPipeline\napplication.pipelines.*"]:::componentSecondary
   StageRunner["StageRunner\napplication.pipelines.stage_runner"]:::componentSecondary
   HooksManager["HooksManager\napplication.pipelines.hooks_manager"]:::componentSecondary
-  ErrorPolicyMgr["ErrorPolicyManager\napplication.pipelines.error_policy_manager"]:::componentSecondary
+  ErrorPolicyMgr["ErrorPolicyFacade\napplication.pipelines.error_policy_facade"]:::componentSecondary
   HooksImpl["Logging + Metrics hooks\napplication.pipelines.hooks_impl"]:::componentSecondary
 end
 class Application group;

--- a/src/bioetl.egg-info/SOURCES.txt
+++ b/src/bioetl.egg-info/SOURCES.txt
@@ -18,7 +18,7 @@ src/bioetl/config/pipeline_config_schema.py
 src/bioetl/application/pipelines/__init__.py
 src/bioetl/application/pipelines/base.py
 src/bioetl/application/pipelines/contracts.py
-src/bioetl/application/pipelines/error_policy_manager.py
+src/bioetl/application/pipelines/error_policy_facade.py
 src/bioetl/application/pipelines/hooks_impl.py
 src/bioetl/application/pipelines/hooks_manager.py
 src/bioetl/application/pipelines/registry.py

--- a/src/bioetl/application/pipelines/base.py
+++ b/src/bioetl/application/pipelines/base.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable
 import pandas as pd
 
 from bioetl.application.pipelines.contracts import ExtractorABC
-from bioetl.application.pipelines.error_policy_manager import ErrorPolicyManager
+from bioetl.application.pipelines.error_policy_facade import ErrorPolicyFacade
 from bioetl.application.pipelines.hooks_manager import HooksManager
 from bioetl.application.pipelines.stage_runner import StageRunner
 from bioetl.domain.clients.base.output.contracts import WriteResult
@@ -91,7 +91,7 @@ class PipelineBase(ABC):
             pipeline_id=self._config.id,
         )
         self._error_policy = error_policy or FailFastErrorPolicyImpl()
-        self._error_policy_manager = ErrorPolicyManager(
+        self._error_policy_facade = ErrorPolicyFacade(
             error_policy=self._error_policy,
             hooks_manager=self._hooks_manager,
             logger=self._logger,
@@ -101,7 +101,7 @@ class PipelineBase(ABC):
         )
         self._stage_runner = StageRunner(
             hooks_manager=self._hooks_manager,
-            error_policy_manager=self._error_policy_manager,
+            error_policy_facade=self._error_policy_facade,
             entity_name=self._config.entity_name,
             provider_id=self._provider_id,
         )
@@ -120,14 +120,14 @@ class PipelineBase(ABC):
         Запускает полный цикл ETL-пайплайна.
         """
         self._hooks_manager.reset()
-        self._error_policy_manager.reset()
+        self._error_policy_facade.reset()
         if hasattr(self._hash_service, "reset_state"):
             self._hash_service.reset_state()
 
         context = self._build_context(dry_run)
         self._logger = self._logger.bind(run_id=context.run_id)
         self._hooks_manager.set_logger(self._logger)
-        self._error_policy_manager.set_logger(self._logger)
+        self._error_policy_facade.set_logger(self._logger)
         self._logger.info("Pipeline started", run_id=context.run_id)
         stages_results: list[StageResult] = []
         counters = self._init_stage_counters()
@@ -193,7 +193,7 @@ class PipelineBase(ABC):
                 error.stage,
                 0,
                 success=False,
-                errors=self._error_policy_manager.get_last_error_messages(),
+                errors=self._error_policy_facade.get_last_error_messages(),
             )
             stages_results.append(stage_result)
             self._hooks_manager.notify_stage_end(error.stage, stage_result)
@@ -248,7 +248,7 @@ class PipelineBase(ABC):
         reset_iterator()
         while True:
             try:
-                raw_chunk_obj = self._error_policy_manager.execute(
+                raw_chunk_obj = self._error_policy_facade.execute(
                     "extract",
                     context,
                     lambda: next(chunk_iterator),  # type: ignore
@@ -348,7 +348,7 @@ class PipelineBase(ABC):
             else pd.DataFrame()
         )
 
-        write_result_obj = self._error_policy_manager.execute(
+        write_result_obj = self._error_policy_facade.execute(
             "write",
             context,
             lambda: self.write(
@@ -466,7 +466,7 @@ class PipelineBase(ABC):
     def set_error_policy(self, error_policy: ErrorPolicyABC) -> None:
         """Устанавливает политику обработки ошибок."""
         self._error_policy = error_policy
-        self._error_policy_manager = ErrorPolicyManager(
+        self._error_policy_facade = ErrorPolicyFacade(
             error_policy=error_policy,
             hooks_manager=self._hooks_manager,
             logger=self._logger,
@@ -476,7 +476,7 @@ class PipelineBase(ABC):
         )
         self._stage_runner = StageRunner(
             hooks_manager=self._hooks_manager,
-            error_policy_manager=self._error_policy_manager,
+            error_policy_facade=self._error_policy_facade,
             entity_name=self._config.entity_name,
             provider_id=self._provider_id,
         )
@@ -499,7 +499,7 @@ class PipelineBase(ABC):
     def _create_chunk_iterator(
         self, context: RunContext, **kwargs: Any
     ) -> Iterable[pd.DataFrame]:
-        iterator = self._error_policy_manager.execute(
+        iterator = self._error_policy_facade.execute(
             "extract",
             context,
             lambda: self.iter_chunks(**kwargs),
@@ -521,7 +521,7 @@ class PipelineBase(ABC):
         attempt: int = 1,
     ) -> Any:
         self._hooks_manager.notify_stage_start(stage, context)
-        return self._error_policy_manager.execute(
+        return self._error_policy_facade.execute(
             stage,
             context,
             action,

--- a/src/bioetl/application/pipelines/error_policy_facade.py
+++ b/src/bioetl/application/pipelines/error_policy_facade.py
@@ -11,7 +11,7 @@ from bioetl.domain.pipelines.contracts import ErrorPolicyABC
 from bioetl.domain.providers import ProviderId
 
 
-class ErrorPolicyManager:
+class ErrorPolicyFacade:
     """Делегат для применения политики ошибок и вызова хуков."""
 
     def __init__(

--- a/src/bioetl/application/pipelines/stage_runner.py
+++ b/src/bioetl/application/pipelines/stage_runner.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 
 import pandas as pd
 
-from bioetl.application.pipelines.error_policy_manager import ErrorPolicyManager
+from bioetl.application.pipelines.error_policy_facade import ErrorPolicyFacade
 from bioetl.application.pipelines.hooks_manager import HooksManager
 from bioetl.domain.errors import PipelineStageError
 from bioetl.domain.models import RunContext, RunResult, StageResult
@@ -19,12 +19,12 @@ class StageRunner:
         self,
         *,
         hooks_manager: HooksManager,
-        error_policy_manager: ErrorPolicyManager,
+        error_policy_facade: ErrorPolicyFacade,
         entity_name: str,
         provider_id: ProviderId,
     ) -> None:
         self._hooks_manager = hooks_manager
-        self._error_policy_manager = error_policy_manager
+        self._error_policy_facade = error_policy_facade
         self._entity_name = entity_name
         self._provider_id = provider_id
 
@@ -100,7 +100,7 @@ class StageRunner:
             self._hooks_manager.notify_stage_start(stage, context)
             started = True
 
-        df_result = self._error_policy_manager.execute(stage, context, action)
+        df_result = self._error_policy_facade.execute(stage, context, action)
         if df_result is None:
             raise PipelineStageError(
                 provider=self._provider_id.value,
@@ -150,7 +150,7 @@ class StageRunner:
         count: int = 0,
         chunks: int = 0,
     ) -> RunResult:
-        errors = self._error_policy_manager.get_last_error_messages()
+        errors = self._error_policy_facade.get_last_error_messages()
         stage_result = self.make_stage_result(
             stage,
             count,

--- a/tests/bioetl/application/pipelines/test_pipeline_base.py
+++ b/tests/bioetl/application/pipelines/test_pipeline_base.py
@@ -311,7 +311,7 @@ def test_error_policy_retry_callback_and_skip(
         provider=pipeline._provider_id.value,  # noqa: SLF001
     )
 
-    result_df = pipeline._error_policy_manager.execute(  # noqa: SLF001
+    result_df = pipeline._error_policy_facade.execute(  # noqa: SLF001
         "extract",
         context,
         failing_action,
@@ -322,7 +322,7 @@ def test_error_policy_retry_callback_and_skip(
     assert result_df.empty
     assert attempts["count"] == 2
     on_retry.assert_called_once()
-    last_error = pipeline._error_policy_manager.last_error  # noqa: SLF001
+    last_error = pipeline._error_policy_facade.last_error  # noqa: SLF001
     assert last_error is not None
     assert last_error.attempt == 2
 

--- a/tests/bioetl/application/pipelines/test_pipeline_collaborators.py
+++ b/tests/bioetl/application/pipelines/test_pipeline_collaborators.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 import pandas as pd
 import pytest
 
-from bioetl.application.pipelines.error_policy_manager import ErrorPolicyManager
+from bioetl.application.pipelines.error_policy_facade import ErrorPolicyFacade
 from bioetl.application.pipelines.hooks_impl import ContinueOnErrorPolicyImpl
 from bioetl.application.pipelines.hooks_manager import HooksManager
 from bioetl.application.pipelines.stage_runner import StageRunner
@@ -47,14 +47,14 @@ def test_hooks_manager_notifies_hooks(mock_logger):
 
 
 @pytest.mark.unit
-def test_error_policy_manager_retry_and_skip(mock_logger):
+def test_error_policy_facade_retry_and_skip(mock_logger):
     hooks_manager = HooksManager(
         logger=mock_logger,
         provider_id=ProviderId("chembl"),
         entity_name="entity",
     )
     policy = ContinueOnErrorPolicyImpl(max_retries=1)
-    manager = ErrorPolicyManager(
+    manager = ErrorPolicyFacade(
         error_policy=policy,
         hooks_manager=hooks_manager,
         logger=mock_logger,
@@ -83,7 +83,7 @@ def test_stage_runner_process_and_failure(mock_logger):
         provider_id=ProviderId("chembl"),
         entity_name="entity",
     )
-    manager = ErrorPolicyManager(
+    manager = ErrorPolicyFacade(
         error_policy=ContinueOnErrorPolicyImpl(),
         hooks_manager=hooks_manager,
         logger=mock_logger,
@@ -93,7 +93,7 @@ def test_stage_runner_process_and_failure(mock_logger):
     )
     runner = StageRunner(
         hooks_manager=hooks_manager,
-        error_policy_manager=manager,
+        error_policy_facade=manager,
         entity_name="entity",
         provider_id=ProviderId("chembl"),
     )
@@ -155,7 +155,7 @@ def test_stage_runner_handles_skip_and_counts(mock_logger):
         provider_id=ProviderId("chembl"),
         entity_name="entity",
     )
-    manager = ErrorPolicyManager(
+    manager = ErrorPolicyFacade(
         error_policy=ContinueOnErrorPolicyImpl(),
         hooks_manager=hooks_manager,
         logger=mock_logger,
@@ -165,7 +165,7 @@ def test_stage_runner_handles_skip_and_counts(mock_logger):
     )
     runner = StageRunner(
         hooks_manager=hooks_manager,
-        error_policy_manager=manager,
+        error_policy_facade=manager,
         entity_name="entity",
         provider_id=ProviderId("chembl"),
     )
@@ -208,7 +208,7 @@ def test_stage_runner_raises_on_missing_result(mock_logger):
         provider_id=ProviderId("chembl"),
         entity_name="entity",
     )
-    manager = ErrorPolicyManager(
+    manager = ErrorPolicyFacade(
         error_policy=ContinueOnErrorPolicyImpl(),
         hooks_manager=hooks_manager,
         logger=mock_logger,
@@ -218,7 +218,7 @@ def test_stage_runner_raises_on_missing_result(mock_logger):
     )
     runner = StageRunner(
         hooks_manager=hooks_manager,
-        error_policy_manager=manager,
+        error_policy_facade=manager,
         entity_name="entity",
         provider_id=ProviderId("chembl"),
     )


### PR DESCRIPTION
## Summary
- rename the error policy component to ErrorPolicyFacade and update module naming
- adjust pipeline collaborators and stage runner to use the new facade naming
- refresh related diagrams and package source list to reflect the rename

## Testing
- pytest tests/bioetl/application/pipelines/test_pipeline_collaborators.py tests/bioetl/application/pipelines/test_pipeline_base.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69353474e04883248448281c0ffdfebd)