### PR TITLE
Remove duplication in normalization services

### DIFF
--- a/src/bioetl/infrastructure/transform/factories.py
+++ b/src/bioetl/infrastructure/transform/factories.py
@@ -19,8 +19,8 @@ from bioetl.domain.transform.contracts import (
     NormalizationServiceABC,
     TimestampProviderABC,
 )
-from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl import (  # noqa: E501
-    DefaultNormalizationTransformerImpl,
+from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl import (
+    NormalizationServiceImpl,
 )
 from bioetl.infrastructure.transform.impl.hash_service import Blake2bHashService
 from bioetl.infrastructure.transform.impl.hasher import HasherImpl
@@ -79,7 +79,7 @@ def create_normalization_service(
     config: NormalizationConfigProviderProtocol,
 ) -> NormalizationServiceABC:
     """Create a new normalization service."""
-    return DefaultNormalizationTransformerImpl(config)
+    return NormalizationServiceImpl(config)
 
 
 # ---------------------------------------------------------------------------
@@ -148,12 +148,12 @@ def default_chembl_normalization_service(
     """DEPRECATED: Use create_normalization_service() with appropriate parameters."""
     warnings.warn(
         "default_chembl_normalization_service is deprecated. "
-        "Use create_normalization_service or DefaultNormalizationTransformerImpl "
+        "Use create_normalization_service or NormalizationServiceImpl "
         "with empty_value=None, serialize_array_in_series=False instead.",
         DeprecationWarning,
         stacklevel=2,
     )
-    return DefaultNormalizationTransformerImpl(
+    return NormalizationServiceImpl(
         config,
         empty_value=None,
         support_base_model=True,

--- a/src/bioetl/infrastructure/transform/impl/__init__.py
+++ b/src/bioetl/infrastructure/transform/impl/__init__.py
@@ -5,8 +5,8 @@ import warnings
 from bioetl.infrastructure.transform.impl.chembl_normalization_service_impl import (
     ChemblNormalizationService,
 )
-from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl import (  # noqa: E501
-    DefaultNormalizationTransformerImpl,
+from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl import (
+    NormalizationServiceImpl,
 )
 from bioetl.infrastructure.transform.impl.hash_service import Blake2bHashService
 from bioetl.infrastructure.transform.impl.hasher import HasherImpl
@@ -20,6 +20,7 @@ from bioetl.infrastructure.transform.impl.timestamp_provider import (
 # Deprecated aliases for backward compatibility
 _DEPRECATED_ALIASES = {
     "ChemblNormalizationServiceImpl": "ChemblNormalizationService",
+    "DefaultNormalizationTransformerImpl": "NormalizationServiceImpl",
 }
 
 
@@ -40,7 +41,8 @@ __all__ = [
     "Blake2bHashService",
     "DeterministicTimestampProvider",
     "SequentialIndexGenerator",
-    "DefaultNormalizationTransformerImpl",
+    "NormalizationServiceImpl",
+    "DefaultNormalizationTransformerImpl",  # Deprecated alias
     "ChemblNormalizationService",
     "ChemblNormalizationServiceImpl",  # Deprecated alias
 ]

--- a/src/bioetl/infrastructure/transform/impl/chembl_normalization_service_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/chembl_normalization_service_impl.py
@@ -1,46 +1,105 @@
 """ChEMBL-specific normalization service implementation.
 
-DEPRECATED: Use DefaultNormalizationTransformerImpl with appropriate parameters instead.
+DEPRECATED: Use NormalizationServiceImpl with appropriate parameters instead.
 This module is kept for backward compatibility and will be removed in a future version.
 """
 
 from __future__ import annotations
 
-from typing import Any
 import warnings
+from typing import TYPE_CHECKING, Any
+
+import pandas as pd
 
 from bioetl.domain.transform.contracts import (
     NormalizationConfigProviderProtocol,
-)
-from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl import (  # noqa: E501
-    DefaultNormalizationTransformerImpl,
+    NormalizationServiceABC,
 )
 
+if TYPE_CHECKING:
+    from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl import (
+        NormalizationServiceImpl,
+    )
 
-class ChemblNormalizationService(DefaultNormalizationTransformerImpl):
-    """Normalization service for ChEMBL records.
 
-    DEPRECATED: Use DefaultNormalizationTransformerImpl directly.
+class ChemblNormalizationService(NormalizationServiceABC):
+    """ChEMBL-specific normalization delegating to base service.
 
-    This class is preserved for backward compatibility. It configures
-    DefaultNormalizationTransformerImpl with empty_value=None and
-    serialize_array_in_series=False to match legacy ChEMBL behavior.
+    DEPRECATED: Use NormalizationServiceImpl directly with
+    empty_value=None, serialize_array_in_series=False.
+
+    This class uses composition to delegate normalization to the base service
+    while allowing ChEMBL-specific preprocessing if needed.
+
+    Args:
+        config: Normalization configuration provider.
+        base: Optional base normalization service. If None, creates
+            NormalizationServiceImpl with ChEMBL-specific defaults.
     """
 
-    def __init__(self, config: NormalizationConfigProviderProtocol):
+    def __init__(
+        self,
+        config: NormalizationConfigProviderProtocol,
+        base: NormalizationServiceABC | None = None,
+    ):
         warnings.warn(
             "ChemblNormalizationService is deprecated. "
-            "Use DefaultNormalizationTransformerImpl(config, empty_value=None, "
+            "Use NormalizationServiceImpl(config, empty_value=None, "
             "serialize_array_in_series=False) instead. Will be removed in v3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
-        super().__init__(
-            config,
-            empty_value=None,
-            support_base_model=True,
-            serialize_array_in_series=False,
-        )
+        if base is not None:
+            self._base = base
+        else:
+            # Lazy import to avoid circular dependency
+            from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl import (
+                NormalizationServiceImpl,
+            )
+
+            self._base = NormalizationServiceImpl(
+                config,
+                empty_value=None,
+                support_base_model=True,
+                serialize_array_in_series=False,
+            )
+
+    def normalize(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Normalize dataframe according to configured fields."""
+        return self._base.normalize(df)
+
+    def normalize_record(self, record: dict[str, Any]) -> dict[str, Any]:
+        """Normalize single record using configured field rules."""
+        return self._base.normalize_record(record)
+
+    def ensure_numeric_columns(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Coerce numeric columns to appropriate types."""
+        return self._base.ensure_numeric_columns(df)
+
+    # Delegate additional methods for backward compatibility
+    def apply_normalize(
+        self, raw: pd.Series | dict[str, Any]
+    ) -> dict[str, Any]:
+        """Normalize a raw record into a dict using configured field rules."""
+        return self._base.apply_normalize(raw)
+
+    def apply_normalize_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Normalize configured columns in the provided dataframe."""
+        return self._base.apply_normalize_dataframe(df)
+
+    def apply_normalize_batch(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Normalize a batch dataframe and coerce numeric columns."""
+        return self._base.apply_normalize_batch(df)
+
+    def apply_normalize_series(
+        self, series: pd.Series, field_cfg: dict[str, Any]
+    ) -> pd.Series:
+        """Normalize a single series according to field configuration."""
+        return self._base.apply_normalize_series(series, field_cfg)
+
+
+# Type alias for backward compatibility
+NormalizedRecord = dict[str, Any]
 
 
 # Deprecated aliases for backward compatibility
@@ -61,12 +120,8 @@ def __getattr__(name: str):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-# Type alias for backward compatibility
-NormalizedRecord = dict[str, Any]
-
-
 __all__ = [
     "ChemblNormalizationService",
-    "ChemblNormalizationServiceImpl",
+    "ChemblNormalizationServiceImpl",  # Deprecated alias
     "NormalizedRecord",
 ]

--- a/src/bioetl/infrastructure/transform/impl/default_normalization_transformer_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/default_normalization_transformer_impl.py
@@ -1,5 +1,6 @@
-"""Infrastructure implementation of the default normalization transformer."""
+"""Infrastructure implementation of the normalization service."""
 
+import warnings
 from typing import Any, Callable, cast
 
 import pandas as pd
@@ -16,9 +17,7 @@ from bioetl.infrastructure.transform.impl.base_normalizer import (
 )
 
 
-class DefaultNormalizationTransformerImpl(
-    BaseNormalizationService, NormalizationServiceABC
-):
+class NormalizationServiceImpl(BaseNormalizationService, NormalizationServiceABC):
     """
     Unified normalization service for all data sources.
 
@@ -224,4 +223,25 @@ class DefaultNormalizationTransformerImpl(
         return cast(pd.Series, series.apply(_normalize_value_from_series))
 
 
-__all__ = ["DefaultNormalizationTransformerImpl"]
+# Deprecated alias for backward compatibility
+_DEPRECATED_ALIASES = {
+    "DefaultNormalizationTransformerImpl": "NormalizationServiceImpl",
+}
+
+
+def __getattr__(name: str):
+    if name in _DEPRECATED_ALIASES:
+        warnings.warn(
+            f"{name} is deprecated, use {_DEPRECATED_ALIASES[name]} instead. "
+            "Will be removed in v3.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()[_DEPRECATED_ALIASES[name]]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [
+    "NormalizationServiceImpl",
+    "DefaultNormalizationTransformerImpl",  # Deprecated alias
+]

--- a/src/bioetl/infrastructure/transform/impl/normalize.py
+++ b/src/bioetl/infrastructure/transform/impl/normalize.py
@@ -2,7 +2,7 @@
 Normalization implementation for domain entities.
 """
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 import warnings
 
 import pandas as pd
@@ -13,11 +13,6 @@ from bioetl.domain.transform.normalizers import (
     normalize_uniprot,
 )
 from bioetl.domain.transform.normalizers.registry import get_normalizer
-
-if TYPE_CHECKING:
-    from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl import (  # noqa: E501
-        DefaultNormalizationTransformerImpl,
-    )
 
 # Aliases for backward compatibility or convenience
 normalize_pubmed_id = normalize_pmid
@@ -79,24 +74,22 @@ def __getattr__(name: str) -> Any:
     """Emit deprecation warnings for legacy aliases and lazy imports."""
     # Lazy import to avoid circular dependency
     from bioetl.infrastructure.transform.impl.default_normalization_transformer_impl import (  # noqa: E501
-        DefaultNormalizationTransformerImpl as _DefaultImpl,
+        NormalizationServiceImpl as _NormImpl,
     )
 
-    if name == "DefaultNormalizationTransformerImpl":
-        return _DefaultImpl
+    # Canonical export
+    if name == "NormalizationServiceImpl":
+        return _NormImpl
 
-    deprecated_aliases = {
-        "NormalizationTransformer": _DefaultImpl,
-        "NormalizationServiceImpl": _DefaultImpl,
-        "NormalizationService": _DefaultImpl,
-    }
-    if name in deprecated_aliases:
+    # Single deprecated alias for migration
+    if name == "NormalizationService":
         warnings.warn(
-            f"{name} is deprecated. Use DefaultNormalizationTransformerImpl instead.",
+            "NormalizationService is deprecated. Use NormalizationServiceImpl instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return deprecated_aliases[name]
+        return _NormImpl
+
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -106,5 +99,6 @@ __all__ = [
     "normalize_pubchem_cid",
     "normalize_uniprot_id",
     "get_normalizer",
-    "DefaultNormalizationTransformerImpl",
+    "NormalizationServiceImpl",
+    "NormalizationService",  # Deprecated alias
 ]

--- a/tests/bioetl/infrastructure/transform/test_target_normalization_service.py
+++ b/tests/bioetl/infrastructure/transform/test_target_normalization_service.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 import pandas as pd
 
 from bioetl.infrastructure.transform.impl.normalize import (
-    DefaultNormalizationTransformerImpl,
+    NormalizationServiceImpl,
 )
 
 
@@ -27,7 +27,7 @@ class _DummyConfig:
 
 
 def test_normalization_service_handles_target_arrays():
-    service = DefaultNormalizationTransformerImpl(_DummyConfig())
+    service = NormalizationServiceImpl(_DummyConfig())
     df = pd.DataFrame(
         {
             "target_components": [

--- a/tests/bioetl/pipelines/chembl/publication/test_transform.py
+++ b/tests/bioetl/pipelines/chembl/publication/test_transform.py
@@ -8,7 +8,7 @@ import pytest
 from bioetl.application.pipelines.chembl.base import ChemblPipelineBase
 from bioetl.domain.schemas.chembl.publication import PublicationTableSchema
 from bioetl.infrastructure.transform.impl.normalize import (
-    DefaultNormalizationTransformerImpl,
+    NormalizationServiceImpl,
 )
 
 
@@ -46,7 +46,7 @@ def pipeline():
         PublicationTableSchema.to_schema().columns.keys()
     )
 
-    normalization_service = DefaultNormalizationTransformerImpl(config)
+    normalization_service = NormalizationServiceImpl(config)
 
     index_generator = MagicMock()
     index_generator.next_index.return_value = 0


### PR DESCRIPTION
…iases

- Rename DefaultNormalizationTransformerImpl to NormalizationServiceImpl
- Refactor ChemblNormalizationService to use composition pattern
- Clean up redundant aliases in normalize.py (keep only NormalizationService)
- Add proper deprecated aliases with warnings for backward compatibility
- Update factories and test imports to use new canonical names