### PR TITLE
Review and improve code architecture quality

### DIFF
--- a/src/bioetl/application/orchestrator.py
+++ b/src/bioetl/application/orchestrator.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 from concurrent.futures import Future
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable
-import warnings
 
 if TYPE_CHECKING:
     from concurrent.futures import ProcessPoolExecutor
@@ -56,29 +55,24 @@ from bioetl.domain.value_objects import EntityName, StageName
 ProviderLoaderProtocol = ProviderRegistryLoaderABC
 
 
-def _get_default_registry_factory_deprecated() -> ProviderRegistryFactory:
-    """Get the default provider registry factory (DEPRECATED).
-
-    .. deprecated:: 1.0
-        Use ``create_provider_registry_factory()`` from
-        ``bioetl.interfaces.factories`` instead.
-
-    This function lazily imports from infrastructure to provide backward
-    compatibility. New code should inject the factory explicitly via
-    ``provider_registry_factory`` parameter.
-
-    Returns:
-        Factory function that creates InMemoryProviderRegistry instances.
-    """
-    # Lazy import from infrastructure (allowed for backward compatibility)
-    # Note: This is deprecated and should be replaced with dependency injection
-    from bioetl.infrastructure.provider_registry import InMemoryProviderRegistry
-
-    return InMemoryProviderRegistry
-
-
 class PipelineOrchestrator:
-    """Manages pipeline assembly and execution."""
+    """Manages pipeline assembly and execution.
+
+    Args:
+        pipeline_name: Name of the pipeline to execute.
+        config: Pipeline configuration.
+        provider_registry: Optional pre-configured provider registry.
+        provider_registry_provider: Callable that returns a provider registry.
+        provider_registry_factory: Factory for creating provider registries.
+            Required parameter - use create_provider_registry_factory()
+            from bioetl.interfaces.factories.
+        container_factory: Factory for creating pipeline containers.
+        provider_loader: Loader for provider definitions.
+        provider_loader_factory: Factory for creating provider loaders.
+
+    Raises:
+        ValueError: If provider_registry_factory is not provided.
+    """
 
     def __init__(
         self,
@@ -87,7 +81,7 @@ class PipelineOrchestrator:
         *,
         provider_registry: ProviderRegistryABC | None = None,
         provider_registry_provider: Callable[[], ProviderRegistryABC] | None = None,
-        provider_registry_factory: ProviderRegistryFactory | None = None,
+        provider_registry_factory: ProviderRegistryFactory,
         container_factory: Callable[..., PipelineContainerABC] | None = None,
         provider_loader: ProviderLoaderProtocol | None = None,
         provider_loader_factory: Callable[[], ProviderLoaderProtocol] | None = None,
@@ -96,20 +90,7 @@ class PipelineOrchestrator:
         self._config = config
         self._provider_registry = provider_registry
         self._provider_registry_provider = provider_registry_provider
-
-        if provider_registry_factory is None:
-            warnings.warn(
-                "Using default provider_registry_factory is deprecated. "
-                "Pass provider_registry_factory explicitly via "
-                "create_provider_registry_factory() from bioetl.interfaces.factories. "
-                "This will become a required parameter in a future release.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            self._provider_registry_factory = _get_default_registry_factory_deprecated()
-        else:
-            self._provider_registry_factory = provider_registry_factory
-
+        self._provider_registry_factory = provider_registry_factory
         self._container_factory = self._resolve_container_factory(container_factory)
         self._provider_loader = provider_loader
         self._provider_loader_factory = provider_loader_factory
@@ -243,6 +224,7 @@ class PipelineOrchestrator:
             self._provider_loader_factory,
             self._container_factory,
             registry_snapshot,
+            self._provider_registry_factory,
         )
 
         if created_executor:
@@ -259,16 +241,20 @@ class PipelineOrchestrator:
         provider_loader_factory: Callable[[], ProviderLoaderProtocol] | None,
         container_factory: Callable[..., PipelineContainerABC] | None,
         registry_payload: list[ProviderDefinition] | None,
+        registry_factory: ProviderRegistryFactory,
     ) -> RunResult:
         config = PipelineConfig(**config_payload)
         loader = provider_loader_factory() if provider_loader_factory else None
         registry = PipelineOrchestrator._build_registry_for_subprocess(
-            loader=loader, registry_payload=registry_payload
+            loader=loader,
+            registry_payload=registry_payload,
+            registry_factory=registry_factory,
         )
         orchestrator = PipelineOrchestrator(
             pipeline_name,
             config,
             provider_registry=registry,
+            provider_registry_factory=registry_factory,
             provider_loader=loader,
             provider_loader_factory=provider_loader_factory,
             container_factory=container_factory,
@@ -345,18 +331,27 @@ class PipelineOrchestrator:
         *,
         loader: ProviderLoaderProtocol | None,
         registry_payload: list[ProviderDefinition] | None,
-        registry_factory: ProviderRegistryFactory | None = None,
+        registry_factory: ProviderRegistryFactory,
     ) -> ProviderRegistryABC:
-        factory = registry_factory or _get_default_registry_factory_deprecated()
+        """Build registry for subprocess execution.
+
+        Args:
+            loader: Optional provider loader.
+            registry_payload: Optional serialized provider definitions.
+            registry_factory: Factory for creating registry instances.
+
+        Returns:
+            Configured provider registry.
+        """
         if registry_payload is not None:
-            registry = factory()
+            registry = registry_factory()
             registry.restore_provider_registry(registry_payload)
             return registry
 
         if loader is not None:
-            return loader.get_registry(registry=factory())
+            return loader.get_registry(registry=registry_factory())
 
-        return factory()
+        return registry_factory()
 
 
 __all__ = ["PipelineOrchestrator"]

--- a/src/bioetl/domain/ARCHITECTURE.md
+++ b/src/bioetl/domain/ARCHITECTURE.md
@@ -1,0 +1,200 @@
+# Domain Layer Architecture
+
+This document describes the architectural rules and conventions for the `bioetl.domain` layer.
+
+## Overview
+
+The domain layer contains pure business logic without external dependencies. It defines:
+
+- **Ports (ABCs/Protocols)**: Interfaces that infrastructure adapters implement
+- **Domain Models**: Core business entities and value objects
+- **Errors**: Domain-specific exceptions
+- **Contracts**: Type definitions and protocols
+- **Services**: Pure business logic services
+
+## Layer Dependencies
+
+### Forbidden Imports
+
+The domain layer must NOT import from:
+
+```python
+# FORBIDDEN - Infrastructure concerns
+from bioetl.infrastructure import *
+from bioetl.application import *
+from bioetl.interfaces import *
+
+# FORBIDDEN - External libraries (infrastructure concerns)
+import pandas
+import pandera
+import requests
+import httpx
+import yaml
+import boto3
+import sqlalchemy
+
+# FORBIDDEN - Framework-specific
+from pydantic import *  # Use only for configs, not domain models
+```
+
+### Allowed Imports
+
+```python
+# Standard library only
+from typing import Any, Protocol, Iterator
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from datetime import datetime
+import re
+
+# Domain internal imports
+from bioetl.domain.ports import *
+from bioetl.domain.errors import *
+from bioetl.domain.models import *
+from bioetl.domain.types import *
+```
+
+## Module Structure
+
+```
+domain/
+├── clients/           # Client contracts (DataClientABC, etc.)
+│   ├── base/         # Base client contracts
+│   ├── contracts.py  # Main client ABCs
+│   └── resilience.py # Retry/timeout policies
+├── configs/          # Configuration models (Pydantic allowed here)
+├── data.py           # TabularData protocol, RecordBatch
+├── errors.py         # Domain exceptions
+├── models/           # Domain models (RunContext, RunResult, etc.)
+├── observability/    # Logging/metrics ports
+├── pipelines/        # Pipeline contracts and types
+├── ports/            # Port interfaces (hexagonal boundaries)
+│   ├── extraction.py
+│   ├── parsing.py
+│   ├── request_building.py
+│   └── ...
+├── providers/        # Provider definitions
+├── schemas/          # Pipeline contracts and validation schemas
+├── services/         # Pure domain services
+├── transform/        # Transformation contracts
+├── types.py          # Type aliases
+├── validation/       # Validation contracts
+└── value_objects.py  # Immutable value objects
+```
+
+## Key Contracts
+
+### Ports (Hexagonal Architecture)
+
+| Port | Location | Purpose |
+|------|----------|---------|
+| `ExtractionServiceABC` | `ports/extraction.py` | Data extraction contract |
+| `ResponseParserPortABC` | `ports/parsing.py` | Response parsing contract |
+| `RequestBuilderPortABC` | `ports/request_building.py` | Request building contract |
+| `LoaderABC` | `pipelines/contracts.py` | Data loading contract |
+| `LoggingPortABC` | `observability/contracts.py` | Logging contract |
+
+### Data Abstractions
+
+| Type | Location | Purpose |
+|------|----------|---------|
+| `TabularData` | `data.py` | Protocol for tabular data (abstracts pandas) |
+| `RecordBatch` | `data.py` | Type alias for list[dict] records |
+| `ApiPayload` | `types.py` | Type alias for API response data |
+
+### Exceptions
+
+| Exception | Purpose |
+|-----------|---------|
+| `BioetlError` | Base exception |
+| `ClientError` | Client communication errors |
+| `ClientNetworkError` | Network failures |
+| `ClientRateLimitError` | Rate limit errors |
+| `MetadataFetchError` | Metadata retrieval failures |
+| `ParseError` | Response parsing failures |
+| `PipelineStageError` | Pipeline stage failures |
+
+## Design Principles
+
+### 1. Dependency Inversion
+
+The domain defines interfaces (ports), infrastructure provides implementations (adapters).
+
+```python
+# Domain defines the contract
+class ExtractionServiceABC(ABC):
+    @abstractmethod
+    def extract_all(self, entity: str, **filters) -> RecordBatch: ...
+
+# Infrastructure implements it
+class ChemblExtractionServiceImpl(ExtractionServiceABC):
+    def extract_all(self, entity: str, **filters) -> RecordBatch:
+        # Implementation with HTTP client, etc.
+        ...
+```
+
+### 2. No Business Logic Leakage
+
+Domain logic must not depend on:
+- HTTP status codes
+- Database schemas
+- File formats
+- API response structures
+
+### 3. Immutability
+
+Value objects should be immutable:
+
+```python
+@dataclass(frozen=True, slots=True)
+class EntityName:
+    value: str
+```
+
+### 4. Type Safety
+
+Use explicit types, avoid `Any`:
+
+```python
+# Good
+def process(data: RecordBatch) -> RecordBatch: ...
+
+# Avoid
+def process(data: Any) -> Any: ...
+```
+
+## Architectural Tests
+
+Domain boundaries are enforced by tests in `tests/architecture/`:
+
+- `test_domain_boundaries.py`: Verifies no forbidden imports
+- `test_layer_dependencies.py`: Verifies layer isolation
+- `test_architecture_rules.py`: Verifies ABC implementations
+
+Run architectural tests:
+```bash
+pytest tests/architecture/ -v
+```
+
+## Migration Guide
+
+### Adding New Ports
+
+1. Create ABC in `domain/ports/`
+2. Add to `domain/ports/__init__.py` exports
+3. Create infrastructure adapter
+4. Wire in `CompositionRoot`
+
+### Adding New Exceptions
+
+1. Add to `domain/errors.py`
+2. Update `__all__` exports
+3. Inherit from appropriate base (`BioetlError`, `ClientError`, etc.)
+
+## Related Documentation
+
+- [Application Layer](../application/ARCHITECTURE.md)
+- [Infrastructure Layer](../infrastructure/ARCHITECTURE.md)
+- [Interfaces Layer](../interfaces/ARCHITECTURE.md)

