### PR TITLE
Implement S3 connection pooling for resource efficiency

### DIFF
--- a/src/bioetl/infrastructure/checkpoint/s3_checkpoint.py
+++ b/src/bioetl/infrastructure/checkpoint/s3_checkpoint.py
@@ -20,7 +20,6 @@ import json
 from typing import Any
 from uuid import UUID
 
-import boto3
 from botocore.exceptions import ClientError
 
 from bioetl.domain.types import RunID, Watermark
@@ -69,16 +68,14 @@ class S3Checkpoint:
             access_key: AWS access key (optional, uses env vars if None)
             secret_key: AWS secret key (optional, uses env vars if None)
         """
-        session = boto3.Session(
-            aws_access_key_id=access_key,
-            aws_secret_access_key=secret_key,
-            region_name=region,
-        )
+        from bioetl.infrastructure.storage.s3_pool import S3ClientPool
 
-        self.s3_client = session.client(
-            "s3",
+        # Get S3 client from pool for connection reuse
+        self.s3_client = S3ClientPool.get_client(
             endpoint_url=endpoint_url,
-            config=boto3.session.Config(signature_version="s3v4"),
+            region=region,
+            access_key=access_key,
+            secret_key=secret_key,
         )
         self.bucket = bucket
 

--- a/src/bioetl/infrastructure/storage/bronze_writer.py
+++ b/src/bioetl/infrastructure/storage/bronze_writer.py
@@ -68,19 +68,14 @@ class BronzeWriter:
             access_key: AWS access key ID (optional, uses env vars if None)
             secret_key: AWS secret access key (optional, uses env vars if None)
         """
-        import boto3
+        from bioetl.infrastructure.storage.s3_pool import S3ClientPool
 
