### PR TITLE
Move ApiRecordSource to application layer

### DIFF
--- a/src/bioetl/application/factories/record_source.py
+++ b/src/bioetl/application/factories/record_source.py
@@ -15,7 +15,8 @@ from bioetl.application.transform.pandas_batch_adapter import PandasBatchAdapter
 from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.observability import LoggingPortABC
 from bioetl.domain.providers import ProviderDefinition
-from bioetl.domain.record_source import ApiRecordSource, RecordSourceABC
+from bioetl.application.sources import ApiRecordSource
+from bioetl.domain.record_source import RecordSourceABC
 
 
 class RecordSourceFactory:

--- a/src/bioetl/application/pipelines/chembl/extractor.py
+++ b/src/bioetl/application/pipelines/chembl/extractor.py
@@ -19,7 +19,8 @@ from bioetl.domain.ports.extraction import (
     BatchAdapterABC,
     ExtractionServiceABC,
 )
-from bioetl.domain.record_source import ApiRecordSource, RecordSourceABC
+from bioetl.application.sources import ApiRecordSource
+from bioetl.domain.record_source import RecordSourceABC
 from bioetl.domain.schemas.chembl.raw_models import ActivityRawModel
 from bioetl.domain.transform.contracts import NormalizationServiceABC
 

--- a/src/bioetl/application/sources/__init__.py
+++ b/src/bioetl/application/sources/__init__.py
@@ -1,0 +1,10 @@
+"""
+Application layer record source implementations.
+
+This package contains concrete RecordSource implementations that orchestrate
+data fetching from external sources (APIs, files, etc.).
+"""
+
+from bioetl.application.sources.api_record_source import ApiRecordSource
+
+__all__ = ["ApiRecordSource"]

--- a/src/bioetl/application/sources/api_record_source.py
+++ b/src/bioetl/application/sources/api_record_source.py
@@ -1,0 +1,84 @@
+"""
+API-based record source implementation.
+
+This module was moved from bioetl.domain.record_source to application layer
+as part of Hexagonal Architecture refactoring. The ApiRecordSource contains
+orchestration logic that belongs in the application layer, not the domain layer.
+
+Previous location: bioetl.domain.record_source
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, Callable
+
+from bioetl.domain.ports.extraction import RecordFetcherABC
+from bioetl.domain.record_source import RawRecord, RecordSourceABC
+
+
+class ApiRecordSource(RecordSourceABC):
+    """Record source that fetches data from an extraction service.
+
+    This class orchestrates data fetching from external APIs via a
+    RecordFetcherABC port. It belongs in the application layer as it
+    coordinates infrastructure concerns with domain logic.
+
+    Args:
+        extraction_service: The extraction service port for fetching records.
+        entity: The entity type to fetch (e.g., 'molecule', 'activity').
+        filters: Optional filters to apply during extraction.
+        chunk_size: Optional batch size for chunked iteration.
+        batch_adapter: Optional callable to transform raw batches to RawRecord lists.
+
+    Example:
+        >>> source = ApiRecordSource(
+        ...     extraction_service=chembl_fetcher,
+        ...     entity="molecule",
+        ...     filters={"molecule_type": "Small molecule"},
+        ...     chunk_size=1000,
+        ... )
+        >>> for batch in source.iter_records():
+        ...     process(batch)
+    """
+
+    def __init__(
+        self,
+        extraction_service: RecordFetcherABC,
+        entity: str,
+        filters: dict[str, Any] | None = None,
+        chunk_size: int | None = None,
+        batch_adapter: Callable[[Any], list[RawRecord]] | None = None,
+    ) -> None:
+        self._extraction_service = extraction_service
+        self._entity = entity
+        self._filters = filters or {}
+        self._chunk_size = chunk_size
+        self._batch_adapter = batch_adapter
+
+    def iter_records(self) -> Iterable[list[RawRecord]]:
+        """Iterate over extracted provider batches as normalized records.
+
+        Yields:
+            Lists of RawRecord instances, each list representing a batch
+            of records from the extraction service.
+
+        Raises:
+            TypeError: If iter_extract yields non-list values and no
+                batch_adapter is configured.
+        """
+        filters = dict(self._filters)
+        for raw_batch in self._extraction_service.iter_extract(
+            self._entity, chunk_size=self._chunk_size, **filters
+        ):
+            if self._batch_adapter is not None:
+                yield self._batch_adapter(raw_batch)
+                continue
+
+            if not isinstance(raw_batch, list):
+                raise TypeError(
+                    "iter_extract must yield list[RawRecord] when no batch_adapter "
+                    "is set."
+                )
+
+            yield raw_batch

--- a/src/bioetl/domain/record_source.py
+++ b/src/bioetl/domain/record_source.py
@@ -1,14 +1,22 @@
-"""Core record source interfaces and helpers."""
+"""Core record source interfaces and helpers.
+
+This module defines the abstract interface for record sources (RecordSourceABC)
+and the RawRecord value object. Concrete implementations that involve
+orchestration logic are located in the application layer.
+
+See also:
+    - bioetl.application.sources.ApiRecordSource: API-based record source
+    - bioetl.application.files: File-based record sources
+"""
 
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
-from typing import Any, Callable
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict
-
-from bioetl.domain.ports.extraction import RecordFetcherABC
 
 
 class RawRecord(BaseModel):
@@ -42,37 +50,29 @@ class InMemoryRecordSource(RecordSourceABC):
             yield self._records[start : start + self._chunk_size]
 
 
-class ApiRecordSource(RecordSourceABC):
-    """Record source that fetches data from an extraction service."""
+def __getattr__(name: str) -> Any:
+    """Provide backward compatibility for ApiRecordSource import.
 
