### PR TITLE
Clarify normalization service naming in docs

### DIFF
--- a/docs/01-ABC/INDEX.md
+++ b/docs/01-ABC/INDEX.md
@@ -2,7 +2,7 @@
 <!-- generated -->
 
 - `NormalizationServiceABC` — `bioetl.domain.transform.contracts.NormalizationServiceABC`
-  - Normalization service contract for DataFrame/record pipelines. Default factory: `bioetl.infrastructure.transform.factories.default_normalization_service`. Implementations: `NormalizationServiceImpl`, `ChemblNormalizationService`.
+  - Normalization service contract for DataFrame/record pipelines. Default factory: `bioetl.infrastructure.transform.factories.default_normalization_service`. Implementations: `NormalizationServiceImpl`, `ChemblNormalizationServiceImpl`.
 - `HashServiceABC` — `bioetl.domain.transform.contracts.HashServiceABC`
   - Facade for deterministic hash columns; default factory: `bioetl.infrastructure.transform.factories.default_hash_service`. Implementation: `bioetl.infrastructure.transform.impl.hash_service_impl.HashServiceImpl`.
 - `ProviderRegistryABC` — `bioetl.domain.provider_registry.ProviderRegistryABC`

--- a/docs/02-pipelines/01-pipeline-core-normalization.md
+++ b/docs/02-pipelines/01-pipeline-core-normalization.md
@@ -2,18 +2,18 @@
 
 ## Overview
 
-Normalization is driven by `NormalizationServiceABC` (`bioetl.domain.transform.contracts`) backed by provider-specific services. The base factory `bioetl.infrastructure.transform.factories.default_normalization_service` wires the contract using the shared `NormalizationServiceImpl`, while ChEMBL-specific runs can switch to `ChemblNormalizationService` when registered via `abc_impls.yaml`.
+Normalization is driven by `NormalizationServiceABC` (`bioetl.domain.transform.contracts`) backed by provider-specific services. The base factory `bioetl.infrastructure.transform.factories.default_normalization_service` wires the contract using the shared `NormalizationServiceImpl`, while ChEMBL-specific runs can switch to `ChemblNormalizationServiceImpl` when registered via `abc_impls.yaml`.
 
 ## Components
 
-- **Contracts**: `NormalizationServiceABC`, `NormalizationConfigProvider` (field config access) — declared in `bioetl.domain.transform.contracts`.
+- **Contracts**: `NormalizationServiceABC`, `BaseNormalizationServiceABC`, `NormalizationConfigProvider` (field config access) — declared in `bioetl.domain.transform.contracts`.
 - **Factories**: `default_normalization_service(config)` (`bioetl.infrastructure.transform.factories`) returning the default implementation.
-- **Shared helpers**: `BaseNormalizationService` (`bioetl.infrastructure.transform.impl.base_normalizer`) providing deterministic normalization for scalars and containers, numeric coercion, and empty-value handling.
+- **Shared helpers**: `BaseNormalizationServiceImpl` (`bioetl.infrastructure.transform.impl.base_normalizer`) implementing `BaseNormalizationServiceABC` with deterministic normalization for scalars and containers, numeric coercion, and empty-value handling.
 - **Implementations**:
-  - `NormalizationServiceImpl` (`bioetl.infrastructure.transform.impl.normalization_service_impl`) — generic, config-driven normalization over DataFrames and series.
-  - `ChemblNormalizationService` (`bioetl.infrastructure.transform.impl.chembl_normalization_service`) — specialization that injects ChEMBL-specific normalizers and serialization rules for arrays/records.
+  - `NormalizationServiceImpl` (`bioetl.infrastructure.transform.impl.normalization_service_impl`) — generic, config-driven normalization over DataFrames and series on top of the base helper.
+  - `ChemblNormalizationServiceImpl` (`bioetl.infrastructure.transform.impl.chembl_normalization_service_impl`) — specialization that injects ChEMBL-specific normalizers and serialization rules for arrays/records while leveraging the base helper.
 - **Normalizers**: reusable functions in `bioetl.domain.transform.normalizers` for arrays (`normalize_array`), records (`normalize_record`), and identifier-aware scalar normalization.
 
 ## Registry mapping
 
-`src/bioetl/infrastructure/clients/base/abc_impls.yaml` now lists both `NormalizationServiceImpl` (Default) and `ChemblNormalizationService` (Chembl) under the `NormalizationServiceABC` role to allow provider-specific selection in containers and orchestrator.
+`src/bioetl/infrastructure/clients/base/abc_impls.yaml` now lists both `NormalizationServiceImpl` (Default) and `ChemblNormalizationServiceImpl` (Chembl) under the `NormalizationServiceABC` role to allow provider-specific selection in containers and orchestrator.

