### PR TITLE
Create RunPipelineUseCase to reduce duplication

### DIFF
--- a/src/bioetl/application/use_cases/__init__.py
+++ b/src/bioetl/application/use_cases/__init__.py
@@ -1,0 +1,20 @@
+"""Application use cases for BioETL.
+
+This module provides use cases that encapsulate application-level business logic.
+Use cases serve as the entry point for application operations, orchestrating
+domain services and infrastructure components.
+"""
+
+from bioetl.application.use_cases.run_pipeline import (
+    InterfaceDisabledError,
+    RunPipelineRequest,
+    RunPipelineResponse,
+    RunPipelineUseCase,
+)
+
+__all__ = [
+    "InterfaceDisabledError",
+    "RunPipelineRequest",
+    "RunPipelineResponse",
+    "RunPipelineUseCase",
+]

--- a/src/bioetl/application/use_cases/run_pipeline.py
+++ b/src/bioetl/application/use_cases/run_pipeline.py
@@ -1,0 +1,252 @@
+"""Use case для запуска ETL-пайплайна.
+
+Инкапсулирует всю логику:
+- Загрузка конфигурации
+- Разрешение путей
+- Создание orchestrator
+- Запуск пайплайна
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable
+
+from bioetl.application.orchestrator import PipelineOrchestrator
+from bioetl.domain.configs import PipelineConfig
+from bioetl.domain.models import RunResult
+
+if TYPE_CHECKING:
+    from bioetl.application.pipelines.contracts import PipelineContainerABC
+    from bioetl.domain.configs.contracts import PipelineConfigLoaderProtocol
+    from bioetl.domain.provider_registry import ProviderRegistryLoaderABC
+
+
+class InterfaceDisabledError(Exception):
+    """Запрошенный интерфейс отключён в конфигурации."""
+
+    def __init__(self, interface: str) -> None:
+        super().__init__(f"{interface} interface is disabled by configuration")
+        self.interface = interface
+
+
+@dataclass(frozen=True)
+class RunPipelineRequest:
+    """Запрос на выполнение пайплайна."""
+
+    pipeline_name: str
+    profile: str = "default"
+    dry_run: bool = False
+    limit: int | None = None
+    config_path: Path | None = None
+    output_path: Path | None = None
+    require_rest_interface: bool = False
+
+    def get_pipeline_id(self) -> str:
+        """Преобразует имя пайплайна в ID формата provider.entity.
+
+        Имя пайплайна в формате entity_provider преобразуется в provider.entity.
+        Если в имени несколько подчёркиваний, используется последнее для
+        разделения (например, drug_indication_chembl → chembl.drug_indication).
+        """
+        try:
+            entity, provider = self.pipeline_name.rsplit("_", 1)
+        except ValueError:
+            entity = self.pipeline_name
+            provider = "chembl"
+        return f"{provider}.{entity}"
+
+
+@dataclass(frozen=True)
+class RunPipelineResponse:
+    """Результат выполнения пайплайна."""
+
+    run_id: str
+    success: bool
+    row_count: int
+    duration_sec: float
+    output_path: Path | None
+    errors: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_run_result(cls, result: RunResult) -> "RunPipelineResponse":
+        """Создаёт ответ из результата выполнения пайплайна."""
+        return cls(
+            run_id=str(result.run_id),
+            success=result.success,
+            row_count=result.row_count,
+            duration_sec=result.duration_sec,
+            output_path=result.output_path,
+            errors=list(result.errors),
+        )
+
+
+class RunPipelineUseCase:
+    """Use case для запуска ETL-пайплайна.
+
+    Инкапсулирует всю логику:
+    - Загрузка конфигурации
+    - Разрешение путей
+    - Создание orchestrator
+    - Запуск пайплайна
+
+    Example:
+        use_case = RunPipelineUseCase(
+            config_loader=config_loader,
+            container_factory=build_default_container,
+            provider_loader_factory=create_provider_loader,
+        )
+
+        request = RunPipelineRequest(
+            pipeline_name="activity_chembl",
+            limit=100,
+            dry_run=True,
+        )
+
+        response = use_case.execute(request)
+        if response.success:
+            print(f"Processed {response.row_count} rows")
+    """
+
+    def __init__(
+        self,
+        config_loader: "PipelineConfigLoaderProtocol",
+        container_factory: Callable[..., "PipelineContainerABC"],
+        provider_loader_factory: Callable[[], "ProviderRegistryLoaderABC"],
+        configs_root: Path | None = None,
+    ) -> None:
+        """Инициализирует use case с необходимыми зависимостями.
+
+        Args:
+            config_loader: Загрузчик конфигураций пайплайнов.
+            container_factory: Фабрика для создания контейнера зависимостей.
+            provider_loader_factory: Фабрика для создания загрузчика провайдеров.
+            configs_root: Корневая директория конфигураций.
+        """
+        self._config_loader = config_loader
+        self._container_factory = container_factory
+        self._provider_loader_factory = provider_loader_factory
+        self._configs_root = configs_root
+
+    def execute(self, request: RunPipelineRequest) -> RunPipelineResponse:
+        """Выполняет пайплайн и возвращает результат.
+
+        Args:
+            request: Запрос с параметрами запуска.
+
+        Returns:
+            Результат выполнения пайплайна.
+
+        Raises:
+            InterfaceDisabledError: Если требуемый интерфейс отключён.
+        """
+        # 1. Загрузка конфигурации
+        config = self._load_config(request)
+
+        # 2. Проверка доступности интерфейса
+        self._validate_interface_enabled(config, request)
+
+        # 3. Применение переопределений
+        if request.output_path:
+            config = self._apply_output_override(config, request.output_path)
+
+        # 4. Создание и запуск orchestrator
+        orchestrator = self._create_orchestrator(request.pipeline_name, config)
+        result = orchestrator.run_pipeline(
+            dry_run=request.dry_run,
+            limit=request.limit,
+        )
+
+        return RunPipelineResponse.from_run_result(result)
+
+    def _load_config(self, request: RunPipelineRequest) -> PipelineConfig:
+        """Загружает конфигурацию из файла или по ID.
+
+        Args:
+            request: Запрос с параметрами конфигурации.
+
+        Returns:
+            Загруженная конфигурация пайплайна.
+        """
+        if request.config_path:
+            return self._config_loader.get_from_path(
+                request.config_path,
+                profile=request.profile,
+                profiles_root=self._get_profiles_root(),
+            )
+
+        return self._config_loader.get_by_id(
+            request.get_pipeline_id(),
+            profile=request.profile,
+            base_dir=self._configs_root,
+        )
+
+    def _validate_interface_enabled(
+        self, config: PipelineConfig, request: RunPipelineRequest
+    ) -> None:
+        """Проверяет, что требуемый интерфейс включён в конфигурации.
+
+        Args:
+            config: Конфигурация пайплайна.
+            request: Запрос с флагами интерфейсов.
+
+        Raises:
+            InterfaceDisabledError: Если требуемый интерфейс отключён.
+        """
+        if request.require_rest_interface:
+            if not config.features.rest_interface_enabled:
+                raise InterfaceDisabledError("REST")
+
+    def _apply_output_override(
+        self, config: PipelineConfig, output_path: Path
+    ) -> PipelineConfig:
+        """Применяет переопределение пути вывода.
+
+        Args:
+            config: Исходная конфигурация.
+            output_path: Новый путь для вывода.
+
+        Returns:
+            Конфигурация с обновлённым путём вывода.
+        """
+        output_path.mkdir(parents=True, exist_ok=True)
+        new_sink = config.sink.model_copy(update={"output_path": str(output_path)})
+        return config.model_copy(update={"sink": new_sink})
+
+    def _create_orchestrator(
+        self, pipeline_name: str, config: PipelineConfig
+    ) -> PipelineOrchestrator:
+        """Создаёт оркестратор для выполнения пайплайна.
+
+        Args:
+            pipeline_name: Имя пайплайна.
+            config: Конфигурация пайплайна.
+
+        Returns:
+            Настроенный оркестратор.
+        """
+        return PipelineOrchestrator(
+            pipeline_name=pipeline_name,
+            config=config,
+            provider_loader_factory=self._provider_loader_factory,
+            container_factory=self._container_factory,
+        )
+
+    def _get_profiles_root(self) -> Path | None:
+        """Возвращает путь к директории профилей.
+
+        Returns:
+            Путь к директории профилей или None.
+        """
+        if self._configs_root:
+            return self._configs_root / "profiles"
+        return None
+
+
+__all__ = [
+    "InterfaceDisabledError",
+    "RunPipelineRequest",
+    "RunPipelineResponse",
+    "RunPipelineUseCase",
+]

--- a/src/bioetl/interfaces/cli/app.py
+++ b/src/bioetl/interfaces/cli/app.py
@@ -9,11 +9,13 @@ from typing import Annotated
 from rich.console import Console
 import typer
 
-from bioetl.application.bootstrap import ApplicationBootstrap, ApplicationContext
+from bioetl.application.bootstrap import ApplicationBootstrap
 from bioetl.application.config.runtime import build_runtime_config
-from bioetl.application.orchestrator import PipelineOrchestrator
 from bioetl.application.pipelines.registry import PIPELINE_REGISTRY
-from bioetl.domain.configs import PipelineConfig
+from bioetl.application.use_cases import (
+    RunPipelineRequest,
+    RunPipelineUseCase,
+)
 from bioetl.infrastructure.config.provider_registry import (
     create_provider_loader,
 )
@@ -41,19 +43,15 @@ def get_bootstrap() -> ApplicationBootstrap:
     return _bootstrap
 
 
-def get_application_context() -> ApplicationContext:
-    """Initialize and return the application context.
+def _infer_config_path(pipeline_name: str) -> str | None:
+    """Infer config path from pipeline name.
 
-    This function must be called before using any application services.
-    It's idempotent - subsequent calls return the same context.
+    Args:
+        pipeline_name: Pipeline name in format entity_provider.
 
     Returns:
-        ApplicationContext: The initialized application context.
+        Inferred config path or None if cannot infer.
     """
