### PR TITLE
Add input validation for Bronze layer

### DIFF
--- a/src/bioetl/domain/exceptions/__init__.py
+++ b/src/bioetl/domain/exceptions/__init__.py
@@ -41,6 +41,7 @@ from bioetl.domain.exceptions.recoverable import (
     TimeoutError,
 )
 from bioetl.domain.exceptions.storage import (
+    BronzeValidationError,
     BucketNotFoundError,
     SchemaEvolutionError,
     StorageError,
@@ -52,6 +53,7 @@ __all__ = [
     "ApiError",
     "AuthFailureError",
     "BioETLError",
+    "BronzeValidationError",
     "BucketNotFoundError",
     "CheckpointConflictError",
     "ChemblApiError",

--- a/src/bioetl/domain/exceptions/storage.py
+++ b/src/bioetl/domain/exceptions/storage.py
@@ -74,3 +74,36 @@ class SchemaEvolutionError(StorageError):
         if self.removed_fields:
             parts.append(f"removed fields: {sorted(self.removed_fields)}")
         super().__init__(", ".join(parts))
+
+
+class BronzeValidationError(StorageError):
+    """Raised when Bronze layer input validation fails.
+
+    This error indicates that records passed to BronzeWriter
+    are not valid JSON bytes. Critical error that should stop
+    the pipeline to prevent invalid data in Bronze layer.
+    """
+
+    error_type = ErrorType.INVALID_DATA
+
+    def __init__(
+        self,
+        message: str,
+        record_index: int | None = None,
+        original_error: str | None = None,
+    ) -> None:
+        """Initialize BronzeValidationError.
+
+        Args:
+            message: Description of the validation failure.
+            record_index: Optional 0-based index of the invalid record.
+            original_error: Optional original error message from JSON parser.
+        """
+        self.record_index = record_index
+        self.original_error = original_error
+        parts = [message]
+        if record_index is not None:
+            parts.append(f"record_index={record_index}")
+        if original_error is not None:
+            parts.append(f"error={original_error}")
+        super().__init__(", ".join(parts))

--- a/src/bioetl/infrastructure/storage/bronze_writer.py
+++ b/src/bioetl/infrastructure/storage/bronze_writer.py
@@ -21,7 +21,7 @@ import asyncio
 import json
 import time
 from collections.abc import AsyncIterator, Iterator
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -55,6 +55,7 @@ class BronzeWriter:
         metrics: MetricsPort,
         save_json: bool = False,
         json_path: str | None = None,
+        validate_json: bool = True,
     ) -> None:
         """Initialize Bronze writer.
 
@@ -65,6 +66,9 @@ class BronzeWriter:
                      Use NoOpMetrics from composition layer if metrics disabled.
             save_json: If True, also save uncompressed JSON copy
             json_path: Path for JSON files (defaults to base_path/json/)
+            validate_json: If True, validate each record is valid JSON bytes
+                          before writing. Raises BronzeValidationError on invalid.
+                          Default is True for data integrity.
 
         """
         self.base_path = Path(base_path)
@@ -72,6 +76,7 @@ class BronzeWriter:
         self._metrics = metrics
         self.save_json = save_json
         self.json_path = json_path or str(self.base_path / "json")
+        self.validate_json = validate_json
 
     def _validate_bronze_names(self, provider: str, entity: str) -> None:
         """Validate provider and entity names (alphanumeric + underscores only)."""
@@ -126,6 +131,37 @@ class BronzeWriter:
                 f"{param_name} must be UTC, got timezone with offset {offset}. "
                 "Convert to UTC before passing to BronzeWriter."
             )
