### PR TITLE
Unify logging and error handling for ChEMBL utilities

### DIFF
--- a/src/bioetl/infrastructure/clients/chembl/factories.py
+++ b/src/bioetl/infrastructure/clients/chembl/factories.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from bioetl.domain.clients.contracts import DataClientABC
 from bioetl.domain.configs import ChemblSourceConfig, ClientConfig
+from bioetl.domain.observability.contracts import LoggingPortABC
 from bioetl.domain.ports.extraction import ExtractionServiceABC
 from bioetl.infrastructure.clients.base.impl.rate_limiter import (
     TokenBucketRateLimiterImpl,
@@ -87,6 +88,7 @@ def default_chembl_extraction_service(
     client_config: ClientConfig | None = None,
     *,
     client: DataClientABC | None = None,
+    logger: LoggingPortABC | None = None,
 ) -> ExtractionServiceABC:
     """
     Создает сервис экстракции ChEMBL.
@@ -106,4 +108,5 @@ def default_chembl_extraction_service(
         client=client,
         # Allow provider config to set batch_size while keeping a generous hard cap
         batch_size=config.resolve_effective_batch_size(hard_cap=1000),
+        logger=logger,
     )

--- a/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
@@ -9,6 +9,8 @@ from collections.abc import Iterable
 from typing import Any
 
 from bioetl.domain.clients.contracts import DataClientABC
+from bioetl.domain.observability.contracts import LoggingPortABC
+from bioetl.infrastructure.observability.factories import default_logging_port
 from bioetl.domain.ports.extraction import ExtractionServiceABC
 from bioetl.infrastructure.clients.chembl.paginator import ChemblPaginatorImpl
 from bioetl.infrastructure.clients.chembl.response_parser import (
@@ -30,12 +32,16 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC):
         batch_size: int = 1000,
         *,
         flatten_enabled: bool = True,
+        logger: LoggingPortABC | None = None,
     ) -> None:
         self.client = client
         self.batch_size = batch_size
         self.paginator = ChemblPaginatorImpl()
         self.parser = ChemblResponseParserImpl()
         self.flatten_enabled = flatten_enabled
+        provider = getattr(client, "provider", "chembl")
+        base_logger = logger or default_logging_port()
+        self._logger = base_logger.apply_bind(provider=provider)
 
     def get_release_version(self) -> str:
         """Get ChEMBL release version from API metadata."""
@@ -44,8 +50,11 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC):
             return meta.get("chembl_release") or meta.get(
                 "chembl_db_version", "unknown"
             )
-        except Exception:
-            # Fallback if metadata endpoint fails (e.g. timeout or bad response)
+        except Exception as exc:
+            self._logger.warning(
+                "Failed to fetch ChEMBL release metadata; using fallback",
+                error=str(exc),
+            )
             return "unknown"
 
     def _request_entity(
@@ -177,7 +186,11 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC):
 
         try:
             from bioetl.domain.schemas.chembl.assay import OUTPUT_COLUMN_ORDER
-        except Exception:
+        except Exception as exc:
+            self._logger.warning(
+                "Failed to import assay schema; skipping field enrichment",
+                error=str(exc),
+            )
             return filters
 
         skip_meta = {

--- a/src/tools/check_naming_policy.py
+++ b/src/tools/check_naming_policy.py
@@ -10,6 +10,10 @@ import sys
 from typing import Any, Callable, Dict, List
 
 import yaml
+from bioetl.infrastructure.observability.factories import default_logging_port
+
+# Initialize logger early to capture any tool errors
+LOGGER = default_logging_port().apply_bind(tool="check_naming_policy")
 
 # Configuration
 CONFIG_PATH = Path("configs/naming_exceptions.yaml")
@@ -474,7 +478,7 @@ def load_exceptions() -> List[Dict[str, Any]]:
             data = yaml.safe_load(f)
             return data.get("exceptions", []) if data else []
     except (OSError, yaml.YAMLError) as e:
-        print(f"Error loading exceptions: {e}")
+        LOGGER.error("Error loading naming exceptions", error=str(e))
         return []
 
 
@@ -518,7 +522,7 @@ def main():
     exceptions = load_exceptions()
     all_violations = {}
 
-    print("Checking naming policy...")
+    LOGGER.info("Checking naming policy")
 
     for root_dir in ROOT_DIRS:
         root_path = Path(root_dir)
@@ -538,15 +542,16 @@ def main():
                 all_violations[str_path] = total
 
     if all_violations:
-        print(f"\nFound violations in {len(all_violations)} files:\n")
+        LOGGER.error(
+            "Found naming policy violations", count=len(all_violations)
+        )
         for path, violations in sorted(all_violations.items()):
-            print(f"File: {path}")
+            LOGGER.error("File violations", path=path)
             for v in violations:
-                print(f"  - {v}")
-            print("")
+                LOGGER.error("Violation detail", detail=v)
         sys.exit(1)
     else:
-        print("\nNo violations found.")
+        LOGGER.info("No violations found")
         sys.exit(0)
 
 

--- a/src/tools/check_net.py
+++ b/src/tools/check_net.py
@@ -2,16 +2,23 @@ import time
 
 import requests
 
+from bioetl.infrastructure.observability.factories import default_logging_port
+
+
+LOGGER = default_logging_port().apply_bind(tool="check_net")
+
 
 def check(url):
-    print(f"Fetching {url}...")
+    LOGGER.info("Fetching URL", url=url)
     try:
         start = time.time()
         resp = requests.get(url, timeout=10)
-        print(f"Status: {resp.status_code} in {time.time() - start:.2f}s")
-        print(resp.text[:200])
-    except Exception as e:
-        print(f"Error: {e}")
+        LOGGER.info(
+            "Received response", status=resp.status_code, duration_sec=time.time() - start
+        )
+        LOGGER.debug("Response preview", body=resp.text[:200])
+    except Exception as e:  # pragma: no cover - diagnostic helper
+        LOGGER.error("Network check failed", error=str(e))
 
 
 # check("https://www.ebi.ac.uk/chembl/api/data/status")

--- a/src/tools/debug_assay_fetch.py
+++ b/src/tools/debug_assay_fetch.py
@@ -5,18 +5,21 @@ from unittest.mock import patch
 import pandas as pd
 
 from bioetl.infrastructure.clients.chembl.impl import ChemblExtractionServiceImpl
+from bioetl.infrastructure.observability.factories import default_logging_port
 from bioetl.interfaces.cli.app import app
 
 # Create output dir
 Path("data/output/assay").mkdir(parents=True, exist_ok=True)
 
+LOGGER = default_logging_port().apply_bind(tool="debug_assay_fetch")
+
 
 def debug_fetch():
-    print("DEBUG: Inspecting input file...")
+    LOGGER.info("Inspecting input file")
     df = pd.read_csv("data/input/assay.csv", nrows=10)
-    print(f"First 10 IDs: {df['assay_chembl_id'].tolist()}")
+    LOGGER.info("Loaded assay IDs", ids=df["assay_chembl_id"].tolist())
 
-    print("\nDEBUG: Testing single ID fetch...")
+    LOGGER.info("Testing single ID fetch")
     # Use a known ID or one from the file
     test_id = df["assay_chembl_id"].iloc[0]
 
@@ -30,23 +33,23 @@ def debug_fetch():
     service = default_chembl_extraction_service(config)
 
     try:
-        print(f"Requesting batch for ID: {test_id}")
+        LOGGER.info("Requesting batch", test_id=test_id)
         # Note: filter_key should match what pipeline uses: assay_chembl_id__in
         response = service.request_batch("assay", [test_id], "assay_chembl_id__in")
-        print(f"Response keys: {list(response.keys())}")
+        LOGGER.info("Response received", keys=list(response.keys()))
         parsed = service.parse_response(response)
-        print(f"Parsed records: {len(parsed)}")
+        LOGGER.info("Parsed records", count=len(parsed))
         if parsed:
-            print(f"First record keys: {list(parsed[0].keys())}")
+            LOGGER.debug("First record keys", keys=list(parsed[0].keys()))
     except Exception as e:
-        print(f"Fetch error: {e}")
+        LOGGER.error("Fetch error", error=str(e))
 
 
 if __name__ == "__main__":
     # Run debug check first
     debug_fetch()
 
-    print("\n--- Running Pipeline ---")
+    LOGGER.info("Running pipeline")
     sys.argv = [
         "bioetl",
         "run",
@@ -65,6 +68,6 @@ if __name__ == "__main__":
         try:
             app()
         except SystemExit as e:
-            print(f"SystemExit: {e}")
+            LOGGER.error("Pipeline exited", error=str(e))
         except Exception as e:
-            print(f"Error: {e}")
+            LOGGER.error("Pipeline error", error=str(e))

--- a/src/tools/debug_assay_fetch_v2.py
+++ b/src/tools/debug_assay_fetch_v2.py
@@ -1,10 +1,14 @@
 from pathlib import Path
 import sys
+import sys
+import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pandas as pd
 
 from bioetl.infrastructure.clients.chembl.impl import ChemblExtractionServiceImpl
+from bioetl.infrastructure.observability.factories import default_logging_port
 from bioetl.interfaces.cli.app import app
 
 # Force unbuffered stdout
@@ -12,14 +16,16 @@ sys.stdout.reconfigure(line_buffering=True)
 # Create output dir
 Path("data/output/assay").mkdir(parents=True, exist_ok=True)
 
+LOGGER = default_logging_port().apply_bind(tool="debug_assay_fetch_v2")
+
 
 def debug_fetch():
-    print("DEBUG: Inspecting input file...", flush=True)
+    LOGGER.info("Inspecting input file")
     try:
         df = pd.read_csv("data/input/assay.csv", nrows=10)
-        print(f"First 10 IDs: {df['assay_chembl_id'].tolist()}", flush=True)
+        LOGGER.info("Loaded assay IDs", ids=df["assay_chembl_id"].tolist())
 
-        print("\nDEBUG: Testing single ID fetch...", flush=True)
+        LOGGER.info("Testing single ID fetch")
         test_id = df["assay_chembl_id"].iloc[0]
 
         from bioetl.domain.configs import ChemblSourceConfig
@@ -30,20 +36,20 @@ def debug_fetch():
         config = ChemblSourceConfig(base_url="https://www.ebi.ac.uk/chembl/api/data")
         service = default_chembl_extraction_service(config)
 
-        print(f"Requesting batch for ID: {test_id}", flush=True)
+        LOGGER.info("Requesting batch", test_id=test_id)
         response = service.request_batch("assay", [test_id], "assay_chembl_id__in")
-        print(f"Response keys: {list(response.keys())}", flush=True)
+        LOGGER.info("Response received", keys=list(response.keys()))
         parsed = service.parse_response(response)
-        print(f"Parsed records: {len(parsed)}", flush=True)
+        LOGGER.info("Parsed records", count=len(parsed))
         if parsed:
-            print(f"First record keys: {list(parsed[0].keys())}", flush=True)
+            LOGGER.debug("First record keys", keys=list(parsed[0].keys()))
     except Exception as e:
-        print(f"Fetch error: {e}", flush=True)
+        LOGGER.error("Fetch error", error=str(e))
 
 
 if __name__ == "__main__":
     debug_fetch()
-    print("\n--- Running Pipeline ---", flush=True)
+    LOGGER.info("Running pipeline")
     sys.argv = [
         "bioetl",
         "run",
@@ -61,6 +67,6 @@ if __name__ == "__main__":
         try:
             app()
         except SystemExit as e:
-            print(f"SystemExit: {e}", flush=True)
+            LOGGER.error("Pipeline exited", error=str(e))
         except Exception as e:
-            print(f"Error: {e}", flush=True)
+            LOGGER.error("Pipeline error", error=str(e))

--- a/src/tools/run_cmd.py
+++ b/src/tools/run_cmd.py
@@ -2,15 +2,19 @@ from pathlib import Path
 import sys
 from unittest.mock import patch
 
+from bioetl.infrastructure.observability.factories import default_logging_port
+
 # Ensure output dir exists
 Path("data/output/target").mkdir(parents=True, exist_ok=True)
+
+logger = default_logging_port().apply_bind(tool="run_cmd")
 
 try:
     # print(f"Container module: {bioetl.application.container.__file__}")
     from bioetl.infrastructure.clients.chembl.impl import ChemblExtractionServiceImpl
     from bioetl.interfaces.cli.app import app
 except ImportError as e:
-    print(f"ImportError: {e}")
+    logger.error("Failed to import CLI dependencies", error=str(e))
     sys.exit(1)
 
 
@@ -29,7 +33,7 @@ def main():
         "10",
     ]
 
-    print("Running CLI app via wrapper...")
+    logger.info("Running CLI app via wrapper")
 
     # Patch get_release_version to avoid /status call
     with patch.object(
@@ -40,11 +44,11 @@ def main():
         try:
             app()
         except SystemExit as e:
-            print(f"SystemExit: {e}")
+            logger.error("CLI exited", error=str(e))
         except Exception as e:
-            print(f"Exception: {e}")
+            logger.error("Wrapper error", error=str(e))
         finally:
-            print("Wrapper finished.")
+            logger.info("Wrapper finished")
 
 
 if __name__ == "__main__":

--- a/src/tools/run_pipeline.py
+++ b/src/tools/run_pipeline.py
@@ -1,5 +1,6 @@
 import sys
 
+from bioetl.infrastructure.observability.factories import default_logging_port
 from bioetl.interfaces.cli.app import app
 
 # Mock sys.argv
@@ -16,8 +17,9 @@ sys.argv = [
 ]
 
 if __name__ == "__main__":
-    print("Starting pipeline via wrapper script...")
+    logger = default_logging_port().apply_bind(tool="run_pipeline")
+    logger.info("Starting pipeline via wrapper script")
     try:
         app()
     except SystemExit as e:
-        print(f"SystemExit: {e}")
+        logger.error("Pipeline exited", error=str(e))

--- a/src/tools/update_golden_columns.py
+++ b/src/tools/update_golden_columns.py
@@ -7,45 +7,50 @@ import pandas as pd
 # Add src to python path
 sys.path.append(os.path.abspath("src"))
 
-print("Script started")
+from bioetl.infrastructure.observability.factories import default_logging_port
+
+
+LOGGER = default_logging_port().apply_bind(tool="update_golden_columns")
+
+LOGGER.info("Script started")
 
 try:
     from bioetl.domain.schemas.chembl.activity import ActivityTableSchema
 
-    print("Schema imported")
+    LOGGER.info("Schema imported")
 except ImportError as e:
-    print(f"ImportError: {e}")
+    LOGGER.error("Failed to import schema", error=str(e))
     sys.exit(1)
 
 
 def main():
     path = Path("qc/golden/chembl_activity/expected_output.csv")
     if not path.exists():
-        print(f"File not found: {path}")
+        LOGGER.error("Golden file not found", path=str(path))
         # Try absolute path just in case
         path = Path(os.getcwd()) / "qc/golden/chembl_activity/expected_output.csv"
         if not path.exists():
-            print(f"File still not found at {path}")
+            LOGGER.error("Golden file still missing after fallback", path=str(path))
             return
 
-    print(f"Reading {path}")
+    LOGGER.info("Reading golden file", path=str(path))
     df = pd.read_csv(path)
 
     # Get columns from schema to ensure correct order
     schema = ActivityTableSchema.to_schema()
     expected_columns = list(schema.columns.keys())
 
-    print("Reordering columns...")
+    LOGGER.info("Reordering columns to match schema")
     missing = [c for c in expected_columns if c not in df.columns]
     if missing:
-        print(f"Error: Missing columns in CSV: {missing}")
+        LOGGER.error("Missing columns in CSV", missing_columns=missing)
         return
 
     df = df[expected_columns]
 
-    print(f"Writing back to {path}")
+    LOGGER.info("Writing reordered CSV", path=str(path))
     df.to_csv(path, index=False)
-    print("Done.")
+    LOGGER.info("Column update completed")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- inject structured logging into the ChEMBL extraction service and surface metadata/schema failures through the shared logger
- allow the ChEMBL extraction factory to pass logging ports for consistent observability
- replace ad-hoc print/debug output in helper scripts with the unified logging port

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936f5548be48324ab7cb83fe9bea9e3)