### PR TITLE
Review refactoring plans and fix date handling

### DIFF
--- a/benchmarks/test_bronze_write.py
+++ b/benchmarks/test_bronze_write.py
@@ -6,7 +6,7 @@ Measures JSONL + zstd compression throughput.
 import asyncio
 import json
 from collections.abc import Iterator
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
@@ -19,6 +19,16 @@ def _records_to_bytes_iterator(records: list[dict[str, Any]]) -> Iterator[bytes]
     """Convert records to bytes iterator for BronzeWriter."""
     for record in records:
         yield (json.dumps(record) + "\n").encode("utf-8")
+
+
+class FakeMetrics:
+    """Minimal fake metrics for benchmarks."""
+
+    def observe_histogram(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def increment_counter(self, *args: Any, **kwargs: Any) -> None:
+        pass
 
 
 class FakeLogger:
@@ -47,11 +57,12 @@ def test_bronze_write_small(benchmark, small_payload, bronze_output_dir):
     from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 
     logger = FakeLogger()
-    writer = BronzeWriter(base_path=bronze_output_dir, logger=logger)
+    metrics = FakeMetrics()
+    writer = BronzeWriter(base_path=bronze_output_dir, logger=logger, metrics=metrics)
 
     run_id = RunID(uuid4())
     batch_id = BatchID(uuid4())
-    now = datetime.now()
+    now = datetime.now(UTC)
 
     async def write_batch():
         records_iter = _records_to_bytes_iterator(small_payload)
@@ -63,6 +74,7 @@ def test_bronze_write_small(benchmark, small_payload, bronze_output_dir):
             batch_id=batch_id,
             run_id=run_id,
             run_type=RunType.INCREMENTAL,
+            ingestion_ts=now,
         )
 
     result = benchmark(lambda: asyncio.run(write_batch()))
@@ -84,11 +96,12 @@ def test_bronze_write_medium(benchmark, medium_payload, bronze_output_dir):
     from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 
     logger = FakeLogger()
-    writer = BronzeWriter(base_path=bronze_output_dir, logger=logger)
+    metrics = FakeMetrics()
+    writer = BronzeWriter(base_path=bronze_output_dir, logger=logger, metrics=metrics)
 
     run_id = RunID(uuid4())
     batch_id = BatchID(uuid4())
-    now = datetime.now()
+    now = datetime.now(UTC)
 
     async def write_batch():
         records_iter = _records_to_bytes_iterator(medium_payload)
@@ -100,6 +113,7 @@ def test_bronze_write_medium(benchmark, medium_payload, bronze_output_dir):
             batch_id=batch_id,
             run_id=run_id,
             run_type=RunType.INCREMENTAL,
+            ingestion_ts=now,
         )
 
     result = benchmark(lambda: asyncio.run(write_batch()))
@@ -119,11 +133,12 @@ def test_bronze_write_large(benchmark, large_payload, bronze_output_dir):
     from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 
     logger = FakeLogger()
-    writer = BronzeWriter(base_path=bronze_output_dir, logger=logger)
+    metrics = FakeMetrics()
+    writer = BronzeWriter(base_path=bronze_output_dir, logger=logger, metrics=metrics)
 
     run_id = RunID(uuid4())
     batch_id = BatchID(uuid4())
-    now = datetime.now()
+    now = datetime.now(UTC)
 
     async def write_batch():
         records_iter = _records_to_bytes_iterator(large_payload)
@@ -135,6 +150,7 @@ def test_bronze_write_large(benchmark, large_payload, bronze_output_dir):
             batch_id=batch_id,
             run_id=run_id,
             run_type=RunType.INCREMENTAL,
+            ingestion_ts=now,
         )
 
     result = benchmark(lambda: asyncio.run(write_batch()))

--- a/src/bioetl/composition/_bootstrap/observability.py
+++ b/src/bioetl/composition/_bootstrap/observability.py
@@ -98,7 +98,10 @@ def bootstrap_logger(
     )
 
 
-def bootstrap_tracer(service_name: str = "bioetl") -> TracingPort:
+def bootstrap_tracer(
+    settings: Settings,
+    service_name: str = "bioetl",
+) -> TracingPort:
     """Bootstrap distributed tracing.
 
     Unified Observability Contract: Always returns a valid TracingPort.
@@ -106,15 +109,13 @@ def bootstrap_tracer(service_name: str = "bioetl") -> TracingPort:
     returns NoOpTracing (silent fallback).
 
     Args:
+        settings: Application settings (MUST be injected, not loaded globally).
         service_name: Name of the service for tracing context.
 
     Returns:
         TracingPort instance (OpenTelemetryTracer or NoOpTracing).
         Never returns None - uses NoOpTracing as fallback.
     """
-    from bioetl.infrastructure.config import get_settings
-
-    settings = get_settings()
     if settings.observability.tracing_enabled:
         try:
             return OpenTelemetryTracer(service_name=service_name)
