### PR TITLE
Refactor duplicate Medallion cleanup logic

### DIFF
--- a/src/bioetl/application/core/runner.py
+++ b/src/bioetl/application/core/runner.py
@@ -180,28 +180,13 @@ class PipelineRunner:
         self._health_aggregator.assert_healthy(report)
 
     async def _clear_via_lifecycle(self) -> None:
-        """Clear exports using MedallionLifecycleService.
+        """Clear exports using MedallionLifecycleService (policy-based).
 
-        Enforces Medallion architecture invariants:
-        - Only clears data for rebuild/backfill runs
-        - Incremental runs use merge/upsert and should NOT clear existing data
+        Delegates clear decision to MedallionPolicy (Single Source of Truth).
+        The policy determines which layers to clear based on run type:
+        - REBUILD/BACKFILL: Clear both Silver and Gold
+        - INCREMENTAL: Never clear (merge/upsert behavior)
         """
-        from bioetl.domain.types import RunType
-
-        # Medallion invariant: only clear for destructive run types
-        should_clear = self._runtime.run_type in (RunType.REBUILD, RunType.BACKFILL)
-
-        if not should_clear:
-            self._logger.debug(
-                "Skipping clear for incremental run",
-                extra={"run_type": self._runtime.run_type.value},
-            )
-            return
-
-        await self._clear_via_lifecycle_service()
-
-    async def _clear_via_lifecycle_service(self) -> None:
-        """Clear using MedallionLifecycleService (policy-based)."""
         from bioetl.domain.medallion import MedallionPolicy
 
         policy = MedallionPolicy.for_run_type(self._runtime.run_type)
@@ -211,11 +196,21 @@ class PipelineRunner:
             or f"{self._config.provider}.{self._config.entity_type}"
         )
 
-        await self._lifecycle_service.clear(
+        result = await self._lifecycle_service.clear(
             policy=policy,
             silver_table=self._config.silver_table,
             gold_table=gold_table,
             dry_run=self._runtime.dry_run,
+        )
+
+        self._logger.debug(
+            "Medallion clear completed",
+            extra={
+                "run_type": self._runtime.run_type.value,
+                "clear_policy": policy.clear_policy.value,
+                "silver_cleared": result.silver_cleared,
+                "gold_cleared": result.gold_cleared,
+            },
         )
 
     def _collect_batch_metrics(self) -> dict[str, float]:

--- a/tests/integration/test_runner_lifecycle.py
+++ b/tests/integration/test_runner_lifecycle.py
@@ -158,7 +158,10 @@ def mock_logger():
 
 @pytest.fixture
 def mock_lifecycle_service_with_recorder(call_recorder, mock_services_with_recorder):
-    """Create lifecycle service that records calls and delegates to storage."""
+    """Create lifecycle service that records calls and delegates to storage.
+
+    Respects MedallionPolicy - only clears when policy indicates.
+    """
     from bioetl.application.services.medallion_lifecycle import (
         ClearResult,
         MedallionLifecycleService,
@@ -167,16 +170,27 @@ def mock_lifecycle_service_with_recorder(call_recorder, mock_services_with_recor
     service = MagicMock(spec=MedallionLifecycleService)
 
     async def clear_with_recording(*args, **kwargs):
-        # Delegate to storage methods which have their own recording
-        await mock_services_with_recorder.storage.clear_silver(
-            kwargs.get("silver_table", "test.silver"),
+        # Respect policy - only clear when policy indicates (mimics real behavior)
+        policy = kwargs.get("policy")
+        silver_cleared = 0
+        gold_cleared = 0
+
+        if policy and policy.should_clear_silver:
+            silver_cleared = await mock_services_with_recorder.storage.clear_silver(
+                kwargs.get("silver_table", "test.silver"),
+                dry_run=kwargs.get("dry_run", False),
+            )
+        if policy and policy.should_clear_gold:
+            gold_cleared = await mock_services_with_recorder.storage.clear_gold(
+                kwargs.get("gold_table", "test.gold"),
+                dry_run=kwargs.get("dry_run", False),
+            )
+
+        return ClearResult(
+            silver_cleared=silver_cleared or 0,
+            gold_cleared=gold_cleared or 0,
             dry_run=kwargs.get("dry_run", False),
         )
-        await mock_services_with_recorder.storage.clear_gold(
-            kwargs.get("gold_table", "test.gold"),
-            dry_run=kwargs.get("dry_run", False),
-        )
-        return ClearResult(silver_cleared=0, gold_cleared=0, dry_run=False)
 
     service.clear = AsyncMock(side_effect=clear_with_recording)
     return service

--- a/tests/unit/application/core/test_runner.py
+++ b/tests/unit/application/core/test_runner.py
@@ -408,10 +408,13 @@ class TestPipelineRunnerRun:
 
 @pytest.mark.unit
 class TestPipelineRunnerClearViaLifecycle:
-    """Tests for PipelineRunner._clear_via_lifecycle method with lifecycle service."""
+    """Tests for PipelineRunner._clear_via_lifecycle method with lifecycle service.
+
+    Verifies Single Source of Truth pattern: clear decision delegated to MedallionPolicy.
+    """
 
     @pytest.mark.asyncio
-    async def test_clear_via_lifecycle_uses_service(
+    async def test_clear_via_lifecycle_uses_service_for_rebuild(
         self,
         pipeline_config,
         mock_context,
@@ -421,17 +424,17 @@ class TestPipelineRunnerClearViaLifecycle:
         mock_logger,
         mock_lock_manager,
     ):
-        """Test _clear_via_lifecycle uses injected lifecycle service."""
+        """Test _clear_via_lifecycle uses injected lifecycle service for REBUILD."""
         from bioetl.application.services.medallion_lifecycle import (
             ClearResult,
             MedallionLifecycleService,
         )
+        from bioetl.domain.medallion import ClearPolicy
 
         rebuild_runtime = RuntimeConfig(run_type=RunType.REBUILD, limit=None)
 
         services = create_mock_services()
 
-        # Mock lifecycle service
         lifecycle_service = MagicMock(spec=MedallionLifecycleService)
         lifecycle_service.clear = AsyncMock(
             return_value=ClearResult(silver_cleared=5, gold_cleared=3, dry_run=False)
@@ -451,11 +454,12 @@ class TestPipelineRunnerClearViaLifecycle:
 
         await runner._clear_via_lifecycle()
 
-        # Should use lifecycle service
         lifecycle_service.clear.assert_called_once()
+        call_kwargs = lifecycle_service.clear.call_args.kwargs
+        assert call_kwargs["policy"].clear_policy == ClearPolicy.SILVER_AND_GOLD
 
     @pytest.mark.asyncio
-    async def test_clear_via_lifecycle_skips_for_incremental(
+    async def test_clear_via_lifecycle_uses_service_for_backfill(
         self,
         pipeline_config,
         mock_context,
@@ -465,16 +469,69 @@ class TestPipelineRunnerClearViaLifecycle:
         mock_logger,
         mock_lock_manager,
     ):
-        """Test _clear_via_lifecycle skips for incremental runs."""
+        """Test _clear_via_lifecycle uses injected lifecycle service for BACKFILL."""
         from bioetl.application.services.medallion_lifecycle import (
+            ClearResult,
             MedallionLifecycleService,
         )
+        from bioetl.domain.medallion import ClearPolicy
+
+        backfill_runtime = RuntimeConfig(run_type=RunType.BACKFILL, limit=None)
+
+        services = create_mock_services()
+
+        lifecycle_service = MagicMock(spec=MedallionLifecycleService)
+        lifecycle_service.clear = AsyncMock(
+            return_value=ClearResult(silver_cleared=10, gold_cleared=8, dry_run=False)
+        )
+
+        runner = PipelineRunner(
+            config=pipeline_config,
+            runtime=backfill_runtime,
+            services=services,
+            context=mock_context,
+            executor=mock_executor,
+            checkpoint_manager=mock_checkpoint_manager,
+            shutdown_signal=shutdown_signal,
+            logger=mock_logger,
+            lifecycle_service=lifecycle_service,
+        )
+
+        await runner._clear_via_lifecycle()
+
+        lifecycle_service.clear.assert_called_once()
+        call_kwargs = lifecycle_service.clear.call_args.kwargs
+        assert call_kwargs["policy"].clear_policy == ClearPolicy.SILVER_AND_GOLD
+
+    @pytest.mark.asyncio
+    async def test_clear_via_lifecycle_passes_never_policy_for_incremental(
+        self,
+        pipeline_config,
+        mock_context,
+        mock_executor,
+        mock_checkpoint_manager,
+        shutdown_signal,
+        mock_logger,
+        mock_lock_manager,
+    ):
+        """Test _clear_via_lifecycle passes NEVER policy for incremental runs.
+
+        Policy-based approach: service is always called, policy decides behavior.
+        """
+        from bioetl.application.services.medallion_lifecycle import (
+            ClearResult,
+            MedallionLifecycleService,
+        )
+        from bioetl.domain.medallion import ClearPolicy
 
         incremental_runtime = RuntimeConfig(run_type=RunType.INCREMENTAL, limit=None)
 
         services = create_mock_services()
 
         lifecycle_service = MagicMock(spec=MedallionLifecycleService)
+        lifecycle_service.clear = AsyncMock(
+            return_value=ClearResult(silver_cleared=0, gold_cleared=0, dry_run=False)
+        )
 
         runner = PipelineRunner(
             config=pipeline_config,
@@ -490,8 +547,105 @@ class TestPipelineRunnerClearViaLifecycle:
 
         await runner._clear_via_lifecycle()
 
-        # Should not call lifecycle service for incremental
-        lifecycle_service.clear.assert_not_called()
+        # Service is called with NEVER policy (policy decides not to clear)
+        lifecycle_service.clear.assert_called_once()
+        call_kwargs = lifecycle_service.clear.call_args.kwargs
+        assert call_kwargs["policy"].clear_policy == ClearPolicy.NEVER
+
+    @pytest.mark.asyncio
+    async def test_clear_via_lifecycle_uses_default_gold_table(
+        self,
+        mock_context,
+        mock_executor,
+        mock_checkpoint_manager,
+        shutdown_signal,
+        mock_logger,
+        mock_lock_manager,
+    ):
+        """Test gold_table defaults to provider.entity_type when not configured."""
+        from bioetl.application.services.medallion_lifecycle import (
+            ClearResult,
+            MedallionLifecycleService,
+        )
+
+        config_without_gold = PipelineConfig(
+            pipeline_name="test_pipeline",
+            provider="chembl",
+            entity_type="activity",
+            primary_keys=["activity_id"],
+            silver_table="test_silver",
+            gold_table=None,
+        )
+
+        rebuild_runtime = RuntimeConfig(run_type=RunType.REBUILD, limit=None)
+        services = create_mock_services()
+
+        lifecycle_service = MagicMock(spec=MedallionLifecycleService)
+        lifecycle_service.clear = AsyncMock(
+            return_value=ClearResult(silver_cleared=0, gold_cleared=0, dry_run=False)
+        )
+
+        runner = PipelineRunner(
+            config=config_without_gold,
+            runtime=rebuild_runtime,
+            services=services,
+            context=mock_context,
+            executor=mock_executor,
+            checkpoint_manager=mock_checkpoint_manager,
+            shutdown_signal=shutdown_signal,
+            logger=mock_logger,
+            lifecycle_service=lifecycle_service,
+        )
+
+        await runner._clear_via_lifecycle()
+
+        call_kwargs = lifecycle_service.clear.call_args.kwargs
+        assert call_kwargs["gold_table"] == "chembl.activity"
+
+    @pytest.mark.asyncio
+    async def test_clear_via_lifecycle_passes_dry_run_flag(
+        self,
+        pipeline_config,
+        mock_context,
+        mock_executor,
+        mock_checkpoint_manager,
+        shutdown_signal,
+        mock_logger,
+        mock_lock_manager,
+    ):
+        """Test _clear_via_lifecycle passes dry_run flag to service."""
+        from bioetl.application.services.medallion_lifecycle import (
+            ClearResult,
+            MedallionLifecycleService,
+        )
+
+        dry_run_runtime = RuntimeConfig(
+            run_type=RunType.REBUILD, limit=None, dry_run=True
+        )
+
+        services = create_mock_services()
+
+        lifecycle_service = MagicMock(spec=MedallionLifecycleService)
+        lifecycle_service.clear = AsyncMock(
+            return_value=ClearResult(silver_cleared=0, gold_cleared=0, dry_run=True)
+        )
+
+        runner = PipelineRunner(
+            config=pipeline_config,
+            runtime=dry_run_runtime,
+            services=services,
+            context=mock_context,
+            executor=mock_executor,
+            checkpoint_manager=mock_checkpoint_manager,
+            shutdown_signal=shutdown_signal,
+            logger=mock_logger,
+            lifecycle_service=lifecycle_service,
+        )
+
+        await runner._clear_via_lifecycle()
+
+        call_kwargs = lifecycle_service.clear.call_args.kwargs
+        assert call_kwargs["dry_run"] is True
 
 
 @pytest.mark.unit


### PR DESCRIPTION
- Merge _clear_via_lifecycle and _clear_via_lifecycle_service into one
- Delegate clear decision to MedallionPolicy (Single Source of Truth)
- Remove duplicate run_type check from PipelineRunner
- Add comprehensive tests for all run_types (INCREMENTAL/BACKFILL/REBUILD)
- Add tests for policy correctness, default gold_table, and dry_run flag
- Fix integration test mock to respect MedallionPolicy