### PR TITLE
Remove unused file cache implementation

### DIFF
--- a/src/bioetl/infrastructure/clients/base/abc_impls.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_impls.yaml
@@ -10,7 +10,6 @@ CacheABC:
   default_factory: bioetl.infrastructure.clients.base.factories.default_cache
   implementations:
     Memory: bioetl.infrastructure.clients.base.impl.cache.MemoryCacheImpl
-    File: bioetl.infrastructure.clients.base.impl.cache.FileCacheImpl
 
 ProviderRegistryLoaderABC:
   default_factory: bioetl.infrastructure.clients.provider_registry_loader.default_provider_registry_loader

--- a/src/bioetl/infrastructure/clients/base/impl/cache.py
+++ b/src/bioetl/infrastructure/clients/base/impl/cache.py
@@ -1,11 +1,7 @@
-"""In-memory and file-based cache implementations with TTL support."""
+"""In-memory cache implementation with TTL support."""
 
 from __future__ import annotations
 
-import hashlib
-import os
-from pathlib import Path
-import pickle
 import time
 from typing import TypeVar
 
@@ -55,60 +51,3 @@ class MemoryCacheImpl(CacheABC[T]):
     def clear(self) -> None:
         """Clear entire in-memory cache."""
         self._store.clear()
-
-
-class FileCacheImpl(CacheABC[T]):
-    """
-    Файловый кэш с TTL.
-    """
-
-    def __init__(self, cache_dir: str) -> None:
-        self._cache_dir = Path(cache_dir)
-        self._cache_dir.mkdir(parents=True, exist_ok=True)
-
-    def get(self, key: str) -> T | None:
-        """Load cached value from disk if present and valid."""
-        cache_file = self._key_to_path(key)
-        if not cache_file.exists():
-            return None
-
-        try:
-            with cache_file.open("rb") as fh:
-                payload: tuple[T, float | None] = pickle.load(fh)
-        except (OSError, pickle.PickleError):
-            self.invalidate(key)
-            return None
-
-        value, expiry_timestamp = payload
-        if _is_expired(expiry_timestamp):
-            self.invalidate(key)
-            return None
-
-        return value
-
-    def set(self, key: str, value: T, ttl: int | None = None) -> None:
-        """Persist value to disk using atomic write."""
-        cache_file = self._key_to_path(key)
-        tmp_file = cache_file.with_suffix(cache_file.suffix + ".tmp")
-        payload: tuple[T, float | None] = (value, _get_expiry_timestamp(ttl))
-
-        with tmp_file.open("wb") as fh:
-            pickle.dump(payload, fh)
-
-        os.replace(tmp_file, cache_file)
-
-    def invalidate(self, key: str) -> None:
-        """Delete cached file if it exists."""
-        cache_file = self._key_to_path(key)
-        if cache_file.exists():
-            cache_file.unlink(missing_ok=True)
-
-    def clear(self) -> None:
-        """Remove all cache files in directory."""
-        for cache_file in self._cache_dir.glob("*.cache"):
-            cache_file.unlink(missing_ok=True)
-
-    def _key_to_path(self, key: str) -> Path:
-        digest = hashlib.sha256(key.encode("utf-8")).hexdigest()
-        safe_name = f"{digest}.cache"
-        return self._cache_dir / safe_name

--- a/tests/bioetl/infrastructure/clients/base/test_cache.py
+++ b/tests/bioetl/infrastructure/clients/base/test_cache.py
@@ -2,10 +2,9 @@
 Tests for cache implementations.
 """
 
-from pathlib import Path
 import time
 
-from bioetl.infrastructure.clients.base.impl.cache import FileCacheImpl, MemoryCacheImpl
+from bioetl.infrastructure.clients.base.impl.cache import MemoryCacheImpl
 
 
 def test_memory_cache():
@@ -25,26 +24,5 @@ def test_memory_cache_ttl_expiration():
     """Test TTL expiration in memory cache."""
     cache = MemoryCacheImpl[int]()
     cache.set("k", 10, ttl=1)
-    time.sleep(1.2)
-    assert cache.get("k") is None
-
-
-def test_file_cache(tmp_path: Path):
-    """Test file cache operations."""
-    cache = FileCacheImpl(tmp_path)
-    cache.set("k", 1)
-    assert cache.get("k") == 1
-    cache.invalidate("k")
-    assert cache.get("k") is None
-
-    cache.set("k2", 2)
-    cache.clear()
-    assert cache.get("k2") is None
-
-
-def test_file_cache_ttl_expiration(tmp_path: Path):
-    """Test TTL expiration in file cache."""
-    cache = FileCacheImpl(tmp_path)
-    cache.set("k", 5, ttl=1)
     time.sleep(1.2)
     assert cache.get("k") is None


### PR DESCRIPTION
- Remove FileCacheImpl class from cache.py (was not used in production code)
- Remove FileCacheImpl tests (only tested itself)
- Remove File implementation from abc_impls.yaml registry
- Clean up unused imports (hashlib, os, Path, pickle)

MemoryCacheImpl remains as the sole cache implementation used via default_cache() factory.