### PR TITLE
Add standard SLA metrics for adapters

### DIFF
--- a/src/bioetl/infrastructure/adapters/base_metrics.py
+++ b/src/bioetl/infrastructure/adapters/base_metrics.py
@@ -1,0 +1,105 @@
+"""Base metrics instrumentation for adapters.
+
+Provides standardized SLA metrics collection for all HTTP adapters.
+Implements RULES.md observability requirements for adapter monitoring.
+
+Metrics collected:
+- adapter_request_duration_seconds: Histogram of request durations
+- adapter_requests_total: Counter of total requests (success/error)
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bioetl.domain.ports import MetricsPort
+
+
+@dataclass
+class AdapterMetrics:
+    """Metrics instrumentation for adapter requests.
+
+    Collects SLA-relevant metrics for adapter HTTP requests including
+    latency histograms and request counters with success/error status.
+
+    Args:
+        metrics: MetricsPort implementation for recording metrics.
+        provider: Provider name for metric labels (e.g., "chembl", "uniprot").
+
+    Example:
+        >>> from bioetl.domain.ports.noop import NoOpMetrics
+        >>> metrics = AdapterMetrics(NoOpMetrics(), "chembl")
+        >>> with metrics.measure_request("/activity"):
+        ...     # perform HTTP request
+        ...     pass
+
+    """
+
+    metrics: MetricsPort
+    provider: str
+
+    @contextmanager
+    def measure_request(self, endpoint: str) -> Iterator[None]:
+        """Measure request duration and record metrics.
+
+        Context manager that records the duration of an HTTP request
+        and increments appropriate success/error counters.
+
+        Args:
+            endpoint: API endpoint being called (e.g., "/activity", "/compound").
+
+        Yields:
+            None - execution context for the request.
+
+        Records:
+            - adapter_request_duration_seconds: Histogram with provider/endpoint labels
+            - adapter_requests_total: Counter with provider/endpoint/status labels
+
+        """
+        start = time.perf_counter()
+        status = "success"
+        try:
+            yield
+        except Exception:
+            status = "error"
+            raise
+        finally:
+            duration = time.perf_counter() - start
+            labels = {"provider": self.provider, "endpoint": endpoint}
+
+            self.metrics.observe_histogram(
+                "adapter_request_duration_seconds",
+                duration,
+                labels,
+            )
+
+            self.metrics.increment_counter(
+                "adapter_requests_total",
+                1,
+                {**labels, "status": status},
+            )
+
+    def record_batch_size(self, endpoint: str, size: int) -> None:
+        """Record batch size for a request.
+
+        Useful for monitoring effective batch sizes, especially when
+        adapters reduce batch size during degraded health states.
+
+        Args:
+            endpoint: API endpoint being called.
+            size: Number of records in the batch.
+
+        Records:
+            - adapter_batch_size: Histogram with provider/endpoint labels
+
+        """
+        self.metrics.observe_histogram(
+            "adapter_batch_size",
+            float(size),
+            {"provider": self.provider, "endpoint": endpoint},
+        )

--- a/src/bioetl/infrastructure/adapters/chembl/client.py
+++ b/src/bioetl/infrastructure/adapters/chembl/client.py
@@ -23,8 +23,10 @@ from typing import TYPE_CHECKING, Any, NoReturn
 
 from bioetl.domain.error_classifier import ErrorClassifier
 from bioetl.domain.exceptions import ChemblApiError, CriticalError
+from bioetl.domain.ports.noop import NoOpMetrics
 from bioetl.domain.types import ErrorType, HealthStatus
 from bioetl.infrastructure.adapters.base import BaseHttpAdapter
+from bioetl.infrastructure.adapters.base_metrics import AdapterMetrics
 from bioetl.infrastructure.adapters.chembl.entity_mapper import (
     CHEMBL_STATUS_URL,
     ChemblEntityMapper,
@@ -36,7 +38,7 @@ if TYPE_CHECKING:
 
     from httpx import Response
 
-    from bioetl.domain.ports import LoggerPort
+    from bioetl.domain.ports import LoggerPort, MetricsPort
     from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
 
 
@@ -64,6 +66,7 @@ class ChemblAdapter(BaseHttpAdapter):
     logger: LoggerPort
     batch_size: int = 1000
     thread_pool: ThreadPoolExecutor | None = None
+    metrics: MetricsPort | None = None
 
     provider_name: str = field(init=False, default="chembl")
     """Provider identifier (required by DataSourcePort)."""
@@ -80,6 +83,11 @@ class ChemblAdapter(BaseHttpAdapter):
     _mapper: ChemblEntityMapper = field(
         init=False, default_factory=ChemblEntityMapper
     )
+
+    def __post_init__(self) -> None:
+        """Initialize adapter metrics after dataclass init."""
+        metrics_port = self.metrics if self.metrics is not None else NoOpMetrics()
+        self._adapter_metrics = AdapterMetrics(metrics_port, self.provider_name)
 
     def _get_effective_batch_size(self) -> int:
         """Get batch size adjusted for current health status.
