### PR TITLE
Refactor StageRuntimeManager to follow Single Responsibility

### DIFF
--- a/src/bioetl/application/pipelines/hook_notifier.py
+++ b/src/bioetl/application/pipelines/hook_notifier.py
@@ -1,0 +1,111 @@
+"""Hook notification component for pipeline stage events."""
+
+from collections.abc import Iterable
+from datetime import datetime, timezone
+
+from bioetl.domain.errors import PipelineStageError
+from bioetl.domain.models import RunContext, StageResult
+from bioetl.domain.observability import LoggingPortABC
+from bioetl.domain.pipelines.contracts import PipelineHookABC
+
+
+class HookNotifier:
+    """Manages hook registration and notification for pipeline stage events."""
+
+    def __init__(
+        self,
+        *,
+        logger: LoggingPortABC,
+        pipeline_id: str | None = None,
+        hooks: Iterable[PipelineHookABC] | None = None,
+    ) -> None:
+        self._logger = logger
+        self._pipeline_id = pipeline_id
+        self._hooks: list[PipelineHookABC] = list(hooks or [])
+        self._stage_starts: dict[str, datetime] = {}
+        self._current_run_id: str | None = None
+
+    @property
+    def current_run_id(self) -> str | None:
+        """Return the current run ID."""
+        return self._current_run_id
+
+    def set_logger(self, logger: LoggingPortABC) -> None:
+        """Update the logger instance."""
+        self._logger = logger
+
+    def register_hook(self, hook: PipelineHookABC) -> None:
+        """Register a single hook."""
+        self._hooks.append(hook)
+
+    def register_hooks(self, hooks: Iterable[PipelineHookABC]) -> None:
+        """Register multiple hooks."""
+        for hook in hooks:
+            self.register_hook(hook)
+
+    def get_hooks(self) -> list[PipelineHookABC]:
+        """Return list of registered hooks."""
+        return self._hooks
+
+    def notify_stage_start(
+        self,
+        stage: str,
+        context: RunContext,
+        *,
+        provider: str,
+        entity_name: str,
+    ) -> None:
+        """Notify hooks about stage start and log the event."""
+        self._stage_starts[stage] = datetime.now(timezone.utc)
+        self._current_run_id = context.run_id
+        self._logger.info(
+            "Stage started",
+            provider=context.provider,
+            entity=context.entity_name,
+            run_id=context.run_id,
+            stage=stage,
+            pipeline=self._pipeline_id,
+        )
+        for hook in self._hooks:
+            hook.on_stage_start(stage, context)
+
+    def notify_stage_end(
+        self,
+        stage: str,
+        result: StageResult,
+        *,
+        provider: str,
+        entity_name: str,
+    ) -> None:
+        """Notify hooks about stage completion and log the event."""
+        self._logger.info(
+            "Stage finished",
+            records=result.records_processed,
+            chunks=result.chunks_processed,
+            provider=provider,
+            entity=entity_name,
+            stage=stage,
+            pipeline=self._pipeline_id,
+            run_id=self._current_run_id,
+            outcome="success" if result.success else "error",
+        )
+        for hook in self._hooks:
+            hook.on_stage_end(stage, result)
+
+    def notify_stage_error(
+        self,
+        stage: str,
+        error: PipelineStageError,
+    ) -> None:
+        """Notify hooks about stage error."""
+        for hook in self._hooks:
+            hook.on_error(stage, error)
+
+    def get_stage_start(self, stage: str) -> datetime | None:
+        """Return the recorded start time for a stage, if any."""
+        return self._stage_starts.get(stage)
+
+    def reset(self) -> None:
+        """Clear accumulated state."""
+        self._stage_starts.clear()
+        self._current_run_id = None

--- a/src/bioetl/application/pipelines/stage_counter.py
+++ b/src/bioetl/application/pipelines/stage_counter.py
@@ -1,0 +1,81 @@
+"""Stage counter component for tracking records processed by stages."""
+
+from datetime import datetime, timezone
+
+from bioetl.domain.models import StageResult
+
+
+class StageCounter:
+    """Tracks record and chunk counts per pipeline stage."""
+
+    def __init__(self) -> None:
+        self._counts: dict[str, int] = {}
+        self._chunks: dict[str, int] = {}
+        self._stage_starts: dict[str, datetime] = {}
+
+    def increment(self, stage: str, count: int) -> None:
+        """Increment record count for a stage."""
+        self._counts[stage] = self._counts.get(stage, 0) + count
+
+    def increment_chunks(self, stage: str, count: int = 1) -> None:
+        """Increment chunk count for a stage."""
+        self._chunks[stage] = self._chunks.get(stage, 0) + count
+
+    def get_count(self, stage: str) -> int:
+        """Return record count for a stage."""
+        return self._counts.get(stage, 0)
+
+    def get_chunks(self, stage: str) -> int:
+        """Return chunk count for a stage."""
+        return self._chunks.get(stage, 0)
+
+    def get_counts(self) -> dict[str, int]:
+        """Return all stage record counts."""
+        return dict(self._counts)
+
+    def get_all_chunks(self) -> dict[str, int]:
+        """Return all stage chunk counts."""
+        return dict(self._chunks)
+
+    def mark_stage_start(self, stage: str) -> None:
+        """Record start time for a stage."""
+        self._stage_starts[stage] = datetime.now(timezone.utc)
+
+    def get_stage_start(self, stage: str) -> datetime | None:
+        """Return start time for a stage, if recorded."""
+        return self._stage_starts.get(stage)
+
+    def reset(self) -> None:
+        """Clear all counts and timestamps."""
+        self._counts.clear()
+        self._chunks.clear()
+        self._stage_starts.clear()
+
+    def make_stage_result(
+        self,
+        stage: str,
+        *,
+        success: bool = True,
+        errors: list[str] | None = None,
+        override_count: int | None = None,
+        override_chunks: int | None = None,
+    ) -> StageResult:
+        """Build a StageResult with duration and counters."""
+        start_time = self.get_stage_start(stage)
+        duration = 0.0
+        if start_time:
+            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+
+        count = override_count if override_count is not None else self.get_count(stage)
+        chunks = (
+            override_chunks if override_chunks is not None else self.get_chunks(stage)
+        )
+
+        return StageResult(
+            stage_name=stage,
+            success=success,
+            records_processed=count if success else 0,
+            chunks_processed=chunks if success else 0,
+            duration_sec=duration,
+            errors=errors or [],
+        )

