### PR TITLE
Unify observability across pipeline lifecycle

### DIFF
--- a/src/bioetl/application/observability/__init__.py
+++ b/src/bioetl/application/observability/__init__.py
@@ -2,11 +2,21 @@
 
 This package contains:
 - PipelineObserver: Context manager for tracing execution lifecycle
+- LifecyclePhase: Enum for pipeline lifecycle phases
 - Observability utilities for the application layer
 
 Architecture:
 - Application layer defines WHAT to observe (Events)
 - Infrastructure layer defines HOW to observe (Prometheus, Logs)
+
+Unified Observability Pattern:
+- All lifecycle events are emitted through PipelineObserver
+- Services use emit_event() for structured logging with metrics
+- Single source of truth for all observability events
 """
 
 from __future__ import annotations
+
+from bioetl.application.observability.observer import LifecyclePhase, PipelineObserver
+
+__all__ = ["LifecyclePhase", "PipelineObserver"]

--- a/src/bioetl/application/observability/observer.py
+++ b/src/bioetl/application/observability/observer.py
@@ -5,12 +5,18 @@ Handles:
 - Distributed Tracing (Span creation)
 - Metrics (Counter/Histogram)
 - Logging (Structured logs with lifecycle context)
+
+Unified Observability Pattern:
+- All lifecycle events are emitted through this single observer
+- Services use emit_event() to log structured events with metrics
+- This eliminates duplicate logging across runner/preflight/postrun
 """
 
 from __future__ import annotations
 
 import time
 from contextlib import AbstractContextManager
+from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from bioetl.application.core.shutdown import PipelineShutdownError
@@ -20,6 +26,21 @@ if TYPE_CHECKING:
 
     from bioetl.domain.ports import LoggerPort, MetricsPort, TracingPort
     from bioetl.domain.types import RunID, RunType
+
+
+class LifecyclePhase(str, Enum):
+    """Pipeline lifecycle phases for structured observability.
+
+    Each phase represents a distinct stage in pipeline execution
+    that should be tracked for monitoring and debugging.
+    """
+
+    STARTUP = "startup"
+    PREFLIGHT = "preflight"
+    LIFECYCLE_CLEAR = "lifecycle_clear"
+    EXECUTION = "execution"
+    POSTRUN = "postrun"
+    CLEANUP = "cleanup"
 
 
 class PipelineObserver(AbstractContextManager["PipelineObserver"]):
@@ -138,3 +159,206 @@ class PipelineObserver(AbstractContextManager["PipelineObserver"]):
                 pass
 
         return suppress_exception
