### PR TITLE
Add tracing spans to Executor and BatchWriter

### DIFF
--- a/src/bioetl/application/core/batch_writer.py
+++ b/src/bioetl/application/core/batch_writer.py
@@ -13,11 +13,13 @@ from typing import TYPE_CHECKING, Any
 from bioetl.domain.exceptions import SchemaViolationError
 
 if TYPE_CHECKING:
+    from typing import Any as SpanType
+
     from bioetl.application.core.batch_metrics import BatchMetricsRecorder
     from bioetl.application.core.config import RecordProcessorConfig
     from bioetl.domain.context import PipelineContext
     from bioetl.domain.error_classifier import ErrorClassifier
-    from bioetl.domain.ports import GoldValidatorPort, StoragePort
+    from bioetl.domain.ports import GoldValidatorPort, StoragePort, TracingPort
     from bioetl.domain.types import BatchID
 
 
@@ -38,6 +40,7 @@ class BatchWriter:
         gold_validator: GoldValidatorPort,
         error_classifier: ErrorClassifier,
         batch_metrics: BatchMetricsRecorder,
+        tracer: TracingPort | None = None,
     ) -> None:
         """Initialize batch writer.
 
@@ -48,6 +51,7 @@ class BatchWriter:
             gold_validator: Validator for Gold layer records.
             error_classifier: Service for error classification.
             batch_metrics: Metrics recorder for batch processing.
+            tracer: Optional tracing port for distributed tracing.
 
         """
         self._storage = storage
@@ -56,12 +60,59 @@ class BatchWriter:
         self._gold_validator = gold_validator
         self._error_classifier = error_classifier
         self._batch_metrics = batch_metrics
+        self._tracer = tracer
 
         # Convenience properties
         self._provider = config.provider
         self._entity_type = config.entity_type
         self._silver_schema = config.silver_schema
         self._table_config = config.table_config
