### PR TITLE
Unify PubMed extractors with base class

### DIFF
--- a/src/bioetl/application/pipelines/pubmed/extractors/__init__.py
+++ b/src/bioetl/application/pipelines/pubmed/extractors/__init__.py
@@ -2,12 +2,16 @@
 
 This package provides specialized extractors for parsing PubMed XML elements.
 Each extractor is responsible for a single domain of data extraction.
+
+All extractors inherit from BaseFieldExtractor which implements the Template Method
+pattern with extract() -> normalize() -> process() workflow.
 """
 
 from __future__ import annotations
 
 from bioetl.application.pipelines.pubmed.extractors.abstract import AbstractExtractor
 from bioetl.application.pipelines.pubmed.extractors.author import AuthorExtractor
+from bioetl.application.pipelines.pubmed.extractors.base import BaseFieldExtractor
 from bioetl.application.pipelines.pubmed.extractors.classification import (
     ClassificationExtractor,
 )
@@ -19,6 +23,7 @@ from bioetl.application.pipelines.pubmed.extractors.identifier import (
 __all__ = [
     "AbstractExtractor",
     "AuthorExtractor",
+    "BaseFieldExtractor",
     "ClassificationExtractor",
     "DateExtractor",
     "IdentifierExtractor",

--- a/src/bioetl/application/pipelines/pubmed/extractors/abstract.py
+++ b/src/bioetl/application/pipelines/pubmed/extractors/abstract.py
@@ -5,10 +5,13 @@ Handles structured and unstructured abstract parsing.
 
 from __future__ import annotations
 
-import xml.etree.ElementTree as ET
+from typing import cast
+from xml.etree.ElementTree import Element
+
+from bioetl.application.pipelines.pubmed.extractors.base import BaseFieldExtractor
 
 
-class AbstractExtractor:
+class AbstractExtractor(BaseFieldExtractor):
     """Extractor for abstract content from PubMed XML.
 
     Handles:
@@ -17,21 +20,19 @@ class AbstractExtractor:
     - Inline elements within abstract text
     """
 
-    @classmethod
-    def extract_abstract(cls, article_node: ET.Element | None) -> str | None:
-        """Extract abstract, handling structured abstracts with multiple sections.
+    def extract(self, element: Element | None) -> list[str] | None:
+        """Извлечь сырые данные из XML элемента Abstract.
 
         Args:
-            article_node: The Article element.
+            element: The Article element.
 
         Returns:
-            Combined abstract text or None.
-
+            List of text parts with labels, or None if no abstract.
         """
-        if article_node is None:
+        if element is None:
             return None
 
-        abstract_node = article_node.find(".//Abstract")
+        abstract_node = element.find(".//Abstract")
         if abstract_node is None:
             return None
 
@@ -48,4 +49,27 @@ class AbstractExtractor:
             elif full_text.strip():
                 texts.append(full_text.strip())
 
-        return " ".join(texts) if texts else None
+        return texts if texts else None
+
+    def normalize(self, raw_value: list[str]) -> str:
+        """Нормализовать извлечённый текст абстракта.
+
+        Args:
+            raw_value: List of abstract text parts.
+
+        Returns:
+            Combined abstract text.
+        """
+        return " ".join(raw_value)
+
+    @classmethod
+    def extract_abstract(cls, article_node: Element | None) -> str | None:
+        """Extract abstract, handling structured abstracts with multiple sections.
+
+        Args:
+            article_node: The Article element.
+
+        Returns:
+            Combined abstract text or None.
+        """
+        return cast("str | None", cls().process(article_node))

--- a/src/bioetl/application/pipelines/pubmed/extractors/author.py
+++ b/src/bioetl/application/pipelines/pubmed/extractors/author.py
@@ -5,12 +5,23 @@ Handles parsing of author lists including individual and collective authors.
 
 from __future__ import annotations
 
-import xml.etree.ElementTree as ET
+from typing import TypedDict
+from xml.etree.ElementTree import Element
 
+from bioetl.application.pipelines.pubmed.extractors.base import BaseFieldExtractor
 from bioetl.application.pipelines.pubmed.xml_utils import get_text
 
 
