### PR TITLE
Align hash column transformer naming with Impl suffix

### DIFF
--- a/docs/application/pipelines/chembl/activity/00-activity-chembl-overview.md
+++ b/docs/application/pipelines/chembl/activity/00-activity-chembl-overview.md
@@ -7,7 +7,7 @@
 ## Компоненты
 - `ChemblExtractorImpl` — API/CSV/ID-list режимы через `input_mode`.
 - `ChemblTransformerImpl` — приводит к `activity`-схеме, убирает строки с null в обязательных столбцах.
-- Post-transform: `HashColumnsTransformer`, `LocalIndexColumnTransformer`, `DatabaseVersionTransformer`, `FulldateTransformer`.
+- Post-transform: `HashColumnsTransformerImpl`, `IndexColumnTransformerImpl`, `DatabaseVersionTransformerImpl`, `FulldateTransformerImpl`.
 - `ValidationService` + Pandera-схема `chembl.activity`.
 - `UnifiedOutputWriter` — стабильная сортировка, атомарная запись `<output>/activity.csv`, `meta.yaml`.
 

--- a/docs/application/pipelines/chembl/common/00-common-logic.md
+++ b/docs/application/pipelines/chembl/common/00-common-logic.md
@@ -12,7 +12,7 @@
 ## Жизненный цикл (run)
 
 1) `iter_chunks` вызывает `ChemblExtractorImpl` (API/CSV/ID list).  
-2) `transform` применяет `ChemblTransformerImpl` + post-transform цепочку по умолчанию (`HashColumnsTransformer`, `LocalIndexColumnTransformer`, `DatabaseVersionTransformer`, `FulldateTransformer`).
+2) `transform` применяет `ChemblTransformerImpl` + post-transform цепочку по умолчанию (`HashColumnsTransformerImpl`, `IndexColumnTransformerImpl`, `DatabaseVersionTransformerImpl`, `FulldateTransformerImpl`).
 3) `validate` использует `ValidationService` + Pandera-схемы (`domain/schemas/chembl/*`).  
 4) `write` — `UnifiedOutputWriter`: стабильная сортировка по `hashing.business_key_fields`, атомарная запись `<entity>.csv`, checksum, `meta.yaml`.  
 5) Error handling — `ErrorPolicyABC` (по умолчанию fail-fast; retry/skip через хуки). Все события проходят через `PipelineHookABC`.

--- a/docs/application/pipelines/chembl/molecule/00-molecule-chembl-overview.md
+++ b/docs/application/pipelines/chembl/molecule/00-molecule-chembl-overview.md
@@ -9,7 +9,7 @@
 
 - `ChemblExtractorImpl` — `input_mode=id_only` по умолчанию, использует `IdListRecordSourceImpl` (список ChEMBL ID из CSV) или API/CSV при смене режима.
 - `ChemblTransformerImpl` — приводит к схеме `molecule`, нормализует вложенные объекты (structures, properties, hierarchy) и убирает null в обязательных столбцах.
-- Post-transform: `HashColumnsTransformer`, `LocalIndexColumnTransformer`, `DatabaseVersionTransformer`, `FulldateTransformer`.
+- Post-transform: `HashColumnsTransformerImpl`, `IndexColumnTransformerImpl`, `DatabaseVersionTransformerImpl`, `FulldateTransformerImpl`.
 - `ValidationService` + Pandera-схема `chembl.molecule`.
 - `UnifiedOutputWriter` — стабильная сортировка, атомарная запись `<output>/molecule.csv`, `meta.yaml`, QC-отчёты.
 

--- a/docs/architecture/07-diagrams.md
+++ b/docs/architecture/07-diagrams.md
@@ -342,10 +342,10 @@ id: 55f41c2b-cfd6-431b-9a93-85e8bffc9a9c
 ---
 graph TD
     subgraph "Transformers"
