### PR TITLE
Add LoggerPort to all storage writers

### DIFF
--- a/src/bioetl/composition/bootstrap.py
+++ b/src/bioetl/composition/bootstrap.py
@@ -124,11 +124,12 @@ def bootstrap_storage() -> StorageAdapter:
         ),
         silver_writer=DeltaWriter(
             base_path=settings.silver_path,
-            csv_exporter=None,
             logger=noop_logger,
+            csv_exporter=None,
         ),
         gold_writer=GoldWriter(
             base_path=settings.gold_path,
+            logger=noop_logger,
             csv_exporter=None,
         ),
     )

--- a/src/bioetl/composition/factories/storage_factory.py
+++ b/src/bioetl/composition/factories/storage_factory.py
@@ -562,11 +562,12 @@ class StorageFactory:
             ),
             silver_writer=DeltaWriter(
                 base_path=silver_path,
-                csv_exporter=silver_csv_exporter,
                 logger=logger,
+                csv_exporter=silver_csv_exporter,
             ),
             gold_writer=GoldWriter(
                 base_path=gold_path,
+                logger=logger,
                 csv_exporter=gold_csv_exporter,
             ),
         )

--- a/src/bioetl/infrastructure/storage/delta_writer.py
+++ b/src/bioetl/infrastructure/storage/delta_writer.py
@@ -71,16 +71,18 @@ class DeltaWriter:
     def __init__(
         self,
         base_path: str | Path,
+        logger: LoggerPort,
         csv_exporter: CsvExporter | None = None,
-        logger: LoggerPort | None = None,
     ) -> None:
         """Initialize Delta writer.
 
         Args:
             base_path: Base path for Delta tables (local filesystem)
+            logger: Structured logger for observability (MUST be injected)
             csv_exporter: Optional CsvExporter for CSV output (None to disable)
-            logger: Optional logger for debug output
 
+        Note: LoggerPort is required per RULES.md DI requirements. All dependencies
+        MUST be injected through constructor without fallback defaults.
         """
         self.base_path = str(base_path).rstrip("/")
         self.csv_exporter = csv_exporter

--- a/src/bioetl/infrastructure/storage/gold_writer.py
+++ b/src/bioetl/infrastructure/storage/gold_writer.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
 
     from pandera.polars import DataFrameSchema
 
+    from bioetl.domain.ports import LoggerPort
     from bioetl.infrastructure.export.csv_exporter import CsvExporter
 
 
@@ -62,16 +63,21 @@ class GoldWriter:
     def __init__(
         self,
         base_path: str | Path,
+        logger: LoggerPort,
         csv_exporter: CsvExporter | None = None,
     ) -> None:
         """Initialize Gold writer.
 
         Args:
             base_path: Base path for Gold tables (local filesystem)
+            logger: Structured logger for observability (MUST be injected)
             csv_exporter: Optional CsvExporter for CSV output (None to disable)
 
+        Note: LoggerPort is required per RULES.md DI requirements. All dependencies
+        MUST be injected through constructor without fallback defaults.
         """
         self.base_path = str(base_path).rstrip("/")
