### PR TITLE
Add error logging to health check method

### DIFF
--- a/src/bioetl/infrastructure/adapters/sync_base.py
+++ b/src/bioetl/infrastructure/adapters/sync_base.py
@@ -15,7 +15,8 @@ import weakref
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Self
 
-from bioetl.domain.ports import DataSourcePort, LoggerPort
+from bioetl.domain.ports import DataSourcePort, LoggerPort, MetricsPort
+from bioetl.domain.ports.noop import NoOpMetrics
 from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
 from bioetl.infrastructure.adapters.http.health import (
@@ -45,6 +46,7 @@ class BaseSyncAdapter(DataSourcePort):
 
     provider_name: str
     logger: LoggerPort
+    metrics: MetricsPort
     rate_limiter: TokenBucket
     circuit_breaker: CircuitBreaker
     thread_pool: ThreadPoolExecutor
@@ -57,6 +59,7 @@ class BaseSyncAdapter(DataSourcePort):
         circuit_breaker_timeout: int = 300,
         max_workers: int = 4,
         strict_error_handling: bool = False,
+        metrics: MetricsPort | None = None,
     ) -> None:
         """Initialize Sync Adapter resources.
 
@@ -67,9 +70,11 @@ class BaseSyncAdapter(DataSourcePort):
             circuit_breaker_timeout: Recovery timeout in seconds.
             max_workers: Thread pool size.
             strict_error_handling: Whether to raise exceptions or log warnings.
+            metrics: Optional MetricsPort for recording metrics.
 
         """
         self.logger = logger
+        self.metrics = metrics or NoOpMetrics()
         self.strict_error_handling = strict_error_handling
 
         # Common infrastructure components
@@ -117,7 +122,18 @@ class BaseSyncAdapter(DataSourcePort):
         """
         try:
             return await self._probe_health()
-        except Exception:
+        except Exception as e:
+            self.logger.warning(
+                "health_check_failed",
+                provider=self.provider_name,
+                error=str(e),
+                error_type=type(e).__name__,
+            )
+            self.metrics.increment_counter(
+                "health_check_failures_total",
+                1,
+                {"provider": self.provider_name},
+            )
             return self._fallback_health_status()
 
     async def _probe_health(self) -> HealthStatus:

--- a/src/bioetl/infrastructure/observability/metrics.py
+++ b/src/bioetl/infrastructure/observability/metrics.py
@@ -152,6 +152,12 @@ HEALTH_CHECK_DURATION_SECONDS = Histogram(
     buckets=[0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0],
 )
 
+HEALTH_CHECK_FAILURES_TOTAL = Counter(
+    "bioetl_health_check_failures_total",
+    "Total number of health check failures",
+    ["provider"],
+)
+
 
 class MetricsCollector:
     """Collector for pipeline metrics.

