### PR TITLE
Implement instance-level PipelineRegistry for test isolation

### DIFF
--- a/src/bioetl/composition/bootstrap.py
+++ b/src/bioetl/composition/bootstrap.py
@@ -37,7 +37,7 @@ from bioetl.composition._bootstrap import (
 from bioetl.composition.builders import FilterConfigBuilder
 from bioetl.composition.factories.pipeline_factories import register_all_pipelines
 from bioetl.composition.providers.registration import register_all_providers
-from bioetl.composition.registry import PipelineRegistry
+from bioetl.composition.registry import PipelineRegistry, get_default_registry
 from bioetl.domain.config import RuntimeConfig
 from bioetl.infrastructure.config import get_settings, load_pipeline_config
 
@@ -65,7 +65,10 @@ if TYPE_CHECKING:
     from bioetl.domain.context import PipelineRunContext
 
 
-def bootstrap_pipeline(ctx: PipelineRunContext) -> PipelineRunner:
+def bootstrap_pipeline(
+    ctx: PipelineRunContext,
+    registry: PipelineRegistry | None = None,
+) -> PipelineRunner:
     """Composition Root: Assembles and returns a fully configured PipelineRunner.
 
     This is the main entry point for creating a pipeline runner. It:
@@ -78,6 +81,8 @@ def bootstrap_pipeline(ctx: PipelineRunContext) -> PipelineRunner:
     Args:
         ctx: Pipeline run context containing launch parameters including
             pipeline_name, run_id, run_type, resume flag, limit, filters, etc.
+        registry: Optional PipelineRegistry instance. If None, uses the
+            default global registry. Pass a custom registry for test isolation.
 
     Returns:
         PipelineRunner: Fully configured runner ready for execution.
@@ -94,10 +99,19 @@ def bootstrap_pipeline(ctx: PipelineRunContext) -> PipelineRunner:
         ... )
         >>> runner = bootstrap_pipeline(ctx)
         >>> await runner.run()
+
+        # For test isolation:
+        >>> from bioetl.composition.registry import create_registry
+        >>> registry = create_registry()
+        >>> register_all_pipelines(registry=registry)
+        >>> runner = bootstrap_pipeline(ctx, registry=registry)
     """
-    # Explicit registration (idempotent)
+    # Use provided registry or default
+    effective_registry = registry if registry is not None else get_default_registry()
+
+    # Explicit registration (idempotent for default registry)
     register_all_providers()
-    register_all_pipelines()
+    register_all_pipelines(registry=registry)
 
     settings = get_settings()
 
@@ -153,7 +167,7 @@ def bootstrap_pipeline(ctx: PipelineRunContext) -> PipelineRunner:
         )
 
     # Resolve pipeline factory and delegate runner creation
-    pipeline_def = PipelineRegistry.get(ctx.pipeline_name)
+    pipeline_def = effective_registry.get(ctx.pipeline_name)
     factory = pipeline_def.factory
 
     return factory.create_runner(

--- a/src/bioetl/composition/factories/pipeline_factories.py
+++ b/src/bioetl/composition/factories/pipeline_factories.py
@@ -9,12 +9,25 @@ Thread-safety: Registration uses a module-level lock to prevent TOCTOU race cond
 Updated: Transformer injection via DI (Phase 1 refactoring).
 All factories now include transformer_class for proper DI.
 
+Instance-level registry support (2025-12):
+- register_all_pipelines() accepts optional registry parameter
+- Default behavior uses global registry for backward compatibility
+- Tests can use isolated registries for parallel execution
+
 Usage:
     >>> from bioetl.composition.factories.pipeline_factories import register_all_pipelines
     >>> register_all_pipelines()  # Call once at application startup
+
+    # For test isolation:
+    >>> from bioetl.composition.registry import create_registry
+    >>> registry = create_registry()
+    >>> register_all_pipelines(registry=registry)
 """
 
+from __future__ import annotations
+
 import threading
+from typing import TYPE_CHECKING
 
 from bioetl.application.pipelines.chembl.activity import ChEMBLActivityPipeline
 from bioetl.application.pipelines.chembl.activity_transformer import ActivityTransformer
@@ -39,7 +52,7 @@ from bioetl.application.pipelines.pubmed.transformer import PubMedPublicationTra
 from bioetl.application.pipelines.uniprot.protein import UniProtProteinPipeline
 from bioetl.application.pipelines.uniprot.transformer import UniProtProteinTransformer
 from bioetl.composition.factories.generic_factory import GenericPipelineFactory
-from bioetl.composition.registry import PipelineRegistry
+from bioetl.composition.registry import PipelineRegistry, get_default_registry
 from bioetl.infrastructure.schemas.gold import (
     ChEMBLActivityGoldSchema,
     ChEMBLAssayGoldSchema,
@@ -62,6 +75,9 @@ from bioetl.infrastructure.schemas.silver import (
     PUBMED_PUBLICATION_SCHEMA,
     UNIPROT_PROTEIN_SCHEMA,
 )
+
+if TYPE_CHECKING:
+    pass
 
 # Thread-safe registration state
 _registration_lock = threading.Lock()
@@ -158,7 +174,7 @@ pubmed_publications_factory = GenericPipelineFactory(
 )
 
 
-def register_all_pipelines() -> None:
+def register_all_pipelines(registry: PipelineRegistry | None = None) -> None:
     """Explicitly register all pipeline factories with PipelineRegistry.
 
     This function is idempotent and thread-safe - calling it multiple times
@@ -167,10 +183,23 @@ def register_all_pipelines() -> None:
     Uses double-checked locking pattern to minimize lock contention while
     ensuring thread-safe initialization.
 
+    When called with a custom registry, idempotency check is skipped
+    (each registry instance is independent).
+
+    Args:
+        registry: Optional PipelineRegistry instance. If None, uses the
+            default global registry. Pass a custom registry for test isolation.
+
     Should be called once at application startup (e.g., in cli.py or bootstrap.py).
     """
     global _factories_registered
 
+    # For custom registries, register directly without idempotency check
+    if registry is not None:
+        _register_factories_to(registry)
+        return
+
+    # Default registry: use idempotency guard
     # Fast path: already registered (no lock needed)
     if _factories_registered:
         return
@@ -181,17 +210,29 @@ def register_all_pipelines() -> None:
         if _factories_registered:
             return
 
-        PipelineRegistry.register_factory(chembl_activity_factory)
-        PipelineRegistry.register_factory(chembl_assay_factory)
-        PipelineRegistry.register_factory(chembl_document_factory)
-        PipelineRegistry.register_factory(chembl_target_factory)
-        PipelineRegistry.register_factory(chembl_target_component_factory)
-        PipelineRegistry.register_factory(chembl_molecule_factory)
-        PipelineRegistry.register_factory(pubchem_compound_factory)
-        PipelineRegistry.register_factory(uniprot_protein_factory)
-        PipelineRegistry.register_factory(pubmed_publications_factory)
+        default_registry = get_default_registry()
+        _register_factories_to(default_registry)
 
         _factories_registered = True
+
+
+def _register_factories_to(registry: PipelineRegistry) -> None:
+    """Register all factory instances to the given registry.
+
+    Internal helper for register_all_pipelines().
+
+    Args:
+        registry: Target registry instance.
+    """
+    registry.register_factory(chembl_activity_factory)
+    registry.register_factory(chembl_assay_factory)
+    registry.register_factory(chembl_document_factory)
+    registry.register_factory(chembl_target_factory)
+    registry.register_factory(chembl_target_component_factory)
+    registry.register_factory(chembl_molecule_factory)
+    registry.register_factory(pubchem_compound_factory)
+    registry.register_factory(uniprot_protein_factory)
+    registry.register_factory(pubmed_publications_factory)
 
 
 def is_registered() -> bool:
@@ -209,12 +250,15 @@ def is_registered() -> bool:
 def reset_registration() -> None:
     """Reset registration state (for testing only).
 
-    Thread-safe reset of registration flag. Also clears the PipelineRegistry.
+    Thread-safe reset of registration flag. Also clears the default PipelineRegistry.
     WARNING: Only use in tests. Not for production.
+
+    Note: For isolated tests, prefer creating a new registry instance with
+    create_registry() rather than using reset_registration().
     """
     global _factories_registered
     with _registration_lock:
-        PipelineRegistry.clear()
+        get_default_registry().clear()
         _factories_registered = False
 
 

--- a/src/bioetl/composition/registry.py
+++ b/src/bioetl/composition/registry.py
@@ -1,12 +1,19 @@
 """Pipeline Registry for discovering and instantiating pipelines.
 
 MOVED to composition layer to fix dependency direction.
+
+This module provides an instance-level PipelineRegistry for:
+- Test isolation (each test can have its own registry)
+- Parallel test execution without clear()
+- Proper DI through composition root
+
+A default global instance is provided for backward compatibility.
 """
 
 from __future__ import annotations
 
 import threading
-from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, NamedTuple, Protocol, runtime_checkable
 
 import pyarrow as pa
 
@@ -69,20 +76,29 @@ class PipelineDefinition(NamedTuple):
 class PipelineRegistry:
     """Registry for pipeline factories.
 
-    Thread-safe singleton registry for pipeline factory instances.
+    Thread-safe instance-level registry for pipeline factory instances.
     All public methods are protected with RLock for concurrent access.
 
-    Example:
+    This class can be instantiated for test isolation or used via the
+    default global instance for backward compatibility.
+
+    Example (instance-level for tests):
+        >>> registry = PipelineRegistry()
         >>> factory = GenericPipelineFactory(...)
-        >>> PipelineRegistry.register_factory(factory)
+        >>> registry.register_factory(factory)
+
+    Example (backward-compatible class method API):
+        >>> factory = GenericPipelineFactory(...)
+        >>> PipelineRegistry.register_factory(factory)  # Uses default instance
     """
 
-    _registry: ClassVar[dict[str, PipelineDefinition]] = {}
-    _registry_lock: ClassVar[threading.RLock] = threading.RLock()
+    def __init__(self) -> None:
+        """Initialize a new empty registry."""
+        self._registry: dict[str, PipelineDefinition] = {}
+        self._lock = threading.RLock()
 
-    @classmethod
     def register_factory(
-        cls,
+        self,
         factory: PipelineFactoryProtocol,
     ) -> None:
         """Register a pipeline factory instance.
@@ -103,20 +119,19 @@ class PipelineRegistry:
                 "All Gold layer writes require schema validation."
             )
 
