### PR TITLE
Fix unexpected test pass in conftest

### DIFF
--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -290,10 +290,6 @@ def test_env_var_access_only_in_config(src_dir: Path):
 
 
 # --- REQ-ARCH-CLI-001 ---
-@pytest.mark.xfail(
-    reason="CLI has direct infrastructure imports - architectural debt to be refactored",
-    strict=False,
-)
 def test_cli_no_direct_infrastructure_imports(src_dir: Path):
     """CLI module must not import directly from infrastructure adapters.
 


### PR DESCRIPTION
The CLI has been refactored to no longer have direct infrastructure imports, so this test now passes. Removing the xfail marker eliminates the XPASS warning.