### PR TITLE
Add module-level docstrings for architecture

### DIFF
--- a/src/bioetl/application/__init__.py
+++ b/src/bioetl/application/__init__.py
@@ -1,7 +1,23 @@
 """
-Application layer package.
+Application layer — orchestration and use cases.
 
-Provides core orchestration components for pipeline assembly and execution.
+This layer coordinates domain logic and infrastructure adapters.
+It contains no business rules (those are in domain) and no I/O details
+(those are in infrastructure).
+
+Key components:
+    PipelineOrchestrator: Entry point for pipeline execution and assembly.
+    PipelineContainer: DI container for pipeline dependencies.
+    ApplicationBootstrap: Application lifecycle and dependency wiring.
+    Factories: Create specialized services and components.
+
+Typical usage::
+
+    from bioetl.application import PipelineOrchestrator, create_application_bootstrap
+
+    bootstrap = create_application_bootstrap(config_path)
+    orchestrator = PipelineOrchestrator(pipeline_name, config, ...)
+    result = orchestrator.run_pipeline()
 """
 
 from bioetl.application.bootstrap import (

--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -1,4 +1,31 @@
-"""Dependency Injection Container for the application."""
+"""
+Dependency Injection Container for the application.
+
+This module provides the core DI container that assembles pipeline dependencies.
+The container follows the Composition Root pattern — all object graph construction
+happens here, keeping the rest of the application free of "new" calls.
+
+Architecture notes:
+    - PipelineContainer implements PipelineContainerABC (contracts module)
+    - Uses lazy initialization for factories to defer expensive operations
+    - Supports both direct injection and provider callbacks for flexibility
+    - Delegates specialized concerns to sub-factories (service, transform, runtime)
+
+Dependency resolution order:
+    1. Explicit constructor arguments (highest priority)
+    2. Injected factory instances
+    3. Default factory creation (lowest priority)
+
+Example::
+
+    container = PipelineContainer(
+        config,
+        loader=parquet_loader,
+        provider_registry=registry,
+    )
+    logger = container.get_logger()
+    hash_service = container.get_hash_service()
+"""
 
 from __future__ import annotations
 
@@ -110,15 +137,19 @@ class PipelineContainer(PipelineContainerABC):
     # ─────────────────────────────────────────────────────────────────────────
 
     def get_logger(self) -> LoggingPortABC:
+        """Return the logging port for pipeline observability."""
         return self._logger
 
     def get_validation_service(self) -> ValidationService:
+        """Create and return a validation service with schema registry."""
         return ValidationService(self._schema_provider, self._validator_factory)
 
     def get_loader(self) -> LoaderABC:
+        """Return the loader for writing output data."""
         return self._loader
 
     def get_metadata_builder(self) -> RunMetadataBuilderProtocol:
+        """Return the metadata builder for run result construction."""
         return self._metadata_builder
 
     # ─────────────────────────────────────────────────────────────────────────
@@ -126,9 +157,11 @@ class PipelineContainer(PipelineContainerABC):
     # ─────────────────────────────────────────────────────────────────────────
 
     def get_extraction_service(self) -> Any:
+        """Create and return an extraction service via the service factory."""
         return self._get_service_factory().create_extraction_service()
 
     def get_normalization_service(self) -> NormalizationServiceABC:
+        """Create and return a normalization service via the service factory."""
         return self._get_service_factory().create_normalization_service()
 
     # ─────────────────────────────────────────────────────────────────────────
@@ -136,17 +169,28 @@ class PipelineContainer(PipelineContainerABC):
     # ─────────────────────────────────────────────────────────────────────────
 
     def get_hash_service(self) -> HashServiceABC:
+        """Return the hash service for record deduplication."""
         return self._get_transform_factory().get_hash_service()
 
     def get_index_generator(self) -> IndexGeneratorABC:
+        """Return the index generator for unique record identifiers."""
         return self._get_transform_factory().get_index_generator()
 
     def get_timestamp_provider(self) -> TimestampProviderABC:
+        """Return the timestamp provider for record timestamping."""
         return self._get_transform_factory().get_timestamp_provider()
 
     def get_post_transformer(
         self, *, version_provider: Callable[[], str | None] | None = None
     ) -> TransformerABC:
+        """
+        Return the post-transformer for adding standard fields.
+
+        The post-transformer adds hash, index, and timestamp columns to records.
+
+        Args:
+            version_provider: Optional callable returning source version string.
+        """
         if self._post_transformer is not None:
             return self._post_transformer
         return self._get_transform_factory().get_post_transformer(
@@ -166,6 +210,19 @@ class PipelineContainer(PipelineContainerABC):
         model_cls: type | None = None,
         batch_adapter: Any | None = None,
     ) -> RecordSourceABC:
+        """
+        Create a record source for iterating over extracted data.
+
+        Args:
+            extraction_service: Service providing raw data extraction.
+            limit: Optional maximum number of records to extract.
+            logger: Logger instance (defaults to container's logger).
+            model_cls: Optional model class for record conversion.
+            batch_adapter: Optional adapter for batch processing.
+
+        Returns:
+            Record source providing chunked data iteration.
+        """
         return self._get_record_source_factory().create_record_source(
             extraction_service,
             limit=limit,
@@ -179,9 +236,11 @@ class PipelineContainer(PipelineContainerABC):
     # ─────────────────────────────────────────────────────────────────────────
 
     def get_hooks(self) -> list[PipelineHookABC]:
+        """Return the list of pipeline execution hooks."""
         return self._runtime_factory.get_hooks(self.get_logger())
 
     def get_error_policy(self) -> ErrorPolicyABC:
+        """Return the error handling policy for pipeline stages."""
         return self._runtime_factory.get_error_policy()
 
     # ─────────────────────────────────────────────────────────────────────────

--- a/src/bioetl/application/executor.py
+++ b/src/bioetl/application/executor.py
@@ -1,4 +1,31 @@
-"""Pipeline executor that manages state machine for pipeline runs."""
+"""
+Pipeline executor that manages state machine for pipeline runs.
+
+This module implements the execution engine for ETL pipelines. It separates
+the "how to run" logic from the "what to run" logic in PipelineBase.
+
+Architecture notes:
+    - PipelineExecutor implements the State Machine pattern for run lifecycle
+    - Uses _RunState dataclass to maintain execution state (immutable context)
+    - Delegates actual stage work to the pipeline instance
+    - Handles error recovery and result construction
+
+Execution flow:
+    1. Initialize: Reset state, build context, bind logger
+    2. Extract phase: Run extract → transform → validate in chunks
+    3. Write phase: Concatenate validated chunks, write output (if not dry_run)
+    4. Finalize: Build metadata, construct RunResult
+
+Error handling:
+    - PipelineStageError caught and converted to failed RunResult
+    - Stage results recorded even on failure for debugging
+    - Error messages propagated to RunResult.errors list
+
+Example::
+
+    executor = PipelineExecutor(runtime_manager, metadata_builder, logger)
+    result = executor.execute(pipeline, output_path, dry_run=False)
+"""
 
 from __future__ import annotations
 

--- a/src/bioetl/application/orchestrator.py
+++ b/src/bioetl/application/orchestrator.py
@@ -1,4 +1,33 @@
-"""Pipeline orchestration utilities for BioETL."""
+"""
+Pipeline orchestration utilities for BioETL.
+
+This module provides the main entry point for assembling and executing pipelines.
+The orchestrator acts as a facade that hides the complexity of:
+    - Provider registry resolution and lifecycle
+    - Container assembly and dependency injection
+    - Pipeline factory selection and instantiation
+    - Subprocess execution for background runs
+
+Architecture notes:
+    - Orchestrator is stateless except for registry caching
+    - Uses factory pattern for container and registry creation
+    - Supports both synchronous and background (subprocess) execution
+    - Registry can be injected directly or via lazy provider callback
+
+Execution modes:
+    FULL: Extract → Transform → Validate → Write (default)
+    TRANSFORM_ONLY: Extract → Transform → Validate (dry_run=True)
+    EXTRACT_ONLY: Extract only, returns record counts
+
+Example::
+
+    orchestrator = PipelineOrchestrator(
+        "chembl_assay",
+        config,
+        provider_registry=registry,
+    )
+    result = orchestrator.run_pipeline(dry_run=False, limit=1000)
+"""
 
 from __future__ import annotations
 
@@ -79,7 +108,17 @@ class PipelineOrchestrator:
         limit: int | None = None,
         pipeline_type: PipelineType | None = None,
     ) -> RunResult:
-        """Запускает пайплайн в текущем процессе."""
+        """
+        Execute the pipeline synchronously in the current process.
+
+        Args:
+            dry_run: If True, skip the write stage (validate only).
+            limit: Optional maximum number of records to process.
+            pipeline_type: Override pipeline execution mode (FULL, TRANSFORM_ONLY, etc.).
+
+        Returns:
+            RunResult containing execution status, metrics, and metadata.
+        """
         effective_type = pipeline_type or self._config.pipeline_type
         pipeline = self.build_pipeline(limit=limit)
 
@@ -148,7 +187,20 @@ class PipelineOrchestrator:
         limit: int | None = None,
         executor: ProcessPoolExecutor | None = None,
     ) -> Future[RunResult]:
