### PR TITLE
Create schema documentation for BioETL pipelines

### DIFF
--- a/docs/00-map.md
+++ b/docs/00-map.md
@@ -43,6 +43,17 @@ docs/
 │   ├── 06-rules-mapping.md      # RULES.md to docs mapping
 │   └── 07-consistency-check.md  # Consistency verification guide
 │
+├── domain/                      # Domain model documentation
+│   └── schemas/                 # Schema documentation by provider
+│       ├── chembl/              # ChEMBL entity schemas
+│       │   ├── activity-schema.md
+│       │   ├── molecule-schema.md
+│       │   ├── target-schema.md
+│       │   └── assay-schema.md
+│       ├── pubchem/             # PubChem entity schemas
+│       ├── uniprot/             # UniProt entity schemas
+│       └── pubmed/              # PubMed entity schemas
+│
 ├── 02-architecture/             # System architecture
 │   ├── 01-domain-layer.md       # Domain layer architecture
 │   ├── 02-application-layer.md  # Application layer architecture
@@ -135,6 +146,15 @@ docs/
 | Backfill/Replay  | [01-project-rules.md](00-project_rules/01-project-rules.md)            | §2.4     |
 | Quarantine       | [01-project-rules.md](00-project_rules/01-project-rules.md) | §2.6     |
 | Content Hash     | [system-context.md](02-architecture/system-context.md)                                              | §2.8     |
+
+### Schema Documentation
+
+| Provider | Entity | Schema Document | RULES.md |
+|----------|--------|-----------------|----------|
+| ChEMBL | Activity | [activity-schema.md](domain/schemas/chembl/activity-schema.md) | §2.8 |
+| ChEMBL | Molecule | [molecule-schema.md](domain/schemas/chembl/molecule-schema.md) | §2.8 |
+| ChEMBL | Target | [target-schema.md](domain/schemas/chembl/target-schema.md) | §2.8 |
+| ChEMBL | Assay | [assay-schema.md](domain/schemas/chembl/assay-schema.md) | §2.8 |
 
 ### Operations
 
@@ -292,12 +312,13 @@ graph TD
 | RULES.md (docs/)         | 2025-12-27   | v5.7 (Pre-Refactoring)       |
 | refactoring-plan.md      | 2025-12-27   | v5.6 (Consolidated)          |
 | REQUIREMENTS.md          | 2025-12-27   | v1.2 (127 requirements)      |
-| 00-map.md                | 2025-12-27   | v5.7 Synced, structure clean |
+| 00-map.md                | 2025-12-28   | v5.8 Schema docs added       |
 | 00-rules-summary.md      | 2025-12-27   | v5.6 Synced                  |
 | 03-guides/               | 2025-12-20   | Consolidated (10 guides)     |
 | ADR-001..020             | 2025-12-27   | All 20 ADRs documented       |
 | 05-operations/runbooks/  | 2025-12-27   | 4 active runbooks            |
+| domain/schemas/          | 2025-12-28   | ChEMBL schemas (4 entities)  |
 
 ---
 
-*Last updated: 2025-12-27. Update when adding new documentation.*
+*Last updated: 2025-12-28. Update when adding new documentation.*

