### PR TITLE
Add observability to transformer pipeline

### DIFF
--- a/src/bioetl/application/pipelines/chembl/base_chembl_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/base_chembl_transformer.py
@@ -21,6 +21,7 @@ from bioetl.domain.transformations import generate_entity_id
 if TYPE_CHECKING:
     from bioetl.domain.context import PipelineContext
     from bioetl.domain.entities import BaseEntity
+    from bioetl.domain.ports import MetricsPort, TracingPort
     from bioetl.domain.types import BronzeRecord, SilverRecord
 
 
@@ -51,14 +52,21 @@ class BaseChemblTransformer(BaseTransformer):
     entity_class: ClassVar[type[BaseEntity]]
     primary_id_field: ClassVar[str]
 
-    def __init__(self, provider: str = "chembl") -> None:
+    def __init__(
+        self,
+        provider: str = "chembl",
+        tracer: TracingPort | None = None,
+        metrics: MetricsPort | None = None,
+    ) -> None:
         """Initialize ChEMBL transformer.
 
         Args:
             provider: Data provider identifier. Defaults to 'chembl'.
+            tracer: Optional tracing port for distributed tracing (O1 observability).
+            metrics: Optional metrics port for duration/error tracking (O1 observability).
 
         """
-        super().__init__(provider)
+        super().__init__(provider, tracer=tracer, metrics=metrics)
 
     async def _transform_impl(
         self,

--- a/src/bioetl/application/pipelines/pubchem/transformer.py
+++ b/src/bioetl/application/pipelines/pubchem/transformer.py
@@ -14,6 +14,7 @@ from bioetl.domain.transformations import generate_entity_id
 
 if TYPE_CHECKING:
     from bioetl.domain.context import PipelineContext
+    from bioetl.domain.ports import MetricsPort, TracingPort
     from bioetl.domain.types import BronzeRecord, SilverRecord
 
 
@@ -25,14 +26,21 @@ class PubChemCompoundTransformer(BaseTransformer):
     per entity invariant validation.
     """
 
-    def __init__(self, provider: str = "pubchem"):
+    def __init__(
+        self,
+        provider: str = "pubchem",
+        tracer: TracingPort | None = None,
+        metrics: MetricsPort | None = None,
+    ):
         """Initialize PubChem compound transformer.
 
         Args:
             provider: Data provider identifier.
+            tracer: Optional tracing port for distributed tracing (O1 observability).
+            metrics: Optional metrics port for duration/error tracking (O1 observability).
 
         """
-        super().__init__(provider)
+        super().__init__(provider, tracer=tracer, metrics=metrics)
 
     async def _transform_impl(
         self,

--- a/src/bioetl/application/pipelines/pubmed/transformer.py
+++ b/src/bioetl/application/pipelines/pubmed/transformer.py
@@ -22,14 +22,28 @@ from bioetl.domain.transformations import generate_entity_id
 
 if TYPE_CHECKING:
     from bioetl.domain.context import PipelineContext
+    from bioetl.domain.ports import MetricsPort, TracingPort
     from bioetl.domain.types import BronzeRecord, SilverRecord
 
 
 class PubMedPublicationTransformer(BaseTransformer):
     """Transformer for PubMed publication records."""
 
-    def __init__(self, provider: str = "pubmed"):
-        super().__init__(provider)
+    def __init__(
+        self,
+        provider: str = "pubmed",
+        tracer: TracingPort | None = None,
+        metrics: MetricsPort | None = None,
+    ):
+        """Initialize PubMed publication transformer.
+
+        Args:
+            provider: Data provider identifier.
+            tracer: Optional tracing port for distributed tracing (O1 observability).
+            metrics: Optional metrics port for duration/error tracking (O1 observability).
+
+        """
+        super().__init__(provider, tracer=tracer, metrics=metrics)
 
     async def _transform_impl(
         self, context: PipelineContext, record: BronzeRecord

--- a/src/bioetl/application/pipelines/uniprot/transformer.py
+++ b/src/bioetl/application/pipelines/uniprot/transformer.py
@@ -17,6 +17,7 @@ from bioetl.domain.transformations import generate_entity_id
 
 if TYPE_CHECKING:
     from bioetl.domain.context import PipelineContext
+    from bioetl.domain.ports import MetricsPort, TracingPort
     from bioetl.domain.types import BronzeRecord, SilverRecord
 
 
@@ -28,14 +29,21 @@ class UniProtProteinTransformer(BaseTransformer):
     protein_name is optional and may be None.
     """
 
-    def __init__(self, provider: str = "uniprot"):
+    def __init__(
+        self,
+        provider: str = "uniprot",
+        tracer: TracingPort | None = None,
+        metrics: MetricsPort | None = None,
+    ):
         """Initialize UniProt protein transformer.
 
         Args:
             provider: Data provider identifier.
+            tracer: Optional tracing port for distributed tracing (O1 observability).
+            metrics: Optional metrics port for duration/error tracking (O1 observability).
 
         """
-        super().__init__(provider)
+        super().__init__(provider, tracer=tracer, metrics=metrics)
 
     async def _transform_impl(
         self,

--- a/src/bioetl/composition/factories/generic_factory.py
+++ b/src/bioetl/composition/factories/generic_factory.py
@@ -31,7 +31,12 @@ if TYPE_CHECKING:
     from bioetl.composition.observability import ObservabilityBundle
     from bioetl.domain.config import RuntimeConfig
     from bioetl.domain.filter_config import InputFilterConfig
-    from bioetl.domain.ports import DataSourcePort, DQMonitorPort, TracingPort
+    from bioetl.domain.ports import (
+        DataSourcePort,
+        DQMonitorPort,
+        MetricsPort,
+        TracingPort,
+    )
     from bioetl.domain.types import RunID
     from bioetl.infrastructure.config import Settings
     from bioetl.infrastructure.schemas.pipeline_config import PipelineYamlConfig
@@ -110,15 +115,27 @@ class GenericPipelineFactory(Generic[TPipeline]):
             provider
         )
 
-    def create_transformer(self) -> BaseTransformer | None:
+    def create_transformer(
+        self,
+        tracer: TracingPort | None = None,
+        metrics: MetricsPort | None = None,
+    ) -> BaseTransformer | None:
         """Create transformer instance if transformer_class is configured.
+
+        Args:
+            tracer: Optional tracer for distributed tracing (O1 observability).
+            metrics: Optional metrics port for duration/error tracking (O1 observability).
 
         Returns:
             Transformer instance or None if no transformer_class configured.
         """
         if self.transformer_class is None:
             return None
-        return self.transformer_class(provider=self.provider)
+        return self.transformer_class(
+            provider=self.provider,
+            tracer=tracer,
+            metrics=metrics,
+        )
 
     def create_data_source(
         self,
@@ -188,6 +205,7 @@ class GenericPipelineFactory(Generic[TPipeline]):
         filter_config: InputFilterConfig | None = None,
         tracer: TracingPort | None = None,
         dq_monitor: DQMonitorPort | None = None,
+        metrics: MetricsPort | None = None,
     ) -> TPipeline:
         """Create pipeline instance.
 
@@ -203,6 +221,7 @@ class GenericPipelineFactory(Generic[TPipeline]):
             filter_config: Optional input filter configuration
             tracer: Optional tracer (created via bootstrap_tracer())
             dq_monitor: Optional data quality monitor for anomaly detection
+            metrics: Optional metrics port for transformer observability (O1)
 
         Returns:
             Configured pipeline instance
@@ -220,8 +239,11 @@ class GenericPipelineFactory(Generic[TPipeline]):
 
         domain_config = yaml_config_to_domain(yaml_config)
 
-        # Create transformer via DI if configured
-        transformer = self.create_transformer()
+        # Create transformer via DI if configured (with observability O1)
+        transformer = self.create_transformer(
+            tracer=tracer,
+            metrics=metrics,
+        )
 
         return self.pipeline_class.create(
             run_id=run_id,
@@ -259,7 +281,7 @@ class GenericPipelineFactory(Generic[TPipeline]):
         # Load config once if not provided
         yaml_config = config or load_pipeline_config(self.pipeline_name)
 
-        # Create pipeline instance with services, tracer, and dq_monitor
+        # Create pipeline instance with services, tracer, metrics, and dq_monitor (O1)
         pipeline = self.create_with_services(
             run_id=run_id,
             runtime=runtime,
@@ -269,6 +291,7 @@ class GenericPipelineFactory(Generic[TPipeline]):
             filter_config=filter_config,
             tracer=observability.tracer,
             dq_monitor=observability.dq_monitor,
+            metrics=observability.metrics,
         )
 
         # Create Helper Components using ServicesBuilder

--- a/src/bioetl/composition/factories/transformer_factory.py
+++ b/src/bioetl/composition/factories/transformer_factory.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from bioetl.application.core.base_transformer import BaseTransformer
+    from bioetl.domain.ports import MetricsPort, TracingPort
 
 # Mapping of (provider, entity_type) to transformer class
 _TRANSFORMER_REGISTRY: dict[tuple[str, str], type["BaseTransformer"]] = {}
@@ -36,7 +37,12 @@ def register_transformer(
     _TRANSFORMER_REGISTRY[(provider, entity_type)] = transformer_class
 
 
-def create_transformer(provider: str, entity_type: str) -> "BaseTransformer":
+def create_transformer(
+    provider: str,
+    entity_type: str,
+    tracer: TracingPort | None = None,
+    metrics: MetricsPort | None = None,
+) -> "BaseTransformer":
     """Create a transformer instance for the given provider and entity type.
 
     This is the main factory function for creating transformers via DI.
@@ -45,9 +51,11 @@ def create_transformer(provider: str, entity_type: str) -> "BaseTransformer":
     Args:
         provider: Provider name (e.g., 'chembl', 'pubchem').
         entity_type: Entity type (e.g., 'activity', 'compound').
+        tracer: Optional tracing port for distributed tracing (O1 observability).
+        metrics: Optional metrics port for duration/error tracking (O1 observability).
 
     Returns:
-        Configured transformer instance.
+        Configured transformer instance with observability.
 
     Raises:
         KeyError: If no transformer is registered for the provider/entity combination.
@@ -67,7 +75,7 @@ def create_transformer(provider: str, entity_type: str) -> "BaseTransformer":
         )
 
     transformer_class = _TRANSFORMER_REGISTRY[key]
-    return transformer_class(provider=provider)
+    return transformer_class(provider=provider, tracer=tracer, metrics=metrics)
 
 
 def get_transformer_class(


### PR DESCRIPTION
Enable full Bronze→Silver→Gold observability by passing tracer and metrics ports through the transformer dependency injection chain.

Changes:
- GenericPipelineFactory.create_transformer() now accepts tracer/metrics
- create_with_services() and create_runner() pass observability ports
- All concrete transformers forward tracer/metrics to BaseTransformer
- transformer_factory.py create_transformer() supports observability

This ensures transform_duration_seconds and transform_errors_total metrics are published for all transformations (O1 observability).

Ref: RULES.md §2.3 Observability