### PR TITLE
Implement Pydantic models for API responses

### DIFF
--- a/src/bioetl/infrastructure/adapters/__init__.py
+++ b/src/bioetl/infrastructure/adapters/__init__.py
@@ -1,3 +1,20 @@
 """Adapter implementations for external systems."""
 
 from __future__ import annotations
+
+from bioetl.infrastructure.adapters.validation import (
+    ValidationResult,
+    get_record_model,
+    parse_with_validation,
+    validate_record,
+    validate_records,
+)
+
+__all__ = [
+    # Validation Utilities
+    "ValidationResult",
+    "get_record_model",
+    "parse_with_validation",
+    "validate_record",
+    "validate_records",
+]

--- a/src/bioetl/infrastructure/adapters/chembl/__init__.py
+++ b/src/bioetl/infrastructure/adapters/chembl/__init__.py
@@ -7,5 +7,43 @@ See RULES.md Appendix A for rate limits and retry strategy.
 from __future__ import annotations
 
 from bioetl.infrastructure.adapters.chembl.client import ChemblAdapter
+from bioetl.infrastructure.adapters.chembl.models import (
+    CHEMBL_RECORD_MODELS,
+    CHEMBL_RESPONSE_MODELS,
+    ChemblActivityRecord,
+    ChemblActivityResponse,
+    ChemblAssayRecord,
+    ChemblAssayResponse,
+    ChemblDocumentRecord,
+    ChemblDocumentResponse,
+    ChemblMoleculeRecord,
+    ChemblMoleculeResponse,
+    ChemblPageMeta,
+    ChemblTargetComponentRecord,
+    ChemblTargetComponentResponse,
+    ChemblTargetRecord,
+    ChemblTargetResponse,
+)
 
-__all__ = ["ChemblAdapter"]
+__all__ = [
+    # Model Mappings
+    "CHEMBL_RECORD_MODELS",
+    "CHEMBL_RESPONSE_MODELS",
+    # Record Models
+    "ChemblActivityRecord",
+    # Response Models
+    "ChemblActivityResponse",
+    # Adapter
+    "ChemblAdapter",
+    "ChemblAssayRecord",
+    "ChemblAssayResponse",
+    "ChemblDocumentRecord",
+    "ChemblDocumentResponse",
+    "ChemblMoleculeRecord",
+    "ChemblMoleculeResponse",
+    "ChemblPageMeta",
+    "ChemblTargetComponentRecord",
+    "ChemblTargetComponentResponse",
+    "ChemblTargetRecord",
+    "ChemblTargetResponse",
+]

