### PR TITLE
Centralize timestamp generation in application layer

### DIFF
--- a/src/bioetl/application/core/quarantine_manager.py
+++ b/src/bioetl/application/core/quarantine_manager.py
@@ -40,7 +40,8 @@ class QuarantineManager:
         error_type: ErrorType,
         batch_id: BatchID,
         error_details: str,
-        ingestion_ts: datetime | None = None,
+        *,
+        ingestion_ts: datetime,
     ) -> None:
         """Write a record to the quarantine.
 
@@ -49,7 +50,8 @@ class QuarantineManager:
             error_type: Classification of the error.
             batch_id: ID of the batch containing this record.
             error_details: Human-readable error description.
-            ingestion_ts: Ingestion timestamp from context (single source of time).
+            ingestion_ts: Ingestion timestamp from context
+                         (single source of time per ADR-014). Required.
 
         """
         await self._quarantine.write(

--- a/src/bioetl/composition/factories/storage_factory.py
+++ b/src/bioetl/composition/factories/storage_factory.py
@@ -56,9 +56,21 @@ class StorageAdapter:
         batch_id: BatchID,
         run_id: RunID,
         run_type: RunType,
-        ingestion_ts: datetime | None = None,
+        ingestion_ts: datetime,
     ) -> None:
-        """Write raw records to Bronze layer."""
+        """Write raw records to Bronze layer.
+
+        Args:
+            records: Iterator of JSON-encoded record bytes.
+            provider: Provider name.
+            entity: Entity type.
+            date: Date for path partitioning.
+            batch_id: Unique batch identifier.
+            run_id: Pipeline run identifier.
+            run_type: Type of run.
+            ingestion_ts: Ingestion timestamp from application layer
+                         (single source of time per ADR-014). Required.
+        """
         await self.bronze.write_bronze(
             records=records,
             provider=provider,

--- a/src/bioetl/domain/ports/quarantine.py
+++ b/src/bioetl/domain/ports/quarantine.py
@@ -28,7 +28,8 @@ class QuarantinePort(Protocol):
         bronze_batch_id: BatchID,
         run_id: RunID | None = None,
         metadata: dict[str, Any] | None = None,
-        ingestion_ts: datetime | None = None,
+        *,
+        ingestion_ts: datetime,
     ) -> None:
         """Write a record to quarantine.
 
@@ -39,7 +40,8 @@ class QuarantinePort(Protocol):
             bronze_batch_id: The ID of the bronze batch containing the record.
             run_id: Optional ID of the pipeline run for traceability.
             metadata: Optional additional metadata (e.g., error_details, bronze_file_uri).
-            ingestion_ts: Ingestion timestamp from application layer.
+            ingestion_ts: Ingestion timestamp from application layer
+                         (single source of time per ADR-014). Required.
         """
         ...
 

--- a/src/bioetl/domain/ports/storage.py
+++ b/src/bioetl/domain/ports/storage.py
@@ -37,7 +37,7 @@ class StoragePort(Protocol):
         batch_id: BatchID,
         run_id: RunID,
         run_type: RunType,
-        ingestion_ts: datetime | None = None,
+        ingestion_ts: datetime,
     ) -> None:
         """Write raw records to the Bronze layer.
 
@@ -49,7 +49,8 @@ class StoragePort(Protocol):
             batch_id: The unique identifier for the batch of records.
             run_id: The unique identifier for the pipeline run (for traceability).
             run_type: The type of pipeline run (incremental, backfill, rebuild).
-            ingestion_ts: Ingestion timestamp from context (single source of time).
+            ingestion_ts: Ingestion timestamp from application layer
+                         (single source of time per ADR-014). Required.
         """
         ...
 

--- a/src/bioetl/infrastructure/quarantine/unified.py
+++ b/src/bioetl/infrastructure/quarantine/unified.py
@@ -12,7 +12,7 @@ Requirements:
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 import pyarrow as pa
@@ -62,7 +62,8 @@ class UnifiedQuarantine:
         bronze_batch_id: BatchID,
         run_id: RunID | None = None,
         metadata: dict[str, Any] | None = None,
