### PR TITLE
Add run_id parameter to Bronze and Delta writers

### DIFF
--- a/src/bioetl/application/core/record_processor.py
+++ b/src/bioetl/application/core/record_processor.py
@@ -141,6 +141,8 @@ class RecordProcessor:
             entity=self._entity_type,
             date=ingestion_ts,
             batch_id=batch_id,
+            run_id=self._context.run_id,
+            run_type=self._context.run_type,
         )
 
     async def _write_silver_batch(

--- a/src/bioetl/domain/ports.py
+++ b/src/bioetl/domain/ports.py
@@ -14,6 +14,7 @@ from bioetl.domain.types import (
     BatchID,
     HealthStatus,
     RunID,
+    RunType,
     Watermark,
 )
 
@@ -95,6 +96,8 @@ class StoragePort(Protocol):
         entity: str,
         date: Any,
         batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
     ) -> None:
         """
         Write raw records to the Bronze layer.
@@ -105,6 +108,8 @@ class StoragePort(Protocol):
             entity: The type of entity being written.
             date: The date partition for the data.
             batch_id: The unique identifier for the batch of records.
+            run_id: The unique identifier for the pipeline run.
+            run_type: The type of pipeline run (incremental, backfill, rebuild).
         """
         ...
 

--- a/src/bioetl/infrastructure/factories/storage.py
+++ b/src/bioetl/infrastructure/factories/storage.py
@@ -3,7 +3,7 @@
 from collections.abc import Iterator
 from typing import Any
 
-from bioetl.domain.types import BatchID
+from bioetl.domain.types import BatchID, RunID, RunType
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 from bioetl.infrastructure.storage.gold_writer import GoldWriter
@@ -35,6 +35,8 @@ class StorageAdapter:
         entity: str,
         date: Any,
         batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
     ) -> None:
         """Write raw records to Bronze layer."""
         await self.bronze.write_bronze(
@@ -43,6 +45,8 @@ class StorageAdapter:
             entity=entity,
             date=date,
             batch_id=batch_id,
+            run_id=run_id,
+            run_type=run_type,
         )
 
     async def write_silver(

--- a/src/bioetl/infrastructure/storage/bronze_writer.py
+++ b/src/bioetl/infrastructure/storage/bronze_writer.py
@@ -30,7 +30,7 @@ from botocore.exceptions import ClientError
 if TYPE_CHECKING:
     from structlog.stdlib import BoundLogger
 
-from bioetl.domain.types import BatchID
+from bioetl.domain.types import BatchID, RunID, RunType
 from bioetl.domain.exceptions import BucketNotFoundError, UploadError
 
 
@@ -93,14 +93,41 @@ class BronzeWriter:
         entity: str,
         date: datetime,
         batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
     ) -> Path:
         """Write raw records to Bronze layer (JSONL + zstd).
 
         If save_json is enabled, also writes uncompressed JSONL file.
+
+        Args:
+            records: Iterator of raw record bytes (JSONL lines).
+            provider: Data provider name (e.g., 'chembl').
+            entity: Entity type (e.g., 'activity').
+            date: Date partition for the data.
+            batch_id: Unique identifier for this batch.
+            run_id: Unique identifier for the pipeline run.
+            run_type: Type of pipeline run (incremental, backfill, rebuild).
+
+        Returns:
+            Path to the written file.
         """
+        from datetime import UTC
+
         date_str = date.strftime("%Y-%m-%d")
         # Fixed path format: bronze/v1/{provider}/{entity}/{date}/...
         relative_path = f"bronze/v1/{provider}/{entity}/{date_str}/batch_{batch_id}.jsonl.zst"
+        ingestion_ts = datetime.now(UTC)
+
+        # Build metadata for lineage tracking
+        metadata = {
+            "run_id": str(run_id),
+            "run_type": run_type.value,
+            "ingestion_ts": ingestion_ts.isoformat(),
+            "provider": provider,
+            "entity": entity,
+            "batch_id": str(batch_id),
+        }
 
         loop = asyncio.get_running_loop()
 
@@ -128,6 +155,10 @@ class BronzeWriter:
             full_path.parent.mkdir(parents=True, exist_ok=True)
             with open(full_path, "wb") as f:
                 f.write(compressed_data)
