### PR TITLE
Add circuit breaker metrics emission

### DIFF
--- a/src/bioetl/composition/factories/http_client_factory.py
+++ b/src/bioetl/composition/factories/http_client_factory.py
@@ -108,7 +108,7 @@ class HttpClientFactory:
             # Return default client
             return UnifiedHTTPClient(
                 rate_limiter=TokenBucket(rate=5.0, capacity=10),
-                circuit_breaker=CircuitBreaker(provider=provider),
+                circuit_breaker=CircuitBreaker(provider=provider, metrics=metrics),
                 provider=provider,
                 run_id=run_id,
                 tracer=tracer,
@@ -129,7 +129,7 @@ class HttpClientFactory:
 
         return UnifiedHTTPClient(
             rate_limiter=TokenBucket(rate=rate, capacity=capacity),
-            circuit_breaker=CircuitBreaker(provider=provider),
+            circuit_breaker=CircuitBreaker(provider=provider, metrics=metrics),
             provider=provider,
             run_id=run_id,
             tracer=tracer,

--- a/src/bioetl/composition/providers/registration.py
+++ b/src/bioetl/composition/providers/registration.py
@@ -154,6 +154,7 @@ def _create_pubchem_adapter(
     circuit_breaker_timeout = kwargs.pop("circuit_breaker_timeout", 300)
     max_workers = kwargs.pop("max_workers", 4)
     strict_error_handling = kwargs.pop("strict_error_handling", False)
+    metrics = kwargs.pop("metrics", None)
 
     # Create dependencies in Composition Root (DI pattern)
     rate_limiter = TokenBucket(rate=rate, capacity=capacity, provider="pubchem")
@@ -161,6 +162,7 @@ def _create_pubchem_adapter(
         provider="pubchem",
         failure_threshold=circuit_breaker_threshold,
         recovery_timeout=circuit_breaker_timeout,
+        metrics=metrics,
     )
     thread_pool = ThreadPoolExecutor(max_workers=max_workers)
 

--- a/src/bioetl/infrastructure/adapters/http/circuit_breaker.py
+++ b/src/bioetl/infrastructure/adapters/http/circuit_breaker.py
@@ -23,8 +23,21 @@ from bioetl.domain.types import CircuitBreakerState
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
+    from bioetl.domain.ports import MetricsPort
+
 P = ParamSpec("P")
 T = TypeVar("T")
+
+# Metric names as constants for consistency
+METRIC_CIRCUIT_BREAKER_STATE = "circuit_breaker_state"
+METRIC_CIRCUIT_BREAKER_TRIPS = "circuit_breaker_trips_total"
+
+# State values for gauge metric
+_STATE_VALUES: dict[CircuitBreakerState, float] = {
+    CircuitBreakerState.CLOSED: 0.0,
+    CircuitBreakerState.HALF_OPEN: 1.0,
+    CircuitBreakerState.OPEN: 2.0,
+}
 
 
 @dataclass
@@ -38,6 +51,7 @@ class CircuitBreaker:
         provider: Provider name for metrics/logging
         failure_threshold: Consecutive failures before opening (default: 5)
         recovery_timeout: Seconds to wait in OPEN before testing (default: 300)
+        metrics: Optional MetricsPort for emitting circuit breaker metrics
 
     Example:
         >>> cb = CircuitBreaker(provider="chembl", failure_threshold=5)
@@ -52,12 +66,17 @@ class CircuitBreaker:
     provider: str
     failure_threshold: int = 5
     recovery_timeout: int = 300  # 5 minutes
+    metrics: MetricsPort | None = None
 
     _state: CircuitBreakerState = field(init=False, default=CircuitBreakerState.CLOSED)
     _failure_count: int = field(init=False, default=0)
     _last_failure_time: float = field(init=False, default=0.0)
     _trips_total: int = field(init=False, default=0)
     _lock: asyncio.Lock = field(init=False, default_factory=asyncio.Lock)
+
+    def __post_init__(self) -> None:
+        """Emit initial state metric after initialization."""
+        self._emit_state_metric()
 
     def get_state(self) -> CircuitBreakerState:
         """Get current circuit breaker state."""
@@ -71,6 +90,24 @@ class CircuitBreaker:
         """Get total number of times circuit has opened."""
         return self._trips_total
 
+    def _emit_state_metric(self) -> None:
+        """Emit current state as a gauge metric."""
+        if self.metrics is not None:
+            self.metrics.set_gauge(
+                METRIC_CIRCUIT_BREAKER_STATE,
+                _STATE_VALUES[self._state],
+                {"provider": self.provider},
+            )
+
+    def _emit_trip_metric(self) -> None:
+        """Emit circuit trip counter metric."""
+        if self.metrics is not None:
+            self.metrics.increment_counter(
+                METRIC_CIRCUIT_BREAKER_TRIPS,
+                1,
+                {"provider": self.provider},
+            )
+
     def _should_attempt(self) -> bool:
         """Check if request should be attempted based on state."""
         if self._state == CircuitBreakerState.CLOSED:
@@ -81,6 +118,7 @@ class CircuitBreaker:
             elapsed = time.monotonic() - self._last_failure_time
             if elapsed >= self.recovery_timeout:
                 self._state = CircuitBreakerState.HALF_OPEN
+                self._emit_state_metric()
                 return True
             return False
 
@@ -92,6 +130,7 @@ class CircuitBreaker:
         self._failure_count = 0
         if self._state == CircuitBreakerState.HALF_OPEN:
             self._state = CircuitBreakerState.CLOSED
+            self._emit_state_metric()
 
     def _on_failure(self) -> None:
         """Handle failed request."""
@@ -102,6 +141,8 @@ class CircuitBreaker:
             # Failed probe request, go back to OPEN
             self._state = CircuitBreakerState.OPEN
             self._trips_total += 1
+            self._emit_state_metric()
+            self._emit_trip_metric()
         elif (
             self._state == CircuitBreakerState.CLOSED
             and self._failure_count >= self.failure_threshold
@@ -109,6 +150,8 @@ class CircuitBreaker:
             # Threshold reached, open circuit
             self._state = CircuitBreakerState.OPEN
             self._trips_total += 1
+            self._emit_state_metric()
+            self._emit_trip_metric()
 
     def _time_until_retry(self) -> float:
         """Calculate time until next retry is allowed."""
@@ -158,12 +201,15 @@ class CircuitBreaker:
         self._state = CircuitBreakerState.CLOSED
         self._failure_count = 0
         self._last_failure_time = 0.0
+        self._emit_state_metric()
 
     def force_open(self) -> None:
         """Manually force circuit breaker to OPEN state."""
         self._state = CircuitBreakerState.OPEN
         self._last_failure_time = time.monotonic()
         self._trips_total += 1
+        self._emit_state_metric()
+        self._emit_trip_metric()
 
 
 def is_circuit_breaker_error(exc: Exception) -> bool:

--- a/tests/unit/infrastructure/test_circuit_breaker.py
+++ b/tests/unit/infrastructure/test_circuit_breaker.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import asyncio
+from unittest.mock import MagicMock
 
 import pytest
 
 from bioetl.domain.exceptions import CircuitBreakerOpenError
+from bioetl.domain.ports import MetricsPort
 from bioetl.domain.types import CircuitBreakerState
-from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
+from bioetl.infrastructure.adapters.http.circuit_breaker import (
+    METRIC_CIRCUIT_BREAKER_STATE,
+    METRIC_CIRCUIT_BREAKER_TRIPS,
+    CircuitBreaker,
+)
 
 
 class TestCircuitBreaker:
@@ -189,3 +195,215 @@ class TestCircuitBreaker:
         cb.force_open()
         assert cb.get_state() == CircuitBreakerState.OPEN
         assert cb.get_trips_total() == 1
+
+
+class TestCircuitBreakerMetrics:
+    """Tests for CircuitBreaker metrics emission."""
+
+    @pytest.fixture
+    def mock_metrics(self) -> MagicMock:
+        """Create a mock MetricsPort."""
+        return MagicMock(spec=MetricsPort)
+
+    @pytest.mark.unit
+    def test_initial_state_emits_closed_metric(self, mock_metrics: MagicMock) -> None:
+        """Circuit breaker should emit CLOSED state metric on initialization."""
+        CircuitBreaker(provider="test", metrics=mock_metrics)
+
+        mock_metrics.set_gauge.assert_called_once_with(
+            METRIC_CIRCUIT_BREAKER_STATE,
+            0.0,  # CLOSED = 0
+            {"provider": "test"},
+        )
+
+    @pytest.mark.unit
+    async def test_closed_to_open_emits_state_and_trip_metrics(
+        self, mock_metrics: MagicMock
+    ) -> None:
+        """CLOSED -> OPEN transition should emit state and trip metrics."""
+        cb = CircuitBreaker(provider="test", failure_threshold=3, metrics=mock_metrics)
+
+        async def fail() -> None:
+            raise RuntimeError("error")
+
+        # Trigger 3 failures to open the circuit
+        for _ in range(3):
+            with pytest.raises(RuntimeError):
+                await cb.call(fail)
+
+        assert cb.get_state() == CircuitBreakerState.OPEN
+
+        # Check state gauge was set to OPEN (2.0)
+        mock_metrics.set_gauge.assert_called_with(
+            METRIC_CIRCUIT_BREAKER_STATE,
+            2.0,  # OPEN = 2
+            {"provider": "test"},
+        )
+
+        # Check trip counter was incremented
+        mock_metrics.increment_counter.assert_called_once_with(
+            METRIC_CIRCUIT_BREAKER_TRIPS,
+            1,
+            {"provider": "test"},
+        )
+
+    @pytest.mark.unit
+    async def test_open_to_half_open_emits_metric(
+        self, mock_metrics: MagicMock
+    ) -> None:
+        """OPEN -> HALF_OPEN transition should emit state metric."""
+        cb = CircuitBreaker(
+            provider="test",
+            failure_threshold=2,
+            recovery_timeout=0,
+            metrics=mock_metrics,
+        )
+
+        async def fail() -> None:
+            raise RuntimeError("error")
+
+        # Open the circuit
+        for _ in range(2):
+            with pytest.raises(RuntimeError):
+                await cb.call(fail)
+
+        assert cb.get_state() == CircuitBreakerState.OPEN
+        mock_metrics.reset_mock()
+
+        # Wait for recovery
+        await asyncio.sleep(0.01)
+
+        # Probe request that triggers HALF_OPEN transition
+        async def success() -> str:
+            return "ok"
+
+        await cb.call(success)
+
+        # Should have called set_gauge twice: once for HALF_OPEN, once for CLOSED
+        calls = mock_metrics.set_gauge.call_args_list
+        assert len(calls) >= 2
+
+        # First call should be HALF_OPEN (1.0)
+        assert calls[0][0] == (
+            METRIC_CIRCUIT_BREAKER_STATE,
+            1.0,  # HALF_OPEN = 1
+            {"provider": "test"},
+        )
+
+        # Second call should be CLOSED (0.0)
+        assert calls[1][0] == (
+            METRIC_CIRCUIT_BREAKER_STATE,
+            0.0,  # CLOSED = 0
+            {"provider": "test"},
+        )
+
+    @pytest.mark.unit
+    async def test_half_open_failure_emits_metrics(
+        self, mock_metrics: MagicMock
+    ) -> None:
+        """Failed probe in HALF_OPEN should emit state and trip metrics."""
+        cb = CircuitBreaker(
+            provider="test",
+            failure_threshold=2,
+            recovery_timeout=0,
+            metrics=mock_metrics,
+        )
+
+        async def fail() -> None:
+            raise RuntimeError("error")
+
+        # Open the circuit
+        for _ in range(2):
+            with pytest.raises(RuntimeError):
+                await cb.call(fail)
+
+        assert cb.get_state() == CircuitBreakerState.OPEN
+        mock_metrics.reset_mock()
+
+        # Wait for recovery
+        await asyncio.sleep(0.01)
+
+        # Failed probe request
+        with pytest.raises(RuntimeError):
+            await cb.call(fail)
+
+        assert cb.get_state() == CircuitBreakerState.OPEN
+
+        # Should have emitted HALF_OPEN then OPEN state
+        gauge_calls = mock_metrics.set_gauge.call_args_list
+        assert len(gauge_calls) >= 2
+
+        # First should be HALF_OPEN
+        assert gauge_calls[0][0][1] == 1.0  # HALF_OPEN
+
+        # Second should be OPEN
+        assert gauge_calls[1][0][1] == 2.0  # OPEN
+
+        # Should have incremented trip counter
+        mock_metrics.increment_counter.assert_called_with(
+            METRIC_CIRCUIT_BREAKER_TRIPS,
+            1,
+            {"provider": "test"},
+        )
+
+    @pytest.mark.unit
+    def test_force_open_emits_metrics(self, mock_metrics: MagicMock) -> None:
+        """force_open should emit state and trip metrics."""
+        cb = CircuitBreaker(provider="test", metrics=mock_metrics)
+        mock_metrics.reset_mock()
+
+        cb.force_open()
+
+        mock_metrics.set_gauge.assert_called_with(
+            METRIC_CIRCUIT_BREAKER_STATE,
+            2.0,  # OPEN = 2
+            {"provider": "test"},
+        )
+        mock_metrics.increment_counter.assert_called_once_with(
+            METRIC_CIRCUIT_BREAKER_TRIPS,
+            1,
+            {"provider": "test"},
+        )
+
+    @pytest.mark.unit
+    def test_reset_emits_closed_metric(self, mock_metrics: MagicMock) -> None:
+        """reset should emit CLOSED state metric."""
+        cb = CircuitBreaker(provider="test", metrics=mock_metrics)
+        cb.force_open()
+        mock_metrics.reset_mock()
+
+        cb.reset()
+
+        mock_metrics.set_gauge.assert_called_with(
+            METRIC_CIRCUIT_BREAKER_STATE,
+            0.0,  # CLOSED = 0
+            {"provider": "test"},
+        )
+
+    @pytest.mark.unit
+    def test_no_metrics_when_none_provided(self) -> None:
+        """Circuit breaker should work without metrics (None)."""
+        cb = CircuitBreaker(provider="test", metrics=None)
+
+        # Should not raise any errors
+        cb.force_open()
+        cb.reset()
+        assert cb.get_state() == CircuitBreakerState.CLOSED
+
+    @pytest.mark.unit
+    async def test_failures_below_threshold_no_trip_metric(
+        self, mock_metrics: MagicMock
+    ) -> None:
+        """Failures below threshold should not emit trip metrics."""
+        cb = CircuitBreaker(provider="test", failure_threshold=3, metrics=mock_metrics)
+
+        async def fail() -> None:
+            raise RuntimeError("error")
+
+        # Fail 2 times (below threshold of 3)
+        for _ in range(2):
+            with pytest.raises(RuntimeError):
+                await cb.call(fail)
+
+        assert cb.get_state() == CircuitBreakerState.CLOSED
+        mock_metrics.increment_counter.assert_not_called()


### PR DESCRIPTION
…ility

Add metrics emission to CircuitBreaker for better observability:

- Add optional MetricsPort parameter to CircuitBreaker constructor
- Emit circuit_breaker_state gauge (0=Closed, 1=Half-Open, 2=Open) on all state transitions
- Emit circuit_breaker_trips_total counter when circuit opens
- Update HttpClientFactory to pass metrics to CircuitBreaker
- Update PubChem provider registration to pass metrics
- Add comprehensive unit tests for metrics emission

This fulfills the promise in the docstring that metrics would be emitted for circuit_breaker_state and circuit_breaker_trips_total.