### PR TITLE
Fix lock documentation and implementation mismatch

### DIFF
--- a/docs/02-architecture/03-infrastructure-layer.md
+++ b/docs/02-architecture/03-infrastructure-layer.md
@@ -43,11 +43,22 @@
 
 **Расположение:** `src/bioetl/infrastructure/locking/`
 
-Содержит реализацию `LockPort` с использованием Redis. Класс `RedisLockAdapter` использует команды `SETNX` и `EXPIRE` для создания распределённых блокировок, необходимых для предотвращения одновременного запуска одних и тех же пайплайнов.
+Содержит реализацию `LockPort` для координации пайплайнов.
+
+**Текущая реализация (Local-Only):**
+- **`MemoryLock`**: In-memory блокировка для локального развёртывания
+- Однопроцессная изоляция (не распределённая)
+- Поддержка exclusive-режима для backfill/rebuild
+
+> **Note:** Redis-блокировки (ADR-003) superseded в пользу local-only стратегии.
+> См. [ADR-010](decisions/ADR-010-local-only-deployment.md) для обоснования.
+
+**Расширяемость:** Порт `LockPort` остаётся неизменным — при необходимости можно добавить
+Redis-адаптер без изменения domain/application слоёв.
 
 ### 2.4. `checkpoint/` и `quarantine/`
 
-- **`checkpoint/`**: Реализация `CheckpointPort` для сохранения состояния пайплайнов (например, в S3 или Redis).
+- **`checkpoint/`**: Реализация `CheckpointPort` для сохранения состояния пайплайнов. Текущая реализация использует локальную файловую систему (`LocalCheckpoint`). См. [ADR-010](decisions/ADR-010-local-only-deployment.md).
 - **`quarantine/`**: Реализация `QuarantinePort` для записи "плохих" данных в отдельное хранилище для последующего анализа.
 
 ### 2.5. `observability/` — Наблюдаемость

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -312,12 +312,13 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 - **Pipeline Lock**: Один активный инстанс `{provider}_{entity}`
 - **Lock Max Duration**: **4 часа**. Принудительное снятие по истечении.
 
-#### Спецификация для распределённого развёртывания
-См. [ADR-003](02-architecture/decisions/ADR-003-redis-for-distributed-locking.md) (отложено).
-- **Механизм**: Redis `SETNX` + `EXPIRE`
-- **TTL**: 60 секунд
-- **Heartbeat**: Обновление TTL каждые 20 секунд
-- **Fencing Token**: `owner_id` (run_id воркера)
+#### Распределённое развёртывание (Deferred)
+
+> **Status: Deferred** — см. [ADR-010](02-architecture/decisions/ADR-010-local-only-deployment.md)
+>
+> При необходимости распределённого развёртывания можно реализовать `RedisLockAdapter`
+> на основе спецификации ADR-003. Hexagonal-архитектура позволяет добавить адаптер
+> без изменения domain/application слоёв.
 
 **Invariant** (применимо ко всем вариантам развёртывания):
 - Потеря блокировки = Потеря права на запись.


### PR DESCRIPTION
Update infrastructure layer docs to reflect current local-only deployment:
- Replace outdated RedisLockAdapter description with MemoryLock
- Update checkpoint section to reference LocalCheckpoint
- Simplify RULES.md Redis section as deferred specification
- Add cross-references to ADR-010 for context

Resolves documentation drift between Redis specs and actual MemoryLock usage.