### PR TITLE
Rename Chembl provider factory

### DIFF
--- a/docs/application/pipelines/chembl/common/00-common-logic.md
+++ b/docs/application/pipelines/chembl/common/00-common-logic.md
@@ -3,7 +3,7 @@
 ## Текущая реализация
 
 - Базовый класс: `ChemblPipelineBase` (`src/bioetl/application/pipelines/chembl/base.py`) — собирает `ChemblExtractorImpl`, `ChemblTransformerImpl`, `HashService`, `ValidationService`, `UnifiedOutputWriter`.
-- DI и провайдеры: `PipelineContainer` + `ProviderRegistryLoader` (`configs/providers.yaml`) регистрируют `ChemblProviderComponents` и создают клиента/сервис экстракции/нормализации.
+- DI и провайдеры: `PipelineContainer` + `ProviderRegistryLoader` (`configs/providers.yaml`) регистрируют `ChemblProviderComponentsFactory` и создают клиента/сервис экстракции/нормализации.
 - Универсальный пайплайн: `ChemblEntityPipeline` (`pipeline.py`) — использует тот же стек для любой сущности; `primary_key` берётся из `PipelineConfig` (`primary_key` или `pipeline.primary_key`, иначе `<entity>_id`).
 - Экстрактор: `ChemblExtractorImpl` (`extractor.py`) — режимы `input_mode`: `api` (по умолчанию), `csv`, `id_only`; использует `CsvRecordSourceImpl`/`IdListRecordSourceImpl` без эвристик колонок.
 - Трансформер: `ChemblTransformerImpl` (`transformer.py`) — последовательность `pre_transform -> do_transform -> normalize -> enforce_schema -> drop_nulls(required)`; обязательные столбцы подтягиваются из `PipelineSchemaContract`.

--- a/docs/architecture/15-class-diagrams-infrastructure.md
+++ b/docs/architecture/15-class-diagrams-infrastructure.md
@@ -402,7 +402,7 @@ classDiagram
         +create_normalization_service(config) NormalizationService
     }
 
-    class ChemblProviderComponents {
+    class ChemblProviderComponentsFactory {
         +create_client(config) ChemblDataClientABC
         +create_normalization_service(config) NormalizationService
     }
@@ -423,7 +423,7 @@ classDiagram
         +provider: str
     }
 
-    ProviderComponents <|.. ChemblProviderComponents
+    ProviderComponents <|.. ChemblProviderComponentsFactory
     ProviderDefinition --> ProviderComponents : contains
     ProviderDefinition --> BaseProviderConfig : uses
     ChemblSourceConfig --|> BaseProviderConfig

--- a/src/bioetl/infrastructure/clients/chembl/provider.py
+++ b/src/bioetl/infrastructure/clients/chembl/provider.py
@@ -17,7 +17,7 @@ from bioetl.infrastructure.chembl_client import (
 from bioetl.infrastructure.transform.factories import default_normalization_service
 
 
-class ChemblProviderComponents(
+class ChemblProviderComponentsFactory(
     ProviderComponents[
         ChemblDataClientABC,
         ChemblExtractionPortABC,
@@ -65,13 +65,13 @@ def register_chembl_provider() -> ProviderDefinition:
     definition = ProviderDefinition(
         id=ProviderId.CHEMBL,
         config_type=ChemblSourceConfig,
-        components=ChemblProviderComponents(),
+        components=ChemblProviderComponentsFactory(),
         description="ChEMBL data provider",
     )
     return definition
 
 
 __all__ = [
-    "ChemblProviderComponents",
+    "ChemblProviderComponentsFactory",
     "register_chembl_provider",
 ]

--- a/tests/bioetl/infrastructure/clients/chembl/test_provider.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_provider.py
@@ -4,7 +4,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from bioetl.domain.transform.contracts import NormalizationServiceABC
-from bioetl.infrastructure.clients.chembl.provider import ChemblProviderComponents
+from bioetl.infrastructure.clients.chembl.provider import (
+    ChemblProviderComponentsFactory,
+)
 from bioetl.infrastructure.config.models import ChemblSourceConfig
 
 
@@ -36,7 +38,7 @@ def chembl_config() -> ChemblSourceConfig:
 
 
 def test_create_normalization_service_uses_factory(monkeypatch, chembl_config):
-    components = ChemblProviderComponents()
+    components = ChemblProviderComponentsFactory()
     pipeline_config = SimpleNamespace(normalization={}, fields=[])
     stub_service = _NormalizationServiceStub()
 
@@ -55,7 +57,7 @@ def test_create_normalization_service_uses_factory(monkeypatch, chembl_config):
 
 
 def test_create_normalization_service_requires_pipeline_config(chembl_config):
-    components = ChemblProviderComponents()
+    components = ChemblProviderComponentsFactory()
 
     with pytest.raises(ValueError):
         components.create_normalization_service(chembl_config)


### PR DESCRIPTION
## Summary
- rename the Chembl provider components factory class and update registration
- refresh tests and documentation references to the new factory name

## Testing
- pytest tests/bioetl/infrastructure/clients/chembl/test_provider.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69354f10d62883248f2ef287b004bcae)