--- a/src/bioetl/domain/clients/base/contracts.py
+++ b/src/bioetl/domain/clients/base/contracts.py
@@ -22,7 +22,26 @@ if TYPE_CHECKING:
 
 
 class RequestBuilderABC(ABC):
-    """Builder pattern for request creation."""
+    """Builder pattern for request creation.
+
+    This ABC provides a fluent interface for constructing API requests.
+    Implementations should support endpoint configuration and pagination.
+
+    Note:
+        Consider using :class:`bioetl.domain.ports.request_building.RequestBuilderPortABC`
+        for new code - it provides a cleaner port-based contract.
+    """
+
+    @abstractmethod
+    def build_for_endpoint(self, endpoint: str) -> "RequestBuilderABC":
+        """Configure builder for a specific API endpoint.
+
+        Args:
+            endpoint: The API endpoint name (e.g., 'activity', 'assay').
+
+        Returns:
+            Self for method chaining.
+        """
 
     @abstractmethod
     def build_request(self, params: dict[str, Any]) -> Any:
@@ -48,6 +67,19 @@ class RequestBuilderABC(ABC):
             stacklevel=2,
         )
         return self.build_with_pagination(offset, limit)
+
+    def for_endpoint(self, endpoint: str) -> "RequestBuilderABC":
+        """Deprecated alias for build_for_endpoint.
+
+        .. deprecated:: 1.0
+            Use :meth:`build_for_endpoint` instead. Will be removed in 2.0.
+        """
+        warnings.warn(
+            "for_endpoint() is deprecated, use build_for_endpoint() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.build_for_endpoint(endpoint)
 
 
 # =============================================================================

--- a/src/bioetl/domain/clients/contracts.py
+++ b/src/bioetl/domain/clients/contracts.py
@@ -1,9 +1,18 @@
-"""
-Domain contracts for data clients.
+"""Domain contracts for data clients.
+
+This module defines the core abstractions for data source clients.
+Clients provide unified access to external data sources (APIs, databases)
+with support for pagination, metadata, and resource management.
+
+Protocols:
+    DataClientABC: Base contract for all data clients.
+    DataClientWithBuilderABC: Extended contract for clients with request builder.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Iterator
+from typing import Any, Iterator, Protocol, runtime_checkable
+
+from bioetl.domain.clients.base.contracts import RequestBuilderABC
 
 Record = dict[str, Any]
 
@@ -39,3 +48,61 @@ class DataClientABC(ABC):
     @abstractmethod
     def close(self) -> None:
         """Release resources (sessions, connections)."""
+
+
+@runtime_checkable
+class DataClientWithBuilderProtocol(Protocol):
+    """Protocol for data clients that expose a request builder.
+
+    This protocol extends the basic data client contract with a typed
+    request_builder property. Use this when you need access to the
+    builder for advanced request construction.
+
+    Example:
+        >>> def extract(client: DataClientWithBuilderProtocol) -> None:
+        ...     url = client.request_builder.build_for_endpoint("activity").build({})
+        ...     for page in client.iter_pages(url):
+        ...         process(page)
+    """
+
+    @property
+    def request_builder(self) -> RequestBuilderABC:
+        """Return the request builder for this client."""
+        ...
+
+    def fetch(self, entity: str, **filters: Any) -> Any:
+        """Execute query to data source."""
+        ...
+
+    def iter_pages(self, request: Any) -> Iterator[Any]:
+        """Iterator over result pages."""
+        ...
+
+    def metadata(self) -> dict[str, Any]:
+        """Source metadata."""
+        ...
+
+    def close(self) -> None:
+        """Release resources."""
+        ...
+
+
+class DataClientWithBuilderABC(DataClientABC):
+    """Abstract base class for clients with request builder.
+
+    This ABC extends DataClientABC with a required request_builder property.
+    Use this when implementing clients that need builder-based request
+    construction.
+
+    Implementations must provide both the base DataClientABC methods
+    and the request_builder property.
+    """
+
+    @property
+    @abstractmethod
+    def request_builder(self) -> RequestBuilderABC:
+        """Return the request builder for this client.
+
+        The builder is used to construct API requests with proper
+        endpoint configuration and pagination.
+        """

--- a/src/bioetl/domain/errors.py
+++ b/src/bioetl/domain/errors.py
@@ -16,6 +16,8 @@ __all__ = [
     "ClientNetworkError",
     "ClientRateLimitError",
     "ClientResponseError",
+    "MetadataFetchError",
+    "ParseError",
     "PipelineStageError",
 ]
 
@@ -80,6 +82,72 @@ class ClientRateLimitError(ClientError):
 
 class ClientResponseError(ClientError):
     """Client response errors."""
+
+
+class MetadataFetchError(ClientError):
+    """Error fetching metadata from external data source.
+
+    Raised when metadata retrieval fails due to network issues,
+    invalid responses, or service unavailability. Provides structured
+    information about the failure for observability.
+
+    Example:
+        >>> raise MetadataFetchError(
+        ...     provider="chembl",
+        ...     message="Failed to fetch release version",
+        ...     cause=original_exception,
+        ... )
+    """
+
+    def __init__(
+        self,
+        provider: str,
+        message: str,
+        *,
+        cause: Exception | None = None,
+        endpoint: str | None = "metadata",
+        fallback_value: str | None = None,
+    ) -> None:
+        super().__init__(
+            provider=provider,
+            message=message,
+            endpoint=endpoint,
+            cause=cause,
+        )
+        self.fallback_value = fallback_value
+
+
+class ParseError(ClientError):
+    """Error parsing response from external data source.
+
+    Raised when response parsing fails due to unexpected format,
+    missing fields, or invalid data. Distinguishes between recoverable
+    parse errors (empty result) and fatal parse errors.
+
+    Example:
+        >>> raise ParseError(
+        ...     provider="chembl",
+        ...     message="Unexpected response format",
+        ...     raw_response_preview=str(response)[:200],
+        ... )
+    """
+
+    def __init__(
+        self,
+        provider: str,
+        message: str,
+        *,
+        cause: Exception | None = None,
+        endpoint: str | None = None,
+        raw_response_preview: str | None = None,
+    ) -> None:
+        super().__init__(
+            provider=provider,
+            message=message,
+            endpoint=endpoint,
+            cause=cause,
+        )
+        self.raw_response_preview = raw_response_preview
 
 
 class PipelineStageError(BioetlError):

--- a/src/bioetl/domain/ports/__init__.py
+++ b/src/bioetl/domain/ports/__init__.py
@@ -41,6 +41,7 @@ from bioetl.domain.ports.parsing import (
     RawRecordList,
     ResponseParserPortABC,
 )
+from bioetl.domain.ports.request_building import RequestBuilderPortABC
 from bioetl.domain.ports.schema import SchemaContractProviderABC
 from bioetl.domain.types import ApiPayload
 
@@ -73,6 +74,8 @@ __all__: list[str] = [
     "RawRecordDict",  # Backward compatibility alias
     "RawRecordList",  # Backward compatibility alias
     "ResponseParserPortABC",
+    # Request building ports
+    "RequestBuilderPortABC",
     # Schema ports
     "SchemaContractProviderABC",
     # Configuration ports

--- a/src/bioetl/domain/ports/request_building.py
+++ b/src/bioetl/domain/ports/request_building.py
@@ -1,0 +1,107 @@
+"""Ports for building API requests.
+
+This module defines abstract contracts for constructing API requests
+following hexagonal architecture principles. Infrastructure adapters
+implement these ports to build provider-specific requests.
+
+The RequestBuilderPortABC provides a fluent interface for constructing
+URLs or request objects with pagination support.
+
+Example::
+
+    class ChemblRequestBuilder(RequestBuilderPortABC):
+        def build_for_endpoint(self, endpoint: str) -> Self:
+            self._endpoint = endpoint
+            return self
+
+        def build_request(self, params: dict[str, Any]) -> str:
+            return f"{self.base_url}/{self._endpoint}?{urlencode(params)}"
+
+        def build_with_pagination(self, offset: int, limit: int) -> Self:
+            self._params.update(offset=offset, limit=limit)
+            return self
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Self
+
+
+class RequestBuilderPortABC(ABC):
+    """Port for building API requests with fluent interface.
+
+    This abstract base class defines the contract for building API requests
+    without infrastructure-specific details. Implementations provide
+    provider-specific URL construction and pagination.
+
+    The builder uses a fluent interface pattern where methods return self
+    to allow chaining.
+
+    Example:
+        >>> builder = ChemblRequestBuilder(base_url="https://api.example.com")
+        >>> url = builder.build_for_endpoint("activity").build_request({"limit": 100})
+    """
+
+    @abstractmethod
+    def build_for_endpoint(self, endpoint: str) -> Self:
+        """Configure builder for a specific API endpoint.
+
+        Args:
+            endpoint: The API endpoint name (e.g., 'activity', 'assay').
+
+        Returns:
+            Self for method chaining.
+        """
+
+    @abstractmethod
+    def build_request(self, params: dict[str, Any]) -> Any:
+        """Build the final request from parameters.
+
+        Args:
+            params: Query parameters for the request.
+
+        Returns:
+            Request object (URL string, Request instance, etc.).
+        """
+
+    @abstractmethod
+    def build_with_pagination(self, offset: int, limit: int) -> Self:
+        """Configure pagination parameters.
+
+        Args:
+            offset: Starting position in result set.
+            limit: Maximum number of results per page.
+
+        Returns:
+            Self for method chaining.
+        """
+
+    def build(
+        self, endpoint_or_params: dict[str, Any] | str | None = None, **kwargs: Any
+    ) -> Any:
+        """Build request - convenience method.
+
+        Can be called either with:
+        - A dict of params (uses current endpoint)
+        - An endpoint string followed by params via kwargs
+        - No arguments (uses current state)
+
+        Args:
+            endpoint_or_params: Either endpoint name or params dict.
+            **kwargs: Additional params or 'params' dict.
+
+        Returns:
+            Built request object.
+        """
+        if isinstance(endpoint_or_params, str):
+            self.build_for_endpoint(endpoint_or_params)
+            params = kwargs.pop("params", {})
+            params.update(kwargs)
+            return self.build_request(params)
+        params = endpoint_or_params or {}
+        params.update(kwargs)
+        return self.build_request(params)
+
+
+__all__ = ["RequestBuilderPortABC"]

--- a/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
@@ -4,8 +4,13 @@ from __future__ import annotations
 
 from typing import Any, Iterable
 
-from bioetl.domain.clients.contracts import DataClientABC
+from bioetl.domain.clients.contracts import DataClientWithBuilderProtocol
+from bioetl.domain.clients.resilience import RetryExhaustedError
 from bioetl.domain.data import RecordBatch
+from bioetl.domain.errors import (
+    ClientError,
+    MetadataFetchError,
+)
 from bioetl.domain.observability.contracts import LoggingPortABC
 from bioetl.domain.ports.extraction import (
     ExtractionServiceABC,
@@ -13,7 +18,7 @@ from bioetl.domain.ports.extraction import (
 )
 from bioetl.domain.ports.filters import FilterEnricherABC
 from bioetl.domain.ports.parsing import ResponseParserPortABC
-from bioetl.infrastructure.clients.chembl.constants import ENTITY_ENDPOINT_ALIASES
+from bioetl.infrastructure.clients.chembl.constants import resolve_endpoint
 from bioetl.infrastructure.clients.chembl.response_parser import (
     ChemblGenericResponseParser,
 )
@@ -25,31 +30,55 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
     Returns raw dicts - domain model mapping is application layer responsibility.
     All dependencies must be explicitly injected - no default fallbacks.
     Use composition root or factories to create instances.
+
+    Args:
+        client: Data client with request builder support. Must implement
+            DataClientWithBuilderProtocol for typed access to request_builder.
+        logger: Logger for observability.
+        batch_size: Default batch size for extraction.
+        filter_enricher: Optional filter enricher for query augmentation.
+        parser: Response parser. Defaults to ChemblGenericResponseParser.
     """
 
     def __init__(
         self,
-        client: DataClientABC,
+        client: DataClientWithBuilderProtocol,
         logger: LoggingPortABC,
         batch_size: int = 1000,
         filter_enricher: FilterEnricherABC | None = None,
         *,
         parser: ResponseParserPortABC | None = None,
     ) -> None:
-        self.client = client
-        self.batch_size = batch_size
-        self.logger = logger
+        self._client = client
+        self._batch_size = batch_size
+        self._logger = logger
         self._filter_enricher = filter_enricher
         self._parser = parser or ChemblGenericResponseParser()
         self._version_cache: str | None = None
 
+    @property
+    def client(self) -> DataClientWithBuilderProtocol:
+        """Return the underlying data client."""
+        return self._client
+
+    @property
+    def batch_size(self) -> int:
+        """Return the default batch size."""
+        return self._batch_size
+
+    @property
+    def logger(self) -> LoggingPortABC:
+        """Return the logger."""
+        return self._logger
+
     def get_release_version(self) -> str:
-        """
-        Get the raw ChEMBL release version from metadata.
+        """Get the raw ChEMBL release version from metadata.
 
         Returns:
             str: The raw release version string (e.g., '34', '35').
-                 Returns 'unknown' if metadata is unavailable.
+
+        Raises:
+            MetadataFetchError: If metadata cannot be fetched after retries.
 
         Note:
             This returns raw version without 'chembl_' prefix.
@@ -60,16 +89,40 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
             return self._version_cache
 
         try:
-            meta = self.client.metadata()
-            # Expecting {'chembl_release': '34', ...}
+            meta = self._client.metadata()
             if meta and "chembl_release" in meta:
                 self._version_cache = str(meta["chembl_release"])
             else:
+                self._logger.warning(
+                    "metadata_missing_release",
+                    message="ChEMBL metadata response missing 'chembl_release' field",
+                    response_keys=list(meta.keys()) if meta else [],
+                )
                 self._version_cache = "unknown"
-        except Exception as e:
-            if self.logger:
-                self.logger.warning(f"Failed to fetch metadata: {e}")
-            self._version_cache = "unknown"
+        except (ConnectionError, TimeoutError) as exc:
+            self._logger.error(
+                "metadata_fetch_network_error",
+                error_type=type(exc).__name__,
+                error=str(exc),
+            )
+            raise MetadataFetchError(
+                provider="chembl",
+                message=f"Network error fetching ChEMBL metadata: {exc}",
+                cause=exc,
+                fallback_value="unknown",
+            ) from exc
+        except (ClientError, RetryExhaustedError) as exc:
+            self._logger.error(
+                "metadata_fetch_client_error",
+                error_type=type(exc).__name__,
+                error=str(exc),
+            )
+            raise MetadataFetchError(
+                provider="chembl",
+                message=f"Client error fetching ChEMBL metadata: {exc}",
+                cause=exc,
+                fallback_value="unknown",
+            ) from exc
 
         return self._version_cache
 
@@ -99,39 +152,31 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
     def iter_extract(
         self, entity: str, *, chunk_size: int | None = None, **filters: object
     ) -> Iterable[RecordBatch]:
-        """Stream records from ChEMBL as raw dicts."""
-        if chunk_size is None:
-            chunk_size = filters.get("limit", self.batch_size)
-        filters["limit"] = chunk_size
+        """Stream records from ChEMBL as raw dicts.
+
+        Args:
+            entity: Entity name to extract (e.g., 'activity', 'assay').
+            chunk_size: Records per batch. Defaults to batch_size.
+            **filters: Additional query filters.
+
+        Yields:
+            RecordBatch: Batches of raw record dictionaries.
+        """
+        effective_chunk_size = chunk_size or self._batch_size
+        filters["limit"] = effective_chunk_size
 
         # Enrich filters using application-layer logic if available
         filters = self._enrich_filters(entity, filters)
 
-        # Ensure client has request_builder (runtime check)
-        if not hasattr(self.client, "request_builder"):
-            raise TypeError("Client must have request_builder (ChemblHttpClientImpl)")
+        # Resolve entity to API endpoint using domain mapping
+        endpoint = resolve_endpoint(entity)
 
-        # Prepare limit
-        limit = chunk_size or self.batch_size
-        filters["limit"] = limit
+        # Build request URL using typed builder - no runtime checks needed
+        builder = self._client.request_builder
+        url = builder.build_for_endpoint(endpoint).build_request(dict(filters))
 
-        builder = getattr(self.client, "request_builder")
-
-        # Resolve entity alias manually if needed (matches ChemblHttpClientImpl)
-        mapped_entity = ENTITY_ENDPOINT_ALIASES.get(entity, entity)
-
-        # Configure builder via legacy fluent methods expected in tests
-        if hasattr(builder, "build_for_endpoint"):
-            builder.build_for_endpoint(mapped_entity)
-        elif hasattr(builder, "for_endpoint"):
-            builder.for_endpoint(mapped_entity)
-
-        # Build URL using dict-style params
-        url = builder.build(filters)
-
-        # Iterate pages
-        for page_data in self.client.iter_pages(url):
-            # Use generic parser for raw dict output
+        # Iterate pages and parse responses
+        for page_data in self._client.iter_pages(url):
             records: RecordBatch = self._parser.parse_to_records(page_data)
             yield records
 
@@ -141,8 +186,7 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
         batch_ids: list[str],
         filter_key: str,
     ) -> dict[str, Any]:
-        """
-        Request a batch of records by IDs.
+        """Request a batch of records by IDs.
 
         Args:
             entity: Entity name.
@@ -153,7 +197,7 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
             dict[str, Any]: Raw API response.
         """
         filters = {filter_key: ",".join(batch_ids), "limit": len(batch_ids)}
-        return self.client.fetch(entity, **filters)
+        return self._client.fetch(entity, **filters)
 
     def parse_response(self, raw_response: object) -> RecordBatch:
         """Parse raw response into record dicts.
@@ -163,27 +207,16 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
 
         Returns:
             Parsed records as list[dict[str, Any]].
+
+        Raises:
+            TypeError: If raw_response cannot be parsed.
         """
-        # Handle None or invalid input
         if raw_response is None:
             return []
 
-        # Try client's parser first (for backward compatibility)
-        if hasattr(self.client, "response_parser"):
-            parser = getattr(self.client, "response_parser")
-            if hasattr(parser, "parse"):
-                try:
-                    return parser.parse(raw_response)
-                except (AttributeError, TypeError):
-                    # Parser failed, fall through to internal parser
-                    pass
-
-        # Use internal parser (injected or default)
-        try:
-            return self._parser.parse_to_records(raw_response)
-        except (AttributeError, TypeError):
-            # Parser can't handle this input type, return empty list
-            return []
+        # Use the injected parser - no fallback to client parser
+        # This enforces consistent parsing through the configured parser
+        return self._parser.parse_to_records(raw_response)
 
     def serialize_records(self, entity: str, records: RecordBatch) -> RecordBatch:
         """Serialize records for storage.


### PR DESCRIPTION
Key changes:

Phase 1: Ports & Adapters improvements
- Add RequestBuilderPortABC in domain/ports/request_building.py
- Add build_for_endpoint() as abstract method in RequestBuilderABC
- Add DataClientWithBuilderProtocol and DataClientWithBuilderABC
- Remove hasattr/getattr patterns from ChemblExtractionServiceImpl
- Use typed builder interface with resolve_endpoint() helper

Phase 2: Exception handling improvements
- Add MetadataFetchError and ParseError to domain/errors.py
- Narrow exception handling in get_release_version() to specific types
- Add structured logging for error scenarios
- Remove silent error suppression with "unknown" fallback

Phase 4: Remove deprecated infrastructure fallbacks
- Make provider_registry_factory a required parameter in PipelineOrchestrator
- Remove _get_default_registry_factory_deprecated() function
- Update subprocess execution to pass factory explicitly
- Remove warnings import (no longer needed)

Phase 6: Documentation
- Add domain/ARCHITECTURE.md documenting layer rules
- Update domain/ports/__init__.py exports

Expected impact on metrics:
- Ports & Adapters: +1.0
- Error handling: +2.0
- Configuration/DI: +0.5
- Overall score: 6.4 -> ~7.5