### PR TITLE
Set up commitlint GitHub action workflow

### DIFF
--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -5,17 +5,17 @@ rules:
     type-enum:
         - 2
         - always
-        - feat
-        - fix
-        - docs
-        - style
-        - refactor
-        - perf
-        - test
-        - build
-        - ci
-        - chore
-        - revert
+        - - feat
+          - fix
+          - docs
+          - style
+          - refactor
+          - perf
+          - test
+          - build
+          - ci
+          - chore
+          - revert
 
     subject-case:
         - 2


### PR DESCRIPTION
This pull request makes a minor correction to the `.commitlintrc.yaml` configuration file, ensuring the list of allowed commit types is properly formatted as a nested list. This helps prevent configuration errors with commit linting tools.The type-enum rule requires the allowed values to be a nested array (third element), not individual items in the top-level array.