-        ingestion_ts: datetime | None = None,
+        *,
+        ingestion_ts: datetime,
     ) -> None:
         """Write record to quarantine.
 
@@ -73,8 +74,8 @@ class UnifiedQuarantine:
             bronze_batch_id: The ID of the bronze batch containing the record.
             run_id: Optional ID of the pipeline run for traceability.
             metadata: Optional additional metadata (e.g., error_details, bronze_file_uri).
-            ingestion_ts: Ingestion timestamp from application layer.
-                         If None, uses current UTC time (backward compat).
+            ingestion_ts: Ingestion timestamp from application layer
+                         (single source of time per ADR-014). Required.
 
         """
         payload_json = json.dumps(payload, ensure_ascii=True)
@@ -87,11 +88,9 @@ class UnifiedQuarantine:
 
         payload_hash = calculate_hash(payload_json)
         meta = metadata or {}
-        # Use provided timestamp or fall back to current time (backward compat)
-        effective_ts = ingestion_ts or datetime.now(UTC)
 
         record = {
-            "ingestion_ts": effective_ts.isoformat(),
+            "ingestion_ts": ingestion_ts.isoformat(),
             "pipeline": pipeline,
             "error_code": error_code,
             "payload": payload_json,

--- a/src/bioetl/infrastructure/storage/bronze_writer.py
+++ b/src/bioetl/infrastructure/storage/bronze_writer.py
@@ -118,18 +118,33 @@ class BronzeWriter:
         batch_id: BatchID,
         run_id: RunID,
         run_type: RunType,
-        ingestion_ts: datetime | None = None,
+        ingestion_ts: datetime,
     ) -> Path:
-        """Write raw records to Bronze layer (JSONL + zstd)."""
+        """Write raw records to Bronze layer (JSONL + zstd).
+
+        Args:
+            records: Iterator of JSON-encoded record bytes.
+            provider: Provider name (e.g., 'chembl').
+            entity: Entity type (e.g., 'activity').
+            date: Date for path partitioning.
+            batch_id: Unique identifier for this batch.
+            run_id: Pipeline run identifier.
+            run_type: Type of run (incremental, backfill, etc.).
+            ingestion_ts: Ingestion timestamp from application layer
+                         (single source of time per ADR-014).
+
+        Returns:
+            Relative path to the written file.
+
+        """
         self._validate_bronze_names(provider, entity)
 
         date_str = date.strftime("%Y-%m-%d")
         relative_path = (
             f"bronze/v1/{provider}/{entity}/{date_str}/batch_{batch_id}.jsonl.zst"
         )
-        effective_ts = ingestion_ts or date
         metadata = self._build_bronze_metadata(
-            run_id, run_type, effective_ts, provider, entity, batch_id
+            run_id, run_type, ingestion_ts, provider, entity, batch_id
         )
 
         loop = asyncio.get_running_loop()

--- a/tests/architecture/test_no_datetime_now_in_infrastructure.py
+++ b/tests/architecture/test_no_datetime_now_in_infrastructure.py
@@ -19,8 +19,6 @@ INFRASTRUCTURE_DIR = Path("src/bioetl/infrastructure")
 ALLOWED_FILES: set[str] = {
     # Operations use datetime.now() for calculating retention periods (cleanup)
     "operations.py",
-    # Unified quarantine has fallback for backward compatibility
-    "unified.py",
     # Gold writer uses datetime.now() for SCD2 valid_from/valid_to columns
     # TODO (#arch-review): Consider passing timestamp for SCD2 as well
     "gold_writer.py",

--- a/tests/fakes/quarantine_fake.py
+++ b/tests/fakes/quarantine_fake.py
@@ -6,7 +6,7 @@ Implements QuarantinePort interface without filesystem I/O.
 from __future__ import annotations
 
 from collections import defaultdict
-from datetime import UTC, datetime
+from datetime import UTC, datetime  # UTC used in add_record
 from typing import Any
 
 from bioetl.domain.types import BatchID, DQStatus, RunID
@@ -31,14 +31,14 @@ class InMemoryQuarantine:
         bronze_batch_id: BatchID,
         run_id: RunID | None = None,
         metadata: dict[str, Any] | None = None,
-        ingestion_ts: datetime | None = None,
+        *,
+        ingestion_ts: datetime,
     ) -> None:
         """Write record to quarantine."""
         meta = metadata or {}
