### PR TITLE
Increase interfaces layer test coverage

### DIFF
--- a/tests/integration/interfaces/test_cli_maintenance_archive.py
+++ b/tests/integration/interfaces/test_cli_maintenance_archive.py
@@ -1,0 +1,389 @@
+"""Integration tests for CLI maintenance archive command.
+
+Tests the archive command for Delta table archival operations.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bioetl.interfaces.cli import cli
+
+if TYPE_CHECKING:
+
+    from click.testing import CliRunner
+
+
+class TestCliMaintenanceArchiveHelp:
+    """Test archive command help and argument handling."""
+
+    def test_maintenance_archive_help(self, cli_runner: CliRunner):
+        """Test that maintenance archive --help works."""
+        result = cli_runner.invoke(cli, ["maintenance", "archive", "--help"])
+
+        assert result.exit_code == 0
+        assert "archive" in result.output.lower()
+        assert "TABLE" in result.output
+        assert "TARGET_PATH" in result.output
+        assert "--remove-source" in result.output
+
+    def test_maintenance_archive_requires_table(self, cli_runner: CliRunner):
+        """Test that archive requires TABLE argument."""
+        result = cli_runner.invoke(cli, ["maintenance", "archive"])
+
+        assert result.exit_code != 0
+        assert "Missing argument" in result.output or "TABLE" in result.output
+
+    def test_maintenance_archive_requires_target_path(self, cli_runner: CliRunner):
+        """Test that archive requires TARGET_PATH argument."""
+        result = cli_runner.invoke(cli, ["maintenance", "archive", "chembl.activity"])
+
+        assert result.exit_code != 0
+        assert "Missing argument" in result.output or "TARGET_PATH" in result.output
+
+
+class TestCliMaintenanceArchiveExecution:
+    """Test archive command execution scenarios."""
+
+    @pytest.fixture
+    def mock_lifecycle_service(self):
+        """Create a mock lifecycle service."""
+        service = MagicMock()
+        service.archive = AsyncMock(return_value=100)
+        return service
+
+    def test_archive_success(
+        self,
+        cli_runner: CliRunner,
+        mock_lifecycle_service: MagicMock,
+    ):
+        """Test successful archive operation."""
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            return_value=mock_lifecycle_service,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["maintenance", "archive", "chembl.activity", "/archive/2025"],
+            )
+
+        assert result.exit_code == 0
+        assert "100" in result.output or "Archived" in result.output
+
+        # Verify service was called correctly
+        mock_lifecycle_service.archive.assert_called_once_with(
+            table="chembl.activity",
+            target_path="/archive/2025",
+            remove_source=False,
+        )
+
+    def test_archive_with_remove_source(
+        self,
+        cli_runner: CliRunner,
+        mock_lifecycle_service: MagicMock,
+    ):
+        """Test archive with --remove-source flag."""
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            return_value=mock_lifecycle_service,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "maintenance",
+                    "archive",
+                    "chembl.activity",
+                    "/archive/2025",
+                    "--remove-source",
+                ],
+            )
+
+        assert result.exit_code == 0
+
+        mock_lifecycle_service.archive.assert_called_once_with(
+            table="chembl.activity",
+            target_path="/archive/2025",
+            remove_source=True,
+        )
+
+    def test_archive_with_different_tables(
+        self,
+        cli_runner: CliRunner,
+        mock_lifecycle_service: MagicMock,
+    ):
+        """Test archive with different table names."""
+        mock_lifecycle_service.archive.return_value = 50
+
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            return_value=mock_lifecycle_service,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["maintenance", "archive", "pubchem.compound", "/cold/storage"],
+            )
+
+        assert result.exit_code == 0
+        assert "50" in result.output
+
+        mock_lifecycle_service.archive.assert_called_once_with(
+            table="pubchem.compound",
+            target_path="/cold/storage",
+            remove_source=False,
+        )
+
+
+class TestCliMaintenanceArchivePathValidation:
+    """Test archive command path handling."""
+
+    @pytest.fixture
+    def mock_lifecycle_service(self):
+        """Create a mock lifecycle service."""
+        service = MagicMock()
+        service.archive = AsyncMock(return_value=25)
+        return service
+
+    def test_archive_with_absolute_path(
+        self,
+        cli_runner: CliRunner,
+        mock_lifecycle_service: MagicMock,
+    ):
+        """Test archive with absolute target path."""
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            return_value=mock_lifecycle_service,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["maintenance", "archive", "chembl.activity", "/var/archive/delta"],
+            )
+
+        assert result.exit_code == 0
+        mock_lifecycle_service.archive.assert_called_once()
+
+    def test_archive_with_relative_path(
+        self,
+        cli_runner: CliRunner,
+        mock_lifecycle_service: MagicMock,
+    ):
+        """Test archive with relative target path."""
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            return_value=mock_lifecycle_service,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["maintenance", "archive", "chembl.activity", "./archive/backup"],
+            )
+
+        assert result.exit_code == 0
+        mock_lifecycle_service.archive.assert_called_once_with(
+            table="chembl.activity",
+            target_path="./archive/backup",
+            remove_source=False,
+        )
+
+    def test_archive_with_complex_path(
+        self,
+        cli_runner: CliRunner,
+        mock_lifecycle_service: MagicMock,
+    ):
+        """Test archive with path containing special characters."""
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            return_value=mock_lifecycle_service,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "maintenance",
+                    "archive",
+                    "chembl.activity",
+                    "/archive/2025-01-01/chembl_backup",
+                ],
+            )
+
+        assert result.exit_code == 0
+
+
+class TestCliMaintenanceArchiveErrors:
+    """Test archive command error handling."""
+
+    @pytest.fixture
+    def mock_lifecycle_service_error(self):
+        """Create a mock lifecycle service that raises an error."""
+        service = MagicMock()
+        service.archive = AsyncMock(
+            side_effect=RuntimeError("Archive failed: permission denied")
+        )
+        return service
+
+    def test_archive_handles_service_error(
+        self,
+        cli_runner: CliRunner,
+        mock_lifecycle_service_error: MagicMock,
+    ):
+        """Test that archive propagates service errors."""
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            return_value=mock_lifecycle_service_error,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["maintenance", "archive", "chembl.activity", "/archive/path"],
+            )
+
+        # Should fail with non-zero exit code or show error
+        assert result.exit_code != 0 or "error" in result.output.lower()
+
+    def test_archive_handles_table_not_found(
+        self,
+        cli_runner: CliRunner,
+    ):
+        """Test that archive handles missing table."""
+        mock_service = MagicMock()
+        mock_service.archive = AsyncMock(
+            side_effect=FileNotFoundError("Table 'nonexistent.table' not found")
+        )
+
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            return_value=mock_service,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["maintenance", "archive", "nonexistent.table", "/archive/path"],
+            )
+
+        # Should fail
+        assert result.exit_code != 0 or "not found" in result.output.lower()
+
+
+class TestCliMaintenanceArchiveRemoveSource:
+    """Test archive command with remove-source behavior."""
+
+    @pytest.fixture
+    def mock_lifecycle_service(self):
+        """Create a mock lifecycle service."""
+        service = MagicMock()
+        service.archive = AsyncMock(return_value=75)
+        return service
+
+    def test_archive_without_remove_source_keeps_source(
+        self,
+        cli_runner: CliRunner,
+        mock_lifecycle_service: MagicMock,
+    ):
+        """Test that archive without --remove-source keeps the source."""
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            return_value=mock_lifecycle_service,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["maintenance", "archive", "chembl.activity", "/archive/path"],
+            )
+
+        assert result.exit_code == 0
+
+        # Verify remove_source=False was passed
+        call_args = mock_lifecycle_service.archive.call_args
+        assert call_args.kwargs.get("remove_source") is False
+
+    def test_archive_with_remove_source_removes_source(
+        self,
+        cli_runner: CliRunner,
+        mock_lifecycle_service: MagicMock,
+    ):
+        """Test that archive with --remove-source removes the source."""
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            return_value=mock_lifecycle_service,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "maintenance",
+                    "archive",
+                    "chembl.activity",
+                    "/archive/path",
+                    "--remove-source",
+                ],
+            )
+
+        assert result.exit_code == 0
+
+        # Verify remove_source=True was passed
+        call_args = mock_lifecycle_service.archive.call_args
+        assert call_args.kwargs.get("remove_source") is True
+
+
+class TestCliMaintenanceArchiveOutput:
+    """Test archive command output formatting."""
+
+    @pytest.fixture
+    def mock_lifecycle_service(self):
+        """Create a mock lifecycle service."""
+        service = MagicMock()
+        service.archive = AsyncMock(return_value=200)
+        return service
+
+    def test_archive_shows_archived_count(
+        self,
+        cli_runner: CliRunner,
+        mock_lifecycle_service: MagicMock,
+    ):
+        """Test that archive shows the number of archived files."""
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            return_value=mock_lifecycle_service,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["maintenance", "archive", "chembl.activity", "/archive/path"],
+            )
+
+        assert result.exit_code == 0
+        assert "200" in result.output
+        assert "Archived" in result.output or "files" in result.output.lower()
+
+    def test_archive_shows_target_path(
+        self,
+        cli_runner: CliRunner,
+        mock_lifecycle_service: MagicMock,
+    ):
+        """Test that archive output includes target path."""
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            return_value=mock_lifecycle_service,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["maintenance", "archive", "chembl.activity", "/cold/storage/2025"],
+            )
+
+        assert result.exit_code == 0
+        assert "/cold/storage/2025" in result.output
+
+    def test_archive_zero_files(
+        self,
+        cli_runner: CliRunner,
+    ):
+        """Test archive when table is empty."""
+        mock_service = MagicMock()
+        mock_service.archive = AsyncMock(return_value=0)
+
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            return_value=mock_service,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["maintenance", "archive", "empty.table", "/archive/path"],
+            )
+
+        assert result.exit_code == 0
+        assert "0" in result.output

--- a/tests/integration/interfaces/test_cli_maintenance_vacuum.py
+++ b/tests/integration/interfaces/test_cli_maintenance_vacuum.py
@@ -1,0 +1,296 @@
+"""Integration tests for CLI maintenance vacuum command.
+
+Tests the vacuum command for Delta table maintenance operations.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bioetl.interfaces.cli import cli
+
+if TYPE_CHECKING:
+    from click.testing import CliRunner
+
+
+class TestCliMaintenanceVacuumHelp:
+    """Test vacuum command help and argument handling."""
+
+    def test_maintenance_vacuum_help(self, cli_runner: CliRunner):
+        """Test that maintenance vacuum --help works."""
+        result = cli_runner.invoke(cli, ["maintenance", "vacuum", "--help"])
+
+        assert result.exit_code == 0
+        assert "vacuum" in result.output.lower()
+        assert "TABLE" in result.output
+        assert "--retention-days" in result.output
+        assert "--dry-run" in result.output
+
+    def test_maintenance_vacuum_requires_table(self, cli_runner: CliRunner):
+        """Test that vacuum requires TABLE argument."""
+        result = cli_runner.invoke(cli, ["maintenance", "vacuum"])
+
+        assert result.exit_code != 0
+        assert "Missing argument" in result.output or "TABLE" in result.output
+
+
+class TestCliMaintenanceVacuumExecution:
+    """Test vacuum command execution scenarios."""
+
+    @pytest.fixture
+    def mock_lifecycle_service(self):
+        """Create a mock lifecycle service."""
+        service = MagicMock()
+        service.vacuum = AsyncMock(return_value=42)
+        return service
+
+    def test_vacuum_success(
+        self,
+        cli_runner: CliRunner,
+        mock_lifecycle_service: MagicMock,
+    ):
+        """Test successful vacuum operation."""
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            return_value=mock_lifecycle_service,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["maintenance", "vacuum", "chembl.activity"],
+            )
+
+        assert result.exit_code == 0
+        assert "42" in result.output or "Removed" in result.output
+
+        # Verify service was called correctly
+        mock_lifecycle_service.vacuum.assert_called_once_with(
+            table="chembl.activity",
+            retention_days=7,  # Default value
+            dry_run=False,
+        )
+
+    def test_vacuum_with_custom_retention(
+        self,
+        cli_runner: CliRunner,
+        mock_lifecycle_service: MagicMock,
+    ):
+        """Test vacuum with custom retention days."""
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            return_value=mock_lifecycle_service,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["maintenance", "vacuum", "chembl.activity", "--retention-days", "30"],
+            )
+
+        assert result.exit_code == 0
+
+        mock_lifecycle_service.vacuum.assert_called_once_with(
+            table="chembl.activity",
+            retention_days=30,
+            dry_run=False,
+        )
+
+    def test_vacuum_with_short_retention_flag(
+        self,
+        cli_runner: CliRunner,
+        mock_lifecycle_service: MagicMock,
+    ):
+        """Test vacuum with short -r flag for retention."""
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            return_value=mock_lifecycle_service,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["maintenance", "vacuum", "chembl.activity", "-r", "14"],
+            )
+
+        assert result.exit_code == 0
+
+        mock_lifecycle_service.vacuum.assert_called_once_with(
+            table="chembl.activity",
+            retention_days=14,
+            dry_run=False,
+        )
+
+
+class TestCliMaintenanceVacuumDryRun:
+    """Test vacuum command dry-run mode."""
+
+    @pytest.fixture
+    def mock_lifecycle_service(self):
+        """Create a mock lifecycle service."""
+        service = MagicMock()
+        service.vacuum = AsyncMock(return_value=10)
+        return service
+
+    def test_vacuum_dry_run_shows_preview(
+        self,
+        cli_runner: CliRunner,
+        mock_lifecycle_service: MagicMock,
+    ):
+        """Test that --dry-run shows what would be removed."""
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            return_value=mock_lifecycle_service,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["maintenance", "vacuum", "chembl.activity", "--dry-run"],
+            )
+
+        assert result.exit_code == 0
+        assert "[DRY-RUN]" in result.output or "Would" in result.output
+
+        # Verify dry_run flag was passed
+        mock_lifecycle_service.vacuum.assert_called_once_with(
+            table="chembl.activity",
+            retention_days=7,
+            dry_run=True,
+        )
+
+    def test_vacuum_dry_run_shows_file_count(
+        self,
+        cli_runner: CliRunner,
+        mock_lifecycle_service: MagicMock,
+    ):
+        """Test that dry-run shows the number of files that would be removed."""
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            return_value=mock_lifecycle_service,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["maintenance", "vacuum", "chembl.activity", "--dry-run"],
+            )
+
+        assert result.exit_code == 0
+        assert "10" in result.output  # File count from mock
+
+    def test_vacuum_dry_run_combined_with_retention(
+        self,
+        cli_runner: CliRunner,
+        mock_lifecycle_service: MagicMock,
+    ):
+        """Test dry-run with custom retention days."""
+        mock_lifecycle_service.vacuum.return_value = 25
+
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            return_value=mock_lifecycle_service,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["maintenance", "vacuum", "chembl.activity", "--dry-run", "-r", "30"],
+            )
+
+        assert result.exit_code == 0
+        assert "25" in result.output
+
+        mock_lifecycle_service.vacuum.assert_called_once_with(
+            table="chembl.activity",
+            retention_days=30,
+            dry_run=True,
+        )
+
+
+class TestCliMaintenanceVacuumErrors:
+    """Test vacuum command error handling."""
+
+    @pytest.fixture
+    def mock_lifecycle_service_error(self):
+        """Create a mock lifecycle service that raises an error."""
+        service = MagicMock()
+        service.vacuum = AsyncMock(side_effect=RuntimeError("Vacuum failed: table not found"))
+        return service
+
+    def test_vacuum_handles_service_error(
+        self,
+        cli_runner: CliRunner,
+        mock_lifecycle_service_error: MagicMock,
+    ):
+        """Test that vacuum propagates service errors."""
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            return_value=mock_lifecycle_service_error,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["maintenance", "vacuum", "nonexistent.table"],
+            )
+
+        # Should fail with non-zero exit code
+        assert result.exit_code != 0 or "error" in result.output.lower()
+
+    def test_vacuum_with_zero_retention_succeeds(
+        self,
+        cli_runner: CliRunner,
+    ):
+        """Test that vacuum with zero retention is allowed (uses default)."""
+        mock_service = MagicMock()
+        mock_service.vacuum = AsyncMock(return_value=0)
+
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            return_value=mock_service,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["maintenance", "vacuum", "chembl.activity", "-r", "0"],
+            )
+
+        # Should succeed (0 retention is valid)
+        assert result.exit_code == 0
+
+
+class TestCliMaintenanceVacuumOutput:
+    """Test vacuum command output formatting."""
+
+    @pytest.fixture
+    def mock_lifecycle_service(self):
+        """Create a mock lifecycle service."""
+        service = MagicMock()
+        service.vacuum = AsyncMock(return_value=100)
+        return service
+
+    def test_vacuum_shows_removed_count(
+        self,
+        cli_runner: CliRunner,
+        mock_lifecycle_service: MagicMock,
+    ):
+        """Test that vacuum shows the number of removed files."""
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            return_value=mock_lifecycle_service,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["maintenance", "vacuum", "chembl.activity"],
+            )
+
+        assert result.exit_code == 0
+        assert "100" in result.output
+        assert "Removed" in result.output or "files" in result.output.lower()
+
+    def test_vacuum_dry_run_shows_would_remove(
+        self,
+        cli_runner: CliRunner,
+        mock_lifecycle_service: MagicMock,
+    ):
+        """Test that dry-run output says 'would remove'."""
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            return_value=mock_lifecycle_service,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["maintenance", "vacuum", "chembl.activity", "--dry-run"],
+            )
+
+        assert result.exit_code == 0
+        assert "Would" in result.output or "would" in result.output

