### PR TITLE
Remove legacy cleanup path implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **Legacy Cleanup Path**: Удалён `PipelineRunner._clear_exports_legacy()` (~60 строк кода)
+- **Cleanup Service from Runner**: Удалён `PipelineRunner._clear_via_cleanup_service()` и параметр `cleanup_service`
+  - `CleanupService` остаётся для CLI (`bioetl cleanup preview`)
+
+### Changed
+
+- **lifecycle_service обязателен**: Параметр `lifecycle_service` теперь обязателен в `PipelineRunner.__init__`
+  - Ранее был опциональным с fallback на legacy код
+  - `MedallionLifecycleService` — единственный способ очистки данных в Runner
+
 ### Added
 
 - **Port Contract Tests**: Добавлено 51 контрактный тест для проверки портов (`tests/architecture/test_port_contracts.py`)

--- a/src/bioetl/application/core/runner.py
+++ b/src/bioetl/application/core/runner.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
 
     from bioetl.application.core.base import BasePipeline
     from bioetl.application.core.checkpoint_manager import CheckpointManager
-    from bioetl.application.core.cleanup_service import CleanupService
     from bioetl.application.core.executor import PipelineExecutor
     from bioetl.application.core.pipeline_services import PipelineServices
     from bioetl.application.core.shutdown import ShutdownSignal
@@ -46,10 +45,9 @@ class PipelineRunner:
         checkpoint_manager: CheckpointManager,
         shutdown_signal: ShutdownSignal,
         logger: structlog.BoundLogger,
+        lifecycle_service: MedallionLifecycleService,
         pipeline: BasePipeline | None = None,
         tracer: TracingPort | None = None,
-        lifecycle_service: MedallionLifecycleService | None = None,
-        cleanup_service: CleanupService | None = None,
     ) -> None:
         """Initialize pipeline runner.
 
@@ -62,10 +60,9 @@ class PipelineRunner:
             checkpoint_manager: Checkpoint manager.
             shutdown_signal: Shutdown signal for graceful termination.
             logger: Structured logger.
+            lifecycle_service: Medallion lifecycle service for data clearing.
             pipeline: Optional pipeline instance.
             tracer: Optional tracing port.
-            lifecycle_service: Optional medallion lifecycle service (M5).
-            cleanup_service: Optional unified cleanup service.
 
         """
         self._config = config
@@ -76,10 +73,9 @@ class PipelineRunner:
         self._checkpoint_manager = checkpoint_manager
         self.shutdown_signal = shutdown_signal
         self._logger = logger
+        self._lifecycle_service = lifecycle_service
         self.pipeline = pipeline
         self._tracer = tracer
