### PR TITLE
Create service for legacy config format migration

### DIFF
--- a/src/bioetl/domain/configs/migration.py
+++ b/src/bioetl/domain/configs/migration.py
@@ -1,15 +1,22 @@
 """Configuration migration utilities.
 
-Handles migration of legacy pipeline configuration formats to the new decomposed structure.
+Handles migration of legacy pipeline configuration formats to the current structure.
+
+Supported versions:
+- v1 (flat legacy): entity, provider at root + sources section → current nested format
+- v2 (nested): identity section already present → minimal migration
+
+The migrator is idempotent: running it multiple times produces the same result.
 """
 
 from __future__ import annotations
 
+import warnings
 from typing import Any
 
 
 class ConfigMigrator:
-    """Migrates legacy flat pipeline configs to the new decomposed structure.
+    """Migrates legacy pipeline configs to the current decomposed structure.
 
     This class handles backward compatibility by converting:
     - Flat fields (id, provider, entity) -> identity section
@@ -19,6 +26,8 @@ class ConfigMigrator:
     - Flat observability fields -> observability section
     - Flat quality fields -> quality section
     - Flat feature fields -> features section
+    - Legacy sources section -> provider_config
+    - Legacy client config keys (timeout -> timeout_sec, etc.)
     """
 
     # Fields belonging to each section
@@ -33,7 +42,7 @@ class ConfigMigrator:
 
     @classmethod
     def migrate(cls, data: dict[str, Any]) -> dict[str, Any]:
-        """Migrate legacy config format to new decomposed structure.
+        """Migrate legacy config format to current decomposed structure.
 
         Args:
             data: Raw configuration dictionary (possibly in legacy format).
@@ -45,29 +54,107 @@ class ConfigMigrator:
             return data
 
         migrated = dict(data)
+        version = cls._detect_version(migrated)
 
-        # Step 1: Handle entity_name -> entity alias
-        cls._migrate_entity_name_alias(migrated)
+        if version == 1:
+            warnings.warn(
+                "Legacy v1 config format detected. "
+                "Please update to v2 format with identity/source/sink sections. "
+                "See docs/migration.md",
+                DeprecationWarning,
+                stacklevel=4,
+            )
+            cls._migrate_v1_to_v2(migrated)
 
-        # Step 2: Pack identity section
-        cls._pack_identity(migrated)
-
-        # Step 3: Pack source section
-        cls._pack_source(migrated)
-
-        # Step 4: Pack sink section
-        cls._pack_sink(migrated)
-
-        # Step 5: Pack stages from pipeline dict
-        cls._pack_stages(migrated)
-
-        # Step 6: Pack section configs (runtime, observability, quality, features)
-        cls._pack_section("runtime", cls.RUNTIME_FIELDS, migrated)
-        cls._pack_section("observability", cls.OBSERVABILITY_FIELDS, migrated)
-        cls._pack_section("quality", cls.QUALITY_FIELDS, migrated)
-        cls._pack_section("features", cls.FEATURE_FIELDS, migrated)
+        # Always apply current format normalization (idempotent)
+        cls._normalize_current_format(migrated)
 
         return migrated
+
+    @classmethod
+    def _detect_version(cls, data: dict[str, Any]) -> int:
+        """Detect configuration format version.
+
+        Returns:
+            1 for legacy flat format (entity/provider at root without identity section)
+            2 for current nested format (identity section present)
+        """
+        # v2: has identity section
+        if "identity" in data:
+            return 2
+
+        # v1: has flat entity/provider or legacy sources section
+        if "entity" in data or "entity_name" in data:
+            if "provider" in data or "sources" in data:
+                return 1
+
+        # Default to v2 (assume current format)
+        return 2
+
+    @classmethod
+    def _migrate_v1_to_v2(cls, data: dict[str, Any]) -> None:
+        """Migrate v1 (flat legacy) format to v2 (nested) format.
+
+        This handles the original flat config format with:
+        - entity_name as alias for entity
+        - sources section with provider configs
+        - storage section with output_path
+        - pipeline section with name and stages
+        """
+        # Step 1: Handle entity_name -> entity alias
+        cls._migrate_entity_name_alias(data)
+
+        # Step 2: Generate id from pipeline.name or provider.entity
+        cls._generate_pipeline_id(data)
+
+        # Step 3: Extract output_path from storage section
+        cls._migrate_storage_output_path(data)
+
+        # Step 4: Extract batch_size from sources section
+        cls._migrate_batch_size_from_sources(data)
+
+        # Step 5: Extract provider_config from sources section
+        cls._migrate_provider_config_from_sources(data)
+
+        # Step 6: Remove legacy sources section
+        data.pop("sources", None)
+
+        # Step 7: Migrate api_base_url to provider_config
+        cls._migrate_api_base_url(data)
+
+    @classmethod
+    def _normalize_current_format(cls, data: dict[str, Any]) -> None:
+        """Normalize current format (idempotent operations).
+
+        These transformations are safe to run multiple times.
+        """
+        # Handle entity_name alias (can appear in both v1 and v2)
+        cls._migrate_entity_name_alias(data)
+
+        # Pack identity section
+        cls._pack_identity(data)
+
+        # Pack source section
+        cls._pack_source(data)
+
+        # Pack sink section
+        cls._pack_sink(data)
+
+        # Pack stages from pipeline dict
+        cls._pack_stages(data)
+
+        # Pack section configs (runtime, observability, quality, features)
+        cls._pack_section("runtime", cls.RUNTIME_FIELDS, data)
+        cls._pack_section("observability", cls.OBSERVABILITY_FIELDS, data)
+        cls._pack_section("quality", cls.QUALITY_FIELDS, data)
+        cls._pack_section("features", cls.FEATURE_FIELDS, data)
+
+        # Fix legacy client config keys in runtime section
+        cls._migrate_runtime_client_keys(data)
+
+    # =========================================================================
+    # V1 -> V2 migration helpers
+    # =========================================================================
 
     @classmethod
     def _migrate_entity_name_alias(cls, data: dict[str, Any]) -> None:
@@ -76,6 +163,115 @@ class ConfigMigrator:
             data["entity"] = data.pop("entity_name")
         elif "entity_name" in data:
             data.pop("entity_name")
+
+    @classmethod
+    def _generate_pipeline_id(cls, data: dict[str, Any]) -> None:
+        """Generate pipeline id from pipeline.name or provider.entity."""
+        if "id" in data:
+            return
+
+        pipeline_section = data.get("pipeline")
+        if isinstance(pipeline_section, dict) and pipeline_section.get("name"):
+            data["id"] = pipeline_section["name"]
+        elif data.get("provider") and data.get("entity"):
+            data["id"] = f"{data['provider']}.{data['entity']}"
+
+    @classmethod
+    def _migrate_storage_output_path(cls, data: dict[str, Any]) -> None:
+        """Extract output_path from storage section."""
+        if "output_path" in data:
+            return
+
+        storage_section = data.get("storage")
+        if isinstance(storage_section, dict) and "output_path" in storage_section:
+            data["output_path"] = storage_section["output_path"]
+
+    @classmethod
+    def _migrate_batch_size_from_sources(cls, data: dict[str, Any]) -> None:
+        """Extract batch_size from legacy sources section."""
+        if "batch_size" in data:
+            return
+
+        sources_section = data.get("sources")
+        if not isinstance(sources_section, dict):
+            return
+
+        provider = data.get("provider")
+        source_entry: Any | None = None
+        if provider and provider in sources_section:
+            source_entry = sources_section[provider]
+        elif len(sources_section) == 1:
+            source_entry = next(iter(sources_section.values()))
+
+        if isinstance(source_entry, dict):
+            batch_size = source_entry.get("batch_size")
+            if isinstance(batch_size, int):
+                data["batch_size"] = batch_size
+
+    @classmethod
+    def _migrate_provider_config_from_sources(cls, data: dict[str, Any]) -> None:
+        """Extract provider_config from legacy sources section."""
+        if "provider_config" in data:
+            return
+
+        sources_section = data.get("sources")
+        if not isinstance(sources_section, dict):
+            return
+
+        provider = data.get("provider")
+        source_entry: Any | None = None
+        if provider and provider in sources_section:
+            source_entry = sources_section[provider]
+        elif len(sources_section) == 1:
+            source_entry = next(iter(sources_section.values()))
+
+        if not isinstance(source_entry, dict):
+            return
+
+        provider_config = dict(source_entry)
+        if "provider" not in provider_config and provider:
+            provider_config["provider"] = provider
+        data["provider_config"] = provider_config
+
+    @classmethod
+    def _migrate_api_base_url(cls, data: dict[str, Any]) -> None:
+        """Migrate api_base_url to provider_config.base_url."""
+        if "api_base_url" not in data:
+            return
+
+        provider_conf = data.get("provider_config")
+        if isinstance(provider_conf, dict):
+            provider_conf["base_url"] = data.pop("api_base_url")
+        else:
+            data.pop("api_base_url")
+
+    @classmethod
+    def _migrate_runtime_client_keys(cls, data: dict[str, Any]) -> None:
+        """Fix legacy client config keys in runtime section."""
+        runtime = data.get("runtime")
+        if not isinstance(runtime, dict):
+            return
+
+        client = runtime.get("client")
+        if not isinstance(client, dict):
+            return
+
+        # Legacy key mappings
+        legacy_mappings = {
+            "timeout": "timeout_sec",
+            "rate_limit": "rate_limit_per_sec",
+            "backoff": "backoff_factor",
+        }
+
+        for old_key, new_key in legacy_mappings.items():
+            if old_key in client and new_key not in client:
+                client[new_key] = client.pop(old_key)
+            elif old_key in client:
+                client.pop(old_key)
+
+    # =========================================================================
+    # Section packing helpers (v2 normalization)
+    # =========================================================================
 
     @classmethod
     def _pack_identity(cls, data: dict[str, Any]) -> None:

--- a/src/bioetl/infrastructure/config/loader.py
+++ b/src/bioetl/infrastructure/config/loader.py
@@ -7,7 +7,7 @@ from typing import Any, Iterable
 
 from pydantic import ValidationError
 
-from bioetl.domain.configs import PipelineConfig
+from bioetl.domain.configs import ConfigMigrator, PipelineConfig
 from bioetl.domain.errors import ConfigError, ConfigValidationError
 from bioetl.domain.schemas import register_schemas
 from bioetl.domain.schemas.fields import build_field_configs_from_schema
@@ -120,9 +120,15 @@ def _build_config(
     if cli_overrides:
         cli_values = resolve_env_placeholders(cli_overrides)
         merged = apply_deep_merge(merged, cli_values)
-    _migrate_legacy_pipeline_config(merged)
 
-    provider_id = merged.get("provider")
+    # Migration is handled by PipelineConfig.migrate_legacy_format validator,
+    # which delegates to ConfigMigrator. We also apply it here to ensure
+    # provider_config is extracted from sources before provider validation.
+    merged = ConfigMigrator.migrate(merged)
+
+    # After migration, provider is in identity section
+    identity = merged.get("identity", {})
+    provider_id = identity.get("provider") if isinstance(identity, dict) else None
     if isinstance(provider_id, str):
         _ensure_provider_registered(provider_id)
 
@@ -269,117 +275,6 @@ def _iter_candidate_roots(
             continue
         seen.add(base)
         yield base
-
-
-def _migrate_legacy_pipeline_config(config: dict[str, Any]) -> None:
-    """Приводит устаревшие конфиги (entity_name, sources и т.д.) к актуальной схеме."""
-
-    entity_alias = config.get("entity") or config.get("entity_name")
-    if "entity" not in config and entity_alias:
-        config["entity"] = entity_alias
-    config.pop("entity_name", None)
-
-    provider = config.get("provider")
-    pipeline_section = config.get("pipeline")
-    if "id" not in config:
-        if isinstance(pipeline_section, dict) and pipeline_section.get("name"):
-            config["id"] = pipeline_section["name"]
-        elif provider and config.get("entity"):
-            config["id"] = f"{provider}.{config['entity']}"
-
-    if "output_path" not in config:
-        storage_section = config.get("storage")
-        if isinstance(storage_section, dict) and "output_path" in storage_section:
-            config["output_path"] = storage_section["output_path"]
-
-    if "batch_size" not in config:
-        batch_size = _resolve_batch_size_from_sources(config)
-        if batch_size is not None:
-            config["batch_size"] = batch_size
-
-    if "provider_config" not in config:
-        provider_config = _extract_provider_config(config)
-        if provider_config is not None:
-            config["provider_config"] = provider_config
-
-    config.pop("sources", None)
-
-    def _pack(target_section: str, keys: list[str]) -> None:
-        if target_section not in config:
-            config[target_section] = {}
-        target = config[target_section]
-        if not isinstance(target, dict):
-            return
-
-        for key in keys:
-            if key in config:
-                target[key] = config.pop(key)
-
-    _pack("runtime", ["pagination", "client", "storage", "csv", "csv_options"])
-    _pack("observability", ["logging", "metrics"])
-    _pack("quality", ["determinism", "qc", "hashing", "normalization"])
-    _pack("features", ["features", "interface_features", "interfaces"])
-    _pack("output", ["output"])
-
-    # Fix legacy client config keys
-    runtime = config.get("runtime")
-    if isinstance(runtime, dict):
-        client = runtime.get("client")
-        if isinstance(client, dict):
-            if "timeout" in client:
-                client["timeout_sec"] = client.pop("timeout")
-            if "rate_limit" in client:
-                client["rate_limit_per_sec"] = client.pop("rate_limit")
-            if "backoff" in client:
-                client["backoff_factor"] = client.pop("backoff")
-
-    # Fix legacy api_base_url
-    if "api_base_url" in config:
-        provider_conf = config.get("provider_config")
-        if isinstance(provider_conf, dict):
-            provider_conf["base_url"] = config.pop("api_base_url")
-        else:
-            config.pop("api_base_url")
-
-
-def _resolve_batch_size_from_sources(config: dict[str, Any]) -> int | None:
-    sources_section = config.get("sources")
-    if not isinstance(sources_section, dict):
-        return None
-
-    provider = config.get("provider")
-    source_entry: Any | None = None
-    if provider and provider in sources_section:
-        source_entry = sources_section[provider]
-    elif len(sources_section) == 1:
-        source_entry = next(iter(sources_section.values()))
-
-    if isinstance(source_entry, dict):
-        batch_size = source_entry.get("batch_size")
-        if isinstance(batch_size, int):
-            return batch_size
-    return None
-
-
-def _extract_provider_config(config: dict[str, Any]) -> dict[str, Any] | None:
-    sources_section = config.get("sources")
-    if not isinstance(sources_section, dict):
-        return None
-
-    provider = config.get("provider")
-    source_entry: Any | None = None
-    if provider and provider in sources_section:
-        source_entry = sources_section[provider]
-    elif len(sources_section) == 1:
-        source_entry = next(iter(sources_section.values()))
-
-    if not isinstance(source_entry, dict):
-        return None
-
-    provider_config = dict(source_entry)
-    if "provider" not in provider_config and provider:
-        provider_config["provider"] = provider
-    return provider_config
 
 
 __all__ = [

--- a/tests/bioetl/domain/test_config_loader.py
+++ b/tests/bioetl/domain/test_config_loader.py
@@ -69,7 +69,7 @@ def test_env_placeholder_resolved_from_env(
 
     config = get_pipeline_config_from_path(config_path)
 
-    assert config.primary_key == "custom_pk"
+    assert config.identity.primary_key == ["custom_pk"]
 
 
 def test_env_placeholder_falls_back_to_default(
@@ -89,7 +89,7 @@ def test_env_placeholder_falls_back_to_default(
 
     config = get_pipeline_config_from_path(config_path)
 
-    assert config.primary_key == "molecule_chembl_id"
+    assert config.identity.primary_key == ["molecule_chembl_id"]
 
 
 def test_extra_field_triggers_validation_error(
@@ -334,8 +334,8 @@ batch_size: 25
 
     config = get_pipeline_config("chembl.activity", base_dir=base_dir)
 
-    assert config.output_path == "/tmp/out"  # pipeline overrides profile
-    assert config.batch_size == 10
+    assert config.sink.output_path == "/tmp/out"  # pipeline overrides profile
+    assert config.source.batch_size == 10
     assert config.provider_config.client.timeout_sec == 10
 
 

--- a/tests/bioetl/domain/test_config_migration.py
+++ b/tests/bioetl/domain/test_config_migration.py
@@ -1,0 +1,400 @@
+"""Tests for ConfigMigrator."""
+
+import warnings
+from copy import deepcopy
+
+import pytest
+
+from bioetl.domain.configs.migration import ConfigMigrator
+
+
+class TestVersionDetection:
+    """Tests for version detection logic."""
+
+    def test_detects_v2_when_identity_present(self) -> None:
+        """Config with identity section is detected as v2."""
+        data = {"identity": {"provider": "dummy", "entity": "test"}}
+        assert ConfigMigrator._detect_version(data) == 2
+
+    def test_detects_v1_with_flat_entity_and_provider(self) -> None:
+        """Flat entity + provider without identity is detected as v1."""
+        data = {"entity": "test", "provider": "chembl"}
+        assert ConfigMigrator._detect_version(data) == 1
+
+    def test_detects_v1_with_entity_name_alias(self) -> None:
+        """entity_name + provider without identity is detected as v1."""
+        data = {"entity_name": "test", "provider": "chembl"}
+        assert ConfigMigrator._detect_version(data) == 1
+
+    def test_detects_v1_with_sources_section(self) -> None:
+        """entity + sources section is detected as v1."""
+        data = {"entity": "test", "sources": {"chembl": {}}}
+        assert ConfigMigrator._detect_version(data) == 1
+
+    def test_defaults_to_v2_for_minimal_config(self) -> None:
+        """Minimal config defaults to v2."""
+        data = {"some_field": "value"}
+        assert ConfigMigrator._detect_version(data) == 2
+
+    def test_defaults_to_v2_for_empty_config(self) -> None:
+        """Empty config defaults to v2."""
+        assert ConfigMigrator._detect_version({}) == 2
+
+
+class TestV1Migration:
+    """Tests for v1 -> v2 migration."""
+
+    def test_migrates_entity_name_to_entity(self) -> None:
+        """entity_name is migrated to entity."""
+        data = {"entity_name": "test", "provider": "dummy"}
+        result = ConfigMigrator.migrate(data)
+        assert "entity_name" not in result
+        assert result["identity"]["entity"] == "test"
+
+    def test_generates_id_from_provider_entity(self) -> None:
+        """id is generated as provider.entity if not present."""
+        data = {"entity": "molecule", "provider": "chembl"}
+        result = ConfigMigrator.migrate(data)
+        assert result["identity"]["pipeline_id"] == "chembl.molecule"
+
+    def test_generates_id_from_pipeline_name(self) -> None:
+        """id is taken from pipeline.name if present."""
+        data = {
+            "entity": "test",
+            "provider": "dummy",
+            "pipeline": {"name": "custom-pipeline"},
+        }
+        result = ConfigMigrator.migrate(data)
+        assert result["identity"]["pipeline_id"] == "custom-pipeline"
+
+    def test_extracts_output_path_from_storage(self) -> None:
+        """output_path is extracted from storage section."""
+        data = {
+            "entity": "test",
+            "provider": "dummy",
+            "storage": {"output_path": "/data/output"},
+        }
+        result = ConfigMigrator.migrate(data)
+        assert result["sink"]["output_path"] == "/data/output"
+
+    def test_extracts_batch_size_from_sources(self) -> None:
+        """batch_size is extracted from sources section."""
+        data = {
+            "entity": "test",
+            "provider": "chembl",
+            "sources": {"chembl": {"batch_size": 50}},
+        }
+        result = ConfigMigrator.migrate(data)
+        assert result["source"]["batch_size"] == 50
+
+    def test_extracts_provider_config_from_sources(self) -> None:
+        """provider_config is extracted from sources section."""
+        data = {
+            "entity": "test",
+            "provider": "chembl",
+            "sources": {
+                "chembl": {
+                    "base_url": "https://api.example.com",
+                    "timeout_sec": 60,
+                }
+            },
+        }
+        result = ConfigMigrator.migrate(data)
+        assert result["provider_config"]["provider"] == "chembl"
+        assert result["provider_config"]["base_url"] == "https://api.example.com"
+        assert result["provider_config"]["timeout_sec"] == 60
+
+    def test_removes_sources_section(self) -> None:
+        """sources section is removed after migration."""
+        data = {
+            "entity": "test",
+            "provider": "chembl",
+            "sources": {"chembl": {"batch_size": 25}},
+        }
+        result = ConfigMigrator.migrate(data)
+        assert "sources" not in result
+
+    def test_migrates_api_base_url_to_provider_config(self) -> None:
+        """api_base_url is migrated to provider_config.base_url."""
+        data = {
+            "entity": "test",
+            "provider": "dummy",
+            "api_base_url": "https://example.com",
+            "provider_config": {"provider": "dummy"},
+        }
+        result = ConfigMigrator.migrate(data)
+        assert "api_base_url" not in result
+        assert result["provider_config"]["base_url"] == "https://example.com"
+
+    def test_v1_migration_emits_deprecation_warning(self) -> None:
+        """v1 format triggers deprecation warning."""
+        data = {"entity": "test", "provider": "dummy"}
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            ConfigMigrator.migrate(data)
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "Legacy v1 config format" in str(w[0].message)
+
+
+class TestV2Normalization:
+    """Tests for v2 format normalization (always applied)."""
+
+    def test_packs_identity_section(self) -> None:
+        """Flat identity fields are packed into identity section."""
+        data = {"id": "test-pipeline", "provider": "dummy", "entity": "test"}
+        result = ConfigMigrator.migrate(data)
+        assert result["identity"]["pipeline_id"] == "test-pipeline"
+        assert result["identity"]["provider"] == "dummy"
+        assert result["identity"]["entity"] == "test"
+
+    def test_packs_source_section(self) -> None:
+        """Flat source fields are packed into source section."""
+        data = {
+            "identity": {"provider": "dummy", "entity": "test", "pipeline_id": "test"},
+            "input_mode": "csv",
+            "input_path": "/tmp/input.csv",
+            "batch_size": 100,
+        }
+        result = ConfigMigrator.migrate(data)
+        assert result["source"]["input_mode"] == "csv"
+        assert result["source"]["input_path"] == "/tmp/input.csv"
+        assert result["source"]["batch_size"] == 100
+
+    def test_packs_sink_section(self) -> None:
+        """Flat sink fields are packed into sink section."""
+        data = {
+            "identity": {"provider": "dummy", "entity": "test", "pipeline_id": "test"},
+            "output_path": "/tmp/output",
+            "dry_run": True,
+        }
+        result = ConfigMigrator.migrate(data)
+        assert result["sink"]["output_path"] == "/tmp/output"
+        assert result["sink"]["dry_run"] is True
+
+    def test_packs_runtime_section(self) -> None:
+        """Flat runtime fields are packed into runtime section."""
+        data = {
+            "identity": {"provider": "dummy", "entity": "test", "pipeline_id": "test"},
+            "pagination": {"limit": 50},
+            "client": {"timeout_sec": 30},
+        }
+        result = ConfigMigrator.migrate(data)
+        assert result["runtime"]["pagination"] == {"limit": 50}
+        assert result["runtime"]["client"] == {"timeout_sec": 30}
+
+    def test_packs_observability_section(self) -> None:
+        """Flat observability fields are packed into observability section."""
+        data = {
+            "identity": {"provider": "dummy", "entity": "test", "pipeline_id": "test"},
+            "logging": {"level": "DEBUG"},
+            "metrics": {"enabled": False},
+        }
+        result = ConfigMigrator.migrate(data)
+        assert result["observability"]["logging"] == {"level": "DEBUG"}
+        assert result["observability"]["metrics"] == {"enabled": False}
+
+    def test_packs_quality_section(self) -> None:
+        """Flat quality fields are packed into quality section."""
+        data = {
+            "identity": {"provider": "dummy", "entity": "test", "pipeline_id": "test"},
+            "hashing": {"algorithm": "sha256"},
+            "normalization": {"id_fields": ["id"]},
+        }
+        result = ConfigMigrator.migrate(data)
+        assert result["quality"]["hashing"] == {"algorithm": "sha256"}
+        assert result["quality"]["normalization"] == {"id_fields": ["id"]}
+
+    def test_packs_features_section(self) -> None:
+        """Flat feature fields are packed into features section."""
+        data = {
+            "identity": {"provider": "dummy", "entity": "test", "pipeline_id": "test"},
+            "interface_features": {"rest_interface_enabled": True},
+        }
+        result = ConfigMigrator.migrate(data)
+        assert result["features"]["interface_features"] == {"rest_interface_enabled": True}
+
+    def test_migrates_csv_options_to_source(self) -> None:
+        """csv_options at root is moved to source.csv."""
+        data = {
+            "identity": {"provider": "dummy", "entity": "test", "pipeline_id": "test"},
+            "csv_options": {"delimiter": ";"},
+        }
+        result = ConfigMigrator.migrate(data)
+        assert result["source"]["csv"] == {"delimiter": ";"}
+
+    def test_extracts_stages_from_pipeline_dict(self) -> None:
+        """stages are extracted from pipeline dict."""
+        data = {
+            "identity": {"provider": "dummy", "entity": "test", "pipeline_id": "test"},
+            "pipeline": {"extract": True, "transform": True, "load": False},
+        }
+        result = ConfigMigrator.migrate(data)
+        assert result["stages"]["extract"] is True
+        assert result["stages"]["transform"] is True
+        assert result["stages"]["load"] is False
+        assert "pipeline" not in result
+
+    def test_extracts_primary_key_from_pipeline_to_identity(self) -> None:
+        """primary_key in pipeline dict is moved to identity."""
+        data = {
+            "identity": {"provider": "dummy", "entity": "test", "pipeline_id": "test"},
+            "pipeline": {"primary_key": "molecule_chembl_id"},
+        }
+        result = ConfigMigrator.migrate(data)
+        assert result["identity"]["primary_key"] == ["molecule_chembl_id"]
+
+    def test_coerces_primary_key_string_to_list(self) -> None:
+        """String primary_key is coerced to list."""
+        data = {"id": "test", "provider": "dummy", "entity": "test", "primary_key": "id"}
+        result = ConfigMigrator.migrate(data)
+        assert result["identity"]["primary_key"] == ["id"]
+
+
+class TestLegacyClientKeyMigration:
+    """Tests for legacy client config key migration."""
+
+    def test_migrates_timeout_to_timeout_sec(self) -> None:
+        """timeout in client is renamed to timeout_sec."""
+        data = {
+            "identity": {"provider": "dummy", "entity": "test", "pipeline_id": "test"},
+            "runtime": {"client": {"timeout": 30}},
+        }
+        result = ConfigMigrator.migrate(data)
+        assert result["runtime"]["client"]["timeout_sec"] == 30
+        assert "timeout" not in result["runtime"]["client"]
+
+    def test_migrates_rate_limit_to_rate_limit_per_sec(self) -> None:
+        """rate_limit in client is renamed to rate_limit_per_sec."""
+        data = {
+            "identity": {"provider": "dummy", "entity": "test", "pipeline_id": "test"},
+            "runtime": {"client": {"rate_limit": 5}},
+        }
+        result = ConfigMigrator.migrate(data)
+        assert result["runtime"]["client"]["rate_limit_per_sec"] == 5
+        assert "rate_limit" not in result["runtime"]["client"]
+
+    def test_migrates_backoff_to_backoff_factor(self) -> None:
+        """backoff in client is renamed to backoff_factor."""
+        data = {
+            "identity": {"provider": "dummy", "entity": "test", "pipeline_id": "test"},
+            "runtime": {"client": {"backoff": 2.0}},
+        }
+        result = ConfigMigrator.migrate(data)
+        assert result["runtime"]["client"]["backoff_factor"] == 2.0
+        assert "backoff" not in result["runtime"]["client"]
+
+    def test_preserves_new_key_if_both_present(self) -> None:
+        """New key is preserved if both old and new are present."""
+        data = {
+            "identity": {"provider": "dummy", "entity": "test", "pipeline_id": "test"},
+            "runtime": {"client": {"timeout": 30, "timeout_sec": 60}},
+        }
+        result = ConfigMigrator.migrate(data)
+        assert result["runtime"]["client"]["timeout_sec"] == 60
+        assert "timeout" not in result["runtime"]["client"]
+
+
+class TestIdempotency:
+    """Tests that migration is idempotent."""
+
+    def test_migration_is_idempotent(self) -> None:
+        """Running migration twice produces same result."""
+        data = {
+            "entity": "test",
+            "provider": "dummy",
+            "input_mode": "csv",
+            "output_path": "/tmp/output",
+            "logging": {"level": "DEBUG"},
+        }
+        result1 = ConfigMigrator.migrate(data)
+        result2 = ConfigMigrator.migrate(deepcopy(result1))
+        assert result1 == result2
+
+    def test_already_migrated_v2_unchanged(self) -> None:
+        """v2 config is not modified."""
+        data = {
+            "identity": {"pipeline_id": "test", "provider": "dummy", "entity": "test"},
+            "source": {"input_mode": "csv"},
+            "sink": {"output_path": "/tmp/output"},
+            "runtime": {"pagination": {"limit": 100}},
+        }
+        original = deepcopy(data)
+        result = ConfigMigrator.migrate(data)
+        assert result == original
+
+    def test_v2_does_not_emit_deprecation_warning(self) -> None:
+        """v2 format does not trigger deprecation warning."""
+        data = {
+            "identity": {"pipeline_id": "test", "provider": "dummy", "entity": "test"},
+        }
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            ConfigMigrator.migrate(data)
+            assert len(w) == 0
+
+
+class TestEdgeCases:
+    """Tests for edge cases."""
+
+    def test_handles_non_dict_data(self) -> None:
+        """Non-dict data is returned unchanged."""
+        assert ConfigMigrator.migrate("not a dict") == "not a dict"  # type: ignore[arg-type]
+        assert ConfigMigrator.migrate(None) is None  # type: ignore[arg-type]
+        assert ConfigMigrator.migrate([1, 2, 3]) == [1, 2, 3]  # type: ignore[arg-type]
+
+    def test_handles_empty_dict(self) -> None:
+        """Empty dict is handled gracefully."""
+        result = ConfigMigrator.migrate({})
+        assert result == {}
+
+    def test_preserves_existing_identity_section(self) -> None:
+        """Existing identity section is not overwritten."""
+        data = {
+            "identity": {"pipeline_id": "existing", "provider": "dummy", "entity": "e"},
+            "id": "should-be-ignored",
+            "provider": "should-be-ignored",
+        }
+        result = ConfigMigrator.migrate(data)
+        assert result["identity"]["pipeline_id"] == "existing"
+        assert result["identity"]["provider"] == "dummy"
+        # Flat fields should still exist (not packed since identity exists)
+        assert "id" in result
+        assert "provider" in result
+
+    def test_preserves_existing_source_section(self) -> None:
+        """Existing source section is not overwritten."""
+        data = {
+            "identity": {"pipeline_id": "test", "provider": "dummy", "entity": "test"},
+            "source": {"input_mode": "existing"},
+            "input_mode": "should-be-ignored",
+        }
+        result = ConfigMigrator.migrate(data)
+        assert result["source"]["input_mode"] == "existing"
+
+    def test_handles_sources_with_single_provider(self) -> None:
+        """Single provider in sources is extracted correctly."""
+        data = {
+            "entity": "test",
+            "sources": {"chembl": {"base_url": "https://example.com", "batch_size": 10}},
+        }
+        result = ConfigMigrator.migrate(data)
+        assert result["provider_config"]["base_url"] == "https://example.com"
+        assert result["source"]["batch_size"] == 10
+
+    def test_handles_null_primary_key(self) -> None:
+        """Null primary_key is coerced to empty list."""
+        data = {"id": "test", "provider": "dummy", "entity": "test", "primary_key": None}
+        result = ConfigMigrator.migrate(data)
+        assert result["identity"]["primary_key"] == []
+
+    def test_handles_list_primary_key(self) -> None:
+        """List primary_key is preserved."""
+        data = {
+            "id": "test",
+            "provider": "dummy",
+            "entity": "test",
+            "primary_key": ["id", "version"],
+        }
+        result = ConfigMigrator.migrate(data)
+        assert result["identity"]["primary_key"] == ["id", "version"]


### PR DESCRIPTION
Move legacy config migration logic from loader.py to ConfigMigrator class in migration.py. This creates a dedicated service for handling config format migrations with:

- Version detection (v1 flat format vs v2 nested format)
- Deprecation warnings for v1 format
- Idempotent migration transformations
- Comprehensive test coverage (40 new tests)

Changes:
- Extend ConfigMigrator with all migration logic from loader.py
- Remove _migrate_legacy_pipeline_config and helper functions from loader.py
- Update loader.py to use ConfigMigrator.migrate()
- Fix provider_id lookup to check identity section after migration
- Add test_config_migration.py with tests for all migration scenarios
- Update test_config_loader.py to use new decomposed section accessors