### PR TITLE
Fix Gold validator bypassing validation with null schema

### DIFF
--- a/src/bioetl/application/core/gold_validator.py
+++ b/src/bioetl/application/core/gold_validator.py
@@ -18,21 +18,29 @@ class GoldValidator:
     """Валидатор записей для Gold слоя.
 
     Проверяет записи на соответствие Pandera-схеме перед записью в Gold.
-    Если схема не задана, валидация всегда успешна.
+    В strict mode отсутствие схемы приводит к ошибке валидации.
 
     Attributes:
         _schema: Pandera-схема для валидации (опционально).
+        _strict: Если True, отсутствие схемы вызывает ошибку валидации.
 
     """
 
-    def __init__(self, schema: pa.DataFrameSchema | None) -> None:
+    def __init__(
+        self, schema: pa.DataFrameSchema | None, *, strict: bool = False
+    ) -> None:
         """Инициализирует валидатор.
 
         Args:
-            schema: Pandera-схема для валидации. Если None, валидация пропускается.
+            schema: Pandera-схема для валидации. Если None и strict=False,
+                валидация пропускается. Если None и strict=True, валидация
+                завершается с ошибкой.
+            strict: Если True, требует наличия схемы для валидации.
+                По умолчанию False для обратной совместимости.
 
         """
         self._schema = schema
+        self._strict = strict
 
     def validate(self, records: list[dict[str, Any]]) -> ValidationResult:
         """Валидирует список записей.
@@ -44,7 +52,15 @@ class GoldValidator:
             ValidationResult с результатом валидации.
 
         """
-        if not self._schema or not records:
+        if not records:
+            return ValidationResult(valid=True)
+
+        if not self._schema:
+            if self._strict:
+                return ValidationResult(
+                    valid=False,
+                    errors=["Gold schema is required but not provided"],
+                )
             return ValidationResult(valid=True)
 
         import pandas as pd

--- a/src/bioetl/composition/factories/generic_factory.py
+++ b/src/bioetl/composition/factories/generic_factory.py
@@ -308,6 +308,7 @@ class GenericPipelineFactory(Generic[TPipeline]):
             pipeline=pipeline,
             silver_schema=self.silver_schema,
             gold_schema=self.gold_schema,
+            strict_gold_validation=runtime.strict_gold_validation,
         )
 
         # Create Executor

--- a/src/bioetl/composition/factories/services_builder.py
+++ b/src/bioetl/composition/factories/services_builder.py
@@ -79,6 +79,8 @@ class ServicesBuilder:
         transform_callback: Any,
         gold_filter_callback: Any,
         gold_transform_callback: Any,
+        *,
+        strict_gold_validation: bool = False,
     ) -> RecordProcessor:
         """Create configured RecordProcessor.
 
@@ -100,6 +102,8 @@ class ServicesBuilder:
             transform_callback: Bronze to Silver transformation callback
             gold_filter_callback: Gold filtering callback
             gold_transform_callback: Silver to Gold transformation callback
+            strict_gold_validation: If True, validation fails when gold_schema is None.
+                Default False for backward compatibility.
 
         Returns:
             Configured RecordProcessor instance
@@ -125,7 +129,8 @@ class ServicesBuilder:
         )
 
         # Create Gold validator from schema (DI pattern)
-        gold_validator = PanderaGoldValidator(gold_schema)
+        # strict mode requires schema to be provided
+        gold_validator = PanderaGoldValidator(gold_schema, strict=strict_gold_validation)
 
         return RecordProcessor(
             services=services,
@@ -143,6 +148,8 @@ class ServicesBuilder:
         pipeline: BasePipeline,
         silver_schema: pa.Schema | None,
         gold_schema: Any,
+        *,
+        strict_gold_validation: bool = False,
     ) -> RecordProcessor:
         """Create RecordProcessor from pipeline instance.
 
@@ -152,6 +159,8 @@ class ServicesBuilder:
             pipeline: Pipeline instance
             silver_schema: PyArrow schema for Silver layer
             gold_schema: Pandera schema for Gold layer
+            strict_gold_validation: If True, validation fails when gold_schema is None.
+                Default False for backward compatibility.
 
         Returns:
             Configured RecordProcessor instance
