### PR TITLE
Consolidate logging factories into single module

### DIFF
--- a/src/bioetl/infrastructure/logging/factories.py
+++ b/src/bioetl/infrastructure/logging/factories.py
@@ -4,24 +4,37 @@ Naming convention:
 - create_*() - creates a new instance each time
 - get_*() - returns singleton/cached instance
 - build_*() - uses builder pattern
+
+NOTE: Logging factories are consolidated in observability layer.
+Use `bioetl.infrastructure.observability.factories.create_logging_port` as the
+canonical factory. Functions here delegate to observability for backward compatibility.
 """
 
 import warnings
-
-import structlog
 
 from bioetl.domain.observability import LoggingPortABC, ProgressReporterABC
 from bioetl.infrastructure.logging.impl.progress_reporter import (
     TqdmProgressReporterImpl,
 )
-from bioetl.infrastructure.observability import factories as observability_factories
-from bioetl.infrastructure.observability.adapters import StructuredLoggerImpl
 
 
 def create_logger() -> LoggingPortABC:
-    """Create a new configured structured logger instance."""
-    observability_factories._configure_structlog()
-    return StructuredLoggerImpl(logger=structlog.get_logger())
+    """Create structured logger. Delegates to observability layer.
+
+    .. deprecated:: 1.6
+        Use :func:`bioetl.infrastructure.observability.factories.create_logging_port`
+        instead. Will be removed in v2.0.
+    """
+    warnings.warn(
+        "create_logger is deprecated since v1.6, use "
+        "bioetl.infrastructure.observability.factories.create_logging_port instead. "
+        "Will be removed in v2.0.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    from bioetl.infrastructure.observability.factories import create_logging_port
+
+    return create_logging_port()
 
 
 def create_progress_reporter() -> ProgressReporterABC:
@@ -35,13 +48,22 @@ def create_progress_reporter() -> ProgressReporterABC:
 
 
 def default_logger() -> LoggingPortABC:
-    """DEPRECATED: Use create_logger() instead."""
+    """DEPRECATED: Use create_logging_port() from observability.factories instead.
+
+    .. deprecated:: 1.6
+        Use :func:`bioetl.infrastructure.observability.factories.create_logging_port`
+        instead. Will be removed in v2.0.
+    """
     warnings.warn(
-        "default_logger is deprecated, use create_logger instead",
+        "default_logger is deprecated since v1.6, use "
+        "bioetl.infrastructure.observability.factories.create_logging_port instead. "
+        "Will be removed in v2.0.",
         DeprecationWarning,
         stacklevel=2,
     )
-    return create_logger()
+    from bioetl.infrastructure.observability.factories import create_logging_port
+
+    return create_logging_port()
 
 
 def default_progress_reporter() -> ProgressReporterABC:

--- a/src/tools/cleanup_packages.py
+++ b/src/tools/cleanup_packages.py
@@ -17,13 +17,13 @@ def _find_project_root(start: Path) -> Path:
 ROOT = _find_project_root(Path(__file__))
 
 try:
-    from bioetl.infrastructure.logging.factories import (
-        default_logger as get_default_logger,
+    from bioetl.infrastructure.observability.factories import (
+        create_logging_port as get_logging_port,
     )
 except Exception:
-    get_default_logger: Optional[Callable[[], Any]] = None
+    get_logging_port: Optional[Callable[[], Any]] = None
 else:
-    get_default_logger = get_default_logger
+    get_logging_port = get_logging_port
 
 
 IGNORED_FILES = {".DS_Store", "Thumbs.db"}
@@ -166,8 +166,8 @@ def main() -> int:
     args = ap.parse_args()
 
     logger = None
-    if get_default_logger is not None:
-        logger = get_default_logger().apply_bind(task="cleanup_packages")
+    if get_logging_port is not None:
+        logger = get_logging_port().apply_bind(task="cleanup_packages")
 
     scope = [ROOT / "tests", ROOT / "docs", ROOT / "src" / "tools"]
     if args.include_src:

--- a/src/tools/cleanup_project.py
+++ b/src/tools/cleanup_project.py
@@ -139,7 +139,7 @@ def _delete(paths: Iterable[Path]) -> Tuple[int, int]:
 
 
 def main() -> int:
-    from bioetl.infrastructure.logging.factories import default_logger
+    from bioetl.infrastructure.observability.factories import create_logging_port
 
     ap = argparse.ArgumentParser()
     ap.add_argument("--apply", action="store_true")
@@ -147,7 +147,7 @@ def main() -> int:
     ap.add_argument("--purge-logs", action="store_true")
     args = ap.parse_args()
 
-    logger = default_logger().apply_bind(task="cleanup_project")
+    logger = create_logging_port().apply_bind(task="cleanup_project")
     root = PROJECT_ROOT
     patterns = _whitelist_patterns()
     candidates = _iter_candidates(root, patterns)

--- a/src/tools/debug_publication_fetch.py
+++ b/src/tools/debug_publication_fetch.py
@@ -1,10 +1,10 @@
 import requests
 
-from bioetl.infrastructure.logging.factories import default_logger
+from bioetl.infrastructure.observability.factories import create_logging_port
 
 
 def main():
-    logger = default_logger().apply_bind(
+    logger = create_logging_port().apply_bind(
         pipeline="publication_chembl", entity="publication", stage="debug_fetch"
     )
 

--- a/src/tools/run_all_pipelines.py
+++ b/src/tools/run_all_pipelines.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import sys
 
 from bioetl.domain.observability.contracts import LoggingPortABC
-from bioetl.infrastructure.logging.factories import default_logger
+from bioetl.infrastructure.observability.factories import create_logging_port
 from bioetl.interfaces.cli.app import app
 
 # Pipeline dependency order
@@ -78,7 +78,7 @@ def run_pipeline(name: str, limit: int, logger: LoggingPortABC) -> dict:
 
 
 def main():
-    logger = default_logger().apply_bind(
+    logger = create_logging_port().apply_bind(
         pipeline="chembl_all", entity="chembl", stage="runner"
     )
 

--- a/tests/bioetl/infrastructure/logging/test_logging.py
+++ b/tests/bioetl/infrastructure/logging/test_logging.py
@@ -2,9 +2,11 @@
 Tests for logging and progress reporting components.
 """
 
