### PR TITLE
Replace Service Locator with Dependency Injection

### DIFF
--- a/src/bioetl/application/composition_root.py
+++ b/src/bioetl/application/composition_root.py
@@ -1,0 +1,181 @@
+"""
+Composition Root for assembling the application's dependency graph.
+
+This module is the single place where concrete implementations are instantiated
+and wired together. No other module should create dependencies with default fallbacks.
+
+Usage:
+    # For production:
+    root = CompositionRoot()
+    http_transport = root.create_http_transport(provider="chembl", config=http_config)
+
+    # For testing:
+    root = CompositionRoot(
+        logger=mock_logger,
+        metrics=mock_metrics,
+    )
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import requests
+
+from bioetl.domain.clients.base.contracts import RateLimiterABC
+from bioetl.domain.configs import HttpClientConfig
+from bioetl.domain.observability import LoggingPortABC, MetricsPortABC
+from bioetl.infrastructure.clients.base.impl._http_transport import _HttpTransport
+from bioetl.infrastructure.clients.base.impl.rate_limiter import (
+    TokenBucketRateLimiterImpl,
+)
+from bioetl.infrastructure.observability.factories import (
+    default_logging_port,
+    default_metrics_port,
+)
+
+
+@dataclass(frozen=True)
+class ObservabilityStack:
+    """Container for observability dependencies."""
+
+    logger: LoggingPortABC
+    metrics: MetricsPortABC
+
+
+class CompositionRoot:
+    """
+    Central factory for creating application components with proper dependency injection.
+
+    The composition root is the only place where default implementations are created.
+    All other modules receive their dependencies explicitly.
+
+    Example:
+        >>> root = CompositionRoot()
+        >>> transport = root.create_http_transport("chembl", HttpClientConfig())
+
+        # For testing with mocks:
+        >>> root = CompositionRoot(logger=mock_logger, metrics=mock_metrics)
+        >>> transport = root.create_http_transport("chembl", HttpClientConfig())
+    """
+
+    def __init__(
+        self,
+        *,
+        logger: LoggingPortABC | None = None,
+        metrics: MetricsPortABC | None = None,
+        http_session_factory: type | None = None,
+    ) -> None:
+        """
+        Initialize composition root with optional overrides.
+
+        Args:
+            logger: Custom logger implementation (defaults to structured logger)
+            metrics: Custom metrics implementation (defaults to Prometheus)
+            http_session_factory: Factory for HTTP sessions (defaults to requests.Session)
+        """
+        self._logger = logger
+        self._metrics = metrics
+        self._http_session_factory = http_session_factory or requests.Session
+
+    def get_logger(self) -> LoggingPortABC:
+        """Get or create the logger instance."""
+        if self._logger is None:
+            self._logger = default_logging_port()
+        return self._logger
+
+    def get_metrics(self) -> MetricsPortABC:
+        """Get or create the metrics instance."""
+        if self._metrics is None:
+            self._metrics = default_metrics_port()
+        return self._metrics
+
+    def get_observability_stack(self) -> ObservabilityStack:
+        """Get the complete observability stack."""
+        return ObservabilityStack(
+            logger=self.get_logger(),
+            metrics=self.get_metrics(),
+        )
+
+    def create_http_session(self) -> Any:
+        """Create a new HTTP session."""
+        return self._http_session_factory()
+
+    def create_http_transport(
+        self,
+        provider: str,
+        config: HttpClientConfig,
+        *,
+        base_client: Any | None = None,
+    ) -> _HttpTransport:
+        """
+        Create an HTTP transport with all dependencies injected.
+
+        Args:
+            provider: Provider identifier (e.g., "chembl")
+            config: HTTP client configuration
+            base_client: Optional pre-configured HTTP client
+
+        Returns:
+            Fully configured _HttpTransport instance
+        """
+        return _HttpTransport(
+            provider=provider,
+            config=config,
+            base_client=base_client or self.create_http_session(),
+            logger=self.get_logger(),
+            metrics=self.get_metrics(),
+        )
+
+    def create_rate_limiter(
+        self,
+        rate: float,
+        capacity: float | None = None,
+    ) -> RateLimiterABC:
+        """
+        Create a rate limiter with all dependencies injected.
+
+        Args:
+            rate: Tokens per second
+            capacity: Maximum bucket capacity (defaults to rate)
+
+        Returns:
+            Configured rate limiter instance
+        """
+        resolved_capacity = capacity if capacity is not None else max(1.0, rate)
+        return TokenBucketRateLimiterImpl(
+            rate=rate,
+            capacity=resolved_capacity,
+            logger=self.get_logger(),
+        )
+
+
+# Module-level singleton for convenience (can be replaced in tests)
+_default_root: CompositionRoot | None = None
+
+
+def get_composition_root() -> CompositionRoot:
+    """
+    Get the default composition root singleton.
+
+    For testing, create a new CompositionRoot with mock dependencies instead.
+    """
+    global _default_root
+    if _default_root is None:
+        _default_root = CompositionRoot()
+    return _default_root
+
+
+def reset_composition_root() -> None:
+    """Reset the default composition root (useful for tests)."""
+    global _default_root
+    _default_root = None
+
+
+__all__ = [
+    "CompositionRoot",
+    "ObservabilityStack",
+    "get_composition_root",
+    "reset_composition_root",
+]

--- a/src/bioetl/infrastructure/clients/base/factories.py
+++ b/src/bioetl/infrastructure/clients/base/factories.py
@@ -1,7 +1,13 @@
-"""Factories for infrastructure client helpers (cache, retry, rate limit)."""
+"""Factories for infrastructure client helpers (cache, retry, rate limit).
+
+All factories require explicit dependencies - no implicit defaults.
+Use CompositionRoot for creating instances with default implementations.
+"""
 
 import os
 from typing import Any
+
+import requests
 
 from bioetl.domain.clients.base.contracts import (
     CacheABC,
@@ -50,26 +56,42 @@ def _ensure_http_config(
 
 
 def build_rate_limiter(
+    logger: LoggingPortABC,
     *,
     config: HttpClientConfig | None = None,
-    logger: LoggingPortABC | None = None,
 ) -> RateLimiterABC:
-    """Create a rate limiter using HTTP config."""
+    """Create a rate limiter using HTTP config.
+
+    Args:
+        logger: Required logger instance
+        config: Optional HTTP config for rate settings
+
+    Returns:
+        Configured rate limiter
+    """
     resolved = _ensure_http_config(config)
     rate = resolved.rate_limit_per_sec
     capacity = max(1.0, rate)
-    return TokenBucketRateLimiterImpl(rate, capacity, logger=logger)
+    return TokenBucketRateLimiterImpl(rate, capacity, logger)
 
 
 def default_rate_limiter(
+    logger: LoggingPortABC,
     rate: float = _DEFAULT_HTTP_CONFIG.rate_limit_per_sec,
     capacity: float | None = None,
-    *,
-    logger: LoggingPortABC | None = None,
 ) -> RateLimiterABC:
-    """Create the default rate limiter with token bucket semantics."""
+    """Create the default rate limiter with token bucket semantics.
+
+    Args:
+        logger: Required logger instance
+        rate: Tokens per second
+        capacity: Maximum bucket capacity
+
+    Returns:
+        Configured rate limiter
+    """
     resolved_capacity = capacity if capacity is not None else max(1.0, rate)
-    return TokenBucketRateLimiterImpl(rate, resolved_capacity, logger=logger)
+    return TokenBucketRateLimiterImpl(rate, resolved_capacity, logger)
 
 
 def default_cache() -> CacheABC[Any]:
@@ -111,35 +133,58 @@ def default_paginator() -> PaginatorABC:
 def default_api_client(
     provider: str,
     config: HttpClientConfig,
+    logger: LoggingPortABC,
+    metrics: MetricsPortABC,
     *,
     base_client: Any | None = None,
-    logger: LoggingPortABC | None = None,
-    metrics: MetricsPortABC | None = None,
 ) -> _HttpTransport:
-    """Create the default API client without middleware indirection."""
+    """Create the default API client without middleware indirection.
+
+    Args:
+        provider: Provider identifier
+        config: HTTP client configuration
+        logger: Required logger instance
+        metrics: Required metrics instance
+        base_client: Optional pre-configured HTTP client
+
+    Returns:
+        Configured HTTP transport
+    """
     return build_http_client(
         provider,
-        config=config,
-        base_client=base_client,
         logger=logger,
         metrics=metrics,
+        config=config,
+        base_client=base_client,
     )
 
 
 def build_http_client(
     provider: str,
+    logger: LoggingPortABC,
+    metrics: MetricsPortABC,
     *,
     config: HttpClientConfig | None = None,
     base_client: Any | None = None,
-    logger: LoggingPortABC | None = None,
-    metrics: MetricsPortABC | None = None,
 ) -> _HttpTransport:
-    """Construct HTTP client using HttpClientConfig."""
+    """Construct HTTP client using HttpClientConfig.
+
+    Args:
+        provider: Provider identifier
+        logger: Required logger instance
+        metrics: Required metrics instance
+        config: Optional HTTP config
+        base_client: Optional pre-configured HTTP client
+
+    Returns:
+        Configured HTTP transport
+    """
     resolved_config = _ensure_http_config(config)
+    resolved_client = base_client if base_client is not None else requests.Session()
     return _HttpTransport(
         provider=provider,
         config=resolved_config,
-        base_client=base_client,
+        base_client=resolved_client,
         logger=logger,
         metrics=metrics,
     )

--- a/src/bioetl/infrastructure/clients/base/impl/_http_transport.py
+++ b/src/bioetl/infrastructure/clients/base/impl/_http_transport.py
@@ -19,32 +19,30 @@ from bioetl.infrastructure.errors import (
     wrap_http_errors,
 )
 from bioetl.infrastructure.http import ExponentialRetryPolicy
-from bioetl.infrastructure.observability.factories import (
-    default_logging_port,
-    default_metrics_port,
-)
 
 
 class _HttpTransport:
     """
     Внутренний HTTP-транспорт без промежуточных middleware-слоев.
     Делегирует вызовы напрямую базовому HTTP-клиенту.
