### PR TITLE
Decompose large writer modules for maintainability

### DIFF
--- a/src/bioetl/infrastructure/storage/__init__.py
+++ b/src/bioetl/infrastructure/storage/__init__.py
@@ -1,6 +1,10 @@
 """Storage adapters for Bronze/Silver/Gold layers.
 
 Implements RULES.md §2.1 - Medallion Architecture.
+
+This package provides:
+- Writers: BronzeWriter, DeltaWriter (Silver), GoldWriter
+- Utilities: RetentionManager (VACUUM, optimize, time travel), validate_lock_for_write
 """
 
 from __future__ import annotations
@@ -16,6 +20,8 @@ from bioetl.domain.exceptions import (
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 from bioetl.infrastructure.storage.gold_writer import GoldWriter
+from bioetl.infrastructure.storage.lock_validator import validate_lock_for_write
+from bioetl.infrastructure.storage.retention_manager import RetentionManager
 
 __all__ = [
     "BronzeWriter",
@@ -23,8 +29,10 @@ __all__ = [
     "DeltaWriter",
     "GoldWriter",
     "MergeConflictError",
+    "RetentionManager",
     "SchemaViolationError",
     "StorageError",
     "TableNotFoundError",
     "UploadError",
+    "validate_lock_for_write",
 ]

--- a/src/bioetl/infrastructure/storage/bronze_writer.py
+++ b/src/bioetl/infrastructure/storage/bronze_writer.py
@@ -31,10 +31,11 @@ import zstandard as zstd
 if TYPE_CHECKING:
     from bioetl.domain.ports import AuditPort, LoggerPort, MetricsPort, TracingPort
 
-from bioetl.domain.locking import LockContext, LockNotHeldError
+from bioetl.domain.locking import LockContext
 from bioetl.domain.ports.audit import AuditEntry, AuditLayer, AuditOperation
 from bioetl.domain.types import BatchID, RunID, RunType
 from bioetl.infrastructure.storage._atomic import atomic_write_bytes
+from bioetl.infrastructure.storage.lock_validator import validate_lock_for_write
 
 
 class BronzeWriter:
@@ -163,74 +164,19 @@ class BronzeWriter:
     ) -> None:
         """Validate that lock is held before write operation.
 
+        Delegates to centralized lock_validator module.
         Implements RULES.md §3.3 - Writers MUST verify lock held.
-
-        Args:
-            provider: Provider name (e.g., "chembl").
-            entity: Entity name (e.g., "activity").
-            lock_context: The lock context from application layer.
-            expected_owner_id: Expected owner RunID (fencing token). If provided,
-                              validates that lock_context.owner_id matches to prevent
-                              writes from stale lock holders after lock re-acquisition.
-
-        Raises:
-            LockNotHeldError: If lock is not held, doesn't match,
-                             is expired, or owner_id doesn't match.
         """
-        if not self._require_lock:
-            return  # Lock validation disabled (e.g., for tests)
-
         table_name = f"{provider}_{entity}"
-        expected_key = f"lock:{table_name}"
-
-        if lock_context is None:
-            self.logger.error(
-                "Write attempted without lock",
-                provider=provider,
-                entity=entity,
-                expected_key=expected_key,
-            )
-            raise LockNotHeldError("write_bronze", expected_key)
-
-        if not lock_context.matches_table(table_name):
-            self.logger.error(
-                "Write attempted with wrong lock",
-                provider=provider,
-                entity=entity,
-                expected_key=expected_key,
-                actual_key=lock_context.key,
-            )
-            raise LockNotHeldError(
-                f"write_bronze (got {lock_context.key})",
-                expected_key,
-            )
-
-        if not lock_context.is_valid():
-            self.logger.error(
-                "Write attempted with expired lock",
-                provider=provider,
-                entity=entity,
-                lock_key=lock_context.key,
-            )
-            raise LockNotHeldError(
-                "write_bronze (lock expired)",
-                expected_key,
-            )
-
-        # Fencing token validation: verify owner_id matches expected
-        if expected_owner_id is not None and lock_context.owner_id != expected_owner_id:
-            self.logger.error(
-                "Write attempted with wrong owner_id (fencing token mismatch)",
-                provider=provider,
-                entity=entity,
-                expected_owner_id=str(expected_owner_id),
-                actual_owner_id=str(lock_context.owner_id),
-                lock_key=lock_context.key,
-            )
-            raise LockNotHeldError(
-                f"write_bronze (owner mismatch: {lock_context.owner_id} != {expected_owner_id})",
-                expected_key,
-            )
+        validate_lock_for_write(
+            table_name=table_name,
+            lock_context=lock_context,
+            logger=self.logger,
+            operation="write_bronze",
+            require_lock=self._require_lock,
+            expected_owner_id=expected_owner_id,
+            log_context={"provider": provider, "entity": entity},
+        )
 
     def _validate_json_records(self, records: Iterator[bytes]) -> Iterator[bytes]:
         """Validate that each record is valid JSON bytes (lazy generator).

--- a/src/bioetl/infrastructure/storage/delta_writer.py
+++ b/src/bioetl/infrastructure/storage/delta_writer.py
@@ -37,9 +37,8 @@ from bioetl.domain.exceptions import (
     PolicyViolationError,
     SchemaEvolutionError,
     SchemaViolationError,
-    TableNotFoundError,
 )
-from bioetl.domain.locking import LockContext, LockNotHeldError
+from bioetl.domain.locking import LockContext
 from bioetl.domain.medallion import (
     Layer,
     SilverWriteMode,
@@ -47,6 +46,8 @@ from bioetl.domain.medallion import (
     WriteModePolicy,
 )
 from bioetl.domain.types import RunID
+from bioetl.infrastructure.storage.lock_validator import validate_lock_for_write
+from bioetl.infrastructure.storage.retention_manager import RetentionManager
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -130,6 +131,9 @@ class DeltaWriter:
             )
             silver_validator = NoOpSilverValidator()
         self._silver_validator: SilverValidatorPort = silver_validator
+
+        # Delegate retention operations to RetentionManager
+        self._retention_manager = RetentionManager(base_path)
 
     def _prepare_arrow_data(
         self,
@@ -245,68 +249,17 @@ class DeltaWriter:
     ) -> None:
         """Validate that lock is held before write operation.
 
+        Delegates to centralized lock_validator module.
         Implements RULES.md §3.3 - Writers MUST verify lock held.
-
-        Args:
-            table_name: Target table name (format: "provider_entity").
-            lock_context: The lock context from application layer.
-            expected_owner_id: Expected owner RunID (fencing token). If provided,
-                              validates that lock_context.owner_id matches to prevent
-                              writes from stale lock holders after lock re-acquisition.
-
-        Raises:
-            LockNotHeldError: If lock is not held, doesn't match table,
-                             is expired, or owner_id doesn't match.
         """
-        if not self._require_lock:
-            return  # Lock validation disabled (e.g., for tests)
-
-        expected_key = f"lock:{table_name}"
-
-        if lock_context is None:
-            self.logger.error(
-                "Write attempted without lock",
-                table=table_name,
-                expected_key=expected_key,
-            )
-            raise LockNotHeldError("write_silver", expected_key)
-
-        if not lock_context.matches_table(table_name):
-            self.logger.error(
-                "Write attempted with wrong lock",
-                table=table_name,
-                expected_key=expected_key,
-                actual_key=lock_context.key,
-            )
-            raise LockNotHeldError(
-                f"write_silver (got {lock_context.key})",
-                expected_key,
-            )
-
-        if not lock_context.is_valid():
-            self.logger.error(
-                "Write attempted with expired lock",
-                table=table_name,
-                lock_key=lock_context.key,
-            )
-            raise LockNotHeldError(
-                "write_silver (lock expired)",
-                expected_key,
-            )
-
-        # Fencing token validation: verify owner_id matches expected
-        if expected_owner_id is not None and lock_context.owner_id != expected_owner_id:
-            self.logger.error(
-                "Write attempted with wrong owner_id (fencing token mismatch)",
-                table=table_name,
-                expected_owner_id=str(expected_owner_id),
-                actual_owner_id=str(lock_context.owner_id),
-                lock_key=lock_context.key,
-            )
-            raise LockNotHeldError(
-                f"write_silver (owner mismatch: {lock_context.owner_id} != {expected_owner_id})",
-                expected_key,
-            )
+        validate_lock_for_write(
+            table_name=table_name,
+            lock_context=lock_context,
+            logger=self.logger,
+            operation="write_silver",
+            require_lock=self._require_lock,
+            expected_owner_id=expected_owner_id,
+        )
 
     def _to_policy_write_mode(self, mode: SilverWriteMode) -> WriteMode:
         """Map SilverWriteMode to WriteMode for policy validation.
@@ -761,6 +714,8 @@ class DeltaWriter:
     ) -> list[str]:
         """Remove old files that are no longer referenced by the Delta log.
 
+        Delegates to RetentionManager for maintenance operations.
+
         Args:
             table_name: Table name.
             retention_hours: Hours of retention.
@@ -768,21 +723,10 @@ class DeltaWriter:
 
         Returns:
             List of files deleted (or to be deleted).
-
         """
