### PR TITLE
Add medallion policy preflight validation

### DIFF
--- a/src/bioetl/application/core/preflight_service.py
+++ b/src/bioetl/application/core/preflight_service.py
@@ -10,11 +10,13 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from bioetl.application.core.health_aggregator import HealthAggregator
-from bioetl.domain.medallion import MedallionPolicy
+from bioetl.domain.exceptions import PolicyViolationError
+from bioetl.domain.medallion import Layer, MedallionPolicy, WriteMode, WriteModePolicy
 from bioetl.domain.types import (
     ConfigValidationError,
     HealthReport,
     HealthStatus,
+    PreflightReport,
     RunType,
 )
 
@@ -332,6 +334,194 @@ class PreflightService:
                 )
 
         return errors
+
+    def validate_write_modes(self) -> list[ConfigValidationError]:
+        """Validate that config write modes are allowed by medallion policy.
+
+        Проверяет соответствие write_mode и gold_write_mode политике Medallion:
+        - Silver: APPEND или MERGE (REQ-MEDALLION-002)
+        - Gold: MERGE или OVERWRITE (REQ-MEDALLION-003)
+
+        Returns:
+            List of ConfigValidationError if write modes violate policy.
+        """
+        errors: list[ConfigValidationError] = []
+        write_mode_policy = WriteModePolicy()
+
+        # Validate Silver write mode
+        silver_mode = self._config.write_mode
+        try:
+            write_mode_policy.validate(Layer.SILVER, WriteMode(silver_mode))
+        except (PolicyViolationError, ValueError):
+            allowed = WriteModePolicy.ALLOWED_MODES[Layer.SILVER]
+            allowed_names = ", ".join(m.value for m in sorted(allowed, key=lambda x: x.value))
+            errors.append(
+                ConfigValidationError(
+                    field="write_mode",
+                    expected=f"one of: {allowed_names}",
+                    actual=silver_mode,
+                    rule="RULES §2.1: Silver layer allowed modes",
+                )
+            )
+
+        # Validate Gold write mode
+        gold_mode = self._config.gold_write_mode
+        # Gold supports 'scd2' which maps to MERGE for policy purposes
+        effective_gold_mode = "merge" if gold_mode == "scd2" else gold_mode
+        try:
+            write_mode_policy.validate(Layer.GOLD, WriteMode(effective_gold_mode))
+        except (PolicyViolationError, ValueError):
+            allowed = WriteModePolicy.ALLOWED_MODES[Layer.GOLD]
+            allowed_names = ", ".join(m.value for m in sorted(allowed, key=lambda x: x.value))
+            errors.append(
+                ConfigValidationError(
+                    field="gold_write_mode",
+                    expected=f"one of: {allowed_names}, scd2",
+                    actual=gold_mode,
+                    rule="RULES §2.1: Gold layer allowed modes",
+                )
+            )
+
+        # Log validation results
+        if errors:
+            self._logger.warning(
+                "Write mode validation found issues",
+                extra={
+                    "error_count": len(errors),
+                    "errors": [{"field": e.field, "rule": e.rule} for e in errors],
+                },
+            )
+        else:
+            self._logger.debug(
+                "Write mode validation passed",
+                extra={
+                    "silver_mode": silver_mode,
+                    "gold_mode": gold_mode,
+                },
+            )
+
+        return errors
+
+    async def validate_preflight(
+        self,
+        services: PipelineServices,
+        runtime: RuntimeConfig,
+        bronze_path: str,
+        silver_path: str,
+        gold_path: str,
+        silver_format: str | None = None,
+        gold_format: str | None = None,
+    ) -> PreflightReport:
+        """Execute complete preflight validation.
+
+        Performs all preflight checks:
+        1. Infrastructure health validation
+        2. Medallion config validation
+        3. Write mode policy validation
+
+        Args:
+            services: Pipeline services for health checks.
+            runtime: Runtime configuration.
+            bronze_path: Base path for Bronze layer storage.
+            silver_path: Base path for Silver layer storage.
+            gold_path: Base path for Gold layer storage.
+            silver_format: Format of Silver layer.
+            gold_format: Format of Gold layer.
+
+        Returns:
+            PreflightReport with aggregated validation results.
+
+        Raises:
+            InfrastructureError: If critical infrastructure is unhealthy
+                and strict_validation is enabled.
+            ValueError: If medallion policy is invalid and strict_validation
+                is enabled.
+        """
+        self._logger.info(
+            "Starting preflight validation",
+            extra={"stage": "preflight", "strict_mode": runtime.strict_validation},
+        )
+
+        # 1. Validate infrastructure health
+        health_report = await self.validate_infrastructure(services)
+
+        # 2. Validate medallion config
+        config_errors = self.validate_medallion_config(
+            runtime=runtime,
+            bronze_path=bronze_path,
+            silver_path=silver_path,
+            gold_path=gold_path,
+            silver_format=silver_format,
+            gold_format=gold_format,
+        )
+
+        # 3. Validate write modes against policy
+        write_mode_errors = self.validate_write_modes()
+        config_errors.extend(write_mode_errors)
+
+        # Determine if medallion policy is valid
+        medallion_policy_valid = len(config_errors) == 0
+
+        # Create preflight report
+        report = PreflightReport(
+            health_report=health_report,
+            medallion_policy_valid=medallion_policy_valid,
+            config_errors=config_errors,
+        )
+
+        # Record metrics
+        self._record_preflight_metrics(report)
+
+        # Log final result
+        self._logger.info(
+            "Preflight validation completed",
+            extra={
+                "stage": "preflight",
+                "medallion_policy_valid": medallion_policy_valid,
+                "config_error_count": len(config_errors),
+                "is_healthy": health_report.is_healthy,
+                "should_block": report.should_block_startup,
+            },
+        )
+
+        # Block startup if validation failed and strict mode is enabled
+        if report.should_block_startup and runtime.strict_validation:
+            error_messages = [
+                f"{e.field}: {e.actual} (expected: {e.expected})"
+                for e in config_errors
+            ]
+            raise ValueError(
+                f"Preflight validation failed (strict mode): {', '.join(error_messages)}"
+            )
+
+        return report
+
+    def _record_preflight_metrics(self, report: PreflightReport) -> None:
+        """Record preflight validation metrics.
+
+        Records:
+        - preflight_medallion_policy_valid: Whether policy validation passed
+        - preflight_config_errors_total: Count of configuration errors
+
+        Args:
+            report: PreflightReport with validation results.
+        """
+        pipeline = self._config.pipeline_name
+        run_id = str(self._context.run_id)
+
+        # Record medallion policy validation status
+        self._metrics.set_gauge(
+            "preflight_medallion_policy_valid",
+            1.0 if report.medallion_policy_valid else 0.0,
+            {"pipeline": pipeline, "run_id": run_id},
+        )
+
+        # Record config error count
+        self._metrics.set_gauge(
+            "preflight_config_errors_total",
+            float(len(report.config_errors)),
+            {"pipeline": pipeline, "run_id": run_id},
+        )
 
 
 __all__ = ["PreflightService"]

