### PR TITLE
Consolidate scattered constants into unified structure

### DIFF
--- a/src/bioetl/infrastructure/clients/base/impl/_http_transport.py
+++ b/src/bioetl/infrastructure/clients/base/impl/_http_transport.py
@@ -19,6 +19,7 @@ from bioetl.infrastructure.errors import (
     wrap_http_errors,
 )
 from bioetl.infrastructure.http import ExponentialRetryPolicy
+from bioetl.infrastructure.settings.metrics import MetricName
 
 
 class _HttpTransport:
@@ -161,7 +162,7 @@ class _HttpTransport:
             return
 
         self.metrics.inc_counter(
-            "bioetl_client_request_total",
+            MetricName.CLIENT_REQUEST_TOTAL,
             {"provider": self.provider, "endpoint": endpoint, "status": status},
         )
 
@@ -170,7 +171,7 @@ class _HttpTransport:
             return
 
         self.metrics.observe_histogram(
-            "bioetl_client_request_duration_seconds",
+            MetricName.CLIENT_REQUEST_DURATION_SECONDS,
             latency,
             {"provider": self.provider, "endpoint": endpoint, "status": status},
         )
@@ -180,7 +181,7 @@ class _HttpTransport:
             return
 
         self.metrics.inc_counter(
-            "bioetl_client_request_errors_total",
+            MetricName.CLIENT_REQUEST_ERRORS_TOTAL,
             {"provider": self.provider, "endpoint": endpoint, "status": status},
         )
 

--- a/src/bioetl/infrastructure/constants.py
+++ b/src/bioetl/infrastructure/constants.py
@@ -1,10 +1,23 @@
-"""
-Constants for infrastructure layer.
+"""Constants for infrastructure layer.
+
+DEPRECATED: This module is deprecated. Use infrastructure.settings instead.
+
+All constants have been moved to:
+    - infrastructure.settings.files for file operation constants
+    - infrastructure.settings.http for HTTP-related constants
+    - infrastructure.settings.metrics for Prometheus metric names
+
+This module re-exports legacy constants for backward compatibility.
 """
 
-from typing import Final
+from bioetl.infrastructure.settings.files import (
+    CHECKSUM_CHUNK_SIZE,
+    MAX_FILE_RETRIES,
+    RETRY_DELAY_SEC,
+)
 
-# File Operation Constants
-MAX_FILE_RETRIES: Final[int] = 3
-RETRY_DELAY_SEC: Final[float] = 0.5
-CHECKSUM_CHUNK_SIZE: Final[int] = 8192
+__all__ = [
+    "MAX_FILE_RETRIES",
+    "RETRY_DELAY_SEC",
+    "CHECKSUM_CHUNK_SIZE",
+]

--- a/src/bioetl/infrastructure/http/retry.py
+++ b/src/bioetl/infrastructure/http/retry.py
@@ -5,18 +5,11 @@ from __future__ import annotations
 import math
 from typing import Iterable
 
-import requests
-
 from bioetl.domain.clients.base.contracts import RetryPolicyABC
-from bioetl.infrastructure.errors import ApiClientError, ApiTimeoutError
-
-DEFAULT_RETRY_STATUSES = {500, 502, 503, 504}
-DEFAULT_RETRY_EXCEPTIONS: tuple[type[Exception], ...] = (
-    ApiTimeoutError,
-    requests.Timeout,
-    requests.ConnectionError,
-    requests.HTTPError,
-    requests.RequestException,
+from bioetl.infrastructure.errors import ApiClientError
+from bioetl.infrastructure.settings.http import (
+    DEFAULT_RETRY_EXCEPTIONS,
+    DEFAULT_RETRY_STATUSES,
 )
 
 

--- a/src/bioetl/infrastructure/observability/adapters.py
+++ b/src/bioetl/infrastructure/observability/adapters.py
@@ -13,6 +13,7 @@ from bioetl.domain.observability.contracts import (
     TracingPortABC,
 )
 from bioetl.infrastructure.observability import metrics
+from bioetl.infrastructure.settings.metrics import MetricName
 
 
 class StructuredLoggerImpl(LoggingPortABC):
@@ -72,12 +73,12 @@ class PrometheusMetricsPortImpl(MetricsPortABC):
 
     def __init__(self) -> None:
         self._counters: dict[str, Any] = {
-            "bioetl_client_request_total": metrics.CLIENT_REQUEST_TOTAL,
-            "bioetl_client_request_errors_total": metrics.CLIENT_REQUEST_ERRORS_TOTAL,
-            "bioetl_output_write_errors_total": metrics.OUTPUT_WRITE_ERRORS_TOTAL,
+            MetricName.CLIENT_REQUEST_TOTAL: metrics.CLIENT_REQUEST_TOTAL,
+            MetricName.CLIENT_REQUEST_ERRORS_TOTAL: metrics.CLIENT_REQUEST_ERRORS_TOTAL,
+            MetricName.OUTPUT_WRITE_ERRORS_TOTAL: metrics.OUTPUT_WRITE_ERRORS_TOTAL,
         }
         self._histograms: dict[str, Any] = {
-            "bioetl_client_request_duration_seconds": (
+            MetricName.CLIENT_REQUEST_DURATION_SECONDS: (
                 metrics.CLIENT_REQUEST_DURATION_SECONDS
             ),
         }

--- a/src/bioetl/infrastructure/observability/metrics.py
+++ b/src/bioetl/infrastructure/observability/metrics.py
@@ -21,9 +21,14 @@ Examples:
 References:
     - https://prometheus.io/docs/practices/naming/
     - https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
+
+Note:
+    Metric names are centralized in infrastructure.settings.metrics.MetricName.
 """
 
 from prometheus_client import Counter, Histogram
