### PR TITLE
Create application-level mapper for domain models

### DIFF
--- a/src/bioetl/application/mappers/__init__.py
+++ b/src/bioetl/application/mappers/__init__.py
@@ -1,0 +1,5 @@
+"""Application-level mappers for transforming raw records to domain models."""
+
+from bioetl.application.mappers.contracts import RecordMapperABC
+
+__all__ = ["RecordMapperABC"]

--- a/src/bioetl/application/mappers/chembl/__init__.py
+++ b/src/bioetl/application/mappers/chembl/__init__.py
@@ -1,0 +1,5 @@
+"""ChEMBL-specific record mappers."""
+
+from bioetl.application.mappers.chembl.record_mapper import ChemblRecordMapper
+
+__all__ = ["ChemblRecordMapper"]

--- a/src/bioetl/application/mappers/chembl/record_mapper.py
+++ b/src/bioetl/application/mappers/chembl/record_mapper.py
@@ -1,0 +1,91 @@
+"""ChEMBL-specific record mapper implementation."""
+
+from __future__ import annotations
+
+from bioetl.application.mappers.contracts import RecordMapperABC
+from bioetl.domain.ports.parsing import RawRecordList
+from bioetl.domain.record_source import RawRecord
+from bioetl.domain.schemas.chembl.raw_models import (
+    ActivityRawModel,
+    AssayRawModel,
+    DocumentRawModel,
+    MoleculeRawModel,
+    TargetRawModel,
+)
+
+# Registry mapping entity type -> domain model class
+_ENTITY_MODEL_REGISTRY: dict[str, type[RawRecord]] = {
+    "activity": ActivityRawModel,
+    "molecule": MoleculeRawModel,
+    "target": TargetRawModel,
+    "assay": AssayRawModel,
+    "document": DocumentRawModel,
+}
+
+_SUPPORTED_ENTITIES: frozenset[str] = frozenset(_ENTITY_MODEL_REGISTRY.keys())
+
+
+class ChemblRecordMapper(RecordMapperABC):
+    """Maps raw ChEMBL records to typed domain models.
+
+    This mapper converts untyped dictionaries from the infrastructure
+    layer to validated domain RawRecord instances using Pydantic models.
+
+    Example:
+        >>> mapper = ChemblRecordMapper()
+        >>> raw_records = [{"activity_id": 123, "standard_flag": True}]
+        >>> domain_records = mapper.map_records(raw_records, "activity")
+        >>> assert isinstance(domain_records[0], ActivityRawModel)
+    """
+
+    def map_records(
+        self,
+        raw_records: RawRecordList,
+        entity: str,
+    ) -> list[RawRecord]:
+        """Convert raw dicts to typed ChEMBL domain models.
+
+        Args:
+            raw_records: Untyped records from infrastructure parser.
+            entity: Entity type (activity, assay, target, molecule, document).
+
+        Returns:
+            List of validated domain RawRecord instances.
+
+        Raises:
+            ValueError: If entity type is unknown.
+            ValidationError: If record validation fails (from Pydantic).
+        """
+        model_class = self._get_model_class(entity)
+        return [model_class.model_validate(record) for record in raw_records]
+
+    def get_supported_entities(self) -> frozenset[str]:
+        """Return set of entity names this mapper supports.
+
+        Returns:
+            Frozen set containing: activity, assay, target, molecule, document.
+        """
+        return _SUPPORTED_ENTITIES
+
+    def _get_model_class(self, entity: str) -> type[RawRecord]:
+        """Get model class for entity type.
+
+        Args:
+            entity: Entity type name.
+
+        Returns:
+            Pydantic model class for the entity.
+
+        Raises:
+            ValueError: If entity type is unknown.
+        """
+        model_class = _ENTITY_MODEL_REGISTRY.get(entity)
+        if model_class is None:
+            raise ValueError(
+                f"Unknown entity type: {entity}. "
+                f"Supported entities: {sorted(_SUPPORTED_ENTITIES)}"
+            )
+        return model_class
+
+
+__all__ = ["ChemblRecordMapper"]

