### PR TITLE
Make schema required for Gold layer validation

### DIFF
--- a/src/bioetl/application/core/config.py
+++ b/src/bioetl/application/core/config.py
@@ -16,6 +16,6 @@ class RecordProcessorConfig:
     provider: str
     entity_type: str
     silver_schema: Any
-    gold_schema: Any | None = None
+    gold_schema: Any
     dq_config: DQConfig | None = None
     table_config: TableConfig = field(default_factory=TableConfig)

--- a/src/bioetl/application/core/record_processor.py
+++ b/src/bioetl/application/core/record_processor.py
@@ -316,6 +316,7 @@ class RecordProcessor:
         await self._storage.write_gold(
             table_name=table_name,
             records=records,
+            schema=self._config.gold_schema,
             primary_keys=self._table_config.primary_keys,
             mode=write_mode,
         )

--- a/src/bioetl/composition/factories/generic_factory.py
+++ b/src/bioetl/composition/factories/generic_factory.py
@@ -22,7 +22,7 @@ from bioetl.composition.factories.data_source_registry import (
 from bioetl.domain.config import TableConfig
 from bioetl.domain.error_classifier import ErrorClassifier
 from bioetl.infrastructure.config import load_pipeline_config, yaml_config_to_domain
-from bioetl.infrastructure.validation import NoOpGoldValidator, PanderaGoldValidator
+from bioetl.infrastructure.validation import PanderaGoldValidator
 
 if TYPE_CHECKING:
     import pyarrow as pa
@@ -74,7 +74,7 @@ class GenericPipelineFactory(Generic[TPipeline]):
         pipeline_class: type[TPipeline],
         provider: str,
         silver_schema: pa.Schema | None = None,
-        gold_schema: Any | None = None,
+        gold_schema: Any = None,
         data_source_creator: DataSourceCreator | None = None,
     ) -> None:
         """Initialize the factory.
@@ -84,10 +84,18 @@ class GenericPipelineFactory(Generic[TPipeline]):
             pipeline_class: The pipeline class to instantiate
             provider: Provider name for data source creation
             silver_schema: Optional PyArrow schema for Silver layer
-            gold_schema: Optional Pandera schema for Gold layer
+            gold_schema: Pandera schema for Gold layer validation (required)
             data_source_creator: Optional custom creator function. If not provided,
                 uses DataSourceRegistry.get(provider)
+
+        Raises:
+            ValueError: If gold_schema is not provided
         """
+        if gold_schema is None:
+            raise ValueError(
+                f"gold_schema is required for pipeline '{pipeline_name}'. "
+                "All Gold layer writes must have schema validation."
+            )
         self.pipeline_name = pipeline_name
         self.pipeline_class = pipeline_class
         self.provider = provider
@@ -325,11 +333,8 @@ class GenericPipelineFactory(Generic[TPipeline]):
         )
 
         # Create Gold validator from schema (DI pattern)
