### PR TITLE
Align infrastructure naming for ChEMBL client and normalization transformer

### DIFF
--- a/docs/01-ABC/INDEX.md
+++ b/docs/01-ABC/INDEX.md
@@ -2,7 +2,7 @@
 <!-- generated -->
 
 - `NormalizationServiceABC` — `bioetl.domain.transform.contracts.NormalizationServiceABC`
-  - Normalization service contract for DataFrame/record pipelines. Default factory: `bioetl.infrastructure.transform.factories.default_normalization_service`. Implementations: `NormalizationServiceImpl`, `ChemblNormalizationServiceImpl`.
+  - Normalization service contract for DataFrame/record pipelines. Default factory: `bioetl.infrastructure.transform.factories.default_normalization_service`. Implementations: `DefaultNormalizationTransformerImpl`, `ChemblNormalizationServiceImpl`.
 - `HashServiceABC` — `bioetl.domain.transform.contracts.HashServiceABC`
   - Facade for deterministic hash columns; default factory: `bioetl.infrastructure.transform.factories.default_hash_service`. Implementation: `bioetl.domain.transform.hash_service.HashService`.
 - `ProviderRegistryABC` — `bioetl.domain.provider_registry.ProviderRegistryABC`

--- a/docs/02-pipelines/01-pipeline-core-normalization.md
+++ b/docs/02-pipelines/01-pipeline-core-normalization.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Normalization is driven by `NormalizationServiceABC` (`bioetl.domain.transform.contracts`) backed by provider-specific services. The base factory `bioetl.infrastructure.transform.factories.default_normalization_service` wires the contract using the shared `NormalizationServiceImpl`, while ChEMBL-specific runs can switch to `ChemblNormalizationServiceImpl` when registered via `abc_impls.yaml`.
+Normalization is driven by `NormalizationServiceABC` (`bioetl.domain.transform.contracts`) backed by provider-specific services. The base factory `bioetl.infrastructure.transform.factories.default_normalization_service` wires the contract using the shared `DefaultNormalizationTransformerImpl`, while ChEMBL-specific runs can switch to `ChemblNormalizationServiceImpl` when registered via `abc_impls.yaml`.
 
 ## Components
 