@@ -138,7 +146,8 @@ class ChemblAdapter(BaseHttpAdapter):
     ) -> tuple[list[dict[str, Any]], bool]:
         """Fetch a single page and handle errors."""
         try:
-            response = await self.http_client.get(url, params=params)
+            with self._adapter_metrics.measure_request(f"/{entity_type}"):
+                response = await self.http_client.get(url, params=params)
             records, has_next = self._process_response(response, entity_type)
             self._consecutive_errors = 0
             return records, has_next
@@ -395,7 +404,8 @@ class ChemblAdapter(BaseHttpAdapter):
 
         """
         try:
-            response = await self.http_client.get(CHEMBL_STATUS_URL)
+            with self._adapter_metrics.measure_request("/status"):
+                response = await self.http_client.get(CHEMBL_STATUS_URL)
             self._handle_health_response(response)
             return self._cached_health
         except Exception as e:
@@ -499,7 +509,8 @@ class ChemblAdapter(BaseHttpAdapter):
         """Get total count of entities."""
         url = self._mapper.get_resource_url(entity_type)
         params = {"limit": 1, "format": "json"}
-        response = await self.http_client.get(url, params=params)
+        with self._adapter_metrics.measure_request(f"/{entity_type}/count"):
+            response = await self.http_client.get(url, params=params)
         data = response.json()
         page_meta = data.get("page_meta", {})
         total_count: int = page_meta.get("total_count", 0)

--- a/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
+++ b/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
@@ -6,13 +6,15 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Self
 
 from bioetl.domain.exceptions import ApiError
+from bioetl.domain.ports.noop import NoOpMetrics
 from bioetl.domain.types import HealthStatus
+from bioetl.infrastructure.adapters.base_metrics import AdapterMetrics
 from bioetl.infrastructure.adapters.pubmed.xml_processor import PubMedXmlProcessor
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
-    from bioetl.domain.ports import LoggerPort
+    from bioetl.domain.ports import LoggerPort, MetricsPort
     from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
     from bioetl.infrastructure.config import Settings
 
@@ -40,8 +42,14 @@ class PubMedAdapter:
     email: str
     api_key: str | None = None
     batch_size: int = 200
+    metrics: MetricsPort | None = None
 
     provider_name: str = "pubmed"
+
+    def __post_init__(self) -> None:
+        """Initialize adapter metrics after dataclass init."""
+        metrics_port = self.metrics if self.metrics is not None else NoOpMetrics()
+        self._adapter_metrics = AdapterMetrics(metrics_port, self.provider_name)
 
     async def __aenter__(self) -> Self:
         """Enter async context manager."""
@@ -72,7 +80,8 @@ class PubMedAdapter:
             params["api_key"] = self.api_key
 
         try:
-            response = await self.http_client.get(search_url, params=params)
+            with self._adapter_metrics.measure_request("/esearch"):
+                response = await self.http_client.get(search_url, params=params)
             data = response.json()
             idlist: list[str] = data.get("esearchresult", {}).get("idlist", [])
             return idlist
@@ -97,9 +106,10 @@ class PubMedAdapter:
         """Fetch a batch of articles and return parsed records."""
         params = self._build_fetch_params(id_batch)
         try:
-            response = await self.http_client.get(
-                f"{ENTREZ_API_BASE}efetch.fcgi", params=params
-            )
+            with self._adapter_metrics.measure_request("/efetch"):
+                response = await self.http_client.get(
+                    f"{ENTREZ_API_BASE}efetch.fcgi", params=params
+                )
             root = PubMedXmlProcessor.parse_response(response.text)
             if root is None:
                 self.logger.error("XML parse error in batch fetch")
@@ -232,9 +242,10 @@ class PubMedAdapter:
                 params["api_key"] = self.api_key
 
             start_time = time.monotonic()
-            response = await self.http_client.get(
-                f"{ENTREZ_API_BASE}esearch.fcgi", params=params
-            )
+            with self._adapter_metrics.measure_request("/health"):
+                response = await self.http_client.get(
+                    f"{ENTREZ_API_BASE}esearch.fcgi", params=params
+                )
             elapsed = time.monotonic() - start_time
 
             if response.status_code != 200:
@@ -296,7 +307,7 @@ def _create_pubmed_adapter(
         http_client: HTTP клиент
         logger: Логгер
         settings: Настройки приложения
-        **kwargs: Дополнительные параметры (email, api_key)
+        **kwargs: Дополнительные параметры (email, api_key, metrics)
 
     Returns:
         Инициализированный PubMedAdapter
@@ -332,4 +343,5 @@ def _create_pubmed_adapter(
         email=email,
         api_key=api_key,
         batch_size=kwargs.get("batch_size", 200),
+        metrics=kwargs.get("metrics"),
     )

--- a/src/bioetl/infrastructure/adapters/uniprot/client.py
+++ b/src/bioetl/infrastructure/adapters/uniprot/client.py
@@ -19,8 +19,10 @@ from typing import TYPE_CHECKING, Any
 from typing_extensions import override
 
 from bioetl.domain.error_classifier import ErrorClassifier
+from bioetl.domain.ports.noop import NoOpMetrics
 from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.adapters.base import BaseHttpAdapter
+from bioetl.infrastructure.adapters.base_metrics import AdapterMetrics
 from bioetl.infrastructure.adapters.http.pagination import PaginatedFetcherMixin
 from bioetl.infrastructure.adapters.uniprot.fasta_parser import FastaParser
 
@@ -29,7 +31,7 @@ if TYPE_CHECKING:
 
     import httpx
 
-    from bioetl.domain.ports import LoggerPort
+    from bioetl.domain.ports import LoggerPort, MetricsPort
     from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
 
 
@@ -48,6 +50,7 @@ class UniProtAdapter(BaseHttpAdapter, PaginatedFetcherMixin):
         api_key: str | None = None,
         base_url: str = "https://rest.uniprot.org",
         strict_error_handling: bool = False,
+        metrics: MetricsPort | None = None,
     ) -> None:
         """Initialize UniProt client.
 
