### PR TITLE
Refactor PipelineConfig into aggregate root

### DIFF
--- a/src/bioetl/application/factories/record_source.py
+++ b/src/bioetl/application/factories/record_source.py
@@ -55,9 +55,9 @@ class RecordSourceFactory:
         Returns:
             Configured RecordSourceABC instance.
         """
-        mode = self._config.input_mode
-        path = self._config.input_path
-        chunk_size = self._config.batch_size
+        mode = self._config.source.input_mode
+        path = self._config.source.input_path
+        chunk_size = self._config.source.batch_size
 
         if mode == "auto_detect" and path:
             mode = "csv"
@@ -67,7 +67,7 @@ class RecordSourceFactory:
                 raise ValueError("input_path is required for CSV mode")
             return CsvRecordSourceImpl(
                 input_path=Path(path),
-                csv_options=self._config.csv_options,
+                csv_options=self._config.source.csv,
                 limit=limit,
                 logger=logger,
                 chunk_size=chunk_size,
@@ -84,7 +84,7 @@ class RecordSourceFactory:
             return IdListRecordSourceImpl(
                 input_path=Path(path),
                 id_column=id_column,
-                csv_options=self._config.csv_options,
+                csv_options=self._config.source.csv,
                 limit=limit,
                 extraction_service=extraction_service,
                 source_config=source_config,
@@ -94,7 +94,8 @@ class RecordSourceFactory:
                 chunk_size=chunk_size,
             )
 
-        filters = self._config.pipeline.copy()
+        # API filters - stages are not filters, use empty dict for API mode
+        filters: dict[str, Any] = {}
         if limit is not None:
             filters["limit"] = limit
 

--- a/src/bioetl/application/helpers/primary_key.py
+++ b/src/bioetl/application/helpers/primary_key.py
@@ -22,11 +22,10 @@ def resolve_primary_key(
     Resolve the primary key for an entity based on pipeline configuration.
 
     Resolution order:
-    1. config.primary_key (explicit field)
-    2. config.pipeline["primary_key"] (pipeline options dict)
-    3. f"{entity_name}_id" (convention-based fallback)
-    4. fallback parameter (if provided)
-    5. ValueError (if no resolution possible)
+    1. config.identity.primary_key[0] (first element of primary key list)
+    2. f"{entity_name}_id" (convention-based fallback)
+    3. fallback parameter (if provided)
+    4. ValueError (if no resolution possible)
 
     Args:
         config: Pipeline configuration object.
@@ -42,28 +41,25 @@ def resolve_primary_key(
         >>> pk = resolve_primary_key(config)
         >>> pk = resolve_primary_key(config, fallback="id")
     """
-    # 1. Check explicit primary_key field
-    pk = config.primary_key
+    # 1. Check explicit primary_key field (now a list in identity section)
+    pk: str | None = None
+    primary_keys = config.identity.primary_key
+    if primary_keys:
+        pk = primary_keys[0]  # Use first element
 
-    # 2. Check pipeline options dict
-    if not pk:
-        pipeline_opts = config.pipeline or {}
-        if "primary_key" in pipeline_opts:
-            pk = pipeline_opts["primary_key"]
-
-    # 3. Use entity-based convention
+    # 2. Use entity-based convention
     if not pk:
         pk = f"{config.entity_name}_id"
 
-    # 4. Use fallback if provided and pk still empty
+    # 3. Use fallback if provided and pk still empty
     if not pk and fallback is not None:
         pk = fallback
 
-    # 5. Raise if still no resolution
+    # 4. Raise if still no resolution
     if not pk:
         raise ValueError(
             f"Could not resolve primary key for entity '{config.entity_name}'. "
-            "Please set 'primary_key' in config or pipeline options."
+            "Please set 'primary_key' in config."
         )
 
     return pk

--- a/src/bioetl/application/orchestrator.py
+++ b/src/bioetl/application/orchestrator.py
@@ -86,7 +86,7 @@ class PipelineOrchestrator:
         if effective_type == PipelineType.TRANSFORM_ONLY:
             # Выполнить трансформацию и валидацию, пропустив запись
             return pipeline.run(
-                output_path=Path(self._config.output_path),
+                output_path=Path(self._config.sink.output_path),
                 dry_run=True,
                 limit=limit,
             )
@@ -136,7 +136,7 @@ class PipelineOrchestrator:
 
         # FULL (по умолчанию)
         return pipeline.run(
-            output_path=Path(self._config.output_path),
+            output_path=Path(self._config.sink.output_path),
             dry_run=dry_run,
             limit=limit,
         )

--- a/src/bioetl/application/pipelines/chembl/base.py
+++ b/src/bioetl/application/pipelines/chembl/base.py
@@ -113,10 +113,11 @@ class ChemblPipelineBase(PipelineBase):
     def _resolve_primary_key(config: PipelineConfig) -> tuple[str, str]:
         """Resolve entity primary key and API filter key based on config."""
 
-        pk = config.primary_key
-
-        if not pk and config.pipeline and "primary_key" in config.pipeline:
-            pk = config.pipeline["primary_key"]
+        pk: str | None = None
+        # Check explicit primary_key in identity section (now a list)
+        primary_keys = config.identity.primary_key
+        if primary_keys:
+            pk = primary_keys[0]
 
         if not pk:
             pk = f"{config.entity_name}_id"
@@ -126,7 +127,7 @@ class ChemblPipelineBase(PipelineBase):
                 (
                     "Could not resolve ID_COLUMN for entity "
                     f"'{config.entity_name}'. Please set 'primary_key' "
-                    "in config or pipeline options."
+                    "in config."
                 )
             )
 

