### PR TITLE
Fix ChemblAdapter test setup error

### DIFF
--- a/tests/integration/adapters/test_chembl.py
+++ b/tests/integration/adapters/test_chembl.py
@@ -44,7 +44,7 @@ class TestChemblAdapter:
     @pytest.mark.vcr
     @pytest.mark.asyncio
     async def test_fetch_activities(
-        self, chembl_client: Any, _vcr_cassette: str
+        self, chembl_client: Any, vcr_cassette: str
     ) -> None:
         """Test fetching activities from ChEMBL.
 
@@ -67,7 +67,7 @@ class TestChemblAdapter:
 
     @pytest.mark.vcr
     @pytest.mark.asyncio
-    async def test_health_check(self, chembl_client: Any, _vcr_cassette: str) -> None:
+    async def test_health_check(self, chembl_client: Any, vcr_cassette: str) -> None:
         """Test ChEMBL health check endpoint.
 
         This test requires a VCR cassette.
@@ -90,7 +90,7 @@ class TestChemblAdapter:
     @pytest.mark.vcr
     @pytest.mark.asyncio
     async def test_get_entity_count(
-        self, chembl_client: Any, _vcr_cassette: str
+        self, chembl_client: Any, vcr_cassette: str
     ) -> None:
         """Test getting entity count from ChEMBL.
 


### PR DESCRIPTION
Change _vcr_cassette to vcr_cassette to match the actual fixture name provided by the pytest-recording plugin.