### PR TITLE
fix: stabilize ChEMBL activity watermark extraction

### DIFF
--- a/configs/sources/chembl.yaml
+++ b/configs/sources/chembl.yaml
@@ -4,7 +4,7 @@
 source:
     type: api
     load_strategy: incremental
-    watermark_field: molecule_chembl_id
+    watermark_field: updated_on
     batch_size: 20
     provider_config:
         provider: chembl

--- a/src/bioetl/application/pipelines/chembl_activity.py
+++ b/src/bioetl/application/pipelines/chembl_activity.py
@@ -9,7 +9,7 @@ Provider: ChEMBL (https://www.ebi.ac.uk/chembl/)
 
 from __future__ import annotations
 
-from datetime import UTC
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from bioetl.application.core.base import BasePipeline
@@ -118,6 +118,21 @@ class ChEMBLActivityPipeline(BasePipeline):
         activity_id = record.get("activity_id")
         if activity_id:
             return str(activity_id)
-        from datetime import datetime
+        fallback_field = self.config.watermark_field
+        fallback_value = record.get(fallback_field) if fallback_field else None
+        if fallback_value is None:
+            return ""
 
-        return datetime.now(UTC)
+        if isinstance(fallback_value, datetime):
+            return fallback_value.replace(tzinfo=fallback_value.tzinfo or UTC)
+
+        if isinstance(fallback_value, str):
+            try:
+                parsed = datetime.fromisoformat(fallback_value)
+            except ValueError:
+                return fallback_value
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=UTC)
+            return parsed
+
+        return fallback_value

--- a/src/bioetl/domain/pipeline_config.py
+++ b/src/bioetl/domain/pipeline_config.py
@@ -24,6 +24,7 @@ class PipelineConfig:
     batch_size: int = 100
     checkpoint_interval: int = 1000
     fields: List[str] = field(default_factory=list)
+    watermark_field: str | None = None
     dq: DQConfig = field(default_factory=DQConfig)
 
     def __post_init__(self) -> None:

--- a/src/bioetl/infrastructure/config.py
+++ b/src/bioetl/infrastructure/config.py
@@ -145,6 +145,7 @@ def yaml_config_to_domain(yaml_config: PipelineYamlConfig) -> PipelineConfig:
         field["name"]
         for field in yaml_config.source.get("fields", [])
     ]
