### PR TITLE
Fix dependency direction in infrastructure layer

### DIFF
--- a/src/bioetl/infrastructure/logging/impl/unified_logger.py
+++ b/src/bioetl/infrastructure/logging/impl/unified_logger.py
@@ -7,7 +7,7 @@ from typing import Any, Self
 import structlog
 from structlog.stdlib import BoundLogger
 
-from bioetl.interfaces.observability.contracts import LoggingPortABC
+from bioetl.domain.observability.contracts import LoggingPortABC
 
 
 class UnifiedLoggerImpl(LoggingPortABC):

--- a/src/bioetl/infrastructure/observability/adapters.py
+++ b/src/bioetl/infrastructure/observability/adapters.py
@@ -8,7 +8,7 @@ import structlog
 from structlog.stdlib import BoundLogger
 
 from bioetl.infrastructure.observability import metrics
-from bioetl.interfaces.observability import LoggingPortABC, MetricsPortABC, TracingPortABC
+from bioetl.domain.observability.contracts import LoggingPortABC, MetricsPortABC, TracingPortABC
 
 
 class StructuredLoggerImpl(LoggingPortABC):

--- a/src/bioetl/infrastructure/observability/factories.py
+++ b/src/bioetl/infrastructure/observability/factories.py
@@ -9,7 +9,7 @@ from bioetl.infrastructure.observability.adapters import (
     StructuredLoggerImpl,
     TracingAdapterImpl,
 )
-from bioetl.interfaces.observability import (
+from bioetl.domain.observability.contracts import (
     LoggingPortABC,
     MetricsPortABC,
     TracingPortABC,


### PR DESCRIPTION
Infrastructure layer was importing observability contracts from bioetl.interfaces.observability, violating Hexagonal Architecture dependency rules. Changed imports to bioetl.domain.observability.contracts.

Files changed:
- infrastructure/observability/adapters.py
- infrastructure/observability/factories.py
- infrastructure/logging/impl/unified_logger.py