### PR TITLE
Create domain port for API response parsing

### DIFF
--- a/src/bioetl/domain/ports/__init__.py
+++ b/src/bioetl/domain/ports/__init__.py
@@ -1,3 +1,17 @@
 """Domain ports (hexagonal architecture boundaries)."""
 
-__all__: list[str] = []
+from bioetl.domain.ports.parsing import (
+    PaginationInfo,
+    RawPayload,
+    RawRecordDict,
+    RawRecordList,
+    ResponseParserPortABC,
+)
+
+__all__: list[str] = [
+    "PaginationInfo",
+    "RawPayload",
+    "RawRecordDict",
+    "RawRecordList",
+    "ResponseParserPortABC",
+]

--- a/src/bioetl/domain/ports/parsing.py
+++ b/src/bioetl/domain/ports/parsing.py
@@ -1,0 +1,133 @@
+"""Ports for parsing external API responses.
+
+This module defines abstract contracts for parsing raw API responses
+without domain model knowledge, following hexagonal architecture principles.
+Infrastructure adapters implement these ports to parse provider-specific responses
+into generic record dictionaries.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, TypeAlias
+
+# Generic type aliases for infrastructure layer
+# These allow infrastructure code to work without importing domain models
+RawPayload: TypeAlias = dict[str, Any]
+RawRecordDict: TypeAlias = dict[str, Any]
+RawRecordList: TypeAlias = list[RawRecordDict]
+
+
+class ResponseParserPortABC(ABC):
+    """Port for parsing raw API responses without domain model knowledge.
+
+    This abstract base class defines the contract for parsing raw API responses
+    into generic record dictionaries. Implementations in infrastructure layer
+    can parse provider-specific response formats while domain layer remains
+    decoupled from those details.
+
+    Example:
+        >>> class ChemblParserAdapter(ResponseParserPortABC):
+        ...     def parse_to_records(self, raw_response):
+        ...         # Extract records from ChEMBL-specific response structure
+        ...         for key, value in raw_response.items():
+        ...             if isinstance(value, list):
+        ...                 return value
+        ...         return []
+        ...
+        ...     def extract_pagination(self, raw_response):
+        ...         return raw_response.get("page_meta", {})
+    """
+
+    @abstractmethod
+    def parse_to_records(self, raw_response: RawPayload) -> RawRecordList:
+        """Parse raw API response into list of untyped record dicts.
+
+        Args:
+            raw_response: Raw dictionary payload from API response.
+
+        Returns:
+            List of record dictionaries without type validation.
+            Returns empty list if no records found.
+        """
+
+    @abstractmethod
+    def extract_pagination(
+        self, raw_response: RawPayload
+    ) -> dict[str, int | str | None]:
+        """Extract pagination metadata from response.
+
+        Args:
+            raw_response: Raw dictionary payload from API response.
+
+        Returns:
+            Dictionary containing pagination metadata such as
+            total_count, offset, limit, next_url, etc.
+            Keys depend on provider implementation.
+        """
+
+
+@dataclass(frozen=True, slots=True)
+class PaginationInfo:
+    """Value object for pagination metadata.
+
+    Immutable container for pagination state extracted from API responses.
+    Used to track position in paginated result sets.
+
+    Attributes:
+        total_count: Total number of records available (None if unknown).
+        offset: Current offset/starting position in result set.
+        limit: Maximum records per page/request.
+        next_url: URL for next page if cursor-based pagination (None if N/A).
+    """
+
+    total_count: int | None = None
+    offset: int = 0
+    limit: int = 0
+    next_url: str | None = None
+
+    @property
+    def has_more(self) -> bool:
+        """Check if more pages are available.
+
+        Returns:
+            True if there are more records to fetch, False otherwise.
+            Returns True if next_url is set or if offset + limit < total_count.
+        """
+        if self.next_url is not None:
+            return True
+        if self.total_count is not None:
+            return self.offset + self.limit < self.total_count
+        return False
+
+    @classmethod
+    def from_dict(cls, data: dict[str, int | str | None]) -> PaginationInfo:
+        """Create PaginationInfo from a metadata dictionary.
+
+        Args:
+            data: Dictionary with pagination fields
+                (total_count, offset, limit, next_url).
+
+        Returns:
+            New PaginationInfo instance with extracted values.
+        """
+        total = data.get("total_count")
+        offset = data.get("offset")
+        limit = data.get("limit")
+        next_url = data.get("next_url")
+        return cls(
+            total_count=total if isinstance(total, int) else None,
+            offset=offset if isinstance(offset, int) else 0,
+            limit=limit if isinstance(limit, int) else 0,
+            next_url=next_url if isinstance(next_url, str) else None,
+        )
+
+
+__all__ = [
+    "RawPayload",
+    "RawRecordDict",
+    "RawRecordList",
+    "ResponseParserPortABC",
+    "PaginationInfo",
+]

--- a/tests/bioetl/domain/ports/__init__.py
+++ b/tests/bioetl/domain/ports/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for domain ports."""