-class AuthorExtractor:
+class RawAuthor(TypedDict, total=False):
+    """Raw author data before normalization."""
+
+    last_name: str | None
+    initials: str | None
+    fore_name: str | None
+    collective_name: str | None
+
+
+class AuthorExtractor(BaseFieldExtractor):
     """Extractor for author information from PubMed XML.
 
     Handles:
@@ -19,26 +30,50 @@ class AuthorExtractor:
     - Empty author lists
     """
 
-    @classmethod
-    def parse_authors(cls, article_node: ET.Element) -> list[str]:
-        """Extract list of authors in 'LastName, Initials' format.
+    def extract(self, element: Element | None) -> list[RawAuthor] | None:
+        """Извлечь сырые данные об авторах из XML.
 
         Args:
-            article_node: The Article element containing AuthorList.
+            element: The Article element containing AuthorList.
+
+        Returns:
+            List of raw author dicts, or None if no authors.
+        """
+        if element is None:
+            return None
+
+        author_list = element.find(".//AuthorList")
+        if author_list is None:
+            return None
+
+        raw_authors: list[RawAuthor] = []
+        for author in author_list.findall("Author"):
+            raw_authors.append(
+                RawAuthor(
+                    last_name=get_text(author.find("LastName")),
+                    initials=get_text(author.find("Initials")),
+                    fore_name=get_text(author.find("ForeName")),
+                    collective_name=get_text(author.find("CollectiveName")),
+                )
+            )
+
+        return raw_authors if raw_authors else None
+
+    def normalize(self, raw_value: list[RawAuthor]) -> list[str]:
+        """Нормализовать список авторов в формат 'LastName, Initials'.
+
+        Args:
+            raw_value: List of raw author dicts.
 
         Returns:
             List of formatted author names.
-
         """
-        author_list = article_node.find(".//AuthorList")
-        if author_list is None:
-            return []
-
         authors = []
-        for author in author_list.findall("Author"):
-            last_name = get_text(author.find("LastName"))
-            initials = get_text(author.find("Initials"))
-            fore_name = get_text(author.find("ForeName"))
+        for raw in raw_value:
+            last_name = raw.get("last_name")
+            initials = raw.get("initials")
+            fore_name = raw.get("fore_name")
+            collective = raw.get("collective_name")
 
             if last_name:
                 if initials:
@@ -47,10 +82,31 @@ class AuthorExtractor:
                     authors.append(f"{last_name}, {fore_name}")
                 else:
                     authors.append(last_name)
-            else:
-                # Collective/group author
-                collective = get_text(author.find("CollectiveName"))
-                if collective:
-                    authors.append(collective)
+            elif collective:
+                authors.append(collective)
 
         return authors
+
+    def process(self, element: Element | None) -> list[str]:
+        """Template method: extract → normalize.
+
+        Args:
+            element: XML элемент для обработки.
+
+        Returns:
+            List of formatted author names (empty list if no authors).
+        """
+        raw = self.extract(element)
+        return self.normalize(raw) if raw is not None else []
+
+    @classmethod
+    def parse_authors(cls, article_node: Element) -> list[str]:
+        """Extract list of authors in 'LastName, Initials' format.
+
+        Args:
+            article_node: The Article element containing AuthorList.
+
+        Returns:
+            List of formatted author names.
+        """
+        return cls().process(article_node)

--- a/src/bioetl/application/pipelines/pubmed/extractors/base.py
+++ b/src/bioetl/application/pipelines/pubmed/extractors/base.py
@@ -1,0 +1,65 @@
+"""Base class for PubMed XML field extractors.
+
+Implements Template Method pattern for consistent extraction workflow.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+from xml.etree.ElementTree import Element
+
+
+class BaseFieldExtractor(ABC):
+    """Template Method для извлечения полей из PubMed XML.
+
+    Наследники реализуют extract() и normalize() для конкретных полей.
+    Метод process() объединяет их в единый workflow.
+
+    Example:
+        >>> class MyExtractor(BaseFieldExtractor):
+        ...     def extract(self, element):
+        ...         return element.find("MyField").text
+        ...     def normalize(self, raw_value):
+        ...         return raw_value.strip().upper()
+        >>> extractor = MyExtractor()
+        >>> result = extractor.process(some_element)
+    """
+
+    @abstractmethod
+    def extract(self, element: Element | None) -> Any:
+        """Извлечь сырые данные из XML элемента.
+
+        Args:
+            element: XML элемент для извлечения данных.
+
+        Returns:
+            Сырые данные (могут быть None, строкой, списком и т.д.).
+        """
+        ...
+
+    @abstractmethod
+    def normalize(self, raw_value: Any) -> Any:
+        """Нормализовать извлечённое значение.
+
+        Args:
+            raw_value: Сырое значение из extract().
+
+        Returns:
+            Нормализованное значение.
+        """
+        ...
+
+    def process(self, element: Element | None) -> Any:
+        """Template method: extract → normalize.
+
+        Выполняет полный цикл извлечения и нормализации данных.
+
+        Args:
+            element: XML элемент для обработки.
+
+        Returns:
+            Нормализованное значение или None.
+        """
+        raw = self.extract(element)
+        return self.normalize(raw) if raw is not None else None

