### PR TITLE
Review and consolidate refactoring plans

### DIFF
--- a/src/bioetl/application/core/base.py
+++ b/src/bioetl/application/core/base.py
@@ -4,11 +4,12 @@ Defines the structure and logic of a pipeline (config, transformations, filters)
 Does NOT handle execution orchestration.
 
 Refactored per ADR-0005.
+Updated: Transformer injection via DI (Phase 1 refactoring).
 """
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+from abc import ABC
 from typing import TYPE_CHECKING, Any, ClassVar, Self
 
 from bioetl.application.core.shutdown import ShutdownSignal
@@ -17,6 +18,7 @@ from bioetl.domain.context import PipelineContext
 if TYPE_CHECKING:
     import structlog
 
+    from bioetl.application.core.base_transformer import BaseTransformer
     from bioetl.application.core.pipeline_services import PipelineServices
     from bioetl.domain.config import PipelineConfig, RuntimeConfig
     from bioetl.domain.types import BronzeRecord, RunID, RunType, SilverRecord
@@ -40,6 +42,7 @@ class BasePipeline(ABC):
         runtime: RuntimeConfig,
         services: PipelineServices,
         config: PipelineConfig,
+        transformer: "BaseTransformer | None" = None,
     ) -> Self:
         """Create pipeline instance.
 
@@ -50,9 +53,12 @@ class BasePipeline(ABC):
             runtime: Runtime configuration.
             services: Injected services (ports).
             config: Pipeline configuration.
+            transformer: Injected transformer for Bronze→Silver transformation (DI).
+                If provided, the pipeline will use this transformer instead of
+                creating one internally. This is the preferred DI approach.
 
         """
-        return cls(config, runtime, services, run_id)
+        return cls(config, runtime, services, run_id, transformer=transformer)
 
     def __init__(
         self,
@@ -60,6 +66,7 @@ class BasePipeline(ABC):
         runtime: RuntimeConfig,
         services: PipelineServices,
         run_id: RunID,
+        transformer: "BaseTransformer | None" = None,
     ) -> None:
         """Initialize pipeline definition.
 
@@ -69,12 +76,16 @@ class BasePipeline(ABC):
             services: Injected services (ports).
             run_id: Unique identifier for this pipeline run.
                     MUST be passed from CLI/orchestrator to ensure consistency.
+            transformer: Injected transformer for Bronze→Silver transformation.
+                If None, subclass MUST override transform_bronze_to_silver()
+                or set self._transformer in its __init__.
 
         """
         self._config = config
         self._runtime = runtime
         self._services = services
         self._run_id = run_id
+        self._transformer = transformer
         self._logger = services.logger.bind(
             run_id=str(self._run_id),
             pipeline=config.pipeline_name,
@@ -156,14 +167,38 @@ class BasePipeline(ABC):
         """Record limit (from runtime)."""
         return self._runtime.limit
 
+    @property
+    def transformer(self) -> "BaseTransformer | None":
+        """Access the injected transformer."""
+        return self._transformer
+
     # --- Logic Methods (to be used by Executor) ---
 
-    @abstractmethod
     async def transform_bronze_to_silver(
         self, context: PipelineContext, record: BronzeRecord
     ) -> SilverRecord | None:
-        """Transform a raw record from Bronze to Silver format."""
-        pass
+        """Transform a raw record from Bronze to Silver format.
+
+        If a transformer was injected via DI, delegates to it.
+        Otherwise, subclasses MUST override this method.
+
+        Args:
+            context: Pipeline context with run_id, run_type, logger.
+            record: Raw Bronze record from data source.
+
+        Returns:
+            SilverRecord if transformation successful, None if skipped.
+
+        Raises:
+            NotImplementedError: If no transformer is available and method not overridden.
+
+        """
+        if self._transformer is not None:
+            return await self._transformer.transform(context, record)
+        raise NotImplementedError(
+            f"{self.__class__.__name__} must either receive a transformer via DI "
+            "or override transform_bronze_to_silver()"
+        )
 
     # Fields to exclude from Gold layer (JSON strings retained only in Silver)
     GOLD_EXCLUDE_FIELDS: ClassVar[frozenset[str]] = frozenset({

--- a/src/bioetl/application/core/runner.py
+++ b/src/bioetl/application/core/runner.py
@@ -144,6 +144,9 @@ class PipelineRunner:
                 # Check data quality after execution
                 await self._check_data_quality()
 
+                # Run VACUUM if enabled (Phase 1 refactoring)
+                await self._run_vacuum_if_enabled()
+
                 await self._checkpoint_manager.delete_checkpoint()
 
             # Add extra info to logs if needed, though observer handles success/failure logging
@@ -294,3 +297,89 @@ class PipelineRunner:
                     1,
                     {"pipeline": self._config.pipeline_name, "metric": metric_name},
                 )
+
+    async def _run_vacuum_if_enabled(self) -> None:
+        """Run VACUUM on Silver and Gold tables if enabled.
+
+        Executes VACUUM using MedallionLifecycleService when:
+        - runtime.vacuum_after_run is True
+        - runtime.dry_run is False (no vacuum in dry-run mode)
+
+        Uses runtime.vacuum_retention_days for retention policy (default: 7 days).
+        """
+        if not self._runtime.vacuum_after_run:
+            return
+
+        if self._runtime.dry_run:
+            self._logger.info(
+                "VACUUM skipped in dry-run mode",
+                extra={"stage": "vacuum"},
+            )
+            return
+
+        self._logger.info(
+            "Starting VACUUM operation",
+            extra={
+                "stage": "vacuum",
+                "retention_days": self._runtime.vacuum_retention_days,
+            },
+        )
+
+        gold_table = (
+            self._config.gold_table
+            or f"{self._config.provider}.{self._config.entity_type}"
+        )
+
+        # VACUUM Silver table
+        try:
+            silver_files_removed = await self._lifecycle_service.vacuum(
+                table=self._config.silver_table,
+                retention_days=self._runtime.vacuum_retention_days,
+                dry_run=False,
+            )
+            self._logger.info(
+                "VACUUM completed for Silver table",
+                extra={
+                    "table": self._config.silver_table,
+                    "files_removed": silver_files_removed,
+                },
+            )
+
+            if self._services.metrics:
+                self._services.metrics.increment_counter(
+                    "vacuum_files_removed",
+                    silver_files_removed,
+                    {"pipeline": self._config.pipeline_name, "layer": "silver"},
+                )
+        except Exception as e:
+            self._logger.warning(
+                "VACUUM failed for Silver table",
+                extra={"table": self._config.silver_table, "error": str(e)},
+            )
+
+        # VACUUM Gold table
+        try:
+            gold_files_removed = await self._lifecycle_service.vacuum(
+                table=gold_table,
+                retention_days=self._runtime.vacuum_retention_days,
+                dry_run=False,
+            )
+            self._logger.info(
+                "VACUUM completed for Gold table",
+                extra={
+                    "table": gold_table,
+                    "files_removed": gold_files_removed,
+                },
+            )
+
+            if self._services.metrics:
+                self._services.metrics.increment_counter(
+                    "vacuum_files_removed",
+                    gold_files_removed,
+                    {"pipeline": self._config.pipeline_name, "layer": "gold"},
+                )
+        except Exception as e:
+            self._logger.warning(
+                "VACUUM failed for Gold table",
+                extra={"table": gold_table, "error": str(e)},
+            )

--- a/src/bioetl/application/pipelines/chembl/activity.py
+++ b/src/bioetl/application/pipelines/chembl/activity.py
@@ -5,6 +5,8 @@ Bronze → Silver → Gold layers.
 
 Entity: Bioactivity measurements (IC50, Ki, EC50, etc.)
 Provider: ChEMBL (https://www.ebi.ac.uk/chembl/)
+
+Updated: Transformer injection via DI (Phase 1 refactoring).
 """
 
 from __future__ import annotations
