### PR TITLE
Remove services directory and fix deprecated datetime

### DIFF
--- a/src/bioetl/application/pipelines/chembl_activity.py
+++ b/src/bioetl/application/pipelines/chembl_activity.py
@@ -190,9 +190,9 @@ class ChEMBLActivityPipeline(BasePipeline):
             return Watermark(str(activity_id))
 
         # Fallback to timestamp
-        from datetime import datetime
+        from datetime import datetime, timezone
 
-        return Watermark(datetime.utcnow())
+        return Watermark(datetime.now(timezone.utc))
 
 
 class ChEMBLActivityPipelineFactory:

--- a/src/bioetl/infrastructure/observability/anomaly.py
+++ b/src/bioetl/infrastructure/observability/anomaly.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import logging
 import statistics
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import TYPE_CHECKING
 
@@ -281,7 +281,7 @@ class AnomalyDetector:
             anomaly_type=anomaly_type,
             severity=severity,
             z_score=z_score,
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
             message=message,
         )
 
@@ -328,7 +328,7 @@ class AnomalyDetector:
             anomaly_type=AnomalyType.THRESHOLD_EXCEEDED,
             severity=AnomalySeverity.CRITICAL,
             z_score=z_score,
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
             message=message,
         )
 

--- a/src/bioetl/infrastructure/observability/lineage.py
+++ b/src/bioetl/infrastructure/observability/lineage.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import asdict, dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
@@ -193,7 +193,7 @@ class LineageTracker:
             file_path=file_path,
             watermark=watermark,
             metadata=metadata or {},
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
         )
 
         self._write_batch_lineage(batch)
@@ -238,7 +238,7 @@ class LineageTracker:
             success_count=success_count,
             failure_count=failure_count,
             metadata=metadata or {},
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
         )
 
         self._write_transformation_lineage(lineage)
@@ -421,7 +421,7 @@ class LineageTracker:
             df = df.filter(pl.col("layer") == layer)
 
             # Filter by date range
-            cutoff = datetime.utcnow().timestamp() - (days * 86400)
+            cutoff = datetime.now(timezone.utc).timestamp() - (days * 86400)
             df = df.filter(pl.col("timestamp") >= cutoff)
 
             if df.height == 0:

--- a/src/bioetl/infrastructure/quarantine/unified_quarantine.py
+++ b/src/bioetl/infrastructure/quarantine/unified_quarantine.py
@@ -19,7 +19,7 @@ Architecture:
 import hashlib
 import json
 from collections.abc import Iterator
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from uuid import UUID
 
@@ -122,7 +122,7 @@ class UnifiedQuarantine:
 
         # Prepare quarantine record
         record = {
-            "ingestion_ts": datetime.utcnow().isoformat(),
+            "ingestion_ts": datetime.now(timezone.utc).isoformat(),
             "pipeline": pipeline,
             "error_code": error_code,
             "payload": payload_json,
@@ -266,7 +266,7 @@ class UnifiedQuarantine:
             mask = pc.and_(mask, pc.equal(arrow_table["error_code"], error_code))
 
         # Filter by max_age_days
-        cutoff_date = (datetime.utcnow() - timedelta(days=max_age_days)).isoformat()
+        cutoff_date = (datetime.now(timezone.utc) - timedelta(days=max_age_days)).isoformat()
         mask = pc.and_(
             mask,
             pc.greater_equal(arrow_table["ingestion_ts"], cutoff_date),
@@ -314,7 +314,7 @@ class UnifiedQuarantine:
             return 0
 
         # Calculate cutoff date
-        cutoff_date = (datetime.utcnow() - timedelta(days=older_than_days)).isoformat()
+        cutoff_date = (datetime.now(timezone.utc) - timedelta(days=older_than_days)).isoformat()
 
         # Delete old records using Delta Lake delete
         # Build predicate: pipeline = 'X' AND ingestion_ts < 'YYYY-MM-DD'

--- a/src/bioetl/infrastructure/storage/gold_writer.py
+++ b/src/bioetl/infrastructure/storage/gold_writer.py
@@ -14,7 +14,7 @@ Architecture:
 - Enforces data contracts
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 import pandera as pa
@@ -186,7 +186,7 @@ class GoldWriter:
         current_flag_col = scd_config.get("current_flag_col", "is_current")
 
         # Add SCD metadata to new records
-        now = datetime.utcnow().isoformat()
+        now = datetime.now(timezone.utc).isoformat()
         for record in records:
             record[valid_from_col] = now
             record[valid_to_col] = None  # Open-ended (current)
@@ -247,7 +247,7 @@ class GoldWriter:
         )
         merge_condition += f" AND target.{current_flag_col} = true"
 
-        now = datetime.utcnow().isoformat()
+        now = datetime.now(timezone.utc).isoformat()
 
         # Merge logic:
         # 1. Close old current records (set valid_to, is_current=False)

--- a/src/bioetl/services/__init__.py
+++ b/src/bioetl/services/__init__.py
@@ -1,1 +1,0 @@
-"""Services layer: application services and use cases."""


### PR DESCRIPTION
- Remove empty src/bioetl/services/ directory (unused dead code)
- Replace datetime.utcnow() with datetime.now(timezone.utc) across:
  - chembl_activity.py
  - anomaly.py
  - lineage.py
  - unified_quarantine.py
  - gold_writer.py

The datetime.utcnow() function is deprecated in Python 3.12+ because it returns naive datetime objects. Using datetime.now(timezone.utc) returns timezone-aware datetime objects which are more explicit and safer for time zone handling.