### PR TITLE
Rename pipeline schema model references

### DIFF
--- a/docs/application/pipelines/chembl/common/00-common-logic.md
+++ b/docs/application/pipelines/chembl/common/00-common-logic.md
@@ -6,7 +6,7 @@
 - DI и провайдеры: `PipelineContainer` + `ProviderRegistryLoader` (`configs/providers.yaml`) регистрируют `ChemblProviderComponentsFactory` и создают клиента/сервис экстракции/нормализации.
 - Универсальный пайплайн: `ChemblEntityPipeline` (`pipeline.py`) — использует тот же стек для любой сущности; `primary_key` берётся из `PipelineConfig` (`primary_key` или `pipeline.primary_key`, иначе `<entity>_id`).
 - Экстрактор: `ChemblExtractorImpl` (`extractor.py`) — режимы `input_mode`: `api` (по умолчанию), `csv`, `id_only`; использует `CsvRecordSourceImpl`/`IdListRecordSourceImpl` без эвристик колонок.
-- Трансформер: `ChemblTransformerImpl` (`transformer.py`) — последовательность `pre_transform -> do_transform -> normalize -> enforce_schema -> drop_nulls(required)`; обязательные столбцы подтягиваются из `PipelineSchemaContract`.
+- Трансформер: `ChemblTransformerImpl` (`transformer.py`) — последовательность `pre_transform -> do_transform -> normalize -> enforce_schema -> drop_nulls(required)`; обязательные столбцы подтягиваются из `PipelineSchemaModel`.
 - Хуки: `LoggingPipelineHookImpl` + `MetricsPipelineHookImpl` (Prometheus метрики стадий) через `HooksManager`/`StageRunnerFacade`; политика ошибок по умолчанию `FailFastErrorPolicyImpl`.
 
 ## Жизненный цикл (run)

--- a/docs/architecture/diagrams/component/01-application-components.mmd
+++ b/docs/architecture/diagrams/component/01-application-components.mmd
@@ -31,7 +31,7 @@ subgraph Domain["Domain Dependencies"]
     Normalization["NormalizationServiceImpl\nbioetl.infrastructure.transform.impl.normalize"]:::componentSecondary
     Hashing["HashServiceABC\nbioetl.domain.transform.contracts"]:::componentSecondary
     Transformers["TransformerChain\nHash/Index/Fulldate/DbVersion"]:::componentSecondary
-    Contracts["PipelineSchemaContract\nbioetl.domain.schemas.pipeline_contracts"]:::componentSecondary
+    Contracts["PipelineSchemaModel\nbioetl.domain.schemas.pipeline_contracts"]:::componentSecondary
     Schemas["SchemaRegistry + PanderaValidator\nbioetl.domain.schemas.registry"]:::componentSecondary
 end
 class Domain group;

--- a/docs/architecture/diagrams/component/02-domain-components.mmd
+++ b/docs/architecture/diagrams/component/02-domain-components.mmd
@@ -14,7 +14,7 @@ subgraph Domain["Domain Layer"]
     Hashing["HashServiceABC\nbioetl.domain.transform.contracts"]:::componentPrimary
     Transformers["TransformerChain\nHash/Index/DbVersion/Fulldate"]:::componentSecondary
     Hasher["HasherImpl\ncanonical serializer"]:::componentSecondary
-    Schemas["SchemaRegistry\nPipelineSchemaContract\nbioetl.domain.schemas.registry"]:::componentSecondary
+    Schemas["SchemaRegistry\nPipelineSchemaModel\nbioetl.domain.schemas.registry"]:::componentSecondary
     Pandera["PanderaValidator\nbioetl.domain.validation.impl"]:::componentSecondary
     Normalizers["Scalar/array/dict normalizers\nbioetl.domain.transform.normalizers.*"]:::componentSecondary
     ProviderRegistry["ProviderRegistry\nbioetl.domain.provider_registry"]:::componentSecondary

--- a/src/bioetl/application/pipelines/chembl/transformer.py
+++ b/src/bioetl/application/pipelines/chembl/transformer.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from bioetl.domain.models import RunContext
 from bioetl.domain.observability import LoggingPortABC
