### PR TITLE
Add ChEMBL protein classification pipeline

### DIFF
--- a/configs/pipelines/chembl/protein_classification.yaml
+++ b/configs/pipelines/chembl/protein_classification.yaml
@@ -1,0 +1,92 @@
+# configs/pipelines/chembl/protein_classification.yaml
+# Конфигурация пайплайна для сущности Protein Classification из ChEMBL.
+#
+# Hierarchical protein classification (ChEMBL protein family tree).
+# Reference data for target classification.
+# Load strategy: full (reference data, rarely changes).
+
+pipeline_name: chembl_protein_classification
+provider: chembl
+entity_type: protein_classification
+version: "1.0.0"
+description: "Extract protein classification hierarchy from ChEMBL API"
+
+primary_keys: ["protein_class_id"]
+silver_table: "chembl_protein_classification"
+
+# Ссылка на файл с конфигурацией источника данных
+source_file: ../../sources/chembl.yaml
+
+# Gold filters: all classifications with required metadata
+gold_filters:
+    required_fields:
+        - pref_name
+        - class_level
+
+transform:
+    version: "1.0.0"
+    steps:
+        - normalize_values
+        - add_metadata
+        - calculate_content_hash
+
+sink:
+    bronze:
+        path: "data/output/bronze"
+        format: jsonl
+        save_json: true
+        deterministic: true
+
+    silver:
+        path: "data/output/silver"
+        format: delta
+        mode: merge
+        on_schema_mismatch: evolve  # Allow schema evolution for _index field
+        primary_key: [ "protein_class_id" ]
+        partition_by: []
+        classification: public
+        forensic_retention: true
+        deterministic: true
+        sort_by:
+            columns: [ "protein_class_id" ]
+            ascending: true
+        csv_export:
+            enabled: true
+            path: "data/output/csv/silver"
+            delimiter: ","
+            header: true
+            encoding: "utf-8"
+
+    gold:
+        enabled: true
+        validation:
+            strict: true
+        path: "data/output/gold"
+        format: delta
+        mode: overwrite
+        deterministic: true
+        sort_by:
+            columns: [ "protein_class_id", "class_level" ]
+            ascending: true
+        csv_export:
+            enabled: true
+            path: "data/output/csv/gold"
+            delimiter: ","
+            header: true
+            encoding: "utf-8"
+
+dq_rules:
+    soft_fail_threshold: 0.05
+    hard_fail_threshold: 0.20
+
+circuit_breaker:
+    failure_threshold: 5
+    recovery_timeout: 300
+
+# Input filter configuration (for CSV-based ID filtering)
+input_filter:
+    enabled: true
+    source_path: "data/input/protein_classification.csv"
+    column_name: "protein_class_id"
+    filter_field: "protein_class_id"
+    batch_size: 20

--- a/src/bioetl/application/pipelines/chembl/__init__.py
+++ b/src/bioetl/application/pipelines/chembl/__init__.py
@@ -27,6 +27,12 @@ from bioetl.application.pipelines.chembl.molecule import ChEMBLMoleculePipeline
 from bioetl.application.pipelines.chembl.molecule_transformer import (
     MoleculeTransformer,
 )