-        gold_validator = (
-            PanderaGoldValidator(self.gold_schema)
-            if self.gold_schema
-            else NoOpGoldValidator()
-        )
+        # gold_schema is always required, so always use PanderaGoldValidator
+        gold_validator = PanderaGoldValidator(self.gold_schema)
 
         return RecordProcessor(
             services=pipeline.services,
@@ -348,7 +353,7 @@ def create_pipeline_factory(
     pipeline_class: type[TPipeline],
     provider: str,
     silver_schema: pa.Schema | None = None,
-    gold_schema: Any | None = None,
+    gold_schema: Any = None,
 ) -> GenericPipelineFactory[TPipeline]:
     """Convenience function for creating pipeline factories.
 
@@ -357,7 +362,7 @@ def create_pipeline_factory(
         pipeline_class: Pipeline class to instantiate
         provider: Data source provider name
         silver_schema: Optional Silver layer schema
-        gold_schema: Optional Gold layer schema
+        gold_schema: Pandera schema for Gold layer validation (required)
 
     Returns:
         Configured GenericPipelineFactory

--- a/src/bioetl/composition/factories/storage_factory.py
+++ b/src/bioetl/composition/factories/storage_factory.py
@@ -93,6 +93,7 @@ class StorageAdapter:
         self,
         table_name: str,
         records: list[dict[str, Any]],
+        schema: Any,
         primary_keys: list[str] | None = None,
         mode: Literal["overwrite", "append", "scd2"] = "overwrite",
     ) -> None:
@@ -100,6 +101,7 @@ class StorageAdapter:
         await self.gold.write_gold(
             table_name=table_name,
             records=records,
+            schema=schema,
             primary_keys=primary_keys,
             mode=mode,
         )

--- a/src/bioetl/composition/registry.py
+++ b/src/bioetl/composition/registry.py
@@ -61,8 +61,8 @@ class PipelineDefinition(NamedTuple):
     silver_schema: pa.Schema | None
     """PyArrow schema for Silver layer validation."""
 
-    gold_schema: Any | None = None
-    """Pandera schema for Gold layer validation."""
+    gold_schema: Any
+    """Pandera schema for Gold layer validation (required)."""
 
 
 class PipelineRegistry:
@@ -84,8 +84,16 @@ class PipelineRegistry:
 
         Args:
             factory: Factory instance with pipeline_name and silver_schema attributes
+
+        Raises:
+            ValueError: If factory does not have gold_schema attribute
         """
         gold_schema = getattr(factory, "gold_schema", None)
+        if gold_schema is None:
+            raise ValueError(
+                f"Factory '{factory.pipeline_name}' must have gold_schema. "
+                "All Gold layer writes require schema validation."
+            )
 
         cls._registry[factory.pipeline_name] = PipelineDefinition(
             factory=factory,
@@ -142,8 +150,16 @@ class PipelineRegistry:
         Args:
             key: Pipeline name (must match factory.pipeline_name)
             value: Pipeline factory instance
+
+        Raises:
+            ValueError: If factory does not have gold_schema attribute
         """
         gold_schema = getattr(value, "gold_schema", None)
+        if gold_schema is None:
+            raise ValueError(
+                f"Factory '{key}' must have gold_schema. "
+                "All Gold layer writes require schema validation."
+            )
         cls._registry[key] = PipelineDefinition(
             factory=value,
             silver_schema=value.silver_schema,

--- a/src/bioetl/domain/ports/storage.py
+++ b/src/bioetl/domain/ports/storage.py
@@ -78,6 +78,7 @@ class StoragePort(Protocol):
         self,
         table_name: str,
         records: list[dict[str, Any]],
+        schema: Any,
         primary_keys: list[str] | None = None,
         mode: Literal["overwrite", "append", "scd2"] = "overwrite",
     ) -> None:
@@ -86,8 +87,12 @@ class StoragePort(Protocol):
         Args:
             table_name: The name of the table to write to.
             records: A list of dictionaries, where each dictionary is a gold record.
+            schema: Pandera DataFrameSchema for strict validation (required).
             primary_keys: Optional list of column names for sorting/deduplication.
             mode: The write mode (e.g., 'overwrite', 'append', 'scd2').
+
+        Raises:
+            ValueError: If schema validation fails (strict=True required).
         """
         ...
 

--- a/src/bioetl/infrastructure/storage/gold_writer.py
+++ b/src/bioetl/infrastructure/storage/gold_writer.py
@@ -78,8 +78,8 @@ class GoldWriter:
         self,
         table_name: str,
         records: list[dict[str, Any]],
+        schema: DataFrameSchema,
         primary_keys: list[str] | None = None,
-        schema: DataFrameSchema | None = None,
         mode: str = "overwrite",
         partition_cols: list[str] | None = None,
         scd_config: dict[str, Any] | None = None,
@@ -89,8 +89,8 @@ class GoldWriter:
         Args:
             table_name: Target table name
             records: List of records to write
+            schema: Pandera schema for validation (must have strict=True)
             primary_keys: Primary key columns for deterministic sorting
-            schema: Optional Pandera schema (must have strict=True)
             mode: Write mode - 'overwrite', 'append', or 'scd2'
             partition_cols: Optional partition columns
             scd_config: Required config for SCD2 mode
@@ -114,16 +114,15 @@ class GoldWriter:
         if validated_mode == GoldWriteMode.SCD2 and scd_config is None:
             raise ValueError("scd_config required for SCD Type 2 mode")
 
-        if schema is not None:
-            if not schema.strict:
-                raise ValueError("Gold layer requires strict=True schema validation")
-            import polars as pl
+        if not schema.strict:
+            raise ValueError("Gold layer requires strict=True schema validation")
+        import polars as pl
 
-            df = pl.DataFrame(records)
-            try:
-                await self._run_in_executor(lambda: schema.validate(df, lazy=False))
-            except pandera_pa.errors.SchemaError as e:
-                raise ValueError(f"Schema validation failed: {e}") from e
+        df = pl.DataFrame(records)
+        try:
+            await self._run_in_executor(lambda: schema.validate(df, lazy=False))
+        except pandera_pa.errors.SchemaError as e:
+            raise ValueError(f"Schema validation failed: {e}") from e
 
         table_path = f"{self.base_path}/{table_name.replace('.', '/')}"
 

--- a/tests/architecture/test_port_contracts.py
+++ b/tests/architecture/test_port_contracts.py
@@ -260,6 +260,30 @@ class TestStoragePortContract:
         assert "target_path" in params, "archive() MUST have target_path parameter"
         assert "remove_source" in params, "archive() MUST have remove_source parameter"
 
+    def test_storage_port_write_gold_requires_schema(self) -> None:
+        """StoragePort.write_gold() MUST have required schema parameter.
+
+        Gold layer writes MUST include schema for validation.
+        This ensures data quality at the Gold layer boundary.
+        See RULES.md §2.1.1 - Gold Layer specifications.
+        """
+        import inspect
+
+        sig = inspect.signature(ports.StoragePort.write_gold)
+        params = sig.parameters
+
+        assert "schema" in params, (
+            "StoragePort.write_gold() MUST have schema parameter. "
+            "Gold layer requires strict schema validation."
+        )
+
+        # Schema parameter MUST NOT have a default value (i.e., it's required)
+        schema_param = params["schema"]
+        assert schema_param.default is inspect.Parameter.empty, (
+            "StoragePort.write_gold() schema parameter MUST be required (no default). "
+            "All Gold layer writes MUST provide a schema for validation."
+        )
+
 
 # ============================================================================
 # Metrics Port Contract Tests

--- a/tests/fakes/storage_fake.py
+++ b/tests/fakes/storage_fake.py
@@ -109,6 +109,7 @@ class InMemoryStorage:
         self,
         table_name: str,
         records: list[dict[str, Any]],
+        schema: Any,
         primary_keys: list[str] | None = None,
         mode: Literal["overwrite", "append", "scd2"] = "overwrite",
     ) -> None:

--- a/tests/infrastructure/storage/test_gold_writer_integration.py
+++ b/tests/infrastructure/storage/test_gold_writer_integration.py
@@ -34,10 +34,10 @@ def strict_schema():
     )
 
 
