### PR TITLE
Fix testing dependencies and mypy errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ install: ## Create venv and install dependencies
 
 test: ## Run unit and integration tests
 	@echo "$(BLUE)Running tests...$(NC)"
-	$(VENV_PYTHON) -m pytest tests/ -v --cov=src/bioetl --cov-report=term-missing --cov-report=html
+    $(VENV_PYTHON) -m pytest tests/ -v --cov=src/bioetl --cov-report=term-missing --cov-report=html --cov-fail-under=85
 
 test-unit: ## Run only unit tests (fast, no I/O)
 	@echo "$(BLUE)Running unit tests...$(NC)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,7 @@ exclude_lines = [
     "raise NotImplementedError",
     "@abstractmethod",
 ]
-fail_under = 80
+fail_under = 85
 show_missing = true
 
 # ============ MYPY ============
@@ -317,6 +317,7 @@ skips = ["*/domain/*"]
 [dependency-groups]
 dev = [
     # Core testing
+    "pyyaml>=6.0",
     "pytest>=8.0",
     "pytest-cov>=4.0",
     "pytest-asyncio>=0.23",

--- a/src/bioetl/composition/entrypoints.py
+++ b/src/bioetl/composition/entrypoints.py
@@ -366,3 +366,17 @@ async def list_checkpoints(pipeline: str) -> list[str]:
     manager = get_checkpoint_manager(pipeline)
     checkpoints: list[str] = await manager.list_all()
     return checkpoints
+
+
+__all__ = [
+    "RunOptions",
+    "create_pipeline_runner",
+    "get_checkpoint_manager",
+    "get_lifecycle_service",
+    "get_quarantine_manager",
+    "inspect_quarantine",
+    "list_checkpoints",
+    "load_pipeline_config",
+    "preview_cleanup",
+    "run_pipeline",
+]

--- a/src/bioetl/domain/ports/storage.py
+++ b/src/bioetl/domain/ports/storage.py
@@ -11,6 +11,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal, Protocol, runtime_checkable
 
+from bioetl.domain.locking import LockContext
+
 from bioetl.domain.types import (
     ArrowSchema,
     BatchID,
@@ -39,6 +41,7 @@ class StoragePort(Protocol):
         run_id: RunID,
         run_type: RunType,
         ingestion_ts: datetime,
+        lock_context: LockContext | None = None,
     ) -> Path:
         """Write raw records to the Bronze layer.
 
@@ -67,6 +70,7 @@ class StoragePort(Protocol):
         mode: Literal["merge", "append", "delete"] = "merge",
         partition_cols: list[str] | None = None,
         on_schema_mismatch: Literal["error", "evolve", "ignore"] = "error",
+        lock_context: LockContext | None = None,
     ) -> None:
         """Write transformed records to the Silver layer.
 
@@ -97,6 +101,7 @@ class StoragePort(Protocol):
         *,
         ingestion_ts: datetime | None = None,
         run_id: RunID | None = None,
+        lock_context: LockContext | None = None,
     ) -> None:
         """Write aggregated or validated records to the Gold layer.
 

--- a/src/bioetl/infrastructure/observability/logging.py
+++ b/src/bioetl/infrastructure/observability/logging.py
@@ -59,7 +59,7 @@ def create_logger(
         processors.append(structlog.dev.ConsoleRenderer())
 
     structlog.configure(
-        processors=processors,  # type: ignore[arg-type]
+        processors=processors,
         logger_factory=structlog.stdlib.LoggerFactory(),
         wrapper_class=structlog.stdlib.BoundLogger,
         cache_logger_on_first_use=True,

--- a/src/bioetl/infrastructure/serialization/encoders.py
+++ b/src/bioetl/infrastructure/serialization/encoders.py
@@ -31,14 +31,15 @@ from typing import Any
 from bioetl.domain.ports import JsonEncoderPort
 
 # Optional orjson import
-_orjson: types.ModuleType | None
 try:
-    import orjson as _orjson
+    import orjson as _orjson_module
 
     ORJSON_AVAILABLE = True
 except ImportError:
-    _orjson = None
+    _orjson_module = None
     ORJSON_AVAILABLE = False
+
+_orjson: types.ModuleType | None = _orjson_module
 
 
 class StdLibJsonEncoder:

--- a/src/bioetl/infrastructure/storage/bronze_writer.py
+++ b/src/bioetl/infrastructure/storage/bronze_writer.py
@@ -305,7 +305,7 @@ class BronzeWriter:
         run_type: RunType,
         ingestion_ts: datetime,
         lock_context: LockContext | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> Path:
         """Write raw records to Bronze layer (JSONL + zstd).
 

--- a/src/bioetl/infrastructure/storage/delta_writer.py
+++ b/src/bioetl/infrastructure/storage/delta_writer.py
@@ -459,7 +459,7 @@ class DeltaWriter:
         partition_cols: list[str] | None = None,
         on_schema_mismatch: Literal["error", "evolve", "ignore"] = "error",
         lock_context: LockContext | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Write normalized records to Silver layer (Delta Lake merge/upsert).
 

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto


### PR DESCRIPTION
## Summary
- add explicit asyncio configuration for pytest, keep PyYAML in dev dependencies, and raise the coverage threshold to 85% enforced via Makefile
- resolve mypy findings by exporting entrypoints, typing storage port lock parameters, and tightening kwargs handling
- clean up logging configuration typing and orjson module initialization

## Testing
- mypy --strict src/bioetl
- pytest --cov=src/bioetl --cov-report=term --cov-fail-under=85 *(terminated partway due to duration)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695112ae5aa8832497daeb7b3258f9eb)