### PR TITLE
Add run_id parameter to Bronze and Delta writers

### DIFF
--- a/src/bioetl/application/core/record_processor.py
+++ b/src/bioetl/application/core/record_processor.py
@@ -141,6 +141,8 @@ class RecordProcessor:
             entity=self._entity_type,
             date=ingestion_ts,
             batch_id=batch_id,
+            run_id=self._context.run_id,
+            run_type=self._context.run_type,
         )
 
     async def _write_silver_batch(

--- a/src/bioetl/domain/ports.py
+++ b/src/bioetl/domain/ports.py
@@ -14,6 +14,7 @@ from bioetl.domain.types import (
     BatchID,
     HealthStatus,
     RunID,
+    RunType,
     Watermark,
 )
 
@@ -95,6 +96,8 @@ class StoragePort(Protocol):
         entity: str,
         date: Any,
         batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
     ) -> None:
         """
         Write raw records to the Bronze layer.
@@ -105,6 +108,8 @@ class StoragePort(Protocol):
             entity: The type of entity being written.
             date: The date partition for the data.
             batch_id: The unique identifier for the batch of records.
+            run_id: The unique identifier for the pipeline run (for traceability).
+            run_type: The type of pipeline run (incremental, backfill, rebuild).
         """
         ...
 

--- a/src/bioetl/infrastructure/factories/storage.py
+++ b/src/bioetl/infrastructure/factories/storage.py
@@ -3,7 +3,7 @@
 from collections.abc import Iterator
 from typing import Any
 
-from bioetl.domain.types import BatchID
+from bioetl.domain.types import BatchID, RunID, RunType
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 from bioetl.infrastructure.storage.gold_writer import GoldWriter
@@ -35,6 +35,8 @@ class StorageAdapter:
         entity: str,
         date: Any,
         batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
     ) -> None:
         """Write raw records to Bronze layer."""
         await self.bronze.write_bronze(
@@ -43,6 +45,8 @@ class StorageAdapter:
             entity=entity,
             date=date,
             batch_id=batch_id,
+            run_id=run_id,
+            run_type=run_type,
         )
 
     async def write_silver(

--- a/src/bioetl/infrastructure/storage/bronze_writer.py
+++ b/src/bioetl/infrastructure/storage/bronze_writer.py
@@ -30,7 +30,7 @@ from botocore.exceptions import ClientError
 if TYPE_CHECKING:
     from structlog.stdlib import BoundLogger
 
-from bioetl.domain.types import BatchID
+from bioetl.domain.types import BatchID, RunID, RunType
 from bioetl.domain.exceptions import BucketNotFoundError, UploadError
 
 
@@ -93,10 +93,24 @@ class BronzeWriter:
         entity: str,
         date: datetime,
         batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
     ) -> Path:
         """Write raw records to Bronze layer (JSONL + zstd).
 
         If save_json is enabled, also writes uncompressed JSONL file.
+
+        Args:
+            records: Iterator of JSONL bytes to write.
+            provider: Data provider name (e.g., 'chembl').
+            entity: Entity type (e.g., 'activity').
+            date: Ingestion timestamp for date partitioning.
+            batch_id: Unique batch identifier.
+            run_id: Pipeline run ID for traceability.
+            run_type: Type of run (incremental, backfill, rebuild).
+
+        Returns:
+            Path to the written file (relative to bucket).
         """
         date_str = date.strftime("%Y-%m-%d")
         # Fixed path format: bronze/v1/{provider}/{entity}/{date}/...
@@ -129,6 +143,13 @@ class BronzeWriter:
             with open(full_path, "wb") as f:
                 f.write(compressed_data)
         else:
+            # Include run metadata in S3 object metadata for traceability
+            s3_metadata = {
+                "run_id": str(run_id),
+                "run_type": run_type.value,
+                "batch_id": str(batch_id),
+                "ingestion_ts": date.isoformat(),
+            }
             try:
                 await loop.run_in_executor(
                     None,
@@ -137,6 +158,7 @@ class BronzeWriter:
                         Key=relative_path,
                         Body=compressed_data,
                         ContentType="application/zstd",
+                        Metadata=s3_metadata,
                     ),
                 )
             except ClientError as e:
@@ -144,6 +166,17 @@ class BronzeWriter:
                 if error_code == "NoSuchBucket":
                     raise BucketNotFoundError(self.bucket) from e
                 raise UploadError(relative_path, str(e)) from e
