### PR TITLE
Add ingestion timestamp parameter to infrastructure

### DIFF
--- a/src/bioetl/infrastructure/quarantine/operations.py
+++ b/src/bioetl/infrastructure/quarantine/operations.py
@@ -58,18 +58,30 @@ def inspect_records(
 
 def replay_records(
     base_path: str,
-    storage_options: dict[str, str],
+    storage_options: dict[str, str] | None,
     pipeline: str,
     error_code: str | None = None,
     max_age_days: int = 7,
+    *,
+    now: datetime,
 ) -> Iterator[dict[str, Any]]:
-    """Replay quarantine records for reprocessing."""
+    """Replay quarantine records for reprocessing.
+
+    Args:
+        base_path: Path to the quarantine Delta table.
+        storage_options: Storage options for Delta table access.
+        pipeline: Pipeline name to filter by.
+        error_code: Optional error code to filter by.
+        max_age_days: Maximum age of records to replay (default 7).
+        now: Current timestamp from application layer
+             (single source of time per ADR-014). Required.
+    """
     try:
         dt = DeltaTable(base_path, storage_options=storage_options)
     except TableNotFoundError:
         return
 
-    cutoff_date = datetime.now(UTC) - timedelta(days=max_age_days)
+    cutoff_date = now - timedelta(days=max_age_days)
     arrow_table = dt.to_pyarrow_table(
         partitions=[("pipeline", "=", pipeline)],
         filters=[
@@ -141,17 +153,31 @@ def get_statistics(
 
 def purge_records(
     base_path: str,
-    storage_options: dict[str, str],
+    storage_options: dict[str, str] | None,
     pipeline: str,
     older_than_days: int = 30,
+    *,
+    now: datetime,
 ) -> int:
-    """Purge old quarantine records, returns count of deleted records."""
+    """Purge old quarantine records, returns count of deleted records.
+
+    Args:
+        base_path: Path to the quarantine Delta table.
+        storage_options: Storage options for Delta table access.
+        pipeline: Pipeline name to filter by.
+        older_than_days: Delete records older than this (default 30).
+        now: Current timestamp from application layer
+             (single source of time per ADR-014). Required.
+
+    Returns:
+        Count of deleted records.
+    """
     try:
         dt = DeltaTable(base_path, storage_options=storage_options)
     except TableNotFoundError:
         return 0
 
-    cutoff_date = (datetime.now(UTC) - timedelta(days=older_than_days)).isoformat()
+    cutoff_date = (now - timedelta(days=older_than_days)).isoformat()
 
     predicate = (
         f"pipeline = {quote_literal(pipeline)} AND "

--- a/src/bioetl/infrastructure/quarantine/unified.py
+++ b/src/bioetl/infrastructure/quarantine/unified.py
@@ -146,16 +146,42 @@ class UnifiedQuarantine:
         pipeline: str,
         error_code: str | None = None,
         max_age_days: int = 7,
+        *,
+        now: datetime,
     ) -> Iterator[dict[str, Any]]:
-        """Replay quarantine records for reprocessing."""
+        """Replay quarantine records for reprocessing.
+
+        Args:
+            pipeline: Pipeline name to filter by.
+            error_code: Optional error code to filter by.
+            max_age_days: Maximum age of records to replay (default 7).
+            now: Current timestamp from application layer
+                 (single source of time per ADR-014). Required.
+        """
         return replay_records(
-            self.base_path, None, pipeline, error_code, max_age_days
+            self.base_path, None, pipeline, error_code, max_age_days, now=now
         )
 
-    def purge(self, pipeline: str, older_than_days: int = 30) -> int:
-        """Purge old quarantine records."""
+    def purge(
+        self,
+        pipeline: str,
+        older_than_days: int = 30,
+        *,
+        now: datetime,
+    ) -> int:
+        """Purge old quarantine records.
+
+        Args:
+            pipeline: Pipeline name to filter by.
+            older_than_days: Delete records older than this (default 30).
+            now: Current timestamp from application layer
+                 (single source of time per ADR-014). Required.
+
+        Returns:
+            Count of deleted records.
+        """
         return purge_records(
-            self.base_path, None, pipeline, older_than_days
+            self.base_path, None, pipeline, older_than_days, now=now
         )
 
     def update_status(self, payload_hash: str, new_status: DQStatus) -> bool:

--- a/src/bioetl/infrastructure/storage/gold_writer.py
+++ b/src/bioetl/infrastructure/storage/gold_writer.py
@@ -90,6 +90,8 @@ class GoldWriter:
         mode: str = "overwrite",
         partition_cols: list[str] | None = None,
         scd_config: dict[str, Any] | None = None,
+        *,
+        ingestion_ts: datetime | None = None,
     ) -> None:
         """Write validated records to Gold layer.
 
@@ -101,9 +103,12 @@ class GoldWriter:
             mode: Write mode - 'overwrite', 'append', or 'scd2'
             partition_cols: Optional partition columns
             scd_config: Required config for SCD2 mode
+            ingestion_ts: Ingestion timestamp from application layer
+                         (single source of time per ADR-014). Required for SCD2 mode.
 
         Raises:
-            ValueError: If mode is invalid, records empty, or schema not strict
+            ValueError: If mode is invalid, records empty, schema not strict,
+                       or SCD2 mode without ingestion_ts
         """
         # Validate write mode
         try:
@@ -117,9 +122,15 @@ class GoldWriter:
         if not records:
             raise ValueError("No records to write")
 
-        # SCD2 requires scd_config
-        if validated_mode == GoldWriteMode.SCD2 and scd_config is None:
-            raise ValueError("scd_config required for SCD Type 2 mode")
+        # SCD2 requires scd_config and ingestion_ts
+        if validated_mode == GoldWriteMode.SCD2:
+            if scd_config is None:
+                raise ValueError("scd_config required for SCD Type 2 mode")
+            if ingestion_ts is None:
+                raise ValueError(
+                    "ingestion_ts required for SCD Type 2 mode "
+                    "(timestamp must come from application layer per ADR-014)"
+                )
 
         # Check strict attribute - supports both DataFrameSchema and DataFrameModel
         # DataFrameSchema: schema.strict directly
@@ -141,7 +152,11 @@ class GoldWriter:
         table_path = f"{self.base_path}/{table_name.replace('.', '/')}"
 
         if validated_mode == GoldWriteMode.SCD2:
-            await self._write_scd2(table_path, records, scd_config, partition_cols)
+            # ingestion_ts is validated above, assert for type checker
+            assert ingestion_ts is not None
+            await self._write_scd2(
+                table_path, records, scd_config, partition_cols, ingestion_ts
+            )
         else:  # OVERWRITE or APPEND
             await self._write_simple(
                 table_path,
@@ -283,8 +298,18 @@ class GoldWriter:
         records: list[dict[str, Any]],
         scd_config: dict[str, Any],
         partition_cols: list[str] | None,
+        ingestion_ts: datetime,
     ) -> None:
-        """Write records using SCD Type 2 (history tracking)."""
+        """Write records using SCD Type 2 (history tracking).
+
+        Args:
+            table_path: Path to the Delta table.
+            records: List of records to write.
+            scd_config: SCD2 configuration (business_key, version_col, etc.).
+            partition_cols: Optional partition columns.
+            ingestion_ts: Ingestion timestamp from application layer
+                         (single source of time per ADR-014).
+        """
         business_key = scd_config["business_key"]
 
         # Sort records by business key for deterministic processing
@@ -297,9 +322,10 @@ class GoldWriter:
         valid_to_col = scd_config.get("valid_to_col", "valid_to")
         current_flag_col = scd_config.get("current_flag_col", "is_current")
 
-        now = datetime.now(UTC).isoformat()
+        # Use ingestion_ts from application layer (ADR-014: single source of truth)
+        ts_iso = ingestion_ts.isoformat()
         for record in records:
-            record[valid_from_col] = now
+            record[valid_from_col] = ts_iso
             record[valid_to_col] = None
             record[current_flag_col] = True
             record[version_col] = record.get(version_col, 1)
@@ -310,7 +336,9 @@ class GoldWriter:
                     dt = await self._run_in_executor(
                         lambda table_path=table_path: DeltaTable(table_path)
                     )
-                    await self._merge_scd2(dt, records, business_key, scd_config)
+                    await self._merge_scd2(
+                        dt, records, business_key, scd_config, ingestion_ts
+                    )
                 except TableNotFoundError:
                     arrow_data = self._to_arrow_table(records)
                     await self._run_in_executor(
@@ -337,8 +365,18 @@ class GoldWriter:
         records: list[dict[str, Any]],
         business_key: str | list[str],
         scd_config: dict[str, Any],
+        ingestion_ts: datetime,
     ) -> None:
-        """Merge records using SCD Type 2 logic."""
+        """Merge records using SCD Type 2 logic.
+
+        Args:
+            dt: DeltaTable instance to merge into.
+            records: List of records to merge.
+            business_key: Business key column(s) for matching.
+            scd_config: SCD2 configuration.
+            ingestion_ts: Ingestion timestamp from application layer
+                         (single source of time per ADR-014).
+        """
         if isinstance(business_key, str):
             business_keys = [business_key]
         else:
@@ -351,7 +389,8 @@ class GoldWriter:
             f"target.{key} = source.{key}" for key in business_keys
         )
         merge_condition += f" AND target.{current_flag_col} = true"
-        now = datetime.now(UTC).isoformat()
+        # Use ingestion_ts from application layer (ADR-014: single source of truth)
+        ts_iso = ingestion_ts.isoformat()
 
         await self._run_in_executor(
             lambda: (
@@ -365,7 +404,7 @@ class GoldWriter:
                 )
                 .when_matched_update(
                     updates={
-                        valid_to_col: f"'{now}'",
+                        valid_to_col: f"'{ts_iso}'",
                         current_flag_col: "false",
                     }
                 )

--- a/tests/architecture/test_no_datetime_now_in_infrastructure.py
+++ b/tests/architecture/test_no_datetime_now_in_infrastructure.py
@@ -22,15 +22,11 @@ INFRASTRUCTURE_DIR = Path("src/bioetl/infrastructure")
 # 1. Timestamp does not affect determinism of batch operations
 # 2. Timestamp is required for real-time monitoring/operations
 # 3. Timestamp is not used in Bronze/Silver/Gold data
+#
+# REFACTORED (no longer need datetime.now()):
+# - operations.py: Now accepts `now: datetime` parameter from caller
+# - gold_writer.py: Now accepts `ingestion_ts: datetime` parameter for SCD2
 ALLOWED_FILES: set[str] = {
-    # infrastructure/quarantine/operations.py
-    # Uses datetime.now(UTC) for calculating retention cutoff during cleanup.
-    # Example: cutoff_date = datetime.now(UTC) - timedelta(days=max_age_days)
-    "operations.py",
-    # infrastructure/storage/gold_writer.py
-    # Uses datetime.now() for SCD2 valid_from/valid_to columns during merge operations.
-    # TODO (#arch-review): Consider passing timestamp for SCD2 as parameter
-    "gold_writer.py",
     # infrastructure/observability/lineage.py
     # Uses datetime.now(UTC) for provenance tracking in record_run_start(),
     # record_run_end(), and for filtering lineage records by date range.

--- a/tests/unit/infrastructure/quarantine/test_unified_quarantine.py
+++ b/tests/unit/infrastructure/quarantine/test_unified_quarantine.py
@@ -319,7 +319,7 @@ class TestUnifiedQuarantineReplay:
 
         mock_delta_table.side_effect = TableNotFoundError("Not found")
 
-        result = list(quarantine.replay(pipeline="test"))
+        result = list(quarantine.replay(pipeline="test", now=TEST_INGESTION_TS))
 
         assert result == []
 
@@ -347,7 +347,10 @@ class TestUnifiedQuarantineReplay:
         ):
             result = list(
                 quarantine.replay(
-                    pipeline="test", error_code="INVALID_DATA", max_age_days=3
+                    pipeline="test",
+                    error_code="INVALID_DATA",
+                    max_age_days=3,
+                    now=TEST_INGESTION_TS,
                 )
             )
 
@@ -369,7 +372,7 @@ class TestUnifiedQuarantinePurge:
 
         mock_delta_table.side_effect = TableNotFoundError("Not found")
 
-        result = quarantine.purge(pipeline="test")
+        result = quarantine.purge(pipeline="test", now=TEST_INGESTION_TS)
 
         assert result == 0
 
@@ -381,7 +384,9 @@ class TestUnifiedQuarantinePurge:
         mock_table.to_pyarrow_table.return_value = mock_arrow_table
         mock_delta_table.return_value = mock_table
 
-        result = quarantine.purge(pipeline="test", older_than_days=30)
+        result = quarantine.purge(
+            pipeline="test", older_than_days=30, now=TEST_INGESTION_TS
+        )
 
         assert result == 5
         mock_table.delete.assert_called_once()
@@ -394,7 +399,7 @@ class TestUnifiedQuarantinePurge:
         mock_table.to_pyarrow_table.return_value = mock_arrow_table
         mock_delta_table.return_value = mock_table
 
-        result = quarantine.purge(pipeline="test")
+        result = quarantine.purge(pipeline="test", now=TEST_INGESTION_TS)
 
         assert result == 0
         mock_table.delete.assert_not_called()

--- a/tests/unit/infrastructure/storage/test_gold_writer.py
+++ b/tests/unit/infrastructure/storage/test_gold_writer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pyarrow as pa
@@ -55,6 +56,12 @@ def valid_records():
         {"entity_id": "CHEMBL123", "value": 5.5},
         {"entity_id": "CHEMBL456", "value": 7.2},
     ]
+
+
+@pytest.fixture
+def fixed_ingestion_ts():
+    """Create a fixed timestamp for testing SCD2 operations."""
+    return datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
 
 
 @pytest.mark.unit
@@ -164,6 +171,20 @@ class TestGoldWriterValidation:
                 mode="scd2",
             )
 
+    async def test_write_gold_scd2_without_ingestion_ts_raises(
+        self, gold_writer, valid_records, strict_schema
+    ):
+        """Test write_gold raises ValueError for SCD2 mode without ingestion_ts."""
+        scd_config = {"business_key": "entity_id"}
+        with pytest.raises(ValueError, match="ingestion_ts required"):
+            await gold_writer.write_gold(
+                table_name="test.table",
+                records=valid_records,
+                schema=strict_schema,
+                mode="scd2",
+                scd_config=scd_config,
+            )
+
 
 @pytest.mark.unit
 class TestGoldWriterWriteSimple:
@@ -227,7 +248,7 @@ class TestGoldWriterSCD2:
     @patch("bioetl.infrastructure.storage.gold_writer.DeltaTable")
     @patch("bioetl.infrastructure.storage.gold_writer.write_deltalake")
     async def test_write_gold_scd2_creates_new_table(
-        self, mock_write_deltalake, mock_delta_table, gold_writer, valid_records, strict_schema
+        self, mock_write_deltalake, mock_delta_table, gold_writer, valid_records, strict_schema, fixed_ingestion_ts
     ):
         """Test SCD2 write creates new table when table doesn't exist."""
         mock_delta_table.side_effect = TableNotFoundError("Not found")
@@ -246,6 +267,7 @@ class TestGoldWriterSCD2:
             schema=strict_schema,
             mode="scd2",
             scd_config=scd_config,
+            ingestion_ts=fixed_ingestion_ts,
         )
 
         mock_write_deltalake.assert_called_once()
