### PR TITLE
Add metrics to BronzeWriter

### DIFF
--- a/src/bioetl/composition/factories/base_services_factory.py
+++ b/src/bioetl/composition/factories/base_services_factory.py
@@ -64,12 +64,16 @@ class BaseServicesFactory:
         Returns:
             PipelineServices with all dependencies configured
         """
-        storage_ctx = StorageFactory.create(settings, pipeline_config, logger)
+        # Create metrics first so it can be passed to storage factory
+        metrics = cls._create_metrics(settings)
+
+        storage_ctx = StorageFactory.create(
+            settings, pipeline_config, logger, metrics=metrics
+        )
 
         lock = cls._create_lock()
         checkpoint = cls._create_checkpoint(storage_ctx)
         quarantine = cls._create_quarantine(storage_ctx)
-        metrics = cls._create_metrics(settings)
 
         # Use provided tracer or fallback to NoOpTracing
         # Tracer should be created via bootstrap_tracer() for consistent configuration

--- a/src/bioetl/composition/factories/storage_factory.py
+++ b/src/bioetl/composition/factories/storage_factory.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
     import structlog
 
+    from bioetl.domain.ports import MetricsPort
     from bioetl.infrastructure.config import Settings
     from bioetl.infrastructure.schemas.pipeline_config import PipelineYamlConfig
 
@@ -59,6 +60,7 @@ class StorageFactory:
         settings: Settings,
         config: PipelineYamlConfig,
         logger: structlog.BoundLogger,
+        metrics: MetricsPort | None = None,
     ) -> StorageContext:
         """Create a StorageAdapter for local deployment.
 
@@ -66,6 +68,7 @@ class StorageFactory:
             settings: Application settings with data_dir
             config: Pipeline YAML configuration
             logger: Structured logger
+            metrics: Optional metrics port for Bronze observability (O1 metrics).
 
         Returns:
             StorageContext with adapter and paths
@@ -113,6 +116,7 @@ class StorageFactory:
                 logger=logger,
                 save_json=save_json,
                 json_path=json_path,
+                metrics=metrics,
             ),
             silver_writer=DeltaWriter(
                 base_path=silver_path,

--- a/src/bioetl/infrastructure/storage/bronze_writer.py
+++ b/src/bioetl/infrastructure/storage/bronze_writer.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from collections.abc import AsyncIterator, Iterator
 from datetime import datetime
 from io import BytesIO
@@ -28,7 +29,7 @@ from typing import TYPE_CHECKING, Any
 import zstandard as zstd
 
 if TYPE_CHECKING:
-    from bioetl.domain.ports import LoggerPort
+    from bioetl.domain.ports import LoggerPort, MetricsPort
 
 from bioetl.domain.types import BatchID, RunID, RunType
 from bioetl.infrastructure.storage._atomic import AtomicWriteGroup
@@ -53,6 +54,7 @@ class BronzeWriter:
         logger: LoggerPort,
         save_json: bool = False,
         json_path: str | None = None,
+        metrics: MetricsPort | None = None,
     ) -> None:
         """Initialize Bronze writer.
 
@@ -61,12 +63,17 @@ class BronzeWriter:
             logger: Structured logger for observability (MUST be injected)
             save_json: If True, also save uncompressed JSON copy
             json_path: Path for JSON files (defaults to base_path/json/)
+            metrics: Optional metrics port for observability (O1 metrics).
+                     If None, uses NoOpMetrics for null object pattern.
 
         """
+        from bioetl.domain.ports.noop import NoOpMetrics
+
         self.base_path = Path(base_path)
         self.logger = logger
         self.save_json = save_json
         self.json_path = json_path or str(self.base_path / "json")
+        self._metrics = metrics or NoOpMetrics()
 
     def _validate_bronze_names(self, provider: str, entity: str) -> None:
         """Validate provider and entity names (alphanumeric + underscores only)."""