+
+        # Log successful write with run_id for traceability
+        self.logger.info(
+            "bronze_write_complete",
+            path=relative_path,
+            provider=provider,
+            entity=entity,
+            batch_id=str(batch_id),
+            run_id=str(run_id),
+            run_type=run_type.value,
+        )
 
         # Optionally write uncompressed JSON
         if self.save_json:

--- a/tests/integration/memory_storage.py
+++ b/tests/integration/memory_storage.py
@@ -7,10 +7,16 @@ from bioetl.domain.ports import StoragePort
 class MemoryStorage(StoragePort):
     def __init__(self):
         self.data = defaultdict(list)
+        self.bronze_metadata = {}  # Store run metadata for verification
 
-    def write_bronze(self, records, provider, entity, date, batch_id):
+    def write_bronze(self, records, provider, entity, date, batch_id, run_id, run_type):
         key = f"bronze/{provider}/{entity}/{date}/{batch_id}.jsonl.zst"
         self.data[key].extend(records)
+        # Store metadata for test verification
+        self.bronze_metadata[key] = {
+            "run_id": str(run_id),
+            "run_type": run_type.value if hasattr(run_type, "value") else str(run_type),
+        }
 
     def write_silver(self, table_name, records, _primary_keys):
         self.data[table_name].extend(records)

--- a/tests/unit/application/core/test_record_processor.py
+++ b/tests/unit/application/core/test_record_processor.py
@@ -175,6 +175,30 @@ class TestRecordProcessorProcessBatch:
         mock_storage.write_silver.assert_called_once()
         mock_storage.write_gold.assert_called_once()
 
+    async def test_process_batch_propagates_run_id_to_all_layers(
+        self, record_processor, mock_storage, mock_context
+    ):
+        """Test that the same run_id is passed to Bronze and Silver writes.
+
+        This verifies the requirement: one run = one UUID everywhere.
+        """
+        records = [{"id": "1", "value": 10}]
+        batch_id = BatchID(uuid4())
+
+        await record_processor.process_batch(records, batch_id)
+
+        # Verify Bronze write received run_id and run_type from context
+        bronze_call_kwargs = mock_storage.write_bronze.call_args[1]
+        assert bronze_call_kwargs["run_id"] == mock_context.run_id
+        assert bronze_call_kwargs["run_type"] == mock_context.run_type
+
+        # Verify Silver records contain the same run_id
+        silver_call_kwargs = mock_storage.write_silver.call_args[1]
+        silver_records = silver_call_kwargs["records"]
+        for record in silver_records:
+            assert record["_run_id"] == str(mock_context.run_id)
+            assert record["_run_type"] == mock_context.run_type.value
+
     async def test_process_batch_no_gold_records(self, record_processor, mock_storage):
         """Test process_batch when no records pass gold filter."""
         records = [

--- a/tests/unit/infrastructure/factories/test_storage_adapter.py
+++ b/tests/unit/infrastructure/factories/test_storage_adapter.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 import pytest
 
 from bioetl.domain.ports import StoragePort
-from bioetl.domain.types import BatchID
+from bioetl.domain.types import BatchID, RunID, RunType
 from bioetl.infrastructure.factories.storage import StorageAdapter
 
 
@@ -95,6 +95,8 @@ class TestStorageAdapterWriteBronze:
         records = iter([b'{"id": 1}\n', b'{"id": 2}\n'])
         date = datetime(2024, 1, 15)
         batch_id = BatchID(uuid4())
+        run_id = RunID(uuid4())
+        run_type = RunType.INCREMENTAL
 
         await storage_adapter.write_bronze(
             records=records,
@@ -102,6 +104,8 @@ class TestStorageAdapterWriteBronze:
             entity="activity",
             date=date,
             batch_id=batch_id,
+            run_id=run_id,
+            run_type=run_type,
         )
 
         mock_bronze_writer.write_bronze.assert_called_once()
@@ -110,6 +114,8 @@ class TestStorageAdapterWriteBronze:
         assert call_kwargs["entity"] == "activity"
         assert call_kwargs["date"] == date
         assert call_kwargs["batch_id"] == batch_id
+        assert call_kwargs["run_id"] == run_id
+        assert call_kwargs["run_type"] == run_type
 
 
 @pytest.mark.unit

--- a/tests/unit/infrastructure/storage/test_bronze_writer.py
+++ b/tests/unit/infrastructure/storage/test_bronze_writer.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 import pytest
 import zstandard as zstd
 
-from bioetl.domain.types import BatchID
+from bioetl.domain.types import BatchID, RunID, RunType
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 
 
@@ -18,6 +18,18 @@ from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 def batch_id() -> BatchID:
     """Generate a unique batch ID."""
     return BatchID(uuid4())
+
+
+@pytest.fixture
+def run_id() -> RunID:
+    """Generate a unique run ID."""
+    return RunID(uuid4())
+
+
+@pytest.fixture
+def run_type() -> RunType:
+    """Return default run type."""
+    return RunType.INCREMENTAL
 
 
 @pytest.fixture
@@ -140,6 +152,8 @@ class TestBronzeWriterWriteLocal:
         temp_dir: str,
         sample_records: list[bytes],
         batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
     ) -> None:
         """Test writing Bronze data to local storage."""
         writer = BronzeWriter(bucket=temp_dir)
