### PR TITLE
Add shared client resilience strategy

### DIFF
--- a/src/bioetl/domain/ports/__init__.py
+++ b/src/bioetl/domain/ports/__init__.py
@@ -42,6 +42,14 @@ from bioetl.domain.ports.pipeline_contract_loader import (
     PipelineContractLoaderPortABC,
 )
 from bioetl.domain.ports.request_building import RequestBuilderPortABC
+from bioetl.domain.ports.resilience import (
+    BackoffStrategy,
+    ClientResilienceStrategy,
+    ErrorCategory,
+    ErrorClassifierPortABC,
+    RateLimitStrategy,
+    RequestContext,
+)
 from bioetl.domain.ports.schema import SchemaContractProviderABC
 from bioetl.domain.types import ApiPayload
 
@@ -70,6 +78,13 @@ __all__: list[str] = [
     # Parsing ports
     "PaginationInfo",
     "ResponseParserPortABC",
+    # Resilience ports
+    "BackoffStrategy",
+    "ClientResilienceStrategy",
+    "ErrorCategory",
+    "ErrorClassifierPortABC",
+    "RateLimitStrategy",
+    "RequestContext",
     # Request building ports
     "RequestBuilderPortABC",
     # Schema ports

--- a/src/bioetl/domain/ports/resilience.py
+++ b/src/bioetl/domain/ports/resilience.py
@@ -1,0 +1,88 @@
+"""Resilience strategies and error classification ports for clients."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable, Protocol
+
+from bioetl.domain.configs import HttpClientConfig
+
+
+class ErrorCategory(str, Enum):
+    """Unified error categories for client responses."""
+
+    RATE_LIMIT = "rate_limit"
+    SERVER_ERROR = "server_error"
+    CLIENT_ERROR = "client_error"
+    SUCCESS = "success"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class RequestContext:
+    """Context information for outbound requests."""
+
+    provider: str
+    endpoint: str
+    status_code: int | None
+    method: str = "GET"
+    response_body: str | None = None
+
+
+class ErrorClassifierPortABC(Protocol):
+    """Contract for mapping raw responses to canonical error categories."""
+
+    def classify(self, status_code: int | None) -> ErrorCategory:
+        """Return error category for a given HTTP status code."""
+
+
+@dataclass(frozen=True)
+class BackoffStrategy:
+    """Retry/backoff settings for resilient clients."""
+
+    max_attempts: int
+    backoff_factor: float
+    backoff_max: float | None
+    retry_statuses: tuple[int, ...]
+    retry_exceptions: tuple[type[Exception], ...]
+
+
+@dataclass(frozen=True)
+class RateLimitStrategy:
+    """Rate limiting parameters for proactive throttling."""
+
+    rate_limit_per_sec: float
+
+
+@dataclass(frozen=True)
+class ClientResilienceStrategy:
+    """Aggregate resilience configuration for infrastructure clients."""
+
+    backoff: BackoffStrategy
+    rate_limit: RateLimitStrategy
+    error_classifier: ErrorClassifierPortABC
+
+    @classmethod
+    def from_http_config(
+        cls,
+        config: HttpClientConfig,
+        *,
+        classifier: ErrorClassifierPortABC,
+        retry_exceptions: Iterable[type[Exception]] | None = None,
+    ) -> "ClientResilienceStrategy":
+        """Construct strategy from ``HttpClientConfig`` values."""
+
+        retry_statuses = tuple(config.retry_on_status)
+        retry_exceptions_tuple = tuple(retry_exceptions or ())
+
+        backoff = BackoffStrategy(
+            max_attempts=max(1, int(config.max_retries) + 1),
+            backoff_factor=float(config.backoff_factor),
+            backoff_max=float(config.backoff_max),
+            retry_statuses=retry_statuses,
+            retry_exceptions=retry_exceptions_tuple,
+        )
+        rate_limit = RateLimitStrategy(rate_limit_per_sec=float(config.rate_limit_per_sec))
+        return cls(backoff=backoff, rate_limit=rate_limit, error_classifier=classifier)
+

--- a/src/bioetl/infrastructure/clients/base/http_error_handler.py
+++ b/src/bioetl/infrastructure/clients/base/http_error_handler.py
@@ -8,33 +8,34 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from enum import Enum
 from typing import Any
 
 from bioetl.domain.errors import ClientRateLimitError
 from bioetl.domain.observability import LoggingPortABC
+from bioetl.domain.ports.resilience import (
+    ErrorCategory,
+    ErrorClassifierPortABC,
+    RequestContext,
+)
 from bioetl.infrastructure.errors import ApiClientError, ApiUnexpectedStatusError
 
 
-class ErrorCategory(Enum):
-    """Categories of HTTP errors for classification."""
-
-    RATE_LIMIT = "rate_limit"
-    SERVER_ERROR = "server_error"
-    CLIENT_ERROR = "client_error"
-    SUCCESS = "success"
-    UNKNOWN = "unknown"
-
-
 @dataclass(frozen=True)
-class RequestContext:
-    """Context information for an HTTP request."""
+class StatusCodeErrorClassifier(ErrorClassifierPortABC):
+    """Default status-code based classifier."""
 
-    provider: str
-    endpoint: str
-    status_code: int | None
-    method: str = "GET"
-    response_body: str | None = None
+    def classify(self, status_code: int | None) -> ErrorCategory:
+        if status_code is None:
+            return ErrorCategory.UNKNOWN
+        if 200 <= status_code < 400:
+            return ErrorCategory.SUCCESS
+        if status_code == 429:
+            return ErrorCategory.RATE_LIMIT
+        if 500 <= status_code < 600:
+            return ErrorCategory.SERVER_ERROR
+        if 400 <= status_code < 500:
+            return ErrorCategory.CLIENT_ERROR
+        return ErrorCategory.UNKNOWN
 
 
 class HttpErrorHandlerABC(ABC):
@@ -84,7 +85,11 @@ class DefaultHttpErrorHandler(HttpErrorHandlerABC):
     - 2xx/3xx → Success (no error)
     """
 
-    def __init__(self, logger: LoggingPortABC | None = None) -> None:
+    def __init__(
+        self,
+        logger: LoggingPortABC | None = None,
+        classifier: ErrorClassifierPortABC | None = None,
+    ) -> None:
         """
         Initialize error handler.
 
@@ -92,6 +97,7 @@ class DefaultHttpErrorHandler(HttpErrorHandlerABC):
             logger: Optional logger for error details
         """
         self.logger = logger
+        self.classifier = classifier or StatusCodeErrorClassifier()
 
     def handle(self, response: Any, context: RequestContext) -> ApiClientError | None:
         """
@@ -121,7 +127,7 @@ class DefaultHttpErrorHandler(HttpErrorHandlerABC):
                 method=context.method,
             )
 
-        category = self.classify_error(status_code)
+        category = self.classifier.classify(status_code)
 
         if category == ErrorCategory.SUCCESS:
             return None
@@ -138,28 +144,9 @@ class DefaultHttpErrorHandler(HttpErrorHandlerABC):
         return self._create_generic_error(context)
 
     def classify_error(self, status_code: int) -> ErrorCategory:
-        """
-        Classify HTTP status code into error category.
+        """Delegate classification to configured classifier."""
 
-        Args:
-            status_code: HTTP status code
-
-        Returns:
-            ErrorCategory enum value
-        """
-        if 200 <= status_code < 400:
-            return ErrorCategory.SUCCESS
-
-        if status_code == 429:
-            return ErrorCategory.RATE_LIMIT
-
-        if 500 <= status_code < 600:
-            return ErrorCategory.SERVER_ERROR
-
-        if 400 <= status_code < 500:
-            return ErrorCategory.CLIENT_ERROR
-
-        return ErrorCategory.UNKNOWN
+        return self.classifier.classify(status_code)
 
     def _create_rate_limit_error(self, context: RequestContext) -> ClientRateLimitError:
         """Create rate limit error."""

--- a/src/bioetl/infrastructure/clients/base/impl/_http_transport.py
+++ b/src/bioetl/infrastructure/clients/base/impl/_http_transport.py
@@ -12,21 +12,24 @@ import requests
 
 from bioetl.domain.configs import HttpClientConfig
 from bioetl.domain.observability import LoggingPortABC, MetricsPortABC
+from bioetl.domain.ports.resilience import ClientResilienceStrategy, RequestContext
 from bioetl.infrastructure.clients.base.http_error_handler import (
     DefaultHttpErrorHandler,
     HttpErrorHandlerABC,
-    RequestContext,
+    StatusCodeErrorClassifier,
 )
+from bioetl.infrastructure.clients.base.resilience import ResilientRequestMixin
 from bioetl.infrastructure.errors import (
     ApiClientError,
     ApiTimeoutError,
     wrap_http_errors,
 )
 from bioetl.infrastructure.http import ExponentialRetryPolicy
+from bioetl.infrastructure.settings.http import DEFAULT_RETRY
 from bioetl.infrastructure.settings.metrics import MetricName
 
 
-class _HttpTransport:
+class _HttpTransport(ResilientRequestMixin):
     """Internal HTTP transport without middleware layers.
 
     Delegates calls directly to the underlying HTTP client.
@@ -42,21 +45,33 @@ class _HttpTransport:
         logger: LoggingPortABC,
         metrics: MetricsPortABC,
         error_handler: HttpErrorHandlerABC | None = None,
+        resilience_strategy: ClientResilienceStrategy | None = None,
     ) -> None:
         self.provider = provider
         self.config = config
         self.base_client = base_client
         self.logger = logger
         self.metrics = metrics
