### PR TITLE
Extract services from PipelineRunner

### DIFF
--- a/src/bioetl/application/core/runner.py
+++ b/src/bioetl/application/core/runner.py
@@ -14,18 +14,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from bioetl.application.core.lock_manager import LockManager
 from bioetl.application.observability.observer import PipelineObserver
 
 if TYPE_CHECKING:
     from bioetl.application.core.base import BasePipeline
     from bioetl.application.core.checkpoint_manager import CheckpointManager
     from bioetl.application.core.executor import PipelineExecutor
-    from bioetl.application.core.lifecycle_orchestrator import LifecycleOrchestrator
-    # from bioetl.application.core.lock_manager import LockManager
     from bioetl.application.core.pipeline_services import PipelineServices
-    from bioetl.application.core.postrun_service import PostrunService
-    from bioetl.application.core.preflight_service import PreflightService
+    from bioetl.application.core.runner_services import RunnerServices
     from bioetl.application.core.shutdown import ShutdownSignal
     from bioetl.domain.config import PipelineConfig, RuntimeConfig
     from bioetl.domain.context import PipelineContext
@@ -54,10 +50,7 @@ class PipelineRunner:
         checkpoint_manager: CheckpointManager,
         shutdown_signal: ShutdownSignal,
         logger: LoggerPort,
-        lock_manager: LockManager,
-        preflight_service: PreflightService,
-        postrun_service: PostrunService,
-        lifecycle_orchestrator: LifecycleOrchestrator,
+        runner_services: RunnerServices,
         pipeline: BasePipeline | None = None,
         tracer: TracingPort | None = None,
     ) -> None:
@@ -72,10 +65,8 @@ class PipelineRunner:
             checkpoint_manager: Checkpoint manager.
             shutdown_signal: Shutdown signal for graceful termination.
             logger: Structured logger.
-            lock_manager: Lock manager for distributed locking.
-            preflight_service: Pre-flight infrastructure validation service.
-            postrun_service: Post-run DQ checks and VACUUM service.
-            lifecycle_orchestrator: Lifecycle orchestrator for medallion layer.
+            runner_services: Bundle of application services (lock, preflight,
+                postrun, lifecycle). Created via build_runner_services().
             pipeline: Optional pipeline instance.
             tracer: Optional tracing port.
         """
@@ -90,11 +81,11 @@ class PipelineRunner:
         self.pipeline = pipeline
         self._tracer = tracer
 
-        # Injected application services (created in composition layer)
-        self._lock_manager = lock_manager
-        self._preflight_service = preflight_service
-        self._postrun_service = postrun_service
-        self._lifecycle_orchestrator = lifecycle_orchestrator
+        # Extract services from RunnerServices bundle (created in composition layer)
+        self._lock_manager = runner_services.lock_manager
+        self._preflight_service = runner_services.preflight
+        self._postrun_service = runner_services.postrun
+        self._lifecycle_orchestrator = runner_services.lifecycle_orch
 
     @property
     def logger(self) -> LoggerPort:

--- a/src/bioetl/application/core/runner_services.py
+++ b/src/bioetl/application/core/runner_services.py
@@ -1,0 +1,33 @@
+"""Runner services bundle.
+
+Dataclass bundling services injected into PipelineRunner via DI.
+This bundle is created in the composition layer and passed to the runner.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bioetl.application.core.lifecycle_orchestrator import LifecycleOrchestrator
+    from bioetl.application.core.lock_manager import LockManager
+    from bioetl.application.core.postrun_service import PostrunService
+    from bioetl.application.core.preflight_service import PreflightService
+
+
+@dataclass(frozen=True)
+class RunnerServices:
+    """Bundle of services injected into PipelineRunner.
+
+    Attributes:
+        lock_manager: Distributed locking manager.
+        preflight: Pre-flight infrastructure validation service.
+        postrun: Post-run DQ checks and VACUUM service.
+        lifecycle_orch: Lifecycle orchestrator for medallion layer clearing.
+    """
+
+    lock_manager: LockManager
+    preflight: PreflightService
+    postrun: PostrunService
+    lifecycle_orch: LifecycleOrchestrator

--- a/src/bioetl/composition/factories/generic_factory.py
+++ b/src/bioetl/composition/factories/generic_factory.py
@@ -339,7 +339,7 @@ class GenericPipelineFactory(Generic[TPipeline]):
             lifecycle_service=lifecycle_service,
         )
 