-        self._lifecycle_service = lifecycle_service
-        self._cleanup_service = cleanup_service
 
         # The runner is responsible for creating application services
         self._lock_manager = LockManager.create(
@@ -182,12 +178,11 @@ class PipelineRunner:
         self._health_aggregator.assert_healthy(report)
 
     async def _clear_via_lifecycle(self) -> None:
-        """Clear exports using lifecycle or cleanup service.
+        """Clear exports using MedallionLifecycleService.
 
-        Priority order:
-        1. MedallionLifecycleService (policy-based clearing)
-        2. CleanupService (unified cleanup service)
-        3. Legacy inline logic (backward compatibility)
+        Enforces Medallion architecture invariants:
+        - Only clears data for rebuild/backfill runs
+        - Incremental runs use merge/upsert and should NOT clear existing data
         """
         from bioetl.domain.types import RunType
 
@@ -201,18 +196,7 @@ class PipelineRunner:
             )
             return
 
-        # Use lifecycle service if available (policy-based clearing)
-        if self._lifecycle_service is not None:
-            await self._clear_via_lifecycle_service()
-            return
-
-        # Use cleanup service if available (unified cleanup)
-        if self._cleanup_service is not None:
-            await self._clear_via_cleanup_service()
-            return
-
-        # Fallback to legacy inline logic for backward compatibility
-        await self._clear_exports_legacy()
+        await self._clear_via_lifecycle_service()
 
     async def _clear_via_lifecycle_service(self) -> None:
         """Clear using MedallionLifecycleService (policy-based)."""
@@ -225,82 +209,9 @@ class PipelineRunner:
             or f"{self._config.provider}.{self._config.entity_type}"
         )
 
-        await self._lifecycle_service.clear(  # type: ignore[union-attr]
+        await self._lifecycle_service.clear(
             policy=policy,
             silver_table=self._config.silver_table,
             gold_table=gold_table,
             dry_run=self._runtime.dry_run,
         )
-
-    async def _clear_via_cleanup_service(self) -> None:
-        """Clear using unified CleanupService."""
-        gold_table = (
-            self._config.gold_table
-            or f"{self._config.provider}.{self._config.entity_type}"
-        )
-
-        await self._cleanup_service.execute(  # type: ignore[union-attr]
-            silver_table=self._config.silver_table,
-            gold_table=gold_table,
-            dry_run=self._runtime.dry_run,
-        )
-
-    async def _clear_exports_legacy(self) -> None:
-        """Clear export files and Delta tables (legacy fallback).
-
-        This method is kept for backward compatibility when neither lifecycle
-        nor cleanup service is injected. Will be deprecated in future versions.
-
-        Enforces Medallion architecture invariants:
-        - Only clears data for rebuild/backfill runs
-        - Incremental runs use merge/upsert and should NOT clear existing data
-
-        Note: This method has its own run type check for defense-in-depth,
-        even though _clear_via_lifecycle() already checks the run type.
-        """
-        from bioetl.domain.types import RunType
-
-        # Defense-in-depth: double-check run type
-        if self._runtime.run_type not in (RunType.REBUILD, RunType.BACKFILL):
-            return
-
-        storage = self._services.storage
-        silver_table = self._config.silver_table
-        # Gold table defaults to {provider}.{entity_type} if not specified
-        gold_table = (
-            self._config.gold_table
-            or f"{self._config.provider}.{self._config.entity_type}"
-        )
-
-        # Clear Silver and Gold layers using StoragePort methods (async)
-        silver_cleared = await storage.clear_silver(
-            silver_table, dry_run=self._runtime.dry_run
-        )
-        gold_cleared = await storage.clear_gold(
-            gold_table, dry_run=self._runtime.dry_run
-        )
-
-        total_cleared = silver_cleared + gold_cleared
-
-        if self._runtime.dry_run:
-            self._logger.info(
-                "DRY RUN: Would clear storage",
-                extra={
-                    "run_type": self._runtime.run_type.value,
-                    "silver_table": silver_table,
-                    "gold_table": gold_table,
-                    "silver_would_clear": silver_cleared,
-                    "gold_would_clear": gold_cleared,
-                },
-            )
-        elif total_cleared > 0:
-            self._logger.info(
-                "Cleared storage for rebuild/backfill run",
-                extra={
-                    "run_type": self._runtime.run_type.value,
-                    "silver_table": silver_table,
-                    "gold_table": gold_table,
-                    "silver_cleared": silver_cleared,
-                    "gold_cleared": gold_cleared,
-                },
-            )

--- a/tests/integration/test_runner_lifecycle.py
+++ b/tests/integration/test_runner_lifecycle.py
@@ -156,6 +156,32 @@ def mock_logger():
     return logger
 
 
+@pytest.fixture
+def mock_lifecycle_service_with_recorder(call_recorder, mock_services_with_recorder):
+    """Create lifecycle service that records calls and delegates to storage."""
+    from bioetl.application.services.medallion_lifecycle import (
+        ClearResult,
+        MedallionLifecycleService,
+    )
+
+    service = MagicMock(spec=MedallionLifecycleService)
+
+    async def clear_with_recording(*args, **kwargs):
+        # Delegate to storage methods which have their own recording
+        await mock_services_with_recorder.storage.clear_silver(
+            kwargs.get("silver_table", "test.silver"),
+            dry_run=kwargs.get("dry_run", False),
+        )
+        await mock_services_with_recorder.storage.clear_gold(
+            kwargs.get("gold_table", "test.gold"),
+            dry_run=kwargs.get("dry_run", False),
+        )
+        return ClearResult(silver_cleared=0, gold_cleared=0, dry_run=False)
+
+    service.clear = AsyncMock(side_effect=clear_with_recording)
+    return service
+
+
 @pytest.mark.integration
 class TestPipelineRunnerLifecycle:
     """Tests for PipelineRunner lifecycle invariants."""
@@ -167,6 +193,7 @@ class TestPipelineRunnerLifecycle:
         mock_services_with_recorder,
         mock_checkpoint_manager_with_recorder,
         mock_executor_with_recorder,
+        mock_lifecycle_service_with_recorder,
         mock_logger,
     ):
         """Verify call order for REBUILD run type.
@@ -219,6 +246,7 @@ class TestPipelineRunnerLifecycle:
                 checkpoint_manager=mock_checkpoint_manager_with_recorder,
                 shutdown_signal=MagicMock(),
                 logger=mock_logger,
+                lifecycle_service=mock_lifecycle_service_with_recorder,
             )
 
             await runner.run()