-        effective_ts = ingestion_ts or datetime.now(UTC)
 
         record = {
-            "ingestion_ts": effective_ts.isoformat(),
+            "ingestion_ts": ingestion_ts.isoformat(),
             "pipeline": pipeline,
             "error_code": error_code,
             "payload": payload,

--- a/tests/fakes/storage_fake.py
+++ b/tests/fakes/storage_fake.py
@@ -45,16 +45,28 @@ class InMemoryStorage:
         batch_id: BatchID,
         run_id: RunID,
         run_type: RunType,
-        ingestion_ts: datetime | None = None,
+        ingestion_ts: datetime,
     ) -> None:
-        """Write raw records to the Bronze layer."""
+        """Write raw records to the Bronze layer.
+
+        Args:
+            records: Iterator of JSON-encoded record bytes.
+            provider: Provider name.
+            entity: Entity type.
+            date: Date for path partitioning.
+            batch_id: Unique batch identifier.
+            run_id: Pipeline run identifier.
+            run_type: Type of run.
+            ingestion_ts: Ingestion timestamp from application layer.
+
+        """
         key = f"bronze/v1/{provider}/{entity}/{date.strftime('%Y-%m-%d')}/{batch_id}.jsonl.zst"
         record_list = list(records)
         self.bronze[key].extend(record_list)
         self.bronze_metadata[key] = {
             "run_id": str(run_id),
             "run_type": run_type.value if hasattr(run_type, "value") else str(run_type),
-            "ingestion_ts": ingestion_ts.isoformat() if ingestion_ts else None,
+            "ingestion_ts": ingestion_ts.isoformat(),
         }
         self.operations.append({
             "operation": "write_bronze",

--- a/tests/integration/memory_storage.py
+++ b/tests/integration/memory_storage.py
@@ -12,13 +12,16 @@ class MemoryStorage(StoragePort):
         self.data = defaultdict(list)
         self.bronze_metadata = {}  # Store run metadata for verification
 
-    def write_bronze(self, records, provider, entity, date, batch_id, run_id, run_type):
+    def write_bronze(
+        self, records, provider, entity, date, batch_id, run_id, run_type, ingestion_ts
+    ):
         key = f"bronze/{provider}/{entity}/{date}/{batch_id}.jsonl.zst"
         self.data[key].extend(records)
         # Store metadata for test verification
         self.bronze_metadata[key] = {
             "run_id": str(run_id),
             "run_type": run_type.value if hasattr(run_type, "value") else str(run_type),
+            "ingestion_ts": ingestion_ts.isoformat() if ingestion_ts else None,
         }
 
     def write_silver(self, table_name, records, _primary_keys):

--- a/tests/unit/infrastructure/factories/test_factories.py
+++ b/tests/unit/infrastructure/factories/test_factories.py
@@ -66,15 +66,18 @@ class TestStorageAdapter:
         run_id = uuid4()
         run_type = RunType.INCREMENTAL
         records = iter([b"record1", b"record2"])
+        # Fixed timestamp for deterministic tests (ADR-014)
+        ingestion_ts = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
 
         await storage_adapter.write_bronze(
             records=records,
             provider="chembl",
             entity="activity",
-            date=datetime.now(),
+            date=datetime(2024, 1, 15),
             batch_id=batch_id,
             run_id=run_id,
             run_type=run_type,
+            ingestion_ts=ingestion_ts,
         )
 
         mock_bronze_writer.write_bronze.assert_called_once()

--- a/tests/unit/infrastructure/factories/test_storage_adapter.py
+++ b/tests/unit/infrastructure/factories/test_storage_adapter.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -99,6 +99,8 @@ class TestStorageAdapterWriteBronze:
         batch_id = uuid4()
         run_id = uuid4()
         run_type = RunType.INCREMENTAL
+        # Fixed timestamp for deterministic tests (ADR-014)
+        ingestion_ts = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
 
         await storage_adapter.write_bronze(
             records=records,
@@ -108,6 +110,7 @@ class TestStorageAdapterWriteBronze:
             batch_id=batch_id,
             run_id=run_id,
             run_type=run_type,
+            ingestion_ts=ingestion_ts,
         )
 
         mock_bronze_writer.write_bronze.assert_called_once()
@@ -118,6 +121,7 @@ class TestStorageAdapterWriteBronze:
         assert call_kwargs["batch_id"] == batch_id
         assert call_kwargs["run_id"] == run_id
         assert call_kwargs["run_type"] == run_type
+        assert call_kwargs["ingestion_ts"] == ingestion_ts
 
 
 @pytest.mark.unit

--- a/tests/unit/infrastructure/storage/test_bronze_writer.py
+++ b/tests/unit/infrastructure/storage/test_bronze_writer.py
@@ -43,6 +43,12 @@ def run_type() -> RunType:
 
 
 @pytest.fixture
+def ingestion_ts() -> datetime:
+    """Return fixed ingestion timestamp for deterministic tests."""
+    return datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
+
+
+@pytest.fixture
 def sample_records() -> list[bytes]:
     """Create sample records as JSONL bytes."""
     records = [
@@ -147,6 +153,7 @@ class TestBronzeWriterWriteLocal:
         batch_id: BatchID,
         run_id: RunID,
         run_type: RunType,
+        ingestion_ts: datetime,
     ) -> None:
         """Test writing Bronze data to local storage."""
         writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
@@ -160,6 +167,7 @@ class TestBronzeWriterWriteLocal:
             batch_id=batch_id,
             run_id=run_id,
             run_type=run_type,
+            ingestion_ts=ingestion_ts,
         )
 
         # Verify path format (normalize for cross-platform)
@@ -204,6 +212,7 @@ class TestBronzeWriterWriteLocal:
         batch_id: BatchID,
         run_id: RunID,
         run_type: RunType,
+        ingestion_ts: datetime,
     ) -> None:
         """Test that local write is performed asynchronously."""
         writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
