### PR TITLE
Debug empty activity_properties field in pipeline

### DIFF
--- a/src/bioetl/application/core/base_transformer.py
+++ b/src/bioetl/application/core/base_transformer.py
@@ -171,17 +171,32 @@ class BaseTransformer(ABC):
         """Serialize complex values (dict/list) to JSON string.
 
         Used for storing nested structures in Silver layer as JSON strings.
+        - Empty collections ([], {}) are treated as None for semantic consistency
+        - Single-element lists are unwrapped: [x] → x
 
         Args:
             value: Value to serialize.
 
         Returns:
-            JSON string for dict/list, str(value) for other types, None for None.
+            JSON string for non-empty dict/list, str(value) for other types,
+            None for None or empty collections.
 
         """
         if value is None:
             return None
-        if isinstance(value, (dict, list)):
+        if isinstance(value, dict):
+            if len(value) == 0:
+                return None
+            return json.dumps(value, ensure_ascii=False)
+        if isinstance(value, list):
+            if len(value) == 0:
+                return None
+            # Unwrap single-element lists
+            if len(value) == 1:
+                item = value[0]
+                if isinstance(item, dict):
+                    return json.dumps(item, ensure_ascii=False)
+                return str(item)
             return json.dumps(value, ensure_ascii=False)
         return str(value)
 

--- a/tests/unit/application/core/test_base_transformer.py
+++ b/tests/unit/application/core/test_base_transformer.py
@@ -297,3 +297,78 @@ class TestTemplateMethodPattern:
         mock_context.logger.warning.assert_called_once()
         call_args = mock_context.logger.warning.call_args
         assert "entity_validation_failed" in call_args[0]
+
+
+@pytest.mark.unit
+class TestSerializeJson:
+    """Tests for serialize_json static method."""
+
+    def test_returns_none_for_none(self) -> None:
+        """Test returns None for None input."""
+        result = BaseTransformer.serialize_json(None)
+        assert result is None
+
+    def test_returns_none_for_empty_list(self) -> None:
+        """Test returns None for empty list (semantic consistency)."""
+        result = BaseTransformer.serialize_json([])
+        assert result is None
+
+    def test_returns_none_for_empty_dict(self) -> None:
+        """Test returns None for empty dict (semantic consistency)."""
+        result = BaseTransformer.serialize_json({})
+        assert result is None
+
+    def test_unwraps_single_element_list_with_dict(self) -> None:
+        """Test unwraps single-element list containing dict."""
+        data = [{"type": "Ki", "value": 5.0}]
+        result = BaseTransformer.serialize_json(data)
+        # Single dict in list is unwrapped
+        assert result == '{"type": "Ki", "value": 5.0}'
+
+    def test_unwraps_single_element_list_with_string(self) -> None:
+        """Test unwraps single-element list containing string."""
+        data = ["PROTEIN"]
+        result = BaseTransformer.serialize_json(data)
+        assert result == "PROTEIN"
+
+    def test_keeps_multi_element_list(self) -> None:
+        """Test keeps multi-element list as array."""
+        data = [{"type": "Ki"}, {"type": "IC50"}]
+        result = BaseTransformer.serialize_json(data)
+        assert result == '[{"type": "Ki"}, {"type": "IC50"}]'
+
+    def test_serializes_non_empty_dict(self) -> None:
+        """Test serializes non-empty dict to JSON string."""
+        data = {"key": "value", "number": 42}
+        result = BaseTransformer.serialize_json(data)
+        assert result == '{"key": "value", "number": 42}'
+
+    def test_preserves_unicode(self) -> None:
+        """Test preserves unicode characters without escaping."""
+        data = {"name": "Ацетаминофен", "formula": "C₈H₉NO₂"}
+        result = BaseTransformer.serialize_json(data)
+        assert "Ацетаминофен" in result
+        assert "C₈H₉NO₂" in result
+
+    def test_converts_string_to_string(self) -> None:
+        """Test returns string as-is for string input."""
+        result = BaseTransformer.serialize_json("test string")
+        assert result == "test string"
+
+    def test_converts_number_to_string(self) -> None:
+        """Test converts number to string."""
+        result = BaseTransformer.serialize_json(42)
+        assert result == "42"
+
+    def test_serializes_nested_structure(self) -> None:
+        """Test serializes nested structures correctly."""
+        data = {
+            "properties": [
+                {"type": "DOSE", "value": 0.0, "units": "mg/kg"},
+                {"type": "TIME", "value": 3.0, "units": "hr"},
+            ]
+        }
+        result = BaseTransformer.serialize_json(data)
+        assert '"properties"' in result
+        assert '"DOSE"' in result
+        assert '"TIME"' in result

--- a/tests/unit/application/pipelines/test_activity_transformer.py
+++ b/tests/unit/application/pipelines/test_activity_transformer.py
@@ -189,8 +189,8 @@ class TestActivityTransformerTransform:
         assert result["potential_duplicate"] == 0
 
     @pytest.mark.asyncio
-    async def test_transform_with_json_fields(self, transformer, mock_context):
-        """Test transformation serializes complex fields as JSON."""
+    async def test_transform_with_json_fields_single(self, transformer, mock_context):
+        """Test transformation unwraps single-element activity_properties."""
         record = {
             "activity_id": 12345,
             "molecule_chembl_id": "CHEMBL25",
@@ -200,8 +200,38 @@ class TestActivityTransformerTransform:
         result = await transformer.transform(mock_context, record)
 
         assert result is not None
-        # activity_properties should be serialized as JSON string
-        assert isinstance(result.get("activity_properties"), str)
+        # Single-element list is unwrapped to just the dict
+        assert result.get("activity_properties") == '{"type": "Ki", "value": 5.0}'
+
+    @pytest.mark.asyncio
+    async def test_transform_with_json_fields_multiple(self, transformer, mock_context):
+        """Test transformation keeps multi-element activity_properties as array."""
+        record = {
+            "activity_id": 12345,
+            "molecule_chembl_id": "CHEMBL25",
+            "activity_properties": [{"type": "Ki"}, {"type": "IC50"}],
+        }
+
+        result = await transformer.transform(mock_context, record)
+
+        assert result is not None
+        # Multi-element list stays as array
+        assert result.get("activity_properties") == '[{"type": "Ki"}, {"type": "IC50"}]'
+
+    @pytest.mark.asyncio
+    async def test_transform_with_empty_activity_properties(self, transformer, mock_context):
+        """Test transformation returns None for empty activity_properties."""
+        record = {
+            "activity_id": 12345,
+            "molecule_chembl_id": "CHEMBL25",
+            "activity_properties": [],  # Empty array from ChEMBL API
+        }
+
+        result = await transformer.transform(mock_context, record)
+
+        assert result is not None
+        # Empty collections are treated as None for semantic consistency
+        assert result.get("activity_properties") is None
 
     @pytest.mark.asyncio
     async def test_transform_with_action_type(self, transformer, mock_context):


### PR DESCRIPTION
Empty arrays/dicts from ChEMBL API (e.g., activity_properties: []) are now converted to None instead of "[]" string for semantic consistency.

Single-element lists are unwrapped:
- [{"type": "Ki"}] → {"type": "Ki"}
- ["PROTEIN"] → "PROTEIN"
- [a, b] → [a, b] (multi-element lists unchanged)

This improves Silver layer data quality by:
- Making WHERE IS NOT NULL filters work correctly
- Reducing storage overhead from empty JSON strings
- Simplifying single-value access without array parsing

Note: This changes content hashes for affected records.