### PR TITLE
Create unified cleanup service

### DIFF
--- a/src/bioetl/application/core/__init__.py
+++ b/src/bioetl/application/core/__init__.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from bioetl.application.core.base import BasePipeline
 from bioetl.application.core.base_transformer import BaseTransformer
 from bioetl.application.core.checkpoint_manager import CheckpointManager
+from bioetl.application.core.cleanup_service import CleanupService
 from bioetl.application.core.lock_manager import LockManager
 from bioetl.application.core.pipeline_services import PipelineServices
 from bioetl.application.core.quarantine_manager import QuarantineManager
@@ -37,6 +38,7 @@ __all__ = [
     "BaseTransformer",
     # Components
     "CheckpointManager",
+    "CleanupService",
     "LockManager",
     # Decomposed config (ADR-0005) - consolidated in domain.config
     "PipelineConfig",

--- a/src/bioetl/application/core/cleanup_service.py
+++ b/src/bioetl/application/core/cleanup_service.py
@@ -1,0 +1,151 @@
+"""Unified Cleanup Service.
+
+Application Service для очистки данных Silver и Gold слоёв.
+Единая точка входа для preview и actual cleanup операций.
+
+Implements RULES.md §2.3 - Medallion Architecture cleanup invariants.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+from bioetl.domain.types import CleanupPreview, CleanupResult, LayerPreview
+
+if TYPE_CHECKING:
+    from bioetl.domain.ports import LoggerPort, StoragePort
+
+
+class CleanupService:
+    """Сервис унифицированной очистки данных.
+
+    Предоставляет единую точку входа для:
+    - Предпросмотра очистки (preview)
+    - Выполнения очистки (execute)
+
+    Соблюдает архитектурные инварианты Medallion:
+    - Очистка только для REBUILD и BACKFILL операций
+    - INCREMENTAL операции используют merge/upsert
+
+    Example:
+        >>> service = CleanupService(storage=storage, logger=logger)
+        >>> preview = await service.preview("chembl.activity", "chembl.activity")
+        >>> result = await service.execute("chembl.activity", "chembl.activity", dry_run=False)
+    """
+
+    def __init__(self, storage: StoragePort, logger: LoggerPort) -> None:
+        """Инициализация сервиса очистки.
+
+        Args:
+            storage: Порт хранилища данных.
+            logger: Порт логирования.
+        """
+        self._storage = storage
+        self._logger = logger
+
+    async def preview(
+        self,
+        silver_table: str,
+        gold_table: str | None = None,
+    ) -> CleanupPreview:
+        """Предпросмотр операции очистки без фактического удаления.
+
+        Args:
+            silver_table: Имя таблицы Silver слоя.
+            gold_table: Имя таблицы Gold слоя (опционально).
+
+        Returns:
+            CleanupPreview с информацией о файлах для очистки.
+        """
+        # StoragePort.preview_cleanup возвращает dict[str, Any]
+        # Выполняем в executor для избежания блокировки event loop
+        loop = asyncio.get_running_loop()
+        preview_dict: dict[str, Any] = await loop.run_in_executor(
+            None,
+            lambda: self._storage.preview_cleanup(
+                silver_table=silver_table,
+                gold_table=gold_table,
+            ),
+        )
+
+        # Преобразуем dict в типизированный CleanupPreview
+        silver_info = preview_dict["silver"]
+        silver_preview = LayerPreview(
+            path=silver_info["path"],
+            file_count=silver_info["file_count"],
+            exists=silver_info["exists"],
+        )
+
+        gold_preview: LayerPreview | None = None
+        if preview_dict.get("gold"):
+            gold_info = preview_dict["gold"]
+            gold_preview = LayerPreview(
+                path=gold_info["path"],
+                file_count=gold_info["file_count"],
+                exists=gold_info["exists"],
+            )
+
+        return CleanupPreview(
+            silver=silver_preview,
+            gold=gold_preview,
+            total_files=preview_dict["total_files"],
+        )
+
+    async def execute(
+        self,
+        silver_table: str,
+        gold_table: str | None = None,
+        *,
+        dry_run: bool = False,
+    ) -> CleanupResult:
+        """Выполнение очистки Silver и Gold слоёв.
+
+        Args:
+            silver_table: Имя таблицы Silver слоя.
+            gold_table: Имя таблицы Gold слоя (опционально).
+            dry_run: Если True, только подсчитывает без удаления.
+
+        Returns:
+            CleanupResult с информацией об очищенных элементах.
+        """
+        # Очистка Silver слоя
+        silver_cleared = await self._storage.clear_silver(
+            silver_table, dry_run=dry_run
+        )
+
+        # Очистка Gold слоя (если указано)
+        gold_cleared = 0
+        if gold_table:
+            gold_cleared = await self._storage.clear_gold(gold_table, dry_run=dry_run)
+
+        total_cleared = silver_cleared + gold_cleared
+
+        # Логирование результатов
+        if dry_run:
+            self._logger.info(
+                "DRY RUN: Would clear storage",
+                extra={
+                    "silver_table": silver_table,
+                    "gold_table": gold_table,
+                    "silver_would_clear": silver_cleared,
+                    "gold_would_clear": gold_cleared,
+                },
+            )
+        elif total_cleared > 0:
+            self._logger.info(
+                "Cleared storage",
+                extra={
+                    "silver_table": silver_table,
+                    "gold_table": gold_table,
+                    "silver_cleared": silver_cleared,
+                    "gold_cleared": gold_cleared,
+                },
+            )
+
+        return CleanupResult(
+            silver_cleared=silver_cleared,
+            gold_cleared=gold_cleared,
+            total_cleared=total_cleared,
+            dry_run=dry_run,
+        )

--- a/src/bioetl/application/core/runner.py
+++ b/src/bioetl/application/core/runner.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
     from bioetl.application.core.base import BasePipeline
     from bioetl.application.core.checkpoint_manager import CheckpointManager
+    from bioetl.application.core.cleanup_service import CleanupService
     from bioetl.application.core.executor import PipelineExecutor
     from bioetl.application.core.pipeline_services import PipelineServices
     from bioetl.application.core.shutdown import ShutdownSignal
@@ -43,6 +44,7 @@ class PipelineRunner:
         logger: structlog.BoundLogger,
         pipeline: BasePipeline | None = None,
         tracer: TracingPort | None = None,
+        cleanup_service: CleanupService | None = None,
     ) -> None:
         """Initialize pipeline runner.
 
@@ -57,6 +59,7 @@ class PipelineRunner:
             logger: Structured logger.
             pipeline: Optional pipeline instance.
             tracer: Optional tracing port.
+            cleanup_service: Optional cleanup service for unified cleanup operations.
 
         """
         self._config = config
@@ -69,6 +72,7 @@ class PipelineRunner:
         self._logger = logger
         self.pipeline = pipeline
         self._tracer = tracer
+        self._cleanup_service = cleanup_service
 
         # The runner is responsible for creating application services
         self._lock_manager = LockManager.create(
@@ -142,6 +146,9 @@ class PipelineRunner:
         - Incremental runs use merge/upsert and should NOT clear existing data
 
         This ensures data integrity and prevents accidental data loss.
+
+        Uses CleanupService for unified cleanup operations if available,
+        otherwise falls back to direct storage operations.
         """
         from bioetl.domain.types import RunType
 
@@ -155,7 +162,6 @@ class PipelineRunner:
             )
             return
 