-    return get_bootstrap().start()
-
-
-def _infer_config_path(pipeline_name: str) -> str | None:
     parts = pipeline_name.split("_")
     if len(parts) >= 2:
         entity, provider = parts[0], parts[1]
@@ -62,56 +60,25 @@ def _infer_config_path(pipeline_name: str) -> str | None:
 
 
 def _resolve_config_path(config: str) -> Path:
+    """Resolve config path to absolute path.
+
+    Args:
+        config: Config path (relative or absolute).
+
+    Returns:
+        Resolved absolute path.
+
+    Raises:
+        FileNotFoundError: If config file not found.
+    """
     p = Path(config)
     if p.exists():
         return p
-    from bioetl.infrastructure.config.sources import get_configs_root
-
     root = get_configs_root(None)
     candidate = (root / p).resolve()
     if candidate.exists():
         return candidate
     raise FileNotFoundError(f"Config file not found: {config}")
-
-
-def _build_config(config_path: Path, profile: str | None) -> PipelineConfig:
-    context = get_application_context()
-    return build_runtime_config(
-        config_path=config_path,
-        configs_root=get_configs_root(None),
-        loader=context.config_loader,
-        profile=profile,
-    )
-
-
-def _apply_output_override(pipeline_config: PipelineConfig, output: str | None) -> None:
-    if not output:
-        return
-    output_path = Path(output)
-    output_path.mkdir(parents=True, exist_ok=True)
-    # Update frozen sink config using model_copy
-    new_sink = pipeline_config.sink.model_copy(update={"output_path": str(output_path)})
-    object.__setattr__(pipeline_config, "sink", new_sink)
-    # Also update storage if it exists
-    if hasattr(pipeline_config.runtime, "storage"):
-        new_storage = pipeline_config.runtime.storage.model_copy(
-            update={"output_path": str(output_path)}
-        )
-        object.__setattr__(pipeline_config.runtime, "storage", new_storage)
-
-
-def _create_orchestrator(
-    pipeline_name: str, pipeline_config: PipelineConfig
-) -> PipelineOrchestrator:
-    def _provider_loader_factory() -> object:
-        return create_provider_loader()
-
-    return PipelineOrchestrator(
-        pipeline_name=pipeline_name,
-        config=pipeline_config,
-        provider_loader_factory=_provider_loader_factory,
-        container_factory=build_default_container,
-    )
 
 
 @app.command()
