### PR TITLE
Standardize event names across logging

### DIFF
--- a/src/bioetl/application/core/runner.py
+++ b/src/bioetl/application/core/runner.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from bioetl.application.observability.observer import PipelineObserver
+from bioetl.domain.events import PipelineEvent
 
 if TYPE_CHECKING:
     from bioetl.application.core.base import BasePipeline
@@ -106,8 +107,10 @@ class PipelineRunner:
         - Handles tracer close errors without failing the pipeline
         """
         self._logger.info(
-            f"Starting pipeline: {self._config.pipeline_name}",
-            extra={"stage": "startup", "run_type": self._runtime.run_type.value},
+            PipelineEvent.START,
+            pipeline=self._config.pipeline_name,
+            stage="startup",
+            run_type=self._runtime.run_type.value,
         )
 
         observer = PipelineObserver(
@@ -144,8 +147,8 @@ class PipelineRunner:
                     await self._checkpoint_manager.delete_checkpoint()
 
                 self._logger.debug(
-                    "Pipeline execution finished",
-                    extra={"records_fetched": self._executor.records_fetched},
+                    PipelineEvent.COMPLETE,
+                    records_fetched=self._executor.records_fetched,
                 )
         finally:
             await self._postrun_service.cleanup(self._tracer)

--- a/src/bioetl/application/observability/observer.py
+++ b/src/bioetl/application/observability/observer.py
@@ -20,6 +20,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from bioetl.application.core.shutdown import PipelineShutdownError
+from bioetl.domain.events import PipelineEvent
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -84,7 +85,7 @@ class PipelineObserver(AbstractContextManager["PipelineObserver"]):
             self.span.__enter__()
 
         # 2. Log Start
-        self.logger.info("pipeline_started", run_type=self.run_type)
+        self.logger.info(PipelineEvent.START, run_type=self.run_type)
 
         return self
 
@@ -135,15 +136,15 @@ class PipelineObserver(AbstractContextManager["PipelineObserver"]):
         }
         if status == "failed":
             self.logger.error(
-                "pipeline_failed",
+                PipelineEvent.FAILED,
                 **log_ctx,
                 error=str(exc_val),
                 error_type=type(exc_val).__name__,
             )
         elif status == "shutdown":
-            self.logger.warning("pipeline_shutdown", **log_ctx)
+            self.logger.warning(PipelineEvent.SHUTDOWN, **log_ctx)
         else:
-            self.logger.info("pipeline_finished", **log_ctx)
+            self.logger.info(PipelineEvent.COMPLETE, **log_ctx)
 
         # 3. End Trace Span (O3: handle close errors gracefully)
         if self.span:
@@ -211,7 +212,7 @@ class PipelineObserver(AbstractContextManager["PipelineObserver"]):
         Returns:
             Start timestamp for duration calculation.
         """
