### PR TITLE
Extract CSV export from DeltaWriter

### DIFF
--- a/src/bioetl/composition/factories/storage_factory.py
+++ b/src/bioetl/composition/factories/storage_factory.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal
 
 from bioetl.domain.types import ArrowSchema, BatchID, RunID, RunType
+from bioetl.infrastructure.export.csv_exporter import CsvExporter
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 from bioetl.infrastructure.storage.gold_writer import GoldWriter
@@ -149,10 +150,8 @@ class StorageFactory:
 
         # Initialize export variables
         json_path = None
-        silver_csv_path = None
-        silver_csv_options = None
-        gold_csv_path = None
-        gold_csv_options = None
+        silver_csv_exporter: CsvExporter | None = None
+        gold_csv_exporter: CsvExporter | None = None
 
         if is_local_run:
             logger.info(
@@ -171,22 +170,22 @@ class StorageFactory:
             # Handle CSV export (Silver)
             if silver_config and silver_config.csv_export.enabled:
                 csv_cfg = silver_config.csv_export
-                silver_csv_path = csv_cfg.path
-                silver_csv_options = {
-                    "delimiter": csv_cfg.delimiter,
-                    "header": csv_cfg.header,
-                    "encoding": csv_cfg.encoding,
-                }
+                silver_csv_exporter = CsvExporter(
+                    base_path=csv_cfg.path,
+                    delimiter=csv_cfg.delimiter,
+                    header=csv_cfg.header,
+                    encoding=csv_cfg.encoding,
+                )
 
             # Handle CSV export (Gold)
             if gold_config and gold_config.csv_export.enabled:
                 csv_cfg = gold_config.csv_export
-                gold_csv_path = csv_cfg.path
-                gold_csv_options = {
-                    "delimiter": csv_cfg.delimiter,
-                    "header": csv_cfg.header,
-                    "encoding": csv_cfg.encoding,
-                }
+                gold_csv_exporter = CsvExporter(
+                    base_path=csv_cfg.path,
+                    delimiter=csv_cfg.delimiter,
+                    header=csv_cfg.header,
+                    encoding=csv_cfg.encoding,
+                )
         else:
             # Cloud paths
             bronze_path = s3_config.bucket_bronze
@@ -197,10 +196,14 @@ class StorageFactory:
         # Logging
         if json_path:
             logger.info("JSON export enabled for Bronze layer")
-        if silver_csv_path:
-            logger.info(f"CSV export enabled for Silver layer: {silver_csv_path}")
-        if gold_csv_path:
-            logger.info(f"CSV export enabled for Gold layer: {gold_csv_path}")
+        if silver_csv_exporter:
+            logger.info(
+                f"CSV export enabled for Silver layer: {silver_csv_exporter.base_path}"
+            )
+        if gold_csv_exporter:
+            logger.info(
+                f"CSV export enabled for Gold layer: {gold_csv_exporter.base_path}"
+            )
 
         # Determine save_json flag
         save_json = bronze_config.save_json if bronze_config else False
@@ -218,14 +221,12 @@ class StorageFactory:
             silver_writer=DeltaWriter(
                 base_path=silver_base_path,
                 storage_options=storage_options,
-                csv_path=silver_csv_path,
-                csv_options=silver_csv_options,
+                csv_exporter=silver_csv_exporter,
             ),
             gold_writer=GoldWriter(
                 base_path=gold_base_path,
                 storage_options=storage_options,
-                csv_path=gold_csv_path,
-                csv_options=gold_csv_options,
+                csv_exporter=gold_csv_exporter,
             ),
         )
 

--- a/src/bioetl/infrastructure/export/__init__.py
+++ b/src/bioetl/infrastructure/export/__init__.py
@@ -1,0 +1,10 @@
+"""Export adapters for various formats.
+
+Implements RULES.md §2.1 - Data export functionality.
+"""
+
+from bioetl.infrastructure.export.csv_exporter import CsvExporter
+
+__all__ = [
+    "CsvExporter",
+]

