### PR TITLE
Move schema registration to application layer

### DIFF
--- a/src/bioetl/application/services/__init__.py
+++ b/src/bioetl/application/services/__init__.py
@@ -1,0 +1,15 @@
+"""Application layer services."""
+
+from bioetl.application.services.schema_bootstrap import (
+    SchemaBootstrapService,
+    create_schema_bootstrap_service,
+)
+from bioetl.application.services.schema_contract_provider import (
+    SchemaContractProviderImpl,
+)
+
+__all__ = [
+    "SchemaBootstrapService",
+    "SchemaContractProviderImpl",
+    "create_schema_bootstrap_service",
+]

--- a/src/bioetl/application/services/schema_bootstrap.py
+++ b/src/bioetl/application/services/schema_bootstrap.py
@@ -1,0 +1,69 @@
+"""Schema bootstrap service for application initialization."""
+
+from __future__ import annotations
+
+from bioetl.application.services.schema_contract_provider import (
+    SchemaContractProviderImpl,
+)
+from bioetl.domain.ports.schema import SchemaContractProviderABC
+from bioetl.domain.schemas.registry import get_default_schema_registry
+from bioetl.domain.validation import SchemaProviderABC
+
+
+class SchemaBootstrapService:
+    """Service for initializing schema infrastructure.
+
+    This service handles the creation and registration of schemas,
+    providing a clean entry point for application bootstrap.
+    """
+
+    def __init__(
+        self,
+        schema_provider: SchemaProviderABC | None = None,
+    ) -> None:
+        """Initialize the bootstrap service.
+
+        Args:
+            schema_provider: Optional pre-configured schema provider.
+                If None, uses the default schema registry.
+        """
+        self._schema_provider = schema_provider
+
+    def ensure_registered(self) -> SchemaProviderABC:
+        """Ensure schemas are registered and return the provider.
+
+        Returns:
+            The schema provider with all schemas registered.
+        """
+        if self._schema_provider is None:
+            self._schema_provider = get_default_schema_registry()
+        return self._schema_provider
+
+    def create_contract_provider(self) -> SchemaContractProviderABC:
+        """Create a schema contract provider.
+
+        Returns:
+            A configured SchemaContractProviderImpl instance.
+        """
+        schema_provider = self.ensure_registered()
+        return SchemaContractProviderImpl(schema_provider)
+
+
+def create_schema_bootstrap_service(
+    schema_provider: SchemaProviderABC | None = None,
+) -> SchemaBootstrapService:
+    """Factory function for creating the schema bootstrap service.
+
+    Args:
+        schema_provider: Optional pre-configured schema provider.
+
+    Returns:
+        A configured SchemaBootstrapService instance.
+    """
+    return SchemaBootstrapService(schema_provider)
+
+
+__all__ = [
+    "SchemaBootstrapService",
+    "create_schema_bootstrap_service",
+]

