### PR TITLE
Align infrastructure class names with naming conventions

### DIFF
--- a/src/bioetl.egg-info/SOURCES.txt
+++ b/src/bioetl.egg-info/SOURCES.txt
@@ -165,7 +165,7 @@ src/bioetl/infrastructure/output/__init__.py
 src/bioetl/infrastructure/output/column_order.py
 src/bioetl/infrastructure/output/factories.py
 src/bioetl/infrastructure/output/metadata.py
-src/bioetl/infrastructure/output/unified_writer.py
+src/bioetl/infrastructure/output/unified_output_writer_impl.py
 src/bioetl/infrastructure/output/impl/__init__.py
 src/bioetl/infrastructure/output/impl/base_writer.py
 src/bioetl/infrastructure/output/impl/csv_writer.py

--- a/src/bioetl/infrastructure/clients/base/abc_impls.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_impls.yaml
@@ -97,7 +97,7 @@ QualityReportABC:
 OutputWriterABC:
   default_factory: bioetl.infrastructure.output.factories.default_output_writer
   implementations:
-    Unified: bioetl.infrastructure.output.unified_writer.UnifiedOutputWriter
+    Unified: bioetl.infrastructure.output.unified_output_writer_impl.UnifiedOutputWriterImpl
 
 DataClientABC:
   default_factory: bioetl.infrastructure.clients.chembl.factories.default_chembl_client
@@ -122,7 +122,7 @@ PaginatorABC:
 SecretProviderABC:
   default_factory: bioetl.infrastructure.clients.base.factories.default_secret_provider
   implementations:
-    Env: bioetl.infrastructure.clients.base.factories.EnvSecretProvider
+    Env: bioetl.infrastructure.clients.base.factories.EnvSecretProviderImpl
 
 SideInputProviderABC:
   default_factory: bioetl.infrastructure.clients.base.factories.default_side_input_provider

--- a/src/bioetl/infrastructure/clients/base/factories.py
+++ b/src/bioetl/infrastructure/clients/base/factories.py
@@ -29,7 +29,7 @@ from bioetl.infrastructure.clients.chembl.response_parser import (
 )
 
 
-class EnvSecretProvider(SecretProviderABC):
+class EnvSecretProviderImpl(SecretProviderABC):
     """Resolve secrets from environment variables."""
 
     def get_secret(self, name: str) -> str | None:
@@ -58,7 +58,7 @@ def default_cache() -> CacheABC[Any]:
 def default_secret_provider() -> SecretProviderABC:
     """Expose the environment-backed secret provider implementation."""
 
-    return EnvSecretProvider()
+    return EnvSecretProviderImpl()
 
 
 def default_request_builder(*, base_url: str | None = None) -> RequestBuilderABC:

--- a/src/bioetl/infrastructure/clients/base/impl/unified_api_client_impl.py
+++ b/src/bioetl/infrastructure/clients/base/impl/unified_api_client_impl.py
@@ -13,7 +13,7 @@ from bioetl.domain.configs import ClientConfig
 from bioetl.infrastructure.clients.middleware import HttpClientMiddleware
 
 
-class UnifiedAPIClient:
+class UnifiedAPIClientImpl:
     """
     Унифицированный HTTP-клиент.
     Обертка над HttpClientMiddleware с конфигурацией через Pydantic.

--- a/src/bioetl/infrastructure/clients/chembl/factories.py
+++ b/src/bioetl/infrastructure/clients/chembl/factories.py
@@ -10,7 +10,9 @@ from bioetl.domain.ports.extraction import ExtractionServiceABC
 from bioetl.infrastructure.clients.base.impl.rate_limiter import (
     TokenBucketRateLimiterImpl,
 )
-from bioetl.infrastructure.clients.base.impl.unified_client import UnifiedAPIClient
+from bioetl.infrastructure.clients.base.impl.unified_api_client_impl import (
+    UnifiedAPIClientImpl,
+)
 from bioetl.infrastructure.clients.chembl.impl.chembl_extraction_service_impl import (
     ChemblExtractionServiceImpl,
 )
@@ -52,7 +54,7 @@ def default_chembl_client(
         )
 
     # Create Unified Client
-    unified_client = UnifiedAPIClient(
+    unified_client = UnifiedAPIClientImpl(
         provider="chembl",
         config=client_config,
     )

--- a/src/bioetl/infrastructure/clients/chembl/impl/http_client.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/http_client.py
@@ -10,7 +10,9 @@ from typing import Any, Iterator
 from bioetl.domain.clients.base.contracts import RateLimiterABC
 from bioetl.domain.clients.contracts import DataClientABC
 from bioetl.domain.errors import ClientResponseError
-from bioetl.infrastructure.clients.base.impl.unified_client import UnifiedAPIClient
+from bioetl.infrastructure.clients.base.impl.unified_api_client_impl import (
+    UnifiedAPIClientImpl,
+)
 from bioetl.infrastructure.clients.chembl.paginator import ChemblPaginatorImpl
 from bioetl.infrastructure.clients.chembl.request_builder import (
     ChemblRequestBuilderImpl,
@@ -24,7 +26,7 @@ from bioetl.infrastructure.clients.middleware import HttpClientMiddleware
 class ChemblDataClientHTTPImpl(DataClientABC):
     """
     HTTP implementation of ChEMBL client.
