### PR TITLE
Fix failing commit lint and complexity checks

### DIFF
--- a/src/bioetl/composition/factories/pipeline_factory.py
+++ b/src/bioetl/composition/factories/pipeline_factory.py
@@ -209,7 +209,7 @@ class GenericPipelineFactory(Generic[TPipeline]):
             run_id=run_id,
             runtime=runtime,
             settings=settings,
-            logger=cast("LoggerPort", observability.logger),
+            logger=observability.logger,
             config=yaml_config,
             filter_config=filter_config,
             tracer=observability.tracer,
@@ -410,8 +410,7 @@ def assemble_runner(
         Fully initialized PipelineRunner
     """
     # Create Helper Components using ServicesBuilder
-    # Cast logger to LoggerPort - structlog.BoundLogger is runtime-compatible
-    logger_port = cast("LoggerPort", observability.logger)
+    logger_port = observability.logger
 
     checkpoint_manager = ServicesBuilder.create_checkpoint_manager(
         checkpoint_port=pipeline.services.checkpoint,

--- a/src/bioetl/composition/factories/storage_factory.py
+++ b/src/bioetl/composition/factories/storage_factory.py
@@ -58,86 +58,34 @@ class StorageFactory:
         return None
 
     @staticmethod
-    def create(
-        settings: Settings,
-        config: PipelineYamlConfig,
+    def _resolve_layer_path(
+        layer_config: Any, default_path: Path, use_yaml_paths: bool
+    ) -> Path:
+        """Resolve storage path from config or fall back to default."""
+        if use_yaml_paths and layer_config and layer_config.path:
+            return Path(layer_config.path)
+        return default_path
+
+    @staticmethod
+    def _create_storage_adapter(
+        bronze_path: Path,
+        silver_path: Path,
+        gold_path: Path,
+        bronze_config: Any,
+        silver_csv_exporter: CsvExporter | None,
+        gold_csv_exporter: CsvExporter | None,
         logger: LoggerPort,
         metrics: MetricsPort,
-        tracing: TracingPort | None = None,
-    ) -> StorageContext:
-        """Create a StorageAdapter for local deployment.
-
-        Args:
-            settings: Application settings with data_dir
-            config: Pipeline YAML configuration
-            logger: Structured logger
-            metrics: Metrics port for Bronze observability (MUST be injected).
-            tracing: Optional TracingPort for distributed tracing.
-
-        Returns:
-            StorageContext with adapter and paths
-        """
-        # Get layer configs from YAML
-        bronze_config = config.sink.get("bronze")
-        silver_config = config.sink.get("silver")
-        gold_config = config.sink.get("gold")
-
-        # Use YAML paths if specified, otherwise fall back to settings.
-        # In test mode (BIOETL_TEST_MODE=true), always use settings to respect
-        # test isolation with temp directories.
-        use_yaml_paths = not settings.test_mode
-
-        bronze_path = (
-            Path(bronze_config.path)
-            if use_yaml_paths and bronze_config and bronze_config.path
-            else settings.bronze_path
-        )
-        silver_path = (
-            Path(silver_config.path)
-            if use_yaml_paths and silver_config and silver_config.path
-            else settings.silver_path
-        )
-        gold_path = (
-            Path(gold_config.path)
-            if use_yaml_paths and gold_config and gold_config.path
-            else settings.gold_path
-        )
-        checkpoints_path = settings.checkpoint_path
-
+        tracing: TracingPort | None,
+        require_lock: bool,
+    ) -> StorageAdapter:
+        """Create StorageAdapter with all writers configured."""
+        save_json = bronze_config.save_json if bronze_config else False
         json_path = None
-        silver_csv_exporter: CsvExporter | None = None
-        gold_csv_exporter: CsvExporter | None = None
-
-        # Disable lock requirement in test mode (BIOETL_TEST_MODE=true)
-        require_lock = not settings.test_mode
-
-        logger.info(
-            "Using local storage",
-            bronze_path=str(bronze_path),
-            silver_path=str(silver_path),
-            gold_path=str(gold_path),
-            require_lock=require_lock,
-        )
-
         if bronze_config and bronze_config.save_json:
-            # JSON path is sibling to bronze path
             json_path = str(bronze_path.parent / "json")
 
-        if silver_config:
-            silver_csv_exporter = StorageFactory._create_csv_exporter_from_config(
-                silver_config.csv_export
-            )
-        if gold_config:
-            gold_csv_exporter = StorageFactory._create_csv_exporter_from_config(
-                gold_config.csv_export
-            )
-
-        StorageFactory._log_export_status(
-            logger, json_path, silver_csv_exporter, gold_csv_exporter
-        )
-        save_json = bronze_config.save_json if bronze_config else False
-
-        adapter = StorageAdapter(
+        return StorageAdapter(
             bronze_writer=BronzeWriter(
                 base_path=bronze_path,
                 logger=logger,
@@ -163,12 +111,87 @@ class StorageFactory:
             ),
         )
 
+    @staticmethod
+    def create(
+        settings: Settings,
+        config: PipelineYamlConfig,
+        logger: LoggerPort,
+        metrics: MetricsPort,
+        tracing: TracingPort | None = None,
+    ) -> StorageContext:
+        """Create a StorageAdapter for local deployment.
+
+        Args:
+            settings: Application settings with data_dir
+            config: Pipeline YAML configuration
+            logger: Structured logger
+            metrics: Metrics port for Bronze observability (MUST be injected).
+            tracing: Optional TracingPort for distributed tracing.
+
+        Returns:
+            StorageContext with adapter and paths
+        """
+        bronze_config = config.sink.get("bronze")
+        silver_config = config.sink.get("silver")
+        gold_config = config.sink.get("gold")
+
+        # In test mode, always use settings to respect test isolation
+        use_yaml_paths = not settings.test_mode
+
+        bronze_path = StorageFactory._resolve_layer_path(
+            bronze_config, settings.bronze_path, use_yaml_paths
+        )
+        silver_path = StorageFactory._resolve_layer_path(
+            silver_config, settings.silver_path, use_yaml_paths
+        )
+        gold_path = StorageFactory._resolve_layer_path(
+            gold_config, settings.gold_path, use_yaml_paths
+        )
+
+        require_lock = not settings.test_mode
+
+        logger.info(
+            "Using local storage",
+            bronze_path=str(bronze_path),
+            silver_path=str(silver_path),
+            gold_path=str(gold_path),
+            require_lock=require_lock,
+        )
+
+        silver_csv_exporter = StorageFactory._create_csv_exporter_from_config(
+            silver_config.csv_export if silver_config else None
+        )
+        gold_csv_exporter = StorageFactory._create_csv_exporter_from_config(
+            gold_config.csv_export if gold_config else None
+        )
+
+        json_path = None
+        if bronze_config and bronze_config.save_json:
+            json_path = str(bronze_path.parent / "json")
+
+        StorageFactory._log_export_status(
+            logger, json_path, silver_csv_exporter, gold_csv_exporter
+        )
+
+        adapter = StorageFactory._create_storage_adapter(
+            bronze_path=bronze_path,
+            silver_path=silver_path,
+            gold_path=gold_path,
+            bronze_config=bronze_config,
+            silver_csv_exporter=silver_csv_exporter,
+            gold_csv_exporter=gold_csv_exporter,
+            logger=logger,
+            metrics=metrics,
+            tracing=tracing,
+            require_lock=require_lock,
+        )
+
         return StorageContext(
             adapter=adapter,
             bronze_path=bronze_path,
             silver_path=silver_path,
             gold_path=gold_path,
-            checkpoints_path=checkpoints_path,
+            checkpoints_path=settings.checkpoint_path,
         )
 
     @staticmethod

--- a/src/bioetl/infrastructure/observability/logging.py
+++ b/src/bioetl/infrastructure/observability/logging.py
@@ -147,7 +147,7 @@ def create_logger(
         processors.append(structlog.dev.ConsoleRenderer())
 
     structlog.configure(
-        processors=processors,  # type: ignore[arg-type]
+        processors=processors,
         logger_factory=structlog.stdlib.LoggerFactory(),
         wrapper_class=structlog.stdlib.BoundLogger,
         cache_logger_on_first_use=True,

--- a/src/bioetl/infrastructure/storage/delta_writer.py
+++ b/src/bioetl/infrastructure/storage/delta_writer.py
@@ -241,6 +241,39 @@ class DeltaWriter:
                 f"Invalid Silver write mode '{mode}'. Allowed: {valid_modes}"
             ) from None
 
+    def _extract_owner_id_from_records(
+        self, records: list[dict[str, Any]], table_name: str
+    ) -> RunID | None:
+        """Extract owner_id from records for fencing token validation."""
+        if not records:
+            return None
+        run_id_str = records[0].get("_run_id")
+        if not run_id_str:
+            return None
+        from uuid import UUID
+
+        try:
+            return RunID(UUID(run_id_str))
+        except (ValueError, TypeError):
+            self.logger.warning(
+                "Could not parse _run_id for owner validation",
+                table=table_name,
+                run_id=run_id_str,
+            )
+            return None
+
+    def _deduplicate_by_primary_keys(
+        self, records: list[dict[str, Any]], primary_keys: list[str]
+    ) -> list[dict[str, Any]]:
+        """Deduplicate records based on primary keys to prevent duplicates in batch."""
+        if not primary_keys or not records:
+            return records
+        unique_records: dict[tuple[Any, ...], dict[str, Any]] = {}
+        for record in records:
+            key = tuple(record.get(pk) for pk in primary_keys)
+            unique_records[key] = record
+        return list(unique_records.values())
+
     def _validate_lock_held(
         self,
         table_name: str,
@@ -490,33 +523,11 @@ class DeltaWriter:
             span.set_attribute("mode", mode)
             span.set_attribute("record_count", len(records))
 
-            # Extract expected owner_id from records for fencing token validation
-            expected_owner_id: RunID | None = None
-            if records:
-                run_id_str = records[0].get("_run_id")
-                if run_id_str:
-                    from uuid import UUID
-                    try:
-                        expected_owner_id = RunID(UUID(run_id_str))
-                    except (ValueError, TypeError):
-                        # Invalid run_id format, skip owner validation
-                        self.logger.warning(
-                            "Could not parse _run_id for owner validation",
-                            table=table_name,
-                            run_id=run_id_str,
-                        )
-
-            # Validate lock is held before any write operation (RULES.md §3.3)
+            expected_owner_id = self._extract_owner_id_from_records(records, table_name)
             self._validate_lock_held(table_name, lock_context, expected_owner_id)
 
-            # Deduplicate records based on primary keys to prevent duplicates in batch
-            if primary_keys and records:
-                unique_records = {}
-                for record in records:
-                    key = tuple(record.get(pk) for pk in primary_keys)
-                    unique_records[key] = record
-                records = list(unique_records.values())
-                span.set_attribute("record_count", len(records))
+            records = self._deduplicate_by_primary_keys(records, primary_keys)
+            span.set_attribute("record_count", len(records))
 
             validated_mode = self._validate_write_mode(mode)
 


### PR DESCRIPTION
- Remove unused type: ignore comment in logging.py
- Remove redundant cast to LoggerPort in pipeline_factory.py
- Reduce cyclomatic complexity in storage_factory.py:create from CC=15 to CC=5 by extracting _resolve_layer_path and _create_storage_adapter helpers
- Reduce cyclomatic complexity in delta_writer.py:write_silver from CC=15 to CC=8 by extracting _extract_owner_id_from_records and _deduplicate_by_primary_keys helpers