### PR TITLE
Unify health check logic across adapters

### DIFF
--- a/src/bioetl/infrastructure/adapters/chembl/client.py
+++ b/src/bioetl/infrastructure/adapters/chembl/client.py
@@ -435,12 +435,16 @@ class ChemblAdapter(BaseHttpAdapter):
         and internal health state tracking.
 
         Returns:
-            HealthStatus based on status endpoint response or error count.
+            HealthStatus based on status endpoint response.
+
+        Raises:
+            Exception: On request failure (base class handles via _fallback_health_status).
 
         """
         try:
             response = await self.http_client.get(CHEMBL_STATUS_URL)
             self._handle_health_response(response)
+            return self._cached_health
         except Exception as e:
             self._consecutive_errors += 1
             self._update_health()
@@ -451,8 +455,7 @@ class ChemblAdapter(BaseHttpAdapter):
                 error_type=error_type.value,
                 error=str(e),
             )
-
-        return self._cached_health
+            raise  # Let base class handle via _fallback_health_status()
 
     def _fallback_health_status(self) -> HealthStatus:
         """Return cached health status.

--- a/src/bioetl/infrastructure/adapters/pubchem/client.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/client.py
@@ -251,15 +251,14 @@ class PubChemAdapter(BaseSyncAdapter):
         Overrides BaseSyncAdapter._probe_health() to use lightweight
         compound query (water, CID 962) for health assessment.
 
-        Unlike other adapters, PubChem handles exceptions internally
-        to return UNHEALTHY directly rather than using circuit breaker
-        fallback (preserving original behavior).
-
         Returns:
             HealthStatus based on probe response:
             - HEALTHY/DEGRADED: Based on circuit breaker state if compound found
             - DEGRADED: Empty response
-            - UNHEALTHY: Any exception or circuit breaker open
+            - UNHEALTHY: Circuit breaker is open
+
+        Raises:
+            Exception: On request failure (base class handles via _fallback_health_status).
 
         Example:
             >>> adapter = PubChemAdapter()
@@ -289,6 +288,7 @@ class PubChemAdapter(BaseSyncAdapter):
             return HealthStatus.DEGRADED
 
         except CircuitBreakerOpenError:
+            # Circuit breaker open - return UNHEALTHY directly
             self.logger.warning(
                 "health_check_circuit_open",
                 provider=self.provider_name,
@@ -304,7 +304,7 @@ class PubChemAdapter(BaseSyncAdapter):
                 error_type=error_type.value,
                 error=str(e),
             )
-            return HealthStatus.UNHEALTHY
+            raise  # Let base class handle via _fallback_health_status()
 
     def __repr__(self) -> str:
         """Return string representation."""

--- a/tests/infrastructure/adapters/test_pubchem.py
+++ b/tests/infrastructure/adapters/test_pubchem.py
@@ -156,8 +156,30 @@ async def test_health_check_healthy(pubchem_adapter, mock_pcp_compound):
         assert status == HealthStatus.HEALTHY
 
 
-async def test_health_check_unhealthy(pubchem_adapter):
-    """Test health check returns UNHEALTHY on exception."""
+async def test_health_check_degraded_on_probe_failure(pubchem_adapter):
+    """Test health check returns DEGRADED on single probe failure.
+
+    Uses Template Method pattern: exception in _probe_health() triggers
+    _fallback_health_status() which uses circuit breaker assessment.
+    With 1 failure (<=2 threshold), returns DEGRADED.
+    """
+    with patch("pubchempy.get_compounds", side_effect=Exception("Connection error")):
+        status = await pubchem_adapter.health_check()
+        assert status == HealthStatus.DEGRADED
+
+
+async def test_health_check_unhealthy_after_multiple_failures(pubchem_adapter):
+    """Test health check returns UNHEALTHY after multiple failures.
+
+    Circuit breaker records failures, and after threshold (>2),
+    assess_health_from_circuit_breaker returns UNHEALTHY.
+    """
+    # Trigger 3 failures to exceed the threshold (>2 for UNHEALTHY)
+    for _ in range(3):
+        with patch("pubchempy.get_compounds", side_effect=Exception("Connection error")):
+            await pubchem_adapter.health_check()
+
+    # Now health check should return UNHEALTHY
     with patch("pubchempy.get_compounds", side_effect=Exception("Connection error")):
         status = await pubchem_adapter.health_check()
         assert status == HealthStatus.UNHEALTHY


### PR DESCRIPTION
Ensure all adapters properly use the Template Method pattern for health checks:
- _probe_health() performs provider-specific probe and re-raises exceptions
- Base class health_check() catches exceptions and calls _fallback_health_status()

Changes:
- ChemblAdapter._probe_health(): Re-raise exceptions after updating internal state
- PubChemAdapter._probe_health(): Re-raise exceptions (except CircuitBreakerOpenError) to use base class fallback mechanism
- Update test to expect DEGRADED on single failure (circuit breaker behavior)
- Add test for UNHEALTHY after multiple failures

This eliminates duplication of try/except pattern across adapters and ensures consistent fallback behavior using circuit breaker assessment.