@@ -158,6 +165,8 @@ class BronzeWriter:
             Relative path to the written file.
 
         """
+        start_time = time.perf_counter()
+
         self._validate_bronze_names(provider, entity)
         self._validate_records_iterator(records)
 
@@ -178,12 +187,13 @@ class BronzeWriter:
             record_list = []
             records_iter = records
 
-        compressed_data = await loop.run_in_executor(
+        compressed_data, record_count, uncompressed_size = await loop.run_in_executor(
             None, self._compress_records, records_iter
         )
         if not compressed_data:
             raise ValueError("No records to write")
 
+        compressed_size = len(compressed_data)
         full_path = self.base_path / relative_path
         meta_path = full_path.with_suffix(".zst.meta.json")
 
@@ -194,6 +204,26 @@ class BronzeWriter:
             ),
         )
 
+        # Record metrics
+        duration = time.perf_counter() - start_time
+        labels = {"provider": provider, "entity": entity}
+
+        self._metrics.observe_histogram(
+            "bronze_write_duration_seconds",
+            duration,
+            labels,
+        )
+        self._metrics.increment_counter(
+            "bronze_records_written_total",
+            record_count,
+            labels,
+        )
+        self._metrics.increment_counter(
+            "bronze_bytes_written_total",
+            compressed_size,
+            labels,
+        )
+
         self.logger.info(
             "bronze_write_complete",
             path=relative_path,
@@ -202,6 +232,10 @@ class BronzeWriter:
             batch_id=str(batch_id),
             run_id=str(run_id),
             run_type=run_type.value,
+            record_count=record_count,
+            compressed_bytes=compressed_size,
+            uncompressed_bytes=uncompressed_size,
+            duration_seconds=round(duration, 3),
         )
 
         if self.save_json:
@@ -236,8 +270,12 @@ class BronzeWriter:
             lambda: atomic_write_bytes(json_full_path, jsonl_content),
         )
 
-    def _compress_records(self, records: Iterator[bytes]) -> bytes:
-        """Compress JSONL records using zstandard with streaming."""
+    def _compress_records(self, records: Iterator[bytes]) -> tuple[bytes, int, int]:
+        """Compress JSONL records using zstandard with streaming.
+
+        Returns:
+            Tuple of (compressed_data, record_count, uncompressed_size).
+        """
         output = BytesIO()
         compressor = zstd.ZstdCompressor(
             level=self.COMPRESSION_LEVEL,
@@ -247,6 +285,7 @@ class BronzeWriter:
 
         chunk_buffer = bytearray()
         record_count = 0
+        uncompressed_size = 0
 
         with compressor.stream_writer(
             output, closefd=False, write_size=self.COMPRESSION_CHUNK_SIZE
@@ -254,6 +293,7 @@ class BronzeWriter:
             for record in records:
                 chunk_buffer.extend(record)
                 record_count += 1
+                uncompressed_size += len(record)
 
                 if len(chunk_buffer) >= self.COMPRESSION_CHUNK_SIZE:
                     # Pass bytearray directly to avoid memory copy
@@ -266,7 +306,7 @@ class BronzeWriter:
             if record_count == 0:
                 raise ValueError("No records provided for compression")
 
-        return output.getvalue()
+        return output.getvalue(), record_count, uncompressed_size
 
     async def read_bronze(self, path: str) -> AsyncIterator[dict[str, Any]]:
         """Read and decompress Bronze file (for testing/debugging)."""

--- a/tests/unit/infrastructure/storage/test_bronze_writer.py
+++ b/tests/unit/infrastructure/storage/test_bronze_writer.py
@@ -272,13 +272,17 @@ class TestBronzeWriterCompress:
     def test_compress_records(
         self, tmp_path, noop_logger, sample_records: list[bytes]
     ) -> None:
-        """Test record compression."""
+        """Test record compression returns data, count, and size."""
         writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
 
-        compressed = writer._compress_records(iter(sample_records))
+        compressed, record_count, uncompressed_size = writer._compress_records(
+            iter(sample_records)
+        )
 
         assert compressed is not None
         assert len(compressed) > 0
+        assert record_count == len(sample_records)
+        assert uncompressed_size == sum(len(r) for r in sample_records)
 
         # Verify we can decompress (use streaming for robustness)
         decompressor = zstd.ZstdDecompressor()
@@ -302,7 +306,12 @@ class TestBronzeWriterCompress:
         large_record = {"data": "x" * 500_000}
         records = [json.dumps(large_record).encode("utf-8") + b"\n" for _ in range(5)]
 
-        compressed = writer._compress_records(iter(records))
+        compressed, record_count, uncompressed_size = writer._compress_records(
+            iter(records)
+        )
+
+        assert record_count == 5
+        assert uncompressed_size == sum(len(r) for r in records)
 
         # Compression should reduce size
         original_size = sum(len(r) for r in records)
@@ -1003,3 +1012,236 @@ class TestBronzeWriterMetadataDeterminism:
         # Verify keys are sorted
         keys = list(json.loads(serialized).keys())
         assert keys == sorted(keys), "Keys should be alphabetically sorted"
+
+
+@pytest.mark.unit
+class TestBronzeWriterMetrics:
+    """Tests for BronzeWriter metrics collection (O1 observability)."""
+
+    def test_init_with_metrics(self, tmp_path, noop_logger) -> None:
+        """Test initialization with custom metrics port."""
+        mock_metrics = MagicMock()
+        writer = BronzeWriter(
+            base_path=tmp_path, logger=noop_logger, metrics=mock_metrics
+        )
+
+        assert writer._metrics is mock_metrics
+
+    def test_init_without_metrics_uses_noop(self, tmp_path, noop_logger) -> None:
+        """Test initialization without metrics uses NoOpMetrics."""
+        from bioetl.domain.ports.noop import NoOpMetrics
+
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+
+        assert isinstance(writer._metrics, NoOpMetrics)
+
+    @pytest.mark.asyncio
+    async def test_write_bronze_records_duration_metric(
+        self,
+        tmp_path,
+        noop_logger,
+        sample_records: list[bytes],
+        batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
+        ingestion_ts: datetime,
+    ) -> None:
+        """Test that write_bronze records duration histogram."""
+        mock_metrics = MagicMock()
+        writer = BronzeWriter(
+            base_path=tmp_path, logger=noop_logger, metrics=mock_metrics
+        )
+        date = datetime(2024, 1, 15)
+
+        await writer.write_bronze(
+            records=iter(sample_records),
+            provider="chembl",
+            entity="activity",
+            date=date,
+            batch_id=batch_id,
+            run_id=run_id,
+            run_type=run_type,
+            ingestion_ts=ingestion_ts,
+        )
+
+        # Verify observe_histogram was called with duration metric
+        histogram_calls = [
+            call
+            for call in mock_metrics.observe_histogram.call_args_list
+            if call[0][0] == "bronze_write_duration_seconds"
+        ]
+        assert len(histogram_calls) == 1
+
+        call_args = histogram_calls[0]
+        assert call_args[0][0] == "bronze_write_duration_seconds"
+        assert isinstance(call_args[0][1], float)
+        assert call_args[0][1] >= 0  # Duration should be non-negative
+        assert call_args[0][2] == {"provider": "chembl", "entity": "activity"}
+
+    @pytest.mark.asyncio
+    async def test_write_bronze_records_count_metric(
+        self,
+        tmp_path,
+        noop_logger,
+        sample_records: list[bytes],
+        batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
+        ingestion_ts: datetime,
+    ) -> None:
+        """Test that write_bronze records count counter."""
+        mock_metrics = MagicMock()
+        writer = BronzeWriter(
+            base_path=tmp_path, logger=noop_logger, metrics=mock_metrics
+        )
+        date = datetime(2024, 1, 15)
+
+        await writer.write_bronze(
+            records=iter(sample_records),
+            provider="pubchem",
+            entity="compound",
+            date=date,
+            batch_id=batch_id,
+            run_id=run_id,
+            run_type=run_type,
+            ingestion_ts=ingestion_ts,
+        )
+
+        # Verify increment_counter was called with records count metric
+        counter_calls = [
+            call
+            for call in mock_metrics.increment_counter.call_args_list
+            if call[0][0] == "bronze_records_written_total"
+        ]
+        assert len(counter_calls) == 1
+
+        call_args = counter_calls[0]
+        assert call_args[0][0] == "bronze_records_written_total"
+        assert call_args[0][1] == len(sample_records)  # 3 records
+        assert call_args[0][2] == {"provider": "pubchem", "entity": "compound"}
+
+    @pytest.mark.asyncio
+    async def test_write_bronze_records_bytes_metric(
+        self,
+        tmp_path,
+        noop_logger,
+        sample_records: list[bytes],
+        batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
+        ingestion_ts: datetime,
+    ) -> None:
+        """Test that write_bronze records bytes counter."""
+        mock_metrics = MagicMock()
+        writer = BronzeWriter(
+            base_path=tmp_path, logger=noop_logger, metrics=mock_metrics
+        )
+        date = datetime(2024, 1, 15)
+
+        await writer.write_bronze(
+            records=iter(sample_records),
+            provider="uniprot",
+            entity="protein",
+            date=date,
+            batch_id=batch_id,
+            run_id=run_id,
+            run_type=run_type,
+            ingestion_ts=ingestion_ts,
+        )
+
+        # Verify increment_counter was called with bytes metric
+        counter_calls = [
+            call
+            for call in mock_metrics.increment_counter.call_args_list
+            if call[0][0] == "bronze_bytes_written_total"
+        ]
+        assert len(counter_calls) == 1
+
+        call_args = counter_calls[0]
+        assert call_args[0][0] == "bronze_bytes_written_total"
+        assert call_args[0][1] > 0  # Should have written some bytes
+        assert call_args[0][2] == {"provider": "uniprot", "entity": "protein"}
+
+    @pytest.mark.asyncio
+    async def test_write_bronze_all_metrics_recorded(
+        self,
+        tmp_path,
+        noop_logger,
+        sample_records: list[bytes],
+        batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
+        ingestion_ts: datetime,
+    ) -> None:
+        """Test that all 3 metrics are recorded on write."""
+        mock_metrics = MagicMock()
+        writer = BronzeWriter(
+            base_path=tmp_path, logger=noop_logger, metrics=mock_metrics
+        )
+        date = datetime(2024, 1, 15)
+
+        await writer.write_bronze(
+            records=iter(sample_records),
+            provider="chembl",
+            entity="activity",
+            date=date,
+            batch_id=batch_id,
+            run_id=run_id,
+            run_type=run_type,
+            ingestion_ts=ingestion_ts,
+        )
+
+        # Verify histogram was called once (duration)
+        assert mock_metrics.observe_histogram.call_count == 1
+
+        # Verify counter was called twice (records + bytes)
+        assert mock_metrics.increment_counter.call_count == 2
+
+        # Verify all expected metrics were recorded
+        histogram_names = [
+            call[0][0] for call in mock_metrics.observe_histogram.call_args_list
+        ]
+        counter_names = [
+            call[0][0] for call in mock_metrics.increment_counter.call_args_list
+        ]
+
+        assert "bronze_write_duration_seconds" in histogram_names
+        assert "bronze_records_written_total" in counter_names
+        assert "bronze_bytes_written_total" in counter_names
+
+    @pytest.mark.asyncio
+    async def test_logger_includes_metrics_info(
+        self,
+        tmp_path,
+        sample_records: list[bytes],
+        batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
+        ingestion_ts: datetime,
+    ) -> None:
+        """Test that logger call includes record count and byte size."""
+        mock_logger = MagicMock()
+        writer = BronzeWriter(base_path=tmp_path, logger=mock_logger)
+        date = datetime(2024, 1, 15)
+
+        await writer.write_bronze(
+            records=iter(sample_records),
+            provider="chembl",
+            entity="activity",
+            date=date,
+            batch_id=batch_id,
+            run_id=run_id,
+            run_type=run_type,
+            ingestion_ts=ingestion_ts,
+        )
+
+        # Verify logger includes new metrics fields
+        call_kwargs = mock_logger.info.call_args[1]
+        assert "record_count" in call_kwargs
+        assert call_kwargs["record_count"] == len(sample_records)
+        assert "compressed_bytes" in call_kwargs
+        assert call_kwargs["compressed_bytes"] > 0
+        assert "uncompressed_bytes" in call_kwargs
+        assert call_kwargs["uncompressed_bytes"] > 0
+        assert "duration_seconds" in call_kwargs
+        assert call_kwargs["duration_seconds"] >= 0


### PR DESCRIPTION
Implements O1 observability for Bronze layer by adding MetricsPort integration with 3 metrics: write duration, records count, and bytes.

Changes:
- Add metrics parameter to BronzeWriter.__init__ with NoOpMetrics fallback
- Record bronze_write_duration_seconds histogram after each write
- Record bronze_records_written_total counter with record count
- Record bronze_bytes_written_total counter with compressed size
- Update _compress_records to return (data, count, uncompressed_size)
- Enhance logger output with record_count, compressed_bytes, duration
- Update StorageFactory to pass metrics to BronzeWriter
- Update BaseServicesFactory to create metrics before storage

Tests:
- Add TestBronzeWriterMetrics class with 6 new tests
- Update compression tests for new tuple return signature