### PR TITLE
Expand test coverage for BioETL system

### DIFF
--- a/tests/architecture/test_domain_public_api.py
+++ b/tests/architecture/test_domain_public_api.py
@@ -32,6 +32,7 @@ def test_domain_all_is_complete(src_dir: Path) -> None:
         "annotations",
         # Submodules (imported but not re-exported individually)
         "config",
+        "config_types",  # TypedDict definitions for YAML config (not public API)
         "context",
         "entities",
         "error_classifier",

--- a/tests/unit/composition/__init__.py
+++ b/tests/unit/composition/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for composition layer."""

--- a/tests/unit/composition/factories/test_transformer_factory.py
+++ b/tests/unit/composition/factories/test_transformer_factory.py
@@ -1,0 +1,232 @@
+"""Tests for composition/factories/transformer_factory.py.
+
+These tests verify the transformer factory for DI-based transformer creation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from bioetl.composition.factories.transformer_factory import (
+    _TRANSFORMER_REGISTRY,
+    create_transformer,
+    get_transformer_class,
+    register_all_transformers,
+    register_transformer,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_registry() -> None:
+    """Clean the registry before and after each test."""
+    _TRANSFORMER_REGISTRY.clear()
+    yield
+    _TRANSFORMER_REGISTRY.clear()
+
+
+class MockTransformer:
+    """Mock transformer for testing."""
+
+    def __init__(
+        self,
+        provider: str,
+        tracer: Any = None,
+        metrics: Any = None,
+    ):
+        self.provider = provider
+        self.tracer = tracer
+        self.metrics = metrics
+
+
+class TestRegisterTransformer:
+    """Tests for register_transformer function."""
+
+    def test_register_transformer(self) -> None:
+        """register_transformer adds to registry."""
+        register_transformer("test_provider", "test_entity", MockTransformer)
+
+        assert ("test_provider", "test_entity") in _TRANSFORMER_REGISTRY
+        assert _TRANSFORMER_REGISTRY[("test_provider", "test_entity")] is MockTransformer
+
+    def test_register_multiple_transformers(self) -> None:
+        """Multiple transformers can be registered."""
+        register_transformer("provider1", "entity1", MockTransformer)
+        register_transformer("provider2", "entity2", MockTransformer)
+
+        assert len(_TRANSFORMER_REGISTRY) == 2
+
+    def test_register_overwrites_existing(self) -> None:
+        """Registering same key overwrites existing."""
+
+        class AnotherMockTransformer:
+            pass
+
+        register_transformer("provider", "entity", MockTransformer)
+        register_transformer("provider", "entity", AnotherMockTransformer)
+
+        assert _TRANSFORMER_REGISTRY[("provider", "entity")] is AnotherMockTransformer
+
+
+class TestGetTransformerClass:
+    """Tests for get_transformer_class function."""
+
+    def test_get_registered_transformer(self) -> None:
+        """get_transformer_class returns registered class."""
+        register_transformer("chembl", "activity", MockTransformer)
+
+        result = get_transformer_class("chembl", "activity")
+
+        assert result is MockTransformer
+
+    def test_get_unregistered_returns_none(self) -> None:
+        """get_transformer_class returns None for unregistered."""
+        result = get_transformer_class("nonexistent", "entity")
+
+        assert result is None
+
+
+class TestCreateTransformer:
+    """Tests for create_transformer function."""
+
+    def test_create_transformer_basic(self) -> None:
+        """create_transformer creates instance."""
+        register_transformer("chembl", "activity", MockTransformer)
+
+        transformer = create_transformer("chembl", "activity")
+
+        assert isinstance(transformer, MockTransformer)
+        assert transformer.provider == "chembl"
+
+    def test_create_transformer_with_tracer(self) -> None:
+        """create_transformer passes tracer."""
+        mock_tracer = MagicMock()
+        register_transformer("chembl", "activity", MockTransformer)
+
+        transformer = create_transformer("chembl", "activity", tracer=mock_tracer)
+
+        assert transformer.tracer is mock_tracer
+
+    def test_create_transformer_with_metrics(self) -> None:
+        """create_transformer passes metrics."""
+        mock_metrics = MagicMock()
+        register_transformer("chembl", "activity", MockTransformer)
+
+        transformer = create_transformer("chembl", "activity", metrics=mock_metrics)
+
+        assert transformer.metrics is mock_metrics
+
+    def test_create_transformer_with_both_observability(self) -> None:
+        """create_transformer passes both tracer and metrics."""
+        mock_tracer = MagicMock()
+        mock_metrics = MagicMock()
+        register_transformer("chembl", "activity", MockTransformer)
+
+        transformer = create_transformer(
+            "chembl",
+            "activity",
+            tracer=mock_tracer,
+            metrics=mock_metrics,
+        )
+
+        assert transformer.tracer is mock_tracer
+        assert transformer.metrics is mock_metrics
+
+    def test_create_transformer_unregistered_raises(self) -> None:
+        """create_transformer raises KeyError for unregistered."""
+        with pytest.raises(KeyError) as exc_info:
+            create_transformer("nonexistent", "entity")
+
+        assert "No transformer registered" in str(exc_info.value)
+        assert "nonexistent" in str(exc_info.value)
+        assert "entity" in str(exc_info.value)
+
+    def test_create_transformer_error_lists_available(self) -> None:
+        """KeyError includes list of available transformers."""
+        register_transformer("chembl", "activity", MockTransformer)
+
+        with pytest.raises(KeyError) as exc_info:
+            create_transformer("pubchem", "compound")
+
+        error_msg = str(exc_info.value)
+        assert "Available:" in error_msg
+        assert "chembl" in error_msg or "activity" in error_msg
+
+
+class TestRegisterAllTransformers:
+    """Tests for register_all_transformers function."""
+
+    def test_register_all_populates_registry(self) -> None:
+        """register_all_transformers populates the registry."""
+        register_all_transformers()
+
+        # Check ChEMBL transformers
+        assert ("chembl", "activity") in _TRANSFORMER_REGISTRY
+        assert ("chembl", "assay") in _TRANSFORMER_REGISTRY
+        assert ("chembl", "molecule") in _TRANSFORMER_REGISTRY
+        assert ("chembl", "target") in _TRANSFORMER_REGISTRY
+        assert ("chembl", "document") in _TRANSFORMER_REGISTRY
+        assert ("chembl", "target_component") in _TRANSFORMER_REGISTRY
+
+        # Check PubChem transformers
+        assert ("pubchem", "compound") in _TRANSFORMER_REGISTRY
+
+        # Check UniProt transformers
+        assert ("uniprot", "protein") in _TRANSFORMER_REGISTRY
+
+        # Check PubMed transformers
+        assert ("pubmed", "publications") in _TRANSFORMER_REGISTRY
+
+    def test_register_all_is_idempotent(self) -> None:
+        """register_all_transformers can be called multiple times."""
+        register_all_transformers()
+        count_first = len(_TRANSFORMER_REGISTRY)
+
+        register_all_transformers()
+        count_second = len(_TRANSFORMER_REGISTRY)
+
+        assert count_first == count_second
+
+    def test_registered_transformers_are_classes(self) -> None:
+        """Registered items are classes."""
+        register_all_transformers()
+
+        for key, value in _TRANSFORMER_REGISTRY.items():
+            assert isinstance(value, type), f"{key} is not a class"
+
+    def test_create_transformer_after_register_all(self) -> None:
+        """Transformers can be created after register_all."""
+        register_all_transformers()
+
+        # Should not raise
+        transformer = create_transformer("chembl", "activity")
+        assert transformer is not None
+
+    def test_all_providers_registered(self) -> None:
+        """All expected providers are registered."""
+        register_all_transformers()
+
+        providers = {key[0] for key in _TRANSFORMER_REGISTRY.keys()}
+        expected_providers = {"chembl", "pubchem", "uniprot", "pubmed"}
+
+        assert providers == expected_providers
+
+
+class TestModuleExports:
+    """Tests for module __all__ exports."""
+
+    def test_all_exports(self) -> None:
+        """All expected functions are exported."""
+        from bioetl.composition.factories import transformer_factory
+
+        expected = [
+            "create_transformer",
+            "get_transformer_class",
+            "register_all_transformers",
+            "register_transformer",
+        ]
+        for name in expected:
+            assert name in transformer_factory.__all__
+            assert hasattr(transformer_factory, name)

--- a/tests/unit/composition/test_base_registry.py
+++ b/tests/unit/composition/test_base_registry.py
@@ -1,0 +1,319 @@
+"""Tests for composition/base_registry.py Registry Protocol.
+
+These tests verify that the RegistryProtocol is correctly defined
+and can be used for structural subtyping.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+import pytest
+
+from bioetl.composition.base_registry import RegistryProtocol
+
+
+class TestRegistryProtocol:
+    """Tests for RegistryProtocol definition."""
+
+    def test_protocol_is_runtime_checkable(self) -> None:
+        """RegistryProtocol is @runtime_checkable."""
+        # Create a class that implements the protocol
+        class TestRegistry:
+            _registry: ClassVar[dict[str, str]] = {}
+
+            @classmethod
+            def register(cls, key: str, value: str) -> None:
+                cls._registry[key] = value
+
+            @classmethod
+            def get(cls, key: str) -> str:
+                return cls._registry[key]
+
+            @classmethod
+            def list_keys(cls) -> list[str]:
+                return list(cls._registry.keys())
+
+            @classmethod
+            def contains(cls, key: str) -> bool:
+                return key in cls._registry
+
+            @classmethod
+            def clear(cls) -> None:
+                cls._registry.clear()
+
+        # isinstance check should work with @runtime_checkable protocols
+        assert isinstance(TestRegistry(), RegistryProtocol)
+
+    def test_protocol_structural_subtyping(self) -> None:
+        """Classes implementing the protocol interface are valid."""
+
+        class StringRegistry:
+            _registry: ClassVar[dict[str, Any]] = {}
+
+            @classmethod
+            def register(cls, key: str, value: Any) -> None:
+                cls._registry[key] = value
+
+            @classmethod
+            def get(cls, key: str) -> Any:
+                return cls._registry[key]
+
+            @classmethod
+            def list_keys(cls) -> list[str]:
+                return list(cls._registry.keys())
+
+            @classmethod
+            def contains(cls, key: str) -> bool:
+                return key in cls._registry
+
+            @classmethod
+            def clear(cls) -> None:
+                cls._registry.clear()
+
+        # Test the implementation works
+        StringRegistry.register("test_key", "test_value")
+        assert StringRegistry.get("test_key") == "test_value"
+        assert StringRegistry.contains("test_key")
+        assert "test_key" in StringRegistry.list_keys()
+        StringRegistry.clear()
+        assert not StringRegistry.contains("test_key")
+
+    def test_incomplete_implementation_fails_check(self) -> None:
+        """Classes missing methods don't pass isinstance check."""
+
+        class IncompleteRegistry:
+            _registry: ClassVar[dict[str, str]] = {}
+
+            @classmethod
+            def register(cls, key: str, value: str) -> None:
+                cls._registry[key] = value
+
+            # Missing: get, list_keys, contains, clear
+
+        # Without all methods, isinstance should fail
+        assert not isinstance(IncompleteRegistry(), RegistryProtocol)
+
+    def test_protocol_with_different_key_types(self) -> None:
+        """Protocol works with various key types."""
+
+        class IntKeyRegistry:
+            _registry: ClassVar[dict[int, str]] = {}
+
+            @classmethod
+            def register(cls, key: int, value: str) -> None:
+                cls._registry[key] = value
+
+            @classmethod
+            def get(cls, key: int) -> str:
+                return cls._registry[key]
+
+            @classmethod
+            def list_keys(cls) -> list[int]:
+                return list(cls._registry.keys())
+
+            @classmethod
+            def contains(cls, key: int) -> bool:
+                return key in cls._registry
+
+            @classmethod
+            def clear(cls) -> None:
+                cls._registry.clear()
+
+        IntKeyRegistry.register(1, "one")
+        IntKeyRegistry.register(2, "two")
+        assert IntKeyRegistry.get(1) == "one"
+        assert IntKeyRegistry.list_keys() == [1, 2]
+        IntKeyRegistry.clear()
+
+    def test_protocol_with_tuple_key(self) -> None:
+        """Protocol works with tuple keys."""
+
+        class TupleKeyRegistry:
+            _registry: ClassVar[dict[tuple[str, str], Any]] = {}
+
+            @classmethod
+            def register(cls, key: tuple[str, str], value: Any) -> None:
+                cls._registry[key] = value
+
+            @classmethod
+            def get(cls, key: tuple[str, str]) -> Any:
+                return cls._registry[key]
+
+            @classmethod
+            def list_keys(cls) -> list[tuple[str, str]]:
+                return list(cls._registry.keys())
+
+            @classmethod
+            def contains(cls, key: tuple[str, str]) -> bool:
+                return key in cls._registry
+
+            @classmethod
+            def clear(cls) -> None:
+                cls._registry.clear()
+
+        key = ("chembl", "activity")
+        TupleKeyRegistry.register(key, {"transformer": "ActivityTransformer"})
+        assert TupleKeyRegistry.contains(key)
+        assert TupleKeyRegistry.get(key) == {"transformer": "ActivityTransformer"}
+        TupleKeyRegistry.clear()
+
+    def test_protocol_register_idempotent(self) -> None:
+        """Registering the same key twice overwrites the value."""
+
+        class OverwriteRegistry:
+            _registry: ClassVar[dict[str, str]] = {}
+
+            @classmethod
+            def register(cls, key: str, value: str) -> None:
+                cls._registry[key] = value
+
+            @classmethod
+            def get(cls, key: str) -> str:
+                return cls._registry[key]
+
+            @classmethod
+            def list_keys(cls) -> list[str]:
+                return list(cls._registry.keys())
+
+            @classmethod
+            def contains(cls, key: str) -> bool:
+                return key in cls._registry
+
+            @classmethod
+            def clear(cls) -> None:
+                cls._registry.clear()
+
+        OverwriteRegistry.clear()
+        OverwriteRegistry.register("key", "value1")
+        OverwriteRegistry.register("key", "value2")
+        assert OverwriteRegistry.get("key") == "value2"
+        assert len(OverwriteRegistry.list_keys()) == 1
+        OverwriteRegistry.clear()
+
+    def test_protocol_get_raises_keyerror_for_missing(self) -> None:
+        """Get raises KeyError for unregistered keys."""
+
+        class StrictRegistry:
+            _registry: ClassVar[dict[str, str]] = {}
+
+            @classmethod
+            def register(cls, key: str, value: str) -> None:
+                cls._registry[key] = value
+
+            @classmethod
+            def get(cls, key: str) -> str:
+                return cls._registry[key]  # Raises KeyError
+
+            @classmethod
+            def list_keys(cls) -> list[str]:
+                return list(cls._registry.keys())
+
+            @classmethod
+            def contains(cls, key: str) -> bool:
+                return key in cls._registry
+
+            @classmethod
+            def clear(cls) -> None:
+                cls._registry.clear()
+
+        StrictRegistry.clear()
+        with pytest.raises(KeyError):
+            StrictRegistry.get("nonexistent")
+
+    def test_protocol_list_keys_empty(self) -> None:
+        """list_keys returns empty list for empty registry."""
+
+        class EmptyRegistry:
+            _registry: ClassVar[dict[str, str]] = {}
+
+            @classmethod
+            def register(cls, key: str, value: str) -> None:
+                cls._registry[key] = value
+
+            @classmethod
+            def get(cls, key: str) -> str:
+                return cls._registry[key]
+
+            @classmethod
+            def list_keys(cls) -> list[str]:
+                return list(cls._registry.keys())
+
+            @classmethod
+            def contains(cls, key: str) -> bool:
+                return key in cls._registry
+
+            @classmethod
+            def clear(cls) -> None:
+                cls._registry.clear()
+
+        EmptyRegistry.clear()
+        assert EmptyRegistry.list_keys() == []
+
+    def test_protocol_clear_is_idempotent(self) -> None:
+        """clear() can be called multiple times safely."""
+
+        class SafeRegistry:
+            _registry: ClassVar[dict[str, str]] = {}
+
+            @classmethod
+            def register(cls, key: str, value: str) -> None:
+                cls._registry[key] = value
+
+            @classmethod
+            def get(cls, key: str) -> str:
+                return cls._registry[key]
+
+            @classmethod
+            def list_keys(cls) -> list[str]:
+                return list(cls._registry.keys())
+
+            @classmethod
+            def contains(cls, key: str) -> bool:
+                return key in cls._registry
+
+            @classmethod
+            def clear(cls) -> None:
+                cls._registry.clear()
+
+        SafeRegistry.clear()
+        SafeRegistry.clear()
+        SafeRegistry.clear()
+        assert SafeRegistry.list_keys() == []
+
+
+class TestRegistryProtocolTypeVars:
+    """Tests for K and V type variables in protocol."""
+
+    def test_type_vars_allow_any_types(self) -> None:
+        """K and V can be any types."""
+
+        class CallableRegistry:
+            _registry: ClassVar[dict[str, type]] = {}
+
+            @classmethod
+            def register(cls, key: str, value: type) -> None:
+                cls._registry[key] = value
+
+            @classmethod
+            def get(cls, key: str) -> type:
+                return cls._registry[key]
+
+            @classmethod
+            def list_keys(cls) -> list[str]:
+                return list(cls._registry.keys())
+
+            @classmethod
+            def contains(cls, key: str) -> bool:
+                return key in cls._registry
+
+            @classmethod
+            def clear(cls) -> None:
+                cls._registry.clear()
+
+        CallableRegistry.clear()
+        CallableRegistry.register("str", str)
+        CallableRegistry.register("int", int)
+        assert CallableRegistry.get("str") is str
+        assert CallableRegistry.get("int") is int
+        CallableRegistry.clear()

--- a/tests/unit/composition/test_types.py
+++ b/tests/unit/composition/test_types.py
@@ -1,0 +1,151 @@
+"""Tests for composition/types.py module exports.
+
+These tests verify that the types module correctly re-exports
+all required composition layer types.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestTypesModuleExports:
+    """Tests for composition/types.py exports."""
+
+    def test_observability_bundle_importable(self) -> None:
+        """ObservabilityBundle is importable from types."""
+        from bioetl.composition.types import ObservabilityBundle
+
+        assert ObservabilityBundle is not None
+
+    def test_pipeline_definition_importable(self) -> None:
+        """PipelineDefinition is importable from types."""
+        from bioetl.composition.types import PipelineDefinition
+
+        assert PipelineDefinition is not None
+
+    def test_pipeline_registry_importable(self) -> None:
+        """PipelineRegistry is importable from types."""
+        from bioetl.composition.types import PipelineRegistry
+
+        assert PipelineRegistry is not None
+
+    def test_storage_adapter_importable(self) -> None:
+        """StorageAdapter is importable from types."""
+        from bioetl.composition.types import StorageAdapter
+
+        assert StorageAdapter is not None
+
+    def test_create_registry_importable(self) -> None:
+        """create_registry is importable from types."""
+        from bioetl.composition.types import create_registry
+
+        assert callable(create_registry)
+
+    def test_get_default_registry_importable(self) -> None:
+        """get_default_registry is importable from types."""
+        from bioetl.composition.types import get_default_registry
+
+        assert callable(get_default_registry)
+
+    def test_all_exports_defined(self) -> None:
+        """All items in __all__ are defined."""
+        from bioetl.composition import types
+
+        expected_exports = [
+            "ObservabilityBundle",
+            "PipelineDefinition",
+            "PipelineRegistry",
+            "StorageAdapter",
+            "create_registry",
+            "get_default_registry",
+        ]
+        for name in expected_exports:
+            assert name in types.__all__, f"{name} not in __all__"
+            assert hasattr(types, name), f"{name} not in module"
+
+    def test_exports_match_all(self) -> None:
+        """__all__ contains exactly the expected exports."""
+        from bioetl.composition import types
+
+        expected = {
+            "ObservabilityBundle",
+            "PipelineDefinition",
+            "PipelineRegistry",
+            "StorageAdapter",
+            "create_registry",
+            "get_default_registry",
+        }
+        assert set(types.__all__) == expected
+
+
+class TestTypesReExports:
+    """Tests verifying re-exports match source modules."""
+
+    def test_observability_bundle_is_same(self) -> None:
+        """ObservabilityBundle from types is same as from observability."""
+        from bioetl.composition.observability import ObservabilityBundle as DirectBundle
+        from bioetl.composition.types import ObservabilityBundle as ReExportedBundle
+
+        assert DirectBundle is ReExportedBundle
+
+    def test_pipeline_registry_is_same(self) -> None:
+        """PipelineRegistry from types is same as from registry."""
+        from bioetl.composition.registry import PipelineRegistry as DirectRegistry
+        from bioetl.composition.types import PipelineRegistry as ReExportedRegistry
+
+        assert DirectRegistry is ReExportedRegistry
+
+    def test_storage_adapter_is_same(self) -> None:
+        """StorageAdapter from types is same as from storage factory."""
+        from bioetl.composition.factories.storage import (
+            StorageAdapter as DirectAdapter,
+        )
+        from bioetl.composition.types import StorageAdapter as ReExportedAdapter
+
+        assert DirectAdapter is ReExportedAdapter
+
+    def test_create_registry_is_same(self) -> None:
+        """create_registry from types is same as from registry."""
+        from bioetl.composition.registry import create_registry as direct_fn
+        from bioetl.composition.types import create_registry as reexported_fn
+
+        assert direct_fn is reexported_fn
+
+    def test_get_default_registry_is_same(self) -> None:
+        """get_default_registry from types is same as from registry."""
+        from bioetl.composition.registry import get_default_registry as direct_fn
+        from bioetl.composition.types import get_default_registry as reexported_fn
+
+        assert direct_fn is reexported_fn
+
+
+class TestTypesUsability:
+    """Tests verifying types can be used for annotations."""
+
+    def test_types_usable_in_annotation(self) -> None:
+        """Types can be used in function annotations."""
+        from bioetl.composition.types import (
+            ObservabilityBundle,
+            PipelineRegistry,
+            StorageAdapter,
+        )
+
+        # Just verify they can be used as type annotations
+        # (this is a compile-time check, but we verify at runtime)
+        def example_function(
+            registry: PipelineRegistry,
+            storage: StorageAdapter,
+            observability: ObservabilityBundle,
+        ) -> None:
+            pass
+
+        # Function was created successfully
+        assert example_function is not None
+
+    def test_create_registry_returns_pipeline_registry(self) -> None:
+        """create_registry returns a PipelineRegistry instance."""
+        from bioetl.composition.types import PipelineRegistry, create_registry
+
+        registry = create_registry()
+        assert isinstance(registry, PipelineRegistry)

--- a/tests/unit/domain/test_config_types.py
+++ b/tests/unit/domain/test_config_types.py
@@ -1,0 +1,390 @@
+"""Tests for domain/config_types.py TypedDict definitions.
+
+These tests verify that TypedDict structures correctly type-check
+and can be instantiated with valid configuration data.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bioetl.domain.config_types import (
+    BronzeSinkDict,
+    CircuitBreakerDict,
+    ClientConfigDict,
+    CsvExportDict,
+    DQRulesDict,
+    GoldFiltersDict,
+    GoldRangeDict,
+    GoldSinkDict,
+    GoldValidationDict,
+    InputFilterDict,
+    PipelineConfigDict,
+    ProviderConfigDict,
+    RateLimitDict,
+    RuntimeArgsDict,
+    SilverSinkDict,
+    SinkDict,
+    SourceConfigDict,
+    SourceFileDict,
+    TransformDict,
+)
+
+
+class TestGoldRangeDict:
+    """Tests for GoldRangeDict TypedDict."""
+
+    def test_empty_range(self) -> None:
+        """GoldRangeDict can be empty (total=False)."""
+        range_dict: GoldRangeDict = {}
+        assert isinstance(range_dict, dict)
+
+    def test_full_range(self) -> None:
+        """GoldRangeDict with all fields."""
+        range_dict: GoldRangeDict = {
+            "min": 0.0,
+            "max": 100.0,
+            "include_min": True,
+            "include_max": False,
+        }
+        assert range_dict["min"] == 0.0
+        assert range_dict["max"] == 100.0
+        assert range_dict["include_min"] is True
+        assert range_dict["include_max"] is False
+
+    def test_partial_range(self) -> None:
+        """GoldRangeDict with only min."""
+        range_dict: GoldRangeDict = {"min": 5.0}
+        assert range_dict["min"] == 5.0
+
+
+class TestGoldFiltersDict:
+    """Tests for GoldFiltersDict TypedDict."""
+
+    def test_empty_filters(self) -> None:
+        """GoldFiltersDict can be empty."""
+        filters: GoldFiltersDict = {}
+        assert isinstance(filters, dict)
+
+    def test_column_filters(self) -> None:
+        """GoldFiltersDict with column filters."""
+        filters: GoldFiltersDict = {
+            "columns": {
+                "standard_type": ["IC50", "Ki"],
+                "target_type": ["SINGLE PROTEIN"],
+            }
+        }
+        assert "IC50" in filters["columns"]["standard_type"]
+
+    def test_range_filters(self) -> None:
+        """GoldFiltersDict with range filters."""
+        filters: GoldFiltersDict = {
+            "ranges": {
+                "standard_value": {"min": 0.0, "max": 1000.0},
+            }
+        }
+        assert filters["ranges"]["standard_value"]["max"] == 1000.0
+
+    def test_required_fields(self) -> None:
+        """GoldFiltersDict with required_fields."""
+        filters: GoldFiltersDict = {
+            "required_fields": ["molecule_id", "target_id"],
+        }
+        assert "molecule_id" in filters["required_fields"]
+
+    def test_list_filters(self) -> None:
+        """GoldFiltersDict with list_length and list_contains."""
+        filters: GoldFiltersDict = {
+            "list_length": {"synonyms": {"min_length": 1, "max_length": 10}},
+            "list_contains": {"types": {"values": ["protein"], "mode": "any"}},
+        }
+        assert filters["list_length"]["synonyms"]["min_length"] == 1
+
+
+class TestCsvExportDict:
+    """Tests for CsvExportDict TypedDict."""
+
+    def test_full_csv_config(self) -> None:
+        """CsvExportDict with all fields."""
+        config: CsvExportDict = {
+            "enabled": True,
+            "path": "/data/exports/output.csv",
+            "delimiter": ",",
+            "header": True,
+            "encoding": "utf-8",
+        }
+        assert config["enabled"] is True
+        assert config["delimiter"] == ","
+
+
+class TestBronzeSinkDict:
+    """Tests for BronzeSinkDict TypedDict."""
+
+    def test_bronze_sink_config(self) -> None:
+        """BronzeSinkDict configuration."""
+        config: BronzeSinkDict = {
+            "path": "data/bronze",
+            "format": "jsonl",
+            "save_json": True,
+        }
+        assert config["format"] == "jsonl"
+
+
+class TestSilverSinkDict:
+    """Tests for SilverSinkDict TypedDict."""
+
+    def test_silver_sink_full(self) -> None:
+        """SilverSinkDict with all fields."""
+        config: SilverSinkDict = {
+            "path": "data/silver",
+            "format": "delta",
+            "mode": "merge",
+            "primary_key": ["activity_id"],
+            "partition_by": ["year"],
+            "classification": "internal",
+            "forensic_retention": True,
+            "csv_export": {"enabled": False},
+        }
+        assert config["mode"] == "merge"
+        assert config["primary_key"] == ["activity_id"]
+
+
+class TestGoldSinkDict:
+    """Tests for GoldSinkDict TypedDict."""
+
+    def test_gold_sink_config(self) -> None:
+        """GoldSinkDict configuration."""
+        config: GoldSinkDict = {
+            "enabled": True,
+            "validation": {"strict": True},
+            "path": "data/gold",
+            "format": "delta",
+            "mode": "scd2",
+        }
+        assert config["mode"] == "scd2"
+
+
+class TestSinkDict:
+    """Tests for SinkDict TypedDict."""
+
+    def test_complete_sink(self) -> None:
+        """SinkDict with all layers."""
+        config: SinkDict = {
+            "bronze": {"path": "data/bronze", "format": "jsonl"},
+            "silver": {"path": "data/silver", "format": "delta"},
+            "gold": {"enabled": True, "path": "data/gold"},
+        }
+        assert "bronze" in config
+        assert "silver" in config
+        assert "gold" in config
+
+
+class TestTransformDict:
+    """Tests for TransformDict TypedDict."""
+
+    def test_transform_config(self) -> None:
+        """TransformDict configuration."""
+        config: TransformDict = {
+            "version": "1.0.0",
+            "steps": ["normalize", "validate", "enrich"],
+        }
+        assert "normalize" in config["steps"]
+
+
+class TestDQRulesDict:
+    """Tests for DQRulesDict TypedDict."""
+
+    def test_dq_rules_config(self) -> None:
+        """DQRulesDict with thresholds."""
+        config: DQRulesDict = {
+            "soft_fail_threshold": 0.05,
+            "hard_fail_threshold": 0.20,
+            "strict_validation": True,
+        }
+        assert config["soft_fail_threshold"] == 0.05
+        assert config["hard_fail_threshold"] == 0.20
+
+
+class TestCircuitBreakerDict:
+    """Tests for CircuitBreakerDict TypedDict."""
+
+    def test_circuit_breaker_config(self) -> None:
+        """CircuitBreakerDict configuration."""
+        config: CircuitBreakerDict = {
+            "failure_threshold": 5,
+            "recovery_timeout": 300,
+        }
+        assert config["failure_threshold"] == 5
+
+
+class TestInputFilterDict:
+    """Tests for InputFilterDict TypedDict."""
+
+    def test_input_filter_config(self) -> None:
+        """InputFilterDict configuration."""
+        config: InputFilterDict = {
+            "enabled": True,
+            "source_path": "data/filters/molecules.csv",
+            "column_name": "chembl_id",
+            "filter_field": "molecule_chembl_id",
+            "batch_size": 100,
+        }
+        assert config["enabled"] is True
+        assert config["batch_size"] == 100
+
+
+class TestClientConfigDict:
+    """Tests for ClientConfigDict TypedDict."""
+
+    def test_client_config(self) -> None:
+        """ClientConfigDict configuration."""
+        config: ClientConfigDict = {
+            "timeout_sec": 30.0,
+            "max_retries": 3,
+        }
+        assert config["timeout_sec"] == 30.0
+
+
+class TestRateLimitDict:
+    """Tests for RateLimitDict TypedDict."""
+
+    def test_rate_limit_config(self) -> None:
+        """RateLimitDict configuration."""
+        config: RateLimitDict = {
+            "requests_per_second": 10,
+            "burst": 20,
+        }
+        assert config["requests_per_second"] == 10
+
+
+class TestProviderConfigDict:
+    """Tests for ProviderConfigDict TypedDict."""
+
+    def test_provider_config(self) -> None:
+        """ProviderConfigDict configuration."""
+        config: ProviderConfigDict = {
+            "provider": "chembl",
+            "base_url": "https://www.ebi.ac.uk/chembl/api/data",
+            "client": {"timeout_sec": 30.0},
+            "max_url_length": 2048,
+            "batch_size": 100,
+            "page_size": 1000,
+            "api_version": "v1",
+        }
+        assert config["provider"] == "chembl"
+
+
+class TestSourceConfigDict:
+    """Tests for SourceConfigDict TypedDict."""
+
+    def test_source_config(self) -> None:
+        """SourceConfigDict configuration."""
+        config: SourceConfigDict = {
+            "type": "api",
+            "load_strategy": "incremental",
+            "batch_size": 500,
+            "provider_config": {"provider": "chembl"},
+            "circuit_breaker": {"failure_threshold": 5},
+            "rate_limit": {"requests_per_second": 10},
+        }
+        assert config["type"] == "api"
+        assert config["load_strategy"] == "incremental"
+
+
+class TestSourceFileDict:
+    """Tests for SourceFileDict TypedDict."""
+
+    def test_source_file_dict(self) -> None:
+        """SourceFileDict configuration."""
+        config: SourceFileDict = {
+            "source": {
+                "type": "api",
+                "batch_size": 100,
+            }
+        }
+        assert config["source"]["type"] == "api"
+
+
+class TestPipelineConfigDict:
+    """Tests for PipelineConfigDict TypedDict."""
+
+    def test_minimal_pipeline_config(self) -> None:
+        """PipelineConfigDict with required fields only."""
+        config: PipelineConfigDict = {
+            "pipeline_name": "chembl_activity",
+            "provider": "chembl",
+            "entity_type": "activity",
+        }
+        assert config["pipeline_name"] == "chembl_activity"
+
+    def test_full_pipeline_config(self) -> None:
+        """PipelineConfigDict with all fields."""
+        config: PipelineConfigDict = {
+            "pipeline_name": "chembl_activity",
+            "provider": "chembl",
+            "entity_type": "activity",
+            "version": "1.0.0",
+            "description": "ChEMBL Activity Pipeline",
+            "primary_keys": ["activity_id"],
+            "silver_table": "chembl_activity_silver",
+            "gold_table": "chembl_activity_gold",
+            "source_file": "chembl.yaml",
+            "gold_filters": {"columns": {"standard_type": ["IC50"]}},
+            "input_filter": {"enabled": False},
+            "transform": {"version": "1.0"},
+            "sink": {"bronze": {"path": "data/bronze"}},
+            "dq_rules": {"soft_fail_threshold": 0.05},
+            "circuit_breaker": {"failure_threshold": 5},
+        }
+        assert config["version"] == "1.0.0"
+        assert config["primary_keys"] == ["activity_id"]
+
+
+class TestRuntimeArgsDict:
+    """Tests for RuntimeArgsDict TypedDict."""
+
+    def test_runtime_args_config(self) -> None:
+        """RuntimeArgsDict with CLI arguments."""
+        config: RuntimeArgsDict = {
+            "run_type": "incremental",
+            "limit": 1000,
+            "query": "target_id:CHEMBL123",
+            "resume": True,
+            "dry_run": False,
+            "wait_for_lock": True,
+            "lock_wait_timeout": 300,
+            "heartbeat_interval": 30,
+            "vacuum_after_run": True,
+            "vacuum_retention_days": 7,
+            "strict_validation": True,
+            "strict_gold_validation": False,
+            "input_csv": "filters.csv",
+            "filter_column": "molecule_id",
+            "filter_field": "molecule_chembl_id",
+        }
+        assert config["run_type"] == "incremental"
+        assert config["limit"] == 1000
+
+    def test_empty_runtime_args(self) -> None:
+        """RuntimeArgsDict can be empty."""
+        config: RuntimeArgsDict = {}
+        assert isinstance(config, dict)
+
+
+class TestModuleExports:
+    """Tests for module __all__ exports."""
+
+    def test_all_exports_importable(self) -> None:
+        """All items in __all__ are importable."""
+        from bioetl.domain import config_types
+
+        for name in config_types.__all__:
+            assert hasattr(config_types, name), f"{name} not found in module"
+
+    def test_expected_exports_count(self) -> None:
+        """Expected number of exports."""
+        from bioetl.domain import config_types
+
+        # Verify we have the expected TypedDicts
+        expected_count = 20  # 20 TypedDicts defined in config_types.py
+        assert len(config_types.__all__) == expected_count

--- a/tests/unit/infrastructure/adapters/test_logging_utils.py
+++ b/tests/unit/infrastructure/adapters/test_logging_utils.py
@@ -1,0 +1,185 @@
+"""Tests for infrastructure/adapters/logging_utils.py.
+
+These tests verify the standardized error logging utility.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from bioetl.infrastructure.adapters.logging_utils import log_adapter_error
+
+
+class TestLogAdapterError:
+    """Tests for log_adapter_error function."""
+
+    def test_logs_with_standard_logger(self) -> None:
+        """log_adapter_error works with standard logging.Logger."""
+        logger = logging.getLogger("test_logger")
+        logger.error = MagicMock()
+
+        log_adapter_error(
+            logger,
+            provider="chembl",
+            operation="fetch",
+            exc_info=True,
+            batch_id="batch_001",
+        )
+
+        logger.error.assert_called_once()
+        call_args = logger.error.call_args
+        assert call_args[0][0] == "chembl fetch failed"
+        assert call_args[1]["exc_info"] is True
+        assert call_args[1]["extra"]["batch_id"] == "batch_001"
+
+    def test_logs_with_structlog_logger(self) -> None:
+        """log_adapter_error works with structlog-compatible logger."""
+        mock_logger = MagicMock()
+
+        log_adapter_error(
+            mock_logger,
+            provider="pubchem",
+            operation="batch fetch",
+            exc_info=False,
+            record_count=100,
+        )
+
+        mock_logger.error.assert_called_once()
+        call_args = mock_logger.error.call_args
+        assert call_args[0][0] == "pubchem batch fetch failed"
+        assert call_args[1]["exc_info"] is False
+        assert call_args[1]["record_count"] == 100
+
+    def test_message_format(self) -> None:
+        """Message follows '{provider} {operation} failed' format."""
+        mock_logger = MagicMock()
+
+        log_adapter_error(
+            mock_logger,
+            provider="uniprot",
+            operation="health check",
+        )
+
+        call_args = mock_logger.error.call_args
+        assert call_args[0][0] == "uniprot health check failed"
+
+    def test_default_exc_info_true(self) -> None:
+        """exc_info defaults to True."""
+        mock_logger = MagicMock()
+
+        log_adapter_error(mock_logger, provider="chembl", operation="fetch")
+
+        call_args = mock_logger.error.call_args
+        assert call_args[1]["exc_info"] is True
+
+    def test_exc_info_can_be_disabled(self) -> None:
+        """exc_info can be set to False."""
+        mock_logger = MagicMock()
+
+        log_adapter_error(
+            mock_logger,
+            provider="chembl",
+            operation="fetch",
+            exc_info=False,
+        )
+
+        call_args = mock_logger.error.call_args
+        assert call_args[1]["exc_info"] is False
+
+    def test_with_multiple_context_fields(self) -> None:
+        """Multiple context fields are passed through."""
+        mock_logger = MagicMock()
+
+        log_adapter_error(
+            mock_logger,
+            provider="pubmed",
+            operation="xml parse",
+            exc_info=True,
+            run_id="run_123",
+            record_id="PMID:456",
+            error_type="ParseError",
+            retry_count=2,
+        )
+
+        call_args = mock_logger.error.call_args
+        assert call_args[1]["run_id"] == "run_123"
+        assert call_args[1]["record_id"] == "PMID:456"
+        assert call_args[1]["error_type"] == "ParseError"
+        assert call_args[1]["retry_count"] == 2
+
+    def test_with_empty_context(self) -> None:
+        """Works with no additional context."""
+        mock_logger = MagicMock()
+
+        log_adapter_error(mock_logger, provider="chembl", operation="fetch")
+
+        mock_logger.error.assert_called_once()
+
+    def test_with_none_context_values(self) -> None:
+        """Handles None values in context."""
+        mock_logger = MagicMock()
+
+        log_adapter_error(
+            mock_logger,
+            provider="chembl",
+            operation="fetch",
+            optional_field=None,
+        )
+
+        call_args = mock_logger.error.call_args
+        assert call_args[1]["optional_field"] is None
+
+    def test_standard_logger_uses_extra(self) -> None:
+        """Standard logging.Logger receives context via 'extra' kwarg."""
+        logger = logging.getLogger("test_standard")
+        logger.error = MagicMock()
+
+        log_adapter_error(
+            logger,
+            provider="chembl",
+            operation="fetch",
+            custom_field="value",
+        )
+
+        call_args = logger.error.call_args
+        assert "extra" in call_args[1]
+        assert call_args[1]["extra"]["custom_field"] == "value"
+
+    def test_structlog_logger_receives_context_as_kwargs(self) -> None:
+        """Structlog-compatible logger receives context as **kwargs."""
+        mock_logger = MagicMock()
+
+        log_adapter_error(
+            mock_logger,
+            provider="chembl",
+            operation="fetch",
+            custom_field="value",
+        )
+
+        call_args = mock_logger.error.call_args
+        assert call_args[1]["custom_field"] == "value"
+
+    def test_various_providers(self) -> None:
+        """Works with various provider names."""
+        providers = ["chembl", "pubchem", "uniprot", "pubmed"]
+        mock_logger = MagicMock()
+
+        for provider in providers:
+            mock_logger.reset_mock()
+            log_adapter_error(mock_logger, provider=provider, operation="fetch")
+            call_args = mock_logger.error.call_args
+            assert provider in call_args[0][0]
+
+    def test_various_operations(self) -> None:
+        """Works with various operation names."""
+        operations = ["fetch", "batch fetch", "health check", "transform", "validate"]
+        mock_logger = MagicMock()
+
+        for operation in operations:
+            mock_logger.reset_mock()
+            log_adapter_error(mock_logger, provider="test", operation=operation)
+            call_args = mock_logger.error.call_args
+            assert operation in call_args[0][0]

--- a/tests/unit/infrastructure/observability/test_tracing.py
+++ b/tests/unit/infrastructure/observability/test_tracing.py
@@ -1,0 +1,171 @@
+"""Tests for infrastructure/observability/tracing.py.
+
+These tests verify the OpenTelemetry tracing implementation.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bioetl.infrastructure.observability.noop_tracing import NoOpTracing
+
+
+class TestNoOpTracingReExport:
+    """Tests for NoOpTracing re-export from tracing module."""
+
+    def test_noop_tracing_importable(self) -> None:
+        """NoOpTracing is importable from tracing module."""
+        from bioetl.infrastructure.observability.tracing import NoOpTracing
+
+        assert NoOpTracing is not None
+
+    def test_noop_tracing_is_same(self) -> None:
+        """NoOpTracing from tracing is same as direct import."""
+        from bioetl.infrastructure.observability.noop_tracing import (
+            NoOpTracing as Direct,
+        )
+        from bioetl.infrastructure.observability.tracing import (
+            NoOpTracing as ReExported,
+        )
+
+        assert Direct is ReExported
+
+
+class TestModuleImports:
+    """Tests for module-level imports."""
+
+    def test_otel_available_defined(self) -> None:
+        """OTEL_AVAILABLE flag is defined."""
+        from bioetl.infrastructure.observability import tracing
+
+        assert hasattr(tracing, "OTEL_AVAILABLE")
+        assert isinstance(tracing.OTEL_AVAILABLE, bool)
+
+    def test_opentelemetry_tracer_class_defined(self) -> None:
+        """OpenTelemetryTracer class is defined."""
+        from bioetl.infrastructure.observability import tracing
+
+        assert hasattr(tracing, "OpenTelemetryTracer")
+
+
+class TestOpenTelemetryTracerWithoutOTEL:
+    """Tests for OpenTelemetryTracer when OpenTelemetry is not available."""
+
+    def test_init_raises_without_otel(self) -> None:
+        """OpenTelemetryTracer raises ImportError if OTEL not available."""
+        from bioetl.infrastructure.observability import tracing
+
+        if not tracing.OTEL_AVAILABLE:
+            with pytest.raises(ImportError) as exc_info:
+                tracing.OpenTelemetryTracer()
+            assert "OpenTelemetry is not installed" in str(exc_info.value)
+        else:
+            pytest.skip("OpenTelemetry is available")
+
+
+class TestOpenTelemetryTracerWithOTEL:
+    """Tests for OpenTelemetryTracer when OpenTelemetry is available."""
+
+    @pytest.fixture
+    def mock_otel(self) -> None:
+        """Mock OpenTelemetry modules."""
+        mock_trace = MagicMock()
+        mock_provider = MagicMock()
+        mock_processor = MagicMock()
+        mock_exporter = MagicMock()
+        mock_tracer = MagicMock()
+
+        mock_trace.get_tracer.return_value = mock_tracer
+        mock_provider_class = MagicMock(return_value=mock_provider)
+        mock_processor_class = MagicMock(return_value=mock_processor)
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "opentelemetry": MagicMock(),
+                "opentelemetry.trace": mock_trace,
+                "opentelemetry.sdk": MagicMock(),
+                "opentelemetry.sdk.trace": MagicMock(
+                    TracerProvider=mock_provider_class
+                ),
+                "opentelemetry.sdk.trace.export": MagicMock(
+                    BatchSpanProcessor=mock_processor_class,
+                    ConsoleSpanExporter=mock_exporter,
+                ),
+            },
+        ):
+            yield {
+                "trace": mock_trace,
+                "provider": mock_provider,
+                "tracer": mock_tracer,
+            }
+
+    def test_tracer_available(self) -> None:
+        """Test when OTEL is available."""
+        from bioetl.infrastructure.observability import tracing
+
+        if tracing.OTEL_AVAILABLE:
+            # Create tracer - it should work
+            tracer = tracing.OpenTelemetryTracer("test_service")
+            assert tracer is not None
+            tracer.close()
+        else:
+            pytest.skip("OpenTelemetry is not available")
+
+
+class TestOpenTelemetryTracerClose:
+    """Tests for OpenTelemetryTracer close behavior."""
+
+    def test_close_is_idempotent(self) -> None:
+        """close() can be called multiple times safely."""
+        from bioetl.infrastructure.observability import tracing
+
+        if tracing.OTEL_AVAILABLE:
+            tracer = tracing.OpenTelemetryTracer("test")
+            tracer.close()
+            tracer.close()  # Should not raise
+            tracer.close()  # Should not raise
+        else:
+            pytest.skip("OpenTelemetry is not available")
+
+
+class TestModuleAll:
+    """Tests for __all__ exports."""
+
+    def test_all_exports(self) -> None:
+        """All expected items are in __all__."""
+        from bioetl.infrastructure.observability import tracing
+
+        expected = ["NoOpTracing", "OpenTelemetryTracer"]
+        for name in expected:
+            assert name in tracing.__all__
+
+
+class TestTracingIntegration:
+    """Integration tests for tracing module."""
+
+    def test_noop_tracing_usable_as_fallback(self) -> None:
+        """NoOpTracing can be used when OTEL is not available."""
+        from bioetl.infrastructure.observability import tracing
+
+        # Create NoOpTracing as fallback
+        noop = tracing.NoOpTracing()
+        tracer = noop.get_tracer("test")
+
+        # Verify it works
+        assert tracer is not None
+
+    def test_factory_pattern(self) -> None:
+        """Demonstrate factory pattern for choosing tracer."""
+        from bioetl.infrastructure.observability import tracing
+
+        def create_tracer(use_otel: bool = False) -> NoOpTracing:
+            if use_otel and tracing.OTEL_AVAILABLE:
+                return tracing.OpenTelemetryTracer("bioetl")
+            return tracing.NoOpTracing()
+
+        # Should always work
+        tracer = create_tracer(use_otel=False)
+        assert isinstance(tracer, NoOpTracing)


### PR DESCRIPTION
Add comprehensive tests for previously uncovered/low-coverage modules:
- domain/config_types.py: 0% → 100% (TypedDict definitions)
- composition/base_registry.py: 0% → 77% (Registry protocol)
- composition/types.py: 0% → 100% (Re-exports)
- infrastructure/adapters/logging_utils.py: 0% → 100% (Error logging)
- composition/factories/transformer_factory.py: 23% → 100%
- infrastructure/observability/tracing.py: 29% → 37%

Overall coverage: 87.33% → 88.95% (exceeds 85% requirement)

Also fix architecture test to include config_types in excluded patterns.