### PR TITLE
Remove unused code from domain layer

### DIFF
--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -40,7 +40,6 @@ from bioetl.domain.entities import (
     Molecule,
     Protein,
     Publication,
-    RequiredEntityFields,
     Target,
     TargetComponent,
     Work,
@@ -130,12 +129,7 @@ from bioetl.domain.ports import (
 )
 
 # Resilience (domain value objects)
-from bioetl.domain.resilience import (
-    AGGRESSIVE_RETRY_POLICY,
-    CONSERVATIVE_RETRY_POLICY,
-    DEFAULT_RETRY_POLICY,
-    RetryPolicy,
-)
+from bioetl.domain.resilience import RetryPolicy
 
 # Pure domain transformations
 from bioetl.domain.transformations import (
@@ -195,7 +189,6 @@ __all__ = [
     "Molecule",
     "Protein",
     "Publication",
-    "RequiredEntityFields",
     "Target",
     "TargetComponent",
     "Work",
@@ -276,9 +269,6 @@ __all__ = [
     "StoragePort",
     "TracingPort",
     # Resilience
-    "AGGRESSIVE_RETRY_POLICY",
-    "CONSERVATIVE_RETRY_POLICY",
-    "DEFAULT_RETRY_POLICY",
     "RetryPolicy",
     # Transformations (pure functions)
     "META_FIELDS",

--- a/src/bioetl/domain/entities/__init__.py
+++ b/src/bioetl/domain/entities/__init__.py
@@ -16,11 +16,9 @@ Field Classification:
 - REQUIRED: Fields validated in __post_init__ (must be non-None)
 - API-OPTIONAL: Fields from external APIs (may be None)
 - COMPUTED: Derived fields (calculated from other fields)
-
-See base.py for RequiredEntityFields Protocol for type-safe required field checks.
 """
 
-from bioetl.domain.entities.base import BaseEntity, RequiredEntityFields
+from bioetl.domain.entities.base import BaseEntity
 from bioetl.domain.entities.chembl_activity import Activity, Assay
 from bioetl.domain.entities.chembl_compound_record import CompoundRecord
 from bioetl.domain.entities.chembl_structures import (
@@ -46,7 +44,6 @@ __all__ = [
     "Molecule",
     "Protein",
     "Publication",
-    "RequiredEntityFields",
     "Target",
     "TargetComponent",
     "Work",

--- a/src/bioetl/domain/entities/base.py
+++ b/src/bioetl/domain/entities/base.py
@@ -22,43 +22,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Protocol, runtime_checkable
 
 from bioetl.domain.types import BatchID, ContentHash, EntityID, RunID, RunType
-
-
-@runtime_checkable
-class RequiredEntityFields(Protocol):
-    """Protocol defining the minimum required fields for all entities.
-
-    All domain entities MUST have these fields with non-None values.
-    Use isinstance(entity, RequiredEntityFields) for runtime checks.
-    """
-
-    @property
-    def entity_id(self) -> EntityID:
-        """Unique business identifier for the entity."""
-        ...
-
-    @property
-    def content_hash(self) -> ContentHash:
-        """SHA256 hash of canonical record representation."""
-        ...
-
-    @property
-    def run_id(self) -> RunID:
-        """Correlation ID for the pipeline run."""
-        ...
-
-    @property
-    def run_type(self) -> RunType:
-        """Type of pipeline run (incremental/backfill/rebuild)."""
-        ...
-
-    @property
-    def ingestion_ts(self) -> datetime:
-        """Timestamp when the record was ingested."""
-        ...
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/bioetl/domain/resilience.py
+++ b/src/bioetl/domain/resilience.py
@@ -79,24 +79,3 @@ class RetryPolicy:
             True if no more attempts allowed after this one
         """
         return attempt >= self.max_attempts - 1
-
-
-# Pre-configured policies for common scenarios
-DEFAULT_RETRY_POLICY = RetryPolicy()
-"""Default retry policy: 3 attempts, 1s base delay, 2x multiplier."""
-
-AGGRESSIVE_RETRY_POLICY = RetryPolicy(
-    max_attempts=5,
-    base_delay=0.5,
-    max_delay=30.0,
-    multiplier=1.5,
-)
-"""Aggressive retry policy for critical operations: 5 attempts, faster backoff."""
-
-CONSERVATIVE_RETRY_POLICY = RetryPolicy(
-    max_attempts=3,
-    base_delay=2.0,
-    max_delay=120.0,
-    multiplier=3.0,
-)
-"""Conservative retry policy for rate-limited APIs: longer delays."""

--- a/src/tools/naming_audit.py
+++ b/src/tools/naming_audit.py
@@ -174,7 +174,6 @@ ALLOWED_NO_SUFFIX = {
     "BaseFieldExtractor",
     "BaseChemblTransformer",
     "BaseServicesFactory",
-    "RequiredEntityFields",
     # Private helpers
     "_NoOpSpan",
     "_NoOpOtelTracer",


### PR DESCRIPTION
Remove dead code that was defined but never used:
- AGGRESSIVE_RETRY_POLICY, CONSERVATIVE_RETRY_POLICY, DEFAULT_RETRY_POLICY constants from resilience.py (never imported/used anywhere)
- RequiredEntityFields Protocol from entities/base.py (defined for runtime checks but never actually used)

This reduces cognitive load and aligns with §1 pragmatic engineering principle - no unused abstractions.

Verified: All domain imports work, 522 architecture/domain tests pass.