### PR TITLE
Refactor unified client request helpers

### DIFF
--- a/src/bioetl/infrastructure/clients/base/impl/unified_client.py
+++ b/src/bioetl/infrastructure/clients/base/impl/unified_client.py
@@ -42,7 +42,7 @@ class UnifiedAPIClient:
             circuit_breaker_recovery_time=config.circuit_breaker_recovery_time,
         )
 
-    def request(self, method: str, url: str, **kwargs: Any) -> Any:
+    def request_call(self, method: str, url: str, **kwargs: Any) -> Any:
         """Выполнить HTTP-запрос с учетом политик."""
         method_upper = method.upper()
         if method_upper in {"POST", "PUT", "PATCH", "DELETE"}:
@@ -52,13 +52,13 @@ class UnifiedAPIClient:
 
         return self.middleware.request(method, url, **kwargs)
 
-    def get(self, url: str, **kwargs: Any) -> Any:
+    def get_response(self, url: str, **kwargs: Any) -> Any:
         """GET запрос."""
-        return self.request("GET", url, **kwargs)
+        return self.request_call("GET", url, **kwargs)
 
-    def post(self, url: str, **kwargs: Any) -> Any:
+    def request_post(self, url: str, **kwargs: Any) -> Any:
         """POST запрос."""
-        return self.request("POST", url, **kwargs)
+        return self.request_call("POST", url, **kwargs)
 
     def close(self) -> None:
         """Закрыть соединение."""

--- a/tests/bioetl/infrastructure/clients/base/test_middleware.py
+++ b/tests/bioetl/infrastructure/clients/base/test_middleware.py
@@ -342,7 +342,7 @@ def test_idempotency_key_reused_across_retries(monkeypatch, base_client):
         base_client=base_client,
     )
 
-    result = client.request("POST", "http://example.com/resource")
+    result = client.request_call("POST", "http://example.com/resource")
 
     assert result.status_code == 200
     assert base_client.request.call_count == 3
@@ -365,8 +365,8 @@ def test_get_requests_do_not_add_idempotency_key(base_client):
         base_client=base_client,
     )
 
-    client.request("GET", "http://example.com/resource")
-    client.request("HEAD", "http://example.com/resource")
+    client.request_call("GET", "http://example.com/resource")
+    client.request_call("HEAD", "http://example.com/resource")
 
     for call in base_client.request.call_args_list:
         headers = call.kwargs.get("headers")


### PR DESCRIPTION
## Summary
- rename UnifiedAPIClient helper methods to request_call, get_response, and request_post
- update middleware tests to call the renamed helpers

## Testing
- pytest tests/bioetl/infrastructure/clients/base/test_middleware.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935523c4eb0832480be9a9feb66d15d)