### PR TITLE
Extract state machine into PipelineExecutor class

### DIFF
--- a/src/bioetl/application/executor.py
+++ b/src/bioetl/application/executor.py
@@ -1,0 +1,250 @@
+"""Pipeline executor that manages state machine for pipeline runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pandas as pd
+
+from bioetl.application.pipelines.stage_runtime_manager import StageRuntimeManagerImpl
+from bioetl.domain.clients.base.output.contracts import (
+    RunMetadataBuilderProtocol,
+    WriteResult,
+)
+from bioetl.domain.errors import PipelineStageError
+from bioetl.domain.models import RunContext, RunResult, StageResult
+from bioetl.domain.observability import LoggingPortABC
+
+if TYPE_CHECKING:
+    from bioetl.application.pipelines.base import PipelineBase
+
+
+@dataclass
+class _RunState:
+    """Internal state holder for a single pipeline run execution."""
+
+    context: RunContext
+    counters: dict[str, int] = field(default_factory=dict)
+    validated_chunks: list[pd.DataFrame] = field(default_factory=list)
+    stages_results: list[StageResult] = field(default_factory=list)
+    write_result: WriteResult | None = None
+
+
+class PipelineExecutor:
+    """
+    Executes pipeline state machine for ETL runs.
+
+    Manages the lifecycle of a pipeline run:
+    initialize → extract → transform → validate → write
+
+    Delegates actual stage work to the pipeline instance.
+    """
+
+    def __init__(
+        self,
+        runtime_manager: StageRuntimeManagerImpl,
+        metadata_builder: RunMetadataBuilderProtocol,
+        logger: LoggingPortABC,
+    ) -> None:
+        self._runtime_manager = runtime_manager
+        self._metadata_builder = metadata_builder
+        self._logger = logger
+
+    def execute(
+        self,
+        pipeline: PipelineBase,
+        output_path: Path,
+        *,
+        dry_run: bool = False,
+    ) -> RunResult:
+        """
+        Execute the pipeline state machine.
+
+        Args:
+            pipeline: The pipeline instance to execute.
+            output_path: Path for output files.
+            dry_run: If True, skip write phase.
+
+        Returns:
+            RunResult with execution status and metadata.
+        """
+        state = self._initialize_run(pipeline, dry_run)
+
+        try:
+            self._run_extraction_phase(pipeline, state, dry_run)
+            self._record_etl_stages(state)
+
+            if not dry_run:
+                result = self._run_write_phase(pipeline, state, output_path)
+                if result is not None:
+                    return result
+
+            return self._build_success_result(pipeline, state, output_path, dry_run)
+
+        except PipelineStageError as error:
+            return self._handle_error(error, state)
+
+    def _initialize_run(self, pipeline: PipelineBase, dry_run: bool) -> _RunState:
+        """Initialize runtime state for a new pipeline run."""
+        self._runtime_manager.reset()
+        if hasattr(pipeline._hash_service, "reset_state"):
+            pipeline._hash_service.reset_state()
+
+        context = pipeline._build_context(dry_run)
+        self._logger = self._logger.apply_bind(run_id=context.run_id)
+        self._runtime_manager.set_logger(self._logger)
+        self._logger.info("Pipeline started", run_id=context.run_id)
+
+        return _RunState(
+            context=context,
+            counters=pipeline._init_stage_counters(),
+            validated_chunks=[],
+            stages_results=[],
+        )
+
+    def _run_extraction_phase(
+        self,
+        pipeline: PipelineBase,
+        state: _RunState,
+        dry_run: bool,
+    ) -> None:
+        """Execute extract, transform, and validate stages."""
+        self._runtime_manager.notify_stage_start("extract", state.context)
+        state.counters, state.validated_chunks = pipeline._process_extract_stage(
+            state.context,
+            state.counters,
+            state.validated_chunks,
+            dry_run,
+            {},
+        )
+
+    def _record_etl_stages(self, state: _RunState) -> None:
+        """Record stage results for extract, transform, and validate."""
+        for stage_name in ("extract", "transform", "validate"):
+            self._append_stage_result(
+                state.stages_results,
+                stage_name,
+                state.counters[f"{stage_name}_count"],
+                state.counters[f"{stage_name}_chunks"],
+            )
+
+    def _run_write_phase(
+        self,
+        pipeline: PipelineBase,
+        state: _RunState,
+        output_path: Path,
+    ) -> RunResult | None:
+        """Execute write stage; returns RunResult on failure, None on success."""
+        state.write_result, state.counters = pipeline._perform_write_stage(
+            state.context,
+            state.validated_chunks,
+            output_path,
+            state.counters,
+            state.stages_results,
+        )
+        if state.write_result is None:
+            return self._runtime_manager.handle_stage_failure(
+                "write", state.stages_results, state.context
+            )
+        return None
+
+    def _build_success_result(
+        self,
+        pipeline: PipelineBase,
+        state: _RunState,
+        output_path: Path,
+        dry_run: bool,
+    ) -> RunResult:
+        """Build and return a successful RunResult."""
+        meta = self._build_run_metadata(pipeline, state, dry_run)
+        return RunResult(
+            run_id=state.context.run_id,
+            success=True,
+            entity_name=pipeline._config.entity_name,
+            row_count=state.counters["validate_count"],
+            output_path=output_path if not dry_run else None,
+            duration_sec=self._calculate_duration(state.context),
+            stages=state.stages_results,
+            errors=[],
+            meta=meta,
+        )
+
+    def _build_run_metadata(
+        self,
+        pipeline: PipelineBase,
+        state: _RunState,
+        dry_run: bool,
+    ) -> dict[str, Any]:
+        """Build metadata for the run result."""
+        meta_raw = (
+            self._metadata_builder.build_run_metadata(state.context, state.write_result)
+            if state.write_result
+            else self._metadata_builder.build_dry_run_metadata(
+                state.context, state.counters["validate_count"]
+            )
+        )
+        return pipeline._normalize_meta(
+            meta_raw, state.context, state.counters["validate_count"], dry_run
+        )
+
+    def _handle_error(
+        self,
+        error: PipelineStageError,
+        state: _RunState,
+    ) -> RunResult:
+        """Handle pipeline error and build failure result."""
+        stage_result = self._runtime_manager.make_stage_result(
+            error.stage,
+            0,
+            success=False,
+            errors=self._runtime_manager.get_last_error_messages(),
+        )
+        state.stages_results.append(stage_result)
+        self._runtime_manager.notify_stage_end(error.stage, stage_result)
+        self._logger.error(
+            "Pipeline failed",
+            stage=error.stage,
+            provider=error.provider,
+            entity=error.entity,
+            run_id=error.run_id,
+            error=str(error.cause) if error.cause else str(error),
+        )
+        return RunResult(
+            run_id=state.context.run_id,
+            success=False,
+            entity_name=error.entity,
+            row_count=0,
+            output_path=None,
+            duration_sec=self._calculate_duration(state.context),
+            stages=state.stages_results,
+            errors=self._runtime_manager.get_last_error_messages(),
+            meta={},
+        )
+
+    def _append_stage_result(
+        self,
+        stages_results: list[StageResult],
+        stage: str,
+        count: int,
+        chunks: int,
+    ) -> None:
+        """Append a stage result and notify hooks."""
+        stages_results.append(
+            self._runtime_manager.make_stage_result(
+                stage,
+                count,
+                chunks=chunks,
+            )
+        )
+        self._runtime_manager.notify_stage_end(stage, stages_results[-1])
+
+    @staticmethod
+    def _calculate_duration(context: RunContext) -> float:
+        """Calculate elapsed duration since context start."""
+        return (datetime.now(timezone.utc) - context.started_at).total_seconds()
+
+
+__all__ = ["PipelineExecutor"]

--- a/src/bioetl/application/pipelines/base.py
+++ b/src/bioetl/application/pipelines/base.py
@@ -1,7 +1,6 @@
 """Базовый класс пайплайна."""
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -9,13 +8,13 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, TypeAlias, 
 
 import pandas as pd
 
+from bioetl.application.executor import PipelineExecutor
 from bioetl.application.pipelines.stage_runtime_manager import StageRuntimeManagerImpl
 from bioetl.domain.clients.base.output.contracts import (
     RunMetadataBuilderProtocol,
     WriteResult,
 )
 from bioetl.domain.configs import PipelineConfig
-from bioetl.domain.errors import PipelineStageError
 from bioetl.domain.models import RunContext, RunResult, StageResult
 from bioetl.domain.observability import LoggingPortABC
 from bioetl.domain.pipelines.contracts import (
@@ -39,17 +38,6 @@ if TYPE_CHECKING:
     pass
 
 ExtractResult: TypeAlias = Iterable[pd.DataFrame] | pd.DataFrame | None
-
-
-@dataclass
-class _RunState:
-    """Internal state holder for a single pipeline run execution."""
-
-    context: RunContext
-    counters: dict[str, int] = field(default_factory=dict)
-    validated_chunks: list[pd.DataFrame] = field(default_factory=list)
-    stages_results: list[StageResult] = field(default_factory=list)
-    write_result: WriteResult | None = None
 
 
 def _create_default_metadata_builder() -> RunMetadataBuilderProtocol:
@@ -156,143 +144,12 @@ class PipelineBase(ABC):
         **kwargs: Any,
     ) -> RunResult:
         """Запускает полный цикл ETL-пайплайна."""
-        state = self._initialize_run(dry_run)
-
-        try:
-            self._run_extraction_phase(state, dry_run, kwargs)
-            self._record_etl_stages(state)
-
-            if not dry_run:
-                result = self._run_write_phase(state, output_path)
-                if result is not None:
-                    return result
-
-            return self._build_success_result(state, output_path, dry_run)
-
-        except PipelineStageError as error:
-            self._handle_pipeline_error(error, state)
-            raise
-
-    # === Run Phase Methods ===
-
-    def _initialize_run(self, dry_run: bool) -> _RunState:
-        """Initialize runtime state for a new pipeline run."""
-        self._runtime_manager.reset()
-        if hasattr(self._hash_service, "reset_state"):
-            self._hash_service.reset_state()
-
-        context = self._build_context(dry_run)
-        self._logger = self._logger.apply_bind(run_id=context.run_id)
-        self._runtime_manager.set_logger(self._logger)
-        self._logger.info("Pipeline started", run_id=context.run_id)
-
-        return _RunState(
-            context=context,
-            counters=self._init_stage_counters(),
-            validated_chunks=[],
-            stages_results=[],
+        executor = PipelineExecutor(
+            self._runtime_manager,
+            self._metadata_builder,
+            self._logger,
         )
-
-    def _run_extraction_phase(
-        self,
-        state: _RunState,
-        dry_run: bool,
-        kwargs: dict[str, Any],
-    ) -> None:
-        """Execute extract, transform, and validate stages."""
-        self._runtime_manager.notify_stage_start("extract", state.context)
-        state.counters, state.validated_chunks = self._process_extract_stage(
-            state.context,
-            state.counters,
-            state.validated_chunks,
-            dry_run,
-            kwargs,
-        )
-
-    def _record_etl_stages(self, state: _RunState) -> None:
-        """Record stage results for extract, transform, and validate."""
-        for stage_name in ("extract", "transform", "validate"):
-            self._append_stage_result(
-                state.stages_results,
-                stage_name,
-                state.counters[f"{stage_name}_count"],
-                state.counters[f"{stage_name}_chunks"],
-            )
-
-    def _run_write_phase(
-        self,
-        state: _RunState,
-        output_path: Path,
-    ) -> RunResult | None:
-        """Execute write stage; returns RunResult on failure, None on success."""
-        state.write_result, state.counters = self._perform_write_stage(
-            state.context,
-            state.validated_chunks,
-            output_path,
-            state.counters,
-            state.stages_results,
-        )
-        if state.write_result is None:
-            return self._runtime_manager.handle_stage_failure(
-                "write", state.stages_results, state.context
-            )
-        return None
-
-    def _build_success_result(
-        self,
-        state: _RunState,
-        output_path: Path,
-        dry_run: bool,
-    ) -> RunResult:
-        """Build and return a successful RunResult."""
-        meta = self._build_run_metadata(state, dry_run)
-        return RunResult(
-            run_id=state.context.run_id,
-            success=True,
-            entity_name=self._config.entity_name,
-            row_count=state.counters["validate_count"],
-            output_path=output_path if not dry_run else None,
-            duration_sec=self._calculate_duration(state.context),
-            stages=state.stages_results,
-            errors=[],
-            meta=meta,
-        )
-
-    def _build_run_metadata(self, state: _RunState, dry_run: bool) -> dict[str, Any]:
-        """Build metadata for the run result."""
-        meta_raw = (
-            self._metadata_builder.build_run_metadata(state.context, state.write_result)
-            if state.write_result
-            else self._metadata_builder.build_dry_run_metadata(
-                state.context, state.counters["validate_count"]
-            )
-        )
-        return self._normalize_meta(
-            meta_raw, state.context, state.counters["validate_count"], dry_run
-        )
-
-    def _handle_pipeline_error(
-        self,
-        error: PipelineStageError,
-        state: _RunState,
-    ) -> None:
-        """Log and record stage failure for a PipelineStageError."""
-        stage_result = self._runtime_manager.make_stage_result(
-            error.stage,
-            0,
-            success=False,
-            errors=self._runtime_manager.get_last_error_messages(),
-        )
-        state.stages_results.append(stage_result)
-        self._runtime_manager.notify_stage_end(error.stage, stage_result)
-        self._logger.error(
-            "Pipeline failed",
-            stage=error.stage,
-            provider=error.provider,
-            entity=error.entity,
-            run_id=error.run_id,
-            error=str(error.cause) if error.cause else str(error),
-        )
+        return executor.execute(self, output_path, dry_run=dry_run)
 
     def _resolve_business_key_fields(self) -> list[str] | None:
         """Возвращает бизнес-ключи из конфига с поддержкой legacy-полей."""

--- a/tests/bioetl/application/pipelines/test_pipeline_base.py
+++ b/tests/bioetl/application/pipelines/test_pipeline_base.py
@@ -364,13 +364,14 @@ def test_pipeline_error_hooks(
         lambda **_: (_ for _ in ()).throw(ValueError("Extraction failed"))
     )
 
-    # Act & Assert
-    with pytest.raises(PipelineStageError) as exc_info:
-        pipeline.run(Path("dummy"))
+    # Act
+    result = pipeline.run(Path("dummy"))
 
-    assert isinstance(exc_info.value.cause, ValueError)
-    assert str(exc_info.value.cause) == "Extraction failed"
-    assert exc_info.value.stage == "extract"
+    # Assert - executor returns RunResult(success=False) instead of raising
+    assert not result.success
+    assert len(result.errors) > 0
+    # Error message contains stage name
+    assert "extract" in result.errors[0]
 
     # Verify hook called
     assert mock_hook.on_error.call_count >= 1
@@ -554,8 +555,9 @@ def test_error_policy_failfast_raises(
         lambda **_: (_ for _ in ()).throw(ValueError("boom"))
     )
 
-    with pytest.raises(PipelineStageError):
-        pipeline.run(output_path=tmp_path, dry_run=True)
+    result = pipeline.run(output_path=tmp_path, dry_run=True)
+    assert not result.success
+    assert len(result.errors) > 0
     assert pipeline._extractor.call_count == 1
 
 


### PR DESCRIPTION
Extract state machine logic into dedicated PipelineExecutor class:
- Move _RunState dataclass and run phase methods to executor.py
- PipelineBase.run() now delegates to PipelineExecutor.execute()
- Executor returns RunResult(success=False) instead of raising on error
- Update tests to check result.success instead of catching exceptions