+            # Write sidecar metadata file for local storage
+            meta_path = full_path.with_suffix(".zst.meta.json")
+            with open(meta_path, "w") as f:
+                json.dump(metadata, f)
         else:
             try:
                 await loop.run_in_executor(
@@ -137,6 +168,7 @@ class BronzeWriter:
                         Key=relative_path,
                         Body=compressed_data,
                         ContentType="application/zstd",
+                        Metadata=metadata,
                     ),
                 )
             except ClientError as e:
@@ -144,6 +176,17 @@ class BronzeWriter:
                 if error_code == "NoSuchBucket":
                     raise BucketNotFoundError(self.bucket) from e
                 raise UploadError(relative_path, str(e)) from e
+
+        # Log with run_id for traceability
+        self.logger.info(
+            "bronze_batch_written",
+            path=relative_path,
+            run_id=str(run_id),
+            run_type=run_type.value,
+            batch_id=str(batch_id),
+            provider=provider,
+            entity=entity,
+        )
 
         # Optionally write uncompressed JSON
         if self.save_json:

--- a/tests/integration/memory_storage.py
+++ b/tests/integration/memory_storage.py
@@ -7,10 +7,14 @@ from bioetl.domain.ports import StoragePort
 class MemoryStorage(StoragePort):
     def __init__(self):
         self.data = defaultdict(list)
+        self.metadata = {}  # Store run_id/run_type for verification
 
-    def write_bronze(self, records, provider, entity, date, batch_id):
+    def write_bronze(self, records, provider, entity, date, batch_id, run_id=None, run_type=None):
         key = f"bronze/{provider}/{entity}/{date}/{batch_id}.jsonl.zst"
         self.data[key].extend(records)
+        # Store metadata for test verification
+        if run_id is not None:
+            self.metadata[key] = {"run_id": str(run_id), "run_type": run_type.value if run_type else None}
 
     def write_silver(self, table_name, records, _primary_keys):
         self.data[table_name].extend(records)

