### PR TITLE
Add pytest bootstrap helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ bioetl checkpoint list
 
 The project uses `pytest` for testing, split into Unit, Integration, and Architecture tests.
 
+* **Quick Check (with dependencies auto-synced and coverage):**
+  ```bash
+  ./scripts/run_pytest.sh
+  ```
+  The helper bootstraps the virtual environment (installs `pytest-cov`, `orjson`, `syrupy`, and other test-only dependencies) and reproduces the default CI command with coverage output.
+
 * **Run All Tests**:
   ```bash
   make test

--- a/scripts/run_pytest.sh
+++ b/scripts/run_pytest.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+if [ ! -d ".venv" ]; then
+    uv sync --extra dev --extra tracing
+fi
+
+PYTHONPATH="src:${PYTHONPATH:-}"
+export PYTHONPATH
+
+exec uv run pytest --cov=src/bioetl --cov-report=term -q --maxfail=1 "$@"


### PR DESCRIPTION
## Summary
- add a helper script to bootstrap the virtual environment and run pytest with coverage flags
- document the helper command in README to ensure test dependencies like orjson and syrupy are installed before execution

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695212fc25688324a1f33d2370bce407)