@@ -174,4 +183,5 @@ class ServicesBuilder:
             transform_callback=pipeline.transform_bronze_to_silver,
             gold_filter_callback=pipeline.should_write_gold,
             gold_transform_callback=pipeline.transform_for_gold,
+            strict_gold_validation=strict_gold_validation,
         )

--- a/src/bioetl/domain/config.py
+++ b/src/bioetl/domain/config.py
@@ -205,6 +205,12 @@ class RuntimeConfig:
     # When False, violations are logged as warnings
     strict_validation: bool = False
 
+    # Gold layer schema validation (strict mode)
+    # When True, pipelines fail if Gold schema is not provided
+    # When False (default), missing Gold schema skips validation
+    # Use False during migration, True for production readiness
+    strict_gold_validation: bool = False
+
     def __post_init__(self) -> None:
         """Validate runtime config."""
         if self.limit is not None and self.limit <= 0:

--- a/src/bioetl/infrastructure/validation/pandera_validator.py
+++ b/src/bioetl/infrastructure/validation/pandera_validator.py
@@ -19,19 +19,28 @@ class PanderaGoldValidator:
     Validates records against a Pandera schema before writing to Gold layer.
     Implements GoldValidatorPort protocol.
 
+    In strict mode, validation fails if no schema is provided.
+
     Args:
-        schema: Pandera DataFrameSchema for validation. If None, validation is skipped.
+        schema: Pandera DataFrameSchema for validation. If None and strict=False,
+            validation is skipped. If None and strict=True, validation fails.
+        strict: If True, requires schema to be provided. Default False for
+            backward compatibility.
 
     """
 
-    def __init__(self, schema: pa.DataFrameSchema | None = None) -> None:
+    def __init__(
+        self, schema: pa.DataFrameSchema | None = None, *, strict: bool = False
+    ) -> None:
         """Initialize Pandera validator.
 
         Args:
             schema: Pandera schema to validate against.
+            strict: If True, validation fails when schema is None.
 
         """
         self._schema = schema
+        self._strict = strict
 
     def validate(self, records: list[dict[str, Any]]) -> ValidationResult:
         """Validate records using Pandera schema.