--- a/src/bioetl/application/services/schema_contract_provider.py
+++ b/src/bioetl/application/services/schema_contract_provider.py
@@ -1,0 +1,62 @@
+"""Application layer implementation of schema contract provider."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from bioetl.domain.ports.schema import SchemaContractProviderABC
+from bioetl.domain.schemas.fields import build_field_configs_from_schema
+from bioetl.domain.schemas.pipeline_contracts import get_pipeline_contract
+from bioetl.domain.validation import SchemaProviderABC
+
+
+class SchemaContractProviderImpl(SchemaContractProviderABC):
+    """Application layer implementation of schema contract provider.
+
+    This adapter bridges the domain schema functionality with infrastructure
+    components that need schema information without direct domain dependencies.
+    """
+
+    def __init__(self, schema_provider: SchemaProviderABC) -> None:
+        """Initialize with a schema provider.
+
+        Args:
+            schema_provider: Provider for accessing registered schemas.
+        """
+        self._provider = schema_provider
+
+    def get_output_schema_name(
+        self,
+        pipeline_code: str,
+        *,
+        default_entity: str | None = None,
+    ) -> str:
+        """Get output schema name for pipeline.
+
+        Args:
+            pipeline_code: Pipeline identifier (e.g., 'chembl.activity').
+            default_entity: Fallback entity name if pipeline has no explicit contract.
+
+        Returns:
+            Schema name to use for output validation and field derivation.
+        """
+        contract = get_pipeline_contract(pipeline_code, default_entity=default_entity)
+        return contract.get_output_schema()
+
+    def get_field_configs(self, schema_name: str) -> list[dict[str, Any]]:
+        """Get field configurations from schema.
+
+        Args:
+            schema_name: Name of the registered schema.
+
+        Returns:
+            List of field configuration dictionaries.
+
+        Raises:
+            ValueError: If schema is not registered.
+        """
+        schema = self._provider.get_schema(schema_name)
+        return build_field_configs_from_schema(schema)
+
+
+__all__ = ["SchemaContractProviderImpl"]

--- a/src/bioetl/domain/ports/__init__.py
+++ b/src/bioetl/domain/ports/__init__.py
@@ -16,6 +16,7 @@ from bioetl.domain.ports.parsing import (
     RawRecordList,
     ResponseParserPortABC,
 )
+from bioetl.domain.ports.schema import SchemaContractProviderABC
 
 __all__: list[str] = [
     # Extraction ports
@@ -33,4 +34,6 @@ __all__: list[str] = [
     "RawPayload",
     "RawRecordList",
     "ResponseParserPortABC",
+    # Schema ports
+    "SchemaContractProviderABC",
 ]

--- a/src/bioetl/domain/ports/schema.py
+++ b/src/bioetl/domain/ports/schema.py
@@ -1,0 +1,49 @@
+"""Domain port for schema contract operations."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class SchemaContractProviderABC(ABC):
+    """Port for accessing schema contracts.
+
+    This port defines the interface for retrieving schema-related information
+    needed by infrastructure components without direct domain dependencies.
+    """
+
+    @abstractmethod
+    def get_output_schema_name(
+        self,
+        pipeline_code: str,
+        *,
+        default_entity: str | None = None,
+    ) -> str:
+        """Get output schema name for pipeline.
+
+        Args:
+            pipeline_code: Pipeline identifier (e.g., 'chembl.activity').
+            default_entity: Fallback entity name if pipeline has no explicit contract.
+
+        Returns:
+            Schema name to use for output validation and field derivation.
+        """
+
+    @abstractmethod
+    def get_field_configs(self, schema_name: str) -> list[dict[str, Any]]:
+        """Get field configurations from schema.
+
+        Args:
+            schema_name: Name of the registered schema.
+
+        Returns:
+            List of field configuration dictionaries containing name, data_type,
+            is_nullable, is_filterable, and description keys.
+
+        Raises:
+            ValueError: If schema is not registered.
+        """
+
+
+__all__ = ["SchemaContractProviderABC"]

--- a/src/bioetl/infrastructure/config/loader.py
+++ b/src/bioetl/infrastructure/config/loader.py
@@ -9,12 +9,8 @@ from pydantic import ValidationError
 
 from bioetl.domain.configs import ConfigMigrator, PipelineConfig
 from bioetl.domain.errors import ConfigError, ConfigValidationError
-from bioetl.domain.schemas import register_schemas
-from bioetl.domain.schemas.fields import build_field_configs_from_schema
-from bioetl.domain.schemas.pipeline_contracts import get_pipeline_contract
-from bioetl.domain.schemas.registry import default_schema_provider
+from bioetl.domain.ports.schema import SchemaContractProviderABC
 from bioetl.domain.transform.merge import apply_deep_merge
-from bioetl.domain.validation import SchemaProviderABC
 from bioetl.infrastructure.config.env import resolve_env_placeholders
 from bioetl.infrastructure.config.provider_registry import (
     ProviderNotConfiguredError,
@@ -156,42 +152,47 @@ def _ensure_provider_registered(provider_id: str) -> None:
         ) from exc
 
 
-_SCHEMA_PROVIDER: SchemaProviderABC | None = None
-_SCHEMAS_REGISTERED = False
+_schema_contract_provider: SchemaContractProviderABC | None = None
 
 
-def _get_schema_provider() -> SchemaProviderABC:
-    """Возвращает провайдера схем, гарантируя регистрацию стандартных сущностей."""
+def set_schema_contract_provider(provider: SchemaContractProviderABC) -> None:
+    """Inject schema contract provider (called from application bootstrap).
 
-    global _SCHEMA_PROVIDER, _SCHEMAS_REGISTERED  # noqa: PLW0603
+    Args:
+        provider: The schema contract provider implementation.
+    """
+    global _schema_contract_provider  # noqa: PLW0603
+    _schema_contract_provider = provider
 