-        T_Chain[TransformerChain]
-        T_Hash[HashColumnsTransformer]
-        T_Index[LocalIndexColumnTransformer]
-        T_Date[FulldateTransformer]
+        T_Chain[TransformerChainImpl]
+        T_Hash[HashColumnsTransformerImpl]
+        T_Index[IndexColumnTransformerImpl]
+        T_Date[FulldateTransformerImpl]
         T_ABC[<<TransformerABC>>]
     end
 

--- a/docs/architecture/14-class-diagrams-domain.md
+++ b/docs/architecture/14-class-diagrams-domain.md
@@ -64,38 +64,38 @@ classDiagram
         +apply(df, context)* DataFrame
     }
 
-    class TransformerChain {
+    class TransformerChainImpl {
         -_transformers: list[TransformerABC]
         +apply(df, context) DataFrame
     }
 
-    class HashColumnsTransformer {
+    class HashColumnsTransformerImpl {
         -_hash_service: HashService
         -_business_key_fields: list[str]
         +apply(df, context) DataFrame
     }
 
-    class LocalIndexColumnTransformer {
+    class IndexColumnTransformerImpl {
         -_hash_service: HashService
         +apply(df, context) DataFrame
     }
 
-    class DatabaseVersionTransformer {
+    class DatabaseVersionTransformerImpl {
         -_hash_service: HashService
         -_database_version_provider: Callable
         +apply(df, context) DataFrame
     }
 
-    class FulldateTransformer {
+    class FulldateTransformerImpl {
         -_hash_service: HashService
         +apply(df, context) DataFrame
     }
 
-    TransformerABC <|-- TransformerChain
-    TransformerABC <|-- HashColumnsTransformer
-    TransformerABC <|-- LocalIndexColumnTransformer
-    TransformerABC <|-- DatabaseVersionTransformer
-    TransformerABC <|-- FulldateTransformer
+    TransformerABC <|-- TransformerChainImpl
+    TransformerABC <|-- HashColumnsTransformerImpl
+    TransformerABC <|-- IndexColumnTransformerImpl
+    TransformerABC <|-- DatabaseVersionTransformerImpl
+    TransformerABC <|-- FulldateTransformerImpl
 ```
 
 ## 3. Hash Service

--- a/docs/architecture/diagrams/class/16-hashing-normalization-classes.mmd
+++ b/docs/architecture/diagrams/class/16-hashing-normalization-classes.mmd
@@ -18,13 +18,13 @@ class HashService {
 }
 
 class TransformerABC
-class TransformerChain {
+class TransformerChainImpl {
   +apply(df, context)
 }
-class HashColumnsTransformer
-class LocalIndexColumnTransformer
-class DatabaseVersionTransformer
-class FulldateTransformer
+class HashColumnsTransformerImpl
+class IndexColumnTransformerImpl
+class DatabaseVersionTransformerImpl
+class FulldateTransformerImpl
 
 class BaseNormalizationService
 class NormalizationServiceABC
@@ -34,23 +34,23 @@ class NormalizationConfigProvider
 
 HasherImpl ..|> HasherABC
 HashService --> HasherABC
-TransformerChain --> TransformerABC : components
-HashColumnsTransformer ..|> TransformerABC
-LocalIndexColumnTransformer ..|> TransformerABC
-DatabaseVersionTransformer ..|> TransformerABC
-FulldateTransformer ..|> TransformerABC
-TransformerChain --> HashColumnsTransformer
-TransformerChain --> LocalIndexColumnTransformer
-TransformerChain --> DatabaseVersionTransformer
-TransformerChain --> FulldateTransformer
+TransformerChainImpl --> TransformerABC : components
+HashColumnsTransformerImpl ..|> TransformerABC
+IndexColumnTransformerImpl ..|> TransformerABC
+DatabaseVersionTransformerImpl ..|> TransformerABC
+FulldateTransformerImpl ..|> TransformerABC
+TransformerChainImpl --> HashColumnsTransformerImpl
+TransformerChainImpl --> IndexColumnTransformerImpl
+TransformerChainImpl --> DatabaseVersionTransformerImpl
+TransformerChainImpl --> FulldateTransformerImpl
 ChemblNormalizationService --|> BaseNormalizationService
 NormalizationServiceImpl --|> BaseNormalizationService
 ChemblNormalizationService ..|> NormalizationServiceABC
 NormalizationServiceImpl ..|> NormalizationServiceABC
 ChemblNormalizationService --> NormalizationConfigProvider
 NormalizationServiceImpl --> NormalizationConfigProvider
-HashColumnsTransformer --> HashService
-LocalIndexColumnTransformer --> HashService
-DatabaseVersionTransformer --> HashService
-FulldateTransformer --> HashService
+HashColumnsTransformerImpl --> HashService
+IndexColumnTransformerImpl --> HashService
+DatabaseVersionTransformerImpl --> HashService
+FulldateTransformerImpl --> HashService
 

--- a/docs/architecture/diagrams/flow/domain-services-transform.mmd
+++ b/docs/architecture/diagrams/flow/domain-services-transform.mmd
@@ -9,10 +9,10 @@ classDef interface       fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#1
 classDef group           fill:#e6ecef,stroke:#333,stroke-width:1.5px,color:#111,font-size:22px;
 
 subgraph Transformers
-    T_Chain[TransformerChain]:::domainPrimary
-    T_Hash[HashColumnsTransformer]:::domainSecondary
-    T_Index[LocalIndexColumnTransformer]:::domainSecondary
-    T_Date[FulldateTransformer]:::domainSecondary
+    T_Chain[TransformerChainImpl]:::domainPrimary
+    T_Hash[HashColumnsTransformerImpl]:::domainSecondary
+    T_Index[IndexColumnTransformerImpl]:::domainSecondary
+    T_Date[FulldateTransformerImpl]:::domainSecondary
     T_ABC[<<TransformerABC>>]:::interface
 end
 class Transformers group;

--- a/docs/domain-class-diagrams.md
+++ b/docs/domain-class-diagrams.md
@@ -135,23 +135,23 @@ classDiagram
     class HasherImpl
     class HashService { +add_hash_columns(); +add_index_column(); +add_database_version_column(); +add_fulldate_column(); +reset_state() }
     class TransformerABC { <<ABC>> +apply(df, context) }
-    class TransformerChain
-    class HashColumnsTransformer
-    class LocalIndexColumnTransformer
-    class DatabaseVersionTransformer
-    class FulldateTransformer
+    class TransformerChainImpl
+    class HashColumnsTransformerImpl
+    class IndexColumnTransformerImpl
+    class DatabaseVersionTransformerImpl
+    class FulldateTransformerImpl
 
     HasherABC <|-- HasherImpl
     HashService --> HasherABC
-    TransformerABC <|-- TransformerChain
-    TransformerABC <|-- HashColumnsTransformer
-    TransformerABC <|-- LocalIndexColumnTransformer
-    TransformerABC <|-- DatabaseVersionTransformer
-    TransformerABC <|-- FulldateTransformer
-    HashColumnsTransformer --> HashService
-    LocalIndexColumnTransformer --> HashService
-    DatabaseVersionTransformer --> HashService
-    FulldateTransformer --> HashService
+    TransformerABC <|-- TransformerChainImpl
+    TransformerABC <|-- HashColumnsTransformerImpl
+    TransformerABC <|-- IndexColumnTransformerImpl
+    TransformerABC <|-- DatabaseVersionTransformerImpl
+    TransformerABC <|-- FulldateTransformerImpl
+    HashColumnsTransformerImpl --> HashService
+    IndexColumnTransformerImpl --> HashService
+    DatabaseVersionTransformerImpl --> HashService
+    FulldateTransformerImpl --> HashService
 ```
 
 ## Validation and Schemas


### PR DESCRIPTION
## Summary
- update ChEMBL pipeline documentation to reference HashColumnsTransformerImpl and other Impl post-transformers
- refresh architecture diagrams to show Impl suffix for hashing-related transformers

## Testing
- pytest tests/bioetl/application/pipelines/test_pipeline_base.py::test_hashing_logic


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693538ba424483249fa2cbc6ca7f288e)