### PR TITLE
Add tracing context to base transformer

### DIFF
--- a/src/bioetl/application/core/base_transformer.py
+++ b/src/bioetl/application/core/base_transformer.py
@@ -6,6 +6,7 @@ Provides common functionality for all entity transformers:
 - Entity to SilverRecord conversion with lineage field renaming
 - Template Method pattern for unified error handling
 - Helper methods for field extraction and entity creation
+- Tracing and metrics for observability (O1)
 
 Implements DRY principle by extracting shared logic from entity transformers.
 """
@@ -13,6 +14,7 @@ Implements DRY principle by extracting shared logic from entity transformers.
 from __future__ import annotations
 
 import json
+import time
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -21,6 +23,7 @@ from bioetl.domain.transformations import generate_content_hash
 if TYPE_CHECKING:
     from bioetl.domain.context import PipelineContext
     from bioetl.domain.entities import BaseEntity
+    from bioetl.domain.ports import MetricsPort, TracingPort
     from bioetl.domain.types import BronzeRecord, ContentHash, SilverRecord
 
 T = TypeVar("T", bound="BaseEntity")
@@ -61,18 +64,35 @@ class BaseTransformer(ABC):
     - `_extract_nested()`: Safe extraction of nested dictionary values
     - `_create_entity()`: Unified entity creation with lineage metadata
 
+    Observability (O1):
+    - Tracing spans for transform operations
+    - Duration histograms by entity_type
+    - Error counters by error_type
+
     Subclasses MUST implement:
     - `_transform_impl()`: Entity-specific transformation logic
     """
 
-    def __init__(self, provider: str) -> None:
-        """Initialize transformer with provider name.
+    def __init__(
+        self,
+        provider: str,
+        entity_type: str | None = None,
+        tracer: TracingPort | None = None,
+        metrics: MetricsPort | None = None,
+    ) -> None:
+        """Initialize transformer with provider name and optional observability.
 
         Args:
             provider: Data provider identifier (e.g., 'chembl', 'pubchem').
+            entity_type: Entity type for metrics labels (e.g., 'activity', 'compound').
+            tracer: Optional tracing port for distributed tracing.
+            metrics: Optional metrics port for duration/error tracking.
 
         """
         self.provider = provider
+        self.entity_type = entity_type or "unknown"
+        self._tracer = tracer
+        self._metrics = metrics
 
     async def transform(
         self,
@@ -85,6 +105,11 @@ class BaseTransformer(ABC):
         Handles common error handling and logging, delegating actual
         transformation to `_transform_impl()`.
 
+        Observability (O1):
+        - Creates tracing span "transform_record" with provider/entity attributes
+        - Records transform_duration_seconds histogram by entity_type
+        - Increments transform_errors_total counter by error_type on failure
+
         Args:
             context: Pipeline context with run_id, run_type, logger.
             record: Raw Bronze record from data source.
@@ -93,23 +118,79 @@ class BaseTransformer(ABC):
             SilverRecord if transformation successful, None if record should be skipped.
 
         """
+        start_time = time.perf_counter()
+        span = None
+        error_type: str | None = None
+
+        # Start tracing span if tracer is available
+        if self._tracer:
+            otel_tracer = self._tracer.get_tracer("bioetl.transformer")
+            span = otel_tracer.start_as_current_span(
+                "transform_record",
+                attributes={
+                    "bioetl.provider": self.provider,
+                    "bioetl.entity_type": self.entity_type,
+                    "bioetl.run_id": str(context.run_id),
+                },
+            )
+            span.__enter__()
+
         try:
-            return await self._transform_impl(context, record)
+            result = await self._transform_impl(context, record)
+            return result
         except TransformationError as e:
+            error_type = "transformation_error"
             context.logger.warning(
                 "transformation_skipped",
                 reason=str(e),
                 field=e.field,
                 provider=self.provider,
             )
+            if span:
+                span.set_attribute("error", True)
+                span.set_attribute("error.type", error_type)
             return None
         except ValueError as e:
+            error_type = "validation_error"
             context.logger.warning(
                 "entity_validation_failed",
                 error=str(e),
                 provider=self.provider,
             )
+            if span:
+                span.set_attribute("error", True)
+                span.set_attribute("error.type", error_type)
             return None
+        finally:
+            duration = time.perf_counter() - start_time
+
+            # Record duration histogram
+            if self._metrics:
+                self._metrics.observe_histogram(
+                    "transform_duration_seconds",
+                    duration,
+                    labels={
+                        "provider": self.provider,
+                        "entity_type": self.entity_type,
+                    },
+                )
+
+                # Record error counter if error occurred
+                if error_type:
+                    self._metrics.increment_counter(
+                        "transform_errors_total",
+                        1,
+                        labels={
+                            "provider": self.provider,
+                            "entity_type": self.entity_type,
+                            "error_type": error_type,
+                        },
+                    )
+
+            # End tracing span
+            if span:
+                span.set_attribute("bioetl.duration_ms", duration * 1000)
+                span.__exit__(None, None, None)
 
     @abstractmethod
     async def _transform_impl(

--- a/src/bioetl/application/core/executor.py
+++ b/src/bioetl/application/core/executor.py
@@ -1,4 +1,9 @@
-"""Pipeline Executor: orchestrates the data flow from extraction to processing."""
+"""Pipeline Executor: orchestrates the data flow from extraction to processing.
+
+Observability (O2):
+- Root span for each batch with batch_id, record_count, run_type attributes
+- Nested spans for fetch → transform → write operations
+"""
 
 from __future__ import annotations
 
@@ -14,12 +19,19 @@ if TYPE_CHECKING:
     from bioetl.application.core.checkpoint_manager import CheckpointManager
     from bioetl.application.core.pipeline_services import PipelineServices
     from bioetl.application.core.record_processor import RecordProcessor
+    from bioetl.domain.ports import TracingPort
+    from bioetl.domain.types import RunType
 
 
 class PipelineExecutor:
     """Orchestrates the data flow: extracts data, accumulates batches.
 
     Also delegates processing to a RecordProcessor.
+
+    Observability (O2):
+    - Root span "batch_{batch_id}" for each batch
+    - Span attributes: batch_id, record_count, run_type
+    - Nested spans delegated to RecordProcessor
     """
 
     DEFAULT_BATCH_SIZE = 100
@@ -34,6 +46,8 @@ class PipelineExecutor:
         entity_type: str,
         batch_size: int | None = None,
         checkpoint_interval: int | None = None,
+        run_type: RunType | None = None,
+        tracer: TracingPort | None = None,
     ):
         """Initialize pipeline executor.
 
@@ -45,6 +59,8 @@ class PipelineExecutor:
             entity_type: Type of entity to process.
             batch_size: Number of records per batch.
             checkpoint_interval: Number of records between checkpoints.
+            run_type: Type of pipeline run (for tracing attributes).
+            tracer: Optional tracing port for distributed tracing.
 
         """
         self._data_source = services.data_source
@@ -57,6 +73,8 @@ class PipelineExecutor:
         )
 
         self._record_processor = record_processor
+        self._run_type = run_type
+        self._tracer = tracer
 
         # Counters
         self.records_fetched = 0
@@ -115,13 +133,53 @@ class PipelineExecutor:
             raise
 
     async def _process_and_update_counts(self, batch: list[dict[str, Any]]) -> None:
