### PR TITLE
Extract TransformFactory from PipelineContainer

### DIFF
--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -17,6 +17,10 @@ from bioetl.application.factories.service_factory import (
     ApplicationServiceFactory,
     ApplicationServiceFactoryABC,
 )
+from bioetl.application.factories.transform_factory import (
+    TransformComponentFactory,
+    TransformComponentFactoryABC,
+)
 from bioetl.application.pipelines.hooks_impl import FailFastErrorPolicyImpl
 from bioetl.domain.clients.base.output.contracts import (
     RunMetadataBuilderProtocol,
@@ -35,7 +39,6 @@ from bioetl.domain.transform.contracts import (
     NormalizationServiceABC,
     TimestampProviderABC,
 )
-from bioetl.domain.transform.factories import default_post_transformer
 from bioetl.domain.transform.transformers import TransformerABC
 from bioetl.domain.validation import SchemaProviderABC, ValidatorFactoryABC
 from bioetl.domain.validation.service import ValidationService
@@ -51,6 +54,7 @@ class PipelineContainer(PipelineContainerABC):
         config: PipelineConfig,
         *,
         service_factory: ApplicationServiceFactoryABC | None = None,
+        transform_factory: TransformComponentFactoryABC | None = None,
         logger: LoggingPortABC | None = None,
         loader: LoaderABC | None = None,
         validator_factory: ValidatorFactoryABC | None = None,
@@ -93,7 +97,9 @@ class PipelineContainer(PipelineContainerABC):
 
         # Initialize factory helpers
         self._injected_service_factory = service_factory
+        self._injected_transform_factory = transform_factory
         self._service_factory: ApplicationServiceFactoryABC | None = None
+        self._transform_factory: TransformComponentFactoryABC | None = None
         self._record_source_factory: RecordSourceFactory | None = None
         self._hook_factory: PipelineHookFactory | None = None
 
@@ -109,6 +115,19 @@ class PipelineContainer(PipelineContainerABC):
                     metrics=self._metrics_port,
                 )
         return self._service_factory
+
+    def _get_transform_factory(self) -> TransformComponentFactoryABC:
+        if self._transform_factory is None:
+            if self._injected_transform_factory is not None:
+                self._transform_factory = self._injected_transform_factory
+            else:
+                self._transform_factory = TransformComponentFactory(
+                    self._config,
+                    hash_service=self._hash_service,
+                    index_generator=self._index_generator,
+                    timestamp_provider=self._timestamp_provider,
+                )
+        return self._transform_factory
 
     def _get_record_source_factory(self) -> RecordSourceFactory:
         if self._record_source_factory is None:
@@ -214,51 +233,36 @@ class PipelineContainer(PipelineContainerABC):
     def get_hash_service(self) -> HashServiceABC:
         """Get the hash service.
 
-        The concrete implementation must be injected from outer layers
-        (e.g. interfaces wiring or tests) to avoid application →
-        infrastructure dependencies.
+        Delegates to TransformComponentFactory.
         """
-        if self._hash_service is None:
-            raise RuntimeError("Hash service is not configured for this container")
-        return self._hash_service
+        return self._get_transform_factory().get_hash_service()
 
     def get_index_generator(self) -> IndexGeneratorABC:
         """Get the index generator.
 
-        The concrete implementation must be injected from outer layers
-        (e.g. interfaces wiring or tests) to avoid application →
-        infrastructure dependencies.
+        Delegates to TransformComponentFactory.
         """
-        if self._index_generator is None:
-            raise RuntimeError("Index generator is not configured for this container")
-        return self._index_generator
+        return self._get_transform_factory().get_index_generator()
 
     def get_timestamp_provider(self) -> TimestampProviderABC:
         """Get the timestamp provider.
 
-        The concrete implementation must be injected from outer layers
-        (e.g. interfaces wiring or tests) to avoid application →
-        infrastructure dependencies.
+        Delegates to TransformComponentFactory.
         """
-        if self._timestamp_provider is None:
-            raise RuntimeError(
-                "Timestamp provider is not configured for this container"
-            )
-        return self._timestamp_provider
+        return self._get_transform_factory().get_timestamp_provider()
 
     def get_post_transformer(
-        self, *, version_provider: Callable[[], str] | None = None
+        self, *, version_provider: Callable[[], str | None] | None = None
     ) -> TransformerABC:
-        """Собирает цепочку стандартных трансформеров."""
-        if self._post_transformer is None:
-            self._post_transformer = default_post_transformer(
-                hash_service=self.get_hash_service(),
-                index_generator=self.get_index_generator(),
-                timestamp_provider=self.get_timestamp_provider(),
-                business_key_fields=self._config.quality.hashing.business_key_fields,
-                version_provider=version_provider,
-            )
-        return self._post_transformer
+        """Build the standard post-transformer chain.
+
+        Delegates to TransformComponentFactory.
+        """
+        if self._post_transformer is not None:
+            return self._post_transformer
+        return self._get_transform_factory().get_post_transformer(
+            version_provider=version_provider
+        )
 
     def get_hooks(self) -> list[PipelineHookABC]:
         """Возвращает список хуков выполнения пайплайна."""

--- a/src/bioetl/application/factories/__init__.py
+++ b/src/bioetl/application/factories/__init__.py
@@ -17,6 +17,10 @@ from bioetl.application.factories.service_factory import (
     ApplicationServiceFactoryABC,
 )
 from bioetl.application.factories.services import ProviderServiceFactory
