### PR TITLE
Make domain config fields immutable

### DIFF
--- a/src/bioetl/composition/factories/services_builder.py
+++ b/src/bioetl/composition/factories/services_builder.py
@@ -8,6 +8,7 @@ Extracted from generic_factory.py for better separation of concerns.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from bioetl.application.core.checkpoint_manager import CheckpointManager
@@ -69,7 +70,7 @@ class ServicesBuilder:
         silver_schema: pa.Schema | None,
         gold_schema: Any,
         dq_config: Any,
-        primary_keys: list[str],
+        primary_keys: Sequence[str],
         silver_table: str,
         gold_table: str,
         silver_write_mode: str,

--- a/src/bioetl/domain/config.py
+++ b/src/bioetl/domain/config.py
@@ -65,17 +65,30 @@ class DQConfig:
 
 @dataclass(frozen=True)
 class TableConfig:
-    """Configuration for database tables and keys."""
+    """Configuration for database tables and keys.
 
-    primary_keys: list[str] = field(default_factory=lambda: ["entity_id"])
+    All collection fields are immutable tuples to ensure true immutability
+    of the frozen dataclass. The __post_init__ converts any incoming lists
+    to tuples for backward compatibility.
+    """
+
+    primary_keys: tuple[str, ...] = ("entity_id",)
     silver_table: str | None = None
     gold_table: str | None = None
     # Write modes from YAML sink config
     silver_write_mode: Literal["merge", "append", "overwrite"] = "merge"
     gold_write_mode: Literal["append", "overwrite", "scd2"] = "append"
-    partition_cols: list[str] = field(default_factory=list)
+    partition_cols: tuple[str, ...] = ()
     # Schema drift handling for Silver layer
     on_schema_mismatch: Literal["error", "evolve", "ignore"] = "error"
+
+    def __post_init__(self) -> None:
+        """Convert incoming lists to tuples for immutability."""
+        # Use object.__setattr__ because frozen=True
+        if isinstance(self.primary_keys, list):
+            object.__setattr__(self, "primary_keys", tuple(self.primary_keys))
+        if isinstance(self.partition_cols, list):
+            object.__setattr__(self, "partition_cols", tuple(self.partition_cols))
 
 
 @dataclass(frozen=True)
@@ -95,25 +108,34 @@ class PipelineConfig:
     entity_type: str
 
     # Table configuration
-    primary_keys: list[str]
+    primary_keys: tuple[str, ...]
     silver_table: str
     gold_table: str | None = None
     write_mode: Literal["merge", "append", "overwrite"] = "merge"
     gold_write_mode: Literal["append", "overwrite", "scd2"] = "append"
-    partition_cols: list[str] = field(default_factory=list)
+    partition_cols: tuple[str, ...] = ()
     on_schema_mismatch: Literal["error", "evolve", "ignore"] = "error"
 
     # Processing
     gold_filters: GoldFilterConfig | None = None  # Configurable Gold layer filters
     batch_size: int = 100
     checkpoint_interval: int = 1000
-    fields: list[str] = field(default_factory=list)
+    fields: tuple[str, ...] = ()
 
     # Data Quality
     dq: DQConfig = field(default_factory=DQConfig)
 
     def __post_init__(self) -> None:
-        """Validate configuration on creation."""
+        """Convert lists to tuples and validate configuration on creation."""
+        # Convert incoming lists to tuples for immutability (object.__setattr__ for frozen)
+        if isinstance(self.primary_keys, list):
+            object.__setattr__(self, "primary_keys", tuple(self.primary_keys))
+        if isinstance(self.partition_cols, list):
+            object.__setattr__(self, "partition_cols", tuple(self.partition_cols))
+        if isinstance(self.fields, list):
+            object.__setattr__(self, "fields", tuple(self.fields))
+
+        # Validate configuration
         validations = [
             (not self.pipeline_name, "pipeline_name cannot be empty"),
             (not self.provider, "provider cannot be empty"),

--- a/tests/unit/application/test_pipeline_config.py
+++ b/tests/unit/application/test_pipeline_config.py
@@ -24,7 +24,7 @@ class TestPipelineConfig:
         assert config.pipeline_name == "test_pipeline"
         assert config.provider == "test_provider"
         assert config.entity_type == "test_entity"
-        assert config.primary_keys == ["id"]
+        assert config.primary_keys == ("id",)  # Lists converted to tuples
         assert config.silver_table == "test_silver"
         assert config.gold_table is None
         assert config.batch_size == 100  # default

--- a/tests/unit/domain/test_config.py
+++ b/tests/unit/domain/test_config.py
@@ -76,7 +76,7 @@ class TestTableConfig:
         """Test default configuration values."""
         config = TableConfig()
 
-        assert config.primary_keys == ["entity_id"]
+        assert config.primary_keys == ("entity_id",)
         assert config.silver_table is None
         assert config.gold_table is None
 
@@ -84,7 +84,8 @@ class TestTableConfig:
         """Test custom primary keys."""
         config = TableConfig(primary_keys=["id", "version"])
 
-        assert config.primary_keys == ["id", "version"]
+        # Lists are converted to tuples
+        assert config.primary_keys == ("id", "version")
 
     def test_custom_table_names(self) -> None:
         """Test custom table names."""
@@ -112,26 +113,58 @@ class TestTableConfig:
         assert config1 == config2
         assert config1 != config3
 
-    def test_not_hashable_due_to_list(self) -> None:
-        """Test that TableConfig is not hashable due to list field."""
-        config = TableConfig(silver_table="test")
+    def test_hashable_with_tuple(self) -> None:
+        """Test that TableConfig is hashable with tuple fields."""
+        config1 = TableConfig(silver_table="test")
+        config2 = TableConfig(silver_table="test")
 
-        # Lists are not hashable, so frozen dataclass with list field isn't hashable
-        with pytest.raises(TypeError, match="unhashable"):
-            hash(config)
+        # Tuples are hashable, so frozen dataclass with tuple field is hashable
+        assert hash(config1) == hash(config2)
+
+        # Can be used in sets/dicts
+        config_set = {config1, config2}
+        assert len(config_set) == 1
+
+    def test_immutable_primary_keys(self) -> None:
+        """Test that primary_keys tuple cannot be mutated."""
+        config = TableConfig(primary_keys=["id", "version"])
+
+        # Tuples don't support item assignment - raises TypeError
+        with pytest.raises(TypeError):
+            config.primary_keys[0] = "new_key"  # type: ignore[index]
+
+    def test_immutable_partition_cols(self) -> None:
+        """Test that partition_cols tuple cannot be mutated."""
+        config = TableConfig(partition_cols=["col1", "col2"])
+
+        # Tuples don't support item assignment - raises TypeError
+        with pytest.raises(TypeError):
+            config.partition_cols[0] = "col3"  # type: ignore[index]
+
+    def test_list_to_tuple_conversion(self) -> None:
+        """Test that incoming lists are converted to tuples."""
+        config = TableConfig(
+            primary_keys=["id", "version"],
+            partition_cols=["col1"],
+        )
+
+        assert isinstance(config.primary_keys, tuple)
+        assert isinstance(config.partition_cols, tuple)
+        assert config.primary_keys == ("id", "version")
+        assert config.partition_cols == ("col1",)
 
     def test_empty_primary_keys(self) -> None:
-        """Test with empty primary keys list."""
+        """Test with empty primary keys."""
         config = TableConfig(primary_keys=[])
 
-        assert config.primary_keys == []
+        assert config.primary_keys == ()
 
     def test_multiple_primary_keys(self) -> None:
         """Test with multiple primary keys."""
         keys = ["org_id", "entity_id", "version"]
         config = TableConfig(primary_keys=keys)
 
-        assert config.primary_keys == keys
+        assert config.primary_keys == ("org_id", "entity_id", "version")
         assert len(config.primary_keys) == 3
 
     def test_full_configuration(self) -> None:
@@ -142,6 +175,6 @@ class TestTableConfig:
             gold_table="chembl_activity_gold",
         )
 