@@ -223,6 +232,7 @@ class TestBronzeWriterWriteLocal:
                 batch_id=batch_id,
                 run_id=run_id,
                 run_type=run_type,
+                ingestion_ts=ingestion_ts,
             )
 
             # Verify run_in_executor was called at least twice (1 for compression, 1 for write)
@@ -242,6 +252,7 @@ class TestBronzeWriterWriteLocal:
         batch_id: BatchID,
         run_id: RunID,
         run_type: RunType,
+        ingestion_ts: datetime,
     ) -> None:
         """Test writing Bronze data with JSON copy."""
         writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, save_json=True)
@@ -255,6 +266,7 @@ class TestBronzeWriterWriteLocal:
             batch_id=batch_id,
             run_id=run_id,
             run_type=run_type,
+            ingestion_ts=ingestion_ts,
         )
 
         # Verify JSON copy exists
@@ -276,6 +288,7 @@ class TestBronzeWriterWriteLocal:
         batch_id: BatchID,
         run_id: RunID,
         run_type: RunType,
+        ingestion_ts: datetime,
     ) -> None:
         """Test that empty records raise ValueError."""
         writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
@@ -290,6 +303,7 @@ class TestBronzeWriterWriteLocal:
                 batch_id=batch_id,
                 run_id=run_id,
                 run_type=run_type,
+                ingestion_ts=ingestion_ts,
             )
 
 
@@ -306,6 +320,7 @@ class TestBronzeWriterReadLocal:
         batch_id: BatchID,
         run_id: RunID,
         run_type: RunType,
+        ingestion_ts: datetime,
     ) -> None:
         """Test reading Bronze data from local storage."""
         writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
@@ -320,6 +335,7 @@ class TestBronzeWriterReadLocal:
             batch_id=batch_id,
             run_id=run_id,
             run_type=run_type,
+            ingestion_ts=ingestion_ts,
         )
 
         # Read back
@@ -345,6 +361,7 @@ class TestBronzeWriterListBatches:
         sample_records: list[bytes],
         run_id: RunID,
         run_type: RunType,
+        ingestion_ts: datetime,
     ) -> None:
         """Test listing batches from local storage."""
         writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
@@ -361,6 +378,7 @@ class TestBronzeWriterListBatches:
             batch_id=BatchID(uuid4()),
             run_id=run_id,
             run_type=run_type,