--- a/docs/domain/schemas/chembl/activity-schema.md
+++ b/docs/domain/schemas/chembl/activity-schema.md
@@ -1,0 +1,469 @@
+# Activity Schema (ChEMBL)
+*Version: 1.0.0 | Aligned with RULES.md v5.0*
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Entity ID** | `activity_id` (Business Key) |
+| **Content Hash** | `content_hash` (SHA256 for SCD Type 2) |
+| **Source** | ChEMBL API (`/chembl/api/data/activity.json`) |
+| **Update Frequency** | Weekly (ChEMBL release cycle) |
+| **Schema Version** | 1.0.0 (ChEMBL 34 aligned) |
+
+### Purpose
+Activity records represent bioactivity measurements from scientific publications and patents. Each record links a molecule to a biological target through an assay, with quantitative or qualitative activity data.
+
+### Key Relationships
+```
+Activity ───► Molecule (molecule_chembl_id)
+    │
+    ├───► Target (target_chembl_id)
+    │
+    ├───► Assay (assay_chembl_id)
+    │
+    └───► Document (document_chembl_id)
+```
+
+---
+
+## Medallion Representation
+
+| Layer | Format | Validation | Partition Key | Retention |
+|-------|--------|------------|---------------|-----------|
+| Bronze | JSONL+zstd | None | `ingestion_date` | 90 days |
+| Silver | Delta Lake | Pandera (soft) | None | Permanent |
+| Gold | Delta Lake | Pandera (strict) | None | Permanent |
+
+### Gold Layer Filtering
+Gold layer applies strict filters to ensure high-quality data for analysis:
+
+| Filter | Values | Purpose |
+|--------|--------|---------|
+| `standard_type` | `["IC50", "Ki"]` | Focus on affinity measurements |
+| `standard_units` | `["nM"]` | Normalized units |
+| `standard_relation` | `["="]` | Exact measurements only |
+| `assay_type` | `["B", "F"]` | Binding and Functional assays |
+| `potential_duplicate` | `["0"]` | Exclude duplicates |
+| `standard_value` | `> 0` | Valid positive values |
+
+**Required Fields for Gold**: `standard_type`, `standard_value`, `standard_units`, `target_chembl_id`
+
+---
+
+## Field Schemas
+
+### Primary Key
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `activity_id` | `str` | No | — | Primary key (integer as string) | `activities[].activity_id` |
+
+### Foreign Keys
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `assay_chembl_id` | `str` | No | `^CHEMBL\d+$` | FK to Assay entity | `activities[].assay_chembl_id` |
+| `molecule_chembl_id` | `str` | No | `^CHEMBL\d+$` | FK to Molecule entity | `activities[].molecule_chembl_id` |
+| `target_chembl_id` | `str` | Yes | `^CHEMBL\d+$` | FK to Target entity | `activities[].target_chembl_id` |
+| `document_chembl_id` | `str` | Yes | `^CHEMBL\d+$` | FK to Document entity | `activities[].document_chembl_id` |
+| `record_id` | `int` | Yes | — | FK to compound_record | `activities[].record_id` |
+| `src_id` | `int` | Yes | — | Source database ID | `activities[].src_id` |
+
+### Standardized Activity Values
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `standard_type` | `str` | Yes | `isin=["IC50", "EC50", "Ki", "Kd", "AC50", "GI50", "Potency", "Inhibition", "% Inhibition", "Activity", "Ratio", "ED50", "ID50"]` | Standardized measurement type | `activities[].standard_type` |
+| `standard_value` | `float` | Yes | `ge=0` | Standardized numeric value | `activities[].standard_value` |
+| `standard_units` | `str` | Yes | — | Standardized units (e.g., nM) | `activities[].standard_units` |
+| `standard_relation` | `str` | Yes | `isin=["=", "<", "<=", ">", ">="]` | Relation operator | `activities[].standard_relation` |
+| `standard_flag` | `int` | Yes | `isin=[0, 1]` | 1 if value was standardized | `activities[].standard_flag` |
+| `standard_upper_value` | `float` | Yes | — | Upper bound (for ranges) | `activities[].standard_upper_value` |
+| `standard_text_value` | `str` | Yes | — | Text-based measurement | `activities[].standard_text_value` |
+
+### Original Activity Values
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `type` | `str` | Yes | — | Original measurement type | `activities[].type` |
+| `value` | `float` | Yes | — | Original numeric value | `activities[].value` |
+| `units` | `str` | Yes | — | Original units | `activities[].units` |
+| `relation` | `str` | Yes | — | Original relation | `activities[].relation` |
+| `upper_value` | `float` | Yes | — | Original upper bound | `activities[].upper_value` |
+| `text_value` | `str` | Yes | — | Original text value | `activities[].text_value` |
+
+### Derived Metrics
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `pchembl_value` | `float` | Yes | `ge=0, le=14` | -log10 molar activity (comparable across types) | `activities[].pchembl_value` |
+
+### Ligand Efficiency Metrics
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `ligand_efficiency_bei` | `float` | Yes | — | Binding Efficiency Index | `activities[].ligand_efficiency.bei` |
+| `ligand_efficiency_le` | `float` | Yes | — | Ligand Efficiency | `activities[].ligand_efficiency.le` |
+| `ligand_efficiency_lle` | `float` | Yes | — | Lipophilic Ligand Efficiency | `activities[].ligand_efficiency.lle` |
+| `ligand_efficiency_sei` | `float` | Yes | — | Surface Efficiency Index | `activities[].ligand_efficiency.sei` |
+
+### Molecule Fields (Denormalized)
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `canonical_smiles` | `str` | Yes | — | Canonical SMILES structure | `activities[].canonical_smiles` |
+| `molecule_pref_name` | `str` | Yes | — | Preferred molecule name | `activities[].molecule_pref_name` |
+| `parent_molecule_chembl_id` | `str` | Yes | — | Parent molecule ID (for salts) | `activities[].parent_molecule_chembl_id` |
+
+### Target Fields (Denormalized)
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `target_pref_name` | `str` | Yes | — | Preferred target name | `activities[].target_pref_name` |
+| `target_organism` | `str` | Yes | — | Target organism (e.g., "Homo sapiens") | `activities[].target_organism` |
+| `target_tax_id` | `str` | Yes | — | NCBI Taxonomy ID | `activities[].target_tax_id` |
+
+### Assay Fields (Denormalized)
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `assay_type` | `str` | Yes | — | Assay type code (B=Binding, F=Functional) | `activities[].assay_type` |
+| `assay_description` | `str` | Yes | — | Full assay description | `activities[].assay_description` |
+| `assay_variant_accession` | `str` | Yes | — | UniProt accession for variants | `activities[].assay_variant_accession` |
+| `assay_variant_mutation` | `str` | Yes | — | Mutation description | `activities[].assay_variant_mutation` |
+
+### Ontology Annotations
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `bao_endpoint` | `str` | Yes | `^BAO:\d+$` | BioAssay Ontology endpoint ID | `activities[].bao_endpoint` |
+| `bao_format` | `str` | Yes | — | BioAssay Ontology format ID | `activities[].bao_format` |
+| `bao_label` | `str` | Yes | — | Human-readable BAO label | `activities[].bao_label` |
+| `uo_units` | `str` | Yes | `^UO:\d+$` | Units Ontology ID | `activities[].uo_units` |
+| `qudt_units` | `str` | Yes | — | QUDT unit URI | `activities[].qudt_units` |
+
+### Quality Annotations
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `activity_comment` | `str` | Yes | — | Free-text comment | `activities[].activity_comment` |
+| `data_validity_comment` | `str` | Yes | `isin=[...]` | Structured DQ comment | `activities[].data_validity_comment` |
+| `potential_duplicate` | `int` | Yes | `isin=[0, 1]` | 1 if likely duplicate | `activities[].potential_duplicate` |
+
+**Valid `data_validity_comment` values:**
+- `"Potential missing data"`
+- `"Potential author error"`
+- `"Manually validated"`
+- `"Potential transcription error"`
+- `"Outside typical range"`
+- `"Non standard unit for type"`
+- `"Author confirmed error"`
+
+### Action Type (Flattened)
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `action_type_action_type` | `str` | Yes | — | Action type (e.g., INHIBITOR) | `activities[].action_type.action_type` |
+| `action_type_description` | `str` | Yes | — | Action description | `activities[].action_type.description` |
+| `action_type_parent_type` | `str` | Yes | — | Parent action category | `activities[].action_type.parent_type` |
+
+### Document Fields (Denormalized)
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `document_journal` | `str` | Yes | — | Journal name | `activities[].document_journal` |
+| `document_year` | `float` | Yes | — | Publication year | `activities[].document_year` |
+
+### Other Fields
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `activity_properties` | `str` | Yes | — | JSON string of additional properties | `activities[].activity_properties` |
+| `toid` | `int` | Yes | — | Test Occasion ID | `activities[].toid` |
+
+---
+
+## Meta-Fields (RULES.md §2.4)
+
+| Field | Type | Nullable | Purpose | Included in Content Hash |
+|-------|------|----------|---------|-------------------------|
+| `entity_id` | `str` | No | Business key (= activity_id) | Yes |
+| `content_hash` | `str` | No | SHA256 for SCD Type 2 | — |
+| `_run_id` | `UUID` | No | Pipeline run correlation ID | No |
+| `_run_type` | `Enum` | No | incremental/backfill/rebuild | No |
+| `_source_batch_id` | `UUID` | Yes | FK to lineage_log | No |
+| `_ingestion_ts` | `Timestamp` | No | Ingestion time (UTC) | No |
+| `_dq_warn` | `bool` | No | DQ warning flag | No |
+| `_index` | `int` | No | Record index in batch | No |
+
+---
+
+## Transformations
+
+### Bronze → Silver
+
+| Source Field | Target Field | Transformation |
+|--------------|--------------|----------------|
+| `activity_id` | `activity_id` | `str(value)` |
+| `standard_value` | `standard_value` | `safe_float()` |
+| `value` | `value` | `safe_float()` |
+| `pchembl_value` | `pchembl_value` | `safe_float()` |
+| `standard_flag` | `standard_flag` | `safe_int()` |
+| `potential_duplicate` | `potential_duplicate` | `safe_int()` |
+| `document_year` | `document_year` | `safe_int()` |
+| `record_id` | `record_id` | `safe_int()` |
+| `src_id` | `src_id` | `safe_int()` |
+| `toid` | `toid` | `safe_int()` |
+| `ligand_efficiency` | `ligand_efficiency_*` | `flatten_nested_dict()` → 4 float fields |
+| `action_type` | `action_type_*` | `flatten_nested_dict()` → 3 str fields |
+| `activity_properties` | `activity_properties` | `json.dumps()` if list |
+
+### Normalization Rules (RULES.md §2.8.1)
+
+| Data Type | Normalization |
+|-----------|---------------|
+| **Floats** | `round(val, 10)` |
+| **Dates** | ISO `YYYY-MM-DD` |
+| **Strings** | `strip()` |
+| **NaN/Inf** | → `null` |
+
+### Content Hash Calculation
+
+```python
+sha256(
+    provider="chembl"
+    + canonical_json(
+        record,
+        exclude=["_run_id", "_run_type", "_source_batch_id", "_ingestion_ts", "_dq_warn", "_index"]
+    )
+)
+```
+
+---
+
+## Validation Rules
+
+### Pandera Schema
+
+```python
+class ActivitySchema(ETLRecordSchema):
+    """Activity validation schema for Silver layer."""
+
+    # Primary Key
+    activity_id: Series[str] = pa.Field(nullable=False)
+
+    # Foreign Keys
+    assay_chembl_id: Series[str] = pa.Field(
+        nullable=False, str_matches=r"^CHEMBL\d+$"
+    )
+    molecule_chembl_id: Series[str] = pa.Field(
+        nullable=False, str_matches=r"^CHEMBL\d+$"
+    )
+    target_chembl_id: Optional[Series[str]] = pa.Field(
+        nullable=True, str_matches=r"^CHEMBL\d+$"
+    )
+
+    # Standardized Values
+    standard_value: Optional[Series[float]] = pa.Field(
+        nullable=True, ge=0
+    )
+    pchembl_value: Optional[Series[float]] = pa.Field(
+        nullable=True, ge=0, le=14
+    )
+
+    class Config:
+        strict = True
+        ordered = False
+        coerce = True
+```
+
+### DQ Checks
+
+| Check | Column | Threshold | Action |
+|-------|--------|-----------|--------|
+| null_rate | `activity_id` | 0% | Critical (fail batch) |
+| null_rate | `molecule_chembl_id` | 0% | Critical (fail batch) |
+| null_rate | `assay_chembl_id` | 0% | Critical (fail batch) |
+| null_rate | `standard_value` | <5% warn, <20% fail | RULES.md §3.1.2 |
+| range | `pchembl_value` | 0-14 | Quarantine |
+| regex | `*_chembl_id` | `^CHEMBL\d+$` | Quarantine |
+| enum | `standard_relation` | `=, <, <=, >, >=` | Quarantine |
+
+### Entity Invariants
+
+```python
+def _validate_invariants(self) -> None:
+    if not self.activity_id:
+        raise ValueError("Activity ID is required")
+    if not self.molecule_chembl_id:
+        raise ValueError("Molecule ID is required")
+    if self.pchembl_value is not None and self.pchembl_value < 0:
+        raise ValueError(f"pChemBL value must be non-negative")
+```
+
+---
+
+## Cross-Source Mapping
+
+| Source | ID Field | Mapping Strategy |
+|--------|----------|------------------|
+| ChEMBL | `activity_id` | Primary source |
+| PubChem | N/A | Activities not mapped directly |
+| ChEMBL Molecule | `molecule_chembl_id` | FK join |
+| ChEMBL Target | `target_chembl_id` | FK join |
+| UniProt | `target_components.accession` | Via Target entity |
+
+---
+
+## Example Records
+
+### Bronze (Raw API Response)
+
+```json
+{
+  "activity_id": 31864,
+  "assay_chembl_id": "CHEMBL872937",
+  "assay_description": "In vivo inhibitory activity against human Heparanase",
+  "assay_type": "B",
+  "assay_variant_accession": null,
+  "assay_variant_mutation": null,
+  "bao_endpoint": "BAO_0000190",
+  "bao_format": "BAO_0000218",
+  "bao_label": "organism-based format",
+  "canonical_smiles": "Cc1ccc2oc(-c3cccc(N4C(=O)c5ccc(C(=O)O)cc5C4=O)c3)nc2c1",
+  "data_validity_comment": null,
+  "document_chembl_id": "CHEMBL1146658",
+  "document_journal": "Bioorg Med Chem Lett",
+  "document_year": 2004,
+  "ligand_efficiency": {
+    "bei": "14.06",
+    "le": "0.26",
+    "lle": "1.30",
+    "sei": "5.56"
+  },
+  "molecule_chembl_id": "CHEMBL324340",
+  "pchembl_value": "5.60",
+  "potential_duplicate": 0,
+  "qudt_units": "http://www.openphacts.org/units/Nanomolar",
+  "record_id": 208970,
+  "relation": "=",
+  "src_id": 1,
+  "standard_flag": 1,
+  "standard_relation": "=",
+  "standard_type": "IC50",
+  "standard_units": "nM",
+  "standard_value": "2500.0",
+  "target_chembl_id": "CHEMBL3921",
+  "target_organism": "Homo sapiens",
+  "target_pref_name": "Heparanase",
+  "target_tax_id": "9606",
+  "type": "IC50",
+  "units": "uM",
+  "uo_units": "UO_0000065",
+  "value": "2.5"
+}
+```
+
+### Silver (Normalized)
+
+```json
+{
+  "entity_id": "31864",
+  "activity_id": "31864",
+  "content_hash": "sha256:a1b2c3d4e5f6...",
+  "_run_id": "550e8400-e29b-41d4-a716-446655440000",
+  "_run_type": "incremental",
+  "_source_batch_id": null,
+  "_ingestion_ts": "2024-01-15T10:30:00Z",
+  "_dq_warn": false,
+  "_index": 0,
+
+  "assay_chembl_id": "CHEMBL872937",
+  "molecule_chembl_id": "CHEMBL324340",
+  "target_chembl_id": "CHEMBL3921",
+  "document_chembl_id": "CHEMBL1146658",
+
+  "standard_type": "IC50",
+  "standard_value": 2500.0,
+  "standard_units": "nM",
+  "standard_relation": "=",
+  "standard_flag": 1,
+
+  "pchembl_value": 5.60,
+
+  "ligand_efficiency_bei": 14.06,
+  "ligand_efficiency_le": 0.26,
+  "ligand_efficiency_lle": 1.30,
+  "ligand_efficiency_sei": 5.56,
+
+  "canonical_smiles": "Cc1ccc2oc(-c3cccc(N4C(=O)c5ccc(C(=O)O)cc5C4=O)c3)nc2c1",
+  "target_pref_name": "Heparanase",
+  "target_organism": "Homo sapiens",
+  "assay_type": "B",
+
+  "type": "IC50",
+  "value": 2.5,
+  "units": "uM",
+  "relation": "=",
+
+  "document_journal": "Bioorg Med Chem Lett",
+  "document_year": 2004,
+  "potential_duplicate": 0
+}
+```
+
+### Gold (Filtered & Flattened)
+
+Gold layer contains only records passing gold_filters:
+- `standard_type` in `["IC50", "Ki"]`
+- `standard_units` = `"nM"`
+- `standard_relation` = `"="`
+- `standard_value` > 0
+- `target_chembl_id` is not null
+
+```json
+{
+  "entity_id": "31864",
+  "activity_id": "31864",
+  "content_hash": "sha256:a1b2c3d4e5f6...",
+
+  "molecule_chembl_id": "CHEMBL324340",
+  "target_chembl_id": "CHEMBL3921",
+  "assay_chembl_id": "CHEMBL872937",
+
+  "standard_type": "IC50",
+  "standard_value": 2500.0,
+  "standard_units": "nM",
+  "pchembl_value": 5.60,
+
+  "canonical_smiles": "Cc1ccc2oc(-c3cccc(N4C(=O)c5ccc(C(=O)O)cc5C4=O)c3)nc2c1",
+  "target_pref_name": "Heparanase",
+  "target_organism": "Homo sapiens"
+}
+```
+
+---
+
+## Related Artifacts
+
+| Artifact | Path |
+|----------|------|
+| Pandera Schema | `src/bioetl/domain/schemas/chembl/activity.py` |
+| Domain Entity | `src/bioetl/domain/entities/chembl_activity.py` |
+| Base Schema | `src/bioetl/domain/schemas/base.py` |
+| Transformer | `src/bioetl/application/pipelines/chembl/activity_transformer.py` |
+| Pipeline Config | `configs/pipelines/chembl/activity.yaml` |
+| VCR Cassettes | `tests/fixtures/vcr/TestChemblActivityPipeline.*.yaml` |
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0.0 | 2024-12-28 | Initial schema documentation |
+
+---
+
+*Build reliably. Document honestly. Ask boldly.*

