### PR TITLE
Remove remaining direct domain imports from infrastructure

### DIFF
--- a/src/bioetl/infrastructure/ARCHITECTURE.md
+++ b/src/bioetl/infrastructure/ARCHITECTURE.md
@@ -1,0 +1,119 @@
+# Infrastructure Layer Architecture
+
+This document describes the architectural rules and allowed dependencies for the
+infrastructure layer in the BioETL project.
+
+## Layer Dependency Rules
+
+The infrastructure layer implements technical concerns (HTTP clients, file I/O,
+database access, etc.) and must follow strict dependency rules to maintain clean
+architecture.
+
+### Allowed Domain Imports
+
+Infrastructure layer **MAY** import from the following domain modules:
+
+| Module Pattern | Description |
+|----------------|-------------|
+| `domain.ports.*` | Port interfaces (ABCs) defining contracts |
+| `domain.configs.*` | Configuration models (Pydantic models) |
+| `domain.errors.*` | Exception classes |
+| `domain.observability.*` | Logging/metrics ports and contracts |
+| `domain.clients.base.contracts` | Base client contracts |
+| `domain.clients.contracts` | Client-specific contracts |
+| `domain.transform.contracts` | Transformation contracts |
+| `domain.transform.merge` | Deep merge utilities |
+| `domain.transform.normalizers` | Normalization utilities |
+| `domain.transform.serializers` | Serialization utilities |
+| `domain.validation` | Validation contracts and types |
+| `domain.pipelines.contracts` | Pipeline contracts |
+| `domain.provider_registry` | Provider registry types |
+| `domain.providers` | Provider definitions |
+| `domain.models` | Domain models (RunContext, etc.) |
+
+### Forbidden Domain Imports
+
+Infrastructure layer **MUST NOT** import at module level:
+
+| Module Pattern | Reason | Alternative |
+|----------------|--------|-------------|
+| `domain.schemas.chembl.raw_models.*` | Domain-specific data models | Use application layer mappers |
+| `domain.schemas.pipeline_contracts.*` | Pipeline contracts | Use `SchemaContractProviderABC` port |
+| `domain.schemas.registry` (direct class import) | Implementation detail | Use `get_default_schema_registry()` via lazy import or DI |
+
+### Allowed Import Patterns
+
+When infrastructure needs to reference domain schemas, use these patterns:
+
+#### 1. TYPE_CHECKING for Type Hints
+
+```python
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bioetl.domain.schemas.chembl.raw_models import ActivityRawModel
+
+def process(data: "ActivityRawModel") -> None:
+    ...
+```
+
+#### 2. Lazy Import for Backward Compatibility
+
+```python
+def deprecated_factory() -> SomeType:
+    """Deprecated factory with lazy import."""
+    warnings.warn("Use new_factory() instead", DeprecationWarning)
+    # Lazy import inside function - acceptable for backward compatibility
+    from bioetl.domain.schemas.chembl.raw_models import ActivityRawModel
+    return SomeType(ActivityRawModel)
+```
+
+#### 3. Dependency Injection
+
+```python
+class MyFactory:
+    def __init__(
+        self,
+        schema_provider_factory: Callable[[], SchemaProviderABC] | None = None,
+    ) -> None:
+        self._schema_provider_factory = schema_provider_factory
+
+    def create(self) -> SchemaProviderABC:
+        if self._schema_provider_factory is not None:
+            return self._schema_provider_factory()
+        # Lazy import as fallback
+        from bioetl.domain.schemas.registry import get_default_schema_registry
+        return get_default_schema_registry()
+```
+
+## Architectural Tests
+
+These rules are enforced by automated tests in:
+
+- `tests/architecture/test_layer_dependencies.py`
+
+Key tests:
+
+| Test | Description |
+|------|-------------|
+| `test_domain_has_no_outer_dependencies` | Domain must not depend on infrastructure or application |
+| `test_infrastructure_does_not_depend_on_application` | Infrastructure must not import application layer |
+| `test_infrastructure_does_not_import_domain_schemas_at_module_level` | Enforces forbidden domain schema imports |
+| `test_infrastructure_impls_are_not_cross_used` | Implementation modules must not cross-reference |
+
+## Rationale
+
+These rules support:
+
+1. **Testability**: Infrastructure can be easily mocked/stubbed via ports
+2. **Flexibility**: Domain schemas can evolve without breaking infrastructure
+3. **Separation of Concerns**: Business logic (domain) stays separate from technical details (infrastructure)
+4. **Dependency Inversion**: High-level modules (domain) don't depend on low-level modules (infrastructure)
+
+## Migration Guide
+
+If you find code that violates these rules:
+
+1. **Module-level schema import** -> Move to `TYPE_CHECKING` block or use lazy import
+2. **Direct `SchemaRegistry()` creation** -> Use `get_default_schema_registry()` or inject via constructor
+3. **Runtime schema usage** -> Create a port/ABC in domain and implement in infrastructure

