### PR TITLE
Separate CLI from composition root

### DIFF
--- a/src/bioetl/composition/entrypoints.py
+++ b/src/bioetl/composition/entrypoints.py
@@ -1,0 +1,339 @@
+"""Entrypoints for BioETL pipeline operations.
+
+Provides high-level functions for running pipelines and managing resources.
+These entrypoints are designed to be used by CLI, Prefect, REST APIs, or any
+other orchestration layer without direct dependency on bootstrap functions.
+
+The CLI should only import from this module, not from bootstrap.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+from uuid import uuid4
+
+from bioetl.domain.types import RunID
+
+from bioetl.composition.bootstrap import (
+    bootstrap_checkpoint_manager,
+    bootstrap_cleanup,
+    bootstrap_lifecycle_service,
+    bootstrap_pipeline,
+    bootstrap_quarantine_manager,
+    load_pipeline_config,
+)
+from bioetl.composition.factories.pipeline_factories import register_all_pipelines
+from bioetl.composition.providers.registration import register_all_providers
+from bioetl.domain.context import PipelineRunContext
+from bioetl.domain.types import RunType
+
+if TYPE_CHECKING:
+    from bioetl.application.checkpoint.manager import CheckpointManager
+    from bioetl.application.core.runner import PipelineRunner
+    from bioetl.application.quarantine.manager import QuarantineManager
+    from bioetl.application.services.cleanup_service import CleanupPreview
+    from bioetl.application.services.lifecycle_service import LifecycleService
+
+
+@dataclass(frozen=True)
+class RunOptions:
+    """Options for running a pipeline.
+
+    These are the user-facing options that can be set via CLI, Prefect, or REST.
+    The entrypoint converts these to internal domain types.
+
+    Attributes:
+        run_type: Type of run (incremental, backfill, rebuild). Default: incremental.
+        resume: Whether to resume from the last checkpoint.
+        limit: Maximum number of records to process.
+        input_csv: Path to CSV file with filter IDs.
+        filter_column: Column name in CSV containing filter IDs.
+        filter_field: API field name to filter by.
+        dry_run: Preview mode without execution.
+    """
+
+    run_type: str = "incremental"
+    resume: bool = False
+    limit: int | None = None
+    input_csv: str | None = None
+    filter_column: str | None = None
+    filter_field: str | None = None
+    dry_run: bool = False
+
+
+@dataclass(frozen=True)
+class VacuumOptions:
+    """Options for vacuum operation.
+
+    Attributes:
+        retention_days: Minimum age of files to remove (days).
+        dry_run: Preview mode showing what would be removed.
+    """
+
+    retention_days: int = 7
+    dry_run: bool = False
+
+
+@dataclass(frozen=True)
+class ArchiveOptions:
+    """Options for archive operation.
+
+    Attributes:
+        target_path: Destination path for archive.
+        remove_source: Remove source table after archiving.
+    """
+
+    target_path: str
+    remove_source: bool = False
+
+
+def _ensure_registrations() -> None:
+    """Ensure all providers and pipelines are registered.
+
+    This is idempotent and safe to call multiple times.
+    """
+    register_all_providers()
+    register_all_pipelines()
+
+
+def build_pipeline_context(name: str, options: RunOptions) -> PipelineRunContext:
+    """Build a PipelineRunContext from user-facing options.
+
+    Args:
+        name: Pipeline name (e.g., 'chembl_activity').
+        options: User-facing run options.
+
+    Returns:
+        PipelineRunContext ready for bootstrap_pipeline.
+    """
+    return PipelineRunContext(
+        pipeline_name=name,
+        run_id=cast(RunID, uuid4()),
+        run_type=RunType(options.run_type),
+        resume=options.resume,
+        limit=options.limit,
+        input_csv=options.input_csv,
+        filter_column=options.filter_column,
+        filter_field=options.filter_field,
+        dry_run=options.dry_run,
+    )
+
+
+def create_pipeline_runner(name: str, options: RunOptions) -> PipelineRunner:
+    """Create a pipeline runner for the given pipeline and options.
+
+    This is the main entrypoint for pipeline execution. It handles:
+    - Registration of providers and pipelines
+    - Building the pipeline context
+    - Bootstrapping the runner with all dependencies
+
+    Args:
+        name: Pipeline name (e.g., 'chembl_activity').
+        options: User-facing run options.
+
+    Returns:
+        PipelineRunner ready for execution via runner.run().
+
+    Raises:
+        ValueError: If pipeline name is unknown or options are invalid.
+        FileNotFoundError: If pipeline config file is missing.
+
+    Example:
+        >>> options = RunOptions(run_type="incremental", limit=100)
+        >>> runner = create_pipeline_runner("chembl_activity", options)
+        >>> await runner.run()
+    """
+    _ensure_registrations()
+    ctx = build_pipeline_context(name, options)
+    return bootstrap_pipeline(ctx)
+
+
+async def run_pipeline(name: str, options: RunOptions) -> None:
+    """Run a pipeline with the given options.
+
+    Convenience function that creates and executes a pipeline runner.
+    For more control over execution, use create_pipeline_runner() directly.
+
+    Args:
+        name: Pipeline name (e.g., 'chembl_activity').
+        options: User-facing run options.
+
+    Raises:
+        ValueError: If pipeline name is unknown or options are invalid.
+        FileNotFoundError: If pipeline config file is missing.
+        PipelineShutdownError: If pipeline was gracefully shut down.
+
+    Example:
+        >>> options = RunOptions(run_type="incremental", limit=100)
+        >>> await run_pipeline("chembl_activity", options)
+    """
+    runner = create_pipeline_runner(name, options)
+    await runner.run()
+
+
+def get_quarantine_manager(pipeline: str) -> QuarantineManager:
+    """Get a quarantine manager for the given pipeline.
+
+    Used for inspecting and managing quarantined (failed) records.
+
+    Args:
+        pipeline: Pipeline name (e.g., 'chembl_activity').
+
+    Returns:
+        QuarantineManager instance for the pipeline.
+
+    Example:
+        >>> manager = get_quarantine_manager("chembl_activity")
+        >>> records = await manager.inspect(limit=100)
+    """
+    _ensure_registrations()
+    return bootstrap_quarantine_manager(pipeline)
+
+
+def get_checkpoint_manager(pipeline: str) -> CheckpointManager:
+    """Get a checkpoint manager for the given pipeline.
+
+    Used for listing, loading, and managing pipeline checkpoints.
+
+    Args:
+        pipeline: Pipeline name (e.g., 'chembl_activity').
+
+    Returns:
+        CheckpointManager instance for the pipeline.
+
+    Example:
+        >>> manager = get_checkpoint_manager("chembl_activity")
+        >>> checkpoints = await manager.list_all()
+    """
+    _ensure_registrations()
+    return bootstrap_checkpoint_manager(pipeline)
+
+
+def get_lifecycle_service() -> LifecycleService:
+    """Get the lifecycle service for maintenance operations.
+
+    Used for vacuum and archive operations on Delta tables.
+
+    Returns:
+        LifecycleService instance.
+
+    Example:
+        >>> service = get_lifecycle_service()
+        >>> removed = await service.vacuum("chembl.activity", retention_days=7)
+    """
+    _ensure_registrations()
+    return bootstrap_lifecycle_service()
+
+
+async def vacuum_table(table: str, options: VacuumOptions) -> int:
+    """Vacuum a Delta table to reclaim storage space.
+
+    Args:
+        table: Table name in format "provider.entity" (e.g., 'chembl.activity').
+        options: Vacuum options including retention and dry_run.
+
+    Returns:
+        Number of files removed (or would be removed in dry_run mode).
+
+    Example:
+        >>> options = VacuumOptions(retention_days=30, dry_run=True)
+        >>> files_removed = await vacuum_table("chembl.activity", options)
+    """
+    service = get_lifecycle_service()
+    result: int = await service.vacuum(
+        table=table,
+        retention_days=options.retention_days,
+        dry_run=options.dry_run,
+    )
+    return result
+
+
+async def archive_table(table: str, options: ArchiveOptions) -> int:
+    """Archive a Delta table to cold storage.
+
+    Args:
+        table: Table name to archive.
+        options: Archive options including target path and remove_source.
+
+    Returns:
+        Number of files archived.
+
+    Example:
+        >>> options = ArchiveOptions(target_path="/archive/chembl", remove_source=False)
+        >>> files_archived = await archive_table("chembl.activity", options)
+    """
+    service = get_lifecycle_service()
+    result: int = await service.archive(
+        table=table,
+        target_path=options.target_path,
+        remove_source=options.remove_source,
+    )
+    return result
+
+
+async def preview_cleanup(pipeline: str) -> CleanupPreview:
+    """Preview what data would be cleared for a pipeline.
+
+    Used for dry-run mode of rebuild/backfill operations.
+
+    Args:
+        pipeline: Pipeline name (e.g., 'chembl_activity').
+
+    Returns:
+        CleanupPreview with information about what would be cleared.
+
+    Example:
+        >>> preview = await preview_cleanup("chembl_activity")
+        >>> print(f"Would clear {preview.total_files} files")
+    """
+    _ensure_registrations()
+    config = load_pipeline_config(pipeline)
+    cleanup_service = bootstrap_cleanup()
+    return await cleanup_service.preview(
+        silver_table=config.silver_table,
+        gold_table=config.gold_table,
+    )
+
+
+async def inspect_quarantine(pipeline: str, limit: int = 100) -> list[dict[str, Any]]:
+    """Inspect quarantined records for a pipeline.
+
+    Convenience function for quick quarantine inspection.
+
+    Args:
+        pipeline: Pipeline name (e.g., 'chembl_activity').
+        limit: Maximum number of records to return.
+
+    Returns:
+        List of quarantine record dictionaries.
+
+    Example:
+        >>> records = await inspect_quarantine("chembl_activity", limit=50)
+        >>> for rec in records:
+        ...     print(f"Error: {rec['error_code']}")
+    """
+    manager = get_quarantine_manager(pipeline)
+    records: list[dict[str, Any]] = await manager.inspect(limit=limit)
+    return records
+
+
+async def list_checkpoints(pipeline: str) -> list[str]:
+    """List all checkpoints for a pipeline.
+
+    Convenience function for quick checkpoint listing.
+
+    Args:
+        pipeline: Pipeline name (e.g., 'chembl_activity').
+
+    Returns:
+        List of checkpoint identifiers.
+
+    Example:
+        >>> checkpoints = await list_checkpoints("chembl_activity")
+        >>> for cp in checkpoints:
+        ...     print(f"- {cp}")
+    """
+    manager = get_checkpoint_manager(pipeline)
+    checkpoints: list[str] = await manager.list_all()
+    return checkpoints

--- a/src/bioetl/interfaces/cli.py
+++ b/src/bioetl/interfaces/cli.py
@@ -1,8 +1,7 @@
 """Command-line interface for BioETL.
 
 This is the primary entry point for running pipelines from the command line.
