### PR TITLE
Implement ChEMBL cell line data pipeline

### DIFF
--- a/configs/pipelines/chembl/cell_line.yaml
+++ b/configs/pipelines/chembl/cell_line.yaml
@@ -1,0 +1,92 @@
+# configs/pipelines/chembl/cell_line.yaml
+# Конфигурация пайплайна для сущности Cell Line из ChEMBL.
+#
+# Cell lines are biological objects used for in vitro experiments.
+# They have M:N relationship with Assay (via assay.cell_chembl_id FK).
+# Load strategy: full (reference data, rarely changes).
+
+pipeline_name: chembl_cell_line
+provider: chembl
+entity_type: cell_line
+version: "1.0.0"
+description: "Extract cell lines from ChEMBL API"
+
+primary_keys: ["cell_chembl_id"]
+silver_table: "chembl_cell_line"
+
+# Ссылка на файл с конфигурацией источника данных
+source_file: ../../sources/chembl.yaml
+
+# Gold filters: all cell lines with required metadata
+gold_filters:
+    required_fields:
+        - cell_name
+        - cell_source_organism
+
+transform:
+    version: "1.0.0"
+    steps:
+        - normalize_values
+        - add_metadata
+        - calculate_content_hash
+
+sink:
+    bronze:
+        path: "data/output/bronze"
+        format: jsonl
+        save_json: true
+        deterministic: true
+
+    silver:
+        path: "data/output/silver"
+        format: delta
+        mode: merge
+        on_schema_mismatch: evolve  # Allow schema evolution for _index field
+        primary_key: [ "cell_chembl_id" ]
+        partition_by: []
+        classification: public
+        forensic_retention: true
+        deterministic: true
+        sort_by:
+            columns: [ "cell_chembl_id" ]
+            ascending: true
+        csv_export:
+            enabled: true
+            path: "data/output/csv/silver"
+            delimiter: ","
+            header: true
+            encoding: "utf-8"
+
+    gold:
+        enabled: true
+        validation:
+            strict: true
+        path: "data/output/gold"
+        format: delta
+        mode: overwrite
+        deterministic: true
+        sort_by:
+            columns: [ "cell_chembl_id", "cell_name" ]
+            ascending: true
+        csv_export:
+            enabled: true
+            path: "data/output/csv/gold"
+            delimiter: ","
+            header: true
+            encoding: "utf-8"
+
+dq_rules:
+    soft_fail_threshold: 0.05
+    hard_fail_threshold: 0.20
+
+circuit_breaker:
+    failure_threshold: 5
+    recovery_timeout: 300
+
+# Input filter configuration (for CSV-based ID filtering)
+input_filter:
+    enabled: true
+    source_path: "data/input/cell_line.csv"
+    column_name: "cell_chembl_id"
+    filter_field: "cell_chembl_id"
+    batch_size: 20

--- a/src/bioetl/application/pipelines/chembl/__init__.py
+++ b/src/bioetl/application/pipelines/chembl/__init__.py
@@ -15,6 +15,10 @@ from bioetl.application.pipelines.chembl.assay_transformer import AssayTransform
 from bioetl.application.pipelines.chembl.base_chembl_transformer import (
     BaseChemblTransformer,
 )
