### PR TITLE
Remove Redis SETNX/EXPIRE must requirement

### DIFF
--- a/docs/00-project_rules/02-user-rules.md
+++ b/docs/00-project_rules/02-user-rules.md
@@ -160,15 +160,14 @@
 
 ### 2.13. Конкурентность и блокировки (MUST)
 
-| Параметр      | Значение                 |
+> **Note**: Local-Only Deployment (ADR-010). Redis отложен для будущего распределённого развёртывания.
+
+| Параметр      | Значение (Local-Only)    |
 |---------------|--------------------------|
-| Механизм      | Redis `SETNX` + `EXPIRE` |
-| TTL           | 60 секунд                |
-| Heartbeat     | Каждые 20 сек            |
-| Fencing Token | `owner_id` (run_id)      |
+| Механизм      | `MemoryLock` (in-process)|
 | Max Duration  | 4 часа                   |
 
-**Invariant**: Потеря блокировки = потеря права на запись. Safety Guard **MUST** валидировать `owner_id` перед записью.
+**Invariant**: Потеря блокировки = потеря права на запись. Safety Guard **MUST** валидировать lock ownership перед записью.
 
 ### 2.14. Рефакторинг модулей (MUST)
 
@@ -219,7 +218,6 @@ grep -r "X" src/bioetl/domain/__init__.py
 | Рефакторить без карты зависимостей         | Высокий риск регрессии              |
 | Sentinel values (-1, "N/A")                | Используйте NULL                    |
 | Raw Parquet в Silver                       | Используйте Delta Lake              |
-| Смешивание бэкендов (Redis + DB) для locks | Inconsistency                       |
 | Использовать `print()` для логирования     | Нарушает политику структурных логов |
 
 ## 4. Disaster Recovery (SHOULD)

--- a/docs/00-project_rules/07-consistency-check.md
+++ b/docs/00-project_rules/07-consistency-check.md
@@ -12,7 +12,7 @@
     - Delta `VACUUM` еженедельно `retention_period=7 days`.
     - Forensic retention (7d по умолчанию; 30d для Critical).
     - Schema Drift policy (Info/Warn/Critical + SLA 48h).
-    - Locking: Redis SETNX + EXPIRE; TTL=60s; heartbeat=20s; fencing token; Max 4h; safety guard.
+    - Locking: MemoryLock (Local-Only); Max 4h; safety guard.
     - Circuit Breaker: trigger=5, open=5m, half-open probe; метрики `circuit_breaker_state`, `trips_total`.
     - DQ thresholds: 5%/20%; аномалии: 2x/5x baseline; cold start.
     - Secrets policy; PII salted; Graceful Shutdown; DR RPO/RTO.
@@ -33,7 +33,7 @@ grep -R "Синхронизировано с RULES.md v5.0" docs/00-project_rule
 # 2) Ключевые формулировки (примерный набор)
 grep -R "Raw Parquet" docs/00-project_rules/00-rules-summary.md
 grep -R "VACUUM" docs/00-project_rules/
-grep -R "Redis.*SETNX.*EXPIRE" -n docs/00-project_rules/
+grep -R "MemoryLock" -n docs/00-project_rules/
 grep -R "Trigger | 5" -n docs/00-project_rules/00-rules-summary.md
 grep -R "5%.*20%" -n docs/00-project_rules/
 grep -R "forensic_retention" -n docs/

--- a/docs/templates/pipeline-review-checklist.md
+++ b/docs/templates/pipeline-review-checklist.md
@@ -96,12 +96,11 @@ Use this checklist when reviewing new or modified pipelines.
 
 ## 9. Locking & Concurrency (RULES.md §3.3)
 
-- [ ] Distributed lock implemented (Redis SETNX + EXPIRE)
+> **Note**: Local-Only Deployment (ADR-010). MemoryLock используется для локального развёртывания.
+
+- [ ] Lock implemented (`MemoryLock` for Local-Only)
 - [ ] Lock key format: `lock:{provider}_{entity}`
 - [ ] Backfill uses exclusive lock: `lock:{provider}_{entity}:exclusive`
-- [ ] TTL: 60 seconds
-- [ ] Heartbeat: every 20 seconds
-- [ ] Fencing Token (`owner_id`) validated before write
 - [ ] Max Duration: 4 hours
 - [ ] Safety Guard: lock validated before Delta write
 


### PR DESCRIPTION
Replace Redis distributed locking requirements with MemoryLock for Local-Only deployment (ADR-010). Redis remains documented as a future option for distributed deployment but is no longer a MUST requirement.

Files updated:
- 02-user-rules.md: Section 2.13 now uses MemoryLock
- 07-consistency-check.md: Updated locking invariant
- pipeline-review-checklist.md: Updated locking checklist