### PR TITLE
Honor dq thresholds from pipeline configuration

### DIFF
--- a/src/bioetl/application/core/record_processor.py
+++ b/src/bioetl/application/core/record_processor.py
@@ -98,10 +98,20 @@ class RecordProcessor:
         # Check DQ thresholds
         if self._dq_config and records:
             error_rate = records_quarantined / len(records)
-            if self._dq_config.get("hard_fail_threshold") and error_rate >= self._dq_config["hard_fail_threshold"]:
-                 raise RuntimeError(f"DQ Hard Threshold exceeded: {error_rate:.2%} errors")
-            if self._dq_config.get("soft_fail_threshold") and error_rate >= self._dq_config["soft_fail_threshold"]:
-                 self._context.logger.warning("DQ Soft Threshold exceeded", error_rate=error_rate)
+            if (
+                self._dq_config.get("hard_fail_threshold")
+                and error_rate >= self._dq_config["hard_fail_threshold"]
+            ):
+                raise RuntimeError(
+                    f"DQ Hard Threshold exceeded: {error_rate:.2%} errors"
+                )
+            if (
+                self._dq_config.get("soft_fail_threshold")
+                and error_rate >= self._dq_config["soft_fail_threshold"]
+            ):
+                self._context.logger.warning(
+                    "DQ Soft Threshold exceeded", error_rate=error_rate
+                )
 
         if self._metrics:
             pipeline_label = f"{self._provider}_{self._entity_type}"

--- a/src/bioetl/domain/pipeline_config.py
+++ b/src/bioetl/domain/pipeline_config.py
@@ -6,6 +6,28 @@ from typing import List
 
 
 @dataclass(frozen=True)