-        # Assemble Runner with injected services
+        # Assemble Runner with injected RunnerServices bundle
         return PipelineRunner(
             config=pipeline.config,
             runtime=pipeline.runtime,
@@ -349,10 +349,7 @@ class GenericPipelineFactory(Generic[TPipeline]):
             checkpoint_manager=checkpoint_manager,
             shutdown_signal=pipeline.shutdown_signal,
             logger=observability.logger,
-            lock_manager=runner_services.lock_manager,
-            preflight_service=runner_services.preflight,
-            postrun_service=runner_services.postrun,
-            lifecycle_orchestrator=runner_services.lifecycle_orch,
+            runner_services=runner_services,
             pipeline=pipeline,
             tracer=observability.tracer,
         )

--- a/src/bioetl/composition/factories/runner_services.py
+++ b/src/bioetl/composition/factories/runner_services.py
@@ -8,13 +8,15 @@ and injected into PipelineRunner.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from bioetl.application.core.lifecycle_orchestrator import LifecycleOrchestrator
 from bioetl.application.core.lock_manager import LockManager
 from bioetl.application.core.postrun_service import PostrunService
 from bioetl.application.core.preflight_service import PreflightService
+
+# Re-export RunnerServices from application layer for backwards compatibility
+from bioetl.application.core.runner_services import RunnerServices
 
 if TYPE_CHECKING:
     from bioetl.application.core.checkpoint_manager import CheckpointManager
@@ -26,26 +28,6 @@ if TYPE_CHECKING:
     from bioetl.domain.config import PipelineConfig, RuntimeConfig
     from bioetl.domain.context import PipelineContext
     from bioetl.domain.ports import LoggerPort
-
-
-@dataclass(frozen=True, slots=True)
-class RunnerServices:
-    """Bundle of application services for PipelineRunner.
-
-    Encapsulates all services that PipelineRunner requires.
-    Created via build_runner_services() factory function.
-
-    Attributes:
-        lock_manager: Lock manager for distributed locking.
-        preflight: Pre-flight infrastructure validation service.
-        postrun: Post-run DQ checks and VACUUM service.
-        lifecycle_orch: Lifecycle orchestrator for medallion layer clearing.
-    """
-
-    lock_manager: LockManager
-    preflight: PreflightService
-    postrun: PostrunService
-    lifecycle_orch: LifecycleOrchestrator
 
 
 def build_runner_services(

--- a/tests/integration/test_runner_lifecycle.py
+++ b/tests/integration/test_runner_lifecycle.py
@@ -23,6 +23,7 @@ from bioetl.application.core.lock_manager import LockManager
 from bioetl.application.core.preflight_service import PreflightService
 from bioetl.application.core.postrun_service import PostrunService
 from bioetl.application.core.lifecycle_orchestrator import LifecycleOrchestrator
+from bioetl.application.core.runner_services import RunnerServices
 from bioetl.domain.config import PipelineConfig, RuntimeConfig
 from bioetl.domain.context import PipelineContext
 from bioetl.domain.types import RunType
@@ -296,36 +297,38 @@ class TestPipelineRunnerLifecycle:
             logger=mock_logger,
         )
 
-        with patch("bioetl.application.core.runner.LockManager") as mock_lm:
-            lock_manager = MagicMock()
+        lock_manager = MagicMock()
 
-            async def lm_aenter(self):
-                call_recorder.record("lock_manager.__aenter__")
-                return lock_manager
+        async def lm_aenter(self):
+            call_recorder.record("lock_manager.__aenter__")
+            return lock_manager
 
-            async def lm_aexit(self, *args):
-                call_recorder.record("lock_manager.__aexit__")
+        async def lm_aexit(self, *args):
+            call_recorder.record("lock_manager.__aexit__")
 
-            lock_manager.__aenter__ = lm_aenter
-            lock_manager.__aexit__ = lm_aexit
-            mock_lm.create.return_value = lock_manager
+        lock_manager.__aenter__ = lm_aenter
+        lock_manager.__aexit__ = lm_aexit
 
-            runner = PipelineRunner(
-                config=config,
-                runtime=runtime,
-                services=mock_services_with_recorder,
-                context=context,
-                executor=mock_executor_with_recorder,
-                checkpoint_manager=mock_checkpoint_manager_with_recorder,
-                shutdown_signal=MagicMock(),
-                logger=mock_logger,
-                lifecycle_orchestrator=mock_orchestrator,
-                preflight_service=mock_preflight_service,
-                postrun_service=mock_postrun_service,
-                lock_manager=lock_manager,
-            )
+        runner_services = RunnerServices(
+            lock_manager=lock_manager,
+            preflight=mock_preflight_service,
+            postrun=mock_postrun_service,
+            lifecycle_orch=mock_orchestrator,
+        )
 