-async def test_write_gold_no_records(gold_writer):
+async def test_write_gold_no_records(gold_writer, strict_schema):
     """Test writing empty records raises ValueError."""
     with pytest.raises(ValueError, match="No records to write"):
-        await gold_writer.write_gold("test_table", [])
+        await gold_writer.write_gold("test_table", [], schema=strict_schema)
 
 
 async def test_write_gold_schema_not_strict(gold_writer, valid_records):
@@ -58,18 +58,18 @@ async def test_write_gold_schema_validation_failure(gold_writer, strict_schema):
         )
 
 
-async def test_write_gold_invalid_mode(gold_writer, valid_records):
+async def test_write_gold_invalid_mode(gold_writer, valid_records, strict_schema):
     """Test invalid write mode raises ValueError."""
     with pytest.raises(ValueError, match="Invalid Gold write mode"):
-        await gold_writer.write_gold("test_table", valid_records, mode="invalid")
+        await gold_writer.write_gold("test_table", valid_records, schema=strict_schema, mode="invalid")
 
 
-async def test_write_simple_overwrite(gold_writer, valid_records):
+async def test_write_simple_overwrite(gold_writer, valid_records, strict_schema):
     """Test simple overwrite mode."""
     with patch(
         "bioetl.infrastructure.storage.gold_writer.write_deltalake"
     ) as mock_write:
-        await gold_writer.write_gold("test_table", valid_records, mode="overwrite")
+        await gold_writer.write_gold("test_table", valid_records, schema=strict_schema, mode="overwrite")
 
         mock_write.assert_called_once()
         call_kwargs = mock_write.call_args[1]
@@ -85,25 +85,25 @@ async def test_write_simple_overwrite(gold_writer, valid_records):
         assert actual_data.equals(expected_table)
 
 
-async def test_write_simple_append(gold_writer, valid_records):
+async def test_write_simple_append(gold_writer, valid_records, strict_schema):
     """Test simple append mode."""
     with patch(
         "bioetl.infrastructure.storage.gold_writer.write_deltalake"
     ) as mock_write:
-        await gold_writer.write_gold("test_table", valid_records, mode="append")
+        await gold_writer.write_gold("test_table", valid_records, schema=strict_schema, mode="append")
 
         mock_write.assert_called_once()
         call_kwargs = mock_write.call_args[1]
         assert call_kwargs["mode"] == "append"
 
 
-async def test_write_scd2_missing_config(gold_writer, valid_records):
+async def test_write_scd2_missing_config(gold_writer, valid_records, strict_schema):
     """Test SCD2 mode without config raises ValueError."""
     with pytest.raises(ValueError, match="scd_config required"):
-        await gold_writer.write_gold("test_table", valid_records, mode="scd2")
+        await gold_writer.write_gold("test_table", valid_records, schema=strict_schema, mode="scd2")
 
 
-async def test_write_scd2_new_table(gold_writer, valid_records):
+async def test_write_scd2_new_table(gold_writer, valid_records, strict_schema):
     """Test SCD2 write when table does not exist (creates new)."""
     scd_config = {"business_key": "id"}
 
@@ -116,7 +116,7 @@ async def test_write_scd2_new_table(gold_writer, valid_records):
         mock_dt.side_effect = TableNotFoundError("Table not found")
 
         await gold_writer.write_gold(
-            "test_table", valid_records, mode="scd2", scd_config=scd_config
+            "test_table", valid_records, schema=strict_schema, mode="scd2", scd_config=scd_config
         )
 
         # Should call write_deltalake to create table
@@ -137,7 +137,7 @@ async def test_write_scd2_new_table(gold_writer, valid_records):
         assert written_data[0]["valid_to"] is None
 
 
-async def test_write_scd2_existing_table(gold_writer, valid_records):
+async def test_write_scd2_existing_table(gold_writer, valid_records, strict_schema):
     """Test SCD2 merge with existing table."""
     scd_config = {"business_key": "id"}
 
@@ -152,7 +152,7 @@ async def test_write_scd2_existing_table(gold_writer, valid_records):
         return_value=mock_dt_instance,
     ):
         await gold_writer.write_gold(
-            "test_table", valid_records, mode="scd2", scd_config=scd_config
+            "test_table", valid_records, schema=strict_schema, mode="scd2", scd_config=scd_config
         )
 
         # Should call merge

--- a/tests/integration/memory_storage.py
+++ b/tests/integration/memory_storage.py
@@ -24,5 +24,5 @@ class MemoryStorage(StoragePort):
     def write_silver(self, table_name, records, _primary_keys):
         self.data[table_name].extend(records)
 
-    def write_gold(self, table_name, records, _mode):
+    def write_gold(self, table_name, records, schema, _mode):
         self.data[table_name].extend(records)

--- a/tests/unit/infrastructure/factories/test_factories.py
+++ b/tests/unit/infrastructure/factories/test_factories.py
@@ -125,17 +125,21 @@ class TestStorageAdapter:
 
     async def test_write_gold_delegates(self, storage_adapter, mock_gold_writer):
         """Test write_gold delegates to gold writer."""
+        from unittest.mock import MagicMock
         records = [{"metric": "count", "value": 100}]
+        mock_schema = MagicMock()
 
         await storage_adapter.write_gold(
             table_name="gold.metrics",
             records=records,
+            schema=mock_schema,
             mode="overwrite",
         )
 
         mock_gold_writer.write_gold.assert_called_once_with(
             table_name="gold.metrics",
             records=records,
+            schema=mock_schema,
             primary_keys=None,
             mode="overwrite",
         )

--- a/tests/unit/infrastructure/factories/test_storage_adapter.py
+++ b/tests/unit/infrastructure/factories/test_storage_adapter.py
@@ -178,10 +178,12 @@ class TestStorageAdapterWriteGold:
     ) -> None:
         """Test that write_gold delegates to gold writer."""
         records = [{"id": 1, "aggregated_value": 100}]
+        mock_schema = MagicMock()
 
         await storage_adapter.write_gold(
             table_name="gold_table",
             records=records,
+            schema=mock_schema,
             mode="overwrite",
         )
 
@@ -189,6 +191,7 @@ class TestStorageAdapterWriteGold:
         call_kwargs = mock_gold_writer.write_gold.call_args[1]
         assert call_kwargs["table_name"] == "gold_table"
         assert call_kwargs["records"] == records
+        assert call_kwargs["schema"] == mock_schema
         assert call_kwargs["mode"] == "overwrite"
 
     @pytest.mark.asyncio
