### PR TITLE
Remove duplicate primary key resolution function

### DIFF
--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -16,7 +16,7 @@ from bioetl.domain.observability import LoggingPortABC, MetricsPortABC
 from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
 from bioetl.domain.provider_registry import ProviderRegistryABC
 from bioetl.domain.providers import ProviderDefinition, ProviderId
-from bioetl.domain.record_source import RecordSource
+from bioetl.domain.record_source import RecordSourceABC
 from bioetl.domain.schemas import register_schemas
 from bioetl.domain.schemas.registry import SchemaRegistry
 from bioetl.domain.transform.contracts import HashServiceABC, NormalizationServiceABC
@@ -171,7 +171,7 @@ class PipelineContainer(PipelineContainerABC):
         *,
         limit: int | None = None,
         logger: LoggingPortABC | None = None,
-    ) -> RecordSource:
+    ) -> RecordSourceABC:
         """Create record source based on pipeline input configuration."""
         return self._get_record_source_factory().create_record_source(
             extraction_service,

--- a/src/bioetl/application/factories/record_source.py
+++ b/src/bioetl/application/factories/record_source.py
@@ -11,6 +11,7 @@ from bioetl.application.files.csv_record_source import (
     CsvRecordSourceImpl,
     IdListRecordSourceImpl,
 )
+from bioetl.application.helpers import resolve_primary_key
 from bioetl.application.transform.pandas_batch_adapter import PandasBatchAdapter
 from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.observability import LoggingPortABC
@@ -62,7 +63,7 @@ class RecordSourceFactory:
                 raise ValueError("input_path is required for ID-only mode")
 
             source_config = self._resolve_provider_config(self._provider_definition)
-            id_column = self._resolve_primary_key()
+            id_column = resolve_primary_key(self._config)
             filter_key = f"{id_column}__in"
             return IdListRecordSourceImpl(
                 input_path=Path(path),
@@ -88,15 +89,3 @@ class RecordSourceFactory:
             chunk_size=self._config.batch_size,
             batch_adapter=PandasBatchAdapter().process_batch,
         )
-
-    def _resolve_primary_key(self) -> str:
-        pk = self._config.primary_key
-        if not pk and self._config.pipeline and "primary_key" in self._config.pipeline:
-            pk = self._config.pipeline["primary_key"]
-        if not pk:
-            pk = f"{self._config.entity_name}_id"
-        if not pk:
-            raise ValueError(
-                f"Could not resolve primary key for entity '{self._config.entity_name}'"
-            )
-        return pk

--- a/src/bioetl/application/helpers/__init__.py
+++ b/src/bioetl/application/helpers/__init__.py
@@ -1,0 +1,11 @@
+"""Application helpers module."""
+
+from bioetl.application.helpers.primary_key import (
+    resolve_primary_key,
+    resolve_primary_key_with_filter,
+)
+
+__all__ = [
+    "resolve_primary_key",
+    "resolve_primary_key_with_filter",
+]

--- a/src/bioetl/application/helpers/primary_key.py
+++ b/src/bioetl/application/helpers/primary_key.py
@@ -1,0 +1,98 @@
+"""
+Unified primary key resolution for BioETL pipelines.
+
+This module provides a single source of truth for resolving entity primary keys
+from pipeline configuration.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bioetl.domain.configs import PipelineConfig
+
+
+def resolve_primary_key(
+    config: PipelineConfig,
+    *,
+    fallback: str | None = None,
+) -> str:
+    """
+    Resolve the primary key for an entity based on pipeline configuration.
+
+    Resolution order:
+    1. config.primary_key (explicit field)
+    2. config.pipeline["primary_key"] (pipeline options dict)
+    3. f"{entity_name}_id" (convention-based fallback)
+    4. fallback parameter (if provided)
+    5. ValueError (if no resolution possible)
+
+    Args:
+        config: Pipeline configuration object.
+        fallback: Optional fallback value if primary key cannot be determined.
+
+    Returns:
+        The resolved primary key field name.
+
+    Raises:
+        ValueError: If primary key cannot be resolved and no fallback provided.
+
+    Examples:
+        >>> pk = resolve_primary_key(config)
+        >>> pk = resolve_primary_key(config, fallback="id")
+    """
+    # 1. Check explicit primary_key field
+    pk = config.primary_key
+
+    # 2. Check pipeline options dict
+    if not pk:
+        pipeline_opts = config.pipeline or {}
+        if "primary_key" in pipeline_opts:
+            pk = pipeline_opts["primary_key"]
+
+    # 3. Use entity-based convention
+    if not pk:
+        pk = f"{config.entity_name}_id"
+
+    # 4. Use fallback if provided and pk still empty
+    if not pk and fallback is not None:
+        pk = fallback
+
+    # 5. Raise if still no resolution
+    if not pk:
+        raise ValueError(
+            f"Could not resolve primary key for entity '{config.entity_name}'. "
+            "Please set 'primary_key' in config or pipeline options."
+        )
+
+    return pk
+
+
+def resolve_primary_key_with_filter(
+    config: PipelineConfig,
+    *,
+    fallback: str | None = None,
+) -> tuple[str, str]:
+    """
+    Resolve primary key and its corresponding API filter key.
+
+    This is a convenience wrapper that returns both the primary key
+    and the filter key (pk + "__in") used for API batch queries.
+
+    Args:
+        config: Pipeline configuration object.
+        fallback: Optional fallback value if primary key cannot be determined.
+
+    Returns:
+        Tuple of (primary_key, filter_key) where filter_key is "{pk}__in".
+
+    Raises:
+        ValueError: If primary key cannot be resolved and no fallback provided.
+
+    Examples:
+        >>> pk, filter_key = resolve_primary_key_with_filter(config)
+        >>> # pk = "activity_id", filter_key = "activity_id__in"
+    """
+    pk = resolve_primary_key(config, fallback=fallback)
+    return pk, f"{pk}__in"

--- a/src/bioetl/application/pipelines/chembl/base.py
+++ b/src/bioetl/application/pipelines/chembl/base.py
@@ -19,6 +19,7 @@ from bioetl.domain.clients.base.output.contracts import (
     RunMetadataBuilderProtocol,
     WriteResult,
 )
+from bioetl.application.helpers import resolve_primary_key_with_filter
 from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.models import RunContext
 from bioetl.domain.observability import LoggingPortABC
@@ -26,7 +27,7 @@ from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
 from bioetl.domain.ports.extraction import (
     ExtractionServiceABC,
 )
-from bioetl.domain.record_source import RecordSource
+from bioetl.domain.record_source import RecordSourceABC
 from bioetl.domain.schemas.chembl.raw_models import ActivityRawModel
 from bioetl.domain.schemas.pipeline_contracts import get_pipeline_contract
 from bioetl.domain.transform.contracts import HashServiceABC, NormalizationServiceABC
@@ -46,7 +47,7 @@ class ChemblPipelineBase(PipelineBase):
         hash_service: HashServiceABC,
         loader: LoaderABC | None = None,
         metadata_builder: RunMetadataBuilderProtocol | None = None,
-        record_source: RecordSource | None = None,
+        record_source: RecordSourceABC | None = None,
         normalization_service: NormalizationServiceABC | None = None,
         hooks: list[PipelineHookABC] | None = None,
         error_policy: ErrorPolicyABC | None = None,
@@ -55,7 +56,7 @@ class ChemblPipelineBase(PipelineBase):
         self._extraction_service: ExtractionServiceABC = extraction_service
         self._chembl_release: str | None = None
 
-        self.ID_COLUMN, self.API_FILTER_KEY = self._resolve_primary_key(config)
+        self.ID_COLUMN, self.API_FILTER_KEY = resolve_primary_key_with_filter(config)
 
         if normalization_service is None:
             raise ValueError(
@@ -105,29 +106,6 @@ class ChemblPipelineBase(PipelineBase):
         self._loader = resolved_loader
         self._extractor = extractor
         self._transformer = transformer
-
-    @staticmethod
-    def _resolve_primary_key(config: PipelineConfig) -> tuple[str, str]:
-        """Resolve entity primary key and API filter key based on config."""
-
-        pk = config.primary_key
-
-        if not pk and config.pipeline and "primary_key" in config.pipeline:
-            pk = config.pipeline["primary_key"]
-
-        if not pk:
-            pk = f"{config.entity_name}_id"
-
-        if not pk:
-            raise ValueError(
-                (
-                    "Could not resolve ID_COLUMN for entity "
-                    f"'{config.entity_name}'. Please set 'primary_key' "
-                    "in config or pipeline options."
-                )
-            )
-
-        return pk, f"{pk}__in"
 
     def get_version(self) -> str:
         """Возвращает версию релиза ChEMBL (например, 'chembl_34')."""

--- a/src/bioetl/application/pipelines/chembl/extractor.py
+++ b/src/bioetl/application/pipelines/chembl/extractor.py
@@ -12,6 +12,7 @@ from bioetl.application.files.csv_record_source import (
     CsvRecordSourceImpl,
     IdListRecordSourceImpl,
 )
+from bioetl.application.helpers import resolve_primary_key
 from bioetl.application.pipelines.contracts import ExtractorABC
 from bioetl.domain.configs import ChemblSourceConfig, CsvInputConfig, PipelineConfig
 from bioetl.domain.observability import LoggingPortABC
@@ -108,19 +109,6 @@ class ChemblExtractorImpl(ExtractorABC):
 
         return self._build_api_source(limit=limit, chunk_size=batch_size)
 
-    def _resolve_primary_key(self) -> str:
-        pk = getattr(self.config, "primary_key", None)
-        pipeline_cfg = getattr(self.config, "pipeline", {}) or {}
-        if not pk and "primary_key" in pipeline_cfg:
-            pk = pipeline_cfg["primary_key"]
-        if not pk:
-            pk = f"{self.config.entity_name}_id"
-        if not pk:
-            raise ValueError(
-                f"Could not resolve ID column for entity '{self.config.entity_name}'"
-            )
-        return pk
-
     def _resolve_mode(self) -> tuple[str, str | None]:
         mode = getattr(self.config, "input_mode", "auto_detect")
         input_path = getattr(self.config, "input_path", None)
@@ -166,7 +154,7 @@ class ChemblExtractorImpl(ExtractorABC):
     ) -> RecordSourceABC:
         if not input_path:
             raise ValueError("input_path is required for ID-only mode")
-        id_column = self._resolve_primary_key()
+        id_column = resolve_primary_key(self.config)
         filter_key = f"{id_column}__in"
         source_config_raw = self.config.get_source_config(self.config.provider)
         source_config = cast(ChemblSourceConfig, source_config_raw)

--- a/src/bioetl/application/pipelines/contracts.py
+++ b/src/bioetl/application/pipelines/contracts.py
@@ -12,7 +12,7 @@ from bioetl.domain.pipelines.contracts import (
     LoaderABC,
     PipelineHookABC,
 )
-from bioetl.domain.record_source import RecordSource
+from bioetl.domain.record_source import RecordSourceABC
 from bioetl.domain.transform.contracts import HashServiceABC, NormalizationServiceABC
 from bioetl.domain.transform.transformers import TransformerABC
 from bioetl.domain.validation.service import ValidationService
@@ -59,7 +59,7 @@ class PipelineContainerABC(ABC):
         *,
         limit: int | None = None,
         logger: LoggingPortABC | None = None,
-    ) -> RecordSource:
+    ) -> RecordSourceABC:
         """Return record source for pipeline input according to config."""
 
     @abstractmethod

--- a/tests/bioetl/application/helpers/__init__.py
+++ b/tests/bioetl/application/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for application helpers."""

--- a/tests/bioetl/application/helpers/test_primary_key.py
+++ b/tests/bioetl/application/helpers/test_primary_key.py
@@ -1,0 +1,129 @@
+"""Unit tests for primary key resolution helper."""
+
+import pytest
+
+from bioetl.application.helpers import resolve_primary_key, resolve_primary_key_with_filter
+from bioetl.infrastructure.config.models import (
+    ChemblSourceConfig,
+    ClientConfig,
+    PipelineConfig,
+)
+
+
+def _make_config(
+    *,
+    entity: str = "activity",
+    primary_key: str | None = None,
+    pipeline: dict | None = None,
+) -> PipelineConfig:
+    """Helper to create a minimal PipelineConfig for testing."""
+    return PipelineConfig(
+        id=f"chembl.{entity}",
+        provider="chembl",
+        entity=entity,
+        primary_key=primary_key,
+        pipeline=pipeline or {},
+        input_mode="auto_detect",
+        input_path=None,
+        output_path="/tmp/out",
+        batch_size=100,
+        provider_config=ChemblSourceConfig(
+            base_url="https://www.ebi.ac.uk/chembl/api/data",
+            client=ClientConfig(
+                timeout_sec=30,
+                max_retries=3,
+                rate_limit_per_sec=10.0,
+            ),
+        ),
+    )
+
+
+class TestResolvePrimaryKey:
+    """Tests for resolve_primary_key function."""
+
+    def test_explicit_primary_key_field(self) -> None:
+        """Primary key from config.primary_key takes precedence."""
+        config = _make_config(entity="activity", primary_key="custom_pk")
+        assert resolve_primary_key(config) == "custom_pk"
+
+    def test_primary_key_from_pipeline_dict(self) -> None:
+        """Fallback to pipeline dict when primary_key field is not set."""
+        config = _make_config(
+            entity="activity",
+            primary_key=None,
+            pipeline={"primary_key": "legacy_pk"},
+        )
+        assert resolve_primary_key(config) == "legacy_pk"
+
+    def test_explicit_field_wins_over_pipeline_dict(self) -> None:
+        """Explicit primary_key field takes precedence over pipeline dict."""
+        config = _make_config(
+            entity="activity",
+            primary_key="explicit_pk",
+            pipeline={"primary_key": "legacy_pk"},
+        )
+        assert resolve_primary_key(config) == "explicit_pk"
+
+    def test_entity_based_default(self) -> None:
+        """Falls back to {entity_name}_id convention."""
+        config = _make_config(entity="assay", primary_key=None)
+        assert resolve_primary_key(config) == "assay_id"
+
+    def test_fallback_parameter_used_when_needed(self) -> None:
+        """Fallback parameter is used if resolution fails."""
+        # This case should not happen in practice since entity_name_id
+        # is always generated, but test the fallback logic anyway.
+        # We test that fallback doesn't override valid resolution.
+        config = _make_config(entity="molecule", primary_key=None)
+        result = resolve_primary_key(config, fallback="fallback_id")
+        # entity_name_id should be used, not fallback
+        assert result == "molecule_id"
+
+
+class TestResolvePrimaryKeyWithFilter:
+    """Tests for resolve_primary_key_with_filter function."""
+
+    def test_returns_tuple(self) -> None:
+        """Function returns (pk, filter_key) tuple."""
+        config = _make_config(entity="target", primary_key="target_chembl_id")
+        pk, filter_key = resolve_primary_key_with_filter(config)
+        assert pk == "target_chembl_id"
+        assert filter_key == "target_chembl_id__in"
+
+    def test_filter_key_suffix(self) -> None:
+        """Filter key is always pk + '__in'."""
+        config = _make_config(entity="activity", primary_key=None)
+        pk, filter_key = resolve_primary_key_with_filter(config)
+        assert filter_key == f"{pk}__in"
+
+    def test_with_fallback(self) -> None:
+        """Fallback parameter is passed through."""
+        config = _make_config(entity="publication", primary_key=None)
+        pk, filter_key = resolve_primary_key_with_filter(config, fallback="doc_id")
+        # Should use entity_name_id, not fallback
+        assert pk == "publication_id"
+        assert filter_key == "publication_id__in"
+
+
+class TestEdgeCases:
+    """Edge case tests for primary key resolution."""
+
+    def test_empty_pipeline_dict(self) -> None:
+        """Empty pipeline dict does not cause issues."""
+        config = _make_config(entity="activity", primary_key=None, pipeline={})
+        assert resolve_primary_key(config) == "activity_id"
+
+    def test_pipeline_with_other_keys(self) -> None:
+        """Other keys in pipeline dict are ignored."""
+        config = _make_config(
+            entity="activity",
+            primary_key=None,
+            pipeline={"some_key": "value", "another": 123},
+        )
+        assert resolve_primary_key(config) == "activity_id"
+
+    def test_empty_string_primary_key_uses_fallback(self) -> None:
+        """Empty string primary_key triggers fallback logic."""
+        config = _make_config(entity="activity", primary_key="")
+        # Empty string is falsy, so entity_name_id should be used
+        assert resolve_primary_key(config) == "activity_id"


### PR DESCRIPTION
Extract duplicated _resolve_primary_key() logic from three locations:
- ChemblPipelineBase
- ChemblExtractorImpl
- RecordSourceFactory

Create new application helper module with:
- resolve_primary_key(config) - returns primary key string
- resolve_primary_key_with_filter(config) - returns (pk, filter_key) tuple

Also fix RecordSource -> RecordSourceABC import errors in:
- contracts.py
- container.py
- chembl/base.py

This eliminates DRY violation and provides single source of truth for primary key resolution logic.