### PR TITLE
Merge source and sink into DataFlow aggregate

### DIFF
--- a/src/bioetl/domain/configs/__init__.py
+++ b/src/bioetl/domain/configs/__init__.py
@@ -28,6 +28,7 @@ from bioetl.domain.configs.defaults import (
 )
 
 # Bounded context configs
+from bioetl.domain.configs.data_flow import DataFlowConfig
 from bioetl.domain.configs.identity import PipelineIdentityConfig
 from bioetl.domain.configs.normalization import NormalizationConfig
 
@@ -71,6 +72,7 @@ from bioetl.domain.configs._compat import __all__ as _COMPAT_ALL
 __all__ = [
     # Bounded context configs (new modular structure)
     "PipelineIdentityConfig",
+    "DataFlowConfig",
     "DataSourceConfig",
     "DataSinkConfig",
     "OutputOptionsConfig",

--- a/src/bioetl/domain/configs/data_flow.py
+++ b/src/bioetl/domain/configs/data_flow.py
@@ -1,0 +1,72 @@
+"""Data flow configuration - aggregate for source and sink."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+from bioetl.domain.configs.sink import DataSinkConfig
+from bioetl.domain.configs.source import DataSourceConfig
+
+
+class DataFlowConfig(BaseModel):
+    """Aggregate for data source and destination configuration.
+
+    Groups DataSourceConfig and DataSinkConfig into a single bounded context
+    representing the complete data flow: where data comes from and where it goes.
+
+    This aggregate enforces consistency constraints between source and sink,
+    such as preventing output to the same file as input.
+
+    Attributes:
+        source: Data source configuration (input_mode, input_path, batch_size, csv).
+        sink: Data sink configuration (output_path, dry_run, output options).
+    """
+
+    source: DataSourceConfig
+    sink: DataSinkConfig
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    @model_validator(mode="after")
+    def validate_flow_consistency(self) -> DataFlowConfig:
+        """Ensure source and sink are compatible.
+
+        Validates that:
+        - Input and output paths don't point to the same file (when applicable)
+        - Other cross-cutting constraints between source and sink
+
+        Returns:
+            Self if validation passes.
+
+        Raises:
+            ValueError: If source and sink configuration is inconsistent.
+        """
+        # Prevent writing to the same file we're reading from
+        if self.source.input_path and self.source.input_mode in ("csv", "id_only"):
+            input_path = Path(self.source.input_path).resolve()
+            output_path = Path(self.sink.output_path).resolve()
+
+            # Check if output path is the same file as input
+            if input_path == output_path:
+                raise ValueError(
+                    f"Output path cannot be the same as input path: {input_path}"
+                )
+
+            # Check if output is inside a directory that is the input file
+            # (shouldn't happen, but defensive check)
+            try:
+                output_path.relative_to(input_path)
+                if input_path.is_file():
+                    raise ValueError(
+                        f"Output path cannot be inside input file path: {input_path}"
+                    )
+            except ValueError:
+                # Not a relative path, which is fine
+                pass
+
+        return self
+
+
+__all__ = ["DataFlowConfig"]

--- a/src/bioetl/domain/configs/pipeline.py
+++ b/src/bioetl/domain/configs/pipeline.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from bioetl.domain.transform.contracts import NormalizationConfigProviderProtocol
 
 # Import bounded context configs
+from bioetl.domain.configs.data_flow import DataFlowConfig
 from bioetl.domain.configs.identity import PipelineIdentityConfig
 from bioetl.domain.configs.normalization import NormalizationConfig
 from bioetl.domain.configs.sink import DataSinkConfig, OutputOptionsConfig
@@ -536,10 +537,13 @@ class PipelineConfig(BaseModel):
         - Removed 20+ backward compatibility property accessors
         - Only convenience accessors for entity and provider remain
 
+    Breaking Changes (v2.1):
+        - source and sink are now grouped into data_flow section
+        - Backward compatibility via .source and .sink properties
+
     Sections:
         identity: Pipeline identification (pipeline_id, provider, entity, primary_key)
-        source: Data source settings (input_mode, input_path, batch_size, csv)
-        sink: Data sink settings (output_path, dry_run, output options)
+        data_flow: Data flow settings (source + sink aggregate)
         stages: Pipeline stage flags (extract, transform, load)
         runtime: Execution settings (pagination, http, storage)
         observability: Logging and metrics
@@ -547,12 +551,15 @@ class PipelineConfig(BaseModel):
         features: Feature flags
         transform: Transform stage settings
         provider_config: Provider-specific configuration
+
+    Backward Compatibility:
+        .source -> data_flow.source
+        .sink -> data_flow.sink
     """
 
     # Core bounded context configs
     identity: PipelineIdentityConfig
-    source: DataSourceConfig
-    sink: DataSinkConfig
+    data_flow: DataFlowConfig
     stages: PipelineStagesConfig = Field(default_factory=PipelineStagesConfig)
 
     # Existing structured sections
@@ -569,6 +576,28 @@ class PipelineConfig(BaseModel):
     fields: list[dict[str, Any]] = Field(default_factory=list)
 
     model_config = ConfigDict(extra="forbid")
+
+    # =========================================================================
+    # Backward compatibility properties for data_flow decomposition
+    # =========================================================================
+
+    @property
+    def source(self) -> DataSourceConfig:
+        """Access source from data_flow section.
+
+        Backward compatibility property for v2.0 code that accessed
+        config.source directly.
+        """
+        return self.data_flow.source
+
+    @property
+    def sink(self) -> DataSinkConfig:
+        """Access sink from data_flow section.
+
+        Backward compatibility property for v2.0 code that accessed
+        config.sink directly.
+        """
+        return self.data_flow.sink
 
     # =========================================================================
     # Convenience accessors (minimal, no backward compatibility)
@@ -686,6 +715,7 @@ __all__ = [
     "PipelineConfig",
     # Bounded context configs (re-exported for convenience)
     "PipelineIdentityConfig",
+    "DataFlowConfig",
     "DataSourceConfig",
     "DataSinkConfig",
     "OutputOptionsConfig",

--- a/src/bioetl/infrastructure/config/migration.py
+++ b/src/bioetl/infrastructure/config/migration.py
@@ -25,8 +25,9 @@ class ConfigMigrator:
 
     This class handles backward compatibility by converting:
     - Flat fields (id, provider, entity) -> identity section
-    - Flat fields (input_mode, input_path, batch_size) -> source section
-    - Flat fields (output_path, dry_run) -> sink section
+    - Flat fields (input_mode, input_path, batch_size) -> data_flow.source section
+    - Flat fields (output_path, dry_run) -> data_flow.sink section
+    - Legacy source/sink sections -> data_flow aggregate
     - Legacy pipeline dict -> stages section
     - Flat observability fields -> observability section
     - Flat quality fields -> quality section
@@ -139,11 +140,8 @@ class ConfigMigrator:
         # Pack identity section
         cls._pack_identity(data)
 
-        # Pack source section
-        cls._pack_source(data)
-
-        # Pack sink section
-        cls._pack_sink(data)
+        # Pack data_flow section (source + sink aggregate)
+        cls._pack_data_flow(data)
 
         # Pack stages from pipeline dict
         cls._pack_stages(data)
@@ -306,12 +304,33 @@ class ConfigMigrator:
             data["identity"] = identity_fields
 
     @classmethod
-    def _pack_source(cls, data: dict[str, Any]) -> None:
-        """Pack source fields into source section."""
-        if "source" in data:
+    def _pack_data_flow(cls, data: dict[str, Any]) -> None:
+        """Pack source and sink into data_flow aggregate.
+
+        Handles migration from:
+        - Flat source/sink fields at root level
+        - Legacy source/sink sections at root level
+        - Already migrated data_flow section
+
+        The data_flow section contains:
+        - source: DataSourceConfig fields
+        - sink: DataSinkConfig fields
+        """
+        # If data_flow already exists, migrate any remaining flat fields into it
+        if "data_flow" in data:
+            cls._migrate_flat_fields_to_data_flow(data)
             return
 
+        # Build source section
         source_fields: dict[str, Any] = {}
+
+        # Use existing source section if present
+        if "source" in data:
+            existing_source = data.pop("source")
+            if isinstance(existing_source, dict):
+                source_fields.update(existing_source)
+
+        # Pack flat source fields
         for field in cls.SOURCE_FIELDS:
             if field in data:
                 source_fields[field] = data.pop(field)
@@ -323,16 +342,16 @@ class ConfigMigrator:
             # csv at root level goes to source if no runtime section
             source_fields["csv"] = data.pop("csv")
 
-        if source_fields:
-            data["source"] = source_fields
-
-    @classmethod
-    def _pack_sink(cls, data: dict[str, Any]) -> None:
-        """Pack sink fields into sink section."""
-        if "sink" in data:
-            return
-
+        # Build sink section
         sink_fields: dict[str, Any] = {}
+
+        # Use existing sink section if present
+        if "sink" in data:
+            existing_sink = data.pop("sink")
+            if isinstance(existing_sink, dict):
+                sink_fields.update(existing_sink)
+
+        # Pack flat sink fields
         for field in cls.SINK_FIELDS:
             if field in data:
                 sink_fields[field] = data.pop(field)
@@ -343,8 +362,58 @@ class ConfigMigrator:
             if isinstance(output_val, dict):
                 sink_fields["output"] = output_val
 
-        if sink_fields:
-            data["sink"] = sink_fields
+        # Create data_flow section if we have any content
+        if source_fields or sink_fields:
+            data_flow: dict[str, Any] = {}
+            if source_fields:
+                data_flow["source"] = source_fields
+            if sink_fields:
+                data_flow["sink"] = sink_fields
+            data["data_flow"] = data_flow
+
+    @classmethod
+    def _migrate_flat_fields_to_data_flow(cls, data: dict[str, Any]) -> None:
+        """Migrate any remaining flat source/sink fields into existing data_flow."""
+        data_flow = data.get("data_flow", {})
+        if not isinstance(data_flow, dict):
+            return
+
+        # Migrate flat source fields
+        source = data_flow.setdefault("source", {})
+        for field in cls.SOURCE_FIELDS:
+            if field in data and field not in source:
+                source[field] = data.pop(field)
+
+        # Handle csv_options at root
+        if "csv_options" in data and "csv" not in source:
+            source["csv"] = data.pop("csv_options")
+
+        # Migrate flat sink fields
+        sink = data_flow.setdefault("sink", {})
+        for field in cls.SINK_FIELDS:
+            if field in data and field not in sink:
+                sink[field] = data.pop(field)
+
+        # Handle output at root
+        if "output" in data and "output" not in sink:
+            output_val = data.pop("output")
+            if isinstance(output_val, dict):
+                sink["output"] = output_val
+
+        # Also handle legacy source/sink sections at root (shouldn't happen but defensive)
+        if "source" in data:
+            existing_source = data.pop("source")
+            if isinstance(existing_source, dict):
+                for k, v in existing_source.items():
+                    if k not in source:
+                        source[k] = v
+
+        if "sink" in data:
+            existing_sink = data.pop("sink")
+            if isinstance(existing_sink, dict):
+                for k, v in existing_sink.items():
+                    if k not in sink:
+                        sink[k] = v
 
     @classmethod
     def _pack_stages(cls, data: dict[str, Any]) -> None:

--- a/tests/bioetl/domain/test_config_migration.py
+++ b/tests/bioetl/domain/test_config_migration.py
@@ -73,7 +73,7 @@ class TestV1Migration:
             "storage": {"output_path": "/data/output"},
         }
         result = ConfigMigrator.migrate(data)
-        assert result["sink"]["output_path"] == "/data/output"
+        assert result["data_flow"]["sink"]["output_path"] == "/data/output"
 
     def test_extracts_batch_size_from_sources(self) -> None:
         """batch_size is extracted from sources section."""
@@ -83,7 +83,7 @@ class TestV1Migration:
             "sources": {"chembl": {"batch_size": 50}},
         }
         result = ConfigMigrator.migrate(data)