+        self.logger = logger
         self.csv_exporter = csv_exporter
 
     async def write_gold(

--- a/tests/architecture/test_port_contracts.py
+++ b/tests/architecture/test_port_contracts.py
@@ -494,3 +494,49 @@ class TestDQMonitorPortContract:
         assert is_runtime_checkable, (
             "DQMonitorPort MUST be decorated with @runtime_checkable"
         )
+
+
+# ============================================================================
+# Storage Writer LoggerPort Contract Tests
+# ============================================================================
+
+
+class TestStorageWriterLoggerContract:
+    """Tests for storage writer LoggerPort requirements.
+
+    All storage writers (BronzeWriter, DeltaWriter, GoldWriter) MUST
+    require a LoggerPort parameter in their constructor for observability.
+    Per RULES.md: Dependencies MUST be injected through constructor.
+    """
+
+    STORAGE_WRITERS = [
+        ("BronzeWriter", "bioetl.infrastructure.storage.bronze_writer"),
+        ("DeltaWriter", "bioetl.infrastructure.storage.delta_writer"),
+        ("GoldWriter", "bioetl.infrastructure.storage.gold_writer"),
+    ]
+
+    @pytest.mark.parametrize("writer_name,module_path", STORAGE_WRITERS)
+    def test_storage_writer_has_required_logger_parameter(
+        self, writer_name: str, module_path: str
+    ) -> None:
+        """All storage writers MUST have LoggerPort as required parameter."""
+        import importlib
+        import inspect
+
+        module = importlib.import_module(module_path)
+        writer_class = getattr(module, writer_name)
+
+        sig = inspect.signature(writer_class.__init__)
+        params = sig.parameters
+
+        assert "logger" in params, (
+            f"{writer_name}.__init__() MUST have 'logger' parameter. "
+            "All writers require LoggerPort for observability."
+        )
+
+        # Check that logger is a required parameter (no default value)
+        logger_param = params["logger"]
+        assert logger_param.default is inspect.Parameter.empty, (
+            f"{writer_name}.__init__() 'logger' MUST be required (no default). "
+            "Optional loggers violate DI principles per RULES.md."
+        )

--- a/tests/infrastructure/storage/test_gold_writer_integration.py
+++ b/tests/infrastructure/storage/test_gold_writer_integration.py
@@ -10,12 +10,19 @@ import pytest
 from deltalake.exceptions import TableNotFoundError
 from pandera.polars import DataFrameSchema
 
+from bioetl.infrastructure.observability.noop_logger import NoOpLogger
 from bioetl.infrastructure.storage.gold_writer import GoldWriter
 
 
 @pytest.fixture
-def gold_writer():
-    return GoldWriter(base_path="s3://test-bucket/gold")
+def noop_logger():
+    """Provide a NoOpLogger for tests."""
+    return NoOpLogger()
+
+
+@pytest.fixture
+def gold_writer(noop_logger):
+    return GoldWriter(base_path="s3://test-bucket/gold", logger=noop_logger)
 
 
 @pytest.fixture

--- a/tests/integration/infrastructure/storage/test_delta_writer.py
+++ b/tests/integration/infrastructure/storage/test_delta_writer.py
@@ -8,7 +8,14 @@ import pyarrow as pa
 import pytest
 from deltalake import DeltaTable
 
+from bioetl.infrastructure.observability.noop_logger import NoOpLogger
 from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+
+
+@pytest.fixture
+def noop_logger():
+    """Provide a NoOpLogger for tests."""
+    return NoOpLogger()
 
 
 @pytest.fixture
@@ -19,8 +26,8 @@ def temp_delta_path(tmp_path):
 
 
 @pytest.fixture
-def delta_writer(temp_delta_path):
-    return DeltaWriter(base_path=temp_delta_path)
+def delta_writer(temp_delta_path, noop_logger):
+    return DeltaWriter(base_path=temp_delta_path, logger=noop_logger)
 
 
 @pytest.fixture

--- a/tests/integration/interfaces/conftest.py
+++ b/tests/integration/interfaces/conftest.py
@@ -119,11 +119,12 @@ def create_local_storage_context(
         ),
         silver_writer=DeltaWriter(
             base_path=str(storage_paths["silver"]),
-            csv_exporter=None,
             logger=logger,
+            csv_exporter=None,
         ),
         gold_writer=GoldWriter(
             base_path=str(storage_paths["gold"]),
+            logger=logger,
             csv_exporter=None,
         ),
     )

--- a/tests/integration/pipelines/base.py
+++ b/tests/integration/pipelines/base.py
@@ -88,10 +88,12 @@ class IntegrationPipelineTestCase:
             ),
             silver_writer=DeltaWriter(
                 base_path=self.silver_path,
+                logger=logger,
                 csv_exporter=None,
             ),
             gold_writer=GoldWriter(
                 base_path=self.gold_path,
+                logger=logger,
                 csv_exporter=None,
             ),
         )

--- a/tests/unit/infrastructure/storage/test_delta_writer.py
+++ b/tests/unit/infrastructure/storage/test_delta_writer.py
@@ -7,6 +7,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from bioetl.domain.exceptions import SchemaViolationError
+from bioetl.infrastructure.observability.noop_logger import NoOpLogger
+
+
+@pytest.fixture
+def noop_logger():
+    """Provide a NoOpLogger for tests."""
+    return NoOpLogger()
 
 
 @pytest.fixture
@@ -36,28 +43,30 @@ def valid_records():
 class TestDeltaWriterInit:
     """Tests for DeltaWriter initialization."""
 
-    def test_init_strips_trailing_slash(self):
+    def test_init_strips_trailing_slash(self, noop_logger):
         """Test that trailing slash is stripped from base_path."""
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
-        writer = DeltaWriter(base_path="s3://bucket/path/")
+        writer = DeltaWriter(base_path="s3://bucket/path/", logger=noop_logger)
         assert writer.base_path == "s3://bucket/path"
 
