### PR TITLE
Refactor base normalization service into ABC and impl

### DIFF
--- a/docs/ABC_INDEX.md
+++ b/docs/ABC_INDEX.md
@@ -73,6 +73,9 @@
 - `HashServiceABC` — `bioetl.domain.transform.contracts.HashServiceABC`
   - Фасад для вычисления hash_row/hash_business_key и служебных колонок. Default factory: `bioetl.infrastructure.transform.factories.default_hash_service`. Implementation: `bioetl.infrastructure.transform.impl.hash_service_impl.HashServiceImpl`.
 
+- `BaseNormalizationServiceABC` — `bioetl.domain.transform.contracts.BaseNormalizationServiceABC`
+  - Базовый контракт сервисов нормализации. Default factory: ``bioetl.infrastructure.transform.factories.default_base_normalization_service``. Implementations: ``BaseNormalizationServiceImpl``.
+
 - `NormalizationServiceABC` — `bioetl.domain.transform.contracts.NormalizationServiceABC`
   - Сервис нормализации данных в DataFrame. Обязательные операции: - normalize: нормализация единичной записи - normalize_fields: пакетная нормализация DataFrame по конфигурации - normalize_dataframe: совместимый алиас для normalize_fields - normalize_batch: пакетная нормализация чанка - normalize_series: нормализация столбца по конфигурации. Default factory: ``bioetl.infrastructure.transform.factories.default_normalization_service``. Implementations: ``NormalizationServiceImpl``, ``ChemblNormalizationService``.
 

--- a/src/bioetl/domain/transform/contracts.py
+++ b/src/bioetl/domain/transform/contracts.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+from typing import Any, Callable, Protocol
 
 import pandas as pd
 
@@ -34,6 +34,62 @@ class NormalizationConfigProvider(Protocol):
     def fields(self) -> list[dict[str, Any]]:
         """Return fields configuration."""
         ...
