### PR TITLE
Extract PipelineObserver into composition

### DIFF
--- a/src/bioetl/application/core/runner.py
+++ b/src/bioetl/application/core/runner.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from bioetl.application.observability.observer import PipelineObserver
 from bioetl.domain.events import PipelineEvent
 
 if TYPE_CHECKING:
@@ -87,6 +86,7 @@ class PipelineRunner:
         self._preflight_service = runner_services.preflight
         self._postrun_service = runner_services.postrun
         self._lifecycle_orchestrator = runner_services.lifecycle_orch
+        self._observer = runner_services.observer
 
     @property
     def logger(self) -> LoggerPort:
@@ -113,17 +113,8 @@ class PipelineRunner:
             run_type=self._runtime.run_type.value,
         )
 
-        observer = PipelineObserver(
-            pipeline_name=self._config.pipeline_name,
-            run_id=self._context.run_id,
-            run_type=self._runtime.run_type,
-            metrics=self._services.metrics,
-            logger=self._logger,
-            tracer=self._tracer,
-        )
-
         try:
-            with observer:
+            with self._observer:
                 async with self._services, self._lock_manager:
                     # Pre-flight: validate infrastructure
                     await self._preflight_service.validate_infrastructure(

--- a/src/bioetl/application/core/runner_services.py
+++ b/src/bioetl/application/core/runner_services.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from bioetl.application.core.lock_manager import LockManager
     from bioetl.application.core.postrun_service import PostrunService
     from bioetl.application.core.preflight_service import PreflightService
+    from bioetl.application.observability.observer import PipelineObserver
 
 
 @dataclass(frozen=True)
@@ -25,9 +26,11 @@ class RunnerServices:
         preflight: Pre-flight infrastructure validation service.
         postrun: Post-run DQ checks and VACUUM service.
         lifecycle_orch: Lifecycle orchestrator for medallion layer clearing.
+        observer: Pipeline observability wrapper for tracing, metrics, and logging.
     """
 
     lock_manager: LockManager
     preflight: PreflightService
     postrun: PostrunService
     lifecycle_orch: LifecycleOrchestrator
+    observer: PipelineObserver

--- a/src/bioetl/composition/factories/runner_assembly.py
+++ b/src/bioetl/composition/factories/runner_assembly.py
@@ -244,6 +244,7 @@ def assemble_runner(
         shutdown_signal=pipeline.shutdown_signal,
         checkpoint_manager=checkpoint_manager,
         lifecycle_service=lifecycle_service,
+        tracer=observability.tracer,
     )
 
     # Assemble Runner with injected RunnerServices bundle

--- a/src/bioetl/composition/factories/runner_services.py
+++ b/src/bioetl/composition/factories/runner_services.py
@@ -17,6 +17,7 @@ from bioetl.application.core.preflight_service import PreflightService
 
 # Re-export RunnerServices from application layer for backwards compatibility
 from bioetl.application.core.runner_services import RunnerServices
+from bioetl.application.observability.observer import PipelineObserver
 
 if TYPE_CHECKING:
     from bioetl.application.core.checkpoint_manager import CheckpointManager
@@ -27,7 +28,7 @@ if TYPE_CHECKING:
     )
     from bioetl.domain.config import PipelineConfig, RuntimeConfig
     from bioetl.domain.context import PipelineContext
-    from bioetl.domain.ports import LoggerPort
+    from bioetl.domain.ports import LoggerPort, TracingPort
 
 
 def build_runner_services(
@@ -39,6 +40,7 @@ def build_runner_services(
     shutdown_signal: ShutdownSignal,
     checkpoint_manager: CheckpointManager,
     lifecycle_service: MedallionLifecycleService,
+    tracer: TracingPort | None = None,
 ) -> RunnerServices:
     """Build RunnerServices bundle.
 
@@ -54,6 +56,7 @@ def build_runner_services(
         shutdown_signal: Shutdown signal for graceful termination.
         checkpoint_manager: Checkpoint manager.
         lifecycle_service: Medallion lifecycle service.
+        tracer: Optional tracing port for distributed tracing.
 
     Returns:
         RunnerServices bundle with all required services.
@@ -95,11 +98,21 @@ def build_runner_services(
         lifecycle_service=lifecycle_service,
     )
 
+    observer = PipelineObserver(
+        pipeline_name=config.pipeline_name,
+        run_id=context.run_id,
+        run_type=runtime.run_type,
+        metrics=services.metrics,
+        logger=logger,
+        tracer=tracer,
+    )
+
     return RunnerServices(
         lock_manager=lock_manager,
         preflight=preflight_service,
         postrun=postrun_service,
         lifecycle_orch=lifecycle_orchestrator,
+        observer=observer,
     )
 
 

--- a/tests/architecture/test_di_discipline.py
+++ b/tests/architecture/test_di_discipline.py
@@ -3,8 +3,8 @@
 REQ-ARCH-DI-010: Application layer MUST NOT create infrastructure services.
 
 Application services (LockManager, PreflightService, PostrunService,
-LifecycleOrchestrator) should be created in the composition layer
-and injected via constructors.
+LifecycleOrchestrator, PipelineObserver) should be created in the composition
+layer and injected via constructors.
 
 See CLAUDE.md §2.2 Dependency Injection and §11 Anti-Patterns.
 """
@@ -26,7 +26,16 @@ FORBIDDEN_IN_APPLICATION = [
     "PreflightService(",
     "PostrunService(",
     "LifecycleOrchestrator(",
+    "PipelineObserver(",
 ]
+
+# Files where these classes are defined (class definitions are allowed)
+DEFINITION_FILES = {
+    "PipelineObserver(": {"observability/observer.py"},
+    "PreflightService(": {"core/preflight_service.py"},
+    "PostrunService(": {"core/postrun_service.py"},
+    "LifecycleOrchestrator(": {"core/lifecycle_orchestrator.py"},
+}
 
 
 def _get_base_path(relative_path: Path) -> Path:
@@ -63,8 +72,8 @@ class TestDIDiscipline:
         """Application layer must not create infrastructure services.
 
         REQ-ARCH-DI-010: Services like LockManager, PreflightService,
-        PostrunService, and LifecycleOrchestrator must be injected,
-        not created directly in application layer.
+        PostrunService, LifecycleOrchestrator, and PipelineObserver must be
+        injected, not created directly in application layer.
 
         These services should be created in composition/bootstrap.py or
         composition/factories/ and passed via constructor injection.
@@ -75,15 +84,19 @@ class TestDIDiscipline:
 
         for py_file in application_python_files:
             content = py_file.read_text(encoding="utf-8")
+            relative = py_file.relative_to(_get_base_path(APPLICATION_DIR))
+            relative_str = str(relative).replace("\\", "/")
 
             for pattern in FORBIDDEN_IN_APPLICATION:
+                # Skip files where the class is defined
+                allowed_files = DEFINITION_FILES.get(pattern, set())
+                if relative_str in allowed_files:
+                    continue
+
                 if pattern in content:
                     # Find line numbers for better error messages
                     for i, line in enumerate(content.splitlines(), 1):
                         if pattern in line:
-                            relative = py_file.relative_to(
-                                _get_base_path(APPLICATION_DIR)
-                            )
                             violations.append(
                                 f"{relative}:{i}: {pattern}"
                             )

--- a/tests/integration/test_runner_lifecycle.py
+++ b/tests/integration/test_runner_lifecycle.py
@@ -24,6 +24,7 @@ from bioetl.application.core.preflight_service import PreflightService
 from bioetl.application.core.postrun_service import PostrunService
 from bioetl.application.core.lifecycle_orchestrator import LifecycleOrchestrator
 from bioetl.application.core.runner_services import RunnerServices
+from bioetl.application.observability.observer import PipelineObserver
 from bioetl.domain.config import PipelineConfig, RuntimeConfig
 from bioetl.domain.context import PipelineContext
 from bioetl.domain.types import RunType
@@ -251,6 +252,29 @@ def mock_postrun_service(call_recorder):
     return service
 
 
+@pytest.fixture
+def mock_observer():
+    """Create a mock PipelineObserver (injected via DI).
+
+    This mock properly handles context manager protocol and suppresses
+    PipelineShutdownError as the real observer would.
+    """
+    from bioetl.application.core.shutdown import PipelineShutdownError
+
+    observer = MagicMock(spec=PipelineObserver)
+
+    def exit_side_effect(exc_type, exc_val, exc_tb):
+        # Suppress PipelineShutdownError like the real observer
+        if exc_val and isinstance(exc_val, PipelineShutdownError):
+            return True
+        return False
+
+    observer.__enter__ = MagicMock(return_value=observer)
+    observer.__exit__ = MagicMock(side_effect=exit_side_effect)
+
+    return observer
+
+
 @pytest.mark.integration
 class TestPipelineRunnerLifecycle:
     """Tests for PipelineRunner lifecycle invariants."""
@@ -265,6 +289,7 @@ class TestPipelineRunnerLifecycle:
         mock_orchestrator,
         mock_preflight_service,
         mock_postrun_service,
+        mock_observer,
         mock_logger,
     ):
         """Verify call order for REBUILD run type.
@@ -314,6 +339,7 @@ class TestPipelineRunnerLifecycle:
             preflight=mock_preflight_service,
             postrun=mock_postrun_service,
             lifecycle_orch=mock_orchestrator,
+            observer=mock_observer,
         )
 
         runner = PipelineRunner(
@@ -355,6 +381,7 @@ class TestPipelineRunnerLifecycle:
         mock_executor_with_recorder,
         mock_preflight_service,
         mock_postrun_service,
+        mock_observer,
         mock_logger,
     ):
         """Verify INCREMENTAL run does NOT clear storage.
