### PR TITLE
Add CrossRef schema generation prompts

### DIFF
--- a/src/bioetl/domain/schemas/crossref/__init__.py
+++ b/src/bioetl/domain/schemas/crossref/__init__.py
@@ -1,0 +1,19 @@
+"""CrossRef Pandera schemas for Silver layer validation.
+
+Entity-Relationship:
+    CrossRefWork (1) ─┬── (N) CrossRefAuthor
+                      ├── (N) CrossRefReference
+                      └── (N) CrossRefFunder
+"""
+
+from bioetl.domain.schemas.crossref.author import AuthorSchema
+from bioetl.domain.schemas.crossref.funder import FunderSchema
+from bioetl.domain.schemas.crossref.reference import ReferenceSchema
+from bioetl.domain.schemas.crossref.work import WorkSchema
+
+__all__ = [
+    "AuthorSchema",
+    "FunderSchema",
+    "ReferenceSchema",
+    "WorkSchema",
+]

--- a/src/bioetl/domain/schemas/crossref/author.py
+++ b/src/bioetl/domain/schemas/crossref/author.py
@@ -1,0 +1,82 @@
+"""Pandera schema for CrossRef Author entity.
+
+Aligned with RULES.md v5.0 and CrossRef REST API.
+Represents authors from the "author" field in Works API response.
+"""
+
+from __future__ import annotations
+
+import pandera as pa
+from pandera.typing import Series
+
+from bioetl.domain.schemas.base import ETLRecordSchema
+
+# === Fixed Value Constants ===
+AUTHOR_SEQUENCES = ["first", "additional"]
+
+
+class AuthorSchema(ETLRecordSchema):
+    """CrossRef Author validation schema for Silver layer.
+
+    Represents an author of a CrossRef Work (1:N relationship).
+    Composite PK: (doi, author_sequence)
+    """
+
+    # === Foreign Key ===
+    doi: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^10\.\d{4,}/.*$",
+        description="FK to Work.doi",
+    )
+
+    # === Composite Primary Key Component ===
+    author_sequence: Series[int] = pa.Field(
+        nullable=False, ge=0, description="Author order (0-based index)"
+    )
+
+    # === Author Names ===
+    family_name: Series[str] = pa.Field(
+        nullable=False,
+        str_length={"min_value": 1},
+        description="Family name (required)",
+    )
+    given_name: Series[str] | None = pa.Field(
+        nullable=True, description="Given name(s)"
+    )
+    suffix: Series[str] | None = pa.Field(
+        nullable=True, description="Name suffix (Jr., III, etc.)"
+    )
+
+    # === Identifiers ===
+    orcid: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^\d{4}-\d{4}-\d{4}-\d{3}[\dX]$",
+        description="ORCID (ID only, without URL prefix)",
+    )
+    authenticated_orcid: Series[bool] | None = pa.Field(
+        nullable=True, description="Whether ORCID is CrossRef-authenticated"
+    )
+
+    # === Affiliation ===
+    affiliation: Series[str] | None = pa.Field(
+        nullable=True, description="Primary affiliation (first from affiliations list)"
+    )
+    affiliation_ids: Series[str] | None = pa.Field(
+        nullable=True, description="Affiliation identifiers (ROR, ISNI; joined with '; ')"
+    )
+
+    # === Metadata ===
+    sequence: Series[str] | None = pa.Field(
+        nullable=True,
+        isin=AUTHOR_SEQUENCES,
+        description="Author sequence type ('first' or 'additional')",
+    )
+
+    class Config:
+        """Pandera configuration."""
+
+        strict = True
+        ordered = True
+        coerce = True
+        name = "AuthorSchema"
+        description = "CrossRef Author Silver layer validation"

