### PR TITLE
Update project documentation and diagrams

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,213 @@
+# BioETL Architecture / Архитектура проекта
+
+*Updated: 2025-12-17*
+
+## Overview / Обзор
+
+BioETL is an ETL (Extract-Transform-Load) system for bioactivity data acquisition from public databases (ChEMBL, PubChem, UniProt). Built using **Hexagonal Architecture (Ports & Adapters)** with **Medallion Data Lake** pattern.
+
+## Layer Overview / Обзор слоёв
+
+```mermaid
+flowchart TB
+    subgraph Interfaces["Interfaces Layer"]
+        CLI[CLI - Click]
+        Prefect[Prefect Tasks]
+        Bootstrap[Bootstrap / Factories]
+    end
+
+    subgraph Application["Application Layer"]
+        Orchestrator[PipelineOrchestrator]
+        Executor[PipelineExecutor]
+        Processor[RecordProcessor]
+        Managers[Checkpoint/Lock/Quarantine Managers]
+        Pipelines[Concrete Pipelines]
+    end
+
+    subgraph Domain["Domain Layer"]
+        Ports[Ports - Protocols]
+        Types[Types & Value Objects]
+        Transforms[Transformations]
+        Exceptions[Exception Hierarchy]
+    end
+
+    subgraph Infrastructure["Infrastructure Layer"]
+        Adapters[HTTP/API Adapters]
+        Storage[Bronze/Silver/Gold Writers]
+        Locking[Redis/Memory Lock]
+        Observability[Metrics/Lineage/Anomaly]
+    end
+
+    Interfaces --> Application
+    Application --> Domain
+    Infrastructure -.-> Domain
+    Application --> Infrastructure
+```
+
+## Medallion Architecture / Медальонная архитектура
+
+```mermaid
+flowchart LR
+    subgraph Sources["External Sources"]
+        ChEMBL["ChEMBL API"]
+        PubChem["PubChem API"]
+        UniProt["UniProt API"]
+    end
+
+    subgraph Bronze["Bronze Layer"]
+        direction TB
+        B1["JSONL + zstd"]
+        B2["Append-only"]
+        B3["90 days retention"]
+    end
+
+    subgraph Silver["Silver Layer"]
+        direction TB
+        S1["Delta Lake"]
+        S2["Merge/Upsert"]
+        S3["Permanent"]
+    end
+
+    subgraph Gold["Gold Layer"]
+        direction TB
+        G1["Delta / Parquet"]
+        G2["Pandera validation"]
+        G3["Permanent"]
+    end
+
+    subgraph Side["Side Tables"]
+        Q["Quarantine"]
+        L["Lineage"]
+    end
+
+    Sources -->|REST API| Bronze
+    Bronze -->|Transform| Silver
+    Silver -->|Aggregate| Gold
+    Silver -.->|DQ errors| Q
+    Bronze -.->|batch_id FK| L
+```
+
+## Module Index / Индекс модулей
+
+### Domain Layer
+
+| Module | Type | Diagram | Description |
+|--------|------|---------|-------------|
+| `domain/ports.py` | port | [ports.mmd](./diagrams/domain/ports.mmd) | Abstract port interfaces (Protocol) |
+| `domain/types.py` | value_object | [types.mmd](./diagrams/domain/types.mmd) | Core types: RunID, EntityID, Enums |
+| `domain/transformations.py` | util | [transformations.mmd](./diagrams/domain/transformations.mmd) | Hash generation, schema drift detection |
+| `domain/exceptions.py` | exception | [exceptions.mmd](./diagrams/domain/exceptions.mmd) | Error hierarchy: Critical/Recoverable/DQ |
+| `domain/error_classifier.py` | util | [error_classifier.mmd](./diagrams/domain/error_classifier.mmd) | Exception → ErrorType mapping |
+| `domain/context.py` | value_object | [context.mmd](./diagrams/domain/context.mmd) | PipelineContext (immutable) |
+
+### Application Layer
+
+| Module | Type | Diagram | Description |
+|--------|------|---------|-------------|
+| `application/core/base.py` | service | [base.mmd](./diagrams/application/core/base.mmd) | BasePipeline abstract class |
+| `application/core/orchestrator.py` | service | [orchestrator.mmd](./diagrams/application/core/orchestrator.mmd) | Pipeline lifecycle, signals, locking |
+| `application/core/executor.py` | service | [executor.mmd](./diagrams/application/core/executor.mmd) | Data flow execution |
+| `application/core/record_processor.py` | service | [record_processor.mmd](./diagrams/application/core/record_processor.mmd) | Bronze→Silver→Gold processing |
+| `application/core/lock_manager.py` | service | [lock_manager.mmd](./diagrams/application/core/lock_manager.mmd) | Distributed lock with heartbeat |
+| `application/core/shutdown.py` | util | [shutdown.mmd](./diagrams/application/core/shutdown.mmd) | Graceful shutdown signal |
+| `application/core/*_manager.py` | service | [managers.mmd](./diagrams/application/core/managers.mmd) | Checkpoint/Quarantine managers |
+| `application/pipelines/chembl_activity.py` | pipeline | [chembl_activity.mmd](./diagrams/application/pipelines/chembl_activity.mmd) | ChEMBL activity pipeline |
+
+### Infrastructure Layer
+
+| Module | Type | Diagram | Description |
+|--------|------|---------|-------------|
+| `infrastructure/adapters/http/client.py` | adapter | [client.mmd](./diagrams/infrastructure/adapters/http/client.mmd) | UnifiedHTTPClient |
+| `infrastructure/adapters/http/circuit_breaker.py` | adapter | [circuit_breaker.mmd](./diagrams/infrastructure/adapters/http/circuit_breaker.mmd) | Circuit breaker state machine |
+| `infrastructure/adapters/http/rate_limiter.py` | adapter | [rate_limiter.mmd](./diagrams/infrastructure/adapters/http/rate_limiter.mmd) | Token bucket rate limiter |
+| `infrastructure/adapters/chembl/client.py` | adapter | [chembl/client.mmd](./diagrams/infrastructure/adapters/chembl/client.mmd) | ChEMBL API adapter |
+| `infrastructure/adapters/pubchem/client.py` | adapter | [pubchem/client.mmd](./diagrams/infrastructure/adapters/pubchem/client.mmd) | PubChem API adapter |
+| `infrastructure/adapters/uniprot/client.py` | adapter | [uniprot/client.mmd](./diagrams/infrastructure/adapters/uniprot/client.mmd) | UniProt API adapter |
+| `infrastructure/storage/*.py` | adapter | [medallion.mmd](./diagrams/infrastructure/storage/medallion.mmd) | Bronze/Silver/Gold writers |
+| `infrastructure/locking/*.py` | adapter | [distributed_lock.mmd](./diagrams/infrastructure/locking/distributed_lock.mmd) | Redis/Memory lock |
+| `infrastructure/checkpoint/*.py` | adapter | [s3_checkpoint.mmd](./diagrams/infrastructure/checkpoint/s3_checkpoint.mmd) | S3 checkpoint |
+| `infrastructure/quarantine/*.py` | adapter | [unified_quarantine.mmd](./diagrams/infrastructure/quarantine/unified_quarantine.mmd) | Unified quarantine table |
+| `infrastructure/observability/*.py` | adapter | [overview.mmd](./diagrams/infrastructure/observability/overview.mmd) | Metrics, lineage, anomaly |
+
+### Interfaces Layer
+
+| Module | Type | Diagram | Description |
+|--------|------|---------|-------------|
+| `interfaces/cli.py` | handler | [overview.mmd](./diagrams/interfaces/overview.mmd) | CLI entry point |
+| `interfaces/bootstrap.py` | factory | [bootstrap.mmd](./diagrams/interfaces/bootstrap.mmd) | Composition root |
+| `interfaces/factories/*.py` | factory | [overview.mmd](./diagrams/interfaces/overview.mmd) | Pipeline factories |
+| `interfaces/orchestration/*.py` | handler | [overview.mmd](./diagrams/interfaces/overview.mmd) | Runner, signals, Prefect |
+
+## Dependency Graph / Граф зависимостей
+
+```mermaid
+graph LR
+    subgraph Interfaces
+        CLI
+        Bootstrap
+        Factories
+    end
+
+    subgraph Application
+        BasePipeline
+        Orchestrator
+        Executor
+        RecordProcessor
+    end
+
+    subgraph Domain
+        Ports
+        Types
+        Exceptions
+    end
+
+    subgraph Infrastructure
+        HTTPAdapters
+        Storage
+        Locking
+        Observability
+    end
+
+    CLI --> Bootstrap
+    Bootstrap --> Factories
+    Factories --> BasePipeline
+    Factories --> Infrastructure
+
+    BasePipeline --> Orchestrator
+    Orchestrator --> Executor
+    Executor --> RecordProcessor
+
+    BasePipeline --> Ports
+    Orchestrator --> Ports
+    Executor --> Types
+    RecordProcessor --> Exceptions
+
+    HTTPAdapters -.-> Ports
+    Storage -.-> Ports
+    Locking -.-> Ports
+    Observability -.-> Ports
+
+    style Domain fill:#e1f5fe
+    style Application fill:#fff3e0
+    style Infrastructure fill:#f3e5f5
+    style Interfaces fill:#e8f5e9
+```
+
+## Architectural Patterns / Архитектурные паттерны
+
+| Pattern | Implementation | Location |
+|---------|---------------|----------|
+| **Ports & Adapters** | Protocol-based ports | `domain/ports.py` |
+| **Dependency Injection** | PipelineServices container | `application/core/pipeline_services.py` |
+| **Composition Root** | Bootstrap/Factories | `interfaces/bootstrap.py` |
+| **Circuit Breaker** | State machine | `infrastructure/adapters/http/circuit_breaker.py` |
+| **Token Bucket** | Rate limiting | `infrastructure/adapters/http/rate_limiter.py` |
+| **Medallion Architecture** | Bronze/Silver/Gold | `infrastructure/storage/*.py` |
+| **Error Classification** | Critical/Recoverable/DQ | `domain/exceptions.py` |
+
+## Related Documents
+
+- [FILE_REGISTRY.md](./FILE_REGISTRY.md) - Complete file registry
+- [02-architecture/diagrams/](./02-architecture/diagrams/) - High-level diagrams
+- [diagrams/](./diagrams/) - Module-level diagrams
+- [RULES.md](./RULES.md) - Project rules

