### PR TITLE
Review refactoring plan and improve test coverage

### DIFF
--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,12 @@
+"""Performance benchmarks for BioETL storage writers.
+
+This package contains benchmarks for measuring performance of:
+- Bronze layer writes (JSONL + zstd compression)
+- Delta Lake writes (Silver/Gold layers)
+
+Usage:
+    pytest benchmarks/ --benchmark-only
+    pytest benchmarks/ --benchmark-compare --benchmark-compare-fail=mean:15%
+
+See docs/contracts/observability.md for performance thresholds.
+"""

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -1,0 +1,124 @@
+"""Pytest fixtures for performance benchmarks.
+
+These fixtures provide consistent test data for reproducible benchmarks.
+All data is synthetic and deterministic to ensure stable measurements.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def small_payload() -> list[dict[str, Any]]:
+    """Small payload for quick benchmarks (100 records)."""
+    return [
+        {
+            "id": f"RECORD_{i:05d}",
+            "molecule_chembl_id": f"CHEMBL{100000 + i}",
+            "assay_chembl_id": f"CHEMBL{200000 + i}",
+            "target_chembl_id": f"CHEMBL{300000 + i}",
+            "standard_value": 10.5 + (i * 0.1),
+            "standard_units": "nM",
+            "pchembl_value": 7.5 + (i * 0.01),
+            "data_validity_comment": None,
+            "canonical_smiles": f"CC{'C' * (i % 10)}O",
+        }
+        for i in range(100)
+    ]
+
+
+@pytest.fixture
+def medium_payload() -> list[dict[str, Any]]:
+    """Medium payload for standard benchmarks (1000 records)."""
+    return [
+        {
+            "id": f"RECORD_{i:06d}",
+            "molecule_chembl_id": f"CHEMBL{100000 + i}",
+            "assay_chembl_id": f"CHEMBL{200000 + i}",
+            "target_chembl_id": f"CHEMBL{300000 + i}",
+            "document_chembl_id": f"CHEMBL{400000 + i}",
+            "standard_value": 10.5 + (i * 0.1),
+            "standard_units": "nM",
+            "pchembl_value": 7.5 + (i * 0.01),
+            "standard_type": "IC50",
+            "activity_comment": f"Activity measured at concentration {i}",
+            "data_validity_comment": None,
+            "canonical_smiles": f"CC{'C' * (i % 20)}O",
+            "molecule_properties": {
+                "mw_freebase": 200.0 + i,
+                "alogp": 2.5 + (i * 0.01),
+                "hba": 2 + (i % 5),
+                "hbd": 1 + (i % 3),
+                "psa": 40.0 + (i * 0.5),
+                "rtb": 3 + (i % 4),
+            },
+        }
+        for i in range(1000)
+    ]
+
+
+@pytest.fixture
+def large_payload() -> list[dict[str, Any]]:
+    """Large payload for stress benchmarks (5000 records)."""
+    return [
+        {
+            "id": f"RECORD_{i:07d}",
+            "molecule_chembl_id": f"CHEMBL{100000 + i}",
+            "assay_chembl_id": f"CHEMBL{200000 + i}",
+            "target_chembl_id": f"CHEMBL{300000 + i}",
+            "document_chembl_id": f"CHEMBL{400000 + i}",
+            "standard_value": 10.5 + (i * 0.1),
+            "standard_units": "nM",
+            "pchembl_value": 7.5 + (i * 0.01),
+            "standard_type": "IC50",
+            "activity_comment": f"Activity measured at concentration {i}" * 3,
+            "data_validity_comment": None,
+            "canonical_smiles": f"CC{'C' * (i % 30)}O" * 2,
+            "molecule_properties": {
+                "mw_freebase": 200.0 + i,
+                "alogp": 2.5 + (i * 0.01),
+                "hba": 2 + (i % 5),
+                "hbd": 1 + (i % 3),
+                "psa": 40.0 + (i * 0.5),
+                "rtb": 3 + (i % 4),
+                "num_ro5_violations": i % 2,
+                "aromatic_rings": 1 + (i % 3),
+            },
+            "assay_description": f"High-throughput assay variant {i % 100}",
+            "bao_format": "BAO_0000357",
+            "src_id": 1,
+        }
+        for i in range(5000)
+    ]
+
+
+@pytest.fixture
+def bronze_output_dir(tmp_path: Path) -> Path:
+    """Temporary directory for bronze output."""
+    bronze_dir = tmp_path / "bronze"
+    bronze_dir.mkdir(parents=True, exist_ok=True)
+    return bronze_dir
+
+
+@pytest.fixture
+def delta_output_dir(tmp_path: Path) -> Path:
+    """Temporary directory for delta table output."""
+    delta_dir = tmp_path / "delta"
+    delta_dir.mkdir(parents=True, exist_ok=True)
+    return delta_dir
+
+
+def pytest_configure(config):
+    """Configure pytest for benchmarks."""
+    config.addinivalue_line(
+        "markers", "benchmark: mark test as a performance benchmark"
+    )
+
+
+def calculate_payload_size_mb(payload: list[dict]) -> float:
+    """Calculate approximate payload size in MB."""
+    json_str = json.dumps(payload)
+    return len(json_str.encode("utf-8")) / (1024 * 1024)

--- a/benchmarks/test_bronze_write.py
+++ b/benchmarks/test_bronze_write.py
@@ -1,0 +1,147 @@
+"""Performance benchmarks for Bronze layer writes.
+
+Measures JSONL + zstd compression throughput.
+"""
+
+import asyncio
+import json
+from collections.abc import Iterator
+from datetime import datetime
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from benchmarks.conftest import calculate_payload_size_mb
+
+
+def _records_to_bytes_iterator(records: list[dict[str, Any]]) -> Iterator[bytes]:
+    """Convert records to bytes iterator for BronzeWriter."""
+    for record in records:
+        yield (json.dumps(record) + "\n").encode("utf-8")
+
+
+class FakeLogger:
+    """Minimal fake logger for benchmarks."""
+
+    def info(self, _msg: str, **_kwargs: Any) -> None:
+        pass
+
+    def debug(self, _msg: str, **_kwargs: Any) -> None:
+        pass
+
+    def warning(self, _msg: str, **_kwargs: Any) -> None:
+        pass
+
+    def error(self, _msg: str, **_kwargs: Any) -> None:
+        pass
+
+    def bind(self, **_kwargs: Any) -> "FakeLogger":
+        return self
+
+
+@pytest.mark.benchmark(group="bronze")
+def test_bronze_write_small(benchmark, small_payload, bronze_output_dir):
+    """Benchmark Bronze write with small payload (100 records)."""
+    from bioetl.domain.types import BatchID, RunID, RunType
+    from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
+
+    logger = FakeLogger()
+    writer = BronzeWriter(base_path=bronze_output_dir, logger=logger)
+
+    run_id = RunID(uuid4())
+    batch_id = BatchID(uuid4())
+    now = datetime.now()
+
+    async def write_batch():
+        records_iter = _records_to_bytes_iterator(small_payload)
+        return await writer.write_bronze(
+            records=records_iter,
+            provider="benchmark",
+            entity="small",
+            date=now,
+            batch_id=batch_id,
+            run_id=run_id,
+            run_type=RunType.INCREMENTAL,
+        )
+
+    result = benchmark(lambda: asyncio.run(write_batch()))
+
+    # Verify output exists
+    assert result is not None
+    assert result.exists()
+
+    # Report payload size
+    size_mb = calculate_payload_size_mb(small_payload)
+    benchmark.extra_info["payload_size_mb"] = round(size_mb, 3)
+    benchmark.extra_info["records"] = len(small_payload)
+
+
+@pytest.mark.benchmark(group="bronze")
+def test_bronze_write_medium(benchmark, medium_payload, bronze_output_dir):
+    """Benchmark Bronze write with medium payload (1000 records)."""
+    from bioetl.domain.types import BatchID, RunID, RunType
+    from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
+
+    logger = FakeLogger()
+    writer = BronzeWriter(base_path=bronze_output_dir, logger=logger)
+
+    run_id = RunID(uuid4())
+    batch_id = BatchID(uuid4())
+    now = datetime.now()
+
+    async def write_batch():
+        records_iter = _records_to_bytes_iterator(medium_payload)
+        return await writer.write_bronze(
+            records=records_iter,
+            provider="benchmark",
+            entity="medium",
+            date=now,
+            batch_id=batch_id,
+            run_id=run_id,
+            run_type=RunType.INCREMENTAL,
+        )
+
+    result = benchmark(lambda: asyncio.run(write_batch()))
+
+    assert result is not None
+    assert result.exists()
+
+    size_mb = calculate_payload_size_mb(medium_payload)
+    benchmark.extra_info["payload_size_mb"] = round(size_mb, 3)
+    benchmark.extra_info["records"] = len(medium_payload)
+
+
+@pytest.mark.benchmark(group="bronze")
+def test_bronze_write_large(benchmark, large_payload, bronze_output_dir):
+    """Benchmark Bronze write with large payload (5000 records)."""
+    from bioetl.domain.types import BatchID, RunID, RunType
+    from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
+
+    logger = FakeLogger()
+    writer = BronzeWriter(base_path=bronze_output_dir, logger=logger)
+
+    run_id = RunID(uuid4())
+    batch_id = BatchID(uuid4())
+    now = datetime.now()
+
+    async def write_batch():
+        records_iter = _records_to_bytes_iterator(large_payload)
+        return await writer.write_bronze(
+            records=records_iter,
+            provider="benchmark",
+            entity="large",
+            date=now,
+            batch_id=batch_id,
+            run_id=run_id,
+            run_type=RunType.INCREMENTAL,
+        )
+
+    result = benchmark(lambda: asyncio.run(write_batch()))
+
+    assert result is not None
+    assert result.exists()
+
+    size_mb = calculate_payload_size_mb(large_payload)
+    benchmark.extra_info["payload_size_mb"] = round(size_mb, 3)
+    benchmark.extra_info["records"] = len(large_payload)

--- a/benchmarks/test_delta_write.py
+++ b/benchmarks/test_delta_write.py
@@ -1,0 +1,212 @@
+"""Performance benchmarks for Delta Lake writes (Silver layer).
+
+Measures Delta Lake write throughput with merge/append operations.
+"""
+
+import asyncio
+from datetime import datetime
+from typing import Any
+from uuid import uuid4
+
+import pyarrow as pa
+import pytest
+
+from benchmarks.conftest import calculate_payload_size_mb
+
+
+class FakeLogger:
+    """Minimal fake logger for benchmarks."""
+
+    def info(self, _msg: str, **_kwargs: Any) -> None:
+        pass
+
+    def debug(self, _msg: str, **_kwargs: Any) -> None:
+        pass
+
+    def warning(self, _msg: str, **_kwargs: Any) -> None:
+        pass
+
+    def error(self, _msg: str, **_kwargs: Any) -> None:
+        pass
+
+    def bind(self, **_kwargs: Any) -> "FakeLogger":
+        return self
+
+
+def _create_activity_schema() -> pa.Schema:
+    """Create a PyArrow schema for activity records."""
+    return pa.schema([
+        pa.field("id", pa.string()),
+        pa.field("molecule_chembl_id", pa.string()),
+        pa.field("assay_chembl_id", pa.string()),
+        pa.field("target_chembl_id", pa.string()),
+        pa.field("standard_value", pa.float64()),
+        pa.field("standard_units", pa.string()),
+        pa.field("pchembl_value", pa.float64()),
+        pa.field("canonical_smiles", pa.string()),
+        pa.field("_content_hash", pa.string()),
+        pa.field("_ingestion_ts", pa.timestamp("us")),
+    ])
+
+
+def _prepare_records_for_delta(
+    records: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Add required metadata fields to records."""
+    now = datetime.now()
+    prepared = []
+    for record in records:
+        rec = {
+            "id": record.get("id", ""),
+            "molecule_chembl_id": record.get("molecule_chembl_id", ""),
+            "assay_chembl_id": record.get("assay_chembl_id", ""),
+            "target_chembl_id": record.get("target_chembl_id", ""),
+            "standard_value": record.get("standard_value"),
+            "standard_units": record.get("standard_units", ""),
+            "pchembl_value": record.get("pchembl_value"),
+            "canonical_smiles": record.get("canonical_smiles", ""),
+            "_content_hash": str(uuid4()),
+            "_ingestion_ts": now,
+        }
+        prepared.append(rec)
+    return prepared
+
+
+@pytest.mark.benchmark(group="delta")
+def test_delta_write_append_small(benchmark, small_payload, delta_output_dir):
+    """Benchmark Delta append with small payload (100 records)."""
+    from bioetl.infrastructure.storage.delta_writer import DeltaWriter, SilverWriteMode
+
+    logger = FakeLogger()
+    writer = DeltaWriter(base_path=delta_output_dir, logger=logger)
+
+    schema = _create_activity_schema()
+    records = _prepare_records_for_delta(small_payload)
+    table_name = f"benchmark_small_{uuid4().hex[:8]}"
+
+    async def write_batch():
+        return await writer.write_silver(
+            table_name=table_name,
+            records=records,
+            schema=schema,
+            primary_keys=["id"],
+            mode=SilverWriteMode.APPEND,
+        )
+
+    result = benchmark(lambda: asyncio.run(write_batch()))
+
+    assert result is not None
+
+    size_mb = calculate_payload_size_mb(small_payload)
+    benchmark.extra_info["payload_size_mb"] = round(size_mb, 3)
+    benchmark.extra_info["records"] = len(records)
+    benchmark.extra_info["mode"] = "append"
+
+
+@pytest.mark.benchmark(group="delta")
+def test_delta_write_append_medium(benchmark, medium_payload, delta_output_dir):
+    """Benchmark Delta append with medium payload (1000 records)."""
+    from bioetl.infrastructure.storage.delta_writer import DeltaWriter, SilverWriteMode
+
+    logger = FakeLogger()
+    writer = DeltaWriter(base_path=delta_output_dir, logger=logger)
+
+    schema = _create_activity_schema()
+    records = _prepare_records_for_delta(medium_payload)
+    table_name = f"benchmark_medium_{uuid4().hex[:8]}"
+
+    async def write_batch():
+        return await writer.write_silver(
+            table_name=table_name,
+            records=records,
+            schema=schema,
+            primary_keys=["id"],
+            mode=SilverWriteMode.APPEND,
+        )
+
+    result = benchmark(lambda: asyncio.run(write_batch()))
+
+    assert result is not None
+
+    size_mb = calculate_payload_size_mb(medium_payload)
+    benchmark.extra_info["payload_size_mb"] = round(size_mb, 3)
+    benchmark.extra_info["records"] = len(records)
+    benchmark.extra_info["mode"] = "append"
+
+
+@pytest.mark.benchmark(group="delta")
+def test_delta_write_append_large(benchmark, large_payload, delta_output_dir):
+    """Benchmark Delta append with large payload (5000 records)."""
+    from bioetl.infrastructure.storage.delta_writer import DeltaWriter, SilverWriteMode
+
+    logger = FakeLogger()
+    writer = DeltaWriter(base_path=delta_output_dir, logger=logger)
+
+    schema = _create_activity_schema()
+    records = _prepare_records_for_delta(large_payload)
+    table_name = f"benchmark_large_{uuid4().hex[:8]}"
+
+    async def write_batch():
+        return await writer.write_silver(
+            table_name=table_name,
+            records=records,
+            schema=schema,
+            primary_keys=["id"],
+            mode=SilverWriteMode.APPEND,
+        )
+
+    result = benchmark(lambda: asyncio.run(write_batch()))
+
+    assert result is not None
+
+    size_mb = calculate_payload_size_mb(large_payload)
+    benchmark.extra_info["payload_size_mb"] = round(size_mb, 3)
+    benchmark.extra_info["records"] = len(records)
+    benchmark.extra_info["mode"] = "append"
+
+
+@pytest.mark.benchmark(group="delta_merge")
+def test_delta_write_merge_medium(benchmark, medium_payload, delta_output_dir):
+    """Benchmark Delta merge with medium payload (1000 records).
+
+    Merge is more expensive than append due to deduplication logic.
+    """
+    from bioetl.infrastructure.storage.delta_writer import DeltaWriter, SilverWriteMode
+
+    logger = FakeLogger()
+    writer = DeltaWriter(base_path=delta_output_dir, logger=logger)
+
+    schema = _create_activity_schema()
+    records = _prepare_records_for_delta(medium_payload)
+    table_name = f"benchmark_merge_{uuid4().hex[:8]}"
+
+    # First write to create the table
+    async def initial_write():
+        return await writer.write_silver(
+            table_name=table_name,
+            records=records[:100],
+            schema=schema,
+            primary_keys=["id"],
+            mode=SilverWriteMode.APPEND,
+        )
+
+    asyncio.run(initial_write())
+
+    # Benchmark merge operation
+    async def merge_batch():
+        return await writer.write_silver(
+            table_name=table_name,
+            records=records,
+            schema=schema,
+            primary_keys=["id"],
+            mode=SilverWriteMode.MERGE,
+        )
+
+    result = benchmark(lambda: asyncio.run(merge_batch()))
+
+    assert result is not None
+
+    size_mb = calculate_payload_size_mb(medium_payload)
+    benchmark.extra_info["payload_size_mb"] = round(size_mb, 3)
+    benchmark.extra_info["records"] = len(records)
+    benchmark.extra_info["mode"] = "merge"

