### PR TITLE
Normalize golden expectations in pipeline output tests

### DIFF
--- a/tests/test_pipeline_outputs.py
+++ b/tests/test_pipeline_outputs.py
@@ -143,6 +143,8 @@ def test_pipeline_outputs(
     actual_records = _normalize_records(pd.read_csv(output_csv), sort_key=sort_key)
 
     golden = importlib.import_module(golden_module)
-    expected_records = getattr(golden, expected_attr)
+    expected_records = _normalize_records(
+        pd.DataFrame(getattr(golden, expected_attr)), sort_key=sort_key
+    )
 
     assert actual_records == expected_records


### PR DESCRIPTION
## Summary
- apply shared record normalization to expected pipeline output golden data to align comparisons

## Testing
- python -m pytest tests/test_pipeline_outputs.py -k pipeline_outputs --maxfail=1


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693565f628988324bc54e36f12345c04)