### PR TITLE
Add registry synchronization check and documentation updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,3 +59,9 @@ print('\n'.join(bad)) or sys.exit(1) if bad else sys.exit(0)"
       pass_filenames: false
       files: ^src/bioetl/infrastructure/
 
+    - id: check-registry-sync
+      name: check registry synchronization
+      entry: python src/tools/check_registry_sync.py
+      language: python
+      pass_filenames: false
+

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ BioETL is a data processing framework for acquiring, normalizing, and validating
 - Установить хуки: `pre-commit install`
 - Прогнать форматирование и линтеры: `pre-commit run --all-files` (ruff, black, isort, mypy, import-linter)
 - Запустить архитектурный тест: `pytest tests/architecture/test_layer_dependencies.py`
+- Проверить синхронизацию реестров и INDEX.md: `python src/tools/check_registry_sync.py`
 - Полный цикл lint/type-check в CI: ruff → black --check → isort --check-only → mypy → архитектурные тесты → import-linter
 
 ## Запуск тестов

--- a/docs/01-ABC/INDEX.md
+++ b/docs/01-ABC/INDEX.md
@@ -1,13 +1,80 @@
 # ABC Index
 <!-- generated -->
 
-- `NormalizationServiceABC` — `bioetl.domain.transform.contracts.NormalizationServiceABC`
-  - Normalization service contract for DataFrame/record pipelines. Default factory: `bioetl.infrastructure.transform.factories.default_normalization_service`. Implementations: `DefaultNormalizationTransformerImpl`, `ChemblNormalizationServiceImpl`.
-- `HashServiceABC` — `bioetl.domain.transform.contracts.HashServiceABC`
-  - Facade for deterministic hash columns; default factory: `bioetl.infrastructure.transform.factories.default_hash_service`. Implementation: `bioetl.domain.transform.hash_service.HashService`.
-- `ProviderRegistryABC` — `bioetl.domain.provider_registry.ProviderRegistryABC`
-  - Read/write port for provider definitions consumed by orchestrator and containers (wired explicitly; no global singleton).
+- `DataClientABC` — `bioetl.domain.clients.contracts.DataClientABC`
+  - Universal data source client contract. Supports extraction of arbitrary entities through a unified ``fetch`` method with filters, as well as side operations (pagination, metadata, resource release).
+
+- `RequestBuilderABC` — `bioetl.domain.clients.base.contracts.RequestBuilderABC`
+  - Builder pattern for request creation. This ABC provides a fluent interface for constructing API requests. Implementations should support endpoint configuration and pagination. Note: Consider using :class:`bioetl.domain.ports.request_building.RequestBuilderPortABC` for new code - it provides a cleaner port-based contract.
+
+- `ResponseParserPortABC` — `bioetl.domain.ports.parsing.ResponseParserPortABC`
+  - Port for parsing raw API responses without domain model knowledge. This abstract base class defines the contract for parsing raw API responses into generic record dictionaries. Implementations in infrastructure layer can parse provider-specific response formats while domain layer remains decoupled from those details. Type Parameters: RecordT: The type of records returned by parse_to_records. Defaults to RawRecord (dict[str, Any]) for untyped parsing. Example: >>> # Untyped parser (default) >>> class ChemblParserAdapter(ResponseParserPortABC): ... def parse_to_records(self, raw_response): ... # Extract records from ChEMBL-specific response structure ... for key, value in raw_response.items(): ... if isinstance(value, list): ... return value ... return [] ... ... def extract_pagination(self, raw_response): ... return raw_response.get("page_meta", {}) >>> # Typed parser with Pydantic model >>> class TypedParser(ResponseParserPortABC[MyModel]): ... def parse_to_records(self, raw_response) -> list[MyModel]: ... return [MyModel(**r) for r in raw_response.get("items", [])] ... ... def extract_pagination(self, raw_response): ... return raw_response.get("meta", {})
+
+- `PaginatorABC` — `bioetl.domain.clients.base.contracts.PaginatorABC`
+  - Pagination strategy.
+
+- `RateLimiterABC` — `bioetl.domain.clients.base.contracts.RateLimiterABC`
+  - Request rate limiting.
+
+- `CacheABC` — `bioetl.domain.clients.base.contracts.CacheABC`
+  - Caching interface.
+
+- `SecretProviderABC` — `bioetl.domain.clients.base.contracts.SecretProviderABC`
+  - Secret provider (env, vault).
+
+- `PipelineContainerABC` — `bioetl.application.contracts.PipelineContainerABC`
+  - Dependency container contract for assembling pipelines. Provides factories for core pipeline services, including logging, validation, extraction, normalization, record sourcing, hashing, post-transformation, hooks, and error handling.
+
+- `PipelineHookABC` — `bioetl.domain.pipelines.contracts.PipelineHookABC`
+  - Pipeline lifecycle hooks.
+
+- `ErrorPolicyABC` — `bioetl.domain.pipelines.contracts.ErrorPolicyABC`
+  - Error handling policy.
+
+- `LoaderABC` — `bioetl.domain.pipelines.contracts.LoaderABC`
+  - Component responsible for loading data to destination. Uses domain-level TabularData abstraction for input data.
+
 - `ProviderRegistryLoaderABC` — `bioetl.domain.provider_registry.ProviderRegistryLoaderABC`
