### PR TITLE
01-Remove lazy import from pipeline config validator

### DIFF
--- a/src/bioetl/application/bootstrap.py
+++ b/src/bioetl/application/bootstrap.py
@@ -27,6 +27,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable
 
+from bioetl.application.services.config_migration_service import (
+    ConfigMigrationService,
+    ConfigMigrationServiceProtocol,
+    create_config_migration_service,
+)
 from bioetl.application.services.schema_bootstrap import (
     SchemaBootstrapService,
     create_schema_bootstrap_service,
@@ -60,11 +65,15 @@ class ApplicationContext:
         contract_provider: Provider for schema contracts used by pipelines.
         config_loader: Loader for pipeline configurations (may be None if
             no config loader factory was provided).
+        migration_service: Service for migrating and validating raw configs.
+            Provides application-layer interface for config migration without
+            going through full loader flow.
     """
 
     schema_provider: SchemaProviderABC
     contract_provider: SchemaContractProviderABC
     config_loader: PipelineConfigLoaderProtocol | None = None
+    migration_service: ConfigMigrationServiceProtocol | None = None
 
 
 class ApplicationBootstrap:
@@ -143,10 +152,14 @@ class ApplicationBootstrap:
         if self._config_loader_factory is not None:
             config_loader = self._config_loader_factory(contract_provider)
 
+        # Create migration service
+        migration_service = self._init_migration_service()
+
         self._context = ApplicationContext(
             schema_provider=schema_provider,
             contract_provider=contract_provider,
             config_loader=config_loader,
+            migration_service=migration_service,
         )
         self._started = True
         return self._context
@@ -213,6 +226,14 @@ class ApplicationBootstrap:
         """
         return SchemaContractProviderImpl(schema_provider)
 
+    def _init_migration_service(self) -> ConfigMigrationServiceProtocol:
+        """Initialize and return the config migration service.
+
+        Returns:
+            ConfigMigrationService for migrating and validating raw configs.
+        """
+        return create_config_migration_service()
+
 
 def create_application_bootstrap(
     *,
@@ -256,7 +277,10 @@ __all__ = [
     "ApplicationBootstrap",
     "ApplicationContext",
     "ConfigLoaderFactory",
+    "ConfigMigrationService",
+    "ConfigMigrationServiceProtocol",
     "ProviderClearer",
     "ProviderInjector",
     "create_application_bootstrap",
+    "create_config_migration_service",
 ]

--- a/src/bioetl/application/services/__init__.py
+++ b/src/bioetl/application/services/__init__.py
@@ -1,5 +1,10 @@
 """Application services for pipeline orchestration."""
 
+from bioetl.application.services.config_migration_service import (
+    ConfigMigrationService,
+    ConfigMigrationServiceProtocol,
+    create_config_migration_service,
+)
 from bioetl.application.services.schema_bootstrap import (
     SchemaBootstrapService,
     create_schema_bootstrap_service,
@@ -9,7 +14,10 @@ from bioetl.application.services.schema_contract_provider import (
 )
 
 __all__ = [
+    "ConfigMigrationService",
+    "ConfigMigrationServiceProtocol",
     "SchemaBootstrapService",
     "SchemaContractProviderImpl",
+    "create_config_migration_service",
     "create_schema_bootstrap_service",
 ]

--- a/src/bioetl/application/services/config_migration_service.py
+++ b/src/bioetl/application/services/config_migration_service.py
@@ -1,0 +1,256 @@
+"""Configuration migration service (application layer).
+
+This module provides application-layer services for migrating and validating
+pipeline configurations. It delegates the actual migration logic to the
+infrastructure layer (ConfigMigrator) while keeping the domain layer clean.
+
+This follows Hexagonal Architecture principles:
+- Domain layer (PipelineConfig) contains only business rules
+- Application layer (ConfigMigrationService) orchestrates use cases
+- Infrastructure layer (ConfigMigrator) handles technical migration logic
+
+Example:
+    >>> from bioetl.application.services import ConfigMigrationService
+    >>> service = ConfigMigrationService()
+    >>> config = service.migrate_and_validate({"entity": "activity", ...})
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any
+
+from pydantic import ValidationError
+
+from bioetl.domain.configs import PipelineConfig
+from bioetl.domain.errors import ConfigValidationError
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigMigrationServiceProtocol(ABC):
+    """Protocol for configuration migration services.
+
+    Defines the contract for services that handle migration of legacy
+    configuration formats and validation into PipelineConfig domain objects.
+
+    This protocol enables dependency injection and testability by allowing
+    mock implementations in tests.
+
+    Example:
+        >>> class MockMigrationService(ConfigMigrationServiceProtocol):
+        ...     def migrate_and_validate(self, raw_config: dict) -> PipelineConfig:
+        ...         return PipelineConfig(...)  # Return test fixture
+    """
+
+    @abstractmethod
+    def migrate_and_validate(
+        self,
+        raw_config: dict[str, Any],
+        *,
+        source_hint: str | None = None,
+    ) -> PipelineConfig:
+        """Migrate legacy config format and validate into PipelineConfig.
+
+        Args:
+            raw_config: Raw configuration dictionary (possibly in legacy format).
+            source_hint: Optional hint about config source for error messages
+                (e.g., file path, pipeline_id).
+
+        Returns:
+            Validated PipelineConfig domain object.
+
+        Raises:
+            ConfigValidationError: If validation fails after migration.
+        """
+        ...
+
+    @abstractmethod
+    def migrate(self, raw_config: dict[str, Any]) -> dict[str, Any]:
+        """Migrate legacy config format without validation.
+
+        Useful when additional processing is needed before validation.
+
+        Args:
+            raw_config: Raw configuration dictionary (possibly in legacy format).
+
+        Returns:
+            Migrated configuration dictionary in current format.
+        """
+        ...
+
+    @abstractmethod
+    def was_migration_applied(self, raw_config: dict[str, Any]) -> bool:
+        """Check if migration would be applied to the given config.
+
+        Useful for logging/debugging to determine if a config is in legacy format.
+
+        Args:
+            raw_config: Raw configuration dictionary.
+
+        Returns:
+            True if migration would transform the config, False if already
+            in current format.
+        """
+        ...
+
+
+class ConfigMigrationService(ConfigMigrationServiceProtocol):
+    """Application service for config migration and validation.
+
+    Orchestrates the migration of legacy configuration formats to current
+    structure and validates the result into PipelineConfig domain objects.
+
+    This service:
+    - Delegates migration logic to infrastructure layer (ConfigMigrator)
+    - Logs when migration is applied (for debugging)
+    - Provides clean separation between domain and infrastructure
+
+    Attributes:
+        _migrator_class: Reference to ConfigMigrator for lazy import.
+
+    Example:
+        >>> service = ConfigMigrationService()
+        >>> raw = {"entity": "activity", "provider": "chembl", ...}
+        >>> config = service.migrate_and_validate(raw, source_hint="test.yaml")
+    """
+
+    def __init__(self) -> None:
+        """Initialize the migration service.
+
+        The ConfigMigrator is imported lazily to avoid circular dependencies
+        at module load time.
+        """
+        self._migrator_class: type | None = None
+
+    def _get_migrator(self) -> type:
+        """Lazy import of ConfigMigrator from infrastructure.
+
+        Returns:
+            ConfigMigrator class from infrastructure layer.
+        """
+        if self._migrator_class is None:
+            from bioetl.infrastructure.config.migration import ConfigMigrator
+
+            self._migrator_class = ConfigMigrator
+        return self._migrator_class
+
+    def migrate(self, raw_config: dict[str, Any]) -> dict[str, Any]:
+        """Migrate legacy config format without validation.
+
+        Args:
+            raw_config: Raw configuration dictionary (possibly in legacy format).
+
+        Returns:
+            Migrated configuration dictionary in current format.
+        """
+        if not isinstance(raw_config, dict):
+            return raw_config
+
+        migrator = self._get_migrator()
+        return migrator.migrate(raw_config)
+
+    def was_migration_applied(self, raw_config: dict[str, Any]) -> bool:
+        """Check if migration would be applied to the given config.
+
+        Detects legacy v1 format by checking for flat entity/provider fields
+        without identity section.
+
+        Args:
+            raw_config: Raw configuration dictionary.
+
+        Returns:
+            True if config appears to be in legacy format.
+        """
+        if not isinstance(raw_config, dict):
+            return False
+
+        # Legacy v1 indicators: flat entity/provider without identity section
+        has_identity = "identity" in raw_config
+        has_flat_entity = "entity" in raw_config or "entity_name" in raw_config
+        has_flat_provider = "provider" in raw_config
+
+        # v1: has flat fields but no identity section
+        if not has_identity and (has_flat_entity or has_flat_provider):
+            return True
+
+        # Also check for legacy sources section
+        if "sources" in raw_config and not has_identity:
+            return True
+
+        return False
+
+    def migrate_and_validate(
+        self,
+        raw_config: dict[str, Any],
+        *,
+        source_hint: str | None = None,
+    ) -> PipelineConfig:
+        """Migrate legacy config format and validate into PipelineConfig.
+
+        Performs migration first, then Pydantic validation. Logs when
+        migration is applied to help identify configs that need updating.
+
+        Args:
+            raw_config: Raw configuration dictionary (possibly in legacy format).
+            source_hint: Optional hint about config source for error messages.
+
+        Returns:
+            Validated PipelineConfig domain object.
+
+        Raises:
+            ConfigValidationError: If validation fails after migration.
+
+        Example:
+            >>> service = ConfigMigrationService()
+            >>> config = service.migrate_and_validate(
+            ...     {"entity": "activity", "provider": "chembl"},
+            ...     source_hint="chembl.activity.yaml",
+            ... )
+        """
+        # Check if migration will be applied (for logging)
+        needs_migration = self.was_migration_applied(raw_config)
+
+        # Apply migration
+        migrated = self.migrate(raw_config)
+
+        # Log if migration was applied
+        if needs_migration:
+            source_info = f" from '{source_hint}'" if source_hint else ""
+            logger.debug(
+                "Legacy config format detected%s. "
+                "Consider updating to v2 format with identity/data_flow sections.",
+                source_info,
+            )
+
+        # Validate with Pydantic
+        try:
+            return PipelineConfig.model_validate(migrated)
+        except ValidationError as exc:
+            source_info = f" for {source_hint}" if source_hint else ""
+            raise ConfigValidationError(
+                f"Config validation failed{source_info}: {exc}"
+            ) from exc
+
+
+def create_config_migration_service() -> ConfigMigrationService:
+    """Factory function for creating ConfigMigrationService.
+
+    Provides a clean factory interface for dependency injection.
+
+    Returns:
+        New ConfigMigrationService instance.
+
+    Example:
+        >>> service = create_config_migration_service()
+        >>> config = service.migrate_and_validate(raw_config)
+    """
+    return ConfigMigrationService()
+
+
+__all__ = [
+    "ConfigMigrationService",
+    "ConfigMigrationServiceProtocol",
+    "create_config_migration_service",
+]

--- a/src/bioetl/domain/configs/pipeline.py
+++ b/src/bioetl/domain/configs/pipeline.py
@@ -764,16 +764,6 @@ class PipelineConfig(BaseModel):
                 )
         return self
 
-    @model_validator(mode="before")
-    @classmethod
-    def migrate_legacy_format(cls, data: dict[str, Any]) -> dict[str, Any]:
-        """Delegate migration to ConfigMigrator."""
-        # Lazy import from infrastructure layer to avoid circular imports
-        # ConfigMigrator was moved from domain to infrastructure as migration
-        # is a technical concern, not a business rule
-        from bioetl.infrastructure.config.migration import ConfigMigrator
-
-        return ConfigMigrator.migrate(data)
 
     # =========================================================================
     # Manifest conversion methods

--- a/src/bioetl/infrastructure/config/loader.py
+++ b/src/bioetl/infrastructure/config/loader.py
@@ -323,9 +323,9 @@ def _build_config(
         cli_values = resolve_env_placeholders(cli_overrides)
         merged = apply_deep_merge(merged, cli_values)
 
-    # Migration is handled by PipelineConfig.migrate_legacy_format validator,
-    # which delegates to ConfigMigrator. We also apply it here to ensure
-    # provider_config is extracted from sources before provider validation.
+    # Migration is handled here in the infrastructure layer before Pydantic validation.
+    # This keeps the domain layer (PipelineConfig) clean from infrastructure dependencies.
+    # The migration extracts provider_config from sources before provider validation.
     merged = ConfigMigrator.migrate(merged)
 
     # After migration, provider is in identity section


### PR DESCRIPTION
This change fixes a Hexagonal Architecture violation where domain layer (PipelineConfig) was importing from infrastructure layer (ConfigMigrator).

Changes:
- Remove migrate_legacy_format validator from PipelineConfig (domain)
- Add ConfigMigrationService with Protocol in application layer
- Integrate migration service into ApplicationContext/ApplicationBootstrap
- Update loader.py comment to reflect new architecture

The migration is now performed exclusively in the infrastructure layer (loader.py) before Pydantic validation, keeping the domain layer clean.