@@ -243,7 +244,7 @@ def bootstrap_observability(
         ObservabilityContractError: If bundle creation fails validation.
     """
     logger = bootstrap_logger(pipeline=pipeline, run_id=run_id)
-    tracer = bootstrap_tracer()
+    tracer = bootstrap_tracer(settings)
     metrics = bootstrap_metrics(settings)
     dq_monitor = bootstrap_dq_monitor(settings)
 

--- a/src/bioetl/composition/_bootstrap/storage.py
+++ b/src/bioetl/composition/_bootstrap/storage.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from bioetl.composition.factories.storage_factory import StorageAdapter
 from bioetl.infrastructure.config import get_settings
 from bioetl.infrastructure.observability.noop_logger import NoOpLogger
+from bioetl.infrastructure.observability.noop_metrics import NoOpMetrics
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 from bioetl.infrastructure.storage.gold_writer import GoldWriter
@@ -40,11 +41,13 @@ def bootstrap_storage() -> StorageAdapter:
     """
     settings = get_settings()
     noop_logger = NoOpLogger()
+    noop_metrics = NoOpMetrics()
 
     return StorageAdapter(
         bronze_writer=BronzeWriter(
             base_path=settings.bronze_path,
             logger=noop_logger,
+            metrics=noop_metrics,
             save_json=False,
             json_path=None,
         ),

--- a/src/bioetl/composition/factories/storage_factory.py
+++ b/src/bioetl/composition/factories/storage_factory.py
@@ -60,7 +60,7 @@ class StorageFactory:
         settings: Settings,
         config: PipelineYamlConfig,
         logger: structlog.BoundLogger,
-        metrics: MetricsPort | None = None,
+        metrics: MetricsPort,
     ) -> StorageContext:
         """Create a StorageAdapter for local deployment.
 
@@ -68,7 +68,7 @@ class StorageFactory:
             settings: Application settings with data_dir
             config: Pipeline YAML configuration
             logger: Structured logger
-            metrics: Optional metrics port for Bronze observability (O1 metrics).
+            metrics: Metrics port for Bronze observability (MUST be injected).
 
         Returns:
             StorageContext with adapter and paths

--- a/src/bioetl/infrastructure/storage/bronze_writer.py
+++ b/src/bioetl/infrastructure/storage/bronze_writer.py
@@ -21,7 +21,7 @@ import asyncio
 import json
 import time
 from collections.abc import AsyncIterator, Iterator
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -52,28 +52,26 @@ class BronzeWriter:
         self,
         base_path: str | Path,
         logger: LoggerPort,
+        metrics: MetricsPort,
         save_json: bool = False,
         json_path: str | None = None,
-        metrics: MetricsPort | None = None,
     ) -> None:
         """Initialize Bronze writer.
 
         Args:
             base_path: Base path for Bronze layer storage
             logger: Structured logger for observability (MUST be injected)
+            metrics: Metrics port for observability (MUST be injected).
+                     Use NoOpMetrics from composition layer if metrics disabled.
             save_json: If True, also save uncompressed JSON copy
             json_path: Path for JSON files (defaults to base_path/json/)
-            metrics: Optional metrics port for observability (O1 metrics).
-                     If None, uses NoOpMetrics for null object pattern.
 
         """
-        from bioetl.domain.ports.noop import NoOpMetrics
-
         self.base_path = Path(base_path)
         self.logger = logger
+        self._metrics = metrics
         self.save_json = save_json
         self.json_path = json_path or str(self.base_path / "json")
-        self._metrics = metrics or NoOpMetrics()
 
     def _validate_bronze_names(self, provider: str, entity: str) -> None:
         """Validate provider and entity names (alphanumeric + underscores only)."""
@@ -102,6 +100,31 @@ class BronzeWriter:
         if not hasattr(records, "__iter__") or not hasattr(records, "__next__"):
             raise TypeError(
                 f"records must be an Iterator[bytes], got {type(records).__name__}"
+            )
+
+    def _validate_utc_datetime(self, dt: datetime, param_name: str) -> None:
+        """Validate that datetime is timezone-aware and in UTC.
+
+        Bronze layer requires UTC timestamps for lineage consistency
+        and deterministic behavior (see ADR-014).
+
+        Args:
+            dt: Datetime to validate.
+            param_name: Parameter name for error messages.
+
+        Raises:
+            ValueError: If datetime is naive or not in UTC.
+        """
+        if dt.tzinfo is None:
+            raise ValueError(
+                f"{param_name} must be timezone-aware, got naive datetime. "
+                "Use datetime.now(UTC) or datetime(..., tzinfo=timezone.utc)."
+            )
+        offset = dt.tzinfo.utcoffset(dt)
+        if offset is None or offset != timedelta(0):
+            raise ValueError(
+                f"{param_name} must be UTC, got timezone with offset {offset}. "
+                "Convert to UTC before passing to BronzeWriter."
             )
 
     def _build_bronze_metadata(
@@ -169,6 +192,8 @@ class BronzeWriter:
 
         self._validate_bronze_names(provider, entity)
         self._validate_records_iterator(records)
+        self._validate_utc_datetime(date, "date")
+        self._validate_utc_datetime(ingestion_ts, "ingestion_ts")
 
         date_str = date.strftime("%Y-%m-%d")
         relative_path = (

--- a/tests/integration/interfaces/conftest.py
+++ b/tests/integration/interfaces/conftest.py
@@ -16,6 +16,7 @@ from click.testing import CliRunner
 
 from bioetl.composition.factories.storage_factory import StorageAdapter, StorageContext
 from bioetl.infrastructure.observability.noop_logger import NoOpLogger
+from bioetl.infrastructure.observability.noop_metrics import NoOpMetrics
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 from bioetl.infrastructure.storage.gold_writer import GoldWriter
@@ -114,6 +115,7 @@ def create_local_storage_context(
         bronze_writer=BronzeWriter(
             base_path=str(storage_paths["bronze"]),
             logger=logger,
+            metrics=NoOpMetrics(),
             save_json=save_json,
             json_path=str(storage_paths["json"]) if save_json else None,
         ),

--- a/tests/integration/pipelines/base.py
+++ b/tests/integration/pipelines/base.py
@@ -73,7 +73,7 @@ class IntegrationPipelineTestCase:
         settings: Settings,
         config: PipelineYamlConfig,
         logger: structlog.BoundLogger,
-        metrics: MetricsPort | None = None,
+        metrics: MetricsPort,
     ) -> StorageContext:
         """Create a StorageContext pointing to local temp paths."""
         # Create real writers pointing to local paths
@@ -86,6 +86,7 @@ class IntegrationPipelineTestCase:
             bronze_writer=BronzeWriter(
                 base_path=self.bronze_path,
                 logger=logger,
+                metrics=metrics,
                 save_json=save_json,
                 json_path=self.json_path if save_json else None,
             ),

--- a/tests/performance/test_batching_performance.py
+++ b/tests/performance/test_batching_performance.py
@@ -25,6 +25,7 @@ import pytest
 from bioetl.domain.transformations import generate_content_hash
 from bioetl.domain.types import BatchID, RunID, RunType
 from bioetl.infrastructure.observability.noop_logger import NoOpLogger
+from bioetl.infrastructure.observability.noop_metrics import NoOpMetrics
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
@@ -76,7 +77,7 @@ def logger() -> NoOpLogger:
 @pytest.fixture
 def bronze_writer(tmp_path: Path, logger: NoOpLogger) -> BronzeWriter:
     """Create BronzeWriter for performance tests."""
-    return BronzeWriter(base_path=tmp_path, logger=logger)
+    return BronzeWriter(base_path=tmp_path, logger=logger, metrics=NoOpMetrics())
 
 
 @pytest.fixture

--- a/tests/unit/infrastructure/storage/test_bronze_writer.py
+++ b/tests/unit/infrastructure/storage/test_bronze_writer.py
@@ -12,8 +12,10 @@ from uuid import uuid4
 import pytest
 import zstandard as zstd
 
+from bioetl.domain.ports import MetricsPort
 from bioetl.domain.types import BatchID, RunID, RunType
 from bioetl.infrastructure.observability.noop_logger import NoOpLogger
+from bioetl.infrastructure.observability.noop_metrics import NoOpMetrics
 from bioetl.infrastructure.storage._atomic import AtomicWriteGroup
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 
@@ -22,6 +24,12 @@ from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 def noop_logger() -> NoOpLogger:
     """Provide a NoOpLogger for BronzeWriter tests."""
     return NoOpLogger()
+
+
+@pytest.fixture
+def noop_metrics() -> MetricsPort:
+    """Provide a NoOpMetrics for BronzeWriter tests."""
+    return NoOpMetrics()
 
 
 @pytest.fixture
@@ -65,7 +73,7 @@ class TestBronzeWriterNameValidation:
 
     def test_validate_bronze_names_valid(self, tmp_path, noop_logger) -> None:
         """Test valid provider and entity names pass validation."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
 
         # Should not raise for valid names (alphanumeric + underscore only)
         writer._validate_bronze_names("chembl", "activity")
@@ -75,7 +83,7 @@ class TestBronzeWriterNameValidation:
 
     def test_validate_bronze_names_invalid_provider(self, tmp_path, noop_logger) -> None:
         """Test invalid provider names raise ValueError."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
 
         with pytest.raises(ValueError, match="Invalid provider name"):
             writer._validate_bronze_names("", "activity")
@@ -95,7 +103,7 @@ class TestBronzeWriterNameValidation:
 
     def test_validate_bronze_names_invalid_entity(self, tmp_path, noop_logger) -> None:
         """Test invalid entity names raise ValueError."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
 
         with pytest.raises(ValueError, match="Invalid entity name"):
             writer._validate_bronze_names("chembl", "")
@@ -125,8 +133,8 @@ class TestBronzeWriterNameValidation:
         ingestion_ts: datetime,
     ) -> None:
         """Test write_bronze raises ValueError for invalid provider."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
-        date = datetime(2024, 1, 15)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
+        date = datetime(2024, 1, 15, tzinfo=UTC)
 
         with pytest.raises(ValueError, match="Invalid provider name"):
             await writer.write_bronze(
@@ -152,8 +160,8 @@ class TestBronzeWriterNameValidation:
         ingestion_ts: datetime,
     ) -> None:
         """Test write_bronze raises ValueError for invalid entity."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
