### PR TITLE
Standardize adapter naming conventions

### DIFF
--- a/src/bioetl/composition/factories/data_sources.py
+++ b/src/bioetl/composition/factories/data_sources.py
@@ -19,8 +19,8 @@ class DataSourceFactory:
 
     _adapters: ClassVar[dict[str, tuple[str, str]]] = {
         "chembl": ("bioetl.infrastructure.adapters.chembl.client", "ChemblAdapter"),
-        "pubchem": ("bioetl.infrastructure.adapters.pubchem.client", "PubChemClient"),
-        "uniprot": ("bioetl.infrastructure.adapters.uniprot.client", "UniProtClient"),
+        "pubchem": ("bioetl.infrastructure.adapters.pubchem.client", "PubChemAdapter"),
+        "uniprot": ("bioetl.infrastructure.adapters.uniprot.client", "UniProtAdapter"),
     }
 
     @classmethod

--- a/src/bioetl/infrastructure/adapters/pubchem/client.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/client.py
@@ -26,19 +26,19 @@ from bioetl.infrastructure.adapters.http.health import (
 from bioetl.infrastructure.adapters.sync_base import BaseSyncAdapter
 
 
-class PubChemClient(BaseSyncAdapter):
-    """PubChem API client implementing DataSourcePort.
+class PubChemAdapter(BaseSyncAdapter):
+    """PubChem API adapter implementing DataSourcePort.
 
     Provides access to chemical compound data from PubChem database.
     Uses pubchempy library which is synchronous, so runs in ThreadPoolExecutor.
 
     Example:
-        >>> client = PubChemClient()
+        >>> adapter = PubChemAdapter()
         >>> # Search compounds by name
-        >>> async for compound in client.fetch("compound", query="aspirin", limit=10):
+        >>> async for compound in adapter.fetch("compound", query="aspirin", limit=10):
         ...     print(f"Compound: {compound['cid']}")
         >>> # Check health
-        >>> status = await client.health_check()
+        >>> status = await adapter.health_check()
         >>> print(f"PubChem is {status}")
 
     """
@@ -254,8 +254,8 @@ class PubChemClient(BaseSyncAdapter):
             HealthStatus enum value
 
         Example:
-            >>> client = PubChemClient()
-            >>> status = await client.health_check()
+            >>> adapter = PubChemAdapter()
+            >>> status = await adapter.health_check()
             >>> print(f"PubChem is {status.value}")
 
         """
@@ -280,4 +280,4 @@ class PubChemClient(BaseSyncAdapter):
 
     def __repr__(self) -> str:
         """Return string representation."""
-        return f"PubChemClient(rate={self.rate_limiter.rate})"
+        return f"PubChemAdapter(rate={self.rate_limiter.rate})"

--- a/src/bioetl/infrastructure/adapters/uniprot/client.py
+++ b/src/bioetl/infrastructure/adapters/uniprot/client.py
@@ -27,8 +27,8 @@ from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
 from bioetl.infrastructure.adapters.http.pagination import PaginatedFetcherMixin
 
 
-class UniProtClient(BaseHttpAdapter, PaginatedFetcherMixin):
-    """UniProt API client implementing DataSourcePort.
+class UniProtAdapter(BaseHttpAdapter, PaginatedFetcherMixin):
+    """UniProt API adapter implementing DataSourcePort.
 
     Provides access to protein sequence and functional information from UniProt database.
     """
@@ -287,4 +287,4 @@ class UniProtClient(BaseHttpAdapter, PaginatedFetcherMixin):
     def __repr__(self) -> str:
         """Return string representation."""
         has_key = "with API key" if self.api_key else "without API key"
-        return f"UniProtClient(base_url='{self.base_url}', {has_key})"
+        return f"UniProtAdapter(base_url='{self.base_url}', {has_key})"

--- a/tests/infrastructure/adapters/test_pubchem.py
+++ b/tests/infrastructure/adapters/test_pubchem.py
@@ -1,4 +1,4 @@
-"""Tests for PubChem Client."""
+"""Tests for PubChem Adapter."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ import pytest
 
 from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreakerOpenError
-from bioetl.infrastructure.adapters.pubchem.client import PubChemClient
+from bioetl.infrastructure.adapters.pubchem.client import PubChemAdapter
 
 
 @pytest.fixture
@@ -18,11 +18,11 @@ def mock_logger():
 
 
 @pytest.fixture
-def pubchem_client(mock_logger):
-    client = PubChemClient(logger=mock_logger, rate=100)  # High rate to avoid delays
-    yield client
+def pubchem_adapter(mock_logger):
+    adapter = PubChemAdapter(logger=mock_logger, rate=100)  # High rate to avoid delays
+    yield adapter
     # Cleanup logic if necessary (though close() calls shutdown on threadpool)
-    client.thread_pool.shutdown(wait=False)
+    adapter.thread_pool.shutdown(wait=False)
 
 
 @pytest.fixture
@@ -69,11 +69,11 @@ def mock_pcp_assay():
     }
 
 
-async def test_fetch_compound_by_query(pubchem_client, mock_pcp_compound):
+async def test_fetch_compound_by_query(pubchem_adapter, mock_pcp_compound):
     """Test fetching compounds by query."""
     with patch("pubchempy.get_compounds", return_value=[mock_pcp_compound]) as mock_get:
         results = []
