### PR TITLE
Make ChemblResponseParser generic instead of hardcoded

### DIFF
--- a/src/bioetl/domain/schemas/chembl/raw_models.py
+++ b/src/bioetl/domain/schemas/chembl/raw_models.py
@@ -77,4 +77,99 @@ class ActivityRawModel(RawRecord):
         return str(value)
 
 
-__all__ = ["ActivityRawModel", "JsonValue", "JsonObject", "ScalarValue"]
+class MoleculeRawModel(RawRecord):
+    """Raw ChEMBL molecule payload."""
+
+    model_config = ConfigDict(extra="allow")
+
+    molecule_chembl_id: str
+    pref_name: str | None = None
+    molecule_type: str | None = None
+    max_phase: int | None = None
+    molecule_structures: JsonObject | None = None
+    molecule_properties: JsonObject | None = None
+
+    @field_validator("molecule_chembl_id", mode="before")
+    @classmethod
+    def _stringify_molecule_id(cls, value: str | int) -> str:
+        return str(value)
+
+
+class TargetRawModel(RawRecord):
+    """Raw ChEMBL target payload."""
+
+    model_config = ConfigDict(extra="allow")
+
+    target_chembl_id: str
+    pref_name: str | None = None
+    organism: str | None = None
+    target_type: str | None = None
+    tax_id: int | None = None
+    species_group_flag: bool | None = None
+
+    @field_validator("target_chembl_id", mode="before")
+    @classmethod
+    def _stringify_target_id(cls, value: str | int) -> str:
+        return str(value)
+
+
+class AssayRawModel(RawRecord):
+    """Raw ChEMBL assay payload."""
+
+    model_config = ConfigDict(extra="allow")
+
+    assay_chembl_id: str
+    assay_type: str | None = None
+    description: str | None = None
+    assay_organism: str | None = None
+    assay_tax_id: int | None = None
+    assay_strain: str | None = None
+    assay_tissue: str | None = None
+    assay_cell_type: str | None = None
+    assay_subcellular_fraction: str | None = None
+    target_chembl_id: str | None = None
+    document_chembl_id: str | None = None
+    src_id: int | None = None
+    bao_format: str | None = None
+
+    @field_validator("assay_chembl_id", mode="before")
+    @classmethod
+    def _stringify_assay_id(cls, value: str | int) -> str:
+        return str(value)
+
+
+class DocumentRawModel(RawRecord):
+    """Raw ChEMBL document/publication payload."""
+
+    model_config = ConfigDict(extra="allow")
+
+    document_chembl_id: str
+    journal: str | None = None
+    year: int | None = None
+    volume: str | None = None
+    issue: str | None = None
+    first_page: str | None = None
+    last_page: str | None = None
+    pubmed_id: int | None = None
+    doi: str | None = None
+    title: str | None = None
+    doc_type: str | None = None
+    authors: str | None = None
+    abstract: str | None = None
+
+    @field_validator("document_chembl_id", mode="before")
+    @classmethod
+    def _stringify_document_id(cls, value: str | int) -> str:
+        return str(value)
+
+
+__all__ = [
+    "ActivityRawModel",
+    "MoleculeRawModel",
+    "TargetRawModel",
+    "AssayRawModel",
+    "DocumentRawModel",
+    "JsonValue",
+    "JsonObject",
+    "ScalarValue",
+]

--- a/src/bioetl/infrastructure/clients/chembl/factories.py
+++ b/src/bioetl/infrastructure/clients/chembl/factories.py
@@ -23,7 +23,7 @@ from bioetl.infrastructure.clients.chembl.request_builder import (
     ChemblRequestBuilderImpl,
 )
 from bioetl.infrastructure.clients.chembl.response_parser import (
-    ChemblResponseParserImpl,
+    create_activity_parser,
 )
 
 
@@ -76,7 +76,7 @@ def default_chembl_client(
             base_url=base_url,
             max_url_length=max_url_length,
         ),
-        response_parser=ChemblResponseParserImpl(),
+        response_parser=create_activity_parser(),
         rate_limiter=rate_limiter,
         client=unified_client,
         provider="chembl",

--- a/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
@@ -4,7 +4,7 @@ Implementation of ChemblExtractionService.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import Any, Iterable
 
 from bioetl.domain.clients.contracts import DataClientABC
 from bioetl.domain.observability.contracts import LoggingPortABC
