### PR TITLE
Extract BaseChemblTransformer to reduce duplication

### DIFF
--- a/src/bioetl/application/pipelines/chembl/__init__.py
+++ b/src/bioetl/application/pipelines/chembl/__init__.py
@@ -12,6 +12,9 @@ from bioetl.application.pipelines.chembl.activity_transformer import (
 )
 from bioetl.application.pipelines.chembl.assay import ChEMBLAssayPipeline
 from bioetl.application.pipelines.chembl.assay_transformer import AssayTransformer
+from bioetl.application.pipelines.chembl.base_chembl_transformer import (
+    BaseChemblTransformer,
+)
 from bioetl.application.pipelines.chembl.document import ChEMBLDocumentPipeline
 from bioetl.application.pipelines.chembl.document_transformer import (
     DocumentTransformer,
@@ -30,10 +33,9 @@ from bioetl.application.pipelines.chembl.target_component_transformer import (
 from bioetl.application.pipelines.chembl.target_transformer import TargetTransformer
 
 __all__ = [
-    # Transformers
     "ActivityTransformer",
     "AssayTransformer",
-    # Pipelines
+    "BaseChemblTransformer",
     "ChEMBLActivityPipeline",
     "ChEMBLAssayPipeline",
     "ChEMBLDocumentPipeline",

--- a/src/bioetl/application/pipelines/chembl/activity_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/activity_transformer.py
@@ -5,16 +5,17 @@ Transforms Bronze records to Silver format (Activity entity inflation).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
-from bioetl.application.core.base_transformer import BaseTransformer
 from bioetl.application.core.transform_utils import flatten_nested_dict
+from bioetl.application.pipelines.chembl.base_chembl_transformer import (
+    BaseChemblTransformer,
+)
 from bioetl.domain.entities import Activity
-from bioetl.domain.transformations import generate_entity_id, safe_float, safe_int
+from bioetl.domain.transformations import safe_float, safe_int
 
 if TYPE_CHECKING:
-    from bioetl.domain.context import PipelineContext
-    from bioetl.domain.types import BronzeRecord, SilverRecord
+    from bioetl.domain.types import BronzeRecord
 
 
 # Mapping for ligand efficiency fields extraction
@@ -33,12 +34,11 @@ _ACTION_TYPE_FIELDS: dict[str, Any] = {
 }
 
 
-class ActivityTransformer(BaseTransformer):
+class ActivityTransformer(BaseChemblTransformer):
     """Transforms ChEMBL bronze records to silver."""
 
-    def __init__(self, provider: str = "chembl"):
-        """Initialize ChEMBL activity transformer."""
-        super().__init__(provider)
+    entity_class = Activity
+    primary_id_field = "activity_id"
 
     def _extract_ligand_efficiency(
         self, le_data: dict[str, Any] | None
@@ -136,35 +136,27 @@ class ActivityTransformer(BaseTransformer):
             "toid": safe_int(record.get("toid")),
         }
 
-    async def _transform_impl(
+    def _extract_business_data(
         self,
-        context: PipelineContext,
         record: BronzeRecord,
-    ) -> SilverRecord | None:
-        """Transform raw ChEMBL activity to normalized format."""
-        activity_id = self._get_required_field(record, "activity_id")
+        primary_id: Any,
+    ) -> dict[str, Any]:
+        """Extract Activity business data from bronze record.
+
+        Args:
+            record: Raw Bronze record from ChEMBL API.
+            primary_id: Validated activity_id value.
+
+        Returns:
+            Dictionary of Activity business fields.
+
+        """
+        # Validate secondary required field
         molecule_id = self._get_required_field(record, "molecule_chembl_id")
 
-        entity_id = generate_entity_id(
-            record={"activity_id": str(activity_id)},
-            provider=self.provider,
-            id_field="activity_id",
-        )
-
-        business_data: dict[str, Any] = {
-            **self._map_core_identifiers(record, activity_id, molecule_id),
+        return {
+            **self._map_core_identifiers(record, primary_id, molecule_id),
             **self._map_molecule_target_assay(record),
             **self._map_activity_values(record),
             **self._map_quality_annotations(record),
         }
-
-        content_hash = self.compute_content_hash(business_data, exclude_none=True)
-        entity = self._create_entity(
-            Activity,
-            context,
-            entity_id=entity_id,
-            content_hash=content_hash,
-            **business_data,
-        )
-
-        return cast("SilverRecord", self.entity_to_silver_record(entity))

--- a/src/bioetl/application/pipelines/chembl/assay_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/assay_transformer.py
@@ -5,21 +5,21 @@ Transforms Bronze records to Silver format (Assay entity inflation).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
-from bioetl.application.core.base_transformer import BaseTransformer
 from bioetl.application.core.transform_utils import flatten_nested_dict
+from bioetl.application.pipelines.chembl.base_chembl_transformer import (
+    BaseChemblTransformer,
+)
 from bioetl.domain.entities import Assay
 from bioetl.domain.transformations import (
-    generate_entity_id,
     safe_float,
     safe_int,
     safe_str,
 )
 
 if TYPE_CHECKING:
-    from bioetl.domain.context import PipelineContext
-    from bioetl.domain.types import BronzeRecord, SilverRecord
+    from bioetl.domain.types import BronzeRecord
 
 
 # Mapping for variant sequence fields extraction (from ChEMBL nested structure)
@@ -54,12 +54,11 @@ def _extract_variant(data: dict[str, Any] | None) -> dict[str, Any]:
     return flatten_nested_dict(data, "variant_", _VARIANT_FIELDS)
 
 
-class AssayTransformer(BaseTransformer):
+class AssayTransformer(BaseChemblTransformer):
     """Transforms ChEMBL assay bronze records to silver."""
 
-    def __init__(self, provider: str = "chembl"):
-        """Initialize ChEMBL assay transformer."""
-        super().__init__(provider)
+    entity_class = Assay
+    primary_id_field = "assay_chembl_id"
 
     def _map_core_identifiers(
         self, record: BronzeRecord, assay_chembl_id: Any
@@ -117,34 +116,24 @@ class AssayTransformer(BaseTransformer):
             "assay_parameters": self.serialize_json(record.get("assay_parameters")),
         }
 
-    async def _transform_impl(
+    def _extract_business_data(
         self,
-        context: PipelineContext,
         record: BronzeRecord,
-    ) -> SilverRecord | None:
-        """Transform raw ChEMBL assay to normalized format."""
-        assay_chembl_id = self._get_required_field(record, "assay_chembl_id")
+        primary_id: Any,
+    ) -> dict[str, Any]:
+        """Extract Assay business data from bronze record.
 
-        entity_id = generate_entity_id(
-            record={"assay_chembl_id": str(assay_chembl_id)},
-            provider=self.provider,
-            id_field="assay_chembl_id",
-        )
+        Args:
+            record: Raw Bronze record from ChEMBL API.
+            primary_id: Validated assay_chembl_id value.
 
-        business_data: dict[str, Any] = {
-            **self._map_core_identifiers(record, assay_chembl_id),
+        Returns:
+            Dictionary of Assay business fields.
+
+        """
+        return {
+            **self._map_core_identifiers(record, primary_id),
             **self._map_classification_fields(record),
             **self._map_biological_context(record),
             **self._map_metadata_fields(record),
         }
-
-        content_hash = self.compute_content_hash(business_data, exclude_none=True)
-        entity = self._create_entity(
-            Assay,
-            context,
-            entity_id=entity_id,
-            content_hash=content_hash,
-            **business_data,
-        )
-
-        return cast("SilverRecord", self.entity_to_silver_record(entity))

--- a/src/bioetl/application/pipelines/chembl/base_chembl_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/base_chembl_transformer.py
@@ -1,0 +1,141 @@
+"""Base ChEMBL Transformer.
+
+Provides common transformation logic for all ChEMBL entity transformers.
+Implements Template Method pattern to eliminate duplication across:
+- ActivityTransformer
+- AssayTransformer
+- DocumentTransformer
+- MoleculeTransformer
+- TargetTransformer
+- TargetComponentTransformer
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Any, ClassVar, cast
+
+from bioetl.application.core.base_transformer import BaseTransformer
+from bioetl.domain.transformations import generate_entity_id
+
+if TYPE_CHECKING:
+    from bioetl.domain.context import PipelineContext
+    from bioetl.domain.entities import BaseEntity
+    from bioetl.domain.types import BronzeRecord, SilverRecord
+
+
+class BaseChemblTransformer(BaseTransformer):
+    """Base class for all ChEMBL transformers.
+
+    Provides common field extraction and mapping logic.
+    Implements Template Method pattern for unified transformation flow.
+
+    Subclasses MUST define:
+    - `entity_class`: The domain entity class to create
+    - `primary_id_field`: Field name of the primary identifier
+
+    Subclasses MUST implement:
+    - `_extract_business_data()`: Entity-specific field extraction
+
+    Example:
+        >>> class ActivityTransformer(BaseChemblTransformer):
+        ...     entity_class = Activity
+        ...     primary_id_field = "activity_id"
+        ...
+        ...     def _extract_business_data(self, record, primary_id):
+        ...         return {"activity_id": str(primary_id), ...}
+
+    """
+
+    # Class variables that subclasses must override
+    entity_class: ClassVar[type[BaseEntity]]
+    primary_id_field: ClassVar[str]
+
+    def __init__(self, provider: str = "chembl") -> None:
+        """Initialize ChEMBL transformer.
+
+        Args:
+            provider: Data provider identifier. Defaults to 'chembl'.
+
+        """
+        super().__init__(provider)
+
+    async def _transform_impl(
+        self,
+        context: PipelineContext,
+        record: BronzeRecord,
+    ) -> SilverRecord | None:
+        """Template method implementing common ChEMBL transformation flow.
+
+        Steps:
+        1. Validate and extract primary ID
+        2. Generate entity_id using standard format
+        3. Extract business data (delegated to subclass)
+        4. Compute content hash
+        5. Create domain entity
+        6. Convert to SilverRecord
+
+        Args:
+            context: Pipeline context with run_id, run_type, logger.
+            record: Raw Bronze record from ChEMBL API.
+
+        Returns:
+            SilverRecord if transformation successful, None if skipped.
+
+        """
+        # 1. Validate primary ID
+        primary_id = self._get_required_field(record, self.primary_id_field)
+
+        # 2. Generate entity ID
+        entity_id = generate_entity_id(
+            record={self.primary_id_field: str(primary_id)},
+            provider=self.provider,
+            id_field=self.primary_id_field,
+        )
+
+        # 3. Extract business data (delegated to subclass)
+        business_data = self._extract_business_data(record, primary_id)
+
+        # 4. Compute content hash
+        content_hash = self.compute_content_hash(business_data, exclude_none=True)
+
+        # 5. Create domain entity
+        entity = self._create_entity(
+            self.entity_class,
+            context,
+            entity_id=entity_id,
+            content_hash=content_hash,
+            **business_data,
+        )
+
+        # 6. Convert to SilverRecord
+        return cast("SilverRecord", self.entity_to_silver_record(entity))
+
+    @abstractmethod
+    def _extract_business_data(
+        self,
+        record: BronzeRecord,
+        primary_id: Any,
+    ) -> dict[str, Any]:
+        """Extract business data from the bronze record.
+
+        Subclasses MUST implement this method to extract entity-specific fields.
+        The primary_id is already validated and passed for convenience.
+
+        Args:
+            record: Raw Bronze record from ChEMBL API.
+            primary_id: Validated primary identifier value.
+
+        Returns:
+            Dictionary of business data fields for entity creation.
+
+        Example:
+            >>> def _extract_business_data(self, record, primary_id):
+            ...     return {
+            ...         "activity_id": str(primary_id),
+            ...         "molecule_chembl_id": record.get("molecule_chembl_id"),
+            ...         ...
+            ...     }
+
+        """
+        ...

--- a/src/bioetl/application/pipelines/chembl/document_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/document_transformer.py
@@ -5,47 +5,42 @@ Transforms Bronze records to Silver format (Document entity inflation).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
-from bioetl.application.core.base_transformer import BaseTransformer
+from bioetl.application.pipelines.chembl.base_chembl_transformer import (
+    BaseChemblTransformer,
+)
 from bioetl.domain.entities import Document
-from bioetl.domain.transformations import generate_entity_id, safe_int
+from bioetl.domain.transformations import safe_int
 
 if TYPE_CHECKING:
-    from bioetl.domain.context import PipelineContext
-    from bioetl.domain.types import BronzeRecord, SilverRecord
+    from bioetl.domain.types import BronzeRecord
 
 
-class DocumentTransformer(BaseTransformer):
+class DocumentTransformer(BaseChemblTransformer):
     """Transforms ChEMBL bronze document records to silver."""
 
-    def __init__(self, provider: str = "chembl"):
-        """Initialize ChEMBL document transformer.
+    entity_class = Document
+    primary_id_field = "document_chembl_id"
+
+    def _extract_business_data(
+        self,
+        record: BronzeRecord,
+        primary_id: Any,
+    ) -> dict[str, Any]:
+        """Extract Document business data from bronze record.
 
         Args:
-            provider: Data provider identifier.
+            record: Raw Bronze record from ChEMBL API.
+            primary_id: Validated document_chembl_id value.
+
+        Returns:
+            Dictionary of Document business fields.
 
         """
-        super().__init__(provider)
-
-    async def _transform_impl(
-        self,
-        context: PipelineContext,
-        record: BronzeRecord,
-    ) -> SilverRecord | None:
-        """Transform raw ChEMBL document to normalized format using Domain Entity."""
-        # Validate required field
-        document_chembl_id = self._get_required_field(record, "document_chembl_id")
-
-        entity_id = generate_entity_id(
-            record={"document_chembl_id": str(document_chembl_id)},
-            provider=self.provider,
-            id_field="document_chembl_id",
-        )
-
-        business_data: dict[str, Any] = {
+        return {
             # Primary identifier
-            "document_chembl_id": str(document_chembl_id),
+            "document_chembl_id": str(primary_id),
             # Publication identifiers
             "pubmed_id": safe_int(record.get("pubmed_id")),
             "doi": record.get("doi"),
@@ -66,17 +61,3 @@ class DocumentTransformer(BaseTransformer):
             # Source information
             "src_id": safe_int(record.get("src_id")),
         }
-
-        content_hash = self.compute_content_hash(business_data, exclude_none=True)
-
-        # Create entity using helper method
-        entity = self._create_entity(
-            Document,
-            context,
-            entity_id=entity_id,
-            content_hash=content_hash,
-            **business_data,
-        )
-
-        # Convert Entity to SilverRecord for storage
-        return cast("SilverRecord", self.entity_to_silver_record(entity))

--- a/src/bioetl/application/pipelines/chembl/molecule_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/molecule_transformer.py
@@ -5,16 +5,17 @@ Transforms Bronze records to Silver format (Molecule entity inflation).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
-from bioetl.application.core.base_transformer import BaseTransformer
 from bioetl.application.core.transform_utils import flatten_nested_dict
+from bioetl.application.pipelines.chembl.base_chembl_transformer import (
+    BaseChemblTransformer,
+)
 from bioetl.domain.entities import Molecule
-from bioetl.domain.transformations import generate_entity_id, safe_float, safe_int
+from bioetl.domain.transformations import safe_float, safe_int
 
 if TYPE_CHECKING:
-    from bioetl.domain.context import PipelineContext
-    from bioetl.domain.types import BronzeRecord, SilverRecord
+    from bioetl.domain.types import BronzeRecord
 
 
 # Field mappings for molecule nested structures
@@ -70,12 +71,11 @@ def _extract_structures(data: dict[str, Any] | None) -> dict[str, Any]:
     return flatten_nested_dict(data, "structure_", _STRUCTURES_FIELDS)
 
 
-class MoleculeTransformer(BaseTransformer):
+class MoleculeTransformer(BaseChemblTransformer):
     """Transforms ChEMBL bronze molecule records to silver."""
 
-    def __init__(self, provider: str = "chembl"):
-        """Initialize ChEMBL molecule transformer."""
-        super().__init__(provider)
+    entity_class = Molecule
+    primary_id_field = "molecule_chembl_id"
 
     def _map_core_metadata(self, record: BronzeRecord) -> dict[str, Any]:
         """Map core molecule metadata fields."""
@@ -134,22 +134,23 @@ class MoleculeTransformer(BaseTransformer):
             ),
         }
 
-    async def _transform_impl(
+    def _extract_business_data(
         self,
-        context: PipelineContext,
         record: BronzeRecord,
-    ) -> SilverRecord | None:
-        """Transform raw ChEMBL molecule to normalized format."""
-        molecule_chembl_id = self._get_required_field(record, "molecule_chembl_id")
+        primary_id: Any,
+    ) -> dict[str, Any]:
+        """Extract Molecule business data from bronze record.
 
-        entity_id = generate_entity_id(
-            record={"molecule_chembl_id": str(molecule_chembl_id)},
-            provider=self.provider,
-            id_field="molecule_chembl_id",
-        )
+        Args:
+            record: Raw Bronze record from ChEMBL API.
+            primary_id: Validated molecule_chembl_id value.
 
-        business_data: dict[str, Any] = {
-            "molecule_chembl_id": str(molecule_chembl_id),
+        Returns:
+            Dictionary of Molecule business fields.
+
+        """
+        return {
+            "molecule_chembl_id": str(primary_id),
             **self._map_core_metadata(record),
             **self._map_molecule_flags(record),
             **self._map_additional_metadata(record),
@@ -158,14 +159,3 @@ class MoleculeTransformer(BaseTransformer):
             **_extract_properties(record.get("molecule_properties")),
             **_extract_structures(record.get("molecule_structures")),
         }
-
-        content_hash = self.compute_content_hash(business_data, exclude_none=True)
-        entity = self._create_entity(
-            Molecule,
-            context,
-            entity_id=entity_id,
-            content_hash=content_hash,
-            **business_data,
-        )
-
-        return cast("SilverRecord", self.entity_to_silver_record(entity))

--- a/src/bioetl/application/pipelines/chembl/target_component_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/target_component_transformer.py
@@ -5,48 +5,43 @@ Transforms Bronze records to Silver format (Target Component entity inflation).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
-from bioetl.application.core.base_transformer import BaseTransformer
 from bioetl.application.core.transform_utils import extract_list_field
+from bioetl.application.pipelines.chembl.base_chembl_transformer import (
+    BaseChemblTransformer,
+)
 from bioetl.domain.entities import TargetComponent
-from bioetl.domain.transformations import generate_entity_id, safe_int
+from bioetl.domain.transformations import safe_int
 
 if TYPE_CHECKING:
-    from bioetl.domain.context import PipelineContext
-    from bioetl.domain.types import BronzeRecord, SilverRecord
+    from bioetl.domain.types import BronzeRecord
 
 
-class TargetComponentTransformer(BaseTransformer):
+class TargetComponentTransformer(BaseChemblTransformer):
     """Transforms ChEMBL bronze target component records to silver."""
 
-    def __init__(self, provider: str = "chembl"):
-        """Initialize ChEMBL target component transformer.
+    entity_class = TargetComponent
+    primary_id_field = "component_id"
+
+    def _extract_business_data(
+        self,
+        record: BronzeRecord,
+        primary_id: Any,
+    ) -> dict[str, Any]:
+        """Extract TargetComponent business data from bronze record.
 
         Args:
-            provider: Data provider identifier.
+            record: Raw Bronze record from ChEMBL API.
+            primary_id: Validated component_id value.
+
+        Returns:
+            Dictionary of TargetComponent business fields.
 
         """
-        super().__init__(provider)
-
-    async def _transform_impl(
-        self,
-        context: PipelineContext,
-        record: BronzeRecord,
-    ) -> SilverRecord | None:
-        """Transform raw ChEMBL target component to normalized format using Domain Entity."""
-        # Validate required field
-        component_id = self._get_required_field(record, "component_id")
-
-        entity_id = generate_entity_id(
-            record={"component_id": str(component_id)},
-            provider=self.provider,
-            id_field="component_id",
-        )
-
-        business_data: dict[str, Any] = {
+        return {
             # Primary identifier
-            "component_id": safe_int(component_id),
+            "component_id": safe_int(primary_id),
             # Core metadata
             "accession": record.get("accession"),
             "component_type": record.get("component_type"),
@@ -70,17 +65,3 @@ class TargetComponentTransformer(BaseTransformer):
                 safe_int,
             ),
         }
-
-        content_hash = self.compute_content_hash(business_data, exclude_none=True)
-
-        # Create entity using helper method
-        entity = self._create_entity(
-            TargetComponent,
-            context,
-            entity_id=entity_id,
-            content_hash=content_hash,
-            **business_data,
-        )
-
-        # Convert Entity to SilverRecord for storage
-        return cast("SilverRecord", self.entity_to_silver_record(entity))

--- a/src/bioetl/application/pipelines/chembl/target_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/target_transformer.py
@@ -7,92 +7,25 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
 
-from bioetl.application.core.base_transformer import BaseTransformer
 from bioetl.application.core.transform_utils import (
     aggregate_nested_lists,
     extract_list_field,
 )
+from bioetl.application.pipelines.chembl.base_chembl_transformer import (
+    BaseChemblTransformer,
+)
 from bioetl.domain.entities import Target
-from bioetl.domain.transformations import generate_entity_id, safe_int
+from bioetl.domain.transformations import safe_int
 
 if TYPE_CHECKING:
-    from bioetl.domain.context import PipelineContext
-    from bioetl.domain.types import BronzeRecord, SilverRecord
+    from bioetl.domain.types import BronzeRecord
 
 
-class TargetTransformer(BaseTransformer):
+class TargetTransformer(BaseChemblTransformer):
     """Transforms ChEMBL bronze target records to silver."""
 
-    def __init__(self, provider: str = "chembl"):
-        """Initialize ChEMBL target transformer.
-
-        Args:
-            provider: Data provider identifier.
-
-        """
-        super().__init__(provider)
-
-    async def _transform_impl(
-        self,
-        context: PipelineContext,
-        record: BronzeRecord,
-    ) -> SilverRecord | None:
-        """Transform raw ChEMBL target to normalized format using Domain Entity."""
-        # Validate required field
-        target_chembl_id = self._get_required_field(record, "target_chembl_id")
-
-        entity_id = generate_entity_id(
-            record={"target_chembl_id": str(target_chembl_id)},
-            provider=self.provider,
-            id_field="target_chembl_id",
-        )
-
-        # Extract target_components with proper typing
-        target_components = cast(
-            "list[dict[str, Any]] | None", record.get("target_components")
-        )
-
-        # Extract flattened components
-        flattened_components = self._flatten_target_components(target_components)
-
-        business_data: dict[str, Any] = {
-            # Primary identifier
-            "target_chembl_id": str(target_chembl_id),
-            # Core metadata
-            "pref_name": record.get("pref_name"),
-            "target_type": record.get("target_type"),
-            "organism": record.get("organism"),
-            "tax_id": safe_int(record.get("tax_id")),
-            "species_group_flag": record.get("species_group_flag"),
-            "description": record.get("description"),
-            "downgraded": record.get("downgraded"),
-            # Optional fields (present for specific target types)
-            "dap_id": safe_int(record.get("dap_id")),
-            "pipeline_stages": self.serialize_json(record.get("pipeline_stages")),
-            "target_constraints": self.serialize_json(
-                record.get("target_constraints")
-            ),
-            # Complex fields (JSON serialized)
-            "target_components": self.serialize_json(target_components),
-            "target_component_synonyms": self._aggregate_synonyms(target_components),
-            "cross_references": self._aggregate_component_xrefs(target_components),
-            # Flattened components
-            **flattened_components,
-        }
-
-        content_hash = self.compute_content_hash(business_data, exclude_none=True)
-
-        # Create entity using helper method
-        entity = self._create_entity(
-            Target,
-            context,
-            entity_id=entity_id,
-            content_hash=content_hash,
-            **business_data,
-        )
-
-        # Convert Entity to SilverRecord for storage
-        return cast("SilverRecord", self.entity_to_silver_record(entity))
+    entity_class = Target
+    primary_id_field = "target_chembl_id"
 
     def _flatten_target_components(
         self, components: list[dict[str, Any]] | None
@@ -179,3 +112,51 @@ class TargetTransformer(BaseTransformer):
         """
         xrefs = aggregate_nested_lists(components, "target_component_xrefs")
         return self.serialize_json(xrefs) if xrefs else None
+
+    def _extract_business_data(
+        self,
+        record: BronzeRecord,
+        primary_id: Any,
+    ) -> dict[str, Any]:
+        """Extract Target business data from bronze record.
+
+        Args:
+            record: Raw Bronze record from ChEMBL API.
+            primary_id: Validated target_chembl_id value.
+
+        Returns:
+            Dictionary of Target business fields.
+
+        """
+        # Extract target_components with proper typing
+        target_components = cast(
+            "list[dict[str, Any]] | None", record.get("target_components")
+        )
+
+        # Extract flattened components
+        flattened_components = self._flatten_target_components(target_components)
+
+        return {
+            # Primary identifier
+            "target_chembl_id": str(primary_id),
+            # Core metadata
+            "pref_name": record.get("pref_name"),
+            "target_type": record.get("target_type"),
+            "organism": record.get("organism"),
+            "tax_id": safe_int(record.get("tax_id")),
+            "species_group_flag": record.get("species_group_flag"),
+            "description": record.get("description"),
+            "downgraded": record.get("downgraded"),
+            # Optional fields (present for specific target types)
+            "dap_id": safe_int(record.get("dap_id")),
+            "pipeline_stages": self.serialize_json(record.get("pipeline_stages")),
+            "target_constraints": self.serialize_json(
+                record.get("target_constraints")
+            ),
+            # Complex fields (JSON serialized)
+            "target_components": self.serialize_json(target_components),
+            "target_component_synonyms": self._aggregate_synonyms(target_components),
+            "cross_references": self._aggregate_component_xrefs(target_components),
+            # Flattened components
+            **flattened_components,
+        }

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -395,11 +395,13 @@ class TestChemblActivityFactory:
             )
 
             # Verify run_id is passed to pipeline.create()
+            # Note: transformer is created by factory via DI and passed to pipeline
             mock_pipeline_class.create.assert_called_once_with(
                 run_id=run_id,
                 runtime=runtime,
                 services=mock_services,
                 config=mock_domain_config,
+                transformer=ANY,  # Transformer instance created by factory
             )
             assert result is mock_pipeline
         finally:


### PR DESCRIPTION
Extract common transformation logic into BaseChemblTransformer class:
- Template Method pattern for unified transformation flow
- Abstract _extract_business_data method for entity-specific logic
- Class variables entity_class and primary_id_field

All 6 ChEMBL transformers now inherit from BaseChemblTransformer:
- ActivityTransformer
- AssayTransformer
- DocumentTransformer
- MoleculeTransformer
- TargetTransformer
- TargetComponentTransformer

Duplication eliminated:
- Common __init__ with default provider="chembl"
- Unified _transform_impl flow (validate, generate ID, hash, create entity)
- Consistent entity creation pattern

Test updates:
- Fix test_bootstrap.py to expect transformer parameter from factory DI