### PR TITLE
Implement TTL expiration for MemoryLock

### DIFF
--- a/src/bioetl/infrastructure/locking/memory_lock.py
+++ b/src/bioetl/infrastructure/locking/memory_lock.py
@@ -6,19 +6,62 @@ This lock is not distributed and only works within a single process.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import time
 
 from bioetl.domain.ports import LockPort
 from bioetl.domain.types import RunID
 
+# Default TTL check interval in seconds
+_TTL_CHECK_INTERVAL = 1.0
+
 
 class MemoryLock(LockPort):
-    """A simple in-memory lock for local development and testing."""
+    """A simple in-memory lock for local development and testing.
 
-    def __init__(self) -> None:
-        """Initialize memory lock."""
-        self._locks: dict[str, tuple[str, asyncio.Lock]] = {}
+    Supports TTL-based automatic lock expiration via a background task.
+    """
+
+    def __init__(self, ttl_check_interval: float = _TTL_CHECK_INTERVAL) -> None:
+        """Initialize memory lock.
+
+        Args:
+            ttl_check_interval: Interval in seconds between TTL checks.
+        """
+        # Lock data: key -> (owner_id, asyncio.Lock, expires_at, original_ttl)
+        self._locks: dict[str, tuple[str, asyncio.Lock, float | None, int | None]] = {}
         self._global_lock = asyncio.Lock()
+        self._ttl_check_interval = ttl_check_interval
+        self._ttl_checker_task: asyncio.Task[None] | None = None
+        self._closed = False
+
+    async def _start_ttl_checker(self) -> None:
+        """Start the TTL checker background task if not already running."""
+        if self._ttl_checker_task is None or self._ttl_checker_task.done():
+            self._ttl_checker_task = asyncio.create_task(self._ttl_checker_loop())
+
+    async def _ttl_checker_loop(self) -> None:
+        """Background task to check and release expired locks."""
+        while not self._closed:
+            await asyncio.sleep(self._ttl_check_interval)
+            await self._release_expired_locks()
+
+    async def _release_expired_locks(self) -> None:
+        """Release all locks that have exceeded their TTL."""
+        current_time = time.monotonic()
+        async with self._global_lock:
+            expired_keys = [
+                key
+                for key, (_, lock, expires_at, _) in self._locks.items()
+                if expires_at is not None
+                and current_time > expires_at
+                and lock.locked()
+            ]
+            for key in expired_keys:
+                _, lock, _, _ = self._locks[key]
+                if lock.locked():
+                    lock.release()
+                del self._locks[key]
 
     async def _try_acquire(
         self,
@@ -31,7 +74,7 @@ class MemoryLock(LockPort):
         Args:
             key: Lock key.
             owner_id: Owner identifier.
-            ttl: Time-to-live (unused in memory lock).
+            ttl: Time-to-live in seconds. If None, lock does not expire.
 
         Returns:
             True if lock was acquired, False otherwise.
@@ -39,19 +82,24 @@ class MemoryLock(LockPort):
         """
         async with self._global_lock:
             if key in self._locks:
-                _existing_owner, lock = self._locks[key]
+                _existing_owner, lock, _, _ = self._locks[key]
                 if lock.locked():
                     # Strictly non-reentrant: cannot acquire if already locked
                     return False
 
+            # Calculate expiration time
+            expires_at: float | None = None
+            if ttl is not None:
+                expires_at = time.monotonic() + ttl
+
             # Create new lock or reuse existing unlocked one
             if key not in self._locks:
                 lock = asyncio.Lock()
-                self._locks[key] = (str(owner_id), lock)
+                self._locks[key] = (str(owner_id), lock, expires_at, ttl)
             else:
                 # Lock exists but is not locked - update owner and reuse
-                _, lock = self._locks[key]
-                self._locks[key] = (str(owner_id), lock)
+                _, lock, _, _ = self._locks[key]
+                self._locks[key] = (str(owner_id), lock, expires_at, ttl)
 
             # Acquire the asyncio.Lock
             if not lock.locked():
@@ -74,7 +122,7 @@ class MemoryLock(LockPort):
         Args:
             key: Lock key.
             owner_id: Owner identifier.
-            ttl: Time-to-live (unused in memory lock).
+            ttl: Time-to-live in seconds. If set, lock expires after TTL.
             wait: If True, wait for lock to become available.
             wait_timeout: Maximum time to wait in seconds.
             exclusive: Exclusive lock flag (unused in memory lock).
@@ -83,6 +131,10 @@ class MemoryLock(LockPort):
             True if lock was acquired, False otherwise.
 
         """
+        # Start TTL checker if acquiring with TTL
+        if ttl is not None:
+            await self._start_ttl_checker()
+
         # Try to acquire immediately
         if await self._try_acquire(key, owner_id, ttl):
             return True
@@ -111,7 +163,7 @@ class MemoryLock(LockPort):
             if key not in self._locks:
                 return False
 
-            existing_owner, lock = self._locks[key]
+            existing_owner, lock, _, _ = self._locks[key]
             if existing_owner != str(owner_id):
                 return False
 
@@ -127,17 +179,43 @@ class MemoryLock(LockPort):
         owner_id: RunID,
         exclusive: bool = False,
     ) -> bool:
-        """Heartbeat a lock."""
+        """Heartbeat a lock to extend its TTL.
+
+        Args:
+            key: Lock key.
+            owner_id: Owner identifier.
+            exclusive: Exclusive lock flag (unused in memory lock).
+
+        Returns:
+            True if heartbeat succeeded, False otherwise.
+        """
         async with self._global_lock:
             if key not in self._locks:
                 return False
-            existing_owner, _lock = self._locks[key]
-            return existing_owner == str(owner_id)
+            existing_owner, lock, _, original_ttl = self._locks[key]
+            if existing_owner != str(owner_id):
+                return False
+
+            # Extend TTL using the original TTL value
+            if original_ttl is not None:
+                new_expires_at = time.monotonic() + original_ttl
+                self._locks[key] = (existing_owner, lock, new_expires_at, original_ttl)
+
+            return True
 
     async def aclose(self) -> None:
-        """Close all locks."""
+        """Close all locks and stop background tasks."""
+        self._closed = True
+
+        # Stop the TTL checker task
+        if self._ttl_checker_task is not None:
+            self._ttl_checker_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._ttl_checker_task
+            self._ttl_checker_task = None
+
         async with self._global_lock:
-            for _, (_, lock) in self._locks.items():
+            for _, (_, lock, _, _) in self._locks.items():
                 if lock.locked():
                     lock.release()
             self._locks.clear()

--- a/tests/unit/infrastructure/locking/test_memory_lock.py
+++ b/tests/unit/infrastructure/locking/test_memory_lock.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from bioetl.infrastructure.locking.memory_lock import MemoryLock
@@ -11,6 +13,12 @@ from bioetl.infrastructure.locking.memory_lock import MemoryLock
 def memory_lock():
     """Create a MemoryLock instance."""
     return MemoryLock()
+
+
+@pytest.fixture
+def fast_ttl_lock():
+    """Create a MemoryLock with fast TTL checking for tests."""
+    return MemoryLock(ttl_check_interval=0.05)
 
 
 @pytest.mark.unit
@@ -115,3 +123,181 @@ class TestMemoryLock:
             owner_id="owner_1",
         )
         assert result is False
