### PR TITLE
Rename hasher API methods

### DIFF
--- a/src/bioetl/domain/transform/contracts.py
+++ b/src/bioetl/domain/transform/contracts.py
@@ -98,18 +98,19 @@ class BaseNormalizationServiceABC(ABC):
 class HasherABC(ABC):
     """Хеширование строк."""
 
-    @property
-    def algorithm(self) -> str:
+    def get_algorithm(self) -> str:
         """Используемый алгоритм (по умолчанию blake2b_256)."""
 
         return "blake2b_256"
 
     @abstractmethod
-    def hash_row(self, row: pd.Series) -> str:
+    def compute_hash_row(self, row: pd.Series) -> str:
         """Хеширует строку Series."""
 
     @abstractmethod
-    def hash_columns(self, df: pd.DataFrame, columns: list[str]) -> pd.Series:
+    def compute_hash_columns(
+        self, df: pd.DataFrame, columns: list[str]
+    ) -> pd.Series:
         """Хеширует выбранные колонки DataFrame."""
 
 

--- a/src/bioetl/domain/transform/hash_service.py
+++ b/src/bioetl/domain/transform/hash_service.py
@@ -87,18 +87,17 @@ def _blake2b_hash_hex(data_bytes: bytes, digest_size: int = 32) -> str:
 class _DefaultHasherImpl(HasherABC):
     """Доменная реализация HasherABC с канонической сериализацией."""
 
-    @property
-    def algorithm(self) -> str:
+    def get_algorithm(self) -> str:
         """Return canonical hash algorithm identifier."""
         return "blake2b_256"
 
-    def hash_row(self, row: pd.Series) -> str:
+    def compute_hash_row(self, row: pd.Series) -> str:
         """Hash a pandas Series row using canonical serialization."""
         record = row.to_dict()
         serialized = _serialize_canonical(record)
         return _blake2b_hash_hex(serialized.encode("utf-8"))
 
-    def hash_columns(self, df: pd.DataFrame, columns: list[str]) -> pd.Series:
+    def compute_hash_columns(self, df: pd.DataFrame, columns: list[str]) -> pd.Series:
         """Hash selected columns row-wise; returns Series of digests."""
         if not columns:
             return pd.Series([None] * len(df), index=df.index, dtype=object)
@@ -134,13 +133,15 @@ class HashService(HashServiceABC):
         if business_key_cols:
             cols_to_hash = [c for c in business_key_cols if c in df.columns]
             if cols_to_hash:
-                df["hash_business_key"] = self._hasher.hash_columns(df, cols_to_hash)
+                df["hash_business_key"] = self._hasher.compute_hash_columns(
+                    df, cols_to_hash
+                )
             else:
                 df["hash_business_key"] = None
         else:
             df["hash_business_key"] = None
 
-        df["hash_row"] = df.apply(self._hasher.hash_row, axis=1)
+        df["hash_row"] = df.apply(self._hasher.compute_hash_row, axis=1)
         return df
 
     def add_index_column(self, df: pd.DataFrame) -> pd.DataFrame:

--- a/src/bioetl/infrastructure/transform/impl/hash_service_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/hash_service_impl.py
@@ -41,17 +41,19 @@ class HashServiceImpl(HashServiceABC):
             # Ensure columns exist before hashing
             cols_to_hash = [c for c in business_key_cols if c in df.columns]
             if cols_to_hash:
-                # Uses hash_columns -> list hashing (canonical list)
-                df["hash_business_key"] = self._hasher.hash_columns(df, cols_to_hash)
+                # Uses compute_hash_columns -> list hashing (canonical list)
+                df["hash_business_key"] = self._hasher.compute_hash_columns(
+                    df, cols_to_hash
+                )
             else:
                 df["hash_business_key"] = None
         else:
             df["hash_business_key"] = None
 
         # 2. hash_row
-        # Uses hash_row -> dict hashing (canonical object) of the full row
+        # Uses compute_hash_row -> dict hashing (canonical object) of the full row
         # Note: This includes 'hash_business_key' which was just added/set.
-        df["hash_row"] = df.apply(self._hasher.hash_row, axis=1)
+        df["hash_row"] = df.apply(self._hasher.compute_hash_row, axis=1)
 
         return df
 

