### PR TITLE
Standardize fingerprint and hash terminology

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,0 +1,44 @@
+# Terminology Glossary
+
+This document maps equivalent terms used across different layers of the codebase.
+
+## Hash Terminology
+
+| Canonical Term       | Contract Method         | Schema Column        | Description                                      |
+|---------------------|-------------------------|----------------------|--------------------------------------------------|
+| `record_hash`       | `compute_fingerprint()` | `hash_row`           | SHA-256 hash of entire record (all fields)       |
+| `business_key_hash` | `compute_entity_key()`  | `hash_business_key`  | SHA-256 hash of business key fields only         |
+
+### Layer-specific Usage
+
+- **Domain contracts** (`domain/transform/contracts.py`): Uses `fingerprint` and `entity_key` method names
+- **Schema layer** (`infrastructure/validation/schemas/`): Uses `hash_row` and `hash_business_key` column names
+- **Documentation**: Should prefer canonical terms (`record_hash`, `business_key_hash`)
+
+### Why Different Names?
+
+- **Contract methods**: Domain-focused, describe the *operation* (compute fingerprint, compute entity key)
+- **Schema columns**: Data-focused, describe the *content* (hash of row, hash of business key)
+- **Canonical terms**: Clear, unambiguous names for documentation and API design
+
+## Model Naming
+
+| Canonical Name         | Deprecated Alias     | Schema Name             | Entity Type  |
+|-----------------------|---------------------|-------------------------|--------------|
+| `PublicationRawModel` | `DocumentRawModel`  | `PublicationTableSchema`| `document`   |
+
+### Notes
+
+- `DocumentRawModel` is deprecated and will be removed in v3.0
+- Use `PublicationRawModel` for all new code
+- The ChEMBL API uses "document" as the entity type name (retained for API compatibility)
+
+## Migration Timeline
+
+### v2.x (Current)
+- Both terms work, deprecated aliases emit warnings
+- New code should use canonical terms
+
+### v3.0 (Future)
+- Deprecated aliases will be removed
+- Breaking change for code using deprecated names

--- a/src/bioetl/domain/schemas/chembl/raw_models.py
+++ b/src/bioetl/domain/schemas/chembl/raw_models.py
@@ -2,10 +2,15 @@
 
 These models extend SourceRecordModel to provide typed validation
 for ChEMBL API responses at the system boundary.
+
+Model naming:
+    PublicationRawModel: Canonical name for ChEMBL document/publication payloads.
+    DocumentRawModel: Deprecated alias for PublicationRawModel (will be removed in v3.0).
 """
 
 from __future__ import annotations
 
+import warnings
 from typing import TypeAlias
 
 from pydantic import ConfigDict, field_validator
@@ -143,8 +148,11 @@ class AssayRawModel(SourceRecordModel):
         return str(value)
 
 
-class DocumentRawModel(SourceRecordModel):
-    """Raw ChEMBL document/publication payload."""
+class PublicationRawModel(SourceRecordModel):
+    """Raw ChEMBL publication/document payload.
+
+    This is the canonical model name. Previously named DocumentRawModel.
+    """
 
     model_config = ConfigDict(extra="allow")
 
@@ -168,12 +176,31 @@ class DocumentRawModel(SourceRecordModel):
         return str(value)
 
 
+def __getattr__(name: str) -> type[PublicationRawModel]:
+    """Provide deprecated alias for DocumentRawModel."""
+    if name == "DocumentRawModel":
+        warnings.warn(
+            "DocumentRawModel is deprecated, use PublicationRawModel instead. "
+            "Will be removed in v3.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return PublicationRawModel
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+# Deprecated alias for backward compatibility (will be removed in v3.0)
+# Note: Direct class reference for type checkers; runtime uses __getattr__
+DocumentRawModel = PublicationRawModel
+
+
 __all__ = [
     "ActivityRawModel",
     "MoleculeRawModel",
     "TargetRawModel",
     "AssayRawModel",
-    "DocumentRawModel",
+    "PublicationRawModel",
+    "DocumentRawModel",  # Deprecated alias
     "JsonValue",
     "JsonObject",
     "ScalarValue",

--- a/src/bioetl/domain/schemas/field_specs.py
+++ b/src/bioetl/domain/schemas/field_specs.py
@@ -142,22 +142,28 @@ class FieldSpec:
 
 # ---------------------------------------------------------------------------
 # Generated (Service) Fields - Common to all schemas
+#
+# Terminology mapping (column name → canonical term → contract method):
+#   hash_row         → record_hash        → compute_fingerprint()
+#   hash_business_key → business_key_hash → compute_entity_key()
 # ---------------------------------------------------------------------------
 
 GENERATED_FIELD_SPECS: tuple[FieldSpec, ...] = (
+    # Canonical term: record_hash (contract method: compute_fingerprint)
     FieldSpec(
         name="hash_row",
         data_type="string",
         nullable=False,
         pattern=HEX_64_PATTERN,
-        description="SHA-256 hash of entire row (64 hex characters)",
+        description="SHA-256 hash of entire row (canonical: record_hash)",
     ),
+    # Canonical term: business_key_hash (contract method: compute_entity_key)
     FieldSpec(
         name="hash_business_key",
         data_type="string",
         nullable=True,
         pattern=HEX_64_PATTERN,
-        description="SHA-256 hash of business key",
+        description="SHA-256 hash of business key (canonical: business_key_hash)",
     ),
     FieldSpec(
         name="index",

--- a/src/bioetl/domain/transform/contracts.py
+++ b/src/bioetl/domain/transform/contracts.py
@@ -1,8 +1,19 @@
 """Domain-level transform contracts and DTOs.
 
