### PR TITLE
Validate write modes in Silver Writer

### DIFF
--- a/tests/unit/infrastructure/storage/test_bronze_writer.py
+++ b/tests/unit/infrastructure/storage/test_bronze_writer.py
@@ -60,6 +60,107 @@ def sample_records() -> list[bytes]:
 
 
 @pytest.mark.unit
+class TestBronzeWriterNameValidation:
+    """Tests for BronzeWriter provider/entity name validation."""
+
+    def test_validate_bronze_names_valid(self, tmp_path, noop_logger) -> None:
+        """Test valid provider and entity names pass validation."""
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+
+        # Should not raise for valid names
+        writer._validate_bronze_names("chembl", "activity")
+        writer._validate_bronze_names("pub_chem", "compound_data")
+        writer._validate_bronze_names("uniprot-kb", "protein-entry")
+        writer._validate_bronze_names("Test123", "Entity456")
+
+    def test_validate_bronze_names_invalid_provider(self, tmp_path, noop_logger) -> None:
+        """Test invalid provider names raise ValueError."""
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+
+        with pytest.raises(ValueError, match="Invalid provider name"):
+            writer._validate_bronze_names("", "activity")
+
+        with pytest.raises(ValueError, match="Invalid provider name"):
+            writer._validate_bronze_names("provider/path", "activity")
+
+        with pytest.raises(ValueError, match="Invalid provider name"):
+            writer._validate_bronze_names("provider name", "activity")
+
+        with pytest.raises(ValueError, match="Invalid provider name"):
+            writer._validate_bronze_names("provider.name", "activity")
+
+    def test_validate_bronze_names_invalid_entity(self, tmp_path, noop_logger) -> None:
+        """Test invalid entity names raise ValueError."""
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+
+        with pytest.raises(ValueError, match="Invalid entity name"):
+            writer._validate_bronze_names("chembl", "")
+
+        with pytest.raises(ValueError, match="Invalid entity name"):
+            writer._validate_bronze_names("chembl", "entity/path")
+
+        with pytest.raises(ValueError, match="Invalid entity name"):
+            writer._validate_bronze_names("chembl", "entity name")
+
+        with pytest.raises(ValueError, match="Invalid entity name"):
+            writer._validate_bronze_names("chembl", "entity.name")
+
+    @pytest.mark.asyncio
+    async def test_write_bronze_invalid_provider_raises(
+        self,
+        tmp_path,
+        noop_logger,
+        sample_records: list[bytes],
+        batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
+        ingestion_ts: datetime,
+    ) -> None:
+        """Test write_bronze raises ValueError for invalid provider."""
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        date = datetime(2024, 1, 15)
+
+        with pytest.raises(ValueError, match="Invalid provider name"):
+            await writer.write_bronze(
+                records=iter(sample_records),
+                provider="invalid/provider",
+                entity="activity",
+                date=date,
+                batch_id=batch_id,
+                run_id=run_id,
+                run_type=run_type,
+                ingestion_ts=ingestion_ts,
+            )
+
+    @pytest.mark.asyncio
+    async def test_write_bronze_invalid_entity_raises(
+        self,
+        tmp_path,
+        noop_logger,
+        sample_records: list[bytes],
+        batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
+        ingestion_ts: datetime,
+    ) -> None:
+        """Test write_bronze raises ValueError for invalid entity."""
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        date = datetime(2024, 1, 15)
+
+        with pytest.raises(ValueError, match="Invalid entity name"):
+            await writer.write_bronze(
+                records=iter(sample_records),
+                provider="chembl",
+                entity="invalid entity",
+                date=date,
+                batch_id=batch_id,
+                run_id=run_id,
+                run_type=run_type,
+                ingestion_ts=ingestion_ts,
+            )
+
+
+@pytest.mark.unit
 class TestBronzeWriterInit:
     """Tests for BronzeWriter initialization."""
 

--- a/tests/unit/infrastructure/storage/test_delta_writer.py
+++ b/tests/unit/infrastructure/storage/test_delta_writer.py
@@ -75,13 +75,39 @@ class TestDeltaWriterValidation:
     """Tests for DeltaWriter validation."""
 
     @pytest.mark.asyncio
+    async def test_write_silver_invalid_mode_raises(self, noop_logger, valid_records):
+        """Test write_silver raises ValueError for invalid mode."""
+        from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+
+        import pyarrow as pa
+
+        writer = DeltaWriter(base_path="s3://bucket", logger=noop_logger)
+        schema = pa.schema([
+            pa.field("entity_id", pa.string()),
+            pa.field("value", pa.float64()),
+            pa.field("_run_id", pa.string()),
+            pa.field("_run_type", pa.string()),
+            pa.field("_source_batch_id", pa.string()),
+            pa.field("_ingestion_ts", pa.string()),
+        ])
+
+        with pytest.raises(ValueError, match="Invalid Silver write mode 'invalid'"):
+            await writer.write_silver(
+                table_name="test.table",
+                records=valid_records,
+                primary_keys=["entity_id"],
+                schema=schema,
+                mode="invalid",
+            )
+
+    @pytest.mark.asyncio
     async def test_write_silver_empty_records_raises(self, noop_logger):
         """Test write_silver raises ValueError for empty records."""
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
-        writer = DeltaWriter(base_path="s3://bucket", logger=noop_logger)
-
         import pyarrow as pa