-        storage = self._services.storage
         silver_table = self._config.silver_table
         # Gold table defaults to {provider}.{entity_type} if not specified
         gold_table = (
@@ -163,7 +169,35 @@ class PipelineRunner:
             or f"{self._config.provider}.{self._config.entity_type}"
         )
 
-        # Clear Silver and Gold layers using StoragePort methods (async)
+        # Use CleanupService if available (unified approach)
+        if self._cleanup_service is not None:
+            result = await self._cleanup_service.execute(
+                silver_table=silver_table,
+                gold_table=gold_table,
+                dry_run=self._runtime.dry_run,
+            )
+
+            # Add run_type to logging context for consistency
+            if self._runtime.dry_run:
+                self._logger.debug(
+                    "Cleanup preview completed",
+                    extra={
+                        "run_type": self._runtime.run_type.value,
+                        "total_would_clear": result.total_cleared,
+                    },
+                )
+            elif result.total_cleared > 0:
+                self._logger.debug(
+                    "Cleanup completed via CleanupService",
+                    extra={
+                        "run_type": self._runtime.run_type.value,
+                        "total_cleared": result.total_cleared,
+                    },
+                )
+            return
+
+        # Fallback: direct storage operations (backward compatibility)
+        storage = self._services.storage
         silver_cleared = await storage.clear_silver(
             silver_table, dry_run=self._runtime.dry_run
         )