@@ -255,7 +277,7 @@ class TestGoldWriterSCD2:
 
     @patch("bioetl.infrastructure.storage.gold_writer.DeltaTable")
     async def test_write_gold_scd2_merge_existing_table(
-        self, mock_delta_table, gold_writer, valid_records, strict_schema
+        self, mock_delta_table, gold_writer, valid_records, strict_schema, fixed_ingestion_ts
     ):
         """Test SCD2 write merges into existing table."""
         mock_table_instance = MagicMock()
@@ -275,6 +297,7 @@ class TestGoldWriterSCD2:
             schema=strict_schema,
             mode="scd2",
             scd_config=scd_config,
+            ingestion_ts=fixed_ingestion_ts,
         )
 
         mock_table_instance.merge.assert_called_once()
@@ -283,7 +306,7 @@ class TestGoldWriterSCD2:
 
     @patch("bioetl.infrastructure.storage.gold_writer.DeltaTable")
     async def test_write_gold_scd2_with_list_business_key(
-        self, mock_delta_table, gold_writer
+        self, mock_delta_table, gold_writer, fixed_ingestion_ts
     ):
         """Test SCD2 write with list of business keys."""
         mock_table_instance = MagicMock()
@@ -317,6 +340,7 @@ class TestGoldWriterSCD2:
             schema=multi_key_schema,
             mode="scd2",
             scd_config=scd_config,