-            await runner.run()
+        runner = PipelineRunner(
+            config=config,
+            runtime=runtime,
+            services=mock_services_with_recorder,
+            context=context,
+            executor=mock_executor_with_recorder,
+            checkpoint_manager=mock_checkpoint_manager_with_recorder,
+            shutdown_signal=MagicMock(),
+            logger=mock_logger,
+            runner_services=runner_services,
+        )
+
+        await runner.run()
 
         # Verify invariants - order matters!
         call_recorder.assert_order(
@@ -377,28 +380,30 @@ class TestPipelineRunnerLifecycle:
         orchestrator_no_clear = MagicMock(spec=LifecycleOrchestrator)
         orchestrator_no_clear.clear_for_run = AsyncMock(return_value=None)
 
-        with patch("bioetl.application.core.runner.LockManager") as mock_lm:
-            lock_manager = MagicMock()
-            lock_manager.__aenter__ = AsyncMock(return_value=lock_manager)
-            lock_manager.__aexit__ = AsyncMock()
-            mock_lm.create.return_value = lock_manager
+        lock_manager = MagicMock()
+        lock_manager.__aenter__ = AsyncMock(return_value=lock_manager)
+        lock_manager.__aexit__ = AsyncMock()
 
-            runner = PipelineRunner(
-                config=config,
-                runtime=runtime,
-                services=mock_services_with_recorder,
-                context=context,
-                executor=mock_executor_with_recorder,
-                checkpoint_manager=mock_checkpoint_manager_with_recorder,
-                shutdown_signal=MagicMock(),
-                logger=mock_logger,
-                lifecycle_orchestrator=orchestrator_no_clear,
-                preflight_service=mock_preflight_service,
-                postrun_service=mock_postrun_service,
-                lock_manager=lock_manager,
-            )
+        runner_services = RunnerServices(
+            lock_manager=lock_manager,
+            preflight=mock_preflight_service,
+            postrun=mock_postrun_service,
+            lifecycle_orch=orchestrator_no_clear,
+        )
 
-            await runner.run()
+        runner = PipelineRunner(
+            config=config,
+            runtime=runtime,
+            services=mock_services_with_recorder,
+            context=context,
+            executor=mock_executor_with_recorder,
+            checkpoint_manager=mock_checkpoint_manager_with_recorder,
+            shutdown_signal=MagicMock(),
+            logger=mock_logger,
+            runner_services=runner_services,
+        )
+
+        await runner.run()
 
         # Verify clear was NOT called
         calls = list(call_recorder.calls)
@@ -442,37 +447,39 @@ class TestPipelineRunnerLifecycle:
         failing_executor.execute = AsyncMock(side_effect=RuntimeError("Test error"))
         failing_executor.records_fetched = 0
 
-        with patch("bioetl.application.core.runner.LockManager") as mock_lm:
-            lock_manager = MagicMock()
+        lock_manager = MagicMock()
 
-            async def lm_aenter(self):
-                call_recorder.record("lock_manager.__aenter__")
-                return lock_manager
+        async def lm_aenter(self):
+            call_recorder.record("lock_manager.__aenter__")
+            return lock_manager
 
-            async def lm_aexit(self, *args):
-                call_recorder.record("lock_manager.__aexit__")
+        async def lm_aexit(self, *args):
+            call_recorder.record("lock_manager.__aexit__")
 
-            lock_manager.__aenter__ = lm_aenter
-            lock_manager.__aexit__ = lm_aexit
-            mock_lm.create.return_value = lock_manager
+        lock_manager.__aenter__ = lm_aenter
+        lock_manager.__aexit__ = lm_aexit
 
-            runner = PipelineRunner(
-                config=config,
-                runtime=runtime,
-                services=mock_services_with_recorder,
-                context=context,
-                executor=failing_executor,
-                checkpoint_manager=mock_checkpoint_manager_with_recorder,
-                shutdown_signal=MagicMock(),
-                logger=mock_logger,
-                lifecycle_orchestrator=mock_orchestrator,
-                preflight_service=mock_preflight_service,
-                postrun_service=mock_postrun_service,
-                lock_manager=lock_manager,
-            )
+        runner_services = RunnerServices(
+            lock_manager=lock_manager,
+            preflight=mock_preflight_service,
+            postrun=mock_postrun_service,
+            lifecycle_orch=mock_orchestrator,
+        )
 
-            with pytest.raises(RuntimeError, match="Test error"):
-                await runner.run()
+        runner = PipelineRunner(
+            config=config,
+            runtime=runtime,
+            services=mock_services_with_recorder,
+            context=context,
+            executor=failing_executor,
+            checkpoint_manager=mock_checkpoint_manager_with_recorder,
+            shutdown_signal=MagicMock(),
+            logger=mock_logger,
+            runner_services=runner_services,
+        )
+
+        with pytest.raises(RuntimeError, match="Test error"):
+            await runner.run()
 
         # Verify lock was released despite error
         calls = list(call_recorder.calls)
@@ -518,28 +525,30 @@ class TestPipelineRunnerLifecycle:
 
         mock_orchestrator.clear_for_run = AsyncMock(side_effect=clear_for_run)
 
-        with patch("bioetl.application.core.runner.LockManager") as mock_lm:
-            lock_manager = MagicMock()
-            lock_manager.__aenter__ = AsyncMock(return_value=lock_manager)
-            lock_manager.__aexit__ = AsyncMock()
-            mock_lm.create.return_value = lock_manager
+        lock_manager = MagicMock()
+        lock_manager.__aenter__ = AsyncMock(return_value=lock_manager)
+        lock_manager.__aexit__ = AsyncMock()
 
-            runner = PipelineRunner(
-                config=config,
-                runtime=runtime,
-                services=mock_services_with_recorder,
-                context=context,
-                executor=mock_executor_with_recorder,
-                checkpoint_manager=mock_checkpoint_manager_with_recorder,
-                shutdown_signal=MagicMock(),
-                logger=mock_logger,
-                lifecycle_orchestrator=mock_orchestrator,
-                preflight_service=mock_preflight_service,
-                postrun_service=mock_postrun_service,
-                lock_manager=lock_manager,
-            )
+        runner_services = RunnerServices(
+            lock_manager=lock_manager,
+            preflight=mock_preflight_service,
+            postrun=mock_postrun_service,
+            lifecycle_orch=mock_orchestrator,
+        )
 
-            await runner.run()
+        runner = PipelineRunner(
+            config=config,
+            runtime=runtime,
+            services=mock_services_with_recorder,
+            context=context,
+            executor=mock_executor_with_recorder,
+            checkpoint_manager=mock_checkpoint_manager_with_recorder,
+            shutdown_signal=MagicMock(),
+            logger=mock_logger,
+            runner_services=runner_services,
+        )
+
+        await runner.run()
 
         # Verify clear WAS called for backfill
         calls = list(call_recorder.calls)
@@ -586,40 +595,42 @@ class TestPipelineRunnerLifecycle:
             side_effect=InfrastructureError("health check failed")
         )
 
