### PR TITLE
Add ChEMBL pipeline documentation and index updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,6 @@ npm run test:coverage
 
 ### Пайплайны по провайдерам
 
-- [ChEMBL Pipelines](docs/02-pipelines/chembl/00-index.md) — Activity, Assay, Target, Document, Molecule
+- [ChEMBL Pipelines](docs/02-pipelines/chembl/00-index.md) — Activity, Assay, Target, Publication, Molecule
 
 Детальная документация по конкретным пайплайнам и компонентам доступна через соответствующие INDEX.md файлы.

--- a/docs/02-pipelines/00-index.md
+++ b/docs/02-pipelines/00-index.md
@@ -1,5 +1,5 @@
 # Index
 <!-- generated -->
-
 - [01 Pipeline Core Normalization](01-pipeline-core-normalization.md) — normalization service contracts, factories, and provider-specific implementations.
 - [02 Pipeline Core Provider Registry](02-pipeline-core-provider-registry.md) — provider registry loader port, orchestrator integration, and default factories.
+- [Chembl Pipelines](chembl/00-index.md) — entity-level flows for activity, assay, target, publication, and molecule pipelines.

--- a/docs/02-pipelines/chembl/00-index.md
+++ b/docs/02-pipelines/chembl/00-index.md
@@ -1,0 +1,7 @@
+# 00 Index
+<!-- generated -->
+- [01 Activity Chembl Overview](01-activity-chembl-overview.md) — Extract→transform→validate→export path for `chembl.activity` with deterministic hashing and timestamp enrichment.
+- [02 Assay Chembl Overview](02-assay-chembl-overview.md) — Assay pipeline flow covering API, CSV, and ID-only modes and schema-backed column order.
+- [03 Target Chembl Overview](03-target-chembl-overview.md) — Target pipeline wiring with filter enrichment, nested field serialization, and validation steps.
+- [04 Publication Chembl Overview](04-publication-chembl-overview.md) — Publication/document pipeline stages, required keys, and QC metadata outputs.
+- [05 Molecule Chembl Overview](05-molecule-chembl-overview.md) — Molecule pipeline sequence including structure serialization and schema enforcement.

