### PR TITLE
Create domain abstractions for tabular data

### DIFF
--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -12,8 +12,22 @@ Type Aliases (unified in v3.0):
     - FieldConfig: Field configuration as dict[str, Any]
 
     Import from ``bioetl.domain.types`` for type aliases.
+
+Tabular Data Abstractions:
+    - Record: Single data record (dict-like interface)
+    - RecordSet: Collection of records with schema
+    - TabularData: Full tabular data abstraction (replaces pd.DataFrame)
+    - MutableTabularData: TabularData with mutation capabilities
+
+    Import from ``bioetl.domain.data`` for tabular data protocols.
 """
 
+from bioetl.domain.data import (
+    MutableTabularData,
+    Record,
+    RecordSet,
+    TabularData,
+)
 from bioetl.domain.errors import (
     BioetlError,
     ClientError,
@@ -39,6 +53,11 @@ from bioetl.domain.types import (
 from bioetl.domain.value_objects import ChemblId, EntityName, RunId
 
 __all__ = [
+    # Tabular data abstractions
+    "MutableTabularData",
+    "Record",
+    "RecordSet",
+    "TabularData",
     # Type aliases
     "ApiPayload",
     "FieldConfig",

--- a/src/bioetl/domain/clients/base/output/contracts.py
+++ b/src/bioetl/domain/clients/base/output/contracts.py
@@ -1,4 +1,11 @@
-"""Contracts for writing pipeline outputs and metadata."""
+"""Contracts for writing pipeline outputs and metadata.
+
+Tabular Data Abstractions:
+    This module uses domain-level TabularData instead of pd.DataFrame.
+    Infrastructure layer provides PandasAdapter implementations.
+
+    See bioetl.domain.data for protocol definitions.
+"""
 
 from __future__ import annotations
 
@@ -7,7 +14,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
-import pandas as pd
+from bioetl.domain.data import MutableTabularData, TabularData
 
 
 @dataclass(frozen=True)
@@ -21,17 +28,35 @@ class WriteResult:
 
 
 class QualityReportABC(ABC):
-    """Порт генератора QC-отчетов."""
+    """QC report generator port.
+
+    Uses domain-level TabularData abstraction.
+    """
 
     @abstractmethod
     def build_quality_report(
-        self, df: pd.DataFrame, *, min_coverage: float
-    ) -> pd.DataFrame:
-        """Строит таблицу покрытия и базовых метрик по колонкам."""
+        self, data: TabularData, *, min_coverage: float
+    ) -> TabularData:
+        """Build coverage and basic metrics table by columns.
+
+        Args:
+            data: Input tabular data.
+            min_coverage: Minimum coverage threshold.
+
+        Returns:
+            Tabular data with quality metrics.
+        """
 
     @abstractmethod
-    def build_correlation_report(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Строит корреляционную матрицу по числовым колонкам."""
+    def build_correlation_report(self, data: TabularData) -> TabularData:
+        """Build correlation matrix for numeric columns.
+
+        Args:
+            data: Input tabular data.
+
+        Returns:
+            Tabular data with correlation matrix.
+        """
 
 
 class RunMetadataBuilderProtocol(Protocol):
@@ -48,10 +73,20 @@ class RunMetadataBuilderProtocol(Protocol):
 
 @runtime_checkable
 class OutputFrameConverterABC(Protocol):