--- a/src/bioetl/infrastructure/adapters/chembl/models.py
+++ b/src/bioetl/infrastructure/adapters/chembl/models.py
@@ -1,0 +1,625 @@
+"""Pydantic models for ChEMBL API responses.
+
+These models provide type-safe parsing and validation for ChEMBL API responses.
+They are infrastructure-layer models (not domain models) for raw API data.
+
+Naming convention:
+- *Response: Raw API response structure
+- *Record: Individual record within a response
+
+Configuration:
+- extra='ignore': Ignores unknown fields from API
+- populate_by_name=True: Allows both field names and aliases
+
+See RULES.md §8.2 for JSON response modeling guidelines.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# === Shared Models ===
+
+
+class LigandEfficiency(BaseModel):
+    """Ligand efficiency metrics for an activity record."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    bei: str | None = Field(default=None, description="Binding Efficiency Index")
+    le: str | None = Field(default=None, description="Ligand Efficiency")
+    lle: str | None = Field(default=None, description="Lipophilic Ligand Efficiency")
+    sei: str | None = Field(default=None, description="Surface Efficiency Index")
+
+
+class ActionType(BaseModel):
+    """Action type details for an activity record."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    action_type: str | None = Field(default=None, description="Action type name")
+    description: str | None = Field(default=None, description="Action description")
+    parent_type: str | None = Field(default=None, description="Parent action type")
+
+
+class ChemblPageMeta(BaseModel):
+    """Pagination metadata from ChEMBL API."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    limit: int = Field(description="Number of records per page")
+    offset: int = Field(description="Current offset")
+    total_count: int = Field(description="Total number of records available")
+    next: str | None = Field(default=None, description="Next page URL")
+    previous: str | None = Field(default=None, description="Previous page URL")
+
+
+# === Activity Models ===
+
+
+class ChemblActivityRecord(BaseModel):
+    """Individual activity record from ChEMBL API.
+
+    Represents a single bioactivity measurement from the ChEMBL database.
+    Maps to the 'activities' array in the API response.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    # Primary Key
+    activity_id: int = Field(description="Primary activity identifier")
+
+    # Foreign Keys
+    assay_chembl_id: str = Field(description="ChEMBL ID of the assay")
+    molecule_chembl_id: str = Field(description="ChEMBL ID of the molecule")
+    target_chembl_id: str | None = Field(
+        default=None, description="ChEMBL ID of the target"
+    )
+    document_chembl_id: str | None = Field(
+        default=None, description="ChEMBL ID of the source document"
+    )
+
+    # Standardized Values
+    standard_relation: str | None = Field(
+        default=None, description="Standardized relation operator (=, <, >, etc.)"
+    )
+    standard_value: str | float | None = Field(
+        default=None, description="Standardized activity value"
+    )
+    standard_units: str | None = Field(
+        default=None, description="Standardized units (nM, uM, etc.)"
+    )
+    standard_type: str | None = Field(
+        default=None, description="Standardized measurement type (IC50, EC50, etc.)"
+    )
+    standard_flag: int | None = Field(
+        default=None, description="Standardization flag (0 or 1)"
+    )
+    standard_text_value: str | None = Field(
+        default=None, description="Standardized text value"
+    )
+    standard_upper_value: float | None = Field(
+        default=None, description="Standardized upper bound"
+    )
+
+    # Derived Metrics
+    pchembl_value: str | float | None = Field(
+        default=None, description="-log10 of molar activity"
+    )
+
+    # Ligand Efficiency
+    ligand_efficiency: LigandEfficiency | None = Field(
+        default=None, description="Ligand efficiency metrics"
+    )
+
+    # Action Type
+    action_type: ActionType | str | None = Field(
+        default=None, description="Action type details"
+    )
+
+    # Original Values
+    type: str | None = Field(default=None, description="Original measurement type")
+    relation: str | None = Field(default=None, description="Original relation operator")
+    value: str | float | None = Field(default=None, description="Original value")
+    units: str | None = Field(default=None, description="Original units")
+    text_value: str | None = Field(default=None, description="Text value")
+    upper_value: float | None = Field(default=None, description="Upper bound value")
+
+    # Data Quality
+    data_validity_comment: str | None = Field(
+        default=None, description="Data quality comment"
+    )
+    data_validity_description: str | None = Field(
+        default=None, description="Data validity description"
+    )
+    activity_comment: str | None = Field(
+        default=None, description="Activity textual comment"
+    )
+    potential_duplicate: int | None = Field(
+        default=None, description="Duplicate flag (0 or 1)"
+    )
+
+    # Ontologies
+    bao_endpoint: str | None = Field(default=None, description="BAO endpoint ID")
+    bao_format: str | None = Field(default=None, description="BAO format ID")
+    bao_label: str | None = Field(default=None, description="BAO label")
+    uo_units: str | None = Field(default=None, description="Units Ontology ID")
+    qudt_units: str | None = Field(default=None, description="QUDT unit URI")
+
+    # Source and Record Info
+    src_id: int | None = Field(default=None, description="Source ID")
+    record_id: int | None = Field(
+        default=None, description="Foreign key to compound_record"
+    )
+    toid: int | None = Field(default=None, description="Test Occasion ID")
+
+    # Assay Details (denormalized)
+    assay_description: str | None = Field(
+        default=None, description="Assay description"
+    )
+    assay_type: str | None = Field(default=None, description="Assay type code")
+    assay_variant_accession: str | None = Field(
+        default=None, description="Assay variant accession"
+    )
+    assay_variant_mutation: str | None = Field(
+        default=None, description="Assay variant mutation"
+    )
+
+    # Molecule Details (denormalized)
+    canonical_smiles: str | None = Field(
+        default=None, description="Canonical SMILES structure"
+    )
+    molecule_pref_name: str | None = Field(
+        default=None, description="Molecule preferred name"
+    )
+    parent_molecule_chembl_id: str | None = Field(
+        default=None, description="Parent molecule ChEMBL ID"
+    )
+
+    # Target Details (denormalized)
+    target_pref_name: str | None = Field(
+        default=None, description="Target preferred name"
+    )
+    target_organism: str | None = Field(
+        default=None, description="Target organism name"
+    )
+    target_tax_id: str | None = Field(
+        default=None, description="Target taxonomy ID"
+    )
+
+    # Document Details (denormalized)
+    document_journal: str | None = Field(
+        default=None, description="Source journal name"
+    )
+    document_year: int | None = Field(
+        default=None, description="Publication year"
+    )
+
+    # Activity Properties (complex field)
+    activity_properties: list[dict[str, Any]] | None = Field(
+        default_factory=list, description="Additional activity properties"
+    )
+
+
+class ChemblActivityResponse(BaseModel):
+    """Complete ChEMBL Activity API response.
+
+    Represents the full response from /chembl/api/data/activity.json endpoint.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    activities: list[ChemblActivityRecord] = Field(
+        default_factory=list, description="List of activity records"
+    )
+    page_meta: ChemblPageMeta | None = Field(
+        default=None, description="Pagination metadata"
+    )
+
+
+# === Assay Models ===
+
+
+class ChemblAssayRecord(BaseModel):
+    """Individual assay record from ChEMBL API."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    # Primary Key
+    assay_chembl_id: str = Field(description="ChEMBL ID of the assay")
+
+    # Core Fields
+    assay_type: str | None = Field(default=None, description="Assay type code")
+    assay_type_description: str | None = Field(
+        default=None, description="Assay type description"
+    )
+    description: str | None = Field(default=None, description="Assay description")
+    assay_test_type: str | None = Field(default=None, description="Test type")
+    assay_category: str | None = Field(default=None, description="Assay category")
+    assay_cell_type: str | None = Field(default=None, description="Cell type used")
+    assay_organism: str | None = Field(
+        default=None, description="Organism in the assay"
+    )
+    assay_strain: str | None = Field(default=None, description="Strain used")
+    assay_subcellular_fraction: str | None = Field(
+        default=None, description="Subcellular fraction"
+    )
+    assay_tissue: str | None = Field(default=None, description="Tissue type")
+
+    # Foreign Keys
+    document_chembl_id: str | None = Field(
+        default=None, description="Source document ChEMBL ID"
+    )
+    target_chembl_id: str | None = Field(
+        default=None, description="Target ChEMBL ID"
+    )
+    cell_chembl_id: str | None = Field(
+        default=None, description="Cell line ChEMBL ID"
+    )
+    tissue_chembl_id: str | None = Field(
+        default=None, description="Tissue ChEMBL ID"
+    )
+
+    # Ontology
+    bao_format: str | None = Field(default=None, description="BAO format ID")
+    bao_label: str | None = Field(default=None, description="BAO label")
+
+    # Confidence
+    confidence_score: int | None = Field(
+        default=None, description="Target confidence score"
+    )
+    confidence_description: str | None = Field(
+        default=None, description="Confidence description"
+    )
+
+    # Source
+    src_id: int | None = Field(default=None, description="Source ID")
+    src_assay_id: str | None = Field(default=None, description="Source assay ID")
+
+    # Variants
+    variant_sequence: str | None = Field(default=None, description="Variant sequence")
+    assay_parameters: list[dict[str, Any]] | None = Field(
+        default_factory=list, description="Assay parameters"
+    )
+
+
+class ChemblAssayResponse(BaseModel):
+    """Complete ChEMBL Assay API response."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    assays: list[ChemblAssayRecord] = Field(
+        default_factory=list, description="List of assay records"
+    )
+    page_meta: ChemblPageMeta | None = Field(
+        default=None, description="Pagination metadata"
+    )
+
+
+# === Molecule Models ===
+
+
+class MoleculeHierarchy(BaseModel):
+    """Molecule hierarchy information."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    molecule_chembl_id: str | None = Field(default=None)
+    parent_chembl_id: str | None = Field(default=None)
+    active_chembl_id: str | None = Field(default=None)
+
+
+class MoleculeProperties(BaseModel):
+    """Molecule calculated properties."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    alogp: float | None = Field(default=None, description="ALogP value")
+    aromatic_rings: int | None = Field(default=None)
+    cx_logd: float | None = Field(default=None)
+    cx_logp: float | None = Field(default=None)
+    cx_most_apka: float | None = Field(default=None)
+    cx_most_bpka: float | None = Field(default=None)
+    full_molformula: str | None = Field(default=None)
+    full_mwt: float | None = Field(default=None)
+    hba: int | None = Field(default=None, description="H-bond acceptors")
+    hba_lipinski: int | None = Field(default=None)
+    hbd: int | None = Field(default=None, description="H-bond donors")
+    hbd_lipinski: int | None = Field(default=None)
+    heavy_atoms: int | None = Field(default=None)
+    molecular_species: str | None = Field(default=None)
+    mw_freebase: float | None = Field(default=None)
+    mw_monoisotopic: float | None = Field(default=None)
+    np_likeness_score: float | None = Field(default=None)
+    num_lipinski_ro5_violations: int | None = Field(default=None)
+    num_ro5_violations: int | None = Field(default=None)
+    psa: float | None = Field(default=None, description="Polar surface area")
+    qed_weighted: float | None = Field(default=None)
+    ro3_pass: str | None = Field(default=None)
+    rtb: int | None = Field(default=None, description="Rotatable bonds")
+
+
+class MoleculeStructures(BaseModel):
+    """Molecule structure representations."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    canonical_smiles: str | None = Field(default=None)
+    molfile: str | None = Field(default=None)
+    standard_inchi: str | None = Field(default=None)
+    standard_inchi_key: str | None = Field(default=None)
+
+
+class ChemblMoleculeRecord(BaseModel):
+    """Individual molecule record from ChEMBL API."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    # Primary Key
+    molecule_chembl_id: str = Field(description="ChEMBL ID of the molecule")
+
+    # Core Properties
+    pref_name: str | None = Field(default=None, description="Preferred name")
+    max_phase: float | None = Field(default=None, description="Maximum clinical phase")
+    structure_type: str | None = Field(default=None, description="Structure type")
+    molecule_type: str | None = Field(default=None, description="Molecule type")
+    first_approval: int | None = Field(default=None, description="Year of first approval")
+
+    # Flags
+    therapeutic_flag: bool | None = Field(default=None)
+    oral: bool | None = Field(default=None)
+    parenteral: bool | None = Field(default=None)
+    topical: bool | None = Field(default=None)
+    black_box_warning: int | None = Field(default=None)
+    natural_product: int | None = Field(default=None)
+    first_in_class: int | None = Field(default=None)
+    prodrug: int | None = Field(default=None)
+    inorganic_flag: int | None = Field(default=None)
+    polymer_flag: int | None = Field(default=None)
+    withdrawn_flag: bool | None = Field(default=None)
+    chirality: int | None = Field(default=None)
+    availability_type: int | None = Field(default=None)
+
+    # Complex Fields
+    molecule_hierarchy: MoleculeHierarchy | None = Field(default=None)
+    molecule_properties: MoleculeProperties | None = Field(default=None)
+    molecule_structures: MoleculeStructures | None = Field(default=None)
+    molecule_synonyms: list[dict[str, Any]] | None = Field(default_factory=list)
+    cross_references: list[dict[str, Any]] | None = Field(default_factory=list)
+    atc_classifications: list[str] | None = Field(default_factory=list)
+
+    # USAN Info
+    usan_year: int | None = Field(default=None)
+    usan_stem: str | None = Field(default=None)
+    usan_substem: str | None = Field(default=None)
+    usan_stem_definition: str | None = Field(default=None)
+
+    # Indication
+    indication_class: str | None = Field(default=None)
+
+    # Withdrawn Info
+    withdrawn_year: int | None = Field(default=None)
+    withdrawn_country: str | None = Field(default=None)
+    withdrawn_reason: str | None = Field(default=None)
+    withdrawn_class: str | None = Field(default=None)
+
+
+class ChemblMoleculeResponse(BaseModel):
+    """Complete ChEMBL Molecule API response."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    molecules: list[ChemblMoleculeRecord] = Field(
+        default_factory=list, description="List of molecule records"
+    )
+    page_meta: ChemblPageMeta | None = Field(
+        default=None, description="Pagination metadata"
+    )
+
+
+# === Target Models ===
+
+
+class ChemblTargetRecord(BaseModel):
+    """Individual target record from ChEMBL API."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    # Primary Key
+    target_chembl_id: str = Field(description="ChEMBL ID of the target")
+
+    # Core Fields
+    pref_name: str | None = Field(default=None, description="Preferred name")
+    target_type: str | None = Field(default=None, description="Target type")
+    organism: str | None = Field(default=None, description="Target organism")
+    tax_id: int | None = Field(default=None, description="Taxonomy ID")
+    species_group_flag: int | None = Field(default=None)
+
+    # Complex Fields
+    target_components: list[dict[str, Any]] | None = Field(default_factory=list)
+    cross_references: list[dict[str, Any]] | None = Field(default_factory=list)
+
+
+class ChemblTargetResponse(BaseModel):
+    """Complete ChEMBL Target API response."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    targets: list[ChemblTargetRecord] = Field(
+        default_factory=list, description="List of target records"
+    )
+    page_meta: ChemblPageMeta | None = Field(
+        default=None, description="Pagination metadata"
+    )
+
+
+# === Document Models ===
+
+
+class ChemblDocumentRecord(BaseModel):
+    """Individual document record from ChEMBL API."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    # Primary Key
+    document_chembl_id: str = Field(description="ChEMBL ID of the document")
+
+    # Core Fields
+    doc_type: str | None = Field(default=None, description="Document type")
+    title: str | None = Field(default=None, description="Document title")
+    abstract: str | None = Field(default=None, description="Document abstract")
+    authors: str | None = Field(default=None, description="Authors")
+
+    # Journal Info
+    journal: str | None = Field(default=None, description="Journal name")
+    journal_full_title: str | None = Field(default=None)
+    volume: str | None = Field(default=None)
+    issue: str | None = Field(default=None)
+    first_page: str | None = Field(default=None)
+    last_page: str | None = Field(default=None)
+    year: int | None = Field(default=None, description="Publication year")
+
+    # External IDs
+    doi: str | None = Field(default=None, description="Digital Object Identifier")
+    pubmed_id: int | None = Field(default=None, description="PubMed ID")
+    patent_id: str | None = Field(default=None, description="Patent ID")
+
+    # Source
+    src_id: int | None = Field(default=None, description="Source ID")
+
+
+class ChemblDocumentResponse(BaseModel):
+    """Complete ChEMBL Document API response."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    documents: list[ChemblDocumentRecord] = Field(
+        default_factory=list, description="List of document records"
+    )
+    page_meta: ChemblPageMeta | None = Field(
+        default=None, description="Pagination metadata"
+    )
+
+
+# === Target Component Models ===
+
+
+class ChemblTargetComponentRecord(BaseModel):
+    """Individual target component record from ChEMBL API."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    # Primary Key
+    component_id: int = Field(description="Component ID")
+
+    # Core Fields
+    component_type: str | None = Field(default=None)
+    accession: str | None = Field(default=None, description="UniProt accession")
+    sequence: str | None = Field(default=None, description="Protein sequence")
+    sequence_md5sum: str | None = Field(default=None)
+    description: str | None = Field(default=None)
+    organism: str | None = Field(default=None)
+    tax_id: int | None = Field(default=None)
+
+    # GO Classifications
+    go_slims: list[dict[str, Any]] | None = Field(default_factory=list)
+
+    # Protein Classifications
+    protein_classifications: list[dict[str, Any]] | None = Field(default_factory=list)
+
+    # Target Relations
+    target_component_synonyms: list[dict[str, Any]] | None = Field(default_factory=list)
+    target_component_xrefs: list[dict[str, Any]] | None = Field(default_factory=list)
+
+
+class ChemblTargetComponentResponse(BaseModel):
+    """Complete ChEMBL Target Component API response."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    target_components: list[ChemblTargetComponentRecord] = Field(
+        default_factory=list, description="List of target component records"
+    )
+    page_meta: ChemblPageMeta | None = Field(
+        default=None, description="Pagination metadata"
+    )
+
+
+# === Cell Line Models ===
+
+
+class ChemblCellLineRecord(BaseModel):
+    """Individual cell line record from ChEMBL API."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    # Primary Key
+    cell_chembl_id: str = Field(description="ChEMBL ID of the cell line")
+
+    # Core Fields
+    cell_name: str | None = Field(default=None)
+    cell_description: str | None = Field(default=None)
+    cell_source_organism: str | None = Field(default=None)
+    cell_source_tax_id: int | None = Field(default=None)
+    cell_source_tissue: str | None = Field(default=None)
+    cell_type: str | None = Field(default=None)
+
+    # Identifiers
+    cellosaurus_id: str | None = Field(default=None)
+    clo_id: str | None = Field(default=None)
+    efo_id: str | None = Field(default=None)
+
+
+class ChemblCellLineResponse(BaseModel):
+    """Complete ChEMBL Cell Line API response."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    cell_lines: list[ChemblCellLineRecord] = Field(
+        default_factory=list, description="List of cell line records"
+    )
+    page_meta: ChemblPageMeta | None = Field(
+        default=None, description="Pagination metadata"
+    )
+
+
+# === Status Response ===
+
+
+class ChemblStatusResponse(BaseModel):
+    """ChEMBL API status response."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    status: str = Field(description="Service status (UP, DOWN)")
+    chembl_db_version: str | None = Field(default=None)
+    chembl_release_date: str | None = Field(default=None)
+
+
+# === Response Type Mapping ===
+
+# Mapping from entity type to response class for factory usage
+CHEMBL_RESPONSE_MODELS: dict[str, type[BaseModel]] = {
+    "activity": ChemblActivityResponse,
+    "assay": ChemblAssayResponse,
+    "molecule": ChemblMoleculeResponse,
+    "compound": ChemblMoleculeResponse,
+    "target": ChemblTargetResponse,
+    "target_component": ChemblTargetComponentResponse,
+    "document": ChemblDocumentResponse,
+    "cell_line": ChemblCellLineResponse,
+}
+
+# Mapping from entity type to record class for individual record validation
+CHEMBL_RECORD_MODELS: dict[str, type[BaseModel]] = {
+    "activity": ChemblActivityRecord,
+    "assay": ChemblAssayRecord,
+    "molecule": ChemblMoleculeRecord,
+    "compound": ChemblMoleculeRecord,
+    "target": ChemblTargetRecord,
+    "target_component": ChemblTargetComponentRecord,
+    "document": ChemblDocumentRecord,
+    "cell_line": ChemblCellLineRecord,
+}