+import warnings
 from unittest.mock import patch
 
 from bioetl.infrastructure.logging.factories import (
+    create_logger,
     default_logger,
     default_progress_reporter,
 )
@@ -12,13 +14,37 @@ from bioetl.infrastructure.logging.impl.progress_reporter import (
     TqdmProgressReporterImpl,
 )
 from bioetl.infrastructure.observability.adapters import StructuredLoggerImpl
+from bioetl.infrastructure.observability.factories import create_logging_port
 
 
-def test_default_logger():
-    """Test default logger factory."""
-    with patch("bioetl.infrastructure.logging.factories.structlog"):
+def test_create_logging_port():
+    """Test canonical logger factory from observability layer."""
+    logger = create_logging_port()
+    assert isinstance(logger, StructuredLoggerImpl)
+
+
+def test_create_logger_deprecated():
+    """Test that create_logger emits deprecation warning and delegates."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        logger = create_logger()
+        assert isinstance(logger, StructuredLoggerImpl)
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "v1.6" in str(w[0].message)
+        assert "create_logging_port" in str(w[0].message)
+
+
+def test_default_logger_deprecated():
+    """Test that default_logger emits deprecation warning and delegates."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
         logger = default_logger()
         assert isinstance(logger, StructuredLoggerImpl)
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "v1.6" in str(w[0].message)
+        assert "create_logging_port" in str(w[0].message)
 
 
 def test_default_progress_reporter():


### PR DESCRIPTION
Consolidate dual logging factories into a single source of truth:
- Make observability.factories.create_logging_port the canonical factory
- Update logging.factories.create_logger to delegate to canonical factory
- Update logging.factories.default_logger to delegate to canonical factory
- Add deprecation warnings (v1.6, removal v2.0) to both deprecated functions
- Update all tool imports to use canonical create_logging_port
- Update tests to verify deprecation warnings and canonical factory