### PR TITLE
Remove deprecated aliases from domain layer

### DIFF
--- a/scripts/check_deprecations.py
+++ b/scripts/check_deprecations.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""Scan codebase for usage of deprecated imports.
+
+This script scans Python source files for imports of deprecated names
+from the bioetl.domain layer and generates a migration report.
+
+Usage:
+    python scripts/check_deprecations.py [--path PATH] [--format FORMAT] [--strict]
+
+Options:
+    --path PATH      Root directory to scan (default: src/)
+    --format FORMAT  Output format: text, json, markdown (default: text)
+    --strict         Exit with code 1 if any deprecated usages found
+    --exclude GLOB   Glob pattern for files to exclude (can be repeated)
+    --include-tests  Include test files in the scan
+
+Examples:
+    # Basic scan of source directory
+    python scripts/check_deprecations.py
+
+    # Scan with markdown report
+    python scripts/check_deprecations.py --format markdown
+
+    # Strict mode for CI
+    python scripts/check_deprecations.py --strict
+
+    # Include tests
+    python scripts/check_deprecations.py --include-tests --path .
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterator
+
+# Add src to path for importing deprecations registry
+SRC_PATH = Path(__file__).parent.parent / "src"
+sys.path.insert(0, str(SRC_PATH))
+
+# Import directly from _deprecations to avoid loading full domain (which requires pydantic)
+# We use importlib to import just this module without triggering bioetl.domain.__init__
+import importlib.util
+
+_deprecations_path = SRC_PATH / "bioetl" / "domain" / "_deprecations.py"
+spec = importlib.util.spec_from_file_location("_deprecations", _deprecations_path)
+_deprecations = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+spec.loader.exec_module(_deprecations)  # type: ignore[union-attr]
+
+DEPRECATED_ALIASES: dict[str, "DeprecatedAlias"] = _deprecations.DEPRECATED_ALIASES
+DeprecatedAlias = _deprecations.DeprecatedAlias
+
+
+@dataclass
+class DeprecatedUsage:
+    """Record of a deprecated name usage."""
+
+    file_path: Path
+    line_number: int
+    deprecated_name: str
+    import_statement: str
+    alias: DeprecatedAlias
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "file": str(self.file_path),
+            "line": self.line_number,
+            "name": self.deprecated_name,
+            "statement": self.import_statement,
+            "replacement": self.alias.new_name,
+            "new_module": self.alias.new_module,
+            "category": self.alias.category,
+        }
+
+
+@dataclass
+class ScanResult:
+    """Result of scanning the codebase."""
+
+    usages: list[DeprecatedUsage] = field(default_factory=list)
+    files_scanned: int = 0
+    files_with_issues: set[Path] = field(default_factory=set)
+
+    @property
+    def total_usages(self) -> int:
+        return len(self.usages)
+
+    @property
+    def files_affected(self) -> int:
+        return len(self.files_with_issues)
+
+    def by_deprecated_name(self) -> dict[str, list[DeprecatedUsage]]:
+        """Group usages by deprecated name."""
+        result: dict[str, list[DeprecatedUsage]] = defaultdict(list)
+        for usage in self.usages:
+            result[usage.deprecated_name].append(usage)
+        return dict(result)
+
+    def by_file(self) -> dict[Path, list[DeprecatedUsage]]:
+        """Group usages by file."""
+        result: dict[Path, list[DeprecatedUsage]] = defaultdict(list)
+        for usage in self.usages:
+            result[usage.file_path].append(usage)
+        return dict(result)
+
+
+class DeprecationScanner:
+    """Scanner for deprecated import usages."""
+
+    # Modules that export deprecated names
+    DEPRECATED_MODULES = {
+        "bioetl.domain.types",
+        "bioetl.domain.ports",
+        "bioetl.domain.ports.extraction",
+        "bioetl.domain.record_source",
+        "bioetl.domain",
+    }
+
+    def __init__(
+        self,
+        root_path: Path,
+        exclude_patterns: list[str] | None = None,
+        include_tests: bool = False,
+    ):
+        self.root_path = root_path
+        self.exclude_patterns = exclude_patterns or []
+        self.include_tests = include_tests
+
+    def iter_python_files(self) -> Iterator[Path]:
+        """Iterate over Python files to scan."""
+        for path in self.root_path.rglob("*.py"):
+            # Skip __pycache__ and .git
+            if "__pycache__" in path.parts or ".git" in path.parts:
+                continue
+
+            # Skip test files unless explicitly included
+            if not self.include_tests and "test" in path.parts:
+                continue
+
+            # Skip _deprecations.py itself and this script
+            if path.name == "_deprecations.py":
+                continue
+            if path.name == "check_deprecations.py":
+                continue
+
+            # Apply exclude patterns
+            path_str = str(path)
+            if any(pattern in path_str for pattern in self.exclude_patterns):
+                continue
+
+            yield path
+
+    def scan_file(self, file_path: Path) -> list[DeprecatedUsage]:
+        """Scan a single file for deprecated imports."""
+        usages: list[DeprecatedUsage] = []
+
+        try:
+            source = file_path.read_text(encoding="utf-8")
+            tree = ast.parse(source, filename=str(file_path))
+        except (SyntaxError, UnicodeDecodeError) as e:
+            print(f"Warning: Could not parse {file_path}: {e}", file=sys.stderr)
+            return usages
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                usages.extend(self._check_import_from(node, file_path, source))
+            elif isinstance(node, ast.Import):
+                usages.extend(self._check_import(node, file_path, source))
+
+        return usages
+
+    # Names that are NOT deprecated when imported from these canonical modules
+    CANONICAL_LOCATIONS = {
+        "RecordBatch": {"bioetl.domain.data"},
+        "SourceRecordModel": {"bioetl.domain.record_source"},
+        "RecordSourceABC": {"bioetl.domain.record_source"},
+        "ApiPayload": {"bioetl.domain.types"},
+    }
+
+    def _check_import_from(
+        self, node: ast.ImportFrom, file_path: Path, source: str
+    ) -> list[DeprecatedUsage]:
+        """Check 'from X import Y' statements."""
+        usages: list[DeprecatedUsage] = []
+
+        if node.module is None:
+            return usages
+
+        # Check if importing from a module that has deprecated exports
+        module = node.module
+        if not any(module.startswith(m) for m in self.DEPRECATED_MODULES):
+            return usages
+
+        for alias in node.names:
+            name = alias.name
+            if name in DEPRECATED_ALIASES:
+                # Skip if importing from canonical location
+                canonical_modules = self.CANONICAL_LOCATIONS.get(name, set())
+                if module in canonical_modules:
+                    continue
+
+                # Get the source line
+                lines = source.splitlines()
+                line_text = lines[node.lineno - 1] if node.lineno <= len(lines) else ""
+
+                usages.append(
+                    DeprecatedUsage(
+                        file_path=file_path,
+                        line_number=node.lineno,
+                        deprecated_name=name,
+                        import_statement=line_text.strip(),
+                        alias=DEPRECATED_ALIASES[name],
+                    )
+                )
+
+        return usages
+
+    def _check_import(
+        self, node: ast.Import, file_path: Path, source: str
+    ) -> list[DeprecatedUsage]:
+        """Check 'import X' statements.
+
+        This is less common for deprecated names but included for completeness.
+        """
+        # Direct imports of deprecated names are rare in this codebase
+        return []
+
+    def scan(self) -> ScanResult:
+        """Scan all files and return results."""
+        result = ScanResult()
+
+        for file_path in self.iter_python_files():
+            result.files_scanned += 1
+            usages = self.scan_file(file_path)
+            if usages:
+                result.usages.extend(usages)
+                result.files_with_issues.add(file_path)
+
+        return result
+
+
+def _make_relative(path: Path) -> Path:
+    """Make path relative to cwd if possible, otherwise return as-is."""
+    cwd = Path.cwd()
+    try:
+        return path.relative_to(cwd)
+    except ValueError:
+        return path
+
+
+def format_text(result: ScanResult) -> str:
+    """Format results as plain text."""
+    lines: list[str] = []
+
+    lines.append("=" * 70)
+    lines.append("DEPRECATED IMPORTS SCAN REPORT")
+    lines.append("=" * 70)
+    lines.append("")
+    lines.append(f"Files scanned:     {result.files_scanned}")
+    lines.append(f"Files with issues: {result.files_affected}")
+    lines.append(f"Total usages:      {result.total_usages}")
+    lines.append("")
+
+    if not result.usages:
+        lines.append("No deprecated imports found!")
+        return "\n".join(lines)
+
+    # Group by deprecated name
+    lines.append("-" * 70)
+    lines.append("USAGES BY DEPRECATED NAME")
+    lines.append("-" * 70)
+
+    for name, usages in sorted(result.by_deprecated_name().items()):
+        alias = DEPRECATED_ALIASES[name]
+        lines.append("")
+        lines.append(f"  {name} ({len(usages)} occurrences)")
+        lines.append(f"    → Replace with: {alias.new_name}")
+        lines.append(f"    → From module:  {alias.new_module}")
+        lines.append("")
+        for usage in usages:
+            rel_path = _make_relative(usage.file_path)
+            lines.append(f"      {rel_path}:{usage.line_number}")
+            lines.append(f"        {usage.import_statement}")
+
+    # Summary by file
+    lines.append("")
+    lines.append("-" * 70)
+    lines.append("AFFECTED FILES")
+    lines.append("-" * 70)
+    lines.append("")
+
+    for file_path, usages in sorted(result.by_file().items()):
+        rel_path = _make_relative(file_path)
+        names = sorted(set(u.deprecated_name for u in usages))
+        lines.append(f"  {rel_path}")
+        lines.append(f"    Uses: {', '.join(names)}")
+
+    return "\n".join(lines)
+
+
+def format_markdown(result: ScanResult) -> str:
+    """Format results as Markdown."""
+    lines: list[str] = []
+
+    lines.append("# Deprecated Imports Scan Report")
+    lines.append("")
+    lines.append("## Summary")
+    lines.append("")
+    lines.append(f"- **Files scanned:** {result.files_scanned}")
+    lines.append(f"- **Files with issues:** {result.files_affected}")
+    lines.append(f"- **Total usages:** {result.total_usages}")
+    lines.append("")
+
+    if not result.usages:
+        lines.append("**No deprecated imports found!**")
+        return "\n".join(lines)
+
+    # Table of deprecated names
+    lines.append("## Deprecated Names Found")
+    lines.append("")
+    lines.append("| Deprecated | Occurrences | Replacement | New Module |")
+    lines.append("|------------|-------------|-------------|------------|")
+
+    for name, usages in sorted(result.by_deprecated_name().items()):
+        alias = DEPRECATED_ALIASES[name]
+        lines.append(
+            f"| `{name}` | {len(usages)} | `{alias.new_name}` | `{alias.new_module}` |"
+        )
+
+    lines.append("")
+    lines.append("## Detailed Locations")
+    lines.append("")
+
+    for name, usages in sorted(result.by_deprecated_name().items()):
+        alias = DEPRECATED_ALIASES[name]
+        lines.append(f"### `{name}`")
+        lines.append("")
+        lines.append(f"**Replace with:** `{alias.new_name}` from `{alias.new_module}`")
+        lines.append("")
+
+        for usage in usages:
+            rel_path = _make_relative(usage.file_path)
+            lines.append(f"- `{rel_path}:{usage.line_number}`")
+            lines.append(f"  ```python")
+            lines.append(f"  {usage.import_statement}")
+            lines.append(f"  ```")
+
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def format_json(result: ScanResult) -> str:
+    """Format results as JSON."""
+    data = {
+        "summary": {
+            "files_scanned": result.files_scanned,
+            "files_with_issues": result.files_affected,
+            "total_usages": result.total_usages,
+        },
+        "usages": [u.to_dict() for u in result.usages],
+        "by_name": {
+            name: [u.to_dict() for u in usages]
+            for name, usages in result.by_deprecated_name().items()
+        },
+    }
+    return json.dumps(data, indent=2)
+
+
+def main() -> int:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Scan codebase for deprecated import usages."
+    )
+    parser.add_argument(
+        "--path",
+        type=lambda p: Path(p).resolve(),
+        default=Path("src").resolve(),
+        help="Root directory to scan (default: src/)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json", "markdown"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit with code 1 if deprecated usages found",
+    )
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        dest="exclude_patterns",
+        help="Patterns to exclude (can be repeated)",
+    )
+    parser.add_argument(
+        "--include-tests",
+        action="store_true",
+        help="Include test files in the scan",
+    )
+
+    args = parser.parse_args()
+
+    # Validate path
+    if not args.path.exists():
+        print(f"Error: Path does not exist: {args.path}", file=sys.stderr)
+        return 1
+
+    # Run scanner
+    scanner = DeprecationScanner(
+        root_path=args.path,
+        exclude_patterns=args.exclude_patterns,
+        include_tests=args.include_tests,
+    )
+    result = scanner.scan()
+
+    # Format output
+    if args.format == "json":
+        output = format_json(result)
+    elif args.format == "markdown":
+        output = format_markdown(result)
+    else:
+        output = format_text(result)
+
+    print(output)
+
+    # Return code for CI
+    if args.strict and result.total_usages > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/bioetl/domain/_deprecations.py
+++ b/src/bioetl/domain/_deprecations.py
@@ -1,0 +1,379 @@
+"""Centralized deprecation management for domain layer.
+
+This module provides a unified registry of deprecated names and utilities
+for emitting consistent deprecation warnings across the domain layer.
+
+Removal Schedule
+----------------
+All deprecated aliases listed here are scheduled for removal in v3.0.
+
+Usage in Modules
+----------------
+Modules should import and use this registry for __getattr__ implementations::
+
+    from bioetl.domain._deprecations import (
+        DEPRECATED_ALIASES,
+        emit_deprecation_warning,
+        resolve_deprecated_type,
+    )
+
+    def __getattr__(name: str) -> Any:
+        if name in DEPRECATED_ALIASES:
+            emit_deprecation_warning(name)
+            return resolve_deprecated_type(name)
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+Checking for Usage
+------------------
+Use ``scripts/check_deprecations.py`` to scan the codebase for usage of
+deprecated imports and generate a migration report.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING, Any, NamedTuple
+
+if TYPE_CHECKING:
+    from typing import TypeAlias
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+REMOVAL_VERSION: str = "3.0"
+"""Version in which deprecated aliases will be removed."""
+
+
+# =============================================================================
+# Deprecated Alias Registry
+# =============================================================================
+
+
+class DeprecatedAlias(NamedTuple):
+    """Metadata for a deprecated name.
+
+    Attributes:
+        new_name: The recommended replacement name.
+        new_module: The module where the replacement is defined.
+        category: Type of deprecation (type_alias, class_alias, function).
+        message: Optional custom deprecation message.
+    """
+
+    new_name: str
+    new_module: str
+    category: str = "type_alias"
+    message: str | None = None
+
+
+# Central registry mapping deprecated names to their metadata.
+# Format: old_name -> DeprecatedAlias(new_name, new_module, category, message)
+DEPRECATED_ALIASES: dict[str, DeprecatedAlias] = {
+    # -------------------------------------------------------------------------
+    # Type Aliases (deprecated in domain/types.py, domain/ports/)
+    # -------------------------------------------------------------------------
+    "RawRecordDict": DeprecatedAlias(
+        new_name="Mapping[str, Any]",
+        new_module="typing",
+        category="type_alias",
+        message="RawRecordDict is deprecated. Use Mapping[str, Any] directly.",
+    ),
+    "RawRecordBatch": DeprecatedAlias(
+        new_name="RecordBatch",
+        new_module="bioetl.domain.data",
+        category="type_alias",
+        message="RawRecordBatch is deprecated. Use RecordBatch from bioetl.domain.data.",
+    ),
+    "RawRecordList": DeprecatedAlias(
+        new_name="RecordBatch",
+        new_module="bioetl.domain.data",
+        category="type_alias",
+        message="RawRecordList is deprecated. Use RecordBatch from bioetl.domain.data.",
+    ),
+    "RawPayload": DeprecatedAlias(
+        new_name="ApiPayload",
+        new_module="bioetl.domain.types",
+        category="type_alias",
+        message="RawPayload is deprecated. Use ApiPayload instead.",
+    ),
+    "RawRecord": DeprecatedAlias(
+        new_name="Mapping[str, Any]",
+        new_module="typing",
+        category="type_alias",
+        message="RawRecord is deprecated. Use Mapping[str, Any] or Record protocol.",
+    ),
+    # RecordBatch re-export from types.py (moved to data.py)
+    "RecordBatch": DeprecatedAlias(
+        new_name="RecordBatch",
+        new_module="bioetl.domain.data",
+        category="type_alias",
+        message=(
+            "RecordBatch has moved to bioetl.domain.data. "
+            "Import from there: from bioetl.domain.data import RecordBatch"
+        ),
+    ),
+    # -------------------------------------------------------------------------
+    # Class Aliases (deprecated in domain/record_source.py)
+    # -------------------------------------------------------------------------
+    "SourceRecord": DeprecatedAlias(
+        new_name="SourceRecordModel",
+        new_module="bioetl.domain.record_source",
+        category="class_alias",
+        message="SourceRecord is deprecated, use SourceRecordModel instead.",
+    ),
+    "RecordSource": DeprecatedAlias(
+        new_name="RecordSourceABC",
+        new_module="bioetl.domain.record_source",
+        category="class_alias",
+        message="RecordSource is deprecated. Use RecordSourceABC directly.",
+    ),
+    # -------------------------------------------------------------------------
+    # Function Aliases (deprecated in domain/ports/extraction.py)
+    # -------------------------------------------------------------------------
+    "to_raw_records": DeprecatedAlias(
+        new_name="RecordMapperABC",
+        new_module="bioetl.application.mappers",
+        category="function",
+        message="to_raw_records is deprecated. Use RecordMapperABC in application layer.",
+    ),
+    "from_raw_records": DeprecatedAlias(
+        new_name="(direct dict return)",
+        new_module="(extraction services)",
+        category="function",
+        message="from_raw_records is deprecated. Return dicts directly from extraction.",
+    ),
+}
+
+
+# =============================================================================
+# Utility Functions
+# =============================================================================
+
+
+def emit_deprecation_warning(
+    old_name: str,
+    *,
+    new_name: str | None = None,
+    removal_version: str = REMOVAL_VERSION,
+    stacklevel: int = 3,
+) -> None:
+    """Emit a deprecation warning for a deprecated name.
+
+    Looks up the deprecated name in DEPRECATED_ALIASES to construct the
+    warning message. Falls back to a generic message if not found.
+
+    Args:
+        old_name: The deprecated name being accessed.
+        new_name: Override for the replacement name (uses registry if None).
+        removal_version: Version when the name will be removed.
+        stacklevel: Stack level for the warning (default 3 for __getattr__).
+
+    Example:
+        >>> emit_deprecation_warning("RawRecordDict")
+        # Emits: DeprecationWarning: RawRecordDict is deprecated...
+    """
+    if old_name in DEPRECATED_ALIASES:
+        alias = DEPRECATED_ALIASES[old_name]
+        message = alias.message or f"{old_name} is deprecated, use {alias.new_name} instead."
+        new_location = f"{alias.new_module}.{alias.new_name}" if alias.new_module else alias.new_name
+    else:
+        message = f"{old_name} is deprecated"
+        if new_name:
+            message += f", use {new_name} instead"
+        new_location = new_name or "(see documentation)"
+
+    full_message = (
+        f"{message} "
+        f"Will be removed in v{removal_version}. "
+        f"See migration guide in bioetl.domain.types module docstring."
+    )
+
+    warnings.warn(full_message, DeprecationWarning, stacklevel=stacklevel)
+
+
+def resolve_deprecated_type(name: str) -> Any:
+    """Resolve a deprecated type alias name to its actual type.
+
+    Returns the appropriate type/class for backward compatibility
+    when a deprecated name is accessed via __getattr__.
+
+    Args:
+        name: The deprecated name to resolve.
+
+    Returns:
+        The resolved type, class, or raises AttributeError if unknown.
+
+    Raises:
+        AttributeError: If the name is not a known deprecated alias.
+
+    Example:
+        >>> resolve_deprecated_type("RawRecordBatch")
+        <class 'bioetl.domain.data.RecordBatch'>
+    """
+    if name not in DEPRECATED_ALIASES:
+        raise AttributeError(f"Unknown deprecated alias: {name!r}")
+
+    alias = DEPRECATED_ALIASES[name]
+
+    # Handle type aliases that map to built-in types
+    if alias.new_name == "Mapping[str, Any]":
+        return dict[str, Any]
+
+    # Handle ApiPayload
+    if name == "RawPayload" or alias.new_name == "ApiPayload":
+        from bioetl.domain.types import ApiPayload
+        return ApiPayload
+
+    # Handle RecordBatch variants
+    if alias.new_name == "RecordBatch":
+        from bioetl.domain.data import RecordBatch
+        return RecordBatch
+
+    # Handle SourceRecordModel
+    if alias.new_name == "SourceRecordModel":
+        from bioetl.domain.record_source import SourceRecordModel
+        return SourceRecordModel
+
+    # Handle RecordSourceABC
+    if alias.new_name == "RecordSourceABC":
+        from bioetl.domain.record_source import RecordSourceABC
+        return RecordSourceABC
+
+    # Fallback for unknown types
+    raise AttributeError(f"Cannot resolve deprecated alias: {name!r}")
+
+
+def get_deprecated_names_for_module(module_name: str) -> set[str]:
+    """Get deprecated names that should be handled by a specific module.
+
+    Args:
+        module_name: The module path (e.g., 'bioetl.domain.types').
+
+    Returns:
+        Set of deprecated names that are originally from or re-exported by this module.
+    """
+    module_to_names: dict[str, set[str]] = {
+        "bioetl.domain.types": {
+            "RecordBatch",
+            "RawRecordDict",
+            "RawRecordBatch",
+            "RawRecordList",
+            "RawPayload",
+        },
+        "bioetl.domain.ports.extraction": {
+            "RawRecord",
+            "RawRecordDict",
+            "RawRecordBatch",
+        },
+        "bioetl.domain.ports": {
+            "RawRecord",
+            "RawRecordDict",
+            "RawRecordBatch",
+            "RawRecordList",
+            "RawPayload",
+        },
+        "bioetl.domain.record_source": {
+            "SourceRecord",
+            "RecordSource",
+        },
+    }
+    return module_to_names.get(module_name, set())
+
+
+def make_module_getattr(
+    module_name: str,
+    *,
+    additional_names: dict[str, DeprecatedAlias] | None = None,
+) -> Any:
+    """Create a __getattr__ function for a module with deprecated names.
+
+    Factory function that generates a properly configured __getattr__
+    for modules with deprecated exports.
+
+    Args:
+        module_name: Full module path (e.g., 'bioetl.domain.types').
+        additional_names: Additional deprecated names specific to this module.
+
+    Returns:
+        A __getattr__ function suitable for module-level deprecation handling.
+
+    Example:
+        >>> # In bioetl/domain/types.py
+        >>> from bioetl.domain._deprecations import make_module_getattr
+        >>> __getattr__ = make_module_getattr("bioetl.domain.types")
+    """
+    allowed_names = get_deprecated_names_for_module(module_name)
+    if additional_names:
+        allowed_names = allowed_names | set(additional_names.keys())
+
+    def __getattr__(name: str) -> Any:
+        if name in allowed_names:
+            emit_deprecation_warning(name, stacklevel=3)
+            return resolve_deprecated_type(name)
+        raise AttributeError(f"module {module_name!r} has no attribute {name!r}")
+
+    return __getattr__
+
+
+# =============================================================================
+# Introspection Utilities
+# =============================================================================
+
+
+def list_deprecated_aliases(
+    *,
+    category: str | None = None,
+    include_removed: bool = False,
+) -> list[tuple[str, DeprecatedAlias]]:
+    """List all deprecated aliases, optionally filtered by category.
+
+    Args:
+        category: Filter by category ('type_alias', 'class_alias', 'function').
+        include_removed: Include aliases that have already been removed.
+
+    Returns:
+        List of (old_name, DeprecatedAlias) tuples.
+    """
+    result = []
+    for name, alias in DEPRECATED_ALIASES.items():
+        if category and alias.category != category:
+            continue
+        result.append((name, alias))
+    return sorted(result, key=lambda x: (x[1].category, x[0]))
+
+
+def generate_migration_table() -> str:
+    """Generate a markdown table of deprecated aliases for documentation.
+
+    Returns:
+        Markdown-formatted table of deprecations.
+    """
+    lines = [
+        "| Deprecated Name | Replacement | Module | Category | Removal |",
+        "|-----------------|-------------|--------|----------|---------|",
+    ]
+
+    for name, alias in sorted(DEPRECATED_ALIASES.items()):
+        lines.append(
+            f"| `{name}` | `{alias.new_name}` | `{alias.new_module}` | "
+            f"{alias.category} | v{REMOVAL_VERSION} |"
+        )
+
+    return "\n".join(lines)
+
+
+__all__ = [
+    # Constants
+    "REMOVAL_VERSION",
+    "DEPRECATED_ALIASES",
+    # Types
+    "DeprecatedAlias",
+    # Core functions
+    "emit_deprecation_warning",
+    "resolve_deprecated_type",
+    "get_deprecated_names_for_module",
+    "make_module_getattr",
+    # Introspection
+    "list_deprecated_aliases",
+    "generate_migration_table",
+]

--- a/src/bioetl/domain/ports/__init__.py
+++ b/src/bioetl/domain/ports/__init__.py
@@ -5,8 +5,6 @@ This module re-exports them for convenience but new code should import
 directly from ``bioetl.domain.types``.
 """
 
