### PR TITLE
Add Pandera validation to Silver layer

### DIFF
--- a/src/bioetl/domain/ports/__init__.py
+++ b/src/bioetl/domain/ports/__init__.py
@@ -40,7 +40,7 @@ from bioetl.domain.ports.quarantine import QuarantinePort
 from bioetl.domain.ports.resilience import CircuitBreakerPort, RateLimiterPort
 from bioetl.domain.ports.serialization import JsonEncoderPort
 from bioetl.domain.ports.storage import StoragePort
-from bioetl.domain.ports.validation import GoldValidatorPort
+from bioetl.domain.ports.validation import GoldValidatorPort, SilverValidatorPort
 
 __all__ = [
     "AuditEntry",
@@ -63,6 +63,7 @@ __all__ = [
     "NoOpTracing",
     "QuarantinePort",
     "RateLimiterPort",
+    "SilverValidatorPort",
     "StoragePort",
     "TracingPort",
 ]

--- a/src/bioetl/domain/ports/validation.py
+++ b/src/bioetl/domain/ports/validation.py
@@ -1,8 +1,9 @@
-"""Validation port for Gold layer record validation.
+"""Validation ports for Medallion layer record validation.
 
-This port abstracts the validation mechanism for Gold records,
-allowing different validation strategies (Pandera, Great Expectations, etc.)
-to be injected without coupling RecordProcessor to a specific implementation.
+This module provides port abstractions for validating records at different
+Medallion layers (Silver, Gold), allowing different validation strategies
+(Pandera, Great Expectations, etc.) to be injected without coupling
+components to specific implementations.
 """
 
 from __future__ import annotations
@@ -10,6 +11,30 @@ from __future__ import annotations
 from typing import Any, Protocol, runtime_checkable
 
 from bioetl.domain.types import ValidationResult
+
+
+@runtime_checkable
+class SilverValidatorPort(Protocol):
+    """Port for Silver layer record validation.
+
+    This interface abstracts the validation mechanism for Silver records,
+    allowing different validation strategies (Pandera, Great Expectations, etc.)
+    to be injected without coupling DeltaWriter to a specific implementation.
+
+    Note: SilverValidatorPort uses synchronous methods as validation
+    should be a CPU-bound operation without I/O.
+    """
+
+    def validate(self, records: list[dict[str, Any]]) -> ValidationResult:
+        """Validate records for Silver layer.
+
+        Args:
+            records: List of record dictionaries to validate.
+
+        Returns:
+            ValidationResult with valid flag and any error messages.
+        """
+        ...
 
 
 @runtime_checkable

--- a/src/bioetl/infrastructure/storage/delta_writer.py
+++ b/src/bioetl/infrastructure/storage/delta_writer.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from bioetl.domain.ports import AuditPort, LoggerPort, MetricsPort, TracingPort
+    from bioetl.domain.ports.validation import SilverValidatorPort
     from bioetl.infrastructure.export.csv_exporter import CsvExporter
 
 from bioetl.domain.ports.audit import AuditEntry, AuditLayer, AuditOperation
@@ -78,6 +79,7 @@ class DeltaWriter:
         audit: AuditPort | None = None,
         tracing: TracingPort | None = None,
         require_lock: bool = True,
+        silver_validator: SilverValidatorPort | None = None,
     ) -> None:
         """Initialize Delta writer.
 
@@ -95,6 +97,8 @@ class DeltaWriter:
             require_lock: If True, write operations require valid LockContext.
                          Default is True per RULES.md §3.3.
                          Set to False only for testing or non-concurrent scenarios.
+            silver_validator: Optional SilverValidatorPort for Pandera validation.
+                            Use NoOpSilverValidator if validation is not required.
 
         Note: LoggerPort is required per RULES.md DI requirements. All dependencies
         MUST be injected through constructor without fallback defaults.
@@ -112,6 +116,14 @@ class DeltaWriter:
             from bioetl.infrastructure.observability.noop_tracing import NoOpTracing
             tracing = NoOpTracing()
         self._tracing: TracingPort = tracing
+
+        # Use NoOpSilverValidator if not provided
+        if silver_validator is None:
+            from bioetl.infrastructure.validation.pandera_validator import (
+                NoOpSilverValidator,
+            )
+            silver_validator = NoOpSilverValidator()
+        self._silver_validator: SilverValidatorPort = silver_validator
 
     def _prepare_arrow_data(
         self,
@@ -347,6 +359,33 @@ class DeltaWriter:
                     missing=optional_missing,
                 )
 
+    def _validate_silver_pandera(
+        self, records: list[dict[str, Any]], table_name: str
+    ) -> None:
+        """Validate records using Pandera schema before writing to Silver.
+
+        Args:
+            records: List of record dictionaries to validate.
+            table_name: Target table name for error context.
+
+        Raises:
+            SchemaViolationError: If Pandera validation fails.
+        """
+        result = self._silver_validator.validate(records)
+        if not result.valid:
+            self.logger.error(
+                "Silver Pandera validation failed",
+                table=table_name,
+                errors=result.errors,
+            )
+            if self._metrics:
+                self._metrics.increment_counter(
+                    "silver_validation_failures_total",
+                    1,
+                    {"table": table_name},
+                )
+            raise SchemaViolationError(table_name, result.errors)
+
     async def _dispatch_write(
         self,
         validated_mode: SilverWriteMode,
@@ -463,6 +502,7 @@ class DeltaWriter:
             ValueError: If mode is invalid or records are missing required fields
             PolicyViolationError: If mode is not allowed for Silver layer
             SchemaEvolutionError: If schema drift detected and on_schema_mismatch='error'
+            SchemaViolationError: If Pandera validation fails
             LockNotHeldError: If lock_context is None or invalid (when require_lock=True)
         """
         tracer = self._tracing.get_tracer(__name__)
@@ -480,6 +520,9 @@ class DeltaWriter:
             self._enforce_write_policy(validated_mode, table_name)
 
             self._validate_records(records, table_name, schema)
+
+            # Validate records using Pandera schema (if configured)
+            self._validate_silver_pandera(records, table_name)
 
             # Check for schema drift before writing
             await self._check_schema_drift(table_name, records, on_schema_mismatch)

--- a/src/bioetl/infrastructure/validation/__init__.py
+++ b/src/bioetl/infrastructure/validation/__init__.py
@@ -1,16 +1,21 @@
 """Validation adapters for BioETL.
 
-Provides implementations of GoldValidatorPort for different validation strategies.
+Provides implementations of SilverValidatorPort and GoldValidatorPort
+for different validation strategies.
 """
 
 from __future__ import annotations
 
 from bioetl.infrastructure.validation.pandera_validator import (
     NoOpGoldValidator,
+    NoOpSilverValidator,
     PanderaGoldValidator,
+    PanderaSilverValidator,
 )
 
 __all__ = [
     "NoOpGoldValidator",
+    "NoOpSilverValidator",
     "PanderaGoldValidator",
+    "PanderaSilverValidator",
 ]

--- a/src/bioetl/infrastructure/validation/pandera_validator.py
+++ b/src/bioetl/infrastructure/validation/pandera_validator.py
@@ -1,6 +1,7 @@
-"""Pandera-based Gold layer validator.
+"""Pandera-based Medallion layer validators.
 
-Implements GoldValidatorPort using Pandera for DataFrame validation.
+Implements SilverValidatorPort and GoldValidatorPort using Pandera for
+DataFrame validation at each Medallion layer.
 """
 
 from __future__ import annotations
@@ -11,6 +12,86 @@ from bioetl.domain.types import ValidationResult
 
 if TYPE_CHECKING:
     import pandera as pa
+
+
+class PanderaSilverValidator:
+    """Silver validator using Pandera DataFrameSchema.
+
+    Validates records against a Pandera schema before writing to Silver layer.
+    Implements SilverValidatorPort protocol.
+
+    In strict mode, validation fails if no schema is provided.
+
+    Args:
+        schema: Pandera DataFrameSchema for validation. If None and strict=False,
+            validation is skipped. If None and strict=True, validation fails.
+        strict: If True, requires schema to be provided. Default False for
+            backward compatibility.
+
+    """
+
+    def __init__(
+        self, schema: pa.DataFrameSchema | None = None, *, strict: bool = False
+    ) -> None:
+        """Initialize Pandera validator for Silver layer.
+
+        Args:
+            schema: Pandera schema to validate against.
+            strict: If True, validation fails when schema is None.
+
+        """
+        self._schema = schema
+        self._strict = strict
+
+    def validate(self, records: list[dict[str, Any]]) -> ValidationResult:
+        """Validate records using Pandera schema.
+
+        Args:
+            records: List of record dictionaries to validate.
+
+        Returns:
+            ValidationResult with valid flag and any error messages.
+
+        """
+        if not records:
+            return ValidationResult(valid=True)
+
+        if not self._schema:
+            if self._strict:
+                return ValidationResult(
+                    valid=False,
+                    errors=["Silver schema is required but not provided"],
+                )
+            return ValidationResult(valid=True)
+
+        import pandas as pd
+
+        df = pd.DataFrame(records)
+        try:
+            self._schema.validate(df, lazy=True)
+            return ValidationResult(valid=True)
+        except Exception as e:
+            return ValidationResult(valid=False, errors=[str(e)])
+
+
+class NoOpSilverValidator:
+    """No-operation Silver validator for pipelines without Silver schema.
+
+    Implements SilverValidatorPort protocol with pass-through behavior.
+    Used when Silver validation is not required.
+    """
+
+    def validate(self, records: list[dict[str, Any]]) -> ValidationResult:
+        """Pass through records without validation.
+
+        Args:
+            records: List of record dictionaries.
+
+        Returns:
+            ValidationResult indicating valid (always True for no-op).
+
+        """
+        return ValidationResult(valid=True)
 
 
 class PanderaGoldValidator:

--- a/tests/unit/infrastructure/storage/test_delta_writer_silver_validation.py
+++ b/tests/unit/infrastructure/storage/test_delta_writer_silver_validation.py
@@ -1,0 +1,387 @@
+"""Unit tests for DeltaWriter Silver Pandera validation.
+
+Tests for the integration of PanderaSilverValidator with DeltaWriter.
+"""
+
+from __future__ import annotations
+
+import warnings
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bioetl.domain.exceptions import SchemaViolationError
+from bioetl.infrastructure.observability.noop_logger import NoOpLogger
+from bioetl.infrastructure.validation.pandera_validator import (
+    NoOpSilverValidator,
+    PanderaSilverValidator,
+)
+
+
+@pytest.fixture(autouse=True)
+def suppress_pandera_future_warnings():
+    """Suppress Pandera import FutureWarnings during tests."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning, module="pandera")
+        yield
+
+
+@pytest.fixture
+def noop_logger():
+    """Provide a NoOpLogger for tests."""
+    return NoOpLogger()
+
+
+@pytest.fixture
+def valid_records():
+    """Create valid records with all required metadata."""
+    return [
+        {
+            "entity_id": "CHEMBL123",
+            "value": 5.5,
+            "_run_id": "uuid-123",
+            "_run_type": "incremental",
+            "_source_batch_id": "batch-456",
+            "_ingestion_ts": "2025-01-15T12:00:00Z",
+        },
+        {
+            "entity_id": "CHEMBL456",
+            "value": 7.2,
+            "_run_id": "uuid-123",
+            "_run_type": "incremental",
+            "_source_batch_id": "batch-456",
+            "_ingestion_ts": "2025-01-15T12:00:00Z",
+        },
+    ]
+
+
+@pytest.mark.unit
+class TestDeltaWriterSilverValidatorInit:
+    """Tests for DeltaWriter initialization with Silver validator."""
+
+    def test_init_with_default_validator(self, noop_logger):
+        """Test DeltaWriter creates NoOpSilverValidator when not provided."""
+        from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+
+        writer = DeltaWriter(
+            base_path="/tmp/silver", logger=noop_logger, require_lock=False
+        )
+        assert isinstance(writer._silver_validator, NoOpSilverValidator)
+
+    def test_init_with_custom_validator(self, noop_logger):
+        """Test DeltaWriter accepts custom SilverValidatorPort."""
+        from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+
+        custom_validator = PanderaSilverValidator()
+        writer = DeltaWriter(
+            base_path="/tmp/silver",
+            logger=noop_logger,
+            silver_validator=custom_validator,
+            require_lock=False,
+        )
+        assert writer._silver_validator is custom_validator
+
+    def test_init_with_pandera_schema_validator(self, noop_logger):
+        """Test DeltaWriter with PanderaSilverValidator with schema."""
+        import pandera as pa
+
+        from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+
+        schema = pa.DataFrameSchema(
+            {
+                "entity_id": pa.Column(str),
+                "value": pa.Column(float),
+            }
+        )
+        validator = PanderaSilverValidator(schema=schema)
+        writer = DeltaWriter(
+            base_path="/tmp/silver",
+            logger=noop_logger,
+            silver_validator=validator,
+            require_lock=False,
+        )
+        assert writer._silver_validator is validator
+
+
+@pytest.mark.unit
+class TestDeltaWriterValidateSilverPandera:
+    """Tests for _validate_silver_pandera method."""
+
+    def test_validate_silver_pandera_with_noop_validator(self, noop_logger):
+        """Test _validate_silver_pandera with NoOp validator passes."""
+        from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+
+        writer = DeltaWriter(
+            base_path="/tmp/silver",
+            logger=noop_logger,
+            silver_validator=NoOpSilverValidator(),
+            require_lock=False,
+        )
+        records = [{"entity_id": "CHEMBL123", "value": 5.5}]
+        # Should not raise
+        writer._validate_silver_pandera(records, "test.table")
+
+    def test_validate_silver_pandera_with_valid_records(self, noop_logger):
+        """Test _validate_silver_pandera passes with valid records."""
+        import pandera as pa
+
+        from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+
+        schema = pa.DataFrameSchema(
+            {
+                "entity_id": pa.Column(str),
+                "value": pa.Column(float),
+            }
+        )
+        validator = PanderaSilverValidator(schema=schema)
+        writer = DeltaWriter(
+            base_path="/tmp/silver",
+            logger=noop_logger,
+            silver_validator=validator,
+            require_lock=False,
+        )
+        records = [{"entity_id": "CHEMBL123", "value": 5.5}]
+        # Should not raise
+        writer._validate_silver_pandera(records, "test.table")
+
+    def test_validate_silver_pandera_with_invalid_records_raises(self, noop_logger):
+        """Test _validate_silver_pandera raises SchemaViolationError for invalid records."""
+        import pandera as pa
+
+        from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+
+        schema = pa.DataFrameSchema(
+            {
+                "entity_id": pa.Column(str),
+                "value": pa.Column(float, checks=pa.Check.ge(0)),
+            }
+        )
+        validator = PanderaSilverValidator(schema=schema)
+        writer = DeltaWriter(
+            base_path="/tmp/silver",
+            logger=noop_logger,
+            silver_validator=validator,
+            require_lock=False,
+        )
+        records = [{"entity_id": "CHEMBL123", "value": -5.5}]  # Negative value fails
+
+        with pytest.raises(SchemaViolationError) as exc_info:
+            writer._validate_silver_pandera(records, "test.table")
+
+        assert exc_info.value.table == "test.table"
+        assert len(exc_info.value.errors) > 0
+
+    def test_validate_silver_pandera_logs_error_on_failure(self):
+        """Test _validate_silver_pandera logs error when validation fails."""
+        import pandera as pa
+
+        from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+
+        schema = pa.DataFrameSchema(
+            {
+                "entity_id": pa.Column(str),
+                "value": pa.Column(float, checks=pa.Check.ge(0)),
+            }
+        )
+        validator = PanderaSilverValidator(schema=schema)
+        mock_logger = MagicMock()
+        writer = DeltaWriter(
+            base_path="/tmp/silver",
+            logger=mock_logger,
+            silver_validator=validator,
+            require_lock=False,
+        )
+        records = [{"entity_id": "CHEMBL123", "value": -5.5}]
+
+        with pytest.raises(SchemaViolationError):
+            writer._validate_silver_pandera(records, "test.table")
+
+        mock_logger.error.assert_called_once()
+        call_args = mock_logger.error.call_args
+        assert call_args[0][0] == "Silver Pandera validation failed"
+        assert call_args[1]["table"] == "test.table"
+
+    def test_validate_silver_pandera_increments_metric_on_failure(self):
+        """Test _validate_silver_pandera increments metric when validation fails."""
+        import pandera as pa
+
+        from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+
+        schema = pa.DataFrameSchema(
+            {
+                "entity_id": pa.Column(str),
+                "value": pa.Column(float, checks=pa.Check.ge(0)),
+            }
+        )
+        validator = PanderaSilverValidator(schema=schema)
+        mock_metrics = MagicMock()
+        writer = DeltaWriter(
+            base_path="/tmp/silver",
+            logger=NoOpLogger(),
+            silver_validator=validator,
+            metrics=mock_metrics,
+            require_lock=False,
+        )
+        records = [{"entity_id": "CHEMBL123", "value": -5.5}]
+
+        with pytest.raises(SchemaViolationError):
+            writer._validate_silver_pandera(records, "test.table")
+
+        mock_metrics.increment_counter.assert_called_once_with(
+            "silver_validation_failures_total",
+            1,
+            {"table": "test.table"},
+        )
+
+
+@pytest.mark.unit
+class TestDeltaWriterWriteSilverWithPanderaValidation:
+    """Tests for write_silver with Pandera validation integration."""
+
+    @pytest.mark.asyncio
+    async def test_write_silver_pandera_validation_fails(self, valid_records, noop_logger):
+        """Test write_silver raises SchemaViolationError when Pandera validation fails."""
+        import pandera as pa
+        import pyarrow as arrow_pa
+
+        from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+
+        # Schema that will fail: requires value >= 100
+        pandera_schema = pa.DataFrameSchema(
+            {
+                "value": pa.Column(float, checks=pa.Check.ge(100)),
+            }
+        )
+        validator = PanderaSilverValidator(schema=pandera_schema)
+
+        arrow_schema = arrow_pa.schema(
+            [
+                arrow_pa.field("entity_id", arrow_pa.string()),
+                arrow_pa.field("value", arrow_pa.float64()),
+                arrow_pa.field("_run_id", arrow_pa.string()),
+                arrow_pa.field("_run_type", arrow_pa.string()),
+                arrow_pa.field("_source_batch_id", arrow_pa.string()),
+                arrow_pa.field("_ingestion_ts", arrow_pa.string()),
+            ]
+        )
+
+        writer = DeltaWriter(
+            base_path="/tmp/silver",
+            logger=noop_logger,
+            silver_validator=validator,
+            require_lock=False,
+        )
+
+        with pytest.raises(SchemaViolationError) as exc_info:
+            await writer.write_silver(
+                table_name="test.table",
+                records=valid_records,
+                primary_keys=["entity_id"],
+                schema=arrow_schema,
+                mode="merge",
+            )
+
+        assert exc_info.value.table == "test.table"
+
+    @pytest.mark.asyncio
+    async def test_write_silver_pandera_validation_passes(self, valid_records, noop_logger):
+        """Test write_silver proceeds when Pandera validation passes."""
+        import pandera as pa
+        import pyarrow as arrow_pa
+        from deltalake.exceptions import TableNotFoundError as DeltaTableNotFoundError
+
+        from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+
+        # Schema that will pass: value >= 0
+        pandera_schema = pa.DataFrameSchema(
+            {
+                "value": pa.Column(float, checks=pa.Check.ge(0)),
+            }
+        )
+        validator = PanderaSilverValidator(schema=pandera_schema)
+
+        arrow_schema = arrow_pa.schema(
+            [
+                arrow_pa.field("entity_id", arrow_pa.string()),
+                arrow_pa.field("value", arrow_pa.float64()),
+                arrow_pa.field("_run_id", arrow_pa.string()),
+                arrow_pa.field("_run_type", arrow_pa.string()),
+                arrow_pa.field("_source_batch_id", arrow_pa.string()),
+                arrow_pa.field("_ingestion_ts", arrow_pa.string()),
+            ]
+        )
+
+        with (
+            patch(
+                "bioetl.infrastructure.storage.delta_writer.DeltaTable",
+                side_effect=DeltaTableNotFoundError("Not found"),
+            ),
+            patch(
+                "bioetl.infrastructure.storage.delta_writer.write_deltalake"
+            ) as mock_write,
+        ):
+            writer = DeltaWriter(
+                base_path="/tmp/silver",
+                logger=noop_logger,
+                silver_validator=validator,
+                require_lock=False,
+            )
+
+            # Should not raise
+            await writer.write_silver(
+                table_name="test.table",
+                records=valid_records,
+                primary_keys=["entity_id"],
+                schema=arrow_schema,
+                mode="merge",
+            )
+
+            # Verify write was called (validation passed)
+            mock_write.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_write_silver_noop_validator_allows_write(self, valid_records, noop_logger):
+        """Test write_silver with NoOp validator allows write without Pandera."""
+        import pyarrow as arrow_pa
+        from deltalake.exceptions import TableNotFoundError as DeltaTableNotFoundError
+
+        from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+
+        arrow_schema = arrow_pa.schema(
+            [
+                arrow_pa.field("entity_id", arrow_pa.string()),
+                arrow_pa.field("value", arrow_pa.float64()),
+                arrow_pa.field("_run_id", arrow_pa.string()),
+                arrow_pa.field("_run_type", arrow_pa.string()),
+                arrow_pa.field("_source_batch_id", arrow_pa.string()),
+                arrow_pa.field("_ingestion_ts", arrow_pa.string()),
+            ]
+        )
+
+        with (
+            patch(
+                "bioetl.infrastructure.storage.delta_writer.DeltaTable",
+                side_effect=DeltaTableNotFoundError("Not found"),
+            ),
+            patch(
+                "bioetl.infrastructure.storage.delta_writer.write_deltalake"
+            ) as mock_write,
+        ):
+            # Default NoOp validator
+            writer = DeltaWriter(
+                base_path="/tmp/silver",
+                logger=noop_logger,
+                require_lock=False,
+            )
+
+            # Should not raise
+            await writer.write_silver(
+                table_name="test.table",
+                records=valid_records,
+                primary_keys=["entity_id"],
+                schema=arrow_schema,
+                mode="merge",
+            )
+
+            # Verify write was called
+            mock_write.assert_called_once()

--- a/tests/unit/infrastructure/validation/__init__.py
+++ b/tests/unit/infrastructure/validation/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for validation infrastructure."""

--- a/tests/unit/infrastructure/validation/test_pandera_validator.py
+++ b/tests/unit/infrastructure/validation/test_pandera_validator.py
@@ -1,0 +1,260 @@
+"""Unit tests for Pandera validators.
+
+Tests for PanderaSilverValidator, PanderaGoldValidator, and their NoOp counterparts.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from bioetl.domain.types import ValidationResult
+from bioetl.infrastructure.validation.pandera_validator import (
+    NoOpGoldValidator,
+    NoOpSilverValidator,
+    PanderaGoldValidator,
+    PanderaSilverValidator,
+)
+
+
+@pytest.fixture(autouse=True)
+def suppress_pandera_future_warnings():
+    """Suppress Pandera import FutureWarnings during tests."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning, module="pandera")
+        yield
+
+
+@pytest.mark.unit
+class TestPanderaSilverValidator:
+    """Tests for PanderaSilverValidator."""
+
+    def test_validate_empty_records_returns_valid(self):
+        """Test that empty records list returns valid result."""
+        validator = PanderaSilverValidator()
+        result = validator.validate([])
+        assert result.valid is True
+        assert result.errors == []
+
+    def test_validate_without_schema_returns_valid(self):
+        """Test that validation without schema returns valid (non-strict mode)."""
+        validator = PanderaSilverValidator(schema=None, strict=False)
+        records = [{"entity_id": "CHEMBL123", "value": 5.5}]
+        result = validator.validate(records)
+        assert result.valid is True
+        assert result.errors == []
+
+    def test_validate_without_schema_strict_mode_returns_invalid(self):
+        """Test that validation without schema in strict mode returns invalid."""
+        validator = PanderaSilverValidator(schema=None, strict=True)
+        records = [{"entity_id": "CHEMBL123", "value": 5.5}]
+        result = validator.validate(records)
+        assert result.valid is False
+        assert "Silver schema is required but not provided" in result.errors
+
+    def test_validate_with_schema_valid_records(self):
+        """Test validation passes for records matching schema."""
+        import pandera as pa
+
+        schema = pa.DataFrameSchema(
+            {
+                "entity_id": pa.Column(str),
+                "value": pa.Column(float),
+            }
+        )
+        validator = PanderaSilverValidator(schema=schema)
+        records = [
+            {"entity_id": "CHEMBL123", "value": 5.5},
+            {"entity_id": "CHEMBL456", "value": 7.2},
+        ]
+        result = validator.validate(records)
+        assert result.valid is True
+        assert result.errors == []
+
+    def test_validate_with_schema_invalid_records(self):
+        """Test validation fails for records not matching schema."""
+        import pandera as pa
+
+        schema = pa.DataFrameSchema(
+            {
+                "entity_id": pa.Column(str),
+                "value": pa.Column(float, checks=pa.Check.ge(0)),
+            }
+        )
+        validator = PanderaSilverValidator(schema=schema)
+        records = [
+            {"entity_id": "CHEMBL123", "value": -5.5},  # Negative value should fail
+        ]
+        result = validator.validate(records)
+        assert result.valid is False
+        assert len(result.errors) > 0
+
+    def test_validate_with_schema_missing_column(self):
+        """Test validation fails when required column is missing."""
+        import pandera as pa
+
+        schema = pa.DataFrameSchema(
+            {
+                "entity_id": pa.Column(str),
+                "required_field": pa.Column(str),
+            }
+        )
+        validator = PanderaSilverValidator(schema=schema)
+        records = [
+            {"entity_id": "CHEMBL123"},  # Missing required_field
+        ]
+        result = validator.validate(records)
+        assert result.valid is False
+        assert len(result.errors) > 0
+
+    def test_validate_with_nullable_columns(self):
+        """Test validation passes with nullable columns when using valid types."""
+        import math
+
+        import pandera as pa
+
+        schema = pa.DataFrameSchema(
+            {
+                "entity_id": pa.Column(str),
+                "optional_value": pa.Column(float, nullable=True),
+            }
+        )
+        validator = PanderaSilverValidator(schema=schema)
+        # Use NaN instead of None to maintain float64 dtype
+        records = [
+            {"entity_id": "CHEMBL123", "optional_value": math.nan},
+            {"entity_id": "CHEMBL456", "optional_value": 5.5},
+        ]
+        result = validator.validate(records)
+        assert result.valid is True
+
+
+@pytest.mark.unit
+class TestNoOpSilverValidator:
+    """Tests for NoOpSilverValidator."""
+
+    def test_validate_always_returns_valid(self):
+        """Test that NoOpSilverValidator always returns valid."""
+        validator = NoOpSilverValidator()
+        records = [{"entity_id": "CHEMBL123", "invalid_field": "xyz"}]
+        result = validator.validate(records)
+        assert result.valid is True
+        assert result.errors == []
+
+    def test_validate_empty_records_returns_valid(self):
+        """Test that empty records also returns valid."""
+        validator = NoOpSilverValidator()
+        result = validator.validate([])
+        assert result.valid is True
+        assert result.errors == []
+
+    def test_implements_validation_result_protocol(self):
+        """Test that validate returns ValidationResult type."""
+        validator = NoOpSilverValidator()
+        result = validator.validate([{"test": "data"}])
+        assert isinstance(result, ValidationResult)
+
+
+@pytest.mark.unit
+class TestPanderaGoldValidator:
+    """Tests for PanderaGoldValidator."""
+
+    def test_validate_empty_records_returns_valid(self):
+        """Test that empty records list returns valid result."""
+        validator = PanderaGoldValidator()
+        result = validator.validate([])
+        assert result.valid is True
+        assert result.errors == []
+
+    def test_validate_without_schema_returns_valid(self):
+        """Test that validation without schema returns valid (non-strict mode)."""
+        validator = PanderaGoldValidator(schema=None, strict=False)
+        records = [{"entity_id": "CHEMBL123", "value": 5.5}]
+        result = validator.validate(records)
+        assert result.valid is True
+        assert result.errors == []
+
+    def test_validate_without_schema_strict_mode_returns_invalid(self):
+        """Test that validation without schema in strict mode returns invalid."""
+        validator = PanderaGoldValidator(schema=None, strict=True)
+        records = [{"entity_id": "CHEMBL123", "value": 5.5}]
+        result = validator.validate(records)
+        assert result.valid is False
+        assert "Gold schema is required but not provided" in result.errors
+
+    def test_validate_with_schema_valid_records(self):
+        """Test validation passes for records matching schema."""
+        import pandera as pa
+
+        schema = pa.DataFrameSchema(
+            {
+                "entity_id": pa.Column(str),
+                "value": pa.Column(float),
+            }
+        )
+        validator = PanderaGoldValidator(schema=schema)
+        records = [
+            {"entity_id": "CHEMBL123", "value": 5.5},
+            {"entity_id": "CHEMBL456", "value": 7.2},
+        ]
+        result = validator.validate(records)
+        assert result.valid is True
+        assert result.errors == []
+
+
+@pytest.mark.unit
+class TestNoOpGoldValidator:
+    """Tests for NoOpGoldValidator."""
+
+    def test_validate_always_returns_valid(self):
+        """Test that NoOpGoldValidator always returns valid."""
+        validator = NoOpGoldValidator()
+        records = [{"entity_id": "CHEMBL123", "invalid_field": "xyz"}]
+        result = validator.validate(records)
+        assert result.valid is True
+        assert result.errors == []
+
+    def test_implements_validation_result_protocol(self):
+        """Test that validate returns ValidationResult type."""
+        validator = NoOpGoldValidator()
+        result = validator.validate([{"test": "data"}])
+        assert isinstance(result, ValidationResult)
+
+
+@pytest.mark.unit
+class TestSilverValidatorPortProtocol:
+    """Tests for SilverValidatorPort protocol compliance."""
+
+    def test_pandera_silver_validator_is_runtime_checkable(self):
+        """Test that PanderaSilverValidator can be runtime checked."""
+        from bioetl.domain.ports.validation import SilverValidatorPort
+
+        validator = PanderaSilverValidator()
+        assert isinstance(validator, SilverValidatorPort)
+
+    def test_noop_silver_validator_is_runtime_checkable(self):
+        """Test that NoOpSilverValidator can be runtime checked."""
+        from bioetl.domain.ports.validation import SilverValidatorPort
+
+        validator = NoOpSilverValidator()
+        assert isinstance(validator, SilverValidatorPort)
+
+
+@pytest.mark.unit
+class TestGoldValidatorPortProtocol:
+    """Tests for GoldValidatorPort protocol compliance."""
+
+    def test_pandera_gold_validator_is_runtime_checkable(self):
+        """Test that PanderaGoldValidator can be runtime checked."""
+        from bioetl.domain.ports.validation import GoldValidatorPort
+
+        validator = PanderaGoldValidator()
+        assert isinstance(validator, GoldValidatorPort)
+
+    def test_noop_gold_validator_is_runtime_checkable(self):
+        """Test that NoOpGoldValidator can be runtime checked."""
+        from bioetl.domain.ports.validation import GoldValidatorPort
+
+        validator = NoOpGoldValidator()
+        assert isinstance(validator, GoldValidatorPort)


### PR DESCRIPTION
Implements PanderaSilverValidator analogous to PanderaGoldValidator, allowing Silver records to be validated using Pandera schemas before writing to Delta Lake.

Changes:
- Add SilverValidatorPort protocol in domain/ports/validation.py
- Create PanderaSilverValidator and NoOpSilverValidator classes
- Integrate optional silver_validator into DeltaWriter constructor
- Add _validate_silver_pandera method called during write_silver
- Add comprehensive unit tests for validator and DeltaWriter integration

The validator is optional with NoOpSilverValidator as default for backward compatibility. Validation failures raise SchemaViolationError and increment the silver_validation_failures_total metric.