-        date = datetime(2024, 1, 15)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
+        date = datetime(2024, 1, 15, tzinfo=UTC)
 
         with pytest.raises(ValueError, match="Invalid entity name"):
             await writer.write_bronze(
@@ -169,7 +177,7 @@ class TestBronzeWriterNameValidation:
 
     def test_validate_records_iterator_valid(self, tmp_path, noop_logger) -> None:
         """Test valid iterator passes validation."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
 
         # Should not raise for valid iterators
         writer._validate_records_iterator(iter([b"test"]))
@@ -178,7 +186,7 @@ class TestBronzeWriterNameValidation:
 
     def test_validate_records_iterator_none_raises(self, tmp_path, noop_logger) -> None:
         """Test None records raises TypeError."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
 
         with pytest.raises(TypeError, match="records cannot be None"):
             writer._validate_records_iterator(None)  # type: ignore[arg-type]
@@ -187,7 +195,7 @@ class TestBronzeWriterNameValidation:
         self, tmp_path, noop_logger
     ) -> None:
         """Test non-iterator types raise TypeError."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
 
         # List is not an iterator (has __iter__ but no __next__)
         with pytest.raises(TypeError, match="records must be an Iterator"):
@@ -212,8 +220,8 @@ class TestBronzeWriterNameValidation:
         ingestion_ts: datetime,
     ) -> None:
         """Test write_bronze raises TypeError for invalid records type."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