-    def test_init_with_csv_exporter(self):
+    def test_init_with_csv_exporter(self, noop_logger):
         """Test initialization with CSV exporter."""
         from unittest.mock import MagicMock
 
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
         mock_exporter = MagicMock()
-        writer = DeltaWriter(base_path="/tmp/silver", csv_exporter=mock_exporter)
+        writer = DeltaWriter(
+            base_path="/tmp/silver", logger=noop_logger, csv_exporter=mock_exporter
+        )
         assert writer.csv_exporter is mock_exporter
 
-    def test_init_without_csv_exporter(self):
+    def test_init_without_csv_exporter(self, noop_logger):
         """Test initialization without CSV exporter."""
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
-        writer = DeltaWriter(base_path="/tmp/silver")
+        writer = DeltaWriter(base_path="/tmp/silver", logger=noop_logger)
         assert writer.csv_exporter is None
 
 
@@ -66,11 +75,11 @@ class TestDeltaWriterValidation:
     """Tests for DeltaWriter validation."""
 
     @pytest.mark.asyncio
-    async def test_write_silver_empty_records_raises(self):
+    async def test_write_silver_empty_records_raises(self, noop_logger):
         """Test write_silver raises ValueError for empty records."""
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
-        writer = DeltaWriter(base_path="s3://bucket")
+        writer = DeltaWriter(base_path="s3://bucket", logger=noop_logger)
 
         import pyarrow as pa
 
@@ -85,11 +94,11 @@ class TestDeltaWriterValidation:
             )
 
     @pytest.mark.asyncio
-    async def test_write_silver_missing_metadata_raises(self):
+    async def test_write_silver_missing_metadata_raises(self, noop_logger):
         """Test write_silver raises ValueError for missing metadata."""
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
-        writer = DeltaWriter(base_path="s3://bucket")
+        writer = DeltaWriter(base_path="s3://bucket", logger=noop_logger)
         records = [{"entity_id": "CHEMBL123", "value": 5.5}]
 
         import pyarrow as pa
@@ -105,11 +114,11 @@ class TestDeltaWriterValidation:
             )
 
     @pytest.mark.asyncio
-    async def test_write_silver_missing_run_id_raises(self):
+    async def test_write_silver_missing_run_id_raises(self, noop_logger):
         """Test write_silver raises ValueError when _run_id is missing."""
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
-        writer = DeltaWriter(base_path="s3://bucket")
+        writer = DeltaWriter(base_path="s3://bucket", logger=noop_logger)
         records = [
             {
                 "entity_id": "CHEMBL123",
@@ -136,11 +145,11 @@ class TestDeltaWriterValidation:
 class TestDeltaWriterTablePath:
     """Tests for table path construction."""
 
-    def test_table_path_construction(self):
+    def test_table_path_construction(self, noop_logger):
         """Test table path is constructed correctly."""
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
-        writer = DeltaWriter(base_path="s3://bucket/silver")
+        writer = DeltaWriter(base_path="s3://bucket/silver", logger=noop_logger)
 
         # Access internal path construction
         table_name = "chembl.activity"
@@ -149,11 +158,11 @@ class TestDeltaWriterTablePath:
 
         assert actual_path == expected_path
 
-    def test_table_path_with_nested_name(self):
+    def test_table_path_with_nested_name(self, noop_logger):
         """Test table path with nested table name."""
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
-        writer = DeltaWriter(base_path="s3://bucket/silver")
+        writer = DeltaWriter(base_path="s3://bucket/silver", logger=noop_logger)
 
         table_name = "provider.schema.table"
         expected_path = "s3://bucket/silver/provider/schema/table"
@@ -202,7 +211,7 @@ class TestDeltaWriterVacuum:
 
     @pytest.mark.asyncio
     @patch("bioetl.infrastructure.storage.delta_writer.DeltaTable")
-    async def test_vacuum_returns_deleted_files(self, mock_delta_table):
+    async def test_vacuum_returns_deleted_files(self, mock_delta_table, noop_logger):
         """Test vacuum returns list of deleted files."""
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
@@ -213,7 +222,7 @@ class TestDeltaWriterVacuum:
             "file2.parquet",
         ]
 
-        writer = DeltaWriter(base_path="s3://bucket/silver")
+        writer = DeltaWriter(base_path="s3://bucket/silver", logger=noop_logger)
         result = await writer.vacuum("test.table", retention_hours=168)
 
         assert len(result) == 2
@@ -223,7 +232,7 @@ class TestDeltaWriterVacuum:
 
     @pytest.mark.asyncio
     @patch("bioetl.infrastructure.storage.delta_writer.DeltaTable")
-    async def test_vacuum_dry_run(self, mock_delta_table):
+    async def test_vacuum_dry_run(self, mock_delta_table, noop_logger):
         """Test vacuum dry run."""
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
@@ -231,7 +240,7 @@ class TestDeltaWriterVacuum:
         mock_delta_table.return_value = mock_table_instance
         mock_table_instance.vacuum.return_value = ["file1.parquet"]
 
-        writer = DeltaWriter(base_path="s3://bucket/silver")
+        writer = DeltaWriter(base_path="s3://bucket/silver", logger=noop_logger)
         await writer.vacuum("test.table", retention_hours=24, dry_run=True)
 
         mock_table_instance.vacuum.assert_called_once_with(
@@ -239,7 +248,7 @@ class TestDeltaWriterVacuum:
         )
 
     @pytest.mark.asyncio
-    async def test_vacuum_table_not_found(self):
+    async def test_vacuum_table_not_found(self, noop_logger):
         """Test vacuum raises TableNotFoundError for missing table."""
         from deltalake.exceptions import TableNotFoundError as DeltaTableNotFoundError
 
@@ -250,7 +259,7 @@ class TestDeltaWriterVacuum:
             "bioetl.infrastructure.storage.delta_writer.DeltaTable",
             side_effect=DeltaTableNotFoundError("Not found"),
         ):
