### PR TITLE
Create unified type aliases module for domain layer

### DIFF
--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -4,6 +4,14 @@ Domain layer package.
 Terminology updates (v3.0 migration):
     - SourceRecord: Canonical name for records from data sources.
       Deprecated alias: RawRecord (will be removed in v3.0).
+
+Type Aliases (unified in v3.0):
+    - RawRecord: Single record as dict[str, Any]
+    - RecordBatch: Batch of records as list[RawRecord]
+    - ApiPayload: Raw API response as dict[str, Any]
+    - FieldConfig: Field configuration as dict[str, Any]
+
+    Import from ``bioetl.domain.types`` for type aliases.
 """
 
 from bioetl.domain.errors import (
@@ -22,22 +30,36 @@ from bioetl.domain.record_source import (
     RecordSourceABC,
     SourceRecord,
 )
+from bioetl.domain.types import (
+    ApiPayload,
+    FieldConfig,
+    RawRecord,
+    RecordBatch,
+)
 from bioetl.domain.value_objects import ChemblId, EntityName, RunId
 
 __all__ = [
+    # Type aliases
+    "ApiPayload",
+    "FieldConfig",
+    "RawRecord",
+    "RecordBatch",
+    # Errors
     "BioetlError",
-    "ChemblId",
     "ClientError",
     "ClientNetworkError",
     "ClientRateLimitError",
     "ClientResponseError",
     "ConfigError",
     "ConfigValidationError",
-    "EntityName",
-    "InMemoryRecordSource",
     "PipelineStageError",
     "ProviderError",
-    "RecordSourceABC",
+    # Value objects
+    "ChemblId",
+    "EntityName",
     "RunId",
+    # Record source
+    "InMemoryRecordSource",
+    "RecordSourceABC",
     "SourceRecord",
 ]

--- a/src/bioetl/domain/ports/__init__.py
+++ b/src/bioetl/domain/ports/__init__.py
@@ -1,10 +1,15 @@
-"""Domain ports (hexagonal architecture boundaries)."""
+"""Domain ports (hexagonal architecture boundaries).
+
+Type aliases are available from :mod:`bioetl.domain.types` module.
+This module re-exports them for convenience but new code should import
+directly from ``bioetl.domain.types``.
+"""
+
+import warnings
 
 from bioetl.domain.ports.extraction import (
     BatchAdapterABC,
     ExtractionServiceABC,
-    RawRecordBatch,
-    RawRecordDict,
     RecordFetcherABC,
     VersionProviderABC,
     from_raw_records,
@@ -12,18 +17,56 @@ from bioetl.domain.ports.extraction import (
 )
 from bioetl.domain.ports.parsing import (
     PaginationInfo,
-    RawPayload,
-    RawRecordList,
     ResponseParserPortABC,
 )
 from bioetl.domain.ports.schema import SchemaContractProviderABC
+from bioetl.domain.types import (
+    ApiPayload,
+    RawRecord,
+    RecordBatch,
+)
+
+# =============================================================================
+# Deprecated Type Aliases (backward compatibility re-exports)
+# =============================================================================
+
+_DEPRECATED_TYPE_ALIASES = {
+    "RawRecordDict": "RawRecord",
+    "RawRecordBatch": "RecordBatch",
+    "RawRecordList": "RecordBatch",
+    "RawPayload": "ApiPayload",
+}
+
+
+def __getattr__(name: str) -> type:
+    """Emit deprecation warning for legacy type alias imports."""
+    if name in _DEPRECATED_TYPE_ALIASES:
+        new_name = _DEPRECATED_TYPE_ALIASES[name]
+        warnings.warn(
+            f"{name} is deprecated, use {new_name} from bioetl.domain.types instead. "
+            "See migration guide in bioetl.domain.types module docstring.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from bioetl.domain import types
+
+        return getattr(types, new_name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__: list[str] = [
+    # Canonical type aliases (from domain.types)
+    "ApiPayload",
+    "RawRecord",
+    "RecordBatch",
+    # Deprecated type aliases (for backward compatibility)
+    "RawRecordBatch",
+    "RawRecordDict",
+    "RawRecordList",
+    "RawPayload",
     # Extraction ports
     "BatchAdapterABC",
     "ExtractionServiceABC",
-    "RawRecordBatch",
-    "RawRecordDict",
     "RecordFetcherABC",
     "VersionProviderABC",
     # Backward compatibility helpers
@@ -31,8 +74,6 @@ __all__: list[str] = [
     "to_raw_records",
     # Parsing ports
     "PaginationInfo",
-    "RawPayload",
-    "RawRecordList",
     "ResponseParserPortABC",
     # Schema ports
     "SchemaContractProviderABC",

--- a/src/bioetl/domain/ports/extraction.py
+++ b/src/bioetl/domain/ports/extraction.py
@@ -2,18 +2,33 @@
 
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Protocol, TypeAlias
-import warnings
+from typing import TYPE_CHECKING, Protocol
 
-# Generic types for cross-layer communication
-# These allow domain layer to define contracts without coupling to specific models
-RawRecordDict: TypeAlias = dict[str, Any]
-RawRecordBatch: TypeAlias = list[RawRecordDict]
+from bioetl.domain.types import (
+    ApiPayload,
+    RawRecord,
+    RecordBatch,
+)
+
+# =============================================================================
+# Deprecated Type Aliases (backward compatibility re-exports)
+# =============================================================================
+# Import from bioetl.domain.types for new code.
+# These re-exports emit deprecation warnings via __getattr__ below.
+
+__all__: list[str] = []  # Populated at end of module
+
+# Sentinel for lazy deprecation
+_DEPRECATED_TYPE_ALIASES = {
+    "RawRecordDict": "RawRecord",
+    "RawRecordBatch": "RecordBatch",
+}
 
 if TYPE_CHECKING:
-    from bioetl.domain.record_source import RawRecord
+    from bioetl.domain.record_source import SourceRecord
 
 
 class RecordFetcherABC(ABC):
@@ -27,7 +42,7 @@ class RecordFetcherABC(ABC):
     @abstractmethod
     def iter_extract(
         self, entity: str, *, chunk_size: int | None = None, **filters: object
-    ) -> Iterable[RawRecordBatch]:
+    ) -> Iterable[RecordBatch]:
         """Iterate over batches of raw records.
 
         Args:
@@ -44,7 +59,7 @@ class RecordFetcherABC(ABC):
         """
 
     @abstractmethod
-    def extract_all(self, entity: str, **filters: object) -> RawRecordBatch:
+    def extract_all(self, entity: str, **filters: object) -> RecordBatch:
         """Return all records for entity as raw dicts.
 
         Args:
@@ -91,7 +106,7 @@ class ExtractionServiceABC(RecordFetcherABC):
         """
 
     @abstractmethod
-    def parse_response(self, raw_response: object) -> RawRecordBatch:
+    def parse_response(self, raw_response: object) -> RecordBatch:
         """Parse raw response into record dicts.
 
         Args:
@@ -106,10 +121,10 @@ class BatchAdapterABC(Protocol):
     """Protocol for adapting raw batches to list of record dicts.
 
     Used to normalize different batch formats from extraction services
-    into the expected RawRecordBatch format.
+    into the expected RecordBatch format.
     """
 
-    def process_batch(self, raw_batch: object) -> RawRecordBatch:
+    def process_batch(self, raw_batch: object) -> RecordBatch:
         """Normalize a batch into a list of raw record mappings.
 
         Args:
@@ -126,18 +141,18 @@ class BatchAdapterABC(Protocol):
 # =============================================================================
 
 
-def to_raw_records(batch: RawRecordBatch) -> list["RawRecord"]:
-    """Convert raw dicts to RawRecord models (migration helper).
+def to_raw_records(batch: RecordBatch) -> list["SourceRecord"]:
+    """Convert raw dicts to SourceRecord models (migration helper).
 
     DEPRECATED: Use application layer mappers instead.
-    This function is provided for gradual migration from RawRecord models
+    This function is provided for gradual migration from SourceRecord models
     to generic dicts in extraction services.
 
     Args:
         batch: List of raw record dictionaries.
 
     Returns:
-        List of RawRecord Pydantic models.
+        List of SourceRecord Pydantic models.
 
     Example:
         >>> from bioetl.domain.ports.extraction import to_raw_records
@@ -149,20 +164,20 @@ def to_raw_records(batch: RawRecordBatch) -> list["RawRecord"]:
         DeprecationWarning,
         stacklevel=2,
     )
-    from bioetl.domain.record_source import RawRecord
+    from bioetl.domain.record_source import SourceRecord
 
-    return [RawRecord.model_validate(record) for record in batch]
+    return [SourceRecord.model_validate(record) for record in batch]
 
 
-def from_raw_records(records: list["RawRecord"]) -> RawRecordBatch:
-    """Convert RawRecord models to raw dicts (migration helper).
+def from_raw_records(records: list["SourceRecord"]) -> RecordBatch:
+    """Convert SourceRecord models to raw dicts (migration helper).
 
     DEPRECATED: Use application layer mappers instead.
-    This function is provided for gradual migration from RawRecord models
+    This function is provided for gradual migration from SourceRecord models
     to generic dicts in extraction services.
 
     Args:
-        records: List of RawRecord Pydantic models.
+        records: List of SourceRecord Pydantic models.
 
     Returns:
         List of raw record dictionaries.
@@ -175,8 +190,39 @@ def from_raw_records(records: list["RawRecord"]) -> RawRecordBatch:
     return [record.model_dump() for record in records]
 
 
+# =============================================================================
+# Module __getattr__ for deprecated type alias access
+# =============================================================================
+
+
+def __getattr__(name: str) -> type:
+    """Emit deprecation warning for legacy type alias imports.
+
+    Enables backward-compatible imports like:
+        from bioetl.domain.ports.extraction import RawRecordDict
+
+    But emits a DeprecationWarning directing users to the new location.
+    """
+    if name in _DEPRECATED_TYPE_ALIASES:
+        new_name = _DEPRECATED_TYPE_ALIASES[name]
+        warnings.warn(
+            f"{name} is deprecated, use {new_name} from bioetl.domain.types instead. "
+            "See migration guide in bioetl.domain.types module docstring.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from bioetl.domain import types
+
+        return getattr(types, new_name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 __all__ = [
-    # Type aliases
+    # Canonical type aliases (re-exported from domain.types)
+    "RawRecord",
+    "RecordBatch",
+    "ApiPayload",
+    # Deprecated type aliases (for backward compatibility)
     "RawRecordDict",
     "RawRecordBatch",
     # Abstract base classes

--- a/src/bioetl/domain/ports/parsing.py
+++ b/src/bioetl/domain/ports/parsing.py
@@ -16,7 +16,7 @@ Method mapping:
     - ``extract_metadata(raw_response)`` → ``extract_pagination(raw_response)``
 
 Type changes:
-    - Generic[RecordT] (Pydantic models) → RawRecordList (untyped dicts)
+    - Generic[RecordT] (Pydantic models) → RecordBatch (untyped dicts)
     - This change improves layer isolation (infrastructure doesn't import domain models)
 
 Example migration::
@@ -41,13 +41,24 @@ from __future__ import annotations
 import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, TypeAlias
 
-# Generic type aliases for infrastructure layer
-# These allow infrastructure code to work without importing domain models
-RawPayload: TypeAlias = dict[str, Any]
-RawRecordDict: TypeAlias = dict[str, Any]
-RawRecordList: TypeAlias = list[RawRecordDict]
+from bioetl.domain.types import (
+    ApiPayload,
+    RawRecord,
+    RecordBatch,
+)
+
+# =============================================================================
+# Deprecated Type Aliases (backward compatibility re-exports)
+# =============================================================================
+# Import from bioetl.domain.types for new code.
+# These re-exports emit deprecation warnings via __getattr__ below.
+
+_DEPRECATED_TYPE_ALIASES = {
+    "RawPayload": "ApiPayload",
+    "RawRecordDict": "RawRecord",
+    "RawRecordList": "RecordBatch",
+}
 
 
 class ResponseParserPortABC(ABC):
@@ -72,7 +83,7 @@ class ResponseParserPortABC(ABC):
     """
 
     @abstractmethod
