### PR TITLE
Remove transformer fallback creation logic

### DIFF
--- a/src/bioetl/application/core/base.py
+++ b/src/bioetl/application/core/base.py
@@ -5,6 +5,7 @@ Does NOT handle execution orchestration.
 
 Refactored per ADR-0005.
 Updated: Transformer injection via DI (Phase 1 refactoring).
+Updated: Removed default_transformer_class fallback (REQ-ARCH-DI-007).
 """
 
 from __future__ import annotations
@@ -34,13 +35,9 @@ class BasePipeline(ABC):
 
     It does NOT orchestrate execution. See PipelineRunner for execution logic.
 
-    Subclasses can set `default_transformer_class` to enable fallback transformer
-    creation when no transformer is injected via DI. This eliminates the need
-    for boilerplate __init__ overrides.
+    Transformers MUST be injected via DI from GenericPipelineFactory.
+    BasePipeline does NOT create transformers internally.
     """
-
-    # Override in subclasses to enable fallback transformer creation
-    default_transformer_class: ClassVar[type["BaseTransformer"] | None] = None
 
     @classmethod
     def create(
@@ -49,7 +46,7 @@ class BasePipeline(ABC):
         runtime: RuntimeConfig,
         services: PipelineServices,
         config: PipelineConfig,
-        transformer: "BaseTransformer | None" = None,
+        transformer: BaseTransformer | None = None,
     ) -> Self:
         """Create pipeline instance.
 
@@ -73,7 +70,7 @@ class BasePipeline(ABC):
         runtime: RuntimeConfig,
         services: PipelineServices,
         run_id: RunID,
-        transformer: "BaseTransformer | None" = None,
+        transformer: BaseTransformer | None = None,
     ) -> None:
         """Initialize pipeline definition.
 
@@ -84,21 +81,16 @@ class BasePipeline(ABC):
             run_id: Unique identifier for this pipeline run.
                     MUST be passed from CLI/orchestrator to ensure consistency.
             transformer: Injected transformer for Bronze→Silver transformation.
-                If None, subclass MUST override transform_bronze_to_silver()
-                or set self._transformer in its __init__.
+                MUST be provided via DI from GenericPipelineFactory.
+                If None, transform_bronze_to_silver() will raise NotImplementedError.
 
         """
         self._config = config
         self._runtime = runtime
         self._services = services
         self._run_id = run_id
-        # Use injected transformer, or create from default_transformer_class if available
-        if transformer is not None:
-            self._transformer = transformer
-        elif self.default_transformer_class is not None:
-            self._transformer = self.default_transformer_class(provider=config.provider)
-        else:
-            self._transformer = None
+        # Transformer MUST be injected via DI - no fallback creation
+        self._transformer = transformer
         self._logger = services.logger.bind(
             run_id=str(self._run_id),
             pipeline=config.pipeline_name,
@@ -181,7 +173,7 @@ class BasePipeline(ABC):
         return self._runtime.limit
 
     @property
-    def transformer(self) -> "BaseTransformer | None":
+    def transformer(self) -> BaseTransformer | None:
         """Access the injected transformer."""
         return self._transformer
 

--- a/src/bioetl/application/pipelines/chembl/activity.py
+++ b/src/bioetl/application/pipelines/chembl/activity.py
@@ -6,23 +6,19 @@ Bronze → Silver → Gold layers.
 Entity: Bioactivity measurements (IC50, Ki, EC50, etc.)
 Provider: ChEMBL (https://www.ebi.ac.uk/chembl/)
 
-Refactored: Uses default_transformer_class for fallback (eliminates __init__ boilerplate).
+Transformer is injected via DI from GenericPipelineFactory (REQ-ARCH-DI-007).
 """
 
 from __future__ import annotations
 
 from bioetl.application.core.base import BasePipeline
-from bioetl.application.pipelines.chembl.activity_transformer import ActivityTransformer
 
 
 class ChEMBLActivityPipeline(BasePipeline):
     """Pipeline for ChEMBL bioactivity data.
 
     Transformer is injected via DI from GenericPipelineFactory.
-    Falls back to ActivityTransformer if not injected.
     """
-
-    default_transformer_class = ActivityTransformer
 
     # transform_bronze_to_silver() is inherited from BasePipeline
     # should_write_gold() is inherited from BasePipeline (uses config.gold_filters)