--- a/src/bioetl/domain/types.py
+++ b/src/bioetl/domain/types.py
@@ -335,3 +335,33 @@ class HealthReport:
     def get_failures(self) -> list[ComponentHealthResult]:
         """Return list of components with UNHEALTHY status."""
         return [r for r in self.results if r.status == HealthStatus.UNHEALTHY]
+
+
+@dataclass(frozen=True, slots=True)
+class PreflightReport:
+    """Preflight validation report.
+
+    Aggregates results from infrastructure health checks and
+    medallion policy validation.
+
+    Attributes:
+        health_report: Infrastructure health check results.
+        medallion_policy_valid: True if config is compatible with policy.
+        config_errors: List of configuration validation errors.
+        checked_at: Timestamp when validation was performed.
+    """
+
+    health_report: HealthReport
+    medallion_policy_valid: bool
+    config_errors: list[ConfigValidationError] = field(default_factory=list)
+    checked_at: datetime = field(default_factory=lambda: datetime.now(tz=UTC))
+
+    @property
+    def is_valid(self) -> bool:
+        """Return True if all validations passed."""
+        return self.health_report.is_healthy and self.medallion_policy_valid
+
+    @property
+    def should_block_startup(self) -> bool:
+        """Return True if validation failures should block pipeline startup."""
+        return not self.medallion_policy_valid or not self.health_report.is_healthy

--- a/tests/unit/application/core/test_preflight_service.py
+++ b/tests/unit/application/core/test_preflight_service.py
@@ -13,7 +13,9 @@ from bioetl.domain.context import PipelineContext
 from bioetl.domain.exceptions import InfrastructureError
 from bioetl.domain.types import (
     ConfigValidationError,
+    HealthReport,
     HealthStatus,
+    PreflightReport,
     RunType,
 )
 