@@ -10,10 +10,10 @@ Normalization is driven by `NormalizationServiceABC` (`bioetl.domain.transform.c
 - **Factories**: `default_normalization_service(config)` (`bioetl.infrastructure.transform.factories`) returning the default implementation.
 - **Shared helpers**: `BaseNormalizationServiceImpl` (`bioetl.infrastructure.transform.impl.base_normalizer`) implementing `BaseNormalizationServiceABC` with deterministic normalization for scalars and containers, numeric coercion, and empty-value handling.
 - **Implementations**:
-  - `NormalizationServiceImpl` (`bioetl.infrastructure.transform.impl.normalization_service_impl`) — generic, config-driven normalization over DataFrames and series on top of the base helper.
+  - `DefaultNormalizationTransformerImpl` (`bioetl.infrastructure.transform.impl.default_normalization_transformer_impl`) — generic, config-driven normalization over DataFrames and series on top of the base helper.
   - `ChemblNormalizationServiceImpl` (`bioetl.infrastructure.transform.impl.chembl_normalization_service_impl`) — specialization that injects ChEMBL-specific normalizers and serialization rules for arrays/records while leveraging the base helper.
 - **Normalizers**: reusable functions in `bioetl.domain.transform.normalizers` for arrays (`normalize_array`), records (`normalize_record`), and identifier-aware scalar normalization.
 
 ## Registry mapping
 
-`src/bioetl/infrastructure/clients/base/abc_impls.yaml` now lists both `NormalizationServiceImpl` (Default) and `ChemblNormalizationServiceImpl` (Chembl) under the `NormalizationServiceABC` role to allow provider-specific selection in containers and orchestrator.
+`src/bioetl/infrastructure/clients/base/abc_impls.yaml` now lists both `DefaultNormalizationTransformerImpl` (Default) and `ChemblNormalizationServiceImpl` (Chembl) under the `NormalizationServiceABC` role to allow provider-specific selection in containers and orchestrator.

--- a/docs/ABC_INDEX.md
+++ b/docs/ABC_INDEX.md
@@ -68,7 +68,7 @@
   - Базовый контракт сервисов нормализации. Default factory: ``bioetl.infrastructure.transform.factories.default_base_normalization_service``. Implementations: ``BaseNormalizationServiceImpl``.
 
 - `NormalizationServiceABC` — `bioetl.domain.transform.contracts.NormalizationServiceABC`
-  - Сервис нормализации данных в DataFrame. Обязательные операции: - normalize: нормализация единичной записи - normalize_fields: пакетная нормализация DataFrame по конфигурации - normalize_dataframe: совместимый алиас для normalize_fields - normalize_batch: пакетная нормализация чанка - normalize_series: нормализация столбца по конфигурации. Default factory: ``bioetl.infrastructure.transform.factories.default_normalization_service``. Implementations: ``NormalizationServiceImpl``, ``ChemblNormalizationServiceImpl``.
+  - Сервис нормализации данных в DataFrame. Обязательные операции: - normalize: нормализация единичной записи - normalize_fields: пакетная нормализация DataFrame по конфигурации - normalize_dataframe: совместимый алиас для normalize_fields - normalize_batch: пакетная нормализация чанка - normalize_series: нормализация столбца по конфигурации. Default factory: ``bioetl.infrastructure.transform.factories.default_normalization_service``. Implementations: ``DefaultNormalizationTransformerImpl``, ``ChemblNormalizationServiceImpl``.
 
 - `ValidatorABC` — `bioetl.domain.validation.contracts.ValidatorABC`
   - Валидация данных. Default factory: ``bioetl.infrastructure.validation.factories.default_validator_factory``. Implementations: ``PanderaValidatorImpl`` (`bioetl.infrastructure.validation.impl.pandera_validator`).

--- a/docs/architecture/diagrams/component/03-infrastructure-components.mmd
+++ b/docs/architecture/diagrams/component/03-infrastructure-components.mmd
@@ -10,7 +10,7 @@ classDef group              fill:#e6ecef,stroke:#333,stroke-width:1.5px,color:#1
 
 subgraph Infrastructure["Infrastructure Layer"]
     UnifiedClient["UnifiedAPIClient\nclients.base.impl.unified_client"]:::componentPrimary
-    ChemblHttp["ChemblHttpClientImpl\nclients.chembl.impl.http_client"]:::componentPrimary
+    ChemblHttp["ChemblHttpClientImpl\nclients.chembl.impl.chembl_http_client_impl"]:::componentPrimary
     ExtractionService["ChemblExtractionServiceImpl\nclients.chembl.impl.chembl_extraction_service_impl"]:::componentSecondary
     RequestBuilder["RequestBuilder\nclients.chembl.request_builder"]:::componentSecondary
     ResponseParser["ResponseParser\nclients.chembl.response_parser"]:::componentSecondary

--- a/src/bioetl.egg-info/SOURCES.txt
+++ b/src/bioetl.egg-info/SOURCES.txt
@@ -174,7 +174,7 @@ src/bioetl/infrastructure/transform/impl/__init__.py
 src/bioetl/infrastructure/transform/impl/base_normalizer.py
 src/bioetl/infrastructure/transform/impl/chembl_normalization_service_impl.py
 src/bioetl/infrastructure/transform/impl/hasher.py
-src/bioetl/infrastructure/transform/impl/normalization_service_impl.py
+src/bioetl/infrastructure/transform/impl/default_normalization_transformer_impl.py
 src/bioetl/infrastructure/transform/impl/normalize.py
 src/bioetl/infrastructure/transform/impl/serializer.py
 src/bioetl/infrastructure/validation/__init__.py

--- a/src/bioetl/infrastructure/clients/base/abc_impls.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_impls.yaml
@@ -60,7 +60,7 @@ BaseNormalizationServiceABC:
 NormalizationServiceABC:
   default_factory: bioetl.infrastructure.transform.factories.default_normalization_service
   implementations:
-    Default: bioetl.infrastructure.transform.impl.normalization_service_impl.NormalizationServiceImpl
+    Default: bioetl.infrastructure.transform.impl.default_normalization_transformer_impl.DefaultNormalizationTransformerImpl
     Chembl: bioetl.infrastructure.transform.impl.chembl_normalization_service_impl.ChemblNormalizationServiceImpl
 
 HasherABC:
@@ -97,7 +97,7 @@ OutputWriterABC:
 DataClientABC:
   default_factory: bioetl.infrastructure.clients.chembl.factories.default_chembl_client
   implementations:
-    ChemblHTTP: bioetl.infrastructure.clients.chembl.impl.http_client.ChemblApiPortImpl
+    ChemblHTTP: bioetl.infrastructure.clients.chembl.impl.chembl_http_client_impl.ChemblHttpClientImpl
 
 RequestBuilderABC:
   default_factory: bioetl.infrastructure.clients.base.factories.default_request_builder

--- a/src/bioetl/infrastructure/clients/chembl/factories.py
+++ b/src/bioetl/infrastructure/clients/chembl/factories.py
@@ -16,7 +16,9 @@ from bioetl.infrastructure.clients.base.factories import (
 from bioetl.infrastructure.clients.chembl.impl import (
     ChemblExtractionServiceImpl,
 )
-from bioetl.infrastructure.clients.chembl.impl.http_client import ChemblApiPortImpl
+from bioetl.infrastructure.clients.chembl.impl.chembl_http_client_impl import (
+    ChemblHttpClientImpl,
+)
 from bioetl.infrastructure.clients.chembl.request_builder import (
     ChemblRequestBuilderImpl,
 )
@@ -58,7 +60,7 @@ def default_chembl_client(
     # Using explicit rate limiter in client logic
     rate_limiter = build_rate_limiter(client_config=client_config)
 
-    return ChemblApiPortImpl(
+    return ChemblHttpClientImpl(
         request_builder=ChemblRequestBuilderImpl(
             base_url=base_url,
             max_url_length=max_url_length,

--- a/src/bioetl/infrastructure/clients/chembl/impl/__init__.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/__init__.py
@@ -3,6 +3,6 @@ ChEMBL client implementations.
 """
 
 from .chembl_extraction_service_impl import ChemblExtractionServiceImpl
-from .http_client import ChemblApiPortImpl
+from .chembl_http_client_impl import ChemblHttpClientImpl
 
-__all__ = ["ChemblExtractionServiceImpl", "ChemblApiPortImpl"]
+__all__ = ["ChemblExtractionServiceImpl", "ChemblHttpClientImpl"]

--- a/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 class ChemblExtractionServiceImpl(ExtractionServiceABC):
     """
     Implementation of ExtractionServiceABC for ChEMBL.
-    Uses DataClientABC (expected to be ChemblApiPortImpl) to fetch data.
+    Uses DataClientABC (expected to be ChemblHttpClientImpl) to fetch data.
     """
 
     def __init__(
@@ -63,7 +63,7 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC):
     ) -> Iterable[list[RawRecord]]:
         # Ensure client has request_builder (runtime check)
         if not hasattr(self.client, "request_builder"):
-            raise TypeError("Client must have request_builder (ChemblApiPortImpl)")
+            raise TypeError("Client must have request_builder (ChemblHttpClientImpl)")
 
         # Prepare limit
         limit = chunk_size or self.batch_size
@@ -71,7 +71,7 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC):
 
         builder = getattr(self.client, "request_builder")
 
-        # Resolve entity alias manually if needed (matches ChemblApiPortImpl)
+        # Resolve entity alias manually if needed (matches ChemblHttpClientImpl)
         aliases = {
             "publication": "document",
             "molecule": "molecule",

--- a/src/bioetl/infrastructure/clients/chembl/impl/chembl_http_client_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/chembl_http_client_impl.py
@@ -1,5 +1,5 @@
 """
-HTTP implementation of ChEMBL API port.
+HTTP client implementation for ChEMBL API.
 """
 
 from __future__ import annotations
@@ -18,9 +18,9 @@ from bioetl.domain.errors import ClientResponseError
 from bioetl.infrastructure.clients.chembl.paginator import ChemblPaginatorImpl
 
 
-class ChemblApiPortImpl(DataClientABC):
+class ChemblHttpClientImpl(DataClientABC):
     """
-    ChEMBL API port implemented over HTTP.
+    ChEMBL API client implemented over HTTP.
     Uses UnifiedAPIClientImpl for requests and RateLimiter for proactive throttling.
     """
 

--- a/src/bioetl/infrastructure/transform/factories.py
+++ b/src/bioetl/infrastructure/transform/factories.py
@@ -15,8 +15,8 @@ from bioetl.infrastructure.transform.impl.chembl_normalization_service_impl impo
     ChemblNormalizationServiceImpl,
 )
 from bioetl.infrastructure.transform.impl.hasher import HasherImpl
-from bioetl.infrastructure.transform.impl.normalization_service_impl import (
-    NormalizationServiceImpl,
+from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl import (
+    DefaultNormalizationTransformerImpl,
 )
 
 
@@ -45,7 +45,7 @@ def default_normalization_service(
 ) -> NormalizationServiceABC:
     """Создает сервис нормализации по умолчанию."""
 
-    return NormalizationServiceImpl(config)
+    return DefaultNormalizationTransformerImpl(config)
 
 
 def default_chembl_normalization_service(

--- a/src/bioetl/infrastructure/transform/impl/__init__.py
+++ b/src/bioetl/infrastructure/transform/impl/__init__.py
@@ -3,13 +3,13 @@
 from bioetl.infrastructure.transform.impl.chembl_normalization_service_impl import (
     ChemblNormalizationServiceImpl,
 )
-from bioetl.infrastructure.transform.impl.hasher import HasherImpl
-from bioetl.infrastructure.transform.impl.normalization_service_impl import (
-    NormalizationServiceImpl,
+from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl import (
+    DefaultNormalizationTransformerImpl,
 )
+from bioetl.infrastructure.transform.impl.hasher import HasherImpl
 
 __all__ = [
     "HasherImpl",
-    "NormalizationServiceImpl",
+    "DefaultNormalizationTransformerImpl",
     "ChemblNormalizationServiceImpl",
 ]

--- a/src/bioetl/infrastructure/transform/impl/default_normalization_transformer_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/default_normalization_transformer_impl.py
@@ -1,4 +1,4 @@
-"""Infrastructure implementation of the normalization service."""
+"""Infrastructure implementation of the default normalization transformer."""
 
 from typing import Any, Callable, cast
 
@@ -15,7 +15,9 @@ from bioetl.infrastructure.transform.impl.base_normalizer import (
 from bioetl.infrastructure.transform.impl.serializer import serialize_list
 
 
-class NormalizationServiceImpl(NormalizationServiceABC, BaseNormalizationServiceImpl):
+class DefaultNormalizationTransformerImpl(
+    NormalizationServiceABC, BaseNormalizationServiceImpl
+):
     """
     Сервис нормализации данных.
     Выполняет:
@@ -171,4 +173,4 @@ class NormalizationServiceImpl(NormalizationServiceABC, BaseNormalizationService
         return cast(pd.Series, series.apply(_normalize_value_from_series))
 
 
-__all__ = ["NormalizationServiceImpl"]
+__all__ = ["DefaultNormalizationTransformerImpl"]

--- a/src/bioetl/infrastructure/transform/impl/normalize.py
+++ b/src/bioetl/infrastructure/transform/impl/normalize.py
@@ -21,6 +21,9 @@ from bioetl.domain.transform.normalizers.registry import get_normalizer
 from bioetl.infrastructure.transform.impl.base_normalizer import (
     BaseNormalizationServiceImpl,
 )
+from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl import (
+    DefaultNormalizationTransformerImpl,
+)
 from bioetl.infrastructure.transform.impl.serializer import (
     serialize_dict,
     serialize_list,
@@ -82,160 +85,9 @@ def _normalize_string_value(value: str, mode: str) -> str | None:
     return val.lower()
 
 
-class NormalizationServiceImpl(NormalizationServiceABC, BaseNormalizationServiceImpl):
-    """
-    Сервис нормализации данных.
-    Выполняет:
-    - Сериализацию вложенных структур (list/dict -> str)
-    - Нормализацию скалярных типов (float->round, str->trim/lower/upper)
-    """
-
-    def __init__(self, config: NormalizationConfigProviderProtocol):
-        BaseNormalizationServiceImpl.__init__(self, config, empty_value=pd.NA)
-
-    def apply_normalize(self, raw: pd.Series | dict[str, Any]) -> dict[str, Any]:
-        """Normalize a single raw record into dictionary form."""
-        df = pd.DataFrame([raw])
-        normalized = self.apply_normalize_dataframe(df)
-        return cast(dict[str, Any], normalized.iloc[0].to_dict())
-
-    def apply_normalize_fields(self, df: pd.DataFrame) -> pd.DataFrame:
-        """
-        Проходит по полям конфигурации и применяет нормализацию.
-        """
-        for field_cfg in self._config.get_fields():
-            name = field_cfg["name"]
-            dtype = field_cfg.get("data_type")
-
-            if name not in df.columns:
-                continue
-
-            mode = self._resolve_mode(name)
-            custom_normalizer = get_normalizer(name)
-
-            if custom_normalizer:
-                base_normalizer: Callable[[Any], Any] = custom_normalizer
-            else:
-
-                def _default_normalizer(val: Any, m: str = mode) -> Any:
-                    return normalize_scalar(val, mode=m)
-
-                base_normalizer = _default_normalizer
-
-            def _apply_value(
-                val: Any,
-                norm: Callable[[Any], Any] = base_normalizer,
-                field_name: str = name,
-                data_type: str | None = dtype,
-            ) -> Any:
-                try:
-                    return self._normalize_value(
-                        val,
-                        data_type,
-                        norm,
-                        field_name,
-                        allow_container_normalizer=True,
-                        serialize_with_value_normalizer=False,
-                    )
-                except ValueError as exc:
-                    raise ValueError(
-                        f"Ошибка нормализации поля '{field_name}': {exc}"
-                    ) from exc
-
-            df[name] = df[name].apply(_apply_value)
-
-            if dtype in ("array", "object"):
-                df[name] = df[name].astype("string").replace({pd.NA: None})
-
-        return self.ensure_numeric_columns(df)
-
-    def apply_normalize_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Normalize dataframe using configured field rules."""
-        return self.apply_normalize_fields(df)
-
-    def apply_normalize_batch(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Normalize a batch dataframe (alias for apply_normalize_dataframe)."""
-        return self.apply_normalize_dataframe(df)
-
-    def apply_normalize_series(
-        self, series: pd.Series, field_cfg: dict[str, Any]
-    ) -> pd.Series:
-        """Normalize a single pandas Series according to field config."""
-        name = cast(str, field_cfg.get("name"))
-        dtype = field_cfg.get("data_type")
-        mode = self._resolve_mode(name)
-        custom_normalizer = get_normalizer(name)
-
-        if custom_normalizer:
-            base_normalizer = custom_normalizer
-        else:
-
-            def _default_normalizer(val: Any, m: str = mode) -> Any:
-                return normalize_scalar(val, mode=m)
-
-            base_normalizer = _default_normalizer
-
-        def _normalize_value_from_series(val: Any) -> Any:
-            return self._normalize_value(
-                val,
-                dtype,
-                base_normalizer,
-                name,
-                allow_container_normalizer=True,
-            )
-
-        return cast(pd.Series, series.apply(_normalize_value_from_series))
-
-    def _normalize_container_item(
-        self, item: Any, normalizer: Callable[[Any], Any]
-    ) -> Any:
-        """Normalize nested container item preserving deterministic shape."""
-        if isinstance(item, dict):
-            normalized_dict = normalize_record(item, value_normalizer=normalizer)
-            return normalized_dict if normalized_dict is not None else {}
-        return normalizer(item)
-
-    def _process_list(
-        self,
-        val: Any,
-        norm: Callable[[Any], Any],
-        field_name: str,
-        *,
-        serialize_with_value_normalizer: bool = False,
-    ) -> Any:
-        try:
-
-            def _smart_normalizer(item: Any) -> Any:
-                return self._normalize_container_item(item, norm)
-
-            normalized_list = normalize_array(val, item_normalizer=_smart_normalizer)
-        except ValueError as exc:
-            raise ValueError(
-                f"Ошибка нормализации списка в поле '{field_name}': {exc}"
-            ) from exc
-        if not normalized_list:
-            return pd.NA
-        return serialize_list(
-            normalized_list,
-            value_normalizer=norm if serialize_with_value_normalizer else None,
-        )
-
-    def _process_dict(
-        self, val: Any, norm: Callable[[Any], Any], field_name: str
-    ) -> Any:
-        try:
-            normalized_dict = normalize_record(val, value_normalizer=norm)
-        except ValueError as exc:
-            raise ValueError(
-                f"Ошибка нормализации записи в поле '{field_name}': {exc}"
-            ) from exc
-        if normalized_dict is None:
-            return pd.NA
-        return serialize_dict(dict(normalized_dict))
-
-
-# Backward compatibility alias
-NormalizationService = NormalizationServiceImpl
+NormalizationTransformer = DefaultNormalizationTransformerImpl
+NormalizationServiceImpl = DefaultNormalizationTransformerImpl
+NormalizationService = DefaultNormalizationTransformerImpl
 
 
 __all__ = [
@@ -243,6 +95,8 @@ __all__ = [
     "normalize_pubmed_id",
     "normalize_pubchem_cid",
     "normalize_uniprot_id",
+    "DefaultNormalizationTransformerImpl",
+    "NormalizationTransformer",
     "NormalizationService",
     "NormalizationServiceImpl",
 ]

--- a/tests/architecture/test_architecture_policies.py
+++ b/tests/architecture/test_architecture_policies.py
@@ -183,7 +183,7 @@ def test_duplicate_class_names_are_allowlisted() -> None:
         "ConfigError",
         "ConfigValidationError",
         "BaseProviderConfig",
-        "NormalizationServiceImpl",
+        "DefaultNormalizationTransformerImpl",
         "NormalizationConfig",
         "Config",
     }

--- a/tests/architecture/test_architecture_rules.py
+++ b/tests/architecture/test_architecture_rules.py
@@ -19,7 +19,7 @@ ALLOWED_DUPLICATE_CLASSES = {
     "ProviderRegistryError",
     "ConfigError",
     "ConfigValidationError",
-    "NormalizationServiceImpl",
+    "DefaultNormalizationTransformerImpl",
     "NormalizationConfig",
     "Config",
     "BaseProviderConfig",

--- a/tests/bioetl/application/pipelines/chembl/publication/test_publication_pipeline.py
+++ b/tests/bioetl/application/pipelines/chembl/publication/test_publication_pipeline.py
@@ -7,7 +7,9 @@ import pytest
 
 from bioetl.application.pipelines.chembl.base import ChemblPipelineBase
 from bioetl.domain.schemas.chembl.publication import PublicationTableSchema
-from bioetl.infrastructure.transform.impl.normalize import NormalizationServiceImpl
+from bioetl.infrastructure.transform.impl.normalize import (
+    DefaultNormalizationTransformerImpl,
+)
 
 
 @pytest.fixture
@@ -46,7 +48,7 @@ def pipeline():
         PublicationTableSchema.to_schema().columns.keys()
     )
 
-    normalization_service = NormalizationServiceImpl(config)
+    normalization_service = DefaultNormalizationTransformerImpl(config)
 
     return ChemblPipelineBase(
         config=config,

--- a/tests/bioetl/infrastructure/clients/chembl/test_factories.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_factories.py
@@ -11,8 +11,8 @@ from bioetl.infrastructure.clients.chembl.factories import (
 from bioetl.infrastructure.clients.chembl.impl import (
     ChemblExtractionServiceImpl,
 )
-from bioetl.infrastructure.clients.chembl.impl.http_client import (
-    ChemblApiPortImpl,
+from bioetl.infrastructure.clients.chembl.impl.chembl_http_client_impl import (
+    ChemblHttpClientImpl,
 )
 from bioetl.infrastructure.config.models import (
     ChemblSourceConfig,
@@ -37,7 +37,7 @@ def source_config():
 def test_default_chembl_client_success(source_config):
     """Test default ChEMBL client factory with valid config."""
     client = default_chembl_client(source_config)
-    assert isinstance(client, ChemblApiPortImpl)
+    assert isinstance(client, ChemblHttpClientImpl)
     # Check that parameters propagated to request_builder
     assert client.request_builder.base_url == "https://example.com"
     assert client.request_builder.max_url_length == 1000
@@ -58,7 +58,7 @@ def test_default_chembl_extraction_service(source_config):
     source_config.batch_size = 50
     service = default_chembl_extraction_service(source_config)
     assert isinstance(service, ChemblExtractionServiceImpl)
-    assert isinstance(service.client, ChemblApiPortImpl)
+    assert isinstance(service.client, ChemblHttpClientImpl)
     assert service.batch_size == 50
 
 

--- a/tests/bioetl/infrastructure/clients/chembl/test_http_client.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_http_client.py
@@ -3,7 +3,9 @@ from unittest.mock import Mock
 
 from bioetl.domain.clients.base.contracts import ApiClientABC, RateLimiterABC
 from bioetl.domain.errors import ClientResponseError
-from bioetl.infrastructure.clients.chembl.impl.http_client import ChemblApiPortImpl
+from bioetl.infrastructure.clients.chembl.impl.chembl_http_client_impl import (
+    ChemblHttpClientImpl,
+)
 from bioetl.infrastructure.clients.chembl.request_builder import (
     ChemblRequestBuilderImpl,
 )
@@ -40,8 +42,8 @@ def fixture_client(
     mock_rate_limiter,
     mock_http_client,
 ):
-    """Create ChemblApiPortImpl instance with mocks."""
-    client = ChemblApiPortImpl(
+    """Create ChemblHttpClientImpl instance with mocks."""
+    client = ChemblHttpClientImpl(
         request_builder=mock_request_builder,
         response_parser=mock_response_parser,
         rate_limiter=mock_rate_limiter,

--- a/tests/bioetl/infrastructure/clients/test_chembl_client.py
+++ b/tests/bioetl/infrastructure/clients/test_chembl_client.py
@@ -3,7 +3,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from bioetl.domain.clients.base.contracts import ApiClientABC, RateLimiterABC
-from bioetl.infrastructure.clients.chembl.impl.http_client import ChemblApiPortImpl
+from bioetl.infrastructure.clients.chembl.impl.chembl_http_client_impl import (
+    ChemblHttpClientImpl,
+)
 from bioetl.infrastructure.clients.chembl.request_builder import (
     ChemblRequestBuilderImpl,
 )
@@ -26,7 +28,7 @@ def mock_components():
 
 @pytest.fixture
 def client(mock_components):
-    client = ChemblApiPortImpl(
+    client = ChemblHttpClientImpl(
         request_builder=mock_components["request_builder"],
         response_parser=mock_components["response_parser"],
         rate_limiter=mock_components["rate_limiter"],

--- a/tests/bioetl/infrastructure/transform/test_target_normalization_service.py
+++ b/tests/bioetl/infrastructure/transform/test_target_normalization_service.py
@@ -2,7 +2,9 @@ from types import SimpleNamespace
 
 import pandas as pd
 
-from bioetl.infrastructure.transform.impl.normalize import NormalizationServiceImpl
+from bioetl.infrastructure.transform.impl.normalize import (
+    DefaultNormalizationTransformerImpl,
+)
 
 
 class _DummyConfig:
@@ -24,7 +26,7 @@ class _DummyConfig:
 
 
 def test_normalization_service_handles_target_arrays():
-    service = NormalizationServiceImpl(_DummyConfig())
+    service = DefaultNormalizationTransformerImpl(_DummyConfig())
     df = pd.DataFrame(
         {
             "target_components": [


### PR DESCRIPTION
## Summary
- rename the ChEMBL HTTP client implementation to ChemblHttpClientImpl and update factories, tests, and registry mappings
- rename the default normalization transformer implementation and expose it through normalize helpers and factories
- refresh documentation snippets and metadata to reflect the new implementation names

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937f20013f08324a6659fb70bd365e1)