### PR TITLE
Fix LoggerPort violations in application services

### DIFF
--- a/src/bioetl/application/core/base.py
+++ b/src/bioetl/application/core/base.py
@@ -16,11 +16,10 @@ from bioetl.application.core.shutdown import ShutdownSignal
 from bioetl.domain.context import PipelineContext
 
 if TYPE_CHECKING:
-    import structlog
-
     from bioetl.application.core.base_transformer import BaseTransformer
     from bioetl.application.core.pipeline_services import PipelineServices
     from bioetl.domain.config import PipelineConfig, RuntimeConfig
+    from bioetl.domain.ports import LoggerPort
     from bioetl.domain.types import BronzeRecord, RunID, RunType, SilverRecord
 
 
@@ -139,7 +138,7 @@ class BasePipeline(ABC):
         return self._context
 
     @property
-    def logger(self) -> structlog.BoundLogger:
+    def logger(self) -> LoggerPort:
         """Access bound logger."""
         return self._logger
 

--- a/src/bioetl/application/core/checkpoint_manager.py
+++ b/src/bioetl/application/core/checkpoint_manager.py
@@ -6,13 +6,10 @@ for pipeline run tracking.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from bioetl.domain.ports import CheckpointPort
+from bioetl.domain.ports import CheckpointPort, LoggerPort
 from bioetl.domain.types import RunID
-
-if TYPE_CHECKING:
-    import structlog
 
 
 class CheckpointManager:
@@ -21,7 +18,7 @@ class CheckpointManager:
     def __init__(
         self,
         checkpoint_port: CheckpointPort,
-        logger: structlog.BoundLogger,
+        logger: LoggerPort,
         pipeline_name: str,
         run_id: RunID,
         resume: bool,

--- a/src/bioetl/application/core/lock_manager.py
+++ b/src/bioetl/application/core/lock_manager.py
@@ -10,10 +10,8 @@ from bioetl.application.core.shutdown import PipelineShutdownError, ShutdownSign
 from bioetl.domain.types import RunID, RunType
 
 if TYPE_CHECKING:
-    import structlog
-
     from bioetl.application.core.checkpoint_manager import CheckpointManager
-    from bioetl.domain.ports import LockPort
+    from bioetl.domain.ports import LockPort, LoggerPort
 
 
 class LockManager:
@@ -31,7 +29,7 @@ class LockManager:
         wait_for_lock: bool,
         wait_timeout: int,
         heartbeat_interval: int,
-        logger: structlog.BoundLogger,
+        logger: LoggerPort,
         shutdown_signal: ShutdownSignal,
         checkpoint_manager: CheckpointManager | None = None,
     ) -> None:
@@ -63,7 +61,7 @@ class LockManager:
         wait_for_lock: bool,
         wait_timeout: int,
         heartbeat_interval: int,
-        logger: structlog.BoundLogger,
+        logger: LoggerPort,
         shutdown_signal: ShutdownSignal,
         checkpoint_manager: CheckpointManager | None = None,
     ) -> LockManager:

--- a/src/bioetl/application/observability/observer.py
+++ b/src/bioetl/application/observability/observer.py
@@ -18,9 +18,7 @@ from bioetl.application.core.shutdown import PipelineShutdownError
 if TYPE_CHECKING:
     from types import TracebackType
 
-    import structlog
-
-    from bioetl.domain.ports import MetricsPort, TracingPort
+    from bioetl.domain.ports import LoggerPort, MetricsPort, TracingPort
     from bioetl.domain.types import RunID, RunType
 
 
@@ -33,7 +31,7 @@ class PipelineObserver(AbstractContextManager["PipelineObserver"]):
         run_id: RunID,
         run_type: RunType,
         metrics: MetricsPort,
-        logger: structlog.BoundLogger,
+        logger: LoggerPort,
         tracer: TracingPort | None = None,
     ) -> None:
         """Initialize observer."""

--- a/src/bioetl/application/services/medallion_lifecycle.py
+++ b/src/bioetl/application/services/medallion_lifecycle.py
@@ -10,10 +10,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    import structlog
-
     from bioetl.domain.medallion import MedallionPolicy
