### PR TITLE
Remove datetime.now() from observability layer

### DIFF
--- a/src/bioetl/infrastructure/observability/anomaly/detector.py
+++ b/src/bioetl/infrastructure/observability/anomaly/detector.py
@@ -6,7 +6,7 @@ Main entry point for anomaly detection functionality.
 from __future__ import annotations
 
 import statistics
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 from bioetl.infrastructure.observability.anomaly.detectors.zscore import ZScoreDetector
@@ -91,42 +91,47 @@ class AnomalyDetector:
         self._thresholds[metric_name] = (min_val, max_val)
 
     def detect(
-        self, metric_name: str, current_value: float, now: datetime | None = None
+        self, metric_name: str, current_value: float, timestamp: datetime | None = None
     ) -> Anomaly | None:
         """Detect anomaly in current value.
 
         Args:
             metric_name: Name of metric being analyzed
             current_value: Current observed value
-            now: Optional timestamp for testing (defaults to current UTC time)
+            timestamp: Timestamp for the anomaly (should be created in application layer)
 
         Returns:
             Anomaly if detected, None otherwise
         """
-        if anomaly := self._check_thresholds(metric_name, current_value, now):
+        if anomaly := self._check_thresholds(metric_name, current_value, timestamp):
             return anomaly
 
         baseline = self._baselines.get(metric_name, [])
         if len(baseline) < self.min_baseline_samples:
             return None
 
+        if timestamp is None:
+            return None  # No anomaly without timestamp from application layer
+
         return self.strategy.detect(
-            metric_name, current_value, baseline, self.z_score_threshold, now
+            metric_name, current_value, baseline, self.z_score_threshold, timestamp
         )
 
     def _check_thresholds(
-        self, metric_name: str, current_value: float, now: datetime | None = None
+        self, metric_name: str, current_value: float, timestamp: datetime | None = None
     ) -> Anomaly | None:
         """Check if the current value exceeds configured thresholds."""
         if metric_name not in self._thresholds:
             return None
+        if timestamp is None:
+            return None  # No anomaly without timestamp from application layer
 
         min_val, max_val = self._thresholds[metric_name]
         if min_val <= current_value <= max_val:
             return None
 
         return self._create_threshold_anomaly(
-            metric_name, current_value, min_val, max_val, now
+            metric_name, current_value, min_val, max_val, timestamp
         )
 
     def _create_threshold_anomaly(
@@ -135,7 +140,7 @@ class AnomalyDetector:
         current_value: float,
         min_val: float,
         max_val: float,
-        now: datetime | None = None,
+        timestamp: datetime,
     ) -> Anomaly:
         """Create anomaly for threshold breach."""
         baseline_mean = (min_val + max_val) / 2
@@ -162,7 +167,7 @@ class AnomalyDetector:
             anomaly_type=AnomalyType.THRESHOLD_EXCEEDED,
             severity=AnomalySeverity.CRITICAL,
             z_score=z_score,
-            timestamp=now or datetime.now(UTC),
+            timestamp=timestamp,
             message=message,
         )
 

--- a/src/bioetl/infrastructure/observability/anomaly/detectors/base.py
+++ b/src/bioetl/infrastructure/observability/anomaly/detectors/base.py
@@ -35,7 +35,7 @@ class DetectorStrategy(ABC):
         current_value: float,
         baseline: Sequence[float],
         threshold: float,
