### PR TITLE
Remove duplication in normalization services

### DIFF
--- a/src/bioetl/infrastructure/transform/factories.py
+++ b/src/bioetl/infrastructure/transform/factories.py
@@ -1,5 +1,7 @@
 """Factories for transform infrastructure components."""
 
+import warnings
+
 from bioetl.domain.transform.contracts import (
     HasherABC,
     HashServiceABC,
@@ -7,41 +9,49 @@ from bioetl.domain.transform.contracts import (
     NormalizationServiceABC,
 )
 from bioetl.domain.transform.hash_service import HashService
-from bioetl.infrastructure.transform.impl.chembl_normalization_service_impl import (
-    ChemblNormalizationServiceImpl,
-)
-from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl import (  # noqa: E501
-    DefaultNormalizationTransformerImpl as DefaultNormImpl,
+from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl import (
+    DefaultNormalizationTransformerImpl,
 )
 from bioetl.infrastructure.transform.impl.hasher import HasherImpl
 
 
 def default_hasher() -> HasherABC:
-    """Создает дефолтную реализацию Hasher."""
-
+    """Create default Hasher implementation."""
     return HasherImpl()
 
 
 def default_hash_service() -> HashServiceABC:
-    """Создает дефолтный HashService."""
-
+    """Create default HashService."""
     return HashService(hasher=default_hasher())
 
 
 def default_normalization_service(
     config: NormalizationConfigProviderProtocol,
 ) -> NormalizationServiceABC:
-    """Создает сервис нормализации по умолчанию."""
-
-    return DefaultNormImpl(config)
+    """Create default normalization service."""
+    return DefaultNormalizationTransformerImpl(config)
 
 
 def default_chembl_normalization_service(
     config: NormalizationConfigProviderProtocol,
 ) -> NormalizationServiceABC:
-    """Создает сервис нормализации ChEMBL."""
+    """Create ChEMBL normalization service.
 
-    return ChemblNormalizationServiceImpl(config)
+    DEPRECATED: Use default_normalization_service with appropriate parameters.
+    """
+    warnings.warn(
+        "default_chembl_normalization_service is deprecated. "
+        "Use default_normalization_service or DefaultNormalizationTransformerImpl "
+        "with empty_value=None, serialize_array_in_series=False instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return DefaultNormalizationTransformerImpl(
+        config,
+        empty_value=None,
+        support_base_model=True,
+        serialize_array_in_series=False,
+    )
 
 
 __all__ = [

--- a/src/bioetl/infrastructure/transform/impl/__init__.py
+++ b/src/bioetl/infrastructure/transform/impl/__init__.py
@@ -3,12 +3,10 @@
 from bioetl.infrastructure.transform.impl.chembl_normalization_service_impl import (
     ChemblNormalizationServiceImpl,
 )
-from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl import (  # noqa: E501
-    DefaultNormalizationTransformerImpl as DefaultNormImpl,
+from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl import (
+    DefaultNormalizationTransformerImpl,
 )
 from bioetl.infrastructure.transform.impl.hasher import HasherImpl
-
-DefaultNormalizationTransformerImpl = DefaultNormImpl
 
 __all__ = [
     "HasherImpl",

--- a/src/bioetl/infrastructure/transform/impl/base_normalizer.py
+++ b/src/bioetl/infrastructure/transform/impl/base_normalizer.py
@@ -13,7 +13,14 @@ from bioetl.domain.transform.serializers import serialize_nested
 
 
 class BaseNormalizationServiceImpl:
-    """Provide reusable normalization helpers for normalization services."""
+    """Provide reusable normalization helpers for normalization services.
+
+    Args:
+        config: Provider of normalization configuration.
+        empty_value: Value to use for empty/missing data (default: None).
+        support_base_model: If True, apply_normalize accepts pydantic BaseModel.
+        serialize_array_in_series: If True, arrays are serialized in apply_normalize_series.
+    """
 
     _NUMERIC_DTYPES: dict[str, DtypeArg] = {
         "number": "Float64",
@@ -21,10 +28,17 @@ class BaseNormalizationServiceImpl:
     }
 
     def __init__(
-        self, config: NormalizationConfigProviderProtocol, empty_value: Any = None
+        self,
+        config: NormalizationConfigProviderProtocol,
+        empty_value: Any = None,
+        *,
+        support_base_model: bool = False,
+        serialize_array_in_series: bool = False,
     ):
         self._config = config
         self._empty_value = empty_value
+        self._support_base_model = support_base_model
+        self._serialize_array_in_series = serialize_array_in_series
         mode = getattr(config, "serialization_mode", "json")
         self._serialization_mode = mode if mode in {"json", "flat", "pipe"} else "json"
 

--- a/src/bioetl/infrastructure/transform/impl/chembl_normalization_service_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/chembl_normalization_service_impl.py
@@ -1,142 +1,50 @@
-"""ChEMBL-specific normalization service implementation."""
+"""ChEMBL-specific normalization service implementation.
+
+DEPRECATED: Use DefaultNormalizationTransformerImpl with appropriate parameters instead.
+This module is kept for backward compatibility and will be removed in a future version.
+"""
 
 from __future__ import annotations
 
-from typing import Any, TypedDict, cast
+import warnings
+from typing import Any
 
-import pandas as pd
-from pydantic import BaseModel
-
-from bioetl.domain.record_source import RawRecord
 from bioetl.domain.transform.contracts import (
     NormalizationConfigProviderProtocol,
-    NormalizationServiceABC,
 )
-from bioetl.infrastructure.transform.impl import normalize as normalize_impl
-from bioetl.infrastructure.transform.impl.base_normalizer import (
-    BaseNormalizationServiceImpl,
+from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl import (
+    DefaultNormalizationTransformerImpl,
 )
 
 
-class NormalizedRecord(TypedDict, total=False):
-    """Normalized record ready for downstream processing."""
+class ChemblNormalizationServiceImpl(DefaultNormalizationTransformerImpl):
+    """Normalization service for ChEMBL records.
 
-    ...
+    DEPRECATED: Use DefaultNormalizationTransformerImpl directly.
 
-
-class ChemblNormalizationServiceImpl(
-    BaseNormalizationServiceImpl, NormalizationServiceABC
-):
-    """Normalization service for ChEMBL records."""
+    This class is preserved for backward compatibility. It configures
+    DefaultNormalizationTransformerImpl with empty_value=None and
+    serialize_array_in_series=False to match legacy ChEMBL behavior.
+    """
 
     def __init__(self, config: NormalizationConfigProviderProtocol):
-        super().__init__(config)
+        warnings.warn(
+            "ChemblNormalizationServiceImpl is deprecated. "
+            "Use DefaultNormalizationTransformerImpl(config, empty_value=None, "
+            "serialize_array_in_series=False) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(
+            config,
+            empty_value=None,
+            support_base_model=True,
+            serialize_array_in_series=False,
+        )
 
-    def normalize(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Normalize dataframe according to field configuration."""
-        return self.apply_normalize_dataframe(df)
 
-    def normalize_record(self, record: dict[str, Any]) -> NormalizedRecord:
-        """Normalize single record with deterministic field handling."""
-        return self.apply_normalize(record)
+# Type alias for backward compatibility
+NormalizedRecord = dict[str, Any]
 
-    def apply_normalize(self, raw: RawRecord | pd.Series) -> NormalizedRecord:
-        """Normalize single raw ChEMBL record into flat dict."""
-        normalized: dict[str, Any] = {}
-        raw_data: dict[str, Any]
-        if isinstance(raw, BaseModel):
-            raw_data = raw.model_dump()
-        elif isinstance(raw, pd.Series):
-            raw_data = raw.to_dict()
-        elif isinstance(raw, dict):
-            raw_data = raw
-        else:
-            raw_data = cast(dict[str, Any], raw.model_dump())
 
-        for field_cfg in self._iter_fields():
-            name = field_cfg.get("name")
-            if not isinstance(name, str) or name not in raw_data:
-                continue
-
-            dtype = field_cfg.get("data_type")
-            mode = self._resolve_mode(name)
-            custom_normalizer = normalize_impl.get_normalizer(name)
-
-            if custom_normalizer:
-                base_normalizer = custom_normalizer
-            else:
-
-                def _default_normalizer(val: Any, m: str = mode) -> Any:
-                    return normalize_impl.normalize_scalar(val, mode=m)
-
-                base_normalizer = _default_normalizer
-
-            value = raw_data.get(name)
-            normalized[name] = self._normalize_value(
-                value,
-                dtype,
-                base_normalizer,
-                name,
-                allow_container_normalizer=True,
-            )
-
-        for key, value in raw_data.items():
-            key_str = cast(str, key)
-            if key_str not in normalized:
-                normalized[key_str] = value
-
-        return cast(NormalizedRecord, normalized)
-
-    def apply_normalize_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Normalize configured fields across dataframe columns."""
-        normalized_df = df.copy()
-
-        for field_cfg in self._iter_fields():
-            name = field_cfg.get("name")
-            if not name or name not in normalized_df.columns:
-                continue
-
-            normalized_df[name] = self.apply_normalize_series(
-                normalized_df[name], field_cfg
-            )
-
-        return self.ensure_numeric_columns(normalized_df)
-
-    def apply_normalize_batch(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Normalize an entire batch DataFrame."""
-        normalized = self.apply_normalize_dataframe(df)
-        return self.ensure_numeric_columns(normalized)
-
-    def apply_normalize_fields(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Alias for apply_normalize_dataframe retained for compatibility."""
-        normalized = self.apply_normalize_dataframe(df)
-        return self.ensure_numeric_columns(normalized)
-
-    def apply_normalize_series(
-        self, series: pd.Series, field_cfg: dict[str, Any]
-    ) -> pd.Series:
-        """Normalize a single column according to field configuration."""
-        name = cast(str, field_cfg.get("name"))
-        dtype = field_cfg.get("data_type")
-        mode = self._resolve_mode(name)
-        custom_normalizer = normalize_impl.get_normalizer(name)
-
-        if custom_normalizer:
-            base_normalizer = custom_normalizer
-        else:
-
-            def _default_normalizer(val: Any, m: str = mode) -> Any:
-                return normalize_impl.normalize_scalar(val, mode=m)
-
-            base_normalizer = _default_normalizer
-
-        def _normalize_value_from_series(val: Any) -> Any:
-            return self._normalize_value(
-                val,
-                dtype,
-                base_normalizer,
-                name,
-                allow_container_normalizer=True,
-            )
-
-        return cast(pd.Series, series.apply(_normalize_value_from_series))
+__all__ = ["ChemblNormalizationServiceImpl", "NormalizedRecord"]

--- a/src/bioetl/infrastructure/transform/impl/default_normalization_transformer_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/default_normalization_transformer_impl.py
@@ -3,6 +3,7 @@
 from typing import Any, Callable, cast
 
 import pandas as pd
+from pydantic import BaseModel
 
 from bioetl.domain.transform.contracts import (
     NormalizationConfigProviderProtocol,
@@ -19,14 +20,33 @@ class DefaultNormalizationTransformerImpl(
     BaseNormalizationServiceImpl, NormalizationServiceABC
 ):
     """
-    Сервис нормализации данных.
-    Выполняет:
-    - Сериализацию вложенных структур (list/dict -> str)
-    - Нормализацию скалярных типов (float->round, str->trim/lower/upper)
+    Unified normalization service for all data sources.
+
+    Performs:
+    - Serialization of nested structures (list/dict -> str)
+    - Scalar type normalization (float->round, str->trim/lower/upper)
+
+    Args:
+        config: Normalization configuration provider.
+        empty_value: Value for empty/missing data (default: pd.NA).
+        support_base_model: Accept pydantic BaseModel in apply_normalize.
+        serialize_array_in_series: Serialize arrays in apply_normalize_series.
     """
 
-    def __init__(self, config: NormalizationConfigProviderProtocol):
-        BaseNormalizationServiceImpl.__init__(self, config, empty_value=pd.NA)
+    def __init__(
+        self,
+        config: NormalizationConfigProviderProtocol,
+        empty_value: Any = pd.NA,
+        *,
+        support_base_model: bool = True,
+        serialize_array_in_series: bool = True,
+    ):
+        super().__init__(
+            config,
+            empty_value=empty_value,
+            support_base_model=support_base_model,
+            serialize_array_in_series=serialize_array_in_series,
+        )
 
     def normalize(self, df: pd.DataFrame) -> pd.DataFrame:
         """Normalize dataframe according to configured fields."""
@@ -35,10 +55,6 @@ class DefaultNormalizationTransformerImpl(
     def normalize_record(self, record: dict[str, Any]) -> dict[str, Any]:
         """Normalize single record using configured field rules."""
         return self.apply_normalize(record)
-
-    def ensure_numeric_columns(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Cast configured numeric columns to nullable pandas dtypes."""
-        return BaseNormalizationServiceImpl.ensure_numeric_columns(self, df)
 
     def apply_normalize_fields(self, df: pd.DataFrame) -> pd.DataFrame:
         """Проходит по полям конфигурации и применяет нормализацию."""
@@ -88,13 +104,32 @@ class DefaultNormalizationTransformerImpl(
 
         return self.ensure_numeric_columns(df)
 
-    def apply_normalize(self, raw: pd.Series | dict[str, Any]) -> dict[str, Any]:
-        """Normalize a raw record into a dict using configured field rules."""
+    def apply_normalize(
+        self, raw: pd.Series | dict[str, Any] | BaseModel
+    ) -> dict[str, Any]:
+        """Normalize a raw record into a dict using configured field rules.
+
+        Args:
+            raw: Input data as Series, dict, or pydantic BaseModel.
+
+        Returns:
+            Normalized dictionary with all fields processed.
+        """
+        raw_data: dict[str, Any]
+        if self._support_base_model and isinstance(raw, BaseModel):
+            raw_data = raw.model_dump()
+        elif isinstance(raw, pd.Series):
+            raw_data = raw.to_dict()
+        elif isinstance(raw, dict):
+            raw_data = raw
+        else:
+            raw_data = cast(dict[str, Any], raw.model_dump())
+
         normalized: dict[str, Any] = {}
 
         for field_cfg in self._iter_fields():
             name = field_cfg.get("name")
-            if not isinstance(name, str) or name not in raw:
+            if not isinstance(name, str) or name not in raw_data:
                 continue
 
             dtype = field_cfg.get("data_type")
@@ -110,7 +145,7 @@ class DefaultNormalizationTransformerImpl(
 
                 base_normalizer = _default_normalizer
 
-            value = raw.get(name)
+            value = raw_data.get(name)
             normalized[name] = self._normalize_value(
                 value,
                 dtype,
@@ -119,7 +154,7 @@ class DefaultNormalizationTransformerImpl(
                 allow_container_normalizer=True,
             )
 
-        for key, value in raw.items():
+        for key, value in raw_data.items():
             key_str = cast(str, key)
             if key_str not in normalized:
                 normalized[key_str] = value
@@ -166,17 +201,18 @@ class DefaultNormalizationTransformerImpl(
 
         def _normalize_value_from_series(val: Any) -> Any:
             if (
-                custom_normalizer
+                self._serialize_array_in_series
+                and custom_normalizer
                 and dtype == "array"
                 and isinstance(val, (list, tuple))
             ):
                 normalized_value = custom_normalizer(val)
                 if normalized_value is None or not normalized_value:
-                    return pd.NA
+                    return self._empty_value
                 serialized = serialize_nested(
                     normalized_value, mode=self._serialization_mode
                 )
-                return pd.NA if serialized == "" else serialized
+                return self._empty_value if serialized == "" else serialized
             return self._normalize_value(
                 val,
                 dtype,

--- a/src/bioetl/infrastructure/transform/impl/normalize.py
+++ b/src/bioetl/infrastructure/transform/impl/normalize.py
@@ -2,7 +2,8 @@
 Normalization implementation for domain entities.
 """
 
-from typing import Any
+import warnings
+from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 
@@ -12,9 +13,11 @@ from bioetl.domain.transform.normalizers import (
     normalize_uniprot,
 )
 from bioetl.domain.transform.normalizers.registry import get_normalizer
-from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl import (  # noqa: E501
-    DefaultNormalizationTransformerImpl as DefaultNormImpl,
-)
+
+if TYPE_CHECKING:
+    from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl import (
+        DefaultNormalizationTransformerImpl,
+    )
 
 # Aliases for backward compatibility or convenience
 normalize_pubmed_id = normalize_pmid
@@ -24,7 +27,7 @@ normalize_uniprot_id = normalize_uniprot
 
 def normalize_scalar(value: Any, mode: str = "default") -> Any:
     """
-    Нормализует скалярное значение.
+    Normalize a scalar value.
 
     Modes:
     - "default": trim + lower (str), round 3 (float)
@@ -72,10 +75,29 @@ def _normalize_string_value(value: str, mode: str) -> str | None:
     return val.lower()
 
 
-DefaultNormalizationTransformerImpl = DefaultNormImpl
-NormalizationTransformer = DefaultNormImpl
-NormalizationServiceImpl = DefaultNormImpl
-NormalizationService = DefaultNormImpl
+def __getattr__(name: str) -> Any:
+    """Emit deprecation warnings for legacy aliases and lazy imports."""
+    # Lazy import to avoid circular dependency
+    from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl import (
+        DefaultNormalizationTransformerImpl as _DefaultImpl,
+    )
+
+    if name == "DefaultNormalizationTransformerImpl":
+        return _DefaultImpl
+
+    deprecated_aliases = {
+        "NormalizationTransformer": _DefaultImpl,
+        "NormalizationServiceImpl": _DefaultImpl,
+        "NormalizationService": _DefaultImpl,
+    }
+    if name in deprecated_aliases:
+        warnings.warn(
+            f"{name} is deprecated. Use DefaultNormalizationTransformerImpl instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return deprecated_aliases[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 __all__ = [
@@ -85,7 +107,4 @@ __all__ = [
     "normalize_uniprot_id",
     "get_normalizer",
     "DefaultNormalizationTransformerImpl",
-    "NormalizationTransformer",
-    "NormalizationService",
-    "NormalizationServiceImpl",
 ]


### PR DESCRIPTION
…ationServiceImpl and DefaultNormalizationTransformerImpl

- Parameterize BaseNormalizationServiceImpl with empty_value, support_base_model, and serialize_array_in_series options
- Merge all normalization logic into DefaultNormalizationTransformerImpl as the unified service
- Convert ChemblNormalizationServiceImpl to a deprecated subclass with appropriate warnings
- Reduce 4 redundant aliases to 1 primary export with deprecated __getattr__ for legacy names
- Update factories with deprecation warnings for chembl-specific factory function
- Fix circular import in normalize.py using lazy imports