--- a/docs/02-pipelines/chembl/01-activity-chembl-overview.md
+++ b/docs/02-pipelines/chembl/01-activity-chembl-overview.md
@@ -1,0 +1,32 @@
+# 01 Activity Chembl Overview
+
+## Overview
+
+- Pipeline ID `chembl.activity` is configured in `configs/pipelines/chembl/activity.yaml` with `entity: activity`, primary key `activity_id`, `input_mode: id_only`, and `serialization_mode: pipe` for nested structures.
+- Pipelines are instantiated by `ChemblPipelineFactory`, which builds `ChemblPipelineBase` with provider-specific extraction, normalization, validation, hashing, and loader wiring from the pipeline container.
+- Primary key resolution uses `resolve_primary_key_with_filter`, yielding the API filter `activity_id__in` for batching and file-based ID expansion.
+
+## Flow: extract → transform → validate → export
+
+1. **Extract**: `ChemblPipelineBase` wires an `ExtractStage` that uses `ChemblExtractionServiceImpl` (via the provider) and `ChemblRecordMapper` to stream raw ChEMBL payloads into DataFrames. `RecordSourceResolver` switches between API mode and file-backed sources (`CsvRecordSourceImpl` or `IdListRecordSourceImpl`) based on `input_mode`, applying the `activity_id__in` filter for batched lookups.
+2. **Transform**: `ChemblTransformerImpl` runs pre-transform hooks (no-op), normalizes fields through the injected `NormalizationServiceABC` (Chembl flavor), serializes nested lists/dicts with `serialize_nested` using the configured `pipe` mode, enforces contract column order, and drops rows missing required non-generated columns. The default post-transformer then adds `hash_row`, `hash_business_key`, `index`, timestamps, and source version metadata.
+3. **Validate**: `ValidationService` checks the output against the pipeline contract, aligning columns to `ACTIVITY_OUTPUT_COLUMNS` and ensuring Pandera constraints (types, nullable flags, ranges) defined for the ChEMBL activity schema.
+4. **Export**: The injected `LoaderABC` writes normalized, validated batches to `output_path`, while the metadata builder attaches `chembl_release` and the last endpoint used from `ChemblPipelineBase._enrich_context`.
+
+## Inputs and outputs
+
+- **Inputs**: `api` (default streaming), `csv` (structured rows read via `CsvRecordSourceImpl`), or `id_only` (ID list expanded via API using `activity_id__in`). Provider config supplies base URL, pagination, and retry limits.
+- **Outputs**: Ordered activity table columns plus generated metadata fields, deterministic serialization for arrays/objects, and `meta.yaml` entries populated with release/version context.
+
+## Ports and adapters
+
+- `ExtractionServiceABC` → `ChemblExtractionServiceImpl` with request builder, retry-aware client, and version lookup.
+- `NormalizationServiceABC` → provider factory builds Chembl normalization service used inside `ChemblTransformerImpl`.
+- `EntityModelRegistryABC` feeds `ChemblRecordMapper` for consistent field mapping.
+- `LoaderABC` + `RunMetadataBuilderProtocol` handle output persistence and metadata sidecars.
+- Record sources: `CsvRecordSourceImpl` and `IdListRecordSourceImpl` adapt CSV/ID-list inputs to the extraction port.
+
+## Schemas
+
+- Raw payload guardrails: `ActivityRawModel` validates action types, pChEMBL ranges, and ID formats at the boundary.
+- Output contract: `ACTIVITY_OUTPUT_COLUMNS` defines canonical column order, and the pipeline contract points `schema_out` to the activity Pandera schema enforced during validation.

--- a/docs/02-pipelines/chembl/02-assay-chembl-overview.md
+++ b/docs/02-pipelines/chembl/02-assay-chembl-overview.md
@@ -1,0 +1,32 @@
+# 02 Assay Chembl Overview
+
+## Overview
+
+- Pipeline ID `chembl.assay` is defined in `configs/pipelines/chembl/assay.yaml` with `entity: assay`, primary key `assay_chembl_id`, `input_mode: id_only`, and `serialization_mode: pipe` for nested assay attributes.
+- `ChemblPipelineFactory` constructs `ChemblPipelineBase` instances, wiring extraction, transformation, validation, hashing, and loader services resolved from the pipeline container.
+- `resolve_primary_key_with_filter` yields the API filter `assay_chembl_id__in`, enabling batched ID queries and ID-list expansion for offline modes.
+
+## Flow: extract → transform → validate → export
+
+1. **Extract**: `ChemblPipelineBase` uses `ExtractStage` with `ChemblExtractionServiceImpl` and `ChemblRecordMapper` to stream assay records as DataFrames. `RecordSourceResolver` switches between API pulls and file-backed feeds (`CsvRecordSourceImpl` or `IdListRecordSourceImpl`) based on the configured mode, reusing `assay_chembl_id__in` for batched requests.
+2. **Transform**: `ChemblTransformerImpl` normalizes assay payloads through the Chembl-specific `NormalizationServiceABC`, serializes nested assay classifications/parameters with `serialize_nested` in `pipe` mode, enforces contract ordering, and drops rows missing non-generated required fields. The default post-transformer appends hashes, index, timestamps, and version metadata.
+3. **Validate**: `ValidationService` enforces the assay pipeline contract, aligning columns to `ASSAY_OUTPUT_COLUMNS` and applying Pandera constraints (types, nullability, enumerations) for assay outputs.
+4. **Export**: Loader implementations (`LoaderABC`) persist validated batches to `output_path` while the metadata builder records `chembl_release` and the last endpoint used in the run context.
+
+## Inputs and outputs
+
+- **Inputs**: API streaming by default; `csv` mode reads structured assay rows; `id_only` consumes an ID list and expands via `assay_chembl_id__in`. Provider config supplies base URL, pagination, and retry/timeout limits for API mode.
+- **Outputs**: Column-ordered assay dataset with deterministic serialization for lists/dicts plus generated metadata columns and QC metadata sidecars (`chembl_release`, `database_version`, timestamps).
+
+## Ports and adapters
+
+- `ExtractionServiceABC` → `ChemblExtractionServiceImpl` with request builder, retry/backoff, and metadata fetch support.
+- `NormalizationServiceABC` → Chembl-specific normalization service injected into `ChemblTransformerImpl`.
+- `EntityModelRegistryABC` feeds `ChemblRecordMapper` for consistent assay field mapping.
+- `LoaderABC` + `RunMetadataBuilderProtocol` handle persistence and metadata enrichment.
+- Record sources: `CsvRecordSourceImpl` and `IdListRecordSourceImpl` map file inputs into the extraction pipeline.
+
+## Schemas
+
+- Raw payload guardrails: `AssayRawModel` validates assay identifiers, optional nested structures, and numeric ranges before mapping.
+- Output contract: `ASSAY_OUTPUT_COLUMNS` defines canonical order for assay outputs; the pipeline contract links `schema_out` to the Pandera assay schema enforced during validation.