-        now: datetime | None = None,
+        timestamp: datetime,
     ) -> Anomaly | None:
         """Detect anomaly in current value.
 
@@ -44,7 +44,7 @@ class DetectorStrategy(ABC):
             current_value: Current observed value
             baseline: Historical values for comparison
             threshold: Detection threshold (interpretation varies by strategy)
-            now: Optional timestamp for testing (defaults to current UTC time)
+            timestamp: Timestamp for the anomaly (created in application layer)
 
         Returns:
             Anomaly if detected, None otherwise

--- a/src/bioetl/infrastructure/observability/anomaly/detectors/iqr.py
+++ b/src/bioetl/infrastructure/observability/anomaly/detectors/iqr.py
@@ -6,7 +6,7 @@ Uses quartiles to identify outliers, robust to non-normal distributions.
 from __future__ import annotations
 
 import statistics
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 from bioetl.infrastructure.observability.anomaly.detectors.base import DetectorStrategy
@@ -41,11 +41,13 @@ class IQRDetector(DetectorStrategy):
         current_value: float,
         baseline: Sequence[float],
         threshold: float = 1.5,
-        now: datetime | None = None,
+        timestamp: datetime | None = None,
     ) -> Anomaly | None:
         """Detect anomaly using IQR method."""
         if len(baseline) < self.MIN_SAMPLES:
             return None
+        if timestamp is None:
+            return None  # No anomaly without timestamp from application layer
 
         q1, q3 = self._calculate_quartiles(baseline)
         iqr = q3 - q1
@@ -59,7 +61,7 @@ class IQRDetector(DetectorStrategy):
 
         mean = statistics.mean(baseline)
         stddev = statistics.stdev(baseline) if len(baseline) >= 2 else 0.0
-        return self._create_anomaly(metric_name, current_value, mean, stddev, score, now)
+        return self._create_anomaly(metric_name, current_value, mean, stddev, score, timestamp)
 
     def _calculate_quartiles(self, data: Sequence[float]) -> tuple[float, float]:
         """Calculate Q1 and Q3 quartiles."""
@@ -86,7 +88,7 @@ class IQRDetector(DetectorStrategy):
         mean: float,
         stddev: float,
         score: float,
-        now: datetime | None = None,
+        timestamp: datetime,
     ) -> Anomaly:
         """Create Anomaly object from detection results."""
         anomaly_type = AnomalyType.SPIKE if current_value > mean else AnomalyType.DROP
@@ -104,7 +106,7 @@ class IQRDetector(DetectorStrategy):
             anomaly_type=anomaly_type,
             severity=severity,
             z_score=score,
-            timestamp=now or datetime.now(UTC),
+            timestamp=timestamp,
             message=message,
         )
 

--- a/src/bioetl/infrastructure/observability/anomaly/detectors/mad.py
+++ b/src/bioetl/infrastructure/observability/anomaly/detectors/mad.py
@@ -6,7 +6,7 @@ Uses median and MAD for robust outlier detection.
 from __future__ import annotations
 
 import statistics
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 from bioetl.infrastructure.observability.anomaly.detectors.base import DetectorStrategy
@@ -42,11 +42,13 @@ class MADDetector(DetectorStrategy):
         current_value: float,
         baseline: Sequence[float],
         threshold: float = 2.0,
-        now: datetime | None = None,
+        timestamp: datetime | None = None,
     ) -> Anomaly | None:
         """Detect anomaly using MAD method."""
         if len(baseline) < self.MIN_SAMPLES:
             return None
+        if timestamp is None:
+            return None  # No anomaly without timestamp from application layer
 
         median = statistics.median(baseline)
         mad = self._calculate_mad(baseline, median)
@@ -60,7 +62,7 @@ class MADDetector(DetectorStrategy):
 
         mean = statistics.mean(baseline)
         stddev = statistics.stdev(baseline) if len(baseline) >= 2 else 0.0
-        return self._create_anomaly(metric_name, current_value, mean, stddev, score, now)
+        return self._create_anomaly(metric_name, current_value, mean, stddev, score, timestamp)
 
     def _calculate_mad(self, data: Sequence[float], median: float) -> float:
         """Calculate Median Absolute Deviation."""
@@ -80,7 +82,7 @@ class MADDetector(DetectorStrategy):
         mean: float,
         stddev: float,
         score: float,
-        now: datetime | None = None,
+        timestamp: datetime,
     ) -> Anomaly:
         """Create Anomaly object from detection results."""
         anomaly_type = AnomalyType.SPIKE if current_value > mean else AnomalyType.DROP
@@ -98,7 +100,7 @@ class MADDetector(DetectorStrategy):
             anomaly_type=anomaly_type,
             severity=severity,
             z_score=score,
-            timestamp=now or datetime.now(UTC),
+            timestamp=timestamp,
             message=message,
         )
 

--- a/src/bioetl/infrastructure/observability/anomaly/detectors/zscore.py
+++ b/src/bioetl/infrastructure/observability/anomaly/detectors/zscore.py
@@ -6,7 +6,7 @@ Uses standard deviation to identify outliers.
 from __future__ import annotations
 
 import statistics
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 from bioetl.infrastructure.observability.anomaly.detectors.base import DetectorStrategy
@@ -38,11 +38,13 @@ class ZScoreDetector(DetectorStrategy):
         current_value: float,
         baseline: Sequence[float],
         threshold: float = 2.0,
-        now: datetime | None = None,
+        timestamp: datetime | None = None,
     ) -> Anomaly | None:
         """Detect anomaly using Z-score method."""
         if len(baseline) < self.MIN_SAMPLES:
             return None
+        if timestamp is None:
+            return None  # No anomaly without timestamp from application layer
 
         mean = statistics.mean(baseline)
         stddev = statistics.stdev(baseline)
@@ -51,7 +53,7 @@ class ZScoreDetector(DetectorStrategy):
         if z_score is None or z_score < threshold:
             return None
 
-        return self._create_anomaly(metric_name, current_value, mean, stddev, z_score, now)
+        return self._create_anomaly(metric_name, current_value, mean, stddev, z_score, timestamp)
 
     def _calculate_z_score(
         self, value: float, mean: float, stddev: float
@@ -71,7 +73,7 @@ class ZScoreDetector(DetectorStrategy):
         mean: float,
         stddev: float,
         z_score: float,
-        now: datetime | None = None,
+        timestamp: datetime,
     ) -> Anomaly:
         """Create Anomaly object from detection results."""
         anomaly_type = AnomalyType.SPIKE if current_value > mean else AnomalyType.DROP
@@ -89,7 +91,7 @@ class ZScoreDetector(DetectorStrategy):
             anomaly_type=anomaly_type,
             severity=severity,
             z_score=z_score,
-            timestamp=now or datetime.now(UTC),
+            timestamp=timestamp,
             message=message,
         )
 

--- a/src/bioetl/infrastructure/observability/anomaly/monitor.py
+++ b/src/bioetl/infrastructure/observability/anomaly/monitor.py
@@ -6,6 +6,7 @@ Combines multiple detectors to monitor data quality metrics.
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 from bioetl.infrastructure.observability.anomaly.detector import AnomalyDetector
@@ -65,20 +66,32 @@ class DataQualityMonitor:
         if min_threshold is not None or max_threshold is not None:
             self.detector.set_threshold(metric_name, min_threshold, max_threshold)
 
-    def check_quality(self, metrics: dict[str, float]) -> list[Anomaly]:
-        """Check metrics for quality issues."""
+    def check_quality(
+        self, metrics: dict[str, float], timestamp: datetime | None = None
+    ) -> list[Anomaly]:
+        """Check metrics for quality issues.
+
+        Args:
+            metrics: Dictionary of metric names to values
+            timestamp: Timestamp for anomalies (should be created in application layer)
+
+        Returns:
+            List of detected anomalies
+        """
         anomalies: list[Anomaly] = []
 
         for metric_name, current_value in metrics.items():
-            anomaly = self.detector.detect(metric_name, current_value)
+            anomaly = self.detector.detect(metric_name, current_value, timestamp)
             if anomaly:
                 anomalies.append(anomaly)
 
         return anomalies
 
-    def update_baseline_from_metrics(self, metrics: dict[str, float]) -> None:
+    def update_baseline_from_metrics(
+        self, metrics: dict[str, float], timestamp: datetime | None = None
+    ) -> None:
         """Update baseline with current metrics (if no anomalies)."""
-        anomalies = self.check_quality(metrics)
+        anomalies = self.check_quality(metrics, timestamp)
         critical_anomalies = [
             a for a in anomalies if a.severity == AnomalySeverity.CRITICAL
         ]

--- a/src/bioetl/infrastructure/observability/lineage.py
+++ b/src/bioetl/infrastructure/observability/lineage.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import asdict, dataclass
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
@@ -171,9 +171,9 @@ class LineageTracker:
         entity_type: str,
         record_count: int,
         file_path: str,
+        timestamp: datetime,
         watermark: str | None = None,
         metadata: dict[str, Any] | None = None,
-        now: datetime | None = None,
     ) -> None:
         """Record bronze layer batch ingestion.
 
