### PR TITLE
Plan migration for deprecated shim modules

### DIFF
--- a/docs/migration/v2.0-import-changes.md
+++ b/docs/migration/v2.0-import-changes.md
@@ -1,0 +1,134 @@
+# Import Changes in v2.0
+
+## Overview
+
+Version 2.0 reorganizes module structure to enforce proper layer separation.
+Several import paths are deprecated and will be removed in a future release.
+
+## Deprecated Imports
+
+| Old Import | New Import | Removal Version |
+|------------|------------|-----------------|
+| `bioetl.infrastructure.config.models` | `bioetl.domain.configs` | v2.0 |
+| `bioetl.infrastructure.constants` | `bioetl.infrastructure.settings.files` | v2.0 |
+| `bioetl.infrastructure.files.csv_record_source` | `bioetl.application.files.csv_record_source` | v2.0 |
+
+## Detailed Changes
+
+### 1. Configuration Models
+
+Configuration models have been moved to the domain layer as they represent
+pure business logic without I/O dependencies.
+
+**Before:**
+```python
+from bioetl.infrastructure.config.models import PipelineConfig, RuntimeConfig
+```
+
+**After:**
+```python
+from bioetl.domain.configs import PipelineConfig, RuntimeConfig
+```
+
+### 2. Infrastructure Constants
+
+Constants have been reorganized into domain-specific settings modules.
+
+**Before:**
+```python
+from bioetl.infrastructure.constants import (
+    CHECKSUM_CHUNK_SIZE,
+    MAX_FILE_RETRIES,
+    RETRY_DELAY_SEC,
+)
+```
+
+**After:**
+```python
+from bioetl.infrastructure.settings.files import (
+    CHECKSUM_CHUNK_SIZE,
+    MAX_FILE_RETRIES,
+    RETRY_DELAY_SEC,
+)
+```
+
+### 3. CSV Record Sources
+
+CSV record source implementations have been moved to the application layer
+as they orchestrate domain logic and infrastructure components.
+
+**Before:**
+```python
+from bioetl.infrastructure.files.csv_record_source import (
+    CsvRecordSourceImpl,
+    IdListRecordSourceImpl,
+)
+```
+
+**After:**
+```python
+from bioetl.application.files.csv_record_source import (
+    CsvRecordSourceImpl,
+    IdListRecordSourceImpl,
+)
+```
+
+## Migration Steps
+
+### Step 1: Find deprecated imports
+
+Run these commands to identify deprecated imports in your codebase:
+
+```bash
+# Configuration models
+grep -rn "infrastructure.config.models" src/ tests/ --include="*.py"
+
+# Infrastructure constants
+grep -rn "infrastructure.constants" src/ tests/ --include="*.py"
+
+# CSV record sources (old path)
+grep -rn "infrastructure.files.csv_record_source" src/ tests/ --include="*.py"
+```
+
+### Step 2: Update imports
+
+Replace deprecated imports with the new paths as shown in the table above.
+
+### Step 3: Verify changes
+
+```bash
+# Run tests to verify no regressions
+pytest tests/
+
+# Check for deprecation warnings
+python -W error::DeprecationWarning -c "import bioetl"
+```
+
+## Deprecation Warnings
+
+When importing from deprecated paths, a `DeprecationWarning` is emitted:
+
+```
+DeprecationWarning: Importing from bioetl.infrastructure.config.models is deprecated.
+Use bioetl.domain.configs instead. This module will be removed in v2.0.
+```
+
+To catch these warnings in tests:
+
+```python
+import pytest
+
+def test_no_deprecated_imports():
+    with pytest.warns(DeprecationWarning):
+        from bioetl.infrastructure.config import models  # noqa: F401
+```
+
+## Timeline
+
+- **v1.x (current)**: Deprecated imports work but emit warnings
+- **v2.0**: Deprecated imports will be removed
+
+## Related Documentation
+
+- [Hexagonal Architecture Migration](2.0-hexagonal-architecture.md)
+- [Architecture Overview](../architecture/index.md)

