### PR TITLE
Analyze ChEMBL molecule pipeline and missing fields

### DIFF
--- a/src/bioetl/application/pipelines/chembl/molecule_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/molecule_transformer.py
@@ -66,6 +66,21 @@ class MoleculeTransformer(BaseTransformer):
                 "withdrawn_flag": record.get("withdrawn_flag"),
                 "inorganic_flag": safe_int(record.get("inorganic_flag")),
                 "polymer_flag": safe_int(record.get("polymer_flag")),
+                "chirality": safe_int(record.get("chirality")),
+                "dosed_ingredient": safe_int(record.get("dosed_ingredient")),
+                "availability_type": safe_int(record.get("availability_type")),
+                # Withdrawn metadata
+                "withdrawn_year": safe_int(record.get("withdrawn_year")),
+                "withdrawn_country": self.serialize_json(record.get("withdrawn_country")),
+                "withdrawn_reason": self.serialize_json(record.get("withdrawn_reason")),
+                # USAN naming
+                "usan_stem": record.get("usan_stem"),
+                "usan_stem_definition": record.get("usan_stem_definition"),
+                "usan_substem": record.get("usan_substem"),
+                "usan_year": safe_int(record.get("usan_year")),
+                # Other metadata
+                "helm_notation": record.get("helm_notation"),
+                "molecule_species": record.get("molecule_species"),
                 # Complex fields (JSON serialized for history)
                 "molecule_hierarchy": self.serialize_json(
                     record.get("molecule_hierarchy")
@@ -118,10 +133,12 @@ class MoleculeTransformer(BaseTransformer):
             return {
                 "hierarchy_parent_chembl_id": None,
                 "hierarchy_active_chembl_id": None,
+                "hierarchy_child_chembl_id": None,
             }
         return {
             "hierarchy_parent_chembl_id": data.get("parent_chembl_id"),
             "hierarchy_active_chembl_id": data.get("active_chembl_id"),
+            "hierarchy_child_chembl_id": data.get("molecule_chembl_id"),
         }
 
     def _extract_properties(self, data: dict[str, Any] | None) -> dict[str, Any]:
@@ -138,6 +155,12 @@ class MoleculeTransformer(BaseTransformer):
                 "property_heavy_atoms": None,
                 "property_aromatic_rings": None,
                 "property_qed_weighted": None,
+                "property_acd_logd": None,
+                "property_acd_logp": None,
+                "property_acd_most_apka": None,
+                "property_acd_most_bpka": None,
+                "property_full_molformula": None,
+                "property_ro3_pass": None,
             }
         return {
             "property_alogp": safe_float(data.get("alogp")),
@@ -153,6 +176,12 @@ class MoleculeTransformer(BaseTransformer):
             "property_heavy_atoms": safe_int(data.get("heavy_atoms")),
             "property_aromatic_rings": safe_int(data.get("aromatic_rings")),
             "property_qed_weighted": safe_float(data.get("qed_weighted")),
+            "property_acd_logd": safe_float(data.get("acd_logd")),
+            "property_acd_logp": safe_float(data.get("acd_logp")),
+            "property_acd_most_apka": safe_float(data.get("acd_most_apka")),
+            "property_acd_most_bpka": safe_float(data.get("acd_most_bpka")),
+            "property_full_molformula": data.get("full_molformula"),
+            "property_ro3_pass": data.get("ro3_pass"),
         }
 
     def _extract_structures(self, data: dict[str, Any] | None) -> dict[str, Any]:

--- a/src/bioetl/domain/entities.py
+++ b/src/bioetl/domain/entities.py
@@ -360,6 +360,24 @@ class Molecule(BaseEntity):
     withdrawn_flag: bool | None = None
     inorganic_flag: int | None = None
     polymer_flag: int | None = None
+    chirality: int | None = None  # -1 (single), 0 (achiral), 1 (racemic), 2 (mixture)
+    dosed_ingredient: int | None = None
+    availability_type: int | None = None  # -2 to 2
+
+    # Withdrawn metadata
+    withdrawn_year: int | None = None
+    withdrawn_country: str | None = None  # JSON string for multiple countries
+    withdrawn_reason: str | None = None  # JSON string for multiple reasons
+
+    # USAN naming
+    usan_stem: str | None = None
+    usan_stem_definition: str | None = None
+    usan_substem: str | None = None
+    usan_year: int | None = None
+
+    # Other metadata
+    helm_notation: str | None = None
+    molecule_species: str | None = None  # ACID, BASE, NEUTRAL, ZWITTERION
 
     # Complex fields (JSON serialized)
     molecule_hierarchy: str | None = None  # JSON string
@@ -372,6 +390,7 @@ class Molecule(BaseEntity):
     # Flattened Hierarchy
     hierarchy_parent_chembl_id: str | None = None
     hierarchy_active_chembl_id: str | None = None
+    hierarchy_child_chembl_id: str | None = None  # For parent molecules
 
     # Flattened Properties
     property_alogp: float | None = None
@@ -385,6 +404,12 @@ class Molecule(BaseEntity):
     property_heavy_atoms: int | None = None
     property_aromatic_rings: int | None = None
     property_qed_weighted: float | None = None
+    property_acd_logd: float | None = None
+    property_acd_logp: float | None = None
+    property_acd_most_apka: float | None = None
+    property_acd_most_bpka: float | None = None
+    property_full_molformula: str | None = None
+    property_ro3_pass: str | None = None  # "Y" or "N"
 
     # Flattened Structures
     structure_canonical_smiles: str | None = None

