### PR TITLE
Fix missing dependencies lock file error

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -21,17 +21,10 @@ jobs:
           python-version: "3.11"
           cache: "pip"
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .[dev]
-          npm ci
 
       # /run-tests command
       - name: Run Tests (Coverage)


### PR DESCRIPTION
The project-automation workflow had Node.js setup with npm caching enabled, but this project has no package.json or package-lock.json. Removed the unused Node.js and npm ci steps since all workflow commands are Python-based.