### PR TITLE
Fix thread safety in PipelineRegistry

### DIFF
--- a/src/bioetl/composition/factories/pipeline_factories.py
+++ b/src/bioetl/composition/factories/pipeline_factories.py
@@ -4,10 +4,14 @@
 This module creates all pipeline factories using the GenericPipelineFactory
 pattern. Registration is explicit via register_all_pipelines().
 
+Thread-safety: Registration uses a module-level lock to prevent TOCTOU race conditions.
+
 Usage:
     >>> from bioetl.composition.factories.pipeline_factories import register_all_pipelines
     >>> register_all_pipelines()  # Call once at application startup
 """
+
+import threading
 
 from bioetl.application.pipelines.chembl.activity import ChEMBLActivityPipeline
 from bioetl.application.pipelines.chembl.assay import ChEMBLAssayPipeline
@@ -45,7 +49,8 @@ from bioetl.infrastructure.schemas.silver import (
     UNIPROT_PROTEIN_SCHEMA,
 )
 
-# Flag to track if registration has been performed
+# Thread-safe registration state
+_registration_lock = threading.Lock()
 _factories_registered = False
 
 # ChEMBL Activity Pipeline
@@ -133,36 +138,61 @@ pubmed_publications_factory = GenericPipelineFactory(
 def register_all_pipelines() -> None:
     """Explicitly register all pipeline factories with PipelineRegistry.
 
-    This function is idempotent - calling it multiple times has no effect
-    after the first call.
+    This function is idempotent and thread-safe - calling it multiple times
+    or from multiple threads has no effect after the first successful call.
+
+    Uses double-checked locking pattern to minimize lock contention while
+    ensuring thread-safe initialization.
 
     Should be called once at application startup (e.g., in cli.py or bootstrap.py).
     """
     global _factories_registered
 
+    # Fast path: already registered (no lock needed)
     if _factories_registered:
         return
 
-    PipelineRegistry.register_factory(chembl_activity_factory)
-    PipelineRegistry.register_factory(chembl_assay_factory)
-    PipelineRegistry.register_factory(chembl_document_factory)
-    PipelineRegistry.register_factory(chembl_target_factory)
-    PipelineRegistry.register_factory(chembl_target_component_factory)
-    PipelineRegistry.register_factory(chembl_molecule_factory)
-    PipelineRegistry.register_factory(pubchem_compound_factory)
-    PipelineRegistry.register_factory(uniprot_protein_factory)
-    PipelineRegistry.register_factory(pubmed_publications_factory)
+    # Slow path: acquire lock and double-check
+    with _registration_lock:
+        # Double-check after acquiring lock (TOCTOU prevention)
+        if _factories_registered:
+            return
 
-    _factories_registered = True
+        PipelineRegistry.register_factory(chembl_activity_factory)
+        PipelineRegistry.register_factory(chembl_assay_factory)
+        PipelineRegistry.register_factory(chembl_document_factory)
+        PipelineRegistry.register_factory(chembl_target_factory)
+        PipelineRegistry.register_factory(chembl_target_component_factory)
+        PipelineRegistry.register_factory(chembl_molecule_factory)
+        PipelineRegistry.register_factory(pubchem_compound_factory)
+        PipelineRegistry.register_factory(uniprot_protein_factory)
+        PipelineRegistry.register_factory(pubmed_publications_factory)
+
+        _factories_registered = True
 
 
 def is_registered() -> bool:
     """Check if factories have been registered.
 
+    Thread-safe check of registration state.
+
     Returns:
         True if register_all_pipelines() has been called.
     """
+    # Reading a bool is atomic in Python, no lock needed for read
     return _factories_registered
+
+
+def reset_registration() -> None:
+    """Reset registration state (for testing only).
+
+    Thread-safe reset of registration flag. Also clears the PipelineRegistry.
+    WARNING: Only use in tests. Not for production.
+    """
+    global _factories_registered
+    with _registration_lock:
+        PipelineRegistry.clear()
+        _factories_registered = False
 
 
 __all__ = [
@@ -176,5 +206,6 @@ __all__ = [
     "pubchem_compound_factory",
     "pubmed_publications_factory",
     "register_all_pipelines",
+    "reset_registration",
     "uniprot_protein_factory",
 ]

--- a/src/bioetl/composition/registry.py
+++ b/src/bioetl/composition/registry.py
@@ -5,6 +5,7 @@ MOVED to composition layer to fix dependency direction.
 
 from __future__ import annotations
 
+import threading
 from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, Protocol, runtime_checkable
 
 import pyarrow as pa
@@ -68,12 +69,16 @@ class PipelineDefinition(NamedTuple):
 class PipelineRegistry:
     """Registry for pipeline factories.
 
