### PR TITLE
Decompose RecordProcessor into smaller modules

### DIFF
--- a/src/bioetl/application/core/__init__.py
+++ b/src/bioetl/application/core/__init__.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 from bioetl.application.core.base import BasePipeline
 from bioetl.application.core.base_transformer import BaseTransformer
+from bioetl.application.core.batch_transformer import BatchTransformer, TransformResult
+from bioetl.application.core.batch_writer import BatchWriter
 from bioetl.application.core.checkpoint_manager import CheckpointManager
 from bioetl.application.core.cleanup_service import (
     CleanupPreview,
@@ -49,6 +51,8 @@ from bioetl.domain.config import PipelineConfig, RuntimeConfig
 __all__ = [
     "BasePipeline",
     "BaseTransformer",
+    "BatchTransformer",
+    "BatchWriter",
     "CheckpointManager",
     "CleanupPreview",
     "CleanupResult",
@@ -67,6 +71,7 @@ __all__ = [
     "QuarantineManager",
     "RuntimeConfig",
     "ShutdownSignal",
+    "TransformResult",
     "VacuumResult",
     "aggregate_nested_lists",
     "extract_list_field",

--- a/src/bioetl/application/core/batch_transformer.py
+++ b/src/bioetl/application/core/batch_transformer.py
@@ -1,0 +1,174 @@
+"""Batch transformation from Bronze to Silver/Gold.
+
+Handles record transformation, error handling, and quarantine management.
+Extracted from RecordProcessor for single responsibility (SRP).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from bioetl.application.core.batch_metrics import BatchMetricsRecorder
+from bioetl.application.core.quarantine_manager import QuarantineManager
+from bioetl.domain.exceptions import DataQualityThresholdError
+
+if TYPE_CHECKING:
+    from bioetl.application.core.config import RecordProcessorConfig
+    from bioetl.application.core.protocols import (
+        GoldFilterCallback,
+        GoldTransformCallback,
+        TransformCallback,
+    )
+    from bioetl.domain.context import PipelineContext
+    from bioetl.domain.error_classifier import ErrorClassifier
+    from bioetl.domain.types import BatchID
+
+
+@dataclass(frozen=True, slots=True)
+class TransformResult:
+    """Result of batch transformation."""
+
+    silver_records: list[dict[str, Any]]
+    gold_records: list[dict[str, Any]]
+    quarantined_count: int
+
+
+class BatchTransformer:
+    """Transforms Bronze records to Silver/Gold with error handling.
+
+    Handles:
+    - Bronze → Silver transformation via callback
+    - Silver → Gold filtering and transformation
+    - Error classification and quarantine
+    - DQ threshold checking
+    """
+
+    def __init__(
+        self,
+        context: PipelineContext,
+        config: RecordProcessorConfig,
+        error_classifier: ErrorClassifier,
+        quarantine_manager: QuarantineManager,
+        batch_metrics: BatchMetricsRecorder,
+        transform_callback: TransformCallback,
+        gold_filter_callback: GoldFilterCallback,
+        gold_transform_callback: GoldTransformCallback,
+    ) -> None:
+        """Initialize batch transformer.
+
+        Args:
+            context: Pipeline execution context.
+            config: Record processor configuration.
+            error_classifier: Service for error classification.
+            quarantine_manager: Manager for quarantining failed records.
+            batch_metrics: Metrics recorder for batch processing.
+            transform_callback: Callback for Bronze -> Silver transformation.
+            gold_filter_callback: Callback for filtering Silver records.
+            gold_transform_callback: Callback for Silver -> Gold transformation.
+
+        """
+        self._context = context
+        self._config = config
+        self._error_classifier = error_classifier
+        self._quarantine_manager = quarantine_manager
+        self._batch_metrics = batch_metrics
+        self._transform = transform_callback
+        self._gold_filter = gold_filter_callback
+        self._gold_transform = gold_transform_callback
+
+    async def transform_batch(
+        self, records: list[dict[str, Any]], batch_id: BatchID
+    ) -> TransformResult:
+        """Transform all records in batch, returning silver, gold, and quarantine count.
+
+        Args:
+            records: Raw Bronze records to transform.
+            batch_id: Identifier for the current batch.
+
+        Returns:
+            TransformResult with silver records, gold records, and quarantine count.
+
+        Raises:
+            DataQualityThresholdError: If DQ hard threshold exceeded.
+
+        """
+        silver_records: list[dict[str, Any]] = []
+        gold_records: list[dict[str, Any]] = []
+        records_quarantined = 0
+
+        for raw_record in records:
+            record_context = self._context.bind_logger(
+                batch_id=str(batch_id),
+                entity_id=raw_record.get("activity_id"),
+            )
+            try:
+                transformed = await self._transform(record_context, raw_record)
+                if transformed:
+                    silver_records.append(transformed)
+                    if self._gold_filter(record_context, transformed):
+                        gold_record = self._gold_transform(record_context, transformed)
+                        gold_records.append(gold_record)
+            except Exception as e:
+                error_type = self._error_classifier.classify(e)
+                if error_type.is_data_quality():
+                    await self._quarantine_manager.quarantine_record(
+                        raw_record,
+                        error_type,
+                        batch_id,
+                        str(e),
+                        ingestion_ts=self._context.started_at,
+                    )
+                    records_quarantined += 1
+                    self._batch_metrics.track_error("transform", error_type)
+                    self._batch_metrics.track_quarantined_records(error_type, 1)
+                else:
+                    raise
+
+        # Check DQ thresholds after transformation
+        self._check_dq_thresholds(records, records_quarantined)
+
+        return TransformResult(
+            silver_records=silver_records,
+            gold_records=gold_records,
+            quarantined_count=records_quarantined,
+        )
+
+    def _check_dq_thresholds(
+        self, records: list[dict[str, Any]], quarantined_count: int
+    ) -> None:
+        """Check DQ thresholds and raise/warn as appropriate.
+
+        Args:
+            records: Original records in the batch.
+            quarantined_count: Number of quarantined records.
+
+        Raises:
+            DataQualityThresholdError: If hard threshold exceeded.
+
+        """
+        if not records:
+            return
+
+        total_count = len(records)
+        error_rate = quarantined_count / total_count if total_count > 0 else 0.0
+        dq_config = self._config.dq_config
+
+        if not dq_config:
+            return
+
+        # Hard fail check
+        if dq_config.hard_fail_threshold and error_rate >= dq_config.hard_fail_threshold:
+            raise DataQualityThresholdError(error_rate, dq_config.hard_fail_threshold)
+
+        # Soft fail check with detailed logging
+        if dq_config.soft_fail_threshold and error_rate >= dq_config.soft_fail_threshold:
+            self._context.logger.warning(
+                "DQ Soft Threshold exceeded",
+                error_rate=round(error_rate, 4),
+                threshold=dq_config.soft_fail_threshold,
+                quarantined_count=quarantined_count,
+                total_count=total_count,
+                hard_threshold=dq_config.hard_fail_threshold,
+                pipeline=self._config.pipeline_name,
+            )

--- a/src/bioetl/application/core/batch_writer.py
+++ b/src/bioetl/application/core/batch_writer.py
@@ -1,0 +1,227 @@
+"""Batch writing to Bronze, Silver, and Gold layers.
+
+Handles all storage operations with proper metadata enrichment.
+Extracted from RecordProcessor for single responsibility (SRP).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from bioetl.domain.exceptions import SchemaViolationError
+
+if TYPE_CHECKING:
+    from bioetl.application.core.batch_metrics import BatchMetricsRecorder
+    from bioetl.application.core.config import RecordProcessorConfig
+    from bioetl.domain.context import PipelineContext
+    from bioetl.domain.error_classifier import ErrorClassifier
+    from bioetl.domain.ports import GoldValidatorPort, StoragePort
+    from bioetl.domain.types import BatchID
+
+
+class BatchWriter:
+    """Writes records to Bronze, Silver, and Gold layers.
+
+    Handles:
+    - Bronze: JSONL serialization with deterministic ordering
+    - Silver: Metadata enrichment (_run_id, _run_type, etc.)
+    - Gold: Schema validation and column filtering
+    """
+
+    def __init__(
+        self,
+        storage: StoragePort,
+        context: PipelineContext,
+        config: RecordProcessorConfig,
+        gold_validator: GoldValidatorPort,
+        error_classifier: ErrorClassifier,
+        batch_metrics: BatchMetricsRecorder,
+    ) -> None:
+        """Initialize batch writer.
+
+        Args:
+            storage: Storage port for writing to all layers.
+            context: Pipeline execution context.
+            config: Record processor configuration.
+            gold_validator: Validator for Gold layer records.
+            error_classifier: Service for error classification.
+            batch_metrics: Metrics recorder for batch processing.
+
+        """
+        self._storage = storage
+        self._context = context
+        self._config = config
+        self._gold_validator = gold_validator
+        self._error_classifier = error_classifier
+        self._batch_metrics = batch_metrics
+
+        # Convenience properties
+        self._provider = config.provider
+        self._entity_type = config.entity_type
+        self._silver_schema = config.silver_schema
+        self._table_config = config.table_config
+
+    async def write_bronze(
+        self, records: list[dict[str, Any]], batch_id: BatchID, ingestion_ts: datetime
+    ) -> None:
+        """Write records to Bronze layer.
+
+        Serializes records to JSON with deterministic key ordering,
+        sorts by content for reproducibility.
+
+        Args:
+            records: Raw records to write.
+            batch_id: Identifier for the current batch.
+            ingestion_ts: Ingestion timestamp from context.
+
+        """
+        # Serialize with deterministic key ordering
+        json_strings = [json.dumps(r, sort_keys=True) for r in records]
+
+        # Sort for deterministic file content
+        json_strings.sort()
+
+        # Create generator for bytes
+        record_bytes = ((s + "\n").encode("utf-8") for s in json_strings)
+
+        await self._storage.write_bronze(
+            records=record_bytes,
+            provider=self._provider,
+            entity=self._entity_type,
+            date=ingestion_ts,
+            batch_id=batch_id,
+            run_id=self._context.run_id,
+            run_type=self._context.run_type,
+            ingestion_ts=ingestion_ts,
+        )
+
+    async def write_silver(
+        self, records: list[dict[str, Any]], batch_id: BatchID, ingestion_ts: datetime
+    ) -> None:
+        """Write records to Silver layer with metadata.
+
+        Enriches records with _run_id, _run_type, _source_batch_id, _ingestion_ts.
+
+        Args:
+            records: Transformed Silver records.
+            batch_id: Identifier for the source batch.
+            ingestion_ts: Ingestion timestamp from context.
+
+        """
+        records_with_meta = [
+            {
+                **r,
+                "_run_id": str(self._context.run_id),
+                "_run_type": self._context.run_type.value,
+                "_source_batch_id": str(batch_id),
+                "_ingestion_ts": ingestion_ts.isoformat(),
+            }
+            for r in records
+        ]
+
+        table_name = (
+            self._table_config.silver_table or f"{self._provider}.{self._entity_type}"
+        )
+
+        # For "overwrite" mode, use "append" for batch writes
+        write_mode = self._table_config.silver_write_mode
+        if write_mode == "overwrite":
+            write_mode = "append"
+
+        await self._storage.write_silver(
+            table_name=table_name,
+            records=records_with_meta,
+            primary_keys=self._table_config.primary_keys,
+            schema=self._silver_schema,
+            mode=write_mode,
+            on_schema_mismatch=self._table_config.on_schema_mismatch,
+        )
+
+    async def write_gold(self, records: list[dict[str, Any]]) -> None:
+        """Write records to Gold layer with validation.
+
+        Filters columns to match Gold schema, validates records.
+
+        Args:
+            records: Transformed Gold records.
+
+        Raises:
+            SchemaViolationError: If validation fails.
+
+        """
+        gold_schema = self._config.gold_schema
+        schema_columns = self._get_schema_columns(gold_schema)
+
+        # Filter to only include columns defined in Gold schema
+        if schema_columns:
+            records = [
+                {k: v for k, v in r.items() if k in schema_columns} for r in records
+            ]
+
+        # Validate Gold records
+        result = self._gold_validator.validate(records)
+        if not result.valid:
+            raise SchemaViolationError("gold", result.errors)
+
+        table_name = (
+            self._table_config.gold_table or f"{self._provider}.{self._entity_type}"
+        )
+
+        # For "overwrite" mode, use "append" for batch writes
+        write_mode = self._table_config.gold_write_mode
+        if write_mode == "overwrite":
+            write_mode = "append"
+
+        await self._storage.write_gold(
+            table_name=table_name,
+            records=records,
+            schema=gold_schema,
+            primary_keys=self._table_config.primary_keys,
+            mode=write_mode,
+        )
+
+    def _get_schema_columns(self, schema: Any) -> set[str] | None:
+        """Extract column names from Pandera schema.
+
+        Args:
+            schema: Pandera DataFrameModel or DataFrameSchema.
+
+        Returns:
+            Set of column names, or None if schema is not recognized.
+
+        """
+        # Handle Pandera DataFrameModel (class with to_schema method)
+        if hasattr(schema, "to_schema"):
+            try:
+                converted = schema.to_schema()
+                return set(converted.columns.keys())
+            except Exception:
+                pass
+
+        # Handle Pandera DataFrameSchema (instance with columns dict)
+        if hasattr(schema, "columns"):
+            return set(schema.columns.keys())
+
+        return None
+
+    def log_and_track_write_error(
+        self, layer: str, error: Exception, batch_id: BatchID
+    ) -> None:
+        """Log write error and track metrics.
+
+        Args:
+            layer: Layer name (bronze, silver, gold).
+            error: Exception that occurred.
+            batch_id: Identifier for the batch.
+
+        """
+        error_type = self._error_classifier.classify(error)
+        self._context.logger.error(
+            f"{layer} write failed",
+            error=str(error),
+            error_type=error_type.value,
+            batch_id=str(batch_id),
+        )
+        self._batch_metrics.track_error(f"{layer}_write", error_type)

--- a/src/bioetl/application/core/record_processor.py
+++ b/src/bioetl/application/core/record_processor.py
@@ -1,20 +1,17 @@
-"""Processes a batch of records through the Bronze, Silver, and Gold layers.
+"""Orchestrates batch processing through Bronze, Silver, and Gold layers.
 
-Observability (O2):
-- Nested spans for each stage: transform → write_bronze → write_silver → write_gold
-- Span attributes include record counts and batch metadata
+Observability: Nested spans for transform → write_bronze → write_silver → write_gold.
 """
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
-from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from bioetl.application.core.batch_metrics import BatchMetricsRecorder
+from bioetl.application.core.batch_transformer import BatchTransformer, TransformResult
+from bioetl.application.core.batch_writer import BatchWriter
 from bioetl.application.core.quarantine_manager import QuarantineManager
-from bioetl.domain.exceptions import DataQualityThresholdError, SchemaViolationError
 
 if TYPE_CHECKING:
     from bioetl.application.core.config import RecordProcessorConfig
@@ -41,14 +38,7 @@ class BatchResult:
 
 
 class RecordProcessor:
-    """Handles the transformation and writing of a single batch of records.
-
-    This class contains the core ETL logic for a batch.
-
-    Observability (O2):
-    - Nested spans for transform, write_bronze, write_silver, write_gold
-    - Each span includes relevant record counts and status
-    """
+    """Orchestrates batch transformation and writing across all layers."""
 
     def __init__(
         self,
@@ -62,389 +52,133 @@ class RecordProcessor:
         gold_validator: GoldValidatorPort,
         tracer: TracingPort | None = None,
     ):
-        """Initialize record processor.
-
-        Args:
-            services: Common pipeline services.
-            error_classifier: Service for error classification.
-            context: Pipeline execution context.
-            config: Record processor configuration.
-            transform_callback: Callback for Bronze -> Silver transformation.
-            gold_filter_callback: Callback for filtering Silver records.
-            gold_transform_callback: Callback for Silver -> Gold transformation.
-            gold_validator: Validator for Gold layer records.
-            tracer: Optional tracing port for distributed tracing.
-
-        """
-        self._storage = services.storage
-        self._quarantine_manager = QuarantineManager(
-            quarantine_port=services.quarantine,
-            pipeline_name=config.pipeline_name,
-        )
-        self._error_classifier = error_classifier
         self._context = context
-        self._config = config
-        self._transform = transform_callback
-        self._gold_filter = gold_filter_callback
-        self._gold_transform = gold_transform_callback
-        self._gold_validator = gold_validator
         self._tracer = tracer
 
-        # Convenience properties
-        self._provider = config.provider
-        self._entity_type = config.entity_type
-        self._silver_schema = config.silver_schema
-        self._dq_config = config.dq_config
-        self._table_config = config.table_config
-
-        # Instantiate Metrics Recorder
-        pipeline_label = f"{self._provider}_{self._entity_type}"
-        run_type_label = self._context.run_type.value
+        pipeline_label = f"{config.provider}_{config.entity_type}"
         self._batch_metrics = BatchMetricsRecorder(
-            services.metrics, pipeline_label, run_type_label
+            services.metrics, pipeline_label, context.run_type.value
         )
 
-    def _log_and_track_write_error(
-        self, layer: str, error: Exception, batch_id: BatchID
-    ) -> None:
-        """Log write error and track metrics."""
-        error_type = self._error_classifier.classify(error)
-        self._context.logger.error(
-            f"{layer} write failed",
-            error=str(error),
-            error_type=error_type.value,
-            batch_id=str(batch_id),
+        self._transformer = BatchTransformer(
+            context=context,
+            config=config,
+            error_classifier=error_classifier,
+            quarantine_manager=QuarantineManager(
+                quarantine_port=services.quarantine,
+                pipeline_name=config.pipeline_name,
+            ),
+            batch_metrics=self._batch_metrics,
+            transform_callback=transform_callback,
+            gold_filter_callback=gold_filter_callback,
+            gold_transform_callback=gold_transform_callback,
         )
-        self._batch_metrics.track_error(f"{layer}_write", error_type)
 
-    def _start_span(self, name: str, **attributes: Any) -> Any:
-        """Start a tracing span if tracer is available.
+        self._writer = BatchWriter(
+            storage=services.storage,
+            context=context,
+            config=config,
+            gold_validator=gold_validator,
+            error_classifier=error_classifier,
+            batch_metrics=self._batch_metrics,
+        )
 
-        Args:
-            name: Name of the span.
-            **attributes: Span attributes.
+    async def process_batch(
+        self, records: list[dict[str, Any]], batch_id: BatchID
+    ) -> BatchResult:
+        """Process batch through Bronze -> Silver -> Gold with tracing."""
+        ingestion_ts = self._context.started_at
 
-        Returns:
-            Span object or None if tracer not available.
-        """
+        # Write to Bronze
+        await self._execute_with_span(
+            "write_bronze",
+            self._writer.write_bronze(records, batch_id, ingestion_ts),
+            batch_id, len(records),
+            on_error=lambda e: self._writer.log_and_track_write_error("bronze", e, batch_id),
+        )
+        self._batch_metrics.track_batch_size("bronze", len(records))
+        self._batch_metrics.track_processed_records("bronze", len(records))
+
+        # Transform records
+        result = await self._execute_transform_with_span(records, batch_id)
+        self._batch_metrics.track_processed_records("quarantined", result.quarantined_count)
+        self._batch_metrics.track_processed_records("silver", len(result.silver_records))
+        self._batch_metrics.track_processed_records("gold", len(result.gold_records))
+
+        # Write to Silver
+        if result.silver_records:
+            await self._execute_with_span(
+                "write_silver",
+                self._writer.write_silver(result.silver_records, batch_id, ingestion_ts),
+                batch_id, len(result.silver_records),
+                on_error=lambda e: self._writer.log_and_track_write_error("silver", e, batch_id),
+            )
+
+        # Write to Gold
+        if result.gold_records:
+            await self._execute_with_span(
+                "write_gold",
+                self._writer.write_gold(result.gold_records),
+                batch_id, len(result.gold_records),
+                on_error=lambda e: self._writer.log_and_track_write_error("gold", e, batch_id),
+            )
+
+        return BatchResult(
+            bronze_count=len(records),
+            silver_count=len(result.silver_records),
+            gold_count=len(result.gold_records),
+            quarantined_count=result.quarantined_count,
+        )
+
+    async def _execute_with_span(
+        self, name: str, coro: Any, batch_id: BatchID, count: int, on_error: Any = None
+    ) -> Any:
+        """Execute coroutine with tracing span."""
+        span = self._start_span(name, batch_id, count)
+        try:
+            result = await coro
+            self._end_span(span)
+            return result
+        except Exception as e:
+            self._end_span(span, e)
+            if on_error:
+                on_error(e)
+            raise
+
+    async def _execute_transform_with_span(
+        self, records: list[dict[str, Any]], batch_id: BatchID
+    ) -> TransformResult:
+        """Execute transformation with extended span attributes."""
+        span = self._start_span("transform", batch_id, len(records), input_count=True)
+        try:
+            result = await self._transformer.transform_batch(records, batch_id)
+            if span:
+                span.set_attribute("bioetl.silver_count", len(result.silver_records))
+                span.set_attribute("bioetl.gold_count", len(result.gold_records))
+                span.set_attribute("bioetl.quarantined_count", result.quarantined_count)
+            self._end_span(span)
+            return result
+        except Exception as e:
+            self._end_span(span, e)
+            raise
+
+    def _start_span(
+        self, name: str, batch_id: BatchID, count: int, input_count: bool = False
+    ) -> Any:
+        """Start a tracing span if tracer is available."""
         if not self._tracer:
             return None
-        otel_tracer = self._tracer.get_tracer("bioetl.processor")
-        span = otel_tracer.start_as_current_span(name, attributes=attributes)
+        count_key = "bioetl.input_count" if input_count else "bioetl.record_count"
+        attrs = {"bioetl.batch_id": str(batch_id), count_key: count}
+        span = self._tracer.get_tracer("bioetl.processor").start_as_current_span(name, attributes=attrs)
         span.__enter__()
         return span
 
     def _end_span(self, span: Any, error: Exception | None = None) -> None:
-        """End a tracing span.
-
-        Args:
-            span: Span object to end.
-            error: Optional exception to record.
-        """
+        """End a tracing span."""
         if not span:
             return
         if error:
             span.set_attribute("error", True)
             span.record_exception(error)
         span.__exit__(None, None, None)
-
-    async def _transform_records_batch(
-        self, records: list[dict[str, Any]], batch_id: BatchID
-    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], int]:
-        """Transform all records, returning silver, gold, and quarantine count."""
-        silver_records: list[dict[str, Any]] = []
-        gold_records: list[dict[str, Any]] = []
-        records_quarantined = 0
-
-        for raw_record in records:
-            record_context = self._context.bind_logger(
-                batch_id=str(batch_id),
-                entity_id=raw_record.get("activity_id"),
-            )
-            try:
-                transformed = await self._transform_record(record_context, raw_record)
-                if transformed:
-                    silver_records.append(transformed)
-                    if self._gold_filter(record_context, transformed):
-                        gold_record = self._gold_transform(record_context, transformed)
-                        gold_records.append(gold_record)
-            except Exception as e:
-                error_type = self._error_classifier.classify(e)
-                if error_type.is_data_quality():
-                    await self._quarantine_manager.quarantine_record(
-                        raw_record,
-                        error_type,
-                        batch_id,
-                        str(e),
-                        ingestion_ts=self._context.started_at,
-                    )
-                    records_quarantined += 1
-                    self._batch_metrics.track_error("transform", error_type)
-                    self._batch_metrics.track_quarantined_records(error_type, 1)
-                else:
-                    raise
-
-        return silver_records, gold_records, records_quarantined
-
-    async def process_batch(
-        self,
-        records: list[dict[str, Any]],
-        batch_id: BatchID,
-    ) -> BatchResult:
-        """Process a batch of records through Bronze -> Silver -> Gold.
-
-        Creates nested spans for each stage:
-        - write_bronze: Writing raw records to Bronze layer
-        - transform: Transforming records to Silver/Gold formats
-        - write_silver: Writing to Silver Delta Lake
-        - write_gold: Writing to Gold Delta Lake
-        """
-        # Use context.started_at as single source of time (see ADR-014)
-        ingestion_ts = self._context.started_at
-
-        # 1. Write to Bronze with span
-        span = self._start_span(
-            "write_bronze",
-            **{
-                "bioetl.batch_id": str(batch_id),
-                "bioetl.record_count": len(records),
-            },
-        )
-        try:
-            await self._write_bronze_batch(records, batch_id, ingestion_ts)
-            self._end_span(span)
-        except Exception as e:
-            self._end_span(span, e)
-            self._log_and_track_write_error("bronze", e, batch_id)
-            raise
-
-        records_bronze = len(records)
-        self._batch_metrics.track_batch_size("bronze", records_bronze)
-        self._batch_metrics.track_processed_records("bronze", records_bronze)
-
-        # 2. Transform and collect Silver/Gold with span
-        span = self._start_span(
-            "transform",
-            **{
-                "bioetl.batch_id": str(batch_id),
-                "bioetl.input_count": len(records),
-            },
-        )
-        try:
-            silver_records, gold_records, records_quarantined = (
-                await self._transform_records_batch(records, batch_id)
-            )
-            if span:
-                span.set_attribute("bioetl.silver_count", len(silver_records))
-                span.set_attribute("bioetl.gold_count", len(gold_records))
-                span.set_attribute("bioetl.quarantined_count", records_quarantined)
-            self._end_span(span)
-        except Exception as e:
-            self._end_span(span, e)
-            raise
-
-        self._collect_dq_stats(records, records_quarantined)
-
-        # Update metrics
-        self._batch_metrics.track_processed_records("quarantined", records_quarantined)
-        self._batch_metrics.track_processed_records("silver", len(silver_records))
-        self._batch_metrics.track_processed_records("gold", len(gold_records))
-
-        # 3. Write to Silver with span
-        if silver_records:
-            span = self._start_span(
-                "write_silver",
-                **{
-                    "bioetl.batch_id": str(batch_id),
-                    "bioetl.record_count": len(silver_records),
-                },
-            )
-            try:
-                await self._write_silver_batch(silver_records, batch_id, ingestion_ts)
-                self._end_span(span)
-            except Exception as e:
-                self._end_span(span, e)
-                self._log_and_track_write_error("silver", e, batch_id)
-                raise
-
-        # 4. Write to Gold with span
-        if gold_records:
-            span = self._start_span(
-                "write_gold",
-                **{
-                    "bioetl.batch_id": str(batch_id),
-                    "bioetl.record_count": len(gold_records),
-                },
-            )
-            try:
-                await self._write_gold_batch(gold_records)
-                self._end_span(span)
-            except Exception as e:
-                self._end_span(span, e)
-                self._log_and_track_write_error("gold", e, batch_id)
-                raise
-
-        return BatchResult(
-            bronze_count=records_bronze,
-            silver_count=len(silver_records),
-            gold_count=len(gold_records),
-            quarantined_count=records_quarantined,
-        )
-
-    async def _transform_record(
-        self, record_context: PipelineContext, raw_record: dict[str, Any]
-    ) -> dict[str, Any] | None:
-        """Transform a single record using the callback."""
-        return await self._transform(record_context, raw_record)
-
-    def _collect_dq_stats(
-        self, records: list[dict[str, Any]], quarantined_count: int
-    ) -> None:
-        """Collect DQ stats and check thresholds.
-
-        Tracks quarantined records via metrics and checks against
-        configured soft/hard thresholds.
-        """
-        if not records:
-            return
-
-        total_count = len(records)
-        error_rate = quarantined_count / total_count if total_count > 0 else 0.0
-
-        if not self._dq_config:
-            return
-
-        # Hard fail check
-        if (
-            self._dq_config.hard_fail_threshold
-            and error_rate >= self._dq_config.hard_fail_threshold
-        ):
-            raise DataQualityThresholdError(
-                error_rate, self._dq_config.hard_fail_threshold
-            )
-
-        # Soft fail check with detailed logging
-        if (
-            self._dq_config.soft_fail_threshold
-            and error_rate >= self._dq_config.soft_fail_threshold
-        ):
-            self._context.logger.warning(
-                "DQ Soft Threshold exceeded",
-                error_rate=round(error_rate, 4),
-                threshold=self._dq_config.soft_fail_threshold,
-                quarantined_count=quarantined_count,
-                total_count=total_count,
-                hard_threshold=self._dq_config.hard_fail_threshold,
-                pipeline=self._config.pipeline_name,
-            )
-
-    async def _write_bronze_batch(
-        self, records: list[dict[str, Any]], batch_id: BatchID, ingestion_ts: datetime
-    ) -> None:
-        # 1. Serialize all records to JSON strings with deterministic key ordering
-        # This avoids serializing twice (once for sort, once for write)
-        json_strings = [json.dumps(r, sort_keys=True) for r in records]
-
-        # 2. Sort the JSON strings to ensure deterministic file content
-        json_strings.sort()
-
-        # 3. Create generator for bytes
-        record_bytes = ((s + "\n").encode("utf-8") for s in json_strings)
-
-        await self._storage.write_bronze(
-            records=record_bytes,
-            provider=self._provider,
-            entity=self._entity_type,
-            date=ingestion_ts,
-            batch_id=batch_id,
-            run_id=self._context.run_id,
-            run_type=self._context.run_type,
-            ingestion_ts=ingestion_ts,  # Pass from context (single source of time)
-        )
-
-    async def _write_silver_batch(
-        self, records: list[dict[str, Any]], batch_id: BatchID, ingestion_ts: datetime
-    ) -> None:
-        records_with_meta = [
-            {
-                **r,
-                "_run_id": str(self._context.run_id),
-                "_run_type": self._context.run_type.value,
-                "_source_batch_id": str(batch_id),
-                "_ingestion_ts": ingestion_ts.isoformat(),
-            }
-            for r in records
-        ]
-        # Use configured table name or default
-        table_name = (
-            self._table_config.silver_table or f"{self._provider}.{self._entity_type}"
-        )
-        # For "overwrite" mode, use "append" for batch writes since table is cleared at run start
-        # This allows accumulating batches within a run while still replacing previous run data
-        write_mode = self._table_config.silver_write_mode
-        if write_mode == "overwrite":
-            write_mode = "append"
-        await self._storage.write_silver(
-            table_name=table_name,
-            records=records_with_meta,
-            primary_keys=self._table_config.primary_keys,
-            schema=self._silver_schema,
-            mode=write_mode,
-            on_schema_mismatch=self._table_config.on_schema_mismatch,
-        )
-
-    async def _write_gold_batch(self, records: list[dict[str, Any]]) -> None:
-        # Get schema column names for filtering (strict mode requires exact columns)
-        gold_schema = self._config.gold_schema
-        schema_columns = self._get_schema_columns(gold_schema)
-
-        # Filter records to only include columns defined in Gold schema
-        if schema_columns:
-            records = [
-                {k: v for k, v in r.items() if k in schema_columns} for r in records
-            ]
-
-        # Validate Gold records using dedicated validator (SRP)
-        result = self._gold_validator.validate(records)
-        if not result.valid:
-            raise SchemaViolationError("gold", result.errors)
-
-        # Use configured table name or default
-        table_name = (
-            self._table_config.gold_table or f"{self._provider}.{self._entity_type}"
-        )
-        # For "overwrite" mode, use "append" for batch writes since table is cleared at run start
-        # This allows accumulating batches within a run while still replacing previous run data
-        write_mode = self._table_config.gold_write_mode
-        if write_mode == "overwrite":
-            write_mode = "append"
-        await self._storage.write_gold(
-            table_name=table_name,
-            records=records,
-            schema=gold_schema,
-            primary_keys=self._table_config.primary_keys,
-            mode=write_mode,
-        )
-
-    def _get_schema_columns(self, schema: Any) -> set[str] | None:
-        """Extract column names from Pandera schema.
-
-        Args:
-            schema: Pandera DataFrameModel or DataFrameSchema.
-
-        Returns:
-            Set of column names, or None if schema is not recognized.
-
-        """
-        # Handle Pandera DataFrameModel (class with to_schema method)
-        # Use to_schema() to get actual column names including aliases
-        if hasattr(schema, "to_schema"):
-            try:
-                converted = schema.to_schema()
-                return set(converted.columns.keys())
-            except Exception:
-                pass
-        # Handle Pandera DataFrameSchema (instance with columns dict)
-        if hasattr(schema, "columns"):
-            return set(schema.columns.keys())
-        return None

--- a/tests/architecture/test_code_metrics.py
+++ b/tests/architecture/test_code_metrics.py
@@ -249,7 +249,6 @@ class TestClassSize:
         "LineageTracker": 400,
         "ChemblAdapter": 490,  # 481 lines - complex API adapter with Template Method health check
         "GenericPipelineFactory": 350,  # 305 lines - factory pattern
-        "RecordProcessor": 410,  # 407 lines - core ETL logic
     }
 
     def test_classes_under_300_lines(self, src_dir: Path) -> None:

--- a/tests/unit/application/core/test_batch_transformer.py
+++ b/tests/unit/application/core/test_batch_transformer.py
@@ -1,0 +1,371 @@
+"""Unit tests for BatchTransformer."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from bioetl.application.core.batch_metrics import BatchMetricsRecorder
+from bioetl.application.core.batch_transformer import BatchTransformer, TransformResult
+from bioetl.application.core.config import RecordProcessorConfig
+from bioetl.application.core.quarantine_manager import QuarantineManager
+from bioetl.domain.config import DQConfig
+from bioetl.domain.context import PipelineContext
+from bioetl.domain.error_classifier import ErrorClassifier
+from bioetl.domain.exceptions import DataQualityError, DataQualityThresholdError
+from bioetl.domain.types import BatchID, RunType
+
+
+@pytest.fixture
+def mock_context():
+    """Create mock pipeline context."""
+    mock_logger = MagicMock()
+    mock_logger.bind = MagicMock(return_value=mock_logger)
+    return PipelineContext(
+        run_id=uuid4(),
+        run_type=RunType.INCREMENTAL,
+        logger=mock_logger,
+    )
+
+
+@pytest.fixture
+def mock_error_classifier():
+    """Create error classifier."""
+    return ErrorClassifier()
+
+
+@pytest.fixture
+def mock_quarantine_manager():
+    """Create mock quarantine manager."""
+    manager = MagicMock(spec=QuarantineManager)
+    manager.quarantine_record = AsyncMock()
+    return manager
+
+
+@pytest.fixture
+def mock_batch_metrics():
+    """Create mock batch metrics recorder."""
+    metrics = MagicMock(spec=BatchMetricsRecorder)
+    return metrics
+
+
+@pytest.fixture
+def transform_callback():
+    """Create mock transform callback."""
+
+    async def transform(ctx, record):
+        return {"entity_id": record.get("id", "unknown"), "value": record.get("value")}
+
+    return transform
+
+
+@pytest.fixture
+def gold_filter_callback():
+    """Create mock gold filter callback."""
+
+    def filter_gold(ctx, record):
+        return record.get("value", 0) > 5
+
+    return filter_gold
+
+
+@pytest.fixture
+def gold_transform_callback():
+    """Create mock gold transform callback."""
+
+    def transform_gold(ctx, record):
+        return record
+
+    return transform_gold
+
+
+@pytest.fixture
+def batch_transformer(
+    mock_context,
+    mock_error_classifier,
+    mock_quarantine_manager,
+    mock_batch_metrics,
+    transform_callback,
+    gold_filter_callback,
+    gold_transform_callback,
+):
+    """Create BatchTransformer instance."""
+    config = RecordProcessorConfig(
+        pipeline_name="test_provider_test_entity",
+        provider="test_provider",
+        entity_type="test_entity",
+        silver_schema=MagicMock(),
+        gold_schema=MagicMock(),
+    )
+    return BatchTransformer(
+        context=mock_context,
+        config=config,
+        error_classifier=mock_error_classifier,
+        quarantine_manager=mock_quarantine_manager,
+        batch_metrics=mock_batch_metrics,
+        transform_callback=transform_callback,
+        gold_filter_callback=gold_filter_callback,
+        gold_transform_callback=gold_transform_callback,
+    )
+
+
+@pytest.mark.unit
+class TestBatchTransformerTransform:
+    """Tests for BatchTransformer.transform_batch method."""
+
+    async def test_transform_batch_returns_silver_and_gold_records(
+        self, batch_transformer
+    ):
+        """Test successful transformation returns correct records."""
+        records = [
+            {"id": "1", "value": 10},  # Goes to gold (value > 5)
+            {"id": "2", "value": 3},  # Not in gold
+        ]
+        batch_id = BatchID(uuid4())
+
+        result = await batch_transformer.transform_batch(records, batch_id)
+
+        assert isinstance(result, TransformResult)
+        assert len(result.silver_records) == 2
+        assert len(result.gold_records) == 1
+        assert result.quarantined_count == 0
+
+    async def test_transform_batch_empty_records(self, batch_transformer):
+        """Test transformation with empty records list."""
+        result = await batch_transformer.transform_batch([], BatchID(uuid4()))
+
+        assert result.silver_records == []
+        assert result.gold_records == []
+        assert result.quarantined_count == 0
+
+    async def test_transform_batch_quarantines_dq_errors(
+        self,
+        mock_context,
+        mock_error_classifier,
+        mock_quarantine_manager,
+        mock_batch_metrics,
+        gold_filter_callback,
+        gold_transform_callback,
+    ):
+        """Test that data quality errors result in quarantine."""
+
+        async def failing_transform(ctx, record):
+            if record.get("id") == "bad":
+                raise DataQualityError("Invalid data")
+            return {"entity_id": record.get("id"), "value": record.get("value")}
+
+        config = RecordProcessorConfig(
+            pipeline_name="test",
+            provider="test",
+            entity_type="test",
+            silver_schema=MagicMock(),
+            gold_schema=MagicMock(),
+        )
+
+        transformer = BatchTransformer(
+            context=mock_context,
+            config=config,
+            error_classifier=mock_error_classifier,
+            quarantine_manager=mock_quarantine_manager,
+            batch_metrics=mock_batch_metrics,
+            transform_callback=failing_transform,
+            gold_filter_callback=gold_filter_callback,
+            gold_transform_callback=gold_transform_callback,
+        )
+
+        records = [
+            {"id": "good", "value": 10},
+            {"id": "bad", "value": 5},
+        ]
+        batch_id = BatchID(uuid4())
+
+        result = await transformer.transform_batch(records, batch_id)
+
+        assert len(result.silver_records) == 1
+        assert result.quarantined_count == 1
+        mock_quarantine_manager.quarantine_record.assert_called_once()
+
+    async def test_transform_batch_raises_non_dq_errors(
+        self,
+        mock_context,
+        mock_error_classifier,
+        mock_quarantine_manager,
+        mock_batch_metrics,
+        gold_filter_callback,
+        gold_transform_callback,
+    ):
+        """Test that non-DQ errors are re-raised."""
+        from bioetl.domain.exceptions import LockLostError
+
+        async def failing_transform(ctx, record):
+            raise LockLostError("resource_key", "test_run_id")
+
+        config = RecordProcessorConfig(
+            pipeline_name="test",
+            provider="test",
+            entity_type="test",
+            silver_schema=MagicMock(),
+            gold_schema=MagicMock(),
+        )
+
+        transformer = BatchTransformer(
+            context=mock_context,
+            config=config,
+            error_classifier=mock_error_classifier,
+            quarantine_manager=mock_quarantine_manager,
+            batch_metrics=mock_batch_metrics,
+            transform_callback=failing_transform,
+            gold_filter_callback=gold_filter_callback,
+            gold_transform_callback=gold_transform_callback,
+        )
+
+        records = [{"id": "test", "value": 5}]
+        batch_id = BatchID(uuid4())
+
+        with pytest.raises(LockLostError):
+            await transformer.transform_batch(records, batch_id)
+
+
+@pytest.mark.unit
+class TestBatchTransformerDQThresholds:
+    """Tests for DQ threshold checking."""
+
+    async def test_hard_threshold_exceeded_raises_error(
+        self,
+        mock_context,
+        mock_error_classifier,
+        mock_quarantine_manager,
+        mock_batch_metrics,
+        gold_filter_callback,
+        gold_transform_callback,
+    ):
+        """Test that exceeding hard threshold raises DataQualityThresholdError."""
+
+        async def failing_transform(ctx, record):
+            if record.get("id") == "bad":
+                raise DataQualityError("Invalid data")
+            return {"entity_id": record.get("id"), "value": record.get("value")}
+
+        config = RecordProcessorConfig(
+            pipeline_name="test",
+            provider="test",
+            entity_type="test",
+            silver_schema=MagicMock(),
+            gold_schema=MagicMock(),
+            dq_config=DQConfig(soft_fail_threshold=0.1, hard_fail_threshold=0.4),
+        )
+
+        transformer = BatchTransformer(
+            context=mock_context,
+            config=config,
+            error_classifier=mock_error_classifier,
+            quarantine_manager=mock_quarantine_manager,
+            batch_metrics=mock_batch_metrics,
+            transform_callback=failing_transform,
+            gold_filter_callback=gold_filter_callback,
+            gold_transform_callback=gold_transform_callback,
+        )
+
+        # 50% error rate (1/2) > hard_fail_threshold (0.4)
+        records = [
+            {"id": "good", "value": 10},
+            {"id": "bad", "value": 5},
+        ]
+        batch_id = BatchID(uuid4())
+
+        with pytest.raises(DataQualityThresholdError):
+            await transformer.transform_batch(records, batch_id)
+
+    async def test_soft_threshold_logs_warning(
+        self,
+        mock_context,
+        mock_error_classifier,
+        mock_quarantine_manager,
+        mock_batch_metrics,
+        gold_filter_callback,
+        gold_transform_callback,
+    ):
+        """Test that exceeding soft threshold logs warning but doesn't raise."""
+
+        async def failing_transform(ctx, record):
+            if record.get("id") == "bad":
+                raise DataQualityError("Invalid data")
+            return {"entity_id": record.get("id"), "value": record.get("value")}
+
+        config = RecordProcessorConfig(
+            pipeline_name="test",
+            provider="test",
+            entity_type="test",
+            silver_schema=MagicMock(),
+            gold_schema=MagicMock(),
+            dq_config=DQConfig(soft_fail_threshold=0.1, hard_fail_threshold=0.9),
+        )
+
+        transformer = BatchTransformer(
+            context=mock_context,
+            config=config,
+            error_classifier=mock_error_classifier,
+            quarantine_manager=mock_quarantine_manager,
+            batch_metrics=mock_batch_metrics,
+            transform_callback=failing_transform,
+            gold_filter_callback=gold_filter_callback,
+            gold_transform_callback=gold_transform_callback,
+        )
+
+        # 50% error rate > soft_fail_threshold (0.1) but < hard_fail_threshold (0.9)
+        records = [
+            {"id": "good", "value": 10},
+            {"id": "bad", "value": 5},
+        ]
+        batch_id = BatchID(uuid4())
+
+        result = await transformer.transform_batch(records, batch_id)
+
+        assert len(result.silver_records) == 1
+        assert result.quarantined_count == 1
+        mock_context.logger.warning.assert_called_once()
+
+    async def test_below_thresholds_no_warning(
+        self,
+        mock_context,
+        mock_error_classifier,
+        mock_quarantine_manager,
+        mock_batch_metrics,
+        gold_filter_callback,
+        gold_transform_callback,
+    ):
+        """Test that below thresholds results in no warnings."""
+
+        async def transform(ctx, record):
+            return {"entity_id": record.get("id"), "value": record.get("value")}
+
+        config = RecordProcessorConfig(
+            pipeline_name="test",
+            provider="test",
+            entity_type="test",
+            silver_schema=MagicMock(),
+            gold_schema=MagicMock(),
+            dq_config=DQConfig(soft_fail_threshold=0.5, hard_fail_threshold=0.9),
+        )
+
+        transformer = BatchTransformer(
+            context=mock_context,
+            config=config,
+            error_classifier=mock_error_classifier,
+            quarantine_manager=mock_quarantine_manager,
+            batch_metrics=mock_batch_metrics,
+            transform_callback=transform,
+            gold_filter_callback=gold_filter_callback,
+            gold_transform_callback=gold_transform_callback,
+        )
+
+        records = [{"id": "1", "value": 10}, {"id": "2", "value": 5}]
+        batch_id = BatchID(uuid4())
+
+        result = await transformer.transform_batch(records, batch_id)
+
+        assert len(result.silver_records) == 2
+        assert result.quarantined_count == 0
+        mock_context.logger.warning.assert_not_called()

--- a/tests/unit/application/core/test_batch_writer.py
+++ b/tests/unit/application/core/test_batch_writer.py
@@ -1,0 +1,297 @@
+"""Unit tests for BatchWriter."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from bioetl.application.core.batch_metrics import BatchMetricsRecorder
+from bioetl.application.core.batch_writer import BatchWriter
+from bioetl.application.core.config import RecordProcessorConfig
+from bioetl.domain.config import TableConfig
+from bioetl.domain.context import PipelineContext
+from bioetl.domain.error_classifier import ErrorClassifier
+from bioetl.domain.exceptions import SchemaViolationError
+from bioetl.domain.types import BatchID, RunType, ValidationResult
+
+
+@pytest.fixture
+def mock_storage():
+    """Create mock storage."""
+    storage = AsyncMock()
+    storage.write_bronze = AsyncMock()
+    storage.write_silver = AsyncMock()
+    storage.write_gold = AsyncMock()
+    return storage
+
+
+@pytest.fixture
+def mock_context():
+    """Create mock pipeline context."""
+    mock_logger = MagicMock()
+    mock_logger.bind = MagicMock(return_value=mock_logger)
+    return PipelineContext(
+        run_id=uuid4(),
+        run_type=RunType.INCREMENTAL,
+        logger=mock_logger,
+    )
+
+
+@pytest.fixture
+def mock_gold_validator():
+    """Create mock gold validator."""
+    validator = MagicMock()
+    validator.validate = MagicMock(return_value=ValidationResult(valid=True))
+    return validator
+
+
+@pytest.fixture
+def mock_error_classifier():
+    """Create error classifier."""
+    return ErrorClassifier()
+
+
+@pytest.fixture
+def mock_batch_metrics():
+    """Create mock batch metrics recorder."""
+    return MagicMock(spec=BatchMetricsRecorder)
+
+
+@pytest.fixture
+def batch_writer(
+    mock_storage,
+    mock_context,
+    mock_gold_validator,
+    mock_error_classifier,
+    mock_batch_metrics,
+):
+    """Create BatchWriter instance."""
+    config = RecordProcessorConfig(
+        pipeline_name="test_provider_test_entity",
+        provider="test_provider",
+        entity_type="test_entity",
+        silver_schema=MagicMock(),
+        gold_schema=MagicMock(),
+        table_config=TableConfig(),
+    )
+    return BatchWriter(
+        storage=mock_storage,
+        context=mock_context,
+        config=config,
+        gold_validator=mock_gold_validator,
+        error_classifier=mock_error_classifier,
+        batch_metrics=mock_batch_metrics,
+    )
+
+
+@pytest.mark.unit
+class TestBatchWriterBronze:
+    """Tests for BatchWriter.write_bronze method."""
+
+    async def test_write_bronze_serializes_to_json(self, batch_writer, mock_storage):
+        """Test that records are serialized to JSON."""
+        records = [{"id": "1", "value": 10}, {"id": "2", "value": 20}]
+        batch_id = BatchID(uuid4())
+        ingestion_ts = datetime.now(timezone.utc)
+
+        await batch_writer.write_bronze(records, batch_id, ingestion_ts)
+
+        mock_storage.write_bronze.assert_called_once()
+        call_kwargs = mock_storage.write_bronze.call_args[1]
+        assert call_kwargs["provider"] == "test_provider"
+        assert call_kwargs["entity"] == "test_entity"
+        assert call_kwargs["batch_id"] == batch_id
+
+    async def test_write_bronze_propagates_run_id(
+        self, batch_writer, mock_storage, mock_context
+    ):
+        """Test that run_id is passed to storage."""
+        records = [{"id": "1", "value": 10}]
+        batch_id = BatchID(uuid4())
+        ingestion_ts = mock_context.started_at
+
+        await batch_writer.write_bronze(records, batch_id, ingestion_ts)
+
+        call_kwargs = mock_storage.write_bronze.call_args[1]
+        assert call_kwargs["run_id"] == mock_context.run_id
+        assert call_kwargs["run_type"] == mock_context.run_type
+
+    async def test_write_bronze_deterministic_ordering(
+        self, batch_writer, mock_storage
+    ):
+        """Test that records are sorted for deterministic output."""
+        # Records in reverse order
+        records = [{"z": "last", "a": "first"}, {"a": "first", "z": "last"}]
+        batch_id = BatchID(uuid4())
+        ingestion_ts = datetime.now(timezone.utc)
+
+        await batch_writer.write_bronze(records, batch_id, ingestion_ts)
+
+        mock_storage.write_bronze.assert_called_once()
+
+
+@pytest.mark.unit
+class TestBatchWriterSilver:
+    """Tests for BatchWriter.write_silver method."""
+
+    async def test_write_silver_adds_metadata(
+        self, batch_writer, mock_storage, mock_context
+    ):
+        """Test that Silver records get metadata fields."""
+        records = [{"entity_id": "1", "value": 10}]
+        batch_id = BatchID(uuid4())
+        ingestion_ts = mock_context.started_at
+
+        await batch_writer.write_silver(records, batch_id, ingestion_ts)
+
+        call_kwargs = mock_storage.write_silver.call_args[1]
+        silver_records = call_kwargs["records"]
+        assert len(silver_records) == 1
+        assert silver_records[0]["_run_id"] == str(mock_context.run_id)
+        assert silver_records[0]["_run_type"] == mock_context.run_type.value
+        assert silver_records[0]["_source_batch_id"] == str(batch_id)
+        assert "_ingestion_ts" in silver_records[0]
+
+    async def test_write_silver_uses_table_config(self, mock_storage, mock_context):
+        """Test that table configuration is applied."""
+        config = RecordProcessorConfig(
+            pipeline_name="test",
+            provider="test",
+            entity_type="entity",
+            silver_schema=MagicMock(),
+            gold_schema=MagicMock(),
+            table_config=TableConfig(
+                silver_table="custom_silver_table",
+                primary_keys=["entity_id"],
+            ),
+        )
+
+        writer = BatchWriter(
+            storage=mock_storage,
+            context=mock_context,
+            config=config,
+            gold_validator=MagicMock(
+                validate=MagicMock(return_value=ValidationResult(valid=True))
+            ),
+            error_classifier=ErrorClassifier(),
+            batch_metrics=MagicMock(spec=BatchMetricsRecorder),
+        )
+
+        records = [{"entity_id": "1", "value": 10}]
+        batch_id = BatchID(uuid4())
+
+        await writer.write_silver(records, batch_id, mock_context.started_at)
+
+        call_kwargs = mock_storage.write_silver.call_args[1]
+        assert call_kwargs["table_name"] == "custom_silver_table"
+        assert call_kwargs["primary_keys"] == ["entity_id"]
+
+
+@pytest.mark.unit
+class TestBatchWriterGold:
+    """Tests for BatchWriter.write_gold method."""
+
+    async def test_write_gold_validates_records(
+        self, batch_writer, mock_storage, mock_gold_validator
+    ):
+        """Test that Gold records are validated."""
+        records = [{"entity_id": "1", "value": 10}]
+
+        await batch_writer.write_gold(records)
+
+        mock_gold_validator.validate.assert_called_once()
+        mock_storage.write_gold.assert_called_once()
+
+    async def test_write_gold_raises_on_validation_failure(
+        self, mock_storage, mock_context
+    ):
+        """Test that validation failure raises SchemaViolationError."""
+        failing_validator = MagicMock()
+        failing_validator.validate = MagicMock(
+            return_value=ValidationResult(valid=False, errors=["field_error"])
+        )
+
+        config = RecordProcessorConfig(
+            pipeline_name="test",
+            provider="test",
+            entity_type="entity",
+            silver_schema=MagicMock(),
+            gold_schema=MagicMock(),
+        )
+
+        writer = BatchWriter(
+            storage=mock_storage,
+            context=mock_context,
+            config=config,
+            gold_validator=failing_validator,
+            error_classifier=ErrorClassifier(),
+            batch_metrics=MagicMock(spec=BatchMetricsRecorder),
+        )
+
+        records = [{"entity_id": "1", "value": "invalid"}]
+
+        with pytest.raises(SchemaViolationError):
+            await writer.write_gold(records)
+
+        mock_storage.write_gold.assert_not_called()
+
+    async def test_write_gold_filters_to_schema_columns(
+        self, mock_storage, mock_context
+    ):
+        """Test that records are filtered to schema columns."""
+
+        class MockSchema:
+            @staticmethod
+            def to_schema():
+                schema = MagicMock()
+                schema.columns = {"entity_id": MagicMock(), "value": MagicMock()}
+                return schema
+
+        config = RecordProcessorConfig(
+            pipeline_name="test",
+            provider="test",
+            entity_type="entity",
+            silver_schema=MagicMock(),
+            gold_schema=MockSchema,
+        )
+
+        writer = BatchWriter(
+            storage=mock_storage,
+            context=mock_context,
+            config=config,
+            gold_validator=MagicMock(
+                validate=MagicMock(return_value=ValidationResult(valid=True))
+            ),
+            error_classifier=ErrorClassifier(),
+            batch_metrics=MagicMock(spec=BatchMetricsRecorder),
+        )
+
+        records = [{"entity_id": "1", "value": 10, "extra_field": "should_be_removed"}]
+
+        await writer.write_gold(records)
+
+        call_kwargs = mock_storage.write_gold.call_args[1]
+        gold_records = call_kwargs["records"]
+        assert "extra_field" not in gold_records[0]
+        assert "entity_id" in gold_records[0]
+        assert "value" in gold_records[0]
+
+
+@pytest.mark.unit
+class TestBatchWriterErrorLogging:
+    """Tests for error logging functionality."""
+
+    def test_log_and_track_write_error(
+        self, batch_writer, mock_context, mock_batch_metrics
+    ):
+        """Test that errors are logged and tracked."""
+        batch_id = BatchID(uuid4())
+        error = ValueError("Test error")
+
+        batch_writer.log_and_track_write_error("silver", error, batch_id)
+
+        mock_context.logger.error.assert_called_once()
+        mock_batch_metrics.track_error.assert_called_once()


### PR DESCRIPTION
Extract transformation and writing logic into dedicated classes:
- BatchTransformer: handles Bronze -> Silver/Gold transformation with error classification, quarantine management, and DQ threshold checks
- BatchWriter: handles writing to all layers with metadata enrichment, schema validation, and deterministic serialization

RecordProcessor now orchestrates these services with proper tracing.

Changes:
- record_processor.py: 451 -> 184 LOC (orchestration only)
- batch_transformer.py: 174 LOC (transformation + DQ)
- batch_writer.py: 227 LOC (storage operations)
- Removed RecordProcessor exemption from code_metrics tests
- Added comprehensive unit tests for new classes