### PR TITLE
Expand E2E tests for edge cases

### DIFF
--- a/tests/e2e/test_pipeline_circuit_breaker_e2e.py
+++ b/tests/e2e/test_pipeline_circuit_breaker_e2e.py
@@ -1,0 +1,478 @@
+"""E2E tests for pipeline circuit breaker behavior.
+
+Tests the circuit breaker pattern for provider failure handling per ADR-007:
+- Circuit opens after consecutive failures
+- Requests blocked while circuit is open
+- Circuit transitions through CLOSED -> OPEN -> HALF_OPEN -> CLOSED
+
+Per RULES.md §4.3 Circuit Breaker:
+- Trigger: 5 consecutive errors
+- Open Duration: 5 minutes
+- Recovery: Half-Open → 1 probe → Closed/Open
+- Metrics: circuit_breaker_state, trips_total
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import httpx
+import pytest
+
+from bioetl.domain.exceptions import CircuitBreakerOpenError
+from bioetl.domain.types import CircuitBreakerState
+from bioetl.infrastructure.adapters.http.circuit_breaker import (
+    CircuitBreaker,
+    is_circuit_breaker_error,
+)
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+class TestCircuitBreakerStateTransitions:
+    """Tests for circuit breaker state transitions."""
+
+    async def test_initial_state_is_closed(self):
+        """E2E: Circuit breaker starts in CLOSED state."""
+        cb = CircuitBreaker(provider="test_provider")
+
+        assert cb.get_state() == CircuitBreakerState.CLOSED
+        assert cb.get_failure_count() == 0
+        assert cb.get_trips_total() == 0
+
+    async def test_successful_calls_keep_circuit_closed(self):
+        """E2E: Successful calls maintain CLOSED state."""
+        cb = CircuitBreaker(provider="test_provider", failure_threshold=5)
+
+        async def success():
+            return "ok"
+
+        for _ in range(10):
+            result = await cb.call(success)
+            assert result == "ok"
+
+        assert cb.get_state() == CircuitBreakerState.CLOSED
+        assert cb.get_failure_count() == 0
+
+    async def test_failures_increment_count(self):
+        """E2E: Failures increment the failure counter."""
+        cb = CircuitBreaker(provider="test_provider", failure_threshold=5)
+
+        async def fail():
+            raise RuntimeError("Provider error")
+
+        for i in range(3):
+            with pytest.raises(RuntimeError):
+                await cb.call(fail)
+
+        assert cb.get_failure_count() == 3
+        assert cb.get_state() == CircuitBreakerState.CLOSED  # Not yet open
+
+    async def test_threshold_failures_open_circuit(self):
+        """E2E: Reaching failure threshold opens circuit."""
+        cb = CircuitBreaker(provider="test_provider", failure_threshold=5)
+
+        async def fail():
+            raise RuntimeError("Provider error")
+
+        for _ in range(5):
+            with pytest.raises(RuntimeError):
+                await cb.call(fail)
+
+        assert cb.get_state() == CircuitBreakerState.OPEN
+        assert cb.get_trips_total() == 1
+
+    async def test_open_circuit_blocks_calls(self):
+        """E2E: Open circuit blocks subsequent calls."""
+        cb = CircuitBreaker(
+            provider="test_provider",
+            failure_threshold=3,
+            recovery_timeout=300,  # Long timeout
+        )
+
+        async def fail():
+            raise RuntimeError("Error")
+
+        # Open the circuit
+        for _ in range(3):
+            with pytest.raises(RuntimeError):
+                await cb.call(fail)
+
+        assert cb.get_state() == CircuitBreakerState.OPEN
+
+        # Next call should be blocked
+        async def would_succeed():
+            return "success"
+
+        with pytest.raises(CircuitBreakerOpenError) as exc_info:
+            await cb.call(would_succeed)
+
+        assert exc_info.value.provider == "test_provider"
+        assert exc_info.value.retry_after > 0
+
+    async def test_half_open_after_timeout(self):
+        """E2E: Circuit transitions to HALF_OPEN after timeout."""
+        cb = CircuitBreaker(
+            provider="test_provider",
+            failure_threshold=3,
+            recovery_timeout=0,  # Immediate recovery for testing
+        )
+
+        async def fail():
+            raise RuntimeError("Error")
+
+        # Open the circuit
+        for _ in range(3):
+            with pytest.raises(RuntimeError):
+                await cb.call(fail)
+
+        assert cb.get_state() == CircuitBreakerState.OPEN
+
+        # Wait for recovery (instant in this test)
+        await asyncio.sleep(0.01)
+
+        # Next successful call should transition to CLOSED
+        async def success():
+            return "ok"
+
+        result = await cb.call(success)
+        assert result == "ok"
+        assert cb.get_state() == CircuitBreakerState.CLOSED
+
+    async def test_half_open_failure_reopens(self):
+        """E2E: Failed probe in HALF_OPEN reopens circuit."""
+        cb = CircuitBreaker(
+            provider="test_provider",
+            failure_threshold=3,
+            recovery_timeout=0,
+        )
+
+        async def fail():
+            raise RuntimeError("Error")
+
+        # Open the circuit
+        for _ in range(3):
+            with pytest.raises(RuntimeError):
+                await cb.call(fail)
+
+        initial_trips = cb.get_trips_total()
+        assert cb.get_state() == CircuitBreakerState.OPEN
+
+        # Wait for recovery
+        await asyncio.sleep(0.01)
+
+        # Probe fails - should reopen
+        with pytest.raises(RuntimeError):
+            await cb.call(fail)
+
+        assert cb.get_state() == CircuitBreakerState.OPEN
+        assert cb.get_trips_total() == initial_trips + 1
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+class TestCircuitBreakerRecovery:
+    """Tests for circuit breaker recovery behavior."""
+
+    async def test_success_resets_failure_count(self):
+        """E2E: Successful call resets consecutive failure count."""
+        cb = CircuitBreaker(provider="test_provider", failure_threshold=5)
+
+        async def fail():
+            raise RuntimeError("Error")
+
+        async def success():
+            return "ok"
+
+        # Accumulate some failures
+        for _ in range(3):
+            with pytest.raises(RuntimeError):
+                await cb.call(fail)
+
+        assert cb.get_failure_count() == 3
+
+        # Successful call resets count
+        await cb.call(success)
+
+        assert cb.get_failure_count() == 0
+        assert cb.get_state() == CircuitBreakerState.CLOSED
+
+    async def test_manual_reset(self):
+        """E2E: Manual reset returns circuit to CLOSED state."""
+        cb = CircuitBreaker(
+            provider="test_provider",
+            failure_threshold=2,
+            recovery_timeout=300,
+        )
+
+        async def fail():
+            raise RuntimeError("Error")
+
+        # Open the circuit
+        for _ in range(2):
+            with pytest.raises(RuntimeError):
+                await cb.call(fail)
+
+        assert cb.get_state() == CircuitBreakerState.OPEN
+
+        # Manual reset
+        cb.reset()
+
+        assert cb.get_state() == CircuitBreakerState.CLOSED
+        assert cb.get_failure_count() == 0
+
+    async def test_force_open(self):
+        """E2E: force_open() manually opens circuit."""
+        cb = CircuitBreaker(provider="test_provider", failure_threshold=5)
+
+        assert cb.get_state() == CircuitBreakerState.CLOSED
+
+        cb.force_open()
+
+        assert cb.get_state() == CircuitBreakerState.OPEN
+        assert cb.get_trips_total() == 1
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+class TestCircuitBreakerErrorClassification:
+    """Tests for error classification in circuit breaker."""
+
+    def test_connection_error_triggers_breaker(self):
+        """E2E: Connection errors trigger circuit breaker."""
+        error = httpx.ConnectError("Connection failed")
+
+        assert is_circuit_breaker_error(error) is True
+
+    def test_timeout_error_triggers_breaker(self):
+        """E2E: Timeout errors trigger circuit breaker."""
+        connect_timeout = httpx.ConnectTimeout("Connection timeout")
+        read_timeout = httpx.ReadTimeout("Read timeout")
+
+        assert is_circuit_breaker_error(connect_timeout) is True
+        assert is_circuit_breaker_error(read_timeout) is True
+
+    def test_server_error_triggers_breaker(self):
+        """E2E: 5xx server errors trigger circuit breaker."""
+        request = httpx.Request("GET", "https://api.example.com")
+        response = httpx.Response(500, request=request)
+        error = httpx.HTTPStatusError("Server error", request=request, response=response)
+
+        assert is_circuit_breaker_error(error) is True
+
+    def test_rate_limit_triggers_breaker(self):
+        """E2E: 429 Rate limit triggers circuit breaker."""
+        request = httpx.Request("GET", "https://api.example.com")
+        response = httpx.Response(429, request=request)
+        error = httpx.HTTPStatusError("Rate limited", request=request, response=response)
+
+        assert is_circuit_breaker_error(error) is True
+
+    def test_client_error_does_not_trigger_breaker(self):
+        """E2E: 4xx client errors (except 429) don't trigger circuit breaker."""
+        request = httpx.Request("GET", "https://api.example.com")
+
+        for status_code in [400, 401, 403, 404, 422]:
+            response = httpx.Response(status_code, request=request)
+            error = httpx.HTTPStatusError("Client error", request=request, response=response)
+            assert is_circuit_breaker_error(error) is False, f"Status {status_code} should not trigger"
+
+    def test_business_error_does_not_trigger_breaker(self):
+        """E2E: Business logic errors don't trigger circuit breaker."""
+        error = ValueError("Invalid data format")
+
+        assert is_circuit_breaker_error(error) is False
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+class TestCircuitBreakerMetrics:
+    """Tests for circuit breaker metrics."""
+
+    async def test_trips_total_increments_on_open(self):
+        """E2E: trips_total increments each time circuit opens."""
+        cb = CircuitBreaker(
+            provider="test_provider",
+            failure_threshold=2,
+            recovery_timeout=0,
+        )
+
+        async def fail():
+            raise RuntimeError("Error")
+
+        async def success():
+            return "ok"
+
+        # First trip
+        for _ in range(2):
+            with pytest.raises(RuntimeError):
+                await cb.call(fail)
+
+        assert cb.get_trips_total() == 1
+
+        # Recover
+        await asyncio.sleep(0.01)
+        await cb.call(success)
+
+        # Second trip
+        for _ in range(2):
+            with pytest.raises(RuntimeError):
+                await cb.call(fail)
+
+        assert cb.get_trips_total() == 2
+
+    async def test_retry_after_calculation(self):
+        """E2E: retry_after correctly calculates remaining timeout."""
+        cb = CircuitBreaker(
+            provider="test_provider",
+            failure_threshold=2,
+            recovery_timeout=10,  # 10 seconds
+        )
+
+        async def fail():
+            raise RuntimeError("Error")
+
+        # Open the circuit
+        for _ in range(2):
+            with pytest.raises(RuntimeError):
+                await cb.call(fail)
+
+        async def probe():
+            return "ok"
+
+        # Try to call - should get retry_after close to 10
+        with pytest.raises(CircuitBreakerOpenError) as exc_info:
+            await cb.call(probe)
+
+        # retry_after should be close to recovery_timeout (accounting for small delays)
+        assert exc_info.value.retry_after > 9.0
+        assert exc_info.value.retry_after <= 10.0
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+class TestCircuitBreakerConcurrency:
+    """Tests for concurrent access to circuit breaker."""
+
+    async def test_concurrent_calls_consistent_state(self):
+        """E2E: Concurrent calls maintain consistent state."""
+        cb = CircuitBreaker(
+            provider="test_provider",
+            failure_threshold=10,
+        )
+        success_count = 0
+        failure_count = 0
+
+        async def mixed_call(should_fail: bool):
+            nonlocal success_count, failure_count
+            if should_fail:
+                raise RuntimeError("Error")
+            return "ok"
+
+        async def worker(worker_id: int):
+            nonlocal success_count, failure_count
+            for i in range(10):
+                try:
+                    should_fail = (worker_id + i) % 3 == 0
+                    result = await cb.call(
+                        lambda: mixed_call(should_fail) if not should_fail else mixed_call(True)
+                    )
+                    success_count += 1
+                except RuntimeError:
+                    failure_count += 1
+                except CircuitBreakerOpenError:
+                    pass
+
+        # Run concurrent workers
+        tasks = [asyncio.create_task(worker(i)) for i in range(5)]
+        await asyncio.gather(*tasks)
+
+        # Circuit should be in a valid state
+        assert cb.get_state() in (
+            CircuitBreakerState.CLOSED,
+            CircuitBreakerState.OPEN,
+            CircuitBreakerState.HALF_OPEN,
+        )
+
+    async def test_rapid_failures_open_circuit(self):
+        """E2E: Rapid failures correctly open circuit."""
+        cb = CircuitBreaker(
+            provider="test_provider",
+            failure_threshold=5,
+        )
+
+        async def fail():
+            raise RuntimeError("Error")
+
+        # Rapid concurrent failures
+        async def fail_many():
+            tasks = [cb.call(fail) for _ in range(10)]
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            return results
+
+        results = await fail_many()
+
+        # All should have failed
+        runtime_errors = [r for r in results if isinstance(r, RuntimeError)]
+        circuit_errors = [r for r in results if isinstance(r, CircuitBreakerOpenError)]
+
+        # Some should be RuntimeError, some CircuitBreakerOpenError
+        assert len(runtime_errors) + len(circuit_errors) == 10
+        assert cb.get_state() == CircuitBreakerState.OPEN
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+class TestCircuitBreakerProviderIsolation:
+    """Tests for provider isolation in circuit breakers."""
+
+    async def test_separate_providers_independent(self):
+        """E2E: Separate providers have independent circuit breakers."""
+        cb_chembl = CircuitBreaker(provider="chembl", failure_threshold=3)
+        cb_pubchem = CircuitBreaker(provider="pubchem", failure_threshold=3)
+
+        async def fail():
+            raise RuntimeError("Error")
+
+        async def success():
+            return "ok"
+
+        # Open ChEMBL circuit
+        for _ in range(3):
+            with pytest.raises(RuntimeError):
+                await cb_chembl.call(fail)
+
+        assert cb_chembl.get_state() == CircuitBreakerState.OPEN
+        assert cb_pubchem.get_state() == CircuitBreakerState.CLOSED
+
+        # PubChem should still work
+        result = await cb_pubchem.call(success)
+        assert result == "ok"
+        assert cb_pubchem.get_state() == CircuitBreakerState.CLOSED
+
+    async def test_provider_name_in_error(self):
+        """E2E: Provider name included in CircuitBreakerOpenError."""
+        cb = CircuitBreaker(
+            provider="test_api_v2",
+            failure_threshold=2,
+            recovery_timeout=60,
+        )
+
+        async def fail():
+            raise RuntimeError("Error")
+
+        for _ in range(2):
+            with pytest.raises(RuntimeError):
+                await cb.call(fail)
+
+        async def probe():
+            return "ok"
+
+        with pytest.raises(CircuitBreakerOpenError) as exc_info:
+            await cb.call(probe)
+
+        assert exc_info.value.provider == "test_api_v2"

