### PR TITLE
Split UnifiedHTTPClient into separate components

### DIFF
--- a/src/bioetl/composition/factories/http_client_factory.py
+++ b/src/bioetl/composition/factories/http_client_factory.py
@@ -2,6 +2,10 @@
 
 Ensures consistent rate limiting and circuit breaker settings across providers.
 Uses ProviderRegistry for unified configuration management.
+
+SRP Compliance:
+- Creates UnifiedHTTPClient with injected RateLimiterPort and CircuitBreakerPort
+- RetryPolicy is configured via domain value object
 """
 
 from __future__ import annotations
@@ -9,6 +13,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from bioetl.composition.providers import ProviderRegistry, ensure_providers_loaded
+from bioetl.domain.resilience import RetryPolicy
 from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
 from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
 from bioetl.infrastructure.adapters.http.rate_limiter import TokenBucket

--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -93,6 +93,7 @@ from bioetl.domain.medallion import ClearPolicy, MedallionPolicy
 # Ports
 from bioetl.domain.ports import (
     CheckpointPort,
+    CircuitBreakerPort,
     DataSourcePort,
     DQMonitorPort,
     FilterableDataSourcePort,
@@ -102,8 +103,17 @@ from bioetl.domain.ports import (
     LoggerPort,
     MetricsPort,
     QuarantinePort,
+    RateLimiterPort,
     StoragePort,
     TracingPort,
+)
+
+# Resilience (domain value objects)
+from bioetl.domain.resilience import (
+    AGGRESSIVE_RETRY_POLICY,
+    CONSERVATIVE_RETRY_POLICY,
+    DEFAULT_RETRY_POLICY,
+    RetryPolicy,
 )
 
 # Pure domain transformations
@@ -180,6 +190,7 @@ __all__ = [
     "LockAcquisitionError",
     "LockLostError",
     "MergeConflictError",
+    "PolicyViolationError",
     # Exceptions - Recoverable
     "ChemblApiError",
     "CircuitBreakerOpenError",
@@ -210,6 +221,7 @@ __all__ = [
     "MedallionPolicy",
     # Ports
     "CheckpointPort",
+    "CircuitBreakerPort",
     "DataSourcePort",
     "DQMonitorPort",
     "FilterableDataSourcePort",
@@ -219,8 +231,14 @@ __all__ = [
     "LoggerPort",
     "MetricsPort",
     "QuarantinePort",
+    "RateLimiterPort",
     "StoragePort",
     "TracingPort",
+    # Resilience
+    "AGGRESSIVE_RETRY_POLICY",
+    "CONSERVATIVE_RETRY_POLICY",
+    "DEFAULT_RETRY_POLICY",
+    "RetryPolicy",
     # Transformations (pure functions)
     "META_FIELDS",
     "calculate_dq_score",

--- a/src/bioetl/domain/ports/__init__.py
+++ b/src/bioetl/domain/ports/__init__.py
@@ -11,6 +11,7 @@ This package contains all port definitions organized by domain:
 - observability: TracingPort, MetricsPort, LoggerPort, DQMonitorPort
 - validation: GoldValidatorPort for Gold layer validation
 - filtering: InputFilterPort for CSV filter loading
+- resilience: RateLimiterPort, CircuitBreakerPort for fault tolerance
 """
 
 from bioetl.domain.ports.checkpoint import CheckpointPort
@@ -27,11 +28,13 @@ from bioetl.domain.ports.observability import (
     TracingPort,
 )
 from bioetl.domain.ports.quarantine import QuarantinePort