+
+    # --- Unified Lifecycle Event Emission ---
+
+    def emit_event(
+        self,
+        event_name: str,
+        phase: LifecyclePhase,
+        level: str = "info",
+        **extra: Any,
+    ) -> None:
+        """Emit a structured lifecycle event through unified observability.
+
+        This is the single source of truth for lifecycle events.
+        All events are logged with consistent context and optionally traced.
+
+        Args:
+            event_name: Event identifier (e.g., "preflight_started").
+            phase: Current lifecycle phase.
+            level: Log level ("debug", "info", "warning", "error").
+            **extra: Additional context for the event.
+        """
+        ctx = {
+            "phase": phase.value,
+            "pipeline": self.pipeline_name,
+            "run_id": self.run_id,
+            **extra,
+        }
+
+        log_method = getattr(self.logger, level, self.logger.info)
+        log_method(event_name, **ctx)
+
+        # Add span event if tracing is active
+        if self.span:
+            try:
+                self.span.set_attribute(f"bioetl.{event_name}", True)
+            except Exception:
+                pass  # Best effort
+
+    def emit_phase_started(
+        self,
+        phase: LifecyclePhase,
+        **extra: Any,
+    ) -> float:
+        """Emit phase start event and return start timestamp.
+
+        Args:
+            phase: Lifecycle phase starting.
+            **extra: Additional context.
+
+        Returns:
+            Start timestamp for duration calculation.
+        """
+        self.emit_event(f"{phase.value}_started", phase, **extra)
+        return time.monotonic()
+
+    def emit_phase_completed(
+        self,
+        phase: LifecyclePhase,
+        start_time: float,
+        success: bool = True,
+        **extra: Any,
+    ) -> None:
+        """Emit phase completion event with duration.
+
+        Args:
+            phase: Lifecycle phase completed.
+            start_time: Timestamp from emit_phase_started().
+            success: Whether phase completed successfully.
+            **extra: Additional context.
+        """
+        duration = time.monotonic() - start_time
+        status = "success" if success else "failed"
+
+        self.emit_event(
+            f"{phase.value}_completed",
+            phase,
+            level="info" if success else "error",
+            duration_seconds=round(duration, 4),
+            status=status,
+            **extra,
+        )
+
+        # Record phase duration metric
+        self.metrics.observe_histogram(
+            "bioetl_phase_duration_seconds",
+            duration,
+            labels={
+                "pipeline": self.pipeline_name,
+                "phase": phase.value,
+                "status": status,
+            },
+        )
+
+    def emit_health_check_result(
+        self,
+        component: str,
+        healthy: bool,
+        duration_ms: float | None = None,
+        **extra: Any,
+    ) -> None:
+        """Emit health check result for a component.
+
+        Unified interface for health check observability.
+
+        Args:
+            component: Component name (e.g., "storage", "data_source").
+            healthy: Whether component is healthy.
+            duration_ms: Optional check duration in milliseconds.
+            **extra: Additional context.
+        """
+        self.emit_event(
+            "health_check_completed",
+            LifecyclePhase.PREFLIGHT,
+            level="info" if healthy else "warning",
+            component=component,
+            healthy=healthy,
+            duration_ms=duration_ms,
+            **extra,
+        )
+
+        self.metrics.set_gauge(
+            "pipeline_health_check_passed",
+            1.0 if healthy else 0.0,
+            {"pipeline": self.pipeline_name, "component": component},
+        )
+
+    def emit_dq_anomaly(
+        self,
+        metric_name: str,
+        severity: str,
+        anomaly_type: str,
+        current_value: float,
+        baseline_mean: float | None = None,
+        **extra: Any,
+    ) -> None:
+        """Emit data quality anomaly detection event.
+
+        Args:
+            metric_name: Name of the metric with anomaly.
+            severity: Anomaly severity ("warning", "critical").
+            anomaly_type: Type of anomaly detected.
+            current_value: Current metric value.
+            baseline_mean: Baseline mean for comparison.
+            **extra: Additional context.
+        """
+        level = "error" if severity == "critical" else "warning"
+        self.emit_event(
+            "dq_anomaly_detected",
+            LifecyclePhase.POSTRUN,
+            level=level,
+            metric=metric_name,
+            severity=severity,
+            anomaly_type=anomaly_type,
+            current_value=current_value,
+            baseline_mean=baseline_mean,
+            **extra,
+        )
+
+        self.metrics.increment_counter(
+            "dq_anomaly_detected",
+            1,
+            {
+                "pipeline": self.pipeline_name,
+                "metric": metric_name,
+                "severity": severity,
+                "anomaly_type": anomaly_type,
+            },
+        )
+
+    def emit_vacuum_result(
+        self,
+        layer: str,
+        table: str,
+        files_removed: int,
+        success: bool = True,
+        **extra: Any,
+    ) -> None:
+        """Emit VACUUM operation result.
+
+        Args:
+            layer: Storage layer ("silver", "gold").
+            table: Table name.
+            files_removed: Number of files removed.
+            success: Whether operation succeeded.
+            **extra: Additional context.
+        """
+        self.emit_event(
+            "vacuum_completed",
+            LifecyclePhase.POSTRUN,
+            level="info" if success else "warning",
+            layer=layer,
+            table=table,
+            files_removed=files_removed,
+            success=success,
+            **extra,
+        )
+
+        if success:
+            self.metrics.increment_counter(
+                "vacuum_files_removed",
+                files_removed,
+                {"pipeline": self.pipeline_name, "layer": layer},
+            )

