### PR TITLE
03-Refactor config loader to respect architecture boundaries

### DIFF
--- a/src/bioetl/application/mappers/chembl/record_mapper.py
+++ b/src/bioetl/application/mappers/chembl/record_mapper.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from bioetl.application.mappers.contracts import RecordMapperABC
 from bioetl.domain.ports.entity_models import EntityModelRegistryABC
 from bioetl.domain.ports.parsing import RawRecordList
-from bioetl.domain.record_source import RawRecord
+from bioetl.domain.record_source import SourceRecordModel
 from bioetl.infrastructure.chembl.model_registry import get_chembl_model_registry
 
 
@@ -13,7 +13,7 @@ class ChemblRecordMapper(RecordMapperABC):
     """Maps raw ChEMBL records to typed domain models.
 
     This mapper converts untyped dictionaries from the infrastructure
-    layer to validated domain RawRecord instances using Pydantic models.
+    layer to validated SourceRecordModel instances using Pydantic models.
 
     Args:
         registry: Entity model registry for resolving entity types to models.
@@ -42,7 +42,7 @@ class ChemblRecordMapper(RecordMapperABC):
         self,
         raw_records: RawRecordList,
         entity: str,
-    ) -> list[RawRecord]:
+    ) -> list[SourceRecordModel]:
         """Convert raw dicts to typed ChEMBL domain models.
 
         Args:
@@ -50,7 +50,7 @@ class ChemblRecordMapper(RecordMapperABC):
             entity: Entity type (activity, assay, target, molecule, document).
 
         Returns:
-            List of validated domain RawRecord instances.
+            List of validated SourceRecordModel instances.
 
         Raises:
             ValueError: If entity type is unknown.

--- a/src/bioetl/application/transform/pandas_batch_adapter.py
+++ b/src/bioetl/application/transform/pandas_batch_adapter.py
@@ -1,4 +1,4 @@
-"""Адаптер для конвертации pandas DataFrame и других батчей в RawRecord."""
+"""Адаптер для конвертации pandas DataFrame и других батчей в SourceRecordModel."""
 
 from __future__ import annotations
 
@@ -8,28 +8,28 @@ import pandas as pd
 from pydantic import BaseModel
 
 from bioetl.domain.ports.extraction import BatchAdapterABC
-from bioetl.domain.record_source import RawRecord
+from bioetl.domain.record_source import SourceRecordModel
 
 
 class PandasBatchAdapter(BatchAdapterABC):
-    """Конвертирует сырые батчи в список записей RawRecord."""
+    """Конвертирует сырые батчи в список записей SourceRecordModel."""
 
     def __init__(self, model_cls: type[BaseModel] | None = None) -> None:
-        self._model_cls: type[BaseModel] = model_cls or RawRecord
+        self._model_cls: type[BaseModel] = model_cls or SourceRecordModel
 
-    def process_batch(self, raw_batch: Any) -> list[RawRecord]:
+    def process_batch(self, raw_batch: Any) -> list[SourceRecordModel]:
         """Нормализует батч провайдера в список моделей."""
         if raw_batch is None:
             return []
 
         if isinstance(raw_batch, pd.DataFrame):
             return [
-                cast(RawRecord, self._model_cls.model_validate(record))
+                cast(SourceRecordModel, self._model_cls.model_validate(record))
                 for record in raw_batch.to_dict("records")
             ]
 
         if isinstance(raw_batch, list):
-            normalized: list[RawRecord] = []
+            normalized: list[SourceRecordModel] = []
             for item in raw_batch:
                 normalized.append(self._convert_record(item))
             return normalized
@@ -42,14 +42,14 @@ class PandasBatchAdapter(BatchAdapterABC):
             f"'{type(raw_batch).__name__}' for PandasBatchAdapter"
         )
 
-    def adapt_batch(self, raw_batch: Any) -> list[RawRecord]:
+    def adapt_batch(self, raw_batch: Any) -> list[SourceRecordModel]:
         """Alias для process_batch для обратной совместимости."""
         return self.process_batch(raw_batch)
 
-    def _convert_record(self, item: Any) -> RawRecord:
+    def _convert_record(self, item: Any) -> SourceRecordModel:
         if isinstance(item, BaseModel):
-            return cast(RawRecord, item)
-        return cast(RawRecord, self._model_cls.model_validate(item))
+            return cast(SourceRecordModel, item)
+        return cast(SourceRecordModel, self._model_cls.model_validate(item))
 
 
 __all__ = ["PandasBatchAdapter"]


### PR DESCRIPTION
Update imports in record_mapper.py and pandas_batch_adapter.py to use SourceRecordModel instead of the removed RawRecord alias. This follows the migration guide in domain/record_source.py which specifies that RawRecord was removed and SourceRecordModel should be used instead.

The loader.py already complies with architectural boundaries - it uses SchemaContractProviderABC port instead of direct domain imports.