--- a/src/bioetl/infrastructure/validation/factories.py
+++ b/src/bioetl/infrastructure/validation/factories.py
@@ -1,8 +1,16 @@
 """
 Factories for validation components based on Pandera.
+
+This module provides factory implementations for validation components,
+following the dependency inversion principle by depending on abstractions
+from the domain layer rather than concrete implementations.
 """
 
-from bioetl.domain.schemas.registry import SchemaRegistry
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
 from bioetl.domain.validation import (
     SchemaProviderABC,
     SchemaProviderFactoryABC,
@@ -11,6 +19,9 @@ from bioetl.domain.validation import (
     schema_type,
 )
 from bioetl.infrastructure.validation.impl.pandera_validator import PanderaValidatorImpl
+
+if TYPE_CHECKING:
+    pass  # No type-only imports needed currently
 
 
 class PanderaValidatorFactory(ValidatorFactoryABC):
@@ -22,11 +33,39 @@ class PanderaValidatorFactory(ValidatorFactoryABC):
 
 
 class PanderaSchemaProviderFactory(SchemaProviderFactoryABC):
-    """Фабрика провайдеров схем для Pandera."""
+    """Фабрика провайдеров схем для Pandera.
+
+    This factory supports dependency injection via constructor parameter,
+    allowing tests to provide mock schema providers. When no factory is
+    provided, it uses the default schema registry from the domain layer
+    via lazy import to avoid module-level coupling.
+    """
+
+    def __init__(
+        self,
+        schema_provider_factory: Callable[[], SchemaProviderABC] | None = None,
+    ) -> None:
+        """Initialize with optional schema provider factory.
+
+        Args:
+            schema_provider_factory: Callable that creates SchemaProviderABC instances.
+                If None, uses default factory from domain via lazy import.
+        """
+        self._schema_provider_factory = schema_provider_factory
 
     def create_schema_provider(self) -> SchemaProviderABC:
-        """Create schema provider backed by in-memory registry."""
-        return SchemaRegistry()
+        """Create schema provider backed by in-memory registry.
+
+        Uses lazy import to avoid module-level domain coupling.
+        This maintains architectural boundaries while providing
+        sensible defaults.
+        """
+        if self._schema_provider_factory is not None:
+            return self._schema_provider_factory()
+        # Lazy import to avoid module-level domain schema coupling
+        from bioetl.domain.schemas.registry import get_default_schema_registry
+
+        return get_default_schema_registry()
 
 
 def default_validator_factory() -> ValidatorFactoryABC:

--- a/tests/architecture/test_layer_dependencies.py
+++ b/tests/architecture/test_layer_dependencies.py
@@ -206,3 +206,125 @@ def test_infrastructure_impls_are_not_cross_used() -> None:
                 )
 
     _assert_no_violations(violations)
