### PR TITLE
Add centralized retry policy for HTTP clients

### DIFF
--- a/src/bioetl/domain/clients/base/contracts.py
+++ b/src/bioetl/domain/clients/base/contracts.py
@@ -106,7 +106,7 @@ class RetryPolicyABC(ABC):
         """Определяет, нужно ли повторять попытку."""
 
     @abstractmethod
-    def get_delay(self, attempt: int) -> float:
+    def get_backoff(self, attempt: int) -> float:
         """Возвращает задержку перед следующей попыткой (в секундах)."""
 
 

--- a/src/bioetl/domain/configs/pipeline.py
+++ b/src/bioetl/domain/configs/pipeline.py
@@ -41,6 +41,7 @@ class HttpClientSettings(BaseModel):
     retries: int = 3
     backoff: float = 2.0
     rate_limit: float = 2.5
+    retry_enabled: bool = True
 
     model_config = ConfigDict(extra="forbid")
 
@@ -52,6 +53,7 @@ class HttpClientDefaults(BaseModel):
     retries: int = 3
     backoff_factor: float = 2.0
     rate_limit: float = 2.5
+    retry_enabled: bool = True
 
     model_config = ConfigDict(extra="forbid")
 
@@ -74,6 +76,7 @@ class ClientConfig(BaseModel):
     backoff_factor: float = Field(
         default_factory=lambda: HTTP_CLIENT_DEFAULTS.backoff_factor
     )
+    retry_enabled: bool = True
     circuit_breaker_threshold: int = 5
     circuit_breaker_recovery_time: float = 60.0
 
@@ -95,6 +98,7 @@ class ClientConfig(BaseModel):
                 "max_retries": http_client.retries,
                 "rate_limit_per_sec": float(http_client.rate_limit),
                 "backoff_factor": http_client.backoff,
+                "retry_enabled": http_client.retry_enabled,
             }
         )
 
@@ -253,7 +257,13 @@ class BaseProviderConfig(BaseModel):
         client_data = data.get("client") or {}
 
         client_payload: dict[str, Any] = {}
-        for legacy_field in ("timeout_sec", "max_retries", "rate_limit_per_sec", "backoff_factor"):
+        for legacy_field in (
+            "timeout_sec",
+            "max_retries",
+            "rate_limit_per_sec",
+            "backoff_factor",
+            "retry_enabled",
+        ):
             if legacy_field in data:
                 client_payload[legacy_field] = data[legacy_field]
         client_payload.update(client_data if isinstance(client_data, dict) else {})
@@ -268,9 +278,23 @@ class BaseProviderConfig(BaseModel):
             retries=client_config.max_retries,
             backoff=float(client_config.backoff_factor),
             rate_limit=float(client_config.rate_limit_per_sec),
+            retry_enabled=bool(client_config.retry_enabled),
         )
 
-        cleaned = {key: value for key, value in data.items() if key not in {"base_url", "client", "timeout_sec", "max_retries", "rate_limit_per_sec", "backoff_factor"}}
+        cleaned = {
+            key: value
+            for key, value in data.items()
+            if key
+            not in {
+                "base_url",
+                "client",
+                "timeout_sec",
+                "max_retries",
+                "rate_limit_per_sec",
+                "backoff_factor",
+                "retry_enabled",
+            }
+        }
         cleaned["http_client"] = http_client
         return cleaned
 

--- a/src/bioetl/infrastructure/clients/base/factories.py
+++ b/src/bioetl/infrastructure/clients/base/factories.py
@@ -58,6 +58,7 @@ def _resolve_http_defaults(
             retries=http_settings.retries,
             backoff_factor=http_settings.backoff,
             rate_limit=http_settings.rate_limit,
+            retry_enabled=http_settings.retry_enabled,
         )
 
     if client_config is None:
@@ -68,6 +69,7 @@ def _resolve_http_defaults(
         retries=client_config.max_retries,
         backoff_factor=client_config.backoff_factor,
         rate_limit=float(client_config.rate_limit_per_sec),
+        retry_enabled=bool(client_config.retry_enabled),
     )
 
 