-  - Loader port for provider registries used by `PipelineOrchestrator` background execution. Default factory: `bioetl.infrastructure.config.provider_registry.default_provider_registry_loader`. Implementation: `ProviderRegistryLoader`.
-- `PipelineContainerABC` — `bioetl.application.pipelines.contracts.PipelineContainerABC`
-  - Dependency container port for orchestrating pipeline assembly (logger, validation, output writer, extractor, normalization, hash, hooks, error policy).
+  - Protocol for provider registry loader.
+
+- `ProviderRegistryABC` — `bioetl.domain.provider_registry.ProviderRegistryABC`
+  - Abstract base class for provider registry.
+
+- `ProgressReporterABC` — `bioetl.domain.observability.contracts.ProgressReporterABC`
+  - Progress reporting interface. Concrete implementation is selected by infrastructure and bound to the container.
+
+- `LoggingPortABC` — `bioetl.domain.observability.contracts.LoggingPortABC`
+  - Port describing structured logging operations.
+
+- `TracingPortABC` — `bioetl.domain.observability.contracts.TracingPortABC`
+  - Port describing distributed tracing operations. Experimental: not yet integrated into main pipeline flow.
+
+- `HasherABC` — `bioetl.domain.transform.contracts.HasherABC`
+  - Low-level hashing abstraction. Provides primitive hashing operations used by HashServiceABC. Uses domain-level Record and TabularData instead of pandas types. Infrastructure implementations can work with pandas internally. Note: This is an internal abstraction. Prefer HashServiceABC for domain code.
+
+- `HashServiceABC` — `bioetl.domain.transform.contracts.HashServiceABC`
+  - Stateless service for computing deterministic hashes. Responsible for computing and adding hash columns to data. Does not contain stateful logic (indices, timestamps). Terminology (see module docstring for full mapping): fingerprint: Computes record_hash - hash of entire record. entity_key: Computes business_key_hash - hash of business key fields. Output columns (schema layer): hash_row: Contains the record_hash (fingerprint result). hash_business_key: Contains the business_key_hash (entity_key result). Example: >>> service: HashServiceABC = get_hash_service() >>> digest = service.compute_fingerprint({"id": 1, "name": "test"}) >>> print(digest.value) # hex string
+
+- `TimestampProviderABC` — `bioetl.domain.transform.contracts.TimestampProviderABC`
+  - Timestamp provider for data extraction. Provides deterministic timestamp within a session.
+
+- `IndexGeneratorABC` — `bioetl.domain.transform.contracts.IndexGeneratorABC`
+  - Sequential index generator for data rows. Stateful: maintains counter value between calls.
+
+- `NormalizationServiceABC` — `bioetl.domain.transform.contracts.NormalizationServiceABC`
+  - Data normalization service. Provides batch and record-level normalization operations. Uses domain-level TabularData abstraction.
+
+- `SchemaProviderABC` — `bioetl.domain.validation.contracts.SchemaProviderABC`
+  - Data schema provider (technology-agnostic).
+
+- `ValidatorFactoryABC` — `bioetl.domain.validation.contracts.ValidatorFactoryABC`
+  - Factory for schema-specific validators.
+
+- `SchemaProviderFactoryABC` — `bioetl.domain.validation.contracts.SchemaProviderFactoryABC`
+  - Factory for schema providers.
+
+- `QualityReportABC` — `bioetl.domain.clients.base.output.contracts.QualityReportABC`
+  - QC report generator port. Uses domain-level TabularData abstraction.
+
+- `OutputFrameConverterABC` — `bioetl.domain.clients.base.output.contracts.OutputFrameConverterABC`
+  - Tabular data converter for post-processing before write. Uses domain-level TabularData abstraction.

