### PR TITLE
Remove dead code and unused dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Removed
+
+- **Dead Code Cleanup (infrastructure)**: Removed unused import in `infrastructure/config.py`:
+  - `DQConfig as DomainDQConfig` import was never used (imported but not referenced)
+  - Identified via vulture + autoflake static analysis
+  - Verified no external consumers via grep search
+
 ## [5.0.5] - 2025-12-29
 
 ### Added

--- a/src/bioetl/infrastructure/config.py
+++ b/src/bioetl/infrastructure/config.py
@@ -31,7 +31,6 @@ from pydantic_settings import (
     SettingsConfigDict,
 )
 
-from bioetl.domain.config import DQConfig as DomainDQConfig
 from bioetl.domain.config import PipelineConfig
 from bioetl.domain.filter_config import (
     GoldColumnFilter,


### PR DESCRIPTION
Remove dead code identified by vulture and autoflake static analysis:
- `DQConfig as DomainDQConfig` in infrastructure/config.py was imported but never used in the module

Verified no external consumers via grep search.