### PR TITLE
Standardize Prometheus metrics naming convention

### DIFF
--- a/src/bioetl/infrastructure/clients/base/impl/_http_transport.py
+++ b/src/bioetl/infrastructure/clients/base/impl/_http_transport.py
@@ -163,7 +163,7 @@ class _HttpTransport:
             return
 
         self.metrics.inc_counter(
-            "client_request_total",
+            "bioetl_client_request_total",
             {"provider": self.provider, "endpoint": endpoint, "status": status},
         )
 
@@ -172,7 +172,7 @@ class _HttpTransport:
             return
 
         self.metrics.observe_histogram(
-            "client_request_duration_seconds",
+            "bioetl_client_request_duration_seconds",
             latency,
             {"provider": self.provider, "endpoint": endpoint, "status": status},
         )
@@ -182,7 +182,7 @@ class _HttpTransport:
             return
 
         self.metrics.inc_counter(
-            "client_request_errors",
+            "bioetl_client_request_errors_total",
             {"provider": self.provider, "endpoint": endpoint, "status": status},
         )
 

--- a/src/bioetl/infrastructure/observability/adapters.py
+++ b/src/bioetl/infrastructure/observability/adapters.py
@@ -72,12 +72,12 @@ class PrometheusMetricsPortImpl(MetricsPortABC):
 
     def __init__(self) -> None:
         self._counters: dict[str, Any] = {
-            "client_request_total": metrics.CLIENT_REQUEST_TOTAL,
-            "client_request_errors": metrics.CLIENT_REQUEST_ERRORS,
-            "output_write_errors_total": metrics.OUTPUT_WRITE_ERRORS_TOTAL,
+            "bioetl_client_request_total": metrics.CLIENT_REQUEST_TOTAL,
+            "bioetl_client_request_errors_total": metrics.CLIENT_REQUEST_ERRORS_TOTAL,
+            "bioetl_output_write_errors_total": metrics.OUTPUT_WRITE_ERRORS_TOTAL,
         }
         self._histograms: dict[str, Any] = {
-            "client_request_duration_seconds": metrics.CLIENT_REQUEST_DURATION_SECONDS,
+            "bioetl_client_request_duration_seconds": metrics.CLIENT_REQUEST_DURATION_SECONDS,
         }
 
     def inc_counter(self, name: str, labels: dict[str, str]) -> None:

--- a/src/bioetl/infrastructure/observability/metrics.py
+++ b/src/bioetl/infrastructure/observability/metrics.py
@@ -1,17 +1,42 @@
-"""Prometheus metrics used across BioETL components."""
+"""Prometheus metrics used across BioETL components.
+
+Naming Convention
+-----------------
+All metrics MUST follow these rules:
+
+1. **Prefix**: All metrics start with ``bioetl_`` to namespace them
+2. **Snake_case**: Use lowercase with underscores (e.g., ``bioetl_stage_duration_seconds``)
+3. **Unit suffix**: Include unit as suffix when applicable (``_seconds``, ``_bytes``, ``_total``)
+4. **Counter suffix**: All Counter metrics end with ``_total``
+5. **Descriptive names**: Use clear, descriptive names that indicate what is being measured
+
+Examples:
+    - ``bioetl_stage_duration_seconds`` (Histogram with unit)
+    - ``bioetl_client_request_total`` (Counter with _total suffix)
+    - ``bioetl_output_write_errors_total`` (Counter for errors)
+
+References:
+    - https://prometheus.io/docs/practices/naming/
+    - https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
+"""
 
 from prometheus_client import Counter, Histogram
 
 __all__ = [
+    # Stage metrics
     "STAGE_DURATION_SECONDS",
     "STAGE_TOTAL",
-    "HTTP_REQUESTS_TOTAL",
-    "HTTP_LATENCY_SECONDS",
+    # Client request metrics
     "CLIENT_REQUEST_TOTAL",
     "CLIENT_REQUEST_DURATION_SECONDS",
-    "CLIENT_REQUEST_ERRORS",
+    "CLIENT_REQUEST_ERRORS_TOTAL",
+    # Output metrics
     "OUTPUT_WRITE_ERRORS_TOTAL",
 ]