+    watermark_field = yaml_config.source.get("watermark_field")
 
     return PipelineConfig(
         pipeline_name=yaml_config.pipeline_name,
@@ -156,6 +157,7 @@ def yaml_config_to_domain(yaml_config: PipelineYamlConfig) -> PipelineConfig:
         batch_size=yaml_config.batch_size,
         checkpoint_interval=yaml_config.checkpoint_interval,
         fields=source_fields,
+        watermark_field=watermark_field,
         dq=DomainDQConfig(
             soft_fail_threshold=yaml_config.dq_rules.soft_fail_threshold,
             hard_fail_threshold=yaml_config.dq_rules.hard_fail_threshold,

--- a/tests/unit/pipelines/test_chembl_activity.py
+++ b/tests/unit/pipelines/test_chembl_activity.py
@@ -1,0 +1,126 @@
+"""Unit tests for ChEMBL activity pipeline watermark extraction."""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from bioetl.application.core.pipeline_config import PipelineRuntimeConfig
+from bioetl.application.core.pipeline_services import PipelineServices
+from bioetl.application.pipelines.chembl_activity import ChEMBLActivityPipeline
+from bioetl.application.core.checkpoint_manager import CheckpointManager
+from bioetl.domain.context import PipelineContext
+from bioetl.domain.pipeline_config import PipelineConfig
+from bioetl.domain.types import RunID, RunType
+
+
+@pytest.fixture
+def chembl_pipeline() -> ChEMBLActivityPipeline:
+    """Создает пайплайн ChEMBL с детерминированным watermark."""
+
+    config = PipelineConfig(
+        pipeline_name="chembl_activity",
+        provider="chembl",
+        entity_type="activity",
+        primary_keys=["activity_id"],
+        silver_table="chembl_activity",
+        batch_size=10,
+        checkpoint_interval=5,
+        watermark_field="updated_on",
+    )
+
+    runtime = PipelineRuntimeConfig(run_type=RunType.INCREMENTAL)
+
+    logger = MagicMock()
+    logger.bind.return_value = MagicMock()
+
+    services = PipelineServices(
+        data_source=AsyncMock(),
+        storage=AsyncMock(),
+        lock=AsyncMock(),
+        checkpoint=AsyncMock(),
+        quarantine=AsyncMock(),
+        metrics=MagicMock(),
+        logger=logger,
+    )
+
+    return ChEMBLActivityPipeline(config=config, runtime=runtime, services=services)
+
+
+@pytest.fixture
+def context(chembl_pipeline: ChEMBLActivityPipeline) -> PipelineContext:
+    """Возвращает PipelineContext с тестовым run_id."""
+
+    return PipelineContext(
+        run_id=RunID(uuid4()),
+        run_type=RunType.INCREMENTAL,
+        logger=chembl_pipeline.logger,
+    )
+
+
+def test_extract_watermark_with_activity_id(
+    chembl_pipeline: ChEMBLActivityPipeline, context: PipelineContext
+) -> None:
+    """Возвращает activity_id как строку."""
+
+    record = {"activity_id": 123, "updated_on": "2024-01-01T00:00:00+00:00"}
+
+    watermark = chembl_pipeline.extract_watermark(context, record)
+
+    assert watermark == "123"
+
+
+def test_extract_watermark_with_fallback_field(
+    chembl_pipeline: ChEMBLActivityPipeline, context: PipelineContext
+) -> None:
+    """Парсит updated_on из конфигурации в datetime UTC."""
+
+    record = {"updated_on": "2024-02-02T10:00:00"}
+
+    watermark = chembl_pipeline.extract_watermark(context, record)
+
+    assert isinstance(watermark, datetime)
+    assert watermark.tzinfo is UTC
+    assert watermark == datetime(2024, 2, 2, 10, 0, tzinfo=UTC)
+
+
+def test_extract_watermark_without_cursor_fields(
+    chembl_pipeline: ChEMBLActivityPipeline, context: PipelineContext
+) -> None:
+    """Возвращает пустую строку без доступных курсоров."""
+
+    watermark = chembl_pipeline.extract_watermark(context, {})
+
+    assert watermark == ""
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_watermark_idempotent(
+    chembl_pipeline: ChEMBLActivityPipeline, context: PipelineContext
+) -> None:
+    """CheckpointManager сохраняет одинаковый watermark для одинаковых записей."""
+
+    checkpoint_port = AsyncMock()
+    checkpoint_port.load = AsyncMock(return_value=None)
+
+    manager = CheckpointManager(
+        checkpoint_port=checkpoint_port,
+        logger=chembl_pipeline.logger,
+        pipeline_name=chembl_pipeline.pipeline_name,
+        run_id=chembl_pipeline.run_id,
+        resume=True,
+        watermark_extractor=lambda record: chembl_pipeline.extract_watermark(
+            context, record
+        ),
+    )
+
+    record = {"updated_on": "2024-03-03T12:30:00+00:00"}
+
+    await manager.save_checkpoint(last_record=record, records_processed=1)
+    await manager.save_checkpoint(last_record=record, records_processed=2)
+
+    first_watermark = checkpoint_port.save.call_args_list[0].kwargs["watermark"]
+    second_watermark = checkpoint_port.save.call_args_list[1].kwargs["watermark"]
+
+    assert first_watermark == second_watermark


### PR DESCRIPTION
## Summary
- add configurable watermark cursor support to ChEMBL activity pipeline and parse fallback timestamps deterministically
- propagate `watermark_field` from source configuration and set ChEMBL source to use `updated_on`
- cover watermark extraction and checkpoint idempotency with new unit tests

## Testing
- pytest tests/unit/pipelines/test_chembl_activity.py tests/unit/application/test_pipeline_config.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69440282b7fc8324ba6a2e9716eabf20)