### PR TITLE
Remove unused abstract classes from domain layer

### DIFF
--- a/src/bioetl/application/factories/record_source.py
+++ b/src/bioetl/application/factories/record_source.py
@@ -15,7 +15,7 @@ from bioetl.application.transform.pandas_batch_adapter import PandasBatchAdapter
 from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.observability import LoggingPortABC
 from bioetl.domain.providers import ProviderDefinition
-from bioetl.domain.record_source import ApiRecordSource, RecordSource
+from bioetl.domain.record_source import ApiRecordSource, RecordSourceABC
 
 
 class RecordSourceFactory:
@@ -37,7 +37,7 @@ class RecordSourceFactory:
         *,
         limit: int | None = None,
         logger: LoggingPortABC,
-    ) -> RecordSource:
+    ) -> RecordSourceABC:
         """Create record source based on pipeline input configuration."""
         mode = self._config.input_mode
         path = self._config.input_path

--- a/src/bioetl/application/pipelines/chembl/extractor.py
+++ b/src/bioetl/application/pipelines/chembl/extractor.py
@@ -19,7 +19,7 @@ from bioetl.domain.ports.extraction import (
     BatchAdapterABC,
     ExtractionServiceABC,
 )
-from bioetl.domain.record_source import ApiRecordSource, RecordSource
+from bioetl.domain.record_source import ApiRecordSource, RecordSourceABC
 from bioetl.domain.schemas.chembl.raw_models import ActivityRawModel
 from bioetl.domain.transform.contracts import NormalizationServiceABC
 
@@ -36,7 +36,7 @@ class ChemblExtractorImpl(ExtractorABC):
         normalization_service: NormalizationServiceABC,
         logger: LoggingPortABC,
         batch_adapter: BatchAdapterABC,
-        record_source: RecordSource | None = None,
+        record_source: RecordSourceABC | None = None,
     ) -> None:
         self.config = config
         self.extraction_service = extraction_service
@@ -79,7 +79,7 @@ class ChemblExtractorImpl(ExtractorABC):
                 if remaining <= 0:
                     break
 
-    def _resolve_record_source(self, *, limit: int | None) -> RecordSource:
+    def _resolve_record_source(self, *, limit: int | None) -> RecordSourceABC:
         """
         Builds record source based on current pipeline config.
         Falls back to API iteration when no input file is provided.
@@ -143,7 +143,7 @@ class ChemblExtractorImpl(ExtractorABC):
         csv_options: dict[str, Any] | CsvInputConfig,
         limit: int | None,
         chunk_size: int | None,
-    ) -> RecordSource:
+    ) -> RecordSourceABC:
         if not input_path:
             raise ValueError("input_path is required for CSV mode")
         return CsvRecordSourceImpl(
@@ -162,7 +162,7 @@ class ChemblExtractorImpl(ExtractorABC):
         csv_options: dict[str, Any] | CsvInputConfig,
         limit: int | None,
         chunk_size: int | None,
-    ) -> RecordSource:
+    ) -> RecordSourceABC:
         if not input_path:
             raise ValueError("input_path is required for ID-only mode")
         id_column = self._resolve_primary_key()
@@ -190,7 +190,7 @@ class ChemblExtractorImpl(ExtractorABC):
 
     def _build_api_source(
         self, *, limit: int | None, chunk_size: int | None
-    ) -> RecordSource:
+    ) -> RecordSourceABC:
         filters = dict(getattr(self.config, "pipeline", {}) or {})
         if limit is not None:
             filters["limit"] = limit

--- a/src/bioetl/domain/clients/base/__init__.py
+++ b/src/bioetl/domain/clients/base/__init__.py
@@ -8,7 +8,6 @@ from bioetl.domain.clients.base.contracts import (
     ResponseParserABC,
     RetryPolicyABC,
     SecretProviderABC,
-    SideInputProviderABC,
 )
 
 __all__ = [
@@ -19,5 +18,4 @@ __all__ = [
     "ResponseParserABC",
     "RetryPolicyABC",
     "SecretProviderABC",
-    "SideInputProviderABC",
 ]

--- a/src/bioetl/domain/clients/base/contracts.py
+++ b/src/bioetl/domain/clients/base/contracts.py
@@ -131,20 +131,6 @@ class SecretProviderABC(ABC):
         """Возвращает значение секрета."""
 
 
-class SideInputProviderABC(ABC):
-    """
-    Провайдер побочных данных (справочников).
-    """
-
-    @abstractmethod
-    def get_side_input(self, name: str) -> Any:
-        """Возвращает справочник (обычно DataFrame)."""
-
-    @abstractmethod
-    def refresh(self, name: str) -> None:
-        """Обновляет справочник."""
-
-
 class ApiClientABC(ABC):
     """
     Низкоуровневый HTTP‑клиент.

