### PR TITLE
Update documentation rules and automation checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,6 +335,7 @@ await self._run_in_executor(sync_func, *args)
 ### Архитектура
 - ❌ Импорт `infrastructure` в `domain` или `application`
 - ❌ Создание зависимостей внутри классов
+- ❌ Прямой импорт `structlog` в `application` или `interfaces` → Использовать `LoggerPort`
 
 ### Код
 - ❌ Sentinel values (`-1`, `"N/A"`, `9999`) → Использовать `None`

--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,9 @@ quality: lint arch-lint complexity typecheck ## Run all quality checks
 	@echo "$(GREEN)All quality checks passed!$(NC)"
 
 # CI/CD targets
+ci: lint test arch-all ## Run complete CI pipeline (lint + test + architecture)
+	@echo "$(GREEN)CI checks complete!$(NC)"
+
 ci-lint: lint security arch-lint ## Run all CI linting checks
 
 ci-test: test arch-all ## Run all tests for CI (includes architecture checks)

--- a/docs/02-architecture/decisions/ADR-014-deterministic-writes.md
+++ b/docs/02-architecture/decisions/ADR-014-deterministic-writes.md
@@ -91,6 +91,14 @@ await quarantine.write(..., ingestion_ts=ingestion_ts)
 |------|------|
 | `test_no_random_in_writers` | Блокирует `import random` в `infrastructure/storage/` |
 | `test_no_datetime_now_in_infrastructure` | Блокирует `datetime.now()` в `infrastructure/` |
+| `test_no_structlog_in_application_interfaces` | Блокирует прямой импорт `structlog` в `application/` и `interfaces/` |
+
+### 5. Изоляция логирования
+
+Application и interfaces слои **MUST NOT** импортировать `structlog` напрямую — использовать абстракцию `LoggerPort` из `domain.ports`. Это обеспечивает:
+- Тестируемость (можно подменить логгер в тестах)
+- Независимость от конкретной реализации
+- Единообразие обработки ошибок
 
 ## Justification
 
@@ -126,6 +134,7 @@ await quarantine.write(..., ingestion_ts=ingestion_ts)
 
 - `tests/architecture/test_no_random_in_writers.py`
 - `tests/architecture/test_no_datetime_now_in_infrastructure.py`
+- `tests/architecture/test_no_structlog_in_application_interfaces.py`
 
 ## Alternatives Considered
 
@@ -169,3 +178,5 @@ with frozen_time(timestamp):
 - RULES.md §4.3 Детерминизм и Воспроизводимость
 - `tests/architecture/test_no_random_in_writers.py`
 - `tests/architecture/test_no_datetime_now_in_infrastructure.py`
+- `tests/architecture/test_no_structlog_in_application_interfaces.py`
+- ADR-006 Logger and Metrics Ports

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -247,11 +247,12 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 - **Hard Threshold**: >20% ошибок -> Fail Batch. 
 - **Metric Scope**: Отслеживать как `record_error_rate` (доля битых строк), так и `entity_error_rate` (доля битых уникальных сущностей). 
  
-### 3.1.3. Параметры Retry (Backoff) 
-Для типа ошибок **Recoverable** применять стратегию Exponential Backoff: 
-- **Max Attempts**: 3 
-- **Multiplier**: 2.0 (wait 1s, 2s, 4s...) 
+### 3.1.3. Параметры Retry (Backoff)
+Для типа ошибок **Recoverable** применять стратегию Exponential Backoff:
+- **Max Attempts**: 3
+- **Multiplier**: 2.0 (wait 1s, 2s, 4s...)
 - **Jitter**: Random(0.1s, 0.5s). Jitter **SHOULD** применяться для избежания thundering herd.
