### PR TITLE
Fix LoggerPort missing StructlogLogger adapter

### DIFF
--- a/src/bioetl/composition/_bootstrap/observability.py
+++ b/src/bioetl/composition/_bootstrap/observability.py
@@ -15,10 +15,10 @@ from __future__ import annotations
 
 import contextlib
 from typing import TYPE_CHECKING
-
-import structlog
+from uuid import UUID
 
 from bioetl.composition.observability import ObservabilityBundle
+from bioetl.domain.ports import LoggerPort, MetricsPort, TracingPort
 from bioetl.infrastructure.observability.logging import (
     create_logger as create_infra_logger,
 )
@@ -29,9 +29,7 @@ from bioetl.infrastructure.observability.server import start_metrics_server
 from bioetl.infrastructure.observability.tracing import OpenTelemetryTracer
 
 if TYPE_CHECKING:
-    from uuid import UUID
-
-    from bioetl.domain.ports import DQMonitorPort, MetricsPort, TracingPort
+    from bioetl.domain.ports import DQMonitorPort
     from bioetl.infrastructure.config import Settings
 
 __all__ = [
@@ -48,7 +46,7 @@ def validate_observability_preflight(
     tracer: TracingPort,
     metrics: MetricsPort,
     environment: str,
-    logger: structlog.stdlib.BoundLogger,
+    logger: LoggerPort,
 ) -> None:
     """Validate observability components for production readiness.
 
@@ -91,8 +89,12 @@ def validate_observability_preflight(
 
 def bootstrap_logger(
     pipeline: str, run_id: UUID, log_level: str = "INFO"
-) -> structlog.stdlib.BoundLogger:
-    """Create a logger for the application layer (e.g., CLI)."""
+) -> LoggerPort:
+    """Create a logger for the application layer (e.g., CLI).
+
+    Returns:
+        StructlogLogger implementing LoggerPort.
+    """
     return create_infra_logger(
         pipeline=pipeline, run_id=run_id, log_level=log_level, json_format=True
     )

--- a/src/bioetl/composition/observability.py
+++ b/src/bioetl/composition/observability.py
@@ -15,10 +15,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    import structlog.stdlib
+from bioetl.domain.ports import LoggerPort, MetricsPort, TracingPort
 
-    from bioetl.domain.ports import DQMonitorPort, MetricsPort, TracingPort
+if TYPE_CHECKING:
+    from bioetl.domain.ports import DQMonitorPort
 
 
 class ObservabilityContractError(Exception):
@@ -53,7 +53,7 @@ class ObservabilityBundle:
         dq_monitor: Optional data quality anomaly detector.
     """
 
-    logger: structlog.stdlib.BoundLogger
+    logger: LoggerPort
     metrics: MetricsPort
     tracer: TracingPort | None = None
     dq_monitor: DQMonitorPort | None = None
@@ -74,7 +74,7 @@ class ObservabilityBundle:
     @classmethod
     def create(
         cls,
-        logger: structlog.stdlib.BoundLogger,
+        logger: LoggerPort,
         metrics: MetricsPort,
         tracer: TracingPort | None = None,
         dq_monitor: DQMonitorPort | None = None,

--- a/src/bioetl/infrastructure/observability/__init__.py
+++ b/src/bioetl/infrastructure/observability/__init__.py
@@ -11,14 +11,18 @@ Implements RULES.md §3 (Observability).
 
 from __future__ import annotations
 
+from bioetl.infrastructure.observability.logging import StructlogLogger
+from bioetl.infrastructure.observability.noop_logger import NoOpLogger
 from bioetl.infrastructure.observability.noop_metrics import NoOpMetrics
 from bioetl.infrastructure.observability.noop_tracing import NoOpTracing
 from bioetl.infrastructure.observability.prometheus_metrics import PrometheusMetrics
 from bioetl.infrastructure.observability.tracing import OpenTelemetryTracer
 
 __all__ = [
+    "NoOpLogger",
     "NoOpMetrics",
     "NoOpTracing",
     "OpenTelemetryTracer",
     "PrometheusMetrics",
+    "StructlogLogger",
 ]

--- a/src/bioetl/infrastructure/observability/logging.py
+++ b/src/bioetl/infrastructure/observability/logging.py
@@ -19,10 +19,98 @@ from __future__ import annotations
 
 import logging
 import sys
-from typing import cast
+from typing import Any, Self
 from uuid import UUID
 
 import structlog
+
+from bioetl.domain.ports import LoggerPort
+
+
+class StructlogLogger:
+    """Formal LoggerPort adapter wrapping structlog.
+
+    This adapter provides a formal implementation of LoggerPort,
+    replacing duck typing with explicit interface implementation.
+
+    The class wraps structlog.stdlib.BoundLogger and ensures
+    type-safe integration with the domain layer.
+
+    Example:
+        >>> logger = StructlogLogger(structlog.get_logger())
+        >>> logger.info("event_name", key="value")
+        >>> bound = logger.bind(run_id="123")
+        >>> bound.warning("another_event")
+    """
+
+    __slots__ = ("_logger",)
+
+    def __init__(self, logger: structlog.stdlib.BoundLogger) -> None:
+        """Initialize with a structlog BoundLogger.
+
+        Args:
+            logger: The underlying structlog logger instance.
+        """
+        self._logger = logger
+
+    def bind(self, **kwargs: Any) -> Self:
+        """Bind additional context to the logger.
+
+        Returns a new StructlogLogger instance with the bound context.
+
+        Args:
+            **kwargs: Key-value pairs to bind to the logger context.
+
+        Returns:
+            New StructlogLogger with bound context.
+        """
+        bound = self._logger.bind(**kwargs)
+        return self.__class__(bound)
+
+    def info(self, _event: str, **kwargs: Any) -> Any:
+        """Log an informational message.
+
+        Args:
+            _event: The event name/message.
+            **kwargs: Additional context for the log entry.
+        """
+        return self._logger.info(_event, **kwargs)
+
+    def warning(self, _event: str, **kwargs: Any) -> Any:
+        """Log a warning message.
+
+        Args:
+            _event: The event name/message.
+            **kwargs: Additional context for the log entry.
+        """
+        return self._logger.warning(_event, **kwargs)
+
+    def error(self, _event: str, **kwargs: Any) -> Any:
+        """Log an error message.
+
+        Args:
+            _event: The event name/message.
+            **kwargs: Additional context for the log entry.
+        """
+        return self._logger.error(_event, **kwargs)
+
+    def debug(self, _event: str, **kwargs: Any) -> Any:
+        """Log a debug message.
+
+        Args:
+            _event: The event name/message.
+            **kwargs: Additional context for the log entry.
+        """
+        return self._logger.debug(_event, **kwargs)
+
+    def exception(self, _event: str, **kwargs: Any) -> Any:
+        """Log an exception with traceback.
+
+        Args:
+            _event: The event name/message.
+            **kwargs: Additional context for the log entry.
+        """
+        return self._logger.exception(_event, **kwargs)
 
 
 def create_logger(
@@ -30,7 +118,7 @@ def create_logger(
     run_id: UUID,
     log_level: str = "INFO",
     json_format: bool = True,
-) -> structlog.stdlib.BoundLogger:
+) -> LoggerPort:
     """Create a structured logger factory.
 
     Args:
@@ -40,7 +128,7 @@ def create_logger(
         json_format: Use JSON output format (default: True).
 
     Returns:
-        Configured structlog logger with bound context.
+        StructlogLogger implementing LoggerPort with bound context.
 
     """
     processors = [
@@ -75,4 +163,4 @@ def create_logger(
         format="%(message)s",
     )
 
-    return cast(structlog.stdlib.BoundLogger, bound_logger)
+    return StructlogLogger(bound_logger)

--- a/tests/unit/infrastructure/observability/test_logging.py
+++ b/tests/unit/infrastructure/observability/test_logging.py
@@ -6,7 +6,65 @@ from uuid import uuid4
 
 import pytest
 
-from bioetl.infrastructure.observability.logging import create_logger
+from bioetl.domain.ports import LoggerPort
+from bioetl.infrastructure.observability.logging import StructlogLogger, create_logger
+
+
+@pytest.mark.unit
+class TestStructlogLogger:
+    """Tests for StructlogLogger adapter."""
+
+    def test_structlog_logger_implements_logger_port(self) -> None:
+        """Test that StructlogLogger implements LoggerPort protocol."""
+        run_id = uuid4()
+        logger = create_logger(
+            pipeline="test_pipeline",
+            run_id=run_id,
+        )
+
+        # StructlogLogger must implement LoggerPort
+        assert isinstance(logger, LoggerPort)
+
+    def test_structlog_logger_is_structlog_logger_type(self) -> None:
+        """Test that create_logger returns StructlogLogger instance."""
+        run_id = uuid4()
+        logger = create_logger(
+            pipeline="test_pipeline",
+            run_id=run_id,
+        )
+
+        assert isinstance(logger, StructlogLogger)
+
+    def test_structlog_logger_bind_returns_self_type(self) -> None:
+        """Test that bind() returns StructlogLogger, not BoundLogger."""
+        run_id = uuid4()
+        logger = create_logger(
+            pipeline="test_pipeline",
+            run_id=run_id,
+        )
+
+        bound = logger.bind(extra_key="value")
+
+        # bind() must return StructlogLogger, not raw BoundLogger
+        assert isinstance(bound, StructlogLogger)
+        assert isinstance(bound, LoggerPort)
+
+    def test_structlog_logger_all_methods(self) -> None:
+        """Test that StructlogLogger has all LoggerPort methods."""
+        run_id = uuid4()
+        logger = create_logger(
+            pipeline="test_pipeline",
+            run_id=run_id,
+        )
+
+        # All these methods should exist and not raise
+        logger.info("info_event", key="value")
+        logger.warning("warning_event", key="value")
+        logger.error("error_event", key="value")
+        logger.debug("debug_event", key="value")
+
+        # exception requires exc_info in context, just check it exists
+        assert hasattr(logger, "exception")
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Replace duck typing with explicit LoggerPort implementation for structlog. The new StructlogLogger class wraps structlog.stdlib.BoundLogger and provides type-safe integration with the domain layer.

Changes:
- Add StructlogLogger class in infrastructure/observability/logging.py
- Update create_logger() to return StructlogLogger (implements LoggerPort)
- Export StructlogLogger and NoOpLogger from observability __init__.py
- Update ObservabilityBundle to use LoggerPort type annotation
- Update bootstrap_logger() to return LoggerPort
- Add unit tests verifying LoggerPort implementation