### PR TITLE
Review BioETL refactoring plan and improvements

### DIFF
--- a/src/bioetl/application/registry.py
+++ b/src/bioetl/application/registry.py
@@ -123,3 +123,22 @@ class PipelineRegistry:
     def list_pipelines(cls) -> list[str]:
         """List all registered pipeline names."""
         return list(cls._registry.keys())
+
+    @classmethod
+    def is_initialized(cls) -> bool:
+        """Check if any pipelines are registered.
+
+        Returns:
+            True if registry contains at least one pipeline.
+        """
+        return bool(cls._registry)
+
+    @classmethod
+    def reset(cls) -> None:
+        """Clear all registered pipelines.
+
+        WARNING: For testing purposes only. Do not use in production code.
+        This method is intended for test isolation to ensure a clean registry
+        state between tests.
+        """
+        cls._registry.clear()

--- a/src/bioetl/composition/bootstrap.py
+++ b/src/bioetl/composition/bootstrap.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-# Factories are imported to ensure registration happens
-import bioetl.composition.factories.pipeline_factories  # noqa: F401
 from bioetl.application.core.checkpoint_manager import CheckpointManager
 from bioetl.application.core.executor import PipelineExecutor
 from bioetl.application.core.record_processor import RecordProcessor
@@ -128,7 +126,11 @@ def bootstrap_pipeline(
         filter_field: API field name to filter by (overrides config)
         query: Optional query string for data sources that support it
     """
-    from bioetl.domain.filter_config import InputFilterConfig
+    from bioetl.composition.builders import FilterConfigBuilder
+    from bioetl.composition.factories.pipeline_factories import register_all_pipelines
+
+    # Ensure factories are registered (idempotent)
+    register_all_pipelines()
 
     settings = get_settings()
     logger = bootstrap_logger(pipeline=pipeline_name, run_id=run_id)
@@ -145,33 +147,14 @@ def bootstrap_pipeline(
         query=query,
     )
 
-    # Build filter config from YAML defaults, CLI overrides
-    filter_config = None
-    yaml_filter = yaml_config.input_filter
-
-    # Determine effective values: CLI > YAML config
-    effective_csv = input_csv or yaml_filter.source_path
-    effective_column = filter_column or yaml_filter.column_name
-    effective_field = filter_field or yaml_filter.filter_field
-
-    # Enable filter if: CLI provides --input-csv OR config has enabled=true
-    filter_enabled = bool(input_csv) or yaml_filter.enabled
-
-    if filter_enabled and effective_csv:
-        filter_config = InputFilterConfig(
-            enabled=True,
-            source_path=effective_csv,
-            column_name=effective_column,
-            filter_field=effective_field,
-            batch_size=yaml_filter.batch_size,
-        )
-        logger.info(
-            "input_filter_enabled",
-            csv_path=effective_csv,
-            column=effective_column,
-            filter_field=effective_field,
-            source="cli" if input_csv else "config",
-        )
+    # Build filter config (CLI overrides YAML)
+    filter_config = FilterConfigBuilder.build(
+        yaml_filter=yaml_config.input_filter,
+        cli_csv=input_csv,
+        cli_column=filter_column,
+        cli_field=filter_field,
+        logger=logger,
+    )
 
     # Resolve pipeline factory from registry
     pipeline_def = PipelineRegistry.get(pipeline_name)

--- a/src/bioetl/composition/builders.py
+++ b/src/bioetl/composition/builders.py
@@ -1,0 +1,94 @@
+"""Configuration builders for composition layer.
+
+Handles merging of configuration from multiple sources (YAML, CLI)
+while keeping domain models pure. This module belongs to the composition
+layer and is responsible for translating infrastructure configs to domain configs.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from bioetl.domain.filter_config import InputFilterConfig
+
+if TYPE_CHECKING:
+    from structlog import BoundLogger
+
+    from bioetl.infrastructure.schemas.pipeline_config import (
+        InputFilterConfig as YamlInputFilterConfig,
+    )
+
+
+class FilterConfigBuilder:
+    """Builds InputFilterConfig from YAML config and CLI overrides.
+
+    This builder encapsulates the priority logic for merging configuration
+    from multiple sources:
+    - CLI arguments have highest priority (explicit user intent)
+    - YAML config provides defaults
+
+    Example:
+        >>> from bioetl.composition.builders import FilterConfigBuilder
+        >>> config = FilterConfigBuilder.build(
+        ...     yaml_filter=yaml_config.input_filter,
+        ...     cli_csv="/path/to/ids.csv",
+        ...     cli_column=None,  # Use YAML default
+        ...     cli_field=None,
+        ...     logger=logger,
+        ... )
+    """
+
+    @staticmethod
+    def build(
+        yaml_filter: YamlInputFilterConfig,
+        cli_csv: str | None,
+        cli_column: str | None,
+        cli_field: str | None,
+        logger: BoundLogger | None = None,
+    ) -> InputFilterConfig | None:
+        """Build filter config with CLI overrides.
+
+        Priority: CLI arguments > YAML config values.
+
+        Args:
+            yaml_filter: Filter configuration from YAML file.
+            cli_csv: CLI --input-csv argument (overrides yaml).
+            cli_column: CLI --filter-column argument (overrides yaml).
+            cli_field: CLI --filter-field argument (overrides yaml).
+            logger: Optional logger for debugging filter configuration.
+
+        Returns:
+            InputFilterConfig if filtering is enabled, None otherwise.
+            Filtering is enabled if either:
+            - CLI provides --input-csv argument, OR
+            - YAML config has enabled=true with a valid source_path
+        """
+        # Determine effective values: CLI > YAML
+        effective_csv = cli_csv or yaml_filter.source_path
+        effective_column = cli_column or yaml_filter.column_name
+        effective_field = cli_field or yaml_filter.filter_field
+
+        # Enable filter if: CLI provides --input-csv OR config has enabled=true
+        filter_enabled = bool(cli_csv) or yaml_filter.enabled
+
+        if not filter_enabled or not effective_csv:
+            return None
+
+        config = InputFilterConfig(
+            enabled=True,
+            source_path=effective_csv,
+            column_name=effective_column,
+            filter_field=effective_field,
+            batch_size=yaml_filter.batch_size,
+        )
+
+        if logger:
+            logger.info(
+                "input_filter_enabled",
+                csv_path=effective_csv,
+                column=effective_column,
+                filter_field=effective_field,
+                source="cli" if cli_csv else "config",
+            )
+
+        return config

--- a/src/bioetl/composition/factories/pipeline_factories.py
+++ b/src/bioetl/composition/factories/pipeline_factories.py
@@ -65,15 +65,38 @@ pubmed_publications_factory = GenericPipelineFactory(
     gold_schema=PubMedPublicationGoldSchema,
 )
 
-# Register all factories with the PipelineRegistry
-PipelineRegistry.register_factory(chembl_activity_factory)
-PipelineRegistry.register_factory(pubchem_compound_factory)
-PipelineRegistry.register_factory(uniprot_protein_factory)
-PipelineRegistry.register_factory(pubmed_publications_factory)
+# All factories for explicit registration
+_ALL_FACTORIES = [
+    chembl_activity_factory,
+    pubchem_compound_factory,
+    uniprot_protein_factory,
+    pubmed_publications_factory,
+]
+
+
+def register_all_pipelines() -> None:
+    """Explicitly register all pipeline factories.
+
+    Call this function once at application startup (e.g., in bootstrap).
+    Idempotent: safe to call multiple times.
+
+    Example:
+        >>> from bioetl.composition.factories.pipeline_factories import register_all_pipelines
+        >>> register_all_pipelines()
+        >>> PipelineRegistry.list_pipelines()
+        ['chembl_activity', 'pubchem_compound', 'uniprot_protein', 'pubmed_publications']
+    """
+    if PipelineRegistry.is_initialized():
+        return  # Already registered
+
+    for factory in _ALL_FACTORIES:
+        PipelineRegistry.register_factory(factory)
+
 
 __all__ = [
     "chembl_activity_factory",
     "pubchem_compound_factory",
     "pubmed_publications_factory",
+    "register_all_pipelines",
     "uniprot_protein_factory",
 ]

--- a/tests/architecture/test_layer_dependencies.py
+++ b/tests/architecture/test_layer_dependencies.py
@@ -687,3 +687,48 @@ def test_no_mutable_defaults_in_frozen_dataclasses(src_dir: Path) -> None:
         "Found mutable defaults in dataclasses (use field(default_factory=...) instead):\n"
         + "\n".join(f"  - {v}" for v in violations)
     )