@@ -13,12 +13,10 @@ from bioetl.domain.ports.extraction import (
     VersionProviderABC,
 )
 from bioetl.domain.ports.providers import DefaultFieldProviderABC
-from bioetl.domain.schemas.chembl.raw_models import ActivityRawModel
+from bioetl.domain.record_source import RawRecord
 from bioetl.infrastructure.clients.chembl.constants import ENTITY_ENDPOINT_ALIASES
+from bioetl.infrastructure.clients.chembl.parser_registry import get_parser_for_entity
 from bioetl.infrastructure.observability.factories import default_logging_port
-
-if TYPE_CHECKING:
-    from bioetl.domain.record_source import RawRecord
 
 
 class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
@@ -135,7 +133,7 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
 
         # Iterate pages
         for page_data in self.client.iter_pages(url):
-            records = self.parse_response(page_data)
+            records = self.parse_response(page_data, entity=mapped_entity)
             yield records
 
     def request_batch(
@@ -158,16 +156,20 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
         filters = {filter_key: ",".join(batch_ids), "limit": len(batch_ids)}
         return self.client.fetch(entity, **filters)
 
-    def parse_response(self, raw_response: dict[str, object]) -> list[ActivityRawModel]:
+    def parse_response(
+        self, raw_response: dict[str, object], *, entity: str = "activity"
+    ) -> list[RawRecord]:
         """
         Parse raw response into a list of records.
 
         Args:
             raw_response: The raw API response.
+            entity: Entity type for selecting appropriate parser.
 
         Returns:
-            list[dict[str, Any]]: List of parsed records.
+            list[RawRecord]: List of parsed records.
         """
+        # Try client's parser first (for backward compatibility)
         if hasattr(self.client, "response_parser"):
             parser = getattr(self.client, "response_parser")
             if hasattr(parser, "parse_response"):
@@ -175,15 +177,13 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
             if hasattr(parser, "parse"):
                 return parser.parse(raw_response)
 
-        # Fallback simple parsing
-        for value in raw_response.values():
-            if isinstance(value, list):
-                return [ActivityRawModel.model_validate(item) for item in value]
-        return []
+        # Use registry to get appropriate parser for entity type
+        parser = get_parser_for_entity(entity)
+        return parser.parse(raw_response)
 
     def serialize_records(
-        self, entity: str, records: list[ActivityRawModel]
-    ) -> list[ActivityRawModel]:
+        self, entity: str, records: list[RawRecord]
+    ) -> list[RawRecord]:
         """
         Serialize records for storage.
 
@@ -192,6 +192,6 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
             records: List of records.
 
         Returns:
-            list[dict[str, Any]]: Serialized records.
+            list[RawRecord]: Serialized records.
         """
         return records

--- a/src/bioetl/infrastructure/clients/chembl/parser_registry.py
+++ b/src/bioetl/infrastructure/clients/chembl/parser_registry.py
@@ -1,0 +1,80 @@
+"""Registry for ChEMBL entity parsers."""
+
+from typing import Literal, TypeAlias
+
+from pydantic import BaseModel
+
+from bioetl.domain.schemas.chembl.raw_models import (
+    ActivityRawModel,
+    AssayRawModel,
+    DocumentRawModel,
+    MoleculeRawModel,
+    TargetRawModel,
+)
+from bioetl.infrastructure.clients.chembl.response_parser import (
+    ChemblResponseParserImpl,
+)
+
+ChemblEntityType: TypeAlias = Literal[
+    "activity", "molecule", "target", "assay", "document"
+]
+
+# Mapping entity type -> model class
+ENTITY_MODEL_REGISTRY: dict[str, type[BaseModel]] = {
+    "activity": ActivityRawModel,
+    "molecule": MoleculeRawModel,
+    "target": TargetRawModel,
+    "assay": AssayRawModel,
+    "document": DocumentRawModel,
+}
+
+
+def get_model_for_entity(entity: str) -> type[BaseModel]:
+    """
+    Get model class for entity type.
+
+    Args:
+        entity: Entity type name (activity, molecule, target, assay, document).
+
+    Returns:
+        Pydantic model class for the entity.
+
+    Raises:
+        ValueError: If entity type is unknown.
+    """
+    model_class = ENTITY_MODEL_REGISTRY.get(entity)
+    if model_class is None:
+        raise ValueError(
+            f"Unknown entity type: {entity}. "
+            f"Available: {list(ENTITY_MODEL_REGISTRY.keys())}"
+        )
+    return model_class
+
+
+def get_parser_for_entity(entity: str) -> ChemblResponseParserImpl[BaseModel]:
+    """
+    Factory function: return parser for specified entity type.
+
+    Args:
+        entity: Entity type name (activity, molecule, target, assay, document).
+
+    Returns:
+        Configured ChemblResponseParserImpl for the entity type.
+
+    Raises:
+        ValueError: If entity type is unknown.
+
+    Example:
+        >>> parser = get_parser_for_entity("molecule")
+        >>> records = parser.parse({"molecules": [{"molecule_chembl_id": "CHEMBL1"}]})
+    """
+    model_class = get_model_for_entity(entity)
+    return ChemblResponseParserImpl(model_class)
+
+
+__all__ = [
+    "ChemblEntityType",
+    "ENTITY_MODEL_REGISTRY",
+    "get_model_for_entity",
+    "get_parser_for_entity",
+]

