### PR TITLE
Update documentation on testing mock preferences

### DIFF
--- a/.claude/PROJECT_CONTEXT.md
+++ b/.claude/PROJECT_CONTEXT.md
@@ -213,7 +213,7 @@ sha256(provider + canonical_json(record))
 
 | Уровень | Директория | Правила |
 |---------|------------|---------|
-| **Unit** | `tests/unit/` | Изолированные, in-memory fakes. **БЕЗ моков** внешних библиотек. |
+| **Unit** | `tests/unit/` | Изолированные, in-memory fakes предпочтительны, MagicMock допустим. |
 | **Integration** | `tests/integration/` | VCR.py для HTTP. Очистка секретов из кассет. |
 | **E2E** | `tests/e2e/` | `@pytest.mark.e2e`, in-memory инфраструктура |
 | **Architecture** | `tests/architecture/` | Проверка слоёв, imports, именования |
@@ -287,7 +287,7 @@ await loop.run_in_executor(thread_pool, fetch_func)
 - ❌ `print()` → `structlog` с `run_id`
 
 ### Тесты
-- ❌ Мокинг доменных сущностей → Реальные Value Objects
+- ⚠️ Мокинг доменных сущностей → Реальные Value Objects предпочтительны, MagicMock допустим
 - ❌ HTTP без VCR → VCR-кассеты обязательны
 - ❌ Секреты в кассетах → Очистка в `before_record`
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -153,7 +153,7 @@ src/bioetl/
 
 | Уровень | Директория | Правила |
 |---------|------------|---------|
-| **Unit** | `tests/unit/` | Изолированные, in-memory fakes. **БЕЗ моков** внешних библиотек. |
+| **Unit** | `tests/unit/` | Изолированные, in-memory fakes предпочтительны, MagicMock допустим. |
 | **Integration** | `tests/integration/` | VCR.py для HTTP. Очистка секретов из кассет. |
 | **E2E** | `tests/e2e/` | `@pytest.mark.e2e`, in-memory инфраструктура |
 | **Architecture** | `tests/architecture/` | Проверка слоёв, imports, именования |
@@ -205,7 +205,7 @@ flowchart TD
 - **Игнорирование Rate Limits:** Отсутствие `TokenBucket` или аналога в адаптерах.
 
 ### 6.3. Тестирование
-- **Мокинг доменных сущностей:** `mock_activity = Mock(spec=Activity)`. **MUST** использовать реальные Value Objects.
+- **Мокинг доменных сущностей:** Реальные Value Objects предпочтительны, MagicMock допустим.
 - **Тесты без VCR для HTTP:** `real_api_call()`. **MUST** записывать HTTP-ответы в VCR-кассеты.
 - **Секреты в кассетах:** Забыть очистить `Authorization` или `X-API-Key` из фикстур.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,7 @@ sha256(provider + canonical_json(record))
 
 | Уровень | Директория | Тестов | Правила |
 |---------|------------|--------|---------|
-| **Unit** | `tests/unit/` | ~1294 | Изолированные, in-memory fakes. **БЕЗ моков** внешних библиотек. |
+| **Unit** | `tests/unit/` | ~1294 | Изолированные, in-memory fakes предпочтительны, MagicMock допустим. |
 | **Integration** | `tests/integration/` | ~80 | VCR.py для HTTP. Очистка секретов из кассет. |
 | **E2E** | `tests/e2e/` | - | `@pytest.mark.e2e`, Local-Only архитектура |
 | **Architecture** | `tests/architecture/` | 97 | Проверка слоёв, imports, контракты портов |
@@ -344,7 +344,7 @@ await self._run_in_executor(sync_func, *args)
 - ❌ `print()` → `structlog` с `run_id`
 
 ### Тесты
-- ❌ Мокинг доменных сущностей → Реальные Value Objects
+- ⚠️ Мокинг доменных сущностей → Реальные Value Objects предпочтительны, MagicMock допустим
 - ❌ HTTP без VCR → VCR-кассеты обязательны
 - ❌ Секреты в кассетах → Очистка в `before_record`
 

--- a/docs/03-guides/testing.md
+++ b/docs/03-guides/testing.md
@@ -8,14 +8,14 @@
 - **Покрытие**: `pytest-cov`
 - **Запись HTTP**: `VCR.py`
 - **Property-based**: `Hypothesis`
-- **Mocking**: `unittest.mock` (для инфраструктуры), in-memory fakes (для домена)
+- **Mocking**: In-memory fakes предпочтительны, `unittest.mock.MagicMock` допустим
 
 ## 2. Уровни Тестирования
 
 ### 2.1. Unit Tests (`tests/unit/`)
 Изолированные тесты бизнес-логики и трансформаций.
 - **Domain**: Тестирование сущностей и чистых функций в `src/bioetl/domain/`.
-- **Application**: Тестирование трансформеров и логики пайплайнов с использованием моков портов.
+- **Application**: Тестирование трансформеров и логики пайплайнов. In-memory fakes предпочтительны, MagicMock допустим.
 - **Правило**: Никакого сетевого взаимодействия или реального ввода-вывода.
 
 ### 2.2. Integration Tests (`tests/integration/`)

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -413,7 +413,7 @@ class LegacyAdapter(BaseSyncAdapter):
 ### 4.2. Политика Тестирования
 **Цель покрытия:** >80% line coverage (проверяется в CI через `--cov-fail-under=80`).
 
-- **Unit**: Только доменная логика. In-memory фейки. Никаких моков (mocks) внешних библиотек.
+- **Unit**: Только доменная логика. In-memory fakes предпочтительны, MagicMock допустим.
 - **Integration**:
     - **VCR.py**: Запись ответов API в кассеты (`tests/fixtures/vcr/`).
     - **Санитизация**: Обязательная очистка секретов (`Authorization`, `X-API-Key`) и PII в хуке `before_record`.


### PR DESCRIPTION
…icMock allowed

Update testing documentation across all project files to clarify that:
- In-memory fakes remain the preferred approach for unit tests
- MagicMock usage is now explicitly allowed as an alternative

Files updated:
- CLAUDE.md
- AGENT.md
- docs/RULES.md
- docs/03-guides/testing.md
- .claude/PROJECT_CONTEXT.md