-        async for record in pubchem_client.fetch("compound", query="aspirin"):
+        async for record in pubchem_adapter.fetch("compound", query="aspirin"):
             results.append(record)
 
         assert len(results) == 1
@@ -82,11 +82,11 @@ async def test_fetch_compound_by_query(pubchem_client, mock_pcp_compound):
         mock_get.assert_called_with("aspirin", "name")
 
 
-async def test_fetch_compound_with_limit(pubchem_client, mock_pcp_compound):
+async def test_fetch_compound_with_limit(pubchem_adapter, mock_pcp_compound):
     """Test fetching compounds with limit."""
     with patch("pubchempy.get_compounds", return_value=[mock_pcp_compound]) as mock_get:
         results = []
-        async for record in pubchem_client.fetch("compound", query="aspirin", limit=1):
+        async for record in pubchem_adapter.fetch("compound", query="aspirin", limit=1):
             results.append(record)
 
         assert len(results) == 1
@@ -94,13 +94,13 @@ async def test_fetch_compound_with_limit(pubchem_client, mock_pcp_compound):
         mock_get.assert_called_with("aspirin", "name")
 
 
-async def test_fetch_substance(pubchem_client, mock_pcp_substance):
+async def test_fetch_substance(pubchem_adapter, mock_pcp_substance):
     """Test fetching substances."""
     with patch(
         "pubchempy.get_substances", return_value=[mock_pcp_substance]
     ) as mock_get:
         results = []
-        async for record in pubchem_client.fetch("substance", query="aspirin"):
+        async for record in pubchem_adapter.fetch("substance", query="aspirin"):
             results.append(record)
 
         assert len(results) == 1
@@ -109,11 +109,11 @@ async def test_fetch_substance(pubchem_client, mock_pcp_substance):
         mock_get.assert_called_with("aspirin", "name")
 
 
-async def test_fetch_assay(pubchem_client, mock_pcp_assay):
+async def test_fetch_assay(pubchem_adapter, mock_pcp_assay):
     """Test fetching assays."""
     with patch("pubchempy.get_assays", return_value=[mock_pcp_assay]) as mock_get:
         results = []
-        async for record in pubchem_client.fetch("assay", query="12345"):
+        async for record in pubchem_adapter.fetch("assay", query="12345"):
             results.append(record)
 
         assert len(results) == 1
@@ -121,62 +121,62 @@ async def test_fetch_assay(pubchem_client, mock_pcp_assay):
         mock_get.assert_called_with("12345")
 
 
-async def test_fetch_unsupported_entity(pubchem_client):
+async def test_fetch_unsupported_entity(pubchem_adapter):
     """Test fetching unsupported entity raises ValueError."""
     with pytest.raises(ValueError, match="Unsupported entity type"):
-        async for _ in pubchem_client.fetch("invalid_entity"):
+        async for _ in pubchem_adapter.fetch("invalid_entity"):
             pass
 
 
-async def test_fetch_compound_missing_query(pubchem_client):
+async def test_fetch_compound_missing_query(pubchem_adapter):
     """Test fetching compound without query raises ValueError."""
     with pytest.raises(ValueError, match="Query is required for compound fetch"):
-        async for _ in pubchem_client.fetch("compound"):
+        async for _ in pubchem_adapter.fetch("compound"):
             pass
 
 
-async def test_fetch_substance_missing_query(pubchem_client):
+async def test_fetch_substance_missing_query(pubchem_adapter):
     """Test fetching substance without query raises ValueError."""
     with pytest.raises(ValueError, match="Query is required"):
-        async for _ in pubchem_client.fetch("substance"):
+        async for _ in pubchem_adapter.fetch("substance"):
             pass
 
 
-async def test_fetch_assay_missing_query(pubchem_client):
+async def test_fetch_assay_missing_query(pubchem_adapter):
     """Test fetching assay without query raises ValueError."""
     with pytest.raises(ValueError, match="Query is required"):
-        async for _ in pubchem_client.fetch("assay"):
+        async for _ in pubchem_adapter.fetch("assay"):
             pass
 
 
-async def test_health_check_healthy(pubchem_client, mock_pcp_compound):
+async def test_health_check_healthy(pubchem_adapter, mock_pcp_compound):
     """Test health check returns HEALTHY."""
     with patch("pubchempy.get_compounds", return_value=[mock_pcp_compound]):
-        status = await pubchem_client.health_check()
+        status = await pubchem_adapter.health_check()
         assert status == HealthStatus.HEALTHY
 
 
-async def test_health_check_unhealthy(pubchem_client):
+async def test_health_check_unhealthy(pubchem_adapter):
     """Test health check returns UNHEALTHY on exception."""
     with patch("pubchempy.get_compounds", side_effect=Exception("Connection error")):
-        status = await pubchem_client.health_check()
+        status = await pubchem_adapter.health_check()
         assert status == HealthStatus.UNHEALTHY
 
 
-async def test_circuit_breaker(pubchem_client):
+async def test_circuit_breaker(pubchem_adapter):
     """Test circuit breaker opens after failures."""
     # Set low threshold
-    pubchem_client.circuit_breaker.failure_threshold = 1
+    pubchem_adapter.circuit_breaker.failure_threshold = 1
 
     with patch("pubchempy.get_compounds", side_effect=Exception("API Error")):
         # First call fails and increments failure count
         try:
-            async for _ in pubchem_client.fetch("compound", query="fail"):
+            async for _ in pubchem_adapter.fetch("compound", query="fail"):
                 pass
         except Exception:
             pass
 
         # Second call should raise CircuitBreakerOpenError
         with pytest.raises(CircuitBreakerOpenError):
-            async for _ in pubchem_client.fetch("compound", query="fail"):
+            async for _ in pubchem_adapter.fetch("compound", query="fail"):
                 pass

--- a/tests/infrastructure/adapters/test_uniprot.py
+++ b/tests/infrastructure/adapters/test_uniprot.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-"Tests for UniProt Client."
+"Tests for UniProt Adapter."
 
 from unittest.mock import MagicMock
 
@@ -11,7 +11,7 @@ from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
 from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
 from bioetl.infrastructure.adapters.http.rate_limiter import TokenBucket
-from bioetl.infrastructure.adapters.uniprot.client import UniProtClient
+from bioetl.infrastructure.adapters.uniprot.client import UniProtAdapter
 
 
 @pytest.fixture
@@ -29,9 +29,9 @@ def unified_http_client():
 
 
 @pytest.fixture
-def uniprot_client(unified_http_client, mock_logger):
-    """Fixture for UniProtClient."""
-    return UniProtClient(http_client=unified_http_client, logger=mock_logger)
+def uniprot_adapter(unified_http_client, mock_logger):
+    """Fixture for UniProtAdapter."""
+    return UniProtAdapter(http_client=unified_http_client, logger=mock_logger)
 
 
 @pytest.fixture
@@ -82,15 +82,15 @@ def mock_fasta_response():
 
 
 @respx.mock
-async def test_fetch_protein_success(uniprot_client, mock_protein_response):
+async def test_fetch_protein_success(uniprot_adapter, mock_protein_response):
     """Test fetching proteins successfully."""
     route = respx.get("https://rest.uniprot.org/uniprotkb/search").mock(
         return_value=Response(200, json=mock_protein_response)
     )
 
     results = []
-    async with uniprot_client:
-        async for record in uniprot_client.fetch("protein", query="gene:TEST1"):
+    async with uniprot_adapter:
+        async for record in uniprot_adapter.fetch("protein", query="gene:TEST1"):
             results.append(record)
 
     assert len(results) == 1
@@ -100,12 +100,12 @@ async def test_fetch_protein_success(uniprot_client, mock_protein_response):
 
 @respx.mock
 async def test_fetch_protein_pagination(
-    uniprot_client, mock_protein_response_page1, mock_protein_response
+    uniprot_adapter, mock_protein_response_page1, mock_protein_response
 ):
     """Test fetching proteins with pagination."""
     # Mocking exact params is tricky due to size calc and defaults.
     # We'll use a regex or looser matching if possible, but respx strict matching requires exact params.
-    # The issue might be that the client code calculates `size` dynamically based on limit.
+    # The issue might be that the adapter code calculates `size` dynamically based on limit.
     # Let's mock based on path only for this test to avoid timeout loops.
 
     route = respx.get("https://rest.uniprot.org/uniprotkb/search")
@@ -115,23 +115,23 @@ async def test_fetch_protein_pagination(
     ]
 
     results = []
-    async with uniprot_client:
-        async for record in uniprot_client.fetch("protein", query="gene:TEST1"):
+    async with uniprot_adapter:
+        async for record in uniprot_adapter.fetch("protein", query="gene:TEST1"):
             results.append(record)
 
     assert len(results) == 2
 
 
 @respx.mock
-async def test_fetch_features(uniprot_client, mock_feature_response):
+async def test_fetch_features(uniprot_adapter, mock_feature_response):
     """Test fetching protein features."""
     respx.get("https://rest.uniprot.org/uniprotkb/P12345.json").mock(
         return_value=Response(200, json=mock_feature_response)
     )
 
     results = []
-    async with uniprot_client:
-        async for record in uniprot_client.fetch("feature", query="P12345"):
+    async with uniprot_adapter:
+        async for record in uniprot_adapter.fetch("feature", query="P12345"):
             results.append(record)
 
     assert len(results) == 1
@@ -140,58 +140,58 @@ async def test_fetch_features(uniprot_client, mock_feature_response):
 
 
 @respx.mock
-async def test_fetch_sequences(uniprot_client, mock_fasta_response):
+async def test_fetch_sequences(uniprot_adapter, mock_fasta_response):
     """Test fetching protein sequences."""
     respx.get("https://rest.uniprot.org/uniprotkb/stream").mock(
         return_value=Response(200, text=mock_fasta_response)
     )
 
     results = []
-    async with uniprot_client:
-        async for record in uniprot_client.fetch("sequence", query="P12345"):
+    async with uniprot_adapter:
+        async for record in uniprot_adapter.fetch("sequence", query="P12345"):
             results.append(record)
 
     assert len(results) == 1
     assert "MKTLLLLAVVLLLGAAQA" in results[0]["sequence"]
 
 
-async def test_fetch_unsupported_entity(uniprot_client):
+async def test_fetch_unsupported_entity(uniprot_adapter):
     """Test fetching unsupported entity raises ValueError."""
