### PR TITLE
Strengthen exception typing in tests

### DIFF
--- a/tests/infrastructure/adapters/test_pubchem.py
+++ b/tests/infrastructure/adapters/test_pubchem.py
@@ -224,12 +224,12 @@ async def test_circuit_breaker(pubchem_adapter):
     # Set low threshold
     pubchem_adapter.circuit_breaker.failure_threshold = 1
 
-    with patch("pubchempy.get_compounds", side_effect=Exception("API Error")):
+    with patch("pubchempy.get_compounds", side_effect=RuntimeError("API Error")):
         # First call fails and increments failure count
         try:
             async for _ in pubchem_adapter.fetch("compound", query="fail"):
                 pass
-        except Exception:
+        except RuntimeError:
             pass
 
         # Second call should raise CircuitBreakerOpenError

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -371,7 +371,7 @@ def test_io_ports_are_async():
                         origin = get_origin(return_type)
                         if origin in (AsyncIterator, AsyncGenerator):
                             is_async = True
-                except Exception:
+                except (NameError, TypeError, AttributeError):
                     pass  # Type hints may not be resolvable in all cases
 
             if not is_async:

--- a/tests/unit/composition/test_observability_contract.py
+++ b/tests/unit/composition/test_observability_contract.py
@@ -10,6 +10,7 @@ Verifies that:
 
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -91,7 +92,7 @@ class TestObservabilityBundle:
 
         bundle = ObservabilityBundle(logger=mock_logger, metrics=mock_metrics)
 
-        with pytest.raises(Exception):  # FrozenInstanceError
+        with pytest.raises(FrozenInstanceError):
             bundle.metrics = MagicMock()  # type: ignore[misc]
 
 

--- a/tests/unit/infrastructure/test_config_settings.py
+++ b/tests/unit/infrastructure/test_config_settings.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from bioetl.domain.config import DQConfig as DomainDQConfig
 from bioetl.domain.config import PipelineConfig
@@ -55,10 +56,10 @@ class TestPipelineSettings:
         assert settings.batch_size == 10000
 
         # Invalid
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             PipelineSettings(batch_size=0)
 
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             PipelineSettings(batch_size=10001)
 
     def test_heartbeat_interval_validation(self) -> None:
@@ -71,10 +72,10 @@ class TestPipelineSettings:
         assert settings.heartbeat_interval == 60
 
         # Invalid
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             PipelineSettings(heartbeat_interval=4)
 
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             PipelineSettings(heartbeat_interval=61)
 
 


### PR DESCRIPTION
Replace overly broad `pytest.raises(Exception)` and `except Exception:` with specific exception types for better test precision:

- test_config_settings.py: use `ValidationError` for Pydantic validation
- test_observability_contract.py: use `FrozenInstanceError` for frozen dataclass
- test_architecture.py: use `(NameError, TypeError, AttributeError)` for type hints
- test_pubchem.py: use `RuntimeError` for circuit breaker test