### PR TITLE
Remove ChemblExtractionClientImpl alias

### DIFF
--- a/src/bioetl/infrastructure/clients/chembl/__init__.py
+++ b/src/bioetl/infrastructure/clients/chembl/__init__.py
@@ -4,6 +4,4 @@ from bioetl.infrastructure.clients.chembl.impl.chembl_extraction_service_impl im
     ChemblExtractionServiceImpl,
 )
 
-ChemblExtractionClientImpl = ChemblExtractionServiceImpl
-
-__all__ = ["ChemblExtractionServiceImpl", "ChemblExtractionClientImpl"]
+__all__ = ["ChemblExtractionServiceImpl"]


### PR DESCRIPTION
## Summary
- remove the ChemblExtractionClientImpl alias export in the ChEMBL client package to use the service implementation directly

## Testing
- pytest tests/bioetl/infrastructure/clients/chembl/test_factories.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937baee03c08324942b27f42c0b2151)