-        date = datetime(2024, 1, 15)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
+        date = datetime(2024, 1, 15, tzinfo=UTC)
 
         with pytest.raises(TypeError, match="records must be an Iterator"):
             await writer.write_bronze(
@@ -229,12 +237,130 @@ class TestBronzeWriterNameValidation:
 
 
 @pytest.mark.unit
+class TestBronzeWriterUTCValidation:
+    """Tests for BronzeWriter UTC datetime validation (ADR-014 determinism)."""
+
+    def test_validate_utc_datetime_valid(self, tmp_path, noop_logger) -> None:
+        """Test valid UTC datetime passes validation."""
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
+
+        # Should not raise for UTC datetime
+        utc_dt = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
+        writer._validate_utc_datetime(utc_dt, "test_param")
+
+    def test_validate_utc_datetime_naive_raises(self, tmp_path, noop_logger) -> None:
+        """Test naive datetime raises ValueError."""
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
+
+        naive_dt = datetime(2024, 1, 15, 12, 0, 0)  # No tzinfo
+        with pytest.raises(ValueError, match="must be timezone-aware"):
+            writer._validate_utc_datetime(naive_dt, "date")
+
+    def test_validate_utc_datetime_non_utc_raises(self, tmp_path, noop_logger) -> None:
+        """Test non-UTC timezone raises ValueError."""
+        from datetime import timezone, timedelta
+
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
+
+        # Create datetime with non-UTC timezone (e.g., UTC+3)
+        non_utc_tz = timezone(timedelta(hours=3))
+        non_utc_dt = datetime(2024, 1, 15, 12, 0, 0, tzinfo=non_utc_tz)
+
+        with pytest.raises(ValueError, match="must be UTC"):
+            writer._validate_utc_datetime(non_utc_dt, "ingestion_ts")
+
+    @pytest.mark.asyncio
+    async def test_write_bronze_naive_date_raises(
+        self,
+        tmp_path,
+        noop_logger,
+        sample_records: list[bytes],
+        batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
+        ingestion_ts: datetime,
+    ) -> None:
+        """Test write_bronze raises ValueError for naive date."""
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
+        naive_date = datetime(2024, 1, 15)  # No tzinfo
+
+        with pytest.raises(ValueError, match="date must be timezone-aware"):
+            await writer.write_bronze(
+                records=iter(sample_records),
+                provider="chembl",
+                entity="activity",
+                date=naive_date,
+                batch_id=batch_id,
+                run_id=run_id,
+                run_type=run_type,
+                ingestion_ts=ingestion_ts,
+            )
+
+    @pytest.mark.asyncio
+    async def test_write_bronze_naive_ingestion_ts_raises(
+        self,
+        tmp_path,
+        noop_logger,
+        sample_records: list[bytes],
+        batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
+    ) -> None:
+        """Test write_bronze raises ValueError for naive ingestion_ts."""
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
+        utc_date = datetime(2024, 1, 15, tzinfo=UTC)
+        naive_ingestion = datetime(2024, 1, 15, 12, 0, 0)  # No tzinfo
+
+        with pytest.raises(ValueError, match="ingestion_ts must be timezone-aware"):
+            await writer.write_bronze(
+                records=iter(sample_records),
+                provider="chembl",
+                entity="activity",
+                date=utc_date,
+                batch_id=batch_id,
+                run_id=run_id,
+                run_type=run_type,
+                ingestion_ts=naive_ingestion,
+            )
+
+    @pytest.mark.asyncio
+    async def test_write_bronze_non_utc_date_raises(
+        self,
+        tmp_path,
+        noop_logger,
+        sample_records: list[bytes],
+        batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
+        ingestion_ts: datetime,
+    ) -> None:
+        """Test write_bronze raises ValueError for non-UTC date."""
+        from datetime import timezone, timedelta
+
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
+        non_utc_tz = timezone(timedelta(hours=5))
+        non_utc_date = datetime(2024, 1, 15, tzinfo=non_utc_tz)
+
+        with pytest.raises(ValueError, match="date must be UTC"):
+            await writer.write_bronze(
+                records=iter(sample_records),
+                provider="chembl",
+                entity="activity",
+                date=non_utc_date,
+                batch_id=batch_id,
+                run_id=run_id,
+                run_type=run_type,
+                ingestion_ts=ingestion_ts,
+            )
+
+
+@pytest.mark.unit
 class TestBronzeWriterInit:
     """Tests for BronzeWriter initialization."""
 
     def test_init_local_storage(self, tmp_path, noop_logger) -> None:
         """Test initialization for local storage."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
 
         assert writer.base_path == tmp_path
         assert writer.save_json is False
@@ -242,7 +368,7 @@ class TestBronzeWriterInit:
 
     def test_init_with_save_json(self, tmp_path, noop_logger) -> None:
         """Test initialization with JSON saving enabled."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, save_json=True)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics(), save_json=True)
 
         assert writer.save_json is True
         assert writer.json_path is not None
@@ -253,6 +379,7 @@ class TestBronzeWriterInit:
         writer = BronzeWriter(
             base_path=tmp_path,
             logger=noop_logger,
+            metrics=NoOpMetrics(),
             save_json=True,
             json_path=custom_path,
         )
@@ -273,7 +400,7 @@ class TestBronzeWriterCompress:
         self, tmp_path, noop_logger, sample_records: list[bytes]
     ) -> None:
         """Test record compression returns data, count, and size."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
 
         compressed, record_count, uncompressed_size = writer._compress_records(
             iter(sample_records)
@@ -293,14 +420,14 @@ class TestBronzeWriterCompress:
 
     def test_compress_empty_records_raises(self, tmp_path, noop_logger) -> None:
         """Test that empty records raise ValueError."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
 
         with pytest.raises(ValueError, match="No records provided"):
             writer._compress_records(iter([]))
 
     def test_compress_large_records(self, tmp_path, noop_logger) -> None:
         """Test compression with records larger than chunk size."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
 
         # Create large records
         large_record = {"data": "x" * 500_000}
@@ -334,8 +461,8 @@ class TestBronzeWriterWriteLocal:
         ingestion_ts: datetime,
     ) -> None:
         """Test writing Bronze data to local storage."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