-        self.error_handler = error_handler or DefaultHttpErrorHandler(logger)
-        attempts = max(1, int(config.max_retries) + 1)
-        self.retry_policy = (
-            ExponentialRetryPolicy(
-                max_attempts=attempts,
-                backoff_factor=float(config.backoff_factor),
-            )
-            if config.max_retries > 0
-            else None
+        classifier = StatusCodeErrorClassifier()
+        self.resilience_strategy = resilience_strategy or ClientResilienceStrategy.from_http_config(
+            config,
+            classifier=classifier,
+            retry_exceptions=DEFAULT_RETRY.retry_exceptions,
+        )
+        resolved_error_handler = error_handler or DefaultHttpErrorHandler(
+            logger, classifier=self.resilience_strategy.error_classifier
+        )
+        retry_policy = ExponentialRetryPolicy(
+            max_attempts=self.resilience_strategy.backoff.max_attempts,
+            backoff_factor=self.resilience_strategy.backoff.backoff_factor,
+            backoff_max=self.resilience_strategy.backoff.backoff_max,
+            retry_statuses=self.resilience_strategy.backoff.retry_statuses,
+            retry_exceptions=self.resilience_strategy.backoff.retry_exceptions,
+        )
+        self._init_resilience(
+            retry_policy=retry_policy,
+            error_handler=resolved_error_handler,
+            logger=logger,
         )
         self.logger.info(
             "http_client_initialized",
@@ -68,79 +83,14 @@ class _HttpTransport:
         )
 
     def request_call(self, method: str, url: str, **kwargs: Any) -> Any:
-        """Execute HTTP request with client settings.
-
-        Args:
-            method: HTTP method (GET, POST, etc.).
-            url: Target URL for the request.
-            **kwargs: Additional request parameters passed to underlying client.
-
-        Returns:
-            Response object from the underlying HTTP client.
-
-        Raises:
-            ApiTimeoutError: If request times out.
-            ApiClientError: If request fails with HTTP error.
-        """
-        start = time.monotonic()
-        status_label = "unknown"
-
-        try:
-            with wrap_http_errors(
-                provider=self.provider, endpoint=url, logger=self.logger
-            ) as context:
-                method_upper = method.upper()
-                if method_upper in {"POST", "PUT", "PATCH", "DELETE"}:
-                    headers = dict(kwargs.get("headers") or {})
-                    headers.setdefault("Idempotency-Key", str(uuid4()))
-                    kwargs["headers"] = headers
-
-                timeout = kwargs.pop("timeout", self.config.timeout_sec)
-                response = self.base_client.request(
-                    method=method, url=url, timeout=timeout, **kwargs
-                )
-                raw_status = getattr(response, "status_code", None)
-                context["status_code"] = (
-                    raw_status if isinstance(raw_status, int) else None
-                )
-                status_label = self._normalize_status(context["status_code"])
-
-                # Use unified error handler
-                request_context = RequestContext(
-                    provider=self.provider,
-                    endpoint=url,
-                    status_code=context["status_code"],
-                    method=method_upper,
-                )
-                error = self.error_handler.handle(response, request_context)
-
-                log_method = (
-                    self.logger.error
-                    if context["status_code"] is not None
-                    and context["status_code"] >= 400
-                    else self.logger.info
-                )
-                log_method(
-                    "http_request_completed",
-                    provider=self.provider,
-                    method=method_upper,
-                    url=url,
-                    status_code=context["status_code"],
-                    latency_sec=time.monotonic() - start,
-                )
-
-                if error is not None:
-                    raise error
-
-                return response
-        except Exception as exc:
-            status_label = self._status_from_exception(status_label, exc)
-            self._record_error(url, status_label)
-            raise
-        finally:
-            latency = time.monotonic() - start
-            self._observe_latency(url, latency, status_label)
-            self._record_total(url, status_label)
+        """Execute HTTP request with client settings."""
+        context = RequestContext(
+            provider=self.provider, endpoint=url, status_code=None, method=method
+        )
+        return self._execute_with_resilience(
+            lambda: self._send_once(method, url, context, **kwargs),
+            context=context,
+        )
 
     def request(self, method: str, url: str, **kwargs: Any) -> Any:
         """Execute a request using the configured HTTP client."""
@@ -155,27 +105,7 @@ class _HttpTransport:
         return self.request("POST", url, **kwargs)
 
     def _request_with_retry(self, method: str, url: str, **kwargs: Any) -> Any:
-        attempt = 1
-        while True:
-            try:
-                return self.request_call(method, url, **kwargs)
-            except Exception as exc:
-                if self.retry_policy is None or not self.retry_policy.should_retry(
-                    exc, attempt
-                ):
-                    raise
-
-                backoff = self.retry_policy.get_backoff(attempt)
-                self.logger.warning(
-                    "http_request_retry",
-                    provider=self.provider,
-                    url=url,
-                    attempt=attempt,
-                    backoff_sec=backoff,
-                    error=str(exc),
-                )
-                time.sleep(backoff)
-                attempt += 1
+        return self.request_call(method, url, **kwargs)
 
     def close(self) -> None:
         """Close the underlying HTTP connection."""
@@ -223,3 +153,58 @@ class _HttpTransport:
             if status_code is not None:
                 return str(status_code)
         return exc.__class__.__name__ or current_status
+
+    def _send_once(
+        self, method: str, url: str, context: RequestContext, **kwargs: Any
+    ) -> tuple[Any, RequestContext]:
+        start = time.monotonic()
+        status_label = "unknown"
+        method_upper = method.upper()
+        try:
+            with wrap_http_errors(
+                provider=self.provider, endpoint=url, logger=self.logger
+            ) as error_context:
+                if method_upper in {"POST", "PUT", "PATCH", "DELETE"}:
+                    headers = dict(kwargs.get("headers") or {})
+                    headers.setdefault("Idempotency-Key", str(uuid4()))
+                    kwargs["headers"] = headers
+
+                timeout = kwargs.pop("timeout", self.config.timeout_sec)
+                response = self.base_client.request(
+                    method=method, url=url, timeout=timeout, **kwargs
+                )
+                raw_status = getattr(response, "status_code", None)
+                status_code = raw_status if isinstance(raw_status, int) else None
+                error_context["status_code"] = status_code
+                status_label = self._normalize_status(status_code)
+
+                log_method = (
+                    self.logger.error
+                    if status_code is not None and status_code >= 400
+                    else self.logger.info
+                )
+                log_method(
+                    "http_request_completed",
+                    provider=self.provider,
+                    method=method_upper,
+                    url=url,
+                    status_code=status_code,
+                    latency_sec=time.monotonic() - start,
+                )
+
+                updated_context = RequestContext(
+                    provider=context.provider,
+                    endpoint=context.endpoint,
+                    status_code=status_code,
+                    method=method_upper,
+                    response_body=context.response_body,
+                )
+                return response, updated_context
+        except Exception as exc:
+            status_label = self._status_from_exception(status_label, exc)
+            self._record_error(url, status_label)
+            raise
+        finally:
+            latency = time.monotonic() - start
+            self._observe_latency(url, latency, status_label)
+            self._record_total(url, status_label)

--- a/src/bioetl/infrastructure/clients/base/resilience.py
+++ b/src/bioetl/infrastructure/clients/base/resilience.py
@@ -1,0 +1,58 @@
+"""Shared resilience helpers for infrastructure clients."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable, Tuple
+
+from bioetl.domain.clients.base.contracts import RetryPolicyABC
+from bioetl.domain.observability import LoggingPortABC
+from bioetl.domain.ports.resilience import RequestContext
+from bioetl.infrastructure.clients.base.http_error_handler import HttpErrorHandlerABC
+
+
+class ResilientRequestMixin:
+    """Mixin providing unified retry/error-handling workflow."""
+
+    def _init_resilience(
+        self,
+        *,
+        retry_policy: RetryPolicyABC | None,
+        error_handler: HttpErrorHandlerABC,
+        logger: LoggingPortABC,
+    ) -> None:
+        self._resilience_retry_policy = retry_policy
+        self._resilience_error_handler = error_handler
+        self._resilience_logger = logger
+
+    def _execute_with_resilience(
+        self,
+        send: Callable[[], Tuple[Any, RequestContext]],
+        *,
+        context: RequestContext,
+    ) -> Any:
+        attempt = 1
+        while True:
+            try:
+                response, context = send()
+                error = self._resilience_error_handler.handle(response, context)
+                if error is not None:
+                    raise error
+                return response
+            except Exception as exc:  # noqa: BLE001 - propagate after retry decision
+                retry_policy = self._resilience_retry_policy
+                if retry_policy is None or not retry_policy.should_retry(exc, attempt):
+                    raise
+
+                backoff = retry_policy.get_backoff(attempt)
+                self._resilience_logger.warning(
+                    "http_request_retry",
+                    provider=context.provider,
+                    endpoint=context.endpoint,
+                    attempt=attempt,
+                    backoff_sec=backoff,
+                    error=str(exc),
+                )
+                time.sleep(backoff)
+                attempt += 1
+

--- a/src/bioetl/infrastructure/clients/chembl/impl/chembl_http_client_impl.py
+++ b/src/bioetl/infrastructure/clients/chembl/impl/chembl_http_client_impl.py
@@ -12,21 +12,24 @@ from bioetl.domain.clients.base.contracts import (
     RequestBuilderABC,
 )
 from bioetl.domain.clients.contracts import DataClientABC
+from bioetl.domain.configs import HttpClientConfig
 from bioetl.domain.observability import LoggingPortABC
+from bioetl.domain.ports.resilience import ClientResilienceStrategy, RequestContext
 from bioetl.domain.ports.parsing import ResponseParserPortABC
 from bioetl.infrastructure.clients.base.http_error_handler import (
     DefaultHttpErrorHandler,
     HttpErrorHandlerABC,
-    RequestContext,
 )
+from bioetl.infrastructure.clients.base.resilience import ResilientRequestMixin
 from bioetl.infrastructure.clients.chembl.constants import resolve_endpoint
 from bioetl.infrastructure.clients.chembl.paginator import ChemblPaginatorImpl
+from bioetl.infrastructure.http import ExponentialRetryPolicy
 from bioetl.infrastructure.errors import (
     wrap_http_errors,
 )
 
 
-class ChemblHttpClientImpl(DataClientABC):
+class ChemblHttpClientImpl(DataClientABC, ResilientRequestMixin):
     """
     ChEMBL API client implemented over HTTP.
     Uses RateLimiter for proactive throttling.
@@ -46,6 +49,7 @@ class ChemblHttpClientImpl(DataClientABC):
         provider: str = "chembl",
         fallbacks: dict[str, list[str]] | None = None,
         error_handler: HttpErrorHandlerABC | None = None,
+        resilience_strategy: ClientResilienceStrategy | None = None,
     ) -> None:
         self.request_builder = request_builder
         self.response_parser = response_parser
