### PR TITLE
Refactor logger and metrics to use ports

### DIFF
--- a/docs/02-architecture/decisions/ADR-005-logger-metrics-ports.md
+++ b/docs/02-architecture/decisions/ADR-005-logger-metrics-ports.md
@@ -1,0 +1,140 @@
+# ADR-005: Ports for Logger and Metrics
+
+*   **Status**: Accepted
+*   **Date**: 2025-12-18
+*   **Context**: Logger and metrics dependencies were not consistently formalized as ports. The logger was typed as a concrete `structlog.BoundLogger` in `PipelineServices`, while metrics already had a proper `MetricsPort`. This inconsistency violated the Ports & Adapters architecture principle.
+
+## The Decision
+
+We have chosen to:
+
+1. **Create `LoggerPort`** in `domain/ports.py` as a formal Protocol for logging
+2. **Keep `MetricsPort`** as-is (already properly defined)
+3. **Use ports consistently** in `PipelineServices` for both logger and metrics
+4. **Maintain backward compatibility** via `BoundLogger` alias in `domain/context.py`
+
+## Justification
+
+### 1. Architectural Consistency
+
+All external dependencies should be abstracted through ports:
+
+| Dependency | Port | Location |
+|------------|------|----------|
+| Data Source | `DataSourcePort` | `domain/ports.py` |
+| Storage | `StoragePort` | `domain/ports.py` |
+| Lock | `LockPort` | `domain/ports.py` |
+| Checkpoint | `CheckpointPort` | `domain/ports.py` |
+| Quarantine | `QuarantinePort` | `domain/ports.py` |
+| Metrics | `MetricsPort` | `domain/ports.py` |
+| **Logger** | **`LoggerPort`** | `domain/ports.py` |
+
+### 2. Testability
+
+Using a port allows easy mocking in tests:
+
+```python
+# Before: tight coupling to structlog
+logger: "structlog.BoundLogger"
+
+# After: protocol-based abstraction
+logger: LoggerPort
+
+# Tests can use any implementation
+mock_logger = MagicMock(spec=LoggerPort)
+```
+
+### 3. Future Flexibility
+
+The abstraction allows switching logging implementations without changing application code:
+- structlog (current)
+- loguru
+- Standard library logging
+- Custom implementations
+
+### 4. Domain Layer Purity
+
+The domain layer should not depend on infrastructure details. By defining `LoggerPort` in `domain/ports.py`, we ensure the domain only depends on an abstract contract, not on `structlog`.
+
+## Implementation Details
+
+### LoggerPort Definition
+
+```python
+class LoggerPort(Protocol):
+    """Port for structured logging."""
+
+    def bind(self, **kwargs: Any) -> "LoggerPort": ...
+    def info(self, msg: str, **kwargs: Any) -> None: ...
+    def warning(self, msg: str, **kwargs: Any) -> None: ...
+    def error(self, msg: str, **kwargs: Any) -> None: ...
+    def debug(self, msg: str, **kwargs: Any) -> None: ...
+    def exception(self, msg: str, **kwargs: Any) -> None: ...
+```
+
+### Backward Compatibility
+
+To avoid breaking existing code, `BoundLogger` is preserved as an alias:
+
+```python
+# domain/context.py
+from bioetl.domain.ports import LoggerPort
+
+# Backward compatibility alias
+BoundLogger = LoggerPort
+```
+
+### PipelineServices Update
+
+```python
+@dataclass(frozen=True)
+class PipelineServices:
+    data_source: DataSourcePort
+    storage: StoragePort
+    lock: LockPort
+    checkpoint: CheckpointPort
+    quarantine: QuarantinePort
+    metrics: MetricsPort    # Already a port
+    logger: LoggerPort      # Now also a port (was structlog.BoundLogger)
+```
+
+## Alternatives Considered
+
+### 1. Keep structlog typing
+
+Rejected because:
+- Violates Ports & Adapters architecture
+- Creates tight coupling to infrastructure
+- Makes testing harder
+- Inconsistent with other dependencies
+
+### 2. Create separate LoggingPort with different interface
+
+Rejected because:
+- The structlog interface (`bind`, `info`, `error`, etc.) is already a good abstraction
+- No benefit in creating a different interface
+- Would require adapters for existing code
+
+### 3. Move LoggerPort to a separate file
+
+Rejected because:
+- All other ports are in `domain/ports.py`
+- Keeping them together improves discoverability
+- No circular dependency issues
+
+## Consequences
+
+### Positive
+- Consistent architecture across all dependencies
+- Improved testability
+- Future flexibility for logging implementations
+- Clean domain layer without infrastructure dependencies
+
+### Negative
+- Minor: Existing code using `BoundLogger` still works but should migrate to `LoggerPort`
+
+## Migration Path
+
+1. New code should use `LoggerPort` directly
+2. Existing code using `BoundLogger` continues to work
+3. Gradual migration as files are modified

