### PR TITLE
Create architecture and structure diagrams

### DIFF
--- a/docs/diagrams/00-DIAGRAM-INDEX.md
+++ b/docs/diagrams/00-DIAGRAM-INDEX.md
@@ -9,44 +9,65 @@ This directory contains Mermaid diagrams for understanding the BioETL architectu
 ```
 docs/diagrams/
 ├── 00-DIAGRAM-INDEX.md          # This file
+├── overview/                     # High-level architecture diagrams
+│   ├── hexagonal-architecture.mmd
+│   ├── layer-dependencies.mmd
+│   ├── data-flow.mmd
+│   └── system-context.mmd
 ├── layers/                       # Layer-level component diagrams
 │   ├── 01-domain-layer.mmd
 │   ├── 02-application-layer.mmd
 │   ├── 03-infrastructure-layer.mmd
 │   └── 04-interfaces-layer.mmd
 ├── packages/                     # Package-level component diagrams
-│   ├── domain/                   # Domain layer packages
+│   ├── domain/                   # Domain layer packages (13 diagrams)
+│   │   ├── aggregates.mmd
+│   │   ├── clients.mmd
+│   │   ├── configs.mmd
 │   │   ├── entities.mmd
+│   │   ├── observability.mmd
+│   │   ├── output.mmd
+│   │   ├── pipelines.mmd
 │   │   ├── ports.mmd
 │   │   ├── schemas.mmd
-│   │   ├── configs.mmd
 │   │   ├── services.mmd
 │   │   ├── transform.mmd
 │   │   ├── validation.mmd
-│   │   ├── clients.mmd
 │   │   └── value-objects.mmd
-│   ├── application/              # Application layer packages
-│   │   ├── factories.mmd
-│   │   ├── services.mmd
-│   │   ├── pipelines.mmd
-│   │   ├── sources.mmd
-│   │   ├── mappers.mmd
-│   │   ├── use-cases.mmd
-│   │   └── config.mmd
-│   ├── infrastructure/           # Infrastructure layer packages
-│   │   ├── clients.mmd
-│   │   ├── output.mmd
+│   ├── application/              # Application layer packages (14 diagrams)
 │   │   ├── config.mmd
-│   │   ├── transform.mmd
-│   │   ├── validation.mmd
+│   │   ├── factories.mmd
 │   │   ├── files.mmd
+│   │   ├── helpers.mmd
+│   │   ├── mappers.mmd
+│   │   ├── metadata.mmd
+│   │   ├── pipelines.mmd
+│   │   ├── ports.mmd
+│   │   ├── providers.mmd
+│   │   ├── runtime.mmd
+│   │   ├── services.mmd
+│   │   ├── sources.mmd
+│   │   ├── transform.mmd
+│   │   └── use-cases.mmd
+│   ├── infrastructure/           # Infrastructure layer packages (12 diagrams)
+│   │   ├── adapters.mmd
+│   │   ├── chembl.mmd
+│   │   ├── clients.mmd
+│   │   ├── config.mmd
+│   │   ├── files.mmd
+│   │   ├── http.mmd
 │   │   ├── logging.mmd
-│   │   └── adapters.mmd
-│   └── interfaces/               # Interfaces layer packages
+│   │   ├── observability.mmd
+│   │   ├── output.mmd
+│   │   ├── settings.mmd
+│   │   ├── transform.mmd
+│   │   └── validation.mmd
+│   └── interfaces/               # Interfaces layer packages (4 diagrams)
 │       ├── cli.mmd
 │       ├── factories.mmd
+│       ├── monitoring.mmd
 │       └── rest.mmd
-├── classes/                      # Class diagrams by object type
+├── classes/                      # Class diagrams by object type (14 diagrams)
 │   ├── 01-factories.mmd
 │   ├── 02-services.mmd
 │   ├── 03-ports-abc.mmd
@@ -61,18 +82,69 @@ docs/diagrams/
 │   ├── 12-domain-entities.mmd
 │   ├── 13-value-objects.mmd
 │   └── 14-configs.mmd
-└── overview/                     # High-level architecture diagrams
-    ├── hexagonal-architecture.mmd
-    ├── layer-dependencies.mmd
-    ├── data-flow.mmd
-    └── system-context.mmd
+├── component/                    # Component diagrams (11 diagrams)
+│   ├── 01-application-components.mmd
+│   ├── 02-domain-components.mmd
+│   ├── 03-infrastructure-components.mmd
+│   ├── 04-interfaces-components.mmd
+│   ├── 05-system-context-bioetl.mmd
+│   ├── 06-hexagonal-architecture.mmd
+│   ├── 07-physical-layer-mapping.mmd
+│   ├── 08-key-modules-overview.mmd
+│   ├── 09-architecture-rules.mmd
+│   ├── 10-cli-architecture.mmd
+│   └── 11-test-suite-structure.mmd
+├── flow/                         # Flow diagrams (17 diagrams)
+│   ├── api-to-storage-dataflow.mmd
+│   ├── chembl-pipeline-dependency-graph.mmd
+│   ├── ci-workflow.mmd
+│   ├── cli-extension-flow.mmd
+│   ├── cli-option-mapping.mmd
+│   ├── config-loading-flow.mmd
+│   ├── csv-input-flow.mmd
+│   ├── ddd-layered-architecture.mmd
+│   ├── domain-services-transform.mmd
+│   ├── error-policy-flow.mmd
+│   ├── etl-stage-dag.mmd
+│   ├── external-enrichment-flow.mmd
+│   ├── high-level-architecture.mmd
+│   ├── layer-dependency-graph.mmd
+│   ├── pagination-flow.mmd
+│   ├── pipeline-error-flowchart.mmd
+│   ├── project-package-structure.mmd
+│   ├── rate-limiter-timeline.mmd
+│   ├── retry-policy-flow.mmd
+│   └── testing-pyramid.mmd
+└── sequence/                     # Sequence diagrams (5 diagrams)
+    ├── chembl-api-request-sequence.mmd
+    ├── cli-run-sequence.mmd
+    ├── manual-di-assembly-sequence.mmd
+    ├── pipeline-hooks-sequence.mmd
+    └── pipeline-run-sequence.mmd
 ```
+
+**Total: 100+ Mermaid diagrams**
 
 ---
 
 ## Diagram Catalog
 
-### 1. Layer Component Diagrams (`layers/`)
+### 1. Overview Diagrams (`overview/`)
+
+High-level architecture and system context diagrams.
+
+| File | Description |
+|------|-------------|
+| `hexagonal-architecture.mmd` | Hexagonal architecture pattern overview |
+| `layer-dependencies.mmd` | Layer dependency graph |
+| `data-flow.mmd` | Data flow through ETL pipeline |
+| `system-context.mmd` | System context and external integrations |
+
+---
+
+### 2. Layer Component Diagrams (`layers/`)
+
+One diagram per architectural layer showing all packages.
 
 | File | Description |
 |------|-------------|
@@ -83,46 +155,63 @@ docs/diagrams/
 
 ---
 
-### 2. Package Component Diagrams (`packages/`)
+### 3. Package Component Diagrams (`packages/`)
+
+Detailed diagrams for each package within a layer.
 
 #### Domain Layer Packages (`packages/domain/`)
 
 | File | Description |
 |------|-------------|
+| `aggregates.mmd` | Aggregate roots: PipelineIdentity |
+| `clients.mmd` | Client base contracts and resilience |
+| `configs.mmd` | Configuration models: pipeline, source, sink, execution |
 | `entities.mmd` | Domain entities: Activity, Assay, Target, Molecule, Publication |
+| `observability.mmd` | Observability contracts: logging, metrics, tracing, progress |
+| `output.mmd` | Deterministic output specifications and writers |
+| `pipelines.mmd` | Pipeline contracts: ExtractorABC, LoaderABC, PipelineHookABC |
 | `ports.mmd` | Abstract ports: extraction, output, config, parsing, filters |
 | `schemas.mmd` | Validation schemas: Pandera schemas, field specs, pipeline contracts |
-| `configs.mmd` | Configuration models: pipeline, source, sink, execution |
 | `services.mmd` | Domain services: entity factory, business key service, version formatter |
 | `transform.mmd` | Transform contracts: normalizers, serializers, transformers |
 | `validation.mmd` | Validation service contracts |
-| `clients.mmd` | Client base contracts and resilience |
 | `value-objects.mmd` | Value objects: identifiers, temporal, network, crypto |
 
 #### Application Layer Packages (`packages/application/`)
 
 | File | Description |
 |------|-------------|
-| `factories.mmd` | Application factories: service, runtime, hooks, transform, record source |
-| `services.mmd` | Application services: configuration, schema bootstrap, observability |
-| `pipelines.mmd` | Pipeline components: base, ChEMBL, stages, hooks, context |
-| `sources.mmd` | Record sources: API, CSV, ID list |
-| `mappers.mmd` | Record mappers: ChEMBL mapper |
-| `use-cases.mmd` | Use cases: RunPipelineUseCase |
 | `config.mmd` | Config resolution and runtime |
+| `factories.mmd` | Application factories: service, runtime, hooks, transform, record source |
+| `files.mmd` | File-based record sources: CsvRecordSourceImpl, IdListRecordSourceImpl |
+| `helpers.mmd` | Utility functions: primary key resolution |
+| `mappers.mmd` | Record mappers: ChEMBL mapper |
+| `metadata.mmd` | Run metadata builders |
+| `pipelines.mmd` | Pipeline components: base, ChEMBL, stages, hooks, context |
+| `ports.mmd` | Application-level ports: ObservabilityFactoryPortABC |
+| `providers.mmd` | Default field providers |
+| `runtime.mmd` | Pipeline runtime support |
+| `services.mmd` | Application services: configuration, schema bootstrap, observability |
+| `sources.mmd` | Record sources: API, CSV, ID list |
+| `transform.mmd` | Batch adapters: PandasBatchAdapter |
+| `use-cases.mmd` | Use cases: RunPipelineUseCase |
 
 #### Infrastructure Layer Packages (`packages/infrastructure/`)
 
 | File | Description |
 |------|-------------|
+| `adapters.mmd` | Port adapters: config loader adapter, pandas tabular adapter |
+| `chembl.mmd` | ChEMBL-specific model registry |
 | `clients.mmd` | HTTP clients: ChEMBL client, request builder, paginator, response parser |
-| `output.mmd` | Output writers: CSV, Parquet, metadata, QC reports |
 | `config.mmd` | Config loaders: YAML loader, path resolver, provider loader |
+| `files.mmd` | File operations: atomic writer, checksum calculator, path resolver |
+| `http.mmd` | HTTP retry policies: ExponentialRetryPolicy |
+| `logging.mmd` | Logging: progress reporter, unified logger |
+| `observability.mmd` | Observability implementations: structlog, prometheus |
+| `output.mmd` | Output writers: CSV, Parquet, metadata, QC reports |
+| `settings.mmd` | Configuration constants: timeouts, retry, connection pool |
 | `transform.mmd` | Transform implementations: hash service, normalizer, timestamp provider |
 | `validation.mmd` | Validation: Pandera validator, schema implementations |
-| `files.mmd` | File operations: atomic writer, checksum calculator, path resolver |
-| `logging.mmd` | Logging: progress reporter, unified logger |
-| `adapters.mmd` | Port adapters: config loader adapter, pandas tabular adapter |
 
 #### Interfaces Layer Packages (`packages/interfaces/`)
 
@@ -130,11 +219,14 @@ docs/diagrams/
 |------|-------------|
 | `cli.mmd` | CLI commands: Typer application, command groups |
 | `factories.mmd` | Interface factories: infrastructure, observability |
+| `monitoring.mmd` | Prometheus metrics integration |
 | `rest.mmd` | REST API endpoints |
 
 ---
 
-### 3. Class Diagrams by Object Type (`classes/`)
+### 4. Class Diagrams by Object Type (`classes/`)
+
+Cross-layer class diagrams organized by object type.
 
 | File | Description |
 |------|-------------|
@@ -155,14 +247,66 @@ docs/diagrams/
 
 ---
 
-### 4. Overview Diagrams (`overview/`)
+### 5. Component Diagrams (`component/`)
+
+C4-style component diagrams showing system structure.
 
 | File | Description |
 |------|-------------|
-| `hexagonal-architecture.mmd` | Hexagonal architecture pattern overview |
-| `layer-dependencies.mmd` | Layer dependency graph |
-| `data-flow.mmd` | Data flow through ETL pipeline |
-| `system-context.mmd` | System context and external integrations |
+| `01-application-components.mmd` | Application layer component diagram |
+| `02-domain-components.mmd` | Domain layer component diagram |
+| `03-infrastructure-components.mmd` | Infrastructure layer component diagram |
+| `04-interfaces-components.mmd` | Interfaces layer component diagram |
+| `05-system-context-bioetl.mmd` | System context diagram |
+| `06-hexagonal-architecture.mmd` | Hexagonal architecture overview |
+| `07-physical-layer-mapping.mmd` | Directory to layer mapping |
+| `08-key-modules-overview.mmd` | Key modules overview |
+| `09-architecture-rules.mmd` | Architecture constraints and rules |
+| `10-cli-architecture.mmd` | CLI architecture |
+| `11-test-suite-structure.mmd` | Test suite structure |
+
+---
+
+### 6. Flow Diagrams (`flow/`)
+
+Process flows, data flows, and decision diagrams.
+
+| File | Description |
+|------|-------------|
+| `api-to-storage-dataflow.mmd` | Complete data flow from API to storage |
+| `chembl-pipeline-dependency-graph.mmd` | ChEMBL pipeline dependencies |
+| `ci-workflow.mmd` | CI/CD workflow |
+| `cli-extension-flow.mmd` | CLI extension flow |
+| `cli-option-mapping.mmd` | CLI option mapping |
+| `config-loading-flow.mmd` | Configuration loading process |
+| `csv-input-flow.mmd` | CSV input processing flow |
+| `ddd-layered-architecture.mmd` | DDD layered architecture |
+| `domain-services-transform.mmd` | Domain services transform flow |
+| `error-policy-flow.mmd` | Error policy decision flow |
+| `etl-stage-dag.mmd` | ETL stage directed acyclic graph |
+| `external-enrichment-flow.mmd` | External data enrichment flow |
+| `high-level-architecture.mmd` | High-level architecture overview |
+| `layer-dependency-graph.mmd` | Layer dependency graph |
+| `pagination-flow.mmd` | Pagination mechanism flow |
+| `pipeline-error-flowchart.mmd` | Pipeline error handling flowchart |
+| `project-package-structure.mmd` | Project package structure |
+| `rate-limiter-timeline.mmd` | Rate limiter timeline |
+| `retry-policy-flow.mmd` | Retry policy decision flow |
+| `testing-pyramid.mmd` | Testing pyramid |
+
+---
+
+### 7. Sequence Diagrams (`sequence/`)
+
+Interaction diagrams showing message flows.
+
+| File | Description |
+|------|-------------|
+| `chembl-api-request-sequence.mmd` | ChEMBL API request sequence |
+| `cli-run-sequence.mmd` | CLI run command sequence |
+| `manual-di-assembly-sequence.mmd` | Manual dependency injection assembly |
+| `pipeline-hooks-sequence.mmd` | Pipeline hooks execution sequence |
+| `pipeline-run-sequence.mmd` | Pipeline run sequence |
 
 ---
 
@@ -187,6 +331,9 @@ mmdc -i diagram.mmd -o diagram.png
 
 # Generate SVG
 mmdc -i diagram.mmd -o diagram.svg
+
+# Batch convert all diagrams
+find . -name "*.mmd" -exec sh -c 'mmdc -i "$1" -o "${1%.mmd}.png"' _ {} \;
 ```
 
 ---
@@ -194,15 +341,20 @@ mmdc -i diagram.mmd -o diagram.svg
 ## Conventions
 
 ### Styling
-- **Primary components**: `fill:#f5f5f5,stroke:#444`
-- **Secondary components**: `fill:#e3e7ec,stroke:#555`
-- **External/Interface**: `fill:#dde7f2,stroke:#44546a`
 - **Domain**: `fill:#e8f5e9,stroke:#2e7d32`
 - **Application**: `fill:#e3f2fd,stroke:#1565c0`
 - **Infrastructure**: `fill:#fff3e0,stroke:#ef6c00`
 - **Interfaces**: `fill:#fce4ec,stroke:#c2185b`
+- **Abstract/Ports**: `fill:#a5d6a7,stroke:#43a047`
+- **External**: `fill:#dde7f2,stroke:#44546a`
 
 ### Naming
 - Use lowercase with hyphens for filenames
-- Prefix layer diagrams with numbers for ordering
+- Prefix numbered diagrams for ordering (e.g., `01-`, `02-`)
 - Use descriptive names that indicate content
+
+### Diagram Types
+- **Class diagrams**: Show class relationships and hierarchies
+- **Component diagrams**: Show system structure (C4-style)
+- **Flow diagrams**: Show processes and data flows
+- **Sequence diagrams**: Show message interactions

