### PR TITLE
Refactor pipeline base write stage to use loader

### DIFF
--- a/src/bioetl/application/pipelines/base.py
+++ b/src/bioetl/application/pipelines/base.py
@@ -530,11 +530,10 @@ class PipelineBase(ABC):
         output_schema_name = self._schema_contract.get_output_schema()
         output_columns = self._validation_service.get_schema_columns(output_schema_name)
 
-        return self._output_writer.write_result(
+        return self._loader.load(
             df=df,
             output_path=output_path,
-            entity_name=self._config.entity_name,
-            run_context=context,
+            context=context,
             column_order=output_columns,
         )
 


### PR DESCRIPTION
## Summary
- delegate PipelineBase internal write helper to LoaderABC load method
- align write-stage handling with loader-based contract

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69370d4974c48324a42460b9fd5dfff5)