### PR TITLE
Parameterize datetime for better testability

### DIFF
--- a/src/bioetl/infrastructure/observability/anomaly/detector.py
+++ b/src/bioetl/infrastructure/observability/anomaly/detector.py
@@ -90,9 +90,20 @@ class AnomalyDetector:
 
         self._thresholds[metric_name] = (min_val, max_val)
 
-    def detect(self, metric_name: str, current_value: float) -> Anomaly | None:
-        """Detect anomaly in current value."""
-        if anomaly := self._check_thresholds(metric_name, current_value):
+    def detect(
+        self, metric_name: str, current_value: float, now: datetime | None = None
+    ) -> Anomaly | None:
+        """Detect anomaly in current value.
+
+        Args:
+            metric_name: Name of metric being analyzed
+            current_value: Current observed value
+            now: Optional timestamp for testing (defaults to current UTC time)
+
+        Returns:
+            Anomaly if detected, None otherwise
+        """
+        if anomaly := self._check_thresholds(metric_name, current_value, now):
             return anomaly
 
         baseline = self._baselines.get(metric_name, [])
@@ -100,11 +111,11 @@ class AnomalyDetector:
             return None
 
         return self.strategy.detect(
-            metric_name, current_value, baseline, self.z_score_threshold
+            metric_name, current_value, baseline, self.z_score_threshold, now
         )
 
     def _check_thresholds(
-        self, metric_name: str, current_value: float
+        self, metric_name: str, current_value: float, now: datetime | None = None
     ) -> Anomaly | None:
         """Check if the current value exceeds configured thresholds."""
         if metric_name not in self._thresholds:
@@ -115,7 +126,7 @@ class AnomalyDetector:
             return None
 
         return self._create_threshold_anomaly(
-            metric_name, current_value, min_val, max_val
+            metric_name, current_value, min_val, max_val, now
         )
 
     def _create_threshold_anomaly(
@@ -124,6 +135,7 @@ class AnomalyDetector:
         current_value: float,
         min_val: float,
         max_val: float,
+        now: datetime | None = None,
     ) -> Anomaly:
         """Create anomaly for threshold breach."""
         baseline_mean = (min_val + max_val) / 2
@@ -150,7 +162,7 @@ class AnomalyDetector:
             anomaly_type=AnomalyType.THRESHOLD_EXCEEDED,
             severity=AnomalySeverity.CRITICAL,
             z_score=z_score,
-            timestamp=datetime.now(UTC),
+            timestamp=now or datetime.now(UTC),
             message=message,
         )
 

--- a/src/bioetl/infrastructure/observability/anomaly/detectors/base.py
+++ b/src/bioetl/infrastructure/observability/anomaly/detectors/base.py
@@ -6,6 +6,7 @@ Defines interface that all detection algorithms must implement.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -34,6 +35,7 @@ class DetectorStrategy(ABC):
         current_value: float,
         baseline: Sequence[float],
         threshold: float,