+
+        writer = DeltaWriter(base_path="s3://bucket", logger=noop_logger)
 
         dummy_schema = pa.schema([pa.field("entity_id", pa.string())])
 
@@ -139,6 +165,53 @@ class TestDeltaWriterValidation:
                 primary_keys=["entity_id"],
                 schema=dummy_schema,
             )
+
+
+@pytest.mark.unit
+class TestDeltaWriterWriteModeEnum:
+    """Tests for SilverWriteMode enum."""
+
+    def test_silver_write_mode_values(self):
+        """Test all valid SilverWriteMode values."""
+        from bioetl.infrastructure.storage.delta_writer import SilverWriteMode
+
+        assert SilverWriteMode.MERGE.value == "merge"
+        assert SilverWriteMode.APPEND.value == "append"
+        assert SilverWriteMode.DELETE.value == "delete"
+
+    def test_silver_write_mode_from_string(self):
+        """Test creating SilverWriteMode from string."""
+        from bioetl.infrastructure.storage.delta_writer import SilverWriteMode
+
+        assert SilverWriteMode("merge") == SilverWriteMode.MERGE
+        assert SilverWriteMode("append") == SilverWriteMode.APPEND
+        assert SilverWriteMode("delete") == SilverWriteMode.DELETE
+
+    def test_silver_write_mode_invalid_raises(self):
+        """Test invalid mode string raises ValueError."""
+        from bioetl.infrastructure.storage.delta_writer import SilverWriteMode
+
+        with pytest.raises(ValueError):
+            SilverWriteMode("invalid")
+
+        with pytest.raises(ValueError):
+            SilverWriteMode("MERGE")  # Case sensitive
+
+    def test_validate_write_mode_method(self, noop_logger):
+        """Test _validate_write_mode returns correct enum."""
+        from bioetl.infrastructure.storage.delta_writer import DeltaWriter, SilverWriteMode
+
+        writer = DeltaWriter(base_path="/tmp/silver", logger=noop_logger)
+
+        assert writer._validate_write_mode("merge") == SilverWriteMode.MERGE
+        assert writer._validate_write_mode("append") == SilverWriteMode.APPEND
+        assert writer._validate_write_mode("delete") == SilverWriteMode.DELETE
+
+        with pytest.raises(ValueError, match="Invalid Silver write mode 'invalid'"):
+            writer._validate_write_mode("invalid")
+
+        with pytest.raises(ValueError, match="Allowed"):
+            writer._validate_write_mode("overwrite")  # Valid for Gold, not Silver
 
 
 @pytest.mark.unit

--- a/tests/unit/infrastructure/storage/test_gold_writer.py
+++ b/tests/unit/infrastructure/storage/test_gold_writer.py
@@ -58,6 +58,40 @@ def valid_records():
 
 
 @pytest.mark.unit
+class TestGoldWriterWriteModeEnum:
+    """Tests for GoldWriteMode enum."""
+
+    def test_gold_write_mode_values(self):
+        """Test all valid GoldWriteMode values."""
+        from bioetl.infrastructure.storage.gold_writer import GoldWriteMode
+
+        assert GoldWriteMode.OVERWRITE.value == "overwrite"
+        assert GoldWriteMode.APPEND.value == "append"
+        assert GoldWriteMode.SCD2.value == "scd2"
+
+    def test_gold_write_mode_from_string(self):
+        """Test creating GoldWriteMode from string."""
+        from bioetl.infrastructure.storage.gold_writer import GoldWriteMode
+
+        assert GoldWriteMode("overwrite") == GoldWriteMode.OVERWRITE
+        assert GoldWriteMode("append") == GoldWriteMode.APPEND
+        assert GoldWriteMode("scd2") == GoldWriteMode.SCD2
+
+    def test_gold_write_mode_invalid_raises(self):
+        """Test invalid mode string raises ValueError."""
+        from bioetl.infrastructure.storage.gold_writer import GoldWriteMode
+
+        with pytest.raises(ValueError):
+            GoldWriteMode("invalid")
+
+        with pytest.raises(ValueError):
+            GoldWriteMode("merge")  # Valid for Silver, not Gold
+
+        with pytest.raises(ValueError):
+            GoldWriteMode("OVERWRITE")  # Case sensitive
+
+
+@pytest.mark.unit
 class TestGoldWriterInit:
     """Tests for GoldWriter initialization."""
 


### PR DESCRIPTION
…ation

Add missing test coverage for M1-M4 Medallion invariants:
- Silver Writer: SilverWriteMode enum tests and invalid mode validation
- Gold Writer: GoldWriteMode enum tests
- Bronze Writer: provider/entity name validation edge cases

All M1-M4 functionality (SilverWriteMode, GoldWriteMode enums, schema drift handling, name validation) was already implemented. This commit adds test coverage for edge cases and enum behavior.