-    from bioetl.domain.ports import StoragePort
+    from bioetl.domain.ports import LoggerPort, StoragePort
 
 
 @dataclass(frozen=True, slots=True)
@@ -68,7 +66,7 @@ class MedallionLifecycleService:
     """
 
     storage: StoragePort
-    logger: structlog.BoundLogger
+    logger: LoggerPort
 
     async def clear(
         self,

--- a/tests/architecture/test_no_structlog_in_application_interfaces.py
+++ b/tests/architecture/test_no_structlog_in_application_interfaces.py
@@ -17,12 +17,6 @@ INTERFACES_DIR = Path("src/bioetl/interfaces")
 # Baseline exemptions for existing files (technical debt)
 # These files need refactoring to use LoggerPort instead of direct structlog
 EXEMPTED_FILES = {
-    # Application layer baseline
-    "bioetl/application/core/base.py",
-    "bioetl/application/core/checkpoint_manager.py",
-    "bioetl/application/core/lock_manager.py",
-    "bioetl/application/observability/observer.py",
-    "bioetl/application/services/medallion_lifecycle.py",
     # Interfaces layer baseline
     "bioetl/interfaces/cli.py",
     "bioetl/interfaces/orchestration/signals.py",
@@ -134,4 +128,57 @@ def test_no_structlog_parametrized(layer_name: str, layer_dir: Path) -> None:
         f"Direct structlog imports found in {layer_name} layer:\n"
         + "\n".join(f"  - {v}" for v in violations)
         + f"\n\nThe {layer_name} layer MUST use LoggerPort abstraction. See ADR-006."
+    )
+
+
+def _check_structlog_boundlogger_usage(directory: Path) -> list[str]:
+    """Check for structlog.BoundLogger type annotations in source code.
+
+    Scans Python files for usage of 'structlog.BoundLogger' as type annotation.
+    This catches cases where structlog types are used even inside TYPE_CHECKING blocks.
+
+    Args:
+        directory: Directory to scan for Python files.
+
+    Returns:
+        List of violation messages with file path and line number.
+    """
+    violations = []
+
+    if not directory.exists():
+        return violations
+
+    for py_file in directory.rglob("*.py"):
+        rel_path = py_file.relative_to(Path("src"))
+
+        try:
+            source = py_file.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+
+        # Check for structlog.BoundLogger usage in source
+        for lineno, line in enumerate(source.splitlines(), start=1):
+            if "structlog.BoundLogger" in line:
+                violations.append(f"{rel_path}:{lineno}: {line.strip()}")
+
+    return violations
+
+
+def test_no_structlog_boundlogger_in_application() -> None:
+    """Application layer MUST use LoggerPort, not structlog.BoundLogger.
+
+    REQ-ARCH-032: The application layer should be decoupled from
+    concrete logging implementations. Use LoggerPort from domain.ports.
+
+    This test ensures that structlog.BoundLogger is not used as a type
+    annotation anywhere in the application layer, including in
+    TYPE_CHECKING blocks.
+    """
+    violations = _check_structlog_boundlogger_usage(APPLICATION_DIR)
+
+    assert not violations, (
+        "structlog.BoundLogger usage found in application layer:\n"
+        + "\n".join(f"  - {v}" for v in violations)
+        + "\n\nApplication layer MUST use LoggerPort, not structlog.BoundLogger."
+        + "\nImport LoggerPort from bioetl.domain.ports instead."
     )


### PR DESCRIPTION
Fixes architectural violations by replacing direct structlog.BoundLogger usage with LoggerPort abstraction in application layer files:

- medallion_lifecycle.py: Use LoggerPort for dataclass field
- lock_manager.py: Use LoggerPort in __init__ and create methods
- checkpoint_manager.py: Use LoggerPort in __init__
- observer.py: Use LoggerPort in __init__
- base.py: Use LoggerPort for logger property

Updates test_no_structlog_in_application_interfaces.py:
- Remove fixed files from EXEMPTED_FILES baseline
- Add test_no_structlog_boundlogger_in_application() test

Verified: grep -r "structlog.BoundLogger" src/bioetl/application/ = 0 results All 5 architecture structlog tests pass.

REQ-ARCH-032: Application layer uses LoggerPort abstraction.