### PR TITLE
Extract PipelineObserver into composition

### DIFF
--- a/src/bioetl/application/core/runner.py
+++ b/src/bioetl/application/core/runner.py
@@ -8,13 +8,13 @@ Delegates to specialized services (injected via RunnerServices):
 - PreflightService: Infrastructure health validation
 - PostrunService: DQ checks, VACUUM, cleanup
 - LifecycleOrchestrator: Medallion layer clearing
+- PipelineObserver: Unified observability (tracing, metrics, logging)
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from bioetl.application.observability.observer import PipelineObserver
 from bioetl.domain.events import PipelineEvent
 
 if TYPE_CHECKING:
@@ -87,6 +87,7 @@ class PipelineRunner:
         self._preflight_service = runner_services.preflight
         self._postrun_service = runner_services.postrun
         self._lifecycle_orchestrator = runner_services.lifecycle_orch
+        self._observer = runner_services.observer
 
     @property
     def logger(self) -> LoggerPort:
@@ -105,6 +106,8 @@ class PipelineRunner:
         - Uses try/finally to ensure cleanup runs on all exit paths
         - Flushes tracer spans before shutdown
         - Handles tracer close errors without failing the pipeline
+
+        Uses injected PipelineObserver from RunnerServices for unified observability.
         """
         self._logger.info(
             PipelineEvent.START,
@@ -113,17 +116,8 @@ class PipelineRunner:
             run_type=self._runtime.run_type.value,
         )
 
-        observer = PipelineObserver(
-            pipeline_name=self._config.pipeline_name,
-            run_id=self._context.run_id,
-            run_type=self._runtime.run_type,
-            metrics=self._services.metrics,
-            logger=self._logger,
-            tracer=self._tracer,
-        )
-
         try:
-            with observer:
+            with self._observer:
                 async with self._services, self._lock_manager:
                     # Pre-flight: validate infrastructure
                     await self._preflight_service.validate_infrastructure(

--- a/src/bioetl/application/core/runner_services.py
+++ b/src/bioetl/application/core/runner_services.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from bioetl.application.core.lock_manager import LockManager
     from bioetl.application.core.postrun_service import PostrunService
     from bioetl.application.core.preflight_service import PreflightService
+    from bioetl.application.observability.observer import PipelineObserver
 
 
 @dataclass(frozen=True)
@@ -25,9 +26,11 @@ class RunnerServices:
         preflight: Pre-flight infrastructure validation service.
         postrun: Post-run DQ checks and VACUUM service.
         lifecycle_orch: Lifecycle orchestrator for medallion layer clearing.
+        observer: Pipeline observer for unified observability.
     """
 
     lock_manager: LockManager
     preflight: PreflightService
     postrun: PostrunService
     lifecycle_orch: LifecycleOrchestrator
+    observer: PipelineObserver

--- a/src/bioetl/composition/factories/runner_assembly.py
+++ b/src/bioetl/composition/factories/runner_assembly.py
@@ -244,6 +244,7 @@ def assemble_runner(
         shutdown_signal=pipeline.shutdown_signal,
         checkpoint_manager=checkpoint_manager,
         lifecycle_service=lifecycle_service,
+        tracer=observability.tracer,
     )
 
     # Assemble Runner with injected RunnerServices bundle

--- a/src/bioetl/composition/factories/runner_services.py
+++ b/src/bioetl/composition/factories/runner_services.py
@@ -17,6 +17,7 @@ from bioetl.application.core.preflight_service import PreflightService
 
 # Re-export RunnerServices from application layer for backwards compatibility
 from bioetl.application.core.runner_services import RunnerServices
+from bioetl.application.observability.observer import PipelineObserver
 
 if TYPE_CHECKING:
     from bioetl.application.core.checkpoint_manager import CheckpointManager
@@ -27,7 +28,7 @@ if TYPE_CHECKING:
     )
     from bioetl.domain.config import PipelineConfig, RuntimeConfig
     from bioetl.domain.context import PipelineContext
