### PR TITLE
Create ApplicationBootstrap in application layer

### DIFF
--- a/src/bioetl/application/__init__.py
+++ b/src/bioetl/application/__init__.py
@@ -4,6 +4,14 @@ Application layer package.
 Provides core orchestration components for pipeline assembly and execution.
 """
 
+from bioetl.application.bootstrap import (
+    ApplicationBootstrap,
+    ApplicationContext,
+    ConfigLoaderFactory,
+    ProviderClearer,
+    ProviderInjector,
+    create_application_bootstrap,
+)
 from bioetl.application.container import (
     PipelineContainer,
     create_default_container_factory,
@@ -11,7 +19,13 @@ from bioetl.application.container import (
 from bioetl.application.orchestrator import PipelineOrchestrator
 
 __all__ = [
+    "ApplicationBootstrap",
+    "ApplicationContext",
+    "ConfigLoaderFactory",
     "PipelineContainer",
     "PipelineOrchestrator",
+    "ProviderClearer",
+    "ProviderInjector",
+    "create_application_bootstrap",
     "create_default_container_factory",
 ]

--- a/src/bioetl/application/bootstrap.py
+++ b/src/bioetl/application/bootstrap.py
@@ -1,0 +1,262 @@
+"""Application bootstrap for initializing the application layer.
+
+This module provides the central entry point for bootstrapping the application.
+It ensures all application-level services are initialized in the correct order
+and provides an ApplicationContext with ready-to-use dependencies.
+
+Note:
+    This module contains only application-layer code and does not depend on
+    infrastructure. Infrastructure-specific initialization (config loaders,
+    provider injection) should be provided via dependency injection from
+    the interfaces layer.
+
+Example:
+    >>> # Basic usage (application layer only)
+    >>> bootstrap = ApplicationBootstrap()
+    >>> context = bootstrap.start()
+    >>> schema = context.schema_provider.get_schema("activity")
+    >>>
+    >>> # With infrastructure integration (from interfaces layer)
+    >>> from bioetl.interfaces.bootstrap_factory import create_default_bootstrap
+    >>> bootstrap = create_default_bootstrap()
+    >>> context = bootstrap.start()
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable
+
+from bioetl.application.services.schema_bootstrap import (
+    SchemaBootstrapService,
+    create_schema_bootstrap_service,
+)
+from bioetl.application.services.schema_contract_provider import (
+    SchemaContractProviderImpl,
+)
+from bioetl.domain.configs.contracts import PipelineConfigLoaderProtocol
+from bioetl.domain.ports.schema import SchemaContractProviderABC
+from bioetl.domain.validation import SchemaProviderABC
+
+if TYPE_CHECKING:
+    pass
+
+# Type aliases for callbacks
+ConfigLoaderFactory = Callable[[SchemaContractProviderABC], PipelineConfigLoaderProtocol]
+ProviderInjector = Callable[[SchemaContractProviderABC], None]
+ProviderClearer = Callable[[], None]
+
+
+@dataclass(frozen=True)
+class ApplicationContext:
+    """Context of an initialized application.
+
+    Provides access to all bootstrapped services needed by the application.
+    This is an immutable data class that holds references to the initialized
+    services.
+
+    Attributes:
+        schema_provider: Provider for accessing registered schemas.
+        contract_provider: Provider for schema contracts used by pipelines.
+        config_loader: Loader for pipeline configurations (may be None if
+            no config loader factory was provided).
+    """
+
+    schema_provider: SchemaProviderABC
+    contract_provider: SchemaContractProviderABC
+    config_loader: PipelineConfigLoaderProtocol | None = None
+
+
+class ApplicationBootstrap:
+    """Central entry point for application initialization.
+
+    Ensures all application-level services are initialized in the correct
+    order and ready for use. Provides idempotent initialization - multiple
+    calls to start() return the same context.
+
+    This class eliminates the need for global state by encapsulating
+    all bootstrap logic in a single, testable object.
+
+    Infrastructure-specific functionality (config loaders, provider injection)
+    can be provided via dependency injection through constructor parameters.
+
+    Args:
+        config_loader_factory: Optional factory for creating config loaders.
+            If provided, will be called with the contract provider to create
+            a config loader.
+        provider_injector: Optional callback to inject the contract provider
+            into infrastructure for backward compatibility.
+        provider_clearer: Optional callback to clear the injected provider
+            during shutdown.
+
+    Example:
+        >>> # Basic usage without infrastructure
+        >>> bootstrap = ApplicationBootstrap()
+        >>> context = bootstrap.start()
+        >>> schema = context.schema_provider.get_schema("activity")
+        >>>
+        >>> # With config loader factory
+        >>> def make_loader(provider):
+        ...     return MyConfigLoader(provider)
+        >>> bootstrap = ApplicationBootstrap(config_loader_factory=make_loader)
+        >>> context = bootstrap.start()
+        >>> config = context.config_loader.get_by_id("chembl.activity")
+    """
+
+    def __init__(
+        self,
+        *,
+        config_loader_factory: ConfigLoaderFactory | None = None,
+        provider_injector: ProviderInjector | None = None,
+        provider_clearer: ProviderClearer | None = None,
+    ) -> None:
+        """Initialize the bootstrap instance with optional infrastructure hooks."""
+        self._context: ApplicationContext | None = None
+        self._started: bool = False
+        self._schema_bootstrap_service: SchemaBootstrapService | None = None
+
+        # Infrastructure hooks (dependency injection)
+        self._config_loader_factory = config_loader_factory
+        self._provider_injector = provider_injector
+        self._provider_clearer = provider_clearer
+
+    def start(self) -> ApplicationContext:
+        """Initialize the application and return the context.
+
+        Idempotent: subsequent calls return the same context.
+
+        Returns:
+            ApplicationContext with all initialized services.
+        """
+        if self._started:
+            return self._get_context()
+
+        schema_provider = self._init_schema_provider()
+        contract_provider = self._init_contract_provider(schema_provider)
+
+        # Inject provider if callback provided (for backward compatibility)
+        if self._provider_injector is not None:
+            self._provider_injector(contract_provider)
+
+        # Create config loader if factory provided
+        config_loader: PipelineConfigLoaderProtocol | None = None
+        if self._config_loader_factory is not None:
+            config_loader = self._config_loader_factory(contract_provider)
+
+        self._context = ApplicationContext(
+            schema_provider=schema_provider,
+            contract_provider=contract_provider,
+            config_loader=config_loader,
+        )
+        self._started = True
+        return self._context
+
+    def shutdown(self) -> None:
+        """Release resources and reset state (for graceful shutdown).
+
+        Clears the cached context and resets initialization state.
+        This is primarily useful for testing scenarios where you need
+        to re-initialize the application.
+        """
+        # Clear provider if callback provided
+        if self._provider_clearer is not None:
+            self._provider_clearer()
+
+        self._context = None
+        self._started = False
+        self._schema_bootstrap_service = None
+
+    @property
+    def is_started(self) -> bool:
+        """Check if the application has been started."""
+        return self._started
+
+    @property
+    def context(self) -> ApplicationContext | None:
+        """Get the current context (may be None if not started)."""
+        return self._context
+
+    def _get_context(self) -> ApplicationContext:
+        """Get context or raise if not started.
+
+        Returns:
+            The initialized ApplicationContext.
+
+        Raises:
+            RuntimeError: If application has not been started.
+        """
+        if self._context is None:
+            raise RuntimeError("Application not started. Call start() first.")
+        return self._context
+
+    def _init_schema_provider(self) -> SchemaProviderABC:
+        """Initialize and return the schema provider.
+
+        Creates a SchemaBootstrapService and ensures all schemas are registered.
+
+        Returns:
+            Fully initialized schema provider with all schemas registered.
+        """
+        self._schema_bootstrap_service = create_schema_bootstrap_service()
+        return self._schema_bootstrap_service.ensure_registered()
+
+    def _init_contract_provider(
+        self, schema_provider: SchemaProviderABC
+    ) -> SchemaContractProviderABC:
+        """Initialize and return the schema contract provider.
+
+        Args:
+            schema_provider: The initialized schema provider.
+
+        Returns:
+            SchemaContractProviderImpl wrapping the schema provider.
+        """
+        return SchemaContractProviderImpl(schema_provider)
+
+
+def create_application_bootstrap(
+    *,
+    config_loader_factory: ConfigLoaderFactory | None = None,
+    provider_injector: ProviderInjector | None = None,
+    provider_clearer: ProviderClearer | None = None,
+) -> ApplicationBootstrap:
+    """Create an ApplicationBootstrap instance.
+
+    Factory function for creating ApplicationBootstrap instances.
+    Provides a clean way to create bootstrap objects with optional
+    infrastructure hooks.
+
+    Args:
+        config_loader_factory: Optional factory for creating config loaders.
+        provider_injector: Optional callback to inject the contract provider.
+        provider_clearer: Optional callback to clear the injected provider.
+
+    Returns:
+        New ApplicationBootstrap instance.
+
+    Example:
+        >>> # Basic usage
+        >>> bootstrap = create_application_bootstrap()
+        >>> context = bootstrap.start()
+        >>>
+        >>> # With infrastructure hooks
+        >>> bootstrap = create_application_bootstrap(
+        ...     config_loader_factory=my_loader_factory,
+        ...     provider_injector=inject_provider,
+        ... )
+    """
+    return ApplicationBootstrap(
+        config_loader_factory=config_loader_factory,
+        provider_injector=provider_injector,
+        provider_clearer=provider_clearer,
+    )
+
+
+__all__ = [
+    "ApplicationBootstrap",
+    "ApplicationContext",
+    "ConfigLoaderFactory",
+    "ProviderClearer",
+    "ProviderInjector",
+    "create_application_bootstrap",
+]

