### PR TITLE
Remove all deprecation warnings

### DIFF
--- a/src/bioetl/composition/factories/storage_factory.py
+++ b/src/bioetl/composition/factories/storage_factory.py
@@ -87,7 +87,9 @@ class StorageFactory:
             json_path = str(bronze_path.parent / "json")
 
         # Ensure tracing is always explicitly provided (DI pattern)
-        effective_tracing: TracingPort = tracing if tracing is not None else NoOpTracing()
+        effective_tracing: TracingPort = (
+            tracing if tracing is not None else NoOpTracing()
+        )
 
         return StorageAdapter(
             bronze_writer=BronzeWriter(

--- a/src/bioetl/domain/config.py
+++ b/src/bioetl/domain/config.py
@@ -13,7 +13,6 @@ Consolidated configuration classes (post-refactoring):
 
 from __future__ import annotations
 
-import warnings
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal
 
@@ -66,19 +65,10 @@ class DQConfig:
 
 
 def _convert_silver_write_mode(mode: SilverWriteMode | str) -> SilverWriteMode:
-    """Convert string to SilverWriteMode, handling deprecated values."""
+    """Convert string to SilverWriteMode."""
     if isinstance(mode, SilverWriteMode):
         return mode
-    mode_str = mode
-    if mode_str == "overwrite":
-        warnings.warn(
-            "silver_write_mode='overwrite' is deprecated. "
-            "Use SilverWriteMode.DELETE for rebuild operations.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        mode_str = "delete"
-    return SilverWriteMode.from_string(mode_str)
+    return SilverWriteMode.from_string(mode)
 
 
 def _convert_gold_write_mode(mode: GoldWriteMode | str) -> GoldWriteMode:

--- a/src/bioetl/domain/error_classifier.py
+++ b/src/bioetl/domain/error_classifier.py
@@ -2,12 +2,10 @@
 
 Pure domain logic - classifies exceptions into error categories.
 Primary classification uses the explicit error_type attribute on BioETLError subclasses.
-Falls back to keyword matching ONLY for non-domain exceptions with deprecation warning.
+Falls back to keyword matching for non-domain exceptions (tracked via fallback_usage_count).
 """
 
 from __future__ import annotations
-
-import warnings
 
 from bioetl.domain.exceptions import (
     BioETLError,
@@ -65,7 +63,7 @@ class ErrorClassifier:
 
     This is a pure domain class that uses the centralized exception hierarchy.
     Primary classification uses the explicit error_type attribute on BioETLError subclasses.
-    Falls back to keyword matching ONLY for non-domain exceptions with deprecation warning.
+    Falls back to keyword matching for non-domain exceptions (tracked for observability).
 
     Attributes:
         strict_mode: If True, raise ValueError for unknown non-domain exceptions.
@@ -126,7 +124,7 @@ class ErrorClassifier:
         return error.get_error_type()
 
     def _classify_external_error(self, error: Exception) -> ErrorType:
-        """Classify non-domain exceptions using keyword matching (with warning).
+        """Classify non-domain exceptions using keyword matching.
 
         Args:
             error: Non-BioETLError exception
@@ -141,21 +139,11 @@ class ErrorClassifier:
         error_name = type(error).__name__
         result = _match_error_type(error_name)
 
-        # Emit deprecation warning for observability
-        if result == ErrorType.INVALID_DATA:
-            msg = (
+        # In strict mode, raise for unknown exception types
+        if self._strict_mode and result == ErrorType.INVALID_DATA:
+            raise ValueError(
                 f"Unknown exception type: {error_name}. "
                 f"Consider wrapping in BioETLError subclass with explicit error_type."
-            )
-            if self._strict_mode:
-                raise ValueError(msg)
-            warnings.warn(msg, DeprecationWarning, stacklevel=3)
-        else:
-            warnings.warn(
-                f"Using keyword fallback for {error_name} -> {result.value}. "
-                f"Consider wrapping in BioETLError subclass.",
-                DeprecationWarning,
-                stacklevel=3,
             )
 
         return result

--- a/src/bioetl/domain/resilience.py
+++ b/src/bioetl/domain/resilience.py
@@ -25,7 +25,6 @@ class RetryPolicy:
         max_delay: Maximum delay in seconds (default: 60.0)
         multiplier: Delay multiplier per attempt (default: 2.0)
         jitter: Random jitter factor 0-1 (default: 0.1)
-        deterministic: Use hash-based jitter for reproducibility (default: True)
         jitter_seed: Seed for deterministic jitter (default: None)
 
     Example:
@@ -40,15 +39,14 @@ class RetryPolicy:
     max_delay: float = 60.0
     multiplier: float = 2.0
     jitter: float = 0.1
-    deterministic: bool = True
     jitter_seed: int | None = None
 
     def calculate_delay(self, attempt: int, url: str = "") -> float:
         """Calculate delay for given attempt number (0-indexed).
 
-        Uses exponential backoff with optional jitter.
-        When deterministic=True, jitter is calculated using MD5 hash
-        for cross-process reproducibility (ADR-014).
+        Uses exponential backoff with deterministic jitter.
+        Jitter is calculated using MD5 hash for cross-process
+        reproducibility (ADR-014).
 
         Args:
             attempt: Attempt number (0-indexed)
@@ -61,26 +59,13 @@ class RetryPolicy:
         delay = min(delay, self.max_delay)
 
         jitter_range = delay * self.jitter
-        if self.deterministic:
-            # MD5-based deterministic jitter for cross-process reproducibility (ADR-014)
-            # Note: hash() is not stable across Python processes due to PYTHONHASHSEED
-            hash_input = f"{attempt}:{url}:{self.jitter_seed or 0}"
-            digest = hashlib.md5(hash_input.encode(), usedforsecurity=False).hexdigest()
-            jitter_factor = int(digest[:8], 16) / 0xFFFFFFFF
-            # Map 0.0-1.0 to -1.0 to +1.0
-            delay += jitter_range * (jitter_factor * 2 - 1)
-        else:
-            # Non-deterministic jitter (deprecated, use deterministic=True)
-            import random
-            import warnings
-
-            warnings.warn(
-                "Non-deterministic jitter is deprecated per ADR-014. "
-                "Use deterministic=True for reproducibility.",
-                DeprecationWarning,
-                stacklevel=3,
-            )
-            delay += random.uniform(-jitter_range, jitter_range)
+        # MD5-based deterministic jitter for cross-process reproducibility (ADR-014)
+        # Note: hash() is not stable across Python processes due to PYTHONHASHSEED
+        hash_input = f"{attempt}:{url}:{self.jitter_seed or 0}"
+        digest = hashlib.md5(hash_input.encode(), usedforsecurity=False).hexdigest()
+        jitter_factor = int(digest[:8], 16) / 0xFFFFFFFF
+        # Map 0.0-1.0 to -1.0 to +1.0
+        delay += jitter_range * (jitter_factor * 2 - 1)
 
         return max(0.0, delay)
 

--- a/tests/architecture/test_write_mode_types.py
+++ b/tests/architecture/test_write_mode_types.py
@@ -185,25 +185,16 @@ def test_pipeline_config_converts_strings_to_enums() -> None:
     assert config.gold_write_mode == GoldWriteMode.SCD2
 
 
-def test_deprecated_overwrite_for_silver_warns() -> None:
-    """silver_write_mode='overwrite' SHOULD warn and convert to DELETE."""
-    import warnings
+def test_overwrite_for_silver_raises_error() -> None:
+    """silver_write_mode='overwrite' MUST raise ValueError.
 
+    The deprecated 'overwrite' alias for Silver layer has been removed.
+    Use SilverWriteMode.DELETE explicitly for rebuild operations.
+    """
     from bioetl.domain.config import TableConfig
-    from bioetl.domain.medallion import SilverWriteMode
 
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        config = TableConfig(silver_write_mode="overwrite")
-
-        # Should have deprecation warning
-        assert len(w) == 1
-        assert issubclass(w[0].category, DeprecationWarning)
-        assert "overwrite" in str(w[0].message)
-        assert "DELETE" in str(w[0].message)
-
-        # Should be converted to DELETE
-        assert config.silver_write_mode == SilverWriteMode.DELETE
+    with pytest.raises(ValueError, match="Invalid Silver write mode.*overwrite"):
+        TableConfig(silver_write_mode="overwrite")
 
 
 def test_no_silent_degradation_in_batch_writer() -> None:

--- a/tests/unit/application/core/test_preflight_service.py
+++ b/tests/unit/application/core/test_preflight_service.py
@@ -699,26 +699,21 @@ class TestValidateWriteModes:
     def test_silver_overwrite_mode_is_invalid(
         self, mock_context, mock_logger, mock_metrics
     ):
-        """Test that Silver 'overwrite' mode is invalid."""
-        config = PipelineConfig(
-            pipeline_name="test",
-            provider="chembl",
-            entity_type="activity",
-            primary_keys=["id"],
-            silver_table="silver",
-            write_mode="overwrite",
-            gold_write_mode="scd2",
-        )
-        service = PreflightService(
-            config=config,
-            context=mock_context,
-            logger=mock_logger,
-            metrics=mock_metrics,
-        )
-        errors = service.validate_write_modes()
-        silver_errors = [e for e in errors if e.field == "write_mode"]
-        assert len(silver_errors) == 1
-        assert "RULES §2.1" in silver_errors[0].rule
+        """Test that Silver 'overwrite' mode is invalid.
+
+        The 'overwrite' mode is not a valid SilverWriteMode.
+        PipelineConfig raises ValueError during construction.
+        """
+        with pytest.raises(ValueError, match="Invalid Silver write mode.*overwrite"):
+            PipelineConfig(
+                pipeline_name="test",
+                provider="chembl",
+                entity_type="activity",
+                primary_keys=["id"],
+                silver_table="silver",
+                write_mode="overwrite",
+                gold_write_mode="scd2",
+            )
 
     def test_gold_merge_mode_is_valid(self, mock_context, mock_logger, mock_metrics):
         """Test that Gold 'merge' mode is valid."""
@@ -818,14 +813,19 @@ class TestValidateWriteModes:
     def test_logs_warning_on_invalid_modes(
         self, mock_context, mock_logger, mock_metrics
     ):
-        """Test that invalid write modes are logged as warnings."""
+        """Test that invalid write modes are logged as warnings.
+
+        SilverWriteMode.DELETE is valid enum but not allowed by policy.
+        """
+        from bioetl.domain.medallion import SilverWriteMode
+
         config = PipelineConfig(
             pipeline_name="test",
             provider="chembl",
             entity_type="activity",
             primary_keys=["id"],
             silver_table="silver",
-            write_mode="overwrite",  # Invalid
+            write_mode=SilverWriteMode.DELETE,  # Valid enum, invalid for policy
             gold_write_mode="scd2",
         )
         service = PreflightService(
@@ -958,14 +958,19 @@ class TestValidatePreflight:
         mock_services,
         incremental_runtime,
     ):
-        """Test validate_preflight includes write mode validation errors."""
+        """Test validate_preflight includes write mode validation errors.
+
+        SilverWriteMode.DELETE is valid enum but not allowed by policy.
+        """
+        from bioetl.domain.medallion import SilverWriteMode
+
         config = PipelineConfig(
             pipeline_name="test",
             provider="chembl",
             entity_type="activity",
             primary_keys=["id"],
             silver_table="silver",
-            write_mode="overwrite",  # Invalid for Silver
+            write_mode=SilverWriteMode.DELETE,  # Valid enum, invalid for policy
             gold_write_mode="scd2",
         )
         service = PreflightService(

--- a/tests/unit/infrastructure/adapters/http/test_http_client.py
+++ b/tests/unit/infrastructure/adapters/http/test_http_client.py
@@ -56,19 +56,11 @@ class TestRetryConfig:
         delay = config.calculate_delay(5)  # Would be 320 without cap
         assert delay == 15.0
 
-    def test_calculate_delay_with_jitter(self):
-        """Test that jitter adds randomness."""
-        config = RetryConfig(base_delay=10.0, jitter=0.1, deterministic=False)
-        delays = [config.calculate_delay(0) for _ in range(10)]
-        # With 10% jitter, delays should vary between 9 and 11
-        assert not all(d == delays[0] for d in delays)  # Some variation expected
-
-    def test_deterministic_jitter_same_input_same_output(self):
-        """Test deterministic mode produces same delay for same inputs."""
+    def test_jitter_same_input_same_output(self):
+        """Test jitter produces same delay for same inputs (deterministic)."""
         config = RetryConfig(
             base_delay=10.0,
             jitter=0.1,
-            deterministic=True,
             jitter_seed=42,
         )
         url = "https://api.example.com/data"
@@ -85,12 +77,11 @@ class TestRetryConfig:
         delay_a1_again = config.calculate_delay(attempt=1, url=url)
         assert delay_a1 == delay_a1_again
 
-    def test_deterministic_jitter_different_urls_different_output(self):
-        """Test deterministic mode produces different delays for different URLs."""
+    def test_jitter_different_urls_different_output(self):
+        """Test jitter produces different delays for different URLs."""
         config = RetryConfig(
             base_delay=10.0,
             jitter=0.1,
-            deterministic=True,
             jitter_seed=42,
         )
 
@@ -104,28 +95,7 @@ class TestRetryConfig:
         assert 9.0 <= delay1 <= 11.0
         assert 9.0 <= delay2 <= 11.0
 
-    def test_non_deterministic_mode_uses_random(self):
-        """Test non-deterministic mode produces varying delays."""
-        config = RetryConfig(
-            base_delay=10.0,
-            jitter=0.1,
-            deterministic=False,  # Explicit non-deterministic
-        )
-        url = "https://api.example.com/data"
-
-        # Collect multiple delay values
-        delays = [config.calculate_delay(attempt=0, url=url) for _ in range(20)]
-
-        # With random jitter, not all delays should be identical
-        # (extremely unlikely for 20 random values to be the same)
-        unique_delays = set(delays)
-        assert len(unique_delays) > 1, "Random jitter should produce varying delays"
-
-        # All delays should still be within jitter range
-        for delay in delays:
-            assert 9.0 <= delay <= 11.0
-
-    def test_deterministic_jitter_cross_process_stability(self):
+    def test_jitter_cross_process_stability(self):
         """Test deterministic jitter produces stable values across processes.
 
         This test verifies that the jitter calculation uses MD5 (not Python's
@@ -141,7 +111,6 @@ class TestRetryConfig:
         config = RetryConfig(
             base_delay=10.0,
             jitter=0.1,
-            deterministic=True,
             jitter_seed=42,
         )
         url = "https://api.example.com/test"
@@ -166,8 +135,8 @@ class TestRetryConfig:
         assert config.calculate_delay(attempt=0, url=url) == expected_delay
         assert config.calculate_delay(attempt=0, url=url) == expected_delay
 
-    def test_deterministic_jitter_known_values(self):
-        """Test deterministic jitter produces known stable values.
+    def test_jitter_known_values(self):
+        """Test jitter produces known stable values.
 
         These values are pre-computed and serve as a regression test.
         If this test fails, it means the jitter algorithm has changed.
@@ -175,7 +144,6 @@ class TestRetryConfig:
         config = RetryConfig(
             base_delay=1.0,
             jitter=0.5,
-            deterministic=True,
             jitter_seed=123,
         )
 

--- a/tests/unit/infrastructure/test_storage_factory.py
+++ b/tests/unit/infrastructure/test_storage_factory.py
@@ -428,7 +428,9 @@ class TestStorageAdapterHealthCheck:
                 return False
             return original_check(path)
 
-        with patch.object(StorageAdapter, "_check_directory_writable", side_effect=mock_check):
+        with patch.object(
+            StorageAdapter, "_check_directory_writable", side_effect=mock_check
+        ):
             result = await adapter.health_check()
 
         # DEGRADED because gold layer is not writable but bronze/silver are


### PR DESCRIPTION
- Remove deprecated 'overwrite' alias for SilverWriteMode in config.py Use SilverWriteMode.DELETE explicitly for rebuild operations

- Remove non-deterministic jitter option from RetryPolicy in resilience.py All jitter is now deterministic using MD5 hash (ADR-014)

- Replace DeprecationWarning with silent fallback in error_classifier.py Fallback usage is still tracked via fallback_usage_count for observability

- Update tests to reflect removed deprecated features:
  - test_write_mode_types.py: test ValueError for 'overwrite' Silver mode
  - test_preflight_service.py: use SilverWriteMode.DELETE for policy tests
  - test_http_client.py: remove tests for deterministic=False