### PR TITLE
Rename normalization config provider accessors

### DIFF
--- a/src/bioetl/domain/configs/pipeline.py
+++ b/src/bioetl/domain/configs/pipeline.py
@@ -67,6 +67,16 @@ class PipelineConfig(BaseModel):
         """Return canonical entity name."""
         return self.entity
 
+    def get_normalization(self) -> NormalizationConfig:
+        """Return normalization configuration section."""
+
+        return self.normalization
+
+    def get_fields(self) -> list[dict[str, Any]]:
+        """Return fields configuration."""
+
+        return self.fields
+
     def get_normalization_config_provider(self) -> NormalizationConfigProviderProtocol:
         """Return self to satisfy NormalizationConfigProviderProtocol."""
 

--- a/src/bioetl/domain/transform/contracts.py
+++ b/src/bioetl/domain/transform/contracts.py
@@ -28,13 +28,11 @@ class NormalizationConfigProviderProtocol(Protocol):
     PipelineConfig from bioetl.domain.configs implements this implicitly.
     """
 
-    @property
-    def normalization(self) -> Any:
+    def get_normalization(self) -> Any:
         """Return normalization section."""
         ...
 
-    @property
-    def fields(self) -> list[dict[str, Any]]:
+    def get_fields(self) -> list[dict[str, Any]]:
         """Return fields configuration."""
         ...
 

--- a/src/bioetl/infrastructure/transform/impl/base_normalizer.py
+++ b/src/bioetl/infrastructure/transform/impl/base_normalizer.py
@@ -33,7 +33,7 @@ class BaseNormalizationServiceImpl(BaseNormalizationServiceABC):
     def coerce_numeric_columns(self, df: pd.DataFrame) -> pd.DataFrame:
         """Cast configured numeric columns to nullable pandas dtypes."""
 
-        for field_cfg in self._config.fields:
+        for field_cfg in self._config.get_fields():
             name = field_cfg.get("name")
             dtype = field_cfg.get("data_type")
 
@@ -50,7 +50,9 @@ class BaseNormalizationServiceImpl(BaseNormalizationServiceABC):
         return df
 
     def _resolve_mode(self, field_name: str) -> str:
-        if field_name in self._config.normalization.case_sensitive_fields:
+        normalization_config = self._config.get_normalization()
+
+        if field_name in normalization_config.case_sensitive_fields:
             return "sensitive"
         if self._is_id_field(field_name):
             return "id"
@@ -265,7 +267,7 @@ class BaseNormalizationServiceImpl(BaseNormalizationServiceABC):
         return normalizer(item)
 
     def _is_id_field(self, field_name: str) -> bool:
-        if field_name in self._config.normalization.id_fields:
+        if field_name in self._config.get_normalization().id_fields:
             return True
         if field_name.endswith("_id") or field_name.endswith("_chembl_id"):
             return True

--- a/src/bioetl/infrastructure/transform/impl/chembl_normalization_service_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/chembl_normalization_service_impl.py
@@ -43,7 +43,7 @@ class ChemblNormalizationServiceImpl(
         """Normalize single raw ChEMBL record into flat dict."""
         normalized: dict[str, Any] = {}
 
-        for field_cfg in self._config.fields:
+        for field_cfg in self._config.get_fields():
             name = field_cfg.get("name")
             if not isinstance(name, str) or name not in raw:
                 continue
@@ -81,7 +81,7 @@ class ChemblNormalizationServiceImpl(
         """Normalize configured fields across dataframe columns."""
         normalized_df = df.copy()
 
-        for field_cfg in self._config.fields:
+        for field_cfg in self._config.get_fields():
             name = field_cfg.get("name")
             if not name or name not in normalized_df.columns:
                 continue

--- a/src/bioetl/infrastructure/transform/impl/normalization_service_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/normalization_service_impl.py
@@ -34,7 +34,7 @@ class NormalizationServiceImpl(
 
     def normalize_fields(self, df: pd.DataFrame) -> pd.DataFrame:
         """Проходит по полям конфигурации и применяет нормализацию."""
-        for field_cfg in self._config.fields:
+        for field_cfg in self._config.get_fields():
             name = field_cfg["name"]
             dtype = field_cfg.get("data_type")
 
@@ -84,7 +84,7 @@ class NormalizationServiceImpl(
         """Normalize a raw record into a dict using configured field rules."""
         normalized: dict[str, Any] = {}
 
-        for field_cfg in self._config.fields:
+        for field_cfg in self._config.get_fields():
             name = field_cfg.get("name")
             if not isinstance(name, str) or name not in raw:
                 continue
@@ -122,7 +122,7 @@ class NormalizationServiceImpl(
         """Normalize configured columns in the provided dataframe."""
         normalized_df = df.copy()
 
-        for field_cfg in self._config.fields:
+        for field_cfg in self._config.get_fields():
             name = field_cfg.get("name")
             if not name or name not in normalized_df.columns:
                 continue

--- a/src/bioetl/infrastructure/transform/impl/normalize.py
+++ b/src/bioetl/infrastructure/transform/impl/normalize.py
@@ -105,7 +105,7 @@ class NormalizationServiceImpl(
         """
         Проходит по полям конфигурации и применяет нормализацию.
         """
-        for field_cfg in self._config.fields:
+        for field_cfg in self._config.get_fields():
             name = field_cfg["name"]
             dtype = field_cfg.get("data_type")
 

--- a/tests/bioetl/domain/test_normalization_service.py
+++ b/tests/bioetl/domain/test_normalization_service.py
@@ -29,6 +29,12 @@ class _ConfigStub:
         ]
     )
 
+    def get_normalization(self) -> NormalizationConfig:
+        return self.normalization
+
+    def get_fields(self) -> list[dict[str, str]]:
+        return self.fields
+
 
 def test_chembl_normalization_service_normalizes_scalars_and_ids() -> None:
     service = ChemblNormalizationServiceImpl(_ConfigStub())


### PR DESCRIPTION
## Summary
- rename NormalizationConfigProviderProtocol accessors to get_normalization and get_fields
- update PipelineConfig and normalization services to use the new accessors
- adjust normalization service test stub for the updated interface

## Testing
- pytest tests/bioetl/domain/test_normalization_service.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69355239aa088324bbffd21b9bdd39b1)