### PR TITLE
Remove SourceClientABC and align client contracts

### DIFF
--- a/docs/ABC_INDEX.md
+++ b/docs/ABC_INDEX.md
@@ -1,8 +1,11 @@
 # ABC Index
 <!-- generated -->
 
-- `SourceClientABC` — `bioetl.domain.clients.base.contracts.SourceClientABC`
-  - Основной контракт клиента источника данных. Наследует доменный контракт DataClientABC.
+- `DataClientABC` — `bioetl.domain.clients.contracts.DataClientABC`
+  - Базовый контракт клиента источника данных.
+
+- `ChemblDataClientABC` — `bioetl.domain.clients.chembl.contracts.ChemblDataClientABC`
+  - Контракт клиента ChEMBL.
 
 - `RequestBuilderABC` — `bioetl.domain.clients.base.contracts.RequestBuilderABC`
   - Паттерн Builder для создания запросов.

--- a/docs/architecture/07-diagrams.md
+++ b/docs/architecture/07-diagrams.md
@@ -288,12 +288,16 @@ flowchart TD
 
 ```mermaid
 classDiagram
-    class SourceClientABC {
+    class DataClientABC {
         <<Interface>>
         +fetch_one(id)
         +fetch_many(ids)
         +iter_pages(request)
         +metadata()
+    }
+
+    class ChemblDataClientABC {
+        <<Interface>>
     }
 
     class RequestBuilderABC {
@@ -318,12 +322,13 @@ classDiagram
     }
 
     class ChemblClientFactory {
-        +create_client(config) SourceClientABC
-        +create_default() SourceClientABC
+        +create_client(config) ChemblDataClientABC
+        +create_default() ChemblDataClientABC
     }
 
-    SourceClientABC <|-- ChemblClientHTTPImpl
-    ChemblClientFactory ..> SourceClientABC : creates
+    DataClientABC <|-- ChemblDataClientABC
+    ChemblDataClientABC <|-- ChemblClientHTTPImpl
+    ChemblClientFactory ..> ChemblDataClientABC : creates
     ChemblClientFactory ..> ChemblClientHTTPImpl : instantiates
 
     ChemblClientHTTPImpl *-- RequestBuilderABC : uses
@@ -406,7 +411,7 @@ flowchart LR
   end
   subgraph Interfaces["**Interfaces (Ports)**"]
     IF_Pipeline["**PipelineBase**, **ChemblPipelineBase** *bioetl.application.pipelines.base*"]
-    IF_Client["**BaseClient**, **SourceClientABC** *bioetl.interfaces.clients*"]
+    IF_Client["**BaseClient**, **DataClientABC**, **ChemblDataClientABC** *bioetl.interfaces.clients*"]
     IF_Logger["**LoggerAdapterABC** *bioetl.interfaces.logging*"]
     IF_Writer["**WriterABC**, **UnifiedOutputWriterABC** *bioetl.interfaces.output*"]
     IF_Validator["**ValidatorABC** *bioetl.interfaces.validation*"]

--- a/docs/architecture/15-class-diagrams-infrastructure.md
+++ b/docs/architecture/15-class-diagrams-infrastructure.md
@@ -11,7 +11,7 @@
 id: 9f5e7de8-3350-47cb-8b63-8ec00ddc9944
 ---
 classDiagram
-    class SourceClientABC {
+    class DataClientABC {
         <<abstract>>
         +fetch_one(id)*
         +fetch_many(ids)*
@@ -48,7 +48,7 @@ classDiagram
         +close()
     }
 
-    SourceClientABC <|-- ChemblDataClientABC
+    DataClientABC <|-- ChemblDataClientABC
     ChemblDataClientABC <|-- ChemblDataClientHTTPImpl
     ChemblDataClientHTTPImpl --> UnifiedAPIClient : uses
 ```

--- a/docs/architecture/diagrams/class/13-client-abc-default-impl-classes.mmd
+++ b/docs/architecture/diagrams/class/13-client-abc-default-impl-classes.mmd
@@ -4,7 +4,8 @@ id: 3d4e1b0a-6d83-4d8b-9c6f-1e6e8f2471ab
 %%{init: {"class": {"domainPrimary": {"fill": "#f5f5f5", "stroke": "#444", "strokeWidth": 1.5, "color": "#111", "fontSize": "22px"}, "domainSecondary": {"fill": "#e3e7ec", "stroke": "#555", "strokeWidth": 1.2, "color": "#111", "fontSize": "18px"}, "interface": {"fill": "#dde7f2", "stroke": "#44546a", "strokeWidth": 1.5, "color": "#111", "fontSize": "22px"}}}}%%
 classDiagram-v2
 