-    async with uniprot_client:
+    async with uniprot_adapter:
         with pytest.raises(ValueError, match="Unsupported entity type"):
-            async for _ in uniprot_client.fetch("invalid_entity"):
+            async for _ in uniprot_adapter.fetch("invalid_entity"):
                 pass
 
 
-async def test_fetch_features_missing_query(uniprot_client):
+async def test_fetch_features_missing_query(uniprot_adapter):
     """Test fetching features without query raises ValueError."""
-    async with uniprot_client:
+    async with uniprot_adapter:
         with pytest.raises(ValueError, match="Query is required"):
-            async for _ in uniprot_client.fetch("feature"):
+            async for _ in uniprot_adapter.fetch("feature"):
                 pass
 
 
-async def test_fetch_sequences_missing_query(uniprot_client):
+async def test_fetch_sequences_missing_query(uniprot_adapter):
     """Test fetching sequences without query raises ValueError."""
-    async with uniprot_client:
+    async with uniprot_adapter:
         with pytest.raises(ValueError, match="Query is required"):
-            async for _ in uniprot_client.fetch("sequence"):
+            async for _ in uniprot_adapter.fetch("sequence"):
                 pass
 
 
 @respx.mock
-async def test_health_check_healthy(uniprot_client):
+async def test_health_check_healthy(uniprot_adapter):
     """Test health check returns HEALTHY."""
     respx.get("https://rest.uniprot.org/uniprotkb/search").mock(
         return_value=Response(200)
     )
-    async with uniprot_client:
-        status = await uniprot_client.health_check()
+    async with uniprot_adapter:
+        status = await uniprot_adapter.health_check()
     assert status == HealthStatus.HEALTHY
 
 
 @respx.mock
-async def test_health_check_on_server_error(uniprot_client):
+async def test_health_check_on_server_error(uniprot_adapter):
     """Test health check behavior on server error (500).
 
     When http_client raises HTTPStatusError on 500, it's caught and
@@ -200,14 +200,14 @@ async def test_health_check_on_server_error(uniprot_client):
     respx.get("https://rest.uniprot.org/uniprotkb/search").mock(
         return_value=Response(500)
     )
-    async with uniprot_client:
-        status = await uniprot_client.health_check()
+    async with uniprot_adapter:
+        status = await uniprot_adapter.health_check()
     # 500 causes exception in http_client, falls back to CB check (HEALTHY if no failures)
     assert status == HealthStatus.HEALTHY
 
 
 @respx.mock
-async def test_health_check_on_connection_error(uniprot_client):
+async def test_health_check_on_connection_error(uniprot_adapter):
     """Test health check behavior on connection error.
 
     Connection errors fall back to circuit breaker state which may
@@ -216,7 +216,7 @@ async def test_health_check_on_connection_error(uniprot_client):
     respx.get("https://rest.uniprot.org/uniprotkb/search").mock(
         side_effect=Exception("Connection error")
     )
-    async with uniprot_client:
-        status = await uniprot_client.health_check()
+    async with uniprot_adapter:
+        status = await uniprot_adapter.health_check()
     # Connection error falls back to circuit breaker which may show degraded
     assert status in (HealthStatus.HEALTHY, HealthStatus.DEGRADED)

--- a/tests/infrastructure/factories/test_data_sources.py
+++ b/tests/infrastructure/factories/test_data_sources.py
@@ -8,8 +8,8 @@ import pytest
 
 from bioetl.composition.factories.data_sources import DataSourceFactory
 from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
-from bioetl.infrastructure.adapters.pubchem.client import PubChemClient
-from bioetl.infrastructure.adapters.uniprot.client import UniProtClient
+from bioetl.infrastructure.adapters.pubchem.client import PubChemAdapter
+from bioetl.infrastructure.adapters.uniprot.client import UniProtAdapter
 
 
 @pytest.fixture
@@ -26,11 +26,11 @@ def test_create_pubchem_adapter(mock_http_client, mock_logger):
     """Test creating PubChem adapter."""
     # PubChem doesn't use http_client, so it should be ignored by the factory logic
     # but we pass it anyway because the factory signature requires it (or allows it).
-    # We also mock PubChemClient to avoid creating threads/ratelimits during test
+    # We also mock PubChemAdapter to avoid creating threads/ratelimits during test
     with patch(
-        "bioetl.infrastructure.adapters.pubchem.client.PubChemClient"
+        "bioetl.infrastructure.adapters.pubchem.client.PubChemAdapter"
     ) as MockPubChem:
-        adapter_mock = Mock(spec=PubChemClient)
+        adapter_mock = Mock(spec=PubChemAdapter)
         MockPubChem.return_value = adapter_mock
 
         adapter = DataSourceFactory.create(
@@ -45,9 +45,9 @@ def test_create_uniprot_adapter(mock_http_client, mock_logger):
     """Test creating UniProt adapter."""
     # UniProt uses http_client.
     with patch(
-        "bioetl.infrastructure.adapters.uniprot.client.UniProtClient"
+        "bioetl.infrastructure.adapters.uniprot.client.UniProtAdapter"
     ) as MockUniProt:
-        adapter_mock = Mock(spec=UniProtClient)
+        adapter_mock = Mock(spec=UniProtAdapter)
         MockUniProt.return_value = adapter_mock
 
         adapter = DataSourceFactory.create(

--- a/tests/integration/adapters/test_uniprot.py
+++ b/tests/integration/adapters/test_uniprot.py
@@ -13,8 +13,8 @@ import pytest
 
 
 @pytest.mark.integration
-class TestUniProtClientIntegration:
-    """Integration tests for UniProtClient.
+class TestUniProtAdapterIntegration:
+    """Integration tests for UniProtAdapter.
 
     Note: These tests require VCR cassettes to run in CI.
     Use --vcr-record=new_episodes to record new cassettes.
@@ -26,7 +26,7 @@ class TestUniProtClientIntegration:
         return MagicMock()
 
     @pytest.fixture
-    def uniprot_client_internal(self, token_bucket: Any, circuit_breaker: Any) -> Any:
+    def uniprot_http_client(self, token_bucket: Any, circuit_breaker: Any) -> Any:
         """Create UniProt HTTP client for testing."""
         from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
 
@@ -37,28 +37,28 @@ class TestUniProtClientIntegration:
         )
 
     @pytest.fixture
-    def uniprot_adapter(self, uniprot_client_internal: Any, mock_logger: MagicMock) -> Any:
-        """Create UniProtClient instance."""
-        from bioetl.infrastructure.adapters.uniprot.client import UniProtClient
+    def uniprot_adapter(self, uniprot_http_client: Any, mock_logger: MagicMock) -> Any:
+        """Create UniProtAdapter instance."""
+        from bioetl.infrastructure.adapters.uniprot.client import UniProtAdapter
 
-        return UniProtClient(http_client=uniprot_client_internal, logger=mock_logger)
+        return UniProtAdapter(http_client=uniprot_http_client, logger=mock_logger)
 
     def test_provider_name(self, uniprot_adapter: Any) -> None:
         """Adapter should have correct provider name."""
         assert uniprot_adapter.provider_name == "uniprot"
 
     @pytest.mark.vcr
-    async def test_health_check(self, uniprot_client_internal: Any, mock_logger: MagicMock) -> None:
+    async def test_health_check(self, uniprot_http_client: Any, mock_logger: MagicMock) -> None:
         """Test UniProt health check probe.
 
         This test requires a VCR cassette.
         Record with: pytest --vcr-record=new_episodes -k test_health_check
         """
         from bioetl.domain.types import HealthStatus
-        from bioetl.infrastructure.adapters.uniprot.client import UniProtClient
+        from bioetl.infrastructure.adapters.uniprot.client import UniProtAdapter
 
-        async with uniprot_client_internal:
-            adapter = UniProtClient(http_client=uniprot_client_internal, logger=mock_logger)
+        async with uniprot_http_client:
+            adapter = UniProtAdapter(http_client=uniprot_http_client, logger=mock_logger)
             status = await adapter.health_check()
 
             # Should return a valid health status
@@ -69,16 +69,16 @@ class TestUniProtClientIntegration:
             ]
 
     @pytest.mark.vcr
-    async def test_fetch_proteins(self, uniprot_client_internal: Any, mock_logger: MagicMock) -> None:
+    async def test_fetch_proteins(self, uniprot_http_client: Any, mock_logger: MagicMock) -> None:
         """Test fetching proteins from UniProt.
 
         This test requires a VCR cassette.
         Record with: pytest --vcr-record=new_episodes -k test_fetch_proteins
         """
-        from bioetl.infrastructure.adapters.uniprot.client import UniProtClient
+        from bioetl.infrastructure.adapters.uniprot.client import UniProtAdapter
 
-        async with uniprot_client_internal:
-            adapter = UniProtClient(http_client=uniprot_client_internal, logger=mock_logger)
+        async with uniprot_http_client:
+            adapter = UniProtAdapter(http_client=uniprot_http_client, logger=mock_logger)
 
             records = []
             async for record in adapter.fetch("protein", query="gene:MYC", limit=2):

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -635,8 +635,8 @@ def test_adapters_implement_protocols(src_dir: Path):
     try:
         from bioetl.composition.factories.storage_factory import StorageAdapter
         from bioetl.infrastructure.adapters.chembl.client import ChemblAdapter
-        from bioetl.infrastructure.adapters.pubchem.client import PubChemClient
-        from bioetl.infrastructure.adapters.uniprot.client import UniProtClient
+        from bioetl.infrastructure.adapters.pubchem.client import PubChemAdapter
+        from bioetl.infrastructure.adapters.uniprot.client import UniProtAdapter
         from bioetl.infrastructure.checkpoint.local_checkpoint import LocalCheckpoint
         from bioetl.infrastructure.locking.memory_lock import MemoryLock
         from bioetl.infrastructure.observability.noop_metrics import NoOpMetrics