-        result = await self._record_processor.process_batch(
-            records=batch, batch_id=BatchID(uuid4())
-        )
-        self.records_bronze += result.bronze_count
-        self.records_silver += result.silver_count
-        self.records_gold += result.gold_count
-        self.records_quarantined += result.quarantined_count
+        """Process batch with tracing span.
+
+        Creates a root span for the batch with attributes:
+        - batch_id: Unique identifier for this batch
+        - record_count: Number of records in the batch
+        - run_type: Type of pipeline run
+        """
+        batch_id = BatchID(uuid4())
+        span = None
+
+        # Start batch tracing span if tracer is available
+        if self._tracer:
+            otel_tracer = self._tracer.get_tracer("bioetl.executor")
+            span = otel_tracer.start_as_current_span(
+                f"batch_{batch_id}",
+                attributes={
+                    "bioetl.batch_id": str(batch_id),
+                    "bioetl.record_count": len(batch),
+                    "bioetl.run_type": self._run_type.value if self._run_type else "unknown",
+                    "bioetl.entity_type": self._entity_type,
+                },
+            )
+            span.__enter__()
+
+        try:
+            result = await self._record_processor.process_batch(
+                records=batch, batch_id=batch_id
+            )
+            self.records_bronze += result.bronze_count
+            self.records_silver += result.silver_count
+            self.records_gold += result.gold_count
+            self.records_quarantined += result.quarantined_count
+
+            # Add result attributes to span
+            if span:
+                span.set_attribute("bioetl.bronze_count", result.bronze_count)
+                span.set_attribute("bioetl.silver_count", result.silver_count)
+                span.set_attribute("bioetl.gold_count", result.gold_count)
+                span.set_attribute("bioetl.quarantined_count", result.quarantined_count)
+        except Exception as e:
+            if span:
+                span.set_attribute("error", True)
+                span.record_exception(e)
+            raise
+        finally:
+            if span:
+                span.__exit__(None, None, None)
 
     async def _extract(
         self, limit: int | None, query: str | None = None

--- a/src/bioetl/application/core/record_processor.py
+++ b/src/bioetl/application/core/record_processor.py
@@ -1,4 +1,9 @@
-"""Processes a batch of records through the Bronze, Silver, and Gold layers."""
+"""Processes a batch of records through the Bronze, Silver, and Gold layers.
+
+Observability (O2):
+- Nested spans for each stage: transform → write_bronze → write_silver → write_gold
+- Span attributes include record counts and batch metadata
+"""
 
 from __future__ import annotations
 
@@ -21,7 +26,7 @@ if TYPE_CHECKING:
     )
     from bioetl.domain.context import PipelineContext
     from bioetl.domain.error_classifier import ErrorClassifier
-    from bioetl.domain.ports import GoldValidatorPort
+    from bioetl.domain.ports import GoldValidatorPort, TracingPort
     from bioetl.domain.types import BatchID
 
 
@@ -39,6 +44,10 @@ class RecordProcessor:
     """Handles the transformation and writing of a single batch of records.
 
     This class contains the core ETL logic for a batch.
+
+    Observability (O2):
+    - Nested spans for transform, write_bronze, write_silver, write_gold
+    - Each span includes relevant record counts and status
     """
 
     def __init__(
@@ -51,6 +60,7 @@ class RecordProcessor:
         gold_filter_callback: GoldFilterCallback,
         gold_transform_callback: GoldTransformCallback,
         gold_validator: GoldValidatorPort,
+        tracer: TracingPort | None = None,
     ):
         """Initialize record processor.
 
@@ -63,6 +73,7 @@ class RecordProcessor:
             gold_filter_callback: Callback for filtering Silver records.
             gold_transform_callback: Callback for Silver -> Gold transformation.
             gold_validator: Validator for Gold layer records.
+            tracer: Optional tracing port for distributed tracing.
 
         """
         self._storage = services.storage
@@ -77,6 +88,7 @@ class RecordProcessor:
         self._gold_filter = gold_filter_callback
         self._gold_transform = gold_transform_callback
         self._gold_validator = gold_validator
+        self._tracer = tracer
 
         # Convenience properties
         self._provider = config.provider
@@ -104,6 +116,37 @@ class RecordProcessor:
             batch_id=str(batch_id),
         )
         self._batch_metrics.track_error(f"{layer}_write", error_type)
