### PR TITLE
Refactor PipelineBase to use loader abstraction

### DIFF
--- a/src/bioetl/application/orchestrator.py
+++ b/src/bioetl/application/orchestrator.py
@@ -6,7 +6,7 @@ from concurrent.futures import Future, ProcessPoolExecutor
 from pathlib import Path
 from typing import Callable, cast
 
-from bioetl.application.pipelines.base import PipelineBase
+from bioetl.application.pipelines.base import OutputWriterLoaderAdapter, PipelineBase
 from bioetl.application.pipelines.contracts import PipelineContainerABC
 from bioetl.application.pipelines.registry import get_pipeline_class
 from bioetl.domain.configs import PipelineConfig
@@ -56,6 +56,7 @@ class PipelineOrchestrator:
         logger = container.get_logger()
         validation_service = container.get_validation_service()
         output_writer = container.get_output_writer()
+        loader = OutputWriterLoaderAdapter(output_writer)
         extraction_service = container.get_extraction_service()
         normalization_service = container.get_normalization_service()
         record_source = container.get_record_source(
@@ -73,7 +74,7 @@ class PipelineOrchestrator:
             config=self._config,
             logger=logger,
             validation_service=validation_service,
-            output_writer=output_writer,
+            loader=loader,
             extraction_service=extraction_service,
             record_source=record_source,
             normalization_service=normalization_service,

--- a/src/bioetl/application/pipelines/base.py
+++ b/src/bioetl/application/pipelines/base.py
@@ -1,6 +1,6 @@
 """Базовый класс пайплайна."""
 
-from abc import ABC
+from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -8,12 +8,9 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable, cast
 
 import pandas as pd
 
-from bioetl.application.pipelines.contracts import ExtractorABC
+from bioetl.application.pipelines.contracts import ExtractorABC, LoaderABC
 from bioetl.application.pipelines.stage_runtime_manager import StageRuntimeManagerImpl
-from bioetl.domain.clients.base.output.contracts import (
-    RunMetadataBuilderProtocol,
-    WriteResult,
-)
+from bioetl.domain.clients.base.output.contracts import RunMetadataBuilderProtocol, WriteResult
 from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.errors import PipelineStageError
 from bioetl.domain.models import RunContext, RunResult, StageResult
@@ -54,6 +51,29 @@ def _create_default_metadata_builder() -> RunMetadataBuilderProtocol:
     )
 
 
+class OutputWriterLoaderAdapter(LoaderABC):
+    """Adapter that bridges legacy OutputWriterABC to LoaderABC."""
+
+    def __init__(self, output_writer: "OutputWriterABC") -> None:
+        self._output_writer = output_writer
+
+    def load(
+        self,
+        df: pd.DataFrame,
+        output_path: Path,
+        context: RunContext,
+        *,
+        column_order: list[str] | None = None,
+    ) -> WriteResult:
+        return self._output_writer.write_result(
+            df=df,
+            output_path=output_path,
+            entity_name=context.entity_name,
+            run_context=context,
+            column_order=column_order or [],
+        )
+
+
 class PipelineBase(ABC):
     """
     Абстрактный базовый класс для всех ETL-пайплайнов.
@@ -69,7 +89,7 @@ class PipelineBase(ABC):
         config: PipelineConfig,
         logger: LoggingPortABC,
         validation_service: ValidationService,
-        output_writer: "OutputWriterABC",
+        loader: LoaderABC,
         hash_service: HashServiceABC,
         metadata_builder: RunMetadataBuilderProtocol | None = None,
         extractor: ExtractorABC | None = None,
@@ -86,7 +106,7 @@ class PipelineBase(ABC):
             pipeline=config.id,
         )
         self._validation_service = validation_service
-        self._output_writer = output_writer
+        self._loader = loader
         self._hash_service = hash_service
         self._metadata_builder = metadata_builder or _create_default_metadata_builder()
         self._extractor = extractor
@@ -443,21 +463,13 @@ class PipelineBase(ABC):
         """Возвращает версию источника данных. По умолчанию 'unknown'."""
         return "unknown"
 
-    def extract(self, **kwargs: Any) -> pd.DataFrame:
-        """Deprecated: used only if not iterating chunks."""
-        if not self._extractor:
-            return pd.DataFrame()
+    @abstractmethod
+    def extract(self, **kwargs: Any) -> Iterable[pd.DataFrame]:
+        """Возвращает итератор чанков исходных данных."""
 
-        chunks = list(self._extractor.extract(**kwargs))
-        if not chunks:
-            return pd.DataFrame()
-        return pd.concat(chunks, ignore_index=True)
-
+    @abstractmethod
     def transform(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Преобразует сырые данные используя injected transformer."""  # noqa: E501
