### PR TITLE
Fix Mypy type errors in factories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,18 @@ module = [
     "vcr.*",
     "fakeredis.*",
     "structlog.*",
+    "pyarrow",
+    "pyarrow.*",
+    "httpx",
+    "httpx.*",
+    "pydantic",
+    "pydantic.*",
+    "pydantic_settings",
+    "pydantic_settings.*",
+    "zstandard",
+    "zstandard.*",
+    "yaml",
+    "yaml.*",
 ]
 ignore_missing_imports = true
 

--- a/src/bioetl/application/core/base.py
+++ b/src/bioetl/application/core/base.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Self
 from uuid import uuid4
 
 from bioetl.application.core.pipeline_config import PipelineRuntimeConfig
@@ -47,7 +47,7 @@ class BasePipeline(ABC):
         runtime: PipelineRuntimeConfig,
         services: PipelineServices,
         config: PipelineConfig,
-    ) -> BasePipeline:
+    ) -> Self:
         """Create pipeline instance.
 
         Default factory method. Subclasses can override if custom initialization is needed.

--- a/src/bioetl/application/core/filtered_data_source.py
+++ b/src/bioetl/application/core/filtered_data_source.py
@@ -92,6 +92,8 @@ class FilteredDataSource:
         watermark: Watermark | None = None,
         limit: int | None = None,
         query: str | None = None,
+        filter_ids: set[str] | None = None,
+        filter_field: str | None = None,
     ) -> AsyncIterator[dict[str, Any]]:
         """Fetch records with optional filtering.
 
@@ -103,10 +105,15 @@ class FilteredDataSource:
             watermark: Last checkpoint for incremental load.
             limit: Maximum number of records.
             query: Optional search query for providers that support it.
+            filter_ids: External filter IDs (ignored - uses internal filter from CSV).
+            filter_field: External filter field (ignored - uses internal config).
 
         Yields:
             Records from the data source, filtered if configured.
         """
+        # Note: External filter_ids/filter_field are ignored -
+        # this class manages its own filter state from InputFilterConfig
+        _ = filter_ids, filter_field  # Mark as intentionally unused
         if self._filter_config.enabled and self._filter_ids:
             # Filtered fetch: pass IDs to adapter
             async for record in self._data_source.fetch(

--- a/src/bioetl/composition/factories/base_pipeline_factory.py
+++ b/src/bioetl/composition/factories/base_pipeline_factory.py
@@ -104,7 +104,7 @@ class BasePipelineFactory(Generic[TPipeline], ABC):
         logger: structlog.BoundLogger,
         config: PipelineYamlConfig | None = None,
         filter_config: InputFilterConfig | None = None,
-        **_kwargs,
+        **_kwargs: object,
     ) -> PipelineServices:
         """Builds PipelineServices from settings.
 
@@ -140,7 +140,7 @@ class BasePipelineFactory(Generic[TPipeline], ABC):
         logger: structlog.BoundLogger,
         config: PipelineYamlConfig | None = None,
         filter_config: InputFilterConfig | None = None,
-        **kwargs,
+        **kwargs: object,
     ) -> TPipeline:
         """Creates pipeline instance.
 

--- a/src/bioetl/composition/factories/generic_factory.py
+++ b/src/bioetl/composition/factories/generic_factory.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from bioetl.application.core.pipeline_config import PipelineRuntimeConfig
     from bioetl.application.core.pipeline_services import PipelineServices
     from bioetl.domain.filter_config import InputFilterConfig
+    from bioetl.domain.ports import DataSourcePort
     from bioetl.infrastructure.config import Settings
     from bioetl.infrastructure.schemas.pipeline_config import PipelineYamlConfig
 
@@ -89,7 +90,7 @@ class GenericPipelineFactory(Generic[TPipeline]):
         settings: Settings,
         pipeline_config: PipelineYamlConfig,
         filter_config: InputFilterConfig | None = None,
-    ):
+    ) -> DataSourcePort:
         """Create data source using the configured creator.
 
         Args:

--- a/src/bioetl/composition/factories/pubchem_compound.py
+++ b/src/bioetl/composition/factories/pubchem_compound.py
@@ -9,6 +9,7 @@ from bioetl.infrastructure.factories.data_sources import DataSourceFactory
 from bioetl.infrastructure.schemas.silver import PUBCHEM_COMPOUND_SCHEMA
 
 if TYPE_CHECKING:
+    from bioetl.domain.filter_config import InputFilterConfig
     from bioetl.domain.ports import DataSourcePort
     from bioetl.infrastructure.config import Settings
     from bioetl.infrastructure.schemas.pipeline_config import PipelineYamlConfig

--- a/src/bioetl/composition/factories/pubmed_publications.py
+++ b/src/bioetl/composition/factories/pubmed_publications.py
@@ -11,6 +11,7 @@ from bioetl.infrastructure.adapters.pubmed.pubmed_client import PubMedAdapter
 from bioetl.infrastructure.schemas.silver import PUBMED_PUBLICATION_SCHEMA
 
 if TYPE_CHECKING:
+    from bioetl.domain.filter_config import InputFilterConfig
     from bioetl.domain.ports import DataSourcePort
     from bioetl.infrastructure.config import Settings
     from bioetl.infrastructure.schemas.pipeline_config import PipelineYamlConfig
@@ -27,6 +28,7 @@ class PubMedPublicationsPipelineFactory(BasePipelineFactory[PubMedPublicationsPi
         cls,
         settings: Settings,
         pipeline_config: PipelineYamlConfig,
+        filter_config: InputFilterConfig | None = None,
     ) -> DataSourcePort:
         """Создает источник данных PubMed."""
         # Use HttpClientFactory for centralized config

--- a/src/bioetl/composition/factories/uniprot_protein.py
+++ b/src/bioetl/composition/factories/uniprot_protein.py
@@ -10,6 +10,7 @@ from bioetl.infrastructure.factories.data_sources import DataSourceFactory
 from bioetl.infrastructure.schemas.silver import UNIPROT_PROTEIN_SCHEMA
 
 if TYPE_CHECKING:
+    from bioetl.domain.filter_config import InputFilterConfig
     from bioetl.domain.ports import DataSourcePort
     from bioetl.infrastructure.config import Settings
     from bioetl.infrastructure.schemas.pipeline_config import PipelineYamlConfig
@@ -27,6 +28,7 @@ class UniProtProteinPipelineFactory(BasePipelineFactory[UniProtProteinPipeline])
         cls,
         settings: Settings,
         pipeline_config: PipelineYamlConfig,
+        filter_config: InputFilterConfig | None = None,
     ) -> DataSourcePort:
         """Create UniProt data source."""
         source_config = pipeline_config.source.get("api", {})

--- a/src/bioetl/domain/ports.py
+++ b/src/bioetl/domain/ports.py
@@ -43,8 +43,10 @@ class DataSourcePort(Protocol):
     implementation of the data source client.
     """
 
-    provider_name: str
-    """The unique name of the data provider (e.g., 'chembl')."""
+    @property
+    def provider_name(self) -> str:
+        """The unique name of the data provider (e.g., 'chembl')."""
+        ...
 
     async def __aenter__(self) -> Self:
         """Enter the async context manager."""
@@ -59,15 +61,21 @@ class DataSourcePort(Protocol):
         """Exit the async context manager."""
         ...
 
-    async def fetch(
+    def fetch(
         self,
         entity_type: str,
         watermark: Watermark | None = None,
         limit: int | None = None,
         query: str | None = None,
+        filter_ids: set[str] | None = None,
+        filter_field: str | None = None,
     ) -> AsyncIterator[dict[str, Any]]:
         """
         Fetch records from the data source (async generator).
+
+        Note: This is NOT an async def because async generator functions
+        return AsyncIterator directly without needing to be awaited.
+        Implementations should be async generators (async def with yield).
 
         Args:
             entity_type: The type of entity to fetch (e.g., 'activity', 'molecule').
@@ -75,6 +83,8 @@ class DataSourcePort(Protocol):
                        fetches from the beginning.
             limit: The maximum number of records to fetch.
             query: Optional search query for providers that support it (e.g., PubChem, UniProt).
+            filter_ids: Optional set of IDs to filter by (for adapters that support filtering).
+            filter_field: Optional field name to filter on (for adapters that support filtering).
 
         Yields:
             A dictionary representing a single record from the data source.

--- a/src/bioetl/infrastructure/adapters/pubchem/client.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/client.py
@@ -102,11 +102,16 @@ class PubChemClient:
     async def fetch(
         self,
         entity_type: str,
-        query: str | None = None,
         watermark: Watermark | None = None,
         limit: int | None = None,
+        query: str | None = None,
+        filter_ids: set[str] | None = None,
+        filter_field: str | None = None,
     ) -> AsyncIterator[dict[str, Any]]:
         """Fetch records from PubChem."""
+        # Note: filter_ids and filter_field are ignored for PubChem -
+        # filtering should be done via query parameter
+        _ = filter_ids, filter_field  # Mark as intentionally unused
         # Apply rate limiting
         await self.rate_limiter.acquire()
 

--- a/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
+++ b/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
@@ -69,24 +69,32 @@ class PubMedAdapter:
     async def fetch(
         self,
         entity_type: str,
-        search_term: str = "pharmacogenomics[Title/Abstract]",
-        limit: int | None = None,
         watermark: Watermark | None = None,
+        limit: int | None = None,
+        query: str | None = None,
+        filter_ids: set[str] | None = None,
+        filter_field: str | None = None,
     ) -> AsyncIterator[dict[str, Any]]:
         """Fetch PubMed records.
 
         Args:
             entity_type: Must be 'publication'
-            search_term: PubMed search query
-            limit: Max records to fetch
             watermark: Unused for now (required by protocol)
+            limit: Max records to fetch
+            query: PubMed search query (defaults to pharmacogenomics search)
+            filter_ids: Optional set of IDs to filter by (unused in PubMed)
+            filter_field: Optional field name to filter on (unused in PubMed)
 
         Yields:
             Dict containing pmid, article_title, and raw_xml
         """
+        # Note: filter_ids and filter_field are ignored for PubMed -
+        # filtering should be done via query parameter
+        _ = filter_ids, filter_field  # Mark as intentionally unused
         if entity_type != "publication":
             raise ValueError("PubMedAdapter only supports 'publication'")
 
+        search_term = query or "pharmacogenomics[Title/Abstract]"
         pmids = await self._get_pmids(search_term, limit or 10000)
 
         if not pmids:

--- a/src/bioetl/infrastructure/adapters/uniprot/client.py
+++ b/src/bioetl/infrastructure/adapters/uniprot/client.py
@@ -62,11 +62,16 @@ class UniProtClient(BaseHttpAdapter, PaginatedFetcherMixin):
     async def fetch(
         self,
         entity_type: str,
-        query: str | None = None,
         watermark: Watermark | None = None,
         limit: int | None = None,
+        query: str | None = None,
+        filter_ids: set[str] | None = None,
+        filter_field: str | None = None,
     ) -> AsyncIterator[dict[str, Any]]:
         """Fetch records from UniProt."""
+        # Note: filter_ids and filter_field are ignored for UniProt -
+        # filtering should be done via query parameter
+        _ = filter_ids, filter_field  # Mark as intentionally unused
         strategy = self._fetch_strategies.get(entity_type)
         if not strategy:
             raise ValueError(

--- a/src/bioetl/infrastructure/factories/data_sources.py
+++ b/src/bioetl/infrastructure/factories/data_sources.py
@@ -23,7 +23,7 @@ class DataSourceFactory:
 
     @classmethod
     def create(
-        cls, provider: str, http_client: "UnifiedHTTPClient", **kwargs: Any
+        cls, provider: str, http_client: "UnifiedHTTPClient | None" = None, **kwargs: Any
     ) -> DataSourcePort:
         """Create a data source adapter.
 


### PR DESCRIPTION
…Protocol

- Add filter_config parameter to uniprot_protein.py and pubmed_publications.py factories
- Add missing InputFilterConfig import to pubchem_compound.py
- Fix DataSourcePort.fetch Protocol signature (remove async for async generators)
- Convert DataSourcePort.provider_name to property for compatibility
- Add filter_ids and filter_field parameters to all adapter fetch methods
- Fix PubMedAdapter.fetch parameter order to match Protocol
- Fix UniProtClient.fetch parameter order to match Protocol
- Fix PubChemClient.fetch parameter order to match Protocol
- Add FilteredDataSource.fetch filter params for Protocol conformance
- Add type annotations to factory methods (**kwargs: object)
- Change BasePipeline.create return type to Self for TypeVar compatibility
- Update DataSourceFactory.create to accept optional http_client
- Add missing library stubs to mypy ignore_missing_imports

Eliminates all mypy errors originating from src/bioetl/composition/factories/