--- a/src/bioetl/domain/schemas/crossref/funder.py
+++ b/src/bioetl/domain/schemas/crossref/funder.py
@@ -1,0 +1,65 @@
+"""Pandera schema for CrossRef Funder entity.
+
+Aligned with RULES.md v5.0 and CrossRef REST API.
+Represents funders from the "funder" field in Works API response.
+Integrates with CrossRef Funder Registry (DOI prefix: 10.13039/).
+"""
+
+from __future__ import annotations
+
+import pandera as pa
+from pandera.typing import Series
+
+from bioetl.domain.schemas.base import ETLRecordSchema
+
+
+class FunderSchema(ETLRecordSchema):
+    """CrossRef Funder validation schema for Silver layer.
+
+    Represents a funder of a CrossRef Work (1:N relationship).
+    Composite PK: (doi, funder_sequence)
+    """
+
+    # === Foreign Key ===
+    doi: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^10\.\d{4,}/.*$",
+        description="FK to Work.doi",
+    )
+
+    # === Composite Primary Key Component ===
+    funder_sequence: Series[int] = pa.Field(
+        nullable=False, ge=0, description="Funder order (0-based index)"
+    )
+
+    # === Funder Details ===
+    name: Series[str] = pa.Field(
+        nullable=False,
+        str_length={"min_value": 1},
+        description="Funder organization name",
+    )
+    funder_doi: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^10\.13039/\d+$",
+        description="Funder Registry DOI (10.13039/...)",
+    )
+    funder_id: Series[str] | None = pa.Field(
+        nullable=True, description="Funder ID (legacy, without DOI prefix)"
+    )
+
+    # === Awards/Grants ===
+    award_numbers: Series[str] | None = pa.Field(
+        nullable=True, description="Grant/award numbers (joined with '; ')"
+    )
+    award_count: Series[int] | None = pa.Field(
+        nullable=True, ge=0, description="Number of awards from this funder"
+    )
+
+    class Config:
+        """Pandera configuration."""
+
+        strict = True
+        ordered = True
+        coerce = True
+        name = "FunderSchema"
+        description = "CrossRef Funder Silver layer validation"

--- a/src/bioetl/domain/schemas/crossref/reference.py
+++ b/src/bioetl/domain/schemas/crossref/reference.py
@@ -1,0 +1,95 @@
+"""Pandera schema for CrossRef Reference entity.
+
+Aligned with RULES.md v5.0 and CrossRef REST API.
+Represents bibliographic references from the "reference" field in Works API response.
+"""
+
+from __future__ import annotations
+
+import pandera as pa
+from pandera.typing import Series
+
+from bioetl.domain.schemas.base import ETLRecordSchema
+
+
+class ReferenceSchema(ETLRecordSchema):
+    """CrossRef Reference validation schema for Silver layer.
+
+    Represents a bibliographic reference in a CrossRef Work (1:N relationship).
+    Composite PK: (source_doi, reference_key)
+    """
+
+    # === Foreign Key ===
+    source_doi: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^10\.\d{4,}/.*$",
+        description="DOI of citing work (FK to Work.doi)",
+    )
+
+    # === Composite Primary Key Component ===
+    reference_key: Series[str] = pa.Field(
+        nullable=False,
+        str_length={"min_value": 1},
+        description="Unique reference key within source work",
+    )
+
+    # === Target Reference ===
+    target_doi: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^10\.\d{4,}/.*$",
+        description="DOI of cited work (if resolved)",
+    )
+    unstructured: Series[str] | None = pa.Field(
+        nullable=True, description="Unstructured citation string"
+    )
+
+    # === Bibliographic Details ===
+    article_title: Series[str] | None = pa.Field(
+        nullable=True, description="Article title"
+    )
+    journal_title: Series[str] | None = pa.Field(
+        nullable=True, description="Journal name"
+    )
+    series_title: Series[str] | None = pa.Field(
+        nullable=True, description="Series name"
+    )
+    volume: Series[str] | None = pa.Field(nullable=True, description="Volume number")
+    issue: Series[str] | None = pa.Field(nullable=True, description="Issue number")
+    first_page: Series[str] | None = pa.Field(
+        nullable=True, description="First page number"
+    )
+    year: Series[int] | None = pa.Field(
+        nullable=True,
+        ge=1800,
+        le=2100,
+        description="Publication year",
+    )
+    author: Series[str] | None = pa.Field(
+        nullable=True, description="First author (Family, Given or just family)"
+    )
+
+    # === Identifiers ===
+    isbn: Series[str] | None = pa.Field(nullable=True, description="ISBN (for books)")
+    issn: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^\d{4}-\d{3}[\dX]$",
+        description="ISSN",
+    )
+    component: Series[str] | None = pa.Field(
+        nullable=True, description="Component DOI"
+    )
+
+    # === Additional Metadata ===
+    edition: Series[str] | None = pa.Field(nullable=True, description="Edition number")
+    standards_body: Series[str] | None = pa.Field(
+        nullable=True, description="Standards organization"
+    )
+
+    class Config:
+        """Pandera configuration."""
+
+        strict = True
+        ordered = True
+        coerce = True
+        name = "ReferenceSchema"
+        description = "CrossRef Reference Silver layer validation"

