### PR TITLE
Decompose BasePipeline into separate modules

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -32,5 +32,4 @@ forbidden_modules =
     bioetl.infrastructure.locking
     bioetl.infrastructure.checkpoint
     bioetl.infrastructure.quarantine
-ignore_imports =
-    bioetl.application.pipelines.chembl_activity -> bioetl.infrastructure.*
+    bioetl.infrastructure.factories

--- a/src/bioetl/application/pipeline/__init__.py
+++ b/src/bioetl/application/pipeline/__init__.py
@@ -1,1 +1,19 @@
 """Pipeline components and base classes."""
+
+from bioetl.application.pipeline.base import (
+    BasePipeline,
+    PipelineShutdownError,
+    run_pipeline_flow,
+)
+from bioetl.application.pipeline.checkpoint_manager import PipelineCheckpointManager
+from bioetl.application.pipeline.lock_manager import PipelineLockManager
+from bioetl.application.pipeline.record_processor import PipelineRecordProcessor
+
+__all__ = [
+    "BasePipeline",
+    "PipelineShutdownError",
+    "run_pipeline_flow",
+    "PipelineCheckpointManager",
+    "PipelineLockManager",
+    "PipelineRecordProcessor",
+]

--- a/src/bioetl/application/pipeline/base.py
+++ b/src/bioetl/application/pipeline/base.py
@@ -1,310 +1,95 @@
-"""Base ETL Pipeline class with Prefect integration.
+"""Base ETL Pipeline class with Prefect integration."""
 
-Implements RULES.md §4 - Generic ETL Pipeline pattern.
-
-Requirements:
-- Lock acquisition and heartbeat
-- Checkpoint save/restore
-- Graceful shutdown (SIGTERM/SIGINT)
-- Bronze → Silver → Gold flow
-- Error handling and quarantine
-- Observability (logging, metrics)
-- Prefect integration for orchestration
-"""
-
-import asyncio
-import json
-import signal
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator
 from datetime import datetime, UTC
 from typing import Any
 from uuid import uuid4
 
 from prefect import flow, task
 
+from bioetl.application.pipeline.checkpoint_manager import PipelineCheckpointManager
+from bioetl.application.pipeline.lock_manager import PipelineLockManager
+from bioetl.application.pipeline.record_processor import PipelineRecordProcessor
 from bioetl.domain.ports import (
-    CheckpointPort,
-    DataSourcePort,
-    LockPort,
-    QuarantinePort,
-    StoragePort,
+    CheckpointPort, DataSourcePort, LockPort, QuarantinePort, StoragePort,
 )
-from bioetl.domain.types import (
-    BatchID,
-    ErrorType,
-    RunID,
-    RunType,
-    Watermark,
-)
+from bioetl.domain.types import RunID, RunType, Watermark
 from bioetl.infrastructure.observability.logging import create_logger
 
 
 class PipelineShutdownError(Exception):
     """Raised when pipeline receives shutdown signal."""
 
-    pass
 
-
-@flow(
-    name="{self.pipeline_name}",
-    log_prints=True,
-    validate_parameters=False,
-)
+@flow(name="{self.pipeline_name}", log_prints=True, validate_parameters=False)
 async def run_pipeline_flow(pipeline: "BasePipeline") -> None:
     """Prefect flow to run the ETL pipeline."""
     await pipeline.run()
 
 
 class BasePipeline(ABC):
-    """Base class for ETL pipelines.
-
-    Implements common pipeline patterns:
-    - Lock acquisition with heartbeat
-    - Checkpoint management
-    - Graceful shutdown
-    - Bronze → Silver → Gold flow
-    - Error handling and quarantine
-
-    Example:
-        >>> class MyPipeline(BasePipeline):
-        ...     # ... implementation ...
-        ...
-        >>> pipeline = MyPipeline(...)
-        >>> await run_pipeline_flow(pipeline)
-    """
+    """Base class for ETL pipelines."""
 
     def __init__(
-        self,
-        pipeline_name: str,
-        provider: str,
-        entity_type: str,
-        run_type: RunType,
-        data_source: DataSourcePort,
-        storage: StoragePort,
-        lock: LockPort,
-        checkpoint: CheckpointPort,
-        quarantine: QuarantinePort,
+        self, pipeline_name: str, provider: str, entity_type: str,
+        run_type: RunType, data_source: DataSourcePort, storage: StoragePort,
+        lock: LockPort, checkpoint: CheckpointPort, quarantine: QuarantinePort,
         resume: bool = False,
     ) -> None:
-        self.pipeline_name = pipeline_name
-        self.provider = provider
-        self.entity_type = entity_type
-        self.run_type = run_type
-        self.data_source = data_source
-        self.storage = storage
-        self.lock = lock
-        self.checkpoint = checkpoint
-        self.quarantine = quarantine
-        self.resume = resume
-        self.run_id = RunID(uuid4())
-        self.shutdown_requested = False
-        self.heartbeat_task: asyncio.Task[None] | None = None
+        self.pipeline_name, self.provider, self.entity_type = pipeline_name, provider, entity_type
+        self.run_type, self.resume, self.run_id = run_type, resume, RunID(uuid4())
+        self.logger = create_logger(run_id=str(self.run_id), pipeline=pipeline_name)
         self.records_fetched = 0