-    def __init__(
-        self,
-        extraction_service: RecordFetcherABC,
-        entity: str,
-        filters: dict[str, Any] | None = None,
-        chunk_size: int | None = None,
-        batch_adapter: Callable[[Any], list[RawRecord]] | None = None,
-    ) -> None:
-        self._extraction_service = extraction_service
-        self._entity = entity
-        self._filters = filters or {}
-        self._chunk_size = chunk_size
-        self._batch_adapter = batch_adapter
+    This function allows importing ApiRecordSource from the old location
+    while emitting a deprecation warning.
 
-    def iter_records(self) -> Iterable[list[RawRecord]]:
-        """Iterate over extracted provider batches as normalized records."""
-        filters = dict(self._filters)
-        for raw_batch in self._extraction_service.iter_extract(
-            self._entity, chunk_size=self._chunk_size, **filters
-        ):
-            if self._batch_adapter is not None:
-                yield self._batch_adapter(raw_batch)
-                continue
+    Args:
+        name: The attribute name being accessed.
 
-            if not isinstance(raw_batch, list):
-                raise TypeError(
-                    "iter_extract must yield list[RawRecord] when no batch_adapter "
-                    "is set."
-                )
+    Returns:
+        The ApiRecordSource class from its new location.
 
-            yield raw_batch
+    Raises:
+        AttributeError: If the requested attribute is not ApiRecordSource.
+    """
+    if name == "ApiRecordSource":
+        warnings.warn(
+            "Importing ApiRecordSource from bioetl.domain.record_source is deprecated. "
+            "Use 'from bioetl.application.sources import ApiRecordSource' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from bioetl.application.sources import ApiRecordSource
+
+        return ApiRecordSource
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/bioetl/domain/test_record_source.py
+++ b/tests/bioetl/domain/test_record_source.py
@@ -2,7 +2,8 @@ from collections.abc import Iterable
 from typing import cast
 
 from bioetl.domain.ports.extraction import ExtractionServiceABC
-from bioetl.domain.record_source import ApiRecordSource, InMemoryRecordSource, RawRecord
+from bioetl.application.sources import ApiRecordSource
+from bioetl.domain.record_source import InMemoryRecordSource, RawRecord
 
 
 class _DummyExtractionService:


### PR DESCRIPTION
…n layer

Move ApiRecordSource class to application layer to comply with Hexagonal Architecture principles. The class contains orchestration logic that coordinates infrastructure concerns (API fetching) with domain logic, which belongs in the application layer rather than domain.

Changes:
- Create src/bioetl/application/sources/ package
- Move ApiRecordSource to application/sources/api_record_source.py
- Add deprecation warning for imports from old location
- Update all imports in dependent files
- Preserve backward compatibility via __getattr__ in domain module