--- a/src/bioetl/infrastructure/clients/chembl/response_parser.py
+++ b/src/bioetl/infrastructure/clients/chembl/response_parser.py
@@ -1,24 +1,43 @@
 """Response parser for ChEMBL API responses."""
 
-from pydantic import TypeAdapter
+from typing import Generic, TypeVar
+
+from pydantic import BaseModel, TypeAdapter
 
 from bioetl.domain.clients.base.contracts import ResponseParserABC
 from bioetl.domain.schemas.chembl.raw_models import ActivityRawModel
 
+T = TypeVar("T", bound=BaseModel)
 
-class ChemblResponseParserImpl(ResponseParserABC[ActivityRawModel]):
+
+class ChemblResponseParserImpl(ResponseParserABC[T], Generic[T]):
     """
-    Парсер ответов ChEMBL API.
+    Generic parser for ChEMBL API responses.
+
+    Supports parsing any Pydantic model from ChEMBL API responses.
+
+    Example:
+        >>> parser = ChemblResponseParserImpl(ActivityRawModel)
+        >>> records = parser.parse({"activities": [{"activity_id": "1", ...}]})
     """
 
-    def parse(self, raw_response: dict[str, object]) -> list[ActivityRawModel]:
+    def __init__(self, model_class: type[T]) -> None:
+        """
+        Initialize parser with model class.
+
+        Args:
+            model_class: Pydantic model class to use for validation.
+        """
+        self._model_class = model_class
+
+    def parse(self, raw_response: dict[str, object]) -> list[T]:
         """Parse raw response into models."""
         for key, value in raw_response.items():
             if isinstance(value, list) and (not value or isinstance(value[0], dict)):
-                return [ActivityRawModel.model_validate(item) for item in value]
+                return [self._model_class.model_validate(item) for item in value]
         return []
 
-    def parse_response(self, raw_response: dict[str, object]) -> list[ActivityRawModel]:
+    def parse_response(self, raw_response: dict[str, object]) -> list[T]:
         """Alias for parse."""
         return self.parse(raw_response)
 
@@ -31,3 +50,12 @@ class ChemblResponseParserImpl(ResponseParserABC[ActivityRawModel]):
         )
         page_meta = raw_response.get("page_meta", {})
         return adapter.validate_python(page_meta)
+
+
+# Backward compatibility alias
+ChemblActivityResponseParser = ChemblResponseParserImpl[ActivityRawModel]
+
+
+def create_activity_parser() -> ChemblResponseParserImpl[ActivityRawModel]:
+    """Factory for creating activity parser (backward compatibility)."""
+    return ChemblResponseParserImpl(ActivityRawModel)

