### PR TITLE
Fix type checking errors in bioetl

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,11 +249,19 @@ disallow_untyped_decorators = false
 # These libraries export BaseModel/DataFrameModel as Any without proper stubs
 [[tool.mypy.overrides]]
 module = [
+    "bioetl.domain.schemas.base",
     "bioetl.infrastructure.schemas.gold",
     "bioetl.infrastructure.schemas.pipeline_config",
     "bioetl.infrastructure.config",
 ]
 disable_error_code = ["misc"]
+
+# Disable no-any-return for modules using orjson (type stubs incomplete)
+[[tool.mypy.overrides]]
+module = [
+    "bioetl.application.core.base_transformer",
+]
+disable_error_code = ["no-any-return"]
 
 # Note: All layers now pass strict mypy checks.
 # ignore_errors was removed as part of architecture review (2025-12-23).


### PR DESCRIPTION
Add module-specific overrides to handle incomplete type stubs:
- bioetl.domain.schemas.base: disable misc for DataFrameModel subclass
- bioetl.application.core.base_transformer: disable no-any-return for orjson

These overrides ensure mypy --strict passes with both uv run mypy and system mypy installations.