@@ -389,6 +416,7 @@ class TestPipelineRunnerLifecycle:
             preflight=mock_preflight_service,
             postrun=mock_postrun_service,
             lifecycle_orch=orchestrator_no_clear,
+            observer=mock_observer,
         )
 
         runner = PipelineRunner(
@@ -421,6 +449,7 @@ class TestPipelineRunnerLifecycle:
         mock_orchestrator,
         mock_preflight_service,
         mock_postrun_service,
+        mock_observer,
         mock_logger,
     ):
         """Verify lock is released even when executor raises.
@@ -464,6 +493,7 @@ class TestPipelineRunnerLifecycle:
             preflight=mock_preflight_service,
             postrun=mock_postrun_service,
             lifecycle_orch=mock_orchestrator,
+            observer=mock_observer,
         )
 
         runner = PipelineRunner(
@@ -500,6 +530,7 @@ class TestPipelineRunnerLifecycle:
         mock_orchestrator,
         mock_preflight_service,
         mock_postrun_service,
+        mock_observer,
         mock_logger,
     ):
         """Verify BACKFILL run clears storage (same as REBUILD)."""
@@ -534,6 +565,7 @@ class TestPipelineRunnerLifecycle:
             preflight=mock_preflight_service,
             postrun=mock_postrun_service,
             lifecycle_orch=mock_orchestrator,
+            observer=mock_observer,
         )
 
         runner = PipelineRunner(
@@ -565,6 +597,7 @@ class TestPipelineRunnerLifecycle:
         mock_orchestrator,
         mock_preflight_service,
         mock_postrun_service,
+        mock_observer,
         mock_logger,
     ):
         """Verify pipeline aborts when infrastructure health check fails.