-        if self._transformer:
-            return self._transformer.apply(df)
-        return df
+        """Преобразует сырые данные."""
 
     def validate(self, df: pd.DataFrame) -> pd.DataFrame:
         """Валидирует DataFrame по Pandera-схеме."""
@@ -466,6 +478,7 @@ class PipelineBase(ABC):
             entity_name=self._schema_contract.schema_out,
         )
 
+    @abstractmethod
     def write(
         self,
         df: pd.DataFrame,
@@ -473,39 +486,22 @@ class PipelineBase(ABC):
         context: RunContext,
     ) -> WriteResult:
         """Записывает валидированный DataFrame."""
+
+    def _write_with_loader(
+        self,
+        df: pd.DataFrame,
+        output_path: Path,
+        context: RunContext,
+    ) -> WriteResult:
         output_schema_name = self._schema_contract.get_output_schema()
         output_columns = self._validation_service.get_schema_columns(output_schema_name)
 
-        return self._output_writer.write_result(
+        return self._loader.load(
             df=df,
             output_path=output_path,
-            entity_name=self._config.entity_name,
-            run_context=context,
+            context=context,
             column_order=output_columns,
         )
-
-    def iter_chunks(self, **kwargs: Any) -> Iterable[pd.DataFrame]:
-        """Возвращает итератор по чанкам данных после extract."""
-        if self._extractor is not None:
-            extractor = self._extractor
-
-            def _extractor_generator() -> Iterable[pd.DataFrame]:
-                self._increment_extract_call_count()
-                result = extractor.extract(**kwargs)
-                if isinstance(result, pd.DataFrame):
-                    yield result
-                    return
-                if isinstance(result, Iterable):
-                    yield from result
-                    return
-                raise TypeError(
-                    "Extractor.extract() must return DataFrame or iterable of "
-                    "DataFrames."
-                )
-
-            return _extractor_generator()
-
-        return self._iter_chunks_without_extractor(**kwargs)
 
     # === Hooks ===
 
@@ -543,7 +539,7 @@ class PipelineBase(ABC):
         iterator = self._runtime_manager.execute_stage(
             "extract",
             context,
-            lambda: self.iter_chunks(**kwargs),
+            lambda: self.extract(**kwargs),
         )
         if iterator is None:
             return iter([])
@@ -578,31 +574,6 @@ class PipelineBase(ABC):
             return pd.DataFrame()
         return None
 
-    def _iter_chunks_without_extractor(self, **kwargs: Any) -> Iterable[pd.DataFrame]:
-        """
-        Fallback chunk iterator when external extractor is not provided.
-
-        Uses subclass extract() implementation; raises if not overridden.
-        """
-        if self.__class__.extract is PipelineBase.extract:
-            raise ValueError("Extractor is required when extract() is not overridden.")
-
-        def _generator() -> Iterable[pd.DataFrame]:
-            result = self.extract(**kwargs)
-            if result is None:
-                return
-            if isinstance(result, pd.DataFrame):
-                yield result
-                return
-            if isinstance(result, Iterable):
-                yield from result
-                return
-            raise TypeError(
-                "extract() must return a DataFrame or iterable of DataFrames."
-            )
-
-        return _generator()
-
     def _instrument_extract_calls(self) -> None:
         """
         Wraps extract() to expose call_count for tests without altering logic.
@@ -621,12 +592,6 @@ class PipelineBase(ABC):
 
         setattr(_wrapped_extract, "call_count", 0)
         self.extract = _wrapped_extract  # type: ignore[method-assign]
-
-    def _increment_extract_call_count(self) -> None:
-        """Helper to bump extract.call_count when using external extractor."""
-        call_count = getattr(self.extract, "call_count", None)
-        if isinstance(call_count, int):
-            setattr(self.extract, "call_count", call_count + 1)
 
     def _enrich_context(self, context: RunContext) -> None:
         """

--- a/src/bioetl/application/pipelines/chembl/base.py
+++ b/src/bioetl/application/pipelines/chembl/base.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from bioetl.application.pipelines.base import (
+    OutputWriterLoaderAdapter,
     PipelineBase,
     _create_default_metadata_builder,
 )
 from bioetl.application.pipelines.chembl.extractor import ChemblExtractorImpl
 from bioetl.application.pipelines.chembl.transformer import ChemblTransformerImpl
+from bioetl.application.pipelines.contracts import LoaderABC
 from bioetl.application.transform.pandas_batch_adapter import PandasBatchAdapter
 from bioetl.domain.clients.base.output.contracts import (
     OutputWriterABC,
@@ -33,7 +35,7 @@ class ChemblPipelineBase(PipelineBase):
         config: PipelineConfig,
         logger: LoggingPortABC,
         validation_service: ValidationService,
-        output_writer: OutputWriterABC,
+        loader: LoaderABC | None = None,
         extraction_service: ExtractionServiceABC,
         hash_service: HashServiceABC,
         metadata_builder: RunMetadataBuilderProtocol | None = None,
@@ -42,6 +44,7 @@ class ChemblPipelineBase(PipelineBase):
         hooks: list[PipelineHookABC] | None = None,
         error_policy: ErrorPolicyABC | None = None,
         post_transformer: TransformerABC | None = None,
+        output_writer: OutputWriterABC | None = None,
     ) -> None:
         self._extraction_service = extraction_service
         self._chembl_release: str | None = None
@@ -74,11 +77,17 @@ class ChemblPipelineBase(PipelineBase):
             logger=logger,
         )
 
