### PR TITLE
04-Move record conversion logic to application layer

### DIFF
--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -228,21 +228,24 @@ class PipelineContainer(PipelineContainerABC):
         """
         Create a record source for iterating over extracted data.
 
+        Record sources return raw dicts. Domain model conversion should happen
+        via RecordMapperABC in ExtractStage.
+
         Args:
             extraction_service: Service providing raw data extraction.
             limit: Optional maximum number of records to extract.
             logger: Logger instance (defaults to container's logger).
-            model_cls: Optional model class for record conversion.
+            model_cls: Deprecated. Use RecordMapperABC for domain model conversion.
             batch_adapter: Optional adapter for batch processing.
 
         Returns:
-            Record source providing chunked data iteration.
+            Record source providing chunked data iteration (raw dicts).
         """
         return self._get_record_source_factory().create_record_source(
             extraction_service,
             limit=limit,
             logger=logger or self.get_logger(),
-            model_cls=model_cls,
+            model_cls=model_cls,  # Deprecated, triggers warning if not None
             batch_adapter=batch_adapter,
         )
 

--- a/src/bioetl/application/contracts.py
+++ b/src/bioetl/application/contracts.py
@@ -76,7 +76,21 @@ class PipelineContainerABC(ABC):
         model_cls: type | None = None,
         batch_adapter: Any | None = None,
     ) -> RecordSourceABC:
-        """Return record source for pipeline input according to config."""
+        """Return record source for pipeline input according to config.
+
+        Record sources return raw dicts. Domain model conversion should happen
+        via RecordMapperABC in ExtractStage.
+
+        Args:
+            extraction_service: Service for data extraction.
+            limit: Optional maximum records to extract.
+            logger: Logger instance.
+            model_cls: Deprecated. Use RecordMapperABC for domain model conversion.
+            batch_adapter: Optional batch processing adapter.
+
+        Returns:
+            RecordSourceABC returning raw dicts.
+        """
 
     @abstractmethod
     def get_hash_service(self) -> HashServiceABC:

--- a/src/bioetl/application/factories/record_source.py
+++ b/src/bioetl/application/factories/record_source.py
@@ -26,6 +26,10 @@ class RecordSourceFactoryABC(ABC):
 
     Defines the contract for factories that create RecordSourceABC instances
     based on pipeline input configuration (CSV, ID-only, or API mode).
+
+    Note:
+        Record sources return raw dicts. Domain model conversion should happen
+        via RecordMapperABC in ExtractStage.
     """
 
     @abstractmethod
@@ -44,11 +48,11 @@ class RecordSourceFactoryABC(ABC):
             extraction_service: Service for API extraction.
             limit: Maximum number of records to fetch.
             logger: Logger instance.
-            model_cls: Optional Pydantic model class for CSV parsing.
+            model_cls: Deprecated. Use RecordMapperABC for domain model conversion.
             batch_adapter: Optional batch processing callable for API mode.
 
         Returns:
-            Configured RecordSourceABC instance.
+            Configured RecordSourceABC instance returning raw dicts.
         """
 
 
@@ -76,16 +80,19 @@ class RecordSourceFactory(RecordSourceFactoryABC):
     ) -> RecordSourceABC:
         """Create record source based on pipeline input configuration.
 
+        Record sources return raw dicts. Domain model conversion should happen
+        via RecordMapperABC in ExtractStage.
+
         Args:
             extraction_service: Service for API extraction.
             limit: Maximum number of records to fetch.
             logger: Logger instance.
-            model_cls: Optional Pydantic model class for CSV parsing.
+            model_cls: Deprecated. Use RecordMapperABC for domain model conversion.
             batch_adapter: Optional batch processing callable for API mode.
                 If not provided, creates a default PandasBatchAdapter.
 
         Returns:
-            Configured RecordSourceABC instance.
+            Configured RecordSourceABC instance returning raw dicts.
         """
         mode = self._config.source.input_mode
         path = self._config.source.input_path
