### PR TITLE
Refactor ChEMBL version formatting logic

### DIFF
--- a/src/bioetl/application/pipelines/chembl/base.py
+++ b/src/bioetl/application/pipelines/chembl/base.py
@@ -26,6 +26,7 @@ from bioetl.domain.ports.extraction import (
     ExtractionServiceABC,
 )
 from bioetl.domain.record_source import RecordSourceABC
+from bioetl.domain.services.version_formatter import format_chembl_version
 from bioetl.domain.schemas.pipeline_contracts import get_pipeline_contract
 from bioetl.domain.transform.contracts import (
     HashServiceABC,
@@ -119,7 +120,11 @@ class ChemblPipelineBase(PipelineBase):
         self._transformer = transformer
 
     def get_version(self) -> str:
-        """Возвращает версию релиза ChEMBL (например, 'chembl_34')."""
+        """Возвращает версию релиза ChEMBL (например, 'chembl_34').
+
+        Extraction service возвращает сырую версию (например, '34').
+        Форматирование выполняется в application layer через domain service.
+        """
         if self._chembl_release is not None:
             return self._chembl_release
 
@@ -128,7 +133,8 @@ class ChemblPipelineBase(PipelineBase):
             return self._chembl_release
 
         try:
-            self._chembl_release = self._extraction_service.get_release_version()
+            raw_version = self._extraction_service.get_release_version()
+            self._chembl_release = format_chembl_version(raw_version)
         except Exception as exc:  # pragma: no cover - защитный контур
             self._logger.warning(
                 "Failed to fetch ChEMBL release; using 'unknown'",

--- a/src/bioetl/domain/ports/extraction.py
+++ b/src/bioetl/domain/ports/extraction.py
@@ -63,7 +63,12 @@ class VersionProviderABC(ABC):
 
     @abstractmethod
     def get_release_version(self) -> str:
-        """Get data source version identifier (e.g., 'chembl_34')."""
+        """Get raw data source version identifier (e.g., '34').
+
+        Returns:
+            Raw version string without provider prefix.
+            Use domain.services.version_formatter for formatted output.
+        """
 
 
 class ExtractionServiceABC(RecordFetcherABC):
@@ -75,7 +80,7 @@ class ExtractionServiceABC(RecordFetcherABC):
 
     @abstractmethod
     def get_release_version(self) -> str:
-        """Get data source version identifier."""
+        """Get raw data source version identifier (e.g., '34')."""
 
     @abstractmethod
     def request_batch(

--- a/src/bioetl/domain/services/__init__.py
+++ b/src/bioetl/domain/services/__init__.py
@@ -1,0 +1,11 @@
+"""Domain services for business logic."""
+
+from bioetl.domain.services.version_formatter import (
+    ChemblVersionFormatter,
+    format_chembl_version,
+)
+
+__all__ = [
+    "ChemblVersionFormatter",
+    "format_chembl_version",
+]

--- a/src/bioetl/domain/services/version_formatter.py
+++ b/src/bioetl/domain/services/version_formatter.py
@@ -1,0 +1,76 @@
+"""Version formatting utilities for ChEMBL data sources.
+
+This module contains domain logic for formatting version strings.
+The formatting rules are business logic that belongs in the domain layer,
+not in infrastructure (where raw data is fetched).
+"""
+
+from __future__ import annotations
+
+CHEMBL_VERSION_PREFIX = "chembl_"
+UNKNOWN_VERSION = "unknown"
+
+
+def format_chembl_version(raw_version: str) -> str:
+    """Format raw ChEMBL version to standard format.
+
+    Args:
+        raw_version: Raw version string from API (e.g., '34', '35').
+
+    Returns:
+        Formatted version string (e.g., 'chembl_34', 'chembl_35').
+        Returns 'unknown' if raw_version is empty or 'unknown'.
+
+    Examples:
+        >>> format_chembl_version('34')
+        'chembl_34'
+        >>> format_chembl_version('unknown')
+        'unknown'
+        >>> format_chembl_version('')
+        'unknown'
+    """
+    if not raw_version or raw_version == UNKNOWN_VERSION:
+        return UNKNOWN_VERSION
+
+    # Already formatted - return as is
+    if raw_version.startswith(CHEMBL_VERSION_PREFIX):
+        return raw_version
+
+    return f"{CHEMBL_VERSION_PREFIX}{raw_version}"
+
+
+class ChemblVersionFormatter:
+    """Formatter for ChEMBL version strings.
+
+    Stateless service that encapsulates version formatting logic.
+    Can be injected as a dependency for better testability.
+
+    Example:
+        >>> formatter = ChemblVersionFormatter()
+        >>> formatter.format('34')
+        'chembl_34'
+    """
+
+    @staticmethod
+    def format(raw_version: str) -> str:
+        """Format raw version to standard ChEMBL format.
+
+        Args:
+            raw_version: Raw version from extraction service.
+
+        Returns:
+            Formatted version string.
+        """
+        return format_chembl_version(raw_version)
+
+    @staticmethod
+    def is_valid(version: str) -> bool:
+        """Check if version string is valid (not unknown).
+
+        Args:
+            version: Version string to check.
+
+        Returns:
+            True if version is valid, False otherwise.
+        """
+        return bool(version) and version != UNKNOWN_VERSION

--- a/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
@@ -45,10 +45,16 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
 
     def get_release_version(self) -> str:
         """
-        Get the ChEMBL release version from metadata.
+        Get the raw ChEMBL release version from metadata.
 
         Returns:
-            str: The release version string (e.g., 'chembl_34').
+            str: The raw release version string (e.g., '34', '35').
+                 Returns 'unknown' if metadata is unavailable.
+
+        Note:
+            This returns raw version without 'chembl_' prefix.
+            Use domain.services.version_formatter.format_chembl_version()
+            in application layer for formatted version.
         """
         if self._version_cache:
             return self._version_cache
@@ -57,13 +63,13 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
             meta = self.client.metadata()
             # Expecting {'chembl_release': '34', ...}
             if meta and "chembl_release" in meta:
-                self._version_cache = f"chembl_{meta['chembl_release']}"
+                self._version_cache = str(meta["chembl_release"])
             else:
-                self._version_cache = "chembl_unknown"
+                self._version_cache = "unknown"
         except Exception as e:
             if self.logger:
                 self.logger.warning(f"Failed to fetch metadata: {e}")
-            self._version_cache = "chembl_unknown"
+            self._version_cache = "unknown"
 
         return self._version_cache
 

--- a/tests/bioetl/application/pipelines/chembl/test_base.py
+++ b/tests/bioetl/application/pipelines/chembl/test_base.py
@@ -112,9 +112,14 @@ def pipeline_fixture(mock_dependencies_fixture):
 
 
 def test_get_chembl_release(pipeline_fixture, mock_dependencies_fixture, monkeypatch):
-    """Test ChEMBL release version retrieval."""
+    """Test ChEMBL release version retrieval.
+
+    ExtractionService returns raw version ('34'), application layer
+    formats it using domain service to 'chembl_34'.
+    """
+    # ExtractionService now returns raw version without prefix
     mock_dependencies_fixture["extraction_service"].get_release_version.return_value = (
-        "chembl_34"
+        "34"
     )
     monkeypatch.setattr(
         pipeline_fixture, "_should_skip_release_lookup", lambda: False, raising=False
@@ -123,6 +128,7 @@ def test_get_chembl_release(pipeline_fixture, mock_dependencies_fixture, monkeyp
     release1 = pipeline_fixture.get_chembl_release()
     release2 = pipeline_fixture.get_chembl_release()
 
+    # Application layer formats to 'chembl_34'
     assert release1 == "chembl_34"
     assert release2 == "chembl_34"
     (
@@ -133,9 +139,14 @@ def test_get_chembl_release(pipeline_fixture, mock_dependencies_fixture, monkeyp
 
 
 def test_enrich_context(pipeline_fixture, mock_dependencies_fixture, monkeypatch):
-    """Test context enrichment with ChEMBL release."""
+    """Test context enrichment with ChEMBL release.
+
+    ExtractionService returns raw version ('99'), application layer
+    formats it and stores as 'chembl_99' in context metadata.
+    """
+    # ExtractionService now returns raw version without prefix
     mock_dependencies_fixture["extraction_service"].get_release_version.return_value = (
-        "chembl_99"
+        "99"
     )
     monkeypatch.setattr(
         pipeline_fixture, "_should_skip_release_lookup", lambda: False, raising=False
@@ -147,6 +158,7 @@ def test_enrich_context(pipeline_fixture, mock_dependencies_fixture, monkeypatch
     pipeline_fixture._enrich_context(context)
 
     assert "chembl_release" in context.metadata
+    # Formatted in application layer
     assert context.metadata["chembl_release"] == "chembl_99"
 
 

--- a/tests/bioetl/domain/services/__init__.py
+++ b/tests/bioetl/domain/services/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for domain services."""

--- a/tests/bioetl/domain/services/test_version_formatter.py
+++ b/tests/bioetl/domain/services/test_version_formatter.py
@@ -1,0 +1,55 @@
+"""Tests for ChEMBL version formatter."""
+
+import pytest
+
+from bioetl.domain.services.version_formatter import (
+    ChemblVersionFormatter,
+    format_chembl_version,
+)
+
+
+class TestFormatChemblVersion:
+    """Tests for format_chembl_version function."""
+
+    def test_formats_raw_version(self):
+        """Raw version number gets chembl_ prefix."""
+        assert format_chembl_version("34") == "chembl_34"
+        assert format_chembl_version("35") == "chembl_35"
+
+    def test_handles_unknown(self):
+        """Unknown version returns 'unknown'."""
+        assert format_chembl_version("unknown") == "unknown"
+
+    def test_handles_empty_string(self):
+        """Empty string returns 'unknown'."""
+        assert format_chembl_version("") == "unknown"
+
+    def test_already_formatted_passes_through(self):
+        """Already formatted version is not double-prefixed."""
+        assert format_chembl_version("chembl_34") == "chembl_34"
+
+    def test_handles_numeric_string(self):
+        """Handles version as string of number."""
+        assert format_chembl_version("100") == "chembl_100"
+
+
+class TestChemblVersionFormatter:
+    """Tests for ChemblVersionFormatter class."""
+
+    def test_format_method(self):
+        """format() method works same as function."""
+        formatter = ChemblVersionFormatter()
+        assert formatter.format("34") == "chembl_34"
+        assert formatter.format("unknown") == "unknown"
+
+    def test_is_valid_with_valid_version(self):
+        """is_valid() returns True for valid versions."""
+        formatter = ChemblVersionFormatter()
+        assert formatter.is_valid("34") is True
+        assert formatter.is_valid("chembl_34") is True
+
+    def test_is_valid_with_invalid_version(self):
+        """is_valid() returns False for invalid versions."""
+        formatter = ChemblVersionFormatter()
+        assert formatter.is_valid("unknown") is False
+        assert formatter.is_valid("") is False


### PR DESCRIPTION
- ExtractionService now returns raw version (e.g., '34') instead of formatted
- Created domain/services/version_formatter.py with format_chembl_version()
- Application layer (ChemblPipelineBase) applies formatting via domain service
- Updated tests to reflect new layer responsibilities