### PR TITLE
Integrate RecordMapper into pipeline flow

### DIFF
--- a/src/bioetl/application/pipelines/chembl/__init__.py
+++ b/src/bioetl/application/pipelines/chembl/__init__.py
@@ -5,9 +5,11 @@ Provides pipeline implementation and factory for ChEMBL data source.
 """
 
 from bioetl.application.pipelines.chembl.base import ChemblPipelineBase
+from bioetl.application.pipelines.chembl.common import ChemblCommonPipeline
 from bioetl.application.pipelines.chembl.factories import ChemblPipelineFactory
 
 __all__ = [
+    "ChemblCommonPipeline",
     "ChemblPipelineBase",
     "ChemblPipelineFactory",
 ]

--- a/src/bioetl/application/pipelines/chembl/common.py
+++ b/src/bioetl/application/pipelines/chembl/common.py
@@ -1,0 +1,68 @@
+"""Common ChEMBL pipeline with record mapping support."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from bioetl.application.mappers.chembl.record_mapper import ChemblRecordMapper
+from bioetl.application.pipelines.chembl.base import ChemblPipelineBase
+from bioetl.application.pipelines.stages.extract import ExtractStage
+
+if TYPE_CHECKING:
+    from bioetl.domain.ports.extraction import ExtractionServiceABC
+
+
+class ChemblCommonPipeline(ChemblPipelineBase):
+    """Common ChEMBL pipeline with record mapping.
+
+    This pipeline extends ChemblPipelineBase by providing an ExtractStage
+    configured with ChemblRecordMapper for domain model validation.
+
+    The mapper validates raw records against domain models (ActivityRawModel,
+    MoleculeRawModel, etc.) before converting to DataFrames, ensuring data
+    quality at the application layer.
+
+    Example:
+        >>> pipeline = ChemblCommonPipeline(
+        ...     config=config,
+        ...     logger=logger,
+        ...     extraction_service=extraction_service,
+        ...     # ... other dependencies
+        ... )
+        >>> extract_stage = pipeline.create_extract_stage()
+        >>> for df in extract_stage.extract("activity", target_chembl_id="CHEMBL25"):
+        ...     transformed = pipeline.transform(df)
+    """
+
+    def create_extract_stage(self) -> ExtractStage:
+        """Create an ExtractStage with ChEMBL record mapping.
+
+        Returns:
+            ExtractStage configured with:
+            - The pipeline's extraction service
+            - ChemblRecordMapper for domain model validation
+        """
+        return ExtractStage(
+            extraction_service=self._extraction_service,
+            record_mapper=ChemblRecordMapper(),
+        )
+
+    def create_raw_extract_stage(self) -> ExtractStage:
+        """Create an ExtractStage without record mapping.
+
+        Returns:
+            ExtractStage configured with extraction service only.
+            Records are converted directly to DataFrames without validation.
+        """
+        return ExtractStage(
+            extraction_service=self._extraction_service,
+            record_mapper=None,
+        )
+
+    @property
+    def extraction_service(self) -> "ExtractionServiceABC":
+        """Get the underlying extraction service."""
+        return self._extraction_service
+
+
+__all__ = ["ChemblCommonPipeline"]

--- a/src/bioetl/application/pipelines/stages/__init__.py
+++ b/src/bioetl/application/pipelines/stages/__init__.py
@@ -1,0 +1,5 @@
+"""Pipeline stages for ETL processing."""
+
+from bioetl.application.pipelines.stages.extract import ExtractStage
+
+__all__ = ["ExtractStage"]

