### PR TITLE
Remove dead code in ChemblAdapter

### DIFF
--- a/src/bioetl/infrastructure/adapters/chembl/client.py
+++ b/src/bioetl/infrastructure/adapters/chembl/client.py
@@ -144,7 +144,7 @@ class ChemblAdapter(BaseHttpAdapter):
             return records, has_next
         except Exception as e:
             self._handle_error(e)
-            return [], False
+            raise  # explicit re-raise для линтеров (handle_error всегда raises)
 
     async def _page_iterator(
         self, entity_type: str, limit: int | None = None


### PR DESCRIPTION
Replace dead `return [], False` with explicit `raise` statement in ChemblAdapter._fetch_page for clearer control flow.

The _handle_error method always raises an exception, making the return statement unreachable. Using explicit raise satisfies linters and makes the intent clear.