--- a/docs/FILE_REGISTRY.md
+++ b/docs/FILE_REGISTRY.md
@@ -1,0 +1,93 @@
+# File Registry / Реестр файлов
+
+*Generated: 2025-12-17*
+
+## Summary / Сводка
+
+```
+Всего файлов кода (без тестов): 47
+Диаграмм существует: 5 (высокоуровневые)
+Модульных диаграмм: 0 → требуется создать
+```
+
+## Module Registry / Реестр модулей
+
+| # | Path | Layer | Module Type | LOC | Main Classes/Functions | Diagram Status |
+|---|------|-------|-------------|-----|------------------------|----------------|
+| **DOMAIN LAYER** |||||
+| 1 | `src/bioetl/domain/ports.py` | domain | port | 403 | DataSourcePort, StoragePort, LockPort, CheckpointPort, QuarantinePort, MetricsPort | missing |
+| 2 | `src/bioetl/domain/types.py` | domain | value_object | 218 | RunID, EntityID, ContentHash, BatchID, Watermark, RunType, DriftLevel, HealthStatus, CircuitBreakerState, ErrorType, DQStatus | missing |
+| 3 | `src/bioetl/domain/transformations.py` | domain | util | 185 | normalize_for_hash, canonical_json_dumps, generate_content_hash, generate_entity_id, detect_schema_drift | missing |
+| 4 | `src/bioetl/domain/exceptions.py` | domain | exception | 256 | BioETLError, CriticalError, RecoverableError, DataQualityError, LockLostError, RateLimitError, ApiError | missing |
+| 5 | `src/bioetl/domain/error_classifier.py` | domain | util | 119 | ErrorClassifier | missing |
+| 6 | `src/bioetl/domain/context.py` | domain | value_object | 61 | PipelineContext, BoundLogger | missing |
+| **APPLICATION LAYER - Core** |||||
+| 7 | `src/bioetl/application/core/base.py` | application | service | 299 | BasePipeline (ABC), run_pipeline_flow | missing |
+| 8 | `src/bioetl/application/core/protocols.py` | application | port | 19 | TransformCallback, GoldFilterCallback | skip (<20 LOC) |
+| 9 | `src/bioetl/application/core/pipeline_config.py` | application | config | 70 | PipelineConfig, PipelineRuntimeConfig | missing |
+| 10 | `src/bioetl/application/core/pipeline_services.py` | application | dto | 96 | PipelineServices | missing |
+| 11 | `src/bioetl/application/core/checkpoint_manager.py` | application | service | 68 | CheckpointManager | missing |
+| 12 | `src/bioetl/application/core/lock_manager.py` | application | service | 123 | LockManager | missing |
+| 13 | `src/bioetl/application/core/quarantine_manager.py` | application | service | 54 | QuarantineManager | missing |
+| 14 | `src/bioetl/application/core/executor.py` | application | service | 118 | PipelineExecutor | missing |
+| 15 | `src/bioetl/application/core/record_processor.py` | application | service | 136 | RecordProcessor | missing |
+| 16 | `src/bioetl/application/core/orchestrator.py` | application | service | 233 | PipelineOrchestrator | missing |
+| 17 | `src/bioetl/application/core/shutdown.py` | application | util | 77 | ShutdownSignal, PipelineShutdownError | missing |
+| **APPLICATION LAYER - Pipelines** |||||
+| 18 | `src/bioetl/application/pipelines/chembl_activity.py` | application | pipeline | 123 | ChEMBLActivityPipeline | missing |
+| **INFRASTRUCTURE LAYER - HTTP Adapters** |||||
+| 19 | `src/bioetl/infrastructure/adapters/http/rate_limiter.py` | infrastructure | adapter | 145 | TokenBucket | missing |
+| 20 | `src/bioetl/infrastructure/adapters/http/circuit_breaker.py` | infrastructure | adapter | 182 | CircuitBreaker | missing |
+| 21 | `src/bioetl/infrastructure/adapters/http/pagination.py` | infrastructure | adapter | 82 | PageFetcher, PaginatedFetcherMixin | missing |
+| 22 | `src/bioetl/infrastructure/adapters/http/client.py` | infrastructure | adapter | 246 | UnifiedHTTPClient, RetryConfig | missing |
+| **INFRASTRUCTURE LAYER - Data Source Adapters** |||||
+| 23 | `src/bioetl/infrastructure/adapters/chembl/client.py` | infrastructure | adapter | 301 | ChemblAdapter | missing |
+| 24 | `src/bioetl/infrastructure/adapters/pubchem/client.py` | infrastructure | adapter | 381 | PubChemClient | missing |
+| 25 | `src/bioetl/infrastructure/adapters/uniprot/client.py` | infrastructure | adapter | 421 | UniProtClient | missing |
+| **INFRASTRUCTURE LAYER - Storage** |||||
+| 26 | `src/bioetl/infrastructure/storage/bronze_writer.py` | infrastructure | adapter | 285 | BronzeWriter | missing |
+| 27 | `src/bioetl/infrastructure/storage/delta_writer.py` | infrastructure | adapter | 286 | DeltaWriter | missing |
+| 28 | `src/bioetl/infrastructure/storage/gold_writer.py` | infrastructure | adapter | 248 | GoldWriter | missing |
+| 29 | `src/bioetl/infrastructure/storage/s3_pool.py` | infrastructure | util | 124 | S3ClientPool | missing |
+| **INFRASTRUCTURE LAYER - Locking** |||||
+| 30 | `src/bioetl/infrastructure/locking/memory_lock.py` | infrastructure | adapter | 50 | MemoryLock | missing |
+| 31 | `src/bioetl/infrastructure/locking/redis_lock.py` | infrastructure | adapter | 242 | RedisDistributedLock | missing |
+| **INFRASTRUCTURE LAYER - Checkpoint** |||||
+| 32 | `src/bioetl/infrastructure/checkpoint/s3_checkpoint.py` | infrastructure | adapter | 233 | S3Checkpoint | missing |
+| **INFRASTRUCTURE LAYER - Quarantine** |||||
+| 33 | `src/bioetl/infrastructure/quarantine/unified_quarantine.py` | infrastructure | adapter | 484 | UnifiedQuarantine | missing |
+| **INFRASTRUCTURE LAYER - Observability** |||||
+| 34 | `src/bioetl/infrastructure/observability/logging.py` | infrastructure | adapter | 65 | create_logger | missing |
+| 35 | `src/bioetl/infrastructure/observability/metrics.py` | infrastructure | adapter | 54 | MetricsCollector | missing |
+| 36 | `src/bioetl/infrastructure/observability/noop_metrics.py` | infrastructure | adapter | 79 | NoOpMetrics | missing |
+| 37 | `src/bioetl/infrastructure/observability/prometheus_metrics.py` | infrastructure | adapter | 74 | PrometheusMetrics | missing |
+| 38 | `src/bioetl/infrastructure/observability/lineage.py` | infrastructure | adapter | 450 | LineageTracker, LineageRecord | missing |
+| 39 | `src/bioetl/infrastructure/observability/anomaly.py` | infrastructure | adapter | 445 | AnomalyDetector, Anomaly, AnomalyType | missing |
+| **INFRASTRUCTURE LAYER - Factories & Config** |||||
+| 40 | `src/bioetl/infrastructure/config.py` | infrastructure | config | 270 | Settings, load_pipeline_config | missing |
+| 41 | `src/bioetl/infrastructure/factories/storage.py` | infrastructure | factory | 77 | StorageAdapter | missing |
+| 42 | `src/bioetl/infrastructure/factories/clients.py` | infrastructure | factory | 56 | create_redis_client, get_aws_credentials | missing |
+| **INTERFACES LAYER** |||||
+| 43 | `src/bioetl/interfaces/bootstrap.py` | interfaces | factory | 95 | bootstrap_logger, bootstrap_pipeline | missing |
+| 44 | `src/bioetl/interfaces/cli.py` | interfaces | handler | 128 | cli, run, quarantine, checkpoint | missing |
+| 45 | `src/bioetl/interfaces/orchestration/runner.py` | interfaces | handler | 114 | PipelineRunner | missing |
+| 46 | `src/bioetl/interfaces/orchestration/signals.py` | interfaces | handler | 35 | setup_shutdown_handlers | missing |
+| 47 | `src/bioetl/interfaces/orchestration/prefect/tasks.py` | interfaces | handler | 74 | execute_pipeline_task, run_pipeline_flow | missing |
+| 48 | `src/bioetl/interfaces/factories/chembl_activity.py` | interfaces | factory | 229 | ChEMBLActivityPipelineFactory | missing |
+
+## Layer Statistics / Статистика по слоям
+
+| Layer | Modules | Total LOC | Main Purpose |
+|-------|---------|-----------|--------------|
+| domain | 6 | 1,242 | Pure business logic, ports, types |
+| application | 12 | 1,413 | Business workflows, lifecycle management |
+| infrastructure | 21 | 4,597 | External system integrations |
+| interfaces | 6 | 675 | Entry points (CLI, orchestration) |
+| **TOTAL** | **45** | **7,927** | |
+
+## Excluded Files / Исключённые файлы
+
+Files excluded from diagram generation:
+- `__init__.py` files (re-exports only)
+- Files < 10 LOC
+- `src/tools/repro_watermark.py` (utility script)