@@ -97,13 +104,14 @@ class RecordSourceFactory(RecordSourceFactoryABC):
         if mode == "csv":
             if path is None:
                 raise ValueError("input_path is required for CSV mode")
+            # Note: model_cls is deprecated, pass to trigger warning if used
             return CsvRecordSourceImpl(
                 input_path=Path(path),
                 csv_options=self._config.source.csv,
                 limit=limit,
                 logger=logger,
                 chunk_size=chunk_size,
-                model_cls=model_cls,
+                model_cls=model_cls,  # Deprecated, triggers warning if not None
             )
 
         if mode == "id_only":
@@ -133,8 +141,9 @@ class RecordSourceFactory(RecordSourceFactoryABC):
 
         resolved_batch_adapter = batch_adapter
         if resolved_batch_adapter is None:
+            # Note: model_cls is deprecated, pass to trigger warning if used
             resolved_batch_adapter = PandasBatchAdapter(
-                model_cls=model_cls
+                model_cls=model_cls  # Deprecated, triggers warning if not None
             ).process_batch
 
         return ApiRecordSource(

--- a/src/bioetl/application/files/csv_record_source.py
+++ b/src/bioetl/application/files/csv_record_source.py
@@ -1,18 +1,21 @@
-"""CSV-based record source implementations for application layer."""
+"""CSV-based record source implementations for application layer.
+
+These sources return raw dicts (Mapping[str, Any]) per RecordSourceABC contract.
+Domain model conversion should happen via RecordMapperABC in ExtractStage.
+"""
 
 from __future__ import annotations
 
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import pandas as pd
-from pydantic import BaseModel
 
 from bioetl.domain.configs import ChemblSourceConfig, CsvInputConfig
 from bioetl.domain.observability import LoggingPortABC
 from bioetl.domain.ports.extraction import ExtractionServiceABC
-from bioetl.domain.record_source import RecordSourceABC, SourceRecordModel
+from bioetl.domain.record_source import RecordSourceABC
 
 
 def _chunk_list(data: list[Any], size: int) -> Iterator[list[Any]]:
@@ -28,7 +31,11 @@ def ensure_csv_options(options: dict[str, Any] | CsvInputConfig) -> CsvInputConf
 
 
 class CsvRecordSourceImpl(RecordSourceABC):
-    """Record source that reads full datasets from CSV."""
+    """Record source that reads full datasets from CSV.
+
+    Returns raw dicts per RecordSourceABC contract. Domain model conversion
+    should happen via RecordMapperABC in ExtractStage if needed.
+    """
 
     def __init__(
         self,
@@ -37,17 +44,30 @@ class CsvRecordSourceImpl(RecordSourceABC):
         limit: int | None,
         logger: LoggingPortABC,
         chunk_size: int | None = None,
-        model_cls: type[BaseModel] | None = None,
+        model_cls: Any = None,  # Deprecated, kept for backward compatibility
     ) -> None:
         self._input_path = input_path
         self._csv_options = ensure_csv_options(csv_options)
         self._limit = limit
         self._logger = logger
         self._chunk_size = chunk_size
-        self._model_cls: type[BaseModel] = model_cls or SourceRecordModel
+        # model_cls is no longer used - validation happens via RecordMapperABC
+        if model_cls is not None:
+            import warnings
+
+            warnings.warn(
+                "model_cls parameter is deprecated. Use RecordMapperABC in "
+                "ExtractStage for domain model conversion.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
     def iter_records(self) -> Iterable[Sequence[Mapping[str, Any]]]:
-        """Read CSV dataset and yield records respecting limits and chunking."""
+        """Read CSV dataset and yield records respecting limits and chunking.
+
+        Returns raw dicts. Domain model validation should be performed by
+        RecordMapperABC in the extraction stage.
+        """
         header = 0 if self._csv_options.header else None
         self._logger.info(f"Extracting records from CSV dataset: {self._input_path}")
         df = pd.read_csv(
@@ -57,11 +77,10 @@ class CsvRecordSourceImpl(RecordSourceABC):
         )
         if self._limit is not None:
             df = df.head(self._limit)
-        records_dicts = df.to_dict(orient="records")
-        records: list[SourceRecordModel] = [
-            cast(SourceRecordModel, self._model_cls.model_validate(item))
-            for item in records_dicts
-        ]
+
+        # Return raw dicts - no model conversion
+        records: list[Mapping[str, Any]] = df.to_dict(orient="records")
+
         if self._chunk_size is None or self._chunk_size <= 0:
             yield records
             return

--- a/src/bioetl/application/pipelines/chembl/factories.py
+++ b/src/bioetl/application/pipelines/chembl/factories.py
@@ -40,11 +40,8 @@ class ChemblPipelineFactory(PipelineFactoryABC):
         logger = container.get_logger()
         extraction_service = container.get_extraction_service()
 
-        record_source = container.get_record_source(
-            extraction_service,
-            limit=limit,
-            logger=logger,
-        )
+        # Note: ChemblPipelineBase uses ExtractStage with ChemblRecordMapper
+        # internally, so record_source is not needed here.
 
         pipeline: PipelineBase = ChemblPipelineBase(
             config=container.config,
@@ -56,7 +53,6 @@ class ChemblPipelineFactory(PipelineFactoryABC):
             index_generator=container.get_index_generator(),
             timestamp_provider=container.get_timestamp_provider(),
             metadata_builder=container.get_metadata_builder(),
-            record_source=record_source,
             normalization_service=container.get_normalization_service(),
             hooks=container.get_hooks(),
             error_policy=container.get_error_policy(),

--- a/src/bioetl/application/transform/pandas_batch_adapter.py
+++ b/src/bioetl/application/transform/pandas_batch_adapter.py
@@ -1,35 +1,53 @@
-"""Адаптер для конвертации pandas DataFrame и других батчей в SourceRecord."""
+"""Адаптер для конвертации pandas DataFrame и других батчей в raw dicts.
+
+Returns raw dicts (Mapping[str, Any]) per BatchAdapterABC contract.
+Domain model conversion should happen via RecordMapperABC in ExtractStage.
+"""
 
 from __future__ import annotations
 
-from typing import Any, cast
+from collections.abc import Mapping
+from typing import Any
 
 import pandas as pd
 from pydantic import BaseModel
 
 from bioetl.domain.ports.extraction import BatchAdapterABC
-from bioetl.domain.record_source import SourceRecord
 
 
 class PandasBatchAdapter(BatchAdapterABC):
-    """Конвертирует сырые батчи в список записей SourceRecord."""
+    """Конвертирует сырые батчи в список записей (raw dicts).
 
-    def __init__(self, model_cls: type[BaseModel] | None = None) -> None:
-        self._model_cls: type[BaseModel] = model_cls or SourceRecord
+    Returns raw dicts per BatchAdapterABC contract. Domain model conversion
+    should happen via RecordMapperABC in ExtractStage if needed.
+    """
 
-    def process_batch(self, raw_batch: Any) -> list[SourceRecord]:
-        """Нормализует батч провайдера в список моделей."""
+    def __init__(self, model_cls: Any = None) -> None:
+        # model_cls is no longer used - validation happens via RecordMapperABC
+        if model_cls is not None:
+            import warnings
+
+            warnings.warn(
+                "model_cls parameter is deprecated. Use RecordMapperABC in "
+                "ExtractStage for domain model conversion.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+    def process_batch(self, raw_batch: Any) -> list[Mapping[str, Any]]:
+        """Нормализует батч провайдера в список raw dicts.
+
+        Returns raw dicts. Domain model validation should be performed by
+        RecordMapperABC in the extraction stage.
+        """
         if raw_batch is None:
             return []
 
         if isinstance(raw_batch, pd.DataFrame):
-            return [
-                cast(SourceRecord, self._model_cls.model_validate(record))
-                for record in raw_batch.to_dict("records")
-            ]
+            return raw_batch.to_dict("records")
 
         if isinstance(raw_batch, list):
-            normalized: list[SourceRecord] = []
+            normalized: list[Mapping[str, Any]] = []
             for item in raw_batch:
                 normalized.append(self._convert_record(item))
             return normalized
@@ -42,14 +60,19 @@ class PandasBatchAdapter(BatchAdapterABC):
             f"'{type(raw_batch).__name__}' for PandasBatchAdapter"
         )
 
-    def adapt_batch(self, raw_batch: Any) -> list[SourceRecord]:
+    def adapt_batch(self, raw_batch: Any) -> list[Mapping[str, Any]]:
         """Alias для process_batch для обратной совместимости."""
         return self.process_batch(raw_batch)
 
-    def _convert_record(self, item: Any) -> SourceRecord:
+    def _convert_record(self, item: Any) -> Mapping[str, Any]:
+        """Convert a single record to raw dict."""
         if isinstance(item, BaseModel):
-            return cast(SourceRecord, item)
-        return cast(SourceRecord, self._model_cls.model_validate(item))
+            return item.model_dump()
+        if isinstance(item, Mapping):
+            return dict(item)
+        raise TypeError(
+            f"Cannot convert {type(item).__name__} to Mapping[str, Any]"
+        )
 
 
 __all__ = ["PandasBatchAdapter"]

--- a/tests/bioetl/application/files/test_app_csv_record_source.py
+++ b/tests/bioetl/application/files/test_app_csv_record_source.py
@@ -1,3 +1,8 @@
+"""Tests for CSV record source implementation.
+
+CsvRecordSourceImpl returns raw dicts per RecordSourceABC contract.
+Domain model conversion should happen via RecordMapperABC in ExtractStage.
+"""
 from pathlib import Path
 from typing import cast
 
@@ -6,10 +11,10 @@ import pandas as pd
 from bioetl.application.files.csv_record_source import CsvRecordSourceImpl
 from bioetl.domain.configs import CsvInputConfig
 from bioetl.domain.observability import LoggingPortABC
-from bioetl.domain.record_source import SourceRecordModel
 
 
 def test_csv_record_source_reads_full_dataset(tmp_path):
+    """CsvRecordSourceImpl returns raw dicts, not domain models."""
     csv = tmp_path / "data.csv"
     pd.DataFrame({"a": [1, 2], "b": ["x", "y"]}).to_csv(csv, index=False)
 
@@ -22,8 +27,8 @@ def test_csv_record_source_reads_full_dataset(tmp_path):
 
     batches = list(src.iter_records())
     assert len(batches) == 1
-    # Records are SourceRecordModel instances
-    assert [r.model_dump() for r in batches[0]] == [
-        SourceRecordModel(a=1, b="x").model_dump(),
-        SourceRecordModel(a=2, b="y").model_dump(),
+    # Records are raw dicts (Mapping[str, Any]) - no model conversion
+    assert list(batches[0]) == [
+        {"a": 1, "b": "x"},
+        {"a": 2, "b": "y"},
     ]


### PR DESCRIPTION
- Remove model_validate from CsvRecordSourceImpl - now returns raw dicts
- Remove model_validate from PandasBatchAdapter - now returns raw dicts
- Add DeprecationWarning for model_cls parameter (use RecordMapperABC instead)
- Fix bug in ChemblPipelineFactory: remove unused record_source parameter
- Update docstrings to document new contract (raw dicts returned)
- Update test to expect raw dicts instead of SourceRecordModel

Domain model conversion should now happen via RecordMapperABC in ExtractStage, consistent with the deprecation of to_raw_records/from_raw_records functions.