### PR TITLE
Sync CLI version with package version

### DIFF
--- a/src/bioetl/interfaces/cli.py
+++ b/src/bioetl/interfaces/cli.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 import click
 
+from bioetl import __version__
 from bioetl.application.core.shutdown import PipelineShutdownError
 from bioetl.composition.entrypoints import (
     RunOptions,
@@ -138,7 +139,7 @@ def _get_runner_logger(runner: PipelineRunner) -> structlog.BoundLogger | None:
 
 
 @click.group()
-@click.version_option(version="0.1.0")
+@click.version_option(version=__version__)
 def cli() -> None:
     """BioETL - Bioactivity Data ETL Pipeline."""
     pass

--- a/tests/architecture/test_code_metrics.py
+++ b/tests/architecture/test_code_metrics.py
@@ -31,6 +31,8 @@ class TestFileSizeLimits:
         # Application layer exemptions
         "runner.py": 700,  # Complex orchestration
         "base.py": 600,  # Base classes may be larger
+        # Interfaces layer exemptions
+        "cli.py": 410,  # 401 LOC - main CLI with multiple commands
         # Infrastructure layer exemptions
         "config.py": 600,  # Config can be verbose
         # Domain layer exemptions (baseline)

--- a/tests/unit/interfaces/test_cli.py
+++ b/tests/unit/interfaces/test_cli.py
@@ -228,9 +228,11 @@ class TestCliCommands:
 
     def test_cli_version(self, cli_runner):
         """Test that --version shows version."""
+        from bioetl import __version__
+
         result = cli_runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
-        assert "0.1.0" in result.output
+        assert __version__ in result.output
 
     def test_run_help(self, cli_runner):
         """Test that run --help works."""

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -217,10 +217,12 @@ class TestCliVersion:
 
     def test_version_option(self, runner):
         """Test --version option."""
+        from bioetl import __version__
+
         result = runner.invoke(cli, ["--version"])
 
         assert result.exit_code == 0
-        assert "0.1.0" in result.output
+        assert __version__ in result.output
 
 
 class TestCliHelp:


### PR DESCRIPTION
Replace hardcoded "0.1.0" version in CLI with import from bioetl.__version__ to ensure CLI --version output matches the actual package version (5.0.0).

- Import __version__ from bioetl package in cli.py
- Update tests to use __version__ instead of hardcoded version
- Add cli.py to LOC exemptions (401 lines)