### PR TITLE
Organize application layer init files

### DIFF
--- a/src/bioetl/application/__init__.py
+++ b/src/bioetl/application/__init__.py
@@ -1,5 +1,14 @@
 """
 Application layer package.
+
+Provides core orchestration components for pipeline assembly and execution.
 """
 
-__all__ = []
+from bioetl.application.container import PipelineContainer, create_default_container_factory
+from bioetl.application.orchestrator import PipelineOrchestrator
+
+__all__ = [
+    "PipelineContainer",
+    "PipelineOrchestrator",
+    "create_default_container_factory",
+]

--- a/src/bioetl/application/factories/__init__.py
+++ b/src/bioetl/application/factories/__init__.py
@@ -1,3 +1,15 @@
 """
 Application factories package.
+
+Provides factories for creating pipeline services and components.
 """
+
+from bioetl.application.factories.hooks import PipelineHookFactory
+from bioetl.application.factories.record_source import RecordSourceFactory
+from bioetl.application.factories.services import ProviderServiceFactory
+
+__all__ = [
+    "PipelineHookFactory",
+    "ProviderServiceFactory",
+    "RecordSourceFactory",
+]

--- a/src/bioetl/application/pipelines/__init__.py
+++ b/src/bioetl/application/pipelines/__init__.py
@@ -1,3 +1,24 @@
 """
-Pipelines.
+Pipelines package.
+
+Provides base pipeline implementation, contracts, and factory registry.
 """
+
+from bioetl.application.pipelines.base import PipelineBase
+from bioetl.application.pipelines.contracts import PipelineContainerABC, PipelineFactoryABC
+from bioetl.application.pipelines.registry import (
+    get_factory,
+    get_pipeline_factory,
+    get_registered_factories,
+    get_registered_pipelines,
+)
+
+__all__ = [
+    "PipelineBase",
+    "PipelineContainerABC",
+    "PipelineFactoryABC",
+    "get_factory",
+    "get_pipeline_factory",
+    "get_registered_factories",
+    "get_registered_pipelines",
+]

--- a/src/bioetl/application/pipelines/chembl/__init__.py
+++ b/src/bioetl/application/pipelines/chembl/__init__.py
@@ -1,3 +1,13 @@
 """
 ChEMBL pipelines.
+
+Provides pipeline implementation and factory for ChEMBL data source.
 """
+
+from bioetl.application.pipelines.chembl.base import ChemblPipelineBase
+from bioetl.application.pipelines.chembl.factories import ChemblPipelineFactory
+
+__all__ = [
+    "ChemblPipelineBase",
+    "ChemblPipelineFactory",
+]


### PR DESCRIPTION
Add explicit exports to previously empty __init__.py files in the application layer:

- application/__init__.py: export PipelineContainer, PipelineOrchestrator
- application/pipelines/__init__.py: export PipelineBase, contracts, registry
- application/factories/__init__.py: export factory classes
- application/pipelines/chembl/__init__.py: export ChemblPipelineBase, factory

This follows the established pattern in the codebase and improves discoverability of public APIs.