### PR TITLE
Rename HooksManager to HooksRegistry

### DIFF
--- a/docs/application/pipelines/chembl/common/00-common-logic.md
+++ b/docs/application/pipelines/chembl/common/00-common-logic.md
@@ -7,7 +7,7 @@
 - Универсальный пайплайн: `ChemblEntityPipeline` (`pipeline.py`) — использует тот же стек для любой сущности; `primary_key` берётся из `PipelineConfig` (`primary_key` или `pipeline.primary_key`, иначе `<entity>_id`).
 - Экстрактор: `ChemblExtractorImpl` (`extractor.py`) — режимы `input_mode`: `api` (по умолчанию), `csv`, `id_only`; использует `CsvRecordSourceImpl`/`IdListRecordSourceImpl` без эвристик колонок.
 - Трансформер: `ChemblTransformerImpl` (`transformer.py`) — последовательность `pre_transform -> do_transform -> normalize -> enforce_schema -> drop_nulls(required)`; обязательные столбцы подтягиваются из `PipelineSchemaContract`.
-- Хуки: `LoggingPipelineHookImpl` + `MetricsPipelineHookImpl` (Prometheus метрики стадий) через `HooksManager`/`StageRunner`; политика ошибок по умолчанию `FailFastErrorPolicyImpl`.
+- Хуки: `LoggingPipelineHookImpl` + `MetricsPipelineHookImpl` (Prometheus метрики стадий) через `HooksRegistry`/`StageRunner`; политика ошибок по умолчанию `FailFastErrorPolicyImpl`.
 
 ## Жизненный цикл (run)
 

--- a/docs/architecture/diagrams/class/11-pipeline-classes.mmd
+++ b/docs/architecture/diagrams/class/11-pipeline-classes.mmd
@@ -13,7 +13,7 @@ class ChemblExtractorImpl
 class ChemblTransformerImpl
 class ChemblExtractionServiceImpl
 class StageRunner
-class HooksManager
+class HooksRegistry
 class ErrorPolicyManager
 class RecordSource
 class ValidationService
@@ -37,15 +37,15 @@ ChemblPipelineBase --> NormalizationServiceABC
 ChemblPipelineBase --> HashService
 ChemblPipelineBase --> UnifiedOutputWriter
 PipelineBase --> StageRunner
-PipelineBase --> HooksManager
+PipelineBase --> HooksRegistry
 PipelineBase --> ErrorPolicyManager
 PipelineBase --> TransformerABC : post_transformer
 PipelineBase --> ExtractorABC
 ChemblExtractorImpl --> ExtractionServiceABC
 ChemblExtractorImpl --> RecordSource
 ChemblTransformerImpl --> TransformerABC
-HooksManager --> PipelineHookABC
+HooksRegistry --> PipelineHookABC
 ErrorPolicyManager --> ErrorPolicyABC
-StageRunner --> HooksManager
+StageRunner --> HooksRegistry
 StageRunner --> ErrorPolicyManager
 

--- a/docs/architecture/diagrams/class/pipeline-class-structure.mmd
+++ b/docs/architecture/diagrams/class/pipeline-class-structure.mmd
@@ -15,7 +15,7 @@ classDiagram-v2
         +transform()* DataFrame
         +validate(df) DataFrame
         +write(df, path, context) WriteResult
-        #_hooks_manager: HooksManager
+        #_hooks_manager: HooksRegistry
         #_error_policy_manager: ErrorPolicyManager
         #_stage_runner: StageRunner
         #_extractor: ExtractorABC
@@ -42,7 +42,7 @@ classDiagram-v2
         +handle_stage_failure(stage, results, context)
     }
 
