### PR TITLE
Fix failing test in bioactivity data acquisition

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,37 @@
+# Docker Compose file for integration tests.
+# Contains only the minimal services required for testing (minio, redis).
+# This avoids issues with directory sharing for services like Grafana.
+
+services:
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio_data:/data
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+
+volumes:
+  minio_data:
+  redis_data:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,8 +229,13 @@ def docker_ip():
 
 @pytest.fixture(scope="session")
 def docker_compose_file(project_root: Path) -> str:
-    """Path to docker-compose.yml for pytest-docker."""
-    return str(project_root / "docker-compose.yml")
+    """Path to docker-compose.test.yml for pytest-docker.
+
+    Uses a separate compose file with only the minimal services (minio, redis)
+    required for testing. This avoids issues with directory sharing for
+    services like Grafana that mount local directories.
+    """
+    return str(project_root / "docker-compose.test.yml")
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Add docker-compose.test.yml with only minio and redis services needed for testing, avoiding Grafana's local directory mount that fails on Windows when directory sharing is declined.

Update conftest.py to use the test-specific compose file.