### PR TITLE
Add health_check method to PubMedAdapter

### DIFF
--- a/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
+++ b/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
@@ -1,6 +1,7 @@
 # src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
 from __future__ import annotations
 
+import time
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Self
@@ -183,7 +184,15 @@ class PubMedAdapter:
             yield record
 
     async def health_check(self) -> HealthStatus:
-        """Check PubMed API availability."""
+        """Проверка доступности PubMed API.
+
+        Выполняет lightweight запрос к esearch endpoint.
+
+        Returns:
+            HealthStatus.HEALTHY — API доступен
+            HealthStatus.DEGRADED — медленный отклик (>5 сек)
+            HealthStatus.UNHEALTHY — ошибка или timeout
+        """
         try:
             # Use esearch for a lightweight check
             params = {
@@ -196,15 +205,34 @@ class PubMedAdapter:
             if self.api_key:
                 params["api_key"] = self.api_key
 
+            start_time = time.monotonic()
             response = await self.http_client.get(
                 f"{ENTREZ_API_BASE}esearch.fcgi", params=params
             )
-            return (
-                HealthStatus.HEALTHY
-                if response.status_code == 200
-                else HealthStatus.UNHEALTHY
+            elapsed = time.monotonic() - start_time
+
+            if response.status_code != 200:
+                self.logger.warning(
+                    "pubmed_health_check_failed",
+                    status_code=response.status_code,
+                )
+                return HealthStatus.UNHEALTHY
+
+            # Медленный отклик = degraded
+            if elapsed > 5.0:
+                self.logger.warning(
+                    "pubmed_health_check_slow",
+                    elapsed_seconds=round(elapsed, 2),
+                )
+                return HealthStatus.DEGRADED
+
+            return HealthStatus.HEALTHY
+
+        except Exception as e:
+            self.logger.warning(
+                "pubmed_health_check_failed",
+                error=str(e),
             )
-        except Exception:
             return HealthStatus.UNHEALTHY
 
     async def aclose(self) -> None:

--- a/tests/unit/infrastructure/adapters/pubmed/test_pubmed_client.py
+++ b/tests/unit/infrastructure/adapters/pubmed/test_pubmed_client.py
@@ -1,10 +1,11 @@
 # tests/unit/infrastructure/adapters/pubmed/test_pubmed_client.py
 """Unit tests for PubMedAdapter."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.adapters.pubmed.pubmed_client import PubMedAdapter
 
 
@@ -117,3 +118,92 @@ async def test_aclose_no_resource_leak_after_context_exit(adapter):
     # After context exit, _client should still be closable via aclose
     # In real usage, __aexit__ already closed it, but aclose should be safe
     await adapter.aclose()
+
+
+# =============================================================================
+# health_check tests
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_health_check_returns_healthy(adapter, mock_http_client):
+    """Test health_check returns HEALTHY when API responds 200 quickly."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_http_client.get = AsyncMock(return_value=mock_response)
+
+    result = await adapter.health_check()
+
+    assert result == HealthStatus.HEALTHY
+    mock_http_client.get.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_health_check_returns_unhealthy_on_error(adapter, mock_http_client):
+    """Test health_check returns UNHEALTHY on exception."""
+    mock_http_client.get = AsyncMock(side_effect=Exception("Connection error"))
+
+    result = await adapter.health_check()
+
+    assert result == HealthStatus.UNHEALTHY
+
+
+@pytest.mark.asyncio
+async def test_health_check_returns_unhealthy_on_non_200(
+    adapter, mock_http_client, mock_logger
+):
+    """Test health_check returns UNHEALTHY on non-200 status code."""
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_http_client.get = AsyncMock(return_value=mock_response)
+
+    result = await adapter.health_check()
+
+    assert result == HealthStatus.UNHEALTHY
+    mock_logger.warning.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_health_check_returns_degraded_on_slow_response(
+    adapter, mock_http_client, mock_logger
+):
+    """Test health_check returns DEGRADED when response takes >5 seconds."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_http_client.get = AsyncMock(return_value=mock_response)
+
+    # Simulate slow response by patching time.monotonic
+    call_count = 0
+
+    def mock_monotonic():
+        nonlocal call_count
+        call_count += 1
+        # First call (start_time) returns 0, second call returns 6 (elapsed = 6 sec)
+        return 0.0 if call_count == 1 else 6.0
+
+    with patch(
+        "bioetl.infrastructure.adapters.pubmed.pubmed_client.time.monotonic",
+        side_effect=mock_monotonic,
+    ):
+        result = await adapter.health_check()
+
+    assert result == HealthStatus.DEGRADED
+    mock_logger.warning.assert_called_once()
+    # Verify the warning was about slow response
+    call_args = mock_logger.warning.call_args
+    assert call_args[0][0] == "pubmed_health_check_slow"
+
+
+@pytest.mark.asyncio
+async def test_health_check_logs_error_on_exception(
+    adapter, mock_http_client, mock_logger
+):
+    """Test health_check logs error details on exception."""
+    mock_http_client.get = AsyncMock(side_effect=Exception("Network timeout"))
+
+    await adapter.health_check()
+
+    mock_logger.warning.assert_called_once()
+    call_args = mock_logger.warning.call_args
+    assert call_args[0][0] == "pubmed_health_check_failed"
+    assert "Network timeout" in call_args[1]["error"]


### PR DESCRIPTION
- Add timing measurement using time.monotonic()
- Return DEGRADED when response takes >5 seconds
- Add structured logging for slow responses and failures
- Update docstring with Russian description per project standards
- Add 5 unit tests for health_check functionality:
  * test_health_check_returns_healthy
  * test_health_check_returns_unhealthy_on_error
  * test_health_check_returns_unhealthy_on_non_200
  * test_health_check_returns_degraded_on_slow_response
  * test_health_check_logs_error_on_exception

Closes: add-pubmed-health-check