### PR TITLE
Use run context timestamp for fulldate transformer

### DIFF
--- a/docs/application/pipelines/chembl/activity/00-activity-chembl-overview.md
+++ b/docs/application/pipelines/chembl/activity/00-activity-chembl-overview.md
@@ -7,7 +7,7 @@
 ## Компоненты
 - `ChemblExtractorImpl` — API/CSV/ID-list режимы через `input_mode`.
 - `ChemblTransformerImpl` — приводит к `activity`-схеме, убирает строки с null в обязательных столбцах.
-- Post-transform: `HashColumnsTransformer`, `LocalIndexColumnTransformer`, `DatabaseVersionTransformer`, `FulldateTransformer`.
+- Post-transform: `HashColumnsTransformer`, `LocalIndexColumnTransformer`, `DatabaseVersionTransformer`, `FulldateTransformerImpl`.
 - `ValidationService` + Pandera-схема `chembl.activity`.
 - `UnifiedOutputWriter` — стабильная сортировка, атомарная запись `<output>/activity.csv`, `meta.yaml`.
 

--- a/docs/application/pipelines/chembl/common/00-common-logic.md
+++ b/docs/application/pipelines/chembl/common/00-common-logic.md
@@ -12,7 +12,7 @@
 ## Жизненный цикл (run)
 
 1) `iter_chunks` вызывает `ChemblExtractorImpl` (API/CSV/ID list).  
-2) `transform` применяет `ChemblTransformerImpl` + post-transform цепочку по умолчанию (`HashColumnsTransformer`, `LocalIndexColumnTransformer`, `DatabaseVersionTransformer`, `FulldateTransformer`).
+2) `transform` применяет `ChemblTransformerImpl` + post-transform цепочку по умолчанию (`HashColumnsTransformer`, `LocalIndexColumnTransformer`, `DatabaseVersionTransformer`, `FulldateTransformerImpl`).
 3) `validate` использует `ValidationService` + Pandera-схемы (`domain/schemas/chembl/*`).  
 4) `write` — `UnifiedOutputWriter`: стабильная сортировка по `hashing.business_key_fields`, атомарная запись `<entity>.csv`, checksum, `meta.yaml`.  
 5) Error handling — `ErrorPolicyABC` (по умолчанию fail-fast; retry/skip через хуки). Все события проходят через `PipelineHookABC`.

--- a/docs/application/pipelines/chembl/molecule/00-molecule-chembl-overview.md
+++ b/docs/application/pipelines/chembl/molecule/00-molecule-chembl-overview.md
@@ -9,7 +9,7 @@
 
 - `ChemblExtractorImpl` — `input_mode=id_only` по умолчанию, использует `IdListRecordSourceImpl` (список ChEMBL ID из CSV) или API/CSV при смене режима.
 - `ChemblTransformerImpl` — приводит к схеме `molecule`, нормализует вложенные объекты (structures, properties, hierarchy) и убирает null в обязательных столбцах.
-- Post-transform: `HashColumnsTransformer`, `LocalIndexColumnTransformer`, `DatabaseVersionTransformer`, `FulldateTransformer`.
+- Post-transform: `HashColumnsTransformer`, `LocalIndexColumnTransformer`, `DatabaseVersionTransformer`, `FulldateTransformerImpl`.
 - `ValidationService` + Pandera-схема `chembl.molecule`.
 - `UnifiedOutputWriter` — стабильная сортировка, атомарная запись `<output>/molecule.csv`, `meta.yaml`, QC-отчёты.
 

--- a/docs/architecture/07-diagrams.md
+++ b/docs/architecture/07-diagrams.md
@@ -345,7 +345,7 @@ graph TD
         T_Chain[TransformerChain]
         T_Hash[HashColumnsTransformer]
         T_Index[LocalIndexColumnTransformer]
-        T_Date[FulldateTransformer]
+        T_Date[FulldateTransformerImpl]
         T_ABC[<<TransformerABC>>]
     end
 

--- a/docs/architecture/14-class-diagrams-domain.md
+++ b/docs/architecture/14-class-diagrams-domain.md
@@ -86,7 +86,7 @@ classDiagram
         +apply(df, context) DataFrame
     }
 