--- a/src/bioetl/infrastructure/adapters/crossref/__init__.py
+++ b/src/bioetl/infrastructure/adapters/crossref/__init__.py
@@ -8,9 +8,23 @@ from bioetl.infrastructure.adapters.crossref.client import (
     _create_crossref_adapter,
 )
 from bioetl.infrastructure.adapters.crossref.mappers import WorkToPublicationMapper
+from bioetl.infrastructure.adapters.crossref.models import (
+    CROSSREF_RECORD_MODELS,
+    CrossRefWorkRecord,
+    CrossRefWorkResponse,
+    CrossRefWorksResponse,
+)
 
 __all__ = [
+    # Model Mappings
+    "CROSSREF_RECORD_MODELS",
+    # Adapter
     "CrossRefAdapter",
+    # Record Models
+    "CrossRefWorkRecord",
+    # Response Models
+    "CrossRefWorkResponse",
+    "CrossRefWorksResponse",
     "WorkToPublicationMapper",
     "_create_crossref_adapter",
 ]

--- a/src/bioetl/infrastructure/adapters/crossref/models.py
+++ b/src/bioetl/infrastructure/adapters/crossref/models.py
@@ -1,0 +1,404 @@
+"""Pydantic models for CrossRef API responses.
+
+These models provide type-safe parsing and validation for CrossRef REST API responses.
+They are infrastructure-layer models (not domain models) for raw API data.
+
+Documentation: https://api.crossref.org/swagger-ui/index.html
+
+See RULES.md §8.2 for JSON response modeling guidelines.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# === Shared Models ===
+
+
+class CrossRefAuthor(BaseModel):
+    """Author information from CrossRef."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    given: str | None = Field(default=None, description="Given (first) name")
+    family: str | None = Field(default=None, description="Family (last) name")
+    name: str | None = Field(
+        default=None, description="Full name (for organizations)"
+    )
+    suffix: str | None = Field(default=None, description="Name suffix")
+    sequence: str | None = Field(
+        default=None, description="Author sequence (first, additional)"
+    )
+    orcid: str | None = Field(
+        default=None, alias="ORCID", description="ORCID identifier"
+    )
+    authenticated_orcid: bool | None = Field(
+        default=None,
+        alias="authenticated-orcid",
+        description="Whether ORCID is authenticated"
+    )
+    affiliation: list[dict[str, Any]] | None = Field(
+        default_factory=list, description="Author affiliations"
+    )
+
+
+class CrossRefFunder(BaseModel):
+    """Funder information from CrossRef."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    doi: str | None = Field(
+        default=None, alias="DOI", description="Funder DOI"
+    )
+    name: str | None = Field(default=None, description="Funder name")
+    award: list[str] | None = Field(
+        default_factory=list, description="Award numbers"
+    )
+    doi_asserted_by: str | None = Field(
+        default=None, alias="doi-asserted-by", description="Who asserted the DOI"
+    )
+
+
+class CrossRefLicense(BaseModel):
+    """License information from CrossRef."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    url: str | None = Field(default=None, alias="URL", description="License URL")
+    content_version: str | None = Field(
+        default=None, alias="content-version", description="Content version"
+    )
+    delay_in_days: int | None = Field(
+        default=None, alias="delay-in-days", description="Embargo delay"
+    )
+    start: dict[str, Any] | None = Field(
+        default=None, description="License start date"
+    )
+
+
+class CrossRefLink(BaseModel):
+    """Content link from CrossRef."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    url: str | None = Field(default=None, alias="URL", description="Link URL")
+    content_type: str | None = Field(
+        default=None, alias="content-type", description="MIME type"
+    )
+    content_version: str | None = Field(
+        default=None, alias="content-version", description="Content version"
+    )
+    intended_application: str | None = Field(
+        default=None, alias="intended-application", description="Intended use"
+    )
+
+
+class CrossRefReference(BaseModel):
+    """Reference/citation from CrossRef."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    key: str | None = Field(default=None, description="Reference key")
+    doi: str | None = Field(default=None, alias="DOI", description="Reference DOI")
+    doi_asserted_by: str | None = Field(
+        default=None, alias="doi-asserted-by", description="Who asserted DOI"
+    )
+    unstructured: str | None = Field(
+        default=None, description="Unstructured reference text"
+    )
+    issue: str | None = Field(default=None, description="Issue")
+    first_page: str | None = Field(
+        default=None, alias="first-page", description="First page"
+    )
+    volume: str | None = Field(default=None, description="Volume")
+    author: str | None = Field(default=None, description="First author")
+    year: str | None = Field(default=None, description="Publication year")
+    journal_title: str | None = Field(
+        default=None, alias="journal-title", description="Journal title"
+    )
+    article_title: str | None = Field(
+        default=None, alias="article-title", description="Article title"
+    )
+
+
+class CrossRefAssertion(BaseModel):
+    """Publisher assertion from CrossRef."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    name: str | None = Field(default=None, description="Assertion name")
+    value: str | None = Field(default=None, description="Assertion value")
+    label: str | None = Field(default=None, description="Assertion label")
+    group: dict[str, Any] | None = Field(
+        default=None, description="Assertion group"
+    )
+
+
+class CrossRefClinicalTrial(BaseModel):
+    """Clinical trial number from CrossRef."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    clinical_trial_number: str | None = Field(
+        default=None, alias="clinical-trial-number", description="Trial number"
+    )
+    registry: str | None = Field(default=None, description="Trial registry")
+    type: str | None = Field(default=None, description="Trial type")
+
+
+class CrossRefDateParts(BaseModel):
+    """Date representation from CrossRef (date-parts format)."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    date_parts: list[list[int]] | None = Field(
+        default=None, alias="date-parts", description="Date parts [[year, month, day]]"
+    )
+    date_time: str | None = Field(
+        default=None, alias="date-time", description="ISO date-time string"
+    )
+    timestamp: int | None = Field(
+        default=None, description="Unix timestamp in milliseconds"
+    )
+
+
+# === Work Record Model ===
+
+
+class CrossRefWorkRecord(BaseModel):
+    """Individual work record from CrossRef API.
+
+    Represents a publication (article, book, dataset, etc.) with DOI.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    # Primary Identifier
+    doi: str = Field(alias="DOI", description="Digital Object Identifier")
+
+    # Type
+    type: str = Field(description="Work type (journal-article, book-chapter, etc.)")
+    subtype: str | None = Field(default=None, description="Work subtype")
+
+    # Titles
+    title: list[str] | None = Field(
+        default_factory=list, description="Work titles"
+    )
+    subtitle: list[str] | None = Field(
+        default_factory=list, description="Subtitles"
+    )
+    short_title: list[str] | None = Field(
+        default_factory=list, alias="short-title", description="Short titles"
+    )
+    original_title: list[str] | None = Field(
+        default_factory=list, alias="original-title", description="Original titles"
+    )
+
+    # Container (Journal/Book)
+    container_title: list[str] | None = Field(
+        default_factory=list, alias="container-title", description="Container title"
+    )
+    short_container_title: list[str] | None = Field(
+        default_factory=list,
+        alias="short-container-title",
+        description="Short container title"
+    )
+    publisher: str | None = Field(default=None, description="Publisher name")
+    publisher_location: str | None = Field(
+        default=None, alias="publisher-location", description="Publisher location"
+    )
+
+    # Identifiers
+    issn: list[str] | None = Field(
+        default_factory=list, alias="ISSN", description="ISSNs"
+    )
+    isbn: list[str] | None = Field(
+        default_factory=list, alias="ISBN", description="ISBNs"
+    )
+    prefix: str | None = Field(default=None, description="DOI prefix")
+    member: str | None = Field(default=None, description="Member ID")
+    source: str | None = Field(default=None, description="Source system")
+
+    # Volume/Issue/Pages
+    volume: str | None = Field(default=None, description="Volume")
+    issue: str | None = Field(default=None, description="Issue")
+    page: str | None = Field(default=None, description="Page range")
+    article_number: str | None = Field(
+        default=None, alias="article-number", description="Article number"
+    )
+
+    # Authors/Editors
+    author: list[CrossRefAuthor] | None = Field(
+        default_factory=list, description="Authors"
+    )
+    editor: list[CrossRefAuthor] | None = Field(
+        default_factory=list, description="Editors"
+    )
+    chair: list[CrossRefAuthor] | None = Field(
+        default_factory=list, description="Chairs"
+    )
+    translator: list[CrossRefAuthor] | None = Field(
+        default_factory=list, description="Translators"
+    )
+
+    # Dates
+    issued: CrossRefDateParts | None = Field(
+        default=None, description="Publication date"
+    )
+    published_print: CrossRefDateParts | None = Field(
+        default=None, alias="published-print", description="Print publication date"
+    )
+    published_online: CrossRefDateParts | None = Field(
+        default=None, alias="published-online", description="Online publication date"
+    )
+    created: CrossRefDateParts | None = Field(
+        default=None, description="Record creation date"
+    )
+    deposited: CrossRefDateParts | None = Field(
+        default=None, description="Last deposit date"
+    )
+    indexed: CrossRefDateParts | None = Field(
+        default=None, description="Last index date"
+    )
+
+    # Content
+    abstract: str | None = Field(default=None, description="Abstract text")
+    language: str | None = Field(default=None, description="Language code")
+    subject: list[str] | None = Field(
+        default_factory=list, description="Subject areas"
+    )
+
+    # Funding
+    funder: list[CrossRefFunder] | None = Field(
+        default_factory=list, description="Funders"
+    )
+
+    # License
+    license: list[CrossRefLicense] | None = Field(
+        default_factory=list, description="Licenses"
+    )
+
+    # Links
+    link: list[CrossRefLink] | None = Field(
+        default_factory=list, description="Content links"
+    )
+
+    # Relations
+    relation: dict[str, Any] | None = Field(
+        default=None, description="Related works"
+    )
+    update_to: list[dict[str, Any]] | None = Field(
+        default_factory=list, alias="update-to", description="Updates to other works"
+    )
+    updated_by: list[dict[str, Any]] | None = Field(
+        default_factory=list, alias="updated-by", description="Works updating this one"
+    )
+
+    # References
+    reference: list[CrossRefReference] | None = Field(
+        default_factory=list, description="References/bibliography"
+    )
+    references_count: int | None = Field(
+        default=None, alias="references-count", description="Reference count"
+    )
+
+    # Citations
+    is_referenced_by_count: int | None = Field(
+        default=None, alias="is-referenced-by-count", description="Citation count"
+    )
+
+    # Clinical Trials
+    clinical_trial_number: list[CrossRefClinicalTrial] | None = Field(
+        default_factory=list,
+        alias="clinical-trial-number",
+        description="Clinical trial numbers"
+    )
+
+    # Assertions
+    assertion: list[CrossRefAssertion] | None = Field(
+        default_factory=list, description="Publisher assertions"
+    )
+
+    # Scores
+    score: float | None = Field(default=None, description="Search relevance score")
+
+    # Standards Bodies
+    standards_body: list[dict[str, Any]] | None = Field(
+        default_factory=list, alias="standards-body", description="Standards bodies"
+    )
+
+    # Update Policy
+    update_policy: str | None = Field(
+        default=None, alias="update-policy", description="Update policy DOI"
+    )
+
+
+# === API Response Models ===
+
+
+class CrossRefMessage(BaseModel):
+    """Message wrapper for CrossRef API responses."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    # Facets
+    facets: dict[str, Any] | None = Field(
+        default=None, description="Search facets"
+    )
+
+    # Pagination
+    total_results: int | None = Field(
+        default=None, alias="total-results", description="Total result count"
+    )
+    items_per_page: int | None = Field(
+        default=None, alias="items-per-page", description="Items per page"
+    )
+    query: dict[str, Any] | None = Field(
+        default=None, description="Query information"
+    )
+
+    # Cursor
+    next_cursor: str | None = Field(
+        default=None, alias="next-cursor", description="Next cursor"
+    )
+
+    # Items (for list responses)
+    items: list[CrossRefWorkRecord] | None = Field(
+        default_factory=list, description="Work records"
+    )
+
+
+class CrossRefWorksResponse(BaseModel):
+    """Complete CrossRef works API response (list endpoint)."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    status: str = Field(description="Response status")
+    message_type: str = Field(alias="message-type", description="Message type")
+    message_version: str | None = Field(
+        default=None, alias="message-version", description="API version"
+    )
+    message: CrossRefMessage = Field(description="Response message")
+
+
+class CrossRefWorkResponse(BaseModel):
+    """Complete CrossRef work API response (single work endpoint)."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    status: str = Field(description="Response status")
+    message_type: str = Field(alias="message-type", description="Message type")
+    message_version: str | None = Field(
+        default=None, alias="message-version", description="API version"
+    )
+    message: CrossRefWorkRecord = Field(description="Work record")
+
+
+# === Record Type Mapping ===
+
+CROSSREF_RECORD_MODELS: dict[str, type[BaseModel]] = {
+    "work": CrossRefWorkRecord,
+    "publication": CrossRefWorkRecord,
+}

--- a/src/bioetl/infrastructure/adapters/pubchem/__init__.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/__init__.py
@@ -4,3 +4,26 @@ Implements RULES.md Appendix A - PubChem data source.
 """
 
 from __future__ import annotations
