### PR TITLE
Remove duplicate ChEMBL entity endpoint mapping

### DIFF
--- a/src/bioetl/infrastructure/clients/chembl/constants.py
+++ b/src/bioetl/infrastructure/clients/chembl/constants.py
@@ -1,0 +1,62 @@
+"""
+Constants for ChEMBL API client.
+
+This module contains mappings and constants used across ChEMBL client implementations.
+"""
+
+from types import MappingProxyType
+from typing import Mapping
+
+# Entity to endpoint mapping for ChEMBL API.
+#
+# ChEMBL API uses different endpoint names than our domain entity names in some cases.
+# This mapping translates our internal entity names to ChEMBL API endpoint names.
+#
+# Mapping rationale:
+#   - "activity" → "activity": Direct mapping, no translation needed.
+#   - "assay" → "assay": Direct mapping, no translation needed.
+#   - "target" → "target": Direct mapping, no translation needed.
+#   - "molecule" → "molecule": Direct mapping, no translation needed.
+#   - "publication" → "document": ChEMBL API uses "document" endpoint for publications.
+#     The ChEMBL database stores publication data (journal articles, patents, etc.)
+#     in the "document" table, hence the API endpoint is named "document".
+#     Our domain model uses "publication" as it better represents the concept.
+#
+# Reference: https://www.ebi.ac.uk/chembl/api/data/docs
+ENTITY_ENDPOINT_ALIASES: Mapping[str, str] = MappingProxyType(
+    {
+        "activity": "activity",
+        "assay": "assay",
+        "target": "target",
+        "molecule": "molecule",
+        "publication": "document",
+    }
+)
+
+# Set of supported entity names for validation
+SUPPORTED_ENTITIES: frozenset[str] = frozenset(ENTITY_ENDPOINT_ALIASES.keys())
+
+
+def resolve_endpoint(entity: str) -> str:
+    """
+    Resolve entity name to ChEMBL API endpoint.
+
+    Args:
+        entity: The domain entity name (e.g., "publication", "activity").
+
+    Returns:
+        The corresponding ChEMBL API endpoint name.
+
+    Raises:
+        ValueError: If the entity is not supported.
+    """
+    if entity not in ENTITY_ENDPOINT_ALIASES:
+        raise ValueError(f"Unknown entity: {entity}")
+    return ENTITY_ENDPOINT_ALIASES[entity]
+
+
+__all__ = [
+    "ENTITY_ENDPOINT_ALIASES",
+    "SUPPORTED_ENTITIES",
+    "resolve_endpoint",
+]

--- a/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
@@ -14,6 +14,7 @@ from bioetl.domain.ports.extraction import (
 )
 from bioetl.domain.ports.providers import DefaultFieldProviderABC
 from bioetl.domain.schemas.chembl.raw_models import ActivityRawModel
+from bioetl.infrastructure.clients.chembl.constants import ENTITY_ENDPOINT_ALIASES
 from bioetl.infrastructure.observability.factories import default_logging_port
 
 if TYPE_CHECKING:
@@ -121,14 +122,7 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
         builder = getattr(self.client, "request_builder")
 
         # Resolve entity alias manually if needed (matches ChemblHttpClientImpl)
-        aliases = {
-            "publication": "document",
-            "molecule": "molecule",
-            "activity": "activity",
-            "assay": "assay",
-            "target": "target",
-        }
-        mapped_entity = aliases.get(entity, entity)
+        mapped_entity = ENTITY_ENDPOINT_ALIASES.get(entity, entity)
 
         # Configure builder via legacy fluent methods expected in tests
         if hasattr(builder, "build_for_endpoint"):

--- a/src/bioetl/infrastructure/clients/chembl/impl/chembl_http_client_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/chembl_http_client_impl.py
@@ -15,6 +15,7 @@ from bioetl.domain.clients.base.contracts import (
 )
 from bioetl.domain.clients.contracts import DataClientABC
 from bioetl.domain.observability import LoggingPortABC
