### PR TITLE
Add owner_id fencing token validation for writers

### DIFF
--- a/src/bioetl/infrastructure/storage/bronze_writer.py
+++ b/src/bioetl/infrastructure/storage/bronze_writer.py
@@ -159,6 +159,7 @@ class BronzeWriter:
         provider: str,
         entity: str,
         lock_context: LockContext | None,
+        expected_owner_id: RunID | None = None,
     ) -> None:
         """Validate that lock is held before write operation.
 
@@ -168,9 +169,13 @@ class BronzeWriter:
             provider: Provider name (e.g., "chembl").
             entity: Entity name (e.g., "activity").
             lock_context: The lock context from application layer.
+            expected_owner_id: Expected owner RunID (fencing token). If provided,
+                              validates that lock_context.owner_id matches to prevent
+                              writes from stale lock holders after lock re-acquisition.
 
         Raises:
-            LockNotHeldError: If lock is not held or doesn't match.
+            LockNotHeldError: If lock is not held, doesn't match,
+                             is expired, or owner_id doesn't match.
         """
         if not self._require_lock:
             return  # Lock validation disabled (e.g., for tests)
@@ -209,6 +214,21 @@ class BronzeWriter:
             )
             raise LockNotHeldError(
                 "write_bronze (lock expired)",
+                expected_key,
+            )
+
+        # Fencing token validation: verify owner_id matches expected
+        if expected_owner_id is not None and lock_context.owner_id != expected_owner_id:
+            self.logger.error(
+                "Write attempted with wrong owner_id (fencing token mismatch)",
+                provider=provider,
+                entity=entity,
+                expected_owner_id=str(expected_owner_id),
+                actual_owner_id=str(lock_context.owner_id),
+                lock_key=lock_context.key,
+            )
+            raise LockNotHeldError(
+                f"write_bronze (owner mismatch: {lock_context.owner_id} != {expected_owner_id})",
                 expected_key,
             )
 
@@ -374,7 +394,8 @@ class BronzeWriter:
             start_time = time.perf_counter()
 
             # Validate lock is held before any write operation (RULES.md §3.3)
-            self._validate_lock_held(provider, entity, lock_context)
+            # Pass run_id as expected_owner_id for fencing token validation
+            self._validate_lock_held(provider, entity, lock_context, run_id)
 
             self._validate_bronze_names(provider, entity)
             self._validate_records_iterator(records)

--- a/src/bioetl/infrastructure/storage/delta_writer.py
+++ b/src/bioetl/infrastructure/storage/delta_writer.py
@@ -46,6 +46,7 @@ from bioetl.domain.medallion import (
     WriteMode,
     WriteModePolicy,
 )
+from bioetl.domain.types import RunID
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -223,6 +224,7 @@ class DeltaWriter:
         self,
         table_name: str,
         lock_context: LockContext | None,
+        expected_owner_id: RunID | None = None,
     ) -> None:
         """Validate that lock is held before write operation.
 
@@ -231,9 +233,13 @@ class DeltaWriter:
         Args:
             table_name: Target table name (format: "provider_entity").
             lock_context: The lock context from application layer.
+            expected_owner_id: Expected owner RunID (fencing token). If provided,
+                              validates that lock_context.owner_id matches to prevent
+                              writes from stale lock holders after lock re-acquisition.
 
         Raises:
-            LockNotHeldError: If lock is not held or doesn't match table.
+            LockNotHeldError: If lock is not held, doesn't match table,
+                             is expired, or owner_id doesn't match.
         """
         if not self._require_lock:
             return  # Lock validation disabled (e.g., for tests)
@@ -268,6 +274,20 @@ class DeltaWriter:
             )
             raise LockNotHeldError(
                 "write_silver (lock expired)",
+                expected_key,
+            )
+
+        # Fencing token validation: verify owner_id matches expected
+        if expected_owner_id is not None and lock_context.owner_id != expected_owner_id:
+            self.logger.error(
+                "Write attempted with wrong owner_id (fencing token mismatch)",
+                table=table_name,
+                expected_owner_id=str(expected_owner_id),
+                actual_owner_id=str(lock_context.owner_id),
+                lock_key=lock_context.key,
+            )
+            raise LockNotHeldError(
+                f"write_silver (owner mismatch: {lock_context.owner_id} != {expected_owner_id})",
                 expected_key,
             )
 
@@ -471,8 +491,24 @@ class DeltaWriter:
             span.set_attribute("mode", mode)
             span.set_attribute("record_count", len(records))
 
