### PR TITLE
Introduce typed ChEMBL activity models

### DIFF
--- a/src/bioetl/application/files/csv_record_source.py
+++ b/src/bioetl/application/files/csv_record_source.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, cast
 
 import pandas as pd
+from pydantic import BaseModel
 
 from bioetl.domain.configs import ChemblSourceConfig, CsvInputConfig
 from bioetl.domain.observability import LoggingPortABC
@@ -29,12 +30,14 @@ class CsvRecordSourceImpl(RecordSource):
         limit: int | None,
         logger: LoggingPortABC,
         chunk_size: int | None = None,
+        model_cls: type[BaseModel] | None = None,
     ) -> None:
         self._input_path = input_path
         self._csv_options = self._ensure_csv_options(csv_options)
         self._limit = limit
         self._logger = logger
         self._chunk_size = chunk_size
+        self._model_cls: type[BaseModel] = model_cls or RawRecord
 
     def iter_records(self) -> Iterable[list[RawRecord]]:
         """Read CSV dataset and yield records respecting limits and chunking."""
@@ -48,7 +51,10 @@ class CsvRecordSourceImpl(RecordSource):
         if self._limit is not None:
             df = df.head(self._limit)
         records_dicts = df.to_dict(orient="records")
-        records: list[RawRecord] = cast(list[RawRecord], records_dicts)
+        records: list[RawRecord] = [
+            cast(RawRecord, self._model_cls.model_validate(item))
+            for item in records_dicts
+        ]
         if self._chunk_size is None or self._chunk_size <= 0:
             yield records
             return

--- a/src/bioetl/application/pipelines/chembl/base.py
+++ b/src/bioetl/application/pipelines/chembl/base.py
@@ -29,6 +29,7 @@ from bioetl.domain.ports.extraction import ExtractionServiceABC
 from bioetl.domain.record_source import RecordSource
 from bioetl.domain.schemas.pipeline_contracts import get_pipeline_contract
 from bioetl.domain.transform.contracts import HashServiceABC, NormalizationServiceABC
+from bioetl.infrastructure.clients.chembl.models import ActivityRawModel
 from bioetl.domain.transform.transformers import TransformerABC
 from bioetl.domain.validation.service import ValidationService
 
@@ -69,7 +70,7 @@ class ChemblPipelineBase(PipelineBase):
             extraction_service=extraction_service,
             normalization_service=norm_service,
             logger=logger,
-            batch_adapter=PandasBatchAdapter(),
+            batch_adapter=PandasBatchAdapter(model_cls=ActivityRawModel),
             record_source=record_source,
         )
 

--- a/src/bioetl/application/pipelines/chembl/extractor.py
+++ b/src/bioetl/application/pipelines/chembl/extractor.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Iterable, cast
 
 import pandas as pd
