### PR TITLE
Add configurable nested serialization

### DIFF
--- a/configs/pipelines/chembl/activity.yaml
+++ b/configs/pipelines/chembl/activity.yaml
@@ -31,6 +31,9 @@ pipeline:
   description: "Extract biological activity records from ChEMBL API"
   enable_denormalization: false
 
+transform:
+  serialization_mode: pipe
+
 fields:
   - name: action_type
     data_type: string

--- a/configs/pipelines/chembl/assay.yaml
+++ b/configs/pipelines/chembl/assay.yaml
@@ -30,6 +30,9 @@ pipeline:
   owner: "Data Acquisition Team"
   description: "Extract assay records from ChEMBL API"
 
+transform:
+  serialization_mode: pipe
+
 fields:
   - name: aidx
     data_type: string

--- a/configs/pipelines/chembl/molecule.yaml
+++ b/configs/pipelines/chembl/molecule.yaml
@@ -30,6 +30,9 @@ pipeline:
   owner: bioetl-team
   description: "ChEMBL Molecules (/molecule) pipeline"
 
+transform:
+  serialization_mode: pipe
+
 fields:
   - name: atc_classifications
     data_type: array

--- a/configs/pipelines/chembl/publication.yaml
+++ b/configs/pipelines/chembl/publication.yaml
@@ -30,6 +30,9 @@ pipeline:
   owner: "Data Acquisition Team"
   description: "Extract publication records from ChEMBL API"
 
+transform:
+  serialization_mode: pipe
+
 fields:
   - name: abstract
     data_type: string

--- a/configs/pipelines/chembl/target.yaml
+++ b/configs/pipelines/chembl/target.yaml
@@ -30,6 +30,9 @@ pipeline:
   owner: "Data Acquisition Team"
   description: "Extract target records from ChEMBL API"
 
+transform:
+  serialization_mode: pipe
+
 fields:
   - name: target_chembl_id
     data_type: string

--- a/src/bioetl/application/pipelines/chembl/base.py
+++ b/src/bioetl/application/pipelines/chembl/base.py
@@ -82,6 +82,7 @@ class ChemblPipelineBase(PipelineBase):
             schema_contract=contract,
             normalization_service=norm_service,
             logger=logger,
+            serialization_mode=config.serialization_mode,
         )
 
         resolved_loader = loader

