### PR TITLE
Fix pytest configuration for asyncio marker and benchmark warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ markers = [
     "security: Security tests",
     "vcr: VCR.py recorded HTTP interactions",
     "performance: Performance regression tests (optional CI stage)",
+    "asyncio: AsyncIO-based tests",
 ]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
@@ -129,7 +130,7 @@ filterwarnings = [
     # Pytest cleanup warnings (sockets/event loops not closed during teardown)
     "ignore::pytest.PytestUnraisableExceptionWarning",
     # pytest-benchmark warning when xdist is active (expected in parallel mode)
-    "ignore:Benchmarks are automatically disabled:pytest_benchmark.logger.PytestBenchmarkWarning",
+    "ignore:Benchmarks are automatically disabled::",
 ]
 
 # ============ COVERAGE ============


### PR DESCRIPTION
## Summary
- declare the asyncio marker so strict marker validation accepts asyncio tests
- relax the pytest-benchmark warning filter to avoid importing the plugin when absent

## Testing
- pytest --cov=src/bioetl --cov-report=term *(fails: missing dev dependencies such as pyarrow, pydantic, prometheus_client)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69516571bc8c83249d459c204002b7cd)