+from bioetl.application.pipelines.chembl.protein_classification import (
+    ChEMBLProteinClassificationPipeline,
+)
+from bioetl.application.pipelines.chembl.protein_classification_transformer import (
+    ProteinClassificationTransformer,
+)
 from bioetl.application.pipelines.chembl.target import ChEMBLTargetPipeline
 from bioetl.application.pipelines.chembl.target_component import (
     ChEMBLTargetComponentPipeline,
@@ -46,10 +52,12 @@ __all__ = [
     "ChEMBLCellLinePipeline",
     "ChEMBLDocumentPipeline",
     "ChEMBLMoleculePipeline",
+    "ChEMBLProteinClassificationPipeline",
     "ChEMBLTargetComponentPipeline",
     "ChEMBLTargetPipeline",
     "DocumentTransformer",
     "MoleculeTransformer",
+    "ProteinClassificationTransformer",
     "TargetComponentTransformer",
     "TargetTransformer",
 ]

--- a/src/bioetl/application/pipelines/chembl/protein_classification.py
+++ b/src/bioetl/application/pipelines/chembl/protein_classification.py
@@ -1,0 +1,28 @@
+"""ChEMBL Protein Classification Pipeline.
+
+Fetches protein classification hierarchy from ChEMBL database and processes through
+Bronze -> Silver -> Gold layers.
+
+Entity: Protein Classification (hierarchical protein family tree)
+Provider: ChEMBL (https://www.ebi.ac.uk/chembl/)
+
+Transformer is injected via DI from GenericPipelineFactory (REQ-ARCH-DI-007).
+"""
+
+from __future__ import annotations
+
+from bioetl.application.core.base import BasePipeline
+
+
+class ChEMBLProteinClassificationPipeline(BasePipeline):
+    """Pipeline for ChEMBL protein classification data.
+
+    Protein classifications form a hierarchical tree (ChEMBL protein family tree).
+    They are reference data (~10K records) used for target classification.
+    Self-referential hierarchy via parent_id FK.
+
+    Transformer is injected via DI from GenericPipelineFactory.
+    """
+
+    # transform_bronze_to_silver() is inherited from BasePipeline
+    # should_write_gold() is inherited from BasePipeline (uses config.gold_filters)

--- a/src/bioetl/application/pipelines/chembl/protein_classification_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/protein_classification_transformer.py
@@ -1,0 +1,104 @@
+"""ChEMBL Protein Classification Transformer.
+
+Transforms Bronze records to Silver format (ProteinClassification entity inflation).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from bioetl.application.pipelines.chembl.base_chembl_transformer import (
+    BaseChemblTransformer,
+)
+from bioetl.domain.entities import ProteinClassification
+from bioetl.domain.transformations import safe_int
+
+if TYPE_CHECKING:
+    from bioetl.domain.types import BronzeRecord
+
+
+class ProteinClassificationTransformer(BaseChemblTransformer):
+    """Transforms ChEMBL bronze protein classification records to silver.
+
+    Protein classifications form a hierarchical tree (ChEMBL protein family tree).
+    They are reference data used for target classification and filtering.
+    Self-referential hierarchy via parent_id FK.
+    """
+
+    entity_class = ProteinClassification
+    primary_id_field = "protein_class_id"
+
+    def _normalize_text(self, value: Any) -> str | None:
+        """Normalize text field by stripping whitespace, NULL if empty.
+
+        Args:
+            value: Raw text value from API.
+
+        Returns:
+            Stripped string or None if empty/None.
+
+        """
+        if value is None:
+            return None
+        str_value = str(value).strip()
+        return str_value if str_value else None
+
+    def _validate_class_level(self, value: Any) -> int | None:
+        """Validate class level (must be 1-8 or NULL).
+
+        Args:
+            value: Raw class_level value from API.
+
+        Returns:
+            Valid class_level (1-8) or None.
+
+        """
+        level = safe_int(value)
+        if level is not None and not (1 <= level <= 8):
+            return None
+        return level
+
+    def _validate_parent_id(self, value: Any) -> int | None:
+        """Validate parent_id (must be > 0 or NULL).
+
+        Args:
+            value: Raw parent_id value from API.
+
+        Returns:
+            Valid parent_id (>= 1) or None.
+
+        """
+        parent_id = safe_int(value)
+        if parent_id is not None and parent_id < 1:
+            return None
+        return parent_id
+
+    def _extract_business_data(
+        self,
+        record: BronzeRecord,
+        primary_id: Any,
+    ) -> dict[str, Any]:
+        """Extract ProteinClassification business data from bronze record.
+
+        Args:
+            record: Raw Bronze record from ChEMBL API.
+            primary_id: Validated protein_class_id value.
+
+        Returns:
+            Dictionary of ProteinClassification business fields.
+
+        """
+        return {
+            # Primary identifier (convert to int)
+            "protein_class_id": safe_int(primary_id),
+            # Hierarchy information
+            "parent_id": self._validate_parent_id(record.get("parent_id")),
+            "class_level": self._validate_class_level(record.get("class_level")),
+            # Core metadata (with strip normalization)
+            "pref_name": self._normalize_text(record.get("pref_name")),
+            "short_name": self._normalize_text(record.get("short_name")),
+            "protein_class_desc": self._normalize_text(
+                record.get("protein_class_desc")
+            ),
+            "definition": self._normalize_text(record.get("definition")),
+        }

--- a/src/bioetl/composition/factories/pipeline_factories.py
+++ b/src/bioetl/composition/factories/pipeline_factories.py
@@ -33,10 +33,20 @@ from bioetl.application.pipelines.chembl.activity import ChEMBLActivityPipeline
 from bioetl.application.pipelines.chembl.activity_transformer import ActivityTransformer
 from bioetl.application.pipelines.chembl.assay import ChEMBLAssayPipeline
 from bioetl.application.pipelines.chembl.assay_transformer import AssayTransformer
+from bioetl.application.pipelines.chembl.cell_line import ChEMBLCellLinePipeline
+from bioetl.application.pipelines.chembl.cell_line_transformer import (
+    CellLineTransformer,
+)
 from bioetl.application.pipelines.chembl.document import ChEMBLDocumentPipeline
 from bioetl.application.pipelines.chembl.document_transformer import DocumentTransformer
 from bioetl.application.pipelines.chembl.molecule import ChEMBLMoleculePipeline
 from bioetl.application.pipelines.chembl.molecule_transformer import MoleculeTransformer
+from bioetl.application.pipelines.chembl.protein_classification import (
+    ChEMBLProteinClassificationPipeline,
+)
+from bioetl.application.pipelines.chembl.protein_classification_transformer import (
+    ProteinClassificationTransformer,
+)
 from bioetl.application.pipelines.chembl.target import ChEMBLTargetPipeline
 from bioetl.application.pipelines.chembl.target_component import (
     ChEMBLTargetComponentPipeline,
@@ -56,8 +66,10 @@ from bioetl.composition.registry import PipelineRegistry, get_default_registry
 from bioetl.infrastructure.schemas.gold import (
     ChEMBLActivityGoldSchema,
     ChEMBLAssayGoldSchema,
+    ChEMBLCellLineGoldSchema,
     ChEMBLDocumentGoldSchema,
     ChEMBLMoleculeGoldSchema,
+    ChEMBLProteinClassificationGoldSchema,
     ChEMBLTargetComponentGoldSchema,
     ChEMBLTargetGoldSchema,
     PubChemCompoundGoldSchema,
@@ -67,8 +79,10 @@ from bioetl.infrastructure.schemas.gold import (
 from bioetl.infrastructure.schemas.silver import (
     CHEMBL_ACTIVITY_SCHEMA,
     CHEMBL_ASSAY_SCHEMA,
+    CHEMBL_CELL_LINE_SCHEMA,
     CHEMBL_DOCUMENT_SCHEMA,
     CHEMBL_MOLECULE_SCHEMA,
+    CHEMBL_PROTEIN_CLASSIFICATION_SCHEMA,
     CHEMBL_TARGET_COMPONENT_SCHEMA,
     CHEMBL_TARGET_SCHEMA,
     PUBCHEM_COMPOUND_SCHEMA,
@@ -101,6 +115,16 @@ chembl_assay_factory = GenericPipelineFactory(
     silver_schema=CHEMBL_ASSAY_SCHEMA,
     gold_schema=ChEMBLAssayGoldSchema,
     transformer_class=AssayTransformer,
+)
+
+# ChEMBL Cell Line Pipeline
+chembl_cell_line_factory = GenericPipelineFactory(
+    pipeline_name="chembl_cell_line",
+    pipeline_class=ChEMBLCellLinePipeline,
+    provider="chembl",
+    silver_schema=CHEMBL_CELL_LINE_SCHEMA,
+    gold_schema=ChEMBLCellLineGoldSchema,
+    transformer_class=CellLineTransformer,
 )
 
 # ChEMBL Document Pipeline
@@ -141,6 +165,16 @@ chembl_molecule_factory = GenericPipelineFactory(
     silver_schema=CHEMBL_MOLECULE_SCHEMA,
     gold_schema=ChEMBLMoleculeGoldSchema,
     transformer_class=MoleculeTransformer,
+)
+
+# ChEMBL Protein Classification Pipeline
+chembl_protein_classification_factory = GenericPipelineFactory(
+    pipeline_name="chembl_protein_classification",
+    pipeline_class=ChEMBLProteinClassificationPipeline,
+    provider="chembl",
+    silver_schema=CHEMBL_PROTEIN_CLASSIFICATION_SCHEMA,
+    gold_schema=ChEMBLProteinClassificationGoldSchema,
+    transformer_class=ProteinClassificationTransformer,
 )
 
 # PubChem Compound Pipeline
@@ -226,10 +260,12 @@ def _register_factories_to(registry: PipelineRegistry) -> None:
     """
     registry.register_factory(chembl_activity_factory)
     registry.register_factory(chembl_assay_factory)
+    registry.register_factory(chembl_cell_line_factory)
     registry.register_factory(chembl_document_factory)
     registry.register_factory(chembl_target_factory)
     registry.register_factory(chembl_target_component_factory)
     registry.register_factory(chembl_molecule_factory)
+    registry.register_factory(chembl_protein_classification_factory)
     registry.register_factory(pubchem_compound_factory)
     registry.register_factory(uniprot_protein_factory)
     registry.register_factory(pubmed_publications_factory)
@@ -265,8 +301,10 @@ def reset_registration() -> None:
 __all__ = [
     "chembl_activity_factory",
     "chembl_assay_factory",
+    "chembl_cell_line_factory",
     "chembl_document_factory",
     "chembl_molecule_factory",
+    "chembl_protein_classification_factory",
     "chembl_target_component_factory",
     "chembl_target_factory",
     "is_registered",

--- a/src/bioetl/composition/factories/transformer_factory.py
+++ b/src/bioetl/composition/factories/transformer_factory.py
@@ -106,11 +106,17 @@ def register_all_transformers() -> None:
         ActivityTransformer,
     )
     from bioetl.application.pipelines.chembl.assay_transformer import AssayTransformer
+    from bioetl.application.pipelines.chembl.cell_line_transformer import (
+        CellLineTransformer,
+    )
     from bioetl.application.pipelines.chembl.document_transformer import (
         DocumentTransformer,
     )
     from bioetl.application.pipelines.chembl.molecule_transformer import (
         MoleculeTransformer,
+    )
+    from bioetl.application.pipelines.chembl.protein_classification_transformer import (
+        ProteinClassificationTransformer,
     )
     from bioetl.application.pipelines.chembl.target_component_transformer import (
         TargetComponentTransformer,
@@ -129,8 +135,10 @@ def register_all_transformers() -> None:
     # ChEMBL transformers
     register_transformer("chembl", "activity", ActivityTransformer)
     register_transformer("chembl", "assay", AssayTransformer)
+    register_transformer("chembl", "cell_line", CellLineTransformer)
     register_transformer("chembl", "document", DocumentTransformer)
     register_transformer("chembl", "molecule", MoleculeTransformer)
+    register_transformer("chembl", "protein_classification", ProteinClassificationTransformer)
     register_transformer("chembl", "target", TargetTransformer)
     register_transformer("chembl", "target_component", TargetComponentTransformer)
 

--- a/src/bioetl/domain/entities/__init__.py
+++ b/src/bioetl/domain/entities/__init__.py
@@ -26,6 +26,7 @@ from bioetl.domain.entities.chembl_structures import (
     CellLine,
     Document,
     Molecule,
+    ProteinClassification,
     Target,
     TargetComponent,
 )
@@ -43,6 +44,7 @@ __all__ = [
     "Document",
     "Molecule",
     "Protein",
+    "ProteinClassification",
     "Publication",
     "RequiredEntityFields",
     "Target",

--- a/src/bioetl/domain/entities/chembl_structures.py
+++ b/src/bioetl/domain/entities/chembl_structures.py
@@ -277,3 +277,44 @@ class Molecule(BaseEntity):
             raise ValueError("Molecule ChEMBL ID is required")
         if self.max_phase is not None and not (0 <= self.max_phase <= 4):
             raise ValueError(f"max_phase must be 0-4, got {self.max_phase}")
+
+
+@dataclass(frozen=True, kw_only=True)
+class ProteinClassification(BaseEntity):
+    """Represents a protein classification (ChEMBL Protein Classification).
+
+    Hierarchical classification of proteins (ChEMBL protein family tree).
+    Reference data used for target classification and filtering.
+
+    Contains all fields from ChEMBL protein_classification API endpoint.
+    See: https://www.ebi.ac.uk/chembl/api/data/protein_classification
+    """
+
+    # Primary identifier (REQUIRED)
+    protein_class_id: int
+
+    # Hierarchy information
+    parent_id: int | None = None  # FK to parent (NULL for root nodes)
+    class_level: int | None = None  # Level in hierarchy (1-8)
+
+    # Core metadata
+    pref_name: str | None = None  # Preferred name
+    short_name: str | None = None  # Short name
+    protein_class_desc: str | None = None  # Description
+    definition: str | None = None  # Definition of the class
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self._validate_invariants()
+
+    def _validate_invariants(self) -> None:
+        if not self.protein_class_id:
+            raise ValueError("Protein class ID is required")
+        if self.protein_class_id < 1:
+            raise ValueError(
+                f"protein_class_id must be >= 1, got {self.protein_class_id}"
+            )
+        if self.class_level is not None and not (1 <= self.class_level <= 8):
+            raise ValueError(f"class_level must be 1-8, got {self.class_level}")
+        if self.parent_id is not None and self.parent_id < 1:
+            raise ValueError(f"parent_id must be >= 1 if set, got {self.parent_id}")

--- a/src/bioetl/infrastructure/schemas/gold.py
+++ b/src/bioetl/infrastructure/schemas/gold.py
@@ -426,3 +426,69 @@ class ChEMBLMoleculeGoldSchema(pa.DataFrameModel):
 
     class Config:
         strict = True
+
+
+class ChEMBLCellLineGoldSchema(pa.DataFrameModel):
+    """Schema for ChEMBL Cell Line in Gold layer."""
+
+    # System fields
+    entity_id: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(nullable=False)
+
+    # Primary identifier
+    cell_chembl_id: Series[str] = pa.Field(nullable=False)
+
+    # Core metadata
+    cell_name: Series[str] = pa.Field(nullable=False)
+    cell_description: Series[str] = pa.Field(nullable=True)
+
+    # Source information
+    cell_source_tissue: Series[str] = pa.Field(nullable=True)
+    cell_source_organism: Series[str] = pa.Field(nullable=True)
+    cell_source_tax_id: Series[float] = pa.Field(nullable=True, coerce=True)  # int64
+
+    # External identifiers
+    cellosaurus_id: Series[str] = pa.Field(nullable=True)
+    cl_lincs_id: Series[str] = pa.Field(nullable=True)
+    efo_id: Series[str] = pa.Field(nullable=True)
+
+    # Metadata
+    run_id: Series[str] = pa.Field(nullable=False, alias="_run_id")
+    run_type: Series[str] = pa.Field(nullable=False, alias="_run_type")
+    source_batch_id: Series[str] = pa.Field(nullable=True, alias="_source_batch_id")
+    ingestion_ts: Series[str] = pa.Field(nullable=False, alias="_ingestion_ts")
+    index: Series[int] = pa.Field(nullable=False, alias="_index")
+
+    class Config:
+        strict = True
+
+
+class ChEMBLProteinClassificationGoldSchema(pa.DataFrameModel):
+    """Schema for ChEMBL Protein Classification in Gold layer."""
+
+    # System fields
+    entity_id: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(nullable=False)
+
+    # Primary identifier
+    protein_class_id: Series[float] = pa.Field(nullable=False, coerce=True)  # int64
+
+    # Hierarchy information
+    parent_id: Series[float] = pa.Field(nullable=True, coerce=True)  # int64
+    class_level: Series[float] = pa.Field(nullable=True, coerce=True)  # int64
+
+    # Core metadata
+    pref_name: Series[str] = pa.Field(nullable=True)
+    short_name: Series[str] = pa.Field(nullable=True)
+    protein_class_desc: Series[str] = pa.Field(nullable=True)
+    definition: Series[str] = pa.Field(nullable=True)
+
+    # Metadata
+    run_id: Series[str] = pa.Field(nullable=False, alias="_run_id")
+    run_type: Series[str] = pa.Field(nullable=False, alias="_run_type")
+    source_batch_id: Series[str] = pa.Field(nullable=True, alias="_source_batch_id")
+    ingestion_ts: Series[str] = pa.Field(nullable=False, alias="_ingestion_ts")
+    index: Series[int] = pa.Field(nullable=False, alias="_index")
+
+    class Config:
+        strict = True

--- a/src/bioetl/infrastructure/schemas/silver.py
+++ b/src/bioetl/infrastructure/schemas/silver.py
@@ -454,3 +454,29 @@ CHEMBL_MOLECULE_SCHEMA = pa.schema(
         pa.field("_index", pa.int64()),
     ]
 )
+
+# Schema for ChEMBL Protein Classification
+# See: https://www.ebi.ac.uk/chembl/api/data/protein_classification
+CHEMBL_PROTEIN_CLASSIFICATION_SCHEMA = pa.schema(
+    [
+        # System fields
+        pa.field("entity_id", pa.string()),
+        pa.field("content_hash", pa.string()),
+        # Primary identifier
+        pa.field("protein_class_id", pa.int64()),
+        # Hierarchy information
+        pa.field("parent_id", pa.int64()),
+        pa.field("class_level", pa.int64()),
+        # Core metadata
+        pa.field("pref_name", pa.string()),
+        pa.field("short_name", pa.string()),
+        pa.field("protein_class_desc", pa.string()),
+        pa.field("definition", pa.string()),
+        # Lineage metadata
+        pa.field("_run_id", pa.string()),
+        pa.field("_run_type", pa.string()),
+        pa.field("_source_batch_id", pa.string()),
+        pa.field("_ingestion_ts", pa.string()),
+        pa.field("_index", pa.int64()),
+    ]
+)

--- a/tests/unit/application/pipelines/test_protein_classification_transformer.py
+++ b/tests/unit/application/pipelines/test_protein_classification_transformer.py
@@ -1,0 +1,387 @@
+"""Unit tests for ChEMBL Protein Classification Transformer."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from bioetl.application.pipelines.chembl.protein_classification_transformer import (
+    ProteinClassificationTransformer,
+)
+from bioetl.domain.context import PipelineContext
+from bioetl.domain.types import RunType
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock pipeline context."""
+    mock_logger = MagicMock()
+    mock_logger.bind = MagicMock(return_value=mock_logger)
+    mock_logger.warning = MagicMock()
+    return PipelineContext(
+        run_id=uuid4(),
+        run_type=RunType.INCREMENTAL,
+        logger=mock_logger,
+    )
+
+
+@pytest.mark.unit
+class TestProteinClassificationTransformer:
+    """Tests for ProteinClassificationTransformer."""
+
+    @pytest.fixture
+    def transformer(self):
+        """Create ProteinClassificationTransformer instance."""
+        return ProteinClassificationTransformer(provider="chembl")
+
+    @pytest.mark.asyncio
+    async def test_transform_valid_record(self, transformer, mock_context):
+        """Test transformation of valid protein classification record."""
+        record = {
+            "protein_class_id": 1,
+            "parent_id": None,
+            "class_level": 1,
+            "pref_name": "Enzyme",
+            "short_name": "Enzyme",
+            "protein_class_desc": "Protein with catalytic activity",
+            "definition": "An enzyme is a protein that catalyzes reactions",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["protein_class_id"] == 1
+        assert result["parent_id"] is None
+        assert result["class_level"] == 1
+        assert result["pref_name"] == "Enzyme"
+        assert result["short_name"] == "Enzyme"
+        assert result["protein_class_desc"] == "Protein with catalytic activity"
+        assert result["definition"] == "An enzyme is a protein that catalyzes reactions"
+        assert "entity_id" in result
+        assert "content_hash" in result
+        assert "_run_id" in result
+
+    @pytest.mark.asyncio
+    async def test_transform_missing_protein_class_id(self, transformer, mock_context):
+        """Test transformation returns None when protein_class_id is missing."""
+        record = {
+            "pref_name": "Enzyme",
+            "class_level": 1,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_transform_minimal_record(self, transformer, mock_context):
+        """Test transformation with only required fields."""
+        record = {
+            "protein_class_id": 1,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["protein_class_id"] == 1
+        assert result["parent_id"] is None
+        assert result["class_level"] is None
+        assert result["pref_name"] is None
+        assert result["short_name"] is None
+        assert result["protein_class_desc"] is None
+        assert result["definition"] is None
+
+    @pytest.mark.asyncio
+    async def test_transform_with_parent_id(self, transformer, mock_context):
+        """Test transformation of child classification with parent_id."""
+        record = {
+            "protein_class_id": 100,
+            "parent_id": 1,
+            "class_level": 2,
+            "pref_name": "Kinase",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["protein_class_id"] == 100
+        assert result["parent_id"] == 1
+        assert result["class_level"] == 2
+        assert result["pref_name"] == "Kinase"
+
+    @pytest.mark.asyncio
+    async def test_transform_with_whitespace_in_pref_name(
+        self, transformer, mock_context
+    ):
+        """Test that pref_name is stripped of leading/trailing whitespace."""
+        record = {
+            "protein_class_id": 1,
+            "pref_name": "  Enzyme  ",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["pref_name"] == "Enzyme"
+
+    @pytest.mark.asyncio
+    async def test_transform_with_empty_text_fields(self, transformer, mock_context):
+        """Test that empty string text fields become None."""
+        record = {
+            "protein_class_id": 1,
+            "pref_name": "",
+            "short_name": "   ",
+            "protein_class_desc": None,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["pref_name"] is None
+        assert result["short_name"] is None
+        assert result["protein_class_desc"] is None
+
+    @pytest.mark.asyncio
+    async def test_transform_strips_text_whitespace(self, transformer, mock_context):
+        """Test that text fields are stripped of whitespace."""
+        record = {
+            "protein_class_id": 1,
+            "pref_name": "  Kinase  ",
+            "short_name": "\tKin\n",
+            "definition": "  A phosphorylating enzyme  ",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["pref_name"] == "Kinase"
+        assert result["short_name"] == "Kin"
+        assert result["definition"] == "A phosphorylating enzyme"
+
+    @pytest.mark.asyncio
+    async def test_transform_with_invalid_class_level_zero(
+        self, transformer, mock_context
+    ):
+        """Test that class_level of 0 becomes None (must be 1-8)."""
+        record = {
+            "protein_class_id": 1,
+            "class_level": 0,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["class_level"] is None
+
+    @pytest.mark.asyncio
+    async def test_transform_with_invalid_class_level_negative(
+        self, transformer, mock_context
+    ):
+        """Test that negative class_level becomes None (must be 1-8)."""
+        record = {
+            "protein_class_id": 1,
+            "class_level": -1,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["class_level"] is None
+
+    @pytest.mark.asyncio
+    async def test_transform_with_invalid_class_level_too_high(
+        self, transformer, mock_context
+    ):
+        """Test that class_level > 8 becomes None (must be 1-8)."""
+        record = {
+            "protein_class_id": 1,
+            "class_level": 9,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["class_level"] is None
+
+    @pytest.mark.asyncio
+    async def test_transform_with_valid_class_levels(self, transformer, mock_context):
+        """Test that valid class_levels 1-8 are preserved."""
+        for level in range(1, 9):
+            record = {
+                "protein_class_id": level,
+                "class_level": level,
+            }
+
+            result = await transformer.transform(mock_context, record, index=0)
+
+            assert result is not None
+            assert result["class_level"] == level
+
+    @pytest.mark.asyncio
+    async def test_transform_with_invalid_parent_id_zero(
+        self, transformer, mock_context
+    ):
+        """Test that parent_id of 0 becomes None (must be >= 1)."""
+        record = {
+            "protein_class_id": 1,
+            "parent_id": 0,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["parent_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_transform_with_negative_parent_id(self, transformer, mock_context):
+        """Test that negative parent_id becomes None (must be >= 1)."""
+        record = {
+            "protein_class_id": 1,
+            "parent_id": -1,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["parent_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_transform_with_valid_parent_id(self, transformer, mock_context):
+        """Test that valid parent_id is preserved."""
+        record = {
+            "protein_class_id": 100,
+            "parent_id": 1,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["parent_id"] == 1
+
+    @pytest.mark.asyncio
+    async def test_transform_with_class_level_as_string(
+        self, transformer, mock_context
+    ):
+        """Test that class_level as string is converted to int."""
+        record = {
+            "protein_class_id": 1,
+            "class_level": "3",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["class_level"] == 3
+
+    @pytest.mark.asyncio
+    async def test_transform_custom_provider(self, mock_context):
+        """Test transformation with custom provider."""
+        transformer = ProteinClassificationTransformer(provider="custom_provider")
+        record = {
+            "protein_class_id": 123,
+            "pref_name": "CustomClass",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert "entity_id" in result
+
+    @pytest.mark.asyncio
+    async def test_transform_generates_content_hash(self, transformer, mock_context):
+        """Test that content_hash is generated and is 64 hex characters."""
+        record = {
+            "protein_class_id": 1,
+            "pref_name": "Enzyme",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert "content_hash" in result
+        assert len(result["content_hash"]) == 64
+        # Verify it's a valid hex string
+        int(result["content_hash"], 16)
+
+    @pytest.mark.asyncio
+    async def test_transform_includes_lineage_fields(self, transformer, mock_context):
+        """Test that all lineage fields are present."""
+        record = {
+            "protein_class_id": 1,
+            "pref_name": "Enzyme",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert "_run_id" in result
+        assert "_run_type" in result
+        assert "_source_batch_id" in result
+        assert "_ingestion_ts" in result
+        assert "_index" in result
+        assert result["_index"] == 0
+
+    @pytest.mark.asyncio
+    async def test_transform_with_null_values(self, transformer, mock_context):
+        """Test transformation handles None values correctly."""
+        record = {
+            "protein_class_id": 1,
+            "parent_id": None,
+            "class_level": None,
+            "pref_name": None,
+            "short_name": None,
+            "protein_class_desc": None,
+            "definition": None,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["parent_id"] is None
+        assert result["class_level"] is None
+        assert result["pref_name"] is None
+        assert result["short_name"] is None
+        assert result["protein_class_desc"] is None
+        assert result["definition"] is None
+
+    @pytest.mark.asyncio
+    async def test_transform_root_node(self, transformer, mock_context):
+        """Test transformation of a root classification node (class_level=1, no parent)."""
+        record = {
+            "protein_class_id": 1,
+            "parent_id": None,
+            "class_level": 1,
+            "pref_name": "Protein",
+            "short_name": "Protein",
+            "definition": "A polypeptide chain of amino acids",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["protein_class_id"] == 1
+        assert result["parent_id"] is None
+        assert result["class_level"] == 1
+
+    @pytest.mark.asyncio
+    async def test_transform_leaf_node(self, transformer, mock_context):
+        """Test transformation of a leaf classification node (deep in hierarchy)."""
+        record = {
+            "protein_class_id": 12345,
+            "parent_id": 1234,
+            "class_level": 7,
+            "pref_name": "Tyrosine kinase receptor family member A",
+            "short_name": "TrkA",
+            "protein_class_desc": "Neurotrophic tyrosine kinase receptor",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["protein_class_id"] == 12345
+        assert result["parent_id"] == 1234
+        assert result["class_level"] == 7
+        assert result["pref_name"] == "Tyrosine kinase receptor family member A"
+        assert result["short_name"] == "TrkA"


### PR DESCRIPTION
…hierarchy

Implement a new pipeline for extracting hierarchical protein classification data from ChEMBL. This reference data (~10K records) is used for target classification and filtering.

Components added:
- ProteinClassification entity with hierarchy support (parent_id, class_level)
- ProteinClassificationTransformer with validation (class_level 1-8, parent_id > 0)
- Pipeline config with full load strategy
- Silver and Gold schemas
- 21 unit tests for transformer

Also fixed: registered chembl_cell_line factory from previous PR that was missing.