### PR TITLE
Fix errors in project tests

### DIFF
--- a/tests/unit/application/core/test_record_processor.py
+++ b/tests/unit/application/core/test_record_processor.py
@@ -163,14 +163,12 @@ class TestRecordProcessorProcessBatch:
         ]
         batch_id = BatchID(uuid4())
 
-        bronze, silver, gold, quarantined = await record_processor.process_batch(
-            records, batch_id
-        )
+        result = await record_processor.process_batch(records, batch_id)
 
-        assert bronze == 2
-        assert silver == 2
-        assert gold == 1
-        assert quarantined == 0
+        assert result.bronze_count == 2
+        assert result.silver_count == 2
+        assert result.gold_count == 1
+        assert result.quarantined_count == 0
         mock_storage.write_bronze.assert_called_once()
         mock_storage.write_silver.assert_called_once()
         mock_storage.write_gold.assert_called_once()
@@ -207,11 +205,9 @@ class TestRecordProcessorProcessBatch:
         ]
         batch_id = BatchID(uuid4())
 
-        bronze, silver, gold, quarantined = await record_processor.process_batch(
-            records, batch_id
-        )
+        result = await record_processor.process_batch(records, batch_id)
 
-        assert gold == 0
+        assert result.gold_count == 0
         mock_storage.write_gold.assert_not_called()
 
     async def test_process_batch_handles_transform_error(
@@ -242,13 +238,11 @@ class TestRecordProcessorProcessBatch:
         ]
         batch_id = BatchID(uuid4())
 
-        bronze, silver, gold, quarantined = await processor.process_batch(
-            records, batch_id
-        )
+        result = await processor.process_batch(records, batch_id)
 
-        assert bronze == 2
-        assert silver == 1
-        assert quarantined == 1
+        assert result.bronze_count == 2
+        assert result.silver_count == 1
+        assert result.quarantined_count == 1
         # Quarantine logic is now internal to Processor via QuarantineManager -> Port
         mock_services.quarantine.write.assert_called_once()
 
@@ -284,13 +278,11 @@ class TestRecordProcessorProcessBatch:
         records = []
         batch_id = BatchID(uuid4())
 
-        bronze, silver, gold, quarantined = await record_processor.process_batch(
-            records, batch_id
-        )
+        result = await record_processor.process_batch(records, batch_id)
 
-        assert bronze == 0
-        assert silver == 0
-        assert gold == 0
+        assert result.bronze_count == 0
+        assert result.silver_count == 0
+        assert result.gold_count == 0
         mock_storage.write_silver.assert_not_called()
         mock_storage.write_gold.assert_not_called()
 
@@ -379,14 +371,12 @@ class TestRecordProcessorProcessBatch:
             {"id": "bad", "value": 2},
         ]
 
-        bronze, silver, gold, quarantined = await processor.process_batch(
-            records, BatchID(uuid4())
-        )
+        result = await processor.process_batch(records, BatchID(uuid4()))
 
-        assert bronze == 2
-        assert silver == 1
-        assert gold == 1
-        assert quarantined == 1
+        assert result.bronze_count == 2
+        assert result.silver_count == 1
+        assert result.gold_count == 1
+        assert result.quarantined_count == 1
         mock_context.logger.warning.assert_not_called()
 
         get_pipeline_config.cache_clear()

--- a/tests/unit/application/test_pipeline_executor.py
+++ b/tests/unit/application/test_pipeline_executor.py
@@ -6,6 +6,7 @@ import pytest
 
 from bioetl.application.core.checkpoint_manager import CheckpointManager
 from bioetl.application.core.executor import PipelineExecutor
+from bioetl.application.core.record_processor import BatchResult
 from bioetl.application.core.shutdown import ShutdownSignal
 
 
@@ -39,7 +40,14 @@ def mock_services():
 def mock_record_processor():
     """Create mock RecordProcessor."""
     processor = AsyncMock()
-    processor.process_batch = AsyncMock(return_value=(1, 1, 1, 0))
+    processor.process_batch = AsyncMock(
+        return_value=BatchResult(
+            bronze_count=1,
+            silver_count=1,
+            gold_count=1,
+            quarantined_count=0,
+        )
+    )
     return processor
 
 

--- a/tests/unit/infrastructure/quarantine/test_unified_quarantine.py
+++ b/tests/unit/infrastructure/quarantine/test_unified_quarantine.py
@@ -94,7 +94,7 @@ def batch_id():
 def mock_write_deltalake():
     """Mock write_deltalake function."""
     with patch(
-        "bioetl.infrastructure.quarantine.unified_quarantine.write_deltalake"
+        "bioetl.infrastructure.quarantine.unified.write_deltalake"
     ) as mock:
         yield mock
 
@@ -104,7 +104,7 @@ def mock_delta_table():
     """Mock DeltaTable class in all modules."""
     mock = MagicMock()
     with patch(
-        "bioetl.infrastructure.quarantine.unified_quarantine.DeltaTable", mock
+        "bioetl.infrastructure.quarantine.unified.DeltaTable", mock
     ), patch(
         "bioetl.infrastructure.quarantine.operations.DeltaTable", mock
     ):

--- a/tests/unit/infrastructure/test_quarantine.py
+++ b/tests/unit/infrastructure/test_quarantine.py
@@ -26,7 +26,7 @@ def _extract_record_from_call(mock_call) -> dict:
 def mock_deltalake():
     """Fixture for mocking deltalake functions."""
     with patch(
-        "bioetl.infrastructure.quarantine.unified_quarantine.write_deltalake"
+        "bioetl.infrastructure.quarantine.unified.write_deltalake"
     ) as mock_write_deltalake:
         yield mock_write_deltalake
 

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -143,6 +143,7 @@ class TestChEMBLActivityPipelineFactory:
     @patch("bioetl.composition.factories.http_client_factory.UnifiedHTTPClient")
     def test_build_services_creates_data_source(
         self,
+        mock_http_client,
         mock_load_config,
         mock_data_source_create,
         mock_base_services,
@@ -175,6 +176,7 @@ class TestChEMBLActivityPipelineFactory:
     @patch("bioetl.composition.factories.http_client_factory.UnifiedHTTPClient")
     def test_build_services_calls_base_services_factory(
         self,
+        mock_http_client,
         mock_load_config,
         mock_data_source_create,
         mock_base_services,
@@ -211,6 +213,7 @@ class TestChEMBLActivityPipelineFactory:
     @patch("bioetl.composition.factories.http_client_factory.UnifiedHTTPClient")
     def test_build_services_uses_provided_config(
         self,
+        mock_http_client,
         mock_load_config,
         mock_data_source_create,
         mock_base_services,
@@ -242,6 +245,7 @@ class TestChEMBLActivityPipelineFactory:
     @patch("bioetl.composition.factories.http_client_factory.UnifiedHTTPClient")
     def test_create_with_services(
         self,
+        mock_http_client,
         mock_data_source_create,
         mock_base_services,
         mock_load_config,


### PR DESCRIPTION
- Fix UnifiedQuarantine tests by patching correct module path (unified.py instead of unified_quarantine.py shim)
- Fix RecordProcessor tests to handle BatchResult dataclass instead of tuple unpacking
- Fix PipelineExecutor tests to return BatchResult mock instead of tuple
- Fix bootstrap factory tests by correcting decorator parameter ordering (decorators are applied bottom-up)

All 818 unit tests now pass.