--- a/tests/e2e/test_pipeline_graceful_shutdown_e2e.py
+++ b/tests/e2e/test_pipeline_graceful_shutdown_e2e.py
@@ -1,0 +1,397 @@
+"""E2E tests for pipeline graceful shutdown handling.
+
+Tests the pipeline's graceful shutdown behavior per ADR-008:
+- SIGTERM/SIGINT handling via ShutdownSignal
+- Checkpoint saving before exit
+- Current batch completion before shutdown
+
+Per RULES.md §4.4 Graceful Shutdown:
+1. Stop extracting new records
+2. Wait for current batch to complete
+3. Save checkpoint locally
+4. Exit with code 0
+"""
+
+from __future__ import annotations
+
+import asyncio
+import signal
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from bioetl.application.core.shutdown import PipelineShutdownError, ShutdownSignal
+from bioetl.domain.context import PipelineContext
+from bioetl.domain.types import RunType
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+class TestShutdownSignal:
+    """Tests for ShutdownSignal behavior."""
+
+    async def test_shutdown_signal_initial_state(self):
+        """E2E: ShutdownSignal starts in non-requested state."""
+        signal = ShutdownSignal()
+
+        assert signal.is_requested is False
+
+    async def test_shutdown_signal_request_sets_state(self):
+        """E2E: Requesting shutdown sets the signal state."""
+        shutdown = ShutdownSignal()
+
+        shutdown.request()
+
+        assert shutdown.is_requested is True
+
+    async def test_shutdown_signal_request_is_idempotent(self):
+        """E2E: Multiple request() calls have no additional effect."""
+        shutdown = ShutdownSignal()
+
+        shutdown.request()
+        shutdown.request()
+        shutdown.request()
+
+        assert shutdown.is_requested is True
+
+    async def test_shutdown_signal_wait_blocks_until_requested(self):
+        """E2E: wait() blocks until shutdown is requested."""
+        shutdown = ShutdownSignal()
+
+        async def request_after_delay():
+            await asyncio.sleep(0.1)
+            shutdown.request()
+
+        # Start background task to request shutdown
+        task = asyncio.create_task(request_after_delay())
+
+        # Wait should complete after request
+        await asyncio.wait_for(shutdown.wait(), timeout=1.0)
+
+        assert shutdown.is_requested is True
+        await task
+
+    async def test_shutdown_signal_reset(self):
+        """E2E: reset() clears the signal for reuse."""
+        shutdown = ShutdownSignal()
+
+        shutdown.request()
+        assert shutdown.is_requested is True
+
+        shutdown.reset()
+        assert shutdown.is_requested is False
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+class TestOSSignalHandling:
+    """Tests for OS signal handling integration."""
+
+    async def test_setup_shutdown_handlers_registers_sigterm(self):
+        """E2E: setup_shutdown_handlers registers SIGTERM handler."""
+        from bioetl.interfaces.orchestration.signals import setup_shutdown_handlers
+
+        shutdown = ShutdownSignal()
+
+        # Store original handler
+        original_handler = signal.getsignal(signal.SIGTERM)
+
+        try:
+            setup_shutdown_handlers(shutdown, logger=None)
+
+            # Verify handler was set (not the default)
+            current_handler = signal.getsignal(signal.SIGTERM)
+            assert current_handler != signal.SIG_DFL
+        finally:
+            # Restore original handler
+            signal.signal(signal.SIGTERM, original_handler)
+
+    async def test_setup_shutdown_handlers_registers_sigint(self):
+        """E2E: setup_shutdown_handlers registers SIGINT handler."""
+        from bioetl.interfaces.orchestration.signals import setup_shutdown_handlers
+
+        shutdown = ShutdownSignal()
+
+        # Store original handler
+        original_handler = signal.getsignal(signal.SIGINT)
+
+        try:
+            setup_shutdown_handlers(shutdown, logger=None)
+
+            # Verify handler was set
+            current_handler = signal.getsignal(signal.SIGINT)
+            assert current_handler != signal.SIG_DFL
+        finally:
+            # Restore original handler
+            signal.signal(signal.SIGINT, original_handler)
+
+    async def test_signal_handler_logs_warning(self):
+        """E2E: Signal handler logs warning when signal received."""
+        from bioetl.interfaces.orchestration.signals import setup_shutdown_handlers
+
+        shutdown = ShutdownSignal()
+        mock_logger = MagicMock()
+
+        # Store original handler
+        original_handler = signal.getsignal(signal.SIGTERM)
+
+        try:
+            setup_shutdown_handlers(shutdown, logger=mock_logger)
+
+            # Get the handler that was set
+            handler = signal.getsignal(signal.SIGTERM)
+
+            # Call the handler directly (simulate receiving signal)
+            handler(signal.SIGTERM, None)
+
+            # Verify logging
+            mock_logger.warning.assert_called()
+            assert shutdown.is_requested is True
+        finally:
+            signal.signal(signal.SIGTERM, original_handler)
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+class TestGracefulShutdownBehavior:
+    """Tests for graceful shutdown during pipeline execution."""
+
+    async def test_shutdown_stops_iteration(self):
+        """E2E: Shutdown signal stops iteration over records."""
+        shutdown = ShutdownSignal()
+        processed_count = 0
+
+        async def process_with_shutdown_check(records):
+            nonlocal processed_count
+            for i, record in enumerate(records):
+                if shutdown.is_requested:
+                    break
+                processed_count += 1
+                await asyncio.sleep(0.01)  # Simulate processing
+                if i == 5:  # Request shutdown mid-processing
+                    shutdown.request()
+
+        records = list(range(100))
+        await process_with_shutdown_check(records)
+
+        # Should have stopped early
+        assert processed_count == 6  # 0-5 processed, then stopped
+        assert shutdown.is_requested is True
+
+    async def test_current_batch_completes_before_shutdown(self):
+        """E2E: Current batch completes before shutdown is honored."""
+        shutdown = ShutdownSignal()
+        batch_completed = False
+
+        async def process_batch(batch):
+            nonlocal batch_completed
+            # Simulate batch processing
+            for record in batch:
+                await asyncio.sleep(0.01)
+            batch_completed = True
+
+        # Request shutdown before processing
+        shutdown.request()
+
+        # But current batch should still complete
+        await process_batch([1, 2, 3, 4, 5])
+
+        assert batch_completed is True
+
+    async def test_shutdown_waits_for_async_operation(self):
+        """E2E: Shutdown waits for async operation to complete."""
+        shutdown = ShutdownSignal()
+        operation_completed = False
+
+        async def long_running_operation():
+            nonlocal operation_completed
+            await asyncio.sleep(0.2)
+            operation_completed = True
+
+        async def shutdown_coordinator():
+            # Start operation
+            operation_task = asyncio.create_task(long_running_operation())
+
+            # Request shutdown
+            await asyncio.sleep(0.05)
+            shutdown.request()
+
+            # Wait for operation to complete
+            await operation_task
+
+        await shutdown_coordinator()
+
+        assert operation_completed is True
+        assert shutdown.is_requested is True
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+class TestCheckpointSavingOnShutdown:
+    """Tests for checkpoint saving during graceful shutdown."""
+
+    async def test_checkpoint_saved_on_shutdown(self, e2e_data_dir: Path):
+        """E2E: Checkpoint is saved when shutdown is requested."""
+        shutdown = ShutdownSignal()
+        checkpoint_path = e2e_data_dir / "checkpoints" / "test_checkpoint.json"
+        checkpoint_saved = False
+
+        async def save_checkpoint(path: Path, state: dict):
+            nonlocal checkpoint_saved
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text('{"offset": 100}')
+            checkpoint_saved = True
+
+        async def pipeline_with_checkpoint():
+            # Simulate processing
+            for i in range(10):
+                if shutdown.is_requested:
+                    # Save checkpoint on shutdown
+                    await save_checkpoint(checkpoint_path, {"offset": i * 10})
+                    break
+                await asyncio.sleep(0.01)
+
+                if i == 5:
+                    shutdown.request()
+
+        await pipeline_with_checkpoint()
+
+        assert checkpoint_saved is True
+        assert checkpoint_path.exists()
+
+    async def test_shutdown_does_not_lose_data(self, e2e_data_dir: Path):
+        """E2E: Data processed before shutdown is not lost."""
+        shutdown = ShutdownSignal()
+        processed_records: list[int] = []
+
+        async def process_and_track(records):
+            for i, record in enumerate(records):
+                if shutdown.is_requested:
+                    # Still track this record before breaking
+                    processed_records.append(record)
+                    break
+                processed_records.append(record)
+                await asyncio.sleep(0.01)
+
+                if i == 4:
+                    shutdown.request()
+
+        records = list(range(100))
+        await process_and_track(records)
+
+        # All records up to and including shutdown point are tracked
+        assert len(processed_records) == 6  # 0-5
+        assert processed_records == [0, 1, 2, 3, 4, 5]
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+class TestPipelineShutdownError:
+    """Tests for PipelineShutdownError exception."""
+
+    async def test_pipeline_shutdown_error_is_exception(self):
+        """E2E: PipelineShutdownError is a proper exception."""
+        error = PipelineShutdownError()
+
+        assert isinstance(error, Exception)
+
+    async def test_pipeline_shutdown_error_can_be_caught(self):
+        """E2E: PipelineShutdownError can be caught and handled."""
+        caught = False
+
+        async def pipeline_that_shuts_down():
+            raise PipelineShutdownError()
+
+        try:
+            await pipeline_that_shuts_down()
+        except PipelineShutdownError:
+            caught = True
+
+        assert caught is True
+
+    async def test_shutdown_signal_can_trigger_exception(self):
+        """E2E: ShutdownSignal can trigger PipelineShutdownError."""
+        shutdown = ShutdownSignal()
+
+        async def check_shutdown():
+            if shutdown.is_requested:
+                raise PipelineShutdownError()
+
+        shutdown.request()
+
+        with pytest.raises(PipelineShutdownError):
+            await check_shutdown()
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+class TestConcurrentShutdown:
+    """Tests for concurrent operations during shutdown."""
+
+    async def test_multiple_tasks_see_shutdown(self):
+        """E2E: Multiple concurrent tasks can see shutdown signal."""
+        shutdown = ShutdownSignal()
+        task_states = {"task1": False, "task2": False, "task3": False}
+
+        async def worker(name: str):
+            for _ in range(100):
+                if shutdown.is_requested:
+                    task_states[name] = True
+                    return
+                await asyncio.sleep(0.01)
+
+        async def coordinator():
+            # Start workers
+            tasks = [
+                asyncio.create_task(worker("task1")),
+                asyncio.create_task(worker("task2")),
+                asyncio.create_task(worker("task3")),
+            ]
+
+            # Request shutdown after brief delay
+            await asyncio.sleep(0.05)
+            shutdown.request()
+
+            # Wait for all workers
+            await asyncio.gather(*tasks)
+
+        await coordinator()
+
+        # All tasks should have seen the shutdown
+        assert all(task_states.values())
+
+    async def test_shutdown_with_pending_writes(self, e2e_data_dir: Path):
+        """E2E: Shutdown allows pending writes to complete."""
+        shutdown = ShutdownSignal()
+        writes_completed = 0
+        write_lock = asyncio.Lock()
+
+        async def write_record(record_id: int):
+            nonlocal writes_completed
+            async with write_lock:
+                # Simulate I/O
+                await asyncio.sleep(0.02)
+                writes_completed += 1
+
+        async def writer_task():
+            for i in range(20):
+                if shutdown.is_requested and i > 5:
+                    # Only check shutdown after some writes
+                    break
+                await write_record(i)
+
+        async def shutdown_task():
+            await asyncio.sleep(0.05)
+            shutdown.request()
+
+        await asyncio.gather(
+            writer_task(),
+            shutdown_task(),
+        )
+
+        # Some writes should have completed
+        assert writes_completed > 0
+        assert writes_completed <= 20

