### PR TITLE
01-Replace primitives with Value Objects in PipelineConfig

### DIFF
--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -57,7 +57,14 @@ from bioetl.domain.types import (
     ApiPayload,
     FieldConfig,
 )
-from bioetl.domain.value_objects import ChemblId, EntityName, HashDigest, PipelineId, RunId
+from bioetl.domain.value_objects import (
+    ChemblId,
+    EntityName,
+    HashDigest,
+    PipelineId,
+    RunId,
+    StageName,
+)
 
 __all__ = [
     # Tabular data abstractions (from domain.data)
@@ -85,6 +92,7 @@ __all__ = [
     "HashDigest",
     "PipelineId",
     "RunId",
+    "StageName",
     # Aggregates
     "PipelineIdentity",
     # Record source

--- a/src/bioetl/domain/configs/identity.py
+++ b/src/bioetl/domain/configs/identity.py
@@ -2,12 +2,76 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated, Any
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, PlainSerializer, PlainValidator
 
 if TYPE_CHECKING:
     from bioetl.domain.aggregates.pipeline_identity import PipelineIdentity
+    from bioetl.domain.providers import ProviderId
+    from bioetl.domain.value_objects import EntityName, PipelineId
+
+
+def _coerce_pipeline_id(value: Any) -> "PipelineId":
+    """Coerce str to PipelineId for backwards compatibility."""
+    from bioetl.domain.value_objects import PipelineId
+
+    if isinstance(value, PipelineId):
+        return value
+    if isinstance(value, str):
+        return PipelineId(value)
+    raise TypeError(f"Expected str or PipelineId, got {type(value).__name__}")
+
+
+def _coerce_provider_id(value: Any) -> "ProviderId":
+    """Coerce str to ProviderId for backwards compatibility."""
+    from bioetl.domain.providers import ProviderId
+
+    if isinstance(value, ProviderId):
+        return value
+    if isinstance(value, str):
+        return ProviderId(value)
+    raise TypeError(f"Expected str or ProviderId, got {type(value).__name__}")
+
+
+def _coerce_entity_name(value: Any) -> "EntityName":
+    """Coerce str to EntityName for backwards compatibility."""
+    from bioetl.domain.value_objects import EntityName
+
+    if isinstance(value, EntityName):
+        return value
+    if isinstance(value, str):
+        return EntityName(value)
+    raise TypeError(f"Expected str or EntityName, got {type(value).__name__}")
+
+
+def _coerce_primary_key(value: str | list[str] | None) -> list[str]:
+    """Coerce primary_key to list if string is provided."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value] if value else []
+    return list(value)
+
+
+# Annotated types with validators and serializers for Pydantic
+PipelineIdField = Annotated[
+    Any,
+    PlainValidator(_coerce_pipeline_id),
+    PlainSerializer(lambda v: str(v), return_type=str),
+]
+
+ProviderIdField = Annotated[
+    Any,
+    PlainValidator(_coerce_provider_id),
+    PlainSerializer(lambda v: v.value if hasattr(v, "value") else str(v), return_type=str),
+]
+
+EntityNameField = Annotated[
+    Any,
+    PlainValidator(_coerce_entity_name),
+    PlainSerializer(lambda v: str(v), return_type=str),
+]
 
 
 class PipelineIdentityConfig(BaseModel):
@@ -16,77 +80,29 @@ class PipelineIdentityConfig(BaseModel):
     Groups fields that identify the pipeline and its data domain.
     This is a frozen immutable model for thread-safety and hashability.
 
-    This is a Pydantic config model that uses primitive types (str)
-    for serialization compatibility. Use to_domain() to convert to
-    the rich domain model with Value Objects.
+    Uses Value Objects for type-safe fields with automatic
+    validation and serialization. Accepts both str and Value Objects
+    for backwards compatibility.
 
     Attributes:
-        pipeline_id: Unique identifier for the pipeline run.
-        provider: Name of the data provider (e.g., "chembl", "uniprot").
-        entity: Type of entity being extracted (e.g., "activity", "target").
+        pipeline_id: Unique identifier for the pipeline (PipelineId).
+        provider: Data provider identifier (ProviderId enum).
+        entity: Type of entity being extracted (EntityName).
         primary_key: List of fields that form the primary key for deduplication.
     """
 
-    pipeline_id: str = Field(..., description="Unique identifier for the pipeline")
-    provider: str = Field(..., description="Data provider name")
-    entity: str = Field(..., description="Entity type being extracted")
-    primary_key: list[str] = Field(
+    pipeline_id: PipelineIdField = Field(
+        ..., description="Unique identifier for the pipeline"
+    )
+    provider: ProviderIdField = Field(..., description="Data provider identifier")
+    entity: EntityNameField = Field(..., description="Entity type being extracted")
+    primary_key: Annotated[list[str], PlainValidator(_coerce_primary_key)] = Field(
         default_factory=list, description="Primary key fields for deduplication"
     )
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    @field_validator("pipeline_id")
-    @classmethod
-    def validate_pipeline_id_not_empty(cls, value: str) -> str:
-        """Ensure pipeline_id is not empty and validate via PipelineId."""
-        # Lazy import to avoid circular dependency
-        from bioetl.domain.value_objects import PipelineId
-
-        # Validation through value object (will raise if invalid)
-        PipelineId(value)
-        return value.strip()
-
-    @field_validator("provider")
-    @classmethod
-    def validate_provider_known(cls, value: str) -> str:
-        """Ensure provider identifier is known to the registry.
-
-        Uses lazy import to avoid circular dependencies with providers module.
-        """
-        # Lazy import to avoid circular dependency
-        from bioetl.domain.providers import ProviderId
-
-        known = {provider.value for provider in ProviderId}
-        if value not in known:
-            raise ValueError(f"Unknown provider: {value}. Known: {known}")
-        return value
-
-    @field_validator("entity")
-    @classmethod
-    def validate_entity_format(cls, value: str) -> str:
-        """Ensure entity follows EntityName format (snake_case).
-
-        Uses lazy import to avoid circular dependencies.
-        """
-        # Lazy import to avoid circular dependency
-        from bioetl.domain.value_objects import EntityName
-
-        # Validation through value object (will raise if invalid)
-        EntityName(value)
-        return value.strip()
-
-    @field_validator("primary_key", mode="before")
-    @classmethod
-    def coerce_primary_key_to_list(cls, value: str | list[str] | None) -> list[str]:
-        """Coerce primary_key to list if string is provided."""
-        if value is None:
-            return []
-        if isinstance(value, str):
-            return [value] if value else []
-        return list(value)
-
-    def to_domain(self) -> PipelineIdentity:
+    def to_domain(self) -> "PipelineIdentity":
         """Convert to domain value object aggregate.
 
         Returns:
@@ -103,15 +119,13 @@ class PipelineIdentityConfig(BaseModel):
             >>> isinstance(identity.pipeline_id, PipelineId)
             True
         """
-        # Lazy imports to avoid circular dependencies
+        # Lazy import to avoid circular dependency
         from bioetl.domain.aggregates.pipeline_identity import PipelineIdentity
-        from bioetl.domain.providers import ProviderId
-        from bioetl.domain.value_objects import EntityName, PipelineId
 
         return PipelineIdentity(
-            pipeline_id=PipelineId(self.pipeline_id),
-            provider=ProviderId(self.provider),
-            entity=EntityName(self.entity),
+            pipeline_id=self.pipeline_id,
+            provider=self.provider,
+            entity=self.entity,
             primary_key=tuple(self.primary_key),
         )
 

--- a/src/bioetl/domain/configs/manifest.py
+++ b/src/bioetl/domain/configs/manifest.py
@@ -61,7 +61,7 @@ class PipelineManifest(BaseModel):
     Example:
         >>> manifest = PipelineManifest(
         ...     identity=PipelineIdentityConfig(
-        ...         pipeline_id="chembl_activity_v1",
+        ...         pipeline_id="chembl.activity",
         ...         provider="chembl",
         ...         entity="activity"
         ...     ),

--- a/src/bioetl/domain/models.py
+++ b/src/bioetl/domain/models.py
@@ -7,19 +7,34 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
-from bioetl.domain.value_objects import RunId
+from bioetl.domain.providers import ProviderId
+from bioetl.domain.value_objects import EntityName, RunId, StageName
 
 
 @dataclass
 class StageResult:
-    """Результат выполнения стадии."""
+    """Результат выполнения стадии.
 
-    stage_name: str
+    Attributes:
+        stage_name: Имя стадии (StageName). Принимает str для обратной совместимости.
+        success: Успешность выполнения.
+        records_processed: Количество обработанных записей.
+        chunks_processed: Количество обработанных чанков.
+        duration_sec: Длительность выполнения в секундах.
+        errors: Список ошибок.
+    """
+
+    stage_name: StageName
     success: bool
     records_processed: int
     chunks_processed: int
     duration_sec: float
     errors: list[str]
+
+    def __post_init__(self) -> None:
+        """Coerce str to StageName for backwards compatibility."""
+        if isinstance(self.stage_name, str):
+            object.__setattr__(self, "stage_name", StageName(self.stage_name))
 
 
 @dataclass
@@ -27,15 +42,39 @@ class RunContext:
     """
     Контекст выполнения пайплайна.
     Содержит информацию о текущем запуске, конфигурации и окружении.
+
+    Attributes:
+        run_id: Уникальный идентификатор запуска (RunId).
+        entity_name: Имя сущности (EntityName). Принимает str для обратной совместимости.
+        provider: Идентификатор провайдера (ProviderId). Принимает str для обратной совместимости.
+        started_at: Время начала выполнения.
+        config: Конфигурация запуска.
+        dry_run: Флаг тестового запуска.
+        metadata: Дополнительные метаданные.
     """
 
     run_id: RunId = field(default_factory=RunId.generate)
-    entity_name: str = ""
-    provider: str = ""
+    entity_name: EntityName | None = None
+    provider: ProviderId | None = None
     started_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     config: dict[str, Any] = field(default_factory=dict)
     dry_run: bool = False
     metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Coerce str to Value Objects for backwards compatibility."""
+        if isinstance(self.entity_name, str):
+            value = self.entity_name
+            if value:
+                object.__setattr__(self, "entity_name", EntityName(value))
+            else:
+                object.__setattr__(self, "entity_name", None)
+        if isinstance(self.provider, str):
+            value = self.provider
+            if value:
+                object.__setattr__(self, "provider", ProviderId(value))
+            else:
+                object.__setattr__(self, "provider", None)
 
 
 @dataclass

--- a/src/bioetl/domain/value_objects.py
+++ b/src/bioetl/domain/value_objects.py
@@ -65,6 +65,58 @@ class RunId:
         )
 
 
+class StageName:
+    """Value Object для имени стадии pipeline (snake_case).
+
+    Используется для идентификации стадий в pipeline.
+
+    Examples:
+        - "fetch"
+        - "transform"
+        - "normalize_data"
+    """
+
+    __slots__ = ("_value",)
+    _pattern = re.compile(r"^[a-z][a-z0-9_]*$")
+    _max_length = 64
+
+    def __init__(self, value: str) -> None:
+        if not self._pattern.match(value):
+            raise ValueError(f"StageName must be snake_case: {value}")
+        if len(value) > self._max_length:
+            raise ValueError(f"StageName too long: {len(value)} > {self._max_length}")
+        self._value = value
+
+    @property
+    def value(self) -> str:
+        """String representation of StageName."""
+        return self._value
+
+    def __str__(self) -> str:
+        return self._value
+
+    def __repr__(self) -> str:
+        return f"StageName({self._value!r})"
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, StageName):
+            return self._value == other._value
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(self._value)
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: type, handler: GetCoreSchemaHandler
+    ) -> CoreSchema:
+        return core_schema.no_info_after_validator_function(
+            cls,
+            core_schema.str_schema(),
+            serialization=core_schema.plain_serializer_function_ser_schema(str),
+        )
+
+
 class EntityName:
     """Value Object для имени сущности (snake_case)."""
 


### PR DESCRIPTION
- Add StageName Value Object for type-safe stage identification
- Update PipelineIdentityConfig to use PipelineId, ProviderId, EntityName
- Update RunContext to use EntityName and ProviderId with backwards compat
- Update StageResult to use StageName with backwards compat
- Use Annotated types with PlainValidator/PlainSerializer in PipelineIdentityConfig to avoid circular imports while maintaining Pydantic serialization
- All models accept str input for backwards compatibility via __post_init__ (dataclasses) or field validators (Pydantic)
- Fix docstring example in PipelineManifest (chembl.activity format)