### PR TITLE
Move filter enrichment logic to application layer

### DIFF
--- a/src/bioetl/application/factories/services.py
+++ b/src/bioetl/application/factories/services.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Callable, cast
 
 from bioetl.application.providers import ApplicationFieldProvider
+from bioetl.application.services import FilterEnrichmentService
 from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.observability.contracts import LoggingPortABC, MetricsPortABC
 from bioetl.domain.providers import ProviderDefinition
@@ -76,14 +77,15 @@ class ProviderServiceFactory(ProviderServiceFactoryABC):
         source_config = self._resolve_provider_config(self._provider_definition)
         components = self._provider_definition.components
 
-        # Inject application-level defaults
+        # Create filter enricher with application-level field provider
         field_provider = ApplicationFieldProvider()
+        filter_enricher = FilterEnrichmentService(field_provider)
 
         # Pass logger and metrics to create_extraction_service
         # It will create client internally if needed
         return components.create_extraction_service(
             source_config,
-            field_provider=field_provider,
+            filter_enricher=filter_enricher,
             logger=self._logger,
             metrics=self._metrics,
         )

--- a/src/bioetl/application/services/__init__.py
+++ b/src/bioetl/application/services/__init__.py
@@ -5,6 +5,10 @@ from bioetl.application.services.config_migration_service import (
     ConfigMigrationServiceProtocol,
     create_config_migration_service,
 )