--- a/src/bioetl/application/pipelines/chembl/assay.py
+++ b/src/bioetl/application/pipelines/chembl/assay.py
@@ -6,23 +6,19 @@ Bronze → Silver → Gold layers.
 Entity: Bioassay definitions (binding, functional, ADMET, etc.)
 Provider: ChEMBL (https://www.ebi.ac.uk/chembl/)
 
-Refactored: Uses default_transformer_class for fallback (eliminates __init__ boilerplate).
+Transformer is injected via DI from GenericPipelineFactory (REQ-ARCH-DI-007).
 """
 
 from __future__ import annotations
 
 from bioetl.application.core.base import BasePipeline
-from bioetl.application.pipelines.chembl.assay_transformer import AssayTransformer
 
 
 class ChEMBLAssayPipeline(BasePipeline):
     """Pipeline for ChEMBL assay data.
 
     Transformer is injected via DI from GenericPipelineFactory.
-    Falls back to AssayTransformer if not injected.
     """
-
-    default_transformer_class = AssayTransformer
 
     # transform_bronze_to_silver() is inherited from BasePipeline
     # should_write_gold() is inherited from BasePipeline (uses config.gold_filters)

--- a/src/bioetl/application/pipelines/chembl/document.py
+++ b/src/bioetl/application/pipelines/chembl/document.py
@@ -6,23 +6,19 @@ Bronze → Silver → Gold layers.
 Entity: Scientific Documents (publications, patents)
 Provider: ChEMBL (https://www.ebi.ac.uk/chembl/)
 
-Refactored: Uses default_transformer_class for fallback (eliminates __init__ boilerplate).
+Transformer is injected via DI from GenericPipelineFactory (REQ-ARCH-DI-007).
 """
 
 from __future__ import annotations
 
 from bioetl.application.core.base import BasePipeline
-from bioetl.application.pipelines.chembl.document_transformer import DocumentTransformer
 
 
 class ChEMBLDocumentPipeline(BasePipeline):
     """Pipeline for ChEMBL document data.
 
     Transformer is injected via DI from GenericPipelineFactory.
-    Falls back to DocumentTransformer if not injected.
     """
-
-    default_transformer_class = DocumentTransformer
 
     # transform_bronze_to_silver() is inherited from BasePipeline
     # should_write_gold() is inherited from BasePipeline (uses config.gold_filters)

--- a/src/bioetl/application/pipelines/chembl/molecule.py
+++ b/src/bioetl/application/pipelines/chembl/molecule.py
@@ -6,23 +6,19 @@ Bronze -> Silver -> Gold layers.
 Entity: Chemical Compounds (small molecules, antibodies, etc.)
 Provider: ChEMBL (https://www.ebi.ac.uk/chembl/)
 
-Refactored: Uses default_transformer_class for fallback (eliminates __init__ boilerplate).
+Transformer is injected via DI from GenericPipelineFactory (REQ-ARCH-DI-007).
 """
 
 from __future__ import annotations
 
 from bioetl.application.core.base import BasePipeline
-from bioetl.application.pipelines.chembl.molecule_transformer import MoleculeTransformer
 
 
 class ChEMBLMoleculePipeline(BasePipeline):
     """Pipeline for ChEMBL molecule data.
 
     Transformer is injected via DI from GenericPipelineFactory.
-    Falls back to MoleculeTransformer if not injected.
     """
-
-    default_transformer_class = MoleculeTransformer
 
     # transform_bronze_to_silver() is inherited from BasePipeline
     # should_write_gold() is inherited from BasePipeline (uses config.gold_filters)

--- a/src/bioetl/application/pipelines/chembl/target.py
+++ b/src/bioetl/application/pipelines/chembl/target.py
@@ -6,23 +6,19 @@ Bronze → Silver → Gold layers.
 Entity: Biological Targets (proteins, complexes, organisms)
 Provider: ChEMBL (https://www.ebi.ac.uk/chembl/)
 
-Refactored: Uses default_transformer_class for fallback (eliminates __init__ boilerplate).
+Transformer is injected via DI from GenericPipelineFactory (REQ-ARCH-DI-007).
 """
 
 from __future__ import annotations
 
 from bioetl.application.core.base import BasePipeline
-from bioetl.application.pipelines.chembl.target_transformer import TargetTransformer
 
 
 class ChEMBLTargetPipeline(BasePipeline):
     """Pipeline for ChEMBL target data.
 
     Transformer is injected via DI from GenericPipelineFactory.
-    Falls back to TargetTransformer if not injected.
     """
-
-    default_transformer_class = TargetTransformer
 
     # transform_bronze_to_silver() is inherited from BasePipeline
     # should_write_gold() is inherited from BasePipeline (uses config.gold_filters)

--- a/src/bioetl/application/pipelines/chembl/target_component.py
+++ b/src/bioetl/application/pipelines/chembl/target_component.py
@@ -6,25 +6,19 @@ Bronze → Silver → Gold layers.
 Entity: Target Components (protein sequences, etc.)
 Provider: ChEMBL (https://www.ebi.ac.uk/chembl/)
 
-Refactored: Uses default_transformer_class for fallback (eliminates __init__ boilerplate).
+Transformer is injected via DI from GenericPipelineFactory (REQ-ARCH-DI-007).
 """
 
 from __future__ import annotations
 
 from bioetl.application.core.base import BasePipeline
-from bioetl.application.pipelines.chembl.target_component_transformer import (
-    TargetComponentTransformer,
-)
 
 
 class ChEMBLTargetComponentPipeline(BasePipeline):
     """Pipeline for ChEMBL target component data.
 
     Transformer is injected via DI from GenericPipelineFactory.
-    Falls back to TargetComponentTransformer if not injected.
     """
-
-    default_transformer_class = TargetComponentTransformer
 
     # transform_bronze_to_silver() is inherited from BasePipeline
     # should_write_gold() is inherited from BasePipeline (uses config.gold_filters)

--- a/src/bioetl/application/pipelines/pubchem/compound.py
+++ b/src/bioetl/application/pipelines/pubchem/compound.py
@@ -1,21 +1,17 @@
 """PubChem Compound Pipeline Implementation.
 
-Refactored: Uses default_transformer_class for fallback (eliminates __init__ boilerplate).
+Transformer is injected via DI from GenericPipelineFactory (REQ-ARCH-DI-007).
 """
 
 from __future__ import annotations
 
 from bioetl.application.core.base import BasePipeline
-from bioetl.application.pipelines.pubchem.transformer import PubChemCompoundTransformer
 
 
 class PubChemCompoundPipeline(BasePipeline):
     """Pipeline for processing PubChem compounds.
 
     Transformer is injected via DI from GenericPipelineFactory.
-    Falls back to PubChemCompoundTransformer if not injected.
     """
-
-    default_transformer_class = PubChemCompoundTransformer
 
     # transform_bronze_to_silver() is inherited from BasePipeline

--- a/src/bioetl/application/pipelines/pubmed/publications.py
+++ b/src/bioetl/application/pipelines/pubmed/publications.py
@@ -1,22 +1,18 @@
 # src/bioetl/application/pipelines/pubmed/publications.py
 """PubMed Publications Pipeline.
 
-Refactored: Uses default_transformer_class for fallback (eliminates __init__ boilerplate).
+Transformer is injected via DI from GenericPipelineFactory (REQ-ARCH-DI-007).
 """
 
 from __future__ import annotations
 
 from bioetl.application.core.base import BasePipeline
-from bioetl.application.pipelines.pubmed.transformer import PubMedPublicationTransformer
 
 
 class PubMedPublicationsPipeline(BasePipeline):
     """Пайплайн для данных о публикациях из PubMed.
 
     Transformer is injected via DI from GenericPipelineFactory.
-    Falls back to PubMedPublicationTransformer if not injected.
     """
-
-    default_transformer_class = PubMedPublicationTransformer
 
     # transform_bronze_to_silver() is inherited from BasePipeline

--- a/src/bioetl/application/pipelines/uniprot/protein.py
+++ b/src/bioetl/application/pipelines/uniprot/protein.py
@@ -1,21 +1,17 @@
 """UniProt Protein Pipeline Implementation.
 
-Refactored: Uses default_transformer_class for fallback (eliminates __init__ boilerplate).
+Transformer is injected via DI from GenericPipelineFactory (REQ-ARCH-DI-007).
 """
 
 from __future__ import annotations
 
 from bioetl.application.core.base import BasePipeline
-from bioetl.application.pipelines.uniprot.transformer import UniProtProteinTransformer
 
 
 class UniProtProteinPipeline(BasePipeline):
     """Pipeline for processing UniProt proteins.
 
     Transformer is injected via DI from GenericPipelineFactory.
-    Falls back to UniProtProteinTransformer if not injected.
     """
-
-    default_transformer_class = UniProtProteinTransformer
 
     # transform_bronze_to_silver() is inherited from BasePipeline

--- a/tests/architecture/test_no_transformer_fallback.py
+++ b/tests/architecture/test_no_transformer_fallback.py
@@ -1,0 +1,194 @@
+"""Architecture tests: No transformer fallback in BasePipeline.
+
+REQ-ARCH-DI-007: BasePipeline MUST NOT create transformers internally.
+Transformers MUST be injected via DI from GenericPipelineFactory.
+
+This ensures all dependency creation is centralized in the composition root.
+
+See CLAUDE.md §2.2 Dependency Injection.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+# Paths relative to project root
+APPLICATION_DIR = Path("src/bioetl/application")
+PIPELINES_DIR = Path("src/bioetl/application/pipelines")
+
+
+def _get_base_path(relative_path: Path) -> Path:
+    """Resolve path - works from project root or tests directory."""
+    if relative_path.exists():
+        return relative_path
+    # Try from tests directory context
+    return Path(__file__).parent.parent.parent / relative_path
+
+
+class TestNoTransformerFallback:
+    """Tests ensuring transformer fallback is not used in pipelines."""
+
+    def test_no_default_transformer_class_in_basepipeline(self) -> None:
+        """BasePipeline must not have default_transformer_class attribute.
+
+        REQ-ARCH-DI-007: Transformers must be injected via DI.
+        BasePipeline should not have fallback transformer creation.
+        """
+        base_file = _get_base_path(APPLICATION_DIR) / "core" / "base.py"
+        if not base_file.exists():
+            pytest.skip("BasePipeline file not found")
+
+        content = base_file.read_text(encoding="utf-8")
+
+        # Check for class variable definition
+        pattern = r"default_transformer_class\s*[=:]"
+        matches = list(re.finditer(pattern, content))
+
+        assert not matches, (
+            "BasePipeline must not define default_transformer_class.\n"
+            "Transformers must be injected via DI from GenericPipelineFactory.\n"
+            f"Found: {len(matches)} occurrences in base.py\n"
+            "See REQ-ARCH-DI-007 and CLAUDE.md §2.2"
+        )
+
+    def test_basepipeline_init_does_not_create_transformer(self) -> None:
+        """BasePipeline.__init__ must not create transformers internally.
+
+        REQ-ARCH-DI-007: All transformers must be injected via constructor,
+        not created inside __init__.
+        """
+        base_file = _get_base_path(APPLICATION_DIR) / "core" / "base.py"
+        if not base_file.exists():
+            pytest.skip("BasePipeline file not found")
+
+        content = base_file.read_text(encoding="utf-8")
+
+        try:
+            tree = ast.parse(content)
+        except SyntaxError:
+            pytest.fail("Failed to parse base.py")
+
+        # Find BasePipeline class
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name == "BasePipeline":
+                # Find __init__ method
+                for item in node.body:
+                    if isinstance(item, ast.FunctionDef) and item.name == "__init__":
+                        init_source = ast.get_source_segment(content, item)
+                        if init_source:
+                            # Check for patterns that indicate transformer creation
+                            forbidden_patterns = [
+                                r"self\.default_transformer_class\(",
+                                r"Transformer\(\)",  # Any Transformer() call
+                                r"transformer_class\(",  # transformer_class() call
+                            ]
+                            for pattern in forbidden_patterns:
+                                if re.search(pattern, init_source):
+                                    pytest.fail(
+                                        f"BasePipeline.__init__ contains forbidden pattern: {pattern}\n"
+                                        "Transformers must be injected via DI, not created internally.\n"
+                                        "See REQ-ARCH-DI-007"
+                                    )
+                        return
+
+        pytest.fail("Could not find BasePipeline.__init__ method")
+
+    def test_no_default_transformer_class_in_pipeline_subclasses(self) -> None:
+        """Pipeline subclasses must not define default_transformer_class.
+
+        REQ-ARCH-DI-007: All transformers are provided via GenericPipelineFactory.
+        Pipeline classes should be simple containers without transformer fallbacks.
+        """
+        pipelines_path = _get_base_path(PIPELINES_DIR)
+        if not pipelines_path.exists():
+            pytest.skip("Pipelines directory not found")
+
+        violations = []
+
+        for py_file in pipelines_path.rglob("*.py"):
+            # Skip transformers and other non-pipeline files
+            if "transformer" in py_file.name.lower():
+                continue
+            if py_file.name.startswith("_"):
+                continue
+
+            content = py_file.read_text(encoding="utf-8")
+
+            # Check for default_transformer_class assignment
+            pattern = r"default_transformer_class\s*="
+            if re.search(pattern, content):
+                relative = py_file.relative_to(_get_base_path(PIPELINES_DIR))
+                violations.append(str(relative))
+
+        assert not violations, (
+            "Pipeline subclasses must not define default_transformer_class.\n"
+            "Transformers are injected via GenericPipelineFactory.\n\n"
+            "Violations found:\n" + "\n".join(f"  - {v}" for v in violations)
+            + "\n\nSee REQ-ARCH-DI-007 and CLAUDE.md §2.2"
+        )
+
+    def test_all_factories_have_transformer_class(self) -> None:
+        """All pipeline factories must have transformer_class configured.
+
+        REQ-ARCH-DI-007: Since BasePipeline has no fallback, factories
+        must provide transformer_class for proper DI.
+        """
+        factories_file = (
+            _get_base_path(Path("src/bioetl/composition/factories"))
+            / "pipeline_factories.py"
+        )
+        if not factories_file.exists():
+            pytest.skip("pipeline_factories.py not found")
+
+        content = factories_file.read_text(encoding="utf-8")
+
+        # Find all GenericPipelineFactory instantiations
+        factory_pattern = r"GenericPipelineFactory\([^)]+\)"
+
+        # Check that each factory has transformer_class parameter
+        for match in re.finditer(factory_pattern, content, re.DOTALL):
+            factory_def = match.group(0)
+            if "transformer_class=" not in factory_def:
+                pytest.fail(
+                    f"Factory missing transformer_class:\n{factory_def[:200]}...\n"
+                    "All factories must specify transformer_class for DI.\n"
+                    "See REQ-ARCH-DI-007"
+                )
+
+
+class TestTransformerInjectionPath:
+    """Tests verifying the transformer injection path through factories."""
+
+    def test_generic_factory_creates_transformer(self) -> None:
+        """GenericPipelineFactory must create and inject transformer.
+
+        Verify that the factory has create_transformer() method and
+        uses it in create_with_services().
+        """
+        factory_file = (
+            _get_base_path(Path("src/bioetl/composition/factories"))
+            / "generic_factory.py"
+        )
+        if not factory_file.exists():
+            pytest.skip("generic_factory.py not found")
+
+        content = factory_file.read_text(encoding="utf-8")
+
+        # Check for create_transformer method
+        assert "def create_transformer" in content, (
+            "GenericPipelineFactory must have create_transformer() method"
+        )
+
+        # Check that create_with_services calls create_transformer
+        assert "self.create_transformer()" in content, (
+            "GenericPipelineFactory.create_with_services must call create_transformer()"
+        )
+
+        # Check that transformer is passed to pipeline
+        assert "transformer=transformer" in content, (
+            "GenericPipelineFactory must pass transformer to pipeline constructor"
+        )


### PR DESCRIPTION
Remove default_transformer_class fallback creation to centralize all dependency creation in composition root (GenericPipelineFactory).

Changes:
- Remove default_transformer_class class variable from BasePipeline
- Remove fallback transformer creation logic from BasePipeline.__init__
- Remove default_transformer_class from all 9 pipeline subclasses
- Add architecture tests to prevent regression (REQ-ARCH-DI-007)

This ensures transformers are always injected via DI from GenericPipelineFactory, never created internally by pipelines.

Closes the task for centralizing dependency creation.