### PR TITLE
Refactor normalization services to reuse base helpers

### DIFF
--- a/src/bioetl/infrastructure/transform/impl/chembl_normalization_service_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/chembl_normalization_service_impl.py
@@ -11,17 +11,9 @@ from bioetl.domain.transform.contracts import (
     NormalizationConfigProviderProtocol,
     NormalizationServiceABC,
 )
-from bioetl.domain.transform.normalizers import (
-    normalize_array,
-    normalize_record,
-)
 from bioetl.infrastructure.transform.impl import normalize as normalize_impl
 from bioetl.infrastructure.transform.impl.base_normalizer import (
     BaseNormalizationServiceImpl,
-)
-from bioetl.infrastructure.transform.impl.serializer import (
-    serialize_dict,
-    serialize_list,
 )
 
 
@@ -43,7 +35,7 @@ class ChemblNormalizationServiceImpl(
         """Normalize single raw ChEMBL record into flat dict."""
         normalized: dict[str, Any] = {}
 
-        for field_cfg in self._config.get_fields():
+        for field_cfg in self._iter_fields():
             name = field_cfg.get("name")
             if not isinstance(name, str) or name not in raw:
                 continue
@@ -81,7 +73,7 @@ class ChemblNormalizationServiceImpl(
         """Normalize configured fields across dataframe columns."""
         normalized_df = df.copy()
 
-        for field_cfg in self._config.get_fields():
+        for field_cfg in self._iter_fields():
             name = field_cfg.get("name")
             if not name or name not in normalized_df.columns:
                 continue
@@ -130,54 +122,3 @@ class ChemblNormalizationServiceImpl(
             )
 
         return cast(pd.Series, series.apply(_normalize_value_from_series))
-
-    def _process_list(
-        self,
-        value: Any,
-        normalizer: Any,
-        field_name: str,
-        *,
-        serialize_with_value_normalizer: bool = True,
-    ) -> Any:
-        """Normalize list container and serialize deterministically."""
-        try:
-            normalized_list = normalize_array(
-                value,
-                item_normalizer=lambda item: self._normalize_container_item(
-                    item, normalizer
-                ),
-            )
-        except ValueError as exc:
-            raise ValueError(
-                f"Ошибка нормализации списка в поле '{field_name}': {exc}"
-            ) from exc
-
-        if not normalized_list:
-            return None
-        return serialize_list(
-            normalized_list,
-            value_normalizer=normalizer if serialize_with_value_normalizer else None,
-        )
-
-    def _process_dict(self, value: Any, normalizer: Any, field_name: str) -> Any:
-        """Normalize mapping container and serialize deterministically."""
-        try:
-            dict_value = cast(dict[str, Any], value)
-            normalized_dict = normalize_record(dict_value, value_normalizer=normalizer)
-        except ValueError as exc:
-            raise ValueError(
-                f"Ошибка нормализации записи в поле '{field_name}': {exc}"
-            ) from exc
-
-        if normalized_dict is None:
-            return None
-        return serialize_dict(dict(normalized_dict))
-
-    def _normalize_container_item(self, item: Any, normalizer: Any) -> Any:
-        """Normalize individual item inside container preserving type rules."""
-        if isinstance(item, dict):
-            normalized_dict = normalize_record(
-                cast(dict[str, Any], item), value_normalizer=normalizer
-            )
-            return normalized_dict if normalized_dict is not None else {}
-        return normalizer(item)

--- a/src/bioetl/infrastructure/transform/impl/normalization_service_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/normalization_service_impl.py
@@ -8,15 +8,11 @@ from bioetl.domain.transform.contracts import (
     NormalizationConfigProviderProtocol,
     NormalizationServiceABC,
 )
-from bioetl.domain.transform.normalizers import normalize_array, normalize_record
 from bioetl.infrastructure.transform.impl import normalize
 from bioetl.infrastructure.transform.impl.base_normalizer import (
     BaseNormalizationServiceImpl,
 )
-from bioetl.infrastructure.transform.impl.serializer import (
-    serialize_dict,
-    serialize_list,
-)
+from bioetl.infrastructure.transform.impl.serializer import serialize_list
 
 
 class NormalizationServiceImpl(NormalizationServiceABC, BaseNormalizationServiceImpl):
@@ -29,16 +25,6 @@ class NormalizationServiceImpl(NormalizationServiceABC, BaseNormalizationService
 
     def __init__(self, config: NormalizationConfigProviderProtocol):
         BaseNormalizationServiceImpl.__init__(self, config, empty_value=pd.NA)
-
-    def _iter_fields(self) -> list[dict[str, Any]]:
-        """Safely iterate over field configs from various config shapes."""
-
-        if hasattr(self._config, "get_fields"):
-            fields = cast(list[dict[str, Any]], self._config.get_fields())
-            return fields
-        if hasattr(self._config, "fields"):
-            return list(cast(list[dict[str, Any]], self._config.fields))
-        raise AttributeError("Normalization config must expose fields")
 
     def apply_normalize_fields(self, df: pd.DataFrame) -> pd.DataFrame:
         """Проходит по полям конфигурации и применяет нормализацию."""
@@ -183,56 +169,6 @@ class NormalizationServiceImpl(NormalizationServiceABC, BaseNormalizationService
             )
 
         return cast(pd.Series, series.apply(_normalize_value_from_series))
-
-    def _normalize_container_item(
-        self, item: Any, normalizer: Callable[[Any], Any]
-    ) -> Any:
-        """Normalize nested container items preserving structure."""
-        if isinstance(item, dict):
-            normalized_dict = normalize_record(item, value_normalizer=normalizer)
-            return normalized_dict if normalized_dict is not None else {}
-        return normalizer(item)
-
-    def _process_list(
-        self,
-        val: Any,
-        norm: Callable[[Any], Any],
-        field_name: str,
-        *,
-        serialize_with_value_normalizer: bool = False,
-    ) -> Any:
-        """Normalize list values and serialize deterministically."""
-        try:
-
-            def _smart_normalizer(item: Any) -> Any:
-                return self._normalize_container_item(item, norm)
-
-            normalized_list = normalize_array(
-                list(val), item_normalizer=_smart_normalizer
-            )
-        except ValueError as exc:
-            raise ValueError(
-                f"Ошибка нормализации списка в поле '{field_name}': {exc}"
-            ) from exc
-        if not normalized_list:
-            return pd.NA
-        return serialize_list(
-            normalized_list,
-            value_normalizer=norm if serialize_with_value_normalizer else None,
-        )
-
-    def _process_dict(
-        self, val: Any, norm: Callable[[Any], Any], field_name: str
-    ) -> Any:
-        try:
-            normalized_dict = normalize_record(val, value_normalizer=norm)
-        except ValueError as exc:
-            raise ValueError(
-                f"Ошибка нормализации записи в поле '{field_name}': {exc}"
-            ) from exc
-        if normalized_dict is None:
-            return pd.NA
-        return serialize_dict(normalized_dict)
 
 
 __all__ = ["NormalizationServiceImpl"]


### PR DESCRIPTION
## Summary
- remove duplicated container normalization logic from both service implementations
- rely on BaseNormalizationServiceImpl for shared field iteration and serialization helpers

## Testing
- pytest tests/bioetl/domain/test_normalization_service.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937ddaff1c883248a0ae3037fff0861)