### PR TITLE
Implement BioETL architecture refactoring plan

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -29,10 +29,6 @@ source_modules =
     bioetl.application
 forbidden_modules =
     bioetl.infrastructure
-ignore_imports =
-    # Legacy: Lazy import for backward compatibility (deprecation warning issued)
-    # Tracked for removal - see test_application_has_no_runtime_infrastructure_imports
-    bioetl.application.orchestrator -> bioetl.infrastructure.provider_registry
 
 [contract:application_no_interfaces]
 name = Application layer cannot depend on interfaces layer

--- a/src/bioetl/application/pipelines/base.py
+++ b/src/bioetl/application/pipelines/base.py
@@ -455,8 +455,8 @@ class PipelineBase(ABC):
         """Return iterator of source data chunks."""
 
     @abstractmethod
-    def transform(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Transform raw data."""
+    def transform(self, df: TabularData) -> TabularData:
+        """Transform raw tabular data."""
 
     def validate(self, df: pd.DataFrame) -> pd.DataFrame:
         """Validate DataFrame against Pandera schema, respecting column order."""

--- a/src/bioetl/application/pipelines/chembl/base.py
+++ b/src/bioetl/application/pipelines/chembl/base.py
@@ -21,6 +21,7 @@ from bioetl.domain.clients.base.output.contracts import (
     WriteResult,
 )
 from bioetl.domain.configs import ChemblSourceConfig, PipelineConfig
+from bioetl.domain.data import TabularData
 from bioetl.domain.models import RunContext
 from bioetl.domain.observability import LoggingPortABC
 from bioetl.domain.pipelines.contracts import ErrorPolicyABC, LoaderABC, PipelineHookABC
@@ -178,11 +179,14 @@ class ChemblPipelineBase(PipelineBase):
             return True
         return bool(pipeline_cfg.get("skip_release_lookup"))
 
-    def extract(self, **kwargs: Any) -> pd.DataFrame:
-        """Return single DataFrame for unit tests and local checks.
+    def extract(self, **kwargs: Any) -> TabularData:
+        """Return single TabularData for unit tests and local checks.
 
         Main run process uses self._extractor directly, so
         chunk materialization in this wrapper doesn't affect production flow.
+
+        Returns:
+            TabularData (pd.DataFrame is compatible with TabularData protocol).
         """
         extractor = self._extractor
         if extractor is None:
@@ -217,8 +221,15 @@ class ChemblPipelineBase(PipelineBase):
 
         return pd.concat(chunks, ignore_index=True, copy=False)
 
-    def transform(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Runs Chembl-specific transformer pipeline on dataframe."""
+    def transform(self, df: TabularData) -> TabularData:
+        """Runs Chembl-specific transformer pipeline on tabular data.
+
+        Args:
+            df: Input tabular data (pd.DataFrame compatible).
+
+        Returns:
+            Transformed tabular data.
+        """
         transformer = self._transformer
         if transformer is None:
             raise RuntimeError("Chembl transformer is not initialized.")
@@ -226,11 +237,20 @@ class ChemblPipelineBase(PipelineBase):
 
     def write(
         self,
-        df: pd.DataFrame,
+        df: TabularData,
         output_path: Path,
         context: RunContext,
     ) -> WriteResult:
-        """Persists transformed dataframe using the resolved loader."""
+        """Persists transformed tabular data using the resolved loader.
+
+        Args:
+            df: Tabular data to write (pd.DataFrame compatible).
+            output_path: Path for output file.
+            context: Run context with execution details.
+
+        Returns:
+            WriteResult with path and row count.
+        """
         return self._write_with_loader(df, output_path, context)
 
     # === Internal helpers ===

--- a/src/bioetl/application/pipelines/chembl/components.py
+++ b/src/bioetl/application/pipelines/chembl/components.py
@@ -1,0 +1,193 @@
+"""ChEMBL pipeline components container.
+
+This module provides dataclasses for grouping ChEMBL pipeline dependencies,
+reducing the number of constructor parameters and improving code organization.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bioetl.domain.clients.base.output.contracts import RunMetadataBuilderProtocol
+    from bioetl.domain.observability import LoggingPortABC
+    from bioetl.domain.pipelines.contracts import (
+        ErrorPolicyABC,
+        LoaderABC,
+        PipelineHookABC,
+    )
+    from bioetl.domain.ports.entity_models import EntityModelRegistryABC
+    from bioetl.domain.ports.extraction import ExtractionServiceABC
+    from bioetl.domain.record_source import RecordSourceABC
+    from bioetl.domain.schemas.pipeline_contracts import PipelineSchemaModel
+    from bioetl.domain.transform.contracts import (
+        HashServiceABC,
+        IndexGeneratorABC,
+        NormalizationServiceABC,
+        TimestampProviderABC,
+    )
+    from bioetl.domain.transform.transformers import TransformerABC
+    from bioetl.domain.validation.service import ValidationService
+
+
+@dataclass(frozen=True)
+class ChemblCoreServices:
+    """Core services required for ChEMBL pipeline operation.
+
+    Groups the essential services that every ChEMBL pipeline needs.
+    """
+
+    extraction_service: "ExtractionServiceABC"
+    """Service for extracting data from ChEMBL API."""
+
+    validation_service: "ValidationService"
+    """Service for schema validation."""
+
+    normalization_service: "NormalizationServiceABC"
+    """Service for data normalization."""
+
+    entity_model_registry: "EntityModelRegistryABC"
+    """Registry for entity model mappings."""
+
+
+@dataclass(frozen=True)
+class ChemblTransformServices:
+    """Services for data transformation in ChEMBL pipeline.
+
+    Groups hash, index, and timestamp services used during
+    the transform stage.
+    """
+
+    hash_service: "HashServiceABC"
+    """Service for computing record hashes."""
+
+    index_generator: "IndexGeneratorABC"
+    """Service for generating record indices."""
+
+    timestamp_provider: "TimestampProviderABC"
+    """Service for providing timestamps."""
+
+
+@dataclass(frozen=True)
+class ChemblPipelineComponents:
+    """Complete set of components for ChEMBL pipeline.
+
+    This dataclass groups all dependencies needed to construct a ChEMBL
+    pipeline, reducing constructor parameters from 16+ to a single
+    components object plus config.
+
+    Example:
+        >>> components = ChemblPipelineComponents(
+        ...     core=ChemblCoreServices(...),
+        ...     transform=ChemblTransformServices(...),
+        ...     loader=my_loader,
+        ...     logger=my_logger,
+        ... )
+        >>> pipeline = ChemblPipelineBase(config, components)
+    """
+
+    core: ChemblCoreServices
+    """Core services (extraction, validation, normalization)."""
+
+    transform: ChemblTransformServices
+    """Transform services (hash, index, timestamp)."""
+
+    loader: "LoaderABC"
+    """Loader for writing output data."""
+
+    logger: "LoggingPortABC"
+    """Logger for pipeline operations."""
+
+    # Optional components with defaults handled by pipeline
+    schema_contract: "PipelineSchemaModel | None" = None
+    """Optional schema contract override."""
+
+    metadata_builder: "RunMetadataBuilderProtocol | None" = None
+    """Optional metadata builder override."""
+
+    hooks: "list[PipelineHookABC] | None" = None
+    """Optional pipeline hooks."""
+
+    error_policy: "ErrorPolicyABC | None" = None
+    """Optional error handling policy."""
+
+    post_transformer: "TransformerABC | None" = None
+    """Optional post-transformation handler."""
+
+    record_source: "RecordSourceABC | None" = None
+    """Optional record source override."""
+
+
+def create_chembl_components(
+    *,
+    extraction_service: "ExtractionServiceABC",
+    validation_service: "ValidationService",
+    normalization_service: "NormalizationServiceABC",
+    entity_model_registry: "EntityModelRegistryABC",
+    hash_service: "HashServiceABC",
+    index_generator: "IndexGeneratorABC",
+    timestamp_provider: "TimestampProviderABC",
+    loader: "LoaderABC",
+    logger: "LoggingPortABC",
+    schema_contract: "PipelineSchemaModel | None" = None,
+    metadata_builder: "RunMetadataBuilderProtocol | None" = None,
+    hooks: "list[PipelineHookABC] | None" = None,
+    error_policy: "ErrorPolicyABC | None" = None,
+    post_transformer: "TransformerABC | None" = None,
+    record_source: "RecordSourceABC | None" = None,
+) -> ChemblPipelineComponents:
+    """Factory function for creating ChemblPipelineComponents.
+
+    This provides a flat parameter interface for cases where the
+    grouped dataclass structure is not convenient.
+
+    Args:
+        extraction_service: ChEMBL extraction service.
+        validation_service: Schema validation service.
+        normalization_service: Data normalization service.
+        entity_model_registry: Entity model registry.
+        hash_service: Hash computation service.
+        index_generator: Index generation service.
+        timestamp_provider: Timestamp provider.
+        loader: Output data loader.
+        logger: Pipeline logger.
+        schema_contract: Optional schema contract.
+        metadata_builder: Optional metadata builder.
+        hooks: Optional pipeline hooks.
+        error_policy: Optional error policy.
+        post_transformer: Optional post-transformer.
+        record_source: Optional record source.
+
+    Returns:
+        ChemblPipelineComponents instance.
+    """
+    return ChemblPipelineComponents(
+        core=ChemblCoreServices(
+            extraction_service=extraction_service,
+            validation_service=validation_service,
+            normalization_service=normalization_service,
+            entity_model_registry=entity_model_registry,
+        ),
+        transform=ChemblTransformServices(
+            hash_service=hash_service,
+            index_generator=index_generator,
+            timestamp_provider=timestamp_provider,
+        ),
+        loader=loader,
+        logger=logger,
+        schema_contract=schema_contract,
+        metadata_builder=metadata_builder,
+        hooks=hooks,
+        error_policy=error_policy,
+        post_transformer=post_transformer,
+        record_source=record_source,
+    )
+
+
+__all__ = [
+    "ChemblCoreServices",
+    "ChemblPipelineComponents",
+    "ChemblTransformServices",
+    "create_chembl_components",
+]

--- a/src/bioetl/application/pipelines/chembl/record_source_resolver.py
+++ b/src/bioetl/application/pipelines/chembl/record_source_resolver.py
@@ -1,0 +1,201 @@
+"""Record source resolution for ChEMBL pipelines.
+
+This module provides the RecordSourceResolver class that handles
+determination and creation of the appropriate record source based
+on pipeline configuration.
+
+Extracted from ChemblPipelineBase to reduce class size and improve
+testability of record source resolution logic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from bioetl.application.files.csv_record_source import (
+    CsvRecordSourceImpl,
+    IdListRecordSourceImpl,
+)
+from bioetl.domain.configs import ChemblSourceConfig
+from bioetl.domain.record_source import RecordSourceABC
+
+if TYPE_CHECKING:
+    from bioetl.domain.configs import PipelineConfig
+    from bioetl.domain.observability import LoggingPortABC
+    from bioetl.domain.ports.extraction import ExtractionServiceABC
+
+
+class RecordSourceResolver:
+    """Resolves and creates appropriate record source for ChEMBL pipelines.
+
+    This class encapsulates the logic for determining which record source
+    to use based on the pipeline configuration's input mode.
+
+    Supported modes:
+        - csv: Read records from a CSV file
+        - id_only: Read IDs from file and fetch records from API
+        - auto_detect: Automatically determine mode based on input_path
+        - api (default): Fetch records directly from ChEMBL API
+    """
+
+    def __init__(
+        self,
+        config: PipelineConfig,
+        logger: LoggingPortABC,
+        extraction_service: ExtractionServiceABC,
+        id_column: str,
+        filter_key: str,
+    ) -> None:
+        """Initialize record source resolver.
+
+        Args:
+            config: Pipeline configuration.
+            logger: Logger for diagnostic messages.
+            extraction_service: Service for API-based extraction.
+            id_column: Column name for record IDs.
+            filter_key: API filter key for ID-based queries.
+        """
+        self._config = config
+        self._logger = logger
+        self._extraction_service = extraction_service
+        self._id_column = id_column
+        self._filter_key = filter_key
+
+    def resolve(self) -> RecordSourceABC | None:
+        """Resolve and create the appropriate record source.
+
+        Returns:
+            RecordSourceABC instance for file-based modes, or None for API mode.
+
+        Raises:
+            ValueError: If required configuration is missing.
+            TypeError: If provider config type is invalid.
+        """
+        source_cfg = self._config.source
+        mode = self._resolve_effective_mode(source_cfg)
+
+        if mode == "csv":
+            return self._create_csv_source(source_cfg)
+        elif mode == "id_only":
+            return self._create_id_list_source(source_cfg)
+
+        # API mode - no file-based record source needed
+        return None
+
+    def _resolve_effective_mode(self, source_cfg: "DataSourceConfig") -> str:  # type: ignore[name-defined]
+        """Determine effective input mode from configuration.
+
+        Args:
+            source_cfg: Source configuration section.
+
+        Returns:
+            Effective input mode string.
+        """
+        mode = source_cfg.input_mode
+
+        # Auto-detect based on input_path presence
+        if mode == "auto_detect" and source_cfg.input_path:
+            return "csv"
+
+        return mode or "api"
+
+    def _create_csv_source(
+        self, source_cfg: "DataSourceConfig"  # type: ignore[name-defined]
+    ) -> CsvRecordSourceImpl:
+        """Create CSV record source.
+
+        Args:
+            source_cfg: Source configuration.
+
+        Returns:
+            CsvRecordSourceImpl instance.
+
+        Raises:
+            ValueError: If input_path is not configured.
+        """
+        input_path = source_cfg.input_path
+        if input_path is None:
+            raise ValueError("input_path is required when input_mode is 'csv'.")
+
+        return CsvRecordSourceImpl(
+            input_path=Path(input_path),
+            csv_options=source_cfg.csv,
+            limit=None,
+            logger=self._logger,
+            chunk_size=source_cfg.batch_size,
+        )
+
+    def _create_id_list_source(
+        self, source_cfg: "DataSourceConfig"  # type: ignore[name-defined]
+    ) -> IdListRecordSourceImpl:
+        """Create ID list record source.
+
+        Args:
+            source_cfg: Source configuration.
+
+        Returns:
+            IdListRecordSourceImpl instance.
+
+        Raises:
+            ValueError: If input_path is not configured.
+            TypeError: If provider config is not ChemblSourceConfig.
+        """
+        input_path = source_cfg.input_path
+        if input_path is None:
+            raise ValueError("input_path is required when input_mode is 'id_only'.")
+
+        provider_cfg = self._config.get_source_config(self._config.provider)
+
+        if not isinstance(provider_cfg, ChemblSourceConfig):
+            raise TypeError(
+                "ChemblSourceConfig is required for id_only input_mode."
+            )
+
+        return IdListRecordSourceImpl(
+            input_path=Path(input_path),
+            id_column=self._id_column,
+            csv_options=source_cfg.csv,
+            limit=None,
+            extraction_service=self._extraction_service,
+            source_config=provider_cfg,
+            entity=self._config.entity_name,
+            filter_key=self._filter_key,
+            logger=self._logger,
+            chunk_size=source_cfg.batch_size,
+        )
+
+
+def resolve_record_source(
+    config: PipelineConfig,
+    logger: LoggingPortABC,
+    extraction_service: ExtractionServiceABC,
+    id_column: str,
+    filter_key: str,
+) -> RecordSourceABC | None:
+    """Convenience function to resolve record source.
+
+    Args:
+        config: Pipeline configuration.
+        logger: Logger instance.
+        extraction_service: Extraction service.
+        id_column: ID column name.
+        filter_key: API filter key.
+
+    Returns:
+        Resolved record source or None.
+    """
+    resolver = RecordSourceResolver(
+        config=config,
+        logger=logger,
+        extraction_service=extraction_service,
+        id_column=id_column,
+        filter_key=filter_key,
+    )
+    return resolver.resolve()
+
+
+__all__ = [
+    "RecordSourceResolver",
+    "resolve_record_source",
+]

--- a/src/bioetl/application/pipelines/context_builder.py
+++ b/src/bioetl/application/pipelines/context_builder.py
@@ -1,0 +1,96 @@
+"""Context building utilities for ETL pipelines.
+
+This module provides the ContextBuilder class that handles creation
+and normalization of run contexts and metadata.
+
+Extracted from PipelineBase to reduce class size and improve separation
+of concerns.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from bioetl.domain.models import RunContext
+from bioetl.domain.providers import ProviderId
+from bioetl.domain.value_objects import EntityName
+
+if TYPE_CHECKING:
+    from bioetl.domain.configs import PipelineConfig
+
+
+class ContextBuilder:
+    """Builds and normalizes pipeline run contexts.
+
+    Encapsulates the logic for creating RunContext instances and
+    normalizing metadata dictionaries.
+    """
+
+    def __init__(
+        self,
+        config: PipelineConfig,
+        provider_id: ProviderId,
+    ) -> None:
+        """Initialize context builder.
+
+        Args:
+            config: Pipeline configuration.
+            provider_id: Provider identifier.
+        """
+        self._config = config
+        self._provider_id = provider_id
+
+    def build_context(self, dry_run: bool) -> RunContext:
+        """Build a new run context.
+
+        Args:
+            dry_run: Whether this is a dry run.
+
+        Returns:
+            New RunContext instance.
+        """
+        return RunContext(
+            entity_name=EntityName(self._config.entity_name),
+            provider=self._provider_id,
+            config=self._config.model_dump(),
+            dry_run=dry_run,
+        )
+
+    def normalize_meta(
+        self,
+        meta: dict[str, Any],
+        context: RunContext,
+        row_count: int,
+        dry_run: bool,
+    ) -> dict[str, Any]:
+        """Normalize metadata ensuring required fields are present.
+
+        Args:
+            meta: Raw metadata from builder.
+            context: Run context.
+            row_count: Number of rows processed.
+            dry_run: Whether this is a dry run.
+
+        Returns:
+            Normalized metadata dictionary.
+
+        Raises:
+            TypeError: If meta is not a dict.
+        """
+        if not isinstance(meta, dict):
+            raise TypeError("Metadata builder must return a dict.")
+
+        normalized_meta = dict(meta)
+        normalized_meta.setdefault("run_id", context.run_id)
+        normalized_meta.setdefault("provider", context.provider)
+        normalized_meta.setdefault("entity", context.entity_name)
+        normalized_meta.setdefault("row_count", row_count)
+        if dry_run:
+            normalized_meta["dry_run"] = True
+        else:
+            normalized_meta.setdefault("dry_run", False)
+
+        return normalized_meta
+
+
+__all__ = ["ContextBuilder"]

--- a/src/bioetl/application/pipelines/stage_processor.py
+++ b/src/bioetl/application/pipelines/stage_processor.py
@@ -1,0 +1,256 @@
+"""Stage processing utilities for ETL pipelines.
+
+This module provides the StageProcessor class that handles the execution
+of individual ETL stages (extract, transform, validate, write).
+
+Extracted from PipelineBase to reduce class size and improve separation
+of concerns. StageProcessor handles the "how" of stage execution while
+PipelineBase handles the "what" (template method pattern).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, Iterator, cast
+
+import pandas as pd
+
+from bioetl.application.pipelines.stage_runtime_manager import StageRuntimeManagerImpl
+from bioetl.domain.clients.base.output.contracts import WriteResult
+from bioetl.domain.models import RunContext, StageResult
+
+if TYPE_CHECKING:
+    pass
+
+
+class StageProcessor:
+    """Handles execution of ETL stages.
+
+    Encapsulates the logic for processing extract, transform, validate,
+    and write stages, delegating runtime management to StageRuntimeManagerImpl.
+    """
+
+    def __init__(
+        self,
+        runtime_manager: StageRuntimeManagerImpl,
+    ) -> None:
+        """Initialize stage processor.
+
+        Args:
+            runtime_manager: Manager for stage execution and hooks.
+        """
+        self._runtime_manager = runtime_manager
+
+    def init_stage_counters(self) -> dict[str, int]:
+        """Initialize counters for all stages.
+
+        Returns:
+            Dictionary with zero counters for each stage.
+        """
+        return {
+            "extract_count": 0,
+            "extract_chunks": 0,
+            "transform_count": 0,
+            "transform_chunks": 0,
+            "validate_count": 0,
+            "validate_chunks": 0,
+            "export_count": 0,
+            "export_chunks": 0,
+        }
+
+    def process_extract_stage(
+        self,
+        context: RunContext,
+        counters: dict[str, int],
+        validated_chunks: list[pd.DataFrame],
+        dry_run: bool,
+        kwargs: dict[str, Any],
+        *,
+        extract_fn: Callable[..., Any],
+        transform_fn: Callable[[pd.DataFrame], pd.DataFrame],
+        apply_transformers: Callable[[pd.DataFrame, RunContext], pd.DataFrame],
+        validate_fn: Callable[[pd.DataFrame], pd.DataFrame],
+        normalize_extract_result: Callable[[Any], Iterator[pd.DataFrame]],
+    ) -> tuple[dict[str, int], list[pd.DataFrame]]:
+        """Process extract stage with transform and validate.
+
+        Args:
+            context: Run context.
+            counters: Stage counters to update.
+            validated_chunks: List to accumulate validated chunks.
+            dry_run: Whether this is a dry run.
+            kwargs: Additional arguments for extract function.
+            extract_fn: Function to call for extraction.
+            transform_fn: Function for transformation.
+            apply_transformers: Function to apply post-transformers.
+            validate_fn: Function for validation.
+            normalize_extract_result: Function to normalize extract results.
+
+        Returns:
+            Tuple of (updated counters, validated chunks).
+        """
+        chunk_iterator: Iterator[pd.DataFrame] | None = None
+        transform_started = False
+        validate_started = False
+
+        def reset_iterator() -> None:
+            """Recreate extractor iterator for retries."""
+            nonlocal chunk_iterator
+            extract_result = self._runtime_manager.execute_stage(
+                "extract",
+                context,
+                lambda: extract_fn(**kwargs),
+            )
+            chunk_iterator = normalize_extract_result(extract_result)
+
+        reset_iterator()
+        while True:
+            try:
+                raw_chunk_obj = self._runtime_manager.execute_stage(
+                    "extract",
+                    context,
+                    lambda: next(cast(Iterator[pd.DataFrame], chunk_iterator)),
+                    on_retry=reset_iterator,
+                )
+            except StopIteration:
+                break
+
+            counters["extract_chunks"] += 1
+            if raw_chunk_obj is None:
+                raw_chunk: pd.DataFrame = pd.DataFrame()
+            elif isinstance(raw_chunk_obj, pd.DataFrame):
+                raw_chunk = raw_chunk_obj
+            else:
+                raise TypeError("Extractor must yield pandas DataFrame chunks.")
+            counters["extract_count"] += len(raw_chunk)
+
+            (
+                transform_started,
+                counters["transform_chunks"],
+                counters["transform_count"],
+                validate_started,
+                counters["validate_chunks"],
+                counters["validate_count"],
+            ) = self._runtime_manager.process_chunk(
+                raw_chunk,
+                context,
+                transform_started=transform_started,
+                transform_chunks=counters["transform_chunks"],
+                transform_count=counters["transform_count"],
+                validate_started=validate_started,
+                validate_chunks=counters["validate_chunks"],
+                validate_count=counters["validate_count"],
+                validated_chunks=validated_chunks,
+                dry_run=dry_run,
+                transform_fn=transform_fn,
+                apply_transformers=apply_transformers,
+                validate_fn=validate_fn,
+            )
+
+        # Ensure transform is started even if no data
+        if not transform_started:
+            (
+                transform_started,
+                counters["transform_chunks"],
+                counters["transform_count"],
+                validate_started,
+                counters["validate_chunks"],
+                counters["validate_count"],
+            ) = self._runtime_manager.process_chunk(
+                pd.DataFrame(),
+                context,
+                transform_started=transform_started,
+                transform_chunks=counters["transform_chunks"],
+                transform_count=counters["transform_count"],
+                validate_started=validate_started,
+                validate_chunks=counters["validate_chunks"],
+                validate_count=counters["validate_count"],
+                validated_chunks=validated_chunks,
+                dry_run=dry_run,
+                transform_fn=transform_fn,
+                apply_transformers=apply_transformers,
+                validate_fn=validate_fn,
+            )
+
+        return counters, validated_chunks
+
+    def perform_write_stage(
+        self,
+        context: RunContext,
+        validated_chunks: list[pd.DataFrame],
+        output_path: Path,
+        counters: dict[str, int],
+        stages_results: list[StageResult],
+        *,
+        write_fn: Callable[[pd.DataFrame, Path, RunContext], WriteResult],
+    ) -> tuple[WriteResult | None, dict[str, int]]:
+        """Perform write stage.
+
+        Args:
+            context: Run context.
+            validated_chunks: Validated data chunks.
+            output_path: Output file path.
+            counters: Stage counters to update.
+            stages_results: List to append stage results.
+            write_fn: Function to perform the actual write.
+
+        Returns:
+            Tuple of (write result or None, updated counters).
+        """
+        if not self._runtime_manager.get_stage_start("export"):
+            self._runtime_manager.notify_stage_start("export", context)
+
+        df_to_write = (
+            pd.concat(validated_chunks, ignore_index=True)
+            if validated_chunks
+            else pd.DataFrame()
+        )
+
+        write_result_obj = self._runtime_manager.execute_stage(
+            "export",
+            context,
+            lambda: write_fn(df_to_write, output_path, context),
+        )
+        if write_result_obj is None:
+            return None, counters
+        if not isinstance(write_result_obj, WriteResult):
+            raise TypeError("Writer must return WriteResult or None.")
+        write_result = write_result_obj
+
+        counters["export_count"] = write_result.row_count
+        counters["export_chunks"] = max(counters["validate_chunks"], 1)
+
+        self._append_stage_result(
+            stages_results,
+            "export",
+            write_result.row_count,
+            counters["export_chunks"],
+        )
+        return write_result, counters
+
+    def _append_stage_result(
+        self,
+        stages_results: list[StageResult],
+        stage: str,
+        count: int,
+        chunks: int,
+    ) -> None:
+        """Append stage result and notify hooks.
+
+        Args:
+            stages_results: List to append to.
+            stage: Stage name.
+            count: Record count.
+            chunks: Chunk count.
+        """
+        stages_results.append(
+            self._runtime_manager.make_stage_result(
+                stage,
+                count,
+                chunks=chunks,
+            )
+        )
+        self._runtime_manager.notify_stage_end(stage, stages_results[-1])
+
+
+__all__ = ["StageProcessor"]

--- a/src/bioetl/domain/ports/output.py
+++ b/src/bioetl/domain/ports/output.py
@@ -10,6 +10,8 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
+from bioetl.domain.data import TabularData
+
 if TYPE_CHECKING:
     import pandas as pd
 
@@ -19,7 +21,7 @@ if TYPE_CHECKING:
 
 
 class DataWriterPort(Protocol):
-    """Port for writing DataFrame to various formats (parquet, csv, json).
+    """Port for writing tabular data to various formats (parquet, csv, json).
 
     Implementations handle format-specific serialization without
     knowledge of QC reports, metadata, or checksums.
@@ -27,15 +29,15 @@ class DataWriterPort(Protocol):
 
     def write(
         self,
-        df: Any,
+        data: TabularData,
         path: Path,
         *,
         column_order: list[str] | None = None,
     ) -> "WriteResult":
-        """Write DataFrame to the specified path.
+        """Write tabular data to the specified path.
 
         Args:
-            df: DataFrame to write.
+            data: Tabular data to write.
             path: Target file path.
             column_order: Optional column ordering.
 
@@ -64,26 +66,28 @@ class QcReportGeneratorPort(ABC):
     """
 
     @abstractmethod
-    def build_quality_report(self, df: Any, *, min_coverage: float) -> Any:
-        """Build quality metrics report for DataFrame columns.
+    def build_quality_report(
+        self, data: TabularData, *, min_coverage: float
+    ) -> TabularData:
+        """Build quality metrics report for tabular data columns.
 
         Args:
-            df: Source DataFrame.
+            data: Source tabular data.
             min_coverage: Minimum coverage threshold.
 
         Returns:
-            DataFrame with column-level quality metrics.
+            TabularData with column-level quality metrics.
         """
 
     @abstractmethod
-    def build_correlation_report(self, df: Any) -> Any:
+    def build_correlation_report(self, data: TabularData) -> TabularData:
         """Build correlation matrix for numeric columns.
 
         Args:
-            df: Source DataFrame.
+            data: Source tabular data.
 
         Returns:
-            DataFrame with correlation matrix.
+            TabularData with correlation matrix.
         """
 
 

--- a/src/bioetl/interfaces/composition_root.py
+++ b/src/bioetl/interfaces/composition_root.py
@@ -31,8 +31,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
-import requests
-
 from bioetl.application.container import PipelineContainer
 from bioetl.application.contracts import PipelineContainerABC
 from bioetl.application.services.config_migration_service import (
@@ -106,7 +104,7 @@ class CompositionRoot:
         self._observability = observability_factory or DefaultObservabilityFactory()
         self._infrastructure = infrastructure_factory or DefaultInfrastructureFactory()
 
-        self._http_session_factory = http_session_factory or requests.Session
+        self._http_session_factory = http_session_factory
         self._schema_contract_provider = schema_contract_provider
 
         # Lazy-loaded provider registry
@@ -173,7 +171,15 @@ class CompositionRoot:
 
     def create_http_session(self) -> Any:
         """Create a new HTTP session."""
-        return self._http_session_factory()
+        return self._get_http_session_factory()()
+
+    def _get_http_session_factory(self) -> type:
+        """Get HTTP session factory, using lazy import if not explicitly set."""
+        if self._http_session_factory is None:
+            import requests  # Lazy import to avoid module-level dependency
+
+            return requests.Session
+        return self._http_session_factory
 
     def create_http_transport(
         self,


### PR DESCRIPTION
Phase 2:
- Use lazy import for requests.Session in CompositionRoot to decouple interfaces layer from infrastructure details

Phase 3:
- Use TabularData protocol in public APIs (ChemblPipelineBase)
- Strengthen typing in domain ports (Any → TabularData)

Phase 5:
- Create StageProcessor for stage execution logic extraction
- Create ContextBuilder for context building logic extraction
- Create ChemblPipelineComponents dataclass for dependency grouping
- Create RecordSourceResolver for record source resolution logic

Phase 6:
- Remove ignore_import exception from .importlinter (import already removed from orchestrator.py)