-        assert config.primary_keys == ["activity_id", "assay_chembl_id"]
+        assert config.primary_keys == ("activity_id", "assay_chembl_id")
         assert config.silver_table == "chembl_activity_silver"
         assert config.gold_table == "chembl_activity_gold"

--- a/tests/unit/domain/test_pipeline_config.py
+++ b/tests/unit/domain/test_pipeline_config.py
@@ -24,7 +24,7 @@ class TestPipelineConfig:
         assert config.pipeline_name == "test_pipeline"
         assert config.provider == "test_provider"
         assert config.entity_type == "test_entity"
-        assert config.primary_keys == ["id"]
+        assert config.primary_keys == ("id",)  # Lists converted to tuples
         assert config.silver_table == "test_silver"
 
     def test_default_values(self) -> None:
@@ -40,7 +40,7 @@ class TestPipelineConfig:
         assert config.gold_table is None
         assert config.batch_size == 100
         assert config.checkpoint_interval == 1000
-        assert config.fields == []
+        assert config.fields == ()  # Empty tuple
         assert isinstance(config.dq, DQConfig)
 
     def test_custom_batch_size(self) -> None:
@@ -84,8 +84,8 @@ class TestPipelineConfig:
         assert config.dq.soft_fail_threshold == 0.10
         assert config.dq.hard_fail_threshold == 0.50
 
-    def test_fields_list(self) -> None:
-        """Test fields configuration."""
+    def test_fields_tuple(self) -> None:
+        """Test fields configuration (converted to tuple)."""
         config = PipelineConfig(
             pipeline_name="test",
             provider="test",
@@ -95,7 +95,8 @@ class TestPipelineConfig:
             fields=["field1", "field2", "field3"],
         )
 
-        assert config.fields == ["field1", "field2", "field3"]
+        assert config.fields == ("field1", "field2", "field3")
+        assert isinstance(config.fields, tuple)
 
     def test_lock_key_property(self) -> None:
         """Test lock_key property generation."""
@@ -255,7 +256,7 @@ class TestPipelineConfig:
         assert config.pipeline_name == "chembl_activity"
         assert config.provider == "chembl"
         assert config.entity_type == "activity"
-        assert config.primary_keys == ["activity_id", "assay_chembl_id"]
+        assert config.primary_keys == ("activity_id", "assay_chembl_id")
         assert config.silver_table == "chembl_activity_silver"
         assert config.gold_table == "chembl_activity_gold"
         assert config.batch_size == 250
@@ -291,9 +292,16 @@ class TestPipelineConfig:
         assert config1 == config2
         assert config1 != config3
 