-    """DataFrame → DataFrame конвертер для пост-обработки перед записью."""
+    """Tabular data converter for post-processing before write.
 
-    def convert(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Преобразует DataFrame (rename/reorder/drop/enrich)."""
+    Uses domain-level TabularData abstraction.
+    """
+
+    def convert(self, data: TabularData) -> MutableTabularData:
+        """Convert tabular data (rename/reorder/drop/enrich).
+
+        Args:
+            data: Input tabular data.
+
+        Returns:
+            Transformed tabular data.
+        """
         ...
 
 

--- a/src/bioetl/domain/data.py
+++ b/src/bioetl/domain/data.py
@@ -1,0 +1,269 @@
+"""Domain abstractions for tabular data.
+
+This module provides Protocol-based abstractions for working with tabular data
+in the domain layer, decoupling domain logic from pandas implementation details.
+
+The abstractions are designed to be minimal yet sufficient for domain operations:
+- Record: Single data record (row)
+- RecordSet: Collection of records with schema information
+- TabularData: Full tabular data abstraction with iteration and shape
+
+Infrastructure layer provides concrete implementations (e.g., PandasAdapter).
+
+Example usage in domain contracts::
+
+    from bioetl.domain.data import TabularData, Record
+
+    class ValidatorABC(ABC):
+        @abstractmethod
+        def validate(self, data: TabularData) -> ValidationResult:
+            '''Validates tabular data and returns result.'''
+
+Migration Guide
+---------------
+Replace pd.DataFrame with TabularData in domain contracts:
+
++-----------------------+------------------+
+| Before (pandas)       | After (domain)   |
++=======================+==================+
+| df: pd.DataFrame      | data: TabularData|
++-----------------------+------------------+
+| row: pd.Series        | row: Record      |
++-----------------------+------------------+
+
+Infrastructure adapters implement these protocols wrapping pandas objects.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Iterator, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+__all__ = [
+    "Record",
+    "RecordSet",
+    "TabularData",
+    "MutableTabularData",
+]
+
+
+@runtime_checkable
+class Record(Protocol):
+    """Single data record abstraction.
+
+    Represents a single row of tabular data with dict-like access.
+    Implementations should provide key-value access to record fields.
+
+    This protocol is compatible with:
+    - dict[str, Any]
+    - pd.Series (via adapter)
+    - Any Mapping[str, Any]
+
+    Example:
+        >>> def process_record(record: Record) -> str:
+        ...     return record["molecule_chembl_id"]
+    """
+
+    def __getitem__(self, key: str) -> Any:
+        """Get value by column name.
+
+        Args:
+            key: Column/field name.
+
+        Returns:
+            Value at the given key.
+
+        Raises:
+            KeyError: If key does not exist.
+        """
+        ...
+
+    def keys(self) -> Iterator[str]:
+        """Return iterator over column names.
+
+        Returns:
+            Iterator yielding column/field names.
+        """
+        ...
+
+    def values(self) -> Iterator[Any]:
+        """Return iterator over values.
+
+        Returns:
+            Iterator yielding field values.
+        """
+        ...
+
+    def items(self) -> Iterator[tuple[str, Any]]:
+        """Return iterator over (key, value) pairs.
+
+        Returns:
+            Iterator yielding (column_name, value) tuples.
+        """
+        ...
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Get value by key with optional default.
+
+        Args:
+            key: Column/field name.
+            default: Value to return if key doesn't exist.
+
+        Returns:
+            Value at key or default.
+        """
+        ...
+
+
+@runtime_checkable
+class RecordSet(Protocol):
+    """Collection of records with schema information.
+
+    Represents a read-only collection of records that can be iterated.
+    Provides schema information via columns() method.
+
+    Example:
+        >>> def count_records(records: RecordSet) -> int:
+        ...     return len(records)
+        ...
+        >>> def get_columns(records: RecordSet) -> list[str]:
+        ...     return records.columns()
+    """
+
+    def columns(self) -> list[str]:
+        """Return list of column names.
+
+        Returns:
+            Ordered list of column names defining the schema.
+        """
+        ...
+
+    def __iter__(self) -> Iterator[Mapping[str, Any]]:
+        """Iterate over records as mappings.
+
+        Yields:
+            Each record as a Mapping[str, Any].
+        """
+        ...
+
+    def __len__(self) -> int:
+        """Return number of records.
+
+        Returns:
+            Count of records in the collection.
+        """
+        ...
+
+
+@runtime_checkable
+class TabularData(Protocol):
+    """Tabular data abstraction replacing pd.DataFrame in domain contracts.
+
+    This protocol defines the minimal interface needed for domain operations
+    on tabular data. It is intentionally minimal to:
+    1. Keep domain layer pure and implementation-agnostic
+    2. Allow multiple backends (pandas, polars, etc.)
+    3. Support testing with simple dict-based implementations
+
+    Key design decisions:
+    - columns is a property (not method) for pandas compatibility
+    - iterrows returns (index, Mapping) for row-by-row processing
+    - to_records returns list[dict] for serialization/interop
+
+    Example:
+        >>> def process_data(data: TabularData) -> int:
+        ...     print(f"Processing {data.shape[0]} rows, {data.shape[1]} columns")
+        ...     for idx, row in data.iterrows():
+        ...         # Process each row
+        ...         pass
+        ...     return data.shape[0]
+    """
+
+    @property
+    def columns(self) -> list[str]:
+        """Return list of column names.
+
+        Returns:
+            Ordered list of column names.
+        """
+        ...
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        """Return (rows, columns) dimensions.
+
+        Returns:
+            Tuple of (num_rows, num_columns).
+        """
+        ...
+
+    def iterrows(self) -> Iterator[tuple[int, Mapping[str, Any]]]:
+        """Iterate over rows as (index, record) pairs.
+
+        Yields:
+            Tuple of (row_index, row_data) where row_data is a Mapping.
+
+        Note:
+            Index is typically integer position but may vary by implementation.
+        """
+        ...
+
+    def to_records(self) -> list[dict[str, Any]]:
+        """Convert to list of dictionaries.
+
+        Returns:
+            List where each element is a dict representing one row.
+
+        Note:
+            This creates a copy of the data. Use iterrows() for
+            memory-efficient iteration.
+        """
+        ...
+
+    def __len__(self) -> int:
+        """Return number of rows.
+
+        Returns:
+            Row count (same as shape[0]).
+        """
+        ...
+
+    def __iter__(self) -> Iterator[str]:
+        """Iterate over column names.
+
+        Yields:
+            Column names (for pandas compatibility).
+        """
+        ...
+
+
+@runtime_checkable
+class MutableTabularData(TabularData, Protocol):
+    """Mutable tabular data with column operations.
+
+    Extends TabularData with mutation capabilities needed for
+    transformation operations in the domain layer.
+
+    Note:
+        Most domain contracts should use TabularData (immutable).
+        Use MutableTabularData only when mutation is required.
+    """
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        """Set column values.
+
+        Args:
+            key: Column name.
+            value: Values to set (scalar or sequence).
+        """
+        ...
+
+    def copy(self) -> "MutableTabularData":
+        """Create a copy of the data.
+
+        Returns:
+            New MutableTabularData with copied data.
+        """
+        ...

--- a/src/bioetl/domain/pipelines/contracts.py
+++ b/src/bioetl/domain/pipelines/contracts.py
@@ -1,12 +1,18 @@
-"""Domain-level pipeline contracts."""
+"""Domain-level pipeline contracts.
+
+Tabular Data Abstractions:
+    This module uses domain-level TabularData instead of pd.DataFrame.
+    Infrastructure layer provides PandasAdapter implementations.
+
+    See bioetl.domain.data for protocol definitions.
+"""
 
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Iterable
 
-import pandas as pd
-
 from bioetl.domain.clients.base.output.contracts import WriteResult
+from bioetl.domain.data import TabularData
 from bioetl.domain.enums import ErrorAction
 from bioetl.domain.errors import PipelineStageError
 from bioetl.domain.models import RunContext, StageResult
@@ -48,39 +54,64 @@ class ErrorPolicyABC(ABC):
 
 
 class ExtractorABC(ABC):
-    """
-    Component responsible for extracting data from source.
+    """Component responsible for extracting data from source.
+
+    Uses domain-level TabularData abstraction for extracted data chunks.
     """
 
     @abstractmethod