@@ -43,7 +52,15 @@ class PanderaGoldValidator:
             ValidationResult with valid flag and any error messages.
 
         """
-        if not self._schema or not records:
+        if not records:
+            return ValidationResult(valid=True)
+
+        if not self._schema:
+            if self._strict:
+                return ValidationResult(
+                    valid=False,
+                    errors=["Gold schema is required but not provided"],
+                )
             return ValidationResult(valid=True)
 
         import pandas as pd

--- a/tests/unit/application/core/test_gold_validator.py
+++ b/tests/unit/application/core/test_gold_validator.py
@@ -42,11 +42,26 @@ class TestGoldValidatorInit:
         mock_schema = MagicMock()
         validator = GoldValidator(mock_schema)
         assert validator._schema is mock_schema
+        assert validator._strict is False
 
     def test_init_without_schema(self):
         """Test initialization without a schema."""
         validator = GoldValidator(None)
         assert validator._schema is None
+        assert validator._strict is False
+
+    def test_init_with_strict_mode(self):
+        """Test initialization with strict mode enabled."""
+        mock_schema = MagicMock()
+        validator = GoldValidator(mock_schema, strict=True)
+        assert validator._schema is mock_schema
+        assert validator._strict is True
+
+    def test_init_without_schema_strict_mode(self):
+        """Test initialization without schema but with strict mode."""
+        validator = GoldValidator(None, strict=True)
+        assert validator._schema is None
+        assert validator._strict is True
 
 
 @pytest.mark.unit
@@ -54,11 +69,31 @@ class TestGoldValidatorValidate:
     """Tests for GoldValidator.validate method."""
 
     def test_validate_without_schema_returns_valid(self):
-        """Test that validation without schema always returns valid."""
+        """Test that validation without schema always returns valid (non-strict)."""
         validator = GoldValidator(None)
         records = [{"id": 1, "value": "test"}]
 
         result = validator.validate(records)
+
+        assert result.valid is True
+        assert result.errors == []
+
+    def test_validate_without_schema_strict_mode_fails(self):
+        """Test that validation without schema in strict mode fails."""
+        validator = GoldValidator(None, strict=True)
+        records = [{"id": 1, "value": "test"}]
+
+        result = validator.validate(records)
+
+        assert result.valid is False
+        assert len(result.errors) == 1
+        assert "Gold schema is required but not provided" in result.errors[0]
+
+    def test_validate_empty_records_strict_mode_returns_valid(self):
+        """Test that validation of empty records returns valid even in strict mode."""
+        validator = GoldValidator(None, strict=True)
+
+        result = validator.validate([])
 
         assert result.valid is True
         assert result.errors == []
@@ -184,3 +219,64 @@ class TestGoldValidatorIntegration:
 
         assert result.valid is False
         assert len(result.errors) > 0
+
+
+@pytest.mark.unit
+class TestPanderaGoldValidatorStrictMode:
+    """Tests for PanderaGoldValidator strict mode."""
+
+    def test_pandera_validator_without_schema_non_strict(self):
+        """Test PanderaGoldValidator without schema (non-strict) returns valid."""
+        from bioetl.infrastructure.validation import PanderaGoldValidator
+
+        validator = PanderaGoldValidator(None, strict=False)
+        records = [{"id": 1, "value": "test"}]
+
+        result = validator.validate(records)
+
+        assert result.valid is True
+        assert result.errors == []
+
+    def test_pandera_validator_without_schema_strict(self):
+        """Test PanderaGoldValidator without schema (strict) returns invalid."""
+        from bioetl.infrastructure.validation import PanderaGoldValidator
+
+        validator = PanderaGoldValidator(None, strict=True)
+        records = [{"id": 1, "value": "test"}]
+
+        result = validator.validate(records)
+
+        assert result.valid is False
+        assert len(result.errors) == 1
+        assert "Gold schema is required but not provided" in result.errors[0]
+
+    def test_pandera_validator_empty_records_strict(self):
+        """Test PanderaGoldValidator with empty records in strict mode."""
+        from bioetl.infrastructure.validation import PanderaGoldValidator
+
+        validator = PanderaGoldValidator(None, strict=True)
+
+        result = validator.validate([])
+
+        assert result.valid is True
+        assert result.errors == []
+
+    def test_pandera_validator_with_schema_strict(self):
+        """Test PanderaGoldValidator with schema in strict mode validates normally."""
+        import pandera.pandas as pa
+
+        from bioetl.infrastructure.validation import PanderaGoldValidator
+
+        schema = pa.DataFrameSchema(
+            {
+                "id": pa.Column(int),
+                "name": pa.Column(str),
+            }
+        )
+        validator = PanderaGoldValidator(schema, strict=True)
+        records = [{"id": 1, "name": "test"}]
+
+        result = validator.validate(records)
+
+        assert result.valid is True
+        assert result.errors == []

--- a/tests/unit/application/test_pipeline_config.py
+++ b/tests/unit/application/test_pipeline_config.py
@@ -200,3 +200,16 @@ class TestRuntimeConfig:
         for run_type in RunType:
             runtime = RuntimeConfig(run_type=run_type)
             assert runtime.run_type == run_type
+
+    def test_strict_gold_validation_default_false(self):
+        """Test that strict_gold_validation defaults to False."""
+        runtime = RuntimeConfig(run_type=RunType.INCREMENTAL)
+        assert runtime.strict_gold_validation is False
+
+    def test_strict_gold_validation_true(self):
+        """Test setting strict_gold_validation to True."""
+        runtime = RuntimeConfig(
+            run_type=RunType.INCREMENTAL,
+            strict_gold_validation=True,
+        )
+        assert runtime.strict_gold_validation is True


### PR DESCRIPTION
- Add strict mode parameter to GoldValidator and PanderaGoldValidator
- When strict=True and schema is None, validation fails with error message
- Add strict_gold_validation field to RuntimeConfig (default False)
- Update ServicesBuilder and GenericPipelineFactory to pass strict flag
- Add comprehensive tests for strict mode validation

This allows pipelines to enforce Gold schema requirements while maintaining backward compatibility with existing pipelines via feature flag.

Refs: REQ-GOLD-001