-        with patch("bioetl.application.core.runner.LockManager") as mock_lm:
-            lock_manager = MagicMock()
+        lock_manager = MagicMock()
 
-            async def lm_aenter(self):
-                call_recorder.record("lock_manager.__aenter__")
-                return lock_manager
+        async def lm_aenter(self):
+            call_recorder.record("lock_manager.__aenter__")
+            return lock_manager
 
-            async def lm_aexit(self, *args):
-                call_recorder.record("lock_manager.__aexit__")
+        async def lm_aexit(self, *args):
+            call_recorder.record("lock_manager.__aexit__")
 
-            lock_manager.__aenter__ = lm_aenter
-            lock_manager.__aexit__ = lm_aexit
-            mock_lm.create.return_value = lock_manager
+        lock_manager.__aenter__ = lm_aenter
+        lock_manager.__aexit__ = lm_aexit
 
-            runner = PipelineRunner(
-                config=config,
-                runtime=runtime,
-                services=mock_services_with_recorder,
-                context=context,
-                executor=mock_executor_with_recorder,
-                checkpoint_manager=mock_checkpoint_manager_with_recorder,
-                shutdown_signal=MagicMock(),
-                logger=mock_logger,
-                lifecycle_orchestrator=mock_orchestrator,
-                preflight_service=mock_preflight_service,
-                postrun_service=mock_postrun_service,
-                lock_manager=lock_manager,
-            )
+        runner_services = RunnerServices(
+            lock_manager=lock_manager,
+            preflight=mock_preflight_service,
+            postrun=mock_postrun_service,
+            lifecycle_orch=mock_orchestrator,
+        )
 
-            with pytest.raises(InfrastructureError) as exc_info:
-                await runner.run()
+        runner = PipelineRunner(
+            config=config,
+            runtime=runtime,
+            services=mock_services_with_recorder,
+            context=context,
+            executor=mock_executor_with_recorder,
+            checkpoint_manager=mock_checkpoint_manager_with_recorder,
+            shutdown_signal=MagicMock(),
+            logger=mock_logger,
+            runner_services=runner_services,
+        )
 