--- a/src/bioetl/application/pipelines/chembl/transformer.py
+++ b/src/bioetl/application/pipelines/chembl/transformer.py
@@ -2,7 +2,7 @@
 ChEMBL data transformer implementation.
 """
 
-from typing import Any, Sequence
+from typing import Any
 
 import pandas as pd
 
@@ -12,48 +12,7 @@ from bioetl.domain.schemas.pipeline_contracts import PipelineSchemaModel
 from bioetl.domain.transform.contracts import NormalizationServiceABC
 from bioetl.domain.transform.transformers import TransformerABC
 from bioetl.domain.validation.service import ValidationService
-
-
-def _serialize_dict(value: dict[str, Any]) -> Any:
-    """Детерминированно сериализует словарь в строку key:value|key:value."""
-    if not value:
-        return pd.NA
-
-    parts: list[str] = []
-    for key in sorted(value.keys()):
-        val = value[key]
-        if val is None or isinstance(val, (list, dict)):
-            continue
-        if val is pd.NA:
-            continue
-        parts.append(f"{key}:{val}")
-
-    return pd.NA if not parts else "|".join(parts)
-
-
-def _serialize_list(value: Sequence[Any]) -> Any:
-    """Детерминированно сериализует список или список словарей."""
-    if not value:
-        return pd.NA
-
-    if value and isinstance(value[0], dict):
-        parts = [
-            serialized
-            for serialized in (
-                _serialize_dict(item) for item in value if isinstance(item, dict)
-            )
-            if serialized is not pd.NA and serialized is not None
-        ]
-    else:
-        parts = [
-            str(item)
-            for item in value
-            if not isinstance(item, (list, dict))
-            and item is not pd.NA
-            and item is not None
-        ]
-
-    return pd.NA if not parts else "|".join(parts)
+from bioetl.infrastructure.transform.impl.serializer import serialize_nested
 
 
 class ChemblTransformerImpl(TransformerABC):
@@ -70,11 +29,14 @@ class ChemblTransformerImpl(TransformerABC):
         schema_contract: PipelineSchemaModel,
         normalization_service: NormalizationServiceABC,
         logger: LoggingPortABC,
+        *,
+        serialization_mode: str = "json",
     ) -> None:
         self.validation_service = validation_service
         self.schema_contract = schema_contract
         self.normalization_service = normalization_service
         self.logger = logger
+        self._serialization_mode = serialization_mode
 
     def apply(
         self, df: pd.DataFrame, context: RunContext | None = None
@@ -105,9 +67,11 @@ class ChemblTransformerImpl(TransformerABC):
             if value is None or value is pd.NA:
                 return pd.NA
             if isinstance(value, dict):
-                return _serialize_dict(value)
+                serialized = serialize_nested(value, mode=self._serialization_mode)
+                return pd.NA if serialized == "" else serialized
             if isinstance(value, (list, tuple)):
-                return _serialize_list(list(value))
+                serialized = serialize_nested(value, mode=self._serialization_mode)
+                return pd.NA if serialized == "" else serialized
             return value
 
         serialized = df.copy()

--- a/src/bioetl/domain/configs/__init__.py
+++ b/src/bioetl/domain/configs/__init__.py
@@ -37,6 +37,7 @@ from bioetl.domain.configs.pipeline import (
     QualityConfig,
     RuntimeConfig,
     StorageConfig,
+    TransformConfig,
 )
 from bioetl.domain.configs.profile import ProfileConfig
 
@@ -72,6 +73,7 @@ __all__ = [
     "QualityConfig",
     "RuntimeConfig",
     "QcConfig",
+    "TransformConfig",
     "StorageConfig",
     "PipelineConfig",
     "SourceDefaultsConfig",

--- a/src/bioetl/domain/configs/pipeline.py
+++ b/src/bioetl/domain/configs/pipeline.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
 # Import NormalizationConfig from the dedicated normalization module
 from bioetl.domain.configs.normalization import NormalizationConfig
+from bioetl.domain.configs.transform import TransformConfig
 
 
 class PaginationConfig(BaseModel):
@@ -448,6 +449,7 @@ class PipelineConfig(BaseModel):
     observability: ObservabilityConfig = Field(default_factory=ObservabilityConfig)
     quality: QualityConfig = Field(default_factory=QualityConfig)
     features: FeatureFlagsConfig = Field(default_factory=FeatureFlagsConfig)
+    transform: TransformConfig = Field(default_factory=TransformConfig)
 
     pipeline: dict[str, Any] = Field(default_factory=dict)
     fields: list[dict[str, Any]] = Field(default_factory=list)
@@ -597,6 +599,12 @@ class PipelineConfig(BaseModel):
         """Return normalization configuration section."""
 
         return self.quality.normalization
+
+    @property
+    def serialization_mode(self) -> str:
+        """Shortcut for transform.serialization_mode."""
+
+        return self.transform.serialization_mode
 
     def get_fields(self) -> list[dict[str, Any]]:
         """Return fields configuration."""

--- a/src/bioetl/domain/configs/transform.py
+++ b/src/bioetl/domain/configs/transform.py
@@ -1,0 +1,20 @@
+"""Transform-stage configuration models."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TransformConfig(BaseModel):
+    """Настройки стадии transform."""
+
+    serialization_mode: Literal["json", "flat", "pipe"] = Field(
+        default="json", description="Канонический формат сериализации вложенных полей"
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+__all__ = ["TransformConfig"]

--- a/src/bioetl/domain/transform/contracts.py
+++ b/src/bioetl/domain/transform/contracts.py
@@ -19,6 +19,10 @@ class NormalizationConfigProviderProtocol(Protocol):
     def get_fields(self) -> list[dict[str, Any]]:
         """Return field configuration for normalization."""
 
+    @property
+    def serialization_mode(self) -> str:
+        """Return configured serialization mode for nested structures."""
+
 
 class BaseNormalizationServiceABC(ABC):
     """

--- a/src/bioetl/infrastructure/clients/chembl/serializers.py
+++ b/src/bioetl/infrastructure/clients/chembl/serializers.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Mapping, MutableMapping, Set
 
+from bioetl.infrastructure.transform.impl.serializer import serialize_nested
+
 # Container fields that should not be flattened; they are handled later by normalizers.
 DEFAULT_BYPASS_FIELDS: Set[str] = {
     "assay_classifications",
@@ -20,34 +22,15 @@ DEFAULT_BYPASS_FIELDS: Set[str] = {
 }
 
 
-def _flatten_value(value: Any) -> Any:
+def _flatten_value(value: Any, *, mode: str = "pipe") -> Any:
     if value is None:
         return None
 
-    if isinstance(value, Mapping):
-        dict_parts = [
-            f"{key}:{_scalar_to_str(val)}"
-            for key, val in value.items()
-            if val not in (None, "")
-        ]
-        return "|".join(dict_parts) if dict_parts else None
-
-    if isinstance(value, list):
-        parts: list[str] = []
-        for item in value:
-            flattened = _flatten_value(item)
-            if flattened not in (None, ""):
-                parts.append(str(flattened))
-        return "|".join(parts) if parts else None
+    if isinstance(value, (Mapping, list)):
+        serialized = serialize_nested(value, mode=mode)
+        return None if serialized == "" else serialized
 
     return value
-
-
-def _scalar_to_str(value: Any) -> str:
-    if isinstance(value, (Mapping, list)):
-        nested = _flatten_value(value)
-        return "" if nested is None else str(nested)
-    return str(value)
 
 
 def serialize_chembl_payload(

--- a/src/bioetl/infrastructure/transform/impl/base_normalizer.py
+++ b/src/bioetl/infrastructure/transform/impl/base_normalizer.py
@@ -12,10 +12,7 @@ from bioetl.domain.transform.contracts import (
     NormalizationConfigProviderProtocol,
 )
 from bioetl.domain.transform.normalizers import normalize_array, normalize_record
-from bioetl.infrastructure.transform.impl.serializer import (
-    serialize_dict,
-    serialize_list,
-)
+from bioetl.infrastructure.transform.impl.serializer import serialize_nested
 
 
 class BaseNormalizationServiceImpl(BaseNormalizationServiceABC):
@@ -31,6 +28,8 @@ class BaseNormalizationServiceImpl(BaseNormalizationServiceABC):
     ):
         self._config = config
         self._empty_value = empty_value
+        mode = getattr(config, "serialization_mode", "json")
+        self._serialization_mode = mode if mode in {"json", "flat", "pipe"} else "json"
 
     def _iter_fields(self) -> list[dict[str, Any]]:
         """Return field configs from provider, supporting legacy shapes."""
@@ -167,23 +166,14 @@ class BaseNormalizationServiceImpl(BaseNormalizationServiceABC):
                 return direct_result
 
         if isinstance(container_value, (list, tuple)):
-            return self._process_list(
-                container_value,
-                normalizer,
-                field_name,
-                serialize_with_value_normalizer=serialize_with_value_normalizer,
-            )
+            return self._process_list(container_value, normalizer, field_name)
 
         if isinstance(container_value, dict):
             return self._process_dict(container_value, normalizer, field_name)
 
         normalized = self._apply_normalizer(container_value, normalizer, field_name)
         if isinstance(normalized, (list, tuple, dict)):
-            return self._serialize_container_result(
-                normalized,
-                normalizer,
-                serialize_with_value_normalizer=serialize_with_value_normalizer,
-            )
+            return self._serialize_container_result(normalized)
         return normalized
 
     def _is_empty_value(self, value: Any) -> bool:
@@ -201,8 +191,6 @@ class BaseNormalizationServiceImpl(BaseNormalizationServiceABC):
         value: Any,
         normalizer: Callable[[Any], Any],
         field_name: str,
-        *,
-        serialize_with_value_normalizer: bool = True,
     ) -> Any:
         try:
             normalized_list = normalize_array(
@@ -219,10 +207,10 @@ class BaseNormalizationServiceImpl(BaseNormalizationServiceABC):
         if not normalized_list:
             return self._empty_value
 
-        return serialize_list(
-            normalized_list,
-            value_normalizer=normalizer if serialize_with_value_normalizer else None,
+        serialized = serialize_nested(
+            normalized_list, mode=self._serialization_mode
         )
+        return self._empty_value if serialized == "" else serialized
 
     def _process_dict(
         self, value: Any, normalizer: Callable[[Any], Any], field_name: str
@@ -238,7 +226,8 @@ class BaseNormalizationServiceImpl(BaseNormalizationServiceABC):
         if normalized_dict is None:
             return self._empty_value
 
-        return serialize_dict(dict(normalized_dict))
+        serialized = serialize_nested(dict(normalized_dict), mode=self._serialization_mode)
+        return self._empty_value if serialized == "" else serialized
 
     def _apply_normalizer(
         self, value: Any, normalizer: Callable[[Any], Any], field_name: str
@@ -253,27 +242,18 @@ class BaseNormalizationServiceImpl(BaseNormalizationServiceABC):
         value: Any,
         normalizer: Callable[[Any], Any],
         field_name: str,
-        *,
-        serialize_with_value_normalizer: bool = True,
     ) -> tuple[bool, Any]:
         try:
             result = normalizer(value)
         except (ValueError, TypeError):
             return False, None
 
-        serialized = self._serialize_container_result(
-            result,
-            normalizer,
-            serialize_with_value_normalizer=serialize_with_value_normalizer,
-        )
+        serialized = self._serialize_container_result(result)
         return True, serialized
 
     def _serialize_container_result(
         self,
         result: Any,
-        normalizer: Callable[[Any], Any],
-        *,
-        serialize_with_value_normalizer: bool = True,
     ) -> Any:
         if result is None or result is pd.NA:
             return self._empty_value
@@ -281,18 +261,17 @@ class BaseNormalizationServiceImpl(BaseNormalizationServiceABC):
         if isinstance(result, (list, tuple)):
             if not result:
                 return self._empty_value
-            return serialize_list(
-                list(result),
-                value_normalizer=(
-                    normalizer if serialize_with_value_normalizer else None
-                ),
-            )
+            serialized = serialize_nested(result, mode=self._serialization_mode)
+            return self._empty_value if serialized == "" else serialized
 
         if isinstance(result, dict):
-            serialized_dict = serialize_dict(cast(dict[str, Any], result))
-            return self._empty_value if serialized_dict is pd.NA else serialized_dict
+            serialized_dict = serialize_nested(
+                cast(dict[str, Any], result), mode=self._serialization_mode
+            )
+            return self._empty_value if serialized_dict == "" else serialized_dict
 
-        return str(result)
+        serialized_scalar = serialize_nested(result, mode=self._serialization_mode)
+        return self._empty_value if serialized_scalar == "" else serialized_scalar
 
     def _normalize_container_item(
         self, item: Any, normalizer: Callable[[Any], Any]

--- a/src/bioetl/infrastructure/transform/impl/default_normalization_transformer_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/default_normalization_transformer_impl.py
@@ -12,7 +12,7 @@ from bioetl.infrastructure.transform.impl import normalize
 from bioetl.infrastructure.transform.impl.base_normalizer import (
     BaseNormalizationServiceImpl,
 )
-from bioetl.infrastructure.transform.impl.serializer import serialize_list
+from bioetl.infrastructure.transform.impl.serializer import serialize_nested
 
 
 class DefaultNormalizationTransformerImpl(
@@ -161,7 +161,10 @@ class DefaultNormalizationTransformerImpl(
                 normalized_value = custom_normalizer(val)
                 if normalized_value is None or not normalized_value:
                     return pd.NA
-                return serialize_list(normalized_value, value_normalizer=None)
+                serialized = serialize_nested(
+                    normalized_value, mode=self._serialization_mode
+                )
+                return pd.NA if serialized == "" else serialized
             return self._normalize_value(
                 val,
                 dtype,

--- a/src/bioetl/infrastructure/transform/impl/serializer.py
+++ b/src/bioetl/infrastructure/transform/impl/serializer.py
@@ -1,87 +1,98 @@
-"""
-Serialization utilities for domain entities.
-"""
+"""Serialization utilities for domain entities."""
 
-from typing import Any, Callable, Optional, Sequence
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal
 
 import pandas as pd
 
 
-def serialize_dict(
-    value: dict[str, Any], value_normalizer: Optional[Callable[[Any], Any]] = None
-) -> Any:
-    """
-    Преобразует словарь в строку key:value|key:value.
-    Пропускает вложенные списки и словари (глубина 1).
-    """
-    if not value:
-        return pd.NA
+def serialize_nested(
+    value: Any, *, mode: Literal["json", "flat", "pipe"] = "json"
+) -> str:
+    """Serialize nested structures deterministically to a string."""
 
-    parts = []
-    norm_func = value_normalizer if value_normalizer else (lambda x: x)
+    if _is_missing(value):
+        return ""
 
-    # Sort keys for determinism
-    for k in sorted(value.keys()):
-        v = value[k]
-        if v is None:
-            continue
-        if isinstance(v, (list, dict)):
-            continue
+    if mode not in {"json", "flat", "pipe"}:
+        raise ValueError(f"Unsupported serialization mode: {mode}")
 
-        # Normalize value
-        val_norm = norm_func(v)
-        if val_norm is not pd.NA and val_norm is not None:
-            parts.append(f"{k}:{val_norm}")
+    if mode == "json":
+        return _serialize_json(value)
 
-    if not parts:
-        return pd.NA
+    if isinstance(value, Mapping):
+        return _serialize_mapping(value, mode)
 
-    return "|".join(parts)
+    if isinstance(value, (list, tuple, set, frozenset, Sequence)) and not isinstance(
+        value, (str, bytes, bytearray)
+    ):
+        return _serialize_sequence(value, mode)
+
+    return str(value)
 
 
-def serialize_list(
-    value: Sequence[Any], value_normalizer: Optional[Callable[[Any], Any]] = None
-) -> Any:
-    """
-    Преобразует список в строку, соединяя элементы через |.
-    Для списка словарей объединяет их сериализованные представления.
-    """
-    if not value:
-        return pd.NA
-    norm_func = value_normalizer if value_normalizer else (lambda x: x)
-
-    if value and isinstance(value[0], dict):
-        parts = _serialize_dict_items(value, norm_func)
-    else:
-        parts = _serialize_flat_items(value, norm_func)
-
-    return pd.NA if not parts else "|".join(parts)
+def _serialize_json(value: Any) -> str:
+    try:
+        return json.dumps(
+            value,
+            default=_json_default,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    except TypeError:
+        return json.dumps(str(value), ensure_ascii=False)
 
 
-def _serialize_dict_items(
-    value: Sequence[Any], norm_func: Callable[[Any], Any]
-) -> list[str]:
+def _json_default(value: Any) -> Any:
+    if isinstance(value, (set, frozenset)):
+        return sorted(value)
+    if isinstance(value, Mapping):
+        return dict(sorted(value.items()))
+    if isinstance(value, (list, tuple, Sequence)) and not isinstance(
+        value, (str, bytes, bytearray)
+    ):
+        return list(value)
+    return str(value)
+
+
+def _serialize_mapping(mapping: Mapping[str, Any], mode: str) -> str:
+    delimiter = "|" if mode == "pipe" else ","
+    kv_separator = ":" if mode == "pipe" else "="
     parts: list[str] = []
-    for item in value:
-        if not isinstance(item, dict):
+
+    for key in sorted(mapping.keys()):
+        serialized_value = serialize_nested(mapping[key], mode=mode)
+        if serialized_value == "":
             continue
-        serialized = serialize_dict(item, value_normalizer=norm_func)
-        if serialized is not pd.NA and serialized is not None:
-            parts.append(serialized)
-    return parts
+        parts.append(f"{key}{kv_separator}{serialized_value}")
+
+    return delimiter.join(parts)
 
 
-def _serialize_flat_items(
-    value: Sequence[Any], norm_func: Callable[[Any], Any]
-) -> list[str]:
+def _serialize_sequence(seq: Sequence[Any], mode: str) -> str:
+    delimiter = "|" if mode == "pipe" else ","
     parts: list[str] = []
-    for item in value:
-        if isinstance(item, (list, dict)):
+
+    for item in seq:
+        serialized_value = serialize_nested(item, mode=mode)
+        if serialized_value == "":
             continue
-        val_norm = norm_func(item)
-        if val_norm is not pd.NA and val_norm is not None:
-            parts.append(str(val_norm))
-    return parts
+        parts.append(serialized_value)
+
+    return delimiter.join(parts)
 
 
-__all__ = ["serialize_dict", "serialize_list"]
+def _is_missing(value: Any) -> bool:
+    if value is None:
+        return True
+    try:
+        return bool(pd.isna(value))
+    except (TypeError, ValueError):
+        return False
+
+
+__all__ = ["serialize_nested"]

--- a/tests/bioetl/infrastructure/transform/test_serializer.py
+++ b/tests/bioetl/infrastructure/transform/test_serializer.py
@@ -1,0 +1,31 @@
+import pandas as pd
+
+from bioetl.infrastructure.transform.impl.serializer import serialize_nested
+
+
+def test_serialize_list_pipe_mode():
+    assert serialize_nested(["a", "b"], mode="pipe") == "a|b"
+
+
+def test_serialize_dict_pipe_mode_sorted_and_compact():
+    assert serialize_nested({"b": 2, "a": 1}, mode="pipe") == "a:1|b:2"
+
+
+def test_serialize_nested_structures_pipe_mode():
+    payload = {"items": [1, 2], "meta": {"kind": "x"}}
+    assert serialize_nested(payload, mode="pipe") == "items:1|2|meta:kind:x"
+
+
+def test_serialize_json_mode_preserves_structure():
+    payload = {"b": {"c": "d"}, "a": [1, 2]}
+    assert serialize_nested(payload, mode="json") == '{"a":[1,2],"b":{"c":"d"}}'
+
+
+def test_serialize_flat_mode_with_nested():
+    payload = {"items": ["x", "y"], "extra": {"a": "b"}}
+    assert serialize_nested(payload, mode="flat") == "extra=a=b,items=x,y"
+
+
+def test_serialize_none_returns_empty_string():
+    assert serialize_nested(None, mode="json") == ""
+    assert serialize_nested(pd.NA, mode="pipe") == ""


### PR DESCRIPTION
## Summary
- add a shared serialize_nested helper with json/flat/pipe modes and expose the setting via pipeline transform config
- apply the configured serialization mode across normalization and Chembl transformers, updating pipeline configs to use pipe
- add unit tests covering serialization of lists, dicts, nested structures, and missing values

## Testing
- python -m pytest tests/bioetl/infrastructure/transform/test_serializer.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69380d6608388324a4f8fb5814d14ae5)