### PR TITLE
Refactor ChEMBL normalization service impl

### DIFF
--- a/src/bioetl/infrastructure/clients/base/abc_impls.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_impls.yaml
@@ -56,7 +56,7 @@ NormalizationServiceABC:
   default_factory: bioetl.infrastructure.transform.factories.default_normalization_service
   implementations:
     Default: bioetl.infrastructure.transform.impl.normalization_service_impl.NormalizationServiceImpl
-    Chembl: bioetl.infrastructure.transform.impl.chembl_normalization_service.ChemblNormalizationService
+    Chembl: bioetl.infrastructure.transform.impl.chembl_normalization_service_impl.ChemblNormalizationServiceImpl
 
 HasherABC:
   default_factory: bioetl.infrastructure.transform.factories.default_hasher

--- a/src/bioetl/infrastructure/transform/factories.py
+++ b/src/bioetl/infrastructure/transform/factories.py
@@ -12,6 +12,9 @@ from bioetl.infrastructure.transform.impl.hash_service_impl import HashServiceIm
 from bioetl.infrastructure.transform.impl.base_normalizer import (
     BaseNormalizationServiceImpl,
 )
+from bioetl.infrastructure.transform.impl.chembl_normalization_service_impl import (
+    ChemblNormalizationServiceImpl,
+)
 from bioetl.infrastructure.transform.impl.normalization_service_impl import (
     NormalizationServiceImpl,
 )