-            writer = DeltaWriter(base_path="s3://bucket/silver")
+            writer = DeltaWriter(base_path="s3://bucket/silver", logger=noop_logger)
 
             with pytest.raises(TableNotFoundError):
                 await writer.vacuum("nonexistent.table")
@@ -262,7 +271,7 @@ class TestDeltaWriterOptimize:
 
     @pytest.mark.asyncio
     @patch("bioetl.infrastructure.storage.delta_writer.DeltaTable")
-    async def test_optimize_returns_metrics(self, mock_delta_table):
+    async def test_optimize_returns_metrics(self, mock_delta_table, noop_logger):
         """Test optimize returns compaction metrics."""
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
@@ -275,7 +284,7 @@ class TestDeltaWriterOptimize:
             "numFilesRemoved": 5,
         }
 
-        writer = DeltaWriter(base_path="s3://bucket/silver")
+        writer = DeltaWriter(base_path="s3://bucket/silver", logger=noop_logger)
         result = await writer.optimize("test.table")
 
         assert result["numFilesRemoved"] == 5
@@ -283,7 +292,7 @@ class TestDeltaWriterOptimize:
 
     @pytest.mark.asyncio
     @patch("bioetl.infrastructure.storage.delta_writer.DeltaTable")
-    async def test_optimize_with_partition_filters(self, mock_delta_table):
+    async def test_optimize_with_partition_filters(self, mock_delta_table, noop_logger):
         """Test optimize with partition filters."""
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
@@ -293,7 +302,7 @@ class TestDeltaWriterOptimize:
         mock_table_instance.optimize = mock_optimize
         mock_optimize.compact.return_value = {}
 
-        writer = DeltaWriter(base_path="s3://bucket/silver")
+        writer = DeltaWriter(base_path="s3://bucket/silver", logger=noop_logger)
         await writer.optimize("test.table", partition_filters=[("year", "=", 2025)])
 
         mock_optimize.compact.assert_called_once_with(
@@ -301,7 +310,7 @@ class TestDeltaWriterOptimize:
         )
 
     @pytest.mark.asyncio
-    async def test_optimize_table_not_found(self):
+    async def test_optimize_table_not_found(self, noop_logger):
         """Test optimize raises TableNotFoundError for missing table."""
         from deltalake.exceptions import TableNotFoundError as DeltaTableNotFoundError
 
@@ -312,7 +321,7 @@ class TestDeltaWriterOptimize:
             "bioetl.infrastructure.storage.delta_writer.DeltaTable",
             side_effect=DeltaTableNotFoundError("Not found"),
         ):
-            writer = DeltaWriter(base_path="s3://bucket/silver")
+            writer = DeltaWriter(base_path="s3://bucket/silver", logger=noop_logger)
 
             with pytest.raises(TableNotFoundError):
                 await writer.optimize("nonexistent.table")
