### PR TITLE
Unify class naming conventions across codebase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,123 @@
+# Contributing to BioETL
+
+## Class Naming Convention
+
+This project follows a strict naming convention for classes to ensure consistency and clarity.
+
+### Rules
+
+#### 1. `*Impl` Suffix - Interface Implementations
+
+Use the `Impl` suffix **only** for classes that implement an abstract base class (ABC) interface.
+
+**Correct:**
+```python
+class ChemblHttpClientImpl(DataClientABC):
+    """Implements DataClientABC for ChEMBL API."""
+    pass
+
+class StructuredLoggerImpl(LoggingPortABC):
+    """Implements LoggingPortABC using structlog."""
+    pass
+```
+
+**Incorrect:**
+```python
+# Wrong: No ABC interface exists
+class BaseWriterImpl:  # Should be: BaseWriter
+    pass
+```
+
+#### 2. `*Factory` Suffix - Factory Classes
+
+Use the `Factory` suffix for classes that create other objects. Factories may or may not have an ABC interface.
+
+```python
+class PipelineHookFactory:
+    """Creates pipeline hook instances."""
+
+    @staticmethod
+    def create_logging_hook() -> PipelineHookABC:
+        return LoggingPipelineHookImpl()
+```
+
+#### 3. `*ABC` Suffix - Abstract Base Classes
+
+Use the `ABC` suffix for abstract base classes that define interfaces.
+
+```python
+from abc import ABC, abstractmethod
+
+class DataClientABC(ABC):
+    """Abstract interface for data clients."""
+
+    @abstractmethod
+    def fetch(self, url: str) -> dict:
+        pass
+```
+
+#### 4. No Suffix - Standalone Classes
+
+Classes without abstraction should have no suffix.
+
+```python
+class HttpTransport:
+    """HTTP transport utility (no ABC interface)."""
+    pass
+
+class CircuitBreaker:
+    """Circuit breaker pattern implementation."""
+    pass
+```
+
+### Summary Table
+
+| Suffix | When to Use | Example |
+|--------|-------------|---------|
+| `*Impl` | Implements an `*ABC` interface | `ChemblHttpClientImpl(DataClientABC)` |
+| `*Factory` | Creates other objects | `PipelineHookFactory` |
+| `*ABC` | Defines an abstract interface | `DataClientABC(ABC)` |
+| (none) | Standalone class without abstraction | `HttpTransport` |
+
+### Backward Compatibility
+
+When renaming classes, always provide a deprecated alias:
+
+```python
+class NewClassName:
+    """The actual implementation."""
+    pass
+
+# Deprecated alias for backward compatibility (will be removed in next major version)
+OldClassName = NewClassName
+
+__all__ = ["NewClassName", "OldClassName"]
+```
+
+### Breaking Changes
+
+Class renames are breaking changes and should be:
+1. Planned for major releases
+2. Documented in CHANGELOG
+3. Accompanied by deprecated aliases for one major version
+
+## Code Style
+
+- Follow PEP 8
+- Use type hints
+- Write docstrings for public APIs
+- Keep functions focused and small
+
+## Testing
+
+- Write tests for new functionality
+- Ensure all tests pass before submitting PR
+- Aim for high test coverage
+
+## Pull Request Process
+
+1. Create a feature branch
+2. Make your changes
+3. Write/update tests
+4. Update documentation if needed
+5. Submit PR with clear description

--- a/src/bioetl/infrastructure/clients/base/abc_impls.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_impls.yaml
@@ -55,7 +55,7 @@ NormalizationServiceABC:
   default_factory: bioetl.infrastructure.transform.factories.default_normalization_service
   implementations:
     Default: bioetl.infrastructure.transform.impl.default_normalization_transformer_impl.DefaultNormalizationTransformerImpl
-    Chembl: bioetl.infrastructure.transform.impl.chembl_normalization_service_impl.ChemblNormalizationServiceImpl
+    Chembl: bioetl.infrastructure.transform.impl.chembl_normalization_service_impl.ChemblNormalizationService
 
 HasherABC:
   default_factory: bioetl.infrastructure.transform.factories.default_hasher

--- a/src/bioetl/infrastructure/output/factories.py
+++ b/src/bioetl/infrastructure/output/factories.py
@@ -8,24 +8,24 @@ from bioetl.domain.clients.base.output.contracts import (
 )
 from bioetl.domain.configs import DeterminismConfig, QcConfig
 from bioetl.domain.observability import MetricsPortABC
-from bioetl.infrastructure.output.impl.csv_writer import CsvWriterImpl
-from bioetl.infrastructure.output.impl.metadata_writer import MetadataWriterImpl
+from bioetl.infrastructure.output.impl.csv_writer import CsvWriter
+from bioetl.infrastructure.output.impl.metadata_writer import MetadataWriter
 from bioetl.infrastructure.output.impl.quality_report import QualityReportImpl
 from bioetl.infrastructure.output.unified_loader_impl import (
     UnifiedLoaderImpl,
 )
 
 
