### PR TITLE
Fix PubChem canonical_smiles deprecation warning

### DIFF
--- a/src/bioetl/infrastructure/adapters/pubchem/client.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/client.py
@@ -199,13 +199,21 @@ class PubChemAdapter(BaseSyncAdapter):
         Returns:
             Dictionary with compound data
 
+        Note:
+            Uses connectivity_smiles and smiles properties instead of deprecated
+            canonical_smiles and isomeric_smiles (deprecated in pubchempy 1.0.5).
+            Output keys remain canonical_smiles/isomeric_smiles for backward
+            compatibility with domain entities and schemas.
+
         """
         return {
             "cid": compound.cid,
             "molecular_formula": compound.molecular_formula,
             "molecular_weight": compound.molecular_weight,
-            "canonical_smiles": compound.canonical_smiles,
-            "isomeric_smiles": compound.isomeric_smiles,
+            # Use connectivity_smiles (replaces deprecated canonical_smiles)
+            "canonical_smiles": compound.connectivity_smiles,
+            # Use smiles (replaces deprecated isomeric_smiles)
+            "isomeric_smiles": compound.smiles,
             "inchi": compound.inchi,
             "inchikey": compound.inchikey,
             "iupac_name": compound.iupac_name,

--- a/tests/e2e/test_pubchem_compound_e2e.py
+++ b/tests/e2e/test_pubchem_compound_e2e.py
@@ -29,16 +29,10 @@ def vcr_cassette_dir() -> Path:
 @pytest.mark.e2e
 @pytest.mark.vcr
 @pytest.mark.asyncio
-@pytest.mark.skip(
-    reason="pubchempy canonical_smiles deprecation warning - needs client update"
-)
 async def test_pubchem_compound_full_cycle(e2e_data_dir: Path):
     """E2E: PubChem Compound pipeline from fetch to Silver.
 
     Note: PubChem requires a query parameter for compound search.
-
-    SKIPPED: pubchempy library raises PubChemPyDeprecationWarning
-    for canonical_smiles. Client needs update to use connectivity_smiles.
     """
     # Arrange - PubChem requires query
     ctx = create_test_context("pubchem_compound", limit=5, query="aspirin")
@@ -68,9 +62,6 @@ async def test_pubchem_compound_full_cycle(e2e_data_dir: Path):
 @pytest.mark.e2e
 @pytest.mark.vcr
 @pytest.mark.asyncio
-@pytest.mark.skip(
-    reason="pubchempy canonical_smiles deprecation warning - needs client update"
-)
 async def test_pubchem_compound_structural_fields(e2e_data_dir: Path):
     """E2E: Verify structural fields are extracted for PubChem compounds.
 
@@ -106,9 +97,6 @@ async def test_pubchem_compound_structural_fields(e2e_data_dir: Path):
 @pytest.mark.e2e
 @pytest.mark.vcr
 @pytest.mark.asyncio
-@pytest.mark.skip(
-    reason="pubchempy canonical_smiles deprecation warning - needs client update"
-)
 async def test_pubchem_compound_query_filter(e2e_data_dir: Path):
     """E2E: Verify query parameter filters compounds correctly.
 

--- a/tests/infrastructure/adapters/test_pubchem.py
+++ b/tests/infrastructure/adapters/test_pubchem.py
@@ -61,8 +61,10 @@ def mock_pcp_compound():
     compound.cid = 123
     compound.molecular_formula = "C9H8O4"
     compound.molecular_weight = 180.16
-    compound.canonical_smiles = "CC(=O)OC1=CC=CC=C1C(=O)O"
-    compound.isomeric_smiles = "CC(=O)OC1=CC=CC=C1C(=O)O"
+    # connectivity_smiles replaces deprecated canonical_smiles (pubchempy 1.0.5)
+    compound.connectivity_smiles = "CC(=O)OC1=CC=CC=C1C(=O)O"
+    # smiles replaces deprecated isomeric_smiles (pubchempy 1.0.5)
+    compound.smiles = "CC(=O)OC1=CC=CC=C1C(=O)O"
     compound.inchi = (
         "InChI=1S/C9H8O4/c1-6(10)13-8-5-3-2-4-7(8)9(11)12/h2-5H,1H3,(H,11,12)"
     )

--- a/tests/unit/infrastructure/test_adapters.py
+++ b/tests/unit/infrastructure/test_adapters.py
@@ -153,12 +153,15 @@ class TestPubChemAdapter:
         )
 
         # Mock compound object
+        # Uses connectivity_smiles/smiles (pubchempy 1.0.5 replacements)
         class MockCompound:
             cid = 2244
             molecular_formula = "C9H8O4"
             molecular_weight = 180.16
-            canonical_smiles = "CC(=O)OC1=CC=CC=C1C(=O)O"
-            isomeric_smiles = None
+            # connectivity_smiles replaces deprecated canonical_smiles
+            connectivity_smiles = "CC(=O)OC1=CC=CC=C1C(=O)O"
+            # smiles replaces deprecated isomeric_smiles
+            smiles = None
             inchi = (
                 "InChI=1S/C9H8O4/c1-6(10)13-8-5-3-2-4-7(8)9(11)12/h2-5H,1H3,(H,11,12)"
             )


### PR DESCRIPTION
…miles

pubchempy 1.0.5 deprecated canonical_smiles and isomeric_smiles properties, replacing them with connectivity_smiles and smiles respectively.

- Update PubChemAdapter._compound_to_dict() to use new property names
- Maintain backward compatibility by keeping output keys unchanged
- Update test mocks to use new pubchempy property names
- Remove @pytest.mark.skip from 3 PubChem E2E tests