### PR TITLE
Refactor overlapping HTTP settings models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **HTTP Configuration Refactoring**: Consolidated three overlapping HTTP configuration models into a single source of truth:
+  - New `HttpClientConfig` class replaces `HttpClientSettings`, `HttpClientDefaults`, and `ClientConfig`
+  - New `ProviderHttpConfig` extends `HttpClientConfig` with `base_url` for provider-specific configs
+  - Field naming standardized: `timeout` → `timeout_sec`, `retries` → `max_retries`, `rate_limit` → `rate_limit_per_sec`
+  - Added `retry_on_status`, `backoff_max`, `circuit_breaker_enabled` fields
+  - Backward compatibility maintained via model validators and deprecated property aliases
 - Добавлены типизированные поля `input_mode`/`input_path`/`csv_options` для пайплайнов; `cli.input_file` автоматически мигрирует с предупреждением.
 - ChEMBL pipeline теперь выбирает источник записей явно (API/CSV/id-only) без колонковой эвристики; CLI умеет переопределять режим и CSV-опции.
 - `HashService` больше не содержит собственной реализации `Hasher`: доменный фасад требует инжектируемый `HasherABC`, а фабрика по умолчанию использует `HasherImpl`.
@@ -19,8 +25,24 @@ All notable changes to this project will be documented in this file.
 - Удалены устаревшие интерфейсы (`default_provider_registry()`, `bioetl.application.services.chembl_extraction`) и middleware-шимы.
 - Удалены `src/bioetl/infrastructure/transform/impl/hash_service_impl.py`, `src/bioetl/domain/clients/base/logging/`, `src/bioetl/domain/configs/base.py`, `src/bioetl/domain/contracts.py`.
 
+### Deprecated
+
+- `HttpClientSettings`, `HttpClientDefaults`, `ClientConfig`, `HTTP_CLIENT_DEFAULTS` — use `HttpClientConfig` instead
+- `BaseProviderConfig.http_client`, `BaseProviderConfig.client` — use `.http` field instead
+- `RuntimeConfig.client` — use `.http` field instead
+- `ProviderDefinition.http_client` — use `.http` field instead
+- `ProviderRegistryEntryModel.http_client` — use `.http` field instead
+- `ClientConfig.from_http_settings()` method removed — use `HttpClientConfig` constructor with field mapping
+
 ### Breaking Changes
 
+- HTTP configuration field names changed (backward compatibility maintained via validators):
+  - `timeout` → `timeout_sec`
+  - `retries` → `max_retries`
+  - `rate_limit` → `rate_limit_per_sec`
+  - `circuit_breaker_recovery_time` → `circuit_breaker_recovery_sec`
+- `BaseProviderConfig` now uses `http: ProviderHttpConfig` instead of `http_client: HttpClientSettings` + `client: ClientConfig`
+- Factory functions (`build_http_client`, `build_rate_limiter`) signature simplified to use single `config: HttpClientConfig` parameter
 - Поле `assay_enrichment` удалено из конфигурации. Если использовалось в YAML-конфигах — удалить.
 - Флаг `features.enable_provider_loader_port` больше не поддерживается: порт загрузчика провайдеров активен всегда, а CLI/REST/MQ требуют валидного `providers.yaml` или явного `ProviderRegistry`.
 - `HashService` больше нельзя инстанцировать без `HasherABC`; проекты должны создавать сервис через `bioetl.infrastructure.transform.factories.default_hash_service()` или явно передавать `Hasher`.