@@ -612,6 +645,7 @@ class TestPipelineRunnerLifecycle:
             preflight=mock_preflight_service,
             postrun=mock_postrun_service,
             lifecycle_orch=mock_orchestrator,
+            observer=mock_observer,
         )
 
         runner = PipelineRunner(
@@ -722,6 +756,7 @@ class TestPipelineRunnerLifecycle:
         mock_orchestrator,
         mock_preflight_service,
         mock_postrun_service,
+        mock_observer,
         mock_logger,
     ):
         """Verify pipeline resumes from checkpoint after previous failure.
@@ -773,6 +808,7 @@ class TestPipelineRunnerLifecycle:
             preflight=mock_preflight_service,
             postrun=mock_postrun_service,
             lifecycle_orch=mock_orchestrator,
+            observer=mock_observer,
         )
 
         runner = PipelineRunner(
@@ -808,6 +844,7 @@ class TestPipelineRunnerLifecycle:
         mock_orchestrator,
         mock_preflight_service,
         mock_postrun_service,
+        mock_observer,
         mock_logger,
     ):
         """Verify data quality anomalies are detected and logged.
@@ -894,6 +931,7 @@ class TestPipelineRunnerLifecycle:
             preflight=mock_preflight_service,
             postrun=mock_postrun_service,
             lifecycle_orch=mock_orchestrator,