--- a/src/bioetl/application/pipelines/stages/extract.py
+++ b/src/bioetl/application/pipelines/stages/extract.py
@@ -1,0 +1,122 @@
+"""Extract stage with optional record mapping support."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pandas as pd
+
+from bioetl.application.mappers.contracts import RecordMapperABC
+from bioetl.domain.ports.extraction import ExtractionServiceABC
+
+
+class ExtractStage:
+    """Extract stage with optional record mapping.
+
+    This stage wraps an ExtractionServiceABC and optionally validates
+    records through a RecordMapperABC before converting to DataFrames.
+
+    When a mapper is provided, records are validated against domain models
+    before conversion, ensuring data quality. When no mapper is provided,
+    raw dicts are converted directly to DataFrame without validation.
+
+    Example:
+        >>> from bioetl.application.mappers.chembl import ChemblRecordMapper
+        >>> stage = ExtractStage(extraction_service, ChemblRecordMapper())
+        >>> for df in stage.extract("activity", target_chembl_id="CHEMBL25"):
+        ...     process(df)
+    """
+
+    def __init__(
+        self,
+        extraction_service: ExtractionServiceABC,
+        record_mapper: RecordMapperABC | None = None,
+    ) -> None:
+        """Initialize extract stage.
+
+        Args:
+            extraction_service: Service for fetching raw records.
+            record_mapper: Optional mapper for domain model validation.
+        """
+        self._extraction_service = extraction_service
+        self._mapper = record_mapper
+
+    @property
+    def extraction_service(self) -> ExtractionServiceABC:
+        """Get the underlying extraction service."""
+        return self._extraction_service
+
+    @property
+    def record_mapper(self) -> RecordMapperABC | None:
+        """Get the record mapper if configured."""
+        return self._mapper
+
+    def extract(
+        self,
+        entity: str,
+        *,
+        chunk_size: int | None = None,
+        **filters: object,
+    ) -> Iterable[pd.DataFrame]:
+        """Extract and optionally map records to DataFrames.
+
+        If mapper is provided, records are validated against domain models
+        before conversion. Otherwise, raw dicts are converted directly.
+
+        Args:
+            entity: Entity type to extract (e.g., 'activity', 'molecule').
+            chunk_size: Optional batch size for pagination.
+            **filters: Additional filters to apply during extraction.
+
+        Yields:
+            DataFrames containing extracted records.
+
+        Raises:
+            ValueError: If entity type is unknown to mapper.
+            ValidationError: If record validation fails (when mapper is used).
+        """
+        for batch in self._extraction_service.iter_extract(
+            entity, chunk_size=chunk_size, **filters
+        ):
+            if not batch:
+                continue
+
+            if self._mapper:
+                # Map to domain models first (validates structure)
+                typed_records = self._mapper.map_records(batch, entity)
+                df = pd.DataFrame([r.model_dump() for r in typed_records])
+            else:
+                # Direct conversion (no validation)
+                df = pd.DataFrame(batch)
+
+            yield df
+
+    def extract_all(
+        self,
+        entity: str,
+        **filters: object,
+    ) -> pd.DataFrame:
+        """Extract all records as a single DataFrame.
+
+        Convenience method that collects all batches into one DataFrame.
+
+        Args:
+            entity: Entity type to extract.
+            **filters: Additional filters to apply.
+
+        Returns:
+            DataFrame containing all extracted records.
+        """
+        all_records = self._extraction_service.extract_all(entity, **filters)
+
+        if not all_records:
+            return pd.DataFrame()
+
+        if self._mapper:
+            typed_records = self._mapper.map_records(all_records, entity)
+            return pd.DataFrame([r.model_dump() for r in typed_records])
+
+        return pd.DataFrame(all_records)
+
+
+__all__ = ["ExtractStage"]

--- a/tests/bioetl/application/pipelines/stages/__init__.py
+++ b/tests/bioetl/application/pipelines/stages/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for pipeline stages."""