@@ -184,9 +184,9 @@ class LineageTracker:
             entity_type: Entity type
             record_count: Number of records
             file_path: Storage location
+            timestamp: Ingestion timestamp (created in application layer)
             watermark: Optional position marker (deprecated)
             metadata: Additional metadata
-            now: Optional timestamp for testing (defaults to current UTC time)
 
         """
         batch = BatchLineage(
@@ -200,7 +200,7 @@ class LineageTracker:
             file_path=file_path,
             watermark=watermark,
             metadata=metadata or {},
-            timestamp=now or datetime.now(UTC),
+            timestamp=timestamp,
         )
 
         self._write_batch_lineage(batch)
@@ -216,8 +216,8 @@ class LineageTracker:
         record_count: int,
         success_count: int,
         failure_count: int,
+        timestamp: datetime,
         metadata: dict[str, Any] | None = None,
-        now: datetime | None = None,
     ) -> None:
         """Record data transformation between layers.
 
@@ -231,8 +231,8 @@ class LineageTracker:
             record_count: Total records processed
             success_count: Successful transformations
             failure_count: Failed transformations
+            timestamp: Transformation timestamp (created in application layer)
             metadata: Additional metadata
-            now: Optional timestamp for testing (defaults to current UTC time)
 
         """
         lineage = LineageRecord(
@@ -248,7 +248,7 @@ class LineageTracker:
             success_count=success_count,
             failure_count=failure_count,
             metadata=metadata or {},
-            timestamp=now or datetime.now(UTC),
+            timestamp=timestamp,
         )
 
         self._write_transformation_lineage(lineage)
@@ -318,7 +318,7 @@ class LineageTracker:
         """
         try:
             dt = DeltaTable(str(self.batch_table_path))