-Terminology:
-    fingerprint: Hash of entire record (all fields).
-    entity_key: Hash of business key fields only.
+Terminology Mapping (contracts ↔ schemas):
+    This module uses domain-specific terms for hash concepts. The schema layer
+    uses column names that differ for data storage compatibility.
+
+    | Contract term | Schema column      | Canonical term       |
+    |---------------|--------------------|----------------------|
+    | fingerprint   | hash_row           | record_hash          |
+    | entity_key    | hash_business_key  | business_key_hash    |
+
+    Definitions:
+        record_hash (fingerprint): SHA-256 hash of entire record (all fields).
+            Provides content-based deduplication and change detection.
+        business_key_hash (entity_key): SHA-256 hash of business key fields only.
+            Identifies logical entity regardless of non-key field changes.
 
 Tabular Data Abstractions:
     This module uses domain-level abstractions (Record, TabularData, RecordBatch)
@@ -130,9 +141,13 @@ class HashServiceABC(ABC):
     Responsible for computing and adding hash columns to data.
     Does not contain stateful logic (indices, timestamps).
 
-    Terminology:
-        fingerprint: Hash of entire record (all fields).
-        entity_key: Hash of business key fields only.
+    Terminology (see module docstring for full mapping):
+        fingerprint: Computes record_hash - hash of entire record.
+        entity_key: Computes business_key_hash - hash of business key fields.
+
+    Output columns (schema layer):
+        hash_row: Contains the record_hash (fingerprint result).
+        hash_business_key: Contains the business_key_hash (entity_key result).
 
     Example:
         >>> service: HashServiceABC = get_hash_service()
@@ -147,13 +162,16 @@ class HashServiceABC(ABC):
 
     @abstractmethod
     def compute_fingerprint(self, record: Mapping[str, Any]) -> HashDigest:
-        """Compute hash fingerprint of entire record.
+        """Compute record_hash (fingerprint) of entire record.
+
+        This produces the canonical record_hash value, stored in schema
+        column ``hash_row``.
 
         Args:
             record: Record data as mapping (dict-like).
 
         Returns:
-            HashDigest value object containing the hash.
+            HashDigest value object containing the record_hash.
         """
 
     @abstractmethod
@@ -162,14 +180,17 @@ class HashServiceABC(ABC):
         record: Mapping[str, Any],
         key_fields: Sequence[str],
     ) -> HashDigest:
-        """Compute hash of business key fields.
+        """Compute business_key_hash (entity_key) from key fields.
+
+        This produces the canonical business_key_hash value, stored in
+        schema column ``hash_business_key``.
 
         Args:
             record: Record data as mapping.
             key_fields: Sequence of field names forming the business key.
 
         Returns:
-            HashDigest value object containing the hash.
+            HashDigest value object containing the business_key_hash.
         """
 
     @abstractmethod
@@ -178,7 +199,7 @@ class HashServiceABC(ABC):
         records: RecordBatch,
         key_fields: Sequence[str] | None = None,
     ) -> list[dict[str, Any]]:
-        """Add hash_row and hash_business_key to each record.
+        """Add hash columns (record_hash, business_key_hash) to each record.
 
         This is the pandas-free version for processing record batches.
 