+
+    All dependencies must be explicitly injected - no default fallbacks.
+    Use composition root or factories to create instances.
     """
 
     def __init__(
         self,
         provider: str,
         config: HttpClientConfig,
-        base_client: Any | None = None,
-        *,
-        logger: LoggingPortABC | None = None,
-        metrics: MetricsPortABC | None = None,
+        base_client: Any,
+        logger: LoggingPortABC,
+        metrics: MetricsPortABC,
     ) -> None:
         self.provider = provider
         self.config = config
-        self.base_client = base_client or requests.Session()
-        self.logger = logger or default_logging_port()
-        self.metrics = metrics or default_metrics_port()
+        self.base_client = base_client
+        self.logger = logger
+        self.metrics = metrics
         attempts = max(1, int(config.max_retries) + 1)
         self.retry_policy = (
             ExponentialRetryPolicy(

--- a/src/bioetl/infrastructure/clients/base/impl/rate_limiter.py
+++ b/src/bioetl/infrastructure/clients/base/impl/rate_limiter.py
@@ -5,23 +5,25 @@ import time
 
 from bioetl.domain.clients.base.contracts import RateLimiterABC
 from bioetl.domain.observability import LoggingPortABC
-from bioetl.infrastructure.observability.factories import default_logging_port
 
 
 class TokenBucketRateLimiterImpl(RateLimiterABC):
     """
     Реализация алгоритма Token Bucket.
