### PR TITLE
Fix Mermaid diagram validation in docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,10 +5,12 @@ on:
     branches: [ "main" ]
     paths:
       - 'docs/**'
+      - '.github/workflows/docs.yml'
   pull_request:
     branches: [ "main" ]
     paths:
       - 'docs/**'
+      - '.github/workflows/docs.yml'
 
 jobs:
   validate-mermaid:
@@ -22,16 +24,40 @@ jobs:
         with:
           node-version: '18'
 
+      - name: Install system dependencies for Puppeteer
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y chromium-browser
+
       - name: Install Mermaid CLI
         run: npm install -g @mermaid-js/mermaid-cli
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
+
+      - name: Create Puppeteer config
+        run: |
+          cat > /tmp/puppeteer-config.json << 'EOF'
+          {
+            "executablePath": "/usr/bin/chromium-browser",
+            "args": ["--no-sandbox", "--disable-setuid-sandbox"]
+          }
+          EOF
 
       - name: Validate Mermaid diagrams
         run: |
           shopt -s globstar nullglob
+          failed=0
           for file in docs/**/*.mermaid; do
             echo "Validating $file..."
-            mmdc -i "$file" -o /dev/null || exit 1
+            if ! mmdc -i "$file" -o /dev/null -p /tmp/puppeteer-config.json 2>&1; then
+              echo "::error file=$file::Mermaid validation failed for $file"
+              failed=1
+            fi
           done
+          if [ $failed -eq 1 ]; then
+            echo "::error::One or more Mermaid diagrams failed validation"
+            exit 1
+          fi
           echo "All Mermaid diagrams validated successfully"
 
   render-diagrams:
@@ -46,8 +72,24 @@ jobs:
         with:
           node-version: '18'
 
+      - name: Install system dependencies for Puppeteer
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y chromium-browser
+
       - name: Install Mermaid CLI
         run: npm install -g @mermaid-js/mermaid-cli
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
+
+      - name: Create Puppeteer config
+        run: |
+          cat > /tmp/puppeteer-config.json << 'EOF'
+          {
+            "executablePath": "/usr/bin/chromium-browser",
+            "args": ["--no-sandbox", "--disable-setuid-sandbox"]
+          }
+          EOF
 
       - name: Render Mermaid diagrams to SVG
         run: |
@@ -56,7 +98,7 @@ jobs:
           for dir in docs/02-architecture/diagrams docs/architecture/diagrams; do
             if [ -d "$dir" ]; then
               for file in "$dir"/*.mermaid; do
-                [ -f "$file" ] && mmdc -i "$file" -o "rendered-diagrams/$(basename "$file" .mermaid).svg"
+                [ -f "$file" ] && mmdc -i "$file" -o "rendered-diagrams/$(basename "$file" .mermaid).svg" -p /tmp/puppeteer-config.json
               done
             fi
           done


### PR DESCRIPTION
- Install system Chromium instead of downloading via Puppeteer
- Configure Puppeteer to use system Chrome with no-sandbox flags
- Add better error reporting with file-level error annotations
- Include workflow file in path triggers for easier CI updates
- Continue validating all files and report all failures at once

The original workflow was failing due to Puppeteer/Chrome download issues in the CI environment. This fix uses the system-installed Chromium browser, which is more reliable in GitHub Actions.