### PR TITLE
Replace global variable with dependency injection

### DIFF
--- a/src/bioetl/infrastructure/config/loader.py
+++ b/src/bioetl/infrastructure/config/loader.py
@@ -1,4 +1,19 @@
-"""Загрузчик конфигураций пайплайнов."""
+"""Загрузчик конфигураций пайплайнов.
+
+This module provides pipeline configuration loading functionality with support
+for dependency injection of schema contract providers.
+
+Preferred usage (DI approach):
+    >>> from bioetl.interfaces.composition_root import get_composition_root
+    >>> root = get_composition_root()
+    >>> loader = root.create_schema_contract_loader()
+    >>> config = loader.get_pipeline_config("chembl.activity")
+
+Legacy usage (deprecated, will be removed):
+    >>> from bioetl.infrastructure.config.loader import get_pipeline_config
+    >>> set_schema_contract_provider(provider)  # deprecated
+    >>> config = get_pipeline_config("chembl.activity")
+"""
 
 from __future__ import annotations
 
@@ -38,6 +53,143 @@ class UnknownProviderError(ConfigError):
     def __init__(self, provider: str) -> None:
         super().__init__(f"Unknown provider: {provider}")
         self.provider = provider
+
+
+# ============================================================================
+# SchemaContractLoader - DI-based configuration loader
+# ============================================================================
+
+
+class SchemaContractLoader:
+    """Configuration loader with injected schema contract provider.
+
+    This class provides the preferred DI-based approach for loading pipeline
+    configurations. The schema contract provider is injected through the
+    constructor, eliminating global state.
+
+    Example:
+        >>> from bioetl.interfaces.composition_root import get_composition_root
+        >>> root = get_composition_root()
+        >>> loader = root.create_schema_contract_loader()
+        >>> config = loader.get_pipeline_config("chembl.activity")
+
+    Attributes:
+        schema_contract_provider: The injected schema contract provider.
+    """
+
+    def __init__(self, schema_contract_provider: SchemaContractProviderABC) -> None:
+        """Initialize loader with schema contract provider.
+
+        Args:
+            schema_contract_provider: Provider for schema contracts.
+                Must not be None.
+
+        Raises:
+            ValueError: If schema_contract_provider is None.
+        """
+        if schema_contract_provider is None:
+            raise ValueError("schema_contract_provider must not be None")
+        self._schema_contract_provider = schema_contract_provider
+
+    @property
+    def schema_contract_provider(self) -> SchemaContractProviderABC:
+        """Get the schema contract provider."""
+        return self._schema_contract_provider
+
+    def get_pipeline_config(
+        self,
+        pipeline_id: str,
+        *,
+        profile: str | None = None,
+        cli_overrides: dict[str, Any] | None = None,
+        env_overrides: dict[str, Any] | None = None,
+        base_dir: str | Path | None = None,
+    ) -> PipelineConfig:
+        """Load pipeline configuration by identifier.
+
+        Args:
+            pipeline_id: Pipeline identifier (e.g., "chembl.activity").
+            profile: Profile name to apply.
+            cli_overrides: CLI overrides.
+            env_overrides: Environment variable overrides.
+            base_dir: Base directory for configuration search.
+
+        Returns:
+            Loaded and validated pipeline configuration.
+
+        Raises:
+            ConfigFileNotFoundError: Configuration file not found.
+            ConfigValidationError: Configuration validation failed.
+            UnknownProviderError: Unknown provider in configuration.
+        """
+        try:
+            config_path, raw_config = get_yaml_for_pipeline(
+                pipeline_id,
+                profile=profile,
+                base_dir=base_dir,
+            )
+        except FileNotFoundError as exc:
+            path_str = str(exc).rsplit(": ", maxsplit=1)[-1]
+            raise ConfigFileNotFoundError(Path(path_str)) from exc
+
+        return _build_config(
+            raw_config,
+            config_path=config_path,
+            schema_contract_provider=self._schema_contract_provider,
+            cli_overrides=cli_overrides,
+            env_overrides=env_overrides,
+            base_dir=Path(base_dir) if base_dir is not None else None,
+        )
+
+    def get_pipeline_config_from_path(
+        self,
+        config_path: str | Path,
+        *,
+        profile: str | None = None,
+        profiles_root: str | Path | None = None,
+        cli_overrides: dict[str, Any] | None = None,
+        env_overrides: dict[str, Any] | None = None,
+    ) -> PipelineConfig:
+        """Load pipeline configuration from file path.
+
+        Args:
+            config_path: Path to configuration file.
+            profile: Profile name to apply.
+            profiles_root: Root directory for profiles.
+            cli_overrides: CLI overrides.
+            env_overrides: Environment variable overrides.
+
+        Returns:
+            Loaded and validated pipeline configuration.
+
+        Raises:
+            ConfigFileNotFoundError: Configuration file not found.
+            ConfigValidationError: Configuration validation failed.
+            UnknownProviderError: Unknown provider in configuration.
+        """
+        try:
+            path, raw_config = get_yaml_from_path(
+                config_path,
+                profile=profile,
+                profiles_root=profiles_root,
+            )
+        except FileNotFoundError as exc:
+            path_str = str(exc).rsplit(": ", maxsplit=1)[-1]
+            raise ConfigFileNotFoundError(Path(path_str)) from exc
+
+        return _build_config(
+            raw_config,
+            config_path=path,
+            schema_contract_provider=self._schema_contract_provider,
+            cli_overrides=cli_overrides,
+            env_overrides=env_overrides,
+            base_dir=None,
+        )
+
+
+# ============================================================================
+# Module-level functions (use explicit provider or deprecated global state)
+# ============================================================================
 
 
 def get_pipeline_config(
@@ -353,6 +505,47 @@ def _set_provider_internal(provider: SchemaContractProviderABC) -> None:
     _SCHEMA_CONTRACT_PROVIDER = provider
 
 
+def create_schema_contract_loader(
+    schema_contract_provider: SchemaContractProviderABC | None = None,
+) -> SchemaContractLoader:
+    """Create a SchemaContractLoader with the given or global provider.
+
+    .. deprecated::
+        This factory function is deprecated. Use dependency injection
+        via CompositionRoot.create_schema_contract_loader() instead,
+        or instantiate SchemaContractLoader directly with an explicit provider.
+
+    Args:
+        schema_contract_provider: Provider for schema contracts.
+            If None, falls back to global state (deprecated).
+
+    Returns:
+        Configured SchemaContractLoader instance.
+
+    Raises:
+        RuntimeError: If no provider is available.
+
+    Example (deprecated):
+        >>> loader = create_schema_contract_loader()
+        >>> config = loader.get_pipeline_config("chembl.activity")
+
+    Preferred (DI approach):
+        >>> from bioetl.interfaces.composition_root import get_composition_root
+        >>> root = get_composition_root()
+        >>> loader = root.create_schema_contract_loader()
+    """
+    warnings.warn(
+        "create_schema_contract_loader() is deprecated. "
+        "Use CompositionRoot.create_schema_contract_loader() "
+        "or instantiate SchemaContractLoader directly with an explicit provider. "
+        "This function will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    effective_provider = _resolve_schema_provider(schema_contract_provider)
+    return SchemaContractLoader(effective_provider)
+
+
 def _populate_fields_from_schema(
     config: PipelineConfig,
     *,
@@ -467,11 +660,16 @@ def _iter_candidate_roots(
 
 
 __all__ = [
+    # Primary API (DI-based)
+    "SchemaContractLoader",
+    # Exceptions
     "ConfigFileNotFoundError",
     "UnknownProviderError",
+    # Module-level functions (support explicit provider or deprecated global state)
     "get_pipeline_config",
     "get_pipeline_config_from_path",
-    # Deprecated functions (for backward compatibility)
+    # Deprecated functions (for backward compatibility, will be removed)
+    "create_schema_contract_loader",
     "set_schema_contract_provider",
     "get_schema_contract_provider",
     "clear_schema_contract_provider",

--- a/src/bioetl/interfaces/composition_root.py
+++ b/src/bioetl/interfaces/composition_root.py
@@ -8,24 +8,27 @@ Usage:
     # For production:
     root = CompositionRoot()
     http_transport = root.create_http_transport(provider="chembl", config=http_config)
+    loader = root.create_schema_contract_loader()
 
     # For testing:
     root = CompositionRoot(
         logger=mock_logger,
         metrics=mock_metrics,
+        schema_contract_provider=mock_provider,
     )
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import requests
 
 from bioetl.domain.clients.base.contracts import RateLimiterABC
 from bioetl.domain.configs import HttpClientConfig
 from bioetl.domain.observability import LoggingPortABC, MetricsPortABC
+from bioetl.domain.ports.schema import SchemaContractProviderABC
 from bioetl.infrastructure.clients.base.factories import (
     build_http_client,
     default_rate_limiter,
@@ -34,6 +37,9 @@ from bioetl.infrastructure.observability.factories import (
     default_logging_port,
     default_metrics_port,
 )
+
+if TYPE_CHECKING:
+    from bioetl.infrastructure.config.loader import SchemaContractLoader
 
 
 @dataclass(frozen=True)
@@ -55,9 +61,14 @@ class CompositionRoot:
     Example:
         >>> root = CompositionRoot()
         >>> transport = root.create_http_transport("chembl", HttpClientConfig())
+        >>> loader = root.create_schema_contract_loader()
 
         # For testing with mocks:
-        >>> root = CompositionRoot(logger=mock_logger, metrics=mock_metrics)
+        >>> root = CompositionRoot(
+        ...     logger=mock_logger,
+        ...     metrics=mock_metrics,
+        ...     schema_contract_provider=mock_provider,
+        ... )
         >>> transport = root.create_http_transport("chembl", HttpClientConfig())
     """
 
@@ -67,6 +78,7 @@ class CompositionRoot:
         logger: LoggingPortABC | None = None,
         metrics: MetricsPortABC | None = None,
         http_session_factory: type | None = None,
+        schema_contract_provider: SchemaContractProviderABC | None = None,
     ) -> None:
         """
         Initialize composition root with optional overrides.
@@ -76,10 +88,13 @@ class CompositionRoot:
             metrics: Custom metrics implementation (defaults to Prometheus)
             http_session_factory: Factory for HTTP sessions
                 (defaults to requests.Session)
+            schema_contract_provider: Custom schema contract provider
+                (defaults to bootstrapped provider from schema registry)
         """
         self._logger = logger
         self._metrics = metrics
         self._http_session_factory = http_session_factory or requests.Session
+        self._schema_contract_provider = schema_contract_provider
 
     def get_logger(self) -> LoggingPortABC:
         """Get or create the logger instance."""
@@ -150,6 +165,57 @@ class CompositionRoot:
             rate=rate,
             capacity=capacity,
         )
+
+    def get_schema_contract_provider(self) -> SchemaContractProviderABC:
+        """Get or create the schema contract provider instance.
+
+        If not provided during initialization, creates a default provider
+        by bootstrapping the schema registry.
+
+        Returns:
+            Configured SchemaContractProviderABC instance.
+        """
+        if self._schema_contract_provider is None:
+            self._schema_contract_provider = _create_default_schema_contract_provider()
+        return self._schema_contract_provider
+
+    def create_schema_contract_loader(self) -> "SchemaContractLoader":
+        """Create a SchemaContractLoader with the configured provider.
+
+        This is the preferred method for obtaining a configuration loader
+        with proper dependency injection.
+
+        Returns:
+            SchemaContractLoader with injected schema contract provider.
+
+        Example:
+            >>> root = CompositionRoot()
+            >>> loader = root.create_schema_contract_loader()
+            >>> config = loader.get_pipeline_config("chembl.activity")
+        """
+        from bioetl.infrastructure.config.loader import SchemaContractLoader
+
+        return SchemaContractLoader(self.get_schema_contract_provider())
+
+
+def _create_default_schema_contract_provider() -> SchemaContractProviderABC:
+    """Create default schema contract provider by bootstrapping schema registry.
+
+    This function is called lazily when no provider is explicitly configured.
+
+    Returns:
+        Configured SchemaContractProviderImpl instance.
+    """
+    from bioetl.application.services.schema_bootstrap import (
+        create_schema_bootstrap_service,
+    )
+    from bioetl.application.services.schema_contract_provider import (
+        SchemaContractProviderImpl,
+    )
+
+    schema_service = create_schema_bootstrap_service()
+    schema_provider = schema_service.ensure_registered()
+    return SchemaContractProviderImpl(schema_provider)
 
 
 # Module-level singleton for convenience (can be replaced in tests)


### PR DESCRIPTION
…ction

Replace global state pattern with proper DI for schema contract provider:

- Add SchemaContractLoader class that accepts provider via __init__
- Add create_schema_contract_loader() method to CompositionRoot
- Add get_schema_contract_provider() method to CompositionRoot
- Add deprecated create_schema_contract_loader() factory function for backward compatibility with existing code

The global _SCHEMA_CONTRACT_PROVIDER and related functions are kept for backward compatibility but remain deprecated. Migration path:

Before (deprecated):
  set_schema_contract_provider(provider)
  config = get_pipeline_config("chembl.activity")

After (preferred):
  root = CompositionRoot()
  loader = root.create_schema_contract_loader()
  config = loader.get_pipeline_config("chembl.activity")