### PR TITLE
Implement unified observability contract

### DIFF
--- a/src/bioetl/application/core/runner.py
+++ b/src/bioetl/application/core/runner.py
@@ -2,10 +2,15 @@
 
 Application Service that orchestrates pipeline execution lifecycle.
 Coordinates locking, checkpointing, and execution.
+
+Records health-check metrics per Unified Observability Contract:
+- pipeline_health_check_passed: Per-component health status
+- infrastructure_validated: Overall infrastructure validation status
 """
 
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING, Any
 
 from bioetl.application.core.health_aggregator import HealthAggregator
@@ -156,6 +161,11 @@ class PipelineRunner:
         """Validate infrastructure health before pipeline execution.
 
         Performs health checks on storage and data source components.
+        Records metrics per Unified Observability Contract:
+        - pipeline_health_check_passed: Per-component health status (1=passed, 0=failed)
+        - infrastructure_validated: Overall validation status
+        - health_check_duration_seconds: Total health check duration
+
         Raises InfrastructureError if critical components are unhealthy.
         """
         self._logger.info(
@@ -163,7 +173,12 @@ class PipelineRunner:
             extra={"stage": "health_check"},
         )
 
+        start_time = time.perf_counter()
         report = await self._health_aggregator.check_all(self._services)
+        duration = time.perf_counter() - start_time
+
+        # Record per-component health check metrics
+        self._record_health_check_metrics(report, duration)
 
         # Log overall health status
         self._logger.info(
@@ -173,6 +188,7 @@ class PipelineRunner:
                 "overall_status": report.overall_status.value,
                 "is_healthy": report.is_healthy,
                 "components_checked": len(report.results),
+                "duration_seconds": round(duration, 4),
             },
         )
 
@@ -294,3 +310,49 @@ class PipelineRunner:
                     1,
                     {"pipeline": self._config.pipeline_name, "metric": metric_name},
                 )
+
+    def _record_health_check_metrics(
+        self,
+        report: Any,
+        duration: float,
+    ) -> None:
+        """Record health-check metrics per Unified Observability Contract.
+
+        Records:
+        - pipeline_health_check_passed: Per-component status (1=passed, 0=failed)
+        - infrastructure_validated: Overall validation status
+        - health_check_duration_seconds: Total duration
+
+        Args:
+            report: HealthReport from health aggregator.
+            duration: Total health check duration in seconds.
+        """
+        from bioetl.domain.types import HealthStatus
+
+        metrics = self._services.metrics
+        pipeline = self._config.pipeline_name
+        run_id = str(self._context.run_id)
+
+        # Record per-component health check passed status
+        for result in report.results:
+            passed = 1.0 if result.status == HealthStatus.HEALTHY else 0.0
+            metrics.set_gauge(
+                "pipeline_health_check_passed",
+                passed,
+                {"pipeline": pipeline, "component": result.component},
+            )
+
+        # Record overall infrastructure validation status
+        validated = 1.0 if report.is_healthy else 0.0
+        metrics.set_gauge(
+            "infrastructure_validated",
+            validated,
+            {"pipeline": pipeline, "run_id": run_id},
+        )
+
+        # Record health check duration
+        metrics.observe_histogram(
+            "health_check_duration_seconds",
+            duration,
+            {"pipeline": pipeline},
+        )

--- a/src/bioetl/composition/_bootstrap/observability.py
+++ b/src/bioetl/composition/_bootstrap/observability.py
@@ -2,6 +2,13 @@
 
 Contains bootstrap functions for logging, tracing, metrics, and data quality
 monitoring. These functions configure the observability stack for the pipeline.
+
+Unified Observability Contract:
+- bootstrap_observability() always returns valid implementations
+- Logger: StructlogLogger (always valid)
+- Metrics: PrometheusMetrics or NoOpMetrics (never None)
+- Tracer: OpenTelemetryTracer or NoOpTracer (never None)
+- DQMonitor: DataQualityMonitor or None (optional)
 """
 
 from __future__ import annotations