--- a/tests/bioetl/infrastructure/clients/chembl/test_parser_registry.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_parser_registry.py
@@ -1,0 +1,143 @@
+"""Tests for ChEMBL parser registry."""
+
+import pytest
+
+from bioetl.domain.schemas.chembl.raw_models import (
+    ActivityRawModel,
+    AssayRawModel,
+    DocumentRawModel,
+    MoleculeRawModel,
+    TargetRawModel,
+)
+from bioetl.infrastructure.clients.chembl.parser_registry import (
+    ENTITY_MODEL_REGISTRY,
+    get_model_for_entity,
+    get_parser_for_entity,
+)
+from bioetl.infrastructure.clients.chembl.response_parser import (
+    ChemblResponseParserImpl,
+)
+
+
+class TestEntityModelRegistry:
+    """Tests for ENTITY_MODEL_REGISTRY."""
+
+    def test_registry_contains_all_entity_types(self):
+        """Test that registry contains all expected entity types."""
+        expected_entities = ["activity", "molecule", "target", "assay", "document"]
+        for entity in expected_entities:
+            assert entity in ENTITY_MODEL_REGISTRY
+
+    def test_registry_maps_to_correct_models(self):
+        """Test that registry maps entities to correct model classes."""
+        assert ENTITY_MODEL_REGISTRY["activity"] is ActivityRawModel
+        assert ENTITY_MODEL_REGISTRY["molecule"] is MoleculeRawModel
+        assert ENTITY_MODEL_REGISTRY["target"] is TargetRawModel
+        assert ENTITY_MODEL_REGISTRY["assay"] is AssayRawModel
+        assert ENTITY_MODEL_REGISTRY["document"] is DocumentRawModel
+
+
+class TestGetModelForEntity:
+    """Tests for get_model_for_entity function."""
+
+    @pytest.mark.parametrize(
+        "entity,expected_model",
+        [
+            ("activity", ActivityRawModel),
+            ("molecule", MoleculeRawModel),
+            ("target", TargetRawModel),
+            ("assay", AssayRawModel),
+            ("document", DocumentRawModel),
+        ],
+    )
+    def test_returns_correct_model(self, entity, expected_model):
+        """Test that function returns correct model for each entity."""
+        assert get_model_for_entity(entity) is expected_model
+
+    def test_raises_for_unknown_entity(self):
+        """Test that function raises ValueError for unknown entity."""
+        with pytest.raises(ValueError, match="Unknown entity type: unknown"):
+            get_model_for_entity("unknown")
+
+    def test_error_message_lists_available_entities(self):
+        """Test that error message lists available entity types."""
+        with pytest.raises(ValueError) as exc_info:
+            get_model_for_entity("invalid")
+        assert "Available:" in str(exc_info.value)
+
+
+class TestGetParserForEntity:
+    """Tests for get_parser_for_entity function."""
+
+    @pytest.mark.parametrize(
+        "entity", ["activity", "molecule", "target", "assay", "document"]
+    )
+    def test_returns_parser_instance(self, entity):
+        """Test that function returns ChemblResponseParserImpl instance."""
+        parser = get_parser_for_entity(entity)
+        assert isinstance(parser, ChemblResponseParserImpl)
+
+    def test_activity_parser_parses_activities(self):
+        """Test that activity parser correctly parses activities."""
+        parser = get_parser_for_entity("activity")
+        response = {
+            "activities": [
+                {"activity_id": "1", "standard_flag": True},
+            ],
+        }
+        records = parser.parse(response)
+        assert len(records) == 1
+        assert isinstance(records[0], ActivityRawModel)
+
+    def test_molecule_parser_parses_molecules(self):
+        """Test that molecule parser correctly parses molecules."""
+        parser = get_parser_for_entity("molecule")
+        response = {
+            "molecules": [
+                {"molecule_chembl_id": "CHEMBL1"},
+            ],
+        }
+        records = parser.parse(response)
+        assert len(records) == 1
+        assert isinstance(records[0], MoleculeRawModel)
+
+    def test_target_parser_parses_targets(self):
+        """Test that target parser correctly parses targets."""
+        parser = get_parser_for_entity("target")
+        response = {
+            "targets": [
+                {"target_chembl_id": "CHEMBL1234"},
+            ],
+        }
+        records = parser.parse(response)
+        assert len(records) == 1
+        assert isinstance(records[0], TargetRawModel)
+
+    def test_assay_parser_parses_assays(self):
+        """Test that assay parser correctly parses assays."""
+        parser = get_parser_for_entity("assay")
+        response = {
+            "assays": [
+                {"assay_chembl_id": "CHEMBL1000"},
+            ],
+        }
+        records = parser.parse(response)
+        assert len(records) == 1
+        assert isinstance(records[0], AssayRawModel)
+
+    def test_document_parser_parses_documents(self):
+        """Test that document parser correctly parses documents."""
+        parser = get_parser_for_entity("document")
+        response = {
+            "documents": [
+                {"document_chembl_id": "CHEMBL_DOC_1"},
+            ],
+        }
+        records = parser.parse(response)
+        assert len(records) == 1
+        assert isinstance(records[0], DocumentRawModel)
+
+    def test_raises_for_unknown_entity(self):
+        """Test that function raises ValueError for unknown entity."""
+        with pytest.raises(ValueError, match="Unknown entity type"):
+            get_parser_for_entity("unknown")