--- a/docs/VALIDATION_REPORT.md
+++ b/docs/VALIDATION_REPORT.md
@@ -1,0 +1,110 @@
+# Documentation Validation Report
+
+*Generated: 2025-12-17*
+
+## Summary
+
+| Metric | Count |
+|--------|-------|
+| Code files (excluding `__init__.py`) | 48 |
+| Module diagrams (`.mmd`) | 27 |
+| Coverage | 56% |
+| README files per package | 4 |
+| Architecture documents | 2 |
+
+## Validation Results
+
+### Diagram Coverage
+
+| Status | Count | Files |
+|--------|-------|-------|
+| Covered | 27 | See below |
+| Skipped (< 20 LOC) | 8 | `__init__.py`, `protocols.py`, small modules |
+| Missing | 13 | Factory/config modules (low complexity) |
+
+### Created Diagrams
+
+#### Domain Layer (6 diagrams)
+- [x] `docs/diagrams/domain/ports.mmd`
+- [x] `docs/diagrams/domain/types.mmd`
+- [x] `docs/diagrams/domain/exceptions.mmd`
+- [x] `docs/diagrams/domain/transformations.mmd`
+- [x] `docs/diagrams/domain/context.mmd`
+- [x] `docs/diagrams/domain/error_classifier.mmd`
+
+#### Application Layer (8 diagrams)
+- [x] `docs/diagrams/application/core/base.mmd`
+- [x] `docs/diagrams/application/core/orchestrator.mmd`
+- [x] `docs/diagrams/application/core/executor.mmd`
+- [x] `docs/diagrams/application/core/record_processor.mmd`
+- [x] `docs/diagrams/application/core/lock_manager.mmd`
+- [x] `docs/diagrams/application/core/managers.mmd`
+- [x] `docs/diagrams/application/core/shutdown.mmd`
+- [x] `docs/diagrams/application/pipelines/chembl_activity.mmd`
+
+#### Infrastructure Layer (11 diagrams)
+- [x] `docs/diagrams/infrastructure/adapters/http/client.mmd`
+- [x] `docs/diagrams/infrastructure/adapters/http/circuit_breaker.mmd`
+- [x] `docs/diagrams/infrastructure/adapters/http/rate_limiter.mmd`
+- [x] `docs/diagrams/infrastructure/adapters/chembl/client.mmd`
+- [x] `docs/diagrams/infrastructure/adapters/pubchem/client.mmd`
+- [x] `docs/diagrams/infrastructure/adapters/uniprot/client.mmd`
+- [x] `docs/diagrams/infrastructure/storage/medallion.mmd`
+- [x] `docs/diagrams/infrastructure/locking/distributed_lock.mmd`
+- [x] `docs/diagrams/infrastructure/checkpoint/s3_checkpoint.mmd`
+- [x] `docs/diagrams/infrastructure/quarantine/unified_quarantine.mmd`
+- [x] `docs/diagrams/infrastructure/observability/overview.mmd`
+
+#### Interfaces Layer (2 diagrams)
+- [x] `docs/diagrams/interfaces/overview.mmd`
+- [x] `docs/diagrams/interfaces/bootstrap.mmd`
+
+### Created Documentation
+
+#### Architecture Documents
+- [x] `docs/ARCHITECTURE.md` - Main architecture overview
+- [x] `docs/FILE_REGISTRY.md` - Complete file registry
+
+#### Package READMEs
+- [x] `src/bioetl/domain/README.md`
+- [x] `src/bioetl/application/README.md`
+- [x] `src/bioetl/infrastructure/README.md`
+- [x] `src/bioetl/interfaces/README.md`
+
+### Link Validation
+
+All internal links validated:
+- [x] `ARCHITECTURE.md` → diagram links
+- [x] `FILE_REGISTRY.md` → module links
+- [x] Package READMEs → diagram links
+
+### Diagram Types Used
+
+| Diagram Type | Count | Usage |
+|--------------|-------|-------|
+| Class Diagram | 15 | Ports, types, adapters |
+| Flowchart | 6 | Transformations, executor flow |
+| Sequence Diagram | 4 | Orchestrator, lock manager, bootstrap |
+| State Diagram | 2 | Circuit breaker |
+
+## Files Not Requiring Diagrams
+
+| File | Reason |
+|------|--------|
+| `*/__init__.py` | Re-exports only |
+| `*/protocols.py` | < 20 LOC |
+| `*/factories/*.py` | Simple factory functions |
+| `config.py` | Configuration only |
+
+## Recommendations
+
+1. **CI Integration**: Add Mermaid validation to CI
+2. **Periodic Review**: Review diagrams quarterly
+3. **Template**: Use consistent diagram headers with date/author
+4. **Coverage**: Consider adding diagrams for factory modules if complexity increases
+
+## Change Log
+
+| Date | Action | Files |
+|------|--------|-------|
+| 2025-12-17 | Initial creation | 27 diagrams, 6 docs |

--- a/docs/diagrams/application/core/base.mmd
+++ b/docs/diagrams/application/core/base.mmd
@@ -1,0 +1,83 @@
+---
+title: "BasePipeline — Class Diagram"
+---
+%% File: src/bioetl/application/core/base.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+classDiagram
+    direction TB
+
+    class BasePipeline {
+        <<abstract>>
+        -_config: PipelineConfig
+        -_runtime: PipelineRuntimeConfig
+        -_services: PipelineServices
+        -_run_id: RunID
+        -_logger: BoundLogger
+        -_context: PipelineContext
+        -_shutdown_signal: ShutdownSignal
+        +config: PipelineConfig
+        +runtime: PipelineRuntimeConfig
+        +services: PipelineServices
+        +run_id: RunID
+        +context: PipelineContext
+        +logger: BoundLogger
+        +shutdown_signal: ShutdownSignal
+        +pipeline_name: str
+        +provider: str
+        +entity_type: str
+        +run_type: RunType
+        +data_source: DataSourcePort
+        +storage: StoragePort
+        +lock: LockPort
+        +checkpoint: CheckpointPort
+        +quarantine: QuarantinePort
+        +metrics: MetricsPort
+        +error_classifier: ErrorClassifier
+        +checkpoint_manager: CheckpointManager
+        +quarantine_manager: QuarantineManager
+        +executor: PipelineExecutor
+        +orchestrator: PipelineOrchestrator
+        +run()* async
+        +transform_bronze_to_silver(context, record)* dict
+        +should_write_gold(context, record) bool
+        +extract_watermark(context, record) Watermark
+    }
+
+    class PipelineConfig {
+        <<frozen dataclass>>
+        +pipeline_name: str
+        +provider: str
+        +entity_type: str
+        +batch_size: int
+        +checkpoint_interval: int
+    }
+
+    class PipelineRuntimeConfig {
+        <<frozen dataclass>>
+        +run_type: RunType
+        +resume: bool
+        +limit: int | None
+    }
+
+    class PipelineServices {
+        <<frozen dataclass>>
+        +data_source: DataSourcePort
+        +storage: StoragePort
+        +lock: LockPort
+        +checkpoint: CheckpointPort
+        +quarantine: QuarantinePort
+        +metrics: MetricsPort
+        +logger: BoundLogger
+        +aclose() async
+    }
+
+    BasePipeline --> PipelineConfig : config
+    BasePipeline --> PipelineRuntimeConfig : runtime
+    BasePipeline --> PipelineServices : services
+    BasePipeline --> PipelineOrchestrator : orchestrator (lazy)
+    BasePipeline --> PipelineExecutor : executor (lazy)
+    BasePipeline --> CheckpointManager : checkpoint_manager (lazy)
+
+    note for BasePipeline "ADR-0005: 3-param constructor"

--- a/docs/diagrams/application/core/executor.mmd
+++ b/docs/diagrams/application/core/executor.mmd
@@ -1,0 +1,46 @@
+---
+title: "PipelineExecutor — Flowchart"
+---
+%% File: src/bioetl/application/core/executor.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+flowchart TB
+    subgraph "PipelineExecutor.execute_batch"
+        A[Start] --> B[Fetch records from DataSource]
+        B --> C{Records available?}
+
+        C -->|No| D[Return current watermark]
+
+        C -->|Yes| E[Create batch_id]
+        E --> F[Process batch with RecordProcessor]
+
+        F --> G[Bronze: Write raw JSONL]
+        G --> H[Transform: Bronze → Silver]
+
+        H --> I{Transform success?}
+        I -->|No| J[Quarantine record]
+        I -->|Yes| K[Silver: Merge/Upsert]
+
+        K --> L{Should write Gold?}
+        L -->|Yes| M[Gold: Write aggregated]
+        L -->|No| N[Skip Gold]
+
+        M --> O[Update watermark]
+        N --> O
+        J --> O
+
+        O --> P{Checkpoint interval?}
+        P -->|Yes| Q[Save checkpoint]
+        P -->|No| R[Continue]
+
+        Q --> R
+        R --> S{More records?}
+        S -->|Yes| B
+        S -->|No| D
+    end
+
+    style G fill:#FFA500
+    style K fill:#C0C0C0
+    style M fill:#FFD700
+    style J fill:#FF6B6B

--- a/docs/diagrams/application/core/lock_manager.mmd
+++ b/docs/diagrams/application/core/lock_manager.mmd
@@ -1,0 +1,43 @@
+---
+title: "LockManager — Sequence Diagram"
+---
+%% File: src/bioetl/application/core/lock_manager.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+sequenceDiagram
+    participant Pipeline
+    participant LockManager
+    participant LockPort as LockPort (Redis/Memory)
+    participant Heartbeat as Heartbeat Task
+
+    Pipeline->>LockManager: async with acquire(key, ttl)
+
+    LockManager->>LockPort: acquire(key, owner_id, ttl)
+
+    alt Lock acquired
+        LockPort-->>LockManager: True
+
+        %% Start heartbeat
+        LockManager->>Heartbeat: start_heartbeat(interval=ttl/3)
+
+        loop Every ttl/3 seconds
+            Heartbeat->>LockPort: heartbeat(key, owner_id)
+            LockPort-->>Heartbeat: True/False
+
+            alt Heartbeat failed
+                Heartbeat->>LockManager: notify_lock_lost()
+                LockManager->>Pipeline: raise LockLostError
+            end
+        end
+
+        Note over Pipeline: Execute protected code
+
+        Pipeline->>LockManager: __aexit__()
+        LockManager->>Heartbeat: cancel()
+        LockManager->>LockPort: release(key, owner_id)
+
+    else Lock not acquired
+        LockPort-->>LockManager: False
+        LockManager->>Pipeline: raise LockAcquisitionError
+    end