-            df: pl.DataFrame = pl.from_arrow(dt.to_pyarrow_table())  # type: ignore[assignment]
+            df: pl.DataFrame = pl.from_arrow(dt.to_pyarrow_table())
 
             # Filter by pipeline
             df = df.filter(pl.col("pipeline_name") == self.pipeline_name)
@@ -359,7 +359,7 @@ class LineageTracker:
         """
         try:
             dt = DeltaTable(str(self.transformation_table_path))
-            df: pl.DataFrame = pl.from_arrow(dt.to_pyarrow_table())  # type: ignore[assignment]
+            df: pl.DataFrame = pl.from_arrow(dt.to_pyarrow_table())
 
             # Filter by pipeline
             df = df.filter(pl.col("pipeline_name") == self.pipeline_name)
@@ -398,7 +398,7 @@ class LineageTracker:
         """
         try:
             dt = DeltaTable(str(self.transformation_table_path))
-            df: pl.DataFrame = pl.from_arrow(dt.to_pyarrow_table())  # type: ignore[assignment]
+            df: pl.DataFrame = pl.from_arrow(dt.to_pyarrow_table())
 
             # Filter by pipeline and entity_id
             df = df.filter(pl.col("pipeline_name") == self.pipeline_name)
@@ -416,15 +416,15 @@ class LineageTracker:
     def get_batch_statistics(
         self,
         layer: str,
+        timestamp: datetime,
         days: int = 7,
-        now: datetime | None = None,
     ) -> dict[str, Any]:
         """Get batch statistics for a layer.
 
         Args:
             layer: Data layer (bronze, silver, gold)
+            timestamp: Current timestamp for calculating date range (created in application layer)
             days: Number of days to analyze
-            now: Optional timestamp for testing (defaults to current UTC time)
 
         Returns:
             Dictionary with statistics (total_batches, total_records, avg_batch_size)
@@ -432,14 +432,13 @@ class LineageTracker:
         """
         try:
             dt = DeltaTable(str(self.batch_table_path))
-            df: pl.DataFrame = pl.from_arrow(dt.to_pyarrow_table())  # type: ignore[assignment]
+            df: pl.DataFrame = pl.from_arrow(dt.to_pyarrow_table())
 
             # Filter by pipeline and layer
             df = df.filter(pl.col("pipeline_name") == self.pipeline_name)
             df = df.filter(pl.col("layer") == layer)
 
             # Filter by date range
-            timestamp = now or datetime.now(UTC)
             cutoff = timestamp.timestamp() - (days * 86400)
             df = df.filter(pl.col("timestamp") >= cutoff)
 

--- a/tests/unit/infrastructure/observability/test_anomaly.py
+++ b/tests/unit/infrastructure/observability/test_anomaly.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import statistics
+from datetime import UTC, datetime
 
 import pytest
 
@@ -128,20 +129,20 @@ class TestAnomalyDetector:
 
     def test_detect_no_baseline_returns_none(self, detector):
         """Test detect returns None when no baseline exists."""
-        result = detector.detect("unknown_metric", 100)
+        result = detector.detect("unknown_metric", 100, timestamp=datetime.now(UTC))
         assert result is None
 
     def test_detect_normal_value_returns_none(self, detector):
         """Test detect returns None for normal value."""
         detector.update_baseline("metric", [100.0, 100.0, 100.0, 100.0, 100.0])
-        result = detector.detect("metric", 100.0)
+        result = detector.detect("metric", 100.0, timestamp=datetime.now(UTC))
         assert result is None
 
     def test_detect_spike_anomaly(self, detector):
         """Test detection of spike anomaly."""
         # Use values with some variance so stddev > 0
         detector.update_baseline("metric", [95.0, 100.0, 105.0, 98.0, 102.0])
-        result = detector.detect("metric", 500.0)
+        result = detector.detect("metric", 500.0, timestamp=datetime.now(UTC))
 
         assert result is not None
         assert result.anomaly_type == AnomalyType.SPIKE
@@ -151,7 +152,7 @@ class TestAnomalyDetector:
         """Test detection of drop anomaly."""
         # Use values with some variance so stddev > 0
         detector.update_baseline("metric", [95.0, 100.0, 105.0, 98.0, 102.0])
-        result = detector.detect("metric", 10.0)
+        result = detector.detect("metric", 10.0, timestamp=datetime.now(UTC))
 
         assert result is not None
         assert result.anomaly_type == AnomalyType.DROP
@@ -169,7 +170,7 @@ class TestAnomalyDetector:
         """Test detection when standard deviation is zero."""
         detector.update_baseline("metric", [100.0, 100.0, 100.0, 100.0, 100.0])
         # When stddev is 0, special handling applies
-        result = detector.detect("metric", 150.0)
+        result = detector.detect("metric", 150.0, timestamp=datetime.now(UTC))
 
         # Should handle gracefully without division by zero
         # Per implementation, uses percentage deviation when stddev=0