+
+from bioetl.infrastructure.adapters.pubchem.client import PubChemAdapter
+from bioetl.infrastructure.adapters.pubchem.models import (
+    PUBCHEM_RECORD_MODELS,
+    PubChemAssayRecord,
+    PubChemBioactivityRecord,
+    PubChemCompoundDetailRecord,
+    PubChemCompoundRecord,
+    PubChemSubstanceRecord,
+)
+
+__all__ = [
+    # Model Mappings
+    "PUBCHEM_RECORD_MODELS",
+    # Adapter
+    "PubChemAdapter",
+    "PubChemAssayRecord",
+    "PubChemBioactivityRecord",
+    "PubChemCompoundDetailRecord",
+    # Record Models
+    "PubChemCompoundRecord",
+    "PubChemSubstanceRecord",
+]

--- a/src/bioetl/infrastructure/adapters/pubchem/models.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/models.py
@@ -1,0 +1,252 @@
+"""Pydantic models for PubChem API responses.
+
+These models provide type-safe parsing and validation for PubChem data.
+They are infrastructure-layer models (not domain models) for normalized adapter output.
+
+Note: PubChem uses pubchempy library which returns Compound/Substance objects.
+These models validate the dictionary representation returned by adapter methods.
+
+See RULES.md §8.2 for JSON response modeling guidelines.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PubChemCompoundRecord(BaseModel):
+    """Normalized compound record from PubChem.
+
+    Represents data extracted from a pubchempy.Compound object
+    via the adapter's _compound_to_dict method.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    # Primary Key
+    cid: int = Field(description="PubChem Compound ID")
+
+    # Molecular Properties
+    molecular_formula: str | None = Field(
+        default=None, description="Molecular formula"
+    )
+    molecular_weight: float | None = Field(
+        default=None, description="Molecular weight in g/mol"
+    )
+
+    # Structure Representations
+    canonical_smiles: str | None = Field(
+        default=None, description="Canonical SMILES (from connectivity_smiles)"
+    )
+    isomeric_smiles: str | None = Field(
+        default=None, description="Isomeric SMILES (from smiles property)"
+    )
+    inchi: str | None = Field(
+        default=None, description="InChI string"
+    )
+    inchikey: str | None = Field(
+        default=None, description="InChI Key"
+    )
+
+    # Names
+    iupac_name: str | None = Field(
+        default=None, description="IUPAC systematic name"
+    )
+
+    # Physical/Chemical Properties
+    charge: int | None = Field(
+        default=None, description="Formal charge"
+    )
+    complexity: float | None = Field(
+        default=None, description="Molecular complexity score"
+    )
+    h_bond_acceptor_count: int | None = Field(
+        default=None, description="Number of hydrogen bond acceptors"
+    )
+    h_bond_donor_count: int | None = Field(
+        default=None, description="Number of hydrogen bond donors"
+    )
+    rotatable_bond_count: int | None = Field(
+        default=None, description="Number of rotatable bonds"
+    )
+
+    # Fingerprints
+    fingerprint: str | None = Field(
+        default=None, description="PubChem fingerprint"
+    )
+
+
+class PubChemSubstanceRecord(BaseModel):
+    """Normalized substance record from PubChem.
+
+    Represents data extracted from a pubchempy.Substance object
+    via the adapter's _substance_to_dict method.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    # Primary Key
+    sid: int = Field(description="PubChem Substance ID")
+
+    # Source Information
+    source_name: str | None = Field(
+        default=None, description="Name of the depositing source"
+    )
+    source_id: str | None = Field(
+        default=None, description="ID from the source database"
+    )
+
+    # Associated Compounds
+    cids: list[int] | None = Field(
+        default_factory=list, description="List of standardized compound IDs"
+    )
+
+    # Names
+    synonyms: list[str] | None = Field(
+        default_factory=list, description="List of substance synonyms"
+    )
+
+
+class PubChemAssayRecord(BaseModel):
+    """Normalized assay record from PubChem.
+
+    Represents data from PubChem BioAssay.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    # Primary Key
+    aid: int | None = Field(
+        default=None, description="PubChem Assay ID"
+    )
+
+    # Core Fields
+    name: str | None = Field(
+        default=None, description="Assay name"
+    )
+    description: str | None = Field(
+        default=None, description="Assay description"
+    )
+    protocol: str | None = Field(
+        default=None, description="Assay protocol"
+    )
+    target: dict[str, Any] | None = Field(
+        default=None, description="Target information"
+    )
+
+
+# === Extended Compound Record with Additional Fields ===
+
+
+class PubChemCompoundDetailRecord(BaseModel):
+    """Extended compound record with additional computed properties.
+
+    Used when fetching detailed compound information from PubChem PUG REST API.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    # Primary Key
+    cid: int = Field(description="PubChem Compound ID")
+
+    # Basic Properties (from PubChemCompoundRecord)
+    molecular_formula: str | None = Field(default=None)
+    molecular_weight: float | None = Field(default=None)
+    canonical_smiles: str | None = Field(default=None)
+    isomeric_smiles: str | None = Field(default=None)
+    inchi: str | None = Field(default=None)
+    inchikey: str | None = Field(default=None)
+    iupac_name: str | None = Field(default=None)
+    charge: int | None = Field(default=None)
+
+    # Extended Properties
+    xlogp: float | None = Field(
+        default=None, description="XLogP3 partition coefficient"
+    )
+    exact_mass: float | None = Field(
+        default=None, description="Exact monoisotopic mass"
+    )
+    monoisotopic_mass: float | None = Field(
+        default=None, description="Monoisotopic mass"
+    )
+    tpsa: float | None = Field(
+        default=None, description="Topological polar surface area"
+    )
+    heavy_atom_count: int | None = Field(
+        default=None, description="Number of heavy (non-hydrogen) atoms"
+    )
+    atom_stereo_count: int | None = Field(
+        default=None, description="Number of stereocenters"
+    )
+    defined_atom_stereo_count: int | None = Field(
+        default=None, description="Number of defined stereocenters"
+    )
+    undefined_atom_stereo_count: int | None = Field(
+        default=None, description="Number of undefined stereocenters"
+    )
+    bond_stereo_count: int | None = Field(
+        default=None, description="Number of stereogenic bonds"
+    )
+    covalent_unit_count: int | None = Field(
+        default=None, description="Number of covalently bonded units"
+    )
+
+    # Identifiers
+    cactvs_fingerprint: str | None = Field(
+        default=None, description="CACTVS fingerprint"
+    )
+
+    # Synonyms
+    synonyms: list[str] | None = Field(
+        default_factory=list, description="Common names and synonyms"
+    )
+
+
+# === Bioactivity Records ===
+
+
+class PubChemBioactivityRecord(BaseModel):
+    """Bioactivity data from PubChem BioAssay.
+
+    Represents activity data for a compound-assay pair.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    # IDs
+    cid: int | None = Field(default=None, description="Compound ID")
+    sid: int | None = Field(default=None, description="Substance ID")
+    aid: int | None = Field(default=None, description="Assay ID")
+
+    # Activity Outcome
+    activity_outcome: str | None = Field(
+        default=None, description="Activity outcome (Active, Inactive, etc.)"
+    )
+    activity_score: float | None = Field(
+        default=None, description="Activity score"
+    )
+
+    # Target Info
+    target_gi: int | None = Field(
+        default=None, description="Target GI number"
+    )
+    target_name: str | None = Field(
+        default=None, description="Target name"
+    )
+
+    # Activity Values
+    activity_values: list[dict[str, Any]] | None = Field(
+        default_factory=list, description="List of activity measurements"
+    )
+
+
+# === Record Type Mapping ===
+
+# Mapping from entity type to record model
+PUBCHEM_RECORD_MODELS: dict[str, type[BaseModel]] = {
+    "compound": PubChemCompoundRecord,
+    "substance": PubChemSubstanceRecord,
+    "assay": PubChemAssayRecord,
+}