@@ -666,3 +668,379 @@ class TestRuntimeConfigStrictValidation:
         assert runtime.strict_validation is True
         assert runtime.dry_run is True
         assert runtime.limit == 100
+
+
+@pytest.mark.unit
+class TestValidateWriteModes:
+    """Tests for PreflightService.validate_write_modes method."""
+
+    def test_valid_write_modes_returns_empty_errors(
+        self, preflight_service
+    ):
+        """Test that valid write modes return no errors."""
+        errors = preflight_service.validate_write_modes()
+        assert errors == []
+
+    def test_silver_merge_mode_is_valid(
+        self, mock_context, mock_logger, mock_metrics
+    ):
+        """Test that Silver 'merge' mode is valid."""
+        config = PipelineConfig(
+            pipeline_name="test",
+            provider="chembl",
+            entity_type="activity",
+            primary_keys=["id"],
+            silver_table="silver",
+            write_mode="merge",
+        )
+        service = PreflightService(
+            config=config, context=mock_context, logger=mock_logger, metrics=mock_metrics
+        )
+        errors = service.validate_write_modes()
+        assert len([e for e in errors if e.field == "write_mode"]) == 0
+
+    def test_silver_append_mode_is_valid(
+        self, mock_context, mock_logger, mock_metrics
+    ):
+        """Test that Silver 'append' mode is valid."""
+        config = PipelineConfig(
+            pipeline_name="test",
+            provider="chembl",
+            entity_type="activity",
+            primary_keys=["id"],
+            silver_table="silver",
+            write_mode="append",
+        )
+        service = PreflightService(
+            config=config, context=mock_context, logger=mock_logger, metrics=mock_metrics
+        )
+        errors = service.validate_write_modes()
+        assert len([e for e in errors if e.field == "write_mode"]) == 0
+
+    def test_silver_overwrite_mode_is_invalid(
+        self, mock_context, mock_logger, mock_metrics
+    ):
+        """Test that Silver 'overwrite' mode is invalid."""
+        config = PipelineConfig(
+            pipeline_name="test",
+            provider="chembl",
+            entity_type="activity",
+            primary_keys=["id"],
+            silver_table="silver",
+            write_mode="overwrite",
+        )
+        service = PreflightService(
+            config=config, context=mock_context, logger=mock_logger, metrics=mock_metrics
+        )
+        errors = service.validate_write_modes()
+        silver_errors = [e for e in errors if e.field == "write_mode"]
+        assert len(silver_errors) == 1
+        assert "RULES §2.1" in silver_errors[0].rule
+
+    def test_gold_merge_mode_is_valid(
+        self, mock_context, mock_logger, mock_metrics
+    ):
+        """Test that Gold 'merge' mode is valid."""
+        config = PipelineConfig(
+            pipeline_name="test",
+            provider="chembl",
+            entity_type="activity",
+            primary_keys=["id"],
+            silver_table="silver",
+            gold_write_mode="merge",
+        )
+        service = PreflightService(
+            config=config, context=mock_context, logger=mock_logger, metrics=mock_metrics
+        )
+        errors = service.validate_write_modes()
+        assert len([e for e in errors if e.field == "gold_write_mode"]) == 0
+
+    def test_gold_overwrite_mode_is_valid(
+        self, mock_context, mock_logger, mock_metrics
+    ):
+        """Test that Gold 'overwrite' mode is valid."""
+        config = PipelineConfig(
+            pipeline_name="test",
+            provider="chembl",
+            entity_type="activity",
+            primary_keys=["id"],
+            silver_table="silver",
+            gold_write_mode="overwrite",
+        )
+        service = PreflightService(
+            config=config, context=mock_context, logger=mock_logger, metrics=mock_metrics
+        )
+        errors = service.validate_write_modes()
+        assert len([e for e in errors if e.field == "gold_write_mode"]) == 0
+
+    def test_gold_scd2_mode_is_valid(
+        self, mock_context, mock_logger, mock_metrics
+    ):
+        """Test that Gold 'scd2' mode is valid (maps to merge)."""
+        config = PipelineConfig(
+            pipeline_name="test",
+            provider="chembl",
+            entity_type="activity",
+            primary_keys=["id"],
+            silver_table="silver",
+            gold_write_mode="scd2",
+        )
+        service = PreflightService(
+            config=config, context=mock_context, logger=mock_logger, metrics=mock_metrics
+        )
+        errors = service.validate_write_modes()
+        assert len([e for e in errors if e.field == "gold_write_mode"]) == 0
+
+    def test_gold_append_mode_is_invalid(
+        self, mock_context, mock_logger, mock_metrics
+    ):
+        """Test that Gold 'append' mode is invalid."""
+        config = PipelineConfig(
+            pipeline_name="test",
+            provider="chembl",
+            entity_type="activity",
+            primary_keys=["id"],
+            silver_table="silver",
+            gold_write_mode="append",
+        )
+        service = PreflightService(
+            config=config, context=mock_context, logger=mock_logger, metrics=mock_metrics
+        )
+        errors = service.validate_write_modes()
+        gold_errors = [e for e in errors if e.field == "gold_write_mode"]
+        assert len(gold_errors) == 1
+        assert "RULES §2.1" in gold_errors[0].rule
+
+    def test_logs_warning_on_invalid_modes(
+        self, mock_context, mock_logger, mock_metrics
+    ):
+        """Test that invalid write modes are logged as warnings."""
+        config = PipelineConfig(
+            pipeline_name="test",
+            provider="chembl",
+            entity_type="activity",
+            primary_keys=["id"],
+            silver_table="silver",
+            write_mode="overwrite",  # Invalid
+        )
+        service = PreflightService(
+            config=config, context=mock_context, logger=mock_logger, metrics=mock_metrics
+        )
+        service.validate_write_modes()
+        mock_logger.warning.assert_called()
+
+    def test_logs_debug_on_valid_modes(
+        self, preflight_service, mock_logger
+    ):
+        """Test that valid write modes are logged as debug."""
+        preflight_service.validate_write_modes()
+        mock_logger.debug.assert_called()
+
+
+@pytest.mark.unit
+class TestValidatePreflight:
+    """Tests for PreflightService.validate_preflight method."""
+
+    @pytest.mark.asyncio
+    async def test_validate_preflight_returns_report(
+        self, preflight_service, mock_services, incremental_runtime
+    ):
+        """Test validate_preflight returns a PreflightReport."""
+        report = await preflight_service.validate_preflight(
+            services=mock_services,
+            runtime=incremental_runtime,
+            bronze_path="/data/bronze",
+            silver_path="/data/silver",
+            gold_path="/data/gold",
+            silver_format="delta",
+            gold_format="delta",
+        )
+
+        assert isinstance(report, PreflightReport)
+        assert report.medallion_policy_valid is True
+        assert report.health_report is not None
+        assert len(report.config_errors) == 0
+
+    @pytest.mark.asyncio
+    async def test_validate_preflight_with_config_errors(
+        self, preflight_service, mock_services, incremental_runtime
+    ):
+        """Test validate_preflight with configuration errors."""
+        report = await preflight_service.validate_preflight(
+            services=mock_services,
+            runtime=incremental_runtime,
+            bronze_path="/data/bronze",
+            silver_path="/data/silver",
+            gold_path="/data/gold",
+            silver_format="parquet",  # Invalid!
+            gold_format="delta",
+        )
+
+        assert report.medallion_policy_valid is False
+        assert len(report.config_errors) > 0
+        assert report.should_block_startup is True
+
+    @pytest.mark.asyncio
+    async def test_validate_preflight_strict_mode_raises(
+        self, preflight_service, mock_services
+    ):
+        """Test validate_preflight raises in strict mode on errors."""
+        strict_runtime = RuntimeConfig(
+            run_type=RunType.INCREMENTAL,
+            strict_validation=True,
+        )
+
+        with pytest.raises(ValueError, match="Preflight validation failed"):
+            await preflight_service.validate_preflight(
+                services=mock_services,
+                runtime=strict_runtime,
+                bronze_path="/data/bronze",
+                silver_path="/data/silver",
+                gold_path="/data/gold",
+                silver_format="parquet",  # Invalid!
+                gold_format="delta",
+            )
+
+    @pytest.mark.asyncio
+    async def test_validate_preflight_non_strict_mode_returns_report(
+        self, preflight_service, mock_services, incremental_runtime
+    ):
+        """Test validate_preflight returns report in non-strict mode with errors."""
+        report = await preflight_service.validate_preflight(
+            services=mock_services,
+            runtime=incremental_runtime,
+            bronze_path="/data/bronze",
+            silver_path="/data/silver",
+            gold_path="/data/gold",
+            silver_format="parquet",  # Invalid!
+            gold_format="delta",
+        )
+
+        # Should not raise, should return report
+        assert report.medallion_policy_valid is False
+
+    @pytest.mark.asyncio
+    async def test_validate_preflight_records_metrics(
+        self, preflight_service, mock_services, incremental_runtime, mock_metrics
+    ):
+        """Test validate_preflight records metrics."""
+        await preflight_service.validate_preflight(
+            services=mock_services,
+            runtime=incremental_runtime,
+            bronze_path="/data/bronze",
+            silver_path="/data/silver",
+            gold_path="/data/gold",
+            silver_format="delta",
+            gold_format="delta",
+        )
+
+        # Check metrics were recorded
+        gauge_calls = [
+            call for call in mock_metrics.set_gauge.call_args_list
+            if call[0][0] == "preflight_medallion_policy_valid"
+        ]
+        assert len(gauge_calls) == 1
+        assert gauge_calls[0][0][1] == 1.0  # Valid
+
+    @pytest.mark.asyncio
+    async def test_validate_preflight_includes_write_mode_errors(
+        self, mock_context, mock_logger, mock_metrics, mock_services, incremental_runtime
+    ):
+        """Test validate_preflight includes write mode validation errors."""
+        config = PipelineConfig(
+            pipeline_name="test",
+            provider="chembl",
+            entity_type="activity",
+            primary_keys=["id"],
+            silver_table="silver",
+            write_mode="overwrite",  # Invalid for Silver
+        )
+        service = PreflightService(
+            config=config, context=mock_context, logger=mock_logger, metrics=mock_metrics
+        )
+
+        report = await service.validate_preflight(
+            services=mock_services,
+            runtime=incremental_runtime,
+            bronze_path="/data/bronze",
+            silver_path="/data/silver",
+            gold_path="/data/gold",
+            silver_format="delta",
+            gold_format="delta",
+        )
+
+        assert report.medallion_policy_valid is False
+        write_mode_errors = [e for e in report.config_errors if e.field == "write_mode"]
+        assert len(write_mode_errors) == 1
+
+
+@pytest.mark.unit
+class TestPreflightReportDataclass:
+    """Tests for PreflightReport dataclass."""
+
+    def test_preflight_report_creation(self):
+        """Test PreflightReport can be created with required fields."""
+        health_report = HealthReport(results=[])
+        report = PreflightReport(
+            health_report=health_report,
+            medallion_policy_valid=True,
+        )
+
+        assert report.health_report == health_report
+        assert report.medallion_policy_valid is True
+        assert report.config_errors == []
+
+    def test_preflight_report_with_errors(self):
+        """Test PreflightReport with config errors."""
+        health_report = HealthReport(results=[])
+        error = ConfigValidationError(
+            field="test", expected="a", actual="b", rule="test rule"
+        )
+        report = PreflightReport(
+            health_report=health_report,
+            medallion_policy_valid=False,
+            config_errors=[error],
+        )
+
+        assert report.medallion_policy_valid is False
+        assert len(report.config_errors) == 1
+
+    def test_preflight_report_is_valid_when_all_pass(self):
+        """Test is_valid returns True when all validations pass."""
+        health_report = HealthReport(results=[])
+        report = PreflightReport(
+            health_report=health_report,
+            medallion_policy_valid=True,
+        )
+
+        assert report.is_valid is True
+
+    def test_preflight_report_is_valid_false_on_policy_error(self):
+        """Test is_valid returns False on policy errors."""
+        health_report = HealthReport(results=[])
+        report = PreflightReport(
+            health_report=health_report,
+            medallion_policy_valid=False,
+        )
+
+        assert report.is_valid is False
+
+    def test_preflight_report_should_block_startup(self):
+        """Test should_block_startup returns True on policy errors."""
+        health_report = HealthReport(results=[])
+        report = PreflightReport(
+            health_report=health_report,
+            medallion_policy_valid=False,
+        )
+
+        assert report.should_block_startup is True
+
+    def test_preflight_report_should_not_block_when_valid(self):
+        """Test should_block_startup returns False when valid."""
+        health_report = HealthReport(results=[])
+        report = PreflightReport(
+            health_report=health_report,
+            medallion_policy_valid=True,
+        )
+
+        assert report.should_block_startup is False


### PR DESCRIPTION
Add preflight validation that checks if pipeline config is compatible with medallion policy:

- Add PreflightReport dataclass with medallion_policy_valid field
- Add validate_write_modes() to check write modes against WriteModePolicy
- Add validate_preflight() for complete preflight validation
- Record preflight_medallion_policy_valid metric
- Block startup when validation fails in strict mode

Implements REQ-MEDALLION-002 and REQ-MEDALLION-003.