### PR TITLE
Add deprecation warnings to class aliases

### DIFF
--- a/src/bioetl/infrastructure/output/converters/factories.py
+++ b/src/bioetl/infrastructure/output/converters/factories.py
@@ -72,7 +72,7 @@ def default_output_frame_converter(
     """DEPRECATED: Use create_output_frame_converter() instead."""
     warnings.warn(
         "default_output_frame_converter is deprecated, "
-        "use create_output_frame_converter instead",
+        "use create_output_frame_converter instead. Will be removed in v3.0.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/src/bioetl/infrastructure/output/factories.py
+++ b/src/bioetl/infrastructure/output/factories.py
@@ -72,7 +72,8 @@ def create_loader(
 def default_writer() -> CsvWriter:
     """DEPRECATED: Use create_writer() instead."""
     warnings.warn(
-        "default_writer is deprecated, use create_writer instead",
+        "default_writer is deprecated, use create_writer instead. "
+        "Will be removed in v3.0.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -82,7 +83,8 @@ def default_writer() -> CsvWriter:
 def default_metadata_writer() -> MetadataWriter:
     """DEPRECATED: Use create_metadata_writer() instead."""
     warnings.warn(
-        "default_metadata_writer is deprecated, use create_metadata_writer instead",
+        "default_metadata_writer is deprecated, use create_metadata_writer instead. "
+        "Will be removed in v3.0.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -92,7 +94,8 @@ def default_metadata_writer() -> MetadataWriter:
 def default_quality_reporter() -> QualityReportABC:
     """DEPRECATED: Use create_quality_reporter() instead."""
     warnings.warn(
-        "default_quality_reporter is deprecated, use create_quality_reporter instead",
+        "default_quality_reporter is deprecated, use create_quality_reporter instead. "
+        "Will be removed in v3.0.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -111,7 +114,8 @@ def default_loader(
 ) -> UnifiedLoaderImpl:
     """DEPRECATED: Use create_loader() instead."""
     warnings.warn(
-        "default_loader is deprecated, use create_loader instead",
+        "default_loader is deprecated, use create_loader instead. "
+        "Will be removed in v3.0.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/src/bioetl/infrastructure/output/impl/base_writer.py
+++ b/src/bioetl/infrastructure/output/impl/base_writer.py
@@ -4,9 +4,10 @@ Base helpers for writer implementations.
 
 from __future__ import annotations
 
+import time
+import warnings
 from collections.abc import Callable
 from pathlib import Path
-import time
 
 import pandas as pd
 
@@ -63,7 +64,22 @@ class BaseWriter:
         raise NotImplementedError
 
 
-# Deprecated alias for backward compatibility (will be removed in next major version)
-BaseWriterImpl = BaseWriter
+# Deprecated aliases for backward compatibility
+_DEPRECATED_ALIASES = {
+    "BaseWriterImpl": "BaseWriter",
+}
+
+
+def __getattr__(name: str):
+    if name in _DEPRECATED_ALIASES:
+        warnings.warn(
+            f"{name} is deprecated, use {_DEPRECATED_ALIASES[name]} instead. "
+            "Will be removed in v3.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()[_DEPRECATED_ALIASES[name]]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = ["BaseWriter", "BaseWriterImpl"]

--- a/src/bioetl/infrastructure/output/impl/csv_writer.py
+++ b/src/bioetl/infrastructure/output/impl/csv_writer.py
@@ -4,6 +4,7 @@ CSV Writer implementation.
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 
 import pandas as pd
@@ -29,7 +30,22 @@ class CsvWriter(BaseWriter):
         return fmt.lower() == "csv"
 
 
-# Deprecated alias for backward compatibility (will be removed in next major version)
-CsvWriterImpl = CsvWriter
+# Deprecated aliases for backward compatibility
+_DEPRECATED_ALIASES = {
+    "CsvWriterImpl": "CsvWriter",
+}
+
+
+def __getattr__(name: str):
+    if name in _DEPRECATED_ALIASES:
+        warnings.warn(
+            f"{name} is deprecated, use {_DEPRECATED_ALIASES[name]} instead. "
+            "Will be removed in v3.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()[_DEPRECATED_ALIASES[name]]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = ["CsvWriter", "CsvWriterImpl"]

--- a/src/bioetl/infrastructure/output/impl/metadata_writer.py
+++ b/src/bioetl/infrastructure/output/impl/metadata_writer.py
@@ -1,5 +1,6 @@
 """Writers for pipeline metadata and QC artifacts."""
 
+import warnings
 from pathlib import Path
 
 import pandas as pd
@@ -67,7 +68,22 @@ class MetadataWriter:
         return compute_files_sha256(paths)
 
 
-# Deprecated alias for backward compatibility (will be removed in next major version)
-MetadataWriterImpl = MetadataWriter
+# Deprecated aliases for backward compatibility
+_DEPRECATED_ALIASES = {
+    "MetadataWriterImpl": "MetadataWriter",
+}
+
+
+def __getattr__(name: str):
+    if name in _DEPRECATED_ALIASES:
+        warnings.warn(
+            f"{name} is deprecated, use {_DEPRECATED_ALIASES[name]} instead. "
+            "Will be removed in v3.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()[_DEPRECATED_ALIASES[name]]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = ["MetadataWriter", "MetadataWriterImpl", "build_quality_report_table"]

--- a/src/bioetl/infrastructure/output/impl/parquet_writer.py
+++ b/src/bioetl/infrastructure/output/impl/parquet_writer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from pathlib import Path
 
@@ -26,7 +27,22 @@ class ParquetWriter(BaseWriter):
         return fmt.lower() == "parquet"
 
 
-# Deprecated alias for backward compatibility (will be removed in next major version)
-ParquetWriterImpl = ParquetWriter
+# Deprecated aliases for backward compatibility
+_DEPRECATED_ALIASES = {
+    "ParquetWriterImpl": "ParquetWriter",
+}
+
+
+def __getattr__(name: str):
+    if name in _DEPRECATED_ALIASES:
+        warnings.warn(
+            f"{name} is deprecated, use {_DEPRECATED_ALIASES[name]} instead. "
+            "Will be removed in v3.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()[_DEPRECATED_ALIASES[name]]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = ["ParquetWriter", "ParquetWriterImpl"]

--- a/src/bioetl/infrastructure/transform/impl/__init__.py
+++ b/src/bioetl/infrastructure/transform/impl/__init__.py
@@ -1,10 +1,9 @@
 """Concrete transform implementations."""
 
+import warnings
+
 from bioetl.infrastructure.transform.impl.chembl_normalization_service_impl import (
     ChemblNormalizationService,
-)
-from bioetl.infrastructure.transform.impl.chembl_normalization_service_impl import (
-    ChemblNormalizationServiceImpl,  # Deprecated alias
 )
 from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl import (  # noqa: E501
     DefaultNormalizationTransformerImpl,
@@ -17,6 +16,24 @@ from bioetl.infrastructure.transform.impl.index_generator import (
 from bioetl.infrastructure.transform.impl.timestamp_provider import (
     DeterministicTimestampProvider,
 )
+
+# Deprecated aliases for backward compatibility
+_DEPRECATED_ALIASES = {
+    "ChemblNormalizationServiceImpl": "ChemblNormalizationService",
+}
+
+
+def __getattr__(name: str):
+    if name in _DEPRECATED_ALIASES:
+        warnings.warn(
+            f"{name} is deprecated, use {_DEPRECATED_ALIASES[name]} instead. "
+            "Will be removed in v3.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()[_DEPRECATED_ALIASES[name]]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "HasherImpl",

--- a/src/bioetl/infrastructure/transform/impl/base_normalizer.py
+++ b/src/bioetl/infrastructure/transform/impl/base_normalizer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import Any, Callable, cast
 
 import pandas as pd
@@ -307,7 +308,22 @@ class BaseNormalizationService:
         return False
 
 
-# Deprecated alias for backward compatibility (will be removed in next major version)
-BaseNormalizationServiceImpl = BaseNormalizationService
+# Deprecated aliases for backward compatibility
+_DEPRECATED_ALIASES = {
+    "BaseNormalizationServiceImpl": "BaseNormalizationService",
+}
+
+
+def __getattr__(name: str):
+    if name in _DEPRECATED_ALIASES:
+        warnings.warn(
+            f"{name} is deprecated, use {_DEPRECATED_ALIASES[name]} instead. "
+            "Will be removed in v3.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()[_DEPRECATED_ALIASES[name]]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = ["BaseNormalizationService", "BaseNormalizationServiceImpl"]

--- a/src/bioetl/infrastructure/transform/impl/chembl_normalization_service_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/chembl_normalization_service_impl.py
@@ -31,7 +31,7 @@ class ChemblNormalizationService(DefaultNormalizationTransformerImpl):
         warnings.warn(
             "ChemblNormalizationService is deprecated. "
             "Use DefaultNormalizationTransformerImpl(config, empty_value=None, "
-            "serialize_array_in_series=False) instead.",
+            "serialize_array_in_series=False) instead. Will be removed in v3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -43,8 +43,23 @@ class ChemblNormalizationService(DefaultNormalizationTransformerImpl):
         )
 
 
-# Deprecated alias for backward compatibility (will be removed in next major version)
-ChemblNormalizationServiceImpl = ChemblNormalizationService
+# Deprecated aliases for backward compatibility
+_DEPRECATED_ALIASES = {
+    "ChemblNormalizationServiceImpl": "ChemblNormalizationService",
+}
+
+
+def __getattr__(name: str):
+    if name in _DEPRECATED_ALIASES:
+        warnings.warn(
+            f"{name} is deprecated, use {_DEPRECATED_ALIASES[name]} instead. "
+            "Will be removed in v3.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()[_DEPRECATED_ALIASES[name]]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 # Type alias for backward compatibility
 NormalizedRecord = dict[str, Any]


### PR DESCRIPTION
Add DeprecationWarning with "Will be removed in v3.0" for class aliases:
- CsvWriterImpl → CsvWriter
- ParquetWriterImpl → ParquetWriter
- BaseWriterImpl → BaseWriter
- MetadataWriterImpl → MetadataWriter
- BaseNormalizationServiceImpl → BaseNormalizationService
- ChemblNormalizationServiceImpl → ChemblNormalizationService

Also update existing deprecated functions with v3.0 removal notice:
- default_writer → create_writer
- default_metadata_writer → create_metadata_writer
- default_quality_reporter → create_quality_reporter
- default_loader → create_loader
- default_output_frame_converter → create_output_frame_converter

Uses module-level __getattr__ for class aliases to emit warnings on import.