### PR TITLE
Refactor pipeline registry usage in CLI

### DIFF
--- a/src/bioetl/application/pipelines/registry.py
+++ b/src/bioetl/application/pipelines/registry.py
@@ -1,12 +1,16 @@
 """Registry of available pipeline implementations."""
 
+from __future__ import annotations
+
+from collections.abc import Callable
 from typing import Type
 
 from bioetl.application.pipelines.base import PipelineBase
 from bioetl.application.pipelines.chembl.base import ChemblPipelineBase
 
-# Registry mapping pipeline names to their implementation classes
-PIPELINE_REGISTRY: dict[str, Type[PipelineBase]] = {
+PipelineFactory = Callable[..., PipelineBase]
+
+_PIPELINE_REGISTRY: dict[str, PipelineFactory] = {
     "activity_chembl": ChemblPipelineBase,
     "assay_chembl": ChemblPipelineBase,
     "publication_chembl": ChemblPipelineBase,
@@ -15,18 +19,29 @@ PIPELINE_REGISTRY: dict[str, Type[PipelineBase]] = {
 }
 
 
-def get_pipeline_class(name: str) -> Type[PipelineBase]:
-    """
-    Returns the pipeline class for the given name.
+def get_pipeline_factory(name: str) -> PipelineFactory:
+    """Return factory callable for the given pipeline name."""
 
-    Args:
-        name: Pipeline name (e.g. 'activity_chembl')
-
-    Raises:
-        ValueError: If pipeline is not found.
-    """
-    if name not in PIPELINE_REGISTRY:
+    try:
+        return _PIPELINE_REGISTRY[name]
+    except KeyError as exc:
         raise ValueError(
-            f"Pipeline '{name}' not found. Available: {list(PIPELINE_REGISTRY.keys())}"
-        )
-    return PIPELINE_REGISTRY[name]
+            f"Pipeline '{name}' not found. Available: {list(_PIPELINE_REGISTRY.keys())}"
+        ) from exc
+
+
+def get_pipeline_class(name: str) -> Type[PipelineBase]:
+    """Return pipeline class for the given name when registered as a class."""
+
+    factory = get_pipeline_factory(name)
+    if isinstance(factory, type) and issubclass(factory, PipelineBase):
+        return factory
+    raise ValueError(
+        f"Pipeline '{name}' is registered with a non-class factory: {factory}"
+    )
+
+
+def get_registered_pipelines() -> dict[str, PipelineFactory]:
+    """Return a copy of the registered pipeline mapping."""
+
+    return dict(_PIPELINE_REGISTRY)

--- a/src/bioetl/interfaces/cli/app.py
+++ b/src/bioetl/interfaces/cli/app.py
@@ -16,7 +16,10 @@ import typer
 
 from bioetl.application.config.runtime import build_runtime_config
 from bioetl.application.orchestrator import PipelineOrchestrator
-from bioetl.application.pipelines.registry import PIPELINE_REGISTRY
+from bioetl.application.pipelines.registry import (
+    get_pipeline_factory,
+    get_registered_pipelines,
+)
 from bioetl.domain.configs import MetricsConfig
 from bioetl.domain.provider_registry import (
     InMemoryProviderRegistry,
@@ -73,8 +76,8 @@ def list_pipelines() -> None:
     table.add_column("Name", style="cyan")
     table.add_column("Class", style="green")
 
-    for name, cls in PIPELINE_REGISTRY.items():
-        table.add_row(name, cls.__name__)
+    for name, factory in get_registered_pipelines().items():
+        table.add_row(name, _get_pipeline_factory_name(factory))
 
     console.print(table)
 
@@ -171,6 +174,10 @@ def run(
     }
 
     try:
+        pipeline_factory = get_pipeline_factory(pipeline_name)
+        config_context["pipeline_factory"] = _get_pipeline_factory_name(
+            pipeline_factory
+        )
         base_dir = _get_config_base_dir()
         requested_config_path = config_path or _resolve_config_path(
             pipeline_name,
@@ -285,6 +292,10 @@ def run(
                 **config_context,
             )
             sys.exit(1)
+
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/red]")
+        sys.exit(1)
 
     except Exception:  # pragma: no cover - CLI safety
         elapsed = time.perf_counter() - start_time
@@ -418,6 +429,14 @@ def _collect_cli_overrides(
     if csv_options:
         overrides["csv_options"] = csv_options
     return overrides
+
+
+def _get_pipeline_factory_name(factory: Any) -> str:
+    """Return a human-readable name for a pipeline factory."""
+
+    if hasattr(factory, "__name__"):
+        return str(getattr(factory, "__name__"))
+    return factory.__class__.__name__
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation


### PR DESCRIPTION
## Summary
- centralize pipeline registry definitions under the application layer and add factory accessors
- update CLI commands to rely on application registry helpers and validate pipeline names
- add shared helper for displaying pipeline factory names when listing pipelines

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937ba0a8b6c8324b1db577697a2a942)