-        """Запускает пайплайн в отдельном процессе."""
+        """
+        Execute the pipeline asynchronously in a separate process.
+
+        Useful for long-running pipelines to avoid blocking the main thread.
+        The pipeline configuration is serialized and executed in a subprocess.
+
+        Args:
+            dry_run: If True, skip the write stage.
+            limit: Optional maximum number of records to process.
+            executor: Optional ProcessPoolExecutor (creates one if not provided).
+
+        Returns:
+            Future that resolves to RunResult when pipeline completes.
+        """
         from concurrent.futures import ProcessPoolExecutor
 
         executor_to_use = executor or ProcessPoolExecutor(max_workers=1)

--- a/src/bioetl/application/pipelines/base.py
+++ b/src/bioetl/application/pipelines/base.py
@@ -1,4 +1,39 @@
-"""Базовый класс пайплайна."""
+"""
+Base pipeline class — Template Method pattern for ETL stages.
+
+This module provides the abstract base class that all concrete pipelines extend.
+It implements the Template Method pattern where the algorithm skeleton (extract →
+transform → validate → write) is defined here, while concrete steps are
+deferred to subclasses.
+
+Architecture notes:
+    - PipelineBase is abstract: subclasses MUST implement extract() and transform()
+    - Uses composition for cross-cutting concerns (hooks, error policy, transformers)
+    - Delegates execution orchestration to PipelineExecutor
+    - StageRuntimeManager handles hook notifications and error recovery
+
+Key extension points:
+    extract(): Yield raw data chunks from source (abstract)
+    transform(): Convert raw data to domain model (abstract)
+    validate(): Validate against Pandera schema (default provided)
+    write(): Persist to output (default uses injected Loader)
+    get_version(): Return source version string (override for versioned sources)
+
+Stage composition:
+    - Pre-transform: extract() yields raw chunks
+    - Transform: transform() + _apply_transformers() (adds hash/index/timestamp)
+    - Validate: validate() ensures schema compliance
+    - Write: write() persists via Loader
+
+Example::
+
+    class ChEMBLAssayPipeline(PipelineBase):
+        def extract(self, **kwargs) -> Iterator[pd.DataFrame]:
+            yield from self._extraction_service.fetch_assays(limit=kwargs.get("limit"))
+
+        def transform(self, df: pd.DataFrame) -> pd.DataFrame:
+            return self._normalization_service.normalize_assays(df)
+"""
 
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
@@ -143,7 +178,21 @@ class PipelineBase(ABC):
         dry_run: bool = False,
         **kwargs: Any,
     ) -> RunResult:
-        """Запускает полный цикл ETL-пайплайна."""
+        """
+        Execute the complete ETL pipeline cycle.
+
+        This is the main entry point for pipeline execution. It creates an
+        executor and delegates the actual run to it, ensuring proper state
+        management and error handling.
+
+        Args:
+            output_path: Path where output files will be written.
+            dry_run: If True, skip the write stage (useful for validation).
+            **kwargs: Additional arguments passed to extract stage.
+
+        Returns:
+            RunResult with execution status, metrics, and any errors.
+        """
         executor = PipelineExecutor(
             self._runtime_manager,
             self._metadata_builder,


### PR DESCRIPTION
Add comprehensive module-level docstrings describing architecture to:
- __init__.py: Application layer overview and key components
- container.py: DI container and composition root pattern
- orchestrator.py: Pipeline assembly and execution facade
- executor.py: State machine for ETL runs
- pipelines/base.py: Template Method pattern for stages

Also add docstrings to all public methods in container.py and enhance method docstrings in orchestrator.py and base.py.