### PR TITLE
Clean up Composition Root infrastructure exports

### DIFF
--- a/src/bioetl/composition/bootstrap.py
+++ b/src/bioetl/composition/bootstrap.py
@@ -8,7 +8,12 @@ Bootstrap functions are organized into submodules:
 - bootstrap.storage: storage adapters, cleanup, lifecycle services
 - bootstrap.checkpoint: checkpoint and quarantine management
 
-All functions are re-exported here for backward compatibility.
+All bootstrap functions are re-exported here for convenience.
+
+Note:
+    Infrastructure types (BronzeWriter, DeltaWriter, etc.) are NOT exported
+    from this module. Import them directly from infrastructure modules or
+    use composition/types.py for type annotations.
 """
 
 from __future__ import annotations
@@ -31,33 +36,12 @@ from bioetl.composition._bootstrap import (
 )
 from bioetl.composition.builders import FilterConfigBuilder
 from bioetl.composition.factories.pipeline_factories import register_all_pipelines
-from bioetl.composition.factories.storage_factory import StorageAdapter
-from bioetl.composition.observability import ObservabilityBundle
 from bioetl.composition.providers.registration import register_all_providers
 from bioetl.composition.registry import PipelineRegistry
 from bioetl.domain.config import RuntimeConfig
-from bioetl.infrastructure.checkpoint.local_checkpoint import LocalCheckpoint
 from bioetl.infrastructure.config import get_settings, load_pipeline_config
-from bioetl.infrastructure.locking.memory_lock import MemoryLock
-from bioetl.infrastructure.observability.prometheus_metrics import PrometheusMetrics
-from bioetl.infrastructure.observability.server import MetricsServerError
-from bioetl.infrastructure.quarantine.unified_quarantine import UnifiedQuarantine
-from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
-from bioetl.infrastructure.storage.delta_writer import DeltaWriter
-from bioetl.infrastructure.storage.gold_writer import GoldWriter
 
 __all__ = [
-    # Infrastructure components (re-exports for convenience)
-    "BronzeWriter",
-    "DeltaWriter",
-    "GoldWriter",
-    "LocalCheckpoint",
-    "MemoryLock",
-    "MetricsServerError",
-    "ObservabilityBundle",
-    "PrometheusMetrics",
-    "StorageAdapter",
-    "UnifiedQuarantine",
     # Bootstrap functions (from submodules)
     "bootstrap_checkpoint",
     "bootstrap_checkpoint_manager",

--- a/src/bioetl/composition/types.py
+++ b/src/bioetl/composition/types.py
@@ -1,0 +1,24 @@
+"""Public types for composition layer.
+
+This module provides type definitions and re-exports for external annotation needs.
+Use these types when you need to annotate variables or function parameters
+that work with composition-layer constructs.
+
+For actual runtime imports, use the specific modules:
+- ObservabilityBundle: from bioetl.composition.observability
+- StorageAdapter: from bioetl.composition.factories.storage_factory
+- PipelineRegistry: from bioetl.composition.registry
+"""
+
+from __future__ import annotations
+
+from bioetl.composition.factories.storage_factory import StorageAdapter
+from bioetl.composition.observability import ObservabilityBundle
+from bioetl.composition.registry import PipelineDefinition, PipelineRegistry
+
+__all__ = [
+    "ObservabilityBundle",
+    "PipelineDefinition",
+    "PipelineRegistry",
+    "StorageAdapter",
+]

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -451,7 +451,8 @@ class TestBootstrapMetrics:
         mock_start_server: MagicMock,
     ) -> None:
         """Test that fail_fast=True propagates MetricsServerError."""
-        from bioetl.composition.bootstrap import MetricsServerError, bootstrap_metrics
+        from bioetl.composition.bootstrap import bootstrap_metrics
+        from bioetl.interfaces.observability import MetricsServerError
 
         settings = MagicMock()
         settings.metrics_port = 8000


### PR DESCRIPTION
…p.py

Clean up Composition Root to export only bootstrap functions and load_pipeline_config. Infrastructure classes (BronzeWriter, DeltaWriter, GoldWriter, MemoryLock, etc.) are no longer re-exported.

Changes:
- Remove infrastructure imports only used for re-export
- Create composition/types.py for public type annotations
- Update test_bootstrap.py to import MetricsServerError from interfaces.observability instead of bootstrap
- Update docstring to clarify export policy