--- a/src/bioetl/composition/bootstrap.py
+++ b/src/bioetl/composition/bootstrap.py
@@ -45,6 +45,7 @@ __all__ = [
     "UnifiedHTTPClient",
     "UnifiedQuarantine",
     "bootstrap_checkpoint",
+    "bootstrap_cleanup",
     "bootstrap_logger",
     "bootstrap_metrics",
     "bootstrap_observability",
@@ -58,6 +59,7 @@ if TYPE_CHECKING:
 
     import structlog
 
+    from bioetl.application.core.cleanup_service import CleanupService
     from bioetl.application.core.runner import PipelineRunner
     from bioetl.domain.context import PipelineRunContext
     from bioetl.domain.ports import (
@@ -115,6 +117,23 @@ def bootstrap_storage() -> StorageAdapter:
             csv_exporter=None,
         ),
     )
+
+
+def bootstrap_cleanup() -> CleanupService:
+    """Bootstrap the cleanup service for CLI and Runner operations.
+
+    Creates a CleanupService with storage adapter and logger.
+    Used for both preview and actual cleanup operations.
+
+    Returns:
+        CleanupService configured for the current environment.
+    """
+    from bioetl.application.core.cleanup_service import CleanupService
+
+    storage = bootstrap_storage()
+    logger = NoOpLogger()
+
+    return CleanupService(storage=storage, logger=logger)
 
 
 def bootstrap_logger(

--- a/src/bioetl/composition/factories/generic_factory.py
+++ b/src/bioetl/composition/factories/generic_factory.py
@@ -258,6 +258,14 @@ class GenericPipelineFactory(Generic[TPipeline]):
             checkpoint_interval=pipeline.config.checkpoint_interval,
         )
 