--- a/src/bioetl/interfaces/bootstrap_factory.py
+++ b/src/bioetl/interfaces/bootstrap_factory.py
@@ -1,0 +1,142 @@
+"""Factory for creating ApplicationBootstrap with infrastructure integration.
+
+This module provides factory functions for creating ApplicationBootstrap
+instances configured with infrastructure-layer components (config loaders,
+provider injection).
+
+The separation between application-layer bootstrap logic and infrastructure
+integration maintains clean architecture boundaries while providing a
+convenient entry point for CLI and other interfaces.
+
+Example:
+    >>> from bioetl.interfaces.bootstrap_factory import create_default_bootstrap
+    >>> bootstrap = create_default_bootstrap()
+    >>> context = bootstrap.start()
+    >>> config = context.config_loader.get_by_id("chembl.activity")
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+from bioetl.application.bootstrap import (
+    ApplicationBootstrap,
+    ConfigLoaderFactory,
+    ProviderClearer,
+    ProviderInjector,
+)
+from bioetl.domain.configs.contracts import PipelineConfigLoaderProtocol
+from bioetl.domain.ports.schema import SchemaContractProviderABC
+
+
+def _create_config_loader_factory() -> ConfigLoaderFactory:
+    """Create a config loader factory using infrastructure components.
+
+    Returns:
+        Factory function that creates a config loader given a contract provider.
+    """
+    from bioetl.infrastructure.config.loader import (
+        get_pipeline_config,
+        get_pipeline_config_from_path,
+    )
+
+    def factory(contract_provider: SchemaContractProviderABC) -> PipelineConfigLoaderProtocol:
+        def get_by_id(
+            pipeline_id: str,
+            *,
+            profile: str | None = None,
+            cli_overrides: dict | None = None,
+            env_overrides: dict | None = None,
+            base_dir: str | Path | None = None,
+        ):
+            return get_pipeline_config(
+                pipeline_id,
+                schema_contract_provider=contract_provider,
+                profile=profile,
+                cli_overrides=cli_overrides,
+                env_overrides=env_overrides,
+                base_dir=base_dir,
+            )
+
+        def get_from_path(
+            config_path: str | Path,
+            *,
+            profile: str | None = None,
+            profiles_root: str | Path | None = None,
+            cli_overrides: dict | None = None,
+            env_overrides: dict | None = None,
+        ):
+            return get_pipeline_config_from_path(
+                config_path,
+                schema_contract_provider=contract_provider,
+                profile=profile,
+                profiles_root=profiles_root,
+                cli_overrides=cli_overrides,
+                env_overrides=env_overrides,
+            )
+
+        return cast(
+            PipelineConfigLoaderProtocol,
+            SimpleNamespace(
+                get_by_id=get_by_id,
+                get_from_path=get_from_path,
+            ),
+        )
+
+    return factory
+
+
+def _create_provider_injector() -> ProviderInjector:
+    """Create a provider injector for backward compatibility.
+
+    Returns:
+        Callback function that injects the provider into infrastructure.
+    """
+    from bioetl.infrastructure.config.loader import _set_provider_internal
+
+    def injector(provider: SchemaContractProviderABC) -> None:
+        _set_provider_internal(provider)
+
+    return injector
+
+
+def _create_provider_clearer() -> ProviderClearer:
+    """Create a provider clearer for cleanup.
+
+    Returns:
+        Callback function that clears the provider from infrastructure.
+    """
+    from bioetl.infrastructure.config.loader import _clear_provider_internal
+
+    def clearer() -> None:
+        _clear_provider_internal()
+
+    return clearer
+
+
+def create_default_bootstrap() -> ApplicationBootstrap:
+    """Create an ApplicationBootstrap with default infrastructure integration.
+
+    This factory creates a fully configured ApplicationBootstrap instance
+    with config loader support and provider injection for backward compatibility.
+
+    Returns:
+        ApplicationBootstrap configured with infrastructure components.
+
+    Example:
+        >>> bootstrap = create_default_bootstrap()
+        >>> context = bootstrap.start()
+        >>> config = context.config_loader.get_by_id("chembl.activity")
+    """
+    return ApplicationBootstrap(
+        config_loader_factory=_create_config_loader_factory(),
+        provider_injector=_create_provider_injector(),
+        provider_clearer=_create_provider_clearer(),
+    )
+
+
+__all__ = [
+    "create_default_bootstrap",
+]

--- a/src/bioetl/interfaces/cli/app.py
+++ b/src/bioetl/interfaces/cli/app.py
@@ -9,59 +9,48 @@ from typing import Annotated
 from rich.console import Console
 import typer
 
+from bioetl.application.bootstrap import ApplicationBootstrap, ApplicationContext
 from bioetl.application.config.runtime import build_runtime_config
 from bioetl.application.orchestrator import PipelineOrchestrator
 from bioetl.application.pipelines.registry import PIPELINE_REGISTRY
-from bioetl.application.services.schema_bootstrap import create_schema_bootstrap_service
 from bioetl.domain.configs import PipelineConfig
-from bioetl.domain.ports.schema import SchemaContractProviderABC
-from bioetl.infrastructure.config.loader import _set_provider_internal
 from bioetl.infrastructure.config.provider_registry import (
     create_provider_loader,
 )
 from bioetl.infrastructure.config.sources import get_configs_root
+from bioetl.interfaces.bootstrap_factory import create_default_bootstrap
 from bioetl.interfaces.container_factory import (
     build_default_container,
-    create_config_loader,
 )
 
 app = typer.Typer(help="BioETL - Bioactivity Data Acquisition ETL")
 console = Console()
 
-_application_bootstrapped = False
-_contract_provider: SchemaContractProviderABC | None = None
+_bootstrap: ApplicationBootstrap | None = None
 
 
-def bootstrap_application() -> SchemaContractProviderABC:
-    """Initialize application layer before using infrastructure.
-
-    This function must be called before loading any pipeline configs.
-    It sets up the schema contract provider through dependency injection.
+def get_bootstrap() -> ApplicationBootstrap:
+    """Get the application bootstrap instance (singleton).
 
     Returns:
-        SchemaContractProviderABC: The initialized contract provider.
+        ApplicationBootstrap: The bootstrap instance.
     """