+
+    @pytest.mark.asyncio
+    async def test_aclose_releases_locks(self, memory_lock):
+        """Test aclose releases all locks."""
+        await memory_lock.acquire(key="key1", owner_id="owner_1")
+        await memory_lock.acquire(key="key2", owner_id="owner_2")
+
+        await memory_lock.aclose()
+
+        # Locks should be cleared
+        assert len(memory_lock._locks) == 0
+
+
+@pytest.mark.unit
+class TestMemoryLockTTL:
+    """Tests for MemoryLock TTL expiration functionality."""
+
+    @pytest.mark.asyncio
+    async def test_lock_expires_after_ttl(self, fast_ttl_lock):
+        """Test that lock is automatically released after TTL expires."""
+        # Acquire lock with short TTL
+        result = await fast_ttl_lock.acquire(
+            key="test_key",
+            owner_id="owner_1",
+            ttl=1,  # 1 second TTL
+        )
+        assert result is True
+
+        # Another owner cannot acquire immediately
+        result = await fast_ttl_lock.acquire(
+            key="test_key",
+            owner_id="owner_2",
+            wait=False,
+        )
+        assert result is False
+
+        # Wait for TTL to expire (TTL + check interval buffer)
+        await asyncio.sleep(1.2)
+
+        # Now another owner should be able to acquire
+        result = await fast_ttl_lock.acquire(
+            key="test_key",
+            owner_id="owner_2",
+            wait=False,
+        )
+        assert result is True
+
+        await fast_ttl_lock.aclose()
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_extends_ttl(self, fast_ttl_lock):
+        """Test that heartbeat extends the lock TTL."""
+        # Acquire lock with short TTL
+        await fast_ttl_lock.acquire(
+            key="test_key",
+            owner_id="owner_1",
+            ttl=1,  # 1 second TTL
+        )
+
+        # Wait half the TTL
+        await asyncio.sleep(0.5)
+
+        # Heartbeat to extend TTL
+        result = await fast_ttl_lock.heartbeat(
+            key="test_key",
+            owner_id="owner_1",
+        )
+        assert result is True
+
+        # Wait another 0.7 seconds (original TTL would have expired)
+        await asyncio.sleep(0.7)
+
+        # Lock should still be held because heartbeat extended it
+        result = await fast_ttl_lock.acquire(
+            key="test_key",
+            owner_id="owner_2",
+            wait=False,
+        )
+        assert result is False
+
+        await fast_ttl_lock.aclose()
+
+    @pytest.mark.asyncio
+    async def test_ttl_checker_starts_only_when_needed(self):
+        """Test that TTL checker task starts only when acquiring with TTL."""
+        lock = MemoryLock(ttl_check_interval=0.1)
+
+        # No TTL checker before any acquire
+        assert lock._ttl_checker_task is None
+
+        # Acquire without TTL - no checker started
+        await lock.acquire(key="key1", owner_id="owner_1")
+        assert lock._ttl_checker_task is None
+
+        # Acquire with TTL - checker should start
+        await lock.acquire(key="key2", owner_id="owner_1", ttl=10)
+        assert lock._ttl_checker_task is not None
+        assert not lock._ttl_checker_task.done()
+
+        await lock.aclose()
+
+    @pytest.mark.asyncio
+    async def test_aclose_stops_ttl_checker(self, fast_ttl_lock):
+        """Test that aclose stops the TTL checker task."""
+        # Acquire with TTL to start the checker
+        await fast_ttl_lock.acquire(
+            key="test_key",
+            owner_id="owner_1",
+            ttl=10,
+        )
+
+        # Checker should be running
+        assert fast_ttl_lock._ttl_checker_task is not None
+
+        await fast_ttl_lock.aclose()
+
+        # Checker should be stopped and cleared
+        assert fast_ttl_lock._ttl_checker_task is None
+        assert fast_ttl_lock._closed is True
+
+    @pytest.mark.asyncio
+    async def test_lock_without_ttl_does_not_expire(self, fast_ttl_lock):
+        """Test that lock without TTL never expires automatically."""
+        # Acquire lock without TTL
+        result = await fast_ttl_lock.acquire(
+            key="test_key",
+            owner_id="owner_1",
+        )
+        assert result is True
+
+        # Wait some time (would have expired if TTL was set)
+        await asyncio.sleep(0.3)
+
+        # Lock should still be held
+        result = await fast_ttl_lock.acquire(
+            key="test_key",
+            owner_id="owner_2",
+            wait=False,
+        )
+        assert result is False
+
+        await fast_ttl_lock.aclose()
+
+    @pytest.mark.asyncio
+    async def test_multiple_locks_with_different_ttl(self, fast_ttl_lock):
+        """Test multiple locks with different TTL values."""
+        # Acquire two locks with different TTLs
+        await fast_ttl_lock.acquire(
+            key="short_ttl",
+            owner_id="owner_1",
+            ttl=1,  # 1 second
+        )
+        await fast_ttl_lock.acquire(
+            key="long_ttl",
+            owner_id="owner_1",
+            ttl=5,  # 5 seconds
+        )
+
+        # Wait for short TTL to expire
+        await asyncio.sleep(1.2)
+
+        # Short TTL lock should be available
+        result = await fast_ttl_lock.acquire(
+            key="short_ttl",
+            owner_id="owner_2",
+            wait=False,
+        )
+        assert result is True
+
+        # Long TTL lock should still be held
+        result = await fast_ttl_lock.acquire(
+            key="long_ttl",
+            owner_id="owner_2",
+            wait=False,
+        )
+        assert result is False
+
+        await fast_ttl_lock.aclose()


### PR DESCRIPTION
Add automatic lock expiration based on TTL parameter with background task that periodically checks and releases expired locks:

- Store expiration time and original TTL with each lock
- Add configurable TTL checker background task
- Extend TTL on heartbeat using original TTL value
- Stop TTL checker cleanly on aclose()
- Add comprehensive tests for TTL expiration behavior