### PR TITLE
Audit and standardize BioETL project structure

### DIFF
--- a/docs/00-project_rules/03-file-policy.md
+++ b/docs/00-project_rules/03-file-policy.md
@@ -1,5 +1,5 @@
 # File Policy
-*Синхронизировано с RULES.md v5.6 (2025-12-27)*
+*Синхронизировано с RULES.md v5.7 (2025-12-28)*
 
 Этот документ фиксирует структуру репозитория и правила размещения файлов.
 
@@ -14,11 +14,17 @@
 
 ```text
 .
+├── assets/                     # MkDocs theme assets (stylesheets, js)
+├── benchmarks/                 # Performance tests (pytest-benchmark)
 ├── configs/                    # Runtime конфигурации (YAML)
 │   ├── pipelines/              # Конфиги пайплайнов по провайдерам
 │   │   └── {provider}/         # e.g., chembl/, pubchem/
 │   │       └── {entity}.yaml   # e.g., activity.yaml
 │   └── providers/              # Конфиги провайдеров (rate limits, URLs)
+├── data/                       # Данные (Bronze/Silver/Gold)
+│   ├── bronze/                 # {format_version}/{provider}/{entity}/{date}/
+│   ├── silver/                 # Delta Lake таблицы
+│   └── gold/                   # Витрины
 ├── docs/                       # Документация
 │   ├── application/            # Use Cases (описания пайплайнов)
 │   │   └── pipelines/          # По провайдерам и сущностям
@@ -34,28 +40,37 @@
 │   ├── interfaces/             # CLI документация
 │   ├── templates/              # Шаблоны (pipeline-review-checklist.md)
 │   └── 00-map.md               # Навигатор по проекту
+├── grafana/                    # Grafana dashboards (observability)
+│   ├── dashboards/             # JSON dashboard definitions
+│   └── provisioning/           # Auto-provisioning configs
+├── qc/                         # Quality Control artifacts
+│   └── golden/                 # Golden test artifacts
+├── scripts/                    # Operational scripts (не утилиты!)
+│   ├── check_architecture.py   # CI архитектурные проверки
+│   └── cleanup_cache.py        # Очистка кэшей
 ├── src/                        # Исходный код
-│   └── bioetl/                 # Root package
-│       ├── application/        # Пайплайны, Use Cases
-│       │   └── pipelines/      # {provider}/{entity}/
-│       ├── domain/             # Чистая логика, Protocols
-│       │   ├── configs/        # Pydantic-модели конфигов
-│       │   ├── ports/          # Интерфейсы (typing.Protocol) — пакет с фасадом
-│       │   └── schemas/        # Pandera-схемы
-│       ├── infrastructure/     # Адаптеры
-│       │   ├── clients/        # HTTP клиенты по провайдерам
-│       │   └── config/         # Инфраструктурные модели
-│       └── interfaces/         # CLI (Typer)
-├── tests/                      # Тесты (зеркалят src/)
-│   ├── fixtures/               # VCR.py кассеты
-│   │   └── vcr/                # Записи API-ответов
-│   └── golden/                 # Эталонные данные
-├── data/                       # Данные (Bronze/Silver/Gold)
-│   ├── bronze/                 # {format_version}/{provider}/{entity}/{date}/
-│   ├── silver/                 # Delta Lake таблицы
-│   └── gold/                   # Витрины
-└── qc/                         # Quality Control
-    └── golden/                 # Golden test artifacts
+│   ├── bioetl/                 # Root package
+│   │   ├── application/        # Пайплайны, Use Cases
+│   │   │   └── pipelines/      # {provider}/{entity}/
+│   │   ├── composition/        # DI-контейнер, factories, bootstrap
+│   │   ├── domain/             # Чистая логика, Protocols
+│   │   │   ├── configs/        # Pydantic-модели конфигов
+│   │   │   ├── ports/          # Интерфейсы (typing.Protocol)
+│   │   │   └── schemas/        # Pandera-схемы
+│   │   ├── infrastructure/     # Адаптеры
+│   │   │   ├── clients/        # HTTP клиенты по провайдерам
+│   │   │   └── config/         # Инфраструктурные модели
+│   │   └── interfaces/         # CLI (Click)
+│   └── tools/                  # Утилиты проекта
+│       ├── audit_structure.py  # Аудит структуры проекта
+│       └── create_pipeline.py  # Генератор boilerplate
+└── tests/                      # Тесты (зеркалят src/)
+    ├── architecture/           # Архитектурные тесты
+    ├── benchmarks/             # Интеграция с pytest-benchmark
+    ├── fixtures/               # VCR.py кассеты
+    │   └── vcr/                # Записи API-ответов
+    ├── integration/            # Интеграционные тесты
+    └── unit/                   # Unit тесты
 ```
 
 ## Medallion Architecture Paths (MUST)
