### PR TITLE
Standardize HTTP error handling for infrastructure clients

### DIFF
--- a/src/bioetl/infrastructure/clients/base/impl/unified_api_client_impl.py
+++ b/src/bioetl/infrastructure/clients/base/impl/unified_api_client_impl.py
@@ -13,6 +13,7 @@ import requests
 from bioetl.domain.clients.base.contracts import ApiClientABC
 from bioetl.domain.configs import ClientConfig
 from bioetl.domain.observability import LoggingPortABC
+from bioetl.infrastructure.errors import wrap_http_errors
 from bioetl.infrastructure.observability.factories import default_logging_port
 
 
@@ -45,27 +46,32 @@ class UnifiedAPIClientImpl(ApiClientABC):
 
     def request_call(self, method: str, url: str, **kwargs: Any) -> Any:
         """Выполнить HTTP-запрос с настройками клиента."""
-        method_upper = method.upper()
-        if method_upper in {"POST", "PUT", "PATCH", "DELETE"}:
-            headers = dict(kwargs.get("headers") or {})
-            headers.setdefault("Idempotency-Key", str(uuid4()))
-            kwargs["headers"] = headers
+        with wrap_http_errors(
+            provider=self.provider, endpoint=url, logger=self.logger
+        ) as context:
+            method_upper = method.upper()
+            if method_upper in {"POST", "PUT", "PATCH", "DELETE"}:
+                headers = dict(kwargs.get("headers") or {})
+                headers.setdefault("Idempotency-Key", str(uuid4()))
+                kwargs["headers"] = headers
 
-        timeout = kwargs.pop("timeout", self.config.timeout_sec)
-        start = time.monotonic()
-        response = self.base_client.request(
-            method=method, url=url, timeout=timeout, **kwargs
-        )
-        latency = time.monotonic() - start
-        self.logger.info(
-            "http_request_completed",
-            provider=self.provider,
-            method=method_upper,
-            url=url,
-            status_code=getattr(response, "status_code", None),
-            latency_sec=latency,
-        )
-        return response
+            timeout = kwargs.pop("timeout", self.config.timeout_sec)
+            start = time.monotonic()
+            response = self.base_client.request(
+                method=method, url=url, timeout=timeout, **kwargs
+            )
+            latency = time.monotonic() - start
+            raw_status = getattr(response, "status_code", None)
+            context["status_code"] = raw_status if isinstance(raw_status, int) else None
+            self.logger.info(
+                "http_request_completed",
+                provider=self.provider,
+                method=method_upper,
+                url=url,
+                status_code=context["status_code"],
+                latency_sec=latency,
+            )
+            return response
 
     def request(self, method: str, url: str, **kwargs: Any) -> Any:
         """Execute a request using the configured HTTP client."""

--- a/src/bioetl/infrastructure/clients/chembl/impl/http_client.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/http_client.py
@@ -15,8 +15,11 @@ from bioetl.domain.clients.base.contracts import (
     ResponseParserABC,
 )
 from bioetl.domain.clients.contracts import DataClientABC
-from bioetl.domain.errors import ClientResponseError
 from bioetl.domain.observability import LoggingPortABC
+from bioetl.infrastructure.errors import (
+    ApiUnexpectedStatusError,
+    wrap_http_errors,
+)
 from bioetl.infrastructure.clients.chembl.paginator import ChemblPaginatorImpl
 from bioetl.infrastructure.observability.factories import default_logging_port
 
@@ -93,36 +96,42 @@ class ChemblApiPortImpl(DataClientABC):
         return self._execute_request(url)
 
     def _execute_request(self, url: str) -> dict[str, Any]:
-        start = time.monotonic()
-        response = self.http.request("GET", url)
-        latency = time.monotonic() - start
-        status_code = getattr(response, "status_code", None)
-        log_level = self.logger.error if status_code and status_code >= 400 else self.logger.info
-        log_level(
-            "http_request_completed",
-            provider=self.provider,
-            method="GET",
-            url=url,
-            status_code=status_code,
-            latency_sec=latency,
-        )
-        try:
-            return response.json()
-        except ValueError as exc:
-            self.logger.error(
-                "response_deserialization_failed",
+        with wrap_http_errors(
+            provider=self.provider, endpoint=url, logger=self.logger
+        ) as context:
+            start = time.monotonic()
+            response = self.http.request("GET", url)
+            latency = time.monotonic() - start
+            raw_status = getattr(response, "status_code", None)
+            status_code = raw_status if isinstance(raw_status, int) else None
+            context["status_code"] = status_code
+            log_level = (
+                self.logger.error
+                if status_code is not None and status_code >= 400
+                else self.logger.info
+            )
+            log_level(
+                "http_request_completed",
                 provider=self.provider,
+                method="GET",
                 url=url,
                 status_code=status_code,
-                error=str(exc),
+                latency_sec=latency,
             )
-            raise ClientResponseError(
-                provider=self.provider,
-                endpoint=url,
-                status_code=getattr(response, "status_code", None),
-                message="Failed to parse response JSON",
-                cause=exc,
-            ) from exc
+            if status_code is not None and status_code >= 400:
+                self.logger.error(
+                    "api_unexpected_status",
+                    provider=self.provider,
+                    url=url,
+                    status_code=status_code,
+                )
+                raise ApiUnexpectedStatusError(
+                    f"Unexpected status code: {status_code}",
+                    provider=self.provider,
+                    endpoint=url,
+                    status_code=status_code,
+                )
+            return response.json()
 
     def _build_request_url(self, endpoint: str, filters: dict[str, Any]) -> str:
         """

--- a/src/bioetl/infrastructure/errors.py
+++ b/src/bioetl/infrastructure/errors.py
@@ -1,0 +1,121 @@
+"""Shared HTTP client error wrappers and helpers."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+import requests
+
+from bioetl.domain.observability import LoggingPortABC
+
+__all__ = [
+    "ApiClientError",
+    "ApiTimeoutError",
+    "ApiParseError",
+    "ApiUnexpectedStatusError",
+    "wrap_http_errors",
+]
+
+
+class ApiClientError(Exception):
+    """Base error for HTTP client failures."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        provider: str | None = None,
+        endpoint: str | None = None,
+        status_code: int | None = None,
+        cause: Exception | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.provider = provider
+        self.endpoint = endpoint
+        self.status_code = status_code
+        self.cause = cause
+
+    def __str__(self) -> str:
+        base = self.__class__.__name__
+        if self.provider:
+            base += f" provider='{self.provider}'"
+        if self.endpoint:
+            base += f" endpoint='{self.endpoint}'"
+        if self.status_code is not None:
+            base += f" status={self.status_code}"
+        return f"{base}: {self.args[0]}"
+
+
+class ApiTimeoutError(ApiClientError):
+    """Raised when an HTTP request exceeds the configured timeout."""
+
+
+class ApiParseError(ApiClientError):
+    """Raised when HTTP response payload cannot be parsed."""
+
+
+class ApiUnexpectedStatusError(ApiClientError):
+    """Raised when HTTP response contains an unexpected status code."""
+
+
+@contextmanager
+def wrap_http_errors(
+    *,
+    provider: str,
+    endpoint: str | None = None,
+    logger: LoggingPortABC | None = None,
+) -> Iterator[dict[str, Any]]:
+    """Context manager to standardize HTTP error handling and logging."""
+
+    context: dict[str, Any] = {
+        "provider": provider,
+        "endpoint": endpoint,
+        "status_code": None,
+    }
+    try:
+        yield context
+    except ApiClientError:
+        raise
+    except requests.Timeout as exc:
+        _log_error("api_timeout_error", exc, context, logger)
+        raise ApiTimeoutError(
+            "HTTP request timed out",
+            provider=provider,
+            endpoint=endpoint,
+            status_code=context["status_code"],
+            cause=exc,
+        ) from exc
+    except requests.RequestException as exc:
+        _log_error("api_request_error", exc, context, logger)
+        raise ApiClientError(
+            "HTTP request failed",
+            provider=provider,
+            endpoint=endpoint,
+            status_code=context["status_code"],
+            cause=exc,
+        ) from exc
+    except ValueError as exc:
+        _log_error("api_parse_error", exc, context, logger)
+        raise ApiParseError(
+            "Failed to parse HTTP response",
+            provider=provider,
+            endpoint=endpoint,
+            status_code=context["status_code"],
+            cause=exc,
+        ) from exc
+
+
+def _log_error(
+    event: str, exc: Exception, context: dict[str, Any], logger: LoggingPortABC | None
+) -> None:
+    if logger is None:
+        return
+
+    logger.error(
+        event,
+        provider=context.get("provider"),
+        endpoint=context.get("endpoint"),
+        status_code=context.get("status_code"),
+        error=str(exc),
+    )

--- a/tests/bioetl/infrastructure/clients/base/test_unified_api_client_impl.py
+++ b/tests/bioetl/infrastructure/clients/base/test_unified_api_client_impl.py
@@ -1,0 +1,41 @@
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from bioetl.domain.configs import ClientConfig
+from bioetl.domain.observability import LoggingPortABC
+from bioetl.infrastructure.clients.base.impl.unified_api_client_impl import (
+    UnifiedAPIClientImpl,
+)
+from bioetl.infrastructure.errors import ApiClientError, ApiTimeoutError
+
+
+def test_request_call_wraps_timeout_error() -> None:
+    base_client = Mock()
+    base_client.request.side_effect = requests.Timeout("timeout")
+    logger = Mock(spec=LoggingPortABC)
+    client = UnifiedAPIClientImpl(
+        provider="chembl", config=ClientConfig(), base_client=base_client, logger=logger
+    )
+
+    with pytest.raises(ApiTimeoutError) as err:
+        client.request("GET", "https://example.org")
+
+    assert err.value.provider == "chembl"
+    assert err.value.endpoint == "https://example.org"
+    logger.error.assert_called_once()
+
+
+def test_request_call_wraps_request_exception() -> None:
+    base_client = Mock()
+    base_client.request.side_effect = requests.RequestException("boom")
+    client = UnifiedAPIClientImpl(
+        provider="chembl", config=ClientConfig(), base_client=base_client
+    )
+
+    with pytest.raises(ApiClientError) as err:
+        client.request("POST", "https://example.org", data={})
+
+    assert err.value.provider == "chembl"
+    assert err.value.endpoint == "https://example.org"

--- a/tests/bioetl/infrastructure/clients/chembl/test_http_client.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_http_client.py
@@ -2,14 +2,19 @@ from unittest.mock import Mock
 
 import pytest
 
+import requests
 from bioetl.domain.clients.base.contracts import ApiClientABC, RateLimiterABC
-from bioetl.domain.errors import ClientResponseError
 from bioetl.infrastructure.clients.chembl.impl.http_client import ChemblApiPortImpl
 from bioetl.infrastructure.clients.chembl.request_builder import (
     ChemblRequestBuilderImpl,
 )
 from bioetl.infrastructure.clients.chembl.response_parser import (
     ChemblResponseParserImpl,
+)
+from bioetl.infrastructure.errors import (
+    ApiParseError,
+    ApiTimeoutError,
+    ApiUnexpectedStatusError,
 )
 
 
@@ -100,8 +105,12 @@ def test_execute_request_json_error(client):
     mock_response.json.side_effect = ValueError("bad json")
     client.http.request.return_value = mock_response
 
-    with pytest.raises(ClientResponseError):
+    with pytest.raises(ApiParseError) as err:
         client.fetch("activity")
+
+    assert err.value.provider == "chembl"
+    assert err.value.endpoint == "http://test-url"
+    assert err.value.status_code == 200
 
 
 def test_rate_limiter_called(client):
@@ -167,3 +176,26 @@ def test_iter_pages_without_next_stops_after_first(client):
 
     assert pages == [response.json.return_value]
     client.http.request.assert_called_once_with("GET", "https://example.org/page1")
+
+
+def test_execute_request_wraps_timeout(client):
+    client.http.request.side_effect = requests.Timeout("timeout")
+
+    with pytest.raises(ApiTimeoutError) as err:
+        client.fetch("activity")
+
+    assert err.value.provider == "chembl"
+    assert err.value.endpoint == "http://test-url"
+
+
+def test_execute_request_unexpected_status(client):
+    response = Mock()
+    response.status_code = 503
+    response.json.return_value = {}
+    client.http.request.return_value = response
+
+    with pytest.raises(ApiUnexpectedStatusError) as err:
+        client.fetch("activity")
+
+    assert err.value.status_code == 503
+    assert err.value.endpoint == "http://test-url"


### PR DESCRIPTION
## Summary
- add shared infrastructure error classes and a wrap_http_errors helper for consistent HTTP error handling
- apply the wrapper to UnifiedAPIClientImpl and ChemblApiPortImpl to centralize logging and context on failures
- update unit tests to cover wrapped exceptions, timeouts, and unexpected statuses

## Testing
- pytest tests/bioetl/infrastructure/clients/chembl/test_http_client.py tests/bioetl/infrastructure/clients/base/test_unified_api_client_impl.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937f2ed21248324a25d1393731b3825)