### PR TITLE
Unify HTTP client across all adapters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,18 +237,32 @@ assert_silver_table_has_records(data_dir, "chembl_activity", expected_min=1)
 
 | Категория | Инструмент | Назначение |
 |-----------|------------|------------|
-| **HTTP** | httpx (async) | HTTP-клиент |
+| **HTTP** | `UnifiedHTTPClient` (httpx) | Унифицированный HTTP-клиент для всех адаптеров |
 | **Data** | Polars, Delta Lake | Обработка, хранение |
 | **Storage** | Локальная ФС | Bronze/Silver/Gold/Checkpoints |
 | **Validation** | Pandera | Валидация схем |
 | **Linting** | Ruff + mypy | Код и типы |
 | **CLI** | Click | Командный интерфейс |
 
+### Унифицированный HTTP-клиент
+
+**Все адаптеры используют единую HTTP-инфраструктуру:**
+
+| Адаптер | Базовый класс | HTTP-клиент |
+|---------|---------------|-------------|
+| ChemblAdapter | `BaseHttpAdapter` | `UnifiedHTTPClient` |
+| UniProtAdapter | `BaseHttpAdapter` | `UnifiedHTTPClient` |
+| PubMedAdapter | `@dataclass` | `UnifiedHTTPClient` |
+| PubChemAdapter | `BaseSyncAdapter` | `pubchempy` + ThreadPool |
+
+**Компоненты:** Rate Limiter, Circuit Breaker, Retry Logic, Metrics.
+
 ### Legacy Wrappers (MUST)
 
-Библиотеки без async (pubchempy, biopython):
+Библиотеки без async (pubchempy) используют `BaseSyncAdapter`:
 ```python
-await loop.run_in_executor(None, func, *args)
+# BaseSyncAdapter автоматически оборачивает sync-вызовы
+await self._run_in_executor(sync_func, *args)
 ```
 
 **Строгий режим:** `BIOETL_STRICT_ERROR_HANDLING=true` → raise, иначе warning