--- a/docs/ABC_INDEX.md
+++ b/docs/ABC_INDEX.md
@@ -77,7 +77,7 @@
   - Базовый контракт сервисов нормализации. Default factory: ``bioetl.infrastructure.transform.factories.default_base_normalization_service``. Implementations: ``BaseNormalizationServiceImpl``.
 
 - `NormalizationServiceABC` — `bioetl.domain.transform.contracts.NormalizationServiceABC`
-  - Сервис нормализации данных в DataFrame. Обязательные операции: - normalize: нормализация единичной записи - normalize_fields: пакетная нормализация DataFrame по конфигурации - normalize_dataframe: совместимый алиас для normalize_fields - normalize_batch: пакетная нормализация чанка - normalize_series: нормализация столбца по конфигурации. Default factory: ``bioetl.infrastructure.transform.factories.default_normalization_service``. Implementations: ``NormalizationServiceImpl``, ``ChemblNormalizationService``.
+  - Сервис нормализации данных в DataFrame. Обязательные операции: - normalize: нормализация единичной записи - normalize_fields: пакетная нормализация DataFrame по конфигурации - normalize_dataframe: совместимый алиас для normalize_fields - normalize_batch: пакетная нормализация чанка - normalize_series: нормализация столбца по конфигурации. Default factory: ``bioetl.infrastructure.transform.factories.default_normalization_service``. Implementations: ``NormalizationServiceImpl``, ``ChemblNormalizationServiceImpl``.
 
 - `ValidatorABC` — `bioetl.domain.validation.contracts.ValidatorABC`
   - Валидация данных. Default factory: ``bioetl.infrastructure.validation.factories.default_validator_factory``. Implementations: ``PanderaValidatorImpl`` (`bioetl.infrastructure.validation.impl.pandera_validator`).

--- a/docs/architecture/14-class-diagrams-domain.md
+++ b/docs/architecture/14-class-diagrams-domain.md
@@ -142,31 +142,34 @@ classDiagram
 id: 94ef3597-e183-4cc2-a707-ab005656c990
 ---
 classDiagram
-    class NormalizationService {
-        <<Protocol>>
-        +normalize_record(record, config) NormalizedRecord
-    }
-
-    class ChemblNormalizationService {
-        +normalize_record(record, config) NormalizedRecord
-        -_normalize_field(field_name, value, config)
-    }
-
     class NormalizationServiceABC {
-        <<abstract>>
-        +normalize_record(record, config)* NormalizedRecord
+        <<ABC>>
+        +normalize_record(record, config) NormalizedRecord
     }
 
