### PR TITLE
01-Unify RecordBatch type definitions

### DIFF
--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -1,31 +1,31 @@
 """
 Domain layer package.
 
-Terminology updates (v3.0 migration):
-    - SourceRecord: Canonical name for records from data sources.
-      Deprecated alias: RawRecord (will be removed in v3.0).
-
-Type Aliases (unified in v3.0):
-    - RawRecord: Single record as dict[str, Any]
-    - RecordBatch: Batch of records as list[RawRecord]
+Type Aliases
+------------
+API-specific types (from ``bioetl.domain.types``):
     - ApiPayload: Raw API response as dict[str, Any]
     - FieldConfig: Field configuration as dict[str, Any]
 
-    Import from ``bioetl.domain.types`` for type aliases.
-
-Tabular Data Abstractions:
+Tabular Data Abstractions (from ``bioetl.domain.data``):
     - Record: Single data record (dict-like interface)
+    - RecordBatch: Batch of records as Sequence[Mapping[str, Any]]
     - RecordSet: Collection of records with schema
     - TabularData: Full tabular data abstraction (replaces pd.DataFrame)
     - MutableTabularData: TabularData with mutation capabilities
 
-    Import from ``bioetl.domain.data`` for tabular data protocols.
+Migration Notes (v3.0)
+----------------------
+- ``RawRecord`` is deprecated. Use ``Mapping[str, Any]`` or ``Record`` protocol.
+- ``RecordBatch`` moved from ``domain.types`` to ``domain.data``.
+  The canonical definition is now ``Sequence[Mapping[str, Any]]``.
 """
 
 from bioetl.domain.aggregates import PipelineIdentity
 from bioetl.domain.data import (
     MutableTabularData,
     Record,
+    RecordBatch,
     RecordSet,
     TabularData,
 )
