### PR TITLE
Create missing ADRs for error handling

### DIFF
--- a/docs/02-architecture/decisions/ADR-016-error-handling-strategy.md
+++ b/docs/02-architecture/decisions/ADR-016-error-handling-strategy.md
@@ -1,0 +1,255 @@
+# ADR-016: Error Handling Strategy
+
+*   **Status**: Accepted
+*   **Date**: 2025-12-26
+*   **Context**: The BioETL pipeline needs a consistent strategy for handling errors across all adapters and processing stages. Without a unified approach, error handling becomes fragmented, leading to inconsistent behavior, difficulty in debugging, and potential data loss.
+
+## The Decision
+
+We have implemented a **differentiated error handling strategy** with three tiers of classification, unified retry logic with deterministic jitter, Circuit Breaker pattern, and a Unified Quarantine mechanism.
+
+### 1. Three-Tier Error Classification
+
+| Error Type | Behavior | Examples |
+|------------|----------|----------|
+| **Critical** | Pipeline fail | Auth failure (401), schema mismatch in Gold, database unavailable |
+| **Recoverable** | Retry with backoff (max 3 attempts) | 429 Rate Limit, 502/504 Timeout, network errors |
+| **Data Quality** | Log + skip record | Invalid SMILES, missing optional field |
+
+This decision implements RULES.md Section 3.1.
+
+### 2. Exponential Backoff with Deterministic Jitter
+
+```python
+# RetryConfig parameters
+max_attempts: 3
+multiplier: 2.0        # wait 1s, 2s, 4s...
+jitter: (0.1s, 0.5s)   # random range
+
+# Deterministic mode (for reproducibility)
+deterministic: True    # Hash-based jitter instead of random
+jitter_seed: 42        # Optional seed for reproducibility
+```
+
+**Deterministic Jitter Calculation:**
+```python
+hash_input = f"{attempt}:{url}:{seed}"
+jitter_factor = (hash(hash_input) % 1000) / 1000.0
+jitter = jitter_min + jitter_factor * (jitter_max - jitter_min)
+```
+
+### 3. Circuit Breaker
+
+State machine pattern for cascading failure protection:
+
+```
+         ┌─────────────────────────────────────────┐
+         │                                         │
+         ▼                                         │
+     ┌───────┐  failure_threshold  ┌──────┐      success
+     │CLOSED │ ─────────────────▶ │ OPEN │ ──────────┐
+     └───────┘                     └──────┘          │
+         ▲                            │              │
+         │                    recovery_timeout       │
+         │                            │              │
+         │                            ▼              │
+         │                      ┌───────────┐        │
+         └────── success ────── │ HALF_OPEN │ ───────┘
+                                └───────────┘
+                                      │
+                                   failure
+                                      │
+                                      ▼
+                                  ┌──────┐
+                                  │ OPEN │
+                                  └──────┘
+```
+
+**Configuration:**
+- `failure_threshold`: 5 consecutive errors
+- `recovery_timeout`: 300s (5 minutes)
+- Triggering errors: 5xx, 429, connection timeouts
+
+See [ADR-007](ADR-007-circuit-breaker-implementation.md) for implementation details.
+
+### 4. Unified Quarantine with 64KB Truncation
+
+All failed records are stored in a single quarantine table `common.quarantine`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ingestion_ts` | Timestamp | Time of incident |
+| `pipeline` | String | Pipeline name (e.g., `chembl_activity`) |
+| `error_code` | String | Error type (e.g., `SCHEMA_VIOLATION`) |
+| `payload` | JSON/Text | Raw record (**truncated to 64KB**) |
+| `payload_hash` | String | SHA256 for deduplication |
+| `bronze_batch_id` | UUID | Reference to source batch |
+| `dq_status` | String | `NEW` \| `IGNORED` \| `REPROCESSED` |
+
+**64KB Truncation Rationale:**
+- Prevents storage bloat from large malformed records
+- Maintains linkage to Bronze via `bronze_batch_id` for full payload access
+- Sufficient context for debugging most issues
+
+### 5. Batch Error Thresholds
+
+| Threshold | Condition | Action |
+|-----------|-----------|--------|
+| **Soft** | >5% DQ errors | Warning |
+| **Hard** | >20% DQ errors | Fail Batch |
+
+Metrics tracked:
+- `record_error_rate`: Ratio of bad rows
+- `entity_error_rate`: Ratio of bad unique entities
+
+## Justification
+
+### 1. Differentiated Handling Prevents Over-Engineering
+
+Not all errors deserve the same treatment:
+- Critical errors need immediate attention
+- Recoverable errors should be retried automatically
+- Data quality issues shouldn't stop the pipeline
+
+### 2. Deterministic Jitter Enables Reproducibility
+
+Per [ADR-014](ADR-014-deterministic-writes.md), infrastructure must be deterministic:
+- Hash-based jitter allows reproducible retries in tests
+- Random jitter still used in production for thundering herd prevention
+- Configurable via `RetryConfig(deterministic=True)`
+
+### 3. Unified Quarantine Simplifies Operations
+
+Instead of per-pipeline quarantine tables:
+- Single location for all failed records
+- Consistent schema for tooling
+- Cross-pipeline analysis capability
+- Simpler retention management
+
+### 4. Circuit Breaker Prevents Cascading Failures
+
+When external APIs fail:
+- Stops hammering failing services
+- Preserves rate limit quotas
+- Enables graceful degradation
+- Automatic recovery via half-open probing
+
+## Implementation Details
+
+### Error Classification
+
+```python
+from bioetl.domain.exceptions import (
+    CriticalPipelineError,   # Stops pipeline
+    RecoverableError,         # Retry with backoff
+    DataQualityError,         # Log and skip
+)
+
+def handle_error(error: Exception) -> None:
+    if isinstance(error, CriticalPipelineError):
+        raise  # Pipeline fails
+    elif isinstance(error, RecoverableError):
+        # Retry logic handles this
+        pass
+    elif isinstance(error, DataQualityError):
+        quarantine.write(
+            pipeline=context.pipeline_name,
+            error_code=error.code,
+            payload=error.record,
+            bronze_batch_id=batch_id,
+            ingestion_ts=context.started_at,
+        )
+```
+
+### Circuit Breaker Usage
+
+```python
+from bioetl.infrastructure.adapters.http.circuit_breaker import (
+    CircuitBreaker,
+    is_circuit_breaker_error,
+)
+
+cb = CircuitBreaker(provider="chembl", failure_threshold=5)
+
+async def fetch_with_protection(url: str) -> dict:
+    return await cb.call(http_client.get, url)
+```
+
+### Quarantine Port
+
+```python
+class QuarantinePort(Protocol):
+    async def write(
+        self,
+        pipeline: str,
+        error_code: str,
+        payload: dict[str, Any],
+        bronze_batch_id: BatchID,
+        run_id: RunID | None = None,
+        metadata: dict[str, Any] | None = None,
+        *,
+        ingestion_ts: datetime,
+    ) -> None: ...
+
+    async def inspect(
+        self,
+        pipeline: str,
+        limit: int = 10,
+        error_code: str | None = None,
+    ) -> list[dict[str, Any]]: ...
+
+    async def get_stats(self, pipeline: str) -> dict[str, Any]: ...
+```
+
+## Alternatives Considered
+
+### 1. Fail-Fast Only
+
+Rejected because:
+- Wastes resources on transient failures
+- Doesn't distinguish data quality from infrastructure issues
+- Poor user experience for minor issues
+
+### 2. Per-Pipeline Quarantine Tables
+
+Rejected because:
+- Schema duplication
+- Tooling complexity
+- Cross-pipeline analysis difficult
+- Higher storage overhead
+
+### 3. Unlimited Payload in Quarantine
+
+Rejected because:
+- Storage cost explosion with malformed large records
+- 64KB covers 99% of debugging needs
+- Full payload accessible via Bronze linkage
+
+### 4. No Deterministic Mode
+
+Rejected because:
+- Tests become non-reproducible
+- Debugging retry issues is difficult
+- Violates [ADR-014](ADR-014-deterministic-writes.md) principles
+
+## Consequences
+
+### Positive
+
+- **Consistent behavior** across all pipelines
+- **Graceful degradation** instead of hard failures
+- **Reproducible retries** in deterministic mode
+- **Unified operations** via single quarantine table
+- **Cost control** via payload truncation
+
+### Negative
+
+- **Complexity**: Three error types require understanding
+- **Truncation risk**: Very large records lose data in quarantine (mitigated by Bronze linkage)
+- **Circuit breaker scope**: Per-provider, not per-endpoint (acceptable tradeoff)
+
+## Related ADRs
+
+- [ADR-007](ADR-007-circuit-breaker-implementation.md): Circuit Breaker Implementation
+- [ADR-008](ADR-008-graceful-shutdown-strategy.md): Graceful Shutdown Strategy
+- [ADR-014](ADR-014-deterministic-writes.md): Deterministic Writes and Retries

--- a/docs/02-architecture/decisions/ADR-017-observability-architecture.md
+++ b/docs/02-architecture/decisions/ADR-017-observability-architecture.md
@@ -1,0 +1,268 @@
+# ADR-017: Observability Architecture
+
+*   **Status**: Accepted
+*   **Date**: 2025-12-26
+*   **Context**: BioETL pipelines require comprehensive observability for debugging, performance monitoring, and operational alerting. The observability stack must follow the Ports & Adapters architecture to maintain testability and avoid infrastructure dependencies in domain/application layers.
+
+## The Decision
+
+We have implemented a **port-based observability architecture** with three formal Protocol definitions (`LoggerPort`, `MetricsPort`, `TracingPort`), Prometheus metrics with standardized labels, and NoOp implementations for testing.
+
+### 1. Observability Ports as Formal Protocols
+
+All observability concerns are abstracted through ports in `domain/ports/observability.py`:
+
+```python
+@runtime_checkable
+class LoggerPort(Protocol):
+    """Port for structured logging."""
+    def bind(self, **kwargs: Any) -> Self: ...
+    def info(self, _event: str, **kwargs: Any) -> Any: ...
+    def warning(self, _event: str, **kwargs: Any) -> Any: ...
+    def error(self, _event: str, **kwargs: Any) -> Any: ...
+    def debug(self, _event: str, **kwargs: Any) -> Any: ...
+    def exception(self, _event: str, **kwargs: Any) -> Any: ...
+
+@runtime_checkable
+class MetricsPort(Protocol):
+    """Port for metrics collection."""
+    def observe_histogram(self, name: str, value: float, labels: dict[str, str]) -> None: ...
+    def increment_counter(self, name: str, value: int, labels: dict[str, str]) -> None: ...
+    def set_gauge(self, name: str, value: float, labels: dict[str, str]) -> None: ...
+    def close(self) -> None: ...
+
+@runtime_checkable
+class TracingPort(Protocol):
+    """Port for distributed tracing (OpenTelemetry)."""
+    def get_tracer(self, name: str) -> Any: ...
+    def close(self) -> None: ...
+```
+
+### 2. Prometheus Metrics with Standardized Labels
+
+Metrics are exposed at `http://localhost:{BIOETL_METRICS_PORT}/metrics` (default: 8000).
+
+**Pipeline Metrics (prefix: `bioetl_`):**
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `pipeline_duration_seconds` | Histogram | pipeline, stage, status, run_type | Stage execution duration |
+| `records_processed_total` | Counter | pipeline, stage, run_type | Processed record count |
+| `errors_total` | Counter | pipeline, stage, error_code | Error count by type |
+| `batch_size_records` | Histogram | pipeline, stage | Batch size distribution |
+
+**Circuit Breaker Metrics:**
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `circuit_breaker_state` | Gauge | provider | 0=Closed, 1=Half-Open, 2=Open |
+| `circuit_breaker_trips_total` | Counter | provider | Total OPEN transitions |
+| `circuit_breaker_success_total` | Counter | provider | Successful requests |
+| `circuit_breaker_failure_total` | Counter | provider | Failed requests |
+
+**Data Quality Metrics:**
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `dq_records_quarantined_total` | Counter | pipeline, error_code | Quarantined records |
+| `dq_anomaly_detected` | Counter | pipeline, metric, severity | Anomaly detections |
+| `dq_baseline_samples` | Gauge | pipeline, metric | Baseline sample count |
+
+**Maintenance Metrics:**
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `vacuum_duration_seconds` | Histogram | table | VACUUM operation time |
+| `vacuum_files_removed_total` | Counter | table | Removed file count |
+| `archive_duration_seconds` | Histogram | provider, entity | Archive operation time |
+
+### 3. NoOp Implementations for Testing
+
+Each port has a corresponding NoOp implementation in `infrastructure/observability/`:
+
+| Port | NoOp Implementation | Purpose |
+|------|---------------------|---------|
+| `LoggerPort` | `NoOpLogger` | Silent logging for tests |
+| `MetricsPort` | `NoOpMetrics` | Metric collection disabled |
+| `TracingPort` | `NoOpTracing` | Tracing disabled |
+
+**Key Features of NoOp Implementations:**
+- Null Object Pattern: silently ignore all operations
+- Idempotent: safe for repeated calls
+- Warning on use (configurable): alerts developers in non-test environments
+- Thread-safe: no shared mutable state
+
+```python
+# Testing: explicit opt-out, no warning
+metrics = NoOpMetrics(warn_on_use=False)
+
+# Production: warning if accidentally used
+metrics = NoOpMetrics()  # Emits UserWarning
+```
+
+### 4. Log Schema
+
+Structured JSON logs with mandatory fields:
+
+| Field | Required | Example |
+|-------|----------|---------|
+| `ts` | MUST | `2025-12-26T10:00:00Z` |
+| `level` | MUST | `INFO`, `ERROR` |
+| `run_id` | MUST | UUID |
+| `pipeline` | MUST | `chembl_activity` |
+| `stage` | MUST | `extract`, `transform`, `load` |
+| `dataset` | SHOULD | `chembl.activity` |
+| `record_count` | SHOULD | 1000 |
+| `error_type` | On errors | `SCHEMA_VIOLATION` |
+
+## Justification
+
+### 1. Ports Enable Clean Architecture
+
+Application layer must not depend on infrastructure:
+- `structlog` is never imported in `application/` or `interfaces/`
+- All logging goes through `LoggerPort`
+- Verified by architectural test `test_no_structlog_in_application_interfaces`
+
+### 2. NoOp Pattern Simplifies Testing
+
+Tests don't need to mock observability:
+- Inject `NoOpLogger`, `NoOpMetrics`, `NoOpTracing`
+- Zero overhead in test execution
+- No side effects (file writes, network calls)
+
+### 3. Standardized Labels Enable Aggregation
+
+Consistent labeling across all metrics:
+- `pipeline`: identifies the data pipeline
+- `stage`: extract/transform/load phase
+- `run_type`: incremental/backfill/rebuild
+- Enables PromQL queries like: `sum(errors_total{pipeline="chembl_activity"}) by (error_code)`
+
+### 4. Runtime Checkable Protocols
+
+All ports use `@runtime_checkable`:
+- Enables `isinstance()` checks at runtime
+- Validates adapter implementations
+- Tested by `tests/architecture/test_port_contracts.py`
+
+## Implementation Details
+
+### Port Location
+
+```
+src/bioetl/domain/ports/observability.py
+    LoggerPort
+    MetricsPort
+    TracingPort
+    DQMonitorPort
+```
+
+### Adapter Location
+
+```
+src/bioetl/infrastructure/observability/
+    logging.py          # structlog adapter
+    metrics.py          # Prometheus metric definitions
+    prometheus_metrics.py # PrometheusMetrics adapter
+    tracing.py          # OpenTelemetry adapter
+    noop_logger.py      # NoOpLogger
+    noop_metrics.py     # NoOpMetrics
+    noop_tracing.py     # NoOpTracing
+```
+
+### Dependency Injection
+
+```python
+# composition/factories/observability.py
+def create_metrics(config: Config) -> MetricsPort:
+    if config.metrics_enabled:
+        return PrometheusMetrics()
+    return NoOpMetrics(warn_on_use=False)
+
+def create_logger(config: Config) -> LoggerPort:
+    if config.logging_enabled:
+        return configure_structlog()
+    return NoOpLogger()
+```
+
+### Usage in Pipeline
+
+```python
+# Application layer uses ports only
+class PipelineRunner:
+    def __init__(
+        self,
+        logger: LoggerPort,
+        metrics: MetricsPort,
+        tracing: TracingPort,
+    ):
+        self.logger = logger
+        self.metrics = metrics
+        self.tracing = tracing
+
+    async def run_stage(self, stage: str) -> None:
+        self.logger.info("stage_started", stage=stage)
+        start = time.monotonic()
+
+        # ... processing ...
+
+        duration = time.monotonic() - start
+        self.metrics.observe_histogram(
+            "pipeline_duration_seconds",
+            duration,
+            {"pipeline": self.name, "stage": stage, "status": "success"},
+        )
+```
+
+## Alternatives Considered
+
+### 1. Direct structlog/Prometheus Usage
+
+Rejected because:
+- Violates layered architecture
+- Tight coupling to infrastructure
+- Difficult to test without mocks
+
+### 2. Single Observability Port
+
+Rejected because:
+- Conflates separate concerns (logging, metrics, tracing)
+- Some pipelines need only logging, not metrics
+- Different lifecycle (metrics server vs log writes)
+
+### 3. Mocking Instead of NoOp
+
+Rejected because:
+- `MagicMock` is heavier than NoOp objects
+- No type safety on mock calls
+- NoOp is cleaner Null Object Pattern
+
+### 4. Global Logger/Metrics
+
+Rejected because:
+- Hides dependencies
+- Difficult to test in isolation
+- Violates dependency injection principle
+
+## Consequences
+
+### Positive
+
+- **Clean architecture**: No infrastructure leakage into domain/application
+- **Easy testing**: NoOp implementations require zero setup
+- **Flexible backends**: Can swap Prometheus for CloudWatch, structlog for loguru
+- **Type safety**: `@runtime_checkable` validates implementations
+- **Consistent labels**: Standard aggregation patterns in dashboards
+
+### Negative
+
+- **Boilerplate**: Port + Adapter + NoOp for each concern
+- **Indirection**: One level of abstraction vs direct calls
+- **Learning curve**: Developers must use ports, not direct imports
+
+## Related ADRs
+
+- [ADR-006](ADR-006-logger-metrics-ports.md): Logger and Metrics Ports (initial decision)
+- [ADR-014](ADR-014-deterministic-writes.md): Deterministic Writes (logging constraints)
+- [ADR-016](ADR-016-error-handling-strategy.md): Error Handling Strategy (metric integration)

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -233,6 +233,8 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 ## 3. Обработка Ошибок и Наблюдаемость
 
 ### 3.1. Стратегия Обработки Ошибок