--- a/src/bioetl/application/pipelines/pubmed/extractors/classification.py
+++ b/src/bioetl/application/pipelines/pubmed/extractors/classification.py
@@ -5,10 +5,29 @@ Handles extraction of keywords, MeSH terms, and publication types.
 
 from __future__ import annotations
 
-import xml.etree.ElementTree as ET
+from typing import TypedDict
+from xml.etree.ElementTree import Element
+
+from bioetl.application.pipelines.pubmed.extractors.base import BaseFieldExtractor
 
 
-class ClassificationExtractor:
+class RawClassification(TypedDict):
+    """Raw classification data before normalization."""
+
+    keywords: list[str | None]
+    mesh_terms: list[str | None]
+    publication_types: list[str | None]
+
+
+class NormalizedClassification(TypedDict):
+    """Normalized classification data."""
+
+    keywords: list[str]
+    mesh_terms: list[str]
+    publication_types: list[str]
+
+
+class ClassificationExtractor(BaseFieldExtractor):
     """Extractor for classification data from PubMed XML.
 
     Handles:
@@ -17,8 +36,80 @@ class ClassificationExtractor:
     - Publication types from PublicationTypeList
     """
 
+    def extract(self, element: Element | None) -> RawClassification | None:
+        """Извлечь сырые данные классификации из XML.
+
+        Args:
+            element: Root PubmedArticle element.
+
+        Returns:
+            Dict with raw keywords, mesh_terms, and publication_types.
+        """
+        if element is None:
+            return None
+
+        medline = element.find(".//MedlineCitation")
+        article = element.find(".//Article")
+
+        return RawClassification(
+            keywords=self._extract_keywords_raw(medline),
+            mesh_terms=self._extract_mesh_raw(medline),
+            publication_types=self._extract_pub_types_raw(article),
+        )
+
+    def normalize(self, raw_value: RawClassification) -> NormalizedClassification:
+        """Нормализовать данные классификации.
+
+        Args:
+            raw_value: Raw classification dict.
+
+        Returns:
+            Normalized classification dict with cleaned lists.
+        """
+        return NormalizedClassification(
+            keywords=self._normalize_list(raw_value["keywords"]),
+            mesh_terms=self._normalize_list(raw_value["mesh_terms"]),
+            publication_types=self._normalize_list(raw_value["publication_types"]),
+        )
+
+    def _extract_keywords_raw(self, medline: Element | None) -> list[str | None]:
+        """Extract raw keyword texts."""
+        if medline is None:
+            return []
+        keyword_list = medline.find(".//KeywordList")
+        if keyword_list is None:
+            return []
+        return [kw.text for kw in keyword_list.findall("Keyword")]
+
+    def _extract_mesh_raw(self, medline: Element | None) -> list[str | None]:
+        """Extract raw MeSH descriptor texts."""
+        if medline is None:
+            return []
+        mesh_list = medline.find(".//MeshHeadingList")
+        if mesh_list is None:
+            return []
+        texts = []
+        for heading in mesh_list.findall("MeshHeading"):
+            descriptor = heading.find("DescriptorName")
+            if descriptor is not None:
+                texts.append(descriptor.text)
+        return texts
+
+    def _extract_pub_types_raw(self, article: Element | None) -> list[str | None]:
+        """Extract raw publication type texts."""
+        if article is None:
+            return []
+        type_list = article.find(".//PublicationTypeList")
+        if type_list is None:
+            return []
+        return [pt.text for pt in type_list.findall("PublicationType")]
+
+    def _normalize_list(self, raw_list: list[str | None]) -> list[str]:
+        """Normalize a list by stripping and filtering empty values."""
+        return [text.strip() for text in raw_list if text and text.strip()]
+
     @classmethod
