### PR TITLE
Fix double rate limiting in PubChem fetch

### DIFF
--- a/src/bioetl/infrastructure/adapters/pubchem/client.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/client.py
@@ -94,8 +94,6 @@ class PubChemAdapter(BaseSyncAdapter):
         # Note: filter_ids and filter_field are ignored for PubChem -
         # filtering should be done via query parameter
         _ = filter_ids, filter_field  # Mark as intentionally unused
-        # Apply rate limiting
-        await self.rate_limiter.acquire()
 
         strategy = self._fetch_strategies.get(entity_type)
         if not strategy:

--- a/tests/infrastructure/adapters/test_pubchem.py
+++ b/tests/infrastructure/adapters/test_pubchem.py
@@ -202,3 +202,75 @@ async def test_circuit_breaker(pubchem_adapter):
         with pytest.raises(CircuitBreakerOpenError):
             async for _ in pubchem_adapter.fetch("compound", query="fail"):
                 pass
+
+
+async def test_rate_limiter_called_once_per_compound_fetch(
+    pubchem_adapter, mock_pcp_compound
+):
+    """Test rate limiter acquire() is called exactly once per fetch (no double limiting).
+
+    Verifies fix for double rate limiting issue where fetch() called acquire()
+    and then internal methods called acquire() again, reducing throughput
+    from 5 req/sec to ~2.5 req/sec.
+    """
+    with patch("pubchempy.get_compounds", return_value=[mock_pcp_compound]):
+        # Replace rate limiter with a mock to count calls
+        original_acquire = pubchem_adapter.rate_limiter.acquire
+        call_count = 0
+
+        async def counting_acquire():
+            nonlocal call_count
+            call_count += 1
+            return await original_acquire()
+
+        pubchem_adapter.rate_limiter.acquire = counting_acquire
+
+        # Fetch compounds
+        results = []
+        async for record in pubchem_adapter.fetch("compound", query="aspirin"):
+            results.append(record)
+
+        # Should be exactly 1 acquire() call per logical request
+        assert call_count == 1, f"Expected 1 acquire() call, got {call_count}"
+
+
+async def test_rate_limiter_called_once_per_substance_fetch(
+    pubchem_adapter, mock_pcp_substance
+):
+    """Test rate limiter is called exactly once for substance fetch."""
+    with patch("pubchempy.get_substances", return_value=[mock_pcp_substance]):
+        original_acquire = pubchem_adapter.rate_limiter.acquire
+        call_count = 0
+
+        async def counting_acquire():
+            nonlocal call_count
+            call_count += 1
+            return await original_acquire()
+
+        pubchem_adapter.rate_limiter.acquire = counting_acquire
+
+        results = []
+        async for record in pubchem_adapter.fetch("substance", query="aspirin"):
+            results.append(record)
+
+        assert call_count == 1, f"Expected 1 acquire() call, got {call_count}"
+
+
+async def test_rate_limiter_called_once_per_assay_fetch(pubchem_adapter, mock_pcp_assay):
+    """Test rate limiter is called exactly once for assay fetch."""
+    with patch("pubchempy.get_assays", return_value=[mock_pcp_assay]):
+        original_acquire = pubchem_adapter.rate_limiter.acquire
+        call_count = 0
+
+        async def counting_acquire():
+            nonlocal call_count
+            call_count += 1
+            return await original_acquire()
+
+        pubchem_adapter.rate_limiter.acquire = counting_acquire
+
+        results = []
+        async for record in pubchem_adapter.fetch("assay", query="12345"):
+            results.append(record)
+
+        assert call_count == 1, f"Expected 1 acquire() call, got {call_count}"


### PR DESCRIPTION
The fetch() method was calling rate_limiter.acquire() before delegating to internal methods (_fetch_by_query, _fetch_substances, _fetch_assays) which also called acquire(). This resulted in double rate limiting, reducing actual throughput from 5 req/sec to ~2.5 req/sec.

Removed the redundant acquire() call from fetch(), keeping rate limiting in the internal methods where the actual API calls happen.

Added tests to verify rate limiter is called exactly once per logical request for all entity types (compound, substance, assay).