### PR TITLE
Fix mypy strict mode error with Pandera

### DIFF
--- a/src/bioetl/domain/schemas/base.py
+++ b/src/bioetl/domain/schemas/base.py
@@ -11,7 +11,7 @@ import pandera as pa
 from pandera.typing import Series
 
 
-class ETLRecordSchema(pa.DataFrameModel):
+class ETLRecordSchema(pa.DataFrameModel):  # type: ignore[misc]
     """Base schema with common system and lineage fields."""
 
     # === System Fields ===


### PR DESCRIPTION
Pandera lacks complete type stubs, causing mypy --strict to fail when subclassing DataFrameModel (seen as Any). Added # type: ignore[misc] to suppress this known issue.