### PR TITLE
Rename normalization apply methods and numeric helper

### DIFF
--- a/docs/architecture/refactoring-examples.py
+++ b/docs/architecture/refactoring-examples.py
@@ -19,7 +19,7 @@ from dependency_injector import containers, providers
 class OldNormalizer:
     """Текущая реализация с множеством if-else и смешанной логикой"""
     
-    def normalize_fields(self, df: pd.DataFrame) -> pd.DataFrame:
+    def apply_normalize_fields(self, df: pd.DataFrame) -> pd.DataFrame:
         for field_cfg in self._config.fields:
             name = field_cfg["name"]
             dtype = field_cfg.get("data_type")
@@ -209,7 +209,7 @@ class OptimizedNormalizer:
     def __init__(self, factory: NormalizerFactory):
         self.factory = factory
         
-    def normalize_dataframe(self, df: pd.DataFrame, fields: List[FieldConfig]) -> pd.DataFrame:
+    def apply_normalize_dataframe(self, df: pd.DataFrame, fields: List[FieldConfig]) -> pd.DataFrame:
         """Нормализует DataFrame используя векторизованные операции"""
         df = df.copy()
         

--- a/src/bioetl/application/pipelines/chembl/extractor.py
+++ b/src/bioetl/application/pipelines/chembl/extractor.py
@@ -59,7 +59,9 @@ class ChemblExtractorImpl(ExtractorABC):
 
             working_chunk = pd.DataFrame(chunk_records)
 
-            normalized_chunk = self.normalization_service.normalize_batch(working_chunk)
+            normalized_chunk = self.normalization_service.apply_normalize_batch(
+                working_chunk
+            )
 
             if not normalized_chunk.empty:
                 yield normalized_chunk

--- a/src/bioetl/application/pipelines/chembl/transformer.py
+++ b/src/bioetl/application/pipelines/chembl/transformer.py
@@ -38,7 +38,7 @@ class ChemblTransformerImpl(TransformerABC):
         """Apply ChEMBL pipeline transforms to the dataframe."""
         df = self.pre_transform(df)
         df = self.do_transform(df)
-        df = self.normalization_service.normalize_dataframe(df)
+        df = self.normalization_service.apply_normalize_dataframe(df)
         df = self._enforce_schema(df)
         df = self._drop_nulls_in_required_columns(df)
         return df

--- a/src/bioetl/domain/transform/contracts.py
+++ b/src/bioetl/domain/transform/contracts.py
@@ -51,7 +51,7 @@ class BaseNormalizationServiceABC(ABC):
     """
 
     @abstractmethod
-    def coerce_numeric_columns(self, df: pd.DataFrame) -> pd.DataFrame:
+    def ensure_numeric_columns(self, df: pd.DataFrame) -> pd.DataFrame:
         """Приводит числовые столбцы к nullable pandas dtypes."""
 
     @abstractmethod
@@ -118,31 +118,31 @@ class NormalizationServiceABC(ABC):
     Сервис нормализации данных в DataFrame.
 
     Обязательные операции:
-    - normalize: нормализация единичной записи
-    - normalize_fields: пакетная нормализация DataFrame по конфигурации
-    - normalize_dataframe: совместимый алиас для normalize_fields
-    - normalize_batch: пакетная нормализация чанка
-    - normalize_series: нормализация столбца по конфигурации
+    - apply_normalize: нормализация единичной записи
+    - apply_normalize_fields: пакетная нормализация DataFrame по конфигурации
+    - apply_normalize_dataframe: совместимый алиас для apply_normalize_fields
+    - apply_normalize_batch: пакетная нормализация чанка
+    - apply_normalize_series: нормализация столбца по конфигурации
     """
 
     @abstractmethod
-    def normalize(self, raw: pd.Series | dict[str, Any]) -> dict[str, Any]:
+    def apply_normalize(self, raw: pd.Series | dict[str, Any]) -> dict[str, Any]:
         """Нормализует одиночную запись или Series."""
 
     @abstractmethod
-    def normalize_fields(self, df: pd.DataFrame) -> pd.DataFrame:
+    def apply_normalize_fields(self, df: pd.DataFrame) -> pd.DataFrame:
         """Нормализует поля DataFrame согласно конфигурации."""
 
     @abstractmethod
