### PR TITLE
Refactor ChEMBL schemas with shared generated columns base

### DIFF
--- a/docs/domain/schemas/01-pandera-validation-rules.md
+++ b/docs/domain/schemas/01-pandera-validation-rules.md
@@ -65,9 +65,11 @@ Every ChEMBL and most internal schemas must include the following service column
 
 These columns are part of the lineage and determinism chain defined in project rules (deterministic I/O, hashing, lineage metadata).
 
+- Reuse `BaseGeneratedColumnsSchema` from `bioetl.domain.schemas.chembl.base` to inherit these fields and the strict Pandera `Config`.
+
 ### Column order
 
-- Preserve a dedicated constant `OUTPUT_COLUMN_ORDER` that lists all business columns first, followed by the system columns above.
+- Preserve a dedicated constant `OUTPUT_COLUMN_ORDER` that lists all business columns first, followed by the system columns above (use `build_output_column_order` helper to append generated columns consistently).
 - Writers must respect `OUTPUT_COLUMN_ORDER` to guarantee deterministic files and stable hashes.
 - Schema definitions should match this order; avoid ad-hoc column sorting inside pipelines.
 

--- a/src/bioetl/domain/schemas/chembl/__init__.py
+++ b/src/bioetl/domain/schemas/chembl/__init__.py
@@ -4,6 +4,11 @@ ChEMBL specific schemas.
 
 from bioetl.domain.schemas.chembl.activity import ActivitySchema
 from bioetl.domain.schemas.chembl.assay import AssaySchema
