### PR TITLE
Extract common transformation utilities module

### DIFF
--- a/src/bioetl/application/core/__init__.py
+++ b/src/bioetl/application/core/__init__.py
@@ -16,6 +16,15 @@ from bioetl.application.core.lock_manager import LockManager
 from bioetl.application.core.pipeline_services import PipelineServices
 from bioetl.application.core.quarantine_manager import QuarantineManager
 from bioetl.application.core.shutdown import PipelineShutdownError, ShutdownSignal
+from bioetl.application.core.transform_utils import (
+    aggregate_nested_lists,
+    extract_list_field,
+    flatten_nested_dict,
+    normalize_string,
+    parse_date_field,
+    safe_extract,
+    validate_smiles,
+)
 
 # Re-exports from consolidated domain location
 from bioetl.domain.config import PipelineConfig, RuntimeConfig
@@ -35,4 +44,12 @@ __all__ = [
     "RuntimeConfig",
     # Shutdown coordination (ADR-0005)
     "ShutdownSignal",
+    # Transform utilities
+    "aggregate_nested_lists",
+    "extract_list_field",
+    "flatten_nested_dict",
+    "normalize_string",
+    "parse_date_field",
+    "safe_extract",
+    "validate_smiles",
 ]

--- a/src/bioetl/application/core/transform_utils.py
+++ b/src/bioetl/application/core/transform_utils.py
@@ -1,0 +1,301 @@
+"""Common transformation utilities for all pipelines.
+
+Реализует общие паттерны трансформации для уменьшения дублирования
+в ChEMBL и других трансформерах.
+
+Функции:
+- flatten_nested_dict: Разворачивание вложенных словарей с префиксом
+- extract_list_field: Извлечение поля из списка словарей
+- aggregate_nested_lists: Агрегация вложенных списков
+- normalize_string: Нормализация строковых полей
+- parse_date_field: Парсинг даты с обработкой ошибок
+- validate_smiles: Валидация SMILES строки
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date
+from typing import Any, Callable, TypeVar
+
+from bioetl.domain.transformations import safe_float, safe_int
+
+T = TypeVar("T")
+
+
+def flatten_nested_dict(
+    data: dict[str, Any] | None,
+    prefix: str,
+    field_mapping: dict[str, Callable[[Any], Any] | None],
+) -> dict[str, Any]:
+    """Разворачивает вложенный словарь в плоскую структуру с префиксом.
+
+    Используется для извлечения полей из вложенных структур API
+    (molecule_properties, molecule_hierarchy, ligand_efficiency и т.д.).
+
+    Args:
+        data: Вложенный словарь для разворачивания. Если None, возвращает
+              словарь с None значениями для всех ключей.
+        prefix: Префикс для результирующих ключей (e.g., "property_", "hierarchy_").
+        field_mapping: Словарь {исходный_ключ: конвертер}.
+                       Конвертер может быть safe_float, safe_int или None (без конвертации).
+
+    Returns:
+        Плоский словарь с префиксами и сконвертированными значениями.
+
+    Example:
+        >>> data = {"alogp": "3.5", "hba": 2}
+        >>> mapping = {"alogp": safe_float, "hba": safe_int}
+        >>> flatten_nested_dict(data, "property_", mapping)
+        {'property_alogp': 3.5, 'property_hba': 2}
+
+        >>> flatten_nested_dict(None, "property_", mapping)
+        {'property_alogp': None, 'property_hba': None}
+
+    """
+    if not data or not isinstance(data, dict):
+        return {f"{prefix}{key}": None for key in field_mapping}
+
+    result: dict[str, Any] = {}
+    for source_key, converter in field_mapping.items():
+        value = data.get(source_key)
+        if converter is not None and value is not None:
+            result[f"{prefix}{source_key}"] = converter(value)
+        else:
+            result[f"{prefix}{source_key}"] = value
+
+    return result
+
+
+def extract_list_field(
+    items: list[dict[str, Any]] | None,
+    field: str,
+    converter: Callable[[Any], T] | None = None,
+) -> list[T] | None:
+    """Извлекает значения поля из списка словарей.
+
+    Используется для агрегации полей из компонентов, классификаций и т.д.
+
+    Args:
+        items: Список словарей для обработки.
+        field: Имя поля для извлечения.
+        converter: Опциональный конвертер (safe_int, safe_float и т.д.).
+                   Если None, значения возвращаются как есть.
+
+    Returns:
+        Список значений или None, если результат пустой.
+
+    Example:
+        >>> items = [{"id": "1"}, {"id": "2"}, {"id": None}]
+        >>> extract_list_field(items, "id")
+        ['1', '2']
+
+        >>> extract_list_field(items, "id", safe_int)
+        [1, 2]
+
+    """
+    if not items or not isinstance(items, list):
+        return None
+
+    values: list[T] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        raw_value = item.get(field)
+        if raw_value is None:
+            continue
+
+        if converter is not None:
+            converted = converter(raw_value)
+            if converted is not None:
+                values.append(converted)
+        else:
+            values.append(raw_value)
+
+    return values if values else None
+
+
+def aggregate_nested_lists(
+    items: list[dict[str, Any]] | None,
+    field: str,
+) -> list[Any] | None:
+    """Агрегирует вложенные списки из списка словарей.
+
+    Используется для сбора synonyms, xrefs и других вложенных списков
+    из множества компонентов в один плоский список.
+
+    Args:
+        items: Список словарей, каждый из которых может содержать вложенный список.
+        field: Имя поля со вложенным списком.
+
+    Returns:
+        Объединённый список или None, если результат пустой.
+
+    Example:
+        >>> items = [
+        ...     {"synonyms": ["a", "b"]},
+        ...     {"synonyms": ["c"]},
+        ...     {"other": "data"}
+        ... ]
+        >>> aggregate_nested_lists(items, "synonyms")
+        ['a', 'b', 'c']
+
+    """
+    if not items or not isinstance(items, list):
+        return None
+
+    aggregated: list[Any] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        nested = item.get(field)
+        if nested and isinstance(nested, list):
+            aggregated.extend(nested)
+
+    return aggregated if aggregated else None
+
+
+def normalize_string(value: str | None) -> str | None:
+    """Нормализует строковое поле.
+
+    Удаляет пробельные символы по краям и возвращает None для пустых строк.
+
+    Args:
+        value: Строка для нормализации.
+
+    Returns:
+        Нормализованная строка или None.
+
+    Example:
+        >>> normalize_string("  hello world  ")
+        'hello world'
+        >>> normalize_string("   ")
+        None
+        >>> normalize_string(None)
+        None
+
+    """
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped if stripped else None
+
+
+def parse_date_field(
+    value: str | None,
+    fmt: str = "%Y-%m-%d",
+) -> date | None:
+    """Парсит строку даты в объект date.
+
+    Безопасный парсинг с обработкой ошибок и невалидных форматов.
+
+    Args:
+        value: Строка с датой или None.
+        fmt: Формат даты (по умолчанию ISO: YYYY-MM-DD).
+
+    Returns:
+        Объект date или None при ошибке парсинга.
+
+    Example:
+        >>> parse_date_field("2024-01-15")
+        datetime.date(2024, 1, 15)
+        >>> parse_date_field("invalid")
+        None
+        >>> parse_date_field("15/01/2024", "%d/%m/%Y")
+        datetime.date(2024, 1, 15)
+
+    """
+    if value is None:
+        return None
+
+    from datetime import datetime
+
+    try:
+        return datetime.strptime(value.strip(), fmt).date()
+    except (ValueError, AttributeError):
+        return None
+
+
+# SMILES validation regex (базовая проверка синтаксиса)
+# Допускает: буквы, цифры, скобки, точки, знаки, решётки, проценты, @, +, -, =, #
+_SMILES_PATTERN = re.compile(
+    r"^[A-Za-z0-9@+\-=#$()\[\]\\/%.*]+$"
+)
+
+
+def validate_smiles(smiles: str | None) -> bool:
+    """Проверяет валидность SMILES строки.
+
+    Выполняет базовую синтаксическую проверку без полного парсинга молекулы.
+    Для полной валидации используйте RDKit или другую химическую библиотеку.
+
+    Args:
+        smiles: SMILES строка для проверки.
+
+    Returns:
+        True если строка соответствует базовому синтаксису SMILES.
+
+    Example:
+        >>> validate_smiles("CCO")  # Ethanol
+        True
+        >>> validate_smiles("C1=CC=CC=C1")  # Benzene
+        True
+        >>> validate_smiles("")
+        False
+        >>> validate_smiles(None)
+        False
+        >>> validate_smiles("invalid smiles with spaces")
+        False
+
+    """
+    if not smiles or not isinstance(smiles, str):
+        return False
+
+    stripped = smiles.strip()
+    if not stripped:
+        return False
+
+    return bool(_SMILES_PATTERN.match(stripped))
+
+
+def safe_extract(
+    record: dict[str, Any],
+    key: str,
+    default: T | None = None,
+) -> T | Any | None:
+    """Безопасно извлекает значение из словаря с логированием.
+
+    Обёртка над dict.get() для унифицированного извлечения полей.
+    Для использования с логированием используйте в связке с контекстом.
+
+    Args:
+        record: Словарь для извлечения.
+        key: Ключ для поиска.
+        default: Значение по умолчанию (None).
+
+    Returns:
+        Значение по ключу или default.
+
+    Example:
+        >>> record = {"name": "test", "value": 42}
+        >>> safe_extract(record, "name")
+        'test'
+        >>> safe_extract(record, "missing", "default")
+        'default'
+
+    """
+    return record.get(key, default)
+
+
+# Re-export safe_float and safe_int for convenience
+__all__ = [
+    "flatten_nested_dict",
+    "extract_list_field",
+    "aggregate_nested_lists",
+    "normalize_string",
+    "parse_date_field",
+    "validate_smiles",
+    "safe_extract",
+    "safe_float",
+    "safe_int",
+]

--- a/src/bioetl/application/pipelines/chembl/activity_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/activity_transformer.py
@@ -8,12 +8,22 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, cast
 
 from bioetl.application.core.base_transformer import BaseTransformer
+from bioetl.application.core.transform_utils import flatten_nested_dict
 from bioetl.domain.entities import Activity
 from bioetl.domain.transformations import generate_entity_id, safe_float, safe_int
 
 if TYPE_CHECKING:
     from bioetl.domain.context import PipelineContext
     from bioetl.domain.types import BronzeRecord, SilverRecord
+
+
+# Mapping for ligand efficiency fields extraction
+_LIGAND_EFFICIENCY_FIELDS: dict[str, Any] = {
+    "bei": safe_float,
+    "le": safe_float,
+    "lle": safe_float,
+    "sei": safe_float,
+}
 
 
 class ActivityTransformer(BaseTransformer):
@@ -89,8 +99,12 @@ class ActivityTransformer(BaseTransformer):
             "standard_flag": safe_int(record.get("standard_flag")),
             # Derived metrics
             "pchembl_value": safe_float(record.get("pchembl_value")),
-            # Ligand efficiency metrics (flattened)
-            **self._extract_ligand_efficiency(record.get("ligand_efficiency")),
+            # Ligand efficiency metrics (flattened via transform_utils)
+            **flatten_nested_dict(
+                record.get("ligand_efficiency"),
+                "ligand_efficiency_",
+                _LIGAND_EFFICIENCY_FIELDS,
+            ),
             # Units ontology
             "qudt_units": record.get("qudt_units"),
             "uo_units": record.get("uo_units"),
@@ -124,32 +138,3 @@ class ActivityTransformer(BaseTransformer):
 
         # Convert Entity to SilverRecord for storage
         return cast("SilverRecord", self.entity_to_silver_record(entity))
-
-    def _extract_ligand_efficiency(
-        self, le_data: dict[str, Any] | None
-    ) -> dict[str, float | None]:
-        """Extract and flatten ligand efficiency metrics from ChEMBL dict.
-
-        Args:
-            le_data: Ligand efficiency dict from ChEMBL API with keys:
-                     'bei', 'le', 'lle', 'sei' (all as strings)
-
-        Returns:
-            Dict with flattened keys: ligand_efficiency_{bei,le,lle,sei}
-            All values are converted to float or None
-
-        """
-        if not le_data or not isinstance(le_data, dict):
-            return {
-                "ligand_efficiency_bei": None,
-                "ligand_efficiency_le": None,
-                "ligand_efficiency_lle": None,
-                "ligand_efficiency_sei": None,
-            }
-
-        return {
-            "ligand_efficiency_bei": safe_float(le_data.get("bei")),
-            "ligand_efficiency_le": safe_float(le_data.get("le")),
-            "ligand_efficiency_lle": safe_float(le_data.get("lle")),
-            "ligand_efficiency_sei": safe_float(le_data.get("sei")),
-        }

--- a/src/bioetl/application/pipelines/chembl/molecule_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/molecule_transformer.py
@@ -8,12 +8,70 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, cast
 
 from bioetl.application.core.base_transformer import BaseTransformer
+from bioetl.application.core.transform_utils import flatten_nested_dict
 from bioetl.domain.entities import Molecule
 from bioetl.domain.transformations import generate_entity_id, safe_float, safe_int
 
 if TYPE_CHECKING:
     from bioetl.domain.context import PipelineContext
     from bioetl.domain.types import BronzeRecord, SilverRecord
+
+
+# Field mappings for molecule nested structures
+_HIERARCHY_FIELDS: dict[str, Any] = {
+    "parent_chembl_id": None,
+    "active_chembl_id": None,
+    "molecule_chembl_id": None,
+}
+
+_PROPERTIES_FIELDS: dict[str, Any] = {
+    "alogp": safe_float,
+    "mw_freebase": safe_float,
+    "full_mwt": safe_float,
+    "hba": safe_int,
+    "hbd": safe_int,
+    "psa": safe_float,
+    "rtb": safe_int,
+    "num_lipinski_ro5_violations": safe_int,
+    "heavy_atoms": safe_int,
+    "aromatic_rings": safe_int,
+    "qed_weighted": safe_float,
+    "acd_logd": safe_float,
+    "acd_logp": safe_float,
+    "acd_most_apka": safe_float,
+    "acd_most_bpka": safe_float,
+    "full_molformula": None,
+    "ro3_pass": None,
+}
+
+_STRUCTURES_FIELDS: dict[str, Any] = {
+    "canonical_smiles": None,
+    "standard_inchi": None,
+    "standard_inchi_key": None,
+}
+
+
+def _extract_hierarchy(data: dict[str, Any] | None) -> dict[str, Any]:
+    """Extract and rename hierarchy fields using flatten_nested_dict."""
+    result = flatten_nested_dict(data, "hierarchy_", _HIERARCHY_FIELDS)
+    # Rename molecule_chembl_id -> child_chembl_id for clarity
+    result["hierarchy_child_chembl_id"] = result.pop("hierarchy_molecule_chembl_id")
+    return result
+
+
+def _extract_properties(data: dict[str, Any] | None) -> dict[str, Any]:
+    """Extract and rename properties fields using flatten_nested_dict."""
+    result = flatten_nested_dict(data, "property_", _PROPERTIES_FIELDS)
+    # Rename num_lipinski_ro5_violations -> ro5_violations
+    result["property_ro5_violations"] = result.pop(
+        "property_num_lipinski_ro5_violations"
+    )
+    return result
+
+
+def _extract_structures(data: dict[str, Any] | None) -> dict[str, Any]:
+    """Extract structures fields using flatten_nested_dict."""
+    return flatten_nested_dict(data, "structure_", _STRUCTURES_FIELDS)
 
 
 class MoleculeTransformer(BaseTransformer):
@@ -43,10 +101,10 @@ class MoleculeTransformer(BaseTransformer):
             id_field="molecule_chembl_id",
         )
 
-        # Extract and flatten complex fields
-        hierarchy = self._extract_hierarchy(record.get("molecule_hierarchy"))
-        properties = self._extract_properties(record.get("molecule_properties"))
-        structures = self._extract_structures(record.get("molecule_structures"))
+        # Extract and flatten complex fields via module-level functions
+        hierarchy = _extract_hierarchy(record.get("molecule_hierarchy"))
+        properties = _extract_properties(record.get("molecule_properties"))
+        structures = _extract_structures(record.get("molecule_structures"))
 
         business_data: dict[str, Any] = {
             # Primary identifier
@@ -120,72 +178,3 @@ class MoleculeTransformer(BaseTransformer):
 
         # Convert Entity to SilverRecord for storage
         return cast("SilverRecord", self.entity_to_silver_record(entity))
-
-    def _extract_hierarchy(self, data: dict[str, Any] | None) -> dict[str, Any]:
-        if not data:
-            return {
-                "hierarchy_parent_chembl_id": None,
-                "hierarchy_active_chembl_id": None,
-                "hierarchy_child_chembl_id": None,
-            }
-        return {
-            "hierarchy_parent_chembl_id": data.get("parent_chembl_id"),
-            "hierarchy_active_chembl_id": data.get("active_chembl_id"),
-            "hierarchy_child_chembl_id": data.get("molecule_chembl_id"),
-        }
-
-    def _extract_properties(self, data: dict[str, Any] | None) -> dict[str, Any]:
-        if not data:
-            return {
-                "property_alogp": None,
-                "property_mw_freebase": None,
-                "property_full_mwt": None,
-                "property_hba": None,
-                "property_hbd": None,
-                "property_psa": None,
-                "property_rtb": None,
-                "property_ro5_violations": None,
-                "property_heavy_atoms": None,
-                "property_aromatic_rings": None,
-                "property_qed_weighted": None,
-                "property_acd_logd": None,
-                "property_acd_logp": None,
-                "property_acd_most_apka": None,
-                "property_acd_most_bpka": None,
-                "property_full_molformula": None,
-                "property_ro3_pass": None,
-            }
-        return {
-            "property_alogp": safe_float(data.get("alogp")),
-            "property_mw_freebase": safe_float(data.get("mw_freebase")),
-            "property_full_mwt": safe_float(data.get("full_mwt")),
-            "property_hba": safe_int(data.get("hba")),
-            "property_hbd": safe_int(data.get("hbd")),
-            "property_psa": safe_float(data.get("psa")),
-            "property_rtb": safe_int(data.get("rtb")),
-            "property_ro5_violations": safe_int(
-                data.get("num_lipinski_ro5_violations")
-            ),
-            "property_heavy_atoms": safe_int(data.get("heavy_atoms")),
-            "property_aromatic_rings": safe_int(data.get("aromatic_rings")),
-            "property_qed_weighted": safe_float(data.get("qed_weighted")),
-            "property_acd_logd": safe_float(data.get("acd_logd")),
-            "property_acd_logp": safe_float(data.get("acd_logp")),
-            "property_acd_most_apka": safe_float(data.get("acd_most_apka")),
-            "property_acd_most_bpka": safe_float(data.get("acd_most_bpka")),
-            "property_full_molformula": data.get("full_molformula"),
-            "property_ro3_pass": data.get("ro3_pass"),
-        }
-
-    def _extract_structures(self, data: dict[str, Any] | None) -> dict[str, Any]:
-        if not data:
-            return {
-                "structure_canonical_smiles": None,
-                "structure_standard_inchi": None,
-                "structure_standard_inchi_key": None,
-            }
-        return {
-            "structure_canonical_smiles": data.get("canonical_smiles"),
-            "structure_standard_inchi": data.get("standard_inchi"),
-            "structure_standard_inchi_key": data.get("standard_inchi_key"),
-        }

--- a/src/bioetl/application/pipelines/chembl/target_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/target_transformer.py
@@ -8,6 +8,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, cast
 
 from bioetl.application.core.base_transformer import BaseTransformer
+from bioetl.application.core.transform_utils import (
+    aggregate_nested_lists,
+    extract_list_field,
+)
 from bioetl.domain.entities import Target
 from bioetl.domain.transformations import generate_entity_id, safe_int
 
@@ -132,34 +136,18 @@ class TargetTransformer(BaseTransformer):
     def _extract_basic_component_fields(
         self, components: list[dict[str, Any]]
     ) -> dict[str, list[Any] | None]:
-        """Extract basic fields from component list."""
+        """Extract basic fields from component list via transform_utils."""
         return {
-            "component_accessions": self._extract_field(components, "accession"),
-            "component_ids": self._extract_int_field(components, "component_id"),
-            "component_types": self._extract_field(components, "component_type"),
-            "component_relationships": self._extract_field(components, "relationship"),
-            "component_descriptions": self._extract_field(
+            "component_accessions": extract_list_field(components, "accession"),
+            "component_ids": extract_list_field(components, "component_id", safe_int),
+            "component_types": extract_list_field(components, "component_type"),
+            "component_relationships": extract_list_field(components, "relationship"),
+            "component_descriptions": extract_list_field(
                 components, "component_description"
             ),
-            "component_organisms": self._extract_field(components, "organism"),
-            "component_tax_ids": self._extract_int_field(components, "tax_id"),
+            "component_organisms": extract_list_field(components, "organism"),
+            "component_tax_ids": extract_list_field(components, "tax_id", safe_int),
         }
-
-    def _extract_field(
-        self, components: list[dict[str, Any]], field: str
-    ) -> list[Any] | None:
-        """Extract a string field from all components."""
-        values = [c.get(field) for c in components if c.get(field)]
-        return values or None
-
-    def _extract_int_field(
-        self, components: list[dict[str, Any]], field: str
-    ) -> list[int] | None:
-        """Extract an integer field from all components."""
-        values = [
-            safe_int(c.get(field)) for c in components if c.get(field) is not None
-        ]
-        return values or None
 
     def _extract_protein_classifications(
         self, components: list[dict[str, Any]]
@@ -204,6 +192,8 @@ class TargetTransformer(BaseTransformer):
     ) -> str | None:
         """Aggregate synonyms from all components into a single JSON list.
 