--- a/src/bioetl/infrastructure/adapters/pubmed/__init__.py
+++ b/src/bioetl/infrastructure/adapters/pubmed/__init__.py
@@ -5,8 +5,22 @@ This package provides the adapter for interacting with the PubMed API.
 
 from __future__ import annotations
 
+from bioetl.infrastructure.adapters.pubmed.models import (
+    PUBMED_RECORD_MODELS,
+    PubMedArticleRecord,
+    PubMedExtendedRecord,
+    PubMedSearchResponse,
+)
 from bioetl.infrastructure.adapters.pubmed.pubmed_client import PubMedAdapter
 
 __all__ = [
+    # Model Mappings
+    "PUBMED_RECORD_MODELS",
+    # Adapter
     "PubMedAdapter",
+    # Record Models
+    "PubMedArticleRecord",
+    "PubMedExtendedRecord",
+    # Response Models
+    "PubMedSearchResponse",
 ]

--- a/src/bioetl/infrastructure/adapters/pubmed/models.py
+++ b/src/bioetl/infrastructure/adapters/pubmed/models.py
@@ -1,0 +1,295 @@
+"""Pydantic models for PubMed API responses.
+
+These models provide type-safe parsing and validation for PubMed data.
+They are infrastructure-layer models (not domain models) for parsed XML records.
+
+Note: PubMed returns XML responses which are parsed by PubMedXmlProcessor.
+These models validate the dictionary representation after XML parsing.
+
+Documentation: https://www.ncbi.nlm.nih.gov/books/NBK25499/
+
+See RULES.md §8.2 for JSON response modeling guidelines.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# === Basic Record Model (matches current xml_processor output) ===
+
+
+class PubMedArticleRecord(BaseModel):
+    """Basic article record from PubMed XML parsing.
+
+    Matches the output of PubMedXmlProcessor.extract_record().
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    # Primary Key
+    pmid: str | None = Field(
+        default=None, description="PubMed ID"
+    )
+
+    # Article Content
+    article_title: str = Field(
+        default="No title found", description="Article title"
+    )
+
+    # Raw XML for forensic analysis (uses underscore prefix in source data)
+    raw_xml: str | None = Field(
+        default=None, alias="_raw_xml", description="Raw XML content"
+    )
+
+
+# === Extended Record Model (for comprehensive extraction) ===
+
+
+class PubMedAuthor(BaseModel):
+    """Author information from PubMed."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    last_name: str | None = Field(default=None, description="Author last name")
+    fore_name: str | None = Field(default=None, description="Author first name")
+    initials: str | None = Field(default=None, description="Author initials")
+    affiliation: str | None = Field(default=None, description="Author affiliation")
+    collective_name: str | None = Field(
+        default=None, description="Collective/organization name"
+    )
+
+
+class PubMedJournal(BaseModel):
+    """Journal information from PubMed."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    title: str | None = Field(default=None, description="Full journal title")
+    iso_abbreviation: str | None = Field(
+        default=None, description="ISO journal abbreviation"
+    )
+    issn: str | None = Field(default=None, description="ISSN")
+    issn_type: str | None = Field(
+        default=None, description="ISSN type (Print/Electronic)"
+    )
+    volume: str | None = Field(default=None, description="Volume number")
+    issue: str | None = Field(default=None, description="Issue number")
+    country: str | None = Field(default=None, description="Country of publication")
+    nlm_unique_id: str | None = Field(default=None, description="NLM unique ID")
+
+
+class PubMedPubDate(BaseModel):
+    """Publication date from PubMed."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    year: int | None = Field(default=None, description="Publication year")
+    month: int | str | None = Field(default=None, description="Publication month")
+    day: int | None = Field(default=None, description="Publication day")
+
+
+class PubMedMeshHeading(BaseModel):
+    """MeSH heading from PubMed."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    descriptor_name: str | None = Field(default=None, description="MeSH descriptor")
+    descriptor_ui: str | None = Field(default=None, description="MeSH descriptor UI")
+    major_topic: bool = Field(default=False, description="Is major topic")
+    qualifiers: list[dict[str, Any]] | None = Field(
+        default_factory=list, description="MeSH qualifiers"
+    )
+
+
+class PubMedChemical(BaseModel):
+    """Chemical substance from PubMed."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    registry_number: str | None = Field(default=None, description="CAS registry number")
+    name: str | None = Field(default=None, description="Substance name")
+    ui: str | None = Field(default=None, description="Substance UI")
+
+
+class PubMedGrant(BaseModel):
+    """Grant information from PubMed."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    grant_id: str | None = Field(default=None, description="Grant ID")
+    acronym: str | None = Field(default=None, description="Grant acronym")
+    agency: str | None = Field(default=None, description="Funding agency")
+    country: str | None = Field(default=None, description="Funding country")
+
+
+class PubMedReference(BaseModel):
+    """Reference/citation from PubMed."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    citation: str | None = Field(default=None, description="Reference citation text")
+    pmid: str | None = Field(default=None, description="Referenced PMID")
+
+
+class PubMedArticleId(BaseModel):
+    """Article identifier from PubMed."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    id_type: str = Field(description="ID type (pubmed, doi, pmc, etc.)")
+    value: str = Field(description="ID value")
+
+
+class PubMedExtendedRecord(BaseModel):
+    """Extended article record with full metadata from PubMed.
+
+    Represents a comprehensive extraction of PubMed article data.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    # Primary Key
+    pmid: int = Field(description="PubMed ID")
+
+    # Article Identifiers
+    doi: str | None = Field(default=None, description="Digital Object Identifier")
+    pmc_id: str | None = Field(default=None, description="PubMed Central ID")
+    pii: str | None = Field(default=None, description="Publisher Item Identifier")
+
+    # Article Content
+    title: str = Field(description="Article title")
+    abstract: str | None = Field(default=None, description="Abstract text")
+    abstract_structured: bool = Field(
+        default=False, description="Whether abstract has NLM sections"
+    )
+    vernacular_title: str | None = Field(
+        default=None, description="Original non-English title"
+    )
+    language: str | None = Field(default=None, description="Primary language code")
+
+    # Authors
+    authors: list[PubMedAuthor] | None = Field(
+        default_factory=list, description="Article authors"
+    )
+    author_count: int | None = Field(default=None, description="Number of authors")
+
+    # Journal Information
+    journal: PubMedJournal | None = Field(
+        default=None, description="Journal information"
+    )
+
+    # Publication Details
+    pub_date: PubMedPubDate | None = Field(
+        default=None, description="Publication date"
+    )
+    medline_pgn: str | None = Field(
+        default=None, description="Page numbers (MEDLINE format)"
+    )
+    publication_status: str | None = Field(
+        default=None, description="Publication status"
+    )
+    publication_types: list[str] | None = Field(
+        default_factory=list, description="Publication types"
+    )
+
+    # MeSH Terms
+    mesh_headings: list[PubMedMeshHeading] | None = Field(
+        default_factory=list, description="MeSH headings"
+    )
+    mesh_heading_count: int | None = Field(
+        default=None, description="Number of MeSH headings"
+    )
+
+    # Keywords
+    keywords: list[str] | None = Field(
+        default_factory=list, description="Keywords"
+    )
+    keyword_count: int | None = Field(default=None, description="Number of keywords")
+
+    # Chemicals
+    chemicals: list[PubMedChemical] | None = Field(
+        default_factory=list, description="Chemical substances"
+    )
+    chemical_count: int | None = Field(
+        default=None, description="Number of chemicals"
+    )
+
+    # Grants
+    grants: list[PubMedGrant] | None = Field(
+        default_factory=list, description="Grant information"
+    )
+    grant_count: int | None = Field(default=None, description="Number of grants")
+
+    # References
+    references: list[PubMedReference] | None = Field(
+        default_factory=list, description="Article references"
+    )
+    reference_count: int | None = Field(
+        default=None, description="Number of references"
+    )
+
+    # Dates
+    date_completed: str | None = Field(
+        default=None, description="MEDLINE processing completion date"
+    )
+    date_revised: str | None = Field(
+        default=None, description="Record revision date"
+    )
+
+    # Citation
+    citation_subset: str | None = Field(
+        default=None, description="Citation subset codes"
+    )
+
+    # Article IDs
+    article_ids: list[PubMedArticleId] | None = Field(
+        default_factory=list, description="All article identifiers"
+    )
+
+
+# === ESearch Response Models ===
+
+
+class PubMedSearchResult(BaseModel):
+    """Result from PubMed ESearch endpoint."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    count: int | None = Field(default=None, description="Total count of results")
+    ret_max: int | None = Field(
+        default=None, alias="retmax", description="Maximum records to return"
+    )
+    ret_start: int | None = Field(
+        default=None, alias="retstart", description="Starting index"
+    )
+    id_list: list[str] = Field(
+        default_factory=list, alias="idlist", description="List of PMIDs"
+    )
+
+    # Web Environment for history server
+    web_env: str | None = Field(
+        default=None, alias="webenv", description="Web environment ID"
+    )
+    query_key: str | None = Field(
+        default=None, alias="querykey", description="Query key"
+    )
+
+
+class PubMedSearchResponse(BaseModel):
+    """Complete PubMed ESearch API response."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    esearchresult: PubMedSearchResult | None = Field(
+        default=None, description="Search result data"
+    )
+
+
+# === Record Type Mapping ===
+
+PUBMED_RECORD_MODELS: dict[str, type[BaseModel]] = {
+    "publication": PubMedArticleRecord,
+    "publication_extended": PubMedExtendedRecord,
+}

--- a/src/bioetl/infrastructure/adapters/uniprot/__init__.py
+++ b/src/bioetl/infrastructure/adapters/uniprot/__init__.py
@@ -4,3 +4,25 @@ Implements RULES.md Appendix A - UniProt data source.
 """
 
 from __future__ import annotations
