### PR TITLE
Complete ProviderRegistry migration and remove legacy fallback

### DIFF
--- a/src/bioetl/composition/factories/data_sources.py
+++ b/src/bioetl/composition/factories/data_sources.py
@@ -6,8 +6,7 @@ Uses ProviderRegistry for unified provider registration.
 
 from __future__ import annotations
 
-import importlib
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any
 
 from bioetl.composition.providers import ProviderRegistry, ensure_providers_loaded
 
@@ -21,16 +20,7 @@ class DataSourceFactory:
     """Factory for creating data source adapters.
 
     Uses ProviderRegistry for provider lookup and adapter creation.
-    Falls back to legacy static mapping for backward compatibility.
     """
-
-    # Legacy mapping for backward compatibility
-    # Will be removed after full migration to ProviderRegistry
-    _adapters: ClassVar[dict[str, tuple[str, str]]] = {
-        "chembl": ("bioetl.infrastructure.adapters.chembl.client", "ChemblAdapter"),
-        "pubchem": ("bioetl.infrastructure.adapters.pubchem.client", "PubChemAdapter"),
-        "uniprot": ("bioetl.infrastructure.adapters.uniprot.client", "UniProtAdapter"),
-    }
 
     @classmethod
     def create(
@@ -43,8 +33,7 @@ class DataSourceFactory:
     ) -> DataSourcePort:
         """Create a data source adapter.
 
-        First attempts to use ProviderRegistry for provider lookup.
-        Falls back to legacy static mapping if provider not found in registry.
+        Uses ProviderRegistry for provider lookup and adapter creation.
 
         Args:
             provider: The name of the data provider (e.g., 'chembl', 'pubchem').
@@ -62,70 +51,28 @@ class DataSourceFactory:
         # Ensure providers are loaded
         ensure_providers_loaded()
 
+        # Validate provider is registered
+        if not ProviderRegistry.is_registered(provider):
+            available = ", ".join(ProviderRegistry.list_providers())
+            raise ValueError(f"Unknown provider: {provider}. Available: {available}")
+
         # Remove filter_config from kwargs - it's handled by FilteredDataSource wrapper
         adapter_kwargs = {k: v for k, v in kwargs.items() if k != "filter_config"}
 
-        # Try ProviderRegistry first
-        if ProviderRegistry.is_registered(provider):
-            return ProviderRegistry.create_adapter(
-                provider,
-                http_client=http_client,
-                logger=logger,
-                settings=settings,
-                **adapter_kwargs,
-            )
-
-        # Legacy fallback for backward compatibility
-        return cls._create_legacy(provider, http_client, logger, **adapter_kwargs)
-
-    @classmethod
-    def _create_legacy(
-        cls,
-        provider: str,
-        http_client: UnifiedHTTPClient | None,
-        logger: LoggerPort | None,
-        **kwargs: Any,
-    ) -> DataSourcePort:
-        """Legacy adapter creation method.
-
-        Used for backward compatibility with adapters not yet migrated
-        to ProviderRegistry.
-
-        Args:
-            provider: Provider name
-            http_client: HTTP client
-            logger: Logger
-            **kwargs: Additional arguments
-
-        Returns:
-            DataSourcePort instance
-
-        Raises:
-            ValueError: If provider is unknown
-        """
-        if provider not in cls._adapters:
-            raise ValueError(f"Unknown provider: {provider}")
-
-        module_path, class_name = cls._adapters[provider]
-        module = importlib.import_module(module_path)
-        adapter_cls = getattr(module, class_name)
-
-        if provider == "chembl":
-            return adapter_cls(http_client=http_client, logger=logger, **kwargs)
-
-        if provider == "uniprot":
-            return adapter_cls(http_client=http_client, logger=logger, **kwargs)
-
-        # PubChem manages its own client, only needs logger
-        return adapter_cls(logger=logger, **kwargs)
+        return ProviderRegistry.create_adapter(
+            provider,
+            http_client=http_client,
+            logger=logger,
+            settings=settings,
+            **adapter_kwargs,
+        )
 
     @classmethod
     def list_providers(cls) -> list[str]:
         """List all available providers.
 
-        Returns providers from both ProviderRegistry and legacy mapping.
+        Returns:
+            Sorted list of registered provider names.
         """
         ensure_providers_loaded()
-        registry_providers = set(ProviderRegistry.list_providers())
-        legacy_providers = set(cls._adapters.keys())
-        return sorted(registry_providers | legacy_providers)
+        return ProviderRegistry.list_providers()

--- a/src/bioetl/composition/factories/http_client_factory.py
+++ b/src/bioetl/composition/factories/http_client_factory.py
@@ -6,7 +6,7 @@ Uses ProviderRegistry for unified configuration management.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING
 
 from bioetl.composition.providers import ProviderRegistry, ensure_providers_loaded
 from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
@@ -21,17 +21,7 @@ class HttpClientFactory:
     """Factory for creating HTTP clients.
 
     Uses ProviderRegistry for configuration lookup.
