### PR TITLE
Implement unified retry and circuit breaker policy

### DIFF
--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -129,7 +129,7 @@ from bioetl.domain.ports import (
 )
 
 # Resilience (domain value objects)
-from bioetl.domain.resilience import RetryPolicy
+from bioetl.domain.resilience import CircuitBreakerConfig, RetryConfig, RetryPolicy
 
 # Pure domain transformations
 from bioetl.domain.transformations import (
@@ -269,6 +269,8 @@ __all__ = [
     "StoragePort",
     "TracingPort",
     # Resilience
+    "CircuitBreakerConfig",
+    "RetryConfig",
     "RetryPolicy",
     # Transformations (pure functions)
     "META_FIELDS",

--- a/src/bioetl/domain/resilience.py
+++ b/src/bioetl/domain/resilience.py
@@ -7,39 +7,72 @@ Contains pure configuration and logic for retry behavior (no I/O).
 from __future__ import annotations
 
 import hashlib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+
+# Default retryable HTTP status codes per RULES.md §3.1.3
+DEFAULT_RETRYABLE_STATUSES: frozenset[int] = frozenset({429, 502, 503, 504})
 
 
 @dataclass(frozen=True, slots=True)
-class RetryPolicy:
-    """Configuration for exponential backoff retry strategy.
+class RetryConfig:
+    """Unified configuration for retry strategy.
 
-    Implements RULES.md §4.1 recoverable error handling:
+    Implements RULES.md §3.1.3 - Retry policy parameters:
     - Exponential backoff with configurable multiplier
     - Maximum delay cap
     - Deterministic jitter for reproducibility (ADR-014)
+    - Configurable retryable HTTP status codes
+    - Configurable retryable exception types
 
     Args:
         max_attempts: Maximum number of attempts (default: 3)
+        multiplier: Delay multiplier per attempt (default: 2.0, results in 1s, 2s, 4s)
+        jitter_range: Min/max jitter factor as tuple (default: (0.1, 0.5))
+        retryable_statuses: HTTP status codes to retry (default: 429, 502, 503, 504)
+        retryable_exceptions: Exception types to retry (default: ConnectionError, TimeoutError)
         base_delay: Base delay in seconds (default: 1.0)
         max_delay: Maximum delay in seconds (default: 60.0)
-        multiplier: Delay multiplier per attempt (default: 2.0)
-        jitter: Random jitter factor 0-1 (default: 0.1)
         jitter_seed: Seed for deterministic jitter (default: None)
 
     Example:
-        >>> policy = RetryPolicy(max_attempts=5, base_delay=2.0)
-        >>> delay = policy.calculate_delay(attempt=0, url="https://api.example.com")
-        >>> f"First retry after {delay:.2f} seconds"
-        'First retry after 2.00 seconds'
+        >>> config = RetryConfig(max_attempts=5, multiplier=2.0)
+        >>> delay = config.calculate_delay(attempt=0, url="https://api.example.com")
+        >>> config.is_retryable_status(429)
+        True
     """
 
     max_attempts: int = 3
+    multiplier: float = 2.0
+    jitter_range: tuple[float, float] = (0.1, 0.5)
+    retryable_statuses: frozenset[int] = field(
+        default_factory=lambda: DEFAULT_RETRYABLE_STATUSES
+    )
+    retryable_exceptions: tuple[type[Exception], ...] = (ConnectionError, TimeoutError)
     base_delay: float = 1.0
     max_delay: float = 60.0
-    multiplier: float = 2.0
-    jitter: float = 0.1
     jitter_seed: int | None = None
+
+    def is_retryable_status(self, status_code: int) -> bool:
+        """Check if HTTP status code is retryable.
+
+        Args:
+            status_code: HTTP status code to check
+
+        Returns:
+            True if status code should trigger a retry
+        """
+        return status_code in self.retryable_statuses
+
+    def is_retryable_exception(self, exc: Exception) -> bool:
+        """Check if exception is retryable.
+
+        Args:
+            exc: Exception to check
+
+        Returns:
+            True if exception type should trigger a retry
+        """
+        return isinstance(exc, self.retryable_exceptions)
 
     def calculate_delay(self, attempt: int, url: str = "") -> float:
         """Calculate delay for given attempt number (0-indexed).
@@ -58,16 +91,21 @@ class RetryPolicy:
         delay = self.base_delay * (self.multiplier**attempt)
         delay = min(delay, self.max_delay)
 
-        jitter_range = delay * self.jitter
+        # Calculate jitter using range (min, max)
+        jitter_min, jitter_max = self.jitter_range
+        jitter_span = jitter_max - jitter_min
+
         # MD5-based deterministic jitter for cross-process reproducibility (ADR-014)
         # Note: hash() is not stable across Python processes due to PYTHONHASHSEED
         hash_input = f"{attempt}:{url}:{self.jitter_seed or 0}"
         digest = hashlib.md5(hash_input.encode(), usedforsecurity=False).hexdigest()
         jitter_factor = int(digest[:8], 16) / 0xFFFFFFFF
-        # Map 0.0-1.0 to -1.0 to +1.0
-        delay += jitter_range * (jitter_factor * 2 - 1)
 
-        return max(0.0, delay)
+        # Apply jitter: delay * (1 + jitter_amount) where jitter_amount is in [jitter_min, jitter_max]
+        jitter_amount = jitter_min + (jitter_span * jitter_factor)
+        delay = delay * (1 + jitter_amount)
+
+        return max(0.0, min(delay, self.max_delay))
 
     def is_last_attempt(self, attempt: int) -> bool:
         """Check if this is the last allowed attempt.
@@ -79,3 +117,30 @@ class RetryPolicy:
             True if no more attempts allowed after this one
         """
         return attempt >= self.max_attempts - 1
+
+
+@dataclass(frozen=True, slots=True)
+class CircuitBreakerConfig:
+    """Configuration for circuit breaker pattern.
+
+    Implements RULES.md §3.1.4 - Circuit breaker parameters:
+    - State machine: CLOSED -> OPEN (after failures) -> HALF_OPEN -> CLOSED
+    - Configurable failure threshold
+    - Configurable recovery timeout
+
+    Args:
+        failure_threshold: Consecutive failures before opening (default: 5)
+        recovery_timeout: Seconds to wait in OPEN before testing (default: 300 = 5 minutes)
+
+    Example:
+        >>> config = CircuitBreakerConfig(failure_threshold=3, recovery_timeout=60)
+        >>> config.failure_threshold
+        3
+    """
+
+    failure_threshold: int = 5
+    recovery_timeout: int = 300  # 5 minutes
+
+
+# Backward compatibility alias
+RetryPolicy = RetryConfig

--- a/src/bioetl/infrastructure/adapters/chembl/client.py
+++ b/src/bioetl/infrastructure/adapters/chembl/client.py
@@ -11,6 +11,7 @@ Error Handling (RULES.md §3.1):
 - Data quality errors: Log and skip record
 
 Health-Aware Fetching:
+- Uses circuit breaker state for health-aware batch sizing
 - HEALTHY: Normal batch_size
 - DEGRADED: batch_size ÷ 2 (per RULES.md §3.5)
 - UNHEALTHY: Fail fast with clear error
@@ -24,12 +25,15 @@ from typing import TYPE_CHECKING, Any, NoReturn
 from bioetl.domain.error_classifier import ErrorClassifier
 from bioetl.domain.exceptions import ChemblApiError, CriticalError
 from bioetl.domain.ports.noop import NoOpMetrics
-from bioetl.domain.types import ErrorType, HealthStatus
+from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.adapters.base import BaseHttpAdapter
 from bioetl.infrastructure.adapters.base_metrics import AdapterMetrics
 from bioetl.infrastructure.adapters.chembl.entity_mapper import (
     CHEMBL_STATUS_URL,
     ChemblEntityMapper,
+)
+from bioetl.infrastructure.adapters.http.health import (
+    assess_health_from_circuit_breaker,
 )
 
 if TYPE_CHECKING:
@@ -55,7 +59,7 @@ class ChemblAdapter(BaseHttpAdapter):
         batch_size: Number of records per API request (default: 1000)
         thread_pool: ThreadPoolExecutor for sync operations
 
-    Health-Aware Behavior:
+    Health-Aware Behavior (uses circuit breaker state):
         - HEALTHY: Uses configured batch_size
         - DEGRADED: Uses batch_size ÷ 2 to reduce load
         - UNHEALTHY: Raises CriticalError to prevent futile requests
@@ -71,13 +75,10 @@ class ChemblAdapter(BaseHttpAdapter):
     provider_name: str = field(init=False, default="chembl")
     """Provider identifier (required by DataSourcePort)."""
 
-    _consecutive_errors: int = field(init=False, default=0)
-    _cached_health: HealthStatus = field(init=False, default=HealthStatus.HEALTHY)
+    # Error classifier for logging purposes (no state tracking)
     _error_classifier: ErrorClassifier = field(
         init=False, default_factory=ErrorClassifier
     )
-    _total_errors: int = field(init=False, default=0)
-    _error_counts: dict[ErrorType, int] = field(init=False, default_factory=dict)
 
     # Entity mapper for URL and key resolution
     _mapper: ChemblEntityMapper = field(init=False, default_factory=ChemblEntityMapper)
@@ -87,8 +88,21 @@ class ChemblAdapter(BaseHttpAdapter):
         metrics_port = self.metrics if self.metrics is not None else NoOpMetrics()
         self._adapter_metrics = AdapterMetrics(metrics_port, self.provider_name)
 
+    def _get_health_status(self) -> HealthStatus:
+        """Get health status from circuit breaker state.
+
+        Uses circuit breaker failure count for health assessment,
+        avoiding duplicate state tracking.
+
+        Returns:
+            HealthStatus based on circuit breaker state.
+        """
+        return assess_health_from_circuit_breaker(self.http_client.circuit_breaker)
+
     def _get_effective_batch_size(self) -> int:
         """Get batch size adjusted for current health status.
+
+        Uses circuit breaker state for health-aware batching.
 
         Returns:
             - Normal batch_size when HEALTHY
@@ -98,19 +112,22 @@ class ChemblAdapter(BaseHttpAdapter):
             CriticalError: When UNHEALTHY to prevent futile requests
 
         """
-        if self._cached_health == HealthStatus.UNHEALTHY:
+        health_status = self._get_health_status()
+        failure_count = self.http_client.circuit_breaker.get_failure_count()
+
+        if health_status == HealthStatus.UNHEALTHY:
             raise CriticalError(
-                f"ChEMBL adapter is UNHEALTHY after {self._consecutive_errors} "
-                f"consecutive errors. Total errors: {self._total_errors}"
+                f"ChEMBL adapter is UNHEALTHY after {failure_count} "
+                f"consecutive errors (circuit breaker)"
             )
-        if self._cached_health == HealthStatus.DEGRADED:
+        if health_status == HealthStatus.DEGRADED:
             reduced = max(100, self.batch_size // 2)  # Minimum 100
             self.logger.warning(
                 "chembl_degraded_mode",
                 provider="chembl",
                 original_batch_size=self.batch_size,
                 effective_batch_size=reduced,
-                consecutive_errors=self._consecutive_errors,
+                consecutive_errors=failure_count,
             )
             return reduced
         return self.batch_size
@@ -142,12 +159,15 @@ class ChemblAdapter(BaseHttpAdapter):
     async def _fetch_page(
         self, url: str, params: dict[str, Any], entity_type: str
     ) -> tuple[list[dict[str, Any]], bool]:
-        """Fetch a single page and handle errors."""
+        """Fetch a single page and handle errors.
+
+        Note: Success/failure tracking is handled by the circuit breaker
+        in UnifiedHTTPClient, no duplicate tracking needed here.
+        """
         try:
             with self._adapter_metrics.measure_request(f"/{entity_type}"):
                 response = await self.http_client.get(url, params=params)
             records, has_next = self._process_response(response, entity_type)
-            self._consecutive_errors = 0
             return records, has_next
         except Exception as e:
             self._handle_error(e)
@@ -227,7 +247,10 @@ class ChemblAdapter(BaseHttpAdapter):
                 break
 
     def _handle_error(self, e: Exception, context: str = "fetch") -> NoReturn:
-        """Handle fetch errors with classification and metrics.
+        """Handle fetch errors with classification and logging.
+
+        Error tracking is handled by the circuit breaker in UnifiedHTTPClient,
+        so this method focuses on classification and logging only.
 
         Args:
             e: The exception that occurred
@@ -238,16 +261,10 @@ class ChemblAdapter(BaseHttpAdapter):
             ChemblApiError: For recoverable and other errors
 
         """
-        # Classify the error
+        # Classify the error for logging
         error_type = self._error_classifier.classify(e)
-
-        # Update error counters
-        self._consecutive_errors += 1
-        self._total_errors += 1
-        self._error_counts[error_type] = self._error_counts.get(error_type, 0) + 1
-
-        # Update health status
-        self._update_health()
+        failure_count = self.http_client.circuit_breaker.get_failure_count()
+        health_status = self._get_health_status()
 
         # Log with full context
         self.logger.error(
@@ -258,9 +275,8 @@ class ChemblAdapter(BaseHttpAdapter):
             error_type=error_type.value,
             is_critical=error_type.is_critical(),
             is_recoverable=error_type.is_recoverable(),
-            consecutive_errors=self._consecutive_errors,
-            total_errors=self._total_errors,
-            health_status=self._cached_health.value,
+            circuit_breaker_failures=failure_count,
+            health_status=health_status.value,
         )
 
         # Critical errors should fail immediately
@@ -391,11 +407,11 @@ class ChemblAdapter(BaseHttpAdapter):
     async def _probe_health(self) -> HealthStatus:
         """Perform ChEMBL-specific health probe.
 
-        Overrides BaseHttpAdapter._probe_health() to use ChEMBL status endpoint
-        and internal health state tracking.
+        Overrides BaseHttpAdapter._probe_health() to use ChEMBL status endpoint.
+        Uses circuit breaker state for health tracking.
 
         Returns:
-            HealthStatus based on status endpoint response.
+            HealthStatus based on status endpoint response and circuit breaker state.
 
         Raises:
             Exception: On request failure (base class handles via _fallback_health_status).
@@ -404,11 +420,8 @@ class ChemblAdapter(BaseHttpAdapter):
         try:
             with self._adapter_metrics.measure_request("/status"):
                 response = await self.http_client.get(CHEMBL_STATUS_URL)
-            self._handle_health_response(response)
-            return self._cached_health
+            return self._handle_health_response(response)
         except Exception as e:
-            self._consecutive_errors += 1
-            self._update_health()
             error_type = self._error_classifier.classify(e)
             self.logger.warning(
                 "health_check_failed",
@@ -419,85 +432,62 @@ class ChemblAdapter(BaseHttpAdapter):
             raise  # Let base class handle via _fallback_health_status()
 
     def _fallback_health_status(self) -> HealthStatus:
-        """Return cached health status.
-
-        Overrides BaseHttpAdapter._fallback_health_status() to use
-        ChEMBL's internal health state rather than circuit breaker.
+        """Return health status based on circuit breaker state.
 
         Returns:
-            Cached HealthStatus based on consecutive error count.
+            HealthStatus based on circuit breaker failure count.
 
         """
-        return self._cached_health
+        return self._get_health_status()
 
-    def _handle_health_response(self, response: Response) -> None:
-        """Process health check response."""
+    def _handle_health_response(self, response: Response) -> HealthStatus:
+        """Process health check response.
+
+        Args:
+            response: HTTP response from status endpoint
+
+        Returns:
+            HealthStatus based on response and API status.
+        """
         if response.status_code == 200:
-            # Reset error counter on any successful HTTP response
-            self._consecutive_errors = 0
             data = response.json()
             if data.get("status") == "UP":
-                self._cached_health = HealthStatus.HEALTHY
+                return HealthStatus.HEALTHY
             else:
-                self._cached_health = HealthStatus.DEGRADED
                 self.logger.warning(
                     "health_check_degraded",
                     provider=self.provider_name,
                     reason="status_not_up",
                     api_status=data.get("status"),
                 )
+                return HealthStatus.DEGRADED
         else:
-            self._consecutive_errors += 1
-            self._update_health()
             self.logger.warning(
                 "health_check_degraded",
                 provider=self.provider_name,
                 reason="non_200_response",
                 status_code=response.status_code,
             )
-
-    def _update_health(self) -> None:
-        """Update health status based on error count."""
-        previous_health = self._cached_health
-        if self._consecutive_errors >= 3:
-            self._cached_health = HealthStatus.UNHEALTHY
-        elif self._consecutive_errors >= 1:
-            self._cached_health = HealthStatus.DEGRADED
-        else:
-            self._cached_health = HealthStatus.HEALTHY
-
-        # Log health transitions
-        if previous_health != self._cached_health:
-            self.logger.info(
-                "chembl_health_transition",
-                provider="chembl",
-                previous_status=previous_health.value,
-                current_status=self._cached_health.value,
-                consecutive_errors=self._consecutive_errors,
-            )
+            return HealthStatus.DEGRADED
 
     def get_error_stats(self) -> dict[str, Any]:
-        """Get error statistics for monitoring.
+        """Get error statistics from circuit breaker for monitoring.
 
         Returns:
-            Dictionary with error counts and health status.
+            Dictionary with circuit breaker stats and health status.
 
         """
         return {
-            "consecutive_errors": self._consecutive_errors,
-            "total_errors": self._total_errors,
-            "health_status": self._cached_health.value,
-            "error_counts_by_type": {k.value: v for k, v in self._error_counts.items()},
+            "circuit_breaker_failures": self.http_client.circuit_breaker.get_failure_count(),
+            "circuit_breaker_state": self.http_client.circuit_breaker.get_state().value,
+            "health_status": self._get_health_status().value,
         }
 
-    def reset_error_counters(self) -> None:
-        """Reset error counters (e.g., after successful recovery)."""
-        self._consecutive_errors = 0
-        self._total_errors = 0
-        self._error_counts.clear()
-        self._cached_health = HealthStatus.HEALTHY
+    def reset_circuit_breaker(self) -> None:
+        """Reset circuit breaker (e.g., after successful recovery)."""
+        self.http_client.circuit_breaker.reset()
         self.logger.info(
-            "chembl_error_counters_reset",
+            "chembl_circuit_breaker_reset",
             provider="chembl",
         )
 

--- a/src/bioetl/infrastructure/adapters/http/client.py
+++ b/src/bioetl/infrastructure/adapters/http/client.py
@@ -25,7 +25,7 @@ import httpx
 
 from bioetl.domain.exceptions import CircuitBreakerOpenError, RetryExhaustedError
 from bioetl.domain.ports import NoOpMetrics, NoOpTracing
-from bioetl.domain.resilience import RetryPolicy
+from bioetl.domain.resilience import RetryConfig
 
 if TYPE_CHECKING:
     from bioetl.domain.ports import (
@@ -38,22 +38,8 @@ if TYPE_CHECKING:
     from bioetl.domain.types import RunID
 
 
-# Backward compatibility alias (deprecated)
-RetryConfig = RetryPolicy
-
-
-def _is_retryable_status(status_code: int) -> bool:
-    """Check if HTTP status code is retryable."""
-    return status_code in {429, 500, 502, 503, 504}
-
-
-def _is_retryable_error(exc: Exception) -> bool:
-    """Check if exception is retryable."""
-    if isinstance(exc, httpx.ConnectError | httpx.ConnectTimeout | httpx.ReadTimeout):
-        return True
-    if isinstance(exc, httpx.HTTPStatusError):
-        return _is_retryable_status(exc.response.status_code)
-    return False
+# Backward compatibility aliases
+RetryPolicy = RetryConfig
 
 
 @dataclass
@@ -72,7 +58,7 @@ class UnifiedHTTPClient:
     Args:
         rate_limiter: RateLimiterPort implementation for rate limiting
         circuit_breaker: CircuitBreakerPort implementation for fault tolerance
-        retry_policy: RetryPolicy for exponential backoff configuration
+        retry_config: RetryConfig for exponential backoff configuration
         timeout: Request timeout in seconds (default: 30.0)
         run_id: Current run ID for correlation header
         user_agent: User-Agent string (default: "BioETL/5.0.0")
@@ -94,7 +80,7 @@ class UnifiedHTTPClient:
 
     rate_limiter: RateLimiterPort
     circuit_breaker: CircuitBreakerPort
-    retry_policy: RetryPolicy = field(default_factory=RetryPolicy)
+    retry_config: RetryConfig = field(default_factory=RetryConfig)
     timeout: float = 30.0
     run_id: RunID | None = None
     user_agent: str = "BioETL/5.0.0"
@@ -152,15 +138,20 @@ class UnifiedHTTPClient:
         attempt: int,
         url: str = "",
         response: httpx.Response | None = None,
-    ) -> None:
-        """Calculate and sleep for the appropriate retry delay."""
-        delay = self.retry_policy.calculate_delay(attempt, url)
+    ) -> float:
+        """Calculate and sleep for the appropriate retry delay.
+
+        Returns:
+            The actual wait time in seconds (for logging).
+        """
+        delay = self.retry_config.calculate_delay(attempt, url)
         if response:
             retry_after = response.headers.get("Retry-After")
             if retry_after:
                 with suppress(ValueError):
                     delay = float(retry_after)
         await asyncio.sleep(delay)
+        return delay
 
     def _record_request_metrics(
         self,
@@ -206,24 +197,34 @@ class UnifiedHTTPClient:
         url: str,
         method: str,
         attempt: int,
+        wait_seconds: float,
         *,
         status_code: int | None = None,
-        error: str | None = None,
+        reason: str | None = None,
     ) -> None:
-        """Log retry attempt if logger is configured."""
+        """Log retry attempt with structured fields per RULES.md §3.1.3.
+
+        Args:
+            url: Request URL
+            method: HTTP method
+            attempt: Current attempt number (0-indexed)
+            wait_seconds: Time to wait before next attempt
+            status_code: HTTP status code if available
+            reason: Error reason string
+        """
         if not self.logger:
             return
-        kwargs: dict[str, Any] = {
-            "url": url,
-            "method": method,
-            "attempt": attempt + 1,
-            "provider": self.provider,
-        }
-        if status_code is not None:
-            kwargs["status_code"] = status_code
-        if error is not None:
-            kwargs["error"] = error
-        self.logger.debug("http_retry", **kwargs)
+        self.logger.warning(
+            "Retrying request",
+            stage="extract",
+            attempt=attempt + 1,
+            max_attempts=self.retry_config.max_attempts,
+            wait_seconds=round(wait_seconds, 3),
+            reason=reason or f"HTTP {status_code}" if status_code else "unknown",
+            url=url,
+            method=method,
+            provider=self.provider,
+        )
 
     async def _execute_single_attempt(
         self,
@@ -267,7 +268,7 @@ class UnifiedHTTPClient:
         span.__enter__()
 
         try:
-            for attempt in range(self.retry_policy.max_attempts):
+            for attempt in range(self.retry_config.max_attempts):
                 result = await self._attempt_request(
                     client, method, url, attempt, span, kwargs
                 )
@@ -285,7 +286,7 @@ class UnifiedHTTPClient:
             span.set_attribute("error.type", "retry_exhausted")
             if last_error:
                 span.record_exception(last_error)
-            raise RetryExhaustedError(url, self.retry_policy.max_attempts, last_error)
+            raise RetryExhaustedError(url, self.retry_config.max_attempts, last_error)
 
         finally:
             duration = time.perf_counter() - start_time
@@ -295,6 +296,21 @@ class UnifiedHTTPClient:
             self._record_request_metrics(
                 method, duration, status_code, retries, last_error
             )
+
+    def _is_retryable_error(self, exc: Exception) -> bool:
+        """Check if exception should trigger a retry.
+
+        Uses RetryConfig for httpx-specific exception types plus
+        configured retryable_exceptions.
+        """
+        # Check httpx-specific exceptions (connection/timeout errors)
+        if isinstance(exc, httpx.ConnectError | httpx.ConnectTimeout | httpx.ReadTimeout):
+            return True
+        # Check httpx status errors using configured retryable statuses
+        if isinstance(exc, httpx.HTTPStatusError):
+            return self.retry_config.is_retryable_status(exc.response.status_code)
+        # Check other configured retryable exceptions
+        return self.retry_config.is_retryable_exception(exc)
 
     async def _attempt_request(
         self,
@@ -315,11 +331,13 @@ class UnifiedHTTPClient:
             response = await self._execute_single_attempt(client, method, url, **kwargs)
             status_code = response.status_code
 
-            if _is_retryable_status(
+            if self.retry_config.is_retryable_status(
                 status_code
-            ) and not self.retry_policy.is_last_attempt(attempt):
-                self._log_retry(url, method, attempt, status_code=status_code)
-                await self._handle_retry_delay(attempt, url, response)
+            ) and not self.retry_config.is_last_attempt(attempt):
+                wait_seconds = await self._handle_retry_delay(attempt, url, response)
+                self._log_retry(
+                    url, method, attempt, wait_seconds, status_code=status_code
+                )
                 return (True, status_code, 1, None)
 
             response.raise_for_status()
@@ -336,19 +354,20 @@ class UnifiedHTTPClient:
                     url=url,
                     method=method,
                     provider=self.provider,
+                    retry_after=exc.retry_after,
                 )
             raise
 
         except Exception as exc:
-            if not _is_retryable_error(exc):
+            if not self._is_retryable_error(exc):
                 span.set_attribute("error", True)
                 span.set_attribute("error.type", type(exc).__name__)
                 span.record_exception(exc)
                 raise
 
-            if not self.retry_policy.is_last_attempt(attempt):
-                self._log_retry(url, method, attempt, error=str(exc))
-                await self._handle_retry_delay(attempt, url)
+            if not self.retry_config.is_last_attempt(attempt):
+                wait_seconds = await self._handle_retry_delay(attempt, url)
+                self._log_retry(url, method, attempt, wait_seconds, reason=str(exc))
             return (True, 0, 1, exc)
 
     async def get(

--- a/tests/unit/infrastructure/adapters/http/test_http_client.py
+++ b/tests/unit/infrastructure/adapters/http/test_http_client.py
@@ -9,12 +9,8 @@ import httpx
 import pytest
 
 from bioetl.domain.exceptions import CircuitBreakerOpenError, RetryExhaustedError
-from bioetl.infrastructure.adapters.http.client import (
-    RetryConfig,
-    UnifiedHTTPClient,
-    _is_retryable_error,
-    _is_retryable_status,
-)
+from bioetl.domain.resilience import RetryConfig
+from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
 
 
 @pytest.mark.unit
@@ -28,39 +24,68 @@ class TestRetryConfig:
         assert config.base_delay == 1.0
         assert config.max_delay == 60.0
         assert config.multiplier == 2.0
-        assert config.jitter == 0.1
+        assert config.jitter_range == (0.1, 0.5)
+        assert config.retryable_statuses == frozenset({429, 502, 503, 504})
+        assert ConnectionError in config.retryable_exceptions
+        assert TimeoutError in config.retryable_exceptions
 
     def test_calculate_delay_first_attempt(self):
-        """Test delay calculation for first attempt."""
-        config = RetryConfig(base_delay=1.0, multiplier=2.0, jitter=0.0)
+        """Test delay calculation for first attempt (no jitter)."""
+        config = RetryConfig(base_delay=1.0, multiplier=2.0, jitter_range=(0.0, 0.0))
         delay = config.calculate_delay(0)
         assert delay == 1.0
 
     def test_calculate_delay_second_attempt(self):
-        """Test delay calculation for second attempt."""
-        config = RetryConfig(base_delay=1.0, multiplier=2.0, jitter=0.0)
+        """Test delay calculation for second attempt (no jitter)."""
+        config = RetryConfig(base_delay=1.0, multiplier=2.0, jitter_range=(0.0, 0.0))
         delay = config.calculate_delay(1)
         assert delay == 2.0
 
     def test_calculate_delay_third_attempt(self):
-        """Test delay calculation for third attempt."""
-        config = RetryConfig(base_delay=1.0, multiplier=2.0, jitter=0.0)
+        """Test delay calculation for third attempt (no jitter)."""
+        config = RetryConfig(base_delay=1.0, multiplier=2.0, jitter_range=(0.0, 0.0))
         delay = config.calculate_delay(2)
         assert delay == 4.0
 
     def test_calculate_delay_respects_max_delay(self):
         """Test that delay is capped at max_delay."""
         config = RetryConfig(
-            base_delay=10.0, multiplier=2.0, max_delay=15.0, jitter=0.0
+            base_delay=10.0, multiplier=2.0, max_delay=15.0, jitter_range=(0.0, 0.0)
         )
         delay = config.calculate_delay(5)  # Would be 320 without cap
         assert delay == 15.0
+
+    def test_is_retryable_status(self):
+        """Test is_retryable_status method."""
+        config = RetryConfig()
+        assert config.is_retryable_status(429)
+        assert config.is_retryable_status(502)
+        assert config.is_retryable_status(503)
+        assert config.is_retryable_status(504)
+        assert not config.is_retryable_status(200)
+        assert not config.is_retryable_status(400)
+        assert not config.is_retryable_status(401)
+        assert not config.is_retryable_status(500)  # Not in default list
+
+    def test_is_retryable_exception(self):
+        """Test is_retryable_exception method."""
+        config = RetryConfig()
+        assert config.is_retryable_exception(ConnectionError("test"))
+        assert config.is_retryable_exception(TimeoutError("test"))
+        assert not config.is_retryable_exception(ValueError("test"))
+
+    def test_custom_retryable_statuses(self):
+        """Test custom retryable status codes."""
+        config = RetryConfig(retryable_statuses=frozenset({500, 502}))
+        assert config.is_retryable_status(500)
+        assert config.is_retryable_status(502)
+        assert not config.is_retryable_status(429)  # No longer in list
 
     def test_jitter_same_input_same_output(self):
         """Test jitter produces same delay for same inputs (deterministic)."""
         config = RetryConfig(
             base_delay=10.0,
-            jitter=0.1,
+            jitter_range=(0.1, 0.3),
             jitter_seed=42,
         )
         url = "https://api.example.com/data"
@@ -81,7 +106,7 @@ class TestRetryConfig:
         """Test jitter produces different delays for different URLs."""
         config = RetryConfig(
             base_delay=10.0,
-            jitter=0.1,
+            jitter_range=(0.1, 0.2),
             jitter_seed=42,
         )
 
@@ -91,26 +116,22 @@ class TestRetryConfig:
         # Different URLs should produce different jitter values
         assert delay1 != delay2
 
-        # Both should still be within jitter range (9.0 to 11.0)
-        assert 9.0 <= delay1 <= 11.0
-        assert 9.0 <= delay2 <= 11.0
+        # Both should still be within jitter range: base * (1 + jitter)
+        # With jitter_range=(0.1, 0.2), delay should be between 11.0 and 12.0
+        assert 11.0 <= delay1 <= 12.0
+        assert 11.0 <= delay2 <= 12.0
 
     def test_jitter_cross_process_stability(self):
         """Test deterministic jitter produces stable values across processes.
 
         This test verifies that the jitter calculation uses MD5 (not Python's
-        hash()) which is stable across different Python processes. Python's
-        built-in hash() uses PYTHONHASHSEED and produces different values in
-        different processes.
-
-        The expected values are pre-computed using MD5 and will remain constant
-        regardless of which Python process runs this test.
+        hash()) which is stable across different Python processes.
         """
         import hashlib
 
         config = RetryConfig(
             base_delay=10.0,
-            jitter=0.1,
+            jitter_range=(0.1, 0.2),
             jitter_seed=42,
         )
         url = "https://api.example.com/test"
@@ -119,9 +140,12 @@ class TestRetryConfig:
         hash_input = f"0:{url}:42"
         digest = hashlib.md5(hash_input.encode(), usedforsecurity=False).hexdigest()
         jitter_factor = int(digest[:8], 16) / 0xFFFFFFFF
+
         base_delay = 10.0
-        jitter_range = base_delay * 0.1
-        expected_delay = base_delay + jitter_range * (jitter_factor * 2 - 1)
+        jitter_min, jitter_max = 0.1, 0.2
+        jitter_span = jitter_max - jitter_min
+        jitter_amount = jitter_min + (jitter_span * jitter_factor)
+        expected_delay = min(base_delay * (1 + jitter_amount), config.max_delay)
 
         # Verify implementation matches our expectation
         actual_delay = config.calculate_delay(attempt=0, url=url)
@@ -135,89 +159,13 @@ class TestRetryConfig:
         assert config.calculate_delay(attempt=0, url=url) == expected_delay
         assert config.calculate_delay(attempt=0, url=url) == expected_delay
 
-    def test_jitter_known_values(self):
-        """Test jitter produces known stable values.
-
-        These values are pre-computed and serve as a regression test.
-        If this test fails, it means the jitter algorithm has changed.
-        """
-        config = RetryConfig(
-            base_delay=1.0,
-            jitter=0.5,
-            jitter_seed=123,
-        )
-
-        # Pre-computed expected values using MD5
-        # These should remain constant across all Python processes
-        test_cases = [
-            (0, "https://example.com/a", 0.6598315358068402),
-            (1, "https://example.com/a", 1.2365159788719648),
-            (0, "https://example.com/b", 1.0166028722926517),
-            (2, "https://example.com/c", 3.1987770072181654),
-        ]
-
-        for attempt, url, expected in test_cases:
-            actual = config.calculate_delay(attempt=attempt, url=url)
-            assert abs(actual - expected) < 1e-10, (
-                f"Delay mismatch for attempt={attempt}, url={url}. "
-                f"Expected {expected}, got {actual}"
-            )
-
-
-@pytest.mark.unit
-class TestIsRetryableStatus:
-    """Tests for _is_retryable_status function."""
-
-    @pytest.mark.parametrize("status", [429, 500, 502, 503, 504])
-    def test_retryable_statuses(self, status):
-        """Test that retryable statuses return True."""
-        assert _is_retryable_status(status) is True
-
-    @pytest.mark.parametrize("status", [200, 201, 400, 401, 403, 404, 405])
-    def test_non_retryable_statuses(self, status):
-        """Test that non-retryable statuses return False."""
-        assert _is_retryable_status(status) is False
-
-
-@pytest.mark.unit
-class TestIsRetryableError:
-    """Tests for _is_retryable_error function."""
-
-    def test_connect_error_is_retryable(self):
-        """Test ConnectError is retryable."""
-        exc = httpx.ConnectError("Connection failed")
-        assert _is_retryable_error(exc) is True
-
-    def test_connect_timeout_is_retryable(self):
-        """Test ConnectTimeout is retryable."""
-        exc = httpx.ConnectTimeout("Connection timed out")
-        assert _is_retryable_error(exc) is True
-
-    def test_read_timeout_is_retryable(self):
-        """Test ReadTimeout is retryable."""
-        exc = httpx.ReadTimeout("Read timed out")
-        assert _is_retryable_error(exc) is True
-
-    def test_http_status_error_with_retryable_code(self):
-        """Test HTTPStatusError with retryable status code."""
-        response = MagicMock()
-        response.status_code = 503
-        exc = httpx.HTTPStatusError(
-            "Service Unavailable", request=MagicMock(), response=response
-        )
-        assert _is_retryable_error(exc) is True
-
-    def test_http_status_error_with_non_retryable_code(self):
-        """Test HTTPStatusError with non-retryable status code."""
-        response = MagicMock()
-        response.status_code = 404
-        exc = httpx.HTTPStatusError("Not Found", request=MagicMock(), response=response)
-        assert _is_retryable_error(exc) is False
-
-    def test_other_exception_not_retryable(self):
-        """Test other exceptions are not retryable."""
-        exc = ValueError("Some error")
-        assert _is_retryable_error(exc) is False
+    def test_is_last_attempt(self):
+        """Test is_last_attempt method."""
+        config = RetryConfig(max_attempts=3)
+        assert not config.is_last_attempt(0)
+        assert not config.is_last_attempt(1)
+        assert config.is_last_attempt(2)
+        assert config.is_last_attempt(3)  # Beyond last
 
 
 @pytest.fixture
@@ -242,7 +190,7 @@ def http_client(mock_rate_limiter, mock_circuit_breaker):
     return UnifiedHTTPClient(
         rate_limiter=mock_rate_limiter,
         circuit_breaker=mock_circuit_breaker,
-        retry_policy=RetryConfig(max_attempts=2, jitter=0.0),
+        retry_config=RetryConfig(max_attempts=2, jitter_range=(0.0, 0.0)),
         timeout=10.0,
     )
 
@@ -592,7 +540,7 @@ class TestUnifiedHTTPClientObservability:
         return UnifiedHTTPClient(
             rate_limiter=mock_rate_limiter,
             circuit_breaker=mock_circuit_breaker,
-            retry_policy=RetryConfig(max_attempts=2, jitter=0.0),
+            retry_config=RetryConfig(max_attempts=2, jitter_range=(0.0, 0.0)),
             timeout=10.0,
             provider="test_provider",
             tracer=tracer,


### PR DESCRIPTION
- Add RetryConfig dataclass with configurable retryable_statuses, retryable_exceptions, jitter_range (min, max), and helper methods
- Add CircuitBreakerConfig for circuit breaker configuration
- Update UnifiedHTTPClient to use RetryConfig methods for retry logic
- Enhance retry logging with stage, max_attempts, wait_seconds fields
- Simplify ChemblAdapter: remove duplicate health tracking, use circuit breaker state for health-aware batching instead of internal counters
- Export RetryConfig and CircuitBreakerConfig from domain package
- Update tests for new API (jitter_range tuple, retry_config param)

Implements RULES.md §3.1.3 (retry policy) and §3.1.4 (circuit breaker). Removes ~100 LOC of duplicate state tracking from ChemblAdapter.