-        date = datetime(2024, 1, 15)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
+        date = datetime(2024, 1, 15, tzinfo=UTC)
 
         path = await writer.write_bronze(
             records=iter(sample_records),
@@ -393,7 +520,7 @@ class TestBronzeWriterWriteLocal:
         ingestion_ts: datetime,
     ) -> None:
         """Test that local write is performed asynchronously."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
         date = datetime(2023, 1, 1, tzinfo=UTC)
 
         # We patch run_in_executor to verify it's called for file I/O
@@ -433,8 +560,8 @@ class TestBronzeWriterWriteLocal:
         ingestion_ts: datetime,
     ) -> None:
         """Test writing Bronze data with JSON copy."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, save_json=True)
-        date = datetime(2024, 1, 15)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics(), save_json=True)
+        date = datetime(2024, 1, 15, tzinfo=UTC)
 
         await writer.write_bronze(
             records=iter(sample_records),
@@ -469,8 +596,8 @@ class TestBronzeWriterWriteLocal:
         ingestion_ts: datetime,
     ) -> None:
         """Test that empty records raise ValueError."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
-        date = datetime(2024, 1, 15)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
+        date = datetime(2024, 1, 15, tzinfo=UTC)
 
         with pytest.raises(ValueError, match="No records"):
             await writer.write_bronze(
@@ -501,8 +628,8 @@ class TestBronzeWriterReadLocal:
         ingestion_ts: datetime,
     ) -> None:
         """Test reading Bronze data from local storage."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
-        date = datetime(2024, 1, 15)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
+        date = datetime(2024, 1, 15, tzinfo=UTC)
 
         # Write first
         path = await writer.write_bronze(
@@ -542,7 +669,7 @@ class TestBronzeWriterListBatches:
         ingestion_ts: datetime,
     ) -> None:
         """Test listing batches from local storage."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
 
         # Write multiple batches
         date1 = datetime(2024, 1, 15)
@@ -584,7 +711,7 @@ class TestBronzeWriterListBatches:
         ingestion_ts: datetime,
     ) -> None:
         """Test listing batches with date filter."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
 
         date1 = datetime(2024, 1, 15)
         date2 = datetime(2024, 1, 16)
