### PR TITLE
Add structured logging to health check

### DIFF
--- a/src/bioetl/infrastructure/adapters/chembl/client.py
+++ b/src/bioetl/infrastructure/adapters/chembl/client.py
@@ -441,9 +441,16 @@ class ChemblAdapter(BaseHttpAdapter):
         try:
             response = await self.http_client.get(CHEMBL_STATUS_URL)
             self._handle_health_response(response)
-        except Exception:
+        except Exception as e:
             self._consecutive_errors += 1
             self._update_health()
+            error_type = self._error_classifier.classify(e)
+            self.logger.warning(
+                "health_check_failed",
+                provider=self.provider_name,
+                error_type=error_type.value,
+                error=str(e),
+            )
 
         self._last_health_check = datetime.now()
         return self._cached_health
@@ -458,9 +465,21 @@ class ChemblAdapter(BaseHttpAdapter):
                 self._cached_health = HealthStatus.HEALTHY
             else:
                 self._cached_health = HealthStatus.DEGRADED
+                self.logger.warning(
+                    "health_check_degraded",
+                    provider=self.provider_name,
+                    reason="status_not_up",
+                    api_status=data.get("status"),
+                )
         else:
             self._consecutive_errors += 1
             self._update_health()
+            self.logger.warning(
+                "health_check_degraded",
+                provider=self.provider_name,
+                reason="non_200_response",
+                status_code=response.status_code,
+            )
 
     def _update_health(self) -> None:
         """Update health status based on error count."""

--- a/src/bioetl/infrastructure/adapters/pubchem/client.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/client.py
@@ -18,6 +18,8 @@ from typing import TYPE_CHECKING, Any
 import pubchempy as pcp
 
 from bioetl.composition.providers import register_provider
+from bioetl.domain.error_classifier import ErrorClassifier
+from bioetl.domain.exceptions import CircuitBreakerOpenError
 from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.adapters.http.health import (
     assess_health_from_circuit_breaker,
@@ -282,10 +284,30 @@ class PubChemAdapter(BaseSyncAdapter):
 
             if compound:
                 return assess_health_from_circuit_breaker(self.circuit_breaker)
-            else:
-                return HealthStatus.DEGRADED
 
-        except Exception:
+            self.logger.warning(
+                "health_check_degraded",
+                provider=self.provider_name,
+                reason="empty_response",
+            )
+            return HealthStatus.DEGRADED
+
+        except CircuitBreakerOpenError:
+            self.logger.warning(
+                "health_check_circuit_open",
+                provider=self.provider_name,
+            )
+            return HealthStatus.UNHEALTHY
+
+        except Exception as e:
+            error_classifier = ErrorClassifier()
+            error_type = error_classifier.classify(e)
+            self.logger.warning(
+                "health_check_failed",
+                provider=self.provider_name,
+                error_type=error_type.value,
+                error=str(e),
+            )
             return HealthStatus.UNHEALTHY
 
     def __repr__(self) -> str:

--- a/src/bioetl/infrastructure/adapters/uniprot/client.py
+++ b/src/bioetl/infrastructure/adapters/uniprot/client.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any
 from typing_extensions import override
 
 from bioetl.composition.providers import register_provider
+from bioetl.domain.error_classifier import ErrorClassifier
 from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.adapters.base import BaseHttpAdapter
 from bioetl.infrastructure.adapters.http.pagination import PaginatedFetcherMixin
@@ -290,9 +291,23 @@ class UniProtAdapter(BaseHttpAdapter, PaginatedFetcherMixin):
                 f"{self.base_url}/uniprotkb/search", params=params
             )
             if resp.status_code != 200:
+                self.logger.warning(
+                    "health_check_degraded",
+                    provider=self.provider_name,
+                    reason="non_200_response",
+                    status_code=resp.status_code,
+                )
                 return HealthStatus.DEGRADED
-        except Exception:
-            pass  # Fallback to circuit breaker check
+        except Exception as e:
+            error_classifier = ErrorClassifier()
+            error_type = error_classifier.classify(e)
+            self.logger.warning(
+                "health_check_failed",
+                provider=self.provider_name,
+                error_type=error_type.value,
+                error=str(e),
+            )
+            # Fallback to circuit breaker check
 
         return await super().health_check()
 


### PR DESCRIPTION
Add structured logging with error classification to health_check() methods in PubChem, ChEMBL, and UniProt adapters for improved observability when health checks fail or degrade.

Changes:
- PubChem: Log degraded (empty_response), circuit_open, and failed states
- ChEMBL: Log degraded (status_not_up, non_200_response) and failed states
- UniProt: Log degraded (non_200_response) and failed states

All logs include provider name, error_type, and error details.