### PR TITLE
Merge duplicate provider registry loader modules

### DIFF
--- a/src/bioetl/infrastructure/clients/provider_registry_loader.py
+++ b/src/bioetl/infrastructure/clients/provider_registry_loader.py
@@ -1,253 +1,40 @@
-"""Loader for provider registry definitions from YAML configuration."""
+"""Loader for provider registry definitions from YAML configuration.
+
+.. deprecated::
+    This module is deprecated. Use :mod:`bioetl.infrastructure.config.provider_registry`
+    instead. All symbols are re-exported for backward compatibility.
+
+Migration guide:
+    Replace imports from:
+        ``from bioetl.infrastructure.clients.provider_registry_loader import ...``
+    With:
+        ``from bioetl.infrastructure.config.provider_registry import ...``
+"""
 
 from __future__ import annotations
 
-import importlib
-from pathlib import Path
-from typing import Any
+import warnings
 
-from pydantic import BaseModel, ConfigDict, ValidationError
-import yaml
-
-from bioetl.domain.configs import HttpClientSettings
-from bioetl.domain.observability import LoggingPortABC
-from bioetl.domain.provider_registry import (
-    InMemoryProviderRegistry,
-    ProviderAlreadyRegisteredError,
-    ProviderRegistryABC,
-    ProviderRegistryLoaderABC,
+from bioetl.infrastructure.config.provider_registry import (
+    DEFAULT_PROVIDERS_CONFIG_PATH,
+    ProviderLoaderImpl,
+    ProviderRegistryConfig,
+    ProviderRegistryConfigNotFoundError,
+    ProviderRegistryEntryModel,
+    ProviderRegistryLoader,
+    ProviderRegistryLoaderError,
+    ProviderRegistryValidationError,
+    create_provider_loader,
+    default_provider_registry_loader,
+    get_provider_registry,
 )
-from bioetl.domain.providers import ProviderDefinition, ProviderId
-from bioetl.infrastructure.clients.chembl.provider import register_chembl_provider
-from bioetl.infrastructure.observability.factories import default_logging_port
 
-DEFAULT_PROVIDERS_CONFIG_PATH = Path("configs/providers.yaml")
-
-
-class ProviderRegistryLoaderError(Exception):
-    """Base error for provider registry loading."""
-
-
-class ProviderRegistryConfigNotFoundError(ProviderRegistryLoaderError):
-    """Raised when provider registry config file is missing."""
-
-    def __init__(self, path: Path) -> None:
-        super().__init__(f"Provider registry config not found: {path}")
-        self.path = path
-
-
-class ProviderRegistryValidationError(ProviderRegistryLoaderError):
-    """Raised when provider registry config is invalid."""
-
-    def __init__(self, path: Path, message: str) -> None:
-        super().__init__(f"{path}: {message}")
-        self.path = path
-
-
-class ProviderRegistryEntryModel(BaseModel):
-    """Single provider entry from registry config."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    id: ProviderId
-    module: str
-    factory: str
-    active: bool = True
-    description: str | None = None
-    http_client: HttpClientSettings | None = None
-
-
-class ProviderRegistryConfig(BaseModel):
-    """Root provider registry configuration."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    providers: list[ProviderRegistryEntryModel]
-
-
-class ProviderLoaderImpl(ProviderRegistryLoaderABC):
-    """Loads provider registry entries and registers them dynamically."""
-
-    def __init__(
-        self,
-        config_path: str | Path | None = None,
-        *,
-        logger: LoggingPortABC | None = None,
-    ) -> None:
-        self._config_path = (
-            Path(config_path) if config_path else DEFAULT_PROVIDERS_CONFIG_PATH
-        )
-        self._logger = logger or default_logging_port()
-
-    def get_providers(
-        self,
-        *,
-        registry: ProviderRegistryABC | None = None,
-    ) -> list[ProviderDefinition]:
-        """Get providers from YAML and register active entries."""
-
-        registry_to_use = registry or InMemoryProviderRegistry()
-        raw_config = self._load_config(self._config_path)
-        try:
-            config = ProviderRegistryConfig.model_validate(raw_config)
-        except ValidationError as exc:
-            raise ProviderRegistryValidationError(
-                self._config_path,
-                exc.__str__(),
-            ) from exc
-
-        registered: list[ProviderDefinition] = []
-        for entry in config.providers:
-            if not entry.active:
-                self._logger.debug(
-                    "Provider entry is disabled; skipping",
-                    provider=entry.id.value,
-                    module=entry.module,
-                )
-                continue
-            definition = self._register_entry(entry, registry_to_use)
-            if definition:
-                registered.append(definition)
-        # Fallback to builtin ChEMBL provider if nothing was registered (defensive).
-        if not registered:
-            builtin = register_chembl_provider()
-            try:
-                registry_to_use.register_provider(builtin)
-            except ProviderAlreadyRegisteredError:
-                self._logger.debug(
-                    "Provider already registered; reusing existing definition",
-                    provider=builtin.id.value,
-                    module="bioetl.infrastructure.clients.chembl.provider",
-                )
-                registered.append(registry_to_use.get_provider(builtin.id))
-            else:
-                registered.append(builtin)
-        return registered
-
-    def load(
-        self, *, registry: ProviderRegistryABC | None = None
-    ) -> list[ProviderDefinition]:
-        """
-        Backward-compatible alias for get_providers expected by tests and callers.
-        """
-
-        return self.get_providers(registry=registry)
-
-    def get_registry(
-        self, *, registry: ProviderRegistryABC | None = None
-    ) -> ProviderRegistryABC:
-        """Get providers and return populated registry (Protocol compatibility)."""
-
-        registry_to_use = registry or InMemoryProviderRegistry()
-        self.get_providers(registry=registry_to_use)
-        return registry_to_use
-
-    def _register_entry(
-        self,
-        entry: ProviderRegistryEntryModel,
-        registry: ProviderRegistryABC,
-    ) -> ProviderDefinition | None:
-        try:
-            module = importlib.import_module(entry.module)
-        except Exception as exc:  # pragma: no cover - defensive logging
-            self._logger.error(
-                "Failed to import provider module",
-                provider=entry.id.value,
-                module=entry.module,
-                error=str(exc),
-            )
-            return None
-
-        factory: Any = getattr(module, entry.factory, None)
-        if factory is None:
-            self._logger.error(
-                "Provider factory not found",
-                provider=entry.id.value,
-                module=entry.module,
-                factory=entry.factory,
-            )
-            return None
-
-        try:
-            definition = factory(http_client=entry.http_client)
-        except Exception as exc:  # pragma: no cover - defensive logging
-            self._logger.error(
-                "Provider factory invocation failed",
-                provider=entry.id.value,
-                module=entry.module,
-                factory=entry.factory,
-                error=str(exc),
-            )
-            return None
-
-        if not isinstance(definition, ProviderDefinition):
-            self._logger.error(
-                "Factory returned unexpected type",
-                provider=entry.id.value,
-                module=entry.module,
-                factory=entry.factory,
-                returned_type=type(definition).__name__,
-            )
-            return None
-
-        try:
-            registry.register_provider(definition)
-        except ProviderAlreadyRegisteredError:
-            self._logger.debug(
-                "Provider already registered; reusing existing definition",
-                provider=entry.id.value,
-                module=entry.module,
-            )
-            return registry.get_provider(definition.id)
-        return definition
-
-    def _load_config(self, path: Path) -> dict[str, Any]:
-        if not path.exists():
-            raise ProviderRegistryConfigNotFoundError(path)
-
-        with path.open("r", encoding="utf-8") as file:
-            data = yaml.safe_load(file) or {}
-        return data
-
-
-def get_provider_registry(
-    *,
-    config_path: str | Path | None = None,
-    logger: LoggingPortABC | None = None,
-    registry: ProviderRegistryABC | None = None,
-) -> ProviderRegistryABC:
-    """Utility to return populated provider registry."""
-
-    loader = default_provider_registry_loader(
-        config_path=config_path,
-        logger=logger,
-    )
-    registry_to_use = registry or InMemoryProviderRegistry()
-    return loader.get_registry(registry=registry_to_use)
-
-
-def create_provider_loader(
-    *,
-    config_path: str | Path | None = None,
-    logger: LoggingPortABC | None = None,
-) -> ProviderRegistryLoaderABC:
-    """Factory for ProviderLoaderProtocol implementations."""
-
-    return ProviderLoaderImpl(config_path=config_path, logger=logger)
-
-
-ProviderRegistryLoader = ProviderLoaderImpl
-
-
-def default_provider_registry_loader(
-    *,
-    config_path: str | Path | None = None,
-    logger: LoggingPortABC | None = None,
-) -> ProviderRegistryLoaderABC:
-    """Default factory for provider registry loader."""
-
-    return ProviderLoaderImpl(config_path=config_path, logger=logger)
-
+warnings.warn(
+    "bioetl.infrastructure.clients.provider_registry_loader is deprecated. "
+    "Use bioetl.infrastructure.config.provider_registry instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 __all__ = [
     "ProviderLoaderImpl",
@@ -258,4 +45,7 @@ __all__ = [
     "ProviderRegistryLoaderError",
     "ProviderRegistryConfigNotFoundError",
     "ProviderRegistryValidationError",
+    "ProviderRegistryEntryModel",
+    "ProviderRegistryConfig",
+    "DEFAULT_PROVIDERS_CONFIG_PATH",
 ]

--- a/src/bioetl/infrastructure/config/loader.py
+++ b/src/bioetl/infrastructure/config/loader.py
@@ -16,7 +16,7 @@ from bioetl.domain.schemas.registry import default_schema_provider
 from bioetl.domain.transform.merge import apply_deep_merge
 from bioetl.domain.validation import SchemaProviderABC
 from bioetl.infrastructure.config.env import resolve_env_placeholders
-from bioetl.infrastructure.config.provider_registry_loader import (
+from bioetl.infrastructure.config.provider_registry import (
     ProviderNotConfiguredError,
     ProviderRegistryError,
     ensure_provider_known,

--- a/src/bioetl/infrastructure/config/provider_registry.py
+++ b/src/bioetl/infrastructure/config/provider_registry.py
@@ -1,0 +1,422 @@
+"""Unified provider registry loader from YAML configuration.
+
+This module provides a single source of truth for loading and validating
+provider registry configuration from providers.yaml.
+
+It combines functionality from:
+- Provider validation and caching (ensure_provider_known, etc.)
+- Dynamic provider loading via importlib (ProviderLoaderImpl)
+"""
+
+from __future__ import annotations
+
+import importlib
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+import yaml
+
+from bioetl.domain.configs import HttpClientSettings
+from bioetl.domain.observability import LoggingPortABC
+from bioetl.domain.provider_registry import (
+    InMemoryProviderRegistry,
+    ProviderAlreadyRegisteredError,
+    ProviderRegistryABC,
+    ProviderRegistryLoaderABC,
+)
+from bioetl.domain.providers import ProviderDefinition, ProviderId
+from bioetl.infrastructure.clients.chembl.provider import register_chembl_provider
+from bioetl.infrastructure.observability.factories import default_logging_port
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_CONFIGS_ROOT = Path("configs")
+DEFAULT_PROVIDERS_REGISTRY_PATH = DEFAULT_CONFIGS_ROOT / "providers.yaml"
+DEFAULT_PROVIDERS_CONFIG_PATH = DEFAULT_PROVIDERS_REGISTRY_PATH  # Alias for compatibility
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class ProviderRegistryError(Exception):
+    """Base error for provider registry issues."""
+
+
+class ProviderRegistryNotFoundError(ProviderRegistryError):
+    """Registry file is missing."""
+
+    def __init__(self, registry_path: Path) -> None:
+        self.registry_path = registry_path
+        self.path = registry_path  # Alias for compatibility
+        super().__init__(f"Providers registry not found: {registry_path}")
+
+
+class ProviderRegistryFormatError(ProviderRegistryError):
+    """Registry file has invalid structure."""
+
+    def __init__(self, registry_path: Path, message: str) -> None:
+        self.registry_path = registry_path
+        self.path = registry_path  # Alias for compatibility
+        super().__init__(f"{registry_path}: {message}")
+
+
+class ProviderNotConfiguredError(ProviderRegistryError):
+    """Requested provider is absent in registry."""
+
+    def __init__(self, provider: str, registry_path: Path) -> None:
+        self.provider = provider
+        self.registry_path = registry_path
+        super().__init__(
+            (
+                "Provider '{provider}' is not configured in providers config "
+                "{registry_path}"
+            ).format(provider=provider, registry_path=registry_path)
+        )
+
+
+# Aliases for backward compatibility with clients/provider_registry_loader.py
+ProviderRegistryLoaderError = ProviderRegistryError
+ProviderRegistryConfigNotFoundError = ProviderRegistryNotFoundError
+ProviderRegistryValidationError = ProviderRegistryFormatError
+
+
+# ---------------------------------------------------------------------------
+# Pydantic Models
+# ---------------------------------------------------------------------------
+
+
+class ProviderRegistryEntryModel(BaseModel):
+    """Single provider entry from providers.yaml.
+
+    This is the canonical model for provider registry entries.
+    Supports both string IDs (for validation) and ProviderId enum (for loading).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str | ProviderId
+    module: str
+    factory: str
+    active: bool = True
+    description: str | None = None
+    http_client: HttpClientSettings | None = None
+
+
+# Alias for backward compatibility
+ProviderRegistryEntryConfig = ProviderRegistryEntryModel
+
+
+class ProviderRegistryConfig(BaseModel):
+    """Root provider registry configuration (validated providers.yaml content)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    providers: list[ProviderRegistryEntryModel] = []
+
+
+# Alias for backward compatibility
+ProviderRegistryModel = ProviderRegistryConfig
+
+
+# ---------------------------------------------------------------------------
+# YAML Loading (with caching)
+# ---------------------------------------------------------------------------
+
+
+def _read_registry_data(registry_path: Path) -> Any:
+    """Read raw YAML data from registry file."""
+    if not registry_path.exists():
+        raise ProviderRegistryNotFoundError(registry_path)
+
+    with registry_path.open("r", encoding="utf-8") as file:
+        return yaml.safe_load(file) or {}
+
+
+@lru_cache(maxsize=None)
+def _load_provider_registry(registry_path: Path) -> ProviderRegistryConfig:
+    """Load and validate provider registry from YAML (cached)."""
+    data: Any = _read_registry_data(registry_path)
+    try:
+        return ProviderRegistryConfig.model_validate(data)
+    except ValidationError as exc:
+        raise ProviderRegistryFormatError(registry_path, str(exc)) from exc
+
+
+def clear_provider_registry_cache() -> None:
+    """Reset cached registry content (used in tests)."""
+    _load_provider_registry.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Provider Validation
+# ---------------------------------------------------------------------------
+
+
+def ensure_provider_known(provider: str, *, registry_path: Path | None = None) -> str:
+    """Validate that provider exists in registry and return it back.
+
+    Args:
+        provider: Provider ID to validate
+        registry_path: Optional path to providers.yaml
+
+    Returns:
+        The provider ID if valid
+
+    Raises:
+        ProviderNotConfiguredError: If provider is not in registry
+        ProviderRegistryNotFoundError: If registry file is missing
+        ProviderRegistryFormatError: If registry has invalid structure
+    """
+    path = registry_path or DEFAULT_PROVIDERS_REGISTRY_PATH
+    registry = _load_provider_registry(path)
+
+    # Extract ID as string for comparison
+    registered_ids = set()
+    for entry in registry.providers:
+        if entry.active:
+            entry_id = entry.id.value if isinstance(entry.id, ProviderId) else entry.id
+            registered_ids.add(entry_id)
+
+    if provider in registered_ids:
+        return provider
+
+    raise ProviderNotConfiguredError(provider, path)
+
+
+# ---------------------------------------------------------------------------
+# Dynamic Provider Loader
+# ---------------------------------------------------------------------------
+
+
+class ProviderLoaderImpl(ProviderRegistryLoaderABC):
+    """Loads provider registry entries and registers them dynamically.
+
+    This class loads provider definitions from providers.yaml and dynamically
+    imports the specified modules to invoke factory functions.
+    """
+
+    def __init__(
+        self,
+        config_path: str | Path | None = None,
+        *,
+        logger: LoggingPortABC | None = None,
+    ) -> None:
+        self._config_path = (
+            Path(config_path) if config_path else DEFAULT_PROVIDERS_CONFIG_PATH
+        )
+        self._logger = logger or default_logging_port()
+
+    def get_providers(
+        self,
+        *,
+        registry: ProviderRegistryABC | None = None,
+    ) -> list[ProviderDefinition]:
+        """Get providers from YAML and register active entries."""
+        registry_to_use = registry or InMemoryProviderRegistry()
+        raw_config = self._load_config(self._config_path)
+        try:
+            config = ProviderRegistryConfig.model_validate(raw_config)
+        except ValidationError as exc:
+            raise ProviderRegistryFormatError(
+                self._config_path,
+                str(exc),
+            ) from exc
+
+        registered: list[ProviderDefinition] = []
+        for entry in config.providers:
+            if not entry.active:
+                entry_id = (
+                    entry.id.value if isinstance(entry.id, ProviderId) else entry.id
+                )
+                self._logger.debug(
+                    "Provider entry is disabled; skipping",
+                    provider=entry_id,
+                    module=entry.module,
+                )
+                continue
+            definition = self._register_entry(entry, registry_to_use)
+            if definition:
+                registered.append(definition)
+
+        # Fallback to builtin ChEMBL provider if nothing was registered (defensive).
+        if not registered:
+            builtin = register_chembl_provider()
+            try:
+                registry_to_use.register_provider(builtin)
+            except ProviderAlreadyRegisteredError:
+                self._logger.debug(
+                    "Provider already registered; reusing existing definition",
+                    provider=builtin.id.value,
+                    module="bioetl.infrastructure.clients.chembl.provider",
+                )
+                registered.append(registry_to_use.get_provider(builtin.id))
+            else:
+                registered.append(builtin)
+        return registered
+
+    def load(
+        self, *, registry: ProviderRegistryABC | None = None
+    ) -> list[ProviderDefinition]:
+        """Backward-compatible alias for get_providers expected by tests and callers."""
+        return self.get_providers(registry=registry)
+
+    def get_registry(
+        self, *, registry: ProviderRegistryABC | None = None
+    ) -> ProviderRegistryABC:
+        """Get providers and return populated registry (Protocol compatibility)."""
+        registry_to_use = registry or InMemoryProviderRegistry()
+        self.get_providers(registry=registry_to_use)
+        return registry_to_use
+
+    def _register_entry(
+        self,
+        entry: ProviderRegistryEntryModel,
+        registry: ProviderRegistryABC,
+    ) -> ProviderDefinition | None:
+        entry_id = entry.id.value if isinstance(entry.id, ProviderId) else entry.id
+
+        try:
+            module = importlib.import_module(entry.module)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self._logger.error(
+                "Failed to import provider module",
+                provider=entry_id,
+                module=entry.module,
+                error=str(exc),
+            )
+            return None
+
+        factory: Any = getattr(module, entry.factory, None)
+        if factory is None:
+            self._logger.error(
+                "Provider factory not found",
+                provider=entry_id,
+                module=entry.module,
+                factory=entry.factory,
+            )
+            return None
+
+        try:
+            definition = factory(http_client=entry.http_client)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self._logger.error(
+                "Provider factory invocation failed",
+                provider=entry_id,
+                module=entry.module,
+                factory=entry.factory,
+                error=str(exc),
+            )
+            return None
+
+        if not isinstance(definition, ProviderDefinition):
+            self._logger.error(
+                "Factory returned unexpected type",
+                provider=entry_id,
+                module=entry.module,
+                factory=entry.factory,
+                returned_type=type(definition).__name__,
+            )
+            return None
+
+        try:
+            registry.register_provider(definition)
+        except ProviderAlreadyRegisteredError:
+            self._logger.debug(
+                "Provider already registered; reusing existing definition",
+                provider=entry_id,
+                module=entry.module,
+            )
+            return registry.get_provider(definition.id)
+        return definition
+
+    def _load_config(self, path: Path) -> dict[str, Any]:
+        if not path.exists():
+            raise ProviderRegistryNotFoundError(path)
+
+        with path.open("r", encoding="utf-8") as file:
+            data = yaml.safe_load(file) or {}
+        return data
+
+
+# Alias for backward compatibility
+ProviderRegistryLoader = ProviderLoaderImpl
+
+
+# ---------------------------------------------------------------------------
+# Factory Functions
+# ---------------------------------------------------------------------------
+
+
+def get_provider_registry(
+    *,
+    config_path: str | Path | None = None,
+    logger: LoggingPortABC | None = None,
+    registry: ProviderRegistryABC | None = None,
+) -> ProviderRegistryABC:
+    """Utility to return populated provider registry."""
+    loader = default_provider_registry_loader(
+        config_path=config_path,
+        logger=logger,
+    )
+    registry_to_use = registry or InMemoryProviderRegistry()
+    return loader.get_registry(registry=registry_to_use)
+
+
+def create_provider_loader(
+    *,
+    config_path: str | Path | None = None,
+    logger: LoggingPortABC | None = None,
+) -> ProviderRegistryLoaderABC:
+    """Factory for ProviderLoaderProtocol implementations."""
+    return ProviderLoaderImpl(config_path=config_path, logger=logger)
+
+
+def default_provider_registry_loader(
+    *,
+    config_path: str | Path | None = None,
+    logger: LoggingPortABC | None = None,
+) -> ProviderRegistryLoaderABC:
+    """Default factory for provider registry loader."""
+    return ProviderLoaderImpl(config_path=config_path, logger=logger)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+__all__ = [
+    # Constants
+    "DEFAULT_CONFIGS_ROOT",
+    "DEFAULT_PROVIDERS_REGISTRY_PATH",
+    "DEFAULT_PROVIDERS_CONFIG_PATH",
+    # Exceptions
+    "ProviderRegistryError",
+    "ProviderRegistryNotFoundError",
+    "ProviderRegistryFormatError",
+    "ProviderNotConfiguredError",
+    # Backward-compatible exception aliases
+    "ProviderRegistryLoaderError",
+    "ProviderRegistryConfigNotFoundError",
+    "ProviderRegistryValidationError",
+    # Models
+    "ProviderRegistryEntryModel",
+    "ProviderRegistryEntryConfig",  # Alias
+    "ProviderRegistryConfig",
+    "ProviderRegistryModel",  # Alias
+    # Loader class
+    "ProviderLoaderImpl",
+    "ProviderRegistryLoader",  # Alias
+    # Validation functions
+    "ensure_provider_known",
+    "clear_provider_registry_cache",
+    # Factory functions
+    "get_provider_registry",
+    "create_provider_loader",
+    "default_provider_registry_loader",
+]

--- a/src/bioetl/infrastructure/config/provider_registry_loader.py
+++ b/src/bioetl/infrastructure/config/provider_registry_loader.py
@@ -1,18 +1,38 @@
-"""Infrastructure loader for provider registry configuration."""
+"""Infrastructure loader for provider registry configuration.
+
+.. deprecated::
+    This module is deprecated. Use :mod:`bioetl.infrastructure.config.provider_registry`
+    instead. All symbols are re-exported for backward compatibility.
+
+Migration guide:
+    Replace imports from:
+        ``from bioetl.infrastructure.config.provider_registry_loader import ...``
+    With:
+        ``from bioetl.infrastructure.config.provider_registry import ...``
+"""
 
 from __future__ import annotations
 
-from functools import lru_cache
-from pathlib import Path
-from typing import Any
+import warnings
 
-from pydantic import BaseModel, ConfigDict, ValidationError
-import yaml
+from bioetl.infrastructure.config.provider_registry import (
+    DEFAULT_PROVIDERS_REGISTRY_PATH,
+    ProviderNotConfiguredError,
+    ProviderRegistryConfig as ProviderRegistryModel,
+    ProviderRegistryEntryConfig,
+    ProviderRegistryError,
+    ProviderRegistryFormatError,
+    ProviderRegistryNotFoundError,
+    clear_provider_registry_cache,
+    ensure_provider_known,
+)
 
-from bioetl.domain.configs import HttpClientSettings
-
-DEFAULT_CONFIGS_ROOT = Path("configs")
-DEFAULT_PROVIDERS_REGISTRY_PATH = DEFAULT_CONFIGS_ROOT / "providers.yaml"
+warnings.warn(
+    "bioetl.infrastructure.config.provider_registry_loader is deprecated. "
+    "Use bioetl.infrastructure.config.provider_registry instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 __all__ = [
     "DEFAULT_PROVIDERS_REGISTRY_PATH",
@@ -22,95 +42,7 @@ __all__ = [
     "ProviderRegistryNotFoundError",
     "clear_provider_registry_cache",
     "ensure_provider_known",
+    # Deprecated aliases
+    "ProviderRegistryModel",
+    "ProviderRegistryEntryConfig",
 ]
-
-
-class ProviderRegistryError(Exception):
-    """Base error for provider registry issues."""
-
-
-class ProviderRegistryNotFoundError(ProviderRegistryError):
-    """Registry file is missing."""
-
-    def __init__(self, registry_path: Path) -> None:
-        self.registry_path = registry_path
-        super().__init__(f"Providers registry not found: {registry_path}")
-
-
-class ProviderRegistryFormatError(ProviderRegistryError):
-    """Registry file has invalid structure."""
-
-    def __init__(self, registry_path: Path, message: str) -> None:
-        self.registry_path = registry_path
-        super().__init__(f"{registry_path}: {message}")
-
-
-class ProviderNotConfiguredError(ProviderRegistryError):
-    """Requested provider is absent in registry."""
-
-    def __init__(self, provider: str, registry_path: Path) -> None:
-        self.provider = provider
-        self.registry_path = registry_path
-        super().__init__(
-            (
-                "Provider '{provider}' is not configured in providers config "
-                "{registry_path}"
-            ).format(provider=provider, registry_path=registry_path)
-        )
-
-
-class ProviderRegistryEntryConfig(BaseModel):
-    """Single provider entry from providers.yaml (private config model)."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    id: str
-    module: str
-    factory: str
-    active: bool = True
-    description: str | None = None
-    http_client: HttpClientSettings | None = None
-
-
-class ProviderRegistryModel(BaseModel):
-    """Validated providers.yaml content."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    providers: list[ProviderRegistryEntryConfig] = []
-
-
-def ensure_provider_known(provider: str, *, registry_path: Path | None = None) -> str:
-    """Validate that provider exists in registry and return it back."""
-
-    path = registry_path or DEFAULT_PROVIDERS_REGISTRY_PATH
-    registry = _load_provider_registry(path)
-    registered_ids = {entry.id for entry in registry.providers if entry.active}
-
-    if provider in registered_ids:
-        return provider
-
-    raise ProviderNotConfiguredError(provider, path)
-
-
-def clear_provider_registry_cache() -> None:
-    """Reset cached registry content (used in tests)."""
-
-    _load_provider_registry.cache_clear()
-
-
-def _read_registry_data(registry_path: Path) -> Any:
-    if not registry_path.exists():
-        raise ProviderRegistryNotFoundError(registry_path)
-
-    with registry_path.open("r", encoding="utf-8") as file:
-        return yaml.safe_load(file) or {}
-
-
-@lru_cache(maxsize=None)
-def _load_provider_registry(registry_path: Path) -> ProviderRegistryModel:
-    data: Any = _read_registry_data(registry_path)
-    try:
-        return ProviderRegistryModel.model_validate(data)
-    except ValidationError as exc:
-        raise ProviderRegistryFormatError(registry_path, exc.__str__()) from exc

--- a/src/bioetl/interfaces/cli/app.py
+++ b/src/bioetl/interfaces/cli/app.py
@@ -16,7 +16,7 @@ from bioetl.application.config.resolution import (
 from bioetl.application.orchestrator import PipelineOrchestrator
 from bioetl.application.pipelines.registry import PIPELINE_REGISTRY
 from bioetl.domain.configs import PipelineConfig
-from bioetl.infrastructure.clients.provider_registry_loader import (
+from bioetl.infrastructure.config.provider_registry import (
     create_provider_loader,
 )
 from bioetl.infrastructure.config.sources import get_configs_root

--- a/src/bioetl/interfaces/rest/server.py
+++ b/src/bioetl/interfaces/rest/server.py
@@ -18,7 +18,7 @@ from bioetl.domain.provider_registry import (
     ProviderRegistryABC,
     ProviderRegistryLoaderABC,
 )
-from bioetl.infrastructure.clients.provider_registry_loader import (
+from bioetl.infrastructure.config.provider_registry import (
     create_provider_loader,
 )
 from bioetl.interfaces.container_factory import create_config_loader

--- a/tests/bioetl/infrastructure/config/test_provider_registry.py
+++ b/tests/bioetl/infrastructure/config/test_provider_registry.py
@@ -1,0 +1,750 @@
+"""Unit tests for the unified provider registry module."""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Callable
+
+import pytest
+import yaml
+
+from bioetl.domain.configs import DummyProviderConfig, HttpClientSettings
+from bioetl.domain.observability.contracts import LoggingPortABC
+from bioetl.domain.provider_registry import InMemoryProviderRegistry
+from bioetl.domain.providers import ProviderComponents, ProviderDefinition, ProviderId
+from bioetl.infrastructure.config.provider_registry import (
+    DEFAULT_PROVIDERS_REGISTRY_PATH,
+    ProviderLoaderImpl,
+    ProviderNotConfiguredError,
+    ProviderRegistryConfig,
+    ProviderRegistryEntryModel,
+    ProviderRegistryError,
+    ProviderRegistryFormatError,
+    ProviderRegistryNotFoundError,
+    clear_provider_registry_cache,
+    create_provider_loader,
+    default_provider_registry_loader,
+    ensure_provider_known,
+    get_provider_registry,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test Fixtures and Helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DummyComponents(ProviderComponents):
+    """Test provider components."""
+
+    def create_client(self, config: DummyProviderConfig) -> dict[str, str]:
+        return {"provider": config.provider}
+
+    def create_extraction_service(
+        self, config: DummyProviderConfig, *, client: dict[str, str] | None = None
+    ) -> tuple[dict[str, str], str]:
+        resolved_client = client or self.create_client(config)
+        return resolved_client, config.provider
+
+
+class RecordingLogger(LoggingPortABC):
+    """Logger that records all log calls for testing."""
+
+    def __init__(self) -> None:
+        self.records: list[tuple[str, str, dict[str, Any]]] = []
+
+    def info(self, msg: str, **ctx: Any) -> None:
+        self.records.append(("info", msg, ctx))
+
+    def error(self, msg: str, **ctx: Any) -> None:
+        self.records.append(("error", msg, ctx))
+
+    def debug(self, msg: str, **ctx: Any) -> None:
+        self.records.append(("debug", msg, ctx))
+
+    def warning(self, msg: str, **ctx: Any) -> None:
+        self.records.append(("warning", msg, ctx))
+
+    def apply_bind(self, **ctx: Any) -> RecordingLogger:
+        self.records.append(("bind", "", ctx))
+        return self
+
+    @property
+    def errors(self) -> list[tuple[str, str, dict[str, Any]]]:
+        return [record for record in self.records if record[0] == "error"]
+
+    @property
+    def debugs(self) -> list[tuple[str, str, dict[str, Any]]]:
+        return [record for record in self.records if record[0] == "debug"]
+
+
+@pytest.fixture
+def provider_definition_factory() -> Callable[[ProviderId], ProviderDefinition]:
+    """Factory fixture for creating test provider definitions."""
+
+    def _factory(provider_id: ProviderId) -> ProviderDefinition:
+        return ProviderDefinition(
+            id=provider_id,
+            config_type=DummyProviderConfig,
+            components=DummyComponents(),
+            description="Test provider",
+        )
+
+    return _factory
+
+
+@pytest.fixture
+def recording_logger() -> RecordingLogger:
+    """Fixture for recording logger."""
+    return RecordingLogger()
+
+
+@pytest.fixture(autouse=True)
+def clear_cache() -> None:
+    """Clear registry cache before and after each test."""
+    clear_provider_registry_cache()
+    yield
+    clear_provider_registry_cache()
+
+
+def _register_module(
+    module_name: str, factory_name: str, factory: Callable[..., Any]
+) -> None:
+    """Register a synthetic module with a factory function."""
+    module = ModuleType(module_name)
+    setattr(module, factory_name, factory)
+    sys.modules[module_name] = module
+
+
+def _unregister_module(module_name: str) -> None:
+    """Remove a synthetic module from sys.modules."""
+    sys.modules.pop(module_name, None)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Exceptions
+# ---------------------------------------------------------------------------
+
+
+class TestProviderRegistryExceptions:
+    """Tests for exception classes."""
+
+    def test_provider_registry_not_found_error(self) -> None:
+        path = Path("/nonexistent/providers.yaml")
+        error = ProviderRegistryNotFoundError(path)
+        assert error.registry_path == path
+        assert error.path == path  # Alias
+        assert "not found" in str(error).lower()
+
+    def test_provider_registry_format_error(self) -> None:
+        path = Path("/test/providers.yaml")
+        error = ProviderRegistryFormatError(path, "invalid schema")
+        assert error.registry_path == path
+        assert error.path == path  # Alias
+        assert "invalid schema" in str(error)
+
+    def test_provider_not_configured_error(self) -> None:
+        path = Path("/test/providers.yaml")
+        error = ProviderNotConfiguredError("unknown_provider", path)
+        assert error.provider == "unknown_provider"
+        assert error.registry_path == path
+        assert "unknown_provider" in str(error)
+
+    def test_exception_inheritance(self) -> None:
+        assert issubclass(ProviderRegistryNotFoundError, ProviderRegistryError)
+        assert issubclass(ProviderRegistryFormatError, ProviderRegistryError)
+        assert issubclass(ProviderNotConfiguredError, ProviderRegistryError)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Pydantic Models
+# ---------------------------------------------------------------------------
+
+
+class TestProviderRegistryModels:
+    """Tests for Pydantic models."""
+
+    def test_entry_model_with_string_id(self) -> None:
+        entry = ProviderRegistryEntryModel(
+            id="chembl",
+            module="bioetl.infrastructure.clients.chembl.provider",
+            factory="register_chembl_provider",
+        )
+        assert entry.id == "chembl"
+        assert entry.active is True
+        assert entry.description is None
+        assert entry.http_client is None
+
+    def test_entry_model_with_provider_id_enum(self) -> None:
+        entry = ProviderRegistryEntryModel(
+            id=ProviderId.CHEMBL,
+            module="bioetl.infrastructure.clients.chembl.provider",
+            factory="register_chembl_provider",
+            active=False,
+            description="ChEMBL provider",
+        )
+        assert entry.id == ProviderId.CHEMBL
+        assert entry.active is False
+        assert entry.description == "ChEMBL provider"
+
+    def test_entry_model_with_http_client(self) -> None:
+        http_settings = HttpClientSettings(
+            base_url="https://api.example.com", timeout=60, retries=5
+        )
+        entry = ProviderRegistryEntryModel(
+            id="custom",
+            module="custom.module",
+            factory="create_provider",
+            http_client=http_settings,
+        )
+        assert entry.http_client is not None
+        assert entry.http_client.timeout == 60
+        assert entry.http_client.retries == 5
+
+    def test_registry_config_model(self) -> None:
+        config = ProviderRegistryConfig(
+            providers=[
+                ProviderRegistryEntryModel(
+                    id="chembl",
+                    module="bioetl.infrastructure.clients.chembl.provider",
+                    factory="register_chembl_provider",
+                ),
+                ProviderRegistryEntryModel(
+                    id="pubchem",
+                    module="bioetl.infrastructure.clients.pubchem.provider",
+                    factory="register_pubchem_provider",
+                    active=False,
+                ),
+            ]
+        )
+        assert len(config.providers) == 2
+        assert config.providers[0].id == "chembl"
+        assert config.providers[1].active is False
+
+    def test_registry_config_empty_providers(self) -> None:
+        config = ProviderRegistryConfig()
+        assert config.providers == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: ensure_provider_known
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureProviderKnown:
+    """Tests for ensure_provider_known function."""
+
+    def test_known_provider_returns_id(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "providers.yaml"
+        config_file.write_text(
+            yaml.dump(
+                {
+                    "providers": [
+                        {
+                            "id": "chembl",
+                            "module": "test.module",
+                            "factory": "create",
+                            "active": True,
+                        }
+                    ]
+                }
+            )
+        )
+
+        result = ensure_provider_known("chembl", registry_path=config_file)
+        assert result == "chembl"
+
+    def test_unknown_provider_raises_error(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "providers.yaml"
+        config_file.write_text(
+            yaml.dump(
+                {
+                    "providers": [
+                        {
+                            "id": "chembl",
+                            "module": "test.module",
+                            "factory": "create",
+                            "active": True,
+                        }
+                    ]
+                }
+            )
+        )
+
+        with pytest.raises(ProviderNotConfiguredError) as exc_info:
+            ensure_provider_known("unknown", registry_path=config_file)
+        assert exc_info.value.provider == "unknown"
+
+    def test_inactive_provider_not_found(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "providers.yaml"
+        config_file.write_text(
+            yaml.dump(
+                {
+                    "providers": [
+                        {
+                            "id": "chembl",
+                            "module": "test.module",
+                            "factory": "create",
+                            "active": False,
+                        }
+                    ]
+                }
+            )
+        )
+
+        with pytest.raises(ProviderNotConfiguredError):
+            ensure_provider_known("chembl", registry_path=config_file)
+
+    def test_missing_registry_file_raises_error(self, tmp_path: Path) -> None:
+        nonexistent = tmp_path / "nonexistent.yaml"
+
+        with pytest.raises(ProviderRegistryNotFoundError) as exc_info:
+            ensure_provider_known("chembl", registry_path=nonexistent)
+        assert exc_info.value.registry_path == nonexistent
+
+    def test_invalid_registry_format_raises_error(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "providers.yaml"
+        config_file.write_text(
+            yaml.dump(
+                {
+                    "providers": [
+                        {"invalid": "schema"}  # Missing required fields
+                    ]
+                }
+            )
+        )
+
+        with pytest.raises(ProviderRegistryFormatError):
+            ensure_provider_known("chembl", registry_path=config_file)
+
+
+# ---------------------------------------------------------------------------
+# Tests: ProviderLoaderImpl
+# ---------------------------------------------------------------------------
+
+
+class TestProviderLoaderImpl:
+    """Tests for ProviderLoaderImpl class."""
+
+    def test_loader_raises_on_missing_config(
+        self, tmp_path: Path, recording_logger: RecordingLogger
+    ) -> None:
+        nonexistent = tmp_path / "nonexistent.yaml"
+        loader = ProviderLoaderImpl(config_path=nonexistent, logger=recording_logger)
+
+        with pytest.raises(ProviderRegistryNotFoundError):
+            loader.get_providers()
+
+    def test_loader_raises_on_invalid_config(
+        self, tmp_path: Path, recording_logger: RecordingLogger
+    ) -> None:
+        config_file = tmp_path / "providers.yaml"
+        # Write valid YAML but invalid schema (missing required fields)
+        config_file.write_text(
+            yaml.dump(
+                {
+                    "providers": [
+                        {"invalid_field": "value"}  # Missing required id, module, factory
+                    ]
+                }
+            )
+        )
+        loader = ProviderLoaderImpl(config_path=config_file, logger=recording_logger)
+
+        with pytest.raises(ProviderRegistryFormatError):
+            loader.get_providers()
+
+    def test_loader_skips_disabled_entries(
+        self,
+        tmp_path: Path,
+        recording_logger: RecordingLogger,
+        provider_definition_factory: Callable[[ProviderId], ProviderDefinition],
+    ) -> None:
+        # Register test module
+        def factory(http_client: HttpClientSettings | None = None) -> ProviderDefinition:
+            return provider_definition_factory(ProviderId.DUMMY)
+
+        _register_module("test_module_disabled", "create_provider", factory)
+
+        try:
+            config_file = tmp_path / "providers.yaml"
+            config_file.write_text(
+                yaml.dump(
+                    {
+                        "providers": [
+                            {
+                                "id": "dummy",
+                                "module": "test_module_disabled",
+                                "factory": "create_provider",
+                                "active": False,
+                            }
+                        ]
+                    }
+                )
+            )
+
+            loader = ProviderLoaderImpl(
+                config_path=config_file, logger=recording_logger
+            )
+            providers = loader.get_providers()
+
+            # Should fallback to ChEMBL since no active providers
+            assert len(providers) == 1
+            assert providers[0].id == ProviderId.CHEMBL
+
+            # Should have logged debug message about disabled entry
+            debug_msgs = [r[1] for r in recording_logger.debugs]
+            assert any("disabled" in msg.lower() for msg in debug_msgs)
+        finally:
+            _unregister_module("test_module_disabled")
+
+    def test_loader_handles_module_import_error(
+        self, tmp_path: Path, recording_logger: RecordingLogger
+    ) -> None:
+        config_file = tmp_path / "providers.yaml"
+        config_file.write_text(
+            yaml.dump(
+                {
+                    "providers": [
+                        {
+                            "id": "dummy",
+                            "module": "nonexistent.module",
+                            "factory": "create_provider",
+                            "active": True,
+                        }
+                    ]
+                }
+            )
+        )
+
+        loader = ProviderLoaderImpl(config_path=config_file, logger=recording_logger)
+        providers = loader.get_providers()
+
+        # Should fallback to ChEMBL
+        assert len(providers) == 1
+        assert providers[0].id == ProviderId.CHEMBL
+
+        # Should have logged error about import failure
+        error_msgs = [r[1] for r in recording_logger.errors]
+        assert any("import" in msg.lower() for msg in error_msgs)
+
+    def test_loader_handles_missing_factory(
+        self, tmp_path: Path, recording_logger: RecordingLogger
+    ) -> None:
+        # Register test module without factory
+        _register_module("test_module_no_factory", "other_function", lambda: None)
+
+        try:
+            config_file = tmp_path / "providers.yaml"
+            config_file.write_text(
+                yaml.dump(
+                    {
+                        "providers": [
+                            {
+                                "id": "dummy",
+                                "module": "test_module_no_factory",
+                                "factory": "create_provider",
+                                "active": True,
+                            }
+                        ]
+                    }
+                )
+            )
+
+            loader = ProviderLoaderImpl(
+                config_path=config_file, logger=recording_logger
+            )
+            providers = loader.get_providers()
+
+            # Should fallback to ChEMBL
+            assert len(providers) == 1
+            assert providers[0].id == ProviderId.CHEMBL
+
+            # Should have logged error about missing factory
+            error_msgs = [r[1] for r in recording_logger.errors]
+            assert any("not found" in msg.lower() for msg in error_msgs)
+        finally:
+            _unregister_module("test_module_no_factory")
+
+    def test_loader_handles_factory_returning_wrong_type(
+        self, tmp_path: Path, recording_logger: RecordingLogger
+    ) -> None:
+        # Register test module with factory returning wrong type
+        def wrong_factory(
+            http_client: HttpClientSettings | None = None,
+        ) -> dict[str, str]:
+            return {"not": "a provider"}
+
+        _register_module("test_module_wrong_type", "create_provider", wrong_factory)
+
+        try:
+            config_file = tmp_path / "providers.yaml"
+            config_file.write_text(
+                yaml.dump(
+                    {
+                        "providers": [
+                            {
+                                "id": "dummy",
+                                "module": "test_module_wrong_type",
+                                "factory": "create_provider",
+                                "active": True,
+                            }
+                        ]
+                    }
+                )
+            )
+
+            loader = ProviderLoaderImpl(
+                config_path=config_file, logger=recording_logger
+            )
+            providers = loader.get_providers()
+
+            # Should fallback to ChEMBL
+            assert len(providers) == 1
+            assert providers[0].id == ProviderId.CHEMBL
+
+            # Should have logged error about unexpected type
+            error_msgs = [r[1] for r in recording_logger.errors]
+            assert any("unexpected type" in msg.lower() for msg in error_msgs)
+        finally:
+            _unregister_module("test_module_wrong_type")
+
+    def test_loader_registers_provider_successfully(
+        self,
+        tmp_path: Path,
+        recording_logger: RecordingLogger,
+        provider_definition_factory: Callable[[ProviderId], ProviderDefinition],
+    ) -> None:
+        # Register test module with valid factory
+        def valid_factory(
+            http_client: HttpClientSettings | None = None,
+        ) -> ProviderDefinition:
+            return provider_definition_factory(ProviderId.DUMMY)
+
+        _register_module("test_module_valid", "create_provider", valid_factory)
+
+        try:
+            config_file = tmp_path / "providers.yaml"
+            config_file.write_text(
+                yaml.dump(
+                    {
+                        "providers": [
+                            {
+                                "id": "dummy",
+                                "module": "test_module_valid",
+                                "factory": "create_provider",
+                                "active": True,
+                            }
+                        ]
+                    }
+                )
+            )
+
+            loader = ProviderLoaderImpl(
+                config_path=config_file, logger=recording_logger
+            )
+            providers = loader.get_providers()
+
+            assert len(providers) == 1
+            assert providers[0].id == ProviderId.DUMMY
+        finally:
+            _unregister_module("test_module_valid")
+
+    def test_get_registry_returns_populated_registry(
+        self,
+        tmp_path: Path,
+        recording_logger: RecordingLogger,
+        provider_definition_factory: Callable[[ProviderId], ProviderDefinition],
+    ) -> None:
+        def valid_factory(
+            http_client: HttpClientSettings | None = None,
+        ) -> ProviderDefinition:
+            return provider_definition_factory(ProviderId.DUMMY)
+
+        _register_module("test_module_registry", "create_provider", valid_factory)
+
+        try:
+            config_file = tmp_path / "providers.yaml"
+            config_file.write_text(
+                yaml.dump(
+                    {
+                        "providers": [
+                            {
+                                "id": "dummy",
+                                "module": "test_module_registry",
+                                "factory": "create_provider",
+                                "active": True,
+                            }
+                        ]
+                    }
+                )
+            )
+
+            loader = ProviderLoaderImpl(
+                config_path=config_file, logger=recording_logger
+            )
+            registry = loader.get_registry()
+
+            assert registry is not None
+            provider = registry.get_provider(ProviderId.DUMMY)
+            assert provider.id == ProviderId.DUMMY
+        finally:
+            _unregister_module("test_module_registry")
+
+    def test_load_method_is_alias_for_get_providers(
+        self, tmp_path: Path, recording_logger: RecordingLogger
+    ) -> None:
+        config_file = tmp_path / "providers.yaml"
+        config_file.write_text(yaml.dump({"providers": []}))
+
+        loader = ProviderLoaderImpl(config_path=config_file, logger=recording_logger)
+
+        providers_via_get = loader.get_providers()
+        providers_via_load = loader.load()
+
+        # Both should return ChEMBL fallback
+        assert len(providers_via_get) == len(providers_via_load) == 1
+        assert providers_via_get[0].id == providers_via_load[0].id == ProviderId.CHEMBL
+
+
+# ---------------------------------------------------------------------------
+# Tests: Factory Functions
+# ---------------------------------------------------------------------------
+
+
+class TestFactoryFunctions:
+    """Tests for factory functions."""
+
+    def test_create_provider_loader(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "providers.yaml"
+        config_file.write_text(yaml.dump({"providers": []}))
+
+        loader = create_provider_loader(config_path=config_file)
+
+        assert isinstance(loader, ProviderLoaderImpl)
+
+    def test_default_provider_registry_loader(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "providers.yaml"
+        config_file.write_text(yaml.dump({"providers": []}))
+
+        loader = default_provider_registry_loader(config_path=config_file)
+
+        assert isinstance(loader, ProviderLoaderImpl)
+
+    def test_get_provider_registry_function(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "providers.yaml"
+        config_file.write_text(yaml.dump({"providers": []}))
+
+        registry = get_provider_registry(config_path=config_file)
+
+        assert registry is not None
+        # Should have ChEMBL fallback
+        provider = registry.get_provider(ProviderId.CHEMBL)
+        assert provider.id == ProviderId.CHEMBL
+
+
+# ---------------------------------------------------------------------------
+# Tests: Cache
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryCache:
+    """Tests for registry caching behavior."""
+
+    def test_clear_cache_function(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "providers.yaml"
+        config_file.write_text(
+            yaml.dump(
+                {
+                    "providers": [
+                        {
+                            "id": "chembl",
+                            "module": "test.module",
+                            "factory": "create",
+                            "active": True,
+                        }
+                    ]
+                }
+            )
+        )
+
+        # First call caches the result
+        result1 = ensure_provider_known("chembl", registry_path=config_file)
+        assert result1 == "chembl"
+
+        # Modify file
+        config_file.write_text(
+            yaml.dump(
+                {
+                    "providers": [
+                        {
+                            "id": "pubchem",
+                            "module": "test.module",
+                            "factory": "create",
+                            "active": True,
+                        }
+                    ]
+                }
+            )
+        )
+
+        # Without clearing cache, should still find chembl (cached)
+        result2 = ensure_provider_known("chembl", registry_path=config_file)
+        assert result2 == "chembl"
+
+        # After clearing cache, should not find chembl
+        clear_provider_registry_cache()
+        with pytest.raises(ProviderNotConfiguredError):
+            ensure_provider_known("chembl", registry_path=config_file)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Constants
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    """Tests for module constants."""
+
+    def test_default_paths(self) -> None:
+        assert DEFAULT_PROVIDERS_REGISTRY_PATH == Path("configs/providers.yaml")
+
+
+# ---------------------------------------------------------------------------
+# Tests: Backward Compatibility Aliases
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompatibilityAliases:
+    """Tests to ensure backward compatibility aliases work."""
+
+    def test_exception_aliases(self) -> None:
+        from bioetl.infrastructure.config.provider_registry import (
+            ProviderRegistryConfigNotFoundError,
+            ProviderRegistryLoaderError,
+            ProviderRegistryValidationError,
+        )
+
+        assert ProviderRegistryLoaderError is ProviderRegistryError
+        assert ProviderRegistryConfigNotFoundError is ProviderRegistryNotFoundError
+        assert ProviderRegistryValidationError is ProviderRegistryFormatError
+
+    def test_model_aliases(self) -> None:
+        from bioetl.infrastructure.config.provider_registry import (
+            ProviderRegistryEntryConfig,
+            ProviderRegistryModel,
+        )
+
+        assert ProviderRegistryEntryConfig is ProviderRegistryEntryModel
+        assert ProviderRegistryModel is ProviderRegistryConfig
+
+    def test_loader_alias(self) -> None:
+        from bioetl.infrastructure.config.provider_registry import (
+            ProviderRegistryLoader,
+        )
+
+        assert ProviderRegistryLoader is ProviderLoaderImpl


### PR DESCRIPTION
…nto single module

Consolidate two provider registry loader modules into a unified module at infrastructure/config/provider_registry.py to establish a single source of truth.

Changes:
- Create unified provider_registry.py combining validation, caching, and dynamic provider loading functionality
- Update old modules to re-export from new location with DeprecationWarning
- Update direct imports in loader.py, server.py, and app.py
- Add comprehensive unit tests (31 test cases)

The merged module includes:
- All exceptions: ProviderRegistryError, ProviderNotConfiguredError, etc.
- Pydantic models: ProviderRegistryEntryModel, ProviderRegistryConfig
- Validation: ensure_provider_known() with caching
- Dynamic loading: ProviderLoaderImpl class
- Factory functions: create_provider_loader(), get_provider_registry()

Backward compatibility is preserved via re-exports with deprecation warnings.