### PR TITLE
Fix undefined validated_records variable in tests

### DIFF
--- a/src/bioetl/application/core/record_processor.py
+++ b/src/bioetl/application/core/record_processor.py
@@ -276,7 +276,7 @@ class RecordProcessor:
             write_mode = "append"
         await self._storage.write_gold(
             table_name=table_name,
-            records=validated_records,
+            records=records,
             primary_keys=self._table_config.primary_keys,
             mode=write_mode,
         )


### PR DESCRIPTION
…ords

The _write_gold_batch method referenced an undefined variable validated_records when writing to gold storage. This caused a NameError that failed 29 tests across unit, integration, and e2e test suites.

The fix uses the records parameter that was already validated by the GoldValidator.validate() call above.