--- a/docs/domain/schemas/chembl/assay-schema.md
+++ b/docs/domain/schemas/chembl/assay-schema.md
@@ -1,0 +1,322 @@
+# Assay Schema (ChEMBL)
+*Version: 1.0.0 | Aligned with RULES.md v5.0*
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Entity ID** | `assay_chembl_id` (Business Key) |
+| **Content Hash** | `content_hash` (SHA256 for SCD Type 2) |
+| **Source** | ChEMBL API (`/chembl/api/data/assay.json`) |
+| **Update Frequency** | Quarterly (ChEMBL release cycle) |
+| **Schema Version** | 1.0.0 (ChEMBL 34 aligned) |
+
+### Purpose
+Assay records define the experimental conditions under which bioactivity measurements were made. Each assay links to a target and contains information about the assay type, biological context (organism, tissue, cell type), and confidence of target assignment.
+
+### Key Relationships
+```
+Assay ◄─── Activity (assay_chembl_id)
+    │
+    ├───► Target (target_chembl_id)
+    │
+    ├───► Document (document_chembl_id)
+    │
+    └───► Cell Line (cell_chembl_id)
+```
+
+---
+
+## Medallion Representation
+
+| Layer | Format | Validation | Partition Key | Retention |
+|-------|--------|------------|---------------|-----------|
+| Bronze | JSONL+zstd | None | `ingestion_date` | 90 days |
+| Silver | Delta Lake | Pandera (soft) | `assay_type` | Permanent |
+| Gold | Delta Lake | Pandera (strict) | None | Permanent |
+
+### Gold Layer Filtering
+Gold layer applies filters for high-confidence assays:
+
+| Filter | Values | Purpose |
+|--------|--------|---------|
+| `assay_type` | `["B", "F"]` | Binding and Functional only |
+| `confidence_score` | `["8", "9"]` | High confidence (0-9 scale) |
+| `relationship_type` | `["D"]` | Direct target interaction |
+
+**Required Fields for Gold**: `assay_type`, `description`
+
+---
+
+## Field Schemas
+
+### Primary Key
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `assay_chembl_id` | `str` | No | `^CHEMBL\d+$` | ChEMBL assay identifier | `assays[].assay_chembl_id` |
+
+### Description & Classification
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `description` | `str` | Yes | — | Full assay description | `assays[].description` |
+| `assay_type` | `str` | Yes | `isin=["B","F","A","T","P","U"]` | Assay type code | `assays[].assay_type` |
+| `assay_test_type` | `str` | Yes | `isin=["In vivo","In vitro","Ex vivo"]` | Test type | `assays[].assay_test_type` |
+| `assay_category` | `str` | Yes | `isin=[...]` | Assay category | `assays[].assay_category` |
+| `assay_group` | `str` | Yes | — | Assay group | `assays[].assay_group` |
+| `assay_pref_name` | `str` | Yes | — | Preferred assay name | `assays[].assay_pref_name` |
+
+**Assay Type Codes:**
+| Code | Description |
+|------|-------------|
+| `B` | Binding assay |
+| `F` | Functional assay |
+| `A` | ADMET assay |
+| `T` | Toxicity assay |
+| `P` | Physicochemical assay |
+| `U` | Unclassified |
+
+**Assay Categories:**
+- `screening` - High-throughput screening
+- `confirmatory` - Confirmatory assay
+- `panel` - Panel assay
+- `summary` - Summary data
+- `other` - Other category
+
+### Biological Context
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `assay_organism` | `str` | Yes | — | Assay organism | `assays[].assay_organism` |
+| `assay_tax_id` | `int` | Yes | — | NCBI Taxonomy ID | `assays[].assay_tax_id` |
+| `assay_strain` | `str` | Yes | — | Strain | `assays[].assay_strain` |
+| `assay_tissue` | `str` | Yes | — | Tissue | `assays[].assay_tissue` |
+| `assay_cell_type` | `str` | Yes | — | Cell type | `assays[].assay_cell_type` |
+| `assay_subcellular_fraction` | `str` | Yes | — | Subcellular fraction | `assays[].assay_subcellular_fraction` |
+
+### Foreign Keys
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `target_chembl_id` | `str` | Yes | `^CHEMBL\d+$` | FK to Target | `assays[].target_chembl_id` |
+| `document_chembl_id` | `str` | Yes | `^CHEMBL\d+$` | FK to Document | `assays[].document_chembl_id` |
+| `cell_chembl_id` | `str` | Yes | — | FK to Cell Line | `assays[].cell_chembl_id` |
+| `tissue_chembl_id` | `str` | Yes | — | FK to Tissue | `assays[].tissue_chembl_id` |
+| `src_id` | `int` | Yes | — | Source database ID | `assays[].src_id` |
+| `src_assay_id` | `str` | Yes | — | Source assay ID | `assays[].src_assay_id` |
+
+### Target Relationship & Confidence
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `relationship_type` | `str` | Yes | `isin=["D","H","M","N","S","U"]` | Target relationship | `assays[].relationship_type` |
+| `relationship_description` | `str` | Yes | — | Relationship description | `assays[].relationship_description` |
+| `confidence_score` | `int` | Yes | `ge=0, le=9` | Target confidence (0-9) | `assays[].confidence_score` |
+| `confidence_description` | `str` | Yes | — | Confidence description | `assays[].confidence_description` |
+
+**Relationship Type Codes:**
+| Code | Description |
+|------|-------------|
+| `D` | Direct interaction |
+| `H` | Homologous target |
+| `M` | Molecular target |
+| `N` | Non-molecular mechanism |
+| `S` | Substrate/product |
+| `U` | Unknown |
+
+### BioAssay Ontology
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `bao_format` | `str` | Yes | `^BAO:\d+$` | BAO assay format ID | `assays[].bao_format` |
+| `bao_label` | `str` | Yes | — | BAO format label | `assays[].bao_label` |
+
+### Variant Information (Flattened)
+
+| Field | Type | Nullable | Description | Source |
+|-------|------|----------|-------------|--------|
+| `variant_accession` | `str` | Yes | UniProt accession | `variant_sequence.accession` |
+| `variant_isoform` | `str` | Yes | Isoform identifier | `variant_sequence.isoform` |
+| `variant_mutation` | `str` | Yes | Mutation (e.g., V600E) | `variant_sequence.mutation` |
+| `variant_organism` | `str` | Yes | Variant organism | `variant_sequence.organism` |
+| `variant_sequence` | `str` | Yes | Amino acid sequence | `variant_sequence.sequence` |
+| `variant_tax_id` | `int` | Yes | Variant taxonomy ID | `variant_sequence.tax_id` |
+| `variant_sequence_json` | `str` | Yes | Full JSON (forensic) | JSON of variant_sequence |
+
+### Other Fields
+
+| Field | Type | Nullable | Description | Source |
+|-------|------|----------|-------------|--------|
+| `score` | `float` | Yes | Assay score | `assays[].score` |
+| `aidx` | `str` | Yes | Assay index | `assays[].aidx` |
+
+### Complex Fields (JSON Serialized)
+
+| Field | Type | Nullable | Description | Source |
+|-------|------|----------|-------------|--------|
+| `assay_classifications` | `str` | Yes | Classification hierarchy (JSON) | `assays[].assay_classifications` |
+| `assay_parameters` | `str` | Yes | Assay parameters (JSON) | `assays[].assay_parameters` |
+
+---
+
+## Meta-Fields (RULES.md §2.4)
+
+| Field | Type | Nullable | Purpose | Included in Content Hash |
+|-------|------|----------|---------|-------------------------|
+| `entity_id` | `str` | No | Business key (= assay_chembl_id) | Yes |
+| `content_hash` | `str` | No | SHA256 for SCD Type 2 | — |
+| `_run_id` | `UUID` | No | Pipeline run correlation ID | No |
+| `_run_type` | `Enum` | No | incremental/backfill/rebuild | No |
+| `_source_batch_id` | `UUID` | Yes | FK to lineage_log | No |
+| `_ingestion_ts` | `Timestamp` | No | Ingestion time (UTC) | No |
+| `_dq_warn` | `bool` | No | DQ warning flag | No |
+| `_index` | `int` | No | Record index in batch | No |
+
+---
+
+## Transformations
+
+### Bronze → Silver
+
+| Source Field | Target Field | Transformation |
+|--------------|--------------|----------------|
+| `assay_chembl_id` | `assay_chembl_id` | Direct |
+| `assay_tax_id` | `assay_tax_id` | `safe_int()` |
+| `confidence_score` | `confidence_score` | `safe_int()` |
+| `variant_sequence` | `variant_*` | Flatten nested dict |
+| `variant_sequence` | `variant_sequence_json` | `json.dumps()` |
+| `assay_classifications` | `assay_classifications` | `json.dumps()` |
+| `assay_parameters` | `assay_parameters` | `json.dumps()` |
+
+---
+
+## Validation Rules
+
+### Pandera Schema
+
+```python
+class AssaySchema(ETLRecordSchema):
+    """Assay validation schema for Silver layer."""
+
+    assay_chembl_id: Series[str] = pa.Field(
+        nullable=False, str_matches=r"^CHEMBL\d+$"
+    )
+    assay_type: Optional[Series[str]] = pa.Field(
+        nullable=True, isin=["B", "F", "A", "T", "P", "U"]
+    )
+    confidence_score: Optional[Series[int]] = pa.Field(
+        nullable=True, ge=0, le=9
+    )
+    target_chembl_id: Optional[Series[str]] = pa.Field(
+        nullable=True, str_matches=r"^CHEMBL\d+$"
+    )
+
+    class Config:
+        strict = True
+        ordered = False
+        coerce = True
+```
+
+### Entity Invariants
+
+```python
+def _validate_invariants(self) -> None:
+    if not self.assay_chembl_id:
+        raise ValueError("Assay ChEMBL ID is required")
+    if self.confidence_score is not None and not (0 <= self.confidence_score <= 9):
+        raise ValueError(f"Confidence score must be 0-9, got {self.confidence_score}")
+```
+
+---
+
+## Cross-Source Mapping
+
+| Source | ID Field | Mapping Strategy |
+|--------|----------|------------------|
+| ChEMBL | `assay_chembl_id` | Primary source |
+| BioAssay Ontology | `bao_format` | Via BAO ID |
+| PubChem BioAssay | `src_assay_id` (when src_id=7) | Source mapping |
+
+---
+
+## Example Records
+
+### Bronze (Raw API Response)
+
+```json
+{
+  "assay_chembl_id": "CHEMBL872937",
+  "description": "In vivo inhibitory activity against human Heparanase",
+  "assay_type": "B",
+  "assay_test_type": "In vivo",
+  "assay_organism": "Homo sapiens",
+  "assay_tax_id": 9606,
+  "target_chembl_id": "CHEMBL3921",
+  "document_chembl_id": "CHEMBL1146658",
+  "confidence_score": 9,
+  "confidence_description": "Direct single protein target assigned",
+  "relationship_type": "D",
+  "relationship_description": "Direct protein target assigned",
+  "bao_format": "BAO_0000218",
+  "bao_label": "organism-based format",
+  "src_id": 1
+}
+```
+
+### Silver (Normalized)
+
+```json
+{
+  "entity_id": "CHEMBL872937",
+  "assay_chembl_id": "CHEMBL872937",
+  "content_hash": "sha256:ghi789...",
+  "_run_id": "550e8400-e29b-41d4-a716-446655440002",
+  "_run_type": "incremental",
+  "_ingestion_ts": "2024-01-15T10:30:00Z",
+  "_dq_warn": false,
+  "_index": 0,
+
+  "description": "In vivo inhibitory activity against human Heparanase",
+  "assay_type": "B",
+  "assay_test_type": "In vivo",
+  "assay_organism": "Homo sapiens",
+  "assay_tax_id": 9606,
+
+  "target_chembl_id": "CHEMBL3921",
+  "document_chembl_id": "CHEMBL1146658",
+
+  "confidence_score": 9,
+  "confidence_description": "Direct single protein target assigned",
+  "relationship_type": "D",
+  "relationship_description": "Direct protein target assigned",
+
+  "bao_format": "BAO_0000218",
+  "bao_label": "organism-based format",
+
+  "src_id": 1
+}
+```
+
+---
+
+## Related Artifacts
+
+| Artifact | Path |
+|----------|------|
+| Pandera Schema | `src/bioetl/domain/schemas/chembl/assay.py` |
+| Domain Entity | `src/bioetl/domain/entities/chembl_activity.py` |
+| Pipeline Config | `configs/pipelines/chembl/assay.yaml` |
+| Activity Schema | `docs/domain/schemas/chembl/activity-schema.md` |
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0.0 | 2024-12-28 | Initial schema documentation |
+
+---
+
+*Build reliably. Document honestly. Ask boldly.*

