### PR TITLE
Fix Mermaid diagram validation timeout

### DIFF
--- a/docs/architecture/diagrams/14-provider-health-states.mermaid
+++ b/docs/architecture/diagrams/14-provider-health-states.mermaid
@@ -84,7 +84,7 @@ stateDiagram-v2
         • Requires successful health_check
     end note
 
-    ---
+    %% Provider-specific configurations section
 
     state ProviderSpecificBehavior {
         state "ChEMBL" as ChEMBL {

--- a/docs/architecture/diagrams/20-quarantine-record-states.mermaid
+++ b/docs/architecture/diagrams/20-quarantine-record-states.mermaid
@@ -93,7 +93,7 @@ stateDiagram-v2
         5. Mark as REPROCESSED
     end note
 
-    ---
+    %% Error codes section
 
     state ErrorCodes {
         state "Common Error Types" as CET {
@@ -106,7 +106,7 @@ stateDiagram-v2
         }
     }
 
-    ---
+    %% Statistics and metrics section
 
     state QuarantineStats {
         state "Metrics Tracked" as MT {


### PR DESCRIPTION
The --- syntax is not valid in Mermaid stateDiagram-v2 and was causing the validate-mermaid CI check to fail. Replaced with %% comments.