### PR TITLE
Clean up unused aliases and legacy code

### DIFF
--- a/src/bioetl/application/bootstrap.py
+++ b/src/bioetl/application/bootstrap.py
@@ -296,6 +296,3 @@ __all__ = [
     "create_application_bootstrap",
     "create_config_migration_service",
 ]
-
-# Backward compatibility alias
-ApplicationContext = ApplicationServicesContext

--- a/src/bioetl/application/orchestrator.py
+++ b/src/bioetl/application/orchestrator.py
@@ -56,8 +56,6 @@ from bioetl.domain.provider_registry import (
 from bioetl.domain.providers import ProviderId
 from bioetl.domain.value_objects import EntityName, StageName
 
-ProviderLoaderProtocol = ProviderRegistryLoaderABC
-
 
 class PipelineOrchestrator:
     """Manages pipeline assembly and execution.
@@ -91,8 +89,8 @@ class PipelineOrchestrator:
         provider_registry_provider: Callable[[], ProviderRegistryABC] | None = None,
         provider_registry_factory: ProviderRegistryFactory,
         container_factory: Callable[..., PipelineContainerABC] | None = None,
-        provider_loader: ProviderLoaderProtocol | None = None,
-        provider_loader_factory: Callable[[], ProviderLoaderProtocol] | None = None,
+        provider_loader: ProviderRegistryLoaderABC | None = None,
+        provider_loader_factory: Callable[[], ProviderRegistryLoaderABC] | None = None,
     ) -> None:
         self._pipeline_name = pipeline_name
         self._config = config

--- a/src/bioetl/application/transform/pandas_batch_adapter.py
+++ b/src/bioetl/application/transform/pandas_batch_adapter.py
@@ -22,18 +22,6 @@ class PandasBatchAdapter(BatchAdapterABC):
     should happen via RecordMapperABC in ExtractStage if needed.
     """
 
-    def __init__(self, model_cls: Any = None) -> None:
-        # model_cls is no longer used - validation happens via RecordMapperABC
-        if model_cls is not None:
-            import warnings
-
-            warnings.warn(
-                "model_cls parameter is deprecated. Use RecordMapperABC in "
-                "ExtractStage for domain model conversion.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
     def process_batch(self, raw_batch: Any) -> list[Mapping[str, Any]]:
         """Normalize provider batch to list of raw dicts.
 
@@ -59,10 +47,6 @@ class PandasBatchAdapter(BatchAdapterABC):
             "Unsupported batch type "
             f"'{type(raw_batch).__name__}' for PandasBatchAdapter"
         )
-
-    def adapt_batch(self, raw_batch: Any) -> list[Mapping[str, Any]]:
-        """Alias for process_batch for backward compatibility."""
-        return self.process_batch(raw_batch)
 
     def _convert_record(self, item: Any) -> Mapping[str, Any]:
         """Convert a single record to raw dict."""

--- a/src/bioetl/domain/clients/base/__init__.py
+++ b/src/bioetl/domain/clients/base/__init__.py
@@ -1,11 +1,4 @@
-"""Base contracts for data source clients.
-
-Note:
-    ``ResponseParserABC`` is deprecated. Use ``ResponseParserPortABC``
-    from ``bioetl.domain.ports.parsing`` instead.
-"""
-
-import warnings
+"""Base contracts for data source clients."""
 
 from bioetl.domain.clients.base.contracts import (
     CacheABC,
@@ -21,23 +14,6 @@ __all__ = [
     "PaginatorABC",
     "RateLimiterABC",
     "RequestBuilderABC",
-    "ResponseParserABC",  # Deprecated: re-exported for backward compatibility
     "RetryPolicyABC",
     "SecretProviderABC",
 ]
-
-
-def __getattr__(name: str) -> type:
-    """Lazy import with deprecation warning for ResponseParserABC."""
-    if name == "ResponseParserABC":
-        from bioetl.domain.ports.parsing import ResponseParserPortABC
-
-        warnings.warn(
-            "ResponseParserABC is deprecated. "
-            "Use ResponseParserPortABC from bioetl.domain.ports.parsing instead. "
-            "See migration guide in bioetl.domain.ports.parsing module docstring.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return ResponseParserPortABC
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/bioetl/domain/clients/base/contracts.py
+++ b/src/bioetl/domain/clients/base/contracts.py
@@ -1,21 +1,12 @@
-"""Base contracts for data source helpers.
-
-Note:
-    ``ResponseParserABC`` has been deprecated and unified with
-    ``ResponseParserPortABC`` from ``bioetl.domain.ports.parsing``.
-    Import ``ResponseParserPortABC`` directly from ``bioetl.domain.ports.parsing``
-    for new code. The re-export here is provided for backward compatibility only.
-"""
+"""Base contracts for data source helpers."""
 
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
-import warnings
 
 from pydantic import BaseModel
 
 T = TypeVar("T")
 RecordT = TypeVar("RecordT", bound=BaseModel)
-RecordModel = BaseModel
 
 if TYPE_CHECKING:
     pass
@@ -56,67 +47,12 @@ class RequestBuilderABC(ABC):
     def build_with_pagination(self, offset: int, limit: int) -> "RequestBuilderABC":
         """Add pagination parameters."""
 
-    def with_pagination(self, offset: int, limit: int) -> "RequestBuilderABC":
-        """Deprecated alias for build_with_pagination.
-
-        .. deprecated:: 1.0
-            Use :meth:`build_with_pagination` instead. Will be removed in 2.0.
-        """
-        warnings.warn(
-            "with_pagination() is deprecated, use build_with_pagination() instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.build_with_pagination(offset, limit)
-
-    def for_endpoint(self, endpoint: str) -> "RequestBuilderABC":
-        """Deprecated alias for build_for_endpoint.
-
-        .. deprecated:: 1.0
-            Use :meth:`build_for_endpoint` instead. Will be removed in 2.0.
-        """
-        warnings.warn(
-            "for_endpoint() is deprecated, use build_for_endpoint() instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.build_for_endpoint(endpoint)
-
-
-# =============================================================================
-# Deprecated: ResponseParserABC
-# =============================================================================
-# ResponseParserABC has been unified with ResponseParserPortABC.
-# This section provides backward compatibility via re-export with deprecation.
-
-
-def __getattr__(name: str) -> type:
-    """Lazy import with deprecation warning for ResponseParserABC.
-
-    This enables backward-compatible imports like:
-        from bioetl.domain.clients.base.contracts import ResponseParserABC
-
-    But emits a DeprecationWarning directing users to the new location.
-    """
-    if name == "ResponseParserABC":
-        from bioetl.domain.ports.parsing import ResponseParserPortABC
-
-        warnings.warn(
-            "ResponseParserABC is deprecated. "
-            "Use ResponseParserPortABC from bioetl.domain.ports.parsing instead. "
-            "See migration guide in bioetl.domain.ports.parsing module docstring.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return ResponseParserPortABC
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
 
 class PaginatorABC(ABC):
     """Pagination strategy."""
 
     @abstractmethod
-    def get_items(self, response: Any) -> list[RecordModel]:
+    def get_items(self, response: Any) -> list[BaseModel]:
         """Extract items from response."""
 
     @abstractmethod

--- a/src/bioetl/domain/configs/__init__.py
+++ b/src/bioetl/domain/configs/__init__.py
@@ -27,7 +27,6 @@ from bioetl.domain.configs.pipeline import (
     BusinessKeyConfig,
     CanonicalizationConfig,
     ChemblSourceConfig,
-    ClientConfig,
     CsvInputConfig,
     DataSinkConfig,
     DataSourceConfig,
@@ -110,6 +109,4 @@ __all__ = [
     "SourcesDefaultsConfig",
     # Protocols
     "PipelineConfigLoaderProtocol",
-    # Deprecated aliases (for backward compatibility)
-    "ClientConfig",
 ]

--- a/src/bioetl/domain/configs/pipeline.py
+++ b/src/bioetl/domain/configs/pipeline.py
@@ -68,44 +68,6 @@ class HttpClientConfig(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    @model_validator(mode="before")
-    @classmethod
-    def migrate_legacy_fields(cls, data: Any) -> Any:
-        """Support legacy field names for backward compatibility."""
-        if not isinstance(data, dict):
-            return data
-
-        migrated = dict(data)
-
-        # HttpClientSettings/HttpClientDefaults field mappings
-        legacy_mappings = {
-            "timeout": "timeout_sec",
-            "retries": "max_retries",
-            "backoff": "backoff_factor",
-            "rate_limit": "rate_limit_per_sec",
-            "circuit_breaker_recovery_time": "circuit_breaker_recovery_sec",
-        }
-
-        for old_name, new_name in legacy_mappings.items():
-            if old_name in migrated and new_name not in migrated:
-                value = migrated.pop(old_name)
-                if old_name in ("timeout", "retries"):
-                    value = float(value) if old_name == "timeout" else int(value)
-                migrated[new_name] = value
-
-        # Handle retry_enabled -> if False, set max_retries to 0
-        if "retry_enabled" in migrated:
-            retry_enabled = migrated.pop("retry_enabled")
-            if not retry_enabled and "max_retries" not in migrated:
-                migrated["max_retries"] = 0
-
-        return migrated
-
-    @property
-    def retry_enabled(self) -> bool:
-        """Backward compatibility property for retry_enabled."""
-        return self.max_retries > 0
-
 
 class ProviderHttpConfig(HttpClientConfig):
     """HTTP configuration for a specific provider with base URL."""
@@ -596,11 +558,6 @@ class PipelineConfig(BaseModel):
         return prov.value if hasattr(prov, "value") else str(prov)
 
     @property
-    def entity_name(self) -> str:
-        """Alias for entity (backward compatibility)."""
-        return str(self.identity.entity)
-
-    @property
     def id(self) -> str:
         """Access pipeline_id from identity section."""
         return str(self.identity.pipeline_id)
@@ -667,29 +624,6 @@ class PipelineConfig(BaseModel):
             runtime=self.runtime,
             transform=self.transform,
         )
-
-    # --- Backward-compatible execution properties ---
-    # These delegate to execution aggregate for consistency
-
-    @property
-    def is_extract_enabled(self) -> bool:
-        """Check if extract stage is enabled (backward-compatible shortcut)."""
-        return self.stages.extract is not False
-
-    @property
-    def is_transform_enabled(self) -> bool:
-        """Check if transform stage is enabled (backward-compatible shortcut)."""
-        return self.stages.transform is not False
-
-    @property
-    def is_load_enabled(self) -> bool:
-        """Check if load stage is enabled (backward-compatible shortcut)."""
-        return self.stages.load is not False
-
-    @property
-    def effective_batch_size(self) -> int:
-        """Get effective batch size from runtime pagination (backward-compatible)."""
-        return self.runtime.pagination.limit
 
     # =========================================================================
     # Public methods
@@ -847,11 +781,4 @@ __all__ = [
     "InterfaceFeaturesConfig",
     "NormalizationConfig",
     "TransformConfig",
-    # Deprecated aliases
-    "ClientConfig",
-    "HttpClientSettings",
 ]
-
-# Deprecated aliases for backward compatibility
-ClientConfig = HttpClientConfig
-HttpClientSettings = HttpClientConfig

--- a/src/bioetl/domain/configs/source.py
+++ b/src/bioetl/domain/configs/source.py
@@ -112,10 +112,5 @@ class DataSourceConfig(BaseModel):
             )
         return self
 
-    @property
-    def csv_options(self) -> CsvInputConfig:
-        """Backward compatibility alias for csv."""
-        return self.csv
-
 
 __all__ = ["CsvInputConfig", "DataSourceConfig"]

--- a/src/bioetl/domain/provider_registry.py
+++ b/src/bioetl/domain/provider_registry.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Protocol, runtime_checkable
+from typing import Callable, Protocol, runtime_checkable
 
 from bioetl.domain.providers import ProviderDefinition, ProviderId
 
@@ -70,31 +70,6 @@ class ProviderRegistryLoaderABC(Protocol):
         self, *, registry: ProviderRegistryABC | None = None
     ) -> ProviderRegistryABC:
         """Load providers and return populated registry."""
-
-
-def __getattr__(name: str) -> Any:
-    """Handle removed names with helpful error messages."""
-    removed = {
-        "InMemoryProviderRegistry": (
-            "InMemoryProviderRegistry has been moved to "
-            "bioetl.infrastructure.provider_registry"
-        ),
-        "set_provider_registry": (
-            "set_provider_registry() has been removed. "
-            "Use CompositionRoot.get_provider_registry() instead."
-        ),
-        "get_provider_registry": (
-            "get_provider_registry() has been removed from domain. "
-            "Use CompositionRoot.get_provider_registry() instead."
-        ),
-        "default_provider_registry": (
-            "default_provider_registry() has been removed. "
-            "Use CompositionRoot.get_provider_registry() instead."
-        ),
-    }
-    if name in removed:
-        raise AttributeError(removed[name])
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 __all__ = [

--- a/src/bioetl/domain/schemas/registry.py
+++ b/src/bioetl/domain/schemas/registry.py
@@ -5,7 +5,6 @@ Registry implementation for schema objects (technology-agnostic).
 from __future__ import annotations
 
 from collections.abc import Callable
-import warnings
 
 from bioetl.domain.schemas.contracts import SchemaGeneratorProtocol
 from bioetl.domain.validation import SchemaProviderABC, schema_type
@@ -162,62 +161,10 @@ def reset_default_schema_registry() -> None:
     _default_registry = None
 
 
-# ---------------------------------------------------------------------------
-# Backward compatibility - deprecated global singleton
-# ---------------------------------------------------------------------------
-
-
-class _DeprecatedRegistryProxy:
-    """
-    Proxy that emits deprecation warning on first attribute access.
-
-    This maintains backward compatibility while encouraging migration
-    to the factory pattern.
-    """
-
-    _warned: bool = False
-    _instance: SchemaRegistry | None = None
-
-    def _warn_once(self) -> None:
-        if not self._warned:
-            warnings.warn(
-                "Global 'registry' is deprecated. "
-                "Use get_default_schema_registry() or "
-                "create_default_schema_registry() instead.",
-                DeprecationWarning,
-                stacklevel=3,
-            )
-            self._warned = True
-
-    def _get_instance(self) -> SchemaRegistry:
-        if self._instance is None:
-            self._instance = get_default_schema_registry()
-        return self._instance
-
-    def __getattr__(self, name: str) -> object:
-        self._warn_once()
-        return getattr(self._get_instance(), name)
-
-    def __repr__(self) -> str:
-        return f"<DeprecatedRegistryProxy wrapping {self._get_instance()!r}>"
-
-
-# Deprecated: use get_default_schema_registry() instead
-registry: SchemaRegistry = _DeprecatedRegistryProxy()  # type: ignore[assignment]
-
-
-def default_schema_provider() -> SchemaProviderABC:
-    """Return the default schema provider (in-memory registry)."""
-    return get_default_schema_registry()
-
-
 __all__ = [
     "SchemaRegistry",
     "create_default_schema_registry",
     "register_schemas",
     "get_default_schema_registry",
     "reset_default_schema_registry",
-    # Deprecated exports (for backward compatibility)
-    "registry",
-    "default_schema_provider",
 ]

--- a/src/bioetl/infrastructure/config/provider_registry.py
+++ b/src/bioetl/infrastructure/config/provider_registry.py
@@ -82,10 +82,6 @@ class ProviderNotConfiguredError(ProviderRegistryError):
         )
 
 
-# Aliases for backward compatibility with clients/provider_registry_loader.py
-ProviderRegistryLoaderError = ProviderRegistryError
-ProviderRegistryConfigNotFoundError = ProviderRegistryNotFoundError
-ProviderRegistryValidationError = ProviderRegistryFormatError
 
 
 # ---------------------------------------------------------------------------
@@ -109,25 +105,7 @@ class ProviderRegistryEntryModel(BaseModel):
     description: str | None = None
     http: ProviderHttpConfig | None = None
 
-    @model_validator(mode="before")
-    @classmethod
-    def migrate_http_client(cls, data: Any) -> Any:
-        """Support legacy 'http_client' field name."""
-        if not isinstance(data, dict):
-            return data
-        if "http_client" in data and "http" not in data:
-            data = dict(data)
-            data["http"] = data.pop("http_client")
-        return data
 
-    @property
-    def http_client(self) -> ProviderHttpConfig | None:
-        """DEPRECATED: Use .http instead."""
-        return self.http
-
-
-# Alias for backward compatibility
-ProviderRegistryEntryConfig = ProviderRegistryEntryModel
 
 
 class ProviderRegistryConfig(BaseModel):
@@ -138,8 +116,6 @@ class ProviderRegistryConfig(BaseModel):
     providers: list[ProviderRegistryEntryModel] = []
 
 
-# Alias for backward compatibility
-ProviderRegistryModel = ProviderRegistryConfig
 
 
 # ---------------------------------------------------------------------------
@@ -362,8 +338,6 @@ class ProviderLoaderImpl(ProviderRegistryLoaderABC):
         return data
 
 
-# Alias for backward compatibility
-ProviderRegistryLoader = ProviderLoaderImpl
 
 
 # ---------------------------------------------------------------------------
@@ -418,18 +392,11 @@ __all__ = [
     "ProviderRegistryNotFoundError",
     "ProviderRegistryFormatError",
     "ProviderNotConfiguredError",
-    # Backward-compatible exception aliases
-    "ProviderRegistryLoaderError",
-    "ProviderRegistryConfigNotFoundError",
-    "ProviderRegistryValidationError",
     # Models
     "ProviderRegistryEntryModel",
-    "ProviderRegistryEntryConfig",  # Alias
     "ProviderRegistryConfig",
-    "ProviderRegistryModel",  # Alias
     # Loader class
     "ProviderLoaderImpl",
-    "ProviderRegistryLoader",  # Alias
     # Validation functions
     "ensure_provider_known",
     "clear_provider_registry_cache",

--- a/src/bioetl/interfaces/__init__.py
+++ b/src/bioetl/interfaces/__init__.py
@@ -36,11 +36,7 @@ from bioetl.interfaces.factories import (
     InfrastructureFactoryABC,
     ObservabilityFactoryABC,
 )
-from bioetl.interfaces.use_case_factory import (
-    UseCaseFactory,
-    get_use_case_factory,
-    reset_use_case_factory,
-)
+from bioetl.interfaces.use_case_factory import UseCaseFactory
 
 __all__ = [
     # Application context
@@ -68,6 +64,4 @@ __all__ = [
     "DefaultInfrastructureFactory",
     # Use case factory
     "UseCaseFactory",
-    "get_use_case_factory",
-    "reset_use_case_factory",
 ]

--- a/src/bioetl/interfaces/cli/app.py
+++ b/src/bioetl/interfaces/cli/app.py
@@ -11,8 +11,8 @@ import typer
 
 from bioetl.application.pipelines.registry import PIPELINE_REGISTRY
 from bioetl.application.use_cases import RunPipelineRequest, RunPipelineResponse
+from bioetl.interfaces.application_context import get_application_context
 from bioetl.interfaces.composition_root import get_composition_root
-from bioetl.interfaces.use_case_factory import get_use_case_factory
 
 app = typer.Typer(help="BioETL - Bioactivity Data Acquisition ETL")
 console = Console()
@@ -136,7 +136,7 @@ def run(
         )
 
         # 2. Get use case via factory
-        use_case = get_use_case_factory().create_run_pipeline_use_case()
+        use_case = get_application_context().use_case_factory.create_run_pipeline_use_case()
 
         # 3. Execute
         _print_start_info(pipeline_name, limit, dry_run)

--- a/src/bioetl/interfaces/rest/server.py
+++ b/src/bioetl/interfaces/rest/server.py
@@ -11,7 +11,7 @@ from bioetl.application.use_cases import (
     InterfaceDisabledError,
     RunPipelineRequest,
 )
-from bioetl.interfaces.use_case_factory import get_use_case_factory
+from bioetl.interfaces.application_context import get_application_context
 
 
 class PipelineRunRequest(BaseModel):
@@ -53,7 +53,7 @@ def create_rest_app() -> FastAPI:
         )
 
         # 2. Get use case via factory
-        use_case = get_use_case_factory().create_run_pipeline_use_case()
+        use_case = get_application_context().use_case_factory.create_run_pipeline_use_case()
 
         # 3. Execute in thread pool
         loop = asyncio.get_running_loop()

--- a/src/bioetl/interfaces/use_case_factory.py
+++ b/src/bioetl/interfaces/use_case_factory.py
@@ -12,9 +12,6 @@ Usage:
     # Direct instantiation (for testing)
     factory = UseCaseFactory(mock_context)
     use_case = factory.create_run_pipeline_use_case()
-
-    # Legacy singleton (deprecated, delegates to ApplicationContext)
-    factory = get_use_case_factory()
 """
 
 from __future__ import annotations
@@ -82,33 +79,6 @@ class UseCaseFactory:
         )
 
 
-def get_use_case_factory() -> UseCaseFactory:
-    """Get use case factory from ApplicationContext singleton.
-
-    This function delegates to ApplicationContext to ensure single source
-    of truth for application dependencies.
-
-    Returns:
-        UseCaseFactory configured with current ApplicationContext.
-    """
-    from bioetl.interfaces.application_context import get_application_context
-
-    return get_application_context().use_case_factory
-
-
-def reset_use_case_factory() -> None:
-    """Reset use case factory (for testing).
-
-    Since UseCaseFactory is now created from ApplicationContext,
-    this function resets the ApplicationContext instead.
-    """
-    from bioetl.interfaces.application_context import reset_application_context
-
-    reset_application_context()
-
-
 __all__ = [
     "UseCaseFactory",
-    "get_use_case_factory",
-    "reset_use_case_factory",
 ]

--- a/tests/architecture/test_architecture_rules.py
+++ b/tests/architecture/test_architecture_rules.py
@@ -39,7 +39,6 @@ ALLOWED_ABCS_WITHOUT_IMPL = {
     "PipelineHookABC",
     "ProviderRegistryABC",
     "RequestBuilderABC",
-    "ResponseParserABC",
     "SchemaProviderABC",
     "SecretProviderABC",
 }

--- a/tests/bioetl/infrastructure/clients/base/test_http_transport.py
+++ b/tests/bioetl/infrastructure/clients/base/test_http_transport.py
@@ -19,7 +19,7 @@ def test_request_call_wraps_timeout_error() -> None:
     metrics = Mock(spec=MetricsPortABC)
     client = _HttpTransport(
         provider="chembl",
-        config=HttpClientConfig(retry_enabled=False),
+        config=HttpClientConfig(max_retries=0),
         base_client=base_client,
         logger=logger,
         metrics=metrics,
@@ -44,7 +44,7 @@ def test_request_call_wraps_request_exception() -> None:
     metrics = Mock(spec=MetricsPortABC)
     client = _HttpTransport(
         provider="chembl",
-        config=HttpClientConfig(retry_enabled=False),
+        config=HttpClientConfig(max_retries=0),
         base_client=base_client,
         logger=logger,
         metrics=metrics,

--- a/tests/bioetl/infrastructure/config/test_provider_registry.py
+++ b/tests/bioetl/infrastructure/config/test_provider_registry.py
@@ -715,37 +715,3 @@ class TestConstants:
         assert DEFAULT_PROVIDERS_REGISTRY_PATH == Path("configs/providers.yaml")
 
 
-# ---------------------------------------------------------------------------
-# Tests: Backward Compatibility Aliases
-# ---------------------------------------------------------------------------
-
-
-class TestBackwardCompatibilityAliases:
-    """Tests to ensure backward compatibility aliases work."""
-
-    def test_exception_aliases(self) -> None:
-        from bioetl.infrastructure.config.provider_registry import (
-            ProviderRegistryConfigNotFoundError,
-            ProviderRegistryLoaderError,
-            ProviderRegistryValidationError,
-        )
-
-        assert ProviderRegistryLoaderError is ProviderRegistryError
-        assert ProviderRegistryConfigNotFoundError is ProviderRegistryNotFoundError
-        assert ProviderRegistryValidationError is ProviderRegistryFormatError
-
-    def test_model_aliases(self) -> None:
-        from bioetl.infrastructure.config.provider_registry import (
-            ProviderRegistryEntryConfig,
-            ProviderRegistryModel,
-        )
-
-        assert ProviderRegistryEntryConfig is ProviderRegistryEntryModel
-        assert ProviderRegistryModel is ProviderRegistryConfig
-
-    def test_loader_alias(self) -> None:
-        from bioetl.infrastructure.config.provider_registry import (
-            ProviderRegistryLoader,
-        )
-
-        assert ProviderRegistryLoader is ProviderLoaderImpl

--- a/tests/bioetl/interfaces/cli/test_cli.py
+++ b/tests/bioetl/interfaces/cli/test_cli.py
@@ -106,7 +106,7 @@ def test_validate_config_success(mock_loader):
 
 
 @pytest.mark.unit
-@patch("bioetl.interfaces.cli.app.get_use_case_factory")
+@patch("bioetl.interfaces.cli.app.get_application_context")
 @patch("bioetl.interfaces.cli.app._resolve_config_path")
 def test_run_command(mock_resolve, mock_get_factory):
     """Test the run command."""
@@ -115,8 +115,8 @@ def test_run_command(mock_resolve, mock_get_factory):
     mock_use_case.execute.return_value = MagicMock(
         success=True, row_count=10, duration_sec=1.0, output_path="out", errors=[]
     )
-    factory = mock_get_factory.return_value
-    factory.create_run_pipeline_use_case.return_value = mock_use_case
+    mock_context = mock_get_factory.return_value
+    mock_context.use_case_factory.create_run_pipeline_use_case.return_value = mock_use_case
 
     result = runner.invoke(app, ["run", "activity_chembl", "--config", "test.yaml"])
 
@@ -146,7 +146,7 @@ def test_smoke_run(mock_run):
 
 
 @pytest.mark.unit
-@patch("bioetl.interfaces.cli.app.get_use_case_factory")
+@patch("bioetl.interfaces.cli.app.get_application_context")
 def test_run_config_not_found_explicit(mock_get_factory):
     """Test run command with explicit config that doesn't exist.
 
@@ -154,8 +154,8 @@ def test_run_config_not_found_explicit(mock_get_factory):
     """
     mock_use_case = MagicMock()
     mock_use_case.execute.side_effect = FileNotFoundError("Config file not found")
-    factory = mock_get_factory.return_value
-    factory.create_run_pipeline_use_case.return_value = mock_use_case
+    mock_context = mock_get_factory.return_value
+    mock_context.use_case_factory.create_run_pipeline_use_case.return_value = mock_use_case
 
     result = runner.invoke(
         app, ["run", "activity_chembl", "--config", "nonexistent.yaml"]
@@ -166,15 +166,15 @@ def test_run_config_not_found_explicit(mock_get_factory):
 
 
 @pytest.mark.unit
-@patch("bioetl.interfaces.cli.app.get_use_case_factory")
+@patch("bioetl.interfaces.cli.app.get_application_context")
 def test_run_with_limit_and_dry_run(mock_get_factory):
     """Test run command with limit and dry-run options."""
     mock_use_case = MagicMock()
     mock_use_case.execute.return_value = MagicMock(
         success=True, row_count=5, duration_sec=0.5, output_path="out", errors=[]
     )
-    factory = mock_get_factory.return_value
-    factory.create_run_pipeline_use_case.return_value = mock_use_case
+    mock_context = mock_get_factory.return_value
+    mock_context.use_case_factory.create_run_pipeline_use_case.return_value = mock_use_case
 
     result = runner.invoke(app, ["run", "activity_chembl", "--limit", "5", "--dry-run"])
 
@@ -188,13 +188,13 @@ def test_run_with_limit_and_dry_run(mock_get_factory):
 
 
 @pytest.mark.unit
-@patch("bioetl.interfaces.cli.app.get_use_case_factory")
+@patch("bioetl.interfaces.cli.app.get_application_context")
 def test_run_pipeline_failure(mock_get_factory):
     """Test run command when pipeline fails."""
     mock_use_case = MagicMock()
     mock_use_case.execute.return_value = MagicMock(success=False, errors=["Error 1"])
-    factory = mock_get_factory.return_value
-    factory.create_run_pipeline_use_case.return_value = mock_use_case
+    mock_context = mock_get_factory.return_value
+    mock_context.use_case_factory.create_run_pipeline_use_case.return_value = mock_use_case
 
     result = runner.invoke(app, ["run", "activity_chembl"])
 
@@ -203,13 +203,13 @@ def test_run_pipeline_failure(mock_get_factory):
 
 
 @pytest.mark.unit
-@patch("bioetl.interfaces.cli.app.get_use_case_factory")
+@patch("bioetl.interfaces.cli.app.get_application_context")
 def test_run_exception(mock_get_factory):
     """Test run command unhandled exception."""
     mock_use_case = MagicMock()
     mock_use_case.execute.side_effect = RuntimeError("Unexpected error")
-    factory = mock_get_factory.return_value
-    factory.create_run_pipeline_use_case.return_value = mock_use_case
+    mock_context = mock_get_factory.return_value
+    mock_context.use_case_factory.create_run_pipeline_use_case.return_value = mock_use_case
 
     result = runner.invoke(app, ["run", "activity_chembl"])
 

--- a/tests/project_rules/test_abc_impl_pattern.py
+++ b/tests/project_rules/test_abc_impl_pattern.py
@@ -21,7 +21,6 @@ ALLOWED_ABCS_WITHOUT_IMPL = {
     "PipelineHookABC",
     "ProviderRegistryABC",
     "RequestBuilderABC",
-    "ResponseParserABC",
     "SchemaProviderABC",
     "SecretProviderABC",
 }


### PR DESCRIPTION
…ity code

- Remove class aliases: ClientConfig, HttpClientSettings, ProviderRegistryLoader, ProviderRegistryEntryConfig, ProviderRegistryModel, ApplicationContext, ProviderLoaderProtocol, RecordModel
- Remove deprecated methods: with_pagination(), for_endpoint(), adapt_batch(), migrate_legacy_fields validator, retry_enabled property, csv_options property, entity_name property, backward-compatible execution properties
- Remove __getattr__ lazy import shims for ResponseParserABC and removed domain functions
- Remove deprecated global objects: _DeprecatedRegistryProxy, registry singleton, default_schema_provider(), get_use_case_factory(), reset_use_case_factory()
- Update CLI and REST to use get_application_context() directly
- Clean up __init__.py exports
- Update tests to work with new API