--- a/src/bioetl/application/mappers/contracts.py
+++ b/src/bioetl/application/mappers/contracts.py
@@ -1,0 +1,56 @@
+"""Contracts for record mapping between layers."""
+
+from abc import ABC, abstractmethod
+
+from bioetl.domain.ports.parsing import RawRecordList
+from bioetl.domain.record_source import RawRecord
+
+
+class RecordMapperABC(ABC):
+    """Maps raw records from infrastructure to domain models.
+
+    This abstract base class defines the contract for mapping untyped
+    record dictionaries from the infrastructure layer to typed domain
+    RawRecord models. Implementations handle source-specific mapping
+    logic and validation.
+
+    Example:
+        >>> class MyMapper(RecordMapperABC):
+        ...     def map_records(self, raw_records, entity):
+        ...         model_cls = get_model_for_entity(entity)
+        ...         return [model_cls.model_validate(r) for r in raw_records]
+        ...
+        ...     def get_supported_entities(self):
+        ...         return frozenset({"activity", "molecule"})
+    """
+
+    @abstractmethod
+    def map_records(
+        self,
+        raw_records: RawRecordList,
+        entity: str,
+    ) -> list[RawRecord]:
+        """Convert raw dicts to typed domain RawRecord models.
+
+        Args:
+            raw_records: Untyped records from infrastructure parser.
+            entity: Entity type (activity, assay, target, molecule, document).
+
+        Returns:
+            List of validated domain RawRecord instances.
+
+        Raises:
+            ValueError: If entity type is unknown.
+            ValidationError: If record validation fails.
+        """
+
+    @abstractmethod
+    def get_supported_entities(self) -> frozenset[str]:
+        """Return set of entity names this mapper supports.
+
+        Returns:
+            Frozen set of entity type names (e.g., "activity", "molecule").
+        """
+
+
+__all__ = ["RecordMapperABC"]