+            # Extract expected owner_id from records for fencing token validation
+            expected_owner_id: RunID | None = None
+            if records:
+                run_id_str = records[0].get("_run_id")
+                if run_id_str:
+                    from uuid import UUID
+                    try:
+                        expected_owner_id = RunID(UUID(run_id_str))
+                    except (ValueError, TypeError):
+                        # Invalid run_id format, skip owner validation
+                        self.logger.warning(
+                            "Could not parse _run_id for owner validation",
+                            table=table_name,
+                            run_id=run_id_str,
+                        )
+
             # Validate lock is held before any write operation (RULES.md §3.3)
-            self._validate_lock_held(table_name, lock_context)
+            self._validate_lock_held(table_name, lock_context, expected_owner_id)
 
             validated_mode = self._validate_write_mode(mode)
 

--- a/src/bioetl/infrastructure/storage/gold_writer.py
+++ b/src/bioetl/infrastructure/storage/gold_writer.py
@@ -98,6 +98,7 @@ class GoldWriter:
         self,
         table_name: str,
         lock_context: LockContext | None,
+        expected_owner_id: RunID | None = None,
     ) -> None:
         """Validate that lock is held before write operation.
 
@@ -106,9 +107,13 @@ class GoldWriter:
         Args:
             table_name: Target table name (format: "provider_entity").
             lock_context: The lock context from application layer.
+            expected_owner_id: Expected owner RunID (fencing token). If provided,
+                              validates that lock_context.owner_id matches to prevent
+                              writes from stale lock holders after lock re-acquisition.
 
         Raises:
-            LockNotHeldError: If lock is not held or doesn't match table.
+            LockNotHeldError: If lock is not held, doesn't match table,
+                             is expired, or owner_id doesn't match.
         """
         if not self._require_lock:
             return  # Lock validation disabled (e.g., for tests)
@@ -143,6 +148,20 @@ class GoldWriter:
             )
             raise LockNotHeldError(
                 "write_gold (lock expired)",
+                expected_key,
+            )
+
+        # Fencing token validation: verify owner_id matches expected
+        if expected_owner_id is not None and lock_context.owner_id != expected_owner_id:
+            self.logger.error(
+                "Write attempted with wrong owner_id (fencing token mismatch)",
+                table=table_name,
+                expected_owner_id=str(expected_owner_id),
+                actual_owner_id=str(lock_context.owner_id),
+                lock_key=lock_context.key,
+            )
+            raise LockNotHeldError(
+                f"write_gold (owner mismatch: {lock_context.owner_id} != {expected_owner_id})",
                 expected_key,
             )
 
@@ -189,7 +208,8 @@ class GoldWriter:
             span.set_attribute("record_count", len(records))
 
             # Validate lock is held before any write operation (RULES.md §3.3)
-            self._validate_lock_held(table_name, lock_context)
+            # Pass run_id as expected_owner_id for fencing token validation
+            self._validate_lock_held(table_name, lock_context, run_id)
 
             validated_mode = self._validate_write_mode(mode)
             self._validate_records(records)

--- a/tests/unit/infrastructure/storage/test_writer_lock_validation.py
+++ b/tests/unit/infrastructure/storage/test_writer_lock_validation.py
@@ -73,6 +73,23 @@ def wrong_table_lock_context(run_id: RunID) -> LockContext:
     )
 
 
+@pytest.fixture
+def different_owner_id() -> RunID:
+    """Create a different run ID (simulates lock re-acquisition)."""
+    return RunID(uuid4())
+
+
+@pytest.fixture
+def wrong_owner_lock_context(different_owner_id: RunID) -> LockContext:
+    """Create a lock context with different owner (fencing token mismatch)."""
+    return LockContext.create(
+        provider="chembl",
+        entity="activity",
+        owner_id=different_owner_id,
+        exclusive=False,
+    )
+
+
 class TestLockContext:
     """Tests for LockContext value object."""
 
@@ -223,6 +240,51 @@ class TestDeltaWriterLockValidation:
         # Should not raise even with None
         delta_writer_no_lock._validate_lock_held("chembl_activity", None)
 
