### PR TITLE
Fix environment variable test and type errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -318,5 +318,5 @@ skips = ["*/domain/*"]
 dev = [
     "hypothesis>=6.148.7",
     "pytest>=9.0.2",
-    "pytest-asyncio>=1.3.0",
+    "pytest-asyncio>=0.23",
 ]

--- a/src/bioetl/composition/factories/storage_factory.py
+++ b/src/bioetl/composition/factories/storage_factory.py
@@ -9,7 +9,6 @@ to improve maintainability and reduce file size.
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -20,11 +19,6 @@ from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 from bioetl.infrastructure.storage.gold_writer import GoldWriter
 
 from .storage_adapter import StorageAdapter
-
-
-def _is_test_mode() -> bool:
-    """Check if running in test mode (disables lock requirement)."""
-    return os.environ.get("BIOETL_TEST_MODE", "").lower() in ("true", "1", "yes")
 
 if TYPE_CHECKING:
     from typing import Any
@@ -125,9 +119,6 @@ class StorageFactory:
             logger, json_path, silver_csv_exporter, gold_csv_exporter
         )
         save_json = bronze_config.save_json if bronze_config else False
-
-        # Disable lock requirement in test mode (BIOETL_TEST_MODE=true)
-        require_lock = not _is_test_mode()
 
         adapter = StorageAdapter(
             bronze_writer=BronzeWriter(


### PR DESCRIPTION
- Remove redundant _is_test_mode() that used os.environ directly
- Use settings.test_mode instead (already computed at line 97)
- Fix pytest-asyncio version constraint (1.3.0 → 0.23)

This fixes test_env_var_centralization which requires os.getenv/environ only in infrastructure/config.py and serialization/encoders.py.