--- a/src/bioetl/infrastructure/export/csv_exporter.py
+++ b/src/bioetl/infrastructure/export/csv_exporter.py
@@ -1,0 +1,166 @@
+"""CSV exporter for data layers.
+
+Provides atomic CSV export functionality with support for complex types
+(lists, structs) serialization to JSON strings.
+
+Architecture:
+- Uses composition pattern - injected into storage writers
+- Supports configurable delimiters, headers, encoding
+- Implements atomic write for Windows compatibility
+"""
+
+import asyncio
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.csv as pv
+
+
+class CsvExporter:
+    """Exporter for CSV format with atomic writes.
+
+    Handles conversion of complex PyArrow types to CSV-compatible format
+    and provides atomic file writes to avoid locking issues.
+    """
+
+    def __init__(
+        self,
+        base_path: str,
+        delimiter: str = ",",
+        header: bool = True,
+        encoding: str = "utf-8",
+    ) -> None:
+        """Initialize CSV exporter.
+
+        Args:
+            base_path: Base directory for CSV files
+            delimiter: Field delimiter (default: ",")
+            header: Include header row (default: True)
+            encoding: File encoding (default: "utf-8")
+        """
+        self.base_path = Path(base_path)
+        self.delimiter = delimiter
+        self.header = header
+        self.encoding = encoding
+
+    @staticmethod
+    def _flatten_for_csv(table: pa.Table) -> pa.Table:
+        """Convert complex types (list, struct) to JSON strings for CSV export.
+
+        Args:
+            table: PyArrow table with potentially complex types
+
+        Returns:
+            PyArrow table with complex types serialized to JSON strings
+        """
+        new_columns = []
+        for i, field in enumerate(table.schema):
+            col = table.column(i)
+            if (
+                pa.types.is_list(field.type)
+                or pa.types.is_large_list(field.type)
+                or pa.types.is_struct(field.type)
+            ):
+                json_strings = [
+                    json.dumps(val.as_py()) if val.as_py() is not None else None
+                    for val in col
+                ]
+                new_columns.append(pa.array(json_strings, type=pa.string()))
+            else:
+                new_columns.append(col)
+
+        new_schema = pa.schema(
+            [
+                pa.field(
+                    f.name,
+                    (
+                        pa.string()
+                        if pa.types.is_list(f.type)
+                        or pa.types.is_large_list(f.type)
+                        or pa.types.is_struct(f.type)
+                        else f.type
+                    ),
+                    f.nullable,
+                )
+                for f in table.schema
+            ]
+        )
+        return pa.Table.from_arrays(new_columns, schema=new_schema)
+
+    @staticmethod
+    def _atomic_csv_write(
+        data: pa.Table,
+        target_path: Path,
+        write_options: pv.WriteOptions,
+    ) -> None:
+        """Write CSV atomically to avoid file lock issues on Windows.
+
+        Writes to a temporary file in the same directory, then renames.
+        This avoids WinError 32 when the target file is briefly locked.
+
+        Args:
+            data: PyArrow table to write
+            target_path: Destination file path
+            write_options: PyArrow CSV write options
+        """
+        target_dir = target_path.parent
+        fd, temp_path_str = tempfile.mkstemp(
+            suffix=".csv.tmp",
+            prefix=target_path.stem + "_",
+            dir=target_dir,
+        )
+        temp_path = Path(temp_path_str)
+        try:
+            os.close(fd)  # Close fd, PyArrow will open by path
+            pv.write_csv(data, temp_path, write_options=write_options)
+
+            # On Windows, need to remove target first if exists
+            if os.name == "nt" and target_path.exists():
+                target_path.unlink()
+
+            # Atomic rename
+            temp_path.rename(target_path)
+        except Exception:
+            # Clean up temp file on error
+            if temp_path.exists():
+                temp_path.unlink()
+            raise
+
+    async def export(
+        self,
+        table_name: str,
+        data: pa.Table,
+    ) -> Path:
+        """Export PyArrow table to CSV file.
+
+        Args:
+            table_name: Name of the table (used for file naming)
+            data: PyArrow table to export
+
+        Returns:
+            Path to the written CSV file
+        """
+        # Construct target path
+        csv_full_path = self.base_path / f"{table_name}.csv"
+        csv_full_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Build CSV write options
+        write_options = pv.WriteOptions(
+            include_header=self.header,
+            delimiter=self.delimiter,
+        )
+
+        # Convert list/struct columns to JSON strings for CSV compatibility
+        csv_data = self._flatten_for_csv(data)
+
+        # Atomic write in executor to avoid blocking
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            None,
+            lambda: self._atomic_csv_write(csv_data, csv_full_path, write_options),
+        )
+
+        return csv_full_path

