### PR TITLE
Add performance tests for batching

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ markers = [
     "slow: Slow tests",
     "security: Security tests",
     "vcr: VCR.py recorded HTTP interactions",
+    "performance: Performance regression tests (optional CI stage)",
 ]
 asyncio_mode = "auto"
 filterwarnings = [

--- a/tests/performance/__init__.py
+++ b/tests/performance/__init__.py
@@ -1,0 +1,4 @@
+"""Performance tests for BioETL.
+
+Monitors for performance regressions in critical data processing paths.
+"""

--- a/tests/performance/test_batching_performance.py
+++ b/tests/performance/test_batching_performance.py
@@ -1,0 +1,427 @@
+"""Performance tests for batching operations.
+
+Monitors for performance regressions in Bronze write, Silver transform,
+and related data processing operations.
+
+Requirements:
+- REQ-PERF-001: Bronze batch write 1000 records under 1s
+- REQ-PERF-002: Silver transformation 1000 records under 2s
+- REQ-PERF-003: Content hash generation 1000 records under 0.5s
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import pyarrow as pa
+import pytest
+
+from bioetl.domain.transformations import generate_content_hash
+from bioetl.domain.types import BatchID, RunID, RunType
+from bioetl.infrastructure.observability.noop_logger import NoOpLogger
+from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
+from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+
+
+def generate_test_record(idx: int) -> dict[str, Any]:
+    """Generate a realistic test record for performance benchmarks.
+
+    Creates records similar to ChEMBL activity data structure.
+    """
+    return {
+        "activity_id": idx,
+        "molecule_chembl_id": f"CHEMBL{idx}",
+        "target_chembl_id": f"CHEMBL_TARGET_{idx % 100}",
+        "assay_chembl_id": f"CHEMBL_ASSAY_{idx % 50}",
+        "standard_type": "IC50",
+        "standard_value": 10.5 + (idx * 0.001),
+        "standard_units": "nM",
+        "pchembl_value": 7.5 + (idx * 0.0001),
+        "activity_comment": f"Test activity {idx}",
+        "data_validity_comment": None,
+        "potential_duplicate": False,
+        "canonical_smiles": f"CC(=O)Oc1ccccc1C(=O)O{idx % 10}",
+        "target_organism": "Homo sapiens",
+        "target_type": "SINGLE PROTEIN",
+        "document_chembl_id": f"CHEMBL_DOC_{idx % 200}",
+        "src_id": 1,
+        "bao_format": "BAO_0000357",
+        "bao_label": "single protein format",
+        "metadata": {
+            "version": "1.0",
+            "source": "test",
+            "nested": {"key1": "value1", "key2": idx},
+        },
+    }
+
+
+def generate_bronze_record_bytes(idx: int) -> bytes:
+    """Generate JSON-encoded bytes for Bronze layer test."""
+    record = generate_test_record(idx)
+    return json.dumps(record).encode("utf-8") + b"\n"
+
+
+@pytest.fixture
+def logger() -> NoOpLogger:
+    """Provide no-op logger for performance tests."""
+    return NoOpLogger()
+
+
+@pytest.fixture
+def bronze_writer(tmp_path: Path, logger: NoOpLogger) -> BronzeWriter:
+    """Create BronzeWriter for performance tests."""
+    return BronzeWriter(base_path=tmp_path, logger=logger)
+
+
+@pytest.fixture
+def delta_writer(tmp_path: Path, logger: NoOpLogger) -> DeltaWriter:
+    """Create DeltaWriter for performance tests."""
+    return DeltaWriter(base_path=tmp_path / "silver", logger=logger)
+
+
+@pytest.fixture
+def activity_schema() -> pa.Schema:
+    """Create PyArrow schema for activity records."""
+    return pa.schema([
+        pa.field("entity_id", pa.string()),
+        pa.field("content_hash", pa.string()),
+        pa.field("activity_id", pa.int64()),
+        pa.field("molecule_chembl_id", pa.string()),
+        pa.field("target_chembl_id", pa.string()),
+        pa.field("assay_chembl_id", pa.string()),
+        pa.field("standard_type", pa.string()),
+        pa.field("standard_value", pa.float64()),
+        pa.field("standard_units", pa.string()),
+        pa.field("pchembl_value", pa.float64()),
+        pa.field("activity_comment", pa.string()),
+        pa.field("data_validity_comment", pa.string()),
+        pa.field("potential_duplicate", pa.bool_()),
+        pa.field("canonical_smiles", pa.string()),
+        pa.field("target_organism", pa.string()),
+        pa.field("target_type", pa.string()),
+        pa.field("document_chembl_id", pa.string()),
+        pa.field("src_id", pa.int64()),
+        pa.field("bao_format", pa.string()),
+        pa.field("bao_label", pa.string()),
+        pa.field("metadata", pa.string()),
+        pa.field("_run_id", pa.string()),
+        pa.field("_run_type", pa.string()),
+        pa.field("_source_batch_id", pa.string()),
+        pa.field("_ingestion_ts", pa.string()),
+    ])
+
+
+@pytest.mark.performance
+class TestBatchingPerformance:
+    """Performance tests for batch operations."""
+
+    # Performance thresholds (in seconds)
+    BRONZE_WRITE_1000_THRESHOLD = 1.0
+    SILVER_TRANSFORM_1000_THRESHOLD = 2.0
+    CONTENT_HASH_1000_THRESHOLD = 0.5
+    ARROW_PREPARE_1000_THRESHOLD = 0.5
+    JSON_SERIALIZE_1000_THRESHOLD = 0.3
+
+    def test_bronze_write_1000_records_under_1s(
+        self, bronze_writer: BronzeWriter, tmp_path: Path
+    ) -> None:
+        """Bronze batch write should complete within 1 second for 1000 records.
+
+        Tests the critical path for raw data ingestion into Bronze layer
+        with JSONL + zstd compression.
+        """
+        records = [generate_bronze_record_bytes(i) for i in range(1000)]
+        run_id = RunID(uuid4())
+        batch_id = BatchID(uuid4())
+        now = datetime.now(tz=UTC)
+
+        start = time.perf_counter()
+        asyncio.run(
+            bronze_writer.write_bronze(
+                records=iter(records),
+                provider="chembl",
+                entity="activity",
+                date=now,
+                batch_id=batch_id,
+                run_id=run_id,
+                run_type=RunType.INCREMENTAL,
+                ingestion_ts=now,
+            )
+        )
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < self.BRONZE_WRITE_1000_THRESHOLD, (
+            f"Bronze write took {elapsed:.3f}s, "
+            f"threshold is {self.BRONZE_WRITE_1000_THRESHOLD}s"
+        )
+
+    def test_silver_transform_1000_records_under_2s(
+        self, delta_writer: DeltaWriter, activity_schema: pa.Schema
+    ) -> None:
+        """Silver transformation should not degrade beyond 2s for 1000 records.
+
+        Tests the Delta Lake write path including Arrow conversion,
+        data validation, and ACID-compliant storage.
+        """
+        run_id = str(uuid4())
+        batch_id = str(uuid4())
+        now = datetime.now(tz=UTC).isoformat()
+
+        records = []
+        for i in range(1000):
+            record = generate_test_record(i)
+            record["entity_id"] = f"chembl:activity:{i}"
+            record["content_hash"] = generate_content_hash(record, "chembl")
+            record["metadata"] = json.dumps(record.get("metadata", {}))
+            record["_run_id"] = run_id
+            record["_run_type"] = "incremental"
+            record["_source_batch_id"] = batch_id
+            record["_ingestion_ts"] = now
+            records.append(record)
+
+        start = time.perf_counter()
+        asyncio.run(
+            delta_writer.write_silver(
+                table_name="chembl.activity",
+                records=records,
+                primary_keys=["entity_id"],
+                schema=activity_schema,
+                mode="append",
+            )
+        )
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < self.SILVER_TRANSFORM_1000_THRESHOLD, (
+            f"Silver transform took {elapsed:.3f}s, "
+            f"threshold is {self.SILVER_TRANSFORM_1000_THRESHOLD}s"
+        )
+
+    def test_content_hash_generation_1000_records_under_500ms(self) -> None:
+        """Content hash generation should be fast (<0.5s for 1000 records).
+
+        Tests the canonical JSON serialization and SHA256 hashing used
+        for record versioning (RULES.md section 2.8.1).
+        """
+        records = [generate_test_record(i) for i in range(1000)]
+
+        start = time.perf_counter()
+        for record in records:
+            generate_content_hash(record, "chembl")
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < self.CONTENT_HASH_1000_THRESHOLD, (
+            f"Content hash generation took {elapsed:.3f}s, "
+            f"threshold is {self.CONTENT_HASH_1000_THRESHOLD}s"
+        )
+
+    def test_arrow_data_preparation_1000_records_under_500ms(
+        self, delta_writer: DeltaWriter, activity_schema: pa.Schema
+    ) -> None:
+        """Arrow table preparation should be fast (<0.5s for 1000 records).
+
+        Tests the data conversion from Python dicts to PyArrow tables
+        which is a critical step in the Silver write path.
+        """
+        run_id = str(uuid4())
+        batch_id = str(uuid4())
+        now = datetime.now(tz=UTC).isoformat()
+
+        records = []
+        for i in range(1000):
+            record = generate_test_record(i)
+            record["entity_id"] = f"chembl:activity:{i}"
+            record["content_hash"] = f"hash_{i}"
+            record["metadata"] = json.dumps(record.get("metadata", {}))
+            record["_run_id"] = run_id
+            record["_run_type"] = "incremental"
+            record["_source_batch_id"] = batch_id
+            record["_ingestion_ts"] = now
+            records.append(record)
+
+        start = time.perf_counter()
+        delta_writer._prepare_arrow_data(
+            records=records,
+            schema=activity_schema,
+            primary_keys=["entity_id"],
+        )
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < self.ARROW_PREPARE_1000_THRESHOLD, (
+            f"Arrow preparation took {elapsed:.3f}s, "
+            f"threshold is {self.ARROW_PREPARE_1000_THRESHOLD}s"
+        )
+
+    def test_json_serialization_1000_complex_records_under_300ms(self) -> None:
+        """JSON serialization of complex nested data should be fast.
+
+        Tests the serialize_json helper used for storing nested structures
+        in Silver layer as JSON strings.
+        """
+        from bioetl.application.core.base_transformer import BaseTransformer
+
+        complex_data = [
+            {
+                "nested": {
+                    "level1": {
+                        "level2": {"key": f"value_{i}"},
+                        "array": list(range(10)),
+                    },
+                    "metadata": {"version": "1.0", "index": i},
+                },
+                "tags": [f"tag_{j}" for j in range(5)],
+                "properties": {f"prop_{j}": j * 1.5 for j in range(10)},
+            }
+            for i in range(1000)
+        ]
+
+        start = time.perf_counter()
+        for data in complex_data:
+            BaseTransformer.serialize_json(data["nested"])
+            BaseTransformer.serialize_json(data["tags"])
+            BaseTransformer.serialize_json(data["properties"])
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < self.JSON_SERIALIZE_1000_THRESHOLD, (
+            f"JSON serialization took {elapsed:.3f}s, "
+            f"threshold is {self.JSON_SERIALIZE_1000_THRESHOLD}s"
+        )
+
+    def test_bronze_compression_efficiency(
+        self, bronze_writer: BronzeWriter, tmp_path: Path
+    ) -> None:
+        """Verify compression efficiency for Bronze layer.
+
+        Ensures zstd compression provides reasonable space savings
+        while maintaining write performance.
+        """
+        records = [generate_bronze_record_bytes(i) for i in range(1000)]
+        uncompressed_size = sum(len(r) for r in records)
+
+        run_id = RunID(uuid4())
+        batch_id = BatchID(uuid4())
+        now = datetime.now(tz=UTC)
+
+        asyncio.run(
+            bronze_writer.write_bronze(
+                records=iter(records),
+                provider="chembl",
+                entity="activity",
+                date=now,
+                batch_id=batch_id,
+                run_id=run_id,
+                run_type=RunType.INCREMENTAL,
+                ingestion_ts=now,
+            )
+        )
+
+        # Find the compressed file
+        bronze_path = tmp_path / "bronze" / "v1" / "chembl" / "activity"
+        compressed_files = list(bronze_path.rglob("*.jsonl.zst"))
+        assert len(compressed_files) == 1
+
+        compressed_size = compressed_files[0].stat().st_size
+        compression_ratio = uncompressed_size / compressed_size
+
+        # Expect at least 2x compression for JSON data
+        assert compression_ratio >= 2.0, (
+            f"Compression ratio {compression_ratio:.2f}x is below expected 2x minimum. "
+            f"Uncompressed: {uncompressed_size} bytes, "
+            f"Compressed: {compressed_size} bytes"
+        )
+
+
+@pytest.mark.performance
+class TestScalabilityPerformance:
+    """Scalability tests for larger batch sizes."""
+
+    def test_bronze_write_5000_records_linear_scaling(
+        self, bronze_writer: BronzeWriter, tmp_path: Path
+    ) -> None:
+        """Verify Bronze write scales linearly with record count.
+
+        Tests that 5000 records takes approximately 5x the time of 1000 records,
+        indicating no unexpected O(n^2) behavior.
+        """
+        run_id = RunID(uuid4())
+        now = datetime.now(tz=UTC)
+
+        # Benchmark 1000 records
+        records_1k = [generate_bronze_record_bytes(i) for i in range(1000)]
+        batch_id_1k = BatchID(uuid4())
+
+        start_1k = time.perf_counter()
+        asyncio.run(
+            bronze_writer.write_bronze(
+                records=iter(records_1k),
+                provider="chembl",
+                entity="activity_1k",
+                date=now,
+                batch_id=batch_id_1k,
+                run_id=run_id,
+                run_type=RunType.INCREMENTAL,
+                ingestion_ts=now,
+            )
+        )
+        time_1k = time.perf_counter() - start_1k
+
+        # Benchmark 5000 records
+        records_5k = [generate_bronze_record_bytes(i) for i in range(5000)]
+        batch_id_5k = BatchID(uuid4())
+
+        start_5k = time.perf_counter()
+        asyncio.run(
+            bronze_writer.write_bronze(
+                records=iter(records_5k),
+                provider="chembl",
+                entity="activity_5k",
+                date=now,
+                batch_id=batch_id_5k,
+                run_id=run_id,
+                run_type=RunType.INCREMENTAL,
+                ingestion_ts=now,
+            )
+        )
+        time_5k = time.perf_counter() - start_5k
+
+        # Allow 7x time (with overhead) for 5x records
+        scaling_factor = time_5k / time_1k if time_1k > 0 else float("inf")
+        assert scaling_factor < 7.0, (
+            f"Bronze write scaling is non-linear: "
+            f"1000 records took {time_1k:.3f}s, "
+            f"5000 records took {time_5k:.3f}s "
+            f"(factor: {scaling_factor:.2f}x, expected <7x)"
+        )
+
+    def test_content_hash_batch_vs_single(self) -> None:
+        """Compare batch processing vs single record hash generation.
+
+        Ensures no significant overhead per record in batch scenarios.
+        """
+        records = [generate_test_record(i) for i in range(100)]
+
+        # Single record timing (averaged)
+        single_times = []
+        for record in records[:10]:
+            start = time.perf_counter()
+            generate_content_hash(record, "chembl")
+            single_times.append(time.perf_counter() - start)
+        avg_single_time = sum(single_times) / len(single_times)
+
+        # Batch timing
+        start = time.perf_counter()
+        for record in records:
+            generate_content_hash(record, "chembl")
+        batch_time = time.perf_counter() - start
+
+        # Batch should not have more than 10% overhead per record
+        expected_batch_time = avg_single_time * len(records) * 1.1
+        assert batch_time < expected_batch_time, (
+            f"Batch processing has unexpected overhead: "
+            f"expected max {expected_batch_time:.4f}s, got {batch_time:.4f}s"
+        )


### PR DESCRIPTION
Add 8 performance tests for critical data processing paths:
- Bronze batch write 1000 records (<1s threshold)
- Silver transformation 1000 records (<2s threshold)
- Content hash generation 1000 records (<0.5s threshold)
- Arrow data preparation 1000 records (<0.5s threshold)
- JSON serialization 1000 records (<0.3s threshold)
- Bronze compression efficiency (>2x ratio)
- Bronze write scalability (linear scaling)
- Batch vs single record processing overhead

Tests use @pytest.mark.performance marker for optional CI stage.