### PR TITLE
Refine CLI error handling and add tests

### DIFF
--- a/src/bioetl/interfaces/cli/app.py
+++ b/src/bioetl/interfaces/cli/app.py
@@ -2,50 +2,27 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-import sys
 from typing import Annotated, Any
 
 from rich.console import Console
 import typer
 
 from bioetl.application.pipelines.registry import PIPELINE_REGISTRY
-from bioetl.application.use_cases import RunPipelineRequest, RunPipelineResponse
+from bioetl.application.use_cases import InterfaceDisabledError, RunPipelineResponse
 from bioetl.interfaces.application_context import get_application_context
 from bioetl.interfaces.composition_root import get_composition_root
+from bioetl.interfaces.cli.presenter import CliPresenter
+from bioetl.interfaces.cli.run_command_helper import RunCommandParams, RunCommandRequestBuilder
 
 app = typer.Typer(help="BioETL - Bioactivity Data Acquisition ETL")
 console = Console()
-
-
-def _print_start_info(pipeline_name: str, limit: int | None, dry_run: bool) -> None:
-    """Print pipeline start information."""
-    console.print(f"[bold]Starting pipeline:[/bold] {pipeline_name}")
-    if limit:
-        console.print(f"[dim]Limit:[/dim] {limit} records")
-    if dry_run:
-        console.print("[dim]Mode:[/dim] dry-run")
-
-
-def _present_result(response: RunPipelineResponse) -> None:
-    """Format and display pipeline result."""
-    if response.success:
-        console.print("[green]✓ Pipeline finished successfully[/green]")
-        console.print(f"  Rows: {response.row_count}")
-        if response.output_path:
-            console.print(f"  Output: {response.output_path}")
-    else:
-        console.print("[red]✗ Pipeline failed[/red]")
-        for error in response.errors:
-            console.print(f"  [red]Error:[/red] {error}")
+presenter = CliPresenter(console)
 
 
 @app.command()
 def list_pipelines() -> None:
     """List all available pipelines."""
