### PR TITLE
01-Clarify raw record type definitions

### DIFF
--- a/src/bioetl/application/files/csv_record_source.py
+++ b/src/bioetl/application/files/csv_record_source.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from pathlib import Path
 from typing import Any, cast
 
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 from bioetl.domain.configs import ChemblSourceConfig, CsvInputConfig
 from bioetl.domain.observability import LoggingPortABC
 from bioetl.domain.ports.extraction import ExtractionServiceABC
-from bioetl.domain.record_source import RawRecord, RecordSourceABC as RecordSource
+from bioetl.domain.record_source import RecordSourceABC, SourceRecordModel
 
 
 def _chunk_list(data: list[Any], size: int) -> Iterator[list[Any]]:
@@ -27,7 +27,7 @@ def ensure_csv_options(options: dict[str, Any] | CsvInputConfig) -> CsvInputConf
     return CsvInputConfig(**options)
 
 
-class CsvRecordSourceImpl(RecordSource):
+class CsvRecordSourceImpl(RecordSourceABC):
     """Record source that reads full datasets from CSV."""
 
     def __init__(
@@ -44,9 +44,9 @@ class CsvRecordSourceImpl(RecordSource):
         self._limit = limit
         self._logger = logger
         self._chunk_size = chunk_size
-        self._model_cls: type[BaseModel] = model_cls or RawRecord
+        self._model_cls: type[BaseModel] = model_cls or SourceRecordModel
 
-    def iter_records(self) -> Iterable[list[RawRecord]]:
+    def iter_records(self) -> Iterable[Sequence[Mapping[str, Any]]]:
         """Read CSV dataset and yield records respecting limits and chunking."""
         header = 0 if self._csv_options.header else None
         self._logger.info(f"Extracting records from CSV dataset: {self._input_path}")
@@ -58,8 +58,8 @@ class CsvRecordSourceImpl(RecordSource):
         if self._limit is not None:
             df = df.head(self._limit)
         records_dicts = df.to_dict(orient="records")
-        records: list[RawRecord] = [
-            cast(RawRecord, self._model_cls.model_validate(item))
+        records: list[SourceRecordModel] = [
+            cast(SourceRecordModel, self._model_cls.model_validate(item))
             for item in records_dicts
         ]
         if self._chunk_size is None or self._chunk_size <= 0:
@@ -69,7 +69,7 @@ class CsvRecordSourceImpl(RecordSource):
         yield from _chunk_list(records, self._chunk_size)
 
 
-class IdListRecordSourceImpl(RecordSource):
+class IdListRecordSourceImpl(RecordSourceABC):
     """Record source for ID-only CSVs enriched via API."""
 
     def __init__(
@@ -101,7 +101,7 @@ class IdListRecordSourceImpl(RecordSource):
         self._logger = logger
         self._chunk_size = chunk_size
 
-    def iter_records(self) -> Iterable[list[RawRecord]]:
+    def iter_records(self) -> Iterable[Sequence[Mapping[str, Any]]]:
         """Stream records resolved by IDs from CSV via extraction service."""
         header = 0 if self._csv_options.header else None
         usecols: list[Any] = [self._id_column] if self._csv_options.header else [0]
@@ -151,7 +151,7 @@ class IdListRecordSourceImpl(RecordSource):
 
     def _fetch_records(
         self, ids: list[str], batch_size: int
-    ) -> Iterable[list[RawRecord]]:
+    ) -> Iterable[Sequence[Mapping[str, Any]]]:
         for batch_ids in _chunk_list(ids, batch_size):
             self._logger.info("Fetching batch from API", batch_size=len(batch_ids))
             response = self._extraction_service.request_batch(
@@ -161,7 +161,9 @@ class IdListRecordSourceImpl(RecordSource):
             serialized = self._extraction_service.serialize_records(
                 self._entity, cast(list[object], batch_records)
             )
-            serialized_records: list[RawRecord] = cast(list[RawRecord], serialized)
+            serialized_records: list[Mapping[str, Any]] = cast(
+                list[Mapping[str, Any]], serialized
+            )
             if self._chunk_size is None or self._chunk_size <= 0:
                 yield serialized_records
                 continue

--- a/src/bioetl/application/mappers/contracts.py
+++ b/src/bioetl/application/mappers/contracts.py
@@ -1,9 +1,11 @@
 """Contracts for record mapping between layers."""
 
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from typing import Any
 
 from bioetl.domain.ports.parsing import RawRecordList
-from bioetl.domain.record_source import RawRecord
+from bioetl.domain.record_source import SourceRecordModel
 
 
 class RecordMapperABC(ABC):
@@ -11,8 +13,8 @@ class RecordMapperABC(ABC):
 
     This abstract base class defines the contract for mapping untyped
     record dictionaries from the infrastructure layer to typed domain
-    RawRecord models. Implementations handle source-specific mapping
-    logic and validation.
+    SourceRecordModel instances. Implementations handle source-specific
+    mapping logic and validation.
 
     Example:
         >>> class MyMapper(RecordMapperABC):
@@ -29,15 +31,15 @@ class RecordMapperABC(ABC):
         self,
         raw_records: RawRecordList,
         entity: str,
-    ) -> list[RawRecord]:
-        """Convert raw dicts to typed domain RawRecord models.
+    ) -> list[SourceRecordModel]:
+        """Convert raw dicts to typed domain SourceRecordModel instances.
 
         Args:
             raw_records: Untyped records from infrastructure parser.
             entity: Entity type (activity, assay, target, molecule, document).
 
         Returns:
-            List of validated domain RawRecord instances.
+            List of validated domain SourceRecordModel instances.
 
         Raises:
             ValueError: If entity type is unknown.

--- a/src/bioetl/application/sources/api_record_source.py
+++ b/src/bioetl/application/sources/api_record_source.py
@@ -10,11 +10,11 @@ Previous location: bioetl.domain.record_source
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping, Sequence
 from typing import Any, Callable, cast
 
 from bioetl.domain.ports.extraction import RecordFetcherABC
-from bioetl.domain.record_source import RawRecord, RecordSourceABC
+from bioetl.domain.record_source import RecordSourceABC
 
 
 class ApiRecordSource(RecordSourceABC):
@@ -29,7 +29,7 @@ class ApiRecordSource(RecordSourceABC):
         entity: The entity type to fetch (e.g., 'molecule', 'activity').
         filters: Optional filters to apply during extraction.
         chunk_size: Optional batch size for chunked iteration.
-        batch_adapter: Optional callable to transform raw batches to RawRecord lists.
+        batch_adapter: Optional callable to transform raw batches.
 
     Example:
         >>> source = ApiRecordSource(
@@ -48,7 +48,7 @@ class ApiRecordSource(RecordSourceABC):
         entity: str,
         filters: dict[str, Any] | None = None,
         chunk_size: int | None = None,
-        batch_adapter: Callable[[Any], list[RawRecord]] | None = None,
+        batch_adapter: Callable[[Any], list[Mapping[str, Any]]] | None = None,
     ) -> None:
         self._extraction_service = extraction_service
         self._entity = entity
@@ -56,11 +56,11 @@ class ApiRecordSource(RecordSourceABC):
         self._chunk_size = chunk_size
         self._batch_adapter = batch_adapter
 
-    def iter_records(self) -> Iterable[list[RawRecord]]:
+    def iter_records(self) -> Iterable[Sequence[Mapping[str, Any]]]:
         """Iterate over extracted provider batches as normalized records.
 
         Yields:
-            Lists of RawRecord instances, each list representing a batch
+            Sequences of record Mappings, each representing a batch
             of records from the extraction service.
 
         Raises:
@@ -75,15 +75,11 @@ class ApiRecordSource(RecordSourceABC):
                 yield self._batch_adapter(raw_batch)
                 continue
 
-            if not isinstance(raw_batch, list):
+            if not isinstance(raw_batch, (list, tuple)):
                 raise TypeError(
-                    "iter_extract must yield list[RawRecord] when no batch_adapter "
-                    "is set."
+                    "iter_extract must yield Sequence[Mapping[str, Any]] when no "
+                    "batch_adapter is set."
                 )
 
-            # Auto-convert dicts to RawRecord models if needed
-            if raw_batch and isinstance(raw_batch[0], dict):
-                yield [RawRecord.model_validate(item) for item in raw_batch]
-                continue
-
-            yield cast(list[RawRecord], raw_batch)
+            # Raw batch is already a sequence of mappings
+            yield cast(Sequence[Mapping[str, Any]], raw_batch)

--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -14,11 +14,18 @@ Tabular Data Abstractions (from ``bioetl.domain.data``):
     - TabularData: Full tabular data abstraction (replaces pd.DataFrame)
     - MutableTabularData: TabularData with mutation capabilities
 
+Pydantic Models (from ``bioetl.domain.record_source``):
+    - SourceRecordModel: Pydantic model for API boundary parsing
+    - SourceRecord: Deprecated alias for SourceRecordModel
+
 Migration Notes (v3.0)
 ----------------------
-- ``RawRecord`` is deprecated. Use ``Mapping[str, Any]`` or ``Record`` protocol.
+- ``RawRecord`` has been removed. Use ``Mapping[str, Any]`` or ``Record`` protocol.
+- ``SourceRecord`` renamed to ``SourceRecordModel``. Old name available as alias.
 - ``RecordBatch`` moved from ``domain.types`` to ``domain.data``.
   The canonical definition is now ``Sequence[Mapping[str, Any]]``.
+- ``RecordSourceABC.iter_records()`` now returns ``Iterable[Sequence[Mapping[str, Any]]]``
+  instead of ``Iterable[list[SourceRecord]]``.
 """
 
 from bioetl.domain.aggregates import PipelineIdentity
@@ -43,7 +50,8 @@ from bioetl.domain.errors import (
 from bioetl.domain.record_source import (
     InMemoryRecordSource,
     RecordSourceABC,
-    SourceRecord,
+    SourceRecord,  # Deprecated alias for SourceRecordModel
+    SourceRecordModel,
 )
 from bioetl.domain.types import (
     ApiPayload,
@@ -82,5 +90,6 @@ __all__ = [
     # Record source
     "InMemoryRecordSource",
     "RecordSourceABC",
-    "SourceRecord",
+    "SourceRecordModel",
+    "SourceRecord",  # Deprecated alias for SourceRecordModel
 ]

--- a/src/bioetl/domain/ports/extraction.py
+++ b/src/bioetl/domain/ports/extraction.py
@@ -26,7 +26,7 @@ _DEPRECATED_TYPE_ALIASES = {
 }
 
 if TYPE_CHECKING:
-    from bioetl.domain.record_source import SourceRecord
+    from bioetl.domain.record_source import SourceRecordModel
 
 
 class RecordFetcherABC(ABC):
@@ -156,18 +156,18 @@ class BatchAdapterABC(Protocol):
 # =============================================================================
 
 
-def to_raw_records(batch: RecordBatch) -> list["SourceRecord"]:
-    """Convert raw dicts to SourceRecord models (migration helper).
+def to_raw_records(batch: RecordBatch) -> list["SourceRecordModel"]:
+    """Convert raw dicts to SourceRecordModel instances (migration helper).
 
     DEPRECATED: Use application layer mappers instead.
-    This function is provided for gradual migration from SourceRecord models
+    This function is provided for gradual migration from SourceRecordModel
     to generic dicts in extraction services.
 
     Args:
         batch: List of raw record dictionaries.
 
     Returns:
-        List of SourceRecord Pydantic models.
+        List of SourceRecordModel Pydantic models.
 
     Example:
         >>> from bioetl.domain.ports.extraction import to_raw_records
@@ -179,20 +179,20 @@ def to_raw_records(batch: RecordBatch) -> list["SourceRecord"]:
         DeprecationWarning,
         stacklevel=2,
     )
-    from bioetl.domain.record_source import SourceRecord
+    from bioetl.domain.record_source import SourceRecordModel
 
-    return [SourceRecord.model_validate(record) for record in batch]
+    return [SourceRecordModel.model_validate(record) for record in batch]
 
 
-def from_raw_records(records: list["SourceRecord"]) -> RecordBatch:
-    """Convert SourceRecord models to raw dicts (migration helper).
+def from_raw_records(records: list["SourceRecordModel"]) -> RecordBatch:
+    """Convert SourceRecordModel instances to raw dicts (migration helper).
 
     DEPRECATED: Use application layer mappers instead.
-    This function is provided for gradual migration from SourceRecord models
+    This function is provided for gradual migration from SourceRecordModel
     to generic dicts in extraction services.
 
     Args:
-        records: List of SourceRecord Pydantic models.
+        records: List of SourceRecordModel Pydantic models.
 
     Returns:
         List of raw record dictionaries.

--- a/src/bioetl/domain/record_source.py
+++ b/src/bioetl/domain/record_source.py
@@ -1,76 +1,204 @@
 """Core record source interfaces and helpers.
 
 This module defines the abstract interface for record sources (RecordSourceABC)
-and the SourceRecord value object. Concrete implementations that involve
-orchestration logic are located in the application layer.
+and the SourceRecordModel Pydantic model for API response parsing.
+
+Terminology & Migration Guide
+-----------------------------
++------------------+-------------------+---------------------------------------------+
+| Old Name         | New Name          | Notes                                       |
++==================+===================+=============================================+
+| SourceRecord     | SourceRecordModel | Pydantic model for API boundary parsing.    |
+|                  |                   | SourceRecord kept as deprecated alias.      |
++------------------+-------------------+---------------------------------------------+
+| RawRecord        | (removed)         | Was deprecated alias for SourceRecord.      |
+|                  |                   | Use Mapping[str, Any] or domain.data.Record |
++------------------+-------------------+---------------------------------------------+
+
+SourceRecordModel Usage
+-----------------------
+``SourceRecordModel`` is a Pydantic model intended for use ONLY at system
+boundaries (parsing API responses). It provides validation and serialization.
+
+For internal domain contracts, use the pandas-free abstractions:
+    - ``Mapping[str, Any]`` for single records
+    - ``Sequence[Mapping[str, Any]]`` for batches (RecordBatch from domain.data)
+    - ``Record`` protocol from domain.data for typed access
+
+Example migration::
+
+    # Before (deprecated)
+    from bioetl.domain.record_source import SourceRecord, RawRecord
+
+    def parse_response(data: dict) -> list[SourceRecord]:
+        return [SourceRecord.model_validate(r) for r in data["items"]]
+
+    # After (recommended) - for API boundary
+    from bioetl.domain.record_source import SourceRecordModel
+
+    def parse_response(data: dict) -> list[SourceRecordModel]:
+        return [SourceRecordModel.model_validate(r) for r in data["items"]]
+
+    # After (recommended) - for domain contracts
+    from collections.abc import Mapping, Sequence
+    from typing import Any
+
+    def process_records(records: Sequence[Mapping[str, Any]]) -> None:
+        for record in records:
+            # Process using Mapping interface
+            ...
 
 See also:
+    - bioetl.domain.data: Record, RecordBatch, TabularData protocols
     - bioetl.application.sources.ApiRecordSource: API-based record source
     - bioetl.application.files: File-based record sources
-
-Terminology:
-    SourceRecord: A record extracted from a data source before normalization.
-    RawRecord: Deprecated alias for SourceRecord (will be removed in v3.0).
 """
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any
 import warnings
+from abc import ABC, abstractmethod
+from collections.abc import Iterable, Mapping, Sequence
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ConfigDict
 
 
-class SourceRecord(BaseModel):
-    """Record extracted from a data source before normalization.
+class SourceRecordModel(BaseModel):
+    """Pydantic model for records extracted from external data sources.
 
-    This is the canonical name for raw records in the domain model.
+    This model is intended for use at system boundaries (parsing API responses,
+    validating external data). It uses ``extra="allow"`` to accept any fields.
+
+    For internal domain contracts, prefer using ``Mapping[str, Any]`` or the
+    ``Record`` protocol from ``bioetl.domain.data``.
+
+    Example:
+        >>> # At API boundary - validation and parsing
+        >>> record = SourceRecordModel.model_validate({"id": "123", "name": "Test"})
+        >>> record.model_dump()
+        {'id': '123', 'name': 'Test'}
+
+        >>> # For domain contracts, use generic types
+        >>> from collections.abc import Mapping
+        >>> def process(record: Mapping[str, Any]) -> str:
+        ...     return record["id"]
+
+    Attributes:
+        Any fields are accepted due to ``extra="allow"`` configuration.
+
+    Note:
+        Previously named ``SourceRecord``. The old name is available as a
+        deprecated alias for backward compatibility.
     """
 
     model_config = ConfigDict(extra="allow")
 
 
+# =============================================================================
+# Deprecated Aliases (backward compatibility)
+# =============================================================================
+
+# Deprecated alias - use SourceRecordModel instead
+SourceRecord = SourceRecordModel
+"""Deprecated alias for SourceRecordModel.
+
+.. deprecated:: 2.1
+    Use ``SourceRecordModel`` instead. ``SourceRecord`` will be removed in v3.0.
+"""
+
+
 def __getattr__(name: str) -> Any:
     """Module-level __getattr__ for deprecation warnings."""
-    if name == "RawRecord":
+    if name == "SourceRecord":
         warnings.warn(
-            "RawRecord is deprecated, use SourceRecord instead. "
+            "SourceRecord is deprecated, use SourceRecordModel instead. "
             "Will be removed in v3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return SourceRecord
+        return SourceRecordModel
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-# Type alias for backward compatibility
-# TODO: Remove in v3.0
+# Type alias for backward compatibility in TYPE_CHECKING
 if TYPE_CHECKING:
-    RawRecord = SourceRecord
+    # Allow static type checkers to see deprecated aliases
+    pass  # SourceRecord already defined above
+
+
+# =============================================================================
+# Record Source Abstract Base Classes
+# =============================================================================
 
 
 class RecordSourceABC(ABC):
-    """Abstract base class for record sources returning record batches."""
+    """Abstract base class for record sources returning record batches.
+
+    Record sources provide iteration over batches of records from various
+    data sources (API, files, databases, etc.).
+
+    The ``iter_records`` method returns generic ``Sequence[Mapping[str, Any]]``
+    batches, allowing implementations to return any mapping-like objects
+    without coupling to specific Pydantic models.
+
+    Example:
+        >>> class MyRecordSource(RecordSourceABC):
+        ...     def iter_records(self) -> Iterable[Sequence[Mapping[str, Any]]]:
+        ...         yield [{"id": "1", "name": "first"}, {"id": "2", "name": "second"}]
+
+    Note:
+        Implementations may internally use SourceRecordModel for validation,
+        but the interface returns generic Mapping types for flexibility.
+    """
 
     @abstractmethod
-    def iter_records(self) -> Iterable[list[SourceRecord]]:
-        """Return iterable over source record batches as lists of mappings."""
+    def iter_records(self) -> Iterable[Sequence[Mapping[str, Any]]]:
+        """Yield batches of records from the source.
+
+        Returns:
+            Iterable of record batches. Each batch is a Sequence of Mappings.
+            Empty batches may be yielded; consumers should handle them.
+
+        Yields:
+            Sequence[Mapping[str, Any]]: A batch of records where each record
+            is a mapping of field names to values.
+        """
 
 
 class InMemoryRecordSource(RecordSourceABC):
-    """Simple record source backed by an in-memory list."""
+    """Simple record source backed by an in-memory list.
+
+    Useful for testing and for wrapping pre-loaded data.
+
+    Args:
+        records: List of records (SourceRecordModel or Mapping[str, Any]).
+        chunk_size: Optional size for chunking. If None or <= 0, yields all at once.
+
+    Example:
+        >>> records = [{"id": "1"}, {"id": "2"}]
+        >>> source = InMemoryRecordSource(records)
+        >>> list(source.iter_records())
+        [[{'id': '1'}, {'id': '2'}]]
+
+        >>> # With chunking
+        >>> source = InMemoryRecordSource(records, chunk_size=1)
+        >>> list(source.iter_records())
+        [[{'id': '1'}], [{'id': '2'}]]
+    """
 
     def __init__(
         self,
-        records: list[SourceRecord],
+        records: list[SourceRecordModel] | list[Mapping[str, Any]],
         chunk_size: int | None = None,
     ):
-        self._records = list(records)
+        # Normalize to list of mappings
+        self._records: list[Mapping[str, Any]] = [
+            r.model_dump() if isinstance(r, BaseModel) else dict(r) for r in records
+        ]
         self._chunk_size = chunk_size
 
-    def iter_records(self) -> Iterable[list[SourceRecord]]:
+    def iter_records(self) -> Iterable[Sequence[Mapping[str, Any]]]:
         """Yield in-memory records in configured chunk sizes."""
         if self._chunk_size is None or self._chunk_size <= 0:
             yield self._records[:]
@@ -80,5 +208,20 @@ class InMemoryRecordSource(RecordSourceABC):
             yield self._records[start : start + self._chunk_size]
 
 
-# Type alias for backward compatibility
+# Deprecated type alias for backward compatibility
 RecordSource = RecordSourceABC
+"""Deprecated alias for RecordSourceABC.
+
+.. deprecated:: 2.0
+    Use ``RecordSourceABC`` directly. Will be removed in v3.0.
+"""
+
+__all__ = [
+    # Canonical exports
+    "SourceRecordModel",
+    "RecordSourceABC",
+    "InMemoryRecordSource",
+    # Deprecated aliases (for backward compatibility)
+    "SourceRecord",
+    "RecordSource",
+]

--- a/src/bioetl/domain/schemas/chembl/raw_models.py
+++ b/src/bioetl/domain/schemas/chembl/raw_models.py
@@ -1,4 +1,8 @@
-"""Typed raw models for ChEMBL payloads."""
+"""Typed raw models for ChEMBL payloads.
+
+These models extend SourceRecordModel to provide typed validation
+for ChEMBL API responses at the system boundary.
+"""
 
 from __future__ import annotations
 
@@ -6,7 +10,7 @@ from typing import TypeAlias
 
 from pydantic import ConfigDict, field_validator
 
-from bioetl.domain.record_source import RawRecord
+from bioetl.domain.record_source import SourceRecordModel
 
 ScalarValue: TypeAlias = str | int | float | bool | None
 JsonValue: TypeAlias = (
@@ -19,7 +23,7 @@ JsonObject: TypeAlias = dict[
 ]
 
 
-class ActivityRawModel(RawRecord):
+class ActivityRawModel(SourceRecordModel):
     """Raw ChEMBL activity payload."""
 
     model_config = ConfigDict(extra="forbid")
@@ -77,7 +81,7 @@ class ActivityRawModel(RawRecord):
         return str(value)
 
 
-class MoleculeRawModel(RawRecord):
+class MoleculeRawModel(SourceRecordModel):
     """Raw ChEMBL molecule payload."""
 
     model_config = ConfigDict(extra="allow")
@@ -95,7 +99,7 @@ class MoleculeRawModel(RawRecord):
         return str(value)
 
 
-class TargetRawModel(RawRecord):
+class TargetRawModel(SourceRecordModel):
     """Raw ChEMBL target payload."""
 
     model_config = ConfigDict(extra="allow")
@@ -113,7 +117,7 @@ class TargetRawModel(RawRecord):
         return str(value)
 
 
-class AssayRawModel(RawRecord):
+class AssayRawModel(SourceRecordModel):
     """Raw ChEMBL assay payload."""
 
     model_config = ConfigDict(extra="allow")
@@ -138,7 +142,7 @@ class AssayRawModel(RawRecord):
         return str(value)
 
 
-class DocumentRawModel(RawRecord):
+class DocumentRawModel(SourceRecordModel):
     """Raw ChEMBL document/publication payload."""
 
     model_config = ConfigDict(extra="allow")

--- a/src/bioetl/domain/types.py
+++ b/src/bioetl/domain/types.py
@@ -21,13 +21,19 @@ Migration Guide
 ---------------
 The following type aliases have been moved or deprecated:
 
-+------------------+---------------+---------------------------------------------+
-| Old Location     | New Location  | Notes                                       |
-+==================+===============+=============================================+
-| types.RawRecord  | (removed)     | Use Mapping[str, Any] or domain.data.Record |
-+------------------+---------------+---------------------------------------------+
-| types.RecordBatch| data.RecordBatch | More general type: Sequence[Mapping]     |
-+------------------+---------------+---------------------------------------------+
++------------------+------------------+---------------------------------------------+
+| Old Location     | New Location     | Notes                                       |
++==================+==================+=============================================+
+| types.RecordBatch| data.RecordBatch | More general type: Sequence[Mapping]        |
++------------------+------------------+---------------------------------------------+
+
+Removed types (no longer available):
+
++------------------+-------------------------------------------------------------+
+| Removed Name     | Replacement                                                 |
++==================+=============================================================+
+| RawRecord        | Use ``Mapping[str, Any]`` or ``domain.data.Record`` protocol|
++------------------+-------------------------------------------------------------+
 
 Legacy deprecated aliases (will be removed in v3.0):
 
@@ -120,12 +126,9 @@ Example:
 # =============================================================================
 
 # Map of deprecated names to (new_location, deprecation_message)
+# NOTE: RawRecord has been removed completely. Do not add it here.
+# Use Mapping[str, Any] or bioetl.domain.data.Record protocol instead.
 _DEPRECATED_NAMES: dict[str, tuple[str, str]] = {
-    "RawRecord": (
-        "Mapping[str, Any]",
-        "RawRecord is deprecated. Use Mapping[str, Any] directly or "
-        "bioetl.domain.data.Record protocol for typed access.",
-    ),
     "RecordBatch": (
         "bioetl.domain.data.RecordBatch",
         "RecordBatch has moved to bioetl.domain.data. "
@@ -164,7 +167,7 @@ def __getattr__(name: str) -> TypeAlias:
             stacklevel=2,
         )
         # Return appropriate fallback types for backward compatibility
-        if name in ("RawRecord", "RawRecordDict"):
+        if name == "RawRecordDict":
             return dict[str, Any]
         elif name in ("RecordBatch", "RawRecordBatch", "RawRecordList"):
             # Import from data module for the actual type

--- a/tests/bioetl/application/files/test_app_csv_record_source.py
+++ b/tests/bioetl/application/files/test_app_csv_record_source.py
@@ -6,7 +6,7 @@ import pandas as pd
 from bioetl.application.files.csv_record_source import CsvRecordSourceImpl
 from bioetl.domain.configs import CsvInputConfig
 from bioetl.domain.observability import LoggingPortABC
-from bioetl.domain.record_source import RawRecord
+from bioetl.domain.record_source import SourceRecordModel
 
 
 def test_csv_record_source_reads_full_dataset(tmp_path):
@@ -22,7 +22,8 @@ def test_csv_record_source_reads_full_dataset(tmp_path):
 
     batches = list(src.iter_records())
     assert len(batches) == 1
+    # Records are SourceRecordModel instances
     assert [r.model_dump() for r in batches[0]] == [
-        RawRecord(a=1, b="x").model_dump(),
-        RawRecord(a=2, b="y").model_dump(),
+        SourceRecordModel(a=1, b="x").model_dump(),
+        SourceRecordModel(a=2, b="y").model_dump(),
     ]

--- a/tests/bioetl/application/pipelines/stages/test_extract_stage.py
+++ b/tests/bioetl/application/pipelines/stages/test_extract_stage.py
@@ -10,7 +10,7 @@ from bioetl.application.mappers.chembl import ChemblRecordMapper
 from bioetl.application.mappers.contracts import RecordMapperABC
 from bioetl.application.pipelines.stages.extract import ExtractStage
 from bioetl.domain.ports.extraction import ExtractionServiceABC
-from bioetl.domain.record_source import RawRecord
+from bioetl.domain.record_source import SourceRecordModel
 
 # =============================================================================
 # Fixtures
@@ -252,7 +252,7 @@ class TestExtractStageEdgeCases:
     ) -> None:
         """Empty batches are skipped."""
         mock_extraction_service.iter_extract.return_value = [[], [{"id": 1}], []]
-        mock_record = MagicMock(spec=RawRecord)
+        mock_record = MagicMock(spec=SourceRecordModel)
         mock_record.model_dump.return_value = {"id": 1}
         mock_mapper.map_records.return_value = [mock_record]
 

--- a/tests/bioetl/domain/ports/test_extraction.py
+++ b/tests/bioetl/domain/ports/test_extraction.py
@@ -14,7 +14,7 @@ from bioetl.domain.ports.extraction import (
     from_raw_records,
     to_raw_records,
 )
-from bioetl.domain.record_source import RawRecord
+from bioetl.domain.record_source import SourceRecordModel
 
 
 class TestTypeAliases:
@@ -294,7 +294,7 @@ class TestBackwardCompatibilityHelpers:
             records = to_raw_records(batch)
 
         assert len(records) == 2
-        assert all(isinstance(r, RawRecord) for r in records)
+        assert all(isinstance(r, SourceRecordModel) for r in records)
         assert records[0].id == "1"  # type: ignore[attr-defined]
         assert records[1].name == "second"  # type: ignore[attr-defined]
 
@@ -322,10 +322,10 @@ class TestBackwardCompatibilityHelpers:
         assert records[0].list == [1, 2, 3]  # type: ignore[attr-defined]
 
     def test_from_raw_records_converts_models_to_dicts(self) -> None:
-        """from_raw_records should convert RawRecord models to dicts."""
+        """from_raw_records should convert SourceRecordModel models to dicts."""
         records = [
-            RawRecord.model_validate({"id": "1", "name": "first"}),
-            RawRecord.model_validate({"id": "2", "name": "second"}),
+            SourceRecordModel.model_validate({"id": "1", "name": "first"}),
+            SourceRecordModel.model_validate({"id": "2", "name": "second"}),
         ]
 
         with pytest.warns(DeprecationWarning, match="from_raw_records is deprecated"):

--- a/tests/bioetl/domain/test_record_source.py
+++ b/tests/bioetl/domain/test_record_source.py
@@ -1,29 +1,31 @@
-from collections.abc import Iterable
-from typing import cast
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any, cast
 
 from bioetl.application.sources import ApiRecordSource
 from bioetl.domain.ports.extraction import ExtractionServiceABC
-from bioetl.domain.record_source import InMemoryRecordSource, RawRecord
+from bioetl.domain.record_source import InMemoryRecordSource, SourceRecordModel
 
 
 class _DummyExtractionService:
     def __init__(self) -> None:
         self.called_with: dict[str, str] | None = None
 
-    def extract_all(self, entity: str, **filters: str) -> list[RawRecord]:  # type: ignore[override]
+    def extract_all(
+        self, entity: str, **filters: str
+    ) -> list[dict[str, Any]]:  # type: ignore[override]
         record_batches = list(self.iter_extract(entity, **filters))
-        flattened: list[RawRecord] = []
+        flattened: list[dict[str, Any]] = []
         for batch in record_batches:
             flattened.extend(batch)
         return flattened
 
     def iter_extract(
         self, entity: str, *, chunk_size: int | None = None, **filters: str
-    ) -> Iterable[list[RawRecord]]:  # type: ignore[override]
+    ) -> Iterable[list[dict[str, Any]]]:  # type: ignore[override]
         self.called_with = {"entity": entity, **filters, "chunk_size": chunk_size}
         records = [
-            RawRecord.model_validate({"id": "1", "name": "alpha"}),
-            RawRecord.model_validate({"id": "2", "name": "beta"}),
+            {"id": "1", "name": "alpha"},
+            {"id": "2", "name": "beta"},
         ]
         if chunk_size is None or chunk_size <= 0:
             yield records
@@ -50,9 +52,10 @@ class _DummyExtractionService:
 
 
 def test_in_memory_record_source_iterates_stably() -> None:
-    records: list[RawRecord] = [
-        RawRecord.model_validate({"id": "1", "value": "a"}),
-        RawRecord.model_validate({"id": "2", "value": "b"}),
+    """InMemoryRecordSource should support stable iteration over plain dicts."""
+    records: list[dict[str, Any]] = [
+        {"id": "1", "value": "a"},
+        {"id": "2", "value": "b"},
     ]
     source = InMemoryRecordSource(records)
 
@@ -64,7 +67,23 @@ def test_in_memory_record_source_iterates_stably() -> None:
     assert second_pass[0] == records
 
 
+def test_in_memory_record_source_accepts_pydantic_models() -> None:
+    """InMemoryRecordSource should accept SourceRecordModel instances."""
+    records = [
+        SourceRecordModel.model_validate({"id": "1", "value": "a"}),
+        SourceRecordModel.model_validate({"id": "2", "value": "b"}),
+    ]
+    source = InMemoryRecordSource(records)
+
+    batches = list(source.iter_records())
+
+    assert len(batches) == 1
+    # Records are converted to dicts internally
+    assert batches[0] == [{"id": "1", "value": "a"}, {"id": "2", "value": "b"}]
+
+
 def test_api_record_source_returns_serialized_records() -> None:
+    """ApiRecordSource should return batches of dict records."""
     extraction = _DummyExtractionService()
     source = ApiRecordSource(
         extraction_service=cast(ExtractionServiceABC, extraction),
@@ -81,7 +100,7 @@ def test_api_record_source_returns_serialized_records() -> None:
     }
     assert len(records) == 1
     expected_records = [
-        RawRecord.model_validate({"id": "1", "name": "alpha"}),
-        RawRecord.model_validate({"id": "2", "name": "beta"}),
+        {"id": "1", "name": "alpha"},
+        {"id": "2", "name": "beta"},
     ]
     assert records[0] == expected_records


### PR DESCRIPTION
This change completes the migration of record type terminology:

- Rename SourceRecord -> SourceRecordModel in domain/record_source.py
  - SourceRecordModel: Pydantic model for API boundary parsing
  - SourceRecord: kept as deprecated alias for backward compatibility

- Remove RawRecord alias completely
  - Was deprecated alias pointing to SourceRecord
  - Now removed from domain/types.py and record_source.py
  - Use Mapping[str, Any] or domain.data.Record protocol instead

- Update RecordSourceABC.iter_records() signature
  - Now returns Iterable[Sequence[Mapping[str, Any]]]
  - Not tied to specific Pydantic model

- Update all dependent files:
  - domain/schemas/chembl/raw_models.py: inherit from SourceRecordModel
  - application/mappers/contracts.py: use SourceRecordModel
  - application/files/csv_record_source.py: use SourceRecordModel
  - application/sources/api_record_source.py: use generic Mapping types
  - domain/ports/extraction.py: update helpers to use SourceRecordModel

- Add comprehensive migration guide in record_source.py docstring

Breaking changes:
- RawRecord is no longer available - use Mapping[str, Any]
- iter_records() return type changed to Iterable[Sequence[Mapping[str, Any]]]