--- a/src/bioetl/infrastructure/storage/delta_writer.py
+++ b/src/bioetl/infrastructure/storage/delta_writer.py
@@ -16,18 +16,17 @@ Architecture:
 - Supports partitioning for query optimization
 - Implements merge/upsert based on primary keys
 - ACID guarantees for concurrent writes
+- CSV export delegated to CsvExporter (composition)
 """
+
+from __future__ import annotations
 
 import asyncio
 import json
-import os
-import tempfile
 from datetime import datetime
-from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import pyarrow as pa
-import pyarrow.csv as pv
 from deltalake import DeltaTable, write_deltalake
 from deltalake.exceptions import DeltaError, SchemaMismatchError
 from deltalake.exceptions import TableNotFoundError as DeltaTableNotFoundError
@@ -39,58 +38,33 @@ from bioetl.domain.exceptions import (
     TableNotFoundError,
 )
 
+if TYPE_CHECKING:
+    from bioetl.infrastructure.export.csv_exporter import CsvExporter
+
 
 class DeltaWriter:
     """Writer for Silver layer (normalized data in Delta Lake).
 
     Implements merge/upsert strategy to handle updates and deduplication.
+    CSV export is delegated to an optional CsvExporter (composition pattern).
     """
-
-    @staticmethod
-    def _flatten_for_csv(table: pa.Table) -> pa.Table:
-        """Convert complex types (list, struct) to JSON strings for CSV export."""
-        import json as json_module
-
-        new_columns = []
-        for i, field in enumerate(table.schema):
-            col = table.column(i)
-            if pa.types.is_list(field.type) or pa.types.is_large_list(field.type) or pa.types.is_struct(field.type):
-                json_strings = [
-                    json_module.dumps(val.as_py()) if val.as_py() is not None else None
-                    for val in col
-                ]
-                new_columns.append(pa.array(json_strings, type=pa.string()))
-            else:
-                new_columns.append(col)
-
-        new_schema = pa.schema([
-            pa.field(f.name, pa.string() if pa.types.is_list(f.type) or pa.types.is_large_list(f.type) or pa.types.is_struct(f.type) else f.type, f.nullable)
-            for f in table.schema
-        ])
-        return pa.Table.from_arrays(new_columns, schema=new_schema)
 
     def __init__(
         self,
         base_path: str,
         storage_options: dict[str, str] | None = None,
-        csv_path: str | None = None,
-        csv_options: dict[str, Any] | None = None,
+        csv_exporter: CsvExporter | None = None,
     ) -> None:
         """Initialize Delta writer.
 
         Args:
             base_path: Base path for Delta tables
             storage_options: Storage options for S3/MinIO
