### PR TITLE
Remove kwargs from storage adapter

### DIFF
--- a/src/bioetl/composition/factories/storage_adapter.py
+++ b/src/bioetl/composition/factories/storage_adapter.py
@@ -59,7 +59,6 @@ class StorageAdapter:
         run_type: RunType,
         ingestion_ts: datetime,
         lock_context: LockContext | None = None,
-        **kwargs: Any,
     ) -> Path:
         """Write raw records to Bronze layer.
 
@@ -100,7 +99,6 @@ class StorageAdapter:
         partition_cols: list[str] | None = None,
         on_schema_mismatch: Literal["error", "evolve", "ignore"] = "error",
         lock_context: LockContext | None = None,
-        **kwargs: Any,
     ) -> None:
         """Write transformed records to Silver layer."""
         await self.silver.write_silver(
@@ -125,7 +123,6 @@ class StorageAdapter:
         ingestion_ts: datetime | None = None,
         run_id: RunID | None = None,
         lock_context: LockContext | None = None,
-        **kwargs: Any,
     ) -> None:
         """Write aggregated records to Gold layer.
 


### PR DESCRIPTION
Remove unused **kwargs from write_bronze, write_silver, and write_gold methods to match StoragePort protocol signature exactly. Improves type safety and mypy checks.