-    if _SCHEMA_PROVIDER is None:
-        _SCHEMA_PROVIDER = default_schema_provider()
-    if not _SCHEMAS_REGISTERED:
-        register_schemas(_SCHEMA_PROVIDER)
-        _SCHEMAS_REGISTERED = True
-    return _SCHEMA_PROVIDER
+
+def reset_schema_contract_provider() -> None:
+    """Reset the schema contract provider (for testing purposes)."""
+    global _schema_contract_provider  # noqa: PLW0603
+    _schema_contract_provider = None
 
 
 def _populate_fields_from_schema(config: PipelineConfig) -> None:
-    """Автоматически заполняет config.fields, если секция отсутствует в YAML."""
-
+    """Populate config.fields using injected schema contract provider."""
     if config.fields:
         return
 
-    contract = get_pipeline_contract(config.id, default_entity=config.entity_name)
-    schema_name = contract.get_output_schema()
-    provider = _get_schema_provider()
+    if _schema_contract_provider is None:
+        raise RuntimeError(
+            "SchemaContractProvider not initialized. "
+            "Call application bootstrap before loading configs."
+        )
+
+    schema_name = _schema_contract_provider.get_output_schema_name(
+        config.id,
+        default_entity=config.entity_name,
+    )
 
     try:
-        schema = provider.get_schema(schema_name)
+        fields = _schema_contract_provider.get_field_configs(schema_name)
     except ValueError as exc:
         raise ConfigValidationError(
             f"Schema '{schema_name}' is not registered for pipeline '{config.id}'"
         ) from exc
