### PR TITLE
Set up dependencies and fix test errors

### DIFF
--- a/src/bioetl/infrastructure/schemas/gold.py
+++ b/src/bioetl/infrastructure/schemas/gold.py
@@ -41,6 +41,14 @@ class PubChemCompoundGoldSchema(pa.DataFrameModel):
     molecular_formula: Series[str] = pa.Field(nullable=True)
     molecular_weight: Series[str] = pa.Field(nullable=True)
     canonical_smiles: Series[str] = pa.Field(nullable=True)
+    isomeric_smiles: Series[str] = pa.Field(nullable=True)
+    inchi: Series[str] = pa.Field(nullable=True)
+    inchikey: Series[str] = pa.Field(nullable=True)
+    iupac_name: Series[str] = pa.Field(nullable=True)
+
+    # Metadata (use alias for underscore-prefixed columns)
+    run_id: Series[str] = pa.Field(nullable=False, alias="_run_id")
+    ingestion_ts: Series[str] = pa.Field(nullable=False, alias="_ingestion_ts")
 
     # Metadata (use alias for underscore-prefixed columns)
     run_id: Series[str] = pa.Field(nullable=False, alias="_run_id")


### PR DESCRIPTION
…tibility

- Transform molecular_weight from float to string in PubChemCompoundTransformer to match PUBCHEM_COMPOUND_SCHEMA which expects pa.string()
- Update PubChemCompoundGoldSchema with strict=True and add missing fields (isomeric_smiles, inchi, inchikey, iupac_name, _run_id, _ingestion_ts) per REQ-DATA-009
- Update integration tests to expect string molecular_weight values