### PR TITLE
Move provider registry to infrastructure layer

### DIFF
--- a/src/bioetl/domain/provider_registry.py
+++ b/src/bioetl/domain/provider_registry.py
@@ -67,51 +67,48 @@ class ProviderRegistryLoaderABC(Protocol):
         """Загружает провайдеры и возвращает заполненный реестр."""
 
 
-class InMemoryProviderRegistry(ProviderRegistryABC):
-    """Реализация реестра провайдеров в памяти."""
+def get_provider_registry() -> ProviderRegistryABC:
+    """Factory для получения registry.
 
-    def __init__(self) -> None:
-        self._providers: dict[ProviderId, ProviderDefinition] = {}
-
-    def register_provider(self, definition: ProviderDefinition) -> None:
-        """Регистрирует провайдер в реестре."""
-        if definition.id in self._providers:
-            raise ProviderAlreadyRegisteredError(definition.id)
-        self._providers[definition.id] = definition
-
-    def get_provider(self, provider_id: ProviderId) -> ProviderDefinition:
-        """Получает определение провайдера по идентификатору."""
-        if provider_id not in self._providers:
-            raise ProviderNotRegisteredError(provider_id)
-        return self._providers[provider_id]
-
-    def list_providers(self) -> list[ProviderDefinition]:
-        """Возвращает список всех зарегистрированных провайдеров."""
-        return list(self._providers.values())
-
-    def reset_provider_registry(self) -> None:
-        """Очищает реестр провайдеров."""
-        self._providers.clear()
-
-    def restore_provider_registry(self, definitions: list[ProviderDefinition]) -> None:
-        """Восстанавливает реестр из списка определений."""
-        self._providers.clear()
-        for definition in definitions:
-            self._providers[definition.id] = definition
-
-
-def default_provider_registry() -> ProviderRegistryABC:
-    """Возвращает in-memory реализацию реестра провайдеров по умолчанию."""
+    Возвращает реализацию ProviderRegistryABC из infrastructure слоя.
+    Конфигурируется через DI контейнер.
+    """
+    from bioetl.infrastructure.provider_registry import InMemoryProviderRegistry
 
     return InMemoryProviderRegistry()
 
 
+# Backward compatibility alias
+def default_provider_registry() -> ProviderRegistryABC:
+    """DEPRECATED: Use get_provider_registry() instead.
+
+    Возвращает in-memory реализацию реестра провайдеров по умолчанию.
+    """
+    return get_provider_registry()
+
+
+# Re-export for backward compatibility (will be removed in future)
+# Import is done lazily to avoid circular imports at module load time
+def __getattr__(name: str):
+    """Lazy import for backward compatibility."""
+    if name == "InMemoryProviderRegistry":
+        from bioetl.infrastructure.provider_registry import InMemoryProviderRegistry
+
+        return InMemoryProviderRegistry
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 __all__ = [
+    # Domain abstractions
+    "ProviderRegistryABC",
+    "ProviderRegistryLoaderABC",
+    # Domain errors
     "ProviderRegistryError",
     "ProviderNotRegisteredError",
     "ProviderAlreadyRegisteredError",
-    "ProviderRegistryABC",
-    "ProviderRegistryLoaderABC",
+    # Factory function
+    "get_provider_registry",
+    # Backward compatibility (deprecated - use infrastructure.provider_registry)
     "InMemoryProviderRegistry",
     "default_provider_registry",
 ]

--- a/src/bioetl/infrastructure/config/provider_registry.py
+++ b/src/bioetl/infrastructure/config/provider_registry.py
@@ -21,11 +21,11 @@ import yaml
 from bioetl.domain.configs import HttpClientConfig, ProviderHttpConfig
 from bioetl.domain.observability import LoggingPortABC
 from bioetl.domain.provider_registry import (
-    InMemoryProviderRegistry,
     ProviderAlreadyRegisteredError,
     ProviderRegistryABC,
     ProviderRegistryLoaderABC,
 )