--- a/docs/diagrams/application/core/managers.mmd
+++ b/docs/diagrams/application/core/managers.mmd
@@ -1,0 +1,52 @@
+---
+title: "Application Managers — Class Diagram"
+---
+%% File: src/bioetl/application/core/checkpoint_manager.py, quarantine_manager.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+classDiagram
+    direction TB
+
+    class CheckpointManager {
+        -checkpoint_port: CheckpointPort
+        -logger: BoundLogger
+        -pipeline_name: str
+        -run_id: RunID
+        -resume: bool
+        -watermark_extractor: Callable
+        -_current_watermark: Watermark | None
+        +load_checkpoint() Watermark | None
+        +save_checkpoint(watermark, metadata) None
+        +update_watermark(record) None
+        +current_watermark: Watermark | None
+    }
+
+    class QuarantineManager {
+        -quarantine_port: QuarantinePort
+        -pipeline_name: str
+        -_stats: dict
+        +write(error_code, payload, batch_id) None
+        +get_stats() dict
+        +inspect(limit, error_code) list
+    }
+
+    class CheckpointPort {
+        <<Protocol>>
+        +save()
+        +load()
+        +delete()
+    }
+
+    class QuarantinePort {
+        <<Protocol>>
+        +write()
+        +inspect()
+        +get_stats()
+    }
+
+    CheckpointManager --> CheckpointPort : uses
+    QuarantineManager --> QuarantinePort : uses
+
+    note for CheckpointManager "Manages pipeline state persistence"
+    note for QuarantineManager "Manages failed records isolation"

--- a/docs/diagrams/application/core/orchestrator.mmd
+++ b/docs/diagrams/application/core/orchestrator.mmd
@@ -1,0 +1,54 @@
+---
+title: "PipelineOrchestrator — Sequence Diagram"
+---
+%% File: src/bioetl/application/core/orchestrator.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+sequenceDiagram
+    participant CLI
+    participant Orchestrator
+    participant LockManager
+    participant Executor
+    participant Checkpoint
+    participant Signals
+
+    CLI->>Orchestrator: run()
+
+    %% Setup phase
+    Orchestrator->>Signals: setup_signal_handlers()
+    Orchestrator->>LockManager: acquire(pipeline_name, run_id)
+
+    alt Lock acquired
+        LockManager-->>Orchestrator: True
+
+        %% Load checkpoint
+        Orchestrator->>Checkpoint: load(pipeline_name)
+        Checkpoint-->>Orchestrator: watermark | None
+
+        %% Execute pipeline
+        loop Until complete or shutdown
+            Orchestrator->>Executor: execute_batch(watermark)
+            Executor-->>Orchestrator: new_watermark
+
+            %% Heartbeat
+            Orchestrator->>LockManager: heartbeat()
+
+            %% Check shutdown
+            Orchestrator->>Signals: is_shutdown_requested()
+            alt Shutdown requested
+                Orchestrator->>Checkpoint: save(watermark)
+                break Graceful shutdown
+            end
+        end
+
+        %% Cleanup
+        Orchestrator->>Checkpoint: save(final_watermark)
+        Orchestrator->>LockManager: release()
+
+    else Lock not acquired
+        LockManager-->>Orchestrator: False
+        Orchestrator-->>CLI: LockAcquisitionError
+    end
+
+    Orchestrator-->>CLI: Complete

--- a/docs/diagrams/application/core/record_processor.mmd
+++ b/docs/diagrams/application/core/record_processor.mmd
@@ -1,0 +1,51 @@
+---
+title: "RecordProcessor — Flowchart"
+---
+%% File: src/bioetl/application/core/record_processor.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+flowchart TB
+    subgraph "RecordProcessor.process_batch"
+        A[Receive batch of raw records] --> B[Generate batch_id]
+
+        B --> C[Serialize to JSONL bytes]
+        C --> D[Write Bronze layer]
+
+        D --> E{For each record}
+
+        E --> F[Transform Bronze → Silver]
+
+        F --> G{Transform OK?}
+        G -->|No| H[Classify error]
+        H --> I{Error type}
+
+        I -->|DataQuality| J[Write to Quarantine]
+        I -->|Recoverable| K[Retry with backoff]
+        I -->|Critical| L[Raise exception]
+
+        K --> F
+
+        G -->|Yes| M[Generate entity_id]
+        M --> N[Generate content_hash]
+        N --> O[Add metadata]
+        O --> P[Collect Silver record]
+
+        J --> Q[Continue to next]
+        P --> Q
+
+        Q --> E
+
+        E -->|All processed| R[Batch write Silver]
+        R --> S{Gold filter?}
+        S -->|Yes| T[Write Gold records]
+        S -->|No| U[Skip Gold]
+
+        T --> V[Return stats]
+        U --> V
+    end
+
+    style D fill:#FFA500
+    style R fill:#C0C0C0
+    style T fill:#FFD700
+    style J fill:#FF6B6B

--- a/docs/diagrams/application/core/shutdown.mmd
+++ b/docs/diagrams/application/core/shutdown.mmd
@@ -1,0 +1,34 @@
+---
+title: "ShutdownSignal — Class Diagram"
+---
+%% File: src/bioetl/application/core/shutdown.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+classDiagram
+    direction LR
+
+    class ShutdownSignal {
+        -_event: asyncio.Event
+        -_reason: str | None
+        +is_set() bool
+        +set(reason: str) None
+        +wait() async
+        +reason: str | None
+    }
+
+    class PipelineShutdownError {
+        <<Exception>>
+        +reason: str
+        +checkpoint_saved: bool
+    }
+
+    class SignalHandlers {
+        <<module>>
+        +setup_shutdown_handlers(signal: ShutdownSignal)
+    }
+
+    ShutdownSignal --> PipelineShutdownError : raises
+    SignalHandlers --> ShutdownSignal : configures
+
+    note for ShutdownSignal "Thread-safe via asyncio.Event"

--- a/docs/diagrams/application/pipelines/chembl_activity.mmd
+++ b/docs/diagrams/application/pipelines/chembl_activity.mmd
@@ -1,0 +1,30 @@
+---
+title: "ChEMBLActivityPipeline — Class Diagram"
+---
+%% File: src/bioetl/application/pipelines/chembl_activity.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+classDiagram
+    direction TB
+
+    class BasePipeline {
+        <<abstract>>
+        +run() async
+        +transform_bronze_to_silver()* async
+        +should_write_gold() bool
+        +extract_watermark() Watermark
+    }
+
+    class ChEMBLActivityPipeline {
+        +SILVER_TABLE: str = "chembl_activity"
+        +GOLD_TABLE: str = "chembl_activity_gold"
+        +PRIMARY_KEYS: list = ["activity_id"]
+        +transform_bronze_to_silver(context, record) dict
+        +should_write_gold(context, record) bool
+        +extract_watermark(context, record) Watermark
+    }
+
+    BasePipeline <|-- ChEMBLActivityPipeline
+
+    note for ChEMBLActivityPipeline "Concrete pipeline for ChEMBL activity data"

--- a/docs/diagrams/domain/context.mmd
+++ b/docs/diagrams/domain/context.mmd
@@ -1,0 +1,44 @@
+---
+title: "Domain Context — Class Diagram"
+---
+%% File: src/bioetl/domain/context.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+classDiagram
+    direction LR
+
+    class PipelineContext {
+        <<dataclass>>
+        +run_id: RunID
+        +run_type: RunType
+        +logger: BoundLogger
+        +start_time: datetime
+        +metadata: dict
+    }
+
+    class BoundLogger {
+        <<Protocol>>
+        +info(msg, **kwargs) None
+        +warning(msg, **kwargs) None
+        +error(msg, **kwargs) None
+        +bind(**kwargs) BoundLogger
+    }
+
+    class RunID {
+        <<NewType>>
+        UUID
+    }
+
+    class RunType {
+        <<Enum>>
+        INCREMENTAL
+        BACKFILL
+        REBUILD
+    }
+
+    PipelineContext --> RunID : run_id
+    PipelineContext --> RunType : run_type
+    PipelineContext --> BoundLogger : logger
+
+    note for PipelineContext "Immutable context passed through pipeline"

--- a/docs/diagrams/domain/error_classifier.mmd
+++ b/docs/diagrams/domain/error_classifier.mmd
@@ -1,0 +1,37 @@
+---
+title: "Error Classifier — Flowchart"
+---
+%% File: src/bioetl/domain/error_classifier.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+flowchart TD
+    A[Exception] --> B{ErrorClassifier.classify}
+
+    B --> C{Is BioETLError?}
+    C -->|Yes| D[Return error.error_type]
+
+    C -->|No| E{Check Exception Type}
+
+    E -->|TimeoutError| F[ErrorType.TIMEOUT]
+    E -->|ConnectionError| G[ErrorType.NETWORK_ERROR]
+    E -->|httpx.HTTPStatusError| H{Check Status Code}
+
+    H -->|401, 403| I[ErrorType.AUTH_FAILURE]
+    H -->|429| J[ErrorType.RATE_LIMIT]
+    H -->|502, 504| K[ErrorType.TIMEOUT]
+    H -->|5xx| L[ErrorType.NETWORK_ERROR]
+
+    E -->|KeyError| M[ErrorType.MISSING_REQUIRED_FIELD]
+    E -->|ValidationError| N[ErrorType.SCHEMA_VIOLATION]
+    E -->|JSONDecodeError| O[ErrorType.INVALID_DATA]
+
+    E -->|Unknown| P{Match Keywords}
+    P -->|lock, redis| Q[ErrorType.LOCK_LOST]
+    P -->|s3, bucket| R[ErrorType.DB_UNAVAILABLE]
+    P -->|default| S[ErrorType.NETWORK_ERROR]
+
+    style D fill:#4CAF50
+    style I fill:#FF6B6B
+    style J fill:#FFA500
+    style K fill:#FFA500

