### PR TITLE
Fix ChEMBL database version extraction code

### DIFF
--- a/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/chembl_extraction_service_impl.py
@@ -140,6 +140,7 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
             - 'chembl_36' -> '36'
             - 'chembl36' -> '36' (without underscore)
             - '36' -> '36'
+            - ' ChEMBL_36 ' -> '36' (with whitespace)
 
         Args:
             version_str: Raw version string from API.
@@ -150,20 +151,25 @@ class ChemblExtractionServiceImpl(ExtractionServiceABC, VersionProviderABC):
         if not version_str:
             return "unknown"
 
-        lower = version_str.lower()
+        # Strip whitespace from input
+        stripped = version_str.strip()
+        if not stripped:
+            return "unknown"
+
+        lower = stripped.lower()
 
         # Handle 'ChEMBL_XX' or 'chembl_XX' format (with underscore)
         if lower.startswith("chembl_"):
-            result = version_str[7:]  # Remove 'ChEMBL_' or 'chembl_' prefix
+            result = stripped[7:].strip()  # Remove 'ChEMBL_' or 'chembl_' prefix
             return result if result else "unknown"
 
         # Handle 'chemblXX' format (without underscore)
         if lower.startswith("chembl"):
-            result = version_str[6:]  # Remove 'ChEMBL' or 'chembl' prefix
+            result = stripped[6:].strip()  # Remove 'ChEMBL' or 'chembl' prefix
             return result if result else "unknown"
 
         # Already a plain number or other format
-        return version_str
+        return stripped
 
     def _enrich_filters(
         self, entity: str, filters: dict[str, object]

--- a/tests/bioetl/application/pipelines/chembl/test_extraction.py
+++ b/tests/bioetl/application/pipelines/chembl/test_extraction.py
@@ -127,6 +127,29 @@ class TestParseVersionString:
         assert ChemblExtractionServiceImpl._parse_version_string("chembl_") == "unknown"
         assert ChemblExtractionServiceImpl._parse_version_string("ChEMBL") == "unknown"
 
+    def test_strips_leading_whitespace(self):
+        """Handles leading whitespace in version string."""
+        assert ChemblExtractionServiceImpl._parse_version_string(" ChEMBL_36") == "36"
+        assert ChemblExtractionServiceImpl._parse_version_string("  chembl_36") == "36"
+        assert ChemblExtractionServiceImpl._parse_version_string(" 36") == "36"
+
+    def test_strips_trailing_whitespace(self):
+        """Handles trailing whitespace in version string."""
+        assert ChemblExtractionServiceImpl._parse_version_string("ChEMBL_36 ") == "36"
+        assert ChemblExtractionServiceImpl._parse_version_string("chembl_36  ") == "36"
+        assert ChemblExtractionServiceImpl._parse_version_string("36 ") == "36"
+
+    def test_strips_surrounding_whitespace(self):
+        """Handles whitespace on both sides of version string."""
+        assert ChemblExtractionServiceImpl._parse_version_string(" ChEMBL_36 ") == "36"
+        assert ChemblExtractionServiceImpl._parse_version_string("  chembl36  ") == "36"
+        assert ChemblExtractionServiceImpl._parse_version_string("  34  ") == "34"
+
+    def test_returns_unknown_for_whitespace_only(self):
+        """Returns 'unknown' for whitespace-only string."""
+        assert ChemblExtractionServiceImpl._parse_version_string("   ") == "unknown"
+        assert ChemblExtractionServiceImpl._parse_version_string("\t\n") == "unknown"
+
 
 def test_extract_all_single_page(service, mock_client):
     """Test extraction of a single page."""


### PR DESCRIPTION
_parse_version_string now correctly handles version strings with:
- Leading whitespace: ' ChEMBL_36' -> '36'
- Trailing whitespace: 'ChEMBL_36 ' -> '36'
- Surrounding whitespace: '  34  ' -> '34'
- Whitespace-only strings: '   ' -> 'unknown'

Added tests covering all whitespace edge cases.