--- a/src/bioetl/application/core/pipeline_services.py
+++ b/src/bioetl/application/core/pipeline_services.py
@@ -2,23 +2,23 @@
 
 Part of BasePipeline decomposition (ADR-0005).
 Separates I/O port dependencies from pipeline logic.
+
+Logger and Metrics are formalized as ports (ADR-005).
 """
 
 import asyncio
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Self
+from typing import Self
 
 from bioetl.domain.ports import (
     CheckpointPort,
     DataSourcePort,
     LockPort,
+    LoggerPort,
     MetricsPort,
     QuarantinePort,
     StoragePort,
 )
-
-if TYPE_CHECKING:
-    import structlog
 
 
 @dataclass(frozen=True)
@@ -58,7 +58,7 @@ class PipelineServices:
     checkpoint: CheckpointPort
     quarantine: QuarantinePort
     metrics: MetricsPort
-    logger: "structlog.BoundLogger"
+    logger: LoggerPort
 
     def __post_init__(self) -> None:
         """Validate that all services are provided."""

--- a/src/bioetl/domain/context.py
+++ b/src/bioetl/domain/context.py
@@ -1,40 +1,13 @@
 """Domain context objects."""
 
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import Any
 
+from bioetl.domain.ports import LoggerPort
 from bioetl.domain.types import RunID, RunType
 
-
-class BoundLogger(Protocol):
-    """Protocol for structured loggers with bind capability.
-
-    This allows the domain layer to work with structlog without importing it.
-    """
-
-    def bind(self, **kwargs: Any) -> "BoundLogger":
-        """Bind additional context to the logger."""
-        ...
-
-    def info(self, msg: str, **kwargs: Any) -> None:
-        """Log info message."""
-        ...
-
-    def warning(self, msg: str, **kwargs: Any) -> None:
-        """Log warning message."""
-        ...
-
-    def error(self, msg: str, **kwargs: Any) -> None:
-        """Log error message."""
-        ...
-
-    def debug(self, msg: str, **kwargs: Any) -> None:
-        """Log debug message."""
-        ...
-
-    def exception(self, msg: str, **kwargs: Any) -> None:
-        """Log exception with traceback."""
-        ...
+# Backward compatibility alias
+BoundLogger = LoggerPort
 
 
 @dataclass(frozen=True)
@@ -46,7 +19,7 @@ class PipelineContext:
 
     run_id: RunID
     run_type: RunType
-    logger: BoundLogger
+    logger: LoggerPort
 
     def bind_logger(self, **kwargs: Any) -> "PipelineContext":
         """Bind additional context to the logger.

--- a/src/bioetl/domain/ports.py
+++ b/src/bioetl/domain/ports.py
@@ -437,10 +437,50 @@ class OrchestrationPort(Protocol):
         ...
 
 
+class LoggerPort(Protocol):
+    """Port for structured logging.
+
+    This interface abstracts the logging mechanism, allowing the application
+    to log messages without depending on a specific logging library
+    (e.g., structlog, loguru, stdlib logging).
+
+    Note: LoggerPort uses synchronous methods as logging operations
+    should be fast and non-blocking by design.
+    """
+
+    def bind(self, **kwargs: Any) -> "LoggerPort":
+        """Bind additional context to the logger.
+
+        Returns a new logger instance with the bound context.
+        """
+        ...
+
+    def info(self, msg: str, **kwargs: Any) -> None:
+        """Log an informational message."""
+        ...
+
+    def warning(self, msg: str, **kwargs: Any) -> None:
+        """Log a warning message."""
+        ...
+
+    def error(self, msg: str, **kwargs: Any) -> None:
+        """Log an error message."""
+        ...
+
+    def debug(self, msg: str, **kwargs: Any) -> None:
+        """Log a debug message."""
+        ...
+
+    def exception(self, msg: str, **kwargs: Any) -> None:
+        """Log an exception with traceback."""
+        ...
+
+
 __all__ = [
     "CheckpointPort",
     "DataSourcePort",
     "LockPort",
+    "LoggerPort",
     "MetricsPort",
     "OrchestrationPort",
     "QuarantinePort",


### PR DESCRIPTION
Introduces LoggerPort protocol in domain/ports.py to abstract logging dependency, consistent with other ports (MetricsPort, StoragePort, etc.). Removes direct structlog.BoundLogger coupling from PipelineServices.

- Add LoggerPort Protocol with bind, info, warning, error, debug, exception
- Update PipelineServices to use LoggerPort instead of structlog.BoundLogger
- Update PipelineContext to use LoggerPort
- Keep BoundLogger as backward compatibility alias in context.py
- Document decision in ADR-005-logger-metrics-ports.md