### PR TITLE
Create MetricsPort abstraction for metrics

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -30,6 +30,8 @@ forbidden_modules =
     bioetl.infrastructure.checkpoint
     bioetl.infrastructure.quarantine
     bioetl.infrastructure.factories
+    bioetl.infrastructure.observability.metrics
+    bioetl.infrastructure.observability.prometheus_metrics
 
 [importlinter:contract:infrastructure-no-application]
 name = Infrastructure layer must not import application

--- a/src/bioetl/application/pipeline/base.py
+++ b/src/bioetl/application/pipeline/base.py
@@ -19,6 +19,8 @@ from bioetl.domain.ports import (
     CheckpointPort,
     DataSourcePort,
     LockPort,
+    MetricsPort,
+    NoOpMetrics,
     QuarantinePort,
     StoragePort,
 )
@@ -48,6 +50,7 @@ class BasePipeline(ABC):
         quarantine: QuarantinePort,
         logger: "structlog.BoundLogger",
         resume: bool = False,
+        metrics: MetricsPort | None = None,
     ) -> None:
         self.pipeline_name = pipeline_name
         self.provider = provider
@@ -59,6 +62,7 @@ class BasePipeline(ABC):
         self.checkpoint = checkpoint
         self.quarantine = quarantine
         self.resume = resume
+        self.metrics: MetricsPort = metrics if metrics is not None else NoOpMetrics()
         self.run_id = RunID(uuid4())
         self.logger = logger.bind(run_id=str(self.run_id))
 

--- a/src/bioetl/application/pipeline/orchestrator.py
+++ b/src/bioetl/application/pipeline/orchestrator.py
@@ -14,10 +14,6 @@ from bioetl.domain.types import RunType
 
 if TYPE_CHECKING:
     from bioetl.application.pipeline.base import BasePipeline
-from bioetl.infrastructure.observability.metrics import (
-    PIPELINE_DURATION_SECONDS,
-    RECORDS_PROCESSED_TOTAL,
-)
 
 
 class PipelineShutdownError(Exception):
@@ -104,27 +100,43 @@ class PipelineOrchestrator:
 
             # Record metrics
             duration = time.time() - start_time
-            PIPELINE_DURATION_SECONDS.labels(
-                pipeline_name=self.pipeline.pipeline_name,
-                run_type=self.pipeline.run_type.value,
-                status=status,
-            ).observe(duration)
+            self.pipeline.metrics.observe_histogram(
+                "pipeline_duration_seconds",
+                duration,
+                {
+                    "pipeline_name": self.pipeline.pipeline_name,
+                    "run_type": self.pipeline.run_type.value,
+                    "status": status,
+                },
+            )
 
-            RECORDS_PROCESSED_TOTAL.labels(
-                pipeline_name=self.pipeline.pipeline_name,
-                run_type=self.pipeline.run_type.value,
-                layer="bronze",
-            ).inc(self.pipeline.executor.records_bronze)
-            RECORDS_PROCESSED_TOTAL.labels(
-                pipeline_name=self.pipeline.pipeline_name,
-                run_type=self.pipeline.run_type.value,
-                layer="silver",
-            ).inc(self.pipeline.executor.records_silver)
-            RECORDS_PROCESSED_TOTAL.labels(
-                pipeline_name=self.pipeline.pipeline_name,
-                run_type=self.pipeline.run_type.value,
-                layer="gold",
-            ).inc(self.pipeline.executor.records_gold)
+            self.pipeline.metrics.increment_counter(
+                "records_processed_total",
+                self.pipeline.executor.records_bronze,
+                {
+                    "pipeline_name": self.pipeline.pipeline_name,
+                    "run_type": self.pipeline.run_type.value,
+                    "layer": "bronze",
+                },
+            )
+            self.pipeline.metrics.increment_counter(
+                "records_processed_total",
+                self.pipeline.executor.records_silver,
+                {
+                    "pipeline_name": self.pipeline.pipeline_name,
+                    "run_type": self.pipeline.run_type.value,
+                    "layer": "silver",
+                },
+            )
+            self.pipeline.metrics.increment_counter(
+                "records_processed_total",
+                self.pipeline.executor.records_gold,
+                {
+                    "pipeline_name": self.pipeline.pipeline_name,
+                    "run_type": self.pipeline.run_type.value,
+                    "layer": "gold",
+                },
+            )
 
     async def _heartbeat_loop(self, lock_key: str, exclusive: bool) -> None:
         while not self.shutdown_requested:

--- a/src/bioetl/bootstrap.py
+++ b/src/bioetl/bootstrap.py
@@ -25,6 +25,7 @@ from bioetl.infrastructure.locking.redis_lock import RedisDistributedLock
 from bioetl.infrastructure.observability.logging import (
     create_logger as create_infra_logger,
 )