--- a/docs/diagrams/component/01-application-components.mmd
+++ b/docs/diagrams/component/01-application-components.mmd
@@ -1,0 +1,97 @@
+---
+id: 7a0c7b7f-3f2b-4f8a-8f2c-6c3e0c4da2f2
+title: Application Layer Components
+---
+flowchart TB
+
+classDef componentPrimary   fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+classDef componentSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+classDef external           fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:14px
+classDef entryPoint         fill:#e6ecef,stroke:#333,stroke-width:1.5px,color:#111,font-size:22px
+
+subgraph Entry["Interfaces / Entry Points"]
+    CLI["**CLI (Typer) / REST / MQ**\nbioetl.interfaces.*"]:::external
+end
+class Entry entryPoint
+
+subgraph Application["Application Layer"]
+    Orchestrator["PipelineOrchestrator\nbioetl.application.orchestrator"]:::componentPrimary
+    Container["PipelineContainer\nbioetl.application.container"]:::componentPrimary
+    Contracts["PipelineContainerABC / PipelineFactoryABC\nbioetl.application.contracts"]:::componentSecondary
+    PipelineRegistry["Pipeline Registry\nbioetl.application.pipelines.registry"]:::componentSecondary
+
+    subgraph Factories["Factories (bioetl.application.factories)"]
+        ServiceFactory["ApplicationServiceFactory\nservice_factory.py"]:::componentSecondary
+        TransformFactory["TransformComponentFactory\ntransform_factory.py"]:::componentSecondary
+        RuntimeFactory["PipelineRuntimeFactory\nruntime_factory.py"]:::componentSecondary
+        RecordSourceFactory["RecordSourceFactory\nrecord_source.py"]:::componentSecondary
+        HookFactory["PipelineHookFactory\nhooks.py"]:::componentSecondary
+        ProviderServiceFactory["ProviderServiceFactory\nservices.py"]:::componentSecondary
+    end
+
+    subgraph Config["Configuration (bioetl.application.config)"]
+        ConfigResolution["ConfigPathResolver\nresolution.py"]:::componentSecondary
+        ConfigRuntime["ConfigRuntimeService\nruntime.py"]:::componentSecondary
+    end
+
+    subgraph Pipelines["Pipelines (bioetl.application.pipelines)"]
+        PipelineBase["PipelineBase\nbase.py"]:::componentSecondary
+        ChemblPipelineBase["ChemblPipelineBase\nchembl/base.py"]:::componentSecondary
+        ChemblCommonPipeline["ChemblCommonPipeline\nchembl/common.py"]:::componentSecondary
+        StageRuntimeManager["StageRuntimeManager\nstage_runtime_manager.py"]:::componentSecondary
+        StageErrorHandler["StageErrorHandler\nstage_error_handler.py"]:::componentSecondary
+    end
+
+    subgraph Services["Services (bioetl.application.services)"]
+        SchemaBootstrap["SchemaBootstrapService\nschema_bootstrap.py"]:::componentSecondary
+        SchemaContractProvider["SchemaContractProviderImpl\nschema_contract_provider.py"]:::componentSecondary
+        ConfigMigration["ConfigMigrationService\nconfig_migration_service.py"]:::componentSecondary
+    end
+
+    subgraph UseCases["Use Cases (bioetl.application.use_cases)"]
+        RunPipelineUseCase["RunPipelineUseCase\nrun_pipeline.py"]:::componentSecondary
+    end
+end
+class Application group;
+
+subgraph Domain["Domain Dependencies"]
+    Validation["ValidationService\nbioetl.domain.validation.service"]:::componentSecondary
+    HashServiceABC["HashServiceABC\nbioetl.domain.transform.contracts"]:::componentSecondary
+    NormalizationABC["NormalizationServiceABC\nbioetl.domain.transform.contracts"]:::componentSecondary
+    PipelineSchemaModel["PipelineSchemaModel\nbioetl.domain.schemas.pipeline_contracts"]:::componentSecondary
+    ProviderRegistryABC["ProviderRegistryABC\nbioetl.domain.provider_registry"]:::componentSecondary
+    RecordSourceABC["RecordSourceABC\nbioetl.domain.record_source"]:::componentSecondary
+end
+class Domain group;
+
+subgraph Infrastructure["Infrastructure Dependencies"]
+    ProviderRegistry["ProviderRegistryLoader\ninfrastructure.config.provider_registry"]:::componentSecondary
+    Clients["ChEMBL Client Stack\nUnifiedAPIClient + ChemblHttpClientImpl"]:::componentSecondary
+    Output["UnifiedLoaderImpl\nCSV/Parquet + MetadataWriter"]:::componentSecondary
+    Logging["UnifiedLogger\ninfrastructure.logging.*"]:::componentSecondary
+end
+class Infrastructure group;
+
+CLI --> Orchestrator
+Orchestrator --> PipelineRegistry
+Orchestrator --> Container
+Orchestrator --> ConfigResolution
+Container --> Contracts
+Container --> Pipelines
+Container --> Factories
+Container --> Services
+Container --> Validation
+Container --> HashServiceABC
+Container --> NormalizationABC
+Container --> PipelineSchemaModel
+Container --> ProviderRegistryABC
+Container --> RecordSourceABC
+Container --> ProviderRegistry
+Container --> Clients
+Container --> Output
+Container --> Logging
+Pipelines --> StageRuntimeManager
+StageRuntimeManager --> StageErrorHandler
+UseCases --> Orchestrator
+ServiceFactory --> ProviderServiceFactory
+RuntimeFactory --> HookFactory

--- a/docs/diagrams/component/02-domain-components.mmd
+++ b/docs/diagrams/component/02-domain-components.mmd
@@ -1,0 +1,115 @@
+---
+id: 5ce0c6b3-7f5b-4c5c-8d1a-4c1cbf2c2a9e
+title: Domain Layer Components
+---
+flowchart LR
+
+classDef componentPrimary   fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+classDef componentSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+classDef external           fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px
+classDef group              fill:#e6ecef,stroke:#333,stroke-width:1.5px,color:#111,font-size:22px
+
+subgraph Domain["Domain Layer"]
+    subgraph Ports["Ports (bioetl.domain.ports)"]
+        ExtractionPorts["ExtractionServiceABC\nRecordFetcherABC\nBatchAdapterABC\nextraction.py"]:::componentSecondary
+        OutputPorts["DataWriterPort\nMetadataWriterPort\nQcArtifactWriterPort\noutput.py"]:::componentSecondary
+        ParsingPorts["ResponseParserPortABC\nrequest_building.py"]:::componentSecondary
+        SchemaPorts["SchemaContractProviderABC\nschema.py"]:::componentSecondary
+        ConfigPorts["ConfigLoaderPortABC\nConfigPathResolverPortABC\nconfig_loader_port.py"]:::componentSecondary
+        EntityPorts["EntityModelRegistryABC\nentity_models.py"]:::componentSecondary
+        InfraPorts["ABCRegistryResolverPortABC\nInfrastructureFactoryPortABC\ninfrastructure_factory_port.py"]:::componentSecondary
+    end
+
+    subgraph Transform["Transform (bioetl.domain.transform)"]
+        TransformContracts["HashServiceABC\nNormalizationServiceABC\nIndexGeneratorABC\nTimestampProviderABC\ncontracts.py"]:::componentPrimary
+        Transformers["TransformerABC\nTransformerChain\ntransformers.py"]:::componentSecondary
+        Serializers["SerializerABC\nserializers.py"]:::componentSecondary
+        HashService["HashService\nhash_service.py"]:::componentSecondary
+        Normalizers["BaseNormalizerABC\nnormalizers/base.py\nnormalizers/registry.py"]:::componentSecondary
+    end
+
+    subgraph Validation["Validation (bioetl.domain.validation)"]
+        ValidationService["ValidationService\nservice.py"]:::componentPrimary
+        ValidationContracts["SchemaProviderABC\nValidatorFactoryABC\nValidatorABC\ncontracts.py"]:::componentSecondary
+    end
+
+    subgraph Schemas["Schemas (bioetl.domain.schemas)"]
+        SchemaRegistry["SchemaRegistry\nregistry.py"]:::componentSecondary
+        PipelineContracts["PipelineSchemaModel\nget_pipeline_contract()\npipeline_contracts.py"]:::componentPrimary
+        ChemblSchemas["ChEMBL Raw Models\nActivity/Assay/Target/Molecule\nchembl/*.py"]:::componentSecondary
+    end
+
+    subgraph Clients["Clients (bioetl.domain.clients)"]
+        ClientContracts["DataClientABC\nRateLimiterABC\nCacheABC\nbase/contracts.py"]:::componentSecondary
+        OutputContracts["RunMetadataBuilderProtocol\nbase/output/contracts.py"]:::componentSecondary
+    end
+
+    subgraph Pipelines["Pipelines (bioetl.domain.pipelines)"]
+        PipelineContracts2["PipelineHookABC\nErrorPolicyABC\nLoaderABC\ncontracts.py"]:::componentSecondary
+        PipelineTypes["PipelineType enum\ntypes.py"]:::componentSecondary
+    end
+
+    subgraph Configs["Configs (bioetl.domain.configs)"]
+        PipelineConfig["PipelineConfig\npipeline.py"]:::componentPrimary
+        SourceConfig["SourceConfig\nsource.py"]:::componentSecondary
+        SinkConfig["SinkConfig\nsink.py"]:::componentSecondary
+        HttpClientConfig["HttpClientConfig\nhttp_client.py"]:::componentSecondary
+        QualityConfig["DeterminismConfig\nQcConfig\nquality.py"]:::componentSecondary
+    end
+
+    subgraph CoreModels["Core Models"]
+        DomainModels["RunContext\nRunResult\nStageResult\nmodels.py"]:::componentPrimary
+        DomainErrors["BioetlError\nClientError\nConfigError\nerrors.py"]:::componentSecondary
+        DomainEnums["ErrorAction\nenums.py"]:::componentSecondary
+        ValueObjects["ChemblId\nEntityName\nHashDigest\nPipelineId\nRunId\nvalue_objects/*.py"]:::componentSecondary
+    end
+
+    subgraph DataAbstraction["Data Abstraction"]
+        TabularData["TabularData Protocol\nRecordBatch\nRecordSet\ndata.py"]:::componentPrimary
+        RecordSource["RecordSourceABC\nInMemoryRecordSource\nrecord_source.py"]:::componentSecondary
+        TypeAliases["ApiPayload\nFieldConfig\ntypes.py"]:::componentSecondary
+    end
+
+    subgraph Aggregates["Aggregates"]
+        PipelineIdentity["PipelineIdentity\naggregates/pipeline_identity.py"]:::componentSecondary
+    end
+
+    subgraph ProviderRegistry["Provider Registry"]
+        ProviderRegistryABC["ProviderRegistryABC\nProviderRegistryFactory\nprovider_registry.py"]:::componentPrimary
+        ProviderDefinition["ProviderDefinition\nProviderId\nproviders.py"]:::componentSecondary
+    end
+
+    subgraph Observability["Observability (bioetl.domain.observability)"]
+        ObservabilityContracts["LoggingPortABC\nMetricsPortABC\ncontracts.py"]:::componentSecondary
+    end
+end
+class Domain group
+
+subgraph Application["Application Layer"]
+    Pipeline["PipelineBase / ChemblPipelineBase\napplication.pipelines.*"]:::external
+    Container["PipelineContainer\napplication.container"]:::external
+end
+class Application group;
+
+subgraph Infrastructure["Infrastructure Layer"]
+    Writers["UnifiedLoaderImpl\ninfrastructure.output.*"]:::external
+    InfraClients["ChemblHttpClientImpl\ninfrastructure.clients.chembl.*"]:::external
+end
+class Infrastructure group;
+
+Pipeline --> ValidationService
+Pipeline --> TransformContracts
+Pipeline --> PipelineContracts2
+Pipeline --> DomainModels
+Pipeline --> Configs
+Container --> ProviderRegistryABC
+ValidationService --> ValidationContracts
+ValidationService --> SchemaRegistry
+TransformContracts --> Transformers
+TransformContracts --> HashService
+TransformContracts --> Normalizers
+Transformers --> Serializers
+InfraClients --> ClientContracts
+Writers --> OutputContracts
+Writers --> ObservabilityContracts
+RecordSource --> ExtractionPorts

--- a/docs/diagrams/component/03-infrastructure-components.mmd
+++ b/docs/diagrams/component/03-infrastructure-components.mmd
@@ -1,0 +1,147 @@
+---
+id: 3f8f3a0c-6e6d-4a2b-9eae-6d5d981b37c8
+title: Infrastructure Layer Components
+---
+flowchart LR
+
+classDef componentPrimary   fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+classDef componentSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+classDef external           fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px
+classDef group              fill:#e6ecef,stroke:#333,stroke-width:1.5px,color:#111,font-size:22px
+
+subgraph Infrastructure["Infrastructure Layer"]
+    subgraph ClientsBase["Clients Base (infrastructure.clients.base)"]
+        HTTPTransport["HTTPTransport\nimpl/_http_transport.py"]:::componentSecondary
+        RateLimiter["TokenBucketRateLimiterImpl\nimpl/rate_limiter.py"]:::componentSecondary
+        Cache["MemoryCacheImpl\nimpl/cache.py"]:::componentSecondary
+        ClientFactories["build_http_client()\nfactories.py"]:::componentSecondary
+        ABCRegistry["ABCRegistryResolver\nabc_registry_resolver.py"]:::componentSecondary
+    end
+
+    subgraph ClientsChembl["Clients ChEMBL (infrastructure.clients.chembl)"]
+        ChemblHttpClient["ChemblHttpClientImpl\nimpl/chembl_http_client_impl.py"]:::componentPrimary
+        ExtractionService["ChemblExtractionServiceImpl\nimpl/chembl_extraction_service_impl.py"]:::componentSecondary
+        RequestBuilder["RequestBuilder\nrequest_builder.py"]:::componentSecondary
+        ResponseParser["ResponseParser\nresponse_parser.py"]:::componentSecondary
+        Paginator["ChemblPaginatorImpl\npaginator.py"]:::componentSecondary
+        ParserRegistry["ParserRegistry\nparser_registry.py"]:::componentSecondary
+        ChemblSerializer["Serializers\nserializers.py"]:::componentSecondary
+    end
+
+    subgraph HTTP["HTTP (infrastructure.http)"]
+        RetryPolicy["RetryPolicy\nretry.py"]:::componentSecondary
+    end
+
+    subgraph Output["Output (infrastructure.output)"]
+        UnifiedLoader["UnifiedLoaderImpl\nunified_loader_impl.py"]:::componentPrimary
+        OutputFactories["OutputFactories\nfactories.py"]:::componentSecondary
+        BaseWriter["BaseWriter\nimpl/base_writer.py"]:::componentSecondary
+        CsvWriter["CsvWriter\nimpl/csv_writer.py"]:::componentSecondary
+        ParquetWriter["ParquetWriter\nimpl/parquet_writer.py"]:::componentSecondary
+        MetadataWriter["MetadataWriter\nimpl/metadata_writer.py"]:::componentSecondary
+        QualityReporter["QualityReporter\nimpl/quality_reporter.py"]:::componentSecondary
+        Converters["DropnaRowsConverter\nRenameColumnsConverter\nconverters/*.py"]:::componentSecondary
+        ColumnOrder["ColumnOrder\ncolumn_order.py"]:::componentSecondary
+    end
+
+    subgraph Files["Files (infrastructure.files)"]
+        AtomicIO["AtomicFileOperation\natomic.py"]:::componentSecondary
+        Checksum["Checksum\nchecksum.py"]:::componentSecondary
+    end
+
+    subgraph Transform["Transform (infrastructure.transform)"]
+        NormalizationService["ChemblNormalizationServiceImpl\nimpl/chembl_normalization_service_impl.py"]:::componentPrimary
+        NormalizationImpl["DefaultNormalizationTransformerImpl\nimpl/default_normalization_transformer_impl.py"]:::componentSecondary
+        Hasher["HasherImpl\nimpl/hasher.py"]:::componentSecondary
+        TransformFactories["TransformFactories\nfactories.py"]:::componentSecondary
+        IndexGenerator["IndexGeneratorImpl\nimpl/index_generator.py"]:::componentSecondary
+        TimestampProvider["TimestampProviderImpl\nimpl/timestamp_provider.py"]:::componentSecondary
+    end
+
+    subgraph Validation["Validation (infrastructure.validation)"]
+        PanderaValidator["PanderaValidatorImpl\nimpl/pandera_validator.py"]:::componentSecondary
+        ValidationFactories["ValidationFactories\nfactories.py"]:::componentSecondary
+        ValidationBootstrap["register_schemas()\nbootstrap.py"]:::componentSecondary
+        ValidationSchemas["ChEMBL Pandera Schemas\nschemas/chembl/*.py"]:::componentSecondary
+    end
+
+    subgraph Logging["Logging (infrastructure.logging)"]
+        LoggingFactories["LoggingFactories\nfactories.py"]:::componentSecondary
+        ProgressReporter["ProgressReporter\nimpl/progress_reporter.py"]:::componentSecondary
+        UnifiedLogger["UnifiedLoggerAdapter\nimpl/unified_logger.py"]:::componentSecondary
+    end
+
+    subgraph Observability["Observability (infrastructure.observability)"]
+        ObservabilityServer["MetricsServer\nserver.py"]:::componentSecondary
+        ObservabilityMetrics["PrometheusMetrics\nmetrics.py"]:::componentSecondary
+        ObservabilityAdapters["MetricsAdapter\nadapters.py"]:::componentSecondary
+        ObservabilityFactories["ObservabilityFactories\nfactories.py"]:::componentSecondary
+    end
+
+    subgraph Config["Config (infrastructure.config)"]
+        ConfigLoader["ConfigLoader\nloader.py"]:::componentSecondary
+        ConfigMigrator["ConfigMigrator\nmigration.py"]:::componentSecondary
+        ConfigDefaults["DefaultsLoader\ndefaults_loader.py"]:::componentSecondary
+        ConfigEnv["EnvConfig\nenv.py"]:::componentSecondary
+        ConfigSources["get_configs_root()\nsources.py"]:::componentSecondary
+        ProviderRegistryLoader["ProviderRegistryLoader\nprovider_registry.py"]:::componentSecondary
+    end
+
+    subgraph Adapters["Adapters (infrastructure.adapters)"]
+        ABCRegistryAdapter["ABCRegistryResolverAdapter\nadapter.py"]:::componentSecondary
+        ConfigPathAdapter["ConfigPathResolverAdapter\nconfig_path_adapter.py"]:::componentSecondary
+    end
+
+    subgraph Settings["Settings (infrastructure.settings)"]
+        SettingsManager["Settings\nsettings.py"]:::componentSecondary
+    end
+end
+class Infrastructure group
+
+subgraph External["External Systems"]
+    ChemblAPI[(ChEMBL REST API)]:::external
+    Storage[(Filesystem: CSV/Parquet + meta)]:::external
+end
+class External group;
+
+ChemblHttpClient --> RequestBuilder
+ChemblHttpClient --> ResponseParser
+ChemblHttpClient --> Paginator
+ChemblHttpClient --> HTTPTransport
+ChemblHttpClient --> RateLimiter
+ChemblHttpClient --> RetryPolicy
+ChemblHttpClient --> Cache
+ChemblHttpClient --> ObservabilityMetrics
+ChemblHttpClient --> ChemblAPI
+
+HTTPTransport --> RateLimiter
+HTTPTransport --> RetryPolicy
+HTTPTransport --> Cache
+
+ExtractionService --> ChemblHttpClient
+
+UnifiedLoader --> BaseWriter
+UnifiedLoader --> CsvWriter
+UnifiedLoader --> ParquetWriter
+UnifiedLoader --> MetadataWriter
+UnifiedLoader --> QualityReporter
+UnifiedLoader --> Converters
+UnifiedLoader --> ColumnOrder
+UnifiedLoader --> AtomicIO
+UnifiedLoader --> Checksum
+UnifiedLoader --> Storage
+
+NormalizationService --> NormalizationImpl
+NormalizationService --> TransformFactories
+
+PanderaValidator --> ValidationFactories
+PanderaValidator --> ValidationSchemas
+
+ObservabilityServer --> ObservabilityMetrics
+ObservabilityServer --> ObservabilityAdapters
+
+ConfigLoader --> ConfigDefaults
+ConfigLoader --> ConfigEnv
+ConfigLoader --> ConfigSources
+ConfigLoader --> ConfigMigrator
+ProviderRegistryLoader --> ConfigSources