+class DQRulesConfig:
+    """Пороговые значения правил DQ."""
+
+    soft_fail_threshold: float = 0.05
+    hard_fail_threshold: float = 0.20
+
+    def __post_init__(self) -> None:
+        if not 0 <= self.soft_fail_threshold < 1:
+            raise ValueError(
+                "soft_fail_threshold must be between 0 and 1 (exclusive of 1)"
+            )
+        if not 0 <= self.hard_fail_threshold <= 1:
+            raise ValueError(
+                "hard_fail_threshold must be between 0 and 1"
+            )
+        if self.soft_fail_threshold >= self.hard_fail_threshold:
+            raise ValueError(
+                "soft_fail_threshold must be strictly less than hard_fail_threshold"
+            )
+
+
+@dataclass(frozen=True)
 class PipelineConfig:
     """Immutable pipeline configuration.
 
@@ -22,6 +44,7 @@ class PipelineConfig:
     batch_size: int = 100
     checkpoint_interval: int = 1000
     fields: List[str] = field(default_factory=list)
+    dq_rules: DQRulesConfig = field(default_factory=DQRulesConfig)
 
     def __post_init__(self) -> None:
         """Validate configuration on creation."""

--- a/src/bioetl/infrastructure/config.py
+++ b/src/bioetl/infrastructure/config.py
@@ -25,7 +25,7 @@ from pydantic_settings import (
     SettingsConfigDict,
 )
 
-from bioetl.domain.pipeline_config import PipelineConfig
+from bioetl.domain.pipeline_config import DQRulesConfig, PipelineConfig
 from bioetl.infrastructure.schemas.pipeline_config import PipelineYamlConfig
 
 
@@ -155,6 +155,10 @@ def get_pipeline_config(pipeline_name: str) -> PipelineConfig:
         batch_size=pipeline_yaml_config.batch_size,
         checkpoint_interval=pipeline_yaml_config.checkpoint_interval,
         fields=source_fields,
+        dq_rules=DQRulesConfig(
+            soft_fail_threshold=pipeline_yaml_config.dq_rules.soft_fail_threshold,
+            hard_fail_threshold=pipeline_yaml_config.dq_rules.hard_fail_threshold,
+        ),
     )
 
 

--- a/src/bioetl/infrastructure/schemas/pipeline_config.py
+++ b/src/bioetl/infrastructure/schemas/pipeline_config.py
@@ -5,7 +5,7 @@ Enforces Medallion Architecture constraints and operational limits.
 """
 
 from typing import Any, Literal
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class DQConfig(BaseModel):
@@ -45,6 +45,8 @@ class PipelineYamlConfig(BaseModel):
     Enforces rules from RULES.md.
     """
 
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
     pipeline_name: str
     provider: str
     entity_type: str
@@ -55,7 +57,11 @@ class PipelineYamlConfig(BaseModel):
     checkpoint_interval: int = Field(default=1000, ge=100)
 
     # DQ & Reliability
-    dq: DQConfig = Field(default_factory=DQConfig)
+    dq_rules: DQConfig = Field(
+        default_factory=DQConfig,
+        validation_alias=AliasChoices("dq_rules", "dq"),
+        serialization_alias="dq_rules",
+    )
     circuit_breaker: CircuitBreakerConfig = Field(default_factory=CircuitBreakerConfig)
 
     # Storage

--- a/src/bioetl/interfaces/bootstrap.py
+++ b/src/bioetl/interfaces/bootstrap.py
@@ -169,8 +169,8 @@ def bootstrap_pipeline(
     dq_config = {
         "silver_table": pipeline.config.silver_table,
         "gold_table": pipeline.config.gold_table,
-        "soft_fail_threshold": 0.05,
-        "hard_fail_threshold": 0.20,
+        "soft_fail_threshold": pipeline.config.dq_rules.soft_fail_threshold,
+        "hard_fail_threshold": pipeline.config.dq_rules.hard_fail_threshold,
     }
 
     executor = PipelineExecutor(

--- a/tests/unit/application/core/test_record_processor.py
+++ b/tests/unit/application/core/test_record_processor.py
@@ -1,5 +1,6 @@
 """Unit tests for RecordProcessor."""
 
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -11,6 +12,39 @@ from bioetl.domain.context import PipelineContext
 from bioetl.domain.error_classifier import ErrorClassifier
 from bioetl.domain.exceptions import DataQualityError
 from bioetl.domain.types import BatchID, RunID, RunType
+from bioetl.infrastructure.config import get_pipeline_config
+
+
+def _write_temp_pipeline_config(
+    base_path: Path, pipeline_name: str, soft_threshold: float, hard_threshold: float
+) -> Path:
+    """Создаёт временную YAML-конфигурацию пайплайна с кастомными DQ-порогами."""
+
+    provider, entity = pipeline_name.split("_", 1)
+    config_dir = base_path / "configs" / "pipelines" / provider
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_path = config_dir / f"{entity}.yaml"
+
+    config_path.write_text(
+        "\n".join(
+            [
+                f"pipeline_name: {pipeline_name}",
+                f"provider: {provider}",
+                f"entity_type: {entity}",
+                "primary_keys: ['id']",
+                "silver_table: 'tmp_silver'",
+                "batch_size: 10",
+                "checkpoint_interval: 100",
+                "sink: {}",
+                "dq_rules:",
+                f"  soft_fail_threshold: {soft_threshold}",
+                f"  hard_fail_threshold: {hard_threshold}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    return config_path
 
 
 @pytest.fixture
@@ -220,3 +254,114 @@ class TestRecordProcessorProcessBatch:
         assert gold == 0
         mock_storage.write_silver.assert_not_called()
         mock_storage.write_gold.assert_not_called()
+
+    async def test_dq_thresholds_follow_yaml_hard_fail(
+        self,
+        tmp_path,
+        monkeypatch,
+        mock_storage,
+        mock_quarantine_manager,
+        mock_error_classifier,
+        mock_context,
+    ):
+        """DQ hard threshold берётся из YAML и вызывает ошибку при превышении."""
+
+        pipeline_name = "tmp_pipeline"
+        _write_temp_pipeline_config(tmp_path, pipeline_name, 0.1, 0.4)
+        monkeypatch.chdir(tmp_path)
+        get_pipeline_config.cache_clear()
+
+        config = get_pipeline_config(pipeline_name)
+        dq_config = {
+            "silver_table": config.silver_table,
+            "gold_table": config.gold_table,
+            "soft_fail_threshold": config.dq_rules.soft_fail_threshold,
+            "hard_fail_threshold": config.dq_rules.hard_fail_threshold,
+        }
+
+        async def transform(ctx, record):
+            if record.get("id") == "bad":
+                raise DataQualityError("invalid")
+            return {"entity_id": record.get("id"), "value": record.get("value")}
+
+        processor = RecordProcessor(
+            storage=mock_storage,
+            quarantine_manager=mock_quarantine_manager,
+            error_classifier=mock_error_classifier,
+            context=mock_context,
+            provider="test",
+            entity_type="test",
+            transform_callback=transform,
+            gold_filter_callback=lambda c, r: True,
+            silver_schema=MagicMock(),
+            dq_config=dq_config,
+        )
+
+        records = [
+            {"id": "good", "value": 1},
+            {"id": "bad", "value": 2},
+        ]
+
+        with pytest.raises(RuntimeError):
+            await processor.process_batch(records, BatchID(uuid4()))
+
+        get_pipeline_config.cache_clear()
+
+    async def test_dq_thresholds_follow_yaml_soft_threshold_prevents_warning(
+        self,
+        tmp_path,
+        monkeypatch,
+        mock_storage,
+        mock_quarantine_manager,
+        mock_error_classifier,
+        mock_context,
+    ):
+        """Высокий soft-порог из YAML отключает предупреждения при низкой доле ошибок."""
+
+        pipeline_name = "tmp_pipeline_alt"
+        _write_temp_pipeline_config(tmp_path, pipeline_name, 0.8, 0.95)
+        monkeypatch.chdir(tmp_path)
+        get_pipeline_config.cache_clear()
+
+        config = get_pipeline_config(pipeline_name)
+        dq_config = {
+            "silver_table": config.silver_table,
+            "gold_table": config.gold_table,
+            "soft_fail_threshold": config.dq_rules.soft_fail_threshold,
+            "hard_fail_threshold": config.dq_rules.hard_fail_threshold,
+        }
+
+        async def transform(ctx, record):
+            if record.get("id") == "bad":
+                raise DataQualityError("invalid")
+            return {"entity_id": record.get("id"), "value": record.get("value")}
+
+        processor = RecordProcessor(
+            storage=mock_storage,
+            quarantine_manager=mock_quarantine_manager,
+            error_classifier=mock_error_classifier,
+            context=mock_context,
+            provider="test",
+            entity_type="test",
+            transform_callback=transform,
+            gold_filter_callback=lambda c, r: True,
+            silver_schema=MagicMock(),
+            dq_config=dq_config,
+        )
+
+        records = [
+            {"id": "good", "value": 1},
+            {"id": "bad", "value": 2},
+        ]
+
+        bronze, silver, gold, quarantined = await processor.process_batch(
+            records, BatchID(uuid4())
+        )
+
+        assert bronze == 2
+        assert silver == 1
+        assert gold == 1
+        assert quarantined == 1
+        mock_context.logger.warning.assert_not_called()
+
+        get_pipeline_config.cache_clear()


### PR DESCRIPTION
## Summary
- add dq_rules thresholds to pipeline/domain configs and validate them
- propagate dq thresholds from pipeline YAML into bootstrap executor configuration
- add record processor tests confirming YAML-driven DQ thresholds influence runtime behavior

## Testing
- pytest tests/unit/application/core/test_record_processor.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943d8dc78d883249feb356ce09e35ac)