### PR TITLE
Build ChEMBL document term pipeline

### DIFF
--- a/configs/pipelines/chembl/document_term.yaml
+++ b/configs/pipelines/chembl/document_term.yaml
@@ -1,0 +1,95 @@
+# configs/pipelines/chembl/document_term.yaml
+# Конфигурация пайплайна для сущности Document Term из ChEMBL.
+#
+# Terms (keywords) extracted from documents. Bag-of-words representation
+# for text search with TF-IDF scoring.
+# Load strategy: full (batch load, large volume - many terms per document).
+
+pipeline_name: chembl_document_term
+provider: chembl
+entity_type: document_term
+version: "1.0.0"
+description: "Extract document terms from ChEMBL API"
+
+primary_keys: ["document_chembl_id", "term"]
+silver_table: "chembl_document_term"
+
+# Ссылка на файл с конфигурацией источника данных
+source_file: ../../sources/chembl.yaml
+
+# Gold filters: terms with valid frequency data
+gold_filters:
+    required_fields:
+        - term
+    ranges:
+        term_frequency:
+            min: 1
+            include_min: true
+
+transform:
+    version: "1.0.0"
+    steps:
+        - normalize_values
+        - add_metadata
+        - calculate_content_hash
+
+sink:
+    bronze:
+        path: "data/output/bronze"
+        format: jsonl
+        save_json: true
+        deterministic: true
+
+    silver:
+        path: "data/output/silver"
+        format: delta
+        mode: merge
+        on_schema_mismatch: evolve  # Allow schema evolution for _index field
+        primary_key: [ "document_chembl_id", "term" ]
+        partition_by: []
+        classification: public
+        forensic_retention: true
+        deterministic: true
+        sort_by:
+            columns: [ "document_chembl_id", "term" ]
+            ascending: true
+        csv_export:
+            enabled: true
+            path: "data/output/csv/silver"
+            delimiter: ","
+            header: true
+            encoding: "utf-8"
+
+    gold:
+        enabled: true
+        validation:
+            strict: true
+        path: "data/output/gold"
+        format: delta
+        mode: overwrite
+        deterministic: true
+        sort_by:
+            columns: [ "document_chembl_id", "term" ]
+            ascending: true
+        csv_export:
+            enabled: true
+            path: "data/output/csv/gold"
+            delimiter: ","
+            header: true
+            encoding: "utf-8"
+
+dq_rules:
+    soft_fail_threshold: 0.05
+    hard_fail_threshold: 0.20
+
+circuit_breaker:
+    failure_threshold: 5
+    recovery_timeout: 300
+
+# Input filter configuration (for CSV-based ID filtering)
+input_filter:
+    enabled: true
+    source_path: "data/input/document_term.csv"
+    column_name: "document_chembl_id"
+    filter_field: "document_chembl_id"
+    batch_size: 50

--- a/src/bioetl/application/pipelines/chembl/__init__.py
+++ b/src/bioetl/application/pipelines/chembl/__init__.py
@@ -20,6 +20,12 @@ from bioetl.application.pipelines.chembl.cell_line_transformer import (
     CellLineTransformer,
 )
 from bioetl.application.pipelines.chembl.document import ChEMBLDocumentPipeline
+from bioetl.application.pipelines.chembl.document_term import (
+    ChEMBLDocumentTermPipeline,
+)
+from bioetl.application.pipelines.chembl.document_term_transformer import (
+    DocumentTermTransformer,
+)
 from bioetl.application.pipelines.chembl.document_transformer import (
     DocumentTransformer,
 )