-It acts as the "Composition Root" for the application, where dependencies
-are assembled and the pipeline is executed.
+It delegates to composition/entrypoints.py for all pipeline operations.
 """
 
 from __future__ import annotations
@@ -10,23 +9,20 @@ from __future__ import annotations
 import asyncio
 import sys
 from typing import TYPE_CHECKING
-from uuid import uuid4
 
 import click
 
 from bioetl.application.core.shutdown import PipelineShutdownError
-from bioetl.composition.bootstrap import (
-    bootstrap_checkpoint_manager,
-    bootstrap_cleanup,
-    bootstrap_lifecycle_service,
-    bootstrap_pipeline,
-    bootstrap_quarantine_manager,
-    load_pipeline_config,
+from bioetl.composition.entrypoints import (
+    RunOptions,
+    create_pipeline_runner,
+    get_checkpoint_manager,
+    get_lifecycle_service,
+    get_quarantine_manager,
+    preview_cleanup,
 )
 from bioetl.composition.factories.pipeline_factories import register_all_pipelines
 from bioetl.composition.registry import PipelineRegistry
-from bioetl.domain.context import PipelineRunContext
-from bioetl.domain.types import RunType
 from bioetl.interfaces.orchestration.signals import setup_shutdown_handlers
 
 if TYPE_CHECKING:
@@ -38,37 +34,35 @@ if TYPE_CHECKING:
 async def _preview_cleanup_async(pipeline: str) -> None:
     """Preview what data would be cleared in dry-run mode.
 