--- a/docs/02-architecture/03-infrastructure-layer.md
+++ b/docs/02-architecture/03-infrastructure-layer.md
@@ -24,10 +24,52 @@
 Создание и настройка адаптеров централизованы в [DataSourceRegistry](05-composition-layer.md#22-factories-фабрики-компонентов) слоя Composition.
 
 **Обязанности адаптера:**
-- Управление HTTP-соединениями (`httpx.AsyncClient`).
+- Управление HTTP-соединениями через `UnifiedHTTPClient`.
 - Обработка специфичных для API ошибок (например, `429 Rate Limit`).
 - Преобразование ответа API в стандартизированный формат (словари Python).
 - Реализация `health_check()` для проверки доступности API.
+
+#### 2.1.1. Унифицированный HTTP-клиент
+
+**Все адаптеры используют унифицированную HTTP-инфраструктуру:**
+
+| Адаптер | Базовый класс | HTTP-клиент | Примечание |
+|---------|---------------|-------------|------------|
+| **ChemblAdapter** | `BaseHttpAdapter` | `UnifiedHTTPClient` | Async HTTP |
+| **UniProtAdapter** | `BaseHttpAdapter` | `UnifiedHTTPClient` | Async HTTP |
+| **PubMedAdapter** | `@dataclass` | `UnifiedHTTPClient` | Async HTTP |
+| **PubChemAdapter** | `BaseSyncAdapter` | `pubchempy` + ThreadPool | Legacy sync библиотека |
+
+**Архитектура HTTP-адаптеров:**
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    DataSourcePort (Protocol)                 │
+└─────────────────────────────────────────────────────────────┘
+                              ▲
+              ┌───────────────┴───────────────┐
+              │                               │
+┌─────────────────────────┐     ┌─────────────────────────┐
+│    BaseHttpAdapter      │     │    BaseSyncAdapter      │
+│  (UnifiedHTTPClient)    │     │  (ThreadPoolExecutor)   │
+└─────────────────────────┘     └─────────────────────────┘
+         ▲                                  ▲
+    ┌────┴────┐                             │
+    │         │                             │
+ChemblAdapter UniProtAdapter          PubChemAdapter
+PubMedAdapter                         (pubchempy)
+```
+
+**Ключевые компоненты `UnifiedHTTPClient`:**
+- **Rate Limiter** (`TokenBucket`): Ограничение частоты запросов
+- **Circuit Breaker**: Защита от каскадных отказов
+- **Retry Logic**: Автоматические повторы с exponential backoff
+- **Metrics**: Интеграция с `MetricsPort` для наблюдаемости
+
+**Для sync-библиотек** (pubchempy, biopython) используется `BaseSyncAdapter`:
+- `ThreadPoolExecutor` для изоляции блокирующего I/O
+- Собственные `TokenBucket` и `CircuitBreaker`
+- Async-обёртка через `run_in_executor()`
 
 ### 2.2. `storage/` — Адаптеры Хранилищ
 

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -364,9 +364,51 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 |--------|------------|--------------|-----------------| 
 | **Оркестрация** | **Prefect** | Simple Runner | <5 DAG-ов — свой Runner (скрипт). Иначе Prefect. | 
 | **Валидация** | **Pandera** | Great Expectations | Pandera нативна для DataFrames, легче интегрируется в CI. | 
-| **HTTP Клиент** | **httpx** | requests | Поддержка `async`. **Legacy Wrappers**: Для библиотек без async поддержки (pubchempy, biopython) обязателен запуск в отдельном пуле потоков: `await loop.run_in_executor(thread_pool, fetch_func)`. | 
-| **Линтер** | **Ruff** | Flake8/Black | Скорость и решение "все-в-одном". | 
- 
+| **HTTP Клиент** | **httpx** via `UnifiedHTTPClient` | requests | Поддержка `async`. Все адаптеры **MUST** использовать `UnifiedHTTPClient` (см. §4.1.1). **Legacy Wrappers**: Для библиотек без async поддержки (pubchempy) — `BaseSyncAdapter` с `ThreadPoolExecutor`. | 
+| **Линтер** | **Ruff** | Flake8/Black | Скорость и решение "все-в-одном". |
+
+### 4.1.1. Унифицированный HTTP-клиент (UnifiedHTTPClient)
+
+**Все HTTP-адаптеры используют единую инфраструктуру для HTTP-запросов.**
+
+| Адаптер | Базовый класс | HTTP-клиент | Статус |
+|---------|---------------|-------------|--------|
+| `ChemblAdapter` | `BaseHttpAdapter` | `UnifiedHTTPClient` | ✅ Унифицирован |
+| `UniProtAdapter` | `BaseHttpAdapter` | `UnifiedHTTPClient` | ✅ Унифицирован |
+| `PubMedAdapter` | `@dataclass` | `UnifiedHTTPClient` | ✅ Унифицирован |
+| `PubChemAdapter` | `BaseSyncAdapter` | `pubchempy` + ThreadPool | ✅ Legacy-обёртка |
+
+**Компоненты `UnifiedHTTPClient`:**
+- **Rate Limiter** (`TokenBucket`): Ограничение частоты запросов по провайдеру
+- **Circuit Breaker**: Защита от каскадных отказов (см. [ADR-007](02-architecture/decisions/ADR-007-circuit-breaker-implementation.md))
+- **Retry Logic**: Exponential backoff с configurable jitter
+- **Metrics Integration**: Автоматический сбор метрик через `MetricsPort`
+
+**Расположение:** `src/bioetl/infrastructure/adapters/http/client.py`
+
+**Создание нового адаптера:**
+```python
+from bioetl.infrastructure.adapters.base import BaseHttpAdapter
+from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
+
+class NewProviderAdapter(BaseHttpAdapter):
+    def __init__(self, http_client: UnifiedHTTPClient, logger: LoggerPort):
+        super().__init__(http_client, logger)
+        self.provider_name = "new_provider"
+```
+
+**Для sync-библиотек** используйте `BaseSyncAdapter`:
+```python
+from bioetl.infrastructure.adapters.sync_base import BaseSyncAdapter
+
+class LegacyAdapter(BaseSyncAdapter):
+    provider_name = "legacy"
+
+    async def fetch(self, ...):
+        # Sync call wrapped in executor
+        result = await self._run_in_executor(sync_library.fetch, query)
+```
+
 ### 4.2. Политика Тестирования
 **Цель покрытия:** >80% line coverage (проверяется в CI через `--cov-fail-under=80`).
 


### PR DESCRIPTION
- Add section 2.1.1 to infrastructure layer docs with adapter table
- Add section 4.1.1 to RULES.md with HTTP client requirements
- Update CLAUDE.md stack section with unified client info
- Document BaseHttpAdapter and BaseSyncAdapter patterns