### PR TITLE
Fix duplicate HashDigest class definition

### DIFF
--- a/src/bioetl/domain/value_objects.py
+++ b/src/bioetl/domain/value_objects.py
@@ -293,11 +293,26 @@ class HashDigest:
     """Value Object for cryptographic hash digest (hex-encoded).
 
     Provides type safety for hash values throughout the system.
-    Supports common algorithms: blake2b_256, sha256, md5.
+    Supports multiple algorithms with length validation.
+    Immutable after creation.
 
     Attributes:
         value: Hex-encoded hash string (lowercase).
-        algorithm: Algorithm identifier (e.g., 'blake2b_256').
+        algorithm: Algorithm identifier (default: 'blake2b_256').
+
+    Supported algorithms:
+        - blake2b_256: 64 hex chars (256 bits)
+        - sha256: 64 hex chars (256 bits)
+        - sha512: 128 hex chars (512 bits)
+        - md5: 32 hex chars (128 bits)
+
+    Examples:
+        >>> HashDigest("a" * 64)  # Default blake2b_256
+        HashDigest('aaaa...', algorithm='blake2b_256')
+        >>> HashDigest("b" * 32, "md5")
+        HashDigest('bbbb...', algorithm='md5')
+        >>> HashDigest.blake2b_256("c" * 64)  # Factory method
+        HashDigest('cccc...', algorithm='blake2b_256')
     """
 
     __slots__ = ("_value", "_algorithm")
@@ -330,8 +345,16 @@ class HashDigest:
                 f"expected {expected_len}, got {len(normalized)}"
             )
 
-        self._value = normalized
-        self._algorithm = algorithm
+        object.__setattr__(self, "_value", normalized)
+        object.__setattr__(self, "_algorithm", algorithm)
+
+    def __setattr__(self, name: str, value: object) -> None:
+        """Prevent modification after initialization (immutability guard)."""
+        if hasattr(self, "_value"):
+            raise AttributeError(
+                f"Cannot modify immutable HashDigest: attribute {name!r}"
+            )
+        object.__setattr__(self, name, value)
 
     @property
     def value(self) -> str:
@@ -342,6 +365,11 @@ class HashDigest:
     def algorithm(self) -> str:
         """Algorithm identifier."""
         return self._algorithm
+
+    @property
+    def is_blake2b(self) -> bool:
+        """Check if this is a BLAKE2b-256 hash."""
+        return self._algorithm == "blake2b_256"
 
     def __str__(self) -> str:
         return self._value
@@ -358,8 +386,28 @@ class HashDigest:
         return hash((self._value, self._algorithm))
 
     @classmethod
+    def blake2b_256(cls, hex_value: str) -> Self:
+        """Factory for BLAKE2b-256 hashes (backward compatibility).
+
+        Args:
+            hex_value: 64-character hex string.
+
+        Returns:
+            HashDigest with algorithm='blake2b_256'.
+        """
+        return cls(hex_value, "blake2b_256")
+
+    @classmethod
     def from_hex(cls, hex_string: str, algorithm: str = "blake2b_256") -> Self:
-        """Create HashDigest from hex string."""
+        """Create HashDigest from hex string.
+
+        Args:
+            hex_string: Hex-encoded hash value.
+            algorithm: Algorithm identifier (default: blake2b_256).
+
+        Returns:
+            HashDigest instance.
+        """
         return cls(hex_string, algorithm)
 
     @classmethod
@@ -413,56 +461,6 @@ class ChemblId:
         if isinstance(other, ChemblId):
             return self.numeric_id < other.numeric_id
         return NotImplemented
