### PR TITLE
Create FilterableDataSourcePort protocol for adapters

### DIFF
--- a/src/bioetl/application/core/filtered_data_source.py
+++ b/src/bioetl/application/core/filtered_data_source.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Self
 
+from bioetl.domain.ports import FilterableDataSourcePort
+
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
@@ -29,8 +31,9 @@ class FilteredDataSource:
     4. Records metrics about loaded IDs and duplicates
 
     Note:
-        Filtering requires the underlying adapter to implement a fetch_filtered()
-        method. This is a provider-specific extension not part of DataSourcePort.
+        Filtering requires the underlying adapter to implement FilterableDataSourcePort.
+        This Protocol defines the fetch_filtered() method for adapters that support
+        server-side filtering (e.g., ChemblAdapter, PubMedAdapter).
 
     Example:
         >>> config = InputFilterConfig(
@@ -167,17 +170,25 @@ class FilteredDataSource:
         # this class manages its own filter state from InputFilterConfig
         _ = filter_ids, filter_field  # Mark as intentionally unused
         if self._filter_config.enabled and self._filter_ids:
-            # Check if adapter supports filtering (ChEMBL-specific extension)
-            if not hasattr(self._data_source, "fetch_filtered"):
+            # Check if adapter implements FilterableDataSourcePort
+            if not isinstance(self._data_source, FilterableDataSourcePort):
                 raise TypeError(
-                    f"Adapter {self._data_source.provider_name} does not support "
-                    "fetch_filtered(). Filtering requires an adapter with this method."
+                    f"Adapter {self._data_source.provider_name} does not implement "
+                    "FilterableDataSourcePort. Filtering requires an adapter with "
+                    "fetch_filtered() method."
+                )
+            # Validate filter_field is set when filtering is enabled
+            config_filter_field = self._filter_config.filter_field
+            if config_filter_field is None:
+                raise ValueError(
+                    "filter_field must be specified in InputFilterConfig "
+                    "when filtering is enabled."
                 )
             # Filtered fetch using adapter-specific method
             async for record in self._data_source.fetch_filtered(
                 entity_type=entity_type,
                 filter_ids=self._filter_ids,
-                filter_field=self._filter_config.filter_field,
+                filter_field=config_filter_field,
                 limit=limit,
             ):
                 yield record

--- a/src/bioetl/domain/ports.py
+++ b/src/bioetl/domain/ports.py
@@ -114,6 +114,49 @@ class DataSourcePort(Protocol):
 
 
 @runtime_checkable
+class FilterableDataSourcePort(DataSourcePort, Protocol):
+    """Extended DataSourcePort that supports filtering at API level.
+
+    This Protocol extends DataSourcePort for adapters that can perform
+    server-side filtering by IDs (e.g., ChEMBL, PubMed).
+
+    Use isinstance() check to detect if an adapter supports filtering:
+        if isinstance(adapter, FilterableDataSourcePort):
+            async for record in adapter.fetch_filtered(...):
+                ...
+
+    Note:
+        Adapters that implement this Protocol MUST also implement DataSourcePort.
+        The fetch_filtered() method should delegate to the provider's native
+        filtering capabilities for efficient server-side filtering.
+    """
+
+    def fetch_filtered(
+        self,
+        entity_type: str,
+        filter_ids: list[str],
+        filter_field: str,
+        limit: int | None = None,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Fetch records filtered by specific IDs at the source level.
+
+        This method enables efficient server-side filtering by passing
+        filter criteria directly to the data source API.
+
+        Args:
+            entity_type: The type of entity to fetch (e.g., 'activity', 'publication').
+            filter_ids: Sorted list of IDs to filter by (for deterministic batching).
+            filter_field: Field name to filter on (e.g., 'molecule_chembl_id', 'pmid').
+            limit: Optional maximum number of records to fetch.
+
+        Yields:
+            Dictionary records matching the filter criteria.
+
+        """
+        ...
+
+
+@runtime_checkable
 class InputFilterPort(Protocol):
     """Port for loading filter IDs from external sources.
 
@@ -642,6 +685,7 @@ class GoldValidatorPort(Protocol):
 __all__ = [
     "CheckpointPort",
     "DataSourcePort",
+    "FilterableDataSourcePort",
     "GoldValidatorPort",
     "InputFilterPort",
     "LockPort",

--- a/src/bioetl/infrastructure/adapters/chembl/client.py
+++ b/src/bioetl/infrastructure/adapters/chembl/client.py
@@ -71,7 +71,8 @@ ENTITY_PLURAL = {
 class ChemblAdapter(BaseHttpAdapter):
     """ChEMBL data source adapter.
 
-    Implements DataSourcePort for fetching data from ChEMBL database.
+    Implements DataSourcePort and FilterableDataSourcePort for fetching
+    data from ChEMBL database with optional server-side filtering.
 
     Args:
         http_client: UnifiedHTTPClient instance
@@ -337,7 +338,7 @@ class ChemblAdapter(BaseHttpAdapter):
     ) -> AsyncIterator[dict[str, Any]]:
         """Fetch records from ChEMBL with ID filtering.
 
-        This is a ChEMBL-specific extension not part of DataSourcePort.
+        Implements FilterableDataSourcePort.fetch_filtered().
 
         Args:
             entity_type: Type of entity to fetch

--- a/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
+++ b/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
@@ -22,7 +22,8 @@ ENTREZ_API_BASE = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/"
 class PubMedAdapter:
     """PubMed adapter using UnifiedHTTPClient.
 
-    Implements DataSourcePort for PubMed data extraction.
+    Implements DataSourcePort and FilterableDataSourcePort for PubMed data extraction
+    with optional server-side filtering by PMID lists.
 
     Args:
         http_client: UnifiedHTTPClient instance for making HTTP requests.
@@ -138,14 +139,30 @@ class PubMedAdapter:
         self,
         entity_type: str,
         filter_ids: list[str],
-        filter_field: str | None = None,
+        filter_field: str,
         limit: int | None = None,
     ) -> AsyncIterator[dict[str, Any]]:
-        """Fetch PubMed records by ID list (bypass search)."""
+        """Fetch PubMed records by ID list (bypass search).
+
+        Implements FilterableDataSourcePort.fetch_filtered().
+
+        Args:
+            entity_type: Must be 'publication'.
+            filter_ids: List of PMIDs to fetch.
+            filter_field: Field name (expected 'pmid', others logged as warning).
+            limit: Maximum number of records to fetch.
+
+        Yields:
+            Dictionary records for each article.
+
+        Raises:
+            ValueError: If entity_type is not 'publication'.
+
+        """
         if entity_type != "publication":
             raise ValueError("PubMedAdapter only supports 'publication'")
 
-        if filter_field and filter_field != "pmid":
+        if filter_field != "pmid":
             self.logger.warning(
                 "unsupported_filter_field",
                 field=filter_field,
@@ -166,8 +183,10 @@ class PubMedAdapter:
     ) -> AsyncIterator[dict[str, Any]]:
         """Fetch PubMed records."""
         if filter_ids:
+            # Default to 'pmid' if filter_field not specified
+            effective_filter_field = filter_field or "pmid"
             async for record in self.fetch_filtered(
-                entity_type, filter_ids, filter_field, limit
+                entity_type, filter_ids, effective_filter_field, limit
             ):
                 yield record
             return

--- a/tests/architecture/test_layer_dependencies.py
+++ b/tests/architecture/test_layer_dependencies.py
@@ -748,9 +748,8 @@ def test_no_hasattr_duck_typing_in_application(src_dir: Path) -> None:
     )
 
     # Explicitly allowed hasattr checks (documented extensions)
-    ALLOWED_HASATTR_CHECKS = {
-        "fetch_filtered",  # FilterableDataSourcePort extension (see filtered_data_source.py)
-    }
+    # Note: fetch_filtered is now formalized via FilterableDataSourcePort Protocol
+    ALLOWED_HASATTR_CHECKS: set[str] = set()
 
     violations = []
 
@@ -1178,4 +1177,78 @@ def test_error_classifier_uses_error_type_attribute(src_dir: Path) -> None:
     # Should have get_error_type() call for domain errors
     assert "get_error_type()" in content or "error_type" in content, (
         "ErrorClassifier should use error_type attribute for domain exceptions"
+    )
+
+
+def test_filterable_adapters_implement_protocol(src_dir: Path) -> None:
+    """Adapters with fetch_filtered MUST implement FilterableDataSourcePort.
+
+    REQ-ARCH-025: Replace duck-typing with explicit Protocol for adapters
+    that support filtering at API level. This ensures type safety and
+    enables isinstance() checks instead of hasattr().
+    """
+    adapters_path = src_dir / "bioetl" / "infrastructure" / "adapters"
+    if not adapters_path.exists():
+        pytest.skip("Infrastructure adapters not found")
+
+    violations = []
+
+    for py_file in adapters_path.rglob("*.py"):
+        if py_file.name.startswith("_"):
+            continue
+
+        content = py_file.read_text(encoding="utf-8")
+
+        # Check if file defines fetch_filtered method
+        has_fetch_filtered = (
+            "def fetch_filtered" in content or "async def fetch_filtered" in content
+        )
+
+        if has_fetch_filtered:
+            # Should reference FilterableDataSourcePort in docstring
+            has_protocol_ref = "FilterableDataSourcePort" in content
+
+            if not has_protocol_ref:
+                relative_path = py_file.relative_to(src_dir)
+                violations.append(
+                    f"{relative_path}: defines fetch_filtered but doesn't "
+                    "reference FilterableDataSourcePort"
+                )
+
+    assert not violations, (
+        "Adapters with fetch_filtered must implement FilterableDataSourcePort.\n"
+        "Update class/method docstrings to reference the Protocol:\n"
+        + "\n".join(f"  - {v}" for v in violations)
+    )
+
+
+def test_filtered_data_source_uses_isinstance(src_dir: Path) -> None:
+    """FilteredDataSource MUST use isinstance() for Protocol check.
+
+    REQ-ARCH-026: Replace hasattr() duck-typing with isinstance() check
+    for FilterableDataSourcePort. This enables proper type checking and
+    IDE support.
+    """
+    filtered_source = (
+        src_dir / "bioetl" / "application" / "core" / "filtered_data_source.py"
+    )
+    if not filtered_source.exists():
+        pytest.skip("FilteredDataSource not found")
+
+    content = filtered_source.read_text(encoding="utf-8")
+
+    # Should NOT use hasattr for fetch_filtered
+    uses_hasattr = 'hasattr' in content and 'fetch_filtered' in content
+    assert not uses_hasattr, (
+        "FilteredDataSource should not use hasattr() for fetch_filtered check. "
+        "Use isinstance(adapter, FilterableDataSourcePort) instead."
+    )
+
+    # Should use isinstance with FilterableDataSourcePort
+    uses_isinstance = (
+        "isinstance" in content and "FilterableDataSourcePort" in content
+    )
+    assert uses_isinstance, (
+        "FilteredDataSource must use isinstance(adapter, FilterableDataSourcePort) "
+        "for type-safe Protocol check."
     )


### PR DESCRIPTION
Replace duck-typing with explicit Protocol for adapters that support server-side filtering. This ensures type safety and enables isinstance() checks instead of hasattr().

Changes:
- Add FilterableDataSourcePort Protocol to domain/ports.py
- Update FilteredDataSource to use isinstance() check
- Update ChemblAdapter and PubMedAdapter to reference the Protocol
- Add architecture tests for Protocol compliance
- Remove hasattr exemption from test_no_hasattr_duck_typing_in_application

REQ-ARCH-025, REQ-ARCH-026