### PR TITLE
Refine Chembl client logging with unified logger

### DIFF
--- a/src/bioetl/infrastructure/clients/base/factories.py
+++ b/src/bioetl/infrastructure/clients/base/factories.py
@@ -13,6 +13,7 @@ from bioetl.domain.clients.base.contracts import (
     SecretProviderABC,
     SideInputProviderABC,
 )
+from bioetl.domain.observability import LoggingPortABC
 from bioetl.domain.configs import ClientConfig, HTTP_CLIENT_DEFAULTS, HttpClientDefaults
 from bioetl.infrastructure.clients.base.impl.cache import MemoryCacheImpl
 from bioetl.infrastructure.clients.base.impl.rate_limiter import (
@@ -79,6 +80,7 @@ def build_rate_limiter(
     *,
     client_config: ClientConfig | None = None,
     defaults: HttpClientDefaults | None = None,
+    logger: LoggingPortABC | None = None,
 ) -> RateLimiterABC:
     """Create a rate limiter using unified HTTP defaults."""
 
@@ -87,17 +89,21 @@ def build_rate_limiter(
     )
     rate = resolved_defaults.rate_limit
     capacity = max(1.0, rate)
-    return TokenBucketRateLimiterImpl(rate, capacity)
+    return TokenBucketRateLimiterImpl(rate, capacity, logger=logger)
 
 
 def default_rate_limiter(
     rate: float = HTTP_CLIENT_DEFAULTS.rate_limit,
     capacity: float | None = None,
+    *,
+    logger: LoggingPortABC | None = None,
 ) -> RateLimiterABC:
     """Create the default rate limiter with token bucket semantics."""
 
     resolved_capacity = capacity if capacity is not None else max(1.0, rate)
-    return TokenBucketRateLimiterImpl(rate, resolved_capacity)
+    return TokenBucketRateLimiterImpl(
+        rate, resolved_capacity, logger=logger
+    )
 
 
 def default_cache() -> CacheABC[Any]:
@@ -137,11 +143,20 @@ def default_paginator() -> PaginatorABC:
 
 
 def default_api_client(
-    provider: str, config: ClientConfig, *, base_client: Any | None = None
+    provider: str,
+    config: ClientConfig,
+    *,
+    base_client: Any | None = None,
+    logger: LoggingPortABC | None = None,
 ) -> ApiClientABC:
     """Create the default API client without middleware indirection."""
 
-    return build_http_client(provider, client_config=config, base_client=base_client)
+    return build_http_client(
+        provider,
+        client_config=config,
+        base_client=base_client,
+        logger=logger,
+    )
 
 
 def build_http_client(
@@ -150,6 +165,7 @@ def build_http_client(
     client_config: ClientConfig | None = None,
     defaults: HttpClientDefaults | None = None,
     base_client: Any | None = None,
+    logger: LoggingPortABC | None = None,
 ) -> ApiClientABC:
     """Construct HTTP client using centralized defaults."""
 
@@ -157,7 +173,10 @@ def build_http_client(
         client_config=client_config, defaults=defaults
     )
     return UnifiedAPIClientImpl(
-        provider=provider, config=resolved_config, base_client=base_client
+        provider=provider,
+        config=resolved_config,
+        base_client=base_client,
+        logger=logger,
     )
 
 

--- a/src/bioetl/infrastructure/clients/base/impl/rate_limiter.py
+++ b/src/bioetl/infrastructure/clients/base/impl/rate_limiter.py
@@ -4,6 +4,8 @@ from threading import Lock
 import time
 
 from bioetl.domain.clients.base.contracts import RateLimiterABC
+from bioetl.domain.observability import LoggingPortABC
+from bioetl.infrastructure.observability.factories import default_logging_port
 
 
 class TokenBucketRateLimiterImpl(RateLimiterABC):
@@ -11,12 +13,18 @@ class TokenBucketRateLimiterImpl(RateLimiterABC):
     Реализация алгоритма Token Bucket.
     """
 
-    def __init__(self, rate: float, capacity: float) -> None:
+    def __init__(
+        self, rate: float, capacity: float, *, logger: LoggingPortABC | None = None
+    ) -> None:
         self._rate = rate  # tokens per second
         self._capacity = capacity
         self._tokens = capacity
         self._last_refill = time.monotonic()
         self._lock = Lock()
+        self._logger = logger or default_logging_port()
+        self._logger.info(
+            "rate_limiter_initialized", rate=rate, capacity=capacity
+        )
 
     @property
     def rate(self) -> float:

--- a/src/bioetl/infrastructure/clients/base/impl/unified_api_client_impl.py
+++ b/src/bioetl/infrastructure/clients/base/impl/unified_api_client_impl.py
@@ -4,6 +4,7 @@ Unified HTTP Client implementation.
 
 from __future__ import annotations
 
+import time
 from typing import Any
 from uuid import uuid4
 
@@ -11,6 +12,8 @@ import requests
 
 from bioetl.domain.configs import ClientConfig
 from bioetl.domain.clients.base.contracts import ApiClientABC
+from bioetl.domain.observability import LoggingPortABC
+from bioetl.infrastructure.observability.factories import default_logging_port
 
 
 class UnifiedAPIClientImpl(ApiClientABC):
@@ -24,10 +27,21 @@ class UnifiedAPIClientImpl(ApiClientABC):
         provider: str,
         config: ClientConfig,
         base_client: Any | None = None,
+        *,
+        logger: LoggingPortABC | None = None,
     ) -> None:
         self.provider = provider
         self.config = config
         self.base_client = base_client or requests.Session()
+        self.logger = logger or default_logging_port()
+        self.logger.info(
+            "http_client_initialized",
+            provider=self.provider,
+            timeout_sec=self.config.timeout_sec,
+            max_retries=self.config.max_retries,
+            backoff_factor=self.config.backoff_factor,
+            rate_limit_per_sec=self.config.rate_limit_per_sec,
+        )
 
     def request_call(self, method: str, url: str, **kwargs: Any) -> Any:
         """Выполнить HTTP-запрос с настройками клиента."""
@@ -38,7 +52,20 @@ class UnifiedAPIClientImpl(ApiClientABC):
             kwargs["headers"] = headers
 
         timeout = kwargs.pop("timeout", self.config.timeout_sec)
-        return self.base_client.request(method=method, url=url, timeout=timeout, **kwargs)
+        start = time.monotonic()
+        response = self.base_client.request(
+            method=method, url=url, timeout=timeout, **kwargs
+        )
+        latency = time.monotonic() - start
+        self.logger.info(
+            "http_request_completed",
+            provider=self.provider,
+            method=method_upper,
+            url=url,
+            status_code=getattr(response, "status_code", None),
+            latency_sec=latency,
+        )
+        return response
 
     def request(self, method: str, url: str, **kwargs: Any) -> Any:
         """Execute a request using the configured HTTP client."""

--- a/src/bioetl/infrastructure/clients/chembl/factories.py
+++ b/src/bioetl/infrastructure/clients/chembl/factories.py
@@ -45,9 +45,12 @@ def default_chembl_client(
         client_config = source_config.client.model_copy(deep=True)
 
     # Create Unified Client
+    logger: LoggingPortABC | None = options.get("logger")
+
     unified_client = build_http_client(
         provider="chembl",
         client_config=client_config,
+        logger=logger,
     )
 
     # Allow explicit overrides via kwargs (used in tests and manual runs)
@@ -56,7 +59,9 @@ def default_chembl_client(
 
     # Rate limiter for proactive limiting (in addition to middleware backoff)
     # Using explicit rate limiter in client logic
-    rate_limiter = build_rate_limiter(client_config=client_config)
+    rate_limiter = build_rate_limiter(
+        client_config=client_config, logger=logger
+    )
 
     return ChemblApiPortImpl(
         request_builder=ChemblRequestBuilderImpl(
@@ -67,6 +72,7 @@ def default_chembl_client(
         rate_limiter=rate_limiter,
         client=unified_client,
         provider="chembl",
+        logger=logger,
     )
 
 
@@ -90,7 +96,9 @@ def default_chembl_extraction_service(
         Сервис экстракции.
     """
     if client is None:
-        client = default_chembl_client(config, client_config=client_config)
+        client = default_chembl_client(
+            config, client_config=client_config, logger=logger
+        )
 
     return ChemblExtractionServiceImpl(
         client=client,

--- a/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
@@ -10,6 +10,7 @@ from bioetl.domain.clients.contracts import DataClientABC
 from bioetl.domain.observability.contracts import LoggingPortABC
 from bioetl.domain.ports.extraction import ExtractionServiceABC
 from bioetl.domain.ports.providers import DefaultFieldProviderABC
+from bioetl.infrastructure.observability.factories import default_logging_port
 
 if TYPE_CHECKING:
     from bioetl.domain.record_source import RawRecord
@@ -30,7 +31,7 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC):
     ) -> None:
         self.client = client
         self.batch_size = batch_size
-        self.logger = logger
+        self.logger = logger or default_logging_port()
         self.field_provider = field_provider
         self._version_cache: str | None = None
 

--- a/src/bioetl/infrastructure/clients/chembl/impl/http_client.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/http_client.py
@@ -4,6 +4,7 @@ HTTP implementation of ChEMBL API port.
 
 from __future__ import annotations
 
+import time
 from types import SimpleNamespace
 from typing import Any, Iterator
 
@@ -15,7 +16,9 @@ from bioetl.domain.clients.base.contracts import (
 )
 from bioetl.domain.clients.contracts import DataClientABC
 from bioetl.domain.errors import ClientResponseError
+from bioetl.domain.observability import LoggingPortABC
 from bioetl.infrastructure.clients.chembl.paginator import ChemblPaginatorImpl
+from bioetl.infrastructure.observability.factories import default_logging_port
 
 
 class ChemblApiPortImpl(DataClientABC):
@@ -32,11 +35,13 @@ class ChemblApiPortImpl(DataClientABC):
         client: ApiClientABC | None = None,
         *,
         provider: str = "chembl",
+        logger: LoggingPortABC | None = None,
     ) -> None:
         self.request_builder = request_builder
         self.response_parser = response_parser
         self.rate_limiter = rate_limiter
         self.client = client