--- a/tests/bioetl/application/pipelines/stages/test_extract_stage.py
+++ b/tests/bioetl/application/pipelines/stages/test_extract_stage.py
@@ -1,0 +1,513 @@
+"""Unit tests for ExtractStage."""
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+from pydantic import ValidationError
+
+from bioetl.application.mappers.chembl import ChemblRecordMapper
+from bioetl.application.mappers.contracts import RecordMapperABC
+from bioetl.application.pipelines.stages.extract import ExtractStage
+from bioetl.domain.ports.extraction import ExtractionServiceABC
+from bioetl.domain.record_source import RawRecord
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_extraction_service() -> MagicMock:
+    """Create a mock extraction service."""
+    return MagicMock(spec=ExtractionServiceABC)
+
+
+@pytest.fixture
+def mock_mapper() -> MagicMock:
+    """Create a mock record mapper."""
+    return MagicMock(spec=RecordMapperABC)
+
+
+@pytest.fixture
+def chembl_mapper() -> ChemblRecordMapper:
+    """Create a real ChemblRecordMapper."""
+    return ChemblRecordMapper()
+
+
+# =============================================================================
+# Test ExtractStage Initialization
+# =============================================================================
+
+
+class TestExtractStageInit:
+    """Tests for ExtractStage initialization."""
+
+    def test_init_with_mapper(
+        self, mock_extraction_service: MagicMock, mock_mapper: MagicMock
+    ) -> None:
+        """ExtractStage initializes with extraction service and mapper."""
+        stage = ExtractStage(
+            extraction_service=mock_extraction_service,
+            record_mapper=mock_mapper,
+        )
+
+        assert stage.extraction_service is mock_extraction_service
+        assert stage.record_mapper is mock_mapper
+
+    def test_init_without_mapper(self, mock_extraction_service: MagicMock) -> None:
+        """ExtractStage initializes without mapper (raw mode)."""
+        stage = ExtractStage(
+            extraction_service=mock_extraction_service,
+            record_mapper=None,
+        )
+
+        assert stage.extraction_service is mock_extraction_service
+        assert stage.record_mapper is None
+
+
+# =============================================================================
+# Test ExtractStage.extract() with Mapper
+# =============================================================================
+
+
+class TestExtractStageWithMapper:
+    """Tests for ExtractStage.extract() with record mapping."""
+
+    def test_extract_with_mapper_validates_records(
+        self, mock_extraction_service: MagicMock, chembl_mapper: ChemblRecordMapper
+    ) -> None:
+        """Records are validated through mapper before DataFrame conversion."""
+        raw_batch = [
+            {"activity_id": 1, "standard_flag": True},
+            {"activity_id": 2, "standard_flag": False},
+        ]
+        mock_extraction_service.iter_extract.return_value = [raw_batch]
+
+        stage = ExtractStage(
+            extraction_service=mock_extraction_service,
+            record_mapper=chembl_mapper,
+        )
+
+        dfs = list(stage.extract("activity"))
+
+        assert len(dfs) == 1
+        assert len(dfs[0]) == 2
+        # Verify activity_id is converted to string by model
+        assert dfs[0]["activity_id"].tolist() == ["1", "2"]
+        assert dfs[0]["standard_flag"].tolist() == [True, False]
+
+    def test_extract_with_mapper_multiple_batches(
+        self, mock_extraction_service: MagicMock, chembl_mapper: ChemblRecordMapper
+    ) -> None:
+        """Multiple batches are each converted to separate DataFrames."""
+        batch1 = [{"activity_id": 1, "standard_flag": True}]
+        batch2 = [{"activity_id": 2, "standard_flag": False}]
+        mock_extraction_service.iter_extract.return_value = [batch1, batch2]
+
+        stage = ExtractStage(
+            extraction_service=mock_extraction_service,
+            record_mapper=chembl_mapper,
+        )
+
+        dfs = list(stage.extract("activity"))
+
+        assert len(dfs) == 2
+        assert len(dfs[0]) == 1
+        assert len(dfs[1]) == 1
+        assert dfs[0]["activity_id"].iloc[0] == "1"
+        assert dfs[1]["activity_id"].iloc[0] == "2"
+
+    def test_extract_with_mapper_raises_validation_error(
+        self, mock_extraction_service: MagicMock, chembl_mapper: ChemblRecordMapper
+    ) -> None:
+        """ValidationError is raised for invalid records."""
+        # Missing required field 'standard_flag'
+        invalid_batch = [{"activity_id": 1}]
+        mock_extraction_service.iter_extract.return_value = [invalid_batch]
+
+        stage = ExtractStage(
+            extraction_service=mock_extraction_service,
+            record_mapper=chembl_mapper,
+        )
+
+        with pytest.raises(ValidationError):
+            list(stage.extract("activity"))
+
+    def test_extract_with_mapper_raises_for_unknown_entity(
+        self, mock_extraction_service: MagicMock, chembl_mapper: ChemblRecordMapper
+    ) -> None:
+        """ValueError is raised for unknown entity type."""
+        mock_extraction_service.iter_extract.return_value = [[{"id": 1}]]
+
+        stage = ExtractStage(
+            extraction_service=mock_extraction_service,
+            record_mapper=chembl_mapper,
+        )
+
+        with pytest.raises(ValueError, match="Unknown entity type"):
+            list(stage.extract("unknown_entity"))
+
+    def test_extract_passes_filters_to_service(
+        self, mock_extraction_service: MagicMock, mock_mapper: MagicMock
+    ) -> None:
+        """Filters are passed to extraction service."""
+        mock_extraction_service.iter_extract.return_value = []
+
+        stage = ExtractStage(
+            extraction_service=mock_extraction_service,
+            record_mapper=mock_mapper,
+        )
+
+        list(stage.extract("activity", target_chembl_id="CHEMBL25", limit=100))
+
+        mock_extraction_service.iter_extract.assert_called_once_with(
+            "activity",
+            chunk_size=None,
+            target_chembl_id="CHEMBL25",
+            limit=100,
+        )
+
+    def test_extract_passes_chunk_size_to_service(
+        self, mock_extraction_service: MagicMock, mock_mapper: MagicMock
+    ) -> None:
+        """chunk_size parameter is passed to extraction service."""
+        mock_extraction_service.iter_extract.return_value = []
+
+        stage = ExtractStage(
+            extraction_service=mock_extraction_service,
+            record_mapper=mock_mapper,
+        )
+
+        list(stage.extract("activity", chunk_size=500))
+
+        mock_extraction_service.iter_extract.assert_called_once_with(
+            "activity",
+            chunk_size=500,
+        )
+
+
+# =============================================================================
+# Test ExtractStage.extract() without Mapper (Raw Mode)
+# =============================================================================
+
+
+class TestExtractStageRawMode:
+    """Tests for ExtractStage.extract() without mapper (raw mode)."""
+
+    def test_extract_without_mapper_converts_directly(
+        self, mock_extraction_service: MagicMock
+    ) -> None:
+        """Raw dicts are converted directly to DataFrame without validation."""
+        raw_batch = [
+            {"id": 1, "name": "Test 1"},
+            {"id": 2, "name": "Test 2"},
+        ]
+        mock_extraction_service.iter_extract.return_value = [raw_batch]
+
+        stage = ExtractStage(
+            extraction_service=mock_extraction_service,
+            record_mapper=None,
+        )
+
+        dfs = list(stage.extract("activity"))
+
+        assert len(dfs) == 1
+        assert len(dfs[0]) == 2
+        # Data preserved as-is (no string conversion)
+        assert dfs[0]["id"].tolist() == [1, 2]
+        assert dfs[0]["name"].tolist() == ["Test 1", "Test 2"]
+
+    def test_extract_without_mapper_accepts_any_fields(
+        self, mock_extraction_service: MagicMock
+    ) -> None:
+        """Raw mode accepts any field structure without validation."""
+        raw_batch = [
+            {"custom_field": "value", "nested": {"a": 1}},
+        ]
+        mock_extraction_service.iter_extract.return_value = [raw_batch]
+
+        stage = ExtractStage(
+            extraction_service=mock_extraction_service,
+            record_mapper=None,
+        )
+
+        dfs = list(stage.extract("any_entity"))
+
+        assert len(dfs) == 1
+        assert "custom_field" in dfs[0].columns
+        assert "nested" in dfs[0].columns
+
+
+# =============================================================================
+# Test ExtractStage.extract() Edge Cases
+# =============================================================================
+
+
+class TestExtractStageEdgeCases:
+    """Tests for ExtractStage edge cases."""
+
+    def test_extract_skips_empty_batches(
+        self, mock_extraction_service: MagicMock, mock_mapper: MagicMock
+    ) -> None:
+        """Empty batches are skipped."""
+        mock_extraction_service.iter_extract.return_value = [[], [{"id": 1}], []]
+        mock_record = MagicMock(spec=RawRecord)
+        mock_record.model_dump.return_value = {"id": 1}
+        mock_mapper.map_records.return_value = [mock_record]
+
+        stage = ExtractStage(
+            extraction_service=mock_extraction_service,
+            record_mapper=mock_mapper,
+        )
+
+        dfs = list(stage.extract("activity"))
+
+        # Only non-empty batch produces a DataFrame
+        assert len(dfs) == 1
+        assert len(dfs[0]) == 1
+
+    def test_extract_handles_no_batches(
+        self, mock_extraction_service: MagicMock
+    ) -> None:
+        """No batches returns empty iterator."""
+        mock_extraction_service.iter_extract.return_value = []
+
+        stage = ExtractStage(
+            extraction_service=mock_extraction_service,
+            record_mapper=None,
+        )
+
+        dfs = list(stage.extract("activity"))
+
+        assert dfs == []
+
+
+# =============================================================================
+# Test ExtractStage.extract_all()
+# =============================================================================
+
+
+class TestExtractStageExtractAll:
+    """Tests for ExtractStage.extract_all() method."""
+
+    def test_extract_all_with_mapper(
+        self, mock_extraction_service: MagicMock, chembl_mapper: ChemblRecordMapper
+    ) -> None:
+        """extract_all with mapper validates all records."""
+        all_records = [
+            {"activity_id": 1, "standard_flag": True},
+            {"activity_id": 2, "standard_flag": False},
+        ]
+        mock_extraction_service.extract_all.return_value = all_records
+
+        stage = ExtractStage(
+            extraction_service=mock_extraction_service,
+            record_mapper=chembl_mapper,
+        )
+
+        df = stage.extract_all("activity")
+
+        assert len(df) == 2
+        assert df["activity_id"].tolist() == ["1", "2"]
+
+    def test_extract_all_without_mapper(
+        self, mock_extraction_service: MagicMock
+    ) -> None:
+        """extract_all without mapper converts directly."""
+        all_records = [
+            {"id": 1, "name": "Test"},
+        ]
+        mock_extraction_service.extract_all.return_value = all_records
+
+        stage = ExtractStage(
+            extraction_service=mock_extraction_service,
+            record_mapper=None,
+        )
+
+        df = stage.extract_all("activity")
+
+        assert len(df) == 1
+        assert df["id"].iloc[0] == 1
+
+    def test_extract_all_empty_returns_empty_dataframe(
+        self, mock_extraction_service: MagicMock
+    ) -> None:
+        """extract_all with no records returns empty DataFrame."""
+        mock_extraction_service.extract_all.return_value = []
+
+        stage = ExtractStage(
+            extraction_service=mock_extraction_service,
+            record_mapper=None,
+        )
+
+        df = stage.extract_all("activity")
+
+        assert isinstance(df, pd.DataFrame)
+        assert df.empty
+
+    def test_extract_all_passes_filters(
+        self, mock_extraction_service: MagicMock
+    ) -> None:
+        """extract_all passes filters to extraction service."""
+        mock_extraction_service.extract_all.return_value = []
+
+        stage = ExtractStage(
+            extraction_service=mock_extraction_service,
+            record_mapper=None,
+        )
+
+        stage.extract_all("activity", target_chembl_id="CHEMBL25")
+
+        mock_extraction_service.extract_all.assert_called_once_with(
+            "activity",
+            target_chembl_id="CHEMBL25",
+        )
+
+
+# =============================================================================
+# Test Integration: Extract → Map → DataFrame
+# =============================================================================
+
+
+class TestExtractStageIntegration:
+    """Integration tests for ExtractStage with real mapper."""
+
+    def test_full_flow_activity_extraction(
+        self, mock_extraction_service: MagicMock
+    ) -> None:
+        """Full extraction flow: service → mapper → DataFrame."""
+        # Simulate real ChEMBL activity records
+        raw_records = [
+            {
+                "activity_id": 12345,
+                "standard_flag": True,
+                "assay_chembl_id": "CHEMBL1217643",
+                "molecule_chembl_id": "CHEMBL25",
+                "standard_type": "IC50",
+                "standard_value": 50.0,
+                "standard_units": "nM",
+            },
+            {
+                "activity_id": 12346,
+                "standard_flag": False,
+                "assay_chembl_id": "CHEMBL1217643",
+                "molecule_chembl_id": "CHEMBL26",
+                "standard_type": "Ki",
+                "standard_value": 100.0,
+                "standard_units": "nM",
+            },
+        ]
+        mock_extraction_service.iter_extract.return_value = [raw_records]
+
+        stage = ExtractStage(
+            extraction_service=mock_extraction_service,
+            record_mapper=ChemblRecordMapper(),
+        )
+
+        dfs = list(stage.extract("activity"))
+
+        assert len(dfs) == 1
+        df = dfs[0]
+        assert len(df) == 2
+
+        # Verify domain model transformations applied
+        assert df["activity_id"].dtype == object  # string type
+        assert df["activity_id"].tolist() == ["12345", "12346"]
+        assert df["standard_flag"].tolist() == [True, False]
+        assert df["standard_type"].tolist() == ["IC50", "Ki"]
+
+    def test_full_flow_molecule_extraction(
+        self, mock_extraction_service: MagicMock
+    ) -> None:
+        """Full extraction flow for molecule entity."""
+        raw_records = [
+            {
+                "molecule_chembl_id": "CHEMBL25",
+                "pref_name": "ASPIRIN",
+                "molecule_type": "Small molecule",
+                "max_phase": 4,
+            },
+        ]
+        mock_extraction_service.iter_extract.return_value = [raw_records]
+
+        stage = ExtractStage(
+            extraction_service=mock_extraction_service,
+            record_mapper=ChemblRecordMapper(),
+        )
+
+        dfs = list(stage.extract("molecule"))
+
+        assert len(dfs) == 1
+        df = dfs[0]
+        assert df["molecule_chembl_id"].iloc[0] == "CHEMBL25"
+        assert df["pref_name"].iloc[0] == "ASPIRIN"
+        assert df["max_phase"].iloc[0] == 4
+
+    def test_multiple_entities_supported(
+        self, mock_extraction_service: MagicMock
+    ) -> None:
+        """ExtractStage supports all ChEMBL entity types."""
+        mapper = ChemblRecordMapper()
+
+        test_cases = [
+            ("activity", {"activity_id": 1, "standard_flag": True}),
+            ("molecule", {"molecule_chembl_id": "CHEMBL1"}),
+            ("target", {"target_chembl_id": "CHEMBL1"}),
+            ("assay", {"assay_chembl_id": "CHEMBL1"}),
+            ("document", {"document_chembl_id": "CHEMBL1"}),
+        ]
+
+        for entity, record in test_cases:
+            mock_extraction_service.iter_extract.return_value = [[record]]
+
+            stage = ExtractStage(
+                extraction_service=mock_extraction_service,
+                record_mapper=mapper,
+            )
+
+            dfs = list(stage.extract(entity))
+            assert len(dfs) == 1, f"Failed for entity: {entity}"
+
+
+# =============================================================================
+# Test Properties
+# =============================================================================
+
+
+class TestExtractStageProperties:
+    """Tests for ExtractStage properties."""
+
+    def test_extraction_service_property(
+        self, mock_extraction_service: MagicMock
+    ) -> None:
+        """extraction_service property returns the service."""
+        stage = ExtractStage(
+            extraction_service=mock_extraction_service,
+            record_mapper=None,
+        )
+
+        assert stage.extraction_service is mock_extraction_service
+
+    def test_record_mapper_property_with_mapper(
+        self, mock_extraction_service: MagicMock, mock_mapper: MagicMock
+    ) -> None:
+        """record_mapper property returns the mapper when set."""
+        stage = ExtractStage(
+            extraction_service=mock_extraction_service,
+            record_mapper=mock_mapper,
+        )
+
+        assert stage.record_mapper is mock_mapper
+
+    def test_record_mapper_property_without_mapper(
+        self, mock_extraction_service: MagicMock
+    ) -> None:
+        """record_mapper property returns None when not set."""
+        stage = ExtractStage(
+            extraction_service=mock_extraction_service,
+            record_mapper=None,
+        )
+
+        assert stage.record_mapper is None


### PR DESCRIPTION
Add ExtractStage class that wraps ExtractionServiceABC with optional RecordMapperABC for domain model validation before DataFrame conversion.

Changes:
- Add ExtractStage in application/pipelines/stages/extract.py
- Add ChemblCommonPipeline with create_extract_stage() method
- Export new classes from package __init__.py files
- Add comprehensive tests for ExtractStage (22 test cases)

The ExtractStage supports both validated mode (with mapper) and raw mode (without mapper), enabling flexible extraction with optional type safety.