-    class NormalizationService {
-        -_normalizers: dict[str, Callable]
+    class BaseNormalizationServiceABC { <<ABC>> }
+    class BaseNormalizationServiceImpl {
         +normalize_record(record, config) NormalizedRecord
         -_normalize_scalar(value, mode)
         -_normalize_array(value)
         -_normalize_record(value)
     }
 
-    NormalizationService <|.. ChemblNormalizationService
-    NormalizationServiceABC <|-- NormalizationService
+    class NormalizationServiceImpl {
+        +normalize_record(record, config) NormalizedRecord
+        -_normalize_field(field_name, value, config)
+    }
+
+    class ChemblNormalizationServiceImpl {
+        +normalize_record(record, config) NormalizedRecord
+        -_normalize_field(field_name, value, config)
+    }
+
+    BaseNormalizationServiceImpl ..|> BaseNormalizationServiceABC
+    NormalizationServiceImpl --|> BaseNormalizationServiceImpl
+    ChemblNormalizationServiceImpl --|> BaseNormalizationServiceImpl
+    NormalizationServiceImpl ..|> NormalizationServiceABC
+    ChemblNormalizationServiceImpl ..|> NormalizationServiceABC
 ```
 
 ## 5. Schema Models

--- a/docs/architecture/diagrams/class/12-domain-service-classes.mmd
+++ b/docs/architecture/diagrams/class/12-domain-service-classes.mmd
@@ -14,8 +14,9 @@ class PanderaValidator
 class SchemaRegistry
 
 class NormalizationServiceABC
-class BaseNormalizationService
-class ChemblNormalizationService
+class BaseNormalizationServiceABC
+class BaseNormalizationServiceImpl
+class ChemblNormalizationServiceImpl
 class NormalizationServiceImpl
 class NormalizationConfigProvider
 class NormalizationConfig
@@ -25,11 +26,12 @@ SchemaRegistry ..|> SchemaProviderABC
 PanderaValidator ..|> ValidatorABC
 SchemaRegistry --> PanderaValidator : validator
 
-ChemblNormalizationService --|> BaseNormalizationService
-NormalizationServiceImpl --|> BaseNormalizationService
-ChemblNormalizationService ..|> NormalizationServiceABC
+BaseNormalizationServiceImpl ..|> BaseNormalizationServiceABC
+ChemblNormalizationServiceImpl --|> BaseNormalizationServiceImpl
+NormalizationServiceImpl --|> BaseNormalizationServiceImpl
+ChemblNormalizationServiceImpl ..|> NormalizationServiceABC
 NormalizationServiceImpl ..|> NormalizationServiceABC
-ChemblNormalizationService --> NormalizationConfigProvider
+ChemblNormalizationServiceImpl --> NormalizationConfigProvider
 NormalizationServiceImpl --> NormalizationConfigProvider
 NormalizationConfigProvider --> NormalizationConfig
 

--- a/docs/architecture/diagrams/class/16-hashing-normalization-classes.mmd
+++ b/docs/architecture/diagrams/class/16-hashing-normalization-classes.mmd
@@ -26,9 +26,10 @@ class IndexColumnTransformerImpl
 class DatabaseVersionTransformer
 class FulldateTransformerImpl
 
-class BaseNormalizationService
+class BaseNormalizationServiceABC
+class BaseNormalizationServiceImpl
 class NormalizationServiceABC
-class ChemblNormalizationService
+class ChemblNormalizationServiceImpl
 class NormalizationServiceImpl
 class NormalizationConfigProvider
 
@@ -43,11 +44,12 @@ TransformerChainImpl --> HashColumnsTransformerImpl
 TransformerChainImpl --> IndexColumnTransformerImpl
 TransformerChainImpl --> DatabaseVersionTransformer
 TransformerChainImpl --> FulldateTransformerImpl
-ChemblNormalizationService --|> BaseNormalizationService
-NormalizationServiceImpl --|> BaseNormalizationService
-ChemblNormalizationService ..|> NormalizationServiceABC
+BaseNormalizationServiceImpl ..|> BaseNormalizationServiceABC
+ChemblNormalizationServiceImpl --|> BaseNormalizationServiceImpl
+NormalizationServiceImpl --|> BaseNormalizationServiceImpl
+ChemblNormalizationServiceImpl ..|> NormalizationServiceABC
 NormalizationServiceImpl ..|> NormalizationServiceABC
-ChemblNormalizationService --> NormalizationConfigProvider
+ChemblNormalizationServiceImpl --> NormalizationConfigProvider
 NormalizationServiceImpl --> NormalizationConfigProvider
 HashColumnsTransformerImpl --> HashService
 IndexColumnTransformerImpl --> HashService

--- a/docs/domain-class-diagrams.md
+++ b/docs/domain-class-diagrams.md
@@ -116,16 +116,24 @@ classDiagram
     class RawRecord { <<TypedDict>> ... }
     class NormalizedRecord { <<TypedDict>> ... }
     class NormalizationConfigProvider { <<protocol>> normalization; fields }
-    class NormalizationService { <<protocol>> normalize(); normalize_batch(); normalize_dataframe(); normalize_series() }
-    class ChemblNormalizationService
+    class NormalizationServiceABC { <<ABC>> normalize(); normalize_batch(); normalize_dataframe(); normalize_series() }
+    class BaseNormalizationServiceABC { <<ABC>> }
+    class BaseNormalizationServiceImpl
+    class NormalizationServiceImpl
+    class ChemblNormalizationServiceImpl
 
     RecordSource <|.. InMemoryRecordSource
     RecordSource <|.. ApiRecordSource
     ApiRecordSource --> ExtractionServiceABC
-    ChemblNormalizationService ..|> NormalizationService
-    ChemblNormalizationService --> NormalizationConfigProvider
-    ChemblNormalizationService --> RawRecord
-    ChemblNormalizationService --> NormalizedRecord
+    BaseNormalizationServiceImpl ..|> BaseNormalizationServiceABC
+    NormalizationServiceImpl --|> BaseNormalizationServiceImpl
+    ChemblNormalizationServiceImpl --|> BaseNormalizationServiceImpl
+    NormalizationServiceImpl ..|> NormalizationServiceABC
+    ChemblNormalizationServiceImpl ..|> NormalizationServiceABC
+    NormalizationServiceImpl --> NormalizationConfigProvider
+    ChemblNormalizationServiceImpl --> NormalizationConfigProvider
+    ChemblNormalizationServiceImpl --> RawRecord
+    ChemblNormalizationServiceImpl --> NormalizedRecord
 ```
 
 ## Transformations and Hashing


### PR DESCRIPTION
## Summary
- update normalization pipeline documentation to reflect BaseNormalizationServiceABC/Impl roles and ChemblNormalizationServiceImpl naming
- align class diagrams to show correct inheritance between BaseNormalizationServiceABC, BaseNormalizationServiceImpl, and normalization services
- refresh ABC index entries to list ChemblNormalizationServiceImpl as the implementation

## Testing
- not run (docs-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935335981dc832482e709cb9e2ff6aa)