### PR TITLE
Add automatic pytest plugin sync for local runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ The project uses `pytest` for testing, split into Unit, Integration, and Archite
   uv sync --extra dev --extra tests
   uv run python -m pytest tests --cov=src/bioetl --cov-report=term
   ```
+  Если `pytest` сообщает об отсутствии обязательных плагинов (`pytest-asyncio`, `pytest-cov`), выполните повторную синхронизацию:
+  ```bash
+  uv sync --extra dev --extra tests --extra tracing
+  ```
+  Скрипт `./scripts/run_pytest.sh` проверяет наличие плагинов и автоматически доустанавливает их при необходимости.
 
 * **Run All Tests**:
   ```bash

--- a/scripts/run_pytest.sh
+++ b/scripts/run_pytest.sh
@@ -6,6 +6,21 @@ cd "$PROJECT_ROOT"
 
 if [ ! -d ".venv" ]; then
     uv sync --extra dev --extra tests --extra tracing
+else
+    REQUIRED_MODULES=(pytest_asyncio pytest_cov)
+
+    if ! uv run python - "${REQUIRED_MODULES[@]}" <<'PY'; then
+        import importlib.util
+        import sys
+
+        missing = [name for name in sys.argv[1:] if importlib.util.find_spec(name) is None]
+        if missing:
+            print("Missing pytest plugins:", ", ".join(missing))
+            raise SystemExit(1)
+PY
+        echo "Detected missing pytest plugins. Syncing dev/test extras..."
+        uv sync --extra dev --extra tests --extra tracing
+    fi
 fi
 
 PYTHONPATH="src:${PYTHONPATH:-}"


### PR DESCRIPTION
## Summary
- update run_pytest.sh to detect missing pytest plugins and resync dev/test extras automatically
- add README guidance on resolving missing pytest-asyncio/pytest-cov errors

## Testing
- make lint
- pytest -q --maxfail=1
- bash -n scripts/run_pytest.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952885d1418832488ce6d332df93297)