### PR TITLE
Review and improve refactoring plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,7 @@ src/bioetl/
 
 | Компонент | ❌ Ложное утверждение | ✅ Реальность |
 |-----------|----------------------|---------------|
+| **Email в config/adapters** | "PII поля (email) требуют хэширования HashService" | **НЕ PII**: `default_email` — технический идентификатор для NCBI API, не персональные данные. NCBI требует email для идентификации инструмента. См. `config.py:364-371`, `pubmed_client.py:38-42` |
 | **PipelineRunner** | "God object, слишком много ответственностей" | **173 строки**, делегирует через `RunnerServices` bundle (`runner.py:84-88`) |
 | **bootstrap_pipeline** | "Смешивает сборку и бизнес-логику" | Тонкий фасад, делегирует фабрикам: `factory.create_runner()` |
 | **ChEMBL Adapter** | "Монолит 517 строк, объединяет всё" | **Делегирует** через `EntityMapper` (112 LOC), `ErrorClassifier`, `AdapterMetrics`, `BaseHttpAdapter` (`client.py:30,76-84,90`) |

--- a/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
+++ b/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
@@ -35,7 +35,11 @@ class PubMedAdapter(BaseHttpAdapter):
     Args:
         http_client: UnifiedHTTPClient instance for making HTTP requests.
         logger: LoggerPort instance for structured logging.
-        email: Email address for NCBI API (required).
+        email: Technical email for NCBI API tool identification (required).
+            NOTE: This is NOT PII (Personally Identifiable Information).
+            NCBI requires this for API usage tracking and rate limiting.
+            Typically set to application/developer contact email, not end-user data.
+            See: https://www.ncbi.nlm.nih.gov/books/NBK25497/
         api_key: Optional NCBI API key for higher rate limits.
         batch_size: Number of records to fetch per batch.
         metrics: Optional MetricsPort for recording adapter metrics.

--- a/src/bioetl/infrastructure/config.py
+++ b/src/bioetl/infrastructure/config.py
@@ -361,9 +361,13 @@ class Settings(BaseSettings):
     observability: ObservabilitySettings = Field(default_factory=ObservabilitySettings)
 
     # Provider-specific settings
+    # NOTE: default_email is NOT PII (Personally Identifiable Information).
+    # It is a technical API identifier required by NCBI E-utilities for
+    # tool identification and rate limit management, not user personal data.
+    # See: https://www.ncbi.nlm.nih.gov/books/NBK25497/#chapter2.Usage_Guidelines_and_Requiremen
     default_email: str = Field(
         default="default@example.com",
-        description="Default email for NCBI API",
+        description="Technical email for NCBI API tool identification (NOT user PII)",
     )
     pubmed_api_key: SecretStr | None = Field(
         default=None,

--- a/tests/security/test_security.py
+++ b/tests/security/test_security.py
@@ -260,10 +260,29 @@ class TestPrivateKeyExposure:
 
 
 class TestPIIHandling:
-    """Tests for PII handling patterns."""
+    """Tests for PII handling patterns.
+
+    IMPORTANT: Known False Positives (NOT actual PII):
+    -------------------------------------------------
+    - `email` in config.py and pubmed_client.py: This is a technical API identifier
+      required by NCBI E-utilities for tool identification, NOT user personal data.
+      NCBI mandates this for rate limiting and contact purposes.
+      See: https://www.ncbi.nlm.nih.gov/books/NBK25497/
+
+    This test uses pytest.skip() (not assert fail) because:
+    1. Pattern matching may catch false positives like API identifiers
+    2. Some fields may be intentionally excluded from Silver layer
+    3. Manual review is needed to distinguish real PII from technical identifiers
+    """
 
     def test_silver_layer_uses_hashing(self) -> None:
-        """Verify Silver layer transformers use hashing for PII fields."""
+        """Verify Silver layer transformers use hashing for PII fields.
+
+        Note: This test may flag false positives for technical identifiers
+        (e.g., NCBI API email). The test uses pytest.skip() to request manual
+        review rather than failing, as automated pattern matching cannot
+        distinguish between real PII and API configuration values.
+        """
         # Check that PII-related code uses sha256
         infrastructure_files = list((SRC_DIR / "infrastructure").rglob("*.py"))
         application_files = list((SRC_DIR / "application").rglob("*.py"))
@@ -290,7 +309,8 @@ class TestPIIHandling:
                         )
 
         # This is informational - PII fields without explicit hashing may be OK
-        # if they're excluded from Silver layer
+        # if they're excluded from Silver layer or are technical identifiers
+        # (e.g., NCBI API email is NOT user PII)
         if files_with_pii:
             pytest.skip("Review PII handling:\n" + "\n".join(files_with_pii))
 


### PR DESCRIPTION
Add documentation explaining that `default_email` in config.py and `email` in pubmed_client.py are technical API identifiers required by NCBI E-utilities for tool identification, not user personal data.

Updated files:
- config.py: Added NOTE comment and updated field description
- pubmed_client.py: Extended docstring with PII clarification
- test_security.py: Added class docstring explaining false positives
- CLAUDE.md: Added entry to architectural clarifications table

This prevents false refactoring proposals suggesting HashService implementation for these fields.