@@ -91,6 +93,7 @@ def _ensure_client_config(
         max_retries=resolved.retries,
         rate_limit_per_sec=resolved.rate_limit,
         backoff_factor=resolved.backoff_factor,
+        retry_enabled=resolved.retry_enabled,
     )
 
 

--- a/src/bioetl/infrastructure/clients/base/impl/unified_api_client_impl.py
+++ b/src/bioetl/infrastructure/clients/base/impl/unified_api_client_impl.py
@@ -13,7 +13,13 @@ import requests
 from bioetl.domain.clients.base.contracts import ApiClientABC
 from bioetl.domain.configs import ClientConfig
 from bioetl.domain.observability import LoggingPortABC, MetricsPortABC
-from bioetl.infrastructure.errors import ApiTimeoutError, wrap_http_errors
+from bioetl.infrastructure.errors import (
+    ApiClientError,
+    ApiTimeoutError,
+    ApiUnexpectedStatusError,
+    wrap_http_errors,
+)
+from bioetl.infrastructure.http import ExponentialRetryPolicy
 from bioetl.infrastructure.observability.factories import (
     default_logging_port,
     default_metrics_port,
@@ -40,6 +46,15 @@ class UnifiedAPIClientImpl(ApiClientABC):
         self.base_client = base_client or requests.Session()
         self.logger = logger or default_logging_port()
         self.metrics = metrics or default_metrics_port()
+        attempts = max(1, int(config.max_retries) + 1)
+        self.retry_policy = (
+            ExponentialRetryPolicy(
+                max_attempts=attempts,
+                backoff_factor=float(config.backoff_factor),
+            )
+            if config.retry_enabled
+            else None
+        )
         self.logger.info(
             "http_client_initialized",
             provider=self.provider,
@@ -73,7 +88,13 @@ class UnifiedAPIClientImpl(ApiClientABC):
                     raw_status if isinstance(raw_status, int) else None
                 )
                 status_label = self._normalize_status(context["status_code"])
-                self.logger.info(
+                log_method = (
+                    self.logger.error
+                    if context["status_code"] is not None
+                    and context["status_code"] >= 500
+                    else self.logger.info
+                )
+                log_method(
                     "http_request_completed",
                     provider=self.provider,
                     method=method_upper,
@@ -81,6 +102,16 @@ class UnifiedAPIClientImpl(ApiClientABC):
                     status_code=context["status_code"],
                     latency_sec=time.monotonic() - start,
                 )
+                if (
+                    context["status_code"] is not None
+                    and context["status_code"] >= 500
+                ):
+                    raise ApiUnexpectedStatusError(
+                        f"Unexpected status code: {context['status_code']}",
+                        provider=self.provider,
+                        endpoint=url,
+                        status_code=context["status_code"],
+                    )
                 return response
         except Exception as exc:
             status_label = self._status_from_exception(status_label, exc)
@@ -93,15 +124,38 @@ class UnifiedAPIClientImpl(ApiClientABC):
 
     def request(self, method: str, url: str, **kwargs: Any) -> Any:
         """Execute a request using the configured HTTP client."""
-        return self.request_call(method, url, **kwargs)
+        return self._request_with_retry(method, url, **kwargs)
 
     def get_response(self, url: str, **kwargs: Any) -> Any:
         """GET запрос."""
-        return self.request_call("GET", url, **kwargs)
+        return self._request_with_retry("GET", url, **kwargs)
 
     def request_post(self, url: str, **kwargs: Any) -> Any:
         """POST запрос."""
-        return self.request_call("POST", url, **kwargs)
+        return self._request_with_retry("POST", url, **kwargs)
+
+    def _request_with_retry(self, method: str, url: str, **kwargs: Any) -> Any:
+        attempt = 1
+        while True:
+            try:
+                return self.request_call(method, url, **kwargs)
+            except Exception as exc:
+                if self.retry_policy is None or not self.retry_policy.should_retry(
+                    exc, attempt
+                ):
+                    raise
+
+                backoff = self.retry_policy.get_backoff(attempt)
+                self.logger.warning(
+                    "http_request_retry",
+                    provider=self.provider,
+                    url=url,
+                    attempt=attempt,
+                    backoff_sec=backoff,
+                    error=str(exc),
+                )
+                time.sleep(backoff)
+                attempt += 1
 
     def close(self) -> None:
         """Закрыть соединение."""
@@ -144,4 +198,8 @@ class UnifiedAPIClientImpl(ApiClientABC):
     def _status_from_exception(self, current_status: str, exc: Exception) -> str:
         if isinstance(exc, ApiTimeoutError) or isinstance(exc, requests.Timeout):
             return "timeout"
+        if isinstance(exc, ApiClientError):
+            status_code = getattr(exc, "status_code", None)
+            if status_code is not None:
+                return str(status_code)
         return exc.__class__.__name__ or current_status

--- a/src/bioetl/infrastructure/clients/chembl/factories.py
+++ b/src/bioetl/infrastructure/clients/chembl/factories.py
@@ -112,6 +112,7 @@ def default_chembl_extraction_service(
                 "retries": client_config.max_retries,
                 "backoff": float(client_config.backoff_factor),
                 "rate_limit": float(client_config.rate_limit_per_sec),
+                "retry_enabled": bool(client_config.retry_enabled),
             }
         )
 

--- a/src/bioetl/infrastructure/http/__init__.py
+++ b/src/bioetl/infrastructure/http/__init__.py
@@ -1,0 +1,5 @@
+"""HTTP-level helpers (retry, session policies)."""
+
+from bioetl.infrastructure.http.retry import ExponentialRetryPolicy
+
+__all__ = ["ExponentialRetryPolicy"]

--- a/src/bioetl/infrastructure/http/retry.py
+++ b/src/bioetl/infrastructure/http/retry.py
@@ -1,0 +1,89 @@
+"""Reusable retry policies for HTTP clients."""
+
+from __future__ import annotations
+
+import math
+from typing import Iterable
+
+import requests
+
+from bioetl.domain.clients.base.contracts import RetryPolicyABC
+from bioetl.infrastructure.errors import ApiClientError, ApiTimeoutError
+
+DEFAULT_RETRY_STATUSES = {500, 502, 503, 504}
+DEFAULT_RETRY_EXCEPTIONS: tuple[type[Exception], ...] = (
+    ApiTimeoutError,
+    requests.Timeout,
+    requests.ConnectionError,
+    requests.HTTPError,
+    requests.RequestException,
+)
+
+
+class ExponentialRetryPolicy(RetryPolicyABC):
+    """Экспоненциальная стратегия повторных попыток для HTTP-клиентов."""
+
+    def __init__(
+        self,
+        *,
+        max_attempts: int,
+        backoff_factor: float = 1.0,
+        retry_statuses: Iterable[int] | None = None,
+        retry_exceptions: tuple[type[Exception], ...] | None = None,
+    ) -> None:
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be at least 1")
+        if backoff_factor < 0:
+            raise ValueError("backoff_factor must be non-negative")
+
+        self._max_attempts = int(max_attempts)
+        self._backoff_factor = float(backoff_factor)
+        self.retry_statuses = set(retry_statuses) if retry_statuses else set(
+            DEFAULT_RETRY_STATUSES
+        )
+        self.retry_exceptions = retry_exceptions or DEFAULT_RETRY_EXCEPTIONS
+
+    @property
+    def max_attempts(self) -> int:
+        return self._max_attempts
+
+    @property
+    def backoff_factor(self) -> float:
+        return self._backoff_factor
+
+    def should_retry(self, exception: Exception, attempt: int) -> bool:
+        """Проверяет, можно ли повторить попытку на данном шаге."""
+
+        if attempt >= self.max_attempts:
+            return False
+
+        if isinstance(exception, self.retry_exceptions):
+            return True
+
+        if isinstance(exception, ApiClientError):
+            status = getattr(exception, "status_code", None)
+            if status is not None and status in self.retry_statuses:
+                return True
+
+            cause = getattr(exception, "cause", None)
+            if isinstance(cause, self.retry_exceptions):
+                return True
+
+        status_code = _extract_status_code(exception)
+        return status_code in self.retry_statuses if status_code is not None else False
+
+    def get_backoff(self, attempt: int) -> float:
+        """Возвращает задержку перед следующей попыткой в секундах."""
+
+        exponent = max(0, attempt - 1)
+        return self.backoff_factor * math.pow(2.0, exponent)
+
+
+def _extract_status_code(exc: Exception) -> int | None:
+    """Пробует извлечь код статуса из исключения requests."""
+
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    if isinstance(status, int):
+        return status
+    return None

--- a/tests/bioetl/infrastructure/clients/base/test_unified_api_client_impl.py
+++ b/tests/bioetl/infrastructure/clients/base/test_unified_api_client_impl.py
@@ -1,7 +1,5 @@
 from unittest.mock import Mock
 
-from unittest.mock import Mock
-
 import pytest
 import requests
 
@@ -20,7 +18,7 @@ def test_request_call_wraps_timeout_error() -> None:
     metrics = Mock(spec=MetricsPortABC)
     client = UnifiedAPIClientImpl(
         provider="chembl",
-        config=ClientConfig(),
+        config=ClientConfig(retry_enabled=False),
         base_client=base_client,
         logger=logger,
         metrics=metrics,
@@ -44,7 +42,7 @@ def test_request_call_wraps_request_exception() -> None:
     metrics = Mock(spec=MetricsPortABC)
     client = UnifiedAPIClientImpl(
         provider="chembl",
-        config=ClientConfig(),
+        config=ClientConfig(retry_enabled=False),
         base_client=base_client,
         metrics=metrics,
     )
@@ -78,3 +76,60 @@ def test_request_records_metrics_on_success() -> None:
         {"provider": "chembl", "endpoint": "https://example.org", "status": "200"},
     )
     metrics.observe_histogram.assert_called_once()
+
+
+def test_request_retries_on_timeout_until_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    base_client = Mock()
+    response = Mock()
+    response.status_code = 200
+    base_client.request.side_effect = [requests.Timeout("timeout"), response]
+    metrics = Mock(spec=MetricsPortABC)
+    logger = Mock(spec=LoggingPortABC)
+    client = UnifiedAPIClientImpl(
+        provider="chembl",
+        config=ClientConfig(max_retries=1, backoff_factor=0.1),
+        base_client=base_client,
+        metrics=metrics,
+        logger=logger,
+    )
+
+    monkeypatch.setattr(
+        "bioetl.infrastructure.clients.base.impl.unified_api_client_impl.time.sleep",
+        lambda *_: None,
+    )
+
+    result = client.request("GET", "https://example.org")
+
+    assert result is response
+    assert base_client.request.call_count == 2
+    logger.warning.assert_called_once()
+
+
+def test_request_retries_on_server_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    base_client = Mock()
+    first = Mock()
+    first.status_code = 500
+    second = Mock()
+    second.status_code = 200
+    base_client.request.side_effect = [first, second]
+    metrics = Mock(spec=MetricsPortABC)
+    client = UnifiedAPIClientImpl(
+        provider="chembl",
+        config=ClientConfig(max_retries=1, backoff_factor=0.1),
+        base_client=base_client,
+        metrics=metrics,
+    )
+
+    monkeypatch.setattr(
+        "bioetl.infrastructure.clients.base.impl.unified_api_client_impl.time.sleep",
+        lambda *_: None,
+    )
+
+    result = client.request("GET", "https://example.org")
+
+    assert result is second
+    assert base_client.request.call_count == 2
+    metrics.inc_counter.assert_any_call(
+        "client_request_errors",
+        {"provider": "chembl", "endpoint": "https://example.org", "status": "500"},
+    )


### PR DESCRIPTION
## Summary
- add reusable exponential retry policy and expose it via infrastructure.http
- enable retry handling with optional disable flag for unified HTTP clients and configs
- cover retry behavior for timeouts and server errors with unit tests

## Testing
- pytest tests/bioetl/infrastructure/clients/base/test_unified_api_client_impl.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69380d2a03d08324994a5084b13b151b)