### PR TITLE
Fix ChEMBL database version extraction code

### DIFF
--- a/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
@@ -61,9 +61,11 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
 
         try:
             meta = self.client.metadata()
-            # Expecting {'chembl_release': '34', ...}
-            if meta and "chembl_release" in meta:
-                self._version_cache = str(meta["chembl_release"])
+            # API returns {'chembl_db_version': 'ChEMBL_36', ...}
+            if meta and "chembl_db_version" in meta:
+                raw_version = str(meta["chembl_db_version"])
+                # Extract version number from format 'ChEMBL_36' -> '36'
+                self._version_cache = self._parse_version_string(raw_version)
             else:
                 self._version_cache = "unknown"
         except Exception as e:
@@ -72,6 +74,32 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
             self._version_cache = "unknown"
 
         return self._version_cache
+
+    @staticmethod
+    def _parse_version_string(version_str: str) -> str:
+        """Parse version string from ChEMBL API format.
+
+        Handles formats:
+            - 'ChEMBL_36' -> '36'
+            - 'chembl_36' -> '36'
+            - '36' -> '36'
+
+        Args:
+            version_str: Raw version string from API.
+
+        Returns:
+            Extracted version number as string.
+        """
+        if not version_str:
+            return "unknown"
+
+        # Handle 'ChEMBL_XX' or 'chembl_XX' format
+        lower = version_str.lower()
+        if lower.startswith("chembl_"):
+            return version_str[7:]  # Remove 'ChEMBL_' or 'chembl_' prefix
+
+        # Already a plain number
+        return version_str
 
     def _enrich_filters(
         self, entity: str, filters: dict[str, object]

--- a/tests/bioetl/application/pipelines/chembl/test_extraction.py
+++ b/tests/bioetl/application/pipelines/chembl/test_extraction.py
@@ -46,11 +46,33 @@ def test_get_release_version(service, mock_client):
     ExtractionService returns raw version (e.g., '34'), not formatted.
     Formatting to 'chembl_34' is done in application layer (ChemblPipelineBase).
     """
-    mock_client.metadata.return_value = {"chembl_release": "34"}
+    # Real API returns 'chembl_db_version' with format 'ChEMBL_34'
+    mock_client.metadata.return_value = {"chembl_db_version": "ChEMBL_34"}
     version = service.get_release_version()
-    # Service returns raw version, not formatted
+    # Service extracts version number from 'ChEMBL_34' -> '34'
     assert version == "34"
     mock_client.metadata.assert_called_once()
+
+
+def test_get_release_version_lowercase_format(service, mock_client):
+    """Test getting release version with lowercase format."""
+    mock_client.metadata.return_value = {"chembl_db_version": "chembl_35"}
+    version = service.get_release_version()
+    assert version == "35"
+
+
+def test_get_release_version_plain_number(service, mock_client):
+    """Test getting release version when API returns plain number."""
+    mock_client.metadata.return_value = {"chembl_db_version": "36"}
+    version = service.get_release_version()
+    assert version == "36"
+
+
+def test_get_release_version_missing_key(service, mock_client):
+    """Test getting release version when key is missing."""
+    mock_client.metadata.return_value = {"status": "UP"}
+    version = service.get_release_version()
+    assert version == "unknown"
 
 
 def test_extract_all_single_page(service, mock_client):


### PR DESCRIPTION
…ction

The ChEMBL API status endpoint returns version in 'chembl_db_version' key with format 'ChEMBL_36', not 'chembl_release' with plain number.

Changes:
- Update get_release_version() to use 'chembl_db_version' key
- Add _parse_version_string() to extract version from 'ChEMBL_XX' format
- Add tests for various version formats (uppercase, lowercase, plain)