### PR TITLE
Fix metrics gauge method call mismatch

### DIFF
--- a/src/bioetl/infrastructure/adapters/http/health_monitor.py
+++ b/src/bioetl/infrastructure/adapters/http/health_monitor.py
@@ -200,7 +200,7 @@ class ProviderHealthMonitor:
             state: Provider health state.
         """
         value = state.status.to_metric_value()  # 0, 1, or 2
-        self.metrics.gauge(
+        self.metrics.set_gauge(
             "provider_health_status",
             value,
             labels={"provider": state.provider},

--- a/tests/unit/infrastructure/adapters/http/test_health_monitor.py
+++ b/tests/unit/infrastructure/adapters/http/test_health_monitor.py
@@ -219,7 +219,7 @@ class TestProviderHealthMonitorMetrics:
         """Test that error emits provider_health_status metric."""
         monitor.record_error("chembl")
 
-        mock_metrics.gauge.assert_called_with(
+        mock_metrics.set_gauge.assert_called_with(
             "provider_health_status",
             1,  # DEGRADED = 1
             labels={"provider": "chembl"},
@@ -231,7 +231,7 @@ class TestProviderHealthMonitorMetrics:
         """Test that success emits provider_health_status metric."""
         monitor.record_success("chembl")
 
-        mock_metrics.gauge.assert_called_with(
+        mock_metrics.set_gauge.assert_called_with(
             "provider_health_status",
             2,  # HEALTHY = 2
             labels={"provider": "chembl"},
@@ -243,7 +243,7 @@ class TestProviderHealthMonitorMetrics:
         """Test that health check result emits metric."""
         monitor.record_health_check_result("chembl", HealthStatus.UNHEALTHY)
 
-        mock_metrics.gauge.assert_called_with(
+        mock_metrics.set_gauge.assert_called_with(
             "provider_health_status",
             0,  # UNHEALTHY = 0
             labels={"provider": "chembl"},


### PR DESCRIPTION
HealthMonitor._emit_metric() was calling metrics.gauge() but MetricsPort interface only defines set_gauge() method. This caused type checking errors with mypy --strict.

Updated tests to match the correct method name.

Fixes P1.1 from REFACTORING_PLAN.md