-    global _application_bootstrapped, _contract_provider  # noqa: PLW0603
-    if _application_bootstrapped and _contract_provider is not None:
-        return _contract_provider
+    global _bootstrap  # noqa: PLW0603
+    if _bootstrap is None:
+        _bootstrap = create_default_bootstrap()
+    return _bootstrap
 
-    # 1. Bootstrap schemas
-    schema_service = create_schema_bootstrap_service()
-    schema_provider = schema_service.ensure_registered()
 
-    # 2. Create contract provider
-    from bioetl.application.services.schema_contract_provider import (
-        SchemaContractProviderImpl,
-    )
+def get_application_context() -> ApplicationContext:
+    """Initialize and return the application context.
 
-    _contract_provider = SchemaContractProviderImpl(schema_provider)
+    This function must be called before using any application services.
+    It's idempotent - subsequent calls return the same context.
 
-    # 3. Inject into infrastructure for backward compatibility
-    # Using internal function to avoid deprecation warning
-    _set_provider_internal(_contract_provider)
-
-    _application_bootstrapped = True
-    return _contract_provider
+    Returns:
+        ApplicationContext: The initialized application context.
+    """
+    return get_bootstrap().start()
 
 
 def _infer_config_path(pipeline_name: str) -> str | None:
@@ -86,12 +75,11 @@ def _resolve_config_path(config: str) -> Path:
 
 
 def _build_config(config_path: Path, profile: str | None) -> PipelineConfig:
-    bootstrap_application()
-    config_loader = create_config_loader()
+    context = get_application_context()
     return build_runtime_config(
         config_path=config_path,
         configs_root=get_configs_root(None),
-        loader=config_loader,
+        loader=context.config_loader,
         profile=profile,
     )
 
@@ -140,18 +128,17 @@ def validate_config(
     profile: Annotated[str | None, typer.Option(help="Profile name")] = None,
 ) -> None:
     """Validate a pipeline configuration file."""
-    bootstrap_application()
     config_file = Path(config_path)
     if not config_file.exists():
         console.print(f"[red]Error:[/red] Config file not found: {config_path}")
         raise typer.Exit(1)
 
     try:
-        config_loader = create_config_loader()
+        context = get_application_context()
         build_runtime_config(
             config_path=config_file,
             configs_root=get_configs_root(None),
-            loader=config_loader,
+            loader=context.config_loader,
             profile=profile,
         )
         console.print("[green]✓[/green] Config is valid")

--- a/src/bioetl/interfaces/container_factory.py
+++ b/src/bioetl/interfaces/container_factory.py
@@ -18,10 +18,6 @@ from bioetl.domain.observability import MetricsPortABC
 from bioetl.domain.provider_registry import ProviderRegistryABC
 from bioetl.domain.validation import ValidatorFactoryABC
 from bioetl.infrastructure.clients.base.abc_registry_resolver import ABCRegistryResolver