@@ -243,6 +271,7 @@ class TestPipelineRunnerLifecycle:
         mock_services_with_recorder,
         mock_checkpoint_manager_with_recorder,
         mock_executor_with_recorder,
+        mock_lifecycle_service_with_recorder,
         mock_logger,
     ):
         """Verify INCREMENTAL run does NOT clear storage.
@@ -279,6 +308,7 @@ class TestPipelineRunnerLifecycle:
                 checkpoint_manager=mock_checkpoint_manager_with_recorder,
                 shutdown_signal=MagicMock(),
                 logger=mock_logger,
+                lifecycle_service=mock_lifecycle_service_with_recorder,
             )
 
             await runner.run()
@@ -296,6 +326,7 @@ class TestPipelineRunnerLifecycle:
         call_recorder,
         mock_services_with_recorder,
         mock_checkpoint_manager_with_recorder,
+        mock_lifecycle_service_with_recorder,
         mock_logger,
     ):
         """Verify lock is released even when executor raises.
@@ -345,6 +376,7 @@ class TestPipelineRunnerLifecycle:
                 checkpoint_manager=mock_checkpoint_manager_with_recorder,
                 shutdown_signal=MagicMock(),
                 logger=mock_logger,
+                lifecycle_service=mock_lifecycle_service_with_recorder,
             )
 
             with pytest.raises(RuntimeError, match="Test error"):
@@ -366,6 +398,7 @@ class TestPipelineRunnerLifecycle:
         mock_services_with_recorder,
         mock_checkpoint_manager_with_recorder,
         mock_executor_with_recorder,
+        mock_lifecycle_service_with_recorder,
         mock_logger,
     ):
         """Verify BACKFILL run clears storage (same as REBUILD)."""
@@ -398,6 +431,7 @@ class TestPipelineRunnerLifecycle:
                 checkpoint_manager=mock_checkpoint_manager_with_recorder,
                 shutdown_signal=MagicMock(),
                 logger=mock_logger,
+                lifecycle_service=mock_lifecycle_service_with_recorder,
             )
 
             await runner.run()

--- a/tests/unit/application/core/test_runner.py
+++ b/tests/unit/application/core/test_runner.py
@@ -136,6 +136,21 @@ def mock_lock_manager():
 
 
 @pytest.fixture