-    def extract(self, **kwargs: Any) -> Iterable[pd.DataFrame]:
-        """
-        Yields chunks of data.
+    def extract(self, **kwargs: Any) -> Iterable[TabularData]:
+        """Extract data from source in chunks.
+
+        Args:
+            **kwargs: Source-specific extraction parameters.
+
+        Yields:
+            Chunks of tabular data.
         """
 
 
 class LoaderABC(ABC):
-    """
-    Component responsible for loading data to destination.
+    """Component responsible for loading data to destination.
+
+    Uses domain-level TabularData abstraction for input data.
     """
 
     @abstractmethod
     def load(
         self,
-        df: pd.DataFrame,
+        data: TabularData,
         output_path: Path,
         context: RunContext,
         *,
         column_order: list[str] | None = None,
     ) -> WriteResult:
-        """
-        Loads data to destination.
+        """Load data to destination.
+
+        Args:
+            data: Tabular data to load.
+            output_path: Target path for output.
+            context: Run context with metadata.
+            column_order: Optional column ordering.
+
+        Returns:
+            WriteResult with operation details.
         """
 
     @abstractmethod
-    def write_metadata(self, meta: dict, path: Path) -> None:
-        """Записывает метаданные артефактов пайплайна."""
+    def write_metadata(self, meta: dict[str, Any], path: Path) -> None:
+        """Write pipeline artifact metadata.
+
+        Args:
+            meta: Metadata dictionary.
+            path: Target file path.
+        """
 
     @abstractmethod
-    def write_qc_report(self, df: pd.DataFrame, path: Path) -> None:
-        """Записывает QC-отчет в детерминированном порядке."""
+    def write_qc_report(self, data: TabularData, path: Path) -> None:
+        """Write QC report in deterministic order.
+
+        Args:
+            data: Tabular data for QC analysis.
+            path: Target report path.
+        """

--- a/src/bioetl/domain/transform/contracts.py
+++ b/src/bioetl/domain/transform/contracts.py
@@ -5,17 +5,25 @@ Terminology:
         Deprecated alias: hash_row (will be removed in v3.0).
     compute_entity_key: Computes a hash of the business key columns.
         Deprecated alias: hash_business_key (will be removed in v3.0).
+
+Tabular Data Abstractions:
+    This module uses domain-level abstractions (Record, TabularData) instead of
+    pandas types. Infrastructure layer provides PandasAdapter implementations.
+
+    See bioetl.domain.data for protocol definitions.
 """
 
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 import warnings
-
-import pandas as pd
 
 # Import the canonical NormalizationConfig from configs.normalization
 from bioetl.domain.configs.normalization import NormalizationConfig