--- a/docs/ABC_INDEX.md
+++ b/docs/ABC_INDEX.md
@@ -2,94 +2,79 @@
 <!-- generated -->
 
 - `DataClientABC` — `bioetl.domain.clients.contracts.DataClientABC`
-  - Базовый контракт клиента источника данных.
+  - Universal data source client contract. Supports extraction of arbitrary entities through a unified ``fetch`` method with filters, as well as side operations (pagination, metadata, resource release).
 
 - `RequestBuilderABC` — `bioetl.domain.clients.base.contracts.RequestBuilderABC`
-  - Паттерн Builder для создания запросов.
-
-- `ResponseParserABC` — `bioetl.domain.clients.base.contracts.ResponseParserABC`
-  - Разбор ответов API.
+  - Builder pattern for request creation. This ABC provides a fluent interface for constructing API requests. Implementations should support endpoint configuration and pagination. Note: Consider using :class:`bioetl.domain.ports.request_building.RequestBuilderPortABC` for new code - it provides a cleaner port-based contract.
 
 - `ResponseParserPortABC` — `bioetl.domain.ports.parsing.ResponseParserPortABC`
-  - Порт для парсинга сырых ответов API без знания доменных моделей. Реализации в infrastructure слое парсят provider-specific форматы ответов, в то время как domain слой остается независимым от этих деталей.
+  - Port for parsing raw API responses without domain model knowledge. This abstract base class defines the contract for parsing raw API responses into generic record dictionaries. Implementations in infrastructure layer can parse provider-specific response formats while domain layer remains decoupled from those details. Type Parameters: RecordT: The type of records returned by parse_to_records. Defaults to RawRecord (dict[str, Any]) for untyped parsing. Example: >>> # Untyped parser (default) >>> class ChemblParserAdapter(ResponseParserPortABC): ... def parse_to_records(self, raw_response): ... # Extract records from ChEMBL-specific response structure ... for key, value in raw_response.items(): ... if isinstance(value, list): ... return value ... return [] ... ... def extract_pagination(self, raw_response): ... return raw_response.get("page_meta", {}) >>> # Typed parser with Pydantic model >>> class TypedParser(ResponseParserPortABC[MyModel]): ... def parse_to_records(self, raw_response) -> list[MyModel]: ... return [MyModel(**r) for r in raw_response.get("items", [])] ... ... def extract_pagination(self, raw_response): ... return raw_response.get("meta", {})
 
 - `PaginatorABC` — `bioetl.domain.clients.base.contracts.PaginatorABC`
-  - Стратегия пагинации.
+  - Pagination strategy.
 
 - `RateLimiterABC` — `bioetl.domain.clients.base.contracts.RateLimiterABC`