-        self.records_bronze = 0
-        self.records_silver = 0
-        self.records_gold = 0
-        self.records_quarantined = 0
-        self.logger = create_logger(
-            run_id=str(self.run_id),
-            pipeline=pipeline_name,
+        self._lock_mgr = PipelineLockManager(lock, self.run_id, self.logger)
+        self._ckpt_mgr = PipelineCheckpointManager(checkpoint, pipeline_name, self.run_id, self.logger)
+        self._processor = PipelineRecordProcessor(
+            data_source, storage, quarantine, provider, entity_type,
+            pipeline_name, self.run_id, run_type, self.logger,
         )
 
     async def run(self) -> None:
-        """Execute pipeline. Main entry point."""
-        self.logger.info(
-            f"Starting pipeline: {self.pipeline_name}",
-            extra={"stage": "startup", "run_type": self.run_type.value},
-        )
-        self._setup_shutdown_handlers()
-
+        """Execute pipeline."""
+        self.logger.info(f"Starting pipeline: {self.pipeline_name}")
+        self._lock_mgr.setup_shutdown_handlers()
         lock_key = f"{self.provider}_{self.entity_type}"
         exclusive = self.run_type in (RunType.BACKFILL, RunType.REBUILD)
-
         try:
-            acquired = await self.lock.acquire(
-                key=lock_key, owner_id=self.run_id, wait=False, exclusive=exclusive
-            )
-            if not acquired:
-                self.logger.error(f"Failed to acquire lock for {lock_key}")
+            if not await self._lock_mgr.acquire(lock_key, exclusive):
                 return
-
-            self.logger.info(f"Lock acquired for {lock_key}")
-            self.heartbeat_task = asyncio.create_task(
-                self._heartbeat_loop(lock_key, exclusive)
-            )
-
-            watermark = await self._load_checkpoint_task()
-            await self._execute_pipeline_task(watermark)
-            await self._delete_checkpoint_task()
-
-            self.logger.info(
-                "Pipeline completed successfully",
-                extra={
-                    "stage": "complete",
-                    "records_fetched": self.records_fetched,
-                },
-            )
+            watermark = await self._ckpt_mgr.load(self.resume)
+            await self._execute_pipeline(watermark)
+            await self._ckpt_mgr.delete()
+            self.logger.info("Pipeline completed", extra={"records": self.records_fetched})
         except PipelineShutdownError:
-            self.logger.warning(
-                "Pipeline shutdown requested", extra={"stage": "shutdown"}
-            )
-            raise
-        except Exception as e:
-            self.logger.error(f"Pipeline failed: {e}", exc_info=True)
+            self.logger.warning("Pipeline shutdown requested")
             raise
         finally:
-            if self.heartbeat_task:
-                self.heartbeat_task.cancel()
-            await self.lock.release(lock_key, self.run_id, exclusive=exclusive)
-            self.logger.info("Lock released", extra={"stage": "cleanup"})
-
-    @task(name="Load Checkpoint")
-    async def _load_checkpoint_task(self) -> Watermark | None:
-        if self.resume:
-            checkpoint_data = self.checkpoint.load(self.pipeline_name)
-            if checkpoint_data:
-                watermark, _, metadata = checkpoint_data
-                self.logger.info(
-                    f"Resuming from checkpoint: {watermark}",
-                    extra={"metadata": metadata},
-                )
-                return watermark
-        return None
+            await self._lock_mgr.release(lock_key, exclusive)
 
     @task(name="Execute Pipeline")
-    async def _execute_pipeline_task(self, watermark: Watermark | None) -> None:
-        """Execute main pipeline logic as a Prefect task."""
-        async for raw_record in self._extract(watermark):
-            if self.shutdown_requested:
+    async def _execute_pipeline(self, watermark: Watermark | None) -> None:
+        async for raw in self._processor.extract(watermark):
+            if self._lock_mgr.shutdown_requested:
                 raise PipelineShutdownError("Shutdown during extraction")
-
             self.records_fetched += 1
-            batch_id = await self._load_bronze(raw_record)
-            self.records_bronze += 1
-
+            batch_id = await self._processor.load_bronze(raw)
             try:
-                transformed = await self.transform_bronze_to_silver(raw_record)
-                if transformed:
-                    await self._load_silver(transformed, batch_id)
-                    self.records_silver += 1
-                    if self.should_write_gold(transformed):
-                        await self._load_gold(transformed)
-                        self.records_gold += 1
+                silver = await self.transform_bronze_to_silver(raw)
+                if silver:
+                    await self._processor.load_silver(silver, batch_id)
+                    if self.should_write_gold(silver):
+                        await self._processor.load_gold(silver)
             except Exception as e:
-                error_type = self._classify_error(e)
-                if error_type.is_data_quality():
-                    await self._quarantine_record(
-                        raw_record, error_type, batch_id, str(e)
-                    )
-                    self.records_quarantined += 1
+                err_type = PipelineRecordProcessor.classify_error(e)
+                if err_type.is_data_quality():
+                    await self._processor.quarantine_record(raw, err_type, batch_id, str(e))
                 else:
                     raise
-
             if self.records_fetched % 1000 == 0:
-                await self._save_checkpoint(raw_record)
-
-    @task(name="Delete Checkpoint")
-    async def _delete_checkpoint_task(self) -> None:
-        self.checkpoint.delete(self.pipeline_name)
-
-    async def _extract(
-        self, watermark: Watermark | None
-    ) -> AsyncIterator[dict[str, Any]]:
-        async for record in self.data_source.fetch(
-            entity_type=self.entity_type, watermark=watermark
-        ):
-            yield record
-
-    async def _load_bronze(self, record: dict[str, Any]) -> BatchID:
-        batch_id = BatchID(uuid4())
-        record_bytes = (json.dumps(record) + "\n").encode("utf-8")
-        self.storage.write_bronze(
-            records=iter([record_bytes]),
-            provider=self.provider,
-            entity=self.entity_type,
-            date=datetime.now(UTC),
-            batch_id=batch_id,
-        )
-        return batch_id
-
-    async def _load_silver(self, record: dict[str, Any], batch_id: BatchID) -> None:
-        record_with_meta = {
-            **record,
-            "_run_id": str(self.run_id),
-            "_run_type": self.run_type.value,
-            "_source_batch_id": str(batch_id),
-            "_ingestion_ts": datetime.now(UTC).isoformat(),
-        }
-        table_name = f"{self.provider}.{self.entity_type}"
-        self.storage.write_silver(
-            table_name=table_name,
-            records=[record_with_meta],
-            primary_keys=["entity_id"],
-        )
-
-    async def _load_gold(self, record: dict[str, Any]) -> None:
-        table_name = f"{self.provider}.{self.entity_type}_gold"
-        self.storage.write_gold(table_name=table_name, records=[record], mode="append")
-
-    async def _quarantine_record(
-        self,
-        record: dict[str, Any],
-        error_type: ErrorType,
-        batch_id: BatchID,
-        error_details: str,
-    ) -> None:
-        self.quarantine.write(
-            pipeline=self.pipeline_name,
-            error_code=error_type.value,
-            payload=record,
-            bronze_batch_id=batch_id,
-            error_details={"message": error_details},
-        )
-
-    async def _save_checkpoint(self, last_record: dict[str, Any]) -> None:
-        watermark = self.extract_watermark(last_record)
-        self.checkpoint.save(
-            pipeline=self.pipeline_name,
-            watermark=watermark,
-            run_id=self.run_id,
-            metadata={"records_processed": self.records_fetched},
-        )
-
-    async def _heartbeat_loop(self, lock_key: str, exclusive: bool) -> None:
-        while not self.shutdown_requested:
-            await asyncio.sleep(20)
-            success = await self.lock.heartbeat(
-                lock_key, self.run_id, exclusive=exclusive
-            )
-            if not success:
-                self.logger.error("Lost lock during execution!")
-                self.shutdown_requested = True
-                raise PipelineShutdownError("Lock lost")
-
-    def _setup_shutdown_handlers(self) -> None:
-        def signal_handler(signum: int, _: Any) -> None:
-            self.logger.warning(
-                f"Received signal {signum}, initiating graceful shutdown"
-            )
-            self.shutdown_requested = True
-
-        signal.signal(signal.SIGTERM, signal_handler)
-        signal.signal(signal.SIGINT, signal_handler)
-
-    def _classify_error(self, error: Exception) -> ErrorType:
-        error_name = type(error).__name__
-        if "Schema" in error_name or "Validation" in error_name:
-            return ErrorType.SCHEMA_VIOLATION
-        elif "Missing" in error_name or "Required" in error_name:
-            return ErrorType.MISSING_REQUIRED_FIELD
-        else:
-            return ErrorType.INVALID_DATA
+                await self._ckpt_mgr.save(self.extract_watermark(raw), self.records_fetched)
 
     @abstractmethod
-    async def transform_bronze_to_silver(
-        self, record: dict[str, Any]
-    ) -> dict[str, Any] | None:
+    async def transform_bronze_to_silver(self, record: dict[str, Any]) -> dict[str, Any] | None:
         pass
 
     def should_write_gold(self, _: dict[str, Any]) -> bool:

--- a/src/bioetl/application/pipeline/checkpoint_manager.py
+++ b/src/bioetl/application/pipeline/checkpoint_manager.py
@@ -1,0 +1,66 @@
+"""Checkpoint management for ETL pipelines.
+
+Handles checkpoint save, load, and delete operations.
+"""
+
+from typing import TYPE_CHECKING, Any
+
+from prefect import task
+
+from bioetl.domain.ports import CheckpointPort
+from bioetl.domain.types import RunID, Watermark
+
+if TYPE_CHECKING:
+    from bioetl.infrastructure.observability.logging import PipelineLogger
+
+
+class PipelineCheckpointManager:
+    """Manages checkpoints for pipeline resumability.
+
+    Handles:
+    - Checkpoint loading on resume
+    - Periodic checkpoint saving
+    - Checkpoint cleanup on completion
+    """
+
+    def __init__(
+        self,
+        checkpoint: CheckpointPort,
+        pipeline_name: str,
+        run_id: RunID,
+        logger: "PipelineLogger",
+    ) -> None:
+        self.checkpoint = checkpoint
+        self.pipeline_name = pipeline_name
+        self.run_id = run_id
+        self.logger = logger
+
+    @task(name="Load Checkpoint")
+    async def load(self, resume: bool) -> Watermark | None:
+        """Load checkpoint if resuming."""
+        if resume:
+            checkpoint_data = self.checkpoint.load(self.pipeline_name)
+            if checkpoint_data:
+                watermark, _, metadata = checkpoint_data
+                self.logger.info(
+                    f"Resuming from checkpoint: {watermark}",
+                    extra={"metadata": metadata},
+                )
+                return watermark
+        return None
+
+    async def save(
+        self, watermark: Watermark, records_processed: int
+    ) -> None:
+        """Save checkpoint with current progress."""
+        self.checkpoint.save(
+            pipeline=self.pipeline_name,
+            watermark=watermark,
+            run_id=self.run_id,
+            metadata={"records_processed": records_processed},
+        )
+
+    @task(name="Delete Checkpoint")
+    async def delete(self) -> None:
+        """Delete checkpoint on successful completion."""
+        self.checkpoint.delete(self.pipeline_name)

--- a/src/bioetl/application/pipeline/lock_manager.py
+++ b/src/bioetl/application/pipeline/lock_manager.py
@@ -1,0 +1,89 @@
+"""Lock management for ETL pipelines."""
+
+import asyncio
+import signal
+from typing import TYPE_CHECKING, Any
+
+from bioetl.domain.ports import LockPort
+from bioetl.domain.types import RunID
+
+if TYPE_CHECKING:
+    from bioetl.infrastructure.observability.logging import PipelineLogger
+
+
+class PipelineLockManager:
+    """Manages distributed locks for pipeline execution.
+
+    Handles:
+    - Lock acquisition with exclusive/shared modes
+    - Heartbeat loop to maintain lock
+    - Graceful release on shutdown
+    """
+
+    def __init__(
+        self,
+        lock: LockPort,
+        run_id: RunID,
+        logger: "PipelineLogger",
+    ) -> None:
+        self.lock = lock
+        self.run_id = run_id
+        self.logger = logger
+        self.heartbeat_task: asyncio.Task[None] | None = None
+        self._shutdown_requested = False
+
+    @property
+    def shutdown_requested(self) -> bool:
+        return self._shutdown_requested
+
+    @shutdown_requested.setter
+    def shutdown_requested(self, value: bool) -> None:
+        self._shutdown_requested = value
+
+    async def acquire(self, lock_key: str, exclusive: bool) -> bool:
+        """Acquire lock and start heartbeat."""
+        acquired = await self.lock.acquire(
+            key=lock_key, owner_id=self.run_id, wait=False, exclusive=exclusive
+        )
+        if not acquired:
+            self.logger.error(f"Failed to acquire lock for {lock_key}")
+            return False
+
+        self.logger.info(f"Lock acquired for {lock_key}")
+        self.heartbeat_task = asyncio.create_task(
+            self._heartbeat_loop(lock_key, exclusive)
+        )
+        return True
+
+    async def release(self, lock_key: str, exclusive: bool) -> None:
+        """Stop heartbeat and release lock."""
+        if self.heartbeat_task:
+            self.heartbeat_task.cancel()
+            try:
+                await self.heartbeat_task
+            except asyncio.CancelledError:
+                pass
+        await self.lock.release(lock_key, self.run_id, exclusive=exclusive)
+        self.logger.info("Lock released", extra={"stage": "cleanup"})
+
+    async def _heartbeat_loop(self, lock_key: str, exclusive: bool) -> None:
+        """Maintain lock with periodic heartbeats."""
+        while not self._shutdown_requested:
+            await asyncio.sleep(20)
+            success = await self.lock.heartbeat(
+                lock_key, self.run_id, exclusive=exclusive
+            )
+            if not success:
+                self.logger.error("Lost lock during execution!")
+                self._shutdown_requested = True
+                from bioetl.application.pipeline.base import PipelineShutdownError
+
+                raise PipelineShutdownError("Lock lost")
+
+    def setup_shutdown_handlers(self) -> None:
+        """Setup signal handlers for graceful shutdown."""
+        def handler(signum: int, _: Any) -> None:
+            self.logger.warning(f"Signal {signum}, initiating shutdown")
+            self._shutdown_requested = True
+        signal.signal(signal.SIGTERM, handler)
+        signal.signal(signal.SIGINT, handler)

--- a/src/bioetl/application/pipeline/record_processor.py
+++ b/src/bioetl/application/pipeline/record_processor.py
@@ -1,0 +1,127 @@
+"""Record processing for ETL pipelines.
+
+Handles extraction, transformation, and loading of records.
+"""
+
+import json
+from collections.abc import AsyncIterator
+from datetime import datetime, UTC
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+from bioetl.domain.ports import (
+    DataSourcePort,
+    QuarantinePort,
+    StoragePort,
+)
+from bioetl.domain.types import BatchID, ErrorType, RunID, RunType, Watermark
+
+if TYPE_CHECKING:
+    from bioetl.infrastructure.observability.logging import PipelineLogger
+
+
+class PipelineRecordProcessor:
+    """Processes records through Bronze → Silver → Gold layers.
+
+    Handles:
+    - Extraction from data source
+    - Bronze layer writing
+    - Silver layer transformation and writing
+    - Gold layer filtering and writing
+    - Error classification and quarantine
+    """
+
+    def __init__(
+        self,
+        data_source: DataSourcePort,
+        storage: StoragePort,
+        quarantine: QuarantinePort,
+        provider: str,
+        entity_type: str,
+        pipeline_name: str,
+        run_id: RunID,
+        run_type: RunType,
+        logger: "PipelineLogger",
+    ) -> None:
+        self.data_source = data_source
+        self.storage = storage
+        self.quarantine = quarantine
+        self.provider = provider
+        self.entity_type = entity_type
+        self.pipeline_name = pipeline_name
+        self.run_id = run_id
+        self.run_type = run_type
+        self.logger = logger
+
+    async def extract(
+        self, watermark: Watermark | None
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Extract records from data source."""
+        async for record in self.data_source.fetch(
+            entity_type=self.entity_type, watermark=watermark
+        ):
+            yield record
+
+    async def load_bronze(self, record: dict[str, Any]) -> BatchID:
+        """Write raw record to Bronze layer."""
+        batch_id = BatchID(uuid4())
+        record_bytes = (json.dumps(record) + "\n").encode("utf-8")
+        self.storage.write_bronze(
+            records=iter([record_bytes]),
+            provider=self.provider,
+            entity=self.entity_type,
+            date=datetime.now(UTC),
+            batch_id=batch_id,
+        )
+        return batch_id
+
+    async def load_silver(
+        self, record: dict[str, Any], batch_id: BatchID
+    ) -> None:
+        """Write transformed record to Silver layer."""
+        record_with_meta = {
+            **record,
+            "_run_id": str(self.run_id),
+            "_run_type": self.run_type.value,
+            "_source_batch_id": str(batch_id),
+            "_ingestion_ts": datetime.now(UTC).isoformat(),
+        }
+        table_name = f"{self.provider}.{self.entity_type}"
+        self.storage.write_silver(
+            table_name=table_name,
+            records=[record_with_meta],
+            primary_keys=["entity_id"],
+        )
+
+    async def load_gold(self, record: dict[str, Any]) -> None:
+        """Write record to Gold layer."""
+        table_name = f"{self.provider}.{self.entity_type}_gold"
+        self.storage.write_gold(
+            table_name=table_name, records=[record], mode="append"
+        )
+
+    async def quarantine_record(
+        self,
+        record: dict[str, Any],
+        error_type: ErrorType,
+        batch_id: BatchID,
+        error_details: str,
+    ) -> None:
+        """Send failed record to quarantine."""
+        self.quarantine.write(
+            pipeline=self.pipeline_name,
+            error_code=error_type.value,
+            payload=record,
+            bronze_batch_id=batch_id,
+            error_details={"message": error_details},
+        )
+
+    @staticmethod
+    def classify_error(error: Exception) -> ErrorType:
+        """Classify exception to determine error type."""
+        error_name = type(error).__name__
+        if "Schema" in error_name or "Validation" in error_name:
+            return ErrorType.SCHEMA_VIOLATION
+        elif "Missing" in error_name or "Required" in error_name:
+            return ErrorType.MISSING_REQUIRED_FIELD
+        return ErrorType.INVALID_DATA

--- a/src/bioetl/application/pipelines/chembl_activity.py
+++ b/src/bioetl/application/pipelines/chembl_activity.py
@@ -1,7 +1,7 @@
 """ChEMBL Activity Pipeline.
 
 Fetches bioactivity data from ChEMBL database and processes it through
-Bronze → Silver → Gold layers.
+Bronze -> Silver -> Gold layers.
 
 Entity: Bioactivity measurements (IC50, Ki, EC50, etc.)
 Provider: ChEMBL (https://www.ebi.ac.uk/chembl/)
@@ -21,24 +21,9 @@ class ChEMBLActivityPipeline(BasePipeline):
     - Bronze: Raw JSON from ChEMBL API
     - Silver: Normalized with entity_id, content_hash, metadata
     - Gold: Filtered high-quality activities (optional)
-
-    Example:
-        >>> from bioetl.infrastructure.adapters.chembl.client import ChemblAdapter
-        >>> from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
-        >>> # ... initialize adapters
-        >>> pipeline = ChEMBLActivityPipeline(
-        ...     run_type=RunType.INCREMENTAL,
-        ...     data_source=chembl_adapter,
-        ...     storage=storage_adapter,
-        ...     lock=redis_lock,
-        ...     checkpoint=s3_checkpoint,
-        ...     quarantine=quarantine,
-        ... )
-        >>> await pipeline.run()
     """
 
     def __init__(self, **kwargs: Any) -> None:
-        """Initialize ChEMBL Activity pipeline."""
         super().__init__(
             pipeline_name="chembl_activity",
             provider="chembl",
@@ -50,117 +35,55 @@ class ChEMBLActivityPipeline(BasePipeline):
         self,
         record: dict[str, Any],
     ) -> dict[str, Any] | None:
-        """Transform raw ChEMBL activity to normalized format.
-
-        Args:
-            record: Raw activity record from ChEMBL
-
-        Returns:
-            Normalized record or None if should skip
-
-        Transformation logic:
-        1. Generate stable entity_id from activity_id
-        2. Extract key fields (molecule, target, assay)
-        3. Normalize units and values
-        4. Generate content_hash for deduplication
-        5. Add metadata fields
-        """
-        # Skip if missing critical fields
+        """Transform raw ChEMBL activity to normalized format."""
         if not record.get("activity_id"):
             return None
 
-        # Extract core fields
         activity_id = str(record["activity_id"])
-        molecule_chembl_id = record.get("molecule_chembl_id")
-        target_chembl_id = record.get("target_chembl_id")
-        assay_chembl_id = record.get("assay_chembl_id")
-
-        # Generate entity_id (stable identifier)
         entity_id = generate_entity_id(
             record={"activity_id": activity_id},
             provider=self.provider,
             id_field="activity_id",
         )
 
-        # Extract measurement data
-        standard_type = record.get("standard_type")  # IC50, Ki, EC50, etc.
         standard_value = record.get("standard_value")
-        standard_units = record.get("standard_units")
-        standard_relation = record.get("standard_relation")  # =, <, >, ~
-
-        # Convert value to float if present
         if standard_value is not None:
             try:
                 standard_value = float(standard_value)
             except (ValueError, TypeError):
                 standard_value = None
 
-        # Extract assay information
-        assay_type = record.get("assay_type")
-        assay_description = record.get("assay_description")
-
-        # Extract publication info
-        document_chembl_id = record.get("document_chembl_id")
-        document_year = record.get("document_year")
-
-        # Build normalized record
         normalized = {
             "entity_id": entity_id,
             "activity_id": activity_id,
-            "molecule_chembl_id": molecule_chembl_id,
-            "target_chembl_id": target_chembl_id,
-            "assay_chembl_id": assay_chembl_id,
-            "standard_type": standard_type,
+            "molecule_chembl_id": record.get("molecule_chembl_id"),
+            "target_chembl_id": record.get("target_chembl_id"),
+            "assay_chembl_id": record.get("assay_chembl_id"),
+            "standard_type": record.get("standard_type"),
             "standard_value": standard_value,
-            "standard_units": standard_units,
-            "standard_relation": standard_relation,
-            "assay_type": assay_type,
-            "assay_description": assay_description,
-            "document_chembl_id": document_chembl_id,
-            "document_year": document_year,
-            # Additional fields
-            "pchembl_value": record.get(
-                "pchembl_value"
-            ),  # -log10(molar IC50, XC50, etc)
+            "standard_units": record.get("standard_units"),
+            "standard_relation": record.get("standard_relation"),
+            "assay_type": record.get("assay_type"),
+            "assay_description": record.get("assay_description"),
+            "document_chembl_id": record.get("document_chembl_id"),
+            "document_year": record.get("document_year"),
+            "pchembl_value": record.get("pchembl_value"),
             "activity_comment": record.get("activity_comment"),
             "data_validity_comment": record.get("data_validity_comment"),
         }
 
-        # Generate content_hash for versioning
-        content_hash = generate_content_hash(normalized, self.provider)
-        normalized["content_hash"] = content_hash
-
+        normalized["content_hash"] = generate_content_hash(normalized, self.provider)
         return normalized
 
     def should_write_gold(self, record: dict[str, Any]) -> bool:
-        """Filter records for Gold layer.
-
-        Gold layer criteria:
-        - Must have standard_value (not null)
-        - Must have standard_units
-        - Must have target_chembl_id
-        - Preferred standard_types: IC50, Ki, EC50, Kd
-        - No data validity issues
-
-        Args:
-            record: Silver record
-
-        Returns:
-            True if passes quality filters
-        """
-        # Must have measurement value
+        """Filter records for Gold layer."""
         if record.get("standard_value") is None:
             return False
-
-        # Must have units
         if not record.get("standard_units"):
             return False
-
-        # Must have target
         if not record.get("target_chembl_id"):
             return False
 
-        # Prefer certain measurement types
         standard_type = record.get("standard_type")
         preferred_types = {"IC50", "Ki", "EC50", "Kd", "AC50", "GI50"}
 
@@ -170,164 +93,10 @@ class ChEMBLActivityPipeline(BasePipeline):
         return not record.get("data_validity_comment")
 
     def extract_watermark(self, record: dict[str, Any]) -> Watermark:
-        """Extract watermark from record.
-
-        Uses activity_id as watermark for incremental loading.
-
-        Args:
-            record: Activity record
-
-        Returns:
-            Watermark (activity_id)
-        """
+        """Extract watermark from record."""
         activity_id = record.get("activity_id")
         if activity_id:
             return Watermark(str(activity_id))
 
-        # Fallback to timestamp
         from datetime import datetime, UTC
-
         return Watermark(datetime.now(UTC))
-
-
-class ChEMBLActivityPipelineFactory:
-    """Factory for creating ChEMBL Activity pipelines.
-
-    Simplifies pipeline instantiation by handling adapter initialization.
-
-    Example:
-        >>> factory = ChEMBLActivityPipelineFactory()
-        >>> pipeline = await factory.create(
-        ...     run_type=RunType.INCREMENTAL,
-        ...     resume=False,
-        ... )
-        >>> await pipeline.run()
-    """
-
-    @staticmethod
-    async def create(
-        run_type: Any,  # RunType
-        resume: bool = False,
-        # Adapter configurations
-        s3_bucket_bronze: str = "bioetl-bronze",
-        s3_bucket_silver: str = "bioetl-silver",
-        s3_bucket_checkpoints: str = "bioetl-checkpoints",
-        redis_host: str = "localhost",
-        redis_port: int = 6379,
-        # S3/MinIO config
-        aws_endpoint_url: str | None = None,
-        aws_access_key: str | None = None,
-        aws_secret_key: str | None = None,
-    ) -> ChEMBLActivityPipeline:
-        """Create configured ChEMBL Activity pipeline.
-
-        Args:
-            run_type: Type of run (incremental, backfill, rebuild)
-            resume: Resume from checkpoint if available
-            s3_bucket_bronze: Bronze bucket name
-            s3_bucket_silver: Silver bucket name
-            s3_bucket_checkpoints: Checkpoints bucket name
-            redis_host: Redis host
-            redis_port: Redis port
-            aws_endpoint_url: S3 endpoint (for MinIO)
-            aws_access_key: AWS access key
-            aws_secret_key: AWS secret key
-
-        Returns:
-            Configured pipeline instance
-        """
-        from bioetl.infrastructure.adapters.chembl.client import ChemblAdapter
-        from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
-        from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
-        from bioetl.infrastructure.adapters.http.rate_limiter import TokenBucket
-        from bioetl.infrastructure.checkpoint.s3_checkpoint import S3Checkpoint
-        from bioetl.infrastructure.locking.redis_lock import RedisDistributedLock
-        from bioetl.infrastructure.quarantine.unified_quarantine import (
-            UnifiedQuarantine,
-        )
-        from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
-        from bioetl.infrastructure.storage.delta_writer import DeltaWriter
-
-        # Create storage adapter wrapper
-        class StorageAdapter:
-            """Unified storage adapter for Bronze/Silver/Gold."""
-
-            def __init__(
-                self,
-                bronze_writer: BronzeWriter,
-                silver_writer: DeltaWriter,
-                gold_writer: DeltaWriter,
-            ):
-                self.bronze = bronze_writer
-                self.silver = silver_writer
-                self.gold = gold_writer
-
-            def write_bronze(self, *args: Any, **kwargs: Any) -> Any:
-                return self.bronze.write_bronze(*args, **kwargs)
-
-            def write_silver(self, *args: Any, **kwargs: Any) -> None:
-                return self.silver.write_silver(*args, **kwargs)
-
-            def write_gold(self, *args: Any, **kwargs: Any) -> None:
-                return self.gold.write_gold(*args, **kwargs)
-
-        # Initialize adapters
-        storage_options = {
-            "AWS_ENDPOINT_URL": aws_endpoint_url,
-            "AWS_ACCESS_KEY_ID": aws_access_key,
-            "AWS_SECRET_ACCESS_KEY": aws_secret_key,
-        }
-
-        # Data source (ChEMBL)
-        bucket = TokenBucket(rate=10.0, capacity=20)
-        circuit_breaker = CircuitBreaker(provider="chembl")
-        http_client = UnifiedHTTPClient(bucket, circuit_breaker)
-        data_source = ChemblAdapter(http_client=http_client)
-
-        # Storage
-        bronze_writer = BronzeWriter(
-            bucket=s3_bucket_bronze,
-            endpoint_url=aws_endpoint_url,
-            access_key=aws_access_key,
-            secret_key=aws_secret_key,
-        )
-        silver_writer = DeltaWriter(
-            base_path=f"s3://{s3_bucket_silver}",
-            storage_options=storage_options if aws_endpoint_url else None,
-        )
-        gold_writer = DeltaWriter(
-            base_path=f"s3://{s3_bucket_silver}",  # Same bucket, different tables
-            storage_options=storage_options if aws_endpoint_url else None,
-        )
-        storage = StorageAdapter(bronze_writer, silver_writer, gold_writer)
-
-        # Lock (Redis)
-        import redis.asyncio as aioredis
-
-        redis_client = aioredis.Redis(host=redis_host, port=redis_port)
-        lock = RedisDistributedLock(redis_client=redis_client)
-
-        # Checkpoint (S3)
-        checkpoint = S3Checkpoint(
-            bucket=s3_bucket_checkpoints,
-            endpoint_url=aws_endpoint_url,
-            access_key=aws_access_key,
-            secret_key=aws_secret_key,
-        )
-
-        # Quarantine
-        quarantine = UnifiedQuarantine(
-            base_path=f"s3://{s3_bucket_silver}/common/quarantine",
-            storage_options=storage_options if aws_endpoint_url else None,
-        )
-
-        # Create pipeline
-        return ChEMBLActivityPipeline(
-            run_type=run_type,
-            data_source=data_source,
-            storage=storage,
-            lock=lock,
-            checkpoint=checkpoint,
-            quarantine=quarantine,
-            resume=resume,
-        )

--- a/src/bioetl/infrastructure/factories/__init__.py
+++ b/src/bioetl/infrastructure/factories/__init__.py
@@ -1,0 +1,1 @@
+"""Pipeline factories for dependency injection."""

--- a/src/bioetl/infrastructure/factories/chembl_activity.py
+++ b/src/bioetl/infrastructure/factories/chembl_activity.py
@@ -1,0 +1,115 @@
+"""ChEMBL Activity Pipeline factory.
+
+Handles infrastructure wiring for ChEMBL Activity pipeline.
+"""
+
+from typing import Any
+
+from bioetl.application.pipelines.chembl_activity import ChEMBLActivityPipeline
+from bioetl.infrastructure.adapters.chembl.client import ChemblAdapter
+from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
+from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
+from bioetl.infrastructure.adapters.http.rate_limiter import TokenBucket
+from bioetl.infrastructure.checkpoint.s3_checkpoint import S3Checkpoint
+from bioetl.infrastructure.locking.redis_lock import RedisDistributedLock
+from bioetl.infrastructure.quarantine.unified_quarantine import UnifiedQuarantine
+from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
+from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+
+
+class StorageAdapter:
+    """Unified storage adapter for Bronze/Silver/Gold."""
+
+    def __init__(
+        self,
+        bronze_writer: BronzeWriter,
+        silver_writer: DeltaWriter,
+        gold_writer: DeltaWriter,
+    ):
+        self.bronze = bronze_writer
+        self.silver = silver_writer
+        self.gold = gold_writer
+
+    def write_bronze(self, *args: Any, **kwargs: Any) -> Any:
+        return self.bronze.write_bronze(*args, **kwargs)
+
+    def write_silver(self, *args: Any, **kwargs: Any) -> None:
+        return self.silver.write_silver(*args, **kwargs)
+
+    def write_gold(self, *args: Any, **kwargs: Any) -> None:
+        return self.gold.write_gold(*args, **kwargs)
+
+
+class ChEMBLActivityPipelineFactory:
+    """Factory for creating ChEMBL Activity pipelines.
+
+    Simplifies pipeline instantiation by handling adapter initialization.
+    """
+
+    @staticmethod
+    async def create(
+        run_type: Any,
+        resume: bool = False,
+        s3_bucket_bronze: str = "bioetl-bronze",
+        s3_bucket_silver: str = "bioetl-silver",
+        s3_bucket_checkpoints: str = "bioetl-checkpoints",
+        redis_host: str = "localhost",
+        redis_port: int = 6379,
+        aws_endpoint_url: str | None = None,
+        aws_access_key: str | None = None,
+        aws_secret_key: str | None = None,
+    ) -> ChEMBLActivityPipeline:
+        """Create configured ChEMBL Activity pipeline."""
+        import redis.asyncio as aioredis
+
+        storage_options = {
+            "AWS_ENDPOINT_URL": aws_endpoint_url,
+            "AWS_ACCESS_KEY_ID": aws_access_key,
+            "AWS_SECRET_ACCESS_KEY": aws_secret_key,
+        }
+
+        bucket = TokenBucket(rate=10.0, capacity=20)
+        circuit_breaker = CircuitBreaker(provider="chembl")
+        http_client = UnifiedHTTPClient(bucket, circuit_breaker)
+        data_source = ChemblAdapter(http_client=http_client)
+
+        bronze_writer = BronzeWriter(
+            bucket=s3_bucket_bronze,
+            endpoint_url=aws_endpoint_url,
+            access_key=aws_access_key,
+            secret_key=aws_secret_key,
+        )
+        silver_writer = DeltaWriter(
+            base_path=f"s3://{s3_bucket_silver}",
+            storage_options=storage_options if aws_endpoint_url else None,
+        )
+        gold_writer = DeltaWriter(
+            base_path=f"s3://{s3_bucket_silver}",
+            storage_options=storage_options if aws_endpoint_url else None,
+        )
+        storage = StorageAdapter(bronze_writer, silver_writer, gold_writer)
+
+        redis_client = aioredis.Redis(host=redis_host, port=redis_port)
+        lock = RedisDistributedLock(redis_client=redis_client)
+
+        checkpoint = S3Checkpoint(
+            bucket=s3_bucket_checkpoints,
+            endpoint_url=aws_endpoint_url,
+            access_key=aws_access_key,
+            secret_key=aws_secret_key,
+        )
+
+        quarantine = UnifiedQuarantine(
+            base_path=f"s3://{s3_bucket_silver}/common/quarantine",
+            storage_options=storage_options if aws_endpoint_url else None,
+        )
+
+        return ChEMBLActivityPipeline(
+            run_type=run_type,
+            data_source=data_source,
+            storage=storage,
+            lock=lock,
+            checkpoint=checkpoint,
+            quarantine=quarantine,
+            resume=resume,
+        )


### PR DESCRIPTION
- Extract lock management to lock_manager.py (PipelineLockManager)
- Extract checkpoint handling to checkpoint_manager.py (PipelineCheckpointManager)
- Extract record processing to record_processor.py (PipelineRecordProcessor)
- Move ChEMBLActivityPipelineFactory to infrastructure/factories/
- Reduce base.py from 315 LOC to 99 LOC
- Remove ignore_imports from .importlinter (clean architecture)

Addresses R3 (decomposition) and R4 (import-linter cleanup).