@@ -71,12 +86,41 @@
 - Изменение формата **MUST** создавать новую ветку (`/v2/`).
 - Миграция "in-place" **MUST NOT**.
 
-## Запрет корневых папок (MUST)
+## Политика Корневых Папок (MUST)
 
-- Создание новых папок в корне репозитория **MUST NOT**.
-- Утилиты и скрипты **MUST** размещаться в `src/tools/`.
-- Допустимые корневые каталоги: `src/`, `tests/`, `docs/`, `configs/`, `data/`, `.github/`, `.cursor/`, `.trae/`, `.windsurf/`, `qc/`.
-- Временные отчёты → `reports/` (не коммитятся, см. `.gitignore`).
+Создание **НОВЫХ** папок в корне репозитория **MUST NOT** без обоснования в ADR.
+
+### Допустимые корневые каталоги
+
+| Каталог | Назначение | Комментарий |
+|---------|------------|-------------|
+| `src/` | Исходный код (bioetl, tools) | **Core** |
+| `tests/` | Тесты (зеркалят src/) | **Core** |
+| `docs/` | Документация | **Core** |
+| `configs/` | Runtime конфигурации (YAML) | **Core** |
+| `data/` | Данные (Bronze/Silver/Gold) | В `.gitignore`, кроме структуры |
+| `qc/` | Quality Control артефакты | |
+| `scripts/` | Операционные скрипты (CI, архитектура) | Не путать с `src/tools/` |
+| `benchmarks/` | Performance тесты (pytest-benchmark) | |
+| `grafana/` | Grafana dashboards (observability) | |
+| `assets/` | MkDocs theme assets | |
+| `reports/` | Временные отчёты | Не коммитятся, в `.gitignore` |
+| `.github/` | GitHub workflows | |
+| `.cursor/` | Cursor IDE rules | |
+| `.trae/` | Trae rules | |
+| `.windsurf/` | Windsurf rules | |
+| `.claude/` | Claude Code config | |
+| `.codex/` | OpenAI Codex config | |
+| `.jules/` | Jules config | |
+
+### Разграничение scripts/ и src/tools/
+
+| Директория | Назначение | Примеры |
+|------------|------------|---------|
+| `scripts/` | CI/операционные скрипты, запускаемые извне | `check_architecture.py`, `cleanup_cache.py` |
+| `src/tools/` | Утилиты проекта, часть кодовой базы | `create_pipeline.py`, `audit_structure.py` |
+
+**Правило**: Если скрипт импортирует `bioetl` модули → `src/tools/`. Если standalone → `scripts/`.
 
 ## Правила именования
 