+        now: datetime | None = None,
     ) -> Anomaly | None:
         """Detect anomaly in current value.
 
@@ -42,6 +44,7 @@ class DetectorStrategy(ABC):
             current_value: Current observed value
             baseline: Historical values for comparison
             threshold: Detection threshold (interpretation varies by strategy)
+            now: Optional timestamp for testing (defaults to current UTC time)
 
         Returns:
             Anomaly if detected, None otherwise

--- a/src/bioetl/infrastructure/observability/anomaly/detectors/iqr.py
+++ b/src/bioetl/infrastructure/observability/anomaly/detectors/iqr.py
@@ -41,6 +41,7 @@ class IQRDetector(DetectorStrategy):
         current_value: float,
         baseline: Sequence[float],
         threshold: float = 1.5,
+        now: datetime | None = None,
     ) -> Anomaly | None:
         """Detect anomaly using IQR method."""
         if len(baseline) < self.MIN_SAMPLES:
@@ -58,7 +59,7 @@ class IQRDetector(DetectorStrategy):
 
         mean = statistics.mean(baseline)
         stddev = statistics.stdev(baseline) if len(baseline) >= 2 else 0.0
-        return self._create_anomaly(metric_name, current_value, mean, stddev, score)
+        return self._create_anomaly(metric_name, current_value, mean, stddev, score, now)
 
     def _calculate_quartiles(self, data: Sequence[float]) -> tuple[float, float]:
         """Calculate Q1 and Q3 quartiles."""
@@ -85,6 +86,7 @@ class IQRDetector(DetectorStrategy):
         mean: float,
         stddev: float,
         score: float,
+        now: datetime | None = None,
     ) -> Anomaly:
         """Create Anomaly object from detection results."""
         anomaly_type = AnomalyType.SPIKE if current_value > mean else AnomalyType.DROP
@@ -102,7 +104,7 @@ class IQRDetector(DetectorStrategy):
             anomaly_type=anomaly_type,
             severity=severity,
             z_score=score,
-            timestamp=datetime.now(UTC),
+            timestamp=now or datetime.now(UTC),
             message=message,
         )
 

--- a/src/bioetl/infrastructure/observability/anomaly/detectors/mad.py
+++ b/src/bioetl/infrastructure/observability/anomaly/detectors/mad.py
@@ -42,6 +42,7 @@ class MADDetector(DetectorStrategy):
         current_value: float,
         baseline: Sequence[float],
         threshold: float = 2.0,
+        now: datetime | None = None,
     ) -> Anomaly | None:
         """Detect anomaly using MAD method."""
         if len(baseline) < self.MIN_SAMPLES:
@@ -59,7 +60,7 @@ class MADDetector(DetectorStrategy):
 
         mean = statistics.mean(baseline)
         stddev = statistics.stdev(baseline) if len(baseline) >= 2 else 0.0
-        return self._create_anomaly(metric_name, current_value, mean, stddev, score)
+        return self._create_anomaly(metric_name, current_value, mean, stddev, score, now)
 
     def _calculate_mad(self, data: Sequence[float], median: float) -> float:
         """Calculate Median Absolute Deviation."""
@@ -79,6 +80,7 @@ class MADDetector(DetectorStrategy):
         mean: float,
         stddev: float,
         score: float,
+        now: datetime | None = None,
     ) -> Anomaly:
         """Create Anomaly object from detection results."""
         anomaly_type = AnomalyType.SPIKE if current_value > mean else AnomalyType.DROP
@@ -96,7 +98,7 @@ class MADDetector(DetectorStrategy):
             anomaly_type=anomaly_type,
             severity=severity,
             z_score=score,
-            timestamp=datetime.now(UTC),
+            timestamp=now or datetime.now(UTC),
             message=message,
         )
 

--- a/src/bioetl/infrastructure/observability/anomaly/detectors/zscore.py
+++ b/src/bioetl/infrastructure/observability/anomaly/detectors/zscore.py
@@ -38,6 +38,7 @@ class ZScoreDetector(DetectorStrategy):
         current_value: float,
         baseline: Sequence[float],
         threshold: float = 2.0,
+        now: datetime | None = None,
     ) -> Anomaly | None:
         """Detect anomaly using Z-score method."""
         if len(baseline) < self.MIN_SAMPLES:
@@ -50,7 +51,7 @@ class ZScoreDetector(DetectorStrategy):
         if z_score is None or z_score < threshold:
             return None
 
-        return self._create_anomaly(metric_name, current_value, mean, stddev, z_score)
+        return self._create_anomaly(metric_name, current_value, mean, stddev, z_score, now)
 
     def _calculate_z_score(
         self, value: float, mean: float, stddev: float
@@ -70,6 +71,7 @@ class ZScoreDetector(DetectorStrategy):
         mean: float,
         stddev: float,
         z_score: float,
+        now: datetime | None = None,
     ) -> Anomaly:
         """Create Anomaly object from detection results."""
         anomaly_type = AnomalyType.SPIKE if current_value > mean else AnomalyType.DROP
@@ -87,7 +89,7 @@ class ZScoreDetector(DetectorStrategy):
             anomaly_type=anomaly_type,
             severity=severity,
             z_score=z_score,
-            timestamp=datetime.now(UTC),
+            timestamp=now or datetime.now(UTC),
             message=message,
         )
 

--- a/src/bioetl/infrastructure/observability/lineage.py
+++ b/src/bioetl/infrastructure/observability/lineage.py
@@ -173,6 +173,7 @@ class LineageTracker:
         file_path: str,
         watermark: str | None = None,
         metadata: dict[str, Any] | None = None,
+        now: datetime | None = None,
     ) -> None:
         """Record bronze layer batch ingestion.
 
@@ -185,6 +186,7 @@ class LineageTracker:
             file_path: Storage location
             watermark: Optional position marker (deprecated)
             metadata: Additional metadata
+            now: Optional timestamp for testing (defaults to current UTC time)
 
         """
         batch = BatchLineage(
@@ -198,7 +200,7 @@ class LineageTracker:
             file_path=file_path,
             watermark=watermark,
             metadata=metadata or {},
-            timestamp=datetime.now(UTC),
+            timestamp=now or datetime.now(UTC),
         )
 
         self._write_batch_lineage(batch)
@@ -215,6 +217,7 @@ class LineageTracker:
         success_count: int,
         failure_count: int,
         metadata: dict[str, Any] | None = None,
+        now: datetime | None = None,
     ) -> None:
         """Record data transformation between layers.
 
@@ -229,6 +232,7 @@ class LineageTracker:
             success_count: Successful transformations
             failure_count: Failed transformations
             metadata: Additional metadata
+            now: Optional timestamp for testing (defaults to current UTC time)
 
         """
         lineage = LineageRecord(
@@ -244,7 +248,7 @@ class LineageTracker:
             success_count=success_count,
             failure_count=failure_count,
             metadata=metadata or {},
-            timestamp=datetime.now(UTC),
+            timestamp=now or datetime.now(UTC),
         )
 
         self._write_transformation_lineage(lineage)
@@ -413,12 +417,14 @@ class LineageTracker:
         self,
         layer: str,
         days: int = 7,
+        now: datetime | None = None,
     ) -> dict[str, Any]:
         """Get batch statistics for a layer.
 
         Args:
             layer: Data layer (bronze, silver, gold)
             days: Number of days to analyze
+            now: Optional timestamp for testing (defaults to current UTC time)
 
         Returns:
             Dictionary with statistics (total_batches, total_records, avg_batch_size)
@@ -433,7 +439,8 @@ class LineageTracker:
             df = df.filter(pl.col("layer") == layer)
 
             # Filter by date range
-            cutoff = datetime.now(UTC).timestamp() - (days * 86400)
+            timestamp = now or datetime.now(UTC)
+            cutoff = timestamp.timestamp() - (days * 86400)
             df = df.filter(pl.col("timestamp") >= cutoff)
 
             if df.height == 0:


### PR DESCRIPTION
Add optional `now` parameter to methods that use datetime.now(UTC):

- lineage.py: record_bronze(), record_transformation(), get_batch_statistics()
- detector.py: detect(), _check_thresholds(), _create_threshold_anomaly()
- base.py: DetectorStrategy.detect() (abstract method)
- zscore.py, iqr.py, mad.py: detect(), _create_anomaly()

All methods default to datetime.now(UTC) when `now` is None, preserving backward compatibility. This enables deterministic testing with fixed timestamps.