@@ -45,9 +51,11 @@ __all__ = [
     "ChEMBLAssayPipeline",
     "ChEMBLCellLinePipeline",
     "ChEMBLDocumentPipeline",
+    "ChEMBLDocumentTermPipeline",
     "ChEMBLMoleculePipeline",
     "ChEMBLTargetComponentPipeline",
     "ChEMBLTargetPipeline",
+    "DocumentTermTransformer",
     "DocumentTransformer",
     "MoleculeTransformer",
     "TargetComponentTransformer",

--- a/src/bioetl/application/pipelines/chembl/document_term.py
+++ b/src/bioetl/application/pipelines/chembl/document_term.py
@@ -1,0 +1,27 @@
+"""ChEMBL Document Term Pipeline.
+
+Fetches document terms from ChEMBL database and processes through
+Bronze -> Silver -> Gold layers.
+
+Entity: Document Terms (keywords extracted from documents for text search)
+Provider: ChEMBL (https://www.ebi.ac.uk/chembl/)
+
+Transformer is injected via DI from GenericPipelineFactory (REQ-ARCH-DI-007).
+"""
+
+from __future__ import annotations
+
+from bioetl.application.core.base import BasePipeline
+
+
+class ChEMBLDocumentTermPipeline(BasePipeline):
+    """Pipeline for ChEMBL document term data.
+
+    Document terms are keywords extracted from documents for text search.
+    They use a composite key of (document_chembl_id, term).
+
+    Transformer is injected via DI from GenericPipelineFactory.
+    """
+
+    # transform_bronze_to_silver() is inherited from BasePipeline
+    # should_write_gold() is inherited from BasePipeline (uses config.gold_filters)

--- a/src/bioetl/application/pipelines/chembl/document_term_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/document_term_transformer.py
@@ -1,0 +1,112 @@
+"""ChEMBL Document Term Transformer.
+
+Transforms Bronze records to Silver format (DocumentTerm entity inflation).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+from bioetl.application.pipelines.chembl.base_chembl_transformer import (
+    BaseChemblTransformer,
+)
+from bioetl.domain.entities import DocumentTerm
+from bioetl.domain.transformations import safe_float, safe_int
+
+if TYPE_CHECKING:
+    from bioetl.domain.types import BronzeRecord
+
+
+class DocumentTermTransformer(BaseChemblTransformer):
+    """Transforms ChEMBL bronze document term records to silver.
+
+    Document terms are keywords extracted from documents for text search.
+    They have a composite key of (document_chembl_id, term).
+    """
+
+    entity_class = DocumentTerm
+    primary_id_field = "document_chembl_id"
+
+    def _normalize_term(self, value: Any) -> str | None:
+        """Normalize term by stripping, lowercasing, and removing special chars.
+
+        Args:
+            value: Raw term value from API.
+
+        Returns:
+            Normalized term string or None if empty/None.
+
+        """
+        if value is None:
+            return None
+        str_value = str(value).strip().lower()
+        # Remove leading/trailing special characters but keep internal ones
+        str_value = re.sub(r"^[^\w]+|[^\w]+$", "", str_value)
+        return str_value if str_value else None
+
+    def _validate_frequency(self, value: Any) -> int | None:
+        """Validate frequency (must be >= 1 or NULL).
+
+        Args:
+            value: Raw frequency value from API.
+
+        Returns:
+            Valid frequency (>= 1) or None.
+
+        """
+        freq = safe_int(value)
+        if freq is not None and freq < 1:
+            return None
+        return freq
+
+    def _validate_score(self, value: Any) -> float | None:
+        """Validate score (must be >= 0 or NULL), round to 10 decimal places.
+
+        Args:
+            value: Raw score value from API.
+
+        Returns:
+            Valid score (>= 0) or None.
+
+        """
+        score = safe_float(value)
+        if score is not None:
+            if score < 0:
+                return None
+            # Round to 10 decimal places as per content hash normalization
+            return round(score, 10)
+        return None
+
+    def _extract_business_data(
+        self,
+        record: BronzeRecord,
+        primary_id: Any,
+    ) -> dict[str, Any]:
+        """Extract DocumentTerm business data from bronze record.
+
+        Args:
+            record: Raw Bronze record from ChEMBL API.
+            primary_id: Validated document_chembl_id value.
+
+        Returns:
+            Dictionary of DocumentTerm business fields.
+
+        """
+        # Get and normalize term
+        term = self._normalize_term(record.get("term"))
+
+        # If term is None after normalization, this record is invalid
+        # The entity will fail validation, which is the expected behavior
+        if term is None:
+            term = ""  # Will fail entity validation
+
+        return {
+            # Composite key fields
+            "document_chembl_id": str(primary_id),
+            "term": term,
+            # Frequency metrics
+            "term_frequency": self._validate_frequency(record.get("term_frequency")),
+            "doc_frequency": self._validate_frequency(record.get("doc_frequency")),
+            "score": self._validate_score(record.get("score")),
+        }

--- a/src/bioetl/composition/factories/pipeline_factories.py
+++ b/src/bioetl/composition/factories/pipeline_factories.py
@@ -34,6 +34,10 @@ from bioetl.application.pipelines.chembl.activity_transformer import ActivityTra
 from bioetl.application.pipelines.chembl.assay import ChEMBLAssayPipeline
 from bioetl.application.pipelines.chembl.assay_transformer import AssayTransformer
 from bioetl.application.pipelines.chembl.document import ChEMBLDocumentPipeline
+from bioetl.application.pipelines.chembl.document_term import ChEMBLDocumentTermPipeline
+from bioetl.application.pipelines.chembl.document_term_transformer import (
+    DocumentTermTransformer,
+)
 from bioetl.application.pipelines.chembl.document_transformer import DocumentTransformer
 from bioetl.application.pipelines.chembl.molecule import ChEMBLMoleculePipeline
 from bioetl.application.pipelines.chembl.molecule_transformer import MoleculeTransformer
@@ -57,6 +61,7 @@ from bioetl.infrastructure.schemas.gold import (
     ChEMBLActivityGoldSchema,
     ChEMBLAssayGoldSchema,
     ChEMBLDocumentGoldSchema,
+    ChEMBLDocumentTermGoldSchema,
     ChEMBLMoleculeGoldSchema,
     ChEMBLTargetComponentGoldSchema,
     ChEMBLTargetGoldSchema,
@@ -68,6 +73,7 @@ from bioetl.infrastructure.schemas.silver import (
     CHEMBL_ACTIVITY_SCHEMA,
     CHEMBL_ASSAY_SCHEMA,
     CHEMBL_DOCUMENT_SCHEMA,
+    CHEMBL_DOCUMENT_TERM_SCHEMA,
     CHEMBL_MOLECULE_SCHEMA,
     CHEMBL_TARGET_COMPONENT_SCHEMA,
     CHEMBL_TARGET_SCHEMA,
@@ -111,6 +117,16 @@ chembl_document_factory = GenericPipelineFactory(
     silver_schema=CHEMBL_DOCUMENT_SCHEMA,
     gold_schema=ChEMBLDocumentGoldSchema,
     transformer_class=DocumentTransformer,
+)
+
+# ChEMBL Document Term Pipeline
+chembl_document_term_factory = GenericPipelineFactory(
+    pipeline_name="chembl_document_term",
+    pipeline_class=ChEMBLDocumentTermPipeline,
+    provider="chembl",
+    silver_schema=CHEMBL_DOCUMENT_TERM_SCHEMA,
+    gold_schema=ChEMBLDocumentTermGoldSchema,
+    transformer_class=DocumentTermTransformer,
 )
 
 # ChEMBL Target Pipeline
@@ -227,6 +243,7 @@ def _register_factories_to(registry: PipelineRegistry) -> None:
     registry.register_factory(chembl_activity_factory)
     registry.register_factory(chembl_assay_factory)
     registry.register_factory(chembl_document_factory)
+    registry.register_factory(chembl_document_term_factory)
     registry.register_factory(chembl_target_factory)
     registry.register_factory(chembl_target_component_factory)
     registry.register_factory(chembl_molecule_factory)
@@ -266,6 +283,7 @@ __all__ = [
     "chembl_activity_factory",
     "chembl_assay_factory",
     "chembl_document_factory",
+    "chembl_document_term_factory",
     "chembl_molecule_factory",
     "chembl_target_component_factory",
     "chembl_target_factory",

--- a/src/bioetl/composition/factories/transformer_factory.py
+++ b/src/bioetl/composition/factories/transformer_factory.py
@@ -106,6 +106,9 @@ def register_all_transformers() -> None:
         ActivityTransformer,
     )
     from bioetl.application.pipelines.chembl.assay_transformer import AssayTransformer
+    from bioetl.application.pipelines.chembl.document_term_transformer import (
+        DocumentTermTransformer,
+    )
     from bioetl.application.pipelines.chembl.document_transformer import (
         DocumentTransformer,
     )
@@ -130,6 +133,7 @@ def register_all_transformers() -> None:
     register_transformer("chembl", "activity", ActivityTransformer)
     register_transformer("chembl", "assay", AssayTransformer)
     register_transformer("chembl", "document", DocumentTransformer)
+    register_transformer("chembl", "document_term", DocumentTermTransformer)
     register_transformer("chembl", "molecule", MoleculeTransformer)
     register_transformer("chembl", "target", TargetTransformer)
     register_transformer("chembl", "target_component", TargetComponentTransformer)

--- a/src/bioetl/domain/entities/__init__.py
+++ b/src/bioetl/domain/entities/__init__.py
@@ -25,6 +25,7 @@ from bioetl.domain.entities.chembl_activity import Activity, Assay
 from bioetl.domain.entities.chembl_structures import (
     CellLine,
     Document,
+    DocumentTerm,
     Molecule,
     Target,
     TargetComponent,
@@ -41,6 +42,7 @@ __all__ = [
     "CellLine",
     "Compound",
     "Document",
+    "DocumentTerm",
     "Molecule",
     "Protein",
     "Publication",

--- a/src/bioetl/domain/entities/chembl_structures.py
+++ b/src/bioetl/domain/entities/chembl_structures.py
@@ -187,6 +187,47 @@ class CellLine(BaseEntity):
 
 
 @dataclass(frozen=True, kw_only=True)
+class DocumentTerm(BaseEntity):
+    """Represents a document term (ChEMBL Document Term).
+
+    Terms (keywords) extracted from documents. Bag-of-words representation
+    for text search with TF-IDF scoring.
+
+    Contains all fields from ChEMBL document_term API endpoint.
+    See: https://www.ebi.ac.uk/chembl/api/data/document_term
+    """
+
+    # Composite key fields
+    document_chembl_id: str  # FK → document
+    term: str  # Term/keyword (normalized: lowercase, stripped)
+
+    # Frequency metrics (may be null)
+    term_frequency: int | None = None  # Frequency in this document
+    doc_frequency: int | None = None  # Number of documents containing term
+    score: float | None = None  # TF-IDF or similar score
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self._validate_invariants()
+
+    def _validate_invariants(self) -> None:
+        if not self.document_chembl_id:
+            raise ValueError("Document ChEMBL ID is required")
+        if not self.term:
+            raise ValueError("Term is required")
+        if self.term_frequency is not None and self.term_frequency < 1:
+            raise ValueError(
+                f"term_frequency must be >= 1, got {self.term_frequency}"
+            )
+        if self.doc_frequency is not None and self.doc_frequency < 1:
+            raise ValueError(
+                f"doc_frequency must be >= 1, got {self.doc_frequency}"
+            )
+        if self.score is not None and self.score < 0:
+            raise ValueError(f"score must be >= 0, got {self.score}")
+
+
+@dataclass(frozen=True, kw_only=True)
 class Molecule(BaseEntity):
     """Represents a chemical compound (ChEMBL Molecule).
 

--- a/src/bioetl/infrastructure/schemas/gold.py
+++ b/src/bioetl/infrastructure/schemas/gold.py
@@ -356,6 +356,30 @@ class ChEMBLDocumentGoldSchema(pa.DataFrameModel):
         strict = True
 
 
+class ChEMBLDocumentTermGoldSchema(pa.DataFrameModel):
+    """Schema for ChEMBL Document Term in Gold layer."""
+
+    entity_id: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(nullable=False)
+    # Composite key fields
+    document_chembl_id: Series[str] = pa.Field(nullable=False)
+    term: Series[str] = pa.Field(nullable=False)
+    # Frequency metrics
+    term_frequency: Series[float] = pa.Field(nullable=True, coerce=True)  # int64
+    doc_frequency: Series[float] = pa.Field(nullable=True, coerce=True)  # int64
+    score: Series[float] = pa.Field(nullable=True, coerce=True)
+
+    # Metadata
+    run_id: Series[str] = pa.Field(nullable=False, alias="_run_id")
+    run_type: Series[str] = pa.Field(nullable=False, alias="_run_type")
+    source_batch_id: Series[str] = pa.Field(nullable=True, alias="_source_batch_id")
+    ingestion_ts: Series[str] = pa.Field(nullable=False, alias="_ingestion_ts")
+    index: Series[int] = pa.Field(nullable=False, alias="_index")
+
+    class Config:
+        strict = True
+
+
 class ChEMBLMoleculeGoldSchema(pa.DataFrameModel):
     """Schema for ChEMBL Molecule in Gold layer."""
 

--- a/src/bioetl/infrastructure/schemas/silver.py
+++ b/src/bioetl/infrastructure/schemas/silver.py
@@ -379,6 +379,29 @@ CHEMBL_DOCUMENT_SCHEMA = pa.schema(
     ]
 )
 
