### PR TITLE
Remove unnecessary reexports from application contracts

### DIFF
--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -9,14 +9,14 @@ from bioetl.application.factories.hooks import PipelineHookFactory
 from bioetl.application.factories.noop import create_noop_metrics_port
 from bioetl.application.factories.record_source import RecordSourceFactory
 from bioetl.application.factories.services import ProviderServiceFactory
-from bioetl.application.pipelines.contracts import LoaderABC, PipelineContainerABC
+from bioetl.application.pipelines.contracts import PipelineContainerABC
 from bioetl.application.pipelines.hooks_impl import FailFastErrorPolicyImpl
 from bioetl.domain.clients.base.output.contracts import (
     RunMetadataBuilderProtocol,
 )
 from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.observability import LoggingPortABC, MetricsPortABC
-from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
+from bioetl.domain.pipelines.contracts import ErrorPolicyABC, LoaderABC, PipelineHookABC
 from bioetl.domain.provider_registry import ProviderRegistryABC
 from bioetl.domain.providers import ProviderDefinition, ProviderId
 from bioetl.domain.record_source import RecordSourceABC

--- a/src/bioetl/application/pipelines/base.py
+++ b/src/bioetl/application/pipelines/base.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, TypeAlias, 
 
 import pandas as pd
 
-from bioetl.application.pipelines.contracts import ExtractorABC, LoaderABC
 from bioetl.application.pipelines.stage_runtime_manager import StageRuntimeManagerImpl
 from bioetl.domain.clients.base.output.contracts import (
     RunMetadataBuilderProtocol,
@@ -19,7 +18,12 @@ from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.errors import PipelineStageError
 from bioetl.domain.models import RunContext, RunResult, StageResult
 from bioetl.domain.observability import LoggingPortABC
-from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
+from bioetl.domain.pipelines.contracts import (
+    ErrorPolicyABC,
+    ExtractorABC,
+    LoaderABC,
+    PipelineHookABC,
+)
 from bioetl.domain.providers import ProviderId
 from bioetl.domain.schemas.pipeline_contracts import get_pipeline_contract
 from bioetl.domain.transform.contracts import HashServiceABC

--- a/src/bioetl/application/pipelines/chembl/base.py
+++ b/src/bioetl/application/pipelines/chembl/base.py
@@ -13,7 +13,6 @@ from bioetl.application.pipelines.base import (
 )
 from bioetl.application.pipelines.chembl.extractor import ChemblExtractorImpl
 from bioetl.application.pipelines.chembl.transformer import ChemblTransformerImpl
-from bioetl.application.pipelines.contracts import LoaderABC
 from bioetl.domain.clients.base.output.contracts import (
     RunMetadataBuilderProtocol,
     WriteResult,
@@ -21,7 +20,7 @@ from bioetl.domain.clients.base.output.contracts import (
 from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.models import RunContext
 from bioetl.domain.observability import LoggingPortABC
-from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
+from bioetl.domain.pipelines.contracts import ErrorPolicyABC, LoaderABC, PipelineHookABC
 from bioetl.domain.ports.extraction import (
     ExtractionServiceABC,
 )

--- a/src/bioetl/application/pipelines/chembl/extractor.py
+++ b/src/bioetl/application/pipelines/chembl/extractor.py
@@ -7,7 +7,7 @@ from typing import Any, Iterable
 import pandas as pd
 from pydantic import BaseModel
 
-from bioetl.application.pipelines.contracts import ExtractorABC
+from bioetl.domain.pipelines.contracts import ExtractorABC
 from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.observability import LoggingPortABC
 from bioetl.domain.ports.extraction import ExtractionServiceABC

--- a/src/bioetl/application/pipelines/contracts.py
+++ b/src/bioetl/application/pipelines/contracts.py
@@ -10,7 +10,6 @@ from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.observability import LoggingPortABC
 from bioetl.domain.pipelines.contracts import (
     ErrorPolicyABC,
-    ExtractorABC,
     LoaderABC,
     PipelineHookABC,
 )
@@ -120,8 +119,6 @@ class PipelineFactoryABC(ABC):
 
 
 __all__ = [
-    "ExtractorABC",
-    "LoaderABC",
     "PipelineContainerABC",
     "PipelineFactoryABC",
 ]

--- a/tests/bioetl/application/pipelines/test_pipeline_base.py
+++ b/tests/bioetl/application/pipelines/test_pipeline_base.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pytest
 
 from bioetl.application.pipelines.base import PipelineBase
-from bioetl.application.pipelines.contracts import ExtractorABC, LoaderABC
+from bioetl.domain.pipelines.contracts import ExtractorABC, LoaderABC
 from bioetl.application.pipelines.hooks_impl import (
     ContinueOnErrorPolicyImpl,
     FailFastErrorPolicyImpl,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -407,7 +407,7 @@ def mock_loader():
     """Create a mock loader compatible with LoaderABC."""
     from pathlib import Path
 
-    from bioetl.application.pipelines.contracts import LoaderABC
+    from bioetl.domain.pipelines.contracts import LoaderABC
     from bioetl.domain.clients.base.output.contracts import WriteResult
 
     loader = MagicMock(spec=LoaderABC)


### PR DESCRIPTION
…on contracts

Remove ExtractorABC and LoaderABC re-exports from
application.pipelines.contracts.py. All imports of these types now go directly to domain.pipelines.contracts, reducing unnecessary indirection.

- Update imports in container.py, base.py, chembl/base.py, chembl/extractor.py
- Update test imports in test_pipeline_base.py and conftest.py
- Keep LoaderABC imported (not re-exported) in contracts.py for internal use