@@ -198,9 +201,11 @@ class TestStorageAdapterWriteGold:
         mock_gold_writer: MagicMock,
     ) -> None:
         """Test write_gold with append mode."""
+        mock_schema = MagicMock()
         await storage_adapter.write_gold(
             table_name="gold_table",
             records=[{"id": 1}],
+            schema=mock_schema,
             mode="append",
         )
 
@@ -214,9 +219,11 @@ class TestStorageAdapterWriteGold:
         mock_gold_writer: MagicMock,
     ) -> None:
         """Test write_gold uses default overwrite mode."""
+        mock_schema = MagicMock()
         await storage_adapter.write_gold(
             table_name="test",
             records=[],
+            schema=mock_schema,
         )
 
         call_kwargs = mock_gold_writer.write_gold.call_args[1]

--- a/tests/unit/infrastructure/storage/test_gold_writer.py
+++ b/tests/unit/infrastructure/storage/test_gold_writer.py
@@ -77,12 +77,13 @@ class TestGoldWriterInit:
 class TestGoldWriterValidation:
     """Tests for GoldWriter validation."""
 
-    async def test_write_gold_empty_records_raises(self, gold_writer):
+    async def test_write_gold_empty_records_raises(self, gold_writer, strict_schema):
         """Test write_gold raises ValueError for empty records."""
         with pytest.raises(ValueError, match="No records to write"):
             await gold_writer.write_gold(
                 table_name="test.table",
                 records=[],
+                schema=strict_schema,
                 mode="overwrite",
             )
 
@@ -98,23 +99,25 @@ class TestGoldWriterValidation:
                 mode="overwrite",
             )
 
-    async def test_write_gold_invalid_mode_raises(self, gold_writer, valid_records):
+    async def test_write_gold_invalid_mode_raises(self, gold_writer, valid_records, strict_schema):
         """Test write_gold raises ValueError for invalid mode."""
         with pytest.raises(ValueError, match="Invalid Gold write mode"):
             await gold_writer.write_gold(
                 table_name="test.table",
                 records=valid_records,
+                schema=strict_schema,
                 mode="invalid",
             )
 
     async def test_write_gold_scd2_without_config_raises(
-        self, gold_writer, valid_records
+        self, gold_writer, valid_records, strict_schema
     ):
         """Test write_gold raises ValueError for SCD2 mode without config."""
         with pytest.raises(ValueError, match="scd_config required"):
             await gold_writer.write_gold(
                 table_name="test.table",
                 records=valid_records,
+                schema=strict_schema,
                 mode="scd2",
             )
 
@@ -125,12 +128,13 @@ class TestGoldWriterWriteSimple:
 
     @patch("bioetl.infrastructure.storage.gold_writer.write_deltalake")
     async def test_write_gold_overwrite_mode(
-        self, mock_write_deltalake, gold_writer, valid_records
+        self, mock_write_deltalake, gold_writer, valid_records, strict_schema
     ):
         """Test write_gold with overwrite mode."""
         await gold_writer.write_gold(
             table_name="test.table",
             records=valid_records,
+            schema=strict_schema,
             mode="overwrite",
         )
 
@@ -141,12 +145,13 @@ class TestGoldWriterWriteSimple:
 
     @patch("bioetl.infrastructure.storage.gold_writer.write_deltalake")
     async def test_write_gold_append_mode(
-        self, mock_write_deltalake, gold_writer, valid_records
+        self, mock_write_deltalake, gold_writer, valid_records, strict_schema
     ):
         """Test write_gold with append mode."""
         await gold_writer.write_gold(
             table_name="test.table",
             records=valid_records,
+            schema=strict_schema,
             mode="append",
         )
 
@@ -156,12 +161,13 @@ class TestGoldWriterWriteSimple:
 
     @patch("bioetl.infrastructure.storage.gold_writer.write_deltalake")
     async def test_write_gold_with_partitions(
-        self, mock_write_deltalake, gold_writer, valid_records
+        self, mock_write_deltalake, gold_writer, valid_records, strict_schema
     ):
         """Test write_gold with partition columns."""
         await gold_writer.write_gold(
             table_name="test.table",
             records=valid_records,
+            schema=strict_schema,
             mode="overwrite",
             partition_cols=["year", "month"],
         )