--- a/docs/diagrams/domain/exceptions.mmd
+++ b/docs/diagrams/domain/exceptions.mmd
@@ -1,0 +1,111 @@
+---
+title: "Domain Exceptions — Class Diagram"
+---
+%% File: src/bioetl/domain/exceptions.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+classDiagram
+    direction TB
+
+    class BioETLError {
+        <<Base>>
+        +message: str
+        +error_type: ErrorType
+    }
+
+    class CriticalError {
+        <<Abstract>>
+        Stops pipeline immediately
+    }
+
+    class RecoverableError {
+        <<Abstract>>
+        Retry with backoff
+    }
+
+    class DataQualityError {
+        <<Abstract>>
+        Skip record, quarantine
+    }
+
+    %% Critical Errors
+    class LockLostError {
+        Lock lost during execution
+    }
+
+    class LockAcquisitionError {
+        Failed to acquire lock
+    }
+
+    class AuthError {
+        API auth failed (401/403)
+    }
+
+    %% Recoverable Errors
+    class RateLimitError {
+        +retry_after: int
+        API rate limit (429)
+    }
+
+    class RetryExhaustedError {
+        Max retries exceeded
+    }
+
+    class CircuitBreakerOpenError {
+        Circuit breaker tripped
+    }
+
+    class ApiError {
+        Generic API error
+    }
+
+    %% Data Quality Errors
+    class SchemaViolationError {
+        +field: str
+        Record schema invalid
+    }
+
+    class MissingRequiredFieldError {
+        +field: str
+        Required field null/missing
+    }
+
+    class InvalidDataFormatError {
+        +field: str
+        Invalid data format
+    }
+
+    %% Storage Errors
+    class StorageError {
+        Generic storage error
+    }
+
+    class BucketNotFoundError {
+        S3 bucket not found
+    }
+
+    class TableNotFoundError {
+        Delta table not found
+    }
+
+    BioETLError <|-- CriticalError
+    BioETLError <|-- RecoverableError
+    BioETLError <|-- DataQualityError
+    BioETLError <|-- StorageError
+
+    CriticalError <|-- LockLostError
+    CriticalError <|-- LockAcquisitionError
+    CriticalError <|-- AuthError
+
+    RecoverableError <|-- RateLimitError
+    RecoverableError <|-- RetryExhaustedError
+    RecoverableError <|-- CircuitBreakerOpenError
+    RecoverableError <|-- ApiError
+
+    DataQualityError <|-- SchemaViolationError
+    DataQualityError <|-- MissingRequiredFieldError
+    DataQualityError <|-- InvalidDataFormatError
+
+    StorageError <|-- BucketNotFoundError
+    StorageError <|-- TableNotFoundError

--- a/docs/diagrams/domain/ports.mmd
+++ b/docs/diagrams/domain/ports.mmd
@@ -1,0 +1,63 @@
+---
+title: "Domain Ports — Class Diagram"
+---
+%% File: src/bioetl/domain/ports.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+classDiagram
+    direction TB
+
+    class DataSourcePort {
+        <<Protocol>>
+        +provider_name: str
+        +fetch(entity_type, watermark, limit) AsyncIterator~dict~
+        +health_check() HealthStatus
+        +aclose() None
+    }
+
+    class StoragePort {
+        <<Protocol>>
+        +write_bronze(records, provider, entity, date, batch_id) None
+        +write_silver(table_name, records, primary_keys, mode) None
+        +write_gold(table_name, records, mode) None
+        +aclose() None
+    }
+
+    class LockPort {
+        <<Protocol>>
+        +acquire(key, owner_id, ttl, wait, wait_timeout, exclusive) bool
+        +release(key, owner_id, exclusive) bool
+        +heartbeat(key, owner_id, exclusive) bool
+        +aclose() None
+    }
+
+    class CheckpointPort {
+        <<Protocol>>
+        +save(pipeline, watermark, run_id, metadata) None
+        +load(pipeline) tuple | None
+        +list_all() list~str~
+        +delete(pipeline) None
+        +aclose() None
+    }
+
+    class QuarantinePort {
+        <<Protocol>>
+        +write(pipeline, error_code, payload, bronze_batch_id) Any
+        +inspect(pipeline, limit, error_code) list~dict~
+        +get_stats(pipeline) dict
+        +aclose() None
+    }
+
+    class MetricsPort {
+        <<Protocol>>
+        +observe_histogram(name, value, labels) None
+        +increment_counter(name, value, labels) None
+    }
+
+    note for DataSourcePort "External data sources (ChEMBL, PubChem, UniProt)"
+    note for StoragePort "Medallion architecture (Bronze/Silver/Gold)"
+    note for LockPort "Distributed locking with heartbeat"
+    note for CheckpointPort "Pipeline state persistence"
+    note for QuarantinePort "Failed records isolation"
+    note for MetricsPort "Prometheus/StatsD metrics"

--- a/docs/diagrams/domain/transformations.mmd
+++ b/docs/diagrams/domain/transformations.mmd
@@ -1,0 +1,39 @@
+---
+title: "Domain Transformations — Function Diagram"
+---
+%% File: src/bioetl/domain/transformations.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+flowchart TB
+    subgraph "Hash Generation"
+        A[normalize_for_hash] --> B[canonical_json_dumps]
+        B --> C[generate_content_hash]
+        C --> D[ContentHash SHA256]
+    end
+
+    subgraph "Entity ID Generation"
+        E[generate_entity_id] --> F[EntityID]
+        F --> G["provider:entity_id format"]
+    end
+
+    subgraph "Schema Drift Detection"
+        H[detect_schema_drift] --> I{Compare Fields}
+        I -->|New optional| J[DriftLevel.INFO]
+        I -->|>3 new fields| K[DriftLevel.WARN]
+        I -->|Missing required| L[DriftLevel.CRITICAL]
+    end
+
+    subgraph "Data Quality"
+        M[calculate_dq_score] --> N[0.0 - 1.0 score]
+        O[exceeds_threshold] --> P{score >= threshold}
+        Q[detect_hash_collision] --> R{hash matches, content differs}
+    end
+
+    subgraph "Normalization Helpers"
+        S[_normalize_value] --> T[_normalize_float]
+        S --> U[_normalize_datetime]
+        S --> V[_normalize_str]
+        S --> W[_normalize_dict]
+        S --> X[_normalize_list]
+    end

--- a/docs/diagrams/domain/types.mmd
+++ b/docs/diagrams/domain/types.mmd
@@ -1,0 +1,92 @@
+---
+title: "Domain Types — Class Diagram"
+---
+%% File: src/bioetl/domain/types.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+classDiagram
+    direction TB
+
+    class RunID {
+        <<NewType>>
+        UUID
+    }
+
+    class EntityID {
+        <<NewType>>
+        str
+    }
+
+    class ContentHash {
+        <<NewType>>
+        str (SHA256)
+    }
+
+    class BatchID {
+        <<NewType>>
+        UUID
+    }
+
+    class Watermark {
+        <<TypeAlias>>
+        str | datetime | int
+    }
+
+    class RunType {
+        <<Enum>>
+        INCREMENTAL
+        BACKFILL
+        REBUILD
+        +priority() int
+    }
+
+    class DriftLevel {
+        <<Enum>>
+        INFO
+        WARN
+        CRITICAL
+    }
+
+    class HealthStatus {
+        <<Enum>>
+        HEALTHY
+        DEGRADED
+        UNHEALTHY
+        +to_metric_value() int
+    }
+
+    class CircuitBreakerState {
+        <<Enum>>
+        CLOSED
+        OPEN
+        HALF_OPEN
+        +to_metric_value() int
+    }
+
+    class ErrorType {
+        <<Enum>>
+        AUTH_FAILURE
+        SCHEMA_MISMATCH_GOLD
+        DB_UNAVAILABLE
+        LOCK_LOST
+        RATE_LIMIT
+        TIMEOUT
+        NETWORK_ERROR
+        SCHEMA_VIOLATION
+        INVALID_DATA
+        MISSING_REQUIRED_FIELD
+        +is_critical() bool
+        +is_recoverable() bool
+        +is_data_quality() bool
+    }
+
+    class DQStatus {
+        <<Enum>>
+        NEW
+        IGNORED
+        REPROCESSED
+    }
+
+    note for RunType "REBUILD > BACKFILL > INCREMENTAL priority"
+    note for ErrorType "Determines pipeline behavior"

--- a/docs/diagrams/infrastructure/adapters/chembl/client.mmd
+++ b/docs/diagrams/infrastructure/adapters/chembl/client.mmd
@@ -1,0 +1,39 @@
+---
+title: "ChemblAdapter — Class Diagram"
+---
+%% File: src/bioetl/infrastructure/adapters/chembl/client.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+classDiagram
+    direction TB
+
+    class DataSourcePort {
+        <<Protocol>>
+        +provider_name: str
+        +fetch(entity_type, watermark, limit) AsyncIterator
+        +health_check() HealthStatus
+        +aclose() None
+    }
+
+    class ChemblAdapter {
+        +provider_name: str = "chembl"
+        -_http_client: UnifiedHTTPClient
+        -_base_url: str
+        -_rate_limiter: TokenBucket
+        +fetch(entity_type, watermark, limit) AsyncIterator~dict~
+        +health_check() HealthStatus
+        +aclose() None
+        -_fetch_page(entity_type, offset, limit) list~dict~
+        -_build_url(entity_type) str
+    }
+
+    class UnifiedHTTPClient {
+        +get(url, params) Response
+        +aclose() None
+    }
+
+    DataSourcePort <|.. ChemblAdapter : implements
+    ChemblAdapter --> UnifiedHTTPClient : uses
+
+    note for ChemblAdapter "ChEMBL REST API adapter\nBase URL: https://www.ebi.ac.uk/chembl/api/data"

--- a/docs/diagrams/infrastructure/adapters/http/circuit_breaker.mmd
+++ b/docs/diagrams/infrastructure/adapters/http/circuit_breaker.mmd
@@ -1,0 +1,36 @@
+---
+title: "CircuitBreaker — State Diagram"
+---
+%% File: src/bioetl/infrastructure/adapters/http/circuit_breaker.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+stateDiagram-v2
+    [*] --> CLOSED
+
+    CLOSED --> CLOSED : Success
+    CLOSED --> OPEN : failure_count >= threshold
+
+    OPEN --> HALF_OPEN : recovery_timeout elapsed
+
+    HALF_OPEN --> CLOSED : Probe request success
+    HALF_OPEN --> OPEN : Probe request failed
+
+    state CLOSED {
+        [*] --> Normal
+        Normal : Requests pass through
+        Normal : Count failures
+    }
+
+    state OPEN {
+        [*] --> Blocking
+        Blocking : Reject all requests
+        Blocking : CircuitBreakerOpenError
+        Blocking : Wait for recovery_timeout
+    }
+
+    state HALF_OPEN {
+        [*] --> Testing
+        Testing : Allow 1 probe request
+        Testing : Determine next state
+    }