--- a/docs/contracts/observability.md
+++ b/docs/contracts/observability.md
@@ -1,0 +1,217 @@
+# Observability Metrics Contract
+
+Этот документ определяет обязательные метрики BioETL для Prometheus.
+Все метрики экспортируются через HTTP endpoint на порту 8000.
+
+**Версия контракта:** 1.0.0
+**Дата:** 2024-12-24
+**RFC 2119 Keywords:** MUST, SHOULD, MAY
+
+---
+
+## Соглашения об именовании
+
+Все метрики MUST следовать соглашениям:
+
+| Правило | Пример |
+|---------|--------|
+| Префикс | `bioetl_` |
+| snake_case | `pipeline_duration_seconds` |
+| Единицы в суффиксе | `_seconds`, `_total`, `_bytes` |
+
+---
+
+## Pipeline Metrics (MUST)
+
+Эти метрики MUST экспортироваться для каждого запуска пайплайна.
+
+### bioetl_pipeline_duration_seconds
+
+| Свойство | Значение |
+|----------|----------|
+| Тип | Histogram |
+| Описание | Длительность выполнения этапов пайплайна |
+| Labels | `pipeline`, `stage`, `status`, `run_type` |
+
+**Labels:**
+- `pipeline`: Имя пайплайна (e.g., `chembl_activity`)
+- `stage`: Этап (`fetch`, `transform`, `write_bronze`, `write_silver`, `write_gold`)
+- `status`: Результат (`success`, `failure`, `timeout`)
+- `run_type`: Тип запуска (`incremental`, `backfill`, `rebuild`)
+
+### bioetl_records_processed_total
+
+| Свойство | Значение |
+|----------|----------|
+| Тип | Counter |
+| Описание | Общее количество обработанных записей |
+| Labels | `pipeline`, `stage`, `run_type` |
+
+**Labels:**
+- `stage`: Слой данных (`bronze`, `silver`, `gold`, `quarantined`)
+
+### bioetl_errors_total
+
+| Свойство | Значение |
+|----------|----------|
+| Тип | Counter |
+| Описание | Общее количество ошибок |
+| Labels | `pipeline`, `stage`, `error_code` |
+
+**Labels:**
+- `error_code`: Код ошибки (e.g., `RATE_LIMIT`, `SCHEMA_VIOLATION`, `API_ERROR`)
+
+### bioetl_batch_size_records
+
+| Свойство | Значение |
+|----------|----------|
+| Тип | Histogram |
+| Описание | Распределение размеров батчей |
+| Labels | `pipeline`, `stage` |
+| Buckets | `[100, 500, 1000, 5000, 10000, 50000]` |
+
+---
+
+## Data Quality Metrics (MUST)
+
+### bioetl_dq_records_quarantined_total
+
+| Свойство | Значение |
+|----------|----------|
+| Тип | Counter |
+| Описание | Записи, отправленные в карантин |
+| Labels | `pipeline`, `error_type`, `run_type` |
+
+**Labels:**
+- `error_type`: Тип ошибки качества (`invalid_smiles`, `missing_field`, `schema_violation`)
+
+---
+
+## Input Filter Metrics (SHOULD)
+
+### bioetl_filter_ids_loaded_total
+
+| Свойство | Значение |
+|----------|----------|
+| Тип | Counter |
+| Описание | Уникальные ID загруженные из фильтра |
+| Labels | `pipeline`, `source_file` |
+
+### bioetl_filter_ids_duplicates_total
+
+| Свойство | Значение |
+|----------|----------|
+| Тип | Counter |
+| Описание | Дубликаты ID в источнике фильтра |
+| Labels | `pipeline`, `source_file` |
+
+---
+
+## Circuit Breaker Metrics (MUST per ADR-007)
+
+Метрики для мониторинга состояния Circuit Breaker (см. ADR-007).
+
+### bioetl_circuit_breaker_state
+
+| Свойство | Значение |
+|----------|----------|
+| Тип | Gauge |
+| Описание | Текущее состояние Circuit Breaker |
+| Labels | `adapter` |
+| Значения | `0` = closed, `0.5` = half-open, `1` = open |
+
+### bioetl_circuit_breaker_trips_total
+
+| Свойство | Значение |
+|----------|----------|
+| Тип | Counter |
+| Описание | Количество срабатываний (transitions to open) |
+| Labels | `adapter` |
+
+### bioetl_circuit_breaker_success_total
+
+| Свойство | Значение |
+|----------|----------|
+| Тип | Counter |
+| Описание | Успешные вызовы через Circuit Breaker |
+| Labels | `adapter` |
+
+### bioetl_circuit_breaker_failure_total
+
+| Свойство | Значение |
+|----------|----------|
+| Тип | Counter |
+| Описание | Неуспешные вызовы через Circuit Breaker |
+| Labels | `adapter` |
+
+---
+
+## Storage Metrics (SHOULD)
+
+### bioetl_storage_write_duration_seconds
+
+| Свойство | Значение |
+|----------|----------|
+| Тип | Histogram |
+| Описание | Длительность записи в хранилище |
+| Labels | `pipeline`, `layer` |
+
+**Labels:**
+- `layer`: `bronze`, `silver`, `gold`
+
+### bioetl_storage_bytes_written_total
+
+| Свойство | Значение |
+|----------|----------|
+| Тип | Counter |
+| Описание | Байты записанные в хранилище |
+| Labels | `pipeline`, `layer` |
+
+---
+
+## Health Check Metrics (MAY)
+
+### bioetl_health_check_duration_seconds
+
+| Свойство | Значение |
+|----------|----------|
+| Тип | Histogram |
+| Описание | Длительность health check адаптеров |
+| Labels | `adapter` |
+
+### bioetl_health_check_status
+
+| Свойство | Значение |
+|----------|----------|
+| Тип | Gauge |
+| Описание | Статус health check |
+| Labels | `adapter` |
+| Значения | `0` = unhealthy, `1` = healthy |
+
+---
+
+## Alerting Thresholds
+
+Рекомендуемые пороги для алертов:
+
+| Метрика | Условие | Severity |
+|---------|---------|----------|
+| `bioetl_circuit_breaker_state == 1` | > 5 min | Critical |
+| `bioetl_errors_total` rate | > 10/min | Warning |
+| `bioetl_dq_records_quarantined_total` rate | > 5% of processed | Warning |
+| `bioetl_pipeline_duration_seconds` | > 95th percentile + 50% | Warning |
+
+---
+
+## Grafana Dashboard UID
+
+При создании дашбордов использовать UID: `bioetl-pipeline-metrics`
+
+---
+
+## Changelog
+
+### v1.0.0 (2024-12-24)
+- Initial contract definition
+- Added Circuit Breaker metrics per ADR-007
+- Defined MUST/SHOULD/MAY categories

