### PR TITLE
Fix import violations in infrastructure layer

### DIFF
--- a/src/bioetl/composition/bootstrap.py
+++ b/src/bioetl/composition/bootstrap.py
@@ -13,6 +13,7 @@ from bioetl.composition.builders import FilterConfigBuilder
 from bioetl.composition.factories.pipeline_factories import register_all_pipelines
 from bioetl.composition.factories.storage_factory import StorageAdapter
 from bioetl.composition.observability import ObservabilityBundle
+from bioetl.composition.providers.registration import register_all_providers
 from bioetl.composition.registry import PipelineRegistry
 from bioetl.domain.config import RuntimeConfig
 from bioetl.infrastructure.adapters.chembl.client import ChemblAdapter
@@ -367,6 +368,7 @@ def bootstrap_pipeline(ctx: PipelineRunContext) -> PipelineRunner:
         ctx: Pipeline run context containing launch parameters
     """
     # Explicit registration (idempotent)
+    register_all_providers()
     register_all_pipelines()
 
     settings = get_settings()

--- a/src/bioetl/composition/providers/__init__.py
+++ b/src/bioetl/composition/providers/__init__.py
@@ -5,20 +5,19 @@ Provides unified API for registering data source providers.
 Example:
     >>> from bioetl.composition.providers import (
     ...     ProviderRegistry,
-    ...     register_provider,
     ...     load_providers,
+    ...     register_all_providers,
     ... )
     >>>
-    >>> # Загрузка всех провайдеров
+    >>> # Load all providers
     >>> load_providers()
     >>>
-    >>> # Получение конфигурации провайдера
+    >>> # Get provider configuration
     >>> config = ProviderRegistry.get("chembl")
     >>> print(config.http_config.rate)
     10.0
 """
 
