### PR TITLE
Update RawRecord references to SourceRecord

### DIFF
--- a/src/bioetl/application/mappers/chembl/record_mapper.py
+++ b/src/bioetl/application/mappers/chembl/record_mapper.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from bioetl.application.mappers.contracts import RecordMapperABC
 from bioetl.domain.ports.entity_models import EntityModelRegistryABC
 from bioetl.domain.ports.parsing import RecordBatch
-from bioetl.domain.record_source import SourceRecord
+from bioetl.domain.record_source import SourceRecordModel
 from bioetl.infrastructure.chembl.model_registry import get_chembl_model_registry
 
 
@@ -13,7 +13,7 @@ class ChemblRecordMapper(RecordMapperABC):
     """Maps raw ChEMBL records to typed domain models.
 
     This mapper converts untyped dictionaries from the infrastructure
-    layer to validated domain SourceRecord instances using Pydantic models.
+    layer to validated domain SourceRecordModel instances using Pydantic models.
 
     Args:
         registry: Entity model registry for resolving entity types to models.
@@ -42,7 +42,7 @@ class ChemblRecordMapper(RecordMapperABC):
         self,
         raw_records: RecordBatch,
         entity: str,
-    ) -> list[SourceRecord]:
+    ) -> list[SourceRecordModel]:
         """Convert raw dicts to typed ChEMBL domain models.
 
         Args:
@@ -50,7 +50,7 @@ class ChemblRecordMapper(RecordMapperABC):
             entity: Entity type (activity, assay, target, molecule, document).
 
         Returns:
-            List of validated domain SourceRecord instances.
+            List of validated domain SourceRecordModel instances.
 
         Raises:
             ValueError: If entity type is unknown.


### PR DESCRIPTION
…odel

Update ChemblRecordMapper to use SourceRecordModel instead of the deprecated SourceRecord alias, aligning with the contracts interface.