-    Delegates to CleanupService.preview() for clean architecture.
+    Delegates to entrypoints.preview_cleanup() for clean architecture.
 
     Args:
         pipeline: Pipeline name
     """
-    config = load_pipeline_config(pipeline)
-    cleanup_service = bootstrap_cleanup()
-
-    preview = await cleanup_service.preview(
-        silver_table=config.silver_table,
-        gold_table=config.gold_table,
-    )
+    preview_result = await preview_cleanup(pipeline)
 
     click.echo("\nFiles/directories that would be cleared:")
 
     # Display Silver info
-    if preview.silver.exists:
+    if preview_result.silver.exists:
         click.echo(
-            f"  Silver: {preview.silver.path} ({preview.silver.file_count} files)"
+            f"  Silver: {preview_result.silver.path} "
+            f"({preview_result.silver.file_count} files)"
         )
     else:
-        click.echo(f"  Silver: {preview.silver.path} (does not exist)")
+        click.echo(f"  Silver: {preview_result.silver.path} (does not exist)")
 
     # Display Gold info
-    if preview.gold:
-        if preview.gold.exists:
-            click.echo(f"  Gold: {preview.gold.path} ({preview.gold.file_count} files)")
+    if preview_result.gold:
+        if preview_result.gold.exists:
+            click.echo(
+                f"  Gold: {preview_result.gold.path} "
+                f"({preview_result.gold.file_count} files)"
+            )
         else:
-            click.echo(f"  Gold: {preview.gold.path} (does not exist)")
+            click.echo(f"  Gold: {preview_result.gold.path} (does not exist)")
 
-    click.echo(f"\nTotal items that would be cleared: ~{preview.total_files}")
+    click.echo(f"\nTotal items that would be cleared: ~{preview_result.total_files}")
     click.echo("\nNo changes were made (dry-run mode).")
 
 
@@ -207,13 +201,9 @@ def run(
     if not _handle_destructive_run_confirmation(pipeline, run_type, dry_run, yes):
         return
 
-    run_id = uuid4()
-
     try:
-        ctx = PipelineRunContext(
-            pipeline_name=pipeline,
-            run_id=run_id,
-            run_type=RunType(run_type),
+        options = RunOptions(
+            run_type=run_type,
             resume=resume,
             limit=limit,
             input_csv=input_csv,
@@ -221,7 +211,7 @@ def run(
             filter_field=filter_field,
             dry_run=dry_run,
         )
-        runner = bootstrap_pipeline(ctx)
+        runner = create_pipeline_runner(pipeline, options)
     except (ValueError, FileNotFoundError) as e:
         click.echo(f"Configuration error: {e}", err=True)
         sys.exit(1)
@@ -261,8 +251,8 @@ def quarantine_inspect(pipeline: str, limit: int) -> None:
     """Inspect quarantined records."""
     click.echo(f"Inspecting quarantine for {pipeline} (limit {limit})...")
 
-    # Use application-layer QuarantineManager via bootstrap
-    quarantine_manager = bootstrap_quarantine_manager(pipeline)
+    # Use application-layer QuarantineManager via entrypoints
+    quarantine_manager = get_quarantine_manager(pipeline)
 
     # Run async inspection
     async def _inspect() -> None:
@@ -291,8 +281,8 @@ def checkpoint_list(pipeline: str) -> None:
     """List all checkpoints."""
     click.echo(f"Listing checkpoints for {pipeline}...")
 
-    # Use application-layer CheckpointManager via bootstrap
-    checkpoint_manager = bootstrap_checkpoint_manager(pipeline)
+    # Use application-layer CheckpointManager via entrypoints
+    checkpoint_manager = get_checkpoint_manager(pipeline)
 
     async def _list() -> None:
         checkpoints = await checkpoint_manager.list_all()
@@ -334,7 +324,7 @@ def vacuum_command(table: str, retention_days: int, dry_run: bool) -> None:
 
         bioetl maintenance vacuum chembl.activity -r 30
     """