-        with cls._registry_lock:
-            if factory.pipeline_name in cls._registry:
+        with self._lock:
+            if factory.pipeline_name in self._registry:
                 raise ValueError(
                     f"Pipeline already registered: {factory.pipeline_name}. "
-                    "Use clear() in tests to reset registry state."
+                    "Use a new registry instance or clear() for tests."
                 )
-            cls._registry[factory.pipeline_name] = PipelineDefinition(
+            self._registry[factory.pipeline_name] = PipelineDefinition(
                 factory=factory,
                 silver_schema=factory.silver_schema,
                 gold_schema=gold_schema,
             )
 
-    @classmethod
-    def get(cls, pipeline_name: str) -> PipelineDefinition:
+    def get(self, pipeline_name: str) -> PipelineDefinition:
         """Get pipeline definition by name.
 
         Thread-safe read access to registry.
@@ -131,21 +146,20 @@ class PipelineRegistry:
             RuntimeError: If registry is empty (registration not called)
             ValueError: If pipeline is not registered
         """
-        with cls._registry_lock:
-            if not cls._registry:
+        with self._lock:
+            if not self._registry:
                 raise RuntimeError(
                     "PipelineRegistry is empty. "
                     "Did you forget to call register_all_pipelines()?"
                 )
-            if pipeline_name not in cls._registry:
+            if pipeline_name not in self._registry:
                 raise ValueError(
                     f"Unknown pipeline name: {pipeline_name}. "
-                    f"Available: {sorted(cls._registry.keys())}"
+                    f"Available: {sorted(self._registry.keys())}"
                 )
-            return cls._registry[pipeline_name]
+            return self._registry[pipeline_name]
 
-    @classmethod
-    def list_pipelines(cls) -> list[str]:
+    def list_pipelines(self) -> list[str]:
         """List all registered pipeline names.
 
         Thread-safe listing with deterministic ordering.
@@ -154,12 +168,11 @@ class PipelineRegistry:
         Returns:
             Sorted list of pipeline names (deterministic order).
         """
-        with cls._registry_lock:
-            return sorted(cls._registry.keys())
+        with self._lock:
+            return sorted(self._registry.keys())
 
-    @classmethod
     def register(
-        cls,
+        self,
         key: str,
         value: PipelineFactoryProtocol,
     ) -> None:
@@ -184,28 +197,26 @@ class PipelineRegistry:
                 f"Factory '{key}' must have gold_schema. "
                 "All Gold layer writes require schema validation."
             )
-        with cls._registry_lock:
-            if key in cls._registry:
+        with self._lock:
+            if key in self._registry:
                 raise ValueError(
                     f"Pipeline already registered: {key}. "
-                    "Use clear() in tests to reset registry state."
+                    "Use a new registry instance or clear() for tests."
                 )