@@ -57,12 +60,15 @@ class UniProtAdapter(BaseHttpAdapter, PaginatedFetcherMixin):
             api_key: UniProt API key (optional)
             base_url: UniProt REST API base URL
             strict_error_handling: Whether to raise exceptions (True) or log warnings (False)
+            metrics: MetricsPort instance for recording SLA metrics
 
         """
         super().__init__(http_client, logger)
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
         self.strict_error_handling = strict_error_handling
+        metrics_port = metrics if metrics is not None else NoOpMetrics()
+        self._adapter_metrics = AdapterMetrics(metrics_port, self.provider_name)
         self._fetch_strategies = {
             "protein": self._fetch_proteins,
             "feature": self._fetch_features,
@@ -149,9 +155,10 @@ class UniProtAdapter(BaseHttpAdapter, PaginatedFetcherMixin):
                 query, size, fetched, limit, cursor
             )
             try:
-                response = await self.http_client.get(
-                    f"{self.base_url}/uniprotkb/search", params=params
-                )
+                with self._adapter_metrics.measure_request("/uniprotkb/search"):
+                    response = await self.http_client.get(
+                        f"{self.base_url}/uniprotkb/search", params=params
+                    )
                 return self._parse_response(response)
             except Exception:
                 self._handle_fetch_error("protein", query, cursor)
@@ -177,9 +184,10 @@ class UniProtAdapter(BaseHttpAdapter, PaginatedFetcherMixin):
     async def _get_features_json(self, query: str) -> list[dict[str, Any]]:
         """Retrieve features JSON."""
         try:
-            response = await self.http_client.get(
-                f"{self.base_url}/uniprotkb/{query}.json"
-            )
+            with self._adapter_metrics.measure_request("/uniprotkb/features"):
+                response = await self.http_client.get(
+                    f"{self.base_url}/uniprotkb/{query}.json"
+                )
             if response.status_code == 200:
                 features: list[dict[str, Any]] = response.json().get("features", [])
                 return features
@@ -215,10 +223,11 @@ class UniProtAdapter(BaseHttpAdapter, PaginatedFetcherMixin):
     async def _get_sequence_fasta(self, query: str) -> str | None:
         """Retrieve FASTA sequence."""
         try:
-            response = await self.http_client.get(
-                f"{self.base_url}/uniprotkb/stream",
-                params={"query": query, "format": "fasta"},
-            )
+            with self._adapter_metrics.measure_request("/uniprotkb/stream"):
+                response = await self.http_client.get(
+                    f"{self.base_url}/uniprotkb/stream",
+                    params={"query": query, "format": "fasta"},
+                )
             if response.status_code == 200:
                 return response.text
             return None
@@ -265,9 +274,10 @@ class UniProtAdapter(BaseHttpAdapter, PaginatedFetcherMixin):
         try:
             # Lightweight search probe: Ubiquitin (P62988)
             params = {"query": "accession:P62988", "size": 1, "format": "json"}
-            resp = await self.http_client.get(
-                f"{self.base_url}/uniprotkb/search", params=params
-            )
+            with self._adapter_metrics.measure_request("/health"):
+                resp = await self.http_client.get(
+                    f"{self.base_url}/uniprotkb/search", params=params
+                )
             if resp.status_code != 200:
                 self.logger.warning(
                     "health_check_degraded",

--- a/tests/unit/infrastructure/adapters/test_base_metrics.py
+++ b/tests/unit/infrastructure/adapters/test_base_metrics.py
@@ -1,0 +1,128 @@
+"""Unit tests for AdapterMetrics."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from bioetl.domain.ports.noop import NoOpMetrics
+from bioetl.infrastructure.adapters.base_metrics import AdapterMetrics
+
+
+@pytest.mark.unit
+class TestAdapterMetrics:
+    """Tests for AdapterMetrics."""
+
+    def test_measure_request_records_histogram(self):
+        """Test that measure_request records histogram metric."""
+        mock_metrics = MagicMock()
+        adapter_metrics = AdapterMetrics(metrics=mock_metrics, provider="chembl")
+
+        with adapter_metrics.measure_request("/activity"):
+            pass  # Simulate successful request
+
+        # Verify histogram was observed
+        mock_metrics.observe_histogram.assert_called_once()
+        call_args = mock_metrics.observe_histogram.call_args
+        assert call_args[0][0] == "adapter_request_duration_seconds"
+        assert call_args[0][1] > 0  # Duration should be positive
+        assert call_args[0][2] == {"provider": "chembl", "endpoint": "/activity"}
+
+    def test_measure_request_records_counter_success(self):
+        """Test that measure_request records success counter."""
+        mock_metrics = MagicMock()
+        adapter_metrics = AdapterMetrics(metrics=mock_metrics, provider="uniprot")
+
+        with adapter_metrics.measure_request("/protein"):
+            pass
+
+        # Verify counter was incremented with success status
+        mock_metrics.increment_counter.assert_called_once()
+        call_args = mock_metrics.increment_counter.call_args
+        assert call_args[0][0] == "adapter_requests_total"
+        assert call_args[0][1] == 1
+        assert call_args[0][2] == {
+            "provider": "uniprot",
+            "endpoint": "/protein",
+            "status": "success",
+        }
+
+    def test_measure_request_records_counter_error(self):
+        """Test that measure_request records error counter on exception."""
+        mock_metrics = MagicMock()
+        adapter_metrics = AdapterMetrics(metrics=mock_metrics, provider="pubmed")
+
+        with pytest.raises(ValueError):
+            with adapter_metrics.measure_request("/esearch"):
+                raise ValueError("Test error")
+
+        # Verify counter was incremented with error status
+        mock_metrics.increment_counter.assert_called_once()
+        call_args = mock_metrics.increment_counter.call_args
+        assert call_args[0][0] == "adapter_requests_total"
+        assert call_args[0][2]["status"] == "error"
+
+    def test_measure_request_propagates_exception(self):
+        """Test that exceptions are properly propagated."""
+        mock_metrics = MagicMock()
+        adapter_metrics = AdapterMetrics(metrics=mock_metrics, provider="chembl")
+
+        with pytest.raises(RuntimeError, match="Connection failed"):
+            with adapter_metrics.measure_request("/compound"):
+                raise RuntimeError("Connection failed")
+
+    def test_measure_request_with_noop_metrics(self):
+        """Test that NoOpMetrics works correctly."""
+        noop_metrics = NoOpMetrics()
+        adapter_metrics = AdapterMetrics(metrics=noop_metrics, provider="chembl")
+
+        # Should not raise any exceptions
+        with adapter_metrics.measure_request("/activity"):
+            pass
+
+    def test_record_batch_size(self):
+        """Test that record_batch_size records histogram metric."""
+        mock_metrics = MagicMock()
+        adapter_metrics = AdapterMetrics(metrics=mock_metrics, provider="chembl")
+
+        adapter_metrics.record_batch_size("/activity", 500)
+
+        mock_metrics.observe_histogram.assert_called_once_with(
+            "adapter_batch_size",
+            500.0,
+            {"provider": "chembl", "endpoint": "/activity"},
+        )
+
+    def test_different_endpoints_have_correct_labels(self):
+        """Test that different endpoints get correct labels."""
+        mock_metrics = MagicMock()
+        adapter_metrics = AdapterMetrics(metrics=mock_metrics, provider="uniprot")
+
+        with adapter_metrics.measure_request("/uniprotkb/search"):
+            pass
+
+        with adapter_metrics.measure_request("/uniprotkb/stream"):
+            pass
+
+        # Verify two different endpoints were recorded
+        assert mock_metrics.observe_histogram.call_count == 2
+        calls = mock_metrics.observe_histogram.call_args_list
+        assert calls[0][0][2]["endpoint"] == "/uniprotkb/search"
+        assert calls[1][0][2]["endpoint"] == "/uniprotkb/stream"
+
+    def test_provider_label_preserved(self):
+        """Test that provider label is correctly set."""
+        mock_metrics = MagicMock()
+
+        chembl_metrics = AdapterMetrics(metrics=mock_metrics, provider="chembl")
+        with chembl_metrics.measure_request("/activity"):
+            pass
+
+        uniprot_metrics = AdapterMetrics(metrics=mock_metrics, provider="uniprot")
+        with uniprot_metrics.measure_request("/protein"):
+            pass
+
+        calls = mock_metrics.observe_histogram.call_args_list
+        assert calls[0][0][2]["provider"] == "chembl"
+        assert calls[1][0][2]["provider"] == "uniprot"


### PR DESCRIPTION
Implement AdapterMetrics class to standardize request duration tracking across adapters. The class provides a measure_request context manager that records adapter_request_duration_seconds histogram and adapter_requests_total counter with provider/endpoint/status labels.

Integration:
- ChEMBL adapter: instrumented fetch, health check, and entity count methods
- UniProt adapter: instrumented search, features, stream, and health endpoints
- PubMed adapter: instrumented esearch, efetch, and health check methods

All adapters accept optional MetricsPort parameter; NoOpMetrics is used when not provided, ensuring backward compatibility.