-        table_path = f"{self.base_path}/{table_name.replace('.', '/')}"
-        loop = asyncio.get_running_loop()
-        try:
-            dt = await loop.run_in_executor(
-                None,
-                lambda: DeltaTable(table_path),
-            )
-            return await loop.run_in_executor(
-                None,
-                lambda: dt.vacuum(retention_hours=retention_hours, dry_run=dry_run),
-            )
-        except DeltaTableNotFoundError as e:
-            raise TableNotFoundError(table_path) from e
+        return await self._retention_manager.vacuum(
+            table_name, retention_hours=retention_hours, dry_run=dry_run
+        )
 
     async def optimize(
         self,
@@ -792,6 +736,8 @@ class DeltaWriter:
     ) -> dict[str, Any]:
         """Optimize table layout (compaction).
 
+        Delegates to RetentionManager for maintenance operations.
+
         Args:
             table_name: Table name.
             target_size: Target file size in bytes (currently unused, reserved for future).
@@ -799,49 +745,23 @@ class DeltaWriter:
 
         Returns:
             Optimization metrics.
-
         """
-        # Note: target_size reserved for future delta-rs API support
-        _ = target_size  # Suppress unused variable warning
-        table_path = f"{self.base_path}/{table_name.replace('.', '/')}"
-        loop = asyncio.get_running_loop()
-        filters = partition_filters  # Capture for lambda closure
-        try:
-            dt = await loop.run_in_executor(
-                None,
-                lambda: DeltaTable(table_path),
-            )
-            return await loop.run_in_executor(
-                None, lambda: dt.optimize.compact(partition_filters=filters)
-            )
-        except DeltaTableNotFoundError as e:
-            raise TableNotFoundError(table_path) from e
+        return await self._retention_manager.optimize(
+            table_name, target_size=target_size, partition_filters=partition_filters
+        )
 
     async def get_table_info(self, table_name: str) -> dict[str, Any]:
         """Get metadata about a Delta table.
+
+        Delegates to RetentionManager for maintenance operations.
 
         Args:
             table_name: Table name.
 
         Returns:
             Dictionary with table metadata (version, files, history).
-
         """
