### PR TITLE
Add observability to transformer base class

### DIFF
--- a/src/bioetl/application/core/base_transformer.py
+++ b/src/bioetl/application/core/base_transformer.py
@@ -18,12 +18,12 @@ import time
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, TypeVar
 
+from bioetl.domain.ports import MetricsPort, NoOpMetrics, NoOpTracing, TracingPort
 from bioetl.domain.transformations import generate_content_hash
 
 if TYPE_CHECKING:
     from bioetl.domain.context import PipelineContext
     from bioetl.domain.entities import BaseEntity
-    from bioetl.domain.ports import MetricsPort, TracingPort
     from bioetl.domain.types import BronzeRecord, ContentHash, SilverRecord
 
 T = TypeVar("T", bound="BaseEntity")
@@ -80,19 +80,19 @@ class BaseTransformer(ABC):
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
     ) -> None:
-        """Initialize transformer with provider name and optional observability.
+        """Initialize transformer with provider name and observability.
 
         Args:
             provider: Data provider identifier (e.g., 'chembl', 'pubchem').
             entity_type: Entity type for metrics labels (e.g., 'activity', 'compound').
-            tracer: Optional tracing port for distributed tracing.
-            metrics: Optional metrics port for duration/error tracking.
+            tracer: Tracing port for distributed tracing. Defaults to NoOpTracing.
+            metrics: Metrics port for duration/error tracking. Defaults to NoOpMetrics.
 
         """
         self.provider = provider
         self.entity_type = entity_type or "unknown"
-        self._tracer = tracer
-        self._metrics = metrics
+        self._tracer: TracingPort = tracer if tracer is not None else NoOpTracing()
+        self._metrics: MetricsPort = metrics if metrics is not None else NoOpMetrics()
 
     async def transform(
         self,
@@ -119,21 +119,19 @@ class BaseTransformer(ABC):
 
         """
         start_time = time.perf_counter()
-        span = None
         error_type: str | None = None
 
-        # Start tracing span if tracer is available
-        if self._tracer:
-            otel_tracer = self._tracer.get_tracer("bioetl.transformer")
-            span = otel_tracer.start_as_current_span(
-                "transform_record",
-                attributes={
-                    "bioetl.provider": self.provider,
-                    "bioetl.entity_type": self.entity_type,
-                    "bioetl.run_id": str(context.run_id),
-                },
-            )
-            span.__enter__()
+        # Start tracing span (always available via NoOpTracing default)
+        otel_tracer = self._tracer.get_tracer("bioetl.transformer")
+        span = otel_tracer.start_as_current_span(
+            "transform_record",
+            attributes={
+                "bioetl.provider": self.provider,
+                "bioetl.entity_type": self.entity_type,
+                "bioetl.run_id": str(context.run_id),
+            },
+        )
+        span.__enter__()
 
         try:
             result = await self._transform_impl(context, record)
@@ -146,9 +144,8 @@ class BaseTransformer(ABC):
                 field=e.field,
                 provider=self.provider,
             )
-            if span:
-                span.set_attribute("error", True)
-                span.set_attribute("error.type", error_type)
+            span.set_attribute("error", True)
+            span.set_attribute("error.type", error_type)
             return None
         except ValueError as e:
             error_type = "validation_error"
@@ -157,40 +154,37 @@ class BaseTransformer(ABC):
                 error=str(e),
                 provider=self.provider,
             )
-            if span:
-                span.set_attribute("error", True)
-                span.set_attribute("error.type", error_type)
+            span.set_attribute("error", True)
+            span.set_attribute("error.type", error_type)
             return None
         finally:
             duration = time.perf_counter() - start_time
 
