### PR TITLE
Unify pipeline creation in BioETL

### DIFF
--- a/src/bioetl/application/orchestrator.py
+++ b/src/bioetl/application/orchestrator.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 from concurrent.futures import Future
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, cast
+from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
     from concurrent.futures import ProcessPoolExecutor
 
 from bioetl.application.pipelines.base import PipelineBase
 from bioetl.application.pipelines.contracts import PipelineContainerABC
-from bioetl.application.pipelines.registry import get_pipeline_class
+from bioetl.application.pipelines.registry import get_factory
 from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.models import RunContext, RunResult, StageResult
 from bioetl.domain.pipelines.types import PipelineType
@@ -48,8 +48,21 @@ class PipelineOrchestrator:
         self._provider_loader_factory = provider_loader_factory
 
     def build_pipeline(self, *, limit: int | None = None) -> PipelineBase:
-        """Создает экземпляр пайплайна с зависимостями."""
-        pipeline_cls = get_pipeline_class(self._pipeline_name)
+        """
+        Create a pipeline instance by delegating to the appropriate factory.
+
+        This method is the single entry point for pipeline creation. It:
+        1. Resolves the provider registry
+        2. Creates a dependency container
+        3. Delegates pipeline creation to the registered factory
+
+        Args:
+            limit: Optional record limit for extraction.
+
+        Returns:
+            Fully configured pipeline ready to run.
+        """
+        factory = get_factory(self._pipeline_name)
         registry = self._get_provider_registry()
         container: PipelineContainerABC = self._container_factory(
             self._config,
@@ -57,44 +70,7 @@ class PipelineOrchestrator:
             provider_registry_provider=None,
         )
 
