### PR TITLE
Fix domain layer architecture violations

### DIFF
--- a/src/bioetl/composition/factories/storage_adapter.py
+++ b/src/bioetl/composition/factories/storage_adapter.py
@@ -59,7 +59,7 @@ class StorageAdapter:
         run_type: RunType,
         ingestion_ts: datetime,
         lock_context: LockContext | None = None,
-    ) -> Path:
+    ) -> str:
         """Write raw records to Bronze layer.
 
         Args:
@@ -75,7 +75,7 @@ class StorageAdapter:
             lock_context: Lock context for validation (RULES.md §3.3).
 
         Returns:
-            Path: Relative path to the written file.
+            str: Relative path to the written file.
         """
         return await self.bronze.write_bronze(
             records=records,

--- a/src/bioetl/domain/ports/storage.py
+++ b/src/bioetl/domain/ports/storage.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from datetime import datetime
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 from bioetl.domain.types import (
@@ -43,7 +42,7 @@ class StoragePort(Protocol):
         run_type: RunType,
         ingestion_ts: datetime,
         lock_context: LockContext | None = None,
-    ) -> Path:
+    ) -> str:
         """Write raw records to the Bronze layer.
 
         Args:
@@ -61,7 +60,7 @@ class StoragePort(Protocol):
                          before writing (see ADR-014).
 
         Returns:
-            Path: Relative path to the written file.
+            str: Relative path to the written file.
         """
         ...
 

--- a/src/bioetl/infrastructure/storage/bronze_writer.py
+++ b/src/bioetl/infrastructure/storage/bronze_writer.py
@@ -311,7 +311,7 @@ class BronzeWriter:
         run_type: RunType,
         ingestion_ts: datetime,
         lock_context: LockContext | None = None,
-    ) -> Path:
+    ) -> str:
         """Write raw records to Bronze layer (JSONL + zstd).
 
         Streams records through zstd compressor directly to disk.
@@ -466,7 +466,7 @@ class BronzeWriter:
             span.set_attribute("record_count", record_count)
             span.set_attribute("compressed_size", compressed_size)
 
-            return Path(relative_path)
+            return relative_path
 
     async def _write_json_copy(
         self,


### PR DESCRIPTION
Replace pathlib.Path return type with str in StoragePort.write_bronze() to maintain domain layer purity. Domain layer should use strings for paths since Path is a file-system specific type.

Changes:
- domain/ports/storage.py: Remove pathlib import, change return type
- infrastructure/storage/bronze_writer.py: Return str instead of Path
- composition/factories/storage_adapter.py: Update return type annotation

This aligns with hexagonal architecture principles where domain layer should be agnostic to infrastructure details.