### PR TITLE
Debug empty fields in molecule pipeline extraction

### DIFF
--- a/src/bioetl/application/pipelines/chembl/molecule_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/molecule_transformer.py
@@ -32,16 +32,14 @@ _PROPERTIES_FIELDS: dict[str, Any] = {
     "hbd": safe_int,
     "psa": safe_float,
     "rtb": safe_int,
-    "num_lipinski_ro5_violations": safe_int,
+    "num_ro5_violations": safe_int,  # ChEMBL API field name (not num_lipinski_ro5_violations)
     "heavy_atoms": safe_int,
     "aromatic_rings": safe_int,
     "qed_weighted": safe_float,
-    "acd_logd": safe_float,
-    "acd_logp": safe_float,
-    "acd_most_apka": safe_float,
-    "acd_most_bpka": safe_float,
     "full_molformula": None,
     "ro3_pass": None,
+    # Note: acd_logd, acd_logp, acd_most_apka, acd_most_bpka were removed
+    # as they are not available in the public ChEMBL API
 }
 
 _STRUCTURES_FIELDS: dict[str, Any] = {
@@ -62,10 +60,8 @@ def _extract_hierarchy(data: dict[str, Any] | None) -> dict[str, Any]:
 def _extract_properties(data: dict[str, Any] | None) -> dict[str, Any]:
     """Extract and rename properties fields using flatten_nested_dict."""
     result = flatten_nested_dict(data, "property_", _PROPERTIES_FIELDS)
-    # Rename num_lipinski_ro5_violations -> ro5_violations
-    result["property_ro5_violations"] = result.pop(
-        "property_num_lipinski_ro5_violations"
-    )
+    # Rename num_ro5_violations -> ro5_violations for consistency
+    result["property_ro5_violations"] = result.pop("property_num_ro5_violations")
     return result
 
 
@@ -130,10 +126,8 @@ class MoleculeTransformer(BaseTransformer):
             "chirality": safe_int(record.get("chirality")),
             "dosed_ingredient": safe_int(record.get("dosed_ingredient")),
             "availability_type": safe_int(record.get("availability_type")),
-            # Withdrawn metadata
-            "withdrawn_year": safe_int(record.get("withdrawn_year")),
-            "withdrawn_country": self.serialize_json(record.get("withdrawn_country")),
-            "withdrawn_reason": self.serialize_json(record.get("withdrawn_reason")),
+            # Note: withdrawn_year, withdrawn_country, withdrawn_reason are not available
+            # in the /molecule endpoint. Use /drug_warning endpoint for detailed info.
             # USAN naming
             "usan_stem": record.get("usan_stem"),
             "usan_stem_definition": record.get("usan_stem_definition"),

--- a/src/bioetl/domain/entities.py
+++ b/src/bioetl/domain/entities.py
@@ -418,10 +418,8 @@ class Molecule(BaseEntity):
     dosed_ingredient: int | None = None
     availability_type: int | None = None  # -2 to 2
 
-    # Withdrawn metadata
-    withdrawn_year: int | None = None
-    withdrawn_country: str | None = None  # JSON string for multiple countries
-    withdrawn_reason: str | None = None  # JSON string for multiple reasons
+    # Note: withdrawn_year, withdrawn_country, withdrawn_reason are not available
+    # in the /molecule endpoint. Use /drug_warning endpoint for detailed info.
 
     # USAN naming
     usan_stem: str | None = None
@@ -458,10 +456,8 @@ class Molecule(BaseEntity):
     property_heavy_atoms: int | None = None
     property_aromatic_rings: int | None = None
     property_qed_weighted: float | None = None
-    property_acd_logd: float | None = None
-    property_acd_logp: float | None = None
-    property_acd_most_apka: float | None = None
-    property_acd_most_bpka: float | None = None
+    # Note: property_acd_logd, property_acd_logp, property_acd_most_apka,
+    # property_acd_most_bpka are not available in the public ChEMBL API
     property_full_molformula: str | None = None
     property_ro3_pass: str | None = None  # "Y" or "N"
 

--- a/tests/unit/application/pipelines/__snapshots__/test_transformer_snapshots.ambr
+++ b/tests/unit/application/pipelines/__snapshots__/test_transformer_snapshots.ambr
@@ -158,10 +158,6 @@
     'polymer_flag': None,
     'pref_name': 'ASPIRIN',
     'prodrug': None,
-    'property_acd_logd': None,
-    'property_acd_logp': None,
-    'property_acd_most_apka': None,
-    'property_acd_most_bpka': None,
     'property_alogp': 1.19,
     'property_aromatic_rings': None,
     'property_full_molformula': None,
@@ -185,10 +181,7 @@
     'usan_stem_definition': None,
     'usan_substem': None,
     'usan_year': None,
-    'withdrawn_country': None,
     'withdrawn_flag': None,
-    'withdrawn_reason': None,
-    'withdrawn_year': None,
   })
 # ---
 # name: TestPubChemCompoundTransformerSnapshot.test_transform_snapshot