-from bioetl.composition.providers.decorators import register_provider
 from bioetl.composition.providers.loader import (
     ensure_providers_loaded,
     load_providers,
@@ -28,6 +27,7 @@ from bioetl.composition.providers.provider_registry import (
     ProviderConfig,
     ProviderRegistry,
 )
+from bioetl.composition.providers.registration import register_all_providers
 
 __all__ = [
     "HttpConfig",
@@ -35,5 +35,5 @@ __all__ = [
     "ProviderRegistry",
     "ensure_providers_loaded",
     "load_providers",
-    "register_provider",
+    "register_all_providers",
 ]

--- a/src/bioetl/composition/providers/loader.py
+++ b/src/bioetl/composition/providers/loader.py
@@ -1,90 +1,69 @@
 """Provider loader module.
 
-Обеспечивает явную загрузку и регистрацию всех провайдеров.
-Вызывается из bootstrap.py для инициализации ProviderRegistry.
+Ensures all providers are registered in ProviderRegistry.
+Called from bootstrap.py for initialization.
 """
 
 from __future__ import annotations
 
-import importlib
-
 from bioetl.composition.providers.provider_registry import ProviderRegistry
-
-# Список модулей адаптеров для загрузки
-# При импорте модуля декоратор @register_provider автоматически
-# регистрирует провайдера в ProviderRegistry
-_PROVIDER_MODULES = [
-    "bioetl.infrastructure.adapters.chembl.client",
-    "bioetl.infrastructure.adapters.pubchem.client",
-    "bioetl.infrastructure.adapters.uniprot.client",
-    "bioetl.infrastructure.adapters.pubmed.pubmed_client",
-]
+from bioetl.composition.providers.registration import register_all_providers
 
 _loaded = False
 
 
 def load_providers(force: bool = False) -> None:
-    """Загружает все зарегистрированные провайдеры.
+    """Load and register all providers.
 
-    Эта функция должна вызываться один раз при старте приложения
-    (например, в bootstrap.py) для инициализации ProviderRegistry.
+    This function should be called once at application startup
+    (e.g., in bootstrap.py) to initialize ProviderRegistry.
 
-    Функция идемпотентна — повторные вызовы безопасны (если force=False).
+    Idempotent - repeated calls are safe (if force=False).
 
     Args:
-        force: Если True, перезагружает модули даже если они уже загружены.
-            Используется в тестах для сброса состояния.
+        force: If True, re-register providers even if already loaded.
+            Used in tests to reset state.
 
     Example:
         >>> from bioetl.composition.providers import load_providers
         >>> load_providers()
-        >>> # Теперь можно использовать ProviderRegistry
+        >>> # Now ProviderRegistry is ready
         >>> from bioetl.composition.providers import ProviderRegistry
         >>> config = ProviderRegistry.get("chembl")
 
     """
     global _loaded
-    import sys
 
     if _loaded and not force:
         return
 
-    for module_path in _PROVIDER_MODULES:
-        try:
-            if force and module_path in sys.modules:
-                # Перезагружаем модуль для повторной регистрации
-                importlib.reload(sys.modules[module_path])
-            else:
-                importlib.import_module(module_path)
-        except ImportError as e:
-            # Логируем ошибку, но не падаем — провайдер может быть опциональным
-            import warnings
+    if force:
+        # Clear registry before re-registration
+        ProviderRegistry.clear()
 
-            warnings.warn(
-                f"Failed to load provider module {module_path}: {e}",
-                stacklevel=2,
-            )
+    # Explicit registration of all providers
+    register_all_providers()
 
     _loaded = True
 
 
 def ensure_providers_loaded() -> None:
-    """Гарантирует, что провайдеры загружены.
+    """Ensure providers are loaded.
 
-    Удобная функция для использования в местах, где нужно быть уверенным,
-    что ProviderRegistry инициализирован.
+    Convenience function for use in places where ProviderRegistry
+    must be initialized.
     """
     if not _loaded:
         load_providers()
 
 
 def get_loaded_status() -> bool:
-    """Возвращает статус загрузки провайдеров."""
+    """Return provider loading status."""
     return _loaded
 
 
 def reset_loader() -> None:
-    """Сбрасывает статус загрузки. Только для тестов."""
+    """Reset loading status. Only for tests."""
     global _loaded
     _loaded = False
     ProviderRegistry.clear()

--- a/src/bioetl/composition/providers/registration.py
+++ b/src/bioetl/composition/providers/registration.py
@@ -1,0 +1,102 @@
+"""Explicit provider registration.
+
+Centralizes all provider registrations in the Composition layer.
+This ensures Infrastructure layer does NOT import from Composition.
+
+This module follows the Hexagonal Architecture import matrix:
+- Composition CAN import from Infrastructure (allowed)
+- Infrastructure MUST NOT import from Composition (forbidden)
+"""
+
+from __future__ import annotations
+
+from bioetl.composition.providers.provider_registry import (
+    HttpConfig,
+    ProviderConfig,
+    ProviderRegistry,
+)
+
+# Import adapter classes from Infrastructure (allowed direction)
+from bioetl.infrastructure.adapters.chembl.client import ChemblAdapter
+from bioetl.infrastructure.adapters.pubchem.client import PubChemAdapter
+from bioetl.infrastructure.adapters.pubmed.pubmed_client import (
+    PubMedAdapter,
+    _create_pubmed_adapter,
+)
+from bioetl.infrastructure.adapters.uniprot.client import UniProtAdapter
+
+
+def register_all_providers() -> None:
+    """Explicitly register all data source providers.
+
+    This function MUST be called from bootstrap before using ProviderRegistry.
+    Idempotent - safe to call multiple times.
+
+    Provider configurations:
+    - ChEMBL: 10 req/sec, capacity 20 (async HTTP client)
+    - PubChem: 5 req/sec, capacity 10 (sync via ThreadPoolExecutor)
+    - UniProt: 10 req/sec, 100 with API key, capacity 20 (async HTTP client)
+    - PubMed: 3 req/sec, 10 with API key, capacity 6 (async HTTP client)
+    """
+    # ChEMBL - async HTTP adapter
+    if not ProviderRegistry.is_registered("chembl"):
+        ProviderRegistry.register(
+            "chembl",
+            ProviderConfig(
+                adapter_class=ChemblAdapter,
+                http_config=HttpConfig(
+                    rate=10.0,
+                    capacity=20,
+                ),
+                requires_http_client=True,
+                requires_logger=True,
+            ),
+        )
+
+    # PubChem - sync adapter (uses internal ThreadPoolExecutor)
+    if not ProviderRegistry.is_registered("pubchem"):
+        ProviderRegistry.register(
+            "pubchem",
+            ProviderConfig(
+                adapter_class=PubChemAdapter,
+                http_config=HttpConfig(
+                    rate=5.0,
+                    capacity=10,
+                ),
+                requires_http_client=False,
+                requires_logger=True,
+            ),
+        )
+
+    # UniProt - async HTTP adapter with conditional rate override
+    if not ProviderRegistry.is_registered("uniprot"):
+        ProviderRegistry.register(
+            "uniprot",
+            ProviderConfig(
+                adapter_class=UniProtAdapter,
+                http_config=HttpConfig(
+                    rate=10.0,
+                    capacity=20,
+                    rate_overrides={"uniprot_api_key": 100.0},
+                ),
+                requires_http_client=True,
+                requires_logger=True,
+            ),
+        )
+
+    # PubMed - async HTTP adapter with custom creator for email/API key handling
+    if not ProviderRegistry.is_registered("pubmed"):
+        ProviderRegistry.register(
+            "pubmed",
+            ProviderConfig(
+                adapter_class=PubMedAdapter,
+                http_config=HttpConfig(
+                    rate=3.0,
+                    capacity=6,
+                    rate_overrides={"pubmed_api_key": 10.0},
+                ),
+                requires_http_client=True,
+                requires_logger=True,
+                custom_creator=_create_pubmed_adapter,
+            ),
+        )

--- a/src/bioetl/infrastructure/adapters/chembl/client.py
+++ b/src/bioetl/infrastructure/adapters/chembl/client.py
@@ -22,7 +22,6 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from bioetl.composition.providers import register_provider
 from bioetl.domain.error_classifier import ErrorClassifier
 from bioetl.domain.exceptions import ChemblApiError, CriticalError
 from bioetl.domain.types import ErrorType, HealthStatus
@@ -68,11 +67,6 @@ ENTITY_PLURAL = {
 }
 
 
-@register_provider(
-    "chembl",
-    http_rate=10.0,
-    http_capacity=20,
-)
 @dataclass
 class ChemblAdapter(BaseHttpAdapter):
     """ChEMBL data source adapter.

--- a/src/bioetl/infrastructure/adapters/pubchem/client.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/client.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING, Any
 
 import pubchempy as pcp
 
-from bioetl.composition.providers import register_provider
 from bioetl.domain.error_classifier import ErrorClassifier
 from bioetl.domain.exceptions import CircuitBreakerOpenError
 from bioetl.domain.types import HealthStatus
@@ -32,12 +31,6 @@ if TYPE_CHECKING:
     from bioetl.domain.ports import LoggerPort
 
 
-@register_provider(
-    "pubchem",
-    http_rate=5.0,
-    http_capacity=10,
-    requires_http_client=False,
-)
 class PubChemAdapter(BaseSyncAdapter):
     """PubChem API adapter implementing DataSourcePort.
 

--- a/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
+++ b/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
@@ -326,32 +326,3 @@ def _create_pubmed_adapter(
     )
 
 
-# Регистрация провайдера
-# Используем отложенную регистрацию, чтобы избежать circular imports
-def _register_pubmed() -> None:
-    """Регистрирует PubMed провайдера в ProviderRegistry."""
-    from bioetl.composition.providers.provider_registry import (
-        HttpConfig,
-        ProviderConfig,
-        ProviderRegistry,
-    )
-
-    if ProviderRegistry.is_registered("pubmed"):
-        return
-
-    config = ProviderConfig(
-        adapter_class=PubMedAdapter,
-        http_config=HttpConfig(
-            rate=3.0,
-            capacity=6,
-            rate_overrides={"pubmed_api_key": 10.0},
-        ),
-        requires_http_client=True,
-        requires_logger=True,
-        custom_creator=_create_pubmed_adapter,
-    )
-    ProviderRegistry.register("pubmed", config)
-
-
-# Выполняем регистрацию при импорте модуля
-_register_pubmed()

--- a/src/bioetl/infrastructure/adapters/uniprot/client.py
+++ b/src/bioetl/infrastructure/adapters/uniprot/client.py
@@ -18,7 +18,6 @@ from typing import TYPE_CHECKING, Any
 
 from typing_extensions import override
 
-from bioetl.composition.providers import register_provider
 from bioetl.domain.error_classifier import ErrorClassifier
 from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.adapters.base import BaseHttpAdapter
@@ -33,12 +32,6 @@ if TYPE_CHECKING:
     from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
 
 
-@register_provider(
-    "uniprot",
-    http_rate=10.0,
-    http_capacity=20,
-    rate_overrides={"uniprot_api_key": 100.0},
-)
 class UniProtAdapter(BaseHttpAdapter, PaginatedFetcherMixin):
     """UniProt API adapter implementing DataSourcePort.
 


### PR DESCRIPTION
This change fixes the architecture violation where Infrastructure layer was importing from Composition layer (violating the import matrix).

Changes:
- Remove @register_provider decorator from all adapters (chembl, pubchem, uniprot) and registration code from pubmed_client.py
- Create composition/providers/registration.py with explicit register_all_providers() function
- Update loader.py to call register_all_providers() instead of importing infrastructure modules
- Call register_all_providers() in bootstrap.py before pipeline setup

This ensures:
- Infrastructure → Composition imports are eliminated
- Composition → Infrastructure imports are used (allowed direction)
- Provider registration is explicit and centralized in Composition Root