+from pydantic import BaseModel
 
 from bioetl.application.files.csv_record_source import (
     CsvRecordSourceImpl,
@@ -17,6 +18,7 @@ from bioetl.domain.observability import LoggingPortABC
 from bioetl.domain.ports.extraction import BatchAdapterABC, ExtractionServiceABC
 from bioetl.domain.record_source import ApiRecordSource, RecordSource
 from bioetl.domain.transform.contracts import NormalizationServiceABC
+from bioetl.infrastructure.clients.chembl.models import ActivityRawModel
 
 
 class ChemblExtractorImpl(ExtractorABC):
@@ -57,7 +59,12 @@ class ChemblExtractorImpl(ExtractorABC):
             if remaining is not None:
                 chunk_records = raw_chunk[:remaining]
 
-            working_chunk = pd.DataFrame(chunk_records)
+            normalized_input = [
+                record.model_dump() if isinstance(record, BaseModel) else record
+                for record in chunk_records
+            ]
+
+            working_chunk = pd.DataFrame(normalized_input)
 
             normalized_chunk = self.normalization_service.apply_normalize_batch(
                 working_chunk
@@ -144,6 +151,7 @@ class ChemblExtractorImpl(ExtractorABC):
             limit=limit,
             chunk_size=chunk_size,
             logger=self.logger,
+            model_cls=ActivityRawModel,
         )
 
     def _build_id_list_source(

--- a/src/bioetl/application/transform/pandas_batch_adapter.py
+++ b/src/bioetl/application/transform/pandas_batch_adapter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, cast
 
 import pandas as pd
+from pydantic import BaseModel
 
 from bioetl.domain.ports.extraction import BatchAdapterABC
 from bioetl.domain.record_source import RawRecord
@@ -13,24 +14,28 @@ from bioetl.domain.record_source import RawRecord
 class PandasBatchAdapter(BatchAdapterABC):
     """Конвертирует сырые батчи в список записей RawRecord."""
 
+    def __init__(self, model_cls: type[BaseModel] | None = None) -> None:
+        self._model_cls: type[BaseModel] = model_cls or RawRecord
+
     def process_batch(self, raw_batch: Any) -> list[RawRecord]:
-        """Нормализует батч провайдера в список словарей."""
+        """Нормализует батч провайдера в список моделей."""
         if raw_batch is None:
             return []
 
         if isinstance(raw_batch, pd.DataFrame):
             return [
-                cast(RawRecord, dict(record)) for record in raw_batch.to_dict("records")
+                cast(RawRecord, self._model_cls.model_validate(record))
+                for record in raw_batch.to_dict("records")
             ]
 
         if isinstance(raw_batch, list):
             normalized: list[RawRecord] = []
             for item in raw_batch:
-                normalized.append(cast(RawRecord, dict(item)))
+                normalized.append(self._convert_record(item))
             return normalized
 
         if isinstance(raw_batch, dict):
-            return [cast(RawRecord, dict(raw_batch))]
+            return [self._convert_record(raw_batch)]
 
         raise TypeError(
             "Unsupported batch type "
@@ -40,6 +45,11 @@ class PandasBatchAdapter(BatchAdapterABC):
     def adapt_batch(self, raw_batch: Any) -> list[RawRecord]:
         """Alias для process_batch для обратной совместимости."""
         return self.process_batch(raw_batch)
+
+    def _convert_record(self, item: Any) -> RawRecord:
+        if isinstance(item, BaseModel):
+            return cast(RawRecord, item)
+        return cast(RawRecord, self._model_cls.model_validate(item))
 
 
 __all__ = ["PandasBatchAdapter"]

--- a/src/bioetl/domain/clients/base/contracts.py
+++ b/src/bioetl/domain/clients/base/contracts.py
@@ -3,8 +3,11 @@
 from abc import ABC, abstractmethod
 from typing import Any, Generic, TypeVar
 
+from pydantic import BaseModel
+
 T = TypeVar("T")
-Record = dict[str, Any]
+RecordT = TypeVar("RecordT", bound=BaseModel)
+RecordModel = BaseModel
 
 
 class RequestBuilderABC(ABC):
@@ -21,17 +24,17 @@ class RequestBuilderABC(ABC):
         """Добавляет параметры пагинации."""
 
 
-class ResponseParserABC(ABC):
+class ResponseParserABC(ABC, Generic[RecordT]):
     """
     Разбор ответов API.
     """
 
     @abstractmethod
-    def parse_response(self, raw_response: Any) -> list[Record]:
-        """Парсит сырой ответ в список записей."""
+    def parse_response(self, raw_response: dict[str, object]) -> list[RecordT]:
+        """Парсит сырой ответ в список типизированных записей."""
 
     @abstractmethod
-    def extract_metadata(self, raw_response: Any) -> dict[str, Any]:
+    def extract_metadata(self, raw_response: dict[str, object]) -> dict[str, int | str | None]:
         """Извлекает метаданные из ответа (например, общее кол-во)."""
 
 
@@ -62,7 +65,7 @@ class PaginatorABC(ABC):
     """
 
     @abstractmethod
-    def get_items(self, response: Any) -> list[Record]:
+    def get_items(self, response: Any) -> list[RecordModel]:
         """Извлекает элементы из ответа."""
 
     @abstractmethod

--- a/src/bioetl/domain/ports/extraction.py
+++ b/src/bioetl/domain/ports/extraction.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Protocol
+
+from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from bioetl.domain.record_source import RawRecord
@@ -28,7 +30,7 @@ class ExtractionServiceABC(ABC):
         """
 
     @abstractmethod
-    def extract_all(self, entity: str, **filters: Any) -> list["RawRecord"]:
+    def extract_all(self, entity: str, **filters: object) -> list["RawRecord"]:
         """
         Extract all records for an entity with optional filters.
 
@@ -42,7 +44,7 @@ class ExtractionServiceABC(ABC):
 
     @abstractmethod
     def iter_extract(
-        self, entity: str, *, chunk_size: int | None = None, **filters: Any
+        self, entity: str, *, chunk_size: int | None = None, **filters: object
     ) -> Iterable[list["RawRecord"]]:
         """
         Stream records for an entity in raw record batches.
@@ -62,7 +64,7 @@ class ExtractionServiceABC(ABC):
         entity: str,
         batch_ids: list[str],
         filter_key: str,
-    ) -> dict[str, Any]:
+    ) -> dict[str, object]:
         """
         Request a batch of records by IDs.
 
@@ -76,7 +78,7 @@ class ExtractionServiceABC(ABC):
         """
 
     @abstractmethod
-    def parse_response(self, raw_response: dict[str, Any]) -> list[dict[str, Any]]:
+    def parse_response(self, raw_response: dict[str, object]) -> list[BaseModel]:
         """
         Parse raw API response into list of records.
 
@@ -89,8 +91,8 @@ class ExtractionServiceABC(ABC):
 
     @abstractmethod
     def serialize_records(
-        self, entity: str, records: list[dict[str, Any]]
-    ) -> list[dict[str, Any]]:
+        self, entity: str, records: list[BaseModel]
+    ) -> list[BaseModel]:
         """
         Serialize records (flattening, type conversion) before DataFrame creation.
 
@@ -111,7 +113,7 @@ class BatchAdapterABC(Protocol):
     into the expected list[RawRecord] format.
     """
 
-    def process_batch(self, raw_batch: Any) -> list["RawRecord"]:
+    def process_batch(self, raw_batch: object) -> list["RawRecord"]:
         """
         Normalize a batch into a list of raw record mappings.
 

--- a/src/bioetl/domain/record_source.py
+++ b/src/bioetl/domain/record_source.py
@@ -3,18 +3,18 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Any, Callable, TypedDict
+from typing import Any, Callable
 
+from pydantic import BaseModel, ConfigDict
 from typing_extensions import Protocol
 
 from bioetl.domain.ports.extraction import ExtractionServiceABC
 
 
-class RawRecord(TypedDict, total=False):
-    """Raw record type before normalization."""
+class RawRecord(BaseModel):
+    """Raw record model before normalization."""
 
-    # Arbitrary key/value mapping for raw provider payloads
-    ...
+    model_config = ConfigDict(extra="allow")
 
 
 class RecordSource(Protocol):

--- a/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
@@ -4,13 +4,14 @@ Implementation of ChemblExtractionService.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING, Iterable
 
 from bioetl.domain.clients.contracts import DataClientABC
 from bioetl.domain.observability.contracts import LoggingPortABC
 from bioetl.domain.ports.extraction import ExtractionServiceABC
 from bioetl.domain.ports.providers import DefaultFieldProviderABC
 from bioetl.infrastructure.observability.factories import default_logging_port
+from bioetl.infrastructure.clients.chembl.models import ActivityRawModel
 
 if TYPE_CHECKING:
     from bioetl.domain.record_source import RawRecord
@@ -60,8 +61,8 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC):
         return self._version_cache
 
     def _attach_entity_fields(
-        self, entity: str, filters: dict[str, Any]
-    ) -> dict[str, Any]:
+        self, entity: str, filters: dict[str, object]
+    ) -> dict[str, object]:
         """Attach default fields to filters if configured."""
         if not self.field_provider:
             return filters