@@ -618,7 +745,7 @@ class TestBronzeWriterListBatches:
     @pytest.mark.asyncio
     async def test_list_batches_empty(self, tmp_path, noop_logger) -> None:
         """Test listing batches when none exist."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
 
         batches = await writer.list_batches("nonexistent", "entity")
         assert batches == []
@@ -644,8 +771,8 @@ class TestBronzeWriterAtomicWrite:
         Simulates a failure during the atomic write commit phase.
         Verifies REQ-DATA-004: Atomic writes.
         """
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
-        date = datetime(2024, 1, 15)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
+        date = datetime(2024, 1, 15, tzinfo=UTC)
 
         # Mock AtomicWriteGroup.commit to fail
         def failing_commit(self):
@@ -693,8 +820,8 @@ class TestBronzeWriterAtomicWrite:
 
         Both files must be written together atomically.
         """
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
-        date = datetime(2024, 1, 15)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
+        date = datetime(2024, 1, 15, tzinfo=UTC)
 
         # Successful write
         path = await writer.write_bronze(
@@ -727,8 +854,8 @@ class TestBronzeWriterAtomicWrite:
         ingestion_ts: datetime,
     ) -> None:
         """Test that no temp files remain after successful write."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
-        date = datetime(2024, 1, 15)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
+        date = datetime(2024, 1, 15, tzinfo=UTC)
 
         await writer.write_bronze(
             records=iter(sample_records),
@@ -757,8 +884,8 @@ class TestBronzeWriterAtomicWrite:
         ingestion_ts: datetime,
     ) -> None:
         """Test that failure during AtomicWriteGroup.add cleans up temp files."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
-        date = datetime(2024, 1, 15)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
+        date = datetime(2024, 1, 15, tzinfo=UTC)
 
         # Mock AtomicWriteGroup.add to fail on second call (metadata)
         original_add = AtomicWriteGroup.add
@@ -801,8 +928,8 @@ class TestBronzeWriterAtomicWrite:
         ingestion_ts: datetime,
     ) -> None:
         """Test that JSON copy also uses atomic write."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, save_json=True)
-        date = datetime(2024, 1, 15)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics(), save_json=True)
+        date = datetime(2024, 1, 15, tzinfo=UTC)
 
         await writer.write_bronze(
             records=iter(sample_records),
@@ -841,8 +968,8 @@ class TestBronzeWriterLoggerInjection:
     ) -> None:
         """Test that injected logger is called during write operations."""
         mock_logger = MagicMock()
