### PR TITLE
Extract Pipeline Identity into separate aggregate

### DIFF
--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -22,6 +22,7 @@ Tabular Data Abstractions:
     Import from ``bioetl.domain.data`` for tabular data protocols.
 """
 
+from bioetl.domain.aggregates import PipelineIdentity
 from bioetl.domain.data import (
     MutableTabularData,
     Record,
@@ -50,7 +51,7 @@ from bioetl.domain.types import (
     RawRecord,
     RecordBatch,
 )
-from bioetl.domain.value_objects import ChemblId, EntityName, RunId
+from bioetl.domain.value_objects import ChemblId, EntityName, PipelineId, RunId
 
 __all__ = [
     # Tabular data abstractions
@@ -76,7 +77,10 @@ __all__ = [
     # Value objects
     "ChemblId",
     "EntityName",
+    "PipelineId",
     "RunId",
+    # Aggregates
+    "PipelineIdentity",
     # Record source
     "InMemoryRecordSource",
     "RecordSourceABC",

--- a/src/bioetl/domain/aggregates/__init__.py
+++ b/src/bioetl/domain/aggregates/__init__.py
@@ -1,0 +1,5 @@
+"""Domain aggregates."""
+
+from bioetl.domain.aggregates.pipeline_identity import PipelineIdentity
+
+__all__ = ["PipelineIdentity"]

--- a/src/bioetl/domain/aggregates/pipeline_identity.py
+++ b/src/bioetl/domain/aggregates/pipeline_identity.py
@@ -1,0 +1,49 @@
+"""Pipeline Identity aggregate root.
+
+This module defines the PipelineIdentity aggregate which represents
+the immutable identity and metadata of a data pipeline.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from bioetl.domain.providers import ProviderId
+from bioetl.domain.value_objects import EntityName, PipelineId
+
+
+@dataclass(frozen=True)
+class PipelineIdentity:
+    """Domain aggregate for pipeline identification.
+
+    Encapsulates all information needed to uniquely identify a pipeline
+    and its data domain. This is an immutable value aggregate that serves
+    as the identity component of a pipeline configuration.
+
+    Attributes:
+        pipeline_id: Unique identifier for the pipeline instance.
+        provider: Data provider identifier (e.g., "chembl", "uniprot").
+        entity: Type of entity being processed (e.g., "activity", "target").
+        primary_key: Tuple of field names forming the primary key for deduplication.
+
+    Invariants:
+        - All fields are immutable (frozen dataclass)
+        - pipeline_id, provider, and entity are required and non-empty
+        - provider must be a valid ProviderId enum value
+        - entity must be a valid EntityName (snake_case)
+        - primary_key is a tuple (immutable sequence)
+    """
+
+    pipeline_id: PipelineId
+    provider: ProviderId
+    entity: EntityName
+    primary_key: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        """Validate aggregate invariants."""
+        if not isinstance(self.primary_key, tuple):
+            # Ensure primary_key is always a tuple (defensive)
+            object.__setattr__(self, "primary_key", tuple(self.primary_key))
+
+
+__all__ = ["PipelineIdentity"]

--- a/src/bioetl/domain/configs/identity.py
+++ b/src/bioetl/domain/configs/identity.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+if TYPE_CHECKING:
+    from bioetl.domain.aggregates.pipeline_identity import PipelineIdentity
 
 
 class PipelineIdentityConfig(BaseModel):
@@ -10,6 +15,10 @@ class PipelineIdentityConfig(BaseModel):
 
     Groups fields that identify the pipeline and its data domain.
     This is a frozen immutable model for thread-safety and hashability.
+
+    This is a Pydantic config model that uses primitive types (str)
+    for serialization compatibility. Use to_domain() to convert to
+    the rich domain model with Value Objects.
 
     Attributes:
         pipeline_id: Unique identifier for the pipeline run.
@@ -30,15 +39,22 @@ class PipelineIdentityConfig(BaseModel):
     @field_validator("pipeline_id")
     @classmethod
     def validate_pipeline_id_not_empty(cls, value: str) -> str:
-        """Ensure pipeline_id is not empty."""
-        if not value or not value.strip():
-            raise ValueError("pipeline_id must be a non-empty string")
+        """Ensure pipeline_id is not empty and validate via PipelineId."""
+        # Lazy import to avoid circular dependency
+        from bioetl.domain.value_objects import PipelineId
+
+        # Validation through value object (will raise if invalid)
+        PipelineId(value)
         return value.strip()
 
     @field_validator("provider")
     @classmethod
     def validate_provider_known(cls, value: str) -> str:
-        """Ensure provider identifier is known to the registry."""
+        """Ensure provider identifier is known to the registry.
+
+        Uses lazy import to avoid circular dependencies with providers module.
+        """
+        # Lazy import to avoid circular dependency
         from bioetl.domain.providers import ProviderId
 
         known = {provider.value for provider in ProviderId}
@@ -48,10 +64,16 @@ class PipelineIdentityConfig(BaseModel):
 
     @field_validator("entity")
     @classmethod
-    def validate_entity_not_empty(cls, value: str) -> str:
-        """Ensure entity is not empty."""
-        if not value or not value.strip():
-            raise ValueError("entity must be a non-empty string")
+    def validate_entity_format(cls, value: str) -> str:
+        """Ensure entity follows EntityName format (snake_case).
+
+        Uses lazy import to avoid circular dependencies.
+        """
+        # Lazy import to avoid circular dependency
+        from bioetl.domain.value_objects import EntityName
+
+        # Validation through value object (will raise if invalid)
+        EntityName(value)
         return value.strip()
 
     @field_validator("primary_key", mode="before")
@@ -63,6 +85,35 @@ class PipelineIdentityConfig(BaseModel):
         if isinstance(value, str):
             return [value] if value else []
         return list(value)
+
+    def to_domain(self) -> PipelineIdentity:
+        """Convert to domain value object aggregate.
+
+        Returns:
+            PipelineIdentity: Rich domain model with Value Objects.
+
+        Example:
+            >>> config = PipelineIdentityConfig(
+            ...     pipeline_id="chembl_activity_v1",
+            ...     provider="chembl",
+            ...     entity="activity",
+            ...     primary_key=["activity_id"]
+            ... )
+            >>> identity = config.to_domain()
+            >>> isinstance(identity.pipeline_id, PipelineId)
+            True
+        """
+        # Lazy imports to avoid circular dependencies
+        from bioetl.domain.aggregates.pipeline_identity import PipelineIdentity
+        from bioetl.domain.providers import ProviderId
+        from bioetl.domain.value_objects import EntityName, PipelineId
+
+        return PipelineIdentity(
+            pipeline_id=PipelineId(self.pipeline_id),
+            provider=ProviderId(self.provider),
+            entity=EntityName(self.entity),
+            primary_key=tuple(self.primary_key),
+        )
 
 
 __all__ = ["PipelineIdentityConfig"]

--- a/src/bioetl/domain/value_objects.py
+++ b/src/bioetl/domain/value_objects.py
@@ -107,6 +107,52 @@ class EntityName:
         )
 
 
+class PipelineId:
+    """Value Object для идентификатора pipeline."""
+
+    __slots__ = ("_value",)
+    _max_length = 128
+
+    def __init__(self, value: str) -> None:
+        if not value or not value.strip():
+            raise ValueError("PipelineId must be a non-empty string")
+        normalized = value.strip()
+        if len(normalized) > self._max_length:
+            raise ValueError(
+                f"PipelineId too long: {len(normalized)} > {self._max_length}"
+            )
+        self._value = normalized
+
+    @property
+    def value(self) -> str:
+        """String representation of PipelineId."""
+        return self._value
+
+    def __str__(self) -> str:
+        return self._value
+
+    def __repr__(self) -> str:
+        return f"PipelineId({self._value!r})"
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, PipelineId):
+            return self._value == other._value
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(self._value)
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: type, handler: GetCoreSchemaHandler
+    ) -> CoreSchema:
+        return core_schema.no_info_after_validator_function(
+            cls,
+            core_schema.str_schema(),
+            serialization=core_schema.plain_serializer_function_ser_schema(str),
+        )
+
+
 class ChemblId:
     """Value Object для ChEMBL идентификатора (формат CHEMBL123)."""
 


### PR DESCRIPTION
Extract PipelineIdentity into a dedicated domain aggregate with proper Value Objects, improving type safety and domain modeling.

Changes:
- Add PipelineId value object to domain/value_objects.py
- Create domain/aggregates/pipeline_identity.py with PipelineIdentity aggregate
- Update PipelineIdentityConfig.to_domain() to convert to rich domain model
- Enhance validators to use Value Objects (PipelineId, EntityName)
- Add lazy imports to avoid circular dependencies
- Export PipelineId and PipelineIdentity from domain package

Benefits:
- Type safety: pipeline_id, provider, entity now use Value Objects
- Domain clarity: separate config (Pydantic) from domain (immutable aggregate)
- Validation: enforced through Value Object constructors
- Immutability: PipelineIdentity is frozen dataclass with tuple primary_key

Migration path:
- Config layer uses str for Pydantic compatibility
- Domain layer uses Value Objects via to_domain()
- No breaking changes to existing PipelineIdentityConfig API