-        assert result["source"]["batch_size"] == 50
+        assert result["data_flow"]["source"]["batch_size"] == 50
 
     def test_extracts_provider_config_from_sources(self) -> None:
         """provider_config is extracted from sources section."""
@@ -147,7 +147,7 @@ class TestV2Normalization:
         assert result["identity"]["entity"] == "test"
 
     def test_packs_source_section(self) -> None:
-        """Flat source fields are packed into source section."""
+        """Flat source fields are packed into data_flow.source section."""
         data = {
             "identity": {"provider": "dummy", "entity": "test", "pipeline_id": "test"},
             "input_mode": "csv",
@@ -155,20 +155,20 @@ class TestV2Normalization:
             "batch_size": 100,
         }
         result = ConfigMigrator.migrate(data)
-        assert result["source"]["input_mode"] == "csv"
-        assert result["source"]["input_path"] == "/tmp/input.csv"
-        assert result["source"]["batch_size"] == 100
+        assert result["data_flow"]["source"]["input_mode"] == "csv"
+        assert result["data_flow"]["source"]["input_path"] == "/tmp/input.csv"
+        assert result["data_flow"]["source"]["batch_size"] == 100
 
     def test_packs_sink_section(self) -> None:
-        """Flat sink fields are packed into sink section."""
+        """Flat sink fields are packed into data_flow.sink section."""
         data = {
             "identity": {"provider": "dummy", "entity": "test", "pipeline_id": "test"},
             "output_path": "/tmp/output",
             "dry_run": True,
         }
         result = ConfigMigrator.migrate(data)