+from bioetl.infrastructure.observability.prometheus_metrics import PrometheusMetrics
 from bioetl.infrastructure.quarantine.unified_quarantine import UnifiedQuarantine
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 from bioetl.infrastructure.storage.delta_writer import DeltaWriter
@@ -35,7 +36,12 @@ if TYPE_CHECKING:
     import structlog
 
     from bioetl.application.pipelines.chembl_activity import ChEMBLActivityPipeline
-    from bioetl.domain.ports import CheckpointPort, LockPort, QuarantinePort
+    from bioetl.domain.ports import (
+        CheckpointPort,
+        LockPort,
+        MetricsPort,
+        QuarantinePort,
+    )
     from bioetl.domain.types import RunType
 
 
@@ -135,6 +141,7 @@ class ChEMBLActivityPipelineFactory:
         checkpoint: CheckpointPort | None = None,
         quarantine: QuarantinePort | None = None,
         lock: LockPort | None = None,
+        metrics: MetricsPort | None = None,
     ) -> ChEMBLActivityPipeline:
         """Create configured ChEMBL Activity pipeline.
 
@@ -146,6 +153,7 @@ class ChEMBLActivityPipelineFactory:
             checkpoint: Injected checkpoint service (optional)
             quarantine: Injected quarantine service (optional)
             lock: Injected lock service (optional)
+            metrics: Injected metrics service (optional)
 
         Returns:
             Configured pipeline instance
@@ -217,6 +225,10 @@ class ChEMBLActivityPipelineFactory:
                 storage_options=storage_options,
             )
 
+        # Metrics
+        if metrics is None:
+            metrics = PrometheusMetrics()
+
         return ChEMBLActivityPipeline(
             run_type=run_type,
             data_source=data_source,
@@ -226,4 +238,5 @@ class ChEMBLActivityPipelineFactory:
             quarantine=quarantine,
             logger=logger,
             resume=resume,
+            metrics=metrics,
         )

--- a/src/bioetl/domain/ports.py
+++ b/src/bioetl/domain/ports.py
@@ -320,3 +320,70 @@ class QuarantinePort(Protocol):
             A dictionary of statistics (e.g., count by error code).
         """
         ...
+
+
+@runtime_checkable
+class MetricsPort(Protocol):
+    """
+    Port for metrics collection.
+
+    This interface abstracts the metrics collection mechanism, allowing the
+    application to record metrics without knowing the specific implementation
+    (e.g., Prometheus, StatsD, CloudWatch).
+    """
+
+    def observe_histogram(
+        self,
+        name: str,
+        value: float,
+        labels: dict[str, str],
+    ) -> None:
+        """
+        Observe a value for a histogram metric.
+
+        Args:
+            name: The name of the histogram metric.
+            value: The value to observe.
+            labels: A dictionary of label names to label values.
+        """
+        ...
+
+    def increment_counter(
+        self,
+        name: str,
+        value: int,
+        labels: dict[str, str],
+    ) -> None:
+        """
+        Increment a counter metric.
+
+        Args:
+            name: The name of the counter metric.
+            value: The amount to increment by.
+            labels: A dictionary of label names to label values.
+        """
+        ...
+
+
+class NoOpMetrics:
+    """No-operation metrics implementation.
+
+    Used as default when no metrics backend is configured.
+    All operations are silently ignored.
+    """
+
+    def observe_histogram(
+        self,
+        name: str,
+        value: float,
+        labels: dict[str, str],
+    ) -> None:
+        """No-op histogram observation."""
+
+    def increment_counter(
+        self,
+        name: str,
+        value: int,
+        labels: dict[str, str],
+    ) -> None:
+        """No-op counter increment."""

