### PR TITLE
Add test extras to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,13 @@ tracing = [
 performance = [
     # orjson moved to main dependencies (required by batch_writer, bronze_writer, delta_writer)
 ]
+tests = [
+    "pytest>=8.0",
+    "pytest-cov>=4.0",
+    "pytest-asyncio>=0.23",
+    "pytest-xdist>=3.5",
+    "syrupy>=4.0",
+]
 dev = [
     "pytest>=8.0",
     "pytest-cov>=4.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -195,6 +195,13 @@ docs = [
     { name = "mkdocstrings", extra = ["python"] },
     { name = "pymdown-extensions" },
 ]
+tests = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-xdist" },
+    { name = "syrupy" },
+]
 tracing = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
@@ -256,12 +263,16 @@ requires-dist = [
     { name = "pylint", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.8" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest", marker = "extra == 'tests'", specifier = ">=8.0" },
     { name = "pytest-archon", marker = "extra == 'dev'", specifier = ">=0.0.6" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
+    { name = "pytest-asyncio", marker = "extra == 'tests'", specifier = ">=0.23" },
     { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
+    { name = "pytest-cov", marker = "extra == 'tests'", specifier = ">=4.0" },
     { name = "pytest-vcr", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5" },
+    { name = "pytest-xdist", marker = "extra == 'tests'", specifier = ">=3.5" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "radon", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21" },
@@ -269,12 +280,13 @@ requires-dist = [
     { name = "safety", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "structlog", specifier = ">=24.0" },
     { name = "syrupy", marker = "extra == 'dev'", specifier = ">=4.0" },
+    { name = "syrupy", marker = "extra == 'tests'", specifier = ">=4.0" },
     { name = "vcrpy", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.11" },
     { name = "xenon", marker = "extra == 'dev'", specifier = ">=0.9" },
     { name = "zstandard", specifier = ">=0.22" },
 ]
-provides-extras = ["tracing", "performance", "dev", "docs"]
+provides-extras = ["tracing", "performance", "tests", "dev", "docs"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- add a minimal `tests` extra with pytest and snapshot dependencies for local runs
- refresh uv.lock to capture the new extra metadata and dependency markers

## Testing
- pytest --cov=src/bioetl --cov-report=term -m "not e2e" -n auto


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69516c3f0b9483248c30db1ed7dfa2e6)