@@ -217,7 +218,7 @@ class TestAnomalyDetectorSeverityCalculation:
         # Set baseline with values that give mean~100 and stddev~10
         detector.update_baseline("metric", [90.0, 95.0, 100.0, 105.0, 110.0])
 
-        result = detector.detect("metric", 125.0)  # ~2.5 std dev
+        result = detector.detect("metric", 125.0, timestamp=datetime.now(UTC))  # ~2.5 std dev
 
         if result:
             assert result.severity in (
@@ -230,7 +231,7 @@ class TestAnomalyDetectorSeverityCalculation:
         # Set baseline with values that give mean~100 and stddev~10
         detector.update_baseline("metric", [90.0, 95.0, 100.0, 105.0, 110.0])
 
-        result = detector.detect("metric", 200.0)  # ~10 std dev
+        result = detector.detect("metric", 200.0, timestamp=datetime.now(UTC))  # ~10 std dev
 
         if result:
             assert result.severity in (
@@ -258,7 +259,7 @@ class TestAnomalyDetectorEdgeCases:
         try:
             detector.update_baseline("metric", [100])
             # Stddev of single value is 0
-            detector.detect("metric", 110)
+            detector.detect("metric", 110, timestamp=datetime.now(UTC))
         except (ValueError, statistics.StatisticsError):
             pass  # Expected behavior
 
@@ -266,7 +267,7 @@ class TestAnomalyDetectorEdgeCases:
         """Test handling of negative values."""
         detector = AnomalyDetector()
         detector.update_baseline("metric", [-100, -90, -110, -95, -105])
-        result = detector.detect("metric", -500)
+        result = detector.detect("metric", -500, timestamp=datetime.now(UTC))
 
         # Should detect as anomaly
         assert result is not None
@@ -275,7 +276,7 @@ class TestAnomalyDetectorEdgeCases:
         """Test handling of float values."""
         detector = AnomalyDetector()
         detector.update_baseline("metric", [1.5, 1.6, 1.4, 1.55, 1.45])
-        result = detector.detect("metric", 5.0)
+        result = detector.detect("metric", 5.0, timestamp=datetime.now(UTC))
 
         assert result is not None
 
@@ -315,7 +316,7 @@ class TestAnomalyDetectorThresholds:
         detector = AnomalyDetector()
         detector.set_threshold("metric", min_value=100, max_value=200)
 
-        result = detector.detect("metric", 50)  # Below minimum
+        result = detector.detect("metric", 50, timestamp=datetime.now(UTC))  # Below minimum
 
         assert result is not None
         assert result.anomaly_type == AnomalyType.THRESHOLD_EXCEEDED
@@ -326,7 +327,7 @@ class TestAnomalyDetectorThresholds:
         detector = AnomalyDetector()
         detector.set_threshold("metric", min_value=100, max_value=200)
 
-        result = detector.detect("metric", 250)  # Above maximum
+        result = detector.detect("metric", 250, timestamp=datetime.now(UTC))  # Above maximum
 
         assert result is not None
         assert result.anomaly_type == AnomalyType.THRESHOLD_EXCEEDED
@@ -420,7 +421,7 @@ class TestDataQualityMonitor:
         monitor = DataQualityMonitor()
         monitor.add_metric("record_count", [1000, 1050, 980, 1020, 1010])
 
-        anomalies = monitor.check_quality({"record_count": 1000})
+        anomalies = monitor.check_quality({"record_count": 1000}, timestamp=datetime.now(UTC))
 
         assert anomalies == []
 
@@ -431,7 +432,7 @@ class TestDataQualityMonitor:
         monitor = DataQualityMonitor()
         monitor.add_metric("record_count", [1000, 1050, 980, 1020, 1010])
 
-        anomalies = monitor.check_quality({"record_count": 100})  # Low value
+        anomalies = monitor.check_quality({"record_count": 100}, timestamp=datetime.now(UTC))  # Low value
 
         assert len(anomalies) == 1
 
@@ -442,7 +443,7 @@ class TestDataQualityMonitor:
         monitor = DataQualityMonitor()
         monitor.add_metric("record_count", [1000, 1050, 980])
 
-        monitor.update_baseline_from_metrics({"record_count": 1020})
+        monitor.update_baseline_from_metrics({"record_count": 1020}, timestamp=datetime.now(UTC))
 
         # Baseline should be updated
         assert 1020 in monitor.detector._baselines["record_count"]
@@ -456,7 +457,7 @@ class TestDataQualityMonitor:
         monitor.add_metric("error_rate", [0.01, 0.02, 0.01], max_threshold=0.1)
 
         # This should trigger a critical anomaly (exceeds 0.1 threshold)
-        monitor.update_baseline_from_metrics({"error_rate": 0.5})
+        monitor.update_baseline_from_metrics({"error_rate": 0.5}, timestamp=datetime.now(UTC))
 
         # Baseline should NOT be updated with the anomalous value
         assert 0.5 not in monitor.detector._baselines.get("error_rate", [])

--- a/tests/unit/infrastructure/observability/test_iqr_mad_detectors.py
+++ b/tests/unit/infrastructure/observability/test_iqr_mad_detectors.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 import pytest
 
 from bioetl.infrastructure.observability.anomaly.detectors.iqr import IQRDetector
@@ -24,25 +26,25 @@ class TestIQRDetector:
     def test_detect_returns_none_for_insufficient_samples(self, detector):
         """Test that detect returns None when baseline has < 4 samples."""
         baseline = [100.0, 110.0, 120.0]  # Only 3 samples
-        result = detector.detect("metric", 500.0, baseline)
+        result = detector.detect("metric", 500.0, baseline, timestamp=datetime.now(UTC))
         assert result is None
 
     def test_detect_returns_none_for_zero_iqr(self, detector):
         """Test that detect returns None when IQR is zero."""
         baseline = [100.0, 100.0, 100.0, 100.0, 100.0]  # All same values
-        result = detector.detect("metric", 500.0, baseline)
+        result = detector.detect("metric", 500.0, baseline, timestamp=datetime.now(UTC))
         assert result is None
 
     def test_detect_returns_none_for_normal_value(self, detector):
         """Test that detect returns None for value within bounds."""
         baseline = [100.0, 110.0, 120.0, 130.0, 140.0]
-        result = detector.detect("metric", 125.0, baseline)  # Within IQR
+        result = detector.detect("metric", 125.0, baseline, timestamp=datetime.now(UTC))  # Within IQR
         assert result is None
 
     def test_detect_spike_anomaly(self, detector):
         """Test detection of spike (value above Q3)."""
         baseline = [100.0, 110.0, 120.0, 130.0, 140.0]
-        result = detector.detect("metric", 200.0, baseline, threshold=1.0)
+        result = detector.detect("metric", 200.0, baseline, threshold=1.0, timestamp=datetime.now(UTC))
 
         assert result is not None
         assert result.anomaly_type == AnomalyType.SPIKE
@@ -52,7 +54,7 @@ class TestIQRDetector:
     def test_detect_drop_anomaly(self, detector):
         """Test detection of drop (value below Q1)."""
         baseline = [100.0, 110.0, 120.0, 130.0, 140.0]
-        result = detector.detect("metric", 50.0, baseline, threshold=1.0)
+        result = detector.detect("metric", 50.0, baseline, threshold=1.0, timestamp=datetime.now(UTC))
 
         assert result is not None
         assert result.anomaly_type == AnomalyType.DROP
@@ -104,12 +106,14 @@ class TestIQRDetector:
 
     def test_create_anomaly(self, detector):
         """Test anomaly object creation."""
+        ts = datetime.now(UTC)
         anomaly = detector._create_anomaly(
             metric_name="test_metric",
             current_value=300.0,
             mean=100.0,
             stddev=20.0,
             score=4.0,
+            timestamp=ts,
         )
 
         assert anomaly.metric_name == "test_metric"
@@ -119,7 +123,7 @@ class TestIQRDetector:
         assert anomaly.z_score == 4.0
         assert anomaly.severity == AnomalySeverity.HIGH
         assert anomaly.anomaly_type == AnomalyType.SPIKE
-        assert anomaly.timestamp is not None
+        assert anomaly.timestamp == ts
 
     def test_create_anomaly_drop_type(self, detector):
         """Test anomaly type is DROP when value is below mean."""
@@ -129,6 +133,7 @@ class TestIQRDetector:
             mean=100.0,
             stddev=20.0,
             score=3.0,
+            timestamp=datetime.now(UTC),
         )
 
         assert anomaly.anomaly_type == AnomalyType.DROP
@@ -150,25 +155,25 @@ class TestMADDetector:
     def test_detect_returns_none_for_insufficient_samples(self, detector):
         """Test that detect returns None when baseline has < 3 samples."""
         baseline = [100.0, 110.0]  # Only 2 samples
-        result = detector.detect("metric", 500.0, baseline)
+        result = detector.detect("metric", 500.0, baseline, timestamp=datetime.now(UTC))
         assert result is None
 
     def test_detect_returns_none_for_zero_mad(self, detector):
         """Test that detect returns None when MAD is zero."""
         baseline = [100.0, 100.0, 100.0, 100.0]  # All same values
-        result = detector.detect("metric", 500.0, baseline)
+        result = detector.detect("metric", 500.0, baseline, timestamp=datetime.now(UTC))
         assert result is None
 
     def test_detect_returns_none_for_normal_value(self, detector):
         """Test that detect returns None for value within threshold."""
         baseline = [100.0, 110.0, 120.0, 130.0, 140.0]
-        result = detector.detect("metric", 120.0, baseline)  # Close to median
+        result = detector.detect("metric", 120.0, baseline, timestamp=datetime.now(UTC))  # Close to median
         assert result is None
 
     def test_detect_spike_anomaly(self, detector):
         """Test detection of spike (high value)."""
         baseline = [100.0, 110.0, 120.0, 130.0, 140.0]
-        result = detector.detect("metric", 300.0, baseline, threshold=1.0)
+        result = detector.detect("metric", 300.0, baseline, threshold=1.0, timestamp=datetime.now(UTC))
 
         assert result is not None
         assert result.anomaly_type == AnomalyType.SPIKE
@@ -178,7 +183,7 @@ class TestMADDetector:
     def test_detect_drop_anomaly(self, detector):
         """Test detection of drop (low value)."""
         baseline = [100.0, 110.0, 120.0, 130.0, 140.0]
-        result = detector.detect("metric", 10.0, baseline, threshold=1.0)
+        result = detector.detect("metric", 10.0, baseline, threshold=1.0, timestamp=datetime.now(UTC))
 
         assert result is not None
         assert result.anomaly_type == AnomalyType.DROP
@@ -221,12 +226,14 @@ class TestMADDetector:
 
     def test_create_anomaly(self, detector):
         """Test anomaly object creation."""
+        ts = datetime.now(UTC)
         anomaly = detector._create_anomaly(
             metric_name="test_metric",
             current_value=300.0,
             mean=100.0,
             stddev=20.0,
             score=4.5,
+            timestamp=ts,
         )
 
         assert anomaly.metric_name == "test_metric"
@@ -236,7 +243,7 @@ class TestMADDetector:
         assert anomaly.z_score == 4.5
         assert anomaly.severity == AnomalySeverity.HIGH
         assert anomaly.anomaly_type == AnomalyType.SPIKE
-        assert anomaly.timestamp is not None
+        assert anomaly.timestamp == ts
 
     def test_create_anomaly_drop_type(self, detector):
         """Test anomaly type is DROP when value is below mean."""
@@ -246,6 +253,7 @@ class TestMADDetector:
             mean=100.0,
             stddev=20.0,
             score=3.5,
+            timestamp=datetime.now(UTC),
         )
 
         assert anomaly.anomaly_type == AnomalyType.DROP
