### PR TITLE
Normalize lock parameters TTL and heartbeat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,8 +369,8 @@ sha256(provider + canonical_json(record))
 |----------|----------|
 | Механизм | In-memory (MemoryLock) |
 | Область | Локальный процесс |
-| TTL по умолчанию | `heartbeat_interval * 3` = 90s |
-| Heartbeat | 30s (настраивается в `RuntimeConfig`) |
+| TTL по умолчанию | 60s (настраивается в `RuntimeConfig`) |
+| Heartbeat | 20s (настраивается в `RuntimeConfig`) |
 
 ### 5.1. ⚠️ MemoryLock Достаточен для Локального Запуска
 

--- a/src/bioetl/domain/config.py
+++ b/src/bioetl/domain/config.py
@@ -235,10 +235,10 @@ class RuntimeConfig:
     run_type: RunType
     resume: bool = False
     limit: int | None = None
-    heartbeat_interval: int = 30
+    heartbeat_interval: int = 20
     wait_for_lock: bool = False
     lock_wait_timeout: int = 300
-    lock_ttl: int | None = None
+    lock_ttl: int | None = 60
     query: str | None = None
     dry_run: bool = False
 

--- a/tests/unit/application/test_pipeline_config.py
+++ b/tests/unit/application/test_pipeline_config.py
@@ -213,3 +213,66 @@ class TestRuntimeConfig:
             strict_gold_validation=True,
         )
         assert runtime.strict_gold_validation is True
+
+    def test_lock_defaults(self):
+        """Test that lock parameters have correct defaults (20s/60s).
+
+        REQ-LOCK-001: heartbeat_interval=20s, lock_ttl=60s to reduce
+        split-brain window compared to previous 30s/90s defaults.
+        """
+        runtime = RuntimeConfig(run_type=RunType.INCREMENTAL)
+
+        assert runtime.heartbeat_interval == 20
+        assert runtime.lock_ttl == 60
+
+    def test_effective_lock_ttl_with_explicit_value(self):
+        """Test effective_lock_ttl returns explicit lock_ttl when set."""
+        runtime = RuntimeConfig(
+            run_type=RunType.INCREMENTAL,
+            lock_ttl=120,
+        )
+
+        assert runtime.effective_lock_ttl == 120
+
+    def test_effective_lock_ttl_with_none(self):
+        """Test effective_lock_ttl calculates from heartbeat when lock_ttl is None."""
+        runtime = RuntimeConfig(
+            run_type=RunType.INCREMENTAL,
+            heartbeat_interval=15,
+            lock_ttl=None,
+        )
+
+        # Should be heartbeat_interval * 3
+        assert runtime.effective_lock_ttl == 45
+
+    def test_effective_lock_ttl_default(self):
+        """Test effective_lock_ttl with default values returns 60s."""
+        runtime = RuntimeConfig(run_type=RunType.INCREMENTAL)
+
+        # With default lock_ttl=60, effective_lock_ttl should be 60
+        assert runtime.effective_lock_ttl == 60
+
+    def test_lock_ttl_ratio(self):
+        """Test that default TTL is 3x heartbeat interval.
+
+        This ratio ensures at least 2 heartbeats before TTL expiration,
+        providing safety margin for heartbeat failures.
+        """
+        runtime = RuntimeConfig(run_type=RunType.INCREMENTAL)
+
+        # Default: heartbeat=20, ttl=60 → ratio = 3
+        assert runtime.lock_ttl / runtime.heartbeat_interval == 3
+
+    def test_invalid_heartbeat_interval_raises(self):
+        """Test that non-positive heartbeat_interval raises ValueError."""
+        with pytest.raises(ValueError, match="heartbeat_interval must be positive"):
+            RuntimeConfig(
+                run_type=RunType.INCREMENTAL,
+                heartbeat_interval=0,
+            )
+
+        with pytest.raises(ValueError, match="heartbeat_interval must be positive"):
+            RuntimeConfig(
+                run_type=RunType.INCREMENTAL,
+                heartbeat_interval=-1,
+            )


### PR DESCRIPTION
Update RuntimeConfig defaults to reduce split-brain window:
- heartbeat_interval: 30s -> 20s
- lock_ttl: None (90s computed) -> 60s (explicit)

This change ensures 3x ratio between TTL and heartbeat, providing at least 2 heartbeat opportunities before lock expiration.

Changes:
- domain/config.py: Update RuntimeConfig defaults
- CLAUDE.md: Update documentation to reflect new values
- Add comprehensive tests for lock parameter defaults