-    def parse_keywords(cls, medline_citation: ET.Element | None) -> list[str]:
+    def parse_keywords(cls, medline_citation: Element | None) -> list[str]:
         """Extract keywords from KeywordList.
 
         Args:
@@ -26,21 +117,13 @@ class ClassificationExtractor:
 
         Returns:
             List of keyword strings.
-
         """
-        if medline_citation is None:
-            return []
-
-        keywords = []
-        keyword_list = medline_citation.find(".//KeywordList")
-        if keyword_list is not None:
-            for kw in keyword_list.findall("Keyword"):
-                if kw.text:
-                    keywords.append(kw.text.strip())
-        return keywords
+        extractor = cls()
+        raw = extractor._extract_keywords_raw(medline_citation)
+        return extractor._normalize_list(raw)
 
     @classmethod
-    def parse_mesh_terms(cls, medline_citation: ET.Element | None) -> list[str]:
+    def parse_mesh_terms(cls, medline_citation: Element | None) -> list[str]:
         """Extract MeSH terms from MeshHeadingList.
 
         Args:
@@ -48,22 +131,13 @@ class ClassificationExtractor:
 
         Returns:
             List of MeSH descriptor names.
-
         """
-        if medline_citation is None:
-            return []
-
-        mesh_terms = []
-        mesh_list = medline_citation.find(".//MeshHeadingList")
-        if mesh_list is not None:
-            for heading in mesh_list.findall("MeshHeading"):
-                descriptor = heading.find("DescriptorName")
-                if descriptor is not None and descriptor.text:
-                    mesh_terms.append(descriptor.text.strip())
-        return mesh_terms
+        extractor = cls()
+        raw = extractor._extract_mesh_raw(medline_citation)
+        return extractor._normalize_list(raw)
 
     @classmethod
-    def parse_publication_types(cls, article_node: ET.Element) -> list[str]:
+    def parse_publication_types(cls, article_node: Element) -> list[str]:
         """Extract publication types from PublicationTypeList.
 
         Args:
@@ -71,12 +145,7 @@ class ClassificationExtractor:
 
         Returns:
             List of publication type strings.
-
         """
-        pub_types = []
-        type_list = article_node.find(".//PublicationTypeList")
-        if type_list is not None:
-            for pub_type in type_list.findall("PublicationType"):
-                if pub_type.text:
-                    pub_types.append(pub_type.text.strip())
-        return pub_types
+        extractor = cls()
+        raw = extractor._extract_pub_types_raw(article_node)
+        return extractor._normalize_list(raw)

--- a/src/bioetl/application/pipelines/pubmed/extractors/date.py
+++ b/src/bioetl/application/pipelines/pubmed/extractors/date.py
@@ -6,13 +6,29 @@ and article dates with support for partial dates and month name conversion.
 
 from __future__ import annotations
 
-import xml.etree.ElementTree as ET
-from typing import ClassVar
+from typing import ClassVar, TypedDict
+from xml.etree.ElementTree import Element
 