-    def normalize_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Алиас для normalize_fields для обратной совместимости."""
+    def apply_normalize_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Алиас для apply_normalize_fields для обратной совместимости."""
 
     @abstractmethod
-    def normalize_batch(self, df: pd.DataFrame) -> pd.DataFrame:
+    def apply_normalize_batch(self, df: pd.DataFrame) -> pd.DataFrame:
         """Нормализует DataFrame чанками или целиком."""
 
     @abstractmethod
-    def normalize_series(
+    def apply_normalize_series(
         self,
         series: pd.Series,
         field_cfg: dict[str, Any],

--- a/src/bioetl/infrastructure/transform/impl/base_normalizer.py
+++ b/src/bioetl/infrastructure/transform/impl/base_normalizer.py
@@ -30,7 +30,7 @@ class BaseNormalizationServiceImpl(BaseNormalizationServiceABC):
         self._config = config
         self._empty_value = empty_value
 
-    def coerce_numeric_columns(self, df: pd.DataFrame) -> pd.DataFrame:
+    def ensure_numeric_columns(self, df: pd.DataFrame) -> pd.DataFrame:
         """Cast configured numeric columns to nullable pandas dtypes."""
 
         for field_cfg in self._config.fields:

--- a/src/bioetl/infrastructure/transform/impl/chembl_normalization_service_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/chembl_normalization_service_impl.py
@@ -39,7 +39,7 @@ class ChemblNormalizationServiceImpl(
     def __init__(self, config: NormalizationConfigProviderProtocol):
         super().__init__(config)
 
-    def normalize(self, raw: RawRecord | pd.Series) -> NormalizedRecord:
+    def apply_normalize(self, raw: RawRecord | pd.Series) -> NormalizedRecord:
         """Normalize single raw ChEMBL record into flat dict."""
         normalized: dict[str, Any] = {}
 
@@ -77,7 +77,7 @@ class ChemblNormalizationServiceImpl(
 
         return cast(NormalizedRecord, normalized)
 
-    def normalize_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
+    def apply_normalize_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
         """Normalize configured fields across dataframe columns."""
         normalized_df = df.copy()
 
@@ -86,21 +86,23 @@ class ChemblNormalizationServiceImpl(
             if not name or name not in normalized_df.columns:
                 continue
 
-            normalized_df[name] = self.normalize_series(normalized_df[name], field_cfg)
+            normalized_df[name] = self.apply_normalize_series(
+                normalized_df[name], field_cfg
+            )
 
-        return self.coerce_numeric_columns(normalized_df)
+        return self.ensure_numeric_columns(normalized_df)
 
-    def normalize_batch(self, df: pd.DataFrame) -> pd.DataFrame:
+    def apply_normalize_batch(self, df: pd.DataFrame) -> pd.DataFrame:
         """Normalize an entire batch DataFrame."""
-        normalized = self.normalize_dataframe(df)
-        return self.coerce_numeric_columns(normalized)
+        normalized = self.apply_normalize_dataframe(df)
+        return self.ensure_numeric_columns(normalized)
 
-    def normalize_fields(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Alias for normalize_dataframe retained for compatibility."""
-        normalized = self.normalize_dataframe(df)
-        return self.coerce_numeric_columns(normalized)
+    def apply_normalize_fields(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Alias for apply_normalize_dataframe retained for compatibility."""
+        normalized = self.apply_normalize_dataframe(df)
+        return self.ensure_numeric_columns(normalized)
 
-    def normalize_series(
+    def apply_normalize_series(
         self, series: pd.Series, field_cfg: dict[str, Any]
     ) -> pd.Series:
         """Normalize a single column according to field configuration."""

--- a/src/bioetl/infrastructure/transform/impl/normalization_service_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/normalization_service_impl.py
@@ -32,7 +32,7 @@ class NormalizationServiceImpl(
     def __init__(self, config: NormalizationConfigProviderProtocol):
         BaseNormalizationServiceImpl.__init__(self, config, empty_value=pd.NA)
 
-    def normalize_fields(self, df: pd.DataFrame) -> pd.DataFrame:
+    def apply_normalize_fields(self, df: pd.DataFrame) -> pd.DataFrame:
         """Проходит по полям конфигурации и применяет нормализацию."""
         for field_cfg in self._config.fields:
             name = field_cfg["name"]
@@ -78,9 +78,9 @@ class NormalizationServiceImpl(
             if dtype in ("array", "object"):
                 df[name] = df[name].astype("string").replace({pd.NA: None})
 
-        return self.coerce_numeric_columns(df)
+        return self.ensure_numeric_columns(df)
 
-    def normalize(self, raw: pd.Series | dict[str, Any]) -> dict[str, Any]:
+    def apply_normalize(self, raw: pd.Series | dict[str, Any]) -> dict[str, Any]:
         """Normalize a raw record into a dict using configured field rules."""
         normalized: dict[str, Any] = {}
 
@@ -118,7 +118,7 @@ class NormalizationServiceImpl(
 
         return normalized
 
-    def normalize_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
+    def apply_normalize_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
         """Normalize configured columns in the provided dataframe."""
         normalized_df = df.copy()
 
@@ -127,18 +127,18 @@ class NormalizationServiceImpl(
             if not name or name not in normalized_df.columns:
                 continue
 
-            normalized_df[name] = self.normalize_series(
+            normalized_df[name] = self.apply_normalize_series(
                 normalized_df[name], cast(dict[str, Any], field_cfg)
             )
 
-        return self.coerce_numeric_columns(normalized_df)
+        return self.ensure_numeric_columns(normalized_df)
 
-    def normalize_batch(self, df: pd.DataFrame) -> pd.DataFrame:
+    def apply_normalize_batch(self, df: pd.DataFrame) -> pd.DataFrame:
         """Normalize a batch dataframe and coerce numeric columns."""
-        normalized = self.normalize_dataframe(df)
-        return self.coerce_numeric_columns(normalized)
+        normalized = self.apply_normalize_dataframe(df)
+        return self.ensure_numeric_columns(normalized)
 
-    def normalize_series(
+    def apply_normalize_series(
         self, series: pd.Series, field_cfg: dict[str, Any]
     ) -> pd.Series:
         """Normalize a single series according to field configuration."""

--- a/src/bioetl/infrastructure/transform/impl/normalize.py
+++ b/src/bioetl/infrastructure/transform/impl/normalize.py
@@ -95,13 +95,13 @@ class NormalizationServiceImpl(
     def __init__(self, config: NormalizationConfigProviderProtocol):
         BaseNormalizationServiceImpl.__init__(self, config, empty_value=pd.NA)
 
-    def normalize(self, raw: pd.Series | dict[str, Any]) -> dict[str, Any]:
+    def apply_normalize(self, raw: pd.Series | dict[str, Any]) -> dict[str, Any]:
         """Normalize a single raw record into dictionary form."""
         df = pd.DataFrame([raw])
-        normalized = self.normalize_dataframe(df)
+        normalized = self.apply_normalize_dataframe(df)
         return cast(dict[str, Any], normalized.iloc[0].to_dict())
 
-    def normalize_fields(self, df: pd.DataFrame) -> pd.DataFrame:
+    def apply_normalize_fields(self, df: pd.DataFrame) -> pd.DataFrame:
         """
         Проходит по полям конфигурации и применяет нормализацию.
         """
@@ -149,17 +149,17 @@ class NormalizationServiceImpl(
             if dtype in ("array", "object"):
                 df[name] = df[name].astype("string").replace({pd.NA: None})
 
-        return self.coerce_numeric_columns(df)
+        return self.ensure_numeric_columns(df)
 
-    def normalize_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
+    def apply_normalize_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
         """Normalize dataframe using configured field rules."""
-        return self.normalize_fields(df)
+        return self.apply_normalize_fields(df)
 
-    def normalize_batch(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Normalize a batch dataframe (alias for normalize_dataframe)."""
-        return self.normalize_dataframe(df)
+    def apply_normalize_batch(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Normalize a batch dataframe (alias for apply_normalize_dataframe)."""
+        return self.apply_normalize_dataframe(df)
 
-    def normalize_series(
+    def apply_normalize_series(
         self, series: pd.Series, field_cfg: dict[str, Any]
     ) -> pd.Series:
         """Normalize a single pandas Series according to field config."""

--- a/src/tools/check_naming_policy.py
+++ b/src/tools/check_naming_policy.py
@@ -210,10 +210,10 @@ LAYER_FUNCTION_ALLOWED_NAMES = {
     },
     "domain": {
         "validate",
-        "normalize",
-        "normalize_batch",
-        "normalize_dataframe",
-        "normalize_series",
+        "apply_normalize",
+        "apply_normalize_batch",
+        "apply_normalize_dataframe",
+        "apply_normalize_series",
         "iter_records",
     },
     "infrastructure": {

--- a/tests/bioetl/application/pipelines/chembl/activity/test_activity_pipeline.py
+++ b/tests/bioetl/application/pipelines/chembl/activity/test_activity_pipeline.py
@@ -104,9 +104,9 @@ def test_transform_drops_invalid_rows(pipeline):
     )
 
     pipeline._normalization_service = MagicMock()
-    pipeline._normalization_service.normalize_fields.side_effect = lambda x: x
-    pipeline._normalization_service.normalize.side_effect = lambda record: record
-    pipeline._normalization_service.normalize_dataframe.side_effect = (
+    pipeline._normalization_service.apply_normalize_fields.side_effect = lambda x: x
+    pipeline._normalization_service.apply_normalize.side_effect = lambda record: record
+    pipeline._normalization_service.apply_normalize_dataframe.side_effect = (
         lambda df: df.copy()
     )
 

--- a/tests/bioetl/application/pipelines/chembl/activity/test_extract.py
+++ b/tests/bioetl/application/pipelines/chembl/activity/test_extract.py
@@ -69,8 +69,8 @@ def mock_extraction_service():
 def mock_normalization_service():
     """Create mock normalization service."""
     service = MagicMock()
-    service.normalize_batch.side_effect = lambda df: df
-    service.normalize_dataframe.side_effect = lambda df: df
+    service.apply_normalize_batch.side_effect = lambda df: df
+    service.apply_normalize_dataframe.side_effect = lambda df: df
     return service
 
 

--- a/tests/bioetl/application/pipelines/chembl/test_base.py
+++ b/tests/bioetl/application/pipelines/chembl/test_base.py
@@ -182,7 +182,7 @@ def _assert_normalized_row(
 def test_transform_uses_batch_normalization(mock_dependencies_fixture):
     """Ensure transform delegates batch normalization to the service."""
     normalization_service = MagicMock()
-    normalization_service.normalize_dataframe.return_value = pd.DataFrame(
+    normalization_service.apply_normalize_dataframe.return_value = pd.DataFrame(
         {"a": [1, 2], "transformed": [True, True]}
     )
 
@@ -200,11 +200,11 @@ def test_transform_uses_batch_normalization(mock_dependencies_fixture):
 
     result = pipeline.transform(df)
 
-    normalization_service.normalize_dataframe.assert_called_once()
+    normalization_service.apply_normalize_dataframe.assert_called_once()
 
     # Verify result matches normalization output
     pd.testing.assert_frame_equal(
-        result, normalization_service.normalize_dataframe.return_value
+        result, normalization_service.apply_normalize_dataframe.return_value
     )
 
 
@@ -218,7 +218,7 @@ def test_extract_handles_dataframe_chunks(mock_dependencies_fixture):
     record_source.iter_records.return_value = raw_chunks
 
     normalization_service = MagicMock()
-    normalization_service.normalize_batch.side_effect = lambda df: df.assign(
+    normalization_service.apply_normalize_batch.side_effect = lambda df: df.assign(
         processed=True
     )
 
@@ -235,7 +235,7 @@ def test_extract_handles_dataframe_chunks(mock_dependencies_fixture):
 
     result = pipeline.extract()
 
-    assert normalization_service.normalize_batch.call_count == 2
+    assert normalization_service.apply_normalize_batch.call_count == 2
 
     expected = pd.concat(
         [

--- a/tests/bioetl/application/pipelines/chembl/testitem/test_testitem_pipeline.py
+++ b/tests/bioetl/application/pipelines/chembl/testitem/test_testitem_pipeline.py
@@ -97,7 +97,7 @@ def test_transform_max_phase(pipeline):
     # or be converted to NaN if using robust casting.
     # Generic normalize_scalar raises error for invalid int strings?
     # Or does pandas/pandera handle it?
-    # Actually, NormalizationService.normalize_fields iterates
+    # Actually, NormalizationService.apply_normalize_fields iterates
     # rows for scalars.
     # '3' -> 3. 'invalid' -> ValueError?
     # Let's check normalize_scalar implementation

--- a/tests/bioetl/domain/test_normalization_service.py
+++ b/tests/bioetl/domain/test_normalization_service.py
@@ -39,7 +39,7 @@ def test_chembl_normalization_service_normalizes_scalars_and_ids() -> None:
         "extra": "keep",
     }
 
-    normalized = service.normalize(raw)
+    normalized = service.apply_normalize(raw)
 
     assert normalized["name"] == "alpha"
     assert normalized["activity_id"] == "ACT1"
@@ -55,7 +55,7 @@ def test_chembl_normalization_service_serializes_nested_values() -> None:
         "label": "MiXeD",
     }
 
-    normalized = service.normalize(raw)
+    normalized = service.apply_normalize(raw)
 
     assert normalized["tags"] == "a|b"
     assert normalized["metadata"] == "key:value"
@@ -66,7 +66,7 @@ def test_chembl_normalization_service_handles_empty_collections() -> None:
     service = ChemblNormalizationServiceImpl(_ConfigStub())
     raw = {"tags": [], "metadata": {}, "label": "  NoChange "}
 
-    normalized = service.normalize(raw)
+    normalized = service.apply_normalize(raw)
 
     assert normalized["tags"] is None
     assert normalized["metadata"] is None
@@ -88,7 +88,7 @@ def test_chembl_normalization_service_normalizes_dataframe_batch() -> None:
         }
     )
 
-    normalized_df = service.normalize_dataframe(df)
+    normalized_df = service.apply_normalize_dataframe(df)
 
     assert normalized_df["name"].tolist() == ["alpha", "beta"]
     assert normalized_df["activity_id"].tolist() == ["ACT1", "ACT2"]
@@ -106,7 +106,7 @@ def test_chembl_normalization_service_coerces_numeric_columns() -> None:
         }
     )
 
-    normalized_df = service.normalize_dataframe(df)
+    normalized_df = service.apply_normalize_dataframe(df)
 
     assert str(normalized_df["score"].dtype) == "Float64"
     assert str(normalized_df["count"].dtype) == "Int64"

--- a/tests/bioetl/domain/transform/test_normalize.py
+++ b/tests/bioetl/domain/transform/test_normalize.py
@@ -67,7 +67,7 @@ def test_normalization_service_full():
         }
     )
 
-    res = service.normalize_fields(df)
+    res = service.apply_normalize_fields(df)
 
     # Simple: lower + trim
     assert res["simple"].iloc[0] == "value"
@@ -105,7 +105,7 @@ def test_normalization_service_raises_on_invalid_custom_value():
         df = pd.DataFrame({"fail_field": ["any"]})
 
         with pytest.raises(ValueError) as excinfo:
-            service.normalize_fields(df)
+            service.apply_normalize_fields(df)
         assert "fail_field" in str(excinfo.value)
 
 
@@ -145,7 +145,7 @@ def test_normalization_service_id_detection():
         }
     )
 
-    res = service.normalize_fields(df)
+    res = service.apply_normalize_fields(df)
 
     # _chembl_id -> ID mode (upper)
     assert res["some_chembl_id"].iloc[0] == "LOWER"
@@ -164,7 +164,7 @@ def test_normalization_service_case_sensitive():
     service = default_normalization_service(config)
 
     df = pd.DataFrame({"secret_code": ["  MixEd  "]})
-    res = service.normalize_fields(df)
+    res = service.apply_normalize_fields(df)
 
     # Sensitive -> trim only, preserve case
     assert res["secret_code"].iloc[0] == "MixEd"
@@ -181,7 +181,7 @@ def test_normalization_service_missing_field():
 
     df = pd.DataFrame({"exists": ["A"]})
     # Should not raise error
-    res = service.normalize_fields(df)
+    res = service.apply_normalize_fields(df)
     assert "exists" in res.columns
     assert "missing" not in res.columns
 
@@ -200,7 +200,7 @@ def test_normalization_service_nested_fallback_error():
         df = pd.DataFrame({"bad_nested": ["scalar_val"]})
 
         with pytest.raises(ValueError) as excinfo:
-            service.normalize_fields(df)
+            service.apply_normalize_fields(df)
         assert "bad_nested" in str(excinfo.value)
         assert "Scalar fail" in str(excinfo.value)
 
@@ -212,7 +212,7 @@ def test_normalization_service_nested_na():
     service = default_normalization_service(config)
 
     df = pd.DataFrame({"list_col": [pd.NA, None]})
-    res = service.normalize_fields(df)
+    res = service.apply_normalize_fields(df)
 
     assert pd.isna(res["list_col"].iloc[0])
     assert pd.isna(res["list_col"].iloc[1])
@@ -226,7 +226,7 @@ def test_normalization_service_nested_scalar_success():
 
     # Pass a scalar string to an array field
     df = pd.DataFrame({"arr_col": ["  Value  "]})
-    res = service.normalize_fields(df)
+    res = service.apply_normalize_fields(df)
 
     # Should normalize string (default) and return it
     assert res["arr_col"].iloc[0] == "value"
@@ -242,7 +242,7 @@ def test_normalization_service_nested_complex_structures():
     data = [[{"k1": " V1 "}, {"k2": " V2 "}]]
     df = pd.DataFrame({"complex_col": data})
 
-    res = service.normalize_fields(df)
+    res = service.apply_normalize_fields(df)
 
     # Default scalar normalizer: V1 -> v1, V2 -> v2
     # serialize_list([serialize_dict(d1), serialize_dict(d2)])
@@ -268,7 +268,7 @@ def test_normalization_service_nested_errors_list():
     with patch.dict(CUSTOM_FIELD_NORMALIZERS, {"err_list": fail_on_x}):
         df = pd.DataFrame({"err_list": [["A", "X"]]})
         with pytest.raises(ValueError) as excinfo:
-            service.normalize_fields(df)
+            service.apply_normalize_fields(df)
         assert "err_list" in str(excinfo.value)
         assert "Cannot process X" in str(excinfo.value)
 
@@ -284,6 +284,6 @@ def test_normalization_service_custom_container_normalizer():
 
     with patch.dict(CUSTOM_FIELD_NORMALIZERS, {"custom_container": list_producer}):
         df = pd.DataFrame({"custom_container": ["input"]})
-        res = service.normalize_fields(df)
+        res = service.apply_normalize_fields(df)
         # Should be serialized list "a|b"
         assert res["custom_container"].iloc[0] == "a|b"

--- a/tests/bioetl/infrastructure/clients/chembl/test_provider.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_provider.py
@@ -11,19 +11,19 @@ from bioetl.infrastructure.config.models import ChemblSourceConfig
 
 
 class _NormalizationServiceStub(NormalizationServiceABC):
-    def normalize(self, raw):
+    def apply_normalize(self, raw):
         return {"raw": raw}
 
-    def normalize_fields(self, df):
+    def apply_normalize_fields(self, df):
         return df
 
-    def normalize_dataframe(self, df):
+    def apply_normalize_dataframe(self, df):
         return df
 
-    def normalize_batch(self, df):
+    def apply_normalize_batch(self, df):
         return df
 
-    def normalize_series(self, series, field_cfg):
+    def apply_normalize_series(self, series, field_cfg):
         return series
 
 


### PR DESCRIPTION
## Summary
- rename BaseNormalizationService numeric helper to ensure_numeric_columns and update implementations
- rename normalization service methods to apply_normalize_* and align pipelines and tooling
- refresh tests and examples to reflect the updated normalization API

## Testing
- pytest tests/bioetl/domain/test_normalization_service.py tests/bioetl/domain/transform/test_normalize.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693552305bbc8324b2375c928f8f4c90)