### PR TITLE
Document timestamp exceptions in codebase

### DIFF
--- a/docs/02-architecture/decisions/ADR-014-deterministic-writes.md
+++ b/docs/02-architecture/decisions/ADR-014-deterministic-writes.md
@@ -136,6 +136,29 @@ Application и interfaces слои **MUST NOT** импортировать `stru
 - `tests/architecture/test_no_datetime_now_in_infrastructure.py`
 - `tests/architecture/test_no_structlog_in_application_interfaces.py`
 
+### Исключения для datetime.now() (ALLOWED_FILES)
+
+Следующие файлы имеют **обоснованные исключения** для использования `datetime.now()`.
+Исключения определены в `tests/architecture/test_no_datetime_now_in_infrastructure.py`:
+
+| Файл | Модуль | Обоснование | Использование |
+|------|--------|-------------|---------------|
+| `operations.py` | `infrastructure/quarantine/` | Вычисление retention cutoff для cleanup | `datetime.now(UTC) - timedelta(days=max_age_days)` для определения записей на удаление |
+| `gold_writer.py` | `infrastructure/storage/` | SCD2 `valid_from`/`valid_to` timestamps | Установка временных меток при merge-операциях для Slowly Changing Dimensions Type 2 |
+| `lineage.py` | `infrastructure/observability/` | Provenance tracking | Real-time timestamps для `record_run_start()`, `record_run_end()`, и фильтрации по дате |
+| `detector.py` | `infrastructure/observability/anomaly/` | Anomaly detection monitoring | Timestamp в `AnomalyResult` при обнаружении критических аномалий |
+| `iqr.py` | `infrastructure/observability/anomaly/detectors/` | IQR-based anomaly detection | Timestamp в результате детекции при обнаружении аномалии |
+| `mad.py` | `infrastructure/observability/anomaly/detectors/` | MAD-based anomaly detection | Timestamp в результате детекции при обнаружении аномалии |
+| `zscore.py` | `infrastructure/observability/anomaly/detectors/` | Z-score anomaly detection | Timestamp в результате детекции при обнаружении аномалии |
+| `client.py` | `infrastructure/adapters/` | Caching logic (reserved) | Зарезервировано для TTL-based кэширования HTTP-ответов |
+
+**Критерии для исключения:**
+1. Timestamp не влияет на детерминизм batch-операций
+2. Timestamp необходим для real-time мониторинга/операций
+3. Timestamp не используется в данных Bronze/Silver/Gold
+
+**TODO:** Рассмотреть передачу timestamp для SCD2 в `gold_writer.py` как параметр (см. комментарий в коде).
+
 ## Alternatives Considered
 
 ### 1. Глобальная фиксация времени через context manager

--- a/tests/architecture/test_no_datetime_now_in_infrastructure.py
+++ b/tests/architecture/test_no_datetime_now_in_infrastructure.py
@@ -15,21 +15,40 @@ import pytest
 # Path relative to project root
 INFRASTRUCTURE_DIR = Path("src/bioetl/infrastructure")
 
-# Files allowed to use datetime.now() - with justification
+# Files allowed to use datetime.now() - with justification.
+# Full documentation in ADR-014: docs/02-architecture/decisions/ADR-014-deterministic-writes.md
+#
+# Criteria for exceptions:
+# 1. Timestamp does not affect determinism of batch operations
+# 2. Timestamp is required for real-time monitoring/operations
+# 3. Timestamp is not used in Bronze/Silver/Gold data
 ALLOWED_FILES: set[str] = {
-    # Operations use datetime.now() for calculating retention periods (cleanup)
+    # infrastructure/quarantine/operations.py
+    # Uses datetime.now(UTC) for calculating retention cutoff during cleanup.
+    # Example: cutoff_date = datetime.now(UTC) - timedelta(days=max_age_days)
     "operations.py",
-    # Gold writer uses datetime.now() for SCD2 valid_from/valid_to columns
-    # TODO (#arch-review): Consider passing timestamp for SCD2 as well
+    # infrastructure/storage/gold_writer.py
+    # Uses datetime.now() for SCD2 valid_from/valid_to columns during merge operations.
+    # TODO (#arch-review): Consider passing timestamp for SCD2 as parameter
     "gold_writer.py",
-    # Lineage tracking needs real-time timestamps for provenance
+    # infrastructure/observability/lineage.py
+    # Uses datetime.now(UTC) for provenance tracking in record_run_start(),
+    # record_run_end(), and for filtering lineage records by date range.
     "lineage.py",
-    # Anomaly detectors need real-time timestamps for monitoring
+    # infrastructure/observability/anomaly/detector.py
+    # Uses datetime.now(UTC) for timestamp in AnomalyResult when critical anomalies detected.
     "detector.py",
+    # infrastructure/observability/anomaly/detectors/iqr.py
+    # IQR-based anomaly detector: timestamp in detection result for monitoring.
     "iqr.py",
+    # infrastructure/observability/anomaly/detectors/mad.py
+    # MAD-based anomaly detector: timestamp in detection result for monitoring.
     "mad.py",
+    # infrastructure/observability/anomaly/detectors/zscore.py
+    # Z-score anomaly detector: timestamp in detection result for monitoring.
     "zscore.py",
-    # ChEMBL client uses timestamps for caching logic
+    # infrastructure/adapters/**/client.py
+    # Reserved for TTL-based HTTP response caching logic.
     "client.py",
 }
 


### PR DESCRIPTION
Add formal documentation for timestamp exceptions in ADR-014 and enhanced inline comments in the architecture test file.

Changes:
- ADR-014: New section "Исключения для datetime.now() (ALLOWED_FILES)" documenting all files with justified exceptions
- test_no_datetime_now_in_infrastructure.py: Enhanced comments with module paths, usage details, and reference to ADR-014