### PR TITLE
Unify Registry API across modules

### DIFF
--- a/docs/03-guides/registry-pattern.md
+++ b/docs/03-guides/registry-pattern.md
@@ -1,0 +1,109 @@
+# Registry Pattern
+
+All registries in BioETL follow the unified `RegistryProtocol` for consistent API across the codebase.
+
+## Standard Methods
+
+| Method | Description |
+|--------|-------------|
+| `register(key, value)` | Register an item |
+| `get(key)` | Get item (raises `KeyError` if missing) |
+| `list_keys()` | List all registered keys |
+| `contains(key)` | Check if key is registered |
+| `clear()` | Clear all registrations (testing only) |
+
+## Implementations
+
+### PipelineRegistry
+
+Registry for pipeline factories. Located in `src/bioetl/composition/registry.py`.
+
+```python
+from bioetl.composition.registry import PipelineRegistry
+
+# List all registered pipelines
+pipelines = PipelineRegistry.list_keys()
+
+# Check if pipeline exists
+if PipelineRegistry.contains("chembl_activity"):
+    definition = PipelineRegistry.get("chembl_activity")
+```
+
+### DataSourceRegistry
+
+Registry for data source creators. Located in `src/bioetl/composition/factories/data_source_registry.py`.
+
+```python
+from bioetl.composition.factories.data_source_registry import DataSourceRegistry
+
+# List all registered providers
+providers = DataSourceRegistry.list_keys()
+
+# Check if provider exists
+if DataSourceRegistry.contains("chembl"):
+    creator = DataSourceRegistry.get("chembl")
+```
+
+## Legacy Aliases
+
+For backward compatibility, the following legacy methods are available:
+
+| Registry | Legacy Method | Unified Method |
+|----------|---------------|----------------|
+| `PipelineRegistry` | `register_factory(factory)` | `register(key, factory)` |
+| `PipelineRegistry` | `list_pipelines()` | `list_keys()` |
+| `DataSourceRegistry` | `list_providers()` | `list_keys()` |
+
+## Protocol Definition
+
+The base protocol is defined in `src/bioetl/composition/base_registry.py`:
+
+```python
+from typing import Protocol, TypeVar, runtime_checkable
+
+K = TypeVar("K")  # Key type
+V = TypeVar("V")  # Value type
+
+@runtime_checkable
+class RegistryProtocol(Protocol[K, V]):
+    @classmethod
+    def register(cls, key: K, value: V) -> None: ...
+
+    @classmethod
+    def get(cls, key: K) -> V: ...
+
+    @classmethod
+    def list_keys(cls) -> list[K]: ...
+
+    @classmethod
+    def contains(cls, key: K) -> bool: ...
+
+    @classmethod
+    def clear(cls) -> None: ...
+```
+
+## Error Handling
+
+All registries raise `KeyError` when accessing non-existent keys:
+
+```python
+try:
+    creator = DataSourceRegistry.get("unknown_provider")
+except KeyError as e:
+    print(f"Provider not found: {e}")
+```
+
+**Note:** `PipelineRegistry.get()` raises `RuntimeError` if the registry is empty (registration not called), and `ValueError` for unknown pipeline names. This is for backward compatibility and provides more helpful error messages.
+
+## Testing
+
+When writing tests that modify registries, use the `clear()` method in teardown:
+
+```python
+@pytest.fixture(autouse=True)
+def reset_registries():
+    backup = PipelineRegistry._registry.copy()
+    yield
+    PipelineRegistry._registry.clear()
+    PipelineRegistry._registry.update(backup)
+```