-        table_path = f"{self.base_path}/{table_name.replace('.', '/')}"
-        loop = asyncio.get_running_loop()
-        try:
-            dt = await loop.run_in_executor(
-                None,
-                lambda: DeltaTable(table_path),
-            )
-            return {
-                "version": dt.version(),
-                "num_files": len(dt.files()),
-                "schema": dt.schema().to_arrow(),
-                "metadata": dt.metadata(),
-            }
-        except DeltaTableNotFoundError as e:
-            raise TableNotFoundError(table_path) from e
+        return await self._retention_manager.get_table_info(table_name)
 
     async def time_travel(
         self,
@@ -851,6 +771,8 @@ class DeltaWriter:
     ) -> DeltaTable:
         """Read a previous version of the table.
 
+        Delegates to RetentionManager for maintenance operations.
+
         Args:
             table_name: Table name.
             version: Version number.
@@ -858,35 +780,7 @@ class DeltaWriter:
 
         Returns:
             PyArrow table or equivalent of the snapshot.
-
         """
-        if version is not None and timestamp is not None:
-            raise ValueError("Specify either version or timestamp, not both")
-
-        table_path = f"{self.base_path}/{table_name.replace('.', '/')}"
-        loop = asyncio.get_running_loop()
-
-        try:
-            if version is not None:
-                return await loop.run_in_executor(
-                    None,
-                    lambda: DeltaTable(
-                        table_path,
-                        version=version,
-                    ),
-                )
-            elif timestamp is not None:
-                timestamp_str = timestamp.isoformat()
-                return await loop.run_in_executor(
-                    None,
-                    lambda: DeltaTable(
-                        table_path,
-                        storage_options={
-                            "time_travel": timestamp_str,
-                        },
-                    ),
-                )
-            else:
-                raise ValueError("Must specify either version or timestamp")
-        except DeltaTableNotFoundError as e:
-            raise TableNotFoundError(table_path) from e
+        return await self._retention_manager.time_travel(
+            table_name, version=version, timestamp=timestamp
+        )