--- a/tests/unit/application/pipelines/test_chembl_transformers.py
+++ b/tests/unit/application/pipelines/test_chembl_transformers.py
@@ -259,6 +259,115 @@ class TestMoleculeTransformer:
         assert isinstance(result.get("molecule_hierarchy"), str)
         assert isinstance(result.get("molecule_properties"), str)
 
+    @pytest.mark.asyncio
+    async def test_transform_with_new_core_fields(self, transformer, mock_context):
+        """Test transformation with chirality, availability_type, and other new fields."""
+        record = {
+            "molecule_chembl_id": "CHEMBL456",
+            "chirality": 1,  # racemic
+            "dosed_ingredient": 1,
+            "availability_type": 2,
+            "molecule_species": "NEUTRAL",
+            "helm_notation": "PEPTIDE1{A.G.K}$$$$",
+        }
+
+        result = await transformer.transform(mock_context, record)
+
+        assert result is not None
+        assert result["chirality"] == 1
+        assert result["dosed_ingredient"] == 1
+        assert result["availability_type"] == 2
+        assert result["molecule_species"] == "NEUTRAL"
+        assert result["helm_notation"] == "PEPTIDE1{A.G.K}$$$$"
+
+    @pytest.mark.asyncio
+    async def test_transform_with_withdrawn_fields(self, transformer, mock_context):
+        """Test transformation with withdrawn metadata fields."""
+        record = {
+            "molecule_chembl_id": "CHEMBL789",
+            "withdrawn_flag": True,
+            "withdrawn_year": 2010,
+            "withdrawn_country": ["United States", "United Kingdom"],
+            "withdrawn_reason": ["Hepatotoxicity", "Cardiotoxicity"],
+        }
+
+        result = await transformer.transform(mock_context, record)
+
+        assert result is not None
+        assert result["withdrawn_flag"] is True
+        assert result["withdrawn_year"] == 2010
+        # JSON serialized fields
+        assert isinstance(result["withdrawn_country"], str)
+        assert isinstance(result["withdrawn_reason"], str)
+        assert "United States" in result["withdrawn_country"]
+        assert "Hepatotoxicity" in result["withdrawn_reason"]
+
+    @pytest.mark.asyncio
+    async def test_transform_with_usan_fields(self, transformer, mock_context):
+        """Test transformation with USAN naming fields."""
+        record = {
+            "molecule_chembl_id": "CHEMBL1234",
+            "usan_stem": "-mab",
+            "usan_stem_definition": "monoclonal antibody",
+            "usan_substem": "-xi-",
+            "usan_year": 2015,
+        }
+
+        result = await transformer.transform(mock_context, record)
+
+        assert result is not None
+        assert result["usan_stem"] == "-mab"
+        assert result["usan_stem_definition"] == "monoclonal antibody"
+        assert result["usan_substem"] == "-xi-"
+        assert result["usan_year"] == 2015
+
+    @pytest.mark.asyncio
+    async def test_transform_with_new_properties(self, transformer, mock_context):
+        """Test transformation with new ACD and other property fields."""
+        record = {
+            "molecule_chembl_id": "CHEMBL5678",
+            "molecule_properties": {
+                "alogp": 2.5,
+                "mw_freebase": 300.5,
+                "acd_logd": 1.8,
+                "acd_logp": 2.3,
+                "acd_most_apka": 4.5,
+                "acd_most_bpka": 9.2,
+                "full_molformula": "C15H12O3",
+                "ro3_pass": "Y",
+            },
+        }
+
+        result = await transformer.transform(mock_context, record)
+
+        assert result is not None
+        assert result["property_alogp"] == 2.5
+        assert result["property_acd_logd"] == 1.8
+        assert result["property_acd_logp"] == 2.3
+        assert result["property_acd_most_apka"] == 4.5
+        assert result["property_acd_most_bpka"] == 9.2
+        assert result["property_full_molformula"] == "C15H12O3"
+        assert result["property_ro3_pass"] == "Y"
+
+    @pytest.mark.asyncio
+    async def test_transform_with_hierarchy_child(self, transformer, mock_context):
+        """Test transformation extracts child_chembl_id from hierarchy."""
+        record = {
+            "molecule_chembl_id": "CHEMBL9999",
+            "molecule_hierarchy": {
+                "parent_chembl_id": "CHEMBL1000",
+                "active_chembl_id": "CHEMBL1001",
+                "molecule_chembl_id": "CHEMBL9999",
+            },
+        }
+
+        result = await transformer.transform(mock_context, record)
+
+        assert result is not None
+        assert result["hierarchy_parent_chembl_id"] == "CHEMBL1000"
+        assert result["hierarchy_active_chembl_id"] == "CHEMBL1001"
+        assert result["hierarchy_child_chembl_id"] == "CHEMBL9999"
+
 
 @pytest.mark.unit
 class TestTargetTransformer:


### PR DESCRIPTION
Add new fields from ChEMBL molecule API endpoint:
- Core: chirality, dosed_ingredient, availability_type
- Withdrawn: withdrawn_year, withdrawn_country, withdrawn_reason
- USAN: usan_stem, usan_stem_definition, usan_substem, usan_year
- Other: helm_notation, molecule_species
- Properties: acd_logd, acd_logp, acd_most_apka, acd_most_bpka, full_molformula, ro3_pass
- Hierarchy: child_chembl_id

Includes transformer updates and 6 new unit tests.