### PR TITLE
Remove duplicate metrics port creation function

### DIFF
--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from typing import Any, Callable, cast
 
 from bioetl.application.factories.hooks import PipelineHookFactory
+from bioetl.application.factories.noop import create_noop_metrics_port
 from bioetl.application.factories.record_source import RecordSourceFactory
 from bioetl.application.factories.services import ProviderServiceFactory
 from bioetl.application.pipelines.contracts import LoaderABC, PipelineContainerABC
@@ -126,7 +127,7 @@ class PipelineContainer(PipelineContainerABC):
     def _resolve_metrics_port(
         self, metrics_port: MetricsPortABC | None
     ) -> MetricsPortABC:
-        return metrics_port or _create_noop_metrics_port()
+        return metrics_port or create_noop_metrics_port()
 
     def _resolve_provider_registry(
         self,
@@ -278,20 +279,6 @@ def _create_noop_metadata_builder() -> RunMetadataBuilderProtocol:
                 "run_id": getattr(context, "run_id", None),
                 "row_count": row_count,
             },
-        ),
-    )
-
-
-def _create_noop_metrics_port() -> MetricsPortABC:
-    """Return metrics port that records nothing (for tests)."""
-
-    return cast(
-        MetricsPortABC,
-        SimpleNamespace(
-            inc_counter=lambda *_args, **_kwargs: None,
-            observe_histogram=lambda *_args, **_kwargs: None,
-            update_stage_duration=lambda **_kwargs: None,
-            update_stage_total=lambda **_kwargs: None,
         ),
     )
 

--- a/src/bioetl/application/factories/noop.py
+++ b/src/bioetl/application/factories/noop.py
@@ -1,0 +1,22 @@
+"""No-op (stub) factory functions for testing and fallback scenarios."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+from bioetl.domain.observability import MetricsPortABC
+
+
+def create_noop_metrics_port() -> MetricsPortABC:
+    """Return metrics port that records nothing (for tests/fallback)."""
+
+    return cast(
+        MetricsPortABC,
+        SimpleNamespace(
+            inc_counter=lambda *_args, **_kwargs: None,
+            observe_histogram=lambda *_args, **_kwargs: None,
+            update_stage_duration=lambda **_kwargs: None,
+            update_stage_total=lambda **_kwargs: None,
+        ),
+    )

--- a/src/bioetl/application/pipelines/hooks_impl.py
+++ b/src/bioetl/application/pipelines/hooks_impl.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 
+from bioetl.application.factories.noop import create_noop_metrics_port
 from bioetl.domain.enums import ErrorAction
 from bioetl.domain.errors import PipelineStageError
 from bioetl.domain.models import StageResult
@@ -102,7 +102,7 @@ class MetricsPipelineHookImpl(PipelineHookABC):
         self._pipeline_id = pipeline_id
         self._provider = provider
         self._entity_name = entity_name
-        self._metrics = metrics_port or _create_noop_metrics_port()
+        self._metrics = metrics_port or create_noop_metrics_port()
 
     def on_stage_start(self, stage: str, context: Any) -> None:  # noqa: ARG002
         """Хук старта стадии не требует метрик."""
@@ -128,17 +128,3 @@ class MetricsPipelineHookImpl(PipelineHookABC):
 
     def on_error(self, stage: str, error: PipelineStageError) -> None:  # noqa: ARG002
         """Метрики фиксируются в on_stage_end, поэтому обработка не требуется."""
-
-
-def _create_noop_metrics_port() -> MetricsPortABC:
-    """Return no-op metrics port."""
-
-    return cast(
-        MetricsPortABC,
-        SimpleNamespace(
-            inc_counter=lambda *_args, **_kwargs: None,
-            observe_histogram=lambda *_args, **_kwargs: None,
-            update_stage_duration=lambda **_kwargs: None,
-            update_stage_total=lambda **_kwargs: None,
-        ),
-    )


### PR DESCRIPTION
…dule

Extract duplicated _create_noop_metrics_port() function from container.py and hooks_impl.py into a dedicated noop.py module to avoid code duplication and potential circular import issues.