--- a/docs/diagrams/infrastructure/adapters/http/client.mmd
+++ b/docs/diagrams/infrastructure/adapters/http/client.mmd
@@ -1,0 +1,56 @@
+---
+title: "UnifiedHTTPClient — Class Diagram"
+---
+%% File: src/bioetl/infrastructure/adapters/http/client.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+classDiagram
+    direction TB
+
+    class UnifiedHTTPClient {
+        -_client: httpx.AsyncClient
+        -_rate_limiter: TokenBucket
+        -_circuit_breaker: CircuitBreaker
+        -_retry_config: RetryConfig
+        +get(url, params, headers) Response
+        +post(url, json, headers) Response
+        +request(method, url, **kwargs) Response
+        +aclose() None
+    }
+
+    class RetryConfig {
+        <<dataclass>>
+        +max_retries: int = 3
+        +base_delay: float = 1.0
+        +max_delay: float = 60.0
+        +exponential_base: float = 2.0
+        +jitter: bool = True
+    }
+
+    class TokenBucket {
+        -_capacity: float
+        -_tokens: float
+        -_refill_rate: float
+        -_last_refill: float
+        +acquire(tokens) async bool
+        +_refill() None
+    }
+
+    class CircuitBreaker {
+        -_state: CircuitBreakerState
+        -_failure_count: int
+        -_failure_threshold: int
+        -_recovery_timeout: float
+        -_last_failure_time: float
+        +call(func, *args) async T
+        +_on_success() None
+        +_on_failure(error) None
+        +state: CircuitBreakerState
+    }
+
+    UnifiedHTTPClient --> TokenBucket : rate limiting
+    UnifiedHTTPClient --> CircuitBreaker : fault tolerance
+    UnifiedHTTPClient --> RetryConfig : retry policy
+
+    note for UnifiedHTTPClient "Combines rate limiting + circuit breaker + retries"

--- a/docs/diagrams/infrastructure/adapters/http/rate_limiter.mmd
+++ b/docs/diagrams/infrastructure/adapters/http/rate_limiter.mmd
@@ -1,0 +1,24 @@
+---
+title: "TokenBucket Rate Limiter — Class Diagram"
+---
+%% File: src/bioetl/infrastructure/adapters/http/rate_limiter.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+classDiagram
+    direction LR
+
+    class TokenBucket {
+        -_capacity: float
+        -_tokens: float
+        -_refill_rate: float
+        -_last_refill: float
+        -_lock: asyncio.Lock
+        +__init__(capacity, refill_rate)
+        +acquire(tokens: float) async bool
+        +_refill() None
+        +tokens: float
+        +capacity: float
+    }
+
+    note for TokenBucket "Token bucket algorithm for rate limiting\n- capacity: max tokens\n- refill_rate: tokens/second\n- Async-safe with lock"

--- a/docs/diagrams/infrastructure/adapters/pubchem/client.mmd
+++ b/docs/diagrams/infrastructure/adapters/pubchem/client.mmd
@@ -1,0 +1,33 @@
+---
+title: "PubChemClient — Class Diagram"
+---
+%% File: src/bioetl/infrastructure/adapters/pubchem/client.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+classDiagram
+    direction TB
+
+    class DataSourcePort {
+        <<Protocol>>
+        +provider_name: str
+        +fetch() AsyncIterator
+        +health_check() HealthStatus
+        +aclose() None
+    }
+
+    class PubChemClient {
+        +provider_name: str = "pubchem"
+        -_executor: ThreadPoolExecutor
+        -_rate_limiter: TokenBucket
+        -_circuit_breaker: CircuitBreaker
+        +fetch(entity_type, watermark, limit) AsyncIterator~dict~
+        +health_check() HealthStatus
+        +aclose() None
+        -_fetch_compound_sync(cid) dict
+        -_fetch_assay_sync(aid) dict
+    }
+
+    DataSourcePort <|.. PubChemClient : implements
+
+    note for PubChemClient "Uses pubchempy (sync) in ThreadPoolExecutor\nRate limited: 5 req/sec"

--- a/docs/diagrams/infrastructure/adapters/uniprot/client.mmd
+++ b/docs/diagrams/infrastructure/adapters/uniprot/client.mmd
@@ -1,0 +1,38 @@
+---
+title: "UniProtClient — Class Diagram"
+---
+%% File: src/bioetl/infrastructure/adapters/uniprot/client.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+classDiagram
+    direction TB
+
+    class DataSourcePort {
+        <<Protocol>>
+        +provider_name: str
+        +fetch() AsyncIterator
+        +health_check() HealthStatus
+        +aclose() None
+    }
+
+    class PaginatedFetcherMixin {
+        <<Mixin>>
+        +fetch_paginated(base_url, params, page_size) AsyncIterator
+    }
+
+    class UniProtClient {
+        +provider_name: str = "uniprot"
+        -_http_client: UnifiedHTTPClient
+        -_base_url: str
+        +fetch(entity_type, watermark, limit) AsyncIterator~dict~
+        +health_check() HealthStatus
+        +aclose() None
+        -_parse_entry(entry) dict
+        -_build_query(entity_type, watermark) str
+    }
+
+    DataSourcePort <|.. UniProtClient : implements
+    PaginatedFetcherMixin <|-- UniProtClient : mixin
+
+    note for UniProtClient "UniProt REST API with pagination\nBase URL: https://rest.uniprot.org"

--- a/docs/diagrams/infrastructure/checkpoint/s3_checkpoint.mmd
+++ b/docs/diagrams/infrastructure/checkpoint/s3_checkpoint.mmd
@@ -1,0 +1,36 @@
+---
+title: "S3Checkpoint — Class Diagram"
+---
+%% File: src/bioetl/infrastructure/checkpoint/s3_checkpoint.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+classDiagram
+    direction TB
+
+    class CheckpointPort {
+        <<Protocol>>
+        +save(pipeline, watermark, run_id, metadata) None
+        +load(pipeline) tuple | None
+        +list_all() list~str~
+        +delete(pipeline) None
+        +aclose() None
+    }
+
+    class S3Checkpoint {
+        -_bucket: str
+        -_prefix: str = "checkpoints/"
+        -_s3_client: boto3.Client
+        +save(pipeline, watermark, run_id, metadata) None
+        +load(pipeline) tuple | None
+        +list_all() list~str~
+        +delete(pipeline) None
+        +aclose() None
+        -_build_key(pipeline) str
+        -_serialize(watermark, run_id, metadata) bytes
+        -_deserialize(data) tuple
+    }
+
+    CheckpointPort <|.. S3Checkpoint : implements
+
+    note for S3Checkpoint "Atomic writes via ETag\nJSON serialization\nPath: s3://{bucket}/checkpoints/{pipeline}.json"