-        writer = BronzeWriter(base_path=tmp_path, logger=mock_logger)
-        date = datetime(2024, 1, 15)
+        writer = BronzeWriter(base_path=tmp_path, logger=mock_logger, metrics=NoOpMetrics())
+        date = datetime(2024, 1, 15, tzinfo=UTC)
 
         await writer.write_bronze(
             records=iter(sample_records),
@@ -867,7 +994,7 @@ class TestBronzeWriterLoggerInjection:
     def test_logger_is_stored_as_attribute(self, tmp_path) -> None:
         """Test that injected logger is stored and accessible."""
         mock_logger = MagicMock()
-        writer = BronzeWriter(base_path=tmp_path, logger=mock_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=mock_logger, metrics=NoOpMetrics())
 
         assert writer.logger is mock_logger
 
@@ -891,8 +1018,8 @@ class TestBronzeWriterMetadataDeterminism:
         Verifies REQ-ARCH-030: Deterministic writes for reproducibility.
         Uses sort_keys=True and separators=(',', ':') to ensure consistent output.
         """
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
-        date = datetime(2024, 1, 15)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
+        date = datetime(2024, 1, 15, tzinfo=UTC)
 
         # Write twice with the same parameters but different batch IDs
         batch_id_1 = BatchID(uuid4())
@@ -959,7 +1086,7 @@ class TestBronzeWriterMetadataDeterminism:
         Multiple serializations of the same metadata dict should produce
         identical byte sequences when using sort_keys=True and separators=(',', ':').
         """
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
 
         metadata = writer._build_bronze_metadata(
             run_id=run_id,
@@ -993,7 +1120,7 @@ class TestBronzeWriterMetadataDeterminism:
 
         Using separators=(',', ':') removes spaces after separators.
         """
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
 
         metadata = writer._build_bronze_metadata(
             run_id=run_id,
@@ -1031,7 +1158,7 @@ class TestBronzeWriterMetrics:
         """Test initialization without metrics uses NoOpMetrics."""
         from bioetl.domain.ports.noop import NoOpMetrics
 
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
 
         assert isinstance(writer._metrics, NoOpMetrics)
 
@@ -1051,7 +1178,7 @@ class TestBronzeWriterMetrics:
         writer = BronzeWriter(
             base_path=tmp_path, logger=noop_logger, metrics=mock_metrics
         )
-        date = datetime(2024, 1, 15)
+        date = datetime(2024, 1, 15, tzinfo=UTC)
 
         await writer.write_bronze(
             records=iter(sample_records),
@@ -1094,7 +1221,7 @@ class TestBronzeWriterMetrics:
         writer = BronzeWriter(
             base_path=tmp_path, logger=noop_logger, metrics=mock_metrics
         )
-        date = datetime(2024, 1, 15)
+        date = datetime(2024, 1, 15, tzinfo=UTC)
 
         await writer.write_bronze(
             records=iter(sample_records),
@@ -1136,7 +1263,7 @@ class TestBronzeWriterMetrics:
         writer = BronzeWriter(
             base_path=tmp_path, logger=noop_logger, metrics=mock_metrics
         )
-        date = datetime(2024, 1, 15)
+        date = datetime(2024, 1, 15, tzinfo=UTC)
 
         await writer.write_bronze(
             records=iter(sample_records),
@@ -1178,7 +1305,7 @@ class TestBronzeWriterMetrics:
         writer = BronzeWriter(
             base_path=tmp_path, logger=noop_logger, metrics=mock_metrics
         )
-        date = datetime(2024, 1, 15)
+        date = datetime(2024, 1, 15, tzinfo=UTC)
 
         await writer.write_bronze(
             records=iter(sample_records),
@@ -1221,8 +1348,8 @@ class TestBronzeWriterMetrics:
     ) -> None:
         """Test that logger call includes record count and byte size."""
         mock_logger = MagicMock()
-        writer = BronzeWriter(base_path=tmp_path, logger=mock_logger)
-        date = datetime(2024, 1, 15)
+        writer = BronzeWriter(base_path=tmp_path, logger=mock_logger, metrics=NoOpMetrics())
+        date = datetime(2024, 1, 15, tzinfo=UTC)
 
         await writer.write_bronze(
             records=iter(sample_records),

--- a/tests/unit/infrastructure/test_storage.py
+++ b/tests/unit/infrastructure/test_storage.py
@@ -13,6 +13,7 @@ import zstandard as zstd
 
 from bioetl.domain.types import BatchID, RunID, RunType
 from bioetl.infrastructure.observability.noop_logger import NoOpLogger
+from bioetl.infrastructure.observability.noop_metrics import NoOpMetrics
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 from bioetl.infrastructure.storage.gold_writer import GoldWriter
@@ -50,16 +51,16 @@ class TestBronzeWriter:
 
     def test_bronze_writer_initialization(self, tmp_path, noop_logger):
         """Test BronzeWriter can be initialized."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
         assert writer.base_path == tmp_path
 
     async def test_write_bronze_creates_file(self, tmp_path, noop_logger):
         """Test write_bronze creates file in local storage."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
 
         records = [b'{"id": 1, "data": "test"}\n']
         batch_id = BatchID(UUID("12345678-1234-5678-1234-567812345678"))
-        date = datetime(2023, 1, 1)
+        date = datetime(2023, 1, 1, tzinfo=UTC)
 
         path = await writer.write_bronze(
             records=iter(records),
@@ -77,12 +78,12 @@ class TestBronzeWriter:
 
     async def test_write_bronze_generates_correct_key(self, tmp_path, noop_logger):
         """Test that write_bronze generates the correct path."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
 
         records = [b'{"id": 1}\n']
         provider = "test_provider"
         entity = "test_entity"
-        date = datetime(2023, 1, 1)
+        date = datetime(2023, 1, 1, tzinfo=UTC)
         batch_id = BatchID(UUID("12345678-1234-5678-1234-567812345678"))
 
         path = await writer.write_bronze(
@@ -103,11 +104,11 @@ class TestBronzeWriter:
 
     async def test_write_bronze_compresses_with_zstd(self, tmp_path, noop_logger):
         """REQ-DATA-001: Test that data is compressed with zstandard."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
 
         records = [b'{"id": 1, "data": "test"}\n']
         batch_id = BatchID(UUID("12345678-1234-5678-1234-567812345678"))
-        date = datetime(2023, 1, 1)
+        date = datetime(2023, 1, 1, tzinfo=UTC)
 
         path = await writer.write_bronze(
             records=iter(records),
@@ -136,12 +137,12 @@ class TestBronzeWriter:
 
     async def test_write_bronze_with_no_records(self, tmp_path, noop_logger):
         """Test that write_bronze raises error if there are no records."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
 
         records = []
         provider = "test_provider"
         entity = "test_entity"
-        date = datetime(2023, 1, 1)
+        date = datetime(2023, 1, 1, tzinfo=UTC)
         batch_id = BatchID(UUID("12345678-1234-5678-1234-567812345678"))
 
         with pytest.raises(ValueError, match="No records"):
@@ -162,7 +163,7 @@ class TestBronzeWriter:
 
         records = [b'{"id": 1}\n']
         batch_id = BatchID(UUID("12345678-1234-5678-1234-567812345678"))
-        date = datetime(2023, 1, 1)
+        date = datetime(2023, 1, 1, tzinfo=UTC)
 
         await writer.write_bronze(
             records=iter(records),
@@ -202,7 +203,7 @@ class TestBronzeWriter:
         test_file = bronze_dir / "batch_test.jsonl.zst"
         test_file.write_bytes(compressed)
 
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
 
         # Read it back
         read_records = []
@@ -216,10 +217,10 @@ class TestBronzeWriter:
 
     async def test_list_batches(self, tmp_path, noop_logger):
         """Test list_batches."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
 
         # Write two batches
-        date = datetime(2023, 1, 1)
+        date = datetime(2023, 1, 1, tzinfo=UTC)
         for i in range(2):
             batch_id = BatchID(UUID(f"12345678-1234-5678-1234-56781234567{i}"))
             await writer.write_bronze(
@@ -240,7 +241,7 @@ class TestBronzeWriter:
 
     async def test_list_batches_nonexistent(self, tmp_path, noop_logger):
         """Test list_batches returns empty for nonexistent path."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
 
         batches = await writer.list_batches("nonexistent", "entity", datetime.now())
 
@@ -248,11 +249,11 @@ class TestBronzeWriter:
 
     async def test_writes_metadata_file(self, tmp_path, noop_logger):
         """Test that write_bronze creates metadata file."""
-        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger)
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
 
         records = [b'{"id": 1}\n']
         batch_id = BatchID(UUID("12345678-1234-5678-1234-567812345678"))
-        date = datetime(2023, 1, 1)
+        date = datetime(2023, 1, 1, tzinfo=UTC)
 
         path = await writer.write_bronze(
             records=iter(records),

--- a/tests/unit/infrastructure/test_storage_factory.py
+++ b/tests/unit/infrastructure/test_storage_factory.py
@@ -23,6 +23,12 @@ def mock_logger():
 
 
 @pytest.fixture
+def mock_metrics():
+    """Create a mock metrics port."""
+    return MagicMock()
+
+
+@pytest.fixture
 def mock_settings(tmp_path):
     """Settings for local run."""
     settings = MagicMock()
@@ -135,6 +141,7 @@ class TestStorageFactoryLocal:
         mock_settings,
         mock_config_minimal,
         mock_logger,
+        mock_metrics,
     ):
         """Test that local runs use paths from settings."""
         with (
@@ -146,6 +153,7 @@ class TestStorageFactoryLocal:
                 settings=mock_settings,
                 config=mock_config_minimal,
                 logger=mock_logger,
+                metrics=mock_metrics,
             )
 
             assert isinstance(result, StorageContext)
@@ -159,6 +167,7 @@ class TestStorageFactoryLocal:
         mock_settings,
         mock_config_with_exports,
         mock_logger,
+        mock_metrics,
     ):
         """Test local run with JSON export enabled."""
         with (
@@ -172,6 +181,7 @@ class TestStorageFactoryLocal:
                 settings=mock_settings,
                 config=mock_config_with_exports,
                 logger=mock_logger,
+                metrics=mock_metrics,
             )
 
             # Verify BronzeWriter was called with save_json
@@ -184,6 +194,7 @@ class TestStorageFactoryLocal:
         mock_settings,
         mock_config_with_exports,
         mock_logger,
+        mock_metrics,
     ):
         """Test local run with CSV export enabled for Silver and Gold."""
         from bioetl.infrastructure.export.csv_exporter import CsvExporter
@@ -201,6 +212,7 @@ class TestStorageFactoryLocal:
                 settings=mock_settings,
                 config=mock_config_with_exports,
                 logger=mock_logger,
+                metrics=mock_metrics,
             )
 
             # Verify DeltaWriter (Silver) was called with csv_exporter