--- a/src/bioetl/composition/base_registry.py
+++ b/src/bioetl/composition/base_registry.py
@@ -1,0 +1,87 @@
+"""Base Registry Protocol for unified registration pattern.
+
+All registries (PipelineRegistry, DataSourceRegistry, etc.) should
+follow this protocol for consistent API across the codebase.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Protocol, TypeVar, runtime_checkable
+
+K = TypeVar("K")  # Key type
+V = TypeVar("V")  # Value type
+
+
+@runtime_checkable
+class RegistryProtocol(Protocol[K, V]):
+    """Protocol defining the standard Registry interface.
+
+    All registries MUST implement these methods for consistency.
+
+    Example:
+        >>> class MyRegistry(RegistryProtocol[str, Callable]):
+        ...     _registry: ClassVar[dict[str, Callable]] = {}
+        ...
+        ...     @classmethod
+        ...     def register(cls, key: str, value: Callable) -> None:
+        ...         cls._registry[key] = value
+    """
+
+    _registry: ClassVar[dict[K, V]]
+
+    @classmethod
+    def register(cls, key: K, value: V) -> None:
+        """Register a value with the given key.
+
+        Args:
+            key: Unique identifier for the registered item.
+            value: The item to register.
+
+        Raises:
+            ValueError: If key is already registered (optional - warn instead).
+        """
+        ...
+
+    @classmethod
+    def get(cls, key: K) -> V:
+        """Get a registered value by key.
+
+        Args:
+            key: The key to look up.
+
+        Returns:
+            The registered value.
+
+        Raises:
+            KeyError: If key is not registered.
+        """
+        ...
+
+    @classmethod
+    def list_keys(cls) -> list[K]:
+        """List all registered keys.
+
+        Returns:
+            List of registered keys in registration order.
+        """
+        ...
+
+    @classmethod
+    def contains(cls, key: K) -> bool:
+        """Check if a key is registered.
+
+        Args:
+            key: The key to check.
+
+        Returns:
+            True if key is registered, False otherwise.
+        """
+        ...
+
+    @classmethod
+    def clear(cls) -> None:
+        """Clear all registrations (for testing).
+
+        WARNING: Only use in tests. Not for production.
+        """
+        ...

--- a/src/bioetl/composition/factories/data_source_registry.py
+++ b/src/bioetl/composition/factories/data_source_registry.py
@@ -222,8 +222,37 @@ class DataSourceRegistry:
         """List all registered providers.
 
         Returns providers from both this registry and ProviderRegistry.