-    from bioetl.domain.ports import LoggerPort
+    from bioetl.domain.ports import LoggerPort, TracingPort
 
 
 def build_runner_services(
@@ -39,6 +40,7 @@ def build_runner_services(
     shutdown_signal: ShutdownSignal,
     checkpoint_manager: CheckpointManager,
     lifecycle_service: MedallionLifecycleService,
+    tracer: TracingPort | None = None,
 ) -> RunnerServices:
     """Build RunnerServices bundle.
 
@@ -54,6 +56,7 @@ def build_runner_services(
         shutdown_signal: Shutdown signal for graceful termination.
         checkpoint_manager: Checkpoint manager.
         lifecycle_service: Medallion lifecycle service.
+        tracer: Optional tracing port for distributed tracing.
 
     Returns:
         RunnerServices bundle with all required services.
@@ -95,11 +98,21 @@ def build_runner_services(
         lifecycle_service=lifecycle_service,
     )
 
+    observer = PipelineObserver(
+        pipeline_name=config.pipeline_name,
+        run_id=context.run_id,
+        run_type=runtime.run_type,
+        metrics=services.metrics,
+        logger=logger,
+        tracer=tracer,
+    )
+
     return RunnerServices(
         lock_manager=lock_manager,
         preflight=preflight_service,
         postrun=postrun_service,
         lifecycle_orch=lifecycle_orchestrator,
+        observer=observer,
     )
 
 

--- a/tests/architecture/test_di_discipline.py
+++ b/tests/architecture/test_di_discipline.py
@@ -3,7 +3,7 @@
 REQ-ARCH-DI-010: Application layer MUST NOT create infrastructure services.
 
 Application services (LockManager, PreflightService, PostrunService,
-LifecycleOrchestrator) should be created in the composition layer
+LifecycleOrchestrator, PipelineObserver) should be created in the composition layer
 and injected via constructors.
 
 See CLAUDE.md §2.2 Dependency Injection and §11 Anti-Patterns.
@@ -11,7 +11,6 @@ See CLAUDE.md §2.2 Dependency Injection and §11 Anti-Patterns.
 
 from __future__ import annotations
 
-import ast
 from pathlib import Path
 
 import pytest
@@ -26,6 +25,7 @@ FORBIDDEN_IN_APPLICATION = [
     "PreflightService(",
     "PostrunService(",
     "LifecycleOrchestrator(",
+    "PipelineObserver(",
 ]
 
 
@@ -43,16 +43,26 @@ class TestDIDiscipline:
     def application_python_files(self) -> list[Path]:
         """Get all Python files in application directory.
 
-        Excludes composition layer files since they are allowed to create services.
+        Excludes:
+        - Composition layer files (they are allowed to create services)
+        - Service definition files (they contain class definitions, not instantiations)
         """
         base = _get_base_path(APPLICATION_DIR)
         if not base.exists():
             pytest.skip("Application layer not found")
 
+        # Files that define services (class definitions, not instantiations)
+        excluded_files = {
+            "observer.py",  # PipelineObserver class definition
+        }
+
         files = []
         for py_file in base.rglob("*.py"):
             # Skip composition layer
             if "composition" in str(py_file):
+                continue
+            # Skip service definition files
+            if py_file.name in excluded_files:
                 continue
             files.append(py_file)
         return files
@@ -63,8 +73,8 @@ class TestDIDiscipline:
         """Application layer must not create infrastructure services.
 
         REQ-ARCH-DI-010: Services like LockManager, PreflightService,
-        PostrunService, and LifecycleOrchestrator must be injected,
-        not created directly in application layer.
+        PostrunService, LifecycleOrchestrator, and PipelineObserver must be
+        injected, not created directly in application layer.
 
         These services should be created in composition/bootstrap.py or
         composition/factories/ and passed via constructor injection.

--- a/tests/unit/application/core/test_runner.py
+++ b/tests/unit/application/core/test_runner.py
@@ -16,6 +16,7 @@ from bioetl.application.core.preflight_service import PreflightService
 from bioetl.application.core.runner import PipelineRunner
 from bioetl.application.core.runner_services import RunnerServices
 from bioetl.application.core.shutdown import PipelineShutdownError, ShutdownSignal
+from bioetl.application.observability.observer import PipelineObserver
 from bioetl.domain.config import PipelineConfig, RuntimeConfig
 from bioetl.domain.context import PipelineContext
 from bioetl.domain.types import RunType
@@ -86,11 +87,96 @@ def create_mock_services():
     return services
 
 
+def create_mock_observer(
+    metrics: MagicMock | None = None,
+    logger: MagicMock | None = None,
+    suppress_shutdown: bool = True,
+) -> MagicMock:
+    """Create a mock PipelineObserver for DI injection.
+
+    This mock observer properly simulates the real observer's behavior:
+    - Suppresses PipelineShutdownError exceptions (like the real observer)
+    - Logs and records metrics on exit (if metrics/logger provided)
+
+    Args:
+        metrics: Optional metrics mock to record metrics on exit.
+        logger: Optional logger mock to log on exit.
+        suppress_shutdown: Whether to suppress PipelineShutdownError.
+
+    Returns:
+        MagicMock configured as a PipelineObserver with context manager support.
+    """
+
+    def exit_handler(exc_type, exc_val, exc_tb):
+        """Mock __exit__ that simulates real observer behavior.
+
+        Records metrics and suppresses PipelineShutdownError.
+        """
+        status = "success"
+        suppress = False
+
+        if exc_val:
+            if isinstance(exc_val, PipelineShutdownError):
+                status = "shutdown"
+                suppress = suppress_shutdown
+            else:
+                status = "failed"
+
+        # Record metrics like the real observer
+        if metrics:
+            metrics.observe_histogram(
+                "bioetl_pipeline_duration_seconds",
+                0.1,  # Mock duration
+                labels={
+                    "pipeline": "test_pipeline",
+                    "run_type": "incremental",
+                    "status": status,
+                },
+            )
+            metrics.increment_counter(
+                "bioetl_pipeline_runs_total",
+                1,
+                labels={
+                    "pipeline": "test_pipeline",
+                    "run_type": "incremental",
+                    "status": status,
+                },
+            )
+
+        # Log like the real observer
+        if logger:
+            if status == "failed":
+                logger.error(
+                    "pipeline_failed",
+                    status=status,
+                    error=str(exc_val),
+                    error_type=type(exc_val).__name__,
+                )
+            elif status == "shutdown":
+                logger.warning("pipeline_shutdown", status=status)
+            else:
+                logger.info("pipeline_finished", status=status)
+
+        return suppress
+
+    observer = MagicMock(spec=PipelineObserver)
+    observer.__enter__ = MagicMock(return_value=observer)
+    observer.__exit__ = MagicMock(side_effect=exit_handler)
+    observer.emit_event = MagicMock()
+    observer.emit_phase_started = MagicMock(return_value=0.0)
+    observer.emit_phase_completed = MagicMock()
+    observer.emit_health_check_result = MagicMock()
+    observer.emit_dq_anomaly = MagicMock()
+    observer.emit_vacuum_result = MagicMock()
+    return observer
+
+
 def create_mock_runner_services(
     lock_manager=None,
     preflight_service=None,
     postrun_service=None,
     lifecycle_orchestrator=None,
+    observer=None,
 ) -> RunnerServices:
     """Create mock RunnerServices for DI injection.
 
@@ -99,6 +185,7 @@ def create_mock_runner_services(
         preflight_service: Optional custom preflight service mock.
         postrun_service: Optional custom postrun service mock.
         lifecycle_orchestrator: Optional custom lifecycle orchestrator mock.
+        observer: Optional custom observer mock.
 
     Returns:
         RunnerServices bundle with mock services.
@@ -143,11 +230,15 @@ def create_mock_runner_services(
             )
         )
 
+    if observer is None:
+        observer = create_mock_observer()
+
     return RunnerServices(
         lock_manager=lock_manager,
         preflight=preflight_service,
         postrun=postrun_service,
         lifecycle_orch=lifecycle_orchestrator,
+        observer=observer,
     )
 
 
@@ -265,11 +356,24 @@ def mock_lifecycle_service():
 
 
 @pytest.fixture
+def mock_observer(mock_services, mock_logger):
+    """Create a mock PipelineObserver (injected via DI).
+
+    Uses services.metrics and logger to properly simulate real observer behavior.
+    """
+    return create_mock_observer(
+        metrics=mock_services.metrics,
+        logger=mock_logger,
+    )
+
+
+@pytest.fixture
 def mock_runner_services(
     mock_lock_manager,
     mock_preflight_service,
     mock_postrun_service,
     mock_lifecycle_orchestrator,
+    mock_observer,
 ):
     """Create a mock RunnerServices bundle for PipelineRunner."""
     return RunnerServices(
@@ -277,6 +381,7 @@ def mock_runner_services(
         preflight=mock_preflight_service,
         postrun=mock_postrun_service,
         lifecycle_orch=mock_lifecycle_orchestrator,
+        observer=mock_observer,
     )
 
 
@@ -343,6 +448,7 @@ class TestPipelineRunnerInit:
         assert runner._preflight_service == mock_runner_services.preflight
         assert runner._postrun_service == mock_runner_services.postrun
         assert runner._lifecycle_orchestrator == mock_runner_services.lifecycle_orch
+        assert runner._observer == mock_runner_services.observer
 
     def test_services_are_injected_not_created(
         self,
@@ -374,6 +480,7 @@ class TestPipelineRunnerInit:
         assert runner._preflight_service is mock_runner_services.preflight
         assert runner._postrun_service is mock_runner_services.postrun
         assert runner._lifecycle_orchestrator is mock_runner_services.lifecycle_orch
+        assert runner._observer is mock_runner_services.observer
 
 
 @pytest.mark.unit
@@ -581,6 +688,7 @@ class TestPipelineRunnerClearViaLifecycle:
             preflight=mock_preflight_service,
             postrun=mock_postrun_service,
             lifecycle_orch=lifecycle_orchestrator,
+            observer=create_mock_observer(metrics=services.metrics, logger=mock_logger),
         )
 
         runner = PipelineRunner(
@@ -633,6 +741,7 @@ class TestPipelineRunnerClearViaLifecycle:
             preflight=mock_preflight_service,
             postrun=mock_postrun_service,
             lifecycle_orch=lifecycle_orchestrator,
+            observer=create_mock_observer(metrics=services.metrics, logger=mock_logger),
         )
 
         runner = PipelineRunner(
@@ -707,6 +816,7 @@ class TestPipelineRunnerCheckDataQuality:
             preflight=mock_preflight_service,
             postrun=postrun_service,
             lifecycle_orch=mock_lifecycle_orchestrator,
+            observer=create_mock_observer(metrics=services.metrics, logger=mock_logger),
         )
 
         runner = PipelineRunner(
@@ -763,6 +873,7 @@ class TestPipelineRunnerCheckDataQuality:
             preflight=mock_preflight_service,
             postrun=postrun_service,
             lifecycle_orch=mock_lifecycle_orchestrator,
+            observer=create_mock_observer(metrics=services.metrics, logger=mock_logger),
         )
 
         runner = PipelineRunner(


### PR DESCRIPTION
Move PipelineObserver from being created inside PipelineRunner.run() to being injected via RunnerServices bundle, following the DI pattern.

Changes:
- Add observer field to RunnerServices dataclass
- Create observer in build_runner_services() factory
- Update PipelineRunner to use injected observer
- Add PipelineObserver to DI discipline architecture test
- Update test fixtures with mock observer that properly simulates real observer behavior (exception suppression, metrics recording)

This improves testability and follows the project's DI discipline.