-class SourceClientABC
+class DataClientABC
+class ChemblDataClientABC
 class RequestBuilderABC
 class ResponseParserABC
 class PaginatorABC
@@ -34,7 +35,8 @@ class EnvSecretProvider
 class CircuitBreakerImpl
 class ChemblExtractionServiceImpl
 
-ChemblHttpClientImpl ..|> SourceClientABC
+ChemblDataClientABC ..|> DataClientABC
+ChemblHttpClientImpl ..|> ChemblDataClientABC
 ChemblRequestBuilder ..|> RequestBuilderABC
 ChemblResponseParser ..|> ResponseParserABC
 OffsetPaginator ..|> PaginatorABC
@@ -72,7 +74,8 @@ class MemoryCacheImpl domainSecondary
 class EnvSecretProvider domainSecondary
 class CircuitBreakerImpl domainSecondary
 class BaseClientFactories domainSecondary
-class SourceClientABC interface
+class DataClientABC interface
+class ChemblDataClientABC interface
 class RequestBuilderABC interface
 class ResponseParserABC interface
 class PaginatorABC interface

--- a/docs/architecture/diagrams/class/client-architecture-three-layer.mmd
+++ b/docs/architecture/diagrams/class/client-architecture-three-layer.mmd
@@ -2,12 +2,15 @@
 classDiagram-v2
 
     %% Contracts (Ports)