@@ -652,8 +652,8 @@ def test_adapters_implement_protocols(src_dir: Path):
     # Define Expectations
     expectations = [
         (ChemblAdapter, DataSourcePort),
-        (PubChemClient, DataSourcePort),
-        (UniProtClient, DataSourcePort),
+        (PubChemAdapter, DataSourcePort),
+        (UniProtAdapter, DataSourcePort),
         (LocalCheckpoint, CheckpointPort),
         (MemoryLock, LockPort),
         (UnifiedQuarantine, QuarantinePort),
@@ -716,16 +716,16 @@ def test_http_adapters_inherit_base(src_dir: Path):
 
     try:
         from bioetl.infrastructure.adapters.chembl.client import ChemblAdapter
-        from bioetl.infrastructure.adapters.uniprot.client import UniProtClient
+        from bioetl.infrastructure.adapters.uniprot.client import UniProtAdapter
     except ImportError as e:
         pytest.fail(f"Could not import adapters: {e}")
 
     # List of adapters that are considered "HTTP Adapters"
-    # PubChemClient is excluded as it uses a sync library (pubchempy)
+    # PubChemAdapter is excluded as it uses a sync library (pubchempy)
     # and manages its own thread pool / connection logic.
     http_adapters = [
         ChemblAdapter,
-        UniProtClient,
+        UniProtAdapter,
     ]
 
     violations = []

--- a/tests/unit/infrastructure/adapters/test_client_error_paths.py
+++ b/tests/unit/infrastructure/adapters/test_client_error_paths.py
@@ -53,8 +53,8 @@ def mock_settings_lenient():
         get_settings.cache_clear()
 
 
-class TestUniProtClientErrorPaths:
-    """Tests for UniProt client error handling."""
+class TestUniProtAdapterErrorPaths:
+    """Tests for UniProt adapter error handling."""
 
     @pytest.fixture
     def mock_http_client(self):
@@ -78,7 +78,7 @@ class TestUniProtClientErrorPaths:
 
     async def test_fetch_proteins_logs_error_on_failure(self, mock_http_client, mock_logger):
         """Test that _fetch_proteins logs error when fetch fails."""
-        from bioetl.infrastructure.adapters.uniprot.client import UniProtClient
+        from bioetl.infrastructure.adapters.uniprot.client import UniProtAdapter
 
         with patch.dict(
             os.environ,
@@ -88,11 +88,11 @@ class TestUniProtClientErrorPaths:
             mock_http_client.get = AsyncMock(
                 side_effect=ConnectionError("Network error")
             )
-            client = UniProtClient(http_client=mock_http_client, logger=mock_logger)
+            adapter = UniProtAdapter(http_client=mock_http_client, logger=mock_logger)
 
             results = [
                 r
-                async for r in client._fetch_proteins(
+                async for r in adapter._fetch_proteins(
                     query="test", limit=100
                 )
             ]
@@ -108,23 +108,23 @@ class TestUniProtClientErrorPaths:
 
     async def test_fetch_proteins_raises_in_strict_mode(self, mock_http_client, mock_logger):
         """Test that _fetch_proteins raises exception in strict mode."""
-        from bioetl.infrastructure.adapters.uniprot.client import UniProtClient
+        from bioetl.infrastructure.adapters.uniprot.client import UniProtAdapter
 
         # Make http_client.get raise an exception
         mock_http_client.get = AsyncMock(side_effect=ConnectionError("Network error"))
-        client = UniProtClient(http_client=mock_http_client, logger=mock_logger, strict_error_handling=True)
+        adapter = UniProtAdapter(http_client=mock_http_client, logger=mock_logger, strict_error_handling=True)
 
         with pytest.raises(ConnectionError, match="Network error"):
             _ = [
                 r
-                async for r in client._fetch_proteins(
+                async for r in adapter._fetch_proteins(
                     query="test", limit=100
                 )
             ]
 
     async def test_fetch_features_logs_error_on_failure(self, mock_http_client, mock_logger):
         """Test that _fetch_features logs error when fetch fails."""
-        from bioetl.infrastructure.adapters.uniprot.client import UniProtClient
+        from bioetl.infrastructure.adapters.uniprot.client import UniProtAdapter
 
         with patch.dict(
             os.environ,
@@ -138,11 +138,11 @@ class TestUniProtClientErrorPaths:
             mock_http_client.get = AsyncMock(
                 side_effect=TimeoutError("Request timeout")
             )
-            client = UniProtClient(http_client=mock_http_client, logger=mock_logger)
+            adapter = UniProtAdapter(http_client=mock_http_client, logger=mock_logger)
 
             results = [
                 r
-                async for r in client._fetch_features(
+                async for r in adapter._fetch_features(
                     "P12345", limit=10
                 )
             ]
@@ -158,16 +158,16 @@ class TestUniProtClientErrorPaths:
 
     async def test_fetch_features_raises_in_strict_mode(self, mock_http_client, mock_logger):
         """Test that _fetch_features raises exception in strict mode."""
-        from bioetl.infrastructure.adapters.uniprot.client import UniProtClient
+        from bioetl.infrastructure.adapters.uniprot.client import UniProtAdapter
 
         # Make http_client.get raise an exception
         mock_http_client.get = AsyncMock(side_effect=TimeoutError("Request timeout"))
-        client = UniProtClient(http_client=mock_http_client, logger=mock_logger, strict_error_handling=True)
+        adapter = UniProtAdapter(http_client=mock_http_client, logger=mock_logger, strict_error_handling=True)
 
         with pytest.raises(TimeoutError, match="Request timeout"):
             _ = [
                 r
-                async for r in client._fetch_features(
+                async for r in adapter._fetch_features(
                     "P12345", limit=10
                 )
             ]
@@ -176,7 +176,7 @@ class TestUniProtClientErrorPaths:
         self, mock_http_client, mock_logger
     ):
         """Test that _fetch_sequences logs error when fetch fails."""
-        from bioetl.infrastructure.adapters.uniprot.client import UniProtClient
+        from bioetl.infrastructure.adapters.uniprot.client import UniProtAdapter
 
         with patch.dict(
             os.environ,
@@ -194,11 +194,11 @@ class TestUniProtClientErrorPaths:
                     response=MagicMock(status_code=500),
                 )
             )
-            client = UniProtClient(http_client=mock_http_client, logger=mock_logger)
+            adapter = UniProtAdapter(http_client=mock_http_client, logger=mock_logger)
 
             results = [
                 r
-                async for r in client._fetch_sequences(
+                async for r in adapter._fetch_sequences(
                     "gene:TP53", limit=10
                 )
             ]
@@ -214,7 +214,7 @@ class TestUniProtClientErrorPaths:
 
     async def test_fetch_sequences_raises_in_strict_mode(self, mock_http_client, mock_logger):
         """Test that _fetch_sequences raises exception in strict mode."""
-        from bioetl.infrastructure.adapters.uniprot.client import UniProtClient
+        from bioetl.infrastructure.adapters.uniprot.client import UniProtAdapter
 
         # Make http_client.get raise an exception
         error = httpx.HTTPStatusError(
@@ -223,12 +223,12 @@ class TestUniProtClientErrorPaths:
             response=MagicMock(status_code=500),
         )
         mock_http_client.get = AsyncMock(side_effect=error)
-        client = UniProtClient(http_client=mock_http_client, logger=mock_logger, strict_error_handling=True)
+        adapter = UniProtAdapter(http_client=mock_http_client, logger=mock_logger, strict_error_handling=True)
 
         with pytest.raises(httpx.HTTPStatusError):
             _ = [
                 r
-                async for r in client._fetch_sequences(
+                async for r in adapter._fetch_sequences(
                     "gene:TP53", limit=10
                 )
             ]

--- a/tests/unit/infrastructure/adapters/test_provider_names.py
+++ b/tests/unit/infrastructure/adapters/test_provider_names.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from bioetl.infrastructure.adapters.pubchem.client import PubChemClient
-from bioetl.infrastructure.adapters.uniprot.client import UniProtClient
+from bioetl.infrastructure.adapters.pubchem.client import PubChemAdapter
+from bioetl.infrastructure.adapters.uniprot.client import UniProtAdapter
 
 
 class TestAdapterProviderNames:
@@ -19,15 +19,15 @@ class TestAdapterProviderNames:
         return MagicMock()
 
     def test_pubchem_provider_name(self, mock_logger):
-        """Test PubChemClient provider name."""
-        client = PubChemClient(logger=mock_logger)
-        assert client.provider_name == "pubchem"
-        assert PubChemClient.provider_name == "pubchem"
-        client.close()
+        """Test PubChemAdapter provider name."""
+        adapter = PubChemAdapter(logger=mock_logger)
+        assert adapter.provider_name == "pubchem"
+        assert PubChemAdapter.provider_name == "pubchem"
+        adapter.close()
 
     def test_uniprot_provider_name(self, mock_logger):
-        """Test UniProtClient provider name."""
+        """Test UniProtAdapter provider name."""
         mock_http_client = MagicMock()
-        client = UniProtClient(http_client=mock_http_client, logger=mock_logger)
-        assert client.provider_name == "uniprot"
-        assert UniProtClient.provider_name == "uniprot"
+        adapter = UniProtAdapter(http_client=mock_http_client, logger=mock_logger)
+        assert adapter.provider_name == "uniprot"
+        assert UniProtAdapter.provider_name == "uniprot"

--- a/tests/unit/infrastructure/test_adapters.py
+++ b/tests/unit/infrastructure/test_adapters.py
@@ -14,8 +14,8 @@ from bioetl.infrastructure.adapters.chembl.client import ChemblAdapter
 from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
 from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
 from bioetl.infrastructure.adapters.http.rate_limiter import TokenBucket
-from bioetl.infrastructure.adapters.pubchem.client import PubChemClient
-from bioetl.infrastructure.adapters.uniprot.client import UniProtClient
+from bioetl.infrastructure.adapters.pubchem.client import PubChemAdapter
+from bioetl.infrastructure.adapters.uniprot.client import UniProtAdapter
 
 
 @pytest.mark.unit
@@ -70,37 +70,37 @@ class TestChemblAdapter:
 
 
 @pytest.mark.unit
-class TestPubChemClient:
-    """Test PubChem client initialization and configuration."""
+class TestPubChemAdapter:
+    """Test PubChem adapter initialization and configuration."""
 
     @pytest.fixture
     def mock_logger(self):
         """Create a mock logger."""
         return MagicMock()
 
-    def test_client_creation(self, mock_logger):
-        """Test PubChem client can be created."""
-        client = PubChemClient(logger=mock_logger)
+    def test_adapter_creation(self, mock_logger):
+        """Test PubChem adapter can be created."""
+        adapter = PubChemAdapter(logger=mock_logger)
 
-        assert client.provider_name == "pubchem"
-        assert client.rate_limiter.rate == 5.0  # 5 req/sec per RULES.md
+        assert adapter.provider_name == "pubchem"
+        assert adapter.rate_limiter.rate == 5.0  # 5 req/sec per RULES.md
 
-    def test_client_with_custom_rate(self, mock_logger):
-        """Test PubChem client with custom rate limit."""
-        client = PubChemClient(rate=10.0, logger=mock_logger)
+    def test_adapter_with_custom_rate(self, mock_logger):
+        """Test PubChem adapter with custom rate limit."""
+        adapter = PubChemAdapter(rate=10.0, logger=mock_logger)
 
-        assert client.rate_limiter.rate == 10.0
+        assert adapter.rate_limiter.rate == 10.0
 
     def test_thread_pool_created(self, mock_logger):
         """Test thread pool is created for sync operations."""
-        client = PubChemClient(max_workers=2, logger=mock_logger)
+        adapter = PubChemAdapter(max_workers=2, logger=mock_logger)
 
-        assert client.thread_pool is not None
-        assert client.thread_pool._max_workers == 2
+        assert adapter.thread_pool is not None
+        assert adapter.thread_pool._max_workers == 2
 
     async def test_compound_to_dict(self, mock_logger):
         """Test compound conversion to dictionary."""
-        client = PubChemClient(logger=mock_logger)
+        adapter = PubChemAdapter(logger=mock_logger)
 
         # Mock compound object
         class MockCompound:
@@ -121,7 +121,7 @@ class TestPubChemClient:
             rotatable_bond_count = 3
             fingerprint = "00000000"
 
-        result = client._compound_to_dict(MockCompound())
+        result = adapter._compound_to_dict(MockCompound())
 
         assert result["cid"] == 2244
         assert result["molecular_formula"] == "C9H8O4"
@@ -129,8 +129,8 @@ class TestPubChemClient:
 
 
 @pytest.mark.unit
-class TestUniProtClient:
-    """Test UniProt client initialization and configuration."""
+class TestUniProtAdapter:
+    """Test UniProt adapter initialization and configuration."""
 
     @pytest.fixture
     def http_client(self):
@@ -144,37 +144,37 @@ class TestUniProtClient:
         """Create a mock logger."""
         return MagicMock()
 
-    def test_client_creation_without_api_key(self, http_client, mock_logger):
-        """Test UniProt client without API key."""
-        client = UniProtClient(http_client=http_client, logger=mock_logger)
+    def test_adapter_creation_without_api_key(self, http_client, mock_logger):
+        """Test UniProt adapter without API key."""
+        adapter = UniProtAdapter(http_client=http_client, logger=mock_logger)
 
-        assert client.provider_name == "uniprot"
-        assert client.api_key is None
+        assert adapter.provider_name == "uniprot"
+        assert adapter.api_key is None
 
-    def test_client_creation_with_api_key(self, http_client, mock_logger):
-        """Test UniProt client with API key."""
-        client = UniProtClient(http_client=http_client, logger=mock_logger, api_key="test_key")
+    def test_adapter_creation_with_api_key(self, http_client, mock_logger):
+        """Test UniProt adapter with API key."""
+        adapter = UniProtAdapter(http_client=http_client, logger=mock_logger, api_key="test_key")
 
-        assert client.api_key == "test_key"
+        assert adapter.api_key == "test_key"
 
-    def test_client_with_custom_base_url(self, http_client, mock_logger):
-        """Test UniProt client with custom base URL."""
+    def test_adapter_with_custom_base_url(self, http_client, mock_logger):
+        """Test UniProt adapter with custom base URL."""
         mock_http = MagicMock()
         custom_url = "https://custom.uniprot.org"
-        client = UniProtClient(http_client=mock_http, logger=mock_logger, base_url=custom_url)
+        adapter = UniProtAdapter(http_client=mock_http, logger=mock_logger, base_url=custom_url)
 
-        assert client.base_url == custom_url
+        assert adapter.base_url == custom_url
 
     def test_fasta_parsing(self, http_client, mock_logger):
         """Test FASTA format parsing."""
-        client = UniProtClient(http_client=http_client, logger=mock_logger)
+        adapter = UniProtAdapter(http_client=http_client, logger=mock_logger)
 
         fasta_text = """>sp|P04637|P53_HUMAN Cellular tumor antigen p53
 MEEPQSDPSVEPPLSQETFSDLWKLLPENNVLSPLPSQAMDDLMLSPDDIEQWFTEDPGP
 >sp|Q9Y6K9|NF2L2_HUMAN Nuclear factor erythroid 2-related factor 2
 MDPGQQPPPQPAPQGQGQPPSQPPQGQGPPSGPGQPAPAGTQGQPQ"""
 
-        records = client._parse_fasta(fasta_text)
+        records = adapter._parse_fasta(fasta_text)
 
         assert len(records) == 2
         assert "P04637" in records[0]["header"]


### PR DESCRIPTION
…ming convention

Standardize adapter naming to use {Provider}Adapter pattern:
- PubChemClient → PubChemAdapter
- UniProtClient → UniProtAdapter

Updated files:
- src/bioetl/infrastructure/adapters/pubchem/client.py
- src/bioetl/infrastructure/adapters/uniprot/client.py
- src/bioetl/composition/factories/data_sources.py
- All related test files

This ensures consistency with ChemblAdapter and PubMedAdapter.