### PR TITLE
Implement refactoring plan for bioactivity data

### DIFF
--- a/docs/architecture/DEPENDENCY_FLOW.md
+++ b/docs/architecture/DEPENDENCY_FLOW.md
@@ -1,0 +1,211 @@
+# Dependency Flow Documentation
+
+This document describes the dependency injection flow and composition patterns
+used in BioETL after the refactoring to eliminate global state.
+
+## Overview
+
+BioETL follows the Composition Root pattern where all dependencies are assembled
+in a single location (`CompositionRoot`). This eliminates global mutable state
+and makes the system more testable and maintainable.
+
+## Dependency Graph
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         INTERFACES LAYER                            │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                     │
+│  CompositionRoot                                                    │
+│  ├── ObservabilityFactory → Logger, Metrics                        │
+│  ├── InfrastructureFactory → Loader, Validator, MetadataBuilder    │
+│  ├── ProviderRegistry                                              │
+│  └── SchemaContractProvider                                        │
+│           │                                                        │
+│           ▼                                                        │
+│  SchemaContractLoader ──────────────────┐                          │
+│           │                             │                          │
+│           ▼                             ▼                          │
+│  PipelineContainer ◄─────────── PipelineConfig                     │
+│  ├── ValidationService                                             │
+│  ├── ExtractionService                                             │
+│  ├── NormalizationService                                          │
+│  ├── HashService                                                   │
+│  ├── IndexGenerator                                                │
+│  ├── TimestampProvider                                             │
+│  ├── SchemaContract ←──────── get_schema_contract()                │
+│  └── Loader                                                        │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                         APPLICATION LAYER                           │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                     │
+│  PipelineFactory.create(container)                                  │
+│           │                                                        │
+│           ▼                                                        │
+│  PipelineBase                                                       │
+│  ├── config: PipelineConfig                                        │
+│  ├── logger: LoggingPortABC                                        │
+│  ├── validation_service: ValidationService                         │
+│  ├── loader: LoaderABC                                             │
+│  ├── schema_contract: PipelineSchemaModel  ←── INJECTED           │
+│  ├── extractor: ExtractorABC                                       │
+│  ├── transformer: TransformerABC                                   │
+│  └── post_transformer: TransformerABC                              │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                           DOMAIN LAYER                              │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                     │
+│  PipelineSchemaModel (Immutable data class)                        │
+│  ├── pipeline_code: str                                            │
+│  ├── schema_out: str                                               │
+│  ├── schema_in: str | None                                         │
+│  └── output_schema: str | None                                     │
+│                                                                     │
+│  PIPELINE_CONTRACTS (Static registry - read-only)                  │
+│  get_pipeline_contract() → PipelineSchemaModel                     │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Key Changes from Refactoring
+
+### 1. Global State Elimination
+
+**Before:**
+```python
+# Global mutable state (REMOVED)
+_SCHEMA_CONTRACT_PROVIDER: SchemaContractProviderABC | None = None
+
+def set_schema_contract_provider(provider):
+    global _SCHEMA_CONTRACT_PROVIDER
+    _SCHEMA_CONTRACT_PROVIDER = provider
+```
+
+**After:**
+```python
+# Explicit dependency injection via CompositionRoot
+root = CompositionRoot()
+provider = root.get_schema_contract_provider()
+loader = SchemaContractLoader(provider)
+```
+
+### 2. Schema Contract Injection
+
+**Before:**
+```python
+class PipelineBase:
+    def __init__(self, config, ...):
+        # Called domain function directly
+        self._schema_contract = get_pipeline_contract(config.id)
+```
+
+**After:**
+```python
+class PipelineBase:
+    def __init__(self, config, schema_contract: PipelineSchemaModel, ...):
+        # Schema contract is injected
+        self._schema_contract = schema_contract
+
+# Container provides schema contract
+container.get_schema_contract()  # Returns PipelineSchemaModel
+```
+
+### 3. CompositionRoot Simplification
+
+**Before:**
+```python
+root = CompositionRoot(
+    logger=mock_logger,      # Direct instance injection
+    metrics=mock_metrics,    # Direct instance injection
+)
+```
+
+**After:**
+```python
+# Use factory pattern
+class MockObservabilityFactory(ObservabilityFactoryABC):
+    def create_logger(self) -> LoggingPortABC:
+        return mock_logger
+    def create_metrics(self) -> MetricsPortABC:
+        return mock_metrics
+
+root = CompositionRoot(observability_factory=MockObservabilityFactory())
+```
+
+## Dependency Resolution Order
+
+1. **CompositionRoot** creates infrastructure factories
+2. **Factories** create services (Logger, Metrics, Loader, etc.)
+3. **PipelineContainer** assembles pipeline-specific dependencies
+4. **PipelineFactory** creates pipeline with all dependencies injected
+5. **Pipeline** runs with fully resolved dependency graph
+
+## Testing
+
+For testing, create mock implementations of factory protocols:
+
+```python
+from bioetl.interfaces.factories import ObservabilityFactoryABC
+
+class TestObservabilityFactory(ObservabilityFactoryABC):
+    def __init__(self, logger: LoggingPortABC, metrics: MetricsPortABC):
+        self._logger = logger
+        self._metrics = metrics
+
+    def create_logger(self) -> LoggingPortABC:
+        return self._logger
+
+    def create_metrics(self) -> MetricsPortABC:
+        return self._metrics
+
+# Usage in tests
+root = CompositionRoot(
+    observability_factory=TestObservabilityFactory(mock_logger, mock_metrics)
+)
+```
+
+## Migration Guide
+
+### For Legacy Code
+
+Use the adapter function for backward compatibility:
+
+```python
+from bioetl.interfaces.legacy_adapters import create_composition_root_with_legacy
+
+# Deprecated but still works
+root = create_composition_root_with_legacy(
+    logger=mock_logger,
+    metrics=mock_metrics,
+)
+```
+
+### For New Code
+
+Use the factory-based API:
+
+```python
+from bioetl.interfaces.composition_root import CompositionRoot
+from bioetl.interfaces.factories import ObservabilityFactoryABC
+
+class MyFactory(ObservabilityFactoryABC):
+    ...
+
+root = CompositionRoot(observability_factory=MyFactory())
+```
+
+## Architecture Principles
+
+1. **No Global State**: All state is encapsulated in instances
+2. **Explicit Dependencies**: All dependencies are passed explicitly
+3. **Composition Root**: Single assembly point for dependency graph
+4. **Factory Pattern**: Factories create instances, not direct construction
+5. **Immutable Domain**: Domain objects are immutable data classes

--- a/src/bioetl/application/container.py
+++ b/src/bioetl/application/container.py
@@ -58,6 +58,10 @@ from bioetl.domain.pipelines.contracts import ErrorPolicyABC, LoaderABC, Pipelin
 from bioetl.domain.provider_registry import ProviderRegistryABC
 from bioetl.domain.providers import ProviderDefinition, ProviderId
 from bioetl.domain.record_source import RecordSourceABC
