### PR TITLE
Refactor record source batch adaptation

### DIFF
--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -38,6 +38,7 @@ from bioetl.domain.transform.transformers import TransformerABC
 from bioetl.domain.validation import SchemaProviderABC, ValidatorFactoryABC
 from bioetl.domain.validation.contracts import ValidationResult
 from bioetl.domain.validation.service import ValidationService
+from bioetl.infrastructure.transform.pandas_batch_adapter import PandasBatchAdapter
 
 
 class PipelineContainer(PipelineContainerABC):
@@ -230,6 +231,7 @@ class PipelineContainer(PipelineContainerABC):
             entity=self._config.entity_name,
             filters=filters,
             chunk_size=self._config.batch_size,
+            batch_adapter=PandasBatchAdapter().adapt_batch,
         )
 
     def get_extraction_service(self) -> Any:

--- a/src/bioetl/application/pipelines/chembl/extractor.py
+++ b/src/bioetl/application/pipelines/chembl/extractor.py
@@ -17,6 +17,7 @@ from bioetl.domain.record_source import (
     RecordSource,
 )
 from bioetl.domain.transform.contracts import NormalizationServiceABC
+from bioetl.infrastructure.transform.pandas_batch_adapter import PandasBatchAdapter
 
 
 class ChemblExtractorImpl(ExtractorABC):
@@ -194,4 +195,5 @@ class ChemblExtractorImpl(ExtractorABC):
             entity=self.config.entity_name,
             filters=filters,
             chunk_size=chunk_size,
+            batch_adapter=PandasBatchAdapter().adapt_batch,
         )

--- a/src/bioetl/domain/record_source.py
+++ b/src/bioetl/domain/record_source.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Protocol, TypedDict, cast
-
-import pandas as pd
+from typing import Any, Callable, Protocol, TypedDict, cast
 
 from bioetl.domain.contracts import ExtractionServiceABC
 
@@ -51,11 +49,13 @@ class ApiRecordSource(RecordSource):
         entity: str,
         filters: dict[str, Any] | None = None,
         chunk_size: int | None = None,
+        batch_adapter: Callable[[Any], list[RawRecord]] | None = None,
     ) -> None:
         self._extraction_service = extraction_service
         self._entity = entity
         self._filters = filters or {}
         self._chunk_size = chunk_size
+        self._batch_adapter = batch_adapter
 
     def iter_records(self) -> Iterable[list[RawRecord]]:
         """Iterate over extracted provider batches as normalized records."""
@@ -63,32 +63,16 @@ class ApiRecordSource(RecordSource):
         for raw_batch in self._extraction_service.iter_extract(
             self._entity, chunk_size=self._chunk_size, **filters
         ):
-            yield self._coerce_batch(raw_batch)
+            if self._batch_adapter is not None:
+                yield self._batch_adapter(raw_batch)
+                continue
 
-    def _coerce_batch(self, raw_batch: Any) -> list[RawRecord]:
-        """
-        Normalize provider batches to a list of raw records.
+            if not isinstance(raw_batch, list):
+                raise TypeError(
+                    "iter_extract must yield list[RawRecord] when no batch_adapter is set."
+                )
 
-        Supports DataFrame, mapping, iterable of mappings, and None.
-        """
-        if raw_batch is None:
-            return []
-
-        if isinstance(raw_batch, pd.DataFrame):
-            return cast(list[RawRecord], raw_batch.to_dict(orient="records"))
-
-        if isinstance(raw_batch, dict):
-            return [cast(RawRecord, raw_batch)]
-
-        if isinstance(raw_batch, list):
-            return cast(list[RawRecord], raw_batch)
-
-        if isinstance(raw_batch, Iterable) and not isinstance(raw_batch, (str, bytes)):
-            return cast(list[RawRecord], list(raw_batch))
-
-        raise TypeError(
-            "iter_extract must yield DataFrame, mapping, or iterable of mappings."
-        )
+            yield cast(list[RawRecord], raw_batch)
 
 
 class FileRecordSourceFactoryABC(Protocol):

--- a/src/bioetl/infrastructure/transform/pandas_batch_adapter.py
+++ b/src/bioetl/infrastructure/transform/pandas_batch_adapter.py
@@ -1,0 +1,43 @@
+"""Adapters for normalizing pandas batches into raw record lists."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, cast
+
+import pandas as pd
+
+from bioetl.domain.record_source import RawRecord
+
+
+class PandasBatchAdapter:
+    """Adapter to convert pandas DataFrame batches to raw record lists."""
+
+    def adapt_batch(self, raw_batch: Any) -> list[RawRecord]:
+        """Normalize a batch into a list of raw record mappings."""
+        if raw_batch is None:
+            return []
+
+        if isinstance(raw_batch, pd.DataFrame):
+            return cast(list[RawRecord], raw_batch.to_dict(orient="records"))
+
+        if isinstance(raw_batch, dict):
+            return [cast(RawRecord, raw_batch)]
+
+        if isinstance(raw_batch, list):
+            return cast(list[RawRecord], raw_batch)
+
+        if isinstance(raw_batch, Iterable) and not isinstance(raw_batch, (str, bytes)):
+            return cast(list[RawRecord], list(raw_batch))
+
+        raise TypeError(
+            "iter_extract must yield DataFrame, mapping, or iterable of mappings."
+        )
+
+    def adapt_batches(self, batches: Iterable[Any]) -> Iterable[list[RawRecord]]:
+        """Adapt an iterable of batches lazily."""
+        for batch in batches:
+            yield self.adapt_batch(batch)
+
+
+__all__ = ["PandasBatchAdapter"]

--- a/tests/bioetl/infrastructure/transform/test_pandas_batch_adapter.py
+++ b/tests/bioetl/infrastructure/transform/test_pandas_batch_adapter.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+import pandas as pd
+
+from bioetl.infrastructure.transform.pandas_batch_adapter import PandasBatchAdapter
+
+
+def test_pandas_batch_adapter_converts_dataframe_to_records() -> None:
+    adapter = PandasBatchAdapter()
+    df = pd.DataFrame([{"id": 1, "name": "a"}, {"id": 2, "name": "b"}])
+
+    records = adapter.adapt_batch(df)
+
+    assert records == [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}]
+
+
+def test_record_source_module_has_no_pandas_import() -> None:
+    record_source_path = Path("src/bioetl/domain/record_source.py")
+
+    content = record_source_path.read_text(encoding="utf-8")
+
+    assert "import pandas" not in content


### PR DESCRIPTION
## Summary
- remove pandas dependency from the domain record source by delegating batch conversion
- add PandasBatchAdapter to normalize DataFrame batches into raw records and wire it into API record source creation
- cover the adapter with tests, including verifying the domain module no longer imports pandas

## Testing
- pytest tests/bioetl/domain/test_record_source.py tests/bioetl/infrastructure/transform/test_pandas_batch_adapter.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936663679848324aac06e9317c7543e)