--- a/src/bioetl/domain/configs/__init__.py
+++ b/src/bioetl/domain/configs/__init__.py
@@ -2,6 +2,7 @@
 
 from bioetl.domain.configs.contracts import PipelineConfigLoaderProtocol
 from bioetl.domain.configs.defaults import (
+    ClientDefaultsConfig,
     DefaultsConfig,
     HashingDefaultsConfig,
     HttpDefaultsConfig,
@@ -24,6 +25,7 @@ from bioetl.domain.configs.pipeline import (
     DummyProviderConfig,
     FeatureFlagsConfig,
     HashingConfig,
+    HttpClientConfig,
     HttpClientDefaults,
     HttpClientSettings,
     InterfaceFeaturesConfig,
@@ -33,6 +35,7 @@ from bioetl.domain.configs.pipeline import (
     PaginationConfig,
     PipelineConfig,
     ProviderConfigUnion,
+    ProviderHttpConfig,
     QcConfig,
     QualityConfig,
     RuntimeConfig,
@@ -42,40 +45,50 @@ from bioetl.domain.configs.pipeline import (
 from bioetl.domain.configs.profile import ProfileConfig
 
 __all__ = [
+    # Primary HTTP configuration (single source of truth)
+    "HttpClientConfig",
+    "ProviderHttpConfig",
+    # Provider configs
     "BaseProviderConfig",
+    "ChemblSourceConfig",
+    "DummyProviderConfig",
+    "ProviderConfigUnion",
+    # Pipeline config
+    "PipelineConfig",
+    "RuntimeConfig",
+    # Sub-configs
     "BusinessKeyConfig",
     "CanonicalizationConfig",
-    "ChemblSourceConfig",
-    "ClientConfig",
     "CsvInputConfig",
-    "HTTP_CLIENT_DEFAULTS",
-    "HttpClientDefaults",
-    "HttpClientSettings",
     "DeterminismConfig",
-    "DummyProviderConfig",
     "FeatureFlagsConfig",
     "HashingConfig",
     "InterfaceFeaturesConfig",
     "LoggingConfig",
     "MetricsConfig",
     "NormalizationConfig",
+    "ObservabilityConfig",
+    "PaginationConfig",
+    "ProfileConfig",
+    "QualityConfig",
+    "QcConfig",
+    "StorageConfig",
+    "TransformConfig",
+    # Defaults configs
+    "ClientDefaultsConfig",
     "DefaultsConfig",
     "HashingDefaultsConfig",
     "HttpDefaultsConfig",
     "NetworkDefaultsConfig",
     "NetworkHttpDefaultsConfig",
     "NormalizationDefaultsConfig",
-    "ObservabilityConfig",
-    "PaginationConfig",
-    "ProfileConfig",
-    "ProviderConfigUnion",
-    "PipelineConfigLoaderProtocol",
-    "QualityConfig",
-    "RuntimeConfig",
-    "QcConfig",
-    "TransformConfig",
-    "StorageConfig",
-    "PipelineConfig",
     "SourceDefaultsConfig",
     "SourcesDefaultsConfig",
+    # Protocols
+    "PipelineConfigLoaderProtocol",
+    # DEPRECATED: Legacy aliases (will be removed in future versions)
+    "ClientConfig",  # Use HttpClientConfig
+    "HttpClientDefaults",  # Use HttpClientConfig
+    "HttpClientSettings",  # Use ProviderHttpConfig
+    "HTTP_CLIENT_DEFAULTS",  # Use HttpClientConfig()
 ]

--- a/src/bioetl/domain/configs/base.py
+++ b/src/bioetl/domain/configs/base.py
@@ -11,6 +11,7 @@ from bioetl.domain.configs.pipeline import (
     DummyProviderConfig,
     FeatureFlagsConfig,
     HashingConfig,
+    HttpClientConfig,
     HttpClientSettings,
     InterfaceFeaturesConfig,
     LoggingConfig,
@@ -20,6 +21,7 @@ from bioetl.domain.configs.pipeline import (
     PaginationConfig,
     PipelineConfig,
     ProviderConfigUnion,
+    ProviderHttpConfig,
     QcConfig,
     QualityConfig,
     RuntimeConfig,
@@ -31,13 +33,12 @@ __all__ = [
     "BusinessKeyConfig",
     "CanonicalizationConfig",
     "ChemblSourceConfig",
-    "ClientConfig",
     "CsvInputConfig",
     "DeterminismConfig",
     "DummyProviderConfig",
     "FeatureFlagsConfig",
     "HashingConfig",
-    "HttpClientSettings",
+    "HttpClientConfig",
     "InterfaceFeaturesConfig",
     "LoggingConfig",
     "MetricsConfig",
@@ -46,8 +47,12 @@ __all__ = [
     "PaginationConfig",
     "PipelineConfig",
     "ProviderConfigUnion",
+    "ProviderHttpConfig",
     "QualityConfig",
     "RuntimeConfig",
     "QcConfig",
     "StorageConfig",
+    # DEPRECATED: Legacy aliases
+    "ClientConfig",  # Use HttpClientConfig
+    "HttpClientSettings",  # Use ProviderHttpConfig
 ]

--- a/src/bioetl/domain/configs/defaults.py
+++ b/src/bioetl/domain/configs/defaults.py
@@ -7,8 +7,8 @@ from typing import Annotated
 from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, PositiveInt
 
 from bioetl.domain.configs.pipeline import (
-    ClientConfig,
     HashingConfig,
+    HttpClientConfig,
     NormalizationConfig,
 )
 
@@ -29,10 +29,13 @@ class NormalizationDefaultsConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class ClientDefaultsConfig(ClientConfig):
-    """Default HTTP client limits shared across providers."""
+class ClientDefaultsConfig(HttpClientConfig):
+    """Default HTTP client limits shared across providers.
 
-    model_config = ConfigDict(extra="forbid")
+    DEPRECATED: Use HttpClientConfig directly.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
 
 class HttpDefaultsConfig(BaseModel):
@@ -47,9 +50,14 @@ class NetworkHttpDefaultsConfig(BaseModel):
     """HTTP defaults section containing canonical defaults."""
 
     default: HttpDefaultsConfig
-    client: ClientDefaultsConfig | None = None
+    http: HttpClientConfig | None = None
 
     model_config = ConfigDict(extra="forbid")
+
+    @property
+    def client(self) -> HttpClientConfig | None:
+        """DEPRECATED: Use .http instead."""
+        return self.http
 
 
 class NetworkDefaultsConfig(BaseModel):

--- a/src/bioetl/domain/configs/pipeline.py
+++ b/src/bioetl/domain/configs/pipeline.py
@@ -35,74 +35,104 @@ class PaginationConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class HttpClientSettings(BaseModel):
-    """Унифицированные настройки HTTP-клиента."""
+class HttpClientConfig(BaseModel):
+    """Unified HTTP client configuration (single source of truth).
+
+    This class consolidates HttpClientSettings, HttpClientDefaults, and ClientConfig
+    into a single configuration model.
+
+    Field mapping from legacy classes:
+        HttpClientSettings.timeout -> timeout_sec
+        HttpClientSettings.retries -> max_retries
+        HttpClientSettings.backoff -> backoff_factor
+        HttpClientSettings.rate_limit -> rate_limit_per_sec
+        HttpClientSettings.retry_enabled -> (deprecated, use max_retries > 0)
+        ClientConfig.circuit_breaker_recovery_time -> circuit_breaker_recovery_sec
+    """
+
+    timeout_sec: PositiveFloat = 30.0
+    max_retries: NonNegativeInt = 3
+    retry_on_status: tuple[int, ...] = (429, 500, 502, 503, 504)
+    backoff_factor: float = 2.0
+    backoff_max: float = 60.0
+    rate_limit_per_sec: PositiveFloat = 2.5
+
+    # Circuit breaker settings
+    circuit_breaker_enabled: bool = False
+    circuit_breaker_threshold: int = 5
+    circuit_breaker_recovery_sec: float = 30.0
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_legacy_fields(cls, data: Any) -> Any:
+        """Support legacy field names for backward compatibility."""
+        if not isinstance(data, dict):
+            return data
+
+        migrated = dict(data)
+
+        # HttpClientSettings/HttpClientDefaults field mappings
+        legacy_mappings = {
+            "timeout": "timeout_sec",
+            "retries": "max_retries",
+            "backoff": "backoff_factor",
+            "rate_limit": "rate_limit_per_sec",
+            "circuit_breaker_recovery_time": "circuit_breaker_recovery_sec",
+        }
+
+        for old_name, new_name in legacy_mappings.items():
+            if old_name in migrated and new_name not in migrated:
+                value = migrated.pop(old_name)
+                if old_name in ("timeout", "retries"):
+                    value = float(value) if old_name == "timeout" else int(value)
+                migrated[new_name] = value
+
+        # Handle retry_enabled -> if False, set max_retries to 0
+        if "retry_enabled" in migrated:
+            retry_enabled = migrated.pop("retry_enabled")
+            if not retry_enabled and "max_retries" not in migrated:
+                migrated["max_retries"] = 0
+
+        return migrated
+
+    @property
+    def retry_enabled(self) -> bool:
+        """Backward compatibility property for retry_enabled."""
+        return self.max_retries > 0
+
+
+class ProviderHttpConfig(HttpClientConfig):
+    """HTTP configuration for a specific provider with base URL."""
 
     base_url: str
-    timeout: int = 30
-    retries: int = 3
-    backoff: float = 2.0
-    rate_limit: float = 2.5
-    retry_enabled: bool = True
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
 
-class HttpClientDefaults(BaseModel):
-    """Shared HTTP client defaults to centralize timeouts and limits."""
+# =============================================================================
+# DEPRECATED: Legacy aliases for backward compatibility
+# These will be removed in a future version
+# =============================================================================
 
-    timeout: int = 30
-    retries: int = 3
-    backoff_factor: float = 2.0
-    rate_limit: float = 2.5
-    retry_enabled: bool = True
+# Legacy alias - use HttpClientConfig instead
+HttpClientSettings = ProviderHttpConfig
 
-    model_config = ConfigDict(extra="forbid")
-
-
-HTTP_CLIENT_DEFAULTS = HttpClientDefaults()
+# Legacy alias - use HttpClientConfig instead
+ClientConfig = HttpClientConfig
 
 
-class ClientConfig(BaseModel):
-    """Конфигурация HTTP-клиента."""
+class HttpClientDefaults(HttpClientConfig):
+    """DEPRECATED: Use HttpClientConfig directly.
 
-    timeout_sec: PositiveFloat = Field(
-        default_factory=lambda: float(HTTP_CLIENT_DEFAULTS.timeout)
-    )
-    max_retries: NonNegativeInt = Field(
-        default_factory=lambda: HTTP_CLIENT_DEFAULTS.retries
-    )
-    rate_limit_per_sec: PositiveFloat = Field(
-        default_factory=lambda: float(HTTP_CLIENT_DEFAULTS.rate_limit)
-    )
-    backoff_factor: float = Field(
-        default_factory=lambda: HTTP_CLIENT_DEFAULTS.backoff_factor
-    )
-    retry_enabled: bool = True
-    circuit_breaker_threshold: int = 5
-    circuit_breaker_recovery_time: float = 60.0
+    Shared HTTP client defaults - now just an alias for HttpClientConfig.
+    """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
-    @classmethod
-    def from_http_settings(
-        cls,
-        http_client: HttpClientSettings,
-        *,
-        existing: ClientConfig | None = None,
-    ) -> ClientConfig:
-        """Создает ClientConfig на основе HttpClientSettings."""
 
-        base = existing.model_copy(deep=True) if existing is not None else cls()
-        return base.model_copy(
-            update={
-                "timeout_sec": float(http_client.timeout),
-                "max_retries": http_client.retries,
-                "rate_limit_per_sec": float(http_client.rate_limit),
-                "backoff_factor": http_client.backoff,
-                "retry_enabled": http_client.retry_enabled,
-            }
-        )
+HTTP_CLIENT_DEFAULTS = HttpClientConfig()
 
 
 class StorageConfig(BaseModel):
@@ -236,85 +266,107 @@ class CsvInputConfig(BaseModel):
 
 
 class BaseProviderConfig(BaseModel):
-    """Базовая строгая конфигурация провайдера."""
+    """Базовая строгая конфигурация провайдера.
+
+    Uses HttpClientConfig as the single source of truth for HTTP settings.
+    Legacy fields (http_client, client) are provided for backward compatibility.
+    """
 
     provider: Literal["chembl", "dummy"]
-    http_client: HttpClientSettings
-    client: ClientConfig = Field(default_factory=ClientConfig)
+    http: ProviderHttpConfig
 
     model_config = ConfigDict(extra="forbid")
 
     @model_validator(mode="before")
     @classmethod
-    def migrate_flat_client_fields(cls, data: Any) -> Any:
-        """Поддерживает старый формат с плоскими клиентскими настройками."""
-
+    def migrate_legacy_config(cls, data: Any) -> Any:
+        """Support legacy formats: http_client, client, or flat fields."""
         if not isinstance(data, dict):
             return data
 
-        if "http_client" in data:
-            return data
+        migrated = dict(data)
 
-        base_url = data.get("base_url")
-        client_data = data.get("client") or {}
+        # Collect HTTP config values from various sources
+        http_config: dict[str, Any] = {}
 
-        client_payload: dict[str, Any] = {}
-        for legacy_field in (
+        # If http is already set, extract its values as base
+        if "http" in migrated:
+            existing_http = migrated.pop("http")
+            if isinstance(existing_http, dict):
+                http_config.update(existing_http)
+            elif hasattr(existing_http, "model_dump"):
+                http_config.update(existing_http.model_dump())
+
+        # Priority 1: http_client (legacy HttpClientSettings)
+        if "http_client" in migrated:
+            legacy_http = migrated.pop("http_client")
+            if isinstance(legacy_http, dict):
+                for k, v in legacy_http.items():
+                    if k not in http_config:
+                        http_config[k] = v
+            elif hasattr(legacy_http, "model_dump"):
+                for k, v in legacy_http.model_dump().items():
+                    if k not in http_config:
+                        http_config[k] = v
+
+        # Priority 2: client (legacy ClientConfig)
+        if "client" in migrated:
+            legacy_client = migrated.pop("client")
+            if isinstance(legacy_client, dict):
+                for k, v in legacy_client.items():
+                    if k not in http_config:
+                        http_config[k] = v
+            elif hasattr(legacy_client, "model_dump"):
+                for k, v in legacy_client.model_dump().items():
+                    if k not in http_config:
+                        http_config[k] = v
+
+        # Priority 3: Flat fields at root level
+        flat_fields = (
+            "base_url",
             "timeout_sec",
+            "timeout",
             "max_retries",
+            "retries",
             "rate_limit_per_sec",
+            "rate_limit",
             "backoff_factor",
+            "backoff",
             "retry_enabled",
-        ):
-            if legacy_field in data:
-                client_payload[legacy_field] = data[legacy_field]
-        client_payload.update(client_data if isinstance(client_data, dict) else {})
-
-        if base_url is None:
-            return data
-
-        client_config = ClientConfig.model_validate(client_payload or {})
-        http_client = HttpClientSettings(
-            base_url=str(base_url),
-            timeout=int(client_config.timeout_sec),
-            retries=client_config.max_retries,
-            backoff=float(client_config.backoff_factor),
-            rate_limit=float(client_config.rate_limit_per_sec),
-            retry_enabled=bool(client_config.retry_enabled),
+            "retry_on_status",
+            "backoff_max",
+            "circuit_breaker_enabled",
+            "circuit_breaker_threshold",
+            "circuit_breaker_recovery_sec",
+            "circuit_breaker_recovery_time",
         )
+        for field in flat_fields:
+            if field in migrated:
+                if field not in http_config:
+                    http_config[field] = migrated.pop(field)
+                else:
+                    # Remove duplicate field if already in http_config
+                    migrated.pop(field)
 
-        cleaned = {
-            key: value
-            for key, value in data.items()
-            if key
-            not in {
-                "base_url",
-                "client",
-                "timeout_sec",
-                "max_retries",
-                "rate_limit_per_sec",
-                "backoff_factor",
-                "retry_enabled",
-            }
-        }
-        cleaned["http_client"] = http_client
-        return cleaned
+        if http_config:
+            migrated["http"] = http_config
 
-    @model_validator(mode="after")
-    def sync_client_config(self) -> "BaseProviderConfig":
-        """Гарантирует, что client отражает http_client."""
-
-        synced_client = ClientConfig.from_http_settings(
-            self.http_client, existing=self.client
-        )
-        object.__setattr__(self, "client", synced_client)
-        return self
+        return migrated
 
     @property
     def base_url(self) -> str:
-        """Совместимость с прежним интерфейсом base_url."""
+        """Backward compatibility: access base_url from http config."""
+        return self.http.base_url
 
-        return self.http_client.base_url
+    @property
+    def http_client(self) -> ProviderHttpConfig:
+        """DEPRECATED: Use .http instead. Legacy alias for http config."""
+        return self.http
+
+    @property
+    def client(self) -> HttpClientConfig:
+        """DEPRECATED: Use .http instead. Legacy alias for http config."""
+        return self.http
 
     @field_validator("provider")
     @classmethod
@@ -380,11 +432,27 @@ class RuntimeConfig(BaseModel):
     """Секция исполнения и источников данных."""
 
     pagination: PaginationConfig = Field(default_factory=PaginationConfig)
-    client: ClientConfig = Field(default_factory=ClientConfig)
+    http: HttpClientConfig = Field(default_factory=HttpClientConfig)
     storage: StorageConfig = Field(default_factory=StorageConfig)
     csv: CsvInputConfig = Field(default_factory=CsvInputConfig, alias="csv_options")
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_client_to_http(cls, data: Any) -> Any:
+        """Support legacy 'client' field name."""
+        if not isinstance(data, dict):
+            return data
+        if "client" in data and "http" not in data:
+            data = dict(data)
+            data["http"] = data.pop("client")
+        return data
+
+    @property
+    def client(self) -> HttpClientConfig:
+        """DEPRECATED: Use .http instead. Legacy alias for backward compatibility."""
+        return self.http
 
 
 class ObservabilityConfig(BaseModel):
@@ -532,15 +600,19 @@ class PipelineConfig(BaseModel):
 
     pagination = property(get_pagination, set_pagination)
 
-    def get_client(self) -> ClientConfig:
-        """Backwards compatible access to client section."""
+    def get_client(self) -> HttpClientConfig:
+        """Backwards compatible access to HTTP client config.
 
-        return self.runtime.client
+        DEPRECATED: Use runtime.http instead.
+        """
+        return self.runtime.http
 
-    def set_client(self, value: ClientConfig) -> None:
-        """Update client section in runtime config."""
+    def set_client(self, value: HttpClientConfig) -> None:
+        """Update HTTP client config in runtime.
 
-        self.runtime.client = value
+        DEPRECATED: Use runtime.http instead.
+        """
+        object.__setattr__(self.runtime, "http", value)
 
     client = property(get_client, set_client)
 
@@ -774,7 +846,7 @@ class PipelineConfig(BaseModel):
 
         _pack(
             "runtime",
-            ["pagination", "client", "storage", "csv", "csv_options"],
+            ["pagination", "client", "http", "storage", "csv", "csv_options"],
         )
         _pack("observability", ["logging", "metrics"])
         _pack("quality", ["determinism", "qc", "hashing", "normalization"])
@@ -789,12 +861,12 @@ __all__ = [
     "BusinessKeyConfig",
     "CanonicalizationConfig",
     "ChemblSourceConfig",
-    "ClientConfig",
     "CsvInputConfig",
     "DeterminismConfig",
     "DummyProviderConfig",
     "FeatureFlagsConfig",
     "HashingConfig",
+    "HttpClientConfig",
     "InterfaceFeaturesConfig",
     "LoggingConfig",
     "MetricsConfig",
@@ -803,8 +875,14 @@ __all__ = [
     "PaginationConfig",
     "PipelineConfig",
     "ProviderConfigUnion",
+    "ProviderHttpConfig",
     "QualityConfig",
     "RuntimeConfig",
     "QcConfig",
     "StorageConfig",
+    # DEPRECATED: Legacy aliases (will be removed in future versions)
+    "ClientConfig",  # Use HttpClientConfig
+    "HttpClientDefaults",  # Use HttpClientConfig
+    "HttpClientSettings",  # Use ProviderHttpConfig
+    "HTTP_CLIENT_DEFAULTS",  # Use HttpClientConfig()
 ]

--- a/src/bioetl/domain/providers.py
+++ b/src/bioetl/domain/providers.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Protocol, TypeVar, runtime_checkable
 
-from bioetl.domain.configs import BaseProviderConfig, HttpClientSettings
+from bioetl.domain.configs import BaseProviderConfig, HttpClientConfig
 from bioetl.domain.ports.providers import DefaultFieldProviderABC
 
 if TYPE_CHECKING:
@@ -82,7 +82,12 @@ class ProviderDefinition:
     config_type: type[BaseProviderConfig]
     components: ProviderComponents
     description: str | None = None
-    http_client: HttpClientSettings | None = None
+    http: HttpClientConfig | None = None
+
+    @property
+    def http_client(self) -> HttpClientConfig | None:
+        """DEPRECATED: Use .http instead."""
+        return self.http
 
 
 __all__ = [

--- a/src/bioetl/infrastructure/clients/base/factories.py
+++ b/src/bioetl/infrastructure/clients/base/factories.py
@@ -11,12 +11,7 @@ from bioetl.domain.clients.base.contracts import (
     ResponseParserABC,
     SecretProviderABC,
 )
-from bioetl.domain.configs import (
-    HTTP_CLIENT_DEFAULTS,
-    ClientConfig,
-    HttpClientDefaults,
-    HttpClientSettings,
-)
+from bioetl.domain.configs import HttpClientConfig
 from bioetl.domain.observability import LoggingPortABC, MetricsPortABC
 from bioetl.infrastructure.clients.base.impl._http_transport import _HttpTransport
 from bioetl.infrastructure.clients.base.impl.cache import MemoryCacheImpl
@@ -31,6 +26,9 @@ from bioetl.infrastructure.clients.chembl.response_parser import (
     ChemblResponseParserImpl,
 )
 
+# Default HTTP client configuration (single source of truth)
+_DEFAULT_HTTP_CONFIG = HttpClientConfig()
+
 
 class EnvSecretProviderImpl(SecretProviderABC):
     """Resolve secrets from environment variables."""
@@ -40,84 +38,36 @@ class EnvSecretProviderImpl(SecretProviderABC):
         return os.getenv(name)
 
 
-def _resolve_http_defaults(
-    *,
-    client_config: ClientConfig | None = None,
-    defaults: HttpClientDefaults | None = None,
-    http_settings: HttpClientSettings | None = None,
-) -> HttpClientDefaults:
-    """Return explicit defaults or fall back to canonical HTTP defaults."""
-
-    if http_settings is not None:
-        return HttpClientDefaults(
-            timeout=http_settings.timeout,
-            retries=http_settings.retries,
-            backoff_factor=http_settings.backoff,
-            rate_limit=http_settings.rate_limit,
-            retry_enabled=http_settings.retry_enabled,
-        )
-
-    if client_config is None:
-        return defaults or HTTP_CLIENT_DEFAULTS
-
-    return HttpClientDefaults(
-        timeout=int(client_config.timeout_sec),
-        retries=client_config.max_retries,
-        backoff_factor=client_config.backoff_factor,
-        rate_limit=float(client_config.rate_limit_per_sec),
-        retry_enabled=bool(client_config.retry_enabled),
-    )
-
-
-def _ensure_client_config(
-    *,
-    client_config: ClientConfig | None = None,
-    http_settings: HttpClientSettings | None = None,
-    defaults: HttpClientDefaults | None = None,
-) -> ClientConfig:
-    """Return provided client config or build one from defaults."""
-
-    if http_settings is not None:
-        return ClientConfig.from_http_settings(http_settings, existing=client_config)
-
-    if client_config is not None:
-        return client_config
-
-    resolved = defaults or HTTP_CLIENT_DEFAULTS
-    return ClientConfig(
-        timeout_sec=resolved.timeout,
-        max_retries=resolved.retries,
-        rate_limit_per_sec=resolved.rate_limit,
-        backoff_factor=resolved.backoff_factor,
-        retry_enabled=resolved.retry_enabled,
-    )
+def _ensure_http_config(
+    config: HttpClientConfig | dict[str, Any] | None = None,
+) -> HttpClientConfig:
+    """Normalize config to HttpClientConfig, falling back to defaults."""
+    if config is None:
+        return _DEFAULT_HTTP_CONFIG
+    if isinstance(config, HttpClientConfig):
+        return config
+    return HttpClientConfig.model_validate(config)
 
 
 def build_rate_limiter(
     *,
-    client_config: ClientConfig | None = None,
-    http_settings: HttpClientSettings | None = None,
-    defaults: HttpClientDefaults | None = None,
+    config: HttpClientConfig | None = None,
     logger: LoggingPortABC | None = None,
 ) -> RateLimiterABC:
-    """Create a rate limiter using unified HTTP defaults."""
-
-    resolved_defaults = _resolve_http_defaults(
-        client_config=client_config, defaults=defaults, http_settings=http_settings
-    )
-    rate = resolved_defaults.rate_limit
+    """Create a rate limiter using HTTP config."""
+    resolved = _ensure_http_config(config)
+    rate = resolved.rate_limit_per_sec
     capacity = max(1.0, rate)
     return TokenBucketRateLimiterImpl(rate, capacity, logger=logger)
 
 
 def default_rate_limiter(
-    rate: float = HTTP_CLIENT_DEFAULTS.rate_limit,
+    rate: float = _DEFAULT_HTTP_CONFIG.rate_limit_per_sec,
     capacity: float | None = None,
     *,
     logger: LoggingPortABC | None = None,
 ) -> RateLimiterABC:
     """Create the default rate limiter with token bucket semantics."""
-
     resolved_capacity = capacity if capacity is not None else max(1.0, rate)
     return TokenBucketRateLimiterImpl(rate, resolved_capacity, logger=logger)
 
@@ -160,17 +110,16 @@ def default_paginator() -> PaginatorABC:
 
 def default_api_client(
     provider: str,
-    config: ClientConfig,
+    config: HttpClientConfig,
     *,
     base_client: Any | None = None,
     logger: LoggingPortABC | None = None,
     metrics: MetricsPortABC | None = None,
 ) -> _HttpTransport:
     """Create the default API client without middleware indirection."""
-
     return build_http_client(
         provider,
-        client_config=config,
+        config=config,
         base_client=base_client,
         logger=logger,
         metrics=metrics,
@@ -180,20 +129,13 @@ def default_api_client(
 def build_http_client(
     provider: str,
     *,
-    client_config: ClientConfig | None = None,
-    http_settings: HttpClientSettings | None = None,
-    defaults: HttpClientDefaults | None = None,
+    config: HttpClientConfig | None = None,
     base_client: Any | None = None,
     logger: LoggingPortABC | None = None,
     metrics: MetricsPortABC | None = None,
 ) -> _HttpTransport:
-    """Construct HTTP client using centralized defaults."""
-
-    resolved_config = _ensure_client_config(
-        client_config=client_config,
-        http_settings=http_settings,
-        defaults=defaults,
-    )
+    """Construct HTTP client using HttpClientConfig."""
+    resolved_config = _ensure_http_config(config)
     return _HttpTransport(
         provider=provider,
         config=resolved_config,

--- a/src/bioetl/infrastructure/clients/base/impl/_http_transport.py
+++ b/src/bioetl/infrastructure/clients/base/impl/_http_transport.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 
 import requests
 
-from bioetl.domain.configs import ClientConfig
+from bioetl.domain.configs import HttpClientConfig
 from bioetl.domain.observability import LoggingPortABC, MetricsPortABC
 from bioetl.infrastructure.errors import (
     ApiClientError,
@@ -34,7 +34,7 @@ class _HttpTransport:
     def __init__(
         self,
         provider: str,
-        config: ClientConfig,
+        config: HttpClientConfig,
         base_client: Any | None = None,
         *,
         logger: LoggingPortABC | None = None,

--- a/src/bioetl/infrastructure/clients/chembl/factories.py
+++ b/src/bioetl/infrastructure/clients/chembl/factories.py
@@ -5,7 +5,7 @@ Factories for ChEMBL clients.
 from typing import Any
 
 from bioetl.domain.clients.contracts import DataClientABC
-from bioetl.domain.configs import ChemblSourceConfig, ClientConfig, HttpClientSettings
+from bioetl.domain.configs import ChemblSourceConfig, HttpClientConfig
 from bioetl.domain.observability.contracts import LoggingPortABC
 from bioetl.domain.ports.extraction import ExtractionServiceABC
 from bioetl.domain.ports.providers import DefaultFieldProviderABC
@@ -29,7 +29,7 @@ from bioetl.infrastructure.clients.chembl.response_parser import (
 
 def default_chembl_client(
     source_config: ChemblSourceConfig,
-    http_client: HttpClientSettings | None = None,
+    http_config: HttpClientConfig | None = None,
     **options: Any,
 ) -> DataClientABC:
     """
@@ -37,39 +37,30 @@ def default_chembl_client(
 
     Args:
         source_config: Конфигурация источника.
-        client_config: Конфигурация клиента (опционально).
+        http_config: HTTP конфигурация (опционально, берется из source_config.http).
         **options: Дополнительные опции.
 
     Returns:
         Настроенный экземпляр клиента.
     """
-    resolved_http = http_client or source_config.http_client
-    client_config = ClientConfig.from_http_settings(
-        resolved_http, existing=source_config.client
-    )
-
-    # Create Unified Client
+    # Use provided config or fall back to source_config.http
+    resolved_config = http_config or source_config.http
     logger: LoggingPortABC | None = options.get("logger")
 
+    # Create Unified HTTP Client
     unified_client = build_http_client(
         provider="chembl",
-        client_config=client_config,
-        http_settings=resolved_http,
+        config=resolved_config,
         logger=logger,
     )
 
     # Allow explicit overrides via kwargs (used in tests and manual runs)
     override_base_url = options.get("base_url")
-    base_url = str(override_base_url or resolved_http.base_url)
-    if override_base_url:
-        resolved_http = resolved_http.model_copy(update={"base_url": base_url})
+    base_url = str(override_base_url or source_config.base_url)
     max_url_length = options.get("max_url_length", source_config.max_url_length)
 
-    # Rate limiter for proactive limiting (in addition to middleware backoff)
-    # Using explicit rate limiter in client logic
-    rate_limiter = build_rate_limiter(
-        client_config=client_config, http_settings=resolved_http, logger=logger
-    )
+    # Rate limiter for proactive limiting
+    rate_limiter = build_rate_limiter(config=resolved_config, logger=logger)
 
     return ChemblHttpClientImpl(
         request_builder=ChemblRequestBuilderImpl(
@@ -87,8 +78,7 @@ def default_chembl_client(
 
 def default_chembl_extraction_service(
     config: ChemblSourceConfig,
-    http_client: HttpClientSettings | None = None,
-    client_config: ClientConfig | None = None,
+    http_config: HttpClientConfig | None = None,
     *,
     client: DataClientABC | None = None,
     logger: LoggingPortABC | None = None,
@@ -99,26 +89,20 @@ def default_chembl_extraction_service(
 
     Args:
         config: Конфигурация источника.
-        client_config: Конфигурация клиента.
+        http_config: HTTP конфигурация (опционально).
         client: Уже созданный клиент (опционально).
+        logger: Логгер.
+        field_provider: Провайдер полей.
 
     Returns:
         Сервис экстракции.
     """
-    resolved_http = http_client or config.http_client
-    if client_config is not None:
-        resolved_http = resolved_http.model_copy(
-            update={
-                "timeout": int(client_config.timeout_sec),
-                "retries": client_config.max_retries,
-                "backoff": float(client_config.backoff_factor),
-                "rate_limit": float(client_config.rate_limit_per_sec),
-                "retry_enabled": bool(client_config.retry_enabled),
-            }
-        )
+    resolved_config = http_config or config.http
 
     if client is None:
-        client = default_chembl_client(config, http_client=resolved_http, logger=logger)
+        client = default_chembl_client(
+            config, http_config=resolved_config, logger=logger
+        )
 
     return ChemblExtractionServiceImpl(
         client=client,

--- a/src/bioetl/infrastructure/clients/chembl/provider.py
+++ b/src/bioetl/infrastructure/clients/chembl/provider.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from bioetl.domain.clients.contracts import DataClientABC
-from bioetl.domain.configs import ChemblSourceConfig, HttpClientSettings
+from bioetl.domain.configs import ChemblSourceConfig, HttpClientConfig
 from bioetl.domain.ports.extraction import ExtractionServiceABC
 from bioetl.domain.ports.providers import DefaultFieldProviderABC
 from bioetl.domain.providers import ProviderComponents, ProviderDefinition, ProviderId
@@ -64,16 +64,15 @@ class ChemblProviderComponentsFactory(
 
 
 def register_chembl_provider(
-    http_client: HttpClientSettings | None = None,
+    http: HttpClientConfig | None = None,
 ) -> ProviderDefinition:
     """Create ChEMBL provider definition."""
-
     definition = ProviderDefinition(
         id=ProviderId.CHEMBL,
         config_type=ChemblSourceConfig,
         components=ChemblProviderComponentsFactory(),
         description="ChEMBL data provider",
-        http_client=http_client,
+        http=http,
     )
     return definition
 

--- a/src/bioetl/infrastructure/config/models.py
+++ b/src/bioetl/infrastructure/config/models.py
@@ -19,6 +19,7 @@ from bioetl.domain.configs import (  # noqa: F401
     FeatureFlagsConfig,
     HashingConfig,
     HashingDefaultsConfig,
+    HttpClientConfig,
     HttpClientDefaults,
     HttpClientSettings,
     HttpDefaultsConfig,
@@ -34,6 +35,7 @@ from bioetl.domain.configs import (  # noqa: F401
     PipelineConfig,
     ProfileConfig,
     ProviderConfigUnion,
+    ProviderHttpConfig,
     QcConfig,
     QualityConfig,
     RuntimeConfig,
@@ -43,32 +45,35 @@ from bioetl.domain.configs import (  # noqa: F401
 )
 
 __all__ = [
+    # Primary HTTP configuration
+    "HttpClientConfig",
+    "ProviderHttpConfig",
+    # Provider configs
     "BaseProviderConfig",
+    "ChemblSourceConfig",
+    "DummyProviderConfig",
+    "ProviderConfigUnion",
+    # Pipeline config
+    "PipelineConfig",
+    "RuntimeConfig",
+    # Sub-configs
     "BusinessKeyConfig",
     "CanonicalizationConfig",
-    "ChemblSourceConfig",
-    "ClientConfig",
     "CsvInputConfig",
     "DeterminismConfig",
-    "DummyProviderConfig",
-    "HTTP_CLIENT_DEFAULTS",
-    "HttpClientDefaults",
+    "FeatureFlagsConfig",
     "HashingConfig",
-    "HttpClientSettings",
     "InterfaceFeaturesConfig",
     "LoggingConfig",
     "MetricsConfig",
     "NormalizationConfig",
     "ObservabilityConfig",
     "PaginationConfig",
-    "PipelineConfig",
     "ProfileConfig",
-    "ProviderConfigUnion",
     "QualityConfig",
-    "RuntimeConfig",
     "QcConfig",
     "StorageConfig",
-    "FeatureFlagsConfig",
+    # Defaults configs
     "DefaultsConfig",
     "HashingDefaultsConfig",
     "HttpDefaultsConfig",
@@ -77,4 +82,9 @@ __all__ = [
     "NormalizationDefaultsConfig",
     "SourceDefaultsConfig",
     "SourcesDefaultsConfig",
+    # DEPRECATED: Legacy aliases
+    "ClientConfig",  # Use HttpClientConfig
+    "HttpClientDefaults",  # Use HttpClientConfig
+    "HttpClientSettings",  # Use ProviderHttpConfig
+    "HTTP_CLIENT_DEFAULTS",  # Use HttpClientConfig()
 ]

--- a/src/bioetl/infrastructure/config/provider_registry.py
+++ b/src/bioetl/infrastructure/config/provider_registry.py
@@ -15,10 +15,10 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, ValidationError
+from pydantic import BaseModel, ConfigDict, ValidationError, model_validator
 import yaml
 
-from bioetl.domain.configs import HttpClientSettings
+from bioetl.domain.configs import HttpClientConfig, ProviderHttpConfig
 from bioetl.domain.observability import LoggingPortABC
 from bioetl.domain.provider_registry import (
     InMemoryProviderRegistry,
@@ -105,7 +105,23 @@ class ProviderRegistryEntryModel(BaseModel):
     factory: str
     active: bool = True
     description: str | None = None
-    http_client: HttpClientSettings | None = None
+    http: ProviderHttpConfig | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_http_client(cls, data: Any) -> Any:
+        """Support legacy 'http_client' field name."""
+        if not isinstance(data, dict):
+            return data
+        if "http_client" in data and "http" not in data:
+            data = dict(data)
+            data["http"] = data.pop("http_client")
+        return data
+
+    @property
+    def http_client(self) -> ProviderHttpConfig | None:
+        """DEPRECATED: Use .http instead."""
+        return self.http
 
 
 # Alias for backward compatibility
@@ -303,7 +319,7 @@ class ProviderLoaderImpl(ProviderRegistryLoaderABC):
             return None
 
         try:
-            definition = factory(http_client=entry.http_client)
+            definition = factory(http=entry.http)
         except Exception as exc:  # pragma: no cover - defensive logging
             self._logger.error(
                 "Provider factory invocation failed",

--- a/tests/bioetl/infrastructure/clients/chembl/test_factories.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_factories.py
@@ -16,7 +16,7 @@ from bioetl.infrastructure.clients.chembl.impl.chembl_http_client_impl import (
 )
 from bioetl.infrastructure.config.models import (
     ChemblSourceConfig,
-    ClientConfig,
+    HttpClientConfig,
 )
 
 
@@ -26,7 +26,7 @@ def source_config():
     return ChemblSourceConfig(
         base_url="https://example.com",
         max_url_length=1000,
-        client=ClientConfig(
+        http=HttpClientConfig(
             timeout_sec=30,
             max_retries=3,
             rate_limit_per_sec=5.0,
@@ -41,7 +41,8 @@ def test_default_chembl_client_success(source_config):
     # Check that parameters propagated to request_builder
     assert client.request_builder.base_url == "https://example.com"
     assert client.request_builder.max_url_length == 1000
-    assert client.rate_limiter.rate == 2.5
+    # Rate should match source_config.http.rate_limit_per_sec
+    assert client.rate_limiter.rate == 5.0
 
 
 def test_default_chembl_client_overrides(source_config):

--- a/tests/bioetl/infrastructure/config/test_provider_registry.py
+++ b/tests/bioetl/infrastructure/config/test_provider_registry.py
@@ -11,7 +11,7 @@ from typing import Any, Callable
 import pytest
 import yaml
 
-from bioetl.domain.configs import DummyProviderConfig, HttpClientSettings
+from bioetl.domain.configs import DummyProviderConfig, HttpClientConfig, ProviderHttpConfig
 from bioetl.domain.observability.contracts import LoggingPortABC
 from bioetl.domain.provider_registry import InMemoryProviderRegistry
 from bioetl.domain.providers import ProviderComponents, ProviderDefinition, ProviderId
@@ -192,18 +192,21 @@ class TestProviderRegistryModels:
         assert entry.description == "ChEMBL provider"
 
     def test_entry_model_with_http_client(self) -> None:
-        http_settings = HttpClientSettings(
-            base_url="https://api.example.com", timeout=60, retries=5
+        """Test entry model with HTTP config (legacy http_client field name)."""
+        http_config = ProviderHttpConfig(
+            base_url="https://api.example.com", timeout_sec=60.0, max_retries=5
         )
         entry = ProviderRegistryEntryModel(
             id="custom",
             module="custom.module",
             factory="create_provider",
-            http_client=http_settings,
+            http=http_config,
         )
-        assert entry.http_client is not None
-        assert entry.http_client.timeout == 60
-        assert entry.http_client.retries == 5
+        assert entry.http is not None
+        assert entry.http.timeout_sec == 60.0
+        assert entry.http.max_retries == 5
+        # Legacy property still works
+        assert entry.http_client is entry.http
 
     def test_registry_config_model(self) -> None:
         config = ProviderRegistryConfig(
@@ -365,7 +368,7 @@ class TestProviderLoaderImpl:
         provider_definition_factory: Callable[[ProviderId], ProviderDefinition],
     ) -> None:
         # Register test module
-        def factory(http_client: HttpClientSettings | None = None) -> ProviderDefinition:
+        def factory(http: HttpClientConfig | None = None) -> ProviderDefinition:
             return provider_definition_factory(ProviderId.DUMMY)
 
         _register_module("test_module_disabled", "create_provider", factory)
@@ -475,7 +478,7 @@ class TestProviderLoaderImpl:
     ) -> None:
         # Register test module with factory returning wrong type
         def wrong_factory(
-            http_client: HttpClientSettings | None = None,
+            http: HttpClientConfig | None = None,
         ) -> dict[str, str]:
             return {"not": "a provider"}
 
@@ -521,7 +524,7 @@ class TestProviderLoaderImpl:
     ) -> None:
         # Register test module with valid factory
         def valid_factory(
-            http_client: HttpClientSettings | None = None,
+            http: HttpClientConfig | None = None,
         ) -> ProviderDefinition:
             return provider_definition_factory(ProviderId.DUMMY)
 
@@ -561,7 +564,7 @@ class TestProviderLoaderImpl:
         provider_definition_factory: Callable[[ProviderId], ProviderDefinition],
     ) -> None:
         def valid_factory(
-            http_client: HttpClientSettings | None = None,
+            http: HttpClientConfig | None = None,
         ) -> ProviderDefinition:
             return provider_definition_factory(ProviderId.DUMMY)
 


### PR DESCRIPTION
…nfig

Consolidate three overlapping HTTP configuration models into a single source of truth:

- HttpClientConfig: new unified class replacing HttpClientSettings, HttpClientDefaults, and ClientConfig
- ProviderHttpConfig: extends HttpClientConfig with base_url for providers

Key changes:
- Standardized field names: timeout→timeout_sec, retries→max_retries, rate_limit→rate_limit_per_sec
- Added retry_on_status, backoff_max, circuit_breaker_enabled fields
- BaseProviderConfig now uses single `http` field instead of http_client + client
- Simplified factory functions to use single config parameter
- Added model validators for backward compatibility with legacy field names
- Deprecated old classes (HttpClientSettings, ClientConfig, etc.) as aliases
- Updated all consumers and tests

Breaking: Field names changed but backward compat maintained via validators