### PR TITLE
Add automatic scheduling for maintenance tasks

### DIFF
--- a/src/bioetl/composition/bootstrap.py
+++ b/src/bioetl/composition/bootstrap.py
@@ -111,6 +111,19 @@ def bootstrap_pipeline(ctx: PipelineRunContext) -> PipelineRunner:
     # Load validated YAML config
     yaml_config = load_pipeline_config(ctx.pipeline_name)
 
+    # Merge YAML maintenance config with CLI overrides
+    # CLI flags take precedence over YAML config
+    vacuum_after_run = (
+        ctx.vacuum_after_run
+        if ctx.vacuum_after_run is not None
+        else yaml_config.maintenance.auto_vacuum
+    )
+    vacuum_retention_days = (
+        ctx.vacuum_retention_days
+        if ctx.vacuum_retention_days is not None
+        else yaml_config.maintenance.vacuum_retention_days
+    )
+
     runtime_config = RuntimeConfig(
         run_type=ctx.run_type,
         resume=ctx.resume,
@@ -118,6 +131,8 @@ def bootstrap_pipeline(ctx: PipelineRunContext) -> PipelineRunner:
         heartbeat_interval=settings.pipeline.heartbeat_interval,
         query=ctx.query,
         dry_run=ctx.dry_run,
+        vacuum_after_run=vacuum_after_run,
+        vacuum_retention_days=vacuum_retention_days,
     )
 
     # Build filter config using the dedicated builder