-        logger = container.get_logger()
-        validation_service = container.get_validation_service()
-        loader = container.get_loader()
-        extraction_service = container.get_extraction_service()
-        normalization_service = container.get_normalization_service()
-        record_source = container.get_record_source(
-            extraction_service, limit=limit, logger=logger
-        )
-        hash_service = container.get_hash_service()
-        metadata_builder = container.get_metadata_builder()
-        hooks = container.get_hooks()
-        error_policy = container.get_error_policy()
-
-        pipeline_factory: Callable[..., PipelineBase] = cast(
-            Callable[..., PipelineBase], pipeline_cls
-        )
-        pipeline: PipelineBase = pipeline_factory(
-            config=self._config,
-            logger=logger,
-            validation_service=validation_service,
-            loader=loader,
-            extraction_service=extraction_service,
-            record_source=record_source,
-            normalization_service=normalization_service,
-            hash_service=hash_service,
-            metadata_builder=metadata_builder,
-            hooks=hooks,
-            error_policy=error_policy,
-        )
-
-        pipeline.set_post_transformer(
-            container.get_post_transformer(version_provider=pipeline.get_version)
-        )
-
-        pipeline.register_hooks(hooks)
-        pipeline.set_error_policy(error_policy)
-
-        return pipeline
+        return factory.create(container, limit=limit)
 
     def run_pipeline(
         self,

--- a/src/bioetl/application/pipelines/chembl/factories.py
+++ b/src/bioetl/application/pipelines/chembl/factories.py
@@ -1,41 +1,78 @@
 """
-Factories for ChEMBL pipelines.
+Factory for ChEMBL pipeline creation.
+
+This module provides the single entry point for creating ChEMBL pipelines,
+ensuring consistent configuration and dependency injection.
 """
 
+from __future__ import annotations
+
+from bioetl.application.pipelines.base import PipelineBase
 from bioetl.application.pipelines.chembl.base import ChemblPipelineBase
-from bioetl.application.pipelines.contracts import PipelineContainerABC
-from bioetl.domain.schemas.chembl.raw_models import ActivityRawModel
+from bioetl.application.pipelines.contracts import (
+    PipelineContainerABC,
+    PipelineFactoryABC,
+)
 
 
-def create_chembl_pipeline(container: PipelineContainerABC) -> ChemblPipelineBase:
+class ChemblPipelineFactory(PipelineFactoryABC):
     """
-    Creates a ChEMBL entity pipeline using dependencies from container.
+    Factory for creating ChEMBL entity pipelines.
 
-    Args:
-        container: Dependency injection container.
-
-    Returns:
-        Configured ChemblPipelineBase.
+    This factory centralizes all ChEMBL pipeline creation logic, ensuring
+    dependencies are properly resolved from the container and the pipeline
+    is fully configured before returning.
     """
-    extraction_service = container.get_extraction_service()
-    logger = container.get_logger()
 
-    record_source = container.get_record_source(
-        extraction_service,
-        logger=logger,
-        model_cls=ActivityRawModel,
-    )
+    def create(
+        self,
+        container: PipelineContainerABC,
+        *,
+        limit: int | None = None,
+    ) -> PipelineBase:
+        """
+        Create a fully configured ChEMBL pipeline.
 
-    return ChemblPipelineBase(
-        config=container.config,
-        logger=logger,
-        validation_service=container.get_validation_service(),
-        loader=container.get_loader(),
-        extraction_service=extraction_service,
-        hash_service=container.get_hash_service(),
-        metadata_builder=container.get_metadata_builder(),
-        record_source=record_source,
-        normalization_service=container.get_normalization_service(),
-        hooks=container.get_hooks(),
-        error_policy=container.get_error_policy(),
-    )
+        Args:
+            container: Dependency injection container providing services.
+            limit: Optional record limit for extraction.
+
+        Returns:
+            Configured ChemblPipelineBase ready to run.
+        """
+        logger = container.get_logger()
+        extraction_service = container.get_extraction_service()
+
+        record_source = container.get_record_source(
+            extraction_service,
+            limit=limit,
+            logger=logger,
+        )
+
+        pipeline: PipelineBase = ChemblPipelineBase(
+            config=container.config,
+            logger=logger,
+            validation_service=container.get_validation_service(),
+            loader=container.get_loader(),
+            extraction_service=extraction_service,
+            hash_service=container.get_hash_service(),
+            metadata_builder=container.get_metadata_builder(),
+            record_source=record_source,
+            normalization_service=container.get_normalization_service(),
+            hooks=container.get_hooks(),
+            error_policy=container.get_error_policy(),
+        )
+
+        # Set post-transformer with version provider from the pipeline
+        pipeline.set_post_transformer(
+            container.get_post_transformer(version_provider=pipeline.get_version)
+        )
+
+        # Register hooks and error policy for runtime notifications
+        pipeline.register_hooks(container.get_hooks())
+        pipeline.set_error_policy(container.get_error_policy())
+
+        return pipeline
+
+
+__all__ = ["ChemblPipelineFactory"]

--- a/src/bioetl/application/pipelines/contracts.py
+++ b/src/bioetl/application/pipelines/contracts.py
@@ -1,7 +1,9 @@
 """Contracts for pipeline components."""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 from bioetl.domain.clients.base.output.contracts import RunMetadataBuilderProtocol
 from bioetl.domain.configs import PipelineConfig
@@ -16,6 +18,9 @@ from bioetl.domain.record_source import RecordSourceABC
 from bioetl.domain.transform.contracts import HashServiceABC, NormalizationServiceABC
 from bioetl.domain.transform.transformers import TransformerABC
 from bioetl.domain.validation.service import ValidationService
+
+if TYPE_CHECKING:
+    from bioetl.application.pipelines.base import PipelineBase
 
 
 class PipelineContainerABC(ABC):
@@ -87,4 +92,36 @@ class PipelineContainerABC(ABC):
         """Return builder for run metadata artifacts."""
 
 
-__all__ = ["ExtractorABC", "LoaderABC", "PipelineContainerABC"]
+class PipelineFactoryABC(ABC):
+    """
+    Abstract factory for creating pipeline instances.
+
+    Each pipeline type (e.g., ChEMBL, PubChem) provides a concrete implementation
+    that knows how to assemble the pipeline with its specific dependencies.
+    """
+
+    @abstractmethod
+    def create(
+        self,
+        container: PipelineContainerABC,
+        *,
+        limit: int | None = None,
+    ) -> PipelineBase:
+        """
+        Create a fully configured pipeline instance.
+
+        Args:
+            container: Dependency injection container providing services.
+            limit: Optional record limit for extraction.
+
+        Returns:
+            Configured pipeline ready to run.
+        """
+
+
+__all__ = [
+    "ExtractorABC",
+    "LoaderABC",
+    "PipelineContainerABC",
+    "PipelineFactoryABC",
+]

--- a/src/bioetl/application/pipelines/registry.py
+++ b/src/bioetl/application/pipelines/registry.py
@@ -1,4 +1,4 @@
-"""Registry of available pipeline implementations."""
+"""Registry of available pipeline implementations and factories."""
 
 from __future__ import annotations
 
@@ -7,9 +7,12 @@ from typing import Type
 
 from bioetl.application.pipelines.base import PipelineBase
 from bioetl.application.pipelines.chembl.base import ChemblPipelineBase
+from bioetl.application.pipelines.chembl.factories import ChemblPipelineFactory
+from bioetl.application.pipelines.contracts import PipelineFactoryABC
 
 PipelineFactory = Callable[..., PipelineBase]
 
+# Registry mapping pipeline names to pipeline classes (legacy, for backward compatibility)
 _PIPELINE_REGISTRY: dict[str, PipelineFactory] = {
     "activity_chembl": ChemblPipelineBase,
     "assay_chembl": ChemblPipelineBase,
@@ -20,6 +23,16 @@ _PIPELINE_REGISTRY: dict[str, PipelineFactory] = {
 
 # Backwards-compatible export for tests expecting PIPELINE_REGISTRY
 PIPELINE_REGISTRY = _PIPELINE_REGISTRY
+
+# Factory registry: maps pipeline names to their factory instances
+# This is the preferred way to create pipelines
+_FACTORY_REGISTRY: dict[str, PipelineFactoryABC] = {
+    "activity_chembl": ChemblPipelineFactory(),
+    "assay_chembl": ChemblPipelineFactory(),
+    "publication_chembl": ChemblPipelineFactory(),
+    "target_chembl": ChemblPipelineFactory(),
+    "molecule_chembl": ChemblPipelineFactory(),
+}
 
 
 def get_pipeline_factory(name: str) -> PipelineFactory:
@@ -44,7 +57,48 @@ def get_pipeline_class(name: str) -> Type[PipelineBase]:
     )
 
 
+def get_factory(name: str) -> PipelineFactoryABC:
+    """
+    Return the factory instance for creating pipelines of the given type.
+
+    This is the preferred method for obtaining pipeline factories.
+
+    Args:
+        name: Pipeline name (e.g., 'activity_chembl').
+
+    Returns:
+        Factory instance implementing PipelineFactoryABC.
+
+    Raises:
+        ValueError: If no factory is registered for the given name.
+    """
+    try:
+        return _FACTORY_REGISTRY[name]
+    except KeyError as exc:
+        raise ValueError(
+            f"Pipeline factory '{name}' not found. "
+            f"Available: {list(_FACTORY_REGISTRY.keys())}"
+        ) from exc
+
+
 def get_registered_pipelines() -> dict[str, PipelineFactory]:
     """Return a copy of the registered pipeline mapping."""
 
     return dict(_PIPELINE_REGISTRY)
+
+
+def get_registered_factories() -> dict[str, PipelineFactoryABC]:
+    """Return a copy of the registered factory mapping."""
+
+    return dict(_FACTORY_REGISTRY)
+
+
+__all__ = [
+    "PIPELINE_REGISTRY",
+    "PipelineFactory",
+    "get_factory",
+    "get_pipeline_class",
+    "get_pipeline_factory",
+    "get_registered_factories",
+    "get_registered_pipelines",
+]


### PR DESCRIPTION
Eliminate parallel pipeline creation paths by introducing a unified factory pattern. Previously, pipelines could be created through both PipelineOrchestrator.build_pipeline() and create_chembl_pipeline(), leading to responsibility diffusion and potential desynchronization.

Changes:
- Add PipelineFactoryABC interface in contracts.py for pipeline factories
- Implement ChemblPipelineFactory as the single source of truth for ChEMBL pipeline creation
- Update registry.py with factory registry (get_factory()) while preserving backward compatibility via existing get_pipeline_class()
- Refactor PipelineOrchestrator.build_pipeline() to delegate to the appropriate factory

Benefits:
- Single entry point for pipeline creation
- Easy to add new pipeline types (implement PipelineFactoryABC)
- Clear separation of concerns: orchestrator handles lifecycle, factory handles creation details
- No duplication of pipeline assembly logic