--- a/tests/integration/interfaces/test_cli_shutdown_integration.py
+++ b/tests/integration/interfaces/test_cli_shutdown_integration.py
@@ -1,0 +1,446 @@
+"""Integration tests for CLI graceful shutdown.
+
+Tests the integration between OS signals, ShutdownSignal, and CLI exit codes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bioetl.application.core.shutdown import PipelineShutdownError, ShutdownSignal
+from bioetl.composition.factories.pipeline_factories import register_all_pipelines
+from bioetl.interfaces.cli import cli
+from bioetl.interfaces.orchestration.signals import setup_shutdown_handlers
+
+if TYPE_CHECKING:
+    from click.testing import CliRunner
+
+
+class TestShutdownSignalIntegration:
+    """Test ShutdownSignal integration with signal handlers."""
+
+    def test_setup_shutdown_handlers_registers_sigterm(self):
+        """Test that setup_shutdown_handlers registers SIGTERM handler."""
+        import signal
+
+        shutdown_signal = ShutdownSignal()
+
+        with patch.object(signal, "signal") as mock_signal:
+            setup_shutdown_handlers(shutdown_signal)
+
+            # Should register both SIGTERM and SIGINT
+            calls = [call[0][0] for call in mock_signal.call_args_list]
+            assert signal.SIGTERM in calls
+            assert signal.SIGINT in calls
+
+    def test_shutdown_signal_request_triggers_event(self):
+        """Test that request() sets the is_requested flag."""
+        shutdown_signal = ShutdownSignal()
+
+        assert shutdown_signal.is_requested is False
+        shutdown_signal.request()
+        assert shutdown_signal.is_requested is True
+
+    @pytest.mark.asyncio
+    async def test_shutdown_signal_wait_returns_on_request(self):
+        """Test that wait() returns when request() is called."""
+        shutdown_signal = ShutdownSignal()
+
+        async def delayed_request():
+            await asyncio.sleep(0.05)
+            shutdown_signal.request()
+
+        task = asyncio.create_task(delayed_request())
+
+        # Wait should return after request
+        await asyncio.wait_for(shutdown_signal.wait(), timeout=1.0)
+
+        assert shutdown_signal.is_requested is True
+        await task
+
+    def test_shutdown_signal_reset_clears_flag(self):
+        """Test that reset() clears the shutdown flag."""
+        shutdown_signal = ShutdownSignal()
+
+        shutdown_signal.request()
+        assert shutdown_signal.is_requested is True
+
+        shutdown_signal.reset()
+        assert shutdown_signal.is_requested is False
+
+
+class TestCliGracefulShutdownExitCode:
+    """Test CLI exit codes on graceful shutdown."""
+
+    @pytest.fixture(autouse=True)
+    def setup_pipelines(self):
+        """Register all pipelines before each test."""
+        register_all_pipelines()
+
+    def test_shutdown_error_returns_exit_code_130(
+        self,
+        cli_runner: CliRunner,
+        temp_env: dict[str, str],
+    ):
+        """Test that PipelineShutdownError results in exit code 130."""
+        mock_runner = MagicMock()
+        mock_runner.run = AsyncMock(side_effect=PipelineShutdownError("Shutdown requested"))
+        mock_runner.logger = MagicMock()
+        mock_runner.shutdown_signal = ShutdownSignal()
+
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_pipeline",
+            return_value=mock_runner,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["run", "--pipeline", "chembl_activity"],
+            )
+
+        assert result.exit_code == 130
+
+    def test_normal_completion_returns_exit_code_0(
+        self,
+        cli_runner: CliRunner,
+        temp_env: dict[str, str],
+    ):
+        """Test that normal completion returns exit code 0."""
+        mock_runner = MagicMock()
+        mock_runner.run = AsyncMock(return_value=None)
+        mock_runner.logger = MagicMock()
+        mock_runner.shutdown_signal = ShutdownSignal()
+
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_pipeline",
+            return_value=mock_runner,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["run", "--pipeline", "chembl_activity"],
+            )
+
+        assert result.exit_code == 0
+
+    def test_other_exception_returns_exit_code_1(
+        self,
+        cli_runner: CliRunner,
+        temp_env: dict[str, str],
+    ):
+        """Test that other exceptions return exit code 1."""
+        mock_runner = MagicMock()
+        mock_runner.run = AsyncMock(side_effect=RuntimeError("Something went wrong"))
+        mock_runner.logger = MagicMock()
+        mock_runner.shutdown_signal = ShutdownSignal()
+
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_pipeline",
+            return_value=mock_runner,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["run", "--pipeline", "chembl_activity"],
+            )
+
+        assert result.exit_code == 1
+
+
+class TestSignalHandlerIntegration:
+    """Test signal handler triggers shutdown correctly."""
+
+    def test_signal_handler_requests_shutdown(self):
+        """Test that signal handler calls shutdown_signal.request()."""
+
+        shutdown_signal = ShutdownSignal()
+
+        # Setup handlers
+        setup_shutdown_handlers(shutdown_signal)
+
+        # The handler should have been registered
+        # Simulate calling the handler manually
+        # (We can't actually send signals in unit tests safely)
+
+        assert shutdown_signal.is_requested is False
+
+        # Manually trigger by calling request
+        shutdown_signal.request()
+        assert shutdown_signal.is_requested is True
+
+    def test_shutdown_signal_is_idempotent(self):
+        """Test that multiple request() calls don't cause issues."""
+        shutdown_signal = ShutdownSignal()
+
+        shutdown_signal.request()
+        shutdown_signal.request()
+        shutdown_signal.request()
+
+        assert shutdown_signal.is_requested is True
+
+    @pytest.mark.asyncio
+    async def test_shutdown_during_async_operation(self):
+        """Test that shutdown signal can interrupt async operations."""
+        shutdown_signal = ShutdownSignal()
+
+        async def long_running_task():
+            for _ in range(100):
+                if shutdown_signal.is_requested:
+                    raise PipelineShutdownError("Shutdown requested")
+                await asyncio.sleep(0.01)
+
+        # Request shutdown after a short delay
+        async def delayed_shutdown():
+            await asyncio.sleep(0.05)
+            shutdown_signal.request()
+
+        task = asyncio.create_task(delayed_shutdown())
+
+        with pytest.raises(PipelineShutdownError):
+            await long_running_task()
+
+        await task
+
+
+class TestRunnerShutdownIntegration:
+    """Test runner behavior during shutdown."""
+
+    @pytest.fixture(autouse=True)
+    def setup_pipelines(self):
+        """Register all pipelines before each test."""
+        register_all_pipelines()
+
+    def test_runner_logs_graceful_shutdown(
+        self,
+        cli_runner: CliRunner,
+        temp_env: dict[str, str],
+    ):
+        """Test that runner logs graceful shutdown."""
+        mock_runner = MagicMock()
+        mock_runner.run = AsyncMock(side_effect=PipelineShutdownError())
+        mock_logger = MagicMock()
+        mock_runner.logger = mock_logger
+        mock_runner.shutdown_signal = ShutdownSignal()
+
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_pipeline",
+            return_value=mock_runner,
+        ):
+            cli_runner.invoke(
+                cli,
+                ["run", "--pipeline", "chembl_activity"],
+            )
+
+        # Should have logged the shutdown
+        mock_logger.warning.assert_called()
+        warning_messages = [
+            str(call) for call in mock_logger.warning.call_args_list
+        ]
+        assert any("shut down" in msg.lower() for msg in warning_messages)
+
+    def test_runner_shutdown_signal_passed_to_setup(
+        self,
+        cli_runner: CliRunner,
+        temp_env: dict[str, str],
+    ):
+        """Test that shutdown_signal is passed to setup_shutdown_handlers."""
+        mock_runner = MagicMock()
+        mock_runner.run = AsyncMock(return_value=None)
+        mock_runner.logger = MagicMock()
+        mock_shutdown_signal = MagicMock()
+        mock_runner.shutdown_signal = mock_shutdown_signal
+
+        with (
+            patch(
+                "bioetl.interfaces.cli.bootstrap_pipeline",
+                return_value=mock_runner,
+            ),
+            patch(
+                "bioetl.interfaces.cli.setup_shutdown_handlers"
+            ) as mock_setup,
+        ):
+            cli_runner.invoke(
+                cli,
+                ["run", "--pipeline", "chembl_activity"],
+            )
+
+        mock_setup.assert_called_once_with(mock_shutdown_signal)
+
+
+class TestLockReleaseOnShutdown:
+    """Test that locks are released on shutdown."""
+
+    @pytest.fixture(autouse=True)
+    def setup_pipelines(self):
+        """Register all pipelines before each test."""
+        register_all_pipelines()
+
+    def test_lock_released_after_shutdown(
+        self,
+        cli_runner: CliRunner,
+        temp_env: dict[str, str],
+    ):
+        """Test that lock is released even after shutdown error."""
+        mock_runner = MagicMock()
+        mock_runner.run = AsyncMock(side_effect=PipelineShutdownError("Shutdown"))
+        mock_runner.logger = MagicMock()
+        mock_runner.shutdown_signal = ShutdownSignal()
+
+        with patch(
+            "bioetl.interfaces.cli.bootstrap_pipeline",
+            return_value=mock_runner,
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["run", "--pipeline", "chembl_activity"],
+            )
+
+        # Should complete with 130, not hang
+        assert result.exit_code == 130
+
+
+class TestConcurrentSignals:
+    """Test handling of concurrent signals."""
+
+    def test_multiple_shutdown_requests_are_safe(self):
+        """Test that multiple concurrent shutdown requests are safe."""
+        shutdown_signal = ShutdownSignal()
+
+        # Simulate multiple concurrent requests
+        for _ in range(10):
+            shutdown_signal.request()
+
+        assert shutdown_signal.is_requested is True
+
+    @pytest.mark.asyncio
+    async def test_multiple_waiters_all_unblocked(self):
+        """Test that multiple waiters are all unblocked on shutdown."""
+        shutdown_signal = ShutdownSignal()
+        unblocked = []
+
+        async def waiter(index: int):
+            await shutdown_signal.wait()
+            unblocked.append(index)
+
+        # Create multiple waiters
+        tasks = [asyncio.create_task(waiter(i)) for i in range(5)]
+
+        # Small delay then request shutdown
+        await asyncio.sleep(0.01)
+        shutdown_signal.request()
+
+        # Wait for all tasks to complete
+        await asyncio.gather(*tasks)
+
+        # All waiters should have been unblocked
+        assert len(unblocked) == 5
+        assert set(unblocked) == {0, 1, 2, 3, 4}
+
+
+class TestShutdownWithCheckpointManager:
+    """Test checkpoint manager behavior during shutdown.
+
+    These tests verify that the checkpoint saving mechanism is
+    properly integrated with shutdown handling.
+    """
+
+    @pytest.mark.asyncio
+    async def test_shutdown_signal_in_lock_manager(self):
+        """Test that LockManager uses shutdown_signal correctly."""
+        from bioetl.application.core.lock_manager import LockManager
+
+        mock_lock = MagicMock()
+        mock_lock.acquire = AsyncMock(return_value=True)
+        mock_lock.release = AsyncMock()
+        mock_lock.heartbeat = AsyncMock(return_value=True)
+
+        mock_logger = MagicMock()
+        mock_checkpoint = MagicMock()
+        shutdown_signal = ShutdownSignal()
+
+        from uuid import uuid4
+
+        manager = LockManager(
+            lock_port=mock_lock,
+            run_id=uuid4(),
+            lock_key="test:lock",
+            exclusive=False,
+            lock_ttl=300,
+            wait_for_lock=False,
+            wait_timeout=10,
+            heartbeat_interval=60,
+            logger=mock_logger,
+            shutdown_signal=shutdown_signal,
+            checkpoint_manager=mock_checkpoint,
+        )
+
+        # Acquire lock
+        acquired = await manager.acquire()
+        assert acquired is True
+
+        # Start heartbeat
+        await manager.start_heartbeat()
+
+        # Request shutdown
+        shutdown_signal.request()
+
+        # Give heartbeat loop time to check signal
+        await asyncio.sleep(0.1)
+
+        # Release lock
+        await manager.release()
+
+        # Verify lock was released
+        mock_lock.release.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_failure_triggers_shutdown(self):
+        """Test that heartbeat failure triggers shutdown signal."""
+        from bioetl.application.core.lock_manager import LockManager
+
+        mock_lock = MagicMock()
+        mock_lock.acquire = AsyncMock(return_value=True)
+        mock_lock.release = AsyncMock()
+        # First heartbeat succeeds, subsequent ones fail
+        mock_lock.heartbeat = AsyncMock(side_effect=[True, False])
+
+        mock_logger = MagicMock()
+        shutdown_signal = ShutdownSignal()
+
+        from uuid import uuid4
+
+        manager = LockManager(
+            lock_port=mock_lock,
+            run_id=uuid4(),
+            lock_key="test:lock",
+            exclusive=False,
+            lock_ttl=300,
+            wait_for_lock=False,
+            wait_timeout=10,
+            heartbeat_interval=0,  # Immediate for testing
+            logger=mock_logger,
+            shutdown_signal=shutdown_signal,
+            checkpoint_manager=None,
+        )
+
+        # Acquire lock
+        await manager.acquire()
+
+        # Start heartbeat - this creates a background task
+        await manager.start_heartbeat()
+
+        # Wait for the heartbeat loop to run and fail
+        # The background task should set the shutdown signal
+        await asyncio.sleep(0.1)
+
+        # Verify shutdown was triggered
+        assert shutdown_signal.is_requested is True
+
+        # Clean up - release may raise PipelineShutdownError if the
+        # heartbeat task was awaited and raised it
+        try:
+            await manager.release()
+        except PipelineShutdownError:
+            # Expected when heartbeat failed - the exception propagates on await
+            pass


### PR DESCRIPTION
…tdown

Add 45 new tests to improve interfaces layer coverage:

- test_cli_maintenance_vacuum.py (12 tests):
  - Help and argument handling tests
  - Execution with default and custom retention
  - Dry-run mode preview tests
  - Error handling tests
  - Output formatting tests

- test_cli_maintenance_archive.py (16 tests):
  - Help and required argument tests
  - Execution with and without remove-source
  - Path validation (absolute, relative, complex paths)
  - Error handling (service errors, table not found)
  - Output formatting tests

- test_cli_shutdown_integration.py (17 tests):
  - ShutdownSignal integration with signal handlers
  - CLI exit codes (0, 1, 130 for shutdown)
  - Signal handler trigger tests
  - Runner shutdown integration
  - Lock release on shutdown
  - Concurrent signals handling
  - LockManager shutdown behavior

Closes coverage gap for maintenance vacuum/archive CLI commands and graceful shutdown integration scenarios.