+from bioetl.domain.schemas.chembl.base import (
+    BaseGeneratedColumnsSchema,
+    GENERATED_COLUMN_ORDER,
+    build_output_column_order,
+)
 from bioetl.domain.schemas.chembl.document import DocumentSchema
 from bioetl.domain.schemas.chembl.models import (
     ActivityModel,
@@ -16,12 +21,15 @@ from bioetl.domain.schemas.chembl.target import TargetSchema
 from bioetl.domain.schemas.chembl.testitem import TestitemSchema
 
 __all__ = [
+    "BaseGeneratedColumnsSchema",
     "ActivitySchema",
     "AssaySchema",
     "DocumentSchema",
     "MoleculeSchema",
     "TargetSchema",
     "TestitemSchema",
+    "GENERATED_COLUMN_ORDER",
+    "build_output_column_order",
     "ActivityModel",
     "AssayModel",
     "ChemblRecordModel",

--- a/src/bioetl/domain/schemas/chembl/activity.py
+++ b/src/bioetl/domain/schemas/chembl/activity.py
@@ -5,9 +5,13 @@ Activity Schema (Pandera).
 import pandera as pa
 from pandera.typing import Series
 
+from bioetl.domain.schemas.chembl.base import (
+    BaseGeneratedColumnsSchema,
+    build_output_column_order,
+)
 from bioetl.domain.transform.normalizers import BAO_ID_REGEX, CHEMBL_ID_REGEX
 
-OUTPUT_COLUMN_ORDER: list[str] = [
+_ACTIVITY_BUSINESS_COLUMNS: list[str] = [
     "action_type",
     "activity_comment",
     "activity_id",
@@ -54,15 +58,14 @@ OUTPUT_COLUMN_ORDER: list[str] = [
     "uo_units",
     "upper_value",
     "value",
-    "hash_row",
-    "hash_business_key",
-    "index",
-    "database_version",
-    "extracted_at",
 ]
 
+OUTPUT_COLUMN_ORDER: list[str] = build_output_column_order(
+    _ACTIVITY_BUSINESS_COLUMNS
+)
 
-class ActivitySchema(pa.DataFrameModel):
+
+class ActivitySchema(BaseGeneratedColumnsSchema):
     """Схема данных для таблицы Activity."""
 
     action_type: Series[str] = pa.Field(
@@ -206,26 +209,3 @@ class ActivitySchema(pa.DataFrameModel):
         nullable=True, description="Исходное числовое значение"
     )
 
-    # Generated columns
-    hash_row: Series[str] = pa.Field(
-        str_matches=r"^[a-f0-9]{64}$", description="Хэш всей строки (64 hex символа)"
-    )
-    hash_business_key: Series[str] = pa.Field(
-        nullable=True,
-        str_matches=r"^[a-f0-9]{64}$",
-        description="Хэш бизнес-ключа (для идентификации дубликатов)",
-    )
-    index: Series[int] = pa.Field(ge=0, description="Порядковый номер строки")
-    database_version: Series[str] = pa.Field(
-        nullable=True, description="Версия базы данных"
-    )
-    extracted_at: Series[str] = pa.Field(
-        nullable=True, description="Дата и время извлечения"
-    )
-
-    class Config:
-        """Pandera configuration enforcing strict ordered validation."""
-
-        strict = True
-        coerce = True
-        ordered = True

--- a/src/bioetl/domain/schemas/chembl/assay.py
+++ b/src/bioetl/domain/schemas/chembl/assay.py
@@ -3,9 +3,13 @@
 import pandera as pa
 from pandera.typing import Series
 
+from bioetl.domain.schemas.chembl.base import (
+    BaseGeneratedColumnsSchema,
+    build_output_column_order,
+)
 from bioetl.domain.transform.normalizers import BAO_ID_REGEX, CHEMBL_ID_REGEX
 
-OUTPUT_COLUMN_ORDER: list[str] = [
+_ASSAY_BUSINESS_COLUMNS: list[str] = [
     "aidx",
     "assay_category",
     "assay_cell_type",
@@ -36,15 +40,12 @@ OUTPUT_COLUMN_ORDER: list[str] = [
     "target_chembl_id",
     "tissue_chembl_id",
     "variant_sequence",
-    "hash_row",
-    "hash_business_key",
-    "index",
-    "database_version",
-    "extracted_at",
 ]
 
+OUTPUT_COLUMN_ORDER: list[str] = build_output_column_order(_ASSAY_BUSINESS_COLUMNS)
 
-class AssaySchema(pa.DataFrameModel):
+
+class AssaySchema(BaseGeneratedColumnsSchema):
     """Pandera schema describing normalized ChEMBL assay records."""
 
     aidx: Series[str] = pa.Field(
@@ -149,26 +150,3 @@ class AssaySchema(pa.DataFrameModel):
         nullable=True, description="Последовательность варианта (если таргет – белок)"
     )
 
-    # Generated columns
-    hash_row: Series[str] = pa.Field(
-        str_matches=r"^[a-f0-9]{64}$", description="Хэш всей строки (64 hex)"
-    )
-    hash_business_key: Series[str] = pa.Field(
-        nullable=True,
-        str_matches=r"^[a-f0-9]{64}$",
-        description="Хэш бизнес-идентификатора ассая",
-    )
-    index: Series[int] = pa.Field(ge=0, description="Порядковый номер строки")
-    database_version: Series[str] = pa.Field(
-        nullable=True, description="Версия базы данных"
-    )
-    extracted_at: Series[str] = pa.Field(
-        nullable=True, description="Дата и время извлечения"
-    )
-
-    class Config:
-        """Pandera config enforcing strict, ordered validation."""
-
-        strict = True
-        coerce = True
-        ordered = True

--- a/src/bioetl/domain/schemas/chembl/base.py
+++ b/src/bioetl/domain/schemas/chembl/base.py
@@ -1,0 +1,47 @@
+"""Shared mixins and helpers for ChEMBL Pandera schemas."""
+
+import pandera as pa
+from pandera.typing import Series
+
+HEX_64_PATTERN = r"^[a-f0-9]{64}$"
+GENERATED_COLUMN_ORDER: list[str] = [
+    "hash_row",
+    "hash_business_key",
+    "index",
+    "database_version",
+    "extracted_at",
+]
+
+
+def build_output_column_order(business_columns: list[str]) -> list[str]:
+    """Append generated columns to business column order."""
+
+    return [*business_columns, *GENERATED_COLUMN_ORDER]
+
+
+class BaseGeneratedColumnsSchema(pa.DataFrameModel):
+    """Базовая схема с едиными служебными колонками и Config."""
+
+    hash_row: Series[str] = pa.Field(
+        str_matches=HEX_64_PATTERN,
+        description="Хэш всей строки (64 hex символа)",
+    )
+    hash_business_key: Series[str] = pa.Field(
+        nullable=True,
+        str_matches=HEX_64_PATTERN,
+        description="Хэш бизнес-ключа",
+    )
+    index: Series[int] = pa.Field(ge=0, description="Порядковый номер строки")
+    database_version: Series[str] = pa.Field(
+        nullable=True, description="Версия базы данных"
+    )
+    extracted_at: Series[str] = pa.Field(
+        nullable=True, description="Дата и время извлечения"
+    )
+
+    class Config:
+        """Строгая конфигурация Pandera для всех схем."""
+
+        strict = True
+        coerce = True
+        ordered = True

--- a/src/bioetl/domain/schemas/chembl/document.py
+++ b/src/bioetl/domain/schemas/chembl/document.py
@@ -3,6 +3,7 @@
 import pandera as pa
 from pandera.typing import Series
 
+from bioetl.domain.schemas.chembl.base import BaseGeneratedColumnsSchema
 from bioetl.domain.transform.normalizers import (
     CHEMBL_ID_REGEX,
     DOI_REGEX,
@@ -10,7 +11,7 @@ from bioetl.domain.transform.normalizers import (
 )
 
 
-class DocumentSchema(pa.DataFrameModel):
+class DocumentSchema(BaseGeneratedColumnsSchema):
     """Schema for document/publication data."""
 
     abstract: Series[str] = pa.Field(nullable=True, description="Аннотация документа")
@@ -65,26 +66,3 @@ class DocumentSchema(pa.DataFrameModel):
     volume: Series[str] = pa.Field(nullable=True, description="Том выпуска")
     year: Series[float] = pa.Field(nullable=True, description="Год публикации")
 
-    # Generated columns
-    hash_row: Series[str] = pa.Field(
-        str_matches=r"^[a-f0-9]{64}$", description="Хэш всей строки (64 hex)"
-    )
-    hash_business_key: Series[str] = pa.Field(
-        nullable=True,
-        str_matches=r"^[a-f0-9]{64}$",
-        description="Хэш бизнес-ключа",
-    )
-    index: Series[int] = pa.Field(ge=0, description="Порядковый номер строки")
-    database_version: Series[str] = pa.Field(
-        nullable=True, description="Версия базы данных"
-    )
-    extracted_at: Series[str] = pa.Field(
-        nullable=True, description="Дата и время извлечения"
-    )
-
-    class Config:
-        """Pandera configuration."""
-
-        strict = True
-        coerce = True
-        ordered = True

--- a/src/bioetl/domain/schemas/chembl/molecule.py
+++ b/src/bioetl/domain/schemas/chembl/molecule.py
@@ -3,10 +3,11 @@
 import pandera as pa
 from pandera.typing import Series
 
+from bioetl.domain.schemas.chembl.base import BaseGeneratedColumnsSchema
 from bioetl.domain.transform.normalizers import CHEMBL_ID_REGEX
 
 
-class MoleculeSchema(pa.DataFrameModel):
+class MoleculeSchema(BaseGeneratedColumnsSchema):
     """Schema for molecule data."""
 
     atc_classifications: Series[str] = pa.Field(
@@ -99,26 +100,3 @@ class MoleculeSchema(pa.DataFrameModel):
         nullable=True, description="Снят ли с рынка"
     )
 
-    # Generated columns
-    hash_row: Series[str] = pa.Field(
-        str_matches=r"^[a-f0-9]{64}$", description="Хэш всей строки (64 hex)"
-    )
-    hash_business_key: Series[str] = pa.Field(
-        nullable=True,
-        str_matches=r"^[a-f0-9]{64}$",
-        description="Хэш бизнес-ключа",
-    )
-    index: Series[int] = pa.Field(ge=0, description="Порядковый номер строки")
-    database_version: Series[str] = pa.Field(
-        nullable=True, description="Версия базы данных"
-    )
-    extracted_at: Series[str] = pa.Field(
-        nullable=True, description="Дата и время извлечения"
-    )
-
-    class Config:
-        """Pandera configuration."""
-
-        strict = True
-        coerce = True
-        ordered = True

--- a/src/bioetl/domain/schemas/chembl/output_views.py
+++ b/src/bioetl/domain/schemas/chembl/output_views.py
@@ -8,24 +8,17 @@ import pandera.pandas as pa
 
 from bioetl.domain.schemas.chembl.activity import ActivitySchema
 from bioetl.domain.schemas.chembl.assay import AssaySchema
+from bioetl.domain.schemas.chembl.base import GENERATED_COLUMN_ORDER
 from bioetl.domain.schemas.chembl.document import DocumentSchema
 from bioetl.domain.schemas.chembl.molecule import MoleculeSchema
 from bioetl.domain.schemas.chembl.target import TargetSchema
 from bioetl.domain.schemas.chembl.testitem import TestitemSchema
 
-_OUTPUT_METADATA_COLUMNS = [
-    "hash_row",
-    "hash_business_key",
-    "index",
-    "database_version",
-    "extracted_at",
-]
-
 
 def _metadata_last(schema_cls: Type[pa.DataFrameModel]) -> list[str]:
     columns = list(schema_cls.to_schema().columns.keys())
-    ordered = [col for col in columns if col not in _OUTPUT_METADATA_COLUMNS]
-    ordered.extend(col for col in _OUTPUT_METADATA_COLUMNS if col in columns)
+    ordered = [col for col in columns if col not in GENERATED_COLUMN_ORDER]
+    ordered.extend(col for col in GENERATED_COLUMN_ORDER if col in columns)
     return ordered
 
 

--- a/src/bioetl/domain/schemas/chembl/target.py
+++ b/src/bioetl/domain/schemas/chembl/target.py
@@ -3,13 +3,14 @@
 import pandera as pa
 from pandera.typing import Series
 
+from bioetl.domain.schemas.chembl.base import BaseGeneratedColumnsSchema
 from bioetl.domain.transform.normalizers import (
     CHEMBL_ID_REGEX,
     UNIPROT_ID_REGEX,
 )
 
 
-class TargetSchema(pa.DataFrameModel):
+class TargetSchema(BaseGeneratedColumnsSchema):
     """Schema for biological target data."""
 
     target_chembl_id: Series[str] = pa.Field(
@@ -39,26 +40,3 @@ class TargetSchema(pa.DataFrameModel):
         description="Основной UniProt ID",
     )
 
-    # Generated columns
-    hash_row: Series[str] = pa.Field(
-        str_matches=r"^[a-f0-9]{64}$", description="Хэш всей строки (64 hex)"
-    )
-    hash_business_key: Series[str] = pa.Field(
-        nullable=True,
-        str_matches=r"^[a-f0-9]{64}$",
-        description="Хэш бизнес-ключа",
-    )
-    index: Series[int] = pa.Field(ge=0, description="Порядковый номер строки")
-    database_version: Series[str] = pa.Field(
-        nullable=True, description="Версия базы данных"
-    )
-    extracted_at: Series[str] = pa.Field(
-        nullable=True, description="Дата и время извлечения"
-    )
-
-    class Config:
-        """Pandera configuration."""
-
-        strict = True
-        coerce = True
-        ordered = True

--- a/src/bioetl/domain/schemas/chembl/testitem.py
+++ b/src/bioetl/domain/schemas/chembl/testitem.py
@@ -3,13 +3,14 @@
 import pandera as pa
 from pandera.typing import Series
 
+from bioetl.domain.schemas.chembl.base import BaseGeneratedColumnsSchema
 from bioetl.domain.transform.normalizers import (
     CHEMBL_ID_REGEX,
     PUBCHEM_CID_REGEX,
 )
 
 
-class TestitemSchema(pa.DataFrameModel):
+class TestitemSchema(BaseGeneratedColumnsSchema):
     """Schema for molecule/test item data."""
 
     __test__ = False
@@ -57,28 +58,3 @@ class TestitemSchema(pa.DataFrameModel):
         nullable=True, description="HELM-нотация биотерапевтической молекулы"
     )
 
-    # Generated columns
-    hash_row: Series[str] = pa.Field(
-        str_matches=r"^[a-f0-9]{64}$", description="Хэш всей строки (64 hex)"
-    )
-    hash_business_key: Series[str] = pa.Field(
-        nullable=True,
-        str_matches=r"^[a-f0-9]{64}$",
-        description="Хэш бизнес-ключа",
-    )
-    index: Series[int] = pa.Field(ge=0, description="Порядковый номер строки")
-    database_version: Series[str] = pa.Field(
-        nullable=True,
-        description="Версия базы данных",
-    )
-    extracted_at: Series[str] = pa.Field(
-        nullable=True,
-        description="Дата и время извлечения",
-    )
-
-    class Config:
-        """Pandera configuration."""
-
-        strict = True
-        coerce = True
-        ordered = True

--- a/tests/bioetl/domain/schemas/test_output_column_order.py
+++ b/tests/bioetl/domain/schemas/test_output_column_order.py
@@ -4,6 +4,7 @@ import pytest
 
 from bioetl.domain.schemas.chembl.activity import ActivitySchema
 from bioetl.domain.schemas.chembl.assay import AssaySchema
+from bioetl.domain.schemas.chembl.base import GENERATED_COLUMN_ORDER
 from bioetl.domain.schemas.chembl.document import DocumentSchema
 from bioetl.domain.schemas.chembl.molecule import MoleculeSchema
 from bioetl.domain.schemas.chembl.output_views import (
@@ -16,14 +17,6 @@ from bioetl.domain.schemas.chembl.output_views import (
 )
 from bioetl.domain.schemas.chembl.target import TargetSchema
 from bioetl.domain.schemas.chembl.testitem import TestitemSchema
-
-METADATA_COLUMNS = [
-    "hash_row",
-    "hash_business_key",
-    "index",
-    "database_version",
-    "extracted_at",
-]
 
 
 @pytest.mark.parametrize(
@@ -41,12 +34,16 @@ def test_output_column_order_matches_schema(output_columns, schema_cls) -> None:
     """Порядок колонок совпадает с колонками схемы без дубликатов."""
 
     schema_columns = set(schema_cls.to_schema().columns.keys())
-    business_columns = [col for col in output_columns if col not in METADATA_COLUMNS]
+    business_columns = [
+        col for col in output_columns if col not in GENERATED_COLUMN_ORDER
+    ]
 
     assert output_columns, "Список с колонками не должен быть пустым"
     assert len(output_columns) == len(set(output_columns)), "Повторы недопустимы"
     assert set(output_columns).issubset(schema_columns)
-    assert set(business_columns).issubset(schema_columns - set(METADATA_COLUMNS))
+    assert set(business_columns).issubset(
+        schema_columns - set(GENERATED_COLUMN_ORDER)
+    )
 
 
 @pytest.mark.parametrize(
@@ -63,8 +60,8 @@ def test_output_column_order_matches_schema(output_columns, schema_cls) -> None:
 def test_metadata_columns_last(output_columns) -> None:
     """Служебные колонки идут последними в фиксированном порядке."""
 
-    metadata_suffix = output_columns[-len(METADATA_COLUMNS) :]
-    business_prefix = output_columns[: -len(METADATA_COLUMNS)]
+    metadata_suffix = output_columns[-len(GENERATED_COLUMN_ORDER) :]
+    business_prefix = output_columns[: -len(GENERATED_COLUMN_ORDER)]
 
-    assert metadata_suffix == METADATA_COLUMNS
-    assert not set(METADATA_COLUMNS) & set(business_prefix)
+    assert metadata_suffix == GENERATED_COLUMN_ORDER
+    assert not set(GENERATED_COLUMN_ORDER) & set(business_prefix)


### PR DESCRIPTION
## Summary
- add a shared BaseGeneratedColumnsSchema with generated columns, strict Config, and helpers for output ordering
- refactor ChEMBL schemas and output column helpers to reuse the base metadata definitions and avoid duplication
- align schema documentation and tests with the shared metadata columns and column-order helper

## Testing
- PYTHONPATH=src pytest tests/bioetl/domain/schemas/test_output_column_order.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936627838dc8324a4ee5923ddc6cc66)