+def mock_lifecycle_service():
+    """Create a mock lifecycle service."""
+    from bioetl.application.services.medallion_lifecycle import (
+        ClearResult,
+        MedallionLifecycleService,
+    )
+
+    service = MagicMock(spec=MedallionLifecycleService)
+    service.clear = AsyncMock(
+        return_value=ClearResult(silver_cleared=0, gold_cleared=0, dry_run=False)
+    )
+    return service
+
+
+@pytest.fixture
 def runner(
     pipeline_config,
     runtime_config,
@@ -146,6 +161,7 @@ def runner(
     shutdown_signal,
     mock_logger,
     mock_lock_manager,
+    mock_lifecycle_service,
 ):
     """Create a PipelineRunner instance."""
     return PipelineRunner(
@@ -157,6 +173,7 @@ def runner(
         checkpoint_manager=mock_checkpoint_manager,
         shutdown_signal=shutdown_signal,
         logger=mock_logger,
+        lifecycle_service=mock_lifecycle_service,
     )
 
 
@@ -175,6 +192,7 @@ class TestPipelineRunnerInit:
         shutdown_signal,
         mock_logger,
         mock_lock_manager,
+        mock_lifecycle_service,
     ):
         """Test runner initializes correctly."""
         runner = PipelineRunner(
@@ -186,11 +204,13 @@ class TestPipelineRunnerInit:
             checkpoint_manager=mock_checkpoint_manager,
             shutdown_signal=shutdown_signal,
             logger=mock_logger,
+            lifecycle_service=mock_lifecycle_service,
         )
 
         assert runner._config == pipeline_config
         assert runner._runtime == runtime_config
         assert runner.shutdown_signal == shutdown_signal
+        assert runner._lifecycle_service == mock_lifecycle_service
 
     def test_lock_manager_created_on_init(
         self,
@@ -203,6 +223,7 @@ class TestPipelineRunnerInit:
         shutdown_signal,
         mock_logger,
         mock_lock_manager,
+        mock_lifecycle_service,
     ):
         """Test LockManager is created during initialization."""
         PipelineRunner(
@@ -214,6 +235,7 @@ class TestPipelineRunnerInit:
             checkpoint_manager=mock_checkpoint_manager,
             shutdown_signal=shutdown_signal,
             logger=mock_logger,
+            lifecycle_service=mock_lifecycle_service,
         )
 
         mock_lock_manager.create.assert_called_once()
@@ -358,6 +380,7 @@ class TestPipelineRunnerRun:
         shutdown_signal,
         mock_logger,
         mock_lock_manager,
+        mock_lifecycle_service,
     ):
         """Test run passes limit to executor."""
         runtime_with_limit = RuntimeConfig(
@@ -373,7 +396,7 @@ class TestPipelineRunnerRun:
             checkpoint_manager=mock_checkpoint_manager,
             shutdown_signal=shutdown_signal,
             logger=mock_logger,
-            pipeline=None,
+            lifecycle_service=mock_lifecycle_service,
         )
 
         await runner.run()
