### PR TITLE
Create base transformer class for shared logic

### DIFF
--- a/src/bioetl/application/core/__init__.py
+++ b/src/bioetl/application/core/__init__.py
@@ -10,6 +10,7 @@ Configuration consolidation (all in bioetl.domain.config):
 """
 
 from bioetl.application.core.base import BasePipeline
+from bioetl.application.core.base_transformer import BaseTransformer
 from bioetl.application.core.checkpoint_manager import CheckpointManager
 from bioetl.application.core.lock_manager import LockManager
 from bioetl.application.core.pipeline_services import PipelineServices
@@ -23,8 +24,9 @@ from bioetl.domain.config import (
 )
 
 __all__ = [
-    # Base pipeline
+    # Base classes
     "BasePipeline",
+    "BaseTransformer",
     # Decomposed config (ADR-0005) - consolidated in domain.config
     "PipelineConfig",
     "RuntimeConfig",

--- a/src/bioetl/application/core/base_transformer.py
+++ b/src/bioetl/application/core/base_transformer.py
@@ -1,0 +1,136 @@
+"""Base Transformer class for Bronze → Silver transformations.
+
+Provides common functionality for all entity transformers:
+- Content hash generation (RULES.md §2.8.1)
+- JSON serialization of complex fields
+- Entity to SilverRecord conversion with lineage field renaming
+
+Implements DRY principle by extracting shared logic from entity transformers.
+"""
+
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, cast
+
+from bioetl.domain.transformations import generate_content_hash
+from bioetl.domain.types import ContentHash
+
+if TYPE_CHECKING:
+    from bioetl.domain.context import PipelineContext
+    from bioetl.domain.types import BronzeRecord, SilverRecord
+
+
+class BaseTransformer(ABC):
+    """Abstract base class for Bronze → Silver transformers.
+
+    Provides:
+    - `compute_content_hash()`: Canonical content hash generation (RULES.md §2.8.1)
+    - `serialize_json()`: JSON serialization for complex fields (dict/list)
+    - `entity_to_silver_record()`: Entity → SilverRecord conversion with lineage fields
+
+    Subclasses MUST implement:
+    - `transform()`: Entity-specific transformation logic
+    """
+
+    def __init__(self, provider: str) -> None:
+        """Initialize transformer with provider name.
+
+        Args:
+            provider: Data provider identifier (e.g., 'chembl', 'pubchem').
+        """
+        self.provider = provider
+
+    def compute_content_hash(
+        self,
+        business_data: dict[str, Any],
+        *,
+        exclude_none: bool = True,
+    ) -> ContentHash:
+        """Generate canonical content hash for record versioning.
+
+        Implements RULES.md §2.8.1:
+        - sha256(provider + canonical_json(record))
+        - Normalizes NaN/Inf → null, floats → round(val, 10), dates → ISO
+
+        Args:
+            business_data: Business data dictionary (excluding meta fields).
+            exclude_none: Whether to exclude None values from hash calculation.
+
+        Returns:
+            ContentHash: SHA256 hash of normalized record.
+        """
+        return generate_content_hash(
+            business_data,
+            self.provider,
+            exclude_none=exclude_none,
+        )
+
+    @staticmethod
+    def serialize_json(value: Any) -> str | None:
+        """Serialize complex values (dict/list) to JSON string.
+
+        Used for storing nested structures in Silver layer as JSON strings.
+
+        Args:
+            value: Value to serialize.
+
+        Returns:
+            JSON string for dict/list, str(value) for other types, None for None.
+        """
+        if value is None:
+            return None
+        if isinstance(value, (dict, list)):
+            return json.dumps(value, ensure_ascii=False)
+        return str(value)
+
+    @staticmethod
+    def entity_to_silver_record(entity: Any) -> dict[str, Any]:
+        """Convert Domain Entity to SilverRecord format.
+
+        Handles lineage fields renaming and formatting:
+        - run_id → _run_id (str)
+        - run_type → _run_type (str value)
+        - source_batch_id → _source_batch_id (str)
+        - ingestion_ts → _ingestion_ts (ISO string)
+
+        Args:
+            entity: Domain entity with __dict__ attribute.
+
+        Returns:
+            SilverRecord dictionary with renamed lineage fields.
+        """
+        silver_record = entity.__dict__.copy()
+
+        # Handle lineage fields renaming and formatting
+        silver_record["_run_id"] = str(silver_record.pop("run_id"))
+        silver_record["_run_type"] = str(silver_record.pop("run_type").value)
+        silver_record["_source_batch_id"] = str(silver_record.pop("source_batch_id"))
+        silver_record["_ingestion_ts"] = silver_record.pop("ingestion_ts").isoformat()
+
+        return silver_record
+
+    @abstractmethod
+    async def transform(
+        self,
+        context: PipelineContext,
+        record: BronzeRecord,
+    ) -> SilverRecord | None:
+        """Transform Bronze record to Silver format.
+
+        Subclasses MUST implement entity-specific transformation logic:
+        1. Extract and validate required fields
+        2. Build business_data dictionary
+        3. Generate entity_id and content_hash
+        4. Create Domain Entity
+        5. Convert to SilverRecord using entity_to_silver_record()
+
+        Args:
+            context: Pipeline context with run_id, run_type, logger.
+            record: Raw Bronze record from data source.
+
+        Returns:
+            SilverRecord if transformation successful, None if record should be skipped.
+        """
+        ...

--- a/src/bioetl/application/pipelines/chembl/activity_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/activity_transformer.py
@@ -5,12 +5,11 @@ Transforms Bronze records to Silver format (Activity entity inflation).
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING, Any, cast
 
+from bioetl.application.core.base_transformer import BaseTransformer
 from bioetl.domain.entities import Activity
 from bioetl.domain.transformations import (
-    generate_content_hash,
     generate_entity_id,
     safe_float,
     safe_int,
@@ -21,20 +20,11 @@ if TYPE_CHECKING:
     from bioetl.domain.types import BronzeRecord, SilverRecord
 
 
-def _serialize_json(value: Any) -> str | None:
-    """Serialize complex values (dict/list) to JSON string."""
-    if value is None:
-        return None
-    if isinstance(value, (dict, list)):
-        return json.dumps(value, ensure_ascii=False)
-    return str(value)
-
-
-class ActivityTransformer:
+class ActivityTransformer(BaseTransformer):
     """Transforms ChEMBL bronze records to silver."""
 
     def __init__(self, provider: str = "chembl"):
-        self.provider = provider
+        super().__init__(provider)
 
     async def transform(
         self,
@@ -101,7 +91,7 @@ class ActivityTransformer:
                 "standard_flag": safe_int(record.get("standard_flag")),
                 # Derived metrics
                 "pchembl_value": safe_float(record.get("pchembl_value")),
-                "ligand_efficiency": _serialize_json(record.get("ligand_efficiency")),
+                "ligand_efficiency": self.serialize_json(record.get("ligand_efficiency")),
                 # Units ontology
                 "qudt_units": record.get("qudt_units"),
                 "uo_units": record.get("uo_units"),
@@ -114,19 +104,15 @@ class ActivityTransformer:
                 "data_validity_description": record.get("data_validity_description"),
                 "potential_duplicate": safe_int(record.get("potential_duplicate")),
                 # Action and properties
-                "action_type": _serialize_json(record.get("action_type")),
-                "activity_properties": _serialize_json(
+                "action_type": self.serialize_json(record.get("action_type")),
+                "activity_properties": self.serialize_json(
                     record.get("activity_properties")
                 ),
                 "toid": safe_int(record.get("toid")),
             }
 
             # Generate content hash based on business data (exclude None values)
-            content_hash = generate_content_hash(
-                business_data,
-                self.provider,
-                exclude_none=True,
-            )
+            content_hash = self.compute_content_hash(business_data, exclude_none=True)
 
             entity = Activity(
                 entity_id=entity_id,
@@ -144,13 +130,6 @@ class ActivityTransformer:
             return None
 
         # 2. Convert Entity to SilverRecord for storage
-        # Optimization: Use __dict__ copy instead of manual field mapping (50+ fields)
-        silver_record = entity.__dict__.copy()
-
-        # Handle lineage fields renaming and formatting
-        silver_record["_run_id"] = str(silver_record.pop("run_id"))
-        silver_record["_run_type"] = str(silver_record.pop("run_type").value)
-        silver_record["_source_batch_id"] = str(silver_record.pop("source_batch_id"))
-        silver_record["_ingestion_ts"] = silver_record.pop("ingestion_ts").isoformat()
+        silver_record = self.entity_to_silver_record(entity)
 
         return cast("SilverRecord", silver_record)

--- a/src/bioetl/application/pipelines/chembl/assay_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/assay_transformer.py
@@ -5,12 +5,11 @@ Transforms Bronze records to Silver format (Assay entity inflation).
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING, Any, cast
 
+from bioetl.application.core.base_transformer import BaseTransformer
 from bioetl.domain.entities import Assay
 from bioetl.domain.transformations import (
-    generate_content_hash,
     generate_entity_id,
     safe_int,
 )
@@ -20,20 +19,11 @@ if TYPE_CHECKING:
     from bioetl.domain.types import BronzeRecord, SilverRecord
 
 
-def _serialize_json(value: Any) -> str | None:
-    """Serialize complex values (dict/list) to JSON string."""
-    if value is None:
-        return None
-    if isinstance(value, (dict, list)):
-        return json.dumps(value, ensure_ascii=False)
-    return str(value)
-
-
-class AssayTransformer:
+class AssayTransformer(BaseTransformer):
     """Transforms ChEMBL assay bronze records to silver."""
 
     def __init__(self, provider: str = "chembl"):
-        self.provider = provider
+        super().__init__(provider)
 
     async def transform(
         self,
@@ -88,19 +78,18 @@ class AssayTransformer:
                 "relationship_type": record.get("relationship_type"),
                 "relationship_description": record.get("relationship_description"),
                 # Variant information
-                "variant_sequence": _serialize_json(record.get("variant_sequence")),
+                "variant_sequence": self.serialize_json(record.get("variant_sequence")),
                 # Complex fields (stored as JSON strings)
-                "assay_classifications": _serialize_json(
+                "assay_classifications": self.serialize_json(
                     record.get("assay_classifications")
                 ),
-                "assay_parameters": _serialize_json(record.get("assay_parameters")),
+                "assay_parameters": self.serialize_json(record.get("assay_parameters")),
             }
 
             # Generate content hash based on business data (exclude None values)
-            content_hash = generate_content_hash(
-                {k: v for k, v in business_data.items() if v is not None},
-                self.provider,
-            )
+            # Note: Original used explicit dict comprehension, but compute_content_hash
+            # with exclude_none=True is equivalent
+            content_hash = self.compute_content_hash(business_data, exclude_none=True)
 
             entity = Assay(
                 entity_id=entity_id,
@@ -120,12 +109,6 @@ class AssayTransformer:
             return None
 
         # Convert Entity to SilverRecord for storage
-        silver_record = entity.__dict__.copy()
-
-        # Handle lineage fields renaming and formatting
-        silver_record["_run_id"] = str(silver_record.pop("run_id"))
-        silver_record["_run_type"] = str(silver_record.pop("run_type").value)
-        silver_record["_source_batch_id"] = str(silver_record.pop("source_batch_id"))
-        silver_record["_ingestion_ts"] = silver_record.pop("ingestion_ts").isoformat()
+        silver_record = self.entity_to_silver_record(entity)
 
         return cast("SilverRecord", silver_record)

--- a/src/bioetl/application/pipelines/chembl/document_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/document_transformer.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
 
+from bioetl.application.core.base_transformer import BaseTransformer
 from bioetl.domain.entities import Document
 from bioetl.domain.transformations import (
-    generate_content_hash,
     generate_entity_id,
     safe_int,
 )
@@ -19,11 +19,11 @@ if TYPE_CHECKING:
     from bioetl.domain.types import BronzeRecord, SilverRecord
 
 
-class DocumentTransformer:
+class DocumentTransformer(BaseTransformer):
     """Transforms ChEMBL bronze document records to silver."""
 
     def __init__(self, provider: str = "chembl"):
-        self.provider = provider
+        super().__init__(provider)
 
     async def transform(
         self,
@@ -67,11 +67,7 @@ class DocumentTransformer:
                 "src_id": safe_int(record.get("src_id")),
             }
 
-            content_hash = generate_content_hash(
-                business_data,
-                self.provider,
-                exclude_none=True,
-            )
+            content_hash = self.compute_content_hash(business_data, exclude_none=True)
 
             entity = Document(
                 entity_id=entity_id,
@@ -91,12 +87,6 @@ class DocumentTransformer:
             return None
 
         # Convert Entity to SilverRecord for storage
-        silver_record = entity.__dict__.copy()
-
-        # Handle lineage fields renaming and formatting
-        silver_record["_run_id"] = str(silver_record.pop("run_id"))
-        silver_record["_run_type"] = str(silver_record.pop("run_type").value)
-        silver_record["_source_batch_id"] = str(silver_record.pop("source_batch_id"))
-        silver_record["_ingestion_ts"] = silver_record.pop("ingestion_ts").isoformat()
+        silver_record = self.entity_to_silver_record(entity)
 
         return cast("SilverRecord", silver_record)

--- a/src/bioetl/application/pipelines/chembl/molecule_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/molecule_transformer.py
@@ -5,12 +5,11 @@ Transforms Bronze records to Silver format (Molecule entity inflation).
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING, Any, cast
 
+from bioetl.application.core.base_transformer import BaseTransformer
 from bioetl.domain.entities import Molecule
 from bioetl.domain.transformations import (
-    generate_content_hash,
     generate_entity_id,
     safe_int,
 )
@@ -20,20 +19,11 @@ if TYPE_CHECKING:
     from bioetl.domain.types import BronzeRecord, SilverRecord
 
 
-def _serialize_json(value: Any) -> str | None:
-    """Serialize complex values (dict/list) to JSON string."""
-    if value is None:
-        return None
-    if isinstance(value, (dict, list)):
-        return json.dumps(value, ensure_ascii=False)
-    return str(value)
-
-
-class MoleculeTransformer:
+class MoleculeTransformer(BaseTransformer):
     """Transforms ChEMBL bronze molecule records to silver."""
 
     def __init__(self, provider: str = "chembl"):
-        self.provider = provider
+        super().__init__(provider)
 
     async def transform(
         self,
@@ -75,19 +65,15 @@ class MoleculeTransformer:
                 "inorganic_flag": safe_int(record.get("inorganic_flag")),
                 "polymer_flag": safe_int(record.get("polymer_flag")),
                 # Complex fields (JSON serialized)
-                "molecule_hierarchy": _serialize_json(record.get("molecule_hierarchy")),
-                "molecule_properties": _serialize_json(record.get("molecule_properties")),
-                "molecule_structures": _serialize_json(record.get("molecule_structures")),
-                "molecule_synonyms": _serialize_json(record.get("molecule_synonyms")),
-                "cross_references": _serialize_json(record.get("cross_references")),
-                "atc_classifications": _serialize_json(record.get("atc_classifications")),
+                "molecule_hierarchy": self.serialize_json(record.get("molecule_hierarchy")),
+                "molecule_properties": self.serialize_json(record.get("molecule_properties")),
+                "molecule_structures": self.serialize_json(record.get("molecule_structures")),
+                "molecule_synonyms": self.serialize_json(record.get("molecule_synonyms")),
+                "cross_references": self.serialize_json(record.get("cross_references")),
+                "atc_classifications": self.serialize_json(record.get("atc_classifications")),
             }
 
-            content_hash = generate_content_hash(
-                business_data,
-                self.provider,
-                exclude_none=True,
-            )
+            content_hash = self.compute_content_hash(business_data, exclude_none=True)
 
             entity = Molecule(
                 entity_id=entity_id,
@@ -107,12 +93,6 @@ class MoleculeTransformer:
             return None
 
         # Convert Entity to SilverRecord for storage
-        silver_record = entity.__dict__.copy()
-
-        # Handle lineage fields renaming and formatting
-        silver_record["_run_id"] = str(silver_record.pop("run_id"))
-        silver_record["_run_type"] = str(silver_record.pop("run_type").value)
-        silver_record["_source_batch_id"] = str(silver_record.pop("source_batch_id"))
-        silver_record["_ingestion_ts"] = silver_record.pop("ingestion_ts").isoformat()
+        silver_record = self.entity_to_silver_record(entity)
 
         return cast("SilverRecord", silver_record)

--- a/src/bioetl/application/pipelines/chembl/target_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/target_transformer.py
@@ -5,12 +5,11 @@ Transforms Bronze records to Silver format (Target entity inflation).
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING, Any, cast
 
+from bioetl.application.core.base_transformer import BaseTransformer
 from bioetl.domain.entities import Target
 from bioetl.domain.transformations import (
-    generate_content_hash,
     generate_entity_id,
     safe_int,
 )
@@ -20,20 +19,11 @@ if TYPE_CHECKING:
     from bioetl.domain.types import BronzeRecord, SilverRecord
 
 
-def _serialize_json(value: Any) -> str | None:
-    """Serialize complex values (dict/list) to JSON string."""
-    if value is None:
-        return None
-    if isinstance(value, (dict, list)):
-        return json.dumps(value, ensure_ascii=False)
-    return str(value)
-
-
-class TargetTransformer:
+class TargetTransformer(BaseTransformer):
     """Transforms ChEMBL bronze target records to silver."""
 
     def __init__(self, provider: str = "chembl"):
-        self.provider = provider
+        super().__init__(provider)
 
     async def transform(
         self,
@@ -63,15 +53,11 @@ class TargetTransformer:
                 "tax_id": safe_int(record.get("tax_id")),
                 "species_group_flag": record.get("species_group_flag"),
                 # Complex fields (JSON serialized)
-                "target_components": _serialize_json(record.get("target_components")),
-                "cross_references": _serialize_json(record.get("cross_references")),
+                "target_components": self.serialize_json(record.get("target_components")),
+                "cross_references": self.serialize_json(record.get("cross_references")),
             }
 
-            content_hash = generate_content_hash(
-                business_data,
-                self.provider,
-                exclude_none=True,
-            )
+            content_hash = self.compute_content_hash(business_data, exclude_none=True)
 
             entity = Target(
                 entity_id=entity_id,
@@ -91,12 +77,6 @@ class TargetTransformer:
             return None
 
         # Convert Entity to SilverRecord for storage
-        silver_record = entity.__dict__.copy()
-
-        # Handle lineage fields renaming and formatting
-        silver_record["_run_id"] = str(silver_record.pop("run_id"))
-        silver_record["_run_type"] = str(silver_record.pop("run_type").value)
-        silver_record["_source_batch_id"] = str(silver_record.pop("source_batch_id"))
-        silver_record["_ingestion_ts"] = silver_record.pop("ingestion_ts").isoformat()
+        silver_record = self.entity_to_silver_record(entity)
 
         return cast("SilverRecord", silver_record)

--- a/src/bioetl/application/pipelines/pubchem/compound.py
+++ b/src/bioetl/application/pipelines/pubchem/compound.py
@@ -23,7 +23,7 @@ class PubChemCompoundPipeline(BasePipeline):
         self, context: PipelineContext, record: BronzeRecord
     ) -> SilverRecord | None:
         """Transform raw PubChem record to Silver format."""
-        return self._transformer.transform(record)
+        return await self._transformer.transform(context, record)
 
     def extract_watermark(
         self, context: PipelineContext, record: dict[str, Any]

--- a/src/bioetl/application/pipelines/pubchem/transformer.py
+++ b/src/bioetl/application/pipelines/pubchem/transformer.py
@@ -2,19 +2,27 @@
 
 from __future__ import annotations
 
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
-from bioetl.domain.transformations import generate_content_hash, generate_entity_id
-from bioetl.domain.types import BronzeRecord, SilverRecord
+from bioetl.application.core.base_transformer import BaseTransformer
+from bioetl.domain.transformations import generate_entity_id
+
+if TYPE_CHECKING:
+    from bioetl.domain.context import PipelineContext
+    from bioetl.domain.types import BronzeRecord, SilverRecord
 
 
-class PubChemCompoundTransformer:
+class PubChemCompoundTransformer(BaseTransformer):
     """Transformer for PubChem compound records."""
 
     def __init__(self, provider: str = "pubchem"):
-        self.provider = provider
+        super().__init__(provider)
 
-    def transform(self, record: BronzeRecord) -> SilverRecord | None:
+    async def transform(
+        self,
+        context: PipelineContext,
+        record: BronzeRecord,
+    ) -> SilverRecord | None:
         """Transform raw PubChem record to Silver format."""
         cid = record.get("cid")
         if not cid:
@@ -40,7 +48,7 @@ class PubChemCompoundTransformer:
         normalized["entity_id"] = entity_id
 
         # Генерация content_hash согласно RULES.md §2.8.1
-        content_hash = generate_content_hash(normalized, self.provider)
+        content_hash = self.compute_content_hash(normalized, exclude_none=False)
         normalized["content_hash"] = content_hash
 
         return cast("SilverRecord", normalized)

--- a/src/bioetl/application/pipelines/pubmed/publications.py
+++ b/src/bioetl/application/pipelines/pubmed/publications.py
@@ -25,7 +25,7 @@ class PubMedPublicationsPipeline(BasePipeline):
         record: BronzeRecord,
     ) -> SilverRecord | None:
         """Трансформирует сырую XML-запись в формат Silver."""
-        return self._transformer.transform(context, record, self.logger)
+        return await self._transformer.transform(context, record)
 
     def extract_watermark(
         self, context: PipelineContext, record: dict[str, Any]

--- a/src/bioetl/application/pipelines/pubmed/transformer.py
+++ b/src/bioetl/application/pipelines/pubmed/transformer.py
@@ -3,15 +3,13 @@
 from __future__ import annotations
 
 import xml.etree.ElementTree as ET
-from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, cast
 
+from bioetl.application.core.base_transformer import BaseTransformer
 from bioetl.domain.entities import Publication
-from bioetl.domain.transformations import generate_content_hash, generate_entity_id
+from bioetl.domain.transformations import generate_entity_id
 
 if TYPE_CHECKING:
-    from structlog.stdlib import BoundLogger
-
     from bioetl.domain.context import PipelineContext
     from bioetl.domain.types import BronzeRecord, SilverRecord
 
@@ -31,17 +29,16 @@ def _parse_author_list(article_node: ET.Element) -> list[str]:
     return authors
 
 
-class PubMedPublicationTransformer:
+class PubMedPublicationTransformer(BaseTransformer):
     """Transformer for PubMed publication records."""
 
     def __init__(self, provider: str = "pubmed"):
-        self.provider = provider
+        super().__init__(provider)
 
-    def transform(
+    async def transform(
         self,
         context: PipelineContext,
         record: BronzeRecord,
-        logger: BoundLogger,
     ) -> SilverRecord | None:
         """Трансформирует сырую XML-запись в формат Silver."""
         raw_xml = record.get("_raw_xml")
@@ -77,7 +74,7 @@ class PubMedPublicationTransformer:
                 provider=self.provider,
                 id_field="pmid",
             )
-            content_hash = generate_content_hash(business_data, self.provider)
+            content_hash = self.compute_content_hash(business_data, exclude_none=False)
 
             publication = Publication(
                 entity_id=entity_id,
@@ -88,22 +85,11 @@ class PubMedPublicationTransformer:
                 **business_data,
             )
 
-            silver_record: dict[str, Any] = {
-                "entity_id": publication.entity_id,
-                "content_hash": publication.content_hash,
-                "pmid": publication.pmid,
-                "title": publication.title,
-                "abstract": publication.abstract,
-                "journal": publication.journal,
-                "publication_year": publication.publication_year,
-                "authors": publication.authors,
-                "_run_id": str(context.run_id),
-                "_run_type": str(context.run_type.value),
-                "_ingestion_ts": datetime.now(UTC).isoformat(),
-            }
+            # Convert Entity to SilverRecord for storage
+            silver_record = self.entity_to_silver_record(publication)
 
             return cast("SilverRecord", silver_record)
 
         except ET.ParseError as e:
-            logger.warning("XML_parse_error", error=str(e), pmid=record.get("pmid"))
+            context.logger.warning("XML_parse_error", error=str(e), pmid=record.get("pmid"))
             return None

--- a/src/bioetl/application/pipelines/uniprot/protein.py
+++ b/src/bioetl/application/pipelines/uniprot/protein.py
@@ -23,7 +23,7 @@ class UniProtProteinPipeline(BasePipeline):
         self, context: PipelineContext, record: BronzeRecord
     ) -> SilverRecord | None:
         """Transform raw UniProt record to Silver format."""
-        return self._transformer.transform(record)
+        return await self._transformer.transform(context, record)
 
     def extract_watermark(
         self, context: PipelineContext, record: dict[str, Any]

--- a/src/bioetl/application/pipelines/uniprot/transformer.py
+++ b/src/bioetl/application/pipelines/uniprot/transformer.py
@@ -2,19 +2,27 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
-from bioetl.domain.transformations import generate_content_hash, generate_entity_id
-from bioetl.domain.types import BronzeRecord, SilverRecord
+from bioetl.application.core.base_transformer import BaseTransformer
+from bioetl.domain.transformations import generate_entity_id
+
+if TYPE_CHECKING:
+    from bioetl.domain.context import PipelineContext
+    from bioetl.domain.types import BronzeRecord, SilverRecord
 
 
-class UniProtProteinTransformer:
+class UniProtProteinTransformer(BaseTransformer):
     """Transformer for UniProt protein records."""
 
     def __init__(self, provider: str = "uniprot"):
-        self.provider = provider
+        super().__init__(provider)
 
-    def transform(self, record: BronzeRecord) -> SilverRecord | None:
+    async def transform(
+        self,
+        context: PipelineContext,
+        record: BronzeRecord,
+    ) -> SilverRecord | None:
         """Transform raw UniProt record to Silver format."""
         accession = record.get("primaryAccession")
         if not accession:
@@ -42,7 +50,7 @@ class UniProtProteinTransformer:
         normalized["entity_id"] = entity_id
 
         # Генерация content_hash согласно RULES.md §2.8.1
-        content_hash = generate_content_hash(normalized, self.provider)
+        content_hash = self.compute_content_hash(normalized, exclude_none=False)
         normalized["content_hash"] = content_hash
 
         return cast("SilverRecord", normalized)


### PR DESCRIPTION
- Create BaseTransformer ABC in application/core/base_transformer.py
- Provide compute_content_hash(), serialize_json(), entity_to_silver_record()
- Refactor all 8 transformers to inherit from BaseTransformer:
  - ChEMBL: Activity, Assay, Molecule, Target, Document
  - PubChem: Compound
  - UniProt: Protein
  - PubMed: Publication
- Unify transform() signature to async (context, record) -> SilverRecord | None
- Update pipelines to await async transform calls
- Content hash algorithm unchanged (verified by tests)