-            cls._registry[key] = PipelineDefinition(
+            self._registry[key] = PipelineDefinition(
                 factory=value,
                 silver_schema=value.silver_schema,
                 gold_schema=gold_schema,
             )
 
-    @classmethod
-    def list_keys(cls) -> list[str]:
+    def list_keys(self) -> list[str]:
         """List all registered pipeline names (unified API).
 
         Alias for list_pipelines().
         """
-        return cls.list_pipelines()
+        return self.list_pipelines()
 
-    @classmethod
-    def contains(cls, key: str) -> bool:
+    def contains(self, key: str) -> bool:
         """Check if pipeline is registered.
 
         Thread-safe check for key existence.
@@ -216,15 +227,42 @@ class PipelineRegistry:
         Returns:
             True if pipeline is registered, False otherwise
         """
-        with cls._registry_lock:
-            return key in cls._registry
+        with self._lock:
+            return key in self._registry
 
-    @classmethod
-    def clear(cls) -> None:
+    def clear(self) -> None:
         """Clear all registrations (for testing).
 
         Thread-safe reset of registry state.
         WARNING: Only use in tests. Not for production.
         """
-        with cls._registry_lock:
-            cls._registry.clear()
+        with self._lock:
+            self._registry.clear()
+
+
+# Default global instance for backward compatibility
+_default_registry = PipelineRegistry()
+
+
+def get_default_registry() -> PipelineRegistry:
+    """Get the default global registry instance.
+
+    Use this function when you need access to the shared registry.
+    For tests, prefer creating a new PipelineRegistry() instance.
+
+    Returns:
+        The default global PipelineRegistry instance.
+    """
+    return _default_registry
+
+
+def create_registry() -> PipelineRegistry:
+    """Create a new isolated registry instance.
+
+    Use this for test isolation or when you need multiple registries
+    in the same process.
+
+    Returns:
+        A new empty PipelineRegistry instance.
+    """
+    return PipelineRegistry()

--- a/src/bioetl/composition/types.py
+++ b/src/bioetl/composition/types.py
@@ -8,17 +8,26 @@ For actual runtime imports, use the specific modules:
 - ObservabilityBundle: from bioetl.composition.observability
 - StorageAdapter: from bioetl.composition.factories.storage_factory
 - PipelineRegistry: from bioetl.composition.registry
+- get_default_registry: from bioetl.composition.registry (default instance)
+- create_registry: from bioetl.composition.registry (isolated instance for tests)
 """
 
 from __future__ import annotations
 
 from bioetl.composition.factories.storage_factory import StorageAdapter
 from bioetl.composition.observability import ObservabilityBundle
-from bioetl.composition.registry import PipelineDefinition, PipelineRegistry
+from bioetl.composition.registry import (
+    PipelineDefinition,
+    PipelineRegistry,
+    create_registry,
+    get_default_registry,
+)
 
 __all__ = [
     "ObservabilityBundle",
     "PipelineDefinition",
     "PipelineRegistry",
     "StorageAdapter",
+    "create_registry",
+    "get_default_registry",
 ]

--- a/src/bioetl/interfaces/cli.py
+++ b/src/bioetl/interfaces/cli.py
@@ -23,7 +23,7 @@ from bioetl.composition.entrypoints import (
     preview_cleanup,
 )
 from bioetl.composition.factories.pipeline_factories import register_all_pipelines
-from bioetl.composition.registry import PipelineRegistry
+from bioetl.composition.registry import get_default_registry
 from bioetl.interfaces.orchestration.signals import setup_shutdown_handlers
 
 if TYPE_CHECKING:
@@ -84,7 +84,8 @@ def validate_pipeline_name(
     _ctx: click.Context | None, _param: click.Parameter | None, value: str
 ) -> str:
     """Validate pipeline name against the registry at runtime."""
-    available = PipelineRegistry.list_pipelines()
+    registry = get_default_registry()
+    available = registry.list_pipelines()
     if value not in available:
         raise click.BadParameter(f"Unknown pipeline: {value}. Available: {available}")
     return value

--- a/tests/architecture/test_registry_contracts.py
+++ b/tests/architecture/test_registry_contracts.py
@@ -2,6 +2,8 @@
 
 Verifies that all registries follow the unified BaseRegistry protocol.
 Implements CLAUDE.md §6.3.3 requirements.
+
+Updated for instance-level PipelineRegistry (2025-12).
 """
 
 from __future__ import annotations
@@ -10,21 +12,24 @@ import typing
 
 import pytest
 
+from bioetl.composition.factories.pipeline_factories import register_all_pipelines
+from bioetl.composition.registry import PipelineRegistry, get_default_registry
+
 
 class TestRegistryProtocol:
     """All registries must implement BaseRegistry protocol."""
 
     def test_pipeline_registry_has_required_methods(self) -> None:
         """PipelineRegistry must have get, register_factory, list_pipelines methods."""
-        from bioetl.composition.registry import PipelineRegistry
-
-        assert hasattr(PipelineRegistry, "get"), (
+        # Check class-level methods exist
+        registry = PipelineRegistry()
+        assert hasattr(registry, "get"), (
             "PipelineRegistry MUST have get() method"
         )
-        assert hasattr(PipelineRegistry, "register_factory"), (
+        assert hasattr(registry, "register_factory"), (
             "PipelineRegistry MUST have register_factory() method"
         )
-        assert hasattr(PipelineRegistry, "list_pipelines"), (
+        assert hasattr(registry, "list_pipelines"), (
             "PipelineRegistry MUST have list_pipelines() method"
         )
 
@@ -70,12 +75,11 @@ class TestRegistryProtocol:
 class TestRegistryRaiseOnMissingKey:
     """Registries must raise clear error for unknown keys."""
 
-    def test_pipeline_registry_raises_on_missing(self) -> None:
+    def test_pipeline_registry_raises_on_missing(self, isolated_registry) -> None:
         """PipelineRegistry raises RuntimeError or ValueError for unknown pipeline."""
-        from bioetl.composition.registry import PipelineRegistry
-
+        # Empty registry raises RuntimeError
         with pytest.raises((RuntimeError, ValueError, KeyError)):
-            PipelineRegistry.get("nonexistent_pipeline_12345")
+            isolated_registry.get("nonexistent_pipeline_12345")
 
     def test_datasource_registry_raises_on_missing(self) -> None:
         """DataSourceRegistry raises KeyError for unknown provider."""
@@ -94,23 +98,52 @@ class TestRegistryRaiseOnMissingKey:
             ProviderRegistry.get("nonexistent_provider_12345")
 
 
-class TestRegistryClassVars:
-    """Registries use ClassVar for storage (singleton pattern)."""
+class TestRegistryInstanceVariables:
+    """PipelineRegistry uses instance variables for test isolation."""
 
-    def test_pipeline_registry_uses_classvar(self) -> None:
-        """PipelineRegistry._registry must be ClassVar."""
-        from bioetl.composition.registry import PipelineRegistry
+    def test_pipeline_registry_has_instance_registry(self) -> None:
+        """PipelineRegistry._registry must be an instance variable."""
+        registry = PipelineRegistry()
 
-        # ClassVar should be in annotations
-        assert "_registry" in PipelineRegistry.__annotations__, (
-            "PipelineRegistry MUST have _registry annotation"
+        # Instance should have _registry attribute
+        assert hasattr(registry, "_registry"), (
+            "PipelineRegistry MUST have _registry attribute"
         )
 
-        # Check it's a ClassVar
-        hint = PipelineRegistry.__annotations__["_registry"]
-        # ClassVar is represented as typing.ClassVar[...]
-        assert "ClassVar" in str(hint), (
-            "PipelineRegistry._registry MUST be ClassVar for singleton pattern"
+        # It should be a dict
+        assert isinstance(registry._registry, dict), (
+            "PipelineRegistry._registry MUST be a dict"
+        )
+
+    def test_pipeline_registry_has_instance_lock(self) -> None:
+        """PipelineRegistry._lock must be an instance variable."""
+        import threading
+
+        registry = PipelineRegistry()
+
+        # Instance should have _lock attribute
+        assert hasattr(registry, "_lock"), (
+            "PipelineRegistry MUST have _lock attribute"
+        )
+
+        # It should be an RLock
+        assert isinstance(registry._lock, type(threading.RLock())), (
+            "PipelineRegistry._lock MUST be an RLock"
+        )
+
+    def test_pipeline_registry_instances_are_independent(self) -> None:
+        """Two PipelineRegistry instances must have separate storage."""
+        registry1 = PipelineRegistry()
+        registry2 = PipelineRegistry()
+
+        # Should be different dict instances
+        assert registry1._registry is not registry2._registry, (
+            "PipelineRegistry instances MUST have independent _registry"
+        )
+
+        # Should be different lock instances
+        assert registry1._lock is not registry2._lock, (
+            "PipelineRegistry instances MUST have independent _lock"
         )
 
     def test_datasource_registry_uses_classvar(self) -> None:
@@ -145,11 +178,9 @@ class TestRegistryClassVars:
 class TestRegistryReturnTypes:
     """Registries must return proper types."""
 
-    def test_pipeline_registry_list_returns_list(self) -> None:
+    def test_pipeline_registry_list_returns_list(self, populated_isolated_registry) -> None:
         """PipelineRegistry.list_pipelines must return list[str]."""
-        from bioetl.composition.registry import PipelineRegistry
-
-        result = PipelineRegistry.list_pipelines()
+        result = populated_isolated_registry.list_pipelines()
         assert isinstance(result, list), (
             "list_pipelines() MUST return a list"
         )
@@ -256,4 +287,33 @@ class TestRegistryFactoryProtocol:
         )
         assert hasattr(PipelineFactoryProtocol, "create_runner"), (
             "PipelineFactoryProtocol MUST have create_runner()"
+        )
+
+
+class TestDefaultRegistryHelper:
+    """Test get_default_registry() helper function."""
+
+    def test_get_default_registry_returns_instance(self) -> None:
+        """get_default_registry() must return a PipelineRegistry instance."""
+        registry = get_default_registry()
+        assert isinstance(registry, PipelineRegistry), (
+            "get_default_registry() MUST return PipelineRegistry instance"
+        )
+
+    def test_get_default_registry_returns_same_instance(self) -> None:
+        """get_default_registry() must return the same instance on multiple calls."""
+        registry1 = get_default_registry()
+        registry2 = get_default_registry()
+        assert registry1 is registry2, (
+            "get_default_registry() MUST return the same instance"
+        )
+
+    def test_create_registry_returns_new_instance(self) -> None:
+        """create_registry() must return a new instance each time."""
+        from bioetl.composition.registry import create_registry
+
+        registry1 = create_registry()
+        registry2 = create_registry()
+        assert registry1 is not registry2, (
+            "create_registry() MUST return a new instance"
         )

--- a/tests/architecture/test_registry_threading.py
+++ b/tests/architecture/test_registry_threading.py
@@ -2,6 +2,8 @@
 
 Verifies that registry operations are thread-safe as per CLAUDE.md requirements.
 Tests concurrent access patterns that could expose race conditions.
+
+Updated for instance-level PipelineRegistry (2025-12).
 """
 
 from __future__ import annotations
@@ -15,11 +17,8 @@ from unittest.mock import MagicMock
 import pyarrow as pa
 import pytest
 
-from bioetl.composition.factories.pipeline_factories import (
-    register_all_pipelines,
-    reset_registration,
-)
-from bioetl.composition.registry import PipelineRegistry
+from bioetl.composition.factories.pipeline_factories import register_all_pipelines
+from bioetl.composition.registry import PipelineRegistry, create_registry
 
 if TYPE_CHECKING:
     from bioetl.composition.registry import PipelineFactoryProtocol
@@ -41,18 +40,10 @@ def create_mock_factory(name: str) -> PipelineFactoryProtocol:
     return factory
 
 
-@pytest.fixture(autouse=True)
-def clean_registry():
-    """Reset registry before and after each test."""
-    reset_registration()
-    yield
-    reset_registration()
-
-
 class TestConcurrentRegistration:
     """Tests for concurrent registration safety."""
 
-    def test_concurrent_registration_from_multiple_threads(self) -> None:
+    def test_concurrent_registration_from_multiple_threads(self, isolated_registry) -> None:
         """10 threads registering different factories simultaneously.
 
         Verifies that no race conditions occur during concurrent writes.
@@ -65,7 +56,7 @@ class TestConcurrentRegistration:
             """Register a factory with unique name."""
             try:
                 factory = create_mock_factory(f"test_pipeline_{idx}")
-                PipelineRegistry.register_factory(factory)
+                isolated_registry.register_factory(factory)
                 results.append((f"test_pipeline_{idx}", True))
             except Exception as e:
                 errors.append(e)
@@ -83,13 +74,13 @@ class TestConcurrentRegistration:
         )
 
         # Verify all pipelines are registered
-        registered = PipelineRegistry.list_pipelines()
+        registered = isolated_registry.list_pipelines()
         for i in range(num_threads):
             assert f"test_pipeline_{i}" in registered, (
                 f"Pipeline test_pipeline_{i} not found in registry"
             )
 
-    def test_concurrent_read_write_safety(self) -> None:
+    def test_concurrent_read_write_safety(self, isolated_registry) -> None:
         """Concurrent reads during writes do not cause errors.
 
         Simulates real-world scenario where list_pipelines() is called
@@ -104,7 +95,7 @@ class TestConcurrentRegistration:
             """Register a factory."""
             try:
                 factory = create_mock_factory(f"concurrent_pipeline_{idx}")
-                PipelineRegistry.register_factory(factory)
+                isolated_registry.register_factory(factory)
             except ValueError:
                 # Already registered - expected in some race scenarios
                 pass
@@ -116,7 +107,7 @@ class TestConcurrentRegistration:
             try:
                 # Small delay to interleave with writes
                 time.sleep(0.001)
-                result = PipelineRegistry.list_pipelines()
+                result = isolated_registry.list_pipelines()
                 read_results.append(result)
             except Exception as e:
                 errors.append(e)
@@ -139,7 +130,7 @@ class TestConcurrentRegistration:
         for result in read_results:
             assert isinstance(result, list), "list_pipelines() must return a list"
 
-    def test_double_registration_raises_error(self) -> None:
+    def test_double_registration_raises_error(self, isolated_registry) -> None:
         """Registering the same pipeline twice raises ValueError.
 
         Ensures duplicate detection works correctly.
@@ -147,13 +138,13 @@ class TestConcurrentRegistration:
         factory = create_mock_factory("duplicate_pipeline")
 
         # First registration succeeds
-        PipelineRegistry.register_factory(factory)
+        isolated_registry.register_factory(factory)
 
         # Second registration fails
         with pytest.raises(ValueError, match="Pipeline already registered"):
-            PipelineRegistry.register_factory(factory)
+            isolated_registry.register_factory(factory)
 
-    def test_double_registration_concurrent(self) -> None:
+    def test_double_registration_concurrent(self, isolated_registry) -> None:
         """Concurrent attempts to register same pipeline.
 
         Only one should succeed, others should get ValueError.
@@ -169,7 +160,7 @@ class TestConcurrentRegistration:
             # Synchronize all threads to start at the same time
             barrier.wait()
             try:
-                PipelineRegistry.register_factory(factory)
+                isolated_registry.register_factory(factory)
                 successes.append(idx)
             except ValueError:
                 failures.append(idx)
@@ -191,7 +182,7 @@ class TestConcurrentRegistration:
 class TestListPipelinesDeterminism:
     """Tests for deterministic list_pipelines() behavior."""
 
-    def test_list_pipelines_returns_sorted_list(self) -> None:
+    def test_list_pipelines_returns_sorted_list(self, isolated_registry) -> None:
         """list_pipelines() returns alphabetically sorted list.
 
         Ensures deterministic ordering regardless of registration order.
@@ -200,16 +191,16 @@ class TestListPipelinesDeterminism:
         names = ["zebra", "alpha", "mike", "beta"]
         for name in names:
             factory = create_mock_factory(name)
-            PipelineRegistry.register_factory(factory)
+            isolated_registry.register_factory(factory)
 
-        result = PipelineRegistry.list_pipelines()
+        result = isolated_registry.list_pipelines()
 
         # Verify sorted order
         assert result == sorted(names), (
             f"Expected sorted list {sorted(names)}, got {result}"
         )
 
-    def test_list_pipelines_consistent_across_calls(self) -> None:
+    def test_list_pipelines_consistent_across_calls(self, isolated_registry) -> None:
         """Multiple calls to list_pipelines() return identical results.
 
         Verifies no random ordering or side effects.
@@ -217,10 +208,10 @@ class TestListPipelinesDeterminism:
         # Register some pipelines
         for name in ["pipeline_a", "pipeline_b", "pipeline_c"]:
             factory = create_mock_factory(name)
-            PipelineRegistry.register_factory(factory)
+            isolated_registry.register_factory(factory)
 
         # Call multiple times
-        results = [PipelineRegistry.list_pipelines() for _ in range(10)]
+        results = [isolated_registry.list_pipelines() for _ in range(10)]
 
         # All results should be identical
         first_result = results[0]
@@ -233,20 +224,30 @@ class TestListPipelinesDeterminism:
 class TestRegisterAllPipelinesThreadSafety:
     """Tests for register_all_pipelines() thread safety."""
 
-    def test_concurrent_register_all_pipelines_idempotent(self) -> None:
-        """Multiple threads calling register_all_pipelines() simultaneously.
+    def test_concurrent_register_all_pipelines_idempotent(self, isolated_registry) -> None:
+        """Multiple threads calling register_all_pipelines() with same registry.
 
-        Only one should perform registration, others should return immediately.
+        Since we're using an isolated registry and passing it explicitly,
+        all calls will register to the same instance.
         """
         num_threads = 10
         call_count = []
         lock = threading.Lock()
         barrier = threading.Barrier(num_threads)
+        errors: list[Exception] = []
 
         def call_register() -> None:
             """Call register_all_pipelines()."""
             barrier.wait()
-            register_all_pipelines()
+            try:
+                # First call will register, subsequent calls should fail
+                # since the registry already has the pipelines
+                register_all_pipelines(registry=isolated_registry)
+            except ValueError:
+                # Expected for duplicate registrations
+                pass
+            except Exception as e:
+                errors.append(e)
             with lock:
                 call_count.append(1)
 
@@ -260,43 +261,71 @@ class TestRegisterAllPipelinesThreadSafety:
             f"Expected {num_threads} completions, got {len(call_count)}"
         )
 
-        # Registry should have correct pipelines
-        registered = PipelineRegistry.list_pipelines()
-        assert len(registered) > 0, "No pipelines registered"
+        # Verify no unexpected errors
+        assert len(errors) == 0, f"Unexpected errors: {errors}"
 
-        # Call again - should be idempotent
-        initial_count = len(registered)
-        register_all_pipelines()
-        assert len(PipelineRegistry.list_pipelines()) == initial_count, (
-            "register_all_pipelines() is not idempotent"
-        )
+    def test_multiple_registries_parallel(self) -> None:
+        """Multiple isolated registries can be populated in parallel."""
+        num_registries = 5
+        registries: list[PipelineRegistry] = []
+        errors: list[Exception] = []
+
+        def populate_registry() -> PipelineRegistry:
+            """Create and populate a registry."""
+            try:
+                registry = create_registry()
+                register_all_pipelines(registry=registry)
+                return registry
+            except Exception as e:
+                errors.append(e)
+                raise
+
+        with ThreadPoolExecutor(max_workers=num_registries) as executor:
+            futures = [executor.submit(populate_registry) for _ in range(num_registries)]
+            for future in as_completed(futures):
+                registries.append(future.result())
+
+        # All registries should be populated
+        assert len(registries) == num_registries
+        assert len(errors) == 0, f"Errors: {errors}"
+
+        # All registries should have same pipelines
+        first_pipelines = registries[0].list_pipelines()
+        for registry in registries[1:]:
+            assert registry.list_pipelines() == first_pipelines
+
+        # But all registries should be different instances
+        for i, registry1 in enumerate(registries):
+            for j, registry2 in enumerate(registries):
+                if i != j:
+                    assert registry1 is not registry2
 
 
 class TestRegistryLockBehavior:
     """Tests for RLock reentrant behavior."""
 
-    def test_contains_after_list_pipelines(self) -> None:
+    def test_contains_after_list_pipelines(self, isolated_registry) -> None:
         """Sequential calls using lock don't deadlock.
 
         RLock allows reentrant access from same thread.
         """
         factory = create_mock_factory("reentrant_test")
-        PipelineRegistry.register_factory(factory)
+        isolated_registry.register_factory(factory)
 
         # These operations use the same lock internally
-        pipelines = PipelineRegistry.list_pipelines()
+        pipelines = isolated_registry.list_pipelines()
         for name in pipelines:
             # contains() also uses the lock
-            assert PipelineRegistry.contains(name)
+            assert isolated_registry.contains(name)
 
-    def test_get_after_contains(self) -> None:
+    def test_get_after_contains(self, isolated_registry) -> None:
         """get() works after contains() check.
 
         Verifies no lock issues with consecutive operations.
         """
         factory = create_mock_factory("get_test")
-        PipelineRegistry.register_factory(factory)
+        isolated_registry.register_factory(factory)
 
-        if PipelineRegistry.contains("get_test"):
-            definition = PipelineRegistry.get("get_test")
+        if isolated_registry.contains("get_test"):
+            definition = isolated_registry.get("get_test")
             assert definition.factory.pipeline_name == "get_test"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -212,3 +212,50 @@ def circuit_breaker():
     from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
 
     return CircuitBreaker(provider="test", failure_threshold=5, recovery_timeout=60)
+
+
+# =============================================================================
+# Isolated Registry Fixtures for Test Isolation
+# =============================================================================
+
+
+@pytest.fixture
+def isolated_registry():
+    """Create an isolated PipelineRegistry for test isolation.
+
+    Use this fixture for tests that need to register/unregister pipelines
+    without affecting other tests or global state.
+
+    Returns:
+        A new empty PipelineRegistry instance.
+
+    Example:
+        def test_my_feature(isolated_registry):
+            from bioetl.composition.factories.pipeline_factories import register_all_pipelines
+            register_all_pipelines(registry=isolated_registry)
+            # Test uses isolated_registry...
+    """
+    from bioetl.composition.registry import create_registry
+
+    return create_registry()
+
+
+@pytest.fixture
+def populated_isolated_registry(isolated_registry):
+    """Create an isolated PipelineRegistry with all pipelines registered.
+
+    Use this fixture when you need a fully-populated registry that is
+    isolated from other tests. Ideal for parallel test execution.
+
+    Returns:
+        A PipelineRegistry instance with all pipelines registered.
+
+    Example:
+        def test_pipeline_lookup(populated_isolated_registry):
+            definition = populated_isolated_registry.get("chembl_activity")
+            assert definition.factory.pipeline_name == "chembl_activity"
+    """
+    from bioetl.composition.factories.pipeline_factories import register_all_pipelines
+
+    register_all_pipelines(registry=isolated_registry)
+    return isolated_registry

--- a/tests/e2e/test_cli_safety.py
+++ b/tests/e2e/test_cli_safety.py
@@ -14,10 +14,19 @@ def cli_runner():
     return CliRunner()
 
 
-def test_cli_rebuild_requires_confirmation(cli_runner):
+@pytest.fixture
+def mock_registry():
+    """Create a mock registry for CLI tests."""
+    mock = MagicMock()
+    mock.list_pipelines.return_value = ["test_pipe"]
+    mock.contains.return_value = True
+    return mock
+
+
+def test_cli_rebuild_requires_confirmation(cli_runner, mock_registry):
     """Test that rebuild requires confirmation without --yes."""
     with patch("bioetl.interfaces.cli.create_pipeline_runner") as mock_create_runner, \
-         patch("bioetl.composition.registry.PipelineRegistry.list_pipelines", return_value=["test_pipe"]):
+         patch("bioetl.interfaces.cli.get_default_registry", return_value=mock_registry):
 
         result = cli_runner.invoke(cli, ["run", "--pipeline", "test_pipe", "--run-type", "rebuild"])
 
@@ -27,10 +36,10 @@ def test_cli_rebuild_requires_confirmation(cli_runner):
         mock_create_runner.assert_not_called()
 
 
-def test_cli_rebuild_with_yes(cli_runner):
+def test_cli_rebuild_with_yes(cli_runner, mock_registry):
     """Test that rebuild works with --yes."""
     with patch("bioetl.interfaces.cli.create_pipeline_runner") as mock_create_runner, \
-         patch("bioetl.composition.registry.PipelineRegistry.list_pipelines", return_value=["test_pipe"]):
+         patch("bioetl.interfaces.cli.get_default_registry", return_value=mock_registry):
 
         mock_runner = MagicMock()
         mock_runner.run = AsyncMock()  # Make run awaitable
@@ -43,11 +52,11 @@ def test_cli_rebuild_with_yes(cli_runner):
         mock_create_runner.assert_called_once()
 
 
-def test_cli_dry_run_flag(cli_runner):
+def test_cli_dry_run_flag(cli_runner, mock_registry):
     """Test that --dry-run flag shows preview and does NOT execute pipeline."""
     with patch("bioetl.interfaces.cli.create_pipeline_runner") as mock_create_runner, \
          patch("bioetl.interfaces.cli._preview_cleanup") as mock_preview, \
-         patch("bioetl.composition.registry.PipelineRegistry.list_pipelines", return_value=["test_pipe"]):
+         patch("bioetl.interfaces.cli.get_default_registry", return_value=mock_registry):
 
         result = cli_runner.invoke(cli, ["run", "--pipeline", "test_pipe", "--run-type", "rebuild", "--dry-run"])
 

--- a/tests/unit/composition/test_generic_factory.py
+++ b/tests/unit/composition/test_generic_factory.py
@@ -200,7 +200,7 @@ class TestCreatePipelineFactory:
 class TestPipelineRegistryIntegration:
     """Integration tests for PipelineRegistry with GenericPipelineFactory."""
 
-    def test_register_factory_instance(self):
+    def test_register_factory_instance(self, isolated_registry):
         """Test registering factory instance with registry."""
         mock_pipeline_class = MagicMock()
         mock_schema = MagicMock()
@@ -214,11 +214,9 @@ class TestPipelineRegistryIntegration:
             data_source_creator=MagicMock(),
         )
 
-        PipelineRegistry.register_factory(factory)
+        isolated_registry.register_factory(factory)
 
-        definition = PipelineRegistry.get("test_generic")
+        definition = isolated_registry.get("test_generic")
         assert definition.factory is factory
         assert definition.silver_schema is mock_schema
-
-        # Cleanup
-        del PipelineRegistry._registry["test_generic"]
+        # No cleanup needed - isolated_registry is fresh for each test

--- a/tests/unit/composition/test_registry_protocol.py
+++ b/tests/unit/composition/test_registry_protocol.py
@@ -10,61 +10,61 @@ from unittest.mock import MagicMock
 import pytest
 
 from bioetl.composition.factories.pipeline_factories import register_all_pipelines
-from bioetl.composition.registry import PipelineRegistry
+from bioetl.composition.registry import get_default_registry
 
 
 class TestPipelineRegistryUnifiedAPI:
     """Test that PipelineRegistry has unified API methods."""
 
     @pytest.fixture(autouse=True)
-    def setup_and_teardown(self):
-        """Ensure registry is populated and restore after test."""
-        register_all_pipelines()
-        backup = PipelineRegistry._registry.copy()
-
+    def setup_and_teardown(self, isolated_registry):
+        """Ensure registry is populated using isolated registry."""
+        register_all_pipelines(registry=isolated_registry)
+        self.registry = isolated_registry
         yield
-
-        PipelineRegistry._registry.clear()
-        PipelineRegistry._registry.update(backup)
 
     def test_list_keys_returns_list(self):
         """PipelineRegistry.list_keys() should return a list."""
-        keys = PipelineRegistry.list_keys()
+        keys = self.registry.list_keys()
         assert isinstance(keys, list)
 
     def test_list_keys_matches_list_pipelines(self):
         """list_keys() should return same result as list_pipelines()."""
-        assert PipelineRegistry.list_keys() == PipelineRegistry.list_pipelines()
+        assert self.registry.list_keys() == self.registry.list_pipelines()
 
     def test_contains_returns_true_for_registered(self):
         """contains() should return True for registered pipelines."""
-        keys = PipelineRegistry.list_keys()
+        keys = self.registry.list_keys()
         if keys:
-            assert PipelineRegistry.contains(keys[0])
+            assert self.registry.contains(keys[0])
 
     def test_contains_returns_false_for_unknown(self):
         """contains() should return False for unknown pipeline."""
-        assert not PipelineRegistry.contains("unknown_pipeline_xyz")
+        assert not self.registry.contains("unknown_pipeline_xyz")
 
     def test_clear_empties_registry(self):
         """clear() should empty the registry."""
-        initial_count = len(PipelineRegistry.list_keys())
+        initial_count = len(self.registry.list_keys())
         assert initial_count > 0
 
-        PipelineRegistry.clear()
+        self.registry.clear()
 
-        assert len(PipelineRegistry.list_keys()) == 0
+        assert len(self.registry.list_keys()) == 0
 
     def test_register_adds_pipeline(self):
         """register() should add a pipeline to registry."""
+        # Clear first and register a new pipeline
+        self.registry.clear()
+
         mock_factory = MagicMock()
         mock_factory.pipeline_name = "test_pipeline"
         mock_factory.silver_schema = None
+        mock_factory.gold_schema = MagicMock()  # Required
 
-        PipelineRegistry.register("test_pipeline", mock_factory)
+        self.registry.register("test_pipeline", mock_factory)
 
-        assert PipelineRegistry.contains("test_pipeline")
-        definition = PipelineRegistry.get("test_pipeline")
+        assert self.registry.contains("test_pipeline")
+        definition = self.registry.get("test_pipeline")
         assert definition.factory is mock_factory
 
 
@@ -147,15 +147,22 @@ class TestDataSourceRegistryUnifiedAPI:
 class TestUnifiedAPIConsistency:
     """Test that all registries have consistent API."""
 
+    @pytest.fixture(autouse=True)
+    def setup_registry(self, isolated_registry):
+        """Use isolated registry for tests."""
+        register_all_pipelines(registry=isolated_registry)
+        self.registry = isolated_registry
+        yield
+
     def test_both_registries_have_list_keys(self):
         """Both registries should have list_keys() method."""
         from bioetl.composition.factories.data_source_registry import (
             DataSourceRegistry,
         )
 
-        assert hasattr(PipelineRegistry, "list_keys")
+        assert hasattr(self.registry, "list_keys")
         assert hasattr(DataSourceRegistry, "list_keys")
-        assert callable(PipelineRegistry.list_keys)
+        assert callable(self.registry.list_keys)
         assert callable(DataSourceRegistry.list_keys)
 
     def test_both_registries_have_contains(self):
@@ -164,9 +171,9 @@ class TestUnifiedAPIConsistency:
             DataSourceRegistry,
         )
 
-        assert hasattr(PipelineRegistry, "contains")
+        assert hasattr(self.registry, "contains")
         assert hasattr(DataSourceRegistry, "contains")
-        assert callable(PipelineRegistry.contains)
+        assert callable(self.registry.contains)
         assert callable(DataSourceRegistry.contains)
 
     def test_both_registries_have_clear(self):
@@ -175,9 +182,9 @@ class TestUnifiedAPIConsistency:
             DataSourceRegistry,
         )
 
