### PR TITLE
Add type hints to registry pipeline factory

### DIFF
--- a/src/bioetl/composition/factories/generic_factory.py
+++ b/src/bioetl/composition/factories/generic_factory.py
@@ -24,8 +24,6 @@ from bioetl.infrastructure.config import load_pipeline_config, yaml_config_to_do
 from bioetl.infrastructure.validation import NoOpGoldValidator, PanderaGoldValidator
 
 if TYPE_CHECKING:
-    from uuid import UUID
-
     import pyarrow as pa
     import structlog
 
@@ -34,6 +32,7 @@ if TYPE_CHECKING:
     from bioetl.domain.config import RuntimeConfig
     from bioetl.domain.filter_config import InputFilterConfig
     from bioetl.domain.ports import DataSourcePort, TracingPort
+    from bioetl.domain.types import RunID
     from bioetl.infrastructure.config import Settings
     from bioetl.infrastructure.schemas.pipeline_config import PipelineYamlConfig
 
@@ -155,7 +154,7 @@ class GenericPipelineFactory(Generic[TPipeline]):
 
     def create_with_services(
         self,
-        run_id: UUID,
+        run_id: RunID,
         runtime: RuntimeConfig,
         settings: Settings,
         logger: structlog.BoundLogger,
@@ -200,11 +199,11 @@ class GenericPipelineFactory(Generic[TPipeline]):
 
     def create_runner(
         self,
-        run_id: UUID,
+        run_id: RunID,
         runtime: RuntimeConfig,
         settings: Settings,
         logger: structlog.BoundLogger,
-        tracer: Any,
+        tracer: TracingPort | None,
         filter_config: InputFilterConfig | None = None,
         config: PipelineYamlConfig | None = None,
     ) -> PipelineRunner:
@@ -278,7 +277,7 @@ class GenericPipelineFactory(Generic[TPipeline]):
         self,
         pipeline: TPipeline,
         logger: structlog.BoundLogger,
-        run_id: UUID,
+        run_id: RunID,
         resume: bool,
     ) -> CheckpointManager:
         """Create configured CheckpointManager."""

--- a/src/bioetl/composition/registry.py
+++ b/src/bioetl/composition/registry.py
@@ -3,9 +3,19 @@
 MOVED to composition layer to fix dependency direction.
 """
 
-from typing import Any, ClassVar, NamedTuple, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, Protocol, runtime_checkable
 
 import pyarrow as pa
+
+if TYPE_CHECKING:
+    from bioetl.application.core.base import BasePipeline
+    from bioetl.application.core.runner import PipelineRunner
+    from bioetl.domain.config import RuntimeConfig
+    from bioetl.domain.filter_config import InputFilterConfig
+    from bioetl.domain.ports import LoggerPort, TracingPort
+    from bioetl.domain.types import RunID
+    from bioetl.infrastructure.config import Settings
+    from bioetl.infrastructure.schemas.pipeline_config import PipelineYamlConfig
 
 
 @runtime_checkable
@@ -16,21 +26,26 @@ class PipelineFactoryProtocol(Protocol):
     silver_schema: pa.Schema | None
 
     def create_with_services(
-        self, run_id: Any, runtime: Any, settings: Any, logger: Any, **kwargs: Any
-    ) -> Any:
+        self,
+        run_id: "RunID",
+        runtime: "RuntimeConfig",
+        settings: "Settings",
+        logger: "LoggerPort",
+        **kwargs: Any,
+    ) -> "BasePipeline":
         """Create pipeline with services."""
         ...
 
     def create_runner(
         self,
-        run_id: Any,
-        runtime: Any,
-        settings: Any,
-        logger: Any,
-        tracer: Any,
-        filter_config: Any | None = None,
-        config: Any | None = None,
-    ) -> Any:
+        run_id: "RunID",
+        runtime: "RuntimeConfig",
+        settings: "Settings",
+        logger: "LoggerPort",
+        tracer: "TracingPort | None",
+        filter_config: "InputFilterConfig | None" = None,
+        config: "PipelineYamlConfig | None" = None,
+    ) -> "PipelineRunner":
         """Create pipeline runner."""
         ...
 


### PR DESCRIPTION
Replace Any types with domain types in registry.py:
- RunID, RuntimeConfig, Settings, LoggerPort for method parameters
- TracingPort, InputFilterConfig, PipelineYamlConfig for optional params
- BasePipeline and PipelineRunner for return types
- Keep **kwargs: Any for extensibility

Update GenericPipelineFactory to align with Protocol:
- Use RunID instead of UUID for run_id parameter
- Use TracingPort | None instead of Any for tracer parameter

This improves type safety and enables mypy to catch type errors in factory implementations.