-    class FulldateTransformer {
+    class FulldateTransformerImpl {
         -_hash_service: HashService
         +apply(df, context) DataFrame
     }
@@ -95,7 +95,7 @@ classDiagram
     TransformerABC <|-- HashColumnsTransformer
     TransformerABC <|-- LocalIndexColumnTransformer
     TransformerABC <|-- DatabaseVersionTransformer
-    TransformerABC <|-- FulldateTransformer
+    TransformerABC <|-- FulldateTransformerImpl
 ```
 
 ## 3. Hash Service

--- a/docs/architecture/diagrams/class/16-hashing-normalization-classes.mmd
+++ b/docs/architecture/diagrams/class/16-hashing-normalization-classes.mmd
@@ -24,7 +24,7 @@ class TransformerChain {
 class HashColumnsTransformer
 class LocalIndexColumnTransformer
 class DatabaseVersionTransformer
-class FulldateTransformer
+class FulldateTransformerImpl
 
 class BaseNormalizationService
 class NormalizationServiceABC
@@ -38,11 +38,11 @@ TransformerChain --> TransformerABC : components
 HashColumnsTransformer ..|> TransformerABC
 LocalIndexColumnTransformer ..|> TransformerABC
 DatabaseVersionTransformer ..|> TransformerABC
-FulldateTransformer ..|> TransformerABC
+FulldateTransformerImpl ..|> TransformerABC
 TransformerChain --> HashColumnsTransformer
 TransformerChain --> LocalIndexColumnTransformer
 TransformerChain --> DatabaseVersionTransformer
-TransformerChain --> FulldateTransformer
+TransformerChain --> FulldateTransformerImpl
 ChemblNormalizationService --|> BaseNormalizationService
 NormalizationServiceImpl --|> BaseNormalizationService
 ChemblNormalizationService ..|> NormalizationServiceABC
@@ -52,5 +52,5 @@ NormalizationServiceImpl --> NormalizationConfigProvider
 HashColumnsTransformer --> HashService
 LocalIndexColumnTransformer --> HashService
 DatabaseVersionTransformer --> HashService
-FulldateTransformer --> HashService
+FulldateTransformerImpl --> HashService
 

--- a/docs/architecture/diagrams/flow/domain-services-transform.mmd
+++ b/docs/architecture/diagrams/flow/domain-services-transform.mmd
@@ -12,7 +12,7 @@ subgraph Transformers
     T_Chain[TransformerChain]:::domainPrimary
     T_Hash[HashColumnsTransformer]:::domainSecondary
     T_Index[LocalIndexColumnTransformer]:::domainSecondary
-    T_Date[FulldateTransformer]:::domainSecondary
+    T_Date[FulldateTransformerImpl]:::domainSecondary
     T_ABC[<<TransformerABC>>]:::interface
 end
 class Transformers group;

--- a/docs/domain-class-diagrams.md
+++ b/docs/domain-class-diagrams.md
@@ -139,7 +139,7 @@ classDiagram
     class HashColumnsTransformer
     class LocalIndexColumnTransformer
     class DatabaseVersionTransformer
-    class FulldateTransformer
+    class FulldateTransformerImpl
 
     HasherABC <|-- HasherImpl
     HashService --> HasherABC
@@ -147,11 +147,11 @@ classDiagram
     TransformerABC <|-- HashColumnsTransformer
     TransformerABC <|-- LocalIndexColumnTransformer
     TransformerABC <|-- DatabaseVersionTransformer
-    TransformerABC <|-- FulldateTransformer
+    TransformerABC <|-- FulldateTransformerImpl
     HashColumnsTransformer --> HashService
     LocalIndexColumnTransformer --> HashService
     DatabaseVersionTransformer --> HashService
-    FulldateTransformer --> HashService
+    FulldateTransformerImpl --> HashService
 ```
 
 ## Validation and Schemas

--- a/src/bioetl/domain/transform/hash_service.py
+++ b/src/bioetl/domain/transform/hash_service.py
@@ -154,10 +154,15 @@ class HashService(HashServiceABC):
         df["database_version"] = str(database_version)
         return df
 
-    def add_fulldate_column(self, df: pd.DataFrame) -> pd.DataFrame:
+    def add_fulldate_column(
+        self, df: pd.DataFrame, timestamp: datetime | None = None
+    ) -> pd.DataFrame:
         df = df.copy()
         if self._extracted_at is None:
-            self._extracted_at = self._now_provider().isoformat()
+            ts = timestamp or self._now_provider()
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            self._extracted_at = ts.isoformat()
         df["extracted_at"] = self._extracted_at
         return df
 

--- a/src/bioetl/domain/transform/transformers.py
+++ b/src/bioetl/domain/transform/transformers.py
@@ -99,7 +99,8 @@ class FulldateTransformerImpl(TransformerABC):
     def apply(
         self, df: pd.DataFrame, context: RunContext | None = None
     ) -> pd.DataFrame:
-        return self._hash_service.add_fulldate_column(df)
+        timestamp = context.started_at if context else None
+        return self._hash_service.add_fulldate_column(df, timestamp=timestamp)
 
 
 __all__ = [

--- a/tests/bioetl/domain/transform/test_transformers.py
+++ b/tests/bioetl/domain/transform/test_transformers.py
@@ -1,0 +1,42 @@
+from datetime import datetime, timedelta, timezone
+
+import pandas as pd
+
+from bioetl.domain.models import RunContext
+from bioetl.domain.transform.hash_service import HashService
+from bioetl.domain.transform.transformers import FulldateTransformerImpl
+
+
+def test_fulldate_transformer_uses_run_context_timestamp() -> None:
+    df = pd.DataFrame({"value": [1, 2]})
+    started_at = datetime(2024, 5, 6, 7, 8, 9, tzinfo=timezone.utc)
+    context = RunContext(started_at=started_at)
+
+    transformer = FulldateTransformerImpl(HashService())
+
+    result = transformer.apply(df, context)
+
+    assert result["extracted_at"].unique().tolist() == [started_at.isoformat()]
+
+
+def test_fulldate_transformer_localizes_naive_timestamp_once() -> None:
+    df = pd.DataFrame({"value": [1]})
+    base_ts = datetime(2024, 1, 2, 3, 4, 5)
+
+    call_count = 0
+
+    def _now_provider() -> datetime:
+        nonlocal call_count
+        call_count += 1
+        return base_ts + timedelta(seconds=call_count)
+
+    transformer = FulldateTransformerImpl(HashService(now_provider=_now_provider))
+
+    first = transformer.apply(df)
+    second = transformer.apply(df)
+
+    expected_ts = (base_ts + timedelta(seconds=1)).replace(tzinfo=timezone.utc).isoformat()
+
+    assert first["extracted_at"].tolist() == [expected_ts]
+    assert second["extracted_at"].tolist() == [expected_ts]
+    assert call_count == 1


### PR DESCRIPTION
## Summary
- ensure the fulldate transformer uses the run context start time and stores a localized timestamp
- add transformer unit tests covering context timestamps and cached localization behavior
- align documentation references with the FulldateTransformerImpl naming

## Testing
- pytest tests/bioetl/domain/transform/test_transformers.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693538ba03908324b9093b0efe2d3faa)