+
+
+def test_pipeline_factories_no_side_effects_on_import() -> None:
+    """Importing pipeline_factories should not modify global state.
+
+    REQ-ARCH-017: Factory registration must be explicit via register_all_pipelines(),
+    not triggered automatically by importing the module. This ensures:
+    - Test isolation (registry can be reset between tests)
+    - Predictable initialization order
+    - No hidden dependencies on import order
+    """
+    import importlib
+    import sys
+
+    from bioetl.application.registry import PipelineRegistry
+
+    # Clear registry to start fresh
+    PipelineRegistry.reset()
+
+    # Remove module from cache to force reimport
+    module_name = "bioetl.composition.factories.pipeline_factories"
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+
+    # Import the module - should NOT register anything
+    import bioetl.composition.factories.pipeline_factories as pf
+
+    importlib.reload(pf)
+
+    # Registry should still be empty after import
+    registered = PipelineRegistry.list_pipelines()
+    assert registered == [], (
+        f"Importing pipeline_factories should not register pipelines automatically. "
+        f"Found registered: {registered}. "
+        f"Use register_all_pipelines() explicitly instead."
+    )
+
+    # Verify explicit registration works
+    pf.register_all_pipelines()
+    assert PipelineRegistry.is_initialized(), (
+        "register_all_pipelines() should register factories"
+    )
+
+    # Cleanup: ensure registry is populated for other tests
+    # (already done by register_all_pipelines above)

