### PR TITLE
Consolidate small dataclasses into shared config

### DIFF
--- a/src/bioetl/domain/configs/__init__.py
+++ b/src/bioetl/domain/configs/__init__.py
@@ -36,7 +36,11 @@ from bioetl.domain.configs.defaults import (
 from bioetl.domain.configs.execution import ExecutionConfig
 from bioetl.domain.configs.identity import PipelineIdentityConfig
 from bioetl.domain.configs.manifest import PipelineManifest
-from bioetl.domain.configs.normalization import NormalizationConfig
+from bioetl.domain.configs.pipeline_options import (
+    NormalizationConfig,
+    ProfileConfig,
+    TransformConfig,
+)
 from bioetl.domain.configs.pipeline import (
     BaseProviderConfig,
     BusinessKeyConfig,
@@ -64,9 +68,8 @@ from bioetl.domain.configs.pipeline import (
     QualityControlConfig,
     RuntimeConfig,
     StorageConfig,
-    TransformConfig,
 )
-from bioetl.domain.configs.profile import ProfileConfig
+# ProfileConfig, TransformConfig, NormalizationConfig imported from pipeline_options above
 
 __all__ = [
     # Bounded context configs (new modular structure)

--- a/src/bioetl/domain/configs/execution.py
+++ b/src/bioetl/domain/configs/execution.py
@@ -16,7 +16,7 @@ from bioetl.domain.configs.pipeline import (
     PipelineStagesConfig,
     RuntimeConfig,
 )
-from bioetl.domain.configs.transform import TransformConfig
+from bioetl.domain.configs.pipeline_options import TransformConfig
 
 
 class ExecutionConfig(BaseModel):

--- a/src/bioetl/domain/configs/normalization.py
+++ b/src/bioetl/domain/configs/normalization.py
@@ -1,18 +1,22 @@
-"""Normalization configuration for the domain layer."""
+"""DEPRECATED: Normalization config moved to pipeline_options.py.
+
+This module is deprecated and will be removed in v3.0.
+Import from bioetl.domain.configs.pipeline_options instead:
+
+    from bioetl.domain.configs.pipeline_options import NormalizationConfig
+"""
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+import warnings
 
+from bioetl.domain.configs.pipeline_options import NormalizationConfig
 
-class NormalizationConfig(BaseModel):
-    """Data normalization configuration."""
-
-    case_sensitive_fields: list[str] = Field(default_factory=list)
-    id_fields: list[str] = Field(default_factory=list)
-    custom_normalizers: dict[str, str] = Field(default_factory=dict)
-
-    model_config = {"extra": "forbid"}
-
+warnings.warn(
+    "bioetl.domain.configs.normalization is deprecated. "
+    "Import from bioetl.domain.configs.pipeline_options instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 __all__ = ["NormalizationConfig"]

--- a/src/bioetl/domain/configs/pipeline.py
+++ b/src/bioetl/domain/configs/pipeline.py
@@ -24,10 +24,9 @@ if TYPE_CHECKING:
 # Import bounded context configs
 from bioetl.domain.configs.data_flow import DataFlowConfig
 from bioetl.domain.configs.identity import PipelineIdentityConfig
-from bioetl.domain.configs.normalization import NormalizationConfig
+from bioetl.domain.configs.pipeline_options import NormalizationConfig, TransformConfig
 from bioetl.domain.configs.sink import DataSinkConfig, OutputOptionsConfig
 from bioetl.domain.configs.source import CsvInputConfig, DataSourceConfig
-from bioetl.domain.configs.transform import TransformConfig
 
 
 class PaginationConfig(BaseModel):

--- a/src/bioetl/domain/configs/pipeline_options.py
+++ b/src/bioetl/domain/configs/pipeline_options.py
@@ -1,0 +1,72 @@
+"""Pipeline option configs: profile, transform, normalization.
+
+These are secondary configuration objects used by PipelineConfig.
+Small dataclasses consolidated from profile.py, transform.py, normalization.py.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ProfileConfig(BaseModel):
+    """Profile configuration on top of pipeline config.
+
+    Represents an execution profile with named overrides that can extend
+    other profiles. Used for environment-specific settings (dev, prod, etc.).
+
+    Attributes:
+        name: Profile identifier.
+        extends: Optional parent profile to inherit from.
+        overrides: Dictionary of config overrides to apply.
+    """
+
+    name: str
+    extends: str | None = None
+    overrides: dict[str, object] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class TransformConfig(BaseModel):
+    """Transform stage settings.
+
+    Configuration for the transform stage of the ETL pipeline,
+    controlling how data is serialized and processed.
+
+    Attributes:
+        serialization_mode: Canonical serialization format for nested fields.
+            - "json": Serialize as JSON strings
+            - "flat": Flatten nested structures
+            - "pipe": Pipe-delimited format
+    """
+
+    serialization_mode: Literal["json", "flat", "pipe"] = Field(
+        default="json", description="Canonical serialization format for nested fields"
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class NormalizationConfig(BaseModel):
+    """Data normalization configuration.
+
+    Settings for normalizing data during the transform stage,
+    including case handling, ID field identification, and custom normalizers.
+
+    Attributes:
+        case_sensitive_fields: Fields that should preserve case sensitivity.
+        id_fields: Fields containing identifiers.
+        custom_normalizers: Mapping of field names to normalizer names.
+    """
+
+    case_sensitive_fields: list[str] = Field(default_factory=list)
+    id_fields: list[str] = Field(default_factory=list)
+    custom_normalizers: dict[str, str] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+__all__ = ["ProfileConfig", "TransformConfig", "NormalizationConfig"]

--- a/src/bioetl/domain/configs/profile.py
+++ b/src/bioetl/domain/configs/profile.py
@@ -1,18 +1,22 @@
-"""Profile configuration models (domain layer)."""
+"""DEPRECATED: Profile config moved to pipeline_options.py.
+
+This module is deprecated and will be removed in v3.0.
+Import from bioetl.domain.configs.pipeline_options instead:
+
+    from bioetl.domain.configs.pipeline_options import ProfileConfig
+"""
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+import warnings
 
+from bioetl.domain.configs.pipeline_options import ProfileConfig
 
-class ProfileConfig(BaseModel):
-    """Profile configuration on top of pipeline config."""
-
-    name: str
-    extends: str | None = None
-    overrides: dict[str, object] = Field(default_factory=dict)
-
-    model_config = ConfigDict(extra="forbid")
-
+warnings.warn(
+    "bioetl.domain.configs.profile is deprecated. "
+    "Import from bioetl.domain.configs.pipeline_options instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 __all__ = ["ProfileConfig"]

--- a/src/bioetl/domain/configs/transform.py
+++ b/src/bioetl/domain/configs/transform.py
@@ -1,20 +1,22 @@
-"""Transform-stage configuration models."""
+"""DEPRECATED: Transform config moved to pipeline_options.py.
+
+This module is deprecated and will be removed in v3.0.
+Import from bioetl.domain.configs.pipeline_options instead:
+
+    from bioetl.domain.configs.pipeline_options import TransformConfig
+"""
 
 from __future__ import annotations
 
-from typing import Literal
+import warnings
 
-from pydantic import BaseModel, ConfigDict, Field
+from bioetl.domain.configs.pipeline_options import TransformConfig
 
-
-class TransformConfig(BaseModel):
-    """Transform stage settings."""
-
-    serialization_mode: Literal["json", "flat", "pipe"] = Field(
-        default="json", description="Canonical serialization format for nested fields"
-    )
-
-    model_config = ConfigDict(extra="forbid")
-
+warnings.warn(
+    "bioetl.domain.configs.transform is deprecated. "
+    "Import from bioetl.domain.configs.pipeline_options instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 __all__ = ["TransformConfig"]

--- a/src/bioetl/domain/transform/contracts.py
+++ b/src/bioetl/domain/transform/contracts.py
@@ -27,8 +27,8 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Protocol
 
-# Import the canonical NormalizationConfig from configs.normalization
-from bioetl.domain.configs.normalization import NormalizationConfig
+# Import the canonical NormalizationConfig from pipeline_options
+from bioetl.domain.configs.pipeline_options import NormalizationConfig
 from bioetl.domain.data import MutableTabularData, RecordBatch, TabularData
 from bioetl.domain.value_objects import HashDigest
 


### PR DESCRIPTION
Merge ProfileConfig, TransformConfig, and NormalizationConfig from separate single-class files into one pipeline_options.py module. This reduces file fragmentation and cognitive load.

Changes:
- Create pipeline_options.py with all three config classes
- Update imports in pipeline.py, execution.py, transform/contracts.py
- Convert old files (profile.py, transform.py, normalization.py) to deprecation shims that emit DeprecationWarning
- Old import paths remain working with warnings for backward compat

The old files will be removed in v3.0.