### PR TITLE
Create FilterableDataSourcePort protocol

### DIFF
--- a/src/bioetl/application/core/filtered_data_source.py
+++ b/src/bioetl/application/core/filtered_data_source.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Self
 
+from bioetl.domain.ports import FilterableDataSourcePort
+
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
@@ -163,18 +165,20 @@ class FilteredDataSource:
         # Note: External filter_ids/filter_field are ignored -
         # this class manages its own filter state from InputFilterConfig
         _ = filter_ids, filter_field  # Mark as intentionally unused
-        if self._filter_config.enabled and self._filter_ids:
-            # Check if adapter supports filtering (ChEMBL-specific extension)
-            if not hasattr(self._data_source, "fetch_filtered"):
+        configured_filter_field = self._filter_config.filter_field
+        if self._filter_config.enabled and self._filter_ids and configured_filter_field:
+            # Check if adapter supports filtering via FilterableDataSourcePort
+            if not isinstance(self._data_source, FilterableDataSourcePort):
                 raise TypeError(
-                    f"Adapter {self._data_source.provider_name} does not support "
-                    "fetch_filtered(). Filtering requires an adapter with this method."
+                    f"Adapter {self._data_source.provider_name} does not implement "
+                    "FilterableDataSourcePort. Filtering requires an adapter "
+                    "with fetch_filtered() method."
                 )
             # Filtered fetch using adapter-specific method
             async for record in self._data_source.fetch_filtered(
                 entity_type=entity_type,
                 filter_ids=self._filter_ids,
-                filter_field=self._filter_config.filter_field,
+                filter_field=configured_filter_field,
                 limit=limit,
             ):
                 yield record