@@ -79,7 +80,7 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC):
 
         return new_filters
 
-    def extract_all(self, entity: str, **filters: Any) -> list[RawRecord]:
+    def extract_all(self, entity: str, **filters: object) -> list[RawRecord]:
         """
         Extract all records for an entity matching the filters.
 
@@ -96,7 +97,7 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC):
         return records
 
     def iter_extract(
-        self, entity: str, *, chunk_size: int | None = None, **filters: Any
+        self, entity: str, *, chunk_size: int | None = None, **filters: object
     ) -> Iterable[list[RawRecord]]:
         """Stream records from ChEMBL."""
         if chunk_size is None:
@@ -160,7 +161,7 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC):
         filters = {filter_key: ",".join(batch_ids), "limit": len(batch_ids)}
         return self.client.fetch(entity, **filters)
 
-    def parse_response(self, raw_response: dict[str, Any]) -> list[dict[str, Any]]:
+    def parse_response(self, raw_response: dict[str, object]) -> list[ActivityRawModel]:
         """
         Parse raw response into a list of records.
 
@@ -177,12 +178,12 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC):
         # Fallback simple parsing
         for value in raw_response.values():
             if isinstance(value, list):
-                return value
+                return [ActivityRawModel.model_validate(item) for item in value]
         return []
 
     def serialize_records(
-        self, entity: str, records: list[dict[str, Any]]
-    ) -> list[dict[str, Any]]:
+        self, entity: str, records: list[ActivityRawModel]
+    ) -> list[ActivityRawModel]:
         """
         Serialize records for storage.
 

--- a/src/bioetl/infrastructure/clients/chembl/models.py
+++ b/src/bioetl/infrastructure/clients/chembl/models.py
@@ -1,0 +1,76 @@
+"""Typed raw models for ChEMBL payloads."""
+
+from __future__ import annotations
+
+from typing import TypeAlias
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from bioetl.domain.record_source import RawRecord
+
+ScalarValue: TypeAlias = str | int | float | bool | None
+JsonValue: TypeAlias = ScalarValue | dict[str, ScalarValue | list[ScalarValue]] | list[
+    ScalarValue | dict[str, ScalarValue]
+]
+JsonObject: TypeAlias = dict[str, ScalarValue | list[ScalarValue] | dict[str, ScalarValue]]
+
+
+class ActivityRawModel(RawRecord):
+    """Raw ChEMBL activity payload."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    action_type: str | None = None
+    activity_comment: str | None = None
+    activity_id: str
+    activity_properties: list[JsonObject] | None = None
+    assay_chembl_id: str | None = None
+    assay_description: str | None = None
+    assay_type: str | None = None
+    assay_variant_accession: str | None = None
+    assay_variant_mutation: str | None = None
+    bao_endpoint: str | None = None
+    bao_format: str | None = None
+    bao_label: str | None = None
+    canonical_smiles: str | None = None
+    data_validity_comment: str | None = None
+    data_validity_description: str | None = None
+    document_chembl_id: str | None = None
+    document_journal: str | None = None
+    document_year: int | None = None
+    ligand_efficiency: JsonObject | None = None
+    molecule_chembl_id: str | None = None
+    molecule_pref_name: str | None = None
+    parent_molecule_chembl_id: str | None = None
+    pchembl_value: float | None = None
+    potential_duplicate: bool | None = None
+    qudt_units: str | None = None
+    record_id: int | None = None
+    relation: str | None = None
+    src_id: int | None = None
+    standard_flag: bool
+    standard_relation: str | None = None
+    standard_text_value: str | None = None
+    standard_type: str | None = None
+    standard_units: str | None = None
+    standard_upper_value: float | None = None
+    standard_value: float | None = None
+    target_chembl_id: str | None = None
+    target_organism: str | None = None
+    target_pref_name: str | None = None
+    target_tax_id: int | None = None
+    text_value: str | None = None
+    toid: str | None = None
+    type: str | None = None
+    units: str | None = None
+    uo_units: str | None = None
+    upper_value: float | None = None
+    value: float | None = None
+
+    @field_validator("activity_id", mode="before")
+    @classmethod
+    def _stringify_activity_id(cls, value: str | int) -> str:
+        return str(value)
+
+
+__all__ = ["ActivityRawModel", "JsonValue", "JsonObject", "ScalarValue"]

