### PR TITLE
Rename schema registry entry model

### DIFF
--- a/configs/naming_exceptions.yaml
+++ b/configs/naming_exceptions.yaml
@@ -112,10 +112,10 @@ exceptions:
 
   - path: src/bioetl/domain/schemas/registry.py
     rule_id: CLASS_FORMAT
-    reason: "Private inner class _SchemaEntry"
+    reason: "Private inner class _SchemaEntryModel"
     owner: domain
     expiry: permanent
-  
+
   - path: src/bioetl/domain/schemas/registry.py
     rule_id: CLASS_SUFFIX
     reason: "Private inner class"

--- a/docs/architecture/14-class-diagrams-domain.md
+++ b/docs/architecture/14-class-diagrams-domain.md
@@ -28,7 +28,7 @@ classDiagram
     }
 
     class SchemaRegistry {
-        -_schemas: dict[str, _SchemaEntry]
+        -_schemas: dict[str, _SchemaEntryModel]
         +register(name, schema, column_order)
         +get_schema(name) Type[DataFrameModel]
         +get_schema_columns(name) list[str]

--- a/docs/domain-class-diagrams.md
+++ b/docs/domain-class-diagrams.md
@@ -169,11 +169,11 @@ classDiagram
     class ValidatorABC { <<ABC>> validate(df); is_valid(df) }
     class SchemaProviderABC { <<ABC>> get_schema(name); list_schemas(); get_schema_columns(name); register(name, schema, column_order) }
     class ValidationService { +validate(df, entity_name); +get_schema(); +get_schema_columns() }
-    class _SchemaEntry { <<dataclass>> schema: pa.DataFrameModel; column_order: list[str]? }
+    class _SchemaEntryModel { <<dataclass>> schema: pa.DataFrameModel; column_order: list[str]? }
     class SchemaRegistry
 
     SchemaProviderABC <|.. SchemaRegistry
-    SchemaRegistry --> _SchemaEntry
+    SchemaRegistry --> _SchemaEntryModel
     ValidationService --> SchemaProviderABC
 ```
 

--- a/src/bioetl/domain/schemas/registry.py
+++ b/src/bioetl/domain/schemas/registry.py
@@ -8,7 +8,7 @@ from bioetl.domain.validation import SchemaProviderABC, schema_type
 
 
 @dataclass
-class _SchemaEntry:
+class _SchemaEntryModel:
     schema: schema_type
     column_order: list[str] | None = None
 
@@ -19,7 +19,7 @@ class SchemaRegistry(SchemaProviderABC):
     """
 
     def __init__(self) -> None:
-        self._schemas: dict[str, _SchemaEntry] = {}
+        self._schemas: dict[str, _SchemaEntryModel] = {}
 
     def register(
         self,
@@ -29,7 +29,7 @@ class SchemaRegistry(SchemaProviderABC):
         column_order: list[str] | None = None,
     ) -> None:
         """Register a schema by name."""
-        self._schemas[name] = _SchemaEntry(schema=schema, column_order=column_order)
+        self._schemas[name] = _SchemaEntryModel(schema=schema, column_order=column_order)
 
     def get_schema(self, name: str) -> schema_type:
         """Get schema by name, raises ValueError if not found."""


### PR DESCRIPTION
## Summary
- rename the schema registry dataclass to `_SchemaEntryModel`
- refresh naming exception reason and class diagram references

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935501a58a48324a3e98dd1103ba2d0)