### PR TITLE
Separate domain and use-case logic

### DIFF
--- a/src/bioetl/application/core/transform_utils.py
+++ b/src/bioetl/application/core/transform_utils.py
@@ -7,19 +7,27 @@
 - flatten_nested_dict: Разворачивание вложенных словарей с префиксом
 - extract_list_field: Извлечение поля из списка словарей
 - aggregate_nested_lists: Агрегация вложенных списков
-- normalize_string: Нормализация строковых полей
-- parse_date_field: Парсинг даты с обработкой ошибок
-- validate_smiles: Валидация SMILES строки
+- normalize_string: Нормализация строковых полей (delegated to domain)
+- parse_date_field: Парсинг даты с обработкой ошибок (delegated to domain)
+- validate_smiles: Валидация SMILES строки (delegated to domain)
+
+Note: Business logic functions are delegated to domain layer per REFACTOR-004.
 """
 
 from __future__ import annotations
 
-import re
 from collections.abc import Callable
 from datetime import date
 from typing import Any, TypeVar
 
+from bioetl.domain.normalization import (
+    normalize_string as _domain_normalize_string,
+)
+from bioetl.domain.normalization import (
+    parse_date_field as _domain_parse_date_field,
+)
 from bioetl.domain.transformations import safe_float, safe_int
+from bioetl.domain.validation import validate_smiles as _domain_validate_smiles
 
 T = TypeVar("T")
 
@@ -180,6 +188,8 @@ def normalize_string(value: str | None) -> str | None:
 
     Удаляет пробельные символы по краям и возвращает None для пустых строк.
 
+    Note: Delegated to domain.normalization.normalize_string per REFACTOR-004.
+
     Args:
         value: Строка для нормализации.
 
@@ -195,10 +205,7 @@ def normalize_string(value: str | None) -> str | None:
         None
 
     """