--- a/docs/02-pipelines/chembl/03-target-chembl-overview.md
+++ b/docs/02-pipelines/chembl/03-target-chembl-overview.md
@@ -1,0 +1,32 @@
+# 03 Target Chembl Overview
+
+## Overview
+
+- Pipeline ID `chembl.target` comes from `configs/pipelines/chembl/target.yaml` with `entity: target`, primary key `target_chembl_id`, `input_mode: id_only`, and `serialization_mode: pipe`.
+- `ChemblPipelineFactory` instantiates `ChemblPipelineBase`, injecting extraction, normalization, validation, hashing, and loader services resolved from the pipeline container for the target entity.
+- `resolve_primary_key_with_filter` derives `target_chembl_id__in` for API batching and ID-list driven lookups.
+
+## Flow: extract → transform → validate → export
+
+1. **Extract**: `ChemblPipelineBase` composes an `ExtractStage` that streams target payloads via `ChemblExtractionServiceImpl` and `ChemblRecordMapper`. `RecordSourceResolver` switches between API, `csv`, and `id_only` feeds using `CsvRecordSourceImpl` or `IdListRecordSourceImpl`, applying the `target_chembl_id__in` filter for ID batches.
+2. **Transform**: `ChemblTransformerImpl` normalizes target records through the Chembl-aware `NormalizationServiceABC`, serializes nested target fields with `serialize_nested` (`pipe` mode), enforces contract column ordering, and removes rows missing required fields. Post-transform hashing/indexing/timestamp enrichment is applied automatically.
+3. **Validate**: `ValidationService` aligns output with `TARGET_OUTPUT_COLUMNS` and the Pandera target schema specified by the pipeline contract, ensuring deterministic column sets and constraint enforcement.
+4. **Export**: The configured `LoaderABC` writes validated targets to `output_path` while metadata builders include `chembl_release` and last-endpoint hints from `ChemblPipelineBase._enrich_context`.
+
+## Inputs and outputs
+
+- **Inputs**: Default API streaming; `csv` mode for structured local rows; `id_only` mode expands IDs via `target_chembl_id__in`. Provider config covers base URL, pagination, retries, and rate limits.
+- **Outputs**: Ordered target dataset with deterministic serialization for nested structures, generated metadata columns, and QC metadata sidecars (hashes, timestamps, release version).
+
+## Ports and adapters
+
+- `ExtractionServiceABC` → `ChemblExtractionServiceImpl` backed by the ChEMBL client and response parser.
+- `NormalizationServiceABC` → Chembl normalization service injected into `ChemblTransformerImpl`.
+- `EntityModelRegistryABC` powers `ChemblRecordMapper` for target field mapping.
+- `LoaderABC` + `RunMetadataBuilderProtocol` handle persistence and run metadata assembly.
+- Record sources: `CsvRecordSourceImpl` and `IdListRecordSourceImpl` adapt CSV/ID-list inputs when not streaming directly from the API.
+
+## Schemas
+
+- Raw payload guardrails: `TargetRawModel` validates identifier formats and optional nested payloads before mapping.
+- Output contract: `TARGET_OUTPUT_COLUMNS` defines canonical order; the pipeline contract binds `schema_out` to the target Pandera schema enforced during validation.

