### PR TITLE
Build document similarity matrix pipeline

### DIFF
--- a/configs/pipelines/chembl/document_similarity.yaml
+++ b/configs/pipelines/chembl/document_similarity.yaml
@@ -1,0 +1,89 @@
+# configs/pipelines/chembl/document_similarity.yaml
+# Конфигурация пайплайна для сущности Document Similarity из ChEMBL.
+#
+# Матрица попарного сходства документов. Используется для рекомендаций
+# и кластеризации публикаций.
+# Load strategy: full (O(N²) — очень большой объём, партиционирование).
+
+pipeline_name: chembl_document_similarity
+provider: chembl
+entity_type: document_similarity
+version: "1.0.0"
+description: "Extract document similarity matrix from ChEMBL API"
+
+# Composite Key: пара документов с нормализованным порядком (doc1 < doc2)
+primary_keys: ["document_1_chembl_id", "document_2_chembl_id"]
+silver_table: "chembl_document_similarity"
+
+# Ссылка на файл с конфигурацией источника данных
+source_file: ../../sources/chembl.yaml
+
+# Gold filters: все пары с хотя бы одним Tanimoto coefficient
+gold_filters:
+    required_fields: []  # Все пары проходят, mol_tani/tid_tani могут быть NULL
+
+transform:
+    version: "1.0.0"
+    steps:
+        - normalize_pair_order  # Нормализация: doc1 < doc2 лексикографически
+        - normalize_values
+        - add_metadata
+        - calculate_content_hash
+
+sink:
+    bronze:
+        path: "data/output/bronze"
+        format: jsonl
+        save_json: true
+        deterministic: true
+
+    silver:
+        path: "data/output/silver"
+        format: delta
+        mode: merge
+        on_schema_mismatch: evolve
+        # Composite primary key для upsert
+        primary_key: ["document_1_chembl_id", "document_2_chembl_id"]
+        partition_by: []  # Партиционирование по первым символам doc1 ID опционально
+        classification: public
+        forensic_retention: true
+        deterministic: true
+        sort_by:
+            columns: ["document_1_chembl_id", "document_2_chembl_id"]
+            ascending: true
+        csv_export:
+            enabled: true
+            path: "data/output/csv/silver"
+            delimiter: ","
+            header: true
+            encoding: "utf-8"
+
+    gold:
+        enabled: true
+        validation:
+            strict: true
+        path: "data/output/gold"
+        format: delta
+        mode: overwrite
+        deterministic: true
+        sort_by:
+            columns: ["document_1_chembl_id", "document_2_chembl_id"]
+            ascending: true
+        csv_export:
+            enabled: true
+            path: "data/output/csv/gold"
+            delimiter: ","
+            header: true
+            encoding: "utf-8"
+
+dq_rules:
+    soft_fail_threshold: 0.05
+    hard_fail_threshold: 0.20
+
+circuit_breaker:
+    failure_threshold: 5
+    recovery_timeout: 300
+
+# Input filter configuration (for CSV-based ID filtering)
+input_filter:
+    enabled: false  # Document similarity обычно загружается полностью

--- a/src/bioetl/application/pipelines/chembl/__init__.py
+++ b/src/bioetl/application/pipelines/chembl/__init__.py
@@ -20,6 +20,12 @@ from bioetl.application.pipelines.chembl.cell_line_transformer import (
     CellLineTransformer,
 )
 from bioetl.application.pipelines.chembl.document import ChEMBLDocumentPipeline
+from bioetl.application.pipelines.chembl.document_similarity import (
+    ChEMBLDocumentSimilarityPipeline,
+)
+from bioetl.application.pipelines.chembl.document_similarity_transformer import (
+    DocumentSimilarityTransformer,
+)
 from bioetl.application.pipelines.chembl.document_transformer import (
     DocumentTransformer,
 )
