### PR TITLE
Standardize logging and remove print statements

### DIFF
--- a/src/bioetl/infrastructure/adapters/logging_utils.py
+++ b/src/bioetl/infrastructure/adapters/logging_utils.py
@@ -1,39 +1,56 @@
 """Logging utilities for adapters.
 
 Provides standardized error logging format across all data source adapters.
+Implements RULES.md §3.2.1 Log Schema with mandatory stage field.
 """
 
 from __future__ import annotations
 
-import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from bioetl.domain.ports import LoggerPort
+
+# Stage type for Log Schema compliance
+StageType = Literal["extract", "transform", "load", "validate", "init", "cleanup"]
 
 
 def log_adapter_error(
-    logger: Any,
+    logger: LoggerPort,
     provider: str,
     operation: str,
     *,
+    stage: StageType = "extract",
+    error_type: str = "adapter_error",
     exc_info: bool = True,
     **context: Any,
 ) -> None:
-    """Log adapter error in standardized format.
+    """Log adapter error in standardized format with Log Schema fields.
 
     Формат сообщения: "{provider} {operation} failed"
 
+    Implements RULES.md §3.2.1 - mandatory fields:
+    - stage: Pipeline stage (default: "extract" for adapter operations)
+    - error_type: Error classification
+
     Args:
-        logger: Structlog logger or standard logging.Logger instance
+        logger: LoggerPort-compatible logger instance
         provider: Provider name (e.g., "chembl", "pubchem", "uniprot")
         operation: Operation that failed (e.g., "fetch", "batch fetch", "health check")
+        stage: Pipeline stage for Log Schema (default: "extract")
+        error_type: Classification of error (default: "adapter_error")
         exc_info: Include exception traceback (default: True)
         **context: Additional context fields to include in log
 
     """
     message = f"{provider} {operation} failed"
 
-    # Handle standard logging.Logger
-    if isinstance(logger, logging.Logger):
-        logger.error(message, exc_info=exc_info, extra=context)
-    else:
-        # Assume structlog or compatible
-        logger.error(message, exc_info=exc_info, **context)
+    logger.error(
+        message,
+        stage=stage,
+        error_type=error_type,
+        provider=provider,
+        operation=operation,
+        exc_info=exc_info,
+        **context,
+    )

--- a/src/bioetl/infrastructure/observability/__init__.py
+++ b/src/bioetl/infrastructure/observability/__init__.py
@@ -7,6 +7,9 @@ This package contains implementations of observability ports:
 - Health Checks
 
 Implements RULES.md §3 (Observability).
+
+For new code, prefer UnifiedLogger which enforces Log Schema (§3.2.1)
+with mandatory fields: ts, level, run_id, pipeline, stage.
 """
 
 from __future__ import annotations
@@ -17,6 +20,10 @@ from bioetl.infrastructure.observability.noop_metrics import NoOpMetrics
 from bioetl.infrastructure.observability.noop_tracing import NoOpTracing
 from bioetl.infrastructure.observability.prometheus_metrics import PrometheusMetrics
 from bioetl.infrastructure.observability.tracing import OpenTelemetryTracer
+from bioetl.infrastructure.observability.unified_logger import (
+    UnifiedLogger,
+    create_unified_logger,
+)
 
 __all__ = [
     "NoOpLogger",
@@ -25,4 +32,6 @@ __all__ = [
     "OpenTelemetryTracer",
     "PrometheusMetrics",
     "StructlogLogger",
+    "UnifiedLogger",
+    "create_unified_logger",
 ]

--- a/src/bioetl/infrastructure/observability/anomaly/monitor.py
+++ b/src/bioetl/infrastructure/observability/anomaly/monitor.py
@@ -35,7 +35,12 @@ class DataQualityMonitor:
             "error_rate": 0.15,
         })
         for issue in issues:
-            print(issue)
+            logger.warning(
+                "Data quality issue detected",
+                stage="validate",
+                anomaly_metric=issue.metric_name,
+                severity=issue.severity.value,
+            )
     """
 
     def __init__(

--- a/src/bioetl/infrastructure/observability/unified_logger.py
+++ b/src/bioetl/infrastructure/observability/unified_logger.py
@@ -1,0 +1,338 @@
+"""Unified structured logging with enforced Log Schema.
+
+Implements RULES.md §3.2.1 - Log Schema with mandatory fields:
+- ts: ISO timestamp (automatic via structlog)
+- level: log level (from method call)
+- run_id: correlation ID (MUST be provided at initialization)
+- pipeline: pipeline name (MUST be provided at initialization)
+- stage: extract | transform | load (MUST be provided on each call)
+
+Optional fields:
+- dataset: logical table name (SHOULD)
+- record_count: count of records (SHOULD)
+- error_type: error classification (for error logs)
+
+Requirements:
+- REQ-OBS-001: run_id mandatory in all logs
+- REQ-OBS-004: Structured JSON format
+- REQ-OBS-005: Log Schema with mandatory fields
+
+Example:
+    >>> logger = UnifiedLogger(pipeline="chembl_activity", run_id="abc-123")
+    >>> logger.info("Fetching page", stage="extract", page=5)
+    >>> logger.error("Validation failed", stage="transform", error_type="schema_error")
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import sys
+from typing import TYPE_CHECKING, Any, Literal, Self
+
+import structlog
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+# Stage values allowed by Log Schema
+StageType = Literal["extract", "transform", "load", "validate", "init", "cleanup"]
+
+
+# Patterns for secret detection in log values
+_SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"(?i)(api[_-]?key|apikey)['\"]?\s*[:=]\s*['\"]?[\w-]+", re.IGNORECASE), "[REDACTED_API_KEY]"),
+    (re.compile(r"(?i)(auth|authorization)['\"]?\s*[:=]\s*['\"]?[\w-]+", re.IGNORECASE), "[REDACTED_AUTH]"),
+    (re.compile(r"(?i)(token|bearer)['\"]?\s*[:=]\s*['\"]?[\w-]+", re.IGNORECASE), "[REDACTED_TOKEN]"),
+    (re.compile(r"(?i)(password|passwd|pwd)['\"]?\s*[:=]\s*['\"]?[\w-]+", re.IGNORECASE), "[REDACTED_PASSWORD]"),
+    (re.compile(r"(?i)(secret|private[_-]?key)['\"]?\s*[:=]\s*['\"]?[\w-]+", re.IGNORECASE), "[REDACTED_SECRET]"),
+    # Bearer tokens in headers
+    (re.compile(r"Bearer\s+[\w.-]+", re.IGNORECASE), "Bearer [REDACTED]"),
+    # AWS-style keys
+    (re.compile(r"AKIA[0-9A-Z]{16}"), "[REDACTED_AWS_KEY]"),
+    # Generic long alphanumeric that look like keys (32+ chars)
+    (re.compile(r"(?<![a-zA-Z0-9])[a-zA-Z0-9]{32,}(?![a-zA-Z0-9])"), "[REDACTED_KEY]"),
+]
+
+
+def _mask_secrets(value: Any) -> Any:
+    """Mask potential secrets in log values.
+
+    Args:
+        value: Value to check and potentially mask
+
+    Returns:
+        Original value or masked version if secrets detected
+    """
+    if not isinstance(value, str):
+        return value
+
+    result = value
+    for pattern, replacement in _SECRET_PATTERNS:
+        result = pattern.sub(replacement, result)
+
+    return result
+
+
+def _secret_filter_processor(
+    logger: Any,
+    method_name: str,
+    event_dict: dict[str, Any],
+) -> dict[str, Any]:
+    """Structlog processor that filters secrets from log entries.
+
+    Scans all string values in the event dict and masks potential secrets
+    like API keys, tokens, passwords, and authorization headers.
+
+    Args:
+        logger: The wrapped logger object
+        method_name: Name of the log method called
+        event_dict: Dictionary of event data
+
+    Returns:
+        Event dict with secrets masked
+    """
+    for key, value in event_dict.items():
+        if isinstance(value, str):
+            event_dict[key] = _mask_secrets(value)
+        elif isinstance(value, dict):
+            # Recursively mask nested dicts
+            event_dict[key] = {
+                k: _mask_secrets(v) if isinstance(v, str) else v
+                for k, v in value.items()
+            }
+
+    return event_dict
+
+
+class UnifiedLogger:
+    """Unified logger with enforced Log Schema fields.
+
+    This logger enforces the mandatory fields defined in RULES.md §3.2.1:
+    - run_id and pipeline are bound at initialization
+    - stage is required on every log call
+
+    The logger also includes secret filtering to prevent accidental
+    logging of sensitive data like API keys, tokens, and passwords.
+
+    Example:
+        >>> logger = UnifiedLogger(pipeline="chembl_activity", run_id="abc-123")
+        >>> logger.info("Fetching records", stage="extract", record_count=100)
+        >>> logger.error("Parse failed", stage="transform", error_type="json_error")
+    """
+
+    __slots__ = ("_logger", "_pipeline", "_run_id")
+
+    def __init__(
+        self,
+        pipeline: str,
+        run_id: str | UUID,
+        log_level: str = "INFO",
+        json_format: bool = True,
+    ) -> None:
+        """Initialize UnifiedLogger with mandatory context.
+
+        Args:
+            pipeline: Pipeline name for log context (MUST be provided)
+            run_id: Unique run identifier for tracing (MUST be provided)
+            log_level: Logging level (default: INFO)
+            json_format: Use JSON output format (default: True)
+        """
+        self._pipeline = pipeline
+        self._run_id = str(run_id)
+
+        # Build processor chain with secret filtering
+        processors: list[Any] = [
+            structlog.contextvars.merge_contextvars,
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.UnicodeDecoder(),
+            _secret_filter_processor,  # Filter secrets before output
+        ]
+
+        if json_format:
+            processors.append(structlog.processors.JSONRenderer())
+        else:
+            processors.append(structlog.dev.ConsoleRenderer())
+
+        structlog.configure(
+            processors=processors,
+            logger_factory=structlog.stdlib.LoggerFactory(),
+            wrapper_class=structlog.stdlib.BoundLogger,
+            cache_logger_on_first_use=True,
+        )
+
+        # Create logger with mandatory bound context
+        base_logger = structlog.get_logger(f"bioetl.{pipeline}")
+        self._logger = base_logger.bind(
+            run_id=self._run_id,
+            pipeline=pipeline,
+        )
+
+        # Configure stdlib logging level
+        logging.basicConfig(
+            level=log_level.upper(),
+            stream=sys.stdout,
+            format="%(message)s",
+        )
+
+    def bind(self, **kwargs: Any) -> Self:
+        """Bind additional context to the logger.
+
+        Returns a new UnifiedLogger instance with additional bound context.
+        The pipeline and run_id remain unchanged.
+
+        Args:
+            **kwargs: Key-value pairs to bind to the logger context
+
+        Returns:
+            New UnifiedLogger with bound context
+        """
+        new_logger = object.__new__(self.__class__)
+        new_logger._pipeline = self._pipeline
+        new_logger._run_id = self._run_id
+        new_logger._logger = self._logger.bind(**kwargs)
+        return new_logger
+
+    def info(
+        self,
+        message: str,
+        *,
+        stage: StageType,
+        dataset: str | None = None,
+        record_count: int | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Log an informational message with mandatory stage.
+
+        Args:
+            message: The event message
+            stage: Pipeline stage (extract, transform, load, validate, init, cleanup)
+            dataset: Logical table name (SHOULD provide)
+            record_count: Count of records (SHOULD provide)
+            **kwargs: Additional context for the log entry
+        """
+        extra = {"stage": stage, **kwargs}
+        if dataset is not None:
+            extra["dataset"] = dataset
+        if record_count is not None:
+            extra["record_count"] = record_count
+
+        return self._logger.info(message, **extra)
+
+    def warning(
+        self,
+        message: str,
+        *,
+        stage: StageType,
+        dataset: str | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Log a warning message with mandatory stage.
+
+        Args:
+            message: The event message
+            stage: Pipeline stage
+            dataset: Logical table name (SHOULD provide)
+            **kwargs: Additional context for the log entry
+        """
+        extra = {"stage": stage, **kwargs}
+        if dataset is not None:
+            extra["dataset"] = dataset
+
+        return self._logger.warning(message, **extra)
+
+    def error(
+        self,
+        message: str,
+        *,
+        stage: StageType,
+        error_type: str,
+        dataset: str | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Log an error message with mandatory stage and error_type.
+
+        Args:
+            message: The event message
+            stage: Pipeline stage
+            error_type: Classification of the error (e.g., "network", "validation", "schema")
+            dataset: Logical table name (SHOULD provide)
+            **kwargs: Additional context for the log entry
+        """
+        extra = {"stage": stage, "error_type": error_type, **kwargs}
+        if dataset is not None:
+            extra["dataset"] = dataset
+
+        return self._logger.error(message, **extra)
+
+    def debug(
+        self,
+        message: str,
+        *,
+        stage: StageType,
+        **kwargs: Any,
+    ) -> Any:
+        """Log a debug message with mandatory stage.
+
+        Args:
+            message: The event message
+            stage: Pipeline stage
+            **kwargs: Additional context for the log entry
+        """
+        return self._logger.debug(message, stage=stage, **kwargs)
+
+    def exception(
+        self,
+        message: str,
+        *,
+        stage: StageType,
+        error_type: str,
+        **kwargs: Any,
+    ) -> Any:
+        """Log an exception with traceback.
+
+        Args:
+            message: The event message
+            stage: Pipeline stage
+            error_type: Classification of the error
+            **kwargs: Additional context for the log entry
+        """
+        return self._logger.exception(
+            message,
+            stage=stage,
+            error_type=error_type,
+            **kwargs,
+        )
+
+
+def create_unified_logger(
+    pipeline: str,
+    run_id: str | UUID,
+    log_level: str = "INFO",
+    json_format: bool = True,
+) -> UnifiedLogger:
+    """Factory function to create a UnifiedLogger.
+
+    Convenience function for creating a UnifiedLogger with the
+    specified configuration.
+
+    Args:
+        pipeline: Pipeline name for log context
+        run_id: Unique run identifier for tracing
+        log_level: Logging level (default: INFO)
+        json_format: Use JSON output format (default: True)
+
+    Returns:
+        Configured UnifiedLogger instance
+    """
+    return UnifiedLogger(
+        pipeline=pipeline,
+        run_id=run_id,
+        log_level=log_level,
+        json_format=json_format,
+    )

--- a/tests/unit/infrastructure/observability/test_unified_logger.py
+++ b/tests/unit/infrastructure/observability/test_unified_logger.py
@@ -1,0 +1,274 @@
+"""Unit tests for UnifiedLogger with enforced Log Schema."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from bioetl.infrastructure.observability.unified_logger import (
+    UnifiedLogger,
+    _mask_secrets,
+    _secret_filter_processor,
+    create_unified_logger,
+)
+
+
+@pytest.mark.unit
+class TestUnifiedLogger:
+    """Tests for UnifiedLogger with Log Schema enforcement."""
+
+    def test_unified_logger_creation(self) -> None:
+        """Test that UnifiedLogger can be created with required fields."""
+        run_id = uuid4()
+        logger = UnifiedLogger(
+            pipeline="test_pipeline",
+            run_id=run_id,
+        )
+
+        assert logger is not None
+
+    def test_unified_logger_info_requires_stage(self) -> None:
+        """Test that info() requires stage parameter."""
+        logger = UnifiedLogger(pipeline="test", run_id="abc-123")
+
+        # Should work with stage
+        logger.info("Test message", stage="extract")
+
+        # Without stage should raise TypeError (missing required kwarg)
+        with pytest.raises(TypeError, match="stage"):
+            logger.info("Test message")  # type: ignore[call-arg]
+
+    def test_unified_logger_error_requires_stage_and_error_type(self) -> None:
+        """Test that error() requires both stage and error_type."""
+        logger = UnifiedLogger(pipeline="test", run_id="abc-123")
+
+        # Should work with both parameters
+        logger.error("Error occurred", stage="transform", error_type="validation")
+
+        # Without error_type should raise TypeError
+        with pytest.raises(TypeError, match="error_type"):
+            logger.error("Error occurred", stage="transform")  # type: ignore[call-arg]
+
+    def test_unified_logger_bind_preserves_context(self) -> None:
+        """Test that bind() returns new logger with additional context."""
+        logger = UnifiedLogger(pipeline="test", run_id="abc-123")
+
+        bound = logger.bind(dataset="chembl_activity")
+
+        assert isinstance(bound, UnifiedLogger)
+        assert bound._pipeline == "test"
+        assert bound._run_id == "abc-123"
+
+    def test_unified_logger_with_optional_fields(self) -> None:
+        """Test that optional fields can be passed."""
+        logger = UnifiedLogger(pipeline="test", run_id="abc-123")
+
+        # Should accept optional dataset and record_count
+        logger.info(
+            "Fetched records",
+            stage="extract",
+            dataset="chembl_activity",
+            record_count=100,
+        )
+
+        logger.warning(
+            "Low record count",
+            stage="extract",
+            dataset="chembl_activity",
+            expected_count=1000,
+            actual_count=100,
+        )
+
+    def test_unified_logger_all_stages_accepted(self) -> None:
+        """Test that all valid stage values are accepted."""
+        logger = UnifiedLogger(pipeline="test", run_id="abc-123")
+
+        valid_stages = ["extract", "transform", "load", "validate", "init", "cleanup"]
+
+        for stage in valid_stages:
+            # Should not raise
+            logger.info(f"Testing stage {stage}", stage=stage)  # type: ignore[arg-type]
+
+    def test_unified_logger_debug_requires_stage(self) -> None:
+        """Test that debug() requires stage parameter."""
+        logger = UnifiedLogger(pipeline="test", run_id="abc-123")
+
+        # Should work with stage
+        logger.debug("Debug message", stage="extract")
+
+        # Without stage should raise TypeError
+        with pytest.raises(TypeError):
+            logger.debug("Debug message")  # type: ignore[call-arg]
+
+    def test_unified_logger_exception_requires_stage_and_error_type(self) -> None:
+        """Test that exception() requires stage and error_type."""
+        logger = UnifiedLogger(pipeline="test", run_id="abc-123")
+
+        # Should work with both parameters
+        logger.exception("Exception occurred", stage="load", error_type="io_error")
+
+
+@pytest.mark.unit
+class TestCreateUnifiedLogger:
+    """Tests for create_unified_logger factory function."""
+
+    def test_create_unified_logger_returns_unified_logger(self) -> None:
+        """Test that factory returns UnifiedLogger instance."""
+        logger = create_unified_logger(
+            pipeline="test_pipeline",
+            run_id=uuid4(),
+        )
+
+        assert isinstance(logger, UnifiedLogger)
+
+    def test_create_unified_logger_with_uuid(self) -> None:
+        """Test that UUID run_id is converted to string."""
+        run_id = uuid4()
+        logger = create_unified_logger(
+            pipeline="test_pipeline",
+            run_id=run_id,
+        )
+
+        assert logger._run_id == str(run_id)
+
+    def test_create_unified_logger_with_string_run_id(self) -> None:
+        """Test that string run_id is preserved."""
+        logger = create_unified_logger(
+            pipeline="test_pipeline",
+            run_id="my-custom-run-id",
+        )
+
+        assert logger._run_id == "my-custom-run-id"
+
+
+@pytest.mark.unit
+class TestSecretFiltering:
+    """Tests for secret filtering functionality."""
+
+    def test_mask_api_key(self) -> None:
+        """Test that API keys are masked."""
+        text = "api_key=sk-abc123def456"
+        result = _mask_secrets(text)
+
+        assert "sk-abc123def456" not in result
+        assert "[REDACTED" in result
+
+    def test_mask_authorization_header(self) -> None:
+        """Test that Authorization headers are masked."""
+        text = "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+        result = _mask_secrets(text)
+
+        assert "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" not in result
+        assert "[REDACTED" in result
+
+    def test_mask_password(self) -> None:
+        """Test that passwords are masked."""
+        text = "password=mysecretpassword"
+        result = _mask_secrets(text)
+
+        assert "mysecretpassword" not in result
+        assert "[REDACTED" in result
+
+    def test_mask_aws_key(self) -> None:
+        """Test that AWS access keys are masked."""
+        text = "AKIAIOSFODNN7EXAMPLE"
+        result = _mask_secrets(text)
+
+        assert "AKIAIOSFODNN7EXAMPLE" not in result
+        assert "[REDACTED" in result
+
+    def test_no_mask_for_normal_text(self) -> None:
+        """Test that normal text is not masked."""
+        text = "This is a normal log message with record count 100"
+        result = _mask_secrets(text)
+
+        assert result == text
+
+    def test_mask_secrets_non_string(self) -> None:
+        """Test that non-string values are passed through."""
+        assert _mask_secrets(123) == 123
+        assert _mask_secrets(None) is None
+        assert _mask_secrets(["list"]) == ["list"]
+
+    def test_secret_filter_processor_masks_values(self) -> None:
+        """Test that the processor masks secrets in event dict."""
+        event_dict = {
+            "message": "Login with api_key=secret123",
+            "headers": {"Authorization": "Bearer token123"},
+            "count": 100,  # Should not be affected
+        }
+
+        result = _secret_filter_processor(None, "info", event_dict)
+
+        # Check that secrets are masked
+        assert "secret123" not in result["message"]
+        # Nested dicts should also be processed
+        assert "token123" not in str(result.get("headers", {}))
+        # Numbers should be preserved
+        assert result["count"] == 100
+
+    def test_secret_filter_processor_handles_nested_dicts(self) -> None:
+        """Test that nested dicts are processed."""
+        event_dict = {
+            "config": {
+                "password": "secret123",
+                "timeout": 30,
+            }
+        }
+
+        result = _secret_filter_processor(None, "info", event_dict)
+
+        # Password should be masked if it contains secret pattern
+        # (Note: the key "password" triggers the pattern match)
+        assert result is not None
+
+
+@pytest.mark.unit
+class TestLoggingUtilsIntegration:
+    """Tests for logging_utils integration with Log Schema."""
+
+    def test_log_adapter_error_with_stage(self) -> None:
+        """Test that log_adapter_error accepts stage parameter."""
+        from unittest.mock import MagicMock
+
+        from bioetl.infrastructure.adapters.logging_utils import log_adapter_error
+
+        mock_logger = MagicMock()
+
+        log_adapter_error(
+            logger=mock_logger,
+            provider="chembl",
+            operation="fetch",
+            stage="extract",
+            error_type="network_error",
+        )
+
+        # Verify error was called with correct parameters
+        mock_logger.error.assert_called_once()
+        call_kwargs = mock_logger.error.call_args[1]
+        assert call_kwargs["stage"] == "extract"
+        assert call_kwargs["error_type"] == "network_error"
+        assert call_kwargs["provider"] == "chembl"
+        assert call_kwargs["operation"] == "fetch"
+
+    def test_log_adapter_error_default_stage(self) -> None:
+        """Test that log_adapter_error has sensible default stage."""
+        from unittest.mock import MagicMock
+
+        from bioetl.infrastructure.adapters.logging_utils import log_adapter_error
+
+        mock_logger = MagicMock()
+
+        # Call without explicit stage
+        log_adapter_error(
+            logger=mock_logger,
+            provider="pubchem",
+            operation="health check",
+        )
+
+        call_kwargs = mock_logger.error.call_args[1]
+        # Default stage should be "extract" for adapter operations
+        assert call_kwargs["stage"] == "extract"
+        # Default error_type should be "adapter_error"
+        assert call_kwargs["error_type"] == "adapter_error"


### PR DESCRIPTION
Implements RULES.md §3.2.1 and §10.4 requirements:
- Create UnifiedLogger with mandatory ts, level, run_id, pipeline, stage fields
- Add secret filtering processor to mask API keys, tokens, passwords
- Replace print() in docstring examples with structured logging
- Update logging_utils.py with stage and error_type parameters
- Add 21 unit tests for UnifiedLogger and secret filtering

Changes:
- src/bioetl/infrastructure/observability/unified_logger.py: New UnifiedLogger class with enforced Log Schema, _secret_filter_processor for masking secrets
- src/bioetl/infrastructure/adapters/logging_utils.py: Add stage/error_type params, remove standard logging dependency
- src/bioetl/infrastructure/observability/anomaly/monitor.py: Fix docstring to use structured logging instead of print()
- tests/unit/infrastructure/observability/test_unified_logger.py: Comprehensive tests

Validation:
- grep -rn "print(" src/bioetl/infrastructure/ returns 0 results
- All 31 logging tests pass