@@ -45,9 +48,18 @@ def default_normalization_service(
     return NormalizationServiceImpl(config)
 
 
+def default_chembl_normalization_service(
+    config: NormalizationConfigProvider,
+) -> NormalizationServiceABC:
+    """Создает сервис нормализации ChEMBL."""
+
+    return ChemblNormalizationServiceImpl(config)
+
+
 __all__ = [
     "default_hasher",
     "default_hash_service",
     "default_base_normalization_service",
     "default_normalization_service",
+    "default_chembl_normalization_service",
 ]

--- a/src/bioetl/infrastructure/transform/impl/__init__.py
+++ b/src/bioetl/infrastructure/transform/impl/__init__.py
@@ -1,9 +1,17 @@
 """Concrete transform implementations."""
 
+from bioetl.infrastructure.transform.impl.chembl_normalization_service_impl import (
+    ChemblNormalizationServiceImpl,
+)
 from bioetl.infrastructure.transform.impl.hash_service_impl import HashServiceImpl
 from bioetl.infrastructure.transform.impl.hasher import HasherImpl
 from bioetl.infrastructure.transform.impl.normalization_service_impl import (
     NormalizationServiceImpl,
 )
 
-__all__ = ["HasherImpl", "HashServiceImpl", "NormalizationServiceImpl"]
+__all__ = [
+    "HasherImpl",
+    "HashServiceImpl",
+    "NormalizationServiceImpl",
+    "ChemblNormalizationServiceImpl",
+]

--- a/src/bioetl/infrastructure/transform/impl/chembl_normalization_service_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/chembl_normalization_service_impl.py
@@ -1,8 +1,8 @@
-"""Domain-level normalization service interfaces."""
+"""ChEMBL-specific normalization service implementation."""
 
 from __future__ import annotations
 
-from typing import Any, Protocol, TypedDict, cast
+from typing import Any, TypedDict, cast
 
 import pandas as pd
 
@@ -31,26 +31,8 @@ class NormalizedRecord(TypedDict, total=False):
     ...
 
 
-class NormalizationService(Protocol):
-    """Protocol for record normalization."""
-
-    def normalize(self, raw: RawRecord) -> NormalizedRecord:
-        """Normalize a single raw record."""
-
-    def normalize_batch(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Normalize an entire DataFrame chunk."""
-
-    def normalize_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Normalize a DataFrame with ChEMBL field rules."""
-
-    def normalize_series(
-        self, series: pd.Series, field_cfg: dict[str, Any]
-    ) -> pd.Series:
-        """Normalize a Series using field configuration."""
-
-
-class ChemblNormalizationService(
-    BaseNormalizationServiceImpl, NormalizationServiceABC, NormalizationService
+class ChemblNormalizationServiceImpl(
+    BaseNormalizationServiceImpl, NormalizationServiceABC
 ):
     """Normalization service for ChEMBL records."""
 

--- a/tests/bioetl/application/pipelines/chembl/document/test_document_pipeline.py
+++ b/tests/bioetl/application/pipelines/chembl/document/test_document_pipeline.py
@@ -74,7 +74,7 @@ def test_transform_chembl_release(pipeline):
             return val.get("chembl_release")
         return val
 
-    # Patch get_normalizer in the module used by ChemblNormalizationService
+    # Patch get_normalizer in the module used by ChemblNormalizationServiceImpl
     with patch(
         "bioetl.infrastructure.transform.impl.normalization_service_impl.get_normalizer"
     ) as mock_get:

--- a/tests/bioetl/domain/test_normalization_service.py
+++ b/tests/bioetl/domain/test_normalization_service.py
@@ -3,8 +3,8 @@ from dataclasses import dataclass, field
 import pandas as pd
 
 from bioetl.domain.transform.contracts import NormalizationConfig
-from bioetl.infrastructure.transform.impl.chembl_normalization_service import (
-    ChemblNormalizationService,
+from bioetl.infrastructure.transform.impl.chembl_normalization_service_impl import (
+    ChemblNormalizationServiceImpl,
 )
 
 
@@ -31,7 +31,7 @@ class _ConfigStub:
 
 
 def test_chembl_normalization_service_normalizes_scalars_and_ids() -> None:
-    service = ChemblNormalizationService(_ConfigStub())
+    service = ChemblNormalizationServiceImpl(_ConfigStub())
     raw = {
         "name": "  Alpha  ",
         "activity_id": "act1",
@@ -48,7 +48,7 @@ def test_chembl_normalization_service_normalizes_scalars_and_ids() -> None:
 
 
 def test_chembl_normalization_service_serializes_nested_values() -> None:
-    service = ChemblNormalizationService(_ConfigStub())
+    service = ChemblNormalizationServiceImpl(_ConfigStub())
     raw = {
         "tags": ["A", "b", ""],
         "metadata": {"key": "Value", "other": None},
@@ -63,7 +63,7 @@ def test_chembl_normalization_service_serializes_nested_values() -> None:
 
 
 def test_chembl_normalization_service_handles_empty_collections() -> None:
-    service = ChemblNormalizationService(_ConfigStub())
+    service = ChemblNormalizationServiceImpl(_ConfigStub())
     raw = {"tags": [], "metadata": {}, "label": "  NoChange "}
 
     normalized = service.normalize(raw)
@@ -74,7 +74,7 @@ def test_chembl_normalization_service_handles_empty_collections() -> None:
 
 
 def test_chembl_normalization_service_normalizes_dataframe_batch() -> None:
-    service = ChemblNormalizationService(_ConfigStub())
+    service = ChemblNormalizationServiceImpl(_ConfigStub())
     df = pd.DataFrame(
         {
             "name": ["  Alpha  ", "Beta"],
@@ -98,7 +98,7 @@ def test_chembl_normalization_service_normalizes_dataframe_batch() -> None:
 
 
 def test_chembl_normalization_service_coerces_numeric_columns() -> None:
-    service = ChemblNormalizationService(_ConfigStub())
+    service = ChemblNormalizationServiceImpl(_ConfigStub())
     df = pd.DataFrame(
         {
             "score": ["1.234", "bad", None],


### PR DESCRIPTION
## Summary
- rename the ChEMBL normalization service implementation to follow the Impl suffix and export it
- add a dedicated factory for the ChEMBL normalization service and update registries
- refresh tests to use the renamed service

## Testing
- python -m pytest tests/bioetl/domain/test_normalization_service.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693538c2e7848324848c20e96fc97f42)