+            ingestion_ts=ingestion_ts,
         )
         await writer.write_bronze(
             records=iter(sample_records),
@@ -370,6 +388,7 @@ class TestBronzeWriterListBatches:
             batch_id=BatchID(uuid4()),
             run_id=run_id,
             run_type=run_type,
+            ingestion_ts=ingestion_ts,
         )
 
         # List all batches
@@ -384,6 +403,7 @@ class TestBronzeWriterListBatches:
         sample_records: list[bytes],
         run_id: RunID,
         run_type: RunType,
+        ingestion_ts: datetime,
     ) -> None:
         """Test listing batches with date filter."""
         writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
@@ -399,6 +419,7 @@ class TestBronzeWriterListBatches:
             batch_id=BatchID(uuid4()),
             run_id=run_id,
             run_type=run_type,
+            ingestion_ts=ingestion_ts,
         )
         await writer.write_bronze(
             records=iter(sample_records),
@@ -408,6 +429,7 @@ class TestBronzeWriterListBatches:
             batch_id=BatchID(uuid4()),
             run_id=run_id,
             run_type=run_type,
+            ingestion_ts=ingestion_ts,
         )
 
         # List with date filter
@@ -437,6 +459,7 @@ class TestBronzeWriterAtomicWrite:
         batch_id: BatchID,
         run_id: RunID,
         run_type: RunType,
+        ingestion_ts: datetime,
     ) -> None:
         """Test that no partial files remain if write fails mid-operation.
 
@@ -462,6 +485,7 @@ class TestBronzeWriterAtomicWrite:
                     batch_id=batch_id,
                     run_id=run_id,
                     run_type=run_type,
+                    ingestion_ts=ingestion_ts,
                 )
 
         # Verify no data files exist
@@ -485,6 +509,7 @@ class TestBronzeWriterAtomicWrite:
         batch_id: BatchID,
         run_id: RunID,
         run_type: RunType,
+        ingestion_ts: datetime,
     ) -> None:
         """Test that metadata file never exists without corresponding data file.
 
@@ -502,6 +527,7 @@ class TestBronzeWriterAtomicWrite:
             batch_id=batch_id,
             run_id=run_id,
             run_type=run_type,
+            ingestion_ts=ingestion_ts,
         )
 
         full_path = tmp_path / path
@@ -520,6 +546,7 @@ class TestBronzeWriterAtomicWrite:
         batch_id: BatchID,
         run_id: RunID,
         run_type: RunType,
+        ingestion_ts: datetime,
     ) -> None:
         """Test that no temp files remain after successful write."""
         writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
@@ -533,6 +560,7 @@ class TestBronzeWriterAtomicWrite:
             batch_id=batch_id,
             run_id=run_id,
             run_type=run_type,
+            ingestion_ts=ingestion_ts,
         )
 
         # No temp files should remain
@@ -548,6 +576,7 @@ class TestBronzeWriterAtomicWrite:
         batch_id: BatchID,
         run_id: RunID,
         run_type: RunType,
+        ingestion_ts: datetime,
     ) -> None:
         """Test that failure during AtomicWriteGroup.add cleans up temp files."""
         writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
@@ -575,6 +604,7 @@ class TestBronzeWriterAtomicWrite:
                     batch_id=batch_id,
                     run_id=run_id,
                     run_type=run_type,
+                    ingestion_ts=ingestion_ts,
                 )
 
         # No temp files should remain
@@ -590,6 +620,7 @@ class TestBronzeWriterAtomicWrite:
         batch_id: BatchID,
         run_id: RunID,
         run_type: RunType,
+        ingestion_ts: datetime,
     ) -> None:
         """Test that JSON copy also uses atomic write."""
         writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, save_json=True)
@@ -603,6 +634,7 @@ class TestBronzeWriterAtomicWrite:
             batch_id=batch_id,
             run_id=run_id,
             run_type=run_type,
+            ingestion_ts=ingestion_ts,
         )
 
         # Verify JSON file exists
@@ -627,6 +659,7 @@ class TestBronzeWriterLoggerInjection:
         batch_id: BatchID,
         run_id: RunID,
         run_type: RunType,
+        ingestion_ts: datetime,
     ) -> None:
         """Test that injected logger is called during write operations."""
         mock_logger = MagicMock()
@@ -641,6 +674,7 @@ class TestBronzeWriterLoggerInjection:
             batch_id=batch_id,
             run_id=run_id,
             run_type=run_type,