-        assert hasattr(PipelineRegistry, "clear")
+        assert hasattr(self.registry, "clear")
         assert hasattr(DataSourceRegistry, "clear")
-        assert callable(PipelineRegistry.clear)
+        assert callable(self.registry.clear)
         assert callable(DataSourceRegistry.clear)
 
     def test_both_registries_have_get(self):
@@ -186,9 +193,9 @@ class TestUnifiedAPIConsistency:
             DataSourceRegistry,
         )
 
-        assert hasattr(PipelineRegistry, "get")
+        assert hasattr(self.registry, "get")
         assert hasattr(DataSourceRegistry, "get")
-        assert callable(PipelineRegistry.get)
+        assert callable(self.registry.get)
         assert callable(DataSourceRegistry.get)
 
     def test_both_registries_have_register(self):
@@ -197,7 +204,7 @@ class TestUnifiedAPIConsistency:
             DataSourceRegistry,
         )
 
-        assert hasattr(PipelineRegistry, "register")
+        assert hasattr(self.registry, "register")
         assert hasattr(DataSourceRegistry, "register")
-        assert callable(PipelineRegistry.register)
+        assert callable(self.registry.register)
         assert callable(DataSourceRegistry.register)

--- a/tests/unit/interfaces/test_cli.py
+++ b/tests/unit/interfaces/test_cli.py
@@ -29,14 +29,15 @@ def cli_runner() -> CliRunner:
 
 @pytest.fixture
 def mock_registry():
