### PR TITLE
Update documentation to match test dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.1] - 2025-12-28
+
+### Fixed
+
+- **Test Dependencies**: Добавлены недостающие зависимости в `[project.optional-dependencies].tests`:
+  - `respx>=0.21` — HTTP-мокирование для тестов адаптеров
+  - `hypothesis>=6.100` — property-based тестирование для domain-тестов
+  - `vcrpy>=6.0` и `pytest-vcr>=1.0` — VCR-кассеты для integration-тестов
+  - Исправляет `ModuleNotFoundError` при запуске тестов с `pip install .[tests]`
+
+- **Mypy/Pandera Compatibility**: Добавлен `# type: ignore[misc]` для `DataFrameModel` subclass
+  - Pandera не имеет полных type stubs, вызывая ошибку mypy `--strict` при наследовании
+  - Затронутый файл: `src/bioetl/domain/schemas/base.py`
+
+### Changed
+
+- **Test Dependency Documentation**: Обновлены `docs/RULES.md` и `CLAUDE.md`:
+  - Добавлена секция о тестовых зависимостях и их установке
+  - Документированы все optional dependency группы (`tests`, `dev`, `tracing`, `docs`)
+
 ## [5.0.0] - 2025-12-27
 
 ### Removed (Documentation Audit)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -417,6 +417,27 @@ async def aclose() -> None                             # Graceful shutdown
 **Инструменты:** `pytest`, `pytest-asyncio`, `pytest-cov`, `hypothesis` (property-based)
 **Цель покрытия:** >85% line coverage (проверяется в CI через `--cov-fail-under=85`)
 
+### Тестовые Зависимости
+
+Проект использует optional dependency группы в `pyproject.toml`:
+
+```bash
+# Полный набор для разработки (рекомендуется)
+make install  # или: pip install -e ".[dev]"
+
+# Минимальный набор только для тестов (CI)
+pip install -e ".[tests]"
+```
+
+**Группа `tests` включает:**
+- `pytest`, `pytest-cov`, `pytest-asyncio`, `pytest-xdist` — основа тестирования
+- `respx` — HTTP-мокирование для тестов адаптеров
+- `hypothesis` — property-based тестирование
+- `vcrpy`, `pytest-vcr` — VCR-кассеты для integration-тестов
+- `syrupy` — snapshot-тестирование
+
+См. `docs/RULES.md` §4.2.1 для полного описания.
+
 ### Контрактные тесты портов
 
 Файл `tests/architecture/test_port_contracts.py` (51 тест) проверяет:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ See the root CHANGELOG.md for the complete version history.
 
 | Version | Date | Summary |
 |---------|------|---------|
+| 5.0.1 | 2025-12-28 | Test dependency fixes (respx, hypothesis, vcrpy), mypy/pandera compatibility |
 | 5.3.3 | 2025-12-26 | Architecture test fixes (base_metrics, events export) |
 | 5.3.2 | 2025-12-26 | NoOpTracer OTel compatibility, test infrastructure fixes |
 | 5.3.1 | 2025-12-24 | Atomic write encoding, DQ metrics, CLI safety fixes |

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -464,6 +464,35 @@ class LegacyAdapter(BaseSyncAdapter):
     - **Запуск**: `pytest tests/e2e/ -v -m e2e`.
 - **Contract Tests**: Ежемесячный запуск против *реальных* API (Live) в отдельном CI workflow для обнаружения нарушения контрактов.
 
+#### 4.2.1. Тестовые Зависимости и Установка
+
+Проект использует optional dependency группы в `pyproject.toml`:
+
+| Группа | Установка | Назначение |
+|--------|-----------|------------|
+| `tests` | `pip install .[tests]` | Минимальный набор для запуска тестов |
+| `dev` | `pip install .[dev]` | Полный набор для разработки (включает tests + linting + security) |
+| `tracing` | `pip install .[tracing]` | OpenTelemetry для production tracing |
+| `docs` | `pip install .[docs]` | MkDocs для генерации документации |
+
+**Группа `tests` включает:**
+- `pytest>=8.0`, `pytest-cov>=4.0`, `pytest-asyncio>=0.23`, `pytest-xdist>=3.5` — основа тестирования
+- `respx>=0.21` — HTTP-мокирование для тестов адаптеров
+- `hypothesis>=6.100` — property-based тестирование
+- `vcrpy>=6.0`, `pytest-vcr>=1.0` — VCR-кассеты для integration-тестов
+- `syrupy>=4.0` — snapshot-тестирование
+
+**Рекомендуемый способ установки:**
+```bash
+# Для разработки (полный набор)
+make install  # Эквивалент: pip install -e ".[dev]"
+
+# Только для запуска тестов (CI/lightweight)
+pip install -e ".[tests]"
+```
+
+**ВАЖНО**: При использовании `pip install .[tests]` убедитесь, что все тестовые зависимости доступны. Если тесты падают с `ModuleNotFoundError`, проверьте версию `pyproject.toml` и выполните `pip install -e ".[tests]"` заново.
+
 ### 4.3. Детерминизм и Воспроизводимость
 См. [ADR-014](02-architecture/decisions/ADR-014-deterministic-writes.md).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bioetl"
-version = "5.0.0"
+version = "5.0.1"
 description = "BioETL: Bioactivity data acquisition and processing pipeline"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
- Add CHANGELOG entry for v5.0.1 with test dependency and mypy fixes
- Add RULES.md §4.2.1 documenting test dependency groups and installation
- Add CLAUDE.md test dependencies section with quick reference
- Update version to 5.0.1 in pyproject.toml
- Update docs/CHANGELOG.md quick reference table

Documents recent fixes:
- respx, hypothesis, vcrpy added to tests optional dependency group
- mypy/pandera DataFrameModel type ignore fix