+            observer=mock_observer,
         )
 
         runner = PipelineRunner(
@@ -925,6 +963,7 @@ class TestPipelineRunnerLifecycle:
         mock_orchestrator,
         mock_preflight_service,
         mock_postrun_service,
+        mock_observer,
         mock_logger,
     ):
         """Verify VACUUM runs on Silver and Gold tables after successful run.
@@ -967,6 +1006,7 @@ class TestPipelineRunnerLifecycle:
             preflight=mock_preflight_service,
             postrun=mock_postrun_service,
             lifecycle_orch=mock_orchestrator,
+            observer=mock_observer,
         )
 
         runner = PipelineRunner(

--- a/tests/unit/application/core/test_runner.py
+++ b/tests/unit/application/core/test_runner.py
@@ -16,6 +16,7 @@ from bioetl.application.core.preflight_service import PreflightService
 from bioetl.application.core.runner import PipelineRunner
 from bioetl.application.core.runner_services import RunnerServices
 from bioetl.application.core.shutdown import PipelineShutdownError, ShutdownSignal
+from bioetl.application.observability.observer import PipelineObserver
 from bioetl.domain.config import PipelineConfig, RuntimeConfig
 from bioetl.domain.context import PipelineContext
 from bioetl.domain.types import RunType
@@ -91,6 +92,7 @@ def create_mock_runner_services(
     preflight_service=None,
     postrun_service=None,
     lifecycle_orchestrator=None,
+    observer=None,
 ) -> RunnerServices:
     """Create mock RunnerServices for DI injection.
 
@@ -99,6 +101,7 @@ def create_mock_runner_services(
         preflight_service: Optional custom preflight service mock.
         postrun_service: Optional custom postrun service mock.
         lifecycle_orchestrator: Optional custom lifecycle orchestrator mock.
+        observer: Optional custom observer mock.
 
     Returns:
         RunnerServices bundle with mock services.
@@ -143,11 +146,17 @@ def create_mock_runner_services(
             )
         )
 
+    if observer is None:
+        observer = MagicMock(spec=PipelineObserver)
+        observer.__enter__ = MagicMock(return_value=observer)
+        observer.__exit__ = MagicMock(return_value=None)
+
     return RunnerServices(
         lock_manager=lock_manager,
         preflight=preflight_service,
         postrun=postrun_service,
         lifecycle_orch=lifecycle_orchestrator,
+        observer=observer,
     )
 
 
@@ -265,18 +274,91 @@ def mock_lifecycle_service():
 
 
 @pytest.fixture
+def mock_observer(mock_services, mock_logger):
+    """Create a mock PipelineObserver that delegates to real observer behavior.
+
+    This mock properly handles context manager protocol and calls
+    metrics/logger as the real observer would.
+    """
+    from bioetl.application.core.shutdown import PipelineShutdownError
+
+    observer = MagicMock(spec=PipelineObserver)
+
+    # Track enter/exit state
+    observer._entered = False
+
+    def enter_side_effect():
+        observer._entered = True
+        # Simulate observer logging start
+        mock_logger.info("pipeline_started", run_type="incremental")
+        return observer
+
+    def exit_side_effect(exc_type, exc_val, exc_tb):
+        # Simulate observer logging completion and recording metrics
+        duration = 0.1  # Simulated duration
+        status = "success"
+        suppress_exception = False
+
+        if exc_val:
+            if isinstance(exc_val, PipelineShutdownError):
+                status = "shutdown"
+                suppress_exception = True
+            else:
+                status = "failed"
+                mock_logger.error("pipeline_failed", error=str(exc_val))
+
+        # Record metrics like the real observer
+        mock_services.metrics.observe_histogram(
+            "bioetl_pipeline_duration_seconds",
+            duration,
+            labels={
+                "pipeline": "test_runner_pipeline",
+                "run_type": "incremental",
+                "status": status,
+            },
+        )
+        mock_services.metrics.increment_counter(
+            "bioetl_pipeline_runs_total",
+            1,
+            labels={
+                "pipeline": "test_runner_pipeline",
+                "run_type": "incremental",
+                "status": status,
+            },
+        )
+
+        if status == "success":
+            mock_logger.info("pipeline_finished", status=status)
+        elif status == "shutdown":
+            mock_logger.warning("pipeline_shutdown", status=status)
+
+        return suppress_exception
+
+    observer.__enter__ = MagicMock(side_effect=enter_side_effect)
+    observer.__exit__ = MagicMock(side_effect=exit_side_effect)
+
+    return observer
+
+
+@pytest.fixture
 def mock_runner_services(
     mock_lock_manager,
     mock_preflight_service,
     mock_postrun_service,
     mock_lifecycle_orchestrator,
+    mock_observer,
 ):