-        assert result["sink"]["output_path"] == "/tmp/output"
-        assert result["sink"]["dry_run"] is True
+        assert result["data_flow"]["sink"]["output_path"] == "/tmp/output"
+        assert result["data_flow"]["sink"]["dry_run"] is True
 
     def test_packs_runtime_section(self) -> None:
         """Flat runtime fields are packed into runtime section."""
@@ -215,13 +215,13 @@ class TestV2Normalization:
         }
 
     def test_migrates_csv_options_to_source(self) -> None:
-        """csv_options at root is moved to source.csv."""
+        """csv_options at root is moved to data_flow.source.csv."""
         data = {
             "identity": {"provider": "dummy", "entity": "test", "pipeline_id": "test"},
             "csv_options": {"delimiter": ";"},
         }
         result = ConfigMigrator.migrate(data)
-        assert result["source"]["csv"] == {"delimiter": ";"}
+        assert result["data_flow"]["source"]["csv"] == {"delimiter": ";"}
 
     def test_extracts_stages_from_pipeline_dict(self) -> None:
         """stages are extracted from pipeline dict."""
@@ -317,16 +317,31 @@ class TestIdempotency:
         assert result1 == result2
 
     def test_already_migrated_v2_unchanged(self) -> None:
-        """v2 config is not modified."""
+        """v2 config with data_flow is not modified."""
         data = {
             "identity": {"pipeline_id": "test", "provider": "dummy", "entity": "test"},
-            "source": {"input_mode": "csv"},
-            "sink": {"output_path": "/tmp/output"},
+            "data_flow": {
+                "source": {"input_mode": "csv"},
+                "sink": {"output_path": "/tmp/output"},
+            },
             "runtime": {"pagination": {"limit": 100}},
         }
         original = deepcopy(data)
         result = ConfigMigrator.migrate(data)
         assert result == original