@@ -324,7 +333,7 @@ class TestDeltaWriterGetTableInfo:
 
     @pytest.mark.asyncio
     @patch("bioetl.infrastructure.storage.delta_writer.DeltaTable")
-    async def test_get_table_info_returns_metadata(self, mock_delta_table):
+    async def test_get_table_info_returns_metadata(self, mock_delta_table, noop_logger):
         """Test get_table_info returns table metadata."""
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
@@ -337,14 +346,14 @@ class TestDeltaWriterGetTableInfo:
         mock_table_instance.schema.return_value = mock_schema
         mock_table_instance.metadata.return_value = {"id": "test-table"}
 
-        writer = DeltaWriter(base_path="s3://bucket/silver")
+        writer = DeltaWriter(base_path="s3://bucket/silver", logger=noop_logger)
         result = await writer.get_table_info("test.table")
 
         assert result["version"] == 10
         assert result["num_files"] == 2
 
     @pytest.mark.asyncio
-    async def test_get_table_info_table_not_found(self):
+    async def test_get_table_info_table_not_found(self, noop_logger):
         """Test get_table_info raises TableNotFoundError for missing table."""
         from deltalake.exceptions import TableNotFoundError as DeltaTableNotFoundError
 
@@ -355,7 +364,7 @@ class TestDeltaWriterGetTableInfo:
             "bioetl.infrastructure.storage.delta_writer.DeltaTable",
             side_effect=DeltaTableNotFoundError("Not found"),
         ):
-            writer = DeltaWriter(base_path="s3://bucket/silver")
+            writer = DeltaWriter(base_path="s3://bucket/silver", logger=noop_logger)
 
             with pytest.raises(TableNotFoundError):
                 await writer.get_table_info("nonexistent.table")
@@ -367,14 +376,14 @@ class TestDeltaWriterTimeTravel:
 
     @pytest.mark.asyncio
     @patch("bioetl.infrastructure.storage.delta_writer.DeltaTable")
-    async def test_time_travel_by_version(self, mock_delta_table):
+    async def test_time_travel_by_version(self, mock_delta_table, noop_logger):
         """Test time_travel by version number."""
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
         mock_table_instance = MagicMock()
         mock_delta_table.return_value = mock_table_instance
 
-        writer = DeltaWriter(base_path="s3://bucket/silver")
+        writer = DeltaWriter(base_path="s3://bucket/silver", logger=noop_logger)
         result = await writer.time_travel("test.table", version=5)
 
         assert result == mock_table_instance
@@ -382,7 +391,7 @@ class TestDeltaWriterTimeTravel:
 
     @pytest.mark.asyncio
     @patch("bioetl.infrastructure.storage.delta_writer.DeltaTable")
-    async def test_time_travel_by_timestamp(self, mock_delta_table):
+    async def test_time_travel_by_timestamp(self, mock_delta_table, noop_logger):
         """Test time_travel by timestamp."""
         from datetime import datetime
 
@@ -391,20 +400,20 @@ class TestDeltaWriterTimeTravel:
         mock_table_instance = MagicMock()
         mock_delta_table.return_value = mock_table_instance
 
-        writer = DeltaWriter(base_path="s3://bucket/silver")
+        writer = DeltaWriter(base_path="s3://bucket/silver", logger=noop_logger)
         ts = datetime(2025, 1, 1, 12, 0, 0)
         result = await writer.time_travel("test.table", timestamp=ts)
 
         assert result == mock_table_instance
 
     @pytest.mark.asyncio
-    async def test_time_travel_both_version_and_timestamp_raises(self):
+    async def test_time_travel_both_version_and_timestamp_raises(self, noop_logger):
         """Test time_travel raises ValueError when both version and timestamp given."""
         from datetime import datetime
 
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
-        writer = DeltaWriter(base_path="s3://bucket/silver")
+        writer = DeltaWriter(base_path="s3://bucket/silver", logger=noop_logger)
 
         with pytest.raises(ValueError, match="Specify either version or timestamp"):
             await writer.time_travel(
@@ -412,11 +421,11 @@ class TestDeltaWriterTimeTravel:
             )
 
     @pytest.mark.asyncio