+        resolved_loader = loader
+        if resolved_loader is None:
+            if output_writer is None:
+                raise ValueError("Loader or output_writer must be provided.")
+            resolved_loader = OutputWriterLoaderAdapter(output_writer)
+
         super().__init__(
             config=config,
             logger=logger,
             validation_service=validation_service,
-            output_writer=output_writer,
+            loader=resolved_loader,
             hash_service=hash_service,
             metadata_builder=metadata_builder or _create_default_metadata_builder(),
             extractor=extractor,
@@ -87,6 +96,10 @@ class ChemblPipelineBase(PipelineBase):
             transformer=transformer,
             post_transformer=post_transformer,
         )
+
+        self._loader = resolved_loader
+        self._extractor = extractor
+        self._transformer = transformer
 
     @staticmethod
     def _resolve_primary_key(config: PipelineConfig) -> tuple[str, str]:
@@ -146,3 +159,12 @@ class ChemblPipelineBase(PipelineBase):
         if input_mode == "csv":
             return True
         return bool(pipeline_cfg.get("skip_release_lookup"))
+
+    def extract(self, **kwargs):  # type: ignore[override]
+        return self._extractor.extract(**kwargs)
+
+    def transform(self, df):  # type: ignore[override]
+        return self._transformer.apply(df)
+
+    def write(self, df, output_path, context):  # type: ignore[override]
+        return self._write_with_loader(df, output_path, context)