+from bioetl.application.pipelines.chembl.cell_line import ChEMBLCellLinePipeline
+from bioetl.application.pipelines.chembl.cell_line_transformer import (
+    CellLineTransformer,
+)
 from bioetl.application.pipelines.chembl.document import ChEMBLDocumentPipeline
 from bioetl.application.pipelines.chembl.document_transformer import (
     DocumentTransformer,
@@ -36,8 +40,10 @@ __all__ = [
     "ActivityTransformer",
     "AssayTransformer",
     "BaseChemblTransformer",
+    "CellLineTransformer",
     "ChEMBLActivityPipeline",
     "ChEMBLAssayPipeline",
+    "ChEMBLCellLinePipeline",
     "ChEMBLDocumentPipeline",
     "ChEMBLMoleculePipeline",
     "ChEMBLTargetComponentPipeline",

--- a/src/bioetl/application/pipelines/chembl/cell_line.py
+++ b/src/bioetl/application/pipelines/chembl/cell_line.py
@@ -1,0 +1,27 @@
+"""ChEMBL Cell Line Pipeline.
+
+Fetches cell lines from ChEMBL database and processes through
+Bronze → Silver → Gold layers.
+
+Entity: Cell Lines (biological objects for in vitro experiments)
+Provider: ChEMBL (https://www.ebi.ac.uk/chembl/)
+
+Transformer is injected via DI from GenericPipelineFactory (REQ-ARCH-DI-007).
+"""
+
+from __future__ import annotations
+
+from bioetl.application.core.base import BasePipeline
+
+
+class ChEMBLCellLinePipeline(BasePipeline):
+    """Pipeline for ChEMBL cell line data.
+
+    Cell lines are biological objects used for in vitro experiments.
+    They have M:N relationship with Assay (via assay.cell_chembl_id FK).
+
+    Transformer is injected via DI from GenericPipelineFactory.
+    """
+
+    # transform_bronze_to_silver() is inherited from BasePipeline
+    # should_write_gold() is inherited from BasePipeline (uses config.gold_filters)

--- a/src/bioetl/application/pipelines/chembl/cell_line_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/cell_line_transformer.py
@@ -1,0 +1,98 @@
+"""ChEMBL Cell Line Transformer.
+
+Transforms Bronze records to Silver format (CellLine entity inflation).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from bioetl.application.pipelines.chembl.base_chembl_transformer import (
+    BaseChemblTransformer,
+)
+from bioetl.domain.entities import CellLine
+from bioetl.domain.transformations import safe_int
+
+if TYPE_CHECKING:
+    from bioetl.domain.types import BronzeRecord
+
+
+class CellLineTransformer(BaseChemblTransformer):
+    """Transforms ChEMBL bronze cell line records to silver.
+
+    Cell lines are biological objects used for in vitro experiments.
+    They have M:N relationship with Assay (via assay.cell_chembl_id FK).
+    """
+
+    entity_class = CellLine
+    primary_id_field = "cell_chembl_id"
+
+    def _normalize_external_id(self, value: Any) -> str | None:
+        """Normalize external ID by stripping whitespace, NULL if empty.
+
+        Args:
+            value: Raw external ID value from API.
+
+        Returns:
+            Stripped string or None if empty/None.
+
+        """
+        if value is None:
+            return None
+        str_value = str(value).strip()
+        return str_value if str_value else None
+
+    def _validate_tax_id(self, value: Any) -> int | None:
+        """Validate taxonomy ID (must be > 0 or NULL).
+
+        Args:
+            value: Raw tax_id value from API.
+
+        Returns:
+            Valid tax_id (>= 1) or None.
+
+        """
+        tax_id = safe_int(value)
+        if tax_id is not None and tax_id < 1:
+            return None
+        return tax_id
+
+    def _extract_business_data(
+        self,
+        record: BronzeRecord,
+        primary_id: Any,
+    ) -> dict[str, Any]:
+        """Extract CellLine business data from bronze record.
+
+        Args:
+            record: Raw Bronze record from ChEMBL API.
+            primary_id: Validated cell_chembl_id value.
+
+        Returns:
+            Dictionary of CellLine business fields.
+
+        """
+        # Get cell_name with strip and lowercase normalization for comparison
+        cell_name = record.get("cell_name")
+        if cell_name is not None:
+            cell_name = str(cell_name).strip()
+
+        return {
+            # Primary identifier
+            "cell_chembl_id": str(primary_id),
+            # Core metadata
+            "cell_name": cell_name,
+            "cell_description": record.get("cell_description"),
+            # Source information
+            "cell_source_tissue": record.get("cell_source_tissue"),
+            "cell_source_organism": record.get("cell_source_organism"),
+            "cell_source_tax_id": self._validate_tax_id(
+                record.get("cell_source_tax_id")
+            ),
+            # External identifiers (strip, NULL if empty)
+            "cellosaurus_id": self._normalize_external_id(
+                record.get("cellosaurus_id")
+            ),
+            "cl_lincs_id": self._normalize_external_id(record.get("cl_lincs_id")),
+            "efo_id": self._normalize_external_id(record.get("efo_id")),
+        }

--- a/src/bioetl/domain/entities/__init__.py
+++ b/src/bioetl/domain/entities/__init__.py
@@ -23,6 +23,7 @@ See base.py for RequiredEntityFields Protocol for type-safe required field check
 from bioetl.domain.entities.base import BaseEntity, RequiredEntityFields
 from bioetl.domain.entities.chembl_activity import Activity, Assay
 from bioetl.domain.entities.chembl_structures import (
+    CellLine,
     Document,
     Molecule,
     Target,
@@ -36,6 +37,7 @@ __all__ = [
     "Activity",
     "Assay",
     "BaseEntity",
+    "CellLine",
     "Compound",
     "Document",
     "Molecule",

--- a/src/bioetl/domain/entities/chembl_structures.py
+++ b/src/bioetl/domain/entities/chembl_structures.py
@@ -1,6 +1,6 @@
 """ChEMBL structural domain entities.
 
-Contains Document, Target, TargetComponent, and Molecule entities.
+Contains Document, Target, TargetComponent, CellLine, and Molecule entities.
 """
 
 from __future__ import annotations
@@ -139,6 +139,51 @@ class TargetComponent(BaseEntity):
     def _validate_invariants(self) -> None:
         if not self.component_id:
             raise ValueError("Component ID is required")
+
+
+@dataclass(frozen=True, kw_only=True)
+class CellLine(BaseEntity):
+    """Represents a cell line (ChEMBL Cell Line).
+
+    Cell lines are biological objects used for in vitro experiments.
+    They have M:N relationship with Assay (via assay.cell_chembl_id FK).
+
+    Contains all fields from ChEMBL cell_line API endpoint.
+    See: https://www.ebi.ac.uk/chembl/api/data/cell_line
+    """
+
+    # Primary identifier (REQUIRED)
+    cell_chembl_id: str
+
+    # Core metadata (cell_name is REQUIRED per task spec)
+    cell_name: str
+
+    # Optional metadata (API-OPTIONAL)
+    cell_description: str | None = None
+
+    # Source information (API-OPTIONAL)
+    cell_source_tissue: str | None = None
+    cell_source_organism: str | None = None
+    cell_source_tax_id: int | None = None
+
+    # External identifiers (API-OPTIONAL)
+    cellosaurus_id: str | None = None
+    cl_lincs_id: str | None = None
+    efo_id: str | None = None
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self._validate_invariants()
+
+    def _validate_invariants(self) -> None:
+        if not self.cell_chembl_id:
+            raise ValueError("Cell ChEMBL ID is required")
+        if not self.cell_name:
+            raise ValueError("Cell name is required")
+        if self.cell_source_tax_id is not None and self.cell_source_tax_id < 1:
+            raise ValueError(
+                f"cell_source_tax_id must be >= 1, got {self.cell_source_tax_id}"
+            )
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/bioetl/domain/schemas/chembl/cell_line.py
+++ b/src/bioetl/domain/schemas/chembl/cell_line.py
@@ -1,6 +1,7 @@
 """Pandera schema for ChEMBL Cell Line entity.
 
 Aligned with RULES.md v5.0 and ChEMBL 34 schema.
+See: https://www.ebi.ac.uk/chembl/api/data/cell_line
 """
 
 from __future__ import annotations
@@ -12,53 +13,64 @@ from bioetl.domain.schemas.base import ETLRecordSchema
 
 
 class CellLineSchema(ETLRecordSchema):
-    """Cell Line validation schema for Silver layer."""
+    """Cell Line validation schema for Silver layer.
+
+    Cell lines are biological objects used for in vitro experiments.
+    They have M:N relationship with Assay (via assay.cell_chembl_id FK).
+    """
 
     # === Primary Key ===
-    cell_id: Series[int] = pa.Field(nullable=False, description="Primary key.")
-
-    # === Metadata ===
-    cell_name: Series[str] | None = pa.Field(nullable=True, description="Cell name.")
-    cell_description: Series[str] | None = pa.Field(
-        nullable=True, description="Cell description."
+    cell_chembl_id: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^CHEMBL\d+$",
+        unique=True,
+        description="ChEMBL ID for cell line (PK).",
     )
+
+    # === Core Metadata ===
+    cell_name: Series[str] = pa.Field(
+        nullable=False,
+        description="Cell line name (e.g., HeLa, MCF7).",
+    )
+    cell_description: Series[str] | None = pa.Field(
+        nullable=True,
+        description="Cell line description.",
+    )
+
+    # === Source Information ===
     cell_source_tissue: Series[str] | None = pa.Field(
-        nullable=True, description="Source tissue."
+        nullable=True,
+        description="Source tissue (e.g., Cervix, Breast).",
     )
     cell_source_organism: Series[str] | None = pa.Field(
-        nullable=True, description="Source organism."
+        nullable=True,
+        description="Source organism (e.g., Homo sapiens).",
     )
     cell_source_tax_id: Series[int] | None = pa.Field(
-        nullable=True, description="Source taxonomy ID."
+        nullable=True,
+        ge=1,
+        description="NCBI Taxonomy ID for source organism.",
     )
 
     # === External Identifiers ===
-    clo_id: Series[str] | None = pa.Field(
+    cellosaurus_id: Series[str] | None = pa.Field(
         nullable=True,
-        str_matches=r"^CLO:\d+$",
-        description="CLO ID.",
+        str_matches=r"^CVCL_[A-Z0-9]+$",
+        description="Cellosaurus ID (external reference).",
+    )
+    cl_lincs_id: Series[str] | None = pa.Field(
+        nullable=True,
+        description="LINCS ID (Library of Integrated Network-Based Cellular Signatures).",
     )
     efo_id: Series[str] | None = pa.Field(
         nullable=True,
-        str_matches=r"^EFO:\d+$",
-        description="EFO ID.",
-    )
-    cellosaurus_id: Series[str] | None = pa.Field(
-        nullable=True,
-        str_matches=r"^CVCL_\w+$",
-        description="Cellosaurus ID.",
-    )
-
-    # === Flags ===
-    downgraded: Series[int] | None = pa.Field(
-        nullable=True,
-        isin=[0, 1],
-        description="Downgraded flag.",
+        str_matches=r"^EFO_\d+$",
+        description="EFO ontology ID.",
     )
 
     class Config:
         """Pandera configuration."""
 
         strict = True
-        ordered = True
+        ordered = False
         coerce = True

--- a/src/bioetl/infrastructure/schemas/silver.py
+++ b/src/bioetl/infrastructure/schemas/silver.py
@@ -313,6 +313,35 @@ CHEMBL_TARGET_COMPONENT_SCHEMA = pa.schema(
     ]
 )
 
+# Schema for ChEMBL Cell Line
+# See: https://www.ebi.ac.uk/chembl/api/data/cell_line
+CHEMBL_CELL_LINE_SCHEMA = pa.schema(
+    [
+        # System fields
+        pa.field("entity_id", pa.string()),
+        pa.field("content_hash", pa.string()),
+        # Primary identifier
+        pa.field("cell_chembl_id", pa.string()),
+        # Core metadata
+        pa.field("cell_name", pa.string()),
+        pa.field("cell_description", pa.string()),
+        # Source information
+        pa.field("cell_source_tissue", pa.string()),
+        pa.field("cell_source_organism", pa.string()),
+        pa.field("cell_source_tax_id", pa.int64()),
+        # External identifiers
+        pa.field("cellosaurus_id", pa.string()),
+        pa.field("cl_lincs_id", pa.string()),
+        pa.field("efo_id", pa.string()),
+        # Lineage metadata
+        pa.field("_run_id", pa.string()),
+        pa.field("_run_type", pa.string()),
+        pa.field("_source_batch_id", pa.string()),
+        pa.field("_ingestion_ts", pa.string()),
+        pa.field("_index", pa.int64()),
+    ]
+)
+
 # Schema for ChEMBL Document
 # See: https://www.ebi.ac.uk/chembl/api/data/document
 CHEMBL_DOCUMENT_SCHEMA = pa.schema(

--- a/tests/unit/application/pipelines/test_cell_line_transformer.py
+++ b/tests/unit/application/pipelines/test_cell_line_transformer.py
@@ -1,0 +1,284 @@
+"""Unit tests for ChEMBL Cell Line Transformer."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from bioetl.application.pipelines.chembl.cell_line_transformer import (
+    CellLineTransformer,
+)
+from bioetl.domain.context import PipelineContext
+from bioetl.domain.types import RunType
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock pipeline context."""
+    mock_logger = MagicMock()
+    mock_logger.bind = MagicMock(return_value=mock_logger)
+    mock_logger.warning = MagicMock()
+    return PipelineContext(
+        run_id=uuid4(),
+        run_type=RunType.INCREMENTAL,
+        logger=mock_logger,
+    )
+
+
+@pytest.mark.unit
+class TestCellLineTransformer:
+    """Tests for CellLineTransformer."""
+
+    @pytest.fixture
+    def transformer(self):
+        """Create CellLineTransformer instance."""
+        return CellLineTransformer(provider="chembl")
+
+    @pytest.mark.asyncio
+    async def test_transform_valid_record(self, transformer, mock_context):
+        """Test transformation of valid cell line record."""
+        record = {
+            "cell_chembl_id": "CHEMBL3308376",
+            "cell_name": "HeLa",
+            "cell_description": "Human cervical cancer cell line",
+            "cell_source_tissue": "Cervix",
+            "cell_source_organism": "Homo sapiens",
+            "cell_source_tax_id": 9606,
+            "cellosaurus_id": "CVCL_0030",
+            "cl_lincs_id": "LCL-1234",
+            "efo_id": "EFO_0001185",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["cell_chembl_id"] == "CHEMBL3308376"
+        assert result["cell_name"] == "HeLa"
+        assert result["cell_description"] == "Human cervical cancer cell line"
+        assert result["cell_source_tissue"] == "Cervix"
+        assert result["cell_source_organism"] == "Homo sapiens"
+        assert result["cell_source_tax_id"] == 9606
+        assert result["cellosaurus_id"] == "CVCL_0030"
+        assert result["cl_lincs_id"] == "LCL-1234"
+        assert result["efo_id"] == "EFO_0001185"
+        assert "entity_id" in result
+        assert "content_hash" in result
+        assert "_run_id" in result
+
+    @pytest.mark.asyncio
+    async def test_transform_missing_cell_chembl_id(self, transformer, mock_context):
+        """Test transformation returns None when cell_chembl_id is missing."""
+        record = {
+            "cell_name": "HeLa",
+            "cell_source_organism": "Homo sapiens",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_transform_minimal_record(self, transformer, mock_context):
+        """Test transformation with only required fields."""
+        record = {
+            "cell_chembl_id": "CHEMBL3308376",
+            "cell_name": "HeLa",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["cell_chembl_id"] == "CHEMBL3308376"
+        assert result["cell_name"] == "HeLa"
+        assert result["cell_description"] is None
+        assert result["cell_source_tissue"] is None
+        assert result["cell_source_organism"] is None
+        assert result["cell_source_tax_id"] is None
+        assert result["cellosaurus_id"] is None
+        assert result["cl_lincs_id"] is None
+        assert result["efo_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_transform_with_whitespace_in_cell_name(
+        self, transformer, mock_context
+    ):
+        """Test that cell_name is stripped of leading/trailing whitespace."""
+        record = {
+            "cell_chembl_id": "CHEMBL3308376",
+            "cell_name": "  HeLa  ",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["cell_name"] == "HeLa"
+
+    @pytest.mark.asyncio
+    async def test_transform_with_empty_external_ids(self, transformer, mock_context):
+        """Test that empty string external IDs become None."""
+        record = {
+            "cell_chembl_id": "CHEMBL3308376",
+            "cell_name": "HeLa",
+            "cellosaurus_id": "",
+            "cl_lincs_id": "   ",
+            "efo_id": None,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["cellosaurus_id"] is None
+        assert result["cl_lincs_id"] is None
+        assert result["efo_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_transform_strips_external_id_whitespace(
+        self, transformer, mock_context
+    ):
+        """Test that external IDs are stripped of whitespace."""
+        record = {
+            "cell_chembl_id": "CHEMBL3308376",
+            "cell_name": "HeLa",
+            "cellosaurus_id": "  CVCL_0030  ",
+            "cl_lincs_id": "\tLCL-1234\n",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["cellosaurus_id"] == "CVCL_0030"
+        assert result["cl_lincs_id"] == "LCL-1234"
+
+    @pytest.mark.asyncio
+    async def test_transform_with_invalid_tax_id_zero(
+        self, transformer, mock_context
+    ):
+        """Test that tax_id of 0 becomes None (must be >= 1)."""
+        record = {
+            "cell_chembl_id": "CHEMBL3308376",
+            "cell_name": "HeLa",
+            "cell_source_tax_id": 0,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["cell_source_tax_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_transform_with_negative_tax_id(self, transformer, mock_context):
+        """Test that negative tax_id becomes None (must be >= 1)."""
+        record = {
+            "cell_chembl_id": "CHEMBL3308376",
+            "cell_name": "HeLa",
+            "cell_source_tax_id": -1,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["cell_source_tax_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_transform_with_valid_tax_id(self, transformer, mock_context):
+        """Test that valid tax_id is preserved."""
+        record = {
+            "cell_chembl_id": "CHEMBL3308376",
+            "cell_name": "HeLa",
+            "cell_source_tax_id": 9606,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["cell_source_tax_id"] == 9606
+
+    @pytest.mark.asyncio
+    async def test_transform_with_tax_id_as_string(self, transformer, mock_context):
+        """Test that tax_id as string is converted to int."""
+        record = {
+            "cell_chembl_id": "CHEMBL3308376",
+            "cell_name": "HeLa",
+            "cell_source_tax_id": "9606",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["cell_source_tax_id"] == 9606
+
+    @pytest.mark.asyncio
+    async def test_transform_custom_provider(self, mock_context):
+        """Test transformation with custom provider."""
+        transformer = CellLineTransformer(provider="custom_provider")
+        record = {
+            "cell_chembl_id": "CUSTOM123",
+            "cell_name": "CustomCell",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert "entity_id" in result
+
+    @pytest.mark.asyncio
+    async def test_transform_generates_content_hash(self, transformer, mock_context):
+        """Test that content_hash is generated and is 64 hex characters."""
+        record = {
+            "cell_chembl_id": "CHEMBL3308376",
+            "cell_name": "HeLa",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert "content_hash" in result
+        assert len(result["content_hash"]) == 64
+        # Verify it's a valid hex string
+        int(result["content_hash"], 16)
+
+    @pytest.mark.asyncio
+    async def test_transform_includes_lineage_fields(self, transformer, mock_context):
+        """Test that all lineage fields are present."""
+        record = {
+            "cell_chembl_id": "CHEMBL3308376",
+            "cell_name": "HeLa",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert "_run_id" in result
+        assert "_run_type" in result
+        assert "_source_batch_id" in result
+        assert "_ingestion_ts" in result
+        assert "_index" in result
+        assert result["_index"] == 0
+
+    @pytest.mark.asyncio
+    async def test_transform_with_null_values(self, transformer, mock_context):
+        """Test transformation handles None values correctly."""
+        record = {
+            "cell_chembl_id": "CHEMBL3308376",
+            "cell_name": "HeLa",
+            "cell_description": None,
+            "cell_source_tissue": None,
+            "cell_source_organism": None,
+            "cell_source_tax_id": None,
+            "cellosaurus_id": None,
+            "cl_lincs_id": None,
+            "efo_id": None,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["cell_description"] is None
+        assert result["cell_source_tissue"] is None
+        assert result["cell_source_organism"] is None
+        assert result["cell_source_tax_id"] is None
+        assert result["cellosaurus_id"] is None
+        assert result["cl_lincs_id"] is None
+        assert result["efo_id"] is None


### PR DESCRIPTION
Implement complete ChEMBL cell_line pipeline following existing patterns:

- Add CellLineSchema (Pandera) with cell_chembl_id as PK, unique constraint and regex validation (^CHEMBL\d+$)
- Add CellLine domain entity with validation for required fields
- Add CHEMBL_CELL_LINE_SCHEMA (PyArrow) for Silver layer
- Add CellLineTransformer with external ID normalization and tax_id validation
- Add ChEMBLCellLinePipeline inheriting from BasePipeline
- Add YAML config with load_strategy: full (reference data)
- Add 14 unit tests covering edge cases

Cell lines are biological objects for in vitro experiments with M:N relationship to Assay. Fields include cell_chembl_id (PK), cell_name, source tissue/organism/tax_id, and external IDs (Cellosaurus, LINCS, EFO).