+    Thread-safe singleton registry for pipeline factory instances.
+    All public methods are protected with RLock for concurrent access.
+
     Example:
         >>> factory = GenericPipelineFactory(...)
         >>> PipelineRegistry.register_factory(factory)
     """
 
     _registry: ClassVar[dict[str, PipelineDefinition]] = {}
+    _registry_lock: ClassVar[threading.RLock] = threading.RLock()
 
     @classmethod
     def register_factory(
@@ -82,11 +87,14 @@ class PipelineRegistry:
     ) -> None:
         """Register a pipeline factory instance.
 
+        Thread-safe registration with duplicate detection.
+
         Args:
             factory: Factory instance with pipeline_name and silver_schema attributes
 
         Raises:
             ValueError: If factory does not have gold_schema attribute
+            ValueError: If pipeline is already registered (prevents double registration)
         """
         gold_schema = getattr(factory, "gold_schema", None)
         if gold_schema is None:
@@ -95,15 +103,23 @@ class PipelineRegistry:
                 "All Gold layer writes require schema validation."
             )
 
-        cls._registry[factory.pipeline_name] = PipelineDefinition(
-            factory=factory,
-            silver_schema=factory.silver_schema,
-            gold_schema=gold_schema,
-        )
+        with cls._registry_lock:
+            if factory.pipeline_name in cls._registry:
+                raise ValueError(
+                    f"Pipeline already registered: {factory.pipeline_name}. "
+                    "Use clear() in tests to reset registry state."
+                )
+            cls._registry[factory.pipeline_name] = PipelineDefinition(
+                factory=factory,
+                silver_schema=factory.silver_schema,
+                gold_schema=gold_schema,
+            )
 
     @classmethod
     def get(cls, pipeline_name: str) -> PipelineDefinition:
         """Get pipeline definition by name.
+
+        Thread-safe read access to registry.
 
         Args:
             pipeline_name: Pipeline identifier
@@ -115,25 +131,31 @@ class PipelineRegistry:
             RuntimeError: If registry is empty (registration not called)
             ValueError: If pipeline is not registered
         """
-        if not cls._registry:
-            raise RuntimeError(
-                "PipelineRegistry is empty. "
-                "Did you forget to call register_all_pipelines()?"
-            )
-        if pipeline_name not in cls._registry:
-            raise ValueError(
-                f"Unknown pipeline name: {pipeline_name}. "
-                f"Available: {list(cls._registry.keys())}"
-            )
-        return cls._registry[pipeline_name]
+        with cls._registry_lock:
+            if not cls._registry:
+                raise RuntimeError(
+                    "PipelineRegistry is empty. "
+                    "Did you forget to call register_all_pipelines()?"
+                )
+            if pipeline_name not in cls._registry:
+                raise ValueError(
+                    f"Unknown pipeline name: {pipeline_name}. "
+                    f"Available: {sorted(cls._registry.keys())}"
+                )
+            return cls._registry[pipeline_name]
 
     @classmethod
     def list_pipelines(cls) -> list[str]:
         """List all registered pipeline names.
 
-        Legacy alias for list_keys().
+        Thread-safe listing with deterministic ordering.
+        Returns a snapshot of keys sorted alphabetically.
+
+        Returns:
+            Sorted list of pipeline names (deterministic order).
         """
-        return list(cls._registry.keys())
+        with cls._registry_lock:
+            return sorted(cls._registry.keys())
 
     @classmethod
     def register(
@@ -143,6 +165,7 @@ class PipelineRegistry:
     ) -> None:
         """Register a pipeline factory (unified API).
 
