### PR TITLE
Refactor HashService to remove state and dependencies

### DIFF
--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -22,7 +22,12 @@ from bioetl.domain.providers import ProviderDefinition, ProviderId
 from bioetl.domain.record_source import RecordSourceABC
 from bioetl.domain.schemas import register_schemas
 from bioetl.domain.schemas.registry import SchemaRegistry
-from bioetl.domain.transform.contracts import HashServiceABC, NormalizationServiceABC
+from bioetl.domain.transform.contracts import (
+    HashServiceABC,
+    IndexGeneratorABC,
+    NormalizationServiceABC,
+    TimestampProviderABC,
+)
 from bioetl.domain.transform.factories import default_post_transformer
 from bioetl.domain.transform.transformers import TransformerABC
 from bioetl.domain.validation import SchemaProviderABC, ValidatorFactoryABC
@@ -47,6 +52,8 @@ class PipelineContainer(PipelineContainerABC):
         hooks: list[PipelineHookABC] | None = None,
         error_policy: ErrorPolicyABC | None = None,
         hash_service: HashServiceABC | None = None,
+        index_generator: IndexGeneratorABC | None = None,
+        timestamp_provider: TimestampProviderABC | None = None,
         post_transformer: TransformerABC | None = None,
         provider_registry: ProviderRegistryABC | None = None,
         provider_registry_provider: Callable[[], ProviderRegistryABC] | None = None,
@@ -62,6 +69,8 @@ class PipelineContainer(PipelineContainerABC):
         self._hooks: list[PipelineHookABC] | None = list(hooks) if hooks else None
         self._error_policy = error_policy
         self._hash_service = hash_service
+        self._index_generator = index_generator
+        self._timestamp_provider = timestamp_provider
         self._post_transformer = post_transformer
         self._metadata_builder = self._resolve_metadata_builder(metadata_builder)
         self._metrics_port = self._resolve_metrics_port(metrics_port)
@@ -197,10 +206,31 @@ class PipelineContainer(PipelineContainerABC):
         (e.g. interfaces wiring or tests) to avoid application →
         infrastructure dependencies.
         """
-
         if self._hash_service is None:
             raise RuntimeError("Hash service is not configured for this container")
         return self._hash_service
+
+    def get_index_generator(self) -> IndexGeneratorABC:
+        """Get the index generator.
+
+        The concrete implementation must be injected from outer layers
+        (e.g. interfaces wiring or tests) to avoid application →
+        infrastructure dependencies.
+        """
+        if self._index_generator is None:
+            raise RuntimeError("Index generator is not configured for this container")
+        return self._index_generator
+
+    def get_timestamp_provider(self) -> TimestampProviderABC:
+        """Get the timestamp provider.
+
+        The concrete implementation must be injected from outer layers
+        (e.g. interfaces wiring or tests) to avoid application →
+        infrastructure dependencies.
+        """
+        if self._timestamp_provider is None:
+            raise RuntimeError("Timestamp provider is not configured for this container")
+        return self._timestamp_provider
 
     def get_post_transformer(
         self, *, version_provider: Callable[[], str] | None = None
@@ -209,6 +239,8 @@ class PipelineContainer(PipelineContainerABC):
         if self._post_transformer is None:
             self._post_transformer = default_post_transformer(
                 hash_service=self.get_hash_service(),
+                index_generator=self.get_index_generator(),
+                timestamp_provider=self.get_timestamp_provider(),
                 business_key_fields=self._config.quality.hashing.business_key_fields,
                 version_provider=version_provider,
             )

--- a/src/bioetl/domain/transform/__init__.py
+++ b/src/bioetl/domain/transform/__init__.py
@@ -1,6 +1,10 @@
 """Data transformation logic."""
 
-from bioetl.domain.transform.hash_service import HashService
+from bioetl.domain.transform.contracts import (
+    HashServiceABC,
+    IndexGeneratorABC,
+    TimestampProviderABC,
+)
 from bioetl.domain.transform.transformers import (
     DatabaseVersionTransformerImpl,
     FulldateTransformerImpl,
@@ -17,5 +21,7 @@ __all__ = [
     "IndexColumnTransformerImpl",
     "DatabaseVersionTransformerImpl",
     "FulldateTransformerImpl",
-    "HashService",
+    "HashServiceABC",
+    "IndexGeneratorABC",
+    "TimestampProviderABC",
 ]

--- a/src/bioetl/domain/transform/contracts.py
+++ b/src/bioetl/domain/transform/contracts.py
@@ -59,34 +59,53 @@ class NormalizationServiceABC(ABC):
 
 class HashServiceABC(ABC):
     """
