### PR TITLE
Rename cache contract methods to apply-prefixed variants

### DIFF
--- a/src/bioetl/domain/clients/base/contracts.py
+++ b/src/bioetl/domain/clients/base/contracts.py
@@ -103,19 +103,19 @@ class CacheABC(ABC, Generic[T]):
     """
 
     @abstractmethod
-    def get(self, key: str) -> T | None:
+    def get_value(self, key: str) -> T | None:
         """Получает значение из кэша или ``None``, если его нет или оно истекло."""
 
     @abstractmethod
-    def set(self, key: str, value: T, ttl: int | None = None) -> None:
+    def apply_set(self, key: str, value: T, ttl: int | None = None) -> None:
         """Сохраняет значение в кэш с опциональным TTL в секундах."""
 
     @abstractmethod
-    def invalidate(self, key: str) -> None:
+    def apply_invalidate(self, key: str) -> None:
         """Удаляет значение из кэша."""
 
     @abstractmethod
-    def clear(self) -> None:
+    def apply_clear(self) -> None:
         """Очищает весь кэш."""
 
 

--- a/src/bioetl/infrastructure/clients/base/impl/cache.py
+++ b/src/bioetl/infrastructure/clients/base/impl/cache.py
@@ -30,7 +30,7 @@ class MemoryCacheImpl(CacheABC[T]):
     def __init__(self) -> None:
         self._store: dict[str, tuple[T, float | None]] = {}
 
-    def get(self, key: str) -> T | None:
+    def get_value(self, key: str) -> T | None:
         """Return cached value if present and not expired."""
         value_with_expiry = self._store.get(key)
         if value_with_expiry is None:
@@ -38,21 +38,21 @@ class MemoryCacheImpl(CacheABC[T]):
 
         value, expiry_timestamp = value_with_expiry
         if _is_expired(expiry_timestamp):
-            self.invalidate(key)
+            self.apply_invalidate(key)
             return None
 
         return value
 
-    def set(self, key: str, value: T, ttl: int | None = None) -> None:
+    def apply_set(self, key: str, value: T, ttl: int | None = None) -> None:
         """Store value with optional TTL."""
         self._store[key] = (value, _get_expiry_timestamp(ttl))
 
-    def invalidate(self, key: str) -> None:
+    def apply_invalidate(self, key: str) -> None:
         """Remove entry from cache if present."""
         if key in self._store:
             del self._store[key]
 
-    def clear(self) -> None:
+    def apply_clear(self) -> None:
         """Clear entire in-memory cache."""
         self._store.clear()
 
@@ -66,7 +66,7 @@ class FileCacheImpl(CacheABC[T]):
         self._cache_dir = Path(cache_dir)
         self._cache_dir.mkdir(parents=True, exist_ok=True)
 
-    def get(self, key: str) -> T | None:
+    def get_value(self, key: str) -> T | None:
         """Load cached value from disk if present and valid."""
         cache_file = self._key_to_path(key)
         if not cache_file.exists():
@@ -76,17 +76,17 @@ class FileCacheImpl(CacheABC[T]):
             with cache_file.open("rb") as fh:
                 payload: tuple[T, float | None] = pickle.load(fh)
         except (OSError, pickle.PickleError):
-            self.invalidate(key)
+            self.apply_invalidate(key)
             return None
 
         value, expiry_timestamp = payload
         if _is_expired(expiry_timestamp):
-            self.invalidate(key)
+            self.apply_invalidate(key)
             return None
 
         return value
 
-    def set(self, key: str, value: T, ttl: int | None = None) -> None:
+    def apply_set(self, key: str, value: T, ttl: int | None = None) -> None:
         """Persist value to disk using atomic write."""
         cache_file = self._key_to_path(key)
         tmp_file = cache_file.with_suffix(cache_file.suffix + ".tmp")
@@ -97,13 +97,13 @@ class FileCacheImpl(CacheABC[T]):
 
         os.replace(tmp_file, cache_file)
 
-    def invalidate(self, key: str) -> None:
+    def apply_invalidate(self, key: str) -> None:
         """Delete cached file if it exists."""
         cache_file = self._key_to_path(key)
         if cache_file.exists():
             cache_file.unlink(missing_ok=True)
 
-    def clear(self) -> None:
+    def apply_clear(self) -> None:
         """Remove all cache files in directory."""
         for cache_file in self._cache_dir.glob("*.cache"):
             cache_file.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- rename cache contract methods to get_value/apply_set/apply_invalidate/apply_clear for clarity
- update memory and file cache implementations to match the renamed contract

## Testing
- pytest tests/bioetl/infrastructure/clients/base/test_factories.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69355354aa08832482ee68fe21a0e561)