--- a/src/bioetl/infrastructure/clients/chembl/response_parser.py
+++ b/src/bioetl/infrastructure/clients/chembl/response_parser.py
@@ -1,25 +1,30 @@
 """Response parser for ChEMBL API responses."""
 
-from typing import Any
+from pydantic import TypeAdapter
 
 from bioetl.domain.clients.base.contracts import ResponseParserABC
+from bioetl.infrastructure.clients.chembl.models import ActivityRawModel
 
 
-class ChemblResponseParserImpl(ResponseParserABC):
+class ChemblResponseParserImpl(ResponseParserABC[ActivityRawModel]):
     """
     Парсер ответов ChEMBL API.
     """
 
-    def parse_response(self, raw_response: dict[str, Any]) -> list[dict[str, Any]]:
-        """Extract main payload list from ChEMBL response."""
+    def parse_response(self, raw_response: dict[str, object]) -> list[ActivityRawModel]:
+        """Extract and validate activity payloads from ChEMBL response."""
         # ChEMBL responses are usually { "activities": [...], "page_meta": ... }
         # We need to find the list key.
         # Heuristic: find the key that holds a list of dicts.
         for key, value in raw_response.items():
             if isinstance(value, list) and (not value or isinstance(value[0], dict)):
-                return value
+                return [ActivityRawModel.model_validate(item) for item in value]
         return []
 
