### PR TITLE
Enforce pytest plugin requirements and clarify test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,10 +161,13 @@ The project uses `pytest` for testing, split into Unit, Integration, and Archite
   If you prefer to run the command manually, activate the local virtual environment first to avoid `--cov` argument errors:
   ```bash
   source .venv/bin/activate
+  # Install test extras so pytest-asyncio/pytest-cov options are available
+  pip install -e ".[dev,tests]"
   python -m pytest tests --cov=src/bioetl --cov-report=term
   ```
   With `uv`, the equivalent is:
   ```bash
+  uv sync --extra dev --extra tests
   uv run python -m pytest tests --cov=src/bioetl --cov-report=term
   ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,10 @@ addopts = [
     "--strict-markers",
     "--strict-config",
 ]
+required_plugins = [
+    "pytest-asyncio>=0.23",
+    "pytest-cov>=4.0",
+]
 markers = [
     "unit: Unit tests (fast, no I/O)",
     "integration: Integration tests (may use I/O)",


### PR DESCRIPTION
## Summary
- require pytest-asyncio and pytest-cov plugins via pytest configuration to prevent missing option errors
- document installing dev/tests extras before running pytest manually to ensure coverage flags are available

## Testing
- pytest --collect-only -q --disable-warnings --maxfail=1


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69528629a1a883248a9c46ca9536b189)