### PR TITLE
Translate infrastructure documentation to English

### DIFF
--- a/src/bioetl/application/config/runtime.py
+++ b/src/bioetl/application/config/runtime.py
@@ -1,4 +1,4 @@
-"""Прикладной фасад для загрузки конфигураций пайплайнов."""
+"""Application facade for loading pipeline configurations."""
 
 from __future__ import annotations
 
@@ -19,10 +19,9 @@ def build_runtime_config(
     configs_root: str | Path | None = None,
     loader: PipelineConfigLoaderProtocol | None = None,
 ) -> PipelineConfig:
-    """
-    Загружает конфигурацию пайплайна через инфраструктурный слой.
+    """Load pipeline configuration via infrastructure layer.
 
-    Приоритет значений: CLI overrides → ENV overrides → YAML.
+    Value priority: CLI overrides → ENV overrides → YAML.
     """
 
     if loader is None:

--- a/src/bioetl/application/memory_registry.py
+++ b/src/bioetl/application/memory_registry.py
@@ -15,7 +15,7 @@ from bioetl.domain.providers import ProviderDefinition, ProviderId
 
 
 class InMemoryProviderRegistry(ProviderRegistryABC):
-    """Реализация реестра провайдеров в памяти.
+    """In-memory provider registry implementation.
 
     Concrete implementation of the provider registry that stores
     provider definitions in memory.
@@ -25,27 +25,27 @@ class InMemoryProviderRegistry(ProviderRegistryABC):
         self._providers: dict[ProviderId, ProviderDefinition] = {}
 
     def register_provider(self, definition: ProviderDefinition) -> None:
-        """Регистрирует провайдер в реестре."""
+        """Register provider in registry."""
         if definition.id in self._providers:
             raise ProviderAlreadyRegisteredError(definition.id)
         self._providers[definition.id] = definition
 
     def get_provider(self, provider_id: ProviderId) -> ProviderDefinition:
-        """Получает определение провайдера по идентификатору."""
+        """Get provider definition by identifier."""
         if provider_id not in self._providers:
             raise ProviderNotRegisteredError(provider_id)
         return self._providers[provider_id]
 
     def list_providers(self) -> list[ProviderDefinition]:
-        """Возвращает список всех зарегистрированных провайдеров."""
+        """Return list of all registered providers."""
         return list(self._providers.values())
 
     def reset_provider_registry(self) -> None:
-        """Очищает реестр провайдеров."""
+        """Clear the provider registry."""
         self._providers.clear()
 
     def restore_provider_registry(self, definitions: list[ProviderDefinition]) -> None:
-        """Восстанавливает реестр из списка определений."""
+        """Restore registry from list of definitions."""
         self._providers.clear()
         for definition in definitions:
             self._providers[definition.id] = definition

--- a/src/bioetl/application/orchestrator.py
+++ b/src/bioetl/application/orchestrator.py
@@ -55,7 +55,7 @@ ProviderLoaderProtocol = ProviderRegistryLoaderABC
 
 
 class PipelineOrchestrator:
-    """Управляет сборкой и выполнением пайплайнов."""
+    """Manages pipeline assembly and execution."""
 
     def __init__(
         self,
@@ -123,7 +123,7 @@ class PipelineOrchestrator:
         pipeline = self.build_pipeline(limit=limit)
 
         if effective_type == PipelineType.TRANSFORM_ONLY:
-            # Выполнить трансформацию и валидацию, пропустив запись
+            # Execute transform and validate, skipping write
             return pipeline.run(
                 output_path=Path(self._config.sink.output_path),
                 dry_run=True,
@@ -131,7 +131,7 @@ class PipelineOrchestrator:
             )
 
         if effective_type == PipelineType.EXTRACT_ONLY:
-            # Только извлечение
+            # Extract only
             context = self._build_simple_context()
             extract_callable = pipeline._get_extract_callable()  # noqa: SLF001
             iterator = pipeline._normalize_extract_result(
@@ -173,7 +173,7 @@ class PipelineOrchestrator:
                 },
             )
 
-        # FULL (по умолчанию)
+        # FULL (default)
         return pipeline.run(
             output_path=Path(self._config.sink.output_path),
             dry_run=dry_run,
@@ -281,13 +281,13 @@ class PipelineOrchestrator:
         return self._resolve_registry_from_provider()
 
     def _serialize_provider_registry(self) -> list[ProviderDefinition] | None:
-        """Снимок реестра провайдеров для передачи в подпроцесс."""
+        """Provider registry snapshot for subprocess transfer."""
         if self._provider_registry is None:
             return None
         return list(self._provider_registry.list_providers())
 
     def _load_registry_via_loader(self) -> ProviderRegistryABC | None:
-        """Попытаться загрузить реестр через loader."""
+        """Try to load registry via loader."""
         loader = self._provider_loader
         if loader is None and self._provider_loader_factory is not None:
             loader = self._provider_loader_factory()
@@ -301,7 +301,7 @@ class PipelineOrchestrator:
         return registry
 
     def _resolve_registry_from_provider(self) -> ProviderRegistryABC:
-        """Получить реестр через provider (fallback)."""
+        """Get registry via provider (fallback)."""
         if self._provider_registry_provider is None:
             raise RuntimeError("Provider registry is not configured")
 

--- a/src/bioetl/application/pipelines/base.py
+++ b/src/bioetl/application/pipelines/base.py
@@ -100,13 +100,12 @@ def _create_default_metadata_builder() -> RunMetadataBuilderProtocol:
 
 
 class PipelineBase(ABC):
-    """
-    Абстрактный базовый класс для всех ETL-пайплайнов.
+    """Abstract base class for all ETL pipelines.
 
-    Реализует паттерн Template Method для стадий:
+    Implements Template Method pattern for stages:
     extract → transform → validate → write
 
-    Использует композицию для стадий (Extractor, Transformer).
+    Uses composition for stages (Extractor, Transformer).
     """
 
     def __init__(
@@ -201,7 +200,7 @@ class PipelineBase(ABC):
         return executor.execute(self, output_path, dry_run=dry_run)
 
     def _resolve_business_key_fields(self) -> list[str] | None:
-        """Возвращает бизнес-ключи из конфига с поддержкой legacy-полей."""
+        """Return business keys from config with legacy field support."""
 
         hashing_section = getattr(self._config, "hashing", None)
         if isinstance(hashing_section, property):
@@ -418,28 +417,28 @@ class PipelineBase(ABC):
     # === Abstract Methods ===
 
     def get_database_version(self) -> str | None:
-        """
-        Возвращает версию базы данных источника.
-        Может быть переопределено в наследниках.
+        """Return source database version.
+
+        Can be overridden in subclasses.
         """
         return None
 
     # === Concrete Methods ===
 
     def get_version(self) -> str:
-        """Возвращает версию источника данных. По умолчанию 'unknown'."""
+        """Return data source version. Default is 'unknown'."""
         return "unknown"
 
     @abstractmethod
     def extract(self, **kwargs: Any) -> ExtractResult:
-        """Возвращает итератор чанков исходных данных."""
+        """Return iterator of source data chunks."""
 
     @abstractmethod
     def transform(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Преобразует сырые данные."""
+        """Transform raw data."""
 
     def validate(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Валидирует DataFrame по Pandera-схеме, соблюдая порядок колонок схемы."""
+        """Validate DataFrame against Pandera schema, respecting column order."""
         schema_name = self._schema_contract.schema_out
         schema = self._validation_service.get_schema(schema_name)
         schema_columns = self._resolve_validator_columns(schema)
@@ -466,11 +465,10 @@ class PipelineBase(ABC):
         output_path: Path,
         context: RunContext,
     ) -> WriteResult:
-        """
-        Записывает валидированный DataFrame с помощью предоставленного Loader.
+        """Write validated DataFrame using the provided Loader.
 
-        Наследники могут переопределить метод, если нужно расширить поведение,
-        но по умолчанию используется loader, переданный через конструктор.
+        Subclasses can override to extend behavior,
+        but by default uses loader passed via constructor.
         """
 
         return self._write_with_loader(df=df, output_path=output_path, context=context)
@@ -494,20 +492,20 @@ class PipelineBase(ABC):
     # === Hooks ===
 
     def register_hook(self, hook: PipelineHookABC) -> None:
-        """Добавляет хук выполнения."""
+        """Add execution hook."""
         self._runtime_manager.register_hook(hook)
 
     def register_hooks(self, hooks: list[PipelineHookABC]) -> None:
-        """Добавляет список хуков выполнения."""
+        """Add list of execution hooks."""
         self._runtime_manager.register_hooks(hooks)
 
     def set_error_policy(self, error_policy: ErrorPolicyABC) -> None:
-        """Устанавливает политику обработки ошибок."""
+        """Set error handling policy."""
         self._error_policy = error_policy
         self._runtime_manager.set_error_policy(error_policy)
 
     def set_post_transformer(self, transformer: TransformerABC) -> None:
-        """Позволяет заменить пост-обработчик трансформации."""
+        """Replace post-transform handler."""
         self._post_transformer = transformer
 
     # === Internal Methods ===
@@ -523,7 +521,7 @@ class PipelineBase(ABC):
 
     @staticmethod
     def _resolve_validator_columns(schema: Any) -> list[str]:
-        """Возвращает порядок колонок, объявленный в Pandera-схеме."""
+        """Return column order declared in Pandera schema."""
         schema_obj = schema
         if hasattr(schema_obj, "to_schema"):
             schema_obj = schema_obj.to_schema()
@@ -549,7 +547,7 @@ class PipelineBase(ABC):
         )
 
     def _default_on_skip(self, stage: str) -> Any:
-        """Возвращает безопасное значение по умолчанию при пропуске стадии."""
+        """Return safe default value when skipping stage."""
 
         import pandas as pd  # pylint: disable=import-outside-toplevel
 
@@ -615,6 +613,4 @@ class PipelineBase(ABC):
         raise TypeError("Extractor must return a DataFrame or iterable of DataFrames.")
 
     def _enrich_context(self, context: RunContext) -> None:
-        """
-        Хук для обогащения контекста (например, добавления версии релиза).
-        """
+        """Hook for context enrichment (e.g., adding release version)."""

--- a/src/bioetl/application/pipelines/chembl/base.py
+++ b/src/bioetl/application/pipelines/chembl/base.py
@@ -39,7 +39,7 @@ from bioetl.domain.validation.service import ValidationService
 
 
 class ChemblPipelineBase(PipelineBase):
-    """Базовый класс для ChEMBL-пайплайнов."""
+    """Base class for ChEMBL pipelines."""
 
     def __init__(
         self,
@@ -111,10 +111,10 @@ class ChemblPipelineBase(PipelineBase):
         self._transformer = transformer
 
     def get_version(self) -> str:
-        """Возвращает версию релиза ChEMBL (например, 'chembl_34').
+        """Return ChEMBL release version (e.g., 'chembl_34').
 
-        Extraction service возвращает сырую версию (например, '34').
-        Форматирование выполняется в application layer через domain service.
+        Extraction service returns raw version (e.g., '34').
+        Formatting is done in application layer via domain service.
         """
         if self._chembl_release is not None:
             return self._chembl_release
@@ -126,7 +126,7 @@ class ChemblPipelineBase(PipelineBase):
         try:
             raw_version = self._extraction_service.get_release_version()
             self._chembl_release = format_chembl_version(raw_version)
-        except Exception as exc:  # pragma: no cover - защитный контур
+        except Exception as exc:  # pragma: no cover - defensive guard
             self._logger.warning(
                 "Failed to fetch ChEMBL release; using 'unknown'",
                 error=str(exc),
@@ -153,7 +153,7 @@ class ChemblPipelineBase(PipelineBase):
             pass
 
     def _should_skip_release_lookup(self) -> bool:
-        """True, если версию ChEMBL нужно пропустить (офлайн/CSV режим)."""
+        """True if ChEMBL version lookup should be skipped (offline/CSV mode)."""
         input_mode = getattr(self._config, "input_mode", None)
         pipeline_cfg = getattr(self._config, "pipeline", {}) or {}
         if input_mode == "csv":
@@ -161,11 +161,10 @@ class ChemblPipelineBase(PipelineBase):
         return bool(pipeline_cfg.get("skip_release_lookup"))
 
     def extract(self, **kwargs: Any) -> pd.DataFrame:
-        """
-        Возвращает единый DataFrame для удобства unit-тестов и локальных проверок.
+        """Return single DataFrame for unit tests and local checks.
 
-        Основной run-процесс использует self._extractor напрямую, поэтому
-        материализация чанков в этой обёртке не влияет на боевой поток.
+        Main run process uses self._extractor directly, so
+        chunk materialization in this wrapper doesn't affect production flow.
         """
         extractor = self._extractor
         if extractor is None:
@@ -180,9 +179,9 @@ class ChemblPipelineBase(PipelineBase):
 
         try:
             iterator = iter(extract_result)
-        except TypeError as exc:  # pragma: no cover - защитный контур
+        except TypeError as exc:  # pragma: no cover - defensive guard
             raise TypeError(
-                "ExtractStage.extract() должен возвращать DataFrame или Iterable."
+                "ExtractStage.extract() must return DataFrame or Iterable."
             ) from exc
 
         chunks: list[pd.DataFrame] = []
@@ -190,7 +189,7 @@ class ChemblPipelineBase(PipelineBase):
             if chunk is None:
                 continue
             if not isinstance(chunk, pd.DataFrame):
-                raise TypeError("Extractor chunks должны быть pandas.DataFrame.")
+                raise TypeError("Extractor chunks must be pandas.DataFrame.")
             if chunk.empty:
                 continue
             chunks.append(chunk)

--- a/src/bioetl/application/pipelines/hooks_impl.py
+++ b/src/bioetl/application/pipelines/hooks_impl.py
@@ -1,4 +1,4 @@
-"""Реализации хуков и политик обработки ошибок пайплайна."""
+"""Pipeline hook and error policy implementations."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ from bioetl.domain.pipelines.contracts import ErrorPolicyABC, PipelineHookABC
 
 
 class LoggingPipelineHookImpl(PipelineHookABC):
-    """Хук, логирующий события жизненного цикла стадий."""
+    """Hook that logs stage lifecycle events."""
 
     def __init__(self, logger: LoggingPortABC) -> None:
         self._logger = logger
@@ -52,19 +52,19 @@ class LoggingPipelineHookImpl(PipelineHookABC):
 
 
 class FailFastErrorPolicyImpl(ErrorPolicyABC):
-    """Политика остановки пайплайна при первой ошибке."""
+    """Policy to stop pipeline on first error."""
 
     def handle(self, error: PipelineStageError, context: Any) -> ErrorAction:
         """Always fail the pipeline on first error."""
         return ErrorAction.FAIL
 
-    def can_retry(self, error: PipelineStageError) -> bool:  # noqa: ARG002 - интерфейс
+    def can_retry(self, error: PipelineStageError) -> bool:  # noqa: ARG002 - interface
         """Fail-fast policy never retries."""
         return False
 
 
 class ContinueOnErrorPolicyImpl(ErrorPolicyABC):
-    """Политика продолжения выполнения при ошибках стадий."""
+    """Policy to continue execution on stage errors."""
 
     def __init__(self, *, max_retries: int = 0) -> None:
         self._max_retries = max_retries
@@ -89,7 +89,7 @@ __all__ = [
 
 
 class MetricsPipelineHookImpl(PipelineHookABC):
-    """Хук, фиксирующий метрики завершения стадий."""
+    """Hook that records stage completion metrics."""
 
     def __init__(
         self,
@@ -105,7 +105,7 @@ class MetricsPipelineHookImpl(PipelineHookABC):
         self._metrics = metrics_port or create_noop_metrics_port()
 
     def on_stage_start(self, stage: str, context: Any) -> None:  # noqa: ARG002
-        """Хук старта стадии не требует метрик."""
+        """Stage start hook does not require metrics."""
 
     def on_stage_end(self, stage: str, result: StageResult) -> None:
         """Record Prometheus metrics for stage completion."""
@@ -127,4 +127,4 @@ class MetricsPipelineHookImpl(PipelineHookABC):
         )
 
     def on_error(self, stage: str, error: PipelineStageError) -> None:  # noqa: ARG002
-        """Метрики фиксируются в on_stage_end, поэтому обработка не требуется."""
+        """Metrics are recorded in on_stage_end, so no processing needed."""

--- a/src/bioetl/application/pipelines/stage_runtime_manager.py
+++ b/src/bioetl/application/pipelines/stage_runtime_manager.py
@@ -1,4 +1,4 @@
-"""Управление выполнением стадий пайплайна, хуками и политикой ошибок."""
+"""Pipeline stage execution management, hooks and error policy."""
 
 from collections.abc import Callable, Iterable
 from datetime import datetime, timezone
@@ -60,39 +60,39 @@ class StageRuntimeManagerImpl:
 
     @property
     def last_error(self) -> PipelineStageError | None:
-        """Последняя ошибка выполнения стадии."""
+        """Last stage execution error."""
         return self._error_handler.last_error
 
     def register_hook(self, hook: PipelineHookABC) -> None:
-        """Добавляет хук выполнения."""
+        """Add execution hook."""
         self._hook_notifier.register_hook(hook)
 
     def register_hooks(self, hooks: Iterable[PipelineHookABC]) -> None:
-        """Добавляет список хуков выполнения."""
+        """Add list of execution hooks."""
         self._hook_notifier.register_hooks(hooks)
 
     def get_hooks(self) -> list[PipelineHookABC]:
-        """Возвращает зарегистрированные хуки."""
+        """Return registered hooks."""
         return self._hook_notifier.get_hooks()
 
     def reset(self) -> None:
-        """Сбрасывает накопленное состояние выполнения."""
+        """Reset accumulated execution state."""
         self._hook_notifier.reset()
         self._stage_counter.reset()
         self._error_handler.reset()
 
     def set_logger(self, logger: LoggingPortABC) -> None:
-        """Обновляет логгер для дальнейших сообщений."""
+        """Update logger for subsequent messages."""
         self._logger = logger
         self._hook_notifier.set_logger(logger)
         self._error_handler.set_logger(logger)
 
     def set_error_policy(self, error_policy: ErrorPolicyABC) -> None:
-        """Заменяет используемую политику ошибок."""
+        """Replace the error policy in use."""
         self._error_handler.set_error_policy(error_policy)
 
     def notify_stage_start(self, stage: str, context: RunContext) -> None:
-        """Уведомляет о старте стадии и логирует событие."""
+        """Notify stage start and log the event."""
         self._stage_counter.mark_stage_start(stage)
         self._hook_notifier.notify_stage_start(
             stage,
@@ -102,7 +102,7 @@ class StageRuntimeManagerImpl:
         )
 
     def notify_stage_end(self, stage: str, result: StageResult) -> None:
-        """Уведомляет о завершении стадии и логирует событие."""
+        """Notify stage end and log the event."""
         self._hook_notifier.notify_stage_end(
             stage,
             result,
@@ -111,7 +111,7 @@ class StageRuntimeManagerImpl:
         )
 
     def get_stage_start(self, stage: str) -> datetime | None:
-        """Возвращает время старта указанной стадии, если оно зафиксировано."""
+        """Return stage start time if recorded."""
         return self._stage_counter.get_stage_start(stage)
 
     def execute_stage(
@@ -123,7 +123,7 @@ class StageRuntimeManagerImpl:
         attempt: int = 1,
         on_retry: Callable[[], None] | None = None,
     ) -> object:
-        """Выполняет действие с учётом политики ошибок."""
+        """Execute action according to error policy."""
         try:
             result = action()
             self._error_handler.clear_error()
@@ -157,11 +157,11 @@ class StageRuntimeManagerImpl:
             raise pipeline_error from exc
 
     def get_last_error_messages(self) -> list[str]:
-        """Возвращает список сообщений последней ошибки."""
+        """Return list of last error messages."""
         return self._error_handler.get_last_error_messages()
 
     def get_last_action(self, stage: str) -> ErrorAction | None:
-        """Возвращает последнее действие политики ошибок для стадии."""
+        """Return last error policy action for stage."""
         return self._error_handler.get_last_action(stage)
 
     def process_chunk(
@@ -230,7 +230,7 @@ class StageRuntimeManagerImpl:
         errors: list[str] | None = None,
         chunks: int = 0,
     ) -> StageResult:
-        """Собирает StageResult с длительностью и счётчиками."""
+        """Build StageResult with duration and counters."""
         return self._stage_counter.make_stage_result(
             stage,
             success=success,
@@ -248,7 +248,7 @@ class StageRuntimeManagerImpl:
         count: int = 0,
         chunks: int = 0,
     ) -> RunResult:
-        """Формирует результат неуспешного запуска и уведомляет хуки."""
+        """Build failed run result and notify hooks."""
         errors = self.get_last_error_messages()
         stage_result = self.make_stage_result(
             stage,

--- a/src/bioetl/application/transform/pandas_batch_adapter.py
+++ b/src/bioetl/application/transform/pandas_batch_adapter.py
@@ -1,4 +1,4 @@
-"""Адаптер для конвертации pandas DataFrame и других батчей в raw dicts.
+"""Adapter for converting pandas DataFrame and other batches to raw dicts.
 
 Returns raw dicts (Mapping[str, Any]) per BatchAdapterABC contract.
 Domain model conversion should happen via RecordMapperABC in ExtractStage.
@@ -16,7 +16,7 @@ from bioetl.domain.ports.extraction import BatchAdapterABC
 
 
 class PandasBatchAdapter(BatchAdapterABC):
-    """Конвертирует сырые батчи в список записей (raw dicts).
+    """Converts raw batches to list of records (raw dicts).
 
     Returns raw dicts per BatchAdapterABC contract. Domain model conversion
     should happen via RecordMapperABC in ExtractStage if needed.
@@ -35,7 +35,7 @@ class PandasBatchAdapter(BatchAdapterABC):
             )
 
     def process_batch(self, raw_batch: Any) -> list[Mapping[str, Any]]:
-        """Нормализует батч провайдера в список raw dicts.
+        """Normalize provider batch to list of raw dicts.
 
         Returns raw dicts. Domain model validation should be performed by
         RecordMapperABC in the extraction stage.
@@ -61,7 +61,7 @@ class PandasBatchAdapter(BatchAdapterABC):
         )
 
     def adapt_batch(self, raw_batch: Any) -> list[Mapping[str, Any]]:
-        """Alias для process_batch для обратной совместимости."""
+        """Alias for process_batch for backward compatibility."""
         return self.process_batch(raw_batch)
 
     def _convert_record(self, item: Any) -> Mapping[str, Any]:

--- a/src/bioetl/application/use_cases/run_pipeline.py
+++ b/src/bioetl/application/use_cases/run_pipeline.py
@@ -1,10 +1,10 @@
-"""Use case для запуска ETL-пайплайна.
+"""Use case for running ETL pipeline.
 
-Инкапсулирует всю логику:
-- Загрузка конфигурации
-- Разрешение путей
-- Создание orchestrator
-- Запуск пайплайна
+Encapsulates all logic:
+- Configuration loading
+- Path resolution
+- Orchestrator creation
+- Pipeline execution
 """
 
 from __future__ import annotations
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 
 class InterfaceDisabledError(Exception):
-    """Запрошенный интерфейс отключён в конфигурации."""
+    """Requested interface is disabled in configuration."""
 
     def __init__(self, interface: str) -> None:
         super().__init__(f"{interface} interface is disabled by configuration")
@@ -33,7 +33,7 @@ class InterfaceDisabledError(Exception):
 
 @dataclass(frozen=True)
 class RunPipelineRequest:
-    """Запрос на выполнение пайплайна."""
+    """Pipeline execution request."""
 
     pipeline_name: str
     profile: str = "default"
@@ -44,11 +44,11 @@ class RunPipelineRequest:
     require_rest_interface: bool = False
 
     def get_pipeline_id(self) -> str:
-        """Преобразует имя пайплайна в ID формата provider.entity.
+        """Convert pipeline name to ID in provider.entity format.
 
-        Имя пайплайна в формате entity_provider преобразуется в provider.entity.
-        Если в имени несколько подчёркиваний, используется последнее для
-        разделения (например, drug_indication_chembl → chembl.drug_indication).
+        Pipeline name in entity_provider format is converted to provider.entity.
+        If there are multiple underscores, the last one is used for separation
+        (e.g., drug_indication_chembl → chembl.drug_indication).
         """
         try:
             entity, provider = self.pipeline_name.rsplit("_", 1)
@@ -60,7 +60,7 @@ class RunPipelineRequest:
 
 @dataclass(frozen=True)
 class RunPipelineResponse:
-    """Результат выполнения пайплайна."""
+    """Pipeline execution result."""
 
     run_id: str
     success: bool
@@ -71,7 +71,7 @@ class RunPipelineResponse:
 
     @classmethod
     def from_run_result(cls, result: RunResult) -> "RunPipelineResponse":
-        """Создаёт ответ из результата выполнения пайплайна."""
+        """Create response from pipeline execution result."""
         return cls(
             run_id=str(result.run_id),
             success=result.success,
@@ -83,13 +83,13 @@ class RunPipelineResponse:
 
 
 class RunPipelineUseCase:
-    """Use case для запуска ETL-пайплайна.
+    """Use case for running ETL pipeline.
 
-    Инкапсулирует всю логику:
-    - Загрузка конфигурации
-    - Разрешение путей
-    - Создание orchestrator
-    - Запуск пайплайна
+    Encapsulates all logic:
+    - Configuration loading
+    - Path resolution
+    - Orchestrator creation
+    - Pipeline execution
 
     Example:
         use_case = RunPipelineUseCase(
@@ -116,13 +116,13 @@ class RunPipelineUseCase:
         provider_loader_factory: Callable[[], "ProviderRegistryLoaderABC"],
         configs_root: Path | None = None,
     ) -> None:
-        """Инициализирует use case с необходимыми зависимостями.
+        """Initialize use case with required dependencies.
 
         Args:
-            config_loader: Загрузчик конфигураций пайплайнов.
-            container_factory: Фабрика для создания контейнера зависимостей.
-            provider_loader_factory: Фабрика для создания загрузчика провайдеров.
-            configs_root: Корневая директория конфигураций.
+            config_loader: Pipeline configuration loader.
+            container_factory: Factory for creating dependency container.
+            provider_loader_factory: Factory for creating provider loader.
+            configs_root: Configuration root directory.
         """
         self._config_loader = config_loader
         self._container_factory = container_factory
@@ -130,28 +130,28 @@ class RunPipelineUseCase:
         self._configs_root = configs_root
 
     def execute(self, request: RunPipelineRequest) -> RunPipelineResponse:
-        """Выполняет пайплайн и возвращает результат.
+        """Execute pipeline and return result.
 
         Args:
-            request: Запрос с параметрами запуска.
+            request: Request with execution parameters.
 
         Returns:
-            Результат выполнения пайплайна.
+            Pipeline execution result.
 
         Raises:
-            InterfaceDisabledError: Если требуемый интерфейс отключён.
+            InterfaceDisabledError: If required interface is disabled.
         """
-        # 1. Загрузка конфигурации
+        # 1. Load configuration
         config = self._load_config(request)
 
-        # 2. Проверка доступности интерфейса
+        # 2. Validate interface availability
         self._validate_interface_enabled(config, request)
 
-        # 3. Применение переопределений
+        # 3. Apply overrides
         if request.output_path:
             config = self._apply_output_override(config, request.output_path)
 
-        # 4. Создание и запуск orchestrator
+        # 4. Create and run orchestrator
         orchestrator = self._create_orchestrator(request.pipeline_name, config)
         result = orchestrator.run_pipeline(
             dry_run=request.dry_run,
@@ -161,13 +161,13 @@ class RunPipelineUseCase:
         return RunPipelineResponse.from_run_result(result)
 
     def _load_config(self, request: RunPipelineRequest) -> PipelineConfig:
-        """Загружает конфигурацию из файла или по ID.
+        """Load configuration from file or by ID.
 
         Args:
-            request: Запрос с параметрами конфигурации.
+            request: Request with configuration parameters.
 
         Returns:
-            Загруженная конфигурация пайплайна.
+            Loaded pipeline configuration.
         """
         if request.config_path:
             return self._config_loader.get_from_path(
@@ -185,14 +185,14 @@ class RunPipelineUseCase:
     def _validate_interface_enabled(
         self, config: PipelineConfig, request: RunPipelineRequest
     ) -> None:
-        """Проверяет, что требуемый интерфейс включён в конфигурации.
+        """Verify that required interface is enabled in configuration.
 
         Args:
-            config: Конфигурация пайплайна.
-            request: Запрос с флагами интерфейсов.
+            config: Pipeline configuration.
+            request: Request with interface flags.
 
         Raises:
-            InterfaceDisabledError: Если требуемый интерфейс отключён.
+            InterfaceDisabledError: If required interface is disabled.
         """
         if request.require_rest_interface:
             if not config.features.rest_interface_enabled:
@@ -201,14 +201,14 @@ class RunPipelineUseCase:
     def _apply_output_override(
         self, config: PipelineConfig, output_path: Path
     ) -> PipelineConfig:
-        """Применяет переопределение пути вывода.
+        """Apply output path override.
 
         Args:
-            config: Исходная конфигурация.
-            output_path: Новый путь для вывода.
+            config: Original configuration.
+            output_path: New output path.
 
         Returns:
-            Конфигурация с обновлённым путём вывода.
+            Configuration with updated output path.
         """
         output_path.mkdir(parents=True, exist_ok=True)
         new_sink = config.sink.model_copy(update={"output_path": str(output_path)})
@@ -217,14 +217,14 @@ class RunPipelineUseCase:
     def _create_orchestrator(
         self, pipeline_name: str, config: PipelineConfig
     ) -> PipelineOrchestrator:
-        """Создаёт оркестратор для выполнения пайплайна.
+        """Create orchestrator for pipeline execution.
 
         Args:
-            pipeline_name: Имя пайплайна.
-            config: Конфигурация пайплайна.
+            pipeline_name: Pipeline name.
+            config: Pipeline configuration.
 
         Returns:
-            Настроенный оркестратор.
+            Configured orchestrator.
         """
         return PipelineOrchestrator(
             pipeline_name=pipeline_name,
@@ -234,10 +234,10 @@ class RunPipelineUseCase:
         )
 
     def _get_profiles_root(self) -> Path | None:
-        """Возвращает путь к директории профилей.
+        """Return path to profiles directory.
 
         Returns:
-            Путь к директории профилей или None.
+            Path to profiles directory or None.
         """
         if self._configs_root:
             return self._configs_root / "profiles"

--- a/src/bioetl/domain/clients/base/contracts.py
+++ b/src/bioetl/domain/clients/base/contracts.py
@@ -22,21 +22,19 @@ if TYPE_CHECKING:
 
 
 class RequestBuilderABC(ABC):
-    """
-    Паттерн Builder для создания запросов.
-    """
+    """Builder pattern for request creation."""
 
     @abstractmethod
     def build_request(self, params: dict[str, Any]) -> Any:
-        """Создает объект запроса из параметров."""
+        """Create request object from parameters."""
 
     @abstractmethod
     def build(self, endpoint: str, params: dict[str, Any] | None = None) -> Any:
-        """Создает запрос для указанного endpoint с параметрами."""
+        """Create request for specified endpoint with parameters."""
 
     @abstractmethod
     def build_with_pagination(self, offset: int, limit: int) -> "RequestBuilderABC":
-        """Добавляет параметры пагинации."""
+        """Add pagination parameters."""
 
     def with_pagination(self, offset: int, limit: int) -> "RequestBuilderABC":
         """Deprecated alias for build_with_pagination.
@@ -82,79 +80,69 @@ def __getattr__(name: str) -> type:
 
 
 class PaginatorABC(ABC):
-    """
-    Стратегия пагинации.
-    """
+    """Pagination strategy."""
 
     @abstractmethod
     def get_items(self, response: Any) -> list[RecordModel]:
-        """Извлекает элементы из ответа."""
+        """Extract items from response."""
 
     @abstractmethod
     def get_next_marker(self, response: Any) -> str | int | None:
-        """Возвращает маркер следующей страницы (offset, cursor, url)."""
+        """Return next page marker (offset, cursor, url)."""
 
     @abstractmethod
     def has_more(self, response: Any) -> bool:
-        """Проверяет, есть ли еще страницы."""
+        """Check if there are more pages."""
 
 
 class RateLimiterABC(ABC):
-    """
-    Ограничение частоты запросов.
-    """
+    """Request rate limiting."""
 
     @abstractmethod
     def acquire(self) -> None:
-        """Запрашивает разрешение на выполнение (блокирует при необходимости)."""
+        """Request permission to execute (blocks if necessary)."""
 
 
 class RetryPolicyABC(ABC):
-    """
-    Политика повторных попыток.
-    """
+    """Retry policy."""
 
     @property
     @abstractmethod
     def max_attempts(self) -> int:
-        """Максимальное количество попыток."""
+        """Maximum number of attempts."""
 
     @abstractmethod
     def should_retry(self, error: Exception, attempt: int) -> bool:
-        """Определяет, нужно ли повторять попытку."""
+        """Determine whether to retry."""
 
     @abstractmethod
     def get_backoff(self, attempt: int) -> float:
-        """Возвращает задержку перед следующей попыткой (в секундах)."""
+        """Return delay before next attempt (in seconds)."""
 
 
 class CacheABC(ABC, Generic[T]):
-    """
-    Интерфейс кэширования.
-    """
+    """Caching interface."""
 
     @abstractmethod
     def get(self, key: str) -> T | None:
-        """Возвращает значение из кэша или ``None``."""
+        """Return value from cache or ``None``."""
 
     @abstractmethod
     def set(self, key: str, value: T, ttl: int | None = None) -> None:
-        """Сохраняет значение в кэш с опциональным TTL в секундах."""
+        """Store value in cache with optional TTL in seconds."""
 
     @abstractmethod
     def invalidate(self, key: str) -> None:
-        """Удаляет значение из кэша."""
+        """Remove value from cache."""
 
     @abstractmethod
     def clear(self) -> None:
-        """Очищает весь кэш."""
+        """Clear entire cache."""
 
 
 class SecretProviderABC(ABC):
-    """
-    Поставщик секретов (env, vault).
-    """
+    """Secret provider (env, vault)."""
 
     @abstractmethod
     def get_secret(self, name: str) -> str | None:
-        """Возвращает значение секрета."""
+        """Return secret value."""

--- a/src/bioetl/domain/clients/contracts.py
+++ b/src/bioetl/domain/clients/contracts.py
@@ -9,36 +9,33 @@ Record = dict[str, Any]
 
 
 class DataClientABC(ABC):
-    """
-    Универсальный контракт клиента источника данных.
+    """Universal data source client contract.
 
-    Поддерживает извлечение произвольных сущностей через единый метод
-    ``fetch`` с фильтрами, а также побочные операции (пагинация, метаданные,
-    освобождение ресурсов).
+    Supports extraction of arbitrary entities through a unified ``fetch``
+    method with filters, as well as side operations (pagination, metadata,
+    resource release).
     """
 
     @abstractmethod
     def fetch(self, entity: str, **filters: Any) -> Any:
-        """
-        Выполнить запрос к источнику данных для указанной сущности.
+        """Execute query to data source for specified entity.
 
         Args:
-            entity: Имя сущности/эндпоинта (provider-specific).
-            **filters: Фильтры или параметры запроса.
+            entity: Entity/endpoint name (provider-specific).
+            **filters: Filters or query parameters.
         """
 
     @abstractmethod
     def iter_pages(self, request: Any) -> Iterator[Any]:
-        """
-        Итератор по страницам результатов для заранее построенного запроса.
+        """Iterator over result pages for a pre-built request.
 
-        request: Объект запроса (зависит от реализации).
+        request: Request object (implementation-specific).
         """
 
     @abstractmethod
     def metadata(self) -> dict[str, Any]:
-        """Метаданные источника (версия, release)."""
+        """Source metadata (version, release)."""
 
     @abstractmethod
     def close(self) -> None:
-        """Освободить ресурсы (сессии, соединения)."""
+        """Release resources (sessions, connections)."""

--- a/src/bioetl/domain/configs/normalization.py
+++ b/src/bioetl/domain/configs/normalization.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 
 
 class NormalizationConfig(BaseModel):
-    """Конфигурация нормализации данных."""
+    """Data normalization configuration."""
 
     case_sensitive_fields: list[str] = Field(default_factory=list)
     id_fields: list[str] = Field(default_factory=list)

--- a/src/bioetl/domain/configs/profile.py
+++ b/src/bioetl/domain/configs/profile.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class ProfileConfig(BaseModel):
-    """Конфигурация профиля поверх пайплайн-конфига."""
+    """Profile configuration on top of pipeline config."""
 
     name: str
     extends: str | None = None

--- a/src/bioetl/domain/configs/transform.py
+++ b/src/bioetl/domain/configs/transform.py
@@ -8,10 +8,10 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class TransformConfig(BaseModel):
-    """Настройки стадии transform."""
+    """Transform stage settings."""
 
     serialization_mode: Literal["json", "flat", "pipe"] = Field(
-        default="json", description="Канонический формат сериализации вложенных полей"
+        default="json", description="Canonical serialization format for nested fields"
     )
 
     model_config = ConfigDict(extra="forbid")

--- a/src/bioetl/domain/enums.py
+++ b/src/bioetl/domain/enums.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 
 class ErrorAction(Enum):
-    """Действия при ошибке."""
+    """Error handling actions."""
 
     FAIL = "fail"
     SKIP = "skip"

--- a/src/bioetl/domain/errors.py
+++ b/src/bioetl/domain/errors.py
@@ -1,4 +1,4 @@
-"""Общие исключения BioETL."""
+"""Common BioETL exceptions."""
 
 from __future__ import annotations
 
@@ -21,19 +21,19 @@ __all__ = [
 
 
 class BioetlError(Exception):
-    """Базовое исключение BioETL."""
+    """Base BioETL exception."""
 
 
 class ConfigError(BioetlError):
-    """Ошибки конфигурации."""
+    """Configuration errors."""
 
 
 class ConfigValidationError(ConfigError):
-    """Ошибки валидации конфигурации."""
+    """Configuration validation errors."""
 
 
 class ProviderError(BioetlError):
-    """Ошибки провайдера данных."""
+    """Data provider errors."""
 
     def __init__(
         self, provider: str, message: str, *, cause: Exception | None = None
@@ -44,7 +44,7 @@ class ProviderError(BioetlError):
 
 
 class ClientError(ProviderError):
-    """Базовое исключение для клиентских ошибок."""
+    """Base exception for client errors."""
 
     def __init__(
         self,
@@ -71,19 +71,19 @@ class ClientError(ProviderError):
 
 
 class ClientNetworkError(ClientError):
-    """Сетевые ошибки клиента."""
+    """Client network errors."""
 
 
 class ClientRateLimitError(ClientError):
-    """Ошибки ограничения запросов (rate limit)."""
+    """Rate limit errors."""
 
 
 class ClientResponseError(ClientError):
-    """Ошибки ответа клиента."""
+    """Client response errors."""
 
 
 class PipelineStageError(BioetlError):
-    """Исключение для сбоев на стадиях пайплайна."""
+    """Exception for pipeline stage failures."""
 
     def __init__(
         self,
@@ -121,7 +121,7 @@ class PipelineStageError(BioetlError):
         return self.__reduce__()
 
     def __reduce__(self) -> tuple[Any, tuple[Any, ...]]:
-        """Делает исключение сериализуемым для multiprocessing."""
+        """Make exception serializable for multiprocessing."""
 
         return (
             _rebuild_pipeline_stage_error,
@@ -144,7 +144,7 @@ def _rebuild_pipeline_stage_error(
     run_id: str,
     cause: Exception | None,
 ) -> PipelineStageError:
-    """Восстанавливает PipelineStageError после unpickle."""
+    """Rebuild PipelineStageError after unpickle."""
     return PipelineStageError(
         provider=provider,
         entity=entity,

--- a/src/bioetl/domain/models.py
+++ b/src/bioetl/domain/models.py
@@ -1,6 +1,4 @@
-"""
-Модели данных для ядра ETL-пайплайна.
-"""
+"""Data models for ETL pipeline core."""
 
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -13,15 +11,15 @@ from bioetl.domain.value_objects import EntityName, RunId, StageName
 
 @dataclass
 class StageResult:
-    """Результат выполнения стадии.
+    """Stage execution result.
 
     Attributes:
-        stage_name: Имя стадии (StageName). Принимает str для обратной совместимости.
-        success: Успешность выполнения.
-        records_processed: Количество обработанных записей.
-        chunks_processed: Количество обработанных чанков.
-        duration_sec: Длительность выполнения в секундах.
-        errors: Список ошибок.
+        stage_name: Stage name (StageName). Accepts str for backward compatibility.
+        success: Execution success status.
+        records_processed: Number of processed records.
+        chunks_processed: Number of processed chunks.
+        duration_sec: Execution duration in seconds.
+        errors: List of errors.
     """
 
     stage_name: StageName
@@ -39,18 +37,18 @@ class StageResult:
 
 @dataclass
 class RunContext:
-    """
-    Контекст выполнения пайплайна.
-    Содержит информацию о текущем запуске, конфигурации и окружении.
+    """Pipeline execution context.
+
+    Contains information about current run, configuration and environment.
 
     Attributes:
-        run_id: Уникальный идентификатор запуска (RunId).
-        entity_name: Имя сущности (EntityName). Принимает str для обратной совместимости.
-        provider: Идентификатор провайдера (ProviderId). Принимает str для обратной совместимости.
-        started_at: Время начала выполнения.
-        config: Конфигурация запуска.
-        dry_run: Флаг тестового запуска.
-        metadata: Дополнительные метаданные.
+        run_id: Unique run identifier (RunId).
+        entity_name: Entity name (EntityName). Accepts str for backward compatibility.
+        provider: Provider identifier (ProviderId). Accepts str for backward compatibility.
+        started_at: Execution start time.
+        config: Run configuration.
+        dry_run: Test run flag.
+        metadata: Additional metadata.
     """
 
     run_id: RunId = field(default_factory=RunId.generate)
@@ -79,9 +77,7 @@ class RunContext:
 
 @dataclass
 class RunResult:
-    """
-    Результат выполнения пайплайна.
-    """
+    """Pipeline execution result."""
 
     run_id: RunId
     success: bool
@@ -96,9 +92,9 @@ class RunResult:
 
 @dataclass
 class StageDescriptor:
-    """
-    Дескриптор стадии пайплайна.
-    Описывает стадию, её исполнимый код и метаданные.
+    """Pipeline stage descriptor.
+
+    Describes stage, its executable code and metadata.
     """
 
     name: str

--- a/src/bioetl/domain/observability/contracts.py
+++ b/src/bioetl/domain/observability/contracts.py
@@ -95,23 +95,22 @@ class MetricsPortABC(ABC):
 
 
 class ProgressReporterABC(ABC):
-    """
-    Интерфейс отчетности о прогрессе.
+    """Progress reporting interface.
 
-    Реализация выбирается инфраструктурой и связывается с контейнером.
+    Concrete implementation is selected by infrastructure and bound to the container.
     """
 
     @abstractmethod
     def start(self, total: int, description: str = "") -> None:
-        """Начинает отслеживание прогресса."""
+        """Start progress tracking with the specified total count."""
 
     @abstractmethod
     def apply_update(self, n: int = 1) -> None:
-        """Обновляет прогресс на n единиц."""
+        """Update progress by n units."""
 
     @abstractmethod
     def stop_reporting(self) -> None:
-        """Завершает отслеживание."""
+        """Stop progress tracking and clean up resources."""
 
     @contextmanager
     def create_bar(self, total: int, desc: str = "") -> Iterator[Any]:

--- a/src/bioetl/domain/pipelines/contracts.py
+++ b/src/bioetl/domain/pipelines/contracts.py
@@ -26,31 +26,31 @@ __all__ = [
 
 
 class PipelineHookABC(ABC):
-    """Хуки жизненного цикла пайплайна."""
+    """Pipeline lifecycle hooks."""
 
     @abstractmethod
     def on_stage_start(self, stage: str, context: Any) -> None:
-        """Вызывается перед началом стадии."""
+        """Called before stage starts."""
 
     @abstractmethod
     def on_stage_end(self, stage: str, result: StageResult) -> None:
-        """Вызывается после завершения стадии."""
+        """Called after stage completes."""
 
     @abstractmethod
     def on_error(self, stage: str, error: PipelineStageError) -> None:
-        """Вызывается при ошибке."""
+        """Called on error."""
 
 
 class ErrorPolicyABC(ABC):
-    """Политика обработки ошибок."""
+    """Error handling policy."""
 
     @abstractmethod
     def handle(self, error: PipelineStageError, context: Any) -> ErrorAction:
-        """Определяет действие при ошибке."""
+        """Determine action on error."""
 
     @abstractmethod
     def can_retry(self, error: PipelineStageError) -> bool:
-        """Проверяет, стоит ли повторять операцию."""
+        """Check whether operation should be retried."""
 
 
 class ExtractorABC(ABC):

--- a/src/bioetl/domain/pipelines/types.py
+++ b/src/bioetl/domain/pipelines/types.py
@@ -1,4 +1,4 @@
-"""Типы пайплайнов для определения режима выполнения."""
+"""Pipeline types for defining execution mode."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ from enum import Enum
 
 
 class PipelineType(str, Enum):
-    """Тип режима выполнения пайплайна."""
+    """Pipeline execution mode type."""
 
     EXTRACT_ONLY = "extract"
     FULL = "full"

--- a/src/bioetl/domain/provider_registry.py
+++ b/src/bioetl/domain/provider_registry.py
@@ -9,11 +9,11 @@ from bioetl.domain.providers import ProviderDefinition, ProviderId
 
 
 class ProviderRegistryError(Exception):
-    """Базовая ошибка реестра провайдеров."""
+    """Base provider registry error."""
 
 
 class ProviderNotRegisteredError(ProviderRegistryError):
-    """Провайдер не зарегистрирован."""
+    """Provider not registered error."""
 
     def __init__(self, provider_id: ProviderId) -> None:
         super().__init__(f"Provider '{provider_id.value}' is not registered")
@@ -21,7 +21,7 @@ class ProviderNotRegisteredError(ProviderRegistryError):
 
 
 class ProviderAlreadyRegisteredError(ProviderRegistryError):
-    """Провайдер уже зарегистрирован."""
+    """Provider already registered error."""
 
     def __init__(self, provider_id: ProviderId) -> None:
         super().__init__(f"Provider '{provider_id.value}' is already registered")
@@ -29,42 +29,42 @@ class ProviderAlreadyRegisteredError(ProviderRegistryError):
 
 
 class ProviderRegistryABC(ABC):
-    """Абстрактный базовый класс для реестра провайдеров."""
+    """Abstract base class for provider registry."""
 
     @abstractmethod
     def register_provider(self, definition: ProviderDefinition) -> None:
-        """Регистрирует провайдер в реестре."""
+        """Register provider in registry."""
 
     @abstractmethod
     def get_provider(self, provider_id: ProviderId) -> ProviderDefinition:
-        """Получает определение провайдера по идентификатору."""
+        """Get provider definition by identifier."""
 
     @abstractmethod
     def list_providers(self) -> list[ProviderDefinition]:
-        """Возвращает список всех зарегистрированных провайдеров."""
+        """Return list of all registered providers."""
 
     @abstractmethod
     def reset_provider_registry(self) -> None:
-        """Очищает реестр провайдеров."""
+        """Clear the provider registry."""
 
     @abstractmethod
     def restore_provider_registry(self, definitions: list[ProviderDefinition]) -> None:
-        """Восстанавливает реестр из списка определений."""
+        """Restore registry from list of definitions."""
 
 
 @runtime_checkable
 class ProviderRegistryLoaderABC(Protocol):
-    """Протокол для загрузчика реестра провайдеров."""
+    """Protocol for provider registry loader."""
 
     def get_providers(
         self, *, registry: ProviderRegistryABC | None = None
     ) -> list[ProviderDefinition]:
-        """Загружает провайдеры из конфигурации и регистрирует их."""
+        """Load providers from configuration and register them."""
 
     def get_registry(
         self, *, registry: ProviderRegistryABC | None = None
     ) -> ProviderRegistryABC:
-        """Загружает провайдеры и возвращает заполненный реестр."""
+        """Load providers and return populated registry."""
 
 
 # Global registry instance

--- a/src/bioetl/domain/schemas/pipeline_contracts.py
+++ b/src/bioetl/domain/schemas/pipeline_contracts.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class PipelineSchemaModel:
-    """Описание схем для пайплайна."""
+    """Schema description for pipeline."""
 
     pipeline_code: str
     schema_out: str
@@ -15,7 +15,7 @@ class PipelineSchemaModel:
     output_schema: str | None = None
 
     def get_output_schema(self) -> str:
-        """Возвращает схему для записи (fallback на schema_out)."""
+        """Return schema for writing (fallback to schema_out)."""
 
         return self.output_schema or self.schema_out
 
@@ -67,7 +67,7 @@ PIPELINE_CONTRACTS: dict[str, PipelineSchemaModel] = {
 def get_pipeline_contract(
     pipeline_code: str, *, default_entity: str | None = None
 ) -> PipelineSchemaModel:
-    """Возвращает контракт схем для пайплайна."""
+    """Return schema contract for pipeline."""
 
     if pipeline_code in PIPELINE_CONTRACTS:
         return PIPELINE_CONTRACTS[pipeline_code]

--- a/src/bioetl/domain/schemas/registry.py
+++ b/src/bioetl/domain/schemas/registry.py
@@ -15,9 +15,7 @@ SchemaRegisterFn = Callable[["SchemaRegistry"], SchemaProviderABC]
 
 
 class SchemaRegistry(SchemaProviderABC):
-    """
-    Реестр схем данных.
-    """
+    """Data schema registry."""
 
     def __init__(self) -> None:
         self._schemas: dict[str, schema_type | None] = {}

--- a/src/bioetl/domain/transform/contracts.py
+++ b/src/bioetl/domain/transform/contracts.py
@@ -248,31 +248,29 @@ class HashServiceABC(ABC):
 
 
 class TimestampProviderABC(ABC):
-    """
-    Провайдер временных меток для извлечения данных.
+    """Timestamp provider for data extraction.
 
-    Обеспечивает детерминированный timestamp в рамках сессии.
+    Provides deterministic timestamp within a session.
     """
 
     @abstractmethod
     def get_extraction_timestamp(self) -> datetime:
-        """Возвращает timestamp извлечения данных."""
+        """Return data extraction timestamp."""
 
 
 class IndexGeneratorABC(ABC):
-    """
-    Генератор последовательных индексов для строк данных.
+    """Sequential index generator for data rows.
 
-    Stateful: сохраняет текущее значение счётчика между вызовами.
+    Stateful: maintains counter value between calls.
     """
 
     @abstractmethod
     def next_index(self) -> int:
-        """Возвращает следующий индекс и увеличивает счётчик."""
+        """Return next index and increment counter."""
 
     @abstractmethod
     def reset(self) -> None:
-        """Сбрасывает счётчик в начальное состояние."""
+        """Reset counter to initial state."""
 
 
 __all__ = [

--- a/src/bioetl/domain/transform/factories.py
+++ b/src/bioetl/domain/transform/factories.py
@@ -30,14 +30,14 @@ def default_post_transformer(
     """Create a default chain of post-transformers.
 
     Args:
-        hash_service: Сервис для вычисления хешей.
-        index_generator: Генератор последовательных индексов.
-        timestamp_provider: Провайдер временных меток.
-        business_key_fields: Поля для хеширования бизнес-ключа.
-        version_provider: Опциональный провайдер версии БД.
+        hash_service: Service for computing hashes.
+        index_generator: Sequential index generator.
+        timestamp_provider: Timestamp provider.
+        business_key_fields: Fields for business key hashing.
+        version_provider: Optional database version provider.
 
     Returns:
-        Цепочка трансформеров для пост-обработки данных.
+        Transformer chain for post-processing data.
     """
     provider = version_provider or (lambda: "unknown")
     return TransformerChainImpl(

--- a/src/bioetl/domain/transform/normalizers/collections.py
+++ b/src/bioetl/domain/transform/normalizers/collections.py
@@ -69,14 +69,14 @@ def _coerce_record_mapping(value: Any) -> Mapping[str, Any]:
             try:
                 parsed = json.loads(value)
             except json.JSONDecodeError as exc:
-                raise ValueError(f"Некорректный JSON для записи: {exc}") from exc
+                raise ValueError(f"Invalid JSON for record: {exc}") from exc
 
             if not isinstance(parsed, Mapping):
-                raise ValueError(f"Ожидался словарь, получено {type(parsed).__name__}")
+                raise ValueError(f"Expected dict, got {type(parsed).__name__}")
             return dict(parsed)
 
     if not isinstance(value, Mapping):
-        raise ValueError(f"Ожидался словарь, получено {type(value).__name__}")
+        raise ValueError(f"Expected dict, got {type(value).__name__}")
     # Make a shallow copy to avoid mutating caller-provided mappings and to keep
     # a predictable mapping type downstream.
     return dict(value)
@@ -98,7 +98,7 @@ def _normalize_record_value(
             return override
         return value_normalizer(item) if value_normalizer else item
     except ValueError as exc:
-        raise ValueError(f"Некорректное значение в поле '{str_key}': {exc}") from exc
+        raise ValueError(f"Invalid value in field '{str_key}': {exc}") from exc
 
 
 def _coerce_to_iterable(value: Any) -> Iterable[Any]:
@@ -135,7 +135,7 @@ def _normalize_array_item(
         return str(item)
     except ValueError as exc:
         raise ValueError(
-            f"Ошибка нормализации элемента массива на позиции {idx}: {exc}"
+            f"Error normalizing array element at position {idx}: {exc}"
         ) from exc
 
 
@@ -174,7 +174,7 @@ def _normalize_synonyms(value: Any) -> Any:
     try:
         items = normalize_array(value)
     except ValueError as exc:
-        raise ValueError(f"Некорректный список синонимов: {exc}") from exc
+        raise ValueError(f"Invalid synonym list: {exc}") from exc
 
     normalized: list[str] = []
     for synonym in items:
@@ -197,7 +197,7 @@ def _normalize_component_xrefs(value: Any) -> Any:
     try:
         entries = normalize_array(value)
     except ValueError as exc:
-        raise ValueError(f"Некорректный список component_xrefs: {exc}") from exc
+        raise ValueError(f"Invalid component_xrefs list: {exc}") from exc
 
     normalized_entries: list[str] = []
     for entry in entries:

--- a/src/bioetl/domain/transform/normalizers/identifiers.py
+++ b/src/bioetl/domain/transform/normalizers/identifiers.py
@@ -22,7 +22,7 @@ def normalize_doi(value: Any) -> str | None:
     if is_missing(value):
         return None
     if not isinstance(value, str):
-        raise ValueError(f"DOI должен быть строкой, получено: {type(value)}")
+        raise ValueError(f"DOI must be a string, got: {type(value)}")
 
     doi = value.strip().lower()
     doi = re.sub(r"^(https?://)?(dx\.)?doi\.org/", "", doi)
@@ -33,10 +33,10 @@ def normalize_doi(value: Any) -> str | None:
         return None
 
     if not doi.startswith("10."):
-        raise ValueError(f"Неверный формат DOI (должен начинаться с '10.'): '{value}'")
+        raise ValueError(f"Invalid DOI format (must start with '10.'): '{value}'")
 
     if not DOI_REGEX.match(doi):
-        raise ValueError(f"Неверный формат DOI: '{value}'")
+        raise ValueError(f"Invalid DOI format: '{value}'")
 
     return doi
 
@@ -60,7 +60,7 @@ def normalize_chembl_id(value: Any) -> str | None:
     match = re.fullmatch(r"CHEMBL(\d+)", text)
     if not match:
         raise ValueError(
-            f"Неверный ChEMBL ID (ожидался формат CHEMBL<digits>): '{value}'"
+            f"Invalid ChEMBL ID (expected format CHEMBL<digits>): '{value}'"
         )
 
     return text
@@ -75,11 +75,11 @@ def normalize_pmid(value: Any) -> int | None:
         if value.is_integer():
             value = int(value)
         else:
-            raise ValueError(f"PubMed ID не является целым числом: '{value}'")
+            raise ValueError(f"PubMed ID is not an integer: '{value}'")
 
     if isinstance(value, int):
         if value <= 0:
-            raise ValueError("PubMed ID должен быть положительным числом")
+            raise ValueError("PubMed ID must be a positive number")
         return value
 
     text = str(value).strip()
@@ -87,11 +87,11 @@ def normalize_pmid(value: Any) -> int | None:
         return None
 
     if not text.isdigit():
-        raise ValueError(f"Неверный PubMed ID (содержит нецифровые символы): '{value}'")
+        raise ValueError(f"Invalid PubMed ID (contains non-digit characters): '{value}'")
 
     parsed = int(text)
     if parsed <= 0:
-        raise ValueError("PubMed ID должен быть положительным числом")
+        raise ValueError("PubMed ID must be a positive number")
     return parsed
 
 
@@ -109,14 +109,14 @@ def normalize_uniprot(value: Any) -> str | None:
     if is_missing(value):
         return None
     if not isinstance(value, str):
-        raise ValueError("UniProt ID должен быть строкой")
+        raise ValueError("UniProt ID must be a string")
 
     accession = value.strip().upper()
     if not accession:
         return None
 
     if not UNIPROT_ID_REGEX.match(accession):
-        raise ValueError(f"Неверный UniProt ID: '{value}'")
+        raise ValueError(f"Invalid UniProt ID: '{value}'")
     return accession
 
 
@@ -134,7 +134,7 @@ def normalize_bao_id(value: Any) -> str | None:
         return None
 
     if not BAO_ID_REGEX.match(text):
-        raise ValueError(f"Неверный BAO ID (ожидался формат BAO_<digits>): '{value}'")
+        raise ValueError(f"Invalid BAO ID (expected format BAO_<digits>): '{value}'")
 
     return text
 
@@ -167,7 +167,7 @@ def _parse_positive_int_with_prefixes(
 
     stripped = _strip_prefix(text, prefixes)
     if not stripped.isdigit():
-        raise ValueError(f"Неверный {field_name}: '{value}'")
+        raise ValueError(f"Invalid {field_name}: '{value}'")
 
     parsed = int(stripped)
     _ensure_positive(parsed, field_name)
@@ -177,7 +177,7 @@ def _parse_positive_int_with_prefixes(
 def _coerce_positive_int(value: Any, field_name: str) -> int | None:
     if isinstance(value, float):
         if not value.is_integer():
-            raise ValueError(f"{field_name} не является целым числом: '{value}'")
+            raise ValueError(f"{field_name} is not an integer: '{value}'")
         value = int(value)
 
     if isinstance(value, int):
@@ -196,7 +196,7 @@ def _strip_prefix(text: str, prefixes: tuple[str, ...]) -> str:
 
 def _ensure_positive(value: int, field_name: str) -> None:
     if value <= 0:
-        raise ValueError(f"{field_name} должен быть положительным числом")
+        raise ValueError(f"{field_name} must be a positive number")
 
 
 __all__ = [

--- a/src/bioetl/domain/transform/normalizers/numeric.py
+++ b/src/bioetl/domain/transform/normalizers/numeric.py
@@ -54,13 +54,13 @@ def _coerce_phase_value(value: Any) -> int | None:
             parsed = float(text)
         except ValueError as exc:
             raise ValueError(
-                f"Некорректное числовое значение фазы клинических испытаний: '{value}'"
+                f"Invalid numeric value for clinical trial phase: '{value}'"
             ) from exc
         return _coerce_phase_value(parsed)
 
     raise ValueError(
-        "Ожидалось числовое значение фазы клинических испытаний, "
-        f"получено {type(value).__name__}"
+        "Expected numeric value for clinical trial phase, "
+        f"got {type(value).__name__}"
     )
 
 

--- a/src/bioetl/domain/transform/transformers.py
+++ b/src/bioetl/domain/transform/transformers.py
@@ -19,17 +19,17 @@ from bioetl.domain.transform.contracts import (
 
 
 class TransformerABC(ABC):
-    """Базовый интерфейс для DataFrame-трансформеров."""
+    """Base interface for DataFrame transformers."""
 
     @abstractmethod
     def apply(
         self, df: pd.DataFrame, context: RunContext | None = None
     ) -> pd.DataFrame:
-        """Выполняет преобразование DataFrame."""
+        """Apply transformation to DataFrame."""
 
 
 class TransformerChainImpl(TransformerABC):
-    """Комбинирует несколько трансформеров в последовательность."""
+    """Combines multiple transformers into a sequence."""
 
     def __init__(self, transformers: list[TransformerABC]) -> None:
         self._transformers = transformers
@@ -37,7 +37,7 @@ class TransformerChainImpl(TransformerABC):
     def apply(
         self, df: pd.DataFrame, context: RunContext | None = None
     ) -> pd.DataFrame:
-        """Последовательно применяет зарегистрированные трансформеры."""
+        """Apply registered transformers sequentially."""
         result = df
         for transformer in self._transformers:
             result = transformer.apply(result, context)
@@ -45,7 +45,7 @@ class TransformerChainImpl(TransformerABC):
 
 
 class HashColumnsTransformerImpl(TransformerABC):
-    """Добавляет hash_business_key и hash_row."""
+    """Adds hash_business_key and hash_row columns."""
 
     def __init__(
         self, hash_service: HashServiceABC, business_key_fields: list[str] | None
@@ -56,7 +56,7 @@ class HashColumnsTransformerImpl(TransformerABC):
     def apply(
         self, df: pd.DataFrame, context: RunContext | None = None
     ) -> pd.DataFrame:
-        """Добавляет hash_business_key и hash_row, если DataFrame не пуст."""
+        """Add hash_business_key and hash_row if DataFrame is not empty."""
         if df.empty:
             return df.assign(hash_business_key=None, hash_row=None)
 
@@ -66,7 +66,7 @@ class HashColumnsTransformerImpl(TransformerABC):
 
 
 class IndexColumnTransformerImpl(TransformerABC):
-    """Добавляет индексную колонку."""
+    """Adds index column."""
 
     def __init__(self, index_generator: IndexGeneratorABC) -> None:
         self._index_generator = index_generator
@@ -74,7 +74,7 @@ class IndexColumnTransformerImpl(TransformerABC):
     def apply(
         self, df: pd.DataFrame, context: RunContext | None = None
     ) -> pd.DataFrame:
-        """Добавляет порядковый индекс строк."""
+        """Add sequential row index."""
         df = df.copy()
         start_index = self._index_generator.next_index()
         # Generate range of indices for the batch
@@ -87,7 +87,7 @@ class IndexColumnTransformerImpl(TransformerABC):
 
 
 class DatabaseVersionTransformerImpl(TransformerABC):
-    """Добавляет колонку с версией базы данных."""
+    """Adds database version column."""
 
     def __init__(
         self,
@@ -98,7 +98,7 @@ class DatabaseVersionTransformerImpl(TransformerABC):
     def apply(
         self, df: pd.DataFrame, context: RunContext | None = None
     ) -> pd.DataFrame:
-        """Добавляет database_version, если значение предоставлено."""
+        """Add database_version if value is provided."""
         version = self._database_version_provider()
         if version is None:
             return df
@@ -108,7 +108,7 @@ class DatabaseVersionTransformerImpl(TransformerABC):
 
 
 class FulldateTransformerImpl(TransformerABC):
-    """Добавляет колонку acquisition_timestamp с таймстампом."""
+    """Adds acquisition_timestamp column with timestamp."""
 
     def __init__(self, timestamp_provider: TimestampProviderABC) -> None:
         self._timestamp_provider = timestamp_provider
@@ -116,7 +116,7 @@ class FulldateTransformerImpl(TransformerABC):
     def apply(
         self, df: pd.DataFrame, context: RunContext | None = None
     ) -> pd.DataFrame:
-        """Добавляет acquisition_timestamp (UTC ISO-8601)."""
+        """Add acquisition_timestamp (UTC ISO-8601)."""
         df = df.copy()
         ts = self._timestamp_provider.get_extraction_timestamp()
         if ts.tzinfo is None:

--- a/src/bioetl/domain/validation/contracts.py
+++ b/src/bioetl/domain/validation/contracts.py
@@ -63,19 +63,19 @@ class ValidatorABC(ABC):
 
 
 class SchemaProviderABC(ABC):
-    """Провайдер схем данных (без привязки к конкретной технологии)."""
+    """Data schema provider (technology-agnostic)."""
 
     @abstractmethod
     def get_schema(self, name: str) -> schema_type:
-        """Возвращает схему по имени."""
+        """Return schema by name."""
 
     @abstractmethod
     def list_schemas(self) -> list[str]:
-        """Возвращает список доступных схем."""
+        """Return list of available schemas."""
 
     @abstractmethod
     def get_schema_columns(self, name: str) -> list[str]:
-        """Возвращает порядок колонок для схемы."""
+        """Return column order for schema."""
 
     @abstractmethod
     def register(
@@ -85,20 +85,20 @@ class SchemaProviderABC(ABC):
         *,
         column_order: list[str] | None = None,
     ) -> None:
-        """Регистрирует новую схему."""
+        """Register a new schema."""
 
 
 @runtime_checkable
 class ValidatorFactoryABC(Protocol):
-    """Фабрика валидаторов под конкретную схему."""
+    """Factory for schema-specific validators."""
 
     def create_validator(self, schema: schema_type) -> ValidatorABC:
-        """Создает валидатор для указанной схемы."""
+        """Create validator for the specified schema."""
 
 
 @runtime_checkable
 class SchemaProviderFactoryABC(Protocol):
-    """Фабрика провайдеров схем."""
+    """Factory for schema providers."""
 
     def create_schema_provider(self) -> SchemaProviderABC:
-        """Создает провайдер схем."""
+        """Create schema provider instance."""

--- a/src/bioetl/domain/validation/service.py
+++ b/src/bioetl/domain/validation/service.py
@@ -11,9 +11,7 @@ from bioetl.domain.validation.contracts import (
 
 
 class ValidationService:
-    """
-    Сервис валидации данных, работающий через доменные интерфейсы.
-    """
+    """Data validation service operating through domain interfaces."""
 
     def __init__(
         self,
@@ -25,22 +23,21 @@ class ValidationService:
         self._validator_factory = validator_factory
 
     def get_schema(self, entity_name: str) -> schema_type:
-        """Возвращает схему для сущности."""
+        """Return schema for entity."""
         return self._schema_provider.get_schema(entity_name)
 
     def get_schema_columns(self, entity_name: str) -> list[str]:
-        """Возвращает упорядоченный список колонок схемы."""
+        """Return ordered list of schema columns."""
         return self._schema_provider.get_schema_columns(entity_name)
 
     def validate(self, df: pd.DataFrame, entity_name: str) -> pd.DataFrame:
-        """
-        Валидирует DataFrame по схеме, используя валидатор фабрики.
+        """Validate DataFrame against schema using factory validator.
 
-        Возвращает валидированный DataFrame (если валидатор его модифицирует),
-        либо исходный df при успешной проверке без преобразований.
+        Returns validated DataFrame (if validator modifies it),
+        or original df if validation passes without transformations.
 
         Raises:
-            ValueError: если валидация не пройдена.
+            ValueError: If validation fails.
         """
         schema = self._schema_provider.get_schema(entity_name)
         validator = self._validator_factory.create_validator(schema)

--- a/src/bioetl/domain/value_objects/__init__.py
+++ b/src/bioetl/domain/value_objects/__init__.py
@@ -1,9 +1,8 @@
-"""
-Value Objects для ключевых идентификаторов.
+"""Value Objects for key identifiers.
 
-Обеспечивают type safety и валидацию на уровне типов.
+Provide type safety and type-level validation.
 
-Этот пакет содержит:
+This package contains:
 - identifiers: RunId, PipelineId, EntityName, ChemblId, StageName
 - crypto: HashDigest
 - network: HttpUrl

--- a/src/bioetl/domain/value_objects/crypto.py
+++ b/src/bioetl/domain/value_objects/crypto.py
@@ -1,7 +1,6 @@
-"""
-Value Objects для криптографических примитивов.
+"""Value Objects for cryptographic primitives.
 
-Содержит типобезопасные обёртки для хэшей и дайджестов.
+Contains type-safe wrappers for hashes and digests.
 """
 
 from __future__ import annotations

--- a/src/bioetl/domain/value_objects/identifiers.py
+++ b/src/bioetl/domain/value_objects/identifiers.py
@@ -1,7 +1,6 @@
-"""
-Value Objects для идентификаторов.
+"""Value Objects for identifiers.
 
-Содержит типобезопасные идентификаторы для различных сущностей системы.
+Contains type-safe identifiers for various system entities.
 """
 
 from __future__ import annotations
@@ -15,7 +14,7 @@ from pydantic_core import CoreSchema, core_schema
 
 
 class RunId:
-    """Value Object для идентификатора запуска pipeline (UUID v4)."""
+    """Value Object for pipeline run identifier (UUID v4)."""
 
     __slots__ = ("_value",)
     _pattern = re.compile(
@@ -49,7 +48,7 @@ class RunId:
 
     @classmethod
     def generate(cls) -> Self:
-        """Генерирует новый уникальный RunId."""
+        """Generate a new unique RunId."""
         return cls(str(uuid.uuid4()))
 
     @classmethod
@@ -64,15 +63,15 @@ class RunId:
 
 
 class StageName:
-    """Value Object для имени стадии pipeline.
+    """Value Object for pipeline stage name.
 
-    Ограниченный набор допустимых стадий с поддержкой aliases.
+    Limited set of allowed stages with alias support.
 
     Allowed values:
-        - "extract" - стадия извлечения данных
-        - "transform" - стадия трансформации
-        - "validate" - стадия валидации
-        - "export" - стадия экспорта (alias: "load")
+        - "extract" - data extraction stage
+        - "transform" - transformation stage
+        - "validate" - validation stage
+        - "export" - export stage (alias: "load")
 
     Features:
         - Case-insensitive: StageName("EXTRACT") → StageName("extract")
@@ -176,7 +175,7 @@ StageName.EXPORT = StageName("export")
 
 
 class EntityName:
-    """Value Object для имени сущности (snake_case)."""
+    """Value Object for entity name (snake_case format)."""
 
     __slots__ = ("_value",)
     _pattern = re.compile(r"^[a-z][a-z0-9_]*$")
@@ -220,7 +219,7 @@ class EntityName:
 
 
 class PipelineId:
-    """Value Object для идентификатора pipeline (формат: provider.entity).
+    """Value Object for pipeline identifier (format: provider.entity).
 
     Examples:
         - "chembl.activity"
@@ -273,7 +272,7 @@ class PipelineId:
 
     @classmethod
     def from_parts(cls, provider: str, entity: str) -> Self:
-        """Создаёт PipelineId из отдельных компонентов."""
+        """Create PipelineId from separate components."""
         return cls(f"{provider}.{entity}")
 
     @classmethod
@@ -288,7 +287,7 @@ class PipelineId:
 
 
 class ChemblId:
-    """Value Object для ChEMBL идентификатора (формат CHEMBL123)."""
+    """Value Object for ChEMBL identifier (format: CHEMBL123)."""
 
     __slots__ = ("_value",)
     _pattern = re.compile(r"^CHEMBL\d+$")
@@ -306,7 +305,7 @@ class ChemblId:
 
     @property
     def numeric_id(self) -> int:
-        """Возвращает числовую часть идентификатора."""
+        """Return the numeric part of the identifier."""
         return int(self._value[6:])
 
     def __str__(self) -> str:

--- a/src/bioetl/domain/value_objects/network.py
+++ b/src/bioetl/domain/value_objects/network.py
@@ -1,7 +1,6 @@
-"""
-Value Objects для сетевых примитивов.
+"""Value Objects for network primitives.
 
-Содержит типобезопасные обёртки для URL и сетевых адресов.
+Contains type-safe wrappers for URLs and network addresses.
 """
 
 from __future__ import annotations
@@ -13,7 +12,7 @@ from pydantic_core import CoreSchema, core_schema
 
 
 class HttpUrl:
-    """Value Object для HTTP/HTTPS URL с валидацией и нормализацией."""
+    """Value Object for HTTP/HTTPS URL with validation and normalization."""
 
     __slots__ = ("_value", "_scheme", "_host", "_path")
     _allowed_schemes = frozenset({"http", "https"})
@@ -36,13 +35,13 @@ class HttpUrl:
 
         self._scheme = parsed.scheme.lower()
         self._host = parsed.netloc.lower()
-        # Нормализация path: удаляем trailing slash, если он не единственный символ
+        # Normalize path: remove trailing slash unless it's the only character
         path = parsed.path
         if path and path != "/" and path.endswith("/"):
             path = path.rstrip("/")
         self._path = path or "/"
 
-        # Сборка нормализованного URL
+        # Assemble normalized URL
         query = f"?{parsed.query}" if parsed.query else ""
         fragment = f"#{parsed.fragment}" if parsed.fragment else ""
         self._value = f"{self._scheme}://{self._host}{self._path}{query}{fragment}"

--- a/src/bioetl/domain/value_objects/temporal.py
+++ b/src/bioetl/domain/value_objects/temporal.py
@@ -1,7 +1,6 @@
-"""
-Value Objects для временных примитивов.
+"""Value Objects for temporal primitives.
 
-Содержит типобезопасные обёртки для временных меток.
+Contains type-safe wrappers for timestamps.
 """
 
 from __future__ import annotations
@@ -14,9 +13,9 @@ from pydantic_core import CoreSchema, core_schema
 
 
 class Timestamp:
-    """Value Object для timezone-aware timestamp (всегда UTC).
+    """Value Object for timezone-aware timestamp (always UTC).
 
-    Гарантирует, что все временные метки хранятся в UTC.
+    Ensures that all timestamps are stored in UTC.
     """
 
     __slots__ = ("_value",)
@@ -27,7 +26,7 @@ class Timestamp:
                 "Timestamp must be timezone-aware. "
                 "Use Timestamp.now() or Timestamp.from_iso() for convenience."
             )
-        # Конвертируем в UTC для консистентности
+        # Convert to UTC for consistency
         self._value = value.astimezone(timezone.utc)
 
     def __setattr__(self, name: str, value: object) -> None:
@@ -41,11 +40,11 @@ class Timestamp:
         return self._value
 
     def to_iso(self) -> str:
-        """Возвращает ISO 8601 строку с timezone."""
+        """Return ISO 8601 string with timezone."""
         return self._value.isoformat()
 
     def to_epoch(self) -> float:
-        """Возвращает Unix timestamp (seconds since epoch)."""
+        """Return Unix timestamp (seconds since epoch)."""
         return self._value.timestamp()
 
     def __str__(self) -> str:
@@ -84,12 +83,12 @@ class Timestamp:
 
     @classmethod
     def now(cls) -> Self:
-        """Создаёт Timestamp с текущим временем в UTC."""
+        """Create Timestamp with current time in UTC."""
         return cls(datetime.now(timezone.utc))
 
     @classmethod
     def from_iso(cls, iso_string: str) -> Self:
-        """Создаёт Timestamp из ISO 8601 строки.
+        """Create Timestamp from ISO 8601 string.
 
         Args:
             iso_string: ISO 8601 formatted datetime string.
@@ -112,7 +111,7 @@ class Timestamp:
 
     @classmethod
     def from_epoch(cls, epoch: float) -> Self:
-        """Создаёт Timestamp из Unix timestamp."""
+        """Create Timestamp from Unix timestamp."""
         return cls(datetime.fromtimestamp(epoch, tz=timezone.utc))
 
     @classmethod

--- a/src/bioetl/infrastructure/clients/base/impl/_http_transport.py
+++ b/src/bioetl/infrastructure/clients/base/impl/_http_transport.py
@@ -28,10 +28,9 @@ from bioetl.infrastructure.settings.metrics import MetricName
 
 
 class _HttpTransport:
-    """
-    Внутренний HTTP-транспорт без промежуточных middleware-слоев.
-    Делегирует вызовы напрямую базовому HTTP-клиенту.
+    """Internal HTTP transport without middleware layers.
 
+    Delegates calls directly to the underlying HTTP client.
     All dependencies must be explicitly injected - no default fallbacks.
     Use composition root or factories to create instances.
     """
@@ -70,7 +69,20 @@ class _HttpTransport:
         )
 
     def request_call(self, method: str, url: str, **kwargs: Any) -> Any:
-        """Выполнить HTTP-запрос с настройками клиента."""
+        """Execute HTTP request with client settings.
+
+        Args:
+            method: HTTP method (GET, POST, etc.).
+            url: Target URL for the request.
+            **kwargs: Additional request parameters passed to underlying client.
+
+        Returns:
+            Response object from the underlying HTTP client.
+
+        Raises:
+            ApiTimeoutError: If request times out.
+            ApiClientError: If request fails with HTTP error.
+        """
         start = time.monotonic()
         status_label = "unknown"
 
@@ -136,11 +148,11 @@ class _HttpTransport:
         return self._request_with_retry(method, url, **kwargs)
 
     def get_response(self, url: str, **kwargs: Any) -> Any:
-        """GET запрос."""
+        """Execute GET request."""
         return self.request("GET", url, **kwargs)
 
     def request_post(self, url: str, **kwargs: Any) -> Any:
-        """POST запрос."""
+        """Execute POST request."""
         return self.request("POST", url, **kwargs)
 
     def _request_with_retry(self, method: str, url: str, **kwargs: Any) -> Any:
@@ -167,7 +179,7 @@ class _HttpTransport:
                 attempt += 1
 
     def close(self) -> None:
-        """Закрыть соединение."""
+        """Close the underlying HTTP connection."""
         if hasattr(self.base_client, "close"):
             self.base_client.close()
 

--- a/src/bioetl/infrastructure/clients/base/impl/cache.py
+++ b/src/bioetl/infrastructure/clients/base/impl/cache.py
@@ -19,9 +19,7 @@ def _is_expired(expiry_timestamp: float | None) -> bool:
 
 
 class MemoryCacheImpl(CacheABC[T]):
-    """
-    Простой кэш в памяти.
-    """
+    """Simple in-memory cache."""
 
     def __init__(self) -> None:
         self._store: dict[str, tuple[T, float | None]] = {}

--- a/src/bioetl/infrastructure/clients/base/impl/rate_limiter.py
+++ b/src/bioetl/infrastructure/clients/base/impl/rate_limiter.py
@@ -8,8 +8,7 @@ from bioetl.domain.observability import LoggingPortABC
 
 
 class TokenBucketRateLimiterImpl(RateLimiterABC):
-    """
-    Реализация алгоритма Token Bucket.
+    """Token Bucket algorithm implementation.
 
     All dependencies must be explicitly injected - no default fallbacks.
     Use composition root or factories to create instances.

--- a/src/bioetl/infrastructure/clients/chembl/paginator.py
+++ b/src/bioetl/infrastructure/clients/chembl/paginator.py
@@ -7,9 +7,7 @@ from bioetl.domain.clients.base.contracts import PaginatorABC
 
 
 class ChemblPaginatorImpl(PaginatorABC):
-    """
-    Стратегия пагинации ChEMBL (offset/limit).
-    """
+    """ChEMBL pagination strategy (offset/limit)."""
 
     def get_items(self, response: dict[str, Any]) -> list[dict[str, Any]]:
         """Extract list payload from response body."""

--- a/src/bioetl/infrastructure/clients/chembl/request_builder.py
+++ b/src/bioetl/infrastructure/clients/chembl/request_builder.py
@@ -7,9 +7,7 @@ from bioetl.domain.clients.base.contracts import RequestBuilderABC
 
 
 class ChemblRequestBuilderImpl(RequestBuilderABC):
-    """
-    Builder для запросов к ChEMBL API.
-    """
+    """Builder for ChEMBL API requests."""
 
     def __init__(self, base_url: str, max_url_length: Optional[int] = None) -> None:
         if not base_url:
@@ -62,9 +60,9 @@ class ChemblRequestBuilderImpl(RequestBuilderABC):
         return self.build_request(merged_params)
 
     def build_request(self, params: dict[str, Any]) -> str:
-        """
-        Строит URL с параметрами.
-        Возвращает полный URL (строка; в реальности может быть Request object).
+        """Build URL with parameters.
+
+        Returns full URL string (could be a Request object in practice).
         """
         # Merge base params with call-specific params (without mutating state)
         current_params = self._params.copy()

--- a/src/bioetl/infrastructure/config/defaults_loader.py
+++ b/src/bioetl/infrastructure/config/defaults_loader.py
@@ -1,4 +1,4 @@
-"""Загрузчик глобальных конфигураций по умолчанию."""
+"""Global default configuration loader."""
 
 from __future__ import annotations
 
@@ -25,11 +25,11 @@ from bioetl.infrastructure.config.sources import (
 
 
 class DefaultsConfigError(Exception):
-    """Базовая ошибка загрузки дефолтных конфигов."""
+    """Base error for default config loading."""
 
 
 class DefaultsFileNotFoundError(DefaultsConfigError):
-    """Файл конфигурации не найден."""
+    """Configuration file not found."""
 
     def __init__(self, path: Path) -> None:
         super().__init__(f"Defaults config file not found: {path}")
@@ -37,7 +37,7 @@ class DefaultsFileNotFoundError(DefaultsConfigError):
 
 
 class DefaultsValidationError(DefaultsConfigError):
-    """Ошибка валидации конфигурации."""
+    """Configuration validation error."""
 
     def __init__(self, path: Path, message: str) -> None:
         super().__init__(f"{path}: {message}")
@@ -45,7 +45,7 @@ class DefaultsValidationError(DefaultsConfigError):
 
 
 def get_defaults_config(*, base_dir: str | Path | None = None) -> DefaultsConfig:
-    """Читает и валидирует глобальные конфигурации по умолчанию."""
+    """Read and validate global default configurations."""
 
     primary_root = get_configs_root(base_dir).resolve()
     fallback_root = DEFAULT_CONFIGS_ROOT.resolve()

--- a/src/bioetl/infrastructure/config/loader.py
+++ b/src/bioetl/infrastructure/config/loader.py
@@ -1,4 +1,4 @@
-"""Загрузчик конфигураций пайплайнов.
+"""Pipeline configuration loader.
 
 This module provides pipeline configuration loading functionality with support
 for dependency injection of schema contract providers.
@@ -41,7 +41,7 @@ from bioetl.infrastructure.config.sources import (
 
 
 class ConfigFileNotFoundError(ConfigError):
-    """Файл конфигурации не найден."""
+    """Configuration file not found."""
 
     def __init__(self, path: Path) -> None:
         super().__init__(f"Config file not found: {path}")
@@ -49,7 +49,7 @@ class ConfigFileNotFoundError(ConfigError):
 
 
 class UnknownProviderError(ConfigError):
-    """Неизвестный провайдер."""
+    """Unknown provider."""
 
     def __init__(self, provider: str) -> None:
         super().__init__(f"Unknown provider: {provider}")
@@ -202,23 +202,23 @@ def get_pipeline_config(
     env_overrides: dict[str, Any] | None = None,
     base_dir: str | Path | None = None,
 ) -> PipelineConfig:
-    """Загружает конфигурацию пайплайна по идентификатору.
+    """Load pipeline configuration by identifier.
 
     Args:
-        pipeline_id: Идентификатор пайплайна (например, "chembl.activity").
-        schema_contract_provider: Провайдер схем. Если None, используется
-            глобальный провайдер (deprecated) или выбрасывается RuntimeError.
-        profile: Имя профиля для применения.
-        cli_overrides: Переопределения из CLI.
-        env_overrides: Переопределения из переменных окружения.
-        base_dir: Базовая директория для поиска конфигураций.
+        pipeline_id: Pipeline identifier (e.g., "chembl.activity").
+        schema_contract_provider: Schema provider. If None, uses
+            global provider (deprecated) or raises RuntimeError.
+        profile: Profile name to apply.
+        cli_overrides: CLI overrides.
+        env_overrides: Environment variable overrides.
+        base_dir: Base directory for configuration search.
 
     Returns:
-        PipelineConfig: Загруженная и валидированная конфигурация.
+        PipelineConfig: Loaded and validated configuration.
 
     Raises:
-        ConfigFileNotFoundError: Файл конфигурации не найден.
-        RuntimeError: SchemaContractProvider не инициализирован.
+        ConfigFileNotFoundError: Configuration file not found.
+        RuntimeError: SchemaContractProvider not initialized.
     """
     effective_provider = _resolve_schema_provider(schema_contract_provider)
 
@@ -251,23 +251,23 @@ def get_pipeline_config_from_path(
     cli_overrides: dict[str, Any] | None = None,
     env_overrides: dict[str, Any] | None = None,
 ) -> PipelineConfig:
-    """Загружает конфигурацию пайплайна из файла.
+    """Load pipeline configuration from file.
 
     Args:
-        config_path: Путь к файлу конфигурации.
-        schema_contract_provider: Провайдер схем. Если None, используется
-            глобальный провайдер (deprecated) или выбрасывается RuntimeError.
-        profile: Имя профиля для применения.
-        profiles_root: Корневая директория профилей.
-        cli_overrides: Переопределения из CLI.
-        env_overrides: Переопределения из переменных окружения.
+        config_path: Path to configuration file.
+        schema_contract_provider: Schema provider. If None, uses
+            global provider (deprecated) or raises RuntimeError.
+        profile: Profile name to apply.
+        profiles_root: Profiles root directory.
+        cli_overrides: CLI overrides.
+        env_overrides: Environment variable overrides.
 
     Returns:
-        PipelineConfig: Загруженная и валидированная конфигурация.
+        PipelineConfig: Loaded and validated configuration.
 
     Raises:
-        ConfigFileNotFoundError: Файл конфигурации не найден.
-        RuntimeError: SchemaContractProvider не инициализирован.
+        ConfigFileNotFoundError: Configuration file not found.
+        RuntimeError: SchemaContractProvider not initialized.
     """
     effective_provider = _resolve_schema_provider(schema_contract_provider)
 
@@ -300,22 +300,22 @@ def _build_config(
     env_overrides: dict[str, Any] | None = None,
     base_dir: Path | None = None,
 ) -> PipelineConfig:
-    """Собирает PipelineConfig из сырых данных с применением overrides.
+    """Build PipelineConfig from raw data with applied overrides.
 
     Args:
-        raw_config: Сырые данные конфигурации из YAML.
-        config_path: Путь к файлу конфигурации.
-        schema_contract_provider: Провайдер схем для заполнения полей.
-        cli_overrides: Переопределения из CLI.
-        env_overrides: Переопределения из переменных окружения.
-        base_dir: Базовая директория для разрешения относительных путей.
+        raw_config: Raw configuration data from YAML.
+        config_path: Path to configuration file.
+        schema_contract_provider: Schema provider for populating fields.
+        cli_overrides: CLI overrides.
+        env_overrides: Environment variable overrides.
+        base_dir: Base directory for resolving relative paths.
 
     Returns:
-        PipelineConfig: Собранная и валидированная конфигурация.
+        PipelineConfig: Built and validated configuration.
     """
     merged = resolve_env_placeholders(dict(raw_config))
 
-    # Применяем overrides в порядке приоритета: env → CLI
+    # Apply overrides in priority order: env → CLI
     if env_overrides:
         env_values = resolve_env_placeholders(env_overrides)
         merged = apply_deep_merge(merged, env_values)
@@ -346,7 +346,7 @@ def _build_config(
 
 
 def _ensure_provider_registered(provider_id: str) -> None:
-    """Проверяет наличие провайдера в реестре до валидации схемы."""
+    """Check provider existence in registry before schema validation."""
 
     try:
         ensure_provider_known(provider_id)
@@ -575,7 +575,7 @@ def _populate_fields_from_schema(
         raise ConfigValidationError(
             f"Schema '{schema_name}' is not registered for pipeline '{config.id}'"
         ) from exc
-    except Exception as exc:  # pragma: no cover - защитный контур
+    except Exception as exc:  # pragma: no cover - defensive guard
         raise ConfigValidationError(
             f"Failed to derive fields from schema '{schema_name}' "
             f"for pipeline '{config.id}': {exc}"
@@ -596,7 +596,7 @@ def _ensure_input_source_valid(
     config_path: Path,
     base_dir: Path | None,
 ) -> None:
-    """Проверяет доступность локальных файлов для CSV/id-only режимов."""
+    """Check local file accessibility for CSV/id-only modes."""
 
     if config.source.input_mode not in {"csv", "id_only"}:
         return
@@ -625,7 +625,7 @@ def _resolve_existing_input_path(
     config_path: Path,
     base_dir: Path | None,
 ) -> Path | None:
-    """Пытается разрешить относительный путь к существующему файлу.
+    """Try to resolve relative path to existing file.
 
     Uses PathResolver to check path existence against multiple candidate
     root directories.
@@ -660,7 +660,7 @@ def _iter_candidate_roots(
     config_path: Path,
     base_dir: Path | None,
 ) -> Iterable[Path]:
-    """Генерирует директории, относительно которых ищем входной файл.
+    """Generate directories relative to which we search for input file.
 
     Yields directories in priority order:
     1. base_dir (if provided)

--- a/src/bioetl/infrastructure/files/atomic.py
+++ b/src/bioetl/infrastructure/files/atomic.py
@@ -12,29 +12,26 @@ from bioetl.infrastructure.settings.files import MAX_FILE_RETRIES, RETRY_DELAY_S
 
 
 class AtomicFileOperation:
-    """
-    Утилита для атомарных операций с файлами.
-    """
+    """Utility for atomic file operations."""
 
     def write_atomic(self, path: Path, write_fn: Callable[[Path], None]) -> None:
-        """
-        Выполняет атомарную запись через временный файл.
+        """Perform atomic write via temporary file.
 
         Args:
-            path: Целевой путь.
-            write_fn: Функция записи, принимающая временный путь.
+            path: Target path.
+            write_fn: Write function accepting temporary path.
         """
         tmp_path = path.with_suffix(".tmp")
 
         try:
-            # 1. Запись во временный файл
+            # 1. Write to temporary file
             write_fn(tmp_path)
 
-            # 2. Атомарное перемещение с retry
+            # 2. Atomic move with retry
             self._replace_with_retry(tmp_path, path)
 
         except Exception:
-            # Очистка в случае ошибки (если файл создан)
+            # Cleanup on error (if file was created)
             if tmp_path.exists():
                 try:
                     os.remove(tmp_path)
@@ -43,20 +40,20 @@ class AtomicFileOperation:
             raise
 
     def _replace_with_retry(self, src: Path, dst: Path) -> None:
-        """
-        Атомарная замена файла с повторными попытками (для Windows).
-        Использует os.replace для атомарной замены на всех платформах.
+        """Atomic file replacement with retries (for Windows).
+
+        Uses os.replace for atomic replacement on all platforms.
         """
         last_error: OSError | None = None
         is_windows = platform.system() == "Windows"
-        # На Windows используем более длительную задержку из-за антивирусов/индексаторов
+        # On Windows use longer delay due to antivirus/indexers
         delay = RETRY_DELAY_SEC * (2.0 if is_windows else 1.0)
 
         for attempt in range(MAX_FILE_RETRIES):
             try:
                 if self._try_replace(src, dst, is_windows):
                     return
-                # Если попытка не выбросила исключение, но не удалась, фиксируем ошибку.
+                # If attempt did not raise exception but failed, record the error.
                 last_error = last_error or OSError(
                     "Move failed without explicit error."
                 )
@@ -68,22 +65,21 @@ class AtomicFileOperation:
             time.sleep(delay)
 
     def _try_replace(self, src: Path, dst: Path, is_windows: bool) -> bool:
-        """
-        Попытка заменить файл атомарно.
+        """Attempt to replace file atomically.
 
         Returns:
-            True если замена успешна, False иначе.
+            True if replacement successful, False otherwise.
         """
         try:
             os.replace(src, dst)
             return True
         except PermissionError as exc:
-            # На Windows PermissionError часто означает, что файл заблокирован
+            # On Windows PermissionError often means file is locked
             if self._try_windows_unlock_replace(src, dst, is_windows):
                 return True
             raise exc
         except OSError:
-            # Передаём исключение наверх, чтобы оно учитывалось в retry и сообщениях
+            # Pass exception up so it's accounted for in retry and messages
             raise
 
     def _try_windows_unlock_replace(
@@ -92,11 +88,10 @@ class AtomicFileOperation:
         dst: Path,
         is_windows: bool,
     ) -> bool:
-        """
-        Попытка разблокировать и заменить файл на Windows.
+        """Attempt to unlock and replace file on Windows.
 
         Returns:
-            True если замена успешна, False иначе.
+            True if replacement successful, False otherwise.
         """
         if not is_windows or not dst.exists():
             return False

--- a/src/bioetl/infrastructure/files/checksum.py
+++ b/src/bioetl/infrastructure/files/checksum.py
@@ -7,9 +7,7 @@ from bioetl.infrastructure.settings.files import CHECKSUM_CHUNK_SIZE
 
 
 def compute_file_sha256(path: Path) -> str:
-    """
-    Вычисляет SHA256 хеш файла.
-    """
+    """Compute SHA256 hash of a file."""
     sha256 = hashlib.sha256()
     with open(path, "rb") as f:
         for chunk in iter(lambda: f.read(CHECKSUM_CHUNK_SIZE), b""):
@@ -18,10 +16,9 @@ def compute_file_sha256(path: Path) -> str:
 
 
 def compute_files_sha256(paths: list[Path]) -> dict[str, str]:
-    """
-    Вычисляет SHA256 хеши нескольких файлов.
+    """Compute SHA256 hashes for multiple files.
 
-    Отсутствующие файлы пропускаются.
+    Missing files are skipped.
     """
     checksums: dict[str, str] = {}
     for path in paths:

--- a/src/bioetl/infrastructure/http/retry.py
+++ b/src/bioetl/infrastructure/http/retry.py
@@ -14,7 +14,11 @@ from bioetl.infrastructure.settings.http import (
 
 
 class ExponentialRetryPolicy(RetryPolicyABC):
-    """Экспоненциальная стратегия повторных попыток для HTTP-клиентов."""
+    """Exponential backoff retry policy for HTTP clients.
+
+    Implements configurable retry logic with exponential delay growth.
+    Retries are triggered based on HTTP status codes or exception types.
+    """
 
     def __init__(
         self,
@@ -38,17 +42,24 @@ class ExponentialRetryPolicy(RetryPolicyABC):
 
     @property
     def max_attempts(self) -> int:
-        """Максимальное количество попыток."""
+        """Maximum number of retry attempts."""
         return self._max_attempts
 
     @property
     def backoff_factor(self) -> float:
-        """Множитель задержки между попытками."""
+        """Delay multiplier between retry attempts."""
         return self._backoff_factor
 
     def should_retry(self, exception: Exception, attempt: int) -> bool:
-        """Проверяет, можно ли повторить попытку на данном шаге."""
+        """Check whether a retry should be attempted for the given exception.
 
+        Args:
+            exception: The exception that was raised.
+            attempt: Current attempt number (1-indexed).
+
+        Returns:
+            True if retry should be attempted, False otherwise.
+        """
         if attempt >= self.max_attempts:
             return False
 
@@ -68,15 +79,27 @@ class ExponentialRetryPolicy(RetryPolicyABC):
         return status_code in self.retry_statuses if status_code is not None else False
 
     def get_backoff(self, attempt: int) -> float:
-        """Возвращает задержку перед следующей попыткой в секундах."""
+        """Calculate delay before the next retry attempt in seconds.
 
+        Args:
+            attempt: Current attempt number (1-indexed).
+
+        Returns:
+            Delay in seconds before next retry.
+        """
         exponent = max(0, attempt - 1)
         return self.backoff_factor * math.pow(2.0, exponent)
 
 
 def _extract_status_code(exc: Exception) -> int | None:
-    """Пробует извлечь код статуса из исключения requests."""
+    """Extract HTTP status code from a requests exception.
 
+    Args:
+        exc: Exception that may contain a response object.
+
+    Returns:
+        HTTP status code if available, None otherwise.
+    """
     response = getattr(exc, "response", None)
     status = getattr(response, "status_code", None)
     if isinstance(status, int):

--- a/src/bioetl/infrastructure/logging/impl/progress_reporter.py
+++ b/src/bioetl/infrastructure/logging/impl/progress_reporter.py
@@ -6,9 +6,7 @@ from bioetl.domain.observability import ProgressReporterABC
 
 
 class TqdmProgressReporterImpl(ProgressReporterABC):
-    """
-    Реализация прогресс-бара через tqdm.
-    """
+    """Progress bar implementation using tqdm."""
 
     def __init__(self) -> None:
         self._pbar: tqdm | None = None

--- a/src/bioetl/infrastructure/observability/server.py
+++ b/src/bioetl/infrastructure/observability/server.py
@@ -1,4 +1,4 @@
-"""HTTP сервер экспонирования метрик Prometheus."""
+"""Prometheus metrics HTTP server."""
 
 from __future__ import annotations
 
@@ -11,10 +11,10 @@ _metrics_server_lock = Lock()
 
 
 def start_metrics_server_once(*, enabled: bool, port: int, address: str) -> bool:
-    """Запускает HTTP сервер метрик один раз на процесс.
+    """Start metrics HTTP server once per process.
 
-    Возвращает ``True``, если сервер был запущен в текущем вызове, и ``False``
-    если он уже работал или отключен конфигурацией.
+    Returns ``True`` if server was started in this call, ``False``
+    if already running or disabled by configuration.
     """
 
     if not enabled:

--- a/src/bioetl/infrastructure/output/converters/dropna_rows_converter.py
+++ b/src/bioetl/infrastructure/output/converters/dropna_rows_converter.py
@@ -1,4 +1,4 @@
-"""Конвертер для удаления полностью пустых строк из DataFrame."""
+"""Converter for removing completely empty rows from DataFrame."""
 
 from __future__ import annotations
 
@@ -8,10 +8,10 @@ from bioetl.domain.clients.base.output.contracts import OutputFrameConverterABC
 
 
 class DropNaRowsConverter(OutputFrameConverterABC):
-    """Удаляет строки, где все значения являются NaN."""
+    """Remove rows where all values are NaN."""
 
     def convert(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Удаляет строки, где все значения являются NaN."""
+        """Remove rows where all values are NaN."""
         return df.dropna(how="all")
 
 

--- a/src/bioetl/infrastructure/output/converters/factories.py
+++ b/src/bioetl/infrastructure/output/converters/factories.py
@@ -1,4 +1,4 @@
-"""Фабрика конвертеров DataFrame для пост-обработки перед записью.
+"""DataFrame converter factory for post-processing before writing.
 
 Naming convention:
 - create_*() - creates a new instance each time

--- a/src/bioetl/infrastructure/output/converters/noop_converter.py
+++ b/src/bioetl/infrastructure/output/converters/noop_converter.py
@@ -1,4 +1,4 @@
-"""Конвертер-заглушка, возвращающий DataFrame без изменений."""
+"""No-op converter that returns DataFrame unchanged."""
 
 from __future__ import annotations
 
@@ -8,10 +8,10 @@ from bioetl.domain.clients.base.output.contracts import OutputFrameConverterABC
 
 
 class NoopConverter(OutputFrameConverterABC):
-    """Конвертер, который не изменяет DataFrame."""
+    """Converter that does not modify the DataFrame."""
 
     def convert(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Возвращает DataFrame без изменений."""
+        """Return DataFrame without changes."""
         return df
 
 

--- a/src/bioetl/infrastructure/output/impl/csv_writer.py
+++ b/src/bioetl/infrastructure/output/impl/csv_writer.py
@@ -14,9 +14,9 @@ from bioetl.infrastructure.output.impl.base_writer import BaseWriter
 
 
 class CsvWriter(BaseWriter):
-    """
-    Запись CSV.
-    Делегирует атомарность и хеширование внешнему фасаду.
+    """CSV file writer.
+
+    Delegates atomicity and hashing to external facade.
     """
 
     def __init__(self) -> None:

--- a/src/bioetl/infrastructure/output/impl/metadata_writer.py
+++ b/src/bioetl/infrastructure/output/impl/metadata_writer.py
@@ -25,9 +25,7 @@ def build_quality_report_table(
 
 
 class MetadataWriter:
-    """
-    Запись метаданных и QC отчетов.
-    """
+    """Metadata and QC report writer."""
 
     def __init__(
         self,

--- a/src/bioetl/infrastructure/output/impl/parquet_writer.py
+++ b/src/bioetl/infrastructure/output/impl/parquet_writer.py
@@ -12,9 +12,7 @@ from bioetl.infrastructure.output.impl.base_writer import BaseWriter
 
 
 class ParquetWriter(BaseWriter):
-    """
-    Запись Parquet.
-    """
+    """Parquet file writer."""
 
     def __init__(self, *, checksum_fn: Callable[[Path], str] | None = None) -> None:
         super().__init__(atomic=True, checksum_fn=checksum_fn)

--- a/src/bioetl/infrastructure/output/impl/quality_report.py
+++ b/src/bioetl/infrastructure/output/impl/quality_report.py
@@ -8,7 +8,7 @@ from bioetl.domain.clients.base.output.contracts import QualityReportABC
 
 
 class QualityReportImpl(QualityReportABC):
-    """Генератор QC-отчетов на базе Pandas."""
+    """Pandas-based QC report generator."""
 
     def build_quality_report(
         self, df: pd.DataFrame, *, min_coverage: float

--- a/src/bioetl/infrastructure/output/metadata.py
+++ b/src/bioetl/infrastructure/output/metadata.py
@@ -17,14 +17,13 @@ def build_base_metadata(
     dry_run: bool = False,
     include_metadata: bool = True,
 ) -> dict[str, Any]:
-    """
-    Формирует базовый словарь метаданных.
+    """Build base metadata dictionary.
 
     Args:
-        context: Контекст запуска.
-        row_count: Количество строк результата.
-        dry_run: Признак dry-run.
-        include_metadata: Добавлять ли пользовательские метаданные из контекста.
+        context: Run context.
+        row_count: Number of result rows.
+        dry_run: Dry-run flag.
+        include_metadata: Whether to include user metadata from context.
     """
     meta = {
         "run_id": context.run_id,
@@ -52,12 +51,11 @@ def build_run_metadata(
     qc_checksums: dict[str, str] | None = None,
     qc_config: QcConfig | None = None,
 ) -> dict[str, Any]:
-    """
-    Создает словарь метаданных.
+    """Create run metadata dictionary.
 
     Args:
-        context: Контекст запуска.
-        result: Результат записи.
+        context: Run context.
+        result: Write result.
     """
     files = [result.path.name]
     qc_artifacts = qc_artifacts or []
@@ -98,9 +96,7 @@ def build_run_metadata(
 
 
 def build_dry_run_metadata(context: RunContext, row_count: int) -> dict[str, Any]:
-    """
-    Создает метаданные для dry run.
-    """
+    """Create metadata for dry run."""
     return build_base_metadata(
         context, row_count=row_count, dry_run=True, include_metadata=True
     )

--- a/src/bioetl/infrastructure/provider_registry.py
+++ b/src/bioetl/infrastructure/provider_registry.py
@@ -15,7 +15,7 @@ from bioetl.domain.providers import ProviderDefinition, ProviderId
 
 
 class InMemoryProviderRegistry(ProviderRegistryABC):
-    """Реализация реестра провайдеров в памяти.
+    """In-memory provider registry implementation.
 
     Concrete implementation of the provider registry that stores
     provider definitions in memory. This implementation belongs
@@ -26,27 +26,27 @@ class InMemoryProviderRegistry(ProviderRegistryABC):
         self._providers: dict[ProviderId, ProviderDefinition] = {}
 
     def register_provider(self, definition: ProviderDefinition) -> None:
-        """Регистрирует провайдер в реестре."""
+        """Register provider in registry."""
         if definition.id in self._providers:
             raise ProviderAlreadyRegisteredError(definition.id)
         self._providers[definition.id] = definition
 
     def get_provider(self, provider_id: ProviderId) -> ProviderDefinition:
-        """Получает определение провайдера по идентификатору."""
+        """Get provider definition by identifier."""
         if provider_id not in self._providers:
             raise ProviderNotRegisteredError(provider_id)
         return self._providers[provider_id]
 
     def list_providers(self) -> list[ProviderDefinition]:
-        """Возвращает список всех зарегистрированных провайдеров."""
+        """Return list of all registered providers."""
         return list(self._providers.values())
 
     def reset_provider_registry(self) -> None:
-        """Очищает реестр провайдеров."""
+        """Clear the provider registry."""
         self._providers.clear()
 
     def restore_provider_registry(self, definitions: list[ProviderDefinition]) -> None:
-        """Восстанавливает реестр из списка определений."""
+        """Restore registry from list of definitions."""
         self._providers.clear()
         for definition in definitions:
             self._providers[definition.id] = definition

--- a/src/bioetl/infrastructure/transform/impl/base_normalizer.py
+++ b/src/bioetl/infrastructure/transform/impl/base_normalizer.py
@@ -160,7 +160,7 @@ class BaseNormalizationService:
                 )
             except ValueError as exc:
                 raise ValueError(
-                    f"Ошибка нормализации списка в поле '{field_name}': {exc}"
+                    f"Error normalizing list in field '{field_name}': {exc}"
                 ) from exc
             if not container_value:
                 return self._empty_value
@@ -214,7 +214,7 @@ class BaseNormalizationService:
             )
         except ValueError as exc:
             raise ValueError(
-                f"Ошибка нормализации списка в поле '{field_name}': {exc}"
+                f"Error normalizing list in field '{field_name}': {exc}"
             ) from exc
 
         if not normalized_list:
@@ -231,7 +231,7 @@ class BaseNormalizationService:
             normalized_dict = normalize_record(dict_value, value_normalizer=normalizer)
         except ValueError as exc:
             raise ValueError(
-                f"Ошибка нормализации записи в поле '{field_name}': {exc}"
+                f"Error normalizing record in field '{field_name}': {exc}"
             ) from exc
 
         if normalized_dict is None:
@@ -248,7 +248,7 @@ class BaseNormalizationService:
         try:
             return normalizer(value)
         except ValueError as exc:
-            raise ValueError(f"Ошибка нормализации поля '{field_name}': {exc}") from exc
+            raise ValueError(f"Error normalizing field '{field_name}': {exc}") from exc
 
     def _apply_container_normalizer(
         self,

--- a/src/bioetl/infrastructure/transform/impl/default_normalization_transformer_impl.py
+++ b/src/bioetl/infrastructure/transform/impl/default_normalization_transformer_impl.py
@@ -56,7 +56,7 @@ class NormalizationServiceImpl(BaseNormalizationService, NormalizationServiceABC
         return self.apply_normalize(record)
 
     def apply_normalize_fields(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Проходит по полям конфигурации и применяет нормализацию."""
+        """Iterate through configuration fields and apply normalization."""
         for field_cfg in self._iter_fields():
             name = field_cfg["name"]
             dtype = field_cfg.get("data_type")
@@ -93,7 +93,7 @@ class NormalizationServiceImpl(BaseNormalizationService, NormalizationServiceABC
                     )
                 except ValueError as exc:
                     raise ValueError(
-                        f"Ошибка нормализации поля '{field_name}': {exc}"
+                        f"Error normalizing field '{field_name}': {exc}"
                     ) from exc
 
             df[name] = df[name].apply(_apply_value)

--- a/src/bioetl/infrastructure/transform/impl/hash_service.py
+++ b/src/bioetl/infrastructure/transform/impl/hash_service.py
@@ -18,11 +18,10 @@ from bioetl.domain.value_objects import HashDigest
 
 
 class Blake2bHashService(HashServiceABC):
-    """
-    Stateless хеш-сервис на основе BLAKE2b-256.
+    """Stateless hash service based on BLAKE2b-256.
 
-    Использует HasherABC для вычисления хешей.
-    Не содержит никакого состояния - чистые функции хеширования.
+    Uses HasherABC for hash computation.
+    Contains no state - pure hashing functions.
 
     Methods:
         compute_fingerprint: Compute record_hash of entire record.
@@ -31,9 +30,10 @@ class Blake2bHashService(HashServiceABC):
     """
 
     def __init__(self, hasher: HasherABC) -> None:
-        """
+        """Initialize service.
+
         Args:
-            hasher: Реализация алгоритма хеширования.
+            hasher: Hash algorithm implementation.
         """
         self._hasher = hasher
 
@@ -134,13 +134,13 @@ class Blake2bHashService(HashServiceABC):
     # Legacy methods for backward compatibility
 
     def compute_row_fingerprint(self, row: dict) -> str:
-        """Вычисляет хеш-отпечаток строки как полного объекта (legacy).
+        """Compute hash fingerprint of row as complete object (legacy).
 
         Args:
-            row: Словарь с данными строки.
+            row: Dictionary with row data.
 
         Returns:
-            Hex-строка с хешем строки.
+            Hex string with row hash.
         """
         return self.compute_fingerprint(row).value
 

--- a/src/bioetl/infrastructure/transform/impl/hasher.py
+++ b/src/bioetl/infrastructure/transform/impl/hasher.py
@@ -14,16 +14,12 @@ from bioetl.domain.value_objects import HashDigest
 
 
 def normalize_unicode(text: str) -> str:
-    """
-    Нормализует строку в форму NFC.
-    """
+    """Normalize string to NFC form."""
     return unicodedata.normalize("NFC", text)
 
 
 def format_float(value: float | Decimal) -> str:
-    """
-    Форматирует число с плавающей точкой по спецификации: %.15g.
-    """
+    """Format floating-point number per specification: %.15g."""
     # Decimal is treated as float for canonicalization purposes per spec
     # to avoid discrepancies between float and Decimal types in source
     val = float(value)
@@ -36,9 +32,7 @@ def format_float(value: float | Decimal) -> str:
 
 
 def _serialize_canonical(obj: Any) -> str:
-    """
-    Рекурсивная функция сериализации в строку.
-    """
+    """Recursive function for serializing to string."""
     if obj is None:
         return "null"
     if isinstance(obj, bool):
@@ -84,16 +78,12 @@ def _serialize_mapping(obj: dict[str, Any]) -> str:
 
 
 def blake2b_hash_hex(data_bytes: bytes, digest_size: int = 32) -> str:
-    """
-    Вычисляет BLAKE2b хеш.
-    """
+    """Compute BLAKE2b hash."""
     return hashlib.blake2b(data_bytes, digest_size=digest_size).hexdigest()
 
 
 class HasherImpl(HasherABC):
-    """
-    Реализация хеширования (BLAKE2b-256) с канонической JSON сериализацией.
-    """
+    """Hasher implementation (BLAKE2b-256) with canonical JSON serialization."""
 
     @property
     def algorithm(self) -> str:
@@ -138,18 +128,16 @@ class HasherImpl(HasherABC):
         return "blake2b_256"
 
     def compute_hash_row(self, row: pd.Series) -> str:
-        """
-        Хеширует строку Series как полный объект (hash_row).
-        """
+        """Hash Series row as complete object (hash_row)."""
         record = row.to_dict()
         serialized = _serialize_canonical(record)
         return blake2b_hash_hex(serialized.encode("utf-8"))
 
     def compute_hash_columns(self, df: pd.DataFrame, columns: list[str]) -> pd.Series:
-        """
-        Хеширует выбранные колонки DataFrame (как список значений в заданном порядке).
-        Используется для hash_business_key.
-        Если columns пуст -> возвращает None (в Series).
+        """Hash selected DataFrame columns (as list of values in specified order).
+
+        Used for hash_business_key.
+        If columns is empty, returns None (in Series).
         """
         if not columns:
             return pd.Series([None] * len(df), index=df.index, dtype=object)

--- a/src/bioetl/infrastructure/transform/impl/index_generator.py
+++ b/src/bioetl/infrastructure/transform/impl/index_generator.py
@@ -6,40 +6,39 @@ from bioetl.domain.transform.contracts import IndexGeneratorABC
 
 
 class SequentialIndexGenerator(IndexGeneratorABC):
-    """
-    Генератор последовательных индексов.
+    """Sequential index generator.
 
-    Stateful: сохраняет текущее значение счётчика между вызовами.
-    Используется для присвоения уникальных индексов строкам данных.
+    Stateful: maintains counter value between calls.
+    Used for assigning unique indices to data rows.
     """
 
     def __init__(self, start: int = 0) -> None:
-        """
+        """Initialize generator.
+
         Args:
-            start: Начальное значение счётчика (по умолчанию 0).
+            start: Initial counter value (default 0).
         """
         self._start = start
         self._counter = start
 
     def next_index(self) -> int:
-        """Возвращает следующий индекс и увеличивает счётчик."""
+        """Return next index and increment counter."""
         idx = self._counter
         self._counter += 1
         return idx
 
     def reset(self) -> None:
-        """Сбрасывает счётчик в начальное состояние."""
+        """Reset counter to initial state."""
         self._counter = self._start
 
     def generate_range(self, count: int) -> list[int]:
-        """
-        Генерирует диапазон индексов для batch операций.
+        """Generate index range for batch operations.
 
         Args:
-            count: Количество индексов для генерации.
+            count: Number of indices to generate.
 
         Returns:
-            Список последовательных индексов.
+            List of sequential indices.
         """
         start = self._counter
         self._counter += count

--- a/src/bioetl/infrastructure/transform/impl/timestamp_provider.py
+++ b/src/bioetl/infrastructure/transform/impl/timestamp_provider.py
@@ -8,18 +8,18 @@ from bioetl.domain.transform.contracts import TimestampProviderABC
 
 
 class DeterministicTimestampProvider(TimestampProviderABC):
-    """
-    Провайдер детерминированных временных меток.
+    """Deterministic timestamp provider.
 
-    Фиксирует время при инициализации и возвращает его при всех вызовах.
-    Это обеспечивает детерминизм в рамках одной сессии обработки данных.
+    Fixes time at initialization and returns it for all calls.
+    This ensures determinism within a single data processing session.
     """
 
     def __init__(self, fixed_time: datetime | None = None) -> None:
-        """
+        """Initialize provider.
+
         Args:
-            fixed_time: Фиксированное время. Если не указано,
-                        используется текущее время (UTC).
+            fixed_time: Fixed timestamp. If not specified,
+                        current time (UTC) is used.
         """
         if fixed_time is None:
             self._time = datetime.now(timezone.utc)
@@ -31,7 +31,7 @@ class DeterministicTimestampProvider(TimestampProviderABC):
                 self._time = fixed_time
 
     def get_extraction_timestamp(self) -> datetime:
-        """Возвращает зафиксированный timestamp извлечения данных."""
+        """Return fixed data extraction timestamp."""
         return self._time
 
 

--- a/src/bioetl/infrastructure/validation/factories.py
+++ b/src/bioetl/infrastructure/validation/factories.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
 
 class PanderaValidatorFactory(ValidatorFactoryABC):
-    """Фабрика валидаторов Pandera."""
+    """Pandera validator factory."""
 
     def create_validator(self, schema: schema_type) -> ValidatorABC:
         """Instantiate a Pandera-backed validator for given schema."""
@@ -38,7 +38,7 @@ class PanderaValidatorFactory(ValidatorFactoryABC):
 
 
 class PanderaSchemaProviderFactory(SchemaProviderFactoryABC):
-    """Фабрика провайдеров схем для Pandera.
+    """Schema provider factory for Pandera.
 
     This factory supports dependency injection via constructor parameter,
     allowing tests to provide mock schema providers. When no factory is

--- a/src/bioetl/infrastructure/validation/impl/pandera_validator.py
+++ b/src/bioetl/infrastructure/validation/impl/pandera_validator.py
@@ -12,7 +12,7 @@ from bioetl.domain.validation.contracts import schema_type
 
 
 class PanderaValidatorImpl(ValidatorABC):
-    """Реализация валидатора на основе Pandera."""
+    """Pandera-based validator implementation."""
 
     def __init__(self, schema: schema_type) -> None:
         self._schema = schema

--- a/src/bioetl/interfaces/composition_root.py
+++ b/src/bioetl/interfaces/composition_root.py
@@ -60,10 +60,10 @@ class ObservabilityStack:
 
 
 class CompositionRoot:
-    """Единая точка сборки зависимостей для interfaces layer.
+    """Single dependency assembly point for interfaces layer.
 
-    Все concrete implementations создаются здесь. Другие модули
-    получают зависимости через этот класс, а не создают напрямую.
+    All concrete implementations are created here. Other modules
+    obtain dependencies through this class, not directly.
 
     Example:
         # Production
@@ -78,10 +78,10 @@ class CompositionRoot:
     def __init__(
         self,
         *,
-        # Новые параметры для фабрик
+        # New factory parameters
         observability_factory: ObservabilityFactoryABC | None = None,
         infrastructure_factory: InfrastructureFactoryABC | None = None,
-        # Старые параметры (backward compatibility)
+        # Legacy parameters (backward compatibility)
         logger: LoggingPortABC | None = None,
         metrics: MetricsPortABC | None = None,
         http_session_factory: type | None = None,
@@ -101,11 +101,11 @@ class CompositionRoot:
             schema_contract_provider: Custom schema contract provider
                 (defaults to bootstrapped provider from schema registry)
         """
-        # Фабрики
+        # Factories
         self._observability = observability_factory or DefaultObservabilityFactory()
         self._infrastructure = infrastructure_factory or DefaultInfrastructureFactory()
 
-        # Explicit overrides (для BC и тестов)
+        # Explicit overrides (for BC and tests)
         self._explicit_logger = logger
         self._explicit_metrics = metrics
         self._http_session_factory = http_session_factory or requests.Session

--- a/src/bioetl/interfaces/rest/server.py
+++ b/src/bioetl/interfaces/rest/server.py
@@ -1,4 +1,4 @@
-"""Минимальный REST-сервер для запуска пайплайнов через RunPipelineUseCase."""
+"""Minimal REST server for running pipelines via RunPipelineUseCase."""
 
 from __future__ import annotations
 
@@ -15,22 +15,22 @@ from bioetl.interfaces.use_case_factory import get_use_case_factory
 
 
 class PipelineRunRequest(BaseModel):
-    """Запрос на запуск пайплайна."""
+    """Pipeline run request."""
 
     pipeline_name: str = Field(
-        ..., description="Имя пайплайна в формате entity_provider"
+        ..., description="Pipeline name in entity_provider format"
     )
     profile: str = Field(
-        default="default", description="Активный конфигурационный профиль"
+        default="default", description="Active configuration profile"
     )
-    dry_run: bool = Field(default=False, description="Запуск без записи вывода")
+    dry_run: bool = Field(default=False, description="Run without writing output")
     limit: int | None = Field(
-        default=None, description="Ограничение на количество записей"
+        default=None, description="Record count limit"
     )
 
 
 class PipelineRunResponse(BaseModel):
-    """Ответ с результатами выполнения пайплайна."""
+    """Pipeline execution result response."""
 
     run_id: str
     success: bool
@@ -40,7 +40,7 @@ class PipelineRunResponse(BaseModel):
 
 
 def create_rest_app() -> FastAPI:
-    """Создает и возвращает FastAPI-приложение для запуска пайплайнов."""
+    """Create and return FastAPI application for running pipelines."""
 
     app = FastAPI(title="BioETL REST Interface")
 


### PR DESCRIPTION
Translate all docstrings, comments, and inline documentation from Russian to English across the entire bioetl codebase. This establishes a unified language standard using Google-style docstrings.

Changes include:
- Domain layer: value_objects, models, errors, contracts, transforms
- Infrastructure layer: HTTP transport, config loaders, output writers
- Application layer: pipelines, use cases, orchestrator
- Interfaces layer: REST server, composition root