+from bioetl.infrastructure.provider_registry import InMemoryProviderRegistry
 from bioetl.domain.providers import ProviderDefinition, ProviderId
 from bioetl.infrastructure.clients.chembl.provider import register_chembl_provider
 from bioetl.infrastructure.observability.factories import default_logging_port

--- a/src/bioetl/infrastructure/provider_registry.py
+++ b/src/bioetl/infrastructure/provider_registry.py
@@ -1,0 +1,57 @@
+"""Infrastructure implementation of provider registry.
+
+This module contains the concrete implementation of ProviderRegistryABC
+for the infrastructure layer, following Hexagonal Architecture principles.
+"""
+
+from __future__ import annotations
+
+from bioetl.domain.provider_registry import (
+    ProviderAlreadyRegisteredError,
+    ProviderNotRegisteredError,
+    ProviderRegistryABC,
+)
+from bioetl.domain.providers import ProviderDefinition, ProviderId
+
+
+class InMemoryProviderRegistry(ProviderRegistryABC):
+    """Реализация реестра провайдеров в памяти.
+
+    Concrete implementation of the provider registry that stores
+    provider definitions in memory. This implementation belongs
+    to the infrastructure layer.
+    """
+
+    def __init__(self) -> None:
+        self._providers: dict[ProviderId, ProviderDefinition] = {}
+
+    def register_provider(self, definition: ProviderDefinition) -> None:
+        """Регистрирует провайдер в реестре."""
+        if definition.id in self._providers:
+            raise ProviderAlreadyRegisteredError(definition.id)
+        self._providers[definition.id] = definition
+
+    def get_provider(self, provider_id: ProviderId) -> ProviderDefinition:
+        """Получает определение провайдера по идентификатору."""
+        if provider_id not in self._providers:
+            raise ProviderNotRegisteredError(provider_id)
+        return self._providers[provider_id]
+
+    def list_providers(self) -> list[ProviderDefinition]:
+        """Возвращает список всех зарегистрированных провайдеров."""
+        return list(self._providers.values())
+
+    def reset_provider_registry(self) -> None:
+        """Очищает реестр провайдеров."""
+        self._providers.clear()
+
+    def restore_provider_registry(self, definitions: list[ProviderDefinition]) -> None:
+        """Восстанавливает реестр из списка определений."""
+        self._providers.clear()
+        for definition in definitions:
+            self._providers[definition.id] = definition
+
+
+__all__ = [
+    "InMemoryProviderRegistry",
+]

--- a/tests/bioetl/application/test_container.py
+++ b/tests/bioetl/application/test_container.py
@@ -8,9 +8,7 @@ from typing import Any
 from pydantic import ValidationError
 import pytest
 
-from bioetl.domain.provider_registry import (
-    InMemoryProviderRegistry,
-)
+from bioetl.infrastructure.provider_registry import InMemoryProviderRegistry
 from bioetl.domain.providers import (
     ProviderComponents,
     ProviderDefinition,

--- a/tests/bioetl/application/test_container_provider_registration.py
+++ b/tests/bioetl/application/test_container_provider_registration.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from bioetl.domain.provider_registry import InMemoryProviderRegistry
+from bioetl.infrastructure.provider_registry import InMemoryProviderRegistry
 from bioetl.domain.providers import ProviderId
 from bioetl.infrastructure.clients.provider_registry_loader import (
     create_provider_loader,


### PR DESCRIPTION
Move concrete implementation InMemoryProviderRegistry from domain to infrastructure layer following Hexagonal Architecture principles.

Changes:
- Create src/bioetl/infrastructure/provider_registry.py with InMemoryProviderRegistry
- Add get_provider_registry() factory function in domain layer
- Maintain backward compatibility via __getattr__ lazy import
- Update imports in infrastructure/config/provider_registry.py
- Update test imports to use new location

The domain layer now only contains abstractions (ProviderRegistryABC) and errors, while concrete implementations reside in infrastructure.