-    """Mock PipelineRegistry for validation tests."""
-    with patch("bioetl.interfaces.cli.PipelineRegistry") as mock:
-        mock.list_pipelines.return_value = [
-            "chembl_activity",
-            "chembl_molecule",
-            "pubchem_compound",
-            "uniprot_protein",
-        ]
+    """Mock default registry for validation tests."""
+    mock = MagicMock()
+    mock.list_pipelines.return_value = [
+        "chembl_activity",
+        "chembl_molecule",
+        "pubchem_compound",
+        "uniprot_protein",
+    ]
+    with patch("bioetl.interfaces.cli.get_default_registry", return_value=mock):
         yield mock
 
 

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -132,7 +132,7 @@ class TestBootstrapPipeline:
         with pytest.raises(ValueError, match="Configuration file not found"):
             bootstrap_pipeline(ctx)
 
-    @patch("bioetl.composition.bootstrap.PipelineRegistry")
+    @patch("bioetl.composition.bootstrap.get_default_registry")
     @patch("bioetl.composition.bootstrap.FilterConfigBuilder")
     @patch("bioetl.composition.bootstrap.load_pipeline_config")
     @patch("bioetl.composition._bootstrap.observability.start_metrics_server")
@@ -147,7 +147,7 @@ class TestBootstrapPipeline:
         mock_start_metrics: MagicMock,
         mock_load_config: MagicMock,
         mock_filter_builder: MagicMock,