-            # Record duration histogram
-            if self._metrics:
-                self._metrics.observe_histogram(
-                    "transform_duration_seconds",
-                    duration,
+            # Record duration histogram (always available via NoOpMetrics default)
+            self._metrics.observe_histogram(
+                "transform_duration_seconds",
+                duration,
+                labels={
+                    "provider": self.provider,
+                    "entity_type": self.entity_type,
+                },
+            )
+
+            # Record error counter if error occurred
+            if error_type:
+                self._metrics.increment_counter(
+                    "transform_errors_total",
+                    1,
                     labels={
                         "provider": self.provider,
                         "entity_type": self.entity_type,
+                        "error_type": error_type,
                     },
                 )
 
-                # Record error counter if error occurred
-                if error_type:
-                    self._metrics.increment_counter(
-                        "transform_errors_total",
-                        1,
-                        labels={
-                            "provider": self.provider,
-                            "entity_type": self.entity_type,
-                            "error_type": error_type,
-                        },
-                    )
-
             # End tracing span
-            if span:
-                span.set_attribute("bioetl.duration_ms", duration * 1000)
-                span.__exit__(None, None, None)
+            span.set_attribute("bioetl.duration_ms", duration * 1000)
+            span.__exit__(None, None, None)
 
     @abstractmethod
     async def _transform_impl(

--- a/src/bioetl/domain/ports/__init__.py
+++ b/src/bioetl/domain/ports/__init__.py
@@ -21,6 +21,7 @@ from bioetl.domain.ports.data_source import (
 )
 from bioetl.domain.ports.filtering import InputFilterPort
 from bioetl.domain.ports.locking import LockPort
+from bioetl.domain.ports.noop import NoOpMetrics, NoOpTracing
 from bioetl.domain.ports.observability import (
     DQMonitorPort,
     LoggerPort,
@@ -43,6 +44,8 @@ __all__ = [
     "LockPort",
     "LoggerPort",
     "MetricsPort",
+    "NoOpMetrics",
+    "NoOpTracing",
     "QuarantinePort",
     "RateLimiterPort",
     "StoragePort",

--- a/src/bioetl/domain/ports/noop.py
+++ b/src/bioetl/domain/ports/noop.py
@@ -1,0 +1,199 @@
+"""No-operation implementations for observability ports.
+
+Provides null object pattern implementations for TracingPort and MetricsPort
+when observability is not configured or not needed.
+
+These implementations are in domain/ports (not infrastructure) because:
+- They have no I/O or external dependencies
+- They allow application layer to use defaults without importing infrastructure
+- They maintain layer separation per RULES.md import matrix
+
+Usage:
+    >>> from bioetl.domain.ports.noop import NoOpTracing, NoOpMetrics
+    >>> tracer = NoOpTracing()
+    >>> metrics = NoOpMetrics()
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Self
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+
+class _NoOpSpan:
+    """No-op span that does nothing.
+
+    Implements the span interface used by OpenTelemetry tracers.
+    Supports context manager protocol for use with `with` statements.
+    """
+
+    def __enter__(self) -> Self:
+        """Context manager entry."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Context manager exit."""
+        pass
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        """Set span attribute (no-op)."""
+        pass
+
+    def set_status(self, status: Any) -> None:
+        """Set span status (no-op)."""
+        pass
+
+    def record_exception(self, exception: Exception) -> None:
+        """Record exception (no-op)."""
+        pass
+
+
+class _NoOpOtelTracer:
+    """No-op OpenTelemetry tracer.
+
+    Returns _NoOpSpan instances that implement the span interface.
+    """
+
+    def start_as_current_span(
+        self,
+        _name: str,
+        _context: Any | None = None,
+        _kind: Any | None = None,
+        _attributes: dict[str, Any] | None = None,
+        _links: Any | None = None,
+        _start_time: Any | None = None,
+        _record_exception: bool = True,
+        _set_status_on_exception: bool = True,
+        _end_on_exit: bool = True,
+        **_kwargs: Any,
+    ) -> _NoOpSpan:
+        """Start a new span (no-op).
+
+        Args:
+            name: Span name.
+            context: Context (ignored).
+            kind: Span kind (ignored).
+            attributes: Span attributes (ignored).
+            links: Span links (ignored).
+            start_time: Start time (ignored).
+            record_exception: Whether to record exception (ignored).
+            set_status_on_exception: Whether to set status on exception (ignored).
+            end_on_exit: Whether to end span on exit (ignored).
+            **kwargs: Additional arguments - ignored.
+
+        Returns:
+            A no-op span context manager.
+
+        """
+        return _NoOpSpan()
+
+
+class NoOpTracing:
+    """No-op implementation of TracingPort.
+
+    Used when distributed tracing is disabled or not configured.
+    All operations are silently ignored.
+
+    Implements:
+        TracingPort: Domain port for distributed tracing.
+
+    Example:
+        >>> tracer = NoOpTracing()
+        >>> otel_tracer = tracer.get_tracer("bioetl.transformer")
+        >>> with otel_tracer.start_as_current_span("operation"):
+        ...     # span is a no-op
+        ...     pass
+
+    """
+
+    def get_tracer(self, _name: str) -> _NoOpOtelTracer:
+        """Get a no-op tracer.
+
+        Args:
+            _name: Tracer name (ignored).
+
+        Returns:
+            A no-op OpenTelemetry tracer.
+
+        """
+        return _NoOpOtelTracer()
+
+    def close(self) -> None:
+        """No-op close. Idempotent."""
+        pass
+
+
+class NoOpMetrics:
+    """No-op implementation of MetricsPort.
+
+    Used when metrics collection is disabled or not configured.
+    All operations are silently ignored.
+
+    Implements:
+        MetricsPort: Domain port for metrics collection.
+
+    Example:
+        >>> metrics = NoOpMetrics()
+        >>> metrics.observe_histogram("duration", 1.5, {"entity": "activity"})
+        >>> metrics.increment_counter("errors", 1, {"type": "validation"})
+
+    """
+
+    def observe_histogram(
+        self,
+        name: str,
+        value: float,
+        labels: dict[str, str] | None = None,
+    ) -> None:
+        """Observe a value for a histogram metric (no-op).
+
+        Args:
+            name: The name of the histogram metric.
+            value: The value to observe.
+            labels: A dictionary of label names to label values.
+
+        """
+        pass
+
+    def increment_counter(
+        self,
+        name: str,
+        value: int = 1,
+        labels: dict[str, str] | None = None,
+    ) -> None:
+        """Increment a counter metric (no-op).
+
+        Args:
+            name: The name of the counter metric.
+            value: The amount to increment by.
+            labels: A dictionary of label names to label values.
+
+        """
+        pass
+
+    def set_gauge(
+        self,
+        name: str,
+        value: float,
+        labels: dict[str, str] | None = None,
+    ) -> None:
+        """Set a gauge metric to a specific value (no-op).
+
+        Args:
+            name: The name of the gauge metric.
+            value: The value to set.
+            labels: A dictionary of label names to label values.
+
+        """
+        pass
+
+    def close(self) -> None:
+        """No-op close. Idempotent."""
+        pass


### PR DESCRIPTION
…n transformers

Transformers now always have active tracer/metrics via NoOpTracing and NoOpMetrics defaults, eliminating the need for conditional checks and ensuring consistent observability interfaces.

Changes:
- Add NoOpTracing and NoOpMetrics implementations in domain/ports/noop.py
- Export NoOp classes from domain/ports/__init__.py
- Update BaseTransformer to use NoOp defaults when not provided
- Remove conditional 'if self._tracer:' and 'if self._metrics:' checks