@@ -267,7 +275,7 @@ class TestDetectorEdgeCases:
         """Test IQR detector with negative values."""
         detector = IQRDetector()
         baseline = [-100.0, -90.0, -80.0, -70.0, -60.0]
-        result = detector.detect("metric", -200.0, baseline, threshold=1.0)
+        result = detector.detect("metric", -200.0, baseline, threshold=1.0, timestamp=datetime.now(UTC))
 
         assert result is not None
         assert result.anomaly_type == AnomalyType.DROP
@@ -276,7 +284,7 @@ class TestDetectorEdgeCases:
         """Test MAD detector with negative values."""
         detector = MADDetector()
         baseline = [-100.0, -90.0, -80.0, -70.0, -60.0]
-        result = detector.detect("metric", -200.0, baseline, threshold=1.0)
+        result = detector.detect("metric", -200.0, baseline, threshold=1.0, timestamp=datetime.now(UTC))
 
         assert result is not None
         assert result.anomaly_type == AnomalyType.DROP
@@ -285,7 +293,7 @@ class TestDetectorEdgeCases:
         """Test IQR detector with large baseline."""
         detector = IQRDetector()
         baseline = list(range(1, 101))  # 1 to 100
-        result = detector.detect("metric", 200.0, baseline, threshold=1.0)
+        result = detector.detect("metric", 200.0, baseline, threshold=1.0, timestamp=datetime.now(UTC))
 
         assert result is not None
 
