### PR TITLE
Refactor naming to match domain language

### DIFF
--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -1,5 +1,9 @@
 """
 Domain layer package.
+
+Terminology updates (v3.0 migration):
+    - SourceRecord: Canonical name for records from data sources.
+      Deprecated alias: RawRecord (will be removed in v3.0).
 """
 
 from bioetl.domain.errors import (
@@ -13,6 +17,11 @@ from bioetl.domain.errors import (
     PipelineStageError,
     ProviderError,
 )
+from bioetl.domain.record_source import (
+    InMemoryRecordSource,
+    RecordSourceABC,
+    SourceRecord,
+)
 from bioetl.domain.value_objects import ChemblId, EntityName, RunId
 
 __all__ = [
@@ -25,7 +34,10 @@ __all__ = [
     "ConfigError",
     "ConfigValidationError",
     "EntityName",
+    "InMemoryRecordSource",
     "PipelineStageError",
     "ProviderError",
+    "RecordSourceABC",
     "RunId",
+    "SourceRecord",
 ]

--- a/src/bioetl/domain/configs/__init__.py
+++ b/src/bioetl/domain/configs/__init__.py
@@ -46,6 +46,7 @@ from bioetl.domain.configs.pipeline import (
     ProviderHttpConfig,
     QcConfig,
     QualityConfig,
+    QualityControlConfig,
     RuntimeConfig,
     StorageConfig,
     TransformConfig,
@@ -87,7 +88,7 @@ __all__ = [
     "PaginationConfig",
     "ProfileConfig",
     "QualityConfig",
-    "QcConfig",
+    "QualityControlConfig",
     "StorageConfig",
     "TransformConfig",
     # Defaults configs
@@ -107,4 +108,5 @@ __all__ = [
     "HttpClientDefaults",  # Use HttpClientConfig
     "HttpClientSettings",  # Use ProviderHttpConfig
     "HTTP_CLIENT_DEFAULTS",  # Use HttpClientConfig()
+    "QcConfig",  # Use QualityControlConfig
 ]

--- a/src/bioetl/domain/configs/pipeline.py
+++ b/src/bioetl/domain/configs/pipeline.py
@@ -187,14 +187,42 @@ class DeterminismConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class QcConfig(BaseModel):
-    """Quality control configuration."""
+class QualityControlConfig(BaseModel):
+    """Quality control configuration.
+
+    This is the canonical name for QC configuration in the domain model.
+    """
 
     enable_quality_report: bool = True
     enable_correlation_report: bool = True
     min_coverage: float = 0.85
 
     model_config = ConfigDict(extra="forbid")
+
+
+def _qc_config_deprecation_warning() -> None:
+    """Emit deprecation warning for QcConfig."""
+    import warnings
+
+    warnings.warn(
+        "QcConfig is deprecated, use QualityControlConfig instead. "
+        "Will be removed in v3.0.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
+# Deprecated alias for backward compatibility
+# TODO: Remove in v3.0
+class QcConfig(QualityControlConfig):
+    """Deprecated: Use QualityControlConfig instead.
+
+    Will be removed in v3.0.
+    """
+
+    def __init__(self, **data):
+        _qc_config_deprecation_warning()
+        super().__init__(**data)
 
 
 class CanonicalizationConfig(BaseModel):
@@ -457,11 +485,21 @@ class QualityConfig(BaseModel):
     """Quality and determinism section."""
 
     determinism: DeterminismConfig = Field(default_factory=DeterminismConfig)
-    qc: QcConfig = Field(default_factory=QcConfig)
+    quality_control: QualityControlConfig = Field(
+        default_factory=QualityControlConfig, alias="qc"
+    )
     hashing: HashingConfig = Field(default_factory=HashingConfig)
     normalization: NormalizationConfig = Field(default_factory=NormalizationConfig)
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    @property
+    def qc(self) -> QualityControlConfig:
+        """Deprecated: Use .quality_control instead.
+
+        Backward compatibility property. Will be removed in v3.0.
+        """
+        return self.quality_control
 
 
 class FeatureFlagsConfig(BaseModel):
@@ -691,7 +729,7 @@ __all__ = [
     "LoggingConfig",
     "MetricsConfig",
     "DeterminismConfig",
-    "QcConfig",
+    "QualityControlConfig",
     "HashingConfig",
     "CanonicalizationConfig",
     "BusinessKeyConfig",
@@ -703,4 +741,5 @@ __all__ = [
     "HttpClientDefaults",  # Use HttpClientConfig
     "HttpClientSettings",  # Use ProviderHttpConfig
     "HTTP_CLIENT_DEFAULTS",  # Use HttpClientConfig()
+    "QcConfig",  # Use QualityControlConfig
 ]

--- a/src/bioetl/domain/record_source.py
+++ b/src/bioetl/domain/record_source.py
@@ -1,34 +1,62 @@
 """Core record source interfaces and helpers.
 
 This module defines the abstract interface for record sources (RecordSourceABC)
-and the RawRecord value object. Concrete implementations that involve
+and the SourceRecord value object. Concrete implementations that involve
 orchestration logic are located in the application layer.
 
 See also:
     - bioetl.application.sources.ApiRecordSource: API-based record source
     - bioetl.application.files: File-based record sources
+
+Terminology:
+    SourceRecord: A record extracted from a data source before normalization.
+    RawRecord: Deprecated alias for SourceRecord (will be removed in v3.0).
 """
 
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict
 
 
-class RawRecord(BaseModel):
-    """Raw record model before normalization."""
+class SourceRecord(BaseModel):
+    """Record extracted from a data source before normalization.
+
+    This is the canonical name for raw records in the domain model.
+    """
 
     model_config = ConfigDict(extra="allow")
+
+
+def __getattr__(name: str):
+    """Module-level __getattr__ for deprecation warnings."""
+    if name == "RawRecord":
+        warnings.warn(
+            "RawRecord is deprecated, use SourceRecord instead. "
+            "Will be removed in v3.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return SourceRecord
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+# Type alias for backward compatibility
+# TODO: Remove in v3.0
+if TYPE_CHECKING:
+    RawRecord = SourceRecord
 
 
 class RecordSourceABC(ABC):
     """Abstract base class for record sources returning record batches."""
 
     @abstractmethod
-    def iter_records(self) -> Iterable[list[RawRecord]]:
-        """Return iterable over raw record batches as lists of mappings."""
+    def iter_records(self) -> Iterable[list[SourceRecord]]:
+        """Return iterable over source record batches as lists of mappings."""
 
 
 class InMemoryRecordSource(RecordSourceABC):
@@ -36,13 +64,13 @@ class InMemoryRecordSource(RecordSourceABC):
 
     def __init__(
         self,
-        records: list[RawRecord],
+        records: list[SourceRecord],
         chunk_size: int | None = None,
     ):
         self._records = list(records)
         self._chunk_size = chunk_size
 
-    def iter_records(self) -> Iterable[list[RawRecord]]:
+    def iter_records(self) -> Iterable[list[SourceRecord]]:
         """Yield in-memory records in configured chunk sizes."""
         if self._chunk_size is None or self._chunk_size <= 0:
             yield self._records[:]

--- a/src/bioetl/domain/schemas/chembl/base.py
+++ b/src/bioetl/domain/schemas/chembl/base.py
@@ -1,4 +1,9 @@
-"""Shared mixins and helpers for ChEMBL Pandera schemas."""
+"""Shared mixins and helpers for ChEMBL Pandera schemas.
+
+Terminology:
+    acquisition_timestamp: Timestamp when the data was acquired from the source.
+        Deprecated alias: extracted_at (will be removed in v3.0).
+"""
 
 from typing import Any
 
@@ -6,13 +11,21 @@ import pandera.pandas as pa
 from pandera.typing import Series
 
 HEX_64_PATTERN = r"^[a-f0-9]{64}$"
+
+# Canonical column names for generated columns
 GENERATED_COLUMN_ORDER: list[str] = [
     "hash_row",
     "hash_business_key",
     "index",
     "database_version",
-    "extracted_at",
+    "acquisition_timestamp",
 ]
+
+# Deprecated column name mapping (for backward compatibility)
+# TODO: Remove in v3.0
+DEPRECATED_COLUMN_ALIASES: dict[str, str] = {
+    "extracted_at": "acquisition_timestamp",
+}
 
 
 def build_output_column_order(business_columns: list[str]) -> list[str]:
@@ -26,7 +39,12 @@ _FieldMapping = dict[str, _FieldDefinition]
 
 
 class BaseGeneratedColumnsModel(pa.DataFrameModel):
-    """Базовая схема с едиными служебными колонками и Config."""
+    """Базовая схема с едиными служебными колонками и Config.
+
+    Column naming:
+        acquisition_timestamp: Canonical name for the data acquisition timestamp.
+            Deprecated alias: extracted_at (will be removed in v3.0).
+    """
 
     hash_row: Series[str] = pa.Field(
         str_matches=HEX_64_PATTERN,
@@ -41,8 +59,10 @@ class BaseGeneratedColumnsModel(pa.DataFrameModel):
     database_version: Series[str] = pa.Field(
         nullable=True, description="Версия базы данных"
     )
-    extracted_at: Series[str] = pa.Field(
-        nullable=True, description="Дата и время извлечения"
+    acquisition_timestamp: Series[str] = pa.Field(
+        nullable=True,
+        description="Дата и время получения данных из источника",
+        alias="extracted_at",  # Backward compatibility alias
     )
 
     class Config:

--- a/src/bioetl/domain/transform/contracts.py
+++ b/src/bioetl/domain/transform/contracts.py
@@ -1,5 +1,13 @@
-"""Domain-level transform contracts and DTOs."""
+"""Domain-level transform contracts and DTOs.
 
+Terminology:
+    compute_row_fingerprint: Computes a hash of the entire row.
+        Deprecated alias: hash_row (will be removed in v3.0).
+    compute_entity_key: Computes a hash of the business key columns.
+        Deprecated alias: hash_business_key (will be removed in v3.0).
+"""
+
+import warnings
 from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Any, Protocol
@@ -63,21 +71,63 @@ class HashServiceABC(ABC):
 
     Отвечает только за хеширование строк и бизнес-ключей.
     Не содержит stateful логики (индексы, timestamps).
+
+    Terminology:
+        compute_row_fingerprint: Canonical name for row hashing.
+        compute_entity_key: Canonical name for business key hashing.
+        hash_row: Deprecated alias for compute_row_fingerprint.
+        hash_business_key: Deprecated alias for compute_entity_key.
     """
 
     @abstractmethod
-    def hash_row(self, row: dict) -> str:
-        """Вычисляет хеш строки как полного объекта."""
+    def compute_row_fingerprint(self, row: dict) -> str:
+        """Вычисляет хеш-отпечаток строки как полного объекта.
+
+        This is the canonical method name for row hashing.
+        """
 
     @abstractmethod
-    def hash_business_key(self, row: dict, key_columns: list[str]) -> str:
-        """Вычисляет хеш бизнес-ключа (выбранных колонок)."""
+    def compute_entity_key(self, row: dict, key_columns: list[str]) -> str:
+        """Вычисляет хеш бизнес-ключа (выбранных колонок).
+
+        This is the canonical method name for business key hashing.
+        """
 
     @abstractmethod
     def add_hash_columns(
         self, df: pd.DataFrame, business_key_cols: list[str] | None = None
     ) -> pd.DataFrame:
         """Добавляет hash_row и hash_business_key колонки к DataFrame."""
+
+    # =========================================================================
+    # Deprecated aliases (will be removed in v3.0)
+    # =========================================================================
+
+    def hash_row(self, row: dict) -> str:
+        """Deprecated: Use compute_row_fingerprint() instead.
+
+        Will be removed in v3.0.
+        """
+        warnings.warn(
+            "hash_row() is deprecated, use compute_row_fingerprint() instead. "
+            "Will be removed in v3.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.compute_row_fingerprint(row)
+
+    def hash_business_key(self, row: dict, key_columns: list[str]) -> str:
+        """Deprecated: Use compute_entity_key() instead.
+
+        Will be removed in v3.0.
+        """
+        warnings.warn(
+            "hash_business_key() is deprecated, use compute_entity_key() instead. "
+            "Will be removed in v3.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.compute_entity_key(row, key_columns)
 
 
 class TimestampProviderABC(ABC):

--- a/src/bioetl/infrastructure/transform/impl/hash_service.py
+++ b/src/bioetl/infrastructure/transform/impl/hash_service.py
@@ -1,4 +1,9 @@
-"""Infrastructure implementation of HashService using BLAKE2b."""
+"""Infrastructure implementation of HashService using BLAKE2b.
+
+Terminology:
+    compute_row_fingerprint: Computes a hash fingerprint of the entire row.
+    compute_entity_key: Computes a hash of the business key columns.
+"""
 
 from __future__ import annotations
 
@@ -13,6 +18,10 @@ class Blake2bHashService(HashServiceABC):
 
     Использует HasherABC для вычисления хешей.
     Не содержит никакого состояния - чистые функции хеширования.
+
+    Methods:
+        compute_row_fingerprint: Canonical method for row hashing.
+        compute_entity_key: Canonical method for business key hashing.
     """
 
     def __init__(self, hasher: HasherABC) -> None:
@@ -22,13 +31,28 @@ class Blake2bHashService(HashServiceABC):
         """
         self._hasher = hasher
 
-    def hash_row(self, row: dict) -> str:
-        """Вычисляет хеш строки как полного объекта."""
+    def compute_row_fingerprint(self, row: dict) -> str:
+        """Вычисляет хеш-отпечаток строки как полного объекта.
+
+        Args:
+            row: Словарь с данными строки.
+
+        Returns:
+            Hex-строка с хешем строки.
+        """
         series = pd.Series(row)
         return self._hasher.compute_hash_row(series)
 
-    def hash_business_key(self, row: dict, key_columns: list[str]) -> str:
-        """Вычисляет хеш бизнес-ключа (выбранных колонок)."""
+    def compute_entity_key(self, row: dict, key_columns: list[str]) -> str:
+        """Вычисляет хеш бизнес-ключа (выбранных колонок).
+
+        Args:
+            row: Словарь с данными строки.
+            key_columns: Список колонок бизнес-ключа.
+
+        Returns:
+            Hex-строка с хешем бизнес-ключа.
+        """
         df = pd.DataFrame([row])
         result = self._hasher.compute_hash_columns(df, key_columns)
         return result.iloc[0]


### PR DESCRIPTION
Introduce canonical domain terminology with deprecated aliases for backward compatibility. All deprecated names will be removed in v3.0.

Terminology changes:
- RawRecord → SourceRecord (record_source.py)
- hash_row() → compute_row_fingerprint() (contracts.py)
- hash_business_key() → compute_entity_key() (contracts.py)
- QcConfig → QualityControlConfig (pipeline.py)
- extracted_at → acquisition_timestamp (base.py)

Each deprecated alias emits DeprecationWarning when used.