+            ingestion_ts=ingestion_ts,
         )
 
         # Verify logger.info was called with bronze_write_complete

--- a/tests/unit/infrastructure/test_storage.py
+++ b/tests/unit/infrastructure/test_storage.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import io
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 from uuid import UUID
 
@@ -20,6 +20,8 @@ from bioetl.infrastructure.storage.gold_writer import GoldWriter
 # Default test run metadata
 TEST_RUN_ID: RunID = UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
 TEST_RUN_TYPE = RunType.INCREMENTAL
+# Fixed timestamp for deterministic tests (see ADR-014)
+TEST_INGESTION_TS = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
 
 
 @pytest.fixture
@@ -67,6 +69,7 @@ class TestBronzeWriter:
             batch_id=batch_id,
             run_id=TEST_RUN_ID,
             run_type=TEST_RUN_TYPE,
+            ingestion_ts=TEST_INGESTION_TS,
         )
 
         expected_file = tmp_path / path
@@ -90,6 +93,7 @@ class TestBronzeWriter:
             batch_id=batch_id,
             run_id=TEST_RUN_ID,
             run_type=TEST_RUN_TYPE,
+            ingestion_ts=TEST_INGESTION_TS,
         )
 
         # Check path contains expected parts (path format: bronze/v1/{provider}/{entity}/{date}/batch_{id}.jsonl.zst)
@@ -113,6 +117,7 @@ class TestBronzeWriter:
             batch_id=batch_id,
             run_id=TEST_RUN_ID,
             run_type=TEST_RUN_TYPE,
+            ingestion_ts=TEST_INGESTION_TS,
         )
 
         file_path = tmp_path / path
@@ -148,6 +153,7 @@ class TestBronzeWriter:
                 batch_id=batch_id,
                 run_id=TEST_RUN_ID,
                 run_type=TEST_RUN_TYPE,
+                ingestion_ts=TEST_INGESTION_TS,
             )
 
     async def test_write_bronze_save_json_copy(self, tmp_path, noop_logger):
@@ -166,6 +172,7 @@ class TestBronzeWriter:
             batch_id=batch_id,
             run_id=TEST_RUN_ID,
             run_type=TEST_RUN_TYPE,
+            ingestion_ts=TEST_INGESTION_TS,
         )
 
         # Check JSON file was created
@@ -223,6 +230,7 @@ class TestBronzeWriter:
                 batch_id=batch_id,
                 run_id=TEST_RUN_ID,
                 run_type=TEST_RUN_TYPE,
+                ingestion_ts=TEST_INGESTION_TS,
             )
 
         batches = await writer.list_batches("test_provider", "test_entity", date)
@@ -254,6 +262,7 @@ class TestBronzeWriter:
             batch_id=batch_id,
             run_id=TEST_RUN_ID,
             run_type=TEST_RUN_TYPE,
+            ingestion_ts=TEST_INGESTION_TS,
         )
 
         # Check metadata file was created

--- a/tests/unit/test_ports.py
+++ b/tests/unit/test_ports.py
@@ -128,7 +128,7 @@ class TestStoragePortProtocol:
                 batch_id: BatchID,
                 run_id: Any,
                 run_type: Any,
-                ingestion_ts: Any = None,
+                ingestion_ts: Any,  # Required per ADR-014
             ) -> None:
                 pass
 


### PR DESCRIPTION
Make ingestion_ts a required parameter in:
- StoragePort.write_bronze()
- QuarantinePort.write()
- BronzeWriter.write_bronze()
- UnifiedQuarantine.write()
- QuarantineManager.quarantine_record()
- StorageAdapter.write_bronze()

Remove datetime.now(UTC) fallbacks from infrastructure layer. This enforces that timestamps are created in the application layer (PipelineContext.started_at) and passed down to infrastructure, ensuring determinism and single source of truth for timestamps.

Implements ADR-014: Deterministic Writes.

Changes:
- Make ingestion_ts required (keyword-only) in all write methods
- Remove datetime.now(UTC) fallback from unified.py
- Remove unified.py from architecture test exceptions
- Update all test fakes and mocks to require ingestion_ts
- Add ingestion_ts fixture to all relevant tests