### PR TITLE
Add guard for legacy Chembl pipeline modules

### DIFF
--- a/tests/project_rules/test_no_legacy_chembl_pipelines.py
+++ b/tests/project_rules/test_no_legacy_chembl_pipelines.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+def test_legacy_chembl_pipeline_modules_absent() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    legacy_files = [
+        repo_root / "src/bioetl/pipelines/chembl/thin.py",
+        repo_root / "src/bioetl/pipelines/chembl/base.py",
+    ]
+
+    for path in legacy_files:
+        assert not path.exists(), f"Legacy module should be removed: {path}"
+
+    legacy_run_files = list(
+        (repo_root / "src/bioetl/pipelines/chembl").glob("**/run.py")
+    )
+    assert not legacy_run_files, "Legacy run.py modules should be removed"


### PR DESCRIPTION
## Summary
- add a project rule test to ensure legacy Chembl pipeline modules and run.py entries stay removed

## Testing
- pytest tests/project_rules/test_no_legacy_chembl_pipelines.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937ba16652c8324bea2054088ab9cb6)