### PR TITLE
Add schema-driven pipeline field hydration

### DIFF
--- a/src/bioetl/domain/schemas/fields.py
+++ b/src/bioetl/domain/schemas/fields.py
@@ -1,0 +1,51 @@
+"""Helpers to derive pipeline field configs from Pandera schemas."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandera as pa
+
+_DEFAULT_FILTERABLE = False
+
+
+def _map_dtype_to_field_type(dtype: Any) -> str:
+    """Map Pandera/NumPy dtype representation to config-friendly type name."""
+
+    dtype_str = str(dtype).lower()
+    if "int" in dtype_str:
+        return "integer"
+    if "float" in dtype_str or "double" in dtype_str:
+        return "number"
+    if "bool" in dtype_str:
+        return "boolean"
+    if "object" in dtype_str:
+        return "object"
+    return "string"
+
+
+def build_field_configs_from_schema(
+    schema: type[pa.DataFrameModel] | pa.DataFrameSchema,
+) -> list[dict[str, Any]]:
+    """Convert Pandera schema definition to list of field descriptors."""
+
+    df_schema = schema.to_schema() if hasattr(schema, "to_schema") else schema
+    columns = getattr(df_schema, "columns", None)
+    if columns is None:
+        raise TypeError("Schema must define columns attribute")
+
+    fields: list[dict[str, Any]] = []
+    for name, column in columns.items():
+        fields.append(
+            {
+                "name": name,
+                "data_type": _map_dtype_to_field_type(column.dtype),
+                "is_nullable": bool(column.nullable),
+                "is_filterable": _DEFAULT_FILTERABLE,
+                "description": column.description or "",
+            }
+        )
+    return fields
+
+
+__all__ = ["build_field_configs_from_schema"]

--- a/src/bioetl/infrastructure/config/loader.py
+++ b/src/bioetl/infrastructure/config/loader.py
@@ -8,6 +8,10 @@ from typing import Any
 from pydantic import ValidationError
 
 from bioetl.domain.configs import PipelineConfig
+from bioetl.domain.schemas import register_schemas
+from bioetl.domain.schemas.fields import build_field_configs_from_schema
+from bioetl.domain.schemas.pipeline_contracts import get_pipeline_contract
+from bioetl.domain.schemas.registry import SchemaRegistry
 from bioetl.domain.transform.merge import apply_deep_merge
 from bioetl.infrastructure.config.defaults_loader import get_defaults_config
 from bioetl.infrastructure.config.env import resolve_env_placeholders
@@ -152,6 +156,7 @@ def _finalize_config(
     )
     merged_config = resolve_env_placeholders(merged_config)
     merged_config = _apply_defaults(merged_config, defaults)
+    merged_config = _populate_fields_from_schema(merged_config)
     _validate_input_path_exists(merged_config, config_path)
 
     try:
@@ -185,6 +190,30 @@ def _apply_defaults(config: dict[str, Any], defaults: Any) -> dict[str, Any]:
     )
     merged["quality"] = quality_section
     return merged
+
+
+def _populate_fields_from_schema(config: dict[str, Any]) -> dict[str, Any]:
+    if config.get("fields"):
+        return config
+
+    provider = config.get("provider")
+    entity = config.get("entity")
+    if not provider or not entity:
+        return config
+
+    contract = get_pipeline_contract(f"{provider}.{entity}", default_entity=str(entity))
+    schema_name = contract.get_output_schema()
+
+    registry = SchemaRegistry()
+    register_schemas(registry)
+    try:
+        schema = registry.get_schema(schema_name)
+    except ValueError:
+        return config
+
+    config = dict(config)
+    config["fields"] = build_field_configs_from_schema(schema)
+    return config
 
 
 def _validate_provider(

--- a/tests/bioetl/domain/test_config_loader.py
+++ b/tests/bioetl/domain/test_config_loader.py
@@ -277,3 +277,46 @@ batch_size: 25
     assert config.output_path == "/tmp/out"  # pipeline overrides profile
     assert config.batch_size == 10
     assert config.provider_config.timeout_sec == 10
+
+
+def test_fields_populated_from_schema_when_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    providers_file = Path("tests/fixtures/configs/providers.yaml")
+    monkeypatch.setattr(
+        provider_registry_loader,
+        "DEFAULT_PROVIDERS_REGISTRY_PATH",
+        providers_file,
+    )
+    monkeypatch.setattr(
+        config_loader, "DEFAULT_PROVIDERS_REGISTRY_PATH", providers_file
+    )
+    provider_registry_loader.clear_provider_registry_cache()
+
+    pipelines_root = tmp_path / "pipelines" / "chembl"
+    pipelines_root.mkdir(parents=True)
+    config_path = pipelines_root / "activity.yaml"
+    config_path.write_text(
+        """id: chembl.activity
+provider: chembl
+entity: activity
+input_mode: auto_detect
+input_path: null
+output_path: /tmp/out
+batch_size: 5
+provider_config:
+  provider: chembl
+  base_url: https://www.ebi.ac.uk/chembl/api/data
+  timeout_sec: 30
+  max_retries: 3
+  rate_limit_per_sec: 10.0
+""",
+        encoding="utf-8",
+    )
+
+    config = get_pipeline_config_from_path(config_path)
+
+    field_names = [field["name"] for field in config.fields]
+    assert len(field_names) > 5
+    assert "action_type" in field_names
+    assert "extracted_at" in field_names


### PR DESCRIPTION
## Summary
- add utility to derive pipeline field descriptors from Pandera schemas
- auto-populate pipeline config fields from schema contracts during config loading
- cover schema-driven field hydration with a dedicated config loader test

## Testing
- PYTHONPATH=src pytest tests/bioetl/domain/test_config_loader.py -k fields_populated_from_schema_when_missing


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936ebb7a0248324ab9f1cf12fd0ea5b)