+
+    def _start_span(
+        self, name: str, layer: str, record_count: int, batch_id: BatchID | None = None
+    ) -> SpanType | None:
+        """Start a tracing span for a write operation.
+
+        Args:
+            name: Span name (e.g., "write_bronze").
+            layer: Layer name (bronze, silver, gold).
+            record_count: Number of records being written.
+            batch_id: Optional batch identifier.
+
+        Returns:
+            Span context manager or None if tracer is not available.
+        """
+        if not self._tracer:
+            return None
+
+        attrs: dict[str, Any] = {
+            "bioetl.layer": layer,
+            "bioetl.record_count": record_count,
+            "bioetl.provider": self._provider,
+            "bioetl.entity_type": self._entity_type,
+        }
+        if batch_id:
+            attrs["bioetl.batch_id"] = str(batch_id)
+
+        span = self._tracer.get_tracer("bioetl.batch_writer").start_as_current_span(
+            name, attributes=attrs
+        )
+        span.__enter__()
+        return span
+
+    def _end_span(self, span: SpanType | None, error: Exception | None = None) -> None:
+        """End a tracing span.
+
+        Args:
+            span: Span to end (may be None if tracer was not available).
+            error: Optional exception to record on the span.
+        """
+        if not span:
+            return
+        if error:
+            span.set_attribute("error", True)
+            span.record_exception(error)
+        span.__exit__(None, None, None)
 
     async def write_bronze(
         self, records: list[dict[str, Any]], batch_id: BatchID, ingestion_ts: datetime
@@ -77,25 +128,32 @@ class BatchWriter:
             ingestion_ts: Ingestion timestamp from context.
 
         """
-        # Serialize with deterministic key ordering
-        json_strings = [json.dumps(r, sort_keys=True) for r in records]
+        span = self._start_span("write_bronze", "bronze", len(records), batch_id)
 
-        # Sort for deterministic file content
-        json_strings.sort()
+        try:
+            # Serialize with deterministic key ordering
+            json_strings = [json.dumps(r, sort_keys=True) for r in records]
 
-        # Create generator for bytes
-        record_bytes = ((s + "\n").encode("utf-8") for s in json_strings)
+            # Sort for deterministic file content
+            json_strings.sort()
 
-        await self._storage.write_bronze(
-            records=record_bytes,
-            provider=self._provider,
-            entity=self._entity_type,
-            date=ingestion_ts,
-            batch_id=batch_id,
-            run_id=self._context.run_id,
-            run_type=self._context.run_type,
-            ingestion_ts=ingestion_ts,
-        )
+            # Create generator for bytes
+            record_bytes = ((s + "\n").encode("utf-8") for s in json_strings)
+
+            await self._storage.write_bronze(
+                records=record_bytes,
+                provider=self._provider,
+                entity=self._entity_type,
+                date=ingestion_ts,
+                batch_id=batch_id,
+                run_id=self._context.run_id,
+                run_type=self._context.run_type,
+                ingestion_ts=ingestion_ts,
+            )
+            self._end_span(span)
+        except Exception as e:
+            self._end_span(span, e)
+            raise
 
     async def write_silver(
         self, records: list[dict[str, Any]], batch_id: BatchID, ingestion_ts: datetime
@@ -110,34 +168,42 @@ class BatchWriter:
             ingestion_ts: Ingestion timestamp from context.
 
         """
-        records_with_meta = [
-            {
-                **r,
-                "_run_id": str(self._context.run_id),
-                "_run_type": self._context.run_type.value,
-                "_source_batch_id": str(batch_id),
-                "_ingestion_ts": ingestion_ts.isoformat(),
-            }
-            for r in records
-        ]
+        span = self._start_span("write_silver", "silver", len(records), batch_id)
 
-        table_name = (
-            self._table_config.silver_table or f"{self._provider}.{self._entity_type}"
-        )
+        try:
+            records_with_meta = [
+                {
+                    **r,
+                    "_run_id": str(self._context.run_id),
+                    "_run_type": self._context.run_type.value,
+                    "_source_batch_id": str(batch_id),
+                    "_ingestion_ts": ingestion_ts.isoformat(),
+                }
+                for r in records
+            ]
 
-        # For "overwrite" mode, use "append" for batch writes
-        write_mode = self._table_config.silver_write_mode
-        if write_mode == "overwrite":
-            write_mode = "append"
+            table_name = (
+                self._table_config.silver_table
+                or f"{self._provider}.{self._entity_type}"
+            )
 
-        await self._storage.write_silver(
-            table_name=table_name,
-            records=records_with_meta,
-            primary_keys=self._table_config.primary_keys,
-            schema=self._silver_schema,
-            mode=write_mode,
-            on_schema_mismatch=self._table_config.on_schema_mismatch,
-        )
+            # For "overwrite" mode, use "append" for batch writes
+            write_mode = self._table_config.silver_write_mode
+            if write_mode == "overwrite":
+                write_mode = "append"
+
+            await self._storage.write_silver(
+                table_name=table_name,
+                records=records_with_meta,
+                primary_keys=self._table_config.primary_keys,
+                schema=self._silver_schema,
+                mode=write_mode,
+                on_schema_mismatch=self._table_config.on_schema_mismatch,
+            )
+            self._end_span(span)
+        except Exception as e:
+            self._end_span(span, e)
+            raise
 
     async def write_gold(self, records: list[dict[str, Any]]) -> None:
         """Write records to Gold layer with validation.
@@ -151,36 +217,43 @@ class BatchWriter:
             SchemaViolationError: If validation fails.
 
         """
-        gold_schema = self._config.gold_schema
-        schema_columns = self._get_schema_columns(gold_schema)
+        span = self._start_span("write_gold", "gold", len(records))
 
-        # Filter to only include columns defined in Gold schema
-        if schema_columns:
-            records = [
-                {k: v for k, v in r.items() if k in schema_columns} for r in records
-            ]
+        try:
+            gold_schema = self._config.gold_schema
+            schema_columns = self._get_schema_columns(gold_schema)
 
-        # Validate Gold records
-        result = self._gold_validator.validate(records)
-        if not result.valid:
-            raise SchemaViolationError("gold", result.errors)
+            # Filter to only include columns defined in Gold schema
+            if schema_columns:
+                records = [
+                    {k: v for k, v in r.items() if k in schema_columns} for r in records
+                ]
 
-        table_name = (
-            self._table_config.gold_table or f"{self._provider}.{self._entity_type}"
-        )
+            # Validate Gold records
+            result = self._gold_validator.validate(records)
+            if not result.valid:
+                raise SchemaViolationError("gold", result.errors)
 
-        # For "overwrite" mode, use "append" for batch writes
-        write_mode = self._table_config.gold_write_mode
-        if write_mode == "overwrite":
-            write_mode = "append"
+            table_name = (
+                self._table_config.gold_table or f"{self._provider}.{self._entity_type}"
+            )
 
-        await self._storage.write_gold(
-            table_name=table_name,
-            records=records,
-            schema=gold_schema,
-            primary_keys=self._table_config.primary_keys,
-            mode=write_mode,
-        )
+            # For "overwrite" mode, use "append" for batch writes
+            write_mode = self._table_config.gold_write_mode
+            if write_mode == "overwrite":
+                write_mode = "append"
+
+            await self._storage.write_gold(
+                table_name=table_name,
+                records=records,
+                schema=gold_schema,
+                primary_keys=self._table_config.primary_keys,
+                mode=write_mode,
+            )
+            self._end_span(span)
+        except Exception as e:
+            self._end_span(span, e)
+            raise
 
     def _get_schema_columns(self, schema: Any) -> set[str] | None:
         """Extract column names from Pandera schema.

--- a/src/bioetl/application/core/executor.py
+++ b/src/bioetl/application/core/executor.py
@@ -48,6 +48,8 @@ class PipelineExecutor:
         checkpoint_interval: int | None = None,
         run_type: RunType | None = None,
         tracer: TracingPort | None = None,
+        pipeline_name: str | None = None,
+        run_id: str | None = None,
     ):
         """Initialize pipeline executor.
 
@@ -61,6 +63,8 @@ class PipelineExecutor:
             checkpoint_interval: Number of records between checkpoints.
             run_type: Type of pipeline run (for tracing attributes).
             tracer: Optional tracing port for distributed tracing.
+            pipeline_name: Name of the pipeline (for tracing attributes).
+            run_id: Unique run identifier (for tracing attributes).
 
         """
         self._data_source = services.data_source
@@ -75,6 +79,8 @@ class PipelineExecutor:
         self._record_processor = record_processor
         self._run_type = run_type
         self._tracer = tracer
+        self._pipeline_name = pipeline_name
+        self._run_id = run_id
 
         # Counters
         self.records_fetched = 0
@@ -95,6 +101,23 @@ class PipelineExecutor:
             query: Optional query string for data source.
 
         """
+        # Start root span for pipeline execution if tracer is available
+        root_span = None
+        if self._tracer:
+            otel_tracer = self._tracer.get_tracer("bioetl.executor")
+            root_span = otel_tracer.start_as_current_span(
+                "pipeline_execution",
+                attributes={
+                    "bioetl.pipeline": self._pipeline_name or "unknown",
+                    "bioetl.run_id": self._run_id or "unknown",
+                    "bioetl.entity_type": self._entity_type,
+                    "bioetl.run_type": (
+                        self._run_type.value if self._run_type else "unknown"
+                    ),
+                },
+            )
+            root_span.__enter__()
+
         batch: list[dict[str, Any]] = []
 
         try:
@@ -121,6 +144,16 @@ class PipelineExecutor:
             if batch:
                 await self._process_and_update_counts(batch)
 
+            # Add final counts to root span
+            if root_span:
+                root_span.set_attribute("bioetl.total_fetched", self.records_fetched)
+                root_span.set_attribute("bioetl.total_bronze", self.records_bronze)
+                root_span.set_attribute("bioetl.total_silver", self.records_silver)
+                root_span.set_attribute("bioetl.total_gold", self.records_gold)
+                root_span.set_attribute(
+                    "bioetl.total_quarantined", self.records_quarantined
+                )
+
         except PipelineShutdownError:
             # Re-raise explicit shutdown signal
             try:
@@ -130,7 +163,19 @@ class PipelineExecutor:
             except Exception:
                 # Ignore errors during emergency checkpoint save
                 pass
+            if root_span:
+                root_span.set_attribute("bioetl.shutdown", True)
+                root_span.__exit__(None, None, None)
             raise
+        except Exception as e:
+            if root_span:
+                root_span.set_attribute("error", True)
+                root_span.record_exception(e)
+                root_span.__exit__(None, None, None)
+            raise
+        else:
+            if root_span:
+                root_span.__exit__(None, None, None)
 
     async def _process_and_update_counts(self, batch: list[dict[str, Any]]) -> None:
         """Process batch with tracing span.

--- a/src/bioetl/application/core/record_processor.py
+++ b/src/bioetl/application/core/record_processor.py
@@ -81,6 +81,7 @@ class RecordProcessor:
             gold_validator=gold_validator,
             error_classifier=error_classifier,
             batch_metrics=self._batch_metrics,
+            tracer=tracer,
         )
 
     async def process_batch(

--- a/tests/unit/application/core/test_batch_writer.py
+++ b/tests/unit/application/core/test_batch_writer.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -95,7 +95,7 @@ class TestBatchWriterBronze:
         """Test that records are serialized to JSON."""
         records = [{"id": "1", "value": 10}, {"id": "2", "value": 20}]
         batch_id = BatchID(uuid4())
-        ingestion_ts = datetime.now(timezone.utc)
+        ingestion_ts = datetime.now(UTC)
 
         await batch_writer.write_bronze(records, batch_id, ingestion_ts)
 
@@ -126,7 +126,7 @@ class TestBatchWriterBronze:
         # Records in reverse order
         records = [{"z": "last", "a": "first"}, {"a": "first", "z": "last"}]
         batch_id = BatchID(uuid4())
-        ingestion_ts = datetime.now(timezone.utc)
+        ingestion_ts = datetime.now(UTC)
 
         await batch_writer.write_bronze(records, batch_id, ingestion_ts)
 
@@ -295,3 +295,161 @@ class TestBatchWriterErrorLogging:
 
         mock_context.logger.error.assert_called_once()
         mock_batch_metrics.track_error.assert_called_once()
+
+
+@pytest.fixture
+def mock_tracer():
+    """Create mock tracer for testing spans."""
+    span = MagicMock()
+    span.__enter__ = MagicMock(return_value=span)
+    span.__exit__ = MagicMock(return_value=None)
+    span.set_attribute = MagicMock()
+    span.record_exception = MagicMock()
+
+    inner_tracer = MagicMock()
+    inner_tracer.start_as_current_span = MagicMock(return_value=span)
+
+    tracer = MagicMock()
+    tracer.get_tracer = MagicMock(return_value=inner_tracer)
+    return tracer
+
+
+@pytest.fixture
+def batch_writer_with_tracer(
+    mock_storage,
+    mock_context,
+    mock_gold_validator,
+    mock_error_classifier,
+    mock_batch_metrics,
+    mock_tracer,
+):
+    """Create BatchWriter instance with tracer."""
+    config = RecordProcessorConfig(
+        pipeline_name="test_provider_test_entity",
+        provider="test_provider",
+        entity_type="test_entity",
+        silver_schema=MagicMock(),
+        gold_schema=MagicMock(),
+        table_config=TableConfig(),
+    )
+    return BatchWriter(
+        storage=mock_storage,
+        context=mock_context,
+        config=config,
+        gold_validator=mock_gold_validator,
+        error_classifier=mock_error_classifier,
+        batch_metrics=mock_batch_metrics,
+        tracer=mock_tracer,
+    )
+
+
+@pytest.mark.unit
+class TestBatchWriterTracing:
+    """Tests for BatchWriter tracing spans."""
+
+    async def test_write_bronze_creates_span(
+        self, batch_writer_with_tracer, mock_tracer, mock_storage
+    ):
+        """Test that write_bronze creates a tracing span."""
+        records = [{"id": "1", "value": 10}]
+        batch_id = BatchID(uuid4())
+        ingestion_ts = datetime.now(UTC)
+
+        await batch_writer_with_tracer.write_bronze(records, batch_id, ingestion_ts)
+
+        mock_tracer.get_tracer.assert_called_with("bioetl.batch_writer")
+        inner_tracer = mock_tracer.get_tracer.return_value
+        inner_tracer.start_as_current_span.assert_called_once()
+
+        call_args = inner_tracer.start_as_current_span.call_args
+        assert call_args[0][0] == "write_bronze"
+        attrs = call_args[1]["attributes"]
+        assert attrs["bioetl.layer"] == "bronze"
+        assert attrs["bioetl.record_count"] == 1
+        assert attrs["bioetl.batch_id"] == str(batch_id)
+
+    async def test_write_silver_creates_span(
+        self, batch_writer_with_tracer, mock_tracer, mock_storage, mock_context
+    ):
+        """Test that write_silver creates a tracing span."""
+        records = [{"entity_id": "1", "value": 10}]
+        batch_id = BatchID(uuid4())
+        ingestion_ts = mock_context.started_at
+
+        await batch_writer_with_tracer.write_silver(records, batch_id, ingestion_ts)
+
+        mock_tracer.get_tracer.assert_called_with("bioetl.batch_writer")
+        inner_tracer = mock_tracer.get_tracer.return_value
+        inner_tracer.start_as_current_span.assert_called_once()
+
+        call_args = inner_tracer.start_as_current_span.call_args
+        assert call_args[0][0] == "write_silver"
+        attrs = call_args[1]["attributes"]
+        assert attrs["bioetl.layer"] == "silver"
+        assert attrs["bioetl.record_count"] == 1
+
+    async def test_write_gold_creates_span(
+        self, batch_writer_with_tracer, mock_tracer, mock_storage, mock_gold_validator
+    ):
+        """Test that write_gold creates a tracing span."""
+        records = [{"entity_id": "1", "value": 10}]
+
+        await batch_writer_with_tracer.write_gold(records)
+
+        mock_tracer.get_tracer.assert_called_with("bioetl.batch_writer")
+        inner_tracer = mock_tracer.get_tracer.return_value
+        inner_tracer.start_as_current_span.assert_called_once()
+
+        call_args = inner_tracer.start_as_current_span.call_args
+        assert call_args[0][0] == "write_gold"
+        attrs = call_args[1]["attributes"]
+        assert attrs["bioetl.layer"] == "gold"
+        assert attrs["bioetl.record_count"] == 1
+
+    async def test_span_records_exception_on_error(
+        self, mock_storage, mock_context, mock_tracer
+    ):
+        """Test that span records exception when write fails."""
+        mock_storage.write_bronze = AsyncMock(
+            side_effect=RuntimeError("Storage error")
+        )
+
+        config = RecordProcessorConfig(
+            pipeline_name="test",
+            provider="test",
+            entity_type="entity",
+            silver_schema=MagicMock(),
+            gold_schema=MagicMock(),
+            table_config=TableConfig(),
+        )
+
+        writer = BatchWriter(
+            storage=mock_storage,
+            context=mock_context,
+            config=config,
+            gold_validator=MagicMock(),
+            error_classifier=ErrorClassifier(),
+            batch_metrics=MagicMock(spec=BatchMetricsRecorder),
+            tracer=mock_tracer,
+        )
+
+        records = [{"id": "1"}]
+        batch_id = BatchID(uuid4())
+
+        with pytest.raises(RuntimeError):
+            await writer.write_bronze(records, batch_id, datetime.now(UTC))
+
+        span = mock_tracer.get_tracer.return_value.start_as_current_span.return_value
+        span.set_attribute.assert_called_with("error", True)
+        span.record_exception.assert_called_once()
+
+    async def test_no_span_without_tracer(self, batch_writer, mock_storage):
+        """Test that no span is created when tracer is None."""
+        records = [{"id": "1", "value": 10}]
+        batch_id = BatchID(uuid4())
+        ingestion_ts = datetime.now(UTC)
+
+        # batch_writer fixture doesn't have tracer, should work without errors
+        await batch_writer.write_bronze(records, batch_id, ingestion_ts)
+
+        mock_storage.write_bronze.assert_called_once()

--- a/tests/unit/application/core/test_executor.py
+++ b/tests/unit/application/core/test_executor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
 
 import pytest
 
@@ -11,6 +12,7 @@ from bioetl.application.core.executor import PipelineExecutor
 from bioetl.application.core.pipeline_services import PipelineServices
 from bioetl.application.core.record_processor import BatchResult, RecordProcessor
 from bioetl.application.core.shutdown import PipelineShutdownError, ShutdownSignal
+from bioetl.domain.types import RunType
 
 
 @pytest.fixture
@@ -229,3 +231,171 @@ class TestPipelineExecutorExecute:
         await executor.execute(limit=100)
 
         assert captured_kwargs.get("limit") == 100
+
+
+@pytest.fixture
+def mock_tracer():
+    """Create mock tracer for testing spans."""
+    span = MagicMock()
+    span.__enter__ = MagicMock(return_value=span)
+    span.__exit__ = MagicMock(return_value=None)
+    span.set_attribute = MagicMock()
+    span.record_exception = MagicMock()
+
+    inner_tracer = MagicMock()
+    inner_tracer.start_as_current_span = MagicMock(return_value=span)
+
+    tracer = MagicMock()
+    tracer.get_tracer = MagicMock(return_value=inner_tracer)
+    return tracer
+
+
+@pytest.fixture
+def executor_with_tracer(
+    mock_services,
+    mock_record_processor,
+    mock_checkpoint_manager,
+    shutdown_signal,
+    mock_tracer,
+):
+    """Create PipelineExecutor instance with tracer."""
+    run_id = str(uuid4())
+    return PipelineExecutor(
+        services=mock_services,
+        record_processor=mock_record_processor,
+        checkpoint_manager=mock_checkpoint_manager,
+        shutdown_signal=shutdown_signal,
+        entity_type="test_entity",
+        batch_size=10,
+        checkpoint_interval=5,
+        run_type=RunType.INCREMENTAL,
+        tracer=mock_tracer,
+        pipeline_name="test_pipeline",
+        run_id=run_id,
+    )
+
+
+@pytest.mark.unit
+class TestPipelineExecutorTracing:
+    """Tests for PipelineExecutor tracing spans."""
+
+    async def test_execute_creates_root_span(
+        self, executor_with_tracer, mock_services, mock_tracer
+    ):
+        """Test that execute creates a root span."""
+
+        async def mock_fetch(**kwargs):
+            for i in range(3):
+                yield {"id": str(i), "value": 10}
+
+        mock_services.data_source.fetch = mock_fetch
+
+        await executor_with_tracer.execute(limit=None)
+
+        mock_tracer.get_tracer.assert_called_with("bioetl.executor")
+        inner_tracer = mock_tracer.get_tracer.return_value
+        inner_tracer.start_as_current_span.assert_called()
+
+        # Check root span was created with correct name and attributes
+        calls = inner_tracer.start_as_current_span.call_args_list
+        root_span_call = calls[0]  # First call is the root span
+        assert root_span_call[0][0] == "pipeline_execution"
+        attrs = root_span_call[1]["attributes"]
+        assert attrs["bioetl.pipeline"] == "test_pipeline"
+        assert "bioetl.run_id" in attrs
+        assert attrs["bioetl.entity_type"] == "test_entity"
+        assert attrs["bioetl.run_type"] == "incremental"
+
+    async def test_root_span_records_final_counts(
+        self, executor_with_tracer, mock_services, mock_tracer, mock_record_processor
+    ):
+        """Test that root span records final record counts."""
+
+        async def mock_fetch(**kwargs):
+            for i in range(3):
+                yield {"id": str(i), "value": 10}
+
+        mock_services.data_source.fetch = mock_fetch
+        mock_record_processor.process_batch.return_value = BatchResult(
+            bronze_count=3, silver_count=3, gold_count=3, quarantined_count=0
+        )
+
+        await executor_with_tracer.execute(limit=None)
+
+        span = mock_tracer.get_tracer.return_value.start_as_current_span.return_value
+        # Verify set_attribute was called with count values
+        set_attribute_calls = span.set_attribute.call_args_list
+        attr_names = [call[0][0] for call in set_attribute_calls]
+        assert "bioetl.total_fetched" in attr_names
+        assert "bioetl.total_bronze" in attr_names
+        assert "bioetl.total_silver" in attr_names
+        assert "bioetl.total_gold" in attr_names
+
+    async def test_root_span_records_exception_on_error(
+        self, mock_services, mock_tracer, mock_checkpoint_manager, shutdown_signal
+    ):
+        """Test that root span records exception when execution fails."""
+        mock_record_processor = MagicMock(spec=RecordProcessor)
+        mock_record_processor.process_batch = AsyncMock(
+            side_effect=RuntimeError("Processing error")
+        )
+
+        executor = PipelineExecutor(
+            services=mock_services,
+            record_processor=mock_record_processor,
+            checkpoint_manager=mock_checkpoint_manager,
+            shutdown_signal=shutdown_signal,
+            entity_type="test_entity",
+            batch_size=10,
+            tracer=mock_tracer,
+            pipeline_name="test_pipeline",
+            run_id=str(uuid4()),
+        )
+
+        async def mock_fetch(**kwargs):
+            for i in range(3):
+                yield {"id": str(i), "value": 10}
+
+        mock_services.data_source.fetch = mock_fetch
+
+        with pytest.raises(RuntimeError):
+            await executor.execute(limit=None)
+
+        span = mock_tracer.get_tracer.return_value.start_as_current_span.return_value
+        span.set_attribute.assert_any_call("error", True)
+        # Exception is recorded by both root span and batch span, so called at least once
+        assert span.record_exception.called
+
+    async def test_root_span_records_shutdown(
+        self, executor_with_tracer, mock_services, mock_tracer, shutdown_signal
+    ):
+        """Test that root span records shutdown attribute."""
+        records_yielded = 0
+
+        async def mock_fetch(**kwargs):
+            nonlocal records_yielded
+            for i in range(10):
+                yield {"id": str(i), "value": 10}
+                records_yielded += 1
+                if records_yielded == 3:
+                    shutdown_signal.request()
+
+        mock_services.data_source.fetch = mock_fetch
+
+        with pytest.raises(PipelineShutdownError):
+            await executor_with_tracer.execute(limit=None)
+
+        span = mock_tracer.get_tracer.return_value.start_as_current_span.return_value
+        span.set_attribute.assert_any_call("bioetl.shutdown", True)
+
+    async def test_no_span_without_tracer(self, executor, mock_services):
+        """Test that no span is created when tracer is None."""
+
+        async def mock_fetch(**kwargs):
+            for i in range(3):
+                yield {"id": str(i), "value": 10}
+
+        mock_services.data_source.fetch = mock_fetch
+
+        # executor fixture doesn't have tracer, should work without errors
+        await executor.execute(limit=None)


### PR DESCRIPTION
Add comprehensive distributed tracing for production monitoring:

- Executor: root span "pipeline_execution" with pipeline, run_id, entity_type, and run_type attributes; records final counts on success, shutdown flag on graceful termination, exception on error
- BatchWriter: individual spans for write_bronze, write_silver, write_gold with layer, record_count, and batch_id attributes
- RecordProcessor: passes tracer to BatchWriter for span creation
- New test cases verify span creation, attributes, and error recording

TracingPort is used via DI (NoOpTracing for production without tracing).