### PR TITLE
04-Add abstract contracts to application factories

### DIFF
--- a/src/bioetl/application/factories/__init__.py
+++ b/src/bioetl/application/factories/__init__.py
@@ -6,9 +6,9 @@ Provides factories for creating pipeline services and components.
 Public factories:
     - ApplicationServiceFactory / ApplicationServiceFactoryABC
     - PipelineHookFactory
-    - PipelineRuntimeFactory
-    - ProviderServiceFactory
-    - RecordSourceFactory
+    - PipelineRuntimeFactory / PipelineRuntimeFactoryABC
+    - ProviderServiceFactory / ProviderServiceFactoryABC
+    - RecordSourceFactory / RecordSourceFactoryABC
     - TransformComponentFactory / TransformComponentFactoryABC
 
 No-op factories (for testing/fallback):
@@ -25,13 +25,22 @@ from bioetl.application.factories.noop import (
     create_noop_metrics_port,
     create_noop_validator_factory,
 )
-from bioetl.application.factories.record_source import RecordSourceFactory
-from bioetl.application.factories.runtime_factory import PipelineRuntimeFactory
+from bioetl.application.factories.record_source import (
+    RecordSourceFactory,
+    RecordSourceFactoryABC,
+)
+from bioetl.application.factories.runtime_factory import (
+    PipelineRuntimeFactory,
+    PipelineRuntimeFactoryABC,
+)
 from bioetl.application.factories.service_factory import (
     ApplicationServiceFactory,
     ApplicationServiceFactoryABC,
 )
-from bioetl.application.factories.services import ProviderServiceFactory
+from bioetl.application.factories.services import (
+    ProviderServiceFactory,
+    ProviderServiceFactoryABC,
+)
 from bioetl.application.factories.transform_factory import (
     TransformComponentFactory,
     TransformComponentFactoryABC,
@@ -43,8 +52,11 @@ __all__ = [
     "ApplicationServiceFactoryABC",
     "PipelineHookFactory",
     "PipelineRuntimeFactory",
+    "PipelineRuntimeFactoryABC",
     "ProviderServiceFactory",
+    "ProviderServiceFactoryABC",
     "RecordSourceFactory",
+    "RecordSourceFactoryABC",
     "TransformComponentFactory",
     "TransformComponentFactoryABC",
     # No-op factories

--- a/src/bioetl/application/factories/record_source.py
+++ b/src/bioetl/application/factories/record_source.py
@@ -4,6 +4,7 @@ Factory for creating RecordSource instances.
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Callable
 
@@ -20,7 +21,38 @@ from bioetl.domain.providers import ProviderDefinition
 from bioetl.domain.record_source import RecordSourceABC
 
 
-class RecordSourceFactory:
+class RecordSourceFactoryABC(ABC):
+    """Abstract factory for creating record sources.
+
+    Defines the contract for factories that create RecordSourceABC instances
+    based on pipeline input configuration (CSV, ID-only, or API mode).
+    """
+
+    @abstractmethod
+    def create_record_source(
+        self,
+        extraction_service: Any,
+        *,
+        limit: int | None = None,
+        logger: LoggingPortABC,
+        model_cls: type | None = None,
+        batch_adapter: Callable[..., Any] | None = None,
+    ) -> RecordSourceABC:
+        """Create record source based on pipeline input configuration.
+
+        Args:
+            extraction_service: Service for API extraction.
+            limit: Maximum number of records to fetch.
+            logger: Logger instance.
+            model_cls: Optional Pydantic model class for CSV parsing.
+            batch_adapter: Optional batch processing callable for API mode.
+
+        Returns:
+            Configured RecordSourceABC instance.
+        """
+
+
+class RecordSourceFactory(RecordSourceFactoryABC):
     """Factory for creating record sources."""
 
     def __init__(

--- a/src/bioetl/application/factories/runtime_factory.py
+++ b/src/bioetl/application/factories/runtime_factory.py
@@ -6,6 +6,8 @@ Provides hooks, error policies, and metrics ports for pipeline execution.
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
+
 from bioetl.application.factories.hooks import PipelineHookFactory
 from bioetl.application.factories.noop import create_noop_metrics_port
 from bioetl.application.pipelines.hooks_impl import FailFastErrorPolicyImpl
@@ -14,7 +16,42 @@ from bioetl.domain.observability import LoggingPortABC, MetricsPortABC
 from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
 
 
-class PipelineRuntimeFactory:
+class PipelineRuntimeFactoryABC(ABC):
+    """Abstract factory for creating pipeline runtime components.
+
+    Defines the contract for factories that provide hooks, error policies,
+    and metrics ports used during pipeline execution.
+    """
+
+    @abstractmethod
+    def get_hooks(self, logger: LoggingPortABC) -> list[PipelineHookABC]:
+        """Get pipeline execution hooks.
+
+        Args:
+            logger: Logger to use for logging hooks.
+
+        Returns:
+            List of pipeline hooks.
+        """
+
+    @abstractmethod
+    def get_error_policy(self) -> ErrorPolicyABC:
+        """Get the error handling policy.
+
+        Returns:
+            Error policy for pipeline execution.
+        """
+
+    @abstractmethod
+    def get_metrics_port(self) -> MetricsPortABC:
+        """Get the metrics port.
+
+        Returns:
+            Metrics port for observability.
+        """
+
+
+class PipelineRuntimeFactory(PipelineRuntimeFactoryABC):
     """Factory for creating pipeline runtime components.
 
     Encapsulates creation of hooks, error policies, and metrics ports
@@ -91,4 +128,4 @@ class PipelineRuntimeFactory:
         return self._metrics_port
 
 
-__all__ = ["PipelineRuntimeFactory"]
+__all__ = ["PipelineRuntimeFactory", "PipelineRuntimeFactoryABC"]

--- a/src/bioetl/application/factories/services.py
+++ b/src/bioetl/application/factories/services.py
@@ -4,6 +4,7 @@ Factory for creating provider services (extraction, normalization).
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from typing import Any, Callable, cast
 
 from bioetl.application.providers import ApplicationFieldProvider
@@ -13,7 +14,31 @@ from bioetl.domain.providers import ProviderDefinition
 from bioetl.domain.transform.contracts import NormalizationServiceABC
 
 
-class ProviderServiceFactory:
+class ProviderServiceFactoryABC(ABC):
+    """Abstract factory for creating provider-specific services.
+
+    Defines the contract for factories that create extraction and
+    normalization services based on provider configuration.
+    """
+
+    @abstractmethod
+    def create_normalization_service(self) -> NormalizationServiceABC:
+        """Create normalization service for the configured provider.
+
+        Returns:
+            NormalizationServiceABC instance for data normalization.
+        """
+
+    @abstractmethod
+    def create_extraction_service(self) -> Any:
+        """Create the extraction service based on provider configuration.
+
+        Returns:
+            Extraction service instance for data retrieval.
+        """
+
+
+class ProviderServiceFactory(ProviderServiceFactoryABC):
     """Factory for creating provider-specific services."""
 
     def __init__(


### PR DESCRIPTION
Add ABCs for RecordSourceFactory, PipelineRuntimeFactory, and ProviderServiceFactory to follow the established "ABC → Default factory → Impl" pattern used throughout the codebase.

- RecordSourceFactoryABC: contract for creating record sources
- PipelineRuntimeFactoryABC: contract for runtime components (hooks, error policy, metrics)
- ProviderServiceFactoryABC: contract for provider-specific services
- Update __init__.py to export new ABCs