+from bioetl.application.factories.transform_factory import (
+    TransformComponentFactory,
+    TransformComponentFactoryABC,
+)
 
 __all__ = [
     "ApplicationServiceFactory",
@@ -24,6 +28,8 @@ __all__ = [
     "PipelineHookFactory",
     "ProviderServiceFactory",
     "RecordSourceFactory",
+    "TransformComponentFactory",
+    "TransformComponentFactoryABC",
     "create_noop_logger",
     "create_noop_metadata_builder",
     "create_noop_metrics_port",

--- a/src/bioetl/application/factories/transform_factory.py
+++ b/src/bioetl/application/factories/transform_factory.py
@@ -1,0 +1,152 @@
+"""
+Transform component factory.
+
+Provides factory for creating transform-related components
+(hash service, index generator, timestamp provider, post transformer).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Callable
+
+from bioetl.domain.configs import PipelineConfig
+from bioetl.domain.transform.contracts import (
+    HashServiceABC,
+    IndexGeneratorABC,
+    TimestampProviderABC,
+)
+from bioetl.domain.transform.factories import default_post_transformer
+from bioetl.domain.transform.transformers import TransformerABC
+
+
+class TransformComponentFactoryABC(ABC):
+    """Abstract base for transform component factories."""
+
+    @abstractmethod
+    def get_hash_service(self) -> HashServiceABC:
+        """Get the hash service."""
+
+    @abstractmethod
+    def get_index_generator(self) -> IndexGeneratorABC:
+        """Get the index generator."""
+
+    @abstractmethod
+    def get_timestamp_provider(self) -> TimestampProviderABC:
+        """Get the timestamp provider."""
+
+    @abstractmethod
+    def get_post_transformer(
+        self, *, version_provider: Callable[[], str | None] | None = None
+    ) -> TransformerABC:
+        """Get the post transformer chain."""
+
+
+class TransformComponentFactory(TransformComponentFactoryABC):
+    """
+    Factory for creating transform-related components.
+
+    Encapsulates lazy creation of hash service, index generator,
+    timestamp provider, and post transformer chain.
+
+    All components (hash_service, index_generator, timestamp_provider)
+    must be injected from outer layers (e.g. interfaces wiring or tests)
+    to maintain clean architecture boundaries.
+    """
+
+    def __init__(
+        self,
+        config: PipelineConfig,
+        hash_service: HashServiceABC | None = None,
+        index_generator: IndexGeneratorABC | None = None,
+        timestamp_provider: TimestampProviderABC | None = None,
+    ) -> None:
+        """
+        Initialize the transform component factory.
+
+        Args:
+            config: Pipeline configuration.
+            hash_service: Optional pre-configured hash service.
+            index_generator: Optional pre-configured index generator.
+            timestamp_provider: Optional pre-configured timestamp provider.
+        """
+        self._config = config
+        self._hash_service = hash_service
+        self._index_generator = index_generator
+        self._timestamp_provider = timestamp_provider
+        self._post_transformer: TransformerABC | None = None
+
+    def get_hash_service(self) -> HashServiceABC:
+        """Get the hash service.
+
+        The concrete implementation must be injected from outer layers
+        (e.g. interfaces wiring or tests) to avoid application →
+        infrastructure dependencies.
+
+        Raises:
+            RuntimeError: If hash service is not configured.
+        """
+        if self._hash_service is None:
+            raise RuntimeError("Hash service is not configured for this factory")
+        return self._hash_service
+
+    def get_index_generator(self) -> IndexGeneratorABC:
+        """Get the index generator.
+
+        The concrete implementation must be injected from outer layers
+        (e.g. interfaces wiring or tests) to avoid application →
+        infrastructure dependencies.
+
+        Raises:
+            RuntimeError: If index generator is not configured.
+        """
+        if self._index_generator is None:
+            raise RuntimeError("Index generator is not configured for this factory")
+        return self._index_generator
+
+    def get_timestamp_provider(self) -> TimestampProviderABC:
+        """Get the timestamp provider.
+
+        The concrete implementation must be injected from outer layers
+        (e.g. interfaces wiring or tests) to avoid application →
+        infrastructure dependencies.
+
+        Raises:
+            RuntimeError: If timestamp provider is not configured.
+        """
+        if self._timestamp_provider is None:
+            raise RuntimeError("Timestamp provider is not configured for this factory")
+        return self._timestamp_provider
+
+    def get_post_transformer(
+        self, *, version_provider: Callable[[], str | None] | None = None
+    ) -> TransformerABC:
+        """Build the standard post-transformer chain.
+
+        Creates a chain of transformers that add:
+        - hash_business_key and hash_row columns
+        - index column
+        - database_version column
+        - acquisition_timestamp column
+
+        Args:
+            version_provider: Optional callable returning database version.
+
+        Returns:
+            Configured transformer chain.
+        """
+        if self._post_transformer is None:
+            self._post_transformer = default_post_transformer(
+                hash_service=self.get_hash_service(),
+                index_generator=self.get_index_generator(),
+                timestamp_provider=self.get_timestamp_provider(),
+                business_key_fields=self._config.quality.hashing.business_key_fields,
+                version_provider=version_provider,
+            )
+        return self._post_transformer
+
+
+__all__ = [
+    "TransformComponentFactory",
+    "TransformComponentFactoryABC",
+]


### PR DESCRIPTION
…ontainer

Extract transform-related component creation into dedicated factory:
- Create TransformComponentFactory with get_hash_service, get_index_generator, get_timestamp_provider, get_post_transformer methods
- Create TransformComponentFactoryABC abstract base class
- Update PipelineContainer to delegate transform methods to factory
- Support both injected factory and lazy instantiation with injected components