### PR TITLE
Remove duplicate RecordSource creation logic

### DIFF
--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -174,12 +174,16 @@ class PipelineContainer(PipelineContainerABC):
         *,
         limit: int | None = None,
         logger: LoggingPortABC | None = None,
+        model_cls: type | None = None,
+        batch_adapter: Any | None = None,
     ) -> RecordSourceABC:
         """Create record source based on pipeline input configuration."""
         return self._get_record_source_factory().create_record_source(
             extraction_service,
             limit=limit,
             logger=logger or self.get_logger(),
+            model_cls=model_cls,
+            batch_adapter=batch_adapter,
         )
 
     def get_extraction_service(self) -> Any:

--- a/src/bioetl/application/factories/record_source.py
+++ b/src/bioetl/application/factories/record_source.py
@@ -5,7 +5,7 @@ Factory for creating RecordSource instances.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from bioetl.application.files.csv_record_source import (
     CsvRecordSourceImpl,
@@ -39,10 +39,25 @@ class RecordSourceFactory:
         *,
         limit: int | None = None,
         logger: LoggingPortABC,
+        model_cls: type | None = None,
+        batch_adapter: Callable[..., Any] | None = None,
     ) -> RecordSourceABC:
-        """Create record source based on pipeline input configuration."""
+        """Create record source based on pipeline input configuration.
+
+        Args:
+            extraction_service: Service for API extraction.
+            limit: Maximum number of records to fetch.
+            logger: Logger instance.
+            model_cls: Optional Pydantic model class for CSV parsing.
+            batch_adapter: Optional batch processing callable for API mode.
+                If not provided, creates a default PandasBatchAdapter.
+
+        Returns:
+            Configured RecordSourceABC instance.
+        """
         mode = self._config.input_mode
         path = self._config.input_path
+        chunk_size = self._config.batch_size
 
         if mode == "auto_detect" and path:
             mode = "csv"
@@ -55,7 +70,8 @@ class RecordSourceFactory:
                 csv_options=self._config.csv_options,
                 limit=limit,
                 logger=logger,
-                chunk_size=None,
+                chunk_size=chunk_size,
+                model_cls=model_cls,
             )
 
         if mode == "id_only":
@@ -75,17 +91,23 @@ class RecordSourceFactory:
                 entity=self._config.entity_name,
                 filter_key=filter_key,
                 logger=logger,
-                chunk_size=None,
+                chunk_size=chunk_size,
             )
 
         filters = self._config.pipeline.copy()
         if limit is not None:
             filters["limit"] = limit
 
+        resolved_batch_adapter = batch_adapter
+        if resolved_batch_adapter is None:
+            resolved_batch_adapter = PandasBatchAdapter(
+                model_cls=model_cls
+            ).process_batch
+
         return ApiRecordSource(
             extraction_service=extraction_service,
             entity=self._config.entity_name,
             filters=filters,
-            chunk_size=self._config.batch_size,
-            batch_adapter=PandasBatchAdapter().process_batch,
+            chunk_size=chunk_size,
+            batch_adapter=resolved_batch_adapter,
         )

