### PR TITLE
Extract GoldValidator from RecordProcessor

### DIFF
--- a/src/bioetl/application/core/gold_validator.py
+++ b/src/bioetl/application/core/gold_validator.py
@@ -1,0 +1,66 @@
+"""Gold layer schema validator.
+
+Отвечает за валидацию записей перед записью в Gold слой (SRP).
+Выделен из RecordProcessor для соблюдения принципа единственной ответственности.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import pandera as pa
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationResult:
+    """Результат валидации записей.
+
+    Attributes:
+        valid: True, если валидация прошла успешно.
+        errors: Список ошибок валидации (None если valid=True).
+    """
+
+    valid: bool
+    errors: list[str] = field(default_factory=list)
+
+
+class GoldValidator:
+    """Валидатор записей для Gold слоя.
+
+    Проверяет записи на соответствие Pandera-схеме перед записью в Gold.
+    Если схема не задана, валидация всегда успешна.
+
+    Attributes:
+        _schema: Pandera-схема для валидации (опционально).
+    """
+
+    def __init__(self, schema: pa.DataFrameSchema | None) -> None:
+        """Инициализирует валидатор.
+
+        Args:
+            schema: Pandera-схема для валидации. Если None, валидация пропускается.
+        """
+        self._schema = schema
+
+    def validate(self, records: list[dict[str, Any]]) -> ValidationResult:
+        """Валидирует список записей.
+
+        Args:
+            records: Список записей для валидации.
+
+        Returns:
+            ValidationResult с результатом валидации.
+        """
+        if not self._schema or not records:
+            return ValidationResult(valid=True)
+
+        import pandas as pd
+
+        df = pd.DataFrame(records)
+        try:
+            self._schema.validate(df, lazy=True)
+            return ValidationResult(valid=True)
+        except Exception as e:
+            return ValidationResult(valid=False, errors=[str(e)])

--- a/src/bioetl/application/core/record_processor.py
+++ b/src/bioetl/application/core/record_processor.py
@@ -11,8 +11,9 @@ from typing import TYPE_CHECKING, Any
 
 from bioetl.application.core.batch_metrics import BatchMetricsRecorder
 from bioetl.application.core.config import RecordProcessorConfig
+from bioetl.application.core.gold_validator import GoldValidator
 from bioetl.application.core.quarantine_manager import QuarantineManager
-from bioetl.domain.exceptions import DataQualityThresholdError
+from bioetl.domain.exceptions import DataQualityThresholdError, SchemaViolationError
 
 if TYPE_CHECKING:
     from bioetl.application.core.pipeline_services import PipelineServices
@@ -62,9 +63,11 @@ class RecordProcessor:
         self._provider = config.provider
         self._entity_type = config.entity_type
         self._silver_schema = config.silver_schema
-        self._gold_schema = config.gold_schema
         self._dq_config = config.dq_config
         self._table_config = config.table_config
+
+        # Gold layer validator (SRP)
+        self._gold_validator = GoldValidator(config.gold_schema)
 
         # Instantiate Metrics Recorder
         pipeline_label = f"{self._provider}_{self._entity_type}"
@@ -254,18 +257,10 @@ class RecordProcessor:
         )
 
     async def _write_gold_batch(self, records: list[dict[str, Any]]) -> None:
-        # Validate Gold records if schema is present
-        if self._gold_schema:
-            import pandas as pd
-
-            df = pd.DataFrame(records)
-            try:
-                # Pandera validation
-                self._gold_schema.validate(df, lazy=True)
-            except Exception as e:
-                # Re-wrap in DQ error or let bubble up depending on strategy
-                # For now, we let it bubble up to be caught by the outer loop
-                raise e
+        # Validate Gold records using dedicated validator (SRP)
+        result = self._gold_validator.validate(records)
+        if not result.valid:
+            raise SchemaViolationError("gold", result.errors)
 
         # Use configured table name or default
         table_name = (

--- a/tests/unit/application/core/test_gold_validator.py
+++ b/tests/unit/application/core/test_gold_validator.py
@@ -1,0 +1,184 @@
+"""Unit tests for GoldValidator."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from bioetl.application.core.gold_validator import GoldValidator, ValidationResult
+
+
+@pytest.mark.unit
+class TestValidationResult:
+    """Tests for ValidationResult dataclass."""
+
+    def test_valid_result(self):
+        """Test creating a valid result."""
+        result = ValidationResult(valid=True)
+        assert result.valid is True
+        assert result.errors == []
+
+    def test_invalid_result_with_errors(self):
+        """Test creating an invalid result with errors."""
+        errors = ["Error 1", "Error 2"]
+        result = ValidationResult(valid=False, errors=errors)
+        assert result.valid is False
+        assert result.errors == errors
+
+    def test_result_is_immutable(self):
+        """Test that ValidationResult is immutable (frozen)."""
+        result = ValidationResult(valid=True)
+        with pytest.raises(AttributeError):
+            result.valid = False  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestGoldValidatorInit:
+    """Tests for GoldValidator initialization."""
+
+    def test_init_with_schema(self):
+        """Test initialization with a schema."""
+        mock_schema = MagicMock()
+        validator = GoldValidator(mock_schema)
+        assert validator._schema is mock_schema
+
+    def test_init_without_schema(self):
+        """Test initialization without a schema."""
+        validator = GoldValidator(None)
+        assert validator._schema is None
+
+
+@pytest.mark.unit
+class TestGoldValidatorValidate:
+    """Tests for GoldValidator.validate method."""
+
+    def test_validate_without_schema_returns_valid(self):
+        """Test that validation without schema always returns valid."""
+        validator = GoldValidator(None)
+        records = [{"id": 1, "value": "test"}]
+
+        result = validator.validate(records)
+
+        assert result.valid is True
+        assert result.errors == []
+
+    def test_validate_empty_records_returns_valid(self):
+        """Test that validation of empty records always returns valid."""
+        mock_schema = MagicMock()
+        validator = GoldValidator(mock_schema)
+
+        result = validator.validate([])
+
+        assert result.valid is True
+        assert result.errors == []
+        mock_schema.validate.assert_not_called()
+
+    def test_validate_with_valid_records(self):
+        """Test validation with valid records."""
+        mock_schema = MagicMock()
+        mock_schema.validate.return_value = MagicMock()  # No exception = valid
+        validator = GoldValidator(mock_schema)
+        records = [{"id": 1, "value": "test"}]
+
+        result = validator.validate(records)
+
+        assert result.valid is True
+        assert result.errors == []
+        mock_schema.validate.assert_called_once()
+
+    def test_validate_with_invalid_records(self):
+        """Test validation with invalid records."""
+        mock_schema = MagicMock()
+        mock_schema.validate.side_effect = ValueError("Schema validation failed: missing 'name'")
+        validator = GoldValidator(mock_schema)
+        records = [{"id": 1}]  # Missing 'name' field
+
+        result = validator.validate(records)
+
+        assert result.valid is False
+        assert len(result.errors) == 1
+        assert "Schema validation failed" in result.errors[0]
+
+    def test_validate_converts_records_to_dataframe(self):
+        """Test that records are converted to DataFrame for validation."""
+        mock_schema = MagicMock()
+        validator = GoldValidator(mock_schema)
+        records = [{"id": 1, "name": "test1"}, {"id": 2, "name": "test2"}]
+
+        validator.validate(records)
+
+        # Verify DataFrame was passed to validate
+        call_args = mock_schema.validate.call_args
+        df = call_args[0][0]  # First positional argument
+        assert len(df) == 2
+        assert list(df.columns) == ["id", "name"]
+
+    def test_validate_uses_lazy_mode(self):
+        """Test that validation uses lazy=True."""
+        mock_schema = MagicMock()
+        validator = GoldValidator(mock_schema)
+        records = [{"id": 1}]
+
+        validator.validate(records)
+
+        mock_schema.validate.assert_called_once()
+        call_kwargs = mock_schema.validate.call_args[1]
+        assert call_kwargs.get("lazy") is True
+
+    def test_validate_captures_multiple_errors(self):
+        """Test that validation captures error message from exception."""
+        mock_schema = MagicMock()
+        error_message = "Multiple errors: field1 invalid, field2 missing"
+        mock_schema.validate.side_effect = Exception(error_message)
+        validator = GoldValidator(mock_schema)
+        records = [{"id": 1}]
+
+        result = validator.validate(records)
+
+        assert result.valid is False
+        assert error_message in result.errors[0]
+
+
+@pytest.mark.unit
+class TestGoldValidatorIntegration:
+    """Integration-like tests for GoldValidator with real Pandera schema."""
+
+    def test_validate_with_pandera_schema_valid(self):
+        """Test validation with a real Pandera schema - valid case."""
+        import pandera.pandas as pa
+
+        schema = pa.DataFrameSchema(
+            {
+                "id": pa.Column(int),
+                "name": pa.Column(str),
+            }
+        )
+        validator = GoldValidator(schema)
+        records = [
+            {"id": 1, "name": "test1"},
+            {"id": 2, "name": "test2"},
+        ]
+
+        result = validator.validate(records)
+
+        assert result.valid is True
+        assert result.errors == []
+
+    def test_validate_with_pandera_schema_invalid(self):
+        """Test validation with a real Pandera schema - invalid case."""
+        import pandera.pandas as pa
+
+        schema = pa.DataFrameSchema(
+            {
+                "id": pa.Column(int),
+                "name": pa.Column(str),
+            }
+        )
+        validator = GoldValidator(schema)
+        records = [
+            {"id": "not_an_int", "name": "test1"},  # Invalid: id should be int
+        ]
+
+        result = validator.validate(records)
+
+        assert result.valid is False
+        assert len(result.errors) > 0


### PR DESCRIPTION
- Create GoldValidator class in separate file for SRP compliance
- Move Gold layer schema validation logic to dedicated component
- Remove lazy pandas import from _write_gold_batch method
- Add ValidationResult dataclass for structured validation results
- Update RecordProcessor to use GoldValidator via composition
- Add comprehensive unit tests for GoldValidator