+from bioetl.domain.schemas.pipeline_contracts import (
+    PipelineSchemaModel,
+    get_pipeline_contract,
+)
 from bioetl.domain.transform.contracts import (
     HashServiceABC,
     IndexGeneratorABC,
@@ -267,6 +271,24 @@ class PipelineContainer(PipelineContainerABC):
     def get_error_policy(self) -> ErrorPolicyABC:
         """Return the error handling policy for pipeline stages."""
         return self._runtime_factory.get_error_policy()
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Schema Contract
+    # ─────────────────────────────────────────────────────────────────────────
+
+    def get_schema_contract(self) -> PipelineSchemaModel:
+        """Return schema contract for the pipeline.
+
+        Uses the pipeline configuration to look up the appropriate schema contract
+        from the domain registry.
+
+        Returns:
+            PipelineSchemaModel for the current pipeline configuration.
+        """
+        return get_pipeline_contract(
+            self._config.id,
+            default_entity=self._config.entity_name,
+        )
 
     # ─────────────────────────────────────────────────────────────────────────
     # Private Factory Accessors

--- a/src/bioetl/application/contracts.py
+++ b/src/bioetl/application/contracts.py
@@ -19,6 +19,7 @@ from bioetl.domain.pipelines.contracts import (
     PipelineHookABC,
 )
 from bioetl.domain.record_source import RecordSourceABC
+from bioetl.domain.schemas.pipeline_contracts import PipelineSchemaModel
 from bioetl.domain.transform.contracts import (
     HashServiceABC,
     IndexGeneratorABC,
@@ -125,6 +126,17 @@ class PipelineContainerABC(ABC):
     @abstractmethod
     def get_metadata_builder(self) -> RunMetadataBuilderProtocol:
         """Return builder for run metadata artifacts."""
+
+    @abstractmethod
+    def get_schema_contract(self) -> PipelineSchemaModel:
+        """Return schema contract for the pipeline.
+
+        The schema contract defines input/output schemas for the pipeline,
+        ensuring consistent validation and data flow.
+
+        Returns:
+            PipelineSchemaModel for the current pipeline configuration.
+        """
 
 
 class PipelineFactoryABC(ABC):

--- a/src/bioetl/application/pipelines/base.py
+++ b/src/bioetl/application/pipelines/base.py
@@ -60,7 +60,7 @@ from bioetl.domain.pipelines.contracts import (
     PipelineHookABC,
 )
 from bioetl.domain.providers import ProviderId
-from bioetl.domain.schemas.pipeline_contracts import get_pipeline_contract
+from bioetl.domain.schemas.pipeline_contracts import PipelineSchemaModel
 from bioetl.domain.transform.contracts import (
     HashServiceABC,
     IndexGeneratorABC,
@@ -97,6 +97,7 @@ class PipelineBase(ABC):
         hash_service: HashServiceABC,
         index_generator: IndexGeneratorABC,
         timestamp_provider: TimestampProviderABC,
+        schema_contract: PipelineSchemaModel,
         metadata_builder: RunMetadataBuilderProtocol | None = None,
         extractor: ExtractorABC | None = None,
         hooks: list[PipelineHookABC] | None = None,
@@ -116,6 +117,7 @@ class PipelineBase(ABC):
         self._hash_service = hash_service
         self._index_generator = index_generator
         self._timestamp_provider = timestamp_provider
+        self._schema_contract = schema_contract
         self._metadata_builder = metadata_builder or DefaultRunMetadataBuilder()
         self._extractor = extractor
         self._transformer = transformer
@@ -129,9 +131,6 @@ class PipelineBase(ABC):
                 business_key_fields=business_key_fields,
                 version_provider=self.get_version,
             )
-        self._schema_contract = get_pipeline_contract(
-            config.id, default_entity=config.entity_name
-        )
         from bioetl.application.pipelines.hooks_impl import (  # pylint: disable=import-outside-toplevel
             FailFastErrorPolicyImpl,
         )

--- a/src/bioetl/application/pipelines/chembl/base.py
+++ b/src/bioetl/application/pipelines/chembl/base.py
@@ -29,7 +29,7 @@ from bioetl.domain.ports.extraction import (
     ExtractionServiceABC,
 )
 from bioetl.domain.record_source import RecordSourceABC
-from bioetl.domain.schemas.pipeline_contracts import get_pipeline_contract
+from bioetl.domain.schemas.pipeline_contracts import PipelineSchemaModel
 from bioetl.domain.services.version_formatter import format_chembl_version
 from bioetl.domain.transform.contracts import (
     HashServiceABC,
@@ -54,6 +54,7 @@ class ChemblPipelineBase(PipelineBase):
         index_generator: IndexGeneratorABC,
         timestamp_provider: TimestampProviderABC,
         entity_model_registry: EntityModelRegistryABC,
+        schema_contract: PipelineSchemaModel,
         loader: LoaderABC | None = None,
         metadata_builder: RunMetadataBuilderProtocol | None = None,
         normalization_service: NormalizationServiceABC | None = None,
@@ -82,12 +83,10 @@ class ChemblPipelineBase(PipelineBase):
             record_source=record_source,
         )
 
-        # Create Transformer
-        # Need schema contract
-        contract = get_pipeline_contract(config.id, default_entity=config.entity_name)
+        # Create Transformer with injected schema contract
         transformer = ChemblTransformerImpl(
             validation_service=validation_service,
-            schema_contract=contract,
+            schema_contract=schema_contract,
             normalization_service=norm_service,
             logger=logger,
             serialization_mode=config.serialization_mode,
@@ -105,6 +104,7 @@ class ChemblPipelineBase(PipelineBase):
             hash_service=hash_service,
             index_generator=index_generator,
             timestamp_provider=timestamp_provider,
+            schema_contract=schema_contract,
             metadata_builder=metadata_builder,
             extractor=extractor,
             hooks=hooks,

--- a/src/bioetl/application/pipelines/chembl/factories.py
+++ b/src/bioetl/application/pipelines/chembl/factories.py
@@ -55,6 +55,7 @@ class ChemblPipelineFactory(PipelineFactoryABC):
             index_generator=container.get_index_generator(),
             timestamp_provider=container.get_timestamp_provider(),
             entity_model_registry=container.get_entity_model_registry(),
+            schema_contract=container.get_schema_contract(),
             metadata_builder=container.get_metadata_builder(),
             normalization_service=container.get_normalization_service(),
             hooks=container.get_hooks(),

--- a/src/bioetl/infrastructure/config/loader.py
+++ b/src/bioetl/infrastructure/config/loader.py
@@ -3,23 +3,21 @@
 This module provides pipeline configuration loading functionality with support
 for dependency injection of schema contract providers.
 
-Preferred usage (DI approach):
+Usage (DI approach - recommended):
     >>> from bioetl.interfaces.composition_root import get_composition_root
     >>> root = get_composition_root()
     >>> loader = root.create_schema_contract_loader()
     >>> config = loader.get_pipeline_config("chembl.activity")
 
-Legacy usage (deprecated, will be removed):
+Alternative (explicit provider):
     >>> from bioetl.infrastructure.config.loader import get_pipeline_config
-    >>> set_schema_contract_provider(provider)  # deprecated
-    >>> config = get_pipeline_config("chembl.activity")
+    >>> config = get_pipeline_config("chembl.activity", schema_contract_provider=provider)
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Iterable
-import warnings
 
 from pydantic import ValidationError
 
@@ -189,14 +187,14 @@ class SchemaContractLoader:
 
 
 # ============================================================================
-# Module-level functions (use explicit provider or deprecated global state)
+# Module-level functions (require explicit provider)
 # ============================================================================
 
 
 def get_pipeline_config(
     pipeline_id: str,
     *,
-    schema_contract_provider: SchemaContractProviderABC | None = None,
+    schema_contract_provider: SchemaContractProviderABC,
     profile: str | None = None,
     cli_overrides: dict[str, Any] | None = None,
     env_overrides: dict[str, Any] | None = None,
@@ -206,8 +204,7 @@ def get_pipeline_config(
 
     Args:
         pipeline_id: Pipeline identifier (e.g., "chembl.activity").
-        schema_contract_provider: Schema provider. If None, uses
-            global provider (deprecated) or raises RuntimeError.
+        schema_contract_provider: Schema provider (required).
         profile: Profile name to apply.
         cli_overrides: CLI overrides.
         env_overrides: Environment variable overrides.
@@ -218,9 +215,9 @@ def get_pipeline_config(
 
     Raises:
         ConfigFileNotFoundError: Configuration file not found.
-        RuntimeError: SchemaContractProvider not initialized.
+        ValueError: If schema_contract_provider is not provided.
     """
-    effective_provider = _resolve_schema_provider(schema_contract_provider)
+    effective_provider = _require_schema_provider(schema_contract_provider)
 
     try:
         config_path, raw_config = get_yaml_for_pipeline(
@@ -245,7 +242,7 @@ def get_pipeline_config(
 def get_pipeline_config_from_path(
     config_path: str | Path,
     *,
-    schema_contract_provider: SchemaContractProviderABC | None = None,
+    schema_contract_provider: SchemaContractProviderABC,
     profile: str | None = None,
     profiles_root: str | Path | None = None,
     cli_overrides: dict[str, Any] | None = None,
@@ -255,8 +252,7 @@ def get_pipeline_config_from_path(
 
     Args:
         config_path: Path to configuration file.
-        schema_contract_provider: Schema provider. If None, uses
-            global provider (deprecated) or raises RuntimeError.
+        schema_contract_provider: Schema provider (required).
         profile: Profile name to apply.
         profiles_root: Profiles root directory.
         cli_overrides: CLI overrides.
@@ -267,9 +263,9 @@ def get_pipeline_config_from_path(
 
     Raises:
         ConfigFileNotFoundError: Configuration file not found.
-        RuntimeError: SchemaContractProvider not initialized.
+        ValueError: If schema_contract_provider is not provided.
     """
-    effective_provider = _resolve_schema_provider(schema_contract_provider)
+    effective_provider = _require_schema_provider(schema_contract_provider)
 
     try:
         path, raw_config = get_yaml_from_path(
@@ -361,193 +357,27 @@ def _ensure_provider_registered(provider_id: str) -> None:
         ) from exc
 
 
-# ============================================================================
-# DEPRECATED: Global state for backward compatibility
-# These will be removed in a future release. Pass schema_contract_provider
-# explicitly to get_pipeline_config() and get_pipeline_config_from_path().
-# ============================================================================
-
-_SCHEMA_CONTRACT_PROVIDER: SchemaContractProviderABC | None = None
-
-
-def _resolve_schema_provider(
+def _require_schema_provider(
     explicit_provider: SchemaContractProviderABC | None,
 ) -> SchemaContractProviderABC:
-    """Resolve the schema provider to use, with deprecation warning for global state.
+    """Require explicit schema provider (no global fallback).
 
     Args:
         explicit_provider: Explicitly provided schema contract provider.
 
     Returns:
-        The provider to use (explicit or global fallback).
+        The provider to use.
 
     Raises:
-        RuntimeError: If no provider is available.
+        ValueError: If no provider is provided.
     """
-    if explicit_provider is not None:
-        return explicit_provider
-
-    # Fallback to global state (deprecated)
-    if _SCHEMA_CONTRACT_PROVIDER is not None:
-        warnings.warn(
-            "Using global SchemaContractProvider is deprecated. "
-            "Pass schema_contract_provider explicitly to get_pipeline_config() "
-            "or get_pipeline_config_from_path(). "
-            "Global state will be removed in a future release.",
-            DeprecationWarning,
-            stacklevel=4,
+    if explicit_provider is None:
+        raise ValueError(
+            "schema_contract_provider is required. "
+            "Use CompositionRoot.create_schema_contract_loader() for DI-based loading "
+            "or pass schema_contract_provider explicitly."
         )
-        return _SCHEMA_CONTRACT_PROVIDER
-
-    raise RuntimeError(
-        "SchemaContractProvider not initialized. "
-        "Pass schema_contract_provider parameter explicitly or "
-        "call set_schema_contract_provider() for legacy compatibility."
-    )
-
-
-def set_schema_contract_provider(provider: SchemaContractProviderABC) -> None:
-    """Set the global schema contract provider.
-
-    .. deprecated::
-        Global state injection is deprecated. Pass schema_contract_provider
-        explicitly to get_pipeline_config() and get_pipeline_config_from_path()
-        instead. This function will be removed in a future release.
-
-    Args:
-        provider: Configured SchemaContractProviderABC instance.
-
-    Example:
-        >>> from bioetl.application.services import SchemaContractProviderImpl
-        >>> from bioetl.domain.schemas.registry import get_default_schema_registry
-        >>> provider = SchemaContractProviderImpl(get_default_schema_registry())
-        >>> set_schema_contract_provider(provider)  # deprecated
-    """
-    warnings.warn(
-        "set_schema_contract_provider() is deprecated. "
-        "Pass schema_contract_provider explicitly to get_pipeline_config() "
-        "or get_pipeline_config_from_path(). "
-        "This function will be removed in a future release.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    global _SCHEMA_CONTRACT_PROVIDER  # noqa: PLW0603
-    _SCHEMA_CONTRACT_PROVIDER = provider
-
-
-def get_schema_contract_provider() -> SchemaContractProviderABC | None:
-    """Get the current schema contract provider.
-
-    .. deprecated::
-        Global state access is deprecated. Use explicit provider injection instead.
-
-    Returns:
-        The configured schema contract provider, or None if not set.
-    """
-    warnings.warn(
-        "get_schema_contract_provider() is deprecated. "
-        "Use explicit provider injection instead. "
-        "This function will be removed in a future release.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return _SCHEMA_CONTRACT_PROVIDER
-
-
-def clear_schema_contract_provider() -> None:
-    """Clear the global schema contract provider (for testing).
-
-    .. deprecated::
-        Global state management is deprecated.
-
-    This resets the provider to None, useful for test isolation.
-    """
-    warnings.warn(
-        "clear_schema_contract_provider() is deprecated. "
-        "Use explicit provider injection instead. "
-        "This function will be removed in a future release.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    global _SCHEMA_CONTRACT_PROVIDER  # noqa: PLW0603
-    _SCHEMA_CONTRACT_PROVIDER = None
-
-
-def reset_schema_contract_provider() -> None:
-    """Reset the schema contract provider (for testing purposes).
-
-    .. deprecated::
-        Use clear_schema_contract_provider() instead.
-        This function is kept for backward compatibility.
-    """
-    warnings.warn(
-        "reset_schema_contract_provider() is deprecated. "
-        "Use explicit provider injection instead. "
-        "This function will be removed in a future release.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    _clear_provider_internal()
-
-
-def _clear_provider_internal() -> None:
-    """Internal function to clear provider without deprecation warning.
-
-    Used for test cleanup and internal state management.
-    """
-    global _SCHEMA_CONTRACT_PROVIDER  # noqa: PLW0603
-    _SCHEMA_CONTRACT_PROVIDER = None
-
-
-def _set_provider_internal(provider: SchemaContractProviderABC) -> None:
-    """Internal function to set provider without deprecation warning.
-
-    Used for backward compatibility in container bootstrap.
-    Will be removed when global state is fully deprecated.
-    """
-    global _SCHEMA_CONTRACT_PROVIDER  # noqa: PLW0603
-    _SCHEMA_CONTRACT_PROVIDER = provider
-
-
-def create_schema_contract_loader(
-    schema_contract_provider: SchemaContractProviderABC | None = None,
-) -> SchemaContractLoader:
-    """Create a SchemaContractLoader with the given or global provider.
-
-    .. deprecated::
-        This factory function is deprecated. Use dependency injection
-        via CompositionRoot.create_schema_contract_loader() instead,
-        or instantiate SchemaContractLoader directly with an explicit provider.
-
-    Args:
-        schema_contract_provider: Provider for schema contracts.
-            If None, falls back to global state (deprecated).
-
-    Returns:
-        Configured SchemaContractLoader instance.
-
-    Raises:
-        RuntimeError: If no provider is available.
-
-    Example (deprecated):
-        >>> loader = create_schema_contract_loader()
-        >>> config = loader.get_pipeline_config("chembl.activity")
-
-    Preferred (DI approach):
-        >>> from bioetl.interfaces.composition_root import get_composition_root
-        >>> root = get_composition_root()
-        >>> loader = root.create_schema_contract_loader()
-    """
-    warnings.warn(
-        "create_schema_contract_loader() is deprecated. "
-        "Use CompositionRoot.create_schema_contract_loader() "
-        "or instantiate SchemaContractLoader directly with an explicit provider. "
-        "This function will be removed in a future release.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    effective_provider = _resolve_schema_provider(schema_contract_provider)
-    return SchemaContractLoader(effective_provider)
+    return explicit_provider
 
 
 def _populate_fields_from_schema(
@@ -707,16 +537,7 @@ __all__ = [
     # Exceptions
     "ConfigFileNotFoundError",
     "UnknownProviderError",
-    # Module-level functions (support explicit provider or deprecated global state)
+    # Module-level functions (require explicit provider)
     "get_pipeline_config",
     "get_pipeline_config_from_path",
-    # Deprecated functions (for backward compatibility, will be removed)
-    "create_schema_contract_loader",
-    "set_schema_contract_provider",
-    "get_schema_contract_provider",
-    "clear_schema_contract_provider",
-    "reset_schema_contract_provider",
-    # Internal functions (for container/test use during transition)
-    "_set_provider_internal",
-    "_clear_provider_internal",
 ]

--- a/src/bioetl/interfaces/bootstrap_factory.py
+++ b/src/bioetl/interfaces/bootstrap_factory.py
@@ -1,8 +1,7 @@
 """Factory for creating ApplicationBootstrap with infrastructure integration.
 
 This module provides factory functions for creating ApplicationBootstrap
-instances configured with infrastructure-layer components (config loaders,
-provider injection).
+instances configured with infrastructure-layer components (config loaders).
 
 The separation between application-layer bootstrap logic and infrastructure
 integration maintains clean architecture boundaries while providing a
@@ -24,8 +23,6 @@ from typing import Any, cast
 from bioetl.application.bootstrap import (
     ApplicationBootstrap,
     ConfigLoaderFactory,
-    ProviderClearer,
-    ProviderInjector,
 )
 from bioetl.domain.configs import PipelineConfig
 from bioetl.domain.configs.contracts import PipelineConfigLoaderProtocol
@@ -95,41 +92,11 @@ def _create_config_loader_factory() -> ConfigLoaderFactory:
     return factory
 
 
-def _create_provider_injector() -> ProviderInjector:
-    """Create a provider injector for backward compatibility.
-
-    Returns:
-        Callback function that injects the provider into infrastructure.
-    """
-    from bioetl.infrastructure.config.loader import _set_provider_internal
-
-    def injector(provider: SchemaContractProviderABC) -> None:
-        """Inject provider instance into infrastructure config loader."""
-        _set_provider_internal(provider)
-
-    return injector
-
-
-def _create_provider_clearer() -> ProviderClearer:
-    """Create a provider clearer for cleanup.
-
-    Returns:
-        Callback function that clears the provider from infrastructure.
-    """
-    from bioetl.infrastructure.config.loader import _clear_provider_internal
-
-    def clearer() -> None:
-        """Clear injected provider from infrastructure config loader."""
-        _clear_provider_internal()
-
-    return clearer
-
-
 def create_default_bootstrap() -> ApplicationBootstrap:
     """Create an ApplicationBootstrap with default infrastructure integration.
 
     This factory creates a fully configured ApplicationBootstrap instance
-    with config loader support and provider injection for backward compatibility.
+    with config loader support via explicit dependency injection.
 
     Returns:
         ApplicationBootstrap configured with infrastructure components.
@@ -143,8 +110,6 @@ def create_default_bootstrap() -> ApplicationBootstrap:
 
     return ApplicationBootstrap(
         config_loader_factory=_create_config_loader_factory(),
-        provider_injector=_create_provider_injector(),
-        provider_clearer=_create_provider_clearer(),
         schema_register_fn=register_schemas,
     )
 

--- a/src/bioetl/interfaces/composition_root.py
+++ b/src/bioetl/interfaces/composition_root.py
@@ -10,11 +10,26 @@ Usage:
     container = root.create_pipeline_container(config)
     config_loader = root.create_config_loader()
 
-    # For testing:
+    # For testing with custom observability (recommended):
+    from bioetl.interfaces.factories import ObservabilityFactoryABC
+
+    class MockObservabilityFactory(ObservabilityFactoryABC):
+        def create_logger(self) -> LoggingPortABC:
+            return mock_logger
+        def create_metrics(self) -> MetricsPortABC:
+            return mock_metrics
+
     root = CompositionRoot(
+        observability_factory=MockObservabilityFactory(),
+        schema_contract_provider=mock_provider,
+    )
+
+    # Legacy usage (deprecated - will be removed in future release):
+    # Use create_composition_root_with_legacy() for backward compatibility
+    from bioetl.interfaces.legacy_adapters import create_composition_root_with_legacy
+    root = create_composition_root_with_legacy(
         logger=mock_logger,
         metrics=mock_metrics,
-        schema_contract_provider=mock_provider,
     )
 """
 
@@ -70,20 +85,16 @@ class CompositionRoot:
         root = CompositionRoot()
         container = root.create_pipeline_container(config)
 
-        # Testing
-        root = CompositionRoot(logger=mock_logger, metrics=mock_metrics)
+        # Testing with custom factory (recommended)
+        root = CompositionRoot(observability_factory=MockObservabilityFactory())
         container = root.create_pipeline_container(config)
     """
 
     def __init__(
         self,
         *,
-        # New factory parameters
         observability_factory: ObservabilityFactoryABC | None = None,
         infrastructure_factory: InfrastructureFactoryABC | None = None,
-        # Legacy parameters (backward compatibility)
-        logger: LoggingPortABC | None = None,
-        metrics: MetricsPortABC | None = None,
         http_session_factory: type | None = None,
         schema_contract_provider: SchemaContractProviderABC | None = None,
     ) -> None:
@@ -95,9 +106,7 @@ class CompositionRoot:
                 (defaults to DefaultObservabilityFactory)
             infrastructure_factory: Factory for infrastructure components
                 (defaults to DefaultInfrastructureFactory)
-            logger: Custom logger implementation (backward compatibility)
-            metrics: Custom metrics implementation (backward compatibility)
-            http_session_factory: HTTP session factory class (backward compatibility)
+            http_session_factory: HTTP session factory class
             schema_contract_provider: Custom schema contract provider
                 (defaults to bootstrapped provider from schema registry)
         """
@@ -105,9 +114,6 @@ class CompositionRoot:
         self._observability = observability_factory or DefaultObservabilityFactory()
         self._infrastructure = infrastructure_factory or DefaultInfrastructureFactory()
 
-        # Explicit overrides (for BC and tests)
-        self._explicit_logger = logger
-        self._explicit_metrics = metrics
         self._http_session_factory = http_session_factory or requests.Session
         self._schema_contract_provider = schema_contract_provider
 
@@ -155,14 +161,10 @@ class CompositionRoot:
 
     def get_logger(self) -> LoggingPortABC:
         """Get or create the logger instance."""
-        if self._explicit_logger is not None:
-            return self._explicit_logger
         return self._observability.create_logger()
 
     def get_metrics(self) -> MetricsPortABC:
         """Get or create the metrics instance."""
-        if self._explicit_metrics is not None:
-            return self._explicit_metrics
         return self._observability.create_metrics()
 
     def get_observability_stack(self) -> ObservabilityStack:

--- a/src/bioetl/interfaces/legacy_adapters.py
+++ b/src/bioetl/interfaces/legacy_adapters.py
@@ -1,0 +1,147 @@
+"""Legacy adapters for backward compatibility.
+
+This module provides adapter functions that maintain backward compatibility
+with deprecated API patterns while emitting deprecation warnings.
+
+These adapters will be removed in a future release. Users should migrate
+to the new factory-based API.
+
+Migration guide:
+    Old (deprecated):
+        >>> root = CompositionRoot(logger=my_logger, metrics=my_metrics)
+
+    New (recommended):
+        >>> from bioetl.interfaces.factories import CustomObservabilityFactory
+        >>> class MyObservabilityFactory(ObservabilityFactoryABC):
+        ...     def create_logger(self) -> LoggingPortABC:
+        ...         return my_logger
+        ...     def create_metrics(self) -> MetricsPortABC:
+        ...         return my_metrics
+        >>> root = CompositionRoot(observability_factory=MyObservabilityFactory())
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING
+
+from bioetl.domain.observability import LoggingPortABC, MetricsPortABC
+from bioetl.domain.ports.schema import SchemaContractProviderABC
+from bioetl.interfaces.composition_root import CompositionRoot
+from bioetl.interfaces.factories import (
+    InfrastructureFactoryABC,
+    ObservabilityFactoryABC,
+)
+
+if TYPE_CHECKING:
+    pass
+
+
+class _LegacyObservabilityFactory(ObservabilityFactoryABC):
+    """Observability factory wrapping explicit logger/metrics instances.
+
+    This factory is used internally for backward compatibility when
+    legacy parameters (logger, metrics) are passed to CompositionRoot.
+    """
+
+    def __init__(
+        self,
+        logger: LoggingPortABC | None = None,
+        metrics: MetricsPortABC | None = None,
+        fallback_factory: ObservabilityFactoryABC | None = None,
+    ) -> None:
+        self._logger = logger
+        self._metrics = metrics
+        self._fallback = fallback_factory
+
+    def create_logger(self) -> LoggingPortABC:
+        """Return explicit logger or fallback to factory."""
+        if self._logger is not None:
+            return self._logger
+        if self._fallback is not None:
+            return self._fallback.create_logger()
+        from bioetl.interfaces.factories import DefaultObservabilityFactory
+
+        return DefaultObservabilityFactory().create_logger()
+
+    def create_metrics(self) -> MetricsPortABC:
+        """Return explicit metrics or fallback to factory."""
+        if self._metrics is not None:
+            return self._metrics
+        if self._fallback is not None:
+            return self._fallback.create_metrics()
+        from bioetl.interfaces.factories import DefaultObservabilityFactory
+
+        return DefaultObservabilityFactory().create_metrics()
+
+
+def create_composition_root_with_legacy(
+    *,
+    logger: LoggingPortABC | None = None,
+    metrics: MetricsPortABC | None = None,
+    observability_factory: ObservabilityFactoryABC | None = None,
+    infrastructure_factory: InfrastructureFactoryABC | None = None,
+    http_session_factory: type | None = None,
+    schema_contract_provider: SchemaContractProviderABC | None = None,
+) -> CompositionRoot:
+    """Create CompositionRoot with legacy parameter support.
+
+    .. deprecated::
+        The `logger` and `metrics` parameters are deprecated.
+        Use `observability_factory` instead.
+
+    This function provides backward compatibility for code that passes
+    explicit logger/metrics instances. It wraps them in a factory and
+    emits deprecation warnings.
+
+    Args:
+        logger: Deprecated. Use observability_factory instead.
+        metrics: Deprecated. Use observability_factory instead.
+        observability_factory: Factory for observability components.
+        infrastructure_factory: Factory for infrastructure components.
+        http_session_factory: HTTP session factory class.
+        schema_contract_provider: Custom schema contract provider.
+
+    Returns:
+        Configured CompositionRoot instance.
+
+    Example:
+        Old (deprecated):
+            >>> root = create_composition_root_with_legacy(
+            ...     logger=mock_logger,
+            ...     metrics=mock_metrics,
+            ... )
+
+        New (recommended):
+            >>> root = CompositionRoot(
+            ...     observability_factory=MyObservabilityFactory(),
+            ... )
+    """
+    if logger is not None or metrics is not None:
+        warnings.warn(
+            "logger/metrics parameters are deprecated. "
+            "Use observability_factory instead. "
+            "These parameters will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        # Create a factory that wraps the explicit instances
+        effective_factory = _LegacyObservabilityFactory(
+            logger=logger,
+            metrics=metrics,
+            fallback_factory=observability_factory,
+        )
+    else:
+        effective_factory = observability_factory
+
+    return CompositionRoot(
+        observability_factory=effective_factory,
+        infrastructure_factory=infrastructure_factory,
+        http_session_factory=http_session_factory,
+        schema_contract_provider=schema_contract_provider,
+    )
+
+
+__all__ = [
+    "create_composition_root_with_legacy",
+]

--- a/tests/integration/test_di_flow.py
+++ b/tests/integration/test_di_flow.py
@@ -1,0 +1,199 @@
+"""Integration tests for dependency injection flow.
+
+These tests verify the complete dependency injection graph from
+CompositionRoot to Pipeline creation without global state.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bioetl.domain.observability import LoggingPortABC, MetricsPortABC
+from bioetl.domain.schemas.pipeline_contracts import PipelineSchemaModel
+from bioetl.interfaces.composition_root import CompositionRoot
+from bioetl.interfaces.factories import ObservabilityFactoryABC
+
+
+class MockLogger(LoggingPortABC):
+    """Mock logger for testing."""
+
+    def debug(self, msg: str, **kwargs) -> None:
+        pass
+
+    def info(self, msg: str, **kwargs) -> None:
+        pass
+
+    def warning(self, msg: str, **kwargs) -> None:
+        pass
+
+    def error(self, msg: str, **kwargs) -> None:
+        pass
+
+    def critical(self, msg: str, **kwargs) -> None:
+        pass
+
+    def exception(self, msg: str, **kwargs) -> None:
+        pass
+
+    def apply_bind(self, **kwargs) -> "LoggingPortABC":
+        return self
+
+
+class MockMetrics(MetricsPortABC):
+    """Mock metrics for testing."""
+
+    def increment(self, name: str, value: int = 1, **tags) -> None:
+        pass
+
+    def gauge(self, name: str, value: float, **tags) -> None:
+        pass
+
+    def timing(self, name: str, value: float, **tags) -> None:
+        pass
+
+    def histogram(self, name: str, value: float, **tags) -> None:
+        pass
+
+
+class TestObservabilityFactory(ObservabilityFactoryABC):
+    """Test factory providing mock observability components."""
+
+    def __init__(self) -> None:
+        self._logger = MockLogger()
+        self._metrics = MockMetrics()
+
+    def create_logger(self) -> LoggingPortABC:
+        return self._logger
+
+    def create_metrics(self) -> MetricsPortABC:
+        return self._metrics
+
+
+class TestDIFlow:
+    """Test dependency injection flow integration."""
+
+    def test_composition_root_creates_schema_contract_provider(self) -> None:
+        """Verify CompositionRoot creates schema contract provider."""
+        root = CompositionRoot(
+            observability_factory=TestObservabilityFactory()
+        )
+
+        provider = root.get_schema_contract_provider()
+
+        assert provider is not None
+        # Provider should be cached
+        assert root.get_schema_contract_provider() is provider
+
+    def test_composition_root_creates_schema_contract_loader(self) -> None:
+        """Verify CompositionRoot creates schema contract loader."""
+        root = CompositionRoot(
+            observability_factory=TestObservabilityFactory()
+        )
+
+        loader = root.create_schema_contract_loader()
+
+        assert loader is not None
+        # Loader should be able to get config
+        # (requires actual infrastructure to be bootstrapped)
+
+    def test_composition_root_observability_from_factory(self) -> None:
+        """Verify CompositionRoot uses observability factory."""
+        factory = TestObservabilityFactory()
+        root = CompositionRoot(observability_factory=factory)
+
+        logger = root.get_logger()
+        metrics = root.get_metrics()
+
+        assert isinstance(logger, MockLogger)
+        assert isinstance(metrics, MockMetrics)
+
+    def test_composition_root_provides_provider_registry(self) -> None:
+        """Verify CompositionRoot provides provider registry."""
+        root = CompositionRoot(
+            observability_factory=TestObservabilityFactory()
+        )
+
+        registry = root.get_provider_registry()
+
+        assert registry is not None
+        # Registry should be cached
+        assert root.get_provider_registry() is registry
+
+    def test_no_global_state_in_loader_module(self) -> None:
+        """Verify loader module has no global state."""
+        from bioetl.infrastructure.config import loader
+
+        # These should not exist in __all__
+        assert "set_schema_contract_provider" not in loader.__all__
+        assert "get_schema_contract_provider" not in loader.__all__
+        assert "_set_provider_internal" not in loader.__all__
+        assert "_clear_provider_internal" not in loader.__all__
+
+
+class TestSchemaContractInjection:
+    """Test schema contract injection into pipeline components."""
+
+    def test_get_pipeline_contract_returns_model(self) -> None:
+        """Verify get_pipeline_contract returns PipelineSchemaModel."""
+        from bioetl.domain.schemas.pipeline_contracts import get_pipeline_contract
+
+        contract = get_pipeline_contract("chembl.activity")
+
+        assert isinstance(contract, PipelineSchemaModel)
+        assert contract.pipeline_code == "chembl.activity"
+
+    def test_get_pipeline_contract_uses_default_for_unknown(self) -> None:
+        """Verify get_pipeline_contract creates default for unknown pipeline."""
+        from bioetl.domain.schemas.pipeline_contracts import get_pipeline_contract
+
+        contract = get_pipeline_contract(
+            "unknown.pipeline",
+            default_entity="my_entity"
+        )
+
+        assert isinstance(contract, PipelineSchemaModel)
+        assert contract.pipeline_code == "unknown.pipeline"
+        assert contract.schema_out == "my_entity"
+
+
+class TestLegacyAdapters:
+    """Test legacy adapter for backward compatibility."""
+
+    def test_create_composition_root_with_legacy_emits_warning(self) -> None:
+        """Verify legacy adapter emits deprecation warning."""
+        from bioetl.interfaces.legacy_adapters import (
+            create_composition_root_with_legacy,
+        )
+
+        with pytest.warns(DeprecationWarning, match="logger/metrics parameters"):
+            root = create_composition_root_with_legacy(
+                logger=MockLogger(),
+                metrics=MockMetrics(),
+            )
+
+        assert root is not None
+        assert isinstance(root.get_logger(), MockLogger)
+        assert isinstance(root.get_metrics(), MockMetrics)
+
+    def test_create_composition_root_with_legacy_no_warning_without_legacy_params(
+        self,
+    ) -> None:
+        """Verify legacy adapter doesn't warn when not using legacy params."""
+        import warnings
+
+        from bioetl.interfaces.legacy_adapters import (
+            create_composition_root_with_legacy,
+        )
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            root = create_composition_root_with_legacy(
+                observability_factory=TestObservabilityFactory()
+            )
+
+        # Should not emit deprecation warning
+        deprecation_warnings = [
+            x for x in w if issubclass(x.category, DeprecationWarning)
+        ]
+        assert len(deprecation_warnings) == 0
+        assert root is not None

--- a/tests/project_rules/test_no_global_state.py
+++ b/tests/project_rules/test_no_global_state.py
@@ -1,0 +1,160 @@
+"""Tests for absence of global mutable state in infrastructure.
+
+These tests ensure that the codebase follows the dependency injection pattern
+and does not rely on global mutable state for configuration and providers.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+
+from tests.project_rules.conftest import iter_python_files
+
+
+def _find_global_provider_state(content: str) -> list[str]:
+    """Find global provider state variables in Python source.
+
+    Args:
+        content: Python source code.
+
+    Returns:
+        List of global state variable names found.
+    """
+    try:
+        tree = ast.parse(content)
+    except SyntaxError:
+        return []
+
+    violations = []
+    for node in ast.walk(tree):
+        # Check for annotated assignments like: _PROVIDER: Type | None = None
+        if isinstance(node, ast.AnnAssign):
+            if isinstance(node.target, ast.Name):
+                name = node.target.id
+                if name.startswith("_") and "PROVIDER" in name.upper():
+                    violations.append(name)
+
+        # Check for simple assignments like: _PROVIDER = None
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    name = target.id
+                    if name.startswith("_") and "PROVIDER" in name.upper():
+                        violations.append(name)
+
+    return violations
+
+
+def test_no_global_schema_provider_in_infrastructure(bioetl_root: Path) -> None:
+    """Verify infrastructure has no global schema provider state."""
+    loader_path = bioetl_root / "infrastructure" / "config" / "loader.py"
+
+    assert loader_path.exists(), f"File not found: {loader_path}"
+
+    content = loader_path.read_text()
+    violations = _find_global_provider_state(content)
+
+    assert not violations, (
+        f"Found global state variables in loader.py: {violations}. "
+        "Global state is prohibited - use dependency injection instead."
+    )
+
+
+def test_no_global_provider_references_in_application(bioetl_root: Path) -> None:
+    """Verify application layer doesn't use global provider state."""
+    application_dir = bioetl_root / "application"
+
+    violations: list[str] = []
+    for py_file in iter_python_files(application_dir):
+        content = py_file.read_text()
+
+        # Check for direct references to global state
+        if "_SCHEMA_CONTRACT_PROVIDER" in content:
+            violations.append(f"{py_file}: references _SCHEMA_CONTRACT_PROVIDER")
+
+        # Check for deprecated global state functions
+        deprecated_functions = [
+            "set_schema_contract_provider",
+            "get_schema_contract_provider",
+            "clear_schema_contract_provider",
+            "reset_schema_contract_provider",
+            "_set_provider_internal",
+            "_clear_provider_internal",
+        ]
+        for func_name in deprecated_functions:
+            if func_name in content:
+                # Skip if it's just a type annotation or comment
+                if f"import {func_name}" in content or f"from " in content:
+                    violations.append(f"{py_file}: imports deprecated {func_name}")
+
+    assert not violations, (
+        f"Found global state references in application layer:\n"
+        + "\n".join(violations)
+    )
+
+
+def test_no_global_state_setter_in_bootstrap(bioetl_root: Path) -> None:
+    """Verify bootstrap_factory doesn't use global state setters."""
+    bootstrap_factory_path = (
+        bioetl_root / "interfaces" / "bootstrap_factory.py"
+    )
+
+    assert bootstrap_factory_path.exists(), f"File not found: {bootstrap_factory_path}"
+
+    content = bootstrap_factory_path.read_text()
+
+    deprecated_imports = [
+        "_set_provider_internal",
+        "_clear_provider_internal",
+        "set_schema_contract_provider",
+    ]
+
+    violations = []
+    for func_name in deprecated_imports:
+        if func_name in content:
+            violations.append(func_name)
+
+    assert not violations, (
+        f"bootstrap_factory.py still references deprecated functions: {violations}. "
+        "Provider injection via global state is removed."
+    )
+
+
+def test_infrastructure_loader_exports_only_di_api(bioetl_root: Path) -> None:
+    """Verify loader.py __all__ contains only DI-based API."""
+    loader_path = bioetl_root / "infrastructure" / "config" / "loader.py"
+
+    content = loader_path.read_text()
+    tree = ast.parse(content)
+
+    # Find __all__ assignment
+    all_exports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "__all__":
+                    if isinstance(node.value, ast.List):
+                        for elt in node.value.elts:
+                            if isinstance(elt, ast.Constant):
+                                all_exports.append(elt.value)
+
+    deprecated_exports = {
+        "set_schema_contract_provider",
+        "get_schema_contract_provider",
+        "clear_schema_contract_provider",
+        "reset_schema_contract_provider",
+        "create_schema_contract_loader",
+        "_set_provider_internal",
+        "_clear_provider_internal",
+    }
+
+    found_deprecated = set(all_exports) & deprecated_exports
+
+    assert not found_deprecated, (
+        f"loader.py __all__ still exports deprecated functions: {found_deprecated}. "
+        "Remove deprecated exports from public API."
+    )

--- a/tests/unit/interfaces/__init__.py
+++ b/tests/unit/interfaces/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for interfaces layer."""

--- a/tests/unit/interfaces/test_composition_root.py
+++ b/tests/unit/interfaces/test_composition_root.py
@@ -1,0 +1,213 @@
+"""Unit tests for CompositionRoot."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from bioetl.domain.observability import LoggingPortABC, MetricsPortABC
+from bioetl.interfaces.composition_root import (
+    CompositionRoot,
+    ObservabilityStack,
+    get_composition_root,
+    reset_composition_root,
+)
+from bioetl.interfaces.factories import (
+    InfrastructureFactoryABC,
+    ObservabilityFactoryABC,
+)
+
+
+class MockLogger(LoggingPortABC):
+    """Mock logger for testing."""
+
+    def debug(self, msg: str, **kwargs) -> None:
+        pass
+
+    def info(self, msg: str, **kwargs) -> None:
+        pass
+
+    def warning(self, msg: str, **kwargs) -> None:
+        pass
+
+    def error(self, msg: str, **kwargs) -> None:
+        pass
+
+    def critical(self, msg: str, **kwargs) -> None:
+        pass
+
+    def exception(self, msg: str, **kwargs) -> None:
+        pass
+
+    def apply_bind(self, **kwargs) -> "LoggingPortABC":
+        return self
+
+
+class MockMetrics(MetricsPortABC):
+    """Mock metrics for testing."""
+
+    def increment(self, name: str, value: int = 1, **tags) -> None:
+        pass
+
+    def gauge(self, name: str, value: float, **tags) -> None:
+        pass
+
+    def timing(self, name: str, value: float, **tags) -> None:
+        pass
+
+    def histogram(self, name: str, value: float, **tags) -> None:
+        pass
+
+
+class TestCompositionRootInit:
+    """Test CompositionRoot initialization."""
+
+    def test_init_with_defaults(self) -> None:
+        """Verify CompositionRoot initializes with defaults."""
+        root = CompositionRoot()
+
+        assert root is not None
+
+    def test_init_with_custom_observability_factory(self) -> None:
+        """Verify CompositionRoot uses custom observability factory."""
+        mock_factory = Mock(spec=ObservabilityFactoryABC)
+        mock_factory.create_logger.return_value = MockLogger()
+        mock_factory.create_metrics.return_value = MockMetrics()
+
+        root = CompositionRoot(observability_factory=mock_factory)
+
+        logger = root.get_logger()
+        metrics = root.get_metrics()
+
+        mock_factory.create_logger.assert_called_once()
+        mock_factory.create_metrics.assert_called_once()
+        assert isinstance(logger, MockLogger)
+        assert isinstance(metrics, MockMetrics)
+
+    def test_init_with_custom_infrastructure_factory(self) -> None:
+        """Verify CompositionRoot uses custom infrastructure factory."""
+        mock_factory = Mock(spec=InfrastructureFactoryABC)
+
+        root = CompositionRoot(infrastructure_factory=mock_factory)
+
+        assert root is not None
+
+
+class TestCompositionRootObservability:
+    """Test CompositionRoot observability methods."""
+
+    def test_get_observability_stack(self) -> None:
+        """Verify get_observability_stack returns correct stack."""
+        mock_factory = Mock(spec=ObservabilityFactoryABC)
+        mock_factory.create_logger.return_value = MockLogger()
+        mock_factory.create_metrics.return_value = MockMetrics()
+
+        root = CompositionRoot(observability_factory=mock_factory)
+        stack = root.get_observability_stack()
+
+        assert isinstance(stack, ObservabilityStack)
+        assert isinstance(stack.logger, MockLogger)
+        assert isinstance(stack.metrics, MockMetrics)
+
+
+class TestCompositionRootProviderRegistry:
+    """Test CompositionRoot provider registry methods."""
+
+    def test_get_provider_registry_creates_registry(self) -> None:
+        """Verify get_provider_registry creates registry."""
+        root = CompositionRoot()
+
+        registry = root.get_provider_registry()
+
+        assert registry is not None
+
+    def test_get_provider_registry_caches_result(self) -> None:
+        """Verify get_provider_registry caches result."""
+        root = CompositionRoot()
+
+        registry1 = root.get_provider_registry()
+        registry2 = root.get_provider_registry()
+
+        assert registry1 is registry2
+
+
+class TestCompositionRootSchemaContractProvider:
+    """Test CompositionRoot schema contract provider methods."""
+
+    def test_get_schema_contract_provider_creates_provider(self) -> None:
+        """Verify get_schema_contract_provider creates provider."""
+        root = CompositionRoot()
+
+        provider = root.get_schema_contract_provider()
+
+        assert provider is not None
+
+    def test_get_schema_contract_provider_caches_result(self) -> None:
+        """Verify get_schema_contract_provider caches result."""
+        root = CompositionRoot()
+
+        provider1 = root.get_schema_contract_provider()
+        provider2 = root.get_schema_contract_provider()
+
+        assert provider1 is provider2
+
+    def test_get_schema_contract_provider_uses_explicit_provider(self) -> None:
+        """Verify get_schema_contract_provider uses explicit provider."""
+        from bioetl.domain.ports.schema import SchemaContractProviderABC
+
+        mock_provider = Mock(spec=SchemaContractProviderABC)
+
+        root = CompositionRoot(schema_contract_provider=mock_provider)
+        provider = root.get_schema_contract_provider()
+
+        assert provider is mock_provider
+
+
+class TestCompositionRootSingleton:
+    """Test CompositionRoot singleton functions."""
+
+    def test_get_composition_root_returns_singleton(self) -> None:
+        """Verify get_composition_root returns singleton."""
+        reset_composition_root()
+
+        root1 = get_composition_root()
+        root2 = get_composition_root()
+
+        assert root1 is root2
+
+    def test_reset_composition_root_clears_singleton(self) -> None:
+        """Verify reset_composition_root clears singleton."""
+        reset_composition_root()
+        root1 = get_composition_root()
+
+        reset_composition_root()
+        root2 = get_composition_root()
+
+        assert root1 is not root2
+
+
+class TestCompositionRootHttpInfrastructure:
+    """Test CompositionRoot HTTP infrastructure methods."""
+
+    def test_create_http_session(self) -> None:
+        """Verify create_http_session creates session."""
+        import requests
+
+        root = CompositionRoot()
+
+        session = root.create_http_session()
+
+        assert isinstance(session, requests.Session)
+
+    def test_create_http_session_uses_custom_factory(self) -> None:
+        """Verify create_http_session uses custom factory."""
+
+        class MockSession:
+            pass
+
+        root = CompositionRoot(http_session_factory=MockSession)
+
+        session = root.create_http_session()
+
+        assert isinstance(session, MockSession)


### PR DESCRIPTION
This commit implements the refactoring plan from REFACTORING_PLAN_v3.md focusing on eliminating global mutable state and improving dependency injection.

Task 1: Global State Elimination
- Remove _SCHEMA_CONTRACT_PROVIDER global variable from loader.py
- Remove deprecated functions from public API (__all__)
- Update bootstrap_factory.py to not use global state injection
- Add architectural test test_no_global_state.py

Task 2: Schema Contract Injection
- Add schema_contract parameter to PipelineBase constructor
- Update ChemblPipelineBase to receive schema_contract via injection
- Add get_schema_contract() to PipelineContainerABC and PipelineContainer
- Update ChemblPipelineFactory to inject schema_contract from container

Task 3: CompositionRoot Alignment
- Remove legacy logger/metrics parameters from CompositionRoot.__init__
- Create legacy_adapters.py with create_composition_root_with_legacy()
- Update documentation with new factory-based API examples

Task 4: Documentation
- Create DEPENDENCY_FLOW.md documenting the DI flow
- Update module docstrings with new usage patterns

Task 5: Test Suite Extension
- Add test_no_global_state.py (architectural tests)
- Add test_di_flow.py (integration tests)
- Add test_composition_root.py (unit tests)

Breaking changes:
- get_pipeline_config() now requires schema_contract_provider parameter
- CompositionRoot no longer accepts logger/metrics parameters directly (use observability_factory or create_composition_root_with_legacy())