+
+    All dependencies must be explicitly injected - no default fallbacks.
+    Use composition root or factories to create instances.
     """
 
     def __init__(
-        self, rate: float, capacity: float, *, logger: LoggingPortABC | None = None
+        self, rate: float, capacity: float, logger: LoggingPortABC
     ) -> None:
         self._rate = rate  # tokens per second
         self._capacity = capacity
         self._tokens = capacity
         self._last_refill = time.monotonic()
         self._lock = Lock()
-        self._logger = logger or default_logging_port()
+        self._logger = logger
         self._logger.info("rate_limiter_initialized", rate=rate, capacity=capacity)
 
     @property

--- a/src/bioetl/infrastructure/clients/chembl/factories.py
+++ b/src/bioetl/infrastructure/clients/chembl/factories.py
@@ -1,12 +1,15 @@
 """
 Factories for ChEMBL clients.
+
+All factories require explicit dependencies - no implicit defaults.
+Use CompositionRoot for creating instances with default implementations.
 """
 
 from typing import Any
 
 from bioetl.domain.clients.contracts import DataClientABC
 from bioetl.domain.configs import ChemblSourceConfig, HttpClientConfig
-from bioetl.domain.observability.contracts import LoggingPortABC
+from bioetl.domain.observability.contracts import LoggingPortABC, MetricsPortABC
 from bioetl.domain.ports.extraction import ExtractionServiceABC
 from bioetl.domain.ports.providers import DefaultFieldProviderABC
 from bioetl.infrastructure.clients.base.factories import (
@@ -29,29 +32,33 @@ from bioetl.infrastructure.clients.chembl.response_parser import (
 
 def default_chembl_client(
     source_config: ChemblSourceConfig,
+    logger: LoggingPortABC,
+    metrics: MetricsPortABC,
     http_config: HttpClientConfig | None = None,
     **options: Any,
 ) -> DataClientABC:
     """
-    Создает клиент ChEMBL по умолчанию.
+    Create default ChEMBL client with explicit dependencies.
 
     Args:
-        source_config: Конфигурация источника.
-        http_config: HTTP конфигурация (опционально, берется из source_config.http).
-        **options: Дополнительные опции.
+        source_config: Source configuration.
+        logger: Required logger instance.
+        metrics: Required metrics instance.
+        http_config: Optional HTTP configuration (defaults to source_config.http).
+        **options: Additional options (base_url, max_url_length).
 
     Returns:
-        Настроенный экземпляр клиента.
+        Configured client instance.
     """
     # Use provided config or fall back to source_config.http
     resolved_config = http_config or source_config.http
-    logger: LoggingPortABC | None = options.get("logger")
 
     # Create Unified HTTP Client
     unified_client = build_http_client(
         provider="chembl",
-        config=resolved_config,
         logger=logger,
+        metrics=metrics,
+        config=resolved_config,
     )
 
     # Allow explicit overrides via kwargs (used in tests and manual runs)
@@ -60,7 +67,7 @@ def default_chembl_client(
     max_url_length = options.get("max_url_length", source_config.max_url_length)
 
     # Rate limiter for proactive limiting
-    rate_limiter = build_rate_limiter(config=resolved_config, logger=logger)
+    rate_limiter = build_rate_limiter(logger, config=resolved_config)
 
     return ChemblHttpClientImpl(
         request_builder=ChemblRequestBuilderImpl(
@@ -69,44 +76,47 @@ def default_chembl_client(
         ),
         response_parser=create_activity_parser(),
         rate_limiter=rate_limiter,
-        client=unified_client,
-        provider="chembl",
+        http_client=unified_client,
         logger=logger,
+        provider="chembl",
         fallbacks=source_config.fallbacks or {},
     )
 
 
 def default_chembl_extraction_service(
     config: ChemblSourceConfig,
+    logger: LoggingPortABC,
+    metrics: MetricsPortABC,
     http_config: HttpClientConfig | None = None,
     *,
     client: DataClientABC | None = None,
-    logger: LoggingPortABC | None = None,
     field_provider: DefaultFieldProviderABC | None = None,
 ) -> ExtractionServiceABC:
     """
-    Создает сервис экстракции ChEMBL.
+    Create ChEMBL extraction service with explicit dependencies.
 
     Args:
-        config: Конфигурация источника.
-        http_config: HTTP конфигурация (опционально).
-        client: Уже созданный клиент (опционально).
-        logger: Логгер.
-        field_provider: Провайдер полей.
+        config: Source configuration.
+        logger: Required logger instance.
+        metrics: Required metrics instance.
+        http_config: Optional HTTP configuration.
+        client: Optional pre-created client.
+        field_provider: Optional field provider.
 
     Returns:
-        Сервис экстракции.
+        Configured extraction service.
     """
     resolved_config = http_config or config.http
 
     if client is None:
         client = default_chembl_client(
-            config, http_config=resolved_config, logger=logger
+            config, logger=logger, metrics=metrics, http_config=resolved_config
         )
 
     return ChemblExtractionServiceImpl(
         client=client,
+        logger=logger,
         # Allow provider config to set batch_size while keeping a generous hard cap
         batch_size=config.resolve_effective_batch_size(hard_cap=1000),
-        logger=logger,
+        field_provider=field_provider,
     )

--- a/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
@@ -16,25 +16,27 @@ from bioetl.domain.ports.providers import DefaultFieldProviderABC
 from bioetl.domain.record_source import RawRecord
 from bioetl.infrastructure.clients.chembl.constants import ENTITY_ENDPOINT_ALIASES
 from bioetl.infrastructure.clients.chembl.parser_registry import get_parser_for_entity
-from bioetl.infrastructure.observability.factories import default_logging_port
 
 
 class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
     """
     Implementation of record fetcher for ChEMBL.
     Uses DataClientABC (expected to be ChemblHttpClientImpl) to fetch data.
+
+    All dependencies must be explicitly injected - no default fallbacks.
+    Use composition root or factories to create instances.
     """
 
     def __init__(
         self,
         client: DataClientABC,
+        logger: LoggingPortABC,
         batch_size: int = 1000,
-        logger: LoggingPortABC | None = None,
         field_provider: DefaultFieldProviderABC | None = None,
     ) -> None:
         self.client = client
         self.batch_size = batch_size
-        self.logger = logger or default_logging_port()
+        self.logger = logger
         self.field_provider = field_provider
         self._version_cache: str | None = None
 

--- a/src/bioetl/infrastructure/clients/chembl/impl/chembl_http_client_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/chembl_http_client_impl.py
@@ -5,7 +5,6 @@ HTTP client implementation for ChEMBL API.
 from __future__ import annotations
 
 import time
-from types import SimpleNamespace
 from typing import Any, Iterator
 
 from bioetl.domain.clients.base.contracts import (
@@ -21,13 +20,15 @@ from bioetl.infrastructure.errors import (
     ApiUnexpectedStatusError,
     wrap_http_errors,
 )
-from bioetl.infrastructure.observability.factories import default_logging_port
 
 
 class ChemblHttpClientImpl(DataClientABC):
     """
     ChEMBL API client implemented over HTTP.
     Uses RateLimiter for proactive throttling.