-
-    try:
-        fields = build_field_configs_from_schema(schema)
     except Exception as exc:  # pragma: no cover - защитный контур
         raise ConfigValidationError(
             f"Failed to derive fields from schema '{schema_name}' "
@@ -282,4 +283,6 @@ __all__ = [
     "UnknownProviderError",
     "get_pipeline_config",
     "get_pipeline_config_from_path",
+    "reset_schema_contract_provider",
+    "set_schema_contract_provider",
 ]

--- a/src/bioetl/interfaces/cli/app.py
+++ b/src/bioetl/interfaces/cli/app.py
@@ -12,7 +12,9 @@ import typer
 from bioetl.application.config.runtime import build_runtime_config
 from bioetl.application.orchestrator import PipelineOrchestrator
 from bioetl.application.pipelines.registry import PIPELINE_REGISTRY
+from bioetl.application.services.schema_bootstrap import create_schema_bootstrap_service
 from bioetl.domain.configs import PipelineConfig
+from bioetl.infrastructure.config.loader import set_schema_contract_provider
 from bioetl.infrastructure.config.provider_registry import (
     create_provider_loader,
 )
@@ -24,6 +26,28 @@ from bioetl.interfaces.container_factory import (
 
 app = typer.Typer(help="BioETL - Bioactivity Data Acquisition ETL")
 console = Console()
+
+_application_bootstrapped = False
+
+
+def bootstrap_application() -> None:
+    """Initialize application layer before using infrastructure.
+
+    This function must be called before loading any pipeline configs.
+    It sets up the schema contract provider through dependency injection.
+    """
+    global _application_bootstrapped  # noqa: PLW0603
+    if _application_bootstrapped:
+        return
+
+    # 1. Bootstrap schemas
+    schema_service = create_schema_bootstrap_service()
+
+    # 2. Inject contract provider into infrastructure
+    contract_provider = schema_service.create_contract_provider()
+    set_schema_contract_provider(contract_provider)
+
+    _application_bootstrapped = True
 
 
 def _infer_config_path(pipeline_name: str) -> str | None:
@@ -48,6 +72,7 @@ def _resolve_config_path(config: str) -> Path:
 
 
 def _build_config(config_path: Path, profile: str | None) -> PipelineConfig:
+    bootstrap_application()
     config_loader = create_config_loader()
     return build_runtime_config(
         config_path=config_path,
@@ -101,6 +126,7 @@ def validate_config(
     profile: Annotated[str | None, typer.Option(help="Profile name")] = None,
 ) -> None:
     """Validate a pipeline configuration file."""
+    bootstrap_application()
     config_file = Path(config_path)
     if not config_file.exists():
         console.print(f"[red]Error:[/red] Config file not found: {config_path}")

--- a/tests/bioetl/application/services/__init__.py
+++ b/tests/bioetl/application/services/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for application services."""

--- a/tests/bioetl/application/services/test_schema_bootstrap.py
+++ b/tests/bioetl/application/services/test_schema_bootstrap.py
@@ -1,0 +1,116 @@
+"""Tests for SchemaBootstrapService."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from bioetl.application.services.schema_bootstrap import (
+    SchemaBootstrapService,
+    create_schema_bootstrap_service,
+)
+from bioetl.domain.ports.schema import SchemaContractProviderABC
+from bioetl.domain.validation import SchemaProviderABC
+
+
+class TestSchemaBootstrapService:
+    """Tests for SchemaBootstrapService."""
+
+    def test_ensure_registered_uses_provided_provider(self) -> None:
+        """Test ensure_registered uses provided schema provider."""
+        mock_provider = MagicMock(spec=SchemaProviderABC)
+        service = SchemaBootstrapService(schema_provider=mock_provider)
+
+        result = service.ensure_registered()
+
+        assert result is mock_provider
+
+    def test_ensure_registered_creates_default_registry_when_none(self) -> None:
+        """Test ensure_registered creates default registry when no provider given."""
+        service = SchemaBootstrapService()
+
+        result = service.ensure_registered()
+
+        assert result is not None
+        # Should have schemas registered
+        assert len(result.list_schemas()) > 0
+        assert "activity" in result.list_schemas()
+
+    def test_ensure_registered_is_idempotent(self) -> None:
+        """Test ensure_registered returns same provider on multiple calls."""
+        service = SchemaBootstrapService()
+
+        first_call = service.ensure_registered()
+        second_call = service.ensure_registered()
+
+        assert first_call is second_call
+
+    def test_create_contract_provider_returns_valid_implementation(self) -> None:
+        """Test create_contract_provider returns SchemaContractProviderABC."""
+        service = SchemaBootstrapService()
+
+        provider = service.create_contract_provider()
+
+        assert isinstance(provider, SchemaContractProviderABC)
+
+    def test_create_contract_provider_uses_registered_schemas(self) -> None:
+        """Test contract provider can access registered schemas."""
+        service = SchemaBootstrapService()
+        provider = service.create_contract_provider()
+
+        # Should be able to get field configs for registered schema
+        fields = provider.get_field_configs("activity")
+
+        assert len(fields) > 0
+
+    def test_create_contract_provider_with_custom_provider(self) -> None:
+        """Test create_contract_provider works with custom provider."""
+        from bioetl.domain.schemas.registry import create_default_schema_registry
+
+        custom_registry = create_default_schema_registry()
+        service = SchemaBootstrapService(schema_provider=custom_registry)
+
+        provider = service.create_contract_provider()
+
+        assert isinstance(provider, SchemaContractProviderABC)
+        # Should work with custom provider
+        schema_name = provider.get_output_schema_name("chembl.activity")
+        assert schema_name == "activity_output"
+
+
+class TestCreateSchemaBootstrapService:
+    """Tests for create_schema_bootstrap_service factory function."""
+
+    def test_creates_service_without_provider(self) -> None:
+        """Test factory creates service without explicit provider."""
+        service = create_schema_bootstrap_service()
+
+        assert isinstance(service, SchemaBootstrapService)
+
+    def test_creates_service_with_provider(self) -> None:
+        """Test factory creates service with explicit provider."""
+        mock_provider = MagicMock(spec=SchemaProviderABC)
+
+        service = create_schema_bootstrap_service(schema_provider=mock_provider)
+
+        assert isinstance(service, SchemaBootstrapService)
+        assert service.ensure_registered() is mock_provider
+
+    def test_created_service_works_end_to_end(self) -> None:
+        """Test created service works for complete bootstrap flow."""
+        service = create_schema_bootstrap_service()
+
+        # Simulate bootstrap flow
+        provider = service.ensure_registered()
+        contract_provider = service.create_contract_provider()
+
+        # Should be able to get schema info
+        schema_name = contract_provider.get_output_schema_name(
+            "chembl.activity",
+            default_entity="activity",
+        )
+        fields = contract_provider.get_field_configs(schema_name)
+
+        assert schema_name == "activity_output"
+        assert len(fields) > 0

--- a/tests/bioetl/application/services/test_schema_contract_provider.py
+++ b/tests/bioetl/application/services/test_schema_contract_provider.py
@@ -1,0 +1,150 @@
+"""Tests for SchemaContractProviderImpl."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from bioetl.application.services.schema_contract_provider import (
+    SchemaContractProviderImpl,
+)
+from bioetl.domain.ports.schema import SchemaContractProviderABC
+from bioetl.domain.validation import SchemaProviderABC
+
+
+class TestSchemaContractProviderImpl:
+    """Tests for SchemaContractProviderImpl."""
+
+    @pytest.fixture
+    def mock_schema_provider(self) -> MagicMock:
+        """Create a mock schema provider."""
+        provider = MagicMock(spec=SchemaProviderABC)
+        return provider
+
+    @pytest.fixture
+    def contract_provider(
+        self, mock_schema_provider: MagicMock
+    ) -> SchemaContractProviderImpl:
+        """Create a SchemaContractProviderImpl with mock provider."""
+        return SchemaContractProviderImpl(mock_schema_provider)
+
+    def test_implements_abc(
+        self, contract_provider: SchemaContractProviderImpl
+    ) -> None:
+        """Verify implementation conforms to ABC."""
+        assert isinstance(contract_provider, SchemaContractProviderABC)
+
+    def test_get_output_schema_name_returns_from_contract(
+        self, contract_provider: SchemaContractProviderImpl
+    ) -> None:
+        """Test get_output_schema_name returns schema name from pipeline contract."""
+        # Known pipeline with explicit contract
+        schema_name = contract_provider.get_output_schema_name("chembl.activity")
+
+        assert schema_name == "activity_output"
+
+    def test_get_output_schema_name_uses_default_entity(
+        self, contract_provider: SchemaContractProviderImpl
+    ) -> None:
+        """Test get_output_schema_name uses default_entity for unknown pipeline."""
+        schema_name = contract_provider.get_output_schema_name(
+            "unknown.pipeline",
+            default_entity="custom_entity",
+        )
+
+        assert schema_name == "custom_entity"
+
+    def test_get_output_schema_name_uses_pipeline_code_as_fallback(
+        self, contract_provider: SchemaContractProviderImpl
+    ) -> None:
+        """Test get_output_schema_name uses pipeline_code when no default_entity."""
+        schema_name = contract_provider.get_output_schema_name("unknown.pipeline")
+
+        assert schema_name == "unknown.pipeline"
+
+    def test_get_field_configs_returns_field_list(
+        self,
+        contract_provider: SchemaContractProviderImpl,
+        mock_schema_provider: MagicMock,
+    ) -> None:
+        """Test get_field_configs returns field configuration list."""
+        # Create a mock schema that build_field_configs_from_schema can process
+        mock_schema = MagicMock()
+        mock_schema.to_schema.return_value.columns = {
+            "field1": MagicMock(dtype="int64", nullable=False, description="Field 1"),
+            "field2": MagicMock(dtype="object", nullable=True, description="Field 2"),
+        }
+        mock_schema_provider.get_schema.return_value = mock_schema
+
+        fields = contract_provider.get_field_configs("test_schema")
+
+        mock_schema_provider.get_schema.assert_called_once_with("test_schema")
+        assert len(fields) == 2
+        assert all(isinstance(f, dict) for f in fields)
+        field_names = [f["name"] for f in fields]
+        assert "field1" in field_names
+        assert "field2" in field_names
+
+    def test_get_field_configs_raises_on_missing_schema(
+        self,
+        contract_provider: SchemaContractProviderImpl,
+        mock_schema_provider: MagicMock,
+    ) -> None:
+        """Test get_field_configs raises ValueError for unregistered schema."""
+        mock_schema_provider.get_schema.side_effect = ValueError(
+            "Schema 'missing' not found"
+        )
+
+        with pytest.raises(ValueError, match="not found"):
+            contract_provider.get_field_configs("missing")
+
+
+class TestSchemaContractProviderIntegration:
+    """Integration tests using real schema registry."""
+
+    @pytest.fixture
+    def real_contract_provider(self) -> SchemaContractProviderImpl:
+        """Create provider with real schema registry."""
+        from bioetl.domain.schemas.registry import create_default_schema_registry
+
+        registry = create_default_schema_registry()
+        return SchemaContractProviderImpl(registry)
+
+    def test_get_field_configs_for_activity_schema(
+        self, real_contract_provider: SchemaContractProviderImpl
+    ) -> None:
+        """Test field configs from real activity schema."""
+        fields = real_contract_provider.get_field_configs("activity")
+
+        assert len(fields) > 5
+        field_names = [f["name"] for f in fields]
+        assert "action_type" in field_names
+        assert "extracted_at" in field_names
+
+        # Verify field structure
+        sample_field = next(f for f in fields if f["name"] == "action_type")
+        assert "name" in sample_field
+        assert "data_type" in sample_field
+        assert "is_nullable" in sample_field
+        assert "is_filterable" in sample_field
+        assert "description" in sample_field
+
+    def test_get_output_schema_name_for_known_pipeline(
+        self, real_contract_provider: SchemaContractProviderImpl
+    ) -> None:
+        """Test output schema name for known pipeline contracts."""
+        test_cases = [
+            ("chembl.activity", "activity_output"),
+            ("chembl.assay", "assay_output"),
+            ("chembl.molecule", "molecule_output"),
+            ("chembl.target", "target_output"),
+            ("chembl.document", "document_output"),
+        ]
+
+        for pipeline_code, expected_schema in test_cases:
+            schema_name = real_contract_provider.get_output_schema_name(pipeline_code)
+            assert schema_name == expected_schema, (
+                f"Pipeline {pipeline_code} should return {expected_schema}"
+            )

--- a/tests/bioetl/domain/test_config_loader.py
+++ b/tests/bioetl/domain/test_config_loader.py
@@ -2,7 +2,11 @@ from pathlib import Path
 
 import pytest
 
+from bioetl.application.services.schema_contract_provider import (
+    SchemaContractProviderImpl,
+)
 from bioetl.domain.configs import ChemblSourceConfig
+from bioetl.domain.schemas.registry import create_default_schema_registry
 from bioetl.infrastructure.config import provider_registry
 from bioetl.infrastructure.config.loader import (
     ConfigFileNotFoundError,
@@ -10,6 +14,8 @@ from bioetl.infrastructure.config.loader import (
     UnknownProviderError,
     get_pipeline_config,
     get_pipeline_config_from_path,
+    reset_schema_contract_provider,
+    set_schema_contract_provider,
 )
 
 
@@ -18,6 +24,16 @@ def _reset_provider_registry() -> None:
     provider_registry.clear_provider_registry_cache()
     yield
     provider_registry.clear_provider_registry_cache()
+
+
+@pytest.fixture(autouse=True)
+def _setup_schema_contract_provider() -> None:
+    """Set up schema contract provider for tests."""
+    registry = create_default_schema_registry()
+    contract_provider = SchemaContractProviderImpl(registry)
+    set_schema_contract_provider(contract_provider)
+    yield
+    reset_schema_contract_provider()
 
 
 def _write_pipeline_with_env_placeholder(config_path: Path) -> None:

--- a/tests/bioetl/infrastructure/config/test_loader_schema_provider.py
+++ b/tests/bioetl/infrastructure/config/test_loader_schema_provider.py
@@ -1,0 +1,292 @@
+"""Tests for schema contract provider injection in config loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from bioetl.application.services.schema_contract_provider import (
+    SchemaContractProviderImpl,
+)
+from bioetl.domain.ports.schema import SchemaContractProviderABC
+from bioetl.domain.schemas.registry import create_default_schema_registry
+from bioetl.infrastructure.config import provider_registry
+from bioetl.infrastructure.config.loader import (
+    get_pipeline_config_from_path,
+    reset_schema_contract_provider,
+    set_schema_contract_provider,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_schema_provider() -> None:
+    """Reset schema contract provider before and after each test."""
+    reset_schema_contract_provider()
+    yield
+    reset_schema_contract_provider()
+
+
+@pytest.fixture(autouse=True)
+def _reset_provider_registry() -> None:
+    """Reset provider registry before and after each test."""
+    provider_registry.clear_provider_registry_cache()
+    yield
+    provider_registry.clear_provider_registry_cache()
+
+
+class TestSchemaContractProviderInjection:
+    """Tests for schema contract provider dependency injection."""
+
+    def test_raises_runtime_error_when_provider_not_set(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test RuntimeError when loading config without provider set."""
+        providers_file = Path("tests/fixtures/configs/providers.yaml")
+        monkeypatch.setattr(
+            provider_registry,
+            "DEFAULT_PROVIDERS_REGISTRY_PATH",
+            providers_file,
+        )
+        provider_registry.clear_provider_registry_cache()
+
+        # Create a minimal config without fields section
+        config_path = tmp_path / "chembl_activity.yaml"
+        config_path.write_text(
+            """id: chembl.activity
+provider: chembl
+entity: activity
+input_mode: auto_detect
+input_path: null
+output_path: /tmp/out
+batch_size: 5
+provider_config:
+  provider: chembl
+  base_url: https://www.ebi.ac.uk/chembl/api/data
+  timeout_sec: 30
+  max_retries: 3
+  rate_limit_per_sec: 10.0
+""",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(RuntimeError, match="SchemaContractProvider not initialized"):
+            get_pipeline_config_from_path(config_path)
+
+    def test_set_schema_contract_provider_accepts_implementation(self) -> None:
+        """Test set_schema_contract_provider accepts SchemaContractProviderABC."""
+        mock_provider = MagicMock(spec=SchemaContractProviderABC)
+
+        # Should not raise
+        set_schema_contract_provider(mock_provider)
+
+    def test_fields_populated_with_injected_provider(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test fields populated from schema when provider is injected."""
+        providers_file = Path("tests/fixtures/configs/providers.yaml")
+        monkeypatch.setattr(
+            provider_registry,
+            "DEFAULT_PROVIDERS_REGISTRY_PATH",
+            providers_file,
+        )
+        provider_registry.clear_provider_registry_cache()
+
+        # Inject real provider
+        registry = create_default_schema_registry()
+        contract_provider = SchemaContractProviderImpl(registry)
+        set_schema_contract_provider(contract_provider)
+
+        # Create config without fields section
+        config_path = tmp_path / "chembl_activity.yaml"
+        config_path.write_text(
+            """id: chembl.activity
+provider: chembl
+entity: activity
+input_mode: auto_detect
+input_path: null
+output_path: /tmp/out
+batch_size: 5
+provider_config:
+  provider: chembl
+  base_url: https://www.ebi.ac.uk/chembl/api/data
+  timeout_sec: 30
+  max_retries: 3
+  rate_limit_per_sec: 10.0
+""",
+            encoding="utf-8",
+        )
+
+        config = get_pipeline_config_from_path(config_path)
+
+        # Fields should be populated from schema
+        field_names = [field["name"] for field in config.fields]
+        assert len(field_names) > 5
+        assert "action_type" in field_names
+        assert "extracted_at" in field_names
+
+    def test_fields_not_overwritten_when_present_in_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test existing fields in config are not overwritten."""
+        providers_file = Path("tests/fixtures/configs/providers.yaml")
+        monkeypatch.setattr(
+            provider_registry,
+            "DEFAULT_PROVIDERS_REGISTRY_PATH",
+            providers_file,
+        )
+        provider_registry.clear_provider_registry_cache()
+
+        # Inject provider
+        registry = create_default_schema_registry()
+        contract_provider = SchemaContractProviderImpl(registry)
+        set_schema_contract_provider(contract_provider)
+
+        # Create config WITH fields section
+        config_path = tmp_path / "chembl_activity.yaml"
+        config_path.write_text(
+            """id: chembl.activity
+provider: chembl
+entity: activity
+input_mode: auto_detect
+input_path: null
+output_path: /tmp/out
+batch_size: 5
+fields:
+  - name: custom_field
+    data_type: string
+    is_nullable: false
+    is_filterable: true
+    description: Custom field
+provider_config:
+  provider: chembl
+  base_url: https://www.ebi.ac.uk/chembl/api/data
+  timeout_sec: 30
+  max_retries: 3
+  rate_limit_per_sec: 10.0
+""",
+            encoding="utf-8",
+        )
+
+        config = get_pipeline_config_from_path(config_path)
+
+        # Should keep custom fields
+        assert len(config.fields) == 1
+        assert config.fields[0]["name"] == "custom_field"
+
+    def test_reset_schema_contract_provider_clears_state(self) -> None:
+        """Test reset_schema_contract_provider clears injected provider."""
+        mock_provider = MagicMock(spec=SchemaContractProviderABC)
+        set_schema_contract_provider(mock_provider)
+
+        reset_schema_contract_provider()
+
+        # Now loading should fail
+        # (tested indirectly - if provider was still set, loading would succeed)
+        # This test just ensures reset doesn't raise
+        assert True
+
+
+class TestSchemaContractProviderWithMock:
+    """Tests using mock provider to verify contract."""
+
+    def test_get_output_schema_name_called_correctly(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test provider.get_output_schema_name is called with correct args."""
+        providers_file = Path("tests/fixtures/configs/providers.yaml")
+        monkeypatch.setattr(
+            provider_registry,
+            "DEFAULT_PROVIDERS_REGISTRY_PATH",
+            providers_file,
+        )
+        provider_registry.clear_provider_registry_cache()
+
+        mock_provider = MagicMock(spec=SchemaContractProviderABC)
+        mock_provider.get_output_schema_name.return_value = "test_schema"
+        mock_provider.get_field_configs.return_value = [
+            {
+                "name": "test_field",
+                "data_type": "string",
+                "is_nullable": False,
+                "is_filterable": False,
+                "description": "Test",
+            }
+        ]
+        set_schema_contract_provider(mock_provider)
+
+        config_path = tmp_path / "chembl_activity.yaml"
+        config_path.write_text(
+            """id: chembl.activity
+provider: chembl
+entity: activity
+input_mode: auto_detect
+input_path: null
+output_path: /tmp/out
+batch_size: 5
+provider_config:
+  provider: chembl
+  base_url: https://www.ebi.ac.uk/chembl/api/data
+  timeout_sec: 30
+  max_retries: 3
+  rate_limit_per_sec: 10.0
+""",
+            encoding="utf-8",
+        )
+
+        get_pipeline_config_from_path(config_path)
+
+        mock_provider.get_output_schema_name.assert_called_once()
+        call_args = mock_provider.get_output_schema_name.call_args
+        assert call_args[0][0] == "chembl.activity"  # pipeline_code
+        assert call_args[1]["default_entity"] == "activity"  # entity_name
+
+    def test_get_field_configs_called_with_schema_name(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test provider.get_field_configs is called with returned schema name."""
+        providers_file = Path("tests/fixtures/configs/providers.yaml")
+        monkeypatch.setattr(
+            provider_registry,
+            "DEFAULT_PROVIDERS_REGISTRY_PATH",
+            providers_file,
+        )
+        provider_registry.clear_provider_registry_cache()
+
+        mock_provider = MagicMock(spec=SchemaContractProviderABC)
+        mock_provider.get_output_schema_name.return_value = "custom_schema_name"
+        mock_provider.get_field_configs.return_value = [
+            {
+                "name": "field1",
+                "data_type": "string",
+                "is_nullable": False,
+                "is_filterable": False,
+                "description": "",
+            }
+        ]
+        set_schema_contract_provider(mock_provider)
+
+        config_path = tmp_path / "chembl_activity.yaml"
+        config_path.write_text(
+            """id: chembl.activity
+provider: chembl
+entity: activity
+input_mode: auto_detect
+input_path: null
+output_path: /tmp/out
+batch_size: 5
+provider_config:
+  provider: chembl
+  base_url: https://www.ebi.ac.uk/chembl/api/data
+  timeout_sec: 30
+  max_retries: 3
+  rate_limit_per_sec: 10.0
+""",
+            encoding="utf-8",
+        )
+
+        get_pipeline_config_from_path(config_path)
+
+        mock_provider.get_field_configs.assert_called_once_with("custom_schema_name")


### PR DESCRIPTION
Replace direct domain imports (register_schemas, get_pipeline_contract) in infrastructure layer with proper dependency injection through application layer using SchemaContractProviderABC port.

Changes:
- Add SchemaContractProviderABC port in domain/ports/schema.py
- Add SchemaContractProviderImpl adapter in application/services
- Add SchemaBootstrapService for application initialization
- Update config/loader.py to use injected provider via DI
- Add bootstrap_application() in CLI to initialize schema provider
- Add comprehensive tests for new components