### PR TITLE
Separate CLI responsibilities and dependencies

### DIFF
--- a/src/bioetl/composition/_bootstrap/__init__.py
+++ b/src/bioetl/composition/_bootstrap/__init__.py
@@ -19,6 +19,7 @@ from bioetl.composition._bootstrap.checkpoint import (
     bootstrap_quarantine_manager,
     bootstrap_quarantine_service,
 )
+from bioetl.composition._bootstrap.lock import bootstrap_lock_service
 from bioetl.composition._bootstrap.observability import (
     bootstrap_dq_monitor,
     bootstrap_logger,
@@ -43,6 +44,7 @@ __all__ = [
     "bootstrap_cleanup",
     "bootstrap_dq_monitor",
     "bootstrap_lifecycle_service",
+    "bootstrap_lock_service",
     "bootstrap_logger",
     "bootstrap_metrics",
     "bootstrap_observability",

--- a/src/bioetl/composition/_bootstrap/lock.py
+++ b/src/bioetl/composition/_bootstrap/lock.py
@@ -1,0 +1,37 @@
+"""Bootstrap functions for lock components.
+
+Contains bootstrap functions for lock service used by CLI operations.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from bioetl.infrastructure.locking.memory_lock import MemoryLock
+from bioetl.infrastructure.observability.noop_logger import NoOpLogger
+
+if TYPE_CHECKING:
+    from bioetl.application.services.lock_service import LockService
+
+__all__ = ["bootstrap_lock_service"]
+
+
+def bootstrap_lock_service() -> LockService:
+    """Bootstrap LockService for CLI lock management commands.
+
+    Creates a LockService for administrative lock operations.
+    Used by CLI for `lock release` and `lock list` commands.
+
+    Note: Uses MemoryLock which is the in-process lock implementation.
+    Lock operations only affect the current process. For distributed
+    scenarios, a Redis-based implementation would be needed.
+
+    Returns:
+        LockService configured for the current environment.
+    """
+    from bioetl.application.services.lock_service import LockService
+
+    lock_port = MemoryLock()
+    noop_logger = NoOpLogger()
+
+    return LockService(lock_port=lock_port, logger=noop_logger)

--- a/src/bioetl/composition/entrypoints.py
+++ b/src/bioetl/composition/entrypoints.py
@@ -44,6 +44,7 @@ __all__ = [
     "get_lifecycle_service",
     # Resource management (services - new)
     "get_checkpoint_service",
+    "get_lock_service",
     "get_quarantine_service",
     "get_bronze_cleanup_service",
     "get_vacuum_service",
@@ -60,6 +61,7 @@ __all__ = [
 from bioetl.composition._bootstrap import (
     bootstrap_bronze_cleanup_service,
     bootstrap_checkpoint_service,
+    bootstrap_lock_service,
     bootstrap_quarantine_service,
     bootstrap_vacuum_service,
 )
@@ -88,6 +90,7 @@ if TYPE_CHECKING:
         QuarantineService,
         VacuumService,
     )
+    from bioetl.application.services.lock_service import LockService
     from bioetl.application.services.medallion_lifecycle import (
         MedallionLifecycleService,
     )
@@ -621,6 +624,27 @@ def get_vacuum_service() -> VacuumService:
     """
     _ensure_registrations()
     return bootstrap_vacuum_service()
+
+
+def get_lock_service() -> LockService:
+    """Get a lock service for administrative lock operations.
+
+    Used for releasing stale locks and checking lock status.
+    This is the recommended way to manage locks from CLI.
+
+    Note: Uses in-memory locking which only affects the current process.
+    Lock operations are local to this process instance.
+
+    Returns:
+        LockService instance.
+
+    Example:
+        >>> service = get_lock_service()
+        >>> released = await service.release_lock("chembl_activity", run_id)
+        >>> print(f"Lock released: {released}")
+    """
+    _ensure_registrations()
+    return bootstrap_lock_service()
 
 
 async def cleanup_bronze(

--- a/src/bioetl/interfaces/cli/__init__.py
+++ b/src/bioetl/interfaces/cli/__init__.py
@@ -22,8 +22,8 @@ from __future__ import annotations
 from bioetl.interfaces.cli.commands.run import (
     _get_runner_logger,
     _handle_destructive_run_confirmation,
-    validate_pipeline_name,
 )
+from bioetl.interfaces.cli.commands.run_helpers import validate_pipeline_name
 from bioetl.interfaces.cli.main import cli, main
 
 __all__ = [

--- a/src/bioetl/interfaces/cli/commands/archive.py
+++ b/src/bioetl/interfaces/cli/commands/archive.py
@@ -1,0 +1,48 @@
+"""Archive command for BioETL CLI.
+
+Implements table archival to cold storage.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import click
+
+from bioetl.composition.entrypoints import get_lifecycle_service
+from bioetl.interfaces.cli.formatters import echo_info
+
+
+@click.command("archive")
+@click.argument("table")
+@click.argument("target_path")
+@click.option(
+    "--remove-source",
+    is_flag=True,
+    help="Remove source table after archiving",
+)
+def archive_command(table: str, target_path: str, remove_source: bool) -> None:
+    """Archive Delta table to cold storage.
+
+    TABLE: Table name to archive
+
+    TARGET_PATH: Destination path for archive
+
+    Examples:
+
+        bioetl maintenance archive chembl.activity /archive/chembl
+
+        bioetl maintenance archive chembl.activity /archive/chembl --remove-source
+    """
+    lifecycle = get_lifecycle_service()
+
+    async def _run() -> None:
+        files_archived = await lifecycle.archive(
+            table=table,
+            target_path=target_path,
+            remove_source=remove_source,
+        )
+
+        echo_info(f"Archived {files_archived} files to {target_path}")
+
+    asyncio.run(_run())

--- a/src/bioetl/interfaces/cli/commands/cleanup.py
+++ b/src/bioetl/interfaces/cli/commands/cleanup.py
@@ -1,0 +1,55 @@
+"""Cleanup commands for BioETL CLI.
+
+Implements Bronze layer cleanup per RULES.md retention policy.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import click
+
+from bioetl.composition.entrypoints import get_bronze_cleanup_service
+from bioetl.interfaces.cli.formatters import (
+    echo_dry_run_prefix,
+    echo_info,
+    format_bytes,
+)
+
+
+@click.command("bronze-cleanup")
+@click.option(
+    "-r",
+    "--retention-days",
+    default=90,
+    help="Remove files older than N days",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show what would be removed",
+)
+def bronze_cleanup_command(retention_days: int, dry_run: bool) -> None:
+    """Clean up old Bronze files (RULES.md 2.1 retention, default 90 days).
+
+    Examples:
+
+        bioetl maintenance bronze-cleanup
+
+        bioetl maintenance bronze-cleanup --dry-run
+
+        bioetl maintenance bronze-cleanup -r 30
+    """
+    service = get_bronze_cleanup_service()
+
+    async def _run() -> None:
+        if dry_run:
+            echo_dry_run_prefix(
+                f"Cleanup Bronze files older than {retention_days} days"
+            )
+        result = await service.cleanup(retention_days=retention_days, dry_run=dry_run)
+        action = "Would remove" if dry_run else "Removed"
+        echo_info(f"{action} {result.files_removed} files ({format_bytes(result.bytes_freed)})")
+        echo_info(f"{action} {result.directories_removed} empty directories")
+
+    asyncio.run(_run())

--- a/src/bioetl/interfaces/cli/commands/config.py
+++ b/src/bioetl/interfaces/cli/commands/config.py
@@ -1,0 +1,155 @@
+"""Configuration commands for BioETL CLI.
+
+Implements config inspection and validation commands.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import click
+
+from bioetl.composition.registry import get_default_registry
+from bioetl.infrastructure.config import get_settings, load_pipeline_config
+from bioetl.interfaces.cli.formatters import echo_error, echo_info
+
+
+def _config_to_dict(config: Any) -> dict[str, Any]:
+    """Convert a Pydantic model or dataclass to a JSON-serializable dict."""
+    if hasattr(config, "model_dump"):
+        result: dict[str, Any] = config.model_dump()
+        return result
+    if hasattr(config, "__dict__"):
+        converted: dict[str, Any] = {
+            k: _config_to_dict(v) if hasattr(v, "__dict__") else v
+            for k, v in config.__dict__.items()
+            if not k.startswith("_")
+        }
+        return converted
+    return {"value": config}  # Wrap primitives in a dict
+
+
+@click.group()
+def config() -> None:
+    """View and validate configuration."""
+    pass
+
+
+@config.command("show")
+@click.argument("pipeline")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["json", "yaml"]),
+    default="yaml",
+    help="Output format",
+)
+def show_command(pipeline: str, output_format: str) -> None:
+    """Show configuration for a pipeline.
+
+    PIPELINE: Name of the pipeline (e.g., chembl_activity)
+
+    Examples:
+
+        bioetl config show chembl_activity
+
+        bioetl config show chembl_activity --format json
+    """
+    try:
+        yaml_config = load_pipeline_config(pipeline)
+    except ValueError as e:
+        echo_error("Configuration error", str(e))
+        return
+    except FileNotFoundError as e:
+        echo_error("Config file not found", str(e))
+        return
+
+    config_dict = _config_to_dict(yaml_config)
+
+    if output_format == "json":
+        echo_info(json.dumps(config_dict, indent=2, default=str))
+    else:
+        import yaml
+        echo_info(yaml.dump(config_dict, default_flow_style=False, sort_keys=False))
+
+
+@config.command("validate")
+@click.argument("pipeline")
+def validate_command(pipeline: str) -> None:
+    """Validate configuration for a pipeline.
+
+    PIPELINE: Name of the pipeline (e.g., chembl_activity)
+
+    Examples:
+
+        bioetl config validate chembl_activity
+    """
+    try:
+        yaml_config = load_pipeline_config(pipeline)
+        echo_info(f"Configuration valid for {pipeline}")
+        echo_info(f"  Provider: {yaml_config.provider}")
+        echo_info(f"  Entity type: {yaml_config.entity_type}")
+        echo_info(f"  Silver table: {yaml_config.silver_table}")
+        if yaml_config.gold_table:
+            echo_info(f"  Gold table: {yaml_config.gold_table}")
+    except ValueError as e:
+        echo_error("Configuration invalid", str(e))
+    except FileNotFoundError as e:
+        echo_error("Config file not found", str(e))
+
+
+@config.command("show-settings")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["json", "yaml"]),
+    default="yaml",
+    help="Output format",
+)
+def show_settings_command(output_format: str) -> None:
+    """Show global application settings.
+
+    Displays environment-based configuration from BIOETL_* variables.
+
+    Examples:
+
+        bioetl config show-settings
+
+        bioetl config show-settings --format json
+    """
+    settings = get_settings()
+    settings_dict = settings.model_dump()
+
+    # Mask sensitive values
+    if settings_dict.get("pubmed_api_key"):
+        settings_dict["pubmed_api_key"] = "***MASKED***"
+
+    if output_format == "json":
+        echo_info(json.dumps(settings_dict, indent=2, default=str))
+    else:
+        import yaml
+        echo_info(yaml.dump(settings_dict, default_flow_style=False, sort_keys=False))
+
+
+@config.command("list-pipelines")
+def list_pipelines_command() -> None:
+    """List all registered pipelines.
+
+    Examples:
+
+        bioetl config list-pipelines
+    """
+    from bioetl.composition.factories.pipeline_factories import register_all_pipelines
+
+    register_all_pipelines()
+    registry = get_default_registry()
+    pipelines = registry.list_pipelines()
+
+    if not pipelines:
+        echo_info("No pipelines registered.")
+        return
+
+    echo_info("Available pipelines:")
+    for pipeline in sorted(pipelines):
+        echo_info(f"  - {pipeline}")

--- a/src/bioetl/interfaces/cli/commands/lock.py
+++ b/src/bioetl/interfaces/cli/commands/lock.py
@@ -1,0 +1,94 @@
+"""Lock management commands for BioETL CLI.
+
+Implements lock release and inspection commands.
+Note: Uses in-memory locking - operations only affect current process.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import cast
+from uuid import UUID
+
+import click
+
+from bioetl.composition.entrypoints import get_lock_service
+from bioetl.domain.types import RunID
+from bioetl.interfaces.cli.formatters import echo_error, echo_info, echo_warning
+
+
+@click.group()
+def lock() -> None:
+    """Manage pipeline locks."""
+    pass
+
+
+@lock.command("release")
+@click.option("--pipeline", required=True, help="Pipeline name (lock key)")
+@click.option("--run-id", required=True, help="Run ID that holds the lock")
+@click.option("--exclusive", is_flag=True, help="Release exclusive lock")
+def release_command(pipeline: str, run_id: str, exclusive: bool) -> None:
+    """Release a pipeline lock.
+
+    Use this to clean up stale locks from crashed processes.
+    Only works if the specified run-id holds the lock.
+
+    Examples:
+
+        bioetl lock release --pipeline chembl_activity --run-id abc123
+
+        bioetl lock release --pipeline chembl_activity --run-id abc123 --exclusive
+    """
+    try:
+        parsed_run_id = cast(RunID, UUID(run_id))
+    except ValueError:
+        echo_error("Invalid run-id", "Must be a valid UUID")
+        return
+
+    service = get_lock_service()
+
+    async def _run() -> None:
+        released = await service.release_lock(
+            pipeline_id=pipeline,
+            owner_id=parsed_run_id,
+            exclusive=exclusive,
+        )
+
+        if released:
+            echo_info(f"Lock released for {pipeline}")
+        else:
+            echo_warning(f"Lock not released (not held by run-id {run_id})")
+
+    asyncio.run(_run())
+
+
+@lock.command("check")
+@click.option("--pipeline", required=True, help="Pipeline name (lock key)")
+@click.option("--run-id", required=True, help="Run ID to check")
+def check_command(pipeline: str, run_id: str) -> None:
+    """Check if a lock is held by a specific run-id.
+
+    Examples:
+
+        bioetl lock check --pipeline chembl_activity --run-id abc123
+    """
+    try:
+        parsed_run_id = cast(RunID, UUID(run_id))
+    except ValueError:
+        echo_error("Invalid run-id", "Must be a valid UUID")
+        return
+
+    service = get_lock_service()
+
+    async def _run() -> None:
+        is_held = await service.check_lock(
+            pipeline_id=pipeline,
+            owner_id=parsed_run_id,
+        )
+
+        if is_held:
+            echo_info(f"Lock for {pipeline} IS held by run-id {run_id}")
+        else:
+            echo_info(f"Lock for {pipeline} is NOT held by run-id {run_id}")
+
+    asyncio.run(_run())

--- a/src/bioetl/interfaces/cli/commands/maintenance.py
+++ b/src/bioetl/interfaces/cli/commands/maintenance.py
@@ -1,26 +1,16 @@
-"""Maintenance commands for BioETL CLI.
+"""Maintenance command group for BioETL CLI.
 
-Implements vacuum, archive, and cleanup operations for Delta tables.
+Registers all maintenance-related subcommands for Delta table operations.
+This module is a thin orchestrator that imports and registers commands.
 """
 
 from __future__ import annotations
 
-import asyncio
-
 import click
 
-from bioetl.composition.entrypoints import (
-    get_bronze_cleanup_service,
-    get_lifecycle_service,
-    get_vacuum_service,
-)
-from bioetl.interfaces.cli.formatters import (
-    echo_dry_run_prefix,
-    echo_info,
-    echo_vacuum_all_summary,
-    echo_vacuum_result,
-    format_bytes,
-)
+from bioetl.interfaces.cli.commands.archive import archive_command
+from bioetl.interfaces.cli.commands.cleanup import bronze_cleanup_command
+from bioetl.interfaces.cli.commands.vacuum import vacuum_all_command, vacuum_command
 
 
 @click.group()
@@ -29,155 +19,8 @@ def maintenance() -> None:
     pass
 
 
-@maintenance.command("vacuum")
-@click.argument("table")
-@click.option(
-    "--retention-days",
-    "-r",
-    default=7,
-    help="Minimum age of files to remove (days)",
-)
-@click.option(
-    "--dry-run",
-    is_flag=True,
-    help="Show what would be removed without removing",
-)
-def vacuum_command(table: str, retention_days: int, dry_run: bool) -> None:
-    """Vacuum Delta table to reclaim storage space.
-
-    TABLE: Table name in format "provider.entity" (e.g., chembl.activity)
-
-    Examples:
-
-        bioetl maintenance vacuum chembl.activity
-
-        bioetl maintenance vacuum chembl.activity --dry-run
-
-        bioetl maintenance vacuum chembl.activity -r 30
-    """
-    lifecycle = get_lifecycle_service()
-
-    async def _run() -> None:
-        if dry_run:
-            echo_dry_run_prefix(
-                f"Would vacuum {table} (retention: {retention_days}d)"
-            )
-
-        files_removed = await lifecycle.vacuum(
-            table=table,
-            retention_days=retention_days,
-            dry_run=dry_run,
-        )
-
-        if dry_run:
-            echo_info(f"Would remove {files_removed} files")
-        else:
-            echo_info(f"Removed {files_removed} files")
-
-    asyncio.run(_run())
-
-
-@maintenance.command("vacuum-all")
-@click.option(
-    "--retention-days",
-    "-r",
-    default=7,
-    help="Minimum age of files to remove (days)",
-)
-@click.option(
-    "--dry-run",
-    is_flag=True,
-    help="Show what would be removed without removing",
-)
-@click.option(
-    "--layer",
-    type=click.Choice(["all", "silver", "gold"]),
-    default="all",
-    help="Which layer to vacuum (default: all)",
-)
-def vacuum_all_command(retention_days: int, dry_run: bool, layer: str) -> None:
-    """Vacuum all Delta tables to reclaim storage space.
-
-    Runs VACUUM on all registered Silver and Gold tables.
-
-    Examples:
-
-        bioetl maintenance vacuum-all
-
-        bioetl maintenance vacuum-all --dry-run
-
-        bioetl maintenance vacuum-all -r 30
-
-        bioetl maintenance vacuum-all --layer silver
-    """
-    service = get_vacuum_service()
-    tables_to_vacuum = service.collect_tables(layer)
-
-    if not tables_to_vacuum:
-        echo_info("No tables found to vacuum.")
-        return
-
-    async def _run() -> None:
-        result = await service.vacuum_all(
-            tables=tables_to_vacuum,
-            retention_days=retention_days,
-            dry_run=dry_run,
-        )
-
-        for table_result in result.results:
-            echo_vacuum_result(table_result, dry_run)
-
-        echo_vacuum_all_summary(result)
-
-    asyncio.run(_run())
-
-
-@maintenance.command("archive")
-@click.argument("table")
-@click.argument("target_path")
-@click.option(
-    "--remove-source",
-    is_flag=True,
-    help="Remove source table after archiving",
-)
-def archive_command(table: str, target_path: str, remove_source: bool) -> None:
-    """Archive Delta table to cold storage.
-
-    TABLE: Table name to archive
-
-    TARGET_PATH: Destination path for archive
-    """
-    lifecycle = get_lifecycle_service()
-
-    async def _run() -> None:
-        files_archived = await lifecycle.archive(
-            table=table,
-            target_path=target_path,
-            remove_source=remove_source,
-        )
-
-        echo_info(f"Archived {files_archived} files to {target_path}")
-
-    asyncio.run(_run())
-
-
-@maintenance.command("bronze-cleanup")
-@click.option(
-    "-r", "--retention-days", default=90, help="Remove files older than N days"
-)
-@click.option("--dry-run", is_flag=True, help="Show what would be removed")
-def bronze_cleanup_command(retention_days: int, dry_run: bool) -> None:
-    """Clean up old Bronze files (RULES.md 2.1 retention, default 90 days)."""
-    service = get_bronze_cleanup_service()
-
-    async def _run() -> None:
-        if dry_run:
-            echo_dry_run_prefix(
-                f"Cleanup Bronze files older than {retention_days} days"
-            )
-        result = await service.cleanup(retention_days=retention_days, dry_run=dry_run)
-        action = "Would remove" if dry_run else "Removed"
-        echo_info(f"{action} {result.files_removed} files ({format_bytes(result.bytes_freed)})")
-        echo_info(f"{action} {result.directories_removed} empty directories")
-
-    asyncio.run(_run())
+# Register all maintenance subcommands
+maintenance.add_command(vacuum_command)
+maintenance.add_command(vacuum_all_command)
+maintenance.add_command(archive_command)
+maintenance.add_command(bronze_cleanup_command)

--- a/src/bioetl/interfaces/cli/commands/run.py
+++ b/src/bioetl/interfaces/cli/commands/run.py
@@ -7,121 +7,25 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from typing import TYPE_CHECKING
 
 import click
 
 from bioetl.application.core.shutdown import PipelineShutdownError
-from bioetl.composition.entrypoints import (
-    RunOptions,
-    create_pipeline_runner,
-    preview_cleanup,
+from bioetl.composition.entrypoints import RunOptions, create_pipeline_runner
+from bioetl.interfaces.cli.commands.run_helpers import (
+    get_runner_logger,
+    handle_destructive_run_confirmation,
+    show_cleanup_preview,
+    validate_pipeline_name,
 )
-from bioetl.composition.registry import get_default_registry
-from bioetl.interfaces.cli.formatters import (
-    echo_cleanup_preview,
-    echo_dry_run_prefix,
-    echo_error,
-    echo_info,
-    echo_warning,
-)
+from bioetl.interfaces.cli.formatters import echo_error
 from bioetl.interfaces.orchestration.signals import setup_shutdown_handlers
 
-if TYPE_CHECKING:
-    from bioetl.application.core.runner import PipelineRunner
-    from bioetl.domain.ports import LoggerPort
-
-
-def validate_pipeline_name(
-    _ctx: click.Context | None, _param: click.Parameter | None, value: str
-) -> str:
-    """Validate pipeline name against the registry at runtime.
-
-    Args:
-        _ctx: Click context (unused).
-        _param: Click parameter (unused).
-        value: Pipeline name to validate.
-
-    Returns:
-        Validated pipeline name.
-
-    Raises:
-        click.BadParameter: If pipeline name is not in registry.
-    """
-    registry = get_default_registry()
-    available = registry.list_pipelines()
-    if value not in available:
-        raise click.BadParameter(f"Unknown pipeline: {value}. Available: {available}")
-    return value
-
-
-def _get_runner_logger(runner: PipelineRunner) -> LoggerPort | None:
-    """Get logger from runner with fallback.
-
-    Args:
-        runner: PipelineRunner instance.
-
-    Returns:
-        Logger instance (LoggerPort) or None if not found.
-    """
-    logger = getattr(runner, "logger", None)
-    if logger is None:
-        logger = getattr(runner, "_logger", None)
-    return logger
-
-
-async def _preview_cleanup_async(pipeline: str) -> None:
-    """Preview what data would be cleared in dry-run mode.
-
-    Args:
-        pipeline: Pipeline name.
-    """
-    preview_result = await preview_cleanup(pipeline)
-    echo_cleanup_preview(preview_result)
-
-
-def _preview_cleanup(pipeline: str) -> None:
-    """Sync wrapper for preview_cleanup_async.
-
-    Args:
-        pipeline: Pipeline name.
-    """
-    try:
-        asyncio.run(_preview_cleanup_async(pipeline))
-    except Exception as e:
-        echo_error("Error previewing cleanup", str(e))
-
-
-def _handle_destructive_run_confirmation(
-    pipeline: str, run_type: str, dry_run: bool, yes: bool
-) -> bool:
-    """Handle confirmation for rebuild/backfill runs.
-
-    Args:
-        pipeline: Pipeline name.
-        run_type: Type of run.
-        dry_run: Whether this is a dry run.
-        yes: Whether to skip confirmation.
-
-    Returns:
-        True if should continue with pipeline execution, False if should exit early.
-    """
-    if run_type not in ("rebuild", "backfill"):
-        return True
-
-    if dry_run:
-        echo_dry_run_prefix(f"Would clear data for pipeline: {pipeline}")
-        echo_dry_run_prefix(f"Run type: {run_type}")
-        _preview_cleanup(pipeline)
-        return False
-
-    if not yes:
-        echo_warning(f"{run_type} will clear existing data for {pipeline}.")
-        if not click.confirm("Do you want to continue?"):
-            echo_info("Operation cancelled.")
-            sys.exit(0)
-
-    return True
+# Re-export helpers for backward compatibility with tests
+# These are imported by tests/unit/interfaces/test_cli.py
+_get_runner_logger = get_runner_logger
+_handle_destructive_run_confirmation = handle_destructive_run_confirmation
+_preview_cleanup = show_cleanup_preview
 
 
 @click.command()
@@ -191,7 +95,7 @@ def run(
     vacuum_retention_days: int | None,
 ) -> None:
     """Run an ETL pipeline."""
-    if not _handle_destructive_run_confirmation(pipeline, run_type, dry_run, yes):
+    if not handle_destructive_run_confirmation(pipeline, run_type, dry_run, yes):
         return
 
     try:
@@ -214,7 +118,7 @@ def run(
         echo_error("Initialization failed", str(e))
         sys.exit(1)
 
-    logger = _get_runner_logger(runner)
+    logger = get_runner_logger(runner)
     if logger is None:
         echo_error("Critical: Logger not initialized.")
         sys.exit(1)

--- a/src/bioetl/interfaces/cli/commands/run_helpers.py
+++ b/src/bioetl/interfaces/cli/commands/run_helpers.py
@@ -1,0 +1,126 @@
+"""Helper functions for the run command.
+
+Provides validation, confirmation, and preview utilities for pipeline execution.
+These are CLI-layer responsibilities separated for maintainability.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from typing import TYPE_CHECKING
+
+import click
+
+__all__ = [
+    "get_runner_logger",
+    "handle_destructive_run_confirmation",
+    "show_cleanup_preview",
+    "validate_pipeline_name",
+]
+
+from bioetl.composition.entrypoints import preview_cleanup
+from bioetl.composition.registry import get_default_registry
+from bioetl.interfaces.cli.formatters import (
+    echo_cleanup_preview,
+    echo_dry_run_prefix,
+    echo_error,
+    echo_info,
+    echo_warning,
+)
+
+if TYPE_CHECKING:
+    from bioetl.application.core.runner import PipelineRunner
+    from bioetl.domain.ports import LoggerPort
+
+
+def validate_pipeline_name(
+    _ctx: click.Context | None, _param: click.Parameter | None, value: str
+) -> str:
+    """Validate pipeline name against the registry at runtime.
+
+    Args:
+        _ctx: Click context (unused).
+        _param: Click parameter (unused).
+        value: Pipeline name to validate.
+
+    Returns:
+        Validated pipeline name.
+
+    Raises:
+        click.BadParameter: If pipeline name is not in registry.
+    """
+    registry = get_default_registry()
+    available = registry.list_pipelines()
+    if value not in available:
+        raise click.BadParameter(f"Unknown pipeline: {value}. Available: {available}")
+    return value
+
+
+def get_runner_logger(runner: PipelineRunner) -> LoggerPort | None:
+    """Get logger from runner with fallback.
+
+    Args:
+        runner: PipelineRunner instance.
+
+    Returns:
+        Logger instance (LoggerPort) or None if not found.
+    """
+    logger = getattr(runner, "logger", None)
+    if logger is None:
+        logger = getattr(runner, "_logger", None)
+    return logger
+
+
+async def _preview_cleanup_async(pipeline: str) -> None:
+    """Preview what data would be cleared in dry-run mode.
+
+    Args:
+        pipeline: Pipeline name.
+    """
+    preview_result = await preview_cleanup(pipeline)
+    echo_cleanup_preview(preview_result)
+
+
+def show_cleanup_preview(pipeline: str) -> None:
+    """Show cleanup preview synchronously.
+
+    Args:
+        pipeline: Pipeline name.
+    """
+    try:
+        asyncio.run(_preview_cleanup_async(pipeline))
+    except Exception as e:
+        echo_error("Error previewing cleanup", str(e))
+
+
+def handle_destructive_run_confirmation(
+    pipeline: str, run_type: str, dry_run: bool, yes: bool
+) -> bool:
+    """Handle confirmation for rebuild/backfill runs.
+
+    Args:
+        pipeline: Pipeline name.
+        run_type: Type of run.
+        dry_run: Whether this is a dry run.
+        yes: Whether to skip confirmation.
+
+    Returns:
+        True if should continue with pipeline execution, False if should exit early.
+    """
+    if run_type not in ("rebuild", "backfill"):
+        return True
+
+    if dry_run:
+        echo_dry_run_prefix(f"Would clear data for pipeline: {pipeline}")
+        echo_dry_run_prefix(f"Run type: {run_type}")
+        show_cleanup_preview(pipeline)
+        return False
+
+    if not yes:
+        echo_warning(f"{run_type} will clear existing data for {pipeline}.")
+        if not click.confirm("Do you want to continue?"):
+            echo_info("Operation cancelled.")
+            sys.exit(0)
+
+    return True

--- a/src/bioetl/interfaces/cli/commands/vacuum.py
+++ b/src/bioetl/interfaces/cli/commands/vacuum.py
@@ -1,0 +1,119 @@
+"""Vacuum commands for BioETL CLI.
+
+Implements vacuum operations for Delta tables storage reclamation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import click
+
+from bioetl.composition.entrypoints import get_lifecycle_service, get_vacuum_service
+from bioetl.interfaces.cli.formatters import (
+    echo_dry_run_prefix,
+    echo_info,
+    echo_vacuum_all_summary,
+    echo_vacuum_result,
+)
+
+
+@click.command("vacuum")
+@click.argument("table")
+@click.option(
+    "--retention-days",
+    "-r",
+    default=7,
+    help="Minimum age of files to remove (days)",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show what would be removed without removing",
+)
+def vacuum_command(table: str, retention_days: int, dry_run: bool) -> None:
+    """Vacuum Delta table to reclaim storage space.
+
+    TABLE: Table name in format "provider.entity" (e.g., chembl.activity)
+
+    Examples:
+
+        bioetl maintenance vacuum chembl.activity
+
+        bioetl maintenance vacuum chembl.activity --dry-run
+
+        bioetl maintenance vacuum chembl.activity -r 30
+    """
+    lifecycle = get_lifecycle_service()
+
+    async def _run() -> None:
+        if dry_run:
+            echo_dry_run_prefix(f"Would vacuum {table} (retention: {retention_days}d)")
+
+        files_removed = await lifecycle.vacuum(
+            table=table,
+            retention_days=retention_days,
+            dry_run=dry_run,
+        )
+
+        if dry_run:
+            echo_info(f"Would remove {files_removed} files")
+        else:
+            echo_info(f"Removed {files_removed} files")
+
+    asyncio.run(_run())
+
+
+@click.command("vacuum-all")
+@click.option(
+    "--retention-days",
+    "-r",
+    default=7,
+    help="Minimum age of files to remove (days)",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show what would be removed without removing",
+)
+@click.option(
+    "--layer",
+    type=click.Choice(["all", "silver", "gold"]),
+    default="all",
+    help="Which layer to vacuum (default: all)",
+)
+def vacuum_all_command(retention_days: int, dry_run: bool, layer: str) -> None:
+    """Vacuum all Delta tables to reclaim storage space.
+
+    Runs VACUUM on all registered Silver and Gold tables.
+
+    Examples:
+
+        bioetl maintenance vacuum-all
+
+        bioetl maintenance vacuum-all --dry-run
+
+        bioetl maintenance vacuum-all -r 30
+
+        bioetl maintenance vacuum-all --layer silver
+    """
+    service = get_vacuum_service()
+    tables_to_vacuum = service.collect_tables(layer)
+
+    if not tables_to_vacuum:
+        echo_info("No tables found to vacuum.")
+        return
+
+    async def _run() -> None:
+        result = await service.vacuum_all(
+            tables=tables_to_vacuum,
+            retention_days=retention_days,
+            dry_run=dry_run,
+        )
+
+        for table_result in result.results:
+            echo_vacuum_result(table_result, dry_run)
+
+        echo_vacuum_all_summary(result)
+
+    asyncio.run(_run())

--- a/src/bioetl/interfaces/cli/main.py
+++ b/src/bioetl/interfaces/cli/main.py
@@ -11,6 +11,8 @@ import click
 from bioetl import __version__
 from bioetl.composition.factories.pipeline_factories import register_all_pipelines
 from bioetl.interfaces.cli.commands.checkpoint import checkpoint
+from bioetl.interfaces.cli.commands.config import config
+from bioetl.interfaces.cli.commands.lock import lock
 from bioetl.interfaces.cli.commands.maintenance import maintenance
 from bioetl.interfaces.cli.commands.quarantine import quarantine
 from bioetl.interfaces.cli.commands.run import run
@@ -27,6 +29,8 @@ def cli() -> None:
 cli.add_command(run)
 cli.add_command(quarantine)
 cli.add_command(checkpoint)
+cli.add_command(config)
+cli.add_command(lock)
 cli.add_command(maintenance)
 
 

--- a/tests/unit/interfaces/test_cli.py
+++ b/tests/unit/interfaces/test_cli.py
@@ -38,7 +38,8 @@ def mock_registry():
         "uniprot_protein",
     ]
     with patch(
-        "bioetl.interfaces.cli.commands.run.get_default_registry", return_value=mock
+        "bioetl.interfaces.cli.commands.run_helpers.get_default_registry",
+        return_value=mock,
     ):
         yield mock
 
@@ -93,7 +94,7 @@ class TestHandleDestructiveRunConfirmation:
         )
         assert result is True
 
-    @patch("bioetl.interfaces.cli.commands.run._preview_cleanup")
+    @patch("bioetl.interfaces.cli.commands.run_helpers.show_cleanup_preview")
     def test_rebuild_dry_run_shows_preview_returns_false(self, mock_preview):
         """Test that rebuild with dry-run shows preview and returns False."""
         result = _handle_destructive_run_confirmation(
@@ -106,7 +107,7 @@ class TestHandleDestructiveRunConfirmation:
         assert result is False
         mock_preview.assert_called_once_with("chembl_activity")
 
-    @patch("bioetl.interfaces.cli.commands.run._preview_cleanup")
+    @patch("bioetl.interfaces.cli.commands.run_helpers.show_cleanup_preview")
     def test_backfill_dry_run_shows_preview_returns_false(self, mock_preview):
         """Test that backfill with dry-run shows preview and returns False."""
         result = _handle_destructive_run_confirmation(
@@ -119,7 +120,7 @@ class TestHandleDestructiveRunConfirmation:
         assert result is False
         mock_preview.assert_called_once_with("pubchem_compound")
 
-    @patch("bioetl.interfaces.cli.commands.run.click.confirm", return_value=True)
+    @patch("bioetl.interfaces.cli.commands.run_helpers.click.confirm", return_value=True)
     def test_rebuild_with_confirmation_returns_true(self, mock_confirm):
         """Test that rebuild with user confirmation returns True."""
         result = _handle_destructive_run_confirmation(
@@ -132,8 +133,10 @@ class TestHandleDestructiveRunConfirmation:
         assert result is True
         mock_confirm.assert_called_once()
 
-    @patch("bioetl.interfaces.cli.commands.run.click.confirm", return_value=False)
-    @patch("bioetl.interfaces.cli.commands.run.sys.exit")
+    @patch(
+        "bioetl.interfaces.cli.commands.run_helpers.click.confirm", return_value=False
+    )
+    @patch("bioetl.interfaces.cli.commands.run_helpers.sys.exit")
     def test_rebuild_cancelled_exits(self, mock_exit, mock_confirm):
         """Test that cancelled rebuild exits."""
         _handle_destructive_run_confirmation(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -356,7 +356,7 @@ class TestRunCommandAdvanced:
 class TestDryRunMode:
     """Tests for dry-run mode and _preview_cleanup function."""
 
-    @patch("bioetl.interfaces.cli.commands.run.preview_cleanup")
+    @patch("bioetl.interfaces.cli.commands.run_helpers.preview_cleanup")
     def test_dry_run_shows_preview(
         self,
         mock_preview_cleanup,
@@ -389,7 +389,7 @@ class TestDryRunMode:
         assert "Total items that would be cleared: ~5" in result.output
         assert "No changes were made" in result.output
 
-    @patch("bioetl.interfaces.cli.commands.run.preview_cleanup")
+    @patch("bioetl.interfaces.cli.commands.run_helpers.preview_cleanup")
     def test_dry_run_counts_existing_files(
         self,
         mock_preview_cleanup,
@@ -417,7 +417,7 @@ class TestDryRunMode:
         assert result.exit_code == 0
         assert "2 files" in result.output
 
-    @patch("bioetl.interfaces.cli.commands.run.preview_cleanup")
+    @patch("bioetl.interfaces.cli.commands.run_helpers.preview_cleanup")
     def test_dry_run_preview_exception(
         self,
         mock_preview_cleanup,
@@ -441,7 +441,7 @@ class TestDryRunMode:
         assert result.exit_code == 0  # Should catch exception and print error
         assert "Error previewing cleanup" in result.output
 
-    @patch("bioetl.interfaces.cli.commands.run.preview_cleanup")
+    @patch("bioetl.interfaces.cli.commands.run_helpers.preview_cleanup")
     def test_dry_run_preview_variations(
         self,
         mock_preview_cleanup,


### PR DESCRIPTION
Restructures the CLI module to follow the thin controller pattern per RULES.md §9.5. Each command now delegates to Application services.

Changes:
- Split maintenance.py into vacuum.py, archive.py, cleanup.py
- Extract run command helpers to run_helpers.py
- Add lock commands (release, check) for lock management
- Add config commands (show, validate, show-settings, list-pipelines)
- Add bootstrap_lock_service for LockService DI
- Add get_lock_service entrypoint for CLI usage

File sizes (all under 160 LOC):
- main.py: 44 LOC (entry point)
- formatters.py: 150 LOC (presentation only)
- run.py: 139 LOC (12 options = 50 LOC of decorators)
- vacuum.py: 119 LOC
- config.py: 155 LOC
- run_helpers.py: 126 LOC
- lock.py: 94 LOC
- cleanup.py: 55 LOC
- archive.py: 48 LOC
- maintenance.py: 26 LOC (thin wrapper)

Updated tests to patch new module locations.