### PR TITLE
Split unified loader into separate components

### DIFF
--- a/src/bioetl/domain/ports/__init__.py
+++ b/src/bioetl/domain/ports/__init__.py
@@ -10,6 +10,14 @@ from bioetl.domain.ports.extraction import (
     from_raw_records,
     to_raw_records,
 )
+from bioetl.domain.ports.output import (
+    ChecksumCalculatorPort,
+    DataWriterPort,
+    MetadataBuilderPort,
+    MetadataWriterPort,
+    QcArtifactWriterPort,
+    QcReportGeneratorPort,
+)
 from bioetl.domain.ports.parsing import (
     PaginationInfo,
     RawPayload,
@@ -29,6 +37,13 @@ __all__: list[str] = [
     # Backward compatibility helpers
     "from_raw_records",
     "to_raw_records",
+    # Output ports
+    "ChecksumCalculatorPort",
+    "DataWriterPort",
+    "MetadataBuilderPort",
+    "MetadataWriterPort",
+    "QcArtifactWriterPort",
+    "QcReportGeneratorPort",
     # Parsing ports
     "PaginationInfo",
     "RawPayload",

--- a/src/bioetl/domain/ports/output.py
+++ b/src/bioetl/domain/ports/output.py
@@ -1,0 +1,211 @@
+"""Ports for output components (domain layer).
+
+This module defines the interfaces for output-related components
+following the hexagonal architecture pattern.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol
+
+import pandas as pd
+
+if TYPE_CHECKING:
+    from bioetl.domain.clients.base.output.contracts import WriteResult
+    from bioetl.domain.configs import QcConfig
+    from bioetl.domain.models import RunContext
+
+
+class DataWriterPort(Protocol):
+    """Port for writing DataFrame to various formats (parquet, csv, json).
+
+    Implementations handle format-specific serialization without
+    knowledge of QC reports, metadata, or checksums.
+    """
+
+    def write(
+        self,
+        df: pd.DataFrame,
+        path: Path,
+        *,
+        column_order: list[str] | None = None,
+    ) -> "WriteResult":
+        """Write DataFrame to the specified path.
+
+        Args:
+            df: DataFrame to write.
+            path: Target file path.
+            column_order: Optional column ordering.
+
+        Returns:
+            WriteResult with path, row_count, duration.
+        """
+        ...
+
+    def has_format_support(self, fmt: str) -> bool:
+        """Check if this writer supports the given format.
+
+        Args:
+            fmt: Format name (e.g., 'csv', 'parquet', 'json').
+
+        Returns:
+            True if format is supported.
+        """
+        ...
+
+
+class QcReportGeneratorPort(ABC):
+    """Port for generating QC (quality control) reports.
+
+    Implementations build quality and correlation reports
+    without knowledge of file writing or metadata.
+    """
+
+    @abstractmethod
+    def build_quality_report(
+        self, df: pd.DataFrame, *, min_coverage: float
+    ) -> pd.DataFrame:
+        """Build quality metrics report for DataFrame columns.
+
+        Args:
+            df: Source DataFrame.
+            min_coverage: Minimum coverage threshold.
+
+        Returns:
+            DataFrame with column-level quality metrics.
+        """
+
+    @abstractmethod
+    def build_correlation_report(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Build correlation matrix for numeric columns.
+
+        Args:
+            df: Source DataFrame.
+
+        Returns:
+            DataFrame with correlation matrix.
+        """
+
+
+class MetadataBuilderPort(ABC):
+    """Port for building run metadata.
+
+    Implementations construct metadata dictionaries without
+    knowledge of how they will be persisted.
+    """
+
+    @abstractmethod
+    def build_run_metadata(
+        self,
+        context: "RunContext",
+        result: "WriteResult",
+        *,
+        qc_artifacts: list[Path] | None = None,
+        qc_checksums: dict[str, str] | None = None,
+        qc_config: "QcConfig | None" = None,
+    ) -> dict[str, Any]:
+        """Build metadata for a completed pipeline run.
+
+        Args:
+            context: Run context with execution details.
+            result: Write result with path and checksum.
+            qc_artifacts: List of QC artifact paths.
+            qc_checksums: Checksums for QC artifacts.
+            qc_config: QC configuration used.
+
+        Returns:
+            Metadata dictionary ready for serialization.
+        """
+
+    @abstractmethod
+    def build_dry_run_metadata(
+        self, context: "RunContext", row_count: int
+    ) -> dict[str, Any]:
+        """Build metadata for a dry-run execution.
+
+        Args:
+            context: Run context.
+            row_count: Number of rows that would be written.
+
+        Returns:
+            Metadata dictionary for dry run.
+        """
+
+
+class MetadataWriterPort(Protocol):
+    """Port for persisting metadata to storage.
+
+    Implementations handle serialization format (YAML, JSON)
+    and atomic writes without knowledge of metadata structure.
+    """
+
+    def write_meta(self, meta: dict[str, Any], path: Path) -> None:
+        """Write metadata dictionary to file.
+
+        Args:
+            meta: Metadata dictionary.
+            path: Target file path.
+        """
+        ...
+
+
+class ChecksumCalculatorPort(ABC):
+    """Port for calculating file checksums.
+
+    Implementations provide hash computation without
+    knowledge of file formats or metadata.
+    """
+
+    @abstractmethod
+    def compute_checksum(self, path: Path) -> str:
+        """Compute checksum for a single file.
+
+        Args:
+            path: Path to file.
+
+        Returns:
+            Hex-encoded checksum string.
+        """
+
+    @abstractmethod
+    def compute_checksums(self, paths: list[Path]) -> dict[str, str]:
+        """Compute checksums for multiple files.
+
+        Args:
+            paths: List of file paths.
+
+        Returns:
+            Dict mapping filename to checksum.
+        """
+
+
+class QcArtifactWriterPort(Protocol):
+    """Port for writing QC artifacts (CSV reports).
+
+    Implementations handle atomic CSV writing without
+    knowledge of QC report generation logic.
+    """
+
+    def write_qc_csv(self, df: pd.DataFrame, path: Path) -> Path:
+        """Write QC DataFrame to CSV atomically.
+
+        Args:
+            df: QC report DataFrame.
+            path: Target file path.
+
+        Returns:
+            Path to written file.
+        """
+        ...
+
+
+__all__ = [
+    "ChecksumCalculatorPort",
+    "DataWriterPort",
+    "MetadataBuilderPort",
+    "MetadataWriterPort",
+    "QcArtifactWriterPort",
+    "QcReportGeneratorPort",
+]

--- a/src/bioetl/infrastructure/output/components/__init__.py
+++ b/src/bioetl/infrastructure/output/components/__init__.py
@@ -1,0 +1,19 @@
+"""Output components for unified loader facade."""
+
+from bioetl.infrastructure.output.components.checksum_calculator import (
+    ChecksumCalculator,
+)
+from bioetl.infrastructure.output.components.data_writer import DataWriterAdapter
+from bioetl.infrastructure.output.components.metadata_builder import MetadataBuilder
+from bioetl.infrastructure.output.components.qc_artifact_writer import QcArtifactWriter
+from bioetl.infrastructure.output.components.qc_report_generator import (
+    QcReportGenerator,
+)
+
+__all__ = [
+    "ChecksumCalculator",
+    "DataWriterAdapter",
+    "MetadataBuilder",
+    "QcArtifactWriter",
+    "QcReportGenerator",
+]

--- a/src/bioetl/infrastructure/output/components/checksum_calculator.py
+++ b/src/bioetl/infrastructure/output/components/checksum_calculator.py
@@ -1,0 +1,65 @@
+"""Checksum calculator component implementation."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from bioetl.domain.ports.output import ChecksumCalculatorPort
+from bioetl.infrastructure.constants import CHECKSUM_CHUNK_SIZE
+
+
+class ChecksumCalculator(ChecksumCalculatorPort):
+    """SHA256 checksum calculator for file integrity verification.
+
+    This component handles all checksum-related operations
+    without knowledge of file formats or pipeline context.
+    """
+
+    def __init__(self, *, chunk_size: int | None = None) -> None:
+        """Initialize calculator.
+
+        Args:
+            chunk_size: Size of chunks for reading large files.
+                        Defaults to CHECKSUM_CHUNK_SIZE constant.
+        """
+        self._chunk_size = chunk_size or CHECKSUM_CHUNK_SIZE
+
+    def compute_checksum(self, path: Path) -> str:
+        """Compute SHA256 checksum for a single file.
+
+        Args:
+            path: Path to the file.
+
+        Returns:
+            Hex-encoded SHA256 hash string.
+
+        Raises:
+            FileNotFoundError: If file does not exist.
+        """
+        sha256 = hashlib.sha256()
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(self._chunk_size), b""):
+                sha256.update(chunk)
+        return sha256.hexdigest()
+
+    def compute_checksums(self, paths: list[Path]) -> dict[str, str]:
+        """Compute SHA256 checksums for multiple files.
+
+        Missing files are silently skipped.
+
+        Args:
+            paths: List of file paths.
+
+        Returns:
+            Dict mapping filename (not full path) to checksum.
+        """
+        checksums: dict[str, str] = {}
+        for path in paths:
+            if not path.exists():
+                continue
+            checksums[path.name] = self.compute_checksum(path)
+        return checksums
+
+
+__all__ = ["ChecksumCalculator"]

--- a/src/bioetl/infrastructure/output/components/data_writer.py
+++ b/src/bioetl/infrastructure/output/components/data_writer.py
@@ -1,0 +1,78 @@
+"""Data writer adapter component implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+import pandas as pd
+
+from bioetl.domain.clients.base.output.contracts import WriteResult
+
+
+class FormatWriter(Protocol):
+    """Protocol for format-specific writers (CSV, Parquet, JSON)."""
+
+    def write(
+        self,
+        df: pd.DataFrame,
+        path: Path,
+        *,
+        column_order: list[str] | None = None,
+    ) -> WriteResult:
+        """Write DataFrame to path."""
+        ...
+
+    def has_format_support(self, fmt: str) -> bool:
+        """Check if format is supported."""
+        ...
+
+
+class DataWriterAdapter:
+    """Adapter for format-specific data writers.
+
+    This component delegates to concrete writers (CSV, Parquet)
+    without knowledge of QC reports, metadata, or checksums.
+    It provides a unified interface for the facade.
+    """
+
+    def __init__(self, writer: FormatWriter) -> None:
+        """Initialize adapter with concrete writer.
+
+        Args:
+            writer: Format-specific writer (CsvWriter, ParquetWriter).
+        """
+        self._writer = writer
+
+    def write(
+        self,
+        df: pd.DataFrame,
+        path: Path,
+        *,
+        column_order: list[str] | None = None,
+    ) -> WriteResult:
+        """Write DataFrame to the specified path.
+
+        Args:
+            df: DataFrame to write.
+            path: Target file path.
+            column_order: Optional column ordering.
+
+        Returns:
+            WriteResult with path, row_count, duration.
+        """
+        return self._writer.write(df, path, column_order=column_order)
+
+    def has_format_support(self, fmt: str) -> bool:
+        """Check if this writer supports the given format.
+
+        Args:
+            fmt: Format name (e.g., 'csv', 'parquet').
+
+        Returns:
+            True if format is supported.
+        """
+        return self._writer.has_format_support(fmt)
+
+
+__all__ = ["DataWriterAdapter", "FormatWriter"]

--- a/src/bioetl/infrastructure/output/components/metadata_builder.py
+++ b/src/bioetl/infrastructure/output/components/metadata_builder.py
@@ -1,0 +1,132 @@
+"""Metadata builder component implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from bioetl.domain.clients.base.output.contracts import WriteResult
+from bioetl.domain.configs import QcConfig
+from bioetl.domain.models import RunContext
+from bioetl.domain.ports.output import MetadataBuilderPort
+
+
+class MetadataBuilder(MetadataBuilderPort):
+    """Builder for deterministic run metadata.
+
+    This component constructs metadata dictionaries without
+    knowledge of how they will be serialized or persisted.
+    """
+
+    def build_run_metadata(
+        self,
+        context: RunContext,
+        result: WriteResult,
+        *,
+        qc_artifacts: list[Path] | None = None,
+        qc_checksums: dict[str, str] | None = None,
+        qc_config: QcConfig | None = None,
+    ) -> dict[str, Any]:
+        """Build metadata for a completed pipeline run.
+
+        Args:
+            context: Run context with execution details.
+            result: Write result with path and checksum.
+            qc_artifacts: List of QC artifact paths.
+            qc_checksums: Checksums for QC artifacts.
+            qc_config: QC configuration used.
+
+        Returns:
+            Metadata dictionary with run details.
+        """
+        qc_artifacts = qc_artifacts or []
+        qc_checksums = qc_checksums or {}
+        qc_config = qc_config or QcConfig()
+
+        files = [result.path.name]
+        files.extend(path.name for path in qc_artifacts)
+
+        meta = self._build_base_metadata(
+            context, row_count=result.row_count, include_metadata=False
+        )
+        meta.update(
+            {
+                "checksum": result.checksum,
+                # For backward compatibility and explicitness
+                "hash": result.checksum,
+                "files": sorted(files),
+                "checksums": {
+                    result.path.name: result.checksum,
+                    **qc_checksums,
+                },
+                "qc_artifacts": {
+                    path.name: {
+                        "path": path.name,
+                        "checksum": qc_checksums.get(path.name),
+                    }
+                    for path in sorted(qc_artifacts, key=lambda p: p.name)
+                },
+                "qc_config": {
+                    "enable_quality_report": qc_config.enable_quality_report,
+                    "enable_correlation_report": qc_config.enable_correlation_report,
+                    "min_coverage": qc_config.min_coverage,
+                },
+            }
+        )
+        meta.update(context.metadata)
+        return meta
+
+    def build_dry_run_metadata(
+        self, context: RunContext, row_count: int
+    ) -> dict[str, Any]:
+        """Build metadata for a dry-run execution.
+
+        Args:
+            context: Run context.
+            row_count: Number of rows that would be written.
+
+        Returns:
+            Metadata dictionary for dry run.
+        """
+        return self._build_base_metadata(
+            context, row_count=row_count, dry_run=True, include_metadata=True
+        )
+
+    def _build_base_metadata(
+        self,
+        context: RunContext,
+        *,
+        row_count: int,
+        dry_run: bool = False,
+        include_metadata: bool = True,
+    ) -> dict[str, Any]:
+        """Build base metadata dictionary.
+
+        Args:
+            context: Run context.
+            row_count: Number of rows.
+            dry_run: Whether this is a dry run.
+            include_metadata: Whether to include user metadata from context.
+
+        Returns:
+            Base metadata dictionary.
+        """
+        meta: dict[str, Any] = {
+            "run_id": context.run_id,
+            "entity": context.entity_name,
+            "provider": context.provider,
+            "timestamp": context.started_at.isoformat(),
+            "hash_version": "v1_blake2b_256",
+            "row_count": row_count,
+        }
+
+        if dry_run:
+            meta["dry_run"] = True
+
+        if include_metadata:
+            meta.update(context.metadata)
+
+        return meta
+
+
+__all__ = ["MetadataBuilder"]

--- a/src/bioetl/infrastructure/output/components/qc_artifact_writer.py
+++ b/src/bioetl/infrastructure/output/components/qc_artifact_writer.py
@@ -1,0 +1,49 @@
+"""QC artifact writer component implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from bioetl.infrastructure.files.atomic import AtomicFileOperation
+
+
+class QcArtifactWriter:
+    """Writer for QC artifacts (CSV reports).
+
+    This component handles atomic CSV writing for QC reports
+    without knowledge of QC report generation logic.
+    """
+
+    def __init__(
+        self,
+        atomic_op: AtomicFileOperation | None = None,
+    ) -> None:
+        """Initialize writer.
+
+        Args:
+            atomic_op: Atomic file operation handler.
+        """
+        self._atomic_op = atomic_op or AtomicFileOperation()
+
+    def write_qc_csv(self, df: pd.DataFrame, path: Path) -> Path:
+        """Write QC DataFrame to CSV atomically.
+
+        Args:
+            df: QC report DataFrame.
+            path: Target file path.
+
+        Returns:
+            Path to written file.
+        """
+
+        def _write_wrapper(temp_path: Path) -> None:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            df.to_csv(temp_path, index=False)
+
+        self._atomic_op.write_atomic(path, _write_wrapper)
+        return path
+
+
+__all__ = ["QcArtifactWriter"]

--- a/src/bioetl/infrastructure/output/components/qc_report_generator.py
+++ b/src/bioetl/infrastructure/output/components/qc_report_generator.py
@@ -1,0 +1,83 @@
+"""QC report generator component implementation."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from bioetl.domain.ports.output import QcReportGeneratorPort
+
+
+class QcReportGenerator(QcReportGeneratorPort):
+    """Generator for quality control reports.
+
+    This component builds quality and correlation reports
+    without knowledge of file writing or metadata concerns.
+    """
+
+    def build_quality_report(
+        self, df: pd.DataFrame, *, min_coverage: float
+    ) -> pd.DataFrame:
+        """Compute null/coverage metrics per column with coverage threshold.
+
+        Args:
+            df: Source DataFrame to analyze.
+            min_coverage: Minimum required coverage (0.0 to 1.0).
+
+        Returns:
+            DataFrame with columns: column, null_count, non_null_count,
+            unique_count, dtype, coverage, coverage_ok.
+        """
+        row_count = len(df.index)
+        nulls = df.isnull().sum()
+        non_nulls = df.notnull().sum()
+        unique_counts = df.nunique(dropna=True)
+        coverage = non_nulls / row_count if row_count > 0 else 0.0
+
+        report = pd.DataFrame(
+            {
+                "column": df.columns,
+                "null_count": nulls.values,
+                "non_null_count": non_nulls.values,
+                "unique_count": unique_counts.values,
+                "dtype": df.dtypes.values.astype(str),
+                "coverage": (
+                    coverage.values if hasattr(coverage, "values") else coverage
+                ),
+                "coverage_ok": (
+                    (coverage >= min_coverage).values
+                    if hasattr(coverage, "values")
+                    else False
+                ),
+            }
+        )
+
+        return report.sort_values(by="column", ignore_index=True)
+
+    def build_correlation_report(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Calculate numeric correlation matrix with stable ordering.
+
+        Args:
+            df: Source DataFrame.
+
+        Returns:
+            DataFrame with correlation matrix. First column is 'column'
+            containing row labels, remaining columns are correlations.
+        """
+        numeric_columns = sorted(
+            c for c in df.columns if pd.api.types.is_numeric_dtype(df[c])
+        )
+        if not numeric_columns:
+            return pd.DataFrame(columns=["column"])
+
+        numeric_df = df[numeric_columns].copy()
+        for column in numeric_columns:
+            if pd.api.types.is_bool_dtype(numeric_df[column]):
+                numeric_df[column] = numeric_df[column].astype(int)
+
+        correlation = numeric_df.corr(numeric_only=True)
+        correlation = correlation.loc[numeric_columns, numeric_columns]
+        correlation.insert(0, "column", correlation.index)
+        return correlation.reset_index(drop=True)
+
+
+__all__ = ["QcReportGenerator"]

--- a/src/bioetl/infrastructure/output/unified_loader_impl.py
+++ b/src/bioetl/infrastructure/output/unified_loader_impl.py
@@ -1,72 +1,103 @@
-"""Unified loader implementation for pipeline outputs."""
+"""Unified loader facade for pipeline outputs.
+
+This module provides UnifiedLoaderImpl - a facade that coordinates
+multiple output components following the Single Responsibility Principle.
+"""
+
+from __future__ import annotations
 
 from pathlib import Path
-from typing import Protocol
 
 import pandas as pd
 
 from bioetl.domain.clients.base.output.contracts import (
     OutputFrameConverterABC,
-    QualityReportABC,
     WriteResult,
 )
 from bioetl.domain.configs import DeterminismConfig, QcConfig
 from bioetl.domain.models import RunContext
 from bioetl.domain.observability import MetricsPortABC
 from bioetl.domain.pipelines.contracts import LoaderABC
+from bioetl.domain.ports.output import (
+    ChecksumCalculatorPort,
+    DataWriterPort,
+    MetadataBuilderPort,
+    MetadataWriterPort,
+    QcReportGeneratorPort,
+)
 from bioetl.infrastructure.files.atomic import AtomicFileOperation
-from bioetl.infrastructure.files.checksum import compute_file_sha256
 from bioetl.infrastructure.output.column_order import apply_column_order
-from bioetl.infrastructure.output.metadata import build_run_metadata
-
-
-class _DataWriter(Protocol):
-    def write(
-        self,
-        df: pd.DataFrame,
-        path: Path,
-        *,
-        column_order: list[str] | None = None,
-    ) -> WriteResult:
-        """Write DataFrame to path."""
-        ...
-
-
-class _MetadataWriter(Protocol):
-    def write_meta(self, meta: dict, path: Path) -> None:
-        """Write metadata dict to path."""
-        ...
+from bioetl.infrastructure.output.components.checksum_calculator import (
+    ChecksumCalculator,
+)
+from bioetl.infrastructure.output.components.metadata_builder import MetadataBuilder
+from bioetl.infrastructure.output.components.qc_artifact_writer import QcArtifactWriter
+from bioetl.infrastructure.output.components.qc_report_generator import (
+    QcReportGenerator,
+)
 
 
 class UnifiedLoaderImpl(LoaderABC):
     """
-    Фасад для записи результатов пайплайна.
+    Facade for writing pipeline results.
 
-    Обеспечивает:
-    - Атомарную запись (write-temp-and-rename)
-    - Генерацию meta.yaml
-    - QC-отчеты (quality_report, correlation_report)
+    Coordinates multiple components:
+    - DataWriter: writes data files (parquet, csv)
+    - QcReportGenerator: generates quality reports
+    - MetadataBuilder: constructs run metadata
+    - ChecksumCalculator: computes file checksums
+    - QcArtifactWriter: writes QC CSV files
+
+    Each component has a single responsibility and can be
+    replaced independently via dependency injection.
     """
 
     def __init__(
         self,
-        writer: _DataWriter,
-        metadata_writer: _MetadataWriter,
-        quality_reporter: QualityReportABC,
+        data_writer: DataWriterPort,
+        metadata_writer: MetadataWriterPort,
+        qc_report_generator: QcReportGeneratorPort,
         config: DeterminismConfig,
         qc_config: QcConfig | None = None,
         atomic_op: AtomicFileOperation | None = None,
         metrics: MetricsPortABC | None = None,
         converter: OutputFrameConverterABC | None = None,
+        *,
+        checksum_calculator: ChecksumCalculatorPort | None = None,
+        metadata_builder: MetadataBuilderPort | None = None,
+        qc_artifact_writer: QcArtifactWriter | None = None,
     ) -> None:
-        self._writer = writer
+        """Initialize the unified loader facade.
+
+        Args:
+            data_writer: Component for writing data files.
+            metadata_writer: Component for persisting metadata.
+            qc_report_generator: Component for generating QC reports.
+            config: Determinism configuration.
+            qc_config: QC report configuration.
+            atomic_op: Atomic file operation handler.
+            metrics: Metrics port for observability.
+            converter: Optional DataFrame converter.
+            checksum_calculator: Component for computing checksums.
+            metadata_builder: Component for building metadata dicts.
+            qc_artifact_writer: Component for writing QC CSV files.
+        """
+        # Core dependencies
+        self._data_writer = data_writer
         self._metadata_writer = metadata_writer
-        self._quality_reporter = quality_reporter
+        self._qc_report_generator = qc_report_generator
         self._config = config
         self._qc_config = qc_config or QcConfig()
         self._atomic_op = atomic_op or AtomicFileOperation()
         self._metrics = metrics
         self._converter = converter
+
+        # Component dependencies (with defaults)
+        self._checksum_calculator = checksum_calculator or ChecksumCalculator()
+        self._metadata_builder = metadata_builder or MetadataBuilder()
+        self._qc_artifact_writer = qc_artifact_writer or QcArtifactWriter(
+            self._atomic_op
+        )
 
     def load(
         self,
@@ -76,7 +107,17 @@ class UnifiedLoaderImpl(LoaderABC):
         *,
         column_order: list[str] | None = None,
     ) -> WriteResult:
-        """Alias for internal write logic to implement LoaderABC."""
+        """Load DataFrame to output path with full pipeline processing.
+
+        Args:
+            df: DataFrame to write.
+            output_path: Output directory path.
+            context: Run context with execution details.
+            column_order: Optional column ordering.
+
+        Returns:
+            WriteResult with path, row_count, checksum.
+        """
         return self._write_result(
             df=df,
             output_path=output_path,
@@ -86,13 +127,23 @@ class UnifiedLoaderImpl(LoaderABC):
         )
 
     def write_metadata(self, meta: dict, path: Path) -> None:
-        """Записывает метаданные детерминированно (atomic)."""
+        """Write metadata dictionary to file.
+
+        Args:
+            meta: Metadata dictionary.
+            path: Target file path.
+        """
         path.parent.mkdir(parents=True, exist_ok=True)
         self._metadata_writer.write_meta(meta, path)
 
     def write_qc_report(self, df: pd.DataFrame, path: Path) -> None:
-        """Записывает предоставленный QC-отчет детерминированно."""
-        self._write_qc_csv(path, df)
+        """Write a pre-built QC report to file.
+
+        Args:
+            df: QC report DataFrame.
+            path: Target file path.
+        """
+        self._qc_artifact_writer.write_qc_csv(df, path)
 
     def _write_result(
         self,
@@ -103,36 +154,38 @@ class UnifiedLoaderImpl(LoaderABC):
         *,
         column_order: list[str] | None = None,
     ) -> WriteResult:
-        """Основной метод записи."""
+        """Core write logic coordinating all components.
+
+        Args:
+            df: DataFrame to write.
+            output_path: Output directory.
+            entity_name: Name of the entity being written.
+            run_context: Run context.
+            column_order: Optional column ordering.
+
+        Returns:
+            WriteResult with final checksum.
+        """
         try:
             output_path.mkdir(parents=True, exist_ok=True)
 
-            # 1. Валидация колонок (Check if strictly matches order if provided)
-            # Note: Actual schema validation happens in PipelineBase.validate()
-            # Here we ensure output structure and determinism.
+            # 1. Prepare DataFrame (column order + determinism)
             df_prepared = apply_column_order(df, column_order)
-
-            # 2. Сортировка (Determinism)
             df_prepared = self._stable_sort(df_prepared, run_context, column_order)
 
-            # 2.5. Конвертация кадра перед записью (если задан конвертер)
+            # 2. Apply converter if provided
             if self._converter is not None:
                 df_prepared = self._converter.convert(df_prepared)
 
-            # Порядок колонок для записи — фактический после конвертации,
-            # чтобы не потерять переименованные/переставленные колонки
             column_order_to_write = list(df_prepared.columns)
 
-            # 3. Атомарная запись
+            # 3. Write data file atomically
             data_path = output_path / f"{entity_name}.csv"
-
-            # Wrapper to capture inner write result
             inner_result: WriteResult | None = None
 
             def _write_wrapper(path: Path) -> None:
-                """Write dataset to the provided path via underlying writer."""
                 nonlocal inner_result
-                inner_result = self._writer.write(
+                inner_result = self._data_writer.write(
                     df_prepared, path, column_order=column_order_to_write
                 )
 
@@ -141,8 +194,8 @@ class UnifiedLoaderImpl(LoaderABC):
             if inner_result is None:
                 raise RuntimeError("Inner writer did not return result")
 
-            # 4. Вычисление checksum (после записи)
-            checksum = compute_file_sha256(data_path)
+            # 4. Compute checksum for data file
+            checksum = self._checksum_calculator.compute_checksum(data_path)
 
             final_result = WriteResult(
                 path=data_path,
@@ -151,13 +204,12 @@ class UnifiedLoaderImpl(LoaderABC):
                 checksum=checksum,
             )
 
+            # 5. Generate and write QC artifacts
             qc_artifacts = self._generate_qc_artifacts(df_prepared, output_path)
-            qc_checksums = {
-                path.name: compute_file_sha256(path) for path in qc_artifacts
-            }
+            qc_checksums = self._checksum_calculator.compute_checksums(qc_artifacts)
 
-            # 5. Запись метаданных
-            meta = build_run_metadata(
+            # 6. Build and write metadata
+            meta = self._metadata_builder.build_run_metadata(
                 run_context,
                 final_result,
                 qc_artifacts=qc_artifacts,
@@ -167,6 +219,7 @@ class UnifiedLoaderImpl(LoaderABC):
             self.write_metadata(meta, output_path / "meta.yaml")
 
             return final_result
+
         except Exception as exc:
             self._record_write_error(entity_name, exc)
             raise
@@ -177,63 +230,76 @@ class UnifiedLoaderImpl(LoaderABC):
         context: RunContext,
         column_order: list[str] | None = None,
     ) -> pd.DataFrame:
+        """Apply deterministic sorting to DataFrame.
+
+        Args:
+            df: DataFrame to sort.
+            context: Run context with config.
+            column_order: Optional column order (skips column sorting if provided).
+
+        Returns:
+            Sorted DataFrame.
+        """
         if not self._config.stable_sort:
             return df
 
-        # 1. Sort columns
+        # 1. Sort columns (if no explicit order)
         if not column_order:
             df = df.reindex(sorted(df.columns), axis=1)
 
         # 2. Sort rows by business key if configured
         hashing_config = context.config.get("hashing", {})
-        # Handle Pydantic model dump or dict
         if isinstance(hashing_config, dict):
             keys = hashing_config.get("business_key_fields")
         else:
-            # Should be dict if model_dump() was used, but being safe
             keys = getattr(hashing_config, "business_key_fields", None)
 
         if keys:
-            # Only sort by keys that exist in dataframe
             valid_keys = [k for k in keys if k in df.columns]
             if valid_keys:
                 df = df.sort_values(by=valid_keys, ignore_index=True)
 
         return df
 
-    def _generate_qc_artifacts(self, df: pd.DataFrame, output_path: Path) -> list[Path]:
+    def _generate_qc_artifacts(
+        self, df: pd.DataFrame, output_path: Path
+    ) -> list[Path]:
+        """Generate QC reports using the QC report generator.
+
+        Args:
+            df: Source DataFrame.
+            output_path: Output directory.
+
+        Returns:
+            List of written QC artifact paths.
+        """
         artifacts: list[Path] = []
 
         if self._qc_config.enable_quality_report:
-            artifacts.append(
-                self._write_qc_csv(
-                    output_path / "quality_report_table.csv",
-                    self._quality_reporter.build_quality_report(
-                        df, min_coverage=self._qc_config.min_coverage
-                    ),
-                )
+            quality_report = self._qc_report_generator.build_quality_report(
+                df, min_coverage=self._qc_config.min_coverage
             )
+            path = self._qc_artifact_writer.write_qc_csv(
+                quality_report, output_path / "quality_report_table.csv"
+            )
+            artifacts.append(path)
 
         if self._qc_config.enable_correlation_report:
-            artifacts.append(
-                self._write_qc_csv(
-                    output_path / "correlation_report_table.csv",
-                    self._quality_reporter.build_correlation_report(df),
-                )
+            correlation_report = self._qc_report_generator.build_correlation_report(df)
+            path = self._qc_artifact_writer.write_qc_csv(
+                correlation_report, output_path / "correlation_report_table.csv"
             )
+            artifacts.append(path)
 
         return artifacts
 
-    def _write_qc_csv(self, path: Path, df: pd.DataFrame) -> Path:
-        def _write_qc_wrapper(temp_path: Path) -> None:
-            """Write QC dataframe to a CSV atomically."""
-            path.parent.mkdir(parents=True, exist_ok=True)
-            df.to_csv(temp_path, index=False)
-
-        self._atomic_op.write_atomic(path, _write_qc_wrapper)
-        return path
-
     def _record_write_error(self, entity_name: str, exc: Exception) -> None:
+        """Record write error metric.
+
+        Args:
+            entity_name: Entity that failed.
+            exc: Exception that occurred.
+        """
         if not self._metrics:
             return
 
@@ -241,3 +307,6 @@ class UnifiedLoaderImpl(LoaderABC):
             "bioetl_output_write_errors_total",
             {"entity": entity_name, "error_type": exc.__class__.__name__},
         )
+
+
+__all__ = ["UnifiedLoaderImpl"]

--- a/tests/bioetl/infrastructure/output/components/__init__.py
+++ b/tests/bioetl/infrastructure/output/components/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for output components."""

--- a/tests/bioetl/infrastructure/output/components/test_checksum_calculator.py
+++ b/tests/bioetl/infrastructure/output/components/test_checksum_calculator.py
@@ -1,0 +1,88 @@
+"""Tests for ChecksumCalculator component."""
+
+import pytest
+
+from bioetl.infrastructure.output.components.checksum_calculator import (
+    ChecksumCalculator,
+)
+
+
+@pytest.fixture
+def calculator():
+    """Create ChecksumCalculator instance."""
+    return ChecksumCalculator()
+
+
+def test_compute_checksum_for_file(calculator, tmp_path):
+    """Test computing checksum for a single file."""
+    # Create test file
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("Hello, World!")
+
+    # Compute checksum
+    checksum = calculator.compute_checksum(test_file)
+
+    # SHA256 of "Hello, World!" is known
+    assert checksum == "dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f"
+
+
+def test_compute_checksum_deterministic(calculator, tmp_path):
+    """Test that checksum is deterministic."""
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("Same content")
+
+    checksum1 = calculator.compute_checksum(test_file)
+    checksum2 = calculator.compute_checksum(test_file)
+
+    assert checksum1 == checksum2
+
+
+def test_compute_checksum_different_content(calculator, tmp_path):
+    """Test that different content produces different checksums."""
+    file1 = tmp_path / "file1.txt"
+    file2 = tmp_path / "file2.txt"
+    file1.write_text("Content A")
+    file2.write_text("Content B")
+
+    checksum1 = calculator.compute_checksum(file1)
+    checksum2 = calculator.compute_checksum(file2)
+
+    assert checksum1 != checksum2
+
+
+def test_compute_checksums_multiple_files(calculator, tmp_path):
+    """Test computing checksums for multiple files."""
+    file1 = tmp_path / "file1.txt"
+    file2 = tmp_path / "file2.txt"
+    file1.write_text("Content 1")
+    file2.write_text("Content 2")
+
+    checksums = calculator.compute_checksums([file1, file2])
+
+    assert "file1.txt" in checksums
+    assert "file2.txt" in checksums
+    assert len(checksums) == 2
+
+
+def test_compute_checksums_skips_missing_files(calculator, tmp_path):
+    """Test that missing files are skipped."""
+    existing = tmp_path / "exists.txt"
+    existing.write_text("I exist")
+    missing = tmp_path / "missing.txt"
+
+    checksums = calculator.compute_checksums([existing, missing])
+
+    assert "exists.txt" in checksums
+    assert "missing.txt" not in checksums
+
+
+def test_compute_checksums_empty_list(calculator):
+    """Test computing checksums for empty list."""
+    checksums = calculator.compute_checksums([])
+    assert checksums == {}
+
+
+def test_custom_chunk_size():
+    """Test calculator with custom chunk size."""
+    calculator = ChecksumCalculator(chunk_size=1024)
+    assert calculator._chunk_size == 1024

--- a/tests/bioetl/infrastructure/output/components/test_metadata_builder.py
+++ b/tests/bioetl/infrastructure/output/components/test_metadata_builder.py
@@ -1,0 +1,169 @@
+"""Tests for MetadataBuilder component."""
+
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from bioetl.domain.clients.base.output.contracts import WriteResult
+from bioetl.domain.configs import QcConfig
+from bioetl.infrastructure.output.components.metadata_builder import MetadataBuilder
+
+
+@pytest.fixture
+def builder():
+    """Create MetadataBuilder instance."""
+    return MetadataBuilder()
+
+
+@pytest.fixture
+def mock_context():
+    """Create mock RunContext."""
+    context = MagicMock()
+    context.run_id = "test-run-123"
+    context.entity_name = "test_entity"
+    context.provider = "test_provider"
+    context.started_at = datetime(2024, 1, 15, 10, 30, 0)
+    context.metadata = {"custom_key": "custom_value"}
+    context.config = {}
+    return context
+
+
+@pytest.fixture
+def mock_write_result(tmp_path):
+    """Create mock WriteResult."""
+    return WriteResult(
+        path=tmp_path / "output.csv",
+        row_count=100,
+        duration_sec=1.5,
+        checksum="abc123checksum",
+    )
+
+
+def test_build_run_metadata_basic(builder, mock_context, mock_write_result):
+    """Test basic metadata building."""
+    meta = builder.build_run_metadata(mock_context, mock_write_result)
+
+    assert meta["run_id"] == "test-run-123"
+    assert meta["entity"] == "test_entity"
+    assert meta["provider"] == "test_provider"
+    assert meta["row_count"] == 100
+    assert meta["checksum"] == "abc123checksum"
+    assert meta["hash"] == "abc123checksum"  # Backward compatibility
+
+
+def test_build_run_metadata_timestamp(builder, mock_context, mock_write_result):
+    """Test timestamp is ISO formatted."""
+    meta = builder.build_run_metadata(mock_context, mock_write_result)
+
+    assert meta["timestamp"] == "2024-01-15T10:30:00"
+
+
+def test_build_run_metadata_with_qc_artifacts(builder, mock_context, mock_write_result):
+    """Test metadata with QC artifacts."""
+    qc_artifacts = [
+        Path("/tmp/quality_report.csv"),
+        Path("/tmp/correlation_report.csv"),
+    ]
+    qc_checksums = {
+        "quality_report.csv": "qc_checksum_1",
+        "correlation_report.csv": "qc_checksum_2",
+    }
+
+    meta = builder.build_run_metadata(
+        mock_context,
+        mock_write_result,
+        qc_artifacts=qc_artifacts,
+        qc_checksums=qc_checksums,
+    )
+
+    assert "qc_artifacts" in meta
+    assert "quality_report.csv" in meta["qc_artifacts"]
+    assert "correlation_report.csv" in meta["qc_artifacts"]
+    assert meta["qc_artifacts"]["quality_report.csv"]["checksum"] == "qc_checksum_1"
+
+
+def test_build_run_metadata_files_list(builder, mock_context, mock_write_result):
+    """Test files list includes data and QC artifacts."""
+    qc_artifacts = [Path("/tmp/qc.csv")]
+
+    meta = builder.build_run_metadata(
+        mock_context,
+        mock_write_result,
+        qc_artifacts=qc_artifacts,
+    )
+
+    assert "output.csv" in meta["files"]
+    assert "qc.csv" in meta["files"]
+    assert meta["files"] == sorted(meta["files"])  # Should be sorted
+
+
+def test_build_run_metadata_checksums_dict(builder, mock_context, mock_write_result):
+    """Test checksums dictionary."""
+    qc_checksums = {"qc.csv": "qc_checksum"}
+
+    meta = builder.build_run_metadata(
+        mock_context,
+        mock_write_result,
+        qc_artifacts=[Path("/tmp/qc.csv")],
+        qc_checksums=qc_checksums,
+    )
+
+    assert meta["checksums"]["output.csv"] == "abc123checksum"
+    assert meta["checksums"]["qc.csv"] == "qc_checksum"
+
+
+def test_build_run_metadata_qc_config(builder, mock_context, mock_write_result):
+    """Test QC config is included."""
+    qc_config = QcConfig(
+        enable_quality_report=True,
+        enable_correlation_report=False,
+        min_coverage=0.9,
+    )
+
+    meta = builder.build_run_metadata(
+        mock_context,
+        mock_write_result,
+        qc_config=qc_config,
+    )
+
+    assert meta["qc_config"]["enable_quality_report"] is True
+    assert meta["qc_config"]["enable_correlation_report"] is False
+    assert meta["qc_config"]["min_coverage"] == 0.9
+
+
+def test_build_run_metadata_includes_context_metadata(
+    builder, mock_context, mock_write_result
+):
+    """Test that context metadata is merged."""
+    meta = builder.build_run_metadata(mock_context, mock_write_result)
+
+    assert meta["custom_key"] == "custom_value"
+
+
+def test_build_dry_run_metadata(builder, mock_context):
+    """Test dry run metadata."""
+    meta = builder.build_dry_run_metadata(mock_context, row_count=50)
+
+    assert meta["run_id"] == "test-run-123"
+    assert meta["entity"] == "test_entity"
+    assert meta["row_count"] == 50
+    assert meta["dry_run"] is True
+    assert meta["custom_key"] == "custom_value"
+
+
+def test_build_dry_run_metadata_no_checksum(builder, mock_context):
+    """Test dry run doesn't include checksum fields."""
+    meta = builder.build_dry_run_metadata(mock_context, row_count=50)
+
+    assert "checksum" not in meta
+    assert "hash" not in meta
+    assert "files" not in meta
+
+
+def test_hash_version_constant(builder, mock_context, mock_write_result):
+    """Test hash version is included."""
+    meta = builder.build_run_metadata(mock_context, mock_write_result)
+
+    assert meta["hash_version"] == "v1_blake2b_256"

--- a/tests/bioetl/infrastructure/output/components/test_qc_artifact_writer.py
+++ b/tests/bioetl/infrastructure/output/components/test_qc_artifact_writer.py
@@ -1,0 +1,88 @@
+"""Tests for QcArtifactWriter component."""
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from bioetl.infrastructure.output.components.qc_artifact_writer import QcArtifactWriter
+
+
+@pytest.fixture
+def mock_atomic_op():
+    """Create mock AtomicFileOperation."""
+    op = MagicMock()
+
+    def side_effect(path, write_fn):
+        write_fn(path)
+
+    op.write_atomic.side_effect = side_effect
+    return op
+
+
+@pytest.fixture
+def writer(mock_atomic_op):
+    """Create QcArtifactWriter with mock atomic operation."""
+    return QcArtifactWriter(atomic_op=mock_atomic_op)
+
+
+def test_write_qc_csv_returns_path(writer, tmp_path):
+    """Test that write_qc_csv returns the path."""
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    path = tmp_path / "report.csv"
+
+    result = writer.write_qc_csv(df, path)
+
+    assert result == path
+
+
+def test_write_qc_csv_creates_parent_dirs(writer, tmp_path):
+    """Test that parent directories are created."""
+    df = pd.DataFrame({"a": [1]})
+    path = tmp_path / "nested" / "dir" / "report.csv"
+
+    writer.write_qc_csv(df, path)
+
+    assert path.parent.exists()
+
+
+def test_write_qc_csv_uses_atomic_operation(mock_atomic_op, tmp_path):
+    """Test that atomic operation is used."""
+    writer = QcArtifactWriter(atomic_op=mock_atomic_op)
+    df = pd.DataFrame({"a": [1]})
+    path = tmp_path / "report.csv"
+
+    writer.write_qc_csv(df, path)
+
+    mock_atomic_op.write_atomic.assert_called_once()
+
+
+def test_write_qc_csv_writes_valid_csv(writer, tmp_path):
+    """Test that valid CSV is written."""
+    df = pd.DataFrame({"col1": [1, 2], "col2": ["a", "b"]})
+    path = tmp_path / "report.csv"
+
+    writer.write_qc_csv(df, path)
+
+    # Read back and verify
+    result = pd.read_csv(path)
+    assert list(result.columns) == ["col1", "col2"]
+    assert len(result) == 2
+
+
+def test_write_qc_csv_no_index(writer, tmp_path):
+    """Test that index is not written."""
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    df.index = ["x", "y", "z"]
+    path = tmp_path / "report.csv"
+
+    writer.write_qc_csv(df, path)
+
+    result = pd.read_csv(path)
+    assert "Unnamed: 0" not in result.columns
+
+
+def test_default_atomic_operation():
+    """Test that default AtomicFileOperation is created."""
+    writer = QcArtifactWriter()
+    assert writer._atomic_op is not None

--- a/tests/bioetl/infrastructure/output/components/test_qc_report_generator.py
+++ b/tests/bioetl/infrastructure/output/components/test_qc_report_generator.py
@@ -1,0 +1,155 @@
+"""Tests for QcReportGenerator component."""
+
+import pandas as pd
+import pytest
+
+from bioetl.infrastructure.output.components.qc_report_generator import (
+    QcReportGenerator,
+)
+
+
+@pytest.fixture
+def generator():
+    """Create QcReportGenerator instance."""
+    return QcReportGenerator()
+
+
+def test_build_quality_report_basic(generator):
+    """Test basic quality report generation."""
+    df = pd.DataFrame({
+        "col_a": [1, 2, 3],
+        "col_b": [None, 2, 3],
+        "col_c": [1, 1, 1],
+    })
+
+    report = generator.build_quality_report(df, min_coverage=0.8)
+
+    assert len(report) == 3
+    assert "column" in report.columns
+    assert "null_count" in report.columns
+    assert "non_null_count" in report.columns
+    assert "coverage" in report.columns
+    assert "coverage_ok" in report.columns
+
+
+def test_build_quality_report_coverage_calculation(generator):
+    """Test coverage calculation."""
+    df = pd.DataFrame({
+        "full": [1, 2, 3, 4],
+        "partial": [1, None, 3, None],
+    })
+
+    report = generator.build_quality_report(df, min_coverage=0.8)
+    report = report.set_index("column")
+
+    assert report.loc["full", "coverage"] == 1.0
+    assert report.loc["partial", "coverage"] == 0.5
+
+
+def test_build_quality_report_coverage_ok_flag(generator):
+    """Test coverage_ok flag based on threshold."""
+    df = pd.DataFrame({
+        "high": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        "low": [1, None, None, None, None, None, None, None, None, None],
+    })
+
+    report = generator.build_quality_report(df, min_coverage=0.5)
+    report = report.set_index("column")
+
+    assert report.loc["high", "coverage_ok"] == True  # noqa: E712
+    assert report.loc["low", "coverage_ok"] == False  # noqa: E712
+
+
+def test_build_quality_report_sorted_by_column(generator):
+    """Test that report is sorted by column name."""
+    df = pd.DataFrame({
+        "zebra": [1],
+        "alpha": [2],
+        "middle": [3],
+    })
+
+    report = generator.build_quality_report(df, min_coverage=0.8)
+
+    assert list(report["column"]) == ["alpha", "middle", "zebra"]
+
+
+def test_build_quality_report_empty_dataframe(generator):
+    """Test quality report for empty DataFrame."""
+    df = pd.DataFrame({"a": [], "b": []})
+
+    report = generator.build_quality_report(df, min_coverage=0.8)
+
+    assert len(report) == 2
+
+
+def test_build_correlation_report_numeric_columns(generator):
+    """Test correlation report with numeric columns."""
+    df = pd.DataFrame({
+        "a": [1, 2, 3, 4, 5],
+        "b": [2, 4, 6, 8, 10],  # Perfect correlation with a
+        "c": [5, 4, 3, 2, 1],  # Negative correlation with a
+    })
+
+    report = generator.build_correlation_report(df)
+
+    assert "column" in report.columns
+    assert "a" in report.columns
+    assert "b" in report.columns
+    assert "c" in report.columns
+
+
+def test_build_correlation_report_sorted_columns(generator):
+    """Test that correlation report columns are sorted."""
+    df = pd.DataFrame({
+        "z": [1, 2],
+        "a": [3, 4],
+        "m": [5, 6],
+    })
+
+    report = generator.build_correlation_report(df)
+
+    # Columns should be sorted (excluding 'column')
+    numeric_cols = [c for c in report.columns if c != "column"]
+    assert numeric_cols == ["a", "m", "z"]
+
+
+def test_build_correlation_report_no_numeric_columns(generator):
+    """Test correlation report with no numeric columns."""
+    df = pd.DataFrame({
+        "text_a": ["a", "b", "c"],
+        "text_b": ["x", "y", "z"],
+    })
+
+    report = generator.build_correlation_report(df)
+
+    assert list(report.columns) == ["column"]
+    assert len(report) == 0
+
+
+def test_build_correlation_report_mixed_types(generator):
+    """Test correlation report ignores non-numeric columns."""
+    df = pd.DataFrame({
+        "numeric": [1, 2, 3],
+        "text": ["a", "b", "c"],
+        "another_numeric": [4, 5, 6],
+    })
+
+    report = generator.build_correlation_report(df)
+
+    # Should only include numeric columns
+    assert "numeric" in report.columns
+    assert "another_numeric" in report.columns
+    assert "text" not in report.columns
+
+
+def test_build_correlation_report_bool_conversion(generator):
+    """Test that boolean columns are converted to int for correlation."""
+    df = pd.DataFrame({
+        "numeric": [0, 1, 0, 1],
+        "boolean": [False, True, False, True],
+    })
+
+    report = generator.build_correlation_report(df)
+
+    # Boolean should be converted and correlate perfectly with numeric
+    assert "boolean" in report.columns

--- a/tests/bioetl/infrastructure/output/test_unified_loader.py
+++ b/tests/bioetl/infrastructure/output/test_unified_loader.py
@@ -3,7 +3,7 @@ Tests for the UnifiedLoaderImpl.
 """
 
 # pylint: disable=redefined-outer-name, protected-access
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
@@ -64,12 +64,40 @@ def mock_atomic_op():
 
 
 @pytest.fixture
+def mock_checksum_calculator():
+    """Fixture for mock checksum calculator."""
+    calculator = MagicMock()
+    calculator.compute_checksum.return_value = "mock_checksum"
+    calculator.compute_checksums.return_value = {}
+    return calculator
+
+
+@pytest.fixture
+def mock_metadata_builder():
+    """Fixture for mock metadata builder."""
+    builder = MagicMock()
+    builder.build_run_metadata.return_value = {"run_id": "test"}
+    return builder
+
+
+@pytest.fixture
+def mock_qc_artifact_writer():
+    """Fixture for mock QC artifact writer."""
+    writer = MagicMock()
+    writer.write_qc_csv.side_effect = lambda df, path: path
+    return writer
+
+
+@pytest.fixture
 def unified_writer(
     mock_writer_fixture,
     mock_metadata_writer_fixture,
     mock_quality_reporter,
     mock_config_fixture,
     mock_atomic_op,
+    mock_checksum_calculator,
+    mock_metadata_builder,
+    mock_qc_artifact_writer,
 ):
     """Fixture for unified writer."""
     return UnifiedLoaderImpl(
@@ -78,6 +106,9 @@ def unified_writer(
         mock_quality_reporter,
         mock_config_fixture,
         atomic_op=mock_atomic_op,
+        checksum_calculator=mock_checksum_calculator,
+        metadata_builder=mock_metadata_builder,
+        qc_artifact_writer=mock_qc_artifact_writer,
     )
 
 
@@ -86,6 +117,7 @@ def test_write_result_success(
     mock_writer_fixture,
     mock_metadata_writer_fixture,
     mock_quality_reporter,
+    mock_checksum_calculator,
     run_context_factory,
     tmp_path,
 ):
@@ -104,30 +136,25 @@ def test_write_result_success(
         )
 
     mock_writer_fixture.write.side_effect = create_file
+    mock_checksum_calculator.compute_checksum.return_value = "real_checksum"
+    mock_checksum_calculator.compute_checksums.return_value = {
+        "quality_report_table.csv": "qc_quality",
+        "correlation_report_table.csv": "qc_correlation",
+    }
 
-    # Patch checksum function
-    with patch(
-        "bioetl.infrastructure.output.unified_loader_impl.compute_file_sha256"
-    ) as mock_checksum:
-        mock_checksum.side_effect = [
-            "real_checksum",
-            "qc_quality",
-            "qc_correlation",
-        ]
+    # Act
+    result = unified_writer.load(df, output_dir, run_context)
 
-        # Act
-        result = unified_writer.load(df, output_dir, run_context)
+    # Assert
+    assert result.row_count == 2
+    assert result.checksum == "real_checksum"
 
-        # Assert
-        assert result.row_count == 2
-        assert result.checksum == "real_checksum"
-
-        # Verify calls
-        mock_writer_fixture.write.assert_called_once()
-        mock_metadata_writer_fixture.write_meta.assert_called_once()
-        assert mock_checksum.call_count == 3
-        mock_quality_reporter.build_quality_report.assert_called_once()
-        mock_quality_reporter.build_correlation_report.assert_called_once()
+    # Verify calls
+    mock_writer_fixture.write.assert_called_once()
+    mock_metadata_writer_fixture.write_meta.assert_called_once()
+    mock_checksum_calculator.compute_checksum.assert_called_once()
+    mock_quality_reporter.build_quality_report.assert_called_once()
+    mock_quality_reporter.build_correlation_report.assert_called_once()
 
 
 def test_unified_writer_delegates_atomicity(
@@ -135,6 +162,7 @@ def test_unified_writer_delegates_atomicity(
     mock_writer_fixture,
     mock_atomic_op,
     mock_quality_reporter,
+    mock_qc_artifact_writer,
     run_context_factory,
     tmp_path,
 ):
@@ -148,20 +176,16 @@ def test_unified_writer_delegates_atomicity(
         path=output_dir / "test.csv", row_count=1, checksum="abc", duration_sec=0.1
     )
 
-    with patch(
-        "bioetl.infrastructure.output.unified_loader_impl.compute_file_sha256"
-    ) as mock_checksum:
-        mock_checksum.side_effect = ["abc", "qc1", "qc2"]
+    # Act
+    unified_writer.load(df, output_dir, run_context)
 
-        # Act
-        unified_writer.load(df, output_dir, run_context)
-
-        # Assert
-        assert mock_atomic_op.write_atomic.call_count == 3
-        args_list = mock_atomic_op.write_atomic.call_args_list
-        assert args_list[0][0][0] == output_dir / "test_entity.csv"
-        assert args_list[1][0][0].name == "quality_report_table.csv"
-        assert args_list[2][0][0].name == "correlation_report_table.csv"
+    # Assert - atomic_op is called once for data file
+    # QC files are written through qc_artifact_writer
+    assert mock_atomic_op.write_atomic.call_count == 1
+    args_list = mock_atomic_op.write_atomic.call_args_list
+    assert args_list[0][0][0] == output_dir / "test_entity.csv"
+    # QC files are written via qc_artifact_writer
+    assert mock_qc_artifact_writer.write_qc_csv.call_count == 2
 
 
 def test_unified_writer_column_order_and_fill(
@@ -191,16 +215,12 @@ def test_unified_writer_column_order_and_fill(
 
     mock_writer_fixture.write.side_effect = capture_df
 
-    with patch(
-        "bioetl.infrastructure.output.unified_loader_impl.compute_file_sha256",
-        return_value="chk",
-    ):
-        result = unified_writer.load(
-            df,
-            output_dir,
-            run_context,
-            column_order=["a", "b", "c"],
-        )
+    result = unified_writer.load(
+        df,
+        output_dir,
+        run_context,
+        column_order=["a", "b", "c"],
+    )
 
     assert result.row_count == 1
     assert captured_df is not None
@@ -268,6 +288,9 @@ def test_write_result_records_metric_on_failure(
     mock_quality_reporter,
     mock_config_fixture,
     mock_atomic_op,
+    mock_checksum_calculator,
+    mock_metadata_builder,
+    mock_qc_artifact_writer,
     run_context_factory,
     tmp_path,
 ):
@@ -284,6 +307,9 @@ def test_write_result_records_metric_on_failure(
         mock_config_fixture,
         atomic_op=mock_atomic_op,
         metrics=metrics,
+        checksum_calculator=mock_checksum_calculator,
+        metadata_builder=mock_metadata_builder,
+        qc_artifact_writer=mock_qc_artifact_writer,
     )
 
     with pytest.raises(ValueError):
@@ -300,9 +326,13 @@ def test_unified_writer_applies_converter_rename(
     mock_quality_reporter,
     mock_config_fixture,
     mock_atomic_op,
+    mock_checksum_calculator,
+    mock_metadata_builder,
+    mock_qc_artifact_writer,
     run_context_factory,
     tmp_path,
 ):
+    """Test that converter renames columns correctly."""
     writer = MagicMock()
     captured_df: pd.DataFrame | None = None
 
@@ -325,19 +355,18 @@ def test_unified_writer_applies_converter_rename(
         mock_config_fixture,
         atomic_op=mock_atomic_op,
         converter=converter,
+        checksum_calculator=mock_checksum_calculator,
+        metadata_builder=mock_metadata_builder,
+        qc_artifact_writer=mock_qc_artifact_writer,
     )
 
     df = pd.DataFrame({"a_col": [1], "b_col": [2]})
-    with patch(
-        "bioetl.infrastructure.output.unified_loader_impl.compute_file_sha256",
-        return_value="chk",
-    ):
-        writer_impl.load(
-            df,
-            tmp_path / "out",
-            run_context_factory(),
-            column_order=["a_col", "b_col"],
-        )
+    writer_impl.load(
+        df,
+        tmp_path / "out",
+        run_context_factory(),
+        column_order=["a_col", "b_col"],
+    )
 
     assert captured_df is not None
     assert list(captured_df.columns) == ["a-col", "b-col"]
@@ -348,9 +377,13 @@ def test_unified_writer_applies_converter_dropna(
     mock_quality_reporter,
     mock_config_fixture,
     mock_atomic_op,
+    mock_checksum_calculator,
+    mock_metadata_builder,
+    mock_qc_artifact_writer,
     run_context_factory,
     tmp_path,
 ):
+    """Test that dropna converter removes rows with all nulls."""
     writer = MagicMock()
 
     def create_file(df_to_write, path, **kwargs):
@@ -370,18 +403,17 @@ def test_unified_writer_applies_converter_dropna(
         mock_config_fixture,
         atomic_op=mock_atomic_op,
         converter=converter,
+        checksum_calculator=mock_checksum_calculator,
+        metadata_builder=mock_metadata_builder,
+        qc_artifact_writer=mock_qc_artifact_writer,
     )
 
     df = pd.DataFrame({"a": [None], "b": [None]})
-    with patch(
-        "bioetl.infrastructure.output.unified_loader_impl.compute_file_sha256",
-        return_value="chk",
-    ):
-        result = writer_impl.load(
-            df,
-            tmp_path / "out",
-            run_context_factory(),
-            column_order=["a", "b"],
-        )
+    result = writer_impl.load(
+        df,
+        tmp_path / "out",
+        run_context_factory(),
+        column_order=["a", "b"],
+    )
 
     assert result.row_count == 0


### PR DESCRIPTION
Extract responsibilities from UnifiedLoaderImpl into separate components:

- ChecksumCalculator: computes SHA256 checksums for file integrity
- QcReportGenerator: builds quality and correlation reports
- MetadataBuilder: constructs run metadata dictionaries
- QcArtifactWriter: writes QC CSV files atomically
- DataWriterAdapter: adapts format-specific writers

Each component:
- Has its own interface in domain/ports/output.py
- Accepts dependencies through constructor
- Has no knowledge of other components

UnifiedLoaderImpl now acts as a facade, coordinating these components while maintaining the same public API for backward compatibility.

This improves testability and follows Single Responsibility Principle.