+
+# =============================================================================
+# Stage Metrics
+# =============================================================================
 
 STAGE_DURATION_SECONDS = Histogram(
     "bioetl_stage_duration_seconds",
@@ -25,38 +50,34 @@ STAGE_TOTAL = Counter(
     ["pipeline", "provider", "entity", "stage", "outcome"],
 )
 
-HTTP_REQUESTS_TOTAL = Counter(
-    "bioetl_http_requests_total",
-    "Total HTTP requests performed by BioETL clients.",
-    ["provider", "endpoint", "method", "status_class"],
-)
-
-HTTP_LATENCY_SECONDS = Histogram(
-    "bioetl_http_latency_seconds",
-    "HTTP request latency in seconds.",
-    ["provider", "endpoint", "method", "status_class"],
-)
+# =============================================================================
+# Client Request Metrics
+# =============================================================================
 
 CLIENT_REQUEST_TOTAL = Counter(
-    "client_request_total",
+    "bioetl_client_request_total",
     "Total client requests by provider and endpoint.",
     ["provider", "endpoint", "status"],
 )
 
 CLIENT_REQUEST_DURATION_SECONDS = Histogram(
-    "client_request_duration_seconds",
+    "bioetl_client_request_duration_seconds",
     "Duration of client requests in seconds.",
     ["provider", "endpoint", "status"],
 )
 
-CLIENT_REQUEST_ERRORS = Counter(
-    "client_request_errors",
+CLIENT_REQUEST_ERRORS_TOTAL = Counter(
+    "bioetl_client_request_errors_total",
     "Total client request errors by provider and endpoint.",
     ["provider", "endpoint", "status"],
 )
 
+# =============================================================================
+# Output Metrics
+# =============================================================================
+
 OUTPUT_WRITE_ERRORS_TOTAL = Counter(
-    "output_write_errors_total",
+    "bioetl_output_write_errors_total",
     "Total number of failed output write attempts.",
     ["entity", "error_type"],
 )

--- a/src/bioetl/infrastructure/output/unified_loader_impl.py
+++ b/src/bioetl/infrastructure/output/unified_loader_impl.py
@@ -238,6 +238,6 @@ class UnifiedLoaderImpl(LoaderABC):
             return
 
         self._metrics.inc_counter(
-            "output_write_errors_total",
+            "bioetl_output_write_errors_total",
             {"entity": entity_name, "error_type": exc.__class__.__name__},
         )

--- a/tests/bioetl/infrastructure/clients/base/test_http_transport.py
+++ b/tests/bioetl/infrastructure/clients/base/test_http_transport.py
@@ -31,7 +31,7 @@ def test_request_call_wraps_timeout_error() -> None:
     assert err.value.endpoint == "https://example.org"
     logger.error.assert_called_once()
     metrics.inc_counter.assert_any_call(
-        "client_request_errors",
+        "bioetl_client_request_errors_total",
         {"provider": "chembl", "endpoint": "https://example.org", "status": "timeout"},
     )
 
@@ -53,7 +53,7 @@ def test_request_call_wraps_request_exception() -> None:
     assert err.value.provider == "chembl"
     assert err.value.endpoint == "https://example.org"
     metrics.inc_counter.assert_any_call(
-        "client_request_errors",
+        "bioetl_client_request_errors_total",
         {
             "provider": "chembl",
             "endpoint": "https://example.org",
@@ -79,7 +79,7 @@ def test_request_records_metrics_on_success() -> None:
 
     assert result is response
     metrics.inc_counter.assert_any_call(
-        "client_request_total",
+        "bioetl_client_request_total",
         {"provider": "chembl", "endpoint": "https://example.org", "status": "200"},
     )
     metrics.observe_histogram.assert_called_once()
@@ -139,6 +139,6 @@ def test_request_retries_on_server_error(monkeypatch: pytest.MonkeyPatch) -> Non
     assert result is second
     assert base_client.request.call_count == 2
     metrics.inc_counter.assert_any_call(
-        "client_request_errors",
+        "bioetl_client_request_errors_total",
         {"provider": "chembl", "endpoint": "https://example.org", "status": "500"},
     )

--- a/tests/bioetl/infrastructure/observability/test_adapters.py
+++ b/tests/bioetl/infrastructure/observability/test_adapters.py
@@ -24,11 +24,11 @@ def test_tracing_adapter_noop():
 def test_prometheus_metrics_port_updates():
     port = PrometheusMetricsPortImpl()
     port.inc_counter(
-        "client_request_total",
+        "bioetl_client_request_total",
         {"provider": "chembl", "endpoint": "/e", "status": "200"},
     )
     port.observe_histogram(
-        "client_request_duration_seconds",
+        "bioetl_client_request_duration_seconds",
         0.1,
         {"provider": "chembl", "endpoint": "/e", "status": "200"},
     )

--- a/tests/bioetl/infrastructure/output/test_unified_loader.py
+++ b/tests/bioetl/infrastructure/output/test_unified_loader.py
@@ -290,7 +290,7 @@ def test_write_result_records_metric_on_failure(
         writer_impl.load(pd.DataFrame({"a": [1]}), tmp_path, run_context_factory())
 
     metrics.inc_counter.assert_called_once_with(
-        "output_write_errors_total",
+        "bioetl_output_write_errors_total",
         {"entity": "test_entity", "error_type": "ValueError"},
     )
 


### PR DESCRIPTION
- Add `bioetl_` prefix to all metrics for consistent namespacing
- Rename `client_request_total` → `bioetl_client_request_total`
- Rename `client_request_duration_seconds` → `bioetl_client_request_duration_seconds`
- Rename `client_request_errors` → `bioetl_client_request_errors_total`
- Rename `output_write_errors_total` → `bioetl_output_write_errors_total`
- Remove unused HTTP_REQUESTS_TOTAL and HTTP_LATENCY_SECONDS metrics
- Add comprehensive naming convention documentation in metrics.py
- Update all metric references in adapters, http_transport, and unified_loader
- Update related tests to use new metric names

All Counter metrics now end with `_total` suffix per Prometheus best practices.