### PR TITLE
Clarify pytest setup and sync helper extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,16 @@ The project uses `pytest` for testing, split into Unit, Integration, and Archite
   ```
   The helper bootstraps the virtual environment (installs `pytest-cov`, `orjson`, `syrupy`, and other test-only dependencies) and reproduces the default CI command with coverage output.
 
+  If you prefer to run the command manually, activate the local virtual environment first to avoid `--cov` argument errors:
+  ```bash
+  source .venv/bin/activate
+  python -m pytest tests --cov=src/bioetl --cov-report=term
+  ```
+  With `uv`, the equivalent is:
+  ```bash
+  uv run python -m pytest tests --cov=src/bioetl --cov-report=term
+  ```
+
 * **Run All Tests**:
   ```bash
   make test

--- a/scripts/run_pytest.sh
+++ b/scripts/run_pytest.sh
@@ -5,7 +5,7 @@ PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$PROJECT_ROOT"
 
 if [ ! -d ".venv" ]; then
-    uv sync --extra dev --extra tracing
+    uv sync --extra dev --extra tests --extra tracing
 fi
 
 PYTHONPATH="src:${PYTHONPATH:-}"


### PR DESCRIPTION
## Summary
- ensure the run_pytest helper installs dev, tests, and tracing extras before running coverage
- document manual pytest invocation using the project virtual environment or uv to avoid missing pytest-cov

## Testing
- uv run python -m pytest tests/unit/test_cli.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695224af62b08324a36c43f980830e38)