+        self.logger = logger or default_logging_port()
         if client is not None:
             self.http = client
         else:
@@ -88,10 +93,29 @@ class ChemblApiPortImpl(DataClientABC):
         return self._execute_request(url)
 
     def _execute_request(self, url: str) -> dict[str, Any]:
+        start = time.monotonic()
         response = self.http.request("GET", url)
+        latency = time.monotonic() - start
+        status_code = getattr(response, "status_code", None)
+        log_level = self.logger.error if status_code and status_code >= 400 else self.logger.info
+        log_level(
+            "http_request_completed",
+            provider=self.provider,
+            method="GET",
+            url=url,
+            status_code=status_code,
+            latency_sec=latency,
+        )
         try:
             return response.json()
         except ValueError as exc:
+            self.logger.error(
+                "response_deserialization_failed",
+                provider=self.provider,
+                url=url,
+                status_code=status_code,
+                error=str(exc),
+            )
             raise ClientResponseError(
                 provider=self.provider,
                 endpoint=url,


### PR DESCRIPTION
## Summary
- add unified logger support to HTTP client, rate limiter, and Chembl client stack with initialization logs
- record HTTP request status and latency plus JSON parsing errors through structured logging
- propagate default logger through factories and extraction service construction

## Testing
- pytest tests/bioetl/infrastructure/clients/chembl/test_factories.py tests/bioetl/infrastructure/clients/base/test_rate_limiter.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937f0a7e89c8324aac3df827ab47bb6)