--- a/src/bioetl/infrastructure/config/models.py
+++ b/src/bioetl/infrastructure/config/models.py
@@ -1,0 +1,107 @@
+"""DEPRECATED: Import from bioetl.domain.configs instead.
+
+This module is a backward compatibility shim and will be removed in v2.0.
+All configuration models have been moved to the domain layer.
+
+Migration guide: docs/migration/v2.0-import-changes.md
+"""
+
+import warnings
+
+warnings.warn(
+    "Importing from bioetl.infrastructure.config.models is deprecated. "
+    "Use bioetl.domain.configs instead. This module will be removed in v2.0.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+# Re-export all configuration models from domain.configs for backward compatibility
+from bioetl.domain.configs import (  # noqa: E402, F401
+    BaseProviderConfig,
+    BusinessKeyConfig,
+    CanonicalizationConfig,
+    ChemblSourceConfig,
+    ClientDefaultsConfig,
+    CsvInputConfig,
+    DataFlowConfig,
+    DataSinkConfig,
+    DataSourceConfig,
+    DefaultsConfig,
+    DeterminismConfig,
+    DummyProviderConfig,
+    ExecutionConfig,
+    FeatureFlagsConfig,
+    HashingConfig,
+    HashingDefaultsConfig,
+    HttpClientConfig,
+    HttpDefaultsConfig,
+    InterfaceFeaturesConfig,
+    LoggingConfig,
+    MetricsConfig,
+    NetworkDefaultsConfig,
+    NetworkHttpDefaultsConfig,
+    NormalizationConfig,
+    NormalizationDefaultsConfig,
+    ObservabilityConfig,
+    OutputOptionsConfig,
+    PaginationConfig,
+    PipelineConfig,
+    PipelineIdentityConfig,
+    PipelineManifest,
+    PipelineStagesConfig,
+    ProfileConfig,
+    ProviderConfigUnion,
+    ProviderHttpConfig,
+    QualityConfig,
+    QualityControlConfig,
+    RuntimeConfig,
+    SourceDefaultsConfig,
+    SourcesDefaultsConfig,
+    StorageConfig,
+    TransformConfig,
+)
+
+__all__ = [
+    "BaseProviderConfig",
+    "BusinessKeyConfig",
+    "CanonicalizationConfig",
+    "ChemblSourceConfig",
+    "ClientDefaultsConfig",
+    "CsvInputConfig",
+    "DataFlowConfig",
+    "DataSinkConfig",
+    "DataSourceConfig",
+    "DefaultsConfig",
+    "DeterminismConfig",
+    "DummyProviderConfig",
+    "ExecutionConfig",
+    "FeatureFlagsConfig",
+    "HashingConfig",
+    "HashingDefaultsConfig",
+    "HttpClientConfig",
+    "HttpDefaultsConfig",
+    "InterfaceFeaturesConfig",
+    "LoggingConfig",
+    "MetricsConfig",
+    "NetworkDefaultsConfig",
+    "NetworkHttpDefaultsConfig",
+    "NormalizationConfig",
+    "NormalizationDefaultsConfig",
+    "ObservabilityConfig",
+    "OutputOptionsConfig",
+    "PaginationConfig",
+    "PipelineConfig",
+    "PipelineIdentityConfig",
+    "PipelineManifest",
+    "PipelineStagesConfig",
+    "ProfileConfig",
+    "ProviderConfigUnion",
+    "ProviderHttpConfig",
+    "QualityConfig",
+    "QualityControlConfig",
+    "RuntimeConfig",
+    "SourceDefaultsConfig",
+    "SourcesDefaultsConfig",
+    "StorageConfig",
+    "TransformConfig",
+]

--- a/src/bioetl/infrastructure/constants.py
+++ b/src/bioetl/infrastructure/constants.py
@@ -8,9 +8,22 @@ All constants have been moved to:
     - infrastructure.settings.metrics for Prometheus metric names
 
 This module re-exports legacy constants for backward compatibility.
+This module will be removed in v2.0.
+
+Migration guide: docs/migration/v2.0-import-changes.md
 """
 
-from bioetl.infrastructure.settings.files import (
+import warnings
+
+warnings.warn(
+    "Importing from bioetl.infrastructure.constants is deprecated. "
+    "Use bioetl.infrastructure.settings.files instead. "
+    "This module will be removed in v2.0.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+from bioetl.infrastructure.settings.files import (  # noqa: E402
     CHECKSUM_CHUNK_SIZE,
     MAX_FILE_RETRIES,
     RETRY_DELAY_SEC,

--- a/src/bioetl/infrastructure/files/atomic.py
+++ b/src/bioetl/infrastructure/files/atomic.py
@@ -8,7 +8,7 @@ import platform
 import time
 from typing import Callable
 
-from bioetl.infrastructure.constants import MAX_FILE_RETRIES, RETRY_DELAY_SEC
+from bioetl.infrastructure.settings.files import MAX_FILE_RETRIES, RETRY_DELAY_SEC
 
 
 class AtomicFileOperation:

--- a/src/bioetl/infrastructure/files/checksum.py
+++ b/src/bioetl/infrastructure/files/checksum.py
@@ -3,7 +3,7 @@
 import hashlib
 from pathlib import Path
 
-from bioetl.infrastructure.constants import CHECKSUM_CHUNK_SIZE
+from bioetl.infrastructure.settings.files import CHECKSUM_CHUNK_SIZE
 
 
 def compute_file_sha256(path: Path) -> str:

--- a/src/bioetl/infrastructure/files/csv_record_source.py
+++ b/src/bioetl/infrastructure/files/csv_record_source.py
@@ -1,0 +1,28 @@
+"""DEPRECATED: Import from bioetl.application.files.csv_record_source instead.
+
+This module is a backward compatibility shim and will be removed in v2.0.
+CSV record sources have been moved to the application layer.
+
+Migration guide: docs/migration/v2.0-import-changes.md
+"""
+
+import warnings
+
+warnings.warn(
+    "Importing from bioetl.infrastructure.files.csv_record_source is deprecated. "
+    "Use bioetl.application.files.csv_record_source instead. "
+    "This module will be removed in v2.0.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+# Re-export CSV record source implementations for backward compatibility
+from bioetl.application.files.csv_record_source import (  # noqa: E402, F401
+    CsvRecordSourceImpl,
+    IdListRecordSourceImpl,
+)
+
+__all__ = [
+    "CsvRecordSourceImpl",
+    "IdListRecordSourceImpl",
+]

--- a/src/bioetl/infrastructure/output/components/checksum_calculator.py
+++ b/src/bioetl/infrastructure/output/components/checksum_calculator.py
@@ -6,7 +6,7 @@ import hashlib
 from pathlib import Path
 
 from bioetl.domain.ports.output import ChecksumCalculatorPort
-from bioetl.infrastructure.constants import CHECKSUM_CHUNK_SIZE
+from bioetl.infrastructure.settings.files import CHECKSUM_CHUNK_SIZE
 
 
 class ChecksumCalculator(ChecksumCalculatorPort):

--- a/tests/bioetl/infrastructure/files/test_atomic.py
+++ b/tests/bioetl/infrastructure/files/test_atomic.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from bioetl.infrastructure.constants import MAX_FILE_RETRIES
+from bioetl.infrastructure.settings.files import MAX_FILE_RETRIES
 from bioetl.infrastructure.files.atomic import AtomicFileOperation
 
 

--- a/tests/bioetl/infrastructure/test_deprecation_warnings.py
+++ b/tests/bioetl/infrastructure/test_deprecation_warnings.py
@@ -1,0 +1,186 @@
+"""Tests for deprecation warnings in infrastructure shim modules.
+
+These tests verify that importing from deprecated module paths
+emits the expected DeprecationWarning messages.
+"""
+
+import importlib
+import sys
+import warnings
+
+import pytest
+
+
+class TestConfigModelsDeprecation:
+    """Tests for bioetl.infrastructure.config.models deprecation."""
+
+    def test_config_models_deprecation_warning(self) -> None:
+        """Importing from infrastructure.config.models emits DeprecationWarning."""
+        # Remove from cache if already imported
+        module_name = "bioetl.infrastructure.config.models"
+        if module_name in sys.modules:
+            del sys.modules[module_name]
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            importlib.import_module(module_name)
+
+        deprecation_warnings = [
+            x for x in w if issubclass(x.category, DeprecationWarning)
+        ]
+        assert len(deprecation_warnings) >= 1
+        assert "infrastructure.config.models" in str(deprecation_warnings[0].message)
+        assert "domain.configs" in str(deprecation_warnings[0].message)
+        assert "v2.0" in str(deprecation_warnings[0].message)
+
+    def test_config_models_exports_available(self) -> None:
+        """Deprecated module still exports all expected symbols."""
+        # Suppress warning for this test
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            from bioetl.infrastructure.config import models
+
+        # Verify key exports are available
+        assert hasattr(models, "PipelineConfig")
+        assert hasattr(models, "RuntimeConfig")
+        assert hasattr(models, "HttpClientConfig")
+
+
+class TestCsvRecordSourceDeprecation:
+    """Tests for bioetl.infrastructure.files.csv_record_source deprecation."""
+
+    def test_csv_record_source_deprecation_warning(self) -> None:
+        """Importing from infrastructure.files.csv_record_source emits warning."""
+        module_name = "bioetl.infrastructure.files.csv_record_source"
+        if module_name in sys.modules:
+            del sys.modules[module_name]
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            importlib.import_module(module_name)
+
+        deprecation_warnings = [
+            x for x in w if issubclass(x.category, DeprecationWarning)
+        ]
+        assert len(deprecation_warnings) >= 1
+        assert "infrastructure.files.csv_record_source" in str(
+            deprecation_warnings[0].message
+        )
+        assert "application.files.csv_record_source" in str(
+            deprecation_warnings[0].message
+        )
+        assert "v2.0" in str(deprecation_warnings[0].message)
+
+    def test_csv_record_source_exports_available(self) -> None:
+        """Deprecated module still exports all expected symbols."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            from bioetl.infrastructure.files import csv_record_source
+
+        assert hasattr(csv_record_source, "CsvRecordSourceImpl")
+        assert hasattr(csv_record_source, "IdListRecordSourceImpl")
+
+
+class TestConstantsDeprecation:
+    """Tests for bioetl.infrastructure.constants deprecation."""
+
+    def test_constants_deprecation_warning(self) -> None:
+        """Importing from infrastructure.constants emits DeprecationWarning."""
+        module_name = "bioetl.infrastructure.constants"
+        if module_name in sys.modules:
+            del sys.modules[module_name]
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            importlib.import_module(module_name)
+
+        deprecation_warnings = [
+            x for x in w if issubclass(x.category, DeprecationWarning)
+        ]
+        assert len(deprecation_warnings) >= 1
+        assert "infrastructure.constants" in str(deprecation_warnings[0].message)
+        assert "infrastructure.settings.files" in str(deprecation_warnings[0].message)
+        assert "v2.0" in str(deprecation_warnings[0].message)
+
+    def test_constants_exports_available(self) -> None:
+        """Deprecated module still exports all expected constants."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            from bioetl.infrastructure import constants
+
+        assert hasattr(constants, "MAX_FILE_RETRIES")
+        assert hasattr(constants, "RETRY_DELAY_SEC")
+        assert hasattr(constants, "CHECKSUM_CHUNK_SIZE")
+
+    def test_constants_values_match_new_location(self) -> None:
+        """Constants values match between old and new locations."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            from bioetl.infrastructure import constants
+
+        from bioetl.infrastructure.settings.files import (
+            CHECKSUM_CHUNK_SIZE,
+            MAX_FILE_RETRIES,
+            RETRY_DELAY_SEC,
+        )
+
+        assert constants.MAX_FILE_RETRIES == MAX_FILE_RETRIES
+        assert constants.RETRY_DELAY_SEC == RETRY_DELAY_SEC
+        assert constants.CHECKSUM_CHUNK_SIZE == CHECKSUM_CHUNK_SIZE
+
+
+class TestNewImportsNoWarnings:
+    """Verify new import paths do not emit deprecation warnings."""
+
+    def test_domain_configs_no_warning(self) -> None:
+        """Importing from domain.configs does not emit DeprecationWarning."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            from bioetl.domain.configs import PipelineConfig  # noqa: F401
+
+        deprecation_warnings = [
+            x for x in w if issubclass(x.category, DeprecationWarning)
+        ]
+        # Filter out unrelated deprecation warnings
+        relevant_warnings = [
+            x
+            for x in deprecation_warnings
+            if "infrastructure.config.models" in str(x.message)
+        ]
+        assert len(relevant_warnings) == 0
+
+    def test_settings_files_no_warning(self) -> None:
+        """Importing from settings.files does not emit DeprecationWarning."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            from bioetl.infrastructure.settings.files import (  # noqa: F401
+                MAX_FILE_RETRIES,
+            )
+
+        deprecation_warnings = [
+            x for x in w if issubclass(x.category, DeprecationWarning)
+        ]
+        relevant_warnings = [
+            x
+            for x in deprecation_warnings
+            if "infrastructure.constants" in str(x.message)
+        ]
+        assert len(relevant_warnings) == 0
+
+    def test_application_csv_record_source_no_warning(self) -> None:
+        """Importing from application layer does not emit DeprecationWarning."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            from bioetl.application.files.csv_record_source import (  # noqa: F401
+                CsvRecordSourceImpl,
+            )
+
+        deprecation_warnings = [
+            x for x in w if issubclass(x.category, DeprecationWarning)
+        ]
+        relevant_warnings = [
+            x
+            for x in deprecation_warnings
+            if "infrastructure.files.csv_record_source" in str(x.message)
+        ]
+        assert len(relevant_warnings) == 0


### PR DESCRIPTION
…v2.0 migration

Create backward compatibility shims for deprecated import paths:
- infrastructure/config/models.py -> domain.configs
- infrastructure/files/csv_record_source.py -> application.files.csv_record_source
- infrastructure/constants.py -> infrastructure.settings.files (updated with runtime warning)

Update internal imports to use new paths to avoid self-referential warnings. Add migration guide (docs/migration/v2.0-import-changes.md) and deprecation tests.