@@ -56,7 +60,46 @@ class ChemblHttpClientImpl(DataClientABC):
         self._fallbacks = fallbacks if fallbacks is not None else {}
         self._last_endpoint_used: str | None = None
         self.provider = provider
-        self.error_handler = error_handler or DefaultHttpErrorHandler(logger)
+        strategy = resilience_strategy
+        if strategy is None:
+            client_strategy = getattr(http_client, "resilience_strategy", None)
+            if isinstance(client_strategy, ClientResilienceStrategy):
+                strategy = client_strategy
+        resolved_handler = error_handler
+        if strategy is None:
+            raw_config = getattr(http_client, "config", None)
+            default_config = (
+                raw_config
+                if isinstance(raw_config, HttpClientConfig)
+                else HttpClientConfig(max_retries=1, backoff_factor=0.01, backoff_max=0.05)
+            )
+            default_handler = DefaultHttpErrorHandler(logger)
+            strategy = ClientResilienceStrategy.from_http_config(
+                default_config,
+                classifier=default_handler.classifier,
+                retry_exceptions=(),
+            )
+            resolved_handler = resolved_handler or default_handler
+        resolved_handler = resolved_handler or DefaultHttpErrorHandler(
+            logger, classifier=strategy.error_classifier
+        )
+        self.error_handler = resolved_handler
+
+        retry_policy = None
+        if not hasattr(http_client, "resilience_strategy"):
+            retry_policy = ExponentialRetryPolicy(
+                max_attempts=strategy.backoff.max_attempts,
+                backoff_factor=strategy.backoff.backoff_factor,
+                backoff_max=strategy.backoff.backoff_max,
+                retry_statuses=strategy.backoff.retry_statuses,
+                retry_exceptions=strategy.backoff.retry_exceptions,
+            )
+
+        self._init_resilience(
+            retry_policy=retry_policy,
+            error_handler=resolved_handler,
+            logger=logger,
+        )
 
     def iter_pages(self, request: Any) -> Iterator[Any]:
         """Iterate over paginated responses for a built request."""