--- a/docs/diagrams/component/04-interfaces-components.mmd
+++ b/docs/diagrams/component/04-interfaces-components.mmd
@@ -1,0 +1,101 @@
+---
+id: 6c47be5a-03c8-4c4b-9294-6d7b1f6c2b4c
+title: Interfaces Layer Components
+---
+flowchart TB
+
+classDef componentPrimary   fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+classDef componentSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+classDef external           fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px
+classDef group              fill:#e6ecef,stroke:#333,stroke-width:1.5px,color:#111,font-size:22px
+
+subgraph Interfaces["Interfaces Layer (Driving Ports)"]
+    subgraph CLI["CLI (bioetl.interfaces.cli)"]
+        TyperApp["Typer App\napp.py"]:::componentPrimary
+        RunCommand["run command"]:::componentSecondary
+        ListPipelinesCommand["list-pipelines command"]:::componentSecondary
+        ValidateConfigCommand["validate-config command"]:::componentSecondary
+        SmokeRunCommand["smoke-run command"]:::componentSecondary
+    end
+
+    subgraph REST["REST (bioetl.interfaces.rest)"]
+        RESTServer["FastAPI Server\nserver.py"]:::componentPrimary
+        RESTEndpoints["Endpoints\nendpoints.py"]:::componentSecondary
+    end
+
+    subgraph Monitoring["Monitoring (bioetl.interfaces.monitoring)"]
+        MonitoringModule["Monitoring\n__init__.py"]:::componentSecondary
+    end
+
+    subgraph Factories["Factories (bioetl.interfaces.factories)"]
+        ObservabilityFactory["ObservabilityFactoryABC\nDefaultObservabilityFactory\nobservability.py"]:::componentSecondary
+        InfrastructureFactory["InfrastructureFactoryABC\nDefaultInfrastructureFactory\ninfrastructure.py"]:::componentSecondary
+        ProviderRegistryFactory["create_provider_registry_factory()\nprovider_registry.py"]:::componentSecondary
+    end
+
+    CompositionRoot["CompositionRoot\ncomposition_root.py"]:::componentPrimary
+    ApplicationContext["ApplicationContext\napplication_context.py"]:::componentPrimary
+    ContextManager["application_context()\ncontext_manager.py"]:::componentSecondary
+    UseCaseFactory["UseCaseFactory\nuse_case_factory.py"]:::componentSecondary
+    BootstrapFactory["BootstrapFactory\nbootstrap_factory.py"]:::componentSecondary
+end
+class Interfaces group
+
+subgraph Application["Application Layer"]
+    Orchestrator["PipelineOrchestrator\nbioetl.application.orchestrator"]:::external
+    Container["PipelineContainer\nbioetl.application.container"]:::external
+    Pipelines["PipelineBase / ChemblPipelineBase\nbioetl.application.pipelines.*"]:::external
+    RunPipelineUseCase["RunPipelineUseCase\nbioetl.application.use_cases"]:::external
+end
+class Application group;
+
+subgraph Domain["Domain Layer"]
+    Validation["ValidationService\nbioetl.domain.validation.service"]:::external
+    NormalizationABC["NormalizationServiceABC\nbioetl.domain.transform.contracts"]:::external
+    PipelineContracts["PipelineHookABC / ErrorPolicyABC\nbioetl.domain.pipelines.contracts"]:::external
+    ObservabilityContracts["LoggingPortABC / MetricsPortABC\nbioetl.domain.observability.contracts"]:::external
+end
+class Domain group;
+
+subgraph Infrastructure["Infrastructure Layer"]
+    Clients["ChemblHttpClientImpl\ninfrastructure.clients.chembl.*"]:::external
+    Output["UnifiedLoaderImpl\ninfrastructure.output.*"]:::external
+    NormalizationImpl["ChemblNormalizationServiceImpl\ninfrastructure.transform.impl.*"]:::external
+    ObservabilityImpl["MetricsAdapter / UnifiedLogger\ninfrastructure.observability.*"]:::external
+end
+class Infrastructure group;
+
+TyperApp --> RunCommand
+TyperApp --> ListPipelinesCommand
+TyperApp --> ValidateConfigCommand
+TyperApp --> SmokeRunCommand
+
+RunCommand --> UseCaseFactory
+UseCaseFactory --> ApplicationContext
+ApplicationContext --> CompositionRoot
+CompositionRoot --> Factories
+
+UseCaseFactory --> RunPipelineUseCase
+RunPipelineUseCase --> Orchestrator
+Orchestrator --> Container
+Orchestrator --> Pipelines
+
+RESTServer --> RESTEndpoints
+RESTEndpoints --> UseCaseFactory
+
+CompositionRoot --> Container
+CompositionRoot --> ObservabilityFactory
+CompositionRoot --> InfrastructureFactory
+CompositionRoot --> ProviderRegistryFactory
+
+ObservabilityFactory --> ObservabilityImpl
+InfrastructureFactory --> Output
+InfrastructureFactory --> Clients
+ProviderRegistryFactory --> Domain
+
+Pipelines --> PipelineContracts
+Pipelines --> Validation
+Pipelines --> NormalizationABC
+Pipelines --> ObservabilityContracts
+NormalizationABC --> NormalizationImpl
+ObservabilityContracts --> ObservabilityImpl

--- a/docs/diagrams/component/05-system-context-bioetl.mmd
+++ b/docs/diagrams/component/05-system-context-bioetl.mmd
@@ -1,0 +1,60 @@
+---
+id: a1b2c3d4-5e6f-7890-abcd-ef1234567890
+title: BioETL System Context Diagram
+---
+%%{init: { 'flowchart': { 'htmlLabels': true, 'useMaxWidth': true } }}%%
+flowchart LR
+    classDef componentPrimary   fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+    classDef componentSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+    classDef external           fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px
+    classDef storage            fill:#f0f4d4,stroke:#596235,stroke-width:1.5px,color:#111,font-size:22px
+    classDef group              fill:#e6ecef,stroke:#333,stroke-width:1.5px,color:#111,font-size:22px
+    linkStyle default stroke:#666,stroke-width:1.2px,color:#111
+
+    subgraph Sources["External Data Sources"]
+        chembl[(ChEMBL REST API\nactivity/assay/target/publication/molecule)]:::external
+        uniprot[(UniProt / IUPHAR APIs\nprotein enrichment)]:::external
+        openalex[(OpenAlex API\nliterature enrichment)]:::external
+        semanticscholar[(Semantic Scholar API\ncitation enrichment)]:::external
+    end
+    class Sources group
+
+    subgraph BioETL["BioETL Platform"]
+        orchestrator["PipelineOrchestrator\nbioetl.application.orchestrator"]:::componentPrimary
+        container["PipelineContainer\nbioetl.application.container"]:::componentSecondary
+        pipelines["Entity-specific Pipelines\nActivity/Assay/Target/Publication/Molecule"]:::componentSecondary
+        hooks["Logging & Metrics Hooks\n(Structured logs, Prometheus)"]:::componentSecondary
+        writer["UnifiedLoaderImpl\n(CSV/Parquet + metadata)"]:::componentPrimary
+        registry["ProviderRegistry + UnifiedAPIClient\n(rate-limit, retry, circuit-breaker)"]:::componentSecondary
+        validation["ValidationService\n(Pandera schema validation)"]:::componentSecondary
+        transform["TransformChain\n(normalization, hashing, indexing)"]:::componentSecondary
+    end
+    class BioETL group
+
+    subgraph Sinks["Internal Storage Targets"]
+        csv[(Deterministic CSV exports\nper entity run)]:::storage
+        parquet[(Parquet datasets\nanalytical lake)]:::storage
+        metadata[(meta.yaml + QC sidecars\nchecksums, versions, row_count)]:::storage
+        database[(Optional downstream DB\nwarehouse integration)]:::storage
+    end
+    class Sinks group
+
+    chembl --> registry
+    uniprot --> registry
+    openalex --> registry
+    semanticscholar --> registry
+
+    registry --> orchestrator
+    orchestrator --> container
+    container --> pipelines
+    pipelines --> validation
+    pipelines --> transform
+    pipelines --> hooks
+    pipelines --> writer
+
+    writer --> csv
+    writer --> parquet
+    writer --> metadata
+    metadata --> database
+
+    hooks --> metadata

