### PR TITLE
03-Remove duplicate entity mapping in ChEMBL clients

### DIFF
--- a/src/bioetl/infrastructure/clients/chembl/__init__.py
+++ b/src/bioetl/infrastructure/clients/chembl/__init__.py
@@ -3,6 +3,16 @@
 # Re-export commonly used implementation for test and user imports
 from .impl.chembl_extraction_service_impl import ChemblExtractionServiceImpl
 
+# Constants for ChEMBL entity mapping
+from .constants import (
+    ENTITY_ENDPOINT_ALIASES,
+    SUPPORTED_ENTITIES,
+    resolve_endpoint,
+)
+
 __all__ = [
     "ChemblExtractionServiceImpl",
+    "ENTITY_ENDPOINT_ALIASES",
+    "SUPPORTED_ENTITIES",
+    "resolve_endpoint",
 ]


### PR DESCRIPTION
Add public exports for ENTITY_ENDPOINT_ALIASES, SUPPORTED_ENTITIES, and resolve_endpoint from the chembl package __init__.py.

This completes the deduplication effort by making the centralized constants easily importable from the package root.