### PR TITLE
Add metrics to rate limiter

### DIFF
--- a/src/bioetl/infrastructure/adapters/http/rate_limiter.py
+++ b/src/bioetl/infrastructure/adapters/http/rate_limiter.py
@@ -9,6 +9,10 @@ from __future__ import annotations
 import asyncio
 import time
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bioetl.domain.ports import MetricsPort
 
 
 @dataclass
@@ -39,6 +43,8 @@ class TokenBucket:
 
     rate: float
     capacity: int
+    provider: str = "unknown"
+    metrics: MetricsPort | None = None
     _tokens: float = field(init=False)
     _last_refill: float = field(init=False)
     _lock: asyncio.Lock = field(init=False, default_factory=asyncio.Lock)
@@ -70,18 +76,45 @@ class TokenBucket:
             msg = f"Cannot acquire {tokens} tokens, capacity is {self.capacity}"
             raise ValueError(msg)
 
+        total_wait_time = 0.0
         async with self._lock:
             while True:
                 self._refill()
 
                 if self._tokens >= tokens:
                     self._tokens -= tokens
+                    self._record_metrics(total_wait_time)
                     return
 
                 # Calculate wait time for needed tokens
                 deficit = tokens - self._tokens
                 wait_time = deficit / self.rate
+                total_wait_time += wait_time
                 await asyncio.sleep(wait_time)
+
+    def _record_metrics(self, wait_time: float) -> None:
+        """Record rate limiter metrics.
+
+        Args:
+            wait_time: Total time spent waiting for tokens (seconds)
+
+        """
+        if self.metrics is None:
+            return
+
+        labels = {"provider": self.provider}
+
+        self.metrics.set_gauge(
+            "bioetl_rate_limiter_tokens_available",
+            self._tokens,
+            labels,
+        )
+
+        self.metrics.observe_histogram(
+            "bioetl_rate_limiter_wait_seconds",
+            wait_time,
+            labels,
+        )
 
     def available_tokens(self) -> int:
         """Return current available tokens (floor of float value)."""
@@ -107,44 +140,80 @@ class TokenBucket:
 
 
 # Pre-configured buckets for known providers
-def create_pubchem_bucket() -> TokenBucket:
-    """Create rate limiter for PubChem (5 req/sec)."""
-    return TokenBucket(rate=5.0, capacity=5)
+def create_pubchem_bucket(
+    metrics: MetricsPort | None = None,
+) -> TokenBucket:
+    """Create rate limiter for PubChem (5 req/sec).
+
+    Args:
+        metrics: Optional metrics port for observability
+
+    """
+    return TokenBucket(rate=5.0, capacity=5, provider="pubchem", metrics=metrics)
 
 
-def create_uniprot_bucket(with_api_key: bool = False) -> TokenBucket:
+def create_uniprot_bucket(
+    with_api_key: bool = False,
+    metrics: MetricsPort | None = None,
+) -> TokenBucket:
     """Create rate limiter for UniProt.
 
     Args:
         with_api_key: True if using API key (100 req/sec vs default)
+        metrics: Optional metrics port for observability
 
     """
     rate = 100.0 if with_api_key else 10.0
-    return TokenBucket(rate=rate, capacity=int(rate))
+    return TokenBucket(rate=rate, capacity=int(rate), provider="uniprot", metrics=metrics)
 
 
-def create_openalex_bucket() -> TokenBucket:
-    """Create rate limiter for OpenAlex (10 req/sec polite)."""
-    return TokenBucket(rate=10.0, capacity=10)
+def create_openalex_bucket(
+    metrics: MetricsPort | None = None,
+) -> TokenBucket:
+    """Create rate limiter for OpenAlex (10 req/sec polite).
+
+    Args:
+        metrics: Optional metrics port for observability
+
+    """
+    return TokenBucket(rate=10.0, capacity=10, provider="openalex", metrics=metrics)
 
 
-def create_crossref_bucket() -> TokenBucket:
-    """Create rate limiter for Crossref (50 req/sec polite)."""
-    return TokenBucket(rate=50.0, capacity=50)
+def create_crossref_bucket(
+    metrics: MetricsPort | None = None,
+) -> TokenBucket:
+    """Create rate limiter for Crossref (50 req/sec polite).
+
+    Args:
+        metrics: Optional metrics port for observability
+
+    """
+    return TokenBucket(rate=50.0, capacity=50, provider="crossref", metrics=metrics)
 
 
-def create_semantic_scholar_bucket() -> TokenBucket:
-    """Create rate limiter for Semantic Scholar (100 req/5min)."""
+def create_semantic_scholar_bucket(
+    metrics: MetricsPort | None = None,
+) -> TokenBucket:
+    """Create rate limiter for Semantic Scholar (100 req/5min).
+
+    Args:
+        metrics: Optional metrics port for observability
+
+    """
     # 100 requests per 5 minutes = 0.333 req/sec
-    return TokenBucket(rate=0.333, capacity=10)
+    return TokenBucket(rate=0.333, capacity=10, provider="semantic_scholar", metrics=metrics)
 
 
-def create_pubmed_bucket(with_api_key: bool = False) -> TokenBucket:
+def create_pubmed_bucket(
+    with_api_key: bool = False,
+    metrics: MetricsPort | None = None,
+) -> TokenBucket:
     """Create rate limiter for PubMed.
 
     Args:
         with_api_key: True if using API key (10 req/sec vs 3 req/sec)
+        metrics: Optional metrics port for observability
 
     """
     rate = 10.0 if with_api_key else 3.0