+from bioetl.infrastructure.clients.chembl.constants import resolve_endpoint
 from bioetl.infrastructure.clients.chembl.paginator import ChemblPaginatorImpl
 from bioetl.infrastructure.errors import (
     ApiUnexpectedStatusError,
@@ -215,16 +216,7 @@ class ChemblHttpClientImpl(DataClientABC):
             return callable_method(**filters)
 
     def _resolve_endpoint(self, entity: str) -> str:
-        aliases = {
-            "activity": "activity",
-            "assay": "assay",
-            "target": "target",
-            "publication": "document",
-            "molecule": "molecule",
-        }
-        if entity not in aliases:
-            raise ValueError(f"Unknown entity: {entity}")
-        return aliases[entity]
+        return resolve_endpoint(entity)
 
     # Optional accessor for metadata enrichment
     def get_last_endpoint_used(self) -> str | None:

--- a/tests/bioetl/infrastructure/clients/chembl/test_constants.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_constants.py
@@ -1,0 +1,86 @@
+"""Tests for ChEMBL constants module."""
+
+import pytest
+
+from bioetl.infrastructure.clients.chembl.constants import (
+    ENTITY_ENDPOINT_ALIASES,
+    SUPPORTED_ENTITIES,
+    resolve_endpoint,
+)
+
+
+class TestEntityEndpointAliases:
+    """Tests for ENTITY_ENDPOINT_ALIASES mapping."""
+
+    def test_contains_all_expected_entities(self):
+        """Verify all expected entities are present in the mapping."""
+        expected_entities = {"activity", "assay", "target", "molecule", "publication"}
+        assert set(ENTITY_ENDPOINT_ALIASES.keys()) == expected_entities
+
+    def test_publication_maps_to_document(self):
+        """
+        Verify 'publication' maps to 'document'.
+
+        ChEMBL API uses 'document' endpoint for publication data,
+        while our domain uses 'publication' as the entity name.
+        """
+        assert ENTITY_ENDPOINT_ALIASES["publication"] == "document"
+
+    def test_direct_mappings(self):
+        """Verify direct entity-to-endpoint mappings (same name)."""
+        direct_mappings = ["activity", "assay", "target", "molecule"]
+        for entity in direct_mappings:
+            assert ENTITY_ENDPOINT_ALIASES[entity] == entity
+
+    def test_mapping_is_immutable(self):
+        """Verify ENTITY_ENDPOINT_ALIASES cannot be modified."""
+        with pytest.raises(TypeError):
+            ENTITY_ENDPOINT_ALIASES["new_entity"] = "new_endpoint"  # type: ignore[index]
+
+    def test_all_endpoints_are_strings(self):
+        """Verify all endpoint values are non-empty strings."""
+        for entity, endpoint in ENTITY_ENDPOINT_ALIASES.items():
+            assert isinstance(entity, str), f"Entity key {entity!r} is not a string"
+            assert isinstance(endpoint, str), f"Endpoint {endpoint!r} is not a string"
+            assert entity, "Entity key should not be empty"
+            assert endpoint, "Endpoint value should not be empty"
+
+
+class TestSupportedEntities:
+    """Tests for SUPPORTED_ENTITIES frozenset."""
+
+    def test_matches_aliases_keys(self):
+        """Verify SUPPORTED_ENTITIES matches ENTITY_ENDPOINT_ALIASES keys."""
+        assert SUPPORTED_ENTITIES == frozenset(ENTITY_ENDPOINT_ALIASES.keys())
+
+    def test_is_immutable(self):
+        """Verify SUPPORTED_ENTITIES is a frozenset."""
+        assert isinstance(SUPPORTED_ENTITIES, frozenset)
+
+
+class TestResolveEndpoint:
+    """Tests for resolve_endpoint function."""
+
+    @pytest.mark.parametrize(
+        "entity,expected_endpoint",
+        [
+            ("activity", "activity"),
+            ("assay", "assay"),
+            ("target", "target"),
+            ("molecule", "molecule"),
+            ("publication", "document"),
+        ],
+    )
+    def test_resolves_valid_entities(self, entity: str, expected_endpoint: str):
+        """Verify resolve_endpoint returns correct endpoint for valid entities."""
+        assert resolve_endpoint(entity) == expected_endpoint
+
+    def test_raises_for_unknown_entity(self):
+        """Verify resolve_endpoint raises ValueError for unknown entities."""
+        with pytest.raises(ValueError, match="Unknown entity: unknown"):
+            resolve_endpoint("unknown")
+
+    def test_raises_for_empty_entity(self):
+        """Verify resolve_endpoint raises ValueError for empty entity."""
+        with pytest.raises(ValueError, match="Unknown entity: "):
+            resolve_endpoint("")


### PR DESCRIPTION
Extract duplicated ENTITY_ENDPOINT_ALIASES dict from chembl_http_client_impl.py and chembl_extraction_service_impl.py into a shared constants module.

- Create constants.py with ENTITY_ENDPOINT_ALIASES (immutable MappingProxyType)
- Add resolve_endpoint() helper function with validation
- Add SUPPORTED_ENTITIES frozenset for entity validation
- Document the publication → document mapping rationale
- Add comprehensive tests for constants module