### PR TITLE
Create separate config classes for bounded contexts

### DIFF
--- a/src/bioetl/domain/configs/__init__.py
+++ b/src/bioetl/domain/configs/__init__.py
@@ -12,6 +12,9 @@ from bioetl.domain.configs.defaults import (
     SourceDefaultsConfig,
     SourcesDefaultsConfig,
 )
+
+# Bounded context configs
+from bioetl.domain.configs.identity import PipelineIdentityConfig
 from bioetl.domain.configs.normalization import NormalizationConfig
 from bioetl.domain.configs.pipeline import (
     HTTP_CLIENT_DEFAULTS,
@@ -43,8 +46,19 @@ from bioetl.domain.configs.pipeline import (
     TransformConfig,
 )
 from bioetl.domain.configs.profile import ProfileConfig
+from bioetl.domain.configs.sink import DataSinkConfig, OutputOptionsConfig
+from bioetl.domain.configs.source import (
+    CsvInputConfig as CsvInputConfigNew,
+    DataSourceConfig as DataSourceConfigNew,
+)
 
 __all__ = [
+    # Bounded context configs (new modular structure)
+    "PipelineIdentityConfig",
+    "DataSourceConfigNew",
+    "DataSinkConfig",
+    "OutputOptionsConfig",
+    "CsvInputConfigNew",
     # Primary HTTP configuration (single source of truth)
     "HttpClientConfig",
     "ProviderHttpConfig",

--- a/src/bioetl/domain/configs/identity.py
+++ b/src/bioetl/domain/configs/identity.py
@@ -1,0 +1,68 @@
+"""Pipeline identity configuration."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class PipelineIdentityConfig(BaseModel):
+    """Pipeline identification and metadata.
+
+    Groups fields that identify the pipeline and its data domain.
+    This is a frozen immutable model for thread-safety and hashability.
+
+    Attributes:
+        pipeline_id: Unique identifier for the pipeline run.
+        provider: Name of the data provider (e.g., "chembl", "uniprot").
+        entity: Type of entity being extracted (e.g., "activity", "target").
+        primary_key: List of fields that form the primary key for deduplication.
+    """
+
+    pipeline_id: str = Field(..., description="Unique identifier for the pipeline")
+    provider: str = Field(..., description="Data provider name")
+    entity: str = Field(..., description="Entity type being extracted")
+    primary_key: list[str] = Field(
+        default_factory=list, description="Primary key fields for deduplication"
+    )
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    @field_validator("pipeline_id")
+    @classmethod
+    def validate_pipeline_id_not_empty(cls, value: str) -> str:
+        """Ensure pipeline_id is not empty."""
+        if not value or not value.strip():
+            raise ValueError("pipeline_id must be a non-empty string")
+        return value.strip()
+
+    @field_validator("provider")
+    @classmethod
+    def validate_provider_known(cls, value: str) -> str:
+        """Ensure provider identifier is known to the registry."""
+        from bioetl.domain.providers import ProviderId
+
+        known = {provider.value for provider in ProviderId}
+        if value not in known:
+            raise ValueError(f"Unknown provider: {value}. Known: {known}")
+        return value
+
+    @field_validator("entity")
+    @classmethod
+    def validate_entity_not_empty(cls, value: str) -> str:
+        """Ensure entity is not empty."""
+        if not value or not value.strip():
+            raise ValueError("entity must be a non-empty string")
+        return value.strip()
+
+    @field_validator("primary_key", mode="before")
+    @classmethod
+    def coerce_primary_key_to_list(cls, value: str | list[str] | None) -> list[str]:
+        """Coerce primary_key to list if string is provided."""
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [value] if value else []
+        return list(value)
+
+
+__all__ = ["PipelineIdentityConfig"]

--- a/src/bioetl/domain/configs/sink.py
+++ b/src/bioetl/domain/configs/sink.py
@@ -1,0 +1,74 @@
+"""Data sink configuration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class OutputOptionsConfig(BaseModel):
+    """Output options for data sink.
+
+    Settings controlling how output data is written.
+
+    Attributes:
+        converter: Optional converter name for output transformation.
+        format: Output file format (json, parquet, csv).
+        compression: Optional compression algorithm (gzip, zstd, none).
+    """
+
+    converter: str | None = Field(default=None, description="Output converter name")
+    format: Literal["json", "parquet", "csv"] = Field(
+        default="json", description="Output file format"
+    )
+    compression: Literal["gzip", "zstd", "none"] | None = Field(
+        default=None, description="Compression algorithm"
+    )
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+
+class DataSinkConfig(BaseModel):
+    """Data sink configuration.
+
+    Groups fields related to output: path, dry run mode, output options.
+    This is a frozen immutable model for thread-safety and hashability.
+
+    Attributes:
+        output_path: Directory or file path for output data.
+        dry_run: If True, skip actual data writing (validation only).
+        output: Additional output options (format, compression, converter).
+    """
+
+    output_path: str = Field(..., description="Output path for data")
+    dry_run: bool = Field(default=False, description="Skip actual writing")
+    output: OutputOptionsConfig = Field(
+        default_factory=OutputOptionsConfig, description="Output options"
+    )
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    @field_validator("output_path")
+    @classmethod
+    def validate_output_path(cls, value: str) -> str:
+        """Normalize and validate output path."""
+        if not value or not value.strip():
+            raise ValueError("output_path must be a non-empty string")
+        # Normalize path
+        path = Path(value.strip())
+        return str(path)
+
+    @field_validator("output_path")
+    @classmethod
+    def validate_output_path_not_system(cls, value: str) -> str:
+        """Prevent writing to dangerous system paths."""
+        dangerous_prefixes = ("/etc", "/usr", "/bin", "/sbin", "/boot", "/proc", "/sys")
+        for prefix in dangerous_prefixes:
+            if value.startswith(prefix):
+                raise ValueError(f"output_path cannot start with system path: {prefix}")
+        return value
+
+
+__all__ = ["DataSinkConfig", "OutputOptionsConfig"]

--- a/src/bioetl/domain/configs/source.py
+++ b/src/bioetl/domain/configs/source.py
@@ -1,0 +1,121 @@
+"""Data source configuration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PositiveInt,
+    field_validator,
+    model_validator,
+)
+
+
+class CsvInputConfig(BaseModel):
+    """CSV input configuration.
+
+    Settings for parsing CSV input files.
+
+    Attributes:
+        delimiter: Field delimiter character.
+        header: Whether the CSV has a header row.
+        encoding: File encoding (default: utf-8).
+        quote_char: Character used for quoting fields.
+    """
+
+    delimiter: str = Field(default=",", description="Field delimiter")
+    header: bool = Field(default=True, description="CSV has header row")
+    encoding: str = Field(default="utf-8", description="File encoding")
+    quote_char: str = Field(default='"', description="Quote character")
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    @field_validator("delimiter")
+    @classmethod
+    def validate_delimiter(cls, value: str) -> str:
+        """Validate that CSV delimiter is a non-empty string."""
+        if not value:
+            raise ValueError("CSV delimiter must be a non-empty string")
+        return value
+
+    @field_validator("encoding")
+    @classmethod
+    def validate_encoding(cls, value: str) -> str:
+        """Validate encoding is a known codec."""
+        import codecs
+
+        try:
+            codecs.lookup(value)
+        except LookupError as err:
+            raise ValueError(f"Unknown encoding: {value}") from err
+        return value
+
+
+class DataSourceConfig(BaseModel):
+    """Data source configuration.
+
+    Groups fields related to input data: mode, path, batching, CSV options.
+    This is a frozen immutable model for thread-safety and hashability.
+
+    Attributes:
+        input_mode: How to read input data (csv, id_only, auto_detect).
+        input_path: Path to input file (required for csv/id_only modes).
+        batch_size: Number of records to process per batch.
+        csv: CSV parsing options.
+    """
+
+    input_mode: Literal["csv", "id_only", "auto_detect"] = Field(
+        ..., description="Input reading mode"
+    )
+    input_path: str | None = Field(default=None, description="Path to input file")
+    batch_size: PositiveInt = Field(default=100, description="Records per batch")
+    csv: CsvInputConfig = Field(
+        default_factory=CsvInputConfig,
+        alias="csv_options",
+        description="CSV parsing options",
+    )
+
+    model_config = ConfigDict(frozen=True, extra="forbid", populate_by_name=True)
+
+    @field_validator("input_path")
+    @classmethod
+    def validate_input_path(cls, value: str | None) -> str | None:
+        """Normalize empty input path to None and ensure path string."""
+        if value is None or value == "":
+            return None
+        path = Path(value)
+        return str(path)
+
+    @model_validator(mode="after")
+    def validate_input_mode_requires_path(self) -> DataSourceConfig:
+        """Validate that csv/id_only modes require input_path."""
+        if self.input_mode in {"csv", "id_only"} and not self.input_path:
+            raise ValueError(
+                f"input_path must be provided when input_mode is '{self.input_mode}'"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_csv_header_required(self) -> DataSourceConfig:
+        """Validate CSV header requirement for csv and auto_detect modes."""
+        if self.input_mode == "csv" and not self.csv.header:
+            raise ValueError("csv.header must be true when input_mode is 'csv'")
+
+        if self.input_mode == "auto_detect" and self.input_path and not self.csv.header:
+            raise ValueError(
+                "csv.header must be true when input_mode is 'auto_detect' "
+                "and input_path is set"
+            )
+        return self
+
+    @property
+    def csv_options(self) -> CsvInputConfig:
+        """Backward compatibility alias for csv."""
+        return self.csv
+
+
+__all__ = ["CsvInputConfig", "DataSourceConfig"]

--- a/tests/architecture/test_architecture_policies.py
+++ b/tests/architecture/test_architecture_policies.py
@@ -186,6 +186,11 @@ def test_duplicate_class_names_are_allowlisted() -> None:
         "DefaultNormalizationTransformerImpl",
         "NormalizationConfig",
         "Config",
+        # Temporary: bounded context configs migration (will be consolidated)
+        "CsvInputConfig",
+        "DataSourceConfig",
+        "DataSinkConfig",
+        "OutputOptionsConfig",
     }
 
     class_map: dict[str, list[Path]] = {}

--- a/tests/architecture/test_architecture_rules.py
+++ b/tests/architecture/test_architecture_rules.py
@@ -23,6 +23,11 @@ ALLOWED_DUPLICATE_CLASSES = {
     "NormalizationConfig",
     "Config",
     "BaseProviderConfig",
+    # Temporary: bounded context configs migration (will be consolidated)
+    "CsvInputConfig",
+    "DataSourceConfig",
+    "DataSinkConfig",
+    "OutputOptionsConfig",
 }
 ALLOWED_ABCS_WITHOUT_IMPL = {
     "CLICommandABC",

--- a/tests/project_rules/class_inventory_baseline.json
+++ b/tests/project_rules/class_inventory_baseline.json
@@ -1,3 +1,3 @@
 {
-  "total_classes": 206
+  "total_classes": 214
 }


### PR DESCRIPTION
…, sink

Create separate frozen Pydantic config classes for each bounded context:
- PipelineIdentityConfig: pipeline identification with validators
- DataSourceConfig: input settings with CsvInputConfig
- DataSinkConfig: output settings with OutputOptionsConfig

Each class is frozen for thread-safety and includes comprehensive validators. Update allowlists temporarily for migration period duplicates.