--- a/src/bioetl/domain/schemas/crossref/work.py
+++ b/src/bioetl/domain/schemas/crossref/work.py
@@ -1,0 +1,154 @@
+"""Pandera schema for CrossRef Work entity.
+
+Aligned with RULES.md v5.0 and CrossRef REST API.
+Source: https://api.crossref.org/swagger-ui/index.html
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pandera as pa
+from pandera.typing import Series
+
+from bioetl.domain.schemas.base import ETLRecordSchema
+
+# === Fixed Value Constants ===
+WORK_TYPES = [
+    "journal-article",
+    "book-chapter",
+    "proceedings-article",
+    "book",
+    "dataset",
+    "report",
+    "standard",
+    "peer-review",
+    "component",
+    "posted-content",
+    "monograph",
+    "reference-entry",
+    "dissertation",
+    "other",
+    "journal-issue",
+    "journal",
+    "reference-book",
+    "book-series",
+    "edited-book",
+    "book-set",
+    "book-part",
+    "book-section",
+    "book-track",
+    "proceedings",
+    "proceedings-series",
+    "report-series",
+    "report-component",
+    "grant",
+]
+
+
+class WorkSchema(ETLRecordSchema):
+    """CrossRef Work validation schema for Silver layer.
+
+    Represents a publication (article, book, dataset, etc.) with DOI.
+    """
+
+    # === Primary Key ===
+    doi: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^10\.\d{4,}/.*$",
+        description="Digital Object Identifier (PK)",
+    )
+
+    # === Core Fields ===
+    type: Series[str] = pa.Field(
+        nullable=False,
+        isin=WORK_TYPES,
+        description="Work type (journal-article, book-chapter, etc.)",
+    )
+    title: Series[str] = pa.Field(
+        nullable=False,
+        str_length={"min_value": 1},
+        description="Work title (first element of title array)",
+    )
+
+    # === Container (Journal/Book) ===
+    container_title: Series[str] | None = pa.Field(
+        nullable=True, description="Journal or book name"
+    )
+    publisher: Series[str] | None = pa.Field(
+        nullable=True, description="Publisher name"
+    )
+    issn: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^\d{4}-\d{3}[\dX]$",
+        description="ISSN (print preferred)",
+    )
+    isbn: Series[str] | None = pa.Field(
+        nullable=True, description="ISBN (first from list)"
+    )
+
+    # === Volume/Issue/Pages ===
+    volume: Series[str] | None = pa.Field(nullable=True, description="Volume number")
+    issue: Series[str] | None = pa.Field(nullable=True, description="Issue number")
+    page: Series[str] | None = pa.Field(
+        nullable=True, description="Page range (format: start-end)"
+    )
+
+    # === Dates ===
+    published_date: Series[date] | None = pa.Field(
+        nullable=True, description="Publication date (from issued or published-print)"
+    )
+    created_date: Series[date] | None = pa.Field(
+        nullable=True, description="Record creation date in CrossRef"
+    )
+    deposited_date: Series[date] | None = pa.Field(
+        nullable=True, description="Last update date in CrossRef"
+    )
+
+    # === Content ===
+    abstract: Series[str] | None = pa.Field(
+        nullable=True, description="Abstract text (may contain HTML entities)"
+    )
+    language: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^[a-z]{2}$",
+        description="Language code (ISO 639-1)",
+    )
+    subject: Series[str] | None = pa.Field(
+        nullable=True, description="Subject areas (joined with '; ')"
+    )
+
+    # === License & Access ===
+    license_url: Series[str] | None = pa.Field(
+        nullable=True, description="License URL (first from list)"
+    )
+
+    # === Citation Metrics ===
+    is_referenced_by_count: Series[int] | None = pa.Field(
+        nullable=True, ge=0, description="Citation count (times referenced)"
+    )
+    references_count: Series[int] | None = pa.Field(
+        nullable=True, ge=0, description="Reference count (bibliography size)"
+    )
+
+    # === Funding & Clinical Trials ===
+    funder_names: Series[str] | None = pa.Field(
+        nullable=True, description="Funder names (joined with '; ')"
+    )
+    clinical_trial_numbers: Series[str] | None = pa.Field(
+        nullable=True, description="Clinical trial identifiers (joined with '; ')"
+    )
+
+    # === Policies ===
+    update_policy: Series[str] | None = pa.Field(
+        nullable=True, description="DOI of update policy"
+    )
+
+    class Config:
+        """Pandera configuration."""
+
+        strict = True
+        ordered = True
+        coerce = True
+        name = "WorkSchema"
+        description = "CrossRef Work Silver layer validation"


### PR DESCRIPTION
Add Pandera DataFrameModel schemas for CrossRef API data source:
- WorkSchema: Core entity for publications with DOI
- AuthorSchema: 1:N relationship for work authors
- ReferenceSchema: 1:N relationship for bibliographic references
- FunderSchema: 1:N relationship for grant funders

All schemas inherit from ETLRecordSchema and follow project conventions for Silver layer validation (RULES.md v5.0 aligned).