--- a/tests/unit/composition/__init__.py
+++ b/tests/unit/composition/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for composition layer."""

--- a/tests/unit/composition/test_builders.py
+++ b/tests/unit/composition/test_builders.py
@@ -1,0 +1,223 @@
+"""Tests for composition layer builders.
+
+Tests FilterConfigBuilder which merges YAML config with CLI overrides.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from bioetl.composition.builders import FilterConfigBuilder
+from bioetl.domain.filter_config import InputFilterConfig
+
+
+class TestFilterConfigBuilder:
+    """Tests for FilterConfigBuilder."""
+
+    @pytest.fixture
+    def yaml_filter_enabled(self) -> MagicMock:
+        """Create a mock YAML filter config with filtering enabled."""
+        mock = MagicMock()
+        mock.enabled = True
+        mock.source_path = "/yaml/path.csv"
+        mock.column_name = "yaml_col"
+        mock.filter_field = "yaml_field"
+        mock.batch_size = 100
+        return mock
+
+    @pytest.fixture
+    def yaml_filter_disabled(self) -> MagicMock:
+        """Create a mock YAML filter config with filtering disabled."""
+        mock = MagicMock()
+        mock.enabled = False
+        mock.source_path = None
+        mock.column_name = "default_col"
+        mock.filter_field = "default_field"
+        mock.batch_size = 100
+        return mock
+
+    def test_cli_overrides_yaml_values(self, yaml_filter_enabled: MagicMock) -> None:
+        """CLI arguments should override YAML values."""
+        result = FilterConfigBuilder.build(
+            yaml_filter=yaml_filter_enabled,
+            cli_csv="/cli/path.csv",
+            cli_column="cli_col",
+            cli_field="cli_field",
+        )
+
+        assert result is not None
+        assert result.source_path == "/cli/path.csv"
+        assert result.column_name == "cli_col"
+        assert result.filter_field == "cli_field"
+        assert result.enabled is True
+
+    def test_yaml_defaults_when_cli_none(self, yaml_filter_enabled: MagicMock) -> None:
+        """YAML values should be used when CLI args are None."""
+        result = FilterConfigBuilder.build(
+            yaml_filter=yaml_filter_enabled,
+            cli_csv=None,
+            cli_column=None,
+            cli_field=None,
+        )
+
+        assert result is not None
+        assert result.source_path == "/yaml/path.csv"
+        assert result.column_name == "yaml_col"
+        assert result.filter_field == "yaml_field"
+        assert result.batch_size == 100
+
+    def test_returns_none_when_disabled_and_no_cli(
+        self, yaml_filter_disabled: MagicMock
+    ) -> None:
+        """Should return None when filtering is disabled and no CLI csv provided."""
+        result = FilterConfigBuilder.build(
+            yaml_filter=yaml_filter_disabled,
+            cli_csv=None,
+            cli_column=None,
+            cli_field=None,
+        )
+
+        assert result is None
+
+    def test_cli_csv_enables_filter_even_when_yaml_disabled(
+        self, yaml_filter_disabled: MagicMock
+    ) -> None:
+        """Providing --input-csv should enable filtering even if YAML disabled."""
+        result = FilterConfigBuilder.build(
+            yaml_filter=yaml_filter_disabled,
+            cli_csv="/cli/path.csv",
+            cli_column="cli_col",
+            cli_field="cli_field",
+        )
+
+        assert result is not None
+        assert result.enabled is True
+        assert result.source_path == "/cli/path.csv"
+
+    def test_partial_cli_overrides(self, yaml_filter_enabled: MagicMock) -> None:
+        """CLI should only override provided values, use YAML for rest."""
+        result = FilterConfigBuilder.build(
+            yaml_filter=yaml_filter_enabled,
+            cli_csv="/cli/path.csv",  # Override
+            cli_column=None,  # Use YAML
+            cli_field=None,  # Use YAML
+        )
+
+        assert result is not None
+        assert result.source_path == "/cli/path.csv"
+        assert result.column_name == "yaml_col"  # From YAML
+        assert result.filter_field == "yaml_field"  # From YAML
+
+    def test_batch_size_from_yaml(self, yaml_filter_enabled: MagicMock) -> None:
+        """Batch size should always come from YAML config."""
+        yaml_filter_enabled.batch_size = 50
+
+        result = FilterConfigBuilder.build(
+            yaml_filter=yaml_filter_enabled,
+            cli_csv="/cli/path.csv",
+            cli_column=None,
+            cli_field=None,
+        )
+
+        assert result is not None
+        assert result.batch_size == 50
+
+    def test_returns_frozen_dataclass(self, yaml_filter_enabled: MagicMock) -> None:
+        """Result should be an immutable InputFilterConfig."""
+        result = FilterConfigBuilder.build(
+            yaml_filter=yaml_filter_enabled,
+            cli_csv=None,
+            cli_column=None,
+            cli_field=None,
+        )
+
+        assert result is not None
+        assert isinstance(result, InputFilterConfig)
+
+        # Verify immutability
+        with pytest.raises(AttributeError):
+            result.source_path = "/new/path.csv"  # type: ignore[misc]
+
+    def test_logger_called_when_filter_enabled(
+        self, yaml_filter_enabled: MagicMock
+    ) -> None:
+        """Logger should be called with filter config details."""
+        mock_logger = MagicMock()
+
+        FilterConfigBuilder.build(
+            yaml_filter=yaml_filter_enabled,
+            cli_csv="/cli/path.csv",
+            cli_column="col",
+            cli_field="field",
+            logger=mock_logger,
+        )
+
+        mock_logger.info.assert_called_once()
+        call_args = mock_logger.info.call_args
+        assert call_args[0][0] == "input_filter_enabled"
+        assert call_args[1]["csv_path"] == "/cli/path.csv"
+        assert call_args[1]["source"] == "cli"
+
+    def test_logger_reports_config_source_when_using_yaml(
+        self, yaml_filter_enabled: MagicMock
+    ) -> None:
+        """Logger should report 'config' as source when using YAML values."""
+        mock_logger = MagicMock()
+
+        FilterConfigBuilder.build(
+            yaml_filter=yaml_filter_enabled,
+            cli_csv=None,  # Not from CLI
+            cli_column=None,
+            cli_field=None,
+            logger=mock_logger,
+        )
+
+        mock_logger.info.assert_called_once()
+        call_args = mock_logger.info.call_args
+        assert call_args[1]["source"] == "config"
+
+    def test_logger_not_called_when_filter_disabled(
+        self, yaml_filter_disabled: MagicMock
+    ) -> None:
+        """Logger should not be called when filter is disabled."""
+        mock_logger = MagicMock()
+
+        FilterConfigBuilder.build(
+            yaml_filter=yaml_filter_disabled,
+            cli_csv=None,
+            cli_column=None,
+            cli_field=None,
+            logger=mock_logger,
+        )
+
+        mock_logger.info.assert_not_called()
+
+    def test_no_logger_no_error(self, yaml_filter_enabled: MagicMock) -> None:
+        """Should work without logger (logger=None)."""
+        result = FilterConfigBuilder.build(
+            yaml_filter=yaml_filter_enabled,
+            cli_csv="/path.csv",
+            cli_column="col",
+            cli_field="field",
+            logger=None,
+        )
+
+        assert result is not None
+
+    def test_enabled_but_no_source_path_returns_none(self) -> None:
+        """Should return None if enabled but no source path available."""
+        yaml_filter = MagicMock()
+        yaml_filter.enabled = True
+        yaml_filter.source_path = None  # No path in YAML
+        yaml_filter.column_name = "col"
+        yaml_filter.filter_field = "field"
+        yaml_filter.batch_size = 100
+
+        result = FilterConfigBuilder.build(
+            yaml_filter=yaml_filter,
+            cli_csv=None,  # No path from CLI either
+            cli_column=None,
+            cli_field=None,
+        )
+
+        assert result is None


### PR DESCRIPTION
- Add PipelineRegistry.reset() and is_initialized() for test isolation
- Replace module-level factory registration with explicit register_all_pipelines()
- Create FilterConfigBuilder to encapsulate config merging logic
- Add architecture test for no side-effects on import (REQ-ARCH-017)
- Add comprehensive unit tests for FilterConfigBuilder

This refactoring improves testability by removing implicit global state mutations on import and separates configuration concerns from bootstrap.

bootstrap_pipeline() reduced from 143 to 129 lines.