+
+from bioetl.infrastructure.settings.metrics import MetricName
 
 __all__ = [
     # Stage metrics
@@ -42,13 +47,13 @@ __all__ = [
 # =============================================================================
 
 STAGE_DURATION_SECONDS = Histogram(
-    "bioetl_stage_duration_seconds",
+    MetricName.STAGE_DURATION_SECONDS.value,
     "Duration of pipeline stages in seconds.",
     ["pipeline", "provider", "entity", "stage", "outcome"],
 )
 
 STAGE_TOTAL = Counter(
-    "bioetl_stage_total",
+    MetricName.STAGE_TOTAL.value,
     "Total count of pipeline stage completions by outcome.",
     ["pipeline", "provider", "entity", "stage", "outcome"],
 )
@@ -58,19 +63,19 @@ STAGE_TOTAL = Counter(
 # =============================================================================
 
 CLIENT_REQUEST_TOTAL = Counter(
-    "bioetl_client_request_total",
+    MetricName.CLIENT_REQUEST_TOTAL.value,
     "Total client requests by provider and endpoint.",
     ["provider", "endpoint", "status"],
 )
 
 CLIENT_REQUEST_DURATION_SECONDS = Histogram(
-    "bioetl_client_request_duration_seconds",
+    MetricName.CLIENT_REQUEST_DURATION_SECONDS.value,
     "Duration of client requests in seconds.",
     ["provider", "endpoint", "status"],
 )
 
 CLIENT_REQUEST_ERRORS_TOTAL = Counter(
-    "bioetl_client_request_errors_total",
+    MetricName.CLIENT_REQUEST_ERRORS_TOTAL.value,
     "Total client request errors by provider and endpoint.",
     ["provider", "endpoint", "status"],
 )
@@ -80,7 +85,7 @@ CLIENT_REQUEST_ERRORS_TOTAL = Counter(
 # =============================================================================
 
 OUTPUT_WRITE_ERRORS_TOTAL = Counter(
-    "bioetl_output_write_errors_total",
+    MetricName.OUTPUT_WRITE_ERRORS_TOTAL.value,
     "Total number of failed output write attempts.",
     ["entity", "error_type"],
 )

--- a/src/bioetl/infrastructure/output/unified_loader_impl.py
+++ b/src/bioetl/infrastructure/output/unified_loader_impl.py
@@ -35,6 +35,7 @@ from bioetl.infrastructure.output.components.qc_artifact_writer import QcArtifac
 from bioetl.infrastructure.output.components.qc_report_generator import (
     QcReportGenerator,
 )
+from bioetl.infrastructure.settings.metrics import MetricName
 
 
 class UnifiedLoaderImpl(LoaderABC):
@@ -304,7 +305,7 @@ class UnifiedLoaderImpl(LoaderABC):
             return
 
         self._metrics.inc_counter(
-            "bioetl_output_write_errors_total",
+            MetricName.OUTPUT_WRITE_ERRORS_TOTAL,
             {"entity": entity_name, "error_type": exc.__class__.__name__},
         )
 

--- a/src/bioetl/infrastructure/settings/__init__.py
+++ b/src/bioetl/infrastructure/settings/__init__.py
@@ -1,0 +1,29 @@
+"""Consolidated infrastructure settings module.
+
+This module provides unified access to all infrastructure constants,
+organized as frozen dataclasses and Enums for type safety.
+
+Modules:
+    http: HTTP client settings (timeouts, retries, connection pool)
+    files: File operation settings (buffer sizes, temp paths)
+    metrics: Prometheus metric names as Enum
+"""
+
+from bioetl.infrastructure.settings.files import FileSettings
+from bioetl.infrastructure.settings.http import (
+    ConnectionPoolSettings,
+    HttpTimeouts,
+    RetrySettings,
+)
+from bioetl.infrastructure.settings.metrics import MetricName
+
+__all__ = [
+    # HTTP settings
+    "HttpTimeouts",
+    "RetrySettings",
+    "ConnectionPoolSettings",
+    # File settings
+    "FileSettings",
+    # Metric names
+    "MetricName",
+]

--- a/src/bioetl/infrastructure/settings/files.py
+++ b/src/bioetl/infrastructure/settings/files.py
@@ -1,0 +1,50 @@
+"""File operation settings: buffer sizes, retry configuration, temp paths.
+
+This module consolidates all file-related constants that were previously
+defined in infrastructure/constants.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+
+@dataclass(frozen=True, slots=True)
+class FileSettings:
+    """File operation configuration.
+
+    Contains settings for atomic file operations, checksum calculations,
+    and retry behavior for file system operations.
+    """
+
+    max_retries: int = 3
+    """Maximum number of retry attempts for file operations (e.g., atomic replace)."""
+
+    retry_delay_sec: float = 0.5
+    """Base delay between file operation retries in seconds."""
+
+    checksum_chunk_size: int = 8192
+    """Buffer size in bytes for reading files during checksum calculation."""
+
+    temp_suffix: str = ".tmp"
+    """Suffix for temporary files during atomic write operations."""
+
+
+# Default instance for convenient access
+DEFAULT_FILE_SETTINGS: Final[FileSettings] = FileSettings()
+
+# Legacy compatibility constants (deprecated, use FileSettings instance instead)
+MAX_FILE_RETRIES: Final[int] = DEFAULT_FILE_SETTINGS.max_retries
+RETRY_DELAY_SEC: Final[float] = DEFAULT_FILE_SETTINGS.retry_delay_sec
+CHECKSUM_CHUNK_SIZE: Final[int] = DEFAULT_FILE_SETTINGS.checksum_chunk_size
+
+
+__all__ = [
+    "FileSettings",
+    "DEFAULT_FILE_SETTINGS",
+    # Legacy compatibility
+    "MAX_FILE_RETRIES",
+    "RETRY_DELAY_SEC",
+    "CHECKSUM_CHUNK_SIZE",
+]

--- a/src/bioetl/infrastructure/settings/http.py
+++ b/src/bioetl/infrastructure/settings/http.py
@@ -1,0 +1,116 @@
+"""HTTP client settings: timeouts, retry configuration, connection pool.
+
+This module consolidates all HTTP-related constants that were previously
+scattered across multiple infrastructure modules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+import requests
+
+from bioetl.infrastructure.errors import ApiClientError, ApiTimeoutError
+
+
+@dataclass(frozen=True, slots=True)
+class HttpTimeouts:
+    """HTTP timeout configuration.
+
+    All values are in seconds.
+    """
+
+    connect: float = 10.0
+    """Connection timeout in seconds."""
+
+    read: float = 30.0
+    """Read timeout in seconds."""
+
+    total: float = 30.0
+    """Total request timeout in seconds (default for single requests)."""
+
+
+@dataclass(frozen=True, slots=True)
+class RetrySettings:
+    """Retry policy settings for HTTP clients.
+
+    Defines default values for retry behavior including which HTTP status codes
+    and exception types should trigger retries.
+    """
+
+    max_attempts: int = 4
+    """Maximum number of retry attempts (including initial request)."""
+
+    backoff_factor: float = 2.0
+    """Multiplier for exponential backoff delay."""
+
+    backoff_max: float = 60.0
+    """Maximum backoff delay in seconds."""
+
+    retry_statuses: frozenset[int] = frozenset({429, 500, 502, 503, 504})
+    """HTTP status codes that should trigger a retry."""
+
+    @property
+    def retry_exceptions(self) -> tuple[type[Exception], ...]:
+        """Exception types that should trigger a retry.
+
+        Returns a fresh tuple each time to avoid mutation issues.
+        """
+        return (
+            ApiTimeoutError,
+            ApiClientError,
+            requests.Timeout,
+            requests.ConnectionError,
+            requests.HTTPError,
+            requests.RequestException,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectionPoolSettings:
+    """HTTP connection pool settings.
+
+    Settings for managing connection pooling and rate limiting.
+    """
+
+    rate_limit_per_sec: float = 2.5
+    """Maximum requests per second."""
+
+    pool_connections: int = 10
+    """Number of connection pools to cache."""
+
+    pool_maxsize: int = 10
+    """Maximum number of connections to save in the pool."""
+
+    pool_block: bool = False
+    """Whether to block when no connections are available."""
+
+
+# Default instances for convenient access
+DEFAULT_TIMEOUTS: Final[HttpTimeouts] = HttpTimeouts()
+DEFAULT_RETRY: Final[RetrySettings] = RetrySettings()
+DEFAULT_POOL: Final[ConnectionPoolSettings] = ConnectionPoolSettings()
+
+# Legacy compatibility constants (deprecated, use dataclass instances instead)
+DEFAULT_RETRY_STATUSES: Final[frozenset[int]] = DEFAULT_RETRY.retry_statuses
+DEFAULT_RETRY_EXCEPTIONS: Final[tuple[type[Exception], ...]] = (
+    ApiTimeoutError,
+    requests.Timeout,
+    requests.ConnectionError,
+    requests.HTTPError,
+    requests.RequestException,
+)
+
+
+__all__ = [
+    "HttpTimeouts",
+    "RetrySettings",
+    "ConnectionPoolSettings",
+    "DEFAULT_TIMEOUTS",
+    "DEFAULT_RETRY",
+    "DEFAULT_POOL",
+    # Legacy compatibility
+    "DEFAULT_RETRY_STATUSES",
+    "DEFAULT_RETRY_EXCEPTIONS",
+]

--- a/src/bioetl/infrastructure/settings/metrics.py
+++ b/src/bioetl/infrastructure/settings/metrics.py
@@ -1,0 +1,71 @@
+"""Prometheus metric name constants as Enum.
+
+This module provides a centralized registry of all Prometheus metric names
+used across BioETL components. Using an Enum ensures type safety and prevents
+typos in metric names.
+
+Naming Convention:
+    - Prefix: All metrics start with ``bioetl_`` namespace
+    - Snake_case: Lowercase with underscores
+    - Unit suffix: Include unit when applicable (_seconds, _bytes, _total)
+    - Counter suffix: All Counter metrics end with ``_total``
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class MetricName(str, Enum):
+    """Prometheus metric names used across BioETL.
+
+    All metric names follow Prometheus naming conventions:
+    - https://prometheus.io/docs/practices/naming/
+    - https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
+
+    Examples:
+        >>> MetricName.CLIENT_REQUEST_TOTAL
+        'bioetl_client_request_total'
+        >>> MetricName.STAGE_DURATION_SECONDS.value
+        'bioetl_stage_duration_seconds'
+    """
+
+    # =========================================================================
+    # Stage Metrics
+    # =========================================================================
+
+    STAGE_DURATION_SECONDS = "bioetl_stage_duration_seconds"
+    """Histogram: Duration of pipeline stages in seconds."""
+
+    STAGE_TOTAL = "bioetl_stage_total"
+    """Counter: Total count of pipeline stage completions by outcome."""
+
+    # =========================================================================
+    # Client Request Metrics
+    # =========================================================================
+
+    CLIENT_REQUEST_TOTAL = "bioetl_client_request_total"
+    """Counter: Total client requests by provider and endpoint."""
+
+    CLIENT_REQUEST_DURATION_SECONDS = "bioetl_client_request_duration_seconds"
+    """Histogram: Duration of client requests in seconds."""
+
+    CLIENT_REQUEST_ERRORS_TOTAL = "bioetl_client_request_errors_total"
+    """Counter: Total client request errors by provider and endpoint."""
+
+    # =========================================================================
+    # Output Metrics
+    # =========================================================================
+
+    OUTPUT_WRITE_ERRORS_TOTAL = "bioetl_output_write_errors_total"
+    """Counter: Total number of failed output write attempts."""
+
+
+# Type alias for metric label dictionaries
+MetricLabels = dict[str, str]
+
+
+__all__ = [
+    "MetricName",
+    "MetricLabels",
+]

--- a/tests/bioetl/infrastructure/clients/base/test_http_transport.py
+++ b/tests/bioetl/infrastructure/clients/base/test_http_transport.py
@@ -9,6 +9,7 @@ from bioetl.infrastructure.clients.base.impl._http_transport import (
     _HttpTransport,
 )
 from bioetl.infrastructure.errors import ApiClientError, ApiTimeoutError
+from bioetl.infrastructure.settings.metrics import MetricName
 
 
 def test_request_call_wraps_timeout_error() -> None:
@@ -31,7 +32,7 @@ def test_request_call_wraps_timeout_error() -> None:
     assert err.value.endpoint == "https://example.org"
     logger.error.assert_called_once()
     metrics.inc_counter.assert_any_call(
-        "bioetl_client_request_errors_total",
+        MetricName.CLIENT_REQUEST_ERRORS_TOTAL,
         {"provider": "chembl", "endpoint": "https://example.org", "status": "timeout"},
     )
 
@@ -55,7 +56,7 @@ def test_request_call_wraps_request_exception() -> None:
     assert err.value.provider == "chembl"
     assert err.value.endpoint == "https://example.org"
     metrics.inc_counter.assert_any_call(
-        "bioetl_client_request_errors_total",
+        MetricName.CLIENT_REQUEST_ERRORS_TOTAL,
         {
             "provider": "chembl",
             "endpoint": "https://example.org",
@@ -83,7 +84,7 @@ def test_request_records_metrics_on_success() -> None:
 
     assert result is response
     metrics.inc_counter.assert_any_call(
-        "bioetl_client_request_total",
+        MetricName.CLIENT_REQUEST_TOTAL,
         {"provider": "chembl", "endpoint": "https://example.org", "status": "200"},
     )
     metrics.observe_histogram.assert_called_once()
@@ -145,6 +146,6 @@ def test_request_retries_on_server_error(monkeypatch: pytest.MonkeyPatch) -> Non
     assert result is second
     assert base_client.request.call_count == 2
     metrics.inc_counter.assert_any_call(
-        "bioetl_client_request_errors_total",
+        MetricName.CLIENT_REQUEST_ERRORS_TOTAL,
         {"provider": "chembl", "endpoint": "https://example.org", "status": "500"},
     )

--- a/tests/bioetl/infrastructure/observability/test_adapters.py
+++ b/tests/bioetl/infrastructure/observability/test_adapters.py
@@ -3,6 +3,7 @@ from bioetl.infrastructure.observability.adapters import (
     StructuredLoggerImpl,
     TracingAdapterImpl,
 )
+from bioetl.infrastructure.settings.metrics import MetricName
 
 
 def test_structured_logger_bind_and_log():
@@ -24,11 +25,11 @@ def test_tracing_adapter_noop():
 def test_prometheus_metrics_port_updates():
     port = PrometheusMetricsPortImpl()
     port.inc_counter(
-        "bioetl_client_request_total",
+        MetricName.CLIENT_REQUEST_TOTAL,
         {"provider": "chembl", "endpoint": "/e", "status": "200"},
     )
     port.observe_histogram(
-        "bioetl_client_request_duration_seconds",
+        MetricName.CLIENT_REQUEST_DURATION_SECONDS,
         0.1,
         {"provider": "chembl", "endpoint": "/e", "status": "200"},
     )

--- a/tests/bioetl/infrastructure/output/test_unified_loader.py
+++ b/tests/bioetl/infrastructure/output/test_unified_loader.py
@@ -15,6 +15,7 @@ from bioetl.infrastructure.output.converters.factories import (
 from bioetl.infrastructure.output.unified_loader_impl import (
     UnifiedLoaderImpl,
 )
+from bioetl.infrastructure.settings.metrics import MetricName
 
 
 @pytest.fixture
@@ -316,7 +317,7 @@ def test_write_result_records_metric_on_failure(
         writer_impl.load(pd.DataFrame({"a": [1]}), tmp_path, run_context_factory())
 
     metrics.inc_counter.assert_called_once_with(
-        "bioetl_output_write_errors_total",
+        MetricName.OUTPUT_WRITE_ERRORS_TOTAL,
         {"entity": "test_entity", "error_type": "ValueError"},
     )
 


### PR DESCRIPTION
… module

Create infrastructure/settings/ module with organized constants:
- http.py: HttpTimeouts, RetrySettings, ConnectionPoolSettings (frozen dataclasses)
- files.py: FileSettings for file operations (frozen dataclass)
- metrics.py: MetricName enum for Prometheus metric names

Changes:
- Move constants from infrastructure/constants.py to settings/files.py
- Update infrastructure/http/retry.py to use settings/http.py
- Update observability/metrics.py to use MetricName enum
- Update observability/adapters.py to use MetricName enum
- Update clients/base/impl/_http_transport.py to use MetricName enum
- Update output/unified_loader_impl.py to use MetricName enum
- Maintain backward compatibility via re-exports in infrastructure/constants.py
- Update tests to use MetricName enum for consistency