### PR TITLE
Remove unnecessary type ignore comment

### DIFF
--- a/src/bioetl/application/core/memory_monitor.py
+++ b/src/bioetl/application/core/memory_monitor.py
@@ -90,7 +90,7 @@ class MemoryMonitor:
     def _check_psutil(self) -> bool:
         """Check if psutil is available for memory monitoring."""
         try:
-            import psutil  # noqa: F401  # type: ignore[import-untyped]
+            import psutil  # noqa: F401
 
             return True
         except ImportError:


### PR DESCRIPTION
psutil now has type stubs, making the import-untyped ignore unnecessary.