### PR TITLE
Rename ChEMBL response parser method to parse_response

### DIFF
--- a/src/bioetl/domain/clients/base/contracts.py
+++ b/src/bioetl/domain/clients/base/contracts.py
@@ -38,7 +38,7 @@ class ResponseParserABC(ABC):
     """
 
     @abstractmethod
-    def parse(self, raw_response: Any) -> list[Record]:
+    def parse_response(self, raw_response: Any) -> list[Record]:
         """Парсит сырой ответ в список записей."""
 
     @abstractmethod

--- a/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
@@ -86,7 +86,7 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC):
 
     def parse_response(self, raw_response: dict[str, Any]) -> list[dict[str, Any]]:
         """Parse raw API response into list of records."""
-        return self.parser.parse(raw_response)
+        return self.parser.parse_response(raw_response)
 
     def serialize_records(
         self, entity: str, records: list[dict[str, Any]]
@@ -130,7 +130,7 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC):
             )
 
             response = self._request_entity(entity, **request_filters)
-            batch_records = self.parser.parse(response)
+            batch_records = self.parser.parse_response(response)
             if not batch_records:
                 break
 

--- a/src/bioetl/infrastructure/clients/chembl/response_parser.py
+++ b/src/bioetl/infrastructure/clients/chembl/response_parser.py
@@ -10,7 +10,7 @@ class ChemblResponseParserImpl(ResponseParserABC):
     Парсер ответов ChEMBL API.
     """
 
-    def parse(self, raw_response: dict[str, Any]) -> list[dict[str, Any]]:
+    def parse_response(self, raw_response: dict[str, Any]) -> list[dict[str, Any]]:
         """Extract main payload list from ChEMBL response."""
         # ChEMBL responses are usually { "activities": [...], "page_meta": ... }
         # We need to find the list key.

--- a/tests/bioetl/application/pipelines/chembl/test_extraction.py
+++ b/tests/bioetl/application/pipelines/chembl/test_extraction.py
@@ -42,7 +42,7 @@ def test_extract_all_single_page(service, mock_client):
 
     # Setup mock responses
     mock_client.request_activity.return_value = {"data": "page1"}
-    mock_parser.parse.return_value = [{"id": 1}, {"id": 2}]
+    mock_parser.parse_response.return_value = [{"id": 1}, {"id": 2}]
     mock_paginator.has_more.return_value = False
 
     # Act
@@ -68,7 +68,7 @@ def test_extract_all_pagination(service, mock_client):
     # Call 2: returns 1 item, has_more=False
 
     mock_client.request_activity.side_effect = [{"data": "page1"}, {"data": "page2"}]
-    mock_parser.parse.side_effect = [[{"id": 1}, {"id": 2}], [{"id": 3}]]
+    mock_parser.parse_response.side_effect = [[{"id": 1}, {"id": 2}], [{"id": 3}]]
     mock_paginator.has_more.side_effect = [True, False]
 
     # Act
@@ -92,7 +92,7 @@ def test_extract_all_serializes_nested_fields(service, mock_client):
     service.paginator = mock_paginator
 
     mock_client.request_activity.return_value = {"data": "page"}
-    mock_parser.parse.return_value = [
+    mock_parser.parse_response.return_value = [
         {
             "id": 1,
             "activity_properties": [{"k1": "v1"}, {"k2": "v2"}],
@@ -116,7 +116,7 @@ def test_extract_all_limit(service, mock_client):
     service.paginator = mock_paginator
 
     # Returns 10 items per call
-    mock_parser.parse.return_value = [{"id": i} for i in range(10)]
+    mock_parser.parse_response.return_value = [{"id": i} for i in range(10)]
     mock_paginator.has_more.return_value = False
 
     # Act - request limit 5
@@ -137,7 +137,7 @@ def test_iter_extract_stops_on_empty_page(service, mock_client):
     service.paginator = mock_paginator
 
     mock_client.request_activity.return_value = {"data": []}
-    mock_parser.parse.return_value = []
+    mock_parser.parse_response.return_value = []
     mock_paginator.has_more.return_value = False
 
     chunks = list(service.iter_extract("activity", chunk_size=5))
@@ -158,7 +158,7 @@ def test_iter_extract_respects_limit_with_pagination(service, mock_client):
         {"data": "page1"},
         {"data": "page2"},
     ]
-    mock_parser.parse.side_effect = [
+    mock_parser.parse_response.side_effect = [
         [{"id": 1}, {"id": 2}],
         [{"id": 3}],
     ]
@@ -194,7 +194,7 @@ def test_extract_entities_dispatch(service, mock_client, entity, method):
     mock_parser = MagicMock()
     service.parser = mock_parser
 
-    mock_parser.parse.return_value = []
+    mock_parser.parse_response.return_value = []
 
     service.extract_all(entity)
 

--- a/tests/bioetl/infrastructure/clients/chembl/test_response_parser.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_response_parser.py
@@ -6,7 +6,7 @@ from bioetl.infrastructure.clients.chembl.response_parser import (
 def test_parse_activities():
     parser = ChemblResponseParserImpl()
     response = {"activities": [{"id": 1}, {"id": 2}], "page_meta": {"limit": 20}}
-    records = parser.parse(response)
+    records = parser.parse_response(response)
     assert len(records) == 2
     assert records[0]["id"] == 1
 
@@ -14,7 +14,7 @@ def test_parse_activities():
 def test_parse_empty():
     parser = ChemblResponseParserImpl()
     response = {"page_meta": {}}
-    records = parser.parse(response)
+    records = parser.parse_response(response)
     assert records == []
 
 

--- a/tests/bioetl/infrastructure/clients/test_chembl_client.py
+++ b/tests/bioetl/infrastructure/clients/test_chembl_client.py
@@ -49,7 +49,9 @@ def test_request_activity(client, mock_components):
     mock_components["http_middleware"].request.return_value = mock_response
 
     # Configure response parser to return the data pass-through or processed
-    mock_components["response_parser"].parse.return_value = {"data": "test"}
+    mock_components["response_parser"].parse_response.return_value = {
+        "data": "test"
+    }
 
     # Act
     result = client.request_activity(molecule_chembl_id="CHEMBL123")


### PR DESCRIPTION
## Summary
- rename Chembl response parser method to `parse_response` and adjust the base interface
- update chembl extraction service and mocks to call the new method
- refresh tests covering chembl response parsing and extraction flow

## Testing
- pytest tests/bioetl/infrastructure/clients/chembl/test_response_parser.py tests/bioetl/application/pipelines/chembl/test_extraction.py tests/bioetl/infrastructure/clients/test_chembl_client.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69355352c270832487b9f8d37fd736ea)