@@ -12,17 +14,20 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from bioetl.application.core.base import BasePipeline
-from bioetl.application.pipelines.chembl.activity_transformer import ActivityTransformer
 
 if TYPE_CHECKING:
+    from bioetl.application.core.base_transformer import BaseTransformer
     from bioetl.application.core.pipeline_services import PipelineServices
     from bioetl.domain.config import PipelineConfig, RuntimeConfig
-    from bioetl.domain.context import PipelineContext
-    from bioetl.domain.types import BronzeRecord, RunID, SilverRecord
+    from bioetl.domain.types import RunID
 
 
 class ChEMBLActivityPipeline(BasePipeline):
-    """Pipeline for ChEMBL bioactivity data."""
+    """Pipeline for ChEMBL bioactivity data.
+
+    Transformer is injected via DI from GenericPipelineFactory.
+    Fallback to local creation for backward compatibility with tests.
+    """
 
     def __init__(
         self,
@@ -30,17 +35,27 @@ class ChEMBLActivityPipeline(BasePipeline):
         runtime: RuntimeConfig,
         services: PipelineServices,
         run_id: RunID,
+        transformer: "BaseTransformer | None" = None,
     ) -> None:
-        """Initialize pipeline with transformer."""
-        super().__init__(config, runtime, services, run_id)
-        self._transformer = ActivityTransformer(provider=self.provider)
+        """Initialize pipeline with optional transformer.
 
-    async def transform_bronze_to_silver(
-        self,
-        context: PipelineContext,
-        record: BronzeRecord,
-    ) -> SilverRecord | None:
-        """Transform raw ChEMBL activity to normalized format using Domain Entity."""
-        return await self._transformer.transform(context, record)
+        Args:
+            config: Pipeline configuration.
+            runtime: Runtime configuration.
+            services: Injected services (ports).
+            run_id: Unique identifier for this pipeline run.
+            transformer: Injected transformer (DI). If None, creates fallback.
 
+        """
+        # Create fallback transformer if not injected (backward compatibility)
+        if transformer is None:
+            from bioetl.application.pipelines.chembl.activity_transformer import (
+                ActivityTransformer,
+            )
+
+            transformer = ActivityTransformer(provider=config.provider)
+
+        super().__init__(config, runtime, services, run_id, transformer=transformer)
+
+    # transform_bronze_to_silver() is inherited from BasePipeline
     # should_write_gold() is inherited from BasePipeline (uses config.gold_filters)