-    def parse_to_records(self, raw_response: RawPayload) -> RawRecordList:
+    def parse_to_records(self, raw_response: ApiPayload) -> RecordBatch:
         """Parse raw API response into list of untyped record dicts.
 
         Args:
@@ -85,7 +96,7 @@ class ResponseParserPortABC(ABC):
 
     @abstractmethod
     def extract_pagination(
-        self, raw_response: RawPayload
+        self, raw_response: ApiPayload
     ) -> dict[str, int | str | None]:
         """Extract pagination metadata from response.
 
@@ -102,7 +113,7 @@ class ResponseParserPortABC(ABC):
     # Backward compatibility aliases (from deprecated ResponseParserABC)
     # =========================================================================
 
-    def parse(self, raw_response: RawPayload) -> RawRecordList:
+    def parse(self, raw_response: ApiPayload) -> RecordBatch:
         """Backward-compatible alias for :meth:`parse_to_records`.
 
         .. deprecated:: 2.0
@@ -123,7 +134,7 @@ class ResponseParserPortABC(ABC):
         return self.parse_to_records(raw_response)
 
     def extract_metadata(
-        self, raw_response: RawPayload
+        self, raw_response: ApiPayload
     ) -> dict[str, int | str | None]:
         """Backward-compatible alias for :meth:`extract_pagination`.
 
