### PR TITLE
Fix empty protein classification fields in pipeline

### DIFF
--- a/src/bioetl/application/pipelines/chembl/target_component_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/target_component_transformer.py
@@ -59,6 +59,9 @@ class TargetComponentTransformer(BaseTransformer):
             "target_component_xrefs": self.serialize_json(
                 record.get("target_component_xrefs")
             ),
+            "protein_classifications": self.serialize_json(
+                record.get("protein_classifications")
+            ),
         }
 
         content_hash = self.compute_content_hash(business_data, exclude_none=True)

--- a/src/bioetl/application/pipelines/chembl/target_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/target_transformer.py
@@ -107,16 +107,17 @@ class TargetTransformer(BaseTransformer):
 
         Returns:
             Dict with aggregated lists for accessions, IDs, types, relationships,
-            descriptions, organisms, tax_ids, and protein classifications.
+            descriptions, organisms, and tax_ids.
+
+        Note:
+            protein_classifications are NOT available in /target endpoint.
+            They are only available via /target_component endpoint.
 
         """
         if not components or not isinstance(components, list):
             return self._empty_component_result()
 
-        basic_fields = self._extract_basic_component_fields(components)
-        classifications = self._extract_protein_classifications(components)
-
-        return {**basic_fields, **classifications}
+        return self._extract_basic_component_fields(components)
 
     def _empty_component_result(self) -> dict[str, None]:
         """Return empty result dict for missing components."""
@@ -128,9 +129,6 @@ class TargetTransformer(BaseTransformer):
             "component_descriptions": None,
             "component_organisms": None,
             "component_tax_ids": None,
-            "protein_classifications": None,
-            "protein_classification_ids": None,
-            "protein_classification_names": None,
         }
 
     def _extract_basic_component_fields(
@@ -148,44 +146,6 @@ class TargetTransformer(BaseTransformer):
             "component_organisms": extract_list_field(components, "organism"),
             "component_tax_ids": extract_list_field(components, "tax_id", safe_int),
         }
-
-    def _extract_protein_classifications(
-        self, components: list[dict[str, Any]]
-    ) -> dict[str, list[Any] | None]:
-        """Extract protein classification details from components."""
-        short_names: list[str] = []
-        ids: list[int] = []
-        pref_names: list[str] = []
-
-        for c in components:
-            pcs = c.get("protein_classifications")
-            if not pcs or not isinstance(pcs, list):
-                continue
-            for pc in pcs:
-                if not isinstance(pc, dict):
-                    continue
-                self._collect_classification_fields(pc, short_names, ids, pref_names)
-
-        return {
-            "protein_classifications": short_names or None,
-            "protein_classification_ids": ids or None,
-            "protein_classification_names": pref_names or None,
-        }
-
-    def _collect_classification_fields(
-        self,
-        pc: dict[str, Any],
-        short_names: list[str],
-        ids: list[int],
-        pref_names: list[str],
-    ) -> None:
-        """Collect fields from a single protein classification dict."""
-        if short_name := pc.get("short_name"):
-            short_names.append(short_name)
-        if (pc_id := safe_int(pc.get("protein_classification_id"))) is not None:
-            ids.append(pc_id)
-        if pref_name := pc.get("pref_name"):
-            pref_names.append(pref_name)
 
     def _aggregate_synonyms(
         self, components: list[dict[str, Any]] | None

--- a/src/bioetl/domain/entities.py
+++ b/src/bioetl/domain/entities.py
@@ -338,10 +338,8 @@ class Target(BaseEntity):
     component_organisms: list[str] | None = None  # Organisms from components
     component_tax_ids: list[int] | None = None  # Tax IDs from components
 
-    # Protein classification fields (aggregated from components)
-    protein_classifications: list[str] | None = None  # short_name values
-    protein_classification_ids: list[int] | None = None  # protein_classification_id
-    protein_classification_names: list[str] | None = None  # pref_name (class names)
+    # Note: protein_classifications are NOT available in /target endpoint.
+    # They are only available via /target_component endpoint (TargetComponent entity).
 
     def __post_init__(self) -> None:
         super().__post_init__()

--- a/src/bioetl/infrastructure/schemas/gold.py
+++ b/src/bioetl/infrastructure/schemas/gold.py
@@ -149,7 +149,8 @@ class ChEMBLTargetGoldSchema(pa.DataFrameModel):
     target_type: Series[str] = pa.Field(nullable=True)
     organism: Series[str] = pa.Field(nullable=True)
     tax_id: Series[float] = pa.Field(nullable=True, coerce=True)
-    protein_classifications: Series[str] = pa.Field(nullable=True)
+    # Note: protein_classifications not available in /target endpoint
+    # Use ChEMBLTargetComponentGoldSchema for protein classification data
 
     # Metadata
     _run_id: Series[str] = pa.Field(nullable=False)

--- a/src/bioetl/infrastructure/schemas/silver.py
+++ b/src/bioetl/infrastructure/schemas/silver.py
@@ -257,7 +257,8 @@ CHEMBL_TARGET_SCHEMA = pa.schema(
         pa.field("component_types", pa.list_(pa.string())),
         pa.field("component_relationships", pa.list_(pa.string())),
         pa.field("component_descriptions", pa.list_(pa.string())),
-        pa.field("protein_classifications", pa.list_(pa.string())),
+        # Note: protein_classifications not available in /target endpoint
+        # Use /target_component endpoint instead (CHEMBL_TARGET_COMPONENT_SCHEMA)
         # Lineage metadata
         pa.field("_run_id", pa.string()),
         pa.field("_run_type", pa.string()),

--- a/tests/unit/application/pipelines/__snapshots__/test_transformer_snapshots.ambr
+++ b/tests/unit/application/pipelines/__snapshots__/test_transformer_snapshots.ambr
@@ -259,19 +259,10 @@
     'organism': 'Homo sapiens',
     'pipeline_stages': None,
     'pref_name': 'Cyclooxygenase-2',
-    'protein_classification_ids': list([
-      597,
-    ]),
-    'protein_classification_names': list([
-      'Enzyme',
-    ]),
-    'protein_classifications': list([
-      'Oxidoreductase',
-    ]),
     'species_group_flag': None,
     'target_chembl_id': 'CHEMBL1862',
     'target_component_synonyms': None,
-    'target_components': '[{"accession": "P35354", "component_id": 123, "component_type": "PROTEIN", "organism": "Homo sapiens", "tax_id": 9606, "target_component_xrefs": [{"xref_id": "P35354", "xref_src_db": "UniProt"}], "protein_classifications": [{"protein_classification_id": 597, "pref_name": "Enzyme", "short_name": "Oxidoreductase"}]}]',
+    'target_components': '[{"accession": "P35354", "component_id": 123, "component_type": "PROTEIN", "organism": "Homo sapiens", "tax_id": 9606, "target_component_xrefs": [{"xref_id": "P35354", "xref_src_db": "UniProt"}]}]',
     'target_constraints': None,
     'target_type': 'SINGLE PROTEIN',
     'tax_id': 9606,

--- a/tests/unit/application/pipelines/test_chembl_transformers.py
+++ b/tests/unit/application/pipelines/test_chembl_transformers.py
@@ -659,40 +659,6 @@ class TestTargetTransformer:
         assert result["component_tax_ids"] == [9606, 10090]
 
     @pytest.mark.asyncio
-    async def test_transform_extracts_protein_classification_details(
-        self, transformer, mock_context
-    ):
-        """Test transformation extracts full protein classification details."""
-        record = {
-            "target_chembl_id": "CHEMBL1862",
-            "target_components": [
-                {
-                    "accession": "P35354",
-                    "component_id": 200,
-                    "protein_classifications": [
-                        {
-                            "protein_classification_id": 597,
-                            "pref_name": "Enzyme",
-                            "short_name": "Oxidoreductase",
-                        },
-                        {
-                            "protein_classification_id": 598,
-                            "pref_name": "Cyclooxygenase",
-                            "short_name": "COX",
-                        },
-                    ],
-                }
-            ],
-        }
-
-        result = await transformer.transform(mock_context, record)
-
-        assert result is not None
-        assert result["protein_classifications"] == ["Oxidoreductase", "COX"]
-        assert result["protein_classification_ids"] == [597, 598]
-        assert result["protein_classification_names"] == ["Enzyme", "Cyclooxygenase"]
-
-    @pytest.mark.asyncio
     async def test_transform_handles_missing_new_fields_gracefully(
         self, transformer, mock_context
     ):
@@ -770,3 +736,32 @@ class TestTargetComponentTransformer:
         assert result is not None
         assert isinstance(result.get("target_component_synonyms"), str)
         assert isinstance(result.get("target_component_xrefs"), str)
+
+    @pytest.mark.asyncio
+    async def test_transform_with_protein_classifications(
+        self, transformer, mock_context
+    ):
+        """Test transformation extracts protein_classifications as JSON.
+
+        Note: ChEMBL API only returns protein_classification_id in this endpoint.
+        pref_name and short_name are available via /protein_classification/{id}.
+        """
+        record = {
+            "component_id": 456,
+            "accession": "P12345",
+            "protein_classifications": [
+                {"protein_classification_id": 1015},
+                {"protein_classification_id": 422},
+            ],
+        }
+
+        result = await transformer.transform(mock_context, record)
+
+        assert result is not None
+        assert isinstance(result.get("protein_classifications"), str)
+        import json
+
+        classifications = json.loads(result["protein_classifications"])
+        assert len(classifications) == 2
+        assert classifications[0]["protein_classification_id"] == 1015
+        assert classifications[1]["protein_classification_id"] == 422

--- a/tests/unit/application/pipelines/test_transformer_snapshots.py
+++ b/tests/unit/application/pipelines/test_transformer_snapshots.py
@@ -276,6 +276,8 @@ class TestTargetTransformerSnapshot:
 
     @pytest.fixture
     def sample_record(self) -> dict[str, Any]:
+        # Note: protein_classifications are NOT available in /target endpoint.
+        # They are only available via /target_component endpoint.
         return {
             "target_chembl_id": "CHEMBL1862",
             "pref_name": "Cyclooxygenase-2",
@@ -292,13 +294,6 @@ class TestTargetTransformerSnapshot:
                     "tax_id": 9606,
                     "target_component_xrefs": [
                         {"xref_id": "P35354", "xref_src_db": "UniProt"},
-                    ],
-                    "protein_classifications": [
-                        {
-                            "protein_classification_id": 597,
-                            "pref_name": "Enzyme",
-                            "short_name": "Oxidoreductase",
-                        },
                     ],
                 }
             ],


### PR DESCRIPTION
ChEMBL /target endpoint does NOT return protein_classifications in target_components. These fields are only available via the /target_component endpoint.

Changes:
- Remove _extract_protein_classifications from TargetTransformer
- Remove protein_classification_ids/names from Target entity
- Add protein_classifications extraction to TargetComponentTransformer
- Update Silver/Gold schemas accordingly
- Update tests and snapshots to match new structure

The TargetComponent entity now properly extracts protein_classifications as a JSON string from /target_component endpoint responses.