### PR TITLE
Rename logger bind to apply_bind

### DIFF
--- a/src/bioetl/application/pipelines/base.py
+++ b/src/bioetl/application/pipelines/base.py
@@ -59,7 +59,7 @@ class PipelineBase(ABC):
     ) -> None:
         self._config = config
         self._provider_id = ProviderId(config.provider)
-        self._logger = logger.bind(
+        self._logger = logger.apply_bind(
             entity=config.entity_name,
             provider=self._provider_id.value,
             pipeline=config.id,
@@ -125,7 +125,7 @@ class PipelineBase(ABC):
             self._hash_service.reset_state()
 
         context = self._build_context(dry_run)
-        self._logger = self._logger.bind(run_id=context.run_id)
+        self._logger = self._logger.apply_bind(run_id=context.run_id)
         self._hooks_manager.set_logger(self._logger)
         self._error_policy_manager.set_logger(self._logger)
         self._logger.info("Pipeline started", run_id=context.run_id)

--- a/src/bioetl/domain/clients/base/logging/contracts.py
+++ b/src/bioetl/domain/clients/base/logging/contracts.py
@@ -34,7 +34,7 @@ class LoggerAdapterABC(ABC):
         """Log warning message."""
 
     @abstractmethod
-    def bind(self, **ctx: Any) -> Self:
+    def apply_bind(self, **ctx: Any) -> Self:
         """Возвращает логгер с привязанным контекстом."""
 
 

--- a/src/bioetl/domain/observability/contracts.py
+++ b/src/bioetl/domain/observability/contracts.py
@@ -30,7 +30,7 @@ class LoggingPortABC(ABC):
         """Log warning message with structured context."""
 
     @abstractmethod
-    def bind(self, **ctx: Any) -> Self:
+    def apply_bind(self, **ctx: Any) -> Self:
         """Return logger instance with bound context."""
 
 

--- a/src/bioetl/infrastructure/logging/impl/unified_logger.py
+++ b/src/bioetl/infrastructure/logging/impl/unified_logger.py
@@ -33,7 +33,7 @@ class UnifiedLoggerImpl(LoggerAdapterABC, LoggingPortABC):
         """Log warning message with structured context."""
         self._logger.warning(msg, **ctx)
 
-    def bind(self, **ctx: Any) -> Self:
+    def apply_bind(self, **ctx: Any) -> Self:
         """Return a logger bound with additional context."""
         return self.__class__(self._logger.bind(**ctx))
 

--- a/src/bioetl/infrastructure/observability/adapters.py
+++ b/src/bioetl/infrastructure/observability/adapters.py
@@ -32,7 +32,7 @@ class StructuredLoggerImpl(LoggingPortABC):
         """Log warning message with structured context."""
         self._logger.warning(msg, **ctx)
 
-    def bind(self, **ctx: Any) -> Self:
+    def apply_bind(self, **ctx: Any) -> Self:
         """Return logger bound with additional context."""
         return self.__class__(self._logger.bind(**ctx))
 

--- a/tests/bioetl/application/test_logging_hook.py
+++ b/tests/bioetl/application/test_logging_hook.py
@@ -24,7 +24,7 @@ class _DummyLogger(LoggingPortABC):
     def warning(self, msg: str, **ctx: object) -> None:
         self.calls.append(("warning", msg, ctx))
 
-    def bind(
+    def apply_bind(
         self, **ctx: object
     ) -> Self:  # pragma: no cover - не используется в тестах
         return self

--- a/tests/bioetl/infrastructure/files/test_csv_record_source.py
+++ b/tests/bioetl/infrastructure/files/test_csv_record_source.py
@@ -53,7 +53,7 @@ class _DummyLogger(LoggingPortABC):
     def warning(self, *args, **kwargs):  # pragma: no cover
         return None
 
-    def bind(self, **kwargs):  # pragma: no cover
+    def apply_bind(self, **kwargs):  # pragma: no cover
         return self
 
 

--- a/tests/bioetl/infrastructure/logging/test_logging.py
+++ b/tests/bioetl/infrastructure/logging/test_logging.py
@@ -34,7 +34,7 @@ def test_unified_logger():
     # UnifiedLoggerImpl usually wraps structlog.get_logger()
 
     # Test binding
-    bound = logger.bind(key="value")
+    bound = logger.apply_bind(key="value")
     assert isinstance(bound, UnifiedLoggerImpl)
     # Check if context is preserved (implementation detail)
 

--- a/tests/bioetl/infrastructure/logging/test_unified_logger.py
+++ b/tests/bioetl/infrastructure/logging/test_unified_logger.py
@@ -36,14 +36,14 @@ def test_log_methods(mock_structlog):
     mock_structlog.warning.assert_called_once_with("warn msg")
 
 
-def test_bind(mock_structlog):
+def test_apply_bind(mock_structlog):
     # Arrange
     bound_mock = MagicMock()
     mock_structlog.bind.return_value = bound_mock
     logger = UnifiedLoggerImpl(mock_structlog)
 
     # Act
-    new_logger = logger.bind(ctx_key="ctx_val")
+    new_logger = logger.apply_bind(ctx_key="ctx_val")
 
     # Assert
     assert isinstance(new_logger, UnifiedLoggerImpl)

--- a/tests/bioetl/interfaces/cli/test_cli.py
+++ b/tests/bioetl/interfaces/cli/test_cli.py
@@ -266,7 +266,7 @@ def test_run_dry_run_pipeline_metadata(
             return result
 
     logger = MagicMock()
-    logger.bind.return_value = logger
+    logger.apply_bind.return_value = logger
     validation_service = MagicMock()
     validation_service.validate.side_effect = lambda df, **__: df
     output_writer = MagicMock()

--- a/tests/bioetl/pipelines/chembl/test_extract_pipeline_errors.py
+++ b/tests/bioetl/pipelines/chembl/test_extract_pipeline_errors.py
@@ -26,7 +26,7 @@ class _LoggerStub:
     def warning(self, msg: str, **ctx):  # pragma: no cover - delegating
         self._logger.warning(msg, extra=ctx)
 
-    def bind(self, **ctx):  # pragma: no cover - delegating
+    def apply_bind(self, **ctx):  # pragma: no cover - delegating
         return self
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,7 +109,7 @@ def mock_config():
 def mock_logger():
     """Create a mock logger."""
     logger = MagicMock(spec=LoggingPortABC)
-    logger.bind.return_value = logger
+    logger.apply_bind.return_value = logger
     return logger
 
 

--- a/tests/integration/test_provider_registry_loader.py
+++ b/tests/integration/test_provider_registry_loader.py
@@ -45,7 +45,7 @@ class RecordingLogger(LoggingPortABC):
     def warning(self, msg: str, **ctx: Any) -> None:
         self.records.append(("warning", msg, ctx))
 
-    def bind(self, **ctx: Any) -> RecordingLogger:
+    def apply_bind(self, **ctx: Any) -> RecordingLogger:
         self.records.append(("bind", "", ctx))
         return self
 


### PR DESCRIPTION
## Summary
- rename logging contract binding method to `apply_bind` and update implementations
- adjust pipeline initialization and test stubs to use the new method name

## Testing
- pytest tests/bioetl/infrastructure/logging/test_unified_logger.py tests/bioetl/infrastructure/logging/test_logging.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693550fcb3ac83249cefb0aa2042f440)