### PR TITLE
Fix mermaid CLI dry run option

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,13 @@ jobs:
         run: npm install -g @mermaid-js/mermaid-cli
 
       - name: Validate Mermaid diagrams
-        run: mmdc -i 'docs/**/*.mermaid' --dryRun
+        run: |
+          shopt -s globstar nullglob
+          for file in docs/**/*.mermaid; do
+            echo "Validating $file..."
+            mmdc -i "$file" -o /dev/null || exit 1
+          done
+          echo "All Mermaid diagrams validated successfully"
 
   render-diagrams:
     needs: validate-mermaid


### PR DESCRIPTION
The mmdc CLI does not have a --dryRun option. Replace with a loop that validates each mermaid file by rendering to /dev/null and checking the exit code.