### PR TITLE
Move heartbeat interval to config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,8 +50,15 @@ BIOETL_REDIS_DB=0
 
 # Lock configuration (RULES.md §3.3)
 BIOETL_LOCK_TTL=60  # seconds
-BIOETL_LOCK_HEARTBEAT_INTERVAL=20  # seconds
 BIOETL_LOCK_MAX_DURATION=14400  # 4 hours in seconds
+
+# =============================================================================
+# PIPELINE CONFIGURATION
+# =============================================================================
+BIOETL_PIPELINE__BATCH_SIZE=100  # 1-10000
+BIOETL_PIPELINE__CHECKPOINT_INTERVAL=1000  # minimum 100
+BIOETL_PIPELINE__MAX_CONCURRENT_BATCHES=4  # 1-16
+BIOETL_PIPELINE__HEARTBEAT_INTERVAL=20  # seconds (5-60, default: 20)
 
 # =============================================================================
 # PROVIDER API KEYS (RULES.md Appendix A)

--- a/src/bioetl/application/pipeline/lock_manager.py
+++ b/src/bioetl/application/pipeline/lock_manager.py
@@ -4,6 +4,7 @@ import asyncio
 from typing import TYPE_CHECKING
 
 from bioetl.application.pipeline.orchestrator import PipelineShutdownError
+from bioetl.config import get_settings
 from bioetl.domain.types import RunType
 
 if TYPE_CHECKING:
@@ -44,8 +45,10 @@ class LockManager:
         self.pipeline.logger.info("Lock released", extra={"stage": "cleanup"})
 
     async def _heartbeat_loop(self, lock_key: str, exclusive: bool) -> None:
+        settings = get_settings()
+        interval = settings.pipeline.heartbeat_interval
         while not self.pipeline.orchestrator.shutdown_requested:
-            await asyncio.sleep(20)
+            await asyncio.sleep(interval)
             success = await self.pipeline.lock.heartbeat(
                 lock_key, self.pipeline.run_id, exclusive=exclusive
             )

--- a/src/bioetl/application/pipeline/orchestrator.py
+++ b/src/bioetl/application/pipeline/orchestrator.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from prefect import flow
 
+from bioetl.config import get_settings
 from bioetl.domain.types import RunType
 
 if TYPE_CHECKING:
@@ -127,8 +128,10 @@ class PipelineOrchestrator:
                     )
 
     async def _heartbeat_loop(self, lock_key: str, exclusive: bool) -> None:
+        settings = get_settings()
+        interval = settings.pipeline.heartbeat_interval
         while not self.shutdown_requested:
-            await asyncio.sleep(20)
+            await asyncio.sleep(interval)
             success = await self.pipeline.lock.heartbeat(
                 lock_key, self.pipeline.run_id, exclusive=exclusive
             )

--- a/src/bioetl/config.py
+++ b/src/bioetl/config.py
@@ -13,6 +13,7 @@ Usage:
 
 from __future__ import annotations
 
+import warnings
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Literal
@@ -95,6 +96,9 @@ class PipelineSettings(BaseSettings):
     max_concurrent_batches: int = Field(default=4, ge=1, le=16)
     """Maximum concurrent batch writes."""
 
+    heartbeat_interval: int = Field(default=20, ge=5, le=60)
+    """Lock heartbeat interval in seconds (default: 20s, range: 5-60s)."""
+
 
 class Settings(BaseSettings):
     """Main application settings."""
@@ -159,11 +163,25 @@ def get_settings() -> Settings:
     return Settings()
 
 
-# Compatibility aliases
-AWSConfig = AWSSettings
-S3Config = S3Settings
-RedisConfig = RedisSettings
-PipelineConfig = PipelineSettings
+# Deprecated aliases - use *Settings classes instead
+_DEPRECATED_ALIASES: dict[str, type] = {
+    "AWSConfig": AWSSettings,
+    "S3Config": S3Settings,
+    "RedisConfig": RedisSettings,
+    "PipelineConfig": PipelineSettings,
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Provide deprecation warnings for old config class names."""
+    if name in _DEPRECATED_ALIASES:
+        warnings.warn(
+            f"{name} is deprecated, use {_DEPRECATED_ALIASES[name].__name__} instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _DEPRECATED_ALIASES[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def get_aws_config() -> AWSSettings:


### PR DESCRIPTION
…nings

- Add heartbeat_interval field to PipelineSettings (default: 20s, range: 5-60s)
- Update orchestrator.py and lock_manager.py to use configurable interval
- Add __getattr__ deprecation warnings for legacy aliases (AWSConfig, etc.)
- Document pipeline configuration in .env.example