### PR TITLE
Merge two refactoring plans into one

### DIFF
--- a/docs/architecture/REFACTORING_PLAN_MERGED.md
+++ b/docs/architecture/REFACTORING_PLAN_MERGED.md
@@ -1,1007 +1,1364 @@
 # Объединённый план рефакторинга архитектуры BioETL
 
+**Версия:** 2.0 (консолидация v5 + docs/REFACTORING_PLAN)
 **Дата создания:** 2025-12-11
-**Основан на:** REFACTORING_PLAN.md (v1) + REFACTORING_PLAN_v2.md (v2)
-**Интегральный балл архитектуры (до):** 6.15-6.38/10
-**Целевой балл (после):** 8.0+
+**Базовые документы:**
+- [docs/REFACTORING_PLAN.md](../REFACTORING_PLAN.md) — фокус на interfaces layer (26 импортов)
+- [REFACTORING_PLAN_v5.md](./REFACTORING_PLAN_v5.md) — фокус на application layer + инкапсуляция
+
+**Текущий интегральный балл:** 6.4–6.8/10
+**Целевой интегральный балл:** ≥7.5/10
 **Статус:** Планирование
 
 ---
 
 ## Оглавление
 
-1. [Сводка выявленных проблем](#сводка-выявленных-проблем)
-2. [Фаза 1: Устранение нарушений границ слоёв (Критично)](#фаза-1-устранение-нарушений-границ-слоёв-критично)
-3. [Фаза 2: Декуплинг Application от Infrastructure (Критично)](#фаза-2-декуплинг-application-от-infrastructure-критично)
-4. [Фаза 3: Реорганизация ABC-реестров (Высокий)](#фаза-3-реорганизация-abc-реестров-высокий)
-5. [Фаза 4: Избавление от глобального состояния (Высокий)](#фаза-4-избавление-от-глобального-состояния-высокий)
-6. [Фаза 5: Полноценная регистрация схем и валидации (Средний)](#фаза-5-полноценная-регистрация-схем-и-валидации-средний)
-7. [Фаза 6: Расширение тестового покрытия (Средний)](#фаза-6-расширение-тестового-покрытия-средний)
-8. [Фаза 7: Усиление наблюдаемости (Низкий)](#фаза-7-усиление-наблюдаемости-низкий)
-9. [Фаза 8: Документация и линтеры (Низкий)](#фаза-8-документация-и-линтеры-низкий)
-10. [Метрики успеха](#метрики-успеха)
-11. [Порядок выполнения](#порядок-выполнения)
+1. [Резюме](#резюме)
+2. [Консолидированная оценка архитектуры](#консолидированная-оценка-архитектуры)
+3. [Полный реестр выявленных проблем](#полный-реестр-выявленных-проблем)
+4. [Приоритеты рефакторинга](#приоритеты-рефакторинга)
+5. [Фаза 1: Изоляция application от infrastructure](#фаза-1-изоляция-application-от-infrastructure)
+6. [Фаза 2: Изоляция interfaces от infrastructure](#фаза-2-изоляция-interfaces-от-infrastructure)
+7. [Фаза 3: Публичный API и инкапсуляция](#фаза-3-публичный-api-и-инкапсуляция)
+8. [Фаза 4: Централизация сервисов](#фаза-4-централизация-сервисов)
+9. [Фаза 5: Усиление архитектурных тестов](#фаза-5-усиление-архитектурных-тестов)
+10. [Фаза 6: Устранение технического долга](#фаза-6-устранение-технического-долга)
+11. [Метрики и контроль](#метрики-и-контроль)
+12. [План выполнения](#план-выполнения)
+13. [Ожидаемые результаты](#ожидаемые-результаты)
 
 ---
 
-## Сводка выявленных проблем
+## Резюме
 
-### Архитектура слоёв (напоминание)
+Данный документ объединяет два плана рефакторинга с разными фокусами:
+
+| План | Фокус | Ключевые проблемы |
+|------|-------|-------------------|
+| docs/REFACTORING_PLAN.md | interfaces → infrastructure | 26 прямых импортов в interfaces layer |
+| REFACTORING_PLAN_v5.md | application → infrastructure | Fallback в orchestrator, приватные методы |
+
+### Общая картина нарушений
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│                        interfaces                            │
-│              (CLI, REST API, composition root)               │
-├─────────────────────────────────────────────────────────────┤
-│                       application                            │
-│          (use cases, orchestration, pipelines)               │
-├─────────────────────────────────────────────────────────────┤
-│                         domain                               │
-│    (entities, value objects, contracts ABC/Protocol)         │
-├─────────────────────────────────────────────────────────────┤
-│                      infrastructure                          │
-│        (HTTP clients, files, DB, Pandera, logging)           │
-└─────────────────────────────────────────────────────────────┘
-
-Правила зависимостей:
-- domain → ничего внешнего
-- application → domain только
-- infrastructure → domain только
-- interfaces → все слои (composition root)
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    ARCHITECTURE VIOLATIONS MAP                          │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│   ┌──────────────┐                                                      │
+│   │  INTERFACES  │──────┐                                               │
+│   │   (26 imp)   │      │                                               │
+│   └──────────────┘      │    DIRECT IMPORTS                             │
+│          ↓              │    (should go through ports)                  │
+│   ┌──────────────┐      │                                               │
+│   │ APPLICATION  │──────┼───────────────────┐                           │
+│   │   (1 imp)    │      │                   │                           │
+│   │   (_private) │      │                   ↓                           │
+│   └──────────────┘      │         ┌─────────────────┐                   │
+│          ↓              └────────→│ INFRASTRUCTURE  │                   │
+│   ┌──────────────┐                │    (impl)       │                   │
+│   │    DOMAIN    │                └─────────────────┘                   │
+│   │  (pandera?)  │                                                      │
+│   │  (global st) │                                                      │
+│   └──────────────┘                                                      │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
 ```
 
-### Консолидированный список нарушений
+### Ключевые цели
 
-| # | Проблема | Источник | Слой | Приоритет |
-|---|----------|----------|------|-----------|
-| 1 | Domain → Infrastructure (dynamic import ConfigMigrator) | v1 + v2 | Domain | Критично |
-| 2 | Application → Infrastructure (orchestrator.py импортирует InMemoryProviderRegistry) | v2 | Application | Критично |
-| 3 | Infrastructure → Application (csv_record_source.py прокси) | v2 | Infrastructure | Критично |
-| 4 | Infrastructure abc_impls.yaml → Application (маппинги) | v2 | Infrastructure | Высокий |
-| 5 | Глобальное состояние `_PROVIDER_REGISTRY` | v1 | Domain | Высокий |
-| 6 | Схемы регистрируются с `schema=None` | v1 | Domain/Infra | Средний |
-| 7 | Неунифицированное логирование и метрики | v1 | Все слои | Низкий |
-
-### Статус выполнения предыдущих задач
-
-| Задача | Статус | Примечание |
-|--------|--------|------------|
-| Удаление ConfigMigrator прокси | ❌ НЕ ВЫПОЛНЕНО | Файл `domain/configs/migration.py` всё ещё содержит importlib прокси |
-| Консолидация InMemoryProviderRegistry | ✅ ВЫПОЛНЕНО | `memory_registry.py` удалён |
-| DefaultRunMetadataBuilder | ✅ ВЫПОЛНЕНО | Создан в `application/metadata/builder.py` |
-| Тест на динамические импорты | ⚠️ ЧАСТИЧНО | Тест существует, но не проходит из-за migration.py |
+1. **Устранить 27 прямых зависимостей** на инфраструктуру из верхних слоёв
+2. **Создать публичные API** для внутренних операций пайплайнов
+3. **Централизовать сервисы** (наблюдаемость, конфигурация)
+4. **Ликвидировать глобальное состояние** и внешние зависимости в domain
+5. **Закрепить архитектурные правила** автоматизированными тестами
 
 ---
 
-## Фаза 1: Устранение нарушений границ слоёв (Критично)
+## Консолидированная оценка архитектуры
 
-**Цель:** Восстановить строгую направленность зависимостей domain → ничего внешнего.
+| Категория | Вес | Оценка | Взвеш. балл | Проблемы |
+|-----------|:---:|:------:|:-----------:|----------|
+| Слоистая архитектура | 0.12 | 6.5 | 0.78 | interfaces→infra, application→infra |
+| Ports & Adapters / DDD | 0.10 | 6 | 0.60 | Недостаточное использование портов |
+| Границы модулей | 0.10 | 6 | 0.60 | Приватные методы, утечки абстракций |
+| Качество доменной модели | 0.10 | 7 | 0.70 | Pandera в domain |
+| Контракты и конфигурация | 0.08 | 6 | 0.48 | Отсутствует ConfigurationService |
+| Обработка ошибок | 0.10 | 6 | 0.60 | Нет централизованного логирования |
+| Тестирование и QA | 0.10 | 6 | 0.60 | Недостаточные архитектурные проверки |
+| Валидация данных | 0.10 | 7 | 0.70 | — |
+| Документация | 0.10 | 7 | 0.70 | — |
+| Сопровождаемость | 0.10 | 6 | 0.60 | Глобальное состояние, ignore_imports |
+| **Интегральный балл** | **1.00** | | **6.36** | |
 
-### Задача 1.1: Удаление ConfigMigrator прокси из Domain
+---
 
-**Источник:** v1 (задача 1.1) + v2 (задача 2.2)
+## Полный реестр выявленных проблем
 
-**Проблема:**
-Файл `src/bioetl/domain/configs/migration.py` содержит динамический импорт из infrastructure:
+### Категория A: Нарушения слоистой архитектуры
 
+| ID | Слой | Файл | Строка | Описание | Источник | Приоритет |
+|:--:|------|------|:------:|----------|:--------:|:---------:|
+| A1 | application | `orchestrator.py` | 58-69 | Импорт `InMemoryProviderRegistry` через fallback | v5 | Критический |
+| A2 | interfaces | `composition_root.py` | — | 10 прямых импортов infrastructure | v1 | Критический |
+| A3 | interfaces | `bootstrap_factory.py` | — | 2 прямых импорта infrastructure | v1 | Высокий |
+| A4 | interfaces | `factories/infrastructure.py` | — | 4 прямых импорта infrastructure | v1 | Высокий |
+| A5 | interfaces | `factories/observability.py` | — | 2 прямых импорта infrastructure | v1 | Высокий |
+| A6 | interfaces | `cli/app.py` | — | 2 прямых импорта infrastructure | v1 | Средний |
+| A7 | interfaces | `use_case_factory.py` | — | 2 прямых импорта infrastructure | v1 | Средний |
+| A8 | interfaces | `application_context.py` | — | 1 прямой импорт infrastructure | v1 | Средний |
+| A9 | interfaces | `monitoring/__init__.py` | — | 3 прямых импорта infrastructure | v1 | Средний |
+
+### Категория B: Нарушения инкапсуляции
+
+| ID | Файл | Строка | Описание | Источник | Приоритет |
+|:--:|------|:------:|----------|:--------:|:---------:|
+| B1 | `orchestrator.py` | 156 | Вызов `pipeline._get_extract_callable()` | v5 | Высокий |
+| B2 | `orchestrator.py` | 157-159 | Вызов `pipeline._normalize_extract_result()` | v5 | Высокий |
+
+### Категория C: Технический долг
+
+| ID | Файл | Описание | Источник | Приоритет |
+|:--:|------|----------|:--------:|:---------:|
+| C1 | `domain/provider_registry.py` | Глобальное состояние `_PROVIDER_REGISTRY` | v5/v4 | Средний |
+| C2 | `domain/schemas/generator.py` | Pandera/YAML импорты в domain | v5/v4 | Средний |
+| C3 | `.importlinter` | 13 исключений (целевое: ≤3) | v5/v4 | Низкий |
+
+### Категория D: Недостающие компоненты
+
+| ID | Описание | Источник | Приоритет |
+|:--:|----------|:--------:|:---------:|
+| D1 | Порты фабрик в application слое | v1 | Критический |
+| D2 | Адаптеры фабрик в infrastructure | v1 | Критический |
+| D3 | ObservabilityService | v1 | Высокий |
+| D4 | ConfigurationService | v1 | Средний |
+| D5 | Тесты на инфраструктурные импорты | v5 | Высокий |
+| D6 | Тесты на приватные атрибуты | v5 | Средний |
+
+---
+
+## Приоритеты рефакторинга
+
+```
+ПРИОРИТЕТ 1: КРИТИЧЕСКИЙ (Блокирующие нарушения)
+══════════════════════════════════════════════════════════════════
+   [A1] Fallback InMemoryProviderRegistry в orchestrator (v5)
+   [A2] 10 импортов infrastructure в composition_root.py (v1)
+   [D1] Создание портов в application/ports/ (v1)
+   [D2] Создание адаптеров в infrastructure/adapters/ (v1)
+
+ПРИОРИТЕТ 2: ВЫСОКИЙ (Инкапсуляция и архитектурные тесты)
+══════════════════════════════════════════════════════════════════
+   [B1-B2] Публичный API для extract-only режима (v5)
+   [A3-A5] Прямые импорты в factories и bootstrap (v1)
+   [D3] ObservabilityService (v1)
+   [D5] Тесты на инфраструктурные импорты (v5)
+
+ПРИОРИТЕТ 3: СРЕДНИЙ (Сервисы и CLI)
+══════════════════════════════════════════════════════════════════
+   [A6-A9] Прямые импорты в CLI, use_case_factory, monitoring (v1)
+   [D4] ConfigurationService (v1)
+   [D6] Тесты на приватные атрибуты (v5)
+
+ПРИОРИТЕТ 4: НИЗКИЙ (Технический долг)
+══════════════════════════════════════════════════════════════════
+   [C1] Глобальное состояние ProviderRegistry (v4)
+   [C2] Pandera в Domain (v4)
+   [C3] Сокращение ignore_imports (v4)
+```
+
+---
+
+## Фаза 1: Изоляция application от infrastructure
+
+**Приоритет:** Критический
+**Источник:** REFACTORING_PLAN_v5.md
+**Решает:** A1
+**Время:** ~3.5 часа
+
+### Задача 1.1: Удаление fallback в PipelineOrchestrator
+
+**Файл:** `src/bioetl/application/orchestrator.py`
+
+**Текущий код (проблема):**
 ```python
-# src/bioetl/domain/configs/migration.py:32-35
-mod = importlib.import_module(
-    ".".join(["bioetl", "infrastructure", "config", "migration"])
-)
-return getattr(mod, "ConfigMigrator")
-```
+def _get_default_registry_factory() -> ProviderRegistryFactory:
+    """Get the default provider registry factory."""
+    from bioetl.infrastructure.provider_registry import InMemoryProviderRegistry
+    return InMemoryProviderRegistry
 
-**Влияние:**
-- Обходит `.importlinter` и статический анализ
-- Нарушает чистоту доменного слоя
-- Deprecation warning уже работает → безопасно удалять
-
-**Шаги выполнения:**
-
-1. Проверить внешние зависимости:
-   ```bash
-   grep -r "from bioetl.domain.configs.migration import\|from bioetl.domain.configs import ConfigMigrator" src/ tests/
-   ```
-
-2. Обновить импорты (если найдены):
-   ```python
-   # Было:
-   from bioetl.domain.configs.migration import ConfigMigrator
-   # Стало:
-   from bioetl.infrastructure.config.migration import ConfigMigrator
-   ```
-
-3. Удалить файл:
-   ```bash
-   rm src/bioetl/domain/configs/migration.py
-   ```
-
-4. Обновить `src/bioetl/domain/configs/__init__.py` — удалить строки 141-153:
-   ```python
-   # Удалить блок:
-   # if name == "ConfigMigrator":
-   #     ...
-   #     return ConfigMigrator
-   ```
-
-5. Запустить архитектурные тесты:
-   ```bash
-   pytest tests/architecture/test_domain_boundaries.py -v
-   ```
-
-**Критерии готовности:**
-- [ ] Файл `domain/configs/migration.py` удалён
-- [ ] Нет `__getattr__` для ConfigMigrator в `domain/configs/__init__.py`
-- [ ] `grep -r "from bioetl.domain.configs.migration" src/ tests/` возвращает пустой результат
-- [ ] Архитектурный тест `test_domain_has_no_dynamic_infrastructure_imports` проходит
-
-**Затронутые файлы:**
-- `src/bioetl/domain/configs/migration.py` (удалить)
-- `src/bioetl/domain/configs/__init__.py` (обновить)
-- `tests/` (обновить импорты, если есть)
-
----
-
-### Задача 1.2: Удаление csv_record_source прокси из Infrastructure
-
-**Источник:** v2 (задача 2.1)
-
-**Проблема:**
-Infrastructure содержит прокси-модуль, ссылающийся на Application:
-
-```python
-# src/bioetl/infrastructure/files/csv_record_source.py
-raise ImportError(
-    "bioetl.infrastructure.files.csv_record_source has been removed. "
-    "Use bioetl.application.files.csv_record_source instead."
-)
-```
-
-**Влияние:**
-- Нарушает границы слоёв на уровне документации/миграции
-- Путает разработчиков относительно правильного расположения кода
-
-**Шаги выполнения:**
-
-1. Проверить внешние зависимости:
-   ```bash
-   grep -r "infrastructure.files.csv_record_source" src/ tests/
-   ```
-
-2. Удалить файл:
-   ```bash
-   rm src/bioetl/infrastructure/files/csv_record_source.py
-   ```
-
-3. Обновить `.importlinter` — убрать ignore для этого пути (если есть)
-
-**Критерии готовности:**
-- [ ] Файл `infrastructure/files/csv_record_source.py` удалён
-- [ ] `grep -r "infrastructure.files.csv_record_source" src/` возвращает пустой результат
-
-**Затронутые файлы:**
-- `src/bioetl/infrastructure/files/csv_record_source.py` (удалить)
-
----
-
-### Задача 1.3: Проверка InMemoryProviderRegistry прокси
-
-**Источник:** v1 (задача 1.2)
-
-**Текущее состояние:**
-```python
-# src/bioetl/domain/provider_registry.py:104-111
-def __getattr__(name: str) -> Any:
-    if name == "InMemoryProviderRegistry":
-        raise ImportError(
-            "InMemoryProviderRegistry is no longer available in bioetl.domain. "
-            "Import it from bioetl.infrastructure.provider_registry instead."
+class PipelineOrchestrator:
+    def __init__(
+        self,
+        ...
+        provider_registry_factory: ProviderRegistryFactory | None = None,
+    ) -> None:
+        self._provider_registry_factory = (
+            provider_registry_factory or _get_default_registry_factory()
         )
-    raise AttributeError(...)
 ```
 
-**Действие:** Оставить как есть — это корректно предотвращает импорт и помогает миграции.
-
-**Проверка:**
-```bash
-grep -r "from bioetl.domain.provider_registry import InMemoryProviderRegistry" src/ tests/
-grep -r "from bioetl.domain import.*InMemoryProviderRegistry" src/ tests/
-```
-
-**Критерий готовности:**
-- [ ] Нет реальных импортов `InMemoryProviderRegistry` из domain
-
----
-
-## Фаза 2: Декуплинг Application от Infrastructure (Критично)
-
-**Цель:** Убрать прямые зависимости application слоя от конкретных реализаций infrastructure.
-
-### Задача 2.1: Внедрение ProviderRegistry через DI в Orchestrator
-
-**Источник:** v2 (задача 1.1)
-
-**Проблема:**
+**Целевой код:**
 ```python
-# src/bioetl/application/orchestrator.py:43
+class PipelineOrchestrator:
+    def __init__(
+        self,
+        ...
+        provider_registry_factory: ProviderRegistryFactory,  # обязательный!
+    ) -> None:
+        self._provider_registry_factory = provider_registry_factory
+```
+
+### Задача 1.2: Фабрика в composition root
+
+**Создать:** `src/bioetl/interfaces/factories/provider_registry.py`
+
+```python
+"""Provider registry factory for composition root."""
+from __future__ import annotations
+
+from bioetl.domain.provider_registry import ProviderRegistryFactory
+
+
+def create_provider_registry_factory() -> ProviderRegistryFactory:
+    """Create the default provider registry factory.
+
+    This is the single place where infrastructure is imported for DI.
+    """
+    from bioetl.infrastructure.provider_registry import InMemoryProviderRegistry
+    return InMemoryProviderRegistry
+```
+
+### Задача 1.3: Обновление точек входа
+
+**Обновить:** `src/bioetl/interfaces/composition_root.py`
+
+```python
+from bioetl.interfaces.factories.provider_registry import (
+    create_provider_registry_factory,
+)
+
+class CompositionRoot:
+    def create_orchestrator(
+        self,
+        pipeline_name: str,
+        config: PipelineConfig,
+    ) -> PipelineOrchestrator:
+        return PipelineOrchestrator(
+            pipeline_name,
+            config,
+            provider_registry_factory=create_provider_registry_factory(),
+            # ... остальные зависимости
+        )
+```
+
+### Задача 1.4: Обновление тестов
+
+```python
+# В тестах:
 from bioetl.infrastructure.provider_registry import InMemoryProviderRegistry
 
-# Используется в:
-# :300 - registry = loader.get_registry(registry=InMemoryProviderRegistry())
-# :323 - registry = InMemoryProviderRegistry()
-# :328 - return loader.get_registry(registry=InMemoryProviderRegistry())
-# :330 - return InMemoryProviderRegistry()
-```
-
-**Влияние:**
-- Снижает тестируемость orchestrator (нужны моки infrastructure)
-- Нарушает инверсию зависимостей (DIP)
-- Затрудняет замену реализации провайдер-реестра
-
-**Предлагаемое решение:**
-
-1. Добавить фабричный тип в Domain:
-   ```python
-   # src/bioetl/domain/provider_registry.py
-   from typing import Callable
-
-   ProviderRegistryFactory = Callable[[], ProviderRegistryABC]
-   ```
-
-2. Изменить orchestrator для приёма фабрики через конструктор:
-   ```python
-   # src/bioetl/application/orchestrator.py
-   from bioetl.domain.provider_registry import ProviderRegistryABC, ProviderRegistryFactory
-
-   class PipelineOrchestrator:
-       def __init__(
-           self,
-           pipeline_name: str,
-           config: PipelineConfig,
-           *,
-           provider_registry: ProviderRegistryABC | None = None,
-           provider_registry_factory: ProviderRegistryFactory | None = None,  # НОВОЕ
-           # ...
-       ) -> None:
-           self._provider_registry = provider_registry
-           self._provider_registry_factory = provider_registry_factory
-
-       def _get_provider_registry(self) -> ProviderRegistryABC:
-           if self._provider_registry is not None:
-               return self._provider_registry
-           if self._provider_registry_factory is not None:
-               return self._provider_registry_factory()
-           raise RuntimeError("No provider registry or factory provided")
-   ```
-
-3. Перенести создание InMemoryProviderRegistry в interfaces/composition_root:
-   ```python
-   # src/bioetl/interfaces/composition_root.py
-   from bioetl.infrastructure.provider_registry import InMemoryProviderRegistry
-
-   def create_orchestrator(...) -> PipelineOrchestrator:
-       return PipelineOrchestrator(
-           ...,
-           provider_registry_factory=InMemoryProviderRegistry,
-       )
-   ```
-
-4. Удалить импорт из orchestrator:
-   ```python
-   # Удалить:
-   # from bioetl.infrastructure.provider_registry import InMemoryProviderRegistry
-   ```
-
-**Критерии готовности:**
-- [ ] `orchestrator.py` не содержит импортов из `bioetl.infrastructure`
-- [ ] `grep "from bioetl.infrastructure" src/bioetl/application/orchestrator.py` возвращает пустой результат
-- [ ] Архитектурные тесты проходят без ignore_imports для orchestrator
-- [ ] Существующие тесты orchestrator проходят
-
-**Затронутые файлы:**
-- `src/bioetl/domain/provider_registry.py` (добавить ProviderRegistryFactory)
-- `src/bioetl/application/orchestrator.py` (рефакторинг)
-- `src/bioetl/interfaces/composition_root.py` (обновить создание)
-- `tests/bioetl/application/test_orchestrator.py` (если существует)
-
----
-
-## Фаза 3: Реорганизация ABC-реестров (Высокий)
-
-**Цель:** Разорвать зависимость infrastructure → application в конфигурации реестров.
-
-### Задача 3.1: Разделение abc_impls.yaml по слоям
-
-**Источник:** v2 (задача 3.1)
-
-**Проблема:**
-Файл `src/bioetl/infrastructure/clients/base/abc_impls.yaml` содержит маппинги на application-классы:
-
-```yaml
-PipelineContainerABC:
-  default_factory: bioetl.application.container.create_default_container_factory
-  implementations:
-    Default: bioetl.application.container.PipelineContainer
-
-PipelineHookABC:
-  default_factory: bioetl.application.factories.hooks.PipelineHookFactory
-  implementations:
-    Logging: bioetl.application.pipelines.hooks_impl.LoggingPipelineHookImpl
-    Metrics: bioetl.application.pipelines.hooks_impl.MetricsPipelineHookImpl
-
-ErrorPolicyABC:
-  default_factory: bioetl.application.pipelines.hooks_impl.FailFastErrorPolicyImpl
-  implementations:
-    FailFast: bioetl.application.pipelines.hooks_impl.FailFastErrorPolicyImpl
-    ContinueOnError: bioetl.application.pipelines.hooks_impl.ContinueOnErrorPolicyImpl
-```
-
-**Влияние:**
-- Нарушает принцип "infrastructure не знает об application"
-- Создаёт runtime-зависимость через `ABCRegistryResolverImpl`
-- Усложняет понимание архитектуры
-
-**Предлагаемое решение (Вариант A — рекомендуемый):**
-
-Разделить YAML-файлы по слоям:
-
-```
-src/bioetl/
-├── infrastructure/clients/base/
-│   ├── abc_impls.yaml          # Только infrastructure реализации
-│   └── abc_registry.yaml       # Только ABC контракты
-└── interfaces/
-    └── abc_impls_application.yaml  # Application реализации
-```
-
-**Шаги выполнения:**
-
-1. Создать `src/bioetl/interfaces/abc_impls_application.yaml`:
-   ```yaml
-   # Application layer implementations
-   # Loaded by CompositionRoot, not by infrastructure
-
-   PipelineContainerABC:
-     default_factory: bioetl.application.container.create_default_container_factory
-     implementations:
-       Default: bioetl.application.container.PipelineContainer
-
-   PipelineHookABC:
-     default_factory: bioetl.application.factories.hooks.PipelineHookFactory
-     implementations:
-       Logging: bioetl.application.pipelines.hooks_impl.LoggingPipelineHookImpl
-       Metrics: bioetl.application.pipelines.hooks_impl.MetricsPipelineHookImpl
-
-   ErrorPolicyABC:
-     default_factory: bioetl.application.pipelines.hooks_impl.FailFastErrorPolicyImpl
-     implementations:
-       FailFast: bioetl.application.pipelines.hooks_impl.FailFastErrorPolicyImpl
-       ContinueOnError: bioetl.application.pipelines.hooks_impl.ContinueOnErrorPolicyImpl
-   ```
-
-2. Удалить application-маппинги из `infrastructure/clients/base/abc_impls.yaml`
-
-3. Обновить `ABCRegistryResolverImpl` или composition root для загрузки нескольких YAML-файлов
-
-4. Добавить CI-проверку:
-   ```bash
-   # scripts/check_abc_impls.sh
-   grep -q "bioetl\.application" src/bioetl/infrastructure/clients/base/abc_impls.yaml && exit 1
-   echo "OK: No application references in infrastructure abc_impls.yaml"
-   ```
-
-**Критерии готовности:**
-- [ ] `grep "bioetl\.application" src/bioetl/infrastructure/clients/base/abc_impls.yaml` возвращает пустой результат
-- [ ] Application-маппинги перенесены в `interfaces/abc_impls_application.yaml`
-- [ ] Архитектурные тесты проходят
-- [ ] Существующая функциональность сохранена
-
-**Затронутые файлы:**
-- `src/bioetl/infrastructure/clients/base/abc_impls.yaml` (очистить от application)
-- `src/bioetl/interfaces/abc_impls_application.yaml` (создать)
-- `src/bioetl/interfaces/composition_root.py` (обновить загрузку)
-- `ABCRegistryResolverImpl` (возможно обновить)
-
----
-
-## Фаза 4: Избавление от глобального состояния (Высокий)
-
-**Цель:** Сделать конфигурацию провайдеров явной и тестируемой через DI.
-
-### Задача 4.1: Анализ текущего глобального состояния
-
-**Источник:** v1 (задачи 3.1-3.2)
-
-**Текущее состояние:**
-```python
-# src/bioetl/domain/provider_registry.py:70-95
-_PROVIDER_REGISTRY: ProviderRegistryABC | None = None
-
-def set_provider_registry(registry: ProviderRegistryABC) -> None:
-    global _PROVIDER_REGISTRY
-    _PROVIDER_REGISTRY = registry
-
-def get_provider_registry() -> ProviderRegistryABC:
-    if _PROVIDER_REGISTRY is None:
-        raise RuntimeError("Provider registry has not been initialized...")
-    return _PROVIDER_REGISTRY
-```
-
-**Проблемы:**
-1. Глобальное состояние создаёт неявные зависимости
-2. Порядок инициализации критичен
-3. Параллельные тесты могут конфликтовать
-4. Затруднена изоляция в unit-тестах
-
-### Задача 4.2: Внедрение реестра через DI-контейнер
-
-**Шаги выполнения:**
-
-1. Добавить реестр в CompositionRoot:
-   ```python
-   # src/bioetl/interfaces/composition_root.py
-
-   class CompositionRoot:
-       def __init__(self, ...):
-           ...
-           self._provider_registry: ProviderRegistryABC | None = None
-
-       def get_provider_registry(self) -> ProviderRegistryABC:
-           """Get or create provider registry instance."""
-           if self._provider_registry is None:
-               from bioetl.infrastructure.provider_registry import (
-                   InMemoryProviderRegistry,
-               )
-               self._provider_registry = InMemoryProviderRegistry()
-               self._bootstrap_providers(self._provider_registry)
-           return self._provider_registry
-
-       def _bootstrap_providers(self, registry: ProviderRegistryABC) -> None:
-           """Register default providers."""
-           from bioetl.infrastructure.config.provider_registry import (
-               ProviderRegistryLoader,
-           )
-           loader = ProviderRegistryLoader()
-           loader.get_providers(registry=registry)
-   ```
-
-2. Обновить PipelineContainer для приёма реестра:
-   ```python
-   # src/bioetl/application/container.py
-
-   class PipelineContainer:
-       def __init__(
-           self,
-           provider_registry: ProviderRegistryABC,  # Явная инъекция!
-           schema_provider: SchemaProviderABC,
-           ...
-       ):
-           self._provider_registry = provider_registry
-           ...
-   ```
-
-3. Пометить глобальные функции deprecated:
-   ```python
-   # src/bioetl/domain/provider_registry.py
-
-   import warnings
-
-   def get_provider_registry() -> ProviderRegistryABC:
-       """DEPRECATED: Use CompositionRoot.get_provider_registry() instead."""
-       warnings.warn(
-           "get_provider_registry() is deprecated. "
-           "Inject ProviderRegistryABC through CompositionRoot.",
-           DeprecationWarning,
-           stacklevel=2,
-       )
-       if _PROVIDER_REGISTRY is None:
-           raise RuntimeError(...)
-       return _PROVIDER_REGISTRY
-   ```
-
-4. Обновить тесты для изоляции:
-   ```python
-   # tests/conftest.py
-
-   @pytest.fixture
-   def isolated_provider_registry() -> ProviderRegistryABC:
-       """Create isolated provider registry for tests."""
-       from bioetl.infrastructure.provider_registry import InMemoryProviderRegistry
-       return InMemoryProviderRegistry()
-
-   @pytest.fixture
-   def pipeline_container(
-       isolated_provider_registry: ProviderRegistryABC,
-       schema_registry: SchemaProviderABC,
-   ) -> PipelineContainer:
-       """Create container with isolated dependencies."""
-       return PipelineContainer(
-           provider_registry=isolated_provider_registry,
-           schema_provider=schema_registry,
-           ...
-       )
-   ```
-
-**Критерии готовности:**
-- [ ] `CompositionRoot.get_provider_registry()` создан
-- [ ] `PipelineContainer` принимает реестр через конструктор
-- [ ] Глобальные функции помечены deprecated
-- [ ] Тесты используют изолированные фикстуры
-- [ ] Параллельные тесты (`pytest -n auto`) проходят без конфликтов
-
-**Затронутые файлы:**
-- `src/bioetl/interfaces/composition_root.py`
-- `src/bioetl/application/container.py`
-- `src/bioetl/domain/provider_registry.py`
-- `tests/conftest.py`
-
----
-
-## Фаза 5: Полноценная регистрация схем и валидации (Средний)
-
-**Цель:** Гарантировать валидацию на уровне инфраструктуры, оставить домен чистым от Pandera.
-
-### Задача 5.1: Создать инфраструктурный bootstrap для схем
-
-**Источник:** v1 (задачи 2.1-2.3)
-
-**Проблема:**
-Домен регистрирует схемы с `schema=None`:
-```python
-# src/bioetl/domain/schemas/__init__.py:37-38
-for name, cols in mapping.items():
-    provider.register(name, None, column_order=cols)  # schema=None!
-```
-
-**Решение:**
-
-1. Создать `src/bioetl/infrastructure/validation/registry_bootstrap.py`:
-   ```python
-   """Bootstrap Pandera schemas into the domain registry."""
-
-   from bioetl.domain.validation import SchemaProviderABC
-   from bioetl.infrastructure.validation.schemas.chembl.activity import (
-       ActivityOutputSchema,
-   )
-   from bioetl.infrastructure.validation.schemas.chembl.assay import AssayOutputSchema
-   # ... другие импорты
-
-
-   def register_pandera_schemas(registry: SchemaProviderABC) -> SchemaProviderABC:
-       """Register actual Pandera schemas into the registry.
-
-       This replaces None placeholders with concrete Pandera DataFrameModel classes.
-       Should be called during application bootstrap, not in domain.
-       """
-       schema_mapping = {
-           "activity_output": ActivityOutputSchema,
-           "assay_output": AssayOutputSchema,
-           "cell_output": CellOutputSchema,
-           "molecule_output": MoleculeOutputSchema,
-           "publication_output": PublicationOutputSchema,
-           "target_output": TargetOutputSchema,
-           "tissue_output": TissueOutputSchema,
-       }
-
-       for name, schema_class in schema_mapping.items():
-           try:
-               column_order = registry.get_schema_columns(name)
-           except ValueError:
-               column_order = None
-
-           registry.register(name, schema_class, column_order=column_order)
-
-       return registry
-   ```
-
-2. Обновить composition root:
-   ```python
-   # src/bioetl/interfaces/composition_root.py
-
-   def _bootstrap_schema_registry(self) -> SchemaProviderABC:
-       """Bootstrap schema registry with Pandera schemas."""
-       from bioetl.domain.schemas import register_schemas
-       from bioetl.domain.schemas.registry import create_default_schema_registry
-       from bioetl.infrastructure.validation.registry_bootstrap import (
-           register_pandera_schemas,
-       )
-
-       # 1. Create empty registry
-       registry = create_default_schema_registry()
-
-       # 2. Register domain column orders
-       register_schemas(registry)
-
-       # 3. Register infrastructure Pandera schemas
-       register_pandera_schemas(registry)
-
-       return registry
-   ```
-
-### Задача 5.2: Golden-тесты на схемы
-
-```python
-# tests/infrastructure/validation/test_schema_contracts.py
-"""Golden tests for Pandera schema column structure."""
-
-import pytest
-from bioetl.domain.schemas.chembl.output_views import (
-    ACTIVITY_OUTPUT_COLUMNS,
-    ASSAY_OUTPUT_COLUMNS,
+orchestrator = PipelineOrchestrator(
+    "test_pipeline",
+    config,
+    provider_registry_factory=InMemoryProviderRegistry,
 )
-from bioetl.infrastructure.validation.schemas.chembl.activity import (
-    ActivityOutputSchema,
+```
+
+### Критерии готовности Фазы 1
+
+- [ ] В `application/orchestrator.py` нет импортов `bioetl.infrastructure.*`
+- [ ] Функция `_get_default_registry_factory()` удалена
+- [ ] `provider_registry_factory` — обязательный параметр конструктора
+- [ ] Все тесты проходят
+
+---
+
+## Фаза 2: Изоляция interfaces от infrastructure
+
+**Приоритет:** Критический
+**Источник:** docs/REFACTORING_PLAN.md
+**Решает:** A2–A9, D1–D2
+**Время:** ~6 часов
+
+### Задача 2.1: Создать порты в application слое
+
+**Новые файлы:**
+
+```
+src/bioetl/application/ports/
+├── __init__.py
+├── config_loader_port.py          # ConfigLoaderPortABC
+├── infrastructure_factory_port.py  # InfrastructureFactoryPortABC
+└── observability_factory_port.py   # ObservabilityFactoryPortABC
+```
+
+**Файл:** `src/bioetl/application/ports/config_loader_port.py`
+
+```python
+"""Port for configuration loading operations."""
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+
+from bioetl.domain.configs.pipeline import PipelineConfig
+
+
+class ConfigLoaderPortABC(ABC):
+    """Abstract port for loading pipeline configurations."""
+
+    @abstractmethod
+    def get_by_id(
+        self,
+        pipeline_id: str,
+        *,
+        profile: str | None = None,
+        cli_overrides: dict[str, Any] | None = None,
+        env_overrides: dict[str, Any] | None = None,
+    ) -> PipelineConfig:
+        """Load pipeline config by ID (e.g., 'chembl.activity')."""
+        ...
+
+    @abstractmethod
+    def get_from_path(
+        self,
+        config_path: Path,
+        *,
+        profile: str | None = None,
+        cli_overrides: dict[str, Any] | None = None,
+    ) -> PipelineConfig:
+        """Load pipeline config from explicit file path."""
+        ...
+
+
+class ConfigPathResolverPortABC(ABC):
+    """Abstract port for resolving configuration paths."""
+
+    @abstractmethod
+    def get_configs_root(self) -> Path:
+        """Return root directory for configurations."""
+        ...
+
+    @abstractmethod
+    def resolve_pipeline_path(self, pipeline_id: str) -> Path:
+        """Resolve path for a pipeline ID."""
+        ...
+```
+
+**Файл:** `src/bioetl/application/ports/infrastructure_factory_port.py`
+
+```python
+"""Port for infrastructure component factories."""
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bioetl.domain.clients.base.contracts import HttpClientABC, RateLimiterABC
+
+
+class InfrastructureFactoryPortABC(ABC):
+    """Abstract factory for infrastructure components."""
+
+    @abstractmethod
+    def create_http_client(self, base_url: str, **kwargs) -> "HttpClientABC":
+        """Create HTTP client instance."""
+        ...
+
+    @abstractmethod
+    def create_rate_limiter(
+        self, requests_per_second: float, **kwargs
+    ) -> "RateLimiterABC":
+        """Create rate limiter instance."""
+        ...
+
+
+class ABCRegistryResolverPortABC(ABC):
+    """Abstract port for resolving ABC implementations."""
+
+    @abstractmethod
+    def resolve(self, abc_name: str) -> type:
+        """Resolve implementation class for given ABC name."""
+        ...
+
+    @abstractmethod
+    def resolve_instance(self, abc_name: str, **kwargs) -> object:
+        """Resolve and instantiate implementation for given ABC name."""
+        ...
+```
+
+**Файл:** `src/bioetl/application/ports/observability_factory_port.py`
+
+```python
+"""Port for observability component factories."""
+from abc import ABC, abstractmethod
+
+from bioetl.domain.observability.contracts import (
+    LoggingPortABC,
+    MetricsPortABC,
+    TracingPortABC,
 )
-from bioetl.infrastructure.validation.schemas.chembl.assay import AssayOutputSchema
 
 
-class TestSchemaColumnContracts:
-    """Verify Pandera schemas match domain column specifications."""
+class ObservabilityFactoryPortABC(ABC):
+    """Abstract factory for observability components."""
 
-    @pytest.mark.parametrize(
-        "schema_class,expected_columns",
-        [
-            (ActivityOutputSchema, ACTIVITY_OUTPUT_COLUMNS),
-            (AssayOutputSchema, ASSAY_OUTPUT_COLUMNS),
-            # ... other schemas
-        ],
-    )
-    def test_schema_columns_match_domain_spec(
-        self, schema_class, expected_columns: list[str]
-    ) -> None:
-        """Verify schema columns match domain column order."""
-        pandera_schema = schema_class.to_schema()
-        actual_columns = list(pandera_schema.columns.keys())
+    @abstractmethod
+    def create_logger(self) -> LoggingPortABC:
+        """Create structured logger instance."""
+        ...
 
-        assert actual_columns == expected_columns, (
-            f"Schema {schema_class.__name__} columns mismatch:\n"
-            f"Expected: {expected_columns}\n"
-            f"Actual: {actual_columns}"
+    @abstractmethod
+    def create_metrics(self) -> MetricsPortABC:
+        """Create metrics collector instance."""
+        ...
+
+    @abstractmethod
+    def create_tracer(self) -> TracingPortABC | None:
+        """Create tracer instance (optional)."""
+        ...
+```
+
+### Задача 2.2: Создать адаптеры в infrastructure слое
+
+**Новые файлы:**
+
+```
+src/bioetl/infrastructure/adapters/
+├── __init__.py
+├── config_loader_adapter.py
+├── infrastructure_factory_adapter.py
+└── observability_factory_adapter.py
+```
+
+**Файл:** `src/bioetl/infrastructure/adapters/config_loader_adapter.py`
+
+```python
+"""Infrastructure adapter for config loading port."""
+from pathlib import Path
+from typing import Any
+
+from bioetl.application.ports.config_loader_port import (
+    ConfigLoaderPortABC,
+    ConfigPathResolverPortABC,
+)
+from bioetl.domain.configs.pipeline import PipelineConfig
+from bioetl.infrastructure.config.loader import (
+    get_pipeline_config,
+    get_pipeline_config_from_path,
+)
+from bioetl.infrastructure.config.sources import (
+    get_configs_root as infra_get_configs_root,
+    resolve_pipeline_config_path,
+)
+
+
+class ConfigLoaderAdapter(ConfigLoaderPortABC):
+    """Adapter implementing config loader port."""
+
+    def __init__(self, schema_contract_provider):
+        self._provider = schema_contract_provider
+
+    def get_by_id(
+        self,
+        pipeline_id: str,
+        *,
+        profile: str | None = None,
+        cli_overrides: dict[str, Any] | None = None,
+        env_overrides: dict[str, Any] | None = None,
+    ) -> PipelineConfig:
+        return get_pipeline_config(
+            pipeline_id,
+            schema_contract_provider=self._provider,
+            profile=profile,
+            cli_overrides=cli_overrides or {},
+            env_overrides=env_overrides or {},
+        )
+
+    def get_from_path(
+        self,
+        config_path: Path,
+        *,
+        profile: str | None = None,
+        cli_overrides: dict[str, Any] | None = None,
+    ) -> PipelineConfig:
+        return get_pipeline_config_from_path(
+            config_path,
+            schema_contract_provider=self._provider,
+            profile=profile,
+            cli_overrides=cli_overrides or {},
+        )
+
+
+class ConfigPathResolverAdapter(ConfigPathResolverPortABC):
+    """Adapter implementing config path resolver port."""
+
+    def __init__(self, base_dir: Path | None = None):
+        self._base_dir = base_dir
+
+    def get_configs_root(self) -> Path:
+        return infra_get_configs_root(self._base_dir)
+
+    def resolve_pipeline_path(self, pipeline_id: str) -> Path:
+        return resolve_pipeline_config_path(pipeline_id, self._base_dir)
+```
+
+### Задача 2.3: Рефакторинг CompositionRoot
+
+**Файл:** `src/bioetl/interfaces/composition_root.py`
+
+```python
+# БЫЛО (26 прямых импортов infrastructure):
+from bioetl.infrastructure.config.loader import SchemaContractLoader
+from bioetl.infrastructure.config.sources import get_configs_root
+# ... ещё импорты
+
+# СТАНЕТ (импорты только портов из application):
+from bioetl.application.ports.config_loader_port import (
+    ConfigLoaderPortABC,
+    ConfigPathResolverPortABC,
+)
+from bioetl.application.ports.infrastructure_factory_port import (
+    InfrastructureFactoryPortABC,
+    ABCRegistryResolverPortABC,
+)
+from bioetl.application.ports.observability_factory_port import (
+    ObservabilityFactoryPortABC,
+)
+
+
+class CompositionRoot:
+    """Dependency injection composition root."""
+
+    def __init__(
+        self,
+        *,
+        config_loader: ConfigLoaderPortABC | None = None,
+        config_resolver: ConfigPathResolverPortABC | None = None,
+        infrastructure_factory: InfrastructureFactoryPortABC | None = None,
+        observability_factory: ObservabilityFactoryPortABC | None = None,
+        abc_resolver: ABCRegistryResolverPortABC | None = None,
+    ):
+        # Lazy initialization - adapters created only when needed
+        self._config_loader = config_loader
+        self._config_resolver = config_resolver
+        self._infrastructure_factory = infrastructure_factory
+        self._observability_factory = observability_factory
+        self._abc_resolver = abc_resolver
+
+    def get_config_loader(self) -> ConfigLoaderPortABC:
+        if self._config_loader is None:
+            # Lazy import adapter only when actually needed
+            from bioetl.infrastructure.adapters.config_loader_adapter import (
+                ConfigLoaderAdapter,
+            )
+            self._config_loader = ConfigLoaderAdapter(
+                self._get_schema_contract_provider()
+            )
+        return self._config_loader
+
+    def get_config_resolver(self) -> ConfigPathResolverPortABC:
+        if self._config_resolver is None:
+            from bioetl.infrastructure.adapters.config_loader_adapter import (
+                ConfigPathResolverAdapter,
+            )
+            self._config_resolver = ConfigPathResolverAdapter()
+        return self._config_resolver
+
+    def get_infrastructure_factory(self) -> InfrastructureFactoryPortABC:
+        if self._infrastructure_factory is None:
+            from bioetl.infrastructure.adapters.infrastructure_factory_adapter import (
+                InfrastructureFactoryAdapter,
+            )
+            self._infrastructure_factory = InfrastructureFactoryAdapter()
+        return self._infrastructure_factory
+
+    def get_observability_factory(self) -> ObservabilityFactoryPortABC:
+        if self._observability_factory is None:
+            from bioetl.infrastructure.adapters.observability_factory_adapter import (
+                ObservabilityFactoryAdapter,
+            )
+            self._observability_factory = ObservabilityFactoryAdapter()
+        return self._observability_factory
+```
+
+### Задача 2.4: Рефакторинг остальных interfaces файлов
+
+| Файл | Действие |
+|------|----------|
+| `bootstrap_factory.py` | Использовать `ConfigLoaderPortABC` |
+| `factories/infrastructure.py` | Удалить, функционал в `CompositionRoot` |
+| `factories/observability.py` | Удалить, функционал в `CompositionRoot` |
+| `cli/app.py` | Использовать `CompositionRoot` |
+| `use_case_factory.py` | Использовать порты из `CompositionRoot` |
+| `application_context.py` | Получать зависимости из `CompositionRoot` |
+| `monitoring/__init__.py` | Использовать `ObservabilityFactoryPortABC` |
+
+### Критерии готовности Фазы 2
+
+- [ ] Все порты созданы в `application/ports/`
+- [ ] Все адаптеры созданы в `infrastructure/adapters/`
+- [ ] `CompositionRoot` использует только порты
+- [ ] Interfaces импортирует только адаптеры через lazy initialization
+- [ ] Количество разрешённых импортов infrastructure в interfaces: ≤3
+
+---
+
+## Фаза 3: Публичный API и инкапсуляция
+
+**Приоритет:** Высокий
+**Источник:** REFACTORING_PLAN_v5.md
+**Решает:** B1, B2
+**Время:** ~3.5 часа
+
+### Задача 3.1: Создание модели результата
+
+**Добавить в:** `src/bioetl/domain/models.py`
+
+```python
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ExtractOnlyResult:
+    """Result of extract-only pipeline execution."""
+    total_rows: int
+    total_chunks: int
+```
+
+### Задача 3.2: Создание публичного метода в PipelineBase
+
+**Файл:** `src/bioetl/application/pipelines/base.py`
+
+```python
+from bioetl.domain.models import ExtractOnlyResult
+
+
+class PipelineBase(ABC):
+    # ... существующий код ...
+
+    def run_extract_only(self, **kwargs: Any) -> ExtractOnlyResult:
+        """Execute only the extract stage and return statistics.
+
+        This method provides a clean public API for extract-only mode,
+        encapsulating the internal extraction logic.
+
+        Args:
+            **kwargs: Arguments passed to the extract stage.
+
+        Returns:
+            ExtractOnlyResult with row count and chunk count.
+        """
+        extract_callable = self._get_extract_callable()
+        iterator = self._normalize_extract_result(extract_callable(**kwargs))
+
+        total_rows = 0
+        total_chunks = 0
+
+        for chunk in iterator:
+            if chunk is None:
+                continue
+            total_rows += len(chunk)
+            total_chunks += 1
+
+        return ExtractOnlyResult(
+            total_rows=total_rows,
+            total_chunks=max(total_chunks, 1),
         )
 ```
 
-**Критерии готовности:**
-- [ ] `register_pandera_schemas()` создан в infrastructure
-- [ ] Composition root вызывает bootstrap схем
-- [ ] Golden-тесты на соответствие колонок проходят
-- [ ] Валидационные тесты проходят с реальными схемами
+### Задача 3.3: Обновление orchestrator
 
-**Затронутые файлы:**
-- `src/bioetl/infrastructure/validation/registry_bootstrap.py` (создать)
-- `src/bioetl/interfaces/composition_root.py` (обновить)
-- `tests/infrastructure/validation/test_schema_contracts.py` (создать)
-
----
-
-## Фаза 6: Расширение тестового покрытия (Средний)
-
-### Задача 6.1: Тест на динамические импорты в Domain
-
-**Источник:** v1 (задача 1.4) + v2 (задача 4.1)
-
-**Файл:** `tests/architecture/test_domain_boundaries.py`
-
-Тест уже существует (`test_domain_has_no_dynamic_infrastructure_imports`), но не проходит из-за `domain/configs/migration.py`. После выполнения Фазы 1 тест должен проходить.
-
-**Критерии готовности:**
-- [ ] Тест `test_domain_has_no_dynamic_infrastructure_imports` проходит
-- [ ] CI включает этот тест
-
----
-
-### Задача 6.2: Тест на abc_impls.yaml
-
-**Источник:** v2 (задача 4.2)
-
-**Файл:** `tests/architecture/test_abc_registry.py` (создать/добавить)
+**Файл:** `src/bioetl/application/orchestrator.py`
 
 ```python
-def test_infrastructure_abc_impls_has_no_application_references() -> None:
-    """Verify infrastructure abc_impls.yaml doesn't reference application."""
-    import yaml
-    from pathlib import Path
+# БЫЛО:
+if effective_type == PipelineType.EXTRACT_ONLY:
+    context = self._build_simple_context()
+    extract_callable = pipeline._get_extract_callable()  # noqa: SLF001
+    iterator = pipeline._normalize_extract_result(
+        extract_callable()
+    )  # noqa: SLF001
 
-    impls_path = Path("src/bioetl/infrastructure/clients/base/abc_impls.yaml")
-    content = impls_path.read_text(encoding="utf-8")
-    data = yaml.safe_load(content)
+    total_rows = 0
+    total_chunks = 0
+    for chunk in iterator:
+        if chunk is None:
+            continue
+        total_rows += len(chunk)
+        total_chunks += 1
+    # ... построение RunResult
 
-    violations: list[str] = []
-    for role, config in data.items():
-        default_factory = config.get("default_factory", "")
-        if "bioetl.application" in default_factory:
-            violations.append(f"{role}.default_factory -> {default_factory}")
+# СТАНЕТ:
+if effective_type == PipelineType.EXTRACT_ONLY:
+    context = self._build_simple_context()
+    extract_result = pipeline.run_extract_only()  # Публичный API!
 
-        for impl_name, impl_path in config.get("implementations", {}).items():
-            if "bioetl.application" in impl_path:
-                violations.append(f"{role}.implementations.{impl_name} -> {impl_path}")
+    stage = StageResult(
+        stage_name=StageName.EXTRACT,
+        success=True,
+        records_processed=extract_result.total_rows,
+        chunks_processed=extract_result.total_chunks,
+        duration_sec=0.0,
+        errors=[],
+    )
 
-    if violations:
-        pytest.fail(
-            "Infrastructure abc_impls.yaml must not reference application:\n"
-            + "\n".join(violations)
+    return RunResult(
+        run_id=context.run_id,
+        success=True,
+        entity_name=self._config.entity_name,
+        row_count=extract_result.total_rows,
+        # ...
+    )
+```
+
+### Критерии готовности Фазы 3
+
+- [ ] `ExtractOnlyResult` добавлен в `domain/models.py`
+- [ ] Метод `run_extract_only()` добавлен в `PipelineBase`
+- [ ] `PipelineOrchestrator` использует публичный API
+- [ ] Ни один модуль в `application/` не обращается к приватным методам пайплайна
+- [ ] Удалены комментарии `noqa: SLF001`
+- [ ] Новый метод покрыт тестами
+
+---
+
+## Фаза 4: Централизация сервисов
+
+**Приоритет:** Средний
+**Источник:** docs/REFACTORING_PLAN.md
+**Решает:** D3, D4
+**Время:** ~4 часа
+
+### Задача 4.1: Расширить контракты наблюдаемости
+
+**Файл:** `src/bioetl/domain/observability/contracts.py`
+
+```python
+from abc import ABC, abstractmethod
+from typing import Any, ContextManager
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SpanContext:
+    """Context for distributed tracing span."""
+    trace_id: str
+    span_id: str
+    parent_span_id: str | None = None
+
+
+class TracingPortABC(ABC):
+    """Abstract port for distributed tracing."""
+
+    @abstractmethod
+    def start_span(
+        self,
+        name: str,
+        *,
+        parent: SpanContext | None = None,
+        attributes: dict[str, Any] | None = None,
+    ) -> ContextManager[SpanContext]:
+        """Start a new tracing span."""
+        ...
+
+    @abstractmethod
+    def get_current_span(self) -> SpanContext | None:
+        """Get current active span context."""
+        ...
+
+
+class ObservabilityContextABC(ABC):
+    """Unified observability context combining logging, metrics, and tracing."""
+
+    @property
+    @abstractmethod
+    def logger(self) -> LoggingPortABC:
+        """Get logger instance."""
+        ...
+
+    @property
+    @abstractmethod
+    def metrics(self) -> MetricsPortABC:
+        """Get metrics instance."""
+        ...
+
+    @property
+    @abstractmethod
+    def tracer(self) -> TracingPortABC | None:
+        """Get tracer instance (optional)."""
+        ...
+
+    @abstractmethod
+    def with_context(self, **kwargs) -> "ObservabilityContextABC":
+        """Create child context with additional bound context."""
+        ...
+```
+
+### Задача 4.2: ObservabilityService
+
+**Файл:** `src/bioetl/application/services/observability_service.py`
+
+```python
+"""Unified observability service for application layer."""
+from dataclasses import dataclass
+from typing import Any
+
+from bioetl.application.ports.observability_factory_port import (
+    ObservabilityFactoryPortABC,
+)
+from bioetl.domain.observability.contracts import (
+    LoggingPortABC,
+    MetricsPortABC,
+    ObservabilityContextABC,
+    TracingPortABC,
+)
+
+
+@dataclass
+class ObservabilityContext(ObservabilityContextABC):
+    """Concrete observability context implementation."""
+
+    _logger: LoggingPortABC
+    _metrics: MetricsPortABC
+    _tracer: TracingPortABC | None
+    _bound_context: dict[str, Any]
+
+    @property
+    def logger(self) -> LoggingPortABC:
+        return self._logger.apply_bind(**self._bound_context)
+
+    @property
+    def metrics(self) -> MetricsPortABC:
+        return self._metrics
+
+    @property
+    def tracer(self) -> TracingPortABC | None:
+        return self._tracer
+
+    def with_context(self, **kwargs) -> "ObservabilityContext":
+        new_context = {**self._bound_context, **kwargs}
+        return ObservabilityContext(
+            _logger=self._logger,
+            _metrics=self._metrics,
+            _tracer=self._tracer,
+            _bound_context=new_context,
+        )
+
+
+class ObservabilityService:
+    """Service for creating and managing observability contexts."""
+
+    def __init__(self, factory: ObservabilityFactoryPortABC):
+        self._factory = factory
+        self._logger: LoggingPortABC | None = None
+        self._metrics: MetricsPortABC | None = None
+        self._tracer: TracingPortABC | None = None
+
+    def create_context(self, **initial_context) -> ObservabilityContext:
+        """Create new observability context with optional initial bindings."""
+        if self._logger is None:
+            self._logger = self._factory.create_logger()
+        if self._metrics is None:
+            self._metrics = self._factory.create_metrics()
+        if self._tracer is None:
+            self._tracer = self._factory.create_tracer()
+
+        return ObservabilityContext(
+            _logger=self._logger,
+            _metrics=self._metrics,
+            _tracer=self._tracer,
+            _bound_context=initial_context,
+        )
+
+    def create_pipeline_context(
+        self,
+        pipeline_id: str,
+        run_id: str,
+    ) -> ObservabilityContext:
+        """Create context specifically for pipeline execution."""
+        return self.create_context(
+            pipeline_id=pipeline_id,
+            run_id=run_id,
         )
 ```
 
----
+### Задача 4.3: ConfigurationService
 
-### Задача 6.3: Unit-тесты orchestrator с моками
-
-**Источник:** v2 (задача 4.3)
-
-**Файл:** `tests/bioetl/application/test_orchestrator_unit.py` (создать)
+**Файл:** `src/bioetl/application/services/configuration_service.py`
 
 ```python
-"""Unit tests for PipelineOrchestrator with mocked dependencies."""
-from unittest.mock import MagicMock
+"""Centralized configuration service for application layer."""
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
 
-import pytest
-
-from bioetl.application.orchestrator import PipelineOrchestrator
-from bioetl.domain.configs import PipelineConfig
-from bioetl.domain.provider_registry import ProviderRegistryABC
-
-
-@pytest.fixture
-def mock_registry() -> MagicMock:
-    return MagicMock(spec=ProviderRegistryABC)
+from bioetl.application.ports.config_loader_port import (
+    ConfigLoaderPortABC,
+    ConfigPathResolverPortABC,
+)
+from bioetl.domain.configs.pipeline import PipelineConfig
 
 
-@pytest.fixture
-def mock_config() -> PipelineConfig:
-    # Minimal valid config
-    return PipelineConfig(...)
+@dataclass(frozen=True)
+class ConfigurationRequest:
+    """Request for loading configuration."""
+    pipeline_id: str | None = None
+    config_path: Path | None = None
+    profile: str | None = None
+    cli_overrides: dict[str, Any] | None = None
+    env_overrides: dict[str, Any] | None = None
 
 
-def test_orchestrator_uses_injected_registry(
-    mock_config: PipelineConfig,
-    mock_registry: MagicMock,
-) -> None:
-    """Orchestrator should use injected registry without infrastructure imports."""
-    orchestrator = PipelineOrchestrator(
-        "test_pipeline",
-        mock_config,
-        provider_registry=mock_registry,
-    )
+class ConfigurationService:
+    """Centralized service for all configuration operations."""
+
+    def __init__(
+        self,
+        loader: ConfigLoaderPortABC,
+        path_resolver: ConfigPathResolverPortABC,
+    ):
+        self._loader = loader
+        self._path_resolver = path_resolver
+
+    def load(self, request: ConfigurationRequest) -> PipelineConfig:
+        """Load configuration based on request parameters."""
+        if request.config_path:
+            return self._loader.get_from_path(
+                request.config_path,
+                profile=request.profile,
+                cli_overrides=request.cli_overrides,
+            )
+
+        if request.pipeline_id:
+            return self._loader.get_by_id(
+                request.pipeline_id,
+                profile=request.profile,
+                cli_overrides=request.cli_overrides,
+                env_overrides=request.env_overrides,
+            )
+
+        raise ValueError("Either pipeline_id or config_path must be provided")
+
+    def get_configs_root(self) -> Path:
+        """Get root directory for configurations."""
+        return self._path_resolver.get_configs_root()
+
+    def list_available_pipelines(self) -> list[str]:
+        """List all available pipeline IDs."""
+        configs_root = self.get_configs_root()
+        pipelines = []
+
+        for provider_dir in configs_root.iterdir():
+            if provider_dir.is_dir() and not provider_dir.name.startswith("_"):
+                for config_file in provider_dir.glob("*.yaml"):
+                    pipeline_id = f"{provider_dir.name}.{config_file.stem}"
+                    pipelines.append(pipeline_id)
+
+        return sorted(pipelines)
+```
+
+### Задача 4.4: Интеграция сервисов в CompositionRoot
+
+**Обновить:** `src/bioetl/interfaces/composition_root.py`
+
+```python
+from bioetl.application.services.configuration_service import ConfigurationService
+from bioetl.application.services.observability_service import ObservabilityService
+
+
+class CompositionRoot:
     # ...
+
+    def get_configuration_service(self) -> ConfigurationService:
+        """Get centralized configuration service."""
+        if self._configuration_service is None:
+            self._configuration_service = ConfigurationService(
+                loader=self.get_config_loader(),
+                path_resolver=self.get_config_resolver(),
+            )
+        return self._configuration_service
+
+    def get_observability_service(self) -> ObservabilityService:
+        """Get centralized observability service."""
+        if self._observability_service is None:
+            self._observability_service = ObservabilityService(
+                factory=self.get_observability_factory(),
+            )
+        return self._observability_service
 ```
+
+### Критерии готовности Фазы 4
+
+- [ ] Контракты наблюдаемости расширены (TracingPortABC, ObservabilityContextABC)
+- [ ] `ObservabilityService` создан и интегрирован
+- [ ] `ConfigurationService` создан и интегрирован
+- [ ] Use cases используют ObservabilityService
+- [ ] CLI использует ConfigurationService
 
 ---
 
-### Задача 6.4: Тест на отсутствие глобального состояния в Domain
+## Фаза 5: Усиление архитектурных тестов
 
-**Источник:** v1 (раздел "Метрики и тесты")
+**Приоритет:** Высокий
+**Источник:** REFACTORING_PLAN_v5.md + docs/REFACTORING_PLAN.md
+**Решает:** D5, D6
+**Время:** ~2.5 часа
+
+### Задача 5.1: Тест на инфраструктурные импорты в application
+
+**Файл:** `tests/architecture/test_layer_dependencies.py`
 
 ```python
-# tests/architecture/test_domain_boundaries.py
+# Whitelist: разрешённые инфраструктурные импорты
+APPLICATION_ALLOWED_INFRA_IMPORTS: set[str] = set()  # Пустой — ничего не разрешено
 
-def test_no_global_mutable_state_in_domain() -> None:
-    """Verify domain has no module-level mutable global state."""
-    import ast
-    from pathlib import Path
 
-    domain_root = Path("src/bioetl/domain")
+def test_application_has_no_infrastructure_imports() -> None:
+    """Verify application layer has no direct infrastructure imports.
+
+    This is stricter than test_application_avoids_infrastructure_implementations
+    which only checks for 'impl' modules. This test catches ANY infrastructure
+    import.
+    """
     violations: list[str] = []
 
-    for py_file in domain_root.rglob("*.py"):
-        tree = ast.parse(py_file.read_text())
-        for node in ast.walk(tree):
-            if isinstance(node, ast.AnnAssign):
-                # Check for _VARIABLE: Type = None pattern
-                if (
-                    isinstance(node.target, ast.Name)
-                    and node.target.id.startswith("_")
-                    and not node.target.id.isupper()
-                ):
-                    violations.append(f"{py_file}: {node.target.id}")
+    for file_path in sorted(APPLICATION_ROOT.rglob("*.py")):
+        for reference in _collect_imports(file_path):
+            if not reference.module.startswith("bioetl.infrastructure"):
+                continue
 
-    if violations:
-        pytest.fail(
-            "Domain should not have mutable global state:\n"
-            + "\n".join(violations)
-        )
+            # Проверяем whitelist
+            if reference.module in APPLICATION_ALLOWED_INFRA_IMPORTS:
+                continue
+
+            violations.append(
+                _format_violation(
+                    file_path,
+                    reference.lineno,
+                    f"application must not import infrastructure "
+                    f"(found {reference.module})",
+                )
+            )
+
+    _assert_no_violations(violations)
 ```
 
-**Критерии готовности Фазы 6:**
-- [ ] Все архитектурные тесты проходят
-- [ ] Тест на abc_impls.yaml добавлен и проходит (после Фазы 3)
-- [ ] Unit-тесты orchestrator созданы
-- [ ] Тест на глобальное состояние добавлен
+### Задача 5.2: Тест на инфраструктурные импорты в interfaces
 
----
+```python
+INTERFACES_ALLOWED_INFRA_IMPORTS: dict[str, set[str]] = {
+    # Only adapters allowed, and only in composition_root.py
+    "composition_root.py": {
+        "bioetl.infrastructure.adapters.config_loader_adapter",
+        "bioetl.infrastructure.adapters.infrastructure_factory_adapter",
+        "bioetl.infrastructure.adapters.observability_factory_adapter",
+    }
+}
 
-## Фаза 7: Усиление наблюдаемости (Низкий)
 
-**Источник:** v1 (Фаза 4)
+def test_interfaces_has_limited_infrastructure_imports() -> None:
+    """Verify interfaces layer only imports allowed infrastructure modules."""
+    violations: list[str] = []
 
-### Задача 7.1: Стандартизация логирования по слоям
+    for file_path in sorted(INTERFACES_ROOT.rglob("*.py")):
+        allowed = INTERFACES_ALLOWED_INFRA_IMPORTS.get(file_path.name, set())
 
-1. Создать `src/bioetl/domain/observability/log_context.py`:
-   ```python
-   from dataclasses import dataclass, asdict
+        for reference in _collect_imports(file_path):
+            if not reference.module.startswith("bioetl.infrastructure"):
+                continue
+            if reference.module in allowed:
+                continue
 
-   @dataclass(frozen=True)
-   class PipelineLogContext:
-       """Structured context for pipeline logs."""
-       run_id: str
-       provider: str
-       entity: str
-       stage: str  # extract | transform | load | validate
+            violations.append(
+                _format_violation(
+                    file_path,
+                    reference.lineno,
+                    f"interfaces must not import infrastructure directly "
+                    f"(found {reference.module})",
+                )
+            )
 
-       def as_dict(self) -> dict[str, str]:
-           return asdict(self)
-   ```
+    _assert_no_violations(violations)
+```
 
-2. Обновить `PipelineBase` для автоматического контекста
+### Задача 5.3: Тест на приватные атрибуты
 
-### Задача 7.2: Добавление метрик по стадиям
+```python
+import re
 
-Целевые метрики:
+PRIVATE_ATTR_PATTERN = re.compile(r"\._[a-z_]+\(")  # Вызовы приватных методов
 
-| Метрика | Тип | Описание |
-|---------|-----|----------|
-| `pipeline_stage_duration_seconds` | Histogram | Время выполнения стадии |
-| `pipeline_records_processed_total` | Counter | Количество обработанных записей |
-| `pipeline_validation_errors_total` | Counter | Количество ошибок валидации |
-| `pipeline_runs_total` | Counter | Количество запусков (success/failure) |
 
----
+def test_no_cross_module_private_access() -> None:
+    """Verify no module accesses private attributes of other modules.
 
-## Фаза 8: Документация и линтеры (Низкий)
+    This catches patterns like:
+    - pipeline._get_extract_callable()
+    - service._internal_method()
+    """
+    violations: list[str] = []
 
-### Задача 8.1: Обновление .importlinter
+    for file_path in sorted(APPLICATION_ROOT.rglob("*.py")):
+        content = file_path.read_text(encoding="utf-8")
 
-**Источник:** v2 (задача 5.1)
+        for line_no, line in enumerate(content.splitlines(), 1):
+            # Пропускаем строки внутри класса (self._method)
+            if "self._" in line:
+                continue
+            if "cls._" in line:
+                continue
 
-После выполнения фаз 1-4 обновить `.importlinter`:
+            # Ищем внешние обращения к приватным методам
+            matches = PRIVATE_ATTR_PATTERN.findall(line)
+            if matches:
+                violations.append(
+                    _format_violation(
+                        file_path,
+                        line_no,
+                        f"cross-module private attribute access: {matches}",
+                    )
+                )
+
+    _assert_no_violations(violations)
+```
+
+### Задача 5.4: Интеграция с ruff
+
+**Обновить:** `pyproject.toml`
+
+```toml
+[tool.ruff.lint]
+select = [
+    # ... существующие правила
+    "SLF001",  # Private member accessed
+]
+
+# Убрать из per-file-ignores:
+# [tool.ruff.lint.per-file-ignores]
+# "src/bioetl/application/orchestrator.py" = ["SLF001"]  # УДАЛИТЬ!
+```
+
+### Задача 5.5: Обновление .importlinter
+
+**Файл:** `.importlinter`
 
 ```ini
-[contract:application_allowed_dependencies]
-name = Application imports domain only
+[contract:interfaces_no_direct_infrastructure]
+name = Interfaces layer must not import infrastructure directly
 type = forbidden
-source_modules =
-    bioetl.application
-forbidden_modules =
-    bioetl.infrastructure
-    bioetl.interfaces
-# Убрать все ignore_imports для infrastructure
+source_modules = bioetl.interfaces
+forbidden_modules = bioetl.infrastructure
+ignore_imports =
+    # ТОЛЬКО адаптеры разрешены для lazy initialization в CompositionRoot
+    bioetl.interfaces.composition_root -> bioetl.infrastructure.adapters.config_loader_adapter
+    bioetl.interfaces.composition_root -> bioetl.infrastructure.adapters.infrastructure_factory_adapter
+    bioetl.interfaces.composition_root -> bioetl.infrastructure.adapters.observability_factory_adapter
 ```
 
-### Задача 8.2: Обновление ARCHITECTURE.md
+### Критерии готовности Фазы 5
 
-**Источник:** v2 (задача 5.2)
-
-Добавить раздел о границах слоёв:
-
-```markdown
-## Layer Boundaries
-
-### Domain Layer
-- NEVER imports from infrastructure, application, or interfaces
-- NEVER uses importlib to dynamically import other layers
-- Contains only: contracts (ABC, Protocol), value objects, pure business logic
-
-### Application Layer
-- MAY import from domain only
-- NEVER imports from infrastructure or interfaces
-- Contains: use cases, orchestration, factories, mappers
-
-### Infrastructure Layer
-- MAY import from domain only
-- NEVER imports from application or interfaces
-- Contains: HTTP clients, file I/O, databases, external services
-
-### Interfaces Layer
-- MAY import from all layers
-- Contains: CLI, REST, composition root, dependency wiring
-```
-
-### Задача 8.3: Документация по мониторингу
-
-**Создать:** `docs/operations/monitoring.md`
+- [ ] Тест `test_application_has_no_infrastructure_imports` добавлен и проходит
+- [ ] Тест `test_interfaces_has_limited_infrastructure_imports` добавлен и проходит
+- [ ] Тест `test_no_cross_module_private_access` добавлен и проходит
+- [ ] ruff правило SLF001 включено без исключений для orchestrator
+- [ ] `.importlinter` обновлён с минимальными исключениями
+- [ ] CI блокирует регресс
 
 ---
 
-## Метрики успеха
+## Фаза 6: Устранение технического долга
 
-### Количественные метрики
+**Приоритет:** Низкий
+**Источник:** REFACTORING_PLAN_v4.md
+**Решает:** C1, C2, C3
+**Время:** ~9.5 часов
 
-| Метрика | До | После (ожидание) |
-|---------|-----|------------------|
-| Импорты infrastructure в application | 1 (orchestrator.py) | 0 |
-| Прокси-модули infra→app | 1 (csv_record_source) | 0 |
-| Динамические импорты в domain | 1 (migration.py) | 0 |
-| Application-ссылки в infra YAML | 6 (abc_impls.yaml) | 0 |
-| ignore_imports в .importlinter | 15+ | <5 |
-| Схемы с `None` вместо Pandera | ~7 | 0 |
-| Глобальные переменные состояния | 2 | 0 (deprecated) |
+### Задача 6.1: Ликвидация глобального состояния ProviderRegistry
 
-### Оценка по категориям
+**Файл:** `src/bioetl/domain/provider_registry.py`
 
-| Категория | До | После |
+Удалить:
+- `_PROVIDER_REGISTRY: ProviderRegistryABC | None = None`
+- `set_provider_registry()`
+- `get_provider_registry()`
+- `default_provider_registry()`
+
+Все места использования должны получать registry через DI.
+
+### Задача 6.2: Вынос Pandera-зависимости из Domain
+
+**Файл:** `src/bioetl/domain/schemas/generator.py`
+
+Перенести динамические импорты Pandera/YAML в infrastructure.
+
+### Задача 6.3: Сокращение ignore_imports в .importlinter
+
+**Текущее количество:** 13 исключений
+**Целевое количество:** ≤3
+
+---
+
+## Метрики и контроль
+
+### Метрики качества
+
+| Метрика | Текущее | Целевое | Команда проверки |
+|---------|:-------:|:-------:|------------------|
+| infrastructure импорты в application | 1 | 0 | `grep -rn "bioetl.infrastructure" src/bioetl/application/` |
+| infrastructure импорты в interfaces | 26 | ≤3 | `grep -rn "bioetl.infrastructure" src/bioetl/interfaces/` |
+| Приватные вызовы (cross-module) | 2 | 0 | `grep -rn "\._[a-z_]*(" src/bioetl/application/ \| grep -v "self\._"` |
+| `noqa: SLF001` в orchestrator | 2 | 0 | `grep -c "noqa: SLF001" src/bioetl/application/orchestrator.py` |
+| ignore_imports в .importlinter | 13 | ≤3 | Подсчёт строк |
+| Архитектурные тесты | pass | pass | `pytest tests/architecture/ -v` |
+
+### Покрытие портов
+
+| Измерение | Целевое значение |
+|-----------|------------------|
+| Порты с адаптерами | 100% |
+| Порты с unit-тестами | ≥80% |
+| Адаптеры с интеграционными тестами | ≥60% |
+
+### Наблюдаемость
+
+| Измерение | До | После |
 |-----------|-----|-------|
-| Слоистая архитектура | 6-7 | 8 |
-| Ports & Adapters / DDD | 6 | 7 |
-| Модульность и связность | 5-6 | 8 |
-| Конфигурация и DI | 5.5 | 7.5 |
-| Валидация данных и схемы | 5 | 7 |
-| Тестирование и QA-гейты | 6-7 | 8 |
-| Логирование и наблюдаемость | 6 | 7 |
-| **Интегральный балл** | **6.15-6.38** | **~8.0** |
+| Шаги с обязательным логированием | ~40% | ≥90% |
+| Пайплайны с метриками | 0% | 100% |
+| Use cases с трассировкой | 0% | ≥50% |
 
----
-
-## Порядок выполнения
-
-```
-Фаза 1: Устранение нарушений границ слоёв (Критично)
-├── 1.1 Удаление ConfigMigrator прокси из domain
-├── 1.2 Удаление csv_record_source прокси из infrastructure
-└── 1.3 Проверка InMemoryProviderRegistry прокси
-
-Фаза 2: Декуплинг Application от Infrastructure (Критично)
-└── 2.1 Внедрение ProviderRegistry через DI в Orchestrator
-
-Фаза 3: Реорганизация ABC-реестров (Высокий)
-└── 3.1 Разделение abc_impls.yaml по слоям
-
-Фаза 4: Избавление от глобального состояния (Высокий)
-├── 4.1 Анализ текущего глобального состояния
-└── 4.2 Внедрение реестра через DI-контейнер
-
-Фаза 5: Регистрация схем и валидация (Средний)
-├── 5.1 Создание infrastructure bootstrap для схем
-└── 5.2 Golden-тесты на схемы
-
-Фаза 6: Расширение тестового покрытия (Средний)
-├── 6.1 Тест на динамические импорты в Domain
-├── 6.2 Тест на abc_impls.yaml
-├── 6.3 Unit-тесты orchestrator с моками
-└── 6.4 Тест на глобальное состояние
-
-Фаза 7: Усиление наблюдаемости (Низкий)
-├── 7.1 Стандартизация логирования
-└── 7.2 Добавление метрик по стадиям
-
-Фаза 8: Документация и линтеры (Низкий)
-├── 8.1 Обновление .importlinter
-├── 8.2 Обновление ARCHITECTURE.md
-└── 8.3 Документация по мониторингу
-```
-
----
-
-## Команды для проверки
+### Полная проверка
 
 ```bash
-# Проверка импортов application→infrastructure
-grep -r "from bioetl.infrastructure" src/bioetl/application/
-
-# Проверка импортов infrastructure→application
-grep -r "from bioetl.application" src/bioetl/infrastructure/
-
-# Проверка динамических импортов в domain
-grep -r "importlib.import_module" src/bioetl/domain/
-
-# Проверка abc_impls.yaml
-grep "bioetl\.application" src/bioetl/infrastructure/clients/base/abc_impls.yaml
-
-# Проверка глобальных переменных
-grep -rn "^_[A-Z].*: .* = None$" src/bioetl/domain/
-
-# Архитектурные тесты
-pytest tests/architecture/ tests/project_rules/ -v
-
-# Import linter
+# Все проверки одной командой
+pytest tests/architecture/ tests/project_rules/ -v && \
+grep -rn "bioetl.infrastructure" src/bioetl/application/ && \
+grep -rn "noqa: SLF001" src/bioetl/application/ && \
 lint-imports
 ```
 
 ---
 
+## План выполнения
+
+```
+═══════════════════════════════════════════════════════════════════════════
+                         ОБЩИЙ ПЛАН ВЫПОЛНЕНИЯ
+═══════════════════════════════════════════════════════════════════════════
+
+ФАЗА 1: Изоляция application от infrastructure (v5)         [3.5 ч]
+├── 1.1 Удаление fallback в orchestrator
+├── 1.2 Фабрика в composition root
+├── 1.3 Обновление точек входа
+└── 1.4 Обновление тестов
+
+ФАЗА 2: Изоляция interfaces от infrastructure (v1)          [6 ч]
+├── 2.1 Создание портов в application/ports/
+├── 2.2 Создание адаптеров в infrastructure/adapters/
+├── 2.3 Рефакторинг CompositionRoot
+└── 2.4 Рефакторинг остальных interfaces файлов
+
+ФАЗА 3: Публичный API и инкапсуляция (v5)                   [3.5 ч]
+├── 3.1 Модель ExtractOnlyResult в domain
+├── 3.2 Метод run_extract_only() в PipelineBase
+└── 3.3 Обновление orchestrator
+
+ФАЗА 4: Централизация сервисов (v1)                         [4 ч]
+├── 4.1 Расширение контрактов наблюдаемости
+├── 4.2 ObservabilityService
+├── 4.3 ConfigurationService
+└── 4.4 Интеграция в CompositionRoot
+
+ФАЗА 5: Усиление архитектурных тестов (v5 + v1)             [2.5 ч]
+├── 5.1 Тест на инфраструктурные импорты в application
+├── 5.2 Тест на инфраструктурные импорты в interfaces
+├── 5.3 Тест на приватные атрибуты
+├── 5.4 Интеграция с ruff
+└── 5.5 Обновление .importlinter
+
+ФАЗА 6: Устранение технического долга (v4)                  [9.5 ч]
+├── 6.1 Глобальное состояние ProviderRegistry
+├── 6.2 Pandera в Domain
+└── 6.3 Сокращение ignore_imports
+
+═══════════════════════════════════════════════════════════════════════════
+                     ИТОГО: ~29 часов
+═══════════════════════════════════════════════════════════════════════════
+
+РЕКОМЕНДУЕМЫЙ ПОРЯДОК:
+──────────────────────────────────────────────────────────────────────────
+  Фаза 1 → Фаза 3 → Фаза 5 (частично) → Фаза 2 → Фаза 4 → Фаза 5 → Фаза 6
+
+  Логика: сначала критические нарушения в application (v5), затем interfaces
+  (v1), архитектурные тесты добавляются по мере готовности компонентов.
+```
+
+---
+
+## Ожидаемые результаты
+
+### Прогноз изменения оценок
+
+| Категория | Текущая | После фаз 1-5 | После всех фаз | Δ |
+|-----------|:-------:|:-------------:|:--------------:|:-:|
+| Слоистая архитектура | 6.5 | 8 | 8.5 | +2 |
+| Ports & Adapters | 6 | 7.5 | 8 | +2 |
+| Границы модулей | 6 | 7.5 | 7.5 | +1.5 |
+| Качество доменной модели | 7 | 7 | 7.5 | +0.5 |
+| Контракты и конфигурация | 6 | 7 | 7 | +1 |
+| Обработка ошибок | 6 | 6 | 6 | 0 |
+| Тестирование и QA | 6 | 7 | 7.5 | +1.5 |
+| Наблюдаемость | 5 | 7 | 7 | +2 |
+| Сопровождаемость | 6 | 7 | 7.5 | +1.5 |
+
+### Прогноз интегрального балла
+
+| Этап | Балл |
+|------|:----:|
+| Текущий | 6.36 |
+| После фаз 1-3 (критические) | ~7.0 |
+| После фаз 1-5 | ~7.3 |
+| После всех фаз | **7.5–7.8** |
+
+---
+
+## Риски и митигация
+
+| Риск | Вероятность | Влияние | Митигация |
+|------|:-----------:|:-------:|-----------|
+| Поломка существующих вызовов orchestrator | Высокая | Среднее | Deprecation warnings на 1-2 релиза |
+| Ложные срабатывания архитектурных тестов | Средняя | Низкое | Whitelist для допустимых случаев |
+| Несовместимость с internal CLI | Средняя | Среднее | Обновить CLI вместе с composition root |
+| Регрессии в тестах | Средняя | Среднее | Полный тест-сьют после каждой фазы |
+| Усложнение DI | Низкая | Низкое | Документирование графа зависимостей |
+| Потеря производительности | Низкая | Низкое | Lazy initialization адаптеров |
+
+### Стратегия миграции
+
+1. **Фаза deprecation:** Добавить warnings в устаревший код
+   ```python
+   warnings.warn(
+       "Using default registry factory is deprecated. "
+       "Pass provider_registry_factory explicitly.",
+       DeprecationWarning,
+       stacklevel=3,
+   )
+   ```
+
+2. **Фаза обновления:** Обновить все точки входа на явный DI
+
+3. **Фаза удаления:** Удалить deprecated код, сделать параметры обязательными
+
+---
+
 ## Ссылки
 
-- [REFACTORING_PLAN.md](./REFACTORING_PLAN.md) — исходный план v1
-- [REFACTORING_PLAN_v2.md](./REFACTORING_PLAN_v2.md) — план v2 с фокусом на границы слоёв
-- [Domain Layer Audit](./18-domain-layer-audit.md)
-- [Architecture Tests](../../tests/architecture/)
-- [.importlinter](../../.importlinter)
+- [docs/REFACTORING_PLAN.md](../REFACTORING_PLAN.md) — план v1 (interfaces layer)
+- [REFACTORING_PLAN_v5.md](./REFACTORING_PLAN_v5.md) — план v5 (application layer)
+- [REFACTORING_PLAN_v4.md](./REFACTORING_PLAN_v4.md) — план v4 (технический долг)
+- [architecture.md](./architecture.md)
+- [PipelineOrchestrator](../../src/bioetl/application/orchestrator.py)
+- [PipelineBase](../../src/bioetl/application/pipelines/base.py)
+- [CompositionRoot](../../src/bioetl/interfaces/composition_root.py)
+- [test_layer_dependencies.py](../../tests/architecture/test_layer_dependencies.py)


### PR DESCRIPTION
Consolidate two refactoring plans with different focuses:
- REFACTORING_PLAN_v5.md: application layer isolation + encapsulation
- docs/REFACTORING_PLAN.md: interfaces layer isolation (26 imports)

Key changes in merged plan:
- 6 phases covering all identified issues
- Prioritized task list with IDs and sources
- Unified architecture violations map
- Combined metrics and expected outcomes
- ~29 hours total estimated effort
- Target: 6.36 → 7.5-7.8 architecture score