-
-    @classmethod
-    def __get_pydantic_core_schema__(
-        cls, source_type: type, handler: GetCoreSchemaHandler
-    ) -> CoreSchema:
-        return core_schema.no_info_after_validator_function(
-            cls,
-            core_schema.str_schema(),
-            serialization=core_schema.plain_serializer_function_ser_schema(str),
-        )
-
-
-class HashDigest:
-    """Value Object для BLAKE2b-256 хеш-дайджеста (64 hex символа)."""
-
-    __slots__ = ("_value",)
-    _pattern = re.compile(r"^[a-f0-9]{64}$")
-
-    def __init__(self, value: str) -> None:
-        normalized = value.lower()
-        if not self._pattern.match(normalized):
-            raise ValueError(
-                f"Invalid HashDigest: '{value}'. "
-                f"Expected 64 lowercase hex characters (BLAKE2b-256)"
-            )
-        self._value = normalized
-
-    def __setattr__(self, name: str, value: object) -> None:
-        if name == "_value" and hasattr(self, "_value"):
-            raise AttributeError("HashDigest is immutable")
-        super().__setattr__(name, value)
-
-    @property
-    def value(self) -> str:
-        """String representation of HashDigest."""
-        return self._value
-
-    def __str__(self) -> str:
-        return self._value
-
-    def __repr__(self) -> str:
-        return f"HashDigest({self._value!r})"
-
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, HashDigest):
-            return self._value == other._value
-        return NotImplemented
-
-    def __hash__(self) -> int:
-        return hash(self._value)
 
     @classmethod
     def __get_pydantic_core_schema__(

--- a/tests/bioetl/domain/test_value_objects.py
+++ b/tests/bioetl/domain/test_value_objects.py
@@ -3,7 +3,7 @@
 import pytest
 from pydantic import BaseModel
 
-from bioetl.domain.value_objects import StageName
+from bioetl.domain.value_objects import HashDigest, StageName
 
 
 class TestStageName:
@@ -206,3 +206,231 @@ class TestStageName:
         stage = StageName("extract")
         with pytest.raises(AttributeError):
             stage._value = "transform"  # type: ignore[misc]
+
+
+class TestHashDigest:
+    """Tests for HashDigest value object."""
+
+    # --- Valid hex hash samples ---
+    VALID_BLAKE2B_256 = "a" * 64
+    VALID_SHA256 = "b" * 64
+    VALID_SHA512 = "c" * 128
+    VALID_MD5 = "d" * 32
+
+    # --- Basic creation with default algorithm ---
+
+    def test_create_default_blake2b(self) -> None:
+        """Test creating HashDigest with default blake2b_256 algorithm."""
+        digest = HashDigest(self.VALID_BLAKE2B_256)
+        assert digest.value == self.VALID_BLAKE2B_256
+        assert digest.algorithm == "blake2b_256"
+
+    def test_normalizes_to_lowercase(self) -> None:
+        """Test that hex values are normalized to lowercase."""
+        upper_hex = "A" * 64
+        digest = HashDigest(upper_hex)
+        assert digest.value == "a" * 64
+
+    # --- Multi-algorithm support ---
+
+    @pytest.mark.parametrize(
+        "hex_value,algorithm,expected_len",
+        [
+            ("a" * 64, "blake2b_256", 64),
+            ("b" * 64, "sha256", 64),
+            ("c" * 128, "sha512", 128),
+            ("d" * 32, "md5", 32),
+        ],
+    )
+    def test_multiple_algorithms(
+        self, hex_value: str, algorithm: str, expected_len: int
+    ) -> None:
+        """Test HashDigest supports multiple algorithms with correct lengths."""
+        digest = HashDigest(hex_value, algorithm)
+        assert digest.value == hex_value
+        assert digest.algorithm == algorithm
+        assert len(digest.value) == expected_len
+
+    def test_unknown_algorithm_no_length_validation(self) -> None:
+        """Test that unknown algorithms skip length validation."""
+        digest = HashDigest("abc123", "custom_algo")
+        assert digest.value == "abc123"
+        assert digest.algorithm == "custom_algo"
+
+    # --- Length validation ---
+
+    @pytest.mark.parametrize(
+        "hex_value,algorithm,expected_len",
+        [
+            ("a" * 63, "blake2b_256", 64),  # Too short
+            ("a" * 65, "blake2b_256", 64),  # Too long
+            ("b" * 127, "sha512", 128),  # Too short
+            ("c" * 31, "md5", 32),  # Too short
+        ],
+    )
+    def test_length_mismatch_raises_error(
+        self, hex_value: str, algorithm: str, expected_len: int
+    ) -> None:
+        """Test that wrong length for known algorithm raises ValueError."""
+        with pytest.raises(ValueError, match="length mismatch"):
+            HashDigest(hex_value, algorithm)
+
+    # --- Invalid hex values ---
+
+    @pytest.mark.parametrize(
+        "invalid_value",
+        [
+            "g" * 64,  # Invalid hex character
+            "xyz123",  # Invalid characters
+            "hello world",  # Spaces
+            "",  # Empty string
+        ],
+    )
+    def test_invalid_hex_raises_error(self, invalid_value: str) -> None:
+        """Test that non-hex values raise ValueError."""
+        with pytest.raises(ValueError, match="must be hex string"):
+            HashDigest(invalid_value)
+
+    # --- Factory methods ---
+
+    def test_blake2b_256_factory(self) -> None:
+        """Test blake2b_256 factory method."""
+        digest = HashDigest.blake2b_256(self.VALID_BLAKE2B_256)
+        assert digest.value == self.VALID_BLAKE2B_256
+        assert digest.algorithm == "blake2b_256"
+        assert digest.is_blake2b is True
+
+    def test_from_hex_factory_default(self) -> None:
+        """Test from_hex factory with default algorithm."""
+        digest = HashDigest.from_hex(self.VALID_BLAKE2B_256)
+        assert digest.value == self.VALID_BLAKE2B_256
+        assert digest.algorithm == "blake2b_256"
+
+    def test_from_hex_factory_with_algorithm(self) -> None:
+        """Test from_hex factory with explicit algorithm."""
+        digest = HashDigest.from_hex(self.VALID_MD5, "md5")
+        assert digest.value == self.VALID_MD5
+        assert digest.algorithm == "md5"
+
+    # --- is_blake2b property ---
+
+    def test_is_blake2b_true(self) -> None:
+        """Test is_blake2b returns True for blake2b_256."""
+        digest = HashDigest(self.VALID_BLAKE2B_256, "blake2b_256")
+        assert digest.is_blake2b is True
+
+    def test_is_blake2b_false(self) -> None:
+        """Test is_blake2b returns False for other algorithms."""
+        digest = HashDigest(self.VALID_MD5, "md5")
+        assert digest.is_blake2b is False
+
+    # --- Immutability ---
+
+    def test_immutability_value(self) -> None:
+        """Test that _value cannot be modified after creation."""
+        digest = HashDigest(self.VALID_BLAKE2B_256)
+        with pytest.raises(AttributeError, match="immutable"):
+            digest._value = "b" * 64  # type: ignore[misc]
+
+    def test_immutability_algorithm(self) -> None:
+        """Test that _algorithm cannot be modified after creation."""
+        digest = HashDigest(self.VALID_BLAKE2B_256)
+        with pytest.raises(AttributeError, match="immutable"):
+            digest._algorithm = "sha256"  # type: ignore[misc]
+
+    def test_immutability_new_attribute(self) -> None:
+        """Test that new attributes cannot be added."""
+        digest = HashDigest(self.VALID_BLAKE2B_256)
+        with pytest.raises(AttributeError):
+            digest.new_attr = "test"  # type: ignore[attr-defined]
+
+    # --- Equality and hashing ---
+
+    def test_equality_same_value_and_algorithm(self) -> None:
+        """Test equality when value and algorithm match."""
+        d1 = HashDigest(self.VALID_BLAKE2B_256, "blake2b_256")
+        d2 = HashDigest(self.VALID_BLAKE2B_256, "blake2b_256")
+        assert d1 == d2
+
+    def test_inequality_same_value_different_algorithm(self) -> None:
+        """Test inequality when algorithms differ."""
+        d1 = HashDigest(self.VALID_SHA256, "blake2b_256")
+        d2 = HashDigest(self.VALID_SHA256, "sha256")
+        assert d1 != d2
+
+    def test_inequality_different_value(self) -> None:
+        """Test inequality when values differ."""
+        d1 = HashDigest("a" * 64)
+        d2 = HashDigest("b" * 64)
+        assert d1 != d2
+
+    def test_equality_with_non_hashdigest(self) -> None:
+        """Test that HashDigest is not equal to non-HashDigest."""
+        digest = HashDigest(self.VALID_BLAKE2B_256)
+        assert (digest == self.VALID_BLAKE2B_256) is False
+        assert digest.__eq__(self.VALID_BLAKE2B_256) is NotImplemented
+
+    def test_hashable_same_values(self) -> None:
+        """Test that identical HashDigests have same hash."""
+        d1 = HashDigest(self.VALID_BLAKE2B_256)
+        d2 = HashDigest(self.VALID_BLAKE2B_256)
+        assert hash(d1) == hash(d2)
+
+    def test_usable_in_set(self) -> None:
+        """Test that HashDigest can be used in sets."""
+        digests = {
+            HashDigest("a" * 64),
+            HashDigest("a" * 64),  # Duplicate
+            HashDigest("b" * 64),
+        }
+        assert len(digests) == 2
+
+    def test_usable_as_dict_key(self) -> None:
+        """Test that HashDigest can be used as dictionary key."""
+        digest = HashDigest(self.VALID_BLAKE2B_256)
+        data = {digest: "test_value"}
+        assert data[HashDigest(self.VALID_BLAKE2B_256)] == "test_value"
+
+    # --- String representation ---
+
+    def test_str_representation(self) -> None:
+        """Test __str__ returns the hex value."""
+        digest = HashDigest(self.VALID_BLAKE2B_256)
+        assert str(digest) == self.VALID_BLAKE2B_256
+
+    def test_repr_representation(self) -> None:
+        """Test __repr__ includes value and algorithm."""
+        digest = HashDigest(self.VALID_BLAKE2B_256, "blake2b_256")
+        expected = f"HashDigest('{self.VALID_BLAKE2B_256}', algorithm='blake2b_256')"
+        assert repr(digest) == expected
+
+    # --- Pydantic integration ---
+
+    def test_pydantic_model_validation(self) -> None:
+        """Test HashDigest works with Pydantic models."""
+
+        class TestModel(BaseModel):
+            digest: HashDigest
+
+        model = TestModel(digest=self.VALID_BLAKE2B_256)
+        assert model.digest.value == self.VALID_BLAKE2B_256
+        assert model.digest.algorithm == "blake2b_256"
+
+    def test_pydantic_model_serialization(self) -> None:
+        """Test HashDigest serializes to string in Pydantic."""
+
+        class TestModel(BaseModel):
+            digest: HashDigest
+
+        model = TestModel(digest=self.VALID_BLAKE2B_256)
+        assert model.model_dump() == {"digest": self.VALID_BLAKE2B_256}
+
+    def test_pydantic_model_invalid_value(self) -> None:
+        """Test Pydantic model rejects invalid hash values."""
+        from pydantic import ValidationError
+
+        class TestModel(BaseModel):
+            digest: HashDigest
+
+        with pytest.raises(ValidationError):
+            TestModel(digest="not_a_valid_hex")


### PR DESCRIPTION
- Remove second HashDigest definition that was overwriting the first
- Add immutability guard (__setattr__) from second version to unified class
- Add blake2b_256() factory method for backward compatibility
- Add is_blake2b property to check algorithm type
- Add comprehensive tests for multi-algorithm support and immutability