@@ -124,43 +167,69 @@ class ChemblHttpClientImpl(DataClientABC):
         raise RuntimeError("No endpoint candidates configured")
 
     def _execute_request(self, url: str) -> dict[str, Any]:
+        context = RequestContext(
+            provider=self.provider,
+            endpoint=url,
+            status_code=None,
+            method="GET",
+        )
+        response = self._execute_with_resilience(
+            lambda: self._send_http_get(url, context),
+            context=context,
+        )
+        status_code = getattr(response, "status_code", None)
         with wrap_http_errors(
             provider=self.provider, endpoint=url, logger=self.logger
-        ) as context:
-            start = time.monotonic()
-            response = self.http.request("GET", url)
-            latency = time.monotonic() - start
-            raw_status = getattr(response, "status_code", None)
-            status_code = raw_status if isinstance(raw_status, int) else None
-            context["status_code"] = status_code
-
-            # Use unified error handler
-            request_context = RequestContext(
-                provider=self.provider,
-                endpoint=url,
-                status_code=status_code,
-                method="GET",
-            )
-            error = self.error_handler.handle(response, request_context)
-
-            log_level = (
-                self.logger.error
-                if status_code is not None and status_code >= 400
-                else self.logger.info
-            )
-            log_level(
-                "http_request_completed",
-                provider=self.provider,
-                method="GET",
-                url=url,
-                status_code=status_code,
-                latency_sec=latency,
-            )
-
-            if error is not None:
-                raise error
-
+        ) as parse_context:
+            parse_context["status_code"] = status_code if isinstance(status_code, int) else None
             return response.json()
