### PR TITLE
Fix BronzeWriter logging to use dependency injection

### DIFF
--- a/src/bioetl/composition/bootstrap.py
+++ b/src/bioetl/composition/bootstrap.py
@@ -22,6 +22,7 @@ from bioetl.infrastructure.locking.memory_lock import MemoryLock
 from bioetl.infrastructure.observability.logging import (
     create_logger as create_infra_logger,
 )
+from bioetl.infrastructure.observability.noop_logger import NoOpLogger
 from bioetl.infrastructure.observability.prometheus_metrics import PrometheusMetrics
 from bioetl.infrastructure.observability.server import start_metrics_server
 from bioetl.infrastructure.observability.tracing import NoOpTracer, OpenTelemetryTracer
@@ -79,23 +80,25 @@ def bootstrap_storage() -> StorageAdapter:
 
     Creates a minimal StorageAdapter suitable for preview operations.
     No CSV export is configured since this is for read-only inspection.
+    Uses NoOpLogger since this is for CLI preview operations without observability.
 
     Returns:
         StorageAdapter configured for the current environment.
     """
     settings = get_settings()
+    noop_logger = NoOpLogger()
 
     return StorageAdapter(
         bronze_writer=BronzeWriter(
             base_path=settings.bronze_path,
+            logger=noop_logger,
             save_json=False,
             json_path=None,
-            logger=None,
         ),
         silver_writer=DeltaWriter(
             base_path=settings.silver_path,
             csv_exporter=None,
-            logger=None,
+            logger=noop_logger,
         ),
         gold_writer=GoldWriter(
             base_path=settings.gold_path,

--- a/src/bioetl/composition/factories/storage_factory.py
+++ b/src/bioetl/composition/factories/storage_factory.py
@@ -366,9 +366,9 @@ class StorageFactory:
         adapter = StorageAdapter(
             bronze_writer=BronzeWriter(
                 base_path=bronze_path,
+                logger=logger,
                 save_json=save_json,
                 json_path=json_path,
-                logger=logger,
             ),
             silver_writer=DeltaWriter(
                 base_path=silver_path,

--- a/src/bioetl/infrastructure/storage/bronze_writer.py
+++ b/src/bioetl/infrastructure/storage/bronze_writer.py
@@ -23,11 +23,10 @@ from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import structlog
 import zstandard as zstd
 
 if TYPE_CHECKING:
-    from structlog.stdlib import BoundLogger
+    from bioetl.domain.ports import LoggerPort
 
 from bioetl.domain.types import BatchID, RunID, RunType
 from bioetl.infrastructure.storage._atomic import AtomicWriteGroup
@@ -37,6 +36,9 @@ class BronzeWriter:
     """Writer for Bronze layer (raw data in JSONL + zstd).
 
     Optionally saves uncompressed JSON copy when save_json=True.
+
+    Note: LoggerPort is required per RULES.md DI requirements. All dependencies
+    MUST be injected through constructor without fallback defaults.
     """
 
     COMPRESSION_CHUNK_SIZE = 256 * 1024
@@ -46,23 +48,23 @@ class BronzeWriter:
     def __init__(
         self,
         base_path: str | Path,
+        logger: "LoggerPort",
         save_json: bool = False,
         json_path: str | None = None,
-        logger: "BoundLogger | None" = None,
     ) -> None:
         """Initialize Bronze writer.
 
         Args:
             base_path: Base path for Bronze layer storage
+            logger: Structured logger for observability (MUST be injected)
             save_json: If True, also save uncompressed JSON copy
             json_path: Path for JSON files (defaults to base_path/json/)