--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -80,6 +80,7 @@ from bioetl.domain.filter_config import (
 from bioetl.domain.ports import (
     CheckpointPort,
     DataSourcePort,
+    FilterableDataSourcePort,
     GoldValidatorPort,
     InputFilterPort,
     LockPort,
@@ -176,6 +177,7 @@ __all__ = [
     # Ports
     "CheckpointPort",
     "DataSourcePort",
+    "FilterableDataSourcePort",
     "GoldValidatorPort",
     "InputFilterPort",
     "LockPort",

--- a/src/bioetl/domain/ports.py
+++ b/src/bioetl/domain/ports.py
@@ -114,6 +114,51 @@ class DataSourcePort(Protocol):
 
 
 @runtime_checkable
+class FilterableDataSourcePort(DataSourcePort, Protocol):
+    """Extended DataSourcePort that supports filtering at API level.
+
+    This protocol formalizes the contract for data sources that can perform
+    filtering directly at the source level (e.g., ChEMBL's molecule_chembl_id__in).
+
+    Adapters implementing this protocol allow FilteredDataSource to delegate
+    filtering to the API instead of filtering records after retrieval.
+
+    Example:
+        >>> if isinstance(data_source, FilterableDataSourcePort):
+        ...     async for record in data_source.fetch_filtered(
+        ...         entity_type="activity",
+        ...         filter_ids=["CHEMBL25", "CHEMBL192"],
+        ...         filter_field="molecule_chembl_id",
+        ...     ):
+        ...         process(record)
+    """
+
+    def fetch_filtered(
+        self,
+        entity_type: str,
+        filter_ids: list[str],
+        filter_field: str,
+        limit: int | None = None,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Fetch records filtered by specific IDs at the source level.
+
+        Args:
+            entity_type: Type of entity to fetch (e.g., 'activity', 'molecule').
+            filter_ids: List of IDs to filter by (passed to API filter).
+            filter_field: Field name to filter on (e.g., 'molecule_chembl_id').
+            limit: Maximum number of records to fetch.
+
+        Yields:
+            Dictionary records matching the filter criteria.
+
+        Note:
+            This is NOT an async def because async generator functions
+            return AsyncIterator directly without needing to be awaited.
+        """
+        ...
+
+
+@runtime_checkable
 class InputFilterPort(Protocol):
     """Port for loading filter IDs from external sources.
 
@@ -642,6 +687,7 @@ class GoldValidatorPort(Protocol):
 __all__ = [
     "CheckpointPort",
     "DataSourcePort",
+    "FilterableDataSourcePort",
     "GoldValidatorPort",
     "InputFilterPort",
     "LockPort",
@@ -649,4 +695,5 @@ __all__ = [
     "MetricsPort",
     "QuarantinePort",
     "StoragePort",
+    "TracingPort",
 ]

--- a/src/bioetl/infrastructure/adapters/chembl/client.py
+++ b/src/bioetl/infrastructure/adapters/chembl/client.py
@@ -71,7 +71,8 @@ ENTITY_PLURAL = {
 class ChemblAdapter(BaseHttpAdapter):
     """ChEMBL data source adapter.
 
-    Implements DataSourcePort for fetching data from ChEMBL database.
+    Implements DataSourcePort and FilterableDataSourcePort for fetching data
+    from ChEMBL database with support for API-level filtering.
 
     Args:
         http_client: UnifiedHTTPClient instance
@@ -83,6 +84,10 @@ class ChemblAdapter(BaseHttpAdapter):
         - HEALTHY: Uses configured batch_size
         - DEGRADED: Uses batch_size ÷ 2 to reduce load
         - UNHEALTHY: Raises CriticalError to prevent futile requests
+
+    FilterableDataSourcePort:
+        Implements fetch_filtered() for efficient API-level filtering using
+        ChEMBL's filter query parameters (e.g., molecule_chembl_id__in).
     """
 
     http_client: UnifiedHTTPClient
@@ -333,7 +338,7 @@ class ChemblAdapter(BaseHttpAdapter):
     ) -> AsyncIterator[dict[str, Any]]:
         """Fetch records from ChEMBL with ID filtering.
 
-        This is a ChEMBL-specific extension not part of DataSourcePort.
+        Implements FilterableDataSourcePort.fetch_filtered() for API-level filtering.
 
         Args:
             entity_type: Type of entity to fetch

--- a/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
+++ b/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
@@ -22,7 +22,7 @@ ENTREZ_API_BASE = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/"
 class PubMedAdapter:
     """PubMed adapter using UnifiedHTTPClient.
 
-    Implements DataSourcePort for PubMed data extraction.
+    Implements DataSourcePort and FilterableDataSourcePort for PubMed data extraction.
 
     Args:
         http_client: UnifiedHTTPClient instance for making HTTP requests.
@@ -30,6 +30,9 @@ class PubMedAdapter:
         email: Email address for NCBI API (required).
         api_key: Optional NCBI API key for higher rate limits.
         batch_size: Number of records to fetch per batch.
+
+    FilterableDataSourcePort:
+        Implements fetch_filtered() for direct PMID-based fetching without search.
     """
 
     http_client: UnifiedHTTPClient
@@ -137,10 +140,13 @@ class PubMedAdapter:
         self,
         entity_type: str,
         filter_ids: list[str],
-        filter_field: str | None = None,
+        filter_field: str = "pmid",
         limit: int | None = None,
     ) -> AsyncIterator[dict[str, Any]]:
-        """Fetch PubMed records by ID list (bypass search)."""
+        """Fetch PubMed records by ID list (bypass search).
+
+        Implements FilterableDataSourcePort.fetch_filtered() for direct PMID fetching.
+        """
         if entity_type != "publication":
             raise ValueError("PubMedAdapter only supports 'publication'")
 

--- a/tests/architecture/test_layer_dependencies.py
+++ b/tests/architecture/test_layer_dependencies.py
@@ -724,8 +724,9 @@ def test_no_hasattr_duck_typing_in_application(src_dir: Path) -> None:
     - TYPE_CHECKING blocks (static analysis only)
     - Checking for dunder methods (__enter__, __aiter__, etc.)
     - Checking for private attributes (_internal)
-    - fetch_filtered: Extension method for filterable adapters (ChEMBL-specific)
-      TODO: Create FilterableDataSourcePort Protocol to formalize this
+
+    Note: fetch_filtered is now formalized via FilterableDataSourcePort Protocol,
+    so isinstance() should be used instead of hasattr().
     """
     import ast
 
@@ -737,7 +738,7 @@ def test_no_hasattr_duck_typing_in_application(src_dir: Path) -> None:
     PORT_METHOD_PATTERNS = (
         "clear_",
         "write_",
-        # "fetch_" excluded: fetch_filtered is a documented extension pattern
+        "fetch_",
         "read_",
         "load_",
         "save_",
@@ -748,9 +749,8 @@ def test_no_hasattr_duck_typing_in_application(src_dir: Path) -> None:
     )
 
     # Explicitly allowed hasattr checks (documented extensions)
-    ALLOWED_HASATTR_CHECKS = {
-        "fetch_filtered",  # FilterableDataSourcePort extension (see filtered_data_source.py)
-    }
+    # Empty after FilterableDataSourcePort formalization
+    ALLOWED_HASATTR_CHECKS: set[str] = set()
 
     violations = []
 
@@ -1178,4 +1178,103 @@ def test_error_classifier_uses_error_type_attribute(src_dir: Path) -> None:
     # Should have get_error_type() call for domain errors
     assert "get_error_type()" in content or "error_type" in content, (
         "ErrorClassifier should use error_type attribute for domain exceptions"
+    )
+
+
+def test_filterable_adapters_implement_protocol(src_dir: Path) -> None:
+    """Adapters with fetch_filtered MUST be compatible with FilterableDataSourcePort.
+
+    REQ-ARCH-025: Adapters that support API-level filtering should implement
+    FilterableDataSourcePort Protocol for proper isinstance() checks.
+    """
+    adapters_path = src_dir / "bioetl" / "infrastructure" / "adapters"
+    if not adapters_path.exists():
+        pytest.skip("Infrastructure adapters not found")
+
+    # Files that might contain filterable adapters
+    excluded_files = {
+        "__init__.py",
+        "base.py",
+        "types.py",
+        "exceptions.py",
+        "pagination.py",
+        "rate_limiter.py",
+        "circuit_breaker.py",
+        "logging_utils.py",
+        "sync_base.py",
+        "health.py",
+    }
+
+    adapters_with_fetch_filtered = []
+
+    for py_file in adapters_path.rglob("*.py"):
+        if py_file.name in excluded_files:
+            continue
+
+        with py_file.open(encoding="utf-8") as f:
+            content = f.read()
+
+        # Check if file defines fetch_filtered method
+        if "def fetch_filtered(" in content or "async def fetch_filtered(" in content:
+            relative_path = py_file.relative_to(src_dir)
+            adapters_with_fetch_filtered.append(str(relative_path))
+
+            # Verify the docstring mentions FilterableDataSourcePort
+            if "FilterableDataSourcePort" not in content:
+                pytest.fail(
+                    f"{relative_path} has fetch_filtered() but doesn't reference "
+                    "FilterableDataSourcePort in docstring. "
+                    "Add Protocol reference for documentation clarity."
+                )
+
+    # Verify at least one adapter implements the protocol (ChemblAdapter)
+    assert adapters_with_fetch_filtered, (
+        "No adapters found with fetch_filtered(). Expected ChemblAdapter."
+    )
+
+
+def test_filtered_data_source_uses_isinstance(src_dir: Path) -> None:
+    """FilteredDataSource MUST use isinstance() instead of hasattr().
+
+    REQ-ARCH-026: After FilterableDataSourcePort formalization,
+    FilteredDataSource should use isinstance() for protocol checks.
+    """
+    filtered_ds_file = (
+        src_dir / "bioetl" / "application" / "core" / "filtered_data_source.py"
+    )
+    if not filtered_ds_file.exists():
+        pytest.skip("FilteredDataSource not found")
+
+    with filtered_ds_file.open(encoding="utf-8") as f:
+        content = f.read()
+
+    # Should import FilterableDataSourcePort
+    assert "FilterableDataSourcePort" in content, (
+        "FilteredDataSource should import FilterableDataSourcePort from domain.ports"
+    )
+
+    # Should NOT use hasattr for fetch_filtered check
+    if "hasattr" in content and "fetch_filtered" in content:
+        # Check if hasattr is used with fetch_filtered (not just mentioned separately)
+        import ast
+
+        tree = ast.parse(content)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                if isinstance(node.func, ast.Name) and node.func.id == "hasattr":
+                    if len(node.args) >= 2:
+                        arg = node.args[1]
+                        if (
+                            isinstance(arg, ast.Constant)
+                            and arg.value == "fetch_filtered"
+                        ):
+                            pytest.fail(
+                                "FilteredDataSource still uses hasattr() for "
+                                "fetch_filtered check. Use isinstance(data_source, "
+                                "FilterableDataSourcePort) instead."
+                            )
+
+    # Should use isinstance with FilterableDataSourcePort
+    assert "isinstance" in content and "FilterableDataSourcePort" in content, (
+        "FilteredDataSource should use isinstance(data_source, FilterableDataSourcePort)"
     )

--- a/tests/unit/application/core/test_filtered_data_source.py
+++ b/tests/unit/application/core/test_filtered_data_source.py
@@ -272,7 +272,7 @@ class TestFilteredDataSourceFetch:
         # Simulate entering context to load filter IDs
         await filtered.__aenter__()
 
-        with pytest.raises(TypeError, match="does not support fetch_filtered"):
+        with pytest.raises(TypeError, match="does not implement FilterableDataSourcePort"):
             async for _ in filtered.fetch("activity"):
                 pass
 


### PR DESCRIPTION
Replace duck-typing with explicit Protocol for adapters supporting API-level filtering. This formalizes the contract for fetch_filtered() method used by FilteredDataSource.

Changes:
- Add FilterableDataSourcePort Protocol to domain/ports.py
- Update FilteredDataSource to use isinstance() instead of hasattr()
- Update ChemblAdapter and PubMedAdapter docstrings
- Add architecture tests for Protocol compliance
- Remove fetch_filtered from hasattr allowlist

Closes the TODO from test_no_hasattr_duck_typing_in_application.