+
+    def _send_http_get(
+        self, url: str, context: RequestContext
+    ) -> tuple[Any, RequestContext]:
+        start = time.monotonic()
+        status_label = "unknown"
+        try:
+            with wrap_http_errors(
+                provider=self.provider, endpoint=url, logger=self.logger
+            ) as error_context:
+                response = self.http.request("GET", url)
+                latency = time.monotonic() - start
+                raw_status = getattr(response, "status_code", None)
+                status_code = raw_status if isinstance(raw_status, int) else None
+                error_context["status_code"] = status_code
+                status_label = str(status_code) if status_code is not None else "unknown"
+
+                log_level = (
+                    self.logger.error
+                    if status_code is not None and status_code >= 400
+                    else self.logger.info
+                )
+                log_level(
+                    "http_request_completed",
+                    provider=self.provider,
+                    method="GET",
+                    url=url,
+                    status_code=status_code,
+                    latency_sec=latency,
+                )
+
+                updated_context = RequestContext(
+                    provider=context.provider,
+                    endpoint=context.endpoint,
+                    status_code=status_code,
+                    method="GET",
+                    response_body=context.response_body,
+                )
+                return response, updated_context
+        except Exception:
+            self.logger.warning(
+                "http_request_failed",
+                provider=self.provider,
+                url=url,
+                status=status_label,
+            )
+            raise
 
     def _build_request_url(self, endpoint: str, filters: dict[str, Any]) -> str:
         """

--- a/src/bioetl/infrastructure/http/retry.py
+++ b/src/bioetl/infrastructure/http/retry.py
@@ -22,6 +22,7 @@ class ExponentialRetryPolicy(RetryPolicyABC):
         *,
         max_attempts: int,
         backoff_factor: float = 1.0,
+        backoff_max: float | None = None,
         retry_statuses: Iterable[int] | None = None,
         retry_exceptions: tuple[type[Exception], ...] | None = None,
     ) -> None:
@@ -32,6 +33,7 @@ class ExponentialRetryPolicy(RetryPolicyABC):
 
         self._max_attempts = int(max_attempts)
         self._backoff_factor = float(backoff_factor)
+        self._backoff_max = backoff_max
         self.retry_statuses = (
             set(retry_statuses) if retry_statuses else set(DEFAULT_RETRY.retry_statuses)
         )
@@ -46,6 +48,12 @@ class ExponentialRetryPolicy(RetryPolicyABC):
     def backoff_factor(self) -> float:
         """Delay multiplier between retry attempts."""
         return self._backoff_factor
+
+    @property
+    def backoff_max(self) -> float | None:
+        """Maximum backoff delay in seconds (if configured)."""
+
+        return self._backoff_max
 
     def should_retry(self, exception: Exception, attempt: int) -> bool:
         """Check whether a retry should be attempted for the given exception.
