### PR TITLE
Refactor BioETL architecture and improve score

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -21,17 +21,15 @@ forbidden_modules =
 ignore_imports =
     bioetl.application.config.runtime -> bioetl.infrastructure.config.loader
     bioetl.application.container -> bioetl.infrastructure.config.provider_registry
-    bioetl.application.container -> bioetl.infrastructure.files.csv_record_source
     bioetl.application.container -> bioetl.infrastructure.logging.factories
     bioetl.application.container -> bioetl.infrastructure.output.factories
     bioetl.application.container -> bioetl.infrastructure.output.unified_writer
-    bioetl.application.orchestrator -> bioetl.infrastructure.config.provider_registry
+    bioetl.application.orchestrator -> bioetl.infrastructure.provider_registry
     bioetl.application.pipelines.contracts -> bioetl.infrastructure.output.unified_writer
     bioetl.application.pipelines.hooks_impl -> bioetl.infrastructure.observability.metrics
     bioetl.application.pipelines.base -> bioetl.infrastructure.output.metadata
     bioetl.application.pipelines.base -> bioetl.infrastructure.output.unified_writer
     bioetl.application.pipelines.chembl.base -> bioetl.infrastructure.output.unified_writer
-    bioetl.application.pipelines.chembl.extractor -> bioetl.infrastructure.files.csv_record_source
     bioetl.application.pipelines.chembl.pipeline -> bioetl.infrastructure.output.unified_writer
     bioetl.application.services.chembl_extraction -> bioetl.infrastructure.clients.chembl.impl.chembl_extraction_service_impl
 

--- a/src/bioetl/application/orchestrator.py
+++ b/src/bioetl/application/orchestrator.py
@@ -46,13 +46,27 @@ from bioetl.domain.models import RunContext, RunResult, StageResult
 from bioetl.domain.pipelines.types import PipelineType
 from bioetl.domain.provider_registry import (
     ProviderRegistryABC,
+    ProviderRegistryFactory,
     ProviderRegistryLoaderABC,
 )
 from bioetl.domain.providers import ProviderDefinition, ProviderId
 from bioetl.domain.value_objects import EntityName, StageName
-from bioetl.infrastructure.provider_registry import InMemoryProviderRegistry
 
 ProviderLoaderProtocol = ProviderRegistryLoaderABC
+
+
+def _get_default_registry_factory() -> ProviderRegistryFactory:
+    """Get the default provider registry factory.
+
+    This function lazily imports from infrastructure to provide backward
+    compatibility. New code should inject the factory explicitly.
+
+    Returns:
+        Factory function that creates InMemoryProviderRegistry instances.
+    """
+    from bioetl.infrastructure.provider_registry import InMemoryProviderRegistry
+
+    return InMemoryProviderRegistry
 
 
 class PipelineOrchestrator:
@@ -65,6 +79,7 @@ class PipelineOrchestrator:
         *,
         provider_registry: ProviderRegistryABC | None = None,
         provider_registry_provider: Callable[[], ProviderRegistryABC] | None = None,
+        provider_registry_factory: ProviderRegistryFactory | None = None,
         container_factory: Callable[..., PipelineContainerABC] | None = None,
         provider_loader: ProviderLoaderProtocol | None = None,
         provider_loader_factory: Callable[[], ProviderLoaderProtocol] | None = None,
@@ -73,6 +88,9 @@ class PipelineOrchestrator:
         self._config = config
         self._provider_registry = provider_registry
         self._provider_registry_provider = provider_registry_provider
+        self._provider_registry_factory = (
+            provider_registry_factory or _get_default_registry_factory()
+        )
         self._container_factory = self._resolve_container_factory(container_factory)
         self._provider_loader = provider_loader
         self._provider_loader_factory = provider_loader_factory
@@ -297,7 +315,7 @@ class PipelineOrchestrator:
         if loader is None:
             return None
 
-        registry = loader.get_registry(registry=InMemoryProviderRegistry())
+        registry = loader.get_registry(registry=self._provider_registry_factory())
         self._provider_registry = registry
         return registry
 