-        # Configure S3 client
-        session = boto3.Session(
-            aws_access_key_id=access_key,
-            aws_secret_access_key=secret_key,
-            region_name=region,
-        )
-
-        self.s3_client = session.client(
-            "s3",
+        # Get S3 client from pool for connection reuse
+        self.s3_client = S3ClientPool.get_client(
             endpoint_url=endpoint_url,
-            config=boto3.session.Config(signature_version="s3v4"),
+            region=region,
+            access_key=access_key,
+            secret_key=secret_key,
         )
         self.bucket = bucket
 

--- a/src/bioetl/infrastructure/storage/s3_pool.py
+++ b/src/bioetl/infrastructure/storage/s3_pool.py
@@ -1,0 +1,124 @@
+"""Thread-safe S3 client pool for connection reuse.
+
+Implements connection pooling to reduce resource consumption when
+multiple components need S3 access.
+
+Architecture:
+- Singleton pattern with class-level instance cache
+- Thread-safe access using threading.Lock
+- Configurable max_pool_connections for boto3
+- Cache key based on (endpoint_url, region) tuple
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import boto3
+from botocore.config import Config
+
+
+class S3ClientPool:
+    """Thread-safe S3 client pool for connection reuse.
+
+    Maintains a pool of S3 clients keyed by (endpoint_url, region).
+    Clients are reused across multiple components to reduce resource
+    consumption and improve performance.
+
+    Example:
+        >>> client = S3ClientPool.get_client(
+        ...     endpoint_url="http://localhost:9000",
+        ...     region="us-east-1",
+        ...     access_key="bioetl",
+        ...     secret_key="bioetl_minio_pass",
+        ... )
+        >>> client.list_buckets()
+
+    Thread Safety:
+        All operations are protected by a threading.Lock to ensure
+        safe concurrent access from multiple threads.
+
+    Note:
+        Credentials are only used when creating a new client for a
+        given (endpoint_url, region) key. If a client already exists
+        for that key, the cached client is returned regardless of
+        credentials provided.
+    """
+
+    _instances: dict[tuple[str | None, str], Any] = {}
+    _lock = threading.Lock()
+
+    @classmethod
+    def get_client(
+        cls,
+        endpoint_url: str | None,
+        region: str,
+        access_key: str | None = None,
+        secret_key: str | None = None,
+        max_pool_connections: int = 50,
+    ) -> Any:
+        """Get or create an S3 client from the pool.
+
+        Args:
+            endpoint_url: S3 endpoint URL (for MinIO, e.g., 'http://localhost:9000')
+            region: AWS region (e.g., 'us-east-1')
+            access_key: AWS access key ID (optional, uses env vars if None)
+            secret_key: AWS secret access key (optional, uses env vars if None)
+            max_pool_connections: Maximum number of connections in the pool (default: 50)
+
+        Returns:
+            boto3 S3 client instance
+
+        Example:
+            >>> client = S3ClientPool.get_client(
+            ...     endpoint_url="http://localhost:9000",
+            ...     region="us-east-1",
+            ... )
+        """
+        key = (endpoint_url, region)
+
+        with cls._lock:
+            if key not in cls._instances:
+                session = boto3.Session(
+                    aws_access_key_id=access_key,
+                    aws_secret_access_key=secret_key,
+                    region_name=region,
+                )
+                cls._instances[key] = session.client(
+                    "s3",
+                    endpoint_url=endpoint_url,
+                    config=Config(
+                        signature_version="s3v4",
+                        max_pool_connections=max_pool_connections,
+                    ),
+                )
+            return cls._instances[key]
+
+    @classmethod
+    def clear_pool(cls) -> None:
+        """Clear all cached clients.
+
+        Useful for testing or when credentials need to be refreshed.
+        After calling this method, subsequent get_client() calls will
+        create new client instances.
+
+        Example:
+            >>> S3ClientPool.clear_pool()  # Reset for testing
+        """
+        with cls._lock:
+            cls._instances.clear()
+
+    @classmethod
+    def pool_size(cls) -> int:
+        """Return the number of cached clients.
+
+        Returns:
+            Number of S3 clients currently in the pool
+
+        Example:
+            >>> size = S3ClientPool.pool_size()
+            >>> print(f"Pool contains {size} clients")
+        """
+        with cls._lock:
+            return len(cls._instances)

--- a/tests/unit/infrastructure/test_s3_pool.py
+++ b/tests/unit/infrastructure/test_s3_pool.py
@@ -1,0 +1,311 @@
+"""Unit tests for S3 client pool with concurrent access."""
+
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bioetl.infrastructure.storage.s3_pool import S3ClientPool
+
+
+@pytest.fixture(autouse=True)
+def clear_pool():
+    """Clear the pool before and after each test."""
+    S3ClientPool.clear_pool()
+    yield
+    S3ClientPool.clear_pool()
+
+
+@pytest.fixture
+def mock_boto3_session():
+    """Mock boto3.Session for testing."""
+    with patch("bioetl.infrastructure.storage.s3_pool.boto3.Session") as mock_session:
+        mock_client = MagicMock()
+        mock_session.return_value.client.return_value = mock_client
+        yield mock_session, mock_client
+
+
+@pytest.mark.unit
+class TestS3ClientPool:
+    """Test S3ClientPool functionality."""
+
+    def test_get_client_creates_new_client(self, mock_boto3_session):
+        """Test that get_client creates a new client when pool is empty."""
+        mock_session, mock_client = mock_boto3_session
+
+        client = S3ClientPool.get_client(
+            endpoint_url="http://localhost:9000",
+            region="us-east-1",
+            access_key="test_key",
+            secret_key="test_secret",
+        )
+
+        assert client is mock_client
+        mock_session.assert_called_once_with(
+            aws_access_key_id="test_key",
+            aws_secret_access_key="test_secret",
+            region_name="us-east-1",
+        )
+        mock_session.return_value.client.assert_called_once()
+
+    def test_get_client_reuses_existing_client(self, mock_boto3_session):
+        """Test that get_client reuses existing client for same key."""
+        mock_session, mock_client = mock_boto3_session
+
+        client1 = S3ClientPool.get_client(
+            endpoint_url="http://localhost:9000",
+            region="us-east-1",
+        )
+        client2 = S3ClientPool.get_client(
+            endpoint_url="http://localhost:9000",
+            region="us-east-1",
+        )
+
+        assert client1 is client2
+        # Session should only be created once
+        assert mock_session.call_count == 1
+
+    def test_different_endpoints_create_different_clients(self, mock_boto3_session):
+        """Test that different endpoints create separate clients."""
+        mock_session, _ = mock_boto3_session
+
+        # Create different mock clients for each call
+        mock_client1 = MagicMock(name="client1")
+        mock_client2 = MagicMock(name="client2")
+        mock_session.return_value.client.side_effect = [mock_client1, mock_client2]
+
+        client1 = S3ClientPool.get_client(
+            endpoint_url="http://localhost:9000",
+            region="us-east-1",
+        )
+        client2 = S3ClientPool.get_client(
+            endpoint_url="http://localhost:9001",
+            region="us-east-1",
+        )
+
+        assert client1 is not client2
+        assert mock_session.call_count == 2
+
+    def test_different_regions_create_different_clients(self, mock_boto3_session):
+        """Test that different regions create separate clients."""
+        mock_session, _ = mock_boto3_session
+
+        mock_client1 = MagicMock(name="client1")
+        mock_client2 = MagicMock(name="client2")
+        mock_session.return_value.client.side_effect = [mock_client1, mock_client2]
+
+        client1 = S3ClientPool.get_client(
+            endpoint_url="http://localhost:9000",
+            region="us-east-1",
+        )
+        client2 = S3ClientPool.get_client(
+            endpoint_url="http://localhost:9000",
+            region="eu-west-1",
+        )
+
+        assert client1 is not client2
+        assert mock_session.call_count == 2
+
+    def test_clear_pool_removes_all_clients(self, mock_boto3_session):
+        """Test that clear_pool removes all cached clients."""
+        mock_session, _ = mock_boto3_session
+
+        S3ClientPool.get_client(
+            endpoint_url="http://localhost:9000",
+            region="us-east-1",
+        )
+        S3ClientPool.get_client(
+            endpoint_url="http://localhost:9001",
+            region="us-east-1",
+        )
+
+        assert S3ClientPool.pool_size() == 2
+
+        S3ClientPool.clear_pool()
+
+        assert S3ClientPool.pool_size() == 0
+
+    def test_pool_size_returns_correct_count(self, mock_boto3_session):
+        """Test that pool_size returns correct number of clients."""
+        mock_session, _ = mock_boto3_session
+
+        assert S3ClientPool.pool_size() == 0
+
+        S3ClientPool.get_client(
+            endpoint_url="http://localhost:9000",
+            region="us-east-1",
+        )
+        assert S3ClientPool.pool_size() == 1
+
+        # Same key, should not increase count
+        S3ClientPool.get_client(
+            endpoint_url="http://localhost:9000",
+            region="us-east-1",
+        )
+        assert S3ClientPool.pool_size() == 1
+
+    def test_none_endpoint_url_is_valid_key(self, mock_boto3_session):
+        """Test that None endpoint_url works for AWS S3."""
+        mock_session, mock_client = mock_boto3_session
+
+        client = S3ClientPool.get_client(
+            endpoint_url=None,
+            region="us-east-1",
+        )
+
+        assert client is mock_client
+        assert S3ClientPool.pool_size() == 1
+
+
+@pytest.mark.unit
+class TestS3ClientPoolConcurrency:
+    """Test S3ClientPool thread safety with concurrent access."""
+
+    def test_concurrent_access_same_key(self, mock_boto3_session):
+        """Test concurrent access to the same key returns same client."""
+        mock_session, mock_client = mock_boto3_session
+        results = []
+        errors = []
+
+        def get_client():
+            try:
+                client = S3ClientPool.get_client(
+                    endpoint_url="http://localhost:9000",
+                    region="us-east-1",
+                )
+                results.append(client)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=get_client) for _ in range(100)]
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0, f"Errors occurred: {errors}"
+        assert len(results) == 100
+        # All clients should be the same instance
+        assert all(client is results[0] for client in results)
+        # Session should only be created once
+        assert mock_session.call_count == 1
+
+    def test_concurrent_access_different_keys(self, mock_boto3_session):
+        """Test concurrent access to different keys creates separate clients."""
+        mock_session, _ = mock_boto3_session
+
+        # Create unique mock clients for each call
+        call_count = 0
+
+        def create_mock_client(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return MagicMock(name=f"client_{call_count}")
+
+        mock_session.return_value.client.side_effect = create_mock_client
+
+        results = {}
+        lock = threading.Lock()
+        errors = []
+
+        def get_client(endpoint_port):
+            try:
+                client = S3ClientPool.get_client(
+                    endpoint_url=f"http://localhost:{endpoint_port}",
+                    region="us-east-1",
+                )
+                with lock:
+                    if endpoint_port not in results:
+                        results[endpoint_port] = []
+                    results[endpoint_port].append(client)
+            except Exception as e:
+                errors.append(e)
+
+        # 10 different endpoints, 10 threads each
+        threads = []
+        for port in range(9000, 9010):
+            for _ in range(10):
+                threads.append(threading.Thread(target=get_client, args=(port,)))
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0, f"Errors occurred: {errors}"
+        assert len(results) == 10  # 10 different endpoints
+
+        # Each endpoint should have 10 results, all the same client
+        for port, clients in results.items():
+            assert len(clients) == 10
+            assert all(c is clients[0] for c in clients)
+
+        # Should have created exactly 10 clients
+        assert S3ClientPool.pool_size() == 10
+
+    def test_concurrent_clear_and_get(self, mock_boto3_session):
+        """Test concurrent clear and get operations are thread-safe."""
+        mock_session, _ = mock_boto3_session
+
+        def create_mock_client(*args, **kwargs):
+            return MagicMock()
+
+        mock_session.return_value.client.side_effect = create_mock_client
+
+        errors = []
+
+        def get_client():
+            try:
+                S3ClientPool.get_client(
+                    endpoint_url="http://localhost:9000",
+                    region="us-east-1",
+                )
+            except Exception as e:
+                errors.append(e)
+
+        def clear_pool():
+            try:
+                S3ClientPool.clear_pool()
+            except Exception as e:
+                errors.append(e)
+
+        # Mix of get and clear operations
+        with ThreadPoolExecutor(max_workers=20) as executor:
+            futures = []
+            for i in range(100):
+                if i % 10 == 0:
+                    futures.append(executor.submit(clear_pool))
+                else:
+                    futures.append(executor.submit(get_client))
+
+            for future in as_completed(futures):
+                future.result()  # Raises exception if any
+
+        assert len(errors) == 0, f"Errors occurred: {errors}"
+
+    def test_memory_stability_many_batches(self, mock_boto3_session):
+        """Test memory usage is stable with many operations (1000+ simulated batches)."""
+        mock_session, _ = mock_boto3_session
+
+        def create_mock_client(*args, **kwargs):
+            return MagicMock()
+
+        mock_session.return_value.client.side_effect = create_mock_client
+
+        # Simulate 1000+ batch operations with a fixed set of endpoints
+        num_batches = 1000
+        num_endpoints = 5
+
+        for batch in range(num_batches):
+            endpoint_port = 9000 + (batch % num_endpoints)
+            S3ClientPool.get_client(
+                endpoint_url=f"http://localhost:{endpoint_port}",
+                region="us-east-1",
+            )
+
+        # Pool size should be fixed regardless of number of batches
+        assert S3ClientPool.pool_size() == num_endpoints
+        # Number of client creations should equal number of unique endpoints
+        assert mock_session.return_value.client.call_count == num_endpoints

--- a/tests/unit/infrastructure/test_storage.py
+++ b/tests/unit/infrastructure/test_storage.py
@@ -17,14 +17,12 @@ from bioetl.infrastructure.storage.gold_writer import GoldWriter
 @pytest.fixture
 def mock_s3_client():
     """Fixture for a mocked S3 client."""
-    # Patch boto3.Session at the global level since it's imported inside __init__
-    with (
-        patch("boto3.Session") as mock_session,
-        patch("boto3.session.Config") as mock_config,
-    ):
+    # Patch S3ClientPool.get_client since BronzeWriter now uses the pool
+    with patch(
+        "bioetl.infrastructure.storage.s3_pool.S3ClientPool.get_client"
+    ) as mock_get_client:
         mock_s3 = MagicMock()
-        mock_session.return_value.client.return_value = mock_s3
-        mock_config.return_value = MagicMock()
+        mock_get_client.return_value = mock_s3
         yield mock_s3
 
 


### PR DESCRIPTION
Implement thread-safe S3 client pool to reuse connections across BronzeWriter and S3Checkpoint, reducing resource consumption.

- Add S3ClientPool class with thread-safe access via threading.Lock
- Update BronzeWriter to use pooled S3 clients
- Update S3Checkpoint to use pooled S3 clients
- Add comprehensive unit tests for concurrent access scenarios
- Update test fixtures to mock S3ClientPool instead of boto3.Session