@@ -45,9 +51,11 @@ __all__ = [
     "ChEMBLAssayPipeline",
     "ChEMBLCellLinePipeline",
     "ChEMBLDocumentPipeline",
+    "ChEMBLDocumentSimilarityPipeline",
     "ChEMBLMoleculePipeline",
     "ChEMBLTargetComponentPipeline",
     "ChEMBLTargetPipeline",
+    "DocumentSimilarityTransformer",
     "DocumentTransformer",
     "MoleculeTransformer",
     "TargetComponentTransformer",

--- a/src/bioetl/application/pipelines/chembl/document_similarity.py
+++ b/src/bioetl/application/pipelines/chembl/document_similarity.py
@@ -1,0 +1,30 @@
+"""ChEMBL Document Similarity Pipeline.
+
+Fetches document similarity matrix from ChEMBL database and processes through
+Bronze → Silver → Gold layers.
+
+Entity: Document Similarity (pairwise similarity between documents)
+Provider: ChEMBL (https://www.ebi.ac.uk/chembl/)
+
+Transformer is injected via DI from GenericPipelineFactory (REQ-ARCH-DI-007).
+"""
+
+from __future__ import annotations
+
+from bioetl.application.core.base import BasePipeline
+
+
+class ChEMBLDocumentSimilarityPipeline(BasePipeline):
+    """Pipeline for ChEMBL document similarity data.
+
+    Pairwise similarity matrix for documents. Used for recommendations
+    and publication clustering.
+
+    Composite Key: (document_1_chembl_id, document_2_chembl_id)
+    Normalized: doc1 < doc2 lexicographically (upper triangle only).
+
+    Transformer is injected via DI from GenericPipelineFactory.
+    """
+
+    # transform_bronze_to_silver() is inherited from BasePipeline
+    # should_write_gold() is inherited from BasePipeline (uses config.gold_filters)

--- a/src/bioetl/application/pipelines/chembl/document_similarity_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/document_similarity_transformer.py
@@ -1,0 +1,185 @@
+"""ChEMBL Document Similarity Transformer.
+
+Transforms Bronze records to Silver format (DocumentSimilarity entity inflation).
+Handles composite key normalization (doc1 < doc2 lexicographically).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Any, cast
+
+from bioetl.application.core.base_transformer import BaseTransformer
+from bioetl.domain.entities import DocumentSimilarity
+from bioetl.domain.types import EntityID
+
+if TYPE_CHECKING:
+    from bioetl.domain.context import PipelineContext
+    from bioetl.domain.filtering import GoldFilterConfig
+    from bioetl.domain.ports import MetricsPort, TracingPort
+    from bioetl.domain.types import BronzeRecord, SilverRecord
+
+
+class DocumentSimilarityTransformer(BaseTransformer):
+    """Transforms ChEMBL bronze document similarity records to silver.
+
+    Handles:
+    - Composite key normalization (doc1 < doc2 lexicographically)
+    - Tanimoto coefficient validation ([0, 1] range)
+    - Content hash generation for deduplication
+    """
+
+    def __init__(
+        self,
+        provider: str = "chembl",
+        tracer: TracingPort | None = None,
+        metrics: MetricsPort | None = None,
+        gold_filters: GoldFilterConfig | None = None,
+    ) -> None:
+        """Initialize DocumentSimilarity transformer.
+
+        Args:
+            provider: Data provider identifier. Defaults to 'chembl'.
+            tracer: Optional tracing port for distributed tracing.
+            metrics: Optional metrics port for duration/error tracking.
+            gold_filters: Optional filter configuration for Gold layer.
+
+        """
+        super().__init__(
+            provider, tracer=tracer, metrics=metrics, gold_filters=gold_filters
+        )
+
+    def _normalize_pair(self, doc1: str, doc2: str) -> tuple[str, str]:
+        """Normalize document pair to ensure doc1 < doc2 lexicographically.
+
+        This ensures deterministic storage of the symmetric similarity matrix
+        (only upper triangle is stored).
+
+        Args:
+            doc1: First document ChEMBL ID.
+            doc2: Second document ChEMBL ID.
+
+        Returns:
+            Tuple (smaller_id, larger_id) in lexicographic order.
+
+        """
+        if doc1 <= doc2:
+            return (doc1, doc2)
+        return (doc2, doc1)
+
+    def _validate_tanimoto(self, value: Any) -> float | None:
+        """Validate and normalize Tanimoto coefficient.
+
+        Tanimoto similarity must be in [0, 1] range.
+        NaN/Inf values are converted to None.
+
+        Args:
+            value: Raw Tanimoto value from API.
+
+        Returns:
+            Valid Tanimoto coefficient or None if invalid/missing.
+
+        """
+        if value is None:
+            return None
+        try:
+            float_val = float(value)
+            # Handle NaN/Inf as NULL
+            if math.isnan(float_val) or math.isinf(float_val):
+                return None
+            # Validate range [0, 1]
+            if float_val < 0 or float_val > 1:
+                return None
+            # Round to 10 decimal places for determinism
+            return round(float_val, 10)
+        except (ValueError, TypeError):
+            return None
+
+    def _generate_composite_entity_id(self, doc1: str, doc2: str) -> EntityID:
+        """Generate entity ID for composite key.
+
+        Format: chembl:{doc1}_{doc2}
+
+        Args:
+            doc1: Normalized document 1 ChEMBL ID (smaller).
+            doc2: Normalized document 2 ChEMBL ID (larger).
+
+        Returns:
+            EntityID in format 'chembl:CHEMBL1_CHEMBL2'.
+
+        """
+        return EntityID(f"{self.provider}:{doc1}_{doc2}")
+
+    async def _transform_impl(
+        self,
+        context: PipelineContext,
+        record: BronzeRecord,
+        index: int,
+    ) -> SilverRecord | None:
+        """Transform document similarity bronze record to silver.
+
+        Steps:
+        1. Extract and validate document ChEMBL IDs
+        2. Normalize pair order (doc1 < doc2)
+        3. Skip self-similarity (doc1 == doc2)
+        4. Validate Tanimoto coefficients
+        5. Generate entity_id and content_hash
+        6. Create domain entity and convert to SilverRecord
+
+        Args:
+            context: Pipeline context with run_id, run_type, logger.
+            record: Raw Bronze record from ChEMBL API.
+            index: Sequential index of the record in the pipeline run.
+
+        Returns:
+            SilverRecord if transformation successful, None if skipped.
+
+        """
+        # 1. Extract document IDs
+        doc1_raw = record.get("document_1_chembl_id")
+        doc2_raw = record.get("document_2_chembl_id")
+
+        if not doc1_raw or not doc2_raw:
+            return None
+
+        doc1_str = str(doc1_raw).strip()
+        doc2_str = str(doc2_raw).strip()
+
+        if not doc1_str or not doc2_str:
+            return None
+
+        # 2. Normalize pair order
+        doc1_normalized, doc2_normalized = self._normalize_pair(doc1_str, doc2_str)
+
+        # 3. Skip self-similarity
+        if doc1_normalized == doc2_normalized:
+            return None
+
+        # 4. Validate and normalize Tanimoto coefficients
+        mol_tani = self._validate_tanimoto(record.get("mol_tani"))
+        tid_tani = self._validate_tanimoto(record.get("tid_tani"))
+
+        # 5. Prepare business data for content hash
+        business_data = {
+            "document_1_chembl_id": doc1_normalized,
+            "document_2_chembl_id": doc2_normalized,
+            "mol_tani": mol_tani,
+            "tid_tani": tid_tani,
+        }
+
+        # 6. Generate entity ID and content hash
+        entity_id = self._generate_composite_entity_id(doc1_normalized, doc2_normalized)
+        content_hash = self.compute_content_hash(business_data, exclude_none=True)
+
+        # 7. Create domain entity
+        entity = self._create_entity(
+            DocumentSimilarity,
+            context,
+            entity_id=entity_id,
+            content_hash=content_hash,
+            index=index,
+            **business_data,
+        )
+
+        # 8. Convert to SilverRecord
+        return cast("SilverRecord", self.entity_to_silver_record(entity))

--- a/src/bioetl/composition/factories/pipeline_factories.py
+++ b/src/bioetl/composition/factories/pipeline_factories.py
@@ -33,7 +33,17 @@ from bioetl.application.pipelines.chembl.activity import ChEMBLActivityPipeline
 from bioetl.application.pipelines.chembl.activity_transformer import ActivityTransformer
 from bioetl.application.pipelines.chembl.assay import ChEMBLAssayPipeline
 from bioetl.application.pipelines.chembl.assay_transformer import AssayTransformer
+from bioetl.application.pipelines.chembl.cell_line import ChEMBLCellLinePipeline
+from bioetl.application.pipelines.chembl.cell_line_transformer import (
+    CellLineTransformer,
+)
 from bioetl.application.pipelines.chembl.document import ChEMBLDocumentPipeline
+from bioetl.application.pipelines.chembl.document_similarity import (
+    ChEMBLDocumentSimilarityPipeline,
+)
+from bioetl.application.pipelines.chembl.document_similarity_transformer import (
+    DocumentSimilarityTransformer,
+)
 from bioetl.application.pipelines.chembl.document_transformer import DocumentTransformer
 from bioetl.application.pipelines.chembl.molecule import ChEMBLMoleculePipeline
 from bioetl.application.pipelines.chembl.molecule_transformer import MoleculeTransformer
@@ -56,7 +66,9 @@ from bioetl.composition.registry import PipelineRegistry, get_default_registry
 from bioetl.infrastructure.schemas.gold import (
     ChEMBLActivityGoldSchema,
     ChEMBLAssayGoldSchema,
+    ChEMBLCellLineGoldSchema,
     ChEMBLDocumentGoldSchema,
+    ChEMBLDocumentSimilarityGoldSchema,
     ChEMBLMoleculeGoldSchema,
     ChEMBLTargetComponentGoldSchema,
     ChEMBLTargetGoldSchema,
@@ -67,7 +79,9 @@ from bioetl.infrastructure.schemas.gold import (
 from bioetl.infrastructure.schemas.silver import (
     CHEMBL_ACTIVITY_SCHEMA,
     CHEMBL_ASSAY_SCHEMA,
+    CHEMBL_CELL_LINE_SCHEMA,
     CHEMBL_DOCUMENT_SCHEMA,
+    CHEMBL_DOCUMENT_SIMILARITY_SCHEMA,
     CHEMBL_MOLECULE_SCHEMA,
     CHEMBL_TARGET_COMPONENT_SCHEMA,
     CHEMBL_TARGET_SCHEMA,
@@ -103,6 +117,16 @@ chembl_assay_factory = GenericPipelineFactory(
     transformer_class=AssayTransformer,
 )
 
+# ChEMBL Cell Line Pipeline
+chembl_cell_line_factory = GenericPipelineFactory(
+    pipeline_name="chembl_cell_line",
+    pipeline_class=ChEMBLCellLinePipeline,
+    provider="chembl",
+    silver_schema=CHEMBL_CELL_LINE_SCHEMA,
+    gold_schema=ChEMBLCellLineGoldSchema,
+    transformer_class=CellLineTransformer,
+)
+
 # ChEMBL Document Pipeline
 chembl_document_factory = GenericPipelineFactory(
     pipeline_name="chembl_document",
@@ -111,6 +135,16 @@ chembl_document_factory = GenericPipelineFactory(
     silver_schema=CHEMBL_DOCUMENT_SCHEMA,
     gold_schema=ChEMBLDocumentGoldSchema,
     transformer_class=DocumentTransformer,
+)
+
+# ChEMBL Document Similarity Pipeline
+chembl_document_similarity_factory = GenericPipelineFactory(
+    pipeline_name="chembl_document_similarity",
+    pipeline_class=ChEMBLDocumentSimilarityPipeline,
+    provider="chembl",
+    silver_schema=CHEMBL_DOCUMENT_SIMILARITY_SCHEMA,
+    gold_schema=ChEMBLDocumentSimilarityGoldSchema,
+    transformer_class=DocumentSimilarityTransformer,
 )
 
 # ChEMBL Target Pipeline
@@ -226,7 +260,9 @@ def _register_factories_to(registry: PipelineRegistry) -> None:
     """
     registry.register_factory(chembl_activity_factory)
     registry.register_factory(chembl_assay_factory)
+    registry.register_factory(chembl_cell_line_factory)
     registry.register_factory(chembl_document_factory)
+    registry.register_factory(chembl_document_similarity_factory)
     registry.register_factory(chembl_target_factory)
     registry.register_factory(chembl_target_component_factory)
     registry.register_factory(chembl_molecule_factory)
@@ -265,7 +301,9 @@ def reset_registration() -> None:
 __all__ = [
     "chembl_activity_factory",
     "chembl_assay_factory",
+    "chembl_cell_line_factory",
     "chembl_document_factory",
+    "chembl_document_similarity_factory",
     "chembl_molecule_factory",
     "chembl_target_component_factory",
     "chembl_target_factory",

--- a/src/bioetl/domain/entities/__init__.py
+++ b/src/bioetl/domain/entities/__init__.py
@@ -25,6 +25,7 @@ from bioetl.domain.entities.chembl_activity import Activity, Assay
 from bioetl.domain.entities.chembl_structures import (
     CellLine,
     Document,
+    DocumentSimilarity,
     Molecule,
     Target,
     TargetComponent,
@@ -41,6 +42,7 @@ __all__ = [
     "CellLine",
     "Compound",
     "Document",
+    "DocumentSimilarity",
     "Molecule",
     "Protein",
     "Publication",

--- a/src/bioetl/domain/entities/chembl_structures.py
+++ b/src/bioetl/domain/entities/chembl_structures.py
@@ -1,6 +1,7 @@
 """ChEMBL structural domain entities.
 
-Contains Document, Target, TargetComponent, CellLine, and Molecule entities.
+Contains Document, DocumentSimilarity, Target, TargetComponent, CellLine,
+and Molecule entities.
 """
 
 from __future__ import annotations
@@ -53,6 +54,52 @@ class Document(BaseEntity):
             raise ValueError("Document ChEMBL ID is required")
         if self.year is not None and (self.year < 1800 or self.year > 2100):
             raise ValueError(f"Year must be between 1800-2100, got {self.year}")
+
+
+@dataclass(frozen=True, kw_only=True)
+class DocumentSimilarity(BaseEntity):
+    """Represents document similarity pair (ChEMBL Document Similarity).
+
+    Pairwise similarity matrix for documents. Used for recommendations
+    and publication clustering.
+
+    Contains all fields from ChEMBL document_similarity API endpoint.
+    See: https://www.ebi.ac.uk/chembl/api/data/document_similarity
+
+    Note: Pair is normalized so document_1_chembl_id < document_2_chembl_id
+    lexicographically for determinism and to store only upper triangle.
+    """
+
+    # Primary identifiers (composite key)
+    document_1_chembl_id: str
+    document_2_chembl_id: str
+
+    # Similarity metrics (Tanimoto coefficients in [0, 1])
+    mol_tani: float | None = None  # Tanimoto similarity (molecules)
+    tid_tani: float | None = None  # Tanimoto similarity (targets)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self._validate_invariants()
+
+    def _validate_invariants(self) -> None:
+        if not self.document_1_chembl_id:
+            raise ValueError("document_1_chembl_id is required")
+        if not self.document_2_chembl_id:
+            raise ValueError("document_2_chembl_id is required")
+        if self.document_1_chembl_id == self.document_2_chembl_id:
+            raise ValueError("Self-similarity not allowed: doc1 must differ from doc2")
+        # Validate normalized order
+        if self.document_1_chembl_id > self.document_2_chembl_id:
+            raise ValueError(
+                f"Pair must be normalized: {self.document_1_chembl_id} > "
+                f"{self.document_2_chembl_id}. Expected doc1 < doc2."
+            )
+        # Validate Tanimoto bounds [0, 1]
+        if self.mol_tani is not None and not (0 <= self.mol_tani <= 1):
+            raise ValueError(f"mol_tani must be in [0, 1], got {self.mol_tani}")
+        if self.tid_tani is not None and not (0 <= self.tid_tani <= 1):
+            raise ValueError(f"tid_tani must be in [0, 1], got {self.tid_tani}")
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/bioetl/domain/schemas/chembl/document_similarity.py
+++ b/src/bioetl/domain/schemas/chembl/document_similarity.py
@@ -1,6 +1,10 @@
 """Pandera schema for ChEMBL Document Similarity entity.
 
 Aligned with RULES.md v5.0 and ChEMBL 34 schema.
+See: https://www.ebi.ac.uk/chembl/api/data/document_similarity
+
+Note: Pair is normalized so document_1_chembl_id < document_2_chembl_id
+lexicographically for determinism (stores only upper triangle of matrix).
 """
 
 from __future__ import annotations
@@ -12,48 +16,41 @@ from bioetl.domain.schemas.base import ETLRecordSchema
 
 
 class DocumentSimilaritySchema(ETLRecordSchema):
-    """Document Similarity validation schema for Silver layer."""
+    """Document Similarity validation schema for Silver layer.
 
-    # === Primary Key ===
-    sim_id: Series[int] = pa.Field(nullable=False, description="Primary key.")
+    Pairwise similarity matrix for documents. Used for recommendations
+    and publication clustering.
+    """
 
-    # === Foreign Keys ===
-    doc_1: Series[int] = pa.Field(nullable=False, description="FK to document 1.")
-    doc_2: Series[int] = pa.Field(nullable=False, description="FK to document 2.")
-
-    # === Identifiers ===
-    pubmed_id1: Series[int] | None = pa.Field(nullable=True, description="PubMed ID 1.")
-    pubmed_id2: Series[int] | None = pa.Field(nullable=True, description="PubMed ID 2.")
-
-    # === Metrics ===
-    tid_tani: Series[float] | None = pa.Field(
-        nullable=True,
-        ge=0,
-        le=1,
-        description="Tanimoto coefficient (TID).",
+    # === Composite Primary Key ===
+    document_1_chembl_id: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^CHEMBL\d+$",
+        description="ChEMBL ID for document 1 (PK part 1, lexicographically smaller).",
     )
+    document_2_chembl_id: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^CHEMBL\d+$",
+        description="ChEMBL ID for document 2 (PK part 2, lexicographically larger).",
+    )
+
+    # === Similarity Metrics (Tanimoto coefficients) ===
     mol_tani: Series[float] | None = pa.Field(
         nullable=True,
         ge=0,
         le=1,
-        description="Tanimoto coefficient (MOL).",
+        description="Tanimoto similarity coefficient (molecules) in [0, 1].",
     )
-    avg_tani: Series[float] | None = pa.Field(
+    tid_tani: Series[float] | None = pa.Field(
         nullable=True,
         ge=0,
         le=1,
-        description="Average Tanimoto coefficient.",
-    )
-    max_tani: Series[float] | None = pa.Field(
-        nullable=True,
-        ge=0,
-        le=1,
-        description="Max Tanimoto coefficient.",
+        description="Tanimoto similarity coefficient (targets) in [0, 1].",
     )
 
     class Config:
         """Pandera configuration."""
 
         strict = True
-        ordered = True
+        ordered = False
         coerce = True

--- a/src/bioetl/infrastructure/schemas/gold.py
+++ b/src/bioetl/infrastructure/schemas/gold.py
@@ -356,6 +356,72 @@ class ChEMBLDocumentGoldSchema(pa.DataFrameModel):
         strict = True
 
 
+class ChEMBLDocumentSimilarityGoldSchema(pa.DataFrameModel):
+    """Schema for ChEMBL Document Similarity in Gold layer.
+
+    Pairwise similarity matrix for documents. Used for recommendations
+    and publication clustering.
+    """
+
+    entity_id: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(nullable=False)
+
+    # Composite primary key (normalized: doc1 < doc2 lexicographically)
+    document_1_chembl_id: Series[str] = pa.Field(nullable=False)
+    document_2_chembl_id: Series[str] = pa.Field(nullable=False)
+
+    # Similarity metrics (Tanimoto coefficients)
+    mol_tani: Series[float] = pa.Field(nullable=True, coerce=True)
+    tid_tani: Series[float] = pa.Field(nullable=True, coerce=True)
+
+    # Metadata
+    run_id: Series[str] = pa.Field(nullable=False, alias="_run_id")
+    run_type: Series[str] = pa.Field(nullable=False, alias="_run_type")
+    source_batch_id: Series[str] = pa.Field(nullable=True, alias="_source_batch_id")
+    ingestion_ts: Series[str] = pa.Field(nullable=False, alias="_ingestion_ts")
+    index: Series[int] = pa.Field(nullable=False, alias="_index")
+
+    class Config:
+        strict = True
+
+
+class ChEMBLCellLineGoldSchema(pa.DataFrameModel):
+    """Schema for ChEMBL Cell Line in Gold layer.
+
+    Cell lines are biological objects used for in vitro experiments.
+    """
+
+    entity_id: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(nullable=False)
+
+    # Primary identifier
+    cell_chembl_id: Series[str] = pa.Field(nullable=False)
+
+    # Core metadata
+    cell_name: Series[str] = pa.Field(nullable=False)
+    cell_description: Series[str] = pa.Field(nullable=True)
+
+    # Source information
+    cell_source_tissue: Series[str] = pa.Field(nullable=True)
+    cell_source_organism: Series[str] = pa.Field(nullable=True)
+    cell_source_tax_id: Series[float] = pa.Field(nullable=True, coerce=True)  # int64
+
+    # External identifiers
+    cellosaurus_id: Series[str] = pa.Field(nullable=True)
+    cl_lincs_id: Series[str] = pa.Field(nullable=True)
+    efo_id: Series[str] = pa.Field(nullable=True)
+
+    # Metadata
+    run_id: Series[str] = pa.Field(nullable=False, alias="_run_id")
+    run_type: Series[str] = pa.Field(nullable=False, alias="_run_type")
+    source_batch_id: Series[str] = pa.Field(nullable=True, alias="_source_batch_id")
+    ingestion_ts: Series[str] = pa.Field(nullable=False, alias="_ingestion_ts")
+    index: Series[int] = pa.Field(nullable=False, alias="_index")
+
+    class Config:
+        strict = True
+
+
 class ChEMBLMoleculeGoldSchema(pa.DataFrameModel):
     """Schema for ChEMBL Molecule in Gold layer."""
 

--- a/src/bioetl/infrastructure/schemas/silver.py
+++ b/src/bioetl/infrastructure/schemas/silver.py
@@ -379,6 +379,28 @@ CHEMBL_DOCUMENT_SCHEMA = pa.schema(
     ]
 )
 
+# Schema for ChEMBL Document Similarity
+# See: https://www.ebi.ac.uk/chembl/api/data/document_similarity
+CHEMBL_DOCUMENT_SIMILARITY_SCHEMA = pa.schema(
+    [
+        # System fields
+        pa.field("entity_id", pa.string()),
+        pa.field("content_hash", pa.string()),
+        # Composite primary key (normalized: doc1 < doc2 lexicographically)
+        pa.field("document_1_chembl_id", pa.string()),
+        pa.field("document_2_chembl_id", pa.string()),
+        # Similarity metrics (Tanimoto coefficients in [0, 1])
+        pa.field("mol_tani", pa.float64()),
+        pa.field("tid_tani", pa.float64()),
+        # Lineage metadata
+        pa.field("_run_id", pa.string()),
+        pa.field("_run_type", pa.string()),
+        pa.field("_source_batch_id", pa.string()),
+        pa.field("_ingestion_ts", pa.string()),
+        pa.field("_index", pa.int64()),
+    ]
+)
+
 # Schema for ChEMBL Molecule
 # See: https://www.ebi.ac.uk/chembl/api/data/molecule
 CHEMBL_MOLECULE_SCHEMA = pa.schema(

--- a/tests/unit/application/pipelines/test_document_similarity_transformer.py
+++ b/tests/unit/application/pipelines/test_document_similarity_transformer.py
@@ -1,0 +1,477 @@
+"""Unit tests for ChEMBL Document Similarity Transformer."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from bioetl.application.pipelines.chembl.document_similarity_transformer import (
+    DocumentSimilarityTransformer,
+)
+from bioetl.domain.context import PipelineContext
+from bioetl.domain.types import RunType
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock pipeline context."""
+    mock_logger = MagicMock()
+    mock_logger.bind = MagicMock(return_value=mock_logger)
+    mock_logger.warning = MagicMock()
+    return PipelineContext(
+        run_id=uuid4(),
+        run_type=RunType.INCREMENTAL,
+        logger=mock_logger,
+    )
+
+
+@pytest.mark.unit
+class TestDocumentSimilarityTransformer:
+    """Tests for DocumentSimilarityTransformer."""
+
+    @pytest.fixture
+    def transformer(self):
+        """Create DocumentSimilarityTransformer instance."""
+        return DocumentSimilarityTransformer(provider="chembl")
+
+    @pytest.mark.asyncio
+    async def test_transform_valid_record(self, transformer, mock_context):
+        """Test transformation of valid document similarity record."""
+        record = {
+            "document_1_chembl_id": "CHEMBL1001",
+            "document_2_chembl_id": "CHEMBL1002",
+            "mol_tani": 0.75,
+            "tid_tani": 0.85,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["document_1_chembl_id"] == "CHEMBL1001"
+        assert result["document_2_chembl_id"] == "CHEMBL1002"
+        assert result["mol_tani"] == 0.75
+        assert result["tid_tani"] == 0.85
+        assert "entity_id" in result
+        assert "content_hash" in result
+        assert "_run_id" in result
+
+    @pytest.mark.asyncio
+    async def test_transform_normalizes_pair_order(self, transformer, mock_context):
+        """Test that document pairs are normalized (doc1 < doc2)."""
+        record = {
+            "document_1_chembl_id": "CHEMBL2000",  # Larger
+            "document_2_chembl_id": "CHEMBL1000",  # Smaller
+            "mol_tani": 0.5,
+            "tid_tani": 0.6,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        # After normalization, doc1 should be the smaller one
+        assert result["document_1_chembl_id"] == "CHEMBL1000"
+        assert result["document_2_chembl_id"] == "CHEMBL2000"
+
+    @pytest.mark.asyncio
+    async def test_transform_skips_self_similarity(self, transformer, mock_context):
+        """Test that self-similarity records are skipped."""
+        record = {
+            "document_1_chembl_id": "CHEMBL1001",
+            "document_2_chembl_id": "CHEMBL1001",
+            "mol_tani": 1.0,
+            "tid_tani": 1.0,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_transform_missing_doc1_id(self, transformer, mock_context):
+        """Test transformation returns None when document_1_chembl_id is missing."""
+        record = {
+            "document_2_chembl_id": "CHEMBL1002",
+            "mol_tani": 0.5,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_transform_missing_doc2_id(self, transformer, mock_context):
+        """Test transformation returns None when document_2_chembl_id is missing."""
+        record = {
+            "document_1_chembl_id": "CHEMBL1001",
+            "mol_tani": 0.5,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_transform_minimal_record(self, transformer, mock_context):
+        """Test transformation with only document IDs."""
+        record = {
+            "document_1_chembl_id": "CHEMBL1001",
+            "document_2_chembl_id": "CHEMBL1002",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["document_1_chembl_id"] == "CHEMBL1001"
+        assert result["document_2_chembl_id"] == "CHEMBL1002"
+        assert result["mol_tani"] is None
+        assert result["tid_tani"] is None
+
+    @pytest.mark.asyncio
+    async def test_transform_with_nan_tanimoto(self, transformer, mock_context):
+        """Test that NaN Tanimoto values become None."""
+        record = {
+            "document_1_chembl_id": "CHEMBL1001",
+            "document_2_chembl_id": "CHEMBL1002",
+            "mol_tani": float("nan"),
+            "tid_tani": float("nan"),
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["mol_tani"] is None
+        assert result["tid_tani"] is None
+
+    @pytest.mark.asyncio
+    async def test_transform_with_inf_tanimoto(self, transformer, mock_context):
+        """Test that Inf Tanimoto values become None."""
+        record = {
+            "document_1_chembl_id": "CHEMBL1001",
+            "document_2_chembl_id": "CHEMBL1002",
+            "mol_tani": float("inf"),
+            "tid_tani": float("-inf"),
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["mol_tani"] is None
+        assert result["tid_tani"] is None
+
+    @pytest.mark.asyncio
+    async def test_transform_with_out_of_range_tanimoto(
+        self, transformer, mock_context
+    ):
+        """Test that out-of-range Tanimoto values become None."""
+        record = {
+            "document_1_chembl_id": "CHEMBL1001",
+            "document_2_chembl_id": "CHEMBL1002",
+            "mol_tani": 1.5,  # > 1
+            "tid_tani": -0.5,  # < 0
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["mol_tani"] is None
+        assert result["tid_tani"] is None
+
+    @pytest.mark.asyncio
+    async def test_transform_rounds_tanimoto_values(self, transformer, mock_context):
+        """Test that Tanimoto values are rounded to 10 decimals."""
+        record = {
+            "document_1_chembl_id": "CHEMBL1001",
+            "document_2_chembl_id": "CHEMBL1002",
+            "mol_tani": 0.123456789012345,
+            "tid_tani": 0.987654321098765,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["mol_tani"] == round(0.123456789012345, 10)
+        assert result["tid_tani"] == round(0.987654321098765, 10)
+
+    @pytest.mark.asyncio
+    async def test_transform_boundary_tanimoto_values(self, transformer, mock_context):
+        """Test that boundary Tanimoto values (0 and 1) are accepted."""
+        record = {
+            "document_1_chembl_id": "CHEMBL1001",
+            "document_2_chembl_id": "CHEMBL1002",
+            "mol_tani": 0.0,
+            "tid_tani": 1.0,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["mol_tani"] == 0.0
+        assert result["tid_tani"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_transform_with_whitespace_in_ids(self, transformer, mock_context):
+        """Test that document IDs are stripped of whitespace."""
+        record = {
+            "document_1_chembl_id": "  CHEMBL1001  ",
+            "document_2_chembl_id": "\tCHEMBL1002\n",
+            "mol_tani": 0.5,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["document_1_chembl_id"] == "CHEMBL1001"
+        assert result["document_2_chembl_id"] == "CHEMBL1002"
+
+    @pytest.mark.asyncio
+    async def test_transform_with_empty_string_ids(self, transformer, mock_context):
+        """Test that empty string IDs return None."""
+        record = {
+            "document_1_chembl_id": "",
+            "document_2_chembl_id": "CHEMBL1002",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_transform_with_string_tanimoto(self, transformer, mock_context):
+        """Test that string Tanimoto values are converted to float."""
+        record = {
+            "document_1_chembl_id": "CHEMBL1001",
+            "document_2_chembl_id": "CHEMBL1002",
+            "mol_tani": "0.75",
+            "tid_tani": "0.85",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["mol_tani"] == 0.75
+        assert result["tid_tani"] == 0.85
+
+    @pytest.mark.asyncio
+    async def test_transform_with_invalid_string_tanimoto(
+        self, transformer, mock_context
+    ):
+        """Test that invalid string Tanimoto values become None."""
+        record = {
+            "document_1_chembl_id": "CHEMBL1001",
+            "document_2_chembl_id": "CHEMBL1002",
+            "mol_tani": "not_a_number",
+            "tid_tani": "invalid",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["mol_tani"] is None
+        assert result["tid_tani"] is None
+
+    @pytest.mark.asyncio
+    async def test_transform_generates_composite_entity_id(
+        self, transformer, mock_context
+    ):
+        """Test that entity_id is generated with composite key format."""
+        record = {
+            "document_1_chembl_id": "CHEMBL1001",
+            "document_2_chembl_id": "CHEMBL1002",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["entity_id"] == "chembl:CHEMBL1001_CHEMBL1002"
+
+    @pytest.mark.asyncio
+    async def test_transform_generates_content_hash(self, transformer, mock_context):
+        """Test that content_hash is generated and is 64 hex characters."""
+        record = {
+            "document_1_chembl_id": "CHEMBL1001",
+            "document_2_chembl_id": "CHEMBL1002",
+            "mol_tani": 0.5,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert "content_hash" in result
+        assert len(result["content_hash"]) == 64
+        # Verify it's a valid hex string
+        int(result["content_hash"], 16)
+
+    @pytest.mark.asyncio
+    async def test_transform_includes_lineage_fields(self, transformer, mock_context):
+        """Test that all lineage fields are present."""
+        record = {
+            "document_1_chembl_id": "CHEMBL1001",
+            "document_2_chembl_id": "CHEMBL1002",
+        }
+
+        result = await transformer.transform(mock_context, record, index=5)
+
+        assert result is not None
+        assert "_run_id" in result
+        assert "_run_type" in result
+        assert "_source_batch_id" in result
+        assert "_ingestion_ts" in result
+        assert "_index" in result
+        assert result["_index"] == 5
+
+    @pytest.mark.asyncio
+    async def test_transform_custom_provider(self, mock_context):
+        """Test transformation with custom provider."""
+        transformer = DocumentSimilarityTransformer(provider="custom_provider")
+        record = {
+            "document_1_chembl_id": "DOC1",
+            "document_2_chembl_id": "DOC2",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["entity_id"] == "custom_provider:DOC1_DOC2"
+
+    @pytest.mark.asyncio
+    async def test_normalize_pair_preserves_already_ordered(self, transformer):
+        """Test that already ordered pairs are not changed."""
+        result = transformer._normalize_pair("CHEMBL1000", "CHEMBL2000")
+        assert result == ("CHEMBL1000", "CHEMBL2000")
+
+    @pytest.mark.asyncio
+    async def test_normalize_pair_swaps_unordered(self, transformer):
+        """Test that unordered pairs are swapped."""
+        result = transformer._normalize_pair("CHEMBL2000", "CHEMBL1000")
+        assert result == ("CHEMBL1000", "CHEMBL2000")
+
+    @pytest.mark.asyncio
+    async def test_validate_tanimoto_valid_values(self, transformer):
+        """Test validation of valid Tanimoto values."""
+        assert transformer._validate_tanimoto(0.0) == 0.0
+        assert transformer._validate_tanimoto(0.5) == 0.5
+        assert transformer._validate_tanimoto(1.0) == 1.0
+
+    @pytest.mark.asyncio
+    async def test_validate_tanimoto_none(self, transformer):
+        """Test validation of None Tanimoto value."""
+        assert transformer._validate_tanimoto(None) is None
+
+    @pytest.mark.asyncio
+    async def test_validate_tanimoto_invalid(self, transformer):
+        """Test validation of invalid Tanimoto values."""
+        assert transformer._validate_tanimoto(float("nan")) is None
+        assert transformer._validate_tanimoto(float("inf")) is None
+        assert transformer._validate_tanimoto(-0.1) is None
+        assert transformer._validate_tanimoto(1.1) is None
+
+
+@pytest.mark.unit
+class TestDocumentSimilarityEntity:
+    """Tests for DocumentSimilarity entity validation."""
+
+    @pytest.fixture
+    def base_entity_fields(self):
+        """Provide base entity required fields."""
+        from datetime import UTC, datetime
+
+        from bioetl.domain.types import RunType
+
+        return {
+            "run_id": uuid4(),
+            "run_type": RunType.INCREMENTAL,
+            "ingestion_ts": datetime.now(UTC),
+            "_index": 0,
+        }
+
+    def test_entity_valid_creation(self, base_entity_fields):
+        """Test creation of valid DocumentSimilarity entity."""
+        from bioetl.domain.entities import DocumentSimilarity
+
+        entity = DocumentSimilarity(
+            entity_id="chembl:CHEMBL1_CHEMBL2",
+            content_hash="a" * 64,
+            document_1_chembl_id="CHEMBL1",
+            document_2_chembl_id="CHEMBL2",
+            mol_tani=0.5,
+            tid_tani=0.7,
+            **base_entity_fields,
+        )
+
+        assert entity.document_1_chembl_id == "CHEMBL1"
+        assert entity.document_2_chembl_id == "CHEMBL2"
+        assert entity.mol_tani == 0.5
+        assert entity.tid_tani == 0.7
+
+    def test_entity_rejects_self_similarity(self, base_entity_fields):
+        """Test that self-similarity is rejected."""
+        from bioetl.domain.entities import DocumentSimilarity
+
+        with pytest.raises(ValueError, match="Self-similarity not allowed"):
+            DocumentSimilarity(
+                entity_id="chembl:CHEMBL1_CHEMBL1",
+                content_hash="a" * 64,
+                document_1_chembl_id="CHEMBL1",
+                document_2_chembl_id="CHEMBL1",
+                **base_entity_fields,
+            )
+
+    def test_entity_rejects_unnormalized_order(self, base_entity_fields):
+        """Test that unnormalized pair order is rejected."""
+        from bioetl.domain.entities import DocumentSimilarity
+
+        with pytest.raises(ValueError, match="Pair must be normalized"):
+            DocumentSimilarity(
+                entity_id="chembl:CHEMBL2_CHEMBL1",
+                content_hash="a" * 64,
+                document_1_chembl_id="CHEMBL2",
+                document_2_chembl_id="CHEMBL1",  # doc1 > doc2 is invalid
+                **base_entity_fields,
+            )
+
+    def test_entity_rejects_invalid_mol_tani(self, base_entity_fields):
+        """Test that invalid mol_tani values are rejected."""
+        from bioetl.domain.entities import DocumentSimilarity
+
+        with pytest.raises(ValueError, match="mol_tani must be in"):
+            DocumentSimilarity(
+                entity_id="chembl:CHEMBL1_CHEMBL2",
+                content_hash="a" * 64,
+                document_1_chembl_id="CHEMBL1",
+                document_2_chembl_id="CHEMBL2",
+                mol_tani=1.5,  # > 1 is invalid
+                **base_entity_fields,
+            )
+
+    def test_entity_rejects_invalid_tid_tani(self, base_entity_fields):
+        """Test that invalid tid_tani values are rejected."""
+        from bioetl.domain.entities import DocumentSimilarity
+
+        with pytest.raises(ValueError, match="tid_tani must be in"):
+            DocumentSimilarity(
+                entity_id="chembl:CHEMBL1_CHEMBL2",
+                content_hash="a" * 64,
+                document_1_chembl_id="CHEMBL1",
+                document_2_chembl_id="CHEMBL2",
+                tid_tani=-0.5,  # < 0 is invalid
+                **base_entity_fields,
+            )
+
+    def test_entity_allows_none_tanimoto(self, base_entity_fields):
+        """Test that None Tanimoto values are allowed."""
+        from bioetl.domain.entities import DocumentSimilarity
+
+        entity = DocumentSimilarity(
+            entity_id="chembl:CHEMBL1_CHEMBL2",
+            content_hash="a" * 64,
+            document_1_chembl_id="CHEMBL1",
+            document_2_chembl_id="CHEMBL2",
+            mol_tani=None,
+            tid_tani=None,
+            **base_entity_fields,
+        )
+
+        assert entity.mol_tani is None
+        assert entity.tid_tani is None


### PR DESCRIPTION
…y matrix

- Add DocumentSimilarity entity with composite key (doc1 < doc2 normalized)
- Implement DocumentSimilarityTransformer with pair normalization and Tanimoto validation
- Create pipeline config YAML with composite primary key
- Add Pandera domain schema with [0,1] range validation for Tanimoto coefficients
- Add Silver (PyArrow) and Gold (Pandera) infrastructure schemas
- Register document_similarity factory in pipeline_factories.py
- Add comprehensive unit tests for transformer and entity validation

Also completes cell_line pipeline registration:
- Add ChEMBLCellLineGoldSchema to infrastructure
- Register chembl_cell_line_factory in pipeline_factories.py