### PR TITLE
Fix storage health check mkdir error

### DIFF
--- a/src/bioetl/composition/factories/storage_factory.py
+++ b/src/bioetl/composition/factories/storage_factory.py
@@ -307,10 +307,11 @@ class StorageAdapter:
 
         Checks if each layer's base directory is writable.
         """
+        # Convert to Path objects since DeltaWriter and GoldWriter store as strings
         layers = [
-            ("bronze", self.bronze.base_path),
-            ("silver", self.silver.base_path),
-            ("gold", self.gold.base_path),
+            ("bronze", Path(self.bronze.base_path)),
+            ("silver", Path(self.silver.base_path)),
+            ("gold", Path(self.gold.base_path)),
         ]
 
         issues = 0

--- a/tests/integration/pipelines/base.py
+++ b/tests/integration/pipelines/base.py
@@ -96,12 +96,14 @@ class IntegrationPipelineTestCase:
             ),
         )
 
+        from pathlib import Path
+
         return StorageContext(
             adapter=adapter,
-            bronze_path=self.bronze_path,
-            silver_path=self.silver_path,
-            gold_path=self.gold_path,
-            checkpoints_path=self.checkpoints_path,
+            bronze_path=Path(self.bronze_path),
+            silver_path=Path(self.silver_path),
+            gold_path=Path(self.gold_path),
+            checkpoints_path=Path(self.checkpoints_path),
         )
 
     @pytest.fixture

--- a/tests/integration/test_runner_lifecycle.py
+++ b/tests/integration/test_runner_lifecycle.py
@@ -60,6 +60,8 @@ def call_recorder():
 @pytest.fixture
 def mock_services_with_recorder(call_recorder):
     """Create services that record all calls."""
+    from bioetl.domain.types import HealthStatus
+
     services = MagicMock()
 
     # Lock methods
@@ -81,6 +83,12 @@ def mock_services_with_recorder(call_recorder):
     services.storage.clear_gold = AsyncMock(
         side_effect=lambda *a, **kw: (call_recorder.record("storage.clear_gold"), 0)[1]
     )
+    # Health check must be async and return HealthStatus
+    services.storage.health_check = AsyncMock(return_value=HealthStatus.HEALTHY)
+
+    # Data source methods (needed for health checks)
+    services.data_source = MagicMock()
+    services.data_source.health_check = AsyncMock(return_value=HealthStatus.HEALTHY)
 
     # Context manager support (self is passed when called as a method)
     async def services_aenter(self):

--- a/tests/unit/test_ports.py
+++ b/tests/unit/test_ports.py
@@ -178,6 +178,11 @@ class TestStoragePortProtocol:
             ) -> dict[str, Any]:
                 return {}
 
+            async def health_check(self) -> Any:
+                from bioetl.domain.types import HealthStatus
+
+                return HealthStatus.HEALTHY
+
         assert isinstance(ValidStorage(), StoragePort)
 
         # Note: @runtime_checkable protocols only check for method presence,


### PR DESCRIPTION
The storage health check was failing because DeltaWriter and GoldWriter store base_path as strings while _check_directory_writable expects Path objects. This commit:

- Converts base_path to Path objects in _check_storage_health_sync
- Adds health_check method to ValidStorage test class
- Adds health_check async mocks for storage and data_source in lifecycle tests
- Fixes StorageContext path types in integration test base