### PR TITLE
Add metrics server configuration to settings

### DIFF
--- a/src/bioetl/composition/bootstrap.py
+++ b/src/bioetl/composition/bootstrap.py
@@ -25,7 +25,10 @@ from bioetl.infrastructure.observability.logging import (
 )
 from bioetl.infrastructure.observability.noop_logger import NoOpLogger
 from bioetl.infrastructure.observability.prometheus_metrics import PrometheusMetrics
-from bioetl.infrastructure.observability.server import start_metrics_server
+from bioetl.infrastructure.observability.server import (
+    MetricsServerError,
+    start_metrics_server,
+)
 from bioetl.infrastructure.observability.tracing import NoOpTracer, OpenTelemetryTracer
 from bioetl.infrastructure.quarantine.unified_quarantine import UnifiedQuarantine
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
@@ -39,6 +42,7 @@ __all__ = [
     "GoldWriter",
     "LocalCheckpoint",
     "MemoryLock",
+    "MetricsServerError",
     "ObservabilityBundle",
     "PrometheusMetrics",
     "StorageAdapter",
@@ -217,12 +221,16 @@ def bootstrap_metrics(settings: Settings) -> MetricsPort | None:
     """Bootstrap metrics with optional server start.
 
     Server is started only if explicitly enabled in settings.
+    Supports fail_fast mode for strict startup validation.
 
     Args:
         settings: Application settings.
 
     Returns:
         MetricsPort instance or None if metrics are disabled.
+
+    Raises:
+        MetricsServerError: If fail_fast=True and server fails to start.
     """
     if not settings.observability.metrics_enabled:
         return None
@@ -230,9 +238,25 @@ def bootstrap_metrics(settings: Settings) -> MetricsPort | None:
     metrics = PrometheusMetrics()
 
     if settings.observability.metrics_server_enabled:
-        # Log but don't fail - metrics collection still works
-        with contextlib.suppress(Exception):
-            start_metrics_server(settings.metrics_port)
+        obs = settings.observability
+
+        if obs.metrics_fail_fast:
+            # In fail_fast mode, let MetricsServerError propagate
+            start_metrics_server(
+                port=settings.metrics_port,
+                fail_fast=True,
+                retry_count=obs.metrics_retry_count,
+                retry_delay=obs.metrics_retry_delay,
+            )
+        else:
+            # Lenient mode: log but don't fail - metrics collection still works
+            with contextlib.suppress(Exception):
+                start_metrics_server(
+                    port=settings.metrics_port,
+                    fail_fast=False,
+                    retry_count=obs.metrics_retry_count,
+                    retry_delay=obs.metrics_retry_delay,
+                )
 
     return metrics
 

--- a/src/bioetl/infrastructure/config.py
+++ b/src/bioetl/infrastructure/config.py
@@ -316,6 +316,15 @@ class ObservabilitySettings(BaseSettings):
     metrics_server_enabled: bool = Field(default=True)
     """Enable Prometheus metrics HTTP server. Requires metrics_enabled=True."""
 
+    metrics_fail_fast: bool = Field(default=False)
+    """If True, exit with error when metrics server fails to start."""
+
+    metrics_retry_count: int = Field(default=3, ge=1, le=10)
+    """Number of retries for transient errors when starting metrics server."""
+
+    metrics_retry_delay: float = Field(default=1.0, ge=0.1, le=10.0)
+    """Delay between retries in seconds when starting metrics server."""
+
     tracing_enabled: bool = Field(default=False)
     """Enable OpenTelemetry tracing."""
 

--- a/src/bioetl/interfaces/observability.py
+++ b/src/bioetl/interfaces/observability.py
@@ -5,25 +5,41 @@ Handles the exposure of metrics and other observability signals to external syst
 
 from __future__ import annotations
 
-# We import from infrastructure to avoid direct dependency on prometheus_client here
-# if we want to be strict, but start_http_server is the standard way.
-# However, to satisfy the architecture test "Forbidden import 'prometheus_client' outside observability",
-# we should probably move this function to infrastructure/observability/server.py
-# and import it here. But since this IS the interface layer for observability,
-# maybe we can just exempt it in the test or move the implementation.
-
-# Let's move the implementation to infrastructure/observability/server.py
-# and call it from here.
-
+from bioetl.infrastructure.observability.server import MetricsServerError
 from bioetl.infrastructure.observability.server import (
     start_metrics_server as _start_server,
 )
 
+__all__ = [
+    "MetricsServerError",
+    "start_metrics_server",
+]
 
-def start_metrics_server(port: int = 8000) -> None:
+
+def start_metrics_server(
+    port: int = 8000,
+    *,
+    fail_fast: bool = False,
+    retry_count: int = 3,
+    retry_delay: float = 1.0,
+) -> bool:
     """Start Prometheus metrics HTTP server in a daemon thread.
 
     Args:
         port: Port to bind the HTTP server (default: 8000)
+        fail_fast: If True, raise MetricsServerError on failure
+        retry_count: Number of retries for transient errors (default: 3)
+        retry_delay: Delay between retries in seconds (default: 1.0)
+
+    Returns:
+        True if server started successfully, False otherwise
+
+    Raises:
+        MetricsServerError: If fail_fast=True and server cannot start
     """
-    _start_server(port)
+    return _start_server(
+        port=port,
+        fail_fast=fail_fast,
+        retry_count=retry_count,
+        retry_delay=retry_delay,
+    )

--- a/tests/unit/interfaces/test_observability.py
+++ b/tests/unit/interfaces/test_observability.py
@@ -43,3 +43,31 @@ def test_start_metrics_server_failure():
         # Server catches exceptions and returns False for graceful degradation
         result = obs_server.start_metrics_server(port=8000, fail_fast=False)
         assert result is False
+
+
+def test_interface_passes_config_params():
+    """Verify interface layer passes all config params to server."""
+    # Patch at the module level where it's imported as _start_server
+    with mock.patch(
+        "bioetl.interfaces.observability._start_server"
+    ) as mock_server:
+        mock_server.return_value = True
+        result = observability.start_metrics_server(
+            port=9090,
+            fail_fast=True,
+            retry_count=5,
+            retry_delay=2.0,
+        )
+
+        mock_server.assert_called_once_with(
+            port=9090,
+            fail_fast=True,
+            retry_count=5,
+            retry_delay=2.0,
+        )
+        assert result is True
+
+
+def test_interface_exposes_metrics_server_error():
+    """Verify MetricsServerError is exported from interface."""
+    assert observability.MetricsServerError is obs_server.MetricsServerError

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -86,16 +86,35 @@ class TestBootstrapLogger:
 class TestBootstrapPipeline:
     """Tests for bootstrap_pipeline function."""
 
+    @patch("bioetl.composition.bootstrap.start_metrics_server")
+    @patch("bioetl.composition.bootstrap.bootstrap_tracer")
     @patch("bioetl.composition.bootstrap.get_settings")
     @patch("bioetl.composition.bootstrap.bootstrap_logger")
     def test_bootstrap_pipeline_unknown_pipeline_raises(
-        self, mock_bootstrap_logger, mock_get_settings, mock_settings, mock_logger
+        self,
+        mock_bootstrap_logger: MagicMock,
+        mock_get_settings: MagicMock,
+        mock_bootstrap_tracer: MagicMock,
+        mock_start_metrics: MagicMock,
+        mock_settings: MagicMock,
+        mock_logger: MagicMock,
     ):
         """Test that unknown pipeline name raises ValueError."""
         from bioetl.composition.bootstrap import bootstrap_pipeline
 
+        # Configure settings with required observability attributes
+        mock_settings.metrics_port = 8000
+        mock_settings.observability = MagicMock()
+        mock_settings.observability.metrics_enabled = True
+        mock_settings.observability.metrics_server_enabled = True
+        mock_settings.observability.metrics_fail_fast = False
+        mock_settings.observability.metrics_retry_count = 3
+        mock_settings.observability.metrics_retry_delay = 1.0
+        mock_settings.observability.tracing_enabled = False
+
         mock_get_settings.return_value = mock_settings
         mock_bootstrap_logger.return_value = mock_logger
+        mock_bootstrap_tracer.return_value = MagicMock()
 
         # Now raises "Configuration file not found" because load_pipeline_config is called first
         ctx = PipelineRunContext(
@@ -138,6 +157,9 @@ class TestBootstrapPipeline:
         test_settings.observability = MagicMock()
         test_settings.observability.metrics_enabled = True
         test_settings.observability.metrics_server_enabled = True
+        test_settings.observability.metrics_fail_fast = False
+        test_settings.observability.metrics_retry_count = 3
+        test_settings.observability.metrics_retry_delay = 1.0
         test_settings.observability.tracing_enabled = False
 
         mock_get_settings.return_value = test_settings
@@ -169,7 +191,12 @@ class TestBootstrapPipeline:
         result = bootstrap_pipeline(ctx)
 
         assert result is mock_runner
-        mock_start_metrics.assert_called_once_with(test_settings.metrics_port)
+        mock_start_metrics.assert_called_once_with(
+            port=test_settings.metrics_port,
+            fail_fast=False,
+            retry_count=3,
+            retry_delay=1.0,
+        )
 
     @pytest.mark.skip(
         reason="Requires full integration setup - covered by integration tests"
@@ -368,3 +395,113 @@ class TestChemblActivityFactory:
         finally:
             # Restore original class
             chembl_activity_factory.pipeline_class = original_class
+
+
+@pytest.mark.unit
+class TestBootstrapMetrics:
+    """Tests for bootstrap_metrics function with metrics configuration."""
+
+    @patch("bioetl.composition.bootstrap.start_metrics_server")
+    @patch("bioetl.composition.bootstrap.PrometheusMetrics")
+    def test_bootstrap_metrics_passes_config_params(
+        self,
+        mock_prometheus: MagicMock,
+        mock_start_server: MagicMock,
+    ) -> None:
+        """Test that bootstrap_metrics passes config params to start_metrics_server."""
+        from bioetl.composition.bootstrap import bootstrap_metrics
+
+        # Create mock settings with metrics config
+        settings = MagicMock()
+        settings.metrics_port = 9090
+        settings.observability.metrics_enabled = True
+        settings.observability.metrics_server_enabled = True
+        settings.observability.metrics_fail_fast = False
+        settings.observability.metrics_retry_count = 5
+        settings.observability.metrics_retry_delay = 2.0
+
+        mock_metrics = MagicMock()
+        mock_prometheus.return_value = mock_metrics
+
+        result = bootstrap_metrics(settings)
+
+        assert result is mock_metrics
+        mock_start_server.assert_called_once_with(
+            port=9090,
+            fail_fast=False,
+            retry_count=5,
+            retry_delay=2.0,
+        )
+
+    @patch("bioetl.composition.bootstrap.start_metrics_server")
+    @patch("bioetl.composition.bootstrap.PrometheusMetrics")
+    def test_bootstrap_metrics_fail_fast_true_raises_error(
+        self,
+        mock_prometheus: MagicMock,
+        mock_start_server: MagicMock,
+    ) -> None:
+        """Test that fail_fast=True propagates MetricsServerError."""
+        from bioetl.composition.bootstrap import MetricsServerError, bootstrap_metrics
+
+        settings = MagicMock()
+        settings.metrics_port = 8000
+        settings.observability.metrics_enabled = True
+        settings.observability.metrics_server_enabled = True
+        settings.observability.metrics_fail_fast = True
+        settings.observability.metrics_retry_count = 3
+        settings.observability.metrics_retry_delay = 1.0
+
+        # Simulate server failure in fail_fast mode
+        mock_start_server.side_effect = MetricsServerError(
+            port=8000, reason="port_in_use"
+        )
+
+        with pytest.raises(MetricsServerError) as exc_info:
+            bootstrap_metrics(settings)
+
+        assert exc_info.value.port == 8000
+        assert exc_info.value.reason == "port_in_use"
+
+    @patch("bioetl.composition.bootstrap.start_metrics_server")
+    @patch("bioetl.composition.bootstrap.PrometheusMetrics")
+    def test_bootstrap_metrics_fail_fast_false_suppresses_error(
+        self,
+        mock_prometheus: MagicMock,
+        mock_start_server: MagicMock,
+    ) -> None:
+        """Test that fail_fast=False suppresses exceptions."""
+        from bioetl.composition.bootstrap import bootstrap_metrics
+
+        settings = MagicMock()
+        settings.metrics_port = 8000
+        settings.observability.metrics_enabled = True
+        settings.observability.metrics_server_enabled = True
+        settings.observability.metrics_fail_fast = False
+        settings.observability.metrics_retry_count = 3
+        settings.observability.metrics_retry_delay = 1.0
+
+        mock_metrics = MagicMock()
+        mock_prometheus.return_value = mock_metrics
+
+        # Simulate exception in lenient mode
+        mock_start_server.side_effect = Exception("Random failure")
+
+        # Should not raise, should return metrics
+        result = bootstrap_metrics(settings)
+
+        assert result is mock_metrics
+
+    @patch("bioetl.composition.bootstrap.PrometheusMetrics")
+    def test_bootstrap_metrics_disabled_returns_none(
+        self, mock_prometheus: MagicMock
+    ) -> None:
+        """Test that disabled metrics returns None without starting server."""
+        from bioetl.composition.bootstrap import bootstrap_metrics
+
+        settings = MagicMock()
+        settings.observability.metrics_enabled = False
+
+        result = bootstrap_metrics(settings)
+
+        assert result is None
+        mock_prometheus.assert_not_called()


### PR DESCRIPTION
Add metrics server configuration options to ObservabilitySettings:
- metrics_fail_fast: exit with error when server fails to start
- metrics_retry_count: number of retries for transient errors
- metrics_retry_delay: delay between retries in seconds

These parameters are now passed from settings to start_metrics_server() in bootstrap_metrics(). When fail_fast=True and server fails to start, MetricsServerError propagates to caller enabling strict startup validation.

Defaults preserve backward compatibility (fail_fast=False).