### PR TITLE
Update ChemblExtractionServiceImpl to return generic dicts

### DIFF
--- a/src/bioetl/infrastructure/clients/chembl/factories.py
+++ b/src/bioetl/infrastructure/clients/chembl/factories.py
@@ -1,5 +1,4 @@
-"""
-Factories for ChEMBL clients.
+"""Factories for ChEMBL clients.
 
 All factories require explicit dependencies - no implicit defaults.
 Use CompositionRoot for creating instances with default implementations.
@@ -11,6 +10,7 @@ from bioetl.domain.clients.contracts import DataClientABC
 from bioetl.domain.configs import ChemblSourceConfig, HttpClientConfig
 from bioetl.domain.observability.contracts import LoggingPortABC, MetricsPortABC
 from bioetl.domain.ports.extraction import ExtractionServiceABC
+from bioetl.domain.ports.parsing import ResponseParserPortABC
 from bioetl.domain.ports.providers import DefaultFieldProviderABC
 from bioetl.infrastructure.clients.base.factories import (
     build_http_client,
@@ -26,7 +26,7 @@ from bioetl.infrastructure.clients.chembl.request_builder import (
     ChemblRequestBuilderImpl,
 )
 from bioetl.infrastructure.clients.chembl.response_parser import (
-    create_activity_parser,
+    ChemblGenericResponseParser,
 )
 
 
@@ -74,7 +74,7 @@ def default_chembl_client(
             base_url=base_url,
             max_url_length=max_url_length,
         ),
-        response_parser=create_activity_parser(),
+        response_parser=ChemblGenericResponseParser(),
         rate_limiter=rate_limiter,
         http_client=unified_client,
         logger=logger,
@@ -91,9 +91,9 @@ def default_chembl_extraction_service(
     *,
     client: DataClientABC | None = None,
     field_provider: DefaultFieldProviderABC | None = None,
+    parser: ResponseParserPortABC | None = None,
 ) -> ExtractionServiceABC:
-    """
-    Create ChEMBL extraction service with explicit dependencies.
+    """Create ChEMBL extraction service with generic parser.
 
     Args:
         config: Source configuration.
@@ -102,9 +102,10 @@ def default_chembl_extraction_service(
         http_config: Optional HTTP configuration.
         client: Optional pre-created client.
         field_provider: Optional field provider.
+        parser: Optional parser instance (defaults to ChemblGenericResponseParser).
 
     Returns:
-        Configured extraction service.
+        Configured extraction service returning raw dicts.
     """
     resolved_config = http_config or config.http
 
@@ -119,4 +120,5 @@ def default_chembl_extraction_service(
         # Allow provider config to set batch_size while keeping a generous hard cap
         batch_size=config.resolve_effective_batch_size(hard_cap=1000),
         field_provider=field_provider,
+        parser=parser or ChemblGenericResponseParser(),
     )

--- a/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
@@ -1,6 +1,4 @@
-"""
-Implementation of ChemblExtractionService.
-"""
+"""Implementation of ChemblExtractionService."""
 
 from __future__ import annotations
 
@@ -10,19 +8,21 @@ from bioetl.domain.clients.contracts import DataClientABC
 from bioetl.domain.observability.contracts import LoggingPortABC
 from bioetl.domain.ports.extraction import (
     ExtractionServiceABC,
+    RawRecordBatch,
     VersionProviderABC,
 )
+from bioetl.domain.ports.parsing import ResponseParserPortABC
 from bioetl.domain.ports.providers import DefaultFieldProviderABC
-from bioetl.domain.record_source import RawRecord
 from bioetl.infrastructure.clients.chembl.constants import ENTITY_ENDPOINT_ALIASES
-from bioetl.infrastructure.clients.chembl.parser_registry import get_parser_for_entity
+from bioetl.infrastructure.clients.chembl.response_parser import (
+    ChemblGenericResponseParser,
+)
 
 
 class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
-    """
-    Implementation of record fetcher for ChEMBL.
-    Uses DataClientABC (expected to be ChemblHttpClientImpl) to fetch data.
+    """Extraction service for ChEMBL data.
 
+    Returns raw dicts - domain model mapping is application layer responsibility.
     All dependencies must be explicitly injected - no default fallbacks.
     Use composition root or factories to create instances.
     """
@@ -33,11 +33,14 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
         logger: LoggingPortABC,
         batch_size: int = 1000,
         field_provider: DefaultFieldProviderABC | None = None,
+        *,
+        parser: ResponseParserPortABC | None = None,
     ) -> None:
         self.client = client
         self.batch_size = batch_size
         self.logger = logger
         self.field_provider = field_provider
+        self._parser = parser or ChemblGenericResponseParser()
         self._version_cache: str | None = None
 
     def get_release_version(self) -> str:
@@ -84,26 +87,25 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
 
         return new_filters
 
-    def extract_all(self, entity: str, **filters: object) -> list[RawRecord]:
-        """
-        Extract all records for an entity matching the filters.
+    def extract_all(self, entity: str, **filters: object) -> RawRecordBatch:
+        """Extract all records for an entity as raw dicts.
 
         Args:
             entity: The entity name.
             **filters: Query filters.
 
         Returns:
-            list[RawRecord]: List of extracted records.
+            All matching records as list[dict[str, Any]].
         """
-        records = []
+        records: RawRecordBatch = []
         for batch in self.iter_extract(entity, **filters):
             records.extend(batch)
         return records
 
     def iter_extract(
         self, entity: str, *, chunk_size: int | None = None, **filters: object
-    ) -> Iterable[list[RawRecord]]:
-        """Stream records from ChEMBL."""
+    ) -> Iterable[RawRecordBatch]:
+        """Stream records from ChEMBL as raw dicts."""
         if chunk_size is None:
             chunk_size = filters.get("limit", self.batch_size)
         filters["limit"] = chunk_size
@@ -135,7 +137,8 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
 
         # Iterate pages
         for page_data in self.client.iter_pages(url):
-            records = self.parse_response(page_data, entity=mapped_entity)
+            # Use generic parser for raw dict output
+            records: RawRecordBatch = self._parser.parse_to_records(page_data)
             yield records
 
     def request_batch(
@@ -158,40 +161,29 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
         filters = {filter_key: ",".join(batch_ids), "limit": len(batch_ids)}
         return self.client.fetch(entity, **filters)
 
-    def parse_response(
-        self, raw_response: dict[str, object], *, entity: str = "activity"
-    ) -> list[RawRecord]:
-        """
-        Parse raw response into a list of records.
+    def parse_response(self, raw_response: object) -> RawRecordBatch:
+        """Parse raw response into record dicts.
 
         Args:
-            raw_response: The raw API response.
-            entity: Entity type for selecting appropriate parser.
+            raw_response: Raw API response object.
 
         Returns:
-            list[RawRecord]: List of parsed records.
+            Parsed records as list[dict[str, Any]].
         """
-        # Try client's parser first (for backward compatibility)
-        if hasattr(self.client, "response_parser"):
-            parser = getattr(self.client, "response_parser")
-            if hasattr(parser, "parse"):
-                return parser.parse(raw_response)
-
-        # Use registry to get appropriate parser for entity type
-        parser = get_parser_for_entity(entity)
-        return parser.parse(raw_response)
+        if not isinstance(raw_response, dict):
+            return []
+        return self._parser.parse_to_records(raw_response)
 
     def serialize_records(
-        self, entity: str, records: list[RawRecord]
-    ) -> list[RawRecord]:
-        """
-        Serialize records for storage.
+        self, entity: str, records: RawRecordBatch
+    ) -> RawRecordBatch:
+        """Serialize records for storage.
 
         Args:
             entity: Entity name.
-            records: List of records.
+            records: List of record dicts.
 
         Returns:
-            list[RawRecord]: Serialized records.
+            Serialized records as list[dict[str, Any]].
         """
         return records

--- a/tests/bioetl/infrastructure/clients/chembl/impl/test_extraction_service.py
+++ b/tests/bioetl/infrastructure/clients/chembl/impl/test_extraction_service.py
@@ -2,11 +2,17 @@
 
 from unittest.mock import Mock
 
+import pytest
+
 from bioetl.domain.clients.contracts import DataClientABC
 from bioetl.domain.observability import LoggingPortABC
+from bioetl.domain.ports.parsing import ResponseParserPortABC
 from bioetl.domain.ports.providers import DefaultFieldProviderABC
 from bioetl.infrastructure.clients.chembl.impl.chembl_extraction_service_impl import (
     ChemblExtractionServiceImpl,
+)
+from bioetl.infrastructure.clients.chembl.response_parser import (
+    ChemblGenericResponseParser,
 )
 
 
@@ -66,3 +72,133 @@ def test_attach_entity_fields_no_provider():
     result = service._attach_entity_fields("assay", filters)
 
     assert "fields" not in result
+
+
+# =============================================================================
+# Generic Parser Tests
+# =============================================================================
+
+
+def test_service_uses_default_generic_parser():
+    """Test that service defaults to ChemblGenericResponseParser."""
+    client = Mock(spec=DataClientABC)
+
+    service = ChemblExtractionServiceImpl(client, logger=_mock_logger())
+
+    assert isinstance(service._parser, ChemblGenericResponseParser)
+
+
+def test_service_accepts_injected_parser():
+    """Test that parser can be injected via DI."""
+    client = Mock(spec=DataClientABC)
+    mock_parser = Mock(spec=ResponseParserPortABC)
+
+    service = ChemblExtractionServiceImpl(
+        client, logger=_mock_logger(), parser=mock_parser
+    )
+
+    assert service._parser is mock_parser
+
+
+def test_parse_response_returns_list_of_dicts():
+    """Test that parse_response returns list[dict], not typed models."""
+    client = Mock(spec=DataClientABC)
+    service = ChemblExtractionServiceImpl(client, logger=_mock_logger())
+
+    raw_response = {
+        "activities": [
+            {"activity_id": "1", "value": 10.5},
+            {"activity_id": "2", "value": 20.0},
+        ]
+    }
+
+    result = service.parse_response(raw_response)
+
+    # Should return list of plain dicts
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert all(isinstance(r, dict) for r in result)
+    # Verify data is preserved
+    assert result[0]["activity_id"] == "1"
+    assert result[1]["value"] == 20.0
+
+
+def test_parse_response_with_non_dict_returns_empty_list():
+    """Test parse_response gracefully handles non-dict input."""
+    client = Mock(spec=DataClientABC)
+    service = ChemblExtractionServiceImpl(client, logger=_mock_logger())
+
+    # Non-dict input should return empty list
+    assert service.parse_response(None) == []
+    assert service.parse_response("string") == []
+    assert service.parse_response([1, 2, 3]) == []
+
+
+def test_parse_response_delegates_to_parser():
+    """Test that parse_response delegates to injected parser."""
+    client = Mock(spec=DataClientABC)
+    mock_parser = Mock(spec=ResponseParserPortABC)
+    mock_parser.parse_to_records.return_value = [{"id": "parsed"}]
+
+    service = ChemblExtractionServiceImpl(
+        client, logger=_mock_logger(), parser=mock_parser
+    )
+
+    raw_response = {"data": [{"id": "raw"}]}
+    result = service.parse_response(raw_response)
+
+    mock_parser.parse_to_records.assert_called_once_with(raw_response)
+    assert result == [{"id": "parsed"}]
+
+
+def test_extract_all_returns_list_of_dicts():
+    """Test that extract_all returns list[dict[str, Any]]."""
+    client = Mock(spec=DataClientABC)
+    client.provider = "chembl"
+
+    # Create mock request builder
+    mock_builder = Mock()
+    mock_builder.build.return_value = "http://test.com/api"
+    client.request_builder = mock_builder
+
+    # Mock iter_pages to return raw response
+    client.iter_pages.return_value = [
+        {"activities": [{"id": "1"}, {"id": "2"}]}
+    ]
+
+    service = ChemblExtractionServiceImpl(client, logger=_mock_logger())
+
+    result = service.extract_all("activity")
+
+    # Should return list of dicts
+    assert isinstance(result, list)
+    assert all(isinstance(r, dict) for r in result)
+    assert len(result) == 2
+
+
+def test_iter_extract_yields_batches_of_dicts():
+    """Test that iter_extract yields batches of raw dicts."""
+    client = Mock(spec=DataClientABC)
+    client.provider = "chembl"
+
+    mock_builder = Mock()
+    mock_builder.build.return_value = "http://test.com/api"
+    client.request_builder = mock_builder
+
+    # Simulate two pages
+    client.iter_pages.return_value = [
+        {"molecules": [{"chembl_id": "CHEMBL1"}]},
+        {"molecules": [{"chembl_id": "CHEMBL2"}]},
+    ]
+
+    service = ChemblExtractionServiceImpl(client, logger=_mock_logger())
+
+    batches = list(service.iter_extract("molecule"))
+
+    assert len(batches) == 2
+    # Each batch is a list of dicts
+    assert all(isinstance(batch, list) for batch in batches)
+    assert all(isinstance(record, dict) for batch in batches for record in batch)
+    # Verify data preserved
+    assert batches[0][0]["chembl_id"] == "CHEMBL1"
+    assert batches[1][0]["chembl_id"] == "CHEMBL2"

--- a/tests/bioetl/infrastructure/clients/chembl/test_factories.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_factories.py
@@ -1,6 +1,4 @@
-"""
-Tests for ChEMBL factories.
-"""
+"""Tests for ChEMBL factories."""
 
 from unittest.mock import Mock
 
@@ -11,6 +9,7 @@ from bioetl.domain.configs import (
     HttpClientConfig,
 )
 from bioetl.domain.observability import LoggingPortABC, MetricsPortABC
+from bioetl.domain.ports.parsing import ResponseParserPortABC
 from bioetl.infrastructure.clients.chembl.factories import (
     default_chembl_client,
     default_chembl_extraction_service,
@@ -20,6 +19,9 @@ from bioetl.infrastructure.clients.chembl.impl import (
 )
 from bioetl.infrastructure.clients.chembl.impl.chembl_http_client_impl import (
     ChemblHttpClientImpl,
+)
+from bioetl.infrastructure.clients.chembl.response_parser import (
+    ChemblGenericResponseParser,
 )
 
 
@@ -93,3 +95,26 @@ def test_default_chembl_extraction_service_default_batch(
     )
     # ChEMBL factory uses hard_cap=1000 for batch_size
     assert service.batch_size == 1000
+
+
+def test_default_chembl_extraction_service_uses_generic_parser(
+    source_config, mock_logger, mock_metrics
+):
+    """Test that factory creates service with generic parser by default."""
+    service = default_chembl_extraction_service(
+        source_config, mock_logger, mock_metrics
+    )
+    assert isinstance(service._parser, ChemblGenericResponseParser)
+
+
+def test_default_chembl_extraction_service_accepts_custom_parser(
+    source_config, mock_logger, mock_metrics
+):
+    """Test that parser can be injected via factory."""
+    custom_parser = Mock(spec=ResponseParserPortABC)
+
+    service = default_chembl_extraction_service(
+        source_config, mock_logger, mock_metrics, parser=custom_parser
+    )
+
+    assert service._parser is custom_parser


### PR DESCRIPTION
…c dicts

Aligns implementation with updated ExtractionServiceABC contract:
- Replace typed RawRecord returns with RawRecordBatch (list[dict])
- Inject ChemblGenericResponseParser via DI instead of using typed parsers
- Remove dependency on deprecated get_parser_for_entity from parser_registry
- Update factory to support parser injection parameter
- Add comprehensive tests for generic dict return types and DI