-  - Ограничение частоты запросов.
-
-- `RetryPolicyABC` — `bioetl.domain.clients.base.contracts.RetryPolicyABC`
-  - Политика повторных попыток.
+  - Request rate limiting.
 
 - `CacheABC` — `bioetl.domain.clients.base.contracts.CacheABC`
-  - Интерфейс кэширования.
+  - Caching interface.
 
 - `SecretProviderABC` — `bioetl.domain.clients.base.contracts.SecretProviderABC`
-  - Поставщик секретов (env, vault).
+  - Secret provider (env, vault).
 
-- `SideInputProviderABC` — `bioetl.domain.clients.base.contracts.SideInputProviderABC`
-  - Провайдер побочных данных (справочников).
-
-- `ProviderRegistryLoaderABC` — `bioetl.domain.provider_registry.ProviderRegistryLoaderABC`
-  - Загрузчик реестра провайдеров из конфигурации. Default factory: ``bioetl.infrastructure.config.provider_registry.default_provider_registry_loader``. Implementations: ``ProviderRegistryLoader``.
-
-- `PipelineContainerABC` — `bioetl.application.pipelines.contracts.PipelineContainerABC`
-  - Контейнер пайплайна.
+- `PipelineContainerABC` — `bioetl.application.contracts.PipelineContainerABC`
+  - Dependency container contract for assembling pipelines. Provides factories for core pipeline services, including logging, validation, extraction, normalization, record sourcing, hashing, post-transformation, hooks, and error handling.
 
 - `PipelineHookABC` — `bioetl.domain.pipelines.contracts.PipelineHookABC`
-  - Хуки жизненного цикла пайплайна.
+  - Pipeline lifecycle hooks.
 
 - `ErrorPolicyABC` — `bioetl.domain.pipelines.contracts.ErrorPolicyABC`