--- a/tests/e2e/test_pipeline_with_dq_errors_e2e.py
+++ b/tests/e2e/test_pipeline_with_dq_errors_e2e.py
@@ -1,0 +1,528 @@
+"""E2E tests for pipeline behavior with Data Quality errors.
+
+Tests the pipeline's handling of DQ errors at various thresholds:
+- Soft threshold (>5%): Warning logged but pipeline continues
+- Hard threshold (>20%): Pipeline fails with DataQualityThresholdError
+
+Per RULES.md §4.2:
+- Soft threshold: >5% DQ errors → Warning
+- Hard threshold: >20% DQ errors → Fail Batch
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from bioetl.application.core.shutdown import ShutdownSignal
+from bioetl.domain.config import DQConfig, PipelineConfig, RuntimeConfig
+from bioetl.domain.context import PipelineContext
+from bioetl.domain.exceptions import DataQualityError, DataQualityThresholdError
+from bioetl.domain.types import RunType
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class ForcedDQError(DataQualityError):
+    """Test-specific DQ error for simulating failures."""
+
+    def __init__(self, record_id: str) -> None:
+        super().__init__(f"Forced DQ error for record {record_id}")
+
+
+@pytest.fixture
+def strict_dq_config() -> DQConfig:
+    """Create a DQ config with strict thresholds for testing."""
+    return DQConfig(
+        soft_fail_threshold=0.05,  # 5%
+        hard_fail_threshold=0.20,  # 20%
+    )
+
+
+@pytest.fixture
+def lenient_dq_config() -> DQConfig:
+    """Create a lenient DQ config that won't trigger warnings."""
+    return DQConfig(
+        soft_fail_threshold=0.50,  # 50%
+        hard_fail_threshold=0.90,  # 90%
+    )
+
+
+def create_mock_transform_callback(
+    error_rate: float,
+) -> Callable[[PipelineContext, dict[str, Any]], dict[str, Any] | None]:
+    """Create a transform callback that fails at specified rate.
+
+    Args:
+        error_rate: Fraction of records that should fail (0.0 to 1.0)
+
+    Returns:
+        Async transform callback function
+    """
+    call_count = 0
+
+    async def transform(ctx: PipelineContext, record: dict[str, Any]) -> dict[str, Any]:
+        nonlocal call_count
+        call_count += 1
+
+        # Fail records based on error_rate
+        if (call_count % 100) / 100.0 < error_rate:
+            raise ForcedDQError(record.get("id", str(call_count)))
+
+        return {
+            "entity_id": record.get("id", f"entity_{call_count}"),
+            "value": record.get("value", 0),
+            "_run_id": str(uuid4()),
+            "_run_type": "incremental",
+            "_source_batch_id": str(uuid4()),
+            "_ingestion_ts": "2025-01-15T12:00:00Z",
+        }
+
+    return transform
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+class TestDQSoftThreshold:
+    """Tests for DQ soft threshold (warning) behavior."""
+
+    async def test_soft_threshold_logs_warning_but_continues(
+        self, e2e_data_dir: Path
+    ):
+        """E2E: Pipeline logs warning when DQ errors exceed soft threshold.
+
+        When error rate is between soft and hard thresholds (5-20%),
+        the pipeline should log a warning but continue processing.
+        """
+        from bioetl.application.core.batch_metrics import BatchMetricsRecorder
+        from bioetl.application.core.batch_transformer import BatchTransformer
+        from bioetl.application.core.config import RecordProcessorConfig
+        from bioetl.application.core.quarantine_manager import QuarantineManager
+        from bioetl.domain.error_classifier import ErrorClassifier
+        from bioetl.domain.types import BatchID
+
+        # Create mock context with warning tracking
+        mock_logger = MagicMock()
+        mock_logger.bind = MagicMock(return_value=mock_logger)
+        mock_logger.warning = MagicMock()
+
+        context = PipelineContext(
+            run_id=uuid4(),
+            run_type=RunType.INCREMENTAL,
+            logger=mock_logger,
+        )
+
+        # Create config with strict DQ thresholds
+        config = RecordProcessorConfig(
+            pipeline_name="test_dq_soft",
+            provider="test",
+            entity_type="entity",
+            silver_schema=MagicMock(),
+            gold_schema=MagicMock(),
+            dq_config=DQConfig(
+                soft_fail_threshold=0.05,
+                hard_fail_threshold=0.20,
+            ),
+        )
+
+        quarantine_manager = MagicMock(spec=QuarantineManager)
+        quarantine_manager.quarantine_record = AsyncMock()
+
+        # Create transformer with 10% error rate (above soft, below hard)
+        error_count = 0
+
+        async def failing_transform(ctx, record):
+            nonlocal error_count
+            error_count += 1
+            if error_count <= 10:  # First 10 of 100 records fail = 10%
+                raise ForcedDQError(str(error_count))
+            return {
+                "entity_id": f"entity_{error_count}",
+                "value": 1,
+            }
+
+        transformer = BatchTransformer(
+            context=context,
+            config=config,
+            error_classifier=ErrorClassifier(),
+            quarantine_manager=quarantine_manager,
+            batch_metrics=MagicMock(spec=BatchMetricsRecorder),
+            transform_callback=failing_transform,
+            gold_filter_callback=lambda ctx, rec: True,
+            gold_transform_callback=lambda ctx, rec: rec,
+        )
+
+        # Create 100 records
+        records = [{"id": str(i), "value": i} for i in range(100)]
+        batch_id = BatchID(uuid4())
+
+        # Act
+        result = await transformer.transform_batch(records, batch_id)
+
+        # Assert - warning was logged
+        mock_logger.warning.assert_called()
+        warning_calls = [
+            call for call in mock_logger.warning.call_args_list
+            if "DQ Soft Threshold" in str(call)
+        ]
+        assert len(warning_calls) >= 1, "Expected DQ Soft Threshold warning"
+
+        # Assert - records were still processed
+        assert len(result.silver_records) == 90  # 100 - 10 errors
+        assert result.quarantined_count == 10
+
+    async def test_below_soft_threshold_no_warning(self, e2e_data_dir: Path):
+        """E2E: Pipeline does not warn when error rate is below soft threshold."""
+        from bioetl.application.core.batch_metrics import BatchMetricsRecorder
+        from bioetl.application.core.batch_transformer import BatchTransformer
+        from bioetl.application.core.config import RecordProcessorConfig
+        from bioetl.application.core.quarantine_manager import QuarantineManager
+        from bioetl.domain.error_classifier import ErrorClassifier
+        from bioetl.domain.types import BatchID
+
+        mock_logger = MagicMock()
+        mock_logger.bind = MagicMock(return_value=mock_logger)
+        mock_logger.warning = MagicMock()
+
+        context = PipelineContext(
+            run_id=uuid4(),
+            run_type=RunType.INCREMENTAL,
+            logger=mock_logger,
+        )
+
+        config = RecordProcessorConfig(
+            pipeline_name="test_dq_below_soft",
+            provider="test",
+            entity_type="entity",
+            silver_schema=MagicMock(),
+            gold_schema=MagicMock(),
+            dq_config=DQConfig(
+                soft_fail_threshold=0.05,
+                hard_fail_threshold=0.20,
+            ),
+        )
+
+        quarantine_manager = MagicMock(spec=QuarantineManager)
+        quarantine_manager.quarantine_record = AsyncMock()
+
+        # Only 2% error rate (below soft threshold)
+        error_count = 0
+
+        async def low_error_transform(ctx, record):
+            nonlocal error_count
+            error_count += 1
+            if error_count <= 2:  # 2 of 100 = 2%
+                raise ForcedDQError(str(error_count))
+            return {"entity_id": f"entity_{error_count}", "value": 1}
+
+        transformer = BatchTransformer(
+            context=context,
+            config=config,
+            error_classifier=ErrorClassifier(),
+            quarantine_manager=quarantine_manager,
+            batch_metrics=MagicMock(spec=BatchMetricsRecorder),
+            transform_callback=low_error_transform,
+            gold_filter_callback=lambda ctx, rec: True,
+            gold_transform_callback=lambda ctx, rec: rec,
+        )
+
+        records = [{"id": str(i)} for i in range(100)]
+        batch_id = BatchID(uuid4())
+
+        result = await transformer.transform_batch(records, batch_id)
+
+        # Assert - no DQ threshold warning
+        dq_warnings = [
+            call for call in mock_logger.warning.call_args_list
+            if "DQ" in str(call) and "Threshold" in str(call)
+        ]
+        assert len(dq_warnings) == 0, "Should not warn below soft threshold"
+
+        assert len(result.silver_records) == 98
+        assert result.quarantined_count == 2
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+class TestDQHardThreshold:
+    """Tests for DQ hard threshold (failure) behavior."""
+
+    async def test_hard_threshold_raises_error(self, e2e_data_dir: Path):
+        """E2E: Pipeline fails when DQ errors exceed hard threshold.
+
+        When error rate exceeds 20%, the pipeline should raise
+        DataQualityThresholdError and stop processing.
+        """
+        from bioetl.application.core.batch_metrics import BatchMetricsRecorder
+        from bioetl.application.core.batch_transformer import BatchTransformer
+        from bioetl.application.core.config import RecordProcessorConfig
+        from bioetl.application.core.quarantine_manager import QuarantineManager
+        from bioetl.domain.error_classifier import ErrorClassifier
+        from bioetl.domain.types import BatchID
+
+        mock_logger = MagicMock()
+        mock_logger.bind = MagicMock(return_value=mock_logger)
+
+        context = PipelineContext(
+            run_id=uuid4(),
+            run_type=RunType.INCREMENTAL,
+            logger=mock_logger,
+        )
+
+        config = RecordProcessorConfig(
+            pipeline_name="test_dq_hard",
+            provider="test",
+            entity_type="entity",
+            silver_schema=MagicMock(),
+            gold_schema=MagicMock(),
+            dq_config=DQConfig(
+                soft_fail_threshold=0.05,
+                hard_fail_threshold=0.20,
+            ),
+        )
+
+        quarantine_manager = MagicMock(spec=QuarantineManager)
+        quarantine_manager.quarantine_record = AsyncMock()
+
+        # 25% error rate (above hard threshold)
+        error_count = 0
+
+        async def high_error_transform(ctx, record):
+            nonlocal error_count
+            error_count += 1
+            if error_count <= 25:  # 25 of 100 = 25%
+                raise ForcedDQError(str(error_count))
+            return {"entity_id": f"entity_{error_count}", "value": 1}
+
+        transformer = BatchTransformer(
+            context=context,
+            config=config,
+            error_classifier=ErrorClassifier(),
+            quarantine_manager=quarantine_manager,
+            batch_metrics=MagicMock(spec=BatchMetricsRecorder),
+            transform_callback=high_error_transform,
+            gold_filter_callback=lambda ctx, rec: True,
+            gold_transform_callback=lambda ctx, rec: rec,
+        )
+
+        records = [{"id": str(i)} for i in range(100)]
+        batch_id = BatchID(uuid4())
+
+        # Act & Assert
+        with pytest.raises(DataQualityThresholdError) as exc_info:
+            await transformer.transform_batch(records, batch_id)
+
+        assert exc_info.value.error_rate == 0.25
+        assert exc_info.value.threshold == 0.20
+
+    async def test_hard_threshold_exactly_at_limit(self, e2e_data_dir: Path):
+        """E2E: Pipeline fails when error rate equals hard threshold exactly."""
+        from bioetl.application.core.batch_metrics import BatchMetricsRecorder
+        from bioetl.application.core.batch_transformer import BatchTransformer
+        from bioetl.application.core.config import RecordProcessorConfig
+        from bioetl.application.core.quarantine_manager import QuarantineManager
+        from bioetl.domain.error_classifier import ErrorClassifier
+        from bioetl.domain.types import BatchID
+
+        mock_logger = MagicMock()
+        mock_logger.bind = MagicMock(return_value=mock_logger)
+
+        context = PipelineContext(
+            run_id=uuid4(),
+            run_type=RunType.INCREMENTAL,
+            logger=mock_logger,
+        )
+
+        config = RecordProcessorConfig(
+            pipeline_name="test_dq_exact",
+            provider="test",
+            entity_type="entity",
+            silver_schema=MagicMock(),
+            gold_schema=MagicMock(),
+            dq_config=DQConfig(
+                soft_fail_threshold=0.05,
+                hard_fail_threshold=0.20,
+            ),
+        )
+
+        quarantine_manager = MagicMock(spec=QuarantineManager)
+        quarantine_manager.quarantine_record = AsyncMock()
+
+        # Exactly 20% error rate
+        error_count = 0
+
+        async def exact_threshold_transform(ctx, record):
+            nonlocal error_count
+            error_count += 1
+            if error_count <= 20:  # 20 of 100 = exactly 20%
+                raise ForcedDQError(str(error_count))
+            return {"entity_id": f"entity_{error_count}", "value": 1}
+
+        transformer = BatchTransformer(
+            context=context,
+            config=config,
+            error_classifier=ErrorClassifier(),
+            quarantine_manager=quarantine_manager,
+            batch_metrics=MagicMock(spec=BatchMetricsRecorder),
+            transform_callback=exact_threshold_transform,
+            gold_filter_callback=lambda ctx, rec: True,
+            gold_transform_callback=lambda ctx, rec: rec,
+        )
+
+        records = [{"id": str(i)} for i in range(100)]
+        batch_id = BatchID(uuid4())
+
+        # Exactly at threshold should fail (>= check)
+        with pytest.raises(DataQualityThresholdError):
+            await transformer.transform_batch(records, batch_id)
+
+    async def test_just_below_hard_threshold_succeeds(self, e2e_data_dir: Path):
+        """E2E: Pipeline continues when error rate is just below hard threshold."""
+        from bioetl.application.core.batch_metrics import BatchMetricsRecorder
+        from bioetl.application.core.batch_transformer import BatchTransformer
+        from bioetl.application.core.config import RecordProcessorConfig
+        from bioetl.application.core.quarantine_manager import QuarantineManager
+        from bioetl.domain.error_classifier import ErrorClassifier
+        from bioetl.domain.types import BatchID
+
+        mock_logger = MagicMock()
+        mock_logger.bind = MagicMock(return_value=mock_logger)
+
+        context = PipelineContext(
+            run_id=uuid4(),
+            run_type=RunType.INCREMENTAL,
+            logger=mock_logger,
+        )
+
+        config = RecordProcessorConfig(
+            pipeline_name="test_dq_below_hard",
+            provider="test",
+            entity_type="entity",
+            silver_schema=MagicMock(),
+            gold_schema=MagicMock(),
+            dq_config=DQConfig(
+                soft_fail_threshold=0.05,
+                hard_fail_threshold=0.20,
+            ),
+        )
+
+        quarantine_manager = MagicMock(spec=QuarantineManager)
+        quarantine_manager.quarantine_record = AsyncMock()
+
+        # 19% error rate (just below hard threshold)
+        error_count = 0
+
+        async def below_hard_transform(ctx, record):
+            nonlocal error_count
+            error_count += 1
+            if error_count <= 19:  # 19 of 100 = 19%
+                raise ForcedDQError(str(error_count))
+            return {"entity_id": f"entity_{error_count}", "value": 1}
+
+        transformer = BatchTransformer(
+            context=context,
+            config=config,
+            error_classifier=ErrorClassifier(),
+            quarantine_manager=quarantine_manager,
+            batch_metrics=MagicMock(spec=BatchMetricsRecorder),
+            transform_callback=below_hard_transform,
+            gold_filter_callback=lambda ctx, rec: True,
+            gold_transform_callback=lambda ctx, rec: rec,
+        )
+
+        records = [{"id": str(i)} for i in range(100)]
+        batch_id = BatchID(uuid4())
+
+        # Should succeed (with warning since above soft threshold)
+        result = await transformer.transform_batch(records, batch_id)
+
+        assert len(result.silver_records) == 81  # 100 - 19
+        assert result.quarantined_count == 19
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+class TestDQQuarantineBehavior:
+    """Tests for quarantine behavior during DQ errors."""
+
+    async def test_quarantined_records_not_in_silver(self, e2e_data_dir: Path):
+        """E2E: Quarantined records should not appear in Silver output."""
+        from bioetl.application.core.batch_metrics import BatchMetricsRecorder
+        from bioetl.application.core.batch_transformer import BatchTransformer
+        from bioetl.application.core.config import RecordProcessorConfig
+        from bioetl.application.core.quarantine_manager import QuarantineManager
+        from bioetl.domain.error_classifier import ErrorClassifier
+        from bioetl.domain.types import BatchID
+
+        mock_logger = MagicMock()
+        mock_logger.bind = MagicMock(return_value=mock_logger)
+
+        context = PipelineContext(
+            run_id=uuid4(),
+            run_type=RunType.INCREMENTAL,
+            logger=mock_logger,
+        )
+
+        config = RecordProcessorConfig(
+            pipeline_name="test_quarantine",
+            provider="test",
+            entity_type="entity",
+            silver_schema=MagicMock(),
+            gold_schema=MagicMock(),
+            dq_config=DQConfig(
+                soft_fail_threshold=0.50,
+                hard_fail_threshold=0.90,
+            ),
+        )
+
+        quarantined_records: list[dict] = []
+        quarantine_manager = MagicMock(spec=QuarantineManager)
+
+        async def capture_quarantine(record, error_type, batch_id, error_msg, **kwargs):
+            quarantined_records.append(record)
+
+        quarantine_manager.quarantine_record = AsyncMock(side_effect=capture_quarantine)
+
+        # Fail specific records
+        failed_ids = {"2", "5", "7"}
+
+        async def selective_transform(ctx, record):
+            if record["id"] in failed_ids:
+                raise ForcedDQError(record["id"])
+            return {"entity_id": f"entity_{record['id']}", "value": 1}
+
+        transformer = BatchTransformer(
+            context=context,
+            config=config,
+            error_classifier=ErrorClassifier(),
+            quarantine_manager=quarantine_manager,
+            batch_metrics=MagicMock(spec=BatchMetricsRecorder),
+            transform_callback=selective_transform,
+            gold_filter_callback=lambda ctx, rec: True,
+            gold_transform_callback=lambda ctx, rec: rec,
+        )
+
+        records = [{"id": str(i)} for i in range(10)]
+        batch_id = BatchID(uuid4())
+
+        result = await transformer.transform_batch(records, batch_id)
+
+        # Verify counts
+        assert len(result.silver_records) == 7
+        assert result.quarantined_count == 3
+        assert len(quarantined_records) == 3
+
+        # Verify failed IDs are not in silver
+        silver_ids = {r["entity_id"] for r in result.silver_records}
+        for failed_id in failed_ids:
+            assert f"entity_{failed_id}" not in silver_ids
+
+        # Verify failed IDs are in quarantine
+        quarantine_ids = {r["id"] for r in quarantined_records}
+        assert quarantine_ids == failed_ids

