### PR TITLE
Rename NormalizationConfigProvider protocol to NormalizationConfigProviderProtocol

### DIFF
--- a/src/bioetl/domain/configs/pipeline.py
+++ b/src/bioetl/domain/configs/pipeline.py
@@ -28,7 +28,7 @@ from bioetl.domain.configs.base import (
     QcConfig,
     StorageConfig,
 )
-from bioetl.domain.transform.contracts import NormalizationConfigProvider
+from bioetl.domain.transform.contracts import NormalizationConfigProviderProtocol
 
 
 class PipelineConfig(BaseModel):
@@ -66,8 +66,8 @@ class PipelineConfig(BaseModel):
     def entity_name(self) -> str:
         return self.entity
 
-    def as_normalization_config_provider(self) -> NormalizationConfigProvider:
-        """Return self to satisfy NormalizationConfigProvider protocol."""
+    def as_normalization_config_provider(self) -> NormalizationConfigProviderProtocol:
+        """Return self to satisfy NormalizationConfigProviderProtocol."""
 
         return self
 

--- a/src/bioetl/domain/transform/contracts.py
+++ b/src/bioetl/domain/transform/contracts.py
@@ -18,7 +18,7 @@ class NormalizationConfig:
     fields: list[dict[str, Any]] = field(default_factory=list)
 
 
-class NormalizationConfigProvider(Protocol):
+class NormalizationConfigProviderProtocol(Protocol):
     """
     Protocol for objects that can provide normalization configuration.
 
@@ -180,7 +180,7 @@ class HashServiceABC(ABC):
 __all__ = [
     "BaseNormalizationServiceABC",
     "NormalizationConfig",
-    "NormalizationConfigProvider",
+    "NormalizationConfigProviderProtocol",
     "HasherABC",
     "NormalizationServiceABC",
     "HashServiceABC",

--- a/src/bioetl/infrastructure/clients/chembl/provider.py
+++ b/src/bioetl/infrastructure/clients/chembl/provider.py
@@ -7,7 +7,7 @@ from bioetl.domain.clients.ports import ChemblExtractionPortABC
 from bioetl.domain.configs import ChemblSourceConfig
 from bioetl.domain.providers import ProviderComponents, ProviderDefinition, ProviderId
 from bioetl.domain.transform.contracts import (
-    NormalizationConfigProvider,
+    NormalizationConfigProviderProtocol,
     NormalizationServiceABC,
 )
 from bioetl.infrastructure.chembl_client import (
@@ -43,12 +43,12 @@ class ChemblProviderComponents(
         config: ChemblSourceConfig,
         *,
         client: ChemblDataClientABC | None = None,
-        pipeline_config: NormalizationConfigProvider | None = None,
+        pipeline_config: NormalizationConfigProviderProtocol | None = None,
     ) -> NormalizationServiceABC:
         _ = client  # signature compatibility; normalization independent from client
         if pipeline_config is None:
             raise ValueError(
-                "NormalizationConfigProvider is required to build normalization service"
+                "NormalizationConfigProviderProtocol is required to build normalization service"
             )
         return default_normalization_service(pipeline_config)
 

--- a/src/bioetl/infrastructure/transform/factories.py
+++ b/src/bioetl/infrastructure/transform/factories.py
@@ -4,7 +4,7 @@ from bioetl.domain.transform.contracts import (
     BaseNormalizationServiceABC,
     HasherABC,
     HashServiceABC,
-    NormalizationConfigProvider,
+    NormalizationConfigProviderProtocol,
     NormalizationServiceABC,
 )
 from bioetl.infrastructure.transform.impl.hasher import HasherImpl
@@ -33,7 +33,7 @@ def default_hash_service() -> HashServiceABC:
 
 
 def default_base_normalization_service(
-    config: NormalizationConfigProvider,
+    config: NormalizationConfigProviderProtocol,
 ) -> BaseNormalizationServiceABC:
     """Создает базовый сервис нормализации."""
 
@@ -41,7 +41,7 @@ def default_base_normalization_service(
 
 
 def default_normalization_service(
-    config: NormalizationConfigProvider,
+    config: NormalizationConfigProviderProtocol,
 ) -> NormalizationServiceABC:
     """Создает сервис нормализации по умолчанию."""
 
@@ -49,7 +49,7 @@ def default_normalization_service(
 
 
 def default_chembl_normalization_service(
-    config: NormalizationConfigProvider,
+    config: NormalizationConfigProviderProtocol,
 ) -> NormalizationServiceABC:
     """Создает сервис нормализации ChEMBL."""
 

--- a/src/bioetl/infrastructure/transform/impl/base_normalizer.py
+++ b/src/bioetl/infrastructure/transform/impl/base_normalizer.py
@@ -9,7 +9,7 @@ from pandas._typing import DtypeArg
 
 from bioetl.domain.transform.contracts import (
     BaseNormalizationServiceABC,
-    NormalizationConfigProvider,
+    NormalizationConfigProviderProtocol,
 )
 from bioetl.domain.transform.normalizers import normalize_array, normalize_record
 from bioetl.infrastructure.transform.impl.serializer import (
@@ -26,7 +26,9 @@ class BaseNormalizationServiceImpl(BaseNormalizationServiceABC):
         "integer": "Int64",
     }
 
-    def __init__(self, config: NormalizationConfigProvider, empty_value: Any = None):
+    def __init__(
+        self, config: NormalizationConfigProviderProtocol, empty_value: Any = None
+    ):
         self._config = config
         self._empty_value = empty_value
 

--- a/src/bioetl/infrastructure/transform/impl/chembl_normalization_service_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/chembl_normalization_service_impl.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 from bioetl.domain.record_source import RawRecord
 from bioetl.domain.transform.contracts import (
-    NormalizationConfigProvider,
+    NormalizationConfigProviderProtocol,
     NormalizationServiceABC,
 )
 from bioetl.domain.transform.normalizers import (
@@ -36,7 +36,7 @@ class ChemblNormalizationServiceImpl(
 ):
     """Normalization service for ChEMBL records."""
 
-    def __init__(self, config: NormalizationConfigProvider):
+    def __init__(self, config: NormalizationConfigProviderProtocol):
         super().__init__(config)
 
     def normalize(self, raw: RawRecord | pd.Series) -> NormalizedRecord:

--- a/src/bioetl/infrastructure/transform/impl/normalization_service_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/normalization_service_impl.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, cast
 import pandas as pd
 
 from bioetl.domain.transform.contracts import (
-    NormalizationConfigProvider,
+    NormalizationConfigProviderProtocol,
     NormalizationServiceABC,
 )
 from bioetl.domain.transform.normalizers import normalize_array, normalize_record
@@ -29,7 +29,7 @@ class NormalizationServiceImpl(
     - Нормализацию скалярных типов (float->round, str->trim/lower/upper)
     """
 