--- a/tests/bioetl/domain/ports/test_parsing.py
+++ b/tests/bioetl/domain/ports/test_parsing.py
@@ -1,0 +1,286 @@
+"""Tests for parsing port contracts and type aliases."""
+
+from typing import Any
+
+import pytest
+
+from bioetl.domain.ports.parsing import (
+    PaginationInfo,
+    RawPayload,
+    RawRecordDict,
+    RawRecordList,
+    ResponseParserPortABC,
+)
+
+
+class TestTypeAliases:
+    """Tests for type alias compatibility and correctness."""
+
+    def test_raw_payload_accepts_dict(self) -> None:
+        """RawPayload should accept dict[str, Any]."""
+        payload: RawPayload = {"key": "value", "number": 123, "nested": {"a": 1}}
+        assert isinstance(payload, dict)
+        assert payload["key"] == "value"
+
+    def test_raw_record_dict_accepts_dict(self) -> None:
+        """RawRecordDict should accept dict[str, Any]."""
+        record: RawRecordDict = {"id": "123", "name": "test", "value": 42.5}
+        assert isinstance(record, dict)
+        assert record["id"] == "123"
+
+    def test_raw_record_list_accepts_list_of_dicts(self) -> None:
+        """RawRecordList should accept list of record dicts."""
+        records: RawRecordList = [
+            {"id": "1", "name": "first"},
+            {"id": "2", "name": "second"},
+        ]
+        assert isinstance(records, list)
+        assert len(records) == 2
+        assert all(isinstance(r, dict) for r in records)
+
+    def test_type_aliases_are_compatible_with_any_values(self) -> None:
+        """Type aliases should allow Any values in dicts."""
+        payload: RawPayload = {
+            "string": "value",
+            "int": 42,
+            "float": 3.14,
+            "bool": True,
+            "none": None,
+            "list": [1, 2, 3],
+            "nested": {"deep": {"value": "ok"}},
+        }
+        assert payload["string"] == "value"
+        assert payload["nested"]["deep"]["value"] == "ok"
+
+
+class TestResponseParserPortABC:
+    """Tests for ResponseParserPortABC contract."""
+
+    def test_is_abstract_class(self) -> None:
+        """ResponseParserPortABC should not be instantiable directly."""
+        with pytest.raises(TypeError, match="abstract"):
+            ResponseParserPortABC()  # type: ignore[abstract]
+
+    def test_requires_parse_to_records_method(self) -> None:
+        """Implementations must provide parse_to_records method."""
+
+        class IncompleteParser(ResponseParserPortABC):
+            def extract_pagination(
+                self, raw_response: RawPayload
+            ) -> dict[str, int | str | None]:
+                return {}
+
+        with pytest.raises(TypeError, match="abstract"):
+            IncompleteParser()  # type: ignore[abstract]
+
+    def test_requires_extract_pagination_method(self) -> None:
+        """Implementations must provide extract_pagination method."""
+
+        class IncompleteParser(ResponseParserPortABC):
+            def parse_to_records(self, raw_response: RawPayload) -> RawRecordList:
+                return []
+
+        with pytest.raises(TypeError, match="abstract"):
+            IncompleteParser()  # type: ignore[abstract]
+
+    def test_complete_implementation_instantiates(self) -> None:
+        """Complete implementation should be instantiable."""
+
+        class CompleteParser(ResponseParserPortABC):
+            def parse_to_records(self, raw_response: RawPayload) -> RawRecordList:
+                for value in raw_response.values():
+                    if isinstance(value, list):
+                        return value
+                return []
+
+            def extract_pagination(
+                self, raw_response: RawPayload
+            ) -> dict[str, int | str | None]:
+                return raw_response.get("page_meta", {})
+
+        parser = CompleteParser()
+        assert isinstance(parser, ResponseParserPortABC)
+
+    def test_implementation_parses_records(self) -> None:
+        """Implementation should correctly parse records from response."""
+
+        class TestParser(ResponseParserPortABC):
+            def parse_to_records(self, raw_response: RawPayload) -> RawRecordList:
+                return raw_response.get("items", [])
+
+            def extract_pagination(
+                self, raw_response: RawPayload
+            ) -> dict[str, int | str | None]:
+                return raw_response.get("meta", {})
+
+        parser = TestParser()
+        response: RawPayload = {
+            "items": [{"id": "1"}, {"id": "2"}],
+            "meta": {"total_count": 100},
+        }
+        records = parser.parse_to_records(response)
+
+        assert len(records) == 2
+        assert records[0]["id"] == "1"
+        assert records[1]["id"] == "2"
+
+    def test_implementation_extracts_pagination(self) -> None:
+        """Implementation should correctly extract pagination metadata."""
+
+        class TestParser(ResponseParserPortABC):
+            def parse_to_records(self, raw_response: RawPayload) -> RawRecordList:
+                return []
+
+            def extract_pagination(
+                self, raw_response: RawPayload
+            ) -> dict[str, int | str | None]:
+                meta = raw_response.get("page_meta", {})
+                return {
+                    "total_count": meta.get("total_count"),
+                    "offset": meta.get("offset"),
+                    "limit": meta.get("limit"),
+                }
+
+        parser = TestParser()
+        response: RawPayload = {
+            "page_meta": {"total_count": 500, "offset": 0, "limit": 100}
+        }
+        pagination = parser.extract_pagination(response)
+
+        assert pagination["total_count"] == 500
+        assert pagination["offset"] == 0
+        assert pagination["limit"] == 100
+
+
+class TestPaginationInfo:
+    """Tests for PaginationInfo value object."""
+
+    def test_default_values(self) -> None:
+        """PaginationInfo should have sensible defaults."""
+        info = PaginationInfo()
+        assert info.total_count is None
+        assert info.offset == 0
+        assert info.limit == 0
+        assert info.next_url is None
+
+    def test_with_all_fields(self) -> None:
+        """PaginationInfo should accept all fields."""
+        info = PaginationInfo(
+            total_count=1000,
+            offset=100,
+            limit=50,
+            next_url="https://api.example.com/next",
+        )
+        assert info.total_count == 1000
+        assert info.offset == 100
+        assert info.limit == 50
+        assert info.next_url == "https://api.example.com/next"
+
+    def test_is_frozen(self) -> None:
+        """PaginationInfo should be immutable."""
+        info = PaginationInfo(total_count=100)
+        with pytest.raises(AttributeError):
+            info.total_count = 200  # type: ignore[misc]
+
+    def test_has_more_with_next_url(self) -> None:
+        """has_more should return True when next_url is set."""
+        info = PaginationInfo(next_url="https://api.example.com/next")
+        assert info.has_more is True
+
+    def test_has_more_with_remaining_records(self) -> None:
+        """has_more should return True when more records exist."""
+        info = PaginationInfo(total_count=100, offset=0, limit=50)
+        assert info.has_more is True
+
+    def test_has_more_false_at_end(self) -> None:
+        """has_more should return False at end of pagination."""
+        info = PaginationInfo(total_count=100, offset=50, limit=50)
+        assert info.has_more is False
+
+    def test_has_more_false_when_unknown(self) -> None:
+        """has_more should return False when total_count is unknown."""
+        info = PaginationInfo(offset=50, limit=50)
+        assert info.has_more is False
+
+    def test_from_dict_with_complete_data(self) -> None:
+        """from_dict should create instance from complete dict."""
+        data: dict[str, Any] = {
+            "total_count": 500,
+            "offset": 100,
+            "limit": 50,
+            "next_url": "https://api.example.com/page2",
+        }
+        info = PaginationInfo.from_dict(data)
+
+        assert info.total_count == 500
+        assert info.offset == 100
+        assert info.limit == 50
+        assert info.next_url == "https://api.example.com/page2"
+
+    def test_from_dict_with_partial_data(self) -> None:
+        """from_dict should handle partial data with defaults."""
+        data: dict[str, Any] = {"total_count": 200}
+        info = PaginationInfo.from_dict(data)
+
+        assert info.total_count == 200
+        assert info.offset == 0
+        assert info.limit == 0
+        assert info.next_url is None
+
+    def test_from_dict_with_empty_dict(self) -> None:
+        """from_dict should handle empty dict with all defaults."""
+        info = PaginationInfo.from_dict({})
+
+        assert info.total_count is None
+        assert info.offset == 0
+        assert info.limit == 0
+        assert info.next_url is None
+
+    def test_from_dict_ignores_invalid_types(self) -> None:
+        """from_dict should use defaults for invalid types."""
+        data: dict[str, Any] = {
+            "total_count": "not_an_int",
+            "offset": None,
+            "limit": 3.14,
+            "next_url": 123,
+        }
+        info = PaginationInfo.from_dict(data)
+
+        assert info.total_count is None
+        assert info.offset == 0
+        assert info.limit == 0
+        assert info.next_url is None
+
+    def test_equality(self) -> None:
+        """PaginationInfo instances with same values should be equal."""
+        info1 = PaginationInfo(total_count=100, offset=0, limit=50)
+        info2 = PaginationInfo(total_count=100, offset=0, limit=50)
+        assert info1 == info2
+
+    def test_hashable(self) -> None:
+        """PaginationInfo should be hashable (usable in sets/dicts)."""
+        info1 = PaginationInfo(total_count=100)
+        info2 = PaginationInfo(total_count=100)
+        info_set = {info1, info2}
+        assert len(info_set) == 1
+
+
+class TestPortsModuleExports:
+    """Tests for module __all__ exports."""
+
+    def test_all_exports_are_importable(self) -> None:
+        """All items in __all__ should be importable from the module."""
+        from bioetl.domain.ports import parsing
+
+        for name in parsing.__all__:
+            assert hasattr(parsing, name), f"{name} not found in module"
+
+    def test_exports_from_package_init(self) -> None:
+        """All exports should be available from package init."""
+        from bioetl.domain import ports
+
+        assert hasattr(ports, "RawPayload")
+        assert hasattr(ports, "RawRecordDict")
+        assert hasattr(ports, "RawRecordList")
+        assert hasattr(ports, "ResponseParserPortABC")
+        assert hasattr(ports, "PaginationInfo")


### PR DESCRIPTION
Add domain port abstraction for parsing API responses, decoupling infrastructure from domain models:

- RawPayload, RawRecordDict, RawRecordList type aliases for generic data
- ResponseParserPortABC abstract class with parse_to_records and extract_pagination methods
- PaginationInfo immutable value object with has_more property and from_dict factory method
- Comprehensive unit tests for contract and type alias compatibility

This enables infrastructure adapters to implement parsing without importing domain schemas directly, following hexagonal architecture.