--- a/src/bioetl/infrastructure/transform/impl/hasher.py
+++ b/src/bioetl/infrastructure/transform/impl/hasher.py
@@ -93,37 +93,31 @@ class HasherImpl(HasherABC):
     Реализация хеширования (BLAKE2b-256) с канонической JSON сериализацией.
     """
 
-    @property
-    def algorithm(self) -> str:
+    def get_algorithm(self) -> str:
         """Return hash algorithm identifier."""
         return "blake2b_256"
 
-    def hash_row(self, row: pd.Series) -> str:
+    def compute_hash_row(self, row: pd.Series) -> str:
         """
         Хеширует строку Series как полный объект (hash_row).
         """
-        # Convert to dict
         record = row.to_dict()
-        # Serialize canonical
         serialized = _serialize_canonical(record)
-        # Hash
         return blake2b_hash_hex(serialized.encode("utf-8"))
 
-    def hash_columns(self, df: pd.DataFrame, columns: list[str]) -> pd.Series:
+    def compute_hash_columns(self, df: pd.DataFrame, columns: list[str]) -> pd.Series:
         """
         Хеширует выбранные колонки DataFrame (как список значений в заданном порядке).
         Используется для hash_business_key.
         Если columns пуст -> возвращает None (в Series).
         """
         if not columns:
-            # Return series of None
             return pd.Series([None] * len(df), index=df.index, dtype=object)
 
         def _hash_vals(row: pd.Series) -> str | None:
             values = []
             for col in columns:
                 val = row.get(col)
-                # Columns exist in DF; None/NaN handled by serializer.
                 values.append(val)
 
             serialized = _serialize_canonical(values)

--- a/tests/bioetl/application/pipelines/chembl/test_base.py
+++ b/tests/bioetl/application/pipelines/chembl/test_base.py
@@ -26,14 +26,13 @@ class ConcreteChemblPipeline(ChemblPipelineBase):
 def mock_dependencies_fixture():
     """Fixture for pipeline dependencies."""
     class _DummyHasher(HasherABC):
-        @property
-        def algorithm(self):
+        def get_algorithm(self):
             return "sha256"
 
-        def hash_row(self, _row):
+        def compute_hash_row(self, _row):
             return "hash_row"
 
-        def hash_columns(self, df, _columns):
+        def compute_hash_columns(self, df, _columns):
             return pd.Series(["hash_business_key"] * len(df))
 
     config = MagicMock()

--- a/tests/bioetl/domain/transform/test_hashing.py
+++ b/tests/bioetl/domain/transform/test_hashing.py
@@ -75,7 +75,7 @@ def test_hasher_impl_business_key():
 
     # Hash columns
     # Should produce hash of canonical json of [100, "assay"]
-    hashes = hasher.hash_columns(df, fields)
+    hashes = hasher.compute_hash_columns(df, fields)
     h = hashes.iloc[0]
 
     assert len(h) == 64
@@ -86,7 +86,7 @@ def test_hasher_impl_business_key():
     assert h == manual_hash
 
     # Order matters
-    h_rev_series = hasher.hash_columns(df, ["type", "id"])
+    h_rev_series = hasher.compute_hash_columns(df, ["type", "id"])
     h_rev = h_rev_series.iloc[0]
     assert h != h_rev
 
@@ -99,8 +99,8 @@ def test_hasher_impl_row_hash():
 
     # Hash row
     # We have to apply it manually or check logic
-    # HashService uses: df.apply(hasher.hash_row, axis=1)
-    h = hasher.hash_row(df.iloc[0])
+    # HashService uses: df.apply(hasher.compute_hash_row, axis=1)
+    h = hasher.compute_hash_row(df.iloc[0])
 
     assert len(h) == 64
 
@@ -139,10 +139,10 @@ def test_golden_examples():
         bk_fields = ex["business_key_fields"]
 
         # Calculate BK Hash manually to match old logic (list of values)
-        # Simulate what hash_columns does for a single row
+        # Simulate what compute_hash_columns does for a single row
         bk_values = []
         # Note: compute_hash_business_key returns None if field missing.
-        # HasherImpl.hash_columns behavior: if we use df, we get columns.
+        # HasherImpl.compute_hash_columns behavior: if we use df, we get columns.
         # If record is missing key, and we make DF, we get NaN?
         # Golden examples are well formed.
         bk_values = [record.get(f) for f in bk_fields]
@@ -154,9 +154,9 @@ def test_golden_examples():
         record_with_hash["hash_business_key"] = bk_hash
 
         # Calculate Row Hash
-        # Use HasherImpl.hash_row
+        # Use HasherImpl.compute_hash_row
         row_series = pd.Series(record_with_hash)
-        row_hash = hasher.hash_row(row_series)
+        row_hash = hasher.compute_hash_row(row_series)
 
         # Assertions if expected provided
         expected_bk = ex.get("expected_hash_business_key")

--- a/tests/bioetl/interfaces/cli/test_cli.py
+++ b/tests/bioetl/interfaces/cli/test_cli.py
@@ -277,10 +277,10 @@ def test_run_dry_run_pipeline_metadata(
     )
 
     class _DummyHasher:
-        def hash_row(self, _row):
+        def compute_hash_row(self, _row):
             return "hash_row"
 
-        def hash_columns(self, df, _columns):
+        def compute_hash_columns(self, df, _columns):
             return pd.Series(["hash_business_key"] * len(df))
 
     # Mock orchestrator to build and run our pipeline


### PR DESCRIPTION
## Summary
- rename hasher contract methods to get_algorithm/compute_hash_* for clarity
- update hash service implementations to use new method names
- adjust tests and stubs to follow the updated hasher interface

## Testing
- pytest tests/bioetl/domain/transform/test_hashing.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69355233f66483249c518dc96df316a2)