-def default_writer() -> CsvWriterImpl:
+def default_writer() -> CsvWriter:
     """Create the default CSV writer implementation."""
 
-    return CsvWriterImpl()
+    return CsvWriter()
 
 
-def default_metadata_writer() -> MetadataWriterImpl:
+def default_metadata_writer() -> MetadataWriter:
     """Create the metadata writer that stores sidecar files."""
 
-    return MetadataWriterImpl()
+    return MetadataWriter()
 
 
 def default_quality_reporter() -> QualityReportABC:

--- a/src/bioetl/infrastructure/output/impl/base_writer.py
+++ b/src/bioetl/infrastructure/output/impl/base_writer.py
@@ -14,7 +14,7 @@ from bioetl.domain.clients.base.output.contracts import WriteResult
 from bioetl.infrastructure.output.column_order import apply_column_order
 
 
-class BaseWriterImpl:
+class BaseWriter:
     """Template for concrete writers with shared bookkeeping."""
 
     def __init__(
@@ -61,3 +61,9 @@ class BaseWriterImpl:
 
     def _write_frame(self, df: pd.DataFrame, path: Path) -> None:
         raise NotImplementedError
+
+
+# Deprecated alias for backward compatibility (will be removed in next major version)
+BaseWriterImpl = BaseWriter
+
+__all__ = ["BaseWriter", "BaseWriterImpl"]

--- a/src/bioetl/infrastructure/output/impl/csv_writer.py
+++ b/src/bioetl/infrastructure/output/impl/csv_writer.py
@@ -9,10 +9,10 @@ from pathlib import Path
 import pandas as pd
 
 from bioetl.infrastructure.files.checksum import compute_file_sha256
-from bioetl.infrastructure.output.impl.base_writer import BaseWriterImpl
+from bioetl.infrastructure.output.impl.base_writer import BaseWriter
 
 
-class CsvWriterImpl(BaseWriterImpl):
+class CsvWriter(BaseWriter):
     """
     Запись CSV.
     Делегирует атомарность и хеширование внешнему фасаду.
@@ -27,3 +27,9 @@ class CsvWriterImpl(BaseWriterImpl):
     def has_format_support(self, fmt: str) -> bool:
         """Return True if writer can handle the requested format."""
         return fmt.lower() == "csv"
+
+
+# Deprecated alias for backward compatibility (will be removed in next major version)
+CsvWriterImpl = CsvWriter
+
+__all__ = ["CsvWriter", "CsvWriterImpl"]

--- a/src/bioetl/infrastructure/output/impl/metadata_writer.py
+++ b/src/bioetl/infrastructure/output/impl/metadata_writer.py
@@ -23,7 +23,7 @@ def build_quality_report_table(
     return reporter.build_quality_report(df, min_coverage=min_coverage)
 
 
-class MetadataWriterImpl:
+class MetadataWriter:
     """
     Запись метаданных и QC отчетов.
     """
@@ -65,3 +65,9 @@ class MetadataWriterImpl:
     def build_checksums(self, paths: list[Path]) -> dict[str, str]:
         """Calculate SHA256 checksums for a list of artifact paths."""
         return compute_files_sha256(paths)
+
+
+# Deprecated alias for backward compatibility (will be removed in next major version)
+MetadataWriterImpl = MetadataWriter
+
+__all__ = ["MetadataWriter", "MetadataWriterImpl", "build_quality_report_table"]

--- a/src/bioetl/infrastructure/output/impl/parquet_writer.py
+++ b/src/bioetl/infrastructure/output/impl/parquet_writer.py
@@ -7,10 +7,10 @@ from pathlib import Path
 
 import pandas as pd
 
-from bioetl.infrastructure.output.impl.base_writer import BaseWriterImpl
+from bioetl.infrastructure.output.impl.base_writer import BaseWriter
 
 
-class ParquetWriterImpl(BaseWriterImpl):
+class ParquetWriter(BaseWriter):
     """
     Запись Parquet.
     """
@@ -24,3 +24,9 @@ class ParquetWriterImpl(BaseWriterImpl):
     def has_format_support(self, fmt: str) -> bool:
         """Return True if parquet format is requested."""
         return fmt.lower() == "parquet"
+
+
+# Deprecated alias for backward compatibility (will be removed in next major version)
+ParquetWriterImpl = ParquetWriter
+
+__all__ = ["ParquetWriter", "ParquetWriterImpl"]

--- a/src/bioetl/infrastructure/transform/impl/__init__.py
+++ b/src/bioetl/infrastructure/transform/impl/__init__.py
@@ -1,7 +1,8 @@
 """Concrete transform implementations."""
 
 from bioetl.infrastructure.transform.impl.chembl_normalization_service_impl import (
-    ChemblNormalizationServiceImpl,
+    ChemblNormalizationService,
+    ChemblNormalizationServiceImpl,  # Deprecated alias
 )
 from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl import (
     DefaultNormalizationTransformerImpl,
@@ -11,5 +12,6 @@ from bioetl.infrastructure.transform.impl.hasher import HasherImpl
 __all__ = [
     "HasherImpl",
     "DefaultNormalizationTransformerImpl",
-    "ChemblNormalizationServiceImpl",
+    "ChemblNormalizationService",
+    "ChemblNormalizationServiceImpl",  # Deprecated alias
 ]

--- a/src/bioetl/infrastructure/transform/impl/base_normalizer.py
+++ b/src/bioetl/infrastructure/transform/impl/base_normalizer.py
@@ -12,7 +12,7 @@ from bioetl.domain.transform.normalizers import normalize_array, normalize_recor
 from bioetl.domain.transform.serializers import serialize_nested
 
 
-class BaseNormalizationServiceImpl:
+class BaseNormalizationService:
     """Provide reusable normalization helpers for normalization services.
 
     Args:
@@ -306,4 +306,7 @@ class BaseNormalizationServiceImpl:
         return False
 
 
-__all__ = ["BaseNormalizationServiceImpl"]
+# Deprecated alias for backward compatibility (will be removed in next major version)
+BaseNormalizationServiceImpl = BaseNormalizationService
+
+__all__ = ["BaseNormalizationService", "BaseNormalizationServiceImpl"]

--- a/src/bioetl/infrastructure/transform/impl/chembl_normalization_service_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/chembl_normalization_service_impl.py
@@ -17,7 +17,7 @@ from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl
 )
 
 