-  - Политика обработки ошибок.
-
-- `CLICommandABC` — `bioetl.interfaces.cli.contracts.CLICommandABC`
-  - Интерфейс команды CLI.
-
-- `ProviderRegistryABC` — `bioetl.domain.provider_registry.ProviderRegistryABC`
-  - Порт для чтения и регистрации определений провайдеров (подключается явно без глобального singleton).
-
-- `LoggingPortABC` — `bioetl.domain.observability.contracts.LoggingPortABC`
-  - Порт структурированного логгирования. Default factory: ``bioetl.infrastructure.observability.factories.default_logging_port``. Implementations: ``StructuredLoggerImpl``.
-
-- `ProgressReporterABC` — `bioetl.domain.observability.contracts.ProgressReporterABC`
-  - Интерфейс отчетности о прогрессе. Default factory: ``bioetl.infrastructure.logging.factories.default_progress_reporter``. Implementations: ``TqdmProgressReporterImpl``.
-
-- `TracingPortABC` — `bioetl.domain.observability.contracts.TracingPortABC`
-  - Порт для распределенной трассировки. Default factory: ``bioetl.infrastructure.observability.factories.default_tracing_port``. Implementations: ``TracingAdapterImpl``.
-
-- `HasherABC` — `bioetl.domain.transform.contracts.HasherABC`
-  - Хеширование строк.
-
-- `HashServiceABC` — `bioetl.domain.transform.contracts.HashServiceABC`
-  - Фасад для вычисления hash_row/hash_business_key и служебных колонок. Default factory: `bioetl.infrastructure.transform.factories.default_hash_service`. Implementation: `bioetl.domain.transform.hash_service.HashService`.
-
-- `TimestampProviderABC` — `bioetl.domain.transform.contracts.TimestampProviderABC`
-  - Провайдер временных меток для детерминированных артефактов.
-
-- `IndexGeneratorABC` — `bioetl.domain.transform.contracts.IndexGeneratorABC`
-  - Генератор индексов для строк данных.
-
-- `NormalizationServiceABC` — `bioetl.domain.transform.contracts.NormalizationServiceABC`
-  - Сервис нормализации данных. Обязательные операции: normalize(df), normalize_record(record), ensure_numeric_columns(df). Default factory: ``bioetl.infrastructure.transform.factories.default_normalization_service``. Implementations: ``DefaultNormalizationTransformerImpl``, ``ChemblNormalizationServiceImpl``.
-
-- `ValidatorABC` — `bioetl.domain.validation.contracts.ValidatorABC`
-  - Валидация данных. Default factory: ``bioetl.infrastructure.validation.factories.default_validator_factory``. Implementations: ``PanderaValidatorImpl`` (`bioetl.infrastructure.validation.impl.pandera_validator`).
-
-- `SchemaProviderABC` — `bioetl.domain.validation.contracts.SchemaProviderABC`
-  - Провайдер схем данных. Default factory: ``bioetl.infrastructure.validation.factories.default_schema_provider_factory``. Implementations: ``SchemaRegistry`` (`bioetl.domain.schemas.registry.SchemaRegistry`).
-
-- `ValidatorFactoryABC` — `bioetl.domain.validation.contracts.ValidatorFactoryABC`
-  - Фабрика валидаторов под конкретную схему. Default factory: ``bioetl.infrastructure.validation.factories.default_validator_factory``. Implementations: ``PanderaValidatorFactory``.
-
-- `SchemaProviderFactoryABC` — `bioetl.domain.validation.contracts.SchemaProviderFactoryABC`
-  - Фабрика провайдеров схем. Default factory: ``bioetl.infrastructure.validation.factories.default_schema_provider_factory``. Implementations: ``PanderaSchemaProviderFactory``.
-
-- `QualityReportABC` — `bioetl.domain.clients.base.output.contracts.QualityReportABC`
-  - Порт генератора QC-отчетов.
-
-- `OutputFrameConverterABC` — `bioetl.domain.clients.base.output.contracts.OutputFrameConverterABC`
-  - DataFrame → DataFrame конвертер для пост-обработки перед записью. Default factory: ``bioetl.infrastructure.output.converters.factories.default_output_frame_converter``. Implementations: ``NoopConverter``, ``RenameColumnsConverter``, ``DropNaRowsConverter``.
+  - Error handling policy.
 
 - `LoaderABC` — `bioetl.domain.pipelines.contracts.LoaderABC`
