### PR TITLE
Fix unexpected passing Redis lock test

### DIFF
--- a/src/bioetl/infrastructure/locking/redis_lock.py
+++ b/src/bioetl/infrastructure/locking/redis_lock.py
@@ -163,6 +163,11 @@ class RedisDistributedLock:
             regular_key = self._make_key(key)
             if await self.redis_client.exists(regular_key):
                 return False
+        else:
+            # If regular, check for exclusive lock
+            exclusive_key = self._make_key(key, exclusive=True)
+            if await self.redis_client.exists(exclusive_key):
+                return False
 
         # Try to acquire lock with SETNX + EXPIRE
         acquired = await self.redis_client.set(
@@ -189,6 +194,10 @@ class RedisDistributedLock:
             if exclusive:
                 regular_key = self._make_key(key)
                 if await self.redis_client.exists(regular_key):
+                    continue
+            else:
+                exclusive_key = self._make_key(key, exclusive=True)
+                if await self.redis_client.exists(exclusive_key):
                     continue
 
             acquired = await self.redis_client.set(

--- a/tests/unit/infrastructure/test_redis_lock.py
+++ b/tests/unit/infrastructure/test_redis_lock.py
@@ -132,7 +132,6 @@ class TestRedisDistributedLock:
         assert success is False
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(reason="exclusive parameter not yet implemented in acquire()")
     async def test_exclusive_lock(
         self, redis_client_fixture, request, run_id: RunID
     ) -> None:
@@ -152,7 +151,6 @@ class TestRedisDistributedLock:
         assert regular_acquired is False
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(reason="exclusive parameter not yet implemented in acquire()")
     async def test_exclusive_fails_if_regular_exists(
         self, redis_client_fixture, request, run_id: RunID
     ) -> None:


### PR DESCRIPTION
The exclusive lock feature was partially implemented - exclusive locks would check for regular locks, but regular locks wouldn't check for exclusive locks. This caused the test_exclusive_lock test to fail.

- Add check for exclusive locks when acquiring regular locks
- Add same check in wait loop for consistency
- Remove xfail markers from tests since feature is now complete