--- a/docs/02-pipelines/chembl/04-publication-chembl-overview.md
+++ b/docs/02-pipelines/chembl/04-publication-chembl-overview.md
@@ -1,0 +1,32 @@
+# 04 Publication Chembl Overview
+
+## Overview
+
+- Pipeline ID `chembl.publication` is defined in `configs/pipelines/chembl/publication.yaml` with `entity: publication`, primary key `document_chembl_id`, `input_mode: id_only`, and `serialization_mode: pipe` for nested metadata fields.
+- `ChemblPipelineFactory` creates `ChemblPipelineBase` instances that wire extraction, normalization, validation, hashing, and loader services from the pipeline container for publication/document runs.
+- Primary key resolution via `resolve_primary_key_with_filter` yields `document_chembl_id__in` for batched API filters and ID-list ingestion.
+
+## Flow: extract → transform → validate → export
+
+1. **Extract**: `ChemblPipelineBase` composes `ExtractStage` with `ChemblExtractionServiceImpl` and `ChemblRecordMapper` to stream publication records. `RecordSourceResolver` toggles between API streaming and file-backed inputs (`CsvRecordSourceImpl` or `IdListRecordSourceImpl`) depending on mode, applying `document_chembl_id__in` when expanding ID lists.
+2. **Transform**: `ChemblTransformerImpl` normalizes publication payloads through the Chembl-specific `NormalizationServiceABC`, serializes nested authors/keywords/journal metadata with `serialize_nested` (`pipe` mode), enforces contract column order, and drops rows missing non-generated required fields. Post-transform hashing, indexing, timestamps, and version metadata are attached automatically.
+3. **Validate**: `ValidationService` enforces the publication pipeline contract, aligning columns to `PUBLICATION_OUTPUT_COLUMNS` and Pandera schema constraints for document outputs.
+4. **Export**: `LoaderABC` instances persist validated batches to `output_path`, while the metadata builder captures `chembl_release` and last-endpoint hints from `ChemblPipelineBase._enrich_context` for `meta.yaml` and sidecars.
+
+## Inputs and outputs
+
+- **Inputs**: Default API streaming; `csv` mode reads structured publication rows; `id_only` mode consumes document IDs and queries via `document_chembl_id__in`. Provider config sets base URL, pagination, timeout, retry, and rate limit parameters.
+- **Outputs**: Column-ordered publication dataset with deterministic serialization of nested fields plus generated metadata columns (`hash_row`, `hash_business_key`, `index`, timestamps, release version).
+
+## Ports and adapters
+
+- `ExtractionServiceABC` → `ChemblExtractionServiceImpl` with ChEMBL request builder and version lookup.
+- `NormalizationServiceABC` → Chembl normalization service injected into `ChemblTransformerImpl`.
+- `EntityModelRegistryABC` feeds `ChemblRecordMapper` for publication-specific mapping.
+- `LoaderABC` + `RunMetadataBuilderProtocol` manage persistence and metadata enrichment.
+- Record sources: `CsvRecordSourceImpl` and `IdListRecordSourceImpl` adapt CSV and ID-list inputs when not streaming directly from the API.
+
+## Schemas
+
+- Raw payload guardrails: `PublicationRawModel` validates document identifiers and optional nested metadata before mapping.
+- Output contract: `PUBLICATION_OUTPUT_COLUMNS` provides canonical column order; the pipeline contract binds `schema_out` to the Pandera publication schema enforced during validation.