-    class SourceClientABC {
+    class DataClientABC {
         <<Interface>>
         +fetch_one(id)
         +fetch_many(ids)
         +iter_pages(request)
         +metadata()
+    }
+    class ChemblDataClientABC {
+        <<Interface>>
     }
     class RequestBuilderABC {
         <<Interface>>
@@ -38,8 +41,8 @@ classDiagram-v2
       +default_secret_provider()
     }
     class ChemblClientFactory {
-      +create_client(config) SourceClientABC
-      +create_default() SourceClientABC
+      +create_client(config) ChemblDataClientABC
+      +create_default() ChemblDataClientABC
     }
     class ChemblExtractionServiceFactory {
       +create_extraction_service(config, client)
@@ -58,7 +61,8 @@ classDiagram-v2
     class EnvSecretProvider
     class ChemblExtractionServiceImpl
 
-    SourceClientABC <|-- ChemblDataClientHTTPImpl
+    DataClientABC <|-- ChemblDataClientABC
+    ChemblDataClientABC <|-- ChemblDataClientHTTPImpl
     RequestBuilderABC <|-- ChemblRequestBuilderImpl
     ResponseParserABC <|-- ChemblResponseParserImpl
     PaginatorABC <|-- OffsetPaginator
@@ -89,7 +93,8 @@ classDiagram-v2
     class ChemblClientFactory domainSecondary
     class ChemblExtractionServiceFactory domainSecondary
     class BaseClientFactories domainSecondary
-    class SourceClientABC interface
+    class DataClientABC interface
+    class ChemblDataClientABC interface
     class RequestBuilderABC interface
     class ResponseParserABC interface
     class PaginatorABC interface

--- a/docs/architecture/diagrams/component/04-interfaces-components.mmd
+++ b/docs/architecture/diagrams/component/04-interfaces-components.mmd
@@ -16,7 +16,7 @@ subgraph Interfaces["Interfaces Layer (Ports)"]
     PipelinePorts["PipelineBase / ChemblPipelineBase\napplication.pipelines.base"]:::componentSecondary
     PipelineRegistry["Pipeline Registry\napplication.pipelines.registry"]:::componentSecondary
     ConfigLoader["Pipeline Config Loader\napplication.config_loader"]:::componentSecondary
-    ClientPorts["SourceClientABC\ninterfaces.clients / domain.clients.base"]:::componentSecondary
+    ClientPorts["DataClientABC / ChemblDataClientABC\ninterfaces.clients / domain.clients.base"]:::componentSecondary
     WriterPorts["WriterABC / UnifiedOutputWriterABC\ninterfaces.output"]:::componentSecondary
     ValidatorPorts["ValidatorABC\ninterfaces.validation"]:::componentSecondary
     LoggerPorts["LoggerAdapterABC\ninterfaces.logging"]:::componentSecondary

--- a/src/bioetl/domain/clients/base/__init__.py
+++ b/src/bioetl/domain/clients/base/__init__.py
@@ -9,7 +9,6 @@ from bioetl.domain.clients.base.contracts import (
     RetryPolicyABC,
     SecretProviderABC,
     SideInputProviderABC,
-    SourceClientABC,
 )
 
 __all__ = [
@@ -21,5 +20,4 @@ __all__ = [
     "RetryPolicyABC",
     "SecretProviderABC",
     "SideInputProviderABC",
-    "SourceClientABC",
 ]

--- a/src/bioetl/domain/clients/base/contracts.py
+++ b/src/bioetl/domain/clients/base/contracts.py
@@ -1,21 +1,10 @@
-"""Base contracts for data source clients and helpers."""
+"""Base contracts for data source helpers."""
 
 from abc import ABC, abstractmethod
 from typing import Any, Generic, TypeVar
 
-from bioetl.domain.clients.contracts import DataClientABC
-
 T = TypeVar("T")
 Record = dict[str, Any]
-
-
-class SourceClientABC(DataClientABC):
-    """
-    Основной контракт клиента источника данных.
-    Наследует доменный контракт DataClientABC.
-    """
-
-    pass
 
 
 class RequestBuilderABC(ABC):

--- a/src/bioetl/domain/clients/chembl/contracts.py
+++ b/src/bioetl/domain/clients/chembl/contracts.py
@@ -3,10 +3,10 @@
 from abc import abstractmethod
 from typing import Any
 
-from bioetl.domain.clients.base.contracts import SourceClientABC
+from bioetl.domain.clients.contracts import DataClientABC
 
 
-class ChemblDataClientABC(SourceClientABC):
+class ChemblDataClientABC(DataClientABC):
     """
     Контракт клиента ChEMBL.
     """

--- a/src/bioetl/infrastructure/clients/base/abc_impls.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_impls.yaml
@@ -104,7 +104,11 @@ OutputWriterABC:
   implementations:
     Unified: bioetl.infrastructure.output.unified_writer.UnifiedOutputWriter
 
-SourceClientABC:
+DataClientABC:
+  implementations:
+    ChemblHTTP: bioetl.infrastructure.clients.chembl.impl.http_client.ChemblDataClientHTTPImpl
+
+ChemblDataClientABC:
   default_factory: bioetl.infrastructure.clients.chembl.factories.default_chembl_client
   implementations:
     ChemblHTTP: bioetl.infrastructure.clients.chembl.impl.http_client.ChemblDataClientHTTPImpl

--- a/src/bioetl/infrastructure/clients/base/abc_registry.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_registry.yaml
@@ -2,7 +2,8 @@
 # This file maps abstract component roles to their interface definitions
 # Format: Role: Module.ClassName
 
-SourceClientABC: bioetl.domain.clients.base.contracts.SourceClientABC
+DataClientABC: bioetl.domain.clients.contracts.DataClientABC
+ChemblDataClientABC: bioetl.domain.clients.chembl.contracts.ChemblDataClientABC
 RequestBuilderABC: bioetl.domain.clients.base.contracts.RequestBuilderABC
 ResponseParserABC: bioetl.domain.clients.base.contracts.ResponseParserABC
 PaginatorABC: bioetl.domain.clients.base.contracts.PaginatorABC

--- a/tests/architecture/test_architecture_rules.py
+++ b/tests/architecture/test_architecture_rules.py
@@ -37,7 +37,6 @@ ALLOWED_ABCS_WITHOUT_IMPL = {
     "SchemaProviderABC",
     "SecretProviderABC",
     "SideInputProviderABC",
-    "SourceClientABC",
     "StageABC",
     "TracerABC",
 }


### PR DESCRIPTION
## Summary
- fold SourceClient responsibilities into DataClient contracts and update Chembl client ABC inheritance
- refresh ABC registries, factories, and architecture tests to target the new base contract
- update client architecture documentation and diagrams to drop the extra SourceClient layer

## Testing
- pytest tests/architecture/test_architecture_rules.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69366625820483249a2fcc47b404cdd2)