@@ -231,6 +243,7 @@ class TestStorageFactoryEdgeCases:
         mock_settings,
         mock_config_empty_sink,
         mock_logger,
+        mock_metrics,
     ):
         """Test handling of empty sink configuration."""
         with (
@@ -244,6 +257,7 @@ class TestStorageFactoryEdgeCases:
                 settings=mock_settings,
                 config=mock_config_empty_sink,
                 logger=mock_logger,
+                metrics=mock_metrics,
             )
 
             # Should still create context with default settings
@@ -258,6 +272,7 @@ class TestStorageFactoryEdgeCases:
         mock_settings,
         mock_config_minimal,
         mock_logger,
+        mock_metrics,
     ):
         """Test that adapter contains all three writers."""
         bronze_instance = MagicMock()
@@ -283,6 +298,7 @@ class TestStorageFactoryEdgeCases:
                 settings=mock_settings,
                 config=mock_config_minimal,
                 logger=mock_logger,
+                metrics=mock_metrics,
             )
 
             assert result.adapter.bronze is bronze_instance


### PR DESCRIPTION
Phase 1: UTC Validation (ADR-014 determinism)
- Add _validate_utc_datetime() method to BronzeWriter
- Validate date and ingestion_ts parameters are timezone-aware UTC
- Reject naive datetime and non-UTC timezones with clear error messages
- Add comprehensive unit tests for UTC validation

Phase 2: DI Cleanup
- Make metrics parameter required in BronzeWriter (remove NoOpMetrics fallback)
- Update all factories to explicitly pass MetricsPort
- Remove get_settings() from bootstrap_tracer (explicit settings injection)
- Update bootstrap_tracer signature to require Settings parameter

Updates:
- Fix datetime in tests to use UTC timezone
- Update benchmarks with FakeMetrics and UTC datetime
- Update integration test fixtures with NoOpMetrics