--- a/tests/e2e/test_pipeline_with_schema_drift_e2e.py
+++ b/tests/e2e/test_pipeline_with_schema_drift_e2e.py
@@ -1,0 +1,560 @@
+"""E2E tests for pipeline schema evolution handling.
+
+Tests the pipeline's handling of schema drift scenarios:
+- New fields added to incoming data (schema evolution)
+- Fields removed from incoming data
+- Schema mismatch handling modes: error, evolve, ignore
+
+Per domain/config.py TableConfig:
+- on_schema_mismatch: Literal["error", "evolve", "ignore"] = "error"
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pyarrow as pa
+import pytest
+
+from bioetl.domain.exceptions import SchemaEvolutionError
+from bioetl.infrastructure.observability.noop_logger import NoOpLogger
+
+
+@pytest.fixture
+def base_schema() -> pa.Schema:
+    """Create base schema for testing."""
+    return pa.schema([
+        pa.field("entity_id", pa.string()),
+        pa.field("name", pa.string()),
+        pa.field("value", pa.float64()),
+        pa.field("_run_id", pa.string()),
+        pa.field("_run_type", pa.string()),
+        pa.field("_source_batch_id", pa.string()),
+        pa.field("_ingestion_ts", pa.string()),
+    ])
+
+
+@pytest.fixture
+def evolved_schema() -> pa.Schema:
+    """Create schema with additional field (evolution)."""
+    return pa.schema([
+        pa.field("entity_id", pa.string()),
+        pa.field("name", pa.string()),
+        pa.field("value", pa.float64()),
+        pa.field("new_field", pa.string()),  # New field added
+        pa.field("_run_id", pa.string()),
+        pa.field("_run_type", pa.string()),
+        pa.field("_source_batch_id", pa.string()),
+        pa.field("_ingestion_ts", pa.string()),
+    ])
+
+
+@pytest.fixture
+def base_records() -> list[dict[str, Any]]:
+    """Create records matching base schema."""
+    return [
+        {
+            "entity_id": "entity_1",
+            "name": "Test Entity 1",
+            "value": 1.0,
+            "_run_id": str(uuid4()),
+            "_run_type": "incremental",
+            "_source_batch_id": str(uuid4()),
+            "_ingestion_ts": "2025-01-15T12:00:00Z",
+        },
+        {
+            "entity_id": "entity_2",
+            "name": "Test Entity 2",
+            "value": 2.0,
+            "_run_id": str(uuid4()),
+            "_run_type": "incremental",
+            "_source_batch_id": str(uuid4()),
+            "_ingestion_ts": "2025-01-15T12:00:00Z",
+        },
+    ]
+
+
+@pytest.fixture
+def evolved_records() -> list[dict[str, Any]]:
+    """Create records with new field (schema evolution)."""
+    return [
+        {
+            "entity_id": "entity_3",
+            "name": "Test Entity 3",
+            "value": 3.0,
+            "new_field": "extra_data",  # New field
+            "_run_id": str(uuid4()),
+            "_run_type": "incremental",
+            "_source_batch_id": str(uuid4()),
+            "_ingestion_ts": "2025-01-15T12:00:00Z",
+        },
+    ]
+
+
+@pytest.fixture
+def reduced_records() -> list[dict[str, Any]]:
+    """Create records missing a field (schema reduction)."""
+    return [
+        {
+            "entity_id": "entity_4",
+            # "name" field is missing
+            "value": 4.0,
+            "_run_id": str(uuid4()),
+            "_run_type": "incremental",
+            "_source_batch_id": str(uuid4()),
+            "_ingestion_ts": "2025-01-15T12:00:00Z",
+        },
+    ]
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+class TestSchemaEvolutionErrorMode:
+    """Tests for schema drift with on_schema_mismatch='error' mode."""
+
+    async def test_schema_drift_error_mode_raises_on_new_field(
+        self, e2e_data_dir: Path, base_schema: pa.Schema, base_records, evolved_records
+    ):
+        """E2E: Schema drift with 'error' mode raises SchemaEvolutionError.
+
+        When on_schema_mismatch='error' and incoming data has new fields,
+        the write operation should fail with SchemaEvolutionError.
+        """
+        from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+
+        logger = NoOpLogger()
+        table_name = "test_schema_error"
+        table_path = e2e_data_dir / "silver" / table_name
+
+        writer = DeltaWriter(
+            base_path=str(e2e_data_dir / "silver"),
+            logger=logger,
+        )
+
+        # First write establishes the schema
+        await writer.write_silver(
+            table_name=table_name,
+            records=base_records,
+            primary_keys=["entity_id"],
+            schema=base_schema,
+            mode="merge",
+            on_schema_mismatch="error",
+        )
+
+        # Verify table was created
+        assert table_path.exists()
+
+        # Second write with new field should fail
+        with pytest.raises(SchemaEvolutionError) as exc_info:
+            await writer.write_silver(
+                table_name=table_name,
+                records=evolved_records,
+                primary_keys=["entity_id"],
+                schema=base_schema,  # Using original schema
+                mode="merge",
+                on_schema_mismatch="error",
+            )
+
+        assert "new_field" in str(exc_info.value.new_fields)
+
+    async def test_schema_drift_error_mode_raises_on_removed_field(
+        self, e2e_data_dir: Path, base_schema: pa.Schema, base_records, reduced_records
+    ):
+        """E2E: Schema drift with 'error' mode raises on removed field."""
+        from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+
+        logger = NoOpLogger()
+        table_name = "test_schema_removed"
+
+        writer = DeltaWriter(
+            base_path=str(e2e_data_dir / "silver"),
+            logger=logger,
+        )
+
+        # First write establishes the schema
+        await writer.write_silver(
+            table_name=table_name,
+            records=base_records,
+            primary_keys=["entity_id"],
+            schema=base_schema,
+            mode="merge",
+            on_schema_mismatch="error",
+        )
+
+        # Second write with missing field should fail
+        with pytest.raises(SchemaEvolutionError) as exc_info:
+            await writer.write_silver(
+                table_name=table_name,
+                records=reduced_records,
+                primary_keys=["entity_id"],
+                schema=base_schema,
+                mode="merge",
+                on_schema_mismatch="error",
+            )
+
+        assert "name" in str(exc_info.value.removed_fields)
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+class TestSchemaEvolutionEvolveMode:
+    """Tests for schema drift with on_schema_mismatch='evolve' mode."""
+
+    async def test_schema_evolve_mode_allows_new_fields(
+        self, e2e_data_dir: Path, base_schema: pa.Schema, evolved_schema: pa.Schema,
+        base_records, evolved_records
+    ):
+        """E2E: Schema evolution with 'evolve' mode allows new fields.
+
+        When on_schema_mismatch='evolve', new fields should be added
+        to the table schema and data written successfully.
+        """
+        from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+        from deltalake import DeltaTable
+
+        logger = NoOpLogger()
+        table_name = "test_schema_evolve"
+        table_path = e2e_data_dir / "silver" / table_name
+
+        writer = DeltaWriter(
+            base_path=str(e2e_data_dir / "silver"),
+            logger=logger,
+        )
+
+        # First write establishes the base schema
+        await writer.write_silver(
+            table_name=table_name,
+            records=base_records,
+            primary_keys=["entity_id"],
+            schema=base_schema,
+            mode="merge",
+            on_schema_mismatch="evolve",
+        )
+
+        initial_count = len(DeltaTable(str(table_path)).to_pyarrow_table())
+        assert initial_count == 2
+
+        # Second write with evolved schema (new field)
+        await writer.write_silver(
+            table_name=table_name,
+            records=evolved_records,
+            primary_keys=["entity_id"],
+            schema=evolved_schema,
+            mode="merge",
+            on_schema_mismatch="evolve",
+        )
+
+        # Verify records were added
+        dt = DeltaTable(str(table_path))
+        final_count = len(dt.to_pyarrow_table())
+        assert final_count == 3  # 2 original + 1 new
+
+    async def test_schema_evolve_mode_logs_warning(
+        self, e2e_data_dir: Path, base_schema: pa.Schema, evolved_schema: pa.Schema,
+        base_records, evolved_records
+    ):
+        """E2E: Schema evolution logs warning about drift."""
+        from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+
+        mock_logger = MagicMock()
+        mock_logger.warning = MagicMock()
+        mock_logger.debug = MagicMock()
+        table_name = "test_schema_evolve_log"
+
+        writer = DeltaWriter(
+            base_path=str(e2e_data_dir / "silver"),
+            logger=mock_logger,
+        )
+
+        # First write
+        await writer.write_silver(
+            table_name=table_name,
+            records=base_records,
+            primary_keys=["entity_id"],
+            schema=base_schema,
+            mode="merge",
+            on_schema_mismatch="evolve",
+        )
+
+        # Second write with new field
+        await writer.write_silver(
+            table_name=table_name,
+            records=evolved_records,
+            primary_keys=["entity_id"],
+            schema=evolved_schema,
+            mode="merge",
+            on_schema_mismatch="evolve",
+        )
+
+        # Verify warning was logged
+        warning_calls = [
+            call for call in mock_logger.warning.call_args_list
+            if "Schema drift" in str(call)
+        ]
+        assert len(warning_calls) >= 1
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+class TestSchemaEvolutionIgnoreMode:
+    """Tests for schema drift with on_schema_mismatch='ignore' mode."""
+
+    async def test_schema_ignore_mode_proceeds_silently(
+        self, e2e_data_dir: Path, base_schema: pa.Schema, base_records, evolved_records
+    ):
+        """E2E: Schema ignore mode proceeds without error.
+
+        When on_schema_mismatch='ignore', schema drift is detected
+        but processing continues without modification.
+        """
+        from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+        from deltalake import DeltaTable
+
+        logger = NoOpLogger()
+        table_name = "test_schema_ignore"
+        table_path = e2e_data_dir / "silver" / table_name
+
+        writer = DeltaWriter(
+            base_path=str(e2e_data_dir / "silver"),
+            logger=logger,
+        )
+
+        # First write
+        await writer.write_silver(
+            table_name=table_name,
+            records=base_records,
+            primary_keys=["entity_id"],
+            schema=base_schema,
+            mode="merge",
+            on_schema_mismatch="ignore",
+        )
+
+        initial_count = len(DeltaTable(str(table_path)).to_pyarrow_table())
+
+        # Second write with evolved records - should not raise
+        await writer.write_silver(
+            table_name=table_name,
+            records=evolved_records,
+            primary_keys=["entity_id"],
+            schema=base_schema,  # Original schema
+            mode="merge",
+            on_schema_mismatch="ignore",
+        )
+
+        # Records should be written (new_field filtered out)
+        dt = DeltaTable(str(table_path))
+        final_count = len(dt.to_pyarrow_table())
+        assert final_count == 3
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+class TestSchemaEvolutionEdgeCases:
+    """Tests for edge cases in schema evolution."""
+
+    async def test_first_write_no_existing_table(
+        self, e2e_data_dir: Path, base_schema: pa.Schema, base_records
+    ):
+        """E2E: First write creates table without schema drift check."""
+        from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+        from deltalake import DeltaTable
+
+        logger = NoOpLogger()
+        table_name = "test_new_table"
+        table_path = e2e_data_dir / "silver" / table_name
+
+        writer = DeltaWriter(
+            base_path=str(e2e_data_dir / "silver"),
+            logger=logger,
+        )
+
+        # Table doesn't exist yet
+        assert not table_path.exists()
+
+        # First write should succeed regardless of on_schema_mismatch
+        await writer.write_silver(
+            table_name=table_name,
+            records=base_records,
+            primary_keys=["entity_id"],
+            schema=base_schema,
+            mode="merge",
+            on_schema_mismatch="error",  # Error mode but no existing table
+        )
+
+        # Table should now exist
+        assert table_path.exists()
+        dt = DeltaTable(str(table_path))
+        assert len(dt.to_pyarrow_table()) == 2
+
+    async def test_same_schema_no_drift(
+        self, e2e_data_dir: Path, base_schema: pa.Schema, base_records
+    ):
+        """E2E: Same schema in subsequent writes does not trigger drift."""
+        from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+
+        mock_logger = MagicMock()
+        mock_logger.warning = MagicMock()
+        mock_logger.debug = MagicMock()
+        table_name = "test_no_drift"
+
+        writer = DeltaWriter(
+            base_path=str(e2e_data_dir / "silver"),
+            logger=mock_logger,
+        )
+
+        # First write
+        await writer.write_silver(
+            table_name=table_name,
+            records=base_records,
+            primary_keys=["entity_id"],
+            schema=base_schema,
+            mode="merge",
+            on_schema_mismatch="error",
+        )
+
+        # Second write with same schema
+        more_records = [
+            {
+                "entity_id": "entity_5",
+                "name": "Test Entity 5",
+                "value": 5.0,
+                "_run_id": str(uuid4()),
+                "_run_type": "incremental",
+                "_source_batch_id": str(uuid4()),
+                "_ingestion_ts": "2025-01-15T12:00:00Z",
+            },
+        ]
+
+        # Should succeed without warning
+        await writer.write_silver(
+            table_name=table_name,
+            records=more_records,
+            primary_keys=["entity_id"],
+            schema=base_schema,
+            mode="merge",
+            on_schema_mismatch="error",
+        )
+
+        # No schema drift warnings
+        drift_warnings = [
+            call for call in mock_logger.warning.call_args_list
+            if "Schema drift" in str(call)
+        ]
+        assert len(drift_warnings) == 0
+
+    async def test_multiple_schema_evolutions(
+        self, e2e_data_dir: Path, base_schema: pa.Schema
+    ):
+        """E2E: Multiple schema evolutions are handled correctly."""
+        from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+        from deltalake import DeltaTable
+
+        logger = NoOpLogger()
+        table_name = "test_multi_evolve"
+        table_path = e2e_data_dir / "silver" / table_name
+
+        writer = DeltaWriter(
+            base_path=str(e2e_data_dir / "silver"),
+            logger=logger,
+        )
+
+        # First write - base schema
+        records_v1 = [
+            {
+                "entity_id": "v1",
+                "name": "Version 1",
+                "value": 1.0,
+                "_run_id": str(uuid4()),
+                "_run_type": "incremental",
+                "_source_batch_id": str(uuid4()),
+                "_ingestion_ts": "2025-01-15T12:00:00Z",
+            },
+        ]
+
+        await writer.write_silver(
+            table_name=table_name,
+            records=records_v1,
+            primary_keys=["entity_id"],
+            schema=base_schema,
+            mode="merge",
+            on_schema_mismatch="evolve",
+        )
+
+        # Second write - add field_a
+        schema_v2 = pa.schema([
+            pa.field("entity_id", pa.string()),
+            pa.field("name", pa.string()),
+            pa.field("value", pa.float64()),
+            pa.field("field_a", pa.string()),  # New field
+            pa.field("_run_id", pa.string()),
+            pa.field("_run_type", pa.string()),
+            pa.field("_source_batch_id", pa.string()),
+            pa.field("_ingestion_ts", pa.string()),
+        ])
+
+        records_v2 = [
+            {
+                "entity_id": "v2",
+                "name": "Version 2",
+                "value": 2.0,
+                "field_a": "added_a",
+                "_run_id": str(uuid4()),
+                "_run_type": "incremental",
+                "_source_batch_id": str(uuid4()),
+                "_ingestion_ts": "2025-01-15T12:00:00Z",
+            },
+        ]
+
+        await writer.write_silver(
+            table_name=table_name,
+            records=records_v2,
+            primary_keys=["entity_id"],
+            schema=schema_v2,
+            mode="merge",
+            on_schema_mismatch="evolve",
+        )
+
+        # Third write - add field_b
+        schema_v3 = pa.schema([
+            pa.field("entity_id", pa.string()),
+            pa.field("name", pa.string()),
+            pa.field("value", pa.float64()),
+            pa.field("field_a", pa.string()),
+            pa.field("field_b", pa.int64()),  # Another new field
+            pa.field("_run_id", pa.string()),
+            pa.field("_run_type", pa.string()),
+            pa.field("_source_batch_id", pa.string()),
+            pa.field("_ingestion_ts", pa.string()),
+        ])
+
+        records_v3 = [
+            {
+                "entity_id": "v3",
+                "name": "Version 3",
+                "value": 3.0,
+                "field_a": "still_a",
+                "field_b": 42,
+                "_run_id": str(uuid4()),
+                "_run_type": "incremental",
+                "_source_batch_id": str(uuid4()),
+                "_ingestion_ts": "2025-01-15T12:00:00Z",
+            },
+        ]
+
+        await writer.write_silver(
+            table_name=table_name,
+            records=records_v3,
+            primary_keys=["entity_id"],
+            schema=schema_v3,
+            mode="merge",
+            on_schema_mismatch="evolve",
+        )
+
+        # Verify all records present
+        dt = DeltaTable(str(table_path))
+        table = dt.to_pyarrow_table()
+        assert len(table) == 3


### PR DESCRIPTION
Add comprehensive E2E tests covering:

- DQ errors: test_pipeline_with_dq_errors_e2e.py
  - Soft threshold (>5%) triggers warning but continues
  - Hard threshold (>20%) raises DataQualityThresholdError
  - Quarantine behavior verification

- Schema drift: test_pipeline_with_schema_drift_e2e.py
  - on_schema_mismatch='error' raises SchemaEvolutionError
  - on_schema_mismatch='evolve' allows schema evolution
  - on_schema_mismatch='ignore' proceeds silently

- Graceful shutdown: test_pipeline_graceful_shutdown_e2e.py
  - ShutdownSignal state management
  - SIGTERM/SIGINT handler registration
  - Checkpoint saving on shutdown

- Circuit breaker: test_pipeline_circuit_breaker_e2e.py
  - State transitions (CLOSED -> OPEN -> HALF_OPEN)
  - Error classification (connection, timeout, 5xx, 429)
  - Provider isolation and metrics

Total E2E tests: 80 (previously 32)