-    console.print("[bold]Available Pipelines:[/bold]")
-    for name in sorted(PIPELINE_REGISTRY.keys()):
-        console.print(f"  - {name}")
+    presenter.show_available_pipelines(sorted(PIPELINE_REGISTRY.keys()))
 
 
 def build_runtime_config(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN201
@@ -55,41 +32,16 @@ def build_runtime_config(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN201
     return _brc(*args, **kwargs)
 
 
-def _resolve_config_path(config: str | None) -> Path | None:
-    """Resolve config path using provided value or BIOETL_CONFIG_DIR."""
-
-    if not config:
-        return None
-
-    provided_path = Path(config)
-    if provided_path.exists():
-        return provided_path
-
-    path_resolver = get_composition_root().create_config_path_resolver()
-    configs_root = path_resolver.configs_root
-    candidate = configs_root / config
-    if candidate.exists():
-        return candidate
-
-    raise FileNotFoundError(
-        f"Config file not found: {config}; tried {provided_path} and {candidate}"
-    )
-
-
 @app.command()
 def validate_config(
     config_path: Annotated[str, typer.Argument(help="Path to pipeline config YAML")],
     profile: Annotated[str | None, typer.Option(help="Profile name")] = None,
 ) -> None:
     """Validate a pipeline configuration file."""
-    from bioetl.interfaces.application_context import get_application_context
+    builder = RunCommandRequestBuilder(get_composition_root())
 
     try:
-        config_file = _resolve_config_path(config_path)
-        if config_file is None or not config_file.exists():
-            console.print(f"[red]Error:[/red] Config file not found: {config_path}")
-            raise typer.Exit(1)
-
+        config_file = builder.resolve_config_path(config_path)
         ctx = get_application_context()
         path_resolver = ctx.composition_root.create_config_path_resolver()
         build_runtime_config(
@@ -98,9 +50,12 @@ def validate_config(
             loader=ctx.config_loader,
             profile=profile,
         )
-        console.print("[green]✓[/green] Config is valid")
-    except Exception as e:
-        console.print(f"[red]Config validation failed:[/red] {e}")
+        presenter.show_config_valid()
+    except FileNotFoundError as error:
+        presenter.show_error(str(error))
+        raise typer.Exit(1)
+    except ValueError as error:
+        presenter.show_error(str(error))
         raise typer.Exit(1)
 
 
@@ -124,40 +79,34 @@ def run(
     ] = None,
 ) -> None:
     """Run a pipeline."""
-    try:
-        # 1. Build request from CLI args
-        request = RunPipelineRequest(
-            pipeline_name=pipeline_name,
-            config_path=_resolve_config_path(config),
-            output_path=Path(output) if output else None,
-            limit=limit,
-            dry_run=dry_run,
-            profile=profile or "default",
-        )
+    builder = RunCommandRequestBuilder(get_composition_root())
 
-        # 2. Get use case via factory
+    params = RunCommandParams(
+        pipeline_name=pipeline_name,
+        config=config,
+        output=output,
+        limit=limit,
+        dry_run=dry_run,
+        profile=profile,
+    )
+
+    try:
+        request = builder.build(params)
         use_case = (
             get_application_context().use_case_factory.create_run_pipeline_use_case()
         )
 
-        # 3. Execute
-        _print_start_info(pipeline_name, limit, dry_run)
+        presenter.show_start_info(pipeline_name, limit, dry_run)
         response = use_case.execute(request)
 
-        # 4. Present result
-        _present_result(response)
+        presenter.present_result(response)
         if not response.success:
             raise typer.Exit(1)
-
     except KeyboardInterrupt:
-        console.print("\n[yellow]Interrupted by user[/yellow]")
+        presenter.show_interrupt()
         raise typer.Exit(130)
-    except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
-        if "--verbose" in sys.argv or "-v" in sys.argv:
-            import traceback
-
-            console.print(traceback.format_exc())
+    except (FileNotFoundError, InterfaceDisabledError, ValueError) as error:
+        presenter.show_error(str(error))
         raise typer.Exit(1)
 
 

--- a/src/bioetl/interfaces/cli/presenter.py
+++ b/src/bioetl/interfaces/cli/presenter.py
@@ -1,0 +1,58 @@
+"""Presentation utilities for CLI output."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from rich.console import Console
+
+from bioetl.application.use_cases import RunPipelineResponse
+
+
+class CliPresenter:
+    """Formats and renders CLI messages."""
+
+    def __init__(self, console: Console) -> None:
+        self._console = console
+
+    def show_available_pipelines(self, names: Iterable[str]) -> None:
+        """Display a list of available pipelines."""
+        self._console.print("[bold]Available Pipelines:[/bold]")
+        for name in names:
+            self._console.print(f"  - {name}")
+
+    def show_start_info(self, pipeline_name: str, limit: int | None, dry_run: bool) -> None:
+        """Show pipeline start details."""
+        self._console.print(f"[bold]Starting pipeline:[/bold] {pipeline_name}")
+        if limit:
+            self._console.print(f"[dim]Limit:[/dim] {limit} records")
+        if dry_run:
+            self._console.print("[dim]Mode:[/dim] dry-run")
+
+    def present_result(self, response: RunPipelineResponse) -> None:
+        """Render pipeline execution result."""
+        if response.success:
+            self._console.print("[green]✓ Pipeline finished successfully[/green]")
+            self._console.print(f"  Rows: {response.row_count}")
+            if response.output_path:
+                self._console.print(f"  Output: {response.output_path}")
+            return
+
+        self._console.print("[red]✗ Pipeline failed[/red]")
+        for error in response.errors:
+            self._console.print(f"  [red]Error:[/red] {error}")
+
+    def show_error(self, message: str) -> None:
+        """Render an error message."""
+        self._console.print(f"[red]Error:[/red] {message}")
+
+    def show_interrupt(self) -> None:
+        """Notify user about interruption."""
+        self._console.print("\n[yellow]Interrupted by user[/yellow]")
+
+    def show_config_valid(self) -> None:
+        """Display successful config validation message."""
+        self._console.print("[green]✓[/green] Config is valid")
+
+
+__all__ = ["CliPresenter"]

--- a/src/bioetl/interfaces/cli/run_command_helper.py
+++ b/src/bioetl/interfaces/cli/run_command_helper.py
@@ -1,0 +1,80 @@
+"""Helpers for validating CLI input and building pipeline requests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from bioetl.application.use_cases import RunPipelineRequest
+from bioetl.interfaces.composition_root import CompositionRoot
+
+
+@dataclass(frozen=True)
+class RunCommandParams:
+    """DTO with parsed CLI parameters for the run command."""
+
+    pipeline_name: str
+    config: str | None
+    output: str | None
+    limit: int | None
+    dry_run: bool
+    profile: str | None
+
+
+class RunCommandRequestBuilder:
+    """Builds validated :class:`RunPipelineRequest` from CLI params."""
+
+    def __init__(self, composition_root: CompositionRoot) -> None:
+        self._composition_root = composition_root
+
+    def build(self, params: RunCommandParams) -> RunPipelineRequest:
+        """Validate arguments and create a request object."""
+        limit = self._validate_limit(params.limit)
+        config_path = self.resolve_config_path(params.config)
+        output_path = Path(params.output) if params.output else None
+
+        return RunPipelineRequest(
+            pipeline_name=params.pipeline_name,
+            config_path=config_path,
+            output_path=output_path,
+            limit=limit,
+            dry_run=params.dry_run,
+            profile=params.profile or "default",
+        )
+
+    def resolve_config_path(self, config: str | None) -> Path | None:
+        """Resolve provided config path or map to configs root."""
+        if not config:
+            return None
+
+        provided_path = Path(config)
+        if provided_path.exists():
+            return provided_path
+
+        path_resolver = self._composition_root.create_config_path_resolver()
+        configs_root = path_resolver.configs_root
+        candidate = configs_root / config if configs_root else None
+        if candidate and candidate.exists():
+            return candidate
+
+        candidates = [str(provided_path)]
+        if candidate:
+            candidates.append(str(candidate))
+
+        raise FileNotFoundError(
+            "Config file not found: {config}; tried {attempts}".format(
+                config=config, attempts=", ".join(candidates)
+            )
+        )
+
+    @staticmethod
+    def _validate_limit(limit: int | None) -> int | None:
+        """Ensure limit is positive when provided."""
+        if limit is None:
+            return None
+        if limit <= 0:
+            raise ValueError("Limit must be a positive integer")
+        return limit
+
+
+__all__ = ["RunCommandParams", "RunCommandRequestBuilder"]

--- a/tests/bioetl/interfaces/cli/test_app.py
+++ b/tests/bioetl/interfaces/cli/test_app.py
@@ -1,0 +1,167 @@
+"""CLI command tests for run and validation workflows."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock
+
+from typer.testing import CliRunner
+
+from bioetl.application.use_cases import InterfaceDisabledError, RunPipelineResponse
+
+cli_app = import_module("bioetl.interfaces.cli.app")
+
+runner = CliRunner()
+
+
+class StubPathResolver:
+    """Stub for config path resolver."""
+
+    def __init__(self, configs_root: Path) -> None:
+        self.configs_root = configs_root
+
+
+class StubCompositionRoot:
+    """Stub composition root for CLI tests."""
+
+    def __init__(self, configs_root: Path) -> None:
+        self._resolver = StubPathResolver(configs_root)
+
+    def create_config_path_resolver(self) -> StubPathResolver:
+        return self._resolver
+
+
+class StubUseCaseFactory:
+    """Factory returning predefined use case stub."""
+
+    def __init__(self, use_case: Any) -> None:
+        self._use_case = use_case
+
+    def create_run_pipeline_use_case(self) -> Any:
+        return self._use_case
+
+
+class StubContext:
+    """Application context stub used by CLI handlers."""
+
+    def __init__(self, use_case: Any, composition_root: StubCompositionRoot) -> None:
+        self.use_case_factory = StubUseCaseFactory(use_case)
+        self.composition_root = composition_root
+        self.config_loader = Mock()
+
+
+class StubRunPipelineUseCase:
+    """Stub use case for controlling run results."""
+
+    def __init__(self, response: RunPipelineResponse | None = None, error: Exception | None = None) -> None:
+        self._response = response
+        self._error = error
+        self.requests: list[Any] = []
+
+    def execute(self, request: Any) -> RunPipelineResponse:
+        self.requests.append(request)
+        if self._error:
+            raise self._error
+        if self._response is None:
+            raise RuntimeError("Response not configured")
+        return self._response
+
+
+def test_run_success(monkeypatch: Any, tmp_path: Path) -> None:
+    """CLI returns zero exit code when pipeline succeeds."""
+    response = RunPipelineResponse(
+        run_id="run-123",
+        success=True,
+        row_count=10,
+        duration_sec=0.1,
+        output_path=None,
+    )
+    composition_root = StubCompositionRoot(tmp_path)
+    context = StubContext(StubRunPipelineUseCase(response=response), composition_root)
+
+    monkeypatch.setattr(cli_app, "get_application_context", lambda: context)
+    monkeypatch.setattr(cli_app, "get_composition_root", lambda: composition_root)
+
+    result = runner.invoke(cli_app.app, ["run", "activity_chembl"])
+
+    assert result.exit_code == 0
+    assert "Pipeline finished successfully" in result.stdout
+
+
+def test_run_interface_disabled(monkeypatch: Any, tmp_path: Path) -> None:
+    """CLI exits with code 1 when interface disabled error is raised."""
+    composition_root = StubCompositionRoot(tmp_path)
+    context = StubContext(
+        StubRunPipelineUseCase(error=InterfaceDisabledError("REST")), composition_root
+    )
+
+    monkeypatch.setattr(cli_app, "get_application_context", lambda: context)
+    monkeypatch.setattr(cli_app, "get_composition_root", lambda: composition_root)
+
+    result = runner.invoke(cli_app.app, ["run", "activity_chembl"])
+
+    assert result.exit_code == 1
+    assert "interface is disabled" in result.stdout
+
+
+def test_run_missing_config(monkeypatch: Any, tmp_path: Path) -> None:
+    """CLI shows file error and exits with code 1 when config missing."""
+    composition_root = StubCompositionRoot(tmp_path)
+    context = StubContext(StubRunPipelineUseCase(response=None), composition_root)
+
+    monkeypatch.setattr(cli_app, "get_application_context", lambda: context)
+    monkeypatch.setattr(cli_app, "get_composition_root", lambda: composition_root)
+
+    result = runner.invoke(
+        cli_app.app, ["run", "activity_chembl", "--config", "missing.yaml"]
+    )
+
+    assert result.exit_code == 1
+    assert "Config file not found" in result.stdout
+
+
+def test_run_invalid_limit(monkeypatch: Any, tmp_path: Path) -> None:
+    """CLI validates limit and exits with code 1 when limit is invalid."""
+    composition_root = StubCompositionRoot(tmp_path)
+    context = StubContext(StubRunPipelineUseCase(response=None), composition_root)
+
+    monkeypatch.setattr(cli_app, "get_application_context", lambda: context)
+    monkeypatch.setattr(cli_app, "get_composition_root", lambda: composition_root)
+
+    result = runner.invoke(cli_app.app, ["run", "activity_chembl", "--limit", "-5"])
+
+    assert result.exit_code == 1
+    assert "Limit must be a positive integer" in result.stdout
+
+
+def test_validate_config_success(monkeypatch: Any, tmp_path: Path) -> None:
+    """Config validation succeeds and returns exit code 0."""
+    config_file = tmp_path / "pipeline.yml"
+    config_file.write_text("content", encoding="utf-8")
+    composition_root = StubCompositionRoot(tmp_path)
+    context = StubContext(StubRunPipelineUseCase(response=None), composition_root)
+
+    monkeypatch.setattr(cli_app, "get_application_context", lambda: context)
+    monkeypatch.setattr(cli_app, "get_composition_root", lambda: composition_root)
+    monkeypatch.setattr(cli_app, "build_runtime_config", lambda **_: None)
+
+    result = runner.invoke(cli_app.app, ["validate-config", str(config_file)])
+
+    assert result.exit_code == 0
+    assert "Config is valid" in result.stdout
+
+
+def test_validate_config_missing(monkeypatch: Any, tmp_path: Path) -> None:
+    """Config validation returns exit code 1 when file not found."""
+    composition_root = StubCompositionRoot(tmp_path)
+    context = StubContext(StubRunPipelineUseCase(response=None), composition_root)
+
+    monkeypatch.setattr(cli_app, "get_application_context", lambda: context)
+    monkeypatch.setattr(cli_app, "get_composition_root", lambda: composition_root)
+
+    result = runner.invoke(cli_app.app, ["validate-config", "missing.yml"])
+
+    assert result.exit_code == 1
+    assert "Config file not found" in result.stdout


### PR DESCRIPTION
## Summary
- add a CLI presenter to format output and restrict handling to expected exceptions
- move run command request assembly and validation into a dedicated helper DTO
- add unit tests covering CLI success and error scenarios with exit codes

## Testing
- pytest tests/bioetl/interfaces/cli/test_app.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b1a063eec83249b15471d52b58951)