### PR TITLE
Fix ChEMBL database version extraction code

### DIFF
--- a/src/bioetl/domain/services/version_formatter.py
+++ b/src/bioetl/domain/services/version_formatter.py
@@ -28,13 +28,16 @@ def format_chembl_version(raw_version: str) -> str:
         'unknown'
         >>> format_chembl_version('')
         'unknown'
+        >>> format_chembl_version('ChEMBL_36')
+        'chembl_36'
     """
     if not raw_version or raw_version == UNKNOWN_VERSION:
         return UNKNOWN_VERSION
 
-    # Already formatted - return as is
-    if raw_version.startswith(CHEMBL_VERSION_PREFIX):
-        return raw_version
+    # Already formatted (case-insensitive check) - normalize to lowercase
+    lower_version = raw_version.lower()
+    if lower_version.startswith(CHEMBL_VERSION_PREFIX):
+        return lower_version
 
     return f"{CHEMBL_VERSION_PREFIX}{raw_version}"
 

--- a/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
@@ -138,23 +138,31 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
         Handles formats:
             - 'ChEMBL_36' -> '36'
             - 'chembl_36' -> '36'
+            - 'chembl36' -> '36' (without underscore)
             - '36' -> '36'
 
         Args:
             version_str: Raw version string from API.
 
         Returns:
-            Extracted version number as string.
+            Extracted version number as string, or 'unknown' if parsing fails.
         """
         if not version_str:
             return "unknown"
 
-        # Handle 'ChEMBL_XX' or 'chembl_XX' format
         lower = version_str.lower()
-        if lower.startswith("chembl_"):
-            return version_str[7:]  # Remove 'ChEMBL_' or 'chembl_' prefix
 
-        # Already a plain number
+        # Handle 'ChEMBL_XX' or 'chembl_XX' format (with underscore)
+        if lower.startswith("chembl_"):
+            result = version_str[7:]  # Remove 'ChEMBL_' or 'chembl_' prefix
+            return result if result else "unknown"
+
+        # Handle 'chemblXX' format (without underscore)
+        if lower.startswith("chembl"):
+            result = version_str[6:]  # Remove 'ChEMBL' or 'chembl' prefix
+            return result if result else "unknown"
+
+        # Already a plain number or other format
         return version_str
 
     def _enrich_filters(

--- a/tests/bioetl/application/pipelines/chembl/test_extraction.py
+++ b/tests/bioetl/application/pipelines/chembl/test_extraction.py
@@ -79,6 +79,55 @@ def test_get_release_version_missing_key(service, mock_client):
     assert version == "unknown"
 
 
+def test_get_release_version_without_underscore(service, mock_client):
+    """Test getting release version when format has no underscore."""
+    mock_client.metadata.return_value = {"chembl_db_version": "chembl36"}
+    version = service.get_release_version()
+    assert version == "36"
+
+
+def test_get_release_version_empty_after_prefix(service, mock_client):
+    """Test getting release version when only prefix is present."""
+    mock_client.metadata.return_value = {"chembl_db_version": "ChEMBL_"}
+    version = service.get_release_version()
+    assert version == "unknown"
+
+
+class TestParseVersionString:
+    """Tests for _parse_version_string static method."""
+
+    def test_parses_chembl_uppercase_with_underscore(self):
+        """Parses 'ChEMBL_36' format."""
+        result = ChemblExtractionServiceImpl._parse_version_string("ChEMBL_36")
+        assert result == "36"
+
+    def test_parses_chembl_lowercase_with_underscore(self):
+        """Parses 'chembl_36' format."""
+        result = ChemblExtractionServiceImpl._parse_version_string("chembl_36")
+        assert result == "36"
+
+    def test_parses_plain_number(self):
+        """Parses plain '36' format."""
+        result = ChemblExtractionServiceImpl._parse_version_string("36")
+        assert result == "36"
+
+    def test_parses_chembl_without_underscore(self):
+        """Parses 'chembl36' format (no underscore)."""
+        result = ChemblExtractionServiceImpl._parse_version_string("chembl36")
+        assert result == "36"
+
+    def test_returns_unknown_for_empty_string(self):
+        """Returns 'unknown' for empty string."""
+        result = ChemblExtractionServiceImpl._parse_version_string("")
+        assert result == "unknown"
+
+    def test_returns_unknown_for_prefix_only(self):
+        """Returns 'unknown' when only prefix is present."""
+        assert ChemblExtractionServiceImpl._parse_version_string("ChEMBL_") == "unknown"
+        assert ChemblExtractionServiceImpl._parse_version_string("chembl_") == "unknown"
+        assert ChemblExtractionServiceImpl._parse_version_string("ChEMBL") == "unknown"
+
+
 def test_extract_all_single_page(service, mock_client):
     """Test extraction of a single page."""
     # Mock parser and paginator attributes on the instance

--- a/tests/bioetl/domain/services/test_version_formatter.py
+++ b/tests/bioetl/domain/services/test_version_formatter.py
@@ -26,6 +26,11 @@ class TestFormatChemblVersion:
         """Already formatted version is not double-prefixed."""
         assert format_chembl_version("chembl_34") == "chembl_34"
 
+    def test_uppercase_chembl_prefix_normalized(self):
+        """ChEMBL_ prefix is normalized to lowercase."""
+        assert format_chembl_version("ChEMBL_36") == "chembl_36"
+        assert format_chembl_version("CHEMBL_36") == "chembl_36"
+
     def test_handles_numeric_string(self):
         """Handles version as string of number."""
         assert format_chembl_version("100") == "chembl_100"


### PR DESCRIPTION
- _parse_version_string: handle 'chembl36' format (without underscore)
- _parse_version_string: return 'unknown' for empty results after prefix
- format_chembl_version: normalize 'ChEMBL_' prefix to lowercase

Previously:
- 'ChEMBL_' returned '' (empty string) instead of 'unknown'
- 'chembl36' returned 'chembl36' without extracting version number
- 'ChEMBL_36' resulted in 'chembl_ChEMBL_36' (double prefix)