### PR TITLE
Consolidate factories to composition layer

### DIFF
--- a/src/bioetl/composition/bootstrap.py
+++ b/src/bioetl/composition/bootstrap.py
@@ -23,11 +23,11 @@ from bioetl.infrastructure.adapters.chembl.client import ChemblAdapter
 from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
 from bioetl.infrastructure.checkpoint.s3_checkpoint import S3Checkpoint
 from bioetl.infrastructure.config import get_settings, load_pipeline_config
-from bioetl.infrastructure.factories.clients import (
+from bioetl.composition.factories.clients import (
     create_redis_client,
     get_aws_credentials,
 )
-from bioetl.infrastructure.factories.storage import StorageAdapter
+from bioetl.composition.factories.storage_factory import StorageAdapter
 from bioetl.infrastructure.locking.redis_lock import RedisDistributedLock
 from bioetl.infrastructure.observability.logging import (
     create_logger as create_infra_logger,

--- a/src/bioetl/composition/factories/__init__.py
+++ b/src/bioetl/composition/factories/__init__.py
@@ -8,13 +8,25 @@ Usage:
     >>> factory = GenericPipelineFactory(...)
 
 All pipeline factories are auto-registered when this module is imported.
+
+New in v5.1: Client, Storage, and DataSource factories consolidated here from
+infrastructure/factories/ following architectural requirements.
 """
+
+# Client factories
+from bioetl.composition.factories.clients import (
+    create_redis_client,
+    get_aws_credentials,
+)
 
 # Core factory infrastructure
 from bioetl.composition.factories.data_source_registry import (
     DataSourceCreator,
     DataSourceRegistry,
 )
+
+# Data source factory
+from bioetl.composition.factories.data_sources import DataSourceFactory
 from bioetl.composition.factories.generic_factory import (
     GenericPipelineFactory,
     create_pipeline_factory,
@@ -28,12 +40,25 @@ from bioetl.composition.factories.pipeline_factories import (
     uniprot_protein_factory,
 )
 
+# Storage factory
+from bioetl.composition.factories.storage_factory import (
+    StorageAdapter,
+    StorageContext,
+    StorageFactory,
+)
+
 __all__ = [
     "DataSourceCreator",
+    "DataSourceFactory",
     "DataSourceRegistry",
     "GenericPipelineFactory",
+    "StorageAdapter",
+    "StorageContext",
+    "StorageFactory",
     "chembl_activity_factory",
     "create_pipeline_factory",
+    "create_redis_client",
+    "get_aws_credentials",
     "pubchem_compound_factory",
     "pubmed_publications_factory",
     "uniprot_protein_factory",

--- a/src/bioetl/composition/factories/base_services_factory.py
+++ b/src/bioetl/composition/factories/base_services_factory.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol
 
 from bioetl.application.core.pipeline_services import PipelineServices
-from bioetl.infrastructure.checkpoint.s3_checkpoint import S3Checkpoint
-from bioetl.infrastructure.factories.clients import (
+from bioetl.composition.factories.clients import (
     create_redis_client,
     get_aws_credentials,
 )
-from bioetl.infrastructure.factories.storage_factory import (
+from bioetl.composition.factories.storage_factory import (
     StorageContext,
     StorageFactory,
 )
+from bioetl.infrastructure.checkpoint.s3_checkpoint import S3Checkpoint
 from bioetl.infrastructure.locking.memory_lock import MemoryLock
 from bioetl.infrastructure.locking.redis_lock import RedisDistributedLock
 from bioetl.infrastructure.observability.noop_metrics import NoOpMetrics

--- a/src/bioetl/composition/factories/clients.py
+++ b/src/bioetl/composition/factories/clients.py
@@ -1,0 +1,56 @@
+"""Factories for creating infrastructure clients (e.g., Redis, S3).
+
+This centralizes client initialization logic, making it reusable and consistent
+across the application, especially in the composition root (bootstrap).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import redis.asyncio as aioredis
+
+if TYPE_CHECKING:
+    from bioetl.infrastructure.config import Settings
+
+
+def create_redis_client(settings: Settings) -> aioredis.Redis:
+    """Create and configure a Redis client from application settings.
+
+    Args:
+        settings: The application settings object.
+
+    Returns:
+        An initialized aioredis.Redis client instance.
+    """
+    redis_config = settings.redis
+    password = (
+        redis_config.password.get_secret_value() if redis_config.password else None
+    )
+    return aioredis.Redis(
+        host=redis_config.host,
+        port=redis_config.port,
+        password=password,
+        db=redis_config.db,
+        decode_responses=True,  # Ensure we get strings, not bytes
+    )
+
+
+def get_aws_credentials(settings: Settings) -> tuple[str | None, str | None]:
+    """Extract AWS credentials (access key, secret key) from settings.
+
+    Handles the secure extraction of the secret key from the SecretStr.
+
+    Args:
+        settings: The application settings object.
+
+    Returns:
+        A tuple containing the access key ID and the secret access key.
+    """
+    aws_config = settings.aws
+    secret_key = (
+        aws_config.secret_access_key.get_secret_value()
+        if aws_config.secret_access_key
+        else None
+    )
+    return aws_config.access_key_id, secret_key

--- a/src/bioetl/composition/factories/data_source_registry.py
+++ b/src/bioetl/composition/factories/data_source_registry.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol
 
 from bioetl.application.core.filtered_data_source import FilteredDataSource
+from bioetl.composition.factories.data_sources import DataSourceFactory
 from bioetl.composition.factories.http_client_factory import HttpClientFactory
 from bioetl.infrastructure.adapters.input.csv_filter_reader import CsvFilterReader
-from bioetl.infrastructure.factories.data_sources import DataSourceFactory
 
 if TYPE_CHECKING:
     from bioetl.domain.filter_config import InputFilterConfig

--- a/src/bioetl/composition/factories/data_sources.py
+++ b/src/bioetl/composition/factories/data_sources.py
@@ -1,0 +1,57 @@
+"""DataSourceFactory for creating data source adapters.
+
+Implements Abstract Factory pattern for data sources.
+"""
+
+import importlib
+from typing import TYPE_CHECKING, Any
+
+from bioetl.domain.ports import DataSourcePort
+
+if TYPE_CHECKING:
+    from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
+
+
+class DataSourceFactory:
+    """Factory for creating data source adapters."""
+
+    _adapters = {
+        "chembl": ("bioetl.infrastructure.adapters.chembl.client", "ChemblAdapter"),
+        "pubchem": ("bioetl.infrastructure.adapters.pubchem.client", "PubChemClient"),
+        "uniprot": ("bioetl.infrastructure.adapters.uniprot.client", "UniProtClient"),
+    }
+
+    @classmethod
+    def create(
+        cls, provider: str, http_client: "UnifiedHTTPClient | None" = None, **kwargs: Any
+    ) -> DataSourcePort:
+        """Create a data source adapter.
+
+        Args:
+            provider: The name of the data provider (e.g., 'chembl', 'pubchem').
+            http_client: The shared HTTP client to use (only for adapters that support it).
+            **kwargs: Additional keyword arguments to pass to the adapter constructor.
+
+        Returns:
+            An instance of the requested data source adapter.
+
+        Raises:
+            ValueError: If the provider is unknown.
+        """
+        if provider not in cls._adapters:
+            raise ValueError(f"Unknown provider: {provider}")
+
+        module_path, class_name = cls._adapters[provider]
+        module = importlib.import_module(module_path)
+        adapter_cls = getattr(module, class_name)
+
+        # Remove filter_config from kwargs - it's handled by FilteredDataSource wrapper,
+        # not by the adapters themselves
+        adapter_kwargs = {k: v for k, v in kwargs.items() if k != "filter_config"}
+
+        if provider == "chembl":
+            return adapter_cls(http_client=http_client, **adapter_kwargs)
+
+        # PubChem and UniProt manage their own clients or have different signatures
+        # so we don't pass http_client to them.
+        return adapter_cls(**adapter_kwargs)

--- a/src/bioetl/composition/factories/storage_factory.py
+++ b/src/bioetl/composition/factories/storage_factory.py
@@ -1,0 +1,238 @@
+"""Unified storage factory for Bronze/Silver/Gold layers.
+
+Contains StorageAdapter, StorageContext, and StorageFactory for creating
+configured storage infrastructure.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Literal
+
+from bioetl.domain.types import ArrowSchema, BatchID, RunID, RunType
+from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
+from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+from bioetl.infrastructure.storage.gold_writer import GoldWriter
+
+if TYPE_CHECKING:
+    import structlog
+
+    from bioetl.infrastructure.config import Settings
+    from bioetl.infrastructure.schemas.pipeline_config import PipelineYamlConfig
+
+
+class StorageAdapter:
+    """Unified storage adapter for Bronze/Silver/Gold.
+
+    Implements StoragePort protocol from domain/ports.py.
+    """
+
+    # Protocol compliance marker
+    REQUIRES_SILVER_SCHEMA: bool = True
+
+    def __init__(
+        self,
+        bronze_writer: BronzeWriter,
+        silver_writer: DeltaWriter,
+        gold_writer: GoldWriter,
+    ):
+        self.bronze = bronze_writer
+        self.silver = silver_writer
+        self.gold = gold_writer
+
+    async def write_bronze(
+        self,
+        records: Iterator[bytes],
+        provider: str,
+        entity: str,
+        date: datetime,
+        batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
+    ) -> None:
+        """Write raw records to Bronze layer."""
+        await self.bronze.write_bronze(
+            records=records,
+            provider=provider,
+            entity=entity,
+            date=date,
+            batch_id=batch_id,
+            run_id=run_id,
+            run_type=run_type,
+        )
+
+    async def write_silver(
+        self,
+        table_name: str,
+        records: list[dict[str, Any]],
+        primary_keys: list[str],
+        schema: ArrowSchema,
+        mode: Literal["merge", "append", "delete"] = "merge",
+    ) -> None:
+        """Write transformed records to Silver layer."""
+        await self.silver.write_silver(
+            table_name=table_name,
+            records=records,
+            primary_keys=primary_keys,
+            schema=schema,
+        )
+
+    async def write_gold(
+        self,
+        table_name: str,
+        records: list[dict[str, Any]],
+        mode: Literal["overwrite", "append", "scd2"] = "overwrite",
+    ) -> None:
+        """Write aggregated records to Gold layer."""
+        await self.gold.write_gold(
+            table_name=table_name,
+            records=records,
+            mode=mode,
+        )
+
+    async def aclose(self) -> None:
+        """Close resources.
+
+        Implements aclose() required by StoragePort protocol.
+        """
+        pass  # Writers don't need explicit cleanup
+
+
+@dataclass(frozen=True)
+class StorageContext:
+    """Context object returned by StorageFactory containing adapter and paths."""
+
+    adapter: StorageAdapter
+    bronze_path: str
+    silver_path: str
+    gold_path: str
+    checkpoints_path: str
+
+
+class StorageFactory:
+    """Factory for creating configured StorageAdapters."""
+
+    @staticmethod
+    def create(
+        settings: Settings,
+        config: PipelineYamlConfig,
+        logger: structlog.BoundLogger,
+    ) -> StorageContext:
+        """Create a StorageAdapter based on environment and pipeline configuration.
+
+        Handles path resolution for local vs cloud runs and configures
+        CSV/JSON export options for local debugging.
+
+        Args:
+            settings: Application settings
+            config: Typed pipeline configuration
+            logger: Structured logger
+
+        Returns:
+            StorageContext containing adapter and resolved paths
+        """
+        # Import here to avoid circular imports during module loading
+        from bioetl.composition.factories.clients import get_aws_credentials
+
+        is_local_run = settings.env != "prod" and not settings.aws.endpoint_url
+        aws_config = settings.aws
+        s3_config = settings.s3
+        storage_options = settings.storage_options if not is_local_run else None
+        access_key, secret_key = get_aws_credentials(settings)
+
+        # Extract sink configs
+        bronze_config = config.sink.get("bronze")
+        silver_config = config.sink.get("silver")
+        gold_config = config.sink.get("gold")
+
+        # Initialize export variables
+        json_path = None
+        silver_csv_path = None
+        silver_csv_options = None
+        gold_csv_path = None
+        gold_csv_options = None
+
+        if is_local_run:
+            logger.info(
+                "Local run detected. Overriding storage paths to 'data/output'."
+            )
+            base_output_path = "data/output"
+            bronze_path = f"{base_output_path}/bronze"
+            silver_base_path = f"{base_output_path}/silver"
+            gold_base_path = f"{base_output_path}/gold"
+            checkpoints_path = f"{base_output_path}/checkpoints"
+
+            # Handle JSON export (Bronze)
+            if bronze_config and bronze_config.save_json:
+                json_path = f"{base_output_path}/json"
+
+            # Handle CSV export (Silver)
+            if silver_config and silver_config.csv_export.enabled:
+                csv_cfg = silver_config.csv_export
+                silver_csv_path = csv_cfg.path
+                silver_csv_options = {
+                    "delimiter": csv_cfg.delimiter,
+                    "header": csv_cfg.header,
+                    "encoding": csv_cfg.encoding,
+                }
+
+            # Handle CSV export (Gold)
+            if gold_config and gold_config.csv_export.enabled:
+                csv_cfg = gold_config.csv_export
+                gold_csv_path = csv_cfg.path
+                gold_csv_options = {
+                    "delimiter": csv_cfg.delimiter,
+                    "header": csv_cfg.header,
+                    "encoding": csv_cfg.encoding,
+                }
+        else:
+            # Cloud paths
+            bronze_path = s3_config.bucket_bronze
+            silver_base_path = f"s3://{s3_config.bucket_silver}"
+            gold_base_path = f"s3://{s3_config.bucket_gold}"
+            checkpoints_path = s3_config.bucket_checkpoints
+
+        # Logging
+        if json_path:
+            logger.info("JSON export enabled for Bronze layer")
+        if silver_csv_path:
+            logger.info(f"CSV export enabled for Silver layer: {silver_csv_path}")
+        if gold_csv_path:
+            logger.info(f"CSV export enabled for Gold layer: {gold_csv_path}")
+
+        # Determine save_json flag
+        save_json = bronze_config.save_json if bronze_config else False
+
+        adapter = StorageAdapter(
+            bronze_writer=BronzeWriter(
+                bucket=bronze_path,
+                endpoint_url=aws_config.endpoint_url if not is_local_run else None,
+                access_key=access_key,
+                secret_key=secret_key,
+                save_json=save_json,
+                json_path=json_path,
+                logger=logger,
+            ),
+            silver_writer=DeltaWriter(
+                base_path=silver_base_path,
+                storage_options=storage_options,
+                csv_path=silver_csv_path,
+                csv_options=silver_csv_options,
+            ),
+            gold_writer=GoldWriter(
+                base_path=gold_base_path,
+                storage_options=storage_options,
+                csv_path=gold_csv_path,
+                csv_options=gold_csv_options,
+            ),
+        )
+
+        return StorageContext(
+            adapter=adapter,
+            bronze_path=bronze_path,
+            silver_path=silver_base_path,
+            gold_path=gold_base_path,
+            checkpoints_path=checkpoints_path,
+        )

--- a/src/bioetl/composition/factories/uniprot_protein.py
+++ b/src/bioetl/composition/factories/uniprot_protein.py
@@ -6,9 +6,9 @@ from bioetl.application.core.filtered_data_source import FilteredDataSource
 from bioetl.application.pipelines.uniprot.protein import UniProtProteinPipeline
 from bioetl.application.registry import PipelineRegistry
 from bioetl.composition.factories.base_pipeline_factory import BasePipelineFactory
+from bioetl.composition.factories.data_sources import DataSourceFactory
 from bioetl.composition.factories.http_client_factory import HttpClientFactory
 from bioetl.infrastructure.adapters.input.csv_filter_reader import CsvFilterReader
-from bioetl.infrastructure.factories.data_sources import DataSourceFactory
 from bioetl.infrastructure.schemas.silver import UNIPROT_PROTEIN_SCHEMA
 
 if TYPE_CHECKING:

--- a/src/bioetl/infrastructure/factories/__init__.py
+++ b/src/bioetl/infrastructure/factories/__init__.py
@@ -1,1 +1,50 @@
-"""Pipeline factories for dependency injection."""
+"""DEPRECATED: Factory modules have been moved to bioetl.composition.factories.
+
+This module provides backwards-compatible re-exports with deprecation warnings.
+Update your imports to use bioetl.composition.factories instead.
+
+Migration guide:
+    OLD: from bioetl.infrastructure.factories.storage import StorageAdapter
+    NEW: from bioetl.composition.factories.storage_factory import StorageAdapter
+
+    OLD: from bioetl.infrastructure.factories.storage_factory import StorageFactory, StorageContext
+    NEW: from bioetl.composition.factories.storage_factory import StorageFactory, StorageContext
+
+    OLD: from bioetl.infrastructure.factories.clients import create_redis_client, get_aws_credentials
+    NEW: from bioetl.composition.factories.clients import create_redis_client, get_aws_credentials
+
+    OLD: from bioetl.infrastructure.factories.data_sources import DataSourceFactory
+    NEW: from bioetl.composition.factories.data_sources import DataSourceFactory
+"""
+
+import warnings
+
+warnings.warn(
+    "bioetl.infrastructure.factories is deprecated. "
+    "Import from bioetl.composition.factories instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+# Re-export for backwards compatibility
+from bioetl.composition.factories.clients import (  # noqa: E402
+    create_redis_client,
+    get_aws_credentials,
+)
+from bioetl.composition.factories.data_sources import (  # noqa: E402
+    DataSourceFactory,
+)
+from bioetl.composition.factories.storage_factory import (  # noqa: E402
+    StorageAdapter,
+    StorageContext,
+    StorageFactory,
+)
+
+__all__ = [
+    "DataSourceFactory",
+    "StorageAdapter",
+    "StorageContext",
+    "StorageFactory",
+    "create_redis_client",
+    "get_aws_credentials",
+]

--- a/src/bioetl/infrastructure/factories/clients.py
+++ b/src/bioetl/infrastructure/factories/clients.py
@@ -1,56 +1,21 @@
-"""Factories for creating infrastructure clients (e.g., Redis, S3).
+"""DEPRECATED: This module has been moved to bioetl.composition.factories.clients.
 
-This centralizes client initialization logic, making it reusable and consistent
-across the application, especially in the composition root (bootstrap).
+This module provides backwards-compatible re-exports with deprecation warnings.
+Update your imports to use bioetl.composition.factories.clients instead.
 """
 
-from __future__ import annotations
+import warnings
 
-from typing import TYPE_CHECKING
+from bioetl.composition.factories.clients import (
+    create_redis_client,
+    get_aws_credentials,
+)
 
-import redis.asyncio as aioredis
+warnings.warn(
+    "bioetl.infrastructure.factories.clients is deprecated. "
+    "Import from bioetl.composition.factories.clients instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
-if TYPE_CHECKING:
-    from bioetl.infrastructure.config import Settings
-
-
-def create_redis_client(settings: Settings) -> aioredis.Redis:
-    """Create and configure a Redis client from application settings.
-
-    Args:
-        settings: The application settings object.
-
-    Returns:
-        An initialized aioredis.Redis client instance.
-    """
-    redis_config = settings.redis
-    password = (
-        redis_config.password.get_secret_value() if redis_config.password else None
-    )
-    return aioredis.Redis(
-        host=redis_config.host,
-        port=redis_config.port,
-        password=password,
-        db=redis_config.db,
-        decode_responses=True,  # Ensure we get strings, not bytes
-    )
-
-
-def get_aws_credentials(settings: Settings) -> tuple[str | None, str | None]:
-    """Extract AWS credentials (access key, secret key) from settings.
-
-    Handles the secure extraction of the secret key from the SecretStr.
-
-    Args:
-        settings: The application settings object.
-
-    Returns:
-        A tuple containing the access key ID and the secret access key.
-    """
-    aws_config = settings.aws
-    secret_key = (
-        aws_config.secret_access_key.get_secret_value()
-        if aws_config.secret_access_key
-        else None
-    )
-    return aws_config.access_key_id, secret_key
+__all__ = ["create_redis_client", "get_aws_credentials"]

--- a/src/bioetl/infrastructure/factories/data_sources.py
+++ b/src/bioetl/infrastructure/factories/data_sources.py
@@ -1,57 +1,18 @@
-"""DataSourceFactory for creating data source adapters.
+"""DEPRECATED: This module has been moved to bioetl.composition.factories.data_sources.
 
-Implements Abstract Factory pattern for data sources.
+This module provides backwards-compatible re-exports with deprecation warnings.
+Update your imports to use bioetl.composition.factories.data_sources instead.
 """
 
-import importlib
-from typing import TYPE_CHECKING, Any
+import warnings
 
-from bioetl.domain.ports import DataSourcePort
+from bioetl.composition.factories.data_sources import DataSourceFactory
 
-if TYPE_CHECKING:
-    from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
+warnings.warn(
+    "bioetl.infrastructure.factories.data_sources is deprecated. "
+    "Import from bioetl.composition.factories.data_sources instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
-
-class DataSourceFactory:
-    """Factory for creating data source adapters."""
-
-    _adapters = {
-        "chembl": ("bioetl.infrastructure.adapters.chembl.client", "ChemblAdapter"),
-        "pubchem": ("bioetl.infrastructure.adapters.pubchem.client", "PubChemClient"),
-        "uniprot": ("bioetl.infrastructure.adapters.uniprot.client", "UniProtClient"),
-    }
-
-    @classmethod
-    def create(
-        cls, provider: str, http_client: "UnifiedHTTPClient | None" = None, **kwargs: Any
-    ) -> DataSourcePort:
-        """Create a data source adapter.
-
-        Args:
-            provider: The name of the data provider (e.g., 'chembl', 'pubchem').
-            http_client: The shared HTTP client to use (only for adapters that support it).
-            **kwargs: Additional keyword arguments to pass to the adapter constructor.
-
-        Returns:
-            An instance of the requested data source adapter.
-
-        Raises:
-            ValueError: If the provider is unknown.
-        """
-        if provider not in cls._adapters:
-            raise ValueError(f"Unknown provider: {provider}")
-
-        module_path, class_name = cls._adapters[provider]
-        module = importlib.import_module(module_path)
-        adapter_cls = getattr(module, class_name)
-
-        # Remove filter_config from kwargs - it's handled by FilteredDataSource wrapper,
-        # not by the adapters themselves
-        adapter_kwargs = {k: v for k, v in kwargs.items() if k != "filter_config"}
-
-        if provider == "chembl":
-            return adapter_cls(http_client=http_client, **adapter_kwargs)
-
-        # PubChem and UniProt manage their own clients or have different signatures
-        # so we don't pass http_client to them.
-        return adapter_cls(**adapter_kwargs)
+__all__ = ["DataSourceFactory"]

--- a/src/bioetl/infrastructure/factories/storage.py
+++ b/src/bioetl/infrastructure/factories/storage.py
@@ -1,87 +1,34 @@
-"""Unified storage adapter for Bronze/Silver/Gold."""
+"""DEPRECATED: This module has been moved to bioetl.composition.factories.storage_factory.
 
-from collections.abc import Iterator
-from datetime import datetime
-from typing import Any, Literal
+This module provides backwards-compatible re-exports with deprecation warnings.
+Update your imports to use bioetl.composition.factories.storage_factory instead.
+"""
 
-from bioetl.domain.types import ArrowSchema, BatchID, RunID, RunType
-from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
-from bioetl.infrastructure.storage.delta_writer import DeltaWriter
-from bioetl.infrastructure.storage.gold_writer import GoldWriter
+import warnings
+
+from bioetl.composition.factories.storage_factory import (
+    StorageAdapter as _StorageAdapter,
+)
+
+warnings.warn(
+    "bioetl.infrastructure.factories.storage is deprecated. "
+    "Import from bioetl.composition.factories.storage_factory instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
-class StorageAdapter:
-    """Unified storage adapter for Bronze/Silver/Gold.
+class StorageAdapter(_StorageAdapter):
+    """DEPRECATED: Use bioetl.composition.factories.storage_factory.StorageAdapter."""
 
-    Implements StoragePort protocol from domain/ports.py.
-    """
-
-    # Protocol compliance marker
-    REQUIRES_SILVER_SCHEMA: bool = True
-
-    def __init__(
-        self,
-        bronze_writer: BronzeWriter,
-        silver_writer: DeltaWriter,
-        gold_writer: GoldWriter,
-    ):
-        self.bronze = bronze_writer
-        self.silver = silver_writer
-        self.gold = gold_writer
-
-    async def write_bronze(
-        self,
-        records: Iterator[bytes],
-        provider: str,
-        entity: str,
-        date: datetime,
-        batch_id: BatchID,
-        run_id: RunID,
-        run_type: RunType,
-    ) -> None:
-        """Write raw records to Bronze layer."""
-        await self.bronze.write_bronze(
-            records=records,
-            provider=provider,
-            entity=entity,
-            date=date,
-            batch_id=batch_id,
-            run_id=run_id,
-            run_type=run_type,
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "StorageAdapter from bioetl.infrastructure.factories.storage is deprecated. "
+            "Import from bioetl.composition.factories.storage_factory instead.",
+            DeprecationWarning,
+            stacklevel=2,
         )
+        super().__init__(*args, **kwargs)
 
-    async def write_silver(
-        self,
-        table_name: str,
-        records: list[dict[str, Any]],
-        primary_keys: list[str],
-        schema: ArrowSchema,
-        mode: Literal["merge", "append", "delete"] = "merge",
-    ) -> None:
-        """Write transformed records to Silver layer."""
-        await self.silver.write_silver(
-            table_name=table_name,
-            records=records,
-            primary_keys=primary_keys,
-            schema=schema,
-        )
 
-    async def write_gold(
-        self,
-        table_name: str,
-        records: list[dict[str, Any]],
-        mode: Literal["overwrite", "append", "scd2"] = "overwrite",
-    ) -> None:
-        """Write aggregated records to Gold layer."""
-        await self.gold.write_gold(
-            table_name=table_name,
-            records=records,
-            mode=mode,
-        )
-
-    async def aclose(self) -> None:
-        """Close resources.
-
-        Implements aclose() required by StoragePort protocol.
-        """
-        pass  # Writers don't need explicit cleanup
+__all__ = ["StorageAdapter"]

--- a/src/bioetl/infrastructure/factories/storage_factory.py
+++ b/src/bioetl/infrastructure/factories/storage_factory.py
@@ -1,150 +1,22 @@
-from __future__ import annotations
+"""DEPRECATED: This module has been moved to bioetl.composition.factories.storage_factory.
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
+This module provides backwards-compatible re-exports with deprecation warnings.
+Update your imports to use bioetl.composition.factories.storage_factory instead.
+"""
 
-from bioetl.infrastructure.config import Settings
-from bioetl.infrastructure.factories.clients import get_aws_credentials
-from bioetl.infrastructure.factories.storage import StorageAdapter
-from bioetl.infrastructure.schemas.pipeline_config import PipelineYamlConfig
-from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
-from bioetl.infrastructure.storage.delta_writer import DeltaWriter
-from bioetl.infrastructure.storage.gold_writer import GoldWriter
+import warnings
 
-if TYPE_CHECKING:
-    import structlog
+from bioetl.composition.factories.storage_factory import (
+    StorageAdapter,
+    StorageContext,
+    StorageFactory,
+)
 
+warnings.warn(
+    "bioetl.infrastructure.factories.storage_factory is deprecated. "
+    "Import from bioetl.composition.factories.storage_factory instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
-@dataclass(frozen=True)
-class StorageContext:
-    """Context object returned by StorageFactory containing adapter and paths."""
-
-    adapter: StorageAdapter
-    bronze_path: str
-    silver_path: str
-    gold_path: str
-    checkpoints_path: str
-
-
-class StorageFactory:
-    """Factory for creating configured StorageAdapters."""
-
-    @staticmethod
-    def create(
-        settings: Settings,
-        config: PipelineYamlConfig,
-        logger: structlog.BoundLogger,
-    ) -> StorageContext:
-        """Create a StorageAdapter based on environment and pipeline configuration.
-
-        Handles path resolution for local vs cloud runs and configures
-        CSV/JSON export options for local debugging.
-
-        Args:
-            settings: Application settings
-            config: Typed pipeline configuration
-            logger: Structured logger
-
-        Returns:
-            StorageContext containing adapter and resolved paths
-        """
-        is_local_run = settings.env != "prod" and not settings.aws.endpoint_url
-        aws_config = settings.aws
-        s3_config = settings.s3
-        storage_options = settings.storage_options if not is_local_run else None
-        access_key, secret_key = get_aws_credentials(settings)
-
-        # Extract sink configs
-        bronze_config = config.sink.get("bronze")
-        silver_config = config.sink.get("silver")
-        gold_config = config.sink.get("gold")
-
-        # Initialize export variables
-        json_path = None
-        silver_csv_path = None
-        silver_csv_options = None
-        gold_csv_path = None
-        gold_csv_options = None
-
-        if is_local_run:
-            logger.info(
-                "Local run detected. Overriding storage paths to 'data/output'."
-            )
-            base_output_path = "data/output"
-            bronze_path = f"{base_output_path}/bronze"
-            silver_base_path = f"{base_output_path}/silver"
-            gold_base_path = f"{base_output_path}/gold"
-            checkpoints_path = f"{base_output_path}/checkpoints"
-
-            # Handle JSON export (Bronze)
-            if bronze_config and bronze_config.save_json:
-                json_path = f"{base_output_path}/json"
-
-            # Handle CSV export (Silver)
-            if silver_config and silver_config.csv_export.enabled:
-                csv_cfg = silver_config.csv_export
-                silver_csv_path = csv_cfg.path
-                silver_csv_options = {
-                    "delimiter": csv_cfg.delimiter,
-                    "header": csv_cfg.header,
-                    "encoding": csv_cfg.encoding,
-                }
-
-            # Handle CSV export (Gold)
-            if gold_config and gold_config.csv_export.enabled:
-                csv_cfg = gold_config.csv_export
-                gold_csv_path = csv_cfg.path
-                gold_csv_options = {
-                    "delimiter": csv_cfg.delimiter,
-                    "header": csv_cfg.header,
-                    "encoding": csv_cfg.encoding,
-                }
-        else:
-            # Cloud paths
-            bronze_path = s3_config.bucket_bronze
-            silver_base_path = f"s3://{s3_config.bucket_silver}"
-            gold_base_path = f"s3://{s3_config.bucket_gold}"
-            checkpoints_path = s3_config.bucket_checkpoints
-
-        # Logging
-        if json_path:
-            logger.info("JSON export enabled for Bronze layer")
-        if silver_csv_path:
-            logger.info(f"CSV export enabled for Silver layer: {silver_csv_path}")
-        if gold_csv_path:
-            logger.info(f"CSV export enabled for Gold layer: {gold_csv_path}")
-
-        # Determine save_json flag
-        save_json = bronze_config.save_json if bronze_config else False
-
-        adapter = StorageAdapter(
-            bronze_writer=BronzeWriter(
-                bucket=bronze_path,
-                endpoint_url=aws_config.endpoint_url if not is_local_run else None,
-                access_key=access_key,
-                secret_key=secret_key,
-                save_json=save_json,
-                json_path=json_path,
-                logger=logger,
-            ),
-            silver_writer=DeltaWriter(
-                base_path=silver_base_path,
-                storage_options=storage_options,
-                csv_path=silver_csv_path,
-                csv_options=silver_csv_options,
-            ),
-            gold_writer=GoldWriter(
-                base_path=gold_base_path,
-                storage_options=storage_options,
-                csv_path=gold_csv_path,
-                csv_options=gold_csv_options,
-            ),
-        )
-
-        return StorageContext(
-            adapter=adapter,
-            bronze_path=bronze_path,
-            silver_path=silver_base_path,
-            gold_path=gold_base_path,
-            checkpoints_path=checkpoints_path,
-        )
+__all__ = ["StorageAdapter", "StorageContext", "StorageFactory"]

--- a/tests/unit/infrastructure/factories/test_factories.py
+++ b/tests/unit/infrastructure/factories/test_factories.py
@@ -25,7 +25,7 @@ class TestCreateRedisClient:
         settings.redis.password = MagicMock()
         settings.redis.password.get_secret_value.return_value = "secret"
 
-        with patch("bioetl.infrastructure.factories.clients.aioredis.Redis") as mock_redis:
+        with patch("bioetl.composition.factories.clients.aioredis.Redis") as mock_redis:
             create_redis_client(settings)
 
             mock_redis.assert_called_once_with(
@@ -46,7 +46,7 @@ class TestCreateRedisClient:
         settings.redis.db = 1
         settings.redis.password = None
 
-        with patch("bioetl.infrastructure.factories.clients.aioredis.Redis") as mock_redis:
+        with patch("bioetl.composition.factories.clients.aioredis.Redis") as mock_redis:
             create_redis_client(settings)
 
             mock_redis.assert_called_once_with(

--- a/tests/unit/infrastructure/test_storage_factory.py
+++ b/tests/unit/infrastructure/test_storage_factory.py
@@ -4,8 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from bioetl.infrastructure.factories.storage_factory import StorageContext, StorageFactory
-from bioetl.infrastructure.factories.storage import StorageAdapter
+from bioetl.composition.factories.storage_factory import StorageAdapter, StorageContext, StorageFactory
 from bioetl.infrastructure.config import Settings
 
 
@@ -152,9 +151,9 @@ class TestStorageFactoryLocal:
         mock_logger,
     ):
         """Test that local runs use data/output paths."""
-        with patch("bioetl.infrastructure.factories.storage_factory.BronzeWriter") as mock_bronze, \
-             patch("bioetl.infrastructure.factories.storage_factory.DeltaWriter") as mock_delta, \
-             patch("bioetl.infrastructure.factories.storage_factory.GoldWriter") as mock_gold:
+        with patch("bioetl.composition.factories.storage_factory.BronzeWriter") as mock_bronze, \
+             patch("bioetl.composition.factories.storage_factory.DeltaWriter") as mock_delta, \
+             patch("bioetl.composition.factories.storage_factory.GoldWriter") as mock_gold:
 
             result = StorageFactory.create(
                 settings=mock_settings_local,
@@ -175,9 +174,9 @@ class TestStorageFactoryLocal:
         mock_logger,
     ):
         """Test local run with JSON export enabled."""
-        with patch("bioetl.infrastructure.factories.storage_factory.BronzeWriter") as mock_bronze, \
-             patch("bioetl.infrastructure.factories.storage_factory.DeltaWriter") as mock_delta, \
-             patch("bioetl.infrastructure.factories.storage_factory.GoldWriter") as mock_gold:
+        with patch("bioetl.composition.factories.storage_factory.BronzeWriter") as mock_bronze, \
+             patch("bioetl.composition.factories.storage_factory.DeltaWriter") as mock_delta, \
+             patch("bioetl.composition.factories.storage_factory.GoldWriter") as mock_gold:
 
             StorageFactory.create(
                 settings=mock_settings_local,
@@ -198,9 +197,9 @@ class TestStorageFactoryLocal:
         mock_logger,
     ):
         """Test local run with CSV export enabled for Silver and Gold."""
-        with patch("bioetl.infrastructure.factories.storage_factory.BronzeWriter") as mock_bronze, \
-             patch("bioetl.infrastructure.factories.storage_factory.DeltaWriter") as mock_delta, \
-             patch("bioetl.infrastructure.factories.storage_factory.GoldWriter") as mock_gold:
+        with patch("bioetl.composition.factories.storage_factory.BronzeWriter") as mock_bronze, \
+             patch("bioetl.composition.factories.storage_factory.DeltaWriter") as mock_delta, \
+             patch("bioetl.composition.factories.storage_factory.GoldWriter") as mock_gold:
 
             StorageFactory.create(
                 settings=mock_settings_local,
@@ -227,9 +226,9 @@ class TestStorageFactoryLocal:
         mock_logger,
     ):
         """Test that local run logs appropriate info message."""
-        with patch("bioetl.infrastructure.factories.storage_factory.BronzeWriter"), \
-             patch("bioetl.infrastructure.factories.storage_factory.DeltaWriter"), \
-             patch("bioetl.infrastructure.factories.storage_factory.GoldWriter"):
+        with patch("bioetl.composition.factories.storage_factory.BronzeWriter"), \
+             patch("bioetl.composition.factories.storage_factory.DeltaWriter"), \
+             patch("bioetl.composition.factories.storage_factory.GoldWriter"):
 
             StorageFactory.create(
                 settings=mock_settings_local,
@@ -257,9 +256,9 @@ class TestStorageFactoryCloud:
         mock_logger,
     ):
         """Test that cloud runs use S3 bucket paths."""
-        with patch("bioetl.infrastructure.factories.storage_factory.BronzeWriter"), \
-             patch("bioetl.infrastructure.factories.storage_factory.DeltaWriter"), \
-             patch("bioetl.infrastructure.factories.storage_factory.GoldWriter"):
+        with patch("bioetl.composition.factories.storage_factory.BronzeWriter"), \
+             patch("bioetl.composition.factories.storage_factory.DeltaWriter"), \
+             patch("bioetl.composition.factories.storage_factory.GoldWriter"):
 
             result = StorageFactory.create(
                 settings=mock_settings_cloud,
@@ -280,9 +279,9 @@ class TestStorageFactoryCloud:
         mock_logger,
     ):
         """Test that cloud runs pass endpoint_url to BronzeWriter."""
-        with patch("bioetl.infrastructure.factories.storage_factory.BronzeWriter") as mock_bronze, \
-             patch("bioetl.infrastructure.factories.storage_factory.DeltaWriter"), \
-             patch("bioetl.infrastructure.factories.storage_factory.GoldWriter"):
+        with patch("bioetl.composition.factories.storage_factory.BronzeWriter") as mock_bronze, \
+             patch("bioetl.composition.factories.storage_factory.DeltaWriter"), \
+             patch("bioetl.composition.factories.storage_factory.GoldWriter"):
 
             StorageFactory.create(
                 settings=mock_settings_cloud,
@@ -301,9 +300,9 @@ class TestStorageFactoryCloud:
         mock_logger,
     ):
         """Test that cloud runs pass storage_options to writers."""
-        with patch("bioetl.infrastructure.factories.storage_factory.BronzeWriter"), \
-             patch("bioetl.infrastructure.factories.storage_factory.DeltaWriter") as mock_delta, \
-             patch("bioetl.infrastructure.factories.storage_factory.GoldWriter") as mock_gold:
+        with patch("bioetl.composition.factories.storage_factory.BronzeWriter"), \
+             patch("bioetl.composition.factories.storage_factory.DeltaWriter") as mock_delta, \
+             patch("bioetl.composition.factories.storage_factory.GoldWriter") as mock_gold:
 
             StorageFactory.create(
                 settings=mock_settings_cloud,
@@ -333,9 +332,9 @@ class TestStorageFactoryEdgeCases:
         mock_logger,
     ):
         """Test handling of empty sink configuration."""
-        with patch("bioetl.infrastructure.factories.storage_factory.BronzeWriter") as mock_bronze, \
-             patch("bioetl.infrastructure.factories.storage_factory.DeltaWriter"), \
-             patch("bioetl.infrastructure.factories.storage_factory.GoldWriter"):
+        with patch("bioetl.composition.factories.storage_factory.BronzeWriter") as mock_bronze, \
+             patch("bioetl.composition.factories.storage_factory.DeltaWriter"), \
+             patch("bioetl.composition.factories.storage_factory.GoldWriter"):
 
             result = StorageFactory.create(
                 settings=mock_settings_local,
@@ -367,9 +366,9 @@ class TestStorageFactoryEdgeCases:
         settings.s3.bucket_checkpoints = "dev-checkpoints"
         settings.storage_options = {}
 
-        with patch("bioetl.infrastructure.factories.storage_factory.BronzeWriter"), \
-             patch("bioetl.infrastructure.factories.storage_factory.DeltaWriter"), \
-             patch("bioetl.infrastructure.factories.storage_factory.GoldWriter"):
+        with patch("bioetl.composition.factories.storage_factory.BronzeWriter"), \
+             patch("bioetl.composition.factories.storage_factory.DeltaWriter"), \
+             patch("bioetl.composition.factories.storage_factory.GoldWriter"):
 
             result = StorageFactory.create(
                 settings=settings,
@@ -393,9 +392,9 @@ class TestStorageFactoryEdgeCases:
         silver_instance = MagicMock()
         gold_instance = MagicMock()
 
-        with patch("bioetl.infrastructure.factories.storage_factory.BronzeWriter") as mock_bronze, \
-             patch("bioetl.infrastructure.factories.storage_factory.DeltaWriter") as mock_delta, \
-             patch("bioetl.infrastructure.factories.storage_factory.GoldWriter") as mock_gold:
+        with patch("bioetl.composition.factories.storage_factory.BronzeWriter") as mock_bronze, \
+             patch("bioetl.composition.factories.storage_factory.DeltaWriter") as mock_delta, \
+             patch("bioetl.composition.factories.storage_factory.GoldWriter") as mock_gold:
 
             mock_bronze.return_value = bronze_instance
             mock_delta.return_value = silver_instance


### PR DESCRIPTION
Move all factories from infrastructure/factories/ to composition/factories/ following the architectural requirement that factories belong in composition root.

Changes:
- Create composition/factories/storage_factory.py (merged storage.py + storage_factory.py)
- Create composition/factories/clients.py (create_redis_client, get_aws_credentials)
- Create composition/factories/data_sources.py (DataSourceFactory)
- Update composition/factories/__init__.py with new exports
- Update imports in base_services_factory, bootstrap, data_source_registry, uniprot_protein
- Add deprecation re-exports in infrastructure/factories/ for backwards compatibility
- Update test files to patch new module paths

All factory imports now go through composition/factories/, with deprecation warnings for old infrastructure/factories/ paths to allow gradual migration.