### PR TITLE
Rename deep_merge utility to apply_deep_merge

### DIFF
--- a/configs/naming_exceptions.yaml
+++ b/configs/naming_exceptions.yaml
@@ -365,7 +365,7 @@ exceptions:
 
   - path: src/bioetl/domain/transform/merge.py
     rule_id: FUNC_PREFIX
-    reason: "Utility function (deep_merge)"
+    reason: "Utility function (apply_deep_merge)"
     owner: domain
     expiry: permanent
 

--- a/docs/architecture/diagrams/class/14-config-loader-classes.mmd
+++ b/docs/architecture/diagrams/class/14-config-loader-classes.mmd
@@ -23,7 +23,7 @@ ConfigFileNotFoundError --|> ConfigError
 ConfigValidationError --|> ConfigError
 UnknownProviderError --|> ConfigError
 ConfigLoader --> PipelineConfig
-ConfigLoader --> DeepMerge : deep_merge
+ConfigLoader --> DeepMerge : apply_deep_merge
 ConfigLoader --> ConfigFileNotFoundError
 ConfigLoader --> ConfigValidationError
 ConfigLoader --> UnknownProviderError

--- a/src/bioetl/domain/transform/merge.py
+++ b/src/bioetl/domain/transform/merge.py
@@ -5,7 +5,7 @@ Utility functions for dictionary merging.
 from typing import Any
 
 
-def deep_merge(base: dict[str, Any], update: dict[str, Any]) -> dict[str, Any]:
+def apply_deep_merge(base: dict[str, Any], update: dict[str, Any]) -> dict[str, Any]:
     """
     Deep merge two dictionaries.
 
@@ -19,7 +19,7 @@ def deep_merge(base: dict[str, Any], update: dict[str, Any]) -> dict[str, Any]:
     result = base.copy()
     for key, value in update.items():
         if key in result and isinstance(result[key], dict) and isinstance(value, dict):
-            result[key] = deep_merge(result[key], value)
+            result[key] = apply_deep_merge(result[key], value)
         else:
             result[key] = value
     return result

--- a/src/bioetl/infrastructure/config/loader.py
+++ b/src/bioetl/infrastructure/config/loader.py
@@ -10,7 +10,7 @@ from typing import Any
 from pydantic import ValidationError
 
 from bioetl.domain.configs import PipelineConfig
-from bioetl.domain.transform.merge import deep_merge
+from bioetl.domain.transform.merge import apply_deep_merge
 from bioetl.infrastructure.config.provider_registry_loader import (
     DEFAULT_PROVIDERS_REGISTRY_PATH,
     ProviderNotConfiguredError,
@@ -162,9 +162,9 @@ def _apply_overrides(
 ) -> dict[str, Any]:
     merged = dict(base_config)
     if env_overrides:
-        merged = deep_merge(merged, env_overrides)
+        merged = apply_deep_merge(merged, env_overrides)
     if cli_overrides:
-        merged = deep_merge(merged, cli_overrides)
+        merged = apply_deep_merge(merged, cli_overrides)
     return merged
 
 

--- a/src/bioetl/infrastructure/config/sources.py
+++ b/src/bioetl/infrastructure/config/sources.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import yaml
 
-from bioetl.domain.transform.merge import deep_merge
+from bioetl.domain.transform.merge import apply_deep_merge
 
 CONFIGS_ROOT_ENV = "BIOETL_CONFIG_DIR"
 DEFAULT_CONFIGS_ROOT = Path("configs")
@@ -56,7 +56,7 @@ def _merge_with_profile(
     merged = dict(config)
     if profile and profile != "default":
         profile_data = _resolve_profile(profile, profiles_root=profiles_root)
-        merged = deep_merge(merged, profile_data)
+        merged = apply_deep_merge(merged, profile_data)
     return merged
 
 
@@ -69,8 +69,8 @@ def _apply_extends(
     extends_profile = config.get("extends")
     if extends_profile:
         base_profile = _resolve_profile(extends_profile, profiles_root=profiles_root)
-        merged = deep_merge(merged, base_profile)
-    merged = deep_merge(merged, config)
+        merged = apply_deep_merge(merged, base_profile)
+    merged = apply_deep_merge(merged, config)
     merged.pop("extends", None)
     return merged
 
@@ -128,7 +128,7 @@ def _resolve_profile(
     parent = profile_data.get("extends")
     if parent:
         parent_data = _resolve_profile(parent, profiles_root=profiles_root)
-        profile_data = deep_merge(parent_data, profile_data)
+        profile_data = apply_deep_merge(parent_data, profile_data)
     return profile_data
 
 

--- a/tests/bioetl/infrastructure/config/test_resolver.py
+++ b/tests/bioetl/infrastructure/config/test_resolver.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from bioetl.domain.transform.merge import deep_merge
+from bioetl.domain.transform.merge import apply_deep_merge
 from bioetl.infrastructure.config.loader import (
     ConfigFileNotFoundError,
     ConfigValidationError,
@@ -83,12 +83,12 @@ provider_config:
     assert config.output_path == "/tmp/out"  # pipeline override
 
 
-def test_deep_merge():
+def test_apply_deep_merge():
     """Test deep dictionary merge."""
     base = {"a": {"x": 1}}
     update = {"a": {"y": 2}, "b": 3}
 
-    result = deep_merge(base, update)
+    result = apply_deep_merge(base, update)
     assert result["a"]["x"] == 1
     assert result["a"]["y"] == 2
     assert result["b"] == 3


### PR DESCRIPTION
## Summary
- rename the dictionary merge helper to `apply_deep_merge`
- update configuration loaders, tests, and diagram references to use the new name
- refresh naming exception description for the renamed helper

## Testing
- pytest tests/bioetl/infrastructure/config/test_resolver.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69355234cfbc83248519c3c572353777)