@@ -48,22 +48,19 @@ from bioetl.domain.record_source import (
 from bioetl.domain.types import (
     ApiPayload,
     FieldConfig,
-    RawRecord,
-    RecordBatch,
 )
 from bioetl.domain.value_objects import ChemblId, EntityName, HashDigest, PipelineId, RunId
 
 __all__ = [
-    # Tabular data abstractions
+    # Tabular data abstractions (from domain.data)
     "MutableTabularData",
     "Record",
+    "RecordBatch",
     "RecordSet",
     "TabularData",
-    # Type aliases
+    # API-specific type aliases (from domain.types)
     "ApiPayload",
     "FieldConfig",
-    "RawRecord",
-    "RecordBatch",
     # Errors
     "BioetlError",
     "ClientError",

--- a/src/bioetl/domain/data.py
+++ b/src/bioetl/domain/data.py
@@ -49,9 +49,20 @@ RecordBatch = Sequence[Mapping[str, Any]]
 RecordBatch represents a collection of records without pandas dependency.
 Each record is a Mapping (dict-like) of field names to values.
 
-Usage:
-    def process_batch(records: RecordBatch) -> list[dict]:
-        return [dict(r) for r in records]
+This is the CANONICAL definition for batch/collection of records in the domain layer.
+Use this type alias instead of the deprecated ``list[RawRecord]`` from ``domain.types``.
+
+Example:
+    >>> batch: RecordBatch = [
+    ...     {"id": "CHEMBL123", "name": "Aspirin", "mw": 180.16},
+    ...     {"id": "CHEMBL456", "name": "Ibuprofen", "mw": 206.29},
+    ... ]
+    >>> def process_batch(records: RecordBatch) -> list[dict[str, Any]]:
+    ...     return [dict(r) for r in records]
+
+Note:
+    ``Sequence[Mapping[str, Any]]`` is more general than ``list[dict[str, Any]]``,
+    allowing tuple of dicts, list of OrderedDicts, etc.
 """
 
 __all__ = [

--- a/src/bioetl/domain/ports/__init__.py
+++ b/src/bioetl/domain/ports/__init__.py
@@ -30,18 +30,16 @@ from bioetl.domain.ports.parsing import (
     ResponseParserPortABC,
 )
 from bioetl.domain.ports.schema import SchemaContractProviderABC
-from bioetl.domain.types import (
-    ApiPayload,
-    RawRecord,
-    RecordBatch,
-)
+from bioetl.domain.data import RecordBatch
+from bioetl.domain.types import ApiPayload
 
 # =============================================================================
 # Deprecated Type Aliases (backward compatibility re-exports)
 # =============================================================================
 
 _DEPRECATED_TYPE_ALIASES = {
-    "RawRecordDict": "RawRecord",
+    "RawRecord": "Mapping[str, Any]",  # Use Mapping[str, Any] directly
+    "RawRecordDict": "Mapping[str, Any]",
     "RawRecordBatch": "RecordBatch",
     "RawRecordList": "RecordBatch",
     "RawPayload": "ApiPayload",
@@ -50,26 +48,34 @@ _DEPRECATED_TYPE_ALIASES = {
 
 def __getattr__(name: str) -> type:
     """Emit deprecation warning for legacy type alias imports."""
+    from typing import Any
+
     if name in _DEPRECATED_TYPE_ALIASES:
         new_name = _DEPRECATED_TYPE_ALIASES[name]
         warnings.warn(
-            f"{name} is deprecated, use {new_name} from bioetl.domain.types instead. "
+            f"{name} is deprecated, use {new_name} instead. "
             "See migration guide in bioetl.domain.types module docstring.",
             DeprecationWarning,
             stacklevel=2,
         )
-        from bioetl.domain import types
+        # Return appropriate fallback types
+        if name in ("RawRecord", "RawRecordDict"):
+            return dict[str, Any]
+        elif name in ("RawRecordBatch", "RawRecordList"):
+            from bioetl.domain.data import RecordBatch as _RecordBatch
 
-        return getattr(types, new_name)
+            return _RecordBatch
+        elif name == "RawPayload":
+            return ApiPayload
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 __all__: list[str] = [
-    # Canonical type aliases (from domain.types)
-    "ApiPayload",
-    "RawRecord",
-    "RecordBatch",
-    # Deprecated type aliases (for backward compatibility)
+    # Canonical type aliases
+    "ApiPayload",  # from domain.types
+    "RecordBatch",  # from domain.data
+    # Deprecated type aliases (for backward compatibility via __getattr__)
+    "RawRecord",  # deprecated, use Mapping[str, Any]
     "RawRecordBatch",
     "RawRecordDict",
     "RawRecordList",

--- a/src/bioetl/domain/ports/extraction.py
+++ b/src/bioetl/domain/ports/extraction.py
@@ -7,11 +7,8 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Protocol
 
-from bioetl.domain.types import (
-    ApiPayload,
-    RawRecord,
-    RecordBatch,
-)
+from bioetl.domain.data import RecordBatch
+from bioetl.domain.types import ApiPayload
 
 # =============================================================================
 # Deprecated Type Aliases (backward compatibility re-exports)
@@ -23,7 +20,8 @@ __all__: list[str] = []  # Populated at end of module
 
 # Sentinel for lazy deprecation
 _DEPRECATED_TYPE_ALIASES = {
-    "RawRecordDict": "RawRecord",
+    "RawRecord": "Mapping[str, Any]",  # Use Mapping[str, Any] directly
+    "RawRecordDict": "Mapping[str, Any]",
     "RawRecordBatch": "RecordBatch",
 }
 
@@ -220,26 +218,32 @@ def __getattr__(name: str) -> object:
 
     But emits a DeprecationWarning directing users to the new location.
     """
+    from typing import Any
+
     if name in _DEPRECATED_TYPE_ALIASES:
         new_name = _DEPRECATED_TYPE_ALIASES[name]
         warnings.warn(
-            f"{name} is deprecated, use {new_name} from bioetl.domain.types instead. "
+            f"{name} is deprecated, use {new_name} instead. "
             "See migration guide in bioetl.domain.types module docstring.",
             DeprecationWarning,
             stacklevel=2,
         )
-        from bioetl.domain import types
+        # Return appropriate fallback types
+        if name in ("RawRecord", "RawRecordDict"):
+            return dict[str, Any]
+        elif name == "RawRecordBatch":
+            from bioetl.domain.data import RecordBatch as _RecordBatch
 
-        return getattr(types, new_name)
+            return _RecordBatch
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 __all__ = [
-    # Canonical type aliases (re-exported from domain.types)
-    "RawRecord",
-    "RecordBatch",
-    "ApiPayload",
+    # Canonical type aliases
+    "RecordBatch",  # from domain.data
+    "ApiPayload",  # from domain.types
     # Deprecated type aliases (for backward compatibility, available via __getattr__)
+    "RawRecord",  # deprecated, use Mapping[str, Any]
     "RawRecordDict",
     "RawRecordBatch",
     # Abstract base classes

--- a/src/bioetl/domain/ports/parsing.py
+++ b/src/bioetl/domain/ports/parsing.py
@@ -58,15 +58,18 @@ from typing import Generic
 
 from typing_extensions import TypeVar
 
-from bioetl.domain.types import (
-    ApiPayload,
-    RawRecord,
-    RecordBatch,
-)
+from collections.abc import Mapping
+from typing import Any
+
+from bioetl.domain.data import RecordBatch
+from bioetl.domain.types import ApiPayload
+
+# Type alias for a single raw record (replacing deprecated RawRecord from types)
+RawRecord = Mapping[str, Any]
 
 # Type variable for generic parser output
 # Uses typing_extensions.TypeVar for default= support on Python < 3.13
-RecordT = TypeVar("RecordT", default=RawRecord)
+RecordT = TypeVar("RecordT", default=dict[str, Any])
 
 # =============================================================================
 # Deprecated Type Aliases (backward compatibility re-exports)
@@ -76,7 +79,7 @@ RecordT = TypeVar("RecordT", default=RawRecord)
 
 _DEPRECATED_TYPE_ALIASES = {
     "RawPayload": "ApiPayload",
-    "RawRecordDict": "RawRecord",
+    "RawRecordDict": "Mapping[str, Any]",
     "RawRecordList": "RecordBatch",
 }
 
@@ -259,24 +262,30 @@ def __getattr__(name: str) -> object:
     if name in _DEPRECATED_TYPE_ALIASES:
         new_name = _DEPRECATED_TYPE_ALIASES[name]
         warnings.warn(
-            f"{name} is deprecated, use {new_name} from bioetl.domain.types instead. "
+            f"{name} is deprecated, use {new_name} instead. "
             "See migration guide in bioetl.domain.types module docstring.",
             DeprecationWarning,
             stacklevel=2,
         )
-        from bioetl.domain import types
+        # Return appropriate fallback types
+        if name == "RawRecordDict":
+            return dict[str, Any]
+        elif name == "RawRecordList":
+            from bioetl.domain.data import RecordBatch as _RecordBatch
 
-        return getattr(types, new_name)
+            return _RecordBatch
+        elif name == "RawPayload":
+            return ApiPayload
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 __all__ = [
     # Type variable
     "RecordT",
-    # Canonical type aliases (re-exported from domain.types)
-    "ApiPayload",
-    "RawRecord",
-    "RecordBatch",
+    # Canonical type aliases
+    "ApiPayload",  # from domain.types
+    "RecordBatch",  # from domain.data
+    "RawRecord",  # local alias for Mapping[str, Any]
     # Deprecated type aliases (for backward compatibility, available via __getattr__)
     "RawPayload",
     "RawRecordDict",

--- a/src/bioetl/domain/types.py
+++ b/src/bioetl/domain/types.py
@@ -1,99 +1,91 @@
 """Unified type aliases for the domain layer.
 
-This module provides canonical type aliases used throughout the domain layer
-to ensure consistency and reduce duplication across ports and contracts.
+This module provides canonical type aliases for API-specific types used
+throughout the domain layer to ensure consistency.
 
 Canonical Type Aliases
 ----------------------
-- ``RawRecord``: A single record as an untyped dictionary (dict[str, Any]).
-- ``RecordBatch``: A batch/list of raw records (list[RawRecord]).
 - ``ApiPayload``: Raw API response payload (dict[str, Any]).
 - ``FieldConfig``: Field configuration dictionary (dict[str, Any]).
 
+Tabular Data Types (moved to domain.data)
+-----------------------------------------
+For tabular data abstractions, import from ``bioetl.domain.data``:
+
+- ``RecordBatch``: Sequence of records (Sequence[Mapping[str, Any]])
+- ``Record``: Single data record protocol
+- ``RecordSet``: Collection of records with schema
+- ``TabularData``: Full tabular data abstraction
+
 Migration Guide
 ---------------
-The following legacy type aliases are deprecated and will be removed in v3.0:
+The following type aliases have been moved or deprecated:
+
++------------------+---------------+---------------------------------------------+
+| Old Location     | New Location  | Notes                                       |
++==================+===============+=============================================+
+| types.RawRecord  | (removed)     | Use Mapping[str, Any] or domain.data.Record |
++------------------+---------------+---------------------------------------------+
+| types.RecordBatch| data.RecordBatch | More general type: Sequence[Mapping]     |
++------------------+---------------+---------------------------------------------+
+
+Legacy deprecated aliases (will be removed in v3.0):
 
 +------------------+---------------+---------------------------------------------+
 | Legacy Name      | New Name      | Module                                      |
 +==================+===============+=============================================+
-| RawRecordDict    | RawRecord     | domain.ports.extraction, domain.ports.parsing|
+| RawRecordDict    | (removed)     | Use Mapping[str, Any]                       |
 +------------------+---------------+---------------------------------------------+
-| RawRecordBatch   | RecordBatch   | domain.ports.extraction                     |
+| RawRecordBatch   | RecordBatch   | bioetl.domain.data                          |
 +------------------+---------------+---------------------------------------------+
-| RawRecordList    | RecordBatch   | domain.ports.parsing                        |
+| RawRecordList    | RecordBatch   | bioetl.domain.data                          |
 +------------------+---------------+---------------------------------------------+
-| RawPayload       | ApiPayload    | domain.ports.parsing                        |
+| RawPayload       | ApiPayload    | bioetl.domain.types                         |
 +------------------+---------------+---------------------------------------------+
 
 Example migration::
 
     # Before (deprecated)
-    from bioetl.domain.ports.extraction import RawRecordDict, RawRecordBatch
-
-    def process(records: RawRecordBatch) -> RawRecordDict:
-        ...
-
-    # After (recommended)
     from bioetl.domain.types import RawRecord, RecordBatch
 
     def process(records: RecordBatch) -> RawRecord:
         ...
 
+    # After (recommended)
+    from bioetl.domain.data import RecordBatch
+    from typing import Mapping, Any
+
+    def process(records: RecordBatch) -> Mapping[str, Any]:
+        ...
+
 Usage Notes
 -----------
-Import from this module for new code::
+Import API-specific types from this module::
 
-    from bioetl.domain.types import RawRecord, RecordBatch, ApiPayload, FieldConfig
+    from bioetl.domain.types import ApiPayload, FieldConfig
 
-For backward compatibility, legacy aliases are re-exported from their original
-modules with deprecation warnings.
+Import tabular data types from domain.data::
+
+    from bioetl.domain.data import RecordBatch, Record, TabularData
 """
 
 from __future__ import annotations
 
 import warnings
-from typing import Any, TypeAlias
+from typing import TYPE_CHECKING, Any, TypeAlias
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
 
 __all__ = [
-    # Canonical type aliases
-    "RawRecord",
-    "RecordBatch",
+    # Canonical type aliases (API-specific)
     "ApiPayload",
     "FieldConfig",
-    # Deprecated aliases (for backward compatibility)
-    "RawRecordDict",
-    "RawRecordBatch",
-    "RawRecordList",
-    "RawPayload",
 ]
 
 # =============================================================================
-# Canonical Type Aliases
+# Canonical Type Aliases (API-specific)
 # =============================================================================
-
-RawRecord: TypeAlias = dict[str, Any]
-"""A single record as an untyped dictionary.
-
-Represents a single data record from an external source (API response,
-database row, etc.) before domain model mapping.
-
-Example:
-    >>> record: RawRecord = {"id": "CHEMBL123", "name": "Aspirin"}
-"""
-
-RecordBatch: TypeAlias = list[RawRecord]
-"""A batch/list of raw records.
-
-Represents multiple records fetched together, typically from a paginated
-API response or batch extraction.
-
-Example:
-    >>> batch: RecordBatch = [
-    ...     {"id": "CHEMBL123", "name": "Aspirin"},
-    ...     {"id": "CHEMBL456", "name": "Ibuprofen"},
-    ... ]
-"""
 
 ApiPayload: TypeAlias = dict[str, Any]
 """Raw API response payload.
@@ -124,66 +116,62 @@ Example:
 
 
 # =============================================================================
-# Deprecated Aliases (Backward Compatibility)
+# Deprecated Type Aliases (Backward Compatibility via __getattr__)
 # =============================================================================
 
-
-def _deprecated_alias(
-    old_name: str, new_name: str, value: TypeAlias
-) -> TypeAlias:
-    """Helper to create deprecated alias with runtime warning on access.
-
-    Note: TypeAlias assignments are resolved at import time, so we can't
-    intercept access. The deprecation warning is emitted via module __getattr__
-    for dynamic imports, and via explicit re-exports in ports modules.
-    """
-    return value
-
-
-# These are direct assignments for static type checkers.
-# Deprecation warnings are emitted via __getattr__ in ports modules.
-RawRecordDict: TypeAlias = RawRecord
-"""Deprecated: Use ``RawRecord`` instead."""
-
-RawRecordBatch: TypeAlias = RecordBatch
-"""Deprecated: Use ``RecordBatch`` instead."""
-
-RawRecordList: TypeAlias = RecordBatch
-"""Deprecated: Use ``RecordBatch`` instead."""
-
-RawPayload: TypeAlias = ApiPayload
-"""Deprecated: Use ``ApiPayload`` instead."""
-
-
-# =============================================================================
-# Module-level __getattr__ for deprecation warnings
-# =============================================================================
-
-_DEPRECATED_NAMES: dict[str, tuple[str, TypeAlias]] = {
-    "RawRecordDict": ("RawRecord", RawRecord),
-    "RawRecordBatch": ("RecordBatch", RecordBatch),
-    "RawRecordList": ("RecordBatch", RecordBatch),
-    "RawPayload": ("ApiPayload", ApiPayload),
+# Map of deprecated names to (new_location, deprecation_message)
+_DEPRECATED_NAMES: dict[str, tuple[str, str]] = {
+    "RawRecord": (
+        "Mapping[str, Any]",
+        "RawRecord is deprecated. Use Mapping[str, Any] directly or "
+        "bioetl.domain.data.Record protocol for typed access.",
+    ),
+    "RecordBatch": (
+        "bioetl.domain.data.RecordBatch",
+        "RecordBatch has moved to bioetl.domain.data. "
+        "Import from there: from bioetl.domain.data import RecordBatch",
+    ),
+    "RawRecordDict": (
+        "Mapping[str, Any]",
+        "RawRecordDict is deprecated. Use Mapping[str, Any] directly.",
+    ),
+    "RawRecordBatch": (
+        "bioetl.domain.data.RecordBatch",
+        "RawRecordBatch is deprecated. Use RecordBatch from bioetl.domain.data.",
+    ),
+    "RawRecordList": (
+        "bioetl.domain.data.RecordBatch",
+        "RawRecordList is deprecated. Use RecordBatch from bioetl.domain.data.",
+    ),
+    "RawPayload": (
+        "ApiPayload",
+        "RawPayload is deprecated. Use ApiPayload instead.",
+    ),
 }
 
 
 def __getattr__(name: str) -> TypeAlias:
     """Emit deprecation warning for legacy type alias access.
 
-    This is triggered for dynamic imports like:
-        getattr(types_module, "RawRecordDict")
-
-    Static imports (from bioetl.domain.types import RawRecordDict) use
-    the module-level assignments above, so deprecation warnings for those
-    are emitted from the ports modules where they're re-exported.
+    Provides backward compatibility for deprecated type aliases by returning
+    appropriate types while emitting deprecation warnings.
     """
     if name in _DEPRECATED_NAMES:
-        new_name, value = _DEPRECATED_NAMES[name]
+        new_location, message = _DEPRECATED_NAMES[name]
         warnings.warn(
-            f"{name} is deprecated, use {new_name} from bioetl.domain.types instead. "
-            "See migration guide in bioetl.domain.types module docstring.",
+            f"{message} See migration guide in bioetl.domain.types module docstring.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return value
+        # Return appropriate fallback types for backward compatibility
+        if name in ("RawRecord", "RawRecordDict"):
+            return dict[str, Any]
+        elif name in ("RecordBatch", "RawRecordBatch", "RawRecordList"):
+            # Import from data module for the actual type
+            from bioetl.domain.data import RecordBatch as _RecordBatch
+
+            return _RecordBatch
+        elif name == "RawPayload":
+            return ApiPayload
+
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
Move RecordBatch to domain.data as single source of truth:
- domain.data.RecordBatch = Sequence[Mapping[str, Any]]
- Remove RawRecord and RecordBatch from domain.types
- Add deprecation __getattr__ re-exports for backward compatibility
- Update domain/__init__.py to export RecordBatch from data module
- Update ports modules (extraction, parsing, __init__) to import from correct locations