-    Falls back to legacy static mapping for backward compatibility.
     """
-
-    # Legacy configurations for backward compatibility
-    # Will be removed after full migration to ProviderRegistry
-    PROVIDER_CONFIGS: ClassVar[dict[str, dict[str, Any]]] = {
-        "chembl": {"rate": 10.0, "capacity": 20},
-        "pubchem": {"rate": 5.0, "capacity": 10},
-        "uniprot": {"rate": 10.0, "capacity": 20},
-        "pubmed": {"rate": 3.0, "capacity": 6},
-    }
 
     @classmethod
     def create_for_provider(
@@ -39,8 +29,7 @@ class HttpClientFactory:
     ) -> UnifiedHTTPClient:
         """Create a configured HTTP client for the given provider.
 
-        First attempts to use ProviderRegistry for configuration.
-        Falls back to legacy static mapping if provider not found.
+        Uses ProviderRegistry for configuration lookup.
 
         Args:
             provider: Provider name (e.g., 'chembl', 'pubmed')
@@ -48,16 +37,19 @@ class HttpClientFactory:
 
         Returns:
             UnifiedHTTPClient configured for the provider
+
+        Raises:
+            ValueError: If the provider is unknown.
         """
         # Ensure providers are loaded
         ensure_providers_loaded()
 
-        # Try ProviderRegistry first
-        if ProviderRegistry.is_registered(provider):
-            return cls._create_from_registry(provider, settings)
+        # Validate provider is registered
+        if not ProviderRegistry.is_registered(provider):
+            available = ", ".join(ProviderRegistry.list_providers())
+            raise ValueError(f"Unknown provider: {provider}. Available: {available}")
 
-        # Legacy fallback
-        return cls._create_legacy(provider, settings)
+        return cls._create_from_registry(provider, settings)
 
     @classmethod
     def _create_from_registry(
@@ -111,41 +103,3 @@ class HttpClientFactory:
         """
         value = getattr(settings, setting_name, None)
         return value is not None and bool(value)
-
-    @classmethod
-    def _create_legacy(
-        cls, provider: str, settings: Settings | None
-    ) -> UnifiedHTTPClient:
-        """Legacy HTTP client creation.
-
-        Used for backward compatibility with providers not yet migrated
-        to ProviderRegistry.
-
-        Args:
-            provider: Provider name
-            settings: Application settings
-
-        Returns:
-            Configured UnifiedHTTPClient
-        """
-        config = cls.PROVIDER_CONFIGS.get(provider, {"rate": 5.0, "capacity": 10})
-        rate = config["rate"]
-        capacity = config["capacity"]
-
-        # Specific overrides based on settings
-        if provider == "pubmed" and settings and settings.pubmed_api_key:
-            rate = 10.0
-            capacity = 20
-
-        if (
-            provider == "uniprot"
-            and settings
-            and getattr(settings, "uniprot_api_key", None)
-        ):
-            rate = 100.0
-            capacity = 200
-
-        return UnifiedHTTPClient(
-            rate_limiter=TokenBucket(rate=rate, capacity=capacity),
-            circuit_breaker=CircuitBreaker(provider=provider),
-        )

--- a/tests/infrastructure/factories/test_data_sources.py
+++ b/tests/infrastructure/factories/test_data_sources.py
@@ -45,6 +45,6 @@ def test_create_uniprot_adapter(mock_http_client, mock_logger):
 
 
 def test_create_unknown_provider(mock_http_client):
-    """Test creating unknown provider raises error."""
-    with pytest.raises((ValueError, KeyError)):
+    """Test creating unknown provider raises ValueError."""
+    with pytest.raises(ValueError, match="Unknown provider: unknown"):
         DataSourceFactory.create("unknown", http_client=mock_http_client)


### PR DESCRIPTION
- Remove _create_legacy() method and _adapters dict from DataSourceFactory
- Remove _create_legacy() method and PROVIDER_CONFIGS dict from HttpClientFactory
- Update create() to raise ValueError for unknown providers
- Update tests to expect only ValueError (not KeyError)

All 4 providers (chembl, pubchem, uniprot, pubmed) are now registered through ProviderRegistry. No legacy fallback needed.