-    return TokenBucket(rate=rate, capacity=int(rate))
+    return TokenBucket(rate=rate, capacity=int(rate), provider="pubmed", metrics=metrics)

--- a/tests/unit/infrastructure/test_rate_limiter.py
+++ b/tests/unit/infrastructure/test_rate_limiter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -11,6 +12,14 @@ from bioetl.infrastructure.adapters.http.rate_limiter import (
     create_pubchem_bucket,
     create_pubmed_bucket,
 )
+
+
+def create_mock_metrics() -> MagicMock:
+    """Create a mock MetricsPort for testing."""
+    mock = MagicMock()
+    mock.set_gauge = MagicMock()
+    mock.observe_histogram = MagicMock()
+    return mock
 
 
 class TestTokenBucket:
@@ -120,3 +129,108 @@ class TestFactoryFunctions:
         """PubMed bucket with API key should have 10 req/sec."""
         bucket = create_pubmed_bucket(with_api_key=True)
         assert bucket.rate == 10.0
+
+    @pytest.mark.unit
+    def test_create_pubchem_bucket_with_metrics(self) -> None:
+        """Factory should pass metrics to bucket."""
+        mock_metrics = create_mock_metrics()
+        bucket = create_pubchem_bucket(metrics=mock_metrics)
+        assert bucket.metrics is mock_metrics
+        assert bucket.provider == "pubchem"
+
+    @pytest.mark.unit
+    def test_create_pubmed_bucket_with_metrics(self) -> None:
+        """Factory should pass metrics to bucket."""
+        mock_metrics = create_mock_metrics()
+        bucket = create_pubmed_bucket(with_api_key=False, metrics=mock_metrics)
+        assert bucket.metrics is mock_metrics
+        assert bucket.provider == "pubmed"
+
+
+class TestTokenBucketMetrics:
+    """Tests for TokenBucket metrics integration."""
+
+    @pytest.mark.unit
+    async def test_acquire_records_metrics(self) -> None:
+        """acquire should record metrics when MetricsPort is provided."""
+        mock_metrics = create_mock_metrics()
+        bucket = TokenBucket(
+            rate=5.0,
+            capacity=10,
+            provider="test_provider",
+            metrics=mock_metrics,
+        )
+
+        await bucket.acquire(1)
+
+        mock_metrics.set_gauge.assert_called_once_with(
+            "bioetl_rate_limiter_tokens_available",
+            9.0,  # 10 - 1 token acquired
+            {"provider": "test_provider"},
+        )
+        mock_metrics.observe_histogram.assert_called_once_with(
+            "bioetl_rate_limiter_wait_seconds",
+            0.0,  # No wait when tokens are available
+            {"provider": "test_provider"},
+        )
+
+    @pytest.mark.unit
+    async def test_acquire_no_metrics_when_none(self) -> None:
+        """acquire should not fail when metrics is None."""
+        bucket = TokenBucket(rate=5.0, capacity=10, provider="test")
+
+        # Should not raise any exception
+        await bucket.acquire(1)
+
+        assert bucket.available_tokens() == 9
+
+    @pytest.mark.unit
+    async def test_acquire_records_wait_time(self) -> None:
+        """acquire should record non-zero wait time when waiting for tokens."""
+        mock_metrics = create_mock_metrics()
+        bucket = TokenBucket(
+            rate=100.0,  # 100 tokens/sec = 0.01s per token
+            capacity=1,
+            provider="test_wait",
+            metrics=mock_metrics,
+        )
+
+        # Consume the only token
+        await bucket.acquire(1)
+        mock_metrics.reset_mock()
+
+        # Next acquire should wait
+        await bucket.acquire(1)
+
+        # Verify metrics were recorded
+        mock_metrics.set_gauge.assert_called_once()
+        mock_metrics.observe_histogram.assert_called_once()
+
+        # Get the wait time from the histogram call
+        call_args = mock_metrics.observe_histogram.call_args
+        wait_time = call_args[0][1]
+
+        # Should have waited (non-zero wait time)
+        assert wait_time > 0.0
+        assert wait_time < 0.5  # But not too long
+
+    @pytest.mark.unit
+    async def test_metrics_called_with_correct_provider(self) -> None:
+        """Metrics should use the correct provider label."""
+        mock_metrics = create_mock_metrics()
+        bucket = TokenBucket(
+            rate=5.0,
+            capacity=10,
+            provider="custom_provider",
+            metrics=mock_metrics,
+        )
+
+        await bucket.acquire(1)
+
+        # Check gauge call
+        gauge_call = mock_metrics.set_gauge.call_args
+        assert gauge_call[0][2] == {"provider": "custom_provider"}
+
+        # Check histogram call
+        histogram_call = mock_metrics.observe_histogram.call_args
+        assert histogram_call[0][2] == {"provider": "custom_provider"}


### PR DESCRIPTION
Add MetricsPort integration to TokenBucket for better observability:
- bioetl_rate_limiter_tokens_available{provider} gauge for token balance
- bioetl_rate_limiter_wait_seconds{provider} histogram for wait time

Updated all factory functions to accept optional metrics parameter. Added 6 unit tests for metrics functionality.