@@ -293,7 +301,7 @@ class TestDetectorEdgeCases:
         """Test MAD detector with large baseline."""
         detector = MADDetector()
         baseline = list(range(1, 101))  # 1 to 100
-        result = detector.detect("metric", 200.0, baseline, threshold=1.0)
+        result = detector.detect("metric", 200.0, baseline, threshold=1.0, timestamp=datetime.now(UTC))
 
         assert result is not None
 
@@ -302,7 +310,7 @@ class TestDetectorEdgeCases:
         detector = IQRDetector()
         baseline = [100.0, 110.0, 120.0, 130.0, 140.0]
         # Test with threshold of 1.5 (default)
-        result = detector.detect("metric", 175.0, baseline, threshold=1.5)
+        result = detector.detect("metric", 175.0, baseline, threshold=1.5, timestamp=datetime.now(UTC))
 
         # Value should be just at or past threshold
         if result is not None:
@@ -313,7 +321,7 @@ class TestDetectorEdgeCases:
         detector = MADDetector()
         baseline = [100.0, 110.0, 120.0, 130.0, 140.0]
         # Test with threshold of 2.0 (default)
-        result = detector.detect("metric", 120.0, baseline, threshold=2.0)
+        result = detector.detect("metric", 120.0, baseline, threshold=2.0, timestamp=datetime.now(UTC))
 
         # Should be None since value is close to median
         assert result is None