--- a/src/bioetl/application/pipelines/stage_error_handler.py
+++ b/src/bioetl/application/pipelines/stage_error_handler.py
@@ -1,0 +1,123 @@
+"""Stage error handler component for managing error policies."""
+
+from collections.abc import Callable
+from typing import Any
+
+from bioetl.domain.enums import ErrorAction
+from bioetl.domain.errors import PipelineStageError
+from bioetl.domain.models import RunContext
+from bioetl.domain.observability import LoggingPortABC
+from bioetl.domain.pipelines.contracts import ErrorPolicyABC
+
+
+class StageErrorHandler:
+    """Handles errors according to configured policy and tracks error state."""
+
+    def __init__(
+        self,
+        *,
+        logger: LoggingPortABC,
+        provider: str,
+        entity_name: str,
+        error_policy: ErrorPolicyABC,
+        default_on_skip: Callable[[str], Any],
+    ) -> None:
+        self._logger = logger
+        self._provider = provider
+        self._entity_name = entity_name
+        self._error_policy = error_policy
+        self._default_on_skip = default_on_skip
+        self._last_error: PipelineStageError | None = None
+        self._last_stage_action: dict[str, ErrorAction | None] = {}
+
+    @property
+    def last_error(self) -> PipelineStageError | None:
+        """Return the last recorded error."""
+        return self._last_error
+
+    def set_logger(self, logger: LoggingPortABC) -> None:
+        """Update the logger instance."""
+        self._logger = logger
+
+    def set_error_policy(self, error_policy: ErrorPolicyABC) -> None:
+        """Replace the error policy."""
+        self._error_policy = error_policy
+
+    def handle_error(
+        self,
+        stage: str,
+        error: Exception,
+        context: RunContext,
+        *,
+        attempt: int,
+    ) -> tuple[ErrorAction, PipelineStageError]:
+        """
+        Process an error and determine the action.
+
+        Returns tuple of (action, wrapped_error).
+        """
+        pipeline_error = PipelineStageError(
+            provider=self._provider,
+            entity=self._entity_name,
+            stage=stage,
+            attempt=attempt,
+            run_id=context.run_id,
+            cause=error,
+        )
+        self._last_error = pipeline_error
+
+        self._logger.error(
+            "Stage failed",
+            stage=stage,
+            provider=self._provider,
+            entity=self._entity_name,
+            run_id=context.run_id,
+            error=str(error),
+        )
+
+        action = self._error_policy.handle(pipeline_error, context)
+        self._last_stage_action[stage] = action
+
+        return action, pipeline_error
+
+    def should_retry(self, error: PipelineStageError) -> bool:
+        """Check if another retry is allowed for the error."""
+        return self._error_policy.can_retry(error)
+
+    def log_skip(self, stage: str, context: RunContext, error: Exception) -> None:
+        """Log that a stage was skipped due to error policy."""
+        self._logger.warning(
+            "Stage skipped due to error policy",
+            stage=stage,
+            provider=self._provider,
+            entity=self._entity_name,
+            run_id=context.run_id,
+            error=str(error),
+        )
+
+    def get_skip_value(self, stage: str) -> Any:
+        """Return the default value to use when skipping a stage."""
+        return self._default_on_skip(stage)
+
+    def clear_error(self) -> None:
+        """Clear the last error state (called on successful execution)."""
+        self._last_error = None
+
+    def get_last_action(self, stage: str) -> ErrorAction | None:
+        """Return the last error action for a stage."""
+        return self._last_stage_action.get(stage)
+
+    def get_last_error_messages(self) -> list[str]:
+        """Return list of messages from the last error."""
+        if self._last_error is None:
+            return []
+
+        messages = [str(self._last_error)]
+        if self._last_error.cause:
+            messages.append(str(self._last_error.cause))
+        return messages
+
+    def reset(self) -> None:
+        """Clear accumulated error state."""
+        self._last_error = None
+        self._last_stage_action.clear()