+
+from bioetl.infrastructure.adapters.uniprot.client import UniProtAdapter
+from bioetl.infrastructure.adapters.uniprot.models import (
+    UNIPROT_RECORD_MODELS,
+    UniProtFeatureRecord,
+    UniProtProteinRecord,
+    UniProtSearchResponse,
+    UniProtSequenceRecord,
+)
+
+__all__ = [
+    # Model Mappings
+    "UNIPROT_RECORD_MODELS",
+    # Adapter
+    "UniProtAdapter",
+    "UniProtFeatureRecord",
+    # Record Models
+    "UniProtProteinRecord",
+    # Response Models
+    "UniProtSearchResponse",
+    "UniProtSequenceRecord",
+]

--- a/src/bioetl/infrastructure/adapters/uniprot/models.py
+++ b/src/bioetl/infrastructure/adapters/uniprot/models.py
@@ -1,0 +1,323 @@
+"""Pydantic models for UniProt API responses.
+
+These models provide type-safe parsing and validation for UniProt REST API responses.
+They are infrastructure-layer models (not domain models) for raw API data.
+
+Documentation: https://www.uniprot.org/help/api
+
+See RULES.md §8.2 for JSON response modeling guidelines.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# === Shared Models ===
+
+
+class UniProtOrganism(BaseModel):
+    """Organism information from UniProt."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    scientific_name: str = Field(
+        alias="scientificName", description="Scientific name"
+    )
+    common_name: str | None = Field(
+        default=None, alias="commonName", description="Common name"
+    )
+    taxon_id: int = Field(alias="taxonId", description="NCBI Taxonomy ID")
+    lineage: list[str] | None = Field(
+        default_factory=list, description="Taxonomic lineage"
+    )
+
+
+class UniProtName(BaseModel):
+    """Name value container."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    value: str = Field(description="Name value")
+
+
+class UniProtFullName(BaseModel):
+    """Full name with optional short names."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    full_name: UniProtName | None = Field(
+        default=None, alias="fullName", description="Full name"
+    )
+    short_names: list[UniProtName] | None = Field(
+        default_factory=list, alias="shortNames", description="Short names"
+    )
+
+
+class UniProtRecommendedName(BaseModel):
+    """Recommended protein name."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    full_name: UniProtName | None = Field(
+        default=None, alias="fullName", description="Full recommended name"
+    )
+    short_names: list[UniProtName] | None = Field(
+        default_factory=list, alias="shortNames", description="Short names"
+    )
+
+
+class UniProtProteinDescription(BaseModel):
+    """Protein description with recommended and alternative names."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    recommended_name: UniProtRecommendedName | None = Field(
+        default=None, alias="recommendedName", description="Recommended name"
+    )
+    alternative_names: list[UniProtFullName] | None = Field(
+        default_factory=list, alias="alternativeNames", description="Alternative names"
+    )
+    submitted_name: list[UniProtFullName] | None = Field(
+        default_factory=list, alias="submittedName", description="Submitted names"
+    )
+
+
+class UniProtGene(BaseModel):
+    """Gene information."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    gene_name: UniProtName | None = Field(
+        default=None, alias="geneName", description="Primary gene name"
+    )
+    synonyms: list[UniProtName] | None = Field(
+        default_factory=list, description="Gene name synonyms"
+    )
+    ordered_locus_names: list[UniProtName] | None = Field(
+        default_factory=list, alias="orderedLocusNames", description="Locus names"
+    )
+    orf_names: list[UniProtName] | None = Field(
+        default_factory=list, alias="orfNames", description="ORF names"
+    )
+
+
+class UniProtEvidence(BaseModel):
+    """Evidence for a feature or annotation."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    evidence_code: str = Field(alias="evidenceCode", description="ECO evidence code")
+    source: str | None = Field(default=None, description="Evidence source")
+    id: str | None = Field(default=None, description="Source ID")
+
+
+class UniProtText(BaseModel):
+    """Text with evidence."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    value: str = Field(description="Text value")
+    evidences: list[UniProtEvidence] | None = Field(
+        default_factory=list, description="Supporting evidence"
+    )
+
+
+class UniProtComment(BaseModel):
+    """Protein comment/annotation."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    comment_type: str = Field(alias="commentType", description="Comment type")
+    texts: list[UniProtText] | None = Field(
+        default_factory=list, description="Comment text entries"
+    )
+    molecule: str | None = Field(default=None, description="Molecule name")
+
+
+class UniProtFeatureLocation(BaseModel):
+    """Location of a feature."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    start: dict[str, Any] | None = Field(default=None, description="Start position")
+    end: dict[str, Any] | None = Field(default=None, description="End position")
+
+
+class UniProtFeature(BaseModel):
+    """Protein feature (domain, site, etc.)."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    type: str = Field(description="Feature type")
+    location: UniProtFeatureLocation | None = Field(
+        default=None, description="Feature location"
+    )
+    description: str | None = Field(default=None, description="Feature description")
+    evidences: list[UniProtEvidence] | None = Field(
+        default_factory=list, description="Supporting evidence"
+    )
+    feature_id: str | None = Field(
+        default=None, alias="featureId", description="Feature ID"
+    )
+
+
+class UniProtCrossReference(BaseModel):
+    """Cross-reference to external database."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    database: str = Field(description="Database name")
+    id: str = Field(description="External ID")
+    properties: list[dict[str, str]] | None = Field(
+        default_factory=list, description="Additional properties"
+    )
+
+
+class UniProtSequence(BaseModel):
+    """Protein sequence information."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    value: str = Field(description="Amino acid sequence")
+    length: int = Field(description="Sequence length")
+    mol_weight: int = Field(alias="molWeight", description="Molecular weight in Da")
+    crc64: str | None = Field(default=None, description="CRC64 checksum")
+    md5: str | None = Field(default=None, description="MD5 checksum")
+
+
+class UniProtExtraAttributes(BaseModel):
+    """Extra attributes for the entry."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    uni_parc_id: str | None = Field(
+        default=None, alias="uniParcId", description="UniParc ID"
+    )
+
+
+# === Main Protein Record ===
+
+
+class UniProtProteinRecord(BaseModel):
+    """Individual protein record from UniProt API.
+
+    Represents a single UniProtKB entry from the /uniprotkb/search endpoint.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    # Entry Type
+    entry_type: str = Field(
+        alias="entryType",
+        description="Entry type (UniProtKB reviewed/unreviewed)"
+    )
+
+    # Primary Identifiers
+    primary_accession: str = Field(
+        alias="primaryAccession", description="Primary accession number"
+    )
+    uniprot_kb_id: str | None = Field(
+        default=None, alias="uniProtkbId", description="UniProtKB ID (entry name)"
+    )
+
+    # Organism
+    organism: UniProtOrganism | None = Field(
+        default=None, description="Source organism"
+    )
+
+    # Protein Names
+    protein_description: UniProtProteinDescription | None = Field(
+        default=None, alias="proteinDescription", description="Protein names"
+    )
+
+    # Genes
+    genes: list[UniProtGene] | None = Field(
+        default_factory=list, description="Gene information"
+    )
+
+    # Annotations
+    comments: list[UniProtComment] | None = Field(
+        default_factory=list, description="Protein annotations/comments"
+    )
+
+    # Features
+    features: list[UniProtFeature] | None = Field(
+        default_factory=list, description="Sequence features"
+    )
+
+    # Cross-References
+    uniprot_kb_cross_references: list[UniProtCrossReference] | None = Field(
+        default_factory=list,
+        alias="uniProtKBCrossReferences",
+        description="External database cross-references"
+    )
+
+    # Sequence
+    sequence: UniProtSequence | None = Field(
+        default=None, description="Protein sequence"
+    )
+
+    # Extra Attributes
+    extra_attributes: UniProtExtraAttributes | None = Field(
+        default=None, alias="extraAttributes", description="Extra attributes"
+    )
+
+    # Secondary Accessions
+    secondary_accessions: list[str] | None = Field(
+        default_factory=list, alias="secondaryAccessions", description="Secondary accessions"
+    )
+
+
+class UniProtSearchResponse(BaseModel):
+    """Complete UniProt search API response."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    results: list[UniProtProteinRecord] = Field(
+        default_factory=list, description="List of protein records"
+    )
+    # Note: pagination is handled via cursor in Link header, not in JSON body
+
+
+# === Feature Record (simplified for feature endpoint) ===
+
+
+class UniProtFeatureRecord(BaseModel):
+    """Simplified feature record from UniProt."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    accession: str = Field(description="Protein accession")
+    type: str | None = Field(default=None, description="Feature type")
+    location: dict[str, Any] | None = Field(
+        default=None, description="Feature location"
+    )
+    description: str | None = Field(default=None, description="Feature description")
+
+
+# === Sequence Record (from FASTA parsing) ===
+
+
+class UniProtSequenceRecord(BaseModel):
+    """Sequence record from FASTA parsing."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    accession: str = Field(description="Primary accession")
+    entry_name: str | None = Field(default=None, description="Entry name")
+    organism_name: str | None = Field(default=None, description="Organism name")
+    gene_name: str | None = Field(default=None, description="Gene name")
+    protein_name: str | None = Field(default=None, description="Protein name")
+    sequence: str = Field(description="Amino acid sequence")
+    length: int | None = Field(default=None, description="Sequence length")
+
+
+# === Record Type Mapping ===
+
+UNIPROT_RECORD_MODELS: dict[str, type[BaseModel]] = {
+    "protein": UniProtProteinRecord,
+    "feature": UniProtFeatureRecord,
+    "sequence": UniProtSequenceRecord,
+}

--- a/src/bioetl/infrastructure/adapters/validation.py
+++ b/src/bioetl/infrastructure/adapters/validation.py
@@ -1,0 +1,229 @@
+"""Shared validation utilities for API response parsing.
+
+Provides type-safe parsing of API responses using Pydantic models with
+graceful error handling that routes invalid records to quarantine.
+
+See RULES.md §8.2 for JSON response modeling guidelines.
+See RULES.md §2.6 for quarantine handling.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from pydantic import BaseModel, ValidationError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from bioetl.domain.ports import LoggerPort
+
+
+T = TypeVar("T", bound=BaseModel)
+
+
+@dataclass
+class ValidationResult:
+    """Result of validating an API record.
+
+    Contains either a validated record or validation error details.
+    """
+
+    record: dict[str, Any] | None = None
+    """The original record data (always present)."""
+
+    validated: BaseModel | None = None
+    """The validated Pydantic model (None if validation failed)."""
+
+    is_valid: bool = False
+    """Whether validation succeeded."""
+
+    error: str | None = None
+    """Error message if validation failed."""
+
+    error_details: list[dict[str, Any]] = field(default_factory=list)
+    """Detailed error information from Pydantic validation."""
+
+
+def validate_record(
+    record: dict[str, Any],
+    model_class: type[T],
+    logger: LoggerPort | None = None,
+    context: str = "",
+) -> ValidationResult:
+    """Validate a single record against a Pydantic model.
+
+    Args:
+        record: Dictionary record to validate.
+        model_class: Pydantic model class for validation.
+        logger: Optional logger for validation errors.
+        context: Context string for error logging (e.g., "chembl_activity").
+
+    Returns:
+        ValidationResult containing validation outcome.
+
+    Example:
+        >>> from bioetl.infrastructure.adapters.chembl.models import ChemblActivityRecord
+        >>> result = validate_record(raw_record, ChemblActivityRecord)
+        >>> if result.is_valid:
+        ...     process(result.validated)
+        ... else:
+        ...     quarantine(result.record, result.error)
+    """
+    try:
+        validated = model_class.model_validate(record)
+        return ValidationResult(
+            record=record,
+            validated=validated,
+            is_valid=True,
+        )
+    except ValidationError as e:
+        error_details = [
+            {
+                "loc": list(err.get("loc", [])),
+                "msg": err.get("msg", ""),
+                "type": err.get("type", ""),
+            }
+            for err in e.errors()
+        ]
+        error_msg = f"Validation failed: {len(e.errors())} errors"
+
+        if logger:
+            logger.warning(
+                "api_record_validation_failed",
+                context=context,
+                error_count=len(e.errors()),
+                errors=error_details[:5],  # Limit to first 5 for logging
+            )
+
+        return ValidationResult(
+            record=record,
+            validated=None,
+            is_valid=False,
+            error=error_msg,
+            error_details=error_details,
+        )
+
+
+def validate_records(
+    records: list[dict[str, Any]],
+    model_class: type[T],
+    logger: LoggerPort | None = None,
+    context: str = "",
+) -> Iterator[ValidationResult]:
+    """Validate multiple records against a Pydantic model.
+
+    Yields ValidationResult for each record, allowing mixed valid/invalid handling.
+
+    Args:
+        records: List of dictionary records to validate.
+        model_class: Pydantic model class for validation.
+        logger: Optional logger for validation errors.
+        context: Context string for error logging.
+
+    Yields:
+        ValidationResult for each record.
+
+    Example:
+        >>> for result in validate_records(raw_records, ChemblActivityRecord):
+        ...     if result.is_valid:
+        ...         yield result.validated.model_dump()
+        ...     else:
+        ...         quarantine_writer.write(result.record, result.error)
+    """
+    for record in records:
+        yield validate_record(record, model_class, logger, context)
+
+
+def parse_with_validation(
+    record: dict[str, Any],
+    model_class: type[T],
+    strict: bool = False,
+    logger: LoggerPort | None = None,
+    context: str = "",
+) -> dict[str, Any]:
+    """Parse a record with optional validation.
+
+    If validation is enabled (strict=True) and fails, raises ValueError.
+    Otherwise, returns the original record unchanged (graceful degradation).
+
+    Args:
+        record: Dictionary record to parse.
+        model_class: Pydantic model class for validation.
+        strict: If True, raise on validation failure. If False, return original.
+        logger: Optional logger for validation warnings.
+        context: Context string for error logging.
+
+    Returns:
+        Validated dict (model_dump) if valid, otherwise original record.
+
+    Raises:
+        ValueError: If strict=True and validation fails.
+
+    Example:
+        >>> # Graceful mode (default) - returns original on failure
+        >>> record = parse_with_validation(raw, ChemblActivityRecord)
+        >>>
+        >>> # Strict mode - raises on failure
+        >>> record = parse_with_validation(raw, ChemblActivityRecord, strict=True)
+    """
+    result = validate_record(record, model_class, logger, context)
+
+    if result.is_valid and result.validated is not None:
+        return result.validated.model_dump(by_alias=False)
+
+    if strict:
+        raise ValueError(result.error or "Validation failed")
+
+    # Graceful degradation: return original record
+    return record
+
+
+def get_record_model(
+    provider: str,
+    entity_type: str,
+) -> type[BaseModel] | None:
+    """Get the appropriate Pydantic model for a provider/entity combination.
+
+    Args:
+        provider: Provider name (chembl, pubchem, uniprot, pubmed, crossref).
+        entity_type: Entity type (activity, assay, compound, etc.).
+
+    Returns:
+        Pydantic model class or None if not found.
+
+    Example:
+        >>> model = get_record_model("chembl", "activity")
+        >>> if model:
+        ...     validated = model.model_validate(record)
+    """
+    # Import here to avoid circular imports
+    if provider == "chembl":
+        from bioetl.infrastructure.adapters.chembl.models import CHEMBL_RECORD_MODELS
+
+        return CHEMBL_RECORD_MODELS.get(entity_type)
+
+    if provider == "pubchem":
+        from bioetl.infrastructure.adapters.pubchem.models import PUBCHEM_RECORD_MODELS
+
+        return PUBCHEM_RECORD_MODELS.get(entity_type)
+
+    if provider == "uniprot":
+        from bioetl.infrastructure.adapters.uniprot.models import UNIPROT_RECORD_MODELS
+
+        return UNIPROT_RECORD_MODELS.get(entity_type)
+
+    if provider == "pubmed":
+        from bioetl.infrastructure.adapters.pubmed.models import PUBMED_RECORD_MODELS
+
+        return PUBMED_RECORD_MODELS.get(entity_type)
+
+    if provider == "crossref":
+        from bioetl.infrastructure.adapters.crossref.models import (
+            CROSSREF_RECORD_MODELS,
+        )
+
+        return CROSSREF_RECORD_MODELS.get(entity_type)
+
+    return None

--- a/tests/unit/composition/test_entrypoints.py
+++ b/tests/unit/composition/test_entrypoints.py
@@ -8,7 +8,7 @@ Tests the unified pipeline execution interface including:
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 


### PR DESCRIPTION
Add type-safe Pydantic models for all provider API responses per RULES.md §8.2:

- ChEMBL: Activity, Assay, Molecule, Target, Document, TargetComponent, CellLine
- PubChem: Compound, Substance, Assay, Bioactivity
- UniProt: Protein, Feature, Sequence
- PubMed: Article, Search, Extended metadata
- CrossRef: Work, Author, Funder, Reference

Key features:
- Models use extra='ignore' to handle unknown API fields gracefully
- populate_by_name=True for alias support (API field name differences)
- Shared validation utility (validate_record, validate_records)
- Record type mappings (PROVIDER_RECORD_MODELS) for factory usage

This enables type-safe parsing of external API responses with validation error handling that can route invalid records to quarantine.