@@ -13,6 +20,7 @@ from bioetl.composition.observability import ObservabilityBundle
 from bioetl.infrastructure.observability.logging import (
     create_logger as create_infra_logger,
 )
+from bioetl.infrastructure.observability.noop_metrics import NoOpMetrics
 from bioetl.infrastructure.observability.prometheus_metrics import PrometheusMetrics
 from bioetl.infrastructure.observability.server import start_metrics_server
 from bioetl.infrastructure.observability.tracing import NoOpTracer, OpenTelemetryTracer
@@ -57,8 +65,11 @@ def bootstrap_tracer(service_name: str = "bioetl") -> TracingPort:
     return NoOpTracer()
 
 
-def bootstrap_metrics(settings: Settings) -> MetricsPort | None:
+def bootstrap_metrics(settings: Settings) -> MetricsPort:
     """Bootstrap metrics with optional server start.
+
+    Unified Observability Contract: Always returns a valid MetricsPort.
+    When metrics are disabled, returns NoOpMetrics (silent fallback).
 
     Server is started only if explicitly enabled in settings.
     Supports fail_fast mode for strict startup validation.
@@ -67,13 +78,15 @@ def bootstrap_metrics(settings: Settings) -> MetricsPort | None:
         settings: Application settings.
 
     Returns:
-        MetricsPort instance or None if metrics are disabled.
+        MetricsPort instance (PrometheusMetrics or NoOpMetrics).
+        Never returns None - uses NoOpMetrics as fallback.
 
     Raises:
         MetricsServerError: If fail_fast=True and server fails to start.
     """
     if not settings.observability.metrics_enabled:
-        return None
+        # Silent fallback - no warning since explicitly disabled
+        return NoOpMetrics(warn_on_use=False)
 
     metrics = PrometheusMetrics()
 
@@ -150,6 +163,11 @@ def bootstrap_observability(
 ) -> ObservabilityBundle:
     """Bootstrap all observability components.
 
+    Unified Observability Contract:
+    - Always returns a valid ObservabilityBundle with non-None logger and metrics
+    - Fallback to StructlogLogger + NoOpMetrics when Prometheus is disabled
+    - Tracer and DQ monitor remain optional
+
     Creates a unified observability bundle containing logger, tracer, metrics,
     and data quality monitor.
 
@@ -159,16 +177,33 @@ def bootstrap_observability(
         settings: Application settings.
 
     Returns:
-        Configured ObservabilityBundle instance.
+        Configured ObservabilityBundle instance with valid implementations.
+        Logger and metrics are guaranteed to be non-None.
+
+    Raises:
+        ObservabilityContractError: If bundle creation fails validation.
     """
     logger = bootstrap_logger(pipeline=pipeline, run_id=run_id)
     tracer = bootstrap_tracer()
     metrics = bootstrap_metrics(settings)
     dq_monitor = bootstrap_dq_monitor(settings)
 