--- a/tests/bioetl/infrastructure/clients/chembl/test_response_parser.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_response_parser.py
@@ -1,44 +1,185 @@
 from pydantic import ValidationError
 import pytest
 
-from bioetl.domain.schemas.chembl.raw_models import ActivityRawModel
+from bioetl.domain.schemas.chembl.raw_models import (
+    ActivityRawModel,
+    AssayRawModel,
+    DocumentRawModel,
+    MoleculeRawModel,
+    TargetRawModel,
+)
 from bioetl.infrastructure.clients.chembl.response_parser import (
+    ChemblActivityResponseParser,
     ChemblResponseParserImpl,
+    create_activity_parser,
 )
 
 
-def test_parse_activities():
-    parser = ChemblResponseParserImpl()
-    response = {
-        "activities": [
-            {"activity_id": "1", "standard_flag": True},
-            {"activity_id": "2", "standard_flag": False},
-        ],
-        "page_meta": {"limit": 20},
-    }
-    records = parser.parse(response)
-    assert len(records) == 2
-    assert isinstance(records[0], ActivityRawModel)
-    assert records[0].activity_id == "1"
+class TestActivityParser:
+    """Tests for activity parsing."""
+
+    def test_parse_activities(self):
+        parser = ChemblResponseParserImpl(ActivityRawModel)
+        response = {
+            "activities": [
+                {"activity_id": "1", "standard_flag": True},
+                {"activity_id": "2", "standard_flag": False},
+            ],
+            "page_meta": {"limit": 20},
+        }
+        records = parser.parse(response)
+        assert len(records) == 2
+        assert isinstance(records[0], ActivityRawModel)
+        assert records[0].activity_id == "1"
+
+    def test_parse_empty(self):
+        parser = ChemblResponseParserImpl(ActivityRawModel)
+        response = {"page_meta": {}}
+        records = parser.parse(response)
+        assert records == []
+
+    def test_parse_invalid_payload(self):
+        parser = ChemblResponseParserImpl(ActivityRawModel)
+        response = {"activities": [{"activity_id": 1}]}
+
+        with pytest.raises(ValidationError):
+            parser.parse(response)
+
+    def test_extract_metadata(self):
+        parser = ChemblResponseParserImpl(ActivityRawModel)
+        response = {"page_meta": {"offset": 10}}
+        meta = parser.extract_metadata(response)
+        assert meta["offset"] == 10
 
 
-def test_parse_empty():
-    parser = ChemblResponseParserImpl()
-    response = {"page_meta": {}}
-    records = parser.parse(response)
-    assert records == []
+class TestMoleculeParser:
+    """Tests for molecule parsing."""
+
+    def test_parse_molecules(self):
+        parser = ChemblResponseParserImpl(MoleculeRawModel)
+        response = {
+            "molecules": [
+                {"molecule_chembl_id": "CHEMBL1", "pref_name": "Aspirin"},
+                {"molecule_chembl_id": "CHEMBL2", "molecule_type": "Small molecule"},
+            ],
+            "page_meta": {"limit": 20},
+        }
+        records = parser.parse(response)
+        assert len(records) == 2
+        assert isinstance(records[0], MoleculeRawModel)
+        assert records[0].molecule_chembl_id == "CHEMBL1"
+        assert records[0].pref_name == "Aspirin"
+
+    def test_parse_molecule_with_extra_fields(self):
+        """Test that extra fields are allowed."""
+        parser = ChemblResponseParserImpl(MoleculeRawModel)
+        response = {
+            "molecules": [
+                {
+                    "molecule_chembl_id": "CHEMBL1",
+                    "unknown_field": "value",
+                    "another_field": 123,
+                },
+            ],
+        }
+        records = parser.parse(response)
+        assert len(records) == 1
+        assert records[0].molecule_chembl_id == "CHEMBL1"
+
+    def test_stringify_molecule_id(self):
+        """Test that molecule_chembl_id is stringified."""
+        parser = ChemblResponseParserImpl(MoleculeRawModel)
+        response = {
+            "molecules": [{"molecule_chembl_id": 12345}],
+        }
+        records = parser.parse(response)
+        assert records[0].molecule_chembl_id == "12345"
 
 
-def test_parse_invalid_payload():
-    parser = ChemblResponseParserImpl()
-    response = {"activities": [{"activity_id": 1}]}
+class TestTargetParser:
+    """Tests for target parsing."""
 