--- a/docs/domain/schemas/chembl/molecule-schema.md
+++ b/docs/domain/schemas/chembl/molecule-schema.md
@@ -1,0 +1,320 @@
+# Molecule Schema (ChEMBL)
+*Version: 1.0.0 | Aligned with RULES.md v5.0*
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Entity ID** | `molecule_chembl_id` (Business Key) |
+| **Content Hash** | `content_hash` (SHA256 for SCD Type 2) |
+| **Source** | ChEMBL API (`/chembl/api/data/molecule.json`) |
+| **Update Frequency** | Quarterly (ChEMBL release cycle) |
+| **Schema Version** | 1.0.0 (ChEMBL 34 aligned) |
+
+### Purpose
+Molecule records represent chemical compounds including small molecules, proteins, antibodies, and oligonucleotides. Each record contains structural information, calculated properties, clinical development status, and regulatory annotations.
+
+### Key Relationships
+```
+Molecule ◄─── Activity (molecule_chembl_id)
+    │
+    └──► Parent Molecule (hierarchy_parent_chembl_id)
+```
+
+---
+
+## Medallion Representation
+
+| Layer | Format | Validation | Partition Key | Retention |
+|-------|--------|------------|---------------|-----------|
+| Bronze | JSONL+zstd | None | `ingestion_date` | 90 days |
+| Silver | Delta Lake | Pandera (soft) | `molecule_type` | Permanent |
+| Gold | Delta Lake | Pandera (strict) | None | Permanent |
+
+### Gold Layer Filtering
+Gold layer applies filters for high-quality drug-like molecules:
+
+| Filter | Values | Purpose |
+|--------|--------|---------|
+| `molecule_type` | `["Small molecule"]` | Focus on small molecules |
+| `structure_type` | `["MOL"]` | Molecules with structures |
+| `inorganic_flag` | `["0"]` | Organic compounds only |
+
+**Required Fields for Gold**: `molecule_chembl_id`
+
+---
+
+## Field Schemas
+
+### Primary Key
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `molecule_chembl_id` | `str` | No | `^CHEMBL\d+$` | ChEMBL molecule identifier | `molecules[].molecule_chembl_id` |
+
+### Core Properties
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `pref_name` | `str` | Yes | — | Preferred name (INN, USAN) | `molecules[].pref_name` |
+| `molecule_type` | `str` | Yes | `isin=[...]` | Molecule type classification | `molecules[].molecule_type` |
+| `structure_type` | `str` | Yes | `isin=["MOL","SEQ","BOTH","NONE"]` | Structure data type | `molecules[].structure_type` |
+| `max_phase` | `float` | Yes | `isin=[-1,0,0.5,1,2,3,4]` | Maximum clinical phase reached | `molecules[].max_phase` |
+| `first_approval` | `int` | Yes | — | Year of first regulatory approval | `molecules[].first_approval` |
+
+**Valid `molecule_type` values:**
+- `Small molecule`, `Inorganic small molecule`, `Polymeric small molecule`
+- `Antibody`, `Antibody drug conjugate`, `Protein`
+- `Oligonucleotide`, `Oligosaccharide`, `Cell`, `Enzyme`
+- `Unknown`, `Unclassified`
+
+### Administration Route Flags
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `oral` | `bool` | Yes | — | Approved for oral administration | `molecules[].oral` |
+| `parenteral` | `bool` | Yes | — | Approved for parenteral (injection) | `molecules[].parenteral` |
+| `topical` | `bool` | Yes | — | Approved for topical application | `molecules[].topical` |
+
+### Regulatory & Safety Flags
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `therapeutic_flag` | `bool` | Yes | — | Has therapeutic application | `molecules[].therapeutic_flag` |
+| `black_box_warning` | `int` | Yes | `isin=[0,1]` | FDA black box warning | `molecules[].black_box_warning` |
+| `withdrawn_flag` | `bool` | Yes | — | Withdrawn from market | `molecules[].withdrawn_flag` |
+| `first_in_class` | `int` | Yes | `isin=[0,1]` | First-in-class mechanism | `molecules[].first_in_class` |
+
+### Chemical Classification Flags
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `natural_product` | `int` | Yes | `isin=[-1,0,1]` | Natural product origin | `molecules[].natural_product` |
+| `prodrug` | `int` | Yes | `isin=[0,1]` | Prodrug that requires activation | `molecules[].prodrug` |
+| `inorganic_flag` | `int` | Yes | `isin=[0,1]` | Inorganic compound | `molecules[].inorganic_flag` |
+| `polymer_flag` | `int` | Yes | `isin=[0,1]` | Polymer | `molecules[].polymer_flag` |
+
+### Complex Fields (JSON Serialized)
+
+| Field | Type | Nullable | Description | Source |
+|-------|------|----------|-------------|--------|
+| `molecule_hierarchy` | `str` | Yes | Parent/child relationships (JSON) | `molecules[].molecule_hierarchy` |
+| `molecule_properties` | `str` | Yes | Calculated molecular properties (JSON) | `molecules[].molecule_properties` |
+| `molecule_structures` | `str` | Yes | SMILES, InChI structures (JSON) | `molecules[].molecule_structures` |
+| `molecule_synonyms` | `str` | Yes | Alternative names (JSON) | `molecules[].molecule_synonyms` |
+| `cross_references` | `str` | Yes | External database links (JSON) | `molecules[].cross_references` |
+| `atc_classifications` | `str` | Yes | WHO ATC codes (JSON) | `molecules[].atc_classifications` |
+
+### Flattened Hierarchy Fields
+
+| Field | Type | Nullable | Description | Source |
+|-------|------|----------|-------------|--------|
+| `hierarchy_parent_chembl_id` | `str` | Yes | Parent molecule (for salts) | `molecule_hierarchy.parent_chembl_id` |
+| `hierarchy_active_chembl_id` | `str` | Yes | Active moiety | `molecule_hierarchy.active_chembl_id` |
+
+### Flattened Property Fields
+
+| Field | Type | Nullable | Description | Source |
+|-------|------|----------|-------------|--------|
+| `property_alogp` | `float` | Yes | Calculated ALogP | `molecule_properties.alogp` |
+| `property_mw_freebase` | `float` | Yes | Molecular weight (freebase) | `molecule_properties.mw_freebase` |
+| `property_full_mwt` | `float` | Yes | Full molecular weight | `molecule_properties.full_mwt` |
+| `property_hba` | `int` | Yes | H-bond acceptor count | `molecule_properties.hba` |
+| `property_hbd` | `int` | Yes | H-bond donor count | `molecule_properties.hbd` |
+| `property_psa` | `float` | Yes | Polar surface area | `molecule_properties.psa` |
+| `property_rtb` | `int` | Yes | Rotatable bond count | `molecule_properties.rtb` |
+| `property_ro5_violations` | `int` | Yes | Lipinski Rule of 5 violations | `molecule_properties.num_ro5_violations` |
+| `property_heavy_atoms` | `int` | Yes | Heavy atom count | `molecule_properties.heavy_atoms` |
+| `property_aromatic_rings` | `int` | Yes | Aromatic ring count | `molecule_properties.aromatic_rings` |
+| `property_qed_weighted` | `float` | Yes | QED drug-likeness score | `molecule_properties.qed_weighted` |
+
+### Flattened Structure Fields
+
+| Field | Type | Nullable | Description | Source |
+|-------|------|----------|-------------|--------|
+| `structure_canonical_smiles` | `str` | Yes | Canonical SMILES | `molecule_structures.canonical_smiles` |
+| `structure_standard_inchi` | `str` | Yes | Standard InChI | `molecule_structures.standard_inchi` |
+| `structure_standard_inchi_key` | `str` | Yes | Standard InChI Key | `molecule_structures.standard_inchi_key` |
+
+---
+
+## Meta-Fields (RULES.md §2.4)
+
+| Field | Type | Nullable | Purpose | Included in Content Hash |
+|-------|------|----------|---------|-------------------------|
+| `entity_id` | `str` | No | Business key (= molecule_chembl_id) | Yes |
+| `content_hash` | `str` | No | SHA256 for SCD Type 2 | — |
+| `_run_id` | `UUID` | No | Pipeline run correlation ID | No |
+| `_run_type` | `Enum` | No | incremental/backfill/rebuild | No |
+| `_source_batch_id` | `UUID` | Yes | FK to lineage_log | No |
+| `_ingestion_ts` | `Timestamp` | No | Ingestion time (UTC) | No |
+| `_dq_warn` | `bool` | No | DQ warning flag | No |
+| `_index` | `int` | No | Record index in batch | No |
+
+---
+
+## Transformations
+
+### Bronze → Silver
+
+| Source Field | Target Field | Transformation |
+|--------------|--------------|----------------|
+| `molecule_chembl_id` | `molecule_chembl_id` | Direct |
+| `max_phase` | `max_phase` | `safe_float()` |
+| `first_approval` | `first_approval` | `safe_int()` |
+| `molecule_hierarchy` | `molecule_hierarchy` | `json.dumps()` |
+| `molecule_hierarchy.parent_chembl_id` | `hierarchy_parent_chembl_id` | Flatten |
+| `molecule_properties` | `molecule_properties` | `json.dumps()` |
+| `molecule_properties.*` | `property_*` | Flatten & convert |
+| `molecule_structures` | `molecule_structures` | `json.dumps()` |
+| `molecule_structures.*` | `structure_*` | Flatten |
+
+---
+
+## Validation Rules
+
+### Pandera Schema
+
+```python
+class MoleculeSchema(ETLRecordSchema):
+    """Molecule validation schema for Silver layer."""
+
+    molecule_chembl_id: Series[str] = pa.Field(
+        nullable=False, str_matches=r"^CHEMBL\d+$"
+    )
+    max_phase: Optional[Series[float]] = pa.Field(
+        nullable=True, isin=[-1, 0, 0.5, 1, 2, 3, 4]
+    )
+    structure_type: Optional[Series[str]] = pa.Field(
+        nullable=True, isin=["MOL", "SEQ", "BOTH", "NONE"]
+    )
+
+    class Config:
+        strict = True
+        ordered = False
+        coerce = True
+```
+
+### Entity Invariants
+
+```python
+def _validate_invariants(self) -> None:
+    if not self.molecule_chembl_id:
+        raise ValueError("Molecule ChEMBL ID is required")
+    if self.max_phase is not None and not (0 <= self.max_phase <= 4):
+        raise ValueError(f"max_phase must be 0-4, got {self.max_phase}")
+```
+
+---
+
+## Cross-Source Mapping
+
+| Source | ID Field | Mapping Strategy |
+|--------|----------|------------------|
+| ChEMBL | `molecule_chembl_id` | Primary source |
+| PubChem | `cross_references[src="PubChem"]` | Via cross_references |
+| DrugBank | `cross_references[src="DrugBank"]` | Via cross_references |
+| ChEBI | `cross_references[src="ChEBI"]` | Via cross_references |
+
+---
+
+## Example Records
+
+### Bronze (Raw API Response)
+
+```json
+{
+  "molecule_chembl_id": "CHEMBL25",
+  "pref_name": "ASPIRIN",
+  "molecule_type": "Small molecule",
+  "structure_type": "MOL",
+  "max_phase": 4,
+  "first_approval": 1950,
+  "oral": true,
+  "parenteral": false,
+  "topical": true,
+  "black_box_warning": 0,
+  "therapeutic_flag": true,
+  "molecule_hierarchy": {
+    "molecule_chembl_id": "CHEMBL25",
+    "parent_chembl_id": "CHEMBL25"
+  },
+  "molecule_properties": {
+    "alogp": 1.31,
+    "full_mwt": 180.16,
+    "hba": 4,
+    "hbd": 1,
+    "psa": 63.6,
+    "rtb": 3,
+    "num_ro5_violations": 0,
+    "qed_weighted": 0.56
+  },
+  "molecule_structures": {
+    "canonical_smiles": "CC(=O)Oc1ccccc1C(=O)O",
+    "standard_inchi": "InChI=1S/C9H8O4/c1-6(10)13-8-5-3-2-4-7(8)9(11)12/h2-5H,1H3,(H,11,12)",
+    "standard_inchi_key": "BSYNRYMUTXBXSQ-UHFFFAOYSA-N"
+  }
+}
+```
+
+### Silver (Normalized)
+
+```json
+{
+  "entity_id": "CHEMBL25",
+  "molecule_chembl_id": "CHEMBL25",
+  "content_hash": "sha256:abc123...",
+  "_run_id": "550e8400-e29b-41d4-a716-446655440000",
+  "_run_type": "incremental",
+  "_ingestion_ts": "2024-01-15T10:30:00Z",
+  "_dq_warn": false,
+  "_index": 0,
+
+  "pref_name": "ASPIRIN",
+  "molecule_type": "Small molecule",
+  "structure_type": "MOL",
+  "max_phase": 4.0,
+  "first_approval": 1950,
+
+  "oral": true,
+  "parenteral": false,
+  "topical": true,
+  "black_box_warning": 0,
+  "therapeutic_flag": true,
+
+  "hierarchy_parent_chembl_id": "CHEMBL25",
+  "property_alogp": 1.31,
+  "property_full_mwt": 180.16,
+  "property_hba": 4,
+  "property_hbd": 1,
+  "property_psa": 63.6,
+  "property_rtb": 3,
+  "property_ro5_violations": 0,
+  "property_qed_weighted": 0.56,
+
+  "structure_canonical_smiles": "CC(=O)Oc1ccccc1C(=O)O",
+  "structure_standard_inchi_key": "BSYNRYMUTXBXSQ-UHFFFAOYSA-N"
+}
+```
+
+---
+
+## Related Artifacts
+
+| Artifact | Path |
+|----------|------|
+| Pandera Schema | `src/bioetl/domain/schemas/chembl/molecule.py` |
+| Domain Entity | `src/bioetl/domain/entities/chembl_structures.py` |
+| Pipeline Config | `configs/pipelines/chembl/molecule.yaml` |
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0.0 | 2024-12-28 | Initial schema documentation |
+
+---
+
+*Build reliably. Document honestly. Ask boldly.*

