### PR TITLE
Centralize environment variable access

### DIFF
--- a/src/bioetl/composition/factories/storage_factory.py
+++ b/src/bioetl/composition/factories/storage_factory.py
@@ -9,7 +9,6 @@ to improve maintainability and reduce file size.
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -20,11 +19,6 @@ from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 from bioetl.infrastructure.storage.gold_writer import GoldWriter
 
 from .storage_adapter import StorageAdapter
-
-
-def _is_test_mode() -> bool:
-    """Check if running in test mode (disables lock requirement)."""
-    return os.environ.get("BIOETL_TEST_MODE", "").lower() in ("true", "1", "yes")
 
 if TYPE_CHECKING:
     from typing import Any
@@ -125,9 +119,6 @@ class StorageFactory:
             logger, json_path, silver_csv_exporter, gold_csv_exporter
         )
         save_json = bronze_config.save_json if bronze_config else False
-
-        # Disable lock requirement in test mode (BIOETL_TEST_MODE=true)
-        require_lock = not _is_test_mode()
 
         adapter = StorageAdapter(
             bronze_writer=BronzeWriter(

--- a/tests/architecture/test_env_var_centralization.py
+++ b/tests/architecture/test_env_var_centralization.py
@@ -1,0 +1,185 @@
+"""Architecture test: os.environ access centralized through Settings.
+
+REQ-ARCH-041: Environment variable access is centralized through Settings.
+Composition and infrastructure layers should not access os.environ directly.
+Instead, they should receive configuration via Settings (pydantic-settings).
+
+This ensures:
+- Single source of truth for configuration
+- Proper validation of environment variables
+- Testability through Settings injection
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+# Paths relative to project root
+COMPOSITION_DIR = Path("src/bioetl/composition")
+INFRASTRUCTURE_DIR = Path("src/bioetl/infrastructure")
+
+# Files allowed to use os.environ - with justification.
+#
+# Criteria for exceptions:
+# 1. The access is for infrastructure-level configuration (not business logic)
+# 2. The access is required before Settings can be loaded
+# 3. The access is properly documented
+#
+ALLOWED_COMPOSITION_FILES: set[str] = set()
+
+ALLOWED_INFRASTRUCTURE_FILES: set[str] = {
+    # config.py contains Settings class which is the centralized configuration.
+    # It uses pydantic-settings internally which accesses os.environ.
+    "config.py",
+    # encoders.py reads BIOETL_JSON_ENCODER to select JSON encoder at import time.
+    # This is infrastructure-level configuration for encoder selection.
+    "encoders.py",
+}
+
+
+def _get_base_path(dir_path: Path) -> Path:
+    """Get the base path, handling both project root and tests directory."""
+    if dir_path.exists():
+        return dir_path
+    return Path(__file__).parent.parent.parent / dir_path
+
+
+def _find_os_environ_usages(py_file: Path, base_path: Path) -> list[str]:
+    """Find os.environ usages in a Python file.
+
+    Detects patterns:
+    - os.environ.get(...)
+    - os.environ[...]
+    - os.environ.setdefault(...)
+    """
+    violations = []
+
+    try:
+        source = py_file.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+    except (SyntaxError, UnicodeDecodeError):
+        return []
+
+    for node in ast.walk(tree):
+        # Check for os.environ attribute access
+        if isinstance(node, ast.Attribute):
+            if node.attr == "environ":
+                # Check if it's os.environ
+                if isinstance(node.value, ast.Name) and node.value.id == "os":
+                    relative_path = py_file.relative_to(base_path)
+                    violations.append(f"{relative_path}:{node.lineno}: os.environ")
+
+        # Check for subscript access os.environ[...]
+        if isinstance(node, ast.Subscript):
+            if isinstance(node.value, ast.Attribute):
+                if node.value.attr == "environ":
+                    if (
+                        isinstance(node.value.value, ast.Name)
+                        and node.value.value.id == "os"
+                    ):
+                        relative_path = py_file.relative_to(base_path)
+                        violations.append(
+                            f"{relative_path}:{node.lineno}: os.environ[...]"
+                        )
+
+    return violations
+
+
+class TestEnvVarCentralization:
+    """Tests ensuring environment variables are accessed via Settings."""
+
+    @pytest.fixture
+    def composition_python_files(self) -> list[Path]:
+        """Get all Python files in composition directory."""
+        base = _get_base_path(COMPOSITION_DIR)
+        return list(base.rglob("*.py"))
+
+    @pytest.fixture
+    def infrastructure_python_files(self) -> list[Path]:
+        """Get all Python files in infrastructure directory."""
+        base = _get_base_path(INFRASTRUCTURE_DIR)
+        return list(base.rglob("*.py"))
+
+    def test_no_os_environ_in_composition(
+        self, composition_python_files: list[Path]
+    ) -> None:
+        """Composition layer MUST NOT access os.environ directly.
+
+        Environment variables should be read via Settings (pydantic-settings)
+        and passed to factories/builders as parameters.
+
+        This ensures:
+        - Centralized configuration validation
+        - Testability via Settings injection
+        - Single source of truth for configuration
+        """
+        violations = []
+        base = _get_base_path(COMPOSITION_DIR)
+
+        for py_file in composition_python_files:
+            if py_file.name in ALLOWED_COMPOSITION_FILES:
+                continue
+
+            violations.extend(_find_os_environ_usages(py_file, base))
+
+        assert not violations, (
+            "os.environ found in composition layer:\n"
+            + "\n".join(f"  - {v}" for v in violations)
+            + "\n\nEnvironment variables should be accessed via Settings "
+            "(pydantic-settings) and passed as parameters. "
+            "Use Settings.test_mode instead of os.environ.get('BIOETL_TEST_MODE')."
+        )
+
+    def test_no_os_environ_in_infrastructure_except_config(
+        self, infrastructure_python_files: list[Path]
+    ) -> None:
+        """Infrastructure layer SHOULD use Settings for configuration.
+
+        The only exception is config.py which defines Settings and
+        necessarily needs to access os.environ through pydantic-settings.
+        """
+        violations = []
+        base = _get_base_path(INFRASTRUCTURE_DIR)
+
+        for py_file in infrastructure_python_files:
+            if py_file.name in ALLOWED_INFRASTRUCTURE_FILES:
+                continue
+
+            violations.extend(_find_os_environ_usages(py_file, base))
+
+        assert not violations, (
+            "os.environ found in infrastructure layer:\n"
+            + "\n".join(f"  - {v}" for v in violations)
+            + "\n\nEnvironment variables should be accessed via Settings. "
+            "Add required configuration to Settings class in config.py."
+        )
+
+    def test_allowed_composition_files_still_exist(
+        self, composition_python_files: list[Path]
+    ) -> None:
+        """Verify that files in ALLOWED_COMPOSITION_FILES actually exist."""
+        if not ALLOWED_COMPOSITION_FILES:
+            pytest.skip("No allowed files in composition layer (expected)")
+
+        existing_names = {f.name for f in composition_python_files}
+        missing = ALLOWED_COMPOSITION_FILES - existing_names
+
+        assert not missing, (
+            f"ALLOWED_COMPOSITION_FILES contains non-existent files: {missing}. "
+            "Remove stale entries from the allowed list."
+        )
+
+    def test_allowed_infrastructure_files_still_exist(
+        self, infrastructure_python_files: list[Path]
+    ) -> None:
+        """Verify that files in ALLOWED_INFRASTRUCTURE_FILES actually exist."""
+        existing_names = {f.name for f in infrastructure_python_files}
+        missing = ALLOWED_INFRASTRUCTURE_FILES - existing_names
+
+        assert not missing, (
+            f"ALLOWED_INFRASTRUCTURE_FILES contains non-existent files: {missing}. "
+            "Remove stale entries from the allowed list."
+        )


### PR DESCRIPTION
Remove direct os.environ access in storage_factory.py:
- Removed _is_test_mode() function that read BIOETL_TEST_MODE directly
- Removed duplicate require_lock assignment on line 130
- Now uses settings.test_mode consistently (line 96)

Add architectural test test_env_var_centralization.py:
- Enforces centralized env var access via Settings (pydantic-settings)
- Prevents direct os.environ usage in composition layer
- Allows config.py and encoders.py in infrastructure (justified exceptions)

This improves testability and ensures single source of truth for configuration.