--- a/src/bioetl/infrastructure/observability/prometheus_metrics.py
+++ b/src/bioetl/infrastructure/observability/prometheus_metrics.py
@@ -23,6 +23,7 @@ from bioetl.infrastructure.observability.metrics import (
     ERRORS_TOTAL,
     FILTER_IDS_DUPLICATES_TOTAL,
     FILTER_IDS_LOADED_TOTAL,
+    HEALTH_CHECK_FAILURES_TOTAL,
     PIPELINE_DURATION_SECONDS,
     RECORDS_PROCESSED_TOTAL,
     VACUUM_DURATION_SECONDS,
@@ -52,6 +53,7 @@ COUNTERS = {
     "archive_files_total": ARCHIVE_FILES_TOTAL,
     "dq_anomaly_detected": DQ_ANOMALY_DETECTED,
     "dq_baseline_updated": DQ_BASELINE_UPDATED,
+    "health_check_failures_total": HEALTH_CHECK_FAILURES_TOTAL,
 }
 
 # Registry of gauge metrics

--- a/tests/infrastructure/adapters/test_sync_base.py
+++ b/tests/infrastructure/adapters/test_sync_base.py
@@ -1,0 +1,164 @@
+"""Tests for BaseSyncAdapter health_check logging and metrics."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from bioetl.domain.types import HealthStatus
+from bioetl.infrastructure.adapters.sync_base import BaseSyncAdapter
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+class ConcreteSyncAdapter(BaseSyncAdapter):
+    """Concrete implementation of BaseSyncAdapter for testing."""
+
+    provider_name: str = "test_provider"
+
+    async def fetch(
+        self,
+        entity_type: str,
+        limit: int | None = None,
+        query: str | None = None,
+        filter_ids: list[str] | None = None,
+        filter_field: str | None = None,
+    ) -> AsyncIterator[dict]:
+        """Fetch implementation for testing."""
+        yield {"id": 1}
+
+
+@pytest.fixture
+def mock_logger():
+    """Create a mock logger."""
+    logger = MagicMock()
+    logger.warning = MagicMock()
+    logger.info = MagicMock()
+    return logger
+
+
+@pytest.fixture
+def mock_metrics():
+    """Create a mock metrics port."""
+    metrics = MagicMock()
+    metrics.increment_counter = MagicMock()
+    return metrics
+
+
+@pytest.fixture
+def adapter_with_mocks(mock_logger, mock_metrics):
+    """Create adapter with mock logger and metrics."""
+    adapter = ConcreteSyncAdapter(
+        rate=10.0,
+        logger=mock_logger,
+        metrics=mock_metrics,
+    )
+    yield adapter
+    adapter.thread_pool.shutdown(wait=False)
+
+
+@pytest.fixture
+def adapter_failing_probe(mock_logger, mock_metrics):
+    """Create adapter with failing health probe."""
+
+    class FailingAdapter(ConcreteSyncAdapter):
+        async def _probe_health(self) -> HealthStatus:
+            raise ConnectionError("Connection refused")
+
+    adapter = FailingAdapter(
+        rate=10.0,
+        logger=mock_logger,
+        metrics=mock_metrics,
+    )
+    yield adapter
+    adapter.thread_pool.shutdown(wait=False)
+
+
+class TestHealthCheckLogging:
+    """Tests for health_check logging on failure."""
+
+    async def test_health_check_logs_warning_on_exception(
+        self, adapter_failing_probe, mock_logger
+    ):
+        """Verify warning is logged when health check fails."""
+        await adapter_failing_probe.health_check()
+
+        mock_logger.warning.assert_called_once()
+        call_kwargs = mock_logger.warning.call_args[1]
+
+        assert call_kwargs["provider"] == "test_provider"
+        assert "Connection refused" in call_kwargs["error"]
+        assert call_kwargs["error_type"] == "ConnectionError"
+
+    async def test_health_check_logs_event_name(
+        self, adapter_failing_probe, mock_logger
+    ):
+        """Verify correct event name is logged."""
+        await adapter_failing_probe.health_check()
+
+        call_args = mock_logger.warning.call_args[0]
+        assert call_args[0] == "health_check_failed"
+
+    async def test_health_check_no_logging_on_success(
+        self, adapter_with_mocks, mock_logger
+    ):
+        """Verify no warning logged when health check succeeds."""
+        # Default _probe_health returns fallback status without exception
+        await adapter_with_mocks.health_check()
+
+        mock_logger.warning.assert_not_called()
+
+
+class TestHealthCheckMetrics:
+    """Tests for health_check metrics on failure."""
+
+    async def test_health_check_increments_counter_on_exception(
+        self, adapter_failing_probe, mock_metrics
+    ):
+        """Verify counter is incremented when health check fails."""
+        await adapter_failing_probe.health_check()
+
+        mock_metrics.increment_counter.assert_called_once_with(
+            "health_check_failures_total",
+            1,
+            {"provider": "test_provider"},
+        )
+
+    async def test_health_check_no_metrics_on_success(
+        self, adapter_with_mocks, mock_metrics
+    ):
+        """Verify no counter increment when health check succeeds."""
+        await adapter_with_mocks.health_check()
+
+        mock_metrics.increment_counter.assert_not_called()
+
+    async def test_health_check_returns_fallback_status_on_failure(
+        self, adapter_failing_probe
+    ):
+        """Verify health check returns fallback status on exception."""
+        status = await adapter_failing_probe.health_check()
+
+        # With fresh circuit breaker (0 failures), fallback returns HEALTHY
+        assert status in (HealthStatus.HEALTHY, HealthStatus.DEGRADED)
+
+
+class TestMetricsDefaultToNoOp:
+    """Tests for default NoOp metrics behavior."""
+
+    async def test_adapter_works_without_explicit_metrics(self, mock_logger):
+        """Verify adapter works when no metrics port is provided."""
+
+        class FailingAdapter(ConcreteSyncAdapter):
+            async def _probe_health(self) -> HealthStatus:
+                raise RuntimeError("Test error")
+
+        adapter = FailingAdapter(rate=10.0, logger=mock_logger)
+        try:
+            # Should not raise - NoOpMetrics handles the call silently
+            status = await adapter.health_check()
+            assert status in (HealthStatus.HEALTHY, HealthStatus.DEGRADED)
+        finally:
+            adapter.thread_pool.shutdown(wait=False)


### PR DESCRIPTION
…th_check

Add warning logging and metrics increment when health check fails in BaseSyncAdapter. This improves observability for debugging health check failures in sync adapters.

Changes:
- Add MetricsPort as optional parameter to BaseSyncAdapter
- Log warning with provider, error, and error_type on health_check failure
- Increment health_check_failures_total counter on failure
- Add HEALTH_CHECK_FAILURES_TOTAL counter to prometheus metrics
- Add comprehensive unit tests for logging and metrics behavior