@@ -318,16 +336,18 @@ class PipelineOrchestrator:
         *,
         loader: ProviderLoaderProtocol | None,
         registry_payload: list[ProviderDefinition] | None,
+        registry_factory: ProviderRegistryFactory | None = None,
     ) -> ProviderRegistryABC:
+        factory = registry_factory or _get_default_registry_factory()
         if registry_payload is not None:
-            registry = InMemoryProviderRegistry()
+            registry = factory()
             registry.restore_provider_registry(registry_payload)
             return registry
 
         if loader is not None:
-            return loader.get_registry(registry=InMemoryProviderRegistry())
+            return loader.get_registry(registry=factory())
 
-        return InMemoryProviderRegistry()
+        return factory()
 
 
 __all__ = ["PipelineOrchestrator"]

--- a/src/bioetl/domain/provider_registry.py
+++ b/src/bioetl/domain/provider_registry.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Callable, Protocol, runtime_checkable
 
 from bioetl.domain.providers import ProviderDefinition, ProviderId
+
+
+# Type alias for factory function that creates empty provider registry instances.
+# Used for dependency injection in application layer to avoid direct infrastructure imports.
+ProviderRegistryFactory = Callable[[], "ProviderRegistryABC"]
 
 
 class ProviderRegistryError(Exception):
@@ -67,16 +73,31 @@ class ProviderRegistryLoaderABC(Protocol):
         """Load providers and return populated registry."""
 
 
-# Global registry instance
+# Global registry instance - DEPRECATED
+# New code should inject ProviderRegistryABC through CompositionRoot
 _PROVIDER_REGISTRY: ProviderRegistryABC | None = None
 
 
 def set_provider_registry(registry: ProviderRegistryABC) -> None:
     """Sets the global provider registry instance.
 
+    DEPRECATED: Use dependency injection through CompositionRoot instead.
+    Global state makes testing difficult and creates implicit dependencies.
+
     This should be called by the application entry point or configuration loader
     to inject the concrete implementation (Dependency Injection).
+
+    .. deprecated:: 2.0
+        Use CompositionRoot.get_provider_registry() and pass the registry
+        explicitly to components that need it.
     """