-    def test_not_hashable_due_to_list(self) -> None:
-        """Test that PipelineConfig is not hashable due to list fields."""
-        config = PipelineConfig(
+    def test_hashable_with_tuple(self) -> None:
+        """Test that PipelineConfig is hashable with tuple fields."""
+        config1 = PipelineConfig(
+            pipeline_name="test",
+            provider="test",
+            entity_type="test",
+            primary_keys=["id"],
+            silver_table="silver",
+        )
+        config2 = PipelineConfig(
             pipeline_name="test",
             provider="test",
             entity_type="test",
@@ -301,6 +309,57 @@ class TestPipelineConfig:
             silver_table="silver",
         )
 
-        # Lists (primary_keys, fields) are not hashable
-        with pytest.raises(TypeError, match="unhashable"):
-            hash(config)
+        # Tuples are hashable, so frozen dataclass with tuple field is hashable
+        assert hash(config1) == hash(config2)
+
+        # Can be used in sets/dicts
+        config_set = {config1, config2}
+        assert len(config_set) == 1
+
+    def test_immutable_primary_keys(self) -> None:
+        """Test that primary_keys tuple cannot be mutated."""
+        config = PipelineConfig(
+            pipeline_name="test",
+            provider="test",
+            entity_type="test",
+            primary_keys=["id", "version"],
+            silver_table="silver",
+        )
+
+        # Tuples don't support item assignment - raises TypeError
+        with pytest.raises(TypeError):
+            config.primary_keys[0] = "new_key"  # type: ignore[index]
+
+    def test_immutable_fields(self) -> None:
+        """Test that fields tuple cannot be mutated."""
+        config = PipelineConfig(
+            pipeline_name="test",
+            provider="test",
+            entity_type="test",
+            primary_keys=["id"],
+            silver_table="silver",
+            fields=["field1", "field2"],
+        )
+
+        # Tuples don't support item assignment - raises TypeError
+        with pytest.raises(TypeError):
+            config.fields[0] = "field3"  # type: ignore[index]
+
+    def test_list_to_tuple_conversion(self) -> None:
+        """Test that incoming lists are converted to tuples."""
+        config = PipelineConfig(
+            pipeline_name="test",
+            provider="test",
+            entity_type="test",
+            primary_keys=["id", "version"],
+            silver_table="silver",
+            partition_cols=["col1"],
+            fields=["f1", "f2"],
+        )
+
+        assert isinstance(config.primary_keys, tuple)
+        assert isinstance(config.partition_cols, tuple)
+        assert isinstance(config.fields, tuple)
+        assert config.primary_keys == ("id", "version")
+        assert config.partition_cols == ("col1",)
+        assert config.fields == ("f1", "f2")

--- a/tests/unit/infrastructure/test_config_dynamic.py
+++ b/tests/unit/infrastructure/test_config_dynamic.py
@@ -145,6 +145,8 @@ def test_gold_filters_loading(setup_configs):
     (pipelines_dir / "chembl" / "filters.yaml").write_text(yaml.dump(config_data))
 
     config = load_pipeline_config("chembl_filters")
+    # Note: load_pipeline_config returns PipelineYamlConfig (infrastructure layer)
+    # which uses lists. Use get_pipeline_config for domain PipelineConfig with tuples.
     assert config.gold_filters.columns == {"standard_type": ["IC50", "Ki"]}
     assert config.gold_filters.required_fields == ["value"]
     assert config.gold_filters.exclude_if_present == ["invalid"]

--- a/tests/unit/infrastructure/test_config_settings.py
+++ b/tests/unit/infrastructure/test_config_settings.py
@@ -168,7 +168,7 @@ class TestYamlConfigToDomain:
         assert result.pipeline_name == "test_pipeline"
         assert result.provider == "test"
         assert result.entity_type == "entity"
-        assert result.primary_keys == ["id"]
+        assert result.primary_keys == ("id",)  # Lists converted to tuples
         assert result.silver_table == "silver_table"
         assert result.gold_table == "gold_table"
         assert result.batch_size == 200
@@ -201,7 +201,7 @@ class TestYamlConfigToDomain:
 
         result = yaml_config_to_domain(yaml_config)
 
-        assert result.fields == ["field1", "field2", "field3"]
+        assert result.fields == ("field1", "field2", "field3")
 
     def test_dq_config_mapping(self) -> None:
         """Test DQ config mapping."""


### PR DESCRIPTION
…taclasses

Replace mutable list[str] fields with immutable tuple[str, ...] in TableConfig and PipelineConfig to enforce true DDD Value Object semantics.

Changes:
- TableConfig: primary_keys, partition_cols now use tuple[str, ...]
- PipelineConfig: primary_keys, partition_cols, fields now use tuple[str, ...]
- Added __post_init__ to convert incoming lists to tuples for backward compatibility
- Updated services_builder.py to accept Sequence[str] for flexibility
- Updated tests to verify immutability (TypeError on mutation attempt)
- Changed test_not_hashable to test_hashable (configs are now hashable)

This prevents accidental mutation of config fields which could cause side effects when configs are cached or shared between components.