### PR TITLE
Unify logging across infrastructure files

### DIFF
--- a/src/bioetl/composition/_bootstrap/observability.py
+++ b/src/bioetl/composition/_bootstrap/observability.py
@@ -176,7 +176,9 @@ def bootstrap_metrics(settings: Settings) -> MetricsPort:
     return metrics
 
 
-def bootstrap_dq_monitor(settings: Settings) -> DQMonitorPort | None:
+def bootstrap_dq_monitor(
+    settings: Settings, logger: LoggerPort | None = None
+) -> DQMonitorPort | None:
     """Bootstrap data quality monitor for anomaly detection.
 
     Creates a DataQualityMonitor configured with settings from ObservabilitySettings.
@@ -184,6 +186,7 @@ def bootstrap_dq_monitor(settings: Settings) -> DQMonitorPort | None:
 
     Args:
         settings: Application settings.
+        logger: Optional logger for DQ monitor. If None, uses NoOpLogger.
 
     Returns:
         Configured DQMonitorPort or None if disabled.
@@ -194,8 +197,12 @@ def bootstrap_dq_monitor(settings: Settings) -> DQMonitorPort | None:
         return None
 
     from bioetl.infrastructure.observability.anomaly import DataQualityMonitor
+    from bioetl.infrastructure.observability.noop_logger import NoOpLogger
+
+    effective_logger = logger if logger is not None else NoOpLogger()
 
     monitor = DataQualityMonitor(
+        logger=effective_logger,
         baseline_window=obs_settings.dq_baseline_window,
         z_score_threshold=obs_settings.dq_z_score_threshold,
     )
@@ -248,7 +255,7 @@ def bootstrap_observability(
     logger = bootstrap_logger(pipeline=pipeline, run_id=run_id)
     tracer = bootstrap_tracer(settings)
     metrics = bootstrap_metrics(settings)
-    dq_monitor = bootstrap_dq_monitor(settings)
+    dq_monitor = bootstrap_dq_monitor(settings, logger)
 
     bundle = ObservabilityBundle(
         logger=logger,

--- a/src/bioetl/composition/factories/storage_factory.py
+++ b/src/bioetl/composition/factories/storage_factory.py
@@ -47,11 +47,14 @@ class StorageFactory:
     """Factory for creating configured StorageAdapters for local deployment."""
 
     @staticmethod
-    def _create_csv_exporter_from_config(csv_cfg: Any) -> CsvExporter | None:
+    def _create_csv_exporter_from_config(
+        csv_cfg: Any, logger: LoggerPort
+    ) -> CsvExporter | None:
         """Create a CsvExporter from configuration if enabled."""
         if csv_cfg and csv_cfg.enabled:
             return CsvExporter(
                 base_path=csv_cfg.path,
+                logger=logger,
                 delimiter=csv_cfg.delimiter,
                 header=csv_cfg.header,
                 encoding=csv_cfg.encoding,
@@ -165,10 +168,10 @@ class StorageFactory:
         )
 
         silver_csv_exporter = StorageFactory._create_csv_exporter_from_config(
-            silver_config.csv_export if silver_config else None
+            silver_config.csv_export if silver_config else None, logger
         )
         gold_csv_exporter = StorageFactory._create_csv_exporter_from_config(
-            gold_config.csv_export if gold_config else None
+            gold_config.csv_export if gold_config else None, logger
         )
 
         json_path = None

--- a/src/bioetl/infrastructure/export/csv_exporter.py
+++ b/src/bioetl/infrastructure/export/csv_exporter.py
@@ -14,15 +14,16 @@ from __future__ import annotations
 
 import asyncio
 import json
-import logging
 import os
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pyarrow as pa
 import pyarrow.csv as pv
 
-logger = logging.getLogger(__name__)
+if TYPE_CHECKING:
+    from bioetl.domain.ports import LoggerPort
 
 
 class CsvExporter:
@@ -35,6 +36,7 @@ class CsvExporter:
     def __init__(
         self,
         base_path: str,
+        logger: LoggerPort,
         delimiter: str = ",",
         header: bool = True,
         encoding: str = "utf-8",
@@ -45,6 +47,7 @@ class CsvExporter:
 
         Args:
             base_path: Base directory for CSV files
+            logger: Structured logger for observability (MUST be injected)
             delimiter: Field delimiter (default: ",")
             header: Include header row (default: True)
             encoding: File encoding (default: "utf-8")
@@ -53,6 +56,7 @@ class CsvExporter:
 
         """
         self.base_path = Path(base_path)