-    async def test_time_travel_neither_version_nor_timestamp_raises(self):
+    async def test_time_travel_neither_version_nor_timestamp_raises(self, noop_logger):
         """Test time_travel raises ValueError when neither version nor timestamp given."""
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
-        writer = DeltaWriter(base_path="s3://bucket/silver")
+        writer = DeltaWriter(base_path="s3://bucket/silver", logger=noop_logger)
 
         with pytest.raises(
             ValueError, match="Must specify either version or timestamp"
@@ -424,7 +433,7 @@ class TestDeltaWriterTimeTravel:
             await writer.time_travel("test.table")
 
     @pytest.mark.asyncio
-    async def test_time_travel_table_not_found(self):
+    async def test_time_travel_table_not_found(self, noop_logger):
         """Test time_travel raises TableNotFoundError for missing table."""
         from deltalake.exceptions import TableNotFoundError as DeltaTableNotFoundError
 
@@ -435,7 +444,7 @@ class TestDeltaWriterTimeTravel:
             "bioetl.infrastructure.storage.delta_writer.DeltaTable",
             side_effect=DeltaTableNotFoundError("Not found"),
         ):
-            writer = DeltaWriter(base_path="s3://bucket/silver")
+            writer = DeltaWriter(base_path="s3://bucket/silver", logger=noop_logger)
 
             with pytest.raises(TableNotFoundError):
                 await writer.time_travel("nonexistent.table", version=1)
@@ -446,7 +455,7 @@ class TestDeltaWriterErrorHandling:
     """Tests for error handling in DeltaWriter."""
 
     @pytest.mark.asyncio
-    async def test_write_silver_schema_mismatch_error(self, valid_records):
+    async def test_write_silver_schema_mismatch_error(self, valid_records, noop_logger):
         """Test write_silver raises SchemaViolationError for schema mismatch."""
         from unittest.mock import patch
 
@@ -470,7 +479,7 @@ class TestDeltaWriterErrorHandling:
             "bioetl.infrastructure.storage.delta_writer.DeltaTable",
             side_effect=SchemaMismatchError("Schema mismatch"),
         ):
-            writer = DeltaWriter(base_path="s3://bucket/silver")
+            writer = DeltaWriter(base_path="s3://bucket/silver", logger=noop_logger)
 
             with pytest.raises(SchemaViolationError):
                 await writer.write_silver(
@@ -481,7 +490,7 @@ class TestDeltaWriterErrorHandling:
                 )
 
     @pytest.mark.asyncio
-    async def test_write_silver_merge_conflict_error(self, valid_records):
+    async def test_write_silver_merge_conflict_error(self, valid_records, noop_logger):
         """Test write_silver raises MergeConflictError for merge conflicts."""
         from unittest.mock import MagicMock, patch
 
@@ -513,7 +522,7 @@ class TestDeltaWriterErrorHandling:
             "bioetl.infrastructure.storage.delta_writer.DeltaTable",
             return_value=mock_table,
         ):