--- a/src/bioetl/domain/configs/__init__.py
+++ b/src/bioetl/domain/configs/__init__.py
@@ -15,6 +15,7 @@ from bioetl.domain.configs.defaults import (
 
 # Bounded context configs
 from bioetl.domain.configs.identity import PipelineIdentityConfig
+from bioetl.domain.configs.migration import ConfigMigrator
 from bioetl.domain.configs.normalization import NormalizationConfig
 from bioetl.domain.configs.pipeline import (
     HTTP_CLIENT_DEFAULTS,
@@ -24,6 +25,8 @@ from bioetl.domain.configs.pipeline import (
     ChemblSourceConfig,
     ClientConfig,
     CsvInputConfig,
+    DataSinkConfig,
+    DataSourceConfig,
     DeterminismConfig,
     DummyProviderConfig,
     FeatureFlagsConfig,
@@ -35,8 +38,10 @@ from bioetl.domain.configs.pipeline import (
     LoggingConfig,
     MetricsConfig,
     ObservabilityConfig,
+    OutputOptionsConfig,
     PaginationConfig,
     PipelineConfig,
+    PipelineStagesConfig,
     ProviderConfigUnion,
     ProviderHttpConfig,
     QcConfig,
@@ -46,19 +51,17 @@ from bioetl.domain.configs.pipeline import (
     TransformConfig,
 )
 from bioetl.domain.configs.profile import ProfileConfig
-from bioetl.domain.configs.sink import DataSinkConfig, OutputOptionsConfig
-from bioetl.domain.configs.source import (
-    CsvInputConfig as CsvInputConfigNew,
-    DataSourceConfig as DataSourceConfigNew,
-)
 
 __all__ = [
     # Bounded context configs (new modular structure)
     "PipelineIdentityConfig",
-    "DataSourceConfigNew",
+    "DataSourceConfig",
     "DataSinkConfig",
     "OutputOptionsConfig",
-    "CsvInputConfigNew",
+    "CsvInputConfig",
+    "PipelineStagesConfig",
+    # Migration utilities
+    "ConfigMigrator",
     # Primary HTTP configuration (single source of truth)
     "HttpClientConfig",
     "ProviderHttpConfig",
@@ -73,7 +76,6 @@ __all__ = [
     # Sub-configs
     "BusinessKeyConfig",
     "CanonicalizationConfig",
-    "CsvInputConfig",
     "DeterminismConfig",
     "FeatureFlagsConfig",
     "HashingConfig",

--- a/src/bioetl/domain/configs/migration.py
+++ b/src/bioetl/domain/configs/migration.py
@@ -1,0 +1,223 @@
+"""Configuration migration utilities.
+
+Handles migration of legacy pipeline configuration formats to the new decomposed structure.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class ConfigMigrator:
+    """Migrates legacy flat pipeline configs to the new decomposed structure.
+
+    This class handles backward compatibility by converting:
+    - Flat fields (id, provider, entity) -> identity section
+    - Flat fields (input_mode, input_path, batch_size) -> source section
+    - Flat fields (output_path, dry_run) -> sink section
+    - Legacy pipeline dict -> stages section
+    - Flat observability fields -> observability section
+    - Flat quality fields -> quality section
+    - Flat feature fields -> features section
+    """
+
+    # Fields belonging to each section
+    IDENTITY_FIELDS = ("id", "provider", "entity", "primary_key")
+    SOURCE_FIELDS = ("input_mode", "input_path", "batch_size")
+    SINK_FIELDS = ("output_path", "dry_run")
+    STAGES_FIELDS = ("extract", "transform", "load")
+    RUNTIME_FIELDS = ("pagination", "client", "http", "storage")
+    OBSERVABILITY_FIELDS = ("logging", "metrics")
+    QUALITY_FIELDS = ("determinism", "qc", "hashing", "normalization")
+    FEATURE_FIELDS = ("features", "interface_features", "interfaces")
+
+    @classmethod
+    def migrate(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Migrate legacy config format to new decomposed structure.
+
+        Args:
+            data: Raw configuration dictionary (possibly in legacy format).
+
+        Returns:
+            Migrated configuration with decomposed sections.
+        """
+        if not isinstance(data, dict):
+            return data
+
+        migrated = dict(data)
+
+        # Step 1: Handle entity_name -> entity alias
+        cls._migrate_entity_name_alias(migrated)
+
+        # Step 2: Pack identity section
+        cls._pack_identity(migrated)
+
+        # Step 3: Pack source section
+        cls._pack_source(migrated)
+
+        # Step 4: Pack sink section
+        cls._pack_sink(migrated)
+
+        # Step 5: Pack stages from pipeline dict
+        cls._pack_stages(migrated)
+
+        # Step 6: Pack section configs (runtime, observability, quality, features)
+        cls._pack_section("runtime", cls.RUNTIME_FIELDS, migrated)
+        cls._pack_section("observability", cls.OBSERVABILITY_FIELDS, migrated)
+        cls._pack_section("quality", cls.QUALITY_FIELDS, migrated)
+        cls._pack_section("features", cls.FEATURE_FIELDS, migrated)
+
+        return migrated
+
+    @classmethod
+    def _migrate_entity_name_alias(cls, data: dict[str, Any]) -> None:
+        """Handle entity_name as alias for entity."""
+        if "entity_name" in data and "entity" not in data:
+            data["entity"] = data.pop("entity_name")
+        elif "entity_name" in data:
+            data.pop("entity_name")
+
+    @classmethod
+    def _pack_identity(cls, data: dict[str, Any]) -> None:
+        """Pack identity fields into identity section."""
+        if "identity" in data:
+            return
+
+        identity_fields: dict[str, Any] = {}
+        for field in cls.IDENTITY_FIELDS:
+            if field in data:
+                value = data.pop(field)
+                # Map 'id' to 'pipeline_id' for PipelineIdentityConfig
+                if field == "id":
+                    identity_fields["pipeline_id"] = value
+                elif field == "primary_key":
+                    # Coerce primary_key to list if string
+                    if isinstance(value, str):
+                        identity_fields["primary_key"] = [value] if value else []
+                    elif value is None:
+                        identity_fields["primary_key"] = []
+                    else:
+                        identity_fields["primary_key"] = list(value)
+                else:
+                    identity_fields[field] = value
+
+        if identity_fields:
+            data["identity"] = identity_fields
+
+    @classmethod
+    def _pack_source(cls, data: dict[str, Any]) -> None:
+        """Pack source fields into source section."""
+        if "source" in data:
+            return
+
+        source_fields: dict[str, Any] = {}
+        for field in cls.SOURCE_FIELDS:
+            if field in data:
+                source_fields[field] = data.pop(field)
+
+        # Handle csv_options -> csv
+        if "csv_options" in data:
+            source_fields["csv"] = data.pop("csv_options")
+        elif "csv" in data and "runtime" not in data:
+            # csv at root level goes to source if no runtime section
+            source_fields["csv"] = data.pop("csv")
+
+        if source_fields:
+            data["source"] = source_fields
+
+    @classmethod
+    def _pack_sink(cls, data: dict[str, Any]) -> None:
+        """Pack sink fields into sink section."""
+        if "sink" in data:
+            return
+
+        sink_fields: dict[str, Any] = {}
+        for field in cls.SINK_FIELDS:
+            if field in data:
+                sink_fields[field] = data.pop(field)
+
+        # Handle output section
+        if "output" in data:
+            output_val = data.pop("output")
+            if isinstance(output_val, dict):
+                sink_fields["output"] = output_val
+
+        if sink_fields:
+            data["sink"] = sink_fields
+
+    @classmethod
+    def _pack_stages(cls, data: dict[str, Any]) -> None:
+        """Pack stages from legacy pipeline dict."""
+        if "pipeline" not in data:
+            return
+
+        pipeline_dict = data.pop("pipeline")
+        if not isinstance(pipeline_dict, dict):
+            return
+
+        # Extract primary_key from pipeline dict -> identity
+        if "primary_key" in pipeline_dict:
+            pk_from_pipeline = pipeline_dict.pop("primary_key")
+            identity = data.setdefault("identity", {})
+            if isinstance(identity, dict) and identity.get("primary_key") is None:
+                # Coerce to list
+                if isinstance(pk_from_pipeline, str):
+                    identity["primary_key"] = (
+                        [pk_from_pipeline] if pk_from_pipeline else []
+                    )
+                elif pk_from_pipeline is None:
+                    identity["primary_key"] = []
+                else:
+                    identity["primary_key"] = list(pk_from_pipeline)
+
+        # Extract stages
+        if "stages" not in data:
+            stages_fields: dict[str, Any] = {}
+            for field in cls.STAGES_FIELDS:
+                if field in pipeline_dict:
+                    stages_fields[field] = pipeline_dict[field]
+            if stages_fields:
+                data["stages"] = stages_fields
+
+    @classmethod
+    def _pack_section(
+        cls, section_key: str, keys: tuple[str, ...], data: dict[str, Any]
+    ) -> None:
+        """Pack flat fields into a section.
+
+        Args:
+            section_key: Name of the target section.
+            keys: Field names that belong to this section.
+            data: Configuration dictionary to modify.
+        """
+        existing_section = (
+            data.get(section_key) if isinstance(data.get(section_key), dict) else None
+        )
+        keys_to_collect = list(keys)
+        if section_key in keys_to_collect and existing_section is not None:
+            keys_to_collect.remove(section_key)
+
+        collected = {key: data.pop(key) for key in keys_to_collect if key in data}
+        if not collected and existing_section is None:
+            return
+
+        target_section: dict[str, Any] = dict(existing_section or {})
+        nested_from_collected = collected.pop(section_key, None)
+        if isinstance(nested_from_collected, dict):
+            target_section |= nested_from_collected
+
+        for key, value in collected.items():
+            if (
+                key in target_section
+                and isinstance(target_section[key], dict)
+                and isinstance(value, dict)
+            ):
+                target_section[key] = {**target_section[key], **value}
+            else:
+                target_section[key] = value
+
+        if target_section:
+            data[section_key] = target_section
+
+
+__all__ = ["ConfigMigrator"]

--- a/src/bioetl/domain/configs/pipeline.py
+++ b/src/bioetl/domain/configs/pipeline.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 from pydantic import (
@@ -20,13 +19,16 @@ if TYPE_CHECKING:
     from bioetl.domain.pipelines.types import PipelineType
     from bioetl.domain.transform.contracts import NormalizationConfigProviderProtocol
 
-# Import NormalizationConfig from the dedicated normalization module
+# Import bounded context configs
+from bioetl.domain.configs.identity import PipelineIdentityConfig
 from bioetl.domain.configs.normalization import NormalizationConfig
+from bioetl.domain.configs.sink import DataSinkConfig, OutputOptionsConfig
+from bioetl.domain.configs.source import CsvInputConfig, DataSourceConfig
 from bioetl.domain.configs.transform import TransformConfig
 
 
 class PaginationConfig(BaseModel):
-    """Конфигурация пагинации."""
+    """Pagination configuration."""
 
     limit: int = 1000
     offset: int = 0
@@ -136,7 +138,7 @@ HTTP_CLIENT_DEFAULTS = HttpClientConfig()
 
 
 class StorageConfig(BaseModel):
-    """Конфигурация путей хранения файлов."""
+    """Storage path configuration."""
 
     output_path: str = "./data/output"
     cache_path: str = "./data/cache"
@@ -146,7 +148,7 @@ class StorageConfig(BaseModel):
 
 
 class LoggingConfig(BaseModel):
-    """Конфигурация логирования."""
+    """Logging configuration."""
 
     level: str = "INFO"
     structured: bool = True
@@ -156,7 +158,7 @@ class LoggingConfig(BaseModel):
 
 
 class MetricsConfig(BaseModel):
-    """Конфигурация экспорта метрик."""
+    """Metrics export configuration."""
 
     enabled: bool = True
     port: int = 9108
@@ -175,7 +177,7 @@ class MetricsConfig(BaseModel):
 
 
 class DeterminismConfig(BaseModel):
-    """Конфигурация детерминизма."""
+    """Determinism configuration."""
 
     stable_sort: bool = True
     utc_timestamps: bool = True
@@ -186,7 +188,7 @@ class DeterminismConfig(BaseModel):
 
 
 class QcConfig(BaseModel):
-    """Конфигурация контроля качества."""
+    """Quality control configuration."""
 
     enable_quality_report: bool = True
     enable_correlation_report: bool = True
@@ -196,7 +198,7 @@ class QcConfig(BaseModel):
 
 
 class CanonicalizationConfig(BaseModel):
-    """Конфигурация канонизации для хеширования."""
+    """Canonicalization configuration for hashing."""
 
     format: Literal["canonical_json"] = "canonical_json"
     utf8: bool = True
@@ -211,7 +213,7 @@ class CanonicalizationConfig(BaseModel):
 
 
 class BusinessKeyConfig(BaseModel):
-    """Конфигурация бизнес-ключа."""
+    """Business key configuration."""
 
     serialization: Literal["json_array", "json_object"] = "json_array"
     use_concatenation: bool = False
@@ -220,7 +222,7 @@ class BusinessKeyConfig(BaseModel):
 
 
 class HashingConfig(BaseModel):
-    """Конфигурация хеширования."""
+    """Hashing configuration."""
 
     algorithm: str = "blake2b"
     digest_size_bytes: int = 32
@@ -239,128 +241,10 @@ class HashingConfig(BaseModel):
 
 
 class InterfaceFeaturesConfig(BaseModel):
-    """Фиче-флаги интерфейсов."""
+    """Interface feature flags."""
 
     rest_interface_enabled: bool = False
     mq_interface_enabled: bool = False
-
-    model_config = ConfigDict(extra="forbid")
-
-
-class CsvInputConfig(BaseModel):
-    """Конфигурация CSV-ввода."""
-
-    delimiter: str = ","
-    header: bool = True
-
-    model_config = ConfigDict(extra="forbid")
-
-    @field_validator("delimiter")
-    @classmethod
-    def validate_delimiter(cls, value: str) -> str:
-        """Validate that CSV delimiter is a non-empty string."""
-
-        if not value:
-            raise ValueError("CSV delimiter must be a non-empty string")
-        return value
-
-
-# =============================================================================
-# Decomposed Configuration Classes
-# =============================================================================
-
-
-class PipelineIdentity(BaseModel):
-    """Pipeline identification and metadata.
-
-    Groups fields that identify the pipeline and its data domain.
-    """
-
-    id: str
-    provider: str
-    entity: str
-    primary_key: str | None = None
-
-    model_config = ConfigDict(extra="forbid")
-
-    @field_validator("provider")
-    @classmethod
-    def validate_provider_known(cls, value: str) -> str:
-        """Ensure provider identifier is known to the registry."""
-        from bioetl.domain.providers import ProviderId
-
-        known = {provider.value for provider in ProviderId}
-        if value not in known:
-            raise ValueError(f"Unknown provider: {value}")
-        return value
-
-
-class DataSourceConfig(BaseModel):
-    """Data source configuration.
-
-    Groups fields related to input data: mode, path, batching, CSV options.
-    """
-
-    input_mode: Literal["csv", "id_only", "auto_detect"]
-    input_path: str | None = None
-    batch_size: PositiveInt
-    csv: CsvInputConfig = Field(default_factory=CsvInputConfig, alias="csv_options")
-
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
-
-    @field_validator("input_path")
-    @classmethod
-    def validate_input_path(cls, value: str | None) -> str | None:
-        """Normalize empty input path to None and ensure path string."""
-        if value is None or value == "":
-            return None
-        path = Path(value)
-        return str(path)
-
-    @model_validator(mode="after")
-    def validate_input_mode_requires_path(self) -> DataSourceConfig:
-        """Validate that input_mode is compatible with provided paths."""
-        if self.input_mode in {"csv", "id_only"} and not self.input_path:
-            raise ValueError(
-                "input_path must be provided when input_mode is 'csv' or 'id_only'"
-            )
-        return self
-
-    @model_validator(mode="after")
-    def validate_csv_header_required(self) -> DataSourceConfig:
-        """Validate CSV header requirement for csv and auto_detect modes."""
-        if self.input_mode == "csv" and not self.csv.header:
-            raise ValueError("csv.header must be true when input_mode is 'csv'")
-
-        if (
-            self.input_mode == "auto_detect"
-            and self.input_path
-            and not self.csv.header
-        ):
-            raise ValueError(
-                "csv.header must be true when input_mode is 'auto_detect' "
-                "and input_path is set"
-            )
-        return self
-
-
-class OutputOptionsConfig(BaseModel):
-    """Опции финальной записи артефактов."""
-
-    converter: str | None = None
-
-    model_config = ConfigDict(extra="forbid")
-
-
-class DataSinkConfig(BaseModel):
-    """Data sink configuration.
-
-    Groups fields related to output: path, dry run mode, output options.
-    """
-
-    output_path: str
-    dry_run: bool = False
-    output: OutputOptionsConfig = Field(default_factory=OutputOptionsConfig)
 
     model_config = ConfigDict(extra="forbid")
 
@@ -379,7 +263,7 @@ class PipelineStagesConfig(BaseModel):
 
 
 class BaseProviderConfig(BaseModel):
-    """Базовая строгая конфигурация провайдера.
+    """Base strict provider configuration.
 
     Uses HttpClientConfig as the single source of truth for HTTP settings.
     Legacy fields (http_client, client) are provided for backward compatibility.
@@ -494,7 +378,7 @@ class BaseProviderConfig(BaseModel):
 
 
 class ChemblSourceConfig(BaseProviderConfig):
-    """Конфигурация источника ChEMBL."""
+    """ChEMBL source configuration."""
 
     provider: Literal["chembl"] = "chembl"
     api_version: str | None = None
@@ -508,7 +392,7 @@ class ChemblSourceConfig(BaseProviderConfig):
     def resolve_effective_batch_size(
         self, limit: int | None = None, hard_cap: int | None = 25
     ) -> int:
-        """Вычисляет эффективный размер батча с учётом ограничений."""
+        """Compute effective batch size with constraints."""
 
         effective_batch = self.batch_size or hard_cap or 25
 
@@ -522,7 +406,7 @@ class ChemblSourceConfig(BaseProviderConfig):
 
 
 class DummyProviderConfig(BaseProviderConfig):
-    """Конфигурация фиктивного провайдера для тестов и шаблонов."""
+    """Dummy provider configuration for tests and templates."""
 
     provider: Literal["dummy"] = "dummy"
 
@@ -534,7 +418,7 @@ ProviderConfigUnion = Annotated[
 
 
 class RuntimeConfig(BaseModel):
-    """Секция исполнения и источников данных."""
+    """Runtime and data source section."""
 
     pagination: PaginationConfig = Field(default_factory=PaginationConfig)
     http: HttpClientConfig = Field(default_factory=HttpClientConfig)
@@ -561,7 +445,7 @@ class RuntimeConfig(BaseModel):
 
 
 class ObservabilityConfig(BaseModel):
-    """Секция логирования и метрик."""
+    """Logging and metrics section."""
 
     logging: LoggingConfig = Field(default_factory=LoggingConfig)
     metrics: MetricsConfig = Field(default_factory=MetricsConfig)
@@ -570,7 +454,7 @@ class ObservabilityConfig(BaseModel):
 
 
 class QualityConfig(BaseModel):
-    """Секция качества и детерминизма."""
+    """Quality and determinism section."""
 
     determinism: DeterminismConfig = Field(default_factory=DeterminismConfig)
     qc: QcConfig = Field(default_factory=QcConfig)
@@ -581,7 +465,7 @@ class QualityConfig(BaseModel):
 
 
 class FeatureFlagsConfig(BaseModel):
-    """Секция фичей интерфейсов."""
+    """Interface features section."""
 
     interfaces: InterfaceFeaturesConfig = Field(
         default_factory=InterfaceFeaturesConfig, alias="features"
@@ -612,7 +496,7 @@ class FeatureFlagsConfig(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def migrate_inline_flags(cls, data: Any) -> Any:
-        """Позволяет передавать плоские фиче-флаги без обёртки."""
+        """Allow flat feature flags without wrapper."""
 
         if not isinstance(data, dict):
             return data
@@ -627,22 +511,31 @@ class FeatureFlagsConfig(BaseModel):
 
 
 class PipelineConfig(BaseModel):
-    """Decomposed pipeline configuration for BioETL.
+    """Aggregate root for pipeline configuration.
 
-    Uses composition of bounded context configs:
-    - identity: Pipeline identification (id, provider, entity, primary_key)
-    - source: Data source settings (input_mode, input_path, batch_size, csv)
-    - sink: Data sink settings (output_path, dry_run, output options)
-    - stages: Pipeline stage flags (extract, transform, load)
-    - runtime: Execution settings (pagination, http, storage)
-    - observability: Logging and metrics
-    - quality: QC, hashing, normalization, determinism
-    - features: Feature flags
-    - transform: Transform stage settings
+    Composes specialized bounded context configurations.
+    Contains no business logic, only structure.
+
+    Breaking Changes (v2.0):
+        - Access via decomposed sections: config.identity.entity, config.source.input_mode, etc.
+        - Removed 20+ backward compatibility property accessors
+        - Only convenience accessors for entity and provider remain
+
+    Sections:
+        identity: Pipeline identification (pipeline_id, provider, entity, primary_key)
+        source: Data source settings (input_mode, input_path, batch_size, csv)
+        sink: Data sink settings (output_path, dry_run, output options)
+        stages: Pipeline stage flags (extract, transform, load)
+        runtime: Execution settings (pagination, http, storage)
+        observability: Logging and metrics
+        quality: QC, hashing, normalization, determinism
+        features: Feature flags
+        transform: Transform stage settings
+        provider_config: Provider-specific configuration
     """
 
-    # Decomposed sections
-    identity: PipelineIdentity
+    # Core bounded context configs
+    identity: PipelineIdentityConfig
     source: DataSourceConfig
     sink: DataSinkConfig
     stages: PipelineStagesConfig = Field(default_factory=PipelineStagesConfig)
@@ -655,7 +548,7 @@ class PipelineConfig(BaseModel):
     transform: TransformConfig = Field(default_factory=TransformConfig)
 
     # Provider-specific config
-    provider_config: ProviderConfigUnion
+    provider_config: ProviderConfigUnion | None = None
 
     # Schema configuration
     fields: list[dict[str, Any]] = Field(default_factory=list)
@@ -663,243 +556,28 @@ class PipelineConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     # =========================================================================
-    # Backward compatibility properties (delegating to decomposed sections)
+    # Convenience accessors (minimal, no backward compatibility)
     # =========================================================================
-
-    @property
-    def id(self) -> str:
-        """Backward compatibility: access id from identity."""
-        return self.identity.id
-
-    @id.setter
-    def id(self, value: str) -> None:
-        """Backward compatibility: set id in identity."""
-        object.__setattr__(self.identity, "id", value)
-
-    @property
-    def provider(self) -> str:
-        """Backward compatibility: access provider from identity."""
-        return self.identity.provider
-
-    @provider.setter
-    def provider(self, value: str) -> None:
-        """Backward compatibility: set provider in identity."""
-        object.__setattr__(self.identity, "provider", value)
 
     @property
     def entity(self) -> str:
-        """Backward compatibility: access entity from identity."""
+        """Access entity from identity section."""
         return self.identity.entity
 
-    @entity.setter
-    def entity(self, value: str) -> None:
-        """Backward compatibility: set entity in identity."""
-        object.__setattr__(self.identity, "entity", value)
+    @property
+    def provider(self) -> str:
+        """Access provider from identity section."""
+        return self.identity.provider
 
     @property
-    def primary_key(self) -> str | None:
-        """Backward compatibility: access primary_key from identity."""
-        return self.identity.primary_key
-
-    @primary_key.setter
-    def primary_key(self, value: str | None) -> None:
-        """Backward compatibility: set primary_key in identity."""
-        object.__setattr__(self.identity, "primary_key", value)
+    def entity_name(self) -> str:
+        """Alias for entity (backward compatibility)."""
+        return self.identity.entity
 
     @property
-    def input_mode(self) -> Literal["csv", "id_only", "auto_detect"]:
-        """Backward compatibility: access input_mode from source."""
-        return self.source.input_mode
-
-    @input_mode.setter
-    def input_mode(self, value: Literal["csv", "id_only", "auto_detect"]) -> None:
-        """Backward compatibility: set input_mode in source."""
-        object.__setattr__(self.source, "input_mode", value)
-
-    @property
-    def input_path(self) -> str | None:
-        """Backward compatibility: access input_path from source."""
-        return self.source.input_path
-
-    @input_path.setter
-    def input_path(self, value: str | None) -> None:
-        """Backward compatibility: set input_path in source."""
-        object.__setattr__(self.source, "input_path", value)
-
-    @property
-    def batch_size(self) -> int:
-        """Backward compatibility: access batch_size from source."""
-        return self.source.batch_size
-
-    @batch_size.setter
-    def batch_size(self, value: int) -> None:
-        """Backward compatibility: set batch_size in source."""
-        object.__setattr__(self.source, "batch_size", value)
-
-    @property
-    def output_path(self) -> str:
-        """Backward compatibility: access output_path from sink."""
-        return self.sink.output_path
-
-    @output_path.setter
-    def output_path(self, value: str) -> None:
-        """Backward compatibility: set output_path in sink."""
-        object.__setattr__(self.sink, "output_path", value)
-
-    @property
-    def dry_run(self) -> bool:
-        """Backward compatibility: access dry_run from sink."""
-        return self.sink.dry_run
-
-    @dry_run.setter
-    def dry_run(self, value: bool) -> None:
-        """Backward compatibility: set dry_run in sink."""
-        object.__setattr__(self.sink, "dry_run", value)
-
-    @property
-    def output(self) -> OutputOptionsConfig:
-        """Backward compatibility: access output from sink."""
-        return self.sink.output
-
-    @output.setter
-    def output(self, value: OutputOptionsConfig) -> None:
-        """Backward compatibility: set output in sink."""
-        object.__setattr__(self.sink, "output", value)
-
-    @property
-    def csv_options(self) -> CsvInputConfig:
-        """Backward compatibility: access csv from source."""
-        return self.source.csv
-
-    @csv_options.setter
-    def csv_options(self, value: CsvInputConfig) -> None:
-        """Backward compatibility: set csv in source."""
-        object.__setattr__(self.source, "csv", value)
-
-    @property
-    def pipeline(self) -> dict[str, Any]:
-        """Backward compatibility: access stages as dict."""
-        return {
-            "extract": self.stages.extract,
-            "transform": self.stages.transform,
-            "load": self.stages.load,
-        }
-
-    # =========================================================================
-    # Backward compatibility for runtime section
-    # =========================================================================
-
-    @property
-    def pagination(self) -> PaginationConfig:
-        """Backward compatibility: access pagination from runtime."""
-        return self.runtime.pagination
-
-    @pagination.setter
-    def pagination(self, value: PaginationConfig) -> None:
-        """Backward compatibility: set pagination in runtime."""
-        object.__setattr__(self.runtime, "pagination", value)
-
-    @property
-    def client(self) -> HttpClientConfig:
-        """DEPRECATED: Use runtime.http instead."""
-        return self.runtime.http
-
-    @client.setter
-    def client(self, value: HttpClientConfig) -> None:
-        """DEPRECATED: Use runtime.http instead."""
-        object.__setattr__(self.runtime, "http", value)
-
-    @property
-    def storage(self) -> StorageConfig:
-        """Backward compatibility: access storage from runtime."""
-        return self.runtime.storage
-
-    @storage.setter
-    def storage(self, value: StorageConfig) -> None:
-        """Backward compatibility: set storage in runtime."""
-        object.__setattr__(self.runtime, "storage", value)
-
-    # =========================================================================
-    # Backward compatibility for observability section
-    # =========================================================================
-
-    @property
-    def logging(self) -> LoggingConfig:
-        """Backward compatibility: access logging from observability."""
-        return self.observability.logging
-
-    @logging.setter
-    def logging(self, value: LoggingConfig) -> None:
-        """Backward compatibility: set logging in observability."""
-        object.__setattr__(self.observability, "logging", value)
-
-    @property
-    def metrics(self) -> MetricsConfig:
-        """Backward compatibility: access metrics from observability."""
-        return self.observability.metrics
-
-    @metrics.setter
-    def metrics(self, value: MetricsConfig) -> None:
-        """Backward compatibility: set metrics in observability."""
-        object.__setattr__(self.observability, "metrics", value)
-
-    # =========================================================================
-    # Backward compatibility for quality section
-    # =========================================================================
-
-    @property
-    def determinism(self) -> DeterminismConfig:
-        """Backward compatibility: access determinism from quality."""
-        return self.quality.determinism
-
-    @determinism.setter
-    def determinism(self, value: DeterminismConfig) -> None:
-        """Backward compatibility: set determinism in quality."""
-        object.__setattr__(self.quality, "determinism", value)
-
-    @property
-    def qc(self) -> QcConfig:
-        """Backward compatibility: access qc from quality."""
-        return self.quality.qc
-
-    @qc.setter
-    def qc(self, value: QcConfig) -> None:
-        """Backward compatibility: set qc in quality."""
-        object.__setattr__(self.quality, "qc", value)
-
-    @property
-    def hashing(self) -> HashingConfig:
-        """Backward compatibility: access hashing from quality."""
-        return self.quality.hashing
-
-    @hashing.setter
-    def hashing(self, value: HashingConfig) -> None:
-        """Backward compatibility: set hashing in quality."""
-        object.__setattr__(self.quality, "hashing", value)
-
-    @property
-    def normalization(self) -> NormalizationConfig:
-        """Backward compatibility: access normalization from quality."""
-        return self.quality.normalization
-
-    @normalization.setter
-    def normalization(self, value: NormalizationConfig) -> None:
-        """Backward compatibility: set normalization in quality."""
-        object.__setattr__(self.quality, "normalization", value)
-
-    # =========================================================================
-    # Backward compatibility for features section
-    # =========================================================================
-
-    @property
-    def interface_features(self) -> InterfaceFeaturesConfig:
-        """Backward compatibility: access interfaces from features."""
-        return self.features.interfaces
-
-    @interface_features.setter
-    def interface_features(self, value: InterfaceFeaturesConfig) -> None:
-        """Backward compatibility: set interfaces in features."""
-        object.__setattr__(self.features, "interfaces", value)
+    def id(self) -> str:
+        """Access pipeline_id from identity section."""
+        return self.identity.pipeline_id
 
     # =========================================================================
     # Computed properties
@@ -931,11 +609,6 @@ class PipelineConfig(BaseModel):
         return PipelineType.FULL
 
     @property
-    def entity_name(self) -> str:
-        """Alias for entity (backward compatibility)."""
-        return self.identity.entity
-
-    @property
     def serialization_mode(self) -> str:
         """Shortcut for transform.serialization_mode."""
         return self.transform.serialization_mode
@@ -963,6 +636,8 @@ class PipelineConfig(BaseModel):
                 f"Requested provider '{provider}' does not match config provider "
                 f"'{self.identity.provider}'"
             )
+        if self.provider_config is None:
+            raise ValueError("provider_config is not set")
         return self.provider_config
 
     # =========================================================================
@@ -972,143 +647,31 @@ class PipelineConfig(BaseModel):
     @model_validator(mode="after")
     def validate_provider_alignment(self) -> PipelineConfig:
         """Ensure provider_config provider aligns with identity.provider."""
-        if self.provider_config.provider != self.identity.provider:
-            raise ValueError(
-                "provider_config.provider must match identity.provider"
-            )
+        if self.provider_config is not None:
+            if self.provider_config.provider != self.identity.provider:
+                raise ValueError(
+                    "provider_config.provider must match identity.provider"
+                )
         return self
 
     @model_validator(mode="before")
     @classmethod
-    def migrate_legacy_layout(cls, data: Any) -> Any:
-        """Migrate flat legacy fields into decomposed sections."""
-        if not isinstance(data, dict):
-            return data
+    def migrate_legacy_format(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Delegate migration to ConfigMigrator."""
+        from bioetl.domain.configs.migration import ConfigMigrator
 
-        migrated = dict(data)
-
-        # -----------------------------------------------------------------
-        # Pack identity section from flat fields
-        # -----------------------------------------------------------------
-        if "identity" not in migrated:
-            identity_fields = {}
-            for field in ("id", "provider", "entity", "primary_key"):
-                if field in migrated:
-                    identity_fields[field] = migrated.pop(field)
-            if identity_fields:
-                migrated["identity"] = identity_fields
-
-        # -----------------------------------------------------------------
-        # Pack source section from flat fields
-        # -----------------------------------------------------------------
-        if "source" not in migrated:
-            source_fields = {}
-            for field in ("input_mode", "input_path", "batch_size"):
-                if field in migrated:
-                    source_fields[field] = migrated.pop(field)
-            # Handle csv_options -> csv
-            if "csv_options" in migrated:
-                source_fields["csv"] = migrated.pop("csv_options")
-            elif "csv" in migrated and "runtime" not in migrated:
-                # csv at root level goes to source
-                source_fields["csv"] = migrated.pop("csv")
-            if source_fields:
-                migrated["source"] = source_fields
-
-        # -----------------------------------------------------------------
-        # Pack sink section from flat fields
-        # -----------------------------------------------------------------
-        if "sink" not in migrated:
-            sink_fields = {}
-            for field in ("output_path", "dry_run"):
-                if field in migrated:
-                    sink_fields[field] = migrated.pop(field)
-            # Handle output section
-            if "output" in migrated:
-                output_val = migrated.pop("output")
-                if isinstance(output_val, dict):
-                    sink_fields["output"] = output_val
-            if sink_fields:
-                migrated["sink"] = sink_fields
-
-        # -----------------------------------------------------------------
-        # Pack stages section from pipeline dict + migrate primary_key
-        # -----------------------------------------------------------------
-        if "pipeline" in migrated:
-            pipeline_dict = migrated.pop("pipeline")
-            if isinstance(pipeline_dict, dict):
-                # Extract primary_key from pipeline dict -> identity
-                if "primary_key" in pipeline_dict:
-                    pk_from_pipeline = pipeline_dict.pop("primary_key")
-                    # Only use if identity.primary_key not already set
-                    if "identity" in migrated:
-                        if migrated["identity"].get("primary_key") is None:
-                            migrated["identity"]["primary_key"] = pk_from_pipeline
-                    else:
-                        migrated["identity"] = {"primary_key": pk_from_pipeline}
-
-                # Extract stages
-                if "stages" not in migrated:
-                    stages_fields = {}
-                    for field in ("extract", "transform", "load"):
-                        if field in pipeline_dict:
-                            stages_fields[field] = pipeline_dict[field]
-                    if stages_fields:
-                        migrated["stages"] = stages_fields
-
-        # -----------------------------------------------------------------
-        # Legacy runtime section packing
-        # -----------------------------------------------------------------
-        def _pack(section_key: str, keys: list[str]) -> None:
-            existing_section = (
-                migrated.get(section_key)
-                if isinstance(migrated.get(section_key), dict)
-                else None
-            )
-            keys_to_collect = list(keys)
-            if section_key in keys_to_collect and existing_section is not None:
-                keys_to_collect.remove(section_key)
-
-            collected = {
-                key: migrated.pop(key) for key in keys_to_collect if key in migrated
-            }
-            if not collected and existing_section is None:
-                return
-
-            target_section: dict[str, Any] = dict(existing_section or {})
-            nested_from_collected = collected.pop(section_key, None)
-            if isinstance(nested_from_collected, dict):
-                target_section |= nested_from_collected
-
-            for key, value in collected.items():
-                if (
-                    key in target_section
-                    and isinstance(target_section[key], dict)
-                    and isinstance(value, dict)
-                ):
-                    target_section[key] = {**target_section[key], **value}
-                else:
-                    target_section[key] = value
-
-            if target_section:
-                migrated[section_key] = target_section
-
-        _pack("runtime", ["pagination", "client", "http", "storage"])
-        _pack("observability", ["logging", "metrics"])
-        _pack("quality", ["determinism", "qc", "hashing", "normalization"])
-        _pack("features", ["features", "interface_features", "interfaces"])
-
-        return migrated
+        return ConfigMigrator.migrate(data)
 
 
 __all__ = [
-    # Decomposed config classes
-    "PipelineIdentity",
-    "DataSourceConfig",
-    "DataSinkConfig",
-    "PipelineStagesConfig",
     # Main config
     "PipelineConfig",
+    # Bounded context configs (re-exported for convenience)
+    "PipelineIdentityConfig",
+    "DataSourceConfig",
+    "DataSinkConfig",
+    "OutputOptionsConfig",
+    "CsvInputConfig",
     # Provider configs
     "BaseProviderConfig",
     "ChemblSourceConfig",
@@ -1120,11 +683,11 @@ __all__ = [
     "ObservabilityConfig",
     "QualityConfig",
     "FeatureFlagsConfig",
+    "PipelineStagesConfig",
     # Sub-section configs
     "PaginationConfig",
     "HttpClientConfig",
     "StorageConfig",
-    "CsvInputConfig",
     "LoggingConfig",
     "MetricsConfig",
     "DeterminismConfig",
@@ -1133,8 +696,8 @@ __all__ = [
     "CanonicalizationConfig",
     "BusinessKeyConfig",
     "InterfaceFeaturesConfig",
-    "OutputOptionsConfig",
     "NormalizationConfig",
+    "TransformConfig",
     # DEPRECATED: Legacy aliases (will be removed in future versions)
     "ClientConfig",  # Use HttpClientConfig
     "HttpClientDefaults",  # Use HttpClientConfig

--- a/src/bioetl/infrastructure/config/loader.py
+++ b/src/bioetl/infrastructure/config/loader.py
@@ -209,10 +209,10 @@ def _ensure_input_source_valid(
 ) -> None:
     """Проверяет доступность локальных файлов для CSV/id-only режимов."""
 
-    if config.input_mode not in {"csv", "id_only"}:
+    if config.source.input_mode not in {"csv", "id_only"}:
         return
 
-    input_path = config.input_path
+    input_path = config.source.input_path
     if not input_path:
         raise ConfigValidationError(
             "input_path must be provided when input_mode is 'csv' or 'id_only'"

--- a/src/bioetl/interfaces/cli/app.py
+++ b/src/bioetl/interfaces/cli/app.py
@@ -62,9 +62,15 @@ def _apply_output_override(pipeline_config: PipelineConfig, output: str | None) 
         return
     output_path = Path(output)
     output_path.mkdir(parents=True, exist_ok=True)
-    pipeline_config.output_path = str(output_path)
-    if hasattr(pipeline_config, "storage"):
-        pipeline_config.storage.output_path = str(output_path)
+    # Update frozen sink config using model_copy
+    new_sink = pipeline_config.sink.model_copy(update={"output_path": str(output_path)})
+    object.__setattr__(pipeline_config, "sink", new_sink)
+    # Also update storage if it exists
+    if hasattr(pipeline_config.runtime, "storage"):
+        new_storage = pipeline_config.runtime.storage.model_copy(
+            update={"output_path": str(output_path)}
+        )
+        object.__setattr__(pipeline_config.runtime, "storage", new_storage)
 
 
 def _create_orchestrator(

--- a/src/bioetl/interfaces/container_factory.py
+++ b/src/bioetl/interfaces/container_factory.py
@@ -72,14 +72,12 @@ def build_default_container(
 
     logger = logger_factory()
     metrics_port = _create_metrics_port()
-    converter_id = getattr(
-        getattr(config, "output", SimpleNamespace()), "converter", None
-    )
+    converter_id = getattr(config.sink.output, "converter", None)
     frame_converter = frame_converter_factory(converter_id)
 
     loader = loader_factory(
-        config=config.determinism,
-        qc_config=config.qc,
+        config=config.quality.determinism,
+        qc_config=config.quality.qc,
         metrics_port=metrics_port,
         converter=frame_converter,
     )

--- a/tests/bioetl/application/helpers/test_primary_key.py
+++ b/tests/bioetl/application/helpers/test_primary_key.py
@@ -14,16 +14,27 @@ from bioetl.domain.configs import (
 def _make_config(
     *,
     entity: str = "activity",
-    primary_key: str | None = None,
-    pipeline: dict | None = None,
+    primary_key: str | list[str] | None = None,
 ) -> PipelineConfig:
-    """Helper to create a minimal PipelineConfig for testing."""
+    """Helper to create a minimal PipelineConfig for testing.
+
+    Args:
+        entity: Entity name.
+        primary_key: Primary key - string or list of strings (will be converted to list).
+    """
+    # Convert string to list for new format
+    pk_list: list[str] = []
+    if primary_key is not None:
+        if isinstance(primary_key, str):
+            pk_list = [primary_key]
+        else:
+            pk_list = list(primary_key)
+
     return PipelineConfig(
         id=f"chembl.{entity}",
         provider="chembl",
         entity=entity,
-        primary_key=primary_key,
-        pipeline=pipeline or {},
+        primary_key=pk_list,
         input_mode="auto_detect",
         input_path=None,
         output_path="/tmp/out",
@@ -43,32 +54,24 @@ class TestResolvePrimaryKey:
     """Tests for resolve_primary_key function."""
 
     def test_explicit_primary_key_field(self) -> None:
-        """Primary key from config.primary_key takes precedence."""
+        """Primary key from identity.primary_key takes precedence."""
         config = _make_config(entity="activity", primary_key="custom_pk")
         assert resolve_primary_key(config) == "custom_pk"
 
-    def test_primary_key_from_pipeline_dict(self) -> None:
-        """Fallback to pipeline dict when primary_key field is not set."""
-        config = _make_config(
-            entity="activity",
-            primary_key=None,
-            pipeline={"primary_key": "legacy_pk"},
-        )
-        assert resolve_primary_key(config) == "legacy_pk"
-
-    def test_explicit_field_wins_over_pipeline_dict(self) -> None:
-        """Explicit primary_key field takes precedence over pipeline dict."""
-        config = _make_config(
-            entity="activity",
-            primary_key="explicit_pk",
-            pipeline={"primary_key": "legacy_pk"},
-        )
-        assert resolve_primary_key(config) == "explicit_pk"
+    def test_primary_key_list_uses_first_element(self) -> None:
+        """First element of primary_key list is used."""
+        config = _make_config(entity="activity", primary_key=["pk1", "pk2"])
+        assert resolve_primary_key(config) == "pk1"
 
     def test_entity_based_default(self) -> None:
         """Falls back to {entity_name}_id convention."""
         config = _make_config(entity="assay", primary_key=None)
         assert resolve_primary_key(config) == "assay_id"
+
+    def test_empty_primary_key_falls_back_to_entity(self) -> None:
+        """Empty primary_key list falls back to entity convention."""
+        config = _make_config(entity="molecule", primary_key=[])
+        assert resolve_primary_key(config) == "molecule_id"
 
     def test_fallback_parameter_used_when_needed(self) -> None:
         """Fallback parameter is used if resolution fails."""
@@ -109,22 +112,13 @@ class TestResolvePrimaryKeyWithFilter:
 class TestEdgeCases:
     """Edge case tests for primary key resolution."""
 
-    def test_empty_pipeline_dict(self) -> None:
-        """Empty pipeline dict does not cause issues."""
-        config = _make_config(entity="activity", primary_key=None, pipeline={})
-        assert resolve_primary_key(config) == "activity_id"
-
-    def test_pipeline_with_other_keys(self) -> None:
-        """Other keys in pipeline dict are ignored."""
-        config = _make_config(
-            entity="activity",
-            primary_key=None,
-            pipeline={"some_key": "value", "another": 123},
-        )
+    def test_none_primary_key_uses_entity_default(self) -> None:
+        """None primary_key falls back to entity_id convention."""
+        config = _make_config(entity="activity", primary_key=None)
         assert resolve_primary_key(config) == "activity_id"
 
     def test_empty_string_primary_key_uses_fallback(self) -> None:
         """Empty string primary_key triggers fallback logic."""
         config = _make_config(entity="activity", primary_key="")
-        # Empty string is falsy, so entity_name_id should be used
+        # Empty string is filtered out in list, so entity_name_id should be used
         assert resolve_primary_key(config) == "activity_id"

--- a/tests/bioetl/application/pipelines/chembl/test_config_resolution.py
+++ b/tests/bioetl/application/pipelines/chembl/test_config_resolution.py
@@ -52,14 +52,13 @@ def test_pk_resolution_from_field_config(dependencies):
     assert pipeline.API_FILTER_KEY == "custom_pk_id__in"
 
 
-def test_pk_resolution_from_pipeline_dict_config(dependencies):
-    """Test fallback to pipeline dict for legacy configs (config module)."""
+def test_pk_resolution_from_identity_primary_key_list_config(dependencies):
+    """Test resolution from identity.primary_key list (config module)."""
     config = PipelineConfig(
         id="chembl.test_entity",
         provider="chembl",
         entity="test_entity",
-        primary_key=None,
-        pipeline={"primary_key": "legacy_pk_id"},
+        primary_key=["my_pk_id", "secondary_pk"],  # Uses first element
         input_mode="auto_detect",
         input_path=None,
         output_path="/tmp/out",
@@ -75,8 +74,8 @@ def test_pk_resolution_from_pipeline_dict_config(dependencies):
     )
 
     pipeline = ChemblPipelineBase(config=config, **dependencies)
-    assert pipeline.ID_COLUMN == "legacy_pk_id"
-    assert pipeline.API_FILTER_KEY == "legacy_pk_id__in"
+    assert pipeline.ID_COLUMN == "my_pk_id"
+    assert pipeline.API_FILTER_KEY == "my_pk_id__in"
 
 
 def test_pk_resolution_default_config(dependencies):

--- a/tests/bioetl/application/pipelines/chembl/test_pk_resolution.py
+++ b/tests/bioetl/application/pipelines/chembl/test_pk_resolution.py
@@ -61,14 +61,13 @@ def test_pk_resolution_from_field(dependencies):
     assert pipeline.API_FILTER_KEY == "custom_pk_id__in"
 
 
-def test_pk_resolution_from_pipeline_dict(dependencies):
-    """Test fallback to pipeline dict for legacy configs."""
+def test_pk_resolution_from_identity_primary_key_list(dependencies):
+    """Test resolution from identity.primary_key list."""
     config = PipelineConfig(
         id="chembl.test_entity",
         provider="chembl",
         entity="test_entity",
-        primary_key=None,
-        pipeline={"primary_key": "legacy_pk_id"},
+        primary_key=["my_pk_id", "secondary_pk"],  # Uses first element
         input_mode="auto_detect",
         input_path=None,
         output_path="/tmp/out",
@@ -84,8 +83,8 @@ def test_pk_resolution_from_pipeline_dict(dependencies):
     )
 
     pipeline = ChemblPipelineBase(config=config, **dependencies)
-    assert pipeline.ID_COLUMN == "legacy_pk_id"
-    assert pipeline.API_FILTER_KEY == "legacy_pk_id__in"
+    assert pipeline.ID_COLUMN == "my_pk_id"
+    assert pipeline.API_FILTER_KEY == "my_pk_id__in"
 
 
 def test_pk_resolution_default(dependencies):

--- a/tests/bioetl/domain/test_pipeline_config.py
+++ b/tests/bioetl/domain/test_pipeline_config.py
@@ -29,7 +29,7 @@ def test_pipeline_config_migrates_legacy_flat_keys() -> None:
     )
 
     # Test decomposed identity section
-    assert config.identity.id == "test"
+    assert config.identity.pipeline_id == "test"
     assert config.identity.provider == "dummy"
     assert config.identity.entity == "entity"
 
@@ -57,10 +57,8 @@ def test_pipeline_config_migrates_legacy_flat_keys() -> None:
     # Test features section
     assert config.features.interfaces.rest_interface_enabled is True
 
-    # Test backward compatibility properties
+    # Test convenience properties (minimal set retained)
     assert config.id == "test"
     assert config.provider == "dummy"
     assert config.entity == "entity"
-    assert config.input_mode == "csv"
-    assert config.output_path == "/tmp/output"
-    assert config.csv_options.delimiter == ";"
+    assert config.entity_name == "entity"


### PR DESCRIPTION
Transform PipelineConfig into a lightweight aggregate root that composes specialized bounded context configurations instead of maintaining 20+ backward compatibility property accessors.

Changes:
- Add ConfigMigrator for legacy flat format migration
- Compose PipelineConfig from identity, source, sink sections
- Remove legacy property accessors (input_mode, output_path, batch_size, etc.)
- Keep minimal convenience accessors: id, provider, entity, entity_name
- Update all usages to access via decomposed sections:
  - config.source.input_mode instead of config.input_mode
  - config.sink.output_path instead of config.output_path
  - config.identity.primary_key instead of config.primary_key
  - config.quality.determinism instead of config.determinism
- Remove legacy pipeline dict fallback for primary_key resolution
- Update tests to reflect new structure

BREAKING CHANGES:
- Removed: config.input_mode -> use config.source.input_mode
- Removed: config.input_path -> use config.source.input_path
- Removed: config.batch_size -> use config.source.batch_size
- Removed: config.output_path -> use config.sink.output_path
- Removed: config.dry_run -> use config.sink.dry_run
- Removed: config.csv_options -> use config.source.csv
- Removed: config.primary_key -> use config.identity.primary_key
- Removed: config.pipeline dict fallback for primary_key
- Removed: config.determinism -> use config.quality.determinism
- Removed: config.qc -> use config.quality.qc