### PR TITLE
Add Pandera schema generation from column order

### DIFF
--- a/src/bioetl/domain/schemas/generator.py
+++ b/src/bioetl/domain/schemas/generator.py
@@ -1,0 +1,34 @@
+"""Helpers for generating Pandera schemas from column descriptors."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandera as pa
+import yaml
+
+__all__ = [
+    "generate_schema_from_column_order",
+    "load_column_order_from_yaml",
+]
+
+
+def generate_schema_from_column_order(columns: list[str]) -> pa.DataFrameSchema:
+    """Build a permissive Pandera schema using the provided column order."""
+
+    return pa.DataFrameSchema(
+        {col: pa.Column(object, nullable=True, coerce=True) for col in columns}
+    )
+
+
+def load_column_order_from_yaml(path: str | Path) -> list[str]:
+    """Load ordered column names from a YAML file."""
+
+    raw = Path(path).read_text(encoding="utf-8")
+    loaded = yaml.safe_load(raw)
+
+    if not isinstance(loaded, list) or not all(isinstance(item, str) for item in loaded):
+        msg = "columns.yaml must contain a list of strings"
+        raise ValueError(msg)
+
+    return list(loaded)

--- a/src/bioetl/domain/schemas/registry.py
+++ b/src/bioetl/domain/schemas/registry.py
@@ -2,6 +2,7 @@
 Registry implementation for schema objects (technology-agnostic).
 """
 
+from bioetl.domain.schemas.generator import generate_schema_from_column_order
 from bioetl.domain.validation import SchemaProviderABC, schema_type
 
 
@@ -11,17 +12,21 @@ class SchemaRegistry(SchemaProviderABC):
     """
 
     def __init__(self) -> None:
-        self._schemas: dict[str, schema_type] = {}
+        self._schemas: dict[str, schema_type | None] = {}
         self._schema_columns: dict[str, list[str] | None] = {}
 
     def register(
         self,
         name: str,
-        schema: schema_type,
+        schema: schema_type | None,
         *,
         column_order: list[str] | None = None,
     ) -> None:
         """Register a schema by name."""
+        if schema is None and column_order is None:
+            msg = "Either schema or column_order must be provided"
+            raise ValueError(msg)
+
         self._schemas[name] = schema
         self._schema_columns[name] = list(column_order) if column_order else None
 
@@ -29,7 +34,17 @@ class SchemaRegistry(SchemaProviderABC):
         """Get schema by name, raises ValueError if not found."""
         if name not in self._schemas:
             raise ValueError(f"Schema for '{name}' not found in registry.")
-        return self._schemas[name]
+        schema = self._schemas[name]
+        if schema is not None:
+            return schema
+
+        column_order = self._schema_columns.get(name)
+        if not column_order:
+            raise ValueError(f"Column order for schema '{name}' is not available.")
+
+        generated_schema = generate_schema_from_column_order(column_order)
+        self._schemas[name] = generated_schema
+        return generated_schema
 
     def get_schema_columns(self, name: str) -> list[str]:
         """Return column order for schema."""
@@ -40,10 +55,11 @@ class SchemaRegistry(SchemaProviderABC):
             return list(column_order)
         # Best-effort extraction of column order if schema exposes to_schema
         schema = self._schemas[name]
-        if hasattr(schema, "to_schema"):
-            columns = getattr(schema, "to_schema")().columns
-            if hasattr(columns, "keys"):
-                return list(columns.keys())
+        if schema is not None:
+            if hasattr(schema, "to_schema"):
+                columns = getattr(schema, "to_schema")().columns
+                if hasattr(columns, "keys"):
+                    return list(columns.keys())
         raise ValueError(f"Column order for schema '{name}' is not available.")
 
     def list_schemas(self) -> list[str]:

--- a/tests/bioetl/domain/schemas/test_schema_generation.py
+++ b/tests/bioetl/domain/schemas/test_schema_generation.py
@@ -1,0 +1,41 @@
+import pandas as pd
+import pandera as pa
+
+from bioetl.domain.schemas.generator import (
+    generate_schema_from_column_order,
+    load_column_order_from_yaml,
+)
+from bioetl.domain.schemas.registry import SchemaRegistry
+from bioetl.infrastructure.validation.impl.pandera_validator import PanderaValidatorImpl
+
+
+def test_generate_schema_from_column_order_validates_missing_columns():
+    columns = ["id", "value"]
+    schema = generate_schema_from_column_order(columns)
+    validator = PanderaValidatorImpl(schema)
+
+    ok_df = pd.DataFrame({"id": [1], "value": ["x"]})
+    assert validator.validate(ok_df).is_valid
+
+    invalid_df = pd.DataFrame({"id": [1]})
+    result = validator.validate(invalid_df)
+
+    assert not result.is_valid
+    assert result.errors
+
+
+def test_register_schema_from_yaml(tmp_path):
+    yaml_path = tmp_path / "columns.yaml"
+    yaml_path.write_text("- id\n- name\n", encoding="utf-8")
+
+    column_order = load_column_order_from_yaml(yaml_path)
+    registry = SchemaRegistry()
+    registry.register("from_yaml", None, column_order=column_order)
+
+    schema = registry.get_schema("from_yaml")
+    assert isinstance(schema, pa.DataFrameSchema)
+    assert registry.get_schema_columns("from_yaml") == ["id", "name"]
+
+    validator = PanderaValidatorImpl(schema)
+    result = validator.validate(pd.DataFrame({"id": [1]}))
+    assert not result.is_valid


### PR DESCRIPTION
## Summary
- add helpers to build Pandera schemas from column order lists or YAML files
- allow the schema registry to auto-generate schemas when only column order is provided
- cover generated schemas with validation tests, including YAML-driven definitions

## Testing
- pytest tests/bioetl/domain/schemas/test_schema_generation.py tests/bioetl/domain/schemas/test_registry.py tests/bioetl/infrastructure/validation/test_pandera_validator.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69381250b2248324a074f56b73206736)