### PR TITLE
01-Refactor ChemblResponseParser for multiple entity types

### DIFF
--- a/src/bioetl/infrastructure/clients/chembl/response_parser.py
+++ b/src/bioetl/infrastructure/clients/chembl/response_parser.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 from bioetl.domain.ports.parsing import (
     ApiPayload,
     RawRecord,
@@ -89,7 +91,43 @@ def create_generic_parser() -> ResponseParserPortABC:
     return ChemblGenericResponseParser()
 
 
+# =============================================================================
+# Deprecated Aliases (Backward Compatibility)
+# =============================================================================
+
+# Legacy class name that was previously typed on ActivityRawModel.
+# Available via __getattr__ to emit deprecation warning on first access.
+_DEPRECATED_ALIASES = {
+    "ChemblResponseParserImpl": "ChemblGenericResponseParser",
+}
+
+
+def __getattr__(name: str) -> object:
+    """Emit deprecation warning for legacy class name imports.
+
+    Enables backward-compatible imports like:
+        from bioetl.infrastructure.clients.chembl.response_parser import (
+            ChemblResponseParserImpl
+        )
+
+    But emits a DeprecationWarning directing users to the new class name.
+    """
+    if name in _DEPRECATED_ALIASES:
+        new_name = _DEPRECATED_ALIASES[name]
+        warnings.warn(
+            f"{name} is deprecated, use {new_name} instead. "
+            "ChemblResponseParserImpl was removed in v2.0 as part of hexagonal "
+            "architecture refactoring. See docs/migration/2.0-hexagonal-architecture.md",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return ChemblGenericResponseParser
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 __all__ = [
     "ChemblGenericResponseParser",
     "create_generic_parser",
+    # Deprecated aliases (available via __getattr__)
+    "ChemblResponseParserImpl",
 ]

--- a/tests/bioetl/infrastructure/clients/chembl/test_generic_response_parser.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_generic_response_parser.py
@@ -197,3 +197,48 @@ class TestNoDomainImportsAtModuleLevel:
         assert "ActivityRawModel" not in source
         assert "MoleculeRawModel" not in source
         assert "TargetRawModel" not in source
+
+
+class TestDeprecatedAlias:
+    """Tests for backward-compatible deprecated alias."""
+
+    def test_chembl_response_parser_impl_alias_emits_warning(self):
+        """Test that importing ChemblResponseParserImpl emits deprecation warning."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            # Import the deprecated alias
+            from bioetl.infrastructure.clients.chembl.response_parser import (
+                ChemblResponseParserImpl,
+            )
+
+            deprecation_warnings = [
+                x for x in w if issubclass(x.category, DeprecationWarning)
+            ]
+            assert len(deprecation_warnings) == 1
+            assert "ChemblResponseParserImpl is deprecated" in str(
+                deprecation_warnings[0].message
+            )
+            assert "ChemblGenericResponseParser" in str(deprecation_warnings[0].message)
+
+    def test_chembl_response_parser_impl_alias_returns_correct_class(self):
+        """Test that ChemblResponseParserImpl alias returns ChemblGenericResponseParser."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            from bioetl.infrastructure.clients.chembl.response_parser import (
+                ChemblResponseParserImpl,
+            )
+
+            assert ChemblResponseParserImpl is ChemblGenericResponseParser
+
+    def test_chembl_response_parser_impl_alias_is_functional(self):
+        """Test that deprecated alias can be instantiated and used."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            from bioetl.infrastructure.clients.chembl.response_parser import (
+                ChemblResponseParserImpl,
+            )
+
+            parser = ChemblResponseParserImpl()
+            response = {"activities": [{"id": "1"}]}
+            records = parser.parse_to_records(response)
+            assert records == [{"id": "1"}]


### PR DESCRIPTION
The generic parser ChemblGenericResponseParser was created as part of the hexagonal architecture refactoring but the deprecated alias for the old class name ChemblResponseParserImpl was missing. This adds backward compatibility for code that imports the legacy name while emitting a DeprecationWarning directing users to the new name.