-from bioetl.application.pipelines.pubmed.xml_utils import get_int, get_text
+from bioetl.application.pipelines.pubmed.extractors.base import BaseFieldExtractor
+from bioetl.application.pipelines.pubmed.xml_utils import get_text
 
 
-class DateExtractor:
+class RawDate(TypedDict):
+    """Raw date components before normalization."""
+
+    year: str | None
+    month: str | None
+    day: str | None
+
+
+class NormalizedDate(TypedDict):
+    """Normalized date result."""
+
+    date_str: str | None
+    year_int: int | None
+
+
+class DateExtractor(BaseFieldExtractor):
     """Extractor for date fields from PubMed XML.
 
     Handles:
@@ -38,6 +54,67 @@ class DateExtractor:
         "dec": "12",
     }
 
+    def extract(self, element: Element | None) -> RawDate | None:
+        """Извлечь сырые компоненты даты из XML элемента.
+
+        Args:
+            element: XML element containing Year, Month, Day children.
+
+        Returns:
+            Dict with raw year, month, day strings, or None.
+        """
+        if element is None:
+            return None
+
+        year = get_text(element.find("Year"))
+        month = get_text(element.find("Month"))
+        day = get_text(element.find("Day"))
+
+        # Return None if no date components found
+        if not any([year, month, day]):
+            return None
+
+        return RawDate(year=year, month=month, day=day)
+
+    def normalize(self, raw_value: RawDate) -> NormalizedDate:
+        """Нормализовать компоненты даты в ISO формат.
+
+        Args:
+            raw_value: Raw date components dict.
+
+        Returns:
+            Dict with formatted date_str and year_int.
+        """
+        year = raw_value.get("year")
+        month = raw_value.get("month")
+        day = raw_value.get("day")
+
+        date_str = self._format_date(year, month, day)
+        year_int = int(year) if year and year.isdigit() else None
+
+        return NormalizedDate(date_str=date_str, year_int=year_int)
+
+    def _format_date(
+        self,
+        year: str | None,
+        month: str | None,
+        day: str | None,
+    ) -> str | None:
+        """Format date components into ISO date string (YYYY-MM-DD or partial)."""
+        if not year:
+            return None
+
+        parts = [year]
+        if month:
+            month_lower = month.lower()[:3]
+            month_num = self.MONTH_MAP.get(month_lower, month.zfill(2))
+            parts.append(month_num)
+
+            if day:
+                parts.append(day.zfill(2))
+
+        return "-".join(parts)
+
     @classmethod
     def format_date(
         cls,
@@ -54,26 +131,13 @@ class DateExtractor:
 
         Returns:
             ISO formatted date string or None if year is missing.
-
         """
-        if not year:
-            return None
-
-        parts = [year]
-        if month:
-            month_lower = month.lower()[:3]
-            month_num = cls.MONTH_MAP.get(month_lower, month.zfill(2))
-            parts.append(month_num)
-
-            if day:
-                parts.append(day.zfill(2))
-
-        return "-".join(parts)
+        return cls()._format_date(year, month, day)
 
     @classmethod
     def extract_date(
         cls,
-        date_node: ET.Element | None,
+        date_node: Element | None,
     ) -> tuple[str | None, int | None]:
         """Extract date string and year from a date element.
 
@@ -82,24 +146,18 @@ class DateExtractor:
 
         Returns:
             Tuple of (formatted_date_string, year_int).
-
         """
-        if date_node is None:
+        extractor = cls()
+        raw = extractor.extract(date_node)
+        if raw is None:
             return None, None
-
-        year = get_text(date_node.find("Year"))
-        month = get_text(date_node.find("Month"))
-        day = get_text(date_node.find("Day"))
-
-        date_str = cls.format_date(year, month, day)
-        year_int = get_int(date_node.find("Year"))
-
-        return date_str, year_int
+        normalized = extractor.normalize(raw)
+        return normalized["date_str"], normalized["year_int"]
 
     @classmethod
     def extract_history_date(
         cls,
-        history_node: ET.Element | None,
+        history_node: Element | None,
         pub_status: str,
     ) -> str | None:
         """Extract a specific date from PubMedPubDate history.
@@ -110,7 +168,6 @@ class DateExtractor:
 
         Returns:
             ISO formatted date string or None.
-
         """
         if history_node is None:
             return None
@@ -124,7 +181,7 @@ class DateExtractor:
     @classmethod
     def extract_article_date(
         cls,
-        article_node: ET.Element | None,
+        article_node: Element | None,
         date_type: str,
     ) -> str | None:
         """Extract date from ArticleDate element by DateType attribute.
@@ -135,7 +192,6 @@ class DateExtractor:
 
         Returns:
             ISO formatted date string or None.
-
         """
         if article_node is None:
             return None

--- a/src/bioetl/application/pipelines/pubmed/extractors/identifier.py
+++ b/src/bioetl/application/pipelines/pubmed/extractors/identifier.py
@@ -5,10 +5,27 @@ Handles extraction of DOI, PMC ID, and other article identifiers.
 
 from __future__ import annotations
 