--- a/src/bioetl/application/pipelines/stage_runtime_manager.py
+++ b/src/bioetl/application/pipelines/stage_runtime_manager.py
@@ -5,6 +5,9 @@ from datetime import datetime, timezone
 
 import pandas as pd
 
+from bioetl.application.pipelines.hook_notifier import HookNotifier
+from bioetl.application.pipelines.stage_counter import StageCounter
+from bioetl.application.pipelines.stage_error_handler import StageErrorHandler
 from bioetl.domain.enums import ErrorAction
 from bioetl.domain.errors import PipelineStageError
 from bioetl.domain.models import RunContext, RunResult, StageResult
@@ -14,7 +17,14 @@ from bioetl.domain.providers import ProviderId
 
 
 class StageRuntimeManagerImpl:
-    """Инкапсулирует вызовы хуков, политику ошибок и исполнение стадий."""
+    """
+    Facade that coordinates stage execution using specialized components.
+
+    Delegates responsibilities to:
+    - HookNotifier: hook registration and event notification
+    - StageCounter: record/chunk counting and stage timing
+    - StageErrorHandler: error policy handling and error state
+    """
 
     def __init__(
         self,
@@ -30,92 +40,79 @@ class StageRuntimeManagerImpl:
         self._logger = logger
         self._provider_id = provider_id
         self._entity_name = entity_name
-        self._error_policy = error_policy
-        self._default_on_skip = default_on_skip
-        self._hooks: list[PipelineHookABC] = list(hooks or [])
-        self._stage_starts: dict[str, datetime] = {}
         self._pipeline_id = pipeline_id
-        self._current_run_id: str | None = None
-        self._last_error: PipelineStageError | None = None
-        self._last_stage_action: dict[str, ErrorAction | None] = {}
+
+        self._hook_notifier = HookNotifier(
+            logger=logger,
+            pipeline_id=pipeline_id,
+            hooks=hooks,
+        )
+
+        self._stage_counter = StageCounter()
+
+        self._error_handler = StageErrorHandler(
+            logger=logger,
+            provider=provider_id.value,
+            entity_name=entity_name,
+            error_policy=error_policy,
+            default_on_skip=default_on_skip,
+        )
 
     @property
     def last_error(self) -> PipelineStageError | None:
         """Последняя ошибка выполнения стадии."""
-
-        return self._last_error
+        return self._error_handler.last_error
 
     def register_hook(self, hook: PipelineHookABC) -> None:
         """Добавляет хук выполнения."""
-
-        self._hooks.append(hook)
+        self._hook_notifier.register_hook(hook)
 
     def register_hooks(self, hooks: Iterable[PipelineHookABC]) -> None:
         """Добавляет список хуков выполнения."""
-
-        for hook in hooks:
-            self.register_hook(hook)
+        self._hook_notifier.register_hooks(hooks)
 
     def get_hooks(self) -> list[PipelineHookABC]:
         """Возвращает зарегистрированные хуки."""
-
-        return self._hooks
+        return self._hook_notifier.get_hooks()
 
     def reset(self) -> None:
         """Сбрасывает накопленное состояние выполнения."""
-
-        self._stage_starts.clear()
-        self._current_run_id = None
-        self._last_error = None
-        self._last_stage_action.clear()
+        self._hook_notifier.reset()
+        self._stage_counter.reset()
+        self._error_handler.reset()
 
     def set_logger(self, logger: LoggingPortABC) -> None:
         """Обновляет логгер для дальнейших сообщений."""
-
         self._logger = logger
+        self._hook_notifier.set_logger(logger)
+        self._error_handler.set_logger(logger)
 
     def set_error_policy(self, error_policy: ErrorPolicyABC) -> None:
         """Заменяет используемую политику ошибок."""
-
-        self._error_policy = error_policy
+        self._error_handler.set_error_policy(error_policy)
 
     def notify_stage_start(self, stage: str, context: RunContext) -> None:
         """Уведомляет о старте стадии и логирует событие."""
-
-        self._stage_starts[stage] = datetime.now(timezone.utc)
-        self._current_run_id = context.run_id
-        self._logger.info(
-            "Stage started",
-            provider=context.provider,
-            entity=context.entity_name,
-            run_id=context.run_id,
-            stage=stage,
-            pipeline=self._pipeline_id,
+        self._stage_counter.mark_stage_start(stage)
+        self._hook_notifier.notify_stage_start(
+            stage,
+            context,
+            provider=self._provider_id.value,
+            entity_name=self._entity_name,
         )
-        for hook in self._hooks:
-            hook.on_stage_start(stage, context)
 
     def notify_stage_end(self, stage: str, result: StageResult) -> None:
         """Уведомляет о завершении стадии и логирует событие."""
-
-        self._logger.info(
-            "Stage finished",
-            records=result.records_processed,
-            chunks=result.chunks_processed,
+        self._hook_notifier.notify_stage_end(
+            stage,
+            result,
             provider=self._provider_id.value,
-            entity=self._entity_name,
-            stage=stage,
-            pipeline=self._pipeline_id,
-            run_id=self._current_run_id,
-            outcome="success" if result.success else "error",
+            entity_name=self._entity_name,
         )
-        for hook in self._hooks:
-            hook.on_stage_end(stage, result)
 
     def get_stage_start(self, stage: str) -> datetime | None:
         """Возвращает время старта указанной стадии, если оно зафиксировано."""
-
-        return self._stage_starts.get(stage)
+        return self._stage_counter.get_stage_start(stage)
 
     def execute_stage(
         self,
@@ -127,39 +124,22 @@ class StageRuntimeManagerImpl:
         on_retry: Callable[[], None] | None = None,
     ) -> object:
         """Выполняет действие с учётом политики ошибок."""
-
         try:
             result = action()
-            self._last_error = None
-            self._last_stage_action[stage] = None
+            self._error_handler.clear_error()
             return result
         except StopIteration:
             raise
         except Exception as exc:  # pylint: disable=broad-except
-            error = PipelineStageError(
-                provider=self._provider_id.value,
-                entity=self._entity_name,
-                stage=stage,
-                attempt=attempt,
-                run_id=context.run_id,
-                cause=exc,
+            error_action, pipeline_error = self._error_handler.handle_error(
+                stage, exc, context, attempt=attempt
             )
-            self._last_error = error
-            self._logger.error(
-                "Stage failed",
-                stage=stage,
-                provider=self._provider_id.value,
-                entity=self._entity_name,
-                run_id=context.run_id,
-                error=str(exc),
-            )
-            for hook in self._hooks:
-                hook.on_error(stage, error)
 
-            action_on_error = self._error_policy.handle(error, context)
-            self._last_stage_action[stage] = action_on_error
-            if action_on_error == ErrorAction.RETRY and self._error_policy.can_retry(
-                error
+            self._hook_notifier.notify_stage_error(stage, pipeline_error)
+
+            if (
+                error_action == ErrorAction.RETRY
+                and self._error_handler.should_retry(pipeline_error)
             ):
                 if on_retry:
                     on_retry()
@@ -170,34 +150,20 @@ class StageRuntimeManagerImpl:
                     attempt=attempt + 1,
                     on_retry=on_retry,
                 )
-            if action_on_error == ErrorAction.SKIP:
-                self._logger.warning(
-                    "Stage skipped due to error policy",
-                    stage=stage,
-                    provider=self._provider_id.value,
-                    entity=self._entity_name,
-                    run_id=context.run_id,
-                    error=str(exc),
-                )
-                return self._default_on_skip(stage)
 
-            raise error from exc
+            if error_action == ErrorAction.SKIP:
+                self._error_handler.log_skip(stage, context, exc)
+                return self._error_handler.get_skip_value(stage)
+
+            raise pipeline_error from exc
 
     def get_last_error_messages(self) -> list[str]:
         """Возвращает список сообщений последней ошибки."""
-
-        if self._last_error is None:
-            return []
-
-        messages = [str(self._last_error)]
-        if self._last_error.cause:
-            messages.append(str(self._last_error.cause))
-        return messages
+        return self._error_handler.get_last_error_messages()
 
     def get_last_action(self, stage: str) -> ErrorAction | None:
         """Возвращает последнее действие политики ошибок для стадии."""
-
-        return self._last_stage_action.get(stage)
+        return self._error_handler.get_last_action(stage)
 
     def process_chunk(
         self,
@@ -217,7 +183,6 @@ class StageRuntimeManagerImpl:
         validate_fn: Callable[[pd.DataFrame], pd.DataFrame],
     ) -> tuple[bool, int, int, bool, int, int]:
         """Run transform and validate stages for a single chunk."""
-
         (
             transform_started,
             transform_chunks,
@@ -267,19 +232,12 @@ class StageRuntimeManagerImpl:
         chunks: int = 0,
     ) -> StageResult:
         """Собирает StageResult с длительностью и счётчиками."""
-
-        start_time = self.get_stage_start(stage)
-        duration = 0.0
-        if start_time:
-            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
-
-        return StageResult(
-            stage_name=stage,
+        return self._stage_counter.make_stage_result(
+            stage,
             success=success,
-            records_processed=count if success else 0,
-            chunks_processed=chunks if success else 0,
-            duration_sec=duration,
-            errors=errors or [],
+            errors=errors,
+            override_count=count,
+            override_chunks=chunks,
         )
 
     def handle_stage_failure(
@@ -292,7 +250,6 @@ class StageRuntimeManagerImpl:
         chunks: int = 0,
     ) -> RunResult:
         """Формирует результат неуспешного запуска и уведомляет хуки."""
-
         errors = self.get_last_error_messages()
         stage_result = self.make_stage_result(
             stage,

--- a/tests/bioetl/application/pipelines/test_hook_notifier.py
+++ b/tests/bioetl/application/pipelines/test_hook_notifier.py
@@ -1,0 +1,175 @@
+"""Unit tests for HookNotifier component."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from bioetl.application.pipelines.hook_notifier import HookNotifier
+from bioetl.domain.errors import PipelineStageError
+from bioetl.domain.models import RunContext, StageResult
+from bioetl.domain.pipelines.contracts import PipelineHookABC
+
+
+def _build_context() -> RunContext:
+    return RunContext(entity_name="test", provider="chembl")
+
+
+@pytest.mark.unit
+def test_hook_notifier_registers_single_hook(mock_logger):
+    """Test registering a single hook."""
+    notifier = HookNotifier(logger=mock_logger)
+    hook = MagicMock(spec=PipelineHookABC)
+
+    notifier.register_hook(hook)
+
+    assert hook in notifier.get_hooks()
+    assert len(notifier.get_hooks()) == 1
+
+
+@pytest.mark.unit
+def test_hook_notifier_registers_multiple_hooks(mock_logger):
+    """Test registering multiple hooks at once."""
+    notifier = HookNotifier(logger=mock_logger)
+    hook1 = MagicMock(spec=PipelineHookABC)
+    hook2 = MagicMock(spec=PipelineHookABC)
+
+    notifier.register_hooks([hook1, hook2])
+
+    hooks = notifier.get_hooks()
+    assert len(hooks) == 2
+    assert hook1 in hooks
+    assert hook2 in hooks
+
+
+@pytest.mark.unit
+def test_hook_notifier_initializes_with_hooks(mock_logger):
+    """Test that hooks can be passed at init time."""
+    hook = MagicMock(spec=PipelineHookABC)
+
+    notifier = HookNotifier(logger=mock_logger, hooks=[hook])
+
+    assert hook in notifier.get_hooks()
+
+
+@pytest.mark.unit
+def test_hook_notifier_notifies_stage_start(mock_logger):
+    """Test that on_stage_start is called on all hooks."""
+    hook1 = MagicMock(spec=PipelineHookABC)
+    hook2 = MagicMock(spec=PipelineHookABC)
+    notifier = HookNotifier(logger=mock_logger, hooks=[hook1, hook2])
+    context = _build_context()
+
+    notifier.notify_stage_start(
+        "extract", context, provider="chembl", entity_name="test"
+    )
+
+    hook1.on_stage_start.assert_called_once_with("extract", context)
+    hook2.on_stage_start.assert_called_once_with("extract", context)
+
+
+@pytest.mark.unit
+def test_hook_notifier_notifies_stage_end(mock_logger):
+    """Test that on_stage_end is called on all hooks."""
+    hook = MagicMock(spec=PipelineHookABC)
+    notifier = HookNotifier(logger=mock_logger, hooks=[hook])
+    result = StageResult(
+        stage_name="extract",
+        success=True,
+        records_processed=100,
+        chunks_processed=2,
+        duration_sec=1.5,
+        errors=[],
+    )
+
+    notifier.notify_stage_end("extract", result, provider="chembl", entity_name="test")
+
+    hook.on_stage_end.assert_called_once_with("extract", result)
+
+
+@pytest.mark.unit
+def test_hook_notifier_notifies_stage_error(mock_logger):
+    """Test that on_error is called on all hooks."""
+    hook = MagicMock(spec=PipelineHookABC)
+    notifier = HookNotifier(logger=mock_logger, hooks=[hook])
+    error = PipelineStageError(
+        provider="chembl",
+        entity="test",
+        stage="extract",
+        attempt=1,
+        run_id="run-123",
+        cause=ValueError("test error"),
+    )
+
+    notifier.notify_stage_error("extract", error)
+
+    hook.on_error.assert_called_once_with("extract", error)
+
+
+@pytest.mark.unit
+def test_hook_notifier_records_stage_start_time(mock_logger):
+    """Test that stage start times are recorded."""
+    notifier = HookNotifier(logger=mock_logger)
+    context = _build_context()
+
+    assert notifier.get_stage_start("extract") is None
+
+    notifier.notify_stage_start(
+        "extract", context, provider="chembl", entity_name="test"
+    )
+
+    assert notifier.get_stage_start("extract") is not None
+
+
+@pytest.mark.unit
+def test_hook_notifier_tracks_current_run_id(mock_logger):
+    """Test that current run_id is tracked."""
+    notifier = HookNotifier(logger=mock_logger)
+    context = _build_context()
+
+    assert notifier.current_run_id is None
+
+    notifier.notify_stage_start(
+        "extract", context, provider="chembl", entity_name="test"
+    )
+
+    assert notifier.current_run_id == context.run_id
+
+
+@pytest.mark.unit
+def test_hook_notifier_reset_clears_state(mock_logger):
+    """Test that reset clears all accumulated state."""
+    notifier = HookNotifier(logger=mock_logger)
+    context = _build_context()
+
+    notifier.notify_stage_start(
+        "extract", context, provider="chembl", entity_name="test"
+    )
+    assert notifier.get_stage_start("extract") is not None
+    assert notifier.current_run_id is not None
+
+    notifier.reset()
+
+    assert notifier.get_stage_start("extract") is None
+    assert notifier.current_run_id is None
+
+
+@pytest.mark.unit
+def test_hook_notifier_logs_stage_events(mock_logger):
+    """Test that stage events are logged."""
+    notifier = HookNotifier(logger=mock_logger, pipeline_id="test-pipeline")
+    context = _build_context()
+    result = StageResult(
+        stage_name="extract",
+        success=True,
+        records_processed=100,
+        chunks_processed=2,
+        duration_sec=1.5,
+        errors=[],
+    )
+
+    notifier.notify_stage_start(
+        "extract", context, provider="chembl", entity_name="test"
+    )
+    notifier.notify_stage_end("extract", result, provider="chembl", entity_name="test")
+
+    assert mock_logger.info.call_count == 2

--- a/tests/bioetl/application/pipelines/test_pipeline_collaborators.py
+++ b/tests/bioetl/application/pipelines/test_pipeline_collaborators.py
@@ -117,7 +117,7 @@ def test_stage_runtime_process_and_failure(mock_logger):
     assert transform_stage.records_processed == 1
     assert transform_stage.duration_sec >= 0
 
-    manager._last_error = PipelineStageError(  # type: ignore[attr-defined]
+    manager._error_handler._last_error = PipelineStageError(  # type: ignore[attr-defined]
         provider="chembl",
         entity="entity",
         stage="validate",

--- a/tests/bioetl/application/pipelines/test_stage_counter.py
+++ b/tests/bioetl/application/pipelines/test_stage_counter.py
@@ -1,0 +1,157 @@
+"""Unit tests for StageCounter component."""
+
+import pytest
+
+from bioetl.application.pipelines.stage_counter import StageCounter
+
+
+@pytest.mark.unit
+def test_stage_counter_initializes_empty():
+    """Test that counter starts with no counts."""
+    counter = StageCounter()
+
+    assert counter.get_count("extract") == 0
+    assert counter.get_chunks("extract") == 0
+    assert counter.get_counts() == {}
+    assert counter.get_all_chunks() == {}
+
+
+@pytest.mark.unit
+def test_stage_counter_increments_records():
+    """Test incrementing record counts."""
+    counter = StageCounter()
+
+    counter.increment("extract", 10)
+    counter.increment("extract", 5)
+
+    assert counter.get_count("extract") == 15
+
+
+@pytest.mark.unit
+def test_stage_counter_increments_chunks():
+    """Test incrementing chunk counts."""
+    counter = StageCounter()
+
+    counter.increment_chunks("extract")
+    counter.increment_chunks("extract", 2)
+
+    assert counter.get_chunks("extract") == 3
+
+
+@pytest.mark.unit
+def test_stage_counter_tracks_multiple_stages():
+    """Test tracking counts for multiple stages independently."""
+    counter = StageCounter()
+
+    counter.increment("extract", 100)
+    counter.increment("transform", 90)
+    counter.increment("validate", 85)
+    counter.increment_chunks("extract", 2)
+    counter.increment_chunks("transform", 2)
+    counter.increment_chunks("validate", 2)
+
+    assert counter.get_counts() == {
+        "extract": 100,
+        "transform": 90,
+        "validate": 85,
+    }
+    assert counter.get_all_chunks() == {
+        "extract": 2,
+        "transform": 2,
+        "validate": 2,
+    }
+
+
+@pytest.mark.unit
+def test_stage_counter_marks_stage_start():
+    """Test recording stage start times."""
+    counter = StageCounter()
+
+    assert counter.get_stage_start("extract") is None
+
+    counter.mark_stage_start("extract")
+
+    start_time = counter.get_stage_start("extract")
+    assert start_time is not None
+
+
+@pytest.mark.unit
+def test_stage_counter_reset_clears_all():
+    """Test that reset clears all state."""
+    counter = StageCounter()
+
+    counter.increment("extract", 100)
+    counter.increment_chunks("extract", 2)
+    counter.mark_stage_start("extract")
+
+    counter.reset()
+
+    assert counter.get_count("extract") == 0
+    assert counter.get_chunks("extract") == 0
+    assert counter.get_stage_start("extract") is None
+    assert counter.get_counts() == {}
+
+
+@pytest.mark.unit
+def test_stage_counter_makes_stage_result():
+    """Test creating StageResult from counter state."""
+    counter = StageCounter()
+
+    counter.mark_stage_start("extract")
+    counter.increment("extract", 100)
+    counter.increment_chunks("extract", 2)
+
+    result = counter.make_stage_result("extract")
+
+    assert result.stage_name == "extract"
+    assert result.success is True
+    assert result.records_processed == 100
+    assert result.chunks_processed == 2
+    assert result.duration_sec >= 0
+    assert result.errors == []
+
+
+@pytest.mark.unit
+def test_stage_counter_makes_failed_stage_result():
+    """Test creating failed StageResult."""
+    counter = StageCounter()
+
+    counter.mark_stage_start("extract")
+    counter.increment("extract", 100)
+
+    result = counter.make_stage_result(
+        "extract", success=False, errors=["Error occurred"]
+    )
+
+    assert result.stage_name == "extract"
+    assert result.success is False
+    assert result.records_processed == 0
+    assert result.chunks_processed == 0
+    assert result.errors == ["Error occurred"]
+
+
+@pytest.mark.unit
+def test_stage_counter_makes_result_with_override():
+    """Test creating StageResult with overridden counts."""
+    counter = StageCounter()
+
+    counter.mark_stage_start("extract")
+    counter.increment("extract", 100)
+    counter.increment_chunks("extract", 2)
+
+    result = counter.make_stage_result(
+        "extract", override_count=50, override_chunks=1
+    )
+
+    assert result.records_processed == 50
+    assert result.chunks_processed == 1
+
+
+@pytest.mark.unit
+def test_stage_counter_duration_without_start():
+    """Test that duration is 0 when start was not recorded."""
+    counter = StageCounter()
+
+    result = counter.make_stage_result("extract")
+
+    assert result.duration_sec == 0.0

--- a/tests/bioetl/application/pipelines/test_stage_error_handler.py
+++ b/tests/bioetl/application/pipelines/test_stage_error_handler.py
@@ -1,0 +1,301 @@
+"""Unit tests for StageErrorHandler component."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from bioetl.application.pipelines.hooks_impl import (
+    ContinueOnErrorPolicyImpl,
+    FailFastErrorPolicyImpl,
+)
+from bioetl.application.pipelines.stage_error_handler import StageErrorHandler
+from bioetl.domain.enums import ErrorAction
+from bioetl.domain.errors import PipelineStageError
+from bioetl.domain.models import RunContext
+
+
+def _build_context() -> RunContext:
+    return RunContext(entity_name="test", provider="chembl")
+
+
+@pytest.mark.unit
+def test_error_handler_tracks_last_error(mock_logger):
+    """Test that last error is tracked."""
+    handler = StageErrorHandler(
+        logger=mock_logger,
+        provider="chembl",
+        entity_name="test",
+        error_policy=FailFastErrorPolicyImpl(),
+        default_on_skip=lambda _: None,
+    )
+    context = _build_context()
+
+    assert handler.last_error is None
+
+    handler.handle_error("extract", ValueError("test"), context, attempt=1)
+
+    assert handler.last_error is not None
+    assert isinstance(handler.last_error, PipelineStageError)
+
+
+@pytest.mark.unit
+def test_error_handler_returns_fail_action(mock_logger):
+    """Test that FailFast policy returns FAIL action."""
+    handler = StageErrorHandler(
+        logger=mock_logger,
+        provider="chembl",
+        entity_name="test",
+        error_policy=FailFastErrorPolicyImpl(),
+        default_on_skip=lambda _: None,
+    )
+    context = _build_context()
+
+    action, error = handler.handle_error(
+        "extract", ValueError("test"), context, attempt=1
+    )
+
+    assert action == ErrorAction.FAIL
+    assert isinstance(error, PipelineStageError)
+
+
+@pytest.mark.unit
+def test_error_handler_returns_retry_action(mock_logger):
+    """Test that ContinueOnError policy can return RETRY action."""
+    handler = StageErrorHandler(
+        logger=mock_logger,
+        provider="chembl",
+        entity_name="test",
+        error_policy=ContinueOnErrorPolicyImpl(max_retries=2),
+        default_on_skip=lambda _: None,
+    )
+    context = _build_context()
+
+    action, _ = handler.handle_error("extract", ValueError("test"), context, attempt=1)
+
+    assert action == ErrorAction.RETRY
+
+
+@pytest.mark.unit
+def test_error_handler_returns_skip_after_retries(mock_logger):
+    """Test that SKIP is returned after max retries."""
+    handler = StageErrorHandler(
+        logger=mock_logger,
+        provider="chembl",
+        entity_name="test",
+        error_policy=ContinueOnErrorPolicyImpl(max_retries=1),
+        default_on_skip=lambda _: None,
+    )
+    context = _build_context()
+
+    action, _ = handler.handle_error("extract", ValueError("test"), context, attempt=2)
+
+    assert action == ErrorAction.SKIP
+
+
+@pytest.mark.unit
+def test_error_handler_should_retry(mock_logger):
+    """Test should_retry method."""
+    handler = StageErrorHandler(
+        logger=mock_logger,
+        provider="chembl",
+        entity_name="test",
+        error_policy=ContinueOnErrorPolicyImpl(max_retries=2),
+        default_on_skip=lambda _: None,
+    )
+
+    error_attempt_1 = PipelineStageError(
+        provider="chembl",
+        entity="test",
+        stage="extract",
+        attempt=1,
+        run_id="run-123",
+    )
+    error_attempt_3 = PipelineStageError(
+        provider="chembl",
+        entity="test",
+        stage="extract",
+        attempt=3,
+        run_id="run-123",
+    )
+
+    assert handler.should_retry(error_attempt_1) is True
+    assert handler.should_retry(error_attempt_3) is False
+
+
+@pytest.mark.unit
+def test_error_handler_logs_error(mock_logger):
+    """Test that errors are logged."""
+    handler = StageErrorHandler(
+        logger=mock_logger,
+        provider="chembl",
+        entity_name="test",
+        error_policy=FailFastErrorPolicyImpl(),
+        default_on_skip=lambda _: None,
+    )
+    context = _build_context()
+
+    handler.handle_error("extract", ValueError("test error"), context, attempt=1)
+
+    mock_logger.error.assert_called_once()
+
+
+@pytest.mark.unit
+def test_error_handler_logs_skip(mock_logger):
+    """Test that skips are logged as warnings."""
+    handler = StageErrorHandler(
+        logger=mock_logger,
+        provider="chembl",
+        entity_name="test",
+        error_policy=ContinueOnErrorPolicyImpl(),
+        default_on_skip=lambda _: None,
+    )
+    context = _build_context()
+
+    handler.log_skip("extract", context, ValueError("test"))
+
+    mock_logger.warning.assert_called_once()
+
+
+@pytest.mark.unit
+def test_error_handler_get_skip_value(mock_logger):
+    """Test getting skip value for different stages."""
+    handler = StageErrorHandler(
+        logger=mock_logger,
+        provider="chembl",
+        entity_name="test",
+        error_policy=FailFastErrorPolicyImpl(),
+        default_on_skip=lambda stage: f"skipped-{stage}",
+    )
+
+    assert handler.get_skip_value("extract") == "skipped-extract"
+    assert handler.get_skip_value("transform") == "skipped-transform"
+
+
+@pytest.mark.unit
+def test_error_handler_clears_error(mock_logger):
+    """Test clearing error state."""
+    handler = StageErrorHandler(
+        logger=mock_logger,
+        provider="chembl",
+        entity_name="test",
+        error_policy=FailFastErrorPolicyImpl(),
+        default_on_skip=lambda _: None,
+    )
+    context = _build_context()
+
+    handler.handle_error("extract", ValueError("test"), context, attempt=1)
+    assert handler.last_error is not None
+
+    handler.clear_error()
+
+    assert handler.last_error is None
+
+
+@pytest.mark.unit
+def test_error_handler_tracks_last_action(mock_logger):
+    """Test tracking last action per stage."""
+    handler = StageErrorHandler(
+        logger=mock_logger,
+        provider="chembl",
+        entity_name="test",
+        error_policy=ContinueOnErrorPolicyImpl(),
+        default_on_skip=lambda _: None,
+    )
+    context = _build_context()
+
+    assert handler.get_last_action("extract") is None
+
+    handler.handle_error("extract", ValueError("test"), context, attempt=1)
+
+    assert handler.get_last_action("extract") == ErrorAction.SKIP
+
+
+@pytest.mark.unit
+def test_error_handler_get_last_error_messages(mock_logger):
+    """Test getting error messages."""
+    handler = StageErrorHandler(
+        logger=mock_logger,
+        provider="chembl",
+        entity_name="test",
+        error_policy=FailFastErrorPolicyImpl(),
+        default_on_skip=lambda _: None,
+    )
+    context = _build_context()
+
+    assert handler.get_last_error_messages() == []
+
+    handler.handle_error("extract", ValueError("test error"), context, attempt=1)
+    messages = handler.get_last_error_messages()
+
+    assert len(messages) == 2
+    assert "test error" in messages[-1]
+
+
+@pytest.mark.unit
+def test_error_handler_reset_clears_state(mock_logger):
+    """Test that reset clears all state."""
+    handler = StageErrorHandler(
+        logger=mock_logger,
+        provider="chembl",
+        entity_name="test",
+        error_policy=ContinueOnErrorPolicyImpl(),
+        default_on_skip=lambda _: None,
+    )
+    context = _build_context()
+
+    handler.handle_error("extract", ValueError("test"), context, attempt=1)
+    assert handler.last_error is not None
+    assert handler.get_last_action("extract") is not None
+
+    handler.reset()
+
+    assert handler.last_error is None
+    assert handler.get_last_action("extract") is None
+
+
+@pytest.mark.unit
+def test_error_handler_set_error_policy(mock_logger):
+    """Test changing error policy at runtime."""
+    handler = StageErrorHandler(
+        logger=mock_logger,
+        provider="chembl",
+        entity_name="test",
+        error_policy=FailFastErrorPolicyImpl(),
+        default_on_skip=lambda _: None,
+    )
+    context = _build_context()
+
+    action, _ = handler.handle_error("extract", ValueError("test"), context, attempt=1)
+    assert action == ErrorAction.FAIL
+
+    handler.set_error_policy(ContinueOnErrorPolicyImpl())
+
+    action, _ = handler.handle_error(
+        "transform", ValueError("test"), context, attempt=1
+    )
+    assert action == ErrorAction.SKIP
+
+
+@pytest.mark.unit
+def test_error_handler_creates_pipeline_error_with_cause(mock_logger):
+    """Test that PipelineStageError includes the original cause."""
+    handler = StageErrorHandler(
+        logger=mock_logger,
+        provider="chembl",
+        entity_name="test",
+        error_policy=FailFastErrorPolicyImpl(),
+        default_on_skip=lambda _: None,
+    )
+    context = _build_context()
+    original_error = ValueError("original error")
+
+    _, pipeline_error = handler.handle_error(
+        "extract", original_error, context, attempt=2
+    )
+
+    assert pipeline_error.provider == "chembl"
+    assert pipeline_error.entity == "test"
+    assert pipeline_error.stage == "extract"
+    assert pipeline_error.attempt == 2
+    assert pipeline_error.run_id == context.run_id
+    assert pipeline_error.cause is original_error


### PR DESCRIPTION
Extract separate components from StageRuntimeManagerImpl:
- HookNotifier: hook registration and stage event notification
- StageCounter: record/chunk counting and stage timing
- StageErrorHandler: error policy handling and error state tracking

StageRuntimeManagerImpl now acts as a facade delegating to these components while maintaining backward API compatibility.

Add comprehensive unit tests for each extracted component.