### PR TITLE
Add import-linter to CI pipeline

### DIFF
--- a/.github/workflows/import-linter.yml
+++ b/.github/workflows/import-linter.yml
@@ -256,12 +256,13 @@ jobs:
       - lint
       - unit-tests
       - integration-tests
+      - arch-tests
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:
       - name: Final status
         run: |
-          if [[ "${{ needs.lint.result }}" != "success" || "${{ needs.unit-tests.result }}" != "success" || "${{ needs['integration-tests'].result }}" != "success" ]]; then
+          if [[ "${{ needs.lint.result }}" != "success" || "${{ needs.unit-tests.result }}" != "success" || "${{ needs['integration-tests'].result }}" != "success" || "${{ needs['arch-tests'].result }}" != "success" ]]; then
             echo "One or more checks failed"
             exit 1
           fi


### PR DESCRIPTION
Add arch-tests (including import-linter) to the checks-complete job so that architecture violations block PR merges. Previously, the arch-tests job ran but its failure didn't prevent merging.

This ensures `make arch-lint` must pass in CI as specified in the acceptance criteria.