@@ -134,7 +101,11 @@ def validate_config(
         raise typer.Exit(1)
 
     try:
-        context = get_application_context()
+        bootstrap = get_bootstrap()
+        context = bootstrap.start()
+        if context.config_loader is None:
+            console.print("[red]Error:[/red] Config loader not available")
+            raise typer.Exit(1)
         build_runtime_config(
             config_path=config_file,
             configs_root=get_configs_root(None),
@@ -168,16 +139,47 @@ def run(
 ) -> None:
     """Run a pipeline."""
     try:
-        inferred = _infer_config_path(pipeline_name) if config is None else config
-        if inferred is None:
-            console.print("[red]Error:[/red] Cannot infer config path. Use --config.")
-            raise typer.Exit(1)
-        config_path = _resolve_config_path(inferred)
-        pipeline_config = _build_config(config_path, profile)
-        _apply_output_override(pipeline_config, output)
-        orchestrator = _create_orchestrator(pipeline_name, pipeline_config)
+        # Resolve config path if provided
+        config_path: Path | None = None
+        if config is not None:
+            config_path = _resolve_config_path(config)
+        else:
+            # Try to infer config path from pipeline name
+            inferred = _infer_config_path(pipeline_name)
+            if inferred is not None:
+                try:
+                    config_path = _resolve_config_path(inferred)
+                except FileNotFoundError:
+                    # If inferred path doesn't exist, let use case use get_by_id
+                    pass
 
-        # Run pipeline
+        # Get application context
+        bootstrap = get_bootstrap()
+        context = bootstrap.start()
+
+        if context.config_loader is None:
+            console.print("[red]Error:[/red] Config loader not available")
+            raise typer.Exit(1)
+
+        # Create use case
+        use_case = RunPipelineUseCase(
+            config_loader=context.config_loader,
+            container_factory=build_default_container,
+            provider_loader_factory=create_provider_loader,
+            configs_root=get_configs_root(None),
+        )
+
+        # Build request
+        request = RunPipelineRequest(
+            pipeline_name=pipeline_name,
+            profile=profile or "default",
+            dry_run=dry_run,
+            limit=limit,
+            config_path=config_path,
+            output_path=Path(output) if output else None,
+        )
+
+        # Run pipeline with progress output
         console.print("Starting pipeline")
         console.print(f"[bold]Running pipeline:[/bold] {pipeline_name}")
         if limit:
@@ -185,21 +187,18 @@ def run(
         if dry_run:
             console.print("[dim]Mode:[/dim] dry-run")
 
-        result = orchestrator.run_pipeline(
-            dry_run=dry_run,
-            limit=limit,
-        )
+        response = use_case.execute(request)
 
-        if result.success:
+        # Present result
+        if response.success:
             console.print("[green]✓ Pipeline finished successfully[/green]")
-            console.print(f"  Rows: {result.row_count}")
-            if result.output_path:
-                console.print(f"  Output: {result.output_path}")
+            console.print(f"  Rows: {response.row_count}")
+            if response.output_path:
+                console.print(f"  Output: {response.output_path}")
         else:
             console.print("[red]✗ Pipeline failed[/red]")
-            if result.errors:
-                for error in result.errors:
-                    console.print(f"  [red]Error:[/red] {error}")
+            for error in response.errors:
+                console.print(f"  [red]Error:[/red] {error}")
             raise typer.Exit(1)
 
     except KeyboardInterrupt:

--- a/src/bioetl/interfaces/rest/server.py
+++ b/src/bioetl/interfaces/rest/server.py
@@ -1,27 +1,24 @@
-"""Минимальный REST-сервер для запуска пайплайнов через PipelineOrchestrator."""
+"""Минимальный REST-сервер для запуска пайплайнов через RunPipelineUseCase."""
 
 from __future__ import annotations
 
 import asyncio
-from functools import partial
-from pathlib import Path
-from typing import Callable
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
-from bioetl.application.config.runtime import build_runtime_config
-from bioetl.application.orchestrator import PipelineOrchestrator
-from bioetl.domain.models import RunResult
-from bioetl.domain.provider_registry import (
-    ProviderRegistryABC,
-    ProviderRegistryLoaderABC,
+from bioetl.application.use_cases import (
+    InterfaceDisabledError,
+    RunPipelineRequest,
+    RunPipelineUseCase,
 )
 from bioetl.infrastructure.config.provider_registry import (
     create_provider_loader,
 )
-from bioetl.infrastructure.provider_registry import InMemoryProviderRegistry
-from bioetl.interfaces.container_factory import create_config_loader
+from bioetl.interfaces.bootstrap_factory import create_default_bootstrap
+from bioetl.interfaces.container_factory import (
+    build_default_container,
+)
 
 
 class PipelineRunRequest(BaseModel):
@@ -49,52 +46,6 @@ class PipelineRunResponse(BaseModel):
     errors: list[str]
 
 
-def _to_pipeline_id(pipeline_name: str) -> str:
-    try:
-        entity, provider = pipeline_name.rsplit("_", 1)
-    except ValueError:
-        entity = pipeline_name
-        provider = "chembl"
-    return f"{provider}.{entity}"
-
-
-def _create_orchestrator(pipeline_name: str, profile: str) -> PipelineOrchestrator:
-    pipeline_id = _to_pipeline_id(pipeline_name)
-    config_loader = create_config_loader()
-    config = build_runtime_config(
-        pipeline_id=pipeline_id, profile=profile, loader=config_loader
-    )
-    if not config.features.rest_interface_enabled:
-        raise HTTPException(
-            status_code=503,
-            detail="REST interface is disabled by configuration",
-        )
-    providers_path = Path("configs") / "providers.yaml"
-    provider_loader_factory: Callable[[], ProviderRegistryLoaderABC] | None = partial(
-        create_provider_loader, config_path=providers_path
-    )
-    provider_loader: ProviderRegistryLoaderABC | None = None
-    provider_registry: ProviderRegistryABC | None = None
-    try:
-        provider_loader = provider_loader_factory()
-    except FileNotFoundError:
-        provider_registry = InMemoryProviderRegistry()
-        provider_loader_factory = None
-    return PipelineOrchestrator(
-        pipeline_name=pipeline_name,
-        config=config,
-        provider_registry=provider_registry,
-        provider_loader=provider_loader,
-        provider_loader_factory=provider_loader_factory,
-    )
-
-
-def _run_pipeline_sync(
-    orchestrator: PipelineOrchestrator, dry_run: bool, limit: int | None
-) -> RunResult:
-    return orchestrator.run_pipeline(dry_run=dry_run, limit=limit)
-
-
 def create_rest_app() -> FastAPI:
     """Создает и возвращает FastAPI-приложение для запуска пайплайнов."""
 
@@ -103,24 +54,50 @@ def create_rest_app() -> FastAPI:
     @app.post("/pipelines/run", response_model=PipelineRunResponse)
     async def run_pipeline(request: PipelineRunRequest) -> PipelineRunResponse:
         """Run a pipeline asynchronously and return execution result."""
-        orchestrator = _create_orchestrator(
+        # Get application context
+        bootstrap = create_default_bootstrap()
+        context = bootstrap.start()
+
+        if context.config_loader is None:
+            raise HTTPException(
+                status_code=500,
+                detail="Config loader not available",
+            )
+
+        # Create use case
+        use_case = RunPipelineUseCase(
+            config_loader=context.config_loader,
+            container_factory=build_default_container,
+            provider_loader_factory=create_provider_loader,
+        )
+
+        # Build domain request with REST interface requirement
+        domain_request = RunPipelineRequest(
             pipeline_name=request.pipeline_name,
             profile=request.profile,
+            dry_run=request.dry_run,
+            limit=request.limit,
+            require_rest_interface=True,
         )
+
+        # Execute in thread pool to avoid blocking
         loop = asyncio.get_running_loop()
-        result = await loop.run_in_executor(
-            None,
-            _run_pipeline_sync,
-            orchestrator,
-            request.dry_run,
-            request.limit,
-        )
+        try:
+            response = await loop.run_in_executor(
+                None, use_case.execute, domain_request
+            )
+        except InterfaceDisabledError:
+            raise HTTPException(
+                status_code=503,
+                detail="REST interface is disabled by configuration",
+            )
+
         return PipelineRunResponse(
-            run_id=result.run_id,
-            success=result.success,
-            row_count=result.row_count,
-            duration_sec=result.duration_sec,
-            errors=result.errors,
+            run_id=response.run_id,
+            success=response.success,
+            row_count=response.row_count,
+            duration_sec=response.duration_sec,
+            errors=response.errors,
         )
 
     return app

--- a/tests/bioetl/application/use_cases/__init__.py
+++ b/tests/bioetl/application/use_cases/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for application use cases."""

--- a/tests/bioetl/application/use_cases/test_run_pipeline.py
+++ b/tests/bioetl/application/use_cases/test_run_pipeline.py
@@ -1,0 +1,453 @@
+"""Tests for RunPipelineUseCase."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from bioetl.application.use_cases import (
+    InterfaceDisabledError,
+    RunPipelineRequest,
+    RunPipelineResponse,
+    RunPipelineUseCase,
+)
+from bioetl.domain.value_objects import RunId
+
+
+class TestRunPipelineRequest:
+    """Tests for RunPipelineRequest dataclass."""
+
+    def test_default_values(self) -> None:
+        """Test that request has sensible defaults."""
+        request = RunPipelineRequest(pipeline_name="activity_chembl")
+
+        assert request.pipeline_name == "activity_chembl"
+        assert request.profile == "default"
+        assert request.dry_run is False
+        assert request.limit is None
+        assert request.config_path is None
+        assert request.output_path is None
+        assert request.require_rest_interface is False
+
+    def test_get_pipeline_id_with_entity_provider_format(self) -> None:
+        """Test pipeline ID extraction from entity_provider format."""
+        request = RunPipelineRequest(pipeline_name="activity_chembl")
+        assert request.get_pipeline_id() == "chembl.activity"
+
+    def test_get_pipeline_id_with_multiple_underscores(self) -> None:
+        """Test pipeline ID extraction with multiple underscores."""
+        request = RunPipelineRequest(pipeline_name="drug_indication_chembl")
+        assert request.get_pipeline_id() == "chembl.drug_indication"
+
+    def test_get_pipeline_id_without_underscore(self) -> None:
+        """Test pipeline ID fallback for names without underscore."""
+        request = RunPipelineRequest(pipeline_name="activity")
+        assert request.get_pipeline_id() == "chembl.activity"
+
+    def test_is_frozen(self) -> None:
+        """Test that request is immutable."""
+        request = RunPipelineRequest(pipeline_name="activity_chembl")
+
+        with pytest.raises(Exception):  # FrozenInstanceError
+            request.pipeline_name = "other"  # type: ignore
+
+    def test_all_fields_can_be_set(self) -> None:
+        """Test that all fields can be set in constructor."""
+        request = RunPipelineRequest(
+            pipeline_name="activity_chembl",
+            profile="production",
+            dry_run=True,
+            limit=100,
+            config_path=Path("/some/config.yaml"),
+            output_path=Path("/some/output"),
+            require_rest_interface=True,
+        )
+
+        assert request.pipeline_name == "activity_chembl"
+        assert request.profile == "production"
+        assert request.dry_run is True
+        assert request.limit == 100
+        assert request.config_path == Path("/some/config.yaml")
+        assert request.output_path == Path("/some/output")
+        assert request.require_rest_interface is True
+
+
+class TestRunPipelineResponse:
+    """Tests for RunPipelineResponse dataclass."""
+
+    def test_default_errors(self) -> None:
+        """Test that errors default to empty list."""
+        response = RunPipelineResponse(
+            run_id="12345678-1234-1234-1234-123456789abc",
+            success=True,
+            row_count=100,
+            duration_sec=1.5,
+            output_path=None,
+        )
+
+        assert response.errors == []
+
+    def test_from_run_result(self) -> None:
+        """Test creation from RunResult."""
+        # Create a mock RunResult
+        run_result = Mock()
+        run_result.run_id = RunId("12345678-1234-1234-1234-123456789abc")
+        run_result.success = True
+        run_result.row_count = 100
+        run_result.duration_sec = 1.5
+        run_result.output_path = Path("/output/data.parquet")
+        run_result.errors = ["warning1", "warning2"]
+
+        response = RunPipelineResponse.from_run_result(run_result)
+
+        assert response.run_id == "12345678-1234-1234-1234-123456789abc"
+        assert response.success is True
+        assert response.row_count == 100
+        assert response.duration_sec == 1.5
+        assert response.output_path == Path("/output/data.parquet")
+        assert response.errors == ["warning1", "warning2"]
+
+    def test_is_frozen(self) -> None:
+        """Test that response is immutable."""
+        response = RunPipelineResponse(
+            run_id="12345678-1234-1234-1234-123456789abc",
+            success=True,
+            row_count=100,
+            duration_sec=1.5,
+            output_path=None,
+        )
+
+        with pytest.raises(Exception):  # FrozenInstanceError
+            response.success = False  # type: ignore
+
+
+class TestInterfaceDisabledError:
+    """Tests for InterfaceDisabledError."""
+
+    def test_error_message(self) -> None:
+        """Test error message format."""
+        error = InterfaceDisabledError("REST")
+        assert str(error) == "REST interface is disabled by configuration"
+        assert error.interface == "REST"
+
+    def test_is_exception(self) -> None:
+        """Test that it's a proper exception."""
+        error = InterfaceDisabledError("MQ")
+        assert isinstance(error, Exception)
+
+
+class TestRunPipelineUseCase:
+    """Tests for RunPipelineUseCase."""
+
+    @pytest.fixture
+    def mock_config_loader(self) -> Mock:
+        """Create mock config loader."""
+        loader = Mock()
+        return loader
+
+    @pytest.fixture
+    def mock_container_factory(self) -> Mock:
+        """Create mock container factory."""
+        return Mock()
+
+    @pytest.fixture
+    def mock_provider_loader_factory(self) -> Mock:
+        """Create mock provider loader factory."""
+        return Mock()
+
+    @pytest.fixture
+    def mock_config(self) -> Mock:
+        """Create mock PipelineConfig."""
+        config = Mock()
+        config.features.rest_interface_enabled = True
+        config.features.mq_interface_enabled = False
+        config.sink.output_path = "/default/output"
+        config.sink.model_copy.return_value = config.sink
+        config.model_copy.return_value = config
+        return config
+
+    @pytest.fixture
+    def mock_run_result(self) -> Mock:
+        """Create mock RunResult."""
+        result = Mock()
+        result.run_id = RunId("12345678-1234-1234-1234-123456789abc")
+        result.success = True
+        result.row_count = 100
+        result.duration_sec = 1.5
+        result.output_path = Path("/output/data.parquet")
+        result.errors = []
+        return result
+
+    def test_execute_with_config_path(
+        self,
+        mock_config_loader: Mock,
+        mock_container_factory: Mock,
+        mock_provider_loader_factory: Mock,
+        mock_config: Mock,
+        mock_run_result: Mock,
+    ) -> None:
+        """Test execute loads config from path when provided."""
+        mock_config_loader.get_from_path.return_value = mock_config
+
+        use_case = RunPipelineUseCase(
+            config_loader=mock_config_loader,
+            container_factory=mock_container_factory,
+            provider_loader_factory=mock_provider_loader_factory,
+            configs_root=Path("/configs"),
+        )
+
+        request = RunPipelineRequest(
+            pipeline_name="activity_chembl",
+            config_path=Path("/custom/config.yaml"),
+            profile="production",
+        )
+
+        with patch.object(
+            use_case, "_create_orchestrator"
+        ) as mock_create_orchestrator:
+            mock_orchestrator = Mock()
+            mock_orchestrator.run_pipeline.return_value = mock_run_result
+            mock_create_orchestrator.return_value = mock_orchestrator
+
+            response = use_case.execute(request)
+
+        mock_config_loader.get_from_path.assert_called_once_with(
+            Path("/custom/config.yaml"),
+            profile="production",
+            profiles_root=Path("/configs/profiles"),
+        )
+        assert response.success is True
+
+    def test_execute_with_pipeline_id(
+        self,
+        mock_config_loader: Mock,
+        mock_container_factory: Mock,
+        mock_provider_loader_factory: Mock,
+        mock_config: Mock,
+        mock_run_result: Mock,
+    ) -> None:
+        """Test execute loads config by ID when no path provided."""
+        mock_config_loader.get_by_id.return_value = mock_config
+
+        use_case = RunPipelineUseCase(
+            config_loader=mock_config_loader,
+            container_factory=mock_container_factory,
+            provider_loader_factory=mock_provider_loader_factory,
+            configs_root=Path("/configs"),
+        )
+
+        request = RunPipelineRequest(
+            pipeline_name="activity_chembl",
+            profile="default",
+        )
+
+        with patch.object(
+            use_case, "_create_orchestrator"
+        ) as mock_create_orchestrator:
+            mock_orchestrator = Mock()
+            mock_orchestrator.run_pipeline.return_value = mock_run_result
+            mock_create_orchestrator.return_value = mock_orchestrator
+
+            response = use_case.execute(request)
+
+        mock_config_loader.get_by_id.assert_called_once_with(
+            "chembl.activity",
+            profile="default",
+            base_dir=Path("/configs"),
+        )
+        assert response.success is True
+
+    def test_execute_raises_on_rest_interface_disabled(
+        self,
+        mock_config_loader: Mock,
+        mock_container_factory: Mock,
+        mock_provider_loader_factory: Mock,
+        mock_config: Mock,
+    ) -> None:
+        """Test execute raises InterfaceDisabledError when REST is disabled."""
+        mock_config.features.rest_interface_enabled = False
+        mock_config_loader.get_by_id.return_value = mock_config
+
+        use_case = RunPipelineUseCase(
+            config_loader=mock_config_loader,
+            container_factory=mock_container_factory,
+            provider_loader_factory=mock_provider_loader_factory,
+        )
+
+        request = RunPipelineRequest(
+            pipeline_name="activity_chembl",
+            require_rest_interface=True,
+        )
+
+        with pytest.raises(InterfaceDisabledError) as exc_info:
+            use_case.execute(request)
+
+        assert exc_info.value.interface == "REST"
+
+    def test_execute_succeeds_without_rest_requirement(
+        self,
+        mock_config_loader: Mock,
+        mock_container_factory: Mock,
+        mock_provider_loader_factory: Mock,
+        mock_config: Mock,
+        mock_run_result: Mock,
+    ) -> None:
+        """Test execute succeeds when REST not required even if disabled."""
+        mock_config.features.rest_interface_enabled = False
+        mock_config_loader.get_by_id.return_value = mock_config
+
+        use_case = RunPipelineUseCase(
+            config_loader=mock_config_loader,
+            container_factory=mock_container_factory,
+            provider_loader_factory=mock_provider_loader_factory,
+        )
+
+        request = RunPipelineRequest(
+            pipeline_name="activity_chembl",
+            require_rest_interface=False,
+        )
+
+        with patch.object(
+            use_case, "_create_orchestrator"
+        ) as mock_create_orchestrator:
+            mock_orchestrator = Mock()
+            mock_orchestrator.run_pipeline.return_value = mock_run_result
+            mock_create_orchestrator.return_value = mock_orchestrator
+
+            response = use_case.execute(request)
+
+        assert response.success is True
+
+    def test_execute_applies_output_override(
+        self,
+        mock_config_loader: Mock,
+        mock_container_factory: Mock,
+        mock_provider_loader_factory: Mock,
+        mock_config: Mock,
+        mock_run_result: Mock,
+        tmp_path: Path,
+    ) -> None:
+        """Test execute creates output directory and updates config."""
+        mock_config_loader.get_by_id.return_value = mock_config
+
+        use_case = RunPipelineUseCase(
+            config_loader=mock_config_loader,
+            container_factory=mock_container_factory,
+            provider_loader_factory=mock_provider_loader_factory,
+        )
+
+        output_path = tmp_path / "custom_output"
+        request = RunPipelineRequest(
+            pipeline_name="activity_chembl",
+            output_path=output_path,
+        )
+
+        with patch.object(
+            use_case, "_create_orchestrator"
+        ) as mock_create_orchestrator:
+            mock_orchestrator = Mock()
+            mock_orchestrator.run_pipeline.return_value = mock_run_result
+            mock_create_orchestrator.return_value = mock_orchestrator
+
+            use_case.execute(request)
+
+        assert output_path.exists()
+        mock_config.sink.model_copy.assert_called_once()
+
+    def test_execute_passes_dry_run_and_limit(
+        self,
+        mock_config_loader: Mock,
+        mock_container_factory: Mock,
+        mock_provider_loader_factory: Mock,
+        mock_config: Mock,
+        mock_run_result: Mock,
+    ) -> None:
+        """Test execute passes dry_run and limit to orchestrator."""
+        mock_config_loader.get_by_id.return_value = mock_config
+
+        use_case = RunPipelineUseCase(
+            config_loader=mock_config_loader,
+            container_factory=mock_container_factory,
+            provider_loader_factory=mock_provider_loader_factory,
+        )
+
+        request = RunPipelineRequest(
+            pipeline_name="activity_chembl",
+            dry_run=True,
+            limit=50,
+        )
+
+        with patch.object(
+            use_case, "_create_orchestrator"
+        ) as mock_create_orchestrator:
+            mock_orchestrator = Mock()
+            mock_orchestrator.run_pipeline.return_value = mock_run_result
+            mock_create_orchestrator.return_value = mock_orchestrator
+
+            use_case.execute(request)
+
+        mock_orchestrator.run_pipeline.assert_called_once_with(
+            dry_run=True,
+            limit=50,
+        )
+
+    def test_create_orchestrator(
+        self,
+        mock_config_loader: Mock,
+        mock_container_factory: Mock,
+        mock_provider_loader_factory: Mock,
+        mock_config: Mock,
+    ) -> None:
+        """Test _create_orchestrator creates orchestrator with correct params."""
+        use_case = RunPipelineUseCase(
+            config_loader=mock_config_loader,
+            container_factory=mock_container_factory,
+            provider_loader_factory=mock_provider_loader_factory,
+        )
+
+        with patch(
+            "bioetl.application.use_cases.run_pipeline.PipelineOrchestrator"
+        ) as MockOrchestrator:
+            use_case._create_orchestrator("activity_chembl", mock_config)
+
+        MockOrchestrator.assert_called_once_with(
+            pipeline_name="activity_chembl",
+            config=mock_config,
+            provider_loader_factory=mock_provider_loader_factory,
+            container_factory=mock_container_factory,
+        )
+
+    def test_get_profiles_root_with_configs_root(
+        self,
+        mock_config_loader: Mock,
+        mock_container_factory: Mock,
+        mock_provider_loader_factory: Mock,
+    ) -> None:
+        """Test _get_profiles_root returns profiles subdirectory."""
+        use_case = RunPipelineUseCase(
+            config_loader=mock_config_loader,
+            container_factory=mock_container_factory,
+            provider_loader_factory=mock_provider_loader_factory,
+            configs_root=Path("/configs"),
+        )
+
+        assert use_case._get_profiles_root() == Path("/configs/profiles")
+
+    def test_get_profiles_root_without_configs_root(
+        self,
+        mock_config_loader: Mock,
+        mock_container_factory: Mock,
+        mock_provider_loader_factory: Mock,
+    ) -> None:
+        """Test _get_profiles_root returns None without configs_root."""
+        use_case = RunPipelineUseCase(
+            config_loader=mock_config_loader,
+            container_factory=mock_container_factory,
+            provider_loader_factory=mock_provider_loader_factory,
+        )
+
+        assert use_case._get_profiles_root() is None


### PR DESCRIPTION
…tion

- Add RunPipelineUseCase in application/use_cases/ to encapsulate pipeline execution logic (config loading, orchestrator creation, run)
- Define RunPipelineRequest/RunPipelineResponse DTOs for type-safe request/response handling
- Add InterfaceDisabledError for REST interface validation
- Update CLI to use RunPipelineUseCase instead of direct orchestrator
- Update REST server to use RunPipelineUseCase with require_rest_interface flag
- Add comprehensive tests for RunPipelineUseCase (20 tests)

This refactoring follows the thin adapters principle by moving all business logic from CLI and REST interfaces into a dedicated use case, eliminating code duplication and improving testability.

Closes REFACTOR-003