+        self._logger = logger
         self.delimiter = delimiter
         self.header = header
         self.encoding = encoding
@@ -81,9 +85,10 @@ class CsvExporter:
                 csv_file.unlink()
                 deleted.append(csv_file)
             except PermissionError:
-                logger.warning(
-                    "Cannot delete locked CSV file: %s (file may be open in another program)",
-                    csv_file,
+                self._logger.warning(
+                    "Cannot delete locked CSV file",
+                    path=str(csv_file),
+                    reason="file may be open in another program",
                 )
 
         return deleted
@@ -171,8 +176,9 @@ class CsvExporter:
         # Verify all primary keys exist in table
         missing_keys = [key for key in primary_keys if key not in table.column_names]
         if missing_keys:
-            logger.warning(
-                "Cannot deduplicate CSV: missing primary keys %s", missing_keys
+            self._logger.warning(
+                "Cannot deduplicate CSV: missing primary keys",
+                missing_keys=missing_keys,
             )
             return table
 
@@ -185,23 +191,23 @@ class CsvExporter:
             dedup_count = len(df)
 
             if dedup_count < original_count:
-                logger.debug(
-                    "Deduplicated CSV data: removed %d rows",
-                    original_count - dedup_count,
+                self._logger.debug(
+                    "Deduplicated CSV data",
+                    removed_rows=original_count - dedup_count,
                 )
 
             # Convert back to PyArrow table
             # Use original schema to preserve types
             return pa.Table.from_pandas(df, schema=table.schema)
         except ImportError:
-            logger.warning("Pandas not available for CSV deduplication")
+            self._logger.warning("Pandas not available for CSV deduplication")
             return table
         except Exception as e:
-            logger.warning("CSV deduplication failed: %s", e)
+            self._logger.warning("CSV deduplication failed", error=str(e))
             return table
 
-    @staticmethod
     def _atomic_csv_write(
+        self,
         data: pa.Table,
         target_path: Path,
         write_options: pv.WriteOptions,
@@ -231,7 +237,9 @@ class CsvExporter:
                 timestamp = int(time.time())
                 backup_path = target_path.with_suffix(f".{timestamp}.csv")
                 temp_path.replace(backup_path)
-                logger.warning("Target CSV locked, wrote to backup: %s", backup_path)
+                self._logger.warning(
+                    "Target CSV locked, wrote to backup", backup_path=str(backup_path)
+                )
                 return
         except Exception:
             if temp_path.exists():

--- a/src/bioetl/infrastructure/observability/anomaly/monitor.py
+++ b/src/bioetl/infrastructure/observability/anomaly/monitor.py
@@ -5,7 +5,6 @@ Combines multiple detectors to monitor data quality metrics.
 
 from __future__ import annotations
 
-import logging
 from datetime import datetime
 from typing import TYPE_CHECKING
 
@@ -15,7 +14,7 @@ from bioetl.infrastructure.observability.anomaly.types import Anomaly, AnomalySe
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-logger = logging.getLogger(__name__)
+    from bioetl.domain.ports import LoggerPort
 
 
 class DataQualityMonitor:
@@ -28,7 +27,7 @@ class DataQualityMonitor:
     - Validation failure rates
 
     Usage:
-        monitor = DataQualityMonitor()
+        monitor = DataQualityMonitor(logger=my_logger)
         monitor.add_metric("record_count", baseline=[1000, 1050, 980])
 
         issues = monitor.check_quality({
@@ -36,15 +35,24 @@ class DataQualityMonitor:
             "error_rate": 0.15,
         })
         for issue in issues:
-            logger.warning(issue)
+            print(issue)
     """
 
     def __init__(
         self,
+        logger: LoggerPort,
         baseline_window: int = 7,
         z_score_threshold: float = 2.5,
     ) -> None:
-        """Initialize data quality monitor."""
+        """Initialize data quality monitor.
+
+        Args:
+            logger: Structured logger for observability (MUST be injected)
+            baseline_window: Number of days to consider for baseline (default: 7)
+            z_score_threshold: Z-score threshold for anomaly detection (default: 2.5)
+
+        """
+        self._logger = logger
         self.detector = AnomalyDetector(
             baseline_window=baseline_window,
             z_score_threshold=z_score_threshold,
@@ -97,8 +105,9 @@ class DataQualityMonitor:
         ]
 
         if critical_anomalies:
-            logger.warning(
-                f"Skipping baseline update due to {len(critical_anomalies)} critical anomalies"
+            self._logger.warning(
+                "Skipping baseline update due to critical anomalies",
+                critical_anomaly_count=len(critical_anomalies),
             )
             return
 

--- a/src/bioetl/infrastructure/observability/lineage.py
+++ b/src/bioetl/infrastructure/observability/lineage.py
@@ -34,7 +34,6 @@ Usage:
 
 from __future__ import annotations
 
-import logging
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, cast
@@ -46,7 +45,7 @@ from deltalake import DeltaTable, write_deltalake
 if TYPE_CHECKING:
     from pathlib import Path
 
-logger = logging.getLogger(__name__)
+    from bioetl.domain.ports import LoggerPort
 
 
 @dataclass(frozen=True)
@@ -146,18 +145,21 @@ class LineageTracker:
         self,
         delta_path: str | Path,
         pipeline_name: str,
+        logger: LoggerPort,
     ) -> None:
         """Initialize lineage tracker.
 
         Args:
             delta_path: Base path for lineage Delta tables
             pipeline_name: Pipeline identifier
+            logger: Structured logger for observability (MUST be injected)
 
         """
         from pathlib import Path
 
         self.delta_path = Path(delta_path)
         self.pipeline_name = pipeline_name
+        self._logger = logger
 
         # Table paths
         self.batch_table_path = self.delta_path / "batch_lineage"
@@ -269,9 +271,9 @@ class LineageTracker:
                 mode="append",
                 schema_mode="merge",
             )
-            logger.debug(f"Recorded batch lineage: {batch.batch_id}")
+            self._logger.debug("Recorded batch lineage", batch_id=batch.batch_id)
         except Exception as e:
-            logger.error(f"Failed to write batch lineage: {e}")
+            self._logger.error("Failed to write batch lineage", error=str(e))
             raise
 
     def _write_transformation_lineage(self, lineage: LineageRecord) -> None:
@@ -294,9 +296,11 @@ class LineageTracker:
                 mode="append",
                 schema_mode="merge",
             )
-            logger.debug(f"Recorded transformation lineage: {lineage.lineage_id}")
+            self._logger.debug(
+                "Recorded transformation lineage", lineage_id=lineage.lineage_id
+            )
         except Exception as e:
-            logger.error(f"Failed to write transformation lineage: {e}")
+            self._logger.error("Failed to write transformation lineage", error=str(e))
             raise
 
     def query_batch_history(
@@ -335,7 +339,7 @@ class LineageTracker:
             return df.head(limit)
 
         except Exception as e:
-            logger.error(f"Failed to query batch history: {e}")
+            self._logger.error("Failed to query batch history", error=str(e))
             return pl.DataFrame()
 
     def query_transformation_history(
@@ -378,7 +382,7 @@ class LineageTracker:
             return df.head(limit)
 
         except Exception as e:
-            logger.error(f"Failed to query transformation history: {e}")
+            self._logger.error("Failed to query transformation history", error=str(e))
             return pl.DataFrame()
 
     def get_entity_lineage(
@@ -410,7 +414,7 @@ class LineageTracker:
             return df
 
         except Exception as e:
-            logger.error(f"Failed to get entity lineage: {e}")
+            self._logger.error("Failed to get entity lineage", error=str(e))
             return pl.DataFrame()
 
     def get_batch_statistics(
@@ -469,7 +473,7 @@ class LineageTracker:
             }
 
         except Exception as e:
-            logger.error(f"Failed to get batch statistics: {e}")
+            self._logger.error("Failed to get batch statistics", error=str(e))
             return {
                 "total_batches": 0,
                 "total_records": 0,

--- a/src/bioetl/infrastructure/observability/server.py
+++ b/src/bioetl/infrastructure/observability/server.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import errno
-import logging
 import time
 from threading import Lock
+from typing import TYPE_CHECKING
 
 from prometheus_client import start_http_server
 
-logger = logging.getLogger(__name__)
+from bioetl.infrastructure.observability.noop_logger import NoOpLogger
+
+if TYPE_CHECKING:
+    from bioetl.domain.ports import LoggerPort
 
 _SERVER_STARTED = False
 _SERVER_LOCK = Lock()
@@ -33,16 +36,16 @@ class MetricsServerError(Exception):
         self.original_error = original_error
 
 
-def _handle_port_in_use(port: int, e: OSError, fail_fast: bool) -> bool:
+def _handle_port_in_use(
+    port: int, e: OSError, fail_fast: bool, logger: LoggerPort
+) -> bool:
     """Handle port already in use error."""
     global _SERVER_STARTED
     logger.warning(
         "Metrics port already in use",
-        extra={
-            "port": port,
-            "errno": e.errno,
-            "action": "metrics_disabled" if not fail_fast else "failing",
-        },
+        port=port,
+        errno=e.errno,
+        action="metrics_disabled" if not fail_fast else "failing",
     )
     if fail_fast:
         raise MetricsServerError(
@@ -54,23 +57,29 @@ def _handle_port_in_use(port: int, e: OSError, fail_fast: bool) -> bool:
     return False
 
 
-def _handle_os_error(port: int, e: OSError, retry_count: int, fail_fast: bool) -> bool:
+def _handle_os_error(
+    port: int, e: OSError, retry_count: int, fail_fast: bool, logger: LoggerPort
+) -> bool:
     """Handle transient OS error after all retries exhausted."""
     logger.error(
         "Failed to start metrics server",
-        extra={"port": port, "errno": e.errno, "attempts": retry_count},
+        port=port,
+        errno=e.errno,
+        attempts=retry_count,
     )
     if fail_fast:
         raise MetricsServerError(port=port, reason="os_error", original_error=e) from e
     return False
 
 
-def _handle_unexpected_error(port: int, e: Exception, fail_fast: bool) -> bool:
+def _handle_unexpected_error(
+    port: int, e: Exception, fail_fast: bool, logger: LoggerPort
+) -> bool:
     """Handle unexpected errors during server startup."""
     logger.error(
         "Unexpected error starting metrics server",
-        extra={"port": port, "error_type": type(e).__name__},
-        exc_info=True,
+        port=port,
+        error_type=type(e).__name__,
     )
     if fail_fast:
         raise MetricsServerError(
@@ -85,6 +94,7 @@ def start_metrics_server(
     fail_fast: bool = False,
     retry_count: int = 3,
     retry_delay: float = 1.0,
+    logger: LoggerPort | None = None,
 ) -> bool:
     """Start Prometheus metrics HTTP server.
 
@@ -96,6 +106,7 @@ def start_metrics_server(
         fail_fast: If True, raise MetricsServerError on failure
         retry_count: Number of retries for transient errors (default: 3)
         retry_delay: Delay between retries in seconds (default: 1.0)
+        logger: Structured logger for observability. If None, uses NoOpLogger.
 
     Returns:
         True if server started successfully, False otherwise
@@ -105,6 +116,9 @@ def start_metrics_server(
 
     """
     global _SERVER_STARTED
+
+    if logger is None:
+        logger = NoOpLogger()
 
     if _SERVER_STARTED:
         logger.debug("Metrics server already started")
@@ -120,18 +134,19 @@ def start_metrics_server(
                 _SERVER_STARTED = True
                 logger.info(
                     "Prometheus metrics server started",
-                    extra={"port": port, "attempt": attempt + 1},
+                    port=port,
+                    attempt=attempt + 1,
                 )
                 return True
             except OSError as e:
                 if e.errno == errno.EADDRINUSE:
-                    return _handle_port_in_use(port, e, fail_fast)
+                    return _handle_port_in_use(port, e, fail_fast, logger)
                 if attempt < retry_count - 1:
                     time.sleep(retry_delay * (2**attempt))
                     continue
-                return _handle_os_error(port, e, retry_count, fail_fast)
+                return _handle_os_error(port, e, retry_count, fail_fast, logger)
             except Exception as e:
-                return _handle_unexpected_error(port, e, fail_fast)
+                return _handle_unexpected_error(port, e, fail_fast, logger)
 
         return False
 

--- a/tests/architecture/test_no_logging_getlogger_in_infrastructure.py
+++ b/tests/architecture/test_no_logging_getlogger_in_infrastructure.py
@@ -1,0 +1,192 @@
+"""Architecture test: no logging.getLogger in infrastructure layer.
+
+REQ-ARCH-033: Infrastructure layer components MUST use LoggerPort
+for structured logging to guarantee run_id inclusion in all log entries.
+
+Components that use logging.getLogger() instead of LoggerPort may produce
+logs without proper context (run_id, pipeline_name), making debugging
+and log correlation difficult.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+INFRASTRUCTURE_DIR = Path("src/bioetl/infrastructure")
+
+# Allowed exemptions (should be empty for new code)
+# logging.py is allowed since it creates the structlog-based logger implementation
+ALLOWED_FILES: set[str] = {
+    "bioetl/infrastructure/observability/logging.py",  # Implements LoggerPort
+}
+
+
+def _check_logging_getlogger_imports(
+    directory: Path, allowed: set[str] | None = None
+) -> list[str]:
+    """Check for logging.getLogger usage in a directory.
+
+    Args:
+        directory: Directory to scan for Python files.
+        allowed: Set of file paths to allow.
+
+    Returns:
+        List of violation messages with file path and line number.
+    """
+    if allowed is None:
+        allowed = set()
+
+    violations = []
+
+    if not directory.exists():
+        return violations
+
+    for py_file in directory.rglob("*.py"):
+        rel_path = py_file.relative_to(Path("src"))
+        # Skip allowed files (normalize path separators)
+        rel_path_str = str(rel_path).replace("\\", "/")
+        if rel_path_str in allowed:
+            continue
+
+        try:
+            source = py_file.read_text(encoding="utf-8")
+            tree = ast.parse(source)
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+
+        for node in ast.walk(tree):
+            # Check for: import logging
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "logging":
+                        # Check if logging.getLogger is called later in the file
+                        if "logging.getLogger" in source:
+                            violations.append(
+                                f"{rel_path}:{node.lineno}: import logging with getLogger usage"
+                            )
+
+            # Check for: from logging import getLogger
+            elif isinstance(node, ast.ImportFrom):
+                if node.module == "logging":
+                    for alias in node.names:
+                        if alias.name == "getLogger":
+                            violations.append(
+                                f"{rel_path}:{node.lineno}: from logging import getLogger"
+                            )
+
+    return violations
+
+
+def _check_getlogger_calls(directory: Path, allowed: set[str] | None = None) -> list[str]:
+    """Check for logging.getLogger() or getLogger() calls in source code.
+
+    Args:
+        directory: Directory to scan for Python files.
+        allowed: Set of file paths to allow.
+
+    Returns:
+        List of violation messages with file path and line number.
+    """
+    if allowed is None:
+        allowed = set()
+
+    violations = []
+
+    if not directory.exists():
+        return violations
+
+    for py_file in directory.rglob("*.py"):
+        rel_path = py_file.relative_to(Path("src"))
+        rel_path_str = str(rel_path).replace("\\", "/")
+        if rel_path_str in allowed:
+            continue
+
+        try:
+            source = py_file.read_text(encoding="utf-8")
+            tree = ast.parse(source)
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                # Check for logging.getLogger()
+                if isinstance(node.func, ast.Attribute):
+                    if (
+                        isinstance(node.func.value, ast.Name)
+                        and node.func.value.id == "logging"
+                        and node.func.attr == "getLogger"
+                    ):
+                        violations.append(
+                            f"{rel_path}:{node.lineno}: logging.getLogger() call"
+                        )
+                # Check for direct getLogger() call
+                elif isinstance(node.func, ast.Name) and node.func.id == "getLogger":
+                    violations.append(
+                        f"{rel_path}:{node.lineno}: getLogger() call"
+                    )
+
+    return violations
+
+
+class TestNoLoggingGetLoggerInInfrastructure:
+    """Test that infrastructure layer does not use logging.getLogger."""
+
+    def test_no_logging_getlogger_imports(self) -> None:
+        """Infrastructure layer MUST NOT use logging.getLogger.
+
+        REQ-ARCH-033: Use LoggerPort injection instead of logging.getLogger()
+        to ensure all logs include run_id and other context fields.
+        """
+        violations = _check_logging_getlogger_imports(
+            INFRASTRUCTURE_DIR, ALLOWED_FILES
+        )
+
+        assert not violations, (
+            "logging.getLogger usage found in infrastructure layer:\n"
+            + "\n".join(f"  - {v}" for v in violations)
+            + "\n\nInfrastructure components MUST use LoggerPort injection."
+            + "\nInject LoggerPort through constructor and use self._logger instead."
+        )
+
+    def test_no_getlogger_calls(self) -> None:
+        """Infrastructure layer MUST NOT call getLogger().
+
+        REQ-ARCH-033: All logging must go through LoggerPort for proper
+        context binding (run_id, pipeline_name, etc.).
+        """
+        violations = _check_getlogger_calls(INFRASTRUCTURE_DIR, ALLOWED_FILES)
+
+        assert not violations, (
+            "getLogger() calls found in infrastructure layer:\n"
+            + "\n".join(f"  - {v}" for v in violations)
+            + "\n\nUse LoggerPort from bioetl.domain.ports instead."
+            + "\nExample: self._logger.info('event', key=value)"
+        )
+
+
+@pytest.mark.parametrize(
+    "check_fn,check_name",
+    [
+        (_check_logging_getlogger_imports, "logging imports"),
+        (_check_getlogger_calls, "getLogger calls"),
+    ],
+)
+def test_no_logging_getlogger_parametrized(
+    check_fn: callable, check_name: str
+) -> None:
+    """Parametrized test for logging.getLogger detection.
+
+    Args:
+        check_fn: Function to check for violations.
+        check_name: Name of the check for error messages.
+    """
+    violations = check_fn(INFRASTRUCTURE_DIR, ALLOWED_FILES)
+
+    assert not violations, (
+        f"{check_name} found in infrastructure layer:\n"
+        + "\n".join(f"  - {v}" for v in violations)
+        + "\n\nInfrastructure MUST use LoggerPort injection."
+    )


### PR DESCRIPTION
Replace logging.getLogger() with LoggerPort injection in 4 infrastructure files to ensure run_id is included in all log entries.

Changes:
- csv_exporter.py: Accept logger in constructor, update all logging calls
- server.py: Add optional logger parameter with NoOpLogger default
- lineage.py: Accept logger in constructor, update all logging calls
- anomaly/monitor.py: Accept logger in constructor, update all logging calls

Factory updates:
- storage_factory.py: Pass logger to CsvExporter creation
- observability.py: Pass logger to DataQualityMonitor creation

Added architectural test test_no_logging_getlogger_in_infrastructure.py to prevent future regressions.

REQ-ARCH-033: Infrastructure components MUST use LoggerPort abstraction.