### PR TITLE
Refactor parser to support generic types

### DIFF
--- a/src/bioetl/infrastructure/clients/chembl/response_parser.py
+++ b/src/bioetl/infrastructure/clients/chembl/response_parser.py
@@ -1,19 +1,140 @@
 """Response parser for ChEMBL API responses."""
 
-from typing import Generic, TypeVar
+from __future__ import annotations
+
 import warnings
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from pydantic import BaseModel, TypeAdapter
 
-from bioetl.domain.clients.base.contracts import ResponseParserABC
-from bioetl.domain.schemas.chembl.raw_models import ActivityRawModel
+from bioetl.domain.ports.parsing import (
+    RawPayload,
+    RawRecordList,
+    ResponseParserPortABC,
+)
+
+if TYPE_CHECKING:
+    from bioetl.domain.clients.base.contracts import ResponseParserABC
+    from bioetl.domain.schemas.chembl.raw_models import ActivityRawModel
 
 T = TypeVar("T", bound=BaseModel)
 
 
-class ChemblResponseParserImpl(ResponseParserABC[T], Generic[T]):
+# =============================================================================
+# New Generic Parser (Recommended)
+# =============================================================================
+
+
+class ChemblGenericResponseParser(ResponseParserPortABC):
+    """Generic parser that returns untyped dicts.
+
+    This parser belongs to infrastructure because:
+    - It handles HTTP response structure (page_meta, nested lists)
+    - It doesn't know about domain models
+    - It only extracts raw data from API-specific format
+
+    Example:
+        >>> parser = ChemblGenericResponseParser()
+        >>> records = parser.parse_to_records({"activities": [{"id": "1"}]})
+        >>> pagination = parser.extract_pagination(response)
     """
