### PR TITLE
Remove default ingestion timestamp from BaseEntity

### DIFF
--- a/src/bioetl/application/core/base_transformer.py
+++ b/src/bioetl/application/core/base_transformer.py
@@ -424,6 +424,7 @@ class BaseTransformer(ABC):
             run_id=context.run_id,
             run_type=context.run_type,
             source_batch_id=None,
+            ingestion_ts=context.started_at,
             **business_data,
         )
 

--- a/src/bioetl/domain/entities/base.py
+++ b/src/bioetl/domain/entities/base.py
@@ -25,7 +25,7 @@ class BaseEntity:
     run_id: RunID
     run_type: RunType
     source_batch_id: BatchID | None = None  # None when batch context unavailable
-    ingestion_ts: datetime = field(default_factory=lambda: datetime.now(UTC))
+    ingestion_ts: datetime  # Required: pass context.started_at (ADR-014)
 
     def __post_init__(self) -> None:
         if not self.entity_id:

--- a/tests/unit/domain/test_entities.py
+++ b/tests/unit/domain/test_entities.py
@@ -20,6 +20,7 @@ def base_entity_kwargs():
         "run_id": uuid4(),
         "run_type": RunType.INCREMENTAL,
         "source_batch_id": uuid4(),
+        "ingestion_ts": datetime.now(UTC),
     }
 
 
@@ -51,8 +52,23 @@ class TestBaseEntity:
                 assay_chembl_id="CHEMBL789",
             )
 
-    def test_base_entity_default_ingestion_ts(self, base_entity_kwargs):
-        """Test that ingestion_ts has a default value."""
+    def test_base_entity_requires_ingestion_ts(self, base_entity_kwargs):
+        """Test that ingestion_ts is required (no default) per ADR-014."""
+        # Remove ingestion_ts to verify it's required
+        kwargs_without_ts = {
+            k: v for k, v in base_entity_kwargs.items() if k != "ingestion_ts"
+        }
+        with pytest.raises(TypeError, match="ingestion_ts"):
+            Activity(
+                **kwargs_without_ts,
+                activity_id="ACT1",
+                molecule_chembl_id="CHEMBL123",
+                target_chembl_id="CHEMBL456",
+                assay_chembl_id="CHEMBL789",
+            )
+
+    def test_base_entity_accepts_explicit_ingestion_ts(self, base_entity_kwargs):
+        """Test that explicitly passed ingestion_ts is used."""
         activity = Activity(
             **base_entity_kwargs,
             activity_id="ACT1",


### PR DESCRIPTION
Remove the default_factory for ingestion_ts in BaseEntity to comply with ADR-014 (deterministic writes). The ingestion_ts must now be explicitly passed from context.started_at.

Changes:
- Remove default from BaseEntity.ingestion_ts field
- Update BaseTransformer._create_entity() to pass ingestion_ts from context
- Add test verifying ingestion_ts is required (no default)
- Update test fixture to include explicit ingestion_ts