--- a/src/bioetl/application/pipelines/chembl/base.py
+++ b/src/bioetl/application/pipelines/chembl/base.py
@@ -14,7 +14,6 @@ from bioetl.application.pipelines.base import (
 from bioetl.application.pipelines.chembl.extractor import ChemblExtractorImpl
 from bioetl.application.pipelines.chembl.transformer import ChemblTransformerImpl
 from bioetl.application.pipelines.contracts import LoaderABC
-from bioetl.application.transform.pandas_batch_adapter import PandasBatchAdapter
 from bioetl.domain.clients.base.output.contracts import (
     RunMetadataBuilderProtocol,
     WriteResult,
@@ -28,7 +27,6 @@ from bioetl.domain.ports.extraction import (
     ExtractionServiceABC,
 )
 from bioetl.domain.record_source import RecordSourceABC
-from bioetl.domain.schemas.chembl.raw_models import ActivityRawModel
 from bioetl.domain.schemas.pipeline_contracts import get_pipeline_contract
 from bioetl.domain.transform.contracts import HashServiceABC, NormalizationServiceABC
 from bioetl.domain.transform.transformers import TransformerABC
@@ -65,12 +63,17 @@ class ChemblPipelineBase(PipelineBase):
             )
         norm_service = normalization_service
 
+        if record_source is None:
+            raise ValueError(
+                "Record source is required. "
+                "Use RecordSourceFactory via container.get_record_source()."
+            )
+
         extractor = ChemblExtractorImpl(
             config=config,
             extraction_service=extraction_service,
             normalization_service=norm_service,
             logger=logger,
-            batch_adapter=PandasBatchAdapter(model_cls=ActivityRawModel),
             record_source=record_source,
         )
 

--- a/src/bioetl/application/pipelines/chembl/extractor.py
+++ b/src/bioetl/application/pipelines/chembl/extractor.py
@@ -2,33 +2,24 @@
 ChEMBL data extractor implementation.
 """
 
-from pathlib import Path
-from typing import Any, Iterable, cast
+from typing import Any, Iterable
 
 import pandas as pd
 from pydantic import BaseModel
 
-from bioetl.application.files.csv_record_source import (
-    CsvRecordSourceImpl,
-    IdListRecordSourceImpl,
-)
-from bioetl.application.helpers import resolve_primary_key
 from bioetl.application.pipelines.contracts import ExtractorABC
-from bioetl.application.sources import ApiRecordSource
-from bioetl.domain.configs import ChemblSourceConfig, CsvInputConfig, PipelineConfig
+from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.observability import LoggingPortABC
-from bioetl.domain.ports.extraction import (
-    BatchAdapterABC,
-    ExtractionServiceABC,
-)
+from bioetl.domain.ports.extraction import ExtractionServiceABC
 from bioetl.domain.record_source import RecordSourceABC
-from bioetl.domain.schemas.chembl.raw_models import ActivityRawModel
 from bioetl.domain.transform.contracts import NormalizationServiceABC
 
 
 class ChemblExtractorImpl(ExtractorABC):
     """
     Extracts data from ChEMBL source (API or File) and applies normalization.
+
+    Record source is injected via constructor and created by RecordSourceFactory.
     """
 
     def __init__(
@@ -37,14 +28,12 @@ class ChemblExtractorImpl(ExtractorABC):
         extraction_service: ExtractionServiceABC,
         normalization_service: NormalizationServiceABC,
         logger: LoggingPortABC,
-        batch_adapter: BatchAdapterABC,
-        record_source: RecordSourceABC | None = None,
+        record_source: RecordSourceABC,
     ) -> None:
         self.config = config
         self.extraction_service = extraction_service
         self.normalization_service = normalization_service
         self.logger = logger
-        self.batch_adapter = batch_adapter
         self.record_source = record_source
 
     def extract(self, **kwargs: Any) -> Iterable[pd.DataFrame]:
@@ -52,11 +41,9 @@ class ChemblExtractorImpl(ExtractorABC):
         Yields chunks of normalized data.
         """
         limit = kwargs.pop("limit", None)
-
         remaining = limit
-        record_source = self.record_source or self._resolve_record_source(limit=limit)
 
-        for raw_chunk in record_source.iter_records():
+        for raw_chunk in self.record_source.iter_records():
             if remaining is not None and remaining <= 0:
                 break
 
@@ -80,113 +67,3 @@ class ChemblExtractorImpl(ExtractorABC):
                 remaining -= len(chunk_records)
                 if remaining <= 0:
                     break
-
-    def _resolve_record_source(self, *, limit: int | None) -> RecordSourceABC:
-        """
-        Builds record source based on current pipeline config.
-        Falls back to API iteration when no input file is provided.
-        """
-
-        mode, input_path = self._resolve_mode()
-        csv_options = self._resolve_csv_options()
-        batch_size = self._resolve_batch_size()
-
-        if mode == "csv":
-            return self._build_csv_source(
-                input_path=input_path,
-                csv_options=csv_options,
-                limit=limit,
-                chunk_size=batch_size,
-            )
-
-        if mode == "id_only":
-            return self._build_id_list_source(
-                input_path=input_path,
-                csv_options=csv_options,
-                limit=limit,
-                chunk_size=batch_size,
-            )
-
-        return self._build_api_source(limit=limit, chunk_size=batch_size)
-
-    def _resolve_mode(self) -> tuple[str, str | None]:
-        mode = getattr(self.config, "input_mode", "auto_detect")
-        input_path = getattr(self.config, "input_path", None)
-        if mode == "auto_detect" and input_path:
-            return "csv", input_path
-        return mode, input_path
-
-    def _resolve_csv_options(self) -> dict[str, Any] | CsvInputConfig:
-        return getattr(self.config, "csv_options", None) or {}
-
-    def _resolve_batch_size(self) -> int | None:
-        raw_batch_size = getattr(self.config, "batch_size", None)
-        if isinstance(raw_batch_size, (int, float)) and raw_batch_size > 0:
-            return int(raw_batch_size)
-        return None
-
-    def _build_csv_source(
-        self,
-        *,
-        input_path: str | None,
-        csv_options: dict[str, Any] | CsvInputConfig,
-        limit: int | None,
-        chunk_size: int | None,
-    ) -> RecordSourceABC:
-        if not input_path:
-            raise ValueError("input_path is required for CSV mode")
-        return CsvRecordSourceImpl(
-            input_path=Path(input_path),
-            csv_options=csv_options,
-            limit=limit,
-            chunk_size=chunk_size,
-            logger=self.logger,
-            model_cls=ActivityRawModel,
-        )
-
-    def _build_id_list_source(
-        self,
-        *,
-        input_path: str | None,
-        csv_options: dict[str, Any] | CsvInputConfig,
-        limit: int | None,
-        chunk_size: int | None,
-    ) -> RecordSourceABC:
-        if not input_path:
-            raise ValueError("input_path is required for ID-only mode")
-        id_column = resolve_primary_key(self.config)
-        filter_key = f"{id_column}__in"
-        source_config_raw = self.config.get_source_config(self.config.provider)
-        source_config = cast(ChemblSourceConfig, source_config_raw)
-        if not isinstance(source_config, ChemblSourceConfig):
-            raise TypeError(
-                "Expected ChemblSourceConfig for provider "
-                f"'{self.config.provider}', got "
-                f"{type(source_config).__name__}"
-            )
-        return IdListRecordSourceImpl(
-            input_path=Path(input_path),
-            id_column=id_column,
-            csv_options=csv_options,
-            limit=limit,
-            chunk_size=chunk_size,
-            extraction_service=self.extraction_service,
-            source_config=source_config,
-            entity=self.config.entity_name,
-            filter_key=filter_key,
-            logger=self.logger,
-        )
-
-    def _build_api_source(
-        self, *, limit: int | None, chunk_size: int | None
-    ) -> RecordSourceABC:
-        filters = dict(getattr(self.config, "pipeline", {}) or {})
-        if limit is not None:
-            filters["limit"] = limit
-        return ApiRecordSource(
-            extraction_service=self.extraction_service,
-            entity=self.config.entity_name,
-            filters=filters,
-            chunk_size=chunk_size,
-            batch_adapter=self.batch_adapter.process_batch,
-        )

--- a/src/bioetl/application/pipelines/chembl/factories.py
+++ b/src/bioetl/application/pipelines/chembl/factories.py
@@ -4,6 +4,7 @@ Factories for ChEMBL pipelines.
 
 from bioetl.application.pipelines.chembl.base import ChemblPipelineBase
 from bioetl.application.pipelines.contracts import PipelineContainerABC
+from bioetl.domain.schemas.chembl.raw_models import ActivityRawModel
 
 
 def create_chembl_pipeline(container: PipelineContainerABC) -> ChemblPipelineBase:
@@ -16,15 +17,24 @@ def create_chembl_pipeline(container: PipelineContainerABC) -> ChemblPipelineBas
     Returns:
         Configured ChemblPipelineBase.
     """
+    extraction_service = container.get_extraction_service()
+    logger = container.get_logger()
+
+    record_source = container.get_record_source(
+        extraction_service,
+        logger=logger,
+        model_cls=ActivityRawModel,
+    )
+
     return ChemblPipelineBase(
         config=container.config,
-        logger=container.get_logger(),
+        logger=logger,
         validation_service=container.get_validation_service(),
         loader=container.get_loader(),
-        extraction_service=container.get_extraction_service(),
+        extraction_service=extraction_service,
         hash_service=container.get_hash_service(),
         metadata_builder=container.get_metadata_builder(),
-        record_source=None,  # Pipeline resolves source based on config
+        record_source=record_source,
         normalization_service=container.get_normalization_service(),
         hooks=container.get_hooks(),
         error_policy=container.get_error_policy(),

--- a/src/bioetl/application/pipelines/contracts.py
+++ b/src/bioetl/application/pipelines/contracts.py
@@ -59,6 +59,8 @@ class PipelineContainerABC(ABC):
         *,
         limit: int | None = None,
         logger: LoggingPortABC | None = None,
+        model_cls: type | None = None,
+        batch_adapter: Any | None = None,
     ) -> RecordSourceABC:
         """Return record source for pipeline input according to config."""
 

--- a/tests/bioetl/application/pipelines/chembl/test_base.py
+++ b/tests/bioetl/application/pipelines/chembl/test_base.py
@@ -91,6 +91,9 @@ def pipeline_fixture(mock_dependencies_fixture):
     """Fixture for pipeline instance."""
     mock_dependencies_fixture["config"].model_dump.return_value = {}
 
+    record_source = MagicMock()
+    record_source.iter_records.return_value = iter([])
+
     return ConcreteChemblPipeline(
         config=mock_dependencies_fixture["config"],
         logger=mock_dependencies_fixture["logger"],
@@ -100,6 +103,7 @@ def pipeline_fixture(mock_dependencies_fixture):
         normalization_service=mock_dependencies_fixture["normalization_service"],
         hash_service=mock_dependencies_fixture["hash_service"],
         metadata_builder=mock_dependencies_fixture["metadata_builder"],
+        record_source=record_source,
     )
 
 
@@ -227,6 +231,9 @@ def test_transform_uses_batch_normalization(mock_dependencies_fixture):
     normalized_df = pd.DataFrame({"a": [1, 2], "transformed": [True, True]})
     normalization_service.normalize.return_value = normalized_df
 
+    record_source = MagicMock()
+    record_source.iter_records.return_value = iter([])
+
     pipeline = ConcreteChemblPipeline(
         config=mock_dependencies_fixture["config"],
         logger=mock_dependencies_fixture["logger"],
@@ -236,6 +243,7 @@ def test_transform_uses_batch_normalization(mock_dependencies_fixture):
         normalization_service=normalization_service,
         hash_service=mock_dependencies_fixture["hash_service"],
         metadata_builder=mock_dependencies_fixture["metadata_builder"],
+        record_source=record_source,
     )
 
     df = pd.DataFrame({"a": [1, 2]})

--- a/tests/bioetl/application/pipelines/chembl/test_config_resolution.py
+++ b/tests/bioetl/application/pipelines/chembl/test_config_resolution.py
@@ -12,6 +12,9 @@ from bioetl.infrastructure.config.models import (
 
 @pytest.fixture
 def dependencies():
+    record_source = MagicMock()
+    record_source.iter_records.return_value = iter([])
+
     return {
         "logger": MagicMock(),
         "validation_service": MagicMock(),
@@ -19,6 +22,7 @@ def dependencies():
         "extraction_service": MagicMock(),
         "hash_service": MagicMock(),
         "normalization_service": MagicMock(),
+        "record_source": record_source,
     }
 
 

--- a/tests/bioetl/application/pipelines/chembl/test_pipelines_smoke.py
+++ b/tests/bioetl/application/pipelines/chembl/test_pipelines_smoke.py
@@ -27,6 +27,9 @@ def common_dependencies():
     normalization_service.normalize_record.side_effect = lambda record: record
     normalization_service.ensure_numeric_columns.side_effect = lambda df: df
 
+    record_source = MagicMock()
+    record_source.iter_records.return_value = iter([])
+
     return {
         "config": config,
         "logger": MagicMock(),
@@ -35,6 +38,7 @@ def common_dependencies():
         "extraction_service": MagicMock(),
         "hash_service": MagicMock(),
         "normalization_service": normalization_service,
+        "record_source": record_source,
     }
 
 
@@ -66,6 +70,7 @@ def test_pipeline_instantiation(pipeline_info, common_dependencies):
         extraction_service=common_dependencies["extraction_service"],
         hash_service=common_dependencies["hash_service"],
         normalization_service=common_dependencies["normalization_service"],
+        record_source=common_dependencies["record_source"],
     )
 
     assert pipeline.ID_COLUMN == id_col

--- a/tests/bioetl/application/pipelines/chembl/test_pk_resolution.py
+++ b/tests/bioetl/application/pipelines/chembl/test_pk_resolution.py
@@ -12,6 +12,9 @@ from bioetl.infrastructure.config.models import (
 
 @pytest.fixture
 def dependencies():
+    record_source = MagicMock()
+    record_source.iter_records.return_value = iter([])
+
     return {
         "logger": MagicMock(),
         "validation_service": MagicMock(),
@@ -19,6 +22,7 @@ def dependencies():
         "extraction_service": MagicMock(),
         "hash_service": MagicMock(),
         "normalization_service": _build_normalization_service(),
+        "record_source": record_source,
     }
 
 

--- a/tests/bioetl/pipelines/chembl/activity/test_extract.py
+++ b/tests/bioetl/pipelines/chembl/activity/test_extract.py
@@ -108,6 +108,12 @@ def pipeline(mock_config, mock_extraction_service, mock_normalization_service):
     loader = MagicMock()
     metadata_builder = MagicMock()
 
+    # Default record source yields dict records (simulating API response)
+    record_source = MagicMock()
+    record_source.iter_records.return_value = iter([
+        [{"activity_id": 1, "standard_flag": 1}, {"activity_id": 2, "standard_flag": 1}]
+    ])
+
     return ChemblPipelineBase(
         config=mock_config,
         logger=logger,
@@ -117,17 +123,18 @@ def pipeline(mock_config, mock_extraction_service, mock_normalization_service):
         hash_service=MagicMock(),
         normalization_service=mock_normalization_service,
         metadata_builder=metadata_builder,
+        record_source=record_source,
     )
 
 
 def test_extract_no_input_file(pipeline, mock_extraction_service):
-    """Test extraction falls back to service when no input file."""
+    """Test extraction uses record source to yield data."""
     pipeline._config.input_mode = "auto_detect"
     pipeline._config.input_path = None
 
     df = _extract_dataframe(pipeline)
 
-    mock_extraction_service.iter_extract.assert_called_once()
+    # Record source iter_records is used (not direct iter_extract call)
     assert not df.empty
     assert "activity_id" in df.columns
 
@@ -158,8 +165,8 @@ def test_extract_full_data_csv(pipeline, mock_extraction_service, tmp_path):
 
     assert len(df) == 2
     assert "standard_value" in df.columns
+    # With record_source injection, extraction service methods are not called
     mock_extraction_service.extract_all.assert_not_called()
-    mock_extraction_service.iter_extract.assert_not_called()
     mock_extraction_service.request_batch.assert_not_called()
 
 

--- a/tests/bioetl/pipelines/chembl/activity/test_transform.py
+++ b/tests/bioetl/pipelines/chembl/activity/test_transform.py
@@ -38,6 +38,9 @@ def pipeline():
     normalization_service.normalize.side_effect = lambda df: df.copy()
     normalization_service.apply_normalize.side_effect = lambda record: record
 
+    record_source = MagicMock()
+    record_source.iter_records.return_value = iter([])
+
     return ChemblPipelineBase(
         config=config,
         logger=MagicMock(),
@@ -47,6 +50,7 @@ def pipeline():
         hash_service=MagicMock(),
         metadata_builder=metadata_builder,
         normalization_service=normalization_service,
+        record_source=record_source,
     )
 
 

--- a/tests/bioetl/pipelines/chembl/assay/test_transform.py
+++ b/tests/bioetl/pipelines/chembl/assay/test_transform.py
@@ -40,6 +40,9 @@ def pipeline():
     normalization_service.normalize.side_effect = lambda df: df.copy()
     normalization_service.apply_normalize.side_effect = lambda record: record
 
+    record_source = MagicMock()
+    record_source.iter_records.return_value = iter([])
+
     return ChemblPipelineBase(
         config=config,
         logger=MagicMock(),
@@ -48,6 +51,7 @@ def pipeline():
         extraction_service=MagicMock(),
         hash_service=MagicMock(),
         normalization_service=normalization_service,
+        record_source=record_source,
     )
 
 

--- a/tests/bioetl/pipelines/chembl/molecule/test_transform.py
+++ b/tests/bioetl/pipelines/chembl/molecule/test_transform.py
@@ -41,6 +41,9 @@ def pipeline():  # pylint: disable=redefined-outer-name
     normalization_service.normalize.side_effect = lambda df: df.copy()
     normalization_service.apply_normalize.side_effect = lambda record: record
 
+    record_source = MagicMock()
+    record_source.iter_records.return_value = iter([])
+
     return ChemblPipelineBase(
         config=config,
         logger=MagicMock(),
@@ -49,6 +52,7 @@ def pipeline():  # pylint: disable=redefined-outer-name
         extraction_service=MagicMock(),
         hash_service=MagicMock(),
         normalization_service=normalization_service,
+        record_source=record_source,
     )
 
 

--- a/tests/bioetl/pipelines/chembl/publication/test_transform.py
+++ b/tests/bioetl/pipelines/chembl/publication/test_transform.py
@@ -48,6 +48,9 @@ def pipeline():
 
     normalization_service = DefaultNormalizationTransformerImpl(config)
 
+    record_source = MagicMock()
+    record_source.iter_records.return_value = iter([])
+
     return ChemblPipelineBase(
         config=config,
         logger=MagicMock(),
@@ -56,6 +59,7 @@ def pipeline():
         extraction_service=MagicMock(),
         hash_service=MagicMock(),
         normalization_service=normalization_service,
+        record_source=record_source,
     )
 
 

--- a/tests/bioetl/pipelines/chembl/target/test_transform.py
+++ b/tests/bioetl/pipelines/chembl/target/test_transform.py
@@ -39,6 +39,9 @@ def pipeline():
     normalization_service.normalize.side_effect = lambda df: df.copy()
     normalization_service.apply_normalize.side_effect = lambda record: record
 
+    record_source = MagicMock()
+    record_source.iter_records.return_value = iter([])
+
     return ChemblPipelineBase(
         config=config,
         logger=MagicMock(),
@@ -47,6 +50,7 @@ def pipeline():
         extraction_service=MagicMock(),
         hash_service=MagicMock(),
         normalization_service=normalization_service,
+        record_source=record_source,
     )
 
 

--- a/tests/bioetl/pipelines/chembl/test_extract_pipeline_errors.py
+++ b/tests/bioetl/pipelines/chembl/test_extract_pipeline_errors.py
@@ -78,6 +78,15 @@ def test_extract_stage_wraps_client_error(
     normalization_service.apply_normalize_fields.side_effect = lambda df, *_: df
     normalization_service.apply_normalize.side_effect = lambda record: record
 
+    # Record source raises ClientNetworkError when iterating
+    def raise_network_error():
+        raise ClientNetworkError(
+            provider="chembl", endpoint="/status", message="timeout"
+        )
+
+    record_source = MagicMock()
+    record_source.iter_records.side_effect = raise_network_error
+
     pipeline = ChemblPipelineBase(
         config=config,
         logger=logger,
@@ -86,6 +95,7 @@ def test_extract_stage_wraps_client_error(
         extraction_service=extraction_service,
         hash_service=hash_service,
         normalization_service=normalization_service,
+        record_source=record_source,
     )
 
     with pytest.raises(PipelineStageError) as exc_info:


### PR DESCRIPTION
Remove duplicate RecordSource creation logic from ChemblExtractorImpl. Now ChemblExtractorImpl receives RecordSource via dependency injection, and RecordSourceFactory is the single source of truth for creating RecordSource instances.

Changes:
- Remove _resolve_record_source and related methods from ChemblExtractorImpl
- Update RecordSourceFactory to support model_cls and batch_adapter params
- ChemblExtractorImpl now requires record_source in constructor
- create_chembl_pipeline creates record_source via container.get_record_source()
- Update all tests to provide record_source mock