### PR TITLE
Add missing TimeoutError to domain facade

### DIFF
--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -70,6 +70,7 @@ from bioetl.domain.exceptions import (
     SchemaViolationError,
     StorageError,
     TableNotFoundError,
+    TimeoutError,
     UploadError,
 )
 
@@ -91,6 +92,7 @@ from bioetl.domain.medallion import ClearPolicy, MedallionPolicy
 from bioetl.domain.ports import (
     CheckpointPort,
     DataSourcePort,
+    DQMonitorPort,
     FilterableDataSourcePort,
     GoldValidatorPort,
     InputFilterPort,
@@ -183,6 +185,7 @@ __all__ = [
     "RetryExhaustedError",
     "StorageError",
     "TableNotFoundError",
+    "TimeoutError",
     "UploadError",
     # Exceptions - Data Quality
     "DataQualityThresholdError",
@@ -203,6 +206,7 @@ __all__ = [
     # Ports
     "CheckpointPort",
     "DataSourcePort",
+    "DQMonitorPort",
     "FilterableDataSourcePort",
     "GoldValidatorPort",
     "InputFilterPort",

--- a/tests/architecture/test_domain_public_api.py
+++ b/tests/architecture/test_domain_public_api.py
@@ -148,3 +148,35 @@ def test_domain_no_infrastructure_types_in_all() -> None:
                 f"Symbol '{symbol}' appears to be infrastructure type "
                 f"(contains '{pattern}') - should not be in domain.__all__"
             )
+
+
+def test_domain_exports_all_submodule_symbols() -> None:
+    """Validate domain.__all__ includes all public submodule exports.
+
+    REQ-ARCH-031: Domain facade must re-export all public symbols from submodules.
+    This ensures that `from bioetl.domain import X` works for any public symbol X
+    defined in exceptions, ports, or entities submodules.
+    """
+    from bioetl import domain
+    from bioetl.domain import exceptions, ports, entities
+
+    domain_all = set(domain.__all__)
+
+    # Submodules with __all__ that should be fully exported
+    submodules = [
+        ("exceptions", exceptions),
+        ("ports", ports),
+        ("entities", entities),
+    ]
+
+    missing_symbols: list[str] = []
+
+    for submodule_name, submodule in submodules:
+        for symbol in submodule.__all__:
+            if symbol not in domain_all:
+                missing_symbols.append(f"{submodule_name}.{symbol}")
+
+    assert not missing_symbols, (
+        "Submodule symbols missing from domain.__all__:\n"
+        + "\n".join(f"  - {s}" for s in sorted(missing_symbols))
+    )


### PR DESCRIPTION
Add missing public symbols to domain/__init__.py:
- TimeoutError from exceptions submodule
- DQMonitorPort from ports submodule

Also add test_domain_exports_all_submodule_symbols() to verify that all symbols from exceptions, ports, and entities submodules are properly re-exported in the domain facade.

Total symbols in domain.__all__: 92 (+2)