--- a/src/bioetl/application/pipelines/chembl/factories.py
+++ b/src/bioetl/application/pipelines/chembl/factories.py
@@ -2,6 +2,7 @@
 Factories for ChEMBL pipelines.
 """
 
+from bioetl.application.pipelines.base import OutputWriterLoaderAdapter
 from bioetl.application.pipelines.chembl.base import ChemblPipelineBase
 from bioetl.application.pipelines.contracts import PipelineContainerABC
 
@@ -20,7 +21,7 @@ def create_chembl_pipeline(container: PipelineContainerABC) -> ChemblPipelineBas
         config=container.config,
         logger=container.get_logger(),
         validation_service=container.get_validation_service(),
-        output_writer=container.get_output_writer(),
+        loader=OutputWriterLoaderAdapter(container.get_output_writer()),
         extraction_service=container.get_extraction_service(),
         hash_service=container.get_hash_service(),
         metadata_builder=container.get_metadata_builder(),

--- a/src/bioetl/application/pipelines/contracts.py
+++ b/src/bioetl/application/pipelines/contracts.py
@@ -1,6 +1,7 @@
 """Contracts for pipeline components."""
 
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any, Callable, Iterable
 
 import pandas as pd
@@ -8,8 +9,10 @@ import pandas as pd
 from bioetl.domain.clients.base.output.contracts import (
     OutputWriterABC,
     RunMetadataBuilderProtocol,
+    WriteResult,
 )
 from bioetl.domain.configs import PipelineConfig
+from bioetl.domain.models import RunContext
 from bioetl.domain.observability import LoggingPortABC
 from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
 from bioetl.domain.record_source import RecordSource
@@ -36,7 +39,14 @@ class LoaderABC(ABC):
     """
 
     @abstractmethod
-    def load(self, df: pd.DataFrame, **kwargs: Any) -> None:
+    def load(
+        self,
+        df: pd.DataFrame,
+        output_path: Path,
+        context: RunContext,
+        *,
+        column_order: list[str] | None = None,
+    ) -> WriteResult:
         """
         Loads data to destination.
         """

--- a/tests/bioetl/application/pipelines/test_pipeline_base.py
+++ b/tests/bioetl/application/pipelines/test_pipeline_base.py
@@ -4,6 +4,7 @@ Tests for the PipelineBase class.
 
 # pylint: disable=redefined-outer-name, protected-access
 from pathlib import Path
+from typing import Callable
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -14,6 +15,7 @@ from bioetl.application.pipelines.hooks_impl import (
     ContinueOnErrorPolicyImpl,
     FailFastErrorPolicyImpl,
 )
+from bioetl.application.pipelines.contracts import ExtractorABC, LoaderABC
 from bioetl.domain.errors import PipelineStageError
 from bioetl.domain.models import RunContext
 from bioetl.domain.pipelines.contracts import PipelineHookABC
