### PR TITLE
Create unified HTTP error handler

### DIFF
--- a/src/bioetl/infrastructure/clients/base/factories.py
+++ b/src/bioetl/infrastructure/clients/base/factories.py
@@ -19,6 +19,10 @@ from bioetl.domain.clients.base.contracts import (
 from bioetl.domain.configs import HttpClientConfig
 from bioetl.domain.observability import LoggingPortABC, MetricsPortABC
 from bioetl.domain.ports.parsing import ResponseParserPortABC
+from bioetl.infrastructure.clients.base.http_error_handler import (
+    DefaultHttpErrorHandler,
+    HttpErrorHandlerABC,
+)
 from bioetl.infrastructure.clients.base.impl._http_transport import _HttpTransport
 from bioetl.infrastructure.clients.base.impl.cache import MemoryCacheImpl
 from bioetl.infrastructure.clients.base.impl.rate_limiter import (
@@ -166,6 +170,7 @@ def build_http_client(
     *,
     config: HttpClientConfig | None = None,
     base_client: Any | None = None,
+    error_handler: HttpErrorHandlerABC | None = None,
 ) -> _HttpTransport:
     """Construct HTTP client using HttpClientConfig.
 
@@ -175,16 +180,19 @@ def build_http_client(
         metrics: Required metrics instance
         config: Optional HTTP config
         base_client: Optional pre-configured HTTP client
+        error_handler: Optional HTTP error handler (defaults to DefaultHttpErrorHandler)
 
     Returns:
         Configured HTTP transport
     """
     resolved_config = _ensure_http_config(config)
     resolved_client = base_client if base_client is not None else requests.Session()
+    resolved_error_handler = error_handler or DefaultHttpErrorHandler(logger)
     return _HttpTransport(
         provider=provider,
         config=resolved_config,
         base_client=resolved_client,
         logger=logger,
         metrics=metrics,
+        error_handler=resolved_error_handler,
     )

--- a/src/bioetl/infrastructure/clients/base/http_error_handler.py
+++ b/src/bioetl/infrastructure/clients/base/http_error_handler.py
@@ -1,0 +1,224 @@
+"""
+HTTP error handler abstractions and implementations.
+
+Provides unified error classification and handling for HTTP responses.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from bioetl.domain.errors import ClientRateLimitError
+from bioetl.domain.observability import LoggingPortABC
+from bioetl.infrastructure.errors import ApiClientError, ApiUnexpectedStatusError
+
+
+class ErrorCategory(Enum):
+    """Categories of HTTP errors for classification."""
+
+    RATE_LIMIT = "rate_limit"
+    SERVER_ERROR = "server_error"
+    CLIENT_ERROR = "client_error"
+    SUCCESS = "success"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class RequestContext:
+    """Context information for an HTTP request."""
+
+    provider: str
+    endpoint: str
+    status_code: int | None
+    method: str = "GET"
+    response_body: str | None = None
+
+
+class HttpErrorHandlerABC(ABC):
+    """
+    Abstract base class for HTTP error handling.
+
+    Provides unified interface for classifying and handling HTTP errors
+    across different client implementations.
+    """
+
+    @abstractmethod
+    def handle(self, response: Any, context: RequestContext) -> ApiClientError | None:
+        """
+        Handle HTTP response and return appropriate error if needed.
+
+        Args:
+            response: HTTP response object
+            context: Request context with provider, endpoint, status_code
+
+        Returns:
+            ApiClientError subclass if error detected, None if successful response
+        """
+        ...
+
+    @abstractmethod
+    def classify_error(self, status_code: int) -> ErrorCategory:
+        """
+        Classify HTTP status code into error category.
+
+        Args:
+            status_code: HTTP status code
+
+        Returns:
+            ErrorCategory enum value
+        """
+        ...
+
+
+class DefaultHttpErrorHandler(HttpErrorHandlerABC):
+    """
+    Default implementation of HTTP error handler.
+
+    Classification logic:
+    - 429 → RateLimitError
+    - 5xx → RetryableServerError (as ApiUnexpectedStatusError)
+    - 4xx → ClientError with details
+    - 2xx/3xx → Success (no error)
+    """
+
+    def __init__(self, logger: LoggingPortABC | None = None) -> None:
+        """
+        Initialize error handler.
+
+        Args:
+            logger: Optional logger for error details
+        """
+        self.logger = logger
+
+    def handle(self, response: Any, context: RequestContext) -> ApiClientError | None:
+        """
+        Handle HTTP response and return appropriate error if needed.
+
+        Args:
+            response: HTTP response object (expected to have status_code attribute)
+            context: Request context
+
+        Returns:
+            ApiClientError subclass if error, None otherwise
+        """
+        status_code = context.status_code
+        if status_code is None:
+            raw_status = getattr(response, "status_code", None)
+            status_code = raw_status if isinstance(raw_status, int) else None
+
+        if status_code is None:
+            return None
+
+        category = self.classify_error(status_code)
+
+        if category == ErrorCategory.SUCCESS:
+            return None
+
+        if category == ErrorCategory.RATE_LIMIT:
+            return self._create_rate_limit_error(context)
+
+        if category == ErrorCategory.SERVER_ERROR:
+            return self._create_server_error(context)
+
+        if category == ErrorCategory.CLIENT_ERROR:
+            return self._create_client_error(context)
+
+        return self._create_generic_error(context)
+
+    def classify_error(self, status_code: int) -> ErrorCategory:
+        """
+        Classify HTTP status code into error category.
+
+        Args:
+            status_code: HTTP status code
+
+        Returns:
+            ErrorCategory enum value
+        """
+        if 200 <= status_code < 400:
+            return ErrorCategory.SUCCESS
+
+        if status_code == 429:
+            return ErrorCategory.RATE_LIMIT
+
+        if 500 <= status_code < 600:
+            return ErrorCategory.SERVER_ERROR
+
+        if 400 <= status_code < 500:
+            return ErrorCategory.CLIENT_ERROR
+
+        return ErrorCategory.UNKNOWN
+
+    def _create_rate_limit_error(self, context: RequestContext) -> ClientRateLimitError:
+        """Create rate limit error."""
+        self._log_error("rate_limit_error", context)
+        return ClientRateLimitError(
+            provider=context.provider,
+            message=f"Rate limit exceeded (HTTP {context.status_code})",
+            endpoint=context.endpoint,
+            status_code=context.status_code,
+        )
+
+    def _create_server_error(self, context: RequestContext) -> ApiUnexpectedStatusError:
+        """Create server error (5xx)."""
+        self._log_error("server_error", context)
+        return ApiUnexpectedStatusError(
+            f"Server error: {context.status_code}",
+            provider=context.provider,
+            endpoint=context.endpoint,
+            status_code=context.status_code,
+        )
+
+    def _create_client_error(self, context: RequestContext) -> ApiUnexpectedStatusError:
+        """Create client error (4xx)."""
+        self._log_error("client_error", context)
+        detail = self._get_client_error_detail(context.status_code)
+        return ApiUnexpectedStatusError(
+            f"Client error ({detail}): {context.status_code}",
+            provider=context.provider,
+            endpoint=context.endpoint,
+            status_code=context.status_code,
+        )
+
+    def _create_generic_error(self, context: RequestContext) -> ApiClientError:
+        """Create generic error for unknown status codes."""
+        self._log_error("unknown_error", context)
+        return ApiClientError(
+            f"Unexpected status code: {context.status_code}",
+            provider=context.provider,
+            endpoint=context.endpoint,
+            status_code=context.status_code,
+        )
+
+    def _get_client_error_detail(self, status_code: int | None) -> str:
+        """Get human-readable detail for client error status codes."""
+        details = {
+            400: "Bad Request",
+            401: "Unauthorized",
+            403: "Forbidden",
+            404: "Not Found",
+            405: "Method Not Allowed",
+            406: "Not Acceptable",
+            408: "Request Timeout",
+            409: "Conflict",
+            410: "Gone",
+            422: "Unprocessable Entity",
+            429: "Too Many Requests",
+        }
+        return details.get(status_code or 0, "Unknown Client Error")
+
+    def _log_error(self, event: str, context: RequestContext) -> None:
+        """Log error details if logger is available."""
+        if self.logger is None:
+            return
+
+        self.logger.error(
+            event,
+            provider=context.provider,
+            endpoint=context.endpoint,
+            status_code=context.status_code,
+            method=context.method,
+        )

--- a/src/bioetl/infrastructure/clients/base/impl/_http_transport.py
+++ b/src/bioetl/infrastructure/clients/base/impl/_http_transport.py
@@ -12,6 +12,11 @@ import requests
 
 from bioetl.domain.configs import HttpClientConfig
 from bioetl.domain.observability import LoggingPortABC, MetricsPortABC
+from bioetl.infrastructure.clients.base.http_error_handler import (
+    DefaultHttpErrorHandler,
+    HttpErrorHandlerABC,
+    RequestContext,
+)
 from bioetl.infrastructure.errors import (
     ApiClientError,
     ApiTimeoutError,
@@ -38,12 +43,14 @@ class _HttpTransport:
         base_client: Any,
         logger: LoggingPortABC,
         metrics: MetricsPortABC,
+        error_handler: HttpErrorHandlerABC | None = None,
     ) -> None:
         self.provider = provider
         self.config = config
         self.base_client = base_client
         self.logger = logger
         self.metrics = metrics
+        self.error_handler = error_handler or DefaultHttpErrorHandler(logger)
         attempts = max(1, int(config.max_retries) + 1)
         self.retry_policy = (
             ExponentialRetryPolicy(
@@ -86,10 +93,20 @@ class _HttpTransport:
                     raw_status if isinstance(raw_status, int) else None
                 )
                 status_label = self._normalize_status(context["status_code"])
+
+                # Use unified error handler
+                request_context = RequestContext(
+                    provider=self.provider,
+                    endpoint=url,
+                    status_code=context["status_code"],
+                    method=method_upper,
+                )
+                error = self.error_handler.handle(response, request_context)
+
                 log_method = (
                     self.logger.error
                     if context["status_code"] is not None
-                    and context["status_code"] >= 500
+                    and context["status_code"] >= 400
                     else self.logger.info
                 )
                 log_method(
@@ -100,13 +117,10 @@ class _HttpTransport:
                     status_code=context["status_code"],
                     latency_sec=time.monotonic() - start,
                 )
-                if context["status_code"] is not None and context["status_code"] >= 500:
-                    raise ApiUnexpectedStatusError(
-                        f"Unexpected status code: {context['status_code']}",
-                        provider=self.provider,
-                        endpoint=url,
-                        status_code=context["status_code"],
-                    )
+
+                if error is not None:
+                    raise error
+
                 return response
         except Exception as exc:
             status_label = self._status_from_exception(status_label, exc)

--- a/src/bioetl/infrastructure/clients/chembl/factories.py
+++ b/src/bioetl/infrastructure/clients/chembl/factories.py
@@ -16,6 +16,9 @@ from bioetl.infrastructure.clients.base.factories import (
     build_http_client,
     build_rate_limiter,
 )
+from bioetl.infrastructure.clients.base.http_error_handler import (
+    DefaultHttpErrorHandler,
+)
 from bioetl.infrastructure.clients.chembl.impl.chembl_extraction_service_impl import (
     ChemblExtractionServiceImpl,
 )
@@ -69,6 +72,9 @@ def default_chembl_client(
     # Rate limiter for proactive limiting
     rate_limiter = build_rate_limiter(logger, config=resolved_config)
 
+    # Create unified error handler
+    error_handler = DefaultHttpErrorHandler(logger)
+
     return ChemblHttpClientImpl(
         request_builder=ChemblRequestBuilderImpl(
             base_url=base_url,
@@ -80,6 +86,7 @@ def default_chembl_client(
         logger=logger,
         provider="chembl",
         fallbacks=source_config.fallbacks or {},
+        error_handler=error_handler,
     )
 
 

--- a/src/bioetl/infrastructure/clients/chembl/impl/chembl_http_client_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/chembl_http_client_impl.py
@@ -14,6 +14,11 @@ from bioetl.domain.clients.base.contracts import (
 from bioetl.domain.ports.parsing import ResponseParserPortABC
 from bioetl.domain.clients.contracts import DataClientABC
 from bioetl.domain.observability import LoggingPortABC
+from bioetl.infrastructure.clients.base.http_error_handler import (
+    DefaultHttpErrorHandler,
+    HttpErrorHandlerABC,
+    RequestContext,
+)
 from bioetl.infrastructure.clients.chembl.constants import resolve_endpoint
 from bioetl.infrastructure.clients.chembl.paginator import ChemblPaginatorImpl
 from bioetl.infrastructure.errors import (
@@ -41,6 +46,7 @@ class ChemblHttpClientImpl(DataClientABC):
         *,
         provider: str = "chembl",
         fallbacks: dict[str, list[str]] | None = None,
+        error_handler: HttpErrorHandlerABC | None = None,
     ) -> None:
         self.request_builder = request_builder
         self.response_parser = response_parser
@@ -51,6 +57,7 @@ class ChemblHttpClientImpl(DataClientABC):
         self._fallbacks = fallbacks if fallbacks is not None else {}
         self._last_endpoint_used: str | None = None
         self.provider = provider
+        self.error_handler = error_handler or DefaultHttpErrorHandler(logger)
 
     def iter_pages(self, request: Any) -> Iterator[Any]:
         """Iterate over paginated responses for a built request."""
@@ -127,6 +134,16 @@ class ChemblHttpClientImpl(DataClientABC):
             raw_status = getattr(response, "status_code", None)
             status_code = raw_status if isinstance(raw_status, int) else None
             context["status_code"] = status_code
+
+            # Use unified error handler
+            request_context = RequestContext(
+                provider=self.provider,
+                endpoint=url,
+                status_code=status_code,
+                method="GET",
+            )
+            error = self.error_handler.handle(response, request_context)
+
             log_level = (
                 self.logger.error
                 if status_code is not None and status_code >= 400
@@ -140,19 +157,10 @@ class ChemblHttpClientImpl(DataClientABC):
                 status_code=status_code,
                 latency_sec=latency,
             )
-            if status_code is not None and status_code >= 400:
-                self.logger.error(
-                    "api_unexpected_status",
-                    provider=self.provider,
-                    url=url,
-                    status_code=status_code,
-                )
-                raise ApiUnexpectedStatusError(
-                    f"Unexpected status code: {status_code}",
-                    provider=self.provider,
-                    endpoint=url,
-                    status_code=status_code,
-                )
+
+            if error is not None:
+                raise error
+
             return response.json()
 
     def _build_request_url(self, endpoint: str, filters: dict[str, Any]) -> str:

--- a/tests/bioetl/infrastructure/clients/base/test_http_error_handler.py
+++ b/tests/bioetl/infrastructure/clients/base/test_http_error_handler.py
@@ -1,0 +1,195 @@
+"""Tests for unified HTTP error handler."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from bioetl.domain.errors import ClientRateLimitError
+from bioetl.infrastructure.clients.base.http_error_handler import (
+    DefaultHttpErrorHandler,
+    ErrorCategory,
+    RequestContext,
+)
+from bioetl.infrastructure.errors import ApiClientError, ApiUnexpectedStatusError
+
+
+class TestErrorCategory:
+    """Test ErrorCategory enum."""
+
+    def test_error_categories_exist(self):
+        """Test that all expected categories exist."""
+        assert ErrorCategory.RATE_LIMIT.value == "rate_limit"
+        assert ErrorCategory.SERVER_ERROR.value == "server_error"
+        assert ErrorCategory.CLIENT_ERROR.value == "client_error"
+        assert ErrorCategory.SUCCESS.value == "success"
+        assert ErrorCategory.UNKNOWN.value == "unknown"
+
+
+class TestDefaultHttpErrorHandler:
+    """Test DefaultHttpErrorHandler implementation."""
+
+    def test_classify_error_success(self):
+        """Test classification of successful status codes."""
+        handler = DefaultHttpErrorHandler()
+
+        assert handler.classify_error(200) == ErrorCategory.SUCCESS
+        assert handler.classify_error(201) == ErrorCategory.SUCCESS
+        assert handler.classify_error(204) == ErrorCategory.SUCCESS
+        assert handler.classify_error(301) == ErrorCategory.SUCCESS
+        assert handler.classify_error(302) == ErrorCategory.SUCCESS
+
+    def test_classify_error_rate_limit(self):
+        """Test classification of rate limit status code."""
+        handler = DefaultHttpErrorHandler()
+
+        assert handler.classify_error(429) == ErrorCategory.RATE_LIMIT
+
+    def test_classify_error_server_errors(self):
+        """Test classification of 5xx server errors."""
+        handler = DefaultHttpErrorHandler()
+
+        assert handler.classify_error(500) == ErrorCategory.SERVER_ERROR
+        assert handler.classify_error(502) == ErrorCategory.SERVER_ERROR
+        assert handler.classify_error(503) == ErrorCategory.SERVER_ERROR
+        assert handler.classify_error(504) == ErrorCategory.SERVER_ERROR
+
+    def test_classify_error_client_errors(self):
+        """Test classification of 4xx client errors."""
+        handler = DefaultHttpErrorHandler()
+
+        assert handler.classify_error(400) == ErrorCategory.CLIENT_ERROR
+        assert handler.classify_error(401) == ErrorCategory.CLIENT_ERROR
+        assert handler.classify_error(403) == ErrorCategory.CLIENT_ERROR
+        assert handler.classify_error(404) == ErrorCategory.CLIENT_ERROR
+        assert handler.classify_error(422) == ErrorCategory.CLIENT_ERROR
+
+    def test_classify_error_unknown(self):
+        """Test classification of unknown status codes."""
+        handler = DefaultHttpErrorHandler()
+
+        assert handler.classify_error(100) == ErrorCategory.UNKNOWN
+        assert handler.classify_error(600) == ErrorCategory.UNKNOWN
+
+    def test_handle_success_response(self):
+        """Test that successful responses return None."""
+        handler = DefaultHttpErrorHandler()
+        response = Mock(status_code=200)
+        context = RequestContext(
+            provider="test",
+            endpoint="https://api.example.com/data",
+            status_code=200,
+        )
+
+        error = handler.handle(response, context)
+
+        assert error is None
+
+    def test_handle_rate_limit_error(self):
+        """Test handling of rate limit error (429)."""
+        handler = DefaultHttpErrorHandler()
+        response = Mock(status_code=429)
+        context = RequestContext(
+            provider="test",
+            endpoint="https://api.example.com/data",
+            status_code=429,
+        )
+
+        error = handler.handle(response, context)
+
+        assert isinstance(error, ClientRateLimitError)
+        assert error.status_code == 429
+        assert error.provider == "test"
+        assert error.endpoint == "https://api.example.com/data"
+
+    def test_handle_server_error(self):
+        """Test handling of server errors (5xx)."""
+        handler = DefaultHttpErrorHandler()
+        response = Mock(status_code=500)
+        context = RequestContext(
+            provider="test",
+            endpoint="https://api.example.com/data",
+            status_code=500,
+        )
+
+        error = handler.handle(response, context)
+
+        assert isinstance(error, ApiUnexpectedStatusError)
+        assert error.status_code == 500
+        assert error.provider == "test"
+        assert "Server error" in str(error)
+
+    def test_handle_client_error(self):
+        """Test handling of client errors (4xx)."""
+        handler = DefaultHttpErrorHandler()
+        response = Mock(status_code=404)
+        context = RequestContext(
+            provider="test",
+            endpoint="https://api.example.com/data",
+            status_code=404,
+        )
+
+        error = handler.handle(response, context)
+
+        assert isinstance(error, ApiUnexpectedStatusError)
+        assert error.status_code == 404
+        assert error.provider == "test"
+        assert "Client error" in str(error)
+
+    def test_handle_with_logger(self):
+        """Test that errors are logged when logger is provided."""
+        logger = Mock()
+        handler = DefaultHttpErrorHandler(logger)
+        response = Mock(status_code=500)
+        context = RequestContext(
+            provider="test",
+            endpoint="https://api.example.com/data",
+            status_code=500,
+            method="GET",
+        )
+
+        error = handler.handle(response, context)
+
+        assert isinstance(error, ApiUnexpectedStatusError)
+        logger.error.assert_called_once()
+        call_args = logger.error.call_args
+        assert call_args[0][0] == "server_error"
+
+    def test_handle_status_code_from_response(self):
+        """Test that status code is extracted from response if not in context."""
+        handler = DefaultHttpErrorHandler()
+        response = Mock(status_code=404)
+        context = RequestContext(
+            provider="test",
+            endpoint="https://api.example.com/data",
+            status_code=None,  # Not provided in context
+        )
+
+        error = handler.handle(response, context)
+
+        assert isinstance(error, ApiUnexpectedStatusError)
+        assert error.status_code == 404
+
+    def test_handle_none_status_code(self):
+        """Test handling when status code is None."""
+        handler = DefaultHttpErrorHandler()
+        response = Mock(spec=[])  # No status_code attribute
+        context = RequestContext(
+            provider="test",
+            endpoint="https://api.example.com/data",
+            status_code=None,
+        )
+
+        error = handler.handle(response, context)
+
+        assert error is None
+
+    def test_client_error_details(self):
+        """Test that client error details are human-readable."""
+        handler = DefaultHttpErrorHandler()
+
+        assert handler._get_client_error_detail(400) == "Bad Request"
+        assert handler._get_client_error_detail(401) == "Unauthorized"
+        assert handler._get_client_error_detail(403) == "Forbidden"
+        assert handler._get_client_error_detail(404) == "Not Found"
+        assert handler._get_client_error_detail(429) == "Too Many Requests"
+        assert handler._get_client_error_detail(999) == "Unknown Client Error"


### PR DESCRIPTION
Created HttpErrorHandlerABC abstract class and DefaultHttpErrorHandler implementation to consolidate HTTP error handling logic that was duplicated across _http_transport.py and chembl_http_client_impl.py.

Key changes:
- Added http_error_handler.py with abstract base class and default implementation
- Implemented error classification logic:
  * 429 → ClientRateLimitError
  * 5xx → ApiUnexpectedStatusError (retryable server error)
  * 4xx → ApiUnexpectedStatusError (client error with details)
  * 2xx/3xx → Success (no error)
- Integrated error handler into both HTTP clients via DI
- Updated factories to inject DefaultHttpErrorHandler
- Added comprehensive unit tests for error handler

This reduces code duplication and makes error handling consistent and extensible across all HTTP clients.