-    return ObservabilityBundle(
+    bundle = ObservabilityBundle(
         logger=logger,
-        tracer=tracer,
         metrics=metrics,
+        tracer=tracer,
         dq_monitor=dq_monitor,
     )
+
+    # Log observability initialization status
+    logger.info(
+        "observability_initialized",
+        extra={
+            "stage": "bootstrap",
+            "metrics_type": type(metrics).__name__,
+            "tracer_type": type(tracer).__name__,
+            "dq_monitor_enabled": dq_monitor is not None,
+        },
+    )
+
+    return bundle

--- a/src/bioetl/composition/observability.py
+++ b/src/bioetl/composition/observability.py
@@ -2,6 +2,12 @@
 
 Aggregates logger, tracer, and metrics into a single injectable dependency,
 simplifying constructor signatures across the codebase.
+
+This module enforces the Unified Observability Contract:
+- logger: REQUIRED - pipeline cannot run without structured logging
+- metrics: REQUIRED - always valid implementation (NoOpMetrics fallback)
+- tracer: Optional - distributed tracing
+- dq_monitor: Optional - data quality anomaly detection
 """
 
 from __future__ import annotations
@@ -15,6 +21,14 @@ if TYPE_CHECKING:
     from bioetl.domain.ports import DQMonitorPort, MetricsPort, TracingPort
 
 
+class ObservabilityContractError(Exception):
+    """Raised when observability contract requirements are not met.
+
+    This error indicates a programming error in the bootstrap/composition layer
+    where required observability components were not properly initialized.
+    """
+
+
 @dataclass(frozen=True)
 class ObservabilityBundle:
     """Unified observability context for pipeline execution.
@@ -23,38 +37,66 @@ class ObservabilityBundle:
     a single injectable dependency. This reduces the number of constructor
     parameters and ensures consistent observability configuration across components.
 
+    Unified Observability Contract:
+    - logger: REQUIRED - structured logger, cannot be None
+    - metrics: REQUIRED - MetricsPort implementation (NoOpMetrics if disabled)
+    - tracer: Optional - distributed tracing port
+    - dq_monitor: Optional - data quality anomaly detector
+
+    Raises:
+        ObservabilityContractError: If required components are None.
+
     Attributes:
         logger: Structured logger for the pipeline.
+        metrics: Metrics collection port (never None - uses NoOpMetrics fallback).
         tracer: Optional distributed tracing port.
-        metrics: Optional metrics collection port.
         dq_monitor: Optional data quality anomaly detector.
     """
 
     logger: structlog.BoundLogger
+    metrics: MetricsPort
     tracer: TracingPort | None = None
-    metrics: MetricsPort | None = None
     dq_monitor: DQMonitorPort | None = None
+
+    def __post_init__(self) -> None:
+        """Validate that required observability components are present."""
+        if self.logger is None:
+            raise ObservabilityContractError(
+                "Logger is required. Cannot run pipeline without structured logging. "
+                "Use bootstrap_observability() to create a valid bundle."
+            )
+        if self.metrics is None:
+            raise ObservabilityContractError(
+                "Metrics port is required. Use NoOpMetrics when metrics are disabled. "
+                "Use bootstrap_observability() to create a valid bundle."
+            )
 
     @classmethod
     def create(
         cls,
         logger: structlog.BoundLogger,
+        metrics: MetricsPort,
         tracer: TracingPort | None = None,
-        metrics: MetricsPort | None = None,
         dq_monitor: DQMonitorPort | None = None,
     ) -> ObservabilityBundle:
         """Factory method for creating observability bundle.
 
+        Enforces the Unified Observability Contract by requiring
+        valid logger and metrics implementations.
+
         Args:
-            logger: Structured logger instance.
+            logger: Structured logger instance (required).
+            metrics: Metrics port implementation (required, use NoOpMetrics if disabled).
             tracer: Optional tracer port.
-            metrics: Optional metrics port.
             dq_monitor: Optional data quality monitor port.
 
         Returns:
             Configured ObservabilityBundle instance.
+
+        Raises:
+            ObservabilityContractError: If logger or metrics is None.
         """
-        return cls(logger=logger, tracer=tracer, metrics=metrics, dq_monitor=dq_monitor)
+        return cls(logger=logger, metrics=metrics, tracer=tracer, dq_monitor=dq_monitor)
 
     def bind(self, **kwargs: object) -> ObservabilityBundle:
         """Create new bundle with bound logger context.
@@ -76,4 +118,4 @@ class ObservabilityBundle:
         )
 
 
-__all__ = ["ObservabilityBundle"]
+__all__ = ["ObservabilityBundle", "ObservabilityContractError"]

--- a/src/bioetl/infrastructure/observability/metrics.py
+++ b/src/bioetl/infrastructure/observability/metrics.py
@@ -129,6 +129,29 @@ DQ_BASELINE_SAMPLES = Gauge(
     ["pipeline", "metric"],
 )
 