@@ -29,31 +31,87 @@ from bioetl.domain.transform.transformers import (
 from bioetl.infrastructure.transform.factories import default_hash_service
 
 
+class ListExtractor(ExtractorABC):
+    """Extractor stub returning predefined chunks."""
+
+    def __init__(self, chunks: list[pd.DataFrame]):
+        self._chunks = chunks
+
+    def extract(self, **kwargs):  # type: ignore[override]
+        _ = kwargs
+        return list(self._chunks)
+
+
+class FunctionTransformer(TransformerABC):
+    """Transformer stub applying provided callable."""
+
+    def __init__(self, fn: Callable[[pd.DataFrame], pd.DataFrame]):
+        self._fn = fn
+
+    def apply(
+        self, df: pd.DataFrame, context: RunContext | None = None
+    ) -> pd.DataFrame:  # noqa: D401
+        _ = context
+        return self._fn(df)
+
+
 class ConcretePipeline(PipelineBase):
     """A concrete implementation of PipelineBase for testing."""
 
-    def extract(self, **_):
-        """Mock extraction returning sample data."""
-        return pd.DataFrame({"id": [1, 2], "val": ["x", "y"]})
+    def __init__(
+        self,
+        *args,
+        extractor: ExtractorABC,
+        transformer: TransformerABC,
+        loader: LoaderABC,
+        **kwargs,
+    ):
+        super().__init__(
+            *args,
+            extractor=extractor,
+            transformer=transformer,
+            loader=loader,
+            **kwargs,
+        )
+        self._extractor = extractor
+        self._transformer = transformer
+        self._loader = loader
+
+    def extract(self, **kwargs):  # type: ignore[override]
+        return self._extractor.extract(**kwargs)
 
     def transform(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Mock transformation adding a column."""
-        df["transformed"] = True
-        return df
+        return self._transformer.apply(df)
+
+    def write(self, df: pd.DataFrame, output_path: Path, context: RunContext):
+        return self._loader.load(df, output_path, context)
 
 
 class DatasetPipeline(PipelineBase):
     """Pipeline that operates on a provided in-memory dataset."""
 
-    def __init__(self, *args, dataset: pd.DataFrame, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, *args, dataset: pd.DataFrame, loader: LoaderABC, **kwargs):
+        extractor = ListExtractor([dataset.copy()])
+        transformer = FunctionTransformer(lambda frame: frame.assign(processed=True))
+        super().__init__(
+            *args,
+            extractor=extractor,
+            transformer=transformer,
+            loader=loader,
+            **kwargs,
+        )
+        self._loader = loader
         self._dataset = dataset
 
-    def extract(self, **_):
-        return self._dataset.copy()
+    def extract(self, **kwargs):  # type: ignore[override]
+        _ = kwargs
+        return [self._dataset.copy()]
 
     def transform(self, df: pd.DataFrame) -> pd.DataFrame:
         return df.assign(processed=True)
+
+    def write(self, df: pd.DataFrame, output_path: Path, context: RunContext):
+        return self._loader.load(df, output_path, context)
 
 
 @pytest.fixture
@@ -63,11 +121,12 @@ def hash_service():
 
 @pytest.fixture
 def default_extractor():
-    extractor = MagicMock()
-    extractor.extract.return_value = [
-        pd.DataFrame({"id": [1, 2], "val": ["x", "y"]}),
-    ]
-    return extractor
+    return ListExtractor([pd.DataFrame({"id": [1, 2], "val": ["x", "y"]})])
+
+
+@pytest.fixture
+def default_transformer():
+    return FunctionTransformer(lambda df: df.assign(transformed=True))
 
 
 @pytest.mark.unit
@@ -75,11 +134,12 @@ def test_pipeline_run_success(
     mock_config,
     mock_logger,
     mock_validation_service,
-    mock_output_writer,
+    mock_loader,
     mock_metadata_builder,
     tmp_path,
     hash_service,
     default_extractor,
+    default_transformer,
 ):
     """Test a successful pipeline run."""
     # Arrange
@@ -87,10 +147,11 @@ def test_pipeline_run_success(
         config=mock_config,
         logger=mock_logger,
         validation_service=mock_validation_service,
-        output_writer=mock_output_writer,
+        loader=mock_loader,
         hash_service=hash_service,
         metadata_builder=mock_metadata_builder,
         extractor=default_extractor,
+        transformer=default_transformer,
     )
 
     output_path = tmp_path / "output.parquet"
@@ -107,7 +168,7 @@ def test_pipeline_run_success(
     mock_logger.info.assert_any_call("Pipeline started", run_id=result.run_id)
 
     # Verify write called
-    mock_output_writer.write_result.assert_called_once()
+    mock_loader.load.assert_called_once()
 
 
 @pytest.mark.unit
@@ -115,11 +176,12 @@ def test_pipeline_dry_run(
     mock_config,
     mock_logger,
     mock_validation_service,
-    mock_output_writer,
+    mock_loader,
     mock_metadata_builder,
     tmp_path,
     hash_service,
     default_extractor,
+    default_transformer,
 ):
     """Test a dry run of the pipeline."""
     # Arrange
@@ -127,10 +189,11 @@ def test_pipeline_dry_run(
         mock_config,
         mock_logger,
         mock_validation_service,
-        mock_output_writer,
-        hash_service,
+        loader=mock_loader,
+        hash_service=hash_service,
         metadata_builder=mock_metadata_builder,
         extractor=default_extractor,
+        transformer=default_transformer,
     )
 
     # Act
@@ -145,7 +208,7 @@ def test_pipeline_dry_run(
     assert "validate" in stage_names
     assert "write" not in stage_names
 
-    mock_output_writer.write_result.assert_not_called()
+    mock_loader.load.assert_not_called()
 
 
 @pytest.mark.unit
@@ -153,10 +216,11 @@ def test_pipeline_hooks(
     mock_config,
     mock_logger,
     mock_validation_service,
-    mock_output_writer,
+    mock_loader,
     mock_metadata_builder,
     hash_service,
     default_extractor,
+    default_transformer,
 ):
     """Test that hooks are called correctly."""
     # Arrange
@@ -164,10 +228,11 @@ def test_pipeline_hooks(
         mock_config,
         mock_logger,
         mock_validation_service,
-        mock_output_writer,
-        hash_service,
+        loader=mock_loader,
+        hash_service=hash_service,
         metadata_builder=mock_metadata_builder,
         extractor=default_extractor,
+        transformer=default_transformer,
     )
     mock_hook = MagicMock(spec=PipelineHookABC)
     pipeline.register_hook(mock_hook)
@@ -189,10 +254,11 @@ def test_pipeline_error_hooks(
     mock_config,
     mock_logger,
     mock_validation_service,
-    mock_output_writer,
+    mock_loader,
     mock_metadata_builder,
     hash_service,
     default_extractor,
+    default_transformer,
 ):
     """Test that error hooks are called on failure."""
     # Arrange
@@ -200,10 +266,11 @@ def test_pipeline_error_hooks(
         mock_config,
         mock_logger,
         mock_validation_service,
-        mock_output_writer,
-        hash_service,
+        loader=mock_loader,
+        hash_service=hash_service,
         metadata_builder=mock_metadata_builder,
         extractor=default_extractor,
+        transformer=default_transformer,
     )
     mock_hook = MagicMock(spec=PipelineHookABC)
     pipeline.register_hook(mock_hook)
@@ -234,11 +301,12 @@ def test_error_policy_skip_stage(
     mock_config,
     mock_logger,
     mock_validation_service,
-    mock_output_writer,
+    mock_loader,
     mock_metadata_builder,
     tmp_path,
     hash_service,
     default_extractor,
+    default_transformer,
 ):
     """Пайплайн продолжает работу при политике SKIP."""
 
@@ -246,11 +314,12 @@ def test_error_policy_skip_stage(
         config=mock_config,
         logger=mock_logger,
         validation_service=mock_validation_service,
-        output_writer=mock_output_writer,
+        loader=mock_loader,
         error_policy=ContinueOnErrorPolicyImpl(),
         hash_service=hash_service,
         metadata_builder=mock_metadata_builder,
         extractor=default_extractor,
+        transformer=default_transformer,
     )
     pipeline._extractor.extract = MagicMock(side_effect=ValueError("boom"))
 
@@ -265,11 +334,12 @@ def test_error_policy_retry(
     mock_config,
     mock_logger,
     mock_validation_service,
-    mock_output_writer,
+    mock_loader,
     mock_metadata_builder,
     tmp_path,
     hash_service,
     default_extractor,
+    default_transformer,
 ):
     """Пайплайн повторяет стадию при политике RETRY."""
 
@@ -277,11 +347,12 @@ def test_error_policy_retry(
         config=mock_config,
         logger=mock_logger,
         validation_service=mock_validation_service,
-        output_writer=mock_output_writer,
+        loader=mock_loader,
         error_policy=ContinueOnErrorPolicyImpl(max_retries=1),
         hash_service=hash_service,
         metadata_builder=mock_metadata_builder,
         extractor=default_extractor,
+        transformer=default_transformer,
     )
 
     pipeline._extractor.extract = MagicMock(
@@ -302,21 +373,23 @@ def test_error_policy_retry_callback_and_skip(
     mock_config,
     mock_logger,
     mock_validation_service,
-    mock_output_writer,
+    mock_loader,
     mock_metadata_builder,
     hash_service,
     default_extractor,
+    default_transformer,
 ):
     """Политика RETRY вызывает on_retry и пропускает стадию после лимита."""
     pipeline = ConcretePipeline(
         config=mock_config,
         logger=mock_logger,
         validation_service=mock_validation_service,
-        output_writer=mock_output_writer,
+        loader=mock_loader,
         error_policy=ContinueOnErrorPolicyImpl(max_retries=1),
         hash_service=hash_service,
         metadata_builder=mock_metadata_builder,
         extractor=default_extractor,
+        transformer=default_transformer,
     )
 
     attempts = {"count": 0}
@@ -352,22 +425,24 @@ def test_error_policy_failfast_raises(
     mock_config,
     mock_logger,
     mock_validation_service,
-    mock_output_writer,
+    mock_loader,
     mock_metadata_builder,
     tmp_path,
     hash_service,
     default_extractor,
+    default_transformer,
 ):
     """FailFast останавливает пайплайн при первой ошибке."""
     pipeline = ConcretePipeline(
         config=mock_config,
         logger=mock_logger,
         validation_service=mock_validation_service,
-        output_writer=mock_output_writer,
+        loader=mock_loader,
         error_policy=FailFastErrorPolicyImpl(),
         hash_service=hash_service,
         metadata_builder=mock_metadata_builder,
         extractor=default_extractor,
+        transformer=default_transformer,
     )
     pipeline._extractor.extract = MagicMock(side_effect=ValueError("boom"))
 
@@ -383,7 +458,7 @@ def test_hashing_logic(
     mock_config,
     mock_logger,
     mock_validation_service,
-    mock_output_writer,
+    mock_loader,
     hash_service,
 ):
     """Test different scenarios for business key hashing."""
@@ -391,7 +466,7 @@ def test_hashing_logic(
         mock_config,
         mock_logger,
         mock_validation_service,
-        mock_output_writer,
+        mock_loader,
     )
     transformer = HashColumnsTransformerImpl(hash_service, ["id"])
     df = pd.DataFrame({"id": [1], "val": ["x"]})
@@ -420,24 +495,21 @@ def test_pipeline_dry_run_metadata_and_stages(
     pipeline_test_config,
     mock_logger,
     mock_validation_service,
-    mock_output_writer,
+    mock_loader,
     mock_metadata_builder,
     small_pipeline_df,
     tmp_path,
     hash_service,
 ):
     """Dry-run returns accurate stage info and metadata."""
-    extractor = MagicMock()
-    extractor.extract.return_value = [small_pipeline_df.copy()]
     pipeline = DatasetPipeline(
         config=pipeline_test_config,
         logger=mock_logger,
         validation_service=mock_validation_service,
-        output_writer=mock_output_writer,
+        loader=mock_loader,
         hash_service=hash_service,
         metadata_builder=mock_metadata_builder,
         dataset=small_pipeline_df,
-        extractor=extractor,
     )
 
     result = pipeline.run(output_path=tmp_path, dry_run=True)
@@ -460,10 +532,11 @@ def test_post_transformer_factory_alignment(
     mock_config,
     mock_logger,
     mock_validation_service,
-    mock_output_writer,
+    mock_loader,
     mock_metadata_builder,
     hash_service,
     default_extractor,
+    default_transformer,
 ):
     """Container и PipelineBase собирают идентичную цепочку
     пост-трансформеров."""
@@ -472,10 +545,11 @@ def test_post_transformer_factory_alignment(
         config=mock_config,
         logger=mock_logger,
         validation_service=mock_validation_service,
-        output_writer=mock_output_writer,
+        loader=mock_loader,
         hash_service=hash_service,
         metadata_builder=mock_metadata_builder,
         extractor=default_extractor,
+        transformer=default_transformer,
     )
 
     factory_transformer = default_post_transformer(

--- a/tests/bioetl/interfaces/cli/test_cli.py
+++ b/tests/bioetl/interfaces/cli/test_cli.py
@@ -15,6 +15,7 @@ from typer.testing import CliRunner
 sys.modules.setdefault("tqdm", MagicMock())
 
 from bioetl.application.pipelines.base import PipelineBase  # noqa: E402
+from bioetl.application.pipelines.contracts import LoaderABC
 from bioetl.domain.configs import (  # noqa: E402
     ChemblSourceConfig,
     ClientConfig,
@@ -249,7 +250,7 @@ def test_run_dry_run_pipeline_metadata(
             config,
             logger,
             validation_service,
-            output_writer,
+            loader,
             hash_service: HashServiceABC,
             extraction_service=None,
         ):
@@ -257,11 +258,12 @@ def test_run_dry_run_pipeline_metadata(
                 config,
                 logger,
                 validation_service,
-                output_writer,
+                loader,
                 hash_service,
             )
             self._dataset = small_pipeline_df
             self.last_result = None
+            self._loader = loader
             created_instances.append(self)
 
         def extract(self, **_):
@@ -269,6 +271,9 @@ def test_run_dry_run_pipeline_metadata(
 
         def transform(self, df):
             return df.assign(cli_processed=True)
+
+        def write(self, df, output_path, context):
+            return self._loader.load(df, output_path, context)
 
         def run(self, *args, **kwargs):  # type: ignore[override]
             result = super().run(*args, **kwargs)
@@ -279,8 +284,8 @@ def test_run_dry_run_pipeline_metadata(
     logger.apply_bind.return_value = logger
     validation_service = MagicMock()
     validation_service.validate.side_effect = lambda df, **__: df
-    output_writer = MagicMock()
-    output_writer.write_result.return_value = MagicMock(
+    loader = MagicMock(spec=LoaderABC)
+    loader.load.return_value = MagicMock(
         row_count=len(small_pipeline_df),
         checksum="checksum",
         path=MagicMock(name="dummy.parquet"),
@@ -301,7 +306,7 @@ def test_run_dry_run_pipeline_metadata(
             config=pipeline_test_config,
             logger=logger,
             validation_service=validation_service,
-            output_writer=output_writer,
+            loader=loader,
             hash_service=hash_service,
         )
         return pipeline_instance

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,6 +147,16 @@ def mock_output_writer():
 
 
 @pytest.fixture
+def mock_loader(mock_output_writer):
+    """Create a mock loader compatible with LoaderABC."""
+    from bioetl.application.pipelines.contracts import LoaderABC
+
+    loader = MagicMock(spec=LoaderABC)
+    loader.load.side_effect = mock_output_writer.write_result
+    return loader
+
+
+@pytest.fixture
 def mock_metadata_builder():
     """Create a mock metadata builder compatible with RunMetadataBuilderProtocol."""
     return SimpleNamespace(


### PR DESCRIPTION
## Summary
- make PipelineBase stage methods abstract and route writing through loader adapters
- update Chembl pipeline construction and orchestrator wiring to resolve loaders from output writers
- refresh pipeline tests with stubbed stages and loader fixtures

## Testing
- pytest tests/bioetl/application/pipelines/test_pipeline_base.py -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69370b11ca8483248f95c7fcdeaf787d)