+- **Deterministic Mode**: При `RetryConfig(deterministic=True)` jitter **MUST** вычисляться через hash вместо random для воспроизводимости. См. [ADR-014](02-architecture/decisions/ADR-014-deterministic-writes.md).
  
 ### 3.1.4. Circuit Breaker (Размыкатель цепи)
 Паттерн защиты от каскадных сбоев. См. [ADR-007](02-architecture/decisions/ADR-007-circuit-breaker-implementation.md).
@@ -432,14 +433,16 @@ class LegacyAdapter(BaseSyncAdapter):
 2. Timestamps **MUST** передаваться из application слоя, не создаваться в infrastructure
 3. Retry jitter **MUST** быть детерминистичным при `deterministic=True`
 4. `PipelineContext.started_at` — единственный источник времени для batch
+5. Application и Interfaces слои **MUST NOT** импортировать `structlog` напрямую — использовать `LoggerPort`
 
 #### Архитектурные Тесты (REQ-ARCH-030)
 | Тест | Цель | Проверки |
 |------|------|----------|
 | `test_no_random_in_writers` | Блокирует `random` в storage writers | `import random`, `from random import`, `random.uniform()`, `random.choice()` |
 | `test_no_datetime_now_in_infrastructure` | Блокирует `datetime.now()` в infra | `datetime.now()`, `datetime.datetime.now()` |
+| `test_no_structlog_in_application_interfaces` | Блокирует прямой импорт `structlog` | `import structlog`, `from structlog import` |
 
