### PR TITLE
Fix failing lint and type check tests

### DIFF
--- a/src/bioetl/application/core/base_transformer.py
+++ b/src/bioetl/application/core/base_transformer.py
@@ -320,7 +320,8 @@ class BaseTransformer(ABC):
         if isinstance(value, dict):
             if len(value) == 0:
                 return None
-            return orjson.dumps(value, option=orjson.OPT_SORT_KEYS).decode("utf-8")
+            json_bytes: bytes = orjson.dumps(value, option=orjson.OPT_SORT_KEYS)
+            return json_bytes.decode("utf-8")
         if isinstance(value, list):
             if len(value) == 0:
                 return None
@@ -328,11 +329,11 @@ class BaseTransformer(ABC):
             if len(value) == 1:
                 item = value[0]
                 if isinstance(item, dict):
-                    return orjson.dumps(item, option=orjson.OPT_SORT_KEYS).decode(
-                        "utf-8"
-                    )
+                    item_bytes: bytes = orjson.dumps(item, option=orjson.OPT_SORT_KEYS)
+                    return item_bytes.decode("utf-8")
                 return str(item)
-            return orjson.dumps(value, option=orjson.OPT_SORT_KEYS).decode("utf-8")
+            list_bytes: bytes = orjson.dumps(value, option=orjson.OPT_SORT_KEYS)
+            return list_bytes.decode("utf-8")
         return str(value)
 
     @staticmethod

--- a/src/bioetl/infrastructure/observability/tracing.py
+++ b/src/bioetl/infrastructure/observability/tracing.py
@@ -18,12 +18,16 @@ try:
         from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
             OTLPSpanExporter,
         )
+
+        OTLP_AVAILABLE = True
     except ImportError:
-        OTLPSpanExporter = None
+        OTLPSpanExporter = None  # type: ignore[misc,assignment,unused-ignore]
+        OTLP_AVAILABLE = False
 
     OTEL_AVAILABLE = True
 except ImportError:
     OTEL_AVAILABLE = False
+    OTLP_AVAILABLE = False
 
 
 class OpenTelemetryTracer:
@@ -47,7 +51,7 @@ class OpenTelemetryTracer:
         self._provider = TracerProvider()
 
         # Prefer OTLP if available (production), fall back to Console (dev/debug)
-        exporter = OTLPSpanExporter() if OTLPSpanExporter else ConsoleSpanExporter()
+        exporter = OTLPSpanExporter() if OTLP_AVAILABLE else ConsoleSpanExporter()
 
         processor = BatchSpanProcessor(exporter)
         self._provider.add_span_processor(processor)


### PR DESCRIPTION
- Add explicit bytes type annotations for orjson.dumps() return values to avoid no-any-return errors with different mypy environments
- Add OTLP_AVAILABLE flag to properly track OTLP exporter availability
- Use type: ignore with unused-ignore to handle different mypy versions