+См. [ADR-016](02-architecture/decisions/ADR-016-error-handling-strategy.md).
+
 Вместо тотального подхода "Fail Fast" используем дифференцированный подход.
 
 ### 3.1.1. Классификация Ошибок 
@@ -261,7 +263,9 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 - **Recovery**: Half-Open → 1 пробный запрос. Success → Closed, Failure → Open +5 мин.
 - **Observability**: Метрики `circuit_breaker_state` (0=Closed, 1=Half-Open, 2=Open), `trips_total`. Алерт при зависании в Open > 10 мин. 
  
-### 3.2. Наблюдаемость (Observability) 
+### 3.2. Наблюдаемость (Observability)
+См. [ADR-017](02-architecture/decisions/ADR-017-observability-architecture.md).
+
 - **Correlation ID**: `run_id` обязателен во всех логах, метриках и блокировках. 
 - **Retention**: Логи хранятся 30 дней, метрики — 90 дней. 
 - **Логи**: Структурированный JSON. 
@@ -797,6 +801,8 @@ fields:
 | [ADR-013](02-architecture/decisions/ADR-013-async-storage-cleanup.md) | Async Storage Cleanup | Accepted | 2025-12-24 |
 | [ADR-014](02-architecture/decisions/ADR-014-deterministic-writes.md) | Deterministic Writes and Retries | Accepted | 2025-12-24 |
 | [ADR-015](02-architecture/decisions/ADR-015-pipeline-services-lifecycle.md) | Pipeline Services Lifecycle | Accepted | 2025-12-24 |