+
+    def test_legacy_source_sink_migrated_to_data_flow(self) -> None:
+        """Legacy source/sink at root are migrated to data_flow."""
+        data = {
+            "identity": {"pipeline_id": "test", "provider": "dummy", "entity": "test"},
+            "source": {"input_mode": "csv"},
+            "sink": {"output_path": "/tmp/output"},
+        }
+        result = ConfigMigrator.migrate(data)
+        assert result["data_flow"]["source"]["input_mode"] == "csv"
+        assert result["data_flow"]["sink"]["output_path"] == "/tmp/output"
+        assert "source" not in result
+        assert "sink" not in result
 
     def test_v2_does_not_emit_deprecation_warning(self) -> None:
         """v2 format does not trigger deprecation warning."""
@@ -367,15 +382,25 @@ class TestEdgeCases:
         assert "id" in result
         assert "provider" in result
 
-    def test_preserves_existing_source_section(self) -> None:
-        """Existing source section is not overwritten."""
+    def test_preserves_existing_data_flow_source_section(self) -> None:
+        """Existing data_flow.source section is not overwritten by flat fields."""
         data = {
             "identity": {"pipeline_id": "test", "provider": "dummy", "entity": "test"},
-            "source": {"input_mode": "existing"},
+            "data_flow": {"source": {"input_mode": "existing"}},
             "input_mode": "should-be-ignored",
         }
         result = ConfigMigrator.migrate(data)
