### PR TITLE
Fix pytest config for asyncio marker and guard benchmark warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ markers = [
     "unit: Unit tests (fast, no I/O)",
     "integration: Integration tests (may use I/O)",
     "e2e: End-to-end tests (slow, requires Docker)",
+    "asyncio: Async IO tests powered by pytest-asyncio",
     "slow: Slow tests",
     "security: Security tests",
     "vcr: VCR.py recorded HTTP interactions",
@@ -129,7 +130,7 @@ filterwarnings = [
     # Pytest cleanup warnings (sockets/event loops not closed during teardown)
     "ignore::pytest.PytestUnraisableExceptionWarning",
     # pytest-benchmark warning when xdist is active (expected in parallel mode)
-    "ignore:Benchmarks are automatically disabled:pytest_benchmark.logger.PytestBenchmarkWarning",
+    "ignore:Benchmarks are automatically disabled",
 ]
 
 # ============ COVERAGE ============


### PR DESCRIPTION
## Summary
- register the pytest `asyncio` marker so strict-marker mode recognizes async tests
- relax the benchmark warning filter to avoid importing the optional pytest-benchmark plugin when missing

## Testing
- pytest --cov=src/bioetl --cov-report=term *(interrupted after most tests passed; command now runs without config errors)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69516571bc8c83249d459c204002b7cd)