--- a/src/bioetl/domain/observability/contracts.py
+++ b/src/bioetl/domain/observability/contracts.py
@@ -37,7 +37,10 @@ class LoggingPortABC(ABC):
 
 
 class TracingPortABC(ABC):
-    """Port describing distributed tracing operations."""
+    """Port describing distributed tracing operations.
+
+    Experimental: not yet integrated into main pipeline flow.
+    """
 
     @abstractmethod
     def start_span(self, name: str) -> Any:

--- a/src/bioetl/domain/ports/extraction.py
+++ b/src/bioetl/domain/ports/extraction.py
@@ -32,12 +32,6 @@ class VersionProviderABC(ABC):
         """Возвращает идентификатор релиза (например, chembl_34)."""
 
 
-class VersionedRecordFetcherABC(RecordFetcherABC, VersionProviderABC):
-    """Fetcher с версией источника."""
-
-    ...
-
-
 class ExtractionServiceABC(RecordFetcherABC):
     """Абстракция сервиса извлечения данных из провайдера."""
 
@@ -94,7 +88,6 @@ class BatchAdapterABC(Protocol):
 __all__ = [
     "RecordFetcherABC",
     "VersionProviderABC",
-    "VersionedRecordFetcherABC",
     "BatchAdapterABC",
     "ExtractionServiceABC",
 ]

--- a/src/bioetl/domain/record_source.py
+++ b/src/bioetl/domain/record_source.py
@@ -25,10 +25,6 @@ class RecordSourceABC(ABC):
         """Return iterable over raw record batches as lists of mappings."""
 
 
-# Alias for backward compatibility during migration
-RecordSource = RecordSourceABC
-
-
 class InMemoryRecordSource(RecordSourceABC):
     """Simple record source backed by an in-memory list."""
 

--- a/src/bioetl/infrastructure/chembl_client.py
+++ b/src/bioetl/infrastructure/chembl_client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from bioetl.domain.clients.contracts import DataClientABC
 from bioetl.domain.configs import ChemblSourceConfig
-from bioetl.domain.ports.extraction import VersionedRecordFetcherABC
+from bioetl.domain.ports.extraction import ExtractionServiceABC
 from bioetl.domain.ports.providers import DefaultFieldProviderABC
 from bioetl.infrastructure.clients.chembl.factories import (
     default_chembl_client,
@@ -25,7 +25,7 @@ def create_extraction_service(
     *,
     client: DataClientABC | None = None,
     field_provider: DefaultFieldProviderABC | None = None,
-) -> VersionedRecordFetcherABC:
+) -> ExtractionServiceABC:
     """Create extraction service using provided or default ChEMBL client."""
 
     resolved_client = client or create_client(config)

--- a/src/bioetl/infrastructure/clients/base/abc_impls.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_impls.yaml
@@ -110,11 +110,6 @@ SecretProviderABC:
   implementations:
     Env: bioetl.infrastructure.clients.base.factories.EnvSecretProviderImpl
 
-SideInputProviderABC:
-  default_factory: bioetl.infrastructure.clients.base.factories.default_side_input_provider
-  implementations:
-    Stub: bioetl.domain.clients.base.contracts.SideInputProviderABC
-
 PipelineContainerABC:
   default_factory: bioetl.application.pipelines.factories.default_pipeline_container
   implementations:

--- a/src/bioetl/infrastructure/clients/base/abc_registry.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_registry.yaml
@@ -9,7 +9,6 @@ PaginatorABC: bioetl.domain.clients.base.contracts.PaginatorABC
 RateLimiterABC: bioetl.domain.clients.base.contracts.RateLimiterABC
 CacheABC: bioetl.domain.clients.base.contracts.CacheABC
 SecretProviderABC: bioetl.domain.clients.base.contracts.SecretProviderABC