+
+    def _validate_json_records(
+        self, records: Iterator[bytes]
+    ) -> Iterator[bytes]:
+        """Validate that each record is valid JSON bytes (lazy generator).
+
+        This method validates JSON structure without modifying records.
+        Uses lazy evaluation to minimize memory overhead - only parses
+        when iterating, immediately yields valid records.
+
+        Args:
+            records: Iterator of bytes, each expected to be valid JSON.
+
+        Yields:
+            Valid JSON bytes records.
+
+        Raises:
+            BronzeValidationError: If a record contains invalid JSON.
+        """
+        from bioetl.domain.exceptions import BronzeValidationError
+
+        for index, record in enumerate(records):
+            try:
+                json.loads(record)
+            except json.JSONDecodeError as e:
+                raise BronzeValidationError(
+                    message="Invalid JSON in Bronze record",
+                    record_index=index,
+                    original_error=str(e),
+                ) from e
+            yield record
 
     def _build_bronze_metadata(
         self,
@@ -194,6 +230,10 @@ class BronzeWriter:
         self._validate_records_iterator(records)
         self._validate_utc_datetime(date, "date")
         self._validate_utc_datetime(ingestion_ts, "ingestion_ts")
+
+        # Apply JSON validation if enabled (lazy generator wrapping)
+        if self.validate_json:
+            records = self._validate_json_records(records)
 
         date_str = date.strftime("%Y-%m-%d")
         relative_path = (

--- a/tests/unit/infrastructure/storage/test_bronze_writer.py
+++ b/tests/unit/infrastructure/storage/test_bronze_writer.py
@@ -1372,3 +1372,261 @@ class TestBronzeWriterMetrics:
         assert call_kwargs["uncompressed_bytes"] > 0
         assert "duration_seconds" in call_kwargs
         assert call_kwargs["duration_seconds"] >= 0
+
+
+@pytest.mark.unit
+class TestBronzeWriterJsonValidation:
+    """Tests for BronzeWriter JSON input validation."""
+
+    def test_init_with_validate_json_default(self, tmp_path, noop_logger) -> None:
+        """Test that validate_json defaults to True."""
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
+        assert writer.validate_json is True
+
+    def test_init_with_validate_json_disabled(self, tmp_path, noop_logger) -> None:
+        """Test initialization with JSON validation disabled."""
+        writer = BronzeWriter(
+            base_path=tmp_path,
+            logger=noop_logger,
+            metrics=NoOpMetrics(),
+            validate_json=False,
+        )
+        assert writer.validate_json is False
+
+    def test_validate_json_records_valid(self, tmp_path, noop_logger) -> None:
+        """Test _validate_json_records passes valid JSON through."""
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
+
+        valid_records = [
+            b'{"id": 1, "name": "test"}\n',
+            b'{"id": 2, "value": 100}\n',
+            b'[1, 2, 3]\n',
+            b'"string"\n',
+            b'123\n',
+            b'null\n',
+        ]
+
+        validated = list(writer._validate_json_records(iter(valid_records)))
+        assert validated == valid_records
+
+    def test_validate_json_records_invalid_raises(self, tmp_path, noop_logger) -> None:
+        """Test _validate_json_records raises BronzeValidationError on invalid JSON."""
+        from bioetl.domain.exceptions import BronzeValidationError
+
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
+
+        invalid_records = [
+            b'{"id": 1}\n',
+            b'not valid json\n',  # This is invalid
+            b'{"id": 3}\n',
+        ]
+
+        with pytest.raises(BronzeValidationError) as exc_info:
+            list(writer._validate_json_records(iter(invalid_records)))
+
+        assert exc_info.value.record_index == 1
+        assert exc_info.value.original_error is not None
+        assert "Invalid JSON" in str(exc_info.value)
+
+    def test_validate_json_records_empty_string(self, tmp_path, noop_logger) -> None:
+        """Test _validate_json_records raises on empty string."""
+        from bioetl.domain.exceptions import BronzeValidationError
+
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
+
+        with pytest.raises(BronzeValidationError) as exc_info:
+            list(writer._validate_json_records(iter([b''])))
+
+        assert exc_info.value.record_index == 0
+
+    def test_validate_json_records_truncated_json(self, tmp_path, noop_logger) -> None:
+        """Test _validate_json_records raises on truncated JSON."""
+        from bioetl.domain.exceptions import BronzeValidationError
+
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
+
+        truncated_records = [
+            b'{"id": 1, "name": "incomplete',  # Missing closing brace and quote
+        ]
+
+        with pytest.raises(BronzeValidationError) as exc_info:
+            list(writer._validate_json_records(iter(truncated_records)))
+
+        assert exc_info.value.record_index == 0
+
+    def test_validate_json_records_is_lazy(self, tmp_path, noop_logger) -> None:
+        """Test _validate_json_records is a lazy generator."""
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
+
+        valid_records = [
+            b'{"id": 1}\n',
+            b'{"id": 2}\n',
+        ]
+
+        # Getting the generator should not consume any records
+        gen = writer._validate_json_records(iter(valid_records))
+        assert hasattr(gen, '__next__')
+
+        # First record should be validated on demand
+        first = next(gen)
+        assert first == b'{"id": 1}\n'
+
+    @pytest.mark.asyncio
+    async def test_write_bronze_validates_json_by_default(
+        self,
+        tmp_path,
+        noop_logger,
+        batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
+        ingestion_ts: datetime,
+    ) -> None:
+        """Test write_bronze validates JSON when validate_json=True (default)."""
+        from bioetl.domain.exceptions import BronzeValidationError
+
+        writer = BronzeWriter(base_path=tmp_path, logger=noop_logger, metrics=NoOpMetrics())
+        date = datetime(2024, 1, 15, tzinfo=UTC)
+
+        invalid_records = [
+            b'{"valid": true}\n',
+            b'invalid json here\n',
+        ]
+
+        with pytest.raises(BronzeValidationError) as exc_info:
+            await writer.write_bronze(
+                records=iter(invalid_records),
+                provider="chembl",
+                entity="activity",
+                date=date,
+                batch_id=batch_id,
+                run_id=run_id,
+                run_type=run_type,
+                ingestion_ts=ingestion_ts,
+            )
+
+        assert exc_info.value.record_index == 1
+        assert "Invalid JSON" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_write_bronze_skips_validation_when_disabled(
+        self,
+        tmp_path,
+        noop_logger,
+        batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
+        ingestion_ts: datetime,
+    ) -> None:
+        """Test write_bronze skips JSON validation when validate_json=False."""
+        writer = BronzeWriter(
+            base_path=tmp_path,
+            logger=noop_logger,
+            metrics=NoOpMetrics(),
+            validate_json=False,
+        )
+        date = datetime(2024, 1, 15, tzinfo=UTC)
+
+        # These are invalid JSON but should still be written when validation disabled
+        # Note: They still need to be bytes
+        invalid_records = [
+            b'not json but bytes\n',
+            b'another invalid line\n',
+        ]
+
+        # Should not raise - writes the bytes as-is
+        path = await writer.write_bronze(
+            records=iter(invalid_records),
+            provider="test",
+            entity="data",
+            date=date,
+            batch_id=batch_id,
+            run_id=run_id,
+            run_type=run_type,
+            ingestion_ts=ingestion_ts,
+        )
+
+        # Verify file was written
+        full_path = tmp_path / path
+        assert full_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_write_bronze_valid_json_succeeds(
+        self,
+        tmp_path,
+        noop_logger,
+        sample_records: list[bytes],
+        batch_id: BatchID,
+        run_id: RunID,
+        run_type: RunType,
+        ingestion_ts: datetime,
+    ) -> None:
+        """Test write_bronze succeeds with valid JSON records and validation enabled."""
+        writer = BronzeWriter(
+            base_path=tmp_path,
+            logger=noop_logger,
+            metrics=NoOpMetrics(),
+            validate_json=True,
+        )
+        date = datetime(2024, 1, 15, tzinfo=UTC)
+
+        path = await writer.write_bronze(
+            records=iter(sample_records),
+            provider="chembl",
+            entity="activity",
+            date=date,
+            batch_id=batch_id,
+            run_id=run_id,
+            run_type=run_type,
+            ingestion_ts=ingestion_ts,
+        )
+
+        # Verify file was written successfully
+        full_path = tmp_path / path
+        assert full_path.exists()
+
+        # Verify we can read back the records
+        records_read = []
+        async for record in writer.read_bronze(str(path)):
+            records_read.append(record)
+
+        assert len(records_read) == len(sample_records)
+
+    def test_bronze_validation_error_attributes(self) -> None:
+        """Test BronzeValidationError has correct attributes."""
+        from bioetl.domain.exceptions import BronzeValidationError
+
+        error = BronzeValidationError(
+            message="Test error",
+            record_index=5,
+            original_error="Expecting value",
+        )
+
+        assert error.record_index == 5
+        assert error.original_error == "Expecting value"
+        assert "Test error" in str(error)
+        assert "record_index=5" in str(error)
+        assert "error=Expecting value" in str(error)
+
+    def test_bronze_validation_error_context(self) -> None:
+        """Test BronzeValidationError exposes context for logging."""
+        from bioetl.domain.exceptions import BronzeValidationError
+
+        error = BronzeValidationError(
+            message="Invalid JSON",
+            record_index=10,
+            original_error="Unterminated string",
+        )
+
+        context = error.context
+        assert context["record_index"] == 10
+        assert context["original_error"] == "Unterminated string"
+
+    def test_bronze_validation_error_without_optional_fields(self) -> None:
+        """Test BronzeValidationError works without optional fields."""
+        from bioetl.domain.exceptions import BronzeValidationError
+
+        error = BronzeValidationError(message="Simple error")
+
+        assert error.record_index is None
+        assert error.original_error is None
+        assert str(error) == "Simple error"


### PR DESCRIPTION
Add input validation to BronzeWriter to prevent invalid JSON data from entering the Bronze layer:

- Add BronzeValidationError exception to domain/exceptions/storage.py
- Add _validate_json_records() lazy generator for efficient validation
- Add validate_json parameter (default=True) to BronzeWriter.__init__
- Validation can be disabled via validate_json=False for performance
- Add 13 unit tests covering validation scenarios

Closes requirements for Bronze Input Validation feature.