### PR TITLE
Rename database version transformer class

### DIFF
--- a/src/bioetl/domain/transform/__init__.py
+++ b/src/bioetl/domain/transform/__init__.py
@@ -2,7 +2,7 @@
 
 from bioetl.domain.transform.hash_service import HashService
 from bioetl.domain.transform.transformers import (
-    DatabaseVersionTransformerImpl,
+    DatabaseVersionTransformer,
     FulldateTransformerImpl,
     HashColumnsTransformerImpl,
     IndexColumnTransformerImpl,
@@ -15,7 +15,7 @@ __all__ = [
     "TransformerChainImpl",
     "HashColumnsTransformerImpl",
     "IndexColumnTransformerImpl",
-    "DatabaseVersionTransformerImpl",
+    "DatabaseVersionTransformer",
     "FulldateTransformerImpl",
     "HashService",
 ]

--- a/src/bioetl/domain/transform/factories.py
+++ b/src/bioetl/domain/transform/factories.py
@@ -4,7 +4,7 @@ from typing import Callable
 
 from bioetl.domain.transform.contracts import HashServiceABC
 from bioetl.domain.transform.transformers import (
-    DatabaseVersionTransformerImpl,
+    DatabaseVersionTransformer,
     FulldateTransformerImpl,
     HashColumnsTransformerImpl,
     IndexColumnTransformerImpl,
@@ -30,7 +30,7 @@ def default_post_transformer(
                 hash_service=hash_service, business_key_fields=business_key_fields
             ),
             IndexColumnTransformerImpl(hash_service=hash_service),
-            DatabaseVersionTransformerImpl(
+            DatabaseVersionTransformer(
                 hash_service=hash_service,
                 database_version_provider=provider,
             ),

--- a/src/bioetl/domain/transform/transformers.py
+++ b/src/bioetl/domain/transform/transformers.py
@@ -70,7 +70,7 @@ class IndexColumnTransformerImpl(TransformerABC):
         return self._hash_service.add_index_column(df)
 
 
-class DatabaseVersionTransformerImpl(TransformerABC):
+class DatabaseVersionTransformer(TransformerABC):
     """Добавляет колонку с версией базы данных."""
 
     def __init__(
@@ -107,6 +107,6 @@ __all__ = [
     "TransformerChainImpl",
     "HashColumnsTransformerImpl",
     "IndexColumnTransformerImpl",
-    "DatabaseVersionTransformerImpl",
+    "DatabaseVersionTransformer",
     "FulldateTransformerImpl",
 ]

--- a/tests/bioetl/application/pipelines/test_pipeline_base.py
+++ b/tests/bioetl/application/pipelines/test_pipeline_base.py
@@ -19,7 +19,7 @@ from bioetl.domain.models import RunContext
 from bioetl.domain.pipelines.contracts import PipelineHookABC
 from bioetl.domain.transform.factories import default_post_transformer
 from bioetl.domain.transform.transformers import (
-    DatabaseVersionTransformerImpl,
+    DatabaseVersionTransformer,
     FulldateTransformerImpl,
     HashColumnsTransformerImpl,
     IndexColumnTransformerImpl,
@@ -311,7 +311,7 @@ def test_error_policy_retry_callback_and_skip(
         provider=pipeline._provider_id.value,  # noqa: SLF001
     )
 
-    result_df = pipeline._error_policy_facade.execute(  # noqa: SLF001
+    result_df = pipeline._error_policy_manager.execute(  # noqa: SLF001
         "extract",
         context,
         failing_action,
@@ -322,7 +322,7 @@ def test_error_policy_retry_callback_and_skip(
     assert result_df.empty
     assert attempts["count"] == 2
     on_retry.assert_called_once()
-    last_error = pipeline._error_policy_facade.last_error  # noqa: SLF001
+    last_error = pipeline._error_policy_manager.last_error  # noqa: SLF001
     assert last_error is not None
     assert last_error.attempt == 2
 
@@ -506,7 +506,7 @@ def _extract_chain_signature(transformer: TransformerABC) -> list[tuple]:
             )
             continue
 
-        if isinstance(component, DatabaseVersionTransformerImpl):
+        if isinstance(component, DatabaseVersionTransformer):
             signature.append(
                 (
                     component.__class__.__name__,


### PR DESCRIPTION
## Summary
- rename the database version transformer to drop the Impl suffix
- update transformer factory chain to use the renamed transformer
- adjust pipeline base tests to match the new transformer name

## Testing
- pytest tests/bioetl/application/pipelines/test_pipeline_base.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693538b846dc8324806451e95e2a38ac)