+
+    def _start_span(self, name: str, **attributes: Any) -> Any:
+        """Start a tracing span if tracer is available.
+
+        Args:
+            name: Name of the span.
+            **attributes: Span attributes.
+
+        Returns:
+            Span object or None if tracer not available.
+        """
+        if not self._tracer:
+            return None
+        otel_tracer = self._tracer.get_tracer("bioetl.processor")
+        span = otel_tracer.start_as_current_span(name, attributes=attributes)
+        span.__enter__()
+        return span
+
+    def _end_span(self, span: Any, error: Exception | None = None) -> None:
+        """End a tracing span.
+
+        Args:
+            span: Span object to end.
+            error: Optional exception to record.
+        """
+        if not span:
+            return
+        if error:
+            span.set_attribute("error", True)
+            span.record_exception(error)
+        span.__exit__(None, None, None)
 
     async def _transform_records_batch(
         self, records: list[dict[str, Any]], batch_id: BatchID
@@ -148,14 +191,30 @@ class RecordProcessor:
         records: list[dict[str, Any]],
         batch_id: BatchID,
     ) -> BatchResult:
-        """Process a batch of records through Bronze -> Silver -> Gold."""
+        """Process a batch of records through Bronze -> Silver -> Gold.
+
+        Creates nested spans for each stage:
+        - write_bronze: Writing raw records to Bronze layer
+        - transform: Transforming records to Silver/Gold formats
+        - write_silver: Writing to Silver Delta Lake
+        - write_gold: Writing to Gold Delta Lake
+        """
         # Use context.started_at as single source of time (see ADR-014)
         ingestion_ts = self._context.started_at
 
-        # 1. Write to Bronze
+        # 1. Write to Bronze with span
+        span = self._start_span(
+            "write_bronze",
+            **{
+                "bioetl.batch_id": str(batch_id),
+                "bioetl.record_count": len(records),
+            },
+        )
         try:
             await self._write_bronze_batch(records, batch_id, ingestion_ts)
+            self._end_span(span)
         except Exception as e:
+            self._end_span(span, e)
             self._log_and_track_write_error("bronze", e, batch_id)
             raise
 
@@ -163,10 +222,27 @@ class RecordProcessor:
         self._batch_metrics.track_batch_size("bronze", records_bronze)
         self._batch_metrics.track_processed_records("bronze", records_bronze)
 