+        Uses aggregate_nested_lists from transform_utils.
+
         Args:
             components: List of component dicts from ChEMBL API.
 
@@ -211,22 +201,15 @@ class TargetTransformer(BaseTransformer):
             JSON string of list of synonyms, or None.
 
         """
-        if not components or not isinstance(components, list):
-            return None
-
-        all_synonyms = []
-        for comp in components:
-            synonyms = comp.get("target_component_synonyms")
-            if synonyms and isinstance(synonyms, list):
-                all_synonyms.extend(synonyms)
-
-        return self.serialize_json(all_synonyms) if all_synonyms else None
+        synonyms = aggregate_nested_lists(components, "target_component_synonyms")
+        return self.serialize_json(synonyms) if synonyms else None
 
     def _aggregate_component_xrefs(
         self, components: list[dict[str, Any]] | None
     ) -> str | None:
         """Aggregate cross-references from all target components.
 
+        Uses aggregate_nested_lists from transform_utils.
         ChEMBL API stores cross-references inside each component's
         target_component_xrefs field, not at the target level.
 
@@ -237,13 +220,5 @@ class TargetTransformer(BaseTransformer):
             JSON string of aggregated xrefs, or None if empty.
 
         """
-        if not components or not isinstance(components, list):
-            return None
-
-        all_xrefs: list[dict[str, Any]] = []
-        for comp in components:
-            xrefs = comp.get("target_component_xrefs")
-            if xrefs and isinstance(xrefs, list):
-                all_xrefs.extend(xrefs)
-
-        return self.serialize_json(all_xrefs) if all_xrefs else None
+        xrefs = aggregate_nested_lists(components, "target_component_xrefs")
+        return self.serialize_json(xrefs) if xrefs else None


### PR DESCRIPTION
Create transform_utils.py module with 7 utility functions:
- flatten_nested_dict: Flatten nested dicts with prefix
- extract_list_field: Extract field from list of dicts
- aggregate_nested_lists: Aggregate nested lists
- normalize_string: Strip and normalize strings
- parse_date_field: Parse dates with error handling
- validate_smiles: Validate SMILES format
- safe_extract: Safe dict value extraction

Refactor 3 ChEMBL transformers to use new utilities:
- ActivityTransformer: Replace _extract_ligand_efficiency
- MoleculeTransformer: Replace _extract_hierarchy/properties/structures
- TargetTransformer: Replace _extract_field/_int_field and aggregates

Net reduction: 34 lines of duplicated code removed.