-    """Create a mock RunnerServices bundle for PipelineRunner."""
+    """Create a mock RunnerServices bundle for PipelineRunner.
+
+    Note: mock_observer depends on mock_services and mock_logger fixtures,
+    which are resolved automatically by pytest.
+    """
     return RunnerServices(
         lock_manager=mock_lock_manager,
         preflight=mock_preflight_service,
         postrun=mock_postrun_service,
         lifecycle_orch=mock_lifecycle_orchestrator,
+        observer=mock_observer,
     )
 
 
@@ -343,6 +425,7 @@ class TestPipelineRunnerInit:
         assert runner._preflight_service == mock_runner_services.preflight
         assert runner._postrun_service == mock_runner_services.postrun
         assert runner._lifecycle_orchestrator == mock_runner_services.lifecycle_orch
+        assert runner._observer == mock_runner_services.observer
 
     def test_services_are_injected_not_created(
         self,
@@ -374,6 +457,7 @@ class TestPipelineRunnerInit:
         assert runner._preflight_service is mock_runner_services.preflight
         assert runner._postrun_service is mock_runner_services.postrun
         assert runner._lifecycle_orchestrator is mock_runner_services.lifecycle_orch
+        assert runner._observer is mock_runner_services.observer
 
 
 @pytest.mark.unit
@@ -576,11 +660,16 @@ class TestPipelineRunnerClearViaLifecycle:
             )
         )
 
+        mock_observer = MagicMock(spec=PipelineObserver)
+        mock_observer.__enter__ = MagicMock(return_value=mock_observer)
+        mock_observer.__exit__ = MagicMock(return_value=None)
+
         runner_services = RunnerServices(
             lock_manager=mock_lock_manager,
             preflight=mock_preflight_service,
             postrun=mock_postrun_service,
             lifecycle_orch=lifecycle_orchestrator,
+            observer=mock_observer,
         )
 
         runner = PipelineRunner(
@@ -628,11 +717,16 @@ class TestPipelineRunnerClearViaLifecycle:
             )
         )
 
+        mock_observer = MagicMock(spec=PipelineObserver)
+        mock_observer.__enter__ = MagicMock(return_value=mock_observer)
+        mock_observer.__exit__ = MagicMock(return_value=None)
+
         runner_services = RunnerServices(
             lock_manager=mock_lock_manager,
             preflight=mock_preflight_service,
             postrun=mock_postrun_service,
             lifecycle_orch=lifecycle_orchestrator,
+            observer=mock_observer,
         )
 
         runner = PipelineRunner(
@@ -702,11 +796,16 @@ class TestPipelineRunnerCheckDataQuality:
         )
         postrun_service.cleanup = AsyncMock()
 
+        mock_observer = MagicMock(spec=PipelineObserver)
+        mock_observer.__enter__ = MagicMock(return_value=mock_observer)
+        mock_observer.__exit__ = MagicMock(return_value=None)
+
         runner_services = RunnerServices(
             lock_manager=mock_lock_manager,
             preflight=mock_preflight_service,
             postrun=postrun_service,
             lifecycle_orch=mock_lifecycle_orchestrator,
+            observer=mock_observer,
         )
 
         runner = PipelineRunner(
@@ -758,11 +857,16 @@ class TestPipelineRunnerCheckDataQuality:
         )
         postrun_service.cleanup = AsyncMock()
 
+        mock_observer = MagicMock(spec=PipelineObserver)
+        mock_observer.__enter__ = MagicMock(return_value=mock_observer)
+        mock_observer.__exit__ = MagicMock(return_value=None)
+
         runner_services = RunnerServices(
             lock_manager=mock_lock_manager,
             preflight=mock_preflight_service,
             postrun=postrun_service,
             lifecycle_orch=mock_lifecycle_orchestrator,
+            observer=mock_observer,
         )
 
         runner = PipelineRunner(


### PR DESCRIPTION
Move PipelineObserver creation from PipelineRunner to composition layer, following DI pattern for improved testability.

Changes:
- Add `observer: PipelineObserver` field to RunnerServices dataclass
- Create PipelineObserver in build_runner_services() factory
- Use injected observer in PipelineRunner.run() instead of creating internally
- Update arch-test to verify PipelineObserver is not created in application layer
- Update unit and integration tests with mock observer fixtures

This follows CLAUDE.md §2.2 DI requirements and improves testability by allowing mock observers to be injected in tests.