-    Фасад для вычисления и добавления хеш-сумм и служебных колонок.
+    Stateless сервис для вычисления и добавления хеш-сумм.
+
+    Отвечает только за хеширование строк и бизнес-ключей.
+    Не содержит stateful логики (индексы, timestamps).
     """
+
+    @abstractmethod
+    def hash_row(self, row: dict) -> str:
+        """Вычисляет хеш строки как полного объекта."""
+
+    @abstractmethod
+    def hash_business_key(self, row: dict, key_columns: list[str]) -> str:
+        """Вычисляет хеш бизнес-ключа (выбранных колонок)."""
 
     @abstractmethod
     def add_hash_columns(
         self, df: pd.DataFrame, business_key_cols: list[str] | None = None
     ) -> pd.DataFrame:
-        """Добавляет hash_row и hash_business_key с учетом бизнес-ключа."""
+        """Добавляет hash_row и hash_business_key колонки к DataFrame."""
+
+
+class TimestampProviderABC(ABC):
+    """
+    Провайдер временных меток для извлечения данных.
+
+    Обеспечивает детерминированный timestamp в рамках сессии.
+    """
 
     @abstractmethod
-    def add_index_column(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Добавляет порядковый индекс строк (int, начиная с 0)."""
+    def get_extraction_timestamp(self) -> datetime:
+        """Возвращает timestamp извлечения данных."""
+
+
+class IndexGeneratorABC(ABC):
+    """
+    Генератор последовательных индексов для строк данных.
+
+    Stateful: сохраняет текущее значение счётчика между вызовами.
+    """
 
     @abstractmethod
-    def add_database_version_column(
-        self, df: pd.DataFrame, database_version: str
-    ) -> pd.DataFrame:
-        """Добавляет колонку database_version."""
+    def next_index(self) -> int:
+        """Возвращает следующий индекс и увеличивает счётчик."""
 
     @abstractmethod