--- a/src/tools/audit_structure.py
+++ b/src/tools/audit_structure.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""
+BioETL Structure Audit Tool.
+
+Проверяет соответствие структуры проекта File Policy (03-file-policy.md).
+
+Usage:
+    python src/tools/audit_structure.py [--json] [--strict]
+
+Flags:
+    --json    Output results in JSON format
+    --strict  Exit with code 1 on SHOULD violations too (default: only MUST)
+
+Aligned with RULES.md v5.7 (2025-12-27)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterator
+
+
+# =============================================================================
+# Configuration: Allowed directories and paths
+# =============================================================================
+
+# Allowed root directories per 03-file-policy.md + project extensions
+ALLOWED_ROOT_DIRS: set[str] = {
+    # Core directories (03-file-policy.md §"Допустимые корневые каталоги")
+    "src",
+    "tests",
+    "docs",
+    "configs",
+    "data",
+    "qc",  # Quality Control
+    # Operational
+    "scripts",  # Operational scripts (vacuum, salt rotation, architecture checks)
+    "reports",  # Temporary reports (not committed, in .gitignore)
+    # CI/DevOps
+    ".github",
+    # IDE/Tool configs (analogous to .cursor/.trae/.windsurf)
+    ".cursor",
+    ".trae",
+    ".windsurf",
+    ".claude",
+    ".codex",
+    ".jules",
+    # Infrastructure monitoring
+    "grafana",  # Grafana dashboards for observability
+    # Documentation assets
+    "assets",  # MkDocs theme assets (stylesheets, javascripts)
+    # Performance tests
+    "benchmarks",  # pytest-benchmark tests (separate from unit tests)
+}
+
+# Directories that SHOULD NOT be committed (generated or temp)
+GENERATED_DIRS: set[str] = {
+    "site",  # MkDocs output (in .gitignore)
+    "build",
+    "dist",
+    "htmlcov",
+    "node_modules",
+}
+
+# Technical directories (auto-generated, always excluded)
+TECHNICAL_DIRS: set[str] = {
+    ".venv",
+    "venv",
+    ".git",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".eggs",
+    ".benchmarks",
+    ".hypothesis",
+}
+
+# Allowed Python paths
+ALLOWED_PYTHON_PATHS: tuple[str, ...] = (
+    "src/",
+    "tests/",
+    "scripts/",
+    "benchmarks/",  # Performance tests
+)
+
+# Allowed root-level Python files
+ALLOWED_ROOT_PY_FILES: set[str] = {
+    "setup.py",
+    "conftest.py",
+}
+
+# Required layers in src/bioetl (per CLAUDE.md §2)
+REQUIRED_BIOETL_LAYERS: set[str] = {
+    "domain",
+    "application",
+    "infrastructure",
+    "interfaces",
+    "composition",  # DI container layer (per CLAUDE.md)
+}
+
+
+# =============================================================================
+# Violation Data Model
+# =============================================================================
+
+
+@dataclass
+class Violation:
+    """Нарушение политики структуры проекта."""
+
+    category: str
+    path: str
+    message: str
+    severity: str  # MUST | SHOULD
+
+    def to_dict(self) -> dict[str, str]:
+        """Convert to dictionary for JSON output."""
+        return {
+            "category": self.category,
+            "path": self.path,
+            "message": self.message,
+            "severity": self.severity,
+        }
+
+
+@dataclass
+class AuditResult:
+    """Результат аудита структуры."""
+
+    violations: list[Violation] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def must_violations(self) -> list[Violation]:
+        """MUST violations (блокеры)."""
+        return [v for v in self.violations if v.severity == "MUST"]
+
+    @property
+    def should_violations(self) -> list[Violation]:
+        """SHOULD violations (рекомендации)."""
+        return [v for v in self.violations if v.severity == "SHOULD"]
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON output."""
+        return {
+            "violations": [v.to_dict() for v in self.violations],
+            "warnings": self.warnings,
+            "summary": {
+                "must_count": len(self.must_violations),
+                "should_count": len(self.should_violations),
+                "total": len(self.violations),
+            },
+        }
+
+
+# =============================================================================
+# Audit Logic
+# =============================================================================
+
+
+def _is_technical_or_generated(name: str) -> bool:
+    """Check if directory is technical/generated."""
+    if name in TECHNICAL_DIRS or name in GENERATED_DIRS:
+        return True
+    if name.endswith(".egg-info"):
+        return True
+    return False
+
+
+def _check_root_directories(project_root: Path) -> Iterator[Violation]:
+    """Проверка корневых каталогов против whitelist."""
+    for item in project_root.iterdir():
+        if not item.is_dir():
+            continue
+
+        name = item.name
+
+        # Skip technical directories
+        if _is_technical_or_generated(name):
+            continue
+
+        # Check hidden directories
+        if name.startswith("."):
+            if name not in ALLOWED_ROOT_DIRS:
+                yield Violation(
+                    category="ROOT_DIR_HIDDEN",
+                    path=str(item.relative_to(project_root)),
+                    message=f"Неразрешённая скрытая папка в корне: {name}",
+                    severity="SHOULD",
+                )
+        # Check regular directories
+        elif name not in ALLOWED_ROOT_DIRS:
+            yield Violation(
+                category="ROOT_DIR",
+                path=str(item.relative_to(project_root)),
+                message=f"Неразрешённая папка в корне: {name}",
+                severity="MUST",
+            )
+
+
+def _check_python_locations(project_root: Path) -> Iterator[Violation]:
+    """Проверка расположения Python-файлов."""
+    for py_file in project_root.rglob("*.py"):
+        rel_path = py_file.relative_to(project_root)
+        str_path = str(rel_path)
+
+        # Skip technical directories
+        if any(tech in str_path for tech in TECHNICAL_DIRS):
+            continue
+        if any(gen in str_path for gen in GENERATED_DIRS):
+            continue
+
+        # Check if in allowed location
+        is_allowed = any(str_path.startswith(p) for p in ALLOWED_PYTHON_PATHS)
+        is_root_allowed = (
+            py_file.parent == project_root and py_file.name in ALLOWED_ROOT_PY_FILES
+        )
+
+        if not is_allowed and not is_root_allowed:
+            yield Violation(
+                category="PYTHON_LOCATION",
+                path=str_path,
+                message=f"Python-файл в недопустимом месте: {str_path}",
+                severity="MUST",
+            )
+
+
+def _check_bioetl_layers(project_root: Path) -> Iterator[Violation]:
+    """Проверка структуры слоёв src/bioetl/."""
+    bioetl_path = project_root / "src" / "bioetl"
+    if not bioetl_path.exists():
+        yield Violation(
+            category="LAYER_MISSING",
+            path="src/bioetl/",
+            message="Директория src/bioetl/ не существует",
+            severity="MUST",
+        )
+        return
+
+    existing_layers = {
+        d.name
+        for d in bioetl_path.iterdir()
+        if d.is_dir() and not d.name.startswith("_")
+    }
+
+    # Check for missing required layers
+    missing = REQUIRED_BIOETL_LAYERS - existing_layers
+    for layer in sorted(missing):
+        yield Violation(
+            category="LAYER_MISSING",
+            path=f"src/bioetl/{layer}/",
+            message=f"Отсутствует обязательный слой: {layer}",
+            severity="MUST",
+        )
+
+    # Check for extra layers
+    extra = existing_layers - REQUIRED_BIOETL_LAYERS
+    for layer in sorted(extra):
+        yield Violation(
+            category="LAYER_EXTRA",
+            path=f"src/bioetl/{layer}/",
+            message=f"Неожиданный каталог в src/bioetl/: {layer}",
+            severity="SHOULD",
+        )
+
+
+def _check_no_python_in_docs(project_root: Path) -> Iterator[Violation]:
+    """Проверка отсутствия Python-кода в docs/."""
+    docs_path = project_root / "docs"
+    if not docs_path.exists():
+        return
+
+    for py_file in docs_path.rglob("*.py"):
+        yield Violation(
+            category="DOCS_CODE",
+            path=str(py_file.relative_to(project_root)),
+            message="Python-код в docs/ запрещён",
+            severity="MUST",
+        )
+
+
+def _check_no_python_in_configs(project_root: Path) -> Iterator[Violation]:
+    """Проверка отсутствия Python-кода в configs/."""
+    configs_path = project_root / "configs"
+    if not configs_path.exists():
+        return
+
+    for py_file in configs_path.rglob("*.py"):
+        yield Violation(
+            category="CONFIGS_CODE",
+            path=str(py_file.relative_to(project_root)),
+            message="Python-код в configs/ запрещён",
+            severity="MUST",
+        )
+
+
+def _check_no_python_in_data(project_root: Path) -> Iterator[Violation]:
+    """Проверка отсутствия Python-кода в data/."""
+    data_path = project_root / "data"
+    if not data_path.exists():
+        return
+
+    for py_file in data_path.rglob("*.py"):
+        yield Violation(
+            category="DATA_CODE",
+            path=str(py_file.relative_to(project_root)),
+            message="Python-код в data/ запрещён",
+            severity="MUST",
+        )
+
+
+def run_audit(project_root: Path) -> AuditResult:
+    """Выполнить полный аудит структуры проекта."""
+    result = AuditResult()
+
+    # Run all checks
+    checks = [
+        _check_root_directories,
+        _check_python_locations,
+        _check_bioetl_layers,
+        _check_no_python_in_docs,
+        _check_no_python_in_configs,
+        _check_no_python_in_data,
+    ]
+
+    for check in checks:
+        result.violations.extend(check(project_root))
+
+    return result
+
+
+# =============================================================================
+# Output Formatting
+# =============================================================================
+
+
+def print_text_report(result: AuditResult) -> None:
+    """Print human-readable report."""
+    print("=" * 70)
+    print("BioETL Structure Audit Report")
+    print("=" * 70)
+    print()
+
+    if result.must_violations:
+        print(f"## MUST Violations ({len(result.must_violations)}) - BLOCKERS")
+        print()
+        for v in result.must_violations:
+            print(f"  [{v.category}] {v.path}")
+            print(f"    → {v.message}")
+        print()
+
+    if result.should_violations:
+        print(f"## SHOULD Violations ({len(result.should_violations)}) - RECOMMENDATIONS")
+        print()
+        for v in result.should_violations:
+            print(f"  [{v.category}] {v.path}")
+            print(f"    → {v.message}")
+        print()
+
+    if not result.violations:
+        print("✓ Структура проекта соответствует File Policy")
+        print()
+
+    print("=" * 70)
+    print(
+        f"Summary: {len(result.must_violations)} MUST, "
+        f"{len(result.should_violations)} SHOULD"
+    )
+    print("=" * 70)
+
+
+def print_json_report(result: AuditResult) -> None:
+    """Print JSON report."""
+    print(json.dumps(result.to_dict(), indent=2, ensure_ascii=False))
+
+
+# =============================================================================
+# CLI Entry Point
+# =============================================================================
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="BioETL Structure Audit Tool",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output results in JSON format",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit with code 1 on SHOULD violations too (default: only MUST)",
+    )
+    parser.add_argument(
+        "--path",
+        type=Path,
+        default=Path.cwd(),
+        help="Project root path (default: current directory)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Entry point."""
+    args = parse_args()
+
+    # Resolve project root
+    project_root = args.path.resolve()
+    if not project_root.exists():
+        print(f"Error: Path does not exist: {project_root}", file=sys.stderr)
+        return 2
+
+    # Run audit
+    result = run_audit(project_root)
+
+    # Output results
+    if args.json:
+        print_json_report(result)
+    else:
+        print_text_report(result)
+
+    # Determine exit code
+    if result.must_violations:
+        return 1
+    if args.strict and result.should_violations:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
- Add src/tools/audit_structure.py for automated project structure validation
- Update docs/00-project_rules/03-file-policy.md with complete directory whitelist
- Add composition/ layer to documented structure
- Clarify scripts/ vs src/tools/ distinction
- Include all IDE/tool config directories (.claude, .codex, .jules)
- Add grafana/, assets/, benchmarks/ to allowed directories

The audit tool checks:
- Root directories against whitelist
- Python file locations
- src/bioetl layer structure
- No Python code in docs/configs/data

Current audit result: 0 MUST violations, 0 SHOULD violations