-from bioetl.infrastructure.config.loader import (
-    get_pipeline_config,
-    get_pipeline_config_from_path,
-)
 from bioetl.infrastructure.config.sources import get_configs_root
 from bioetl.infrastructure.output.metadata import (
     build_dry_run_metadata,
@@ -117,62 +113,21 @@ def create_config_loader() -> PipelineConfigLoaderProtocol:
     """Return config loader port backed by infrastructure loader.
 
     Creates a config loader that uses explicit schema contract provider injection.
-    The provider is obtained from SimplePipelineContainer and bound to the loader
+    The provider is obtained from ApplicationBootstrap and bound to the loader
     functions.
 
     Returns:
         PipelineConfigLoaderProtocol: Config loader with bound schema provider.
     """
-    from bioetl.interfaces.simple_container import SimplePipelineContainer
+    from bioetl.interfaces.bootstrap_factory import create_default_bootstrap
 
-    container = SimplePipelineContainer()
-    container.bootstrap()
+    bootstrap = create_default_bootstrap()
+    context = bootstrap.start()
 
-    # Get the schema contract provider from the container
-    provider = container.schema_contract_provider
+    if context.config_loader is None:
+        raise RuntimeError("Config loader not available in ApplicationContext")
 
-    # Create bound functions that pass the provider explicitly
-    def get_by_id_with_provider(
-        pipeline_id: str,
-        *,
-        profile: str | None = None,
-        cli_overrides: dict | None = None,
-        env_overrides: dict | None = None,
-        base_dir: str | Path | None = None,
-    ):
-        return get_pipeline_config(
-            pipeline_id,
-            schema_contract_provider=provider,
-            profile=profile,
-            cli_overrides=cli_overrides,
-            env_overrides=env_overrides,
-            base_dir=base_dir,
-        )
-
-    def get_from_path_with_provider(
-        config_path: str | Path,
-        *,
-        profile: str | None = None,
-        profiles_root: str | Path | None = None,
-        cli_overrides: dict | None = None,
-        env_overrides: dict | None = None,
-    ):
-        return get_pipeline_config_from_path(
-            config_path,
-            schema_contract_provider=provider,
-            profile=profile,
-            profiles_root=profiles_root,
-            cli_overrides=cli_overrides,
-            env_overrides=env_overrides,
-        )
-
-    return cast(
-        PipelineConfigLoaderProtocol,
-        SimpleNamespace(
-            get_by_id=get_by_id_with_provider,
-            get_from_path=get_from_path_with_provider,
-        ),
-    )
+    return context.config_loader
 
 
 def create_config_path_resolver(

--- a/src/bioetl/interfaces/simple_container.py
+++ b/src/bioetl/interfaces/simple_container.py
@@ -1,5 +1,9 @@
 """Simplified container for pipeline dependencies.
 
+.. deprecated::
+    This module is deprecated. Use :class:`bioetl.application.bootstrap.ApplicationBootstrap`
+    instead for application initialization.
+
 This container provides a streamlined approach to dependency injection
 for the new architecture. It focuses on:
 - SchemaBootstrapService for schema initialization
@@ -10,7 +14,7 @@ for the new architecture. It focuses on:
 
 from __future__ import annotations
 
-from typing import Callable
+import warnings
 
 from bioetl.application.mappers.chembl.record_mapper import ChemblRecordMapper
 from bioetl.application.mappers.contracts import RecordMapperABC
@@ -31,6 +35,10 @@ from bioetl.infrastructure.clients.chembl.response_parser import (
 class SimplePipelineContainer:
     """Simplified container for pipeline dependencies.
 
+    .. deprecated::
+        This class is deprecated. Use :class:`bioetl.application.bootstrap.ApplicationBootstrap`
+        instead for application initialization.
+
     This container provides a streamlined approach to dependency injection
     for the new architecture. It focuses on:
     - SchemaBootstrapService for schema initialization
@@ -39,14 +47,28 @@ class SimplePipelineContainer:
     - ResponseParser for API response parsing
 
     Example:
+        >>> # Deprecated usage:
         >>> container = SimplePipelineContainer()
         >>> container.bootstrap()
-        >>> mapper = container.record_mapper
-        >>> parser = container.response_parser
+        >>>
+        >>> # New recommended usage:
+        >>> from bioetl.application.bootstrap import ApplicationBootstrap
+        >>> bootstrap = ApplicationBootstrap()
+        >>> context = bootstrap.start()
     """
 
     def __init__(self) -> None:
-        """Initialize the container with lazy-initialized components."""
+        """Initialize the container with lazy-initialized components.
+
+        .. deprecated::
+            Use :class:`bioetl.application.bootstrap.ApplicationBootstrap` instead.
+        """
+        warnings.warn(
+            "SimplePipelineContainer is deprecated. "
+            "Use bioetl.application.bootstrap.ApplicationBootstrap instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._schema_bootstrap: SchemaBootstrapService | None = None
         self._schema_contract_provider: SchemaContractProviderABC | None = None
         self._record_mapper: RecordMapperABC | None = None

--- a/tests/bioetl/application/test_bootstrap.py
+++ b/tests/bioetl/application/test_bootstrap.py
@@ -1,0 +1,189 @@
+"""Tests for ApplicationBootstrap."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bioetl.application.bootstrap import (
+    ApplicationBootstrap,
+    ApplicationContext,
+    create_application_bootstrap,
+)
+from bioetl.domain.configs.contracts import PipelineConfigLoaderProtocol
+from bioetl.domain.ports.schema import SchemaContractProviderABC
+from bioetl.domain.validation import SchemaProviderABC
+
+if TYPE_CHECKING:
+    pass
+
+
+class TestApplicationBootstrap:
+    """Tests for ApplicationBootstrap class."""
+
+    def test_start_returns_context(self) -> None:
+        """Test that start() returns an ApplicationContext."""
+        bootstrap = ApplicationBootstrap()
+        context = bootstrap.start()
+
+        assert isinstance(context, ApplicationContext)
+        assert isinstance(context.schema_provider, SchemaProviderABC)
+        assert isinstance(context.contract_provider, SchemaContractProviderABC)
+
+    def test_start_is_idempotent(self) -> None:
+        """Test that multiple calls to start() return the same context."""
+        bootstrap = ApplicationBootstrap()
+
+        context1 = bootstrap.start()
+        context2 = bootstrap.start()
+
+        assert context1 is context2
+
+    def test_is_started_property(self) -> None:
+        """Test is_started property reflects bootstrap state."""
+        bootstrap = ApplicationBootstrap()
+
+        assert not bootstrap.is_started
+
+        bootstrap.start()
+
+        assert bootstrap.is_started
+
+    def test_context_property(self) -> None:
+        """Test context property returns None before start and context after."""
+        bootstrap = ApplicationBootstrap()
+
+        assert bootstrap.context is None
+
+        context = bootstrap.start()
+
+        assert bootstrap.context is context
+
+    def test_shutdown_resets_state(self) -> None:
+        """Test that shutdown() resets the bootstrap state."""
+        bootstrap = ApplicationBootstrap()
+        bootstrap.start()
+
+        assert bootstrap.is_started
+
+        bootstrap.shutdown()
+
+        assert not bootstrap.is_started
+        assert bootstrap.context is None
+
+    def test_can_restart_after_shutdown(self) -> None:
+        """Test that bootstrap can be restarted after shutdown."""
+        bootstrap = ApplicationBootstrap()
+
+        context1 = bootstrap.start()
+        bootstrap.shutdown()
+        context2 = bootstrap.start()
+
+        assert context1 is not context2
+        assert bootstrap.is_started
+
+    def test_config_loader_is_none_without_factory(self) -> None:
+        """Test that config_loader is None when no factory is provided."""
+        bootstrap = ApplicationBootstrap()
+        context = bootstrap.start()
+
+        assert context.config_loader is None
+
+    def test_config_loader_factory_is_called(self) -> None:
+        """Test that config_loader_factory is called with contract_provider."""
+        captured_provider = []
+
+        def mock_factory(provider: SchemaContractProviderABC) -> PipelineConfigLoaderProtocol:
+            captured_provider.append(provider)
+            return object()  # type: ignore
+
+        bootstrap = ApplicationBootstrap(config_loader_factory=mock_factory)
+        context = bootstrap.start()
+
+        assert len(captured_provider) == 1
+        assert captured_provider[0] is context.contract_provider
+        assert context.config_loader is not None
+
+    def test_provider_injector_is_called(self) -> None:
+        """Test that provider_injector callback is called during start."""
+        injected_providers = []
+
+        def mock_injector(provider: SchemaContractProviderABC) -> None:
+            injected_providers.append(provider)
+
+        bootstrap = ApplicationBootstrap(provider_injector=mock_injector)
+        context = bootstrap.start()
+
+        assert len(injected_providers) == 1
+        assert injected_providers[0] is context.contract_provider
+
+    def test_provider_clearer_is_called_on_shutdown(self) -> None:
+        """Test that provider_clearer callback is called during shutdown."""
+        clear_called = []
+
+        def mock_clearer() -> None:
+            clear_called.append(True)
+
+        bootstrap = ApplicationBootstrap(provider_clearer=mock_clearer)
+        bootstrap.start()
+        bootstrap.shutdown()
+
+        assert len(clear_called) == 1
+
+
+class TestCreateApplicationBootstrap:
+    """Tests for create_application_bootstrap factory function."""
+
+    def test_returns_bootstrap_instance(self) -> None:
+        """Test that factory returns ApplicationBootstrap instance."""
+        bootstrap = create_application_bootstrap()
+
+        assert isinstance(bootstrap, ApplicationBootstrap)
+
+    def test_accepts_config_loader_factory(self) -> None:
+        """Test that factory accepts config_loader_factory parameter."""
+        def mock_factory(provider: SchemaContractProviderABC) -> PipelineConfigLoaderProtocol:
+            return object()  # type: ignore
+
+        bootstrap = create_application_bootstrap(config_loader_factory=mock_factory)
+        context = bootstrap.start()
+
+        assert context.config_loader is not None
+
+    def test_accepts_provider_callbacks(self) -> None:
+        """Test that factory accepts provider callback parameters."""
+        injected = []
+        cleared = []
+
+        bootstrap = create_application_bootstrap(
+            provider_injector=lambda p: injected.append(p),
+            provider_clearer=lambda: cleared.append(True),
+        )
+
+        bootstrap.start()
+        assert len(injected) == 1
+
+        bootstrap.shutdown()
+        assert len(cleared) == 1
+
+
+class TestApplicationContext:
+    """Tests for ApplicationContext dataclass."""
+
+    def test_is_frozen(self) -> None:
+        """Test that ApplicationContext is immutable."""
+        bootstrap = ApplicationBootstrap()
+        context = bootstrap.start()
+
+        with pytest.raises(Exception):  # FrozenInstanceError
+            context.schema_provider = None  # type: ignore
+
+    def test_has_required_attributes(self) -> None:
+        """Test that context has all required attributes."""
+        bootstrap = ApplicationBootstrap()
+        context = bootstrap.start()
+
+        assert hasattr(context, "schema_provider")
+        assert hasattr(context, "contract_provider")
+        assert hasattr(context, "config_loader")

--- a/tests/bioetl/interfaces/test_bootstrap_factory.py
+++ b/tests/bioetl/interfaces/test_bootstrap_factory.py
@@ -1,0 +1,75 @@
+"""Tests for bootstrap_factory in interfaces layer."""
+
+from __future__ import annotations
+
+import pytest
+
+from bioetl.application.bootstrap import ApplicationBootstrap, ApplicationContext
+from bioetl.domain.configs.contracts import PipelineConfigLoaderProtocol
+from bioetl.interfaces.bootstrap_factory import create_default_bootstrap
+
+
+class TestCreateDefaultBootstrap:
+    """Tests for create_default_bootstrap factory function."""
+
+    def test_returns_bootstrap_instance(self) -> None:
+        """Test that factory returns ApplicationBootstrap instance."""
+        bootstrap = create_default_bootstrap()
+
+        assert isinstance(bootstrap, ApplicationBootstrap)
+
+    def test_bootstrap_starts_successfully(self) -> None:
+        """Test that created bootstrap starts without errors."""
+        bootstrap = create_default_bootstrap()
+        context = bootstrap.start()
+
+        assert isinstance(context, ApplicationContext)
+
+    def test_context_has_config_loader(self) -> None:
+        """Test that context from default bootstrap has config_loader."""
+        bootstrap = create_default_bootstrap()
+        context = bootstrap.start()
+
+        assert context.config_loader is not None
+
+    def test_config_loader_has_get_by_id(self) -> None:
+        """Test that config_loader has get_by_id method."""
+        bootstrap = create_default_bootstrap()
+        context = bootstrap.start()
+
+        assert hasattr(context.config_loader, "get_by_id")
+        assert callable(context.config_loader.get_by_id)
+
+    def test_config_loader_has_get_from_path(self) -> None:
+        """Test that config_loader has get_from_path method."""
+        bootstrap = create_default_bootstrap()
+        context = bootstrap.start()
+
+        assert hasattr(context.config_loader, "get_from_path")
+        assert callable(context.config_loader.get_from_path)
+
+    def test_shutdown_clears_state(self) -> None:
+        """Test that shutdown clears bootstrap state."""
+        bootstrap = create_default_bootstrap()
+        bootstrap.start()
+
+        assert bootstrap.is_started
+
+        bootstrap.shutdown()
+
+        assert not bootstrap.is_started
+
+    def test_multiple_bootstraps_are_independent(self) -> None:
+        """Test that multiple bootstrap instances are independent."""
+        bootstrap1 = create_default_bootstrap()
+        bootstrap2 = create_default_bootstrap()
+
+        context1 = bootstrap1.start()
+        context2 = bootstrap2.start()
+
+        # Contexts should be different objects
+        assert context1 is not context2
+
+        # But both should be valid
+        assert context1.schema_provider is not None
+        assert context2.schema_provider is not None


### PR DESCRIPTION
- Add ApplicationBootstrap class with dependency injection for clean architecture (config_loader_factory, provider_injector, provider_clearer)
- Add ApplicationContext dataclass with schema_provider, contract_provider, and optional config_loader
- Create bootstrap_factory.py in interfaces layer for infrastructure integration (create_default_bootstrap)
- Update CLI to use ApplicationBootstrap via create_default_bootstrap
- Mark SimplePipelineContainer as deprecated with DeprecationWarning
- Remove global state from CLI (_application_bootstrapped, _contract_provider)
- Add comprehensive unit tests for ApplicationBootstrap and bootstrap_factory

This change moves bootstrap logic from interfaces layer to application layer while maintaining clean layer dependencies through dependency injection. The interfaces layer now only provides infrastructure-specific factories.