@@ -201,10 +212,43 @@ class PaginationInfo:
         )
 
 
+# =============================================================================
+# Module __getattr__ for deprecated type alias access
+# =============================================================================
+
+
+def __getattr__(name: str) -> type:
+    """Emit deprecation warning for legacy type alias imports.
+
+    Enables backward-compatible imports like:
+        from bioetl.domain.ports.parsing import RawPayload
+
+    But emits a DeprecationWarning directing users to the new location.
+    """
+    if name in _DEPRECATED_TYPE_ALIASES:
+        new_name = _DEPRECATED_TYPE_ALIASES[name]
+        warnings.warn(
+            f"{name} is deprecated, use {new_name} from bioetl.domain.types instead. "
+            "See migration guide in bioetl.domain.types module docstring.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from bioetl.domain import types
+
+        return getattr(types, new_name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 __all__ = [
+    # Canonical type aliases (re-exported from domain.types)
+    "ApiPayload",
+    "RawRecord",
+    "RecordBatch",
+    # Deprecated type aliases (for backward compatibility)
     "RawPayload",
     "RawRecordDict",
     "RawRecordList",
+    # ABCs and classes
     "ResponseParserPortABC",
     "PaginationInfo",
 ]

--- a/src/bioetl/domain/types.py
+++ b/src/bioetl/domain/types.py
@@ -1,0 +1,189 @@
+"""Unified type aliases for the domain layer.
+
+This module provides canonical type aliases used throughout the domain layer
+to ensure consistency and reduce duplication across ports and contracts.
+
+Canonical Type Aliases
+----------------------
+- ``RawRecord``: A single record as an untyped dictionary (dict[str, Any]).
+- ``RecordBatch``: A batch/list of raw records (list[RawRecord]).
+- ``ApiPayload``: Raw API response payload (dict[str, Any]).
+- ``FieldConfig``: Field configuration dictionary (dict[str, Any]).
+
+Migration Guide
+---------------
+The following legacy type aliases are deprecated and will be removed in v3.0:
+
++------------------+---------------+---------------------------------------------+
+| Legacy Name      | New Name      | Module                                      |
++==================+===============+=============================================+
+| RawRecordDict    | RawRecord     | domain.ports.extraction, domain.ports.parsing|
++------------------+---------------+---------------------------------------------+
+| RawRecordBatch   | RecordBatch   | domain.ports.extraction                     |
++------------------+---------------+---------------------------------------------+
+| RawRecordList    | RecordBatch   | domain.ports.parsing                        |
++------------------+---------------+---------------------------------------------+
+| RawPayload       | ApiPayload    | domain.ports.parsing                        |
++------------------+---------------+---------------------------------------------+
+
+Example migration::
+
+    # Before (deprecated)
+    from bioetl.domain.ports.extraction import RawRecordDict, RawRecordBatch
+
+    def process(records: RawRecordBatch) -> RawRecordDict:
+        ...
+
+    # After (recommended)
+    from bioetl.domain.types import RawRecord, RecordBatch
+
+    def process(records: RecordBatch) -> RawRecord:
+        ...
+
+Usage Notes
+-----------
+Import from this module for new code::
+
+    from bioetl.domain.types import RawRecord, RecordBatch, ApiPayload, FieldConfig
+
+For backward compatibility, legacy aliases are re-exported from their original
+modules with deprecation warnings.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any, TypeAlias
+
+__all__ = [
+    # Canonical type aliases
+    "RawRecord",
+    "RecordBatch",
+    "ApiPayload",
+    "FieldConfig",
+    # Deprecated aliases (for backward compatibility)
+    "RawRecordDict",
+    "RawRecordBatch",
+    "RawRecordList",
+    "RawPayload",
+]
+
+# =============================================================================
+# Canonical Type Aliases
+# =============================================================================
+
+RawRecord: TypeAlias = dict[str, Any]
+"""A single record as an untyped dictionary.
+
+Represents a single data record from an external source (API response,
+database row, etc.) before domain model mapping.
+
+Example:
+    >>> record: RawRecord = {"id": "CHEMBL123", "name": "Aspirin"}
+"""
+
+RecordBatch: TypeAlias = list[RawRecord]
+"""A batch/list of raw records.
+
+Represents multiple records fetched together, typically from a paginated
+API response or batch extraction.
+
+Example:
+    >>> batch: RecordBatch = [
+    ...     {"id": "CHEMBL123", "name": "Aspirin"},
+    ...     {"id": "CHEMBL456", "name": "Ibuprofen"},
+    ... ]
+"""
+
+ApiPayload: TypeAlias = dict[str, Any]
+"""Raw API response payload.
+
+Represents the complete, unprocessed response from an external API,
+including metadata, pagination info, and record data.
+
+Example:
+    >>> payload: ApiPayload = {
+    ...     "page_meta": {"total_count": 100, "offset": 0},
+    ...     "molecules": [{"id": "CHEMBL123"}],
+    ... }
+"""
+
+FieldConfig: TypeAlias = dict[str, Any]
+"""Field configuration dictionary.
+
+Used for defining field-level settings such as normalization rules,
+validation constraints, or transformation parameters.
+
+Example:
+    >>> config: FieldConfig = {
+    ...     "name": "molecule_chembl_id",
+    ...     "required": True,
+    ...     "normalizer": "chembl_id",
+    ... }
+"""
+
+
+# =============================================================================
+# Deprecated Aliases (Backward Compatibility)
+# =============================================================================
+
+
+def _deprecated_alias(
+    old_name: str, new_name: str, value: TypeAlias
+) -> TypeAlias:
+    """Helper to create deprecated alias with runtime warning on access.
+
+    Note: TypeAlias assignments are resolved at import time, so we can't
+    intercept access. The deprecation warning is emitted via module __getattr__
+    for dynamic imports, and via explicit re-exports in ports modules.
+    """
+    return value
+
+
+# These are direct assignments for static type checkers.
+# Deprecation warnings are emitted via __getattr__ in ports modules.
+RawRecordDict: TypeAlias = RawRecord
+"""Deprecated: Use ``RawRecord`` instead."""
+
+RawRecordBatch: TypeAlias = RecordBatch
+"""Deprecated: Use ``RecordBatch`` instead."""
+
+RawRecordList: TypeAlias = RecordBatch
+"""Deprecated: Use ``RecordBatch`` instead."""
+
+RawPayload: TypeAlias = ApiPayload
+"""Deprecated: Use ``ApiPayload`` instead."""
+
+
+# =============================================================================
+# Module-level __getattr__ for deprecation warnings
+# =============================================================================
+
+_DEPRECATED_NAMES: dict[str, tuple[str, TypeAlias]] = {
+    "RawRecordDict": ("RawRecord", RawRecord),
+    "RawRecordBatch": ("RecordBatch", RecordBatch),
+    "RawRecordList": ("RecordBatch", RecordBatch),
+    "RawPayload": ("ApiPayload", ApiPayload),
+}
+
+
+def __getattr__(name: str) -> TypeAlias:
+    """Emit deprecation warning for legacy type alias access.
+
+    This is triggered for dynamic imports like:
+        getattr(types_module, "RawRecordDict")
+
+    Static imports (from bioetl.domain.types import RawRecordDict) use
+    the module-level assignments above, so deprecation warnings for those
+    are emitted from the ports modules where they're re-exported.
+    """
+    if name in _DEPRECATED_NAMES:
+        new_name, value = _DEPRECATED_NAMES[name]
+        warnings.warn(
+            f"{name} is deprecated, use {new_name} from bioetl.domain.types instead. "
+            "See migration guide in bioetl.domain.types module docstring.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
- Create bioetl.domain.types with canonical type aliases:
  - RawRecord: dict[str, Any] (single record)
  - RecordBatch: list[RawRecord] (batch of records)
  - ApiPayload: dict[str, Any] (raw API response)
  - FieldConfig: dict[str, Any] (field configuration)

- Update domain/ports/extraction.py to use new types
- Update domain/ports/parsing.py to use new types
- Add backward compatibility re-exports with DeprecationWarning for legacy names (RawRecordDict, RawRecordBatch, RawRecordList, RawPayload)
- Export new types from domain/__init__.py and domain/ports/__init__.py

Migration guide included in domain/types.py docstring.