### PR TITLE
Split GenericPipelineFactory into smaller files

### DIFF
--- a/src/bioetl/composition/factories/__init__.py
+++ b/src/bioetl/composition/factories/__init__.py
@@ -34,6 +34,12 @@ from bioetl.composition.factories.pipeline_factories import (
     uniprot_protein_factory,
 )
 
+# Runner assembly functions (extracted from GenericPipelineFactory)
+from bioetl.composition.factories.runner_assembly import (
+    assemble_runner,
+    build_pipeline_services,
+)
+
 # Runner services factory (DI for PipelineRunner)
 from bioetl.composition.factories.runner_services import (
     RunnerServices,
@@ -64,6 +70,8 @@ __all__ = [
     "StorageAdapter",
     "StorageContext",
     "StorageFactory",
+    "assemble_runner",
+    "build_pipeline_services",
     "build_runner_services",
     "chembl_activity_factory",
     "create_pipeline_factory",

--- a/src/bioetl/composition/factories/generic_factory.py
+++ b/src/bioetl/composition/factories/generic_factory.py
@@ -4,23 +4,23 @@ Provides a configurable factory that eliminates the need for boilerplate subclas
 Pipelines can be registered declaratively using configuration rather than class inheritance.
 
 Updated: Transformer injection via DI (Phase 1 refactoring).
+Runner assembly delegated to runner_assembly module.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
-from bioetl.application.core.executor import PipelineExecutor
-from bioetl.application.core.runner import PipelineRunner
-from bioetl.application.services.medallion_lifecycle import MedallionLifecycleService
-from bioetl.composition.factories.base_services_factory import BaseServicesFactory
 from bioetl.composition.factories.data_source_registry import (
     DataSourceCreator,
     DataSourceRegistry,
 )
-from bioetl.composition.factories.runner_services import build_runner_services
-from bioetl.composition.factories.services_builder import ServicesBuilder
-from bioetl.infrastructure.config import load_pipeline_config, yaml_config_to_domain
+from bioetl.composition.factories.runner_assembly import (
+    assemble_runner,
+    build_pipeline_services,
+    create_pipeline_with_services,
+)
+from bioetl.infrastructure.config import load_pipeline_config
 
 if TYPE_CHECKING:
     import pyarrow as pa
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from bioetl.application.core.base import BasePipeline
     from bioetl.application.core.base_transformer import BaseTransformer
     from bioetl.application.core.pipeline_services import PipelineServices
+    from bioetl.application.core.runner import PipelineRunner
     from bioetl.composition.observability import ObservabilityBundle
     from bioetl.domain.config import RuntimeConfig
     from bioetl.domain.filter_config import InputFilterConfig
@@ -46,30 +47,13 @@ TPipeline = TypeVar("TPipeline", bound="BasePipeline")
 
 
 class GenericPipelineFactory(Generic[TPipeline]):
-    """Configurable factory for creating pipelines.
-
-    Unlike BasePipelineFactory which requires subclassing, GenericPipelineFactory
-    is configured via constructor parameters. This reduces boilerplate and
-    centralizes pipeline definitions.
-
-    Example:
-        >>> from bioetl.application.pipelines.chembl.activity import ChEMBLActivityPipeline
-        >>> from bioetl.infrastructure.schemas.silver import CHEMBL_ACTIVITY_SCHEMA
-        >>>
-        >>> factory = GenericPipelineFactory(
-        ...     pipeline_name="chembl_activity",
-        ...     pipeline_class=ChEMBLActivityPipeline,
-        ...     provider="chembl",
-        ...     silver_schema=CHEMBL_ACTIVITY_SCHEMA,
-        ... )
-        >>>
-        >>> # Create pipeline
-        >>> pipeline = factory.create_with_services(runtime, settings, logger)
+    """Configurable factory for creating pipelines via constructor parameters.
 
     Attributes:
         pipeline_name: Unique name for the pipeline
         pipeline_class: The pipeline class to instantiate
         silver_schema: PyArrow schema for Silver layer
+        gold_schema: Pandera schema for Gold layer
     """
 
     def __init__(
@@ -83,18 +67,6 @@ class GenericPipelineFactory(Generic[TPipeline]):
         transformer_class: type[BaseTransformer] | None = None,
     ) -> None:
         """Initialize the factory.
-
-        Args:
-            pipeline_name: Unique name for the pipeline (used for config lookup)
-            pipeline_class: The pipeline class to instantiate
-            provider: Provider name for data source creation
-            silver_schema: Optional PyArrow schema for Silver layer
-            gold_schema: Pandera schema for Gold layer validation (required)
-            data_source_creator: Optional custom creator function. If not provided,
-                uses DataSourceRegistry.get(provider)
-            transformer_class: Transformer class for Bronze→Silver transformation.
-                If provided, factory will create and inject transformer into pipeline.
-                This is the preferred DI approach.
 
         Raises:
             ValueError: If gold_schema is not provided
@@ -121,15 +93,7 @@ class GenericPipelineFactory(Generic[TPipeline]):
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
     ) -> BaseTransformer | None:
-        """Create transformer instance if transformer_class is configured.
-
-        Args:
-            tracer: Optional tracer for distributed tracing (O1 observability).
-            metrics: Optional metrics port for duration/error tracking (O1 observability).
-
-        Returns:
-            Transformer instance or None if no transformer_class configured.
-        """
+        """Create transformer instance if transformer_class is configured."""
         if self.transformer_class is None:
             return None
         return self.transformer_class(
@@ -145,17 +109,7 @@ class GenericPipelineFactory(Generic[TPipeline]):
         logger: structlog.BoundLogger,
         filter_config: InputFilterConfig | None = None,
     ) -> DataSourcePort:
-        """Create data source using the configured creator.
-
-        Args:
-            settings: Application settings
-            pipeline_config: Pipeline configuration
-            logger: LoggerPort instance for structured logging
-            filter_config: Optional filter configuration
-
-        Returns:
-            Configured DataSourcePort
-        """
+        """Create data source using the configured creator."""
         return self._create_data_source(
             settings, pipeline_config, logger, filter_config
         )
@@ -169,29 +123,14 @@ class GenericPipelineFactory(Generic[TPipeline]):
         tracer: TracingPort | None = None,
         dq_monitor: DQMonitorPort | None = None,
     ) -> PipelineServices:
-        """Build PipelineServices from settings.
-
-        Args:
-            settings: Application settings
-            logger: Structured logger
-            config: Pre-loaded pipeline config (avoids duplicate I/O)
-            filter_config: Optional input filter configuration
-            tracer: Optional tracer (created via bootstrap_tracer())
-            dq_monitor: Optional data quality monitor for anomaly detection
-
-        Returns:
-            Configured PipelineServices instance
-        """
-        pipeline_config = config or load_pipeline_config(self.pipeline_name)
-        data_source = self.create_data_source(
-            settings, pipeline_config, logger, filter_config
-        )
-
-        return BaseServicesFactory.create_common_services(
+        """Build PipelineServices from settings."""
+        return build_pipeline_services(
+            pipeline_name=self.pipeline_name,
+            create_data_source_fn=self._create_data_source,
             settings=settings,
             logger=logger,
-            data_source=data_source,
-            pipeline_config=pipeline_config,
+            config=config,
+            filter_config=filter_config,
             tracer=tracer,
             dq_monitor=dq_monitor,
         )
@@ -208,51 +147,23 @@ class GenericPipelineFactory(Generic[TPipeline]):
         dq_monitor: DQMonitorPort | None = None,
         metrics: MetricsPort | None = None,
     ) -> TPipeline:
-        """Create pipeline instance.
-
-        Loads config once and reuses it for both services and pipeline.
-        If transformer_class is configured, creates and injects transformer via DI.
-
-        Args:
-            run_id: Unique identifier for this pipeline run (from CLI/orchestrator)
-            runtime: Pipeline runtime configuration
-            settings: Application settings
-            logger: Structured logger
-            config: Pre-loaded pipeline config (avoids duplicate I/O)
-            filter_config: Optional input filter configuration
-            tracer: Optional tracer (created via bootstrap_tracer())
-            dq_monitor: Optional data quality monitor for anomaly detection
-            metrics: Optional metrics port for transformer observability (O1)
-
-        Returns:
-            Configured pipeline instance
-        """
-        yaml_config = config or load_pipeline_config(self.pipeline_name)
-
-        services = self.build_services(
+        """Create pipeline instance with services and optional transformer."""
+        return cast(TPipeline, create_pipeline_with_services(
+            pipeline_name=self.pipeline_name,
+            pipeline_class=self.pipeline_class,
+            provider=self.provider,
+            create_data_source_fn=self._create_data_source,
+            transformer_class=self.transformer_class,
+            run_id=run_id,
+            runtime=runtime,
             settings=settings,
             logger=logger,
-            config=yaml_config,
+            config=config,
             filter_config=filter_config,
             tracer=tracer,
             dq_monitor=dq_monitor,
-        )
-
-        domain_config = yaml_config_to_domain(yaml_config)
-
-        # Create transformer via DI if configured (with observability O1)
-        transformer = self.create_transformer(
-            tracer=tracer,
             metrics=metrics,
-        )
-
-        return self.pipeline_class.create(
-            run_id=run_id,
-            runtime=runtime,
-            services=services,
-            config=domain_config,
-            transformer=transformer,
-        )
+        ))
 
     def create_runner(
         self,
@@ -263,22 +174,7 @@ class GenericPipelineFactory(Generic[TPipeline]):
         filter_config: InputFilterConfig | None = None,
         config: PipelineYamlConfig | None = None,
     ) -> PipelineRunner:
-        """Create a fully configured PipelineRunner.
-
-        Encapsulates the construction of the entire pipeline execution graph,
-        including services, pipeline instance, record processor, and executor.
-
-        Args:
-            run_id: Unique identifier for this run
-            runtime: Runtime configuration
-            settings: Application settings
-            observability: Unified observability bundle (logger, tracer, metrics, dq_monitor)
-            filter_config: Optional filter configuration
-            config: Pre-loaded pipeline config (optional)
-
-        Returns:
-            Fully initialized PipelineRunner
-        """
+        """Create a fully configured PipelineRunner with all components."""
         # Load config once if not provided
         yaml_config = config or load_pipeline_config(self.pipeline_name)
 
@@ -295,64 +191,13 @@ class GenericPipelineFactory(Generic[TPipeline]):
             metrics=observability.metrics,
         )
 
