### PR TITLE
Extract path resolution logic into service

### DIFF
--- a/src/bioetl/domain/ports/__init__.py
+++ b/src/bioetl/domain/ports/__init__.py
@@ -15,6 +15,7 @@ from bioetl.domain.ports.extraction import (
     from_raw_records,
     to_raw_records,
 )
+from bioetl.domain.ports.filesystem import PathResolverABC
 from bioetl.domain.ports.output import (
     ChecksumCalculatorPort,
     DataWriterPort,
@@ -80,6 +81,8 @@ __all__: list[str] = [
     # Backward compatibility helpers
     "from_raw_records",
     "to_raw_records",
+    # Filesystem ports
+    "PathResolverABC",
     # Output ports
     "ChecksumCalculatorPort",
     "DataWriterPort",

--- a/src/bioetl/domain/ports/filesystem.py
+++ b/src/bioetl/domain/ports/filesystem.py
@@ -1,0 +1,108 @@
+"""Ports for filesystem operations (domain layer).
+
+This module defines the interfaces for filesystem-related components
+following the hexagonal architecture pattern.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+
+class PathResolverABC(ABC):
+    """Abstract base class for path resolution operations.
+
+    Provides a unified interface for resolving various types of paths
+    in the application: configuration files, output directories, and
+    input data files.
+
+    Implementations should handle:
+    - Environment variable resolution (e.g., BIOETL_CONFIG_DIR)
+    - Relative path resolution against base directory
+    - Directory creation for output paths
+    """
+
+    @property
+    @abstractmethod
+    def base_path(self) -> Path:
+        """Return the base path used for resolution.
+
+        Returns:
+            Base directory path for resolving relative paths.
+        """
+
+    @abstractmethod
+    def resolve(self, path: str | Path) -> Path:
+        """Resolve a path relative to the base path.
+
+        If the path is absolute, it is returned as-is (resolved).
+        If the path is relative, it is resolved against base_path.
+
+        Args:
+            path: Path to resolve (absolute or relative).
+
+        Returns:
+            Resolved absolute path.
+        """
+
+    @abstractmethod
+    def resolve_config(self, name: str) -> Path:
+        """Resolve a configuration file path.
+
+        Resolves configuration file paths following the convention:
+        <base_path>/<name> for direct names, or
+        <base_path>/pipelines/<provider>/<entity>.yaml for pipeline IDs.
+
+        Args:
+            name: Configuration name or path fragment.
+
+        Returns:
+            Resolved absolute path to configuration file.
+        """
+
+    @abstractmethod
+    def resolve_output(self, name: str) -> Path:
+        """Resolve an output file path.
+
+        Resolves output file paths, typically relative to an output
+        directory. Ensures parent directories exist.
+
+        Args:
+            name: Output file name or relative path.
+
+        Returns:
+            Resolved absolute path to output file.
+        """
+
+    @abstractmethod
+    def ensure_parent_exists(self, path: Path) -> Path:
+        """Ensure the parent directory of a path exists.
+
+        Creates parent directories if they don't exist (like mkdir -p).
+
+        Args:
+            path: Path whose parent directory should be ensured.
+
+        Returns:
+            The original path (for method chaining).
+        """
+
+    @abstractmethod
+    def resolve_existing(self, path: str | Path) -> Path | None:
+        """Resolve a path only if it exists.
+
+        Attempts to resolve the path and returns it only if the
+        resolved path exists on the filesystem.
+
+        Args:
+            path: Path to resolve and check.
+
+        Returns:
+            Resolved path if it exists, None otherwise.
+        """
+
+
+__all__ = [
+    "PathResolverABC",
+]

--- a/src/bioetl/infrastructure/config/loader.py
+++ b/src/bioetl/infrastructure/config/loader.py
@@ -625,15 +625,32 @@ def _resolve_existing_input_path(
     config_path: Path,
     base_dir: Path | None,
 ) -> Path | None:
-    """Пытается разрешить относительный путь к существующему файлу."""
+    """Пытается разрешить относительный путь к существующему файлу.
+
+    Uses PathResolver to check path existence against multiple candidate
+    root directories.
+
+    Args:
+        path_str: Input path string to resolve.
+        config_path: Path to the configuration file (for relative resolution).
+        base_dir: Optional base directory override.
+
+    Returns:
+        Resolved path if file exists, None otherwise.
+    """
+    from bioetl.infrastructure.files.path_resolver import PathResolver
 
     candidate = Path(path_str).expanduser()
     if candidate.is_absolute():
-        return candidate if candidate.exists() else None
+        # For absolute paths, just check existence
+        resolver = PathResolver(candidate.parent)
+        return resolver.resolve_existing(candidate.name)
 
+    # Try resolving against each candidate root
     for root in _iter_candidate_roots(config_path=config_path, base_dir=base_dir):
-        resolved = (root / candidate).resolve()
-        if resolved.exists():
+        resolver = PathResolver(root)
+        resolved = resolver.resolve_existing(candidate)
+        if resolved is not None:
             return resolved
     return None
 
@@ -643,8 +660,21 @@ def _iter_candidate_roots(
     config_path: Path,
     base_dir: Path | None,
 ) -> Iterable[Path]:
-    """Генерирует директории, относительно которых ищем входной файл."""
+    """Генерирует директории, относительно которых ищем входной файл.
 
+    Yields directories in priority order:
+    1. base_dir (if provided)
+    2. Current working directory
+    3. Config file's parent directory
+    4. All parent directories of config file path
+
+    Args:
+        config_path: Path to the configuration file.
+        base_dir: Optional base directory override.
+
+    Yields:
+        Unique candidate root directories for path resolution.
+    """
     bases: list[Path] = []
     if base_dir is not None:
         bases.append(base_dir.resolve())

--- a/src/bioetl/infrastructure/config/sources.py
+++ b/src/bioetl/infrastructure/config/sources.py
@@ -3,38 +3,58 @@
 from __future__ import annotations
 
 from functools import lru_cache
-import os
 from pathlib import Path
 from typing import Any
 
 import yaml
 
 from bioetl.domain.transform.merge import apply_deep_merge
+from bioetl.infrastructure.files.path_resolver import (
+    CONFIGS_ROOT_ENV,
+    DEFAULT_CONFIGS_ROOT,
+    PathResolver,
+    create_config_resolver,
+)
 
-CONFIGS_ROOT_ENV = "BIOETL_CONFIG_DIR"
-DEFAULT_CONFIGS_ROOT = Path("configs")
+# Re-export constants for backward compatibility
+__all_constants__ = ["CONFIGS_ROOT_ENV", "DEFAULT_CONFIGS_ROOT"]
 
 
 def get_configs_root(base_dir: str | Path | None = None) -> Path:
-    """Return resolved configs root (honours BIOETL_CONFIG_DIR)."""
+    """Return resolved configs root (honours BIOETL_CONFIG_DIR).
 
-    if base_dir is not None:
-        return Path(base_dir)
-    return Path(os.environ.get(CONFIGS_ROOT_ENV, DEFAULT_CONFIGS_ROOT))
+    Args:
+        base_dir: Override base directory. If None, uses BIOETL_CONFIG_DIR
+            environment variable or default "configs" directory.
+
+    Returns:
+        Resolved configuration root directory path.
+    """
+    resolver = create_config_resolver(base_dir)
+    return resolver.base_path
 
 
 def resolve_pipeline_config_path(
     pipeline_id: str, *, base_dir: str | Path | None = None
 ) -> Path:
-    """Return path to pipeline YAML by id '<provider>.<entity>'."""
+    """Return path to pipeline YAML by id '<provider>.<entity>'.
 
-    try:
-        provider, entity = pipeline_id.split(".", maxsplit=1)
-    except ValueError as exc:
-        raise ValueError("Pipeline id must be in format '<provider>.<entity>'") from exc
+    Args:
+        pipeline_id: Pipeline identifier in format 'provider.entity'.
+        base_dir: Override base directory for configuration search.
 
-    root = get_configs_root(base_dir)
-    return root / "pipelines" / provider / f"{entity}.yaml"
+    Returns:
+        Resolved path to pipeline configuration file.
+
+    Raises:
+        ValueError: If pipeline_id is not in expected format.
+    """
+    # Validate format before delegating to resolver
+    if "." not in pipeline_id:
+        raise ValueError("Pipeline id must be in format '<provider>.<entity>'")
+
+    resolver = create_config_resolver(base_dir)
+    return resolver.resolve_config(pipeline_id)
 
 
 def get_yaml(path: Path) -> dict[str, Any]:

--- a/src/bioetl/infrastructure/files/__init__.py
+++ b/src/bioetl/infrastructure/files/__init__.py
@@ -1,0 +1,34 @@
+"""File operation utilities (infrastructure layer).
+
+This module provides file-related infrastructure components including:
+- Atomic file operations
+- Checksum calculation
+- Path resolution
+"""
+
+from bioetl.infrastructure.files.atomic import AtomicFileOperation
+from bioetl.infrastructure.files.checksum import (
+    compute_file_sha256,
+    compute_files_sha256,
+)
+from bioetl.infrastructure.files.path_resolver import (
+    CONFIGS_ROOT_ENV,
+    DEFAULT_CONFIGS_ROOT,
+    PathResolver,
+    create_config_resolver,
+    create_output_resolver,
+)
+
+__all__ = [
+    # Atomic operations
+    "AtomicFileOperation",
+    # Checksum
+    "compute_file_sha256",
+    "compute_files_sha256",
+    # Path resolution
+    "PathResolver",
+    "CONFIGS_ROOT_ENV",
+    "DEFAULT_CONFIGS_ROOT",
+    "create_config_resolver",
+    "create_output_resolver",
+]

--- a/src/bioetl/infrastructure/files/path_resolver.py
+++ b/src/bioetl/infrastructure/files/path_resolver.py
@@ -1,0 +1,168 @@
+"""Path resolution implementation.
+
+This module provides a concrete PathResolver implementation that handles
+path resolution for configuration files, output directories, and input data.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from bioetl.domain.ports.filesystem import PathResolverABC
+
+
+@dataclass(frozen=True)
+class PathResolver(PathResolverABC):
+    """Immutable path resolver for configuration and output paths.
+
+    Provides unified path resolution logic, eliminating duplicate code
+    across configuration loading and output writing modules.
+
+    Attributes:
+        _base_path: The base directory for resolving relative paths.
+
+    Example:
+        >>> resolver = PathResolver(Path("configs"))
+        >>> resolver.resolve("pipelines/chembl/activity.yaml")
+        PosixPath('/absolute/path/configs/pipelines/chembl/activity.yaml')
+    """
+
+    _base_path: Path
+
+    @property
+    def base_path(self) -> Path:
+        """Return the base path used for resolution."""
+        return self._base_path
+
+    def resolve(self, path: str | Path) -> Path:
+        """Resolve a path relative to the base path.
+
+        If the path is absolute, it is returned as-is (resolved).
+        If the path is relative, it is resolved against base_path.
+
+        Args:
+            path: Path to resolve (absolute or relative).
+
+        Returns:
+            Resolved absolute path.
+        """
+        p = Path(path).expanduser()
+        if p.is_absolute():
+            return p.resolve()
+        return (self._base_path / p).resolve()
+
+    def resolve_config(self, name: str) -> Path:
+        """Resolve a configuration file path.
+
+        Handles two naming conventions:
+        1. Direct paths: "pipelines/chembl/activity.yaml"
+        2. Pipeline IDs: "chembl.activity" -> "pipelines/chembl/activity.yaml"
+
+        Args:
+            name: Configuration name, path fragment, or pipeline ID.
+
+        Returns:
+            Resolved absolute path to configuration file.
+        """
+        # Check if it's a pipeline ID format (provider.entity)
+        if "." in name and "/" not in name and not name.endswith((".yaml", ".yml")):
+            parts = name.split(".", maxsplit=1)
+            if len(parts) == 2:
+                provider, entity = parts
+                name = f"pipelines/{provider}/{entity}.yaml"
+
+        return self.resolve(name)
+
+    def resolve_output(self, name: str) -> Path:
+        """Resolve an output file path.
+
+        Resolves output file paths relative to base path and ensures
+        parent directories exist.
+
+        Args:
+            name: Output file name or relative path.
+
+        Returns:
+            Resolved absolute path to output file with parent dirs created.
+        """
+        resolved = self.resolve(name)
+        return self.ensure_parent_exists(resolved)
+
+    def ensure_parent_exists(self, path: Path) -> Path:
+        """Ensure the parent directory of a path exists.
+
+        Creates parent directories if they don't exist (like mkdir -p).
+        This is an idempotent operation.
+
+        Args:
+            path: Path whose parent directory should be ensured.
+
+        Returns:
+            The original path (for method chaining).
+        """
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def resolve_existing(self, path: str | Path) -> Path | None:
+        """Resolve a path only if it exists.
+
+        Attempts to resolve the path and returns it only if the
+        resolved path exists on the filesystem.
+
+        Args:
+            path: Path to resolve and check.
+
+        Returns:
+            Resolved path if it exists, None otherwise.
+        """
+        resolved = self.resolve(path)
+        return resolved if resolved.exists() else None
+
+
+# Environment variable for config directory override
+CONFIGS_ROOT_ENV = "BIOETL_CONFIG_DIR"
+DEFAULT_CONFIGS_ROOT = Path("configs")
+
+
+def create_config_resolver(base_dir: str | Path | None = None) -> PathResolver:
+    """Create a PathResolver for configuration files.
+
+    Respects the BIOETL_CONFIG_DIR environment variable for configuration
+    directory override.
+
+    Args:
+        base_dir: Override base directory. If None, uses environment
+            variable or default "configs" directory.
+
+    Returns:
+        PathResolver configured for config file resolution.
+    """
+    if base_dir is not None:
+        return PathResolver(Path(base_dir))
+    env_dir = os.environ.get(CONFIGS_ROOT_ENV)
+    if env_dir:
+        return PathResolver(Path(env_dir))
+    return PathResolver(DEFAULT_CONFIGS_ROOT)
+
+
+def create_output_resolver(output_dir: str | Path) -> PathResolver:
+    """Create a PathResolver for output files.
+
+    Args:
+        output_dir: Base directory for output files.
+
+    Returns:
+        PathResolver configured for output file resolution.
+    """
+    return PathResolver(Path(output_dir))
+
+
+__all__ = [
+    "PathResolver",
+    "CONFIGS_ROOT_ENV",
+    "DEFAULT_CONFIGS_ROOT",
+    "create_config_resolver",
+    "create_output_resolver",
+]


### PR DESCRIPTION
- Add PathResolverABC interface in domain/ports/filesystem.py
- Add PathResolver implementation in infrastructure/files/path_resolver.py
- Replace duplicate path logic in config/sources.py with PathResolver
- Update config/loader.py to use PathResolver for input path resolution
- Export PathResolverABC from domain/ports and PathResolver from infrastructure/files

The PathResolver provides a unified interface for:
- resolve(): resolve paths relative to base
- resolve_config(): resolve config file paths with pipeline ID support
- resolve_output(): resolve output paths with parent dir creation
- ensure_parent_exists(): create parent directories
- resolve_existing(): resolve paths only if they exist