@@ -151,6 +165,8 @@ class TestBronzeWriterWriteLocal:
             entity="activity",
             date=date,
             batch_id=batch_id,
+            run_id=run_id,
+            run_type=run_type,
         )
 
         # Verify path format (use as_posix for cross-platform compatibility)
@@ -179,6 +195,8 @@ class TestBronzeWriterWriteLocal:
         temp_dir: str,
         sample_records: list[bytes],
         batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
     ) -> None:
         """Test writing Bronze data with JSON copy."""
         writer = BronzeWriter(bucket=temp_dir, save_json=True)
@@ -190,6 +208,8 @@ class TestBronzeWriterWriteLocal:
             entity="compound",
             date=date,
             batch_id=batch_id,
+            run_id=run_id,
+            run_type=run_type,
         )
 
         # Verify JSON copy exists
@@ -208,6 +228,8 @@ class TestBronzeWriterWriteLocal:
         self,
         temp_dir: str,
         batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
     ) -> None:
         """Test that empty records raise ValueError."""
         writer = BronzeWriter(bucket=temp_dir)
@@ -220,6 +242,8 @@ class TestBronzeWriterWriteLocal:
                 entity="test",
                 date=date,
                 batch_id=batch_id,
+                run_id=run_id,
+                run_type=run_type,
             )
 
 
@@ -233,6 +257,8 @@ class TestBronzeWriterReadLocal:
         temp_dir: str,
         sample_records: list[bytes],
         batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
     ) -> None:
         """Test reading Bronze data from local storage."""
         writer = BronzeWriter(bucket=temp_dir)
@@ -245,6 +271,8 @@ class TestBronzeWriterReadLocal:
             entity="activity",
             date=date,
             batch_id=batch_id,
+            run_id=run_id,
+            run_type=run_type,
         )
 
         # Read back (use as_posix for cross-platform compatibility)
@@ -267,6 +295,8 @@ class TestBronzeWriterListBatches:
         self,
         temp_dir: str,
         sample_records: list[bytes],
+        run_id: RunID,
+        run_type: RunType,
     ) -> None:
         """Test listing batches from local storage."""
         writer = BronzeWriter(bucket=temp_dir)
@@ -281,6 +311,8 @@ class TestBronzeWriterListBatches:
             entity="activity",
             date=date1,
             batch_id=BatchID(uuid4()),
+            run_id=run_id,
+            run_type=run_type,
         )
         await writer.write_bronze(
             records=iter(sample_records),
@@ -288,6 +320,8 @@ class TestBronzeWriterListBatches:
             entity="activity",
             date=date2,
             batch_id=BatchID(uuid4()),
+            run_id=run_id,
+            run_type=run_type,
         )
 
         # List all batches
@@ -299,6 +333,8 @@ class TestBronzeWriterListBatches:
         self,
         temp_dir: str,
         sample_records: list[bytes],
+        run_id: RunID,
+        run_type: RunType,
     ) -> None:
         """Test listing batches with date filter."""
         writer = BronzeWriter(bucket=temp_dir)
@@ -312,6 +348,8 @@ class TestBronzeWriterListBatches:
             entity="activity",
             date=date1,
             batch_id=BatchID(uuid4()),
+            run_id=run_id,
+            run_type=run_type,
         )
         await writer.write_bronze(
             records=iter(sample_records),
@@ -319,6 +357,8 @@ class TestBronzeWriterListBatches:
             entity="activity",
             date=date2,
             batch_id=BatchID(uuid4()),
+            run_id=run_id,
+            run_type=run_type,
         )
 
         # List with date filter
@@ -346,6 +386,8 @@ class TestBronzeWriterS3:
         mock_pool: MagicMock,
         sample_records: list[bytes],
         batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
     ) -> None:
         """Test writing Bronze data to S3."""
         mock_client = MagicMock()
