### PR TITLE
Remove redundant provider registry interface

### DIFF
--- a/src/bioetl/interfaces/provider_registry/contracts.py
+++ b/src/bioetl/interfaces/provider_registry/contracts.py
@@ -1,5 +1,0 @@
-"""Interface alias for the provider registry loader port."""
-
-from bioetl.domain.provider_registry import ProviderRegistryLoaderABC
-
-__all__ = ["ProviderRegistryLoaderABC"]


### PR DESCRIPTION
Remove interfaces/provider_registry directory that only re-exported ProviderRegistryLoaderABC from domain layer. No imports were using this module, so it can be safely removed.