+# =============================================================================
+# Health Check metrics (Unified Observability Contract)
+# =============================================================================
+
+PIPELINE_HEALTH_CHECK_PASSED = Gauge(
+    "bioetl_pipeline_health_check_passed",
+    "Health check status for pipeline components (1=passed, 0=failed)",
+    ["pipeline", "component"],
+)
+
+INFRASTRUCTURE_VALIDATED = Gauge(
+    "bioetl_infrastructure_validated",
+    "Infrastructure validation status (1=validated, 0=not validated)",
+    ["pipeline", "run_id"],
+)
+
+HEALTH_CHECK_DURATION_SECONDS = Histogram(
+    "bioetl_health_check_duration_seconds",
+    "Duration of health check operations in seconds",
+    ["pipeline"],
+    buckets=[0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0],
+)
+
 
 class MetricsCollector:
     """Collector for pipeline metrics.

--- a/tests/integration/pipelines/base.py
+++ b/tests/integration/pipelines/base.py
@@ -18,6 +18,7 @@ from bioetl.composition.factories.storage_factory import StorageAdapter, Storage
 from bioetl.composition.observability import ObservabilityBundle
 from bioetl.domain.config import RuntimeConfig
 from bioetl.infrastructure.config import Settings
+from bioetl.infrastructure.observability.noop_metrics import NoOpMetrics
 from bioetl.infrastructure.observability.tracing import NoOpTracer
 from bioetl.infrastructure.schemas.pipeline_config import PipelineYamlConfig
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
@@ -161,10 +162,11 @@ class IntegrationPipelineTestCase:
             pipeline_config = pipeline_config.model_copy(update=config_overrides)
 
         # Create observability bundle for testing
+        # Per Unified Observability Contract, metrics must be non-None
         observability = ObservabilityBundle(
             logger=structlog.get_logger(),
+            metrics=NoOpMetrics(warn_on_use=False),
             tracer=NoOpTracer(),
-            metrics=None,
         )
 
         # Create runner

--- a/tests/unit/application/core/test_run_id_propagation.py
+++ b/tests/unit/application/core/test_run_id_propagation.py
@@ -70,7 +70,7 @@ def mock_services(mock_storage, mock_quarantine):
     """Create mock pipeline services."""
     services = MagicMock(spec=PipelineServices)
     services.storage = mock_storage
-    services.metrics = None
+    services.metrics = MagicMock()  # Per Unified Observability Contract, metrics is never None
     services.quarantine = mock_quarantine
     return services
 

--- a/tests/unit/composition/test_observability_contract.py
+++ b/tests/unit/composition/test_observability_contract.py
@@ -1,0 +1,324 @@
+"""Tests for Unified Observability Contract.
+
+Verifies that:
+1. ObservabilityBundle enforces required components (logger, metrics)
+2. bootstrap_observability() always returns valid implementations
+3. NoOpMetrics is used as fallback when Prometheus disabled
+4. Pipeline cannot run without valid logger
+5. Health-check metrics are properly recorded
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from bioetl.composition.observability import ObservabilityBundle, ObservabilityContractError
+from bioetl.infrastructure.observability.noop_metrics import NoOpMetrics
+
+
+@pytest.mark.unit
+class TestObservabilityBundle:
+    """Tests for ObservabilityBundle contract enforcement."""
+
+    def test_bundle_requires_logger(self) -> None:
+        """Test that bundle creation fails without logger."""
+        mock_metrics = MagicMock()
+
+        with pytest.raises(ObservabilityContractError, match="Logger is required"):
+            ObservabilityBundle(logger=None, metrics=mock_metrics)  # type: ignore[arg-type]
+
+    def test_bundle_requires_metrics(self) -> None:
+        """Test that bundle creation fails without metrics."""
+        mock_logger = MagicMock()
+
+        with pytest.raises(ObservabilityContractError, match="Metrics port is required"):
+            ObservabilityBundle(logger=mock_logger, metrics=None)  # type: ignore[arg-type]
+
+    def test_bundle_allows_optional_tracer_none(self) -> None:
+        """Test that tracer can be None."""
+        mock_logger = MagicMock()
+        mock_metrics = MagicMock()
+
+        bundle = ObservabilityBundle(
+            logger=mock_logger,
+            metrics=mock_metrics,
+            tracer=None,
+            dq_monitor=None,
+        )
+
+        assert bundle.tracer is None
+        assert bundle.dq_monitor is None
+
+    def test_bundle_create_factory_method(self) -> None:
+        """Test factory method enforces contract."""
+        mock_logger = MagicMock()
+        mock_metrics = MagicMock()
+        mock_tracer = MagicMock()
+
+        bundle = ObservabilityBundle.create(
+            logger=mock_logger,
+            metrics=mock_metrics,
+            tracer=mock_tracer,
+        )
+
+        assert bundle.logger is mock_logger
+        assert bundle.metrics is mock_metrics
+        assert bundle.tracer is mock_tracer
+
+    def test_bundle_bind_preserves_metrics(self) -> None:
+        """Test that bind() preserves metrics reference."""
+        mock_logger = MagicMock()
+        mock_logger.bind.return_value = MagicMock()
+        mock_metrics = MagicMock()
+
+        bundle = ObservabilityBundle(logger=mock_logger, metrics=mock_metrics)
+        new_bundle = bundle.bind(run_id="test-123")
+
+        assert new_bundle.metrics is mock_metrics
+
+    def test_bundle_frozen(self) -> None:
+        """Test that bundle is frozen (immutable)."""
+        mock_logger = MagicMock()
+        mock_metrics = MagicMock()
+
+        bundle = ObservabilityBundle(logger=mock_logger, metrics=mock_metrics)
+
+        with pytest.raises(Exception):  # FrozenInstanceError
+            bundle.metrics = MagicMock()  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestBootstrapObservability:
+    """Tests for bootstrap_observability() function."""
+
+    @patch("bioetl.composition._bootstrap.observability.start_metrics_server")
+    @patch("bioetl.composition._bootstrap.observability.PrometheusMetrics")
+    @patch("bioetl.composition._bootstrap.observability.create_infra_logger")
+    def test_bootstrap_returns_valid_bundle(
+        self,
+        mock_create_logger: MagicMock,
+        mock_prometheus: MagicMock,
+        mock_start_server: MagicMock,
+    ) -> None:
+        """Test that bootstrap returns bundle with valid implementations."""
+        from bioetl.composition._bootstrap.observability import bootstrap_observability
+
+        # Setup mocks
+        mock_logger = MagicMock()
+        mock_logger.info = MagicMock()
+        mock_create_logger.return_value = mock_logger
+        mock_metrics = MagicMock()
+        mock_prometheus.return_value = mock_metrics
+
+        settings = MagicMock()
+        settings.metrics_port = 8000
+        settings.observability.metrics_enabled = True
+        settings.observability.metrics_server_enabled = False
+        settings.observability.tracing_enabled = False
+        settings.observability.dq_monitor_enabled = False
+
+        bundle = bootstrap_observability(
+            pipeline="test_pipeline",
+            run_id=uuid4(),
+            settings=settings,
+        )
+
+        assert bundle.logger is mock_logger
+        assert bundle.metrics is mock_metrics
+        assert bundle.tracer is not None  # NoOpTracer
+        assert bundle.dq_monitor is None
+
+    @patch("bioetl.composition._bootstrap.observability.create_infra_logger")
+    def test_bootstrap_uses_noop_metrics_when_disabled(
+        self,
+        mock_create_logger: MagicMock,
+    ) -> None:
+        """Test that NoOpMetrics is used when metrics disabled."""
+        from bioetl.composition._bootstrap.observability import bootstrap_observability
+
+        mock_logger = MagicMock()
+        mock_logger.info = MagicMock()
+        mock_create_logger.return_value = mock_logger
+
+        settings = MagicMock()
+        settings.observability.metrics_enabled = False
+        settings.observability.tracing_enabled = False
+        settings.observability.dq_monitor_enabled = False
+
+        bundle = bootstrap_observability(
+            pipeline="test_pipeline",
+            run_id=uuid4(),
+            settings=settings,
+        )
+
+        assert isinstance(bundle.metrics, NoOpMetrics)
+
+    @patch("bioetl.composition._bootstrap.observability.create_infra_logger")
+    def test_bootstrap_logs_initialization_status(
+        self,
+        mock_create_logger: MagicMock,
+    ) -> None:
+        """Test that bootstrap logs observability initialization."""
+        from bioetl.composition._bootstrap.observability import bootstrap_observability
+
+        mock_logger = MagicMock()
+        mock_create_logger.return_value = mock_logger
+
+        settings = MagicMock()
+        settings.observability.metrics_enabled = False
+        settings.observability.tracing_enabled = False
+        settings.observability.dq_monitor_enabled = False
+
+        bootstrap_observability(
+            pipeline="test_pipeline",
+            run_id=uuid4(),
+            settings=settings,
+        )
+
+        # Verify initialization was logged
+        mock_logger.info.assert_called_with(
+            "observability_initialized",
+            extra={
+                "stage": "bootstrap",
+                "metrics_type": "NoOpMetrics",
+                "tracer_type": "NoOpTracer",
+                "dq_monitor_enabled": False,
+            },
+        )
+
+
+@pytest.mark.unit
+class TestBootstrapMetrics:
+    """Tests for bootstrap_metrics() function."""
+
+    def test_disabled_metrics_returns_noop_metrics(self) -> None:
+        """Test that disabled metrics returns NoOpMetrics, not None."""
+        from bioetl.composition._bootstrap.observability import bootstrap_metrics
+
+        settings = MagicMock()
+        settings.observability.metrics_enabled = False
+
+        result = bootstrap_metrics(settings)
+
+        assert result is not None
+        assert isinstance(result, NoOpMetrics)
+
+    def test_noop_metrics_no_warning_when_disabled(self) -> None:
+        """Test that NoOpMetrics doesn't warn when explicitly disabled."""
+        from bioetl.composition._bootstrap.observability import bootstrap_metrics
+
+        # Reset warning state
+        NoOpMetrics.reset_warning()
+
+        settings = MagicMock()
+        settings.observability.metrics_enabled = False
+
+        import warnings
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            bootstrap_metrics(settings)
+            # No warning should be raised
+            assert len(w) == 0
+
+    @patch("bioetl.composition._bootstrap.observability.start_metrics_server")
+    @patch("bioetl.composition._bootstrap.observability.PrometheusMetrics")
+    def test_enabled_metrics_returns_prometheus_metrics(
+        self,
+        mock_prometheus: MagicMock,
+        mock_start_server: MagicMock,
+    ) -> None:
+        """Test that enabled metrics returns PrometheusMetrics."""
+        from bioetl.composition._bootstrap.observability import bootstrap_metrics
+
+        mock_metrics = MagicMock()
+        mock_prometheus.return_value = mock_metrics
+
+        settings = MagicMock()
+        settings.metrics_port = 8000
+        settings.observability.metrics_enabled = True
+        settings.observability.metrics_server_enabled = False
+
+        result = bootstrap_metrics(settings)
+
+        assert result is mock_metrics
+        mock_prometheus.assert_called_once()
+
+
+@pytest.mark.unit
+class TestNoOpMetricsContract:
+    """Tests for NoOpMetrics as fallback implementation."""
+
+    def test_noop_metrics_implements_port(self) -> None:
+        """Test that NoOpMetrics implements MetricsPort."""
+        from bioetl.domain.ports import MetricsPort
+
+        metrics = NoOpMetrics(warn_on_use=False)
+        assert isinstance(metrics, MetricsPort)
+
+    def test_noop_metrics_all_methods_are_noop(self) -> None:
+        """Test that all NoOpMetrics methods are no-op."""
+        metrics = NoOpMetrics(warn_on_use=False)
+
+        # These should not raise
+        metrics.observe_histogram("test", 1.0, {"label": "value"})
+        metrics.increment_counter("test", 1, {"label": "value"})
+        metrics.set_gauge("test", 1.0, {"label": "value"})
+        metrics.close()
+
+    def test_noop_metrics_close_is_idempotent(self) -> None:
+        """Test that close() can be called multiple times."""
+        metrics = NoOpMetrics(warn_on_use=False)
+
+        # Multiple closes should not raise
+        metrics.close()
+        metrics.close()
+        metrics.close()
+
+
+@pytest.mark.unit
+class TestObservabilityContractError:
+    """Tests for ObservabilityContractError exception."""
+
+    def test_error_is_exception(self) -> None:
+        """Test that ObservabilityContractError is an Exception."""
+        error = ObservabilityContractError("test message")
+        assert isinstance(error, Exception)
+
+    def test_error_has_message(self) -> None:
+        """Test that error message is preserved."""
+        error = ObservabilityContractError("test message")
+        assert str(error) == "test message"
+
+
+@pytest.mark.unit
+class TestHealthCheckMetrics:
+    """Tests for health check metrics definitions."""
+
+    def test_health_check_metrics_exist(self) -> None:
+        """Test that health check metrics are defined."""
+        from bioetl.infrastructure.observability.metrics import (
+            HEALTH_CHECK_DURATION_SECONDS,
+            INFRASTRUCTURE_VALIDATED,
+            PIPELINE_HEALTH_CHECK_PASSED,
+        )
+
+        assert PIPELINE_HEALTH_CHECK_PASSED is not None
+        assert INFRASTRUCTURE_VALIDATED is not None
+        assert HEALTH_CHECK_DURATION_SECONDS is not None
+
+    def test_health_check_metrics_have_correct_labels(self) -> None:
+        """Test that health check metrics have correct labels."""
+        from bioetl.infrastructure.observability.metrics import (
+            INFRASTRUCTURE_VALIDATED,
+            PIPELINE_HEALTH_CHECK_PASSED,
+        )
+
+        # Verify label names from metric description
+        assert "pipeline" in PIPELINE_HEALTH_CHECK_PASSED._labelnames
+        assert "component" in PIPELINE_HEALTH_CHECK_PASSED._labelnames
+        assert "pipeline" in INFRASTRUCTURE_VALIDATED._labelnames
+        assert "run_id" in INFRASTRUCTURE_VALIDATED._labelnames

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -501,17 +501,20 @@ class TestBootstrapMetrics:
 
         assert result is mock_metrics
 
