### PR TITLE
Refactor adapter imports in Composition Root

### DIFF
--- a/src/bioetl/composition/bootstrap.py
+++ b/src/bioetl/composition/bootstrap.py
@@ -16,8 +16,6 @@ from bioetl.composition.observability import ObservabilityBundle
 from bioetl.composition.providers.registration import register_all_providers
 from bioetl.composition.registry import PipelineRegistry
 from bioetl.domain.config import RuntimeConfig
-from bioetl.infrastructure.adapters.chembl.client import ChemblAdapter
-from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
 from bioetl.infrastructure.checkpoint.local_checkpoint import LocalCheckpoint
 from bioetl.infrastructure.config import get_settings, load_pipeline_config
 from bioetl.infrastructure.locking.memory_lock import MemoryLock
@@ -38,7 +36,6 @@ from bioetl.infrastructure.storage.gold_writer import GoldWriter
 
 __all__ = [
     "BronzeWriter",
-    "ChemblAdapter",
     "DeltaWriter",
     "GoldWriter",
     "LocalCheckpoint",
@@ -47,7 +44,6 @@ __all__ = [
     "ObservabilityBundle",
     "PrometheusMetrics",
     "StorageAdapter",
-    "UnifiedHTTPClient",
     "UnifiedQuarantine",
     "bootstrap_checkpoint",
     "bootstrap_checkpoint_manager",

--- a/tests/architecture/test_layer_dependencies.py
+++ b/tests/architecture/test_layer_dependencies.py
@@ -1310,3 +1310,53 @@ def test_filtered_data_source_uses_isinstance(src_dir: Path) -> None:
         "FilteredDataSource must use isinstance(adapter, FilterableDataSourcePort) "
         "for type-safe Protocol check."
     )
+
+
+def test_bootstrap_no_direct_adapter_imports(src_dir: Path) -> None:
+    """bootstrap.py MUST NOT import concrete adapters directly.
+
+    REQ-ARCH-COMP-001: Composition Root delegates adapter creation to factories.
+    Adding a new provider should only require changes in:
+    - providers/registration.py (ProviderRegistry)
+    - factories/data_source_registry.py (DataSourceRegistry)
+
+    This prevents tight coupling and ensures the factory pattern is enforced.
+    """
+    bootstrap_file = src_dir / "bioetl" / "composition" / "bootstrap.py"
+    if not bootstrap_file.exists():
+        pytest.skip("bootstrap.py not found")
+
+    content = bootstrap_file.read_text(encoding="utf-8")
+
+    # Forbidden: direct imports of concrete adapter classes from provider packages
+    # Pattern: from bioetl.infrastructure.adapters.{provider}.{module} import {Class}
+    forbidden_patterns = [
+        (
+            r"from bioetl\.infrastructure\.adapters\.chembl\.\w+ import",
+            "ChEMBL adapter",
+        ),
+        (
+            r"from bioetl\.infrastructure\.adapters\.pubchem\.\w+ import",
+            "PubChem adapter",
+        ),
+        (
+            r"from bioetl\.infrastructure\.adapters\.uniprot\.\w+ import",
+            "UniProt adapter",
+        ),
+        (
+            r"from bioetl\.infrastructure\.adapters\.pubmed\.\w+ import",
+            "PubMed adapter",
+        ),
+    ]
+
+    violations = []
+    for pattern, description in forbidden_patterns:
+        matches = re.findall(pattern, content)
+        if matches:
+            violations.append(f"{description}: {matches}")
+
+    assert not violations, (
+        "bootstrap.py must not import concrete adapters directly.\n"
+        "Use ProviderRegistry and factories (DataSourceFactory, HttpClientFactory) instead.\n"
+        "Violations:\n" + "\n".join(f"  - {v}" for v in violations)
+    )


### PR DESCRIPTION
Remove unused ChemblAdapter and UnifiedHTTPClient imports from bootstrap.py. These were only re-exported in __all__ but never used internally. Adapter creation is properly delegated to ProviderRegistry and DataSourceFactory.

Add architecture test to prevent direct adapter imports in bootstrap, ensuring the factory pattern is enforced (REQ-ARCH-COMP-001).