-import xml.etree.ElementTree as ET
+from typing import TypedDict
+from xml.etree.ElementTree import Element
+
+from bioetl.application.pipelines.pubmed.extractors.base import BaseFieldExtractor
 
 
-class IdentifierExtractor:
+class RawIdentifiers(TypedDict):
+    """Raw identifier data before normalization."""
+
+    doi: str | None
+    pmc_id: str | None
+
+
+class NormalizedIdentifiers(TypedDict):
+    """Normalized identifier data."""
+
+    doi: str | None
+    pmc_id: str | None
+
+
+class IdentifierExtractor(BaseFieldExtractor):
     """Extractor for article identifiers from PubMed XML.
 
     Handles:
@@ -17,8 +34,72 @@ class IdentifierExtractor:
     - PMID (via get_text utility)
     """
 
+    def extract(self, element: Element | None) -> RawIdentifiers | None:
+        """Извлечь сырые идентификаторы из XML.
+
+        Args:
+            element: Root PubmedArticle element.
+
+        Returns:
+            Dict with raw doi and pmc_id, or None.
+        """
+        if element is None:
+            return None
+
+        return RawIdentifiers(
+            doi=self._extract_doi_raw(element),
+            pmc_id=self._extract_pmc_raw(element),
+        )
+
+    def normalize(self, raw_value: RawIdentifiers) -> NormalizedIdentifiers:
+        """Нормализовать идентификаторы.
+
+        Args:
+            raw_value: Raw identifiers dict.
+
+        Returns:
+            Normalized identifiers dict.
+        """
+        return NormalizedIdentifiers(
+            doi=self._normalize_text(raw_value.get("doi")),
+            pmc_id=self._normalize_text(raw_value.get("pmc_id")),
+        )
+
+    def _extract_doi_raw(self, root: Element) -> str | None:
+        """Extract raw DOI from ArticleIdList or ELocationID."""
+        article = root.find(".//Article")
+        if article is None:
+            return None
+
+        # Try ELocationID first
+        for eloc in article.findall(".//ELocationID"):
+            if eloc.get("EIdType") == "doi" and eloc.text:
+                return eloc.text
+
+        # Fallback to ArticleIdList
+        article_id_list = root.find(".//ArticleIdList")
+        if article_id_list is not None:
+            for aid in article_id_list.findall("ArticleId"):
+                if aid.get("IdType") == "doi" and aid.text:
+                    return aid.text
+
+        return None
+
+    def _extract_pmc_raw(self, root: Element) -> str | None:
+        """Extract raw PMC ID from ArticleIdList."""
+        article_id_list = root.find(".//ArticleIdList")
+        if article_id_list is not None:
+            for aid in article_id_list.findall("ArticleId"):
+                if aid.get("IdType") == "pmc" and aid.text:
+                    return aid.text
+        return None
+
+    def _normalize_text(self, text: str | None) -> str | None:
+        """Normalize text by stripping whitespace."""
+        return text.strip() if text else None
+
     @classmethod
-    def extract_doi(cls, root: ET.Element) -> str | None:
+    def extract_doi(cls, root: Element) -> str | None:
         """Extract DOI from ArticleIdList or ELocationID.
 
         First tries ELocationID with EIdType="doi", then falls back
@@ -29,28 +110,13 @@ class IdentifierExtractor:
 
         Returns:
             DOI string or None.
-
         """
-        article = root.find(".//Article")
-        if article is None:
-            return None
-
-        # Try ELocationID first
-        for eloc in article.findall(".//ELocationID"):
-            if eloc.get("EIdType") == "doi" and eloc.text:
-                return eloc.text.strip()
-
-        # Fallback to ArticleIdList
-        article_id_list = root.find(".//ArticleIdList")
-        if article_id_list is not None:
-            for aid in article_id_list.findall("ArticleId"):
-                if aid.get("IdType") == "doi" and aid.text:
-                    return aid.text.strip()
-
-        return None
+        extractor = cls()
+        raw = extractor._extract_doi_raw(root)
+        return extractor._normalize_text(raw)
 
     @classmethod
-    def extract_pmc_id(cls, root: ET.Element) -> str | None:
+    def extract_pmc_id(cls, root: Element) -> str | None:
         """Extract PubMed Central ID from ArticleIdList.
 
         Args:
@@ -58,11 +124,7 @@ class IdentifierExtractor:
 
         Returns:
             PMC ID string or None.
-
         """
