### PR TITLE
Fix BronzeWriter return type mismatch

### DIFF
--- a/src/bioetl/composition/factories/storage_adapter.py
+++ b/src/bioetl/composition/factories/storage_adapter.py
@@ -51,7 +51,7 @@ class StorageAdapter:
         run_id: RunID,
         run_type: RunType,
         ingestion_ts: datetime,
-    ) -> None:
+    ) -> Path:
         """Write raw records to Bronze layer.
 
         Args:
@@ -64,8 +64,11 @@ class StorageAdapter:
             run_type: Type of run.
             ingestion_ts: Ingestion timestamp from application layer
                          (single source of time per ADR-014). Required.
+
+        Returns:
+            Path: Relative path to the written file.
         """
-        await self.bronze.write_bronze(
+        return await self.bronze.write_bronze(
             records=records,
             provider=provider,
             entity=entity,

--- a/src/bioetl/domain/ports/storage.py
+++ b/src/bioetl/domain/ports/storage.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Literal, Protocol, runtime_checkable
 
 from bioetl.domain.types import (
@@ -38,7 +39,7 @@ class StoragePort(Protocol):
         run_id: RunID,
         run_type: RunType,
         ingestion_ts: datetime,
-    ) -> None:
+    ) -> Path:
         """Write raw records to the Bronze layer.
 
         Args:
@@ -51,6 +52,9 @@ class StoragePort(Protocol):
             run_type: The type of pipeline run (incremental, backfill, rebuild).
             ingestion_ts: Ingestion timestamp from application layer
                          (single source of time per ADR-014). Required.
+
+        Returns:
+            Path: Relative path to the written file.
         """
         ...
 

--- a/tests/fakes/storage_fake.py
+++ b/tests/fakes/storage_fake.py
@@ -6,6 +6,7 @@ Implements StoragePort interface without filesystem I/O.
 from __future__ import annotations
 
 from collections import defaultdict
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
@@ -46,7 +47,7 @@ class InMemoryStorage:
         run_id: RunID,
         run_type: RunType,
         ingestion_ts: datetime,
-    ) -> None:
+    ) -> Path:
         """Write raw records to the Bronze layer.
 
         Args:
@@ -59,6 +60,8 @@ class InMemoryStorage:
             run_type: Type of run.
             ingestion_ts: Ingestion timestamp from application layer.
 
+        Returns:
+            Path: Relative path to the written file.
         """
         key = f"bronze/v1/{provider}/{entity}/{date.strftime('%Y-%m-%d')}/{batch_id}.jsonl.zst"
         record_list = list(records)
@@ -73,6 +76,7 @@ class InMemoryStorage:
             "key": key,
             "record_count": len(record_list),
         })
+        return Path(key)
 
     async def write_silver(
         self,

--- a/tests/integration/memory_storage.py
+++ b/tests/integration/memory_storage.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from pathlib import Path
 
 from bioetl.domain.ports import StoragePort
 
@@ -14,7 +15,7 @@ class MemoryStorage(StoragePort):
 
     def write_bronze(
         self, records, provider, entity, date, batch_id, run_id, run_type, ingestion_ts
-    ):
+    ) -> Path:
         key = f"bronze/{provider}/{entity}/{date}/{batch_id}.jsonl.zst"
         self.data[key].extend(records)
         # Store metadata for test verification
@@ -23,6 +24,7 @@ class MemoryStorage(StoragePort):
             "run_type": run_type.value if hasattr(run_type, "value") else str(run_type),
             "ingestion_ts": ingestion_ts.isoformat() if ingestion_ts else None,
         }
+        return Path(key)
 
     def write_silver(self, table_name, records, _primary_keys):
         self.data[table_name].extend(records)


### PR DESCRIPTION
Update StoragePort.write_bronze() to return Path instead of None, matching the actual BronzeWriter implementation. This fixes the type mismatch where BronzeWriter returned Path but StoragePort declared None.

Changes:
- StoragePort.write_bronze() now returns Path (domain/ports/storage.py)
- StorageAdapter.write_bronze() now returns Path (composition/factories)
- InMemoryStorage.write_bronze() returns Path (tests/fakes)
- MemoryStorage.write_bronze() returns Path (tests/integration)