--- a/src/bioetl/infrastructure/observability/prometheus_metrics.py
+++ b/src/bioetl/infrastructure/observability/prometheus_metrics.py
@@ -1,0 +1,74 @@
+"""Prometheus Metrics adapter implementing MetricsPort.
+
+Provides concrete implementation of the MetricsPort interface using
+Prometheus client library.
+"""
+
+from bioetl.domain.ports import MetricsPort
+from bioetl.infrastructure.observability.metrics import (
+    PIPELINE_DURATION_SECONDS,
+    RECORDS_PROCESSED_TOTAL,
+)
+
+# Registry of histogram metrics
+HISTOGRAMS = {
+    "pipeline_duration_seconds": PIPELINE_DURATION_SECONDS,
+}
+
+# Registry of counter metrics
+COUNTERS = {
+    "records_processed_total": RECORDS_PROCESSED_TOTAL,
+}
+
+
+class PrometheusMetrics(MetricsPort):
+    """Prometheus implementation of MetricsPort.
+
+    Maps metric names to pre-defined Prometheus metrics and records observations.
+
+    Example:
+        >>> metrics = PrometheusMetrics()
+        >>> metrics.observe_histogram(
+        ...     "pipeline_duration_seconds",
+        ...     duration=123.45,
+        ...     labels={"pipeline_name": "chembl_activity", "status": "success"}
+        ... )
+    """
+
+    def observe_histogram(
+        self,
+        name: str,
+        value: float,
+        labels: dict[str, str],
+    ) -> None:
+        """Observe a value for a Prometheus histogram.
+
+        Args:
+            name: The name of the histogram metric (must be in HISTOGRAMS registry).
+            value: The value to observe.
+            labels: Label values for the metric.
+
+        Raises:
+            KeyError: If the metric name is not found in HISTOGRAMS.
+        """
+        if name in HISTOGRAMS:
+            HISTOGRAMS[name].labels(**labels).observe(value)
+
+    def increment_counter(
+        self,
+        name: str,
+        value: int,
+        labels: dict[str, str],
+    ) -> None:
+        """Increment a Prometheus counter.
+
+        Args:
+            name: The name of the counter metric (must be in COUNTERS registry).
+            value: The amount to increment by.
+            labels: Label values for the metric.
+
+        Raises:
+            KeyError: If the metric name is not found in COUNTERS.
+        """
+        if name in COUNTERS:
+            COUNTERS[name].labels(**labels).inc(value)

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -10,6 +10,7 @@ from bioetl.domain.ports import (
     CheckpointPort,
     DataSourcePort,
     LockPort,
+    MetricsPort,
     QuarantinePort,
     StoragePort,
 )
@@ -64,6 +65,7 @@ def test_critical_ports_are_runtime_checkable():
         CheckpointPort,
         StoragePort,
         QuarantinePort,
+        MetricsPort,
     ]
     for port in critical_ports:
         assert hasattr(

--- a/tests/unit/test_ports.py
+++ b/tests/unit/test_ports.py
@@ -6,6 +6,8 @@ from bioetl.domain.ports import (
     CheckpointPort,
     DataSourcePort,
     LockPort,
+    MetricsPort,
+    NoOpMetrics,
     QuarantinePort,
     StoragePort,
 )
@@ -22,6 +24,7 @@ class TestPortsAreRuntimeCheckable:
             LockPort,
             CheckpointPort,
             QuarantinePort,
+            MetricsPort,
         ],
     )
     def test_port_is_runtime_checkable(self, port: type) -> None:
@@ -175,3 +178,42 @@ class TestQuarantinePortProtocol:
                 return {}
 
         assert isinstance(ValidQuarantine(), QuarantinePort)
+
+
+class TestMetricsPortProtocol:
+    """Tests for MetricsPort protocol compliance."""
+
+    def test_valid_metrics_passes_check(self) -> None:
+        """Class with all required methods should be MetricsPort."""
+
+        class ValidMetrics:
+            def observe_histogram(self, _name, _value, _labels):
+                pass
+
+            def increment_counter(self, _name, _value, _labels):
+                pass
+
+        assert isinstance(ValidMetrics(), MetricsPort)
+
+    def test_missing_method_fails_check(self) -> None:
+        """Class missing a required method should not be MetricsPort."""
+
+        class IncompleteMetrics:
+            def observe_histogram(self, _name, _value, _labels):
+                pass
+
+            # Missing increment_counter
+
+        assert not isinstance(IncompleteMetrics(), MetricsPort)
+
+    def test_noop_metrics_implements_port(self) -> None:
+        """NoOpMetrics should implement MetricsPort protocol."""
+        noop = NoOpMetrics()
+        assert isinstance(noop, MetricsPort)
+
+    def test_noop_metrics_does_nothing(self) -> None:
+        """NoOpMetrics methods should complete without error."""
+        noop = NoOpMetrics()
+        # Should not raise
+        noop.observe_histogram("test", 1.0, {"label": "value"})
+        noop.increment_counter("test", 1, {"label": "value"})


### PR DESCRIPTION
…imports

- Add MetricsPort protocol and NoOpMetrics implementation in domain/ports.py
- Create PrometheusMetrics adapter in infrastructure/observability/prometheus_metrics.py
- Update BasePipeline to accept optional metrics parameter (defaults to NoOpMetrics)
- Refactor orchestrator.py to use self.pipeline.metrics instead of direct imports
- Update bootstrap.py to inject PrometheusMetrics dependency
- Add observability.metrics to import-linter forbidden modules
- Add MetricsPort tests to test_ports.py and test_architecture.py

This change follows hexagonal architecture principles by abstracting metrics collection behind a port interface, allowing the application layer to remain decoupled from concrete infrastructure implementations.