-        article_id_list = root.find(".//ArticleIdList")
-        if article_id_list is not None:
-            for aid in article_id_list.findall("ArticleId"):
-                if aid.get("IdType") == "pmc" and aid.text:
-                    return aid.text.strip()
-        return None
+        extractor = cls()
+        raw = extractor._extract_pmc_raw(root)
+        return extractor._normalize_text(raw)

--- a/tests/unit/pipelines/pubmed/extractors/test_base_field_extractor.py
+++ b/tests/unit/pipelines/pubmed/extractors/test_base_field_extractor.py
@@ -1,0 +1,101 @@
+"""Unit tests for BaseFieldExtractor."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from typing import Any
+
+from bioetl.application.pipelines.pubmed.extractors.base import BaseFieldExtractor
+
+
+class ConcreteExtractor(BaseFieldExtractor):
+    """Concrete implementation for testing."""
+
+    def extract(self, element: ET.Element | None) -> str | None:
+        """Extract text from element."""
+        if element is None:
+            return None
+        text_elem = element.find("Text")
+        if text_elem is not None and text_elem.text:
+            return text_elem.text
+        return None
+
+    def normalize(self, raw_value: str) -> str:
+        """Normalize by stripping and uppercasing."""
+        return raw_value.strip().upper()
+
+
+class TestBaseFieldExtractor:
+    """Tests for BaseFieldExtractor template method."""
+
+    def test_process_with_valid_element(self):
+        """Test process with valid element returns normalized value."""
+        xml = "<Root><Text>  hello world  </Text></Root>"
+        element = ET.fromstring(xml)
+        extractor = ConcreteExtractor()
+
+        result = extractor.process(element)
+
+        assert result == "HELLO WORLD"
+
+    def test_process_with_none_element(self):
+        """Test process with None element returns None."""
+        extractor = ConcreteExtractor()
+
+        result = extractor.process(None)
+
+        assert result is None
+
+    def test_process_with_empty_element(self):
+        """Test process with element missing Text child returns None."""
+        xml = "<Root></Root>"
+        element = ET.fromstring(xml)
+        extractor = ConcreteExtractor()
+
+        result = extractor.process(element)
+
+        assert result is None
+
+    def test_extract_returns_raw_value(self):
+        """Test extract returns raw unprocessed value."""
+        xml = "<Root><Text>  raw text  </Text></Root>"
+        element = ET.fromstring(xml)
+        extractor = ConcreteExtractor()
+
+        result = extractor.extract(element)
+
+        assert result == "  raw text  "  # Unchanged
+
+    def test_normalize_transforms_value(self):
+        """Test normalize applies transformation."""
+        extractor = ConcreteExtractor()
+
+        result = extractor.normalize("  test value  ")
+
+        assert result == "TEST VALUE"
+
+
+class NullNormalizeExtractor(BaseFieldExtractor):
+    """Extractor that returns None from extract."""
+
+    def extract(self, element: ET.Element | None) -> Any:
+        """Always return None."""
+        return None
+
+    def normalize(self, raw_value: Any) -> Any:
+        """Should not be called when extract returns None."""
+        raise AssertionError("normalize should not be called when extract returns None")
+
+
+class TestNullExtractHandling:
+    """Tests for handling None from extract."""
+
+    def test_process_skips_normalize_when_extract_returns_none(self):
+        """Test that normalize is not called when extract returns None."""
+        xml = "<Root><Text>ignored</Text></Root>"
+        element = ET.fromstring(xml)
+        extractor = NullNormalizeExtractor()
+
+        result = extractor.process(element)
+
+        assert result is None


### PR DESCRIPTION
…attern

Introduces BaseFieldExtractor ABC implementing Template Method pattern for consistent extraction workflow (extract → normalize → process). All 5 PubMed extractors now inherit from this base class while maintaining backward-compatible classmethod APIs.

Changes:
- Add BaseFieldExtractor with abstract extract() and normalize() methods
- Refactor AbstractExtractor to use template pattern
- Refactor AuthorExtractor with RawAuthor TypedDict for structured data
- Refactor ClassificationExtractor with composite extraction
- Refactor DateExtractor with RawDate/NormalizedDate TypedDicts
- Refactor IdentifierExtractor with RawIdentifiers TypedDict
- Add unit tests for BaseFieldExtractor