### PR TITLE
Implement factory pattern for BioETL components

### DIFF
--- a/src/bioetl/application/factories/__init__.py
+++ b/src/bioetl/application/factories/__init__.py
@@ -18,7 +18,10 @@ No-op factories (for testing/fallback):
     - create_noop_validator_factory
 """
 
-from bioetl.application.factories.hooks import PipelineHookFactory
+from bioetl.application.factories.hooks import (
+    PipelineHookFactory,
+    PipelineHookFactoryABC,
+)
 from bioetl.application.factories.noop import (
     create_noop_logger,
     create_noop_metadata_builder,
@@ -51,6 +54,7 @@ __all__ = [
     "ApplicationServiceFactory",
     "ApplicationServiceFactoryABC",
     "PipelineHookFactory",
+    "PipelineHookFactoryABC",
     "PipelineRuntimeFactory",
     "PipelineRuntimeFactoryABC",
     "ProviderServiceFactory",

--- a/src/bioetl/application/factories/hooks.py
+++ b/src/bioetl/application/factories/hooks.py
@@ -4,6 +4,8 @@ Factory for creating pipeline hooks.
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
+
 from bioetl.application.pipelines.hooks_impl import (
     LoggingPipelineHookImpl,
     MetricsPipelineHookImpl,
@@ -13,7 +15,27 @@ from bioetl.domain.observability import LoggingPortABC, MetricsPortABC
 from bioetl.domain.pipelines.contracts import PipelineHookABC
 
 
-class PipelineHookFactory:
+class PipelineHookFactoryABC(ABC):
+    """Abstract factory for creating pipeline hooks.
+
+    Defines the contract for factories that create hooks for pipeline execution.
+    Hooks receive callbacks at various points during pipeline execution
+    (start, batch processed, error, completion).
+    """
+
+    @abstractmethod
+    def create_hooks(self, logger: LoggingPortABC) -> list[PipelineHookABC]:
+        """Create pipeline execution hooks.
+
+        Args:
+            logger: Logger instance for logging hooks.
+
+        Returns:
+            List of pipeline hooks to be invoked during execution.
+        """
+
+
+class PipelineHookFactory(PipelineHookFactoryABC):
     """Factory for creating pipeline hooks."""
 
     def __init__(


### PR DESCRIPTION
Add ABC for PipelineHookFactory following the project pattern "ABC → Default factory → Impl". Update __init__.py exports.