### PR TITLE
Refactor pipeline registry to use factory registry only

### DIFF
--- a/src/bioetl/application/pipelines/__init__.py
+++ b/src/bioetl/application/pipelines/__init__.py
@@ -13,23 +13,20 @@ import from bioetl.application.contracts.
 
 from bioetl.application.pipelines.base import PipelineBase
 from bioetl.application.pipelines.registry import (
-    PIPELINE_REGISTRY,
     get_factory,
     get_pipeline_class,
     get_pipeline_factory,
     get_registered_factories,
-    get_registered_pipelines,
+    list_pipelines,
 )
 
 __all__ = [
     # Base class
     "PipelineBase",
-    # Registry
-    "PIPELINE_REGISTRY",
     # Factory functions
     "get_factory",
     "get_pipeline_class",
     "get_pipeline_factory",
     "get_registered_factories",
-    "get_registered_pipelines",
+    "list_pipelines",
 ]

--- a/src/bioetl/application/pipelines/chembl/factories.py
+++ b/src/bioetl/application/pipelines/chembl/factories.py
@@ -21,6 +21,8 @@ class ChemblPipelineFactory(PipelineFactoryABC):
     is fully configured before returning.
     """
 
+    pipeline_cls = ChemblPipelineBase
+
     def create(
         self,
         container: PipelineContainerABC,

--- a/src/bioetl/application/pipelines/registry.py
+++ b/src/bioetl/application/pipelines/registry.py
@@ -2,27 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Type
 
 from bioetl.application.contracts import PipelineFactoryABC
 from bioetl.application.pipelines.base import PipelineBase
-from bioetl.application.pipelines.chembl.base import ChemblPipelineBase
 from bioetl.application.pipelines.chembl.factories import ChemblPipelineFactory
 
-PipelineFactory = Callable[..., PipelineBase]
-
-# Registry mapping pipeline names to pipeline classes
-PIPELINE_REGISTRY: dict[str, PipelineFactory] = {
-    "activity_chembl": ChemblPipelineBase,
-    "assay_chembl": ChemblPipelineBase,
-    "publication_chembl": ChemblPipelineBase,
-    "target_chembl": ChemblPipelineBase,
-    "molecule_chembl": ChemblPipelineBase,
-}
-
 # Factory registry: maps pipeline names to their factory instances
-# This is the preferred way to create pipelines
 _FACTORY_REGISTRY: dict[str, PipelineFactoryABC] = {
     "activity_chembl": ChemblPipelineFactory(),
     "assay_chembl": ChemblPipelineFactory(),
@@ -32,43 +18,15 @@ _FACTORY_REGISTRY: dict[str, PipelineFactoryABC] = {
 }
 
 
-def get_pipeline_factory(name: str) -> PipelineFactory:
-    """Return factory callable for the given pipeline name."""
+def list_pipelines() -> list[str]:
+    """Return sorted list of available pipeline identifiers."""
 
-    try:
-        return PIPELINE_REGISTRY[name]
-    except KeyError as exc:
-        raise ValueError(
-            f"Pipeline '{name}' not found. Available: {list(PIPELINE_REGISTRY.keys())}"
-        ) from exc
+    return sorted(_FACTORY_REGISTRY.keys())
 
 
-def get_pipeline_class(name: str) -> Type[PipelineBase]:
-    """Return pipeline class for the given name when registered as a class."""
+def get_pipeline_factory(name: str) -> PipelineFactoryABC:
+    """Return the factory instance for the given pipeline name."""
 
-    factory = get_pipeline_factory(name)
-    if isinstance(factory, type) and issubclass(factory, PipelineBase):
-        return factory
-    raise ValueError(
-        f"Pipeline '{name}' is registered with a non-class factory: {factory}"
-    )
-
-
-def get_factory(name: str) -> PipelineFactoryABC:
-    """
-    Return the factory instance for creating pipelines of the given type.
-
-    This is the preferred method for obtaining pipeline factories.
-
-    Args:
-        name: Pipeline name (e.g., 'activity_chembl').
-
-    Returns:
-        Factory instance implementing PipelineFactoryABC.
-
-    Raises:
-        ValueError: If no factory is registered for the given name.
-    """
     try:
         return _FACTORY_REGISTRY[name]
     except KeyError as exc:
@@ -78,10 +36,22 @@ def get_factory(name: str) -> PipelineFactoryABC:
         ) from exc
 
 
-def get_registered_pipelines() -> dict[str, PipelineFactory]:
-    """Return a copy of the registered pipeline mapping."""
+def get_factory(name: str) -> PipelineFactoryABC:
+    """Backward-compatible alias for :func:`get_pipeline_factory`."""
 
-    return dict(PIPELINE_REGISTRY)
+    return get_pipeline_factory(name)
+
+
+def get_pipeline_class(name: str) -> Type[PipelineBase]:
+    """Return pipeline class exposed by the registered factory."""
+
+    factory = get_pipeline_factory(name)
+    pipeline_cls = getattr(factory, "pipeline_cls", None)
+    if isinstance(pipeline_cls, type) and issubclass(pipeline_cls, PipelineBase):
+        return pipeline_cls
+    raise ValueError(
+        f"Pipeline '{name}' is registered without accessible pipeline class"
+    )
 
 
 def get_registered_factories() -> dict[str, PipelineFactoryABC]:
@@ -91,11 +61,9 @@ def get_registered_factories() -> dict[str, PipelineFactoryABC]:
 
 
 __all__ = [
-    "PIPELINE_REGISTRY",
-    "PipelineFactory",
     "get_factory",
     "get_pipeline_class",
     "get_pipeline_factory",
     "get_registered_factories",
-    "get_registered_pipelines",
+    "list_pipelines",
 ]

--- a/src/bioetl/interfaces/cli/app.py
+++ b/src/bioetl/interfaces/cli/app.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any
 from rich.console import Console
 import typer
 
-from bioetl.application.pipelines.registry import PIPELINE_REGISTRY
+from bioetl.application.pipelines.registry import list_pipelines as list_registered_pipelines
 from bioetl.application.use_cases import RunPipelineRequest, RunPipelineResponse
 from bioetl.interfaces.application_context import get_application_context
 from bioetl.interfaces.composition_root import get_composition_root
@@ -44,7 +44,7 @@ def _present_result(response: RunPipelineResponse) -> None:
 def list_pipelines() -> None:
     """List all available pipelines."""
     console.print("[bold]Available Pipelines:[/bold]")
-    for name in sorted(PIPELINE_REGISTRY.keys()):
+    for name in list_registered_pipelines():
         console.print(f"  - {name}")
 
 

--- a/src/tools/check_registry_sync.py
+++ b/src/tools/check_registry_sync.py
@@ -91,14 +91,14 @@ def build_sync_report() -> RegistrySyncReport:
     index_paths = [root / "docs/ABC_INDEX.md", root / "docs/01-ABC/INDEX.md"]
     config_root = root / "configs/pipelines"
 
-    from bioetl.application.pipelines.registry import PIPELINE_REGISTRY
+    from bioetl.application.pipelines.registry import list_pipelines
 
     registry_names = _read_yaml_mapping(registry_path).keys()
 
     impl_names: set[str] = set()
     for path in impl_paths:
         impl_names.update(_read_yaml_mapping(path).keys())
-    pipeline_registry_names = PIPELINE_REGISTRY.keys()
+    pipeline_registry_names = list_pipelines()
     pipeline_config_names = _iter_pipeline_config_names(config_root)
 
     sections: list[SectionResult] = [

--- a/tests/bioetl/application/pipelines/test_registry.py
+++ b/tests/bioetl/application/pipelines/test_registry.py
@@ -1,17 +1,27 @@
 import pytest
 
+from bioetl.application.contracts import PipelineFactoryABC
 from bioetl.application.pipelines.base import PipelineBase
-from bioetl.application.pipelines.registry import PIPELINE_REGISTRY, get_pipeline_class
+from bioetl.application.pipelines.registry import (
+    get_pipeline_class,
+    get_pipeline_factory,
+    list_pipelines,
+)
 
 
 def test_get_pipeline_class_success():
     # Test getting all registered pipelines
-    for name, cls in PIPELINE_REGISTRY.items():
+    for name in list_pipelines():
         pipeline_cls = get_pipeline_class(name)
-        assert pipeline_cls == cls
         assert issubclass(pipeline_cls, PipelineBase)
 
 
 def test_get_pipeline_class_failure():
-    with pytest.raises(ValueError, match="Pipeline 'unknown' not found"):
+    with pytest.raises(ValueError, match="Pipeline factory 'unknown' not found"):
         get_pipeline_class("unknown")
+
+
+def test_get_pipeline_factory_success():
+    for name in list_pipelines():
+        factory = get_pipeline_factory(name)
+        assert isinstance(factory, PipelineFactoryABC)


### PR DESCRIPTION
## Summary
- consolidate pipeline registry on the single factory registry with facade helpers for discovery and lookup
- expose pipeline class via factory metadata and update CLI and tooling to use the unified registry API

## Testing
- python -m pytest tests/bioetl/application/pipelines/test_registry.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b1befc8148324ac6885c89d7c8aa4)