-SideInputProviderABC: bioetl.domain.clients.base.contracts.SideInputProviderABC
 
 PipelineContainerABC: bioetl.application.pipelines.contracts.PipelineContainerABC
 PipelineHookABC: bioetl.domain.pipelines.contracts.PipelineHookABC

--- a/src/bioetl/infrastructure/clients/base/factories.py
+++ b/src/bioetl/infrastructure/clients/base/factories.py
@@ -10,7 +10,6 @@ from bioetl.domain.clients.base.contracts import (
     RequestBuilderABC,
     ResponseParserABC,
     SecretProviderABC,
-    SideInputProviderABC,
 )
 from bioetl.domain.configs import (
     HTTP_CLIENT_DEFAULTS,
@@ -204,7 +203,3 @@ def build_http_client(
     )
 
 
-def default_side_input_provider() -> SideInputProviderABC:
-    """Stub factory for side input providers until implemented."""
-
-    raise NotImplementedError("SideInputProviderABC has no default implementation yet")

--- a/src/bioetl/infrastructure/clients/chembl/factories.py
+++ b/src/bioetl/infrastructure/clients/chembl/factories.py
@@ -7,7 +7,7 @@ from typing import Any
 from bioetl.domain.clients.contracts import DataClientABC
 from bioetl.domain.configs import ChemblSourceConfig, ClientConfig, HttpClientSettings
 from bioetl.domain.observability.contracts import LoggingPortABC
-from bioetl.domain.ports.extraction import VersionedRecordFetcherABC
+from bioetl.domain.ports.extraction import ExtractionServiceABC
 from bioetl.domain.ports.providers import DefaultFieldProviderABC
 from bioetl.infrastructure.clients.base.factories import (
     build_http_client,
@@ -93,7 +93,7 @@ def default_chembl_extraction_service(
     client: DataClientABC | None = None,
     logger: LoggingPortABC | None = None,
     field_provider: DefaultFieldProviderABC | None = None,
-) -> VersionedRecordFetcherABC:
+) -> ExtractionServiceABC:
     """
     Создает сервис экстракции ChEMBL.
 

--- a/src/bioetl/infrastructure/clients/chembl/provider.py
+++ b/src/bioetl/infrastructure/clients/chembl/provider.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from bioetl.domain.clients.contracts import DataClientABC
 from bioetl.domain.configs import ChemblSourceConfig, HttpClientSettings
-from bioetl.domain.ports.extraction import VersionedRecordFetcherABC
+from bioetl.domain.ports.extraction import ExtractionServiceABC
 from bioetl.domain.ports.providers import DefaultFieldProviderABC
 from bioetl.domain.providers import ProviderComponents, ProviderDefinition, ProviderId
 from bioetl.domain.transform.contracts import (
@@ -21,7 +21,7 @@ from bioetl.infrastructure.transform.factories import default_normalization_serv
 class ChemblProviderComponentsFactory(
     ProviderComponents[
         DataClientABC,
-        VersionedRecordFetcherABC,
+        ExtractionServiceABC,
         NormalizationServiceABC,
         object,
     ]
@@ -38,7 +38,7 @@ class ChemblProviderComponentsFactory(
         *,
         client: DataClientABC | None = None,
         field_provider: DefaultFieldProviderABC | None = None,
-    ) -> VersionedRecordFetcherABC:
+    ) -> ExtractionServiceABC:
         """Construct extraction service with optional prebuilt client."""
         return create_extraction_service(
             config, client=client, field_provider=field_provider

--- a/tests/architecture/test_architecture_rules.py
+++ b/tests/architecture/test_architecture_rules.py
@@ -35,7 +35,6 @@ ALLOWED_ABCS_WITHOUT_IMPL = {
     "ResponseParserABC",
     "SchemaProviderABC",
     "SecretProviderABC",
-    "SideInputProviderABC",
 }
 
 


### PR DESCRIPTION
- Remove SideInputProviderABC (0 implementations)
- Remove VersionedRecordFetcherABC (empty marker class)
- Mark TracingPortABC as experimental
- Remove RecordSource backward-compat alias

Closes audit findings: UNUSED-01, UNUSED-05, DUP-05