### PR TITLE
Add architecture test for random in writers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,28 @@ sha256(provider + canonical_json(record))
 | **Completeness** | Все порты экспортированы в `__all__` |
 | **Contracts** | StoragePort, LockPort, CheckpointPort, QuarantinePort методы |
 
+### Тесты детерминизма (REQ-ARCH-030)
+
+Файл `tests/architecture/test_no_random_in_writers.py` проверяет:
+
+| Тест | Проверка |
+|------|----------|
+| `test_no_random_import_in_storage_writers` | Запрет `import random` и `from random import` в storage writers |
+| `test_no_random_uniform_calls_in_storage` | Запрет вызовов `random.uniform()` |
+| `test_no_random_choice_calls_in_storage` | Запрет вызовов `random.choice()` |
+
+**Цель:** Гарантировать детерминизм операций записи для воспроизводимости.
+См. [ADR-014](docs/02-architecture/decisions/ADR-014-deterministic-writes.md).
+
+Файл `tests/architecture/test_no_datetime_now_in_infrastructure.py` проверяет:
+
+| Тест | Проверка |
+|------|----------|
+| `test_no_datetime_now_in_infrastructure` | Запрет `datetime.now()` в infrastructure слое |
+| `test_allowed_files_still_exist` | Проверка актуальности списка исключений |
+
+**Цель:** Timestamps создаются в application слое и передаются как параметры.
+
 ### Команды
 
 ```bash

--- a/docs/03-guides/testing.md
+++ b/docs/03-guides/testing.md
@@ -33,10 +33,16 @@
 ### 2.4. Architecture Tests (`tests/architecture/`)
 Автоматизированный контроль за соблюдением архитектурных правил проекта.
 - **Layer Separation**: Проверка отсутствия импортов `infrastructure` в `domain/application` через `import-linter`.
-- **Rules Enforcement**: 
-    - `test_no_random_in_writers`: Запрет на использование `random` в слое хранилища для детерминизма.
+- **Rules Enforcement**:
+    - `test_no_random_in_writers` (REQ-ARCH-030): Запрет на использование `random` в слое хранилища для детерминизма.
+      - Проверяет: `import random`, `from random import`, `random.uniform()`, `random.choice()`
+      - Область: `src/bioetl/infrastructure/storage/*.py`
     - `test_no_datetime_now_in_infrastructure`: Запрет на создание временных меток в инфраструктурном слое.
+      - Проверяет: `datetime.now()`, `datetime.datetime.now()`
+      - Область: `src/bioetl/infrastructure/**/*.py` (с исключениями)
     - `test_all_ports_have_implementations`: Проверка наличия реализаций для всех протоколов (портов).
+
+**Документация:** См. [ADR-014](../02-architecture/decisions/ADR-014-deterministic-writes.md) для обоснования детерминизма.
 
 ### 2.5. Security Tests (`tests/security/`)
 - Проверка санитизации секретов в VCR-кассетах.

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -433,11 +433,13 @@ class LegacyAdapter(BaseSyncAdapter):
 3. Retry jitter **MUST** быть детерминистичным при `deterministic=True`
 4. `PipelineContext.started_at` — единственный источник времени для batch
 
-#### Архитектурные Тесты
-| Тест | Цель | Файл |
-|------|------|------|
-| `test_no_random_in_writers` | Блокирует `random` в storage | `tests/architecture/` |
-| `test_no_datetime_now_in_infrastructure` | Блокирует `datetime.now()` в infra | `tests/architecture/` |
+#### Архитектурные Тесты (REQ-ARCH-030)
+| Тест | Цель | Проверки |
+|------|------|----------|
+| `test_no_random_in_writers` | Блокирует `random` в storage writers | `import random`, `from random import`, `random.uniform()`, `random.choice()` |
+| `test_no_datetime_now_in_infrastructure` | Блокирует `datetime.now()` в infra | `datetime.now()`, `datetime.datetime.now()` |
+
+**Путь:** `tests/architecture/test_no_random_in_writers.py`, `tests/architecture/test_no_datetime_now_in_infrastructure.py`
 
 #### Детерминистичный Jitter
 ```python


### PR DESCRIPTION
- CLAUDE.md: Add dedicated section "Тесты детерминизма (REQ-ARCH-030)" documenting both random and datetime.now architecture tests
- RULES.md: Enhance architecture tests table with REQ-ARCH-030 reference and detailed list of checks performed
- testing.md: Add details about what each determinism test verifies and link to ADR-014

See ADR-014 for rationale on deterministic writes.