-    lifecycle = bootstrap_lifecycle_service()
+    lifecycle = get_lifecycle_service()
 
     async def _run() -> None:
         if dry_run:
@@ -369,7 +359,7 @@ def archive_command(table: str, target_path: str, remove_source: bool) -> None:
 
     TARGET_PATH: Destination path for archive
     """
-    lifecycle = bootstrap_lifecycle_service()
+    lifecycle = get_lifecycle_service()
 
     async def _run() -> None:
         files_archived = await lifecycle.archive(

--- a/tests/integration/interfaces/test_cli_checkpoint_list.py
+++ b/tests/integration/interfaces/test_cli_checkpoint_list.py
@@ -54,7 +54,7 @@ class TestCliCheckpointList:
         mock_manager.list_all = AsyncMock(return_value=[])
 
         with patch(
-            "bioetl.interfaces.cli.bootstrap_checkpoint_manager",
+            "bioetl.interfaces.cli.get_checkpoint_manager",
             return_value=mock_manager,
         ):
             result = cli_runner.invoke(
@@ -81,7 +81,7 @@ class TestCliCheckpointList:
         mock_manager.list_all = AsyncMock(return_value=sample_checkpoints)
 
         with patch(
-            "bioetl.interfaces.cli.bootstrap_checkpoint_manager",
+            "bioetl.interfaces.cli.get_checkpoint_manager",
             return_value=mock_manager,
         ):
             result = cli_runner.invoke(
@@ -107,7 +107,7 @@ class TestCliCheckpointList:
         mock_manager.list_all = AsyncMock(return_value=sample_checkpoints)
 
         with patch(
-            "bioetl.interfaces.cli.bootstrap_checkpoint_manager",
+            "bioetl.interfaces.cli.get_checkpoint_manager",
             return_value=mock_manager,
         ):
             result = cli_runner.invoke(
@@ -236,7 +236,7 @@ class TestCliCheckpointIntegration:
         mock_manager.list_all = AsyncMock(return_value=["test_pipeline"])
 
         with patch(
-            "bioetl.interfaces.cli.bootstrap_checkpoint_manager",
+            "bioetl.interfaces.cli.get_checkpoint_manager",
             return_value=mock_manager,
         ) as mock_bootstrap:
             result = cli_runner.invoke(

--- a/tests/integration/interfaces/test_cli_maintenance_archive.py
+++ b/tests/integration/interfaces/test_cli_maintenance_archive.py
@@ -62,7 +62,7 @@ class TestCliMaintenanceArchiveExecution:
     ):
         """Test successful archive operation."""
         with patch(
-            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            "bioetl.interfaces.cli.get_lifecycle_service",
             return_value=mock_lifecycle_service,
         ):
             result = cli_runner.invoke(
@@ -87,7 +87,7 @@ class TestCliMaintenanceArchiveExecution:
     ):
         """Test archive with --remove-source flag."""
         with patch(
-            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            "bioetl.interfaces.cli.get_lifecycle_service",
             return_value=mock_lifecycle_service,
         ):
             result = cli_runner.invoke(
@@ -118,7 +118,7 @@ class TestCliMaintenanceArchiveExecution:
         mock_lifecycle_service.archive.return_value = 50
 
         with patch(
-            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            "bioetl.interfaces.cli.get_lifecycle_service",
             return_value=mock_lifecycle_service,
         ):
             result = cli_runner.invoke(
@@ -153,7 +153,7 @@ class TestCliMaintenanceArchivePathValidation:
     ):
         """Test archive with absolute target path."""
         with patch(
-            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            "bioetl.interfaces.cli.get_lifecycle_service",
             return_value=mock_lifecycle_service,
         ):
             result = cli_runner.invoke(
@@ -171,7 +171,7 @@ class TestCliMaintenanceArchivePathValidation:
     ):
         """Test archive with relative target path."""
         with patch(
-            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            "bioetl.interfaces.cli.get_lifecycle_service",
             return_value=mock_lifecycle_service,
         ):
             result = cli_runner.invoke(
@@ -193,7 +193,7 @@ class TestCliMaintenanceArchivePathValidation:
     ):
         """Test archive with path containing special characters."""
         with patch(
-            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            "bioetl.interfaces.cli.get_lifecycle_service",
             return_value=mock_lifecycle_service,
         ):
             result = cli_runner.invoke(
@@ -228,7 +228,7 @@ class TestCliMaintenanceArchiveErrors:
     ):
         """Test that archive propagates service errors."""
         with patch(
-            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            "bioetl.interfaces.cli.get_lifecycle_service",
             return_value=mock_lifecycle_service_error,
         ):
             result = cli_runner.invoke(
@@ -250,7 +250,7 @@ class TestCliMaintenanceArchiveErrors:
         )
 
         with patch(
-            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            "bioetl.interfaces.cli.get_lifecycle_service",
             return_value=mock_service,
         ):
             result = cli_runner.invoke(
@@ -279,7 +279,7 @@ class TestCliMaintenanceArchiveRemoveSource:
     ):
         """Test that archive without --remove-source keeps the source."""
         with patch(
-            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            "bioetl.interfaces.cli.get_lifecycle_service",
             return_value=mock_lifecycle_service,
         ):
             result = cli_runner.invoke(
@@ -300,7 +300,7 @@ class TestCliMaintenanceArchiveRemoveSource:
     ):
         """Test that archive with --remove-source removes the source."""
         with patch(
-            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            "bioetl.interfaces.cli.get_lifecycle_service",
             return_value=mock_lifecycle_service,
         ):
             result = cli_runner.invoke(
@@ -338,7 +338,7 @@ class TestCliMaintenanceArchiveOutput:
     ):
         """Test that archive shows the number of archived files."""
         with patch(
-            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            "bioetl.interfaces.cli.get_lifecycle_service",
             return_value=mock_lifecycle_service,
         ):
             result = cli_runner.invoke(
@@ -357,7 +357,7 @@ class TestCliMaintenanceArchiveOutput:
     ):
         """Test that archive output includes target path."""
         with patch(
-            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            "bioetl.interfaces.cli.get_lifecycle_service",
             return_value=mock_lifecycle_service,
         ):
             result = cli_runner.invoke(
@@ -377,7 +377,7 @@ class TestCliMaintenanceArchiveOutput:
         mock_service.archive = AsyncMock(return_value=0)
 
         with patch(
-            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            "bioetl.interfaces.cli.get_lifecycle_service",
             return_value=mock_service,
         ):
             result = cli_runner.invoke(

--- a/tests/integration/interfaces/test_cli_maintenance_vacuum.py
+++ b/tests/integration/interfaces/test_cli_maintenance_vacuum.py
@@ -54,7 +54,7 @@ class TestCliMaintenanceVacuumExecution:
     ):
         """Test successful vacuum operation."""
         with patch(
-            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            "bioetl.interfaces.cli.get_lifecycle_service",
             return_value=mock_lifecycle_service,
         ):
             result = cli_runner.invoke(
@@ -79,7 +79,7 @@ class TestCliMaintenanceVacuumExecution:
     ):
         """Test vacuum with custom retention days."""
         with patch(
-            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            "bioetl.interfaces.cli.get_lifecycle_service",
             return_value=mock_lifecycle_service,
         ):
             result = cli_runner.invoke(
@@ -102,7 +102,7 @@ class TestCliMaintenanceVacuumExecution:
     ):
         """Test vacuum with short -r flag for retention."""
         with patch(
-            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            "bioetl.interfaces.cli.get_lifecycle_service",
             return_value=mock_lifecycle_service,
         ):
             result = cli_runner.invoke(
@@ -136,7 +136,7 @@ class TestCliMaintenanceVacuumDryRun:
     ):
         """Test that --dry-run shows what would be removed."""
         with patch(
-            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            "bioetl.interfaces.cli.get_lifecycle_service",
             return_value=mock_lifecycle_service,
         ):
             result = cli_runner.invoke(
@@ -161,7 +161,7 @@ class TestCliMaintenanceVacuumDryRun:
     ):
         """Test that dry-run shows the number of files that would be removed."""
         with patch(
-            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            "bioetl.interfaces.cli.get_lifecycle_service",
             return_value=mock_lifecycle_service,
         ):
             result = cli_runner.invoke(
@@ -181,7 +181,7 @@ class TestCliMaintenanceVacuumDryRun:
         mock_lifecycle_service.vacuum.return_value = 25
 
         with patch(
-            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            "bioetl.interfaces.cli.get_lifecycle_service",
             return_value=mock_lifecycle_service,
         ):
             result = cli_runner.invoke(
@@ -216,7 +216,7 @@ class TestCliMaintenanceVacuumErrors:
     ):
         """Test that vacuum propagates service errors."""
         with patch(
-            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            "bioetl.interfaces.cli.get_lifecycle_service",
             return_value=mock_lifecycle_service_error,
         ):
             result = cli_runner.invoke(
@@ -236,7 +236,7 @@ class TestCliMaintenanceVacuumErrors:
         mock_service.vacuum = AsyncMock(return_value=0)
 
         with patch(
-            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            "bioetl.interfaces.cli.get_lifecycle_service",
             return_value=mock_service,
         ):
             result = cli_runner.invoke(
@@ -265,7 +265,7 @@ class TestCliMaintenanceVacuumOutput:
     ):
         """Test that vacuum shows the number of removed files."""
         with patch(
-            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            "bioetl.interfaces.cli.get_lifecycle_service",
             return_value=mock_lifecycle_service,
         ):
             result = cli_runner.invoke(
@@ -284,7 +284,7 @@ class TestCliMaintenanceVacuumOutput:
     ):
         """Test that dry-run output says 'would remove'."""
         with patch(
-            "bioetl.interfaces.cli.bootstrap_lifecycle_service",
+            "bioetl.interfaces.cli.get_lifecycle_service",
             return_value=mock_lifecycle_service,
         ):
             result = cli_runner.invoke(

--- a/tests/integration/interfaces/test_cli_quarantine_inspect.py
+++ b/tests/integration/interfaces/test_cli_quarantine_inspect.py
@@ -56,7 +56,7 @@ class TestCliQuarantineInspect:
         mock_manager.inspect = AsyncMock(return_value=[])
 
         with patch(
-            "bioetl.interfaces.cli.bootstrap_quarantine_manager",
+            "bioetl.interfaces.cli.get_quarantine_manager",
             return_value=mock_manager,
         ):
             result = cli_runner.invoke(
@@ -91,7 +91,7 @@ class TestCliQuarantineInspect:
         mock_manager.inspect = AsyncMock(return_value=sample_records)
 
         with patch(
-            "bioetl.interfaces.cli.bootstrap_quarantine_manager",
+            "bioetl.interfaces.cli.get_quarantine_manager",
             return_value=mock_manager,
         ):
             result = cli_runner.invoke(
@@ -114,7 +114,7 @@ class TestCliQuarantineInspect:
         mock_manager.inspect = AsyncMock(return_value=[])
 
         with patch(
-            "bioetl.interfaces.cli.bootstrap_quarantine_manager",
+            "bioetl.interfaces.cli.get_quarantine_manager",
             return_value=mock_manager,
         ):
             result = cli_runner.invoke(
@@ -136,7 +136,7 @@ class TestCliQuarantineInspect:
         mock_manager.inspect = AsyncMock(return_value=[])
 
         with patch(
-            "bioetl.interfaces.cli.bootstrap_quarantine_manager",
+            "bioetl.interfaces.cli.get_quarantine_manager",
             return_value=mock_manager,
         ):
             result = cli_runner.invoke(
@@ -169,7 +169,7 @@ class TestCliQuarantineInspect:
         mock_manager.inspect = AsyncMock(return_value=sample_records)
 
         with patch(
-            "bioetl.interfaces.cli.bootstrap_quarantine_manager",
+            "bioetl.interfaces.cli.get_quarantine_manager",
             return_value=mock_manager,
         ):
             result = cli_runner.invoke(
@@ -191,7 +191,7 @@ class TestCliQuarantineInspect:
         mock_manager.inspect = AsyncMock(return_value=[])
 
         with patch(
-            "bioetl.interfaces.cli.bootstrap_quarantine_manager",
+            "bioetl.interfaces.cli.get_quarantine_manager",
             return_value=mock_manager,
         ) as mock_bootstrap:
             # Inspect chembl_activity

--- a/tests/integration/interfaces/test_cli_run_dry_run.py
+++ b/tests/integration/interfaces/test_cli_run_dry_run.py
@@ -53,7 +53,7 @@ class TestCliRunDryRun:
         mock_runner.shutdown_signal = None
 
         with patch(
-            "bioetl.interfaces.cli.bootstrap_pipeline",
+            "bioetl.interfaces.cli.create_pipeline_runner",
             return_value=mock_runner,
         ):
             result = cli_runner.invoke(
@@ -73,7 +73,7 @@ class TestCliRunDryRun:
         storage_paths: dict[str, Path],
     ):
         """Test that --dry-run with rebuild shows cleanup preview."""
-        # Create fake cleanup service that returns preview data
+        # Create mock CleanupPreview that preview_cleanup returns directly
         mock_preview = MagicMock()
         mock_preview.silver = MagicMock(
             exists=True,
@@ -87,12 +87,9 @@ class TestCliRunDryRun:
         )
         mock_preview.total_files = 15
 
-        mock_cleanup = MagicMock()
-        mock_cleanup.preview = AsyncMock(return_value=mock_preview)
-
         with patch(
-            "bioetl.interfaces.cli.bootstrap_cleanup",
-            return_value=mock_cleanup,
+            "bioetl.interfaces.cli.preview_cleanup",
+            new=AsyncMock(return_value=mock_preview),
         ):
             result = cli_runner.invoke(
                 cli,
@@ -122,12 +119,9 @@ class TestCliRunDryRun:
         mock_preview.gold = None  # No gold table configured
         mock_preview.total_files = 10
 
-        mock_cleanup = MagicMock()
-        mock_cleanup.preview = AsyncMock(return_value=mock_preview)
-
         with patch(
-            "bioetl.interfaces.cli.bootstrap_cleanup",
-            return_value=mock_cleanup,
+            "bioetl.interfaces.cli.preview_cleanup",
+            new=AsyncMock(return_value=mock_preview),
         ):
             result = cli_runner.invoke(
                 cli,
@@ -157,12 +151,9 @@ class TestCliRunDryRun:
         )
         mock_preview.total_files = 0
 
-        mock_cleanup = MagicMock()
-        mock_cleanup.preview = AsyncMock(return_value=mock_preview)
-
         with patch(
-            "bioetl.interfaces.cli.bootstrap_cleanup",
-            return_value=mock_cleanup,
+            "bioetl.interfaces.cli.preview_cleanup",
+            new=AsyncMock(return_value=mock_preview),
         ):
             result = cli_runner.invoke(
                 cli,
@@ -192,12 +183,9 @@ class TestCliRunDryRun:
         )
         mock_preview.total_files = 59
 
-        mock_cleanup = MagicMock()
-        mock_cleanup.preview = AsyncMock(return_value=mock_preview)
-
         with patch(
-            "bioetl.interfaces.cli.bootstrap_cleanup",
-            return_value=mock_cleanup,
+            "bioetl.interfaces.cli.preview_cleanup",
+            new=AsyncMock(return_value=mock_preview),
         ):
             result = cli_runner.invoke(
                 cli,
@@ -225,12 +213,9 @@ class TestCliDryRunErrorHandling:
         temp_env: dict[str, str],
     ):
         """Test that --dry-run handles preview errors gracefully."""
-        mock_cleanup = MagicMock()
-        mock_cleanup.preview = AsyncMock(side_effect=Exception("Preview failed"))
-
         with patch(
-            "bioetl.interfaces.cli.bootstrap_cleanup",
-            return_value=mock_cleanup,
+            "bioetl.interfaces.cli.preview_cleanup",
+            new=AsyncMock(side_effect=Exception("Preview failed")),
         ):
             result = cli_runner.invoke(
                 cli,

--- a/tests/integration/interfaces/test_cli_run_incremental.py
+++ b/tests/integration/interfaces/test_cli_run_incremental.py
@@ -80,7 +80,7 @@ class TestCliRunIncremental:
         mock_runner.shutdown_signal = None
 
         with patch(
-            "bioetl.interfaces.cli.bootstrap_pipeline",
+            "bioetl.interfaces.cli.create_pipeline_runner",
             return_value=mock_runner,
         ):
             result = cli_runner.invoke(
@@ -103,7 +103,7 @@ class TestCliRunIncremental:
         mock_runner.shutdown_signal = None
 
         with patch(
-            "bioetl.interfaces.cli.bootstrap_pipeline",
+            "bioetl.interfaces.cli.create_pipeline_runner",
             return_value=mock_runner,
         ):
             result = cli_runner.invoke(
@@ -186,7 +186,7 @@ class TestCliRunTypes:
         mock_runner.shutdown_signal = None
 
         with patch(
-            "bioetl.interfaces.cli.bootstrap_pipeline",
+            "bioetl.interfaces.cli.create_pipeline_runner",
             return_value=mock_runner,
         ):
             result = cli_runner.invoke(


### PR DESCRIPTION
Create composition/entrypoints.py module that provides high-level entry points for pipeline operations:
- RunOptions, VacuumOptions, ArchiveOptions dataclasses for user-facing options
- create_pipeline_runner() - main entry point for pipeline execution
- get_quarantine_manager(), get_checkpoint_manager() - manager access
- get_lifecycle_service() - maintenance operations access
- preview_cleanup(), vacuum_table(), archive_table() - convenience wrappers

The CLI now imports from entrypoints instead of bootstrap directly:
- bootstrap_pipeline -> create_pipeline_runner
- bootstrap_quarantine_manager -> get_quarantine_manager
- bootstrap_checkpoint_manager -> get_checkpoint_manager
- bootstrap_lifecycle_service -> get_lifecycle_service
- bootstrap_cleanup + load_pipeline_config -> preview_cleanup

This enables Prefect/REST/other orchestrators to use the same entrypoints without depending on CLI specifics.

Update all CLI integration tests to mock the new entrypoint functions.