--- a/docs/02-pipelines/chembl/05-molecule-chembl-overview.md
+++ b/docs/02-pipelines/chembl/05-molecule-chembl-overview.md
@@ -1,0 +1,32 @@
+# 05 Molecule Chembl Overview
+
+## Overview
+
+- Pipeline ID `chembl.molecule` is configured in `configs/pipelines/chembl/molecule.yaml` with `entity: molecule`, primary key `molecule_chembl_id`, `input_mode: id_only`, and `serialization_mode: pipe` for nested structure fields.
+- `ChemblPipelineFactory` builds `ChemblPipelineBase` instances with Chembl-specific extraction, normalization, validation, hashing, and loader services resolved from the pipeline container.
+- `resolve_primary_key_with_filter` derives `molecule_chembl_id__in` to batch API requests and expand ID lists for offline modes.
+
+## Flow: extract → transform → validate → export
+
+1. **Extract**: `ChemblPipelineBase` wires `ExtractStage` with `ChemblExtractionServiceImpl` and `ChemblRecordMapper` to stream molecule payloads. `RecordSourceResolver` switches between API mode and file-backed inputs (`CsvRecordSourceImpl` or `IdListRecordSourceImpl`) based on configuration, applying `molecule_chembl_id__in` for ID batches.
+2. **Transform**: `ChemblTransformerImpl` normalizes molecule payloads via the Chembl-specific `NormalizationServiceABC`, serializes nested structure/properties with `serialize_nested` (`pipe` mode), enforces contract column order, and drops rows missing required non-generated fields. Post-transform hashing/indexing/timestamp enrichment is applied automatically.
+3. **Validate**: `ValidationService` aligns output with `MOLECULE_OUTPUT_COLUMNS` and the Pandera molecule schema defined in the pipeline contract, ensuring deterministic columns and constraint enforcement.
+4. **Export**: The configured `LoaderABC` writes validated molecules to `output_path`, while the metadata builder records `chembl_release` and last-endpoint details from `ChemblPipelineBase._enrich_context`.
+
+## Inputs and outputs
+
+- **Inputs**: API streaming by default; `csv` mode reads structured molecule rows; `id_only` mode consumes molecule IDs and queries via `molecule_chembl_id__in`. Provider config carries base URL, pagination, retries, and rate limits.
+- **Outputs**: Column-ordered molecule dataset with deterministic serialization for nested fields plus generated metadata columns (hashes, index, timestamps, release version).
+
+## Ports and adapters
+
+- `ExtractionServiceABC` → `ChemblExtractionServiceImpl` with request builder, retry/backoff, and metadata fetch support.
+- `NormalizationServiceABC` → Chembl normalization service injected into `ChemblTransformerImpl`.
+- `EntityModelRegistryABC` feeds `ChemblRecordMapper` for molecule mapping.
+- `LoaderABC` + `RunMetadataBuilderProtocol` handle persistence and metadata enrichment.
+- Record sources: `CsvRecordSourceImpl` and `IdListRecordSourceImpl` adapt CSV/ID-list inputs into the extraction flow.
+
+## Schemas
+
+- Raw payload guardrails: `MoleculeRawModel` validates molecule identifiers, structures, and properties before mapping.
+- Output contract: `MOLECULE_OUTPUT_COLUMNS` defines canonical order; the pipeline contract binds `schema_out` to the molecule Pandera schema enforced during validation.


### PR DESCRIPTION
## Summary
- add a ChEMBL pipeline index plus per-entity overview docs describing extract→transform→validate→export flows
- update the core pipeline index and README to point to the new ChEMBL documentation set

## Testing
- not run (docs-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b1942c1e083249a182f6fd5547fea)