### PR TITLE
Simplify API configuration and remove duplication

### DIFF
--- a/src/bioetl/application/config/__init__.py
+++ b/src/bioetl/application/config/__init__.py
@@ -1,9 +1,10 @@
-"""Public application configuration exports."""
+"""Public application configuration exports.
 
-from bioetl.application.config.resolution import (
-    ConfigPathResolver,
-    build_pipeline_config,
-)
+The main API for loading pipeline configurations is `build_runtime_config`.
+Use `ConfigPathResolver` for resolving config paths from pipeline names.
+"""
+
+from bioetl.application.config.resolution import ConfigPathResolver
 from bioetl.application.config.runtime import build_runtime_config
 from bioetl.domain.configs import (  # noqa: F401
     BaseProviderConfig,
@@ -32,7 +33,6 @@ from bioetl.domain.configs import (  # noqa: F401
 )
 
 __all__ = [
-    "build_pipeline_config",
     "build_runtime_config",
     "ConfigPathResolver",
     "BaseProviderConfig",

--- a/src/bioetl/application/config/resolution.py
+++ b/src/bioetl/application/config/resolution.py
@@ -8,10 +8,6 @@ logic of configuration path resolution from the CLI layer.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
-
-from bioetl.domain.configs import PipelineConfig
-from bioetl.domain.configs.contracts import PipelineConfigLoaderProtocol
 
 
 class ConfigPathResolver:
@@ -109,49 +105,6 @@ class ConfigPathResolver:
         )
 
 
-def build_pipeline_config(
-    config_path: Path,
-    *,
-    configs_root: Path | None = None,
-    loader: PipelineConfigLoaderProtocol,
-    profile: str | None = None,
-    cli_overrides: dict[str, Any] | None = None,
-    env_overrides: dict[str, Any] | None = None,
-) -> PipelineConfig:
-    """Load and validate pipeline config from path.
-
-    This function wraps the infrastructure loader with application-level
-    defaults for configs_root detection.
-
-    Args:
-        config_path: Path to the pipeline config YAML file.
-        configs_root: Root directory for configs. If None, inferred from
-            config_path parent structure.
-        loader: Infrastructure config loader protocol.
-        profile: Optional profile name to merge with base config.
-        cli_overrides: CLI-provided overrides (highest priority).
-        env_overrides: Environment-provided overrides.
-
-    Returns:
-        Fully validated PipelineConfig instance.
-    """
-    effective_configs_root = configs_root
-    if effective_configs_root is None:
-        effective_configs_root = _infer_configs_root(config_path)
-
-    profiles_root = (
-        effective_configs_root / "profiles" if effective_configs_root else None
-    )
-
-    return loader.get_from_path(
-        config_path,
-        profile=profile,
-        profiles_root=profiles_root,
-        cli_overrides=cli_overrides,
-        env_overrides=env_overrides,
-    )
-
-
 def _infer_configs_root(config_path: Path) -> Path:
     """Infer configs root from config file path structure.
 
@@ -174,5 +127,4 @@ def _infer_configs_root(config_path: Path) -> Path:
 
 __all__ = [
     "ConfigPathResolver",
-    "build_pipeline_config",
 ]

--- a/tests/bioetl/application/config/test_resolution.py
+++ b/tests/bioetl/application/config/test_resolution.py
@@ -1,17 +1,12 @@
-"""Tests for ConfigPathResolver and build_pipeline_config."""
+"""Tests for ConfigPathResolver."""
 
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
-from bioetl.application.config.resolution import (
-    ConfigPathResolver,
-    _infer_configs_root,
-    build_pipeline_config,
-)
+from bioetl.application.config.resolution import ConfigPathResolver
 
 
 class TestConfigPathResolver:
@@ -110,114 +105,3 @@ class TestConfigPathResolver:
         """Test configs_root property returns configured root."""
         resolver = ConfigPathResolver(tmp_path)
         assert resolver.configs_root == tmp_path
-
-
-class TestBuildPipelineConfig:
-    """Tests for build_pipeline_config function."""
-
-    def test_build_pipeline_config_calls_loader(self, tmp_path: Path) -> None:
-        """Test that build_pipeline_config delegates to loader."""
-        config_path = tmp_path / "pipelines" / "chembl" / "compound.yaml"
-        config_path.parent.mkdir(parents=True, exist_ok=True)
-        config_path.write_text("id: chembl.compound")
-
-        mock_config = MagicMock()
-        mock_loader = MagicMock()
-        mock_loader.get_from_path.return_value = mock_config
-
-        result = build_pipeline_config(
-            config_path,
-            loader=mock_loader,
-            profile="development",
-        )
-
-        assert result == mock_config
-        mock_loader.get_from_path.assert_called_once()
-        call_kwargs = mock_loader.get_from_path.call_args
-        assert call_kwargs[0][0] == config_path
-        assert call_kwargs[1]["profile"] == "development"
-
-    def test_build_pipeline_config_infers_configs_root(self, tmp_path: Path) -> None:
-        """Test that configs_root is inferred from config path structure."""
-        configs_root = tmp_path / "configs"
-        config_path = configs_root / "pipelines" / "chembl" / "compound.yaml"
-        config_path.parent.mkdir(parents=True, exist_ok=True)
-        config_path.write_text("id: chembl.compound")
-
-        mock_config = MagicMock()
-        mock_loader = MagicMock()
-        mock_loader.get_from_path.return_value = mock_config
-
-        build_pipeline_config(
-            config_path,
-            loader=mock_loader,
-        )
-
-        call_kwargs = mock_loader.get_from_path.call_args
-        # profiles_root should be configs_root / "profiles"
-        expected_profiles_root = configs_root / "profiles"
-        assert call_kwargs[1]["profiles_root"] == expected_profiles_root
-
-    def test_build_pipeline_config_explicit_configs_root(self, tmp_path: Path) -> None:
-        """Test that explicit configs_root overrides inference."""
-        config_path = tmp_path / "some" / "random" / "config.yaml"
-        config_path.parent.mkdir(parents=True, exist_ok=True)
-        config_path.write_text("id: test")
-
-        explicit_root = tmp_path / "my_configs"
-
-        mock_config = MagicMock()
-        mock_loader = MagicMock()
-        mock_loader.get_from_path.return_value = mock_config
-
-        build_pipeline_config(
-            config_path,
-            configs_root=explicit_root,
-            loader=mock_loader,
-        )
-
-        call_kwargs = mock_loader.get_from_path.call_args
-        expected_profiles_root = explicit_root / "profiles"
-        assert call_kwargs[1]["profiles_root"] == expected_profiles_root
-
-    def test_build_pipeline_config_passes_overrides(self, tmp_path: Path) -> None:
-        """Test that cli_overrides and env_overrides are passed through."""
-        config_path = tmp_path / "config.yaml"
-        config_path.write_text("id: test")
-
-        mock_config = MagicMock()
-        mock_loader = MagicMock()
-        mock_loader.get_from_path.return_value = mock_config
-
-        cli_overrides = {"batch_size": 100}
-        env_overrides = {"output_path": "/tmp/out"}
-
-        build_pipeline_config(
-            config_path,
-            loader=mock_loader,
-            cli_overrides=cli_overrides,
-            env_overrides=env_overrides,
-        )
-
-        call_kwargs = mock_loader.get_from_path.call_args
-        assert call_kwargs[1]["cli_overrides"] == cli_overrides
-        assert call_kwargs[1]["env_overrides"] == env_overrides
-
-
-class TestInferConfigsRoot:
-    """Tests for _infer_configs_root helper."""
-
-    def test_infer_from_standard_structure(self, tmp_path: Path) -> None:
-        """Test inference from standard pipelines directory structure."""
-        # configs/pipelines/chembl/compound.yaml
-        config_path = tmp_path / "configs" / "pipelines" / "chembl" / "compound.yaml"
-        result = _infer_configs_root(config_path)
-
-        assert result == tmp_path / "configs"
-
-    def test_infer_fallback_to_default(self, tmp_path: Path) -> None:
-        """Test fallback to 'configs' when structure doesn't match."""
-        config_path = tmp_path / "some" / "random" / "path" / "config.yaml"
-        result = _infer_configs_root(config_path)
-
-        assert result == Path("configs")


### PR DESCRIPTION
- Remove build_pipeline_config function (was only used in its own tests)
- Keep build_runtime_config as the single public API for config loading
- Update __init__.py to export only build_runtime_config
- Remove unused imports (PipelineConfig, PipelineConfigLoaderProtocol)
- Delete obsolete tests for build_pipeline_config and _infer_configs_root