+from bioetl.domain.data import MutableTabularData, Record, TabularData
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class NormalizationConfigProviderProtocol(Protocol):
@@ -33,44 +41,88 @@ class NormalizationConfigProviderProtocol(Protocol):
 
 
 class HasherABC(ABC):
-    """Хеширование строк."""
+    """Row hashing abstraction.
+
+    Uses domain-level Record and TabularData instead of pandas types.
+    Infrastructure implementations can work with pandas internally.
+    """
 
     def get_algorithm(self) -> str:
-        """Используемый алгоритм (по умолчанию blake2b_256)."""
-
+        """Return hashing algorithm name (default: blake2b_256)."""
         return "blake2b_256"
 
     @abstractmethod
-    def compute_hash_row(self, row: pd.Series) -> str:
-        """Хеширует строку Series."""
+    def compute_hash_row(self, row: Record) -> str:
+        """Compute hash of a single record.
+
+        Args:
+            row: Record to hash (dict-like interface).
+
+        Returns:
+            Hex string hash of the record.
+        """
 
     @abstractmethod
-    def compute_hash_columns(self, df: pd.DataFrame, columns: list[str]) -> pd.Series:
-        """Хеширует выбранные колонки DataFrame."""
+    def compute_hash_columns(
+        self, data: TabularData, columns: list[str]
+    ) -> "Sequence[str]":
+        """Compute hash of specified columns for each row.
+
+        Args:
+            data: Tabular data to process.
+            columns: Column names to include in hash.
+
+        Returns:
+            Sequence of hash strings, one per row.
+        """
 
 
 class NormalizationServiceABC(ABC):
-    """Сервис нормализации данных."""
+    """Data normalization service.
+
+    Provides batch and record-level normalization operations.
+    Uses domain-level TabularData abstraction.
+    """
 
     @abstractmethod