-        assert result["source"]["input_mode"] == "existing"
+        assert result["data_flow"]["source"]["input_mode"] == "existing"
+
+    def test_legacy_source_section_migrated_to_data_flow(self) -> None:
+        """Legacy source section at root is migrated to data_flow.source."""
+        data = {
+            "identity": {"pipeline_id": "test", "provider": "dummy", "entity": "test"},
+            "source": {"input_mode": "existing"},
+        }
+        result = ConfigMigrator.migrate(data)
+        assert result["data_flow"]["source"]["input_mode"] == "existing"
+        assert "source" not in result
 
     def test_handles_sources_with_single_provider(self) -> None:
         """Single provider in sources is extracted correctly."""
@@ -387,7 +412,7 @@ class TestEdgeCases:
         }
         result = ConfigMigrator.migrate(data)
         assert result["provider_config"]["base_url"] == "https://example.com"
-        assert result["source"]["batch_size"] == 10
+        assert result["data_flow"]["source"]["batch_size"] == 10
 
     def test_handles_null_primary_key(self) -> None:
         """Null primary_key is coerced to empty list."""

--- a/tests/bioetl/domain/test_data_flow_config.py
+++ b/tests/bioetl/domain/test_data_flow_config.py
@@ -1,0 +1,113 @@
+"""Tests for DataFlowConfig aggregate."""
+
+import pytest
+
+from bioetl.domain.configs.data_flow import DataFlowConfig
+from bioetl.domain.configs.sink import DataSinkConfig
+from bioetl.domain.configs.source import DataSourceConfig
+
+
+class TestDataFlowConfig:
+    """Tests for DataFlowConfig aggregate."""
+
+    def test_creates_valid_data_flow(self) -> None:
+        """DataFlowConfig can be created with valid source and sink."""
+        source = DataSourceConfig(input_mode="csv", input_path="/tmp/input.csv")
+        sink = DataSinkConfig(output_path="/tmp/output")
+
+        data_flow = DataFlowConfig(source=source, sink=sink)
+
+        assert data_flow.source.input_mode == "csv"
+        assert data_flow.sink.output_path == "/tmp/output"
+
+    def test_is_frozen(self) -> None:
+        """DataFlowConfig is immutable."""
+        source = DataSourceConfig(input_mode="csv", input_path="/tmp/input.csv")
+        sink = DataSinkConfig(output_path="/tmp/output")
+        data_flow = DataFlowConfig(source=source, sink=sink)
+
+        with pytest.raises(Exception):  # Pydantic frozen model
+            data_flow.source = DataSourceConfig(input_mode="id_only", input_path="/tmp/other.csv")
+
+    def test_forbids_extra_fields(self) -> None:
+        """DataFlowConfig rejects unknown fields."""
+        source = DataSourceConfig(input_mode="csv", input_path="/tmp/input.csv")
+        sink = DataSinkConfig(output_path="/tmp/output")
+
+        with pytest.raises(Exception):
+            DataFlowConfig(source=source, sink=sink, unknown_field="value")
+
+
+class TestDataFlowValidation:
+    """Tests for DataFlowConfig validation."""
+
+    def test_rejects_same_input_output_path(self) -> None:
+        """DataFlowConfig rejects when input and output paths are the same file."""
+        source = DataSourceConfig(input_mode="csv", input_path="/tmp/data.csv")
+        sink = DataSinkConfig(output_path="/tmp/data.csv")
+
+        with pytest.raises(ValueError, match="Output path cannot be the same as input path"):
+            DataFlowConfig(source=source, sink=sink)
+
+    def test_allows_different_paths(self) -> None:
+        """DataFlowConfig allows different input and output paths."""
+        source = DataSourceConfig(input_mode="csv", input_path="/tmp/input.csv")
+        sink = DataSinkConfig(output_path="/tmp/output.json")
+
+        data_flow = DataFlowConfig(source=source, sink=sink)
+        assert data_flow.source.input_path == "/tmp/input.csv"
+        assert data_flow.sink.output_path == "/tmp/output.json"
+
+    def test_allows_auto_detect_without_input_path(self) -> None:
+        """DataFlowConfig allows auto_detect mode without input path."""
+        source = DataSourceConfig(input_mode="auto_detect")
+        sink = DataSinkConfig(output_path="/tmp/output")
+
+        data_flow = DataFlowConfig(source=source, sink=sink)
+        assert data_flow.source.input_mode == "auto_detect"
+        assert data_flow.source.input_path is None
+
+    def test_allows_output_to_different_directory(self) -> None:
+        """DataFlowConfig allows output to a different directory than input."""
+        source = DataSourceConfig(input_mode="csv", input_path="/data/input/file.csv")
+        sink = DataSinkConfig(output_path="/data/output/")
+
+        data_flow = DataFlowConfig(source=source, sink=sink)
+        assert data_flow.source.input_path == "/data/input/file.csv"
+        assert data_flow.sink.output_path == "/data/output"
+
+
+class TestDataFlowFromDict:
+    """Tests for DataFlowConfig creation from dict."""
+
+    def test_creates_from_nested_dict(self) -> None:
+        """DataFlowConfig can be created from nested dict."""
+        data_flow = DataFlowConfig(
+            source={
+                "input_mode": "csv",
+                "input_path": "/tmp/input.csv",
+                "batch_size": 50,
+            },
+            sink={
+                "output_path": "/tmp/output",
+                "dry_run": True,
+            },
+        )
+
+        assert data_flow.source.input_mode == "csv"
+        assert data_flow.source.batch_size == 50
+        assert data_flow.sink.dry_run is True
+
+    def test_source_csv_options_work(self) -> None:
+        """DataFlowConfig correctly handles CSV options in source."""
+        data_flow = DataFlowConfig(
+            source={
+                "input_mode": "csv",
+                "input_path": "/tmp/input.csv",
+                "csv": {"delimiter": ";", "encoding": "utf-8"},
+            },
+            sink={"output_path": "/tmp/output"},
+        )
+
+        assert data_flow.source.csv.delimiter == ";"
+        assert data_flow.source.csv.encoding == "utf-8"


### PR DESCRIPTION
Create DataFlowConfig that groups DataSourceConfig and DataSinkConfig into a single bounded context representing the complete data flow.

Changes:
- Add domain/configs/data_flow.py with DataFlowConfig aggregate
- Update PipelineConfig to use data_flow instead of separate source/sink
- Add backward compatibility properties for config.source and config.sink
- Update ConfigMigrator to create data_flow section from legacy formats
- Add validation to prevent output path being same as input path

The migration supports:
- Flat source/sink fields at root level -> data_flow.source/sink
- Legacy source/sink sections at root -> data_flow.source/sink
- Already migrated data_flow section (idempotent)