--- a/src/bioetl/application/pipelines/chembl/assay.py
+++ b/src/bioetl/application/pipelines/chembl/assay.py
@@ -5,6 +5,8 @@ Bronze → Silver → Gold layers.
 
 Entity: Bioassay definitions (binding, functional, ADMET, etc.)
 Provider: ChEMBL (https://www.ebi.ac.uk/chembl/)
+
+Updated: Transformer injection via DI (Phase 1 refactoring).
 """
 
 from __future__ import annotations
@@ -12,17 +14,20 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from bioetl.application.core.base import BasePipeline
-from bioetl.application.pipelines.chembl.assay_transformer import AssayTransformer
 
 if TYPE_CHECKING:
+    from bioetl.application.core.base_transformer import BaseTransformer
     from bioetl.application.core.pipeline_services import PipelineServices
     from bioetl.domain.config import PipelineConfig, RuntimeConfig
-    from bioetl.domain.context import PipelineContext
-    from bioetl.domain.types import BronzeRecord, RunID, SilverRecord
+    from bioetl.domain.types import RunID
 
 
 class ChEMBLAssayPipeline(BasePipeline):
-    """Pipeline for ChEMBL assay data."""
+    """Pipeline for ChEMBL assay data.
+
+    Transformer is injected via DI from GenericPipelineFactory.
+    Fallback to local creation for backward compatibility with tests.
+    """
 
     def __init__(
         self,
@@ -30,17 +35,27 @@ class ChEMBLAssayPipeline(BasePipeline):
         runtime: RuntimeConfig,
         services: PipelineServices,
         run_id: RunID,
+        transformer: "BaseTransformer | None" = None,
     ) -> None:
-        """Initialize pipeline with transformer."""
-        super().__init__(config, runtime, services, run_id)
-        self._transformer = AssayTransformer(provider=self.provider)
+        """Initialize pipeline with optional transformer.
 
-    async def transform_bronze_to_silver(
-        self,
-        context: PipelineContext,
-        record: BronzeRecord,
-    ) -> SilverRecord | None:
-        """Transform raw ChEMBL assay to normalized format using Domain Entity."""
-        return await self._transformer.transform(context, record)
+        Args:
+            config: Pipeline configuration.
+            runtime: Runtime configuration.
+            services: Injected services (ports).
+            run_id: Unique identifier for this pipeline run.
+            transformer: Injected transformer (DI). If None, creates fallback.
 
+        """
+        # Create fallback transformer if not injected (backward compatibility)
+        if transformer is None:
+            from bioetl.application.pipelines.chembl.assay_transformer import (
+                AssayTransformer,
+            )
+
+            transformer = AssayTransformer(provider=config.provider)
+
+        super().__init__(config, runtime, services, run_id, transformer=transformer)
+
+    # transform_bronze_to_silver() is inherited from BasePipeline
     # should_write_gold() is inherited from BasePipeline (uses config.gold_filters)

--- a/src/bioetl/application/pipelines/chembl/document.py
+++ b/src/bioetl/application/pipelines/chembl/document.py
@@ -5,6 +5,8 @@ Bronze → Silver → Gold layers.
 
 Entity: Scientific Documents (publications, patents)
 Provider: ChEMBL (https://www.ebi.ac.uk/chembl/)
+
+Updated: Transformer injection via DI (Phase 1 refactoring).
 """
 
 from __future__ import annotations
@@ -12,17 +14,20 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from bioetl.application.core.base import BasePipeline
-from bioetl.application.pipelines.chembl.document_transformer import DocumentTransformer
 
 if TYPE_CHECKING:
+    from bioetl.application.core.base_transformer import BaseTransformer
     from bioetl.application.core.pipeline_services import PipelineServices
     from bioetl.domain.config import PipelineConfig, RuntimeConfig
-    from bioetl.domain.context import PipelineContext
-    from bioetl.domain.types import BronzeRecord, RunID, SilverRecord
+    from bioetl.domain.types import RunID
 
 
 class ChEMBLDocumentPipeline(BasePipeline):
-    """Pipeline for ChEMBL document data."""
+    """Pipeline for ChEMBL document data.
+
+    Transformer is injected via DI from GenericPipelineFactory.
+    Fallback to local creation for backward compatibility with tests.
+    """
 
     def __init__(
         self,
@@ -30,17 +35,27 @@ class ChEMBLDocumentPipeline(BasePipeline):
         runtime: RuntimeConfig,
         services: PipelineServices,
         run_id: RunID,
+        transformer: "BaseTransformer | None" = None,
     ) -> None:
-        """Initialize pipeline with transformer."""
-        super().__init__(config, runtime, services, run_id)
-        self._transformer = DocumentTransformer(provider=self.provider)
+        """Initialize pipeline with optional transformer.
 
-    async def transform_bronze_to_silver(
-        self,
-        context: PipelineContext,
-        record: BronzeRecord,
-    ) -> SilverRecord | None:
-        """Transform raw ChEMBL document to normalized format using Domain Entity."""
-        return await self._transformer.transform(context, record)
+        Args:
+            config: Pipeline configuration.
+            runtime: Runtime configuration.
+            services: Injected services (ports).
+            run_id: Unique identifier for this pipeline run.
+            transformer: Injected transformer (DI). If None, creates fallback.
 
+        """
+        # Create fallback transformer if not injected (backward compatibility)
+        if transformer is None:
+            from bioetl.application.pipelines.chembl.document_transformer import (
+                DocumentTransformer,
+            )
+
+            transformer = DocumentTransformer(provider=config.provider)
+
+        super().__init__(config, runtime, services, run_id, transformer=transformer)
+
+    # transform_bronze_to_silver() is inherited from BasePipeline
     # should_write_gold() is inherited from BasePipeline (uses config.gold_filters)

--- a/src/bioetl/application/pipelines/chembl/molecule.py
+++ b/src/bioetl/application/pipelines/chembl/molecule.py
@@ -5,6 +5,8 @@ Bronze -> Silver -> Gold layers.
 
 Entity: Chemical Compounds (small molecules, antibodies, etc.)
 Provider: ChEMBL (https://www.ebi.ac.uk/chembl/)
+
+Updated: Transformer injection via DI (Phase 1 refactoring).
 """
 
 from __future__ import annotations
@@ -12,17 +14,20 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from bioetl.application.core.base import BasePipeline
-from bioetl.application.pipelines.chembl.molecule_transformer import MoleculeTransformer
 
 if TYPE_CHECKING:
+    from bioetl.application.core.base_transformer import BaseTransformer
     from bioetl.application.core.pipeline_services import PipelineServices
     from bioetl.domain.config import PipelineConfig, RuntimeConfig
-    from bioetl.domain.context import PipelineContext
-    from bioetl.domain.types import BronzeRecord, RunID, SilverRecord
+    from bioetl.domain.types import RunID
 
 
 class ChEMBLMoleculePipeline(BasePipeline):
-    """Pipeline for ChEMBL molecule data."""
+    """Pipeline for ChEMBL molecule data.
+
+    Transformer is injected via DI from GenericPipelineFactory.
+    Fallback to local creation for backward compatibility with tests.
+    """
 
     def __init__(
         self,
@@ -30,17 +35,27 @@ class ChEMBLMoleculePipeline(BasePipeline):
         runtime: RuntimeConfig,
         services: PipelineServices,
         run_id: RunID,
+        transformer: "BaseTransformer | None" = None,
     ) -> None:
-        """Initialize pipeline with transformer."""
-        super().__init__(config, runtime, services, run_id)
-        self._transformer = MoleculeTransformer(provider=self.provider)
+        """Initialize pipeline with optional transformer.
 
-    async def transform_bronze_to_silver(
-        self,
-        context: PipelineContext,
-        record: BronzeRecord,
-    ) -> SilverRecord | None:
-        """Transform raw ChEMBL molecule to normalized format using Domain Entity."""
-        return await self._transformer.transform(context, record)
+        Args:
+            config: Pipeline configuration.
+            runtime: Runtime configuration.
+            services: Injected services (ports).
+            run_id: Unique identifier for this pipeline run.
+            transformer: Injected transformer (DI). If None, creates fallback.
 
+        """
+        # Create fallback transformer if not injected (backward compatibility)
+        if transformer is None:
+            from bioetl.application.pipelines.chembl.molecule_transformer import (
+                MoleculeTransformer,
+            )
+
+            transformer = MoleculeTransformer(provider=config.provider)
+
+        super().__init__(config, runtime, services, run_id, transformer=transformer)
+
+    # transform_bronze_to_silver() is inherited from BasePipeline
     # should_write_gold() is inherited from BasePipeline (uses config.gold_filters)

--- a/src/bioetl/application/pipelines/chembl/target.py
+++ b/src/bioetl/application/pipelines/chembl/target.py
@@ -5,6 +5,8 @@ Bronze → Silver → Gold layers.
 
 Entity: Biological Targets (proteins, complexes, organisms)
 Provider: ChEMBL (https://www.ebi.ac.uk/chembl/)
+
+Updated: Transformer injection via DI (Phase 1 refactoring).
 """
 
 from __future__ import annotations
@@ -12,17 +14,20 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from bioetl.application.core.base import BasePipeline
-from bioetl.application.pipelines.chembl.target_transformer import TargetTransformer
 
 if TYPE_CHECKING:
+    from bioetl.application.core.base_transformer import BaseTransformer
     from bioetl.application.core.pipeline_services import PipelineServices
     from bioetl.domain.config import PipelineConfig, RuntimeConfig
-    from bioetl.domain.context import PipelineContext
-    from bioetl.domain.types import BronzeRecord, RunID, SilverRecord
+    from bioetl.domain.types import RunID
 
 
 class ChEMBLTargetPipeline(BasePipeline):
-    """Pipeline for ChEMBL target data."""
+    """Pipeline for ChEMBL target data.
+
+    Transformer is injected via DI from GenericPipelineFactory.
+    Fallback to local creation for backward compatibility with tests.
+    """
 
     def __init__(
         self,
@@ -30,17 +35,27 @@ class ChEMBLTargetPipeline(BasePipeline):
         runtime: RuntimeConfig,
         services: PipelineServices,
         run_id: RunID,
+        transformer: "BaseTransformer | None" = None,
     ) -> None:
-        """Initialize pipeline with transformer."""
-        super().__init__(config, runtime, services, run_id)
-        self._transformer = TargetTransformer(provider=self.provider)
+        """Initialize pipeline with optional transformer.
 
-    async def transform_bronze_to_silver(
-        self,
-        context: PipelineContext,
-        record: BronzeRecord,
-    ) -> SilverRecord | None:
-        """Transform raw ChEMBL target to normalized format using Domain Entity."""
-        return await self._transformer.transform(context, record)
+        Args:
+            config: Pipeline configuration.
+            runtime: Runtime configuration.
+            services: Injected services (ports).
+            run_id: Unique identifier for this pipeline run.
+            transformer: Injected transformer (DI). If None, creates fallback.
 
+        """
+        # Create fallback transformer if not injected (backward compatibility)
+        if transformer is None:
+            from bioetl.application.pipelines.chembl.target_transformer import (
+                TargetTransformer,
+            )
+
+            transformer = TargetTransformer(provider=config.provider)
+
+        super().__init__(config, runtime, services, run_id, transformer=transformer)
+
+    # transform_bronze_to_silver() is inherited from BasePipeline
     # should_write_gold() is inherited from BasePipeline (uses config.gold_filters)

--- a/src/bioetl/application/pipelines/chembl/target_component.py
+++ b/src/bioetl/application/pipelines/chembl/target_component.py
@@ -5,6 +5,8 @@ Bronze → Silver → Gold layers.
 
 Entity: Target Components (protein sequences, etc.)
 Provider: ChEMBL (https://www.ebi.ac.uk/chembl/)
+
+Updated: Transformer injection via DI (Phase 1 refactoring).
 """
 
 from __future__ import annotations
@@ -12,19 +14,20 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from bioetl.application.core.base import BasePipeline
-from bioetl.application.pipelines.chembl.target_component_transformer import (
-    TargetComponentTransformer,
-)
 
 if TYPE_CHECKING:
+    from bioetl.application.core.base_transformer import BaseTransformer
     from bioetl.application.core.pipeline_services import PipelineServices
     from bioetl.domain.config import PipelineConfig, RuntimeConfig
-    from bioetl.domain.context import PipelineContext
-    from bioetl.domain.types import BronzeRecord, RunID, SilverRecord
+    from bioetl.domain.types import RunID
 
 
 class ChEMBLTargetComponentPipeline(BasePipeline):
-    """Pipeline for ChEMBL target component data."""
+    """Pipeline for ChEMBL target component data.
+
+    Transformer is injected via DI from GenericPipelineFactory.
+    Fallback to local creation for backward compatibility with tests.
+    """
 
     def __init__(
         self,
@@ -32,17 +35,27 @@ class ChEMBLTargetComponentPipeline(BasePipeline):
         runtime: RuntimeConfig,
         services: PipelineServices,
         run_id: RunID,
+        transformer: "BaseTransformer | None" = None,
     ) -> None:
-        """Initialize pipeline with transformer."""
-        super().__init__(config, runtime, services, run_id)
-        self._transformer = TargetComponentTransformer(provider=self.provider)
+        """Initialize pipeline with optional transformer.
 
-    async def transform_bronze_to_silver(
-        self,
-        context: PipelineContext,
-        record: BronzeRecord,
-    ) -> SilverRecord | None:
-        """Transform raw ChEMBL target component to normalized format using Domain Entity."""
-        return await self._transformer.transform(context, record)
+        Args:
+            config: Pipeline configuration.
+            runtime: Runtime configuration.
+            services: Injected services (ports).
+            run_id: Unique identifier for this pipeline run.
+            transformer: Injected transformer (DI). If None, creates fallback.
 
+        """
+        # Create fallback transformer if not injected (backward compatibility)
+        if transformer is None:
+            from bioetl.application.pipelines.chembl.target_component_transformer import (
+                TargetComponentTransformer,
+            )
+
+            transformer = TargetComponentTransformer(provider=config.provider)
+
+        super().__init__(config, runtime, services, run_id, transformer=transformer)
+
+    # transform_bronze_to_silver() is inherited from BasePipeline
     # should_write_gold() is inherited from BasePipeline (uses config.gold_filters)

--- a/src/bioetl/application/pipelines/pubchem/compound.py
+++ b/src/bioetl/application/pipelines/pubchem/compound.py
@@ -1,27 +1,54 @@
-"""PubChem Compound Pipeline Implementation."""
+"""PubChem Compound Pipeline Implementation.
+
+Updated: Transformer injection via DI (Phase 1 refactoring).
+"""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from bioetl.application.core.base import BasePipeline
-from bioetl.application.pipelines.pubchem.transformer import PubChemCompoundTransformer
 
 if TYPE_CHECKING:
-    from bioetl.domain.context import PipelineContext
-    from bioetl.domain.types import BronzeRecord, SilverRecord
+    from bioetl.application.core.base_transformer import BaseTransformer
+    from bioetl.application.core.pipeline_services import PipelineServices
+    from bioetl.domain.config import PipelineConfig, RuntimeConfig
+    from bioetl.domain.types import RunID
 
 
 class PubChemCompoundPipeline(BasePipeline):
-    """Pipeline for processing PubChem compounds."""
+    """Pipeline for processing PubChem compounds.
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Initialize PubChem compound pipeline."""
-        super().__init__(*args, **kwargs)
-        self._transformer = PubChemCompoundTransformer(provider=self.provider)
+    Transformer is injected via DI from GenericPipelineFactory.
+    Fallback to local creation for backward compatibility with tests.
+    """
 
-    async def transform_bronze_to_silver(
-        self, context: PipelineContext, record: BronzeRecord
-    ) -> SilverRecord | None:
-        """Transform raw PubChem record to Silver format."""
-        return await self._transformer.transform(context, record)
+    def __init__(
+        self,
+        config: PipelineConfig,
+        runtime: RuntimeConfig,
+        services: PipelineServices,
+        run_id: RunID,
+        transformer: "BaseTransformer | None" = None,
+    ) -> None:
+        """Initialize PubChem compound pipeline.
+
+        Args:
+            config: Pipeline configuration.
+            runtime: Runtime configuration.
+            services: Injected services (ports).
+            run_id: Unique identifier for this pipeline run.
+            transformer: Injected transformer (DI). If None, creates fallback.
+
+        """
+        # Create fallback transformer if not injected (backward compatibility)
+        if transformer is None:
+            from bioetl.application.pipelines.pubchem.transformer import (
+                PubChemCompoundTransformer,
+            )
+
+            transformer = PubChemCompoundTransformer(provider=config.provider)
+
+        super().__init__(config, runtime, services, run_id, transformer=transformer)
+
+    # transform_bronze_to_silver() is inherited from BasePipeline

--- a/src/bioetl/application/pipelines/pubmed/publications.py
+++ b/src/bioetl/application/pipelines/pubmed/publications.py
@@ -1,28 +1,55 @@
 # src/bioetl/application/pipelines/pubmed/publications.py
+"""PubMed Publications Pipeline.
+
+Updated: Transformer injection via DI (Phase 1 refactoring).
+"""
+
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from bioetl.application.core.base import BasePipeline
-from bioetl.application.pipelines.pubmed.transformer import PubMedPublicationTransformer
 
 if TYPE_CHECKING:
-    from bioetl.domain.context import PipelineContext
-    from bioetl.domain.types import BronzeRecord, SilverRecord
+    from bioetl.application.core.base_transformer import BaseTransformer
+    from bioetl.application.core.pipeline_services import PipelineServices
+    from bioetl.domain.config import PipelineConfig, RuntimeConfig
+    from bioetl.domain.types import RunID
 
 
 class PubMedPublicationsPipeline(BasePipeline):
-    """Пайплайн для данных о публикациях из PubMed."""
+    """Пайплайн для данных о публикациях из PubMed.
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Initialize PubMed publications pipeline."""
-        super().__init__(*args, **kwargs)
-        self._transformer = PubMedPublicationTransformer(provider=self.provider)
+    Transformer is injected via DI from GenericPipelineFactory.
+    Fallback to local creation for backward compatibility with tests.
+    """
 
-    async def transform_bronze_to_silver(
+    def __init__(
         self,
-        context: PipelineContext,
-        record: BronzeRecord,
-    ) -> SilverRecord | None:
-        """Трансформирует сырую XML-запись в формат Silver."""
-        return await self._transformer.transform(context, record)
+        config: PipelineConfig,
+        runtime: RuntimeConfig,
+        services: PipelineServices,
+        run_id: RunID,
+        transformer: "BaseTransformer | None" = None,
+    ) -> None:
+        """Initialize PubMed publications pipeline.
+
+        Args:
+            config: Pipeline configuration.
+            runtime: Runtime configuration.
+            services: Injected services (ports).
+            run_id: Unique identifier for this pipeline run.
+            transformer: Injected transformer (DI). If None, creates fallback.
+
+        """
+        # Create fallback transformer if not injected (backward compatibility)
+        if transformer is None:
+            from bioetl.application.pipelines.pubmed.transformer import (
+                PubMedPublicationTransformer,
+            )
+
+            transformer = PubMedPublicationTransformer(provider=config.provider)
+
+        super().__init__(config, runtime, services, run_id, transformer=transformer)
+
+    # transform_bronze_to_silver() is inherited from BasePipeline

--- a/src/bioetl/application/pipelines/uniprot/protein.py
+++ b/src/bioetl/application/pipelines/uniprot/protein.py
@@ -1,27 +1,54 @@
-"""UniProt Protein Pipeline Implementation."""
+"""UniProt Protein Pipeline Implementation.
+
+Updated: Transformer injection via DI (Phase 1 refactoring).
+"""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from bioetl.application.core.base import BasePipeline
-from bioetl.application.pipelines.uniprot.transformer import UniProtProteinTransformer
 
 if TYPE_CHECKING:
-    from bioetl.domain.context import PipelineContext
-    from bioetl.domain.types import BronzeRecord, SilverRecord
+    from bioetl.application.core.base_transformer import BaseTransformer
+    from bioetl.application.core.pipeline_services import PipelineServices
+    from bioetl.domain.config import PipelineConfig, RuntimeConfig
+    from bioetl.domain.types import RunID
 
 
 class UniProtProteinPipeline(BasePipeline):
-    """Pipeline for processing UniProt proteins."""
+    """Pipeline for processing UniProt proteins.
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Initialize UniProt protein pipeline."""
-        super().__init__(*args, **kwargs)
-        self._transformer = UniProtProteinTransformer(provider=self.provider)
+    Transformer is injected via DI from GenericPipelineFactory.
+    Fallback to local creation for backward compatibility with tests.
+    """
 
-    async def transform_bronze_to_silver(
-        self, context: PipelineContext, record: BronzeRecord
-    ) -> SilverRecord | None:
-        """Transform raw UniProt record to Silver format."""
-        return await self._transformer.transform(context, record)
+    def __init__(
+        self,
+        config: PipelineConfig,
+        runtime: RuntimeConfig,
+        services: PipelineServices,
+        run_id: RunID,
+        transformer: "BaseTransformer | None" = None,
+    ) -> None:
+        """Initialize UniProt protein pipeline.
+
+        Args:
+            config: Pipeline configuration.
+            runtime: Runtime configuration.
+            services: Injected services (ports).
+            run_id: Unique identifier for this pipeline run.
+            transformer: Injected transformer (DI). If None, creates fallback.
+
+        """
+        # Create fallback transformer if not injected (backward compatibility)
+        if transformer is None:
+            from bioetl.application.pipelines.uniprot.transformer import (
+                UniProtProteinTransformer,
+            )
+
+            transformer = UniProtProteinTransformer(provider=config.provider)
+
+        super().__init__(config, runtime, services, run_id, transformer=transformer)
+
+    # transform_bronze_to_silver() is inherited from BasePipeline

--- a/src/bioetl/composition/factories/__init__.py
+++ b/src/bioetl/composition/factories/__init__.py
@@ -41,6 +41,14 @@ from bioetl.composition.factories.storage_factory import (
     StorageFactory,
 )
 
+# Transformer factory (DI for transformers)
+from bioetl.composition.factories.transformer_factory import (
+    create_transformer,
+    get_transformer_class,
+    register_all_transformers,
+    register_transformer,
+)
+
 __all__ = [
     "DataSourceCreator",
     "DataSourceFactory",
@@ -51,7 +59,11 @@ __all__ = [
     "StorageFactory",
     "chembl_activity_factory",
     "create_pipeline_factory",
+    "create_transformer",
+    "get_transformer_class",
     "pubchem_compound_factory",
     "pubmed_publications_factory",
+    "register_all_transformers",
+    "register_transformer",
     "uniprot_protein_factory",
 ]

--- a/src/bioetl/composition/factories/generic_factory.py
+++ b/src/bioetl/composition/factories/generic_factory.py
@@ -2,6 +2,8 @@
 
 Provides a configurable factory that eliminates the need for boilerplate subclasses.
 Pipelines can be registered declaratively using configuration rather than class inheritance.
+
+Updated: Transformer injection via DI (Phase 1 refactoring).
 """
 
 from __future__ import annotations
@@ -29,6 +31,7 @@ if TYPE_CHECKING:
     import structlog
 
     from bioetl.application.core.base import BasePipeline
+    from bioetl.application.core.base_transformer import BaseTransformer
     from bioetl.application.core.pipeline_services import PipelineServices
     from bioetl.composition.observability import ObservabilityBundle
     from bioetl.domain.config import RuntimeConfig
@@ -76,6 +79,7 @@ class GenericPipelineFactory(Generic[TPipeline]):
         silver_schema: pa.Schema | None = None,
         gold_schema: Any = None,
         data_source_creator: DataSourceCreator | None = None,
+        transformer_class: type["BaseTransformer"] | None = None,
     ) -> None:
         """Initialize the factory.
 
@@ -87,6 +91,9 @@ class GenericPipelineFactory(Generic[TPipeline]):
             gold_schema: Pandera schema for Gold layer validation (required)
             data_source_creator: Optional custom creator function. If not provided,
                 uses DataSourceRegistry.get(provider)
+            transformer_class: Transformer class for Bronze→Silver transformation.
+                If provided, factory will create and inject transformer into pipeline.
+                This is the preferred DI approach.
 
         Raises:
             ValueError: If gold_schema is not provided
@@ -101,11 +108,22 @@ class GenericPipelineFactory(Generic[TPipeline]):
         self.provider = provider
         self.silver_schema = silver_schema
         self.gold_schema = gold_schema
+        self.transformer_class = transformer_class
 
         # Use custom creator or look up from registry
         self._create_data_source = data_source_creator or DataSourceRegistry.get(
             provider
         )
+
+    def create_transformer(self) -> "BaseTransformer | None":
+        """Create transformer instance if transformer_class is configured.
+
+        Returns:
+            Transformer instance or None if no transformer_class configured.
+        """
+        if self.transformer_class is None:
+            return None
+        return self.transformer_class(provider=self.provider)
 
     def create_data_source(
         self,
@@ -179,6 +197,7 @@ class GenericPipelineFactory(Generic[TPipeline]):
         """Create pipeline instance.
 
         Loads config once and reuses it for both services and pipeline.
+        If transformer_class is configured, creates and injects transformer via DI.
 
         Args:
             run_id: Unique identifier for this pipeline run (from CLI/orchestrator)
@@ -206,11 +225,15 @@ class GenericPipelineFactory(Generic[TPipeline]):
 
         domain_config = yaml_config_to_domain(yaml_config)
 
+        # Create transformer via DI if configured
+        transformer = self.create_transformer()
+
         return self.pipeline_class.create(
             run_id=run_id,
             runtime=runtime,
             services=services,
             config=domain_config,
+            transformer=transformer,
         )
 
     def create_runner(
@@ -354,6 +377,7 @@ def create_pipeline_factory(
     provider: str,
     silver_schema: pa.Schema | None = None,
     gold_schema: Any = None,
+    transformer_class: type["BaseTransformer"] | None = None,
 ) -> GenericPipelineFactory[TPipeline]:
     """Convenience function for creating pipeline factories.
 
@@ -363,6 +387,7 @@ def create_pipeline_factory(
         provider: Data source provider name
         silver_schema: Optional Silver layer schema
         gold_schema: Pandera schema for Gold layer validation (required)
+        transformer_class: Transformer class for Bronze→Silver transformation (DI)
 
     Returns:
         Configured GenericPipelineFactory
@@ -373,6 +398,7 @@ def create_pipeline_factory(
         ...     pipeline_class=ChEMBLActivityPipeline,
         ...     provider="chembl",
         ...     silver_schema=CHEMBL_ACTIVITY_SCHEMA,
+        ...     transformer_class=ActivityTransformer,
         ... )
     """
     return GenericPipelineFactory(
@@ -381,4 +407,5 @@ def create_pipeline_factory(
         provider=provider,
         silver_schema=silver_schema,
         gold_schema=gold_schema,
+        transformer_class=transformer_class,
     )

--- a/src/bioetl/composition/factories/pipeline_factories.py
+++ b/src/bioetl/composition/factories/pipeline_factories.py
@@ -4,22 +4,36 @@
 This module creates all pipeline factories using the GenericPipelineFactory
 pattern. Registration is explicit via register_all_pipelines().
 
+Updated: Transformer injection via DI (Phase 1 refactoring).
+All factories now include transformer_class for proper DI.
+
 Usage:
     >>> from bioetl.composition.factories.pipeline_factories import register_all_pipelines
     >>> register_all_pipelines()  # Call once at application startup
 """
 
 from bioetl.application.pipelines.chembl.activity import ChEMBLActivityPipeline
+from bioetl.application.pipelines.chembl.activity_transformer import ActivityTransformer
 from bioetl.application.pipelines.chembl.assay import ChEMBLAssayPipeline
+from bioetl.application.pipelines.chembl.assay_transformer import AssayTransformer
 from bioetl.application.pipelines.chembl.document import ChEMBLDocumentPipeline
+from bioetl.application.pipelines.chembl.document_transformer import DocumentTransformer
 from bioetl.application.pipelines.chembl.molecule import ChEMBLMoleculePipeline
+from bioetl.application.pipelines.chembl.molecule_transformer import MoleculeTransformer
 from bioetl.application.pipelines.chembl.target import ChEMBLTargetPipeline
 from bioetl.application.pipelines.chembl.target_component import (
     ChEMBLTargetComponentPipeline,
 )
+from bioetl.application.pipelines.chembl.target_component_transformer import (
+    TargetComponentTransformer,
+)
+from bioetl.application.pipelines.chembl.target_transformer import TargetTransformer
 from bioetl.application.pipelines.pubchem.compound import PubChemCompoundPipeline
+from bioetl.application.pipelines.pubchem.transformer import PubChemCompoundTransformer
 from bioetl.application.pipelines.pubmed.publications import PubMedPublicationsPipeline
+from bioetl.application.pipelines.pubmed.transformer import PubMedPublicationTransformer
 from bioetl.application.pipelines.uniprot.protein import UniProtProteinPipeline
+from bioetl.application.pipelines.uniprot.transformer import UniProtProteinTransformer
 from bioetl.composition.factories.generic_factory import GenericPipelineFactory
 from bioetl.composition.registry import PipelineRegistry
 from bioetl.infrastructure.schemas.gold import (
@@ -55,6 +69,7 @@ chembl_activity_factory = GenericPipelineFactory(
     provider="chembl",
     silver_schema=CHEMBL_ACTIVITY_SCHEMA,
     gold_schema=ChEMBLActivityGoldSchema,
+    transformer_class=ActivityTransformer,
 )
 
 # ChEMBL Assay Pipeline
@@ -64,6 +79,7 @@ chembl_assay_factory = GenericPipelineFactory(
     provider="chembl",
     silver_schema=CHEMBL_ASSAY_SCHEMA,
     gold_schema=ChEMBLAssayGoldSchema,
+    transformer_class=AssayTransformer,
 )
 
 # ChEMBL Document Pipeline
@@ -73,6 +89,7 @@ chembl_document_factory = GenericPipelineFactory(
     provider="chembl",
     silver_schema=CHEMBL_DOCUMENT_SCHEMA,
     gold_schema=ChEMBLDocumentGoldSchema,
+    transformer_class=DocumentTransformer,
 )
 
 # ChEMBL Target Pipeline
@@ -82,6 +99,7 @@ chembl_target_factory = GenericPipelineFactory(
     provider="chembl",
     silver_schema=CHEMBL_TARGET_SCHEMA,
     gold_schema=ChEMBLTargetGoldSchema,
+    transformer_class=TargetTransformer,
 )
 
 # ChEMBL Target Component Pipeline
@@ -91,6 +109,7 @@ chembl_target_component_factory = GenericPipelineFactory(
     provider="chembl",
     silver_schema=CHEMBL_TARGET_COMPONENT_SCHEMA,
     gold_schema=ChEMBLTargetComponentGoldSchema,
+    transformer_class=TargetComponentTransformer,
 )
 
 # ChEMBL Molecule Pipeline
@@ -100,6 +119,7 @@ chembl_molecule_factory = GenericPipelineFactory(
     provider="chembl",
     silver_schema=CHEMBL_MOLECULE_SCHEMA,
     gold_schema=ChEMBLMoleculeGoldSchema,
+    transformer_class=MoleculeTransformer,
 )
 
 # PubChem Compound Pipeline
@@ -109,6 +129,7 @@ pubchem_compound_factory = GenericPipelineFactory(
     provider="pubchem",
     silver_schema=PUBCHEM_COMPOUND_SCHEMA,
     gold_schema=PubChemCompoundGoldSchema,
+    transformer_class=PubChemCompoundTransformer,
 )
 
 # UniProt Protein Pipeline
@@ -118,6 +139,7 @@ uniprot_protein_factory = GenericPipelineFactory(
     provider="uniprot",
     silver_schema=UNIPROT_PROTEIN_SCHEMA,
     gold_schema=UniProtProteinGoldSchema,
+    transformer_class=UniProtProteinTransformer,
 )
 
 # PubMed Publications Pipeline
@@ -127,6 +149,7 @@ pubmed_publications_factory = GenericPipelineFactory(
     provider="pubmed",
     silver_schema=PUBMED_PUBLICATION_SCHEMA,
     gold_schema=PubMedPublicationGoldSchema,
+    transformer_class=PubMedPublicationTransformer,
 )
 
 

--- a/src/bioetl/composition/factories/transformer_factory.py
+++ b/src/bioetl/composition/factories/transformer_factory.py
@@ -1,0 +1,144 @@
+# src/bioetl/composition/factories/transformer_factory.py
+"""Transformer Factory for DI-based transformer creation.
+
+This module provides factory functions for creating transformers,
+enabling Dependency Injection instead of creating transformers inside pipelines.
+
+Usage:
+    >>> from bioetl.composition.factories.transformer_factory import create_transformer
+    >>> transformer = create_transformer("chembl", "activity")
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bioetl.application.core.base_transformer import BaseTransformer
+
+# Mapping of (provider, entity_type) to transformer class
+_TRANSFORMER_REGISTRY: dict[tuple[str, str], type["BaseTransformer"]] = {}
+
+
+def register_transformer(
+    provider: str,
+    entity_type: str,
+    transformer_class: type["BaseTransformer"],
+) -> None:
+    """Register a transformer class for a provider/entity combination.
+
+    Args:
+        provider: Provider name (e.g., 'chembl', 'pubchem').
+        entity_type: Entity type (e.g., 'activity', 'compound').
+        transformer_class: The transformer class to register.
+
+    """
+    _TRANSFORMER_REGISTRY[(provider, entity_type)] = transformer_class
+
+
+def create_transformer(provider: str, entity_type: str) -> "BaseTransformer":
+    """Create a transformer instance for the given provider and entity type.
+
+    This is the main factory function for creating transformers via DI.
+    Uses the transformer registry to find the appropriate class.
+
+    Args:
+        provider: Provider name (e.g., 'chembl', 'pubchem').
+        entity_type: Entity type (e.g., 'activity', 'compound').
+
+    Returns:
+        Configured transformer instance.
+
+    Raises:
+        KeyError: If no transformer is registered for the provider/entity combination.
+
+    Example:
+        >>> transformer = create_transformer("chembl", "activity")
+        >>> isinstance(transformer, ActivityTransformer)
+        True
+
+    """
+    key = (provider, entity_type)
+    if key not in _TRANSFORMER_REGISTRY:
+        raise KeyError(
+            f"No transformer registered for provider='{provider}', "
+            f"entity_type='{entity_type}'. "
+            f"Available: {list(_TRANSFORMER_REGISTRY.keys())}"
+        )
+
+    transformer_class = _TRANSFORMER_REGISTRY[key]
+    return transformer_class(provider=provider)
+
+
+def get_transformer_class(
+    provider: str,
+    entity_type: str,
+) -> type["BaseTransformer"] | None:
+    """Get transformer class without instantiating.
+
+    Args:
+        provider: Provider name.
+        entity_type: Entity type.
+
+    Returns:
+        Transformer class if registered, None otherwise.
+
+    """
+    return _TRANSFORMER_REGISTRY.get((provider, entity_type))
+
+
+def register_all_transformers() -> None:
+    """Register all known transformers.
+
+    Called during application startup to populate the registry.
+    Idempotent - safe to call multiple times.
+    """
+    # Import here to avoid circular imports
+    from bioetl.application.pipelines.chembl.activity_transformer import (
+        ActivityTransformer,
+    )
+    from bioetl.application.pipelines.chembl.assay_transformer import AssayTransformer
+    from bioetl.application.pipelines.chembl.document_transformer import (
+        DocumentTransformer,
+    )
+    from bioetl.application.pipelines.chembl.molecule_transformer import (
+        MoleculeTransformer,
+    )
+    from bioetl.application.pipelines.chembl.target_component_transformer import (
+        TargetComponentTransformer,
+    )
+    from bioetl.application.pipelines.chembl.target_transformer import TargetTransformer
+    from bioetl.application.pipelines.pubchem.transformer import (
+        PubChemCompoundTransformer,
+    )
+    from bioetl.application.pipelines.pubmed.transformer import (
+        PubMedPublicationTransformer,
+    )
+    from bioetl.application.pipelines.uniprot.transformer import (
+        UniProtProteinTransformer,
+    )
+
+    # ChEMBL transformers
+    register_transformer("chembl", "activity", ActivityTransformer)
+    register_transformer("chembl", "assay", AssayTransformer)
+    register_transformer("chembl", "document", DocumentTransformer)
+    register_transformer("chembl", "molecule", MoleculeTransformer)
+    register_transformer("chembl", "target", TargetTransformer)
+    register_transformer("chembl", "target_component", TargetComponentTransformer)
+
+    # PubChem transformers
+    register_transformer("pubchem", "compound", PubChemCompoundTransformer)
+
+    # UniProt transformers
+    register_transformer("uniprot", "protein", UniProtProteinTransformer)
+
+    # PubMed transformers
+    register_transformer("pubmed", "publications", PubMedPublicationTransformer)
+
+
+__all__ = [
+    "create_transformer",
+    "get_transformer_class",
+    "register_all_transformers",
+    "register_transformer",
+]

--- a/src/bioetl/domain/config.py
+++ b/src/bioetl/domain/config.py
@@ -169,6 +169,11 @@ class RuntimeConfig:
     query: str | None = None
     dry_run: bool = False
 
+    # VACUUM automation (Phase 1 refactoring)
+    # When enabled, VACUUM is executed after successful pipeline run
+    vacuum_after_run: bool = False
+    vacuum_retention_days: int = 7
+
     def __post_init__(self) -> None:
         """Validate runtime config."""
         if self.limit is not None and self.limit <= 0:
@@ -180,6 +185,10 @@ class RuntimeConfig:
         if self.lock_wait_timeout <= 0:
             raise ValueError(
                 f"lock_wait_timeout must be positive, got {self.lock_wait_timeout}"
+            )
+        if self.vacuum_retention_days <= 0:
+            raise ValueError(
+                f"vacuum_retention_days must be positive, got {self.vacuum_retention_days}"
             )
 
     @property


### PR DESCRIPTION
Phase 1 of the consolidated refactoring plan:

1. Transformer DI (Critical):
   - Created TransformerFactory in composition/factories/
   - Modified BasePipeline to accept transformer via DI
   - Updated GenericPipelineFactory to create and inject transformers
   - Updated all 9 pipelines (ChEMBL, PubChem, UniProt, PubMed)
   - Pipelines now receive transformers through constructor injection
   - Fallback to local creation for backward compatibility with tests

2. VACUUM Automation (Critical):
   - Added vacuum_after_run and vacuum_retention_days to RuntimeConfig
   - Added _run_vacuum_if_enabled() hook in PipelineRunner
   - VACUUM runs after successful pipeline execution when enabled
   - Metrics tracking for vacuum_files_removed
   - Graceful error handling (warnings, not failures)

This eliminates the DI violation where transformers were created inside pipeline constructors, and automates Delta Lake maintenance.