-            logger: Structured logger for observability
 
         """
         self.base_path = Path(base_path)
+        self.logger = logger
         self.save_json = save_json
         self.json_path = json_path or str(self.base_path / "json")
-        self.logger = logger or structlog.get_logger(__name__)
 
     async def write_bronze(
         self,

--- a/tests/integration/pipelines/base.py
+++ b/tests/integration/pipelines/base.py
@@ -78,9 +78,9 @@ class IntegrationPipelineTestCase:
         adapter = StorageAdapter(
             bronze_writer=BronzeWriter(
                 base_path=self.bronze_path,
+                logger=logger,
                 save_json=save_json,
                 json_path=self.json_path if save_json else None,
-                logger=logger,
             ),
             silver_writer=DeltaWriter(
                 base_path=self.silver_path,

--- a/tests/unit/infrastructure/storage/test_bronze_writer.py
+++ b/tests/unit/infrastructure/storage/test_bronze_writer.py
@@ -4,15 +4,22 @@ import asyncio
 import json
 from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
 import zstandard as zstd
 
 from bioetl.domain.types import BatchID, RunID, RunType
+from bioetl.infrastructure.observability.noop_logger import NoOpLogger
 from bioetl.infrastructure.storage._atomic import AtomicWriteGroup
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
+
+
+@pytest.fixture
+def noop_logger() -> NoOpLogger:
+    """Provide a NoOpLogger for BronzeWriter tests."""
+    return NoOpLogger()
 
 
 @pytest.fixture
@@ -48,39 +55,48 @@ def sample_records() -> list[bytes]:
 class TestBronzeWriterInit:
     """Tests for BronzeWriter initialization."""
 
-    def test_init_local_storage(self, tmp_path) -> None:
+    def test_init_local_storage(self, tmp_path, noop_logger) -> None:
         """Test initialization for local storage."""
-        writer = BronzeWriter(base_path=tmp_path)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
 
         assert writer.base_path == tmp_path
         assert writer.save_json is False
+        assert writer.logger is noop_logger
 
-    def test_init_with_save_json(self, tmp_path) -> None:
+    def test_init_with_save_json(self, tmp_path, noop_logger) -> None:
         """Test initialization with JSON saving enabled."""
-        writer = BronzeWriter(base_path=tmp_path, save_json=True)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, save_json=True)
 
         assert writer.save_json is True
         assert writer.json_path is not None
 
-    def test_init_with_custom_json_path(self, tmp_path) -> None:
+    def test_init_with_custom_json_path(self, tmp_path, noop_logger) -> None:
         """Test initialization with custom JSON path."""
         custom_path = str(tmp_path / "custom_json")
         writer = BronzeWriter(
             base_path=tmp_path,
+            logger=noop_logger,
             save_json=True,
             json_path=custom_path,
         )
 
         assert writer.json_path == custom_path
 
+    def test_init_requires_logger(self, tmp_path) -> None:
+        """Test that logger is required (no fallback)."""
+        with pytest.raises(TypeError, match="logger"):
+            BronzeWriter(base_path=tmp_path)  # type: ignore[call-arg]
+
 
 @pytest.mark.unit
 class TestBronzeWriterCompress:
     """Tests for BronzeWriter compression."""
 
-    def test_compress_records(self, tmp_path, sample_records: list[bytes]) -> None:
+    def test_compress_records(
+        self, tmp_path, noop_logger, sample_records: list[bytes]
+    ) -> None:
         """Test record compression."""
-        writer = BronzeWriter(base_path=tmp_path)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
 
         compressed = writer._compress_records(iter(sample_records))
 
@@ -94,16 +110,16 @@ class TestBronzeWriterCompress:
         expected = b"".join(sample_records)
         assert decompressed == expected
 
-    def test_compress_empty_records_raises(self, tmp_path) -> None:
+    def test_compress_empty_records_raises(self, tmp_path, noop_logger) -> None:
         """Test that empty records raise ValueError."""
-        writer = BronzeWriter(base_path=tmp_path)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
 
         with pytest.raises(ValueError, match="No records provided"):
             writer._compress_records(iter([]))
 
-    def test_compress_large_records(self, tmp_path) -> None:
+    def test_compress_large_records(self, tmp_path, noop_logger) -> None:
         """Test compression with records larger than chunk size."""
-        writer = BronzeWriter(base_path=tmp_path)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
 
         # Create large records
         large_record = {"data": "x" * 500_000}
@@ -124,13 +140,14 @@ class TestBronzeWriterWriteLocal:
     async def test_write_bronze_local(
         self,
         tmp_path,
+        noop_logger,
         sample_records: list[bytes],
         batch_id: BatchID,
         run_id: RunID,
         run_type: RunType,
     ) -> None:
         """Test writing Bronze data to local storage."""
-        writer = BronzeWriter(base_path=tmp_path)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
         date = datetime(2024, 1, 15)
 
         path = await writer.write_bronze(
@@ -180,13 +197,14 @@ class TestBronzeWriterWriteLocal:
     async def test_write_bronze_local_async(
         self,
         tmp_path,
+        noop_logger,
         sample_records: list[bytes],
         batch_id: BatchID,
         run_id: RunID,
         run_type: RunType,
     ) -> None:
         """Test that local write is performed asynchronously."""
-        writer = BronzeWriter(base_path=tmp_path)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
         date = datetime(2023, 1, 1, tzinfo=UTC)
 
         # We patch run_in_executor to verify it's called for file I/O
@@ -217,13 +235,14 @@ class TestBronzeWriterWriteLocal:
     async def test_write_bronze_with_json_copy(
         self,
         tmp_path,
+        noop_logger,
         sample_records: list[bytes],
         batch_id: BatchID,
         run_id: RunID,
         run_type: RunType,
     ) -> None:
         """Test writing Bronze data with JSON copy."""
-        writer = BronzeWriter(base_path=tmp_path, save_json=True)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, save_json=True)
         date = datetime(2024, 1, 15)
 
         await writer.write_bronze(
@@ -251,12 +270,13 @@ class TestBronzeWriterWriteLocal:
     async def test_write_bronze_empty_records_raises(
         self,
         tmp_path,
+        noop_logger,
         batch_id: BatchID,
         run_id: RunID,
         run_type: RunType,
     ) -> None:
         """Test that empty records raise ValueError."""
-        writer = BronzeWriter(base_path=tmp_path)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
         date = datetime(2024, 1, 15)
 
         with pytest.raises(ValueError, match="No records"):
@@ -279,13 +299,14 @@ class TestBronzeWriterReadLocal:
     async def test_read_bronze_local(
         self,
         tmp_path,
+        noop_logger,
         sample_records: list[bytes],
         batch_id: BatchID,
         run_id: RunID,
         run_type: RunType,
     ) -> None:
         """Test reading Bronze data from local storage."""
-        writer = BronzeWriter(base_path=tmp_path)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
         date = datetime(2024, 1, 15)
 
         # Write first
@@ -318,12 +339,13 @@ class TestBronzeWriterListBatches:
     async def test_list_batches_local(
         self,
         tmp_path,
+        noop_logger,
         sample_records: list[bytes],
         run_id: RunID,
         run_type: RunType,
     ) -> None:
         """Test listing batches from local storage."""
-        writer = BronzeWriter(base_path=tmp_path)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
 
         # Write multiple batches
         date1 = datetime(2024, 1, 15)
@@ -356,12 +378,13 @@ class TestBronzeWriterListBatches:
     async def test_list_batches_with_date_filter(
         self,
         tmp_path,
+        noop_logger,
         sample_records: list[bytes],
         run_id: RunID,
         run_type: RunType,
     ) -> None:
         """Test listing batches with date filter."""
-        writer = BronzeWriter(base_path=tmp_path)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
 
         date1 = datetime(2024, 1, 15)
         date2 = datetime(2024, 1, 16)
@@ -391,9 +414,9 @@ class TestBronzeWriterListBatches:
         assert "2024-01-15" in batches[0]
 
     @pytest.mark.asyncio
-    async def test_list_batches_empty(self, tmp_path) -> None:
+    async def test_list_batches_empty(self, tmp_path, noop_logger) -> None:
         """Test listing batches when none exist."""
-        writer = BronzeWriter(base_path=tmp_path)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
 
         batches = await writer.list_batches("nonexistent", "entity")
         assert batches == []
@@ -407,6 +430,7 @@ class TestBronzeWriterAtomicWrite:
     async def test_no_partial_files_on_write_failure(
         self,
         tmp_path,
+        noop_logger,
         sample_records: list[bytes],
         batch_id: BatchID,
         run_id: RunID,
@@ -417,7 +441,7 @@ class TestBronzeWriterAtomicWrite:
         Simulates a failure during the atomic write commit phase.
         Verifies REQ-DATA-004: Atomic writes.
         """