-            writer = DeltaWriter(base_path="s3://bucket/silver")
+            writer = DeltaWriter(base_path="s3://bucket/silver", logger=noop_logger)
 
             with pytest.raises(MergeConflictError):
                 await writer.write_silver(

--- a/tests/unit/infrastructure/storage/test_gold_writer.py
+++ b/tests/unit/infrastructure/storage/test_gold_writer.py
@@ -9,13 +9,20 @@ import pytest
 from deltalake.exceptions import TableNotFoundError
 from pandera.polars import Column, DataFrameSchema
 
+from bioetl.infrastructure.observability.noop_logger import NoOpLogger
 from bioetl.infrastructure.storage.gold_writer import GoldWriter
 
 
 @pytest.fixture
-def gold_writer():
+def noop_logger():
+    """Provide a NoOpLogger for tests."""
+    return NoOpLogger()
+
+
+@pytest.fixture
+def gold_writer(noop_logger):
     """Create a GoldWriter instance."""
-    return GoldWriter(base_path="s3://test-bucket/gold")
+    return GoldWriter(base_path="s3://test-bucket/gold", logger=noop_logger)
 
 
 @pytest.fixture
@@ -54,22 +61,24 @@ def valid_records():
 class TestGoldWriterInit:
     """Tests for GoldWriter initialization."""
 
-    def test_init_strips_trailing_slash(self):
+    def test_init_strips_trailing_slash(self, noop_logger):
         """Test that trailing slash is stripped from base_path."""
-        writer = GoldWriter(base_path="s3://bucket/gold/")
+        writer = GoldWriter(base_path="s3://bucket/gold/", logger=noop_logger)
         assert writer.base_path == "s3://bucket/gold"
 
-    def test_init_with_csv_exporter(self):
+    def test_init_with_csv_exporter(self, noop_logger):
         """Test initialization with CSV exporter."""
         from unittest.mock import MagicMock
 
         mock_exporter = MagicMock()
-        writer = GoldWriter(base_path="/tmp/gold", csv_exporter=mock_exporter)
+        writer = GoldWriter(
+            base_path="/tmp/gold", logger=noop_logger, csv_exporter=mock_exporter
+        )
         assert writer.csv_exporter is mock_exporter
 
-    def test_init_without_csv_exporter(self):
+    def test_init_without_csv_exporter(self, noop_logger):
         """Test initialization without CSV exporter."""
-        writer = GoldWriter(base_path="/tmp/gold")
+        writer = GoldWriter(base_path="/tmp/gold", logger=noop_logger)
         assert writer.csv_exporter is None
 
 

--- a/tests/unit/infrastructure/storage/test_storage_exceptions.py
+++ b/tests/unit/infrastructure/storage/test_storage_exceptions.py
@@ -14,6 +14,7 @@ from bioetl.domain.exceptions import (
     SchemaViolationError,
 )
 from bioetl.domain.exceptions import TableNotFoundError as CustomTableNotFoundError
+from bioetl.infrastructure.observability.noop_logger import NoOpLogger
 from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
 
@@ -27,9 +28,15 @@ def make_sync_executor(loop: asyncio.AbstractEventLoop):
 
 
 @pytest.fixture
-def delta_writer():
+def noop_logger():
+    """Provide a NoOpLogger for tests."""
+    return NoOpLogger()
+
+
+@pytest.fixture
+def delta_writer(noop_logger):
     """Fixture for a DeltaWriter."""
-    return DeltaWriter(base_path="/fake/path")
+    return DeltaWriter(base_path="/fake/path", logger=noop_logger)
 
 
 @pytest.fixture
@@ -50,11 +57,11 @@ class TestDeltaWriterExceptions:
     @pytest.mark.asyncio
     @patch("bioetl.infrastructure.storage.delta_writer.DeltaTable")
     async def test_write_silver_raises_schema_violation_error_on_merge(
-        self, mock_delta_table, valid_record
+        self, mock_delta_table, valid_record, noop_logger
     ):
         """Test that SchemaViolationError is raised on merge."""
         mock_delta_table.side_effect = SchemaMismatchError("Invalid schema")
-        writer = DeltaWriter(base_path="/fake/path")
+        writer = DeltaWriter(base_path="/fake/path", logger=noop_logger)
         # Make run_in_executor execute synchronously for testing
         writer.loop = asyncio.get_event_loop()
         writer.loop.run_in_executor = make_sync_executor(writer.loop)
@@ -78,7 +85,7 @@ class TestDeltaWriterExceptions:
     @pytest.mark.asyncio
     @patch("bioetl.infrastructure.storage.delta_writer.DeltaTable")
     async def test_write_silver_raises_merge_conflict_error(
-        self, mock_delta_table, valid_record
+        self, mock_delta_table, valid_record, noop_logger
     ):
         """Test that MergeConflictError is raised."""
         mock_table_instance = MagicMock()
@@ -89,7 +96,7 @@ class TestDeltaWriterExceptions:
         mock_merge.when_not_matched_insert_all.return_value = mock_merge
         mock_merge.execute.side_effect = DeltaError("Merge-conflict")
 
-        writer = DeltaWriter(base_path="/fake/path")
+        writer = DeltaWriter(base_path="/fake/path", logger=noop_logger)
         # Make run_in_executor execute synchronously for testing
         writer.loop = asyncio.get_event_loop()
         writer.loop.run_in_executor = make_sync_executor(writer.loop)
@@ -117,11 +124,11 @@ class TestDeltaWriterExceptions:
         side_effect=TableNotFoundError,
     )
     async def test_write_silver_raises_schema_error_on_create(
-        self, _mock_delta_table, mock_write_deltalake, valid_record
+        self, _mock_delta_table, mock_write_deltalake, valid_record, noop_logger
     ):
         """Test SchemaViolationError on table creation."""
         mock_write_deltalake.side_effect = ArrowTypeError("Arrow type error")
-        writer = DeltaWriter(base_path="/fake/path")
+        writer = DeltaWriter(base_path="/fake/path", logger=noop_logger)
         # Make run_in_executor execute synchronously for testing
         writer.loop = asyncio.get_event_loop()
         writer.loop.run_in_executor = make_sync_executor(writer.loop)
@@ -143,13 +150,13 @@ class TestDeltaWriterExceptions:
             )
 
     @pytest.mark.asyncio