-  - Компонент записи артефактов пайплайна (данные, метаданные, QC).
+  - Component responsible for loading data to destination. Uses domain-level TabularData abstraction for input data.
+
+- `ProviderRegistryLoaderABC` — `bioetl.domain.provider_registry.ProviderRegistryLoaderABC`
+  - Protocol for provider registry loader.
+
+- `ProviderRegistryABC` — `bioetl.domain.provider_registry.ProviderRegistryABC`
+  - Abstract base class for provider registry.
+
+- `ProgressReporterABC` — `bioetl.domain.observability.contracts.ProgressReporterABC`
+  - Progress reporting interface. Concrete implementation is selected by infrastructure and bound to the container.
+
+- `LoggingPortABC` — `bioetl.domain.observability.contracts.LoggingPortABC`
+  - Port describing structured logging operations.
+
+- `TracingPortABC` — `bioetl.domain.observability.contracts.TracingPortABC`
+  - Port describing distributed tracing operations. Experimental: not yet integrated into main pipeline flow.
+
+- `HasherABC` — `bioetl.domain.transform.contracts.HasherABC`
+  - Low-level hashing abstraction. Provides primitive hashing operations used by HashServiceABC. Uses domain-level Record and TabularData instead of pandas types. Infrastructure implementations can work with pandas internally. Note: This is an internal abstraction. Prefer HashServiceABC for domain code.
+
+- `HashServiceABC` — `bioetl.domain.transform.contracts.HashServiceABC`
+  - Stateless service for computing deterministic hashes. Responsible for computing and adding hash columns to data. Does not contain stateful logic (indices, timestamps). Terminology (see module docstring for full mapping): fingerprint: Computes record_hash - hash of entire record. entity_key: Computes business_key_hash - hash of business key fields. Output columns (schema layer): hash_row: Contains the record_hash (fingerprint result). hash_business_key: Contains the business_key_hash (entity_key result). Example: >>> service: HashServiceABC = get_hash_service() >>> digest = service.compute_fingerprint({"id": 1, "name": "test"}) >>> print(digest.value) # hex string
+
+- `TimestampProviderABC` — `bioetl.domain.transform.contracts.TimestampProviderABC`
+  - Timestamp provider for data extraction. Provides deterministic timestamp within a session.
+
+- `IndexGeneratorABC` — `bioetl.domain.transform.contracts.IndexGeneratorABC`
+  - Sequential index generator for data rows. Stateful: maintains counter value between calls.
+
+- `NormalizationServiceABC` — `bioetl.domain.transform.contracts.NormalizationServiceABC`
+  - Data normalization service. Provides batch and record-level normalization operations. Uses domain-level TabularData abstraction.
+
+- `SchemaProviderABC` — `bioetl.domain.validation.contracts.SchemaProviderABC`
+  - Data schema provider (technology-agnostic).
+
+- `ValidatorFactoryABC` — `bioetl.domain.validation.contracts.ValidatorFactoryABC`
+  - Factory for schema-specific validators.
+
+- `SchemaProviderFactoryABC` — `bioetl.domain.validation.contracts.SchemaProviderFactoryABC`
+  - Factory for schema providers.
+
+- `QualityReportABC` — `bioetl.domain.clients.base.output.contracts.QualityReportABC`
+  - QC report generator port. Uses domain-level TabularData abstraction.
+
+- `OutputFrameConverterABC` — `bioetl.domain.clients.base.output.contracts.OutputFrameConverterABC`
+  - Tabular data converter for post-processing before write. Uses domain-level TabularData abstraction.