+        Legacy alias for list_keys().
         """
         ensure_providers_loaded()
         registry_providers = set(ProviderRegistry.list_providers())
         local_providers = set(cls._creators.keys())
         return sorted(registry_providers | local_providers)
+
+    @classmethod
+    def list_keys(cls) -> list[str]:
+        """List all registered provider names (unified API).
+
+        Alias for list_providers().
+        """
+        return cls.list_providers()
+
+    @classmethod
+    def contains(cls, key: str) -> bool:
+        """Check if provider is registered.
+
+        Args:
+            key: Provider name to check
+
+        Returns:
+            True if provider is registered, False otherwise
+        """
+        return key in cls._creators
+
+    @classmethod
+    def clear(cls) -> None:
+        """Clear all registrations (for testing).
+
+        WARNING: Only use in tests. Not for production.
+        """
+        cls._creators.clear()

--- a/src/bioetl/composition/registry.py
+++ b/src/bioetl/composition/registry.py
@@ -121,5 +121,59 @@ class PipelineRegistry:
 
     @classmethod
     def list_pipelines(cls) -> list[str]:
-        """List all registered pipeline names."""
+        """List all registered pipeline names.
+
+        Legacy alias for list_keys().
+        """
         return list(cls._registry.keys())
+
+    @classmethod
+    def register(
+        cls,
+        key: str,
+        value: PipelineFactoryProtocol,
+    ) -> None:
+        """Register a pipeline factory (unified API).
+
+        This method provides a unified API consistent with other registries.
+        For backward compatibility, use register_factory() which extracts
+        the key from factory.pipeline_name.
+
+        Args:
+            key: Pipeline name (must match factory.pipeline_name)
+            value: Pipeline factory instance
+        """
+        gold_schema = getattr(value, "gold_schema", None)
+        cls._registry[key] = PipelineDefinition(
+            factory=value,
+            silver_schema=value.silver_schema,
+            gold_schema=gold_schema,
+        )
+
+    @classmethod
+    def list_keys(cls) -> list[str]:
+        """List all registered pipeline names (unified API).
+
+        Alias for list_pipelines().
+        """
+        return cls.list_pipelines()
+
+    @classmethod
+    def contains(cls, key: str) -> bool:
+        """Check if pipeline is registered.
+
+        Args:
+            key: Pipeline name to check
+
+        Returns:
+            True if pipeline is registered, False otherwise
+        """
+        return key in cls._registry
+
+    @classmethod
+    def clear(cls) -> None:
+        """Clear all registrations (for testing).
+
+        WARNING: Only use in tests. Not for production.
+        """
+        cls._registry.clear()

--- a/tests/unit/composition/test_registry_protocol.py
+++ b/tests/unit/composition/test_registry_protocol.py
@@ -1,0 +1,200 @@
+"""Unit tests for unified Registry protocol.
+
+Verifies that all registries implement the unified API.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from bioetl.composition.factories.pipeline_factories import register_all_pipelines
+from bioetl.composition.registry import PipelineRegistry
+
+
+class TestPipelineRegistryUnifiedAPI:
+    """Test that PipelineRegistry has unified API methods."""
+
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self):
+        """Ensure registry is populated and restore after test."""
+        register_all_pipelines()
+        backup = PipelineRegistry._registry.copy()
+
+        yield
+
+        PipelineRegistry._registry.clear()
+        PipelineRegistry._registry.update(backup)
+
+    def test_list_keys_returns_list(self):
+        """PipelineRegistry.list_keys() should return a list."""
+        keys = PipelineRegistry.list_keys()
+        assert isinstance(keys, list)
+
+    def test_list_keys_matches_list_pipelines(self):
+        """list_keys() should return same result as list_pipelines()."""
+        assert PipelineRegistry.list_keys() == PipelineRegistry.list_pipelines()
+
+    def test_contains_returns_true_for_registered(self):
+        """contains() should return True for registered pipelines."""
+        keys = PipelineRegistry.list_keys()
+        if keys:
+            assert PipelineRegistry.contains(keys[0])
+
+    def test_contains_returns_false_for_unknown(self):
+        """contains() should return False for unknown pipeline."""
+        assert not PipelineRegistry.contains("unknown_pipeline_xyz")
+
+    def test_clear_empties_registry(self):
+        """clear() should empty the registry."""
+        initial_count = len(PipelineRegistry.list_keys())
+        assert initial_count > 0
+
+        PipelineRegistry.clear()
+
+        assert len(PipelineRegistry.list_keys()) == 0
+
+    def test_register_adds_pipeline(self):
+        """register() should add a pipeline to registry."""
+        mock_factory = MagicMock()
+        mock_factory.pipeline_name = "test_pipeline"
+        mock_factory.silver_schema = None
+
+        PipelineRegistry.register("test_pipeline", mock_factory)
+
+        assert PipelineRegistry.contains("test_pipeline")
+        definition = PipelineRegistry.get("test_pipeline")
+        assert definition.factory is mock_factory
+
+
+class TestDataSourceRegistryUnifiedAPI:
+    """Test that DataSourceRegistry has unified API methods."""
+
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self):
+        """Restore registry after test."""
+        from bioetl.composition.factories.data_source_registry import (
+            DataSourceRegistry,
+        )
+
+        backup = DataSourceRegistry._creators.copy()
+
+        yield
+
+        DataSourceRegistry._creators.clear()
+        DataSourceRegistry._creators.update(backup)
+
+    def test_list_keys_returns_list(self):
+        """DataSourceRegistry.list_keys() should return a list."""
+        from bioetl.composition.factories.data_source_registry import (
+            DataSourceRegistry,
+        )
+
+        keys = DataSourceRegistry.list_keys()
+        assert isinstance(keys, list)
+
+    def test_list_keys_matches_list_providers(self):
+        """list_keys() should return same result as list_providers()."""
+        from bioetl.composition.factories.data_source_registry import (
+            DataSourceRegistry,
+        )
+
+        assert DataSourceRegistry.list_keys() == DataSourceRegistry.list_providers()
+
+    def test_contains_returns_true_for_registered(self):
+        """contains() should return True for registered providers."""
+        from bioetl.composition.factories.data_source_registry import (
+            DataSourceRegistry,
+        )
+
+        assert DataSourceRegistry.contains("chembl")
+
+    def test_contains_returns_false_for_unknown(self):
+        """contains() should return False for unknown provider."""
+        from bioetl.composition.factories.data_source_registry import (
+            DataSourceRegistry,
+        )
+
+        assert not DataSourceRegistry.contains("unknown_provider_xyz")
+
+    def test_clear_empties_registry(self):
+        """clear() should empty the registry."""
+        from bioetl.composition.factories.data_source_registry import (
+            DataSourceRegistry,
+        )
+
+        initial_count = len(DataSourceRegistry._creators)
+        assert initial_count > 0
+
+        DataSourceRegistry.clear()
+
+        assert len(DataSourceRegistry._creators) == 0
+
+    def test_get_raises_keyerror_for_unknown(self):
+        """get() should raise KeyError for unknown provider."""
+        from bioetl.composition.factories.data_source_registry import (
+            DataSourceRegistry,
+        )
+
+        with pytest.raises(KeyError):
+            DataSourceRegistry.get("unknown_provider_xyz")
+
+
+class TestUnifiedAPIConsistency:
+    """Test that all registries have consistent API."""
+
+    def test_both_registries_have_list_keys(self):
+        """Both registries should have list_keys() method."""
+        from bioetl.composition.factories.data_source_registry import (
+            DataSourceRegistry,
+        )
+
+        assert hasattr(PipelineRegistry, "list_keys")
+        assert hasattr(DataSourceRegistry, "list_keys")
+        assert callable(PipelineRegistry.list_keys)
+        assert callable(DataSourceRegistry.list_keys)
+
+    def test_both_registries_have_contains(self):
+        """Both registries should have contains() method."""
+        from bioetl.composition.factories.data_source_registry import (
+            DataSourceRegistry,
+        )
+
+        assert hasattr(PipelineRegistry, "contains")
+        assert hasattr(DataSourceRegistry, "contains")
+        assert callable(PipelineRegistry.contains)
+        assert callable(DataSourceRegistry.contains)
+
+    def test_both_registries_have_clear(self):
+        """Both registries should have clear() method."""
+        from bioetl.composition.factories.data_source_registry import (
+            DataSourceRegistry,
+        )
+
+        assert hasattr(PipelineRegistry, "clear")
+        assert hasattr(DataSourceRegistry, "clear")
+        assert callable(PipelineRegistry.clear)
+        assert callable(DataSourceRegistry.clear)
+
+    def test_both_registries_have_get(self):
+        """Both registries should have get() method."""
+        from bioetl.composition.factories.data_source_registry import (
+            DataSourceRegistry,
+        )
+
+        assert hasattr(PipelineRegistry, "get")
+        assert hasattr(DataSourceRegistry, "get")
+        assert callable(PipelineRegistry.get)
+        assert callable(DataSourceRegistry.get)
+
+    def test_both_registries_have_register(self):
+        """Both registries should have register() method."""
+        from bioetl.composition.factories.data_source_registry import (
+            DataSourceRegistry,
+        )
+
+        assert hasattr(PipelineRegistry, "register")
+        assert hasattr(DataSourceRegistry, "register")
+        assert callable(PipelineRegistry.register)
+        assert callable(DataSourceRegistry.register)


### PR DESCRIPTION
Add unified API to PipelineRegistry and DataSourceRegistry:
- Create base_registry.py with RegistryProtocol definition
- Add register(), list_keys(), contains(), clear() methods
- Add documentation for registry pattern
- Add unit tests for unified API (17 tests)

Legacy methods (register_factory, list_pipelines, list_providers) are preserved as aliases for backward compatibility.