-        self.emit_event(f"{phase.value}_started", phase, **extra)
+        self.emit_event(PipelineEvent.phase_started(phase.value), phase, **extra)
         return time.monotonic()
 
     def emit_phase_completed(
@@ -233,7 +234,7 @@ class PipelineObserver(AbstractContextManager["PipelineObserver"]):
         status = "success" if success else "failed"
 
         self.emit_event(
-            f"{phase.value}_completed",
+            PipelineEvent.phase_completed(phase.value),
             phase,
             level="info" if success else "error",
             duration_seconds=round(duration, 4),
@@ -270,7 +271,7 @@ class PipelineObserver(AbstractContextManager["PipelineObserver"]):
             **extra: Additional context.
         """
         self.emit_event(
-            "health_check_completed",
+            PipelineEvent.HEALTH_CHECK_COMPLETED,
             LifecyclePhase.PREFLIGHT,
             level="info" if healthy else "warning",
             component=component,
@@ -306,7 +307,7 @@ class PipelineObserver(AbstractContextManager["PipelineObserver"]):
         """
         level = "error" if severity == "critical" else "warning"
         self.emit_event(
-            "dq_anomaly_detected",
+            PipelineEvent.DQ_ANOMALY_DETECTED,
             LifecyclePhase.POSTRUN,
             level=level,
             metric=metric_name,
@@ -346,7 +347,7 @@ class PipelineObserver(AbstractContextManager["PipelineObserver"]):
             **extra: Additional context.
         """
         self.emit_event(
-            "vacuum_completed",
+            PipelineEvent.VACUUM_COMPLETED,
             LifecyclePhase.POSTRUN,
             level="info" if success else "warning",
             layer=layer,

--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -45,6 +45,9 @@ from bioetl.domain.entities import (
 # Error classifier
 from bioetl.domain.error_classifier import ErrorClassifier
 
+# Events
+from bioetl.domain.events import PipelineEvent
+
 # Exceptions
 from bioetl.domain.exceptions import (
     ApiError,
@@ -179,6 +182,8 @@ __all__ = [
     "TargetComponent",
     # Error classifier
     "ErrorClassifier",
+    # Events
+    "PipelineEvent",
     # Exceptions - Base
     "ApiError",
     "AuthFailureError",

--- a/src/bioetl/domain/events.py
+++ b/src/bioetl/domain/events.py
@@ -1,0 +1,79 @@
+"""Domain Event Constants.
+
+Standardized event names for pipeline observability.
+All event logging should use these constants for consistency
+and grep-ability across the codebase.
+
+Usage:
+    from bioetl.domain.events import PipelineEvent
+
+    logger.info(PipelineEvent.START, run_type=run_type)
+    observer.emit_event(PipelineEvent.HEALTH_CHECK_COMPLETED, ...)
+"""
+
+from __future__ import annotations
+
+
+class PipelineEvent:
+    """Standardized pipeline event names.
+
+    Constants for all structured logging events.
+    Using class with class-level strings for simplicity and grep-ability.
+    """
+
+    # Pipeline lifecycle events
+    START = "pipeline_started"
+    COMPLETE = "pipeline_finished"
+    FAILED = "pipeline_failed"
+    SHUTDOWN = "pipeline_shutdown"
+
+    # Batch processing events
+    BATCH_START = "batch_started"
+    BATCH_COMPLETE = "batch_completed"
+
+    # Phase events (dynamically suffixed with _started/_completed)
+    STARTUP_STARTED = "startup_started"
+    STARTUP_COMPLETED = "startup_completed"
+    PREFLIGHT_STARTED = "preflight_started"
+    PREFLIGHT_COMPLETED = "preflight_completed"
+    LIFECYCLE_CLEAR_STARTED = "lifecycle_clear_started"
+    LIFECYCLE_CLEAR_COMPLETED = "lifecycle_clear_completed"
+    EXECUTION_STARTED = "execution_started"
+    EXECUTION_COMPLETED = "execution_completed"
+    POSTRUN_STARTED = "postrun_started"
+    POSTRUN_COMPLETED = "postrun_completed"
+    CLEANUP_STARTED = "cleanup_started"
+    CLEANUP_COMPLETED = "cleanup_completed"
+
+    # Health check events
+    HEALTH_CHECK_COMPLETED = "health_check_completed"
+
+    # Data quality events
+    DQ_ANOMALY_DETECTED = "dq_anomaly_detected"
+
+    # Maintenance events
+    VACUUM_COMPLETED = "vacuum_completed"
+
+    @classmethod
+    def phase_started(cls, phase_value: str) -> str:
+        """Generate phase started event name.
+
+        Args:
+            phase_value: LifecyclePhase value (e.g., "preflight").
+
+        Returns:
+            Event name (e.g., "preflight_started").
+        """
+        return f"{phase_value}_started"
+
+    @classmethod
+    def phase_completed(cls, phase_value: str) -> str:
+        """Generate phase completed event name.
+
+        Args:
+            phase_value: LifecyclePhase value (e.g., "preflight").
+
+        Returns:
+            Event name (e.g., "preflight_completed").
+        """
+        return f"{phase_value}_completed"

--- a/tests/unit/application/core/test_runner.py
+++ b/tests/unit/application/core/test_runner.py
@@ -391,12 +391,13 @@ class TestPipelineRunnerRun:
 
     @pytest.mark.asyncio
     async def test_run_logs_start_message(self, runner, mock_logger):
-        """Test run logs start message."""
+        """Test run logs start message using PipelineEvent.START constant."""
         await runner.run()
 
         mock_logger.info.assert_called()
         calls = [str(call) for call in mock_logger.info.call_args_list]
-        assert any("Starting pipeline" in call for call in calls)
+        # Runner now uses PipelineEvent.START = "pipeline_started"
+        assert any("pipeline_started" in call for call in calls)
 
     @pytest.mark.asyncio
     async def test_run_logs_completion_message(self, runner, mock_logger):

--- a/tests/unit/domain/test_events.py
+++ b/tests/unit/domain/test_events.py
@@ -1,0 +1,102 @@
+"""Tests for domain events module.
+
+Verifies PipelineEvent constants and helper methods.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bioetl.domain.events import PipelineEvent
+
+
+class TestPipelineEventConstants:
+    """Tests for PipelineEvent constants."""
+
+    def test_pipeline_lifecycle_events_defined(self) -> None:
+        """Verify all pipeline lifecycle events are defined."""
+        assert PipelineEvent.START == "pipeline_started"
+        assert PipelineEvent.COMPLETE == "pipeline_finished"
+        assert PipelineEvent.FAILED == "pipeline_failed"
+        assert PipelineEvent.SHUTDOWN == "pipeline_shutdown"
+
+    def test_batch_events_defined(self) -> None:
+        """Verify batch processing events are defined."""
+        assert PipelineEvent.BATCH_START == "batch_started"
+        assert PipelineEvent.BATCH_COMPLETE == "batch_completed"
+
+    def test_phase_events_defined(self) -> None:
+        """Verify all phase events are defined."""
+        # Started events
+        assert PipelineEvent.STARTUP_STARTED == "startup_started"
+        assert PipelineEvent.STARTUP_COMPLETED == "startup_completed"
+        assert PipelineEvent.PREFLIGHT_STARTED == "preflight_started"
+        assert PipelineEvent.PREFLIGHT_COMPLETED == "preflight_completed"
+        assert PipelineEvent.LIFECYCLE_CLEAR_STARTED == "lifecycle_clear_started"
+        assert PipelineEvent.LIFECYCLE_CLEAR_COMPLETED == "lifecycle_clear_completed"
+        assert PipelineEvent.EXECUTION_STARTED == "execution_started"
+        assert PipelineEvent.EXECUTION_COMPLETED == "execution_completed"
+        assert PipelineEvent.POSTRUN_STARTED == "postrun_started"
+        assert PipelineEvent.POSTRUN_COMPLETED == "postrun_completed"
+        assert PipelineEvent.CLEANUP_STARTED == "cleanup_started"
+        assert PipelineEvent.CLEANUP_COMPLETED == "cleanup_completed"
+
+    def test_health_check_event_defined(self) -> None:
+        """Verify health check event is defined."""
+        assert PipelineEvent.HEALTH_CHECK_COMPLETED == "health_check_completed"
+
+    def test_dq_anomaly_event_defined(self) -> None:
+        """Verify DQ anomaly event is defined."""
+        assert PipelineEvent.DQ_ANOMALY_DETECTED == "dq_anomaly_detected"
+
+    def test_vacuum_event_defined(self) -> None:
+        """Verify vacuum event is defined."""
+        assert PipelineEvent.VACUUM_COMPLETED == "vacuum_completed"
+
+
+class TestPipelineEventPhaseMethods:
+    """Tests for PipelineEvent phase helper methods."""
+
+    @pytest.mark.parametrize(
+        ("phase_value", "expected"),
+        [
+            ("startup", "startup_started"),
+            ("preflight", "preflight_started"),
+            ("lifecycle_clear", "lifecycle_clear_started"),
+            ("execution", "execution_started"),
+            ("postrun", "postrun_started"),
+            ("cleanup", "cleanup_started"),
+        ],
+    )
+    def test_phase_started_generates_correct_event(
+        self, phase_value: str, expected: str
+    ) -> None:
+        """Verify phase_started generates correct event names."""
+        assert PipelineEvent.phase_started(phase_value) == expected
+
+    @pytest.mark.parametrize(
+        ("phase_value", "expected"),
+        [
+            ("startup", "startup_completed"),
+            ("preflight", "preflight_completed"),
+            ("lifecycle_clear", "lifecycle_clear_completed"),
+            ("execution", "execution_completed"),
+            ("postrun", "postrun_completed"),
+            ("cleanup", "cleanup_completed"),
+        ],
+    )
+    def test_phase_completed_generates_correct_event(
+        self, phase_value: str, expected: str
+    ) -> None:
+        """Verify phase_completed generates correct event names."""
+        assert PipelineEvent.phase_completed(phase_value) == expected
+
+
+class TestPipelineEventImportFromDomain:
+    """Tests for PipelineEvent import from domain facade."""
+
+    def test_can_import_from_domain_facade(self) -> None:
+        """Verify PipelineEvent is exported from domain module."""
+        from bioetl.domain import PipelineEvent as DomainPipelineEvent
+
+        assert DomainPipelineEvent.START == "pipeline_started"


### PR DESCRIPTION
- Create domain/events.py with PipelineEvent class containing all event constants
- Update observer.py to use PipelineEvent constants instead of hardcoded strings
- Update runner.py to use PipelineEvent.START and COMPLETE constants
- Export PipelineEvent from domain facade
- Add unit tests for events module (19 tests)
- Update test_runner.py to reflect new event-based logging

This standardizes all pipeline lifecycle events (pipeline_started, pipeline_finished, pipeline_failed, pipeline_shutdown) and phase events (preflight_started, etc.) to use centralized constants for better grep-ability and consistency.