+
+
+class BaseNormalizationServiceABC(ABC):
+    """
+    Базовый контракт сервисов нормализации.
+
+    Предоставляет вспомогательные методы для нормализации скалярных и
+    контейнерных значений, а также принудительного приведения типов
+    числовых столбцов. Default factory:
+    ``bioetl.infrastructure.transform.factories.default_base_normalization_service``.
+    Реализации: ``BaseNormalizationServiceImpl``.
+    """
+
+    @abstractmethod
+    def coerce_numeric_columns(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Приводит числовые столбцы к nullable pandas dtypes."""
+
+    @abstractmethod
+    def _resolve_mode(self, field_name: str) -> str:
+        """Определяет режим нормализации для поля."""
+
+    @abstractmethod
+    def _normalize_value(
+        self,
+        value: Any,
+        dtype: str | None,
+        normalizer: Callable[[Any], Any],
+        field_name: str,
+        *,
+        allow_container_normalizer: bool = False,
+        serialize_with_value_normalizer: bool = True,
+    ) -> Any:
+        """Нормализует значение с учетом типа и стратегии сериализации."""
+
+    @abstractmethod
+    def _process_list(
+        self,
+        value: Any,
+        normalizer: Callable[[Any], Any],
+        field_name: str,
+        *,
+        serialize_with_value_normalizer: bool = True,
+    ) -> Any:
+        """Нормализует список значений согласно конфигурации поля."""
+
+    @abstractmethod
+    def _process_dict(
+        self, value: Any, normalizer: Callable[[Any], Any], field_name: str
+    ) -> Any:
+        """Нормализует словарь значений согласно конфигурации поля."""
+
+    @abstractmethod
+    def _normalize_container_item(
+        self, item: Any, normalizer: Callable[[Any], Any]
+    ) -> Any:
+        """Нормализует элемент контейнера (dict/list/tuple)."""
 
 
 class HasherABC(ABC):
@@ -122,6 +178,7 @@ class HashServiceABC(ABC):
 
 
 __all__ = [
+    "BaseNormalizationServiceABC",
     "NormalizationConfig",
     "NormalizationConfigProvider",
     "HasherABC",

--- a/src/bioetl/infrastructure/clients/base/abc_impls.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_impls.yaml
@@ -47,6 +47,11 @@ ValidatorABC:
   implementations:
     Pandera: bioetl.infrastructure.validation.impl.pandera_validator.PanderaValidatorImpl
 
+BaseNormalizationServiceABC:
+  default_factory: bioetl.infrastructure.transform.factories.default_base_normalization_service
+  implementations:
+    Base: bioetl.infrastructure.transform.impl.base_normalizer.BaseNormalizationServiceImpl
+
 NormalizationServiceABC:
   default_factory: bioetl.infrastructure.transform.factories.default_normalization_service
   implementations:

--- a/src/bioetl/infrastructure/clients/base/abc_registry.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_registry.yaml
@@ -30,6 +30,7 @@ TracingPort: bioetl.domain.observability.contracts.TracingPort
 
 HasherABC: bioetl.domain.transform.contracts.HasherABC
 HashServiceABC: bioetl.domain.transform.contracts.HashServiceABC
+BaseNormalizationServiceABC: bioetl.domain.transform.contracts.BaseNormalizationServiceABC
 NormalizationServiceABC: bioetl.domain.transform.contracts.NormalizationServiceABC
 
 ValidatorABC: bioetl.domain.validation.contracts.ValidatorABC

--- a/src/bioetl/infrastructure/transform/factories.py
+++ b/src/bioetl/infrastructure/transform/factories.py
@@ -1,6 +1,7 @@
 """Factories for transform infrastructure components."""
 
 from bioetl.domain.transform.contracts import (
+    BaseNormalizationServiceABC,
     HasherABC,
     HashServiceABC,
     NormalizationConfigProvider,
@@ -8,6 +9,9 @@ from bioetl.domain.transform.contracts import (
 )
 from bioetl.infrastructure.transform.impl.hasher import HasherImpl
 from bioetl.infrastructure.transform.impl.hash_service_impl import HashServiceImpl
+from bioetl.infrastructure.transform.impl.base_normalizer import (
+    BaseNormalizationServiceImpl,
+)
 from bioetl.infrastructure.transform.impl.normalization_service_impl import (
     NormalizationServiceImpl,
 )
@@ -25,6 +29,14 @@ def default_hash_service() -> HashServiceABC:
     return HashServiceImpl(hasher=default_hasher())
 
 
+def default_base_normalization_service(
+    config: NormalizationConfigProvider,
+) -> BaseNormalizationServiceABC:
+    """Создает базовый сервис нормализации."""
+
+    return BaseNormalizationServiceImpl(config)
+
+
 def default_normalization_service(
     config: NormalizationConfigProvider,
 ) -> NormalizationServiceABC:
@@ -33,4 +45,9 @@ def default_normalization_service(
     return NormalizationServiceImpl(config)
 
 
-__all__ = ["default_hasher", "default_hash_service", "default_normalization_service"]
+__all__ = [
+    "default_hasher",
+    "default_hash_service",
+    "default_base_normalization_service",
+    "default_normalization_service",
+]

--- a/src/bioetl/infrastructure/transform/impl/base_normalizer.py
+++ b/src/bioetl/infrastructure/transform/impl/base_normalizer.py
@@ -7,7 +7,10 @@ from typing import Any, Callable, cast
 import pandas as pd
 from pandas._typing import DtypeArg
 
-from bioetl.domain.transform.contracts import NormalizationConfigProvider
+from bioetl.domain.transform.contracts import (
+    BaseNormalizationServiceABC,
+    NormalizationConfigProvider,
+)
 from bioetl.domain.transform.normalizers import normalize_array, normalize_record
 from bioetl.infrastructure.transform.impl.serializer import (
     serialize_dict,
@@ -15,8 +18,8 @@ from bioetl.infrastructure.transform.impl.serializer import (
 )
 
 
-class BaseNormalizationService:
-    """Provide reusable normalization helpers for services."""
+class BaseNormalizationServiceImpl(BaseNormalizationServiceABC):
+    """Provide reusable normalization helpers for normalization services."""
 
     _NUMERIC_DTYPES: dict[str, DtypeArg] = {
         "number": "Float64",
@@ -269,3 +272,6 @@ class BaseNormalizationService:
         if field_name.startswith("id_"):
             return True
         return False
+
+
+__all__ = ["BaseNormalizationServiceImpl"]

--- a/src/bioetl/infrastructure/transform/impl/chembl_normalization_service.py
+++ b/src/bioetl/infrastructure/transform/impl/chembl_normalization_service.py
@@ -17,7 +17,7 @@ from bioetl.domain.transform.normalizers import (
 )
 from bioetl.infrastructure.transform.impl import normalize as normalize_impl
 from bioetl.infrastructure.transform.impl.base_normalizer import (
-    BaseNormalizationService,
+    BaseNormalizationServiceImpl,
 )
 from bioetl.infrastructure.transform.impl.serializer import (
     serialize_dict,
@@ -50,7 +50,7 @@ class NormalizationService(Protocol):
 
 
 class ChemblNormalizationService(
-    BaseNormalizationService, NormalizationServiceABC, NormalizationService
+    BaseNormalizationServiceImpl, NormalizationServiceABC, NormalizationService
 ):
     """Normalization service for ChEMBL records."""
 

--- a/src/bioetl/infrastructure/transform/impl/normalization_service_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/normalization_service_impl.py
@@ -10,7 +10,7 @@ from bioetl.domain.transform.contracts import (
 )
 from bioetl.domain.transform.normalizers import normalize_array, normalize_record
 from bioetl.infrastructure.transform.impl.base_normalizer import (
-    BaseNormalizationService,
+    BaseNormalizationServiceImpl,
 )
 from bioetl.infrastructure.transform.impl import normalize
 from bioetl.infrastructure.transform.impl.serializer import (
@@ -19,7 +19,9 @@ from bioetl.infrastructure.transform.impl.serializer import (
 )
 
 
-class NormalizationServiceImpl(NormalizationServiceABC, BaseNormalizationService):
+class NormalizationServiceImpl(
+    NormalizationServiceABC, BaseNormalizationServiceImpl
+):
     """
     Сервис нормализации данных.
     Выполняет:
@@ -28,7 +30,7 @@ class NormalizationServiceImpl(NormalizationServiceABC, BaseNormalizationService
     """
 
     def __init__(self, config: NormalizationConfigProvider):
-        BaseNormalizationService.__init__(self, config, empty_value=pd.NA)
+        BaseNormalizationServiceImpl.__init__(self, config, empty_value=pd.NA)
 
     def normalize_fields(self, df: pd.DataFrame) -> pd.DataFrame:
         """Проходит по полям конфигурации и применяет нормализацию."""

--- a/src/bioetl/infrastructure/transform/impl/normalize.py
+++ b/src/bioetl/infrastructure/transform/impl/normalize.py
@@ -19,7 +19,7 @@ from bioetl.domain.transform.normalizers import (
 )
 from bioetl.domain.transform.normalizers.registry import get_normalizer
 from bioetl.infrastructure.transform.impl.base_normalizer import (
-    BaseNormalizationService,
+    BaseNormalizationServiceImpl,
 )
 from bioetl.infrastructure.transform.impl.serializer import (
     serialize_dict,
@@ -82,7 +82,9 @@ def _normalize_string_value(value: str, mode: str) -> str | None:
     return val.lower()
 
 
-class NormalizationServiceImpl(NormalizationServiceABC, BaseNormalizationService):
+class NormalizationServiceImpl(
+    NormalizationServiceABC, BaseNormalizationServiceImpl
+):
     """
     Сервис нормализации данных.
     Выполняет:
@@ -91,7 +93,7 @@ class NormalizationServiceImpl(NormalizationServiceABC, BaseNormalizationService
     """
 
     def __init__(self, config: NormalizationConfigProvider):
-        BaseNormalizationService.__init__(self, config, empty_value=pd.NA)
+        BaseNormalizationServiceImpl.__init__(self, config, empty_value=pd.NA)
 
     def normalize(self, raw: pd.Series | dict[str, Any]) -> dict[str, Any]:
         df = pd.DataFrame([raw])


### PR DESCRIPTION
## Summary
- add BaseNormalizationServiceABC contract and default factory
- rename base normalization helper to BaseNormalizationServiceImpl and update services
- sync registries and documentation with the new abstraction

## Testing
- python -m pytest tests/bioetl/domain/test_normalization_service.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935351703388324851c1215361ecb65)