-    with pytest.raises(ValidationError):
-        parser.parse(response)
+    def test_parse_targets(self):
+        parser = ChemblResponseParserImpl(TargetRawModel)
+        response = {
+            "targets": [
+                {
+                    "target_chembl_id": "CHEMBL1234",
+                    "pref_name": "Cyclooxygenase-2",
+                    "organism": "Homo sapiens",
+                },
+            ],
+            "page_meta": {"limit": 20},
+        }
+        records = parser.parse(response)
+        assert len(records) == 1
+        assert isinstance(records[0], TargetRawModel)
+        assert records[0].target_chembl_id == "CHEMBL1234"
+        assert records[0].organism == "Homo sapiens"
 
 
-def test_extract_metadata():
-    parser = ChemblResponseParserImpl()
-    response = {"page_meta": {"offset": 10}}
-    meta = parser.extract_metadata(response)
-    assert meta["offset"] == 10
+class TestAssayParser:
+    """Tests for assay parsing."""
+
+    def test_parse_assays(self):
+        parser = ChemblResponseParserImpl(AssayRawModel)
+        response = {
+            "assays": [
+                {
+                    "assay_chembl_id": "CHEMBL1000",
+                    "assay_type": "B",
+                    "description": "Binding assay",
+                },
+            ],
+            "page_meta": {"limit": 20},
+        }
+        records = parser.parse(response)
+        assert len(records) == 1
+        assert isinstance(records[0], AssayRawModel)
+        assert records[0].assay_chembl_id == "CHEMBL1000"
+        assert records[0].assay_type == "B"
+
+
+class TestDocumentParser:
+    """Tests for document parsing."""
+
+    def test_parse_documents(self):
+        parser = ChemblResponseParserImpl(DocumentRawModel)
+        response = {
+            "documents": [
+                {
+                    "document_chembl_id": "CHEMBL_DOC_1",
+                    "journal": "Nature",
+                    "year": 2023,
+                    "title": "Example paper",
+                },
+            ],
+            "page_meta": {"limit": 20},
+        }
+        records = parser.parse(response)
+        assert len(records) == 1
+        assert isinstance(records[0], DocumentRawModel)
+        assert records[0].document_chembl_id == "CHEMBL_DOC_1"
+        assert records[0].journal == "Nature"
+        assert records[0].year == 2023
+
+
+class TestBackwardCompatibility:
+    """Tests for backward compatibility."""
+
+    def test_create_activity_parser_factory(self):
+        """Test factory function creates activity parser."""
+        parser = create_activity_parser()
+        response = {
+            "activities": [
+                {"activity_id": "1", "standard_flag": True},
+            ],
+        }
+        records = parser.parse(response)
+        assert len(records) == 1
+        assert isinstance(records[0], ActivityRawModel)
+
+    def test_chembl_activity_response_parser_alias(self):
+        """Test type alias is available."""
+        # This should not raise - type alias exists
+        assert ChemblActivityResponseParser is not None


### PR DESCRIPTION
Make ChemblResponseParserImpl generic to support parsing different ChEMBL entity types instead of being hardcoded to ActivityRawModel.

Changes:
- Add raw models: MoleculeRawModel, TargetRawModel, AssayRawModel, DocumentRawModel with extra="allow" for flexibility
- Make ChemblResponseParserImpl generic with type parameter T
- Create parser registry with ENTITY_MODEL_REGISTRY and factory function get_parser_for_entity()
- Update ChemblExtractionServiceImpl.parse_response() to accept entity type and use registry as fallback
- Add backward compatibility: ChemblActivityResponseParser alias and create_activity_parser() factory function
- Add comprehensive tests for generic parser and registry