-    Uses UnifiedAPIClient for requests and RateLimiter for proactive throttling.
+    Uses UnifiedAPIClientImpl for requests and RateLimiter for proactive throttling.
     """
 
     def __init__(
@@ -32,7 +34,7 @@ class ChemblDataClientHTTPImpl(DataClientABC):
         request_builder: ChemblRequestBuilderImpl,
         response_parser: ChemblResponseParserImpl,
         rate_limiter: RateLimiterABC,
-        client: UnifiedAPIClient | None = None,
+        client: UnifiedAPIClientImpl | None = None,
         *,
         http_middleware: HttpClientMiddleware | None = None,
         provider: str = "chembl",

--- a/src/bioetl/infrastructure/output/factories.py
+++ b/src/bioetl/infrastructure/output/factories.py
@@ -10,7 +10,9 @@ from bioetl.domain.configs import DeterminismConfig, QcConfig
 from bioetl.infrastructure.output.impl.csv_writer import CsvWriterImpl
 from bioetl.infrastructure.output.impl.metadata_writer import MetadataWriterImpl
 from bioetl.infrastructure.output.impl.quality_report import QualityReportImpl
-from bioetl.infrastructure.output.unified_writer import UnifiedOutputWriter
+from bioetl.infrastructure.output.unified_output_writer_impl import (
+    UnifiedOutputWriterImpl,
+)
 
 
 def default_writer() -> WriterABC:
@@ -41,7 +43,7 @@ def default_output_writer(
 ) -> OutputWriterABC:
     """Compose the unified output writer with optional overrides."""
 
-    return UnifiedOutputWriter(
+    return UnifiedOutputWriterImpl(
         writer=writer or default_writer(),
         metadata_writer=metadata_writer or default_metadata_writer(),
         quality_reporter=quality_reporter or default_quality_reporter(),

--- a/src/bioetl/infrastructure/output/unified_output_writer_impl.py
+++ b/src/bioetl/infrastructure/output/unified_output_writer_impl.py
@@ -21,7 +21,7 @@ from bioetl.infrastructure.output.column_order import apply_column_order
 from bioetl.infrastructure.output.metadata import build_run_metadata
 
 
-class UnifiedOutputWriter(OutputWriterABC):
+class UnifiedOutputWriterImpl(OutputWriterABC):
     """
     Фасад для записи результатов пайплайна.
 

--- a/tests/bioetl/application/test_pipeline_container_metadata.py
+++ b/tests/bioetl/application/test_pipeline_container_metadata.py
@@ -17,7 +17,9 @@ from bioetl.domain.configs import DummyProviderConfig, PipelineConfig
 from bioetl.domain.models import RunContext
 from bioetl.domain.provider_registry import InMemoryProviderRegistry
 from bioetl.infrastructure.output.factories import default_output_writer
-from bioetl.infrastructure.output.unified_writer import UnifiedOutputWriter
+from bioetl.infrastructure.output.unified_output_writer_impl import (
+    UnifiedOutputWriterImpl,
+)
 
 
 class RecordingWriter(WriterABC):
@@ -121,7 +123,7 @@ def test_container_uses_overridden_metadata_writer(
     )
 
     output_writer = container.get_output_writer()
