### PR TITLE
Remove duplicate methods from extraction layer

### DIFF
--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -16,7 +16,7 @@ from bioetl.domain.observability import LoggingPortABC, MetricsPortABC
 from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
 from bioetl.domain.provider_registry import ProviderRegistryABC
 from bioetl.domain.providers import ProviderDefinition, ProviderId
-from bioetl.domain.record_source import RecordSource
+from bioetl.domain.record_source import RecordSourceABC as RecordSource
 from bioetl.domain.schemas import register_schemas
 from bioetl.domain.schemas.registry import SchemaRegistry
 from bioetl.domain.transform.contracts import HashServiceABC, NormalizationServiceABC

--- a/src/bioetl/application/pipelines/chembl/base.py
+++ b/src/bioetl/application/pipelines/chembl/base.py
@@ -26,7 +26,7 @@ from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
 from bioetl.domain.ports.extraction import (
     ExtractionServiceABC,
 )
-from bioetl.domain.record_source import RecordSource
+from bioetl.domain.record_source import RecordSourceABC as RecordSource
 from bioetl.domain.schemas.chembl.raw_models import ActivityRawModel
 from bioetl.domain.schemas.pipeline_contracts import get_pipeline_contract
 from bioetl.domain.transform.contracts import HashServiceABC, NormalizationServiceABC

--- a/src/bioetl/application/pipelines/contracts.py
+++ b/src/bioetl/application/pipelines/contracts.py
@@ -12,7 +12,7 @@ from bioetl.domain.pipelines.contracts import (
     LoaderABC,
     PipelineHookABC,
 )
-from bioetl.domain.record_source import RecordSource
+from bioetl.domain.record_source import RecordSourceABC as RecordSource
 from bioetl.domain.transform.contracts import HashServiceABC, NormalizationServiceABC
 from bioetl.domain.transform.transformers import TransformerABC
 from bioetl.domain.validation.service import ValidationService

--- a/src/bioetl/domain/ports/extraction.py
+++ b/src/bioetl/domain/ports/extraction.py
@@ -33,35 +33,29 @@ class VersionProviderABC(ABC):
 
 
 class ExtractionServiceABC(RecordFetcherABC):
-    """Абстракция сервиса извлечения данных из провайдера."""
+    """Расширенный сервис извлечения с поддержкой версионирования и сериализации.
+
+    Наследует базовые методы iter_extract() и extract_all() от RecordFetcherABC.
+    Добавляет методы для работы с версиями, батчами и сериализацией.
+    """
 
     @abstractmethod
     def get_release_version(self) -> str:
-        """Версия релиза источника (например, chembl_34)."""
-
-    @abstractmethod
-    def extract_all(self, entity: str, **filters: object) -> list["RawRecord"]:
-        """Извлекает все записи указанной сущности, применяя фильтры."""
-
-    @abstractmethod
-    def iter_extract(
-        self, entity: str, *, chunk_size: int | None = None, **filters: object
-    ) -> Iterable[list["RawRecord"]]:
-        """Итерирует по чанкам сырых записей."""
+        """Получить версию источника данных."""
 
     @abstractmethod
     def request_batch(
         self, entity: str, batch_ids: list[str], filter_key: str
     ) -> dict[str, object]:
-        """Запрашивает пакет записей по списку идентификаторов."""
+        """Запросить батч по идентификаторам."""
 
     @abstractmethod
     def parse_response(self, raw_response: object) -> list["RawRecord"]:
-        """Парсит сырой ответ в структуру RawRecord."""
+        """Разобрать сырой ответ в записи."""
 
     @abstractmethod
     def serialize_records(self, entity: str, records: list[object]) -> list[object]:
-        """Сериализует нормализованные записи для экспорта/передачи."""
+        """Сериализовать записи для вывода."""
 
 
 class BatchAdapterABC(Protocol):


### PR DESCRIPTION
- Remove iter_extract() and extract_all() from ExtractionServiceABC as they are inherited from RecordFetcherABC base class
- Fix RecordSource import issues by using RecordSourceABC alias in application layer modules
- Update docstrings to clarify inheritance relationship
- Resolves DUP-04 from domain layer audit