### PR TITLE
Rename transformer implementations to Impl suffix

### DIFF
--- a/src/bioetl/domain/transform/__init__.py
+++ b/src/bioetl/domain/transform/__init__.py
@@ -2,20 +2,20 @@
 
 from bioetl.domain.transform.hash_service import HashService
 from bioetl.domain.transform.transformers import (
-    DatabaseVersionTransformer,
-    FulldateTransformer,
-    HashColumnsTransformer,
-    IndexColumnTransformer,
+    DatabaseVersionTransformerImpl,
+    FulldateTransformerImpl,
+    HashColumnsTransformerImpl,
+    IndexColumnTransformerImpl,
     TransformerABC,
-    TransformerChain,
+    TransformerChainImpl,
 )
 
 __all__ = [
     "TransformerABC",
-    "TransformerChain",
-    "HashColumnsTransformer",
-    "IndexColumnTransformer",
-    "DatabaseVersionTransformer",
-    "FulldateTransformer",
+    "TransformerChainImpl",
+    "HashColumnsTransformerImpl",
+    "IndexColumnTransformerImpl",
+    "DatabaseVersionTransformerImpl",
+    "FulldateTransformerImpl",
     "HashService",
 ]

--- a/src/bioetl/domain/transform/factories.py
+++ b/src/bioetl/domain/transform/factories.py
@@ -4,12 +4,12 @@ from typing import Callable
 
 from bioetl.domain.transform.contracts import HashServiceABC
 from bioetl.domain.transform.transformers import (
-    DatabaseVersionTransformer,
-    FulldateTransformer,
-    HashColumnsTransformer,
-    IndexColumnTransformer,
+    DatabaseVersionTransformerImpl,
+    FulldateTransformerImpl,
+    HashColumnsTransformerImpl,
+    IndexColumnTransformerImpl,
     TransformerABC,
-    TransformerChain,
+    TransformerChainImpl,
 )
 
 __all__ = ["default_post_transformer"]