-    if value is None:
-        return None
-    stripped = value.strip()
-    return stripped if stripped else None
+    return _domain_normalize_string(value)
 
 
 def parse_date_field(
@@ -208,6 +215,8 @@ def parse_date_field(
     """Парсит строку даты в объект date.
 
     Безопасный парсинг с обработкой ошибок и невалидных форматов.
+
+    Note: Delegated to domain.normalization.parse_date_field per REFACTOR-004.
 
     Args:
         value: Строка с датой или None.
@@ -225,20 +234,7 @@ def parse_date_field(
         datetime.date(2024, 1, 15)
 
     """
-    if value is None:
-        return None
-
-    from datetime import datetime
-
-    try:
-        return datetime.strptime(value.strip(), fmt).date()
-    except (ValueError, AttributeError):
-        return None
-
-
-# SMILES validation regex (базовая проверка синтаксиса)
-# Допускает: буквы, цифры, скобки, точки, знаки, решётки, проценты, @, +, -, =, #
-_SMILES_PATTERN = re.compile(r"^[A-Za-z0-9@+\-=#$()\[\]\\/%.*]+$")
+    return _domain_parse_date_field(value, fmt)
 
 
 def validate_smiles(smiles: str | None) -> bool:
@@ -246,6 +242,8 @@ def validate_smiles(smiles: str | None) -> bool:
 
     Выполняет базовую синтаксическую проверку без полного парсинга молекулы.
     Для полной валидации используйте RDKit или другую химическую библиотеку.
+
+    Note: Delegated to domain.validation.validate_smiles per REFACTOR-004.
 
     Args:
         smiles: SMILES строка для проверки.
@@ -266,14 +264,7 @@ def validate_smiles(smiles: str | None) -> bool:
         False
 
     """
-    if not smiles or not isinstance(smiles, str):
-        return False
-
-    stripped = smiles.strip()
-    if not stripped:
-        return False
-
-    return bool(_SMILES_PATTERN.match(stripped))
+    return _domain_validate_smiles(smiles)
 
 
 def safe_extract(

--- a/src/bioetl/application/pipelines/chembl/cell_line_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/cell_line_transformer.py
@@ -1,6 +1,8 @@
 """ChEMBL Cell Line Transformer.
 
 Transforms Bronze records to Silver format (CellLine entity inflation).
+
+Note: Business logic functions are delegated to domain layer per REFACTOR-004.
 """
 
 from __future__ import annotations
@@ -11,7 +13,8 @@ from bioetl.application.pipelines.chembl.base_chembl_transformer import (
     BaseChemblTransformer,
 )
 from bioetl.domain.entities import CellLine
-from bioetl.domain.transformations import safe_int
+from bioetl.domain.normalization import normalize_to_string
+from bioetl.domain.validation import validate_positive_int
 
 if TYPE_CHECKING:
     from bioetl.domain.types import BronzeRecord
@@ -27,42 +30,14 @@ class CellLineTransformer(BaseChemblTransformer):
     entity_class = CellLine
     primary_id_field = "cell_chembl_id"
 
-    def _normalize_external_id(self, value: Any) -> str | None:
-        """Normalize external ID by stripping whitespace, NULL if empty.
-
-        Args:
-            value: Raw external ID value from API.
-
-        Returns:
-            Stripped string or None if empty/None.
-
-        """
-        if value is None:
-            return None
-        str_value = str(value).strip()
-        return str_value if str_value else None
-
-    def _validate_tax_id(self, value: Any) -> int | None:
-        """Validate taxonomy ID (must be > 0 or NULL).
-
-        Args:
-            value: Raw tax_id value from API.
-
-        Returns:
-            Valid tax_id (>= 1) or None.
-
-        """
-        tax_id = safe_int(value)
-        if tax_id is not None and tax_id < 1:
-            return None
-        return tax_id
-
     def _extract_business_data(
         self,
         record: BronzeRecord,
         primary_id: Any,
     ) -> dict[str, Any]:
         """Extract CellLine business data from bronze record.
+
+        Delegates normalization/validation to domain layer per REFACTOR-004.
 
         Args:
             record: Raw Bronze record from ChEMBL API.
@@ -72,10 +47,8 @@ class CellLineTransformer(BaseChemblTransformer):
             Dictionary of CellLine business fields.
 
         """
-        # Get cell_name with strip and lowercase normalization for comparison
-        cell_name = record.get("cell_name")
-        if cell_name is not None:
-            cell_name = str(cell_name).strip()
+        # Get cell_name with strip normalization using domain function
+        cell_name = normalize_to_string(record.get("cell_name"))
 
         return {
             # Primary identifier
@@ -86,13 +59,12 @@ class CellLineTransformer(BaseChemblTransformer):
             # Source information
             "cell_source_tissue": record.get("cell_source_tissue"),
             "cell_source_organism": record.get("cell_source_organism"),
-            "cell_source_tax_id": self._validate_tax_id(
+            # Use domain validation for tax_id (must be positive)
+            "cell_source_tax_id": validate_positive_int(
                 record.get("cell_source_tax_id")
             ),
-            # External identifiers (strip, NULL if empty)
-            "cellosaurus_id": self._normalize_external_id(
-                record.get("cellosaurus_id")
-            ),
-            "cl_lincs_id": self._normalize_external_id(record.get("cl_lincs_id")),
-            "efo_id": self._normalize_external_id(record.get("efo_id")),
+            # External identifiers (strip, NULL if empty) using domain normalization
+            "cellosaurus_id": normalize_to_string(record.get("cellosaurus_id")),
+            "cl_lincs_id": normalize_to_string(record.get("cl_lincs_id")),
+            "efo_id": normalize_to_string(record.get("efo_id")),
         }

--- a/src/bioetl/application/pipelines/chembl/compound_record_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/compound_record_transformer.py
@@ -1,6 +1,8 @@
 """ChEMBL Compound Record Transformer.
 
 Transforms Bronze records to Silver format (CompoundRecord entity inflation).
+
+Note: Business logic functions are delegated to domain layer per REFACTOR-004.
 """
 
 from __future__ import annotations
@@ -11,6 +13,7 @@ from bioetl.application.pipelines.chembl.base_chembl_transformer import (
     BaseChemblTransformer,
 )
 from bioetl.domain.entities import CompoundRecord
+from bioetl.domain.normalization import normalize_to_string
 from bioetl.domain.transformations import safe_int
 
 if TYPE_CHECKING:
@@ -27,42 +30,14 @@ class CompoundRecordTransformer(BaseChemblTransformer):
     entity_class = CompoundRecord
     primary_id_field = "record_id"
 
-    def _normalize_string(self, value: Any) -> str | None:
-        """Normalize string by stripping whitespace, NULL if empty.
-
-        Args:
-            value: Raw string value from API.
-
-        Returns:
-            Stripped string or None if empty/None.
-
-        """
-        if value is None:
-            return None
-        str_value = str(value).strip()
-        return str_value if str_value else None
-
-    def _validate_positive_int(self, value: Any) -> int | None:
-        """Validate integer is positive (>= 1) or return None.
-
-        Args:
-            value: Raw int value from API.
-
-        Returns:
-            Valid int (>= 1) or None.
-
-        """
-        int_value = safe_int(value)
-        if int_value is not None and int_value < 1:
-            return None
-        return int_value
-
     def _extract_business_data(
         self,
         record: BronzeRecord,
         primary_id: Any,
     ) -> dict[str, Any]:
         """Extract CompoundRecord business data from bronze record.
+
+        Delegates normalization to domain layer per REFACTOR-004.
 
         Args:
             record: Raw Bronze record from ChEMBL API.
@@ -79,8 +54,9 @@ class CompoundRecordTransformer(BaseChemblTransformer):
         src_id = safe_int(record.get("src_id"))
 
         # Get molecule_chembl_id and document_chembl_id - required fields
-        molecule_chembl_id = self._normalize_string(record.get("molecule_chembl_id"))
-        document_chembl_id = self._normalize_string(record.get("document_chembl_id"))
+        # Use domain normalization function
+        molecule_chembl_id = normalize_to_string(record.get("molecule_chembl_id"))
+        document_chembl_id = normalize_to_string(record.get("document_chembl_id"))
 
         return {
             # Primary identifier
@@ -89,9 +65,9 @@ class CompoundRecordTransformer(BaseChemblTransformer):
             "molecule_chembl_id": molecule_chembl_id,
             "document_chembl_id": document_chembl_id,
             # Original compound names (strip whitespace, NULL if empty)
-            "compound_key": self._normalize_string(record.get("compound_key")),
-            "compound_name": self._normalize_string(record.get("compound_name")),
+            "compound_key": normalize_to_string(record.get("compound_key")),
+            "compound_name": normalize_to_string(record.get("compound_name")),
             # Source information
             "src_id": src_id,
-            "src_compound_id": self._normalize_string(record.get("src_compound_id")),
+            "src_compound_id": normalize_to_string(record.get("src_compound_id")),
         }

--- a/src/bioetl/application/pipelines/crossref/transformer.py
+++ b/src/bioetl/application/pipelines/crossref/transformer.py
@@ -1,30 +1,35 @@
 """CrossRef Transformer.
 
 Transforms Bronze records to Silver format (Work entity inflation).
-Contains business logic for CrossRef data transformation per Hexagonal Architecture.
+Contains orchestration logic for CrossRef data transformation per Hexagonal Architecture.
 
 This module was refactored from infrastructure/adapters/crossref/mappers.py
 to properly separate business logic from infrastructure concerns.
+
+Note: Business logic functions are delegated to domain layer per REFACTOR-004.
 """
 
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING, Any, cast
 
 from bioetl.application.core.base_transformer import BaseTransformer
 from bioetl.domain.entities.crossref import CROSSREF_TYPE_MAP, Work
+from bioetl.domain.normalization import (
+    extract_first_string,
+    format_date_parts,
+    normalize_doi,
+    parse_page_range,
+    strip_html_tags,
+)
 from bioetl.domain.transformations import generate_entity_id
+from bioetl.domain.validation import validate_year_range
 
 if TYPE_CHECKING:
     from bioetl.domain.context import PipelineContext
     from bioetl.domain.filtering import GoldFilterConfig
     from bioetl.domain.ports import MetricsPort, TracingPort
     from bioetl.domain.types import BronzeRecord, SilverRecord
-
-
-# HTML tag pattern for stripping from abstract
-_HTML_TAG_PATTERN = re.compile(r"<[^>]+>")
 
 
 class CrossRefTransformer(BaseTransformer):
@@ -60,41 +65,14 @@ class CrossRefTransformer(BaseTransformer):
         )
 
     # ========================================================================
-    # Field Extraction Methods (Business Logic)
+    # Field Extraction Methods (Orchestration - delegates to domain)
     # ========================================================================
 
     @staticmethod
-    def normalize_doi(doi: str) -> str:
-        """Normalize DOI to lowercase, stripped format.
-
-        Args:
-            doi: Raw DOI string from API.
-
-        Returns:
-            Normalized DOI (lowercase, stripped).
-
-        """
-        return doi.strip().lower()
-
-    @staticmethod
-    def extract_title(work: dict[str, Any]) -> str | None:
-        """Extract first title from work response.
-
-        Args:
-            work: CrossRef work record.
-
-        Returns:
-            First title or None.
-
-        """
-        titles = work.get("title", [])
-        if titles and len(titles) > 0:
-            return str(titles[0]).strip()
-        return None
-
-    @staticmethod
-    def extract_authors(work: dict[str, Any]) -> list[str]:
+    def _extract_authors(work: dict[str, Any]) -> list[str]:
         """Extract author names in 'given family' format.
+
+        This is CrossRef-specific extraction logic (not generic normalization).
 
         Args:
             work: CrossRef work record.
@@ -116,26 +94,11 @@ class CrossRefTransformer(BaseTransformer):
         return authors
 
     @staticmethod
-    def extract_journal(work: dict[str, Any]) -> str | None:
-        """Extract journal name from container-title.
-
-        Args:
-            work: CrossRef work record.
-
-        Returns:
-            First container title or None.
-
-        """
-        container = work.get("container-title", [])
-        if container and len(container) > 0:
-            return str(container[0]).strip()
-        return None
-
-    @staticmethod
-    def extract_year(work: dict[str, Any]) -> int | None:
+    def _extract_year(work: dict[str, Any]) -> int | None:
         """Extract publication year from date-parts.
 
         Tries published-print, then published-online, then issued.
+        Delegates validation to domain.validation.validate_year_range.
 
         Args:
             work: CrossRef work record.
@@ -149,113 +112,12 @@ class CrossRefTransformer(BaseTransformer):
             date_parts = date_info.get("date-parts", [[]])
             if date_parts and date_parts[0] and len(date_parts[0]) > 0:
                 year = date_parts[0][0]
-                if isinstance(year, int) and 1800 <= year <= 2100:
+                if isinstance(year, int) and validate_year_range(year):
                     return year
         return None
 
     @staticmethod
-    def format_date_parts(date_parts: list[list[int]] | None) -> str | None:
-        """Format date-parts to ISO date string.
-
-        Args:
-            date_parts: CrossRef date-parts array [[year, month, day]].
-
-        Returns:
-            ISO date string (YYYY-MM-DD, YYYY-MM, or YYYY).
-
-        """
-        if not date_parts or not date_parts[0]:
-            return None
-
-        parts = date_parts[0]
-        if len(parts) >= 3:
-            return f"{parts[0]:04d}-{parts[1]:02d}-{parts[2]:02d}"
-        elif len(parts) >= 2:
-            return f"{parts[0]:04d}-{parts[1]:02d}"
-        elif len(parts) >= 1:
-            return f"{parts[0]:04d}"
-        return None
-
-    @staticmethod
-    def extract_pages(work: dict[str, Any]) -> tuple[str | None, str | None]:
-        """Extract first and last page from page field.
-
-        Args:
-            work: CrossRef work record.
-
-        Returns:
-            Tuple of (first_page, last_page).
-
-        """
-        page = work.get("page", "")
-        if not page:
-            return None, None
-
-        if "-" in page:
-            parts = page.split("-", 1)
-            first = parts[0].strip() or None
-            last = parts[1].strip() if len(parts) > 1 else None
-            return first, last
-        return page.strip() or None, None
-
-    @staticmethod
-    def strip_html_tags(text: str) -> str:
-        """Strip HTML tags from abstract text.
-
-        Args:
-            text: Abstract text potentially containing HTML.
-
-        Returns:
-            Plain text with HTML tags removed.
-
-        """
-        return _HTML_TAG_PATTERN.sub("", text).strip()
-
-    @staticmethod
-    def extract_abstract(work: dict[str, Any]) -> str | None:
-        """Extract and clean abstract text.
-
-        Args:
-            work: CrossRef work record.
-
-        Returns:
-            Clean abstract text or None.
-
-        """
-        abstract = work.get("abstract", "")
-        if not abstract:
-            return None
-        return CrossRefTransformer.strip_html_tags(abstract) or None
-
-    @staticmethod
-    def map_doc_type(crossref_type: str) -> str:
-        """Map CrossRef type to internal document type.
-
-        Args:
-            crossref_type: CrossRef work type.
-
-        Returns:
-            Internal document type (PUBLICATION or PREPRINT).
-
-        """
-        return CROSSREF_TYPE_MAP.get(crossref_type, "PUBLICATION")
-
-    @staticmethod
-    def extract_issn(work: dict[str, Any]) -> list[str]:
-        """Extract ISSN list from work.
-
-        Args:
-            work: CrossRef work record.
-
-        Returns:
-            List of ISSNs.
-
-        """
-        issns: list[str] = work.get("ISSN", [])
-        return issns
-
-    @staticmethod
-    def extract_license_url(work: dict[str, Any]) -> str | None:
+    def _extract_license_url(work: dict[str, Any]) -> str | None:
         """Extract license URL from work.
 
         Args:
@@ -271,26 +133,14 @@ class CrossRefTransformer(BaseTransformer):
             return url
         return None
 
-    @staticmethod
-    def extract_subjects(work: dict[str, Any]) -> list[str]:
-        """Extract subject areas from work.
-
-        Args:
-            work: CrossRef work record.
-
-        Returns:
-            List of subject areas.
-
-        """
-        subjects: list[str] = work.get("subject", [])
-        return subjects
-
     # ========================================================================
     # Main Transformation
     # ========================================================================
 
     def _extract_business_data(self, record: BronzeRecord) -> dict[str, Any]:
         """Extract Work business data from bronze record.
+
+        Delegates normalization to domain layer per REFACTOR-004.
 
         Args:
             record: Raw Bronze record from CrossRef API.
@@ -299,38 +149,43 @@ class CrossRefTransformer(BaseTransformer):
             Dictionary of Work business fields.
 
         """
-        doi = self.normalize_doi(record.get("DOI", ""))
-        first_page, last_page = self.extract_pages(record)
+        # Use domain functions for normalization
+        doi = normalize_doi(record.get("DOI", "")) or ""
+        first_page, last_page = parse_page_range(record.get("page"))
 
-        # Extract date fields
+        # Extract date fields using domain functions
         published_print = record.get("published-print", {})
         published_online = record.get("published-online", {})
 
+        # Extract abstract with HTML stripping via domain function
+        abstract_raw = record.get("abstract", "")
+        abstract = strip_html_tags(abstract_raw) if abstract_raw else None
+
         return {
             "doi": doi,
-            "title": self.extract_title(record),
-            "abstract": self.extract_abstract(record),
-            "authors": self.extract_authors(record),
-            "journal": self.extract_journal(record),
-            "issn": self.extract_issn(record),
+            "title": extract_first_string(record.get("title", [])),
+            "abstract": abstract,
+            "authors": self._extract_authors(record),
+            "journal": extract_first_string(record.get("container-title", [])),
+            "issn": record.get("ISSN", []),
             "publisher": record.get("publisher"),
             "volume": record.get("volume"),
             "issue": record.get("issue"),
             "first_page": first_page,
             "last_page": last_page,
-            "year": self.extract_year(record),
-            "published_print": self.format_date_parts(
+            "year": self._extract_year(record),
+            "published_print": format_date_parts(
                 published_print.get("date-parts") if isinstance(published_print, dict) else None
             ),
-            "published_online": self.format_date_parts(
+            "published_online": format_date_parts(
                 published_online.get("date-parts") if isinstance(published_online, dict) else None
             ),
-            "doc_type": self.map_doc_type(record.get("type", "")),
+            "doc_type": CROSSREF_TYPE_MAP.get(record.get("type", ""), "PUBLICATION"),
             "citation_count": record.get("is-referenced-by-count"),
             "reference_count": record.get("references-count"),
             "language": record.get("language"),
-            "license_url": self.extract_license_url(record),
-            "subjects": self.extract_subjects(record),
+            "license_url": self._extract_license_url(record),
+            "subjects": record.get("subject", []),
             "source": "crossref",
         }
 

--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -132,6 +132,19 @@ from bioetl.domain.ports import (
 # Resilience (domain value objects)
 from bioetl.domain.resilience import RetryPolicy
 
+# Pure domain normalization (REFACTOR-004)
+from bioetl.domain.normalization import (
+    extract_first_item,
+    extract_first_string,
+    format_date_parts,
+    normalize_doi,
+    normalize_string,
+    normalize_to_string,
+    parse_date_field,
+    parse_page_range,
+    strip_html_tags,
+)
+
 # Pure domain transformations
 from bioetl.domain.transformations import (
     META_FIELDS,
@@ -146,6 +159,16 @@ from bioetl.domain.transformations import (
     safe_float,
     safe_int,
     safe_str,
+)
+
+# Pure domain validation (REFACTOR-004)
+from bioetl.domain.validation import (
+    validate_doi,
+    validate_non_empty_string,
+    validate_non_negative,
+    validate_positive_int,
+    validate_smiles,
+    validate_year_range,
 )
 
 # Types
@@ -272,6 +295,16 @@ __all__ = [
     "TracingPort",
     # Resilience
     "RetryPolicy",
+    # Normalization (pure functions, REFACTOR-004)
+    "extract_first_item",
+    "extract_first_string",
+    "format_date_parts",
+    "normalize_doi",
+    "normalize_string",
+    "normalize_to_string",
+    "parse_date_field",
+    "parse_page_range",
+    "strip_html_tags",
     # Transformations (pure functions)
     "META_FIELDS",
     "calculate_dq_score",
@@ -285,6 +318,13 @@ __all__ = [
     "safe_float",
     "safe_int",
     "safe_str",
+    # Validation (pure functions, REFACTOR-004)
+    "validate_doi",
+    "validate_non_empty_string",
+    "validate_non_negative",
+    "validate_positive_int",
+    "validate_smiles",
+    "validate_year_range",
     # Types
     "ArrowSchema",
     "BatchID",

--- a/src/bioetl/domain/normalization.py
+++ b/src/bioetl/domain/normalization.py
@@ -1,0 +1,98 @@
+"""Pure domain normalization functions (no I/O).
+
+REFACTOR-004: Domain logic separation from use-case layer.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date
+from typing import Any
+
+
+def normalize_string(value: str | None) -> str | None:
+    """Normalize string by stripping whitespace, return None for empty."""
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped if stripped else None
+
+
+def normalize_to_string(value: Any) -> str | None:
+    """Convert value to string, strip whitespace, return None if empty."""
+    if value is None:
+        return None
+    str_value = str(value).strip()
+    return str_value if str_value else None
+
+
+def normalize_doi(doi: str | None) -> str | None:
+    """Normalize DOI to lowercase, stripped format."""
+    return doi.strip().lower() if doi else None
+
+
+# Date formatting helpers
+_DATE_FORMATS = {3: "{0:04d}-{1:02d}-{2:02d}", 2: "{0:04d}-{1:02d}", 1: "{0:04d}"}
+
+
+def format_date_parts(date_parts: list[list[int]] | None) -> str | None:
+    """Format CrossRef date-parts [[year, month?, day?]] to ISO string."""
+    if not date_parts or not date_parts[0]:
+        return None
+    parts = date_parts[0]
+    fmt = _DATE_FORMATS.get(min(len(parts), 3))
+    return fmt.format(*parts) if fmt else None
+
+
+def parse_date_field(value: str | None, fmt: str = "%Y-%m-%d") -> date | None:
+    """Parse date string to date object, return None on error."""
+    if value is None:
+        return None
+    from datetime import datetime
+    try:
+        return datetime.strptime(value.strip(), fmt).date()
+    except (ValueError, AttributeError):
+        return None
+
+
+_HTML_TAG_PATTERN = re.compile(r"<[^>]+>")
+
+
+def strip_html_tags(text: str | None) -> str | None:
+    """Strip HTML tags from text, return None if empty."""
+    if not text:
+        return None
+    result = _HTML_TAG_PATTERN.sub("", text).strip()
+    return result if result else None
+
+
+def _to_none_if_empty(s: str) -> str | None:
+    """Return None if string is empty after strip."""
+    return s.strip() or None
+
+
+def parse_page_range(page: str | None) -> tuple[str | None, str | None]:
+    """Parse page range '123-456' to (first, last) tuple."""
+    if not page:
+        return None, None
+    first, sep, last = page.partition("-")
+    return _to_none_if_empty(first), _to_none_if_empty(last) if sep else None
+
+
+def extract_first_item(items: list[Any] | None) -> Any | None:
+    """Extract first non-None item from list."""
+    if not items or not isinstance(items, list):
+        return None
+    return next((item for item in items if item is not None), None)
+
+
+def _is_valid_string(item: Any) -> str | None:
+    """Return stripped string if non-empty, else None."""
+    return str(item).strip() if item is not None else None
+
+
+def extract_first_string(items: list[str] | None) -> str | None:
+    """Extract first non-empty stripped string from list."""
+    if not items or not isinstance(items, list):
+        return None
+    return next((s for item in items if (s := _is_valid_string(item))), None)

--- a/src/bioetl/domain/validation.py
+++ b/src/bioetl/domain/validation.py
@@ -1,0 +1,228 @@
+"""Pure domain validation functions (no I/O).
+
+Implements business validation rules as pure functions.
+All functions are deterministic and side-effect free.
+
+Requirements:
+- REQ-ARCH-003: No I/O in domain layer
+- REFACTOR-004: Domain logic separation from use-case layer
+
+See also:
+- docs/RULES.md §1.1 (Domain — pure functions)
+- docs/RULES.md §8.1 (Pandera-schemas for structural validation)
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from .transformations import safe_int
+
+# =============================================================================
+# SMILES Validation (Chemical Structure)
+# =============================================================================
+
+# SMILES validation regex (basic syntax check)
+# Allowed: letters, digits, brackets, dots, signs, hashes, percentages, @, +, -, =, #
+_SMILES_PATTERN = re.compile(r"^[A-Za-z0-9@+\-=#$()\[\]\\/%.*]+$")
+
+
+def validate_smiles(smiles: str | None) -> bool:
+    """Validate SMILES string format.
+
+    Performs basic syntactic validation without full molecule parsing.
+    For complete validation use RDKit or other chemical libraries.
+
+    Args:
+        smiles: SMILES string to validate.
+
+    Returns:
+        True if string matches basic SMILES syntax.
+
+    Example:
+        >>> validate_smiles("CCO")  # Ethanol
+        True
+        >>> validate_smiles("C1=CC=CC=C1")  # Benzene
+        True
+        >>> validate_smiles("")
+        False
+        >>> validate_smiles(None)
+        False
+        >>> validate_smiles("invalid smiles with spaces")
+        False
+
+    """
+    if not smiles or not isinstance(smiles, str):
+        return False
+
+    stripped = smiles.strip()
+    if not stripped:
+        return False
+
+    return bool(_SMILES_PATTERN.match(stripped))
+
+
+# =============================================================================
+# Numeric Validation
+# =============================================================================
+
+
+def validate_positive_int(value: Any) -> int | None:
+    """Validate integer is positive (>= 1) or return None.
+
+    Used for validating IDs, counts, and other positive integer fields.
+
+    Args:
+        value: Raw value to validate (string, int, or other convertible type).
+
+    Returns:
+        Valid int (>= 1) or None if invalid/non-positive.
+
+    Example:
+        >>> validate_positive_int(42)
+        42
+        >>> validate_positive_int("123")
+        123
+        >>> validate_positive_int(0)
+        None
+        >>> validate_positive_int(-1)
+        None
+        >>> validate_positive_int("invalid")
+        None
+
+    """
+    int_value = safe_int(value)
+    if int_value is not None and int_value < 1:
+        return None
+    return int_value
+
+
+def validate_year_range(
+    year: int | None,
+    min_year: int = 1800,
+    max_year: int = 2100,
+) -> bool:
+    """Validate year is within a reasonable range.
+
+    Default range [1800, 2100] covers scientific publications.
+
+    Args:
+        year: Year to validate.
+        min_year: Minimum valid year (inclusive). Default 1800.
+        max_year: Maximum valid year (inclusive). Default 2100.
+
+    Returns:
+        True if year is within range.
+
+    Example:
+        >>> validate_year_range(2024)
+        True
+        >>> validate_year_range(1799)
+        False
+        >>> validate_year_range(2101)
+        False
+        >>> validate_year_range(None)
+        False
+
+    """
+    if year is None:
+        return False
+    return min_year <= year <= max_year
+
+
+def validate_non_negative(value: Any) -> float | None:
+    """Validate numeric value is non-negative (>= 0) or return None.
+
+    Used for validating concentrations, counts, and other non-negative fields.
+
+    Args:
+        value: Raw value to validate.
+
+    Returns:
+        Valid float (>= 0) or None if invalid/negative.
+
+    Example:
+        >>> validate_non_negative(0.0)
+        0.0
+        >>> validate_non_negative(42.5)
+        42.5
+        >>> validate_non_negative(-1.0)
+        None
+        >>> validate_non_negative("invalid")
+        None
+
+    """
+    if value is None:
+        return None
+    try:
+        float_value = float(value)
+        if float_value < 0:
+            return None
+        return float_value
+    except (ValueError, TypeError):
+        return None
+
+
+# =============================================================================
+# String Validation
+# =============================================================================
+
+
+def validate_non_empty_string(value: str | None) -> str | None:
+    """Validate string is non-empty after stripping whitespace.
+
+    Args:
+        value: String to validate.
+
+    Returns:
+        Stripped string if non-empty, None otherwise.
+
+    Example:
+        >>> validate_non_empty_string("  hello  ")
+        'hello'
+        >>> validate_non_empty_string("   ")
+        None
+        >>> validate_non_empty_string(None)
+        None
+
+    """
+    if value is None:
+        return None
+    stripped = str(value).strip()
+    return stripped if stripped else None
+
+
+# =============================================================================
+# DOI Validation
+# =============================================================================
+
+# DOI regex pattern: 10.XXXX/... where XXXX is registrant code
+_DOI_PATTERN = re.compile(r"^10\.\d{4,}/.*$")
+
+
+def validate_doi(doi: str | None) -> bool:
+    """Validate DOI format.
+
+    Checks if DOI matches the standard format: 10.XXXX/...
+
+    Args:
+        doi: DOI string to validate.
+
+    Returns:
+        True if DOI format is valid.
+
+    Example:
+        >>> validate_doi("10.1038/nature12373")
+        True
+        >>> validate_doi("10.1000/xyz123")
+        True
+        >>> validate_doi("invalid")
+        False
+        >>> validate_doi(None)
+        False
+
+    """
+    if not doi or not isinstance(doi, str):
+        return False
+    return bool(_DOI_PATTERN.match(doi.strip().lower()))

--- a/tests/architecture/test_domain_public_api.py
+++ b/tests/architecture/test_domain_public_api.py
@@ -42,11 +42,13 @@ def test_domain_all_is_complete(src_dir: Path) -> None:
         "filtering",
         "locking",
         "medallion",
+        "normalization",  # REFACTOR-004: functions are re-exported, not module
         "ports",
         "resilience",
         "serialization",
         "transformations",
         "types",
+        "validation",  # REFACTOR-004: functions are re-exported, not module
     }
 
     # Get all attributes from the module

--- a/tests/unit/application/pipelines/crossref/test_crossref_transformer.py
+++ b/tests/unit/application/pipelines/crossref/test_crossref_transformer.py
@@ -1,6 +1,8 @@
 """Unit tests for CrossRef Transformer.
 
 Tests for CrossRefTransformer (domain entity creation from Bronze records).
+
+Note: Field extraction tests now use domain functions directly per REFACTOR-004.
 """
 
 from __future__ import annotations
@@ -12,6 +14,8 @@ import pytest
 
 from bioetl.application.pipelines.crossref.transformer import CrossRefTransformer
 from bioetl.domain.context import PipelineContext
+from bioetl.domain.entities.crossref import CROSSREF_TYPE_MAP
+from bioetl.domain.normalization import extract_first_string, normalize_doi
 from bioetl.domain.types import RunID, RunType
 
 
@@ -71,39 +75,39 @@ def minimal_work():
 
 
 # =============================================================================
-# Field extraction tests (delegated to static methods)
+# Field extraction tests (delegated to domain functions per REFACTOR-004)
 # =============================================================================
 
 
-def test_normalize_doi(transformer):
-    """Test DOI normalization."""
-    assert transformer.normalize_doi("10.1234/ABC.DEF") == "10.1234/abc.def"
-    assert transformer.normalize_doi("  10.1234/test  ") == "10.1234/test"
+def test_normalize_doi():
+    """Test DOI normalization using domain function."""
+    assert normalize_doi("10.1234/ABC.DEF") == "10.1234/abc.def"
+    assert normalize_doi("  10.1234/test  ") == "10.1234/test"
 
 
-def test_extract_title(transformer, sample_work):
-    """Test title extraction."""
-    assert transformer.extract_title(sample_work) == "Test Article Title"
-    assert transformer.extract_title({}) is None
+def test_extract_title(sample_work):
+    """Test title extraction using domain function."""
+    assert extract_first_string(sample_work.get("title", [])) == "Test Article Title"
+    assert extract_first_string([]) is None
 
 
 def test_extract_authors(transformer, sample_work):
-    """Test author extraction."""
-    authors = transformer.extract_authors(sample_work)
+    """Test author extraction (CrossRef-specific logic)."""
+    authors = transformer._extract_authors(sample_work)
     assert authors == ["John Doe", "Jane Smith", "Anonymous"]
 
 
 def test_extract_year(transformer, sample_work):
-    """Test year extraction."""
-    assert transformer.extract_year(sample_work) == 2023
-    assert transformer.extract_year({}) is None
+    """Test year extraction (CrossRef-specific logic)."""
+    assert transformer._extract_year(sample_work) == 2023
+    assert transformer._extract_year({}) is None
 
 
-def test_map_doc_type(transformer):
-    """Test document type mapping."""
-    assert transformer.map_doc_type("journal-article") == "PUBLICATION"
-    assert transformer.map_doc_type("posted-content") == "PREPRINT"
-    assert transformer.map_doc_type("unknown") == "PUBLICATION"
+def test_map_doc_type():
+    """Test document type mapping using domain constant."""
+    assert CROSSREF_TYPE_MAP.get("journal-article", "PUBLICATION") == "PUBLICATION"
+    assert CROSSREF_TYPE_MAP.get("posted-content", "PUBLICATION") == "PREPRINT"
+    assert CROSSREF_TYPE_MAP.get("unknown", "PUBLICATION") == "PUBLICATION"
 
 
 # =============================================================================

--- a/tests/unit/domain/test_normalization.py
+++ b/tests/unit/domain/test_normalization.py
@@ -1,0 +1,220 @@
+"""Tests for domain.normalization module.
+
+Tests pure normalization functions per REFACTOR-004.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from bioetl.domain.normalization import (
+    extract_first_item,
+    extract_first_string,
+    format_date_parts,
+    normalize_doi,
+    normalize_string,
+    normalize_to_string,
+    parse_date_field,
+    parse_page_range,
+    strip_html_tags,
+)
+
+
+class TestNormalizeString:
+    """Tests for normalize_string function."""
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("hello", "hello"),
+            ("  hello  ", "hello"),
+            ("hello world", "hello world"),
+            ("  ", None),
+            ("", None),
+            (None, None),
+        ],
+    )
+    def test_normalize_string(self, value: str | None, expected: str | None) -> None:
+        """Test string normalization."""
+        assert normalize_string(value) == expected
+
+
+class TestNormalizeToString:
+    """Tests for normalize_to_string function."""
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("hello", "hello"),
+            ("  hello  ", "hello"),
+            (42, "42"),
+            (3.14, "3.14"),
+            (True, "True"),
+            ("", None),
+            ("  ", None),
+            (None, None),
+        ],
+    )
+    def test_normalize_to_string(self, value, expected: str | None) -> None:
+        """Test conversion and normalization to string."""
+        assert normalize_to_string(value) == expected
+
+
+class TestNormalizeDoi:
+    """Tests for normalize_doi function."""
+
+    @pytest.mark.parametrize(
+        "doi,expected",
+        [
+            ("10.1038/nature12373", "10.1038/nature12373"),
+            ("10.1038/NATURE12373", "10.1038/nature12373"),
+            ("  10.1038/nature12373  ", "10.1038/nature12373"),
+            ("  10.1038/NATURE12373  ", "10.1038/nature12373"),
+            (None, None),
+        ],
+    )
+    def test_normalize_doi(self, doi: str | None, expected: str | None) -> None:
+        """Test DOI normalization."""
+        assert normalize_doi(doi) == expected
+
+
+class TestFormatDateParts:
+    """Tests for format_date_parts function."""
+
+    @pytest.mark.parametrize(
+        "date_parts,expected",
+        [
+            ([[2024, 3, 15]], "2024-03-15"),
+            ([[2024, 3]], "2024-03"),
+            ([[2024]], "2024"),
+            ([[2024, 1, 5]], "2024-01-05"),
+            ([[2024, 12, 31]], "2024-12-31"),
+            (None, None),
+            ([], None),
+            ([[]], None),
+        ],
+    )
+    def test_format_date_parts(
+        self, date_parts: list[list[int]] | None, expected: str | None
+    ) -> None:
+        """Test date-parts formatting."""
+        assert format_date_parts(date_parts) == expected
+
+
+class TestParseDateField:
+    """Tests for parse_date_field function."""
+
+    def test_valid_iso_date(self) -> None:
+        """Test parsing ISO date."""
+        assert parse_date_field("2024-03-15") == date(2024, 3, 15)
+
+    def test_valid_date_with_whitespace(self) -> None:
+        """Test parsing date with whitespace."""
+        assert parse_date_field("  2024-03-15  ") == date(2024, 3, 15)
+
+    def test_custom_format(self) -> None:
+        """Test parsing with custom format."""
+        assert parse_date_field("15/03/2024", "%d/%m/%Y") == date(2024, 3, 15)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "invalid",
+            "2024-13-01",  # Invalid month
+            "2024-01-32",  # Invalid day
+            "",
+            None,
+        ],
+    )
+    def test_invalid_date(self, value: str | None) -> None:
+        """Test invalid dates return None."""
+        assert parse_date_field(value) is None
+
+
+class TestStripHtmlTags:
+    """Tests for strip_html_tags function."""
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("<p>Hello world</p>", "Hello world"),
+            ("<b>Bold</b> text", "Bold text"),
+            ("<jats:p>Abstract text</jats:p>", "Abstract text"),
+            ("Plain text", "Plain text"),
+            ("  <p>Spaced</p>  ", "Spaced"),
+            ("", None),
+            (None, None),
+            ("<p></p>", None),  # Empty after stripping
+        ],
+    )
+    def test_strip_html_tags(self, text: str | None, expected: str | None) -> None:
+        """Test HTML tag stripping."""
+        assert strip_html_tags(text) == expected
+
+    def test_nested_tags(self) -> None:
+        """Test stripping nested HTML tags."""
+        assert strip_html_tags("<div><p>Nested <b>tags</b></p></div>") == "Nested tags"
+
+
+class TestParsePageRange:
+    """Tests for parse_page_range function."""
+
+    @pytest.mark.parametrize(
+        "page,expected",
+        [
+            ("123-456", ("123", "456")),
+            ("123", ("123", None)),
+            ("123-", ("123", None)),
+            ("-456", (None, "456")),
+            ("  123  -  456  ", ("123", "456")),
+            ("", (None, None)),
+            (None, (None, None)),
+        ],
+    )
+    def test_parse_page_range(
+        self, page: str | None, expected: tuple[str | None, str | None]
+    ) -> None:
+        """Test page range parsing."""
+        assert parse_page_range(page) == expected
+
+
+class TestExtractFirstItem:
+    """Tests for extract_first_item function."""
+
+    @pytest.mark.parametrize(
+        "items,expected",
+        [
+            (["a", "b", "c"], "a"),
+            ([1, 2, 3], 1),
+            ([None, "b"], "b"),
+            (["single"], "single"),
+            ([], None),
+            (None, None),
+        ],
+    )
+    def test_extract_first_item(self, items, expected) -> None:
+        """Test first item extraction."""
+        assert extract_first_item(items) == expected
+
+
+class TestExtractFirstString:
+    """Tests for extract_first_string function."""
+
+    @pytest.mark.parametrize(
+        "items,expected",
+        [
+            (["  hello  ", "world"], "hello"),
+            (["title", "subtitle"], "title"),
+            ([None, "fallback"], "fallback"),
+            ([], None),
+            (None, None),
+            (["", "fallback"], "fallback"),  # Empty string skipped
+        ],
+    )
+    def test_extract_first_string(
+        self, items: list[str] | None, expected: str | None
+    ) -> None:
+        """Test first string extraction with normalization."""
+        assert extract_first_string(items) == expected