--- a/src/tools/check_registry_sync.py
+++ b/src/tools/check_registry_sync.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import re
+import sys
+from typing import Iterable, Mapping
+
+import yaml
+
+
+def _find_project_root(start: Path) -> Path:
+    current = start.resolve()
+    for candidate in [current, *current.parents]:
+        if (candidate / "pyproject.toml").exists() or (candidate / ".git").exists():
+            return candidate
+    return current
+
+
+def _read_yaml_mapping(path: Path) -> Mapping[str, object]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, Mapping):
+        raise ValueError(f"Expected mapping in {path}")
+    return data
+
+
+def _parse_index_entries(text: str) -> set[str]:
+    pattern = re.compile(r"^- `([^`]+)`", flags=re.MULTILINE)
+    return set(pattern.findall(text))
+
+
+def _iter_pipeline_config_names(config_root: Path) -> set[str]:
+    names: set[str] = set()
+    for path in config_root.rglob("*.yaml"):
+        payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        pipeline = payload.get("pipeline") or {}
+        name = pipeline.get("name")
+        if name:
+            names.add(str(name))
+    return names
+
+
+@dataclass
+class SectionResult:
+    title: str
+    missing: list[str]
+    unused: list[str]
+
+    @property
+    def has_issues(self) -> bool:
+        return bool(self.missing or self.unused)
+
+    def render(self) -> str:
+        missing = ", ".join(self.missing) if self.missing else "none"
+        unused = ", ".join(self.unused) if self.unused else "none"
+        return f"- {self.title}: missing=[{missing}], unused=[{unused}]"
+
+
+@dataclass
+class RegistrySyncReport:
+    sections: list[SectionResult]
+
+    @property
+    def has_issues(self) -> bool:
+        return any(section.has_issues for section in self.sections)
+
+    def render(self) -> str:
+        lines = ["Registry sync report:"]
+        lines.extend(section.render() for section in self.sections)
+        return "\n".join(lines)
+
+
+def _compare_sets(title: str, expected: Iterable[str], actual: Iterable[str]) -> SectionResult:
+    expected_set = set(expected)
+    actual_set = set(actual)
+    missing = sorted(expected_set - actual_set)
+    unused = sorted(actual_set - expected_set)
+    return SectionResult(title=title, missing=missing, unused=unused)
+
+
+def build_sync_report() -> RegistrySyncReport:
+    root = _find_project_root(Path(__file__))
+    sys.path.insert(0, str(root / "src"))
+
+    registry_path = root / "src/bioetl/infrastructure/clients/base/abc_registry.yaml"
+    impl_paths = [
+        root / "src/bioetl/infrastructure/clients/base/abc_impls.yaml",
+        root / "src/bioetl/interfaces/abc_impls_application.yaml",
+    ]
+    index_paths = [root / "docs/ABC_INDEX.md", root / "docs/01-ABC/INDEX.md"]
+    config_root = root / "configs/pipelines"
+
+    from bioetl.application.pipelines.registry import PIPELINE_REGISTRY
+
+    registry_names = _read_yaml_mapping(registry_path).keys()
+
+    impl_names: set[str] = set()
+    for path in impl_paths:
+        impl_names.update(_read_yaml_mapping(path).keys())
+    pipeline_registry_names = PIPELINE_REGISTRY.keys()
+    pipeline_config_names = _iter_pipeline_config_names(config_root)
+
+    sections: list[SectionResult] = [
+        _compare_sets(
+            "abc_impls.yaml vs abc_registry.yaml",
+            expected=registry_names,
+            actual=impl_names,
+        ),
+    ]
+
+    for path in index_paths:
+        index_names = _parse_index_entries(path.read_text(encoding="utf-8"))
+        sections.append(
+            _compare_sets(
+                f"{path.relative_to(root)} vs abc_registry.yaml",
+                expected=registry_names,
+                actual=index_names,
+            )
+        )
+
+    sections.append(
+        _compare_sets(
+            "pipeline configs vs application registry",
+            expected=pipeline_registry_names,
+            actual=pipeline_config_names,
+        )
+    )
+
+    return RegistrySyncReport(sections=sections)
+
+
+def main() -> int:
+    report = build_sync_report()
+    print(report.render())
+    return 1 if report.has_issues else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tools/generate_abc_index.py
+++ b/src/tools/generate_abc_index.py
@@ -21,7 +21,10 @@ def _find_project_root(start: Path) -> Path:
 ROOT = _find_project_root(Path(__file__))
 SRC_DIR = ROOT / "src"
 REGISTRY_PATH = ROOT / "src/bioetl/infrastructure/clients/base/abc_registry.yaml"
-OUTPUT_PATH = ROOT / "docs/ABC_INDEX.md"
+OUTPUT_PATHS = (
+    ROOT / "docs/ABC_INDEX.md",
+    ROOT / "docs/01-ABC/INDEX.md",
+)
 
 
 def load_registry(path: Path) -> dict[str, str]:
@@ -80,7 +83,8 @@ def generate_index() -> None:
         entries.append((name, target, description))
 
     content = "\n".join(build_lines(entries)).rstrip() + "\n"
-    write_atomic(OUTPUT_PATH, content)
+    for path in OUTPUT_PATHS:
+        write_atomic(path, content)
 
 
 if __name__ == "__main__":

--- a/tests/documentation/test_registry_sync.py
+++ b/tests/documentation/test_registry_sync.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from tools.check_registry_sync import build_sync_report
+
+
+def test_registry_and_docs_are_in_sync() -> None:
+    report = build_sync_report()
+    assert not report.has_issues, report.render()


### PR DESCRIPTION
## Summary
- add a registry sync checker covering ABC registries, pipeline registry, and ABC index documents
- integrate the new check into pre-commit and developer documentation
- regenerate ABC index files from the registry

## Testing
- pytest tests/documentation/test_registry_sync.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b19365be4832481f8949180c4f7be)