-**Путь:** `tests/architecture/test_no_random_in_writers.py`, `tests/architecture/test_no_datetime_now_in_infrastructure.py`
+**Путь:** `tests/architecture/test_no_random_in_writers.py`, `tests/architecture/test_no_datetime_now_in_infrastructure.py`, `tests/architecture/test_no_structlog_in_application_interfaces.py`
 
 #### Детерминистичный Jitter
 ```python
@@ -796,7 +799,7 @@ fields:
 | [ADR-015](02-architecture/decisions/ADR-015-pipeline-services-lifecycle.md) | Pipeline Services Lifecycle | Accepted | 2025-12-24 |
 
 ## История Изменений (Changelog)
-- **5.4** (2025-12-25): Architecture Documentation Update. Добавлены §1.1.2 (Health Check Protocol), §2.4.2 (Medallion Clear Policy), §4.4 (Python Standards), §5.3.2 (Async Cleanup). Реестр ADR расширен (011-015).
+- **5.4** (2025-12-25): Architecture Documentation Update. Добавлены §1.1.2 (Health Check Protocol), §2.4.2 (Medallion Clear Policy), §4.4 (Python Standards), §5.3.2 (Async Cleanup). Реестр ADR расширен (011-015). Добавлено ограничение на structlog в application/interfaces (§4.3, тест `test_no_structlog_in_application_interfaces`). Добавлен deterministic mode для retry jitter (§3.1.3).
 - **5.3** (2025-12-24): Determinism and Reproducibility (ADR-014). Добавлен §4.3 с правилами детерминизма. Архитектурные тесты для random и datetime.now().
 - **5.2** (2025-12-23): Local-Only Deployment (ADR-010). Обновлены §3.3 и §8.2 для MemoryLock. ADR-003 superseded.
 - **5.1** (2025-12-22): ADR additions (007-009), ADR index appendix.
@@ -810,5 +813,4 @@ fields:
 - **4.0** (2025-05-20): Data Contracts, Partitioning, Null Policy, Recovery Playbook. 
 - **3.0** (2025-05-20): Lineage, Backfill, Concurrency, Graceful Shutdown, Dev Experience. 
 - **2.0** (2025-05-20): Классификация ошибок, Medallion, Rate limiting, Перевод на русский. 
-- **1.0** (2025-04-01): Черновик. 
-2
+- **1.0** (2025-04-01): Черновик.

--- a/tests/architecture/test_no_structlog_in_application_interfaces.py
+++ b/tests/architecture/test_no_structlog_in_application_interfaces.py
@@ -1,0 +1,113 @@
+"""Architecture test: structlog только в infrastructure/composition слоях.
+
+REQ-ARCH-032: Application и interfaces слои используют LoggerPort абстракцию.
+См. ADR-006 для обоснования.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+APPLICATION_DIR = Path("src/bioetl/application")
+INTERFACES_DIR = Path("src/bioetl/interfaces")
+
+
+def _check_structlog_imports(directory: Path) -> list[str]:
+    """Check for direct structlog imports in a directory.
+
+    Args:
+        directory: Directory to scan for Python files.
+
+    Returns:
+        List of violation messages with file path and line number.
+    """
+    violations = []
+
+    if not directory.exists():
+        return violations
+
+    for py_file in directory.rglob("*.py"):
+        try:
+            source = py_file.read_text(encoding="utf-8")
+            tree = ast.parse(source)
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "structlog":
+                        rel_path = py_file.relative_to(Path("src"))
+                        violations.append(
+                            f"{rel_path}:{node.lineno}: import structlog"
+                        )
+            elif isinstance(node, ast.ImportFrom):
+                if node.module and node.module.startswith("structlog"):
+                    rel_path = py_file.relative_to(Path("src"))
+                    violations.append(
+                        f"{rel_path}:{node.lineno}: from {node.module} import ..."
+                    )
+
+    return violations
+
+
+class TestNoStructlogInApplicationLayer:
+    """Test that application layer does not import structlog directly."""
+
+    def test_no_structlog_in_application_layer(self) -> None:
+        """Application layer MUST NOT import structlog directly.
+
+        REQ-ARCH-032: Use LoggerPort abstraction instead.
+        See ADR-006 for rationale.
+        """
+        violations = _check_structlog_imports(APPLICATION_DIR)
+
+        assert not violations, (
+            f"Direct structlog imports found in application layer:\n"
+            + "\n".join(f"  - {v}" for v in violations)
+            + "\n\nUse LoggerPort from domain.ports instead. See ADR-006."
+        )
+
+
+class TestNoStructlogInInterfacesLayer:
+    """Test that interfaces layer does not import structlog directly."""
+
+    def test_no_structlog_in_interfaces_layer(self) -> None:
+        """Interfaces layer MUST NOT import structlog directly.
+
+        REQ-ARCH-032: Use LoggerPort abstraction instead.
+        See ADR-006 for rationale.
+        """
+        violations = _check_structlog_imports(INTERFACES_DIR)
+
+        assert not violations, (
+            f"Direct structlog imports found in interfaces layer:\n"
+            + "\n".join(f"  - {v}" for v in violations)
+            + "\n\nUse LoggerPort from domain.ports instead. See ADR-006."
+        )
+
+
+@pytest.mark.parametrize(
+    "layer_name,layer_dir",
+    [
+        ("application", APPLICATION_DIR),
+        ("interfaces", INTERFACES_DIR),
+    ],
+)
+def test_no_structlog_parametrized(layer_name: str, layer_dir: Path) -> None:
+    """Parametrized test for structlog imports in multiple layers.
+
+    Args:
+        layer_name: Name of the layer being tested.
+        layer_dir: Directory path of the layer.
+    """
+    violations = _check_structlog_imports(layer_dir)
+
+    assert not violations, (
+        f"Direct structlog imports found in {layer_name} layer:\n"
+        + "\n".join(f"  - {v}" for v in violations)
+        + f"\n\nThe {layer_name} layer MUST use LoggerPort abstraction. See ADR-006."
+    )


### PR DESCRIPTION
- Add deterministic mode requirement to §3.1.3 retry logic
- Add structlog import restriction to §4.3 MUST list
- Add structlog anti-pattern to CLAUDE.md §11
- Create architecture test for structlog imports in application/interfaces
- Update ADR-014 with structlog isolation requirement
- Add unified `make ci` target to Makefile
- Update changelog to reflect v5.4 additions