### PR TITLE
Implement Hexagonal Architecture for BioETL project

### DIFF
--- a/src/bioetl/composition/factories/services_factory.py
+++ b/src/bioetl/composition/factories/services_factory.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any
 
 from bioetl.application.core.checkpoint_manager import CheckpointManager
 from bioetl.application.core.config import RecordProcessorConfig
@@ -72,12 +72,6 @@ __all__ = [
     "ServicesBuilder",
     "build_runner_services",
 ]
-
-
-class DataSourceFactoryProtocol(Protocol):
-    """Protocol for data source creation."""
-
-    def create(self, settings: Settings, logger: LoggerPort) -> DataSourcePort: ...
 
 
 # =============================================================================

--- a/src/bioetl/domain/ports/noop.py
+++ b/src/bioetl/domain/ports/noop.py
@@ -132,7 +132,7 @@ class NoOpMetrics:
         self,
         name: str,
         value: float,
-        labels: dict[str, str] | None = None,
+        labels: dict[str, str],
     ) -> None:
         """Observe a value for a histogram metric (no-op).
 
@@ -147,8 +147,8 @@ class NoOpMetrics:
     def increment_counter(
         self,
         name: str,
-        value: int = 1,
-        labels: dict[str, str] | None = None,
+        value: int,
+        labels: dict[str, str],
     ) -> None:
         """Increment a counter metric (no-op).
 
@@ -164,7 +164,7 @@ class NoOpMetrics:
         self,
         name: str,
         value: float,
-        labels: dict[str, str] | None = None,
+        labels: dict[str, str],
     ) -> None:
         """Set a gauge metric to a specific value (no-op).
 


### PR DESCRIPTION
… signature

- Remove DataSourceFactoryProtocol from services_factory.py (unused local Protocol)
- Fix NoOpMetrics method signatures in domain/ports/noop.py to match MetricsPort contract:
  - observe_histogram: labels now required (was Optional)
  - increment_counter: labels now required, value no longer has default
  - set_gauge: labels now required

This aligns NoOpMetrics implementation with the MetricsPort Protocol definition, ensuring type consistency across the codebase.

Analysis performed:
- Verified all ABC classes have multiple implementations (BasePipeline: 11, BaseTransformer: 4+, BaseFieldExtractor: 5, DetectorStrategy: 3)
- Domain Ports are essential for Hexagonal Architecture - not candidates for removal
- NoOpTracing/NoOpMetrics duplication is by design (layer separation): domain versions for application layer, infrastructure versions for composition
- DataSourceRegistry is a legitimate backward-compatibility shim
- RegistryProtocol is used for structural subtyping tests