### PR TITLE
Add Prometheus metrics integration for infrastructure

### DIFF
--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -391,6 +391,8 @@ def _create_noop_metrics_port() -> PipelineMetricsPortABC:
     return cast(
         PipelineMetricsPortABC,
         SimpleNamespace(
+            inc_counter=lambda *_args, **_kwargs: None,
+            observe_histogram=lambda *_args, **_kwargs: None,
             update_stage_duration=lambda **_kwargs: None,
             update_stage_total=lambda **_kwargs: None,
         ),

--- a/src/bioetl/application/pipelines/hooks_impl.py
+++ b/src/bioetl/application/pipelines/hooks_impl.py
@@ -136,6 +136,8 @@ def _create_noop_metrics_port() -> PipelineMetricsPortABC:
     return cast(
         PipelineMetricsPortABC,
         SimpleNamespace(
+            inc_counter=lambda *_args, **_kwargs: None,
+            observe_histogram=lambda *_args, **_kwargs: None,
             update_stage_duration=lambda **_kwargs: None,
             update_stage_total=lambda **_kwargs: None,
         ),

--- a/src/bioetl/domain/observability/__init__.py
+++ b/src/bioetl/domain/observability/__init__.py
@@ -2,6 +2,7 @@
 
 from bioetl.domain.observability.contracts import (
     LoggingPortABC,
+    MetricsPortABC,
     PipelineMetricsPortABC,
     ProgressReporterABC,
     TracingPortABC,
@@ -9,6 +10,7 @@ from bioetl.domain.observability.contracts import (
 
 __all__ = [
     "LoggingPortABC",
+    "MetricsPortABC",
     "PipelineMetricsPortABC",
     "TracingPortABC",
     "ProgressReporterABC",

--- a/src/bioetl/domain/observability/contracts.py
+++ b/src/bioetl/domain/observability/contracts.py
@@ -52,7 +52,19 @@ class TracingPortABC(ABC):
         """Inject tracing context into headers."""
 
 
-class PipelineMetricsPortABC(ABC):
+class MetricsPortABC(ABC):
+    """Port for recording generic metrics across infrastructure components."""
+
+    @abstractmethod
+    def inc_counter(self, name: str, labels: dict[str, str]) -> None:
+        """Increment a named counter with provided labels."""
+
+    @abstractmethod
+    def observe_histogram(self, name: str, value: float, labels: dict[str, str]) -> None:
+        """Observe a numeric value for a named histogram metric."""
+
+
+class PipelineMetricsPortABC(MetricsPortABC):
     """Port for recording pipeline stage metrics."""
 
     @abstractmethod
@@ -117,6 +129,7 @@ class ProgressReporterABC(ABC):
 __all__ = [
     "LoggingPortABC",
     "TracingPortABC",
+    "MetricsPortABC",
     "PipelineMetricsPortABC",
     "ProgressReporterABC",
 ]

--- a/src/bioetl/infrastructure/clients/base/factories.py
+++ b/src/bioetl/infrastructure/clients/base/factories.py
@@ -19,7 +19,7 @@ from bioetl.domain.configs import (
     HttpClientDefaults,
     HttpClientSettings,
 )
-from bioetl.domain.observability import LoggingPortABC
+from bioetl.domain.observability import LoggingPortABC, MetricsPortABC
 from bioetl.infrastructure.clients.base.impl.cache import MemoryCacheImpl
 from bioetl.infrastructure.clients.base.impl.rate_limiter import (
     TokenBucketRateLimiterImpl,
@@ -165,6 +165,7 @@ def default_api_client(
     *,
     base_client: Any | None = None,
     logger: LoggingPortABC | None = None,
+    metrics: MetricsPortABC | None = None,
 ) -> ApiClientABC:
     """Create the default API client without middleware indirection."""
 
@@ -173,6 +174,7 @@ def default_api_client(
         client_config=config,
         base_client=base_client,
         logger=logger,
+        metrics=metrics,
     )
 
 
@@ -184,6 +186,7 @@ def build_http_client(
     defaults: HttpClientDefaults | None = None,
     base_client: Any | None = None,
     logger: LoggingPortABC | None = None,
+    metrics: MetricsPortABC | None = None,
 ) -> ApiClientABC:
     """Construct HTTP client using centralized defaults."""
 
@@ -197,6 +200,7 @@ def build_http_client(
         config=resolved_config,
         base_client=base_client,
         logger=logger,
+        metrics=metrics,
     )
 
 

--- a/src/bioetl/infrastructure/clients/base/impl/unified_api_client_impl.py
+++ b/src/bioetl/infrastructure/clients/base/impl/unified_api_client_impl.py
@@ -12,9 +12,12 @@ import requests
 
 from bioetl.domain.clients.base.contracts import ApiClientABC
 from bioetl.domain.configs import ClientConfig
-from bioetl.domain.observability import LoggingPortABC
-from bioetl.infrastructure.errors import wrap_http_errors
-from bioetl.infrastructure.observability.factories import default_logging_port
+from bioetl.domain.observability import LoggingPortABC, MetricsPortABC
+from bioetl.infrastructure.errors import ApiTimeoutError, wrap_http_errors
+from bioetl.infrastructure.observability.factories import (
+    default_logging_port,
+    default_metrics_port,
+)
 
 
 class UnifiedAPIClientImpl(ApiClientABC):
@@ -30,11 +33,13 @@ class UnifiedAPIClientImpl(ApiClientABC):
         base_client: Any | None = None,
         *,
         logger: LoggingPortABC | None = None,
+        metrics: MetricsPortABC | None = None,
     ) -> None:
         self.provider = provider
         self.config = config
         self.base_client = base_client or requests.Session()
         self.logger = logger or default_logging_port()
+        self.metrics = metrics or default_metrics_port()
         self.logger.info(
             "http_client_initialized",
             provider=self.provider,
@@ -46,32 +51,45 @@ class UnifiedAPIClientImpl(ApiClientABC):
 
     def request_call(self, method: str, url: str, **kwargs: Any) -> Any:
         """Выполнить HTTP-запрос с настройками клиента."""
-        with wrap_http_errors(
-            provider=self.provider, endpoint=url, logger=self.logger
-        ) as context:
-            method_upper = method.upper()
-            if method_upper in {"POST", "PUT", "PATCH", "DELETE"}:
-                headers = dict(kwargs.get("headers") or {})
-                headers.setdefault("Idempotency-Key", str(uuid4()))
-                kwargs["headers"] = headers
+        start = time.monotonic()
+        status_label = "unknown"
 
-            timeout = kwargs.pop("timeout", self.config.timeout_sec)
-            start = time.monotonic()
-            response = self.base_client.request(
-                method=method, url=url, timeout=timeout, **kwargs
-            )
+        try:
+            with wrap_http_errors(
+                provider=self.provider, endpoint=url, logger=self.logger
+            ) as context:
+                method_upper = method.upper()
+                if method_upper in {"POST", "PUT", "PATCH", "DELETE"}:
+                    headers = dict(kwargs.get("headers") or {})
+                    headers.setdefault("Idempotency-Key", str(uuid4()))
+                    kwargs["headers"] = headers
+
+                timeout = kwargs.pop("timeout", self.config.timeout_sec)
+                response = self.base_client.request(
+                    method=method, url=url, timeout=timeout, **kwargs
+                )
+                raw_status = getattr(response, "status_code", None)
+                context["status_code"] = (
+                    raw_status if isinstance(raw_status, int) else None
+                )
+                status_label = self._normalize_status(context["status_code"])
+                self.logger.info(
+                    "http_request_completed",
+                    provider=self.provider,
+                    method=method_upper,
+                    url=url,
+                    status_code=context["status_code"],
+                    latency_sec=time.monotonic() - start,
+                )
+                return response
+        except Exception as exc:
+            status_label = self._status_from_exception(status_label, exc)
+            self._record_error(url, status_label)
+            raise
+        finally:
             latency = time.monotonic() - start
-            raw_status = getattr(response, "status_code", None)
-            context["status_code"] = raw_status if isinstance(raw_status, int) else None
-            self.logger.info(
-                "http_request_completed",
-                provider=self.provider,
-                method=method_upper,
-                url=url,
-                status_code=context["status_code"],
-                latency_sec=latency,
-            )
-            return response
+            self._observe_latency(url, latency, status_label)
+            self._record_total(url, status_label)
 
     def request(self, method: str, url: str, **kwargs: Any) -> Any:
         """Execute a request using the configured HTTP client."""
@@ -89,3 +107,41 @@ class UnifiedAPIClientImpl(ApiClientABC):
         """Закрыть соединение."""
         if hasattr(self.base_client, "close"):
             self.base_client.close()
+
+    def _record_total(self, endpoint: str, status: str) -> None:
+        if not self.metrics:
+            return
+
+        self.metrics.inc_counter(
+            "client_request_total",
+            {"provider": self.provider, "endpoint": endpoint, "status": status},
+        )
+
+    def _observe_latency(self, endpoint: str, latency: float, status: str) -> None:
+        if not self.metrics:
+            return
+
+        self.metrics.observe_histogram(
+            "client_request_duration_seconds",
+            latency,
+            {"provider": self.provider, "endpoint": endpoint, "status": status},
+        )
+
+    def _record_error(self, endpoint: str, status: str) -> None:
+        if not self.metrics:
+            return
+
+        self.metrics.inc_counter(
+            "client_request_errors",
+            {"provider": self.provider, "endpoint": endpoint, "status": status},
+        )
+
+    def _normalize_status(self, status_code: int | None) -> str:
+        if status_code is None:
+            return "unknown"
+        return str(status_code)
+
+    def _status_from_exception(self, current_status: str, exc: Exception) -> str:
+        if isinstance(exc, ApiTimeoutError) or isinstance(exc, requests.Timeout):
+            return "timeout"
+        return exc.__class__.__name__ or current_status

--- a/src/bioetl/infrastructure/observability/__init__.py
+++ b/src/bioetl/infrastructure/observability/__init__.py
@@ -1,17 +1,21 @@
 """Observability adapters and default factory exports."""
 
 from bioetl.infrastructure.observability.adapters import (
+    PrometheusMetricsPortImpl,
     StructuredLoggerImpl,
     TracingAdapterImpl,
 )
 from bioetl.infrastructure.observability.factories import (
     default_logging_port,
+    default_metrics_port,
     default_tracing_port,
 )
 
 __all__ = [
     "StructuredLoggerImpl",
+    "PrometheusMetricsPortImpl",
     "TracingAdapterImpl",
     "default_logging_port",
+    "default_metrics_port",
     "default_tracing_port",
 ]

--- a/src/bioetl/infrastructure/observability/adapters.py
+++ b/src/bioetl/infrastructure/observability/adapters.py
@@ -7,7 +7,13 @@ from typing import Any, Self
 import structlog
 from structlog.stdlib import BoundLogger
 
-from bioetl.interfaces.observability import LoggingPortABC, TracingPortABC
+from bioetl.infrastructure.observability import metrics
+from bioetl.interfaces.observability import (
+    LoggingPortABC,
+    MetricsPortABC,
+    PipelineMetricsPortABC,
+    TracingPortABC,
+)
 
 
 class StructuredLoggerImpl(LoggingPortABC):
@@ -57,5 +63,71 @@ class TracingAdapterImpl(TracingPortABC):
 
 __all__ = [
     "StructuredLoggerImpl",
+    "PrometheusMetricsPortImpl",
     "TracingAdapterImpl",
 ]
+
+
+class PrometheusMetricsPortImpl(PipelineMetricsPortABC):
+    """Prometheus-backed implementation of the metrics port."""
+
+    def __init__(self) -> None:
+        self._counters: dict[str, Any] = {
+            "client_request_total": metrics.CLIENT_REQUEST_TOTAL,
+            "client_request_errors": metrics.CLIENT_REQUEST_ERRORS,
+            "output_write_errors_total": metrics.OUTPUT_WRITE_ERRORS_TOTAL,
+        }
+        self._histograms: dict[str, Any] = {
+            "client_request_duration_seconds": metrics.CLIENT_REQUEST_DURATION_SECONDS,
+        }
+
+    def inc_counter(self, name: str, labels: dict[str, str]) -> None:
+        """Increment counter by name using provided labels."""
+
+        counter = self._counters.get(name)
+        if counter is None:
+            raise KeyError(f"Unknown counter metric '{name}'")
+        counter.labels(**labels).inc()
+
+    def observe_histogram(self, name: str, value: float, labels: dict[str, str]) -> None:
+        """Record observation for histogram by name."""
+
+        histogram = self._histograms.get(name)
+        if histogram is None:
+            raise KeyError(f"Unknown histogram metric '{name}'")
+        histogram.labels(**labels).observe(value)
+
+    def update_stage_duration(
+        self,
+        *,
+        pipeline: str,
+        provider: str,
+        entity: str,
+        stage: str,
+        outcome: str,
+        duration_sec: float,
+    ) -> None:
+        metrics.STAGE_DURATION_SECONDS.labels(
+            pipeline=pipeline,
+            provider=provider,
+            entity=entity,
+            stage=stage,
+            outcome=outcome,
+        ).observe(duration_sec)
+
+    def update_stage_total(
+        self,
+        *,
+        pipeline: str,
+        provider: str,
+        entity: str,
+        stage: str,
+        outcome: str,
+    ) -> None:
+        metrics.STAGE_TOTAL.labels(
+            pipeline=pipeline,
+            provider=provider,
+            entity=entity,
+            stage=stage,
+            outcome=outcome,
+        ).inc()

--- a/src/bioetl/infrastructure/observability/factories.py
+++ b/src/bioetl/infrastructure/observability/factories.py
@@ -5,10 +5,15 @@ from __future__ import annotations
 import structlog
 
 from bioetl.infrastructure.observability.adapters import (
+    PrometheusMetricsPortImpl,
     StructuredLoggerImpl,
     TracingAdapterImpl,
 )
-from bioetl.interfaces.observability import LoggingPortABC, TracingPortABC
+from bioetl.interfaces.observability import (
+    LoggingPortABC,
+    MetricsPortABC,
+    TracingPortABC,
+)
 
 
 def _configure_structlog() -> None:
@@ -34,7 +39,14 @@ def default_tracing_port() -> TracingPortABC:
     return TracingAdapterImpl()
 
 
+def default_metrics_port() -> MetricsPortABC:
+    """Create Prometheus-backed metrics port."""
+
+    return PrometheusMetricsPortImpl()
+
+
 __all__ = [
     "default_logging_port",
+    "default_metrics_port",
     "default_tracing_port",
 ]

--- a/src/bioetl/infrastructure/observability/metrics.py
+++ b/src/bioetl/infrastructure/observability/metrics.py
@@ -7,6 +7,10 @@ __all__ = [
     "STAGE_TOTAL",
     "HTTP_REQUESTS_TOTAL",
     "HTTP_LATENCY_SECONDS",
+    "CLIENT_REQUEST_TOTAL",
+    "CLIENT_REQUEST_DURATION_SECONDS",
+    "CLIENT_REQUEST_ERRORS",
+    "OUTPUT_WRITE_ERRORS_TOTAL",
 ]
 
 STAGE_DURATION_SECONDS = Histogram(
@@ -31,4 +35,28 @@ HTTP_LATENCY_SECONDS = Histogram(
     "bioetl_http_latency_seconds",
     "HTTP request latency in seconds.",
     ["provider", "endpoint", "method", "status_class"],
+)
+
+CLIENT_REQUEST_TOTAL = Counter(
+    "client_request_total",
+    "Total client requests by provider and endpoint.",
+    ["provider", "endpoint", "status"],
+)
+
+CLIENT_REQUEST_DURATION_SECONDS = Histogram(
+    "client_request_duration_seconds",
+    "Duration of client requests in seconds.",
+    ["provider", "endpoint", "status"],
+)
+
+CLIENT_REQUEST_ERRORS = Counter(
+    "client_request_errors",
+    "Total client request errors by provider and endpoint.",
+    ["provider", "endpoint", "status"],
+)
+
+OUTPUT_WRITE_ERRORS_TOTAL = Counter(
+    "output_write_errors_total",
+    "Total number of failed output write attempts.",
+    ["entity", "error_type"],
 )

--- a/src/bioetl/infrastructure/output/factories.py
+++ b/src/bioetl/infrastructure/output/factories.py
@@ -7,6 +7,7 @@ from bioetl.domain.clients.base.output.contracts import (
     WriterABC,
 )
 from bioetl.domain.configs import DeterminismConfig, QcConfig
+from bioetl.domain.observability import MetricsPortABC
 from bioetl.infrastructure.output.impl.csv_writer import CsvWriterImpl
 from bioetl.infrastructure.output.impl.metadata_writer import MetadataWriterImpl
 from bioetl.infrastructure.output.impl.quality_report import QualityReportImpl
@@ -40,6 +41,7 @@ def default_output_writer(
     writer: WriterABC | None = None,
     metadata_writer: MetadataWriterABC | None = None,
     quality_reporter: QualityReportABC | None = None,
+    metrics_port: MetricsPortABC | None = None,
 ) -> OutputWriterABC:
     """Compose the unified output writer with optional overrides."""
 
@@ -49,4 +51,5 @@ def default_output_writer(
         quality_reporter=quality_reporter or default_quality_reporter(),
         config=config,
         qc_config=qc_config,
+        metrics=metrics_port,
     )

--- a/src/bioetl/infrastructure/output/unified_output_writer_impl.py
+++ b/src/bioetl/infrastructure/output/unified_output_writer_impl.py
@@ -13,6 +13,7 @@ from bioetl.domain.clients.base.output.contracts import (
     WriterABC,
     WriteResult,
 )
+from bioetl.domain.observability import MetricsPortABC
 from bioetl.domain.configs import DeterminismConfig, QcConfig
 from bioetl.domain.models import RunContext
 from bioetl.infrastructure.files.atomic import AtomicFileOperation
@@ -39,6 +40,7 @@ class UnifiedOutputWriterImpl(OutputWriterABC):
         config: DeterminismConfig,
         qc_config: QcConfig | None = None,
         atomic_op: AtomicFileOperation | None = None,
+        metrics: MetricsPortABC | None = None,
     ) -> None:
         self._writer = writer
         self._metadata_writer = metadata_writer
@@ -46,6 +48,7 @@ class UnifiedOutputWriterImpl(OutputWriterABC):
         self._config = config
         self._qc_config = qc_config or QcConfig()
         self._atomic_op = atomic_op or AtomicFileOperation()
+        self._metrics = metrics
 
     def write_result(
         self,
@@ -57,58 +60,62 @@ class UnifiedOutputWriterImpl(OutputWriterABC):
         column_order: list[str] | None = None,
     ) -> WriteResult:
         """Основной метод записи."""
-        output_path.mkdir(parents=True, exist_ok=True)
+        try:
+            output_path.mkdir(parents=True, exist_ok=True)
 
-        # 1. Валидация колонок (Check if strictly matches order if provided)
-        # Note: Actual schema validation happens in PipelineBase.validate()
-        # Here we ensure output structure and determinism.
-        df_prepared = apply_column_order(df, column_order)
+            # 1. Валидация колонок (Check if strictly matches order if provided)
+            # Note: Actual schema validation happens in PipelineBase.validate()
+            # Here we ensure output structure and determinism.
+            df_prepared = apply_column_order(df, column_order)
 
-        # 2. Сортировка (Determinism)
-        df_prepared = self._stable_sort(df_prepared, run_context, column_order)
+            # 2. Сортировка (Determinism)
+            df_prepared = self._stable_sort(df_prepared, run_context, column_order)
 
-        # 3. Атомарная запись
-        data_path = output_path / f"{entity_name}.csv"
+            # 3. Атомарная запись
+            data_path = output_path / f"{entity_name}.csv"
 
-        # Wrapper to capture inner write result
-        inner_result: WriteResult | None = None
+            # Wrapper to capture inner write result
+            inner_result: WriteResult | None = None
 
-        def _write_wrapper(path: Path) -> None:
-            """Write dataset to the provided path via underlying writer."""
-            nonlocal inner_result
-            inner_result = self._writer.write(
-                df_prepared, path, column_order=column_order
+            def _write_wrapper(path: Path) -> None:
+                """Write dataset to the provided path via underlying writer."""
+                nonlocal inner_result
+                inner_result = self._writer.write(
+                    df_prepared, path, column_order=column_order
+                )
+
+            self._atomic_op.write_atomic(data_path, _write_wrapper)
+
+            if inner_result is None:
+                raise RuntimeError("Inner writer did not return result")
+
+            # 4. Вычисление checksum (после записи)
+            checksum = compute_file_sha256(data_path)
+
+            final_result = WriteResult(
+                path=data_path,
+                row_count=inner_result.row_count,
+                duration_sec=inner_result.duration_sec,
+                checksum=checksum,
             )
 
-        self._atomic_op.write_atomic(data_path, _write_wrapper)
+            qc_artifacts = self._generate_qc_artifacts(df_prepared, output_path)
+            qc_checksums = {path.name: compute_file_sha256(path) for path in qc_artifacts}
 
-        if inner_result is None:
-            raise RuntimeError("Inner writer did not return result")
+            # 5. Запись метаданных
+            meta = build_run_metadata(
+                run_context,
+                final_result,
+                qc_artifacts=qc_artifacts,
+                qc_checksums=qc_checksums,
+                qc_config=self._qc_config,
+            )
+            self._metadata_writer.write_meta(meta, output_path / "meta.yaml")
 
-        # 4. Вычисление checksum (после записи)
-        checksum = compute_file_sha256(data_path)
-
-        final_result = WriteResult(
-            path=data_path,
-            row_count=inner_result.row_count,
-            duration_sec=inner_result.duration_sec,
-            checksum=checksum,
-        )
-
-        qc_artifacts = self._generate_qc_artifacts(df_prepared, output_path)
-        qc_checksums = {path.name: compute_file_sha256(path) for path in qc_artifacts}
-
-        # 5. Запись метаданных
-        meta = build_run_metadata(
-            run_context,
-            final_result,
-            qc_artifacts=qc_artifacts,
-            qc_checksums=qc_checksums,
-            qc_config=self._qc_config,
-        )
-        self._metadata_writer.write_meta(meta, output_path / "meta.yaml")
-
-        return final_result
+            return final_result
+        except Exception as exc:
+            self._record_write_error(entity_name, exc)
+            raise
 
     def _stable_sort(
         self,
@@ -171,3 +178,12 @@ class UnifiedOutputWriterImpl(OutputWriterABC):
 
         self._atomic_op.write_atomic(path, _write_qc_wrapper)
         return path
+
+    def _record_write_error(self, entity_name: str, exc: Exception) -> None:
+        if not self._metrics:
+            return
+
+        self._metrics.inc_counter(
+            "output_write_errors_total",
+            {"entity": entity_name, "error_type": exc.__class__.__name__},
+        )

--- a/src/bioetl/interfaces/container_factory.py
+++ b/src/bioetl/interfaces/container_factory.py
@@ -15,11 +15,11 @@ from bioetl.domain.observability import PipelineMetricsPortABC
 from bioetl.domain.provider_registry import ProviderRegistryABC
 from bioetl.domain.validation import ValidatorFactoryABC
 from bioetl.infrastructure.clients.base.abc_registry_resolver import ABCRegistryResolver
-from bioetl.infrastructure.observability import metrics
 from bioetl.infrastructure.output.metadata import (
     build_dry_run_metadata,
     build_run_metadata,
 )
+from bioetl.interfaces.monitoring import create_prometheus_metrics_port
 
 
 def _create_metadata_builder() -> RunMetadataBuilderProtocol:
@@ -36,28 +36,7 @@ def _create_metadata_builder() -> RunMetadataBuilderProtocol:
 def _create_metrics_port() -> PipelineMetricsPortABC:
     """Return metrics port backed by Prometheus collectors."""
 
-    def _update_duration(**kwargs: Any) -> None:
-        metrics.STAGE_DURATION_SECONDS.labels(
-            pipeline=kwargs["pipeline"],
-            provider=kwargs["provider"],
-            entity=kwargs["entity"],
-            stage=kwargs["stage"],
-            outcome=kwargs["outcome"],
-        ).observe(kwargs["duration_sec"])
-
-    return cast(
-        PipelineMetricsPortABC,
-        SimpleNamespace(
-            update_stage_duration=_update_duration,
-            update_stage_total=lambda **kwargs: metrics.STAGE_TOTAL.labels(
-                pipeline=kwargs["pipeline"],
-                provider=kwargs["provider"],
-                entity=kwargs["entity"],
-                stage=kwargs["stage"],
-                outcome=kwargs["outcome"],
-            ).inc(),
-        ),
-    )
+    return create_prometheus_metrics_port()
 
 
 def _create_validator_factory() -> ValidatorFactoryABC:
@@ -91,15 +70,16 @@ def build_default_container(
     writer = writer_factory()
     metadata_writer = metadata_writer_factory()
     quality_reporter = quality_reporter_factory()
+    metrics_port = _create_metrics_port()
     output_writer = output_writer_factory(
         config=config.determinism,
         qc_config=config.qc,
         writer=writer,
         metadata_writer=metadata_writer,
         quality_reporter=quality_reporter,
+        metrics_port=metrics_port,
     )
     metadata_builder = _create_metadata_builder()
-    metrics_port = _create_metrics_port()
     validator_factory = _create_validator_factory()
     hash_service = hash_service_factory()
 

--- a/src/bioetl/interfaces/monitoring/__init__.py
+++ b/src/bioetl/interfaces/monitoring/__init__.py
@@ -1,0 +1,19 @@
+"""Monitoring interface helpers exposing Prometheus-backed metrics ports."""
+
+from bioetl.infrastructure.observability import metrics as prometheus_metrics
+from bioetl.infrastructure.observability.factories import default_metrics_port
+from bioetl.infrastructure.observability.server import start_metrics_server_once
+from bioetl.interfaces.observability import MetricsPortABC
+
+
+def create_prometheus_metrics_port() -> MetricsPortABC:
+    """Create metrics port wired to Prometheus collectors."""
+
+    return default_metrics_port()
+
+
+__all__ = [
+    "create_prometheus_metrics_port",
+    "prometheus_metrics",
+    "start_metrics_server_once",
+]

--- a/src/bioetl/interfaces/observability/__init__.py
+++ b/src/bioetl/interfaces/observability/__init__.py
@@ -2,8 +2,14 @@
 
 from bioetl.interfaces.observability.contracts import (
     LoggingPortABC,
+    MetricsPortABC,
     PipelineMetricsPortABC,
     TracingPortABC,
 )
 
-__all__ = ["LoggingPortABC", "PipelineMetricsPortABC", "TracingPortABC"]
+__all__ = [
+    "LoggingPortABC",
+    "MetricsPortABC",
+    "PipelineMetricsPortABC",
+    "TracingPortABC",
+]

--- a/src/bioetl/interfaces/observability/contracts.py
+++ b/src/bioetl/interfaces/observability/contracts.py
@@ -7,6 +7,7 @@ live in the domain layer.
 
 from bioetl.domain.observability.contracts import (
     LoggingPortABC,
+    MetricsPortABC,
     PipelineMetricsPortABC,
     ProgressReporterABC,
     TracingPortABC,
@@ -15,6 +16,7 @@ from bioetl.domain.observability.contracts import (
 __all__ = [
     "LoggingPortABC",
     "TracingPortABC",
+    "MetricsPortABC",
     "PipelineMetricsPortABC",
     "ProgressReporterABC",
 ]

--- a/tests/bioetl/infrastructure/clients/base/test_unified_api_client_impl.py
+++ b/tests/bioetl/infrastructure/clients/base/test_unified_api_client_impl.py
@@ -1,10 +1,12 @@
 from unittest.mock import Mock
 
+from unittest.mock import Mock
+
 import pytest
 import requests
 
 from bioetl.domain.configs import ClientConfig
-from bioetl.domain.observability import LoggingPortABC
+from bioetl.domain.observability import LoggingPortABC, MetricsPortABC
 from bioetl.infrastructure.clients.base.impl.unified_api_client_impl import (
     UnifiedAPIClientImpl,
 )
@@ -15,8 +17,13 @@ def test_request_call_wraps_timeout_error() -> None:
     base_client = Mock()
     base_client.request.side_effect = requests.Timeout("timeout")
     logger = Mock(spec=LoggingPortABC)
+    metrics = Mock(spec=MetricsPortABC)
     client = UnifiedAPIClientImpl(
-        provider="chembl", config=ClientConfig(), base_client=base_client, logger=logger
+        provider="chembl",
+        config=ClientConfig(),
+        base_client=base_client,
+        logger=logger,
+        metrics=metrics,
     )
 
     with pytest.raises(ApiTimeoutError) as err:
@@ -25,13 +32,21 @@ def test_request_call_wraps_timeout_error() -> None:
     assert err.value.provider == "chembl"
     assert err.value.endpoint == "https://example.org"
     logger.error.assert_called_once()
+    metrics.inc_counter.assert_any_call(
+        "client_request_errors",
+        {"provider": "chembl", "endpoint": "https://example.org", "status": "timeout"},
+    )
 
 
 def test_request_call_wraps_request_exception() -> None:
     base_client = Mock()
     base_client.request.side_effect = requests.RequestException("boom")
+    metrics = Mock(spec=MetricsPortABC)
     client = UnifiedAPIClientImpl(
-        provider="chembl", config=ClientConfig(), base_client=base_client
+        provider="chembl",
+        config=ClientConfig(),
+        base_client=base_client,
+        metrics=metrics,
     )
 
     with pytest.raises(ApiClientError) as err:
@@ -39,3 +54,27 @@ def test_request_call_wraps_request_exception() -> None:
 
     assert err.value.provider == "chembl"
     assert err.value.endpoint == "https://example.org"
+    metrics.inc_counter.assert_any_call(
+        "client_request_errors",
+        {"provider": "chembl", "endpoint": "https://example.org", "status": "ApiClientError"},
+    )
+
+
+def test_request_records_metrics_on_success() -> None:
+    base_client = Mock()
+    response = Mock()
+    response.status_code = 200
+    base_client.request.return_value = response
+    metrics = Mock(spec=MetricsPortABC)
+    client = UnifiedAPIClientImpl(
+        provider="chembl", config=ClientConfig(), base_client=base_client, metrics=metrics
+    )
+
+    result = client.request("GET", "https://example.org")
+
+    assert result is response
+    metrics.inc_counter.assert_any_call(
+        "client_request_total",
+        {"provider": "chembl", "endpoint": "https://example.org", "status": "200"},
+    )
+    metrics.observe_histogram.assert_called_once()

--- a/tests/bioetl/infrastructure/output/test_unified_writer.py
+++ b/tests/bioetl/infrastructure/output/test_unified_writer.py
@@ -259,3 +259,36 @@ def test_write_result_raises_on_no_inner_result(
     # Act & Assert
     with pytest.raises(RuntimeError, match="Inner writer did not return result"):
         unified_writer.write_result(df, output_dir, "test_entity", run_context)
+
+
+def test_write_result_records_metric_on_failure(
+    mock_metadata_writer_fixture,
+    mock_quality_reporter,
+    mock_config_fixture,
+    mock_atomic_op,
+    run_context_factory,
+    tmp_path,
+):
+    """Failures should increment output write error metric."""
+
+    metrics = MagicMock()
+    writer = MagicMock()
+    writer.write.side_effect = ValueError("boom")
+
+    writer_impl = UnifiedOutputWriterImpl(
+        writer,
+        mock_metadata_writer_fixture,
+        mock_quality_reporter,
+        mock_config_fixture,
+        atomic_op=mock_atomic_op,
+        metrics=metrics,
+    )
+
+    with pytest.raises(ValueError):
+        writer_impl.write_result(
+            pd.DataFrame({"a": [1]}), tmp_path, "entity", run_context_factory()
+        )
+
+    metrics.inc_counter.assert_called_once_with(
+        "output_write_errors_total", {"entity": "entity", "error_type": "ValueError"}
+    )


### PR DESCRIPTION
## Summary
- expand the metrics port with counter/histogram support and expose a Prometheus-backed implementation via interfaces.monitoring
- instrument the unified HTTP client to publish request totals, durations, and errors through the metrics port
- wire metrics through output writer composition and record write failures via counters

## Testing
- pytest tests/bioetl/infrastructure/clients/base/test_unified_api_client_impl.py tests/bioetl/infrastructure/output/test_unified_writer.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69380a3dc144832488d1a4688cbb1545)