-    Generic parser for ChEMBL API responses.
+
+    def parse_to_records(self, raw_response: RawPayload) -> RawRecordList:
+        """Extract list of records from ChEMBL response.
+
+        Args:
+            raw_response: Raw dictionary payload from ChEMBL API.
+
+        Returns:
+            List of record dictionaries without type validation.
+            Returns empty list if no records found.
+        """
+        for key, value in raw_response.items():
+            if isinstance(value, list):
+                # Return as-is without validation
+                return [
+                    dict(item) if isinstance(item, dict) else {"value": item}
+                    for item in value
+                ]
+        return []
+
+    def extract_pagination(
+        self, raw_response: RawPayload
+    ) -> dict[str, int | str | None]:
+        """Extract page_meta from ChEMBL response.
+
+        Args:
+            raw_response: Raw dictionary payload from ChEMBL API.
+
+        Returns:
+            Dictionary containing pagination metadata:
+            total_count, offset, limit, next.
+        """
+        page_meta = raw_response.get("page_meta", {})
+        if not isinstance(page_meta, dict):
+            page_meta = {}
+        return {
+            "total_count": page_meta.get("total_count"),
+            "offset": page_meta.get("offset"),
+            "limit": page_meta.get("limit"),
+            "next": page_meta.get("next"),
+        }
+
+
+# =============================================================================
+# Factory Functions
+# =============================================================================
+
+
+def create_generic_parser() -> ResponseParserPortABC:
+    """Create parser for generic dict output (recommended).
+
+    Returns:
+        ChemblGenericResponseParser instance that parses responses
+        into untyped dictionaries.
+
+    Example:
+        >>> parser = create_generic_parser()
+        >>> records = parser.parse_to_records(response)
+    """
+    return ChemblGenericResponseParser()
+
+
+def create_activity_parser() -> ChemblResponseParserImpl[ActivityRawModel]:
+    """Factory for creating activity parser.
+
+    .. deprecated:: 1.0
+        Use :func:`create_generic_parser` instead.
+        This function will be removed in version 2.0.
+
+    Returns:
+        ChemblResponseParserImpl configured for ActivityRawModel.
+    """
+    warnings.warn(
+        "create_activity_parser() is deprecated. "
+        "Use create_generic_parser() and application-layer mapping instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    # Lazy import to avoid domain coupling at module level
+    from bioetl.domain.schemas.chembl.raw_models import (
+        ActivityRawModel as ActivityModel,
+    )
+
+    return ChemblResponseParserImpl(ActivityModel)
+
+
+# =============================================================================
+# Deprecated Classes (Backward Compatibility)
+# =============================================================================
+
+
+class ChemblResponseParserImpl(Generic[T]):
+    """Generic parser for ChEMBL API responses.
+
+    .. deprecated:: 1.0
+        Use :class:`ChemblGenericResponseParser` instead.
+        This class will be removed in version 2.0.
 
     Supports parsing any Pydantic model from ChEMBL API responses.
 
@@ -23,16 +144,28 @@ class ChemblResponseParserImpl(ResponseParserABC[T], Generic[T]):
     """
 
     def __init__(self, model_class: type[T]) -> None:
-        """
-        Initialize parser with model class.
+        """Initialize parser with model class.
 
         Args:
             model_class: Pydantic model class to use for validation.
         """
+        warnings.warn(
+            "ChemblResponseParserImpl is deprecated. "
+            "Use ChemblGenericResponseParser and application-layer mapping instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._model_class = model_class
 
     def parse(self, raw_response: dict[str, object]) -> list[T]:
-        """Parse raw response into models."""
+        """Parse raw response into models.
+
+        Args:
+            raw_response: Raw dictionary payload from ChEMBL API.
+
+        Returns:
+            List of validated Pydantic model instances.
+        """
         for key, value in raw_response.items():
             if isinstance(value, list) and (not value or isinstance(value[0], dict)):
                 return [self._model_class.model_validate(item) for item in value]
@@ -54,7 +187,14 @@ class ChemblResponseParserImpl(ResponseParserABC[T], Generic[T]):
     def extract_metadata(
         self, raw_response: dict[str, object]
     ) -> dict[str, int | str | None]:
-        """Return pagination metadata section from response."""
+        """Return pagination metadata section from response.
+
+        Args:
+            raw_response: Raw dictionary payload from ChEMBL API.
+
+        Returns:
+            Dictionary containing pagination metadata.
+        """
         adapter: TypeAdapter[dict[str, int | str | None]] = TypeAdapter(
             dict[str, int | str | None]
         )
@@ -63,9 +203,21 @@ class ChemblResponseParserImpl(ResponseParserABC[T], Generic[T]):
 
 
 # Backward compatibility alias
-ChemblActivityResponseParser = ChemblResponseParserImpl[ActivityRawModel]
+def _get_activity_parser_alias() -> type[ChemblResponseParserImpl[Any]]:
+    """Get ChemblActivityResponseParser type alias with lazy import."""
+    return ChemblResponseParserImpl
 
 
-def create_activity_parser() -> ChemblResponseParserImpl[ActivityRawModel]:
-    """Factory for creating activity parser (backward compatibility)."""
-    return ChemblResponseParserImpl(ActivityRawModel)
+# This alias is deprecated but kept for backward compatibility
+ChemblActivityResponseParser = ChemblResponseParserImpl
+
+
+__all__ = [
+    # New recommended API
+    "ChemblGenericResponseParser",
+    "create_generic_parser",
+    # Deprecated (backward compatibility)
+    "ChemblResponseParserImpl",
+    "ChemblActivityResponseParser",
+    "create_activity_parser",
+]

--- a/tests/bioetl/infrastructure/clients/chembl/test_generic_response_parser.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_generic_response_parser.py
@@ -1,0 +1,275 @@
+"""Tests for ChemblGenericResponseParser."""
+
+import warnings
+
+import pytest
+
+from bioetl.domain.ports.parsing import ResponseParserPortABC
+from bioetl.infrastructure.clients.chembl.response_parser import (
+    ChemblGenericResponseParser,
+    ChemblResponseParserImpl,
+    create_activity_parser,
+    create_generic_parser,
+)
+
+
+class TestChemblGenericResponseParser:
+    """Tests for the new generic parser."""
+
+    def test_implements_port_interface(self):
+        """Test that parser implements ResponseParserPortABC."""
+        parser = ChemblGenericResponseParser()
+        assert isinstance(parser, ResponseParserPortABC)
+
+    def test_parse_to_records_returns_list_of_dicts(self):
+        """Test parse_to_records returns list[dict]."""
+        parser = ChemblGenericResponseParser()
+        response = {
+            "activities": [
+                {"activity_id": "1", "standard_flag": True},
+                {"activity_id": "2", "standard_flag": False},
+            ],
+            "page_meta": {"limit": 20},
+        }
+        records = parser.parse_to_records(response)
+
+        assert isinstance(records, list)
+        assert len(records) == 2
+        assert all(isinstance(r, dict) for r in records)
+        assert records[0]["activity_id"] == "1"
+        assert records[1]["activity_id"] == "2"
+
+    def test_parse_to_records_empty_response(self):
+        """Test parse_to_records with no list data."""
+        parser = ChemblGenericResponseParser()
+        response = {"page_meta": {"offset": 0}}
+        records = parser.parse_to_records(response)
+
+        assert records == []
+
+    def test_parse_to_records_empty_list(self):
+        """Test parse_to_records with empty list."""
+        parser = ChemblGenericResponseParser()
+        response = {"activities": [], "page_meta": {}}
+        records = parser.parse_to_records(response)
+
+        assert records == []
+
+    def test_parse_to_records_molecules(self):
+        """Test parse_to_records with molecules data."""
+        parser = ChemblGenericResponseParser()
+        response = {
+            "molecules": [
+                {"molecule_chembl_id": "CHEMBL1", "pref_name": "Aspirin"},
+                {"molecule_chembl_id": "CHEMBL2"},
+            ],
+        }
+        records = parser.parse_to_records(response)
+
+        assert len(records) == 2
+        assert records[0]["molecule_chembl_id"] == "CHEMBL1"
+        assert records[0]["pref_name"] == "Aspirin"
+
+    def test_parse_to_records_non_dict_items(self):
+        """Test parse_to_records wraps non-dict items."""
+        parser = ChemblGenericResponseParser()
+        response = {"values": ["item1", "item2", 123]}
+        records = parser.parse_to_records(response)
+
+        assert len(records) == 3
+        assert records[0] == {"value": "item1"}
+        assert records[1] == {"value": "item2"}
+        assert records[2] == {"value": 123}
+
+    def test_parse_to_records_preserves_all_fields(self):
+        """Test that all fields are preserved without validation."""
+        parser = ChemblGenericResponseParser()
+        response = {
+            "items": [
+                {
+                    "known_field": "value",
+                    "unknown_field": "also preserved",
+                    "nested": {"key": "value"},
+                    "number": 123,
+                    "bool": True,
+                    "null": None,
+                },
+            ],
+        }
+        records = parser.parse_to_records(response)
+
+        assert len(records) == 1
+        record = records[0]
+        assert record["known_field"] == "value"
+        assert record["unknown_field"] == "also preserved"
+        assert record["nested"] == {"key": "value"}
+        assert record["number"] == 123
+        assert record["bool"] is True
+        assert record["null"] is None
+
+
+class TestExtractPagination:
+    """Tests for pagination extraction."""
+
+    def test_extract_pagination_full_metadata(self):
+        """Test extract_pagination with full page_meta."""
+        parser = ChemblGenericResponseParser()
+        response = {
+            "activities": [],
+            "page_meta": {
+                "total_count": 1000,
+                "offset": 100,
+                "limit": 20,
+                "next": "/api/activities?offset=120",
+            },
+        }
+        pagination = parser.extract_pagination(response)
+
+        assert pagination["total_count"] == 1000
+        assert pagination["offset"] == 100
+        assert pagination["limit"] == 20
+        assert pagination["next"] == "/api/activities?offset=120"
+
+    def test_extract_pagination_partial_metadata(self):
+        """Test extract_pagination with partial page_meta."""
+        parser = ChemblGenericResponseParser()
+        response = {
+            "page_meta": {
+                "offset": 0,
+                "limit": 20,
+            },
+        }
+        pagination = parser.extract_pagination(response)
+
+        assert pagination["total_count"] is None
+        assert pagination["offset"] == 0
+        assert pagination["limit"] == 20
+        assert pagination["next"] is None
+
+    def test_extract_pagination_missing_page_meta(self):
+        """Test extract_pagination when page_meta is missing."""
+        parser = ChemblGenericResponseParser()
+        response = {"activities": []}
+        pagination = parser.extract_pagination(response)
+
+        assert pagination["total_count"] is None
+        assert pagination["offset"] is None
+        assert pagination["limit"] is None
+        assert pagination["next"] is None
+
+    def test_extract_pagination_invalid_page_meta_type(self):
+        """Test extract_pagination when page_meta is not a dict."""
+        parser = ChemblGenericResponseParser()
+        response = {"page_meta": "invalid"}
+        pagination = parser.extract_pagination(response)
+
+        assert pagination["total_count"] is None
+        assert pagination["offset"] is None
+        assert pagination["limit"] is None
+        assert pagination["next"] is None
+
+
+class TestCreateGenericParser:
+    """Tests for create_generic_parser factory."""
+
+    def test_create_generic_parser_returns_correct_type(self):
+        """Test factory returns ChemblGenericResponseParser."""
+        parser = create_generic_parser()
+        assert isinstance(parser, ChemblGenericResponseParser)
+        assert isinstance(parser, ResponseParserPortABC)
+
+    def test_create_generic_parser_no_deprecation_warning(self):
+        """Test factory does not emit deprecation warning."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            create_generic_parser()
+            deprecation_warnings = [
+                x for x in w if issubclass(x.category, DeprecationWarning)
+            ]
+            assert len(deprecation_warnings) == 0
+
+
+class TestDeprecationWarnings:
+    """Tests for deprecation warnings on old classes."""
+
+    def test_chembl_response_parser_impl_emits_warning(self):
+        """Test ChemblResponseParserImpl emits deprecation warning."""
+        from pydantic import BaseModel
+
+        class DummyModel(BaseModel):
+            id: str
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            ChemblResponseParserImpl(DummyModel)
+
+            deprecation_warnings = [
+                x for x in w if issubclass(x.category, DeprecationWarning)
+            ]
+            assert len(deprecation_warnings) == 1
+            assert "ChemblResponseParserImpl is deprecated" in str(
+                deprecation_warnings[0].message
+            )
+
+    def test_create_activity_parser_emits_warning(self):
+        """Test create_activity_parser emits deprecation warning."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            create_activity_parser()
+
+            deprecation_warnings = [
+                x for x in w if issubclass(x.category, DeprecationWarning)
+            ]
+            # Should have at least 1 warning for the factory function
+            # (the impl class also emits one, so we may see 2)
+            assert len(deprecation_warnings) >= 1
+            warning_messages = [str(dw.message) for dw in deprecation_warnings]
+            assert any("create_activity_parser" in msg for msg in warning_messages)
+
+    def test_deprecated_parser_still_works(self):
+        """Test deprecated parser still functions correctly."""
+        from pydantic import BaseModel
+
+        class TestModel(BaseModel):
+            name: str
+            value: int
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            parser = ChemblResponseParserImpl(TestModel)
+
+            response = {
+                "items": [
+                    {"name": "test1", "value": 1},
+                    {"name": "test2", "value": 2},
+                ],
+            }
+            records = parser.parse(response)
+
+            assert len(records) == 2
+            assert isinstance(records[0], TestModel)
+            assert records[0].name == "test1"
+            assert records[1].value == 2
+
+
+class TestNodomainImportsAtModuleLevel:
+    """Tests to verify domain models are not imported at module level."""
+
+    def test_generic_parser_has_no_domain_model_dependencies(self):
+        """Verify ChemblGenericResponseParser doesn't use domain models."""
+        import inspect
+
+        source = inspect.getsource(ChemblGenericResponseParser)
+        # Should not reference any *RawModel classes
+        assert "ActivityRawModel" not in source
+        assert "MoleculeRawModel" not in source
+        assert "TargetRawModel" not in source
+
+    def test_module_does_not_import_raw_models_at_top(self):
+        """Verify raw_models is not imported at module level."""
+        import bioetl.infrastructure.clients.chembl.response_parser as module
+
+        # Check the module's __dict__ for ActivityRawModel
+        # It should only be available via TYPE_CHECKING or lazy import
+        module_vars = dir(module)
+        assert "ActivityRawModel" not in module_vars


### PR DESCRIPTION
Add ChemblGenericResponseParser that returns untyped dicts instead of domain models. This follows hexagonal architecture by keeping domain model knowledge out of infrastructure layer.

Changes:
- Add ChemblGenericResponseParser implementing ResponseParserPortABC
- Add create_generic_parser() factory function (recommended API)
- Mark ChemblResponseParserImpl as deprecated with warnings
- Mark create_activity_parser() as deprecated
- Move domain model imports to lazy loading for backward compatibility
- Add comprehensive unit tests for new generic parser

The deprecated classes still work but emit DeprecationWarning.