@@ -188,8 +209,8 @@ class HashServiceABC(ABC):
 
         Returns:
             List of dictionaries with added hash columns:
-            - hash_row: fingerprint of entire record
-            - hash_business_key: hash of key fields (or None if key_fields not provided)
+            - hash_row: record_hash (fingerprint) of entire record
+            - hash_business_key: business_key_hash (or None if key_fields not provided)
         """
 
     def add_hash_columns(
@@ -197,7 +218,11 @@ class HashServiceABC(ABC):
         data: TabularData,
         business_key_cols: Sequence[str] | None = None,
     ) -> MutableTabularData:
-        """Add hash_row and hash_business_key columns to tabular data.
+        """Add hash columns (record_hash, business_key_hash) to tabular data.
+
+        Adds columns:
+            - hash_row: Contains record_hash (fingerprint)
+            - hash_business_key: Contains business_key_hash (entity_key)
 
         This method works with TabularData abstraction (pandas-compatible).
         For pandas-free processing, use add_hashes_to_batch().

--- a/src/bioetl/infrastructure/chembl/model_registry.py
+++ b/src/bioetl/infrastructure/chembl/model_registry.py
@@ -12,18 +12,19 @@ from bioetl.domain.ports.entity_models import EntityModelRegistryABC
 from bioetl.domain.schemas.chembl.raw_models import (
     ActivityRawModel,
     AssayRawModel,
-    DocumentRawModel,
     MoleculeRawModel,
+    PublicationRawModel,
     TargetRawModel,
 )
 
 # Internal mapping of entity type -> model class
+# Note: "document" entity uses PublicationRawModel (canonical name)
 _ENTITY_MODEL_MAP: dict[str, type[BaseModel]] = {
     "activity": ActivityRawModel,
     "molecule": MoleculeRawModel,
     "target": TargetRawModel,
     "assay": AssayRawModel,
-    "document": DocumentRawModel,
+    "document": PublicationRawModel,  # Canonical: PublicationRawModel
 }
 
 
@@ -33,11 +34,15 @@ class ChemblEntityModelRegistry(EntityModelRegistryABC):
     Maps ChEMBL entity type names to their corresponding Pydantic
     domain models.
 
+    Note:
+        The "document" entity maps to PublicationRawModel (canonical name).
+        DocumentRawModel is a deprecated alias.
+
     Example:
         >>> registry = ChemblEntityModelRegistry()
-        >>> model_class = registry.get_model("activity")
+        >>> model_class = registry.get_model("document")
         >>> model_class.__name__
-        'ActivityRawModel'
+        'PublicationRawModel'
     """
 
     def get_model(self, entity: str) -> type[BaseModel]:

--- a/src/bioetl/infrastructure/validation/schemas/pandera_base.py
+++ b/src/bioetl/infrastructure/validation/schemas/pandera_base.py
@@ -77,14 +77,16 @@ class BaseGeneratedColumnsModel(pa.DataFrameModel):
         ordered = True: Validate column order
     """
 
+    # Canonical term: record_hash (contract method: compute_fingerprint)
     hash_row: Series[str] = pa.Field(
         str_matches=HEX_64_PATTERN,
-        description="SHA-256 hash of entire row (64 hex characters)",
+        description="SHA-256 hash of entire row (canonical: record_hash)",
     )
+    # Canonical term: business_key_hash (contract method: compute_entity_key)
     hash_business_key: Series[str] = pa.Field(
         nullable=True,
         str_matches=HEX_64_PATTERN,
-        description="SHA-256 hash of business key",
+        description="SHA-256 hash of business key (canonical: business_key_hash)",
     )
     index: Series[int] = pa.Field(ge=0, description="Row order number")
     database_version: Series[str] = pa.Field(


### PR DESCRIPTION
Add canonical terminology mapping and deprecation infrastructure:

- contracts.py: Document canonical terms (record_hash, business_key_hash) and their mapping to schema columns (hash_row, hash_business_key)
- field_specs.py, pandera_base.py: Add comments linking column names to canonical terms and contract methods
- raw_models.py: Rename DocumentRawModel → PublicationRawModel with deprecated alias for backward compatibility (removal in v3.0)
- model_registry.py: Update to use canonical PublicationRawModel
- GLOSSARY.md: Create terminology reference document

This is the first phase of terminology migration - aliases and documentation only, no breaking changes to data schemas.