-            csv_path: Path for CSV export (None to disable)
-            csv_options: CSV export options:
-                - delimiter: Field delimiter (default: ",")
-                - header: Include header row (default: True)
-                - encoding: File encoding (default: "utf-8")
+            csv_exporter: Optional CsvExporter for CSV output (None to disable)
         """
         self.base_path = base_path.rstrip("/")
         self.storage_options = storage_options or {}
-        self.csv_path = csv_path
-        self.csv_options = csv_options or {}
+        self.csv_exporter = csv_exporter
 
     async def write_silver(
         self,
@@ -166,61 +140,9 @@ class DeltaWriter:
                 raise MergeConflictError(table_name, conflicts=1) from e
             raise
 
-        if self.csv_path:
-            csv_full_path = Path(self.csv_path) / f"{table_name}.csv"
-            csv_full_path.parent.mkdir(parents=True, exist_ok=True)
-
-            # Build CSV write options from config
-            delimiter = self.csv_options.get("delimiter", ",")
-            include_header = self.csv_options.get("header", True)
-
-            write_options = pv.WriteOptions(
-                include_header=include_header,
-                delimiter=delimiter,
-            )
-
-            # Convert list/struct columns to JSON strings for CSV compatibility
-            csv_data = self._flatten_for_csv(arrow_data)
-
-            # Atomic write: write to temp file, then rename to avoid file lock issues on Windows
-            await loop.run_in_executor(
-                None,
-                lambda: self._atomic_csv_write(csv_data, csv_full_path, write_options)
-            )
-
-    @staticmethod
-    def _atomic_csv_write(
-        data: pa.Table,
-        target_path: Path,
-        write_options: pv.WriteOptions,
-    ) -> None:
-        """Write CSV atomically to avoid file lock issues on Windows.
-
-        Writes to a temporary file in the same directory, then renames.
-        This avoids WinError 32 when the target file is briefly locked.
-        """
-        # Create temp file in same directory for atomic rename
-        target_dir = target_path.parent
-        fd, temp_path = tempfile.mkstemp(
-            suffix=".csv.tmp",
-            prefix=target_path.stem + "_",
-            dir=target_dir,
-        )
-        try:
-            os.close(fd)  # Close fd, PyArrow will open by path
-            pv.write_csv(data, temp_path, write_options=write_options)
-
-            # On Windows, need to remove target first if exists
-            if os.name == "nt" and target_path.exists():
-                target_path.unlink()
-
-            # Atomic rename
-            os.rename(temp_path, target_path)
-        except Exception:
-            # Clean up temp file on error
-            if os.path.exists(temp_path):
-                os.unlink(temp_path)
-            raise
+        # Delegate CSV export to CsvExporter if configured
+        if self.csv_exporter:
+            await self.csv_exporter.export(table_name, arrow_data)
 
     async def _merge_records(
         self,

--- a/src/bioetl/infrastructure/storage/gold_writer.py
+++ b/src/bioetl/infrastructure/storage/gold_writer.py
@@ -12,22 +12,24 @@ Architecture:
 - Supports both Delta Lake and Parquet formats
 - Implements SCD Type 2 (Slowly Changing Dimensions) for history tracking
 - Enforces data contracts
+- CSV export delegated to CsvExporter (composition)
 """
 
+from __future__ import annotations
+
 import asyncio
-import os
 import random
-import tempfile
 from datetime import UTC, datetime
-from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import pandera as pandera_pa
 import pyarrow as pa
-import pyarrow.csv as pv
 from deltalake import DeltaTable, write_deltalake
 from deltalake.exceptions import TableNotFoundError
 from pandera.polars import DataFrameSchema
+
+if TYPE_CHECKING:
+    from bioetl.infrastructure.export.csv_exporter import CsvExporter
 
 
 class GoldWriter:
@@ -35,30 +37,25 @@ class GoldWriter:
 
     Enforces strict validation before writing. All records must pass
     schema validation or the entire batch fails.
+    CSV export is delegated to an optional CsvExporter (composition pattern).
     """
 
     def __init__(
         self,
         base_path: str,
         storage_options: dict[str, str] | None = None,
-        csv_path: str | None = None,
-        csv_options: dict[str, Any] | None = None,
+        csv_exporter: CsvExporter | None = None,
     ) -> None:
         """Initialize Gold writer.
 
         Args:
             base_path: Base path for Gold tables
             storage_options: Storage options for S3/MinIO