-from bioetl.domain.schemas.pipeline_contracts import PipelineSchemaContract
+from bioetl.domain.schemas.pipeline_contracts import PipelineSchemaModel
 from bioetl.domain.transform.contracts import NormalizationServiceABC
 from bioetl.domain.transform.transformers import TransformerABC
 from bioetl.domain.validation.service import ValidationService
@@ -23,7 +23,7 @@ class ChemblTransformerImpl(TransformerABC):
     def __init__(
         self,
         validation_service: ValidationService,
-        schema_contract: PipelineSchemaContract,
+        schema_contract: PipelineSchemaModel,
         normalization_service: NormalizationServiceABC,
         logger: LoggingPortABC,
     ) -> None:

--- a/src/bioetl/domain/schemas/pipeline_contracts.py
+++ b/src/bioetl/domain/schemas/pipeline_contracts.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
-class PipelineSchemaContract:
+class PipelineSchemaModel:
     """Описание схем для пайплайна."""
 
     pipeline_code: str
@@ -20,9 +20,9 @@ class PipelineSchemaContract:
         return self.output_schema or self.schema_out
 
 
-def _default_contract(code: str, entity: str | None) -> PipelineSchemaContract:
+def _default_contract(code: str, entity: str | None) -> PipelineSchemaModel:
     schema_name = entity or code
-    return PipelineSchemaContract(
+    return PipelineSchemaModel(
         pipeline_code=code,
         schema_out=schema_name,
         schema_in=schema_name,
@@ -30,38 +30,38 @@ def _default_contract(code: str, entity: str | None) -> PipelineSchemaContract:
     )
 
 
-PIPELINE_CONTRACTS: dict[str, PipelineSchemaContract] = {
-    "chembl.activity": PipelineSchemaContract(
+PIPELINE_CONTRACTS: dict[str, PipelineSchemaModel] = {
+    "chembl.activity": PipelineSchemaModel(
         pipeline_code="chembl.activity",
         schema_out="activity",
         schema_in="activity_input",
         output_schema="activity_output",
     ),
-    "chembl.assay": PipelineSchemaContract(
+    "chembl.assay": PipelineSchemaModel(
         pipeline_code="chembl.assay",
         schema_out="assay",
         schema_in="assay_input",
         output_schema="assay_output",
     ),
-    "chembl.document": PipelineSchemaContract(
+    "chembl.document": PipelineSchemaModel(
         pipeline_code="chembl.document",
         schema_out="document",
         schema_in="document_input",
         output_schema="document_output",
     ),
-    "chembl.target": PipelineSchemaContract(
+    "chembl.target": PipelineSchemaModel(
         pipeline_code="chembl.target",
         schema_out="target",
         schema_in="target_input",
         output_schema="target_output",
     ),
-    "chembl.testitem": PipelineSchemaContract(
+    "chembl.testitem": PipelineSchemaModel(
         pipeline_code="chembl.testitem",
         schema_out="testitem",
         schema_in="testitem_input",
         output_schema="testitem_output",
     ),
-    "chembl.molecule": PipelineSchemaContract(
+    "chembl.molecule": PipelineSchemaModel(
         pipeline_code="chembl.molecule",
         schema_out="molecule",
         schema_in="molecule_input",
@@ -72,7 +72,7 @@ PIPELINE_CONTRACTS: dict[str, PipelineSchemaContract] = {
 
 def get_pipeline_contract(
     pipeline_code: str, *, default_entity: str | None = None
-) -> PipelineSchemaContract:
+) -> PipelineSchemaModel:
     """Возвращает контракт схем для пайплайна."""
 
     if pipeline_code in PIPELINE_CONTRACTS:


### PR DESCRIPTION
## Summary
- rename PipelineSchemaContract to PipelineSchemaModel and update the registry factory to use the new type
- update Chembl transformer dependency annotation
- align documentation and component diagrams with the new schema model name

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935501c294083249c2d9774ac323236)