-        mock_registry: MagicMock,
+        mock_get_registry: MagicMock,
         mock_logger: MagicMock,
     ) -> None:
         """Test that metrics server failure doesn't block pipeline bootstrap."""
@@ -188,7 +188,9 @@ class TestBootstrapPipeline:
         mock_factory = MagicMock()
         mock_runner = MagicMock()
         mock_factory.create_runner.return_value = mock_runner
+        mock_registry = MagicMock()
         mock_registry.get.return_value.factory = mock_factory
+        mock_get_registry.return_value = mock_registry
 
         ctx = PipelineRunContext(
             pipeline_name="chembl_activity",
@@ -214,9 +216,9 @@ class TestBootstrapPipeline:
         reason="Requires full integration setup - covered by integration tests"
     )
     @patch("bioetl.composition.bootstrap.get_settings")
-    @patch("bioetl.composition.bootstrap.PipelineRegistry")
+    @patch("bioetl.composition.bootstrap.get_default_registry")
     def test_bootstrap_pipeline_chembl_activity(
-        self, mock_registry, mock_get_settings, mock_settings, mock_logger
+        self, mock_get_registry, mock_get_settings, mock_settings, mock_logger
     ):
         """Test bootstrap_pipeline creates chembl_activity pipeline."""
         from bioetl.composition.bootstrap import bootstrap_pipeline