-    def __init__(self, config: NormalizationConfigProvider):
+    def __init__(self, config: NormalizationConfigProviderProtocol):
         BaseNormalizationServiceImpl.__init__(self, config, empty_value=pd.NA)
 
     def normalize_fields(self, df: pd.DataFrame) -> pd.DataFrame:

--- a/src/bioetl/infrastructure/transform/impl/normalize.py
+++ b/src/bioetl/infrastructure/transform/impl/normalize.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, cast
 import pandas as pd
 
 from bioetl.domain.transform.contracts import (
-    NormalizationConfigProvider,
+    NormalizationConfigProviderProtocol,
     NormalizationServiceABC,
 )
 from bioetl.domain.transform.normalizers import (
@@ -92,7 +92,7 @@ class NormalizationServiceImpl(
     - Нормализацию скалярных типов (float->round, str->trim/lower/upper)
     """
 
-    def __init__(self, config: NormalizationConfigProvider):
+    def __init__(self, config: NormalizationConfigProviderProtocol):
         BaseNormalizationServiceImpl.__init__(self, config, empty_value=pd.NA)
 
     def normalize(self, raw: pd.Series | dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- rename the normalization config provider protocol to `NormalizationConfigProviderProtocol`
- update pipeline config helpers and normalization service implementations to use the new protocol name
- align factories and ChEMBL provider wiring with the renamed protocol

## Testing
- pytest tests/bioetl/domain/transform tests/bioetl/domain/test_normalization_service.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69353d781f3c8324b8e61046a26577dc)