-    def add_fulldate_column(
-        self, df: pd.DataFrame, timestamp: datetime | None = None
-    ) -> pd.DataFrame:
-        """Добавляет колонку extracted_at (UTC ISO-8601) для детерминизма."""
-
-    @abstractmethod
-    def reset_state(self) -> None:
-        """Сбрасывает внутреннее состояние между запусками."""
+    def reset(self) -> None:
+        """Сбрасывает счётчик в начальное состояние."""
 
 
 __all__ = [
@@ -95,4 +114,6 @@ __all__ = [
     "HasherABC",
     "NormalizationServiceABC",
     "HashServiceABC",
+    "TimestampProviderABC",
+    "IndexGeneratorABC",
 ]

--- a/src/bioetl/domain/transform/factories.py
+++ b/src/bioetl/domain/transform/factories.py
@@ -2,7 +2,11 @@
 
 from typing import Callable
 
-from bioetl.domain.transform.contracts import HashServiceABC
+from bioetl.domain.transform.contracts import (
+    HashServiceABC,
+    IndexGeneratorABC,
+    TimestampProviderABC,
+)
 from bioetl.domain.transform.transformers import (
     DatabaseVersionTransformerImpl,
     FulldateTransformerImpl,
@@ -18,22 +22,31 @@ __all__ = ["default_post_transformer"]
 def default_post_transformer(
     *,
     hash_service: HashServiceABC,
+    index_generator: IndexGeneratorABC,
+    timestamp_provider: TimestampProviderABC,
     business_key_fields: list[str] | None,
     version_provider: Callable[[], str | None] | None = None,
 ) -> TransformerABC:
-    """Create a default chain of post-transformers."""
+    """Create a default chain of post-transformers.
 
+    Args:
+        hash_service: Сервис для вычисления хешей.
+        index_generator: Генератор последовательных индексов.
+        timestamp_provider: Провайдер временных меток.
+        business_key_fields: Поля для хеширования бизнес-ключа.
+        version_provider: Опциональный провайдер версии БД.
+
+    Returns:
+        Цепочка трансформеров для пост-обработки данных.
+    """
     provider = version_provider or (lambda: "unknown")
     return TransformerChainImpl(
         [
             HashColumnsTransformerImpl(
                 hash_service=hash_service, business_key_fields=business_key_fields
             ),
-            IndexColumnTransformerImpl(hash_service=hash_service),
-            DatabaseVersionTransformerImpl(
-                hash_service=hash_service,
-                database_version_provider=provider,
-            ),
-            FulldateTransformerImpl(hash_service=hash_service),
+            IndexColumnTransformerImpl(index_generator=index_generator),
+            DatabaseVersionTransformerImpl(database_version_provider=provider),
+            FulldateTransformerImpl(timestamp_provider=timestamp_provider),
         ]
     )

--- a/src/bioetl/domain/transform/hash_service.py
+++ b/src/bioetl/domain/transform/hash_service.py
@@ -1,85 +1,26 @@
-"""Доменный фасад для хеширования и служебных колонок."""
+"""DEPRECATED: HashService moved to infrastructure layer.
+
+This module is kept for backward compatibility only.
+Use bioetl.infrastructure.transform.impl.hash_service.Blake2bHashService instead.
+
+For the abstract interface, use bioetl.domain.transform.contracts.HashServiceABC.
+"""
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Callable
+import warnings
 
-import pandas as pd
+# Re-export for backward compatibility
+from bioetl.infrastructure.transform.impl.hash_service import (
+    Blake2bHashService as HashService,
+)
 
-from bioetl.domain.transform.contracts import HasherABC, HashServiceABC
-
-
-class HashService(HashServiceABC):
-    """Фасад для детерминированного хеширования и служебных колонок."""
-
-    def __init__(
-        self,
-        *,
-        hasher: HasherABC | None = None,
-        now_provider: Callable[[], datetime] | None = None,
-    ) -> None:
-        if hasher is None:
-            raise ValueError("HashService requires a HasherABC instance")
-        self._hasher = hasher
-        self._index_counter = 0
-        self._now_provider = now_provider or (lambda: datetime.now(timezone.utc))
-        self._extracted_at: str | None = None
-
-    def add_hash_columns(
-        self, df: pd.DataFrame, business_key_cols: list[str] | None = None
-    ) -> pd.DataFrame:
-        """Add deterministic row and business-key hashes."""
-        df = df.copy()
-
-        if business_key_cols:
-            cols_to_hash = [c for c in business_key_cols if c in df.columns]
-            if cols_to_hash:
-                df["hash_business_key"] = self._hasher.compute_hash_columns(
-                    df, cols_to_hash
-                )
-            else:
-                df["hash_business_key"] = None
-        else:
-            df["hash_business_key"] = None
-
-        df["hash_row"] = df.apply(self._hasher.compute_hash_row, axis=1)
-        return df
-
-    def add_index_column(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Append sequential index column starting from current state."""
-        df = df.copy()
-        start_index = self._index_counter
-        end_index = start_index + len(df)
-        df["index"] = list(range(start_index, end_index))
-        self._index_counter = end_index
-        return df
-
-    def add_database_version_column(
-        self, df: pd.DataFrame, database_version: str
-    ) -> pd.DataFrame:
-        """Attach database_version column as string."""
-        df = df.copy()
-        df["database_version"] = str(database_version)
-        return df
-
-    def add_fulldate_column(
-        self, df: pd.DataFrame, timestamp: datetime | None = None
-    ) -> pd.DataFrame:
-        """Attach extracted_at in UTC ISO-8601, cached per service instance."""
-        df = df.copy()
-        if self._extracted_at is None:
-            ts = timestamp or self._now_provider()
-            if ts.tzinfo is None:
-                ts = ts.replace(tzinfo=timezone.utc)
-            self._extracted_at = ts.isoformat()
-        df["extracted_at"] = self._extracted_at
-        return df
-
-    def reset_state(self) -> None:
-        """Reset internal counters and cached timestamps."""
-        self._index_counter = 0
-        self._extracted_at = None
-
+warnings.warn(
+    "bioetl.domain.transform.hash_service is deprecated. "
+    "Use bioetl.infrastructure.transform.impl.hash_service.Blake2bHashService instead. "
+    "For the ABC, use bioetl.domain.transform.contracts.HashServiceABC.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 __all__ = ["HashService"]

--- a/src/bioetl/domain/transform/transformers.py
+++ b/src/bioetl/domain/transform/transformers.py
@@ -5,12 +5,17 @@ Domain-level transformers used in pipelines.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from datetime import timezone
 from typing import Callable
 
 import pandas as pd
 
 from bioetl.domain.models import RunContext
-from bioetl.domain.transform.contracts import HashServiceABC
+from bioetl.domain.transform.contracts import (
+    HashServiceABC,
+    IndexGeneratorABC,
+    TimestampProviderABC,
+)
 
 
 class TransformerABC(ABC):
@@ -63,14 +68,22 @@ class HashColumnsTransformerImpl(TransformerABC):
 class IndexColumnTransformerImpl(TransformerABC):
     """Добавляет индексную колонку."""
 
-    def __init__(self, hash_service: HashServiceABC) -> None:
-        self._hash_service = hash_service
+    def __init__(self, index_generator: IndexGeneratorABC) -> None:
+        self._index_generator = index_generator
 
     def apply(
         self, df: pd.DataFrame, context: RunContext | None = None
     ) -> pd.DataFrame:
         """Добавляет порядковый индекс строк."""
-        return self._hash_service.add_index_column(df)
+        df = df.copy()
+        start_index = self._index_generator.next_index()
+        # Generate range of indices for the batch
+        # We need to adjust counter for remaining rows
+        for _ in range(len(df) - 1):
+            self._index_generator.next_index()
+        end_index = start_index + len(df)
+        df["index"] = list(range(start_index, end_index))
+        return df
 
 
 class DatabaseVersionTransformerImpl(TransformerABC):
@@ -78,10 +91,8 @@ class DatabaseVersionTransformerImpl(TransformerABC):
 
     def __init__(
         self,
-        hash_service: HashServiceABC,
         database_version_provider: Callable[[], str | None],
     ) -> None:
-        self._hash_service = hash_service
         self._database_version_provider = database_version_provider
 
     def apply(
@@ -91,21 +102,27 @@ class DatabaseVersionTransformerImpl(TransformerABC):
         version = self._database_version_provider()
         if version is None:
             return df
-        return self._hash_service.add_database_version_column(df, version)
+        df = df.copy()
+        df["database_version"] = str(version)
+        return df
 
 
 class FulldateTransformerImpl(TransformerABC):
     """Добавляет колонку extracted_at с таймстампом."""
 
-    def __init__(self, hash_service: HashServiceABC) -> None:
-        self._hash_service = hash_service
+    def __init__(self, timestamp_provider: TimestampProviderABC) -> None:
+        self._timestamp_provider = timestamp_provider
 
     def apply(
         self, df: pd.DataFrame, context: RunContext | None = None
     ) -> pd.DataFrame:
-        """Добавляет extracted_at из контекста (UTC)."""
-        timestamp = context.started_at if context else None
-        return self._hash_service.add_fulldate_column(df, timestamp=timestamp)
+        """Добавляет extracted_at (UTC ISO-8601)."""
+        df = df.copy()
+        ts = self._timestamp_provider.get_extraction_timestamp()
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        df["extracted_at"] = ts.isoformat()
+        return df
 
 
 __all__ = [

--- a/src/bioetl/infrastructure/clients/base/abc_impls.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_impls.yaml
@@ -65,7 +65,17 @@ HasherABC:
 HashServiceABC:
   default_factory: bioetl.infrastructure.transform.factories.default_hash_service
   implementations:
-    DomainFacade: bioetl.domain.transform.hash_service.HashService
+    Blake2b: bioetl.infrastructure.transform.impl.hash_service.Blake2bHashService
+
+TimestampProviderABC:
+  default_factory: bioetl.infrastructure.transform.factories.default_timestamp_provider
+  implementations:
+    Deterministic: bioetl.infrastructure.transform.impl.timestamp_provider.DeterministicTimestampProvider
+
+IndexGeneratorABC:
+  default_factory: bioetl.infrastructure.transform.factories.default_index_generator
+  implementations:
+    Sequential: bioetl.infrastructure.transform.impl.index_generator.SequentialIndexGenerator
 
 QualityReportABC:
   default_factory: bioetl.infrastructure.output.factories.default_quality_reporter

--- a/src/bioetl/infrastructure/clients/base/abc_registry.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_registry.yaml
@@ -24,6 +24,8 @@ TracingPortABC: bioetl.domain.observability.contracts.TracingPortABC
 
 HasherABC: bioetl.domain.transform.contracts.HasherABC
 HashServiceABC: bioetl.domain.transform.contracts.HashServiceABC
+TimestampProviderABC: bioetl.domain.transform.contracts.TimestampProviderABC
+IndexGeneratorABC: bioetl.domain.transform.contracts.IndexGeneratorABC
 NormalizationServiceABC: bioetl.domain.transform.contracts.NormalizationServiceABC
 
 ValidatorABC: bioetl.domain.validation.contracts.ValidatorABC

--- a/src/bioetl/infrastructure/transform/__init__.py
+++ b/src/bioetl/infrastructure/transform/__init__.py
@@ -3,11 +3,15 @@
 from bioetl.infrastructure.transform.factories import (
     default_hash_service,
     default_hasher,
+    default_index_generator,
     default_normalization_service,
+    default_timestamp_provider,
 )
 
 __all__ = [
     "default_hasher",
     "default_hash_service",
+    "default_timestamp_provider",
+    "default_index_generator",
     "default_normalization_service",
 ]

--- a/src/bioetl/infrastructure/transform/factories.py
+++ b/src/bioetl/infrastructure/transform/factories.py
@@ -1,18 +1,27 @@
 """Factories for transform infrastructure components."""
 
+from __future__ import annotations
+
 import warnings
+from datetime import datetime
 
 from bioetl.domain.transform.contracts import (
     HasherABC,
     HashServiceABC,
+    IndexGeneratorABC,
     NormalizationConfigProviderProtocol,
     NormalizationServiceABC,
+    TimestampProviderABC,
 )
-from bioetl.domain.transform.hash_service import HashService
 from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl import (
     DefaultNormalizationTransformerImpl,
 )
+from bioetl.infrastructure.transform.impl.hash_service import Blake2bHashService
 from bioetl.infrastructure.transform.impl.hasher import HasherImpl
+from bioetl.infrastructure.transform.impl.index_generator import SequentialIndexGenerator
+from bioetl.infrastructure.transform.impl.timestamp_provider import (
+    DeterministicTimestampProvider,
+)
 
 
 def default_hasher() -> HasherABC:
@@ -20,9 +29,42 @@ def default_hasher() -> HasherABC:
     return HasherImpl()
 
 
-def default_hash_service() -> HashServiceABC:
-    """Create default HashService."""
-    return HashService(hasher=default_hasher())
+def default_hash_service(hasher: HasherABC | None = None) -> HashServiceABC:
+    """Create default HashService (Blake2b-based).
+
+    Args:
+        hasher: Optional custom hasher. Uses default if not provided.
+
+    Returns:
+        Stateless hash service for computing row and business key hashes.
+    """
+    return Blake2bHashService(hasher=hasher or default_hasher())
+
+
+def default_timestamp_provider(
+    fixed_time: datetime | None = None,
+) -> TimestampProviderABC:
+    """Create default timestamp provider.
+
+    Args:
+        fixed_time: Optional fixed timestamp. Uses current time if not provided.
+
+    Returns:
+        Deterministic timestamp provider for extraction timestamps.
+    """
+    return DeterministicTimestampProvider(fixed_time=fixed_time)
+
+
+def default_index_generator(start: int = 0) -> IndexGeneratorABC:
+    """Create default index generator.
+
+    Args:
+        start: Starting index value (default 0).
+
+    Returns:
+        Sequential index generator for row indexing.
+    """
+    return SequentialIndexGenerator(start=start)
 
 
 def default_normalization_service(
@@ -57,6 +99,8 @@ def default_chembl_normalization_service(
 __all__ = [
     "default_hasher",
     "default_hash_service",
+    "default_timestamp_provider",
+    "default_index_generator",
     "default_normalization_service",
     "default_chembl_normalization_service",
 ]

--- a/src/bioetl/infrastructure/transform/impl/__init__.py
+++ b/src/bioetl/infrastructure/transform/impl/__init__.py
@@ -7,10 +7,18 @@ from bioetl.infrastructure.transform.impl.chembl_normalization_service_impl impo
 from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl import (
     DefaultNormalizationTransformerImpl,
 )
+from bioetl.infrastructure.transform.impl.hash_service import Blake2bHashService
 from bioetl.infrastructure.transform.impl.hasher import HasherImpl
+from bioetl.infrastructure.transform.impl.index_generator import SequentialIndexGenerator
+from bioetl.infrastructure.transform.impl.timestamp_provider import (
+    DeterministicTimestampProvider,
+)
 
 __all__ = [
     "HasherImpl",
+    "Blake2bHashService",
+    "DeterministicTimestampProvider",
+    "SequentialIndexGenerator",
     "DefaultNormalizationTransformerImpl",
     "ChemblNormalizationService",
     "ChemblNormalizationServiceImpl",  # Deprecated alias

--- a/src/bioetl/infrastructure/transform/impl/hash_service.py
+++ b/src/bioetl/infrastructure/transform/impl/hash_service.py
@@ -1,0 +1,57 @@
+"""Infrastructure implementation of HashService using BLAKE2b."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from bioetl.domain.transform.contracts import HasherABC, HashServiceABC
+
+
+class Blake2bHashService(HashServiceABC):
+    """
+    Stateless хеш-сервис на основе BLAKE2b-256.
+
+    Использует HasherABC для вычисления хешей.
+    Не содержит никакого состояния - чистые функции хеширования.
+    """
+
+    def __init__(self, hasher: HasherABC) -> None:
+        """
+        Args:
+            hasher: Реализация алгоритма хеширования.
+        """
+        self._hasher = hasher
+
+    def hash_row(self, row: dict) -> str:
+        """Вычисляет хеш строки как полного объекта."""
+        series = pd.Series(row)
+        return self._hasher.compute_hash_row(series)
+
+    def hash_business_key(self, row: dict, key_columns: list[str]) -> str:
+        """Вычисляет хеш бизнес-ключа (выбранных колонок)."""
+        df = pd.DataFrame([row])
+        result = self._hasher.compute_hash_columns(df, key_columns)
+        return result.iloc[0]
+
+    def add_hash_columns(
+        self, df: pd.DataFrame, business_key_cols: list[str] | None = None
+    ) -> pd.DataFrame:
+        """Добавляет hash_row и hash_business_key колонки к DataFrame."""
+        df = df.copy()
+
+        if business_key_cols:
+            cols_to_hash = [c for c in business_key_cols if c in df.columns]
+            if cols_to_hash:
+                df["hash_business_key"] = self._hasher.compute_hash_columns(
+                    df, cols_to_hash
+                )
+            else:
+                df["hash_business_key"] = None
+        else:
+            df["hash_business_key"] = None
+
+        df["hash_row"] = df.apply(self._hasher.compute_hash_row, axis=1)
+        return df
+
+
+__all__ = ["Blake2bHashService"]

--- a/src/bioetl/infrastructure/transform/impl/index_generator.py
+++ b/src/bioetl/infrastructure/transform/impl/index_generator.py
@@ -1,0 +1,49 @@
+"""Infrastructure implementation of IndexGenerator."""
+
+from __future__ import annotations
+
+from bioetl.domain.transform.contracts import IndexGeneratorABC
+
+
+class SequentialIndexGenerator(IndexGeneratorABC):
+    """
+    Генератор последовательных индексов.
+
+    Stateful: сохраняет текущее значение счётчика между вызовами.
+    Используется для присвоения уникальных индексов строкам данных.
+    """
+
+    def __init__(self, start: int = 0) -> None:
+        """
+        Args:
+            start: Начальное значение счётчика (по умолчанию 0).
+        """
+        self._start = start
+        self._counter = start
+
+    def next_index(self) -> int:
+        """Возвращает следующий индекс и увеличивает счётчик."""
+        idx = self._counter
+        self._counter += 1
+        return idx
+
+    def reset(self) -> None:
+        """Сбрасывает счётчик в начальное состояние."""
+        self._counter = self._start
+
+    def generate_range(self, count: int) -> list[int]:
+        """
+        Генерирует диапазон индексов для batch операций.
+
+        Args:
+            count: Количество индексов для генерации.
+
+        Returns:
+            Список последовательных индексов.
+        """
+        start = self._counter
+        self._counter += count
+        return list(range(start, start + count))
+
+
+__all__ = ["SequentialIndexGenerator"]

--- a/src/bioetl/infrastructure/transform/impl/timestamp_provider.py
+++ b/src/bioetl/infrastructure/transform/impl/timestamp_provider.py
@@ -1,0 +1,38 @@
+"""Infrastructure implementation of TimestampProvider."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from bioetl.domain.transform.contracts import TimestampProviderABC
+
+
+class DeterministicTimestampProvider(TimestampProviderABC):
+    """
+    Провайдер детерминированных временных меток.
+
+    Фиксирует время при инициализации и возвращает его при всех вызовах.
+    Это обеспечивает детерминизм в рамках одной сессии обработки данных.
+    """
+
+    def __init__(self, fixed_time: datetime | None = None) -> None:
+        """
+        Args:
+            fixed_time: Фиксированное время. Если не указано,
+                        используется текущее время (UTC).
+        """
+        if fixed_time is None:
+            self._time = datetime.now(timezone.utc)
+        else:
+            # Ensure timezone awareness
+            if fixed_time.tzinfo is None:
+                self._time = fixed_time.replace(tzinfo=timezone.utc)
+            else:
+                self._time = fixed_time
+
+    def get_extraction_timestamp(self) -> datetime:
+        """Возвращает зафиксированный timestamp извлечения данных."""
+        return self._time
+
+
+__all__ = ["DeterministicTimestampProvider"]

--- a/src/bioetl/interfaces/container_factory.py
+++ b/src/bioetl/interfaces/container_factory.py
@@ -69,6 +69,12 @@ def build_default_container(
         "OutputFrameConverterABC"
     )
     hash_service_factory = registry_loader.resolve_default_factory("HashServiceABC")
+    timestamp_provider_factory = registry_loader.resolve_default_factory(
+        "TimestampProviderABC"
+    )
+    index_generator_factory = registry_loader.resolve_default_factory(
+        "IndexGeneratorABC"
+    )
 
     logger = logger_factory()
     metrics_port = _create_metrics_port()
@@ -84,6 +90,8 @@ def build_default_container(
     metadata_builder = _create_metadata_builder()
     validator_factory = _create_validator_factory()
     hash_service = hash_service_factory()
+    timestamp_provider = timestamp_provider_factory()
+    index_generator = index_generator_factory()
 
     return PipelineContainer(
         config,
@@ -93,6 +101,8 @@ def build_default_container(
         metadata_builder=metadata_builder,
         metrics_port=metrics_port,
         hash_service=hash_service,
+        timestamp_provider=timestamp_provider,
+        index_generator=index_generator,
         provider_registry=provider_registry,
         provider_registry_provider=provider_registry_provider,
     )

--- a/tests/bioetl/application/pipelines/chembl/test_base.py
+++ b/tests/bioetl/application/pipelines/chembl/test_base.py
@@ -11,7 +11,7 @@ import pytest
 from bioetl.application.pipelines.chembl.base import ChemblPipelineBase
 from bioetl.domain.models import RunContext
 from bioetl.domain.transform.contracts import HasherABC
-from bioetl.domain.transform.hash_service import HashService
+from bioetl.infrastructure.transform.impl.hash_service import Blake2bHashService
 from bioetl.infrastructure.transform.impl.chembl_normalization_service_impl import (
     ChemblNormalizationServiceImpl,
 )
@@ -80,7 +80,7 @@ def mock_dependencies_fixture():
         "validation_service": validation_service,
         "loader": MagicMock(),
         "extraction_service": MagicMock(),
-        "hash_service": HashService(hasher=_DummyHasher()),
+        "hash_service": Blake2bHashService(hasher=_DummyHasher()),
         "metadata_builder": metadata_builder,
         "normalization_service": normalization_service,
     }

--- a/tests/bioetl/domain/transform/test_hash_service.py
+++ b/tests/bioetl/domain/transform/test_hash_service.py
@@ -1,41 +1,161 @@
+"""Tests for transform services (hash, timestamp, index)."""
+
 import re
+from datetime import datetime, timezone
 
 import pandas as pd
 
-from bioetl.infrastructure.transform.factories import default_hash_service
+from bioetl.infrastructure.transform.factories import (
+    default_hash_service,
+    default_index_generator,
+    default_timestamp_provider,
+)
+from bioetl.domain.transform.transformers import (
+    IndexColumnTransformerImpl,
+    DatabaseVersionTransformerImpl,
+    FulldateTransformerImpl,
+)
 
 
-def test_add_index_column_and_immutability():
+def test_hash_service_add_hash_columns():
+    """Test that hash service adds hash columns correctly."""
     svc = default_hash_service()
+    src = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    out = svc.add_hash_columns(src, business_key_cols=["a"])
+
+    assert "hash_row" in out.columns
+    assert "hash_business_key" in out.columns
+    assert "a" not in src.columns or "hash_row" not in src.columns  # immutability
+
+
+def test_hash_service_hash_row():
+    """Test hash_row computes deterministic hash."""
+    svc = default_hash_service()
+    row = {"a": 1, "b": "test"}
+
+    hash1 = svc.hash_row(row)
+    hash2 = svc.hash_row(row)
+
+    assert hash1 == hash2
+    assert len(hash1) == 64  # blake2b-256 hex
+
+
+def test_hash_service_hash_business_key():
+    """Test hash_business_key computes hash for specific columns."""
+    svc = default_hash_service()
+    row = {"a": 1, "b": "test", "c": 3}
+
+    hash1 = svc.hash_business_key(row, ["a", "b"])
+    hash2 = svc.hash_business_key(row, ["a", "b"])
+
+    assert hash1 == hash2
+    assert len(hash1) == 64
+
+
+def test_index_generator_sequential():
+    """Test sequential index generation."""
+    gen = default_index_generator()
+
+    assert gen.next_index() == 0
+    assert gen.next_index() == 1
+    assert gen.next_index() == 2
+
+    gen.reset()
+    assert gen.next_index() == 0
+
+
+def test_index_generator_with_start():
+    """Test index generator with custom start."""
+    gen = default_index_generator(start=100)
+
+    assert gen.next_index() == 100
+    assert gen.next_index() == 101
+
+
+def test_index_column_transformer():
+    """Test IndexColumnTransformerImpl adds index column."""
+    gen = default_index_generator()
+    transformer = IndexColumnTransformerImpl(index_generator=gen)
     src = pd.DataFrame({"a": [1, 2, 3]})
-    out = svc.add_index_column(src)
+
+    out = transformer.apply(src)
+
     assert "index" in out.columns
     assert list(out["index"]) == [0, 1, 2]
-    # исходный df не должен иметь новую колонку
-    assert "index" not in src.columns
+    assert "index" not in src.columns  # immutability
 
 
-def test_add_database_version_column_and_empty_df():
-    svc = default_hash_service()
-    src = pd.DataFrame({"a": []})
-    out = svc.add_database_version_column(src, "v1.2.3")
-    assert "database_version" in out.columns
-    # на пустом df столбец всё равно существует (пустой)
-    assert out["database_version"].dtype == object or out["database_version"].empty
+def test_timestamp_provider_deterministic():
+    """Test deterministic timestamp provider."""
+    fixed_time = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+    provider = default_timestamp_provider(fixed_time=fixed_time)
 
-    src2 = pd.DataFrame({"a": [1]})
-    out2 = svc.add_database_version_column(src2, "v1.2.3")
-    assert all(out2["database_version"] == "v1.2.3")
+    ts1 = provider.get_extraction_timestamp()
+    ts2 = provider.get_extraction_timestamp()
+
+    assert ts1 == ts2 == fixed_time
 
 
-def test_add_fulldate_column_format_and_consistency():
-    svc = default_hash_service()
+def test_timestamp_provider_uses_current_time():
+    """Test timestamp provider uses current time if not fixed."""
+    provider = default_timestamp_provider()
+
+    ts = provider.get_extraction_timestamp()
+
+    assert ts.tzinfo is not None
+    assert (datetime.now(timezone.utc) - ts).total_seconds() < 1
+
+
+def test_fulldate_transformer():
+    """Test FulldateTransformerImpl adds extracted_at column."""
+    fixed_time = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+    provider = default_timestamp_provider(fixed_time=fixed_time)
+    transformer = FulldateTransformerImpl(timestamp_provider=provider)
     src = pd.DataFrame({"a": [1, 2, 3]})
-    out = svc.add_fulldate_column(src)
+
+    out = transformer.apply(src)
+
     assert "extracted_at" in out.columns
     vals = out["extracted_at"].unique()
-    assert len(vals) == 1  # одинаковая метка для всех строк
+    assert len(vals) == 1
     ts = vals[0]
-    assert isinstance(ts, str) and "T" in ts  # простая проверка ISO-формата
-    # можно попробовать парсить, но это не критично — проверим наличие числа года
+    assert isinstance(ts, str) and "T" in ts
     assert re.search(r"\d{4}-\d{2}-\d{2}T", ts)
+
+
+def test_database_version_transformer():
+    """Test DatabaseVersionTransformerImpl adds version column."""
+    transformer = DatabaseVersionTransformerImpl(
+        database_version_provider=lambda: "v1.2.3"
+    )
+    src = pd.DataFrame({"a": [1]})
+
+    out = transformer.apply(src)
+
+    assert "database_version" in out.columns
+    assert all(out["database_version"] == "v1.2.3")
+
+
+def test_database_version_transformer_empty_df():
+    """Test version transformer handles empty DataFrame."""
+    transformer = DatabaseVersionTransformerImpl(
+        database_version_provider=lambda: "v1.2.3"
+    )
+    src = pd.DataFrame({"a": []})
+
+    out = transformer.apply(src)
+
+    assert "database_version" in out.columns
+    assert out["database_version"].dtype == object or out["database_version"].empty
+
+
+def test_database_version_transformer_none_version():
+    """Test version transformer skips when version is None."""
+    transformer = DatabaseVersionTransformerImpl(
+        database_version_provider=lambda: None
+    )
+    src = pd.DataFrame({"a": [1]})
+
+    out = transformer.apply(src)
+
+    assert "database_version" not in out.columns


### PR DESCRIPTION
Split the monolithic HashService (domain layer) into three focused services following the Single Responsibility Principle:

1. HashServiceABC - Stateless hash computation only
   - hash_row() - compute hash for entire row
   - hash_business_key() - compute hash for selected columns
   - add_hash_columns() - add hash columns to DataFrame

2. TimestampProviderABC - Deterministic timestamp management
   - get_extraction_timestamp() - returns fixed timestamp per session

3. IndexGeneratorABC - Sequential index generation
   - next_index() - returns and increments counter
   - reset() - resets counter to initial value

Infrastructure implementations:
- Blake2bHashService - BLAKE2b-256 based hashing
- DeterministicTimestampProvider - fixed timestamp per instance
- SequentialIndexGenerator - simple counter with reset

Architecture improvements:
- Moved concrete implementation from domain to infrastructure layer
- Domain layer now contains only ABCs (contracts)
- Transformers updated to use appropriate single-purpose services
- DI container updated with new service dependencies
- ABC registry updated with new factories