-class ChemblNormalizationServiceImpl(DefaultNormalizationTransformerImpl):
+class ChemblNormalizationService(DefaultNormalizationTransformerImpl):
     """Normalization service for ChEMBL records.
 
     DEPRECATED: Use DefaultNormalizationTransformerImpl directly.
@@ -29,7 +29,7 @@ class ChemblNormalizationServiceImpl(DefaultNormalizationTransformerImpl):
 
     def __init__(self, config: NormalizationConfigProviderProtocol):
         warnings.warn(
-            "ChemblNormalizationServiceImpl is deprecated. "
+            "ChemblNormalizationService is deprecated. "
             "Use DefaultNormalizationTransformerImpl(config, empty_value=None, "
             "serialize_array_in_series=False) instead.",
             DeprecationWarning,
@@ -43,8 +43,15 @@ class ChemblNormalizationServiceImpl(DefaultNormalizationTransformerImpl):
         )
 
 
+# Deprecated alias for backward compatibility (will be removed in next major version)
+ChemblNormalizationServiceImpl = ChemblNormalizationService
+
 # Type alias for backward compatibility
 NormalizedRecord = dict[str, Any]
 
 
-__all__ = ["ChemblNormalizationServiceImpl", "NormalizedRecord"]
+__all__ = [
+    "ChemblNormalizationService",
+    "ChemblNormalizationServiceImpl",
+    "NormalizedRecord",
+]

--- a/src/bioetl/infrastructure/transform/impl/default_normalization_transformer_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/default_normalization_transformer_impl.py
@@ -12,12 +12,12 @@ from bioetl.domain.transform.contracts import (
 from bioetl.domain.transform.serializers import serialize_nested
 from bioetl.infrastructure.transform.impl import normalize
 from bioetl.infrastructure.transform.impl.base_normalizer import (
-    BaseNormalizationServiceImpl,
+    BaseNormalizationService,
 )
 
 
 class DefaultNormalizationTransformerImpl(
-    BaseNormalizationServiceImpl, NormalizationServiceABC
+    BaseNormalizationService, NormalizationServiceABC
 ):
     """
     Unified normalization service for all data sources.


### PR DESCRIPTION
BREAKING CHANGE: Classes without ABC interfaces renamed to remove Impl suffix. Deprecated aliases provided for backward compatibility.

Renamed classes:
- BaseWriterImpl → BaseWriter
- CsvWriterImpl → CsvWriter
- ParquetWriterImpl → ParquetWriter
- MetadataWriterImpl → MetadataWriter
- BaseNormalizationServiceImpl → BaseNormalizationService
- ChemblNormalizationServiceImpl → ChemblNormalizationService

Convention established:
- *Impl suffix: only for classes implementing *ABC interfaces
- *Factory suffix: for factory classes
- *ABC suffix: for abstract base classes
- No suffix: for standalone classes without abstraction

All old names remain available as deprecated aliases and will be removed in the next major version.

Added CONTRIBUTING.md documenting the naming convention.