### PR TITLE
Create observability factory for logger components

### DIFF
--- a/src/bioetl/interfaces/factories/__init__.py
+++ b/src/bioetl/interfaces/factories/__init__.py
@@ -1,17 +1,19 @@
-from bioetl.interfaces.factories.observability import (
-    ObservabilityFactoryABC,
-    DefaultObservabilityFactory,
-    create_observability_factory,
-)
+"""Factory interfaces for dependency injection."""
+
 from bioetl.interfaces.factories.infrastructure import (
-    InfrastructureFactoryABC,
     DefaultInfrastructureFactory,
+    InfrastructureFactoryABC,
+)
+from bioetl.interfaces.factories.observability import (
+    DefaultObservabilityFactory,
+    ObservabilityFactoryABC,
+    create_observability_factory,
 )
 
 __all__ = [
-    "ObservabilityFactoryABC",
-    "DefaultObservabilityFactory",
-    "create_observability_factory",
-    "InfrastructureFactoryABC",
     "DefaultInfrastructureFactory",
+    "DefaultObservabilityFactory",
+    "InfrastructureFactoryABC",
+    "ObservabilityFactoryABC",
+    "create_observability_factory",
 ]

--- a/src/bioetl/interfaces/factories/observability.py
+++ b/src/bioetl/interfaces/factories/observability.py
@@ -1,9 +1,3 @@
-"""Factory for creating observability components.
-
-Provides abstract factory interface and default implementation for
-observability-layer components: loggers and metrics.
-"""
-
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
@@ -16,47 +10,35 @@ class ObservabilityFactoryABC(ABC):
 
     @abstractmethod
     def create_logger(self) -> LoggingPortABC:
-        """Create a logger instance."""
+        """Create logging port instance."""
 
     @abstractmethod
     def create_metrics(self) -> MetricsPortABC:
-        """Create a metrics instance."""
+        """Create metrics port instance."""
 
 
 class DefaultObservabilityFactory(ObservabilityFactoryABC):
-    """Default implementation of observability factory.
-
-    Uses infrastructure factories to create structured logger and Prometheus metrics.
-    """
+    """Default factory using infrastructure implementations."""
 
     def __init__(self) -> None:
-        """Initialize factory with lazy-loaded components."""
         self._logger: LoggingPortABC | None = None
         self._metrics: MetricsPortABC | None = None
 
     def create_logger(self) -> LoggingPortABC:
-        """Create or return cached logger instance."""
         if self._logger is None:
             from bioetl.infrastructure.observability.factories import create_logging_port
-
             self._logger = create_logging_port()
         return self._logger
 
     def create_metrics(self) -> MetricsPortABC:
-        """Create or return cached metrics instance."""
         if self._metrics is None:
             from bioetl.infrastructure.observability.factories import create_metrics_port
-
             self._metrics = create_metrics_port()
         return self._metrics
 
 
 def create_observability_factory() -> ObservabilityFactoryABC:
-    """Create the default observability factory.
-
-    Returns:
-        Default observability factory instance.
-    """
+    """Factory function for default observability factory."""
     return DefaultObservabilityFactory()
 
 


### PR DESCRIPTION
Extract observability component creation into dedicated factory pattern:
- ObservabilityFactoryABC abstract base class
- DefaultObservabilityFactory with lazy initialization
- create_observability_factory() factory function