-        # 2. Transform and collect Silver/Gold
-        silver_records, gold_records, records_quarantined = (
-            await self._transform_records_batch(records, batch_id)
+        # 2. Transform and collect Silver/Gold with span
+        span = self._start_span(
+            "transform",
+            **{
+                "bioetl.batch_id": str(batch_id),
+                "bioetl.input_count": len(records),
+            },
         )
+        try:
+            silver_records, gold_records, records_quarantined = (
+                await self._transform_records_batch(records, batch_id)
+            )
+            if span:
+                span.set_attribute("bioetl.silver_count", len(silver_records))
+                span.set_attribute("bioetl.gold_count", len(gold_records))
+                span.set_attribute("bioetl.quarantined_count", records_quarantined)
+            self._end_span(span)
+        except Exception as e:
+            self._end_span(span, e)
+            raise
+
         self._collect_dq_stats(records, records_quarantined)
 
         # Update metrics
@@ -174,19 +250,37 @@ class RecordProcessor:
         self._batch_metrics.track_processed_records("silver", len(silver_records))
         self._batch_metrics.track_processed_records("gold", len(gold_records))
 
-        # 3. Write to Silver
+        # 3. Write to Silver with span
         if silver_records:
+            span = self._start_span(
+                "write_silver",
+                **{
+                    "bioetl.batch_id": str(batch_id),
+                    "bioetl.record_count": len(silver_records),
+                },
+            )
             try:
                 await self._write_silver_batch(silver_records, batch_id, ingestion_ts)
+                self._end_span(span)
             except Exception as e:
+                self._end_span(span, e)
                 self._log_and_track_write_error("silver", e, batch_id)
                 raise
 
-        # 4. Write to Gold
+        # 4. Write to Gold with span
         if gold_records:
+            span = self._start_span(
+                "write_gold",
+                **{
+                    "bioetl.batch_id": str(batch_id),
+                    "bioetl.record_count": len(gold_records),
+                },
+            )
             try:
                 await self._write_gold_batch(gold_records)
+                self._end_span(span)
             except Exception as e:
+                self._end_span(span, e)
                 self._log_and_track_write_error("gold", e, batch_id)
                 raise
 

--- a/src/bioetl/application/core/runner.py
+++ b/src/bioetl/application/core/runner.py
@@ -113,7 +113,13 @@ class PipelineRunner:
         return self._services
 
     async def run(self) -> None:
-        """Execute pipeline. Main entry point."""
+        """Execute pipeline. Main entry point.
+
+        Implements graceful shutdown (O3):
+        - Uses try/finally to ensure cleanup runs on all exit paths
+        - Flushes tracer spans before shutdown
+        - Handles tracer close errors without failing the pipeline
+        """
         self._logger.info(
             f"Starting pipeline: {self._config.pipeline_name}",
             extra={"stage": "startup", "run_type": self._runtime.run_type.value},
@@ -129,36 +135,56 @@ class PipelineRunner:
             tracer=self._tracer,
         )
 
-        with observer:
-            # Observer handles ShutdownSignal suppression and status recording
-            async with self._services, self._lock_manager:
-                # Pre-flight health check: validate infrastructure before execution
-                await self._validate_infrastructure()
+        try:
+            with observer:
+                # Observer handles ShutdownSignal suppression and status recording
+                async with self._services, self._lock_manager:
+                    # Pre-flight health check: validate infrastructure before execution
+                    await self._validate_infrastructure()
 
-                # Clear data exports at the start of the run
-                # to avoid appending to stale data from previous runs
-                await self._clear_via_lifecycle()
+                    # Clear data exports at the start of the run
+                    # to avoid appending to stale data from previous runs
+                    await self._clear_via_lifecycle()
 
-                # Load checkpoint metadata (for logging purposes)
-                await self._checkpoint_manager.load_checkpoint()
-                await self._executor.execute(
-                    limit=self._runtime.limit,
-                    query=self._runtime.query,
+                    # Load checkpoint metadata (for logging purposes)
+                    await self._checkpoint_manager.load_checkpoint()
+                    await self._executor.execute(
+                        limit=self._runtime.limit,
+                        query=self._runtime.query,
+                    )
+
+                    # Check data quality after execution
+                    await self._check_data_quality()
+
+                    # Run VACUUM if enabled (Phase 1 refactoring)
+                    await self._run_vacuum_if_enabled()
+
+                    await self._checkpoint_manager.delete_checkpoint()
+
+                # Add extra info to logs if needed, though observer handles success/failure logging
+                self._logger.debug(
+                    "Pipeline execution finished",
+                    extra={"records_fetched": self._executor.records_fetched},
                 )
+        finally:
+            await self._cleanup()
 
-                # Check data quality after execution
-                await self._check_data_quality()
+    async def _cleanup(self) -> None:
+        """Cleanup all resources including observability.
 
-                # Run VACUUM if enabled (Phase 1 refactoring)
-                await self._run_vacuum_if_enabled()
-
-                await self._checkpoint_manager.delete_checkpoint()
-
-            # Add extra info to logs if needed, though observer handles success/failure logging
-            self._logger.debug(
-                "Pipeline execution finished",
-                extra={"records_fetched": self._executor.records_fetched},
-            )
+        Ensures tracer spans are flushed before shutdown (O3).
+        Handles errors gracefully to avoid masking pipeline exceptions.
+        """
+        # Flush tracer spans - explicit cleanup for graceful shutdown
+        if self._tracer is not None:
+            try:
+                self._tracer.close()
+                self._logger.debug("Tracer closed successfully")
+            except Exception as e:
+                self._logger.warning(
+                    "Failed to close tracer",
+                    error=str(e),
+                )
 
     async def _validate_infrastructure(self) -> None:
         """Validate infrastructure health before pipeline execution.

--- a/src/bioetl/application/observability/observer.py
+++ b/src/bioetl/application/observability/observer.py
@@ -126,13 +126,17 @@ class PipelineObserver(AbstractContextManager["PipelineObserver"]):
         else:
             self.logger.info("pipeline_finished", **log_ctx)
 
-        # 3. End Trace Span
+        # 3. End Trace Span (O3: handle close errors gracefully)
         if self.span:
-            self.span.set_attribute("bioetl.status", status)
-            self.span.set_attribute("bioetl.duration_ms", duration * 1000)
-            if status == "failed":
-                self.span.record_exception(exc_val)
-                self.span.set_attribute("error", True)
-            self.span.__exit__(exc_type, exc_val, exc_tb)
+            try:
+                self.span.set_attribute("bioetl.status", status)
+                self.span.set_attribute("bioetl.duration_ms", duration * 1000)
+                if status == "failed":
+                    self.span.record_exception(exc_val)
+                    self.span.set_attribute("error", True)
+                self.span.__exit__(exc_type, exc_val, exc_tb)
+            except Exception:
+                # Best effort - don't fail the pipeline on tracing cleanup
+                pass
 
         return suppress_exception

--- a/tests/unit/application/observability/test_observer.py
+++ b/tests/unit/application/observability/test_observer.py
@@ -1,4 +1,8 @@
-"""Unit tests for PipelineObserver."""
+"""Unit tests for PipelineObserver.
+
+Tests cover:
+- O4: Observer tests for duration, errors, graceful shutdown
+"""
 
 from __future__ import annotations
 
@@ -26,7 +30,27 @@ def logger_mock():
     mock.info = MagicMock()
     mock.error = MagicMock()
     mock.warning = MagicMock()
+    mock.debug = MagicMock()
     return mock
+
+
+@pytest.fixture
+def tracer_mock():
+    """Create a mock tracer that returns a mock span."""
+    mock_span = MagicMock()
+    mock_span.__enter__ = MagicMock(return_value=mock_span)
+    mock_span.__exit__ = MagicMock(return_value=None)
+    mock_span.set_attribute = MagicMock()
+    mock_span.record_exception = MagicMock()
+
+    mock_otel_tracer = MagicMock()
+    mock_otel_tracer.start_as_current_span = MagicMock(return_value=mock_span)
+
+    mock_tracer = MagicMock()
+    mock_tracer.get_tracer = MagicMock(return_value=mock_otel_tracer)
+    mock_tracer.close = MagicMock()
+
+    return mock_tracer
 
 
 @pytest.fixture
@@ -105,3 +129,117 @@ def test_pipeline_observer_shutdown(metrics_mock, logger_mock, run_id):
 
     # Verify warning was logged
     logger_mock.warning.assert_called_once()
+
+
+# ==================== O4: New Observer Tests ====================
+
+
+def test_observer_records_duration(metrics_mock, logger_mock, run_id):
+    """O4: Histogram records duration with correct labels."""
+    observer = PipelineObserver(
+        pipeline_name="chembl_activity",
+        run_id=run_id,
+        run_type=RunType.REBUILD,
+        metrics=metrics_mock,
+        logger=logger_mock,
+    )
+
+    with observer:
+        pass  # Successful execution
+
+    # Verify histogram was called with correct metric name
+    metrics_mock.observe_histogram.assert_called_once()
+    call_args = metrics_mock.observe_histogram.call_args
+
+    # Check metric name
+    assert call_args[0][0] == "bioetl_pipeline_duration_seconds"
+
+    # Check duration is a positive float
+    duration = call_args[0][1]
+    assert isinstance(duration, float)
+    assert duration >= 0
+
+    # Check labels contain required fields
+    labels = call_args[1]["labels"]
+    assert labels["pipeline"] == "chembl_activity"
+    assert labels["run_type"] == "rebuild"
+    assert labels["status"] == "success"
+
+
+def test_observer_tracks_errors(metrics_mock, logger_mock, run_id):
+    """O4: Counter increments by error_type on failure."""
+    observer = PipelineObserver(
+        pipeline_name="test_pipeline",
+        run_id=run_id,
+        run_type=RunType.INCREMENTAL,
+        metrics=metrics_mock,
+        logger=logger_mock,
+    )
+
+    with pytest.raises(RuntimeError), observer:
+        raise RuntimeError("Test error")
+
+    # Verify counter was incremented for failed status
+    metrics_mock.increment_counter.assert_called_once()
+    call_args = metrics_mock.increment_counter.call_args
+
+    assert call_args[0][0] == "bioetl_pipeline_runs_total"
+    assert call_args[0][1] == 1
+    assert call_args[1]["labels"]["status"] == "failed"
+
+    # Verify error was logged with error_type
+    logger_mock.error.assert_called_once()
+    error_call_args = logger_mock.error.call_args
+    assert "error_type" in error_call_args[1]
+    assert error_call_args[1]["error_type"] == "RuntimeError"
+
+
+def test_observer_graceful_shutdown(metrics_mock, logger_mock, tracer_mock, run_id):
+    """O4: Spans are flushed at close()."""
+    observer = PipelineObserver(
+        pipeline_name="test_pipeline",
+        run_id=run_id,
+        run_type=RunType.INCREMENTAL,
+        metrics=metrics_mock,
+        logger=logger_mock,
+        tracer=tracer_mock,
+    )
+
+    with observer:
+        pass  # Successful execution
+
+    # Verify span was created and ended properly
+    tracer_mock.get_tracer.assert_called_once_with("bioetl.pipeline")
+
+    # Verify span __enter__ and __exit__ were called
+    mock_span = tracer_mock.get_tracer.return_value.start_as_current_span.return_value
+    mock_span.__enter__.assert_called_once()
+    mock_span.__exit__.assert_called_once()
+
+    # Verify span attributes were set
+    mock_span.set_attribute.assert_any_call("bioetl.status", "success")
+
+
+def test_observer_handles_close_error(metrics_mock, logger_mock, tracer_mock, run_id):
+    """O4: Error at close() doesn't fail pipeline."""
+    # Configure tracer to raise error on span exit
+    mock_span = tracer_mock.get_tracer.return_value.start_as_current_span.return_value
+    mock_span.__exit__ = MagicMock(side_effect=Exception("Tracer close error"))
+
+    observer = PipelineObserver(
+        pipeline_name="test_pipeline",
+        run_id=run_id,
+        run_type=RunType.INCREMENTAL,
+        metrics=metrics_mock,
+        logger=logger_mock,
+        tracer=tracer_mock,
+    )
+
+    # Should not raise despite tracer error
+    with observer:
+        pass
+
+    # Pipeline should still record success metrics
+    metrics_mock.observe_histogram.assert_called_once()
+    call_args = metrics_mock.observe_histogram.call_args
+    assert call_args[1]["labels"]["status"] == "success"


### PR DESCRIPTION
O1: Add TracingContext to BaseTransformer
- Add optional tracer and metrics to constructor
- Wrap transform() with span "transform_record"
- Record transform_duration_seconds histogram by entity_type
- Track transform_errors_total counter by error_type

O2: Add TracingContext to PipelineExecutor and RecordProcessor
- Add root span for each batch with batch_id, record_count, run_type
- Add nested spans: write_bronze → transform → write_silver → write_gold
- Include span attributes for record counts and batch metadata

O3: Add graceful shutdown for tracer in PipelineRunner
- Wrap run() in try/finally to ensure cleanup runs
- Add _cleanup() method to flush tracer spans
- Handle tracer close errors without failing pipeline

O4: Add observer tests for observability
- test_observer_records_duration: Histogram with correct labels
- test_observer_tracks_errors: Counter by error_type
- test_observer_graceful_shutdown: Spans flushed at close()
- test_observer_handles_close_error: Error handling for close