### PR TITLE
Remove duplicate alias methods in builders

### DIFF
--- a/src/bioetl/domain/clients/base/contracts.py
+++ b/src/bioetl/domain/clients/base/contracts.py
@@ -1,5 +1,6 @@
 """Base contracts for data source helpers."""
 
+import warnings
 from abc import ABC, abstractmethod
 from typing import Any, Generic, TypeVar
 
@@ -28,7 +29,16 @@ class RequestBuilderABC(ABC):
         """Добавляет параметры пагинации."""
 
     def with_pagination(self, offset: int, limit: int) -> "RequestBuilderABC":
-        """Alias for build_with_pagination."""
+        """Deprecated alias for build_with_pagination.
+
+        .. deprecated:: 1.0
+            Use :meth:`build_with_pagination` instead. Will be removed in 2.0.
+        """
+        warnings.warn(
+            "with_pagination() is deprecated, use build_with_pagination() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.build_with_pagination(offset, limit)
 
 
@@ -37,13 +47,22 @@ class ResponseParserABC(ABC, Generic[RecordT]):
     Разбор ответов API.
     """
 
-    def parse(self, raw_response: dict[str, object]) -> list[RecordT]:
-        """Alias for parse_response."""
-        return self.parse_response(raw_response)
-
     @abstractmethod
-    def parse_response(self, raw_response: dict[str, object]) -> list[RecordT]:
+    def parse(self, raw_response: dict[str, object]) -> list[RecordT]:
         """Парсит сырой ответ в список типизированных записей."""
+
+    def parse_response(self, raw_response: dict[str, object]) -> list[RecordT]:
+        """Deprecated alias for parse.
+
+        .. deprecated:: 1.0
+            Use :meth:`parse` instead. Will be removed in 2.0.
+        """
+        warnings.warn(
+            "parse_response() is deprecated, use parse() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.parse(raw_response)
 
     @abstractmethod
     def extract_metadata(

--- a/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
@@ -172,8 +172,6 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
         # Try client's parser first (for backward compatibility)
         if hasattr(self.client, "response_parser"):
             parser = getattr(self.client, "response_parser")
-            if hasattr(parser, "parse_response"):
-                return parser.parse_response(raw_response)
             if hasattr(parser, "parse"):
                 return parser.parse(raw_response)
 

--- a/src/bioetl/infrastructure/clients/chembl/impl/chembl_http_client_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/chembl_http_client_impl.py
@@ -200,8 +200,6 @@ class ChemblHttpClientImpl(DataClientABC):
     def _apply_endpoint_aliases(self, builder: Any, endpoint: str) -> None:
         if hasattr(builder, "build_for_endpoint"):
             builder.build_for_endpoint(endpoint)
-        if hasattr(builder, "for_endpoint"):
-            builder.for_endpoint(endpoint)
 
     def _invoke_builder_method(
         self, builder: Any, method: str, filters: dict[str, Any]

--- a/src/bioetl/infrastructure/clients/chembl/request_builder.py
+++ b/src/bioetl/infrastructure/clients/chembl/request_builder.py
@@ -1,5 +1,6 @@
 """Request builder for constructing ChEMBL API URLs."""
 
+import warnings
 from typing import Any, Optional
 
 from bioetl.domain.clients.base.contracts import RequestBuilderABC
@@ -19,8 +20,16 @@ class ChemblRequestBuilderImpl(RequestBuilderABC):
         self._params: dict[str, Any] = {}
 
     def for_endpoint(self, endpoint: str) -> "ChemblRequestBuilderImpl":
-        """Fluent alias for build_for_endpoint used in tests."""
+        """Deprecated alias for build_for_endpoint.
 
+        .. deprecated:: 1.0
+            Use :meth:`build_for_endpoint` instead. Will be removed in 2.0.
+        """
+        warnings.warn(
+            "for_endpoint() is deprecated, use build_for_endpoint() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.build_for_endpoint(endpoint)
 
     def build_for_endpoint(self, endpoint: str) -> "ChemblRequestBuilderImpl":
@@ -88,5 +97,14 @@ class ChemblRequestBuilderImpl(RequestBuilderABC):
         return self
 
     def with_pagination(self, offset: int, limit: int) -> "ChemblRequestBuilderImpl":
-        """Alias for build_with_pagination."""
+        """Deprecated alias for build_with_pagination.
+
+        .. deprecated:: 1.0
+            Use :meth:`build_with_pagination` instead. Will be removed in 2.0.
+        """
+        warnings.warn(
+            "with_pagination() is deprecated, use build_with_pagination() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.build_with_pagination(offset, limit)

--- a/src/bioetl/infrastructure/clients/chembl/response_parser.py
+++ b/src/bioetl/infrastructure/clients/chembl/response_parser.py
@@ -1,5 +1,6 @@
 """Response parser for ChEMBL API responses."""
 
+import warnings
 from typing import Generic, TypeVar
 
 from pydantic import BaseModel, TypeAdapter
@@ -38,7 +39,16 @@ class ChemblResponseParserImpl(ResponseParserABC[T], Generic[T]):
         return []
 
     def parse_response(self, raw_response: dict[str, object]) -> list[T]:
-        """Alias for parse."""
+        """Deprecated alias for parse.
+
+        .. deprecated:: 1.0
+            Use :meth:`parse` instead. Will be removed in 2.0.
+        """
+        warnings.warn(
+            "parse_response() is deprecated, use parse() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.parse(raw_response)
 
     def extract_metadata(


### PR DESCRIPTION
…parsers

Mark the following methods as @deprecated with warnings:
- for_endpoint() -> use build_for_endpoint()
- with_pagination() -> use build_with_pagination()
- parse_response() -> use parse()

Changes:
- contracts.py: Make parse() abstract, parse_response() deprecated alias
- request_builder.py: Add deprecation warnings to for_endpoint() and with_pagination()
- response_parser.py: Add deprecation warning to parse_response()
- chembl_http_client_impl.py: Remove call to deprecated for_endpoint()
- chembl_extraction_service_impl.py: Use canonical parse() method

All deprecated methods emit DeprecationWarning and will be removed in 2.0.