+from bioetl.domain.ports.resilience import CircuitBreakerPort, RateLimiterPort
 from bioetl.domain.ports.storage import StoragePort
 from bioetl.domain.ports.validation import GoldValidatorPort
 
 __all__ = [
     "CheckpointPort",
+    "CircuitBreakerPort",
     "DQMonitorPort",
     "DataSourcePort",
     "FilterableDataSourcePort",
@@ -41,6 +44,7 @@ __all__ = [
     "LoggerPort",
     "MetricsPort",
     "QuarantinePort",
+    "RateLimiterPort",
     "StoragePort",
     "TracingPort",
 ]

--- a/src/bioetl/domain/ports/resilience.py
+++ b/src/bioetl/domain/ports/resilience.py
@@ -1,0 +1,125 @@
+"""Resilience ports for rate limiting and circuit breaking.
+
+Implements RULES.md §3.1 - Fault tolerance patterns.
+Ports define contracts for SRP-compliant resilience components.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ParamSpec, Protocol, TypeVar, runtime_checkable
+
+from bioetl.domain.types import CircuitBreakerState
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+@runtime_checkable
+class RateLimiterPort(Protocol):
+    """Port for rate limiting API requests.
+
+    Implements token bucket or similar algorithm to enforce
+    provider-specific rate limits (RULES.md §5.1).
+
+    Note: Uses async methods as rate limiting may require
+    waiting for token availability.
+
+    Example:
+        >>> limiter: RateLimiterPort = TokenBucket(rate=5.0, capacity=10)
+        >>> await limiter.acquire()  # Wait for token
+        >>> await limiter.acquire(tokens=2)  # Acquire multiple tokens
+    """
+
+    async def acquire(self, tokens: int = 1) -> None:
+        """Acquire tokens, waiting if necessary.
+
+        Args:
+            tokens: Number of tokens to acquire (default: 1)
+
+        Raises:
+            ValueError: If tokens > capacity
+        """
+        ...
+
+    def try_acquire(self, tokens: int = 1) -> bool:
+        """Try to acquire tokens without waiting.
+
+        Args:
+            tokens: Number of tokens to acquire
+
+        Returns:
+            True if acquired, False otherwise
+        """
+        ...
+
+    def available_tokens(self) -> int:
+        """Return current available tokens.
+
+        Returns:
+            Number of tokens available for immediate acquisition
+        """
+        ...
+
+
+@runtime_checkable
+class CircuitBreakerPort(Protocol):
+    """Port for circuit breaker fault tolerance pattern.
+
+    Implements RULES.md §3.1.4 circuit breaker requirements:
+    - State machine: CLOSED -> OPEN (after failures) -> HALF_OPEN -> CLOSED
+    - Configurable failure threshold (default: 5 consecutive errors)
+    - Configurable recovery timeout (default: 5 minutes)
+
+    Example:
+        >>> breaker: CircuitBreakerPort = CircuitBreaker(provider="chembl")
+        >>> result = await breaker.call(async_func, arg1, arg2)
+    """
+
+    def get_state(self) -> CircuitBreakerState:
+        """Get current circuit breaker state.
+
+        Returns:
+            Current state: CLOSED, OPEN, or HALF_OPEN
+        """
+        ...
+
+    def get_failure_count(self) -> int:
+        """Get current failure count.
+
+        Returns:
+            Number of consecutive failures
+        """
+        ...
+
+    async def call(
+        self,
+        func: Callable[P, Awaitable[T]],
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> T:
+        """Execute function with circuit breaker protection.
+
+        Args:
+            func: Async function to call
+            *args: Positional arguments for func
+            **kwargs: Keyword arguments for func
+
+        Returns:
+            Result from func
+
+        Raises:
+            CircuitBreakerOpenError: If circuit is open
+            Exception: Re-raises exceptions from func
+        """
+        ...
+
+    def reset(self) -> None:
+        """Manually reset circuit breaker to CLOSED state.
+
+        Resets failure count and state. Use with caution
+        as it bypasses normal recovery logic.
+        """
+        ...

--- a/src/bioetl/domain/resilience.py
+++ b/src/bioetl/domain/resilience.py
@@ -1,0 +1,116 @@
+"""Resilience domain types and value objects.
+
+Implements RULES.md §3.1 - Error handling and retry policies.
+Contains pure configuration and logic for retry behavior (no I/O).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class RetryPolicy:
+    """Configuration for exponential backoff retry strategy.
+
+    Implements RULES.md §4.1 recoverable error handling:
+    - Exponential backoff with configurable multiplier
+    - Maximum delay cap
+    - Deterministic jitter for reproducibility (ADR-014)
+
+    Args:
+        max_attempts: Maximum number of attempts (default: 3)
+        base_delay: Base delay in seconds (default: 1.0)
+        max_delay: Maximum delay in seconds (default: 60.0)
+        multiplier: Delay multiplier per attempt (default: 2.0)
+        jitter: Random jitter factor 0-1 (default: 0.1)
+        deterministic: Use hash-based jitter for reproducibility (default: True)
+        jitter_seed: Seed for deterministic jitter (default: None)
+
+    Example:
+        >>> policy = RetryPolicy(max_attempts=5, base_delay=2.0)
+        >>> delay = policy.calculate_delay(attempt=0, url="https://api.example.com")
+        >>> print(f"First retry after {delay:.2f} seconds")
+    """
+
+    max_attempts: int = 3
+    base_delay: float = 1.0
+    max_delay: float = 60.0
+    multiplier: float = 2.0
+    jitter: float = 0.1
+    deterministic: bool = True
+    jitter_seed: int | None = None
+
+    def calculate_delay(self, attempt: int, url: str = "") -> float:
+        """Calculate delay for given attempt number (0-indexed).
+
+        Uses exponential backoff with optional jitter.
+        When deterministic=True, jitter is calculated using MD5 hash
+        for cross-process reproducibility (ADR-014).
+
+        Args:
+            attempt: Attempt number (0-indexed)
+            url: Request URL for deterministic jitter calculation
+
+        Returns:
+            Delay in seconds (never negative)
+        """
+        delay = self.base_delay * (self.multiplier**attempt)
+        delay = min(delay, self.max_delay)
+
+        jitter_range = delay * self.jitter
+        if self.deterministic:
+            # MD5-based deterministic jitter for cross-process reproducibility (ADR-014)
+            # Note: hash() is not stable across Python processes due to PYTHONHASHSEED
+            hash_input = f"{attempt}:{url}:{self.jitter_seed or 0}"
+            digest = hashlib.md5(hash_input.encode(), usedforsecurity=False).hexdigest()
+            jitter_factor = int(digest[:8], 16) / 0xFFFFFFFF
+            # Map 0.0-1.0 to -1.0 to +1.0
+            delay += jitter_range * (jitter_factor * 2 - 1)
+        else:
+            # Non-deterministic jitter (deprecated, use deterministic=True)
+            import random
+            import warnings
+
+            warnings.warn(
+                "Non-deterministic jitter is deprecated per ADR-014. "
+                "Use deterministic=True for reproducibility.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            delay += random.uniform(-jitter_range, jitter_range)
+
+        return max(0.0, delay)
+
+    def is_last_attempt(self, attempt: int) -> bool:
+        """Check if this is the last allowed attempt.
+
+        Args:
+            attempt: Current attempt number (0-indexed)
+
+        Returns:
+            True if no more attempts allowed after this one
+        """
+        return attempt >= self.max_attempts - 1
+
+
+# Pre-configured policies for common scenarios
+DEFAULT_RETRY_POLICY = RetryPolicy()
+"""Default retry policy: 3 attempts, 1s base delay, 2x multiplier."""
+
+AGGRESSIVE_RETRY_POLICY = RetryPolicy(
+    max_attempts=5,
+    base_delay=0.5,
+    max_delay=30.0,
+    multiplier=1.5,
+)
+"""Aggressive retry policy for critical operations: 5 attempts, faster backoff."""
+
+CONSERVATIVE_RETRY_POLICY = RetryPolicy(
+    max_attempts=3,
+    base_delay=2.0,
+    max_delay=120.0,
+    multiplier=3.0,
+)
+"""Conservative retry policy for rate-limited APIs: longer delays."""

--- a/src/bioetl/infrastructure/adapters/http/__init__.py
+++ b/src/bioetl/infrastructure/adapters/http/__init__.py
@@ -1,15 +1,16 @@
 """HTTP infrastructure components.
 
 Provides:
-- TokenBucket: Rate limiting
-- CircuitBreaker: Fault tolerance
+- TokenBucket: Rate limiting (implements RateLimiterPort)
+- CircuitBreaker: Fault tolerance (implements CircuitBreakerPort)
 - UnifiedHTTPClient: Async HTTP client with rate limiting and circuit breaker
+- RetryConfig: Backward compatibility alias for RetryPolicy
 """
 
 from __future__ import annotations
 
 from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
-from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
+from bioetl.infrastructure.adapters.http.client import RetryConfig, UnifiedHTTPClient
 from bioetl.infrastructure.adapters.http.rate_limiter import TokenBucket
 
-__all__ = ["CircuitBreaker", "TokenBucket", "UnifiedHTTPClient"]
+__all__ = ["CircuitBreaker", "RetryConfig", "TokenBucket", "UnifiedHTTPClient"]

--- a/src/bioetl/infrastructure/adapters/http/client.py
+++ b/src/bioetl/infrastructure/adapters/http/client.py
@@ -2,15 +2,20 @@
 
 Implements RULES.md Section 4.1 HTTP client requirements:
 - Async support (httpx)
-- Rate limiting (TokenBucket)
-- Circuit breaker (fault tolerance)
-- Exponential backoff with jitter
+- Rate limiting (RateLimiterPort)
+- Circuit breaker (CircuitBreakerPort)
+- Exponential backoff with jitter (RetryPolicy)
+
+SRP Compliance:
+- RateLimiterPort: Handles rate limiting (injected)
+- CircuitBreakerPort: Handles fault tolerance (injected)
+- RetryPolicy: Handles retry configuration (domain value object)
+- UnifiedHTTPClient: Coordinates HTTP communication
 """
 
 from __future__ import annotations
 
 import asyncio
-import hashlib
 from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -18,72 +23,15 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 from bioetl.domain.exceptions import CircuitBreakerOpenError, RetryExhaustedError
+from bioetl.domain.resilience import RetryPolicy
 
 if TYPE_CHECKING:
+    from bioetl.domain.ports import CircuitBreakerPort, RateLimiterPort
     from bioetl.domain.types import RunID
-    from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
-    from bioetl.infrastructure.adapters.http.rate_limiter import TokenBucket
 
 
-@dataclass
-class RetryConfig:
-    """Configuration for exponential backoff retry.
-
-    Args:
-        max_attempts: Maximum number of attempts (default: 3)
-        base_delay: Base delay in seconds (default: 1.0)
-        max_delay: Maximum delay in seconds (default: 60.0)
-        multiplier: Delay multiplier per attempt (default: 2.0)
-        jitter: Random jitter factor 0-1 (default: 0.1)
-        deterministic: Use hash-based jitter for reproducibility (default: False)
-        jitter_seed: Seed for deterministic jitter (default: None)
-
-    """
-
-    max_attempts: int = 3
-    base_delay: float = 1.0
-    max_delay: float = 60.0
-    multiplier: float = 2.0
-    jitter: float = 0.1
-    deterministic: bool = True
-    jitter_seed: int | None = None
-
-    def calculate_delay(self, attempt: int, url: str = "") -> float:
-        """Calculate delay for given attempt number (0-indexed).
-
-        Args:
-            attempt: Attempt number (0-indexed)
-            url: Request URL for deterministic jitter calculation
-
-        Returns:
-            Delay in seconds
-        """
-        delay = self.base_delay * (self.multiplier**attempt)
-        delay = min(delay, self.max_delay)
-
-        jitter_range = delay * self.jitter
-        if self.deterministic:
-            # MD5-based deterministic jitter for cross-process reproducibility (ADR-014)
-            # Note: hash() is not stable across Python processes due to PYTHONHASHSEED
-            hash_input = f"{attempt}:{url}:{self.jitter_seed or 0}"
-            digest = hashlib.md5(hash_input.encode(), usedforsecurity=False).hexdigest()
-            jitter_factor = int(digest[:8], 16) / 0xFFFFFFFF
-            # Map 0.0-1.0 to -1.0 to +1.0
-            delay += jitter_range * (jitter_factor * 2 - 1)
-        else:
-            # Non-deterministic jitter (deprecated, use deterministic=True)
-            import random
-            import warnings
-
-            warnings.warn(
-                "Non-deterministic jitter is deprecated per ADR-014. "
-                "Use deterministic=True for reproducibility.",
-                DeprecationWarning,
-                stacklevel=3,
-            )
-            delay += random.uniform(-jitter_range, jitter_range)
-
-        return max(0.0, delay)
+# Backward compatibility alias (deprecated)
+RetryConfig = RetryPolicy
 
 
 def _is_retryable_status(status_code: int) -> bool:
@@ -104,19 +52,20 @@ def _is_retryable_error(exc: Exception) -> bool:
 class UnifiedHTTPClient:
     """Async HTTP client with rate limiting and circuit breaker.
 
-    Combines httpx, TokenBucket rate limiter, and CircuitBreaker for
-    resilient HTTP communication.
+    Coordinates HTTP communication using injected resilience components
+    (SRP-compliant design).
 
     Args:
-        rate_limiter: TokenBucket for rate limiting
-        circuit_breaker: CircuitBreaker for fault tolerance
-        retry_config: RetryConfig for exponential backoff
+        rate_limiter: RateLimiterPort implementation for rate limiting
+        circuit_breaker: CircuitBreakerPort implementation for fault tolerance
+        retry_policy: RetryPolicy for exponential backoff configuration
         timeout: Request timeout in seconds (default: 30.0)
         run_id: Current run ID for correlation header
         user_agent: User-Agent string (default: "BioETL/5.0.0")
         contact_email: Optional contact email to append to User-Agent
 
     Example:
+        >>> from bioetl.infrastructure.adapters.http import TokenBucket, CircuitBreaker
         >>> bucket = TokenBucket(rate=5.0, capacity=5)
         >>> cb = CircuitBreaker(provider="chembl")
         >>> client = UnifiedHTTPClient(rate_limiter=bucket, circuit_breaker=cb)
@@ -125,9 +74,9 @@ class UnifiedHTTPClient:
 
     """
 
-    rate_limiter: TokenBucket
-    circuit_breaker: CircuitBreaker
-    retry_config: RetryConfig = field(default_factory=RetryConfig)
+    rate_limiter: RateLimiterPort
+    circuit_breaker: CircuitBreakerPort
+    retry_policy: RetryPolicy = field(default_factory=RetryPolicy)
     timeout: float = 30.0
     run_id: RunID | None = None
     user_agent: str = "BioETL/5.0.0"
@@ -176,7 +125,7 @@ class UnifiedHTTPClient:
         response: httpx.Response | None = None,
     ) -> None:
         """Calculate and sleep for the appropriate retry delay."""
-        delay = self.retry_config.calculate_delay(attempt, url)
+        delay = self.retry_policy.calculate_delay(attempt, url)
         if response:
             retry_after = response.headers.get("Retry-After")
             if retry_after:
@@ -194,7 +143,7 @@ class UnifiedHTTPClient:
         client = self._get_client()
         last_error: Exception | None = None
 
-        for attempt in range(self.retry_config.max_attempts):
+        for attempt in range(self.retry_policy.max_attempts):
             try:
                 await self.rate_limiter.acquire()
                 response = await self.circuit_breaker.call(
@@ -203,7 +152,7 @@ class UnifiedHTTPClient:
 
                 if (
                     _is_retryable_status(response.status_code)
-                    and attempt < self.retry_config.max_attempts - 1
+                    and not self.retry_policy.is_last_attempt(attempt)
                 ):
                     await self._handle_retry_delay(attempt, url, response)
                     continue
@@ -219,10 +168,10 @@ class UnifiedHTTPClient:
                 if not _is_retryable_error(exc):
                     raise
 
-                if attempt < self.retry_config.max_attempts - 1:
+                if not self.retry_policy.is_last_attempt(attempt):
                     await self._handle_retry_delay(attempt, url)
 
-        raise RetryExhaustedError(url, self.retry_config.max_attempts, last_error)
+        raise RetryExhaustedError(url, self.retry_policy.max_attempts, last_error)
 
     async def get(
         self,

--- a/tests/architecture/test_domain_public_api.py
+++ b/tests/architecture/test_domain_public_api.py
@@ -40,6 +40,7 @@ def test_domain_all_is_complete(src_dir: Path) -> None:
         "filter_config",
         "medallion",
         "ports",
+        "resilience",
         "transformations",
         "types",
     }

--- a/tests/architecture/test_port_contracts.py
+++ b/tests/architecture/test_port_contracts.py
@@ -141,6 +141,8 @@ class TestPortRuntimeCheckable:
         "LoggerPort",
         "GoldValidatorPort",
         "DQMonitorPort",
+        "RateLimiterPort",
+        "CircuitBreakerPort",
     ]
 
     @pytest.mark.parametrize("port_name", ALL_PORTS)
@@ -187,6 +189,8 @@ class TestPortExportsComplete:
             "MetricsPort",
             "LoggerPort",
             "GoldValidatorPort",
+            "RateLimiterPort",
+            "CircuitBreakerPort",
         }
 
         actual_exports = set(ports.__all__) if hasattr(ports, "__all__") else set()
@@ -608,4 +612,155 @@ class TestHttpAdapterLoggerContract:
         assert logger_param.default is inspect.Parameter.empty, (
             f"{adapter_name}.__init__() 'logger' MUST be required (no default). "
             "Optional loggers with fallback to NoOpLogger violate DI principles per RULES.md."
+        )
+
+
+# ============================================================================
+# Rate Limiter Port Contract Tests
+# ============================================================================
+
+
+class TestRateLimiterPortContract:
+    """Tests for RateLimiterPort specific contracts.
+
+    RateLimiterPort defines the contract for rate limiting API requests.
+    Implements RULES.md §5.1 rate limiting requirements.
+    """
+
+    REQUIRED_METHODS = ["acquire", "try_acquire", "available_tokens"]
+
+    @pytest.mark.parametrize("method_name", REQUIRED_METHODS)
+    def test_rate_limiter_port_has_required_methods(self, method_name: str) -> None:
+        """RateLimiterPort MUST have all required rate limiting methods."""
+        assert hasattr(ports.RateLimiterPort, method_name), (
+            f"RateLimiterPort MUST define {method_name}() for rate limiting"
+        )
+
+    def test_rate_limiter_port_acquire_is_async(self) -> None:
+        """RateLimiterPort.acquire() MUST be async for non-blocking operation."""
+        import inspect
+
+        acquire_method = ports.RateLimiterPort.acquire
+        # For Protocol, check if it's a coroutine function
+        hints = get_type_hints(acquire_method) if hasattr(acquire_method, "__annotations__") else {}
+
+        # The return type should be None (async def acquire() -> None)
+        assert hints.get("return") is type(None) or "return" not in hints, (
+            "RateLimiterPort.acquire() should return None"
+        )
+
+    def test_rate_limiter_port_is_runtime_checkable(self) -> None:
+        """RateLimiterPort MUST be @runtime_checkable for isinstance() checks."""
+
+        class DummyLimiter:
+            """Dummy class for testing isinstance()."""
+
+            pass
+
+        try:
+            isinstance(DummyLimiter(), ports.RateLimiterPort)
+            is_runtime_checkable = True
+        except TypeError:
+            is_runtime_checkable = False
+
+        assert is_runtime_checkable, (
+            "RateLimiterPort MUST be decorated with @runtime_checkable"
+        )
+
+
+# ============================================================================
+# Circuit Breaker Port Contract Tests
+# ============================================================================
+
+
+class TestCircuitBreakerPortContract:
+    """Tests for CircuitBreakerPort specific contracts.
+
+    CircuitBreakerPort defines the contract for fault tolerance.
+    Implements RULES.md §3.1.4 circuit breaker requirements.
+    """
+
+    REQUIRED_METHODS = ["get_state", "get_failure_count", "call", "reset"]
+
+    @pytest.mark.parametrize("method_name", REQUIRED_METHODS)
+    def test_circuit_breaker_port_has_required_methods(self, method_name: str) -> None:
+        """CircuitBreakerPort MUST have all required circuit breaker methods."""
+        assert hasattr(ports.CircuitBreakerPort, method_name), (
+            f"CircuitBreakerPort MUST define {method_name}() for fault tolerance"
+        )
+
+    def test_circuit_breaker_port_call_is_async(self) -> None:
+        """CircuitBreakerPort.call() MUST be async for non-blocking operation."""
+        import inspect
+
+        call_method = ports.CircuitBreakerPort.call
+        sig = inspect.signature(call_method)
+        params = sig.parameters
+
+        # Should have func parameter for the callable to wrap
+        assert "func" in params, (
+            "CircuitBreakerPort.call() MUST have func parameter for wrapped callable"
+        )
+
+    def test_circuit_breaker_port_get_state_returns_enum(self) -> None:
+        """CircuitBreakerPort.get_state() MUST return CircuitBreakerState."""
+        from bioetl.domain.types import CircuitBreakerState
+
+        hints = get_type_hints(ports.CircuitBreakerPort.get_state)
+
+        assert hints.get("return") is CircuitBreakerState, (
+            "CircuitBreakerPort.get_state() MUST return CircuitBreakerState enum"
+        )
+
+    def test_circuit_breaker_port_is_runtime_checkable(self) -> None:
+        """CircuitBreakerPort MUST be @runtime_checkable for isinstance() checks."""
+
+        class DummyBreaker:
+            """Dummy class for testing isinstance()."""
+
+            pass
+
+        try:
+            isinstance(DummyBreaker(), ports.CircuitBreakerPort)
+            is_runtime_checkable = True
+        except TypeError:
+            is_runtime_checkable = False
+
+        assert is_runtime_checkable, (
+            "CircuitBreakerPort MUST be decorated with @runtime_checkable"
+        )
+
+
+# ============================================================================
+# Resilience Implementation Contract Tests
+# ============================================================================
+
+
+class TestResilienceImplementationContract:
+    """Tests that resilience implementations satisfy port contracts.
+
+    TokenBucket MUST implement RateLimiterPort.
+    CircuitBreaker MUST implement CircuitBreakerPort.
+    """
+
+    def test_token_bucket_implements_rate_limiter_port(self) -> None:
+        """TokenBucket MUST satisfy RateLimiterPort contract."""
+        from bioetl.infrastructure.adapters.http.rate_limiter import TokenBucket
+
+        bucket = TokenBucket(rate=5.0, capacity=10)
+
+        assert isinstance(bucket, ports.RateLimiterPort), (
+            "TokenBucket MUST implement RateLimiterPort protocol. "
+            "Check that all required methods are present."
+        )
+
+    def test_circuit_breaker_implements_circuit_breaker_port(self) -> None:
+        """CircuitBreaker MUST satisfy CircuitBreakerPort contract."""
+        from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
+
+        breaker = CircuitBreaker(provider="test")
+
+        assert isinstance(breaker, ports.CircuitBreakerPort), (
+            "CircuitBreaker MUST implement CircuitBreakerPort protocol. "
+            "Check that all required methods are present."
         )

--- a/tests/unit/infrastructure/adapters/http/test_http_client.py
+++ b/tests/unit/infrastructure/adapters/http/test_http_client.py
@@ -274,7 +274,7 @@ def http_client(mock_rate_limiter, mock_circuit_breaker):
     return UnifiedHTTPClient(
         rate_limiter=mock_rate_limiter,
         circuit_breaker=mock_circuit_breaker,
-        retry_config=RetryConfig(max_attempts=2, jitter=0.0),
+        retry_policy=RetryConfig(max_attempts=2, jitter=0.0),
         timeout=10.0,
     )
 


### PR DESCRIPTION
Extract RateLimiterPort, CircuitBreakerPort, and RetryPolicy into separate domain components following Single Responsibility Principle:

- RateLimiterPort: Protocol for rate limiting in domain/ports/resilience.py
- CircuitBreakerPort: Protocol for circuit breaker in domain/ports/resilience.py
- RetryPolicy: Immutable value object in domain/resilience.py

UnifiedHTTPClient now uses ports instead of concrete implementations, improving testability and adhering to Ports & Adapters architecture.

TokenBucket and CircuitBreaker implementations satisfy the new protocols via structural subtyping (@runtime_checkable).

Includes architecture tests verifying port contracts and implementations.