--- a/src/bioetl/infrastructure/storage/gold_writer.py
+++ b/src/bioetl/infrastructure/storage/gold_writer.py
@@ -27,10 +27,11 @@ import pyarrow as pa
 from deltalake import DeltaTable, write_deltalake
 from deltalake.exceptions import TableNotFoundError
 
-from bioetl.domain.locking import LockContext, LockNotHeldError
+from bioetl.domain.locking import LockContext
 from bioetl.domain.medallion import GoldWriteMode
 from bioetl.domain.ports.audit import AuditEntry, AuditLayer, AuditOperation
 from bioetl.domain.types import RunID
+from bioetl.infrastructure.storage.lock_validator import validate_lock_for_write
 
 T = TypeVar("T")
 
@@ -102,68 +103,17 @@ class GoldWriter:
     ) -> None:
         """Validate that lock is held before write operation.
 
+        Delegates to centralized lock_validator module.
         Implements RULES.md §3.3 - Writers MUST verify lock held.
-
-        Args:
-            table_name: Target table name (format: "provider_entity").
-            lock_context: The lock context from application layer.
-            expected_owner_id: Expected owner RunID (fencing token). If provided,
-                              validates that lock_context.owner_id matches to prevent
-                              writes from stale lock holders after lock re-acquisition.
-
-        Raises:
-            LockNotHeldError: If lock is not held, doesn't match table,
-                             is expired, or owner_id doesn't match.
         """