@@ -92,7 +100,10 @@ class ExponentialRetryPolicy(RetryPolicyABC):
             Delay in seconds before next retry.
         """
         exponent = max(0, attempt - 1)
-        return self.backoff_factor * math.pow(2.0, exponent)
+        delay = self.backoff_factor * math.pow(2.0, exponent)
+        if self.backoff_max is not None:
+            return min(delay, self.backoff_max)
+        return delay
 
 
 def _extract_status_code(exc: Exception) -> int | None:

--- a/tests/bioetl/infrastructure/clients/base/test_http_error_handler.py
+++ b/tests/bioetl/infrastructure/clients/base/test_http_error_handler.py
@@ -3,11 +3,8 @@
 from unittest.mock import Mock
 
 from bioetl.domain.errors import ClientRateLimitError
-from bioetl.infrastructure.clients.base.http_error_handler import (
-    DefaultHttpErrorHandler,
-    ErrorCategory,
-    RequestContext,
-)
+from bioetl.domain.ports.resilience import ErrorCategory, RequestContext
+from bioetl.infrastructure.clients.base.http_error_handler import DefaultHttpErrorHandler
 from bioetl.infrastructure.errors import ApiUnexpectedStatusError
 
 
@@ -30,43 +27,43 @@ class TestDefaultHttpErrorHandler:
         """Test classification of successful status codes."""
         handler = DefaultHttpErrorHandler()
 
-        assert handler.classify_error(200) == ErrorCategory.SUCCESS
-        assert handler.classify_error(201) == ErrorCategory.SUCCESS
-        assert handler.classify_error(204) == ErrorCategory.SUCCESS
-        assert handler.classify_error(301) == ErrorCategory.SUCCESS
-        assert handler.classify_error(302) == ErrorCategory.SUCCESS
+        assert handler.classifier.classify(200) == ErrorCategory.SUCCESS
+        assert handler.classifier.classify(201) == ErrorCategory.SUCCESS
+        assert handler.classifier.classify(204) == ErrorCategory.SUCCESS
+        assert handler.classifier.classify(301) == ErrorCategory.SUCCESS
+        assert handler.classifier.classify(302) == ErrorCategory.SUCCESS
 
     def test_classify_error_rate_limit(self):
         """Test classification of rate limit status code."""
         handler = DefaultHttpErrorHandler()
 
-        assert handler.classify_error(429) == ErrorCategory.RATE_LIMIT
+        assert handler.classifier.classify(429) == ErrorCategory.RATE_LIMIT
 
     def test_classify_error_server_errors(self):
         """Test classification of 5xx server errors."""
         handler = DefaultHttpErrorHandler()
 
-        assert handler.classify_error(500) == ErrorCategory.SERVER_ERROR
-        assert handler.classify_error(502) == ErrorCategory.SERVER_ERROR
-        assert handler.classify_error(503) == ErrorCategory.SERVER_ERROR
-        assert handler.classify_error(504) == ErrorCategory.SERVER_ERROR
+        assert handler.classifier.classify(500) == ErrorCategory.SERVER_ERROR
+        assert handler.classifier.classify(502) == ErrorCategory.SERVER_ERROR
+        assert handler.classifier.classify(503) == ErrorCategory.SERVER_ERROR
+        assert handler.classifier.classify(504) == ErrorCategory.SERVER_ERROR
 
     def test_classify_error_client_errors(self):
         """Test classification of 4xx client errors."""
         handler = DefaultHttpErrorHandler()
 
-        assert handler.classify_error(400) == ErrorCategory.CLIENT_ERROR
-        assert handler.classify_error(401) == ErrorCategory.CLIENT_ERROR
-        assert handler.classify_error(403) == ErrorCategory.CLIENT_ERROR
-        assert handler.classify_error(404) == ErrorCategory.CLIENT_ERROR
-        assert handler.classify_error(422) == ErrorCategory.CLIENT_ERROR
+        assert handler.classifier.classify(400) == ErrorCategory.CLIENT_ERROR
+        assert handler.classifier.classify(401) == ErrorCategory.CLIENT_ERROR
+        assert handler.classifier.classify(403) == ErrorCategory.CLIENT_ERROR
+        assert handler.classifier.classify(404) == ErrorCategory.CLIENT_ERROR
+        assert handler.classifier.classify(422) == ErrorCategory.CLIENT_ERROR
 
     def test_classify_error_unknown(self):
         """Test classification of unknown status codes."""
         handler = DefaultHttpErrorHandler()
 
-        assert handler.classify_error(100) == ErrorCategory.UNKNOWN
-        assert handler.classify_error(600) == ErrorCategory.UNKNOWN
+        assert handler.classifier.classify(100) == ErrorCategory.UNKNOWN
+        assert handler.classifier.classify(600) == ErrorCategory.UNKNOWN
 
     def test_handle_success_response(self):
         """Test that successful responses return None."""

--- a/tests/bioetl/infrastructure/http/test_retry.py
+++ b/tests/bioetl/infrastructure/http/test_retry.py
@@ -24,3 +24,13 @@ def test_backoff_exponential():
     assert policy.get_backoff(1) == 1.0
     assert policy.get_backoff(2) == 2.0
     assert policy.get_backoff(3) == 4.0
+
+
+def test_backoff_cap():
+    policy = ExponentialRetryPolicy(
+        max_attempts=4, backoff_factor=10.0, backoff_max=15.0
+    )
+
+    assert policy.get_backoff(1) == 10.0
+    assert policy.get_backoff(2) == 15.0
+    assert policy.get_backoff(3) == 15.0

--- a/tests/integration/test_client_resilience_integration.py
+++ b/tests/integration/test_client_resilience_integration.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Thread
+from types import SimpleNamespace
+from typing import Any, Iterable
+from unittest.mock import MagicMock
+
+import pytest
+
+from bioetl.domain.configs import ChemblSourceConfig, ProviderHttpConfig
+from bioetl.domain.observability import LoggingPortABC, MetricsPortABC
+from bioetl.infrastructure.clients.chembl.factories import create_chembl_client
+from bioetl.infrastructure.errors import ApiUnexpectedStatusError
+
+
+@contextmanager
+def _run_server(sequence: Iterable[tuple[int, dict[str, Any]]]):
+    calls: dict[str, int] = {"count": 0}
+    sequence_list = list(sequence)
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            idx = min(calls["count"], len(sequence_list) - 1)
+            status, payload = sequence_list[idx]
+            calls["count"] += 1
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(payload).encode("utf-8"))
+
+        def log_message(self, format: str, *args: Any) -> None:  # noqa: A003
+            return
+
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        yield SimpleNamespace(base_url=f"http://{host}:{port}", calls=calls)
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+def _make_client(base_url: str, *, max_retries: int) -> Any:
+    http_config = ProviderHttpConfig(
+        base_url=base_url,
+        timeout_sec=1.0,
+        max_retries=max_retries,
+        backoff_factor=0.05,
+        backoff_max=0.05,
+    )
+    config = ChemblSourceConfig(http=http_config)
+    logger = MagicMock(spec=LoggingPortABC)
+    metrics = MagicMock(spec=MetricsPortABC)
+    return create_chembl_client(config, logger=logger, metrics=metrics, http_config=http_config)
+
+
+@pytest.mark.integration
+def test_chembl_client_retries_and_recovers():
+    """Client retries transient failures and returns payload on success."""
+
+    with _run_server([(503, {"error": "retry"}), (200, {"ok": True})]) as server:
+        client = _make_client(server.base_url, max_retries=2)
+
+        result = client.fetch("activity")
+
+        assert result == {"ok": True}
+        assert server.calls["count"] == 2
+
+
+@pytest.mark.integration
+def test_chembl_client_escalates_after_exhausting_retries():
+    """Client raises after exhausting retry budget."""
+
+    with _run_server([(500, {"error": "fail"}), (500, {"error": "fail"})]) as server:
+        client = _make_client(server.base_url, max_retries=1)
+
+        with pytest.raises(ApiUnexpectedStatusError):
+            client.fetch("activity")
+
+        assert server.calls["count"] == 2


### PR DESCRIPTION
## Summary
- add domain-level resilience strategy and shared HTTP error classifier
- refactor HTTP transport and ChEMBL client to use unified resilience mixin with consistent retries
- cover retry/escalation flows with integration tests and backoff unit coverage

## Testing
- pytest tests/bioetl/infrastructure/http/test_retry.py
- pytest tests/bioetl/infrastructure/clients/base/test_http_error_handler.py
- pytest tests/bioetl/infrastructure/clients/chembl/test_http_client.py
- pytest tests/integration/test_client_resilience_integration.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b18f7792c83249a141735b5df1f74)