@@ -363,6 +405,8 @@ class TestBronzeWriterS3:
             entity="activity",
             date=date,
             batch_id=batch_id,
+            run_id=run_id,
+            run_type=run_type,
         )
 
         # Verify S3 put was called
@@ -371,6 +415,9 @@ class TestBronzeWriterS3:
         assert call_kwargs["Bucket"] == "test-bucket"
         assert "bronze/v1/chembl/activity" in call_kwargs["Key"]
         assert call_kwargs["ContentType"] == "application/zstd"
+        # Verify run metadata is included in S3 object metadata
+        assert call_kwargs["Metadata"]["run_id"] == str(run_id)
+        assert call_kwargs["Metadata"]["run_type"] == run_type.value
 
     @pytest.mark.asyncio
     @patch("bioetl.infrastructure.storage.s3_pool.S3ClientPool")
@@ -379,6 +426,8 @@ class TestBronzeWriterS3:
         mock_pool: MagicMock,
         sample_records: list[bytes],
         batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
     ) -> None:
         """Test S3 write with missing bucket raises BucketNotFoundError."""
         from botocore.exceptions import ClientError
@@ -405,6 +454,8 @@ class TestBronzeWriterS3:
                 entity="activity",
                 date=date,
                 batch_id=batch_id,
+                run_id=run_id,
+                run_type=run_type,
             )
 
     @pytest.mark.asyncio
@@ -414,6 +465,8 @@ class TestBronzeWriterS3:
         mock_pool: MagicMock,
         sample_records: list[bytes],
         batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
     ) -> None:
         """Test S3 write error raises UploadError."""
         from botocore.exceptions import ClientError
@@ -440,6 +493,8 @@ class TestBronzeWriterS3:
                 entity="activity",
                 date=date,
                 batch_id=batch_id,
+                run_id=run_id,
+                run_type=run_type,
             )
 
     @pytest.mark.asyncio

--- a/tests/unit/infrastructure/storage/test_storage_exceptions.py
+++ b/tests/unit/infrastructure/storage/test_storage_exceptions.py
@@ -10,7 +10,7 @@ from botocore.exceptions import ClientError
 from deltalake.exceptions import DeltaError, SchemaMismatchError, TableNotFoundError
 from pyarrow import ArrowTypeError
 
-from bioetl.domain.types import BatchID
+from bioetl.domain.types import BatchID, RunID, RunType
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 from bioetl.domain.exceptions import (
@@ -67,9 +67,11 @@ class TestBronzeWriterExceptions:
             {"Error": {"Code": "NoSuchBucket"}}, "PutObject"
         )
         batch_id = BatchID(UUID("12345678-1234-5678-1234-567812345678"))
+        run_id = RunID(UUID("12345678-1234-5678-1234-567812345678"))
         with pytest.raises(BucketNotFoundError):
             await bronze_writer.write_bronze(
-                iter([b"{}"]), "p", "e", datetime.now(), batch_id
+                iter([b"{}"]), "p", "e", datetime.now(), batch_id,
+                run_id=run_id, run_type=RunType.INCREMENTAL
             )
 
     @pytest.mark.asyncio
@@ -83,9 +85,11 @@ class TestBronzeWriterExceptions:
             {"Error": {"Code": "AccessDenied"}}, "PutObject"
         )
         batch_id = BatchID(UUID("12345678-1234-5678-1234-567812345678"))
+        run_id = RunID(UUID("12345678-1234-5678-1234-567812345678"))
         with pytest.raises(UploadError):
             await bronze_writer.write_bronze(
-                iter([b"{}"]), "p", "e", datetime.now(), batch_id
+                iter([b"{}"]), "p", "e", datetime.now(), batch_id,
+                run_id=run_id, run_type=RunType.INCREMENTAL
             )
 
 


### PR DESCRIPTION
This change ensures that run_id and run_type are propagated from PipelineContext through to BronzeWriter, enabling consistent traceability across all data layers.

Changes:
- Add run_id and run_type parameters to StoragePort.write_bronze()
- Update BronzeWriter.write_bronze() to accept run_id and run_type
- Include run metadata in S3 object metadata for traceability
- Add logging with run_id for Bronze write operations
- Update StorageAdapter to pass run_id and run_type
- Update RecordProcessor to pass context run_id/run_type to Bronze

This fulfills the requirement: one run = one UUID everywhere (Bronze, Silver, logs all share the same run_id).