### PR TITLE
Rename ChEMBL request builder methods

### DIFF
--- a/src/bioetl/domain/clients/base/contracts.py
+++ b/src/bioetl/domain/clients/base/contracts.py
@@ -24,11 +24,11 @@ class RequestBuilderABC(ABC):
     """
 
     @abstractmethod
-    def build(self, params: dict[str, Any]) -> Any:
+    def build_request(self, params: dict[str, Any]) -> Any:
         """Создает объект запроса из параметров."""
 
     @abstractmethod
-    def with_pagination(self, offset: int, limit: int) -> "RequestBuilderABC":
+    def build_with_pagination(self, offset: int, limit: int) -> "RequestBuilderABC":
         """Добавляет параметры пагинации."""
 
 

--- a/src/bioetl/infrastructure/clients/chembl/impl/http_client.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/http_client.py
@@ -88,7 +88,7 @@ class ChemblDataClientHTTPImpl(ChemblDataClientABC):
 
     def metadata(self) -> dict[str, Any]:
         """Fetch ChEMBL API status/metadata endpoint."""
-        url = self.request_builder.for_endpoint("status").build({})
+        url = self.request_builder.build_for_endpoint("status").build_request({})
         data = self._execute_request(url)
         return data
 
@@ -103,27 +103,27 @@ class ChemblDataClientHTTPImpl(ChemblDataClientABC):
 
     def request_activity(self, **filters: Any) -> Any:
         """Request activity endpoint with provided filters."""
-        url = self.request_builder.for_endpoint("activity").build(filters)
+        url = self.request_builder.build_for_endpoint("activity").build_request(filters)
         return self._execute_request(url)
 
     def request_assay(self, **filters: Any) -> Any:
         """Request assay endpoint with provided filters."""
-        url = self.request_builder.for_endpoint("assay").build(filters)
+        url = self.request_builder.build_for_endpoint("assay").build_request(filters)
         return self._execute_request(url)
 
     def request_target(self, **filters: Any) -> Any:
         """Request target endpoint with provided filters."""
-        url = self.request_builder.for_endpoint("target").build(filters)
+        url = self.request_builder.build_for_endpoint("target").build_request(filters)
         return self._execute_request(url)
 
     def request_document(self, **filters: Any) -> Any:
         """Request document endpoint with provided filters."""
-        url = self.request_builder.for_endpoint("document").build(filters)
+        url = self.request_builder.build_for_endpoint("document").build_request(filters)
         return self._execute_request(url)
 
     def request_molecule(self, **filters: Any) -> Any:
         """Request molecule endpoint with provided filters."""
-        url = self.request_builder.for_endpoint("molecule").build(filters)
+        url = self.request_builder.build_for_endpoint("molecule").build_request(filters)
         return self._execute_request(url)
 
     def _execute_request(self, url: str) -> dict[str, Any]:

--- a/src/bioetl/infrastructure/clients/chembl/request_builder.py
+++ b/src/bioetl/infrastructure/clients/chembl/request_builder.py
@@ -18,12 +18,12 @@ class ChemblRequestBuilderImpl(RequestBuilderABC):
         self._endpoint: str = ""
         self._params: dict[str, Any] = {}
 
-    def for_endpoint(self, endpoint: str) -> "ChemblRequestBuilderImpl":
+    def build_for_endpoint(self, endpoint: str) -> "ChemblRequestBuilderImpl":
         """Select API endpoint (e.g., activity, assay, target)."""
         self._endpoint = endpoint.strip("/")
         return self
 
-    def build(self, params: dict[str, Any]) -> str:
+    def build_request(self, params: dict[str, Any]) -> str:
         """
         Строит URL с параметрами.
         Возвращает полный URL (строка; в реальности может быть Request object).
@@ -50,7 +50,9 @@ class ChemblRequestBuilderImpl(RequestBuilderABC):
 
         return url
 
-    def with_pagination(self, offset: int, limit: int) -> "ChemblRequestBuilderImpl":
+    def build_with_pagination(
+        self, offset: int, limit: int
+    ) -> "ChemblRequestBuilderImpl":
         """Attach pagination parameters for subsequent requests."""
         self._params["offset"] = offset
         self._params["limit"] = limit

--- a/tests/bioetl/infrastructure/clients/chembl/test_http_client.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_http_client.py
@@ -23,8 +23,8 @@ from bioetl.infrastructure.clients.middleware import HttpClientMiddleware
 def fixture_request_builder():
     """Mock ChemblRequestBuilderImpl."""
     builder = Mock(spec=ChemblRequestBuilderImpl)
-    builder.for_endpoint.return_value = builder
-    builder.build.return_value = "http://test-url"
+    builder.build_for_endpoint.return_value = builder
+    builder.build_request.return_value = "http://test-url"
     return builder
 
 
@@ -76,7 +76,7 @@ def test_metadata(client, mock_request_builder):
     result = client.metadata()
 
     # Verify
-    mock_request_builder.for_endpoint.assert_called_with("status")
+    mock_request_builder.build_for_endpoint.assert_called_with("status")
     client.http.request.assert_called_with("GET", "http://test-url")
     assert result == {"status": "UP"}
 
@@ -92,8 +92,10 @@ def test_request_activity(client, mock_request_builder):
     result = client.request_activity(molecule_chembl_id="CHEMBL1")
 
     # Verify
-    mock_request_builder.for_endpoint.assert_called_with("activity")
-    mock_request_builder.build.assert_called_with({"molecule_chembl_id": "CHEMBL1"})
+    mock_request_builder.build_for_endpoint.assert_called_with("activity")
+    mock_request_builder.build_request.assert_called_with(
+        {"molecule_chembl_id": "CHEMBL1"}
+    )
     assert result == {"activities": []}
 
 

--- a/tests/bioetl/infrastructure/clients/chembl/test_request_builder.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_request_builder.py
@@ -5,13 +5,13 @@ from bioetl.infrastructure.clients.chembl.request_builder import (
 
 def test_build_url():
     builder = ChemblRequestBuilderImpl("http://api")
-    url = builder.for_endpoint("test").build({"a": 1, "b": None})
+    url = builder.build_for_endpoint("test").build_request({"a": 1, "b": None})
     assert url == "http://api/test.json?a=1"
 
 
 def test_pagination():
     builder = ChemblRequestBuilderImpl("http://api")
-    builder.with_pagination(0, 10)
+    builder.build_with_pagination(0, 10)
     assert builder._params["offset"] == 0
     assert builder._params["limit"] == 10
 
@@ -23,5 +23,5 @@ def test_base_url_trim():
 
 def test_endpoint_trim():
     builder = ChemblRequestBuilderImpl("http://api")
-    builder.for_endpoint("/test/")
+    builder.build_for_endpoint("/test/")
     assert builder._endpoint == "test"


### PR DESCRIPTION
## Summary
- rename ChemblRequestBuilder method names to build_* variants
- update HTTP client and tests to reference the renamed methods

## Testing
- pytest tests/bioetl/infrastructure/clients/chembl/test_request_builder.py tests/bioetl/infrastructure/clients/chembl/test_http_client.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69355352eec4832485aa8b070d6ff536)