@@ -469,506 +492,3 @@ class TestPipelineRunnerClearViaLifecycle:
 
         # Should not call lifecycle service for incremental
         lifecycle_service.clear.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_clear_via_lifecycle_falls_back_to_legacy(
-        self,
-        pipeline_config,
-        mock_context,
-        mock_executor,
-        mock_checkpoint_manager,
-        shutdown_signal,
-        mock_logger,
-        mock_lock_manager,
-    ):
-        """Test _clear_via_lifecycle falls back to legacy when no service."""
-        rebuild_runtime = RuntimeConfig(run_type=RunType.REBUILD, limit=None)
-
-        services = create_mock_services()
-        services.storage.clear_silver = AsyncMock(return_value=5)
-        services.storage.clear_gold = AsyncMock(return_value=3)
-
-        # No lifecycle service injected
-        runner = PipelineRunner(
-            config=pipeline_config,
-            runtime=rebuild_runtime,
-            services=services,
-            context=mock_context,
-            executor=mock_executor,
-            checkpoint_manager=mock_checkpoint_manager,
-            shutdown_signal=shutdown_signal,
-            logger=mock_logger,
-            lifecycle_service=None,
-        )
-
-        await runner._clear_via_lifecycle()
-
-        # Should fall back to calling storage directly
-        services.storage.clear_silver.assert_called_once()
-        services.storage.clear_gold.assert_called_once()
-
-
-@pytest.mark.unit
-class TestPipelineRunnerClearExportsLegacy:
-    """Tests for PipelineRunner._clear_exports_legacy method."""
-
-    @pytest.mark.asyncio
-    async def test_clear_exports_legacy_calls_storage_methods(
-        self,
-        pipeline_config,
-        mock_context,
-        mock_executor,
-        mock_checkpoint_manager,
-        shutdown_signal,
-        mock_logger,
-        mock_lock_manager,
-    ):
-        """Test _clear_exports_legacy calls storage clear methods for REBUILD run."""
-        # Use REBUILD run type to trigger clearing
-        rebuild_runtime = RuntimeConfig(run_type=RunType.REBUILD, limit=None)
-
-        # Create services with storage that has clear methods
-        services = create_mock_services()
-        services.storage.clear_silver = AsyncMock(return_value=5)
-        services.storage.clear_gold = AsyncMock(return_value=1)
-
-        runner = PipelineRunner(
-            config=pipeline_config,
-            runtime=rebuild_runtime,
-            services=services,
-            context=mock_context,
-            executor=mock_executor,
-            checkpoint_manager=mock_checkpoint_manager,
-            shutdown_signal=shutdown_signal,
-            logger=mock_logger,
-        )
-
-        await runner._clear_exports_legacy()
-
-        # Should clear both silver and gold tables
-        services.storage.clear_silver.assert_called_once()
-        services.storage.clear_gold.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_clear_exports_legacy_logs_when_files_cleared(
-        self,
-        pipeline_config,
-        mock_context,
-        mock_executor,
-        mock_checkpoint_manager,
-        shutdown_signal,
-        mock_logger,
-        mock_lock_manager,
-    ):
-        """Test _clear_exports_legacy logs when files are cleared."""
-        # Use REBUILD run type to trigger clearing
-        rebuild_runtime = RuntimeConfig(run_type=RunType.REBUILD, limit=None)
-
-        services = create_mock_services()
-        services.storage.clear_silver = AsyncMock(return_value=3)
-        services.storage.clear_gold = AsyncMock(return_value=2)
-
-        runner = PipelineRunner(
-            config=pipeline_config,
-            runtime=rebuild_runtime,
-            services=services,
-            context=mock_context,
-            executor=mock_executor,
-            checkpoint_manager=mock_checkpoint_manager,
-            shutdown_signal=shutdown_signal,
-            logger=mock_logger,
-        )
-
-        await runner._clear_exports_legacy()
-
-        # Should log when files are cleared
-        info_calls = [str(call) for call in mock_logger.info.call_args_list]
-        assert any("Cleared storage" in call for call in info_calls)
-
-    @pytest.mark.asyncio
-    async def test_clear_exports_legacy_no_log_when_nothing_cleared(
-        self,
-        pipeline_config,
-        mock_context,
-        mock_executor,
-        mock_checkpoint_manager,
-        shutdown_signal,
-        mock_logger,
-        mock_lock_manager,
-    ):
-        """Test _clear_exports_legacy does not log when nothing cleared."""
-        # Use REBUILD run type to trigger clearing logic
-        rebuild_runtime = RuntimeConfig(run_type=RunType.REBUILD, limit=None)
-
-        services = create_mock_services()
-        services.storage.clear_silver = AsyncMock(return_value=0)
-        services.storage.clear_gold = AsyncMock(return_value=0)
-
-        mock_logger.reset_mock()
-
-        runner = PipelineRunner(
-            config=pipeline_config,
-            runtime=rebuild_runtime,
-            services=services,
-            context=mock_context,
-            executor=mock_executor,
-            checkpoint_manager=mock_checkpoint_manager,
-            shutdown_signal=shutdown_signal,
-            logger=mock_logger,
-        )
-
-        await runner._clear_exports_legacy()
-
-        # Should not log about cleared files when nothing was cleared
-        info_calls = [str(call) for call in mock_logger.info.call_args_list]
-        assert not any("Cleared storage" in call for call in info_calls)
-
-    @pytest.mark.asyncio
-    async def test_clear_exports_legacy_uses_default_gold_table(
-        self,
-        mock_context,
-        mock_executor,
-        mock_checkpoint_manager,
-        shutdown_signal,
-        mock_logger,
-        mock_lock_manager,
-    ):
-        """Test _clear_exports_legacy uses default gold table name when not specified."""
-        # Use REBUILD run type to trigger clearing
-        rebuild_runtime = RuntimeConfig(run_type=RunType.REBUILD, limit=None)
-
-        # Config without explicit gold_table
-        config = PipelineConfig(
-            pipeline_name="test_pipeline",
-            provider="chembl",
-            entity_type="activity",
-            primary_keys=["activity_id"],
-            silver_table="chembl.silver_activity",
-            gold_table=None,  # No explicit gold table
-        )
-
-        services = create_mock_services()
-        services.storage.clear_silver = AsyncMock(return_value=0)
-        services.storage.clear_gold = AsyncMock(return_value=0)
-
-        runner = PipelineRunner(
-            config=config,
-            runtime=rebuild_runtime,
-            services=services,
-            context=mock_context,
-            executor=mock_executor,
-            checkpoint_manager=mock_checkpoint_manager,
-            shutdown_signal=shutdown_signal,
-            logger=mock_logger,
-        )
-
-        await runner._clear_exports_legacy()
-
-        # Should use default gold table: provider.entity_type
-        services.storage.clear_silver.assert_called_once_with(
-            "chembl.silver_activity", dry_run=False
-        )
-        services.storage.clear_gold.assert_called_once_with(
-            "chembl.activity", dry_run=False
-        )
-
-    @pytest.mark.asyncio
-    async def test_clear_exports_legacy_skips_for_incremental(
-        self,
-        pipeline_config,
-        mock_context,
-        mock_executor,
-        mock_checkpoint_manager,
-        shutdown_signal,
-        mock_logger,
-        mock_lock_manager,
-    ):
-        """Test _clear_exports_legacy does NOT clear storage for INCREMENTAL run."""
-        # Use INCREMENTAL run type - should skip clearing
-        incremental_runtime = RuntimeConfig(run_type=RunType.INCREMENTAL, limit=None)
-
-        services = create_mock_services()
-        services.storage.clear_silver = AsyncMock(return_value=0)
-        services.storage.clear_gold = AsyncMock(return_value=0)
-
-        runner = PipelineRunner(
-            config=pipeline_config,
-            runtime=incremental_runtime,
-            services=services,
-            context=mock_context,
-            executor=mock_executor,
-            checkpoint_manager=mock_checkpoint_manager,
-            shutdown_signal=shutdown_signal,
-            logger=mock_logger,
-        )
-
-        await runner._clear_exports_legacy()
-
-        # Should NOT call clear methods for incremental run
-        services.storage.clear_silver.assert_not_called()
-        services.storage.clear_gold.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_clear_exports_legacy_dry_run_mode(
-        self,
-        pipeline_config,
-        mock_context,
-        mock_executor,
-        mock_checkpoint_manager,
-        shutdown_signal,
-        mock_logger,
-        mock_lock_manager,
-    ):
-        """Test _clear_exports_legacy passes dry_run=True to storage methods."""
-        # Use REBUILD with dry_run=True
-        dry_run_runtime = RuntimeConfig(
-            run_type=RunType.REBUILD, limit=None, dry_run=True
-        )
-
-        services = create_mock_services()
-        services.storage.clear_silver = AsyncMock(return_value=5)
-        services.storage.clear_gold = AsyncMock(return_value=2)
-
-        runner = PipelineRunner(
-            config=pipeline_config,
-            runtime=dry_run_runtime,
-            services=services,
-            context=mock_context,
-            executor=mock_executor,
-            checkpoint_manager=mock_checkpoint_manager,
-            shutdown_signal=shutdown_signal,
-            logger=mock_logger,
-        )
-
-        await runner._clear_exports_legacy()
-
-        # Should pass dry_run=True to storage methods
-        services.storage.clear_silver.assert_called_once_with(
-            pipeline_config.silver_table, dry_run=True
-        )
-        services.storage.clear_gold.assert_called_once()
-
-
-@pytest.mark.unit
-class TestPipelineRunnerClearViaCleanupService:
-    """Tests for PipelineRunner._clear_via_cleanup_service method."""
-
-    @pytest.mark.asyncio
-    async def test_clear_via_cleanup_service_uses_service(
-        self,
-        pipeline_config,
-        mock_context,
-        mock_executor,
-        mock_checkpoint_manager,
-        shutdown_signal,
-        mock_logger,
-        mock_lock_manager,
-    ):
-        """Test _clear_via_lifecycle uses cleanup service when injected."""
-        from bioetl.application.core.cleanup_service import CleanupResult, CleanupService
-
-        rebuild_runtime = RuntimeConfig(run_type=RunType.REBUILD, limit=None)
-
-        services = create_mock_services()
-
-        # Mock cleanup service
-        cleanup_service = MagicMock(spec=CleanupService)
-        cleanup_service.execute = AsyncMock(
-            return_value=CleanupResult(silver_cleared=5, gold_cleared=3, dry_run=False)
-        )
-
-        runner = PipelineRunner(
-            config=pipeline_config,
-            runtime=rebuild_runtime,
-            services=services,
-            context=mock_context,
-            executor=mock_executor,
-            checkpoint_manager=mock_checkpoint_manager,
-            shutdown_signal=shutdown_signal,
-            logger=mock_logger,
-            cleanup_service=cleanup_service,
-        )
-
-        await runner._clear_via_lifecycle()
-
-        # Should use cleanup service
-        cleanup_service.execute.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_cleanup_service_priority_over_legacy(
-        self,
-        pipeline_config,
-        mock_context,
-        mock_executor,
-        mock_checkpoint_manager,
-        shutdown_signal,
-        mock_logger,
-        mock_lock_manager,
-    ):
-        """Test cleanup service is used over legacy when no lifecycle service."""
-        from bioetl.application.core.cleanup_service import CleanupResult, CleanupService
-
-        rebuild_runtime = RuntimeConfig(run_type=RunType.REBUILD, limit=None)
-
-        services = create_mock_services()
-        services.storage.clear_silver = AsyncMock(return_value=0)
-        services.storage.clear_gold = AsyncMock(return_value=0)
-
-        # Mock cleanup service (no lifecycle service)
-        cleanup_service = MagicMock(spec=CleanupService)
-        cleanup_service.execute = AsyncMock(
-            return_value=CleanupResult(silver_cleared=5, gold_cleared=3, dry_run=False)
-        )
-
-        runner = PipelineRunner(
-            config=pipeline_config,
-            runtime=rebuild_runtime,
-            services=services,
-            context=mock_context,
-            executor=mock_executor,
-            checkpoint_manager=mock_checkpoint_manager,
-            shutdown_signal=shutdown_signal,
-            logger=mock_logger,
-            lifecycle_service=None,  # No lifecycle service
-            cleanup_service=cleanup_service,
-        )
-
-        await runner._clear_via_lifecycle()
-
-        # Should use cleanup service, not storage directly
-        cleanup_service.execute.assert_called_once()
-        services.storage.clear_silver.assert_not_called()
-        services.storage.clear_gold.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_lifecycle_service_priority_over_cleanup(
-        self,
-        pipeline_config,
-        mock_context,
-        mock_executor,
-        mock_checkpoint_manager,
-        shutdown_signal,
-        mock_logger,
-        mock_lock_manager,
-    ):
-        """Test lifecycle service is used over cleanup service when both present."""
-        from bioetl.application.core.cleanup_service import CleanupResult, CleanupService
-        from bioetl.application.services.medallion_lifecycle import (
-            ClearResult,
-            MedallionLifecycleService,
-        )
-
-        rebuild_runtime = RuntimeConfig(run_type=RunType.REBUILD, limit=None)
-
-        services = create_mock_services()
-
-        # Mock both services
-        lifecycle_service = MagicMock(spec=MedallionLifecycleService)
-        lifecycle_service.clear = AsyncMock(
-            return_value=ClearResult(silver_cleared=10, gold_cleared=5, dry_run=False)
-        )
-
-        cleanup_service = MagicMock(spec=CleanupService)
-        cleanup_service.execute = AsyncMock(
-            return_value=CleanupResult(silver_cleared=5, gold_cleared=3, dry_run=False)
-        )
-
-        runner = PipelineRunner(
-            config=pipeline_config,
-            runtime=rebuild_runtime,
-            services=services,
-            context=mock_context,
-            executor=mock_executor,
-            checkpoint_manager=mock_checkpoint_manager,
-            shutdown_signal=shutdown_signal,
-            logger=mock_logger,
-            lifecycle_service=lifecycle_service,
-            cleanup_service=cleanup_service,
-        )
-
-        await runner._clear_via_lifecycle()
-
-        # Should use lifecycle service (higher priority)
-        lifecycle_service.clear.assert_called_once()
-        cleanup_service.execute.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_cleanup_service_skips_for_incremental(
-        self,
-        pipeline_config,
-        mock_context,
-        mock_executor,
-        mock_checkpoint_manager,
-        shutdown_signal,
-        mock_logger,
-        mock_lock_manager,
-    ):
-        """Test cleanup service is not called for incremental runs."""
-        from bioetl.application.core.cleanup_service import CleanupService
-
-        incremental_runtime = RuntimeConfig(run_type=RunType.INCREMENTAL, limit=None)
-
-        services = create_mock_services()
-
-        cleanup_service = MagicMock(spec=CleanupService)
-
-        runner = PipelineRunner(
-            config=pipeline_config,
-            runtime=incremental_runtime,
-            services=services,
-            context=mock_context,
-            executor=mock_executor,
-            checkpoint_manager=mock_checkpoint_manager,
-            shutdown_signal=shutdown_signal,
-            logger=mock_logger,
-            cleanup_service=cleanup_service,
-        )
-
-        await runner._clear_via_lifecycle()
-
-        # Should not call cleanup service for incremental
-        cleanup_service.execute.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_cleanup_service_passes_dry_run(
-        self,
-        pipeline_config,
-        mock_context,
-        mock_executor,
-        mock_checkpoint_manager,
-        shutdown_signal,
-        mock_logger,
-        mock_lock_manager,
-    ):
-        """Test cleanup service receives dry_run flag."""
-        from bioetl.application.core.cleanup_service import CleanupResult, CleanupService
-
-        dry_run_runtime = RuntimeConfig(
-            run_type=RunType.REBUILD, limit=None, dry_run=True
-        )
-
-        services = create_mock_services()
-
-        cleanup_service = MagicMock(spec=CleanupService)
-        cleanup_service.execute = AsyncMock(
-            return_value=CleanupResult(silver_cleared=5, gold_cleared=3, dry_run=True)
-        )
-
-        runner = PipelineRunner(
-            config=pipeline_config,
-            runtime=dry_run_runtime,
-            services=services,
-            context=mock_context,
-            executor=mock_executor,
-            checkpoint_manager=mock_checkpoint_manager,
-            shutdown_signal=shutdown_signal,
-            logger=mock_logger,
-            cleanup_service=cleanup_service,
-        )
-
-        await runner._clear_via_lifecycle()
-
-        # Should pass dry_run=True
-        cleanup_service.execute.assert_called_once()
-        call_kwargs = cleanup_service.execute.call_args.kwargs
-        assert call_kwargs["dry_run"] is True


### PR DESCRIPTION
…mandatory

BREAKING CHANGE: lifecycle_service is now a required parameter in PipelineRunner

Changes:
- Make lifecycle_service mandatory in PipelineRunner.__init__
- Remove cleanup_service parameter from PipelineRunner
- Remove _clear_via_cleanup_service() method
- Remove _clear_exports_legacy() method (~60 lines)
- Simplify _clear_via_lifecycle() to use MedallionLifecycleService directly
- Remove type: ignore comment for lifecycle_service.clear()

Test updates:
- Add mock_lifecycle_service fixture
- Update all PipelineRunner instantiations to include lifecycle_service
- Remove TestPipelineRunnerClearExportsLegacy class (6 tests)
- Remove TestPipelineRunnerClearViaCleanupService class (5 tests)
- Remove legacy fallback test from TestPipelineRunnerClearViaLifecycle
- Update integration tests to use mock_lifecycle_service_with_recorder

Note: CleanupService remains available for CLI (bioetl cleanup preview)

Refs: R2 - Remove Legacy Cleanup Path