-    assert isinstance(output_writer, UnifiedOutputWriter)
+    assert isinstance(output_writer, UnifiedOutputWriterImpl)
 
     class InlineAtomic:
         def write_atomic(self, path: Path, write_fn) -> None:
@@ -191,7 +193,7 @@ def test_container_defaults_use_factories(
     assert writer_calls == 1
     assert metadata_calls == 1
     assert quality_calls == 1
-    assert isinstance(output_writer, UnifiedOutputWriter)
+    assert isinstance(output_writer, UnifiedOutputWriterImpl)
     assert output_writer._writer is default_writer_instance
     assert output_writer._metadata_writer is default_metadata_writer_instance
     assert output_writer._quality_reporter is default_quality_reporter_instance

--- a/tests/bioetl/infrastructure/clients/base/test_factories.py
+++ b/tests/bioetl/infrastructure/clients/base/test_factories.py
@@ -6,7 +6,7 @@ import os
 from unittest.mock import patch
 
 from bioetl.infrastructure.clients.base.factories import (
-    EnvSecretProvider,
+    EnvSecretProviderImpl,
     default_cache,
     default_rate_limiter,
     default_retry_policy,
@@ -31,7 +31,7 @@ def test_default_factories():
 def test_env_secret_provider():
     """Test environment secret provider."""
     provider = default_secret_provider()
-    assert isinstance(provider, EnvSecretProvider)
+    assert isinstance(provider, EnvSecretProviderImpl)
 
     with patch.dict(os.environ, {"TEST_SECRET": "s3cret"}):
         assert provider.get_secret("TEST_SECRET") == "s3cret"

--- a/tests/bioetl/infrastructure/clients/base/test_middleware.py
+++ b/tests/bioetl/infrastructure/clients/base/test_middleware.py
@@ -9,7 +9,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from bioetl.domain.errors import ClientNetworkError, ClientResponseError
-from bioetl.infrastructure.clients.base.impl.unified_client import UnifiedAPIClient
+from bioetl.infrastructure.clients.base.impl.unified_api_client_impl import (
+    UnifiedAPIClientImpl,
+)
 from bioetl.infrastructure.clients.middleware import HttpClientMiddleware
 from bioetl.infrastructure.config.models import ClientConfig
 from bioetl.interfaces.observability import LoggingPortABC
@@ -379,7 +381,7 @@ def test_idempotency_key_reused_across_retries(monkeypatch, base_client):
         _response(200),
     ]
 
-    client = UnifiedAPIClient(
+    client = UnifiedAPIClientImpl(
         provider="chembl",
         config=ClientConfig(max_retries=3, backoff_factor=1.0, timeout=0.1),
         base_client=base_client,
@@ -402,7 +404,7 @@ def test_get_requests_do_not_add_idempotency_key(base_client):
     """GET/HEAD запросы не получают автоматический Idempotency-Key."""
     base_client.request.return_value = _response(200)
 
-    client = UnifiedAPIClient(
+    client = UnifiedAPIClientImpl(
         provider="chembl",
         config=ClientConfig(),
         base_client=base_client,

--- a/tests/bioetl/infrastructure/output/test_unified_writer.py
+++ b/tests/bioetl/infrastructure/output/test_unified_writer.py
@@ -1,5 +1,5 @@
 """
-Tests for the UnifiedOutputWriter.
+Tests for the UnifiedOutputWriterImpl.
 """
 
 # pylint: disable=redefined-outer-name, protected-access
@@ -9,7 +9,9 @@ import pandas as pd
 import pytest
 
 from bioetl.domain.clients.base.output.contracts import WriteResult
-from bioetl.infrastructure.output.unified_writer import UnifiedOutputWriter
+from bioetl.infrastructure.output.unified_output_writer_impl import (
+    UnifiedOutputWriterImpl,
+)
 
 
 @pytest.fixture
@@ -67,7 +69,7 @@ def unified_writer(
     mock_atomic_op,
 ):
     """Fixture for unified writer."""
-    return UnifiedOutputWriter(
+    return UnifiedOutputWriterImpl(
         mock_writer_fixture,
         mock_metadata_writer_fixture,
         mock_quality_reporter,
@@ -102,7 +104,7 @@ def test_write_result_success(
 
     # Patch checksum function
     with patch(
-        "bioetl.infrastructure.output.unified_writer.compute_file_sha256"
+        "bioetl.infrastructure.output.unified_output_writer_impl.compute_file_sha256"
     ) as mock_checksum:
         mock_checksum.side_effect = [
             "real_checksum",
@@ -133,7 +135,7 @@ def test_unified_writer_delegates_atomicity(
     run_context_factory,
     tmp_path,
 ):
-    """Test that UnifiedOutputWriter delegates to AtomicFileOperation."""
+    """Test that UnifiedOutputWriterImpl delegates to AtomicFileOperation."""
     # Arrange
     run_context = run_context_factory()
     df = pd.DataFrame({"a": [1]})
@@ -144,7 +146,7 @@ def test_unified_writer_delegates_atomicity(
     )
 
     with patch(
-        "bioetl.infrastructure.output.unified_writer.compute_file_sha256"
+        "bioetl.infrastructure.output.unified_output_writer_impl.compute_file_sha256"
     ) as mock_checksum:
         mock_checksum.side_effect = ["abc", "qc1", "qc2"]
 
@@ -187,7 +189,7 @@ def test_unified_writer_column_order_and_fill(
     mock_writer_fixture.write.side_effect = capture_df
 
     with patch(
-        "bioetl.infrastructure.output.unified_writer.compute_file_sha256",
+        "bioetl.infrastructure.output.unified_output_writer_impl.compute_file_sha256",
         return_value="chk",
     ):
         result = unified_writer.write_result(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,9 @@ from bioetl.domain.configs import (
 )
 from bioetl.domain.models import RunContext
 from bioetl.domain.validation.service import ValidationService
-from bioetl.infrastructure.output.unified_writer import UnifiedOutputWriter
+from bioetl.infrastructure.output.unified_output_writer_impl import (
+    UnifiedOutputWriterImpl,
+)
 from bioetl.interfaces.observability import LoggingPortABC
 
 # Ensure src is on sys.path even if pytest pythonpath is ignored by runners
@@ -131,7 +133,7 @@ def mock_output_writer():
 
     from bioetl.domain.clients.base.output.contracts import WriteResult
 
-    writer = MagicMock(spec=UnifiedOutputWriter)
+    writer = MagicMock(spec=UnifiedOutputWriterImpl)
     writer.write_result.return_value = WriteResult(
         path=Path("/tmp/test_output.csv"),
         row_count=2,  # Default for most tests

--- a/tests/integration/test_unified_writer_integration.py
+++ b/tests/integration/test_unified_writer_integration.py
@@ -1,4 +1,4 @@
-"""Интеграционный тест UnifiedOutputWriter с реальными зависимостями."""
+"""Интеграционный тест UnifiedOutputWriterImpl с реальными зависимостями."""
 
 from __future__ import annotations
 
@@ -14,7 +14,9 @@ from bioetl.infrastructure.files.atomic import AtomicFileOperation
 from bioetl.infrastructure.output.impl.csv_writer import CsvWriterImpl
 from bioetl.infrastructure.output.impl.metadata_writer import MetadataWriterImpl
 from bioetl.infrastructure.output.impl.quality_report import QualityReportImpl
-from bioetl.infrastructure.output.unified_writer import UnifiedOutputWriter
+from bioetl.infrastructure.output.unified_output_writer_impl import (
+    UnifiedOutputWriterImpl,
+)
 
 
 @pytest.mark.integration
@@ -31,7 +33,7 @@ def test_unified_writer_writes_data_and_meta(tmp_path, run_context_factory):
         config={"hashing": {"business_key_fields": ["id"]}},
     )
 
-    unified_writer = UnifiedOutputWriter(
+    unified_writer = UnifiedOutputWriterImpl(
         writer,
         metadata_writer,
         quality_reporter,


### PR DESCRIPTION
## Summary
- rename infrastructure implementations to use explicit Impl suffixes and clarify roles
- update factories, yaml registry entries, and references to new class names
- adjust tests and metadata to match renamed modules

## Testing
- pytest tests/bioetl/infrastructure/clients/base/test_factories.py tests/bioetl/infrastructure/output/test_unified_writer.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936f131aba8832498b4961159af2503)