--- a/docs/diagrams/component/06-hexagonal-architecture.mmd
+++ b/docs/diagrams/component/06-hexagonal-architecture.mmd
@@ -1,0 +1,91 @@
+---
+id: b9872f45-bffc-42c3-b947-a5aecd424c3a
+title: BioETL Hexagonal Architecture
+---
+%%{init: { 'flowchart': { 'useMaxWidth': true, 'htmlLabels': true } }}%%
+flowchart TB
+    classDef componentPrimary fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+    classDef componentSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+    classDef port fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px
+    classDef group fill:#e6ecef,stroke:#333,stroke-width:1.5px,color:#111,font-size:22px
+    linkStyle default stroke:#666,stroke-width:1.2px,color:#111
+
+    subgraph Interfaces["Driving Ports (Interfaces Layer)"]
+        cli["CLI (Typer commands)\nbioetl.interfaces.cli"]:::port
+        rest["REST (FastAPI)\nbioetl.interfaces.rest"]:::port
+        mq["MQ consumers\nbioetl.interfaces.mq"]:::port
+    end
+    class Interfaces group
+
+    subgraph Application["Application Layer (Use-case Orchestration)"]
+        orchestrator["PipelineOrchestrator\n(run, build_pipeline)"]:::componentPrimary
+        container["PipelineContainer\n(manual DI)"]:::componentSecondary
+        registry["PipelineRegistry\n(entity to class map)"]:::componentSecondary
+        stageRuntimeManager["StageRuntimeManager"]:::componentSecondary
+        hooksImpl["PipelineHookFactory + ErrorPolicy"]:::componentSecondary
+        factories["Factories\nApplicationServiceFactory\nTransformComponentFactory\nRecordSourceFactory"]:::componentSecondary
+        configResolution["ConfigPathResolver\nConfigRuntimeService"]:::componentSecondary
+        useCases["UseCases\nRunPipelineUseCase"]:::componentSecondary
+        services["Services\nSchemaBootstrapService\nConfigMigrationService"]:::componentSecondary
+    end
+    class Application group
+
+    subgraph Domain["Domain Core (Ports & Contracts)"]
+        contracts["ABC Contracts\nExtractionServiceABC\nNormalizationServiceABC\nHashServiceABC\nLoaderABC"]:::componentPrimary
+        pipelineContracts["Pipeline Contracts\nPipelineContainerABC\nPipelineFactoryABC\nPipelineHookABC\nErrorPolicyABC"]:::componentSecondary
+        schemas["SchemaRegistry + ValidationService\nPipelineSchemaModel"]:::componentSecondary
+        transformContracts["Transform Contracts\nTransformerABC\nSerializerABC\nIndexGeneratorABC"]:::componentSecondary
+        observabilityContracts["Observability Contracts\nLoggingPortABC\nMetricsPortABC"]:::componentSecondary
+        configs["Config Models\nPipelineConfig\nSourceConfig\nSinkConfig"]:::componentSecondary
+        providerRegistry["ProviderRegistryABC\nProviderDefinition"]:::componentSecondary
+        recordSource["RecordSourceABC\nTabularData Protocol"]:::componentSecondary
+    end
+    class Domain group
+
+    subgraph Infrastructure["Adapters (Driven Ports)"]
+        apiClients["ChemblHttpClientImpl\nChemblExtractionServiceImpl"]:::componentPrimary
+        recordSources["ApiRecordSource\nCsvRecordSource\nIdListRecordSource"]:::componentSecondary
+        transformers["ChemblNormalizationServiceImpl\nHasherImpl\nIndexGeneratorImpl"]:::componentSecondary
+        writers["UnifiedLoaderImpl\nCsvWriter / ParquetWriter"]:::componentSecondary
+        validationImpl["PanderaValidatorImpl\nValidation Schemas"]:::componentSecondary
+        observability["MetricsAdapter\nUnifiedLoggerAdapter\nMetricsServer"]:::componentSecondary
+        configImpl["ConfigLoader\nProviderRegistryLoader"]:::componentSecondary
+        adapters["ABCRegistryResolverAdapter\nConfigPathResolverAdapter"]:::componentSecondary
+    end
+    class Infrastructure group
+
+    cli --> orchestrator
+    rest --> orchestrator
+    mq --> orchestrator
+
+    orchestrator --> container
+    orchestrator --> configResolution
+    orchestrator --> useCases
+    container --> registry
+    container --> contracts
+    container --> pipelineContracts
+    container --> schemas
+    container --> factories
+    container --> stageRuntimeManager
+    container --> services
+    stageRuntimeManager --> hooksImpl
+
+    contracts --> apiClients
+    contracts --> recordSources
+    contracts --> transformers
+    contracts --> writers
+    contracts --> observabilityContracts
+    pipelineContracts --> transformContracts
+    transformContracts --> transformers
+    schemas --> validationImpl
+    observabilityContracts --> observability
+    providerRegistry --> configImpl
+    recordSource --> recordSources
+
+    apiClients --> Chembl[(ChEMBL API)]
+    recordSources --> Files[(Offline CSV dumps)]
+    writers --> Storage[(Deterministic storage\nCSV/Parquet/meta)]
+    observability --> Monitoring[(Logging, Metrics, Alerts)]
+    configImpl --> ConfigFiles[(configs/*.yaml)]
+
+    class Chembl,Files,Storage,Monitoring,ConfigFiles port

--- a/docs/diagrams/component/07-physical-layer-mapping.mmd
+++ b/docs/diagrams/component/07-physical-layer-mapping.mmd
@@ -1,0 +1,70 @@
+---
+id: 44f9de85-3897-41aa-8bb7-819e9f9fa9eb
+title: Physical Layer Mapping
+---
+%%{init: { 'flowchart': { 'useMaxWidth': true, 'htmlLabels': true } }}%%
+flowchart LR
+    classDef componentPrimary fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+    classDef componentSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+    classDef group fill:#e6ecef,stroke:#333,stroke-width:1.5px,color:#111,font-size:22px
+    linkStyle default stroke:#666,stroke-width:1.2px,color:#111
+
+    subgraph Domain["Domain Layer -> src/bioetl/domain/"]
+        domainSchemas["schemas/\nPandera + Pydantic models\npipeline_contracts.py"]:::componentPrimary
+        domainPorts["ports/\nExtractionServiceABC\nEntityModelRegistryABC\nSchemaContractProviderABC"]:::componentSecondary
+        domainTransform["transform/\nHashServiceABC\nNormalizationServiceABC\nTransformerABC"]:::componentSecondary
+        domainValidation["validation/\nValidationService\nSchemaProviderABC"]:::componentSecondary
+        domainConfigs["configs/\nPipelineConfig\nSourceConfig\nSinkConfig"]:::componentSecondary
+        domainClients["clients/\nDataClientABC\nRateLimiterABC"]:::componentSecondary
+        domainPipelines["pipelines/\nPipelineHookABC\nErrorPolicyABC"]:::componentSecondary
+        domainModels["models.py\nRunContext, RunResult, StageResult"]:::componentSecondary
+        domainProviders["provider_registry.py\nProviderRegistryABC"]:::componentSecondary
+        domainAggregates["aggregates/\nPipelineIdentity"]:::componentSecondary
+        domainValueObjects["value_objects/\nChemblId, EntityName, HashDigest"]:::componentSecondary
+    end
+    class Domain group
+
+    subgraph Application["Application Layer -> src/bioetl/application/"]
+        applicationPipelines["pipelines/\nPipelineBase\nChemblPipelineBase\nChemblCommonPipeline"]:::componentPrimary
+        orchestrator["orchestrator.py\nbuild/run pipelines"]:::componentSecondary
+        container["container.py\nPipelineContainer (DI)"]:::componentSecondary
+        contracts["contracts.py\nPipelineContainerABC\nPipelineFactoryABC"]:::componentSecondary
+        factories["factories/\nApplicationServiceFactory\nTransformComponentFactory\nRecordSourceFactory\nPipelineRuntimeFactory"]:::componentSecondary
+        services["services/\nSchemaBootstrapService\nConfigMigrationService"]:::componentSecondary
+        useCases["use_cases/\nRunPipelineUseCase"]:::componentSecondary
+        config["config/\nConfigPathResolver\nConfigRuntimeService"]:::componentSecondary
+        mappers["mappers/\nchembl/ entity mappers"]:::componentSecondary
+        sources["sources/\nApiRecordSource\nCsvRecordSource"]:::componentSecondary
+    end
+    class Application group
+
+    subgraph Infrastructure["Infrastructure Layer -> src/bioetl/infrastructure/"]
+        infraClients["clients/\nChemblHttpClientImpl\nChemblExtractionServiceImpl\nHTTPTransport"]:::componentPrimary
+        infraOutput["output/\nUnifiedLoaderImpl\nCsvWriter, ParquetWriter\nMetadataWriter"]:::componentSecondary
+        infraFiles["files/\nAtomicFileOperation\nchecksum utilities"]:::componentSecondary
+        infraConfig["config/\nConfigLoader\nProviderRegistryLoader\nConfigMigrator"]:::componentSecondary
+        infraLogging["logging/\nUnifiedLoggerAdapter\nProgressReporter"]:::componentSecondary
+        infraObservability["observability/\nMetricsServer\nMetricsAdapter"]:::componentSecondary
+        infraTransform["transform/\nHasherImpl\nChemblNormalizationServiceImpl\nIndexGeneratorImpl"]:::componentSecondary
+        infraValidation["validation/\nPanderaValidatorImpl\nschemas/chembl/"]:::componentSecondary
+        infraAdapters["adapters/\nABCRegistryResolverAdapter\nConfigPathResolverAdapter"]:::componentSecondary
+        infraHttp["http/\nRetryPolicy"]:::componentSecondary
+    end
+    class Infrastructure group
+
+    subgraph Interfaces["Interfaces Layer -> src/bioetl/interfaces/"]
+        cli["cli/\nTyper app + commands\nrun, list-pipelines, validate-config"]:::componentPrimary
+        rest["rest/\nFastAPI server + endpoints"]:::componentSecondary
+        monitoring["monitoring/\nobservability endpoints"]:::componentSecondary
+        compositionRoot["composition_root.py\nCompositionRoot"]:::componentSecondary
+        applicationContext["application_context.py\nApplicationContext"]:::componentSecondary
+        useCaseFactory["use_case_factory.py\nUseCaseFactory"]:::componentSecondary
+        interfaceFactories["factories/\nObservabilityFactoryABC\nInfrastructureFactoryABC"]:::componentSecondary
+    end
+    class Interfaces group
+
+    Domain --> Application
+    Application --> Infrastructure
+    Interfaces --> Application
+    Infrastructure --> External[(External systems\nChEMBL API, Filesystem)]
+    class External componentSecondary

--- a/docs/diagrams/component/08-key-modules-overview.mmd
+++ b/docs/diagrams/component/08-key-modules-overview.mmd
@@ -1,0 +1,76 @@
+---
+id: c1d2e3f4-5678-90ab-cdef-123456789012
+title: Key Modules Overview
+---
+%%{init: { 'flowchart': { 'useMaxWidth': true, 'htmlLabels': true } }}%%
+flowchart LR
+    classDef componentPrimary fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+    classDef componentSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+    classDef external fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px
+    linkStyle default stroke:#666,stroke-width:1.2px,color:#111
+
+    orchestrator["PipelineOrchestrator\n(entrypoint orchestrator.py)"]:::componentPrimary
+    container["PipelineContainer\n(dependency builder container.py)"]:::componentPrimary
+    registry["ProviderRegistry\n(resolves client factories)"]:::componentSecondary
+    providerCatalog["providers.yaml + factories\n(chembl, local CSV, etc.)"]:::componentSecondary
+
+    subgraph Extraction["Extraction"]
+        unifiedClient["ChemblHttpClientImpl\n(rate limit + retry)"]:::componentPrimary
+        extraction["ChemblExtractionServiceImpl\n(batch iterator + pagination)"]:::componentSecondary
+        recordSource["RecordSourceFactory\n(API/CSV/IdList sources)"]:::componentSecondary
+    end
+
+    subgraph Transform["Transform"]
+        transformer["TransformComponentFactory\n(hash + index + timestamp)"]:::componentSecondary
+        normalization["NormalizationServiceImpl\n(field normalization)"]:::componentSecondary
+    end
+
+    subgraph Validation["Validation"]
+        validation["ValidationService\n(Pandera schema lookup)"]:::componentSecondary
+        schemaBootstrap["SchemaBootstrapService\n(lazy schema registration)"]:::componentSecondary
+    end
+
+    subgraph Output["Output"]
+        writer["UnifiedLoaderImpl\n(stable sort + atomic write)"]:::componentPrimary
+        metadata["MetadataWriter\n(checksums, versions, row_count)"]:::componentSecondary
+    end
+
+    subgraph Runtime["Runtime"]
+        hooks["LoggingPipelineHook + MetricsPipelineHook"]:::componentSecondary
+        errorPolicy["ErrorPolicy\n(FailFast / PartialSuccess)"]:::componentSecondary
+        stageManager["StageRuntimeManager\n(stage lifecycle)"]:::componentSecondary
+    end
+
+    subgraph Context["Application Context"]
+        appContext["ApplicationContext\n(singleton dependency root)"]:::componentSecondary
+        compositionRoot["CompositionRoot\n(DI assembly)"]:::componentSecondary
+        useCaseFactory["UseCaseFactory\n(use case creation)"]:::componentSecondary
+    end
+
+    storage[(Deterministic storage\nCSV/Parquet/meta)]:::external
+
+    orchestrator --> container
+    container --> registry
+    registry --> providerCatalog
+    registry --> unifiedClient
+    container --> recordSource
+    recordSource --> extraction
+    extraction --> unifiedClient
+    container --> transformer
+    container --> normalization
+    container --> validation
+    validation --> schemaBootstrap
+    container --> writer
+    container --> hooks
+    container --> errorPolicy
+    container --> stageManager
+    transformer --> validation
+    normalization --> writer
+    extraction --> transformer
+    writer --> metadata
+    writer --> storage
+    hooks --> orchestrator
+    errorPolicy --> stageManager
+    appContext --> compositionRoot
+    compositionRoot --> container
+    useCaseFactory --> orchestrator

--- a/docs/diagrams/component/09-architecture-rules.mmd
+++ b/docs/diagrams/component/09-architecture-rules.mmd
@@ -1,0 +1,49 @@
+---
+id: d2e3f4a5-6789-0abc-def1-234567890123
+title: Architecture Rules and Invariants
+---
+%%{init: { 'flowchart': { 'useMaxWidth': true, 'htmlLabels': true } }}%%
+flowchart TB
+    classDef rulePrimary fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+    classDef ruleSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+    classDef group fill:#e6ecef,stroke:#333,stroke-width:1.5px,color:#111,font-size:22px
+    linkStyle default stroke:#666,stroke-width:1.2px,color:#111
+
+    rules["BioETL Architecture Invariants"]:::rulePrimary
+
+    direction["One-way Dependencies\nInterfaces -> Application -> Domain\nApplication -> Infrastructure\n(import-linter enforced)"]:::ruleSecondary
+
+    abcPattern["Ports & Adapters Pattern\nDomain ABC -> Default factory -> Impl\nABCRegistryResolver for discovery"]:::ruleSecondary
+
+    determinism["Deterministic IO\nStable sort + Pandera validation\nAtomic write operations"]:::ruleSecondary
+
+    contracts["Contracts & Schemas\nDomain ABC + PipelineSchemaModel\nSingle source of truth"]:::ruleSecondary
+
+    testing["Testing Policy\nUnit + Pipeline golden tests\nCoverage >= 85%\nNo network in unit tests"]:::ruleSecondary
+
+    naming["Naming + Layer Guards\nRegex enforcement for IDs\nimport-linter to block leaks"]:::ruleSecondary
+
+    logging["Structured Observability\nUnifiedLogger + MetricsAdapter\nNo print() statements"]:::ruleSecondary
+
+    config["Typed Configuration\nPydantic models\nYAML validated via schema"]:::ruleSecondary
+
+    secrets["Secrets Policy\nOnly env vars / secret manager\nNo inline tokens"]:::ruleSecondary
+
+    di["Dependency Injection\nCompositionRoot assembly\nPipelineContainer for services\nNo service locator pattern"]:::ruleSecondary
+
+    valueObjects["Value Objects\nImmutable domain primitives\nChemblId, EntityName, HashDigest"]:::ruleSecondary
+
+    errorHandling["Error Handling\nErrorPolicyABC (FailFast/PartialSuccess)\nTyped domain exceptions"]:::ruleSecondary
+
+    rules --> direction
+    rules --> abcPattern
+    rules --> determinism
+    rules --> contracts
+    rules --> testing
+    rules --> naming
+    rules --> logging
+    rules --> config
+    rules --> secrets
+    rules --> di
+    rules --> valueObjects
+    rules --> errorHandling

--- a/docs/diagrams/component/10-cli-architecture.mmd
+++ b/docs/diagrams/component/10-cli-architecture.mmd
@@ -1,0 +1,71 @@
+---
+id: e3f4a5b6-7890-1abc-def2-345678901234
+title: CLI Architecture
+---
+%%{init: { 'flowchart': { 'useMaxWidth': true, 'htmlLabels': true } }}%%
+flowchart LR
+    classDef componentPrimary fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+    classDef componentSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+    classDef external fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px
+    linkStyle default stroke:#666,stroke-width:1.2px,color:#111
+
+    entry["Entry points\nconsole_script / python -m bioetl"]:::external
+    typer["Typer app\nbioetl.interfaces.cli.app"]:::componentPrimary
+
+    subgraph Commands["Commands"]
+        runCmd["run\nExecute pipeline with config"]:::componentSecondary
+        listCmd["list-pipelines\nShow available pipelines"]:::componentSecondary
+        validateCmd["validate-config\nValidate configuration file"]:::componentSecondary
+        smokeCmd["smoke-run\nQuick test with limited data"]:::componentSecondary
+    end
+
+    subgraph Context["Application Context"]
+        appCtx["ApplicationContext\n(logger, metrics, config_loader)"]:::componentSecondary
+        useCaseFactory["UseCaseFactory\ninterfaces.use_case_factory"]:::componentSecondary
+        compositionRoot["CompositionRoot\ninterfaces.composition_root"]:::componentSecondary
+    end
+
+    subgraph UseCases["Use Cases"]
+        runUseCase["RunPipelineUseCase\napplication.use_cases.run_pipeline"]:::componentPrimary
+    end
+
+    subgraph Config["Configuration"]
+        configLoader["ConfigLoader\ninfrastructure.config.loader"]:::componentSecondary
+        configPathResolver["ConfigPathResolver\napplication.config.resolution"]:::componentSecondary
+        providerLoader["ProviderRegistryLoader\ninfrastructure.config.provider_registry"]:::componentSecondary
+    end
+
+    subgraph Orchestration["Orchestration"]
+        containerFactory["build_default_container\ninterfaces.composition_root"]:::componentSecondary
+        orchestrator["PipelineOrchestrator\napplication.orchestrator"]:::componentPrimary
+        pipelineRegistry["Pipeline registry factories\napplication.pipelines.registry"]:::componentSecondary
+        pipelines["Pipelines (ChEMBL activity/assay/...)\nPipelineBase implementations"]:::componentPrimary
+    end
+
+    console["Rich console output\nresult formatting + errors"]:::componentSecondary
+
+    entry --> typer
+    typer --> runCmd
+    typer --> listCmd
+    typer --> validateCmd
+    typer --> smokeCmd
+
+    runCmd --> useCaseFactory
+    smokeCmd --> useCaseFactory
+    validateCmd --> configLoader
+
+    useCaseFactory --> appCtx
+    appCtx --> compositionRoot
+    useCaseFactory --> runUseCase
+
+    runUseCase --> configLoader
+    runUseCase --> configPathResolver
+    runUseCase --> providerLoader
+    runUseCase --> containerFactory
+    runUseCase --> orchestrator
+
+    containerFactory --> compositionRoot
+    orchestrator --> pipelineRegistry
+    orchestrator --> pipelines
+    orchestrator --> console
+    console --> typer

--- a/docs/diagrams/component/11-test-suite-structure.mmd
+++ b/docs/diagrams/component/11-test-suite-structure.mmd
@@ -1,0 +1,60 @@
+---
+id: f4a5b6c7-8901-2abc-def3-456789012345
+title: Test Suite Structure
+---
+%%{init: { 'flowchart': { 'htmlLabels': true, 'useMaxWidth': true } }}%%
+flowchart LR
+    classDef group fill:#e6ecef,stroke:#333,stroke-width:1.5px,color:#111,font-size:22px
+    classDef suite fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+    classDef detail fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+    linkStyle default stroke:#666,stroke-width:1.2px,color:#111
+
+    subgraph Unit["tests/bioetl/**"]
+        application["application/\n- pipelines/test_pipeline_base.py\n- container/orchestrator tests\n- factories/ tests\n- use_cases/ tests"]:::suite
+        domainTests["domain/\n- schemas/test_activity_schema.py\n- services (hash/normalizers)\n- transform/ tests\n- validation/ tests\n- ports/ tests"]:::suite
+        infraTests["infrastructure/\n- clients/test_unified_client.py\n- output/test_writer.py\n- transform/ tests\n- config/ tests\n- validation/ tests"]:::suite
+        interfacesTests["interfaces/\n- cli/test_run_command.py\n- rest/ tests\n- factories/ tests"]:::suite
+    end
+    class Unit group
+
+    subgraph Golden["tests/golden/"]
+        goldenActivity["test_chembl_activity_golden.py\nfixtures: tests/fixtures/input/"]:::suite
+        goldenNormalization["test_normalization_golden.py\nuses golden_examples.json"]:::suite
+        pipelineOutputs["pipeline_outputs/\ngolden output snapshots"]:::suite
+    end
+    class Golden group
+
+    subgraph Integration["tests/integration/"]
+        cliSmoke["test_cli_smoke.py\nruns bioetl run ... --dry-run"]:::suite
+        configIntegration["test_config_profiles.py\nconfig validation tests"]:::suite
+        applicationIntegration["application/\nintegration tests"]:::suite
+    end
+    class Integration group
+
+    subgraph Contracts["tests/contracts/"]
+        contractTests["Contract verification tests\nABC implementation checks"]:::suite
+    end
+    class Contracts group
+
+    subgraph ProjectRules["tests/project_rules/"]
+        architectureRules["test_architecture_rules.py\n(import-linter enforcement)"]:::suite
+        layerDeps["test_layer_dependencies.py\ndependency direction checks"]:::suite
+    end
+    class ProjectRules group
+
+    subgraph UnitSpecific["tests/unit/"]
+        unitApplication["application/\nunit-level app tests"]:::suite
+        unitInterfaces["interfaces/\nunit-level interface tests"]:::suite
+    end
+    class UnitSpecific group
+
+    subgraph Pipelines["tests/bioetl/pipelines/"]
+        chemblPipelines["chembl/\n- activity/\n- assay/\n- molecule/\n- publication/\n- target/"]:::suite
+    end
+    class Pipelines group
+
+    Unit --> Golden --> Integration --> Contracts --> ProjectRules
+    pyramidNote(["pytest.ini markers: unit, integration, golden, contracts"]):::detail
+    Integration --> pyramidNote
+
+    fixturesNote["tests/fixtures/\n- input/: sample CSV/JSON\n- expected/: golden outputs"]:::detail

--- a/docs/diagrams/flow/api-to-storage-dataflow.mmd
+++ b/docs/diagrams/flow/api-to-storage-dataflow.mmd
@@ -1,0 +1,23 @@
+%%{init: { 'flowchart': { 'useMaxWidth': true, 'htmlLabels': true } }}%%
+flowchart LR
+    classDef stepPrimary   fill:#f5f5f5,stroke:#444,stroke-width:1.5px
+    classDef stepSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px
+    classDef external      fill:#dde7f2,stroke:#44546a,stroke-width:1.5px
+    classDef storage       fill:#f0f4d4,stroke:#596235,stroke-width:1.5px
+    linkStyle default stroke:#666,stroke-width:1.2px
+
+    chembl[(ChEMBL REST API JSON)]:::external
+    httpClient["UnifiedAPIClient\n+ retry + rate-limit + circuit breaker"]:::stepPrimary
+    recordModel["flatten_chembl_payload (utility)\nnormalize nested payloads to strings\nbypass configured fields"]:::stepSecondary
+    batches["Batch buffer / generator\nlist of dicts"]:::stepSecondary
+    dataframe["Pandas DataFrame\nconstructed from flattened dicts"]:::stepPrimary
+    normalize["Normalization chain\n(serialization, unit normalization, enrichment)"]:::stepPrimary
+    validate["Pandera schema validation\n(strict order + coerce)"]:::stepPrimary
+    hash["Hash & metadata columns\nhash_row, hash_business_key, index, extracted_at"]:::stepSecondary
+    write["UnifiedOutputWriter\nstable sort + atomic CSV/Parquet"]:::stepPrimary
+    meta["Metadata/QC writers\nmeta.yaml + QC tables + checksums"]:::stepSecondary
+    storage[(Deterministic storage\nCSV/Parquet + QC + meta)]:::storage
+
+    chembl --> httpClient --> recordModel --> batches --> dataframe --> normalize --> validate --> hash --> write --> storage
+    write --> meta --> storage
+

--- a/docs/diagrams/flow/chembl-pipeline-dependency-graph.mmd
+++ b/docs/diagrams/flow/chembl-pipeline-dependency-graph.mmd
@@ -1,0 +1,29 @@
+%%{init: { 'flowchart': { 'useMaxWidth': true, 'htmlLabels': true } }}%%
+flowchart LR
+    classDef pipeline fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+    classDef dependency fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+    classDef group fill:#e6ecef,stroke:#333,stroke-width:1.5px,color:#111,font-size:22px
+    linkStyle default stroke:#666,stroke-width:1.2px,color:#111
+
+    activity["Activity pipeline\noutputs: activity.csv"]:::pipeline
+    assay["Assay pipeline\nassay.csv"]:::pipeline
+    target["Target pipeline\ntarget.csv (with UniProt/IUPHAR enrichment)"]:::pipeline
+    publication["Publication pipeline\ndocument.csv (OpenAlex/Semantic Scholar)"]:::pipeline
+    molecule["Molecule pipeline\n(molecule.csv)"]:::pipeline
+
+    assay -->|assay_chembl_id referenced by| activity
+    target -->|target_chembl_id referenced by| activity
+    publication -->|document_chembl_id referenced by| activity
+    molecule -->|molecule_chembl_id referenced by| activity
+
+    molecule -.->|optionally seed ID list| assay
+    publication -.->|metadata for assays| assay
+    target -.->|component linking to assays| assay
+
+    subgraph Recommended order
+        molecule --> assay
+        assay --> target
+        target --> publication
+        publication --> activity
+    end
+

--- a/docs/diagrams/flow/ci-workflow.mmd
+++ b/docs/diagrams/flow/ci-workflow.mmd
@@ -1,0 +1,21 @@
+%%{init: { 'flowchart': { 'useMaxWidth': true, 'htmlLabels': true } }}%%
+flowchart LR
+    classDef step fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+    classDef stepSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+    classDef stepDecision fill:#e6ecef,stroke:#333,stroke-width:1.5px,color:#111,font-size:22px
+    classDef stepTerminal fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px
+    linkStyle default stroke:#666,stroke-width:1.2px,color:#111
+
+    push([Push/PR]):::stepTerminal
+    lint["Static checks\nruff + black --check + isort --check\nmypy --strict + import-linter"]:::step
+    tests["Unit tests (pytest -m 'not integration')"]:::step
+    coverage["Coverage gate ≥85%"]:::stepDecision
+    golden["Golden tests\npytest tests/golden"]:::step
+    integration["Integration smoke\nCLI run with --limit --dry-run (HTTP mocked)"]:::step
+    artifacts["Upload coverage + lint reports"]:::stepSecondary
+    status([PR status]):::stepTerminal
+
+    push --> lint --> tests --> coverage
+    coverage -- pass --> golden --> integration --> artifacts --> status
+    coverage -- fail --> status
+

--- a/docs/diagrams/flow/cli-extension-flow.mmd
+++ b/docs/diagrams/flow/cli-extension-flow.mmd
@@ -1,0 +1,15 @@
+%%{init: { 'flowchart': { 'useMaxWidth': true, 'htmlLabels': true } }}%%
+flowchart TD
+    classDef step fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+    classDef stepSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+    linkStyle default stroke:#666,stroke-width:1.2px,color:#111
+
+    implement["Implement CLICommandABC subclass\n- register(self, app)\n- run(self, args)"]:::step
+    hook["Register command inside cli/app.py\ncommand.register(app)"]:::stepSecondary
+    typer["Typer auto-generates entrypoint\n`bioetl <command>`"]:::step
+    orchestrate["Command interacts with PipelineOrchestrator\nor auxiliary services"]:::stepSecondary
+    reuse["Reuse shared helpers\nConfig loader, profile resolver, UnifiedLogger"]:::stepSecondary
+    docs["Update docs + autocomplete"]:::stepSecondary
+
+    implement --> hook --> typer --> orchestrate --> reuse --> docs
+

--- a/docs/diagrams/flow/cli-option-mapping.mmd
+++ b/docs/diagrams/flow/cli-option-mapping.mmd
@@ -1,0 +1,28 @@
+%%{init: { 'flowchart': { 'useMaxWidth': true, 'htmlLabels': true } }}%%
+flowchart LR
+    classDef option fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+    classDef target fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+    linkStyle default stroke:#666,stroke-width:1.2px,color:#111
+
+    configFlag["--config PATH"]:::option
+    profileFlag["--profile NAME"]:::option
+    limitFlag["--limit INT"]:::option
+    outputFlag["--output PATH"]:::option
+    dryFlag["--dry-run"]:::option
+    modeFlag["--input-mode {api,csv,id_only}"]:::option
+    filtersFlag["--filter key=val (repeatable)"]:::option
+
+    pipelineConfig["Pipeline YAML"]:::target
+    profileConfig["Profile YAML"]:::target
+    merged["PipelineConfig object\n(application.config.models.PipelineConfig)"]:::target
+
+    configFlag --> pipelineConfig
+    profileFlag --> profileConfig
+    pipelineConfig --> merged
+    profileConfig --> merged
+    limitFlag -->|overrides| merged
+    outputFlag -->|overrides| merged
+    dryFlag -->|sets `stages.write.enabled = False`| merged
+    modeFlag -->|sets `input.mode`| merged
+    filtersFlag -->|extends `extract.filters`| merged
+

--- a/docs/diagrams/flow/config-loading-flow.mmd
+++ b/docs/diagrams/flow/config-loading-flow.mmd
@@ -1,0 +1,18 @@
+%%{init: { 'flowchart': { 'useMaxWidth': true, 'htmlLabels': true } }}%%
+flowchart TD
+    classDef step fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+    classDef stepSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+    classDef stepDecision fill:#e6ecef,stroke:#333,stroke-width:1.5px,color:#111,font-size:22px
+    linkStyle default stroke:#666,stroke-width:1.2px,color:#111
+
+    start([CLI args]):::step
+    detect["Infer pipeline\n(provider/entity) from pipeline name"]:::stepSecondary
+    loadPipeline["Load pipeline YAML\n`configs/pipelines/<provider>/<entity>.yaml`"]:::step
+    loadProfile["Load profile YAML\n`configs/profiles/<profile>.yaml`"]:::step
+    merge["Merge profile ➝ pipeline ➝ CLI overrides\npriority: CLI > pipeline > profile"]:::step
+    validate["Validate with PipelineConfig model\n(required keys, enums, types)"]:::step
+    secrets["Resolve env vars / secrets\n(no defaults for missing required keys)"]:::stepSecondary
+    build["Build PipelineConfig dataclass\npass to PipelineContainer"]:::step
+
+    start --> detect --> loadPipeline --> loadProfile --> merge --> validate --> secrets --> build
+

--- a/docs/diagrams/flow/csv-input-flow.mmd
+++ b/docs/diagrams/flow/csv-input-flow.mmd
@@ -1,0 +1,17 @@
+%%{init: { 'flowchart': { 'useMaxWidth': true, 'htmlLabels': true } }}%%
+flowchart LR
+    classDef stepPrimary fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+    classDef stepSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+    classDef external fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px
+    linkStyle default stroke:#666,stroke-width:1.2px,color:#111
+
+    dump[(Offline CSV dump\n`data/input/<entity>.csv`)]:::external
+    csvReader["CsvRecordSourceImpl\n(stream read by chunks)"]:::stepPrimary
+    dataframe["Pandas DataFrame\nconstructed directly from CSV"]:::stepPrimary
+    fillColumns["Schema enforcement\nadd missing columns + dtype cast"]:::stepSecondary
+    normalization["Normalization chain + enrichment\n(same as API path)"]:::stepPrimary
+    validation["Pandera validation"]:::stepPrimary
+    write["UnifiedOutputWriter\n(atomic write)"]:::stepPrimary
+
+    dump --> csvReader --> dataframe --> fillColumns --> normalization --> validation --> write
+

--- a/docs/diagrams/flow/ddd-layered-architecture.mmd
+++ b/docs/diagrams/flow/ddd-layered-architecture.mmd
@@ -1,0 +1,24 @@
+%%{init: { 'flowchart': { 'useMaxWidth': true, 'htmlLabels': true } }}%%
+flowchart TB
+    classDef layer fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+    classDef note fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+    linkStyle default stroke:#666,stroke-width:1.2px,color:#111
+
+    interfaces["Interfaces\n(CLI, REST, MQ)"]:::layer
+    application["Application\n(PipelineOrchestrator, PipelineContainer, PipelineBase)"]:::layer
+    domain["Domain\n(Contracts, Schemas, Services)"]:::layer
+    infrastructure["Infrastructure\n(HTTP clients, writers, logging, config)"]:::layer
+
+    interfaces -->|Invokes| application
+    application -->|Calls ports| domain
+    application -->|Requests adapters| infrastructure
+    infrastructure -->|Implements| domain
+
+    domain -.->|Defines ABC + schema| infrastructure
+    interfaces -.->|No direct access| domain
+    interfaces -.->|Forbidden| infrastructure
+    application -.->|Forbidden| interfaces
+
+    note1(["Allowed dependency direction only ↓"]):::note
+    interfaces --> note1
+

--- a/docs/diagrams/flow/domain-services-transform.mmd
+++ b/docs/diagrams/flow/domain-services-transform.mmd
@@ -1,0 +1,54 @@
+---
+id: 8f0f89c8-5cff-4b57-a4b9-b5443c28908a
+---
+flowchart LR
+
+classDef domainPrimary   fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+classDef domainSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+classDef interface       fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px
+classDef group           fill:#e6ecef,stroke:#333,stroke-width:1.5px,color:#111,font-size:22px
+
+subgraph Transformers
+    T_Chain[TransformerChainImpl]:::domainPrimary
+    T_Hash[HashColumnsTransformerImpl]:::domainSecondary
+    T_Index[IndexColumnTransformerImpl]:::domainSecondary
+    T_Date[FulldateTransformerImpl]:::domainSecondary
+    T_ABC[<<TransformerABC>>]:::interface
+end
+class Transformers group
+
+subgraph Services
+    HS[HashService]:::domainSecondary
+    VS[ValidationService]:::domainSecondary
+    NS[NormalizationServiceImpl]:::domainSecondary
+end
+class Services group;
+
+subgraph Schemas
+    PS[PanderaValidator]:::domainSecondary
+    Registry[Schema Registry]:::domainSecondary
+end
+class Schemas group;
+
+subgraph NormalizationInputs
+    NCfg[NormalizationConfigProviderProtocol]:::domainSecondary
+    Normalizers[Normalizers Registry]:::domainSecondary
+end
+class NormalizationInputs group;
+
+Pipeline[Pipeline]:::domainPrimary --> T_Chain
+T_Chain --> T_Hash
+T_Chain --> T_Index
+T_Chain --> T_Date
+T_ABC -. template .- T_Chain
+
+T_Hash -- uses --> HS
+T_Index -- uses --> HS
+
+Pipeline -- validates result --> VS
+Pipeline -- normalizes values --> NS
+
+VS -- delegates --> PS
+PS -- lookups schema --> Registry
+NS -- loads rules --> NCfg
+NS -- resolves normalizers --> Normalizers

--- a/docs/diagrams/flow/error-policy-flow.mmd
+++ b/docs/diagrams/flow/error-policy-flow.mmd
@@ -1,0 +1,22 @@
+%%{init: { 'flowchart': { 'useMaxWidth': true, 'htmlLabels': true } }}%%
+flowchart TD
+    classDef stepPrimary fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+    classDef stepDecision fill:#e6ecef,stroke:#333,stroke-width:1.5px,color:#111,font-size:22px
+    classDef stepSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+    classDef stepTerminal fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px
+    linkStyle default stroke:#666,stroke-width:1.2px,color:#111
+
+    stage["Pipeline stage (extract/transform/validate/write)"]:::stepPrimary
+    error["Exception raised / SchemaError / IO error"]:::stepSecondary
+    policy{"ErrorPolicy (FailFast, Retry, Skip)"}:::stepDecision
+    failfast(["FailFast\n- log structured error\n- mark run as failed\n- stop pipeline"]):::stepTerminal
+    skip(["Skip record (future policy)\n- log warning\n- continue next record"]):::stepTerminal
+    retry(["Retry stage (if idempotent)\n- limited attempts\n- escalate if still failing"]):::stepTerminal
+    hooks["Hooks: on_error(event)\nlogging + metrics"]:::stepPrimary
+
+    stage --> error --> policy
+    policy -- FailFast --> failfast
+    policy -- Skip --> skip
+    policy -- Retry --> retry
+    policy --> hooks
+

--- a/docs/diagrams/flow/etl-stage-dag.mmd
+++ b/docs/diagrams/flow/etl-stage-dag.mmd
@@ -1,0 +1,36 @@
+%%{init: { 'flowchart': { 'useMaxWidth': true, 'htmlLabels': true } }}%%
+flowchart LR
+    classDef stepPrimary   fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+    classDef stepSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+    classDef stepDecision  fill:#e6ecef,stroke:#333,stroke-width:1.5px,color:#111,font-size:22px
+    classDef stepTerminal  fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px
+    linkStyle default stroke:#666,stroke-width:1.2px,color:#111
+
+    start([Start pipeline run]):::stepTerminal
+    extract["Extract\n(ChEMBL API / CSV / ID list)\n- pagination\n- retries & rate limit"]:::stepPrimary
+    transform["Transform\n- flatten nested JSON\n- normalization chain\n- enrichment hooks"]:::stepPrimary
+    post["Post-transform\n- hash_business_key\n- hash_row\n- index/database_version/extracted_at"]:::stepSecondary
+    validate["Validate\nPandera schema (ordered, strict)"]:::stepPrimary
+    branch{Dry run?}:::stepDecision
+    write["Write outputs\nstable sort + atomic CSV/Parquet\nmeta.yaml + QC reports"]:::stepPrimary
+    dry["Skip write\n(log + metrics only)"]:::stepSecondary
+    qc["Quality gates\nchecksums, QC tables, meta"]:::stepSecondary
+    success([Success]):::stepTerminal
+    error([FailFast/Error policy]):::stepTerminal
+
+    start --> extract
+    extract --> transform
+    transform --> post
+    post --> validate
+    validate --> branch
+    branch -- No --> write
+    branch -- Yes --> dry
+    dry --> qc
+    write --> qc
+    qc --> success
+
+    extract -->|Error| error
+    transform -->|Error| error
+    validate -->|Schema error| error
+    write -->|IO error| error
+

--- a/docs/diagrams/flow/external-enrichment-flow.mmd
+++ b/docs/diagrams/flow/external-enrichment-flow.mmd
@@ -1,0 +1,26 @@
+%%{init: { 'flowchart': { 'useMaxWidth': true, 'htmlLabels': true } }}%%
+flowchart LR
+    classDef stepPrimary fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+    classDef stepSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+    classDef external fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px
+    linkStyle default stroke:#666,stroke-width:1.2px,color:#111
+
+    baseDf["Base DataFrame\n(ChEMBL payload after flatten)"]:::stepPrimary
+    enrichmentPlanner["NormalizationService\nfigures out enrichment tasks"]:::stepSecondary
+    split["Split IDs by provider\n(uniProt_ids, doi list, etc.)"]:::stepSecondary
+    uniprot[(UniProt / IUPHAR API)]:::external
+    literature[(OpenAlex / Semantic Scholar API)]:::external
+    fetchUni["UnifiedAPIClient (UniProt adapter)\nrate-limit aware"]:::stepPrimary
+    fetchLit["UnifiedAPIClient (OpenAlex adapter)\nparallelized per batch"]:::stepPrimary
+    merge["Merge enrichment payloads back into DataFrame\nleft join by identifier"]:::stepPrimary
+    fallback{API call failed?}:::stepSecondary
+    warn["Log warning + mark enrichment_partial"]:::stepSecondary
+
+    baseDf --> enrichmentPlanner --> split
+    split --> fetchUni --> merge
+    split --> fetchLit --> merge
+    merge -->|updated columns| baseDf
+    fetchUni -->|error| fallback
+    fetchLit -->|error| fallback
+    fallback --> warn --> merge
+

--- a/docs/diagrams/flow/high-level-architecture.mmd
+++ b/docs/diagrams/flow/high-level-architecture.mmd
@@ -1,0 +1,97 @@
+%%{init: { 'flowchart': { 'htmlLabels': true, 'useMaxWidth': true } }}%%
+flowchart LR
+
+classDef componentPrimary   fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+classDef componentSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+classDef external           fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px
+classDef group              fill:#e6ecef,stroke:#333,stroke-width:1.5px,color:#111,font-size:22px
+
+subgraph Interfaces["Interfaces (driving ports)"]
+    CLI["CLI (Typer)\ninterfaces.cli.app"]:::componentPrimary
+    REST["REST API (FastAPI)\ninterfaces.rest.server"]:::componentSecondary
+end
+
+subgraph Application["Application layer"]
+    UseCase["RunPipelineUseCase\napplication.use_cases.run_pipeline"]:::componentPrimary
+    Orchestrator["PipelineOrchestrator\napplication.orchestrator"]:::componentPrimary
+    Container["PipelineContainer\napplication.container"]:::componentPrimary
+    Registry["Pipeline registry + factories\napplication.pipelines.registry"]:::componentSecondary
+    Executor["PipelineExecutor\napplication.executor"]:::componentPrimary
+    Runtime["StageRuntimeManager\n+ HookNotifier + StageErrorHandler\napplication.pipelines.*"]:::componentSecondary
+    Config["Config resolution/runtime\napplication.config.*"]:::componentSecondary
+    Factories["Service/Transform factories\napplication.factories.*"]:::componentSecondary
+end
+
+subgraph Domain["Domain layer (core)"]
+    Pipeline["PipelineBase / ChemblPipelineBase"]:::componentPrimary
+    Validation["ValidationService\n+ SchemaProviderABC + ValidatorFactoryABC"]:::componentPrimary
+    Transform["TransformerChainImpl\nHash/Index/DB version/Fulldate"]:::componentPrimary
+    Contracts["Pipeline contracts\nExtractorABC / LoaderABC / Hooks / ErrorPolicy"]:::componentSecondary
+    ProviderRegistry["ProviderRegistry"]:::componentSecondary
+    Schemas["SchemaRegistry\nPandera schemas"]:::componentSecondary
+end
+
+subgraph Infrastructure["Infrastructure (driven adapters)"]
+    ConfigLoader["PipelineConfigLoader\ninfrastructure.config.loader"]:::componentSecondary
+    ProviderLoader["ProviderRegistryLoader\ninfrastructure.config.provider_registry"]:::componentSecondary
+    RecordSources["ApiRecordSource / CsvRecordSourceImpl / IdListRecordSourceImpl"]:::componentSecondary
+    Clients["UnifiedAPIClient + ChemblDataClientHTTPImpl\ninfrastructure.clients.chembl.*"]:::componentPrimary
+    Extraction["ChemblExtractionServiceImpl"]:::componentSecondary
+    Output["UnifiedLoaderImpl\n+ DataWriter/Metadata/QC/AtomicFileOperation"]:::componentPrimary
+    Hashing["Blake2bHashService + HasherImpl"]:::componentSecondary
+    Indexing["SequentialIndexGenerator"]:::componentSecondary
+    Timestamp["DeterministicTimestampProvider"]:::componentSecondary
+    Normalization["NormalizationServiceImpl"]:::componentSecondary
+    Logging["UnifiedLogger + ProgressReporter"]:::componentSecondary
+    Metrics["Observability server (Prometheus)"]:::componentSecondary
+end
+
+ExtChEMBL[(ChEMBL REST API)]:::external
+FS[(Filesystem: CSV/Parquet + meta.yaml + QC)]:::external
+MetricsSink[(Prometheus / HTTP exporters)]:::external
+
+CLI --> UseCase
+REST --> UseCase
+UseCase --> ConfigLoader
+UseCase --> ProviderLoader
+UseCase --> Orchestrator
+
+Orchestrator --> Registry
+Orchestrator --> Container
+Container --> Factories
+Container --> ProviderRegistry
+ProviderLoader --> ProviderRegistry
+Container --> Pipeline
+Container --> Validation
+Container --> Transform
+Container --> Hashing
+Container --> Indexing
+Container --> Timestamp
+Container --> Normalization
+Container --> Output
+Container --> Logging
+Container --> Metrics
+Container --> Config
+
+Pipeline --> Executor
+Executor --> Runtime
+Pipeline --> Validation
+Validation --> Schemas
+Pipeline --> Transform
+Transform --> Hashing
+Transform --> Indexing
+Transform --> Timestamp
+Transform --> Normalization
+Pipeline --> Output
+
+ProviderRegistry --> Clients
+ProviderRegistry --> RecordSources
+RecordSources --> Extraction
+Extraction --> Clients
+Clients --> ExtChEMBL
+
+Output --> FS
+Logging --> FS
+Metrics --> MetricsSink
+Runtime --> Logging
+Runtime --> Metrics

--- a/docs/diagrams/flow/layer-dependency-graph.mmd
+++ b/docs/diagrams/flow/layer-dependency-graph.mmd
@@ -1,0 +1,39 @@
+%%{init: { 'flowchart': { 'useMaxWidth': true, 'htmlLabels': true } }}%%
+flowchart LR
+    classDef app fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+    classDef domain fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+    classDef infra fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px
+    linkStyle default stroke:#666,stroke-width:1.2px,color:#111
+
+    orchestrator["Application.PipelineOrchestrator"]:::app
+    container["Application.PipelineContainer"]:::app
+    pipeline["Application.ChemblPipelineBase"]:::app
+
+    hookPort["Domain.PipelineHookABC"]:::domain
+    validationPort["Domain.ValidationServiceABC\n+ SchemaRegistry"]:::domain
+    registryPort["Domain.ProviderRegistryABC"]:::domain
+    writerPort["Domain.OutputWriterABC"]:::domain
+    errorPolicyPort["Domain.ErrorPolicyABC"]:::domain
+
+    loggingImpl["Infrastructure.LoggingPipelineHookImpl"]:::infra
+    metricsImpl["Infrastructure.MetricsPipelineHookImpl"]:::infra
+    providerLoader["Infrastructure.ProviderRegistryLoader"]:::infra
+    unifiedWriter["Infrastructure.UnifiedOutputWriter"]:::infra
+    validationSvc["Infrastructure.ValidationService (Pandera)"]:::infra
+    chemblClient["Infrastructure.ChemblDataClientHTTPImpl"]:::infra
+
+    orchestrator --> container
+    container --> pipeline
+    pipeline --> hookPort
+    pipeline --> validationPort
+    pipeline --> writerPort
+    pipeline --> errorPolicyPort
+    container --> registryPort
+    registryPort --> providerLoader
+    hookPort --> loggingImpl
+    hookPort --> metricsImpl
+    validationPort --> validationSvc
+    writerPort --> unifiedWriter
+    registryPort --> chemblClient
+    validationPort -.->|no back-depend| pipeline
+

--- a/docs/diagrams/flow/pagination-flow.mmd
+++ b/docs/diagrams/flow/pagination-flow.mmd
@@ -1,0 +1,26 @@
+%%{init: { 'flowchart': { 'useMaxWidth': true, 'htmlLabels': true } }}%%
+flowchart TD
+    classDef stepPrimary fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+    classDef stepDecision fill:#e6ecef,stroke:#333,stroke-width:1.5px,color:#111,font-size:22px
+    classDef stepSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+    linkStyle default stroke:#666,stroke-width:1.2px,color:#111
+
+    start([Start extract]):::stepPrimary
+    fetch["UnifiedAPIClient.get(endpoint, offset, limit)"]:::stepPrimary
+    parse["ResponseParser -> dict"]:::stepSecondary
+    serialize["Pydantic model -> flattened dict list"]:::stepSecondary
+    accumulate["Yield batch or append to buffer"]:::stepSecondary
+    checkNext{Has next page?}:::stepDecision
+    updateOffset["Increment offset & track limit from config"]:::stepSecondary
+    limitCheck{Global limit reached?}:::stepDecision
+    finish([Return iterator / list to transformer]):::stepPrimary
+
+    start --> fetch --> parse --> serialize --> accumulate --> checkNext
+    checkNext -- No --> finish
+    checkNext -- Yes --> limitCheck
+    limitCheck -- No --> updateOffset --> fetch
+    limitCheck -- Yes --> finish
+
+    fetch -->|HTTP error| retry(["Retry policy\n(backoff until max_retries)"]):::stepSecondary
+    retry --> fetch
+

--- a/docs/diagrams/flow/pipeline-error-flowchart.mmd
+++ b/docs/diagrams/flow/pipeline-error-flowchart.mmd
@@ -1,0 +1,49 @@
+---
+id: 9cb84bf4-39e6-42d7-a431-692142164e18
+---
+graph TD;
+
+classDef stepPrimary   fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+classDef stepDecision  fill:#e6ecef,stroke:#333,stroke-width:1.5px,color:#111,font-size:22px
+classDef stepSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+classDef stepTerminal  fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px
+linkStyle default stroke:#666,stroke-width:1.2px,color:#111
+
+Start([Start Run]) --> Init[Init Context & Reset Services]
+Init --> ExtractStart[Notify Extract Start];
+ExtractStart --> ChunkLoop{Has Next Chunk?};
+
+ChunkLoop -->|Yes| ExtractExec[Execute extract]; ExtractExec -->|Success| TransformStart[Notify Transform Start]; ExtractExec -->|Error| ErrHandler{Error Policy};
+
+ErrHandler -->|Retry| RetryChk{Retries Left?}; RetryChk -->|Yes| ExtractExec; RetryChk -->|No| FailAction[PipelineStageError];
+
+ErrHandler -->|Skip| LogSkip[Log Skip]; LogSkip --> ChunkLoop;
+
+ErrHandler -->|Fail| FailAction; FailAction --> EndFail([Run Failed]);
+
+TransformStart --> TransExec[Execute transform];
+TransExec -->|Success| ValidateStart[Notify Validate Start];
+TransExec -->|Error| ErrHandler;
+
+ValidateStart --> ValExec[Execute validate];
+ValExec -->|Success| Accumulate[Accumulate Chunk];
+ValExec -->|Error| ErrHandler;
+
+Accumulate --> ChunkLoop;
+
+ChunkLoop -->|No| NotifyEnds[Notify Stages End];
+NotifyEnds --> DryRunChk{Dry Run?};
+
+DryRunChk -->|No| WriteStart[Notify Write Start];
+WriteStart --> WriteExec[Execute write];
+WriteExec --> MetaGen[Generate Metadata];
+MetaGen --> NotifyWriteEnd[Notify Write End];
+NotifyWriteEnd --> SuccessResult([Run Success]);
+
+DryRunChk -->|Yes| DryRunMeta[Generate DryRun Metadata];
+DryRunMeta --> SuccessResult;
+
+class Start,ExtractExec,TransExec,ValExec,WriteExec stepPrimary;
+class Init,ExtractStart,TransformStart,ValidateStart,Accumulate,LogSkip,NotifyEnds,WriteStart,MetaGen,NotifyWriteEnd,DryRunMeta stepSecondary;
+class ChunkLoop,ErrHandler,RetryChk,DryRunChk stepDecision;
+class FailAction,EndFail,SuccessResult stepTerminal;

--- a/docs/diagrams/flow/project-package-structure.mmd
+++ b/docs/diagrams/flow/project-package-structure.mmd
@@ -1,0 +1,90 @@
+%%{init: { 'flowchart': { 'useMaxWidth': true, 'htmlLabels': true } }}%%
+flowchart LR
+
+classDef componentPrimary   fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px
+classDef componentSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px
+classDef external           fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px
+classDef group              fill:#e6ecef,stroke:#333,stroke-width:1.5px,color:#111,font-size:22px
+linkStyle default stroke:#666,stroke-width:1.2px,color:#111
+
+subgraph Interfaces["Interfaces (Driving Ports)"]
+    CLI["CLI (Typer)\ninterfaces.cli.app"]:::componentPrimary
+    REST["REST server\ninterfaces.rest.server"]:::componentSecondary
+    MQ["MQ listener\ninterfaces.mq.listener/handler"]:::componentSecondary
+end
+class Interfaces group
+
+subgraph Application["Application Layer"]
+    Orchestrator["PipelineOrchestrator\napplication.orchestrator"]:::componentPrimary
+    ConfigLoader["Config Loader\napplication.config_loader"]:::componentSecondary
+    PipelineRegistry["Pipeline registry\napplication.pipelines.registry"]:::componentSecondary
+    Container["PipelineContainer\napplication.container"]:::componentSecondary
+    Pipelines["PipelineBase / ChemblPipelineBase\napplication.pipelines.*"]:::componentSecondary
+    StageRunnerFacade["StageRunnerFacade\napplication.pipelines.stage_runner_facade"]:::componentSecondary
+    HooksManager["HooksManager\napplication.pipelines.hooks_manager"]:::componentSecondary
+    ErrorPolicyMgr["ErrorPolicyManager\napplication.pipelines.error_policy_manager"]:::componentSecondary
+    HooksImpl["Logging + Metrics hooks\napplication.pipelines.hooks_impl"]:::componentSecondary
+end
+class Application group
+
+subgraph Domain["Domain Layer"]
+    ProviderRegistry["ProviderRegistry\ndomain.provider_registry"]:::componentSecondary
+    Providers["ProviderDefinition / Components\ndomain.providers"]:::componentSecondary
+    RecordSource["ApiRecordSource\ndomain.record_source"]:::componentSecondary
+    Validation["ValidationService + PanderaValidator\ndomain.validation.*"]:::componentPrimary
+    Schemas["SchemaRegistry + PipelineContracts\ndomain.schemas.*"]:::componentSecondary
+    Transform["HashService / TransformerChain\ndomain.transform.*"]:::componentPrimary
+    Normalization["NormalizationServiceImpl\n(infrastructure.transform.impl.normalize)"]:::componentSecondary
+    Hashing["HasherImpl\n(infrastructure.transform.impl.hasher)"]:::componentSecondary
+end
+class Domain group
+
+subgraph Infrastructure["Infrastructure Layer (Driven Adapters)"]
+    ProviderLoader["ProviderRegistryLoader\ninfrastructure.config.provider_registry"]:::componentSecondary
+    ClientsBase["UnifiedAPIClient + rate/retry/cache/circuit\ninfrastructure.clients.base.*"]:::componentSecondary
+    ChemblClient["ChemblDataClientHTTPImpl\n+ RequestBuilder/ResponseParser/Paginator\ninfrastructure.clients.chembl.*"]:::componentPrimary
+    Extraction["ChemblExtractionServiceImpl\ninfrastructure.clients.chembl.impl"]:::componentSecondary
+    RecordSources["CsvRecordSourceImpl / IdListRecordSourceImpl\ninfrastructure.files.csv_record_source"]:::componentSecondary
+    Output["UnifiedOutputWriter + CsvWriter + MetadataWriter + QualityReporter\ninfrastructure.output.*"]:::componentPrimary
+    AtomicIO["AtomicFileOperation + Checksum\ninfrastructure.files.*"]:::componentSecondary
+    Logging["UnifiedLogger\ninfrastructure.logging.*"]:::componentSecondary
+    Observability["Prometheus metrics server\ninfrastructure.observability.*"]:::componentSecondary
+    Config["Config models/resolver\ninfrastructure.config.*"]:::componentSecondary
+end
+class Infrastructure group
+
+ChEMBL_API[(ChEMBL REST API)]:::external
+Storage[(Filesystem: CSV/Parquet, meta, QC)]:::external
+
+CLI --> Orchestrator
+REST --> Orchestrator
+MQ --> Orchestrator
+Orchestrator --> ConfigLoader
+Orchestrator --> PipelineRegistry
+Orchestrator --> Container
+Container --> Pipelines
+Container --> StageRunnerFacade
+Container --> HooksManager
+Container --> ErrorPolicyMgr
+HooksManager --> HooksImpl
+Container --> Validation
+Container --> Normalization
+Container --> Transform
+Container --> ProviderRegistry
+Container --> RecordSource
+Container --> Output
+Container --> Logging
+Container --> Observability
+Container --> Config
+ProviderRegistry --> Providers
+ProviderLoader --> ProviderRegistry
+Providers --> ChemblClient
+ClientsBase --> ChemblClient
+ChemblClient --> Extraction
+RecordSources --> Extraction
+Extraction --> RecordSource
+ChemblClient --> ChEMBL_API
+Output --> AtomicIO
+Output --> Storage
+Observability --> REST
+Logging --> Storage

--- a/docs/diagrams/flow/rate-limiter-timeline.mmd
+++ b/docs/diagrams/flow/rate-limiter-timeline.mmd
@@ -1,0 +1,21 @@
+%%{init: { 'flowchart': { 'useMaxWidth': true, 'htmlLabels': true } }}%%
+flowchart LR
+    classDef stepPrimary fill:#f5f5f5,stroke:#444,stroke-width:1.5px
+    classDef stepSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px
+    classDef stepDecision fill:#e6ecef,stroke:#333,stroke-width:1.5px
+    linkStyle default stroke:#666,stroke-width:1.2px
+
+    request1["Request N (timestamp tₙ)"]:::stepPrimary
+    check["RateLimiter.acquire()\ncompute elapsed = tₙ - tₙ₋₁"]:::stepSecondary
+    allow{elapsed ≥ min_interval?}:::stepDecision
+    sleep["Sleep (min_interval - elapsed)\nrespect global window & burst limits"]:::stepSecondary
+    token["Consume token / store timestamp"]:::stepSecondary
+    request2["Forward to UnifiedAPIClient"]:::stepPrimary
+
+    request1 --> check --> allow
+    allow -- Yes --> token --> request2
+    allow -- No --> sleep --> token --> request2
+
+    note1["min_interval = 1 / requests_per_second\nwindow buckets enforce additional profile-specific caps"]:::stepSecondary
+    request2 --> note1
+

--- a/docs/diagrams/flow/retry-policy-flow.mmd
+++ b/docs/diagrams/flow/retry-policy-flow.mmd
@@ -1,0 +1,25 @@
+%%{init: { 'flowchart': { 'useMaxWidth': true, 'htmlLabels': true } }}%%
+flowchart TD
+    classDef stepPrimary fill:#f5f5f5,stroke:#444,stroke-width:1.5px
+    classDef stepSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px
+    classDef stepDecision fill:#e6ecef,stroke:#333,stroke-width:1.5px
+    classDef stepTerminal fill:#dde7f2,stroke:#44546a,stroke-width:1.5px
+    linkStyle default stroke:#666,stroke-width:1.2px
+
+    start([Request attempt 1]):::stepTerminal
+    httpCall["HTTP call via UnifiedAPIClient"]:::stepPrimary
+    status{"Success?"}:::stepDecision
+    handle(["Return response"]):::stepPrimary
+    error["Capture exception / 5xx response"]:::stepSecondary
+    retryCount["Increment attempt counter"]:::stepSecondary
+    limit{attempts <= max_retries?}:::stepDecision
+    backoff["Sleep backoff (exponential + jitter)\nrespect rate limits"]:::stepSecondary
+    fail([Raise error to caller]):::stepTerminal
+
+    start --> httpCall
+    httpCall --> status
+    status -- Yes --> handle
+    status -- No --> error --> retryCount --> limit
+    limit -- Yes --> backoff --> httpCall
+    limit -- No --> fail
+

--- a/docs/diagrams/flow/testing-pyramid.mmd
+++ b/docs/diagrams/flow/testing-pyramid.mmd
@@ -1,0 +1,18 @@
+%%{init: { 'flowchart': { 'useMaxWidth': true, 'htmlLabels': true } }}%%
+flowchart TB
+    classDef layer fill:#f5f5f5,stroke:#444,stroke-width:1.5px
+    classDef detail fill:#e3e7ec,stroke:#555,stroke-width:1.2px
+    linkStyle default stroke:#666,stroke-width:1.2px
+
+    unit["Unit tests\n- domain services\n- transformers\n- clients with mocks\n(no network)"]:::layer
+    stageTests["Pipeline stage tests\n- PipelineBase behavior\n- container assembly fakes\n- error policy\n(cover branching)"]:::layer
+    golden["Golden tests\n- run pipeline with fixture input\n- compare CSV/meta artefacts byte-to-byte"]:::layer
+    integration["Integration / smoke\n- CLI run with --limit/--dry-run\n- config resolution, logging, metrics"]:::layer
+
+    unit --> stageTests --> golden --> integration
+
+    coverage["Coverage gate ≥85%\n(pytest --cov)"]:::detail
+    lint["Static checks (ruff, mypy, import-linter)\nrun before tests"]:::detail
+    unit -.-> coverage
+    golden -.-> lint
+

--- a/docs/diagrams/packages/application/files.mmd
+++ b/docs/diagrams/packages/application/files.mmd
@@ -1,0 +1,50 @@
+---
+title: Application Files Package
+description: bioetl.application.files - File-based record sources
+---
+classDiagram
+    direction TB
+
+    class RecordSourceABC {
+        <<abstract>>
+        +iter_records() Iterable~Sequence~Mapping~~
+    }
+
+    class CsvRecordSourceImpl {
+        -_input_path: Path
+        -_csv_options: CsvInputConfig
+        -_limit: int | None
+        -_logger: LoggingPortABC
+        -_chunk_size: int | None
+        +iter_records() Iterable~Sequence~Mapping~~
+    }
+
+    class IdListRecordSourceImpl {
+        -_input_path: Path
+        -_id_column: str
+        -_csv_options: CsvInputConfig
+        -_limit: int | None
+        -_extraction_service: ExtractionServiceABC
+        -_source_config: ChemblSourceConfig
+        -_entity: str
+        -_filter_key: str
+        -_logger: LoggingPortABC
+        -_chunk_size: int | None
+        +iter_records() Iterable~Sequence~Mapping~~
+        -_fetch_records(ids, batch_size) Iterable
+    }
+
+    class CsvInputConfig {
+        <<dataclass>>
+        +delimiter: str
+        +header: bool
+    }
+
+    RecordSourceABC <|.. CsvRecordSourceImpl : implements
+    RecordSourceABC <|.. IdListRecordSourceImpl : implements
+    CsvRecordSourceImpl --> CsvInputConfig : uses
+    IdListRecordSourceImpl --> CsvInputConfig : uses
+    IdListRecordSourceImpl --> ExtractionServiceABC : uses
+
+    note for CsvRecordSourceImpl "Reads full datasets from CSV.\nReturns raw dicts per contract."
+    note for IdListRecordSourceImpl "Reads IDs from CSV,\nenriches via API."

--- a/docs/diagrams/packages/application/helpers.mmd
+++ b/docs/diagrams/packages/application/helpers.mmd
@@ -1,0 +1,28 @@
+---
+title: Application Helpers Package
+description: bioetl.application.helpers - Utility functions for pipelines
+---
+flowchart TB
+
+classDef func fill:#e3f2fd,stroke:#1565c0,stroke-width:2px,color:#0d47a1
+classDef helper fill:#bbdefb,stroke:#1976d2,stroke-width:1px,color:#0d47a1
+
+subgraph Helpers["bioetl.application.helpers"]
+    direction TB
+
+    subgraph PrimaryKey["primary_key.py"]
+        resolve_primary_key["resolve_primary_key(config, fallback)\n→ str"]:::func
+        resolve_primary_key_with_filter["resolve_primary_key_with_filter(config, fallback)\n→ tuple[str, str]"]:::func
+
+        _get_primary_keys_from_config["_get_primary_keys_from_config(config)\n→ list | str | None"]:::helper
+        _get_entity_name_from_config["_get_entity_name_from_config(config)\n→ str | None"]:::helper
+        _extract_first_primary_key["_extract_first_primary_key(keys)\n→ str | None"]:::helper
+    end
+end
+
+resolve_primary_key --> _get_primary_keys_from_config
+resolve_primary_key --> _get_entity_name_from_config
+resolve_primary_key --> _extract_first_primary_key
+resolve_primary_key_with_filter --> resolve_primary_key
+
+note "Resolution order:\n1. config.identity.primary_key[0]\n2. {entity_name}_id convention\n3. fallback parameter\n4. ValueError"

--- a/docs/diagrams/packages/application/metadata.mmd
+++ b/docs/diagrams/packages/application/metadata.mmd
@@ -1,0 +1,39 @@
+---
+title: Application Metadata Package
+description: bioetl.application.metadata - Run metadata builders
+---
+classDiagram
+    direction TB
+
+    class RunMetadataBuilderProtocol {
+        <<protocol>>
+        +build_run_metadata(context, write_result) dict
+        +build_dry_run_metadata(context, row_count) dict
+    }
+
+    class DefaultRunMetadataBuilder {
+        +build_run_metadata(context, write_result) dict~str,object~
+        +build_dry_run_metadata(context, row_count) dict~str,object~
+    }
+
+    class RunContext {
+        <<dataclass>>
+        +run_id: str
+        +provider: str
+        +entity_name: str
+    }
+
+    class WriteResult {
+        <<dataclass>>
+        +row_count: int
+        +path: Path
+        +checksum: str
+    }
+
+    RunMetadataBuilderProtocol <|.. DefaultRunMetadataBuilder : implements
+    DefaultRunMetadataBuilder --> RunContext : uses
+    DefaultRunMetadataBuilder --> WriteResult : uses
+
+    note for DefaultRunMetadataBuilder "Default implementation.\nProvides basic metadata\nwithout external dependencies."
+
+    note for RunMetadataBuilderProtocol "Protocol for building\nrun metadata dictionaries."

--- a/docs/diagrams/packages/application/ports.mmd
+++ b/docs/diagrams/packages/application/ports.mmd
@@ -1,0 +1,34 @@
+---
+title: Application Ports Package
+description: bioetl.application.ports - Application-level abstract factories
+---
+classDiagram
+    direction TB
+
+    class ObservabilityFactoryPortABC {
+        <<abstract>>
+        +create_logger() LoggingPortABC
+        +create_metrics() MetricsPortABC
+    }
+
+    class LoggingPortABC {
+        <<abstract>>
+        +info(msg, **ctx)
+        +error(msg, **ctx)
+        +debug(msg, **ctx)
+        +warning(msg, **ctx)
+        +apply_bind(**ctx) Self
+    }
+
+    class MetricsPortABC {
+        <<abstract>>
+        +inc_counter(name, labels)
+        +observe_histogram(name, value, labels)
+        +update_stage_duration(...)
+        +update_stage_total(...)
+    }
+
+    ObservabilityFactoryPortABC --> LoggingPortABC : creates
+    ObservabilityFactoryPortABC --> MetricsPortABC : creates
+
+    note for ObservabilityFactoryPortABC "Abstract factory for\nobservability components.\nImplementations in interfaces layer."

--- a/docs/diagrams/packages/application/providers.mmd
+++ b/docs/diagrams/packages/application/providers.mmd
@@ -1,0 +1,35 @@
+---
+title: Application Providers Package
+description: bioetl.application.providers - Default field providers
+---
+classDiagram
+    direction TB
+
+    class DefaultFieldProviderABC {
+        <<abstract>>
+        +get_default_fields(entity) list~str~
+    }
+
+    class ApplicationFieldProvider {
+        +get_default_fields(entity) list~str~
+    }
+
+    DefaultFieldProviderABC <|.. ApplicationFieldProvider : implements
+
+    note for ApplicationFieldProvider "Provides default fields\nfor entities.\nCurrently supports 'assay'\nwith 30+ default fields."
+
+    class AssayDefaultFields {
+        <<constant>>
+        aidx
+        assay_category
+        assay_cell_type
+        assay_chembl_id
+        assay_classifications
+        assay_group
+        assay_organism
+        assay_parameters
+        assay_type
+        ...30+ fields
+    }
+
+    ApplicationFieldProvider --> AssayDefaultFields : uses

--- a/docs/diagrams/packages/application/runtime.mmd
+++ b/docs/diagrams/packages/application/runtime.mmd
@@ -1,0 +1,31 @@
+---
+title: Application Runtime Package
+description: bioetl.application.runtime - Pipeline runtime support
+---
+flowchart TB
+
+classDef component fill:#e3f2fd,stroke:#1565c0,stroke-width:2px,color:#0d47a1
+classDef runtime fill:#bbdefb,stroke:#1976d2,stroke-width:1px,color:#0d47a1
+
+subgraph Runtime["bioetl.application.runtime"]
+    direction TB
+
+    note1["This package provides runtime\nsupport classes and utilities\nfor pipeline execution."]
+
+    subgraph StageManagement["Stage Management"]
+        StageRuntimeManager["StageRuntimeManager\n- Manages stage lifecycle\n- Tracks execution state"]:::runtime
+        StageCounter["StageCounter\n- Counts processed records\n- Tracks batch progress"]:::runtime
+    end
+
+    subgraph ErrorHandling["Error Handling"]
+        StageErrorHandler["StageErrorHandler\n- Handles stage errors\n- Applies error policies"]:::runtime
+    end
+
+    subgraph Context["Execution Context"]
+        PipelineRuntimeContext["PipelineRuntimeContext\n- Holds runtime state\n- Provides context to stages"]:::runtime
+    end
+end
+
+StageRuntimeManager --> StageCounter : uses
+StageRuntimeManager --> StageErrorHandler : uses
+StageRuntimeManager --> PipelineRuntimeContext : creates

--- a/docs/diagrams/packages/application/transform.mmd
+++ b/docs/diagrams/packages/application/transform.mmd
@@ -1,0 +1,36 @@
+---
+title: Application Transform Package
+description: bioetl.application.transform - Batch adapters and transformers
+---
+classDiagram
+    direction TB
+
+    class BatchAdapterABC {
+        <<abstract>>
+        +process_batch(raw_batch) list~Mapping~
+    }
+
+    class PandasBatchAdapter {
+        +process_batch(raw_batch) list~Mapping[str,Any]~
+        -_convert_record(item) Mapping~str,Any~
+    }
+
+    BatchAdapterABC <|.. PandasBatchAdapter : implements
+
+    note for PandasBatchAdapter "Converts raw batches to\nlist of records (raw dicts).\n\nSupports:\n- pd.DataFrame\n- list of dicts\n- list of Pydantic models\n- single dict"
+
+    class InputTypes {
+        <<supported>>
+        pd.DataFrame
+        list[dict]
+        list[BaseModel]
+        dict
+    }
+
+    class OutputType {
+        <<output>>
+        list[Mapping[str, Any]]
+    }
+
+    PandasBatchAdapter --> InputTypes : accepts
+    PandasBatchAdapter --> OutputType : returns

--- a/docs/diagrams/packages/domain/aggregates.mmd
+++ b/docs/diagrams/packages/domain/aggregates.mmd
@@ -1,0 +1,38 @@
+---
+title: Domain Aggregates Package
+description: bioetl.domain.aggregates - Aggregate roots for domain consistency
+---
+classDiagram
+    direction TB
+
+    class PipelineIdentity {
+        <<frozen dataclass>>
+        +pipeline_id: PipelineId
+        +provider: ProviderId
+        +entity: EntityName
+        +primary_key: tuple[str, ...]
+        +__post_init__() void
+    }
+
+    class PipelineId {
+        <<value object>>
+        +value: str
+    }
+
+    class ProviderId {
+        <<enum>>
+        CHEMBL
+        UNIPROT
+    }
+
+    class EntityName {
+        <<value object>>
+        +value: str
+        +validate() bool
+    }
+
+    PipelineIdentity --> PipelineId : uses
+    PipelineIdentity --> ProviderId : uses
+    PipelineIdentity --> EntityName : uses
+
+    note for PipelineIdentity "Immutable aggregate root\nfor pipeline identification.\nEncapsulates identity and metadata."

--- a/docs/diagrams/packages/domain/observability.mmd
+++ b/docs/diagrams/packages/domain/observability.mmd
@@ -1,0 +1,34 @@
+---
+title: Domain Observability Package
+description: bioetl.domain.observability - Logging, tracing, and metrics contracts
+---
+flowchart TB
+
+classDef port fill:#a5d6a7,stroke:#43a047,stroke-width:2px,color:#1b5e20
+classDef component fill:#c8e6c9,stroke:#388e3c,stroke-width:1px,color:#1b5e20
+
+subgraph Observability["bioetl.domain.observability"]
+    direction TB
+
+    subgraph Logging["Logging"]
+        LoggingPortABC["LoggingPortABC\n- info(msg, **ctx)\n- error(msg, **ctx)\n- debug(msg, **ctx)\n- warning(msg, **ctx)\n- apply_bind(**ctx) -> Self"]:::port
+    end
+
+    subgraph Tracing["Tracing"]
+        TracingPortABC["TracingPortABC\n- start_span(name)\n- end_span(span)\n- inject_context(headers)"]:::port
+    end
+
+    subgraph Metrics["Metrics"]
+        MetricsPortABC["MetricsPortABC\n- inc_counter(name, labels)\n- observe_histogram(name, value, labels)\n- update_stage_duration(...)\n- update_stage_total(...)"]:::port
+    end
+
+    subgraph Progress["Progress Reporting"]
+        ProgressReporterABC["ProgressReporterABC\n- start(total, description)\n- apply_update(n)\n- stop_reporting()\n- create_bar(total, desc)"]:::port
+    end
+
+    subgraph ClientMetrics["Client Metrics"]
+        ClientMetricsABC["ClientMetricsABC\n- record_request(...)\n- record_retry(...)\n- record_error(...)"]:::component
+    end
+end
+
+note "Domain observability contracts.\nImplementations in infrastructure layer."

--- a/docs/diagrams/packages/domain/output.mmd
+++ b/docs/diagrams/packages/domain/output.mmd
@@ -1,0 +1,36 @@
+---
+title: Domain Output Package
+description: bioetl.domain.output - Deterministic output specifications
+---
+classDiagram
+    direction TB
+
+    class DeterministicWriterABC {
+        <<abstract>>
+        +write_atomic(data, target_path, sort_columns, reset_index) DeterministicWriteResult
+        +verify_checksum(path, expected) bool
+        +compute_checksum(path) str
+    }
+
+    class DeterministicWriteResult {
+        <<frozen dataclass>>
+        +path: Path
+        +checksum: str
+        +row_count: int
+        +is_atomic: bool
+        +bytes_written: int
+        +verify(expected_checksum) bool
+    }
+
+    class TabularData {
+        <<protocol>>
+        +columns: Sequence[str]
+        +shape: tuple[int, int]
+    }
+
+    DeterministicWriterABC --> TabularData : uses
+    DeterministicWriterABC --> DeterministicWriteResult : returns
+
+    note for DeterministicWriterABC "Guarantees:\n1. Byte-for-byte identical output\n2. Atomic writes (temp + rename)\n3. Checksum verification"
+
+    note for DeterministicWriteResult "Contains write operation\nresults with checksum\nfor validation"

--- a/docs/diagrams/packages/domain/pipelines.mmd
+++ b/docs/diagrams/packages/domain/pipelines.mmd
@@ -1,0 +1,62 @@
+---
+title: Domain Pipelines Package
+description: bioetl.domain.pipelines - Pipeline contracts and lifecycle hooks
+---
+classDiagram
+    direction TB
+
+    class PipelineHookABC {
+        <<abstract>>
+        +on_stage_start(stage, context) void
+        +on_stage_end(stage, result) void
+        +on_error(stage, error) void
+    }
+
+    class ErrorPolicyABC {
+        <<abstract>>
+        +handle(error, context) ErrorAction
+        +can_retry(error) bool
+    }
+
+    class ExtractorABC {
+        <<abstract>>
+        +extract(**kwargs) Iterable~TabularData~
+    }
+
+    class LoaderABC {
+        <<abstract>>
+        +load(data, output_path, context, column_order) WriteResult
+        +write_metadata(meta, path) void
+        +write_qc_report(data, path) void
+    }
+
+    class ErrorAction {
+        <<enum>>
+        SKIP
+        FAIL
+        RETRY
+    }
+
+    class StageResult {
+        <<dataclass>>
+        +stage: str
+        +success: bool
+        +duration_ms: float
+        +error: Optional~PipelineStageError~
+    }
+
+    class RunContext {
+        <<dataclass>>
+        +run_id: str
+        +provider: str
+        +entity_name: str
+    }
+
+    ErrorPolicyABC --> ErrorAction : returns
+    PipelineHookABC --> StageResult : receives
+    LoaderABC --> RunContext : uses
+
+    note for PipelineHookABC "Observer pattern for\npipeline lifecycle events"
+    note for ErrorPolicyABC "Strategy pattern for\nerror handling decisions"
+    note for ExtractorABC "Template method for\ndata extraction"
+    note for LoaderABC "Template method for\ndata persistence"

--- a/docs/diagrams/packages/infrastructure/chembl.mmd
+++ b/docs/diagrams/packages/infrastructure/chembl.mmd
@@ -1,0 +1,43 @@
+---
+title: Infrastructure ChEMBL Package
+description: bioetl.infrastructure.chembl - ChEMBL-specific model registry
+---
+classDiagram
+    direction TB
+
+    class EntityModelRegistryABC {
+        <<abstract>>
+        +get_model(entity) type~BaseModel~
+        +is_supported(entity) bool
+        +supported_entities() frozenset~str~
+    }
+
+    class ChemblEntityModelRegistry {
+        +get_model(entity) type~BaseModel~
+        +is_supported(entity) bool
+        +supported_entities() frozenset~str~
+    }
+
+    EntityModelRegistryABC <|.. ChemblEntityModelRegistry : implements
+
+    class EntityModels {
+        <<models>>
+        ActivityRawModel
+        AssayRawModel
+        MoleculeRawModel
+        PublicationRawModel
+        TargetRawModel
+    }
+
+    ChemblEntityModelRegistry --> EntityModels : provides
+
+    note for ChemblEntityModelRegistry "Maps entity names to Pydantic models:\n- activity → ActivityRawModel\n- assay → AssayRawModel\n- molecule → MoleculeRawModel\n- publication/document → PublicationRawModel\n- target → TargetRawModel"
+
+    class FactoryFunctions {
+        <<functions>>
+        create_chembl_model_registry() ChemblEntityModelRegistry
+        get_chembl_model_registry() ChemblEntityModelRegistry
+        reset_chembl_model_registry() void
+    }
+
+    FactoryFunctions --> ChemblEntityModelRegistry : creates

--- a/docs/diagrams/packages/infrastructure/http.mmd
+++ b/docs/diagrams/packages/infrastructure/http.mmd
@@ -1,0 +1,42 @@
+---
+title: Infrastructure HTTP Package
+description: bioetl.infrastructure.http - HTTP retry policies and utilities
+---
+classDiagram
+    direction TB
+
+    class RetryPolicyABC {
+        <<abstract>>
+        +max_attempts: int
+        +backoff_factor: float
+        +should_retry(exception, attempt) bool
+        +get_backoff(attempt) float
+    }
+
+    class ExponentialRetryPolicy {
+        -_max_attempts: int
+        -_backoff_factor: float
+        +retry_statuses: set~int~
+        +retry_exceptions: tuple~type~
+        +max_attempts: int
+        +backoff_factor: float
+        +should_retry(exception, attempt) bool
+        +get_backoff(attempt) float
+    }
+
+    RetryPolicyABC <|.. ExponentialRetryPolicy : implements
+
+    class ApiClientError {
+        <<exception>>
+        +status_code: int | None
+        +cause: Exception | None
+    }
+
+    class ApiTimeoutError {
+        <<exception>>
+    }
+
+    ExponentialRetryPolicy --> ApiClientError : handles
+    ExponentialRetryPolicy --> ApiTimeoutError : handles
+
+    note for ExponentialRetryPolicy "Exponential backoff retry policy:\n- Delay = factor * 2^(attempt-1)\n- Retries on: 429, 500, 502, 503, 504\n- Retries on: Timeout, ConnectionError"

--- a/docs/diagrams/packages/infrastructure/observability.mmd
+++ b/docs/diagrams/packages/infrastructure/observability.mmd
@@ -1,0 +1,46 @@
+---
+title: Infrastructure Observability Package
+description: bioetl.infrastructure.observability - Logging, metrics, tracing implementations
+---
+flowchart TB
+
+classDef abc fill:#a5d6a7,stroke:#43a047,stroke-width:2px,color:#1b5e20
+classDef impl fill:#fff3e0,stroke:#ef6c00,stroke-width:2px,color:#e65100
+classDef factory fill:#e3f2fd,stroke:#1565c0,stroke-width:1px,color:#0d47a1
+
+subgraph Observability["bioetl.infrastructure.observability"]
+    direction TB
+
+    subgraph Adapters["adapters.py"]
+        StructuredLoggerImpl["StructuredLoggerImpl\n(implements LoggingPortABC)"]:::impl
+        PrometheusMetricsPortImpl["PrometheusMetricsPortImpl\n(implements MetricsPortABC)"]:::impl
+        TracingAdapterImpl["TracingAdapterImpl\n(implements TracingPortABC)"]:::impl
+    end
+
+    subgraph Factories["factories.py"]
+        create_logging_port["create_logging_port()\n→ LoggingPortABC"]:::factory
+        create_metrics_port["create_metrics_port()\n→ MetricsPortABC"]:::factory
+        create_tracing_port["create_tracing_port()\n→ TracingPortABC"]:::factory
+    end
+
+    subgraph Metrics["metrics.py"]
+        PipelineMetrics["PipelineMetrics\n- stage_duration_histogram\n- stage_total_counter"]:::impl
+    end
+
+    subgraph Server["server.py"]
+        MetricsServer["MetricsServer\n- start_server(port)\n- stop_server()"]:::impl
+    end
+end
+
+create_logging_port --> StructuredLoggerImpl
+create_metrics_port --> PrometheusMetricsPortImpl
+create_tracing_port --> TracingAdapterImpl
+
+subgraph External["External Libraries"]
+    structlog["structlog"]
+    prometheus_client["prometheus_client"]
+end
+
+StructuredLoggerImpl --> structlog : uses
+PrometheusMetricsPortImpl --> prometheus_client : uses
+MetricsServer --> prometheus_client : uses

--- a/docs/diagrams/packages/infrastructure/settings.mmd
+++ b/docs/diagrams/packages/infrastructure/settings.mmd
@@ -1,0 +1,43 @@
+---
+title: Infrastructure Settings Package
+description: bioetl.infrastructure.settings - Configuration constants and defaults
+---
+classDiagram
+    direction TB
+
+    class HttpTimeouts {
+        <<frozen dataclass>>
+        +connect: float = 10.0
+        +read: float = 30.0
+        +total: float = 30.0
+    }
+
+    class RetrySettings {
+        <<frozen dataclass>>
+        +max_attempts: int = 4
+        +backoff_factor: float = 2.0
+        +backoff_max: float = 60.0
+        +retry_statuses: frozenset~int~
+        +retry_exceptions: tuple
+    }
+
+    class ConnectionPoolSettings {
+        <<frozen dataclass>>
+        +rate_limit_per_sec: float = 2.5
+        +pool_connections: int = 10
+        +pool_maxsize: int = 10
+        +pool_block: bool = False
+    }
+
+    class DefaultInstances {
+        <<constants>>
+        DEFAULT_TIMEOUTS: HttpTimeouts
+        DEFAULT_RETRY: RetrySettings
+        DEFAULT_POOL: ConnectionPoolSettings
+    }
+
+    DefaultInstances --> HttpTimeouts : uses
+    DefaultInstances --> RetrySettings : uses
+    DefaultInstances --> ConnectionPoolSettings : uses
+
+    note for RetrySettings "Default retry statuses:\n429, 500, 502, 503, 504\n\nRetry exceptions:\nApiTimeoutError, ApiClientError,\nrequests.Timeout, ConnectionError"

--- a/docs/diagrams/packages/interfaces/monitoring.mmd
+++ b/docs/diagrams/packages/interfaces/monitoring.mmd
@@ -1,0 +1,36 @@
+---
+title: Interfaces Monitoring Package
+description: bioetl.interfaces.monitoring - Prometheus metrics integration
+---
+flowchart TB
+
+classDef factory fill:#fce4ec,stroke:#c2185b,stroke-width:2px,color:#880e4f
+classDef infra fill:#fff3e0,stroke:#ef6c00,stroke-width:1px,color:#e65100
+classDef domain fill:#e8f5e9,stroke:#2e7d32,stroke-width:1px,color:#1b5e20
+
+subgraph Interfaces["bioetl.interfaces.monitoring"]
+    direction TB
+
+    create_prometheus_metrics_port["create_prometheus_metrics_port()\n→ MetricsPortABC"]:::factory
+    start_metrics_server_once["start_metrics_server_once()\n(start HTTP server for Prometheus)"]:::factory
+    prometheus_metrics["prometheus_metrics\n(direct access to collectors)"]:::factory
+end
+
+subgraph Infrastructure["bioetl.infrastructure.observability"]
+    direction TB
+
+    create_metrics_port["create_metrics_port()"]:::infra
+    PrometheusMetricsPortImpl["PrometheusMetricsPortImpl"]:::infra
+    MetricsServer["MetricsServer"]:::infra
+end
+
+subgraph Domain["bioetl.domain.observability"]
+    MetricsPortABC["MetricsPortABC"]:::domain
+end
+
+create_prometheus_metrics_port --> create_metrics_port
+create_metrics_port --> PrometheusMetricsPortImpl
+PrometheusMetricsPortImpl -.-> MetricsPortABC : implements
+start_metrics_server_once --> MetricsServer
+
+note "Provides Prometheus integration:\n- MetricsPortABC factory\n- HTTP metrics endpoint (port 9090)\n- Direct access to collectors"

--- a/docs/diagrams/sequence/chembl-api-request-sequence.mmd
+++ b/docs/diagrams/sequence/chembl-api-request-sequence.mmd
@@ -1,0 +1,54 @@
+%%{init: {
+  "theme": "base",
+  "themeVariables": {
+    "actorLineColor": "#444",
+    "actorTextColor": "#111",
+    "actorBkg": "#f5f5f5",
+    "actorFontSize": "18px",
+    "activationBkgColor": "#e3e7ec",
+    "activationBorderColor": "#444"
+  }
+}}%%
+%% Shared palette (per diagramming policy)
+classDef actorPrimary   fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px;
+classDef actorSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px;
+classDef actorExternal  fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px;
+linkStyle default stroke:#666,stroke-width:1.2px,color:#111;
+
+sequenceDiagram
+    autonumber
+    participant Extraction as ChemblExtractionServiceImpl
+    participant Client as ChemblHttpClientImpl
+    participant Rate as RateLimiter
+    participant HTTP as UnifiedAPIClientImpl
+    participant API as "ChEMBL REST API"
+
+    class Extraction actorPrimary
+    class Client actorPrimary
+    class Rate actorSecondary
+    class HTTP actorSecondary
+    class API actorExternal
+
+    Extraction->>Client: request_activity(filters, offset, limit)
+    Client->>Rate: acquire()
+    Rate-->>Client: ok (sleep if needed)
+    Client->>HTTP: request_call(method, url, timeout, ...)
+    activate HTTP
+    loop retry logic (internal)
+        HTTP->>API: HTTPS request
+        alt success 2xx
+            API-->>HTTP: JSON payload
+            HTTP-->>Client: response
+        else retryable error
+            API--x HTTP: error/timeout
+            HTTP->>HTTP: wait(backoff)
+        end
+    end
+    alt all retries failed
+        HTTP-->>Client: raise ApiError
+        Client-->>Extraction: propagate error
+    end
+    deactivate HTTP
+    Client->>Client: parse via ResponseParser
+    Client-->>Extraction: page dict (records + page_meta)
+

--- a/docs/diagrams/sequence/cli-run-sequence.mmd
+++ b/docs/diagrams/sequence/cli-run-sequence.mmd
@@ -1,0 +1,63 @@
+---
+id: 57544a83-ca5a-4e5a-a348-afc397a7176a
+---
+%%{init: {
+  "theme": "base",
+  "themeVariables": {
+    "actorLineColor": "#444",
+    "actorTextColor": "#111",
+    "actorBkg": "#f5f5f5",
+    "actorBorderRadius": 6,
+    "actorFontSize": "18px",
+    "sequenceNumberColor": "#444",
+    "activationBkgColor": "#e3e7ec",
+    "activationBorderColor": "#444"
+  }
+}%%
+sequenceDiagram
+    autonumber
+
+    %% Shared palette (per diagramming policy)
+    classDef actorPrimary   fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px;
+    classDef actorSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px;
+    classDef actorExternal  fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px;
+    linkStyle default stroke:#666,stroke-width:1.2px,color:#111;
+
+    participant User as Operator
+    participant CLI as Typer CLI (bioetl)
+    participant UseCaseFactory as UseCaseFactory
+    participant AppCtx as ApplicationContext
+    participant UseCase as RunPipelineUseCase
+    participant ConfigLoader as PipelineConfigLoader
+    participant ProviderLoader as ProviderRegistryLoader
+    participant Orchestrator as PipelineOrchestrator
+    participant Pipeline as PipelineBase
+
+    class User actorPrimary
+    class CLI actorPrimary
+    class UseCaseFactory actorSecondary
+    class AppCtx actorSecondary
+    class UseCase actorPrimary
+    class ConfigLoader actorSecondary
+    class ProviderLoader actorSecondary
+    class Orchestrator actorPrimary
+    class Pipeline actorPrimary
+
+    User->>CLI: bioetl run activity_chembl --config ... --profile dev --dry-run --limit 100
+    CLI->>CLI: resolve config path (BIOETL_CONFIG_DIR fallback)
+    CLI->>UseCaseFactory: get_use_case_factory()
+    UseCaseFactory->>AppCtx: get_application_context()
+    AppCtx-->>UseCaseFactory: logger, metrics, config_loader
+    UseCaseFactory->>CLI: create_run_pipeline_use_case()
+    UseCaseFactory-->>CLI: RunPipelineUseCase
+
+    CLI->>UseCase: execute(RunPipelineRequest{pipeline_name, profile, dry_run, limit, output_path})
+    UseCase->>ConfigLoader: load config (path or registry) with profile+profiles_root
+    ConfigLoader-->>UseCase: PipelineConfig
+    UseCase->>ProviderLoader: create_provider_loader()
+    UseCase->>Orchestrator: PipelineOrchestrator(..., container_factory, provider_loader_factory)
+    Orchestrator->>Pipeline: build_pipeline(limit)
+    Pipeline-->>Orchestrator: RunResult (dry_run respected)
+    Orchestrator-->>UseCase: RunResult
+    UseCase-->>CLI: RunPipelineResponse(success, row_count, output_path)
+    CLI-->>User: exit code + summary

--- a/docs/diagrams/sequence/manual-di-assembly-sequence.mmd
+++ b/docs/diagrams/sequence/manual-di-assembly-sequence.mmd
@@ -1,0 +1,47 @@
+%%{init: {
+  "theme": "base",
+  "themeVariables":  
+    "actorLineColor": "#444",
+    "actorTextColor": "#111",
+    "actorBkg": "#f5f5f5",
+    "actorFontSize": "18px",
+    "activationBkgColor": "#e3e7ec",
+    "activationBorderColor": "#444"
+  }
+}%%
+%% Shared palette (per diagramming policy)
+classDef actorPrimary   fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px;
+classDef actorSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px;
+classDef actorExternal  fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px;
+linkStyle default stroke:#666,stroke-width:1.2px,color:#111;
+
+sequenceDiagram
+    autonumber
+    participant CLI as CLI command
+    participant Orchestrator as PipelineOrchestrator
+    participant Wiring as Wiring/Interfaces
+    participant Factory as ContainerFactory
+    participant Registry as ABCRegistryResolver
+    participant Container as PipelineContainer
+    participant Pipeline as Pipeline class
+
+    class CLI actorPrimary
+    class Orchestrator actorPrimary
+    class Wiring actorSecondary
+    class Factory actorSecondary
+    class Registry actorSecondary
+    class Container actorSecondary
+    class Pipeline actorPrimary
+
+    CLI->>Orchestrator: run(pipeline_name, cli_args)
+    Orchestrator->>Wiring: build_default_container(config)
+    Wiring->>Factory: build_default_container(config)
+    Factory->>Registry: resolve_default_factory("LoggingPortABC")
+    Registry-->>Factory: UnifiedLogger factory
+    Factory->>Registry: resolve_default_factory("OutputWriterABC")
+    Registry-->>Factory: OutputWriter factory
+    Factory->>Container: instantiate(logger, output_writer, ...)
+    Container-->>Orchestrator: ready container
+    Orchestrator->>Pipeline: instantiate(pipeline_cls, config, container)
+    Orchestrator-->>CLI: ready Pipeline -> run()
+

--- a/docs/diagrams/sequence/pipeline-hooks-sequence.mmd
+++ b/docs/diagrams/sequence/pipeline-hooks-sequence.mmd
@@ -1,0 +1,61 @@
+---
+id: e94a218b-e485-40b2-a8a5-d0fe48f1c8b5
+---
+%%{init: {
+  "theme": "base",
+  "themeVariables": {
+    "actorLineColor": "#444",
+    "actorTextColor": "#111",
+    "actorBkg": "#f5f5f5",
+    "actorFontSize": "18px",
+    "activationBkgColor": "#e3e7ec",
+    "activationBorderColor": "#444"
+  }
+}}%%
+%% Shared palette (per diagramming policy)
+classDef actorPrimary   fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px;
+classDef actorSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px;
+classDef actorExternal  fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px;
+linkStyle default stroke:#666,stroke-width:1.2px,color:#111;
+
+sequenceDiagram
+    autonumber
+    participant Pipeline as PipelineBase
+    participant Logging as LoggingPipelineHookImpl
+    participant Metrics as MetricsPipelineHookImpl
+    participant Logger as UnifiedLogger
+    participant Prom as PrometheusCollector
+
+    class Pipeline actorPrimary
+    class Logging actorSecondary
+    class Metrics actorSecondary
+    class Logger actorSecondary
+    class Prom actorExternal
+
+    Pipeline->>Logging: on_start(run_ctx)
+    Logging->>Logger: info("pipeline.start", ctx)
+    Pipeline->>Metrics: on_start(run_ctx)
+    Metrics->>Prom: observe("pipeline_runs_total", labels={status:"start"})
+
+    loop stages
+        Pipeline->>Logging: on_stage_start(stage, ctx)
+        Logging->>Logger: info("stage.start", stage, entity, run_id)
+        Pipeline->>Metrics: on_stage_start(stage, ctx)
+        Metrics->>Prom: observe("pipeline_stage_active", labels={stage})
+        Pipeline->>Logging: on_stage_end(stage, ctx)
+        Logging->>Logger: info("stage.finish", duration, records)
+        Pipeline->>Metrics: on_stage_end(stage, ctx)
+        Metrics->>Prom: observe("pipeline_stage_duration_seconds", value=duration)
+    end
+
+    alt error occurs
+        Pipeline->>Logging: on_error(stage, exc, ctx)
+        Logging->>Logger: error("pipeline.error", stage, exc)
+        Pipeline->>Metrics: on_error(stage, ctx)
+        Metrics->>Prom: observe("pipeline_runs_total", labels={status:"error"})
+    else success
+        Pipeline->>Logging: on_finish(success=True, stats)
+        Logging->>Logger: info("pipeline.finish", duration, rows)
+        Pipeline->>Metrics: on_finish(success=True)
+        Metrics->>Prom: observe("pipeline_runs_total", labels={status:"success"})
+    end

--- a/docs/diagrams/sequence/pipeline-run-sequence.mmd
+++ b/docs/diagrams/sequence/pipeline-run-sequence.mmd
@@ -1,0 +1,113 @@
+---
+id: cb06bc9f-659f-4f94-a2ed-9c6d765fe51f
+---
+%%{init: {
+  "theme": "base",
+  "themeVariables": {
+    "actorLineColor": "#444",
+    "actorTextColor": "#111",
+    "actorBkg": "#f5f5f5",
+    "actorBorderRadius": 6,
+    "actorFontSize": "18px",
+    "sequenceNumberColor": "#444",
+    "activationBkgColor": "#e3e7ec",
+    "activationBorderColor": "#444"
+  }
+}}%%
+%% Shared palette (per diagramming policy)
+classDef actorPrimary   fill:#f5f5f5,stroke:#444,stroke-width:1.5px,color:#111,font-size:22px;
+classDef actorSecondary fill:#e3e7ec,stroke:#555,stroke-width:1.2px,color:#111,font-size:18px;
+classDef actorExternal  fill:#dde7f2,stroke:#44546a,stroke-width:1.5px,color:#111,font-size:22px;
+linkStyle default stroke:#666,stroke-width:1.2px,color:#111;
+
+sequenceDiagram
+    autonumber
+
+    participant CLI as CLI/REST (Typer/FastAPI)
+    participant UseCase as RunPipelineUseCase
+    participant ConfigLoader as PipelineConfigLoader
+    participant ProviderLoader as ProviderRegistryLoader
+    participant Orchestrator as PipelineOrchestrator
+    participant ContainerFactory as PipelineContainerFactory
+    participant PipelineFactory as PipelineFactory (registry)
+    participant Pipeline as ChemblPipelineBase
+    participant Executor as PipelineExecutor
+    participant Runtime as StageRuntimeManager
+    participant Extractor as ExtractStage/ChemblExtractionServiceImpl
+    participant Transformer as ChemblTransformerImpl
+    participant PostTransform as TransformerChainImpl
+    participant Validator as ValidationService + PanderaValidator
+    participant Loader as UnifiedLoaderImpl
+    participant AtomicIO as AtomicFileOperation
+    participant Storage as Deterministic Storage
+
+    class CLI actorPrimary
+    class UseCase actorPrimary
+    class ConfigLoader actorSecondary
+    class ProviderLoader actorSecondary
+    class Orchestrator actorPrimary
+    class ContainerFactory actorSecondary
+    class PipelineFactory actorSecondary
+    class Pipeline actorPrimary
+    class Executor actorPrimary
+    class Runtime actorSecondary
+    class Extractor actorSecondary
+    class Transformer actorSecondary
+    class PostTransform actorSecondary
+    class Validator actorSecondary
+    class Loader actorPrimary
+    class AtomicIO actorSecondary
+    class Storage actorExternal
+
+    CLI->>UseCase: execute(request)
+    UseCase->>ConfigLoader: load config (id/path, profile)
+    ConfigLoader-->>UseCase: PipelineConfig
+    UseCase->>ProviderLoader: get_registry()
+    ProviderLoader-->>UseCase: ProviderRegistry
+    UseCase->>Orchestrator: init(pipeline_id, config, container_factory, registry)
+    Orchestrator->>PipelineFactory: resolve factory by pipeline id
+    PipelineFactory-->>Orchestrator: ChemblPipelineFactory
+    Orchestrator->>ContainerFactory: build_default_container(config, registry)
+    ContainerFactory-->>Orchestrator: PipelineContainer
+    Orchestrator->>PipelineFactory: create(container, limit)
+    PipelineFactory-->>Orchestrator: ChemblPipelineBase
+    Orchestrator->>Pipeline: run(dry_run, limit, output_path)
+
+    activate Pipeline
+    Pipeline->>Executor: execute(self, output_path, dry_run)
+    activate Executor
+    Executor->>Runtime: reset() + set_logger(run_id)
+    Runtime->>Runtime: notify_stage_start("extract")
+
+    loop Extract -> Transform -> Validate
+        Executor->>Extractor: extract(limit)
+        Extractor-->>Executor: batch_df
+        Executor->>Transformer: apply(batch_df)
+        Transformer-->>Executor: transformed_df
+        Executor->>PostTransform: hash + index + db_version + fulldate
+        PostTransform-->>Executor: normalized_df
+        Executor->>Validator: validate(normalized_df, schema)
+        Validator-->>Executor: validated_df
+        Executor->>Runtime: record counters + hooks
+    end
+
+    alt dry_run
+        Runtime->>Runtime: notify_stage_start("write") (skipped)
+    else
+        Runtime->>Runtime: notify_stage_start("write")
+        Executor->>Loader: load(all_validated_df, output_path, context)
+        Loader->>AtomicIO: write_atomic(data.csv) + checksum + meta + QC
+        AtomicIO-->>Loader: persisted
+        Loader-->>Storage: deterministic files + sidecars
+        Runtime->>Runtime: notify_stage_end("write")
+    end
+
+    Executor-->>Runtime: stage results + last errors
+    Runtime-->>Executor: error policy decisions
+    Executor-->>Pipeline: RunResult(meta, counters, duration)
+    deactivate Executor
+    Pipeline-->>UseCase: RunResult
+    deactivate Pipeline
+    UseCase-->>CLI: RunPipelineResponse
+
+    Note over Runtime,Executor: StageRuntimeManager applies ErrorPolicy and HookNotifier on every stage (retry/skip/fail).


### PR DESCRIPTION
Add 53 new Mermaid diagrams for better understanding of the BioETL architecture:

Package diagrams (16 new):
- Domain: aggregates, observability, output, pipelines
- Application: files, helpers, metadata, ports, providers, runtime, transform
- Infrastructure: chembl, http, observability, settings
- Interfaces: monitoring

Consolidated from docs/architecture/diagrams (37 diagrams):
- Component diagrams (11): layer components, system context, hexagonal arch
- Flow diagrams (17): data flow, CI workflow, error handling, pagination
- Sequence diagrams (5): CLI, pipeline, API request sequences

Updated diagram index with complete catalog of 100+ diagrams organized by:
- Overview (4), Layers (4), Packages (43), Classes (14)
- Component (11), Flow (17), Sequence (5)