### PR TITLE
Refactor container factory resolution into application layer

### DIFF
--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -38,6 +38,14 @@ from bioetl.domain.transform.transformers import TransformerABC
 from bioetl.domain.validation import SchemaProviderABC, ValidatorFactoryABC
 from bioetl.domain.validation.contracts import ValidationResult
 from bioetl.domain.validation.service import ValidationService
+from bioetl.infrastructure.clients.base.abc_registry_resolver import (
+    ABCRegistryResolver,
+)
+from bioetl.infrastructure.observability import metrics
+from bioetl.infrastructure.output.metadata import (
+    build_dry_run_metadata,
+    build_run_metadata,
+)
 
 
 class PipelineContainer(PipelineContainerABC):
@@ -403,6 +411,99 @@ def _create_noop_validator_factory() -> ValidatorFactoryABC:
         ValidatorFactoryABC,
         SimpleNamespace(create_validator=lambda _schema: validator),
     )
+
+
+def _create_metadata_builder() -> RunMetadataBuilderProtocol:
+    """Return metadata builder port using infrastructure helpers."""
+
+    return SimpleNamespace(
+        build_run_metadata=build_run_metadata,
+        build_dry_run_metadata=build_dry_run_metadata,
+    )
+
+
+def _create_metrics_port() -> PipelineMetricsPortABC:
+    """Return metrics port backed by Prometheus collectors."""
+
+    return SimpleNamespace(
+        update_stage_duration=lambda **kwargs: metrics.STAGE_DURATION_SECONDS.labels(
+            pipeline=kwargs["pipeline"],
+            provider=kwargs["provider"],
+            entity=kwargs["entity"],
+            stage=kwargs["stage"],
+            outcome=kwargs["outcome"],
+        ).observe(kwargs["duration_sec"]),
+        update_stage_total=lambda **kwargs: metrics.STAGE_TOTAL.labels(
+            pipeline=kwargs["pipeline"],
+            provider=kwargs["provider"],
+            entity=kwargs["entity"],
+            stage=kwargs["stage"],
+            outcome=kwargs["outcome"],
+        ).inc(),
+    )
+
+
+def _create_validator_factory() -> ValidatorFactoryABC:
+    """Return validator factory backed by infrastructure implementation."""
+
+    loader = ABCRegistryResolver()
+    factory = loader.resolve_default_factory("ValidatorFactoryABC")
+    return factory()
+
+
+def build_default_container(
+    config: PipelineConfig,
+    *,
+    provider_registry: ProviderRegistryABC | None = None,
+    provider_registry_provider: Callable[[], ProviderRegistryABC] | None = None,
+) -> PipelineContainerABC:
+    """Construct application container with infrastructure defaults."""
+
+    registry_loader = ABCRegistryResolver()
+    logger_factory = registry_loader.resolve_default_factory("LoggingPortABC")
+    writer_factory = registry_loader.resolve_default_factory("WriterABC")
+    metadata_writer_factory = registry_loader.resolve_default_factory(
+        "MetadataWriterABC"
+    )
+    quality_reporter_factory = registry_loader.resolve_default_factory(
+        "QualityReportABC"
+    )
+    output_writer_factory = registry_loader.resolve_default_factory("OutputWriterABC")
+    hash_service_factory = registry_loader.resolve_default_factory("HashServiceABC")
+
+    logger = logger_factory()
+    writer = writer_factory()
+    metadata_writer = metadata_writer_factory()
+    quality_reporter = quality_reporter_factory()
+    output_writer = output_writer_factory(
+        config=config.determinism,
+        qc_config=config.qc,
+        writer=writer,
+        metadata_writer=metadata_writer,
+        quality_reporter=quality_reporter,
+    )
+    metadata_builder = _create_metadata_builder()
+    metrics_port = _create_metrics_port()
+    validator_factory = _create_validator_factory()
+    hash_service = hash_service_factory()
+
+    return build_pipeline_dependencies(
+        config,
+        logger=logger,
+        output_writer=output_writer,
+        validator_factory=validator_factory,
+        metadata_builder=metadata_builder,
+        metrics_port=metrics_port,
+        hash_service=hash_service,
+        provider_registry=provider_registry,
+        provider_registry_provider=provider_registry_provider,
+    )
+
+
+def create_default_container_factory() -> Callable[..., Any]:
+    """Expose default container factory."""
+
+    return build_default_container
 
 
 def build_pipeline_dependencies(

--- a/src/bioetl/application/orchestrator.py
+++ b/src/bioetl/application/orchestrator.py
@@ -163,9 +163,9 @@ class PipelineOrchestrator:
         if container_factory is not None:
             return container_factory
 
-        raise RuntimeError(
-            "Container factory is required. Supply Callable[..., PipelineContainerABC]."
-        )
+        from bioetl.application.container import create_default_container_factory
+
+        return create_default_container_factory()
 
     def _get_provider_registry(self) -> ProviderRegistryABC:
         if self._provider_registry is not None:

--- a/src/bioetl/interfaces/cli/app.py
+++ b/src/bioetl/interfaces/cli/app.py
@@ -34,10 +34,7 @@ from bioetl.infrastructure.observability.server import (
     start_metrics_server_once,
 )
 from bioetl.interfaces.observability import LoggingPortABC
-from bioetl.interfaces.wiring import (
-    create_config_loader,
-    create_container_factory,
-)
+from bioetl.interfaces.wiring import create_config_loader
 
 app = typer.Typer(
     name="bioetl",
@@ -157,7 +154,6 @@ def run(
     """Run an ETL pipeline for the given name and profile."""
 
     config_loader = create_config_loader()
-    container_factory = create_container_factory()
     bound_logger = logger.apply_bind(
         pipeline_name=pipeline_name,
         profile=profile,
@@ -244,7 +240,6 @@ def run(
             provider_registry=provider_registry,
             provider_loader=provider_loader,
             provider_loader_factory=provider_loader_factory,
-            container_factory=container_factory,
         )
 
         console.print(

--- a/src/bioetl/interfaces/rest/server.py
+++ b/src/bioetl/interfaces/rest/server.py
@@ -21,10 +21,7 @@ from bioetl.domain.provider_registry import (
 from bioetl.infrastructure.clients.provider_registry_loader import (
     create_provider_loader,
 )
-from bioetl.interfaces.wiring import (
-    create_config_loader,
-    create_container_factory,
-)
+from bioetl.interfaces.wiring import create_config_loader
 
 
 class PipelineRunRequest(BaseModel):
@@ -83,14 +80,12 @@ def _create_orchestrator(pipeline_name: str, profile: str) -> PipelineOrchestrat
     except FileNotFoundError:
         provider_registry = InMemoryProviderRegistry()
         provider_loader_factory = None
-    container_factory = create_container_factory()
     return PipelineOrchestrator(
         pipeline_name=pipeline_name,
         config=config,
         provider_registry=provider_registry,
         provider_loader=provider_loader,
         provider_loader_factory=provider_loader_factory,
-        container_factory=container_factory,
     )
 
 

--- a/src/bioetl/interfaces/wiring.py
+++ b/src/bioetl/interfaces/wiring.py
@@ -5,26 +5,16 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any, Callable
 
-from bioetl.application.container import build_pipeline_dependencies
-from bioetl.application.pipelines.contracts import PipelineContainerABC
-from bioetl.domain.clients.base.output.contracts import RunMetadataBuilderProtocol
+from bioetl.application.container import (
+    build_default_container as application_build_default_container,
+    create_default_container_factory,
+)
 from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.configs.contracts import PipelineConfigLoaderProtocol
-from bioetl.domain.provider_registry import ProviderRegistryABC
-from bioetl.domain.validation import ValidatorFactoryABC
-from bioetl.infrastructure.clients.base.abc_registry_resolver import (
-    ABCRegistryResolver,
-)
 from bioetl.infrastructure.config.loader import (
     get_pipeline_config,
     get_pipeline_config_from_path,
 )
-from bioetl.infrastructure.observability import metrics
-from bioetl.infrastructure.output.metadata import (
-    build_dry_run_metadata,
-    build_run_metadata,
-)
-from bioetl.interfaces.observability import PipelineMetricsPortABC
 
 
 def create_config_loader() -> PipelineConfigLoaderProtocol:
@@ -36,88 +26,16 @@ def create_config_loader() -> PipelineConfigLoaderProtocol:
     )
 
 
-def _create_metadata_builder() -> RunMetadataBuilderProtocol:
-    """Return metadata builder port using infrastructure helpers."""
-
-    return SimpleNamespace(
-        build_run_metadata=build_run_metadata,
-        build_dry_run_metadata=build_dry_run_metadata,
-    )
-
-
-def _create_metrics_port() -> PipelineMetricsPortABC:
-    """Return metrics port backed by Prometheus collectors."""
-
-    return SimpleNamespace(
-        update_stage_duration=lambda **kwargs: metrics.STAGE_DURATION_SECONDS.labels(
-            pipeline=kwargs["pipeline"],
-            provider=kwargs["provider"],
-            entity=kwargs["entity"],
-            stage=kwargs["stage"],
-            outcome=kwargs["outcome"],
-        ).observe(kwargs["duration_sec"]),
-        update_stage_total=lambda **kwargs: metrics.STAGE_TOTAL.labels(
-            pipeline=kwargs["pipeline"],
-            provider=kwargs["provider"],
-            entity=kwargs["entity"],
-            stage=kwargs["stage"],
-            outcome=kwargs["outcome"],
-        ).inc(),
-    )
-
-
-def _create_validator_factory() -> ValidatorFactoryABC:
-    """Return validator factory backed by infrastructure implementation."""
-
-    loader = ABCRegistryResolver()
-    factory = loader.resolve_default_factory("ValidatorFactoryABC")
-    return factory()
-
-
 def build_default_container(
     config: PipelineConfig,
     *,
-    provider_registry: ProviderRegistryABC | None = None,
-    provider_registry_provider: Callable[[], ProviderRegistryABC] | None = None,
-) -> PipelineContainerABC:
-    """Construct application container with infrastructure defaults."""
+    provider_registry: Any | None = None,
+    provider_registry_provider: Callable[[], Any] | None = None,
+) -> Any:
+    """Proxy to application-level default container factory."""
 
-    registry_loader = ABCRegistryResolver()
-    logger_factory = registry_loader.resolve_default_factory("LoggingPortABC")
-    writer_factory = registry_loader.resolve_default_factory("WriterABC")
-    metadata_writer_factory = registry_loader.resolve_default_factory(
-        "MetadataWriterABC"
-    )
-    quality_reporter_factory = registry_loader.resolve_default_factory(
-        "QualityReportABC"
-    )
-    output_writer_factory = registry_loader.resolve_default_factory("OutputWriterABC")
-    hash_service_factory = registry_loader.resolve_default_factory("HashServiceABC")
-
-    logger = logger_factory()
-    writer = writer_factory()
-    metadata_writer = metadata_writer_factory()
-    quality_reporter = quality_reporter_factory()
-    output_writer = output_writer_factory(
-        config=config.determinism,
-        qc_config=config.qc,
-        writer=writer,
-        metadata_writer=metadata_writer,
-        quality_reporter=quality_reporter,
-    )
-    metadata_builder = _create_metadata_builder()
-    metrics_port = _create_metrics_port()
-    validator_factory = _create_validator_factory()
-    hash_service = hash_service_factory()
-
-    return build_pipeline_dependencies(
+    return application_build_default_container(
         config,
-        logger=logger,
-        output_writer=output_writer,
-        validator_factory=validator_factory,
-        metadata_builder=metadata_builder,
-        metrics_port=metrics_port,
-        hash_service=hash_service,
         provider_registry=provider_registry,
         provider_registry_provider=provider_registry_provider,
     )
@@ -126,7 +44,7 @@ def build_default_container(
 def create_container_factory() -> Callable[..., Any]:
     """Expose default container factory."""
 
-    return build_default_container
+    return create_default_container_factory()
 
 
 __all__ = [

--- a/tests/integration/test_background_run.py
+++ b/tests/integration/test_background_run.py
@@ -10,7 +10,7 @@ from bioetl.application.orchestrator import PipelineOrchestrator
 from bioetl.infrastructure.clients.provider_registry_loader import (
     create_provider_loader,
 )
-from bioetl.interfaces.wiring import create_config_loader, create_container_factory
+from bioetl.interfaces.wiring import create_config_loader
 
 
 def _build_config(tmp_path: Path) -> tuple[Path, dict[str, str], Path]:
@@ -39,14 +39,12 @@ def test_run_in_background_with_loader(tmp_path: Path) -> None:
 
     provider_loader_factory = partial(create_provider_loader)
     provider_loader = provider_loader_factory()
-    container_factory = create_container_factory()
     orchestrator = PipelineOrchestrator(
         "activity_chembl",
         config_copy,
         provider_registry=None,
         provider_loader=provider_loader,
         provider_loader_factory=provider_loader_factory,
-        container_factory=container_factory,
     )
 
     future = orchestrator.run_in_background(dry_run=True, limit=5)
@@ -70,14 +68,12 @@ def test_run_in_background_with_preloaded_registry(tmp_path: Path) -> None:
     )
 
     registry = create_provider_loader().get_registry()
-    container_factory = create_container_factory()
     orchestrator = PipelineOrchestrator(
         "activity_chembl",
         config_copy,
         provider_registry=registry,
         provider_loader=None,
         provider_loader_factory=None,
-        container_factory=container_factory,
     )
 
     future = orchestrator.run_in_background(dry_run=True, limit=5)

--- a/tests/test_pipeline_outputs.py
+++ b/tests/test_pipeline_outputs.py
@@ -17,7 +17,7 @@ from bioetl.domain.models import RunResult
 from bioetl.infrastructure.clients.provider_registry_loader import (
     create_provider_loader,
 )
-from bioetl.interfaces.wiring import create_config_loader, create_container_factory
+from bioetl.interfaces.wiring import create_config_loader
 
 _PIPELINE_CASES = [
     (
@@ -114,14 +114,12 @@ def test_pipeline_outputs(
     provider_loader = provider_loader_factory()
     provider_registry = None
 
-    container_factory = create_container_factory()
     orchestrator = PipelineOrchestrator(
         pipeline_name,
         config,
         provider_registry=provider_registry,
         provider_loader=provider_loader,
         provider_loader_factory=provider_loader_factory,
-        container_factory=container_factory,
     )
     golden = importlib.import_module(golden_module)
     expected_df = pd.DataFrame(getattr(golden, expected_attr))


### PR DESCRIPTION
## Summary
- Move default pipeline container wiring into the application container module
- Allow orchestrator to resolve the default container factory internally and simplify CLI/REST usage
- Update tests and helpers to rely on the new application-level container factory

## Testing
- python -m pytest tests/integration/test_background_run.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937bed1dff883248cb75a328bf6fa25)