-    @patch("bioetl.composition.bootstrap.PrometheusMetrics")
-    def test_bootstrap_metrics_disabled_returns_none(
-        self, mock_prometheus: MagicMock
-    ) -> None:
-        """Test that disabled metrics returns None without starting server."""
+    def test_bootstrap_metrics_disabled_returns_noop_metrics(self) -> None:
+        """Test that disabled metrics returns NoOpMetrics (not None).
+
+        Per Unified Observability Contract, bootstrap_metrics() always
+        returns a valid MetricsPort implementation. When metrics are
+        disabled, NoOpMetrics is used as a silent fallback.
+        """
         from bioetl.composition.bootstrap import bootstrap_metrics
+        from bioetl.infrastructure.observability.noop_metrics import NoOpMetrics
 
         settings = MagicMock()
         settings.observability.metrics_enabled = False
 
         result = bootstrap_metrics(settings)
 
-        assert result is None
-        mock_prometheus.assert_not_called()
+        assert result is not None
+        assert isinstance(result, NoOpMetrics)


### PR DESCRIPTION
- ObservabilityBundle now enforces required components (logger, metrics)
- bootstrap_observability() always returns valid implementations
- Fallback to NoOpMetrics when Prometheus disabled (never None)
- Add ObservabilityContractError for contract violation detection
- Add health-check metrics: pipeline_health_check_passed, infrastructure_validated, health_check_duration_seconds
- Update runner to record health-check metrics on startup
- Add comprehensive tests for observability contract (19 tests)

Breaking: ObservabilityBundle.metrics is now required (non-optional). Uses NoOpMetrics as silent fallback when metrics are disabled.

Closes: unified-observability-contract requirement