-    def extract_metadata(self, raw_response: dict[str, Any]) -> dict[str, Any]:
+    def extract_metadata(self, raw_response: dict[str, object]) -> dict[str, int | str | None]:
         """Return pagination metadata section from response."""
-        return raw_response.get("page_meta", {})
+        adapter: TypeAdapter[dict[str, int | str | None]] = TypeAdapter(
+            dict[str, int | str | None]
+        )
+        page_meta = raw_response.get("page_meta", {})
+        return adapter.validate_python(page_meta)

--- a/src/bioetl/infrastructure/transform/impl/chembl_normalization_service_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/chembl_normalization_service_impl.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, TypedDict, cast
 
 import pandas as pd
+from pydantic import BaseModel
 
 from bioetl.domain.record_source import RawRecord
 from bioetl.domain.transform.contracts import (
@@ -34,10 +35,17 @@ class ChemblNormalizationServiceImpl(
     def apply_normalize(self, raw: RawRecord | pd.Series) -> NormalizedRecord:
         """Normalize single raw ChEMBL record into flat dict."""
         normalized: dict[str, Any] = {}
+        raw_data: dict[str, Any]
+        if isinstance(raw, BaseModel):
+            raw_data = raw.model_dump()
+        elif isinstance(raw, pd.Series):
+            raw_data = raw.to_dict()
+        else:
+            raw_data = cast(dict[str, Any], raw.model_dump())
 
         for field_cfg in self._iter_fields():
             name = field_cfg.get("name")
-            if not isinstance(name, str) or name not in raw:
+            if not isinstance(name, str) or name not in raw_data:
                 continue
 
             dtype = field_cfg.get("data_type")
@@ -53,7 +61,7 @@ class ChemblNormalizationServiceImpl(
 
                 base_normalizer = _default_normalizer
 
-            value = raw.get(name)
+            value = raw_data.get(name)
             normalized[name] = self._normalize_value(
                 value,
                 dtype,
@@ -62,7 +70,7 @@ class ChemblNormalizationServiceImpl(
                 allow_container_normalizer=True,
             )
 
-        for key, value in raw.items():
+        for key, value in raw_data.items():
             key_str = cast(str, key)
             if key_str not in normalized:
                 normalized[key_str] = value

--- a/tests/bioetl/application/pipelines/chembl/activity/test_extract.py
+++ b/tests/bioetl/application/pipelines/chembl/activity/test_extract.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pytest
 
 from bioetl.application.pipelines.chembl.base import ChemblPipelineBase
+from bioetl.infrastructure.clients.chembl.models import ActivityRawModel
 from bioetl.infrastructure.config.models import (
     ChemblSourceConfig,
     ClientConfig,
@@ -185,9 +186,9 @@ def test_extract_ids_only_csv(
     # Mock parse_response to return records only once
     # One batch covers all ids (batch_size=25 > 3), parse called once
     mock_extraction_service.parse_response.return_value = [
-        {"activity_id": 100},
-        {"activity_id": 101},
-        {"activity_id": 102},
+        ActivityRawModel(activity_id="100", standard_flag=True),
+        ActivityRawModel(activity_id="101", standard_flag=True),
+        ActivityRawModel(activity_id="102", standard_flag=True),
     ]
 
     # Mock serialize_records to return input

--- a/tests/bioetl/application/pipelines/chembl/test_extraction.py
+++ b/tests/bioetl/application/pipelines/chembl/test_extraction.py
@@ -11,6 +11,7 @@ from bioetl.domain.clients.contracts import DataClientABC
 from bioetl.infrastructure.clients.chembl.impl.chembl_extraction_service_impl import (
     ChemblExtractionServiceImpl,
 )
+from bioetl.infrastructure.clients.chembl.models import ActivityRawModel
 
 
 @pytest.fixture
@@ -50,14 +51,17 @@ def test_extract_all_single_page(service, mock_client):
     # Setup mock responses
     # iter_pages yields raw page data
     mock_client.iter_pages.return_value = [{"data": "page1"}]
-    mock_parser.parse_response.return_value = [{"id": 1}, {"id": 2}]
+    mock_parser.parse_response.return_value = [
+        ActivityRawModel(activity_id="1", standard_flag=True),
+        ActivityRawModel(activity_id="2", standard_flag=False),
+    ]
 
     # Act
     records = service.extract_all("activity")
 
     # Assert
     assert len(records) == 2
-    assert records[0]["id"] == 1
+    assert records[0].activity_id == "1"
     # Verify iter_pages called with URL from builder
     mock_client.iter_pages.assert_called_once_with("http://mock-url")
     # Verify builder used correct limit
@@ -75,7 +79,13 @@ def test_extract_all_pagination(service, mock_client):
 
     # Setup iteration
     mock_client.iter_pages.return_value = [{"data": "page1"}, {"data": "page2"}]
-    mock_parser.parse_response.side_effect = [[{"id": 1}, {"id": 2}], [{"id": 3}]]
+    mock_parser.parse_response.side_effect = [
+        [
+            ActivityRawModel(activity_id="1", standard_flag=True),
+            ActivityRawModel(activity_id="2", standard_flag=True),
+        ],
+        [ActivityRawModel(activity_id="3", standard_flag=True)],
+    ]
 
     # Act
     records = service.extract_all("activity")
@@ -95,17 +105,18 @@ def test_extract_all_serializes_nested_fields(service, mock_client):
 
     mock_client.iter_pages.return_value = [{"data": "page"}]
     mock_parser.parse_response.return_value = [
-        {
-            "id": 1,
-            "activity_properties": [{"k1": "v1"}, {"k2": "v2"}],
-            "ligand_efficiency": {"le": 1.1},
-        }
+        ActivityRawModel(
+            activity_id="1",
+            standard_flag=True,
+            activity_properties=[{"k1": "v1"}, {"k2": "v2"}],
+            ligand_efficiency={"le": 1.1},
+        )
     ]
 
     records = service.extract_all("activity")
 
-    assert records[0]["activity_properties"] == [{"k1": "v1"}, {"k2": "v2"}]
-    assert records[0]["ligand_efficiency"] == {"le": 1.1}
+    assert records[0].activity_properties == [{"k1": "v1"}, {"k2": "v2"}]
+    assert records[0].ligand_efficiency == {"le": 1.1}
 
 
 def test_extract_all_limit(service, mock_client):
@@ -118,7 +129,9 @@ def test_extract_all_limit(service, mock_client):
 
     # Returns 10 items per call
     mock_client.iter_pages.return_value = [{"data": "page"}]
-    mock_parser.parse_response.return_value = [{"id": i} for i in range(10)]
+    mock_parser.parse_response.return_value = [
+        ActivityRawModel(activity_id=str(i), standard_flag=True) for i in range(10)
+    ]
 
     # Act - request limit 5 (which acts as chunk_size in current impl)
     records = service.extract_all("activity", limit=5)
@@ -160,8 +173,11 @@ def test_iter_extract_respects_limit_with_pagination(service, mock_client):
         {"data": "page2"},
     ]
     mock_parser.parse_response.side_effect = [
-        [{"id": 1}, {"id": 2}],
-        [{"id": 3}],
+        [
+            ActivityRawModel(activity_id="1", standard_flag=True),
+            ActivityRawModel(activity_id="2", standard_flag=True),
+        ],
+        [ActivityRawModel(activity_id="3", standard_flag=True)],
     ]
 
     # chunk_size=2 used for limit

--- a/tests/bioetl/domain/test_record_source.py
+++ b/tests/bioetl/domain/test_record_source.py
@@ -21,8 +21,8 @@ class _DummyExtractionService:
     ) -> Iterable[list[RawRecord]]:  # type: ignore[override]
         self.called_with = {"entity": entity, **filters, "chunk_size": chunk_size}
         records = [
-            {"id": "1", "name": "alpha"},
-            {"id": "2", "name": "beta"},
+            RawRecord.model_validate({"id": "1", "name": "alpha"}),
+            RawRecord.model_validate({"id": "2", "name": "beta"}),
         ]
         if chunk_size is None or chunk_size <= 0:
             yield records
@@ -50,8 +50,8 @@ class _DummyExtractionService:
 
 def test_in_memory_record_source_iterates_stably() -> None:
     records: list[RawRecord] = [
-        cast(RawRecord, {"id": "1", "value": "a"}),
-        cast(RawRecord, {"id": "2", "value": "b"}),
+        RawRecord.model_validate({"id": "1", "value": "a"}),
+        RawRecord.model_validate({"id": "2", "value": "b"}),
     ]
     source = InMemoryRecordSource(records)
 
@@ -80,7 +80,7 @@ def test_api_record_source_returns_serialized_records() -> None:
     }
     assert len(records) == 1
     expected_records = [
-        {"id": "1", "name": "alpha"},
-        {"id": "2", "name": "beta"},
+        RawRecord.model_validate({"id": "1", "name": "alpha"}),
+        RawRecord.model_validate({"id": "2", "name": "beta"}),
     ]
     assert records[0] == expected_records

--- a/tests/bioetl/infrastructure/clients/chembl/test_response_parser.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_response_parser.py
@@ -1,3 +1,8 @@
+import pytest
+
+from pydantic import ValidationError
+
+from bioetl.infrastructure.clients.chembl.models import ActivityRawModel
 from bioetl.infrastructure.clients.chembl.response_parser import (
     ChemblResponseParserImpl,
 )
@@ -5,10 +10,17 @@ from bioetl.infrastructure.clients.chembl.response_parser import (
 
 def test_parse_activities():
     parser = ChemblResponseParserImpl()
-    response = {"activities": [{"id": 1}, {"id": 2}], "page_meta": {"limit": 20}}
+    response = {
+        "activities": [
+            {"activity_id": "1", "standard_flag": True},
+            {"activity_id": "2", "standard_flag": False},
+        ],
+        "page_meta": {"limit": 20},
+    }
     records = parser.parse_response(response)
     assert len(records) == 2
-    assert records[0]["id"] == 1
+    assert isinstance(records[0], ActivityRawModel)
+    assert records[0].activity_id == "1"
 
 
 def test_parse_empty():
@@ -16,6 +28,14 @@ def test_parse_empty():
     response = {"page_meta": {}}
     records = parser.parse_response(response)
     assert records == []
+
+
+def test_parse_invalid_payload():
+    parser = ChemblResponseParserImpl()
+    response = {"activities": [{"activity_id": 1}]}
+
+    with pytest.raises(ValidationError):
+        parser.parse_response(response)
 
 
 def test_extract_metadata():

--- a/tests/bioetl/infrastructure/files/test_csv_record_source.py
+++ b/tests/bioetl/infrastructure/files/test_csv_record_source.py
@@ -5,6 +5,7 @@ import pandas as pd
 from pydantic import AnyHttpUrl
 
 from bioetl.domain.ports.extraction import ExtractionServiceABC
+from bioetl.infrastructure.clients.chembl.models import ActivityRawModel
 from bioetl.infrastructure.config.models import (
     ChemblSourceConfig,
     ClientConfig,
@@ -29,12 +30,19 @@ class _StubExtractionService:
 
     def request_batch(self, entity: str, batch_ids: list[str], filter_key: str):
         self.batches.append(batch_ids)
-        return {"records": [{"id": value} for value in batch_ids]}
+        return {
+            "records": [
+                {"activity_id": value, "standard_flag": True}
+                for value in batch_ids
+            ]
+        }
 
     def parse_response(self, raw_response: dict[str, list[dict[str, str]]]):
-        return raw_response["records"]
+        return [ActivityRawModel.model_validate(item) for item in raw_response["records"]]
 
-    def serialize_records(self, entity: str, records: list[dict[str, str]]):
+    def serialize_records(
+        self, entity: str, records: list[ActivityRawModel]
+    ) -> list[ActivityRawModel]:
         return records
 
 
@@ -57,21 +65,25 @@ class _DummyLogger(LoggingPortABC):
 
 def test_csv_record_source_reads_dataset(tmp_path: Path) -> None:
     csv_path = tmp_path / "dataset.csv"
-    pd.DataFrame([{"id": 1, "name": "alpha"}, {"id": 2, "name": "beta"}]).to_csv(
-        csv_path, index=False
-    )
+    pd.DataFrame(
+        [
+            {"activity_id": "1", "standard_flag": True},
+            {"activity_id": "2", "standard_flag": False},
+        ]
+    ).to_csv(csv_path, index=False)
 
     source = CsvRecordSourceImpl(
         input_path=csv_path,
         csv_options=CsvInputConfig(),
         limit=1,
         logger=cast(LoggingPortABC, _DummyLogger()),
+        model_cls=ActivityRawModel,
     )
 
     chunks = list(source.iter_records())
 
     assert len(chunks) == 1
-    expected = [{"id": 1, "name": "alpha"}]
+    expected = [ActivityRawModel(activity_id="1", standard_flag=True)]
     assert chunks[0] == expected
 
 
@@ -109,5 +121,9 @@ def test_id_list_record_source_fetches_batches(tmp_path: Path) -> None:
     assert extraction.batches == [["A1", "A2"], ["A3"]]
     assert len(records) == 2
     combined = [record for batch in records for record in batch]
-    expected = [{"id": "A1"}, {"id": "A2"}, {"id": "A3"}]
+    expected = [
+        ActivityRawModel(activity_id="A1", standard_flag=True),
+        ActivityRawModel(activity_id="A2", standard_flag=True),
+        ActivityRawModel(activity_id="A3", standard_flag=True),
+    ]
     assert combined == expected


### PR DESCRIPTION
## Summary
- add a typed `ActivityRawModel` for ChEMBL payloads and propagate it through the extraction and parsing layers
- update record sources, batch adapter, and normalization to work with Pydantic models instead of untyped dicts
- extend tests to validate model parsing and to cover the new typed pipelines

## Testing
- pytest tests/bioetl/infrastructure/clients/chembl/test_response_parser.py tests/bioetl/infrastructure/files/test_csv_record_source.py tests/bioetl/application/pipelines/chembl/test_extraction.py tests/bioetl/domain/test_record_source.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937f2fcc9e0832488d008f62a1ebdc9)