+
+    All dependencies must be explicitly injected - no default fallbacks.
+    Use composition root or factories to create instances.
     """
 
     def __init__(
@@ -35,31 +36,20 @@ class ChemblHttpClientImpl(DataClientABC):
         request_builder: RequestBuilderABC,
         response_parser: ResponseParserABC,
         rate_limiter: RateLimiterABC,
-        client: Any | None = None,
+        http_client: Any,
+        logger: LoggingPortABC,
         *,
         provider: str = "chembl",
-        logger: LoggingPortABC | None = None,
         fallbacks: dict[str, list[str]] | None = None,
     ) -> None:
         self.request_builder = request_builder
         self.response_parser = response_parser
         self.rate_limiter = rate_limiter
-        self.client = client
-        self.logger = logger or default_logging_port()
-        self._fallbacks = fallbacks or {}
+        self.client = http_client
+        self.http = http_client
+        self.logger = logger
+        self._fallbacks = fallbacks if fallbacks is not None else {}
         self._last_endpoint_used: str | None = None
-        if client is not None:
-            self.http = client
-        else:
-            # Fallback stub to keep attribute accessible in tests;
-            # real runs must inject a concrete client.
-            def _missing_http_request(
-                method: str, url: str, **_: Any
-            ) -> Any:  # pragma: no cover
-                """Fail fast when HTTP client is not configured."""
-                raise RuntimeError("HTTP client is not configured")
-
-            self.http = SimpleNamespace(request=_missing_http_request)
         self.provider = provider
 
     def iter_pages(self, request: Any) -> Iterator[Any]:

--- a/tests/bioetl/application/pipelines/chembl/test_extraction.py
+++ b/tests/bioetl/application/pipelines/chembl/test_extraction.py
@@ -8,10 +8,17 @@ from unittest.mock import MagicMock
 import pytest
 
 from bioetl.domain.clients.contracts import DataClientABC
+from bioetl.domain.observability import LoggingPortABC
 from bioetl.domain.schemas.chembl.raw_models import ActivityRawModel
 from bioetl.infrastructure.clients.chembl.impl.chembl_extraction_service_impl import (
     ChemblExtractionServiceImpl,
 )
+
+
+@pytest.fixture
+def mock_logger():
+    """Mock logger."""
+    return MagicMock(spec=LoggingPortABC)
 
 
 @pytest.fixture
@@ -26,9 +33,11 @@ def mock_client():
 
 
 @pytest.fixture
-def service(mock_client):
+def service(mock_client, mock_logger):
     """ChemblExtractionServiceImpl instance with mock client."""
-    return ChemblExtractionServiceImpl(client=mock_client, batch_size=10)
+    return ChemblExtractionServiceImpl(
+        client=mock_client, logger=mock_logger, batch_size=10
+    )
 
 
 def test_get_release_version(service, mock_client):

--- a/tests/bioetl/infrastructure/clients/base/test_factories.py
+++ b/tests/bioetl/infrastructure/clients/base/test_factories.py
@@ -3,8 +3,9 @@ Tests for factory implementations.
 """
 
 import os
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
+from bioetl.domain.observability import LoggingPortABC
 from bioetl.infrastructure.clients.base.factories import (
     EnvSecretProviderImpl,
     default_cache,
@@ -19,7 +20,8 @@ from bioetl.infrastructure.clients.base.impl.rate_limiter import (
 
 def test_default_factories():
     """Test default factories return correct implementations."""
-    assert isinstance(default_rate_limiter(), TokenBucketRateLimiterImpl)
+    mock_logger = Mock(spec=LoggingPortABC)
+    assert isinstance(default_rate_limiter(mock_logger), TokenBucketRateLimiterImpl)
     assert isinstance(default_cache(), MemoryCacheImpl)
 
 

--- a/tests/bioetl/infrastructure/clients/base/test_http_transport.py
+++ b/tests/bioetl/infrastructure/clients/base/test_http_transport.py
@@ -39,11 +39,13 @@ def test_request_call_wraps_timeout_error() -> None:
 def test_request_call_wraps_request_exception() -> None:
     base_client = Mock()
     base_client.request.side_effect = requests.RequestException("boom")
+    logger = Mock(spec=LoggingPortABC)
     metrics = Mock(spec=MetricsPortABC)
     client = _HttpTransport(
         provider="chembl",
         config=ClientConfig(retry_enabled=False),
         base_client=base_client,
+        logger=logger,
         metrics=metrics,
     )
 
@@ -67,11 +69,13 @@ def test_request_records_metrics_on_success() -> None:
     response = Mock()
     response.status_code = 200
     base_client.request.return_value = response
+    logger = Mock(spec=LoggingPortABC)
     metrics = Mock(spec=MetricsPortABC)
     client = _HttpTransport(
         provider="chembl",
         config=ClientConfig(),
         base_client=base_client,
+        logger=logger,
         metrics=metrics,
     )
 
@@ -121,11 +125,13 @@ def test_request_retries_on_server_error(monkeypatch: pytest.MonkeyPatch) -> Non
     second = Mock()
     second.status_code = 200
     base_client.request.side_effect = [first, second]
+    logger = Mock(spec=LoggingPortABC)
     metrics = Mock(spec=MetricsPortABC)
     client = _HttpTransport(
         provider="chembl",
         config=ClientConfig(max_retries=1, backoff_factor=0.1),
         base_client=base_client,
+        logger=logger,
         metrics=metrics,
     )
 

--- a/tests/bioetl/infrastructure/clients/base/test_rate_limiter.py
+++ b/tests/bioetl/infrastructure/clients/base/test_rate_limiter.py
@@ -1,12 +1,19 @@
 import time
+from unittest.mock import Mock
 
+from bioetl.domain.observability import LoggingPortABC
 from bioetl.infrastructure.clients.base.impl.rate_limiter import (
     TokenBucketRateLimiterImpl,
 )
 
 
+def _mock_logger() -> LoggingPortABC:
+    """Create mock logger for tests."""
+    return Mock(spec=LoggingPortABC)
+
+
 def test_rate_limiter_acquire():
-    limiter = TokenBucketRateLimiterImpl(rate=50, capacity=1)
+    limiter = TokenBucketRateLimiterImpl(rate=50, capacity=1, logger=_mock_logger())
     start = time.monotonic()
     limiter.acquire()  # consume 1 (immediate if capacity=1)
 
@@ -17,7 +24,7 @@ def test_rate_limiter_acquire():
 
 
 def test_rate_limiter_refill():
-    limiter = TokenBucketRateLimiterImpl(rate=10, capacity=10)
+    limiter = TokenBucketRateLimiterImpl(rate=10, capacity=10, logger=_mock_logger())
     limiter._tokens = 0
     limiter._last_refill = time.monotonic() - 0.5
     limiter._refill()
@@ -25,5 +32,5 @@ def test_rate_limiter_refill():
 
 
 def test_wait_if_needed():
-    limiter = TokenBucketRateLimiterImpl(rate=1, capacity=1)
+    limiter = TokenBucketRateLimiterImpl(rate=1, capacity=1, logger=_mock_logger())
     limiter.acquire()  # Should not raise

--- a/tests/bioetl/infrastructure/clients/chembl/impl/test_extraction_service.py
+++ b/tests/bioetl/infrastructure/clients/chembl/impl/test_extraction_service.py
@@ -3,10 +3,16 @@
 from unittest.mock import Mock
 
 from bioetl.domain.clients.contracts import DataClientABC
+from bioetl.domain.observability import LoggingPortABC
 from bioetl.domain.ports.providers import DefaultFieldProviderABC
 from bioetl.infrastructure.clients.chembl.impl.chembl_extraction_service_impl import (
     ChemblExtractionServiceImpl,
 )
+
+
+def _mock_logger() -> LoggingPortABC:
+    """Create mock logger for tests."""
+    return Mock(spec=LoggingPortABC)
 
 
 def test_attach_entity_fields_uses_provider():
@@ -18,7 +24,9 @@ def test_attach_entity_fields_uses_provider():
     mock_provider = Mock(spec=DefaultFieldProviderABC)
     mock_provider.get_default_fields.return_value = ["col1", "col2"]
 
-    service = ChemblExtractionServiceImpl(client, field_provider=mock_provider)
+    service = ChemblExtractionServiceImpl(
+        client, logger=_mock_logger(), field_provider=mock_provider
+    )
 
     # Case 1: entity="assay", no fields provided
     filters = {}
@@ -34,7 +42,9 @@ def test_attach_entity_fields_skips_if_fields_present():
     client.provider = "chembl"
     mock_provider = Mock(spec=DefaultFieldProviderABC)
 
-    service = ChemblExtractionServiceImpl(client, field_provider=mock_provider)
+    service = ChemblExtractionServiceImpl(
+        client, logger=_mock_logger(), field_provider=mock_provider
+    )
 
     filters = {"fields": "custom"}
     result = service._attach_entity_fields("assay", filters)
@@ -48,11 +58,11 @@ def test_attach_entity_fields_no_provider():
     client = Mock(spec=DataClientABC)
     client.provider = "chembl"
 
-    service = ChemblExtractionServiceImpl(client, field_provider=None)
+    service = ChemblExtractionServiceImpl(
+        client, logger=_mock_logger(), field_provider=None
+    )
 
     filters = {}
     result = service._attach_entity_fields("assay", filters)
 
     assert "fields" not in result
-
-    pass

--- a/tests/bioetl/infrastructure/clients/chembl/test_factories.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_factories.py
@@ -2,8 +2,15 @@
 Tests for ChEMBL factories.
 """
 
+from unittest.mock import Mock
+
 import pytest
 
+from bioetl.domain.configs import (
+    ChemblSourceConfig,
+    HttpClientConfig,
+)
+from bioetl.domain.observability import LoggingPortABC, MetricsPortABC
 from bioetl.infrastructure.clients.chembl.factories import (
     default_chembl_client,
     default_chembl_extraction_service,
@@ -14,10 +21,18 @@ from bioetl.infrastructure.clients.chembl.impl import (
 from bioetl.infrastructure.clients.chembl.impl.chembl_http_client_impl import (
     ChemblHttpClientImpl,
 )
-from bioetl.domain.configs import (
-    ChemblSourceConfig,
-    HttpClientConfig,
-)
+
+
+@pytest.fixture
+def mock_logger() -> LoggingPortABC:
+    """Create mock logger for tests."""
+    return Mock(spec=LoggingPortABC)
+
+
+@pytest.fixture
+def mock_metrics() -> MetricsPortABC:
+    """Create mock metrics for tests."""
+    return Mock(spec=MetricsPortABC)
 
 
 @pytest.fixture
@@ -34,9 +49,9 @@ def source_config():
     )
 
 
-def test_default_chembl_client_success(source_config):
+def test_default_chembl_client_success(source_config, mock_logger, mock_metrics):
     """Test default ChEMBL client factory with valid config."""
-    client = default_chembl_client(source_config)
+    client = default_chembl_client(source_config, mock_logger, mock_metrics)
     assert isinstance(client, ChemblHttpClientImpl)
     # Check that parameters propagated to request_builder
     assert client.request_builder.base_url == "https://example.com"
@@ -45,26 +60,36 @@ def test_default_chembl_client_success(source_config):
     assert client.rate_limiter.rate == 5.0
 
 
-def test_default_chembl_client_overrides(source_config):
+def test_default_chembl_client_overrides(source_config, mock_logger, mock_metrics):
     """Test overriding config parameters via kwargs."""
     client = default_chembl_client(
-        source_config, base_url="https://override.com", max_url_length=500
+        source_config,
+        mock_logger,
+        mock_metrics,
+        base_url="https://override.com",
+        max_url_length=500,
     )
     assert client.request_builder.base_url == "https://override.com"
     assert client.request_builder.max_url_length == 500
 
 
-def test_default_chembl_extraction_service(source_config):
+def test_default_chembl_extraction_service(source_config, mock_logger, mock_metrics):
     """Test default extraction service factory."""
     source_config.batch_size = 50
-    service = default_chembl_extraction_service(source_config)
+    service = default_chembl_extraction_service(
+        source_config, mock_logger, mock_metrics
+    )
     assert isinstance(service, ChemblExtractionServiceImpl)
     assert isinstance(service.client, ChemblHttpClientImpl)
     assert service.batch_size == 50
 
 
-def test_default_chembl_extraction_service_default_batch(source_config):
+def test_default_chembl_extraction_service_default_batch(
+    source_config, mock_logger, mock_metrics
+):
     """Test default batch size calculation."""
-    service = default_chembl_extraction_service(source_config)
+    service = default_chembl_extraction_service(
+        source_config, mock_logger, mock_metrics
+    )
     # ChEMBL factory uses hard_cap=1000 for batch_size
     assert service.batch_size == 1000

--- a/tests/bioetl/infrastructure/clients/chembl/test_fallback_client.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_fallback_client.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 from bioetl.domain.clients.base.contracts import RateLimiterABC, ResponseParserABC
+from bioetl.domain.observability import LoggingPortABC
 from bioetl.infrastructure.clients.chembl.impl.chembl_http_client_impl import (
     ChemblHttpClientImpl,
 )
@@ -10,6 +12,9 @@ from bioetl.infrastructure.clients.chembl.request_builder import (
 
 
 class DummyParser(ResponseParserABC):
+    def parse(self, raw_response):
+        return []
+
     def parse_response(self, raw_response):
         return []
 
@@ -36,6 +41,7 @@ class DummyResponse:
 
 def test_fallback_switch_on_500(monkeypatch):
     builder = ChemblRequestBuilderImpl(base_url="https://api.example")
+    mock_logger = Mock(spec=LoggingPortABC)
 
     # http.request will return 500 for primary, 200 for fallback
     calls = {"activity": 0}
@@ -54,7 +60,8 @@ def test_fallback_switch_on_500(monkeypatch):
         request_builder=builder,
         response_parser=DummyParser(),
         rate_limiter=DummyLimiter(),
-        client=http,
+        http_client=http,
+        logger=mock_logger,
         fallbacks={"activity": ["activity", "activity_archive"]},
     )
 

--- a/tests/bioetl/infrastructure/clients/chembl/test_http_client.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_http_client.py
@@ -4,6 +4,7 @@ import pytest
 import requests
 
 from bioetl.domain.clients.base.contracts import RateLimiterABC
+from bioetl.domain.observability import LoggingPortABC
 from bioetl.infrastructure.clients.chembl.impl.chembl_http_client_impl import (
     ChemblHttpClientImpl,
 )
@@ -41,19 +42,27 @@ def fixture_rate_limiter():
     return Mock(spec=RateLimiterABC)
 
 
+@pytest.fixture(name="mock_logger")
+def fixture_logger():
+    """Mock logger."""
+    return Mock(spec=LoggingPortABC)
+
+
 @pytest.fixture(name="client")
 def fixture_client(
     mock_request_builder,
     mock_response_parser,
     mock_rate_limiter,
     mock_http_client,
+    mock_logger,
 ):
     """Create ChemblHttpClientImpl instance with mocks."""
     client = ChemblHttpClientImpl(
         request_builder=mock_request_builder,
         response_parser=mock_response_parser,
         rate_limiter=mock_rate_limiter,
-        client=mock_http_client,
+        http_client=mock_http_client,
+        logger=mock_logger,
     )
     return client
 

--- a/tests/bioetl/infrastructure/clients/test_chembl_client.py
+++ b/tests/bioetl/infrastructure/clients/test_chembl_client.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from bioetl.domain.clients.base.contracts import RateLimiterABC
+from bioetl.domain.observability import LoggingPortABC
 from bioetl.infrastructure.clients.chembl.impl.chembl_http_client_impl import (
     ChemblHttpClientImpl,
 )
@@ -17,12 +18,13 @@ from bioetl.infrastructure.clients.chembl.response_parser import (
 @pytest.fixture
 def mock_components():
     request_builder = MagicMock(spec=ChemblRequestBuilderImpl)
-    request_builder.for_endpoint = MagicMock(return_value=request_builder)
+    request_builder.build_for_endpoint = MagicMock(return_value=request_builder)
     return {
         "request_builder": request_builder,
         "response_parser": MagicMock(spec=ChemblResponseParserImpl),
         "rate_limiter": MagicMock(spec=RateLimiterABC),
         "http_client": MagicMock(),
+        "logger": MagicMock(spec=LoggingPortABC),
     }
 
 
@@ -32,7 +34,8 @@ def client(mock_components):
         request_builder=mock_components["request_builder"],
         response_parser=mock_components["response_parser"],
         rate_limiter=mock_components["rate_limiter"],
-        client=mock_components["http_client"],
+        http_client=mock_components["http_client"],
+        logger=mock_components["logger"],
     )
     yield client
 
@@ -40,7 +43,7 @@ def client(mock_components):
 def test_fetch_activity_with_http_client(client, mock_components):
     # Arrange
     mock_builder = mock_components["request_builder"]
-    mock_builder.for_endpoint.return_value = mock_builder
+    mock_builder.build_for_endpoint.return_value = mock_builder
     mock_builder.build.return_value = "http://chembl/activity"
 
     mock_response = MagicMock()
@@ -54,7 +57,7 @@ def test_fetch_activity_with_http_client(client, mock_components):
     result = client.fetch("activity", molecule_chembl_id="CHEMBL123")
 
     # Assert
-    mock_builder.for_endpoint.assert_called_with("activity")
+    mock_builder.build_for_endpoint.assert_called_with("activity")
     mock_builder.build.assert_called_with({"molecule_chembl_id": "CHEMBL123"})
     mock_components["http_client"].request.assert_called_with(
         "GET", "http://chembl/activity"


### PR DESCRIPTION
BREAKING CHANGE: All infrastructure classes now require explicit dependency injection - no default fallbacks.

Changes:
- _HttpTransport: logger, metrics, base_client are now mandatory
- TokenBucketRateLimiterImpl: logger is now mandatory
- ChemblHttpClientImpl: http_client (renamed from client), logger mandatory
- ChemblExtractionServiceImpl: logger is now mandatory

Factories updated:
- build_http_client, default_api_client: require logger and metrics
- build_rate_limiter, default_rate_limiter: require logger
- default_chembl_client: require logger and metrics
- default_chembl_extraction_service: require logger and metrics

New CompositionRoot:
- Created src/bioetl/application/composition_root.py
- Single place for assembling dependency graph
- Supports custom dependencies for testing

Tests updated to pass explicit mock dependencies.