@@ -24,16 +24,16 @@ def default_post_transformer(
     """Create a default chain of post-transformers."""
 
     provider = version_provider or (lambda: "unknown")
-    return TransformerChain(
+    return TransformerChainImpl(
         [
-            HashColumnsTransformer(
+            HashColumnsTransformerImpl(
                 hash_service=hash_service, business_key_fields=business_key_fields
             ),
-            IndexColumnTransformer(hash_service=hash_service),
-            DatabaseVersionTransformer(
+            IndexColumnTransformerImpl(hash_service=hash_service),
+            DatabaseVersionTransformerImpl(
                 hash_service=hash_service,
                 database_version_provider=provider,
             ),
-            FulldateTransformer(hash_service=hash_service),
+            FulldateTransformerImpl(hash_service=hash_service),
         ]
     )

--- a/src/bioetl/domain/transform/transformers.py
+++ b/src/bioetl/domain/transform/transformers.py
@@ -23,7 +23,7 @@ class TransformerABC(ABC):
         """Выполняет преобразование DataFrame."""
 
 
-class TransformerChain(TransformerABC):
+class TransformerChainImpl(TransformerABC):
     """Комбинирует несколько трансформеров в последовательность."""
 
     def __init__(self, transformers: list[TransformerABC]) -> None:
@@ -38,7 +38,7 @@ class TransformerChain(TransformerABC):
         return result
 
 
-class HashColumnsTransformer(TransformerABC):
+class HashColumnsTransformerImpl(TransformerABC):
     """Добавляет hash_business_key и hash_row."""
 
     def __init__(
@@ -58,7 +58,7 @@ class HashColumnsTransformer(TransformerABC):
         )
 
 
-class IndexColumnTransformer(TransformerABC):
+class IndexColumnTransformerImpl(TransformerABC):
     """Добавляет индексную колонку."""
 
     def __init__(self, hash_service: HashServiceABC) -> None:
@@ -70,7 +70,7 @@ class IndexColumnTransformer(TransformerABC):
         return self._hash_service.add_index_column(df)
 
 
-class DatabaseVersionTransformer(TransformerABC):
+class DatabaseVersionTransformerImpl(TransformerABC):
     """Добавляет колонку с версией базы данных."""
 
     def __init__(
@@ -90,7 +90,7 @@ class DatabaseVersionTransformer(TransformerABC):
         return self._hash_service.add_database_version_column(df, version)
 
 
-class FulldateTransformer(TransformerABC):
+class FulldateTransformerImpl(TransformerABC):
     """Добавляет колонку extracted_at с таймстампом."""
 
     def __init__(self, hash_service: HashServiceABC) -> None:
@@ -104,9 +104,9 @@ class FulldateTransformer(TransformerABC):
 
 __all__ = [
     "TransformerABC",
-    "TransformerChain",
-    "HashColumnsTransformer",
-    "IndexColumnTransformer",
-    "DatabaseVersionTransformer",
-    "FulldateTransformer",
+    "TransformerChainImpl",
+    "HashColumnsTransformerImpl",
+    "IndexColumnTransformerImpl",
+    "DatabaseVersionTransformerImpl",
+    "FulldateTransformerImpl",
 ]

--- a/tests/bioetl/application/pipelines/test_pipeline_base.py
+++ b/tests/bioetl/application/pipelines/test_pipeline_base.py
@@ -19,12 +19,12 @@ from bioetl.domain.models import RunContext
 from bioetl.domain.pipelines.contracts import PipelineHookABC
 from bioetl.domain.transform.factories import default_post_transformer
 from bioetl.domain.transform.transformers import (
-    DatabaseVersionTransformer,
-    FulldateTransformer,
-    HashColumnsTransformer,
-    IndexColumnTransformer,
+    DatabaseVersionTransformerImpl,
+    FulldateTransformerImpl,
+    HashColumnsTransformerImpl,
+    IndexColumnTransformerImpl,
     TransformerABC,
-    TransformerChain,
+    TransformerChainImpl,
 )
 from bioetl.infrastructure.transform.factories import default_hash_service
 
@@ -369,18 +369,18 @@ def test_hashing_logic(
         mock_validation_service,
         mock_output_writer,
     )
-    transformer = HashColumnsTransformer(hash_service, ["id"])
+    transformer = HashColumnsTransformerImpl(hash_service, ["id"])
     df = pd.DataFrame({"id": [1], "val": ["x"]})
     res = transformer.apply(df)
     assert "hash_row" in res.columns
     assert "hash_business_key" in res.columns
     assert res["hash_business_key"].iloc[0] is not None
 
-    transformer_missing = HashColumnsTransformer(hash_service, ["missing_col"])
+    transformer_missing = HashColumnsTransformerImpl(hash_service, ["missing_col"])
     res_missing = transformer_missing.apply(df)
     assert res_missing["hash_business_key"].iloc[0] is None
 
-    transformer_empty = HashColumnsTransformer(hash_service, [])
+    transformer_empty = HashColumnsTransformerImpl(hash_service, [])
     res_empty = transformer_empty.apply(df)
     assert res_empty["hash_business_key"].iloc[0] is None
 
@@ -483,11 +483,11 @@ def _assert_dry_run_meta(
 
 
 def _extract_chain_signature(transformer: TransformerABC) -> list[tuple]:
-    assert isinstance(transformer, TransformerChain)
+    assert isinstance(transformer, TransformerChainImpl)
 
     signature: list[tuple] = []
     for component in transformer._transformers:  # type: ignore[attr-defined]
-        if isinstance(component, HashColumnsTransformer):
+        if isinstance(component, HashColumnsTransformerImpl):
             signature.append(
                 (
                     component.__class__.__name__,
@@ -497,7 +497,7 @@ def _extract_chain_signature(transformer: TransformerABC) -> list[tuple]:
             )
             continue
 
-        if isinstance(component, IndexColumnTransformer):
+        if isinstance(component, IndexColumnTransformerImpl):
             signature.append(
                 (
                     component.__class__.__name__,
@@ -506,7 +506,7 @@ def _extract_chain_signature(transformer: TransformerABC) -> list[tuple]:
             )
             continue
 
-        if isinstance(component, DatabaseVersionTransformer):
+        if isinstance(component, DatabaseVersionTransformerImpl):
             signature.append(
                 (
                     component.__class__.__name__,
@@ -516,7 +516,7 @@ def _extract_chain_signature(transformer: TransformerABC) -> list[tuple]:
             )
             continue
 
-        if isinstance(component, FulldateTransformer):
+        if isinstance(component, FulldateTransformerImpl):
             signature.append(
                 (
                     component.__class__.__name__,


### PR DESCRIPTION
## Summary
- rename transformer implementation classes to use the Impl suffix and update the default post-transformer chain
- adjust pipeline tests to the renamed transformer implementations

## Testing
- pytest tests/bioetl/application/pipelines/test_pipeline_base.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69353526a0dc83249781a70e24393242)