-            # Verify the error message indicates health check failure
-            assert "health check failed" in str(exc_info.value).lower()
+        with pytest.raises(InfrastructureError) as exc_info:
+            await runner.run()
+
+        # Verify the error message indicates health check failure
+        assert "health check failed" in str(exc_info.value).lower()
 
         # Verify executor was NEVER called
         calls = list(call_recorder.calls)
@@ -753,28 +764,30 @@ class TestPipelineRunnerLifecycle:
         checkpoint_manager.load_checkpoint = load_checkpoint
         checkpoint_manager.delete_checkpoint = delete_checkpoint
 
-        with patch("bioetl.application.core.runner.LockManager") as mock_lm:
-            lock_manager = MagicMock()
-            lock_manager.__aenter__ = AsyncMock(return_value=lock_manager)
-            lock_manager.__aexit__ = AsyncMock()
-            mock_lm.create.return_value = lock_manager
+        lock_manager = MagicMock()
+        lock_manager.__aenter__ = AsyncMock(return_value=lock_manager)
+        lock_manager.__aexit__ = AsyncMock()
 
-            runner = PipelineRunner(
-                config=config,
-                runtime=runtime,
-                services=mock_services_with_recorder,
-                context=context,
-                executor=mock_executor_with_recorder,
-                checkpoint_manager=checkpoint_manager,
-                shutdown_signal=MagicMock(),
-                logger=mock_logger,
-                lifecycle_orchestrator=mock_orchestrator,
-                preflight_service=mock_preflight_service,
-                postrun_service=mock_postrun_service,
-                lock_manager=lock_manager,
-            )
+        runner_services = RunnerServices(
+            lock_manager=lock_manager,
+            preflight=mock_preflight_service,
+            postrun=mock_postrun_service,
+            lifecycle_orch=mock_orchestrator,
+        )
 
-            await runner.run()
+        runner = PipelineRunner(
+            config=config,
+            runtime=runtime,
+            services=mock_services_with_recorder,
+            context=context,
+            executor=mock_executor_with_recorder,
+            checkpoint_manager=checkpoint_manager,
+            shutdown_signal=MagicMock(),
+            logger=mock_logger,
+            runner_services=runner_services,
+        )
+
+        await runner.run()
 
         # Verify checkpoint was loaded
         assert checkpoint_loaded, "Checkpoint must be loaded for resume"
@@ -872,28 +885,30 @@ class TestPipelineRunnerLifecycle:
 
         mock_postrun_service.run_dq_checks = AsyncMock(side_effect=run_dq_checks)
 
-        with patch("bioetl.application.core.runner.LockManager") as mock_lm:
-            lock_manager = MagicMock()
-            lock_manager.__aenter__ = AsyncMock(return_value=lock_manager)
-            lock_manager.__aexit__ = AsyncMock()
-            mock_lm.create.return_value = lock_manager
+        lock_manager = MagicMock()
+        lock_manager.__aenter__ = AsyncMock(return_value=lock_manager)
+        lock_manager.__aexit__ = AsyncMock()
 
-            runner = PipelineRunner(
-                config=config,
-                runtime=runtime,
-                services=services_with_dq,
-                context=context,
-                executor=mock_executor_with_recorder,
-                checkpoint_manager=mock_checkpoint_manager_with_recorder,
-                shutdown_signal=MagicMock(),
-                logger=mock_logger,
-                lifecycle_orchestrator=mock_orchestrator,
-                preflight_service=mock_preflight_service,
-                postrun_service=mock_postrun_service,
-                lock_manager=lock_manager,
-            )
+        runner_services = RunnerServices(
+            lock_manager=lock_manager,
+            preflight=mock_preflight_service,
+            postrun=mock_postrun_service,
+            lifecycle_orch=mock_orchestrator,
+        )
 
-            await runner.run()
+        runner = PipelineRunner(
+            config=config,
+            runtime=runtime,
+            services=services_with_dq,
+            context=context,
+            executor=mock_executor_with_recorder,
+            checkpoint_manager=mock_checkpoint_manager_with_recorder,
+            shutdown_signal=MagicMock(),
+            logger=mock_logger,
+            runner_services=runner_services,
+        )
+
+        await runner.run()
 
         # Verify DQ check was called
         dq_monitor.check_quality.assert_called_once()
@@ -943,28 +958,30 @@ class TestPipelineRunnerLifecycle:
 
         mock_postrun_service.run_vacuum_if_enabled = AsyncMock(side_effect=run_vacuum_if_enabled)
 
-        with patch("bioetl.application.core.runner.LockManager") as mock_lm:
-            lock_manager = MagicMock()
-            lock_manager.__aenter__ = AsyncMock(return_value=lock_manager)
-            lock_manager.__aexit__ = AsyncMock()
-            mock_lm.create.return_value = lock_manager
+        lock_manager = MagicMock()
+        lock_manager.__aenter__ = AsyncMock(return_value=lock_manager)
+        lock_manager.__aexit__ = AsyncMock()
 