-    def normalize(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Пакетно нормализует DataFrame и приводит числовые столбцы."""
+    def normalize(self, data: TabularData) -> MutableTabularData:
+        """Normalize tabular data batch and coerce numeric columns.
+
+        Args:
+            data: Input tabular data.
+
+        Returns:
+            Normalized tabular data (may be new instance).
+        """
 
     @abstractmethod
     def normalize_record(self, record: dict[str, Any]) -> dict[str, Any]:
-        """Нормализует одну запись."""
+        """Normalize a single record.
+
+        Args:
+            record: Record dictionary to normalize.
+
+        Returns:
+            Normalized record dictionary.
+        """
 
     @abstractmethod
-    def ensure_numeric_columns(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Приводит числовые столбцы к nullable pandas dtypes."""
+    def ensure_numeric_columns(self, data: TabularData) -> MutableTabularData:
+        """Coerce numeric columns to appropriate types.
+
+        Args:
+            data: Input tabular data.
+
+        Returns:
+            Data with numeric columns coerced.
+        """
 
 
 class HashServiceABC(ABC):
-    """
-    Stateless сервис для вычисления и добавления хеш-сумм.
+    """Stateless hash computation service.
 
-    Отвечает только за хеширование строк и бизнес-ключей.
-    Не содержит stateful логики (индексы, timestamps).
+    Responsible for computing and adding hash columns to tabular data.
+    Does not contain stateful logic (indices, timestamps).
 
     Terminology:
         compute_row_fingerprint: Canonical name for row hashing.
@@ -80,24 +132,47 @@ class HashServiceABC(ABC):
     """
 
     @abstractmethod
-    def compute_row_fingerprint(self, row: dict) -> str:
-        """Вычисляет хеш-отпечаток строки как полного объекта.
+    def compute_row_fingerprint(self, row: dict[str, Any]) -> str:
+        """Compute hash fingerprint of a row as complete object.
 
-        This is the canonical method name for row hashing.
+        Args:
+            row: Row data as dictionary.
+
+        Returns:
+            Hex string hash of the row.
+
+        Note:
+            This is the canonical method name for row hashing.
         """
 
     @abstractmethod
-    def compute_entity_key(self, row: dict, key_columns: list[str]) -> str:
-        """Вычисляет хеш бизнес-ключа (выбранных колонок).
+    def compute_entity_key(self, row: dict[str, Any], key_columns: list[str]) -> str:
+        """Compute hash of business key columns.
 
-        This is the canonical method name for business key hashing.
+        Args:
+            row: Row data as dictionary.
+            key_columns: List of columns forming the business key.
+
+        Returns:
+            Hex string hash of the business key.
+
+        Note:
+            This is the canonical method name for business key hashing.
         """
 
     @abstractmethod
     def add_hash_columns(
-        self, df: pd.DataFrame, business_key_cols: list[str] | None = None
-    ) -> pd.DataFrame:
-        """Добавляет hash_row и hash_business_key колонки к DataFrame."""
+        self, data: TabularData, business_key_cols: list[str] | None = None
+    ) -> MutableTabularData:
+        """Add hash_row and hash_business_key columns to data.
+
+        Args:
+            data: Input tabular data.
+            business_key_cols: Optional list of business key column names.
+
+        Returns:
+            Data with added hash columns.
+        """
 
     # =========================================================================
     # Deprecated aliases (will be removed in v3.0)

--- a/src/bioetl/domain/validation/contracts.py
+++ b/src/bioetl/domain/validation/contracts.py
@@ -1,34 +1,65 @@
-"""Domain contracts for validation services and schema providers."""
+"""Domain contracts for validation services and schema providers.
+
+Tabular Data Abstractions:
+    This module uses domain-level TabularData instead of pd.DataFrame.
+    Infrastructure layer provides PandasAdapter implementations.
+
+    See bioetl.domain.data for protocol definitions.
+"""
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Protocol, runtime_checkable
 
-import pandas as pd
+from bioetl.domain.data import TabularData
 
 schema_type = Any
 
 
 @dataclass
 class ValidationResult:
-    """Результат валидации доменного уровня."""
+    """Domain-level validation result.
+
+    Attributes:
+        is_valid: Whether validation passed.
+        errors: List of validation errors.
+        warnings: List of validation warnings.
+        validated_data: Validated tabular data (if validation passed).
+    """
 
     is_valid: bool
     errors: list[Any]
     warnings: list[str]
-    validated_df: pd.DataFrame | None = None
+    validated_data: TabularData | None = None
 
 
 class ValidatorABC(ABC):
-    """Доменный интерфейс валидатора."""
+    """Domain validator interface.
+
+    Uses domain-level TabularData abstraction.
+    """
 
     @abstractmethod
-    def validate(self, df: pd.DataFrame) -> ValidationResult:
-        """Валидирует DataFrame и возвращает результат проверки."""
+    def validate(self, data: TabularData) -> ValidationResult:
+        """Validate tabular data and return validation result.
+
+        Args:
+            data: Tabular data to validate.
+
+        Returns:
+            ValidationResult with validation status and details.
+        """
 
     @abstractmethod
-    def is_valid(self, df: pd.DataFrame) -> bool:
-        """Упрощенная проверка валидности."""
+    def is_valid(self, data: TabularData) -> bool:
+        """Simplified validity check.
+
+        Args:
+            data: Tabular data to validate.
+
+        Returns:
+            True if data passes validation.
+        """
 
 
 class SchemaProviderABC(ABC):


### PR DESCRIPTION
…m pandas

Add Protocol-based abstractions for tabular data in domain layer:
- Record: Single data record with dict-like interface
- RecordSet: Collection of records with schema information
- TabularData: Full tabular data abstraction (replaces pd.DataFrame)
- MutableTabularData: TabularData with mutation capabilities

Update domain contracts to use abstractions instead of pandas types:
- transform/contracts.py: HasherABC, NormalizationServiceABC, HashServiceABC
- pipelines/contracts.py: ExtractorABC, LoaderABC
- validation/contracts.py: ValidatorABC, ValidationResult
- clients/base/output/contracts.py: QualityReportABC, OutputFrameConverterABC

Infrastructure implementations will provide PandasAdapter to bridge these abstractions with pandas DataFrames.