-    async def test_vacuum_raises_table_not_found(self):
+    async def test_vacuum_raises_table_not_found(self, noop_logger):
         """Test that vacuum raises CustomTableNotFoundError."""
         with patch(
             "bioetl.infrastructure.storage.delta_writer.DeltaTable",
             side_effect=TableNotFoundError,
         ):
-            writer = DeltaWriter(base_path="/fake/path")
+            writer = DeltaWriter(base_path="/fake/path", logger=noop_logger)
             # Make run_in_executor execute synchronously for testing
             writer.loop = asyncio.get_event_loop()
             writer.loop.run_in_executor = make_sync_executor(writer.loop)

--- a/tests/unit/infrastructure/test_storage.py
+++ b/tests/unit/infrastructure/test_storage.py
@@ -272,19 +272,19 @@ class TestBronzeWriter:
 class TestDeltaWriter:
     """Test DeltaWriter functionality."""
 
-    def test_delta_writer_initialization(self):
+    def test_delta_writer_initialization(self, noop_logger):
         """Test DeltaWriter can be initialized."""
-        writer = DeltaWriter(base_path="/tmp/delta")
+        writer = DeltaWriter(base_path="/tmp/delta", logger=noop_logger)
         assert writer.base_path == "/tmp/delta"
 
-    async def test_write_silver_creates_new_table(self, mock_delta_writer):
+    async def test_write_silver_creates_new_table(self, mock_delta_writer, noop_logger):
         """Test write_silver creates table if not exists."""
         from deltalake.exceptions import TableNotFoundError
 
         mock_delta_table, mock_write_deltalake = mock_delta_writer
         mock_delta_table.side_effect = TableNotFoundError("Not found")
 
-        writer = DeltaWriter(base_path="/tmp/delta")
+        writer = DeltaWriter(base_path="/tmp/delta", logger=noop_logger)
 
         records = [
             {
@@ -315,7 +315,7 @@ class TestDeltaWriter:
 
         mock_write_deltalake.assert_called_once()
 
-    async def test_write_silver_merge_existing_table(self, mock_delta_writer):
+    async def test_write_silver_merge_existing_table(self, mock_delta_writer, noop_logger):
         """Test write_silver merges into existing table."""
         mock_delta_table, _mock_write_deltalake = mock_delta_writer
         mock_table_instance = MagicMock()
@@ -326,7 +326,7 @@ class TestDeltaWriter:
         mock_merge.when_matched_update_all.return_value = mock_merge
         mock_merge.when_not_matched_insert_all.return_value = mock_merge
 
-        writer = DeltaWriter(base_path="/tmp/delta")
+        writer = DeltaWriter(base_path="/tmp/delta", logger=noop_logger)
 
         records = [
             {
@@ -358,8 +358,8 @@ class TestDeltaWriter:
         mock_table_instance.merge.assert_called_once()
 
     @pytest.mark.usefixtures("mock_delta_writer")
-    async def test_write_silver_empty_records_raises_error(self):
-        writer = DeltaWriter(base_path="/tmp/delta")
+    async def test_write_silver_empty_records_raises_error(self, noop_logger):
+        writer = DeltaWriter(base_path="/tmp/delta", logger=noop_logger)
 
         with pytest.raises(ValueError, match="No records to write"):
             await writer.write_silver(
@@ -387,11 +387,11 @@ class TestGoldWriter:
         ):
             yield mock_delta_table, mock_write_deltalake
 
-    async def test_gold_writer_sorts_columns(self, mock_gold_writer_deps):
+    async def test_gold_writer_sorts_columns(self, mock_gold_writer_deps, noop_logger):
         """Test that GoldWriter sorts columns alphabetically in _to_arrow_table."""
         _mock_delta_table, mock_write_deltalake = mock_gold_writer_deps
 
-        writer = GoldWriter(base_path="/tmp/gold")
+        writer = GoldWriter(base_path="/tmp/gold", logger=noop_logger)
 
         # Records with mixed key order
         records = [


### PR DESCRIPTION
Unified LoggerPort dependency injection across all storage writers:
- DeltaWriter: changed `logger: LoggerPort | None = None` to `logger: LoggerPort`
- GoldWriter: added required `logger: LoggerPort` parameter
- Updated bootstrap.py and storage_factory.py to pass logger to all writers
- Fixed all tests to use NoOpLogger() fixture
- Added architecture test to enforce required logger on all writers

Per RULES.md: Dependencies MUST be injected through constructor without defaults.