-        writer = BronzeWriter(base_path=tmp_path)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
         date = datetime(2024, 1, 15)
 
         # Mock AtomicWriteGroup.commit to fail
@@ -456,6 +480,7 @@ class TestBronzeWriterAtomicWrite:
     async def test_no_orphan_metadata_without_data(
         self,
         tmp_path,
+        noop_logger,
         sample_records: list[bytes],
         batch_id: BatchID,
         run_id: RunID,
@@ -465,7 +490,7 @@ class TestBronzeWriterAtomicWrite:
 
         Both files must be written together atomically.
         """
-        writer = BronzeWriter(base_path=tmp_path)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
         date = datetime(2024, 1, 15)
 
         # Successful write
@@ -490,13 +515,14 @@ class TestBronzeWriterAtomicWrite:
     async def test_no_temp_files_after_successful_write(
         self,
         tmp_path,
+        noop_logger,
         sample_records: list[bytes],
         batch_id: BatchID,
         run_id: RunID,
         run_type: RunType,
     ) -> None:
         """Test that no temp files remain after successful write."""
-        writer = BronzeWriter(base_path=tmp_path)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
         date = datetime(2024, 1, 15)
 
         await writer.write_bronze(
@@ -517,13 +543,14 @@ class TestBronzeWriterAtomicWrite:
     async def test_failure_during_add_cleans_up(
         self,
         tmp_path,
+        noop_logger,
         sample_records: list[bytes],
         batch_id: BatchID,
         run_id: RunID,
         run_type: RunType,
     ) -> None:
         """Test that failure during AtomicWriteGroup.add cleans up temp files."""
-        writer = BronzeWriter(base_path=tmp_path)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
         date = datetime(2024, 1, 15)
 
         # Mock AtomicWriteGroup.add to fail on second call (metadata)
@@ -558,13 +585,14 @@ class TestBronzeWriterAtomicWrite:
     async def test_json_copy_uses_atomic_write(
         self,
         tmp_path,
+        noop_logger,
         sample_records: list[bytes],
         batch_id: BatchID,
         run_id: RunID,
         run_type: RunType,
     ) -> None:
         """Test that JSON copy also uses atomic write."""
-        writer = BronzeWriter(base_path=tmp_path, save_json=True)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, save_json=True)
         date = datetime(2024, 1, 15)
 
         await writer.write_bronze(
@@ -585,3 +613,48 @@ class TestBronzeWriterAtomicWrite:
         # No temp files should remain
         tmp_files = list(Path(writer.json_path).rglob("*.tmp"))
         assert len(tmp_files) == 0, f"Found orphan temp files: {tmp_files}"
+
+
+@pytest.mark.unit
+class TestBronzeWriterLoggerInjection:
+    """Tests verifying logger is properly injected and used."""
+
+    @pytest.mark.asyncio
+    async def test_logger_called_on_write(
+        self,
+        tmp_path,
+        sample_records: list[bytes],
+        batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
+    ) -> None:
+        """Test that injected logger is called during write operations."""
+        mock_logger = MagicMock()
+        writer = BronzeWriter(base_path=tmp_path, logger=mock_logger)
+        date = datetime(2024, 1, 15)
+
+        await writer.write_bronze(
+            records=iter(sample_records),
+            provider="chembl",
+            entity="activity",
+            date=date,
+            batch_id=batch_id,
+            run_id=run_id,
+            run_type=run_type,
+        )
+
+        # Verify logger.info was called with bronze_write_complete
+        mock_logger.info.assert_called_once()
+        call_args = mock_logger.info.call_args
+        assert call_args[0][0] == "bronze_write_complete"
+        assert call_args[1]["provider"] == "chembl"
+        assert call_args[1]["entity"] == "activity"
+        assert call_args[1]["batch_id"] == str(batch_id)
+        assert call_args[1]["run_id"] == str(run_id)
+
+    def test_logger_is_stored_as_attribute(self, tmp_path) -> None:
+        """Test that injected logger is stored and accessible."""
+        mock_logger = MagicMock()
+        writer = BronzeWriter(base_path=tmp_path, logger=mock_logger)
+
+        assert writer.logger is mock_logger

--- a/tests/unit/infrastructure/test_storage.py
+++ b/tests/unit/infrastructure/test_storage.py
@@ -10,6 +10,7 @@ import pytest
 import zstandard as zstd
 
 from bioetl.domain.types import BatchID, RunID, RunType
+from bioetl.infrastructure.observability.noop_logger import NoOpLogger
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 from bioetl.infrastructure.storage.gold_writer import GoldWriter
@@ -17,6 +18,12 @@ from bioetl.infrastructure.storage.gold_writer import GoldWriter
 # Default test run metadata
 TEST_RUN_ID: RunID = UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
 TEST_RUN_TYPE = RunType.INCREMENTAL
+
+
+@pytest.fixture
+def noop_logger() -> NoOpLogger:
+    """Provide a NoOpLogger for storage tests."""
+    return NoOpLogger()
 
 
 @pytest.fixture
@@ -37,14 +44,14 @@ def mock_delta_writer():
 class TestBronzeWriter:
     """Test BronzeWriter functionality with local storage."""
 
-    def test_bronze_writer_initialization(self, tmp_path):
+    def test_bronze_writer_initialization(self, tmp_path, noop_logger):
         """Test BronzeWriter can be initialized."""
-        writer = BronzeWriter(base_path=tmp_path)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
         assert writer.base_path == tmp_path
 
-    async def test_write_bronze_creates_file(self, tmp_path):
+    async def test_write_bronze_creates_file(self, tmp_path, noop_logger):
         """Test write_bronze creates file in local storage."""
-        writer = BronzeWriter(base_path=tmp_path)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
 
         records = [b'{"id": 1, "data": "test"}\n']
         batch_id = BatchID(UUID("12345678-1234-5678-1234-567812345678"))
@@ -63,9 +70,9 @@ class TestBronzeWriter:
         expected_file = tmp_path / path
         assert expected_file.exists()
 
-    async def test_write_bronze_generates_correct_key(self, tmp_path):
+    async def test_write_bronze_generates_correct_key(self, tmp_path, noop_logger):
         """Test that write_bronze generates the correct path."""
-        writer = BronzeWriter(base_path=tmp_path)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
 
         records = [b'{"id": 1}\n']
         provider = "test_provider"
@@ -88,9 +95,9 @@ class TestBronzeWriter:
         expected_path = "bronze/v1/test_provider/test_entity/2023-01-01/batch_12345678-1234-5678-1234-567812345678.jsonl.zst"
         assert str(path).replace("\\", "/") == expected_path
 
-    async def test_write_bronze_compresses_with_zstd(self, tmp_path):
+    async def test_write_bronze_compresses_with_zstd(self, tmp_path, noop_logger):
         """REQ-DATA-001: Test that data is compressed with zstandard."""
-        writer = BronzeWriter(base_path=tmp_path)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
 
         records = [b'{"id": 1, "data": "test"}\n']
         batch_id = BatchID(UUID("12345678-1234-5678-1234-567812345678"))
@@ -120,9 +127,9 @@ class TestBronzeWriter:
 
         assert decompressed_data == b'{"id": 1, "data": "test"}\n'
 
-    async def test_write_bronze_with_no_records(self, tmp_path):
+    async def test_write_bronze_with_no_records(self, tmp_path, noop_logger):
         """Test that write_bronze raises error if there are no records."""
-        writer = BronzeWriter(base_path=tmp_path)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
 
         records = []
         provider = "test_provider"
@@ -141,9 +148,9 @@ class TestBronzeWriter:
                 run_type=TEST_RUN_TYPE,
             )
 
-    async def test_write_bronze_save_json_copy(self, tmp_path):
+    async def test_write_bronze_save_json_copy(self, tmp_path, noop_logger):
         """Test that write_bronze saves JSON copy if save_json is True."""
-        writer = BronzeWriter(base_path=tmp_path, save_json=True)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, save_json=True)
 
         records = [b'{"id": 1}\n']
         batch_id = BatchID(UUID("12345678-1234-5678-1234-567812345678"))
@@ -170,7 +177,7 @@ class TestBronzeWriter:
         assert json_path.exists()
         assert json_path.read_bytes() == b'{"id": 1}\n'
 
-    async def test_read_bronze(self, tmp_path):
+    async def test_read_bronze(self, tmp_path, noop_logger):
         """Test read_bronze reads file."""
         # Create a compressed file manually for deterministic testing
         records_data = [{"id": 1, "data": "test"}, {"id": 2, "data": "test2"}]
@@ -186,7 +193,7 @@ class TestBronzeWriter:
         test_file = bronze_dir / "batch_test.jsonl.zst"
         test_file.write_bytes(compressed)
 
-        writer = BronzeWriter(base_path=tmp_path)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
 
         # Read it back
         read_records = []
@@ -198,9 +205,9 @@ class TestBronzeWriter:
         assert len(read_records) == 2
         assert read_records[0]["id"] == 1
 
-    async def test_list_batches(self, tmp_path):
+    async def test_list_batches(self, tmp_path, noop_logger):
         """Test list_batches."""
-        writer = BronzeWriter(base_path=tmp_path)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
 
         # Write two batches
         date = datetime(2023, 1, 1)
@@ -221,17 +228,17 @@ class TestBronzeWriter:
         assert len(batches) == 2
         assert all(b.endswith(".jsonl.zst") for b in batches)
 
-    async def test_list_batches_nonexistent(self, tmp_path):
+    async def test_list_batches_nonexistent(self, tmp_path, noop_logger):
         """Test list_batches returns empty for nonexistent path."""
-        writer = BronzeWriter(base_path=tmp_path)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
 
         batches = await writer.list_batches("nonexistent", "entity", datetime.now())
 
         assert batches == []
 
-    async def test_writes_metadata_file(self, tmp_path):
+    async def test_writes_metadata_file(self, tmp_path, noop_logger):
         """Test that write_bronze creates metadata file."""
-        writer = BronzeWriter(base_path=tmp_path)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
 
         records = [b'{"id": 1}\n']
         batch_id = BatchID(UUID("12345678-1234-5678-1234-567812345678"))


### PR DESCRIPTION
Update BronzeWriter to require LoggerPort as mandatory constructor parameter, eliminating the fallback to structlog.get_logger() which violated DI principles per RULES.md.

Changes:
- Remove fallback logger creation in BronzeWriter.__init__
- Reorder constructor params: base_path, logger, save_json, json_path
- Update StorageFactory to pass logger in correct position
- Update bootstrap_storage() to inject NoOpLogger
- Update all test fixtures to provide logger
- Add TestBronzeWriterLoggerInjection test class

This ensures uniform observability across infrastructure components and simplifies testing/mocking of logging behavior.