+    warnings.warn(
+        "set_provider_registry() is deprecated. "
+        "Use CompositionRoot.get_provider_registry() and pass the registry "
+        "explicitly to components that need it.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     global _PROVIDER_REGISTRY
     _PROVIDER_REGISTRY = registry
 
@@ -84,9 +105,22 @@ def set_provider_registry(registry: ProviderRegistryABC) -> None:
 def get_provider_registry() -> ProviderRegistryABC:
     """Access point for the provider registry.
 
+    DEPRECATED: Use dependency injection through CompositionRoot instead.
+
     Returns the global registry instance.
     Raises RuntimeError if the registry has not been initialized.
+
+    .. deprecated:: 2.0
+        Use CompositionRoot.get_provider_registry() and pass the registry
+        explicitly to components that need it.
     """
+    warnings.warn(
+        "get_provider_registry() is deprecated. "
+        "Use CompositionRoot.get_provider_registry() and pass the registry "
+        "explicitly to components that need it.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     if _PROVIDER_REGISTRY is None:
         raise RuntimeError(
             "Provider registry has not been initialized. "
@@ -97,8 +131,24 @@ def get_provider_registry() -> ProviderRegistryABC:
 
 # Backward compatibility alias
 def default_provider_registry() -> ProviderRegistryABC:
-    """DEPRECATED: Use get_provider_registry() instead."""
-    return get_provider_registry()
+    """DEPRECATED: Use get_provider_registry() instead.
+
+    .. deprecated:: 2.0
+        Use CompositionRoot.get_provider_registry() instead.
+    """
+    warnings.warn(
+        "default_provider_registry() is deprecated. "
+        "Use CompositionRoot.get_provider_registry() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    # Call without triggering double warning
+    if _PROVIDER_REGISTRY is None:
+        raise RuntimeError(
+            "Provider registry has not been initialized. "
+            "Call set_provider_registry() with a concrete implementation first."
+        )
+    return _PROVIDER_REGISTRY
 
 
 def __getattr__(name: str) -> Any:
@@ -119,6 +169,8 @@ __all__ = [
     "ProviderRegistryError",
     "ProviderNotRegisteredError",
     "ProviderAlreadyRegisteredError",
+    # Type aliases for DI
+    "ProviderRegistryFactory",
     # Factory function
     "get_provider_registry",
     "set_provider_registry",

--- a/src/bioetl/infrastructure/clients/base/abc_impls.yaml
+++ b/src/bioetl/infrastructure/clients/base/abc_impls.yaml
@@ -119,22 +119,9 @@ SecretProviderABC:
   implementations:
     Env: bioetl.infrastructure.clients.base.factories.EnvSecretProviderImpl
 
-PipelineContainerABC:
-  default_factory: bioetl.application.container.create_default_container_factory
-  implementations:
-    Default: bioetl.application.container.PipelineContainer
-
-PipelineHookABC:
-  default_factory: bioetl.application.factories.hooks.PipelineHookFactory
-  implementations:
-    Logging: bioetl.application.pipelines.hooks_impl.LoggingPipelineHookImpl
-    Metrics: bioetl.application.pipelines.hooks_impl.MetricsPipelineHookImpl
-
-ErrorPolicyABC:
-  default_factory: bioetl.application.pipelines.hooks_impl.FailFastErrorPolicyImpl
-  implementations:
-    FailFast: bioetl.application.pipelines.hooks_impl.FailFastErrorPolicyImpl
-    ContinueOnError: bioetl.application.pipelines.hooks_impl.ContinueOnErrorPolicyImpl
+# NOTE: Application layer implementations (PipelineContainerABC, PipelineHookABC,
+# ErrorPolicyABC) have been moved to interfaces/abc_impls_application.yaml
+# to maintain layer boundary integrity.
 
 ProviderRegistryABC:
   default_factory: bioetl.domain.provider_registry.default_provider_registry

--- a/src/bioetl/infrastructure/clients/base/abc_registry_resolver.py
+++ b/src/bioetl/infrastructure/clients/base/abc_registry_resolver.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import importlib
 from pathlib import Path
 from typing import Any, Callable
@@ -57,14 +57,33 @@ def _import_from_path(dotted_path: str) -> Any:
 
 @dataclass
 class ABCRegistryResolverImpl:
-    """Resolves ABC registry definitions and factories/implementations."""
+    """Resolves ABC registry definitions and factories/implementations.
+
+    Supports loading multiple implementation YAML files and merging them.
+    This allows layer separation where infrastructure implementations are
+    defined in infrastructure layer and application implementations are
+    defined in interfaces layer.
+
+    Args:
+        registry_path: Path to the ABC registry definitions YAML.
+        impls_path: Path to the primary implementations YAML (infrastructure).
+        additional_impls_paths: Optional list of additional implementation YAML
+            files to merge (e.g., application layer implementations).
+    """
 
     registry_path: Path = Path(__file__).with_name("abc_registry.yaml")
     impls_path: Path = Path(__file__).with_name("abc_impls.yaml")
+    additional_impls_paths: list[Path] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         self._registry = self._load_yaml(self.registry_path)
         self._impls = self._load_yaml(self.impls_path)
+
+        # Merge additional implementation files if provided
+        for additional_path in self.additional_impls_paths:
+            if additional_path.exists():
+                additional_impls = self._load_yaml(additional_path)
+                self._impls.update(additional_impls)
 
     def resolve_default_factory(self, role: str) -> Callable[..., Any]:
         """Return default factory callable for the given role."""

--- a/src/bioetl/infrastructure/files/csv_record_source.py
+++ b/src/bioetl/infrastructure/files/csv_record_source.py
@@ -1,8 +1,0 @@
-"""Module removed. Use bioetl.application.files.csv_record_source instead."""
-
-from __future__ import annotations
-
-raise ImportError(
-    "bioetl.infrastructure.files.csv_record_source has been removed. "
-    "Use bioetl.application.files.csv_record_source instead."
-)

--- a/src/bioetl/interfaces/abc_impls_application.yaml
+++ b/src/bioetl/interfaces/abc_impls_application.yaml
@@ -1,0 +1,23 @@
+# Application layer implementations for ABC registry.
+# These are loaded separately from infrastructure abc_impls.yaml to maintain
+# layer boundary integrity (infrastructure should not reference application).
+#
+# This file is loaded by the CompositionRoot in the interfaces layer,
+# which has access to all layers.
+
+PipelineContainerABC:
+  default_factory: bioetl.application.container.create_default_container_factory
+  implementations:
+    Default: bioetl.application.container.PipelineContainer
+
+PipelineHookABC:
+  default_factory: bioetl.application.factories.hooks.PipelineHookFactory
+  implementations:
+    Logging: bioetl.application.pipelines.hooks_impl.LoggingPipelineHookImpl
+    Metrics: bioetl.application.pipelines.hooks_impl.MetricsPipelineHookImpl
+
+ErrorPolicyABC:
+  default_factory: bioetl.application.pipelines.hooks_impl.FailFastErrorPolicyImpl
+  implementations:
+    FailFast: bioetl.application.pipelines.hooks_impl.FailFastErrorPolicyImpl
+    ContinueOnError: bioetl.application.pipelines.hooks_impl.ContinueOnErrorPolicyImpl

--- a/src/bioetl/interfaces/composition_root.py
+++ b/src/bioetl/interfaces/composition_root.py
@@ -111,6 +111,44 @@ class CompositionRoot:
         self._http_session_factory = http_session_factory or requests.Session
         self._schema_contract_provider = schema_contract_provider
 
+        # Lazy-loaded provider registry
+        self._provider_registry: ProviderRegistryABC | None = None
+
+    # =========================================================================
+    # Provider Registry
+    # =========================================================================
+
+    def get_provider_registry(self) -> ProviderRegistryABC:
+        """Get or create the provider registry instance.
+
+        This method creates and bootstraps the provider registry lazily.
+        The registry is cached for subsequent calls.
+
+        This is the preferred method for obtaining a provider registry,
+        replacing the deprecated global get_provider_registry() function.
+
+        Returns:
+            Configured ProviderRegistryABC instance.
+
+        Example:
+            >>> root = CompositionRoot()
+            >>> registry = root.get_provider_registry()
+            >>> provider = registry.get_provider(ProviderId("chembl"))
+        """
+        if self._provider_registry is None:
+            from bioetl.infrastructure.config.provider_registry import (
+                ProviderRegistryLoader,
+            )
+            from bioetl.infrastructure.provider_registry import (
+                InMemoryProviderRegistry,
+            )
+
+            self._provider_registry = InMemoryProviderRegistry()
+            loader = ProviderRegistryLoader()
+            loader.get_providers(registry=self._provider_registry)
+
+        return self._provider_registry
+
     # =========================================================================
     # Observability
     # =========================================================================
@@ -281,7 +319,11 @@ class CompositionRoot:
             ABCRegistryResolver,
         )
 
-        resolver = ABCRegistryResolver()
+        # Create resolver with both infrastructure and application YAML files
+        application_impls_path = Path(__file__).parent / "abc_impls_application.yaml"
+        resolver = ABCRegistryResolver(
+            additional_impls_paths=[application_impls_path]
+        )
 
         # Resolve factories from registry
         loader_factory = resolver.resolve_default_factory("LoaderABC")

--- a/tests/architecture/test_architecture_rules.py
+++ b/tests/architecture/test_architecture_rules.py
@@ -227,3 +227,36 @@ def test_no_untracked_duplicate_class_names() -> None:
             f"{name}: {sorted(paths)}" for name, paths in sorted(duplicates.items())
         ]
         pytest.fail("Potential duplicate classes detected:\n" + "\n".join(formatted))
+
+
+def test_infrastructure_abc_impls_has_no_application_references() -> None:
+    """Verify infrastructure abc_impls.yaml doesn't reference application layer.
+
+    Application-layer implementations should be defined in interfaces layer
+    (interfaces/abc_impls_application.yaml) to maintain proper layer boundaries.
+    Infrastructure layer must not know about application layer.
+    """
+    impls_path = (
+        BIOETL_ROOT / "infrastructure" / "clients" / "base" / "abc_impls.yaml"
+    )
+    data = yaml.safe_load(impls_path.read_text(encoding="utf-8"))
+
+    violations: list[str] = []
+    for role, config in data.items():
+        if not isinstance(config, dict):
+            continue
+
+        default_factory = config.get("default_factory", "")
+        if "bioetl.application" in default_factory:
+            violations.append(f"{role}.default_factory -> {default_factory}")
+
+        for impl_name, impl_path in config.get("implementations", {}).items():
+            if "bioetl.application" in impl_path:
+                violations.append(f"{role}.implementations.{impl_name} -> {impl_path}")
+
+    if violations:
+        pytest.fail(
+            "Infrastructure abc_impls.yaml must not reference application layer.\n"
+            "Application implementations should be in interfaces/abc_impls_application.yaml.\n"
+            "Violations:\n" + "\n".join(f"  - {v}" for v in violations)
+        )

--- a/tests/bioetl/infrastructure/test_deprecation_warnings.py
+++ b/tests/bioetl/infrastructure/test_deprecation_warnings.py
@@ -58,19 +58,21 @@ class TestConfigModelsDeprecation:
         assert hasattr(models, "HttpClientConfig")
 
 
-class TestCsvRecordSourceDeprecation:
-    """Tests for bioetl.infrastructure.files.csv_record_source deprecation."""
+class TestCsvRecordSourceRemoval:
+    """Tests verifying bioetl.infrastructure.files.csv_record_source is fully removed."""
 
-    def test_csv_record_source_deprecation_warning(self) -> None:
-        """Importing from infrastructure.files.csv_record_source raises ImportError."""
+    def test_csv_record_source_module_not_found(self) -> None:
+        """Importing from infrastructure.files.csv_record_source raises ModuleNotFoundError.
+
+        The module has been completely removed (not just deprecated).
+        Users should import from bioetl.application.files.csv_record_source instead.
+        """
         module_name = "bioetl.infrastructure.files.csv_record_source"
         if module_name in sys.modules:
             del sys.modules[module_name]
 
-        with pytest.raises(ImportError, match="has been removed"):
+        with pytest.raises(ModuleNotFoundError):
             importlib.import_module(module_name)
-
-    # test_csv_record_source_exports_available removed as module is removed
 
 
 class TestConstantsDeprecation:


### PR DESCRIPTION
…efactoring

This commit implements the critical and high-priority phases from the merged refactoring plan to improve layer boundary integrity.

Phase 1 - Layer Boundary Violations:
- Remove csv_record_source.py proxy from infrastructure layer
- Verify InMemoryProviderRegistry proxy correctly prevents domain imports
- Update .importlinter to remove obsolete exceptions

Phase 2 - Application/Infrastructure Decoupling:
- Add ProviderRegistryFactory type alias to domain layer
- Refactor orchestrator.py to accept factory via DI instead of direct imports
- Move InMemoryProviderRegistry instantiation to lazy import for BC

Phase 3 - ABC Registry Reorganization:
- Create interfaces/abc_impls_application.yaml for application implementations
- Remove application references from infrastructure/abc_impls.yaml
- Update ABCRegistryResolverImpl to support multiple YAML paths
- Update composition_root.py to load both YAML files

Phase 4 - Global State Deprecation:
- Add deprecation warnings to set_provider_registry() and get_provider_registry()
- Add get_provider_registry() method to CompositionRoot
- Document migration path to dependency injection

Tests:
- Add test_infrastructure_abc_impls_has_no_application_references()
- Update deprecation warning tests for csv_record_source removal

These changes maintain backward compatibility while encouraging migration to proper DI patterns through CompositionRoot.