### PR TITLE
Refactor provider and normalization configuration sources

### DIFF
--- a/docs/architecture/14-class-diagrams-domain.md
+++ b/docs/architecture/14-class-diagrams-domain.md
@@ -282,7 +282,7 @@ classDiagram
 
     class ProviderDefinition {
         +provider_id: ProviderId
-        +config_class: Type[BaseProviderConfig]
+        +config_type: Type[BaseProviderConfig]
         +components: ProviderComponents
     }
 
@@ -303,6 +303,12 @@ classDiagram
     ProviderRegistry --> ProviderDefinition : stores
     ProviderDefinition --> ProviderId : uses
     ProviderDefinition --> ProviderComponents : contains
+    note right of BaseProviderConfig
+      Canonical provider config lives in
+      bioetl.domain.configs.pipeline and
+      defines provider/base_url/timeouts
+      with strict validation.
+    end note
 ```
 
 ## 8. Normalizers

--- a/docs/architecture/15-class-diagrams-infrastructure.md
+++ b/docs/architecture/15-class-diagrams-infrastructure.md
@@ -409,7 +409,7 @@ classDiagram
 
     class ProviderDefinition {
         +provider_id: ProviderId
-        +config_class: Type[BaseProviderConfig]
+        +config_type: Type[BaseProviderConfig]
         +components: ProviderComponents
     }
 
@@ -420,7 +420,11 @@ classDiagram
     }
 
     class BaseProviderConfig {
-        +provider: str
+        +provider: Literal["chembl", "pubchem", "uniprot", "dummy"]
+        +base_url: AnyHttpUrl
+        +timeout_sec: PositiveFloat
+        +max_retries: NonNegativeInt
+        +rate_limit_per_sec: PositiveFloat?
     }
 
     ProviderComponents <|.. ChemblProviderComponentsFactory

--- a/docs/domain-class-diagrams.md
+++ b/docs/domain-class-diagrams.md
@@ -30,7 +30,14 @@ classDiagram
     class ProviderNotRegisteredError
     class ProviderAlreadyRegisteredError
     class ProviderId { <<enum>> CHEMBL PUBCHEM UNIPROT PUBMED DUMMY }
-    class BaseProviderConfig { <<pydantic.BaseModel>> model_config: ConfigDict(extra="forbid") }
+    class BaseProviderConfig {
+        <<pydantic.BaseModel>>
+        provider: Literal["chembl", "pubchem", "uniprot", "dummy"]
+        base_url: AnyHttpUrl
+        timeout_sec: PositiveFloat
+        max_retries: NonNegativeInt
+        rate_limit_per_sec: PositiveFloat?
+    }
     class ProviderComponents { <<protocol>> create_client(); create_extraction_service(); create_normalization_service()*; create_writer()* }
     class ProviderDefinition { <<dataclass frozen>> id: ProviderId; config_type: type[BaseProviderConfig]; components: ProviderComponents; description: str? }
 

--- a/src/bioetl/domain/providers.py
+++ b/src/bioetl/domain/providers.py
@@ -6,9 +6,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Protocol, TypeVar, runtime_checkable
 
-from pydantic import BaseModel, ConfigDict
-
 if TYPE_CHECKING:
+    from bioetl.domain.configs.pipeline import BaseProviderConfig
     from bioetl.domain.transform.contracts import NormalizationServiceABC
 
 client_t = TypeVar("client_t")
@@ -31,12 +30,6 @@ class ProviderId(str, Enum):
     DUMMY = "dummy"
 
 
-class BaseProviderConfig(BaseModel):
-    """Base provider configuration model."""
-
-    model_config = ConfigDict(extra="forbid")
-
-
 @runtime_checkable
 class ProviderComponents(
     Protocol[
@@ -48,12 +41,12 @@ class ProviderComponents(
 ):
     """Protocol describing provider component factories with consistent signatures."""
 
-    def create_client(self, config: BaseProviderConfig) -> client_t:
+    def create_client(self, config: "BaseProviderConfig") -> client_t:
         """Create provider client instance."""
 
     def create_extraction_service(
         self,
-        config: BaseProviderConfig,
+        config: "BaseProviderConfig",
         *,
         client: client_t | None = None,
     ) -> extraction_service_t:
@@ -62,7 +55,7 @@ class ProviderComponents(
     # Optional factories
     def create_normalization_service(
         self,
-        config: BaseProviderConfig,
+        config: "BaseProviderConfig",
         *,
         client: client_t | None = None,
         pipeline_config: object | None = None,
@@ -71,7 +64,7 @@ class ProviderComponents(
 
     def create_writer(
         self,
-        config: BaseProviderConfig,
+        config: "BaseProviderConfig",
         *,
         client: client_t | None = None,
     ) -> writer_t:  # pragma: no cover - optional
@@ -83,13 +76,12 @@ class ProviderDefinition:
     """Provider metadata and factory entry points."""
 
     id: ProviderId
-    config_type: type[BaseProviderConfig]
+    config_type: type["BaseProviderConfig"]
     components: ProviderComponents
     description: str | None = None
 
 
 __all__ = [
-    "BaseProviderConfig",
     "ProviderComponents",
     "ProviderDefinition",
     "ProviderId",

--- a/tests/bioetl/domain/test_provider_registry_contract.py
+++ b/tests/bioetl/domain/test_provider_registry_contract.py
@@ -1,15 +1,11 @@
 import pytest
 
+from bioetl.domain.configs.pipeline import BaseProviderConfig
 from bioetl.domain.provider_registry import (
     InMemoryProviderRegistry,
     ProviderAlreadyRegisteredError,
 )
-from bioetl.domain.providers import (
-    BaseProviderConfig,
-    ProviderComponents,
-    ProviderDefinition,
-    ProviderId,
-)
+from bioetl.domain.providers import ProviderComponents, ProviderDefinition, ProviderId
 
 
 class DummyProviderConfig(BaseProviderConfig):

--- a/tests/bioetl/domain/transform/test_normalize.py
+++ b/tests/bioetl/domain/transform/test_normalize.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import pandas as pd
 import pytest
 
+from bioetl.domain.configs.normalization import NormalizationConfig
 from bioetl.domain.transform.contracts import NormalizationConfigProviderProtocol
 from bioetl.domain.transform.normalizers.registry import CUSTOM_FIELD_NORMALIZERS
 from bioetl.infrastructure.transform.factories import default_normalization_service
@@ -24,31 +25,19 @@ def test_normalize_scalar():
     assert normalize_scalar("  AbC  ", mode="sensitive") == "AbC"
 
 
-class MockNormalizationConfig:
-    def __init__(
-        self,
-        case_sensitive_fields: list[str] | None = None,
-        id_fields: list[str] | None = None,
-        custom_normalizers: dict[str, Any] | None = None,
-    ):
-        self.case_sensitive_fields = case_sensitive_fields or []
-        self.id_fields = id_fields or []
-        self.custom_normalizers = custom_normalizers or {}
-
-
 class MockConfig(NormalizationConfigProviderProtocol):
     def __init__(
         self,
         fields: list[dict[str, Any]],
-        normalization: MockNormalizationConfig | None = None,
+        normalization: NormalizationConfig | None = None,
     ):
         self._fields = fields
-        self.normalization = normalization or MockNormalizationConfig()
+        self.normalization = normalization or NormalizationConfig()
 
     def get_fields(self) -> list[dict[str, Any]]:
         return self._fields
 
-    def get_normalization(self) -> MockNormalizationConfig:
+    def get_normalization(self) -> NormalizationConfig:
         return self.normalization
 
 
@@ -62,7 +51,7 @@ def test_normalization_service_full():
         {"name": "doi", "data_type": "string"},
     ]
 
-    norm_config = MockNormalizationConfig(id_fields=["id_col"])
+    norm_config = NormalizationConfig(id_fields=["id_col"])
     config = MockConfig(fields, normalization=norm_config)
 
     # Note: 'doi' is registered globally in
@@ -104,7 +93,7 @@ def test_normalization_service_full():
 
 
 def test_normalization_service_raises_on_invalid_custom_value():
-    norm_config = MockNormalizationConfig()
+    norm_config = NormalizationConfig()
     config = MockConfig(
         [{"name": "fail_field", "data_type": "string"}], normalization=norm_config
     )
@@ -173,7 +162,7 @@ def test_normalization_service_id_detection():
 def test_normalization_service_case_sensitive():
     """Test case sensitive field normalization."""
     fields = [{"name": "secret_code", "data_type": "string"}]
-    norm_config = MockNormalizationConfig(case_sensitive_fields=["secret_code"])
+    norm_config = NormalizationConfig(case_sensitive_fields=["secret_code"])
     config = MockConfig(fields, normalization=norm_config)
 
     service = default_normalization_service(config)

--- a/tests/project_rules/class_inventory_baseline.json
+++ b/tests/project_rules/class_inventory_baseline.json
@@ -1,4 +1,4 @@
 {
-  "total_classes": 207
+  "total_classes": 206
 }
 


### PR DESCRIPTION
## Summary
- remove the duplicate provider config model and point provider registry typings to the canonical pipeline configuration
- align normalization tests with the canonical Pydantic NormalizationConfig and drop legacy stubs
- refresh documentation diagrams and class inventory baseline to reflect the unified configuration models

## Testing
- pytest *(fails due to existing style/layer/naming/mypy violations unrelated to these changes)*
- python -m isort --check-only tests/bioetl/domain/test_provider_registry_contract.py tests/bioetl/domain/transform/test_normalize.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693679ed6bcc8324937e2b427e885279)