+        Thread-safe registration with duplicate detection.
         This method provides a unified API consistent with other registries.
         For backward compatibility, use register_factory() which extracts
         the key from factory.pipeline_name.
@@ -153,6 +176,7 @@ class PipelineRegistry:
 
         Raises:
             ValueError: If factory does not have gold_schema attribute
+            ValueError: If pipeline is already registered
         """
         gold_schema = getattr(value, "gold_schema", None)
         if gold_schema is None:
@@ -160,11 +184,17 @@ class PipelineRegistry:
                 f"Factory '{key}' must have gold_schema. "
                 "All Gold layer writes require schema validation."
             )
-        cls._registry[key] = PipelineDefinition(
-            factory=value,
-            silver_schema=value.silver_schema,
-            gold_schema=gold_schema,
-        )
+        with cls._registry_lock:
+            if key in cls._registry:
+                raise ValueError(
+                    f"Pipeline already registered: {key}. "
+                    "Use clear() in tests to reset registry state."
+                )
+            cls._registry[key] = PipelineDefinition(
+                factory=value,
+                silver_schema=value.silver_schema,
+                gold_schema=gold_schema,
+            )
 
     @classmethod
     def list_keys(cls) -> list[str]:
@@ -178,18 +208,23 @@ class PipelineRegistry:
     def contains(cls, key: str) -> bool:
         """Check if pipeline is registered.
 
+        Thread-safe check for key existence.
+
         Args:
             key: Pipeline name to check
 
         Returns:
             True if pipeline is registered, False otherwise
         """
-        return key in cls._registry
+        with cls._registry_lock:
+            return key in cls._registry
 
     @classmethod
     def clear(cls) -> None:
         """Clear all registrations (for testing).
 
