### PR TITLE
Create Value Objects for domain identifiers

### DIFF
--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -13,15 +13,19 @@ from bioetl.domain.errors import (
     PipelineStageError,
     ProviderError,
 )
+from bioetl.domain.value_objects import ChemblId, EntityName, RunId
 
 __all__ = [
     "BioetlError",
+    "ChemblId",
     "ClientError",
     "ClientNetworkError",
     "ClientRateLimitError",
     "ClientResponseError",
     "ConfigError",
     "ConfigValidationError",
+    "EntityName",
     "PipelineStageError",
     "ProviderError",
+    "RunId",
 ]

--- a/src/bioetl/domain/errors.py
+++ b/src/bioetl/domain/errors.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any, SupportsIndex
+from typing import TYPE_CHECKING, Any, SupportsIndex
+
+if TYPE_CHECKING:
+    from bioetl.domain.value_objects import RunId
 
 __all__ = [
     "BioetlError",
@@ -88,7 +91,7 @@ class PipelineStageError(BioetlError):
         entity: str,
         stage: str,
         attempt: int,
-        run_id: str,
+        run_id: str | RunId,
         *,
         cause: Exception | None = None,
     ) -> None:
@@ -101,7 +104,7 @@ class PipelineStageError(BioetlError):
         self.entity = entity
         self.stage = stage
         self.attempt = attempt
-        self.run_id = run_id
+        self.run_id = str(run_id)  # Convert RunId to str for pickle compatibility
         self.cause = cause
 
     def __str__(self) -> str:

--- a/src/bioetl/domain/models.py
+++ b/src/bioetl/domain/models.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
-import uuid
+
+from bioetl.domain.value_objects import RunId
 
 
 @dataclass
@@ -28,7 +29,7 @@ class RunContext:
     Содержит информацию о текущем запуске, конфигурации и окружении.
     """
 
-    run_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    run_id: RunId = field(default_factory=RunId.generate)
     entity_name: str = ""
     provider: str = ""
     started_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
@@ -43,7 +44,7 @@ class RunResult:
     Результат выполнения пайплайна.
     """
 
-    run_id: str
+    run_id: RunId
     success: bool
     entity_name: str
     row_count: int

--- a/src/bioetl/domain/value_objects.py
+++ b/src/bioetl/domain/value_objects.py
@@ -1,0 +1,158 @@
+"""
+Value Objects для ключевых идентификаторов.
+
+Обеспечивают type safety и валидацию на уровне типов.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from typing import Self
+
+from pydantic import GetCoreSchemaHandler
+from pydantic_core import CoreSchema, core_schema
+
+
+class RunId:
+    """Value Object для идентификатора запуска pipeline (UUID v4)."""
+
+    __slots__ = ("_value",)
+    _pattern = re.compile(
+        r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    )
+
+    def __init__(self, value: str) -> None:
+        normalized = value.lower()
+        if not self._pattern.match(normalized):
+            raise ValueError(f"Invalid RunId format: {value}")
+        self._value = normalized
+
+    @property
+    def value(self) -> str:
+        return self._value
+
+    def __str__(self) -> str:
+        return self._value
+
+    def __repr__(self) -> str:
+        return f"RunId({self._value!r})"
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, RunId):
+            return self._value == other._value
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(self._value)
+
+    @classmethod
+    def generate(cls) -> Self:
+        """Генерирует новый уникальный RunId."""
+        return cls(str(uuid.uuid4()))
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: type, handler: GetCoreSchemaHandler
+    ) -> CoreSchema:
+        return core_schema.no_info_after_validator_function(
+            cls,
+            core_schema.str_schema(),
+            serialization=core_schema.plain_serializer_function_ser_schema(str),
+        )
+
+
+class EntityName:
+    """Value Object для имени сущности (snake_case)."""
+
+    __slots__ = ("_value",)
+    _pattern = re.compile(r"^[a-z][a-z0-9_]*$")
+    _max_length = 64
+
+    def __init__(self, value: str) -> None:
+        if not self._pattern.match(value):
+            raise ValueError(f"EntityName must be snake_case: {value}")
+        if len(value) > self._max_length:
+            raise ValueError(
+                f"EntityName too long: {len(value)} > {self._max_length}"
+            )
+        self._value = value
+
+    @property
+    def value(self) -> str:
+        return self._value
+
+    def __str__(self) -> str:
+        return self._value
+
+    def __repr__(self) -> str:
+        return f"EntityName({self._value!r})"
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, EntityName):
+            return self._value == other._value
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(self._value)
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: type, handler: GetCoreSchemaHandler
+    ) -> CoreSchema:
+        return core_schema.no_info_after_validator_function(
+            cls,
+            core_schema.str_schema(),
+            serialization=core_schema.plain_serializer_function_ser_schema(str),
+        )
+
+
+class ChemblId:
+    """Value Object для ChEMBL идентификатора (формат CHEMBL123)."""
+
+    __slots__ = ("_value",)
+    _pattern = re.compile(r"^CHEMBL\d+$")
+
+    def __init__(self, value: str) -> None:
+        normalized = value.upper()
+        if not self._pattern.match(normalized):
+            raise ValueError(f"Invalid ChemblId: {value}")
+        self._value = normalized
+
+    @property
+    def value(self) -> str:
+        return self._value
+
+    @property
+    def numeric_id(self) -> int:
+        """Возвращает числовую часть идентификатора."""
+        return int(self._value[6:])
+
+    def __str__(self) -> str:
+        return self._value
+
+    def __repr__(self) -> str:
+        return f"ChemblId({self._value!r})"
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, ChemblId):
+            return self._value == other._value
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(self._value)
+
+    def __lt__(self, other: object) -> bool:
+        if isinstance(other, ChemblId):
+            return self.numeric_id < other.numeric_id
+        return NotImplemented
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: type, handler: GetCoreSchemaHandler
+    ) -> CoreSchema:
+        return core_schema.no_info_after_validator_function(
+            cls,
+            core_schema.str_schema(),
+            serialization=core_schema.plain_serializer_function_ser_schema(str),
+        )


### PR DESCRIPTION
Add type-safe Value Objects to improve domain model integrity:
- RunId: UUID v4 format validation for pipeline run identifiers
- EntityName: snake_case validation with max length 64
- ChemblId: CHEMBL[0-9]+ format validation with numeric_id property

Update RunContext and RunResult to use RunId instead of str. Update PipelineStageError to accept RunId | str for backward compatibility.

All Value Objects include:
- Immutable design with __slots__
- Pydantic core schema support for serialization
- __hash__ and __eq__ for use in collections