### PR TITLE
Fix activity ID validation in ChEMBL

### DIFF
--- a/src/bioetl/domain/schemas/chembl/raw_models.py
+++ b/src/bioetl/domain/schemas/chembl/raw_models.py
@@ -16,7 +16,7 @@ from typing import Self, TypeAlias
 from pydantic import ConfigDict, field_validator, model_validator
 
 from bioetl.domain.record_source import SourceRecordModel
-from bioetl.domain.value_objects import ChemblId
+from bioetl.domain.value_objects import ActivityId, ChemblId
 
 ScalarValue: TypeAlias = str | int | float | bool | None
 JsonValue: TypeAlias = (
@@ -36,7 +36,7 @@ class ActivityRawModel(SourceRecordModel):
 
     action_type: str | None = None
     activity_comment: str | None = None
-    activity_id: str
+    activity_id: ActivityId
     activity_properties: list[JsonObject] | None = None
     assay_chembl_id: ChemblId | None = None
     assay_description: str | None = None
@@ -80,11 +80,6 @@ class ActivityRawModel(SourceRecordModel):
     uo_units: str | None = None
     upper_value: float | None = None
     value: float | None = None
-
-    @field_validator("activity_id", mode="before")
-    @classmethod
-    def _stringify_activity_id(cls, value: str | int) -> str:
-        return str(value)
 
     @field_validator("pchembl_value")
     @classmethod

--- a/src/bioetl/domain/value_objects/__init__.py
+++ b/src/bioetl/domain/value_objects/__init__.py
@@ -4,7 +4,7 @@ Value Objects для ключевых идентификаторов.
 Обеспечивают type safety и валидацию на уровне типов.
 
 Этот пакет содержит:
-- identifiers: RunId, PipelineId, EntityName, ChemblId, StageName
+- identifiers: ActivityId, RunId, PipelineId, EntityName, ChemblId, StageName
 - crypto: HashDigest
 - network: HttpUrl
 - temporal: Timestamp
@@ -12,6 +12,7 @@ Value Objects для ключевых идентификаторов.
 
 from bioetl.domain.value_objects.crypto import HashDigest
 from bioetl.domain.value_objects.identifiers import (
+    ActivityId,
     ChemblId,
     EntityName,
     PipelineId,
@@ -23,6 +24,7 @@ from bioetl.domain.value_objects.temporal import Timestamp
 
 __all__ = [
     # Identifiers
+    "ActivityId",
     "RunId",
     "StageName",
     "EntityName",

--- a/src/bioetl/domain/value_objects/identifiers.py
+++ b/src/bioetl/domain/value_objects/identifiers.py
@@ -337,3 +337,69 @@ class ChemblId:
             core_schema.str_schema(),
             serialization=core_schema.plain_serializer_function_ser_schema(str),
         )
+
+
+class ActivityId:
+    """Value Object for ChEMBL activity identifier (numeric ID).
+
+    Unlike ChemblId which uses CHEMBL123 format, ActivityId is a pure numeric
+    identifier used in the ChEMBL activity table.
+
+    Examples:
+        >>> ActivityId(12345)
+        ActivityId('12345')
+        >>> ActivityId("67890")
+        ActivityId('67890')
+        >>> ActivityId("12345").numeric
+        12345
+    """
+
+    __slots__ = ("_value",)
+    _pattern = re.compile(r"^\d+$")
+
+    def __init__(self, value: str | int) -> None:
+        str_value = str(value)
+        if not self._pattern.match(str_value):
+            raise ValueError(f"Invalid ActivityId: {value}")
+        self._value = str_value
+
+    @property
+    def value(self) -> str:
+        """String representation of ActivityId."""
+        return self._value
+
+    @property
+    def numeric(self) -> int:
+        """Return numeric value of ActivityId."""
+        return int(self._value)
+
+    def __str__(self) -> str:
+        return self._value
+
+    def __repr__(self) -> str:
+        return f"ActivityId({self._value!r})"
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, ActivityId):
+            return self._value == other._value
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(self._value)
+
+    def __lt__(self, other: object) -> bool:
+        if isinstance(other, ActivityId):
+            return self.numeric < other.numeric
+        return NotImplemented
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: type, handler: GetCoreSchemaHandler
+    ) -> CoreSchema:
+        return core_schema.no_info_after_validator_function(
+            cls,
+            core_schema.union_schema(
+                [core_schema.str_schema(), core_schema.int_schema()]
+            ),
+            serialization=core_schema.plain_serializer_function_ser_schema(str),
+        )


### PR DESCRIPTION
…iers

ActivityId is a numeric identifier (unlike ChemblId which uses CHEMBL123 format). Accepts both str|int input and validates numeric pattern.