@@ -178,7 +184,7 @@ class TestGoldWriterSCD2:
     @patch("bioetl.infrastructure.storage.gold_writer.DeltaTable")
     @patch("bioetl.infrastructure.storage.gold_writer.write_deltalake")
     async def test_write_gold_scd2_creates_new_table(
-        self, mock_write_deltalake, mock_delta_table, gold_writer, valid_records
+        self, mock_write_deltalake, mock_delta_table, gold_writer, valid_records, strict_schema
     ):
         """Test SCD2 write creates new table when table doesn't exist."""
         mock_delta_table.side_effect = TableNotFoundError("Not found")
@@ -194,6 +200,7 @@ class TestGoldWriterSCD2:
         await gold_writer.write_gold(
             table_name="test.table",
             records=valid_records,
+            schema=strict_schema,
             mode="scd2",
             scd_config=scd_config,
         )
@@ -205,7 +212,7 @@ class TestGoldWriterSCD2:
 
     @patch("bioetl.infrastructure.storage.gold_writer.DeltaTable")
     async def test_write_gold_scd2_merge_existing_table(
-        self, mock_delta_table, gold_writer, valid_records
+        self, mock_delta_table, gold_writer, valid_records, strict_schema
     ):
         """Test SCD2 write merges into existing table."""
         mock_table_instance = MagicMock()
@@ -222,6 +229,7 @@ class TestGoldWriterSCD2:
         await gold_writer.write_gold(
             table_name="test.table",
             records=valid_records,
+            schema=strict_schema,
             mode="scd2",
             scd_config=scd_config,
         )
@@ -232,7 +240,7 @@ class TestGoldWriterSCD2:
 
     @patch("bioetl.infrastructure.storage.gold_writer.DeltaTable")
     async def test_write_gold_scd2_with_list_business_key(
-        self, mock_delta_table, gold_writer, valid_records
+        self, mock_delta_table, gold_writer, strict_schema
     ):
         """Test SCD2 write with list of business keys."""
         mock_table_instance = MagicMock()
@@ -253,6 +261,7 @@ class TestGoldWriterSCD2:
         await gold_writer.write_gold(
             table_name="test.table",
             records=records,
+            schema=strict_schema,
             mode="scd2",
             scd_config=scd_config,
         )

--- a/tests/unit/infrastructure/test_storage.py
+++ b/tests/unit/infrastructure/test_storage.py
@@ -389,6 +389,8 @@ class TestGoldWriter:
 
     async def test_gold_writer_sorts_columns(self, mock_gold_writer_deps):
         """Test that GoldWriter sorts columns alphabetically in _to_arrow_table."""
+        from pandera.polars import Column, DataFrameSchema
+
         _mock_delta_table, mock_write_deltalake = mock_gold_writer_deps
 
         writer = GoldWriter(base_path="/tmp/gold")
@@ -399,9 +401,16 @@ class TestGoldWriter:
             {"c": 30, "b": 20, "a": 10},
         ]
 
+        # Create a strict schema matching the records
+        strict_schema = DataFrameSchema(
+            {"a": Column(int), "b": Column(int), "c": Column(int)},
+            strict=True,
+        )
+
         await writer.write_gold(
             table_name="test_table",
             records=records,
+            schema=strict_schema,
             mode="overwrite",
         )
 

--- a/tests/unit/test_ports.py
+++ b/tests/unit/test_ports.py
@@ -147,6 +147,7 @@ class TestStoragePortProtocol:
                 self,
                 table_name: str,
                 records: list[dict[str, Any]],
+                schema: Any,
                 primary_keys: list[str] | None = None,
                 mode: Literal["overwrite", "append", "scd2"] = "overwrite",
             ) -> None:


### PR DESCRIPTION
Breaking change: schema is now a required parameter for write_gold() across all layers (Port, GoldWriter, StorageAdapter).

Changes:
- StoragePort.write_gold: schema parameter is now required (no default)
- GoldWriter.write_gold: schema parameter moved before optional params
- StorageAdapter.write_gold: passes schema through to GoldWriter
- RecordProcessorConfig.gold_schema: now required (no default None)
- GenericPipelineFactory: validates gold_schema is provided
- PipelineRegistry: validates gold_schema on factory registration

Test updates:
- All test files updated to pass schema parameter
- Added architectural test verifying schema is required
- Updated InMemoryStorage and fake storage implementations

This ensures strict schema validation for all Gold layer writes, improving data quality at the Gold layer boundary.

Refs: RULES.md §2.1.1 - Gold Layer specifications