### PR TITLE
Unify hashing API in contracts

### DIFF
--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -51,7 +51,7 @@ from bioetl.domain.types import (
     RawRecord,
     RecordBatch,
 )
-from bioetl.domain.value_objects import ChemblId, EntityName, PipelineId, RunId
+from bioetl.domain.value_objects import ChemblId, EntityName, HashDigest, PipelineId, RunId
 
 __all__ = [
     # Tabular data abstractions
@@ -77,6 +77,7 @@ __all__ = [
     # Value objects
     "ChemblId",
     "EntityName",
+    "HashDigest",
     "PipelineId",
     "RunId",
     # Aggregates

--- a/src/bioetl/domain/data.py
+++ b/src/bioetl/domain/data.py
@@ -36,13 +36,27 @@ Infrastructure adapters implement these protocols wrapping pandas objects.
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Iterator, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    pass
+
+# Type alias for a batch of records (pandas-free)
+RecordBatch = Sequence[Mapping[str, Any]]
+"""Type alias for a sequence of records.
+
+RecordBatch represents a collection of records without pandas dependency.
+Each record is a Mapping (dict-like) of field names to values.
+
+Usage:
+    def process_batch(records: RecordBatch) -> list[dict]:
+        return [dict(r) for r in records]
+"""
 
 __all__ = [
     "Record",
+    "RecordBatch",
     "RecordSet",
     "TabularData",
     "MutableTabularData",

--- a/src/bioetl/domain/transform/__init__.py
+++ b/src/bioetl/domain/transform/__init__.py
@@ -1,6 +1,8 @@
 """Data transformation logic."""
 
 from bioetl.domain.transform.contracts import (
+    HashDigest,
+    HasherABC,
     HashServiceABC,
     IndexGeneratorABC,
     TimestampProviderABC,
@@ -15,13 +17,15 @@ from bioetl.domain.transform.transformers import (
 )
 
 __all__ = [
-    "TransformerABC",
-    "TransformerChainImpl",
-    "HashColumnsTransformerImpl",
-    "IndexColumnTransformerImpl",
     "DatabaseVersionTransformerImpl",
     "FulldateTransformerImpl",
+    "HashColumnsTransformerImpl",
+    "HashDigest",
+    "HasherABC",
     "HashServiceABC",
+    "IndexColumnTransformerImpl",
     "IndexGeneratorABC",
     "TimestampProviderABC",
+    "TransformerABC",
+    "TransformerChainImpl",
 ]

--- a/src/bioetl/domain/transform/contracts.py
+++ b/src/bioetl/domain/transform/contracts.py
@@ -1,29 +1,28 @@
 """Domain-level transform contracts and DTOs.
 
 Terminology:
-    compute_row_fingerprint: Computes a hash of the entire row.
-        Deprecated alias: hash_row (will be removed in v3.0).
-    compute_entity_key: Computes a hash of the business key columns.
-        Deprecated alias: hash_business_key (will be removed in v3.0).
+    fingerprint: Hash of entire record (all fields).
+    entity_key: Hash of business key fields only.
 
 Tabular Data Abstractions:
-    This module uses domain-level abstractions (Record, TabularData) instead of
-    pandas types. Infrastructure layer provides PandasAdapter implementations.
+    This module uses domain-level abstractions (Record, TabularData, RecordBatch)
+    instead of pandas types. Infrastructure layer provides adapter implementations.
 
     See bioetl.domain.data for protocol definitions.
 """
 
 from abc import ABC, abstractmethod
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Protocol
-import warnings
 
 # Import the canonical NormalizationConfig from configs.normalization
 from bioetl.domain.configs.normalization import NormalizationConfig
-from bioetl.domain.data import MutableTabularData, Record, TabularData
+from bioetl.domain.data import MutableTabularData, Record, RecordBatch, TabularData
+from bioetl.domain.value_objects import HashDigest
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    pass
 
 
 class NormalizationConfigProviderProtocol(Protocol):
@@ -41,39 +40,46 @@ class NormalizationConfigProviderProtocol(Protocol):
 
 
 class HasherABC(ABC):
-    """Row hashing abstraction.
+    """Low-level hashing abstraction.
 
+    Provides primitive hashing operations used by HashServiceABC.
     Uses domain-level Record and TabularData instead of pandas types.
     Infrastructure implementations can work with pandas internally.
+
+    Note:
+        This is an internal abstraction. Prefer HashServiceABC for domain code.
     """
 
-    def get_algorithm(self) -> str:
-        """Return hashing algorithm name (default: blake2b_256)."""
+    @property
+    def algorithm(self) -> str:
+        """Return hashing algorithm identifier (e.g., 'blake2b_256')."""
         return "blake2b_256"
 
     @abstractmethod
-    def compute_hash_row(self, row: Record) -> str:
+    def compute_hash(self, record: Mapping[str, Any]) -> HashDigest:
         """Compute hash of a single record.
 
         Args:
-            row: Record to hash (dict-like interface).
+            record: Record to hash (dict-like interface).
 
         Returns:
-            Hex string hash of the record.
+            HashDigest value object.
         """
 
     @abstractmethod
-    def compute_hash_columns(
-        self, data: TabularData, columns: list[str]
-    ) -> "Sequence[str]":
-        """Compute hash of specified columns for each row.
+    def compute_hash_for_fields(
+        self,
+        record: Mapping[str, Any],
+        fields: Sequence[str],
+    ) -> HashDigest:
+        """Compute hash of specified fields from a record.
 
         Args:
-            data: Tabular data to process.
-            columns: Column names to include in hash.
+            record: Record containing fields.
+            fields: Field names to include in hash.
 
         Returns:
-            Sequence of hash strings, one per row.
+            HashDigest value object.
         """
 
 
@@ -119,90 +125,101 @@ class NormalizationServiceABC(ABC):
 
 
 class HashServiceABC(ABC):
-    """Stateless hash computation service.
+    """Stateless service for computing deterministic hashes.
 
-    Responsible for computing and adding hash columns to tabular data.
+    Responsible for computing and adding hash columns to data.
     Does not contain stateful logic (indices, timestamps).
 
     Terminology:
-        compute_row_fingerprint: Canonical name for row hashing.
-        compute_entity_key: Canonical name for business key hashing.
-        hash_row: Deprecated alias for compute_row_fingerprint.
-        hash_business_key: Deprecated alias for compute_entity_key.
+        fingerprint: Hash of entire record (all fields).
+        entity_key: Hash of business key fields only.
+
+    Example:
+        >>> service: HashServiceABC = get_hash_service()
+        >>> digest = service.compute_fingerprint({"id": 1, "name": "test"})
+        >>> print(digest.value)  # hex string
     """
 
+    @property
+    def algorithm(self) -> str:
+        """Return algorithm identifier (e.g., 'blake2b_256')."""
+        return "blake2b_256"
+
     @abstractmethod
-    def compute_row_fingerprint(self, row: dict[str, Any]) -> str:
-        """Compute hash fingerprint of a row as complete object.
+    def compute_fingerprint(self, record: Mapping[str, Any]) -> HashDigest:
+        """Compute hash fingerprint of entire record.
 
         Args:
-            row: Row data as dictionary.
+            record: Record data as mapping (dict-like).
 
         Returns:
-            Hex string hash of the row.
-
-        Note:
-            This is the canonical method name for row hashing.
+            HashDigest value object containing the hash.
         """
 
     @abstractmethod
-    def compute_entity_key(self, row: dict[str, Any], key_columns: list[str]) -> str:
-        """Compute hash of business key columns.
+    def compute_entity_key(
+        self,
+        record: Mapping[str, Any],
+        key_fields: Sequence[str],
+    ) -> HashDigest:
+        """Compute hash of business key fields.
 
         Args:
-            row: Row data as dictionary.
-            key_columns: List of columns forming the business key.
+            record: Record data as mapping.
+            key_fields: Sequence of field names forming the business key.
 
         Returns:
-            Hex string hash of the business key.
-
-        Note:
-            This is the canonical method name for business key hashing.
+            HashDigest value object containing the hash.
         """
 
     @abstractmethod
+    def add_hashes_to_batch(
+        self,
+        records: RecordBatch,
+        key_fields: Sequence[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Add hash_row and hash_business_key to each record.
+
+        This is the pandas-free version for processing record batches.
+
+        Args:
+            records: Sequence of records (Mapping[str, Any]).
+            key_fields: Optional sequence of business key field names.
+
+        Returns:
+            List of dictionaries with added hash columns:
+            - hash_row: fingerprint of entire record
+            - hash_business_key: hash of key fields (or None if key_fields not provided)
+        """
+
     def add_hash_columns(
-        self, data: TabularData, business_key_cols: list[str] | None = None
+        self,
+        data: TabularData,
+        business_key_cols: Sequence[str] | None = None,
     ) -> MutableTabularData:
-        """Add hash_row and hash_business_key columns to data.
+        """Add hash_row and hash_business_key columns to tabular data.
+
+        This method works with TabularData abstraction (pandas-compatible).
+        For pandas-free processing, use add_hashes_to_batch().
 
         Args:
             data: Input tabular data.
-            business_key_cols: Optional list of business key column names.
+            business_key_cols: Optional sequence of business key column names.
 
         Returns:
-            Data with added hash columns.
+            MutableTabularData with added hash columns.
+
+        Note:
+            Default implementation converts to records and back.
+            Infrastructure may override for better performance.
         """
-
-    # =========================================================================
-    # Deprecated aliases (will be removed in v3.0)
-    # =========================================================================
-
-    def hash_row(self, row: dict) -> str:
-        """Deprecated: Use compute_row_fingerprint() instead.
-
-        Will be removed in v3.0.
-        """
-        warnings.warn(
-            "hash_row() is deprecated, use compute_row_fingerprint() instead. "
-            "Will be removed in v3.0.",
-            DeprecationWarning,
-            stacklevel=2,
+        records = data.to_records()
+        hashed = self.add_hashes_to_batch(records, business_key_cols)
+        # Infrastructure layer should provide optimized implementation
+        # This default raises to force infrastructure override
+        raise NotImplementedError(
+            "Infrastructure must override add_hash_columns for TabularData support"
         )
-        return self.compute_row_fingerprint(row)
-
-    def hash_business_key(self, row: dict, key_columns: list[str]) -> str:
-        """Deprecated: Use compute_entity_key() instead.
-
-        Will be removed in v3.0.
-        """
-        warnings.warn(
-            "hash_business_key() is deprecated, use compute_entity_key() instead. "
-            "Will be removed in v3.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.compute_entity_key(row, key_columns)
 
 
 class TimestampProviderABC(ABC):
@@ -234,11 +251,12 @@ class IndexGeneratorABC(ABC):
 
 
 __all__ = [
+    "HashDigest",
+    "HasherABC",
+    "HashServiceABC",
+    "IndexGeneratorABC",
     "NormalizationConfig",
     "NormalizationConfigProviderProtocol",
-    "HasherABC",
     "NormalizationServiceABC",
-    "HashServiceABC",
     "TimestampProviderABC",
-    "IndexGeneratorABC",
 ]

--- a/src/bioetl/domain/value_objects.py
+++ b/src/bioetl/domain/value_objects.py
@@ -153,6 +153,90 @@ class PipelineId:
         )
 
 
+class HashDigest:
+    """Value Object for cryptographic hash digest (hex-encoded).
+
+    Provides type safety for hash values throughout the system.
+    Supports common algorithms: blake2b_256, sha256, md5.
+
+    Attributes:
+        value: Hex-encoded hash string (lowercase).
+        algorithm: Algorithm identifier (e.g., 'blake2b_256').
+    """
+
+    __slots__ = ("_value", "_algorithm")
+    _hex_pattern = re.compile(r"^[0-9a-f]+$")
+    _known_lengths: dict[str, int] = {
+        "blake2b_256": 64,  # 256 bits = 64 hex chars
+        "sha256": 64,
+        "sha512": 128,
+        "md5": 32,
+    }
+
+    def __init__(self, value: str, algorithm: str = "blake2b_256") -> None:
+        """Initialize HashDigest.
+
+        Args:
+            value: Hex-encoded hash string.
+            algorithm: Algorithm identifier (default: blake2b_256).
+
+        Raises:
+            ValueError: If value is not valid hex or has wrong length for algorithm.
+        """
+        normalized = value.lower()
+        if not self._hex_pattern.match(normalized):
+            raise ValueError(f"HashDigest must be hex string: {value}")
+
+        expected_len = self._known_lengths.get(algorithm)
+        if expected_len is not None and len(normalized) != expected_len:
+            raise ValueError(
+                f"HashDigest length mismatch for {algorithm}: "
+                f"expected {expected_len}, got {len(normalized)}"
+            )
+
+        self._value = normalized
+        self._algorithm = algorithm
+
+    @property
+    def value(self) -> str:
+        """Hex-encoded hash string."""
+        return self._value
+
+    @property
+    def algorithm(self) -> str:
+        """Algorithm identifier."""
+        return self._algorithm
+
+    def __str__(self) -> str:
+        return self._value
+
+    def __repr__(self) -> str:
+        return f"HashDigest({self._value!r}, algorithm={self._algorithm!r})"
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, HashDigest):
+            return self._value == other._value and self._algorithm == other._algorithm
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash((self._value, self._algorithm))
+
+    @classmethod
+    def from_hex(cls, hex_string: str, algorithm: str = "blake2b_256") -> Self:
+        """Create HashDigest from hex string."""
+        return cls(hex_string, algorithm)
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: type, handler: GetCoreSchemaHandler
+    ) -> CoreSchema:
+        return core_schema.no_info_after_validator_function(
+            lambda v: cls(v) if isinstance(v, str) else v,
+            core_schema.str_schema(),
+            serialization=core_schema.plain_serializer_function_ser_schema(str),
+        )
+
+
 class ChemblId:
     """Value Object для ChEMBL идентификатора (формат CHEMBL123)."""
 


### PR DESCRIPTION
- Add HashDigest value object for type-safe hash representation
- Update HashServiceABC with new methods:
  - compute_fingerprint() returns HashDigest (replaces compute_row_fingerprint)
  - compute_entity_key() returns HashDigest (updated signature)
  - add_hashes_to_batch() for pandas-free batch processing
- Update HasherABC with simplified interface:
  - compute_hash() returns HashDigest
  - compute_hash_for_fields() for field-specific hashing
- Remove deprecated aliases (hash_row, hash_business_key)
- Add RecordBatch type alias to domain.data
- Export HashDigest from domain and domain.transform