### PR TITLE
Rename ChEMBL API port implementation class

### DIFF
--- a/src/bioetl/infrastructure/clients/base/abc_impls.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_impls.yaml
@@ -102,7 +102,7 @@ OutputWriterABC:
 DataClientABC:
   default_factory: bioetl.infrastructure.clients.chembl.factories.default_chembl_client
   implementations:
-    ChemblHTTP: bioetl.infrastructure.clients.chembl.impl.http_client.ChemblDataClientHTTPImpl
+    ChemblHTTP: bioetl.infrastructure.clients.chembl.impl.http_client.ChemblApiPortImpl
 
 RequestBuilderABC:
   default_factory: bioetl.infrastructure.clients.base.factories.default_request_builder

--- a/src/bioetl/infrastructure/clients/chembl/factories.py
+++ b/src/bioetl/infrastructure/clients/chembl/factories.py
@@ -17,9 +17,7 @@ from bioetl.infrastructure.clients.base.impl.unified_api_client_impl import (
 from bioetl.infrastructure.clients.chembl.impl.chembl_extraction_service_impl import (
     ChemblExtractionServiceImpl,
 )
-from bioetl.infrastructure.clients.chembl.impl.http_client import (
-    ChemblDataClientHTTPImpl,
-)
+from bioetl.infrastructure.clients.chembl.impl.http_client import ChemblApiPortImpl
 from bioetl.infrastructure.clients.chembl.request_builder import (
     ChemblRequestBuilderImpl,
 )
@@ -64,7 +62,7 @@ def default_chembl_client(
         capacity=max(1.0, client_config.rate_limit_per_sec),
     )
 
-    return ChemblDataClientHTTPImpl(
+    return ChemblApiPortImpl(
         request_builder=ChemblRequestBuilderImpl(
             base_url=base_url,
             max_url_length=max_url_length,

--- a/src/bioetl/infrastructure/clients/chembl/impl/http_client.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/http_client.py
@@ -1,5 +1,5 @@
 """
-Implementation of ChEMBL HTTP client.
+HTTP implementation of ChEMBL API port.
 """
 
 from __future__ import annotations
@@ -23,9 +23,9 @@ from bioetl.infrastructure.clients.chembl.response_parser import (
 from bioetl.infrastructure.clients.middleware import HttpClientMiddleware
 
 
-class ChemblDataClientHTTPImpl(DataClientABC):
+class ChemblApiPortImpl(DataClientABC):
     """
-    HTTP implementation of ChEMBL client.
+    ChEMBL API port implemented over HTTP.
     Uses UnifiedAPIClientImpl for requests and RateLimiter for proactive throttling.
     """
 

--- a/tests/bioetl/infrastructure/clients/chembl/test_factories.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_factories.py
@@ -9,9 +9,7 @@ from bioetl.infrastructure.clients.chembl.factories import (
     default_chembl_client,
     default_chembl_extraction_service,
 )
-from bioetl.infrastructure.clients.chembl.impl.http_client import (
-    ChemblDataClientHTTPImpl,
-)
+from bioetl.infrastructure.clients.chembl.impl.http_client import ChemblApiPortImpl
 from bioetl.infrastructure.config.models import ChemblSourceConfig, ClientConfig
 
 
@@ -32,7 +30,7 @@ def source_config():
 def test_default_chembl_client_success(source_config):
     """Test default ChEMBL client factory with valid config."""
     client = default_chembl_client(source_config)
-    assert isinstance(client, ChemblDataClientHTTPImpl)
+    assert isinstance(client, ChemblApiPortImpl)
     # Check that parameters propagated to request_builder
     assert client.request_builder.base_url == "https://example.com"
     assert client.request_builder.max_url_length == 1000
@@ -53,7 +51,7 @@ def test_default_chembl_extraction_service(source_config):
     source_config.batch_size = 50
     service = default_chembl_extraction_service(source_config)
     assert isinstance(service, ChemblExtractionServiceImpl)
-    assert isinstance(service.client, ChemblDataClientHTTPImpl)
+    assert isinstance(service.client, ChemblApiPortImpl)
     assert service.batch_size == 50
 
 

--- a/tests/bioetl/infrastructure/clients/chembl/test_http_client.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_http_client.py
@@ -1,4 +1,4 @@
-"""Tests for ChemblDataClientHTTPImpl."""
+"""Tests for ChemblApiPortImpl."""
 
 # pylint: disable=redefined-outer-name
 from unittest.mock import Mock
@@ -7,9 +7,7 @@ import pytest
 
 from bioetl.domain.clients.base.contracts import RateLimiterABC
 from bioetl.domain.errors import ClientResponseError
-from bioetl.infrastructure.clients.chembl.impl.http_client import (
-    ChemblDataClientHTTPImpl,
-)
+from bioetl.infrastructure.clients.chembl.impl.http_client import ChemblApiPortImpl
 from bioetl.infrastructure.clients.chembl.request_builder import (
     ChemblRequestBuilderImpl,
 )
@@ -47,8 +45,8 @@ def fixture_client(
     mock_rate_limiter,
     mock_http_middleware,
 ):
-    """Create ChemblDataClientHTTPImpl instance with mocks."""
-    client = ChemblDataClientHTTPImpl(
+    """Create ChemblApiPortImpl instance with mocks."""
+    client = ChemblApiPortImpl(
         request_builder=mock_request_builder,
         response_parser=mock_response_parser,
         rate_limiter=mock_rate_limiter,

--- a/tests/bioetl/infrastructure/clients/test_chembl_client.py
+++ b/tests/bioetl/infrastructure/clients/test_chembl_client.py
@@ -1,13 +1,11 @@
-"""Integration-style tests for ChemblDataClientHTTPImpl wiring."""
+"""Integration-style tests for ChemblApiPortImpl wiring."""
 
 from unittest.mock import MagicMock
 
 import pytest
 
 from bioetl.domain.clients.base.contracts import RateLimiterABC
-from bioetl.infrastructure.clients.chembl.impl.http_client import (
-    ChemblDataClientHTTPImpl,
-)
+from bioetl.infrastructure.clients.chembl.impl.http_client import ChemblApiPortImpl
 from bioetl.infrastructure.clients.chembl.request_builder import (
     ChemblRequestBuilderImpl,
 )
@@ -31,7 +29,7 @@ def mock_components():
 
 @pytest.fixture
 def client(mock_components):
-    client = ChemblDataClientHTTPImpl(
+    client = ChemblApiPortImpl(
         request_builder=mock_components["request_builder"],
         response_parser=mock_components["response_parser"],
         rate_limiter=mock_components["rate_limiter"],


### PR DESCRIPTION
## Summary
- rename the ChEMBL HTTP client implementation to `ChemblApiPortImpl` with updated docstring
- update factory wiring and ABC registry references to the new class name
- adjust client-related tests to use the renamed implementation

## Testing
- pytest tests/bioetl/infrastructure/clients/chembl -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936fa264c6c8324ba667905350175df)