--- a/src/bioetl/composition/entrypoints.py
+++ b/src/bioetl/composition/entrypoints.py
@@ -13,8 +13,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
-from bioetl.domain.types import RunID
-
 from bioetl.composition.bootstrap import (
     bootstrap_checkpoint_manager,
     bootstrap_cleanup,
@@ -26,12 +24,12 @@ from bioetl.composition.bootstrap import (
 from bioetl.composition.factories.pipeline_factories import register_all_pipelines
 from bioetl.composition.providers.registration import register_all_providers
 from bioetl.domain.context import PipelineRunContext
-from bioetl.domain.types import RunType
+from bioetl.domain.types import RunID, RunType
 
 if TYPE_CHECKING:
     from bioetl.application.core.checkpoint_manager import CheckpointManager
-    from bioetl.application.core.runner import PipelineRunner
     from bioetl.application.core.quarantine_manager import QuarantineManager
+    from bioetl.application.core.runner import PipelineRunner
     from bioetl.application.services.cleanup_service import CleanupPreview
     from bioetl.application.services.lifecycle_service import LifecycleService
 
@@ -51,6 +49,8 @@ class RunOptions:
         filter_column: Column name in CSV containing filter IDs.
         filter_field: API field name to filter by.
         dry_run: Preview mode without execution.
+        vacuum_after_run: Enable automatic VACUUM after successful run (CLI override).
+        vacuum_retention_days: Minimum age of files to remove during VACUUM (CLI override).
     """
 
     run_type: str = "incremental"
@@ -60,6 +60,8 @@ class RunOptions:
     filter_column: str | None = None
     filter_field: str | None = None
     dry_run: bool = False
+    vacuum_after_run: bool | None = None
+    vacuum_retention_days: int | None = None
 
 
 @dataclass(frozen=True)
@@ -117,6 +119,8 @@ def build_pipeline_context(name: str, options: RunOptions) -> PipelineRunContext
         filter_column=options.filter_column,
         filter_field=options.filter_field,
         dry_run=options.dry_run,
+        vacuum_after_run=options.vacuum_after_run,
+        vacuum_retention_days=options.vacuum_retention_days,
     )
 
 

--- a/src/bioetl/domain/context.py
+++ b/src/bioetl/domain/context.py
@@ -89,3 +89,6 @@ class PipelineRunContext:
     filter_field: str | None = None
     query: str | None = None
     dry_run: bool = False
+    # VACUUM automation (can be set via CLI or YAML)
+    vacuum_after_run: bool | None = None
+    vacuum_retention_days: int | None = None

--- a/src/bioetl/infrastructure/schemas/pipeline_config.py
+++ b/src/bioetl/infrastructure/schemas/pipeline_config.py
@@ -89,6 +89,28 @@ class InputFilterConfig(BaseModel):
     )
 
 
+class MaintenanceConfig(BaseModel):
+    """Configuration for automated maintenance operations.
+
+    Controls automatic VACUUM and other maintenance tasks after pipeline runs.
+
+    Attributes:
+        auto_vacuum: Enable automatic VACUUM after successful run.
+        vacuum_retention_days: Minimum age of files to remove (days).
+    """
+
+    auto_vacuum: bool = Field(
+        default=False,
+        description="Enable automatic VACUUM after successful pipeline run",
+    )
+    vacuum_retention_days: int = Field(
+        default=7,
+        ge=1,
+        le=365,
+        description="Minimum age of files to remove during VACUUM (days)",
+    )
+
+
 class ApiConfig(BaseModel):
     """Configuration for API connection details."""
 
@@ -205,6 +227,7 @@ class PipelineYamlConfig(BaseModel):
     sink: dict[str, SinkLayerConfig] = Field(default_factory=dict)
     source: SourceConfig = Field(default_factory=SourceConfig)
     input_filter: InputFilterConfig = Field(default_factory=InputFilterConfig)
+    maintenance: MaintenanceConfig = Field(default_factory=MaintenanceConfig)
 
     @field_validator("batch_size")
     @classmethod

--- a/src/bioetl/interfaces/cli.py
+++ b/src/bioetl/interfaces/cli.py
@@ -185,6 +185,18 @@ def cli() -> None:
     is_flag=True,
     help="Skip confirmation prompt for rebuild/backfill",
 )
+@click.option(
+    "--vacuum-after-run",
+    is_flag=True,
+    default=None,
+    help="Run VACUUM on Delta tables after successful run (overrides YAML config)",
+)
+@click.option(
+    "--vacuum-retention-days",
+    type=int,
+    default=None,
+    help="Minimum age of files to remove during VACUUM (days, overrides YAML config)",
+)
 def run(
     pipeline: str,
     run_type: str,
@@ -195,6 +207,8 @@ def run(
     filter_field: str | None,
     dry_run: bool,
     yes: bool,
+    vacuum_after_run: bool | None,
+    vacuum_retention_days: int | None,
 ) -> None:
     """Run an ETL pipeline."""
     # Handle rebuild/backfill confirmation before any heavy initialization
@@ -210,6 +224,8 @@ def run(
             filter_column=filter_column,
             filter_field=filter_field,
             dry_run=dry_run,
+            vacuum_after_run=vacuum_after_run if vacuum_after_run else None,
+            vacuum_retention_days=vacuum_retention_days,
         )
         runner = create_pipeline_runner(pipeline, options)
     except (ValueError, FileNotFoundError) as e:

--- a/tests/unit/infrastructure/test_config.py
+++ b/tests/unit/infrastructure/test_config.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import pytest
+
 from bioetl.domain.config import PipelineConfig
 from bioetl.infrastructure.config import yaml_config_to_domain
 from bioetl.infrastructure.schemas.pipeline_config import DQConfig as YamlDQConfig
 from bioetl.infrastructure.schemas.pipeline_config import (
+    MaintenanceConfig,
     PipelineYamlConfig,
     SinkLayerConfig,
 )
@@ -47,3 +50,72 @@ def test_yaml_config_to_domain_default_mode():
     domain_config = yaml_config_to_domain(yaml_config)
 
     assert domain_config.write_mode == "merge"
+
+
+@pytest.mark.unit
+class TestMaintenanceConfig:
+    """Tests for MaintenanceConfig schema validation."""
+
+    def test_maintenance_config_defaults(self):
+        """Test MaintenanceConfig has correct defaults."""
+        config = MaintenanceConfig()
+
+        assert config.auto_vacuum is False
+        assert config.vacuum_retention_days == 7
+
+    def test_maintenance_config_custom_values(self):
+        """Test MaintenanceConfig accepts custom values."""
+        config = MaintenanceConfig(
+            auto_vacuum=True,
+            vacuum_retention_days=30,
+        )
+
+        assert config.auto_vacuum is True
+        assert config.vacuum_retention_days == 30
+
+    def test_maintenance_config_validation_min_retention_days(self):
+        """Test vacuum_retention_days cannot be less than 1."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            MaintenanceConfig(vacuum_retention_days=0)
+
+    def test_maintenance_config_validation_max_retention_days(self):
+        """Test vacuum_retention_days cannot exceed 365."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            MaintenanceConfig(vacuum_retention_days=400)
+
+    def test_pipeline_yaml_config_has_maintenance_field(self):
+        """Test PipelineYamlConfig includes maintenance field with defaults."""
+        yaml_config = PipelineYamlConfig(
+            pipeline_name="test_pipeline",
+            provider="test",
+            entity_type="entity",
+            primary_keys=["id"],
+            silver_table="silver.test",
+        )
+
+        assert yaml_config.maintenance is not None
+        assert yaml_config.maintenance.auto_vacuum is False
+        assert yaml_config.maintenance.vacuum_retention_days == 7
+
+    def test_pipeline_yaml_config_maintenance_from_yaml(self):
+        """Test PipelineYamlConfig parses maintenance from YAML dict."""
+        config_dict = {
+            "pipeline_name": "test_pipeline",
+            "provider": "test",
+            "entity_type": "entity",
+            "primary_keys": ["id"],
+            "silver_table": "silver.test",
+            "maintenance": {
+                "auto_vacuum": True,
+                "vacuum_retention_days": 14,
+            },
+        }
+
+        yaml_config = PipelineYamlConfig.model_validate(config_dict)
+
+        assert yaml_config.maintenance.auto_vacuum is True
+        assert yaml_config.maintenance.vacuum_retention_days == 14

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -511,3 +511,156 @@ class TestBootstrapMetrics:
 
         assert result is not None
         assert isinstance(result, NoOpMetrics)
+
+
+@pytest.mark.unit
+class TestBootstrapVacuumConfig:
+    """Tests for bootstrap_pipeline vacuum configuration merging."""
+
+    @patch("bioetl.composition.bootstrap.PipelineRegistry")
+    @patch("bioetl.composition.bootstrap.FilterConfigBuilder")
+    @patch("bioetl.composition.bootstrap.load_pipeline_config")
+    @patch("bioetl.composition._bootstrap.observability.start_metrics_server")
+    @patch("bioetl.composition.bootstrap.bootstrap_tracer")
+    @patch("bioetl.composition.bootstrap.bootstrap_logger")
+    @patch("bioetl.composition.bootstrap.get_settings")
+    def test_bootstrap_uses_yaml_vacuum_config_when_cli_not_set(
+        self,
+        mock_get_settings: MagicMock,
+        mock_bootstrap_logger: MagicMock,
+        mock_bootstrap_tracer: MagicMock,
+        mock_start_metrics: MagicMock,
+        mock_load_config: MagicMock,
+        mock_filter_builder: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """Test that YAML auto_vacuum config is used when CLI doesn't override."""
+        from bioetl.composition.bootstrap import bootstrap_pipeline
+
+        # Create settings with all required observability attributes
+        settings = MagicMock()
+        settings.metrics_port = 8000
+        settings.pipeline.heartbeat_interval = 30
+        settings.observability.metrics_enabled = False
+        settings.observability.metrics_server_enabled = False
+        settings.observability.metrics_fail_fast = False
+        settings.observability.metrics_retry_count = 3
+        settings.observability.metrics_retry_delay = 1.0
+        settings.observability.tracing_enabled = False
+        settings.observability.dq_baseline_window = 7
+        settings.observability.dq_z_score_threshold = 2.5
+        settings.observability.dq_min_baseline_samples = 3
+        settings.observability.dq_error_rate_max = 0.10
+        settings.observability.dq_quality_score_min = 0.80
+        mock_get_settings.return_value = settings
+
+        # Create logger
+        logger = MagicMock()
+        logger.bind.return_value = logger
+        mock_bootstrap_logger.return_value = logger
+        mock_bootstrap_tracer.return_value = MagicMock()
+        mock_filter_builder.build.return_value = None
+
+        # Setup YAML config with auto_vacuum enabled
+        yaml_config = MagicMock()
+        yaml_config.maintenance.auto_vacuum = True
+        yaml_config.maintenance.vacuum_retention_days = 14
+        yaml_config.input_filter = MagicMock()
+        mock_load_config.return_value = yaml_config
+
+        # Setup pipeline registry
+        mock_factory = MagicMock()
+        mock_runner = MagicMock()
+        mock_factory.create_runner.return_value = mock_runner
+        mock_registry.get.return_value.factory = mock_factory
+
+        # Context without CLI vacuum options (None)
+        ctx = PipelineRunContext(
+            pipeline_name="chembl_activity",
+            run_id=uuid4(),
+            run_type=RunType.INCREMENTAL,
+            vacuum_after_run=None,
+            vacuum_retention_days=None,
+        )
+
+        bootstrap_pipeline(ctx)
+
+        # Verify runtime config was passed with YAML values
+        call_args = mock_factory.create_runner.call_args
+        runtime = call_args.kwargs.get("runtime") or call_args[1].get("runtime")
+        assert runtime.vacuum_after_run is True
+        assert runtime.vacuum_retention_days == 14
+
+    @patch("bioetl.composition.bootstrap.PipelineRegistry")
+    @patch("bioetl.composition.bootstrap.FilterConfigBuilder")
+    @patch("bioetl.composition.bootstrap.load_pipeline_config")
+    @patch("bioetl.composition._bootstrap.observability.start_metrics_server")
+    @patch("bioetl.composition.bootstrap.bootstrap_tracer")
+    @patch("bioetl.composition.bootstrap.bootstrap_logger")
+    @patch("bioetl.composition.bootstrap.get_settings")
+    def test_bootstrap_cli_vacuum_overrides_yaml_config(
+        self,
+        mock_get_settings: MagicMock,
+        mock_bootstrap_logger: MagicMock,
+        mock_bootstrap_tracer: MagicMock,
+        mock_start_metrics: MagicMock,
+        mock_load_config: MagicMock,
+        mock_filter_builder: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """Test that CLI vacuum options override YAML config."""
+        from bioetl.composition.bootstrap import bootstrap_pipeline
+
+        # Create settings with all required observability attributes
+        settings = MagicMock()
+        settings.metrics_port = 8000
+        settings.pipeline.heartbeat_interval = 30
+        settings.observability.metrics_enabled = False
+        settings.observability.metrics_server_enabled = False
+        settings.observability.metrics_fail_fast = False
+        settings.observability.metrics_retry_count = 3
+        settings.observability.metrics_retry_delay = 1.0
+        settings.observability.tracing_enabled = False
+        settings.observability.dq_baseline_window = 7
+        settings.observability.dq_z_score_threshold = 2.5
+        settings.observability.dq_min_baseline_samples = 3
+        settings.observability.dq_error_rate_max = 0.10
+        settings.observability.dq_quality_score_min = 0.80
+        mock_get_settings.return_value = settings
+
+        # Create logger
+        logger = MagicMock()
+        logger.bind.return_value = logger
+        mock_bootstrap_logger.return_value = logger
+        mock_bootstrap_tracer.return_value = MagicMock()
+        mock_filter_builder.build.return_value = None
+
+        # Setup YAML config with auto_vacuum enabled
+        yaml_config = MagicMock()
+        yaml_config.maintenance.auto_vacuum = True
+        yaml_config.maintenance.vacuum_retention_days = 14
+        yaml_config.input_filter = MagicMock()
+        mock_load_config.return_value = yaml_config
+
+        # Setup pipeline registry
+        mock_factory = MagicMock()
+        mock_runner = MagicMock()
+        mock_factory.create_runner.return_value = mock_runner
+        mock_registry.get.return_value.factory = mock_factory
+
+        # Context with CLI overrides (explicit False and 30 days)
+        ctx = PipelineRunContext(
+            pipeline_name="chembl_activity",
+            run_id=uuid4(),
+            run_type=RunType.INCREMENTAL,
+            vacuum_after_run=False,  # CLI override
+            vacuum_retention_days=30,  # CLI override
+        )
+
+        bootstrap_pipeline(ctx)
+
+        # Verify runtime config was passed with CLI values (overriding YAML)
+        call_args = mock_factory.create_runner.call_args
+        runtime = call_args.kwargs.get("runtime") or call_args[1].get("runtime")
+        assert runtime.vacuum_after_run is False
+        assert runtime.vacuum_retention_days == 30


### PR DESCRIPTION
- Add MaintenanceConfig to PipelineYamlConfig for YAML configuration
- Add auto_vacuum and vacuum_retention_days fields to RuntimeConfig
- Add --vacuum-after-run and --vacuum-retention-days CLI flags
- Update bootstrap to merge YAML config with CLI overrides (CLI takes precedence)
- Add PipelineRunContext fields for vacuum options
- Add unit tests for MaintenanceConfig validation and bootstrap merging

YAML configuration example:
```yaml
maintenance:
  auto_vacuum: true
  vacuum_retention_days: 14
```

CLI usage:
```bash
bioetl run --pipeline chembl_activity --vacuum-after-run --vacuum-retention-days 30
```