+# Schema for ChEMBL Document Term
+# See: https://www.ebi.ac.uk/chembl/api/data/document_term
+CHEMBL_DOCUMENT_TERM_SCHEMA = pa.schema(
+    [
+        # System fields
+        pa.field("entity_id", pa.string()),
+        pa.field("content_hash", pa.string()),
+        # Composite key fields
+        pa.field("document_chembl_id", pa.string()),
+        pa.field("term", pa.string()),
+        # Frequency metrics
+        pa.field("term_frequency", pa.int64()),
+        pa.field("doc_frequency", pa.int64()),
+        pa.field("score", pa.float64()),
+        # Lineage metadata
+        pa.field("_run_id", pa.string()),
+        pa.field("_run_type", pa.string()),
+        pa.field("_source_batch_id", pa.string()),
+        pa.field("_ingestion_ts", pa.string()),
+        pa.field("_index", pa.int64()),
+    ]
+)
+
 # Schema for ChEMBL Molecule
 # See: https://www.ebi.ac.uk/chembl/api/data/molecule
 CHEMBL_MOLECULE_SCHEMA = pa.schema(

--- a/tests/unit/application/pipelines/test_chembl_transformers.py
+++ b/tests/unit/application/pipelines/test_chembl_transformers.py
@@ -8,6 +8,9 @@ from uuid import uuid4
 import pytest
 
 from bioetl.application.pipelines.chembl.assay_transformer import AssayTransformer
+from bioetl.application.pipelines.chembl.document_term_transformer import (
+    DocumentTermTransformer,
+)
 from bioetl.application.pipelines.chembl.document_transformer import DocumentTransformer
 from bioetl.application.pipelines.chembl.molecule_transformer import MoleculeTransformer
 from bioetl.application.pipelines.chembl.target_component_transformer import (
@@ -802,3 +805,140 @@ class TestTargetComponentTransformer:
         result_empty = await transformer.transform(mock_context, record_empty, index=0)
         assert result_empty is not None
         assert result_empty.get("protein_classification_ids") is None
+
+
+@pytest.mark.unit
+class TestDocumentTermTransformer:
+    """Tests for DocumentTermTransformer."""
+
+    @pytest.fixture
+    def transformer(self):
+        """Create DocumentTermTransformer instance."""
+        return DocumentTermTransformer(provider="chembl")
+
+    @pytest.mark.asyncio
+    async def test_transform_valid_record(self, transformer, mock_context):
+        """Test transformation of valid document term record."""
+        record = {
+            "document_chembl_id": "CHEMBL1234567",
+            "term": "KINASE",
+            "term_frequency": 10,
+            "doc_frequency": 100,
+            "score": 0.85,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["document_chembl_id"] == "CHEMBL1234567"
+        assert result["term"] == "kinase"  # Normalized to lowercase
+        assert result["term_frequency"] == 10
+        assert result["doc_frequency"] == 100
+        assert result["score"] == 0.85
+        assert "entity_id" in result
+        assert "content_hash" in result
+        assert "_run_id" in result
+
+    @pytest.mark.asyncio
+    async def test_transform_missing_document_id(self, transformer, mock_context):
+        """Test transformation returns None when document_chembl_id is missing."""
+        record = {
+            "term": "KINASE",
+            "term_frequency": 10,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_transform_term_normalization(self, transformer, mock_context):
+        """Test term normalization (lowercase, strip, remove special chars)."""
+        record = {
+            "document_chembl_id": "CHEMBL123",
+            "term": "  **Kinase-Inhibitor**  ",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        # Should be stripped, lowercased, leading/trailing special chars removed
+        assert result["term"] == "kinase-inhibitor"
+
+    @pytest.mark.asyncio
+    async def test_transform_frequency_validation(self, transformer, mock_context):
+        """Test frequency validation (must be >= 1 or NULL)."""
+        # Test with zero frequency (should become None)
+        record = {
+            "document_chembl_id": "CHEMBL123",
+            "term": "test",
+            "term_frequency": 0,
+            "doc_frequency": -1,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["term_frequency"] is None
+        assert result["doc_frequency"] is None
+
+    @pytest.mark.asyncio
+    async def test_transform_score_validation(self, transformer, mock_context):
+        """Test score validation (must be >= 0 or NULL)."""
+        # Test with negative score (should become None)
+        record = {
+            "document_chembl_id": "CHEMBL123",
+            "term": "test",
+            "score": -0.5,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["score"] is None
+
+    @pytest.mark.asyncio
+    async def test_transform_score_rounding(self, transformer, mock_context):
+        """Test score is rounded to 10 decimal places."""
+        record = {
+            "document_chembl_id": "CHEMBL123",
+            "term": "test",
+            "score": 0.123456789012345,  # More than 10 decimal places
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["score"] == round(0.123456789012345, 10)
+
+    @pytest.mark.asyncio
+    async def test_transform_with_null_frequency_fields(self, transformer, mock_context):
+        """Test transformation with null frequency fields."""
+        record = {
+            "document_chembl_id": "CHEMBL123",
+            "term": "test",
+            "term_frequency": None,
+            "doc_frequency": None,
+            "score": None,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["term_frequency"] is None
+        assert result["doc_frequency"] is None
+        assert result["score"] is None
+
+    @pytest.mark.asyncio
+    async def test_transform_custom_provider(self, mock_context):
+        """Test transformation with custom provider."""
+        transformer = DocumentTermTransformer(provider="custom_provider")
+        record = {
+            "document_chembl_id": "CUSTOM123",
+            "term": "test",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert "entity_id" in result


### PR DESCRIPTION
Add complete pipeline for extracting document terms (keywords) from ChEMBL documents with TF-IDF scoring support.

Components added:
- DocumentTerm domain entity with validation invariants
- DocumentTermTransformer with term normalization (lowercase, strip, special chars) and frequency/score validation
- ChEMBLDocumentTermPipeline class
- Silver/Gold schemas (CHEMBL_DOCUMENT_TERM_SCHEMA, ChEMBLDocumentTermGoldSchema)
- YAML configuration (document_term.yaml)
- Factory registration in pipeline_factories.py and transformer_factory.py
- 8 unit tests for transformer covering:
  - Valid record transformation
  - Missing document_chembl_id handling
  - Term normalization (lowercase, strip, special chars)
  - Frequency validation (>= 1 or NULL)
  - Score validation (>= 0 or NULL) with rounding
  - Null frequency fields handling
  - Custom provider support

The pipeline uses composite key (document_chembl_id, term) for entity identification and supports input filtering by document IDs.