+        Thread-safe reset of registry state.
         WARNING: Only use in tests. Not for production.
         """
-        cls._registry.clear()
+        with cls._registry_lock:
+            cls._registry.clear()

--- a/tests/architecture/test_registry_threading.py
+++ b/tests/architecture/test_registry_threading.py
@@ -1,0 +1,302 @@
+"""Tests for PipelineRegistry thread safety.
+
+Verifies that registry operations are thread-safe as per CLAUDE.md requirements.
+Tests concurrent access patterns that could expose race conditions.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pyarrow as pa
+import pytest
+
+from bioetl.composition.factories.pipeline_factories import (
+    register_all_pipelines,
+    reset_registration,
+)
+from bioetl.composition.registry import PipelineRegistry
+
+if TYPE_CHECKING:
+    from bioetl.composition.registry import PipelineFactoryProtocol
+
+
+def create_mock_factory(name: str) -> PipelineFactoryProtocol:
+    """Create a mock factory for testing.
+
+    Args:
+        name: Pipeline name for the factory.
+
+    Returns:
+        Mock factory implementing PipelineFactoryProtocol.
+    """
+    factory = MagicMock()
+    factory.pipeline_name = name
+    factory.silver_schema = pa.schema([("id", pa.int64())])
+    factory.gold_schema = MagicMock()  # Non-None gold_schema required
+    return factory
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    """Reset registry before and after each test."""
+    reset_registration()
+    yield
+    reset_registration()
+
+
+class TestConcurrentRegistration:
+    """Tests for concurrent registration safety."""
+
+    def test_concurrent_registration_from_multiple_threads(self) -> None:
+        """10 threads registering different factories simultaneously.
+
+        Verifies that no race conditions occur during concurrent writes.
+        """
+        num_threads = 10
+        results: list[tuple[str, bool]] = []
+        errors: list[Exception] = []
+
+        def register_factory(idx: int) -> None:
+            """Register a factory with unique name."""
+            try:
+                factory = create_mock_factory(f"test_pipeline_{idx}")
+                PipelineRegistry.register_factory(factory)
+                results.append((f"test_pipeline_{idx}", True))
+            except Exception as e:
+                errors.append(e)
+
+        # Execute all registrations concurrently
+        with ThreadPoolExecutor(max_workers=num_threads) as executor:
+            futures = [executor.submit(register_factory, i) for i in range(num_threads)]
+            for future in as_completed(futures):
+                future.result()  # Raise any exceptions
+
+        # Verify all registrations succeeded
+        assert len(errors) == 0, f"Errors during registration: {errors}"
+        assert len(results) == num_threads, (
+            f"Expected {num_threads} registrations, got {len(results)}"
+        )
+
+        # Verify all pipelines are registered
+        registered = PipelineRegistry.list_pipelines()
+        for i in range(num_threads):
+            assert f"test_pipeline_{i}" in registered, (
+                f"Pipeline test_pipeline_{i} not found in registry"
+            )
+
+    def test_concurrent_read_write_safety(self) -> None:
+        """Concurrent reads during writes do not cause errors.
+
+        Simulates real-world scenario where list_pipelines() is called
+        while register_factory() is in progress.
+        """
+        num_writers = 5
+        num_readers = 10
+        read_results: list[list[str]] = []
+        errors: list[Exception] = []
+
+        def writer(idx: int) -> None:
+            """Register a factory."""
+            try:
+                factory = create_mock_factory(f"concurrent_pipeline_{idx}")
+                PipelineRegistry.register_factory(factory)
+            except ValueError:
+                # Already registered - expected in some race scenarios
+                pass
+            except Exception as e:
+                errors.append(e)
+
+        def reader() -> None:
+            """Read the registry."""
+            try:
+                # Small delay to interleave with writes
+                time.sleep(0.001)
+                result = PipelineRegistry.list_pipelines()
+                read_results.append(result)
+            except Exception as e:
+                errors.append(e)
+
+        # Mix readers and writers
+        with ThreadPoolExecutor(max_workers=num_writers + num_readers) as executor:
+            futures = []
+            for i in range(num_writers):
+                futures.append(executor.submit(writer, i))
+            for _ in range(num_readers):
+                futures.append(executor.submit(reader))
+
+            for future in as_completed(futures):
+                future.result()
+
+        # Verify no errors during concurrent access
+        assert len(errors) == 0, f"Errors during concurrent access: {errors}"
+
+        # Verify all reads returned valid lists
+        for result in read_results:
+            assert isinstance(result, list), "list_pipelines() must return a list"
+
+    def test_double_registration_raises_error(self) -> None:
+        """Registering the same pipeline twice raises ValueError.
+
+        Ensures duplicate detection works correctly.
+        """
+        factory = create_mock_factory("duplicate_pipeline")
+
+        # First registration succeeds
+        PipelineRegistry.register_factory(factory)
+
+        # Second registration fails
+        with pytest.raises(ValueError, match="Pipeline already registered"):
+            PipelineRegistry.register_factory(factory)
+
+    def test_double_registration_concurrent(self) -> None:
+        """Concurrent attempts to register same pipeline.
+
+        Only one should succeed, others should get ValueError.
+        """
+        num_threads = 10
+        successes = []
+        failures = []
+        barrier = threading.Barrier(num_threads)
+
+        def try_register(idx: int) -> None:
+            """Try to register the same factory."""
+            factory = create_mock_factory("same_pipeline")
+            # Synchronize all threads to start at the same time
+            barrier.wait()
+            try:
+                PipelineRegistry.register_factory(factory)
+                successes.append(idx)
+            except ValueError:
+                failures.append(idx)
+
+        with ThreadPoolExecutor(max_workers=num_threads) as executor:
+            futures = [executor.submit(try_register, i) for i in range(num_threads)]
+            for future in as_completed(futures):
+                future.result()
+
+        # Exactly one should succeed
+        assert len(successes) == 1, (
+            f"Expected 1 success, got {len(successes)}: {successes}"
+        )
+        assert len(failures) == num_threads - 1, (
+            f"Expected {num_threads - 1} failures, got {len(failures)}"
+        )
+
+
+class TestListPipelinesDeterminism:
+    """Tests for deterministic list_pipelines() behavior."""
+
+    def test_list_pipelines_returns_sorted_list(self) -> None:
+        """list_pipelines() returns alphabetically sorted list.
+
+        Ensures deterministic ordering regardless of registration order.
+        """
+        # Register in non-alphabetical order
+        names = ["zebra", "alpha", "mike", "beta"]
+        for name in names:
+            factory = create_mock_factory(name)
+            PipelineRegistry.register_factory(factory)
+
+        result = PipelineRegistry.list_pipelines()
+
+        # Verify sorted order
+        assert result == sorted(names), (
+            f"Expected sorted list {sorted(names)}, got {result}"
+        )
+
+    def test_list_pipelines_consistent_across_calls(self) -> None:
+        """Multiple calls to list_pipelines() return identical results.
+
+        Verifies no random ordering or side effects.
+        """
+        # Register some pipelines
+        for name in ["pipeline_a", "pipeline_b", "pipeline_c"]:
+            factory = create_mock_factory(name)
+            PipelineRegistry.register_factory(factory)
+
+        # Call multiple times
+        results = [PipelineRegistry.list_pipelines() for _ in range(10)]
+
+        # All results should be identical
+        first_result = results[0]
+        for result in results[1:]:
+            assert result == first_result, (
+                "list_pipelines() results are not consistent"
+            )
+
+
+class TestRegisterAllPipelinesThreadSafety:
+    """Tests for register_all_pipelines() thread safety."""
+
+    def test_concurrent_register_all_pipelines_idempotent(self) -> None:
+        """Multiple threads calling register_all_pipelines() simultaneously.
+
+        Only one should perform registration, others should return immediately.
+        """
+        num_threads = 10
+        call_count = []
+        lock = threading.Lock()
+        barrier = threading.Barrier(num_threads)
+
+        def call_register() -> None:
+            """Call register_all_pipelines()."""
+            barrier.wait()
+            register_all_pipelines()
+            with lock:
+                call_count.append(1)
+
+        with ThreadPoolExecutor(max_workers=num_threads) as executor:
+            futures = [executor.submit(call_register) for _ in range(num_threads)]
+            for future in as_completed(futures):
+                future.result()
+
+        # All threads should complete
+        assert len(call_count) == num_threads, (
+            f"Expected {num_threads} completions, got {len(call_count)}"
+        )
+
+        # Registry should have correct pipelines
+        registered = PipelineRegistry.list_pipelines()
+        assert len(registered) > 0, "No pipelines registered"
+
+        # Call again - should be idempotent
+        initial_count = len(registered)
+        register_all_pipelines()
+        assert len(PipelineRegistry.list_pipelines()) == initial_count, (
+            "register_all_pipelines() is not idempotent"
+        )
+
+
+class TestRegistryLockBehavior:
+    """Tests for RLock reentrant behavior."""
+
+    def test_contains_after_list_pipelines(self) -> None:
+        """Sequential calls using lock don't deadlock.
+
+        RLock allows reentrant access from same thread.
+        """
+        factory = create_mock_factory("reentrant_test")
+        PipelineRegistry.register_factory(factory)
+
+        # These operations use the same lock internally
+        pipelines = PipelineRegistry.list_pipelines()
+        for name in pipelines:
+            # contains() also uses the lock
+            assert PipelineRegistry.contains(name)
+
+    def test_get_after_contains(self) -> None:
+        """get() works after contains() check.
+
+        Verifies no lock issues with consecutive operations.
+        """
+        factory = create_mock_factory("get_test")
+        PipelineRegistry.register_factory(factory)
+
+        if PipelineRegistry.contains("get_test"):
+            definition = PipelineRegistry.get("get_test")
+            assert definition.factory.pipeline_name == "get_test"


### PR DESCRIPTION
…_pipelines

- Add RLock to PipelineRegistry for thread-safe access to _registry dict
- Protect all public methods (register_factory, register, get, list_pipelines, contains, clear) with _registry_lock
- Add duplicate registration detection in register_factory() and register()
- Fix TOCTOU race condition in register_all_pipelines() using double-checked locking pattern with module-level _registration_lock
- Make list_pipelines() return sorted list for deterministic ordering
- Add reset_registration() helper for tests
- Add 9 concurrency tests verifying:
  - Concurrent registration from 10 threads
  - Concurrent read/write safety
  - Double registration error handling
  - Deterministic list_pipelines() ordering
  - RLock reentrant behavior