### PR TITLE
Implement Medallion architecture policy framework

### DIFF
--- a/src/bioetl/application/core/__init__.py
+++ b/src/bioetl/application/core/__init__.py
@@ -37,6 +37,11 @@ from bioetl.application.core.postrun_service import (
 from bioetl.application.core.preflight_service import PreflightService
 from bioetl.application.core.quarantine_manager import QuarantineManager
 from bioetl.application.core.shutdown import PipelineShutdownError, ShutdownSignal
+from bioetl.application.core.medallion_policy import (
+    Layer,
+    MedallionPolicy,
+    WriteMode,
+)
 from bioetl.application.core.transform_utils import (
     aggregate_nested_lists,
     extract_list_field,
@@ -60,9 +65,11 @@ __all__ = [
     "ClearDecision",
     "DQResult",
     "HealthAggregator",
+    "Layer",
     "LayerInfo",
     "LifecycleOrchestrator",
     "LockManager",
+    "MedallionPolicy",
     "PipelineConfig",
     "PipelineServices",
     "PipelineShutdownError",
@@ -73,6 +80,7 @@ __all__ = [
     "ShutdownSignal",
     "TransformResult",
     "VacuumResult",
+    "WriteMode",
     "aggregate_nested_lists",
     "extract_list_field",
     "flatten_nested_dict",

--- a/src/bioetl/application/core/medallion_policy.py
+++ b/src/bioetl/application/core/medallion_policy.py
@@ -1,0 +1,84 @@
+"""Medallion layer write mode policies.
+
+Validates that write operations comply with medallion architecture rules.
+Per RULES.md §3 (Medallion Architecture):
+- Bronze: Append-only (immutable raw data)
+- Silver: Merge/Upsert or Append (idempotent transforms)
+- Gold: Merge or Overwrite (aggregated/derived data)
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import ClassVar
+
+from bioetl.domain.exceptions import PolicyViolationError
+
+
+class Layer(str, Enum):
+    """Medallion architecture layers.
+
+    Attributes:
+        BRONZE: Raw data layer (immutable, append-only).
+        SILVER: Cleansed/normalized data layer.
+        GOLD: Business-ready aggregated data layer.
+    """
+
+    BRONZE = "bronze"
+    SILVER = "silver"
+    GOLD = "gold"
+
+
+class WriteMode(str, Enum):
+    """Write mode for data operations.
+
+    Attributes:
+        APPEND: Add new records without modifying existing.
+        MERGE: Upsert records based on key (Delta Lake merge).
+        OVERWRITE: Replace entire dataset.
+    """
+
+    APPEND = "append"
+    MERGE = "merge"
+    OVERWRITE = "overwrite"
+
+
+class MedallionPolicy:
+    """Validates write mode compliance with medallion layer policies.
+
+    Enforces medallion architecture invariants:
+    - Bronze: APPEND only (raw data immutability)
+    - Silver: APPEND or MERGE (idempotent upserts)
+    - Gold: MERGE or OVERWRITE (derived data)
+
+    Example:
+        >>> policy = MedallionPolicy()
+        >>> policy.validate(Layer.BRONZE, WriteMode.APPEND)  # OK
+        >>> policy.validate(Layer.BRONZE, WriteMode.OVERWRITE)  # Raises
+        Traceback (most recent call last):
+            ...
+        PolicyViolationError: bronze does not allow overwrite. Allowed: {append}
+    """
+
+    ALLOWED_MODES: ClassVar[dict[Layer, set[WriteMode]]] = {
+        Layer.BRONZE: {WriteMode.APPEND},
+        Layer.SILVER: {WriteMode.MERGE, WriteMode.APPEND},
+        Layer.GOLD: {WriteMode.MERGE, WriteMode.OVERWRITE},
+    }
+
+    def validate(self, layer: Layer, mode: WriteMode) -> None:
+        """Validate that write mode is allowed for the layer.
+
+        Args:
+            layer: Target medallion layer.
+            mode: Requested write mode.
+
+        Raises:
+            PolicyViolationError: If mode is not allowed for the layer.
+        """
+        allowed = self.ALLOWED_MODES[layer]
+        if mode not in allowed:
+            allowed_names = "{" + ", ".join(m.value for m in sorted(allowed, key=lambda x: x.value)) + "}"
+            raise PolicyViolationError(
+                f"{layer.value} does not allow {mode.value}. Allowed: {allowed_names}"
+            )

--- a/src/bioetl/domain/exceptions/__init__.py
+++ b/src/bioetl/domain/exceptions/__init__.py
@@ -23,6 +23,7 @@ from bioetl.domain.exceptions.critical import (
     LockAcquisitionError,
     LockLostError,
     MergeConflictError,
+    PolicyViolationError,
 )
 from bioetl.domain.exceptions.data_quality import (
     DataQualityThresholdError,
@@ -65,6 +66,7 @@ __all__ = [
     "MergeConflictError",
     "MissingRequiredFieldError",
     "NetworkError",
+    "PolicyViolationError",
     "RateLimitError",
     "RecoverableError",
     "RetryExhaustedError",

--- a/src/bioetl/domain/exceptions/critical.py
+++ b/src/bioetl/domain/exceptions/critical.py
@@ -103,3 +103,20 @@ class InfrastructureError(CriticalError):
     def __init__(self, message: str, failed_components: list[str] | None = None) -> None:
         self.failed_components = failed_components or []
         super().__init__(message)
+
+
+class PolicyViolationError(CriticalError):
+    """Raised when medallion layer policy is violated.
+
+    This is a CRITICAL error - pipeline must not proceed with invalid
+    write mode for a given medallion layer.
+
+    Example:
+        - Bronze layer only allows APPEND mode
+        - Attempting OVERWRITE on Bronze raises PolicyViolationError
+    """
+
+    error_type = ErrorType.INVALID_DATA
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)

--- a/tests/unit/application/core/test_medallion_policy.py
+++ b/tests/unit/application/core/test_medallion_policy.py
@@ -1,0 +1,231 @@
+"""Unit tests for MedallionPolicy write mode validation.
+
+Tests all layer/mode combinations per RULES.md §3 (Medallion Architecture):
+- Bronze: APPEND only
+- Silver: APPEND or MERGE
+- Gold: MERGE or OVERWRITE
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bioetl.application.core.medallion_policy import Layer, MedallionPolicy, WriteMode
+from bioetl.domain.exceptions import PolicyViolationError
+
+
+@pytest.mark.unit
+class TestLayer:
+    """Tests for Layer enum."""
+
+    def test_bronze_value(self):
+        """Test Bronze layer value."""
+        assert Layer.BRONZE.value == "bronze"
+
+    def test_silver_value(self):
+        """Test Silver layer value."""
+        assert Layer.SILVER.value == "silver"
+
+    def test_gold_value(self):
+        """Test Gold layer value."""
+        assert Layer.GOLD.value == "gold"
+
+    def test_all_layers_defined(self):
+        """Test that all expected layers are defined."""
+        layers = {layer.value for layer in Layer}
+        assert layers == {"bronze", "silver", "gold"}
+
+
+@pytest.mark.unit
+class TestWriteMode:
+    """Tests for WriteMode enum."""
+
+    def test_append_value(self):
+        """Test APPEND mode value."""
+        assert WriteMode.APPEND.value == "append"
+
+    def test_merge_value(self):
+        """Test MERGE mode value."""
+        assert WriteMode.MERGE.value == "merge"
+
+    def test_overwrite_value(self):
+        """Test OVERWRITE mode value."""
+        assert WriteMode.OVERWRITE.value == "overwrite"
+
+    def test_all_modes_defined(self):
+        """Test that all expected modes are defined."""
+        modes = {mode.value for mode in WriteMode}
+        assert modes == {"append", "merge", "overwrite"}
+
+
+@pytest.mark.unit
+class TestMedallionPolicyAllowedModes:
+    """Tests for MedallionPolicy.ALLOWED_MODES configuration."""
+
+    def test_bronze_allowed_modes(self):
+        """Test Bronze layer allows only APPEND."""
+        assert MedallionPolicy.ALLOWED_MODES[Layer.BRONZE] == {WriteMode.APPEND}
+
+    def test_silver_allowed_modes(self):
+        """Test Silver layer allows APPEND and MERGE."""
+        assert MedallionPolicy.ALLOWED_MODES[Layer.SILVER] == {
+            WriteMode.APPEND,
+            WriteMode.MERGE,
+        }
+
+    def test_gold_allowed_modes(self):
+        """Test Gold layer allows MERGE and OVERWRITE."""
+        assert MedallionPolicy.ALLOWED_MODES[Layer.GOLD] == {
+            WriteMode.MERGE,
+            WriteMode.OVERWRITE,
+        }
+
+    def test_all_layers_have_policies(self):
+        """Test that all layers have defined policies."""
+        defined_layers = set(MedallionPolicy.ALLOWED_MODES.keys())
+        all_layers = set(Layer)
+        assert defined_layers == all_layers
+
+
+@pytest.mark.unit
+class TestMedallionPolicyValidateBronze:
+    """Tests for Bronze layer validation."""
+
+    def test_bronze_append_allowed(self):
+        """Test Bronze APPEND is allowed."""
+        policy = MedallionPolicy()
+        # Should not raise
+        policy.validate(Layer.BRONZE, WriteMode.APPEND)
+
+    def test_bronze_merge_rejected(self):
+        """Test Bronze MERGE is rejected."""
+        policy = MedallionPolicy()
+        with pytest.raises(PolicyViolationError) as exc_info:
+            policy.validate(Layer.BRONZE, WriteMode.MERGE)
+        assert "bronze does not allow merge" in str(exc_info.value)
+        assert "append" in str(exc_info.value)
+
+    def test_bronze_overwrite_rejected(self):
+        """Test Bronze OVERWRITE is rejected (critical criterion)."""
+        policy = MedallionPolicy()
+        with pytest.raises(PolicyViolationError) as exc_info:
+            policy.validate(Layer.BRONZE, WriteMode.OVERWRITE)
+        assert "bronze does not allow overwrite" in str(exc_info.value)
+        assert "append" in str(exc_info.value)
+
+
+@pytest.mark.unit
+class TestMedallionPolicyValidateSilver:
+    """Tests for Silver layer validation."""
+
+    def test_silver_append_allowed(self):
+        """Test Silver APPEND is allowed."""
+        policy = MedallionPolicy()
+        # Should not raise
+        policy.validate(Layer.SILVER, WriteMode.APPEND)
+
+    def test_silver_merge_allowed(self):
+        """Test Silver MERGE is allowed."""
+        policy = MedallionPolicy()
+        # Should not raise
+        policy.validate(Layer.SILVER, WriteMode.MERGE)
+
+    def test_silver_overwrite_rejected(self):
+        """Test Silver OVERWRITE is rejected."""
+        policy = MedallionPolicy()
+        with pytest.raises(PolicyViolationError) as exc_info:
+            policy.validate(Layer.SILVER, WriteMode.OVERWRITE)
+        assert "silver does not allow overwrite" in str(exc_info.value)
+
+
+@pytest.mark.unit
+class TestMedallionPolicyValidateGold:
+    """Tests for Gold layer validation."""
+
+    def test_gold_merge_allowed(self):
+        """Test Gold MERGE is allowed."""
+        policy = MedallionPolicy()
+        # Should not raise
+        policy.validate(Layer.GOLD, WriteMode.MERGE)
+
+    def test_gold_overwrite_allowed(self):
+        """Test Gold OVERWRITE is allowed."""
+        policy = MedallionPolicy()
+        # Should not raise
+        policy.validate(Layer.GOLD, WriteMode.OVERWRITE)
+
+    def test_gold_append_rejected(self):
+        """Test Gold APPEND is rejected."""
+        policy = MedallionPolicy()
+        with pytest.raises(PolicyViolationError) as exc_info:
+            policy.validate(Layer.GOLD, WriteMode.APPEND)
+        assert "gold does not allow append" in str(exc_info.value)
+
+
+@pytest.mark.unit
+class TestMedallionPolicyValidateAllCombinations:
+    """Parametrized tests for all layer/mode combinations."""
+
+    @pytest.mark.parametrize(
+        ("layer", "mode"),
+        [
+            (Layer.BRONZE, WriteMode.APPEND),
+            (Layer.SILVER, WriteMode.APPEND),
+            (Layer.SILVER, WriteMode.MERGE),
+            (Layer.GOLD, WriteMode.MERGE),
+            (Layer.GOLD, WriteMode.OVERWRITE),
+        ],
+    )
+    def test_allowed_combinations(self, layer: Layer, mode: WriteMode):
+        """Test all allowed layer/mode combinations."""
+        policy = MedallionPolicy()
+        # Should not raise
+        policy.validate(layer, mode)
+
+    @pytest.mark.parametrize(
+        ("layer", "mode"),
+        [
+            (Layer.BRONZE, WriteMode.MERGE),
+            (Layer.BRONZE, WriteMode.OVERWRITE),
+            (Layer.SILVER, WriteMode.OVERWRITE),
+            (Layer.GOLD, WriteMode.APPEND),
+        ],
+    )
+    def test_disallowed_combinations(self, layer: Layer, mode: WriteMode):
+        """Test all disallowed layer/mode combinations."""
+        policy = MedallionPolicy()
+        with pytest.raises(PolicyViolationError):
+            policy.validate(layer, mode)
+
+
+@pytest.mark.unit
+class TestPolicyViolationErrorMessage:
+    """Tests for error message formatting."""
+
+    def test_error_message_contains_layer_name(self):
+        """Test error message contains layer name."""
+        policy = MedallionPolicy()
+        with pytest.raises(PolicyViolationError) as exc_info:
+            policy.validate(Layer.BRONZE, WriteMode.OVERWRITE)
+        assert "bronze" in str(exc_info.value)
+
+    def test_error_message_contains_mode_name(self):
+        """Test error message contains mode name."""
+        policy = MedallionPolicy()
+        with pytest.raises(PolicyViolationError) as exc_info:
+            policy.validate(Layer.BRONZE, WriteMode.OVERWRITE)
+        assert "overwrite" in str(exc_info.value)
+
+    def test_error_message_contains_allowed_modes(self):
+        """Test error message contains allowed modes."""
+        policy = MedallionPolicy()
+        with pytest.raises(PolicyViolationError) as exc_info:
+            policy.validate(Layer.BRONZE, WriteMode.OVERWRITE)
+        # Bronze only allows append
+        assert "append" in str(exc_info.value)
+
+    def test_error_is_critical_error(self):
+        """Test that PolicyViolationError is a CriticalError."""
+        from bioetl.domain.exceptions.base import CriticalError
+
+        assert issubclass(PolicyViolationError, CriticalError)


### PR DESCRIPTION
Implements medallion layer write mode policies per RULES.md §3:
- Bronze: APPEND only (immutable raw data)
- Silver: APPEND or MERGE (idempotent transforms)
- Gold: MERGE or OVERWRITE (aggregated/derived data)

Adds PolicyViolationError exception for invalid layer/mode combinations. Includes 34 unit tests covering all layer/mode combinations.