-            runner = PipelineRunner(
-                config=config,
-                runtime=runtime,
-                services=mock_services_with_recorder,
-                context=context,
-                executor=mock_executor_with_recorder,
-                checkpoint_manager=mock_checkpoint_manager_with_recorder,
-                shutdown_signal=MagicMock(),
-                logger=mock_logger,
-                lifecycle_orchestrator=mock_orchestrator,
-                preflight_service=mock_preflight_service,
-                postrun_service=mock_postrun_service,
-                lock_manager=lock_manager,
-            )
+        runner_services = RunnerServices(
+            lock_manager=lock_manager,
+            preflight=mock_preflight_service,
+            postrun=mock_postrun_service,
+            lifecycle_orch=mock_orchestrator,
+        )
 
-            await runner.run()
+        runner = PipelineRunner(
+            config=config,
+            runtime=runtime,
+            services=mock_services_with_recorder,
+            context=context,
+            executor=mock_executor_with_recorder,
+            checkpoint_manager=mock_checkpoint_manager_with_recorder,
+            shutdown_signal=MagicMock(),
+            logger=mock_logger,
+            runner_services=runner_services,
+        )
+
+        await runner.run()
 
         # Verify vacuum was called
         assert "postrun.vacuum" in list(call_recorder.calls)

--- a/tests/unit/application/core/test_runner.py
+++ b/tests/unit/application/core/test_runner.py
@@ -14,6 +14,7 @@ from bioetl.application.core.pipeline_services import PipelineServices
 from bioetl.application.core.postrun_service import PostrunService
 from bioetl.application.core.preflight_service import PreflightService
 from bioetl.application.core.runner import PipelineRunner
+from bioetl.application.core.runner_services import RunnerServices
 from bioetl.application.core.shutdown import PipelineShutdownError, ShutdownSignal
 from bioetl.domain.config import PipelineConfig, RuntimeConfig
 from bioetl.domain.context import PipelineContext
@@ -90,8 +91,8 @@ def create_mock_runner_services(
     preflight_service=None,
     postrun_service=None,
     lifecycle_orchestrator=None,
-):
-    """Create mock runner services for DI injection.
+) -> RunnerServices:
+    """Create mock RunnerServices for DI injection.
 
     Args:
         lock_manager: Optional custom lock manager mock.