+        # Create CleanupService using pipeline's services
+        from bioetl.application.core.cleanup_service import CleanupService
+
+        cleanup_service = CleanupService(
+            storage=pipeline.services.storage,
+            logger=observability.logger,
+        )
+
         # Assemble Runner
         return PipelineRunner(
             config=pipeline.config,
@@ -270,6 +278,7 @@ class GenericPipelineFactory(Generic[TPipeline]):
             logger=observability.logger,
             pipeline=pipeline,
             tracer=observability.tracer,
+            cleanup_service=cleanup_service,
         )
 
     def _create_checkpoint_manager(

--- a/src/bioetl/domain/types.py
+++ b/src/bioetl/domain/types.py
@@ -259,3 +259,50 @@ class ValidationResult:
 
     valid: bool
     errors: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class LayerPreview:
+    """Предпросмотр слоя для очистки.
+
+    Attributes:
+        path: Путь к директории слоя.
+        file_count: Количество файлов в директории.
+        exists: Существует ли директория.
+    """
+
+    path: str
+    file_count: int
+    exists: bool
+
+
+@dataclass(frozen=True, slots=True)
+class CleanupPreview:
+    """Предпросмотр операции очистки (RULES.md §2.3).
+
+    Attributes:
+        silver: Информация о Silver слое.
+        gold: Информация о Gold слое (опционально).
+        total_files: Общее количество файлов для очистки.
+    """
+
+    silver: LayerPreview
+    gold: LayerPreview | None
+    total_files: int
+
+
+@dataclass(frozen=True, slots=True)
+class CleanupResult:
+    """Результат операции очистки (RULES.md §2.3).
+
+    Attributes:
+        silver_cleared: Количество очищенных элементов в Silver.
+        gold_cleared: Количество очищенных элементов в Gold.
+        total_cleared: Общее количество очищенных элементов.
+        dry_run: True если это был пробный запуск.
+    """
+
+    silver_cleared: int
+    gold_cleared: int
+    total_cleared: int
+    dry_run: bool

--- a/src/bioetl/interfaces/cli.py
+++ b/src/bioetl/interfaces/cli.py
@@ -16,57 +16,43 @@ import click
 from bioetl.application.core.shutdown import PipelineShutdownError
 from bioetl.composition.bootstrap import (
     bootstrap_checkpoint,
+    bootstrap_cleanup,
     bootstrap_pipeline,
     bootstrap_quarantine,
-    bootstrap_storage,
 )
 from bioetl.composition.factories.pipeline_factories import register_all_pipelines
 from bioetl.composition.registry import PipelineRegistry
 from bioetl.domain.context import PipelineRunContext
-from bioetl.domain.types import RunType
+from bioetl.domain.types import CleanupPreview, RunType
 from bioetl.infrastructure.config import load_pipeline_config
 from bioetl.interfaces.orchestration.signals import setup_shutdown_handlers
 
 
-def _preview_cleanup(pipeline: str, run_type: str) -> None:
-    """Preview what data would be cleared in dry-run mode.
-
-    Delegates to StoragePort.preview_cleanup() for clean architecture.
+def _display_cleanup_preview(preview: CleanupPreview) -> None:
+    """Display cleanup preview information to the user.
 
     Args:
-        pipeline: Pipeline name
-        run_type: Type of run (rebuild or backfill)
+        preview: CleanupPreview with layer information.
     """
-    try:
-        config = load_pipeline_config(pipeline)
-        storage = bootstrap_storage()
+    click.echo("\nFiles/directories that would be cleared:")
 
-        preview = storage.preview_cleanup(
-            silver_table=config.silver_table,
-            gold_table=config.gold_table,
+    # Display Silver info
+    if preview.silver.exists:
+        click.echo(
+            f"  Silver: {preview.silver.path} ({preview.silver.file_count} files)"
         )
+    else:
+        click.echo(f"  Silver: {preview.silver.path} (does not exist)")
 
-        click.echo("\nFiles/directories that would be cleared:")
-
-        # Display Silver info
-        silver_info = preview["silver"]
-        if silver_info["exists"]:
-            click.echo(f"  Silver: {silver_info['path']} ({silver_info['file_count']} files)")
+    # Display Gold info
+    if preview.gold:
+        if preview.gold.exists:
+            click.echo(f"  Gold: {preview.gold.path} ({preview.gold.file_count} files)")
         else:
-            click.echo(f"  Silver: {silver_info['path']} (does not exist)")
+            click.echo(f"  Gold: {preview.gold.path} (does not exist)")
 
-        # Display Gold info
-        if preview["gold"]:
-            gold_info = preview["gold"]
-            if gold_info["exists"]:
-                click.echo(f"  Gold: {gold_info['path']} ({gold_info['file_count']} files)")
-            else:
-                click.echo(f"  Gold: {gold_info['path']} (does not exist)")
-
-        click.echo(f"\nTotal items that would be cleared: ~{preview['total_files']}")
-        click.echo("\nNo changes were made (dry-run mode).")
-    except Exception as e:
-        click.echo(f"Error previewing cleanup: {e}", err=True)
+    click.echo(f"\nTotal items that would be cleared: ~{preview.total_files}")
+    click.echo("\nNo changes were made (dry-run mode).")
 
 
 def validate_pipeline_name(_ctx, _param, value):
@@ -142,7 +128,20 @@ def run(
         if dry_run:
             click.echo(f"[DRY-RUN] Would clear data for pipeline: {pipeline}")
             click.echo(f"[DRY-RUN] Run type: {run_type}")
-            _preview_cleanup(pipeline, run_type)
+
+            # Use CleanupService for preview (unified approach)
+            try:
+                config = load_pipeline_config(pipeline)
+                cleanup_service = bootstrap_cleanup()
+                preview = asyncio.run(
+                    cleanup_service.preview(
+                        silver_table=config.silver_table,
+                        gold_table=config.gold_table,
+                    )
+                )
+                _display_cleanup_preview(preview)
+            except Exception as e:
+                click.echo(f"Error previewing cleanup: {e}", err=True)
             return
 
         if not yes:

--- a/tests/unit/application/core/test_cleanup_service.py
+++ b/tests/unit/application/core/test_cleanup_service.py
@@ -1,0 +1,306 @@
+"""Unit tests for CleanupService."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bioetl.application.core.cleanup_service import CleanupService
+from bioetl.domain.types import CleanupPreview, CleanupResult, LayerPreview
+
+
+@pytest.fixture
+def mock_storage():
+    """Create a mock storage port."""
+    storage = MagicMock()
+    storage.preview_cleanup = MagicMock(
+        return_value={
+            "silver": {"path": "/data/silver/test_table", "file_count": 10, "exists": True},
+            "gold": {"path": "/data/gold/test_table", "file_count": 5, "exists": True},
+            "total_files": 15,
+        }
+    )
+    storage.clear_silver = AsyncMock(return_value=10)
+    storage.clear_gold = AsyncMock(return_value=5)
+    return storage
+
+
+@pytest.fixture
+def mock_logger():
+    """Create a mock logger."""
+    logger = MagicMock()
+    logger.info = MagicMock()
+    logger.debug = MagicMock()
+    logger.warning = MagicMock()
+    logger.error = MagicMock()
+    return logger
+
+
+@pytest.fixture
+def cleanup_service(mock_storage, mock_logger):
+    """Create a CleanupService instance."""
+    return CleanupService(storage=mock_storage, logger=mock_logger)
+
+
+@pytest.mark.unit
+class TestCleanupServiceInit:
+    """Tests for CleanupService initialization."""
+
+    def test_initialization(self, mock_storage, mock_logger):
+        """Test service initializes correctly."""
+        service = CleanupService(storage=mock_storage, logger=mock_logger)
+
+        assert service._storage == mock_storage
+        assert service._logger == mock_logger
+
+
+@pytest.mark.unit
+class TestCleanupServicePreview:
+    """Tests for CleanupService.preview method."""
+
+    @pytest.mark.asyncio
+    async def test_preview_returns_cleanup_preview(self, cleanup_service, mock_storage):
+        """Test preview returns typed CleanupPreview."""
+        result = await cleanup_service.preview(
+            silver_table="test_silver",
+            gold_table="test_gold",
+        )
+
+        assert isinstance(result, CleanupPreview)
+        assert isinstance(result.silver, LayerPreview)
+        assert result.silver.path == "/data/silver/test_table"
+        assert result.silver.file_count == 10
+        assert result.silver.exists is True
+
+    @pytest.mark.asyncio
+    async def test_preview_with_gold_table(self, cleanup_service, mock_storage):
+        """Test preview includes gold layer info when gold_table is provided."""
+        result = await cleanup_service.preview(
+            silver_table="test_silver",
+            gold_table="test_gold",
+        )
+
+        assert result.gold is not None
+        assert isinstance(result.gold, LayerPreview)
+        assert result.gold.path == "/data/gold/test_table"
+        assert result.gold.file_count == 5
+        assert result.gold.exists is True
+
+    @pytest.mark.asyncio
+    async def test_preview_without_gold_table(self, mock_storage, mock_logger):
+        """Test preview returns None for gold when gold_table not provided."""
+        mock_storage.preview_cleanup.return_value = {
+            "silver": {"path": "/data/silver/test_table", "file_count": 10, "exists": True},
+            "gold": None,
+            "total_files": 10,
+        }
+        service = CleanupService(storage=mock_storage, logger=mock_logger)
+
+        result = await service.preview(silver_table="test_silver", gold_table=None)
+
+        assert result.gold is None
+        assert result.total_files == 10
+
+    @pytest.mark.asyncio
+    async def test_preview_calls_storage_preview_cleanup(
+        self, cleanup_service, mock_storage
+    ):
+        """Test preview calls storage.preview_cleanup with correct arguments."""
+        await cleanup_service.preview(
+            silver_table="my_silver",
+            gold_table="my_gold",
+        )
+
+        mock_storage.preview_cleanup.assert_called_once_with(
+            silver_table="my_silver",
+            gold_table="my_gold",
+        )
+
+    @pytest.mark.asyncio
+    async def test_preview_total_files_count(self, cleanup_service):
+        """Test preview returns correct total_files count."""
+        result = await cleanup_service.preview(
+            silver_table="test_silver",
+            gold_table="test_gold",
+        )
+
+        assert result.total_files == 15
+
+
+@pytest.mark.unit
+class TestCleanupServiceExecuteDryRun:
+    """Tests for CleanupService.execute method with dry_run=True."""
+
+    @pytest.mark.asyncio
+    async def test_execute_dry_run_returns_cleanup_result(
+        self, cleanup_service, mock_storage
+    ):
+        """Test execute with dry_run returns typed CleanupResult."""
+        result = await cleanup_service.execute(
+            silver_table="test_silver",
+            gold_table="test_gold",
+            dry_run=True,
+        )
+
+        assert isinstance(result, CleanupResult)
+        assert result.dry_run is True
+
+    @pytest.mark.asyncio
+    async def test_execute_dry_run_calls_storage_with_dry_run_flag(
+        self, cleanup_service, mock_storage
+    ):
+        """Test execute passes dry_run=True to storage methods."""
+        await cleanup_service.execute(
+            silver_table="test_silver",
+            gold_table="test_gold",
+            dry_run=True,
+        )
+
+        mock_storage.clear_silver.assert_called_once_with("test_silver", dry_run=True)
+        mock_storage.clear_gold.assert_called_once_with("test_gold", dry_run=True)
+
+    @pytest.mark.asyncio
+    async def test_execute_dry_run_logs_preview_message(
+        self, cleanup_service, mock_logger
+    ):
+        """Test execute with dry_run logs appropriate message."""
+        await cleanup_service.execute(
+            silver_table="test_silver",
+            gold_table="test_gold",
+            dry_run=True,
+        )
+
+        mock_logger.info.assert_called()
+        call_args = mock_logger.info.call_args
+        assert "DRY RUN" in call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_execute_dry_run_returns_counts(self, cleanup_service):
+        """Test execute with dry_run returns correct counts."""
+        result = await cleanup_service.execute(
+            silver_table="test_silver",
+            gold_table="test_gold",
+            dry_run=True,
+        )
+
+        assert result.silver_cleared == 10
+        assert result.gold_cleared == 5
+        assert result.total_cleared == 15
+
+
+@pytest.mark.unit
+class TestCleanupServiceExecuteActual:
+    """Tests for CleanupService.execute method with dry_run=False."""
+
+    @pytest.mark.asyncio
+    async def test_execute_actual_returns_cleanup_result(
+        self, cleanup_service, mock_storage
+    ):
+        """Test execute without dry_run returns typed CleanupResult."""
+        result = await cleanup_service.execute(
+            silver_table="test_silver",
+            gold_table="test_gold",
+            dry_run=False,
+        )
+
+        assert isinstance(result, CleanupResult)
+        assert result.dry_run is False
+
+    @pytest.mark.asyncio
+    async def test_execute_actual_calls_storage_without_dry_run(
+        self, cleanup_service, mock_storage
+    ):
+        """Test execute passes dry_run=False to storage methods."""
+        await cleanup_service.execute(
+            silver_table="test_silver",
+            gold_table="test_gold",
+            dry_run=False,
+        )
+
+        mock_storage.clear_silver.assert_called_once_with("test_silver", dry_run=False)
+        mock_storage.clear_gold.assert_called_once_with("test_gold", dry_run=False)
+
+    @pytest.mark.asyncio
+    async def test_execute_actual_logs_cleared_message(
+        self, cleanup_service, mock_logger
+    ):
+        """Test execute without dry_run logs cleared message when files cleared."""
+        await cleanup_service.execute(
+            silver_table="test_silver",
+            gold_table="test_gold",
+            dry_run=False,
+        )
+
+        mock_logger.info.assert_called()
+        call_args = mock_logger.info.call_args
+        assert "Cleared storage" in call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_execute_actual_no_log_when_nothing_cleared(
+        self, mock_storage, mock_logger
+    ):
+        """Test execute does not log when nothing is cleared."""
+        mock_storage.clear_silver = AsyncMock(return_value=0)
+        mock_storage.clear_gold = AsyncMock(return_value=0)
+        service = CleanupService(storage=mock_storage, logger=mock_logger)
+
+        await service.execute(
+            silver_table="test_silver",
+            gold_table="test_gold",
+            dry_run=False,
+        )
+
+        # info should not be called when nothing is cleared
+        info_calls = [str(call) for call in mock_logger.info.call_args_list]
+        assert not any("Cleared storage" in call for call in info_calls)
+
+    @pytest.mark.asyncio
+    async def test_execute_actual_returns_correct_counts(self, cleanup_service):
+        """Test execute returns correct counts after actual cleanup."""
+        result = await cleanup_service.execute(
+            silver_table="test_silver",
+            gold_table="test_gold",
+            dry_run=False,
+        )
+
+        assert result.silver_cleared == 10
+        assert result.gold_cleared == 5
+        assert result.total_cleared == 15
+
+
+@pytest.mark.unit
+class TestCleanupServiceExecuteWithoutGold:
+    """Tests for CleanupService.execute without gold table."""
+
+    @pytest.mark.asyncio
+    async def test_execute_without_gold_table(self, mock_storage, mock_logger):
+        """Test execute only clears silver when gold_table is None."""
+        service = CleanupService(storage=mock_storage, logger=mock_logger)
+
+        result = await service.execute(
+            silver_table="test_silver",
+            gold_table=None,
+            dry_run=False,
+        )
+
+        mock_storage.clear_silver.assert_called_once()
+        mock_storage.clear_gold.assert_not_called()
+        assert result.gold_cleared == 0
+
+    @pytest.mark.asyncio
+    async def test_execute_without_gold_returns_silver_only_count(
+        self, mock_storage, mock_logger
+    ):
+        """Test execute returns correct total when only silver is cleared."""
+        service = CleanupService(storage=mock_storage, logger=mock_logger)
+
+        result = await service.execute(
+            silver_table="test_silver",
+            gold_table=None,
+            dry_run=False,
+        )
+
+        assert result.silver_cleared == 10
+        assert result.gold_cleared == 0
+        assert result.total_cleared == 10


### PR DESCRIPTION
- Create CleanupService in application/core/cleanup_service.py with async preview() and execute() methods
- Add CleanupPreview, CleanupResult, LayerPreview types to domain/types.py
- Add bootstrap_cleanup() to composition/bootstrap.py
- Refactor CLI to use CleanupService for dry-run preview
- Refactor PipelineRunner to use CleanupService (with backward compat)
- Add GenericPipelineFactory injection of CleanupService
- Add comprehensive unit tests for dry_run and actual cleanup modes

Single entry point for preview and actual cleanup operations. Async methods (sync CLI calls via asyncio.run).
Unified logging through structlog.