@@ -519,7 +521,7 @@ class TestBootstrapMetrics:
 class TestBootstrapVacuumConfig:
     """Tests for bootstrap_pipeline vacuum configuration merging."""
 
-    @patch("bioetl.composition.bootstrap.PipelineRegistry")
+    @patch("bioetl.composition.bootstrap.get_default_registry")
     @patch("bioetl.composition.bootstrap.FilterConfigBuilder")
     @patch("bioetl.composition.bootstrap.load_pipeline_config")
     @patch("bioetl.composition._bootstrap.observability.start_metrics_server")
@@ -534,7 +536,7 @@ class TestBootstrapVacuumConfig:
         mock_start_metrics: MagicMock,
         mock_load_config: MagicMock,
         mock_filter_builder: MagicMock,
-        mock_registry: MagicMock,
+        mock_get_registry: MagicMock,
     ) -> None:
         """Test that YAML auto_vacuum config is used when CLI doesn't override."""
         from bioetl.composition.bootstrap import bootstrap_pipeline
@@ -574,7 +576,9 @@ class TestBootstrapVacuumConfig:
         mock_factory = MagicMock()
         mock_runner = MagicMock()
         mock_factory.create_runner.return_value = mock_runner
+        mock_registry = MagicMock()
         mock_registry.get.return_value.factory = mock_factory