+
+
+def _is_inside_type_checking(node: ast.AST, tree: ast.Module) -> bool:
+    """Check if a node is inside an `if TYPE_CHECKING:` block."""
+
+    class TypeCheckingVisitor(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.type_checking_ranges: list[tuple[int, int]] = []
+
+        def visit_If(self, node: ast.If) -> None:
+            # Check if this is `if TYPE_CHECKING:`
+            is_type_checking = False
+            if isinstance(node.test, ast.Name) and node.test.id == "TYPE_CHECKING":
+                is_type_checking = True
+            elif isinstance(node.test, ast.Attribute):
+                if node.test.attr == "TYPE_CHECKING":
+                    is_type_checking = True
+
+            if is_type_checking:
+                # Get the range of lines covered by this block
+                start_line = node.lineno
+                end_line = start_line
+                for child in ast.walk(node):
+                    if hasattr(child, "lineno"):
+                        end_line = max(end_line, child.lineno)
+                self.type_checking_ranges.append((start_line, end_line))
+
+            self.generic_visit(node)
+
+    visitor = TypeCheckingVisitor()
+    visitor.visit(tree)
+
+    if not hasattr(node, "lineno"):
+        return False
+
+    for start, end in visitor.type_checking_ranges:
+        if start <= node.lineno <= end:
+            return True
+    return False
+
+
+def _is_module_level_import(node: ast.AST, tree: ast.Module) -> bool:
+    """Check if an import is at module level (not inside function/class/if)."""
+    # Module level means it's a direct child of the module body
+    return node in tree.body
+
+
+def _collect_module_level_imports(path: Path) -> list[ImportReference]:
+    """Collect only module-level imports, excluding TYPE_CHECKING blocks."""
+    code = path.read_text(encoding="utf-8")
+    tree = ast.parse(code)
+    current_module, is_package = _module_from_path(path)
+    imports: list[ImportReference] = []
+
+    for node in tree.body:
+        # Skip if inside TYPE_CHECKING block
+        if _is_inside_type_checking(node, tree):
+            continue
+
+        imports.extend(
+            _imports_from_node(
+                node, current_module=current_module, is_package=is_package
+            )
+        )
+
+    return imports
+
+
+# Forbidden domain.schemas imports for infrastructure layer
+FORBIDDEN_DOMAIN_SCHEMA_PATTERNS = [
+    "bioetl.domain.schemas.chembl.raw_models",
+    "bioetl.domain.schemas.pipeline_contracts",
+]
+
+# Allowed domain imports for infrastructure layer
+ALLOWED_DOMAIN_PATTERNS = [
+    "bioetl.domain.ports",
+    "bioetl.domain.configs",
+    "bioetl.domain.errors",
+    "bioetl.domain.observability",
+    "bioetl.domain.clients.base.contracts",
+    "bioetl.domain.clients.contracts",
+    "bioetl.domain.transform.contracts",
+    "bioetl.domain.transform.merge",
+    "bioetl.domain.transform.normalizers",
+    "bioetl.domain.transform.serializers",
+    "bioetl.domain.validation",
+    "bioetl.domain.pipelines.contracts",
+    "bioetl.domain.provider_registry",
+    "bioetl.domain.providers",
+    "bioetl.domain.models",
+]
+
+
+def test_infrastructure_does_not_import_domain_schemas_at_module_level() -> None:
+    """Verify infrastructure layer doesn't directly import domain schemas at module level.
+
+    Infrastructure may use domain schemas via:
+    - TYPE_CHECKING blocks (for type hints only)
+    - Lazy imports inside functions (for backward compatibility with deprecation warnings)
+
+    But MUST NOT have module-level imports from:
+    - domain.schemas.chembl.raw_models
+    - domain.schemas.pipeline_contracts
+    """
+    violations: list[str] = []
+
+    for file_path in sorted(INFRASTRUCTURE_ROOT.rglob("*.py")):
+        for reference in _collect_module_level_imports(file_path):
+            for forbidden_pattern in FORBIDDEN_DOMAIN_SCHEMA_PATTERNS:
+                if reference.module.startswith(forbidden_pattern):
+                    violations.append(
+                        _format_violation(
+                            file_path,
+                            reference.lineno,
+                            f"infrastructure must not import {forbidden_pattern} at module level "
+                            "(use TYPE_CHECKING for type hints or lazy import for backward compat). "
+                            f"Found: {reference.module}",
+                        )
+                    )
+
+    _assert_no_violations(violations)


### PR DESCRIPTION
…cture

- Replace module-level SchemaRegistry import with lazy import via get_default_schema_registry() in validation/factories.py
- Add dependency injection support to PanderaSchemaProviderFactory
- Add architectural test to enforce domain schema import rules
- Document allowed/forbidden domain imports in ARCHITECTURE.md

This ensures infrastructure layer follows dependency inversion principle and doesn't directly depend on domain schema implementations.