-        if not self._require_lock:
-            return  # Lock validation disabled (e.g., for tests)
-
-        expected_key = f"lock:{table_name}"
-
-        if lock_context is None:
-            self.logger.error(
-                "Write attempted without lock",
-                table=table_name,
-                expected_key=expected_key,
-            )
-            raise LockNotHeldError("write_gold", expected_key)
-
-        if not lock_context.matches_table(table_name):
-            self.logger.error(
-                "Write attempted with wrong lock",
-                table=table_name,
-                expected_key=expected_key,
-                actual_key=lock_context.key,
-            )
-            raise LockNotHeldError(
-                f"write_gold (got {lock_context.key})",
-                expected_key,
-            )
-
-        if not lock_context.is_valid():
-            self.logger.error(
-                "Write attempted with expired lock",
-                table=table_name,
-                lock_key=lock_context.key,
-            )
-            raise LockNotHeldError(
-                "write_gold (lock expired)",
-                expected_key,
-            )
-
-        # Fencing token validation: verify owner_id matches expected
-        if expected_owner_id is not None and lock_context.owner_id != expected_owner_id:
-            self.logger.error(
-                "Write attempted with wrong owner_id (fencing token mismatch)",
-                table=table_name,
-                expected_owner_id=str(expected_owner_id),
-                actual_owner_id=str(lock_context.owner_id),
-                lock_key=lock_context.key,
-            )
-            raise LockNotHeldError(
-                f"write_gold (owner mismatch: {lock_context.owner_id} != {expected_owner_id})",
-                expected_key,
-            )
+        validate_lock_for_write(
+            table_name=table_name,
+            lock_context=lock_context,
+            logger=self.logger,
+            operation="write_gold",
+            require_lock=self._require_lock,
+            expected_owner_id=expected_owner_id,
+        )
 
     async def write_gold(
         self,

--- a/src/bioetl/infrastructure/storage/lock_validator.py
+++ b/src/bioetl/infrastructure/storage/lock_validator.py
@@ -1,0 +1,101 @@
+"""Lock validation utility for storage writers.
+
+Centralizes lock validation logic per RULES.md §3.3 - Writers MUST verify lock held.
+
+This module provides a single source of truth for lock validation used by:
+- BronzeWriter
+- DeltaWriter (Silver)
+- GoldWriter
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from bioetl.domain.locking import LockContext, LockNotHeldError
+from bioetl.domain.types import RunID
+
+if TYPE_CHECKING:
+    from bioetl.domain.ports import LoggerPort
+
+
+def validate_lock_for_write(
+    *,
+    table_name: str,
+    lock_context: LockContext | None,
+    logger: LoggerPort,
+    operation: str,
+    require_lock: bool = True,
+    expected_owner_id: RunID | None = None,
+    log_context: dict[str, str] | None = None,
+) -> None:
+    """Validate that lock is held before write operation.
+
+    Implements RULES.md §3.3 - Writers MUST verify lock held.
+
+    Args:
+        table_name: Target table name (format: "provider_entity").
+        lock_context: The lock context from application layer.
+        logger: Structured logger for observability.
+        operation: Operation name for error messages (e.g., "write_bronze", "write_silver").
+        require_lock: If True, validate lock is held. If False, skip validation
+                     (e.g., for tests or non-concurrent scenarios).
+        expected_owner_id: Expected owner RunID (fencing token). If provided,
+                          validates that lock_context.owner_id matches to prevent
+                          writes from stale lock holders after lock re-acquisition.
+        log_context: Additional context fields for logging (e.g., provider, entity).
+
+    Raises:
+        LockNotHeldError: If lock is not held, doesn't match table,
+                         is expired, or owner_id doesn't match.
+    """
+    if not require_lock:
+        return  # Lock validation disabled (e.g., for tests)
+
+    expected_key = f"lock:{table_name}"
+    base_log_context = {"table": table_name, "expected_key": expected_key}
+    if log_context:
+        base_log_context.update(log_context)
+
+    if lock_context is None:
+        logger.error(
+            "Write attempted without lock",
+            **base_log_context,
+        )
+        raise LockNotHeldError(operation, expected_key)
+
+    if not lock_context.matches_table(table_name):
+        logger.error(
+            "Write attempted with wrong lock",
+            actual_key=lock_context.key,
+            **base_log_context,
+        )
+        raise LockNotHeldError(
+            f"{operation} (got {lock_context.key})",
+            expected_key,
+        )
+
+    if not lock_context.is_valid():
+        logger.error(
+            "Write attempted with expired lock",
+            lock_key=lock_context.key,
+            **{k: v for k, v in base_log_context.items() if k != "expected_key"},
+        )
+        raise LockNotHeldError(
+            f"{operation} (lock expired)",
+            expected_key,
+        )
+
+    # Fencing token validation: verify owner_id matches expected
+    if expected_owner_id is not None and lock_context.owner_id != expected_owner_id:
+        logger.error(
+            "Write attempted with wrong owner_id (fencing token mismatch)",
+            expected_owner_id=str(expected_owner_id),
+            actual_owner_id=str(lock_context.owner_id),
+            lock_key=lock_context.key,
+            **{k: v for k, v in base_log_context.items() if k != "expected_key"},
+        )
+        raise LockNotHeldError(
+            f"{operation} (owner mismatch: {lock_context.owner_id} != {expected_owner_id})",
+            expected_key,
+        )

--- a/src/bioetl/infrastructure/storage/retention_manager.py
+++ b/src/bioetl/infrastructure/storage/retention_manager.py
@@ -1,0 +1,215 @@
+"""Delta table retention and maintenance operations.
+
+Implements RULES.md §2.1.1 - Delta Lake specifications:
+- REQ-DELTA-002: VACUUM scheduler (7-day retention)
+- REQ-DELTA-003: Forensic retention (7-30 days configurable)
+- REQ-DATA-008: Time Travel support
+
+This module extracts maintenance operations from DeltaWriter for better
+separation of concerns:
+- VACUUM: Remove old files no longer referenced by Delta log
+- Optimize: Compact files for better query performance
+- Time Travel: Read historical versions of tables
+- Table Info: Retrieve metadata about Delta tables
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+from deltalake import DeltaTable
+from deltalake.exceptions import TableNotFoundError as DeltaTableNotFoundError
+
+from bioetl.domain.exceptions import TableNotFoundError
+
+if TYPE_CHECKING:
+    from datetime import datetime
+    from pathlib import Path
+
+
+class RetentionManager:
+    """Manager for Delta table retention and maintenance operations.
+
+    Handles VACUUM, optimize, time travel, and table metadata retrieval.
+    Extracted from DeltaWriter to improve separation of concerns.
+    """
+
+    def __init__(self, base_path: str | Path) -> None:
+        """Initialize retention manager.
+
+        Args:
+            base_path: Base path for Delta tables (local filesystem).
+        """
+        self.base_path = str(base_path).rstrip("/")
+
+    def _get_table_path(self, table_name: str) -> str:
+        """Get the filesystem path for a table.
+
+        Args:
+            table_name: Table name (e.g., 'chembl.activity' or 'chembl_activity').
+
+        Returns:
+            Path string to the table directory.
+        """
+        return f"{self.base_path}/{table_name.replace('.', '/')}"
+
+    async def vacuum(
+        self,
+        table_name: str,
+        retention_hours: int | None = None,
+        dry_run: bool = False,
+    ) -> list[str]:
+        """Remove old files that are no longer referenced by the Delta log.
+
+        Implements REQ-DELTA-002 and REQ-DELTA-003.
+
+        Args:
+            table_name: Table name.
+            retention_hours: Hours of retention (default uses Delta Lake default of 168 hours).
+                            Must be >= 168 hours unless explicitly overridden at table level.
+            dry_run: If True, only list files to be deleted without deleting them.
+
+        Returns:
+            List of files deleted (or to be deleted in dry_run mode).
+
+        Raises:
+            TableNotFoundError: If table does not exist.
+        """
+        table_path = self._get_table_path(table_name)
+        loop = asyncio.get_running_loop()
+        try:
+            dt = await loop.run_in_executor(
+                None,
+                lambda: DeltaTable(table_path),
+            )
+            return await loop.run_in_executor(
+                None,
+                lambda: dt.vacuum(retention_hours=retention_hours, dry_run=dry_run),
+            )
+        except DeltaTableNotFoundError as e:
+            raise TableNotFoundError(table_path) from e
+
+    async def optimize(
+        self,
+        table_name: str,
+        target_size: int | None = None,
+        partition_filters: list[tuple[str, str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        """Optimize table layout through file compaction.
+
+        Compacts small files into larger ones for better query performance.
+
+        Args:
+            table_name: Table name.
+            target_size: Target file size in bytes (currently unused, reserved for future
+                        delta-rs API support).
+            partition_filters: Optional filters to limit optimization to specific partitions.
+                              Format: [(column, op, value), ...] e.g., [("date", "=", "2024-01-01")]
+
+        Returns:
+            Optimization metrics dictionary with details about files processed.
+
+        Raises:
+            TableNotFoundError: If table does not exist.
+        """
+        # Note: target_size reserved for future delta-rs API support
+        _ = target_size  # Suppress unused variable warning
+        table_path = self._get_table_path(table_name)
+        loop = asyncio.get_running_loop()
+        filters = partition_filters  # Capture for lambda closure
+        try:
+            dt = await loop.run_in_executor(
+                None,
+                lambda: DeltaTable(table_path),
+            )
+            return await loop.run_in_executor(
+                None, lambda: dt.optimize.compact(partition_filters=filters)
+            )
+        except DeltaTableNotFoundError as e:
+            raise TableNotFoundError(table_path) from e
+
+    async def get_table_info(self, table_name: str) -> dict[str, Any]:
+        """Get metadata about a Delta table.
+
+        Args:
+            table_name: Table name.
+
+        Returns:
+            Dictionary with table metadata:
+            - version: Current table version number
+            - num_files: Number of data files
+            - schema: PyArrow schema of the table
+            - metadata: Table metadata dictionary
+
+        Raises:
+            TableNotFoundError: If table does not exist.
+        """
+        table_path = self._get_table_path(table_name)
+        loop = asyncio.get_running_loop()
+        try:
+            dt = await loop.run_in_executor(
+                None,
+                lambda: DeltaTable(table_path),
+            )
+            return {
+                "version": dt.version(),
+                "num_files": len(dt.files()),
+                "schema": dt.schema().to_arrow(),
+                "metadata": dt.metadata(),
+            }
+        except DeltaTableNotFoundError as e:
+            raise TableNotFoundError(table_path) from e
+
+    async def time_travel(
+        self,
+        table_name: str,
+        version: int | None = None,
+        timestamp: datetime | None = None,
+    ) -> DeltaTable:
+        """Read a previous version of the table.
+
+        Implements REQ-DATA-008 Time Travel support.
+
+        Args:
+            table_name: Table name.
+            version: Version number to read (mutually exclusive with timestamp).
+            timestamp: Timestamp to read table as of (mutually exclusive with version).
+
+        Returns:
+            DeltaTable instance at the specified version/timestamp.
+
+        Raises:
+            ValueError: If both version and timestamp are specified, or neither is specified.
+            TableNotFoundError: If table does not exist.
+        """
+        if version is not None and timestamp is not None:
+            raise ValueError("Specify either version or timestamp, not both")
+
+        table_path = self._get_table_path(table_name)
+        loop = asyncio.get_running_loop()
+
+        try:
+            if version is not None:
+                return await loop.run_in_executor(
+                    None,
+                    lambda: DeltaTable(
+                        table_path,
+                        version=version,
+                    ),
+                )
+            elif timestamp is not None:
+                timestamp_str = timestamp.isoformat()
+                return await loop.run_in_executor(
+                    None,
+                    lambda: DeltaTable(
+                        table_path,
+                        storage_options={
+                            "time_travel": timestamp_str,
+                        },
+                    ),
+                )
+            else:
+                raise ValueError("Must specify either version or timestamp")
+        except DeltaTableNotFoundError as e:
+            raise TableNotFoundError(table_path) from e

--- a/tests/unit/infrastructure/storage/test_delta_writer.py
+++ b/tests/unit/infrastructure/storage/test_delta_writer.py
@@ -288,7 +288,7 @@ class TestDeltaWriterVacuum:
     """Tests for DeltaWriter vacuum operation."""
 
     @pytest.mark.asyncio
-    @patch("bioetl.infrastructure.storage.delta_writer.DeltaTable")
+    @patch("bioetl.infrastructure.storage.retention_manager.DeltaTable")
     async def test_vacuum_returns_deleted_files(self, mock_delta_table, noop_logger):
         """Test vacuum returns list of deleted files."""
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
@@ -309,7 +309,7 @@ class TestDeltaWriterVacuum:
         )
 
     @pytest.mark.asyncio
-    @patch("bioetl.infrastructure.storage.delta_writer.DeltaTable")
+    @patch("bioetl.infrastructure.storage.retention_manager.DeltaTable")
     async def test_vacuum_dry_run(self, mock_delta_table, noop_logger):
         """Test vacuum dry run."""
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
@@ -334,7 +334,7 @@ class TestDeltaWriterVacuum:
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
         with patch(
-            "bioetl.infrastructure.storage.delta_writer.DeltaTable",
+            "bioetl.infrastructure.storage.retention_manager.DeltaTable",
             side_effect=DeltaTableNotFoundError("Not found"),
         ):
             writer = DeltaWriter(base_path="s3://bucket/silver", logger=noop_logger, require_lock=False)
@@ -348,7 +348,7 @@ class TestDeltaWriterOptimize:
     """Tests for DeltaWriter optimize operation."""
 
     @pytest.mark.asyncio
-    @patch("bioetl.infrastructure.storage.delta_writer.DeltaTable")
+    @patch("bioetl.infrastructure.storage.retention_manager.DeltaTable")
     async def test_optimize_returns_metrics(self, mock_delta_table, noop_logger):
         """Test optimize returns compaction metrics."""
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
@@ -369,7 +369,7 @@ class TestDeltaWriterOptimize:
         mock_optimize.compact.assert_called_once()
 
     @pytest.mark.asyncio
-    @patch("bioetl.infrastructure.storage.delta_writer.DeltaTable")
+    @patch("bioetl.infrastructure.storage.retention_manager.DeltaTable")
     async def test_optimize_with_partition_filters(self, mock_delta_table, noop_logger):
         """Test optimize with partition filters."""
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
@@ -396,7 +396,7 @@ class TestDeltaWriterOptimize:
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
         with patch(
-            "bioetl.infrastructure.storage.delta_writer.DeltaTable",
+            "bioetl.infrastructure.storage.retention_manager.DeltaTable",
             side_effect=DeltaTableNotFoundError("Not found"),
         ):
             writer = DeltaWriter(base_path="s3://bucket/silver", logger=noop_logger, require_lock=False)
@@ -410,7 +410,7 @@ class TestDeltaWriterGetTableInfo:
     """Tests for DeltaWriter get_table_info operation."""
 
     @pytest.mark.asyncio
-    @patch("bioetl.infrastructure.storage.delta_writer.DeltaTable")
+    @patch("bioetl.infrastructure.storage.retention_manager.DeltaTable")
     async def test_get_table_info_returns_metadata(self, mock_delta_table, noop_logger):
         """Test get_table_info returns table metadata."""
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
@@ -439,7 +439,7 @@ class TestDeltaWriterGetTableInfo:
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
         with patch(
-            "bioetl.infrastructure.storage.delta_writer.DeltaTable",
+            "bioetl.infrastructure.storage.retention_manager.DeltaTable",
             side_effect=DeltaTableNotFoundError("Not found"),
         ):
             writer = DeltaWriter(base_path="s3://bucket/silver", logger=noop_logger, require_lock=False)
@@ -453,7 +453,7 @@ class TestDeltaWriterTimeTravel:
     """Tests for DeltaWriter time_travel operation."""
 
     @pytest.mark.asyncio
-    @patch("bioetl.infrastructure.storage.delta_writer.DeltaTable")
+    @patch("bioetl.infrastructure.storage.retention_manager.DeltaTable")
     async def test_time_travel_by_version(self, mock_delta_table, noop_logger):
         """Test time_travel by version number."""
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
@@ -468,7 +468,7 @@ class TestDeltaWriterTimeTravel:
         mock_delta_table.assert_called_once()
 
     @pytest.mark.asyncio
-    @patch("bioetl.infrastructure.storage.delta_writer.DeltaTable")
+    @patch("bioetl.infrastructure.storage.retention_manager.DeltaTable")
     async def test_time_travel_by_timestamp(self, mock_delta_table, noop_logger):
         """Test time_travel by timestamp."""
         from datetime import datetime
@@ -519,7 +519,7 @@ class TestDeltaWriterTimeTravel:
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
         with patch(
-            "bioetl.infrastructure.storage.delta_writer.DeltaTable",
+            "bioetl.infrastructure.storage.retention_manager.DeltaTable",
             side_effect=DeltaTableNotFoundError("Not found"),
         ):
             writer = DeltaWriter(base_path="s3://bucket/silver", logger=noop_logger, require_lock=False)


### PR DESCRIPTION
Extract shared and specialized logic from DeltaWriter, GoldWriter, and BronzeWriter into dedicated modules:

- lock_validator.py: Centralize lock validation logic that was duplicated across all three writers (~70 lines each). New validate_lock_for_write() function handles lock validation with consistent logging and error messages.

- retention_manager.py: Extract Delta table maintenance operations (vacuum, optimize, get_table_info, time_travel) from DeltaWriter. These operations are maintenance-focused rather than write-focused.

Line count changes:
- delta_writer.py: 892 → 787 lines (-12%)
- gold_writer.py: 759 → 709 lines (-7%)
- bronze_writer.py: 616 → 562 lines (-9%)
- New lock_validator.py: 101 lines
- New retention_manager.py: 215 lines

All 227 storage tests and 258 architecture tests pass.