+    def test_validate_lock_held_wrong_owner_id(
+        self,
+        delta_writer: "DeltaWriter",
+        wrong_owner_lock_context: LockContext,
+        run_id: RunID,
+        mock_logger: MagicMock,
+    ) -> None:
+        """Test validation fails when lock has wrong owner_id (fencing token mismatch)."""
+        with pytest.raises(LockNotHeldError) as exc_info:
+            delta_writer._validate_lock_held(
+                "chembl_activity",
+                wrong_owner_lock_context,
+                expected_owner_id=run_id,  # Different from wrong_owner_lock_context.owner_id
+            )
+
+        assert "owner mismatch" in str(exc_info.value)
+        mock_logger.error.assert_called()
+
+    def test_validate_lock_held_matching_owner_id(
+        self,
+        delta_writer: "DeltaWriter",
+        valid_lock_context: LockContext,
+        run_id: RunID,
+    ) -> None:
+        """Test validation passes when owner_id matches expected."""
+        # Should not raise - owner_id matches
+        delta_writer._validate_lock_held(
+            "chembl_activity",
+            valid_lock_context,
+            expected_owner_id=run_id,
+        )
+
+    def test_validate_lock_held_no_expected_owner_skips_check(
+        self,
+        delta_writer: "DeltaWriter",
+        valid_lock_context: LockContext,
+    ) -> None:
+        """Test validation passes when expected_owner_id is None (backward compat)."""
+        # Should not raise - no owner check when expected_owner_id is None
+        delta_writer._validate_lock_held(
+            "chembl_activity",
+            valid_lock_context,
+            expected_owner_id=None,
+        )
+
 
 class TestGoldWriterLockValidation:
     """Tests for GoldWriter lock validation."""
@@ -277,6 +339,38 @@ class TestGoldWriterLockValidation:
         """Test validation is skipped when require_lock=False."""
         # Should not raise even with None
         gold_writer_no_lock._validate_lock_held("chembl_activity", None)
+
+    def test_validate_lock_held_wrong_owner_id(
+        self,
+        gold_writer: "GoldWriter",
+        wrong_owner_lock_context: LockContext,
+        run_id: RunID,
+        mock_logger: MagicMock,
+    ) -> None:
+        """Test validation fails when lock has wrong owner_id (fencing token mismatch)."""
+        with pytest.raises(LockNotHeldError) as exc_info:
+            gold_writer._validate_lock_held(
+                "chembl_activity",
+                wrong_owner_lock_context,
+                expected_owner_id=run_id,
+            )
+
+        assert "owner mismatch" in str(exc_info.value)
+        mock_logger.error.assert_called()
+
+    def test_validate_lock_held_matching_owner_id(
+        self,
+        gold_writer: "GoldWriter",
+        valid_lock_context: LockContext,
+        run_id: RunID,
+    ) -> None:
+        """Test validation passes when owner_id matches expected."""
+        # Should not raise
+        gold_writer._validate_lock_held(
+            "chembl_activity",
+            valid_lock_context,
+            expected_owner_id=run_id,
+        )
 
 
 class TestBronzeWriterLockValidation:
@@ -351,6 +445,40 @@ class TestBronzeWriterLockValidation:
         """Test validation is skipped when require_lock=False."""
         # Should not raise even with None
         bronze_writer_no_lock._validate_lock_held("chembl", "activity", None)
+
+    def test_validate_lock_held_wrong_owner_id(
+        self,
+        bronze_writer: "BronzeWriter",
+        wrong_owner_lock_context: LockContext,
+        run_id: RunID,
+        mock_logger: MagicMock,
+    ) -> None:
+        """Test validation fails when lock has wrong owner_id (fencing token mismatch)."""
+        with pytest.raises(LockNotHeldError) as exc_info:
+            bronze_writer._validate_lock_held(
+                "chembl",
+                "activity",
+                wrong_owner_lock_context,
+                expected_owner_id=run_id,
+            )
+
+        assert "owner mismatch" in str(exc_info.value)
+        mock_logger.error.assert_called()
+
+    def test_validate_lock_held_matching_owner_id(
+        self,
+        bronze_writer: "BronzeWriter",
+        valid_lock_context: LockContext,
+        run_id: RunID,
+    ) -> None:
+        """Test validation passes when owner_id matches expected."""
+        # Should not raise
+        bronze_writer._validate_lock_held(
+            "chembl",
+            "activity",
+            valid_lock_context,
+            expected_owner_id=run_id,
+        )
 
 
 class TestLockManagerGetContext:


### PR DESCRIPTION
Add owner_id validation to prevent writes from stale lock holders after lock re-acquisition. This implements the fencing token pattern for data integrity protection.

Changes:
- DeltaWriter: Extract run_id from records and validate against lock_context.owner_id
- BronzeWriter: Validate run_id parameter against lock_context.owner_id
- GoldWriter: Validate run_id parameter against lock_context.owner_id
- Add comprehensive tests for owner_id validation in all writers

This addresses P1-1 audit finding: Writers now verify owner_id in addition to lock key and TTL, preventing concurrent write issues.