+from bioetl.application.services.filter_enrichment_service import (
+    FilterEnrichmentService,
+    NullFilterEnricher,
+)
 from bioetl.application.services.schema_bootstrap import (
     SchemaBootstrapService,
     create_schema_bootstrap_service,
@@ -16,6 +20,8 @@ from bioetl.application.services.schema_contract_provider import (
 __all__ = [
     "ConfigMigrationService",
     "ConfigMigrationServiceProtocol",
+    "FilterEnrichmentService",
+    "NullFilterEnricher",
     "SchemaBootstrapService",
     "SchemaContractProviderImpl",
     "create_config_migration_service",

--- a/src/bioetl/application/services/filter_enrichment_service.py
+++ b/src/bioetl/application/services/filter_enrichment_service.py
@@ -1,0 +1,73 @@
+"""Filter enrichment service for adding domain-specific defaults to API filters."""
+
+from __future__ import annotations
+
+from bioetl.domain.ports.filters import FilterEnricherABC
+from bioetl.domain.ports.providers import DefaultFieldProviderABC
+
+
+class FilterEnrichmentService(FilterEnricherABC):
+    """Enriches API filters with domain-specific defaults.
+
+    This service encapsulates the business logic for adding default fields
+    and other domain-specific parameters to API filters. This logic belongs
+    in the application layer, not infrastructure.
+
+    Example:
+        >>> provider = ApplicationFieldProvider()
+        >>> enricher = FilterEnrichmentService(provider)
+        >>> filters = enricher.enrich_filters("assay", {"limit": 100})
+        >>> # filters now includes "fields" key with default assay fields
+    """
+
+    def __init__(
+        self,
+        field_provider: DefaultFieldProviderABC | None = None,
+    ) -> None:
+        """Initialize the filter enrichment service.
+
+        Args:
+            field_provider: Optional provider for entity default fields.
+        """
+        self._field_provider = field_provider
+
+    def enrich_filters(
+        self, entity: str, filters: dict[str, object]
+    ) -> dict[str, object]:
+        """Enrich filters with domain-specific defaults.
+
+        Adds default fields for the entity if a field provider is configured
+        and the filters don't already specify fields.
+
+        Args:
+            entity: The entity name (e.g., 'assay', 'activity').
+            filters: Original filter dict.
+
+        Returns:
+            Enriched filter dict with default fields added if applicable.
+        """
+        if self._field_provider is None:
+            return filters
+
+        # Skip if fields already specified
+        if "fields" in filters:
+            return filters
+
+        fields = self._field_provider.get_default_fields(entity)
+        if fields:
+            return {**filters, "fields": ",".join(fields)}
+
+        return filters
+
+
+class NullFilterEnricher(FilterEnricherABC):
+    """No-op filter enricher that passes filters through unchanged.
+
+    Used when no enrichment is needed or as a default/fallback.
+    """
+
+    def enrich_filters(
+        self, entity: str, filters: dict[str, object]
+    ) -> dict[str, object]:
+        """Return filters unchanged."""
+        return filters

--- a/src/bioetl/domain/ports/__init__.py
+++ b/src/bioetl/domain/ports/__init__.py
@@ -27,6 +27,7 @@ from bioetl.domain.ports.parsing import (
     PaginationInfo,
     ResponseParserPortABC,
 )
+from bioetl.domain.ports.filters import FilterEnricherABC
 from bioetl.domain.ports.schema import SchemaContractProviderABC
 from bioetl.domain.data import RecordBatch
 from bioetl.domain.types import ApiPayload
@@ -67,6 +68,8 @@ __all__: list[str] = [
     "RawPayload",
     # Entity model ports
     "EntityModelRegistryABC",
+    # Filter ports
+    "FilterEnricherABC",
     # Extraction ports
     "BatchAdapterABC",
     "ExtractionServiceABC",

--- a/src/bioetl/domain/ports/filters.py
+++ b/src/bioetl/domain/ports/filters.py
@@ -1,0 +1,29 @@
+"""Contracts for filter enrichment."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class FilterEnricherABC(Protocol):
+    """Interface for enriching API filters with domain defaults.
+
+    This is an application-layer concern that should not be implemented
+    in infrastructure. Infrastructure services should accept a filter
+    enricher via dependency injection.
+    """
+
+    def enrich_filters(
+        self, entity: str, filters: dict[str, object]
+    ) -> dict[str, object]:
+        """Enrich filters with domain-specific defaults.
+
+        Args:
+            entity: The entity name (e.g., 'assay', 'activity').
+            filters: Original filter dict.
+
+        Returns:
+            Enriched filter dict (may be same or new dict).
+        """
+        ...

--- a/src/bioetl/domain/providers.py
+++ b/src/bioetl/domain/providers.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Protocol, TypeVar, runtime_checkable
 
 from bioetl.domain.configs import BaseProviderConfig, HttpClientConfig
 from bioetl.domain.observability.contracts import LoggingPortABC, MetricsPortABC
-from bioetl.domain.ports.providers import DefaultFieldProviderABC
+from bioetl.domain.ports.filters import FilterEnricherABC
 
 if TYPE_CHECKING:
     from bioetl.domain.transform.contracts import NormalizationServiceABC
@@ -52,7 +52,7 @@ class ProviderComponents(
         config: BaseProviderConfig,
         *,
         client: client_t | None = None,
-        field_provider: DefaultFieldProviderABC | None = None,
+        filter_enricher: FilterEnricherABC | None = None,
         logger: LoggingPortABC | None = None,
         metrics: MetricsPortABC | None = None,
     ) -> extraction_service_t:

--- a/src/bioetl/infrastructure/chembl_client.py
+++ b/src/bioetl/infrastructure/chembl_client.py
@@ -13,7 +13,7 @@ from typing import Any
 from bioetl.domain.clients.contracts import DataClientABC
 from bioetl.domain.configs import ChemblSourceConfig
 from bioetl.domain.ports.extraction import ExtractionServiceABC
-from bioetl.domain.ports.providers import DefaultFieldProviderABC
+from bioetl.domain.ports.filters import FilterEnricherABC
 from bioetl.infrastructure.clients.chembl.factories import (
     create_chembl_client,
     create_chembl_extraction_service,
@@ -39,7 +39,7 @@ def create_extraction_service(
     config: ChemblSourceConfig,
     *,
     client: DataClientABC | None = None,
-    field_provider: DefaultFieldProviderABC | None = None,
+    filter_enricher: FilterEnricherABC | None = None,
     logger: Any | None = None,
     metrics: Any | None = None,
 ) -> ExtractionServiceABC:
@@ -57,5 +57,5 @@ def create_extraction_service(
         logger=logger,
         metrics=metrics,
         client=client,
-        field_provider=field_provider,
+        filter_enricher=filter_enricher,
     )

--- a/src/bioetl/infrastructure/clients/chembl/factories.py
+++ b/src/bioetl/infrastructure/clients/chembl/factories.py
@@ -16,8 +16,8 @@ from bioetl.domain.clients.contracts import DataClientABC
 from bioetl.domain.configs import ChemblSourceConfig, HttpClientConfig
 from bioetl.domain.observability.contracts import LoggingPortABC, MetricsPortABC
 from bioetl.domain.ports.extraction import ExtractionServiceABC
+from bioetl.domain.ports.filters import FilterEnricherABC
 from bioetl.domain.ports.parsing import ResponseParserPortABC
-from bioetl.domain.ports.providers import DefaultFieldProviderABC
 from bioetl.infrastructure.clients.base.factories import (
     build_http_client,
     build_rate_limiter,
@@ -102,7 +102,7 @@ def create_chembl_extraction_service(
     http_config: HttpClientConfig | None = None,
     *,
     client: DataClientABC | None = None,
-    field_provider: DefaultFieldProviderABC | None = None,
+    filter_enricher: FilterEnricherABC | None = None,
     parser: ResponseParserPortABC | None = None,
 ) -> ExtractionServiceABC:
     """Create a new ChEMBL extraction service with generic parser.
@@ -113,7 +113,7 @@ def create_chembl_extraction_service(
         metrics: Required metrics instance.
         http_config: Optional HTTP configuration.
         client: Optional pre-created client.
-        field_provider: Optional field provider.
+        filter_enricher: Optional filter enricher for adding domain defaults.
         parser: Optional parser instance (defaults to ChemblGenericResponseParser).
 
     Returns:
@@ -131,7 +131,7 @@ def create_chembl_extraction_service(
         logger=logger,
         # Allow provider config to set batch_size while keeping a generous hard cap
         batch_size=config.resolve_effective_batch_size(hard_cap=1000),
-        field_provider=field_provider,
+        filter_enricher=filter_enricher,
         parser=parser or ChemblGenericResponseParser(),
     )
 
@@ -166,7 +166,7 @@ def default_chembl_extraction_service(
     http_config: HttpClientConfig | None = None,
     *,
     client: DataClientABC | None = None,
-    field_provider: DefaultFieldProviderABC | None = None,
+    filter_enricher: FilterEnricherABC | None = None,
     parser: ResponseParserPortABC | None = None,
 ) -> ExtractionServiceABC:
     """DEPRECATED: Use create_chembl_extraction_service() instead."""
@@ -182,6 +182,6 @@ def default_chembl_extraction_service(
         metrics,
         http_config,
         client=client,
-        field_provider=field_provider,
+        filter_enricher=filter_enricher,
         parser=parser,
     )

--- a/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
@@ -11,8 +11,8 @@ from bioetl.domain.ports.extraction import (
     RawRecordBatch,
     VersionProviderABC,
 )
+from bioetl.domain.ports.filters import FilterEnricherABC
 from bioetl.domain.ports.parsing import ResponseParserPortABC
-from bioetl.domain.ports.providers import DefaultFieldProviderABC
 from bioetl.infrastructure.clients.chembl.constants import ENTITY_ENDPOINT_ALIASES
 from bioetl.infrastructure.clients.chembl.response_parser import (
     ChemblGenericResponseParser,
@@ -32,14 +32,14 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
         client: DataClientABC,
         logger: LoggingPortABC,
         batch_size: int = 1000,
-        field_provider: DefaultFieldProviderABC | None = None,
+        filter_enricher: FilterEnricherABC | None = None,
         *,
         parser: ResponseParserPortABC | None = None,
     ) -> None:
         self.client = client
         self.batch_size = batch_size
         self.logger = logger
-        self.field_provider = field_provider
+        self._filter_enricher = filter_enricher
         self._parser = parser or ChemblGenericResponseParser()
         self._version_cache: str | None = None
 
@@ -73,25 +73,13 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
 
         return self._version_cache
 
-    def _attach_entity_fields(
+    def _enrich_filters(
         self, entity: str, filters: dict[str, object]
     ) -> dict[str, object]:
-        """Attach default fields to filters if configured."""
-        if not self.field_provider:
+        """Enrich filters using injected enricher if available."""
+        if self._filter_enricher is None:
             return filters
-
-        # Skip if fields already specified
-        if "fields" in filters:
-            return filters
-
-        new_filters = filters.copy()
-
-        # Use get_default_fields as expected by tests/contracts
-        fields = self.field_provider.get_default_fields(entity)
-        if fields:
-            new_filters["fields"] = ",".join(fields)
-
-        return new_filters
+        return self._filter_enricher.enrich_filters(entity, filters)
 
     def extract_all(self, entity: str, **filters: object) -> RawRecordBatch:
         """Extract all records for an entity as raw dicts.
@@ -116,8 +104,8 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
             chunk_size = filters.get("limit", self.batch_size)
         filters["limit"] = chunk_size
 
-        # Attach default fields if applicable
-        filters = self._attach_entity_fields(entity, filters)
+        # Enrich filters using application-layer logic if available
+        filters = self._enrich_filters(entity, filters)
 
         # Ensure client has request_builder (runtime check)
         if not hasattr(self.client, "request_builder"):

--- a/src/bioetl/infrastructure/clients/chembl/provider.py
+++ b/src/bioetl/infrastructure/clients/chembl/provider.py
@@ -7,7 +7,7 @@ from typing import Any
 from bioetl.domain.clients.contracts import DataClientABC
 from bioetl.domain.configs import ChemblSourceConfig, HttpClientConfig
 from bioetl.domain.ports.extraction import ExtractionServiceABC
-from bioetl.domain.ports.providers import DefaultFieldProviderABC
+from bioetl.domain.ports.filters import FilterEnricherABC
 from bioetl.domain.providers import ProviderComponents, ProviderDefinition, ProviderId
 from bioetl.domain.transform.contracts import (
     NormalizationConfigProviderProtocol,
@@ -39,7 +39,7 @@ class ChemblProviderComponentsFactory(
         config: ChemblSourceConfig,
         *,
         client: DataClientABC | None = None,
-        field_provider: DefaultFieldProviderABC | None = None,
+        filter_enricher: FilterEnricherABC | None = None,
         logger: Any | None = None,
         metrics: Any | None = None,
     ) -> ExtractionServiceABC:
@@ -47,7 +47,7 @@ class ChemblProviderComponentsFactory(
         return create_extraction_service(
             config,
             client=client,
-            field_provider=field_provider,
+            filter_enricher=filter_enricher,
             logger=logger,
             metrics=metrics,
         )

--- a/tests/bioetl/application/services/test_filter_enrichment_service.py
+++ b/tests/bioetl/application/services/test_filter_enrichment_service.py
@@ -1,0 +1,96 @@
+"""Tests for FilterEnrichmentService."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from bioetl.application.services import FilterEnrichmentService, NullFilterEnricher
+from bioetl.domain.ports.providers import DefaultFieldProviderABC
+
+
+class TestFilterEnrichmentService:
+    """Tests for FilterEnrichmentService."""
+
+    def test_enrich_filters_with_provider(self):
+        """Test that fields are added when provider returns fields."""
+        mock_provider = Mock(spec=DefaultFieldProviderABC)
+        mock_provider.get_default_fields.return_value = ["field1", "field2", "field3"]
+
+        enricher = FilterEnrichmentService(mock_provider)
+        result = enricher.enrich_filters("assay", {"limit": 100})
+
+        assert result == {"limit": 100, "fields": "field1,field2,field3"}
+        mock_provider.get_default_fields.assert_called_once_with("assay")
+
+    def test_enrich_filters_skips_if_fields_present(self):
+        """Test that existing fields are not overwritten."""
+        mock_provider = Mock(spec=DefaultFieldProviderABC)
+        mock_provider.get_default_fields.return_value = ["field1", "field2"]
+
+        enricher = FilterEnrichmentService(mock_provider)
+        result = enricher.enrich_filters("assay", {"fields": "custom_field"})
+
+        assert result == {"fields": "custom_field"}
+        mock_provider.get_default_fields.assert_not_called()
+
+    def test_enrich_filters_without_provider(self):
+        """Test that filters pass through when no provider is set."""
+        enricher = FilterEnrichmentService(field_provider=None)
+        original = {"limit": 50, "offset": 10}
+        result = enricher.enrich_filters("activity", original)
+
+        assert result == {"limit": 50, "offset": 10}
+        assert result is original  # Same object returned
+
+    def test_enrich_filters_empty_fields_from_provider(self):
+        """Test that no fields key is added when provider returns empty list."""
+        mock_provider = Mock(spec=DefaultFieldProviderABC)
+        mock_provider.get_default_fields.return_value = []
+
+        enricher = FilterEnrichmentService(mock_provider)
+        result = enricher.enrich_filters("unknown_entity", {"limit": 100})
+
+        assert result == {"limit": 100}
+        assert "fields" not in result
+
+    def test_enrich_filters_returns_new_dict(self):
+        """Test that original dict is not mutated."""
+        mock_provider = Mock(spec=DefaultFieldProviderABC)
+        mock_provider.get_default_fields.return_value = ["field1"]
+
+        enricher = FilterEnrichmentService(mock_provider)
+        original = {"limit": 100}
+        result = enricher.enrich_filters("assay", original)
+
+        # Original should be unchanged
+        assert original == {"limit": 100}
+        # Result should have fields
+        assert result == {"limit": 100, "fields": "field1"}
+        assert result is not original
+
+
+class TestNullFilterEnricher:
+    """Tests for NullFilterEnricher."""
+
+    def test_passes_through_unchanged(self):
+        """Test that filters pass through unchanged."""
+        enricher = NullFilterEnricher()
+        filters = {"limit": 100, "offset": 50, "fields": "custom"}
+        result = enricher.enrich_filters("assay", filters)
+
+        assert result is filters
+
+    def test_handles_empty_filters(self):
+        """Test that empty filters work correctly."""
+        enricher = NullFilterEnricher()
+        result = enricher.enrich_filters("activity", {})
+
+        assert result == {}
+
+    def test_protocol_compliance(self):
+        """Test that NullFilterEnricher satisfies FilterEnricherABC protocol."""
+        from bioetl.domain.ports.filters import FilterEnricherABC
+
+        enricher = NullFilterEnricher()
+        # Protocol check via isinstance with runtime_checkable
+        assert isinstance(enricher, FilterEnricherABC)

--- a/tests/bioetl/infrastructure/clients/chembl/impl/test_extraction_service.py
+++ b/tests/bioetl/infrastructure/clients/chembl/impl/test_extraction_service.py
@@ -2,8 +2,10 @@
 
 from unittest.mock import Mock
 
+from bioetl.application.services import FilterEnrichmentService
 from bioetl.domain.clients.contracts import DataClientABC
 from bioetl.domain.observability import LoggingPortABC
+from bioetl.domain.ports.filters import FilterEnricherABC
 from bioetl.domain.ports.parsing import ResponseParserPortABC
 from bioetl.domain.ports.providers import DefaultFieldProviderABC
 from bioetl.infrastructure.clients.chembl.impl.chembl_extraction_service_impl import (
@@ -19,57 +21,76 @@ def _mock_logger() -> LoggingPortABC:
     return Mock(spec=LoggingPortABC)
 
 
-def test_attach_entity_fields_uses_provider():
-    """Test that field provider is used to populate fields."""
-
-    client = Mock(spec=DataClientABC)
-    client.provider = "chembl"
-
+def test_filter_enricher_uses_provider():
+    """Test that filter enricher uses field provider to populate fields."""
     mock_provider = Mock(spec=DefaultFieldProviderABC)
     mock_provider.get_default_fields.return_value = ["col1", "col2"]
 
-    service = ChemblExtractionServiceImpl(
-        client, logger=_mock_logger(), field_provider=mock_provider
-    )
+    enricher = FilterEnrichmentService(mock_provider)
 
-    # Case 1: entity="assay", no fields provided
-    filters = {}
-    result = service._attach_entity_fields("assay", filters)
+    # entity="assay", no fields provided
+    filters: dict[str, object] = {}
+    result = enricher.enrich_filters("assay", filters)
 
     assert result["fields"] == "col1,col2"
     mock_provider.get_default_fields.assert_called_with("assay")
 
 
-def test_attach_entity_fields_skips_if_fields_present():
-    """Test that provider is ignored if fields are already present."""
-    client = Mock(spec=DataClientABC)
-    client.provider = "chembl"
+def test_filter_enricher_skips_if_fields_present():
+    """Test that enricher is ignored if fields are already present."""
     mock_provider = Mock(spec=DefaultFieldProviderABC)
 
-    service = ChemblExtractionServiceImpl(
-        client, logger=_mock_logger(), field_provider=mock_provider
-    )
+    enricher = FilterEnrichmentService(mock_provider)
 
-    filters = {"fields": "custom"}
-    result = service._attach_entity_fields("assay", filters)
+    filters: dict[str, object] = {"fields": "custom"}
+    result = enricher.enrich_filters("assay", filters)
 
     assert result["fields"] == "custom"
     mock_provider.get_default_fields.assert_not_called()
 
 
-def test_attach_entity_fields_no_provider():
+def test_filter_enricher_no_provider():
     """Test fallback when no provider is configured."""
+    enricher = FilterEnrichmentService(field_provider=None)
+
+    filters: dict[str, object] = {}
+    result = enricher.enrich_filters("assay", filters)
+
+    assert "fields" not in result
+
+
+def test_extraction_service_uses_filter_enricher():
+    """Test that extraction service delegates to filter enricher."""
+    client = Mock(spec=DataClientABC)
+    client.provider = "chembl"
+
+    mock_enricher = Mock(spec=FilterEnricherABC)
+    mock_enricher.enrich_filters.return_value = {"fields": "enriched", "limit": 100}
+
+    service = ChemblExtractionServiceImpl(
+        client, logger=_mock_logger(), filter_enricher=mock_enricher
+    )
+
+    # Test _enrich_filters delegation
+    result = service._enrich_filters("assay", {"limit": 100})
+
+    mock_enricher.enrich_filters.assert_called_once_with("assay", {"limit": 100})
+    assert result == {"fields": "enriched", "limit": 100}
+
+
+def test_extraction_service_no_enricher():
+    """Test extraction service without enricher passes filters through."""
     client = Mock(spec=DataClientABC)
     client.provider = "chembl"
 
     service = ChemblExtractionServiceImpl(
-        client, logger=_mock_logger(), field_provider=None
+        client, logger=_mock_logger(), filter_enricher=None
     )
 
-    filters = {}
-    result = service._attach_entity_fields("assay", filters)
+    filters: dict[str, object] = {"limit": 100}
+    result = service._enrich_filters("assay", filters)
 
-    assert "fields" not in result
+    assert result == {"limit": 100}
 
 
 # =============================================================================

--- a/tests/bioetl/infrastructure/clients/chembl/test_provider.py
+++ b/tests/bioetl/infrastructure/clients/chembl/test_provider.py
@@ -55,7 +55,7 @@ def test_create_normalization_service_uses_factory(monkeypatch, chembl_config):
 
     factory = MagicMock(return_value=stub_service)
     monkeypatch.setattr(
-        "bioetl.infrastructure.clients.chembl.provider.default_normalization_service",
+        "bioetl.infrastructure.clients.chembl.provider.create_normalization_service",
         factory,
     )
 


### PR DESCRIPTION
…ure to application layer

Move business logic for enriching API filters with default fields from infrastructure layer (ChemblExtractionServiceImpl) to application layer.

Changes:
- Add FilterEnricherABC protocol in domain/ports/filters.py
- Add FilterEnrichmentService and NullFilterEnricher in application/services
- Replace field_provider with filter_enricher in ChemblExtractionServiceImpl
- Update factories to create and inject FilterEnrichmentService
- Update ProviderComponents protocol to use filter_enricher
- Add comprehensive tests for FilterEnrichmentService

This improves separation of concerns: infrastructure now delegates filter enrichment to application layer rather than containing business logic about default fields.