+            ingestion_ts=fixed_ingestion_ts,
         )
 
         mock_table_instance.merge.assert_called_once()
@@ -584,7 +608,7 @@ class TestGoldWriterDeterministicBackoff:
     @patch("bioetl.infrastructure.storage.gold_writer.DeltaTable")
     @patch("bioetl.infrastructure.storage.gold_writer.write_deltalake")
     async def test_gold_writer_scd2_deterministic_backoff(
-        self, mock_write_deltalake, mock_delta_table, mock_sleep, gold_writer, valid_records, strict_schema
+        self, mock_write_deltalake, mock_delta_table, mock_sleep, gold_writer, valid_records, strict_schema, fixed_ingestion_ts
     ):
         """Test that SCD2 mode also uses deterministic backoff.
 
@@ -613,6 +637,7 @@ class TestGoldWriterDeterministicBackoff:
             schema=strict_schema,
             mode="scd2",
             scd_config=scd_config,
+            ingestion_ts=fixed_ingestion_ts,
         )
 
         # Verify deterministic backoff delays


### PR DESCRIPTION
Remove datetime.now() calls from infrastructure layer files and require timestamps to be passed as parameters from the application layer, per ADR-014 (single source of truth for timestamps).

Changes:
- gold_writer.py: Add ingestion_ts parameter for SCD2 operations
- operations.py: Add now parameter to replay_records and purge_records
- unified.py: Pass now parameter through to operations functions
- Update ALLOWED_FILES in architecture test (remove refactored files)
- Update tests to provide required timestamp parameters