@@ -100,7 +101,7 @@ def create_mock_runner_services(
         lifecycle_orchestrator: Optional custom lifecycle orchestrator mock.
 
     Returns:
-        Tuple of (lock_manager, preflight_service, postrun_service, lifecycle_orchestrator)
+        RunnerServices bundle with mock services.
     """
     from bioetl.application.core.lifecycle_orchestrator import ClearDecision
     from bioetl.application.core.postrun_service import DQResult, VacuumResult
@@ -142,7 +143,12 @@ def create_mock_runner_services(
             )
         )
 
-    return lock_manager, preflight_service, postrun_service, lifecycle_orchestrator
+    return RunnerServices(
+        lock_manager=lock_manager,
+        preflight=preflight_service,
+        postrun=postrun_service,
+        lifecycle_orch=lifecycle_orchestrator,
+    )
 
 
 @pytest.fixture
@@ -259,6 +265,22 @@ def mock_lifecycle_service():
 
 
 @pytest.fixture
+def mock_runner_services(
+    mock_lock_manager,
+    mock_preflight_service,
+    mock_postrun_service,
+    mock_lifecycle_orchestrator,
+):
+    """Create a mock RunnerServices bundle for PipelineRunner."""
+    return RunnerServices(
+        lock_manager=mock_lock_manager,
+        preflight=mock_preflight_service,
+        postrun=mock_postrun_service,
+        lifecycle_orch=mock_lifecycle_orchestrator,
+    )
+
+
+@pytest.fixture
 def runner(
     pipeline_config,
     runtime_config,
@@ -268,12 +290,9 @@ def runner(
     mock_checkpoint_manager,
     shutdown_signal,
     mock_logger,
-    mock_lock_manager,
-    mock_preflight_service,
-    mock_postrun_service,
-    mock_lifecycle_orchestrator,
+    mock_runner_services,
 ):
-    """Create a PipelineRunner instance with injected services (DI pattern)."""
+    """Create a PipelineRunner instance with injected RunnerServices (DI pattern)."""
     return PipelineRunner(
         config=pipeline_config,
         runtime=runtime_config,
@@ -283,10 +302,7 @@ def runner(
         checkpoint_manager=mock_checkpoint_manager,
         shutdown_signal=shutdown_signal,
         logger=mock_logger,
-        lock_manager=mock_lock_manager,
-        preflight_service=mock_preflight_service,
-        postrun_service=mock_postrun_service,
-        lifecycle_orchestrator=mock_lifecycle_orchestrator,
+        runner_services=mock_runner_services,
     )
 
 
@@ -304,12 +320,9 @@ class TestPipelineRunnerInit:
         mock_checkpoint_manager,
         shutdown_signal,
         mock_logger,
-        mock_lock_manager,
-        mock_preflight_service,
-        mock_postrun_service,
-        mock_lifecycle_orchestrator,
+        mock_runner_services,
     ):
-        """Test runner initializes correctly with injected services."""
+        """Test runner initializes correctly with injected RunnerServices."""
         runner = PipelineRunner(
             config=pipeline_config,
             runtime=runtime_config,
@@ -319,20 +332,17 @@ class TestPipelineRunnerInit:
             checkpoint_manager=mock_checkpoint_manager,
             shutdown_signal=shutdown_signal,
             logger=mock_logger,
-            lock_manager=mock_lock_manager,
-            preflight_service=mock_preflight_service,
-            postrun_service=mock_postrun_service,
-            lifecycle_orchestrator=mock_lifecycle_orchestrator,
+            runner_services=mock_runner_services,
         )
 
         assert runner._config == pipeline_config
         assert runner._runtime == runtime_config
         assert runner.shutdown_signal == shutdown_signal
-        # Verify injected services are stored correctly
-        assert runner._lock_manager == mock_lock_manager
-        assert runner._preflight_service == mock_preflight_service
-        assert runner._postrun_service == mock_postrun_service
-        assert runner._lifecycle_orchestrator == mock_lifecycle_orchestrator
+        # Verify services are extracted from RunnerServices
+        assert runner._lock_manager == mock_runner_services.lock_manager
+        assert runner._preflight_service == mock_runner_services.preflight
+        assert runner._postrun_service == mock_runner_services.postrun
+        assert runner._lifecycle_orchestrator == mock_runner_services.lifecycle_orch
 
     def test_services_are_injected_not_created(
         self,
@@ -344,12 +354,9 @@ class TestPipelineRunnerInit:
         mock_checkpoint_manager,
         shutdown_signal,
         mock_logger,
-        mock_lock_manager,
-        mock_preflight_service,
-        mock_postrun_service,
-        mock_lifecycle_orchestrator,
+        mock_runner_services,
     ):
-        """Test services are injected via DI, not created internally."""
+        """Test services are injected via DI (RunnerServices), not created internally."""
         runner = PipelineRunner(
             config=pipeline_config,
             runtime=runtime_config,
@@ -359,17 +366,14 @@ class TestPipelineRunnerInit:
             checkpoint_manager=mock_checkpoint_manager,
             shutdown_signal=shutdown_signal,
             logger=mock_logger,
-            lock_manager=mock_lock_manager,
-            preflight_service=mock_preflight_service,
-            postrun_service=mock_postrun_service,
-            lifecycle_orchestrator=mock_lifecycle_orchestrator,
+            runner_services=mock_runner_services,
         )
 
-        # The exact same instances should be used (DI, not recreation)
-        assert runner._lock_manager is mock_lock_manager
-        assert runner._preflight_service is mock_preflight_service
-        assert runner._postrun_service is mock_postrun_service
-        assert runner._lifecycle_orchestrator is mock_lifecycle_orchestrator
+        # The exact same instances from RunnerServices should be used (DI)
+        assert runner._lock_manager is mock_runner_services.lock_manager
+        assert runner._preflight_service is mock_runner_services.preflight
+        assert runner._postrun_service is mock_runner_services.postrun
+        assert runner._lifecycle_orchestrator is mock_runner_services.lifecycle_orch
 
 
 @pytest.mark.unit
@@ -508,10 +512,7 @@ class TestPipelineRunnerRun:
         mock_checkpoint_manager,
         shutdown_signal,
         mock_logger,
-        mock_lock_manager,
-        mock_preflight_service,
-        mock_postrun_service,
-        mock_lifecycle_orchestrator,
+        mock_runner_services,
     ):
         """Test run passes limit to executor."""
         runtime_with_limit = RuntimeConfig(
@@ -527,10 +528,7 @@ class TestPipelineRunnerRun:
             checkpoint_manager=mock_checkpoint_manager,
             shutdown_signal=shutdown_signal,
             logger=mock_logger,
-            lock_manager=mock_lock_manager,
-            preflight_service=mock_preflight_service,
-            postrun_service=mock_postrun_service,
-            lifecycle_orchestrator=mock_lifecycle_orchestrator,
+            runner_services=mock_runner_services,
         )
 
         await runner.run()
@@ -577,6 +575,13 @@ class TestPipelineRunnerClearViaLifecycle:
             )
         )
 
+        runner_services = RunnerServices(
+            lock_manager=mock_lock_manager,
+            preflight=mock_preflight_service,
+            postrun=mock_postrun_service,
+            lifecycle_orch=lifecycle_orchestrator,
+        )
+
         runner = PipelineRunner(
             config=pipeline_config,
             runtime=runtime_config,
@@ -586,10 +591,7 @@ class TestPipelineRunnerClearViaLifecycle:
             checkpoint_manager=mock_checkpoint_manager,
             shutdown_signal=shutdown_signal,
             logger=mock_logger,
-            lock_manager=mock_lock_manager,
-            preflight_service=mock_preflight_service,
-            postrun_service=mock_postrun_service,
-            lifecycle_orchestrator=lifecycle_orchestrator,
+            runner_services=runner_services,
         )
 
         await runner._clear_via_lifecycle()
@@ -625,6 +627,13 @@ class TestPipelineRunnerClearViaLifecycle:
             )
         )
 
+        runner_services = RunnerServices(
+            lock_manager=mock_lock_manager,
+            preflight=mock_preflight_service,
+            postrun=mock_postrun_service,
+            lifecycle_orch=lifecycle_orchestrator,
+        )
+
         runner = PipelineRunner(
             config=pipeline_config,
             runtime=runtime_config,
@@ -634,10 +643,7 @@ class TestPipelineRunnerClearViaLifecycle:
             checkpoint_manager=mock_checkpoint_manager,
             shutdown_signal=shutdown_signal,
             logger=mock_logger,
-            lock_manager=mock_lock_manager,
-            preflight_service=mock_preflight_service,
-            postrun_service=mock_postrun_service,
-            lifecycle_orchestrator=lifecycle_orchestrator,
+            runner_services=runner_services,
         )
 
         await runner.run()
@@ -695,6 +701,13 @@ class TestPipelineRunnerCheckDataQuality:
         )
         postrun_service.cleanup = AsyncMock()
 
+        runner_services = RunnerServices(
+            lock_manager=mock_lock_manager,
+            preflight=mock_preflight_service,
+            postrun=postrun_service,
+            lifecycle_orch=mock_lifecycle_orchestrator,
+        )
+
         runner = PipelineRunner(
             config=pipeline_config,
             runtime=runtime_config,
@@ -704,10 +717,7 @@ class TestPipelineRunnerCheckDataQuality:
             checkpoint_manager=mock_checkpoint_manager,
             shutdown_signal=shutdown_signal,
             logger=mock_logger,
-            lock_manager=mock_lock_manager,
-            preflight_service=mock_preflight_service,
-            postrun_service=postrun_service,
-            lifecycle_orchestrator=mock_lifecycle_orchestrator,
+            runner_services=runner_services,
         )
 
         await runner._check_data_quality()
@@ -747,6 +757,13 @@ class TestPipelineRunnerCheckDataQuality:
         )
         postrun_service.cleanup = AsyncMock()
 
+        runner_services = RunnerServices(
+            lock_manager=mock_lock_manager,
+            preflight=mock_preflight_service,
+            postrun=postrun_service,
+            lifecycle_orch=mock_lifecycle_orchestrator,
+        )
+
         runner = PipelineRunner(
             config=pipeline_config,
             runtime=runtime_config,
@@ -756,10 +773,7 @@ class TestPipelineRunnerCheckDataQuality:
             checkpoint_manager=mock_checkpoint_manager,
             shutdown_signal=shutdown_signal,
             logger=mock_logger,
-            lock_manager=mock_lock_manager,
-            preflight_service=mock_preflight_service,
-            postrun_service=postrun_service,
-            lifecycle_orchestrator=mock_lifecycle_orchestrator,
+            runner_services=runner_services,
         )
 
         await runner.run()


### PR DESCRIPTION
PipelineRunner now accepts a single RunnerServices dataclass instead of individual service parameters. This follows the DI pattern where services are bundled in the composition layer and injected as a single unit.

Changes:
- Add RunnerServices dataclass to application/core/runner_services.py
- Update PipelineRunner.__init__() to accept runner_services parameter
- Update GenericPipelineFactory.create_runner() to pass RunnerServices
- Update composition/factories/runner_services.py to re-export from application
- Update tests to use RunnerServices bundle pattern
- Remove patching of LockManager (now injected directly via RunnerServices)