### PR TITLE
Standardize test coverage documentation goals

### DIFF
--- a/.claude/PROJECT_CONTEXT.md
+++ b/.claude/PROJECT_CONTEXT.md
@@ -201,7 +201,7 @@ sha256(provider + canonical_json(record))
 | **Architecture** | `tests/architecture/` | Проверка слоёв, imports, именования |
 
 **Инструменты:** `pytest`, `pytest-asyncio`, `pytest-cov`, `hypothesis` (property-based)
-**Цель покрытия:** >95% line coverage
+**Цель покрытия:** >80% line coverage
 
 ### Команды
 

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -29,7 +29,7 @@ jobs:
             # /run-tests command
             -   name: Run Tests (Coverage)
                 run: |
-                    pytest --cov=src --cov-report=term-missing --cov-fail-under=85
+                    pytest --cov=src --cov-report=term-missing --cov-fail-under=80
 
             # /render-diagrams command
             -   name: Render Diagrams & Check Consistency

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -284,8 +284,10 @@ Lock key включает тип запуска:
 | **HTTP Клиент** | **httpx** | requests | Поддержка `async`. **Legacy Wrappers**: Для библиотек без async поддержки (pubchempy, biopython) обязателен запуск в отдельном пуле потоков: `await loop.run_in_executor(thread_pool, fetch_func)`. | 
 | **Линтер** | **Ruff** | Flake8/Black | Скорость и решение "все-в-одном". | 
  
-### 4.2. Политика Тестирования 
-- **Unit**: Только доменная логика. In-memory фейки. Никаких моков (mocks) внешних библиотек. 
+### 4.2. Политика Тестирования
+**Цель покрытия:** >80% line coverage (проверяется в CI через `--cov-fail-under=80`).
+
+- **Unit**: Только доменная логика. In-memory фейки. Никаких моков (mocks) внешних библиотек.
 - **Integration**: 
     - **VCR.py**: Запись ответов API в кассеты (`tests/fixtures/vcr/`). 
     - **Санитизация**: Обязательная очистка секретов (`Authorization`, `X-API-Key`) и PII в хуке `before_record`. 


### PR DESCRIPTION
- Add explicit coverage target (>80%) to docs/RULES.md section 4.2
- Fix .claude/PROJECT_CONTEXT.md: change coverage target from >95% to >80%
- Fix .github/workflows/project-automation.yml: change --cov-fail-under from 85 to 80

All documents and CI workflows now consistently specify >80% line coverage target, matching pyproject.toml configuration (fail_under = 80).