--- a/tests/unit/domain/test_validation.py
+++ b/tests/unit/domain/test_validation.py
@@ -1,0 +1,224 @@
+"""Tests for domain.validation module.
+
+Tests pure validation functions per REFACTOR-004.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bioetl.domain.validation import (
+    validate_doi,
+    validate_non_empty_string,
+    validate_non_negative,
+    validate_positive_int,
+    validate_smiles,
+    validate_year_range,
+)
+
+
+class TestValidateSmiles:
+    """Tests for validate_smiles function."""
+
+    @pytest.mark.parametrize(
+        "smiles,expected",
+        [
+            ("CCO", True),  # Ethanol
+            ("C1=CC=CC=C1", True),  # Benzene
+            ("CC(=O)O", True),  # Acetic acid
+            ("CN1C=NC2=C1C(=O)N(C(=O)N2C)C", True),  # Caffeine
+            ("c1ccccc1", True),  # Benzene (aromatic)
+            ("[Na+].[Cl-]", True),  # NaCl
+            ("CC(C)CC", True),  # Isopentane
+        ],
+    )
+    def test_valid_smiles(self, smiles: str, expected: bool) -> None:
+        """Test valid SMILES strings are accepted."""
+        assert validate_smiles(smiles) is expected
+
+    @pytest.mark.parametrize(
+        "smiles",
+        [
+            "",
+            None,
+            "   ",
+            "invalid smiles with spaces",
+            "hello world",
+            "123 abc",
+        ],
+    )
+    def test_invalid_smiles(self, smiles: str | None) -> None:
+        """Test invalid SMILES strings are rejected."""
+        assert validate_smiles(smiles) is False
+
+    def test_smiles_with_whitespace(self) -> None:
+        """Test SMILES with leading/trailing whitespace."""
+        assert validate_smiles("  CCO  ") is True
+
+
+class TestValidatePositiveInt:
+    """Tests for validate_positive_int function."""
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (1, 1),
+            (42, 42),
+            (100, 100),
+            ("123", 123),
+            (1.9, 1),  # Truncates to int
+        ],
+    )
+    def test_valid_positive_int(self, value, expected: int) -> None:
+        """Test valid positive integers are returned."""
+        assert validate_positive_int(value) == expected
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            0,
+            -1,
+            -100,
+            "0",
+            "-1",
+            None,
+            "invalid",
+            "",
+        ],
+    )
+    def test_invalid_positive_int(self, value) -> None:
+        """Test invalid values return None."""
+        assert validate_positive_int(value) is None
+
+
+class TestValidateYearRange:
+    """Tests for validate_year_range function."""
+
+    @pytest.mark.parametrize(
+        "year,expected",
+        [
+            (1800, True),
+            (1900, True),
+            (2024, True),
+            (2100, True),
+        ],
+    )
+    def test_valid_year(self, year: int, expected: bool) -> None:
+        """Test valid years in range are accepted."""
+        assert validate_year_range(year) is expected
+
+    @pytest.mark.parametrize(
+        "year",
+        [
+            1799,
+            2101,
+            0,
+            -100,
+            None,
+        ],
+    )
+    def test_invalid_year(self, year: int | None) -> None:
+        """Test invalid years are rejected."""
+        assert validate_year_range(year) is False
+
+    def test_custom_range(self) -> None:
+        """Test custom year range."""
+        assert validate_year_range(1999, min_year=2000, max_year=2050) is False
+        assert validate_year_range(2000, min_year=2000, max_year=2050) is True
+        assert validate_year_range(2025, min_year=2000, max_year=2050) is True
+        assert validate_year_range(2050, min_year=2000, max_year=2050) is True
+        assert validate_year_range(2051, min_year=2000, max_year=2050) is False
+
+
+class TestValidateNonNegative:
+    """Tests for validate_non_negative function."""
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (0, 0.0),
+            (0.0, 0.0),
+            (42.5, 42.5),
+            (100, 100.0),
+            ("3.14", 3.14),
+        ],
+    )
+    def test_valid_non_negative(self, value, expected: float) -> None:
+        """Test valid non-negative values are returned."""
+        assert validate_non_negative(value) == expected
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            -1,
+            -0.001,
+            -100.5,
+            None,
+            "invalid",
+            "",
+        ],
+    )
+    def test_invalid_non_negative(self, value) -> None:
+        """Test invalid values return None."""
+        assert validate_non_negative(value) is None
+
+
+class TestValidateNonEmptyString:
+    """Tests for validate_non_empty_string function."""
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("hello", "hello"),
+            ("  hello  ", "hello"),
+            ("test string", "test string"),
+        ],
+    )
+    def test_valid_string(self, value: str, expected: str) -> None:
+        """Test valid strings are normalized and returned."""
+        assert validate_non_empty_string(value) == expected
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "   ",
+            None,
+        ],
+    )
+    def test_empty_string(self, value: str | None) -> None:
+        """Test empty/whitespace strings return None."""
+        assert validate_non_empty_string(value) is None
+
+
+class TestValidateDoi:
+    """Tests for validate_doi function."""
+
+    @pytest.mark.parametrize(
+        "doi,expected",
+        [
+            ("10.1038/nature12373", True),
+            ("10.1000/xyz123", True),
+            ("10.12345/some-thing.here", True),
+            ("  10.1038/nature12373  ", True),  # With whitespace
+            ("10.1038/NATURE12373", True),  # Uppercase
+        ],
+    )
+    def test_valid_doi(self, doi: str, expected: bool) -> None:
+        """Test valid DOIs are accepted."""
+        assert validate_doi(doi) is expected
+
+    @pytest.mark.parametrize(
+        "doi",
+        [
+            "",
+            None,
+            "invalid",
+            "11.1038/nature",  # Wrong prefix
+            "10.123/nature",  # Registrant too short
+            "doi:10.1038/nature",  # With prefix
+        ],
+    )
+    def test_invalid_doi(self, doi: str | None) -> None:
+        """Test invalid DOIs are rejected."""
+        assert validate_doi(doi) is False


### PR DESCRIPTION
…REFACTOR-004

Move validation and normalization functions from application layer to domain:
- Add domain/validation.py with validate_smiles, validate_positive_int, validate_year_range, validate_doi, validate_non_negative
- Add domain/normalization.py with normalize_string, normalize_doi, format_date_parts, strip_html_tags, parse_page_range, extract_first_string
- Update transform_utils.py to delegate to domain functions
- Update CrossRefTransformer to use domain normalization functions
- Update CellLineTransformer and CompoundRecordTransformer to use domain validation
- Add unit tests for new domain functions (128 tests)
- Export new functions in domain/__init__.py