--- a/src/bioetl/composition/_bootstrap/observability.py
+++ b/src/bioetl/composition/_bootstrap/observability.py
@@ -7,7 +7,7 @@ Unified Observability Contract:
 - bootstrap_observability() always returns valid implementations
 - Logger: StructlogLogger (always valid)
 - Metrics: PrometheusMetrics or NoOpMetrics (never None)
-- Tracer: OpenTelemetryTracer or NoOpTracer (never None)
+- Tracer: OpenTelemetryTracer or NoOpTracing (never None)
 - DQMonitor: DataQualityMonitor or None (optional)
 """
 
@@ -21,9 +21,10 @@ from bioetl.infrastructure.observability.logging import (
     create_logger as create_infra_logger,
 )
 from bioetl.infrastructure.observability.noop_metrics import NoOpMetrics
+from bioetl.infrastructure.observability.noop_tracing import NoOpTracing
 from bioetl.infrastructure.observability.prometheus_metrics import PrometheusMetrics
 from bioetl.infrastructure.observability.server import start_metrics_server
-from bioetl.infrastructure.observability.tracing import NoOpTracer, OpenTelemetryTracer
+from bioetl.infrastructure.observability.tracing import OpenTelemetryTracer
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -52,7 +53,19 @@ def bootstrap_logger(
 
 
 def bootstrap_tracer(service_name: str = "bioetl") -> TracingPort:
-    """Bootstrap distributed tracing."""
+    """Bootstrap distributed tracing.
+
+    Unified Observability Contract: Always returns a valid TracingPort.
+    When tracing is disabled or OpenTelemetry is not installed,
+    returns NoOpTracing (silent fallback).
+
+    Args:
+        service_name: Name of the service for tracing context.
+
+    Returns:
+        TracingPort instance (OpenTelemetryTracer or NoOpTracing).
+        Never returns None - uses NoOpTracing as fallback.
+    """
     from bioetl.infrastructure.config import get_settings
 
     settings = get_settings()
@@ -62,7 +75,7 @@ def bootstrap_tracer(service_name: str = "bioetl") -> TracingPort:
         except ImportError:
             # OpenTelemetry not installed, fall back to no-op
             pass
-    return NoOpTracer()
+    return NoOpTracing()
 
 
 def bootstrap_metrics(settings: Settings) -> MetricsPort:

--- a/src/bioetl/infrastructure/observability/noop_tracing.py
+++ b/src/bioetl/infrastructure/observability/noop_tracing.py
@@ -42,8 +42,20 @@ class NoOpTracer:
 
 
 class NoOpTracing:
-    """No-op implementation of TracingPort."""
+    """No-op implementation of TracingPort.
+
+    Unified implementation for when distributed tracing is disabled.
+    Used as the single source of truth for no-op tracing.
+    """
+
+    def __init__(self) -> None:
+        """Initialize no-op tracing."""
+        self._closed = False
 
     def get_tracer(self, name: str) -> NoOpTracer:
         """Get a no-op tracer."""
         return NoOpTracer()
+
+    def close(self) -> None:
+        """No-op close. Idempotent."""
+        self._closed = True

--- a/src/bioetl/infrastructure/observability/prometheus_metrics.py
+++ b/src/bioetl/infrastructure/observability/prometheus_metrics.py
@@ -115,40 +115,5 @@ class PrometheusMetrics(MetricsPort):
         self._closed = True
 
 
-class NoOpMetrics(MetricsPort):
-    """Null object pattern for metrics (used when Prometheus is disabled)."""
-
-    def __init__(self) -> None:
-        """Initialize no-op metrics."""
-        self._closed = False
-
-    def observe_histogram(
-        self,
-        name: str,
-        value: float,
-        labels: dict[str, str],
-    ) -> None:
-        """No-op histogram observation."""
-        pass
-
-    def increment_counter(
-        self,
-        name: str,
-        value: int,
-        labels: dict[str, str],
-    ) -> None:
-        """No-op counter increment."""
-        pass
-
-    def set_gauge(
-        self,
-        name: str,
-        value: float,
-        labels: dict[str, str],
-    ) -> None:
-        """No-op gauge set."""
-        pass
-
-    def close(self) -> None:
-        """No-op close. Idempotent."""
-        self._closed = True
+# NOTE: NoOpMetrics has been removed from this module to eliminate duplication.
+# Use bioetl.infrastructure.observability.noop_metrics.NoOpMetrics instead.

--- a/src/bioetl/infrastructure/observability/tracing.py
+++ b/src/bioetl/infrastructure/observability/tracing.py
@@ -79,38 +79,6 @@ class OpenTelemetryTracer:
         self._closed = True
 
 
-class NoOpTracer:
-    """Null object pattern for tracing."""
-
-    def __init__(self) -> None:
-        """Initialize no-op tracer."""
-        self._closed = False
-
-    def get_tracer(self, name: str) -> Any:
-        """Return a dummy object that swallows calls."""
-
-        class DummySpan:
-            def __enter__(self) -> "DummySpan":
-                return self
-
-            def __exit__(self, *args: Any) -> None:
-                pass
-
-            def set_attribute(self, *args: Any) -> None:
-                pass
-
-            def add_event(self, *args: Any) -> None:
-                pass
-
-            def record_exception(self, *args: Any) -> None:
-                pass
-
-        class DummyTracer:
-            def start_as_current_span(self, *args: Any, **kwargs: Any) -> DummySpan:
-                return DummySpan()
-
-        return DummyTracer()
-
-    def close(self) -> None:
-        """No-op close. Idempotent."""
-        self._closed = True
+# NOTE: NoOpTracer has been removed from this module to eliminate duplication.
+# Use bioetl.infrastructure.observability.noop_tracing.NoOpTracing instead.
+# This is the single source of truth for no-op tracing implementations.

--- a/tests/architecture/test_code_metrics.py
+++ b/tests/architecture/test_code_metrics.py
@@ -242,6 +242,7 @@ class TestClassSize:
         "BasePipeline": 400,
         "PipelineRunner": 450,  # 441 lines - includes vacuum + health check methods
         "UnifiedHTTPClient": 350,
+        "PipelineObserver": 350,  # 319 lines - unified observability with lifecycle events
         # Baseline exemptions for existing classes
         "StorageAdapter": 500,
         "BaseTransformer": 410,  # 407 lines - complex base with hooks

--- a/tests/integration/pipelines/base.py
+++ b/tests/integration/pipelines/base.py
@@ -19,7 +19,7 @@ from bioetl.composition.observability import ObservabilityBundle
 from bioetl.domain.config import RuntimeConfig
 from bioetl.infrastructure.config import Settings
 from bioetl.infrastructure.observability.noop_metrics import NoOpMetrics
-from bioetl.infrastructure.observability.tracing import NoOpTracer
+from bioetl.infrastructure.observability.noop_tracing import NoOpTracing
 from bioetl.infrastructure.schemas.pipeline_config import PipelineYamlConfig
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 from bioetl.infrastructure.storage.delta_writer import DeltaWriter
@@ -166,7 +166,7 @@ class IntegrationPipelineTestCase:
         observability = ObservabilityBundle(
             logger=structlog.get_logger(),
             metrics=NoOpMetrics(warn_on_use=False),
-            tracer=NoOpTracer(),
+            tracer=NoOpTracing(),
         )
 
         # Create runner

--- a/tests/unit/application/observability/test_observer.py
+++ b/tests/unit/application/observability/test_observer.py
@@ -2,6 +2,7 @@
 
 Tests cover:
 - O4: Observer tests for duration, errors, graceful shutdown
+- Unified Observability: Lifecycle event emission tests
 """
 
 from __future__ import annotations
