### PR TITLE
Fix dependency injection in BaseSyncAdapter

### DIFF
--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -398,12 +398,22 @@ class NewProviderAdapter(BaseHttpAdapter):
         self.provider_name = "new_provider"
 ```
 
-**Для sync-библиотек** используйте `BaseSyncAdapter`:
+**Для sync-библиотек** используйте `BaseSyncAdapter` с DI:
 ```python
 from bioetl.infrastructure.adapters.sync_base import BaseSyncAdapter
 
 class LegacyAdapter(BaseSyncAdapter):
     provider_name = "legacy"
+
+    def __init__(
+        self,
+        logger: LoggerPort,
+        rate_limiter: TokenBucket,
+        circuit_breaker: CircuitBreaker,
+        thread_pool: ThreadPoolExecutor,
+    ):
+        # Все зависимости инжектируются из Composition Root
+        super().__init__(logger, rate_limiter, circuit_breaker, thread_pool)
 
     async def fetch(self, ...):
         # Sync call wrapped in executor

--- a/src/bioetl/composition/providers/registration.py
+++ b/src/bioetl/composition/providers/registration.py
@@ -13,7 +13,8 @@ functions that were previously in DataSourceRegistry.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING, Any
 
 from bioetl.application.core.filtered_data_source import FilteredDataSource
 from bioetl.composition.providers.provider_registry import (
@@ -24,6 +25,8 @@ from bioetl.composition.providers.provider_registry import (
 
 # Import adapter classes from Infrastructure (allowed direction)
 from bioetl.infrastructure.adapters.chembl.client import ChemblAdapter
+from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
+from bioetl.infrastructure.adapters.http.rate_limiter import TokenBucket
 from bioetl.infrastructure.adapters.input.csv_filter_reader import CsvFilterReader
 from bioetl.infrastructure.adapters.pubchem.client import PubChemAdapter
 from bioetl.infrastructure.adapters.pubmed.pubmed_client import (
@@ -35,6 +38,7 @@ from bioetl.infrastructure.adapters.uniprot.client import UniProtAdapter
 if TYPE_CHECKING:
     from bioetl.domain.filter_config import InputFilterConfig
     from bioetl.domain.ports import DataSourcePort, LoggerPort, MetricsPort
+    from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
     from bioetl.infrastructure.config import Settings
     from bioetl.infrastructure.schemas.pipeline_config import PipelineYamlConfig
 
@@ -108,6 +112,62 @@ def _create_chembl_data_source(
     return _wrap_with_filter(base_adapter, filter_config, logger, metrics, pipeline_name)
 
 
+def _create_pubchem_adapter(
+    http_client: UnifiedHTTPClient | None = None,
+    logger: LoggerPort | None = None,
+    settings: Settings | None = None,
+    **kwargs: Any,
+) -> DataSourcePort:
+    """Create PubChem adapter with all dependencies injected.
+
+    This is the custom_creator for PubChem that creates all dependencies
+    in the Composition Root before creating the adapter.
+
+    Args:
+        http_client: Not used for PubChem (uses pubchempy).
+        logger: LoggerPort instance for structured logging.
+        settings: Application settings.
+        **kwargs: Additional keyword arguments (e.g., strict_error_handling).
+
+    Returns:
+        Configured PubChemAdapter instance.
+
+    Raises:
+        ValueError: If logger is not provided.
+    """
+    if logger is None:
+        raise ValueError(
+            "PubChem adapter requires logger but none was provided. "
+            "Ensure logger is passed from Composition Root."
+        )
+
+    # Get configuration parameters
+    rate = kwargs.pop("rate", 5.0)  # 5 req/sec per RULES.md
+    capacity = kwargs.pop("capacity", int(rate * 2))
+    circuit_breaker_threshold = kwargs.pop("circuit_breaker_threshold", 5)
+    circuit_breaker_timeout = kwargs.pop("circuit_breaker_timeout", 300)
+    max_workers = kwargs.pop("max_workers", 4)
+    strict_error_handling = kwargs.pop("strict_error_handling", False)
+
+    # Create dependencies in Composition Root (DI pattern)
+    rate_limiter = TokenBucket(rate=rate, capacity=capacity, provider="pubchem")
+    circuit_breaker = CircuitBreaker(
+        provider="pubchem",
+        failure_threshold=circuit_breaker_threshold,
+        recovery_timeout=circuit_breaker_timeout,
+    )
+    thread_pool = ThreadPoolExecutor(max_workers=max_workers)
+
+    # Create adapter with injected dependencies
+    return PubChemAdapter(
+        logger=logger,
+        rate_limiter=rate_limiter,
+        circuit_breaker=circuit_breaker,
+        thread_pool=thread_pool,
+        strict_error_handling=strict_error_handling,
+    )
+
+
 def _create_pubchem_data_source(
     settings: Settings,
     pipeline_config: PipelineYamlConfig,
@@ -117,11 +177,11 @@ def _create_pubchem_data_source(
     pipeline_name: str = "unknown",
 ) -> DataSourcePort:
     """Create PubChem data source with optional CSV filtering."""
-    DataSourceFactory, _ = _get_factories()
-    data_source = DataSourceFactory.create(
-        "pubchem",
+    # Create adapter via custom creator with all dependencies injected
+    data_source = _create_pubchem_adapter(
         http_client=None,
         logger=logger,
+        settings=settings,
         rate=5.0,
         strict_error_handling=settings.strict_error_handling,
     )
@@ -214,7 +274,9 @@ def register_all_providers() -> None:
             ),
         )
 
-    # PubChem - sync adapter (uses internal ThreadPoolExecutor)
+    # PubChem - sync adapter with DI-compliant custom creator
+    # Dependencies (TokenBucket, CircuitBreaker, ThreadPoolExecutor) are created
+    # in _create_pubchem_adapter following Composition Root pattern
     if not ProviderRegistry.is_registered("pubchem"):
         ProviderRegistry.register(
             "pubchem",
@@ -226,6 +288,7 @@ def register_all_providers() -> None:
                 ),
                 requires_http_client=False,
                 requires_logger=True,
+                custom_creator=_create_pubchem_adapter,
                 data_source_creator=_create_pubchem_data_source,
             ),
         )

--- a/src/bioetl/infrastructure/adapters/pubchem/client.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/client.py
@@ -13,6 +13,7 @@ Documentation: https://pubchemdocs.ncbi.nlm.nih.gov/pug-rest
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any
 
 import pubchempy as pcp
@@ -26,6 +27,8 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
     from bioetl.domain.ports import LoggerPort
+    from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
+    from bioetl.infrastructure.adapters.http.rate_limiter import TokenBucket
 
 
 class PubChemAdapter(BaseSyncAdapter):
@@ -34,14 +37,21 @@ class PubChemAdapter(BaseSyncAdapter):
     Provides access to chemical compound data from PubChem database.
     Uses pubchempy library which is synchronous, so runs in ThreadPoolExecutor.
 
+    All dependencies are injected via constructor (Composition Root pattern).
+
     Example:
-        >>> adapter = PubChemAdapter()
-        >>> # Search compounds by name
+        >>> # Dependencies created in Composition Root
+        >>> rate_limiter = TokenBucket(rate=5.0, capacity=10)
+        >>> circuit_breaker = CircuitBreaker(provider="pubchem")
+        >>> thread_pool = ThreadPoolExecutor(max_workers=4)
+        >>> adapter = PubChemAdapter(
+        ...     logger=logger,
+        ...     rate_limiter=rate_limiter,
+        ...     circuit_breaker=circuit_breaker,
+        ...     thread_pool=thread_pool,
+        ... )
         >>> async for compound in adapter.fetch("compound", query="aspirin", limit=10):
         ...     print(f"Compound: {compound['cid']}")
-        >>> # Check health
-        >>> status = await adapter.health_check()
-        >>> print(f"PubChem is {status}")
 
     """
 
@@ -50,29 +60,28 @@ class PubChemAdapter(BaseSyncAdapter):
     def __init__(
         self,
         logger: LoggerPort,
-        rate: float = 5.0,  # 5 req/sec per RULES.md
-        circuit_breaker_threshold: int = 5,
-        circuit_breaker_timeout: int = 300,
-        max_workers: int = 4,
+        rate_limiter: TokenBucket,
+        circuit_breaker: CircuitBreaker,
+        thread_pool: ThreadPoolExecutor,
         strict_error_handling: bool = False,
     ) -> None:
         """Initialize PubChem client.
 
+        All infrastructure components are injected from Composition Root.
+
         Args:
             logger: LoggerPort instance for structured logging.
-            rate: Requests per second (default: 5.0 per RULES.md).
-            circuit_breaker_threshold: Failures before opening circuit.
-            circuit_breaker_timeout: Recovery timeout in seconds.
-            max_workers: Thread pool size.
+            rate_limiter: Pre-configured token bucket rate limiter.
+            circuit_breaker: Pre-configured circuit breaker.
+            thread_pool: Pre-configured thread pool executor.
             strict_error_handling: Whether to raise exceptions or log warnings.
 
         """
         super().__init__(
-            rate=rate,
             logger=logger,
-            circuit_breaker_threshold=circuit_breaker_threshold,
-            circuit_breaker_timeout=circuit_breaker_timeout,
-            max_workers=max_workers,
+            rate_limiter=rate_limiter,
+            circuit_breaker=circuit_breaker,
+            thread_pool=thread_pool,
             strict_error_handling=strict_error_handling,
         )
 
@@ -261,7 +270,6 @@ class PubChemAdapter(BaseSyncAdapter):
             Exception: On request failure (base class handles via _fallback_health_status).
 
         Example:
-            >>> adapter = PubChemAdapter()
             >>> status = await adapter.health_check()
             >>> print(f"PubChem is {status.value}")
 

--- a/src/bioetl/infrastructure/adapters/sync_base.py
+++ b/src/bioetl/infrastructure/adapters/sync_base.py
@@ -13,21 +13,24 @@ from __future__ import annotations
 import asyncio
 import weakref
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Self
+from typing import TYPE_CHECKING, Any, Self
 
 from bioetl.domain.ports import DataSourcePort, LoggerPort
 from bioetl.domain.types import HealthStatus
-from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
 from bioetl.infrastructure.adapters.http.health import (
     assess_health_from_circuit_breaker,
 )
-from bioetl.infrastructure.adapters.http.rate_limiter import TokenBucket
+
+if TYPE_CHECKING:
+    from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
+    from bioetl.infrastructure.adapters.http.rate_limiter import TokenBucket
 
 
 class BaseSyncAdapter(DataSourcePort):
     """Base class for adapters using synchronous libraries.
 
     Manages a ThreadPoolExecutor, RateLimiter, and CircuitBreaker.
+    All dependencies are injected via constructor (Composition Root pattern).
 
     Uses Template Method pattern for health checks:
     - health_check(): Template method that handles try/except
@@ -37,9 +40,9 @@ class BaseSyncAdapter(DataSourcePort):
     Attributes:
         provider_name: Unique identifier for the data provider.
         logger: LoggerPort instance for structured logging.
-        rate_limiter: Token bucket rate limiter.
-        circuit_breaker: Circuit breaker for fault tolerance.
-        thread_pool: Thread pool for executing sync code.
+        rate_limiter: Token bucket rate limiter (injected).
+        circuit_breaker: Circuit breaker for fault tolerance (injected).
+        thread_pool: Thread pool for executing sync code (injected).
 
     """
 
@@ -51,35 +54,29 @@ class BaseSyncAdapter(DataSourcePort):
 
     def __init__(
         self,
-        rate: float,
         logger: LoggerPort,
-        circuit_breaker_threshold: int = 5,
-        circuit_breaker_timeout: int = 300,
-        max_workers: int = 4,
+        rate_limiter: TokenBucket,
+        circuit_breaker: CircuitBreaker,
+        thread_pool: ThreadPoolExecutor,
         strict_error_handling: bool = False,
     ) -> None:
         """Initialize Sync Adapter resources.
 
+        All infrastructure components are injected from Composition Root.
+
         Args:
-            rate: Requests per second.
             logger: LoggerPort instance for structured logging.
-            circuit_breaker_threshold: Failures before opening circuit.
-            circuit_breaker_timeout: Recovery timeout in seconds.
-            max_workers: Thread pool size.
+            rate_limiter: Pre-configured token bucket rate limiter.
+            circuit_breaker: Pre-configured circuit breaker.
+            thread_pool: Pre-configured thread pool executor.
             strict_error_handling: Whether to raise exceptions or log warnings.
 
         """
         self.logger = logger
+        self.rate_limiter = rate_limiter
+        self.circuit_breaker = circuit_breaker
+        self.thread_pool = thread_pool
         self.strict_error_handling = strict_error_handling
-
-        # Common infrastructure components
-        self.rate_limiter = TokenBucket(rate=rate, capacity=int(rate * 2))
-        self.circuit_breaker = CircuitBreaker(
-            provider=self.provider_name,
-            failure_threshold=circuit_breaker_threshold,
-            recovery_timeout=circuit_breaker_timeout,
-        )
-        self.thread_pool = ThreadPoolExecutor(max_workers=max_workers)
 
         # Safety: ensure shutdown if aclose/context manager is misused
         self._finalizer = weakref.finalize(self, self.thread_pool.shutdown, wait=False)

--- a/tests/infrastructure/adapters/test_pubchem.py
+++ b/tests/infrastructure/adapters/test_pubchem.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from bioetl.domain.types import HealthStatus
-from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreakerOpenError
+from bioetl.infrastructure.adapters.http.circuit_breaker import (
+    CircuitBreaker,
+    CircuitBreakerOpenError,
+)
+from bioetl.infrastructure.adapters.http.rate_limiter import TokenBucket
 from bioetl.infrastructure.adapters.pubchem.client import PubChemAdapter
 
 
@@ -18,11 +23,36 @@ def mock_logger():
 
 
 @pytest.fixture
-def pubchem_adapter(mock_logger):
-    adapter = PubChemAdapter(logger=mock_logger, rate=100)  # High rate to avoid delays
+def rate_limiter():
+    """Create a rate limiter for testing."""
+    return TokenBucket(rate=100.0, capacity=200, provider="pubchem")
+
+
+@pytest.fixture
+def circuit_breaker():
+    """Create a circuit breaker for testing."""
+    return CircuitBreaker(provider="pubchem", failure_threshold=5, recovery_timeout=300)
+
+
+@pytest.fixture
+def thread_pool():
+    """Create a thread pool for testing."""
+    pool = ThreadPoolExecutor(max_workers=4)
+    yield pool
+    pool.shutdown(wait=False)
+
+
+@pytest.fixture
+def pubchem_adapter(mock_logger, rate_limiter, circuit_breaker, thread_pool):
+    """Create PubChemAdapter with injected dependencies."""
+    adapter = PubChemAdapter(
+        logger=mock_logger,
+        rate_limiter=rate_limiter,
+        circuit_breaker=circuit_breaker,
+        thread_pool=thread_pool,
+    )
     yield adapter
-    # Cleanup logic if necessary (though close() calls shutdown on threadpool)
-    adapter.thread_pool.shutdown(wait=False)
+    # Thread pool cleanup is handled by thread_pool fixture
 
 
 @pytest.fixture

--- a/tests/unit/infrastructure/adapters/test_provider_names.py
+++ b/tests/unit/infrastructure/adapters/test_provider_names.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock
 
 import pytest
 
+from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
+from bioetl.infrastructure.adapters.http.rate_limiter import TokenBucket
 from bioetl.infrastructure.adapters.pubchem.client import PubChemAdapter
 from bioetl.infrastructure.adapters.uniprot.client import UniProtAdapter
 
@@ -18,12 +21,26 @@ class TestAdapterProviderNames:
         """Create a mock logger."""
         return MagicMock()
 
-    def test_pubchem_provider_name(self, mock_logger):
+    @pytest.fixture
+    def pubchem_dependencies(self):
+        """Create dependencies for PubChemAdapter."""
+        rate_limiter = TokenBucket(rate=5.0, capacity=10, provider="pubchem")
+        circuit_breaker = CircuitBreaker(provider="pubchem", failure_threshold=5)
+        thread_pool = ThreadPoolExecutor(max_workers=2)
+        yield rate_limiter, circuit_breaker, thread_pool
+        thread_pool.shutdown(wait=False)
+
+    def test_pubchem_provider_name(self, mock_logger, pubchem_dependencies):
         """Test PubChemAdapter provider name."""
-        adapter = PubChemAdapter(logger=mock_logger)
+        rate_limiter, circuit_breaker, thread_pool = pubchem_dependencies
+        adapter = PubChemAdapter(
+            logger=mock_logger,
+            rate_limiter=rate_limiter,
+            circuit_breaker=circuit_breaker,
+            thread_pool=thread_pool,
+        )
         assert adapter.provider_name == "pubchem"
         assert PubChemAdapter.provider_name == "pubchem"
-        adapter.close()
 
     def test_uniprot_provider_name(self, mock_logger):
         """Test UniProtAdapter provider name."""

--- a/tests/unit/infrastructure/test_adapters.py
+++ b/tests/unit/infrastructure/test_adapters.py
@@ -72,29 +72,81 @@ class TestPubChemAdapter:
         """Create a mock logger."""
         return MagicMock()
 
-    def test_adapter_creation(self, mock_logger):
-        """Test PubChem adapter can be created."""
-        adapter = PubChemAdapter(logger=mock_logger)
+    @pytest.fixture
+    def rate_limiter(self):
+        """Create a rate limiter for testing."""
+        return TokenBucket(rate=5.0, capacity=10, provider="pubchem")
+
+    @pytest.fixture
+    def circuit_breaker(self):
+        """Create a circuit breaker for testing."""
+        return CircuitBreaker(provider="pubchem", failure_threshold=5)
+
+    @pytest.fixture
+    def thread_pool(self):
+        """Create a thread pool for testing."""
+        from concurrent.futures import ThreadPoolExecutor
+
+        pool = ThreadPoolExecutor(max_workers=4)
+        yield pool
+        pool.shutdown(wait=False)
+
+    def test_adapter_creation(
+        self, mock_logger, rate_limiter, circuit_breaker, thread_pool
+    ):
+        """Test PubChem adapter can be created with DI."""
+        adapter = PubChemAdapter(
+            logger=mock_logger,
+            rate_limiter=rate_limiter,
+            circuit_breaker=circuit_breaker,
+            thread_pool=thread_pool,
+        )
 
         assert adapter.provider_name == "pubchem"
         assert adapter.rate_limiter.rate == 5.0  # 5 req/sec per RULES.md
 
-    def test_adapter_with_custom_rate(self, mock_logger):
-        """Test PubChem adapter with custom rate limit."""
-        adapter = PubChemAdapter(rate=10.0, logger=mock_logger)
+    def test_adapter_with_custom_rate(self, mock_logger, circuit_breaker, thread_pool):
+        """Test PubChem adapter with custom rate limit via injected rate limiter."""
+        custom_rate_limiter = TokenBucket(rate=10.0, capacity=20, provider="pubchem")
+        adapter = PubChemAdapter(
+            logger=mock_logger,
+            rate_limiter=custom_rate_limiter,
+            circuit_breaker=circuit_breaker,
+            thread_pool=thread_pool,
+        )
 
         assert adapter.rate_limiter.rate == 10.0
 
-    def test_thread_pool_created(self, mock_logger):
-        """Test thread pool is created for sync operations."""
-        adapter = PubChemAdapter(max_workers=2, logger=mock_logger)
+    def test_thread_pool_injected(
+        self, mock_logger, rate_limiter, circuit_breaker
+    ):
+        """Test thread pool is properly injected for sync operations."""
+        from concurrent.futures import ThreadPoolExecutor
 
-        assert adapter.thread_pool is not None
-        assert adapter.thread_pool._max_workers == 2
+        custom_pool = ThreadPoolExecutor(max_workers=2)
+        try:
+            adapter = PubChemAdapter(
+                logger=mock_logger,
+                rate_limiter=rate_limiter,
+                circuit_breaker=circuit_breaker,
+                thread_pool=custom_pool,
+            )
 
-    async def test_compound_to_dict(self, mock_logger):
+            assert adapter.thread_pool is not None
+            assert adapter.thread_pool._max_workers == 2
+        finally:
+            custom_pool.shutdown(wait=False)
+
+    async def test_compound_to_dict(
+        self, mock_logger, rate_limiter, circuit_breaker, thread_pool
+    ):
         """Test compound conversion to dictionary."""
-        adapter = PubChemAdapter(logger=mock_logger)
+        adapter = PubChemAdapter(
+            logger=mock_logger,
+            rate_limiter=rate_limiter,
+            circuit_breaker=circuit_breaker,
+            thread_pool=thread_pool,
+        )
 
         # Mock compound object
         class MockCompound:


### PR DESCRIPTION
Apply Composition Root pattern to BaseSyncAdapter:
- Remove internal creation of TokenBucket, CircuitBreaker, ThreadPoolExecutor
- Accept pre-configured dependencies via constructor injection
- Update PubChemAdapter to use injected dependencies
- Add custom_creator for PubChem in registration.py
- Update all related tests to use DI pattern
- Update RULES.md documentation example

This follows the MUST requirement from RULES.md Section 2.2: "Dependencies must be passed through constructor"