+| [ADR-016](02-architecture/decisions/ADR-016-error-handling-strategy.md) | Error Handling Strategy | Accepted | 2025-12-26 |
+| [ADR-017](02-architecture/decisions/ADR-017-observability-architecture.md) | Observability Architecture | Accepted | 2025-12-26 |
 
 ## История Изменений (Changelog)
 - **5.4** (2025-12-25): Architecture Documentation Update. Добавлены §1.1.2 (Health Check Protocol), §2.4.2 (Medallion Clear Policy), §4.4 (Python Standards), §5.3.2 (Async Cleanup). Реестр ADR расширен (011-015). Добавлено ограничение на structlog в application/interfaces (§4.3, тест `test_no_structlog_in_application_interfaces`). Добавлен deterministic mode для retry jitter (§3.1.3).


### PR DESCRIPTION
…tecture

Add two new Architecture Decision Records:

ADR-016: Error Handling Strategy
- Three-tier error classification (Critical/Recoverable/DataQuality)
- Circuit Breaker with 5-failure threshold
- Exponential backoff with deterministic jitter
- Unified Quarantine with 64KB truncation

ADR-017: Observability Architecture
- LoggerPort, MetricsPort, TracingPort as formal Protocols
- Prometheus metrics with standardized labels
- NoOp implementations for testing

Update RULES.md:
- Add new ADRs to Приложение F registry
- Add references in sections 3.1 and 3.2