### PR TITLE
Create StageName value object with validation

### DIFF
--- a/src/bioetl/domain/value_objects.py
+++ b/src/bioetl/domain/value_objects.py
@@ -66,26 +66,71 @@ class RunId:
 
 
 class StageName:
-    """Value Object для имени стадии pipeline (snake_case).
+    """Value Object для имени стадии pipeline.
 
-    Используется для идентификации стадий в pipeline.
+    Ограниченный набор допустимых стадий с поддержкой aliases.
+
+    Allowed values:
+        - "extract" - стадия извлечения данных
+        - "transform" - стадия трансформации
+        - "validate" - стадия валидации
+        - "export" - стадия экспорта (alias: "load")
+
+    Features:
+        - Case-insensitive: StageName("EXTRACT") → StageName("extract")
+        - Alias support: StageName("load") → StageName("export")
+        - Enum-like access: StageName.EXTRACT, StageName.TRANSFORM, etc.
 
     Examples:
-        - "fetch"
-        - "transform"
-        - "normalize_data"
+        >>> StageName("extract")
+        StageName('extract')
+        >>> StageName("EXTRACT")  # case-insensitive
+        StageName('extract')
+        >>> StageName("load")  # alias for export
+        StageName('export')
+        >>> StageName.EXTRACT
+        StageName('extract')
     """
 
     __slots__ = ("_value",)
-    _pattern = re.compile(r"^[a-z][a-z0-9_]*$")
-    _max_length = 64
+
+    # Allowed stage names
+    _ALLOWED_VALUES: frozenset[str] = frozenset(
+        {"extract", "transform", "validate", "export"}
+    )
+
+    # Aliases mapping (load → export for backward compatibility)
+    _ALIASES: dict[str, str] = {"load": "export"}
+
+    # Class-level constants (initialized after class definition)
+    EXTRACT: StageName
+    TRANSFORM: StageName
+    VALIDATE: StageName
+    EXPORT: StageName
 
     def __init__(self, value: str) -> None:
-        if not self._pattern.match(value):
-            raise ValueError(f"StageName must be snake_case: {value}")
-        if len(value) > self._max_length:
-            raise ValueError(f"StageName too long: {len(value)} > {self._max_length}")
-        self._value = value
+        if not isinstance(value, str):
+            raise TypeError(f"StageName requires str, got {type(value).__name__}")
+
+        normalized = value.lower()
+
+        # Resolve alias
+        if normalized in self._ALIASES:
+            normalized = self._ALIASES[normalized]
+
+        if normalized not in self._ALLOWED_VALUES:
+            allowed = sorted(self._ALLOWED_VALUES | set(self._ALIASES.keys()))
+            raise ValueError(
+                f"Invalid stage name: {value!r}. "
+                f"Allowed values: {', '.join(allowed)}"
+            )
+
+        self._value = normalized
+
+    @classmethod
+    def all_values(cls) -> frozenset[str]:
+        """Return all allowed stage name values."""
+        return cls._ALLOWED_VALUES
 
     @property
     def value(self) -> str:
@@ -115,6 +160,13 @@ class StageName:
             core_schema.str_schema(),
             serialization=core_schema.plain_serializer_function_ser_schema(str),
         )
+
+
+# Initialize enum-like class constants
+StageName.EXTRACT = StageName("extract")
+StageName.TRANSFORM = StageName("transform")
+StageName.VALIDATE = StageName("validate")
+StageName.EXPORT = StageName("export")
 
 
 class EntityName:

--- a/tests/bioetl/domain/test_value_objects.py
+++ b/tests/bioetl/domain/test_value_objects.py
@@ -1,0 +1,208 @@
+"""Tests for domain value objects."""
+
+import pytest
+from pydantic import BaseModel
+
+from bioetl.domain.value_objects import StageName
+
+
+class TestStageName:
+    """Tests for StageName value object."""
+
+    # --- Valid values ---
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("extract", "extract"),
+            ("transform", "transform"),
+            ("validate", "validate"),
+            ("export", "export"),
+        ],
+    )
+    def test_valid_values(self, value: str, expected: str) -> None:
+        """Test that valid stage names are accepted."""
+        stage = StageName(value)
+        assert stage.value == expected
+        assert str(stage) == expected
+
+    # --- Case insensitivity ---
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("EXTRACT", "extract"),
+            ("Extract", "extract"),
+            ("TRANSFORM", "transform"),
+            ("Transform", "transform"),
+            ("VALIDATE", "validate"),
+            ("Validate", "validate"),
+            ("EXPORT", "export"),
+            ("Export", "export"),
+        ],
+    )
+    def test_case_insensitive(self, value: str, expected: str) -> None:
+        """Test that stage names are case-insensitive."""
+        stage = StageName(value)
+        assert stage.value == expected
+
+    # --- Alias support ---
+
+    @pytest.mark.parametrize(
+        "alias,canonical",
+        [
+            ("load", "export"),
+            ("Load", "export"),
+            ("LOAD", "export"),
+        ],
+    )
+    def test_alias_load_to_export(self, alias: str, canonical: str) -> None:
+        """Test that 'load' is an alias for 'export'."""
+        stage = StageName(alias)
+        assert stage.value == canonical
+        assert stage == StageName.EXPORT
+
+    # --- Invalid values ---
+
+    @pytest.mark.parametrize(
+        "invalid_value",
+        [
+            "fetch",
+            "normalize",
+            "invalid",
+            "",
+            "extract_data",
+            "transform_records",
+        ],
+    )
+    def test_invalid_values_raise_error(self, invalid_value: str) -> None:
+        """Test that invalid stage names raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid stage name"):
+            StageName(invalid_value)
+
+    def test_invalid_type_raises_error(self) -> None:
+        """Test that non-string input raises TypeError."""
+        with pytest.raises(TypeError, match="StageName requires str"):
+            StageName(123)  # type: ignore[arg-type]
+
+    # --- Enum-like class constants ---
+
+    def test_extract_constant(self) -> None:
+        """Test StageName.EXTRACT constant."""
+        assert StageName.EXTRACT.value == "extract"
+        assert StageName.EXTRACT == StageName("extract")
+
+    def test_transform_constant(self) -> None:
+        """Test StageName.TRANSFORM constant."""
+        assert StageName.TRANSFORM.value == "transform"
+        assert StageName.TRANSFORM == StageName("transform")
+
+    def test_validate_constant(self) -> None:
+        """Test StageName.VALIDATE constant."""
+        assert StageName.VALIDATE.value == "validate"
+        assert StageName.VALIDATE == StageName("validate")
+
+    def test_export_constant(self) -> None:
+        """Test StageName.EXPORT constant."""
+        assert StageName.EXPORT.value == "export"
+        assert StageName.EXPORT == StageName("export")
+
+    # --- all_values method ---
+
+    def test_all_values(self) -> None:
+        """Test all_values returns all allowed stage names."""
+        values = StageName.all_values()
+        assert values == frozenset({"extract", "transform", "validate", "export"})
+
+    # --- Equality and hashing ---
+
+    def test_equality_same_value(self) -> None:
+        """Test that two StageName with same value are equal."""
+        assert StageName("extract") == StageName("extract")
+        assert StageName("EXTRACT") == StageName("extract")
+
+    def test_equality_different_value(self) -> None:
+        """Test that two StageName with different values are not equal."""
+        assert StageName("extract") != StageName("transform")
+
+    def test_equality_with_non_stagename(self) -> None:
+        """Test that StageName is not equal to non-StageName."""
+        assert (StageName("extract") == "extract") is False
+        assert StageName("extract").__eq__("extract") is NotImplemented
+
+    def test_hashable(self) -> None:
+        """Test that StageName is hashable and can be used in sets."""
+        stages = {StageName("extract"), StageName("EXTRACT"), StageName("transform")}
+        assert len(stages) == 2  # extract and EXTRACT are the same
+
+    def test_usable_as_dict_key(self) -> None:
+        """Test that StageName can be used as dictionary key."""
+        data = {StageName.EXTRACT: "extraction complete"}
+        assert data[StageName("extract")] == "extraction complete"
+
+    # --- String representation ---
+
+    def test_str_representation(self) -> None:
+        """Test __str__ returns the value."""
+        assert str(StageName("extract")) == "extract"
+
+    def test_repr_representation(self) -> None:
+        """Test __repr__ returns a developer-friendly string."""
+        assert repr(StageName("extract")) == "StageName('extract')"
+
+    # --- Pydantic integration ---
+
+    def test_pydantic_model_validation(self) -> None:
+        """Test StageName works with Pydantic models."""
+
+        class TestModel(BaseModel):
+            stage: StageName
+
+        model = TestModel(stage="extract")
+        assert model.stage == StageName.EXTRACT
+        assert model.stage.value == "extract"
+
+    def test_pydantic_model_case_insensitive(self) -> None:
+        """Test Pydantic model accepts case-insensitive values."""
+
+        class TestModel(BaseModel):
+            stage: StageName
+
+        model = TestModel(stage="EXTRACT")
+        assert model.stage.value == "extract"
+
+    def test_pydantic_model_alias(self) -> None:
+        """Test Pydantic model resolves aliases."""
+
+        class TestModel(BaseModel):
+            stage: StageName
+
+        model = TestModel(stage="load")
+        assert model.stage.value == "export"
+
+    def test_pydantic_model_serialization(self) -> None:
+        """Test StageName serializes to string in Pydantic."""
+
+        class TestModel(BaseModel):
+            stage: StageName
+
+        model = TestModel(stage="extract")
+        assert model.model_dump() == {"stage": "extract"}
+
+    def test_pydantic_model_invalid_value(self) -> None:
+        """Test Pydantic model rejects invalid stage names."""
+        from pydantic import ValidationError
+
+        class TestModel(BaseModel):
+            stage: StageName
+
+        with pytest.raises(ValidationError):
+            TestModel(stage="invalid_stage")
+
+    # --- Immutability ---
+
+    def test_immutability(self) -> None:
+        """Test that StageName instances are immutable."""
+        stage = StageName("extract")
+        with pytest.raises(AttributeError):
+            stage._value = "transform"  # type: ignore[misc]


### PR DESCRIPTION
- Restrict StageName to allowed values: extract, transform, validate, export
- Add alias support: "load" resolves to "export"
- Support case-insensitive creation: StageName("EXTRACT") → "extract"
- Add enum-like class constants: StageName.EXTRACT, StageName.TRANSFORM, etc.
- Add all_values() class method to get allowed values
- Maintain full Pydantic compatibility
- Add comprehensive tests for StageName