### PR TITLE
Unify two response parsing interfaces

### DIFF
--- a/src/bioetl/domain/clients/base/__init__.py
+++ b/src/bioetl/domain/clients/base/__init__.py
@@ -1,11 +1,17 @@
-"""Base contracts for data source clients."""
+"""Base contracts for data source clients.
+
+Note:
+    ``ResponseParserABC`` is deprecated. Use ``ResponseParserPortABC``
+    from ``bioetl.domain.ports.parsing`` instead.
+"""
+
+import warnings
 
 from bioetl.domain.clients.base.contracts import (
     CacheABC,
     PaginatorABC,
     RateLimiterABC,
     RequestBuilderABC,
-    ResponseParserABC,
     RetryPolicyABC,
     SecretProviderABC,
 )
@@ -15,7 +21,23 @@ __all__ = [
     "PaginatorABC",
     "RateLimiterABC",
     "RequestBuilderABC",
-    "ResponseParserABC",
+    "ResponseParserABC",  # Deprecated: re-exported for backward compatibility
     "RetryPolicyABC",
     "SecretProviderABC",
 ]
+
+
+def __getattr__(name: str) -> type:
+    """Lazy import with deprecation warning for ResponseParserABC."""
+    if name == "ResponseParserABC":
+        from bioetl.domain.ports.parsing import ResponseParserPortABC
+
+        warnings.warn(
+            "ResponseParserABC is deprecated. "
+            "Use ResponseParserPortABC from bioetl.domain.ports.parsing instead. "
+            "See migration guide in bioetl.domain.ports.parsing module docstring.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return ResponseParserPortABC
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/bioetl/domain/clients/base/contracts.py
+++ b/src/bioetl/domain/clients/base/contracts.py
@@ -1,7 +1,14 @@
-"""Base contracts for data source helpers."""
+"""Base contracts for data source helpers.
+
+Note:
+    ``ResponseParserABC`` has been deprecated and unified with
+    ``ResponseParserPortABC`` from ``bioetl.domain.ports.parsing``.
+    Import ``ResponseParserPortABC`` directly from ``bioetl.domain.ports.parsing``
+    for new code. The re-export here is provided for backward compatibility only.
+"""
 
 from abc import ABC, abstractmethod
-from typing import Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 import warnings
 
 from pydantic import BaseModel
@@ -9,6 +16,9 @@ from pydantic import BaseModel
 T = TypeVar("T")
 RecordT = TypeVar("RecordT", bound=BaseModel)
 RecordModel = BaseModel
+
+if TYPE_CHECKING:
+    from bioetl.domain.ports.parsing import ResponseParserPortABC
 
 
 class RequestBuilderABC(ABC):
@@ -42,33 +52,33 @@ class RequestBuilderABC(ABC):
         return self.build_with_pagination(offset, limit)
 
 
-class ResponseParserABC(ABC, Generic[RecordT]):
+# =============================================================================
+# Deprecated: ResponseParserABC
+# =============================================================================
+# ResponseParserABC has been unified with ResponseParserPortABC.
+# This section provides backward compatibility via re-export with deprecation.
+
+
+def __getattr__(name: str) -> type:
+    """Lazy import with deprecation warning for ResponseParserABC.
+
+    This enables backward-compatible imports like:
+        from bioetl.domain.clients.base.contracts import ResponseParserABC
+
+    But emits a DeprecationWarning directing users to the new location.
     """
-    Разбор ответов API.
-    """
+    if name == "ResponseParserABC":
+        from bioetl.domain.ports.parsing import ResponseParserPortABC
 
-    @abstractmethod
-    def parse(self, raw_response: dict[str, object]) -> list[RecordT]:
-        """Парсит сырой ответ в список типизированных записей."""
-
-    def parse_response(self, raw_response: dict[str, object]) -> list[RecordT]:
-        """Deprecated alias for parse.
-
-        .. deprecated:: 1.0
-            Use :meth:`parse` instead. Will be removed in 2.0.
-        """
         warnings.warn(
-            "parse_response() is deprecated, use parse() instead",
+            "ResponseParserABC is deprecated. "
+            "Use ResponseParserPortABC from bioetl.domain.ports.parsing instead. "
+            "See migration guide in bioetl.domain.ports.parsing module docstring.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.parse(raw_response)
-
-    @abstractmethod
-    def extract_metadata(
-        self, raw_response: dict[str, object]
-    ) -> dict[str, int | str | None]:
-        """Извлекает метаданные из ответа (например, общее кол-во)."""
+        return ResponseParserPortABC
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 class PaginatorABC(ABC):

--- a/src/bioetl/domain/ports/parsing.py
+++ b/src/bioetl/domain/ports/parsing.py
@@ -4,10 +4,41 @@ This module defines abstract contracts for parsing raw API responses
 without domain model knowledge, following hexagonal architecture principles.
 Infrastructure adapters implement these ports to parse provider-specific responses
 into generic record dictionaries.
+
+Migration Guide (from ResponseParserABC):
+-----------------------------------------
+``ResponseParserABC`` from ``bioetl.domain.clients.base.contracts`` is deprecated.
+Use ``ResponseParserPortABC`` from this module instead.
+
+Method mapping:
+    - ``parse(raw_response)`` → ``parse_to_records(raw_response)``
+    - ``parse_response(raw_response)`` → ``parse_to_records(raw_response)`` (was deprecated)
+    - ``extract_metadata(raw_response)`` → ``extract_pagination(raw_response)``
+
+Type changes:
+    - Generic[RecordT] (Pydantic models) → RawRecordList (untyped dicts)
+    - This change improves layer isolation (infrastructure doesn't import domain models)
+
+Example migration::
+
+    # Before (deprecated)
+    from bioetl.domain.clients.base.contracts import ResponseParserABC
+
+    class MyParser(ResponseParserABC[MyModel]):
+        def parse(self, raw_response): ...
+        def extract_metadata(self, raw_response): ...
+
+    # After (recommended)
+    from bioetl.domain.ports.parsing import ResponseParserPortABC
+
+    class MyParser(ResponseParserPortABC):
+        def parse_to_records(self, raw_response): ...
+        def extract_pagination(self, raw_response): ...
 """
 
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, TypeAlias
@@ -66,6 +97,52 @@ class ResponseParserPortABC(ABC):
             total_count, offset, limit, next_url, etc.
             Keys depend on provider implementation.
         """
+
+    # =========================================================================
+    # Backward compatibility aliases (from deprecated ResponseParserABC)
+    # =========================================================================
+
+    def parse(self, raw_response: RawPayload) -> RawRecordList:
+        """Backward-compatible alias for :meth:`parse_to_records`.
+
+        .. deprecated:: 2.0
+            Use :meth:`parse_to_records` instead. Will be removed in 3.0.
+
+        Args:
+            raw_response: Raw dictionary payload from API response.
+
+        Returns:
+            List of record dictionaries without type validation.
+        """
+        warnings.warn(
+            "parse() is deprecated, use parse_to_records() instead. "
+            "See migration guide in bioetl.domain.ports.parsing docstring.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.parse_to_records(raw_response)
+
+    def extract_metadata(
+        self, raw_response: RawPayload
+    ) -> dict[str, int | str | None]:
+        """Backward-compatible alias for :meth:`extract_pagination`.
+
+        .. deprecated:: 2.0
+            Use :meth:`extract_pagination` instead. Will be removed in 3.0.
+
+        Args:
+            raw_response: Raw dictionary payload from API response.
+
+        Returns:
+            Dictionary containing pagination/metadata information.
+        """
+        warnings.warn(
+            "extract_metadata() is deprecated, use extract_pagination() instead. "
+            "See migration guide in bioetl.domain.ports.parsing docstring.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.extract_pagination(raw_response)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/bioetl/infrastructure/clients/chembl/impl/chembl_http_client_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/chembl_http_client_impl.py
@@ -10,8 +10,8 @@ from typing import Any, Iterator
 from bioetl.domain.clients.base.contracts import (
     RateLimiterABC,
     RequestBuilderABC,
-    ResponseParserABC,
 )
+from bioetl.domain.ports.parsing import ResponseParserPortABC
 from bioetl.domain.clients.contracts import DataClientABC
 from bioetl.domain.observability import LoggingPortABC
 from bioetl.infrastructure.clients.chembl.constants import resolve_endpoint
@@ -34,7 +34,7 @@ class ChemblHttpClientImpl(DataClientABC):
     def __init__(
         self,
         request_builder: RequestBuilderABC,
-        response_parser: ResponseParserABC,
+        response_parser: ResponseParserPortABC,
         rate_limiter: RateLimiterABC,
         http_client: Any,
         logger: LoggingPortABC,

--- a/tests/bioetl/infrastructure/clients/chembl/test_fallback_client.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_fallback_client.py
@@ -1,8 +1,9 @@
 from types import SimpleNamespace
 from unittest.mock import Mock
 
-from bioetl.domain.clients.base.contracts import RateLimiterABC, ResponseParserABC
+from bioetl.domain.clients.base.contracts import RateLimiterABC
 from bioetl.domain.observability import LoggingPortABC
+from bioetl.domain.ports.parsing import RawPayload, RawRecordList, ResponseParserPortABC
 from bioetl.infrastructure.clients.chembl.impl.chembl_http_client_impl import (
     ChemblHttpClientImpl,
 )
@@ -11,14 +12,15 @@ from bioetl.infrastructure.clients.chembl.request_builder import (
 )
 
 
-class DummyParser(ResponseParserABC):
-    def parse(self, raw_response):
+class DummyParser(ResponseParserPortABC):
+    """Test parser implementing the unified ResponseParserPortABC interface."""
+
+    def parse_to_records(self, raw_response: RawPayload) -> RawRecordList:
         return []
 
-    def parse_response(self, raw_response):
-        return []
-
-    def extract_metadata(self, raw_response):
+    def extract_pagination(
+        self, raw_response: RawPayload
+    ) -> dict[str, int | str | None]:
         return {}
 
 


### PR DESCRIPTION
…nterfaces

Consolidate two parsing interfaces into one canonical interface (ResponseParserPortABC) following hexagonal architecture principles.

Changes:
- Remove ResponseParserABC class definition from contracts.py
- Add re-export with DeprecationWarning for backward compatibility
- Add migration guide in domain/ports/parsing.py docstring
- Add backward-compatible method aliases (parse, extract_metadata)
- Update infrastructure layer to use ResponseParserPortABC
- Update tests to use the unified interface

BREAKING CHANGE: ResponseParserABC is now deprecated. Use ResponseParserPortABC from bioetl.domain.ports.parsing instead.