--- a/tests/bioetl/application/mappers/__init__.py
+++ b/tests/bioetl/application/mappers/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for application mappers."""

--- a/tests/bioetl/application/mappers/test_chembl_record_mapper.py
+++ b/tests/bioetl/application/mappers/test_chembl_record_mapper.py
@@ -1,0 +1,258 @@
+"""Unit tests for ChemblRecordMapper."""
+
+from pydantic import ValidationError
+import pytest
+
+from bioetl.application.mappers.chembl import ChemblRecordMapper
+from bioetl.domain.schemas.chembl.raw_models import (
+    ActivityRawModel,
+    AssayRawModel,
+    DocumentRawModel,
+    MoleculeRawModel,
+    TargetRawModel,
+)
+
+
+class TestChemblRecordMapperActivityMapping:
+    """Tests for activity record mapping."""
+
+    def test_maps_valid_activity_record(self) -> None:
+        """Valid activity dict is mapped to ActivityRawModel."""
+        mapper = ChemblRecordMapper()
+        raw_records = [
+            {
+                "activity_id": 12345,
+                "standard_flag": True,
+                "assay_chembl_id": "CHEMBL123",
+                "molecule_chembl_id": "CHEMBL456",
+            }
+        ]
+
+        result = mapper.map_records(raw_records, "activity")
+
+        assert len(result) == 1
+        assert isinstance(result[0], ActivityRawModel)
+        assert result[0].activity_id == "12345"
+        assert result[0].standard_flag is True
+        assert result[0].assay_chembl_id == "CHEMBL123"
+
+    def test_maps_multiple_activity_records(self) -> None:
+        """Multiple activity records are all mapped correctly."""
+        mapper = ChemblRecordMapper()
+        raw_records = [
+            {"activity_id": 1, "standard_flag": True},
+            {"activity_id": 2, "standard_flag": False},
+            {"activity_id": 3, "standard_flag": True},
+        ]
+
+        result = mapper.map_records(raw_records, "activity")
+
+        assert len(result) == 3
+        assert all(isinstance(r, ActivityRawModel) for r in result)
+        assert [r.activity_id for r in result] == ["1", "2", "3"]
+
+
+class TestChemblRecordMapperMoleculeMapping:
+    """Tests for molecule record mapping."""
+
+    def test_maps_valid_molecule_record(self) -> None:
+        """Valid molecule dict is mapped to MoleculeRawModel."""
+        mapper = ChemblRecordMapper()
+        raw_records = [
+            {
+                "molecule_chembl_id": "CHEMBL25",
+                "pref_name": "ASPIRIN",
+                "molecule_type": "Small molecule",
+                "max_phase": 4,
+            }
+        ]
+
+        result = mapper.map_records(raw_records, "molecule")
+
+        assert len(result) == 1
+        assert isinstance(result[0], MoleculeRawModel)
+        assert result[0].molecule_chembl_id == "CHEMBL25"
+        assert result[0].pref_name == "ASPIRIN"
+        assert result[0].max_phase == 4
+
+
+class TestChemblRecordMapperTargetMapping:
+    """Tests for target record mapping."""
+
+    def test_maps_valid_target_record(self) -> None:
+        """Valid target dict is mapped to TargetRawModel."""
+        mapper = ChemblRecordMapper()
+        raw_records = [
+            {
+                "target_chembl_id": "CHEMBL204",
+                "pref_name": "Cyclooxygenase-2",
+                "organism": "Homo sapiens",
+                "target_type": "SINGLE PROTEIN",
+                "tax_id": 9606,
+            }
+        ]
+
+        result = mapper.map_records(raw_records, "target")
+
+        assert len(result) == 1
+        assert isinstance(result[0], TargetRawModel)
+        assert result[0].target_chembl_id == "CHEMBL204"
+        assert result[0].organism == "Homo sapiens"
+        assert result[0].tax_id == 9606
+
+
+class TestChemblRecordMapperAssayMapping:
+    """Tests for assay record mapping."""
+
+    def test_maps_valid_assay_record(self) -> None:
+        """Valid assay dict is mapped to AssayRawModel."""
+        mapper = ChemblRecordMapper()
+        raw_records = [
+            {
+                "assay_chembl_id": "CHEMBL1217643",
+                "assay_type": "B",
+                "description": "Binding assay",
+                "assay_organism": "Homo sapiens",
+            }
+        ]
+
+        result = mapper.map_records(raw_records, "assay")
+
+        assert len(result) == 1
+        assert isinstance(result[0], AssayRawModel)
+        assert result[0].assay_chembl_id == "CHEMBL1217643"
+        assert result[0].assay_type == "B"
+        assert result[0].description == "Binding assay"
+
+
+class TestChemblRecordMapperDocumentMapping:
+    """Tests for document record mapping."""
+
+    def test_maps_valid_document_record(self) -> None:
+        """Valid document dict is mapped to DocumentRawModel."""
+        mapper = ChemblRecordMapper()
+        raw_records = [
+            {
+                "document_chembl_id": "CHEMBL1125443",
+                "journal": "J. Med. Chem.",
+                "year": 2007,
+                "pubmed_id": 17181143,
+                "doi": "10.1021/jm0610232",
+            }
+        ]
+
+        result = mapper.map_records(raw_records, "document")
+
+        assert len(result) == 1
+        assert isinstance(result[0], DocumentRawModel)
+        assert result[0].document_chembl_id == "CHEMBL1125443"
+        assert result[0].journal == "J. Med. Chem."
+        assert result[0].year == 2007
+        assert result[0].pubmed_id == 17181143
+
+
+class TestChemblRecordMapperUnknownEntity:
+    """Tests for unknown entity handling."""
+
+    def test_raises_value_error_for_unknown_entity(self) -> None:
+        """ValueError is raised when entity type is not supported."""
+        mapper = ChemblRecordMapper()
+        raw_records = [{"id": 1}]
+
+        with pytest.raises(ValueError, match="Unknown entity type: unknown"):
+            mapper.map_records(raw_records, "unknown")
+
+    def test_error_message_lists_supported_entities(self) -> None:
+        """Error message includes list of supported entity types."""
+        mapper = ChemblRecordMapper()
+        raw_records = [{"id": 1}]
+
+        with pytest.raises(ValueError) as exc_info:
+            mapper.map_records(raw_records, "invalid_entity")
+
+        error_msg = str(exc_info.value)
+        assert "activity" in error_msg
+        assert "molecule" in error_msg
+        assert "target" in error_msg
+        assert "assay" in error_msg
+        assert "document" in error_msg
+
+
+class TestChemblRecordMapperValidationError:
+    """Tests for validation error handling."""
+
+    def test_raises_validation_error_for_missing_required_field(self) -> None:
+        """ValidationError is raised when required field is missing."""
+        mapper = ChemblRecordMapper()
+        # activity_id is required but missing
+        raw_records = [{"standard_flag": True}]
+
+        with pytest.raises(ValidationError):
+            mapper.map_records(raw_records, "activity")
+
+    def test_raises_validation_error_for_invalid_type(self) -> None:
+        """ValidationError is raised when field has invalid type."""
+        mapper = ChemblRecordMapper()
+        # standard_flag must be bool
+        raw_records = [
+            {
+                "activity_id": 1,
+                "standard_flag": "not_a_boolean",
+            }
+        ]
+
+        with pytest.raises(ValidationError):
+            mapper.map_records(raw_records, "activity")
+
+    def test_raises_validation_error_for_extra_fields_in_activity(self) -> None:
+        """ValidationError is raised for extra fields in ActivityRawModel.
+
+        ActivityRawModel uses extra='forbid' configuration.
+        """
+        mapper = ChemblRecordMapper()
+        raw_records = [
+            {
+                "activity_id": 1,
+                "standard_flag": True,
+                "unknown_extra_field": "should_fail",
+            }
+        ]
+
+        with pytest.raises(ValidationError):
+            mapper.map_records(raw_records, "activity")
+
+
+class TestChemblRecordMapperSupportedEntities:
+    """Tests for get_supported_entities method."""
+
+    def test_returns_frozenset(self) -> None:
+        """Method returns a frozenset."""
+        mapper = ChemblRecordMapper()
+        result = mapper.get_supported_entities()
+        assert isinstance(result, frozenset)
+
+    def test_contains_all_entity_types(self) -> None:
+        """Returned set contains all five entity types."""
+        mapper = ChemblRecordMapper()
+        supported = mapper.get_supported_entities()
+
+        expected = {"activity", "molecule", "target", "assay", "document"}
+        assert supported == expected
+
+    def test_frozenset_is_immutable(self) -> None:
+        """Returned frozenset cannot be modified."""
+        mapper = ChemblRecordMapper()
+        supported = mapper.get_supported_entities()
+
+        with pytest.raises(AttributeError):
+            supported.add("new_entity")  # type: ignore[attr-defined]
+
+
+class TestChemblRecordMapperEmptyInput:
+    """Tests for empty input handling."""
+
+    def test_empty_list_returns_empty_list(self) -> None:
+        """Empty input list returns empty output list."""
+        mapper = ChemblRecordMapper()
+        result = mapper.map_records([], "activity")
+        assert result == []


### PR DESCRIPTION
Introduces RecordMapperABC contract and ChemblRecordMapper implementation to convert raw dict records from infrastructure layer to typed domain models (ActivityRawModel, MoleculeRawModel, etc.). This moves domain model instantiation from infrastructure to application layer per hexagonal architecture.