### PR TITLE
Add missing docstrings to BioETL project

### DIFF
--- a/src/bioetl/composition/factories/data_source_factory.py
+++ b/src/bioetl/composition/factories/data_source_factory.py
@@ -159,6 +159,26 @@ class DataSourceRegistry:
             metrics: MetricsPort | None = None,
             pipeline_name: str = "unknown",
         ) -> DataSourcePort:
+            """Create a data source for the captured provider name.
+
+            This closure captures the provider name from the outer scope and
+            delegates creation to ProviderRegistry.create_data_source().
+
+            Args:
+                settings: Application settings for configuration.
+                pipeline_config: Pipeline-specific YAML configuration.
+                logger: LoggerPort for structured logging.
+                filter_config: Optional input filtering configuration.
+                metrics: Optional MetricsPort for observability.
+                pipeline_name: Pipeline identifier for logging context.
+
+            Returns:
+                DataSourcePort implementation for the provider.
+
+            Note:
+                This is a backward-compatibility wrapper. For new code, prefer
+                using ProviderRegistry.create_data_source() directly.
+            """
             return ProviderRegistry.create_data_source(
                 name=provider,
                 settings=settings,

--- a/src/bioetl/composition/providers/decorators.py
+++ b/src/bioetl/composition/providers/decorators.py
@@ -78,6 +78,22 @@ def register_provider(
     """
 
     def decorator(cls: type[T]) -> type[T]:
+        """Inner decorator that performs provider registration.
+
+        Captures configuration from the outer scope and registers the
+        decorated class with ProviderRegistry. Also injects __provider_name__
+        attribute for runtime introspection.
+
+        Args:
+            cls: The adapter class being decorated.
+
+        Returns:
+            The original class unchanged (registration is a side effect).
+
+        Side effects:
+            - Registers provider in ProviderRegistry with captured config
+            - Adds __provider_name__ attribute to the class
+        """
         # Создаём HTTP конфигурацию
         http_config: HttpConfig | None = None
         if requires_http_client:

--- a/src/bioetl/domain/exceptions/base.py
+++ b/src/bioetl/domain/exceptions/base.py
@@ -109,9 +109,18 @@ class CriticalError(BioETLError):
     system resource exhaustion.
     """
 
-    # Default for CriticalError subclasses that don't override
     @classmethod
     def get_error_type(cls) -> ErrorType:
+        """Get the default error type for critical errors.
+
+        Returns:
+            ErrorType.DB_UNAVAILABLE as the default for CriticalError subclasses
+            that don't define their own error_type. This signals that the error
+            is fatal and the pipeline should stop immediately.
+
+        Note:
+            Subclasses may override by defining a class-level error_type attribute.
+        """
         from bioetl.domain.types import ErrorType
 
         return getattr(cls, "error_type", ErrorType.DB_UNAVAILABLE)
@@ -126,6 +135,16 @@ class RecoverableError(BioETLError):
 
     @classmethod
     def get_error_type(cls) -> ErrorType:
+        """Get the default error type for recoverable errors.
+
+        Returns:
+            ErrorType.NETWORK_ERROR as the default for RecoverableError subclasses
+            that don't define their own error_type. This signals that the error
+            is transient and retry with exponential backoff is appropriate (§3.1.3).
+
+        Note:
+            Subclasses may override by defining a class-level error_type attribute.
+        """
         from bioetl.domain.types import ErrorType
 
         return getattr(cls, "error_type", ErrorType.NETWORK_ERROR)
@@ -141,6 +160,16 @@ class DataQualityError(BioETLError):
 
     @classmethod
     def get_error_type(cls) -> ErrorType:
+        """Get the default error type for data quality errors.
+
+        Returns:
+            ErrorType.INVALID_DATA as the default for DataQualityError subclasses
+            that don't define their own error_type. This signals that the record
+            should be quarantined (§2.6) and processing should continue.
+
+        Note:
+            Subclasses may override by defining a class-level error_type attribute.
+        """
         from bioetl.domain.types import ErrorType
 
         return getattr(cls, "error_type", ErrorType.INVALID_DATA)

--- a/src/bioetl/infrastructure/storage/delta_writer.py
+++ b/src/bioetl/infrastructure/storage/delta_writer.py
@@ -122,6 +122,21 @@ class DeltaWriter:
         }
 
         def serialize_value(key: str, value: Any) -> Any:
+            """Serialize complex values to JSON strings for PyArrow compatibility.
+
+            Args:
+                key: Field name to check against string_fields.
+                value: Value to potentially serialize.
+
+            Returns:
+                JSON string if value is dict/list and field is string type,
+                otherwise the original value unchanged.
+
+            Note:
+                Uses OPT_SORT_KEYS for deterministic serialization (§2.8.1).
+                Complex objects in Gold layer are flattened; Silver preserves
+                JSON for forensic purposes.
+            """
             if value is None:
                 return None
             if key in string_fields and isinstance(value, (dict, list)):

--- a/src/bioetl/interfaces/orchestration/signals.py
+++ b/src/bioetl/interfaces/orchestration/signals.py
@@ -29,6 +29,21 @@ def setup_shutdown_handlers(
     """
 
     def signal_handler(signum: int, _: Any) -> None:
+        """Handle OS termination signals for graceful shutdown.
+
+        This callback is registered with signal.signal() for SIGTERM and SIGINT.
+        When triggered, it logs the signal (if logger available) and requests
+        application shutdown via the ShutdownSignal instance.
+
+        Args:
+            signum: The signal number received (e.g., SIGTERM=15, SIGINT=2).
+            _: Stack frame (unused, required by signal handler signature).
+
+        Note:
+            Logger is optional to support testing scenarios where logging
+            infrastructure may not be available. See ADR-008 for graceful
+            shutdown strategy details.
+        """
         if logger is not None:
             logger.warning(
                 "Received signal, initiating graceful shutdown",


### PR DESCRIPTION
Add Google-style docstrings to 7 public functions/methods that were missing documentation:

- domain/exceptions/base.py: CriticalError, RecoverableError, DataQualityError get_error_type() methods with RULES.md references
- infrastructure/storage/delta_writer.py: serialize_value() helper with §2.8.1 reference for deterministic serialization
- interfaces/orchestration/signals.py: signal_handler() callback with ADR-008 reference for graceful shutdown
- composition/factories/data_source_factory.py: creator() closure documenting backward-compatibility wrapper
- composition/providers/decorators.py: decorator() inner function documenting registration side effects

All docstrings follow Google-style format with Args, Returns, and Note sections where appropriate.