--- a/tests/unit/infrastructure/observability/test_lineage.py
+++ b/tests/unit/infrastructure/observability/test_lineage.py
@@ -191,6 +191,7 @@ class TestLineageTrackerRecordBronze:
             entity_type="activity",
             record_count=1000,
             file_path="s3://bucket/bronze/file.jsonl.zst",
+            timestamp=datetime.now(UTC),
         )
 
         mock_write_deltalake.assert_called_once()
@@ -206,6 +207,7 @@ class TestLineageTrackerRecordBronze:
             entity_type="activity",
             record_count=500,
             file_path="path",
+            timestamp=datetime.now(UTC),
             watermark="2025-01-15T00:00:00Z",
         )
 
@@ -220,6 +222,7 @@ class TestLineageTrackerRecordBronze:
             entity_type="activity",
             record_count=100,
             file_path="path",
+            timestamp=datetime.now(UTC),
             metadata={"source_url": "https://api.chembl.com"},
         )
 
@@ -239,6 +242,7 @@ class TestLineageTrackerRecordBronze:
                 entity_type="test",
                 record_count=100,
                 file_path="path",
+                timestamp=datetime.now(UTC),
             )
 
 
@@ -258,6 +262,7 @@ class TestLineageTrackerRecordTransformation:
             record_count=100,
             success_count=95,
             failure_count=5,
+            timestamp=datetime.now(UTC),
         )
 
         mock_write_deltalake.assert_called_once()
@@ -276,6 +281,7 @@ class TestLineageTrackerRecordTransformation:
             record_count=50,
             success_count=50,
             failure_count=0,
+            timestamp=datetime.now(UTC),
             metadata={"enrichment_source": "pubchem"},
         )
 
@@ -295,6 +301,7 @@ class TestLineageTrackerRecordTransformation:
             record_count=3,
             success_count=3,
             failure_count=0,
+            timestamp=datetime.now(UTC),
         )
 
         mock_write_deltalake.assert_called_once()
@@ -441,7 +448,7 @@ class TestLineageTrackerGetBatchStatistics:
         """Test get_batch_statistics returns zeros on error."""
         mock_delta_table.side_effect = Exception("Error")
 
-        result = lineage_tracker.get_batch_statistics(layer="bronze", days=7)
+        result = lineage_tracker.get_batch_statistics(layer="bronze", timestamp=datetime.now(UTC), days=7)
 
         assert result["total_batches"] == 0
         assert result["total_records"] == 0
@@ -463,7 +470,7 @@ class TestLineageTrackerGetBatchStatistics:
         mock_table.to_pyarrow_table.return_value = mock_df.to_arrow()
         mock_delta_table.return_value = mock_table
 
-        result = lineage_tracker.get_batch_statistics(layer="bronze")
+        result = lineage_tracker.get_batch_statistics(layer="bronze", timestamp=datetime.now(UTC))
 
         assert result["total_batches"] == 0
 
@@ -491,7 +498,7 @@ class TestLineageTrackerGetBatchStatistics:
         mock_table.to_pyarrow_table.return_value = mock_df.to_arrow()
         mock_delta_table.return_value = mock_table
 
-        result = lineage_tracker.get_batch_statistics(layer="bronze", days=7)
+        result = lineage_tracker.get_batch_statistics(layer="bronze", timestamp=datetime.now(UTC), days=7)
 
         assert result["total_batches"] == 3
         assert result["total_records"] == 600


### PR DESCRIPTION
Comply with ADR-014 (Deterministic Writes) by ensuring timestamps are created in the application layer and passed as parameters to infrastructure components.

Changes:
- Make timestamp parameter mandatory in DetectorStrategy.detect() protocol
- Update ZScoreDetector, IQRDetector, MADDetector to require timestamp
- Update AnomalyDetector to require timestamp for threshold and anomaly detection
- Make timestamp mandatory in LineageTracker.record_bronze(), record_transformation(), and get_batch_statistics()
- Update DataQualityMonitor.check_quality() to accept timestamp parameter
- Remove all datetime.now(UTC) calls from observability infrastructure
- Update tests to pass timestamps from application layer (using datetime.now(UTC))
- Remove unused type: ignore comments in lineage.py

This ensures all timestamp creation happens in the application layer, making infrastructure operations deterministic and testable.