--- a/tests/unit/application/pipelines/test_chembl_transformers.py
+++ b/tests/unit/application/pipelines/test_chembl_transformers.py
@@ -349,26 +349,21 @@ class TestMoleculeTransformer:
         assert result["helm_notation"] == "PEPTIDE1{A.G.K}$$$$"
 
     @pytest.mark.asyncio
-    async def test_transform_with_withdrawn_fields(self, transformer, mock_context):
-        """Test transformation with withdrawn metadata fields."""
+    async def test_transform_with_withdrawn_flag(self, transformer, mock_context):
+        """Test transformation with withdrawn_flag field.
+
+        Note: withdrawn_year, withdrawn_country, withdrawn_reason are not available
+        in the /molecule endpoint. Use /drug_warning endpoint for detailed info.
+        """
         record = {
             "molecule_chembl_id": "CHEMBL789",
             "withdrawn_flag": True,
-            "withdrawn_year": 2010,
-            "withdrawn_country": ["United States", "United Kingdom"],
-            "withdrawn_reason": ["Hepatotoxicity", "Cardiotoxicity"],
         }
 
         result = await transformer.transform(mock_context, record)
 
         assert result is not None
         assert result["withdrawn_flag"] is True
-        assert result["withdrawn_year"] == 2010
-        # JSON serialized fields
-        assert isinstance(result["withdrawn_country"], str)
-        assert isinstance(result["withdrawn_reason"], str)
-        assert "United States" in result["withdrawn_country"]
-        assert "Hepatotoxicity" in result["withdrawn_reason"]
 
     @pytest.mark.asyncio
     async def test_transform_with_usan_fields(self, transformer, mock_context):
@@ -390,17 +385,18 @@ class TestMoleculeTransformer:
         assert result["usan_year"] == 2015
 
     @pytest.mark.asyncio
-    async def test_transform_with_new_properties(self, transformer, mock_context):
-        """Test transformation with new ACD and other property fields."""
+    async def test_transform_with_extended_properties(self, transformer, mock_context):
+        """Test transformation with extended property fields.
+
+        Note: acd_logd, acd_logp, acd_most_apka, acd_most_bpka are not available
+        in the public ChEMBL API.
+        """
         record = {
             "molecule_chembl_id": "CHEMBL5678",
             "molecule_properties": {
                 "alogp": 2.5,
                 "mw_freebase": 300.5,
-                "acd_logd": 1.8,
-                "acd_logp": 2.3,
-                "acd_most_apka": 4.5,
-                "acd_most_bpka": 9.2,
+                "num_ro5_violations": 1,
                 "full_molformula": "C15H12O3",
                 "ro3_pass": "Y",
             },
@@ -410,10 +406,8 @@ class TestMoleculeTransformer:
 
         assert result is not None
         assert result["property_alogp"] == 2.5
-        assert result["property_acd_logd"] == 1.8
-        assert result["property_acd_logp"] == 2.3
-        assert result["property_acd_most_apka"] == 4.5
-        assert result["property_acd_most_bpka"] == 9.2
+        assert result["property_mw_freebase"] == 300.5
+        assert result["property_ro5_violations"] == 1
         assert result["property_full_molformula"] == "C15H12O3"
         assert result["property_ro3_pass"] == "Y"
 


### PR DESCRIPTION
- Fix ro5_violations mapping: use `num_ro5_violations` instead of non-existent `num_lipinski_ro5_violations`
- Remove ACD fields (acd_logd, acd_logp, acd_most_apka, acd_most_bpka) as they are not available in public ChEMBL API
- Remove withdrawn_year, withdrawn_country, withdrawn_reason fields as they are only available via separate /drug_warning endpoint
- Keep withdrawn_flag which works correctly from /molecule endpoint
- Update tests and snapshots accordingly