### PR TITLE
Extract ServiceFactory from PipelineContainer

### DIFF
--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+from bioetl.application.contracts import PipelineContainerABC
 from bioetl.application.factories.hooks import PipelineHookFactory
 from bioetl.application.factories.noop import (
     create_noop_logger,
@@ -12,8 +13,10 @@ from bioetl.application.factories.noop import (
     create_noop_validator_factory,
 )
 from bioetl.application.factories.record_source import RecordSourceFactory
-from bioetl.application.factories.services import ProviderServiceFactory
-from bioetl.application.contracts import PipelineContainerABC
+from bioetl.application.factories.service_factory import (
+    ApplicationServiceFactory,
+    ApplicationServiceFactoryABC,
+)
 from bioetl.application.pipelines.hooks_impl import FailFastErrorPolicyImpl
 from bioetl.domain.clients.base.output.contracts import (
     RunMetadataBuilderProtocol,
@@ -47,6 +50,7 @@ class PipelineContainer(PipelineContainerABC):
         self,
         config: PipelineConfig,
         *,
+        service_factory: ApplicationServiceFactoryABC | None = None,
         logger: LoggingPortABC | None = None,
         loader: LoaderABC | None = None,
         validator_factory: ValidatorFactoryABC | None = None,
@@ -88,19 +92,22 @@ class PipelineContainer(PipelineContainerABC):
         register_schemas(self._schema_provider)
 
         # Initialize factory helpers
-        self._service_factory: ProviderServiceFactory | None = None
+        self._injected_service_factory = service_factory
+        self._service_factory: ApplicationServiceFactoryABC | None = None
         self._record_source_factory: RecordSourceFactory | None = None
         self._hook_factory: PipelineHookFactory | None = None
 
-    def _get_service_factory(self) -> ProviderServiceFactory:
+    def _get_service_factory(self) -> ApplicationServiceFactoryABC:
         if self._service_factory is None:
-            self._service_factory = ProviderServiceFactory(
-                self._config,
-                self._get_provider_definition(),
-                self._resolve_provider_config,
-                logger=self._logger,
-                metrics=self._metrics_port,
-            )
+            if self._injected_service_factory is not None:
+                self._service_factory = self._injected_service_factory
+            else:
+                self._service_factory = ApplicationServiceFactory(
+                    self._config,
+                    self._get_provider_registry(),
+                    logger=self._logger,
+                    metrics=self._metrics_port,
+                )
         return self._service_factory
 
     def _get_record_source_factory(self) -> RecordSourceFactory:

--- a/src/bioetl/application/factories/__init__.py
+++ b/src/bioetl/application/factories/__init__.py
@@ -12,9 +12,15 @@ from bioetl.application.factories.noop import (
     create_noop_validator_factory,
 )
 from bioetl.application.factories.record_source import RecordSourceFactory
+from bioetl.application.factories.service_factory import (
+    ApplicationServiceFactory,
+    ApplicationServiceFactoryABC,
+)
 from bioetl.application.factories.services import ProviderServiceFactory
 
 __all__ = [
+    "ApplicationServiceFactory",
+    "ApplicationServiceFactoryABC",
     "PipelineHookFactory",
     "ProviderServiceFactory",
     "RecordSourceFactory",

--- a/src/bioetl/application/factories/service_factory.py
+++ b/src/bioetl/application/factories/service_factory.py
@@ -1,0 +1,103 @@
+"""
+Application-level service factory.
+
+Provides a facade for creating extraction and normalization services,
+abstracting away provider-specific details from the container.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from bioetl.application.factories.services import ProviderServiceFactory
+from bioetl.domain.configs import PipelineConfig
+from bioetl.domain.observability.contracts import LoggingPortABC, MetricsPortABC
+from bioetl.domain.provider_registry import ProviderRegistryABC
+from bioetl.domain.providers import ProviderDefinition, ProviderId
+from bioetl.domain.transform.contracts import NormalizationServiceABC
+
+
+class ApplicationServiceFactoryABC(ABC):
+    """Abstract base for application service factories."""
+
+    @abstractmethod
+    def create_extraction_service(self) -> Any:
+        """Create extraction service for the configured provider."""
+
+    @abstractmethod
+    def create_normalization_service(self) -> NormalizationServiceABC:
+        """Create normalization service for the configured provider."""
+
+
+class ApplicationServiceFactory(ApplicationServiceFactoryABC):
+    """
+    Factory for creating application-level services.
+
+    Encapsulates provider resolution and service creation logic,
+    delegating to ProviderServiceFactory for actual service instantiation.
+    """
+
+    def __init__(
+        self,
+        config: PipelineConfig,
+        provider_registry: ProviderRegistryABC,
+        *,
+        logger: LoggingPortABC | None = None,
+        metrics: MetricsPortABC | None = None,
+    ) -> None:
+        """
+        Initialize the application service factory.
+
+        Args:
+            config: Pipeline configuration.
+            provider_registry: Registry for looking up provider definitions.
+            logger: Optional logging port for service creation.
+            metrics: Optional metrics port for service creation.
+        """
+        self._config = config
+        self._provider_registry = provider_registry
+        self._logger = logger
+        self._metrics = metrics
+        self._provider_id = ProviderId(config.provider)
+        self._provider_factory: ProviderServiceFactory | None = None
+
+    def _get_provider_definition(self) -> ProviderDefinition:
+        """Get provider definition from registry."""
+        return self._provider_registry.get_provider(self._provider_id)
+
+    def _resolve_provider_config(self, definition: ProviderDefinition) -> Any:
+        """Resolve and validate provider-specific configuration."""
+        source_config = self._config.get_source_config(self._provider_id.value)
+        if not isinstance(source_config, definition.config_type):
+            raise TypeError(
+                f"Expected config type {definition.config_type.__name__} for "
+                f"provider '{self._provider_id.value}'"
+            )
+        return source_config
+
+    def _get_provider_factory(self) -> ProviderServiceFactory:
+        """Lazily create and cache the provider service factory."""
+        if self._provider_factory is None:
+            self._provider_factory = ProviderServiceFactory(
+                self._config,
+                self._get_provider_definition(),
+                self._resolve_provider_config,
+                logger=self._logger,
+                metrics=self._metrics,
+            )
+        return self._provider_factory
+
+    def create_extraction_service(self) -> Any:
+        """Create extraction service for the configured provider."""
+        return self._get_provider_factory().create_extraction_service()
+
+    def create_normalization_service(self) -> NormalizationServiceABC:
+        """Create normalization service for the configured provider."""
+        return self._get_provider_factory().create_normalization_service()
+
+
+__all__ = [
+    "ApplicationServiceFactory",
+    "ApplicationServiceFactoryABC",
+]


### PR DESCRIPTION
…ontainer

Extract service creation logic into ApplicationServiceFactory class to improve separation of concerns and testability. The factory encapsulates provider resolution and delegates to ProviderServiceFactory for actual service instantiation.

- Create ApplicationServiceFactory with create_extraction_service and create_normalization_service methods
- Add ApplicationServiceFactoryABC abstract base class
- Update PipelineContainer to accept optional service_factory via DI
- Lazy initialization of service factory when not injected