+        mock_get_registry.return_value = mock_registry
 
         # Context without CLI vacuum options (None)
         ctx = PipelineRunContext(
@@ -593,7 +597,7 @@ class TestBootstrapVacuumConfig:
         assert runtime.vacuum_after_run is True
         assert runtime.vacuum_retention_days == 14
 
-    @patch("bioetl.composition.bootstrap.PipelineRegistry")
+    @patch("bioetl.composition.bootstrap.get_default_registry")
     @patch("bioetl.composition.bootstrap.FilterConfigBuilder")
     @patch("bioetl.composition.bootstrap.load_pipeline_config")
     @patch("bioetl.composition._bootstrap.observability.start_metrics_server")
@@ -608,7 +612,7 @@ class TestBootstrapVacuumConfig:
         mock_start_metrics: MagicMock,
         mock_load_config: MagicMock,
         mock_filter_builder: MagicMock,
-        mock_registry: MagicMock,
+        mock_get_registry: MagicMock,
     ) -> None:
         """Test that CLI vacuum options override YAML config."""
         from bioetl.composition.bootstrap import bootstrap_pipeline
@@ -648,7 +652,9 @@ class TestBootstrapVacuumConfig:
         mock_factory = MagicMock()
         mock_runner = MagicMock()
         mock_factory.create_runner.return_value = mock_runner
+        mock_registry = MagicMock()
         mock_registry.get.return_value.factory = mock_factory
+        mock_get_registry.return_value = mock_registry
 
         # Context with CLI overrides (explicit False and 30 days)
         ctx = PipelineRunContext(

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from bioetl.composition.factories.pipeline_factories import register_all_pipelines
-from bioetl.composition.registry import PipelineRegistry
+from bioetl.composition.registry import get_default_registry
 
 
 @pytest.fixture(autouse=True)
@@ -23,6 +23,8 @@ def test_registry_completeness():
     config_dir = Path("configs/pipelines")
     if not config_dir.exists():
         pytest.skip("Config directory not found")
+
+    registry = get_default_registry()
 
     # Walk through the config directory
     found_configs = []
@@ -44,7 +46,7 @@ def test_registry_completeness():
                     found_configs.append(pipeline_name)
 
     # Get registered pipelines
-    registered_pipelines = PipelineRegistry.list_pipelines()
+    registered_pipelines = registry.list_pipelines()
 
     # Check for missing handlers
     missing_handlers = [
@@ -58,13 +60,14 @@ def test_registry_completeness():
 
 def test_registry_contains_expected_pipelines():
     """Sanity check that key pipelines are present."""
+    registry = get_default_registry()
     expected = [
         "chembl_activity",
         "pubchem_compound",
         "uniprot_protein",
         "pubmed_publications",
     ]
-    registered = PipelineRegistry.list_pipelines()
+    registered = registry.list_pipelines()
 
     for pipe in expected:
         assert pipe in registered, f"Expected pipeline {pipe} not found in registry"
@@ -74,28 +77,62 @@ def test_register_all_pipelines_is_idempotent():
     """Test that calling register_all_pipelines multiple times is safe."""
     from bioetl.composition.factories.pipeline_factories import is_registered
 
+    registry = get_default_registry()
+
     # First call already made in fixture
     assert is_registered()
 
     # Get current count
-    initial_count = len(PipelineRegistry.list_pipelines())
+    initial_count = len(registry.list_pipelines())
 
     # Call again - should be no-op
     register_all_pipelines()
 
     # Count should remain the same
-    assert len(PipelineRegistry.list_pipelines()) == initial_count
+    assert len(registry.list_pipelines()) == initial_count
 
 
-def test_registry_empty_raises_runtime_error():
+def test_registry_empty_raises_runtime_error(isolated_registry):
     """Test that accessing empty registry raises RuntimeError."""
-    # Save current registry and clear it
-    saved_registry = PipelineRegistry._registry.copy()
-    PipelineRegistry._registry.clear()
+    # Use the isolated_registry fixture which is empty
+    with pytest.raises(RuntimeError, match="PipelineRegistry is empty"):
+        isolated_registry.get("any_pipeline")
 
-    try:
-        with pytest.raises(RuntimeError, match="PipelineRegistry is empty"):
-            PipelineRegistry.get("any_pipeline")
-    finally:
-        # Restore registry
-        PipelineRegistry._registry = saved_registry
+
+def test_isolated_registry_is_independent(isolated_registry):
+    """Test that isolated registries are independent of each other."""
+    from bioetl.composition.registry import create_registry
+
+    registry1 = isolated_registry
+    registry2 = create_registry()
+
+    # Both should be empty initially
+    assert len(registry1.list_pipelines()) == 0
+    assert len(registry2.list_pipelines()) == 0
+
+    # Register to one
+    register_all_pipelines(registry=registry1)
+
+    # First registry should be populated
+    assert len(registry1.list_pipelines()) > 0
+
+    # Second registry should still be empty
+    assert len(registry2.list_pipelines()) == 0
+
+
+def test_multiple_registries_in_same_process():
+    """Test that we can create 2 registries in one process."""
+    from bioetl.composition.registry import create_registry
+
+    registry1 = create_registry()
+    registry2 = create_registry()
+
+    register_all_pipelines(registry=registry1)
+    register_all_pipelines(registry=registry2)
+
+    # Both should have the same pipelines
+    assert registry1.list_pipelines() == registry2.list_pipelines()
+
+    # But they should be different instances
+    assert registry1 is not registry2
+    assert registry1._registry is not registry2._registry


### PR DESCRIPTION
…t isolation

This change converts PipelineRegistry from a class-level singleton to an instance-based registry to enable:

- Test isolation: Each test can have its own registry instance
- Parallel pytest execution without manual clear() calls
- Multiple registries in the same process for advanced use cases

Key changes:
- PipelineRegistry now uses instance variables (_registry, _lock) instead of ClassVar
- Added get_default_registry() for backward-compatible access to global instance
- Added create_registry() factory function for creating isolated instances
- register_all_pipelines() now accepts optional registry parameter
- bootstrap_pipeline() accepts optional registry parameter for DI

Test fixtures:
- Added isolated_registry fixture for empty registry instances
- Added populated_isolated_registry for pre-populated instances
- Updated all registry-related tests to use isolated registries

The default global instance maintains full backward compatibility for production code while enabling proper test isolation.