### PR TITLE
Validate shared DQ threshold invariants

### DIFF
--- a/src/bioetl/domain/config.py
+++ b/src/bioetl/domain/config.py
@@ -13,6 +13,31 @@ class DQConfig:
     soft_fail_threshold: float = 0.05
     hard_fail_threshold: float = 0.20
 
+    def __post_init__(self) -> None:
+        """Validate threshold invariants on creation."""
+        self.validate_thresholds(
+            soft_fail_threshold=self.soft_fail_threshold,
+            hard_fail_threshold=self.hard_fail_threshold,
+        )
+
+    @staticmethod
+    def validate_thresholds(
+        *, soft_fail_threshold: float, hard_fail_threshold: float
+    ) -> None:
+        """Validate ordering and bounds for DQ thresholds."""
+        if not 0.0 <= soft_fail_threshold <= 1.0:
+            raise ValueError(
+                "soft_fail_threshold must be between 0.0 and 1.0 inclusive"
+            )
+        if not 0.0 <= hard_fail_threshold <= 1.0:
+            raise ValueError(
+                "hard_fail_threshold must be between 0.0 and 1.0 inclusive"
+            )
+        if soft_fail_threshold >= hard_fail_threshold:
+            raise ValueError(
+                "soft_fail_threshold must be strictly less than hard_fail_threshold"
+            )
+
 
 @dataclass(frozen=True)
 class TableConfig:

--- a/src/bioetl/infrastructure/schemas/pipeline_config.py
+++ b/src/bioetl/infrastructure/schemas/pipeline_config.py
@@ -7,19 +7,21 @@ Enforces Medallion Architecture constraints and operational limits.
 from typing import Any, Literal
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from bioetl.domain.config import DQConfig as DomainDQConfig
+
 
 class DQConfig(BaseModel):
     """Data Quality configuration."""
 
-    soft_fail_threshold: float = Field(default=0.05, ge=0.0, le=1.0)
-    hard_fail_threshold: float = Field(default=0.20, ge=0.0, le=1.0)
+    soft_fail_threshold: float = Field(default=0.05)
+    hard_fail_threshold: float = Field(default=0.20)
 
     @model_validator(mode="after")
     def validate_thresholds(self) -> "DQConfig":
-        if self.soft_fail_threshold >= self.hard_fail_threshold:
-            raise ValueError(
-                "soft_fail_threshold must be strictly less than hard_fail_threshold"
-            )
+        DomainDQConfig.validate_thresholds(
+            soft_fail_threshold=self.soft_fail_threshold,
+            hard_fail_threshold=self.hard_fail_threshold,
+        )
         return self
 
 

--- a/tests/unit/domain/test_config_validation.py
+++ b/tests/unit/domain/test_config_validation.py
@@ -1,0 +1,26 @@
+import pytest
+
+from bioetl.domain.config import DQConfig
+from bioetl.domain.pipeline_config import PipelineConfig
+
+
+def test_dq_config_rejects_soft_over_hard() -> None:
+    with pytest.raises(ValueError, match="soft_fail_threshold must be strictly less"):
+        DQConfig(soft_fail_threshold=0.2, hard_fail_threshold=0.2)
+
+
+def test_dq_config_rejects_out_of_bounds() -> None:
+    with pytest.raises(ValueError, match="soft_fail_threshold must be between"):
+        DQConfig(soft_fail_threshold=-0.1, hard_fail_threshold=0.2)
+
+
+def test_pipeline_config_propagates_dq_validation() -> None:
+    with pytest.raises(ValueError, match="hard_fail_threshold must be between"):
+        PipelineConfig(
+            pipeline_name="test_pipeline",
+            provider="chembl",
+            entity_type="activity",
+            primary_keys=["id"],
+            silver_table="silver.table",
+            dq=DQConfig(soft_fail_threshold=0.05, hard_fail_threshold=1.5),
+        )

--- a/tests/unit/infrastructure/test_config_dynamic.py
+++ b/tests/unit/infrastructure/test_config_dynamic.py
@@ -95,3 +95,22 @@ def test_load_fallback_no_underscore(setup_configs):
     config = load_pipeline_config("simple")
     assert isinstance(config, PipelineYamlConfig)
     assert config.pipeline_name == "simple"
+
+
+def test_dq_thresholds_are_validated_once(setup_configs):
+    """DQ thresholds must satisfy domain invariants even in YAML schema."""
+    pipelines_dir = setup_configs
+
+    invalid_config = {
+        "pipeline_name": "dummy_invalid",
+        "provider": "dummy",
+        "entity_type": "invalid",
+        "primary_keys": ["id"],
+        "silver_table": "dummy.test_silver",
+        "dq_rules": {"soft_fail_threshold": 0.3, "hard_fail_threshold": 0.2},
+    }
+
+    (pipelines_dir / "dummy" / "invalid.yaml").write_text(yaml.dump(invalid_config))
+
+    with pytest.raises(ValueError, match="soft_fail_threshold must be strictly less"):
+        load_pipeline_config("dummy_invalid")


### PR DESCRIPTION
## Summary
- add domain-level validation for DQ thresholds and enforce invariants
- reuse domain validation inside pipeline YAML schema to keep single source of rules
- add unit tests to ensure invalid DQ configs are rejected in domain and YAML loading paths

## Testing
- pytest tests/unit/domain/test_config_validation.py tests/unit/infrastructure/test_config_dynamic.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944052dbb1c83249d9671aed83e67f4)