### PR TITLE
04-Replace deprecated RawRecord with SourceRecord

### DIFF
--- a/src/bioetl/application/mappers/chembl/record_mapper.py
+++ b/src/bioetl/application/mappers/chembl/record_mapper.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from bioetl.application.mappers.contracts import RecordMapperABC
 from bioetl.domain.ports.entity_models import EntityModelRegistryABC
-from bioetl.domain.ports.parsing import RawRecordList
-from bioetl.domain.record_source import RawRecord
+from bioetl.domain.ports.parsing import RecordBatch
+from bioetl.domain.record_source import SourceRecord
 from bioetl.infrastructure.chembl.model_registry import get_chembl_model_registry
 
 
@@ -13,7 +13,7 @@ class ChemblRecordMapper(RecordMapperABC):
     """Maps raw ChEMBL records to typed domain models.
 
     This mapper converts untyped dictionaries from the infrastructure
-    layer to validated domain RawRecord instances using Pydantic models.
+    layer to validated domain SourceRecord instances using Pydantic models.
 
     Args:
         registry: Entity model registry for resolving entity types to models.
@@ -40,9 +40,9 @@ class ChemblRecordMapper(RecordMapperABC):
 
     def map_records(
         self,
-        raw_records: RawRecordList,
+        raw_records: RecordBatch,
         entity: str,
-    ) -> list[RawRecord]:
+    ) -> list[SourceRecord]:
         """Convert raw dicts to typed ChEMBL domain models.
 
         Args:
@@ -50,7 +50,7 @@ class ChemblRecordMapper(RecordMapperABC):
             entity: Entity type (activity, assay, target, molecule, document).
 
         Returns:
-            List of validated domain RawRecord instances.
+            List of validated domain SourceRecord instances.
 
         Raises:
             ValueError: If entity type is unknown.

--- a/src/bioetl/application/mappers/contracts.py
+++ b/src/bioetl/application/mappers/contracts.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from typing import Any
 
-from bioetl.domain.ports.parsing import RawRecordList
+from bioetl.domain.ports.parsing import RecordBatch
 from bioetl.domain.record_source import SourceRecordModel
 
 
@@ -29,7 +29,7 @@ class RecordMapperABC(ABC):
     @abstractmethod
     def map_records(
         self,
-        raw_records: RawRecordList,
+        raw_records: RecordBatch,
         entity: str,
     ) -> list[SourceRecordModel]:
         """Convert raw dicts to typed domain SourceRecordModel instances.

--- a/src/bioetl/application/transform/pandas_batch_adapter.py
+++ b/src/bioetl/application/transform/pandas_batch_adapter.py
@@ -1,4 +1,4 @@
-"""Адаптер для конвертации pandas DataFrame и других батчей в RawRecord."""
+"""Адаптер для конвертации pandas DataFrame и других батчей в SourceRecord."""
 
 from __future__ import annotations
 
@@ -8,28 +8,28 @@ import pandas as pd
 from pydantic import BaseModel
 
 from bioetl.domain.ports.extraction import BatchAdapterABC
-from bioetl.domain.record_source import RawRecord
+from bioetl.domain.record_source import SourceRecord
 
 
 class PandasBatchAdapter(BatchAdapterABC):
-    """Конвертирует сырые батчи в список записей RawRecord."""
+    """Конвертирует сырые батчи в список записей SourceRecord."""
 
     def __init__(self, model_cls: type[BaseModel] | None = None) -> None:
-        self._model_cls: type[BaseModel] = model_cls or RawRecord
+        self._model_cls: type[BaseModel] = model_cls or SourceRecord
 
-    def process_batch(self, raw_batch: Any) -> list[RawRecord]:
+    def process_batch(self, raw_batch: Any) -> list[SourceRecord]:
         """Нормализует батч провайдера в список моделей."""
         if raw_batch is None:
             return []
 
         if isinstance(raw_batch, pd.DataFrame):
             return [
-                cast(RawRecord, self._model_cls.model_validate(record))
+                cast(SourceRecord, self._model_cls.model_validate(record))
                 for record in raw_batch.to_dict("records")
             ]
 
         if isinstance(raw_batch, list):
-            normalized: list[RawRecord] = []
+            normalized: list[SourceRecord] = []
             for item in raw_batch:
                 normalized.append(self._convert_record(item))
             return normalized
@@ -42,14 +42,14 @@ class PandasBatchAdapter(BatchAdapterABC):
             f"'{type(raw_batch).__name__}' for PandasBatchAdapter"
         )
 
-    def adapt_batch(self, raw_batch: Any) -> list[RawRecord]:
+    def adapt_batch(self, raw_batch: Any) -> list[SourceRecord]:
         """Alias для process_batch для обратной совместимости."""
         return self.process_batch(raw_batch)
 
-    def _convert_record(self, item: Any) -> RawRecord:
+    def _convert_record(self, item: Any) -> SourceRecord:
         if isinstance(item, BaseModel):
-            return cast(RawRecord, item)
-        return cast(RawRecord, self._model_cls.model_validate(item))
+            return cast(SourceRecord, item)
+        return cast(SourceRecord, self._model_cls.model_validate(item))
 
 
 __all__ = ["PandasBatchAdapter"]


### PR DESCRIPTION
Replace deprecated RawRecord imports from record_source module with SourceRecord in the application layer. Also update RawRecordList type alias to RecordBatch as per the deprecation guidelines.

Files updated:
- pandas_batch_adapter.py: RawRecord → SourceRecord (class and type hints)
- record_mapper.py: RawRecord → SourceRecord, RawRecordList → RecordBatch
- contracts.py: RawRecordList → RecordBatch