### PR TITLE
Rename progress reporter update methods

### DIFF
--- a/src/bioetl/domain/clients/base/logging/contracts.py
+++ b/src/bioetl/domain/clients/base/logging/contracts.py
@@ -50,24 +50,24 @@ class ProgressReporterABC(ABC):
         """Начинает отслеживание прогресса."""
 
     @abstractmethod
-    def update(self, n: int = 1) -> None:
+    def apply_update(self, n: int = 1) -> None:
         """Обновляет прогресс на n единиц."""
 
     @abstractmethod
-    def finish(self) -> None:
+    def stop_reporting(self) -> None:
         """Завершает отслеживание."""
 
     @contextmanager
     def create_bar(self, total: int, desc: str = "") -> Iterator[Any]:
         """
         Context manager for progress bar.
-        Default implementation delegates to start/finish.
+        Default implementation delegates to start/stop.
         """
         self.start(total, description=desc)
         try:
             yield self
         finally:
-            self.finish()
+            self.stop_reporting()
 
 
 class TracerABC(ABC):

--- a/src/bioetl/infrastructure/logging/impl/progress_reporter.py
+++ b/src/bioetl/infrastructure/logging/impl/progress_reporter.py
@@ -19,12 +19,12 @@ class TqdmProgressReporterImpl(ProgressReporterABC):
             self._pbar.close()
         self._pbar = tqdm(total=total, desc=description)
 
-    def update(self, n: int = 1) -> None:
+    def apply_update(self, n: int = 1) -> None:
         """Advance the progress bar by n steps."""
         if self._pbar is not None:
             self._pbar.update(n)
 
-    def finish(self) -> None:
+    def stop_reporting(self) -> None:
         """Close the progress bar and release resources."""
         if self._pbar is not None:
             self._pbar.close()

--- a/tests/bioetl/infrastructure/logging/test_logging.py
+++ b/tests/bioetl/infrastructure/logging/test_logging.py
@@ -58,6 +58,6 @@ def test_progress_reporter():
             assert progress_bar is not None
 
             # Test update
-            reporter.update(10)
+            reporter.apply_update(10)
 
         mock_tqdm.assert_called()


### PR DESCRIPTION
## Summary
- rename progress reporter interface methods to `apply_update` and `stop_reporting`
- update tqdm implementation and progress reporter tests to use new method names

## Testing
- pytest tests/bioetl/infrastructure/logging/test_logging.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693550a9dfd48324baef96cf53131d34)