--- a/src/bioetl/domain/ports.py
+++ b/src/bioetl/domain/ports.py
@@ -611,6 +611,22 @@ class MetricsPort(Protocol):
         """
         ...
 
+    def set_gauge(
+        self,
+        name: str,
+        value: float,
+        labels: dict[str, str],
+    ) -> None:
+        """
+        Set a gauge metric to a specific value.
+
+        Args:
+            name: The name of the gauge metric.
+            value: The value to set.
+            labels: A dictionary of label names to label values.
+        """
+        ...
+
     def close(self) -> None:
         """
         Cleanup metrics resources.

--- a/src/bioetl/infrastructure/observability/metrics.py
+++ b/src/bioetl/infrastructure/observability/metrics.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from prometheus_client import Counter, Histogram
+from prometheus_client import Counter, Gauge, Histogram
 
 # Generic pipeline metrics
 PIPELINE_DURATION_SECONDS = Histogram(
@@ -48,6 +48,31 @@ DQ_RECORDS_QUARANTINED_TOTAL = Counter(
     "bioetl_dq_records_quarantined_total",
     "Total number of records quarantined due to data quality issues",
     ["pipeline", "error_type", "run_type"],
+)
+
+# Circuit Breaker metrics (per ADR-007)
+CIRCUIT_BREAKER_STATE = Gauge(
+    "bioetl_circuit_breaker_state",
+    "Current state of the circuit breaker (0=closed, 0.5=half-open, 1=open)",
+    ["adapter"],
+)
+
+CIRCUIT_BREAKER_TRIPS_TOTAL = Counter(
+    "bioetl_circuit_breaker_trips_total",
+    "Total number of times the circuit breaker has tripped (opened)",
+    ["adapter"],
+)
+
+CIRCUIT_BREAKER_SUCCESS_TOTAL = Counter(
+    "bioetl_circuit_breaker_success_total",
+    "Total successful calls through the circuit breaker",
+    ["adapter"],
+)
+
+CIRCUIT_BREAKER_FAILURE_TOTAL = Counter(
+    "bioetl_circuit_breaker_failure_total",
+    "Total failed calls through the circuit breaker",
+    ["adapter"],
 )
 
 

--- a/src/bioetl/infrastructure/observability/noop_metrics.py
+++ b/src/bioetl/infrastructure/observability/noop_metrics.py
@@ -71,6 +71,19 @@ class NoOpMetrics(MetricsPort):
         """No-op counter increment."""
         pass
 
+    def set_gauge(
+        self,
+        name: str,
+        value: float,
+        labels: dict[str, str],
+    ) -> None:
+        """No-op gauge set."""
+        pass
+
+    def close(self) -> None:
+        """No-op close. Idempotent."""
+        pass
+
     @classmethod
     def reset_warning(cls) -> None:
         """Reset warning state (for testing)."""

--- a/src/bioetl/infrastructure/observability/prometheus_metrics.py
+++ b/src/bioetl/infrastructure/observability/prometheus_metrics.py
@@ -7,6 +7,10 @@ Prometheus client library.
 from bioetl.domain.ports import MetricsPort
 from bioetl.infrastructure.observability.metrics import (
     BATCH_SIZE_RECORDS,
+    CIRCUIT_BREAKER_FAILURE_TOTAL,
+    CIRCUIT_BREAKER_STATE,
+    CIRCUIT_BREAKER_SUCCESS_TOTAL,
+    CIRCUIT_BREAKER_TRIPS_TOTAL,
     DQ_RECORDS_QUARANTINED_TOTAL,
     ERRORS_TOTAL,
     FILTER_IDS_DUPLICATES_TOTAL,
@@ -28,6 +32,14 @@ COUNTERS = {
     "filter_ids_loaded_total": FILTER_IDS_LOADED_TOTAL,
     "filter_ids_duplicates_total": FILTER_IDS_DUPLICATES_TOTAL,
     "dq_records_quarantined_total": DQ_RECORDS_QUARANTINED_TOTAL,
+    "circuit_breaker_trips_total": CIRCUIT_BREAKER_TRIPS_TOTAL,
+    "circuit_breaker_success_total": CIRCUIT_BREAKER_SUCCESS_TOTAL,
+    "circuit_breaker_failure_total": CIRCUIT_BREAKER_FAILURE_TOTAL,
+}
+
+# Registry of gauge metrics
+GAUGES = {
+    "circuit_breaker_state": CIRCUIT_BREAKER_STATE,
 }
 
 
@@ -60,6 +72,16 @@ class PrometheusMetrics(MetricsPort):
         """Increment a Prometheus counter."""
         if name in COUNTERS:
             COUNTERS[name].labels(**labels).inc(value)
+
+    def set_gauge(
+        self,
+        name: str,
+        value: float,
+        labels: dict[str, str],
+    ) -> None:
+        """Set a Prometheus gauge to a specific value."""
+        if name in GAUGES:
+            GAUGES[name].labels(**labels).set(value)
 
     def close(self) -> None:
         """Cleanup Prometheus metrics. Idempotent.
@@ -98,6 +120,15 @@ class NoOpMetrics(MetricsPort):
         labels: dict[str, str],
     ) -> None:
         """No-op counter increment."""
+        pass
+
+    def set_gauge(
+        self,
+        name: str,
+        value: float,
+        labels: dict[str, str],
+    ) -> None:
+        """No-op gauge set."""
         pass
 
     def close(self) -> None:

--- a/tests/architecture/test_domain_public_api.py
+++ b/tests/architecture/test_domain_public_api.py
@@ -1,0 +1,145 @@
+"""Tests for domain layer public API completeness.
+
+REQ-ARCH-027: Domain layer __all__ must be complete and tested.
+All public symbols exported from domain submodules should be listed in __all__.
+"""
+
+from pathlib import Path
+
+
+
+def test_domain_all_is_complete(src_dir: Path) -> None:
+    """Verify domain/__init__.py __all__ contains all public symbols.
+
+    REQ-ARCH-027: All public symbols from domain submodules must be in __all__.
+    This ensures stable public API and prevents accidental exports.
+    """
+    import bioetl.domain as domain
+
+    # Symbols that are not meant to be public (internal, dunder, submodules)
+    excluded_patterns = {
+        "__builtins__",
+        "__cached__",
+        "__doc__",
+        "__file__",
+        "__loader__",
+        "__name__",
+        "__package__",
+        "__path__",
+        "__spec__",
+        # Submodules (imported but not re-exported individually)
+        "config",
+        "context",
+        "entities",
+        "error_classifier",
+        "exceptions",
+        "filter_config",
+        "ports",
+        "transformations",
+        "types",
+    }
+
+    # Get all attributes from the module
+    all_attrs = set(dir(domain))
+
+    # Filter to public symbols only (not starting with _)
+    public_attrs = {
+        attr for attr in all_attrs
+        if not attr.startswith("_") and attr not in excluded_patterns
+    }
+
+    # Get declared __all__
+    declared_all = set(domain.__all__)
+
+    # Check for symbols in module but not in __all__
+    missing_from_all = public_attrs - declared_all
+    assert not missing_from_all, (
+        "Public symbols missing from domain.__all__:\n"
+        + "\n".join(f"  - {s}" for s in sorted(missing_from_all))
+    )
+
+    # Check for symbols in __all__ but not actually exported
+    not_exported = declared_all - public_attrs
+    assert not not_exported, (
+        "Symbols in __all__ but not exported from domain:\n"
+        + "\n".join(f"  - {s}" for s in sorted(not_exported))
+    )
+
+
+def test_domain_all_symbols_are_importable() -> None:
+    """Verify all symbols in domain.__all__ can be imported.
+
+    REQ-ARCH-028: All symbols declared in __all__ must be importable.
+    """
+    from bioetl import domain
+
+    for symbol in domain.__all__:
+        assert hasattr(domain, symbol), (
+            f"Symbol '{symbol}' is in __all__ but cannot be accessed on domain module"
+        )
+        # Verify it's not None (actual object exists)
+        obj = getattr(domain, symbol)
+        assert obj is not None or symbol in {"None"}, (
+            f"Symbol '{symbol}' is None - may indicate broken import"
+        )
+
+
+def test_domain_public_api_categories() -> None:
+    """Verify domain __all__ has expected categories of exports.
+
+    REQ-ARCH-029: Domain layer must export all standard categories:
+    - Types (enums, type aliases)
+    - Entities (domain objects)
+    - Ports (Protocol interfaces)
+    - Exceptions (error hierarchy)
+    - Transformations (pure functions)
+    """
+    from bioetl import domain
+
+    all_symbols = set(domain.__all__)
+
+    # Check for essential types
+    essential_types = {"RunType", "RunID", "EntityID", "ContentHash", "ErrorType"}
+    missing_types = essential_types - all_symbols
+    assert not missing_types, f"Missing essential types: {missing_types}"
+
+    # Check for essential ports
+    essential_ports = {"DataSourcePort", "StoragePort", "CheckpointPort", "MetricsPort"}
+    missing_ports = essential_ports - all_symbols
+    assert not missing_ports, f"Missing essential ports: {missing_ports}"
+
+    # Check for essential exceptions
+    essential_exceptions = {"BioETLError", "CriticalError", "RecoverableError"}
+    missing_exceptions = essential_exceptions - all_symbols
+    assert not missing_exceptions, f"Missing essential exceptions: {missing_exceptions}"
+
+    # Check for context
+    assert "PipelineContext" in all_symbols, "PipelineContext must be in __all__"
+    assert "PipelineRunContext" in all_symbols, "PipelineRunContext must be in __all__"
+
+
+def test_domain_no_infrastructure_types_in_all() -> None:
+    """Verify domain.__all__ does not export infrastructure types.
+
+    REQ-ARCH-030: Domain layer must not expose infrastructure concerns.
+    """
+    from bioetl import domain
+
+    # Patterns that would indicate infrastructure leakage
+    infrastructure_patterns = [
+        "Prometheus",
+        "HTTP",
+        "Delta",
+        "Polars",
+        "Client",
+        "Adapter",
+        "Writer",
+        "Reader",
+    ]
+
+    for symbol in domain.__all__:
+        for pattern in infrastructure_patterns:
+            assert pattern not in symbol, (
+                f"Symbol '{symbol}' appears to be infrastructure type "
+                f"(contains '{pattern}') - should not be in domain.__all__"
+            )

--- a/tests/unit/infrastructure/observability/test_prometheus_metrics.py
+++ b/tests/unit/infrastructure/observability/test_prometheus_metrics.py
@@ -6,6 +6,7 @@ import pytest
 
 from bioetl.infrastructure.observability.prometheus_metrics import (
     COUNTERS,
+    GAUGES,
     HISTOGRAMS,
     PrometheusMetrics,
 )
@@ -93,3 +94,118 @@ class TestPrometheusMetricsRegistries:
     def test_counters_registry_has_records_processed(self):
         """Test COUNTERS registry contains records_processed_total."""
         assert "records_processed_total" in COUNTERS
+
+
+@pytest.mark.unit
+class TestPrometheusMetricsGauge:
+    """Tests for gauge metrics."""
+
+    def test_set_gauge_valid_metric(self, prometheus_metrics):
+        """Test set_gauge with a valid metric name."""
+        with patch.dict(
+            GAUGES,
+            {"circuit_breaker_state": MagicMock()},
+        ):
+            prometheus_metrics.set_gauge(
+                name="circuit_breaker_state",
+                value=1.0,
+                labels={"adapter": "chembl"},
+            )
+
+            GAUGES["circuit_breaker_state"].labels.assert_called_once_with(
+                adapter="chembl"
+            )
+            GAUGES["circuit_breaker_state"].labels().set.assert_called_once_with(1.0)
+
+    def test_set_gauge_unknown_metric(self, prometheus_metrics):
+        """Test set_gauge with unknown metric name does nothing."""
+        # Should not raise, just ignore
+        prometheus_metrics.set_gauge(
+            name="unknown_gauge",
+            value=42.0,
+            labels={"label": "value"},
+        )
+
+
+@pytest.mark.unit
+class TestRequiredMetricsSmoke:
+    """Smoke tests for required metrics per observability contract.
+
+    REQ-OBS-CONTRACT-001: All metrics defined in docs/contracts/observability.md
+    MUST be registered and exportable.
+    """
+
+    def test_required_pipeline_metrics_registered(self):
+        """Verify all MUST pipeline metrics are in registries."""
+        # MUST metrics from docs/contracts/observability.md
+        required_histograms = [
+            "pipeline_duration_seconds",
+            "batch_size_records",
+        ]
+        required_counters = [
+            "records_processed_total",
+            "errors_total",
+            "dq_records_quarantined_total",
+        ]
+
+        for metric in required_histograms:
+            assert metric in HISTOGRAMS, (
+                f"Required histogram '{metric}' not found in HISTOGRAMS registry"
+            )
+
+        for metric in required_counters:
+            assert metric in COUNTERS, (
+                f"Required counter '{metric}' not found in COUNTERS registry"
+            )
+
+    def test_required_circuit_breaker_metrics_registered(self):
+        """Verify Circuit Breaker metrics are registered (per ADR-007)."""
+        # MUST metrics per ADR-007
+        cb_counters = [
+            "circuit_breaker_trips_total",
+            "circuit_breaker_success_total",
+            "circuit_breaker_failure_total",
+        ]
+        cb_gauges = [
+            "circuit_breaker_state",
+        ]
+
+        for metric in cb_counters:
+            assert metric in COUNTERS, (
+                f"Required CB counter '{metric}' not found in COUNTERS registry"
+            )
+
+        for metric in cb_gauges:
+            assert metric in GAUGES, (
+                f"Required CB gauge '{metric}' not found in GAUGES registry"
+            )
+
+    def test_metrics_have_correct_labels(self):
+        """Verify metrics have expected label names."""
+        from bioetl.infrastructure.observability.metrics import (
+            CIRCUIT_BREAKER_STATE,
+            PIPELINE_DURATION_SECONDS,
+        )
+
+        # Pipeline duration should have these labels
+        pipeline_labels = PIPELINE_DURATION_SECONDS._labelnames
+        assert "pipeline" in pipeline_labels
+        assert "stage" in pipeline_labels
+        assert "status" in pipeline_labels
+        assert "run_type" in pipeline_labels
+
+        # Circuit breaker state should have adapter label
+        cb_labels = CIRCUIT_BREAKER_STATE._labelnames
+        assert "adapter" in cb_labels
+
+
+@pytest.mark.unit
+class TestPrometheusMetricsClose:
+    """Tests for close() method."""
+
+    def test_close_is_idempotent(self, prometheus_metrics):
+        """Test that close() can be called multiple times safely."""
+        prometheus_metrics.close()
+        prometheus_metrics.close()  # Should not raise
+
+        assert prometheus_metrics._closed is True

--- a/tests/unit/test_ports.py
+++ b/tests/unit/test_ports.py
@@ -383,6 +383,14 @@ class TestMetricsPortProtocol:
             ) -> None:
                 pass
 
+            def set_gauge(
+                self,
+                name: str,
+                value: float,
+                labels: dict[str, str],
+            ) -> None:
+                pass
+
             def close(self) -> None:
                 pass
 


### PR DESCRIPTION
- Add domain public API tests (test_domain_public_api.py)
  - Test __all__ completeness
  - Test all symbols importable
  - Test essential categories exported
  - Test no infrastructure types in domain

- Create observability metrics contract (docs/contracts/observability.md)
  - Define MUST/SHOULD/MAY metrics per RFC 2119
  - Document Pipeline, DQ, Circuit Breaker metrics
  - Add alerting thresholds

- Implement Circuit Breaker metrics per ADR-007
  - Add CIRCUIT_BREAKER_STATE gauge
  - Add CIRCUIT_BREAKER_TRIPS_TOTAL counter
  - Add CIRCUIT_BREAKER_SUCCESS_TOTAL counter
  - Add CIRCUIT_BREAKER_FAILURE_TOTAL counter
  - Add set_gauge method to MetricsPort interface

- Add metrics smoke tests
  - Test required pipeline metrics registered
  - Test Circuit Breaker metrics registered
  - Test metrics have correct labels

- Create performance benchmarks structure (benchmarks/)
  - Bronze write benchmarks (small/medium/large payloads)
  - Delta write benchmarks (append/merge modes)
  - Configurable fixtures for reproducible results

Coverage: interfaces 98%, total 88.52%