### PR TITLE
Fix errors in project diagrams

### DIFF
--- a/docs/architecture/diagrams/class/11-pipeline-classes.mmd
+++ b/docs/architecture/diagrams/class/11-pipeline-classes.mmd
@@ -2,7 +2,7 @@
 id: 15d7b6ea-8c7c-4b0e-9d3a-0b6e3d6e9f11
 ---
 %%{init: {"class": {"domainPrimary": {"fill": "#f5f5f5", "stroke": "#444", "strokeWidth": 1.5, "color": "#111", "fontSize": "22px"}, "domainSecondary": {"fill": "#e3e7ec", "stroke": "#555", "strokeWidth": 1.2, "color": "#111", "fontSize": "18px"}, "interface": {"fill": "#dde7f2", "stroke": "#44546a", "strokeWidth": 1.5, "color": "#111", "fontSize": "22px"}}}}%%
-classDiagram-v2
+classDiagram
 
 class PipelineBase {
   <<Abstract>>

--- a/docs/architecture/diagrams/class/12-domain-service-classes.mmd
+++ b/docs/architecture/diagrams/class/12-domain-service-classes.mmd
@@ -2,7 +2,7 @@
 id: 7f1b5e5d-4c9a-4bf0-8c6f-0b3fdde2d0ac
 ---
 %%{init: {"class": {"domainPrimary": {"fill": "#f5f5f5", "stroke": "#444", "strokeWidth": 1.5, "color": "#111", "fontSize": "22px"}, "domainSecondary": {"fill": "#e3e7ec", "stroke": "#555", "strokeWidth": 1.2, "color": "#111", "fontSize": "18px"}, "interface": {"fill": "#dde7f2", "stroke": "#44546a", "strokeWidth": 1.5, "color": "#111", "fontSize": "22px"}}}}%%
-classDiagram-v2
+classDiagram
 
 class ValidationService {
   +get_schema(entity_name)

--- a/docs/architecture/diagrams/class/13-client-abc-default-impl-classes.mmd
+++ b/docs/architecture/diagrams/class/13-client-abc-default-impl-classes.mmd
@@ -2,7 +2,7 @@
 id: 3d4e1b0a-6d83-4d8b-9c6f-1e6e8f2471ab
 ---
 %%{init: {"class": {"domainPrimary": {"fill": "#f5f5f5", "stroke": "#444", "strokeWidth": 1.5, "color": "#111", "fontSize": "22px"}, "domainSecondary": {"fill": "#e3e7ec", "stroke": "#555", "strokeWidth": 1.2, "color": "#111", "fontSize": "18px"}, "interface": {"fill": "#dde7f2", "stroke": "#44546a", "strokeWidth": 1.5, "color": "#111", "fontSize": "22px"}}}}%%
-classDiagram-v2
+classDiagram
 
 class DataClientABC
 class ChemblDataClientABC

--- a/docs/architecture/diagrams/class/14-config-loader-classes.mmd
+++ b/docs/architecture/diagrams/class/14-config-loader-classes.mmd
@@ -2,7 +2,7 @@
 id: 2fbc0e6a-4f3d-4d73-8a1d-5f7b9fdf7f0d
 ---
 %%{init: {"class": {"domainPrimary": {"fill": "#f5f5f5", "stroke": "#444", "strokeWidth": 1.5, "color": "#111", "fontSize": "22px"}, "domainSecondary": {"fill": "#e3e7ec", "stroke": "#555", "strokeWidth": 1.2, "color": "#111", "fontSize": "18px"}, "interface": {"fill": "#dde7f2", "stroke": "#44546a", "strokeWidth": 1.5, "color": "#111", "fontSize": "22px"}}}}%%
-classDiagram-v2
+classDiagram
 
 class ConfigLoader {
   +load_pipeline_config(pipeline_id, profile)

--- a/docs/architecture/diagrams/class/15-schema-validation-classes.mmd
+++ b/docs/architecture/diagrams/class/15-schema-validation-classes.mmd
@@ -2,7 +2,7 @@
 id: 5de5bb67-2d1c-4e36-a7d6-f5a3b7a3e4d5
 ---
 %%{init: {"class": {"domainPrimary": {"fill": "#f5f5f5", "stroke": "#444", "strokeWidth": 1.5, "color": "#111", "fontSize": "22px"}, "domainSecondary": {"fill": "#e3e7ec", "stroke": "#555", "strokeWidth": 1.2, "color": "#111", "fontSize": "18px"}, "interface": {"fill": "#dde7f2", "stroke": "#44546a", "strokeWidth": 1.5, "color": "#111", "fontSize": "22px"}}}}%%
-classDiagram-v2
+classDiagram
 
 class SchemaProviderABC
 class SchemaRegistry {

--- a/docs/architecture/diagrams/class/16-hashing-normalization-classes.mmd
+++ b/docs/architecture/diagrams/class/16-hashing-normalization-classes.mmd
@@ -2,7 +2,7 @@
 id: 8e1b7c45-0c2f-4e6a-9fd7-26cbdc6b22a2
 ---
 %%{init: {"class": {"domainPrimary": {"fill": "#f5f5f5", "stroke": "#444", "strokeWidth": 1.5, "color": "#111", "fontSize": "22px"}, "domainSecondary": {"fill": "#e3e7ec", "stroke": "#555", "strokeWidth": 1.2, "color": "#111", "fontSize": "18px"}, "interface": {"fill": "#dde7f2", "stroke": "#44546a", "strokeWidth": 1.5, "color": "#111", "fontSize": "22px"}}}}%%
-classDiagram-v2
+classDiagram
 
 class HasherABC
 class HasherImpl {

--- a/docs/architecture/diagrams/class/17-provider-registry-classes.mmd
+++ b/docs/architecture/diagrams/class/17-provider-registry-classes.mmd
@@ -2,7 +2,7 @@
 id: 4c1d9d2a-0f90-4b7a-97ab-2a8d7e9a7d6b
 ---
 %%{init: {"class": {"domainPrimary": {"fill": "#f5f5f5", "stroke": "#444", "strokeWidth": 1.5, "color": "#111", "fontSize": "22px"}, "domainSecondary": {"fill": "#e3e7ec", "stroke": "#555", "strokeWidth": 1.2, "color": "#111", "fontSize": "18px"}, "interface": {"fill": "#dde7f2", "stroke": "#44546a", "strokeWidth": 1.5, "color": "#111", "fontSize": "22px"}}}}%%
-classDiagram-v2
+classDiagram
 
 class ProviderId
 class BaseProviderConfig

--- a/docs/architecture/diagrams/class/18-orchestrator-container-classes.mmd
+++ b/docs/architecture/diagrams/class/18-orchestrator-container-classes.mmd
@@ -2,7 +2,7 @@
 id: 0f1e2f2a-4f5c-4b6b-b3d0-9d6e3a7c5b2f
 ---
 %%{init: {"class": {"domainPrimary": {"fill": "#f5f5f5", "stroke": "#444", "strokeWidth": 1.5, "color": "#111", "fontSize": "22px"}, "domainSecondary": {"fill": "#e3e7ec", "stroke": "#555", "strokeWidth": 1.2, "color": "#111", "fontSize": "18px"}, "interface": {"fill": "#dde7f2", "stroke": "#44546a", "strokeWidth": 1.5, "color": "#111", "fontSize": "22px"}}}}%%
-classDiagram-v2
+classDiagram
 
 class PipelineOrchestrator {
   +build_pipeline(limit)

--- a/docs/architecture/diagrams/class/client-architecture-three-layer.mmd
+++ b/docs/architecture/diagrams/class/client-architecture-three-layer.mmd
@@ -1,5 +1,5 @@
 %%{init: {"class": {"domainPrimary": {"fill": "#f5f5f5", "stroke": "#444", "strokeWidth": 1.5, "color": "#111", "fontSize": "22px"}, "domainSecondary": {"fill": "#e3e7ec", "stroke": "#555", "strokeWidth": 1.2, "color": "#111", "fontSize": "18px"}, "interface": {"fill": "#dde7f2", "stroke": "#44546a", "strokeWidth": 1.5, "color": "#111", "fontSize": "22px"}}}}%%
-classDiagram-v2
+classDiagram
 
     %% Contracts (Ports)
     class DataClientABC {

--- a/docs/architecture/diagrams/class/pipeline-class-structure.mmd
+++ b/docs/architecture/diagrams/class/pipeline-class-structure.mmd
@@ -1,5 +1,5 @@
 %%{init: { 'classDiagram': { 'useMaxWidth': true } }}%%
-classDiagram-v2
+classDiagram
 class PipelineBase {
     <<Abstract>>
     +run(output_path, dry_run) RunResult

--- a/docs/architecture/diagrams/component/06-hexagonal-architecture.mmd
+++ b/docs/architecture/diagrams/component/06-hexagonal-architecture.mmd
@@ -65,7 +65,6 @@ flowchart TB
 
     contracts --> apiClients
     contracts --> recordSources
-    contracts --> extraction
     contracts --> transformers
     contracts --> writers
     contracts --> observabilityContracts


### PR DESCRIPTION
- Replace deprecated classDiagram-v2 with classDiagram in 10 files
- Remove reference to undefined 'extraction' node in hexagonal-architecture.mmd