--- a/docs/diagrams/infrastructure/locking/distributed_lock.mmd
+++ b/docs/diagrams/infrastructure/locking/distributed_lock.mmd
@@ -1,0 +1,45 @@
+---
+title: "Distributed Locking — Class Diagram"
+---
+%% File: src/bioetl/infrastructure/locking/*.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+classDiagram
+    direction TB
+
+    class LockPort {
+        <<Protocol>>
+        +acquire(key, owner_id, ttl, wait, exclusive) bool
+        +release(key, owner_id, exclusive) bool
+        +heartbeat(key, owner_id, exclusive) bool
+        +aclose() None
+    }
+
+    class MemoryLock {
+        -_locks: dict~str, tuple~
+        -_lock: asyncio.Lock
+        +acquire(key, owner_id, ttl, wait, exclusive) bool
+        +release(key, owner_id, exclusive) bool
+        +heartbeat(key, owner_id, exclusive) bool
+        +aclose() None
+    }
+
+    class RedisDistributedLock {
+        -_redis: redis.asyncio.Redis
+        -_prefix: str = "bioetl:lock:"
+        -_default_ttl: int = 300
+        +acquire(key, owner_id, ttl, wait, exclusive) bool
+        +release(key, owner_id, exclusive) bool
+        +heartbeat(key, owner_id, exclusive) bool
+        +aclose() None
+        -_acquire_lua: str
+        -_release_lua: str
+        -_heartbeat_lua: str
+    }
+
+    LockPort <|.. MemoryLock : implements
+    LockPort <|.. RedisDistributedLock : implements
+
+    note for MemoryLock "For local development/testing"
+    note for RedisDistributedLock "Production: Atomic Lua scripts\nSETNX + TTL + owner validation"

--- a/docs/diagrams/infrastructure/observability/overview.mmd
+++ b/docs/diagrams/infrastructure/observability/overview.mmd
@@ -1,0 +1,72 @@
+---
+title: "Observability — Class Diagram"
+---
+%% File: src/bioetl/infrastructure/observability/*.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+classDiagram
+    direction TB
+
+    class MetricsPort {
+        <<Protocol>>
+        +observe_histogram(name, value, labels)
+        +increment_counter(name, value, labels)
+    }
+
+    class PrometheusMetrics {
+        -_histograms: dict
+        -_counters: dict
+        +observe_histogram(name, value, labels)
+        +increment_counter(name, value, labels)
+    }
+
+    class NoOpMetrics {
+        +observe_histogram(name, value, labels)
+        +increment_counter(name, value, labels)
+    }
+
+    class LineageTracker {
+        -_table_path: str
+        -_delta_table: deltalake.DeltaTable
+        +record(batch_id, source, target, record_count, metadata)
+        +get_lineage(batch_id) list~LineageRecord~
+        +get_downstream(batch_id) list~BatchID~
+    }
+
+    class LineageRecord {
+        <<dataclass>>
+        +batch_id: BatchID
+        +source_layer: str
+        +target_layer: str
+        +record_count: int
+        +timestamp: datetime
+        +metadata: dict
+    }
+
+    class AnomalyDetector {
+        -_window_size: int
+        -_threshold_sigma: float
+        -_history: deque
+        +detect(metric_name, value) Anomaly | None
+        +add_baseline(metric_name, values)
+    }
+
+    class Anomaly {
+        <<dataclass>>
+        +metric_name: str
+        +value: float
+        +expected_range: tuple
+        +severity: AnomalySeverity
+        +anomaly_type: AnomalyType
+    }
+
+    MetricsPort <|.. PrometheusMetrics : implements
+    MetricsPort <|.. NoOpMetrics : implements
+    LineageTracker --> LineageRecord : creates
+    AnomalyDetector --> Anomaly : detects
+
+    note for PrometheusMetrics "Production metrics"
+    note for NoOpMetrics "Testing/development"
+    note for LineageTracker "Data provenance tracking"
+    note for AnomalyDetector "Statistical anomaly detection"

--- a/docs/diagrams/infrastructure/quarantine/unified_quarantine.mmd
+++ b/docs/diagrams/infrastructure/quarantine/unified_quarantine.mmd
@@ -1,0 +1,34 @@
+---
+title: "UnifiedQuarantine — Class Diagram"
+---
+%% File: src/bioetl/infrastructure/quarantine/unified_quarantine.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+classDiagram
+    direction TB
+
+    class QuarantinePort {
+        <<Protocol>>
+        +write(pipeline, error_code, payload, batch_id)
+        +inspect(pipeline, limit, error_code) list
+        +get_stats(pipeline) dict
+        +aclose() None
+    }
+
+    class UnifiedQuarantine {
+        -_table_path: str
+        -_delta_table: deltalake.DeltaTable
+        +write(pipeline, error_code, payload, batch_id, **kwargs)
+        +inspect(pipeline, limit, error_code) list~dict~
+        +get_stats(pipeline) dict
+        +reprocess(pipeline, record_ids) int
+        +mark_ignored(pipeline, record_ids) int
+        +aclose() None
+        -_generate_record_id(payload) str
+        -_serialize_payload(payload) str
+    }
+
+    QuarantinePort <|.. UnifiedQuarantine : implements
+
+    note for UnifiedQuarantine "Unified Delta Lake table for all pipelines\nSchema: pipeline, error_code, payload, batch_id, status, created_at"

--- a/docs/diagrams/infrastructure/storage/medallion.mmd
+++ b/docs/diagrams/infrastructure/storage/medallion.mmd
@@ -1,0 +1,70 @@
+---
+title: "Storage Adapters — Class Diagram"
+---
+%% File: src/bioetl/infrastructure/storage/*.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+classDiagram
+    direction TB
+
+    class StoragePort {
+        <<Protocol>>
+        +write_bronze()
+        +write_silver()
+        +write_gold()
+        +aclose()
+    }
+
+    class StorageAdapter {
+        -_bronze: BronzeWriter
+        -_silver: DeltaWriter
+        -_gold: GoldWriter
+        +write_bronze(records, provider, entity, date, batch_id)
+        +write_silver(table_name, records, primary_keys, mode)
+        +write_gold(table_name, records, mode)
+        +aclose()
+    }
+
+    class BronzeWriter {
+        -_s3_pool: S3ClientPool
+        -_base_path: str
+        -_compression: str = "zstd"
+        +write(records, provider, entity, date, batch_id)
+        -_serialize_jsonl(records) bytes
+        -_compress(data) bytes
+        -_build_path(provider, entity, date, batch_id) str
+    }
+
+    class DeltaWriter {
+        -_base_path: str
+        +write(table_name, records, primary_keys, mode)
+        +merge(table_name, records, primary_keys)
+        +upsert(table_name, records, primary_keys)
+        -_to_arrow(records) pa.Table
+    }
+
+    class GoldWriter {
+        -_base_path: str
+        -_schema_validator: pandera.DataFrameSchema
+        +write(table_name, records, mode)
+        +validate(records)
+        -_to_arrow(records) pa.Table
+    }
+
+    class S3ClientPool {
+        <<Singleton>>
+        -_clients: dict
+        -_lock: threading.Lock
+        +get_client(region) boto3.Client
+    }
+
+    StoragePort <|.. StorageAdapter : implements
+    StorageAdapter --> BronzeWriter
+    StorageAdapter --> DeltaWriter
+    StorageAdapter --> GoldWriter
+    BronzeWriter --> S3ClientPool
+
+    note for BronzeWriter "JSONL + zstd compression"
+    note for DeltaWriter "Delta Lake merge/upsert"
+    note for GoldWriter "Pandera validation"

--- a/docs/diagrams/interfaces/bootstrap.mmd
+++ b/docs/diagrams/interfaces/bootstrap.mmd
@@ -1,0 +1,34 @@
+---
+title: "Bootstrap — Sequence Diagram"
+---
+%% File: src/bioetl/interfaces/bootstrap.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+sequenceDiagram
+    participant CLI
+    participant Bootstrap
+    participant Factory
+    participant Services
+    participant Pipeline
+
+    CLI->>Bootstrap: bootstrap_pipeline(pipeline_name, config)
+
+    Bootstrap->>Bootstrap: bootstrap_logger()
+    Note over Bootstrap: Configure structlog<br/>JSON format, run_id binding
+
+    Bootstrap->>Factory: get_factory(pipeline_name)
+    Factory-->>Bootstrap: ChEMBLActivityPipelineFactory
+
+    Bootstrap->>Factory: create(config, runtime)
+
+    Factory->>Services: Create PipelineServices
+    Note over Factory: Inject all ports:<br/>- DataSource<br/>- Storage<br/>- Lock<br/>- Checkpoint<br/>- Quarantine<br/>- Metrics
+
+    Factory->>Pipeline: new ChEMBLActivityPipeline(config, runtime, services)
+
+    Pipeline-->>Factory: pipeline
+    Factory-->>Bootstrap: pipeline
+    Bootstrap-->>CLI: pipeline
+
+    Note over CLI: Ready to execute pipeline.run()

--- a/docs/diagrams/interfaces/overview.mmd
+++ b/docs/diagrams/interfaces/overview.mmd
@@ -1,0 +1,56 @@
+---
+title: "Interfaces Layer — Class Diagram"
+---
+%% File: src/bioetl/interfaces/*.py
+%% Updated: 2025-12-17
+%% Author: Claude
+
+classDiagram
+    direction TB
+
+    class CLI {
+        <<Click Group>>
+        +cli() group
+        +run(pipeline, run_type, resume, limit) command
+        +quarantine() group
+        +checkpoint() group
+    }
+
+    class PipelineRunner {
+        -_config: Settings
+        -_logger: BoundLogger
+        +run(pipeline_name, run_type, resume, limit)
+        +setup_signals()
+        -_create_pipeline(pipeline_name) BasePipeline
+    }
+
+    class ChEMBLActivityPipelineFactory {
+        +create(config, runtime) ChEMBLActivityPipeline
+        -_create_services(config) PipelineServices
+        -_create_data_source() ChemblAdapter
+        -_create_storage() StorageAdapter
+        -_create_lock() LockPort
+        -_create_checkpoint() CheckpointPort
+        -_create_quarantine() QuarantinePort
+        -_create_metrics() MetricsPort
+    }
+
+    class SignalHandlers {
+        <<module>>
+        +setup_shutdown_handlers(signal: ShutdownSignal)
+    }
+
+    class PrefectTasks {
+        <<module>>
+        +execute_pipeline_task(pipeline_name, run_type)
+        +load_checkpoint_task(pipeline_name) Watermark
+        +run_pipeline_flow() Flow
+    }
+
+    CLI --> PipelineRunner : invokes
+    PipelineRunner --> ChEMBLActivityPipelineFactory : uses
+    PipelineRunner --> SignalHandlers : configures
+    PrefectTasks --> PipelineRunner : uses
+
+    note for CLI "Entry point: bioetl CLI"
+    note for ChEMBLActivityPipelineFactory "Composition root"

--- a/src/bioetl/application/README.md
+++ b/src/bioetl/application/README.md
@@ -1,0 +1,58 @@
+# Application Layer
+
+Business logic and pipeline orchestration.
+
+## Purpose
+
+Coordinates domain logic and infrastructure adapters. Contains pipeline execution flow, managers for cross-cutting concerns.
+
+## Modules
+
+| Module | Type | Diagram |
+|--------|------|---------|
+| `core/base.py` | service | [base.mmd](../../../docs/diagrams/application/core/base.mmd) |
+| `core/orchestrator.py` | service | [orchestrator.mmd](../../../docs/diagrams/application/core/orchestrator.mmd) |
+| `core/executor.py` | service | [executor.mmd](../../../docs/diagrams/application/core/executor.mmd) |
+| `core/record_processor.py` | service | [record_processor.mmd](../../../docs/diagrams/application/core/record_processor.mmd) |
+| `core/lock_manager.py` | service | [lock_manager.mmd](../../../docs/diagrams/application/core/lock_manager.mmd) |
+| `core/checkpoint_manager.py` | service | [managers.mmd](../../../docs/diagrams/application/core/managers.mmd) |
+| `core/quarantine_manager.py` | service | [managers.mmd](../../../docs/diagrams/application/core/managers.mmd) |
+| `core/shutdown.py` | util | [shutdown.mmd](../../../docs/diagrams/application/core/shutdown.mmd) |
+| `core/pipeline_config.py` | config | - |
+| `core/pipeline_services.py` | dto | - |
+| `pipelines/chembl_activity.py` | pipeline | [chembl_activity.mmd](../../../docs/diagrams/application/pipelines/chembl_activity.mmd) |
+
+## Dependencies
+
+- Uses: `domain` (ports, types, exceptions)
+- Used by: `interfaces`
+
+## Key Components
+
+### BasePipeline (Abstract)
+Base class for all ETL pipelines. Constructor accepts 3 parameters per ADR-0005:
+- `config: PipelineConfig` - Static configuration
+- `runtime: PipelineRuntimeConfig` - Runtime parameters
+- `services: PipelineServices` - Injected dependencies
+
+### PipelineOrchestrator
+Manages pipeline lifecycle:
+1. Setup signal handlers
+2. Acquire distributed lock
+3. Load checkpoint
+4. Execute batches
+5. Save checkpoint
+6. Release lock
+
+### PipelineExecutor
+Executes data flow:
+1. Fetch from DataSource
+2. Write Bronze
+3. Transform → Silver
+4. Filter → Gold
+5. Handle errors → Quarantine
+
+### Managers
+- `CheckpointManager` - Watermark persistence
+- `LockManager` - Distributed lock with heartbeat
+- `QuarantineManager` - Failed records handling

--- a/src/bioetl/domain/README.md
+++ b/src/bioetl/domain/README.md
@@ -1,0 +1,53 @@
+# Domain Layer
+
+Pure business logic without I/O operations.
+
+## Purpose
+
+Contains core business types, ports (interfaces), and pure transformations. No external dependencies except standard library.
+
+## Modules
+
+| Module | Type | Diagram |
+|--------|------|---------|
+| `ports.py` | port | [ports.mmd](../../../docs/diagrams/domain/ports.mmd) |
+| `types.py` | value_object | [types.mmd](../../../docs/diagrams/domain/types.mmd) |
+| `transformations.py` | util | [transformations.mmd](../../../docs/diagrams/domain/transformations.mmd) |
+| `exceptions.py` | exception | [exceptions.mmd](../../../docs/diagrams/domain/exceptions.mmd) |
+| `error_classifier.py` | util | [error_classifier.mmd](../../../docs/diagrams/domain/error_classifier.mmd) |
+| `context.py` | value_object | [context.mmd](../../../docs/diagrams/domain/context.mmd) |
+
+## Dependencies
+
+- Uses: Standard library only (typing, datetime, enum, uuid, hashlib)
+- Used by: `application`, `infrastructure`
+
+## Key Concepts
+
+### Ports (Protocol)
+Abstract interfaces for external systems:
+- `DataSourcePort` - Data sources (ChEMBL, PubChem, UniProt)
+- `StoragePort` - Medallion storage (Bronze/Silver/Gold)
+- `LockPort` - Distributed locking
+- `CheckpointPort` - Pipeline state persistence
+- `QuarantinePort` - Failed records isolation
+- `MetricsPort` - Observability metrics
+
+### Types
+Domain value objects:
+- `RunID`, `EntityID`, `BatchID`, `ContentHash` - Identifiers
+- `RunType`, `DriftLevel`, `HealthStatus`, `ErrorType` - Enums
+
+### Exception Hierarchy
+```
+BioETLError
+├── CriticalError (stop pipeline)
+│   ├── LockLostError
+│   └── AuthError
+├── RecoverableError (retry)
+│   ├── RateLimitError
+│   └── TimeoutError
+└── DataQualityError (skip record)
+    ├── SchemaViolationError
+    └── MissingRequiredFieldError
+```

--- a/src/bioetl/infrastructure/README.md
+++ b/src/bioetl/infrastructure/README.md
@@ -1,0 +1,90 @@
+# Infrastructure Layer
+
+Concrete implementations of domain ports.
+
+## Purpose
+
+Implements adapters for external systems: APIs, storage, locking, observability.
+
+## Modules
+
+### HTTP Adapters
+
+| Module | Type | Diagram |
+|--------|------|---------|
+| `adapters/http/client.py` | adapter | [client.mmd](../../../docs/diagrams/infrastructure/adapters/http/client.mmd) |
+| `adapters/http/circuit_breaker.py` | adapter | [circuit_breaker.mmd](../../../docs/diagrams/infrastructure/adapters/http/circuit_breaker.mmd) |
+| `adapters/http/rate_limiter.py` | adapter | [rate_limiter.mmd](../../../docs/diagrams/infrastructure/adapters/http/rate_limiter.mmd) |
+| `adapters/http/pagination.py` | adapter | - |
+
+### Data Source Adapters
+
+| Module | Type | Diagram |
+|--------|------|---------|
+| `adapters/chembl/client.py` | adapter | [chembl/client.mmd](../../../docs/diagrams/infrastructure/adapters/chembl/client.mmd) |
+| `adapters/pubchem/client.py` | adapter | [pubchem/client.mmd](../../../docs/diagrams/infrastructure/adapters/pubchem/client.mmd) |
+| `adapters/uniprot/client.py` | adapter | [uniprot/client.mmd](../../../docs/diagrams/infrastructure/adapters/uniprot/client.mmd) |
+
+### Storage
+
+| Module | Type | Diagram |
+|--------|------|---------|
+| `storage/bronze_writer.py` | adapter | [medallion.mmd](../../../docs/diagrams/infrastructure/storage/medallion.mmd) |
+| `storage/delta_writer.py` | adapter | [medallion.mmd](../../../docs/diagrams/infrastructure/storage/medallion.mmd) |
+| `storage/gold_writer.py` | adapter | [medallion.mmd](../../../docs/diagrams/infrastructure/storage/medallion.mmd) |
+| `storage/s3_pool.py` | util | - |
+
+### Locking
+
+| Module | Type | Diagram |
+|--------|------|---------|
+| `locking/memory_lock.py` | adapter | [distributed_lock.mmd](../../../docs/diagrams/infrastructure/locking/distributed_lock.mmd) |
+| `locking/redis_lock.py` | adapter | [distributed_lock.mmd](../../../docs/diagrams/infrastructure/locking/distributed_lock.mmd) |
+
+### Checkpoint & Quarantine
+
+| Module | Type | Diagram |
+|--------|------|---------|
+| `checkpoint/s3_checkpoint.py` | adapter | [s3_checkpoint.mmd](../../../docs/diagrams/infrastructure/checkpoint/s3_checkpoint.mmd) |
+| `quarantine/unified_quarantine.py` | adapter | [unified_quarantine.mmd](../../../docs/diagrams/infrastructure/quarantine/unified_quarantine.mmd) |
+
+### Observability
+
+| Module | Type | Diagram |
+|--------|------|---------|
+| `observability/metrics.py` | adapter | [overview.mmd](../../../docs/diagrams/infrastructure/observability/overview.mmd) |
+| `observability/prometheus_metrics.py` | adapter | [overview.mmd](../../../docs/diagrams/infrastructure/observability/overview.mmd) |
+| `observability/noop_metrics.py` | adapter | [overview.mmd](../../../docs/diagrams/infrastructure/observability/overview.mmd) |
+| `observability/lineage.py` | adapter | [overview.mmd](../../../docs/diagrams/infrastructure/observability/overview.mmd) |
+| `observability/anomaly.py` | adapter | [overview.mmd](../../../docs/diagrams/infrastructure/observability/overview.mmd) |
+| `observability/logging.py` | adapter | - |
+
+### Factories & Config
+
+| Module | Type | Diagram |
+|--------|------|---------|
+| `config.py` | config | - |
+| `factories/storage.py` | factory | - |
+| `factories/clients.py` | factory | - |
+
+## Dependencies
+
+- Uses: `domain` (ports, types, exceptions)
+- Used by: `interfaces`
+
+## Key Implementations
+
+### Storage Adapters
+- `BronzeWriter` - JSONL + zstd compression on S3
+- `DeltaWriter` - Delta Lake merge/upsert for Silver
+- `GoldWriter` - Pandera-validated Delta/Parquet for Gold
+
+### Locking
+- `MemoryLock` - For local development
+- `RedisDistributedLock` - Production with Lua scripts
+
+### HTTP Client
+`UnifiedHTTPClient` combines:
+- Rate limiting (TokenBucket)
+- Circuit breaker (CLOSED→OPEN→HALF_OPEN)
+- Retry with exponential backoff

--- a/src/bioetl/interfaces/README.md
+++ b/src/bioetl/interfaces/README.md
@@ -1,0 +1,52 @@
+# Interfaces Layer
+
+Entry points and composition root.
+
+## Purpose
+
+Driving adapters that invoke the application layer. Contains CLI, Prefect integration, and factories (composition root).
+
+## Modules
+
+| Module | Type | Diagram |
+|--------|------|---------|
+| `cli.py` | handler | [overview.mmd](../../../docs/diagrams/interfaces/overview.mmd) |
+| `bootstrap.py` | factory | [bootstrap.mmd](../../../docs/diagrams/interfaces/bootstrap.mmd) |
+| `factories/chembl_activity.py` | factory | [overview.mmd](../../../docs/diagrams/interfaces/overview.mmd) |
+| `orchestration/runner.py` | handler | [overview.mmd](../../../docs/diagrams/interfaces/overview.mmd) |
+| `orchestration/signals.py` | handler | - |
+| `orchestration/prefect/tasks.py` | handler | - |
+
+## Dependencies
+
+- Uses: `application`, `infrastructure`, `domain`
+- Used by: External (CLI, Prefect)
+
+## Key Components
+
+### CLI (Click)
+Entry point for pipeline execution:
+```bash
+bioetl run --pipeline chembl_activity --run-type incremental --resume
+bioetl quarantine inspect --pipeline chembl_activity --limit 10
+bioetl checkpoint list
+```
+
+### Bootstrap / Composition Root
+`bootstrap_pipeline()` assembles all dependencies:
+1. Create logger (structlog)
+2. Get pipeline factory
+3. Create PipelineServices with all adapters
+4. Instantiate concrete pipeline
+
+### Pipeline Factories
+Create fully configured pipelines with dependency injection:
+- `ChEMBLActivityPipelineFactory` - ChEMBL activity data
+
+### Prefect Integration
+Tasks for workflow orchestration:
+- `execute_pipeline_task()` - Run single pipeline
+- `run_pipeline_flow()` - Complete flow with checkpointing
+
+### Signal Handlers
+`setup_shutdown_handlers()` catches SIGTERM/SIGINT for graceful shutdown.


### PR DESCRIPTION
- Add FILE_REGISTRY.md with complete module inventory (48 files)
- Add ARCHITECTURE.md with layer overview and dependency graph
- Create 27 Mermaid diagrams for all major modules:
  - Domain: ports, types, exceptions, transformations, context, error_classifier
  - Application: base, orchestrator, executor, record_processor, lock_manager, managers, shutdown, chembl_activity
  - Infrastructure: HTTP client, circuit breaker, rate limiter, data source adapters, storage, locking, checkpoint, quarantine, observability
  - Interfaces: overview, bootstrap
- Add README.md for each package (domain, application, infrastructure, interfaces)
- Add VALIDATION_REPORT.md with coverage metrics

Documentation follows project diagramming policy in docs/02-architecture/diagrams/00-diagramming-policy.md