--- a/docs/domain/schemas/chembl/target-schema.md
+++ b/docs/domain/schemas/chembl/target-schema.md
@@ -1,0 +1,272 @@
+# Target Schema (ChEMBL)
+*Version: 1.0.0 | Aligned with RULES.md v5.0*
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Entity ID** | `target_chembl_id` (Business Key) |
+| **Content Hash** | `content_hash` (SHA256 for SCD Type 2) |
+| **Source** | ChEMBL API (`/chembl/api/data/target.json`) |
+| **Update Frequency** | Quarterly (ChEMBL release cycle) |
+| **Schema Version** | 1.0.0 (ChEMBL 34 aligned) |
+
+### Purpose
+Target records represent biological targets including single proteins, protein complexes, protein families, cell lines, tissues, and organisms. Each target can be linked to activities through assays and contains information about component proteins with UniProt accessions.
+
+### Key Relationships
+```
+Target ◄─── Activity (target_chembl_id)
+    │
+    ├───► Target Component (component_id)
+    │       │
+    │       └───► UniProt (accession)
+    │
+    └───► Assay (target_chembl_id)
+```
+
+---
+
+## Medallion Representation
+
+| Layer | Format | Validation | Partition Key | Retention |
+|-------|--------|------------|---------------|-----------|
+| Bronze | JSONL+zstd | None | `ingestion_date` | 90 days |
+| Silver | Delta Lake | Pandera (soft) | `target_type` | Permanent |
+| Gold | Delta Lake | Pandera (strict) | None | Permanent |
+
+### Gold Layer Filtering
+Gold layer applies filters for single proteins with UniProt mappings:
+
+| Filter | Values | Purpose |
+|--------|--------|---------|
+| `target_type` | `["SINGLE PROTEIN"]` | Focus on single proteins |
+| `component_accessions` | length = 1 | Single component |
+| `component_ids` | length >= 1 | Has component ID |
+| `component_types` | contains `["PROTEIN"]` | Protein components |
+
+**Required Fields for Gold**: `pref_name`, `organism`
+
+---
+
+## Field Schemas
+
+### Primary Key
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `target_chembl_id` | `str` | No | `^CHEMBL\d+$` | ChEMBL target identifier | `targets[].target_chembl_id` |
+
+### Core Metadata
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `pref_name` | `str` | Yes | — | Preferred target name | `targets[].pref_name` |
+| `organism` | `str` | Yes | — | Organism (e.g., "Homo sapiens") | `targets[].organism` |
+| `tax_id` | `int` | Yes | — | NCBI Taxonomy ID | `targets[].tax_id` |
+| `species_group_flag` | `bool` | Yes | — | Species group indicator | `targets[].species_group_flag` |
+
+### Classification
+
+| Field | Type | Nullable | Constraints | Description | Source |
+|-------|------|----------|-------------|-------------|--------|
+| `target_type` | `str` | Yes | `isin=[...]` | Target type classification | `targets[].target_type` |
+
+**Valid `target_type` values:**
+- `SINGLE PROTEIN` - Single protein target
+- `PROTEIN FAMILY` - Group of related proteins
+- `PROTEIN COMPLEX` - Multi-subunit protein
+- `PROTEIN COMPLEX GROUP` - Group of complexes
+- `SELECTIVITY GROUP` - Selectivity panel
+- `CHIMERIC PROTEIN` - Fusion protein
+- `CELL-LINE` - Cell line target
+- `TISSUE` - Tissue target
+- `ORGANISM` - Whole organism
+- `MACROMOLECULE` - DNA/RNA targets
+- `SMALL MOLECULE` - Small molecule target
+- `LIPID` - Lipid target
+- `METAL` - Metal target
+- `UNKNOWN` - Unknown type
+
+### Complex Fields (JSON Serialized)
+
+| Field | Type | Nullable | Description | Source |
+|-------|------|----------|-------------|--------|
+| `target_components` | `str` | Yes | Component proteins/sequences (JSON) | `targets[].target_components` |
+| `cross_references` | `str` | Yes | External database links (JSON) | `targets[].cross_references` |
+
+### Flattened Component Fields
+
+These fields are extracted from the `target_components` array for easier querying:
+
+| Field | Type | Nullable | Description | Source |
+|-------|------|----------|-------------|--------|
+| `component_accessions` | `list[str]` | Yes | UniProt accessions | `target_components[].accession` |
+| `component_ids` | `list[int]` | Yes | Component IDs | `target_components[].component_id` |
+| `component_types` | `list[str]` | Yes | Component types (PROTEIN, etc.) | `target_components[].component_type` |
+| `component_relationships` | `list[str]` | Yes | Relationship types | `target_components[].relationship` |
+| `component_descriptions` | `list[str]` | Yes | Component descriptions | `target_components[].component_description` |
+
+---
+
+## Meta-Fields (RULES.md §2.4)
+
+| Field | Type | Nullable | Purpose | Included in Content Hash |
+|-------|------|----------|---------|-------------------------|
+| `entity_id` | `str` | No | Business key (= target_chembl_id) | Yes |
+| `content_hash` | `str` | No | SHA256 for SCD Type 2 | — |
+| `_run_id` | `UUID` | No | Pipeline run correlation ID | No |
+| `_run_type` | `Enum` | No | incremental/backfill/rebuild | No |
+| `_source_batch_id` | `UUID` | Yes | FK to lineage_log | No |
+| `_ingestion_ts` | `Timestamp` | No | Ingestion time (UTC) | No |
+| `_dq_warn` | `bool` | No | DQ warning flag | No |
+| `_index` | `int` | No | Record index in batch | No |
+
+---
+
+## Transformations
+
+### Bronze → Silver
+
+| Source Field | Target Field | Transformation |
+|--------------|--------------|----------------|
+| `target_chembl_id` | `target_chembl_id` | Direct |
+| `tax_id` | `tax_id` | `safe_int()` |
+| `target_components` | `target_components` | `json.dumps()` |
+| `target_components[*].accession` | `component_accessions` | Extract to list |
+| `target_components[*].component_id` | `component_ids` | Extract to list |
+| `target_components[*].component_type` | `component_types` | Extract to list |
+| `cross_references` | `cross_references` | `json.dumps()` |
+
+---
+
+## Validation Rules
+
+### Pandera Schema
+
+```python
+class TargetSchema(ETLRecordSchema):
+    """Target validation schema for Silver layer."""
+
+    target_chembl_id: Series[str] = pa.Field(
+        nullable=False, str_matches=r"^CHEMBL\d+$"
+    )
+    target_type: Optional[Series[str]] = pa.Field(
+        nullable=True, isin=[
+            "SINGLE PROTEIN", "PROTEIN FAMILY", "PROTEIN COMPLEX",
+            "CELL-LINE", "TISSUE", "ORGANISM", ...
+        ]
+    )
+    tax_id: Optional[Series[int]] = pa.Field(nullable=True)
+
+    # List fields
+    component_accessions: Optional[Series[object]] = pa.Field(nullable=True)
+    component_ids: Optional[Series[object]] = pa.Field(nullable=True)
+
+    class Config:
+        strict = True
+        ordered = False
+        coerce = True
+```
+
+### Entity Invariants
+
+```python
+def _validate_invariants(self) -> None:
+    if not self.target_chembl_id:
+        raise ValueError("Target ChEMBL ID is required")
+```
+
+---
+
+## Cross-Source Mapping
+
+| Source | ID Field | Mapping Strategy |
+|--------|----------|------------------|
+| ChEMBL | `target_chembl_id` | Primary source |
+| UniProt | `component_accessions[]` | Via flattened components |
+| NCBI Taxonomy | `tax_id` | Direct mapping |
+| Gene Ontology | `cross_references[src="GO"]` | Via cross_references |
+
+---
+
+## Example Records
+
+### Bronze (Raw API Response)
+
+```json
+{
+  "target_chembl_id": "CHEMBL3921",
+  "pref_name": "Heparanase",
+  "target_type": "SINGLE PROTEIN",
+  "organism": "Homo sapiens",
+  "tax_id": 9606,
+  "species_group_flag": false,
+  "target_components": [
+    {
+      "accession": "Q9Y251",
+      "component_id": 4553,
+      "component_type": "PROTEIN",
+      "component_description": "Heparanase",
+      "relationship": "SINGLE PROTEIN"
+    }
+  ],
+  "cross_references": [
+    {"xref_id": "Q9Y251", "xref_name": "UniProt", "xref_src": "UniProt"},
+    {"xref_id": "GO:0005576", "xref_name": "extracellular region", "xref_src": "GO"}
+  ]
+}
+```
+
+### Silver (Normalized)
+
+```json
+{
+  "entity_id": "CHEMBL3921",
+  "target_chembl_id": "CHEMBL3921",
+  "content_hash": "sha256:def456...",
+  "_run_id": "550e8400-e29b-41d4-a716-446655440001",
+  "_run_type": "incremental",
+  "_ingestion_ts": "2024-01-15T10:30:00Z",
+  "_dq_warn": false,
+  "_index": 0,
+
+  "pref_name": "Heparanase",
+  "target_type": "SINGLE PROTEIN",
+  "organism": "Homo sapiens",
+  "tax_id": 9606,
+  "species_group_flag": false,
+
+  "target_components": "[{\"accession\": \"Q9Y251\", ...}]",
+  "cross_references": "[{\"xref_id\": \"Q9Y251\", ...}]",
+
+  "component_accessions": ["Q9Y251"],
+  "component_ids": [4553],
+  "component_types": ["PROTEIN"],
+  "component_relationships": ["SINGLE PROTEIN"],
+  "component_descriptions": ["Heparanase"]
+}
+```
+
+---
+
+## Related Artifacts
+
+| Artifact | Path |
+|----------|------|
+| Pandera Schema | `src/bioetl/domain/schemas/chembl/target.py` |
+| Domain Entity | `src/bioetl/domain/entities/chembl_structures.py` |
+| Pipeline Config | `configs/pipelines/chembl/target.yaml` |
+| Target Component Schema | `src/bioetl/domain/schemas/chembl/target_component.py` |
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0.0 | 2024-12-28 | Initial schema documentation |
+
+---
+
+*Build reliably. Document honestly. Ask boldly.*


### PR DESCRIPTION
Add detailed schema documentation for four core ChEMBL entities:
- Activity: bioactivity measurements from scientific publications
- Molecule: chemical compounds with structural and clinical data
- Target: biological targets with component protein mappings
- Assay: experimental conditions for bioactivity measurements

Each document includes:
- Field schemas with types, constraints, and source mappings
- Medallion layer representation (Bronze/Silver/Gold)
- Bronze to Silver transformation rules
- Pandera validation rules and entity invariants
- Cross-source mapping strategies
- Example records for Bronze and Silver layers

Also updates docs/00-map.md with new Schema Documentation section.