-import warnings
-
 from bioetl.domain.ports.entity_models import EntityModelRegistryABC
 from bioetl.domain.ports.extraction import (
     BatchAdapterABC,
@@ -32,41 +30,28 @@ from bioetl.domain.ports.parsing import (
 from bioetl.domain.ports.schema import SchemaContractProviderABC
 from bioetl.domain.data import RecordBatch
 from bioetl.domain.types import ApiPayload
+from bioetl.domain._deprecations import (
+    emit_deprecation_warning,
+    resolve_deprecated_type,
+    get_deprecated_names_for_module,
+)
 
 # =============================================================================
 # Deprecated Type Aliases (backward compatibility re-exports)
 # =============================================================================
+# Deprecated names are now managed centrally in bioetl.domain._deprecations.
 
-_DEPRECATED_TYPE_ALIASES = {
-    "RawRecord": "Mapping[str, Any]",  # Use Mapping[str, Any] directly
-    "RawRecordDict": "Mapping[str, Any]",
-    "RawRecordBatch": "RecordBatch",
-    "RawRecordList": "RecordBatch",
-    "RawPayload": "ApiPayload",
-}
+_DEPRECATED_TYPE_ALIASES = get_deprecated_names_for_module(__name__)
 
 
 def __getattr__(name: str) -> type:
-    """Emit deprecation warning for legacy type alias imports."""
-    from typing import Any
+    """Emit deprecation warning for legacy type alias imports.
 
+    Uses centralized deprecation registry from bioetl.domain._deprecations.
+    """
     if name in _DEPRECATED_TYPE_ALIASES:
-        new_name = _DEPRECATED_TYPE_ALIASES[name]
-        warnings.warn(
-            f"{name} is deprecated, use {new_name} instead. "
-            "See migration guide in bioetl.domain.types module docstring.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        # Return appropriate fallback types
-        if name in ("RawRecord", "RawRecordDict"):
-            return dict[str, Any]
-        elif name in ("RawRecordBatch", "RawRecordList"):
-            from bioetl.domain.data import RecordBatch as _RecordBatch
-
-            return _RecordBatch
-        elif name == "RawPayload":
-            return ApiPayload
+        emit_deprecation_warning(name, stacklevel=2)
+        return resolve_deprecated_type(name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/src/bioetl/domain/ports/extraction.py
+++ b/src/bioetl/domain/ports/extraction.py
@@ -9,21 +9,23 @@ from typing import TYPE_CHECKING, Protocol
 
 from bioetl.domain.data import RecordBatch
 from bioetl.domain.types import ApiPayload
+from bioetl.domain._deprecations import (
+    emit_deprecation_warning,
+    resolve_deprecated_type,
+    get_deprecated_names_for_module,
+)
 
 # =============================================================================
 # Deprecated Type Aliases (backward compatibility re-exports)
 # =============================================================================
 # Import from bioetl.domain.types for new code.
 # These re-exports emit deprecation warnings via __getattr__ below.
+# Deprecated names managed centrally in bioetl.domain._deprecations.
 
 __all__: list[str] = []  # Populated at end of module
 
-# Sentinel for lazy deprecation
-_DEPRECATED_TYPE_ALIASES = {
-    "RawRecord": "Mapping[str, Any]",  # Use Mapping[str, Any] directly
-    "RawRecordDict": "Mapping[str, Any]",
-    "RawRecordBatch": "RecordBatch",
-}
+# Get deprecated names for this module from central registry
+_DEPRECATED_TYPE_ALIASES = get_deprecated_names_for_module(__name__)
 
 if TYPE_CHECKING:
     from bioetl.domain.record_source import SourceRecordModel
@@ -217,24 +219,11 @@ def __getattr__(name: str) -> object:
         from bioetl.domain.ports.extraction import RawRecordDict
 
     But emits a DeprecationWarning directing users to the new location.
+    Uses centralized deprecation registry from bioetl.domain._deprecations.
     """
-    from typing import Any
-
     if name in _DEPRECATED_TYPE_ALIASES:
-        new_name = _DEPRECATED_TYPE_ALIASES[name]
-        warnings.warn(
-            f"{name} is deprecated, use {new_name} instead. "
-            "See migration guide in bioetl.domain.types module docstring.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        # Return appropriate fallback types
-        if name in ("RawRecord", "RawRecordDict"):
-            return dict[str, Any]
-        elif name == "RawRecordBatch":
-            from bioetl.domain.data import RecordBatch as _RecordBatch
-
-            return _RecordBatch
+        emit_deprecation_warning(name, stacklevel=2)
+        return resolve_deprecated_type(name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/src/bioetl/domain/record_source.py
+++ b/src/bioetl/domain/record_source.py
@@ -56,12 +56,17 @@ See also:
 
 from __future__ import annotations
 
-import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ConfigDict
+
+from bioetl.domain._deprecations import (
+    emit_deprecation_warning,
+    resolve_deprecated_type,
+    get_deprecated_names_for_module,
+)
 
 
 class SourceRecordModel(BaseModel):
@@ -108,16 +113,18 @@ SourceRecord = SourceRecordModel
 """
 
 
+# Get deprecated names for this module from central registry
+_DEPRECATED_NAMES = get_deprecated_names_for_module(__name__)
+
+
 def __getattr__(name: str) -> Any:
-    """Module-level __getattr__ for deprecation warnings."""
-    if name == "SourceRecord":
-        warnings.warn(
-            "SourceRecord is deprecated, use SourceRecordModel instead. "
-            "Will be removed in v3.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return SourceRecordModel
+    """Module-level __getattr__ for deprecation warnings.
+
+    Uses centralized deprecation registry from bioetl.domain._deprecations.
+    """
+    if name in _DEPRECATED_NAMES:
+        emit_deprecation_warning(name, stacklevel=2)
+        return resolve_deprecated_type(name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/src/bioetl/domain/types.py
+++ b/src/bioetl/domain/types.py
@@ -77,8 +77,13 @@ Import tabular data types from domain.data::
 
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Any, TypeAlias
+
+from bioetl.domain._deprecations import (
+    emit_deprecation_warning,
+    resolve_deprecated_type,
+    get_deprecated_names_for_module,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -125,32 +130,12 @@ Example:
 # Deprecated Type Aliases (Backward Compatibility via __getattr__)
 # =============================================================================
 
-# Map of deprecated names to (new_location, deprecation_message)
+# Deprecated names are now managed centrally in bioetl.domain._deprecations.
+# This module handles: RecordBatch, RawRecordDict, RawRecordBatch, RawRecordList, RawPayload
 # NOTE: RawRecord has been removed completely. Do not add it here.
 # Use Mapping[str, Any] or bioetl.domain.data.Record protocol instead.
-_DEPRECATED_NAMES: dict[str, tuple[str, str]] = {
-    "RecordBatch": (
-        "bioetl.domain.data.RecordBatch",
-        "RecordBatch has moved to bioetl.domain.data. "
-        "Import from there: from bioetl.domain.data import RecordBatch",
-    ),
-    "RawRecordDict": (
-        "Mapping[str, Any]",
-        "RawRecordDict is deprecated. Use Mapping[str, Any] directly.",
-    ),
-    "RawRecordBatch": (
-        "bioetl.domain.data.RecordBatch",
-        "RawRecordBatch is deprecated. Use RecordBatch from bioetl.domain.data.",
-    ),
-    "RawRecordList": (
-        "bioetl.domain.data.RecordBatch",
-        "RawRecordList is deprecated. Use RecordBatch from bioetl.domain.data.",
-    ),
-    "RawPayload": (
-        "ApiPayload",
-        "RawPayload is deprecated. Use ApiPayload instead.",
-    ),
-}
+
+_DEPRECATED_NAMES = get_deprecated_names_for_module(__name__)
 
 
 def __getattr__(name: str) -> TypeAlias:
@@ -158,23 +143,11 @@ def __getattr__(name: str) -> TypeAlias:
 
     Provides backward compatibility for deprecated type aliases by returning
     appropriate types while emitting deprecation warnings.
+
+    Uses centralized deprecation registry from bioetl.domain._deprecations.
     """
     if name in _DEPRECATED_NAMES:
-        new_location, message = _DEPRECATED_NAMES[name]
-        warnings.warn(
-            f"{message} See migration guide in bioetl.domain.types module docstring.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        # Return appropriate fallback types for backward compatibility
-        if name == "RawRecordDict":
-            return dict[str, Any]
-        elif name in ("RecordBatch", "RawRecordBatch", "RawRecordList"):
-            # Import from data module for the actual type
-            from bioetl.domain.data import RecordBatch as _RecordBatch
-
-            return _RecordBatch
-        elif name == "RawPayload":
-            return ApiPayload
+        emit_deprecation_warning(name, stacklevel=2)
+        return resolve_deprecated_type(name)
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
Add domain/_deprecations.py with:
- DEPRECATED_ALIASES registry mapping old names to replacements
- emit_deprecation_warning() for consistent warning messages
- resolve_deprecated_type() for backward-compatible type resolution
- Introspection utilities for documentation generation

Update modules to use centralized registry:
- domain/types.py
- domain/ports/__init__.py
- domain/ports/extraction.py
- domain/record_source.py

Add scripts/check_deprecations.py scanner that:
- Scans codebase for deprecated imports
- Generates migration reports in text/json/markdown formats
- Supports --strict mode for CI integration