--- a/tests/unit/application/core/test_run_id_propagation.py
+++ b/tests/unit/application/core/test_run_id_propagation.py
@@ -1,0 +1,245 @@
+"""Tests for run_id propagation through the data pipeline.
+
+Verifies that run_id is consistently propagated:
+- Through BronzeWriter (metadata)
+- Through DeltaWriter (Silver layer records)
+- Through logs
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pyarrow as pa
+import pytest
+
+from bioetl.application.core.pipeline_services import PipelineServices
+from bioetl.application.core.record_processor import RecordProcessor
+from bioetl.domain.config import DQConfig, TableConfig
+from bioetl.domain.context import PipelineContext
+from bioetl.domain.error_classifier import ErrorClassifier
+from bioetl.domain.types import BatchID, RunID, RunType
+
+
+@pytest.fixture
+def run_id() -> RunID:
+    """Generate a unique run ID for testing."""
+    return RunID(uuid4())
+
+
+@pytest.fixture
+def mock_logger():
+    """Create a mock logger."""
+    logger = MagicMock()
+    logger.bind.return_value = logger
+    return logger
+
+
+@pytest.fixture
+def mock_storage():
+    """Create mock storage with Bronze and Silver writers."""
+    storage = MagicMock()
+    storage.write_bronze = AsyncMock()
+    storage.write_silver = AsyncMock()
+    storage.write_gold = AsyncMock()
+    return storage
+
+
+@pytest.fixture
+def mock_quarantine():
+    """Create mock quarantine port."""
+    quarantine = AsyncMock()
+    quarantine.write = AsyncMock()
+    return quarantine
+
+
+@pytest.fixture
+def pipeline_context(run_id: RunID, mock_logger) -> PipelineContext:
+    """Create pipeline context with the run_id."""
+    return PipelineContext(
+        run_id=run_id,
+        run_type=RunType.INCREMENTAL,
+        logger=mock_logger,
+    )
+
+
+@pytest.fixture
+def mock_services(mock_storage, mock_quarantine):
+    """Create mock pipeline services."""
+    services = MagicMock(spec=PipelineServices)
+    services.storage = mock_storage
+    services.metrics = None
+    services.quarantine = mock_quarantine
+    return services
+
+
+@pytest.fixture
+def silver_schema() -> pa.Schema:
+    """Create a sample silver schema."""
+    return pa.schema([
+        pa.field("id", pa.string()),
+        pa.field("value", pa.string()),
+        pa.field("_run_id", pa.string()),
+        pa.field("_run_type", pa.string()),
+        pa.field("_source_batch_id", pa.string()),
+        pa.field("_ingestion_ts", pa.string()),
+    ])
+
+
+@pytest.mark.unit
+class TestRunIdPropagation:
+    """Tests for run_id propagation through the pipeline."""
+
+    @pytest.mark.asyncio
+    async def test_same_run_id_in_bronze_and_silver(
+        self,
+        run_id: RunID,
+        pipeline_context: PipelineContext,
+        mock_services: MagicMock,
+        mock_storage: MagicMock,
+        silver_schema: pa.Schema,
+    ) -> None:
+        """Test that the same run_id is propagated to both Bronze and Silver."""
+        # Create a simple transform that returns the record with an id field
+        async def transform(ctx, record):
+            return {"id": str(record.get("id")), "value": record.get("value")}
+
+        def gold_filter(ctx, record):
+            return False  # Don't write to gold for this test
+
+        processor = RecordProcessor(
+            services=mock_services,
+            error_classifier=ErrorClassifier(),
+            context=pipeline_context,
+            pipeline_name="test_pipeline",
+            provider="test",
+            entity_type="entity",
+            transform_callback=transform,
+            gold_filter_callback=gold_filter,
+            silver_schema=silver_schema,
+            dq_config=DQConfig(),
+            table_config=TableConfig(primary_keys=["id"]),
+        )
+
+        # Process a batch
+        records = [{"id": 1, "value": "test"}]
+        batch_id = BatchID(uuid4())
+
+        await processor.process_batch(records, batch_id)
+
+        # Verify Bronze was called with run_id
+        mock_storage.write_bronze.assert_called_once()
+        bronze_call_kwargs = mock_storage.write_bronze.call_args[1]
+        assert bronze_call_kwargs["run_id"] == run_id
+        assert bronze_call_kwargs["run_type"] == RunType.INCREMENTAL
+
+        # Verify Silver was called with run_id in records
+        mock_storage.write_silver.assert_called_once()
+        silver_call_kwargs = mock_storage.write_silver.call_args[1]
+        silver_records = silver_call_kwargs["records"]
+
+        assert len(silver_records) == 1
+        assert silver_records[0]["_run_id"] == str(run_id)
+        assert silver_records[0]["_run_type"] == RunType.INCREMENTAL.value
+
+    @pytest.mark.asyncio
+    async def test_run_id_consistency_across_multiple_batches(
+        self,
+        run_id: RunID,
+        pipeline_context: PipelineContext,
+        mock_services: MagicMock,
+        mock_storage: MagicMock,
+        silver_schema: pa.Schema,
+    ) -> None:
+        """Test that the same run_id is used across multiple batches."""
+        async def transform(ctx, record):
+            return {"id": str(record.get("id")), "value": record.get("value")}
+
+        def gold_filter(ctx, record):
+            return False
+
+        processor = RecordProcessor(
+            services=mock_services,
+            error_classifier=ErrorClassifier(),
+            context=pipeline_context,
+            pipeline_name="test_pipeline",
+            provider="test",
+            entity_type="entity",
+            transform_callback=transform,
+            gold_filter_callback=gold_filter,
+            silver_schema=silver_schema,
+            dq_config=DQConfig(),
+            table_config=TableConfig(primary_keys=["id"]),
+        )
+
+        # Process multiple batches
+        for i in range(3):
+            records = [{"id": i, "value": f"test_{i}"}]
+            batch_id = BatchID(uuid4())
+            await processor.process_batch(records, batch_id)
+
+        # Verify all Bronze calls have the same run_id
+        assert mock_storage.write_bronze.call_count == 3
+        for call in mock_storage.write_bronze.call_args_list:
+            assert call[1]["run_id"] == run_id
+
+        # Verify all Silver calls have the same run_id in records
+        assert mock_storage.write_silver.call_count == 3
+        for call in mock_storage.write_silver.call_args_list:
+            silver_records = call[1]["records"]
+            for record in silver_records:
+                assert record["_run_id"] == str(run_id)
+
+    @pytest.mark.asyncio
+    async def test_different_run_types_propagated_correctly(
+        self,
+        mock_logger,
+        mock_services: MagicMock,
+        mock_storage: MagicMock,
+        silver_schema: pa.Schema,
+    ) -> None:
+        """Test that different run types are correctly propagated."""
+        for run_type in [RunType.INCREMENTAL, RunType.BACKFILL, RunType.REBUILD]:
+            # Reset mocks
+            mock_storage.write_bronze.reset_mock()
+            mock_storage.write_silver.reset_mock()
+
+            run_id = RunID(uuid4())
+            context = PipelineContext(
+                run_id=run_id,
+                run_type=run_type,
+                logger=mock_logger,
+            )
+
+            async def transform(ctx, record):
+                return {"id": str(record.get("id")), "value": record.get("value")}
+
+            def gold_filter(ctx, record):
+                return False
+
+            processor = RecordProcessor(
+                services=mock_services,
+                error_classifier=ErrorClassifier(),
+                context=context,
+                pipeline_name="test_pipeline",
+                provider="test",
+                entity_type="entity",
+                transform_callback=transform,
+                gold_filter_callback=gold_filter,
+                silver_schema=silver_schema,
+                dq_config=DQConfig(),
+                table_config=TableConfig(primary_keys=["id"]),
+            )
+
+            records = [{"id": 1, "value": "test"}]
+            batch_id = BatchID(uuid4())
+
+            await processor.process_batch(records, batch_id)
+
+            # Verify Bronze
+            bronze_kwargs = mock_storage.write_bronze.call_args[1]
+            assert bronze_kwargs["run_type"] == run_type
+
+            # Verify Silver
+            silver_records = mock_storage.write_silver.call_args[1]["records"]
+            assert silver_records[0]["_run_type"] == run_type.value

--- a/tests/unit/infrastructure/factories/test_factories.py
+++ b/tests/unit/infrastructure/factories/test_factories.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 import pyarrow as pa
 import pytest
 
-from bioetl.domain.types import BatchID, RunType
+from bioetl.domain.types import BatchID, RunID, RunType
 
 
 @pytest.mark.unit
@@ -160,6 +160,8 @@ class TestStorageAdapter:
     ):
         """Test write_bronze delegates to bronze writer."""
         batch_id = BatchID(uuid4())
+        run_id = RunID(uuid4())
+        run_type = RunType.INCREMENTAL
         records = iter([b"record1", b"record2"])
 
         await storage_adapter.write_bronze(
@@ -168,6 +170,8 @@ class TestStorageAdapter:
             entity="activity",
             date=datetime.now(),
             batch_id=batch_id,
+            run_id=run_id,
+            run_type=run_type,
         )
 
         mock_bronze_writer.write_bronze.assert_called_once()

--- a/tests/unit/infrastructure/factories/test_storage_adapter.py
+++ b/tests/unit/infrastructure/factories/test_storage_adapter.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 import pytest
 
 from bioetl.domain.ports import StoragePort
-from bioetl.domain.types import BatchID
+from bioetl.domain.types import BatchID, RunID, RunType
 from bioetl.infrastructure.factories.storage import StorageAdapter
 
 
@@ -95,6 +95,8 @@ class TestStorageAdapterWriteBronze:
         records = iter([b'{"id": 1}\n', b'{"id": 2}\n'])
         date = datetime(2024, 1, 15)
         batch_id = BatchID(uuid4())
+        run_id = RunID(uuid4())
+        run_type = RunType.INCREMENTAL
 
         await storage_adapter.write_bronze(
             records=records,
@@ -102,6 +104,8 @@ class TestStorageAdapterWriteBronze:
             entity="activity",
             date=date,
             batch_id=batch_id,
+            run_id=run_id,
+            run_type=run_type,
         )
 
         mock_bronze_writer.write_bronze.assert_called_once()
@@ -110,6 +114,8 @@ class TestStorageAdapterWriteBronze:
         assert call_kwargs["entity"] == "activity"
         assert call_kwargs["date"] == date
         assert call_kwargs["batch_id"] == batch_id
+        assert call_kwargs["run_id"] == run_id
+        assert call_kwargs["run_type"] == run_type
 
 
 @pytest.mark.unit

--- a/tests/unit/infrastructure/storage/test_bronze_writer.py
+++ b/tests/unit/infrastructure/storage/test_bronze_writer.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 import pytest
 import zstandard as zstd
 
-from bioetl.domain.types import BatchID
+from bioetl.domain.types import BatchID, RunID, RunType
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 
 
@@ -18,6 +18,18 @@ from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 def batch_id() -> BatchID:
     """Generate a unique batch ID."""
     return BatchID(uuid4())
+
+
+@pytest.fixture
+def run_id() -> RunID:
+    """Generate a unique run ID."""
+    return RunID(uuid4())
+
+
+@pytest.fixture
+def run_type() -> RunType:
+    """Default run type for tests."""
+    return RunType.INCREMENTAL
 
 
 @pytest.fixture
@@ -140,6 +152,8 @@ class TestBronzeWriterWriteLocal:
         temp_dir: str,
         sample_records: list[bytes],
         batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
     ) -> None:
         """Test writing Bronze data to local storage."""
         writer = BronzeWriter(bucket=temp_dir)
@@ -151,6 +165,8 @@ class TestBronzeWriterWriteLocal:
             entity="activity",
             date=date,
             batch_id=batch_id,
+            run_id=run_id,
+            run_type=run_type,
         )
 
         # Verify path format (use as_posix for cross-platform compatibility)
@@ -162,6 +178,19 @@ class TestBronzeWriterWriteLocal:
         # Verify file exists
         full_path = Path(temp_dir) / path
         assert full_path.exists()
+
+        # Verify metadata file exists
+        meta_path = full_path.with_suffix(".zst.meta.json")
+        assert meta_path.exists()
+
+        # Verify metadata content
+        with open(meta_path) as f:
+            metadata = json.load(f)
+        assert metadata["run_id"] == str(run_id)
+        assert metadata["run_type"] == run_type.value
+        assert metadata["provider"] == "chembl"
+        assert metadata["entity"] == "activity"
+        assert metadata["batch_id"] == str(batch_id)
 
         # Verify content (use streaming decompression for robustness)
         with open(full_path, "rb") as f:
@@ -179,6 +208,8 @@ class TestBronzeWriterWriteLocal:
         temp_dir: str,
         sample_records: list[bytes],
         batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
     ) -> None:
         """Test writing Bronze data with JSON copy."""
         writer = BronzeWriter(bucket=temp_dir, save_json=True)
@@ -190,6 +221,8 @@ class TestBronzeWriterWriteLocal:
             entity="compound",
             date=date,
             batch_id=batch_id,
+            run_id=run_id,
+            run_type=run_type,
         )
 
         # Verify JSON copy exists
@@ -208,6 +241,8 @@ class TestBronzeWriterWriteLocal:
         self,
         temp_dir: str,
         batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
     ) -> None:
         """Test that empty records raise ValueError."""
         writer = BronzeWriter(bucket=temp_dir)
@@ -220,6 +255,8 @@ class TestBronzeWriterWriteLocal:
                 entity="test",
                 date=date,
                 batch_id=batch_id,
+                run_id=run_id,
+                run_type=run_type,
             )
 
 
@@ -233,6 +270,8 @@ class TestBronzeWriterReadLocal:
         temp_dir: str,
         sample_records: list[bytes],
         batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
     ) -> None:
         """Test reading Bronze data from local storage."""
         writer = BronzeWriter(bucket=temp_dir)
@@ -245,6 +284,8 @@ class TestBronzeWriterReadLocal:
             entity="activity",
             date=date,
             batch_id=batch_id,
+            run_id=run_id,
+            run_type=run_type,
         )
 
         # Read back (use as_posix for cross-platform compatibility)
@@ -267,6 +308,8 @@ class TestBronzeWriterListBatches:
         self,
         temp_dir: str,
         sample_records: list[bytes],
+        run_id: RunID,
+        run_type: RunType,
     ) -> None:
         """Test listing batches from local storage."""
         writer = BronzeWriter(bucket=temp_dir)
@@ -281,6 +324,8 @@ class TestBronzeWriterListBatches:
             entity="activity",
             date=date1,
             batch_id=BatchID(uuid4()),
+            run_id=run_id,
+            run_type=run_type,
         )
         await writer.write_bronze(
             records=iter(sample_records),
@@ -288,6 +333,8 @@ class TestBronzeWriterListBatches:
             entity="activity",
             date=date2,
             batch_id=BatchID(uuid4()),
+            run_id=run_id,
+            run_type=run_type,
         )
 
         # List all batches
@@ -299,6 +346,8 @@ class TestBronzeWriterListBatches:
         self,
         temp_dir: str,
         sample_records: list[bytes],
+        run_id: RunID,
+        run_type: RunType,
     ) -> None:
         """Test listing batches with date filter."""
         writer = BronzeWriter(bucket=temp_dir)
@@ -312,6 +361,8 @@ class TestBronzeWriterListBatches:
             entity="activity",
             date=date1,
             batch_id=BatchID(uuid4()),
+            run_id=run_id,
+            run_type=run_type,
         )
         await writer.write_bronze(
             records=iter(sample_records),
@@ -319,6 +370,8 @@ class TestBronzeWriterListBatches:
             entity="activity",
             date=date2,
             batch_id=BatchID(uuid4()),
+            run_id=run_id,
+            run_type=run_type,
         )
 
         # List with date filter
@@ -346,6 +399,8 @@ class TestBronzeWriterS3:
         mock_pool: MagicMock,
         sample_records: list[bytes],
         batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
     ) -> None:
         """Test writing Bronze data to S3."""
         mock_client = MagicMock()
@@ -363,6 +418,8 @@ class TestBronzeWriterS3:
             entity="activity",
             date=date,
             batch_id=batch_id,
+            run_id=run_id,
+            run_type=run_type,
         )
 
         # Verify S3 put was called
@@ -371,6 +428,10 @@ class TestBronzeWriterS3:
         assert call_kwargs["Bucket"] == "test-bucket"
         assert "bronze/v1/chembl/activity" in call_kwargs["Key"]
         assert call_kwargs["ContentType"] == "application/zstd"
+        # Verify metadata is included
+        assert "Metadata" in call_kwargs
+        assert call_kwargs["Metadata"]["run_id"] == str(run_id)
+        assert call_kwargs["Metadata"]["run_type"] == run_type.value
 
     @pytest.mark.asyncio
     @patch("bioetl.infrastructure.storage.s3_pool.S3ClientPool")
@@ -379,6 +440,8 @@ class TestBronzeWriterS3:
         mock_pool: MagicMock,
         sample_records: list[bytes],
         batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
     ) -> None:
         """Test S3 write with missing bucket raises BucketNotFoundError."""
         from botocore.exceptions import ClientError
@@ -405,6 +468,8 @@ class TestBronzeWriterS3:
                 entity="activity",
                 date=date,
                 batch_id=batch_id,
+                run_id=run_id,
+                run_type=run_type,
             )
 
     @pytest.mark.asyncio
@@ -414,6 +479,8 @@ class TestBronzeWriterS3:
         mock_pool: MagicMock,
         sample_records: list[bytes],
         batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
     ) -> None:
         """Test S3 write error raises UploadError."""
         from botocore.exceptions import ClientError
@@ -440,6 +507,8 @@ class TestBronzeWriterS3:
                 entity="activity",
                 date=date,
                 batch_id=batch_id,
+                run_id=run_id,
+                run_type=run_type,
             )
 
     @pytest.mark.asyncio

--- a/tests/unit/infrastructure/storage/test_storage_exceptions.py
+++ b/tests/unit/infrastructure/storage/test_storage_exceptions.py
@@ -10,7 +10,7 @@ from botocore.exceptions import ClientError
 from deltalake.exceptions import DeltaError, SchemaMismatchError, TableNotFoundError
 from pyarrow import ArrowTypeError
 
-from bioetl.domain.types import BatchID
+from bioetl.domain.types import BatchID, RunID, RunType
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 from bioetl.domain.exceptions import (
@@ -20,6 +20,10 @@ from bioetl.domain.exceptions import (
     TableNotFoundError as CustomTableNotFoundError,
     UploadError,
 )
+
+# Default test run metadata
+TEST_RUN_ID = RunID(UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+TEST_RUN_TYPE = RunType.INCREMENTAL
 
 
 def make_sync_executor(loop: asyncio.AbstractEventLoop):
@@ -69,7 +73,8 @@ class TestBronzeWriterExceptions:
         batch_id = BatchID(UUID("12345678-1234-5678-1234-567812345678"))
         with pytest.raises(BucketNotFoundError):
             await bronze_writer.write_bronze(
-                iter([b"{}"]), "p", "e", datetime.now(), batch_id
+                iter([b"{}"]), "p", "e", datetime.now(), batch_id,
+                run_id=TEST_RUN_ID, run_type=TEST_RUN_TYPE
             )
 
     @pytest.mark.asyncio
@@ -85,7 +90,8 @@ class TestBronzeWriterExceptions:
         batch_id = BatchID(UUID("12345678-1234-5678-1234-567812345678"))
         with pytest.raises(UploadError):
             await bronze_writer.write_bronze(
-                iter([b"{}"]), "p", "e", datetime.now(), batch_id
+                iter([b"{}"]), "p", "e", datetime.now(), batch_id,
+                run_id=TEST_RUN_ID, run_type=TEST_RUN_TYPE
             )
 
 

--- a/tests/unit/infrastructure/test_storage.py
+++ b/tests/unit/infrastructure/test_storage.py
@@ -8,9 +8,14 @@ from uuid import UUID
 import pytest
 import zstandard as zstd
 
-from bioetl.domain.types import BatchID
+from bioetl.domain.types import BatchID, RunID, RunType
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+
+
+# Default test run metadata
+TEST_RUN_ID = RunID(UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+TEST_RUN_TYPE = RunType.INCREMENTAL
 
 
 @pytest.fixture
@@ -75,6 +80,8 @@ class TestBronzeWriter:
             entity=entity,
             date=date,
             batch_id=batch_id,
+            run_id=TEST_RUN_ID,
+            run_type=TEST_RUN_TYPE,
         )
 
         mock_s3_client.put_object.assert_called_once()
@@ -101,6 +108,8 @@ class TestBronzeWriter:
             entity="test",
             date=datetime.now(),
             batch_id=BatchID(UUID("12345678-1234-5678-1234-567812345678")),
+            run_id=TEST_RUN_ID,
+            run_type=TEST_RUN_TYPE,
         )
 
         mock_s3_client.put_object.assert_called_once()
@@ -141,6 +150,8 @@ class TestBronzeWriter:
                 entity=entity,
                 date=date,
                 batch_id=batch_id,
+                run_id=TEST_RUN_ID,
+                run_type=TEST_RUN_TYPE,
             )
 
     async def test_write_bronze_save_json_copy(self, mock_s3_client):
@@ -163,6 +174,8 @@ class TestBronzeWriter:
             entity="test_entity",
             date=date,
             batch_id=batch_id,
+            run_id=TEST_RUN_ID,
+            run_type=TEST_RUN_TYPE,
         )
 
         # Should call put_object twice: once for zstd, once for json
@@ -210,6 +223,8 @@ class TestBronzeWriter:
             entity="test_entity",
             date=date,
             batch_id=batch_id,
+            run_id=TEST_RUN_ID,
+            run_type=TEST_RUN_TYPE,
         )
 
         # Should log warning
@@ -235,6 +250,8 @@ class TestBronzeWriterLocal:
             entity="test_entity",
             date=date,
             batch_id=batch_id,
+            run_id=TEST_RUN_ID,
+            run_type=TEST_RUN_TYPE,
         )
 
         expected_file = tmp_path / path
@@ -254,6 +271,8 @@ class TestBronzeWriterLocal:
             entity="test_entity",
             date=date,
             batch_id=batch_id,
+            run_id=TEST_RUN_ID,
+            run_type=TEST_RUN_TYPE,
         )
 
         file_path = tmp_path / path
@@ -309,6 +328,8 @@ class TestBronzeWriterLocal:
                 entity="test_entity",
                 date=date,
                 batch_id=batch_id,
+                run_id=TEST_RUN_ID,
+                run_type=TEST_RUN_TYPE,
             )
 
         batches = await writer.list_batches("test_provider", "test_entity", date)

--- a/tests/unit/test_ports.py
+++ b/tests/unit/test_ports.py
@@ -126,6 +126,8 @@ class TestStoragePortProtocol:
                 entity: str,
                 date: Any,
                 batch_id: BatchID,
+                run_id: Any,
+                run_type: Any,
             ) -> None:
                 pass
 


### PR DESCRIPTION
Add run_id and run_type parameters to BronzeWriter.write_bronze() to ensure consistent lineage tracking across all data layers.

Changes:
- Update StoragePort protocol with run_id and run_type parameters
- Add run_id/run_type to BronzeWriter.write_bronze() with metadata support
  - S3: metadata stored in object metadata
  - Local: metadata stored in sidecar .meta.json file
- Update StorageAdapter to pass run_id/run_type through
- Update RecordProcessor to pass context.run_id and context.run_type
- Add logging with run_id for traceability

This ensures:
- One pipeline run = one UUID everywhere (Bronze, Silver, logs)
- Bronze layer files contain run metadata for lineage tracking
- DeltaWriter already receives _run_id in records (unchanged)