-    class HooksManager {
+    class HooksRegistry {
         +notify_stage_start(stage, context)
         +notify_stage_end(stage, result)
         +reset()
@@ -109,7 +109,7 @@ classDiagram-v2
     PipelineBase o-- ValidationService : uses
     PipelineBase o-- HashService : uses
     PipelineBase o-- UnifiedOutputWriter : uses
-    PipelineBase o-- HooksManager : uses
+    PipelineBase o-- HooksRegistry : uses
     PipelineBase o-- ErrorPolicyManager : uses
     PipelineBase o-- StageRunner : uses
     PipelineBase o-- PipelineHookABC : has many
@@ -122,9 +122,9 @@ classDiagram-v2
     UnifiedOutputWriter ..> WriterABC : delegates
     UnifiedOutputWriter ..> MetadataWriterABC : writes meta
     UnifiedOutputWriter ..> AtomicFileOperation : atomic IO
-    HooksManager ..> PipelineHookABC : notifies
+    HooksRegistry ..> PipelineHookABC : notifies
     ErrorPolicyManager ..> ErrorPolicyABC : delegates
-    StageRunner ..> HooksManager : coordinates
+    StageRunner ..> HooksRegistry : coordinates
     StageRunner ..> ErrorPolicyManager
 
     ChemblPipelineBase o-- ChemblExtractorImpl : builds
@@ -139,7 +139,7 @@ classDiagram-v2
     class HashService domainSecondary
     class UnifiedOutputWriter domainSecondary
     class StageRunner domainSecondary
-    class HooksManager domainSecondary
+    class HooksRegistry domainSecondary
     class ErrorPolicyManager domainSecondary
     class ChemblExtractorImpl domainSecondary
     class ChemblTransformerImpl domainSecondary

--- a/docs/architecture/diagrams/flow/project-package-structure.mmd
+++ b/docs/architecture/diagrams/flow/project-package-structure.mmd
@@ -23,7 +23,7 @@ subgraph Application["Application Layer"]
   Container["PipelineContainer\napplication.container"]:::componentSecondary
   Pipelines["PipelineBase / ChemblPipelineBase /\nChemblEntityPipeline\napplication.pipelines.*"]:::componentSecondary
   StageRunner["StageRunner\napplication.pipelines.stage_runner"]:::componentSecondary
-  HooksManager["HooksManager\napplication.pipelines.hooks_manager"]:::componentSecondary
+  HooksRegistry["HooksRegistry\napplication.pipelines.hooks_registry"]:::componentSecondary
   ErrorPolicyMgr["ErrorPolicyManager\napplication.pipelines.error_policy_manager"]:::componentSecondary
   HooksImpl["Logging + Metrics hooks\napplication.pipelines.hooks_impl"]:::componentSecondary
 end
@@ -66,9 +66,9 @@ Orchestrator --> PipelineRegistry
 Orchestrator --> Container
 Container --> Pipelines
 Container --> StageRunner
-Container --> HooksManager
+Container --> HooksRegistry
 Container --> ErrorPolicyMgr
-HooksManager --> HooksImpl
+HooksRegistry --> HooksImpl
 Container --> Validation
 Container --> Normalization
 Container --> Transform

--- a/src/bioetl.egg-info/SOURCES.txt
+++ b/src/bioetl.egg-info/SOURCES.txt
@@ -20,7 +20,7 @@ src/bioetl/application/pipelines/base.py
 src/bioetl/application/pipelines/contracts.py
 src/bioetl/application/pipelines/error_policy_manager.py
 src/bioetl/application/pipelines/hooks_impl.py
-src/bioetl/application/pipelines/hooks_manager.py
+src/bioetl/application/pipelines/hooks_registry.py
 src/bioetl/application/pipelines/registry.py
 src/bioetl/application/pipelines/stage_runner.py
 src/bioetl/application/pipelines/chembl/__init__.py

--- a/src/bioetl/application/pipelines/base.py
+++ b/src/bioetl/application/pipelines/base.py
@@ -11,7 +11,7 @@ import pandas as pd
 
 from bioetl.application.pipelines.contracts import ExtractorABC
 from bioetl.application.pipelines.error_policy_manager import ErrorPolicyManager
-from bioetl.application.pipelines.hooks_manager import HooksManager
+from bioetl.application.pipelines.hooks_registry import HooksRegistry
 from bioetl.application.pipelines.stage_runner import StageRunner
 from bioetl.domain.clients.base.output.contracts import WriteResult
 from bioetl.domain.configs import PipelineConfig
@@ -83,7 +83,7 @@ class PipelineBase(ABC):
             FailFastErrorPolicyImpl,
         )
 
-        self._hooks_manager = HooksManager(
+        self._hooks_manager = HooksRegistry(
             logger=self._logger,
             provider_id=self._provider_id,
             entity_name=self._config.entity_name,

--- a/src/bioetl/application/pipelines/error_policy_manager.py
+++ b/src/bioetl/application/pipelines/error_policy_manager.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 
-from bioetl.application.pipelines.hooks_manager import HooksManager
+from bioetl.application.pipelines.hooks_registry import HooksRegistry
 from bioetl.domain.enums import ErrorAction
 from bioetl.domain.errors import PipelineStageError
 from bioetl.domain.models import RunContext
@@ -18,7 +18,7 @@ class ErrorPolicyManager:
         self,
         *,
         error_policy: ErrorPolicyABC,
-        hooks_manager: HooksManager,
+        hooks_manager: HooksRegistry,
         logger: LoggingPort,
         provider_id: ProviderId,
         entity_name: str,

--- a/src/bioetl/application/pipelines/hooks_registry.py
+++ b/src/bioetl/application/pipelines/hooks_registry.py
@@ -9,7 +9,7 @@ from bioetl.domain.observability import LoggingPort
 from bioetl.domain.providers import ProviderId
 
 
-class HooksManager:
+class HooksRegistry:
     """Отвечает за вызовы хуков и измерение времени стадий."""
 
     def __init__(

--- a/src/bioetl/application/pipelines/stage_runner.py
+++ b/src/bioetl/application/pipelines/stage_runner.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 import pandas as pd
 
 from bioetl.application.pipelines.error_policy_manager import ErrorPolicyManager
-from bioetl.application.pipelines.hooks_manager import HooksManager
+from bioetl.application.pipelines.hooks_registry import HooksRegistry
 from bioetl.domain.errors import PipelineStageError
 from bioetl.domain.models import RunContext, RunResult, StageResult
 from bioetl.domain.providers import ProviderId
@@ -18,7 +18,7 @@ class StageRunner:
     def __init__(
         self,
         *,
-        hooks_manager: HooksManager,
+        hooks_manager: HooksRegistry,
         error_policy_manager: ErrorPolicyManager,
         entity_name: str,
         provider_id: ProviderId,

--- a/tests/bioetl/application/pipelines/test_pipeline_collaborators.py
+++ b/tests/bioetl/application/pipelines/test_pipeline_collaborators.py
@@ -7,7 +7,7 @@ import pytest
 
 from bioetl.application.pipelines.error_policy_manager import ErrorPolicyManager
 from bioetl.application.pipelines.hooks_impl import ContinueOnErrorPolicyImpl
-from bioetl.application.pipelines.hooks_manager import HooksManager
+from bioetl.application.pipelines.hooks_registry import HooksRegistry
 from bioetl.application.pipelines.stage_runner import StageRunner
 from bioetl.domain.errors import PipelineStageError
 from bioetl.domain.models import RunContext, StageResult
@@ -20,9 +20,9 @@ def _build_context() -> RunContext:
 
 
 @pytest.mark.unit
-def test_hooks_manager_notifies_hooks(mock_logger):
+def test_hooks_registry_notifies_hooks(mock_logger):
     hook = MagicMock(spec=PipelineHookABC)
-    manager = HooksManager(
+    manager = HooksRegistry(
         logger=mock_logger,
         provider_id=ProviderId("chembl"),
         entity_name="entity",
@@ -48,7 +48,7 @@ def test_hooks_manager_notifies_hooks(mock_logger):
 
 @pytest.mark.unit
 def test_error_policy_manager_retry_and_skip(mock_logger):
-    hooks_manager = HooksManager(
+    hooks_manager = HooksRegistry(
         logger=mock_logger,
         provider_id=ProviderId("chembl"),
         entity_name="entity",
@@ -78,7 +78,7 @@ def test_error_policy_manager_retry_and_skip(mock_logger):
 
 @pytest.mark.unit
 def test_stage_runner_process_and_failure(mock_logger):
-    hooks_manager = HooksManager(
+    hooks_manager = HooksRegistry(
         logger=mock_logger,
         provider_id=ProviderId("chembl"),
         entity_name="entity",
@@ -150,7 +150,7 @@ def test_stage_runner_process_and_failure(mock_logger):
 
 @pytest.mark.unit
 def test_stage_runner_handles_skip_and_counts(mock_logger):
-    hooks_manager = HooksManager(
+    hooks_manager = HooksRegistry(
         logger=mock_logger,
         provider_id=ProviderId("chembl"),
         entity_name="entity",
@@ -203,7 +203,7 @@ def test_stage_runner_handles_skip_and_counts(mock_logger):
 
 @pytest.mark.unit
 def test_stage_runner_raises_on_missing_result(mock_logger):
-    hooks_manager = HooksManager(
+    hooks_manager = HooksRegistry(
         logger=mock_logger,
         provider_id=ProviderId("chembl"),
         entity_name="entity",


### PR DESCRIPTION
## Summary
- rename the pipeline hooks coordinator to HooksRegistry and update imports and tests
- refresh architecture diagrams and documentation references to the new registry name

## Testing
- pytest tests/bioetl/application/pipelines/test_pipeline_collaborators.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693534826cc0832485662ad66c9eda96)