### PR TITLE
Create schema documentation for BioETL pipelines

### DIFF
--- a/docs/domain/schemas/chembl/activity-schema.md
+++ b/docs/domain/schemas/chembl/activity-schema.md
@@ -462,7 +462,7 @@ Gold layer contains only records passing gold_filters:
 
 | Version | Date | Changes |
 |---------|------|---------|
-| 1.0.0 | 2024-12-28 | Initial schema documentation |
+| 1.0.0 | 2025-12-28 | Initial schema documentation |
 
 ---
 


### PR DESCRIPTION
Corrected the version date from 2024-12-28 to 2025-12-28 in the ChEMBL Activity schema documentation changelog section.