@@ -12,7 +13,7 @@ from uuid import uuid4
 import pytest
 
 from bioetl.application.core.shutdown import PipelineShutdownError
-from bioetl.application.observability.observer import PipelineObserver
+from bioetl.application.observability.observer import LifecyclePhase, PipelineObserver
 from bioetl.domain.types import RunType
 
 
@@ -243,3 +244,381 @@ def test_observer_handles_close_error(metrics_mock, logger_mock, tracer_mock, ru
     metrics_mock.observe_histogram.assert_called_once()
     call_args = metrics_mock.observe_histogram.call_args
     assert call_args[1]["labels"]["status"] == "success"
+
+
+# ==================== Unified Observability: Lifecycle Event Tests ====================
+
+
+class TestLifecyclePhase:
+    """Tests for LifecyclePhase enum."""
+
+    def test_lifecycle_phase_values(self):
+        """Test that all expected phases are defined."""
+        expected_phases = [
+            "startup",
+            "preflight",
+            "lifecycle_clear",
+            "execution",
+            "postrun",
+            "cleanup",
+        ]
+        actual_phases = [phase.value for phase in LifecyclePhase]
+        assert actual_phases == expected_phases
+
+    def test_lifecycle_phase_is_string_enum(self):
+        """Test that LifecyclePhase values are strings."""
+        for phase in LifecyclePhase:
+            assert isinstance(phase.value, str)
+
+
+class TestObserverEmitEvent:
+    """Tests for emit_event() unified event emission."""
+
+    def test_emit_event_logs_with_context(self, metrics_mock, logger_mock, run_id):
+        """Test emit_event logs event with structured context."""
+        observer = PipelineObserver(
+            pipeline_name="test_pipeline",
+            run_id=run_id,
+            run_type=RunType.INCREMENTAL,
+            metrics=metrics_mock,
+            logger=logger_mock,
+        )
+
+        observer.emit_event(
+            "custom_event",
+            LifecyclePhase.PREFLIGHT,
+            level="info",
+            custom_key="custom_value",
+        )
+
+        logger_mock.info.assert_called_once()
+        call_args = logger_mock.info.call_args
+        assert call_args[0][0] == "custom_event"
+        assert call_args[1]["phase"] == "preflight"
+        assert call_args[1]["pipeline"] == "test_pipeline"
+        assert call_args[1]["custom_key"] == "custom_value"
+
+    def test_emit_event_uses_correct_log_level(self, metrics_mock, logger_mock, run_id):
+        """Test emit_event routes to correct log level."""
+        observer = PipelineObserver(
+            pipeline_name="test_pipeline",
+            run_id=run_id,
+            run_type=RunType.INCREMENTAL,
+            metrics=metrics_mock,
+            logger=logger_mock,
+        )
+
+        # Test warning level
+        observer.emit_event("warn_event", LifecyclePhase.POSTRUN, level="warning")
+        logger_mock.warning.assert_called_once()
+
+        # Test error level
+        observer.emit_event("error_event", LifecyclePhase.POSTRUN, level="error")
+        logger_mock.error.assert_called_once()
+
+    def test_emit_event_adds_span_attribute(
+        self, metrics_mock, logger_mock, tracer_mock, run_id
+    ):
+        """Test emit_event adds span attribute when tracing is active."""
+        observer = PipelineObserver(
+            pipeline_name="test_pipeline",
+            run_id=run_id,
+            run_type=RunType.INCREMENTAL,
+            metrics=metrics_mock,
+            logger=logger_mock,
+            tracer=tracer_mock,
+        )
+
+        with observer:
+            observer.emit_event("test_event", LifecyclePhase.EXECUTION)
+
+        # Verify span attribute was set
+        mock_span = tracer_mock.get_tracer.return_value.start_as_current_span.return_value
+        mock_span.set_attribute.assert_any_call("bioetl.test_event", True)
+
+
+class TestObserverEmitPhase:
+    """Tests for phase start/complete event emission."""
+
+    def test_emit_phase_started_returns_timestamp(self, metrics_mock, logger_mock, run_id):
+        """Test emit_phase_started returns valid timestamp."""
+        observer = PipelineObserver(
+            pipeline_name="test_pipeline",
+            run_id=run_id,
+            run_type=RunType.INCREMENTAL,
+            metrics=metrics_mock,
+            logger=logger_mock,
+        )
+
+        start_time = observer.emit_phase_started(LifecyclePhase.PREFLIGHT)
+
+        assert isinstance(start_time, float)
+        assert start_time > 0
+        logger_mock.info.assert_called_with(
+            "preflight_started",
+            phase="preflight",
+            pipeline="test_pipeline",
+            run_id=str(run_id),
+        )
+
+    def test_emit_phase_completed_records_duration_metric(
+        self, metrics_mock, logger_mock, run_id
+    ):
+        """Test emit_phase_completed records duration in histogram."""
+        observer = PipelineObserver(
+            pipeline_name="test_pipeline",
+            run_id=run_id,
+            run_type=RunType.INCREMENTAL,
+            metrics=metrics_mock,
+            logger=logger_mock,
+        )
+
+        start_time = observer.emit_phase_started(LifecyclePhase.EXECUTION)
+        observer.emit_phase_completed(LifecyclePhase.EXECUTION, start_time, success=True)
+
+        # Find the phase duration metric call
+        histogram_calls = metrics_mock.observe_histogram.call_args_list
+        phase_call = None
+        for call in histogram_calls:
+            if call[0][0] == "bioetl_phase_duration_seconds":
+                phase_call = call
+                break
+
+        assert phase_call is not None
+        assert phase_call[1]["labels"]["phase"] == "execution"
+        assert phase_call[1]["labels"]["status"] == "success"
+
+    def test_emit_phase_completed_logs_failure(self, metrics_mock, logger_mock, run_id):
+        """Test emit_phase_completed logs error on failure."""
+        observer = PipelineObserver(
+            pipeline_name="test_pipeline",
+            run_id=run_id,
+            run_type=RunType.INCREMENTAL,
+            metrics=metrics_mock,
+            logger=logger_mock,
+        )
+
+        import time
+
+        start_time = time.monotonic()
+        observer.emit_phase_completed(LifecyclePhase.PREFLIGHT, start_time, success=False)
+
+        # Verify error was logged for failed phase
+        logger_mock.error.assert_called_once()
+
+
+class TestObserverHealthCheckEvents:
+    """Tests for health check event emission."""
+
+    def test_emit_health_check_result_healthy(self, metrics_mock, logger_mock, run_id):
+        """Test emit_health_check_result for healthy component."""
+        observer = PipelineObserver(
+            pipeline_name="test_pipeline",
+            run_id=run_id,
+            run_type=RunType.INCREMENTAL,
+            metrics=metrics_mock,
+            logger=logger_mock,
+        )
+
+        observer.emit_health_check_result(
+            component="storage",
+            healthy=True,
+            duration_ms=50.0,
+        )
+
+        logger_mock.info.assert_called()
+        metrics_mock.set_gauge.assert_called_with(
+            "pipeline_health_check_passed",
+            1.0,
+            {"pipeline": "test_pipeline", "component": "storage"},
+        )
+
+    def test_emit_health_check_result_unhealthy(self, metrics_mock, logger_mock, run_id):
+        """Test emit_health_check_result for unhealthy component."""
+        observer = PipelineObserver(
+            pipeline_name="test_pipeline",
+            run_id=run_id,
+            run_type=RunType.INCREMENTAL,
+            metrics=metrics_mock,
+            logger=logger_mock,
+        )
+
+        observer.emit_health_check_result(
+            component="data_source",
+            healthy=False,
+            duration_ms=100.0,
+        )
+
+        logger_mock.warning.assert_called()
+        metrics_mock.set_gauge.assert_called_with(
+            "pipeline_health_check_passed",
+            0.0,
+            {"pipeline": "test_pipeline", "component": "data_source"},
+        )
+
+
+class TestObserverDQEvents:
+    """Tests for data quality anomaly event emission."""
+
+    def test_emit_dq_anomaly_warning(self, metrics_mock, logger_mock, run_id):
+        """Test emit_dq_anomaly for warning severity."""
+        observer = PipelineObserver(
+            pipeline_name="test_pipeline",
+            run_id=run_id,
+            run_type=RunType.INCREMENTAL,
+            metrics=metrics_mock,
+            logger=logger_mock,
+        )
+
+        observer.emit_dq_anomaly(
+            metric_name="error_rate",
+            severity="warning",
+            anomaly_type="spike",
+            current_value=0.15,
+            baseline_mean=0.05,
+        )
+
+        logger_mock.warning.assert_called()
+        metrics_mock.increment_counter.assert_called_with(
+            "dq_anomaly_detected",
+            1,
+            {
+                "pipeline": "test_pipeline",
+                "metric": "error_rate",
+                "severity": "warning",
+                "anomaly_type": "spike",
+            },
+        )
+
+    def test_emit_dq_anomaly_critical(self, metrics_mock, logger_mock, run_id):
+        """Test emit_dq_anomaly for critical severity."""
+        observer = PipelineObserver(
+            pipeline_name="test_pipeline",
+            run_id=run_id,
+            run_type=RunType.INCREMENTAL,
+            metrics=metrics_mock,
+            logger=logger_mock,
+        )
+
+        observer.emit_dq_anomaly(
+            metric_name="record_count",
+            severity="critical",
+            anomaly_type="drop",
+            current_value=0.0,
+            baseline_mean=1000.0,
+        )
+
+        # Critical uses error level
+        logger_mock.error.assert_called()
+
+
+class TestObserverVacuumEvents:
+    """Tests for VACUUM operation event emission."""
+
+    def test_emit_vacuum_result_success(self, metrics_mock, logger_mock, run_id):
+        """Test emit_vacuum_result for successful operation."""
+        observer = PipelineObserver(
+            pipeline_name="test_pipeline",
+            run_id=run_id,
+            run_type=RunType.INCREMENTAL,
+            metrics=metrics_mock,
+            logger=logger_mock,
+        )
+
+        observer.emit_vacuum_result(
+            layer="silver",
+            table="chembl_activity",
+            files_removed=42,
+            success=True,
+        )
+
+        logger_mock.info.assert_called()
+        metrics_mock.increment_counter.assert_called_with(
+            "vacuum_files_removed",
+            42,
+            {"pipeline": "test_pipeline", "layer": "silver"},
+        )
+
+    def test_emit_vacuum_result_failure(self, metrics_mock, logger_mock, run_id):
+        """Test emit_vacuum_result for failed operation."""
+        observer = PipelineObserver(
+            pipeline_name="test_pipeline",
+            run_id=run_id,
+            run_type=RunType.INCREMENTAL,
+            metrics=metrics_mock,
+            logger=logger_mock,
+        )
+
+        observer.emit_vacuum_result(
+            layer="gold",
+            table="gold_table",
+            files_removed=0,
+            success=False,
+            error="Table not found",
+        )
+
+        logger_mock.warning.assert_called()
+        # Counter should NOT be called on failure
+        assert metrics_mock.increment_counter.call_count == 0
+
+
+# ==================== Smoke Test: Key Lifecycle Events ====================
+
+
+class TestObserverSmokeTest:
+    """Smoke test covering key lifecycle events through unified observer."""
+
+    def test_full_lifecycle_events_flow(self, metrics_mock, logger_mock, run_id):
+        """Smoke test: Verify all key lifecycle events flow through observer."""
+        observer = PipelineObserver(
+            pipeline_name="chembl_activity",
+            run_id=run_id,
+            run_type=RunType.REBUILD,
+            metrics=metrics_mock,
+            logger=logger_mock,
+        )
+
+        with observer:
+            # 1. Preflight phase
+            preflight_start = observer.emit_phase_started(LifecyclePhase.PREFLIGHT)
+            observer.emit_health_check_result("storage", healthy=True)
+            observer.emit_health_check_result("data_source", healthy=True)
+            observer.emit_phase_completed(LifecyclePhase.PREFLIGHT, preflight_start)
+
+            # 2. Execution phase
+            exec_start = observer.emit_phase_started(LifecyclePhase.EXECUTION)
+            observer.emit_event(
+                "batch_processed",
+                LifecyclePhase.EXECUTION,
+                records=100,
+            )
+            observer.emit_phase_completed(LifecyclePhase.EXECUTION, exec_start)
+
+            # 3. Postrun phase
+            postrun_start = observer.emit_phase_started(LifecyclePhase.POSTRUN)
+            observer.emit_vacuum_result("silver", "chembl_activity", 5)
+            observer.emit_phase_completed(LifecyclePhase.POSTRUN, postrun_start)
+
+        # Verify key events were logged
+        assert logger_mock.info.call_count >= 8  # Multiple info events
+
+        # Verify metrics were recorded
+        histogram_calls = metrics_mock.observe_histogram.call_args_list
+        phase_metrics = [
+            c for c in histogram_calls if c[0][0] == "bioetl_phase_duration_seconds"
+        ]
+        assert len(phase_metrics) == 3  # preflight, execution, postrun
+
+        # Verify health check gauges
+        gauge_calls = metrics_mock.set_gauge.call_args_list
+        health_gauges = [
+            c for c in gauge_calls if c[0][0] == "pipeline_health_check_passed"
+        ]
+        assert len(health_gauges) == 2  # storage, data_source
+
+        # Verify vacuum counter
+        counter_calls = metrics_mock.increment_counter.call_args_list
+        vacuum_counters = [
+            c for c in counter_calls if c[0][0] == "vacuum_files_removed"
+        ]
+        assert len(vacuum_counters) == 1

--- a/tests/unit/composition/test_observability_contract.py
+++ b/tests/unit/composition/test_observability_contract.py
@@ -128,7 +128,7 @@ class TestBootstrapObservability:
 
         assert bundle.logger is mock_logger
         assert bundle.metrics is mock_metrics
-        assert bundle.tracer is not None  # NoOpTracer
+        assert bundle.tracer is not None  # NoOpTracing
         assert bundle.dq_monitor is None
 
     @patch("bioetl.composition._bootstrap.observability.create_infra_logger")
@@ -184,7 +184,7 @@ class TestBootstrapObservability:
             extra={
                 "stage": "bootstrap",
                 "metrics_type": "NoOpMetrics",
-                "tracer_type": "NoOpTracer",
+                "tracer_type": "NoOpTracing",
                 "dq_monitor_enabled": False,
             },
         )


### PR DESCRIPTION
- Remove duplicate NoOpMetrics class from prometheus_metrics.py (use noop_metrics.py as single source)
- Consolidate NoOpTracer implementations into noop_tracing.py (remove duplicate from tracing.py)
- Add close() method to NoOpTracing for TracingPort compliance
- Update bootstrap to use NoOpTracing instead of NoOpTracer
- Add LifecyclePhase enum for structured lifecycle tracking
- Add unified event emission methods to PipelineObserver:
  - emit_event(): Single source for all lifecycle events
  - emit_phase_started()/emit_phase_completed(): Phase tracking
  - emit_health_check_result(): Health check observability
  - emit_dq_anomaly(): Data quality anomaly events
  - emit_vacuum_result(): VACUUM operation events
- Add comprehensive smoke tests for lifecycle event flow

This eliminates metric/tracing duplication across runner, preflight, and postrun by routing all lifecycle events through PipelineObserver.