-        # Create Helper Components using ServicesBuilder
-        checkpoint_manager = ServicesBuilder.create_checkpoint_manager(
-            checkpoint_port=pipeline.services.checkpoint,
-            logger=observability.logger,
-            pipeline_name=pipeline.config.pipeline_name,
-            run_id=run_id,
-            resume=runtime.resume,
-        )
-
-        record_processor = ServicesBuilder.create_record_processor_from_pipeline(
+        # Delegate runner assembly to dedicated module
+        return assemble_runner(
             pipeline=pipeline,
+            observability=observability,
             silver_schema=self.silver_schema,
             gold_schema=self.gold_schema,
             strict_gold_validation=runtime.strict_gold_validation,
-        )
-
-        # Create Executor
-        executor = PipelineExecutor(
-            services=pipeline.services,
-            record_processor=record_processor,
-            checkpoint_manager=checkpoint_manager,
-            shutdown_signal=pipeline.shutdown_signal,
-            entity_type=pipeline.config.entity_type,
-            batch_size=pipeline.config.batch_size,
-            checkpoint_interval=pipeline.config.checkpoint_interval,
-        )
-
-        # Create lifecycle service (M5)
-        lifecycle_service = MedallionLifecycleService(
-            storage=pipeline.services.storage,
-            logger=observability.logger,
-        )
-
-        # Build runner services via DI factory (composition layer)
-        runner_services = build_runner_services(
-            config=pipeline.config,
-            runtime=pipeline.runtime,
-            services=pipeline.services,
-            context=pipeline.context,
-            logger=observability.logger,
-            shutdown_signal=pipeline.shutdown_signal,
-            checkpoint_manager=checkpoint_manager,
-            lifecycle_service=lifecycle_service,
-        )
-
-        # Assemble Runner with injected RunnerServices bundle
-        return PipelineRunner(
-            config=pipeline.config,
-            runtime=pipeline.runtime,
-            services=pipeline.services,
-            context=pipeline.context,
-            executor=executor,
-            checkpoint_manager=checkpoint_manager,
-            shutdown_signal=pipeline.shutdown_signal,
-            logger=observability.logger,
-            runner_services=runner_services,
-            pipeline=pipeline,
-            tracer=observability.tracer,
         )
 
 
@@ -364,28 +209,7 @@ def create_pipeline_factory(
     gold_schema: Any = None,
     transformer_class: type[BaseTransformer] | None = None,
 ) -> GenericPipelineFactory[TPipeline]:
-    """Convenience function for creating pipeline factories.
-
-    Args:
-        pipeline_name: Unique pipeline name
-        pipeline_class: Pipeline class to instantiate
-        provider: Data source provider name
-        silver_schema: Optional Silver layer schema
-        gold_schema: Pandera schema for Gold layer validation (required)
-        transformer_class: Transformer class for Bronze→Silver transformation (DI)
-
-    Returns:
-        Configured GenericPipelineFactory
-
-    Example:
-        >>> factory = create_pipeline_factory(
-        ...     pipeline_name="chembl_activity",
-        ...     pipeline_class=ChEMBLActivityPipeline,
-        ...     provider="chembl",
-        ...     silver_schema=CHEMBL_ACTIVITY_SCHEMA,
-        ...     transformer_class=ActivityTransformer,
-        ... )
-    """
+    """Convenience function for creating pipeline factories."""
     return GenericPipelineFactory(
         pipeline_name=pipeline_name,
         pipeline_class=pipeline_class,

--- a/src/bioetl/composition/factories/runner_assembly.py
+++ b/src/bioetl/composition/factories/runner_assembly.py
@@ -1,0 +1,262 @@
+"""Runner assembly module for pipeline factories.
+
+Provides functions for building PipelineRunner and its services.
+Extracted from GenericPipelineFactory to reduce file size and improve cohesion.
+
+This module handles the "assembly" phase of pipeline creation:
+- Building PipelineServices from settings
+- Creating fully configured PipelineRunner instances
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from bioetl.application.core.executor import PipelineExecutor
+from bioetl.application.core.runner import PipelineRunner
+from bioetl.application.services.medallion_lifecycle import MedallionLifecycleService
+from bioetl.composition.factories.base_services_factory import BaseServicesFactory
+from bioetl.composition.factories.runner_services import build_runner_services
+from bioetl.composition.factories.services_builder import ServicesBuilder
+from bioetl.infrastructure.config import load_pipeline_config, yaml_config_to_domain
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+    import structlog
+
+    from bioetl.application.core.base import BasePipeline
+    from bioetl.application.core.base_transformer import BaseTransformer
+    from bioetl.application.core.pipeline_services import PipelineServices
+    from bioetl.composition.factories.data_source_registry import DataSourceCreator
+    from bioetl.composition.observability import ObservabilityBundle
+    from bioetl.domain.config import RuntimeConfig
+    from bioetl.domain.filter_config import InputFilterConfig
+    from bioetl.domain.ports import (
+        DataSourcePort,
+        DQMonitorPort,
+        MetricsPort,
+        TracingPort,
+    )
+    from bioetl.domain.types import RunID
+    from bioetl.infrastructure.config import Settings
+    from bioetl.infrastructure.schemas.pipeline_config import PipelineYamlConfig
+
+    TPipeline = type["BasePipeline"]
+
+
+def create_data_source(
+    create_data_source_fn: DataSourceCreator,
+    settings: Settings,
+    pipeline_config: PipelineYamlConfig,
+    logger: structlog.BoundLogger,
+    filter_config: InputFilterConfig | None = None,
+) -> DataSourcePort:
+    """Create data source using the provided creator function.
+
+    Args:
+        create_data_source_fn: Data source creator function
+        settings: Application settings
+        pipeline_config: Pipeline configuration
+        logger: Structured logger
+        filter_config: Optional filter configuration
+
+    Returns:
+        Configured DataSourcePort
+    """
+    return create_data_source_fn(settings, pipeline_config, logger, filter_config)
+
+
+def build_pipeline_services(
+    pipeline_name: str,
+    create_data_source_fn: DataSourceCreator,
+    settings: Settings,
+    logger: structlog.BoundLogger,
+    config: PipelineYamlConfig | None = None,
+    filter_config: InputFilterConfig | None = None,
+    tracer: TracingPort | None = None,
+    dq_monitor: DQMonitorPort | None = None,
+) -> PipelineServices:
+    """Build PipelineServices from settings.
+
+    Args:
+        pipeline_name: Name of the pipeline for config lookup
+        create_data_source_fn: Data source creator function
+        settings: Application settings
+        logger: Structured logger
+        config: Pre-loaded pipeline config (avoids duplicate I/O)
+        filter_config: Optional input filter configuration
+        tracer: Optional tracer (created via bootstrap_tracer())
+        dq_monitor: Optional data quality monitor for anomaly detection
+
+    Returns:
+        Configured PipelineServices instance
+    """
+    pipeline_config = config or load_pipeline_config(pipeline_name)
+    data_source = create_data_source(
+        create_data_source_fn, settings, pipeline_config, logger, filter_config
+    )
+
+    return BaseServicesFactory.create_common_services(
+        settings=settings,
+        logger=logger,
+        data_source=data_source,
+        pipeline_config=pipeline_config,
+        tracer=tracer,
+        dq_monitor=dq_monitor,
+    )
+
+
+def create_pipeline_with_services(
+    pipeline_name: str,
+    pipeline_class: type[BasePipeline],
+    provider: str,
+    create_data_source_fn: DataSourceCreator,
+    transformer_class: type[BaseTransformer] | None,
+    run_id: RunID,
+    runtime: RuntimeConfig,
+    settings: Settings,
+    logger: structlog.BoundLogger,
+    config: PipelineYamlConfig | None = None,
+    filter_config: InputFilterConfig | None = None,
+    tracer: TracingPort | None = None,
+    dq_monitor: DQMonitorPort | None = None,
+    metrics: MetricsPort | None = None,
+) -> BasePipeline:
+    """Create pipeline instance with services.
+
+    Loads config once and reuses it for both services and pipeline.
+    If transformer_class is configured, creates and injects transformer via DI.
+
+    Args:
+        pipeline_name: Name of the pipeline
+        pipeline_class: Pipeline class to instantiate
+        provider: Data provider name
+        create_data_source_fn: Data source creator function
+        transformer_class: Optional transformer class for Bronze→Silver
+        run_id: Unique identifier for this pipeline run
+        runtime: Pipeline runtime configuration
+        settings: Application settings
+        logger: Structured logger
+        config: Pre-loaded pipeline config (avoids duplicate I/O)
+        filter_config: Optional input filter configuration
+        tracer: Optional tracer for distributed tracing
+        dq_monitor: Optional data quality monitor
+        metrics: Optional metrics port for transformer observability
+
+    Returns:
+        Configured pipeline instance
+    """
+    yaml_config = config or load_pipeline_config(pipeline_name)
+
+    services = build_pipeline_services(
+        pipeline_name=pipeline_name,
+        create_data_source_fn=create_data_source_fn,
+        settings=settings,
+        logger=logger,
+        config=yaml_config,
+        filter_config=filter_config,
+        tracer=tracer,
+        dq_monitor=dq_monitor,
+    )
+
+    domain_config = yaml_config_to_domain(yaml_config)
+
+    # Create transformer via DI if configured (with observability)
+    transformer = None
+    if transformer_class is not None:
+        transformer = transformer_class(
+            provider=provider,
+            tracer=tracer,
+            metrics=metrics,
+        )
+
+    return pipeline_class.create(
+        run_id=run_id,
+        runtime=runtime,
+        services=services,
+        config=domain_config,
+        transformer=transformer,
+    )
+
+
+def assemble_runner(
+    pipeline: BasePipeline,
+    observability: ObservabilityBundle,
+    silver_schema: pa.Schema | None,
+    gold_schema: Any,
+    strict_gold_validation: bool,
+) -> PipelineRunner:
+    """Assemble a PipelineRunner from a pipeline instance.
+
+    This function handles the construction of the entire pipeline execution graph,
+    including record processor, executor, lifecycle service, and runner services.
+
+    Args:
+        pipeline: Configured pipeline instance
+        observability: Unified observability bundle (logger, tracer, metrics, dq_monitor)
+        silver_schema: PyArrow schema for Silver layer
+        gold_schema: Schema for Gold layer validation
+        strict_gold_validation: Whether to enforce strict Gold validation
+
+    Returns:
+        Fully initialized PipelineRunner
+    """
+    # Create Helper Components using ServicesBuilder
+    checkpoint_manager = ServicesBuilder.create_checkpoint_manager(
+        checkpoint_port=pipeline.services.checkpoint,
+        logger=observability.logger,
+        pipeline_name=pipeline.config.pipeline_name,
+        run_id=pipeline.run_id,
+        resume=pipeline.runtime.resume,
+    )
+
+    record_processor = ServicesBuilder.create_record_processor_from_pipeline(
+        pipeline=pipeline,
+        silver_schema=silver_schema,
+        gold_schema=gold_schema,
+        strict_gold_validation=strict_gold_validation,
+    )
+
+    # Create Executor
+    executor = PipelineExecutor(
+        services=pipeline.services,
+        record_processor=record_processor,
+        checkpoint_manager=checkpoint_manager,
+        shutdown_signal=pipeline.shutdown_signal,
+        entity_type=pipeline.config.entity_type,
+        batch_size=pipeline.config.batch_size,
+        checkpoint_interval=pipeline.config.checkpoint_interval,
+    )
+
+    # Create lifecycle service (M5)
+    lifecycle_service = MedallionLifecycleService(
+        storage=pipeline.services.storage,
+        logger=observability.logger,
+    )
+
+    # Build runner services via DI factory (composition layer)
+    runner_services = build_runner_services(
+        config=pipeline.config,
+        runtime=pipeline.runtime,
+        services=pipeline.services,
+        context=pipeline.context,
+        logger=observability.logger,
+        shutdown_signal=pipeline.shutdown_signal,
+        checkpoint_manager=checkpoint_manager,
+        lifecycle_service=lifecycle_service,
+    )
+
+    # Assemble Runner with injected RunnerServices bundle
+    return PipelineRunner(
+        config=pipeline.config,
+        runtime=pipeline.runtime,
+        services=pipeline.services,
+        context=pipeline.context,
+        executor=executor,
+        checkpoint_manager=checkpoint_manager,
+        shutdown_signal=pipeline.shutdown_signal,
+        logger=observability.logger,
+        runner_services=runner_services,
+        pipeline=pipeline,
+        tracer=observability.tracer,
+    )

--- a/tests/unit/composition/test_generic_factory.py
+++ b/tests/unit/composition/test_generic_factory.py
@@ -142,8 +142,8 @@ class TestGenericPipelineFactory:
         )
         assert result is mock_data_source
 
-    @patch("bioetl.composition.factories.generic_factory.load_pipeline_config")
-    @patch("bioetl.composition.factories.generic_factory.BaseServicesFactory")
+    @patch("bioetl.composition.factories.runner_assembly.load_pipeline_config")
+    @patch("bioetl.composition.factories.runner_assembly.BaseServicesFactory")
     def test_build_services(
         self,
         mock_services_factory,


### PR DESCRIPTION
Extract runner assembly logic into runner_assembly.py:
- build_pipeline_services: builds PipelineServices from settings
- create_pipeline_with_services: creates pipeline instance with DI
- assemble_runner: assembles PipelineRunner from pipeline instance

File size changes:
- generic_factory.py: 397 → 220 lines (✓ <300)
- runner_assembly.py: 262 lines (new, ✓ <300)

Public API preserved:
- GenericPipelineFactory.create_runner() still works
- GenericPipelineFactory.build_services() still works
- All 102 composition tests pass