-            csv_path: Path for CSV export (None to disable)
-            csv_options: CSV export options:
-                - delimiter: Field delimiter (default: ",")
-                - header: Include header row (default: True)
-                - encoding: File encoding (default: "utf-8")
+            csv_exporter: Optional CsvExporter for CSV output (None to disable)
         """
         self.base_path = base_path.rstrip("/")
         self.storage_options = storage_options or {}
-        self.csv_path = csv_path
-        self.csv_options = csv_options or {}
+        self.csv_exporter = csv_exporter
 
     async def write_gold(
         self,
@@ -90,7 +87,7 @@ class GoldWriter:
                 raise ValueError("scd_config required for SCD Type 2 mode")
             await self._write_scd2(table_path, records, scd_config, partition_cols)
         elif mode in ("overwrite", "append"):
-            await self._write_simple(table_path, records, mode, partition_cols, schema)
+            await self._write_simple(table_path, table_name, records, mode, partition_cols, schema)
         else:
             raise ValueError(f"Invalid mode: {mode}. Use 'overwrite', 'append', or 'scd2'")
 
@@ -120,59 +117,6 @@ class GoldWriter:
             item_type = self._sanitize_type_for_delta(dtype.item_type)
             return pa.map_(key_type, item_type)
         return dtype
-
-    def _flatten_for_csv(self, table: pa.Table) -> pa.Table:
-        """Convert complex types (list, struct) to JSON strings for CSV export."""
-        import json as json_module
-
-        new_columns = []
-        for i, field in enumerate(table.schema):
-            col = table.column(i)
-            if pa.types.is_list(field.type) or pa.types.is_large_list(field.type) or pa.types.is_struct(field.type):
-                # Convert to JSON strings
-                json_strings = [
-                    json_module.dumps(val.as_py()) if val.as_py() is not None else None
-                    for val in col
-                ]
-                new_columns.append(pa.array(json_strings, type=pa.string()))
-            else:
-                new_columns.append(col)
-
-        new_schema = pa.schema([
-            pa.field(f.name, pa.string() if pa.types.is_list(f.type) or pa.types.is_large_list(f.type) or pa.types.is_struct(f.type) else f.type, f.nullable)
-            for f in table.schema
-        ])
-        return pa.Table.from_arrays(new_columns, schema=new_schema)
-
-    @staticmethod
-    def _atomic_csv_write(
-        data: pa.Table,
-        target_path: Path,
-        write_options: pv.WriteOptions,
-    ) -> None:
-        """Write CSV atomically to avoid file lock issues on Windows.
-
-        Writes to a temporary file in the same directory, then renames.
-        This avoids WinError 32 when the target file is briefly locked.
-        """
-        target_dir = target_path.parent
-        fd, temp_path = tempfile.mkstemp(
-            suffix=".csv.tmp",
-            prefix=target_path.stem + "_",
-            dir=target_dir,
-        )
-        try:
-            os.close(fd)
-            pv.write_csv(data, temp_path, write_options=write_options)
-
-            if os.name == "nt" and target_path.exists():
-                target_path.unlink()
-
-            os.rename(temp_path, target_path)
-        except Exception:
-            if os.path.exists(temp_path):
-                os.unlink(temp_path)
-            raise
 
     def _to_arrow_table(self, records: list[dict[str, Any]]) -> pa.Table:
         """Convert records to PyArrow table, handling null types.
@@ -215,6 +159,7 @@ class GoldWriter:
     async def _write_simple(
         self,
         table_path: str,
+        table_name: str,
         records: list[dict[str, Any]],
         mode: str,
         partition_cols: list[str] | None,
@@ -243,26 +188,9 @@ class GoldWriter:
                 delay = 0.5 * (2 ** attempt) + random.uniform(0, 0.1)
                 await asyncio.sleep(delay)
 
-        if self.csv_path:
-            csv_full_path = Path(self.csv_path) / f"{table_path.replace(self.base_path, '')}.csv"
-            csv_full_path.parent.mkdir(parents=True, exist_ok=True)
-
-            # Build CSV write options from config
-            delimiter = self.csv_options.get("delimiter", ",")
-            include_header = self.csv_options.get("header", True)
-
-            write_options = pv.WriteOptions(
-                include_header=include_header,
-                delimiter=delimiter,
-            )
-
-            # Convert list/struct columns to JSON strings for CSV compatibility
-            csv_data = self._flatten_for_csv(arrow_data)
-
-            # Atomic write to avoid file lock issues on Windows
-            await self._run_in_executor(
-                lambda: self._atomic_csv_write(csv_data, csv_full_path, write_options)
-            )
+        # Delegate CSV export to CsvExporter if configured
+        if self.csv_exporter:
+            await self.csv_exporter.export(table_name, arrow_data)
 
     async def _write_scd2(
         self,

--- a/tests/unit/infrastructure/export/__init__.py
+++ b/tests/unit/infrastructure/export/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for export infrastructure."""

--- a/tests/unit/infrastructure/export/test_csv_exporter.py
+++ b/tests/unit/infrastructure/export/test_csv_exporter.py
@@ -1,0 +1,191 @@
+"""Unit tests for CsvExporter."""
+
+import json
+from pathlib import Path
+
+import pyarrow as pa
+import pytest
+
+from bioetl.infrastructure.export.csv_exporter import CsvExporter
+
+
+@pytest.mark.unit
+class TestCsvExporterInit:
+    """Tests for CsvExporter initialization."""
+
+    def test_init_with_defaults(self, tmp_path: Path) -> None:
+        """Test initialization with default parameters."""
+        exporter = CsvExporter(base_path=str(tmp_path))
+
+        assert exporter.base_path == tmp_path
+        assert exporter.delimiter == ","
+        assert exporter.header is True
+        assert exporter.encoding == "utf-8"
+
+    def test_init_with_custom_options(self, tmp_path: Path) -> None:
+        """Test initialization with custom parameters."""
+        exporter = CsvExporter(
+            base_path=str(tmp_path),
+            delimiter=";",
+            header=False,
+            encoding="latin-1",
+        )
+
+        assert exporter.delimiter == ";"
+        assert exporter.header is False
+        assert exporter.encoding == "latin-1"
+
+
+@pytest.mark.unit
+class TestCsvExporterFlatten:
+    """Tests for _flatten_for_csv method."""
+
+    def test_flatten_simple_types(self) -> None:
+        """Test that simple types are preserved."""
+        table = pa.Table.from_pydict({
+            "id": [1, 2],
+            "name": ["a", "b"],
+            "value": [1.5, 2.5],
+        })
+
+        result = CsvExporter._flatten_for_csv(table)
+
+        assert result.schema == table.schema
+        assert result.to_pydict() == table.to_pydict()
+
+    def test_flatten_list_type(self) -> None:
+        """Test that list types are converted to JSON strings."""
+        table = pa.Table.from_pydict({
+            "id": [1, 2],
+            "tags": [["a", "b"], ["c"]],
+        })
+
+        result = CsvExporter._flatten_for_csv(table)
+
+        assert pa.types.is_string(result.schema.field("tags").type)
+        assert result.column("tags").to_pylist() == ['["a", "b"]', '["c"]']
+
+    def test_flatten_struct_type(self) -> None:
+        """Test that struct types are converted to JSON strings."""
+        table = pa.Table.from_pydict({
+            "id": [1, 2],
+            "metadata": [{"key": "value1"}, {"key": "value2"}],
+        })
+
+        result = CsvExporter._flatten_for_csv(table)
+
+        assert pa.types.is_string(result.schema.field("metadata").type)
+        metadata_list = result.column("metadata").to_pylist()
+        assert json.loads(metadata_list[0]) == {"key": "value1"}
+        assert json.loads(metadata_list[1]) == {"key": "value2"}
+
+    def test_flatten_null_values(self) -> None:
+        """Test that null values in complex types are handled."""
+        table = pa.Table.from_pydict({
+            "id": [1, 2],
+            "tags": [["a", "b"], None],
+        })
+
+        result = CsvExporter._flatten_for_csv(table)
+
+        tags_list = result.column("tags").to_pylist()
+        assert tags_list[0] == '["a", "b"]'
+        assert tags_list[1] is None
+
+
+@pytest.mark.unit
+class TestCsvExporterExport:
+    """Tests for export method."""
+
+    @pytest.mark.asyncio
+    async def test_export_creates_file(self, tmp_path: Path) -> None:
+        """Test that export creates the CSV file."""
+        exporter = CsvExporter(base_path=str(tmp_path))
+        table = pa.Table.from_pydict({
+            "id": [1, 2],
+            "name": ["a", "b"],
+        })
+
+        result_path = await exporter.export("test_table", table)
+
+        assert result_path.exists()
+        assert result_path == tmp_path / "test_table.csv"
+
+    @pytest.mark.asyncio
+    async def test_export_creates_parent_directories(self, tmp_path: Path) -> None:
+        """Test that export creates parent directories if needed."""
+        nested_path = tmp_path / "nested" / "path"
+        exporter = CsvExporter(base_path=str(nested_path))
+        table = pa.Table.from_pydict({"id": [1]})
+
+        result_path = await exporter.export("table", table)
+
+        assert result_path.exists()
+        assert nested_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_export_with_custom_delimiter(self, tmp_path: Path) -> None:
+        """Test export with custom delimiter."""
+        exporter = CsvExporter(base_path=str(tmp_path), delimiter=";")
+        table = pa.Table.from_pydict({
+            "id": [1, 2],
+            "name": ["a", "b"],
+        })
+
+        result_path = await exporter.export("test", table)
+
+        content = result_path.read_text()
+        assert ";" in content
+        # PyArrow may quote string headers
+        assert '"id";"name"' in content or "id;name" in content
+
+    @pytest.mark.asyncio
+    async def test_export_without_header(self, tmp_path: Path) -> None:
+        """Test export without header row."""
+        exporter = CsvExporter(base_path=str(tmp_path), header=False)
+        table = pa.Table.from_pydict({
+            "id": [1],
+            "name": ["test"],
+        })
+
+        result_path = await exporter.export("test", table)
+
+        content = result_path.read_text()
+        assert "id" not in content
+        assert "name" not in content
+        assert "1" in content
+        assert "test" in content
+
+    @pytest.mark.asyncio
+    async def test_export_complex_types(self, tmp_path: Path) -> None:
+        """Test that complex types are properly serialized to JSON."""
+        exporter = CsvExporter(base_path=str(tmp_path))
+        table = pa.Table.from_pydict({
+            "id": [1],
+            "tags": [["tag1", "tag2"]],
+            "metadata": [{"key": "value"}],
+        })
+
+        result_path = await exporter.export("test", table)
+
+        content = result_path.read_text()
+        # CSV escapes inner quotes with double-quotes, so check for the tag content
+        assert "tag1" in content and "tag2" in content
+        assert "key" in content and "value" in content
+
+    @pytest.mark.asyncio
+    async def test_export_overwrites_existing_file(self, tmp_path: Path) -> None:
+        """Test that export overwrites existing file."""
+        exporter = CsvExporter(base_path=str(tmp_path))
+
+        # First export
+        table1 = pa.Table.from_pydict({"id": [1], "value": ["first"]})
+        await exporter.export("test", table1)
+
+        # Second export
+        table2 = pa.Table.from_pydict({"id": [2], "value": ["second"]})
+        result_path = await exporter.export("test", table2)
+
+        content = result_path.read_text()
+        assert "second" in content
+        assert "first" not in content


### PR DESCRIPTION
- Create CsvExporter class in infrastructure/export/ with:
  - Atomic file writes for Windows compatibility
  - Complex type (list, struct) to JSON string conversion
  - Configurable delimiter, header, encoding options

- Refactor DeltaWriter and GoldWriter to:
  - Accept optional CsvExporter via composition
  - Remove duplicated _flatten_for_csv and _atomic_csv_write methods
  - Simplify constructors by removing csv_path/csv_options params

- Update StorageFactory to:
  - Create CsvExporter instances for silver/gold layers
  - Inject exporters into writers via composition

This improves separation of concerns and eliminates ~150 lines of duplicated CSV export logic across the two writers.