### PR TITLE
Implement health checks for all providers

### DIFF
--- a/src/bioetl/application/core/health_aggregator.py
+++ b/src/bioetl/application/core/health_aggregator.py
@@ -2,6 +2,9 @@
 
 Validates infrastructure readiness before pipeline execution.
 Implements parallel health checks for storage and data source components.
+
+Integrates with ProviderHealthMonitor for centralized health state management
+and P2 alerting on UNHEALTHY status per RULES.md §3.5.
 """
 
 from __future__ import annotations
@@ -15,7 +18,8 @@ from bioetl.domain.types import ComponentHealthResult, HealthReport, HealthStatu
 
 if TYPE_CHECKING:
     from bioetl.application.core.pipeline_services import PipelineServices
-    from bioetl.domain.ports import LoggerPort, MetricsPort
+    from bioetl.domain.ports import HealthMonitorPort, LoggerPort, MetricsPort
+    from bioetl.domain.ports.health_check import HealthCheckResult
 
 
 class HealthAggregator:
@@ -24,28 +28,41 @@ class HealthAggregator:
     Performs parallel health validation of storage and data source
     before pipeline execution. Records metrics for observability.
 
+    Integrates with ProviderHealthMonitor for:
+    - Centralized health state tracking
+    - P2 alerting on UNHEALTHY status
+    - Adaptive client configuration based on health
+
     Attributes:
         _metrics: Optional metrics port for recording health check metrics.
         _logger: Logger for health check status reporting.
+        _health_monitor: Optional ProviderHealthMonitor for state tracking.
+
     """
 
     # Metric names following Prometheus conventions
     METRIC_HEALTH_STATUS = "health_check_status"
     METRIC_HEALTH_DURATION = "health_check_duration_seconds"
+    METRIC_HEALTH_LATENCY = "health_check_latency_ms"
 
     def __init__(
         self,
         metrics: MetricsPort | None = None,
         logger: LoggerPort | None = None,
+        health_monitor: HealthMonitorPort | None = None,
     ) -> None:
         """Initialize HealthAggregator.
 
         Args:
             metrics: Optional metrics port for recording health check metrics.
             logger: Optional logger for health check status reporting.
+            health_monitor: Optional HealthMonitorPort for centralized
+                health state tracking and alerting.
+
         """
         self._metrics = metrics
         self._logger = logger
+        self._health_monitor = health_monitor
 
     async def check_all(self, services: PipelineServices) -> HealthReport:
         """Check health of all critical infrastructure components.
@@ -129,24 +146,50 @@ class HealthAggregator:
     ) -> ComponentHealthResult:
         """Check data source health.
 
+        Uses enhanced check_health() method when available for detailed
+        metrics including latency. Integrates with ProviderHealthMonitor
+        for state tracking and P2 alerting.
+
         Args:
             services: Pipeline services containing data_source.
 
         Returns:
             ComponentHealthResult for data source.
+
         """
         component = "data_source"
         start_time = time.perf_counter()
+        health_result: HealthCheckResult | None = None
 
         try:
-            status = await services.data_source.health_check()
-            duration = time.perf_counter() - start_time
+            # Try using new check_health() method for detailed result
+            if hasattr(services.data_source, "check_health"):
+                health_result = await services.data_source.check_health()
+                status = health_result.status
+                duration = time.perf_counter() - start_time
 
-            result = ComponentHealthResult(
-                component=component,
-                status=status,
-                duration_seconds=duration,
-            )
+                # Update ProviderHealthMonitor if available
+                if self._health_monitor is not None:
+                    self._health_monitor.update_from_health_check_result(
+                        health_result, self._logger
+                    )
+
+                result = ComponentHealthResult(
+                    component=component,
+                    status=status,
+                    duration_seconds=duration,
+                    error_message=health_result.last_error,
+                )
+            else:
+                # Fallback to legacy health_check()
+                status = await services.data_source.health_check()
+                duration = time.perf_counter() - start_time
+
+                result = ComponentHealthResult(
+                    component=component,
+                    status=status,
+                    duration_seconds=duration,
+                )
         except Exception as e:
             duration = time.perf_counter() - start_time
             result = ComponentHealthResult(
@@ -156,15 +199,22 @@ class HealthAggregator:
                 error_message=str(e),
             )
 
-        self._record_metrics(component, result)
+        self._record_metrics(component, result, health_result)
         return result
 
-    def _record_metrics(self, component: str, result: ComponentHealthResult) -> None:
+    def _record_metrics(
+        self,
+        component: str,
+        result: ComponentHealthResult,
+        health_result: HealthCheckResult | None = None,
+    ) -> None:
         """Record health check metrics.
 
         Args:
             component: Component name for metric labels.
             result: Health check result to record.
+            health_result: Optional detailed HealthCheckResult with latency info.
+
         """
         if self._metrics is None:
             return
@@ -184,6 +234,15 @@ class HealthAggregator:
             result.duration_seconds,
             labels,
         )
+
+        # Record latency from HealthCheckResult if available
+        if health_result is not None:
+            provider_labels = {"provider": health_result.provider}
+            self._metrics.observe_histogram(
+                self.METRIC_HEALTH_LATENCY,
+                health_result.latency_ms,
+                provider_labels,
+            )
 
     def _log_report(self, report: HealthReport) -> None:
         """Log health check report.

--- a/src/bioetl/domain/ports/__init__.py
+++ b/src/bioetl/domain/ports/__init__.py
@@ -29,6 +29,12 @@ from bioetl.domain.ports.data_source import (
     FilterableDataSourcePort,
 )
 from bioetl.domain.ports.filtering import InputFilterPort
+from bioetl.domain.ports.health_check import (
+    HealthCheckPort,
+    HealthCheckResult,
+    HealthMonitorPort,
+    HealthStatusLiteral,
+)
 from bioetl.domain.ports.locking import LockPort
 from bioetl.domain.ports.noop import NoOpAudit, NoOpMetrics, NoOpTracing
 from bioetl.domain.ports.observability import (
@@ -55,6 +61,10 @@ __all__ = [
     "DataSourcePort",
     "FilterableDataSourcePort",
     "GoldValidatorPort",
+    "HealthCheckPort",
+    "HealthCheckResult",
+    "HealthMonitorPort",
+    "HealthStatusLiteral",
     "InputFilterPort",
     "JsonEncoderPort",
     "LockPort",

--- a/src/bioetl/domain/ports/health_check.py
+++ b/src/bioetl/domain/ports/health_check.py
@@ -1,0 +1,204 @@
+"""Health check port for external API health monitoring.
+
+Implements RULES.md §3.5 - Provider Health Monitoring.
+
+Provides standardized health check interface for all data source adapters
+with detailed health status information including latency and error tracking.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
+
+from bioetl.domain.types import HealthStatus
+
+if TYPE_CHECKING:
+    from bioetl.domain.ports.observability import LoggerPort
+
+
+@dataclass(frozen=True, slots=True)
+class HealthCheckResult:
+    """Detailed result of a health check operation.
+
+    Contains health status with additional context for monitoring and alerting.
+
+    Attributes:
+        status: Current health status (HEALTHY, DEGRADED, UNHEALTHY).
+        latency_ms: Time taken for the health check probe in milliseconds.
+        last_error: Description of the last error encountered (if any).
+        consecutive_failures: Number of consecutive health check failures.
+        checked_at: Timestamp when the health check was performed.
+        provider: Name of the provider being checked.
+        endpoint: The endpoint used for the health check probe.
+
+    Example:
+        >>> result = HealthCheckResult(
+        ...     status=HealthStatus.HEALTHY,
+        ...     latency_ms=45.3,
+        ...     provider="chembl",
+        ...     endpoint="/chembl/api/data/status.json",
+        ... )
+        >>> result.is_healthy
+        True
+
+    """
+
+    status: HealthStatus
+    latency_ms: float
+    provider: str
+    endpoint: str = ""
+    last_error: str | None = None
+    consecutive_failures: int = 0
+    checked_at: datetime = field(default_factory=lambda: datetime.now(tz=UTC))
+
+    @property
+    def is_healthy(self) -> bool:
+        """Return True if status is HEALTHY."""
+        return self.status == HealthStatus.HEALTHY
+
+    @property
+    def is_degraded(self) -> bool:
+        """Return True if status is DEGRADED."""
+        return self.status == HealthStatus.DEGRADED
+
+    @property
+    def is_unhealthy(self) -> bool:
+        """Return True if status is UNHEALTHY."""
+        return self.status == HealthStatus.UNHEALTHY
+
+    def to_metric_labels(self) -> dict[str, str]:
+        """Convert to metric labels for Prometheus export.
+
+        Returns:
+            Dictionary with provider and status labels.
+
+        """
+        return {
+            "provider": self.provider,
+            "status": self.status.value.lower(),
+        }
+
+    def to_dict(self) -> dict[str, str | float | int | None]:
+        """Convert to dictionary for logging/serialization.
+
+        Returns:
+            Dictionary representation of the health check result.
+
+        """
+        return {
+            "status": self.status.value,
+            "latency_ms": self.latency_ms,
+            "provider": self.provider,
+            "endpoint": self.endpoint,
+            "last_error": self.last_error,
+            "consecutive_failures": self.consecutive_failures,
+            "checked_at": self.checked_at.isoformat(),
+        }
+
+
+@runtime_checkable
+class HealthCheckPort(Protocol):
+    """Port for health check operations on external APIs.
+
+    Provides a standardized interface for checking the health of
+    data source adapters before pipeline execution.
+
+    Health check probes should be:
+    - Lightweight (minimal data transfer)
+    - Fast (timeout of 5s recommended)
+    - Non-mutating (read-only operations)
+
+    Implementations MUST:
+    - Return HealthCheckResult with accurate latency measurement
+    - Handle timeouts gracefully (return UNHEALTHY, not raise)
+    - Track consecutive failures for state machine transitions
+
+    Example:
+        >>> result = await adapter.check_health()
+        >>> if result.is_unhealthy:
+        ...     logger.error("Provider unavailable", **result.to_dict())
+
+    """
+
+    @property
+    def provider_name(self) -> str:
+        """The unique name of the data provider (e.g., 'chembl')."""
+        ...
+
+    async def check_health(self) -> HealthCheckResult:
+        """Perform a health check on the external API.
+
+        Returns:
+            HealthCheckResult with current health status and metrics.
+
+        Note:
+            This method MUST NOT raise exceptions. All errors should be
+            caught and returned as UNHEALTHY status with error details.
+
+        """
+        ...
+
+
+HealthStatusLiteral = Literal["healthy", "degraded", "unhealthy"]
+"""Type alias for health status literal values (for JSON serialization)."""
+
+
+@runtime_checkable
+class HealthMonitorPort(Protocol):
+    """Port for centralized health monitoring across providers.
+
+    Implements RULES.md §3.5 state machine for provider health:
+    - HEALTHY: Provider operational, no errors
+    - DEGRADED: 1-2 consecutive errors, timeout ×2, batch_size ÷2
+    - UNHEALTHY: ≥3 errors, pipeline paused, P2 alert
+
+    This port abstracts the health monitoring implementation, allowing
+    the application layer to track health without depending on
+    infrastructure details.
+
+    """
+
+    def update_from_health_check_result(
+        self,
+        result: HealthCheckResult,
+        logger: LoggerPort | None = None,
+    ) -> HealthStatus:
+        """Update health state from HealthCheckResult.
+
+        Records latency metrics and triggers P2 alert on UNHEALTHY status.
+
+        Args:
+            result: HealthCheckResult from adapter health check.
+            logger: Optional logger for P2 alert on UNHEALTHY.
+
+        Returns:
+            Current HealthStatus after applying transitions.
+
+        """
+        ...
+
+    def record_success(self, provider: str) -> HealthStatus:
+        """Record successful operation for a provider.
+
+        Args:
+            provider: Provider name.
+
+        Returns:
+            Current HealthStatus after recording success.
+
+        """
+        ...
+
+    def record_error(self, provider: str) -> HealthStatus:
+        """Record failed operation for a provider.
+
+        Args:
+            provider: Provider name.
+
+        Returns:
+            Current HealthStatus after recording error.
+
+        """
+        ...

--- a/src/bioetl/infrastructure/adapters/base.py
+++ b/src/bioetl/infrastructure/adapters/base.py
@@ -10,10 +10,12 @@ to circuit breaker assessment on failure.
 
 from __future__ import annotations
 
+import time
 from types import TracebackType
 from typing import TYPE_CHECKING, Self
 
 from bioetl.domain.ports import DataSourcePort, LoggerPort
+from bioetl.domain.ports.health_check import HealthCheckResult
 from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.adapters.http.health import (
     assess_health_from_circuit_breaker,
@@ -97,6 +99,61 @@ class BaseHttpAdapter(DataSourcePort):
             return await self._probe_health()
         except Exception:
             return self._fallback_health_status()
+
+    async def check_health(self) -> HealthCheckResult:
+        """Perform health check and return detailed result.
+
+        This method provides enhanced health check with latency tracking
+        and error details. It wraps the Template Method pattern used by
+        health_check() with additional metrics.
+
+        Returns:
+            HealthCheckResult with status, latency, and error details.
+
+        Note:
+            This method never raises exceptions. All errors are caught
+            and returned as UNHEALTHY status with error details.
+
+        """
+        start_time = time.monotonic()
+        last_error: str | None = None
+        consecutive_failures = 0
+
+        try:
+            status = await self._probe_health()
+        except Exception as e:
+            last_error = str(e)
+            status = self._fallback_health_status()
+            # Get failure count from circuit breaker if available
+            try:
+                consecutive_failures = (
+                    self.http_client.circuit_breaker.get_failure_count()
+                )
+            except Exception:
+                consecutive_failures = 1
+
+        latency_ms = (time.monotonic() - start_time) * 1000
+
+        return HealthCheckResult(
+            status=status,
+            latency_ms=latency_ms,
+            provider=self.provider_name,
+            endpoint=self._get_health_endpoint(),
+            last_error=last_error,
+            consecutive_failures=consecutive_failures,
+        )
+
+    def _get_health_endpoint(self) -> str:
+        """Get the health check endpoint for this adapter.
+
+        Subclasses SHOULD override this to return the specific endpoint
+        used for health probes. Default returns empty string.
+
+        Returns:
+            Health check endpoint path.
+
+        """
+        return ""
 
     async def _probe_health(self) -> HealthStatus:
         """Perform provider-specific health probe.

--- a/src/bioetl/infrastructure/adapters/chembl/client.py
+++ b/src/bioetl/infrastructure/adapters/chembl/client.py
@@ -440,6 +440,15 @@ class ChemblAdapter(BaseHttpAdapter):
         """
         return self._get_health_status()
 
+    def _get_health_endpoint(self) -> str:
+        """Get the health check endpoint for ChEMBL.
+
+        Returns:
+            ChEMBL status endpoint path.
+
+        """
+        return "/chembl/api/data/status.json"
+
     def _handle_health_response(self, response: Response) -> HealthStatus:
         """Process health check response.
 

--- a/src/bioetl/infrastructure/adapters/crossref/client.py
+++ b/src/bioetl/infrastructure/adapters/crossref/client.py
@@ -431,6 +431,15 @@ class CrossRefAdapter(BaseHttpAdapter):
         """
         return HealthStatus.UNHEALTHY
 
+    def _get_health_endpoint(self) -> str:
+        """Get the health check endpoint for CrossRef.
+
+        Returns:
+            CrossRef works endpoint used for health probe.
+
+        """
+        return "/works"
+
     async def aclose(self) -> None:
         """Close adapter resources.
 

--- a/src/bioetl/infrastructure/adapters/http/__init__.py
+++ b/src/bioetl/infrastructure/adapters/http/__init__.py
@@ -6,6 +6,8 @@ Provides:
 - UnifiedHTTPClient: Async HTTP client with rate limiting and circuit breaker
 - RetryConfig: Backward compatibility alias for RetryPolicy
 - ProviderHealthMonitor: Centralized provider health monitoring (RULES.md §3.5)
+- ProviderHealthTracker: Per-provider health state machine wrapper
+- AdjustedClientConfig: Health-based client configuration adjustments
 """
 
 from __future__ import annotations
@@ -13,15 +15,19 @@ from __future__ import annotations
 from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
 from bioetl.infrastructure.adapters.http.client import RetryConfig, UnifiedHTTPClient
 from bioetl.infrastructure.adapters.http.health_monitor import (
+    AdjustedClientConfig,
     ProviderHealthMonitor,
     ProviderHealthState,
+    ProviderHealthTracker,
 )
 from bioetl.infrastructure.adapters.http.rate_limiter import TokenBucket
 
 __all__ = [
+    "AdjustedClientConfig",
     "CircuitBreaker",
     "ProviderHealthMonitor",
     "ProviderHealthState",
+    "ProviderHealthTracker",
     "RetryConfig",
     "TokenBucket",
     "UnifiedHTTPClient",

--- a/src/bioetl/infrastructure/adapters/http/health_monitor.py
+++ b/src/bioetl/infrastructure/adapters/http/health_monitor.py
@@ -22,7 +22,59 @@ from typing import TYPE_CHECKING
 from bioetl.domain.types import HealthStatus
 
 if TYPE_CHECKING:
-    from bioetl.domain.ports import MetricsPort
+    from bioetl.domain.ports import LoggerPort, MetricsPort
+    from bioetl.domain.ports.health_check import HealthCheckResult
+
+
+@dataclass(frozen=True, slots=True)
+class AdjustedClientConfig:
+    """Configuration adjusted based on provider health status.
+
+    Per RULES.md §3.5:
+    - HEALTHY: Normal operation (multiplier=1.0, divisor=1)
+    - DEGRADED: Timeout ×2, batch_size ÷2
+    - UNHEALTHY: Timeout ×4, batch_size ÷4 (aggressive throttling)
+
+    Attributes:
+        timeout_multiplier: Factor to multiply base timeout by.
+        batch_size_divisor: Factor to divide base batch_size by.
+        status: Current health status.
+
+    Example:
+        >>> config = tracker.get_adjusted_config()
+        >>> effective_timeout = base_timeout * config.timeout_multiplier
+        >>> effective_batch_size = base_batch_size // config.batch_size_divisor
+
+    """
+
+    timeout_multiplier: float
+    batch_size_divisor: int
+    status: HealthStatus
+
+    def apply_timeout(self, base_timeout: float) -> float:
+        """Apply timeout multiplier to base timeout.
+
+        Args:
+            base_timeout: Base timeout in seconds.
+
+        Returns:
+            Adjusted timeout value.
+
+        """
+        return base_timeout * self.timeout_multiplier
+
+    def apply_batch_size(self, base_batch_size: int, minimum: int = 1) -> int:
+        """Apply batch size divisor to base batch size.
+
+        Args:
+            base_batch_size: Base batch size.
+            minimum: Minimum allowed batch size (default: 1).
+
+        Returns:
+            Adjusted batch size, at least `minimum`.
+
+        """
+        return max(minimum, base_batch_size // self.batch_size_divisor)
 
 
 @dataclass
@@ -212,3 +264,204 @@ class ProviderHealthMonitor:
             Dictionary of provider name to ProviderHealthState.
         """
         return dict(self._states)
+
+    def update_from_health_check_result(
+        self,
+        result: HealthCheckResult,
+        logger: LoggerPort | None = None,
+    ) -> HealthStatus:
+        """Update state from HealthCheckResult and emit metrics.
+
+        This method provides enhanced integration with HealthCheckResult,
+        recording latency metrics and logging P2 alerts for UNHEALTHY status.
+
+        Args:
+            result: HealthCheckResult from adapter health check.
+            logger: Optional logger for P2 alert on UNHEALTHY.
+
+        Returns:
+            Current HealthStatus after applying transitions.
+
+        """
+        # Record health check latency metric
+        self.metrics.observe_histogram(
+            "health_check_latency_ms",
+            result.latency_ms,
+            labels={"provider": result.provider},
+        )
+
+        # Record health check result metric
+        self.metrics.set_gauge(
+            "provider_health_status",
+            float(result.status.to_metric_value()),
+            labels={"provider": result.provider},
+        )
+
+        # Apply state transitions
+        new_status = self.record_health_check_result(result.provider, result.status)
+
+        # P2 Alert for UNHEALTHY status
+        if new_status == HealthStatus.UNHEALTHY and logger:
+            logger.error(
+                "provider_unhealthy_alert",
+                provider=result.provider,
+                alert_priority="P2",
+                status=new_status.value,
+                consecutive_failures=result.consecutive_failures,
+                last_error=result.last_error,
+                endpoint=result.endpoint,
+                latency_ms=result.latency_ms,
+            )
+
+        return new_status
+
+    def get_adjusted_config(self, provider: str) -> AdjustedClientConfig:
+        """Get adjusted client configuration based on health status.
+
+        Per RULES.md §3.5:
+        - HEALTHY: Normal operation (timeout ×1, batch_size ÷1)
+        - DEGRADED: Timeout ×2, batch_size ÷2
+        - UNHEALTHY: Timeout ×4, batch_size ÷4 (aggressive throttling)
+
+        Args:
+            provider: Provider name.
+
+        Returns:
+            AdjustedClientConfig with multipliers for timeout and batch_size.
+
+        Example:
+            >>> config = monitor.get_adjusted_config("chembl")
+            >>> effective_timeout = 30.0 * config.timeout_multiplier  # 60.0 if DEGRADED
+            >>> effective_batch_size = config.apply_batch_size(1000, minimum=100)
+
+        """
+        timeout_mult, batch_div = self.get_adaptive_params(provider)
+        state = self.get_state(provider)
+        return AdjustedClientConfig(
+            timeout_multiplier=timeout_mult,
+            batch_size_divisor=batch_div,
+            status=state.status,
+        )
+
+
+@dataclass
+class ProviderHealthTracker:
+    """Per-provider health tracker with state machine management.
+
+    Wraps ProviderHealthMonitor for single-provider usage, providing
+    a simpler interface for adapters to track and respond to health changes.
+
+    Implements RULES.md §3.5 state machine:
+    - HEALTHY: Provider operational, no errors
+    - DEGRADED: 1-2 consecutive errors, timeout ×2, batch_size ÷2
+    - UNHEALTHY: ≥3 errors, pipeline paused, P2 alert
+
+    Attributes:
+        provider: Provider name (e.g., 'chembl', 'pubchem').
+        monitor: Centralized ProviderHealthMonitor instance.
+        logger: Optional logger for alerts.
+
+    Example:
+        >>> tracker = ProviderHealthTracker("chembl", monitor, logger)
+        >>> tracker.update(health_result)
+        >>> config = tracker.get_adjusted_config()
+        >>> if config.status == HealthStatus.UNHEALTHY:
+        ...     raise CriticalError("Provider unavailable")
+
+    """
+
+    provider: str
+    monitor: ProviderHealthMonitor
+    logger: LoggerPort | None = None
+
+    # Base configuration defaults
+    _base_timeout: float = 30.0
+    _base_batch_size: int = 1000
+
+    def update(self, result: HealthCheckResult) -> HealthStatus:
+        """Update health state from HealthCheckResult.
+
+        Args:
+            result: HealthCheckResult from health check probe.
+
+        Returns:
+            Current HealthStatus after update.
+
+        """
+        return self.monitor.update_from_health_check_result(result, self.logger)
+
+    def record_success(self) -> HealthStatus:
+        """Record successful operation.
+
+        Returns:
+            Current HealthStatus after recording success.
+
+        """
+        return self.monitor.record_success(self.provider)
+
+    def record_error(self) -> HealthStatus:
+        """Record failed operation.
+
+        Returns:
+            Current HealthStatus after recording error.
+
+        """
+        return self.monitor.record_error(self.provider)
+
+    def get_adjusted_config(self) -> AdjustedClientConfig:
+        """Get adjusted client configuration.
+
+        Returns:
+            AdjustedClientConfig with timeout/batch_size adjustments.
+
+        """
+        return self.monitor.get_adjusted_config(self.provider)
+
+    @property
+    def status(self) -> HealthStatus:
+        """Get current health status.
+
+        Returns:
+            Current HealthStatus for this provider.
+
+        """
+        return self.monitor.get_state(self.provider).status
+
+    @property
+    def consecutive_failures(self) -> int:
+        """Get consecutive failure count.
+
+        Returns:
+            Number of consecutive errors.
+
+        """
+        return self.monitor.get_state(self.provider).consecutive_errors
+
+    def is_healthy(self) -> bool:
+        """Check if provider is healthy.
+
+        Returns:
+            True if status is HEALTHY.
+
+        """
+        return self.status == HealthStatus.HEALTHY
+
+    def is_unhealthy(self) -> bool:
+        """Check if provider is unhealthy.
+
+        Returns:
+            True if status is UNHEALTHY.
+
+        """
+        return self.status == HealthStatus.UNHEALTHY
+
+    def should_pause_pipeline(self) -> bool:
+        """Check if pipeline should be paused due to health.
+
+        Per RULES.md §3.5: UNHEALTHY status pauses pipeline.
+
+        Returns:
+            True if pipeline should be paused.
+
+        """
+        return self.is_unhealthy()

--- a/src/bioetl/infrastructure/adapters/pubchem/client.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/client.py
@@ -322,6 +322,15 @@ class PubChemAdapter(BaseSyncAdapter):
             )
             raise  # Let base class handle via _fallback_health_status()
 
+    def _get_health_endpoint(self) -> str:
+        """Get the health check endpoint for PubChem.
+
+        Returns:
+            PubChem compound query endpoint used for health probe.
+
+        """
+        return "/rest/pug/compound/cid/962/property/MolecularFormula/JSON"
+
     def __repr__(self) -> str:
         """Return string representation."""
         return f"PubChemAdapter(rate={self.rate_limiter.rate})"

--- a/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
+++ b/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
@@ -270,6 +270,15 @@ class PubMedAdapter(BaseHttpAdapter):
         """
         return HealthStatus.UNHEALTHY
 
+    def _get_health_endpoint(self) -> str:
+        """Get the health check endpoint for PubMed.
+
+        Returns:
+            PubMed esearch endpoint used for health probe.
+
+        """
+        return "/entrez/eutils/esearch.fcgi"
+
     async def aclose(self) -> None:
         """Close adapter resources.
 

--- a/src/bioetl/infrastructure/adapters/sync_base.py
+++ b/src/bioetl/infrastructure/adapters/sync_base.py
@@ -11,11 +11,13 @@ to circuit breaker assessment on failure.
 from __future__ import annotations
 
 import asyncio
+import time
 import weakref
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, Self
 
 from bioetl.domain.ports import DataSourcePort, LoggerPort, MetricsPort, NoOpMetrics
+from bioetl.domain.ports.health_check import HealthCheckResult
 from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.adapters.http.health import (
     assess_health_from_circuit_breaker,
@@ -133,6 +135,70 @@ class BaseSyncAdapter(DataSourcePort):
                 {"provider": self.provider_name},
             )
             return self._fallback_health_status()
+
+    async def check_health(self) -> HealthCheckResult:
+        """Perform health check and return detailed result.
+
+        This method provides enhanced health check with latency tracking
+        and error details. It wraps the Template Method pattern used by
+        health_check() with additional metrics.
+
+        Returns:
+            HealthCheckResult with status, latency, and error details.
+
+        Note:
+            This method never raises exceptions. All errors are caught
+            and returned as UNHEALTHY status with error details.
+
+        """
+        start_time = time.monotonic()
+        last_error: str | None = None
+        consecutive_failures = 0
+
+        try:
+            status = await self._probe_health()
+        except Exception as e:
+            last_error = str(e)
+            status = self._fallback_health_status()
+            self.logger.warning(
+                "health_check_failed",
+                provider=self.provider_name,
+                error=str(e),
+                error_type=type(e).__name__,
+            )
+            self.metrics.increment_counter(
+                "health_check_failures_total",
+                1,
+                {"provider": self.provider_name},
+            )
+            # Get failure count from circuit breaker
+            try:
+                consecutive_failures = self.circuit_breaker.get_failure_count()
+            except Exception:
+                consecutive_failures = 1
+
+        latency_ms = (time.monotonic() - start_time) * 1000
+
+        return HealthCheckResult(
+            status=status,
+            latency_ms=latency_ms,
+            provider=self.provider_name,
+            endpoint=self._get_health_endpoint(),
+            last_error=last_error,
+            consecutive_failures=consecutive_failures,
+        )
+
+    def _get_health_endpoint(self) -> str:
+        """Get the health check endpoint for this adapter.
+
+        Subclasses SHOULD override this to return the specific endpoint
+        used for health probes. Default returns empty string.
+
+        Returns:
+            Health check endpoint path.
+
+        """
+        return ""
 
     async def _probe_health(self) -> HealthStatus:
         """Perform provider-specific health probe.

--- a/src/bioetl/infrastructure/adapters/uniprot/client.py
+++ b/src/bioetl/infrastructure/adapters/uniprot/client.py
@@ -300,6 +300,15 @@ class UniProtAdapter(BaseHttpAdapter, PaginatedFetcherMixin):
             )
             raise  # Base class catches and returns _fallback_health_status()
 
+    def _get_health_endpoint(self) -> str:
+        """Get the health check endpoint for UniProt.
+
+        Returns:
+            UniProt search endpoint used for health probe.
+
+        """
+        return "/uniprotkb/search"
+
     def __repr__(self) -> str:
         """Return string representation."""
         has_key = "with API key" if self.api_key else "without API key"

--- a/tests/unit/application/core/test_health_aggregator.py
+++ b/tests/unit/application/core/test_health_aggregator.py
@@ -5,13 +5,31 @@ Tests the infrastructure health validation before pipeline execution.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
 import pytest
 
 from bioetl.application.core.health_aggregator import HealthAggregator
 from bioetl.domain.exceptions import InfrastructureError
+from bioetl.domain.ports.health_check import HealthCheckResult
 from bioetl.domain.types import ComponentHealthResult, HealthReport, HealthStatus
+
+
+def _create_health_check_result(
+    status: HealthStatus = HealthStatus.HEALTHY,
+    provider: str = "test_provider",
+    latency_ms: float = 50.0,
+    last_error: str | None = None,
+) -> HealthCheckResult:
+    """Helper to create HealthCheckResult for tests."""
+    return HealthCheckResult(
+        status=status,
+        latency_ms=latency_ms,
+        provider=provider,
+        endpoint="/health",
+        last_error=last_error,
+        consecutive_failures=0 if status == HealthStatus.HEALTHY else 1,
+    )
 
 
 @pytest.fixture
@@ -45,8 +63,26 @@ def mock_storage():
 
 @pytest.fixture
 def mock_data_source():
-    """Create a mock data source port."""
+    """Create a mock data source port with check_health method.
+
+    Uses spec to ensure only specified methods are available,
+    preventing MagicMock auto-attribute creation from triggering
+    the hasattr check for check_health.
+    """
     data_source = MagicMock()
+    # Remove check_health attribute to trigger legacy fallback
+    del data_source.check_health
+    data_source.health_check = AsyncMock(return_value=HealthStatus.HEALTHY)
+    return data_source
+
+
+@pytest.fixture
+def mock_data_source_with_check_health():
+    """Create a mock data source port with new check_health method."""
+    data_source = MagicMock()
+    data_source.check_health = AsyncMock(
+        return_value=_create_health_check_result(HealthStatus.HEALTHY)
+    )
     data_source.health_check = AsyncMock(return_value=HealthStatus.HEALTHY)
     return data_source
 

--- a/tests/unit/application/core/test_preflight_service.py
+++ b/tests/unit/application/core/test_preflight_service.py
@@ -70,6 +70,8 @@ def mock_services():
     services.storage = MagicMock()
     services.storage.health_check = AsyncMock(return_value=HealthStatus.HEALTHY)
     services.data_source = MagicMock()
+    # Remove check_health attribute to trigger legacy fallback in HealthAggregator
+    del services.data_source.check_health
     services.data_source.health_check = AsyncMock(return_value=HealthStatus.HEALTHY)
     services.logger = MagicMock()
     services.logger.info = MagicMock()
@@ -219,6 +221,8 @@ class TestPreflightServiceValidation:
             return_value=HealthStatus.DEGRADED
         )
         degraded_services.data_source = MagicMock()
+        # Remove check_health to trigger legacy fallback
+        del degraded_services.data_source.check_health
         degraded_services.data_source.health_check = AsyncMock(
             return_value=HealthStatus.HEALTHY
         )

--- a/tests/unit/infrastructure/adapters/http/test_health_monitor.py
+++ b/tests/unit/infrastructure/adapters/http/test_health_monitor.py
@@ -319,3 +319,265 @@ class TestProviderHealthMonitorGetAllStates:
         assert "uniprot" in states
         assert "pubchem" in states
         assert len(states) == 3
+
+
+class TestAdjustedClientConfig:
+    """Tests for AdjustedClientConfig dataclass."""
+
+    def test_apply_timeout_multiplies(self) -> None:
+        """Test apply_timeout multiplies base timeout."""
+        from bioetl.infrastructure.adapters.http.health_monitor import (
+            AdjustedClientConfig,
+        )
+
+        config = AdjustedClientConfig(
+            timeout_multiplier=2.0,
+            batch_size_divisor=2,
+            status=HealthStatus.DEGRADED,
+        )
+
+        assert config.apply_timeout(30.0) == 60.0
+
+    def test_apply_batch_size_divides(self) -> None:
+        """Test apply_batch_size divides base batch size."""
+        from bioetl.infrastructure.adapters.http.health_monitor import (
+            AdjustedClientConfig,
+        )
+
+        config = AdjustedClientConfig(
+            timeout_multiplier=2.0,
+            batch_size_divisor=2,
+            status=HealthStatus.DEGRADED,
+        )
+
+        assert config.apply_batch_size(1000) == 500
+
+    def test_apply_batch_size_respects_minimum(self) -> None:
+        """Test apply_batch_size respects minimum value."""
+        from bioetl.infrastructure.adapters.http.health_monitor import (
+            AdjustedClientConfig,
+        )
+
+        config = AdjustedClientConfig(
+            timeout_multiplier=4.0,
+            batch_size_divisor=4,
+            status=HealthStatus.UNHEALTHY,
+        )
+
+        # 50 / 4 = 12, but minimum is 100
+        assert config.apply_batch_size(50, minimum=100) == 100
+
+
+class TestProviderHealthTracker:
+    """Tests for ProviderHealthTracker wrapper class."""
+
+    @pytest.fixture
+    def mock_logger(self) -> MagicMock:
+        """Create mock logger."""
+        return MagicMock()
+
+    @pytest.fixture
+    def tracker(
+        self, monitor: ProviderHealthMonitor, mock_logger: MagicMock
+    ) -> "ProviderHealthTracker":
+        """Create ProviderHealthTracker."""
+        from bioetl.infrastructure.adapters.http.health_monitor import (
+            ProviderHealthTracker,
+        )
+
+        return ProviderHealthTracker(
+            provider="chembl",
+            monitor=monitor,
+            logger=mock_logger,
+        )
+
+    def test_status_property(
+        self, tracker: "ProviderHealthTracker", monitor: ProviderHealthMonitor
+    ) -> None:
+        """Test status property returns current health status."""
+        assert tracker.status == HealthStatus.HEALTHY
+
+        monitor.record_error("chembl")
+        assert tracker.status == HealthStatus.DEGRADED
+
+    def test_consecutive_failures_property(
+        self, tracker: "ProviderHealthTracker", monitor: ProviderHealthMonitor
+    ) -> None:
+        """Test consecutive_failures property returns error count."""
+        assert tracker.consecutive_failures == 0
+
+        monitor.record_error("chembl")
+        assert tracker.consecutive_failures == 1
+
+        monitor.record_error("chembl")
+        assert tracker.consecutive_failures == 2
+
+    def test_is_healthy_method(self, tracker: "ProviderHealthTracker") -> None:
+        """Test is_healthy returns True when HEALTHY."""
+        assert tracker.is_healthy() is True
+
+    def test_is_unhealthy_method(
+        self, tracker: "ProviderHealthTracker", monitor: ProviderHealthMonitor
+    ) -> None:
+        """Test is_unhealthy returns True when UNHEALTHY."""
+        assert tracker.is_unhealthy() is False
+
+        # Trigger UNHEALTHY
+        monitor.record_error("chembl")
+        monitor.record_error("chembl")
+        monitor.record_error("chembl")
+
+        assert tracker.is_unhealthy() is True
+
+    def test_should_pause_pipeline(
+        self, tracker: "ProviderHealthTracker", monitor: ProviderHealthMonitor
+    ) -> None:
+        """Test should_pause_pipeline returns True when UNHEALTHY."""
+        assert tracker.should_pause_pipeline() is False
+
+        # Trigger UNHEALTHY
+        for _ in range(3):
+            monitor.record_error("chembl")
+
+        assert tracker.should_pause_pipeline() is True
+
+    def test_record_success_delegates(
+        self, tracker: "ProviderHealthTracker", monitor: ProviderHealthMonitor
+    ) -> None:
+        """Test record_success delegates to monitor."""
+        monitor.record_error("chembl")  # DEGRADED
+
+        status = tracker.record_success()
+
+        # Should recover from DEGRADED if clear window passed
+        assert status in (HealthStatus.HEALTHY, HealthStatus.DEGRADED)
+
+    def test_record_error_delegates(
+        self, tracker: "ProviderHealthTracker"
+    ) -> None:
+        """Test record_error delegates to monitor."""
+        status = tracker.record_error()
+
+        assert status == HealthStatus.DEGRADED
+
+    def test_get_adjusted_config(
+        self, tracker: "ProviderHealthTracker", monitor: ProviderHealthMonitor
+    ) -> None:
+        """Test get_adjusted_config returns proper config."""
+        from bioetl.infrastructure.adapters.http.health_monitor import (
+            AdjustedClientConfig,
+        )
+
+        config = tracker.get_adjusted_config()
+
+        assert isinstance(config, AdjustedClientConfig)
+        assert config.timeout_multiplier == 1.0
+        assert config.batch_size_divisor == 1
+        assert config.status == HealthStatus.HEALTHY
+
+
+class TestProviderHealthMonitorUpdateFromResult:
+    """Tests for update_from_health_check_result method."""
+
+    def test_updates_state_from_result(
+        self, monitor: ProviderHealthMonitor, mock_metrics: MagicMock
+    ) -> None:
+        """Test update_from_health_check_result updates state."""
+        from bioetl.domain.ports.health_check import HealthCheckResult
+
+        result = HealthCheckResult(
+            status=HealthStatus.UNHEALTHY,
+            latency_ms=100.0,
+            provider="chembl",
+            endpoint="/status.json",
+            last_error="Connection timeout",
+            consecutive_failures=3,
+        )
+
+        status = monitor.update_from_health_check_result(result)
+
+        assert status == HealthStatus.UNHEALTHY
+
+    def test_emits_latency_metric(
+        self, monitor: ProviderHealthMonitor, mock_metrics: MagicMock
+    ) -> None:
+        """Test update_from_health_check_result emits latency metric."""
+        from bioetl.domain.ports.health_check import HealthCheckResult
+
+        result = HealthCheckResult(
+            status=HealthStatus.HEALTHY,
+            latency_ms=45.5,
+            provider="chembl",
+            endpoint="/status.json",
+        )
+
+        monitor.update_from_health_check_result(result)
+
+        # Should have called observe_histogram for latency
+        mock_metrics.observe_histogram.assert_called_with(
+            "health_check_latency_ms",
+            45.5,
+            labels={"provider": "chembl"},
+        )
+
+    def test_logs_p2_alert_on_unhealthy(
+        self, monitor: ProviderHealthMonitor
+    ) -> None:
+        """Test P2 alert is logged when status becomes UNHEALTHY."""
+        from bioetl.domain.ports.health_check import HealthCheckResult
+
+        mock_logger = MagicMock()
+        result = HealthCheckResult(
+            status=HealthStatus.UNHEALTHY,
+            latency_ms=100.0,
+            provider="chembl",
+            endpoint="/status.json",
+            last_error="API unavailable",
+            consecutive_failures=5,
+        )
+
+        monitor.update_from_health_check_result(result, logger=mock_logger)
+
+        mock_logger.error.assert_called_once()
+        call_args = mock_logger.error.call_args
+        assert call_args[0][0] == "provider_unhealthy_alert"
+        assert call_args[1]["alert_priority"] == "P2"
+        assert call_args[1]["provider"] == "chembl"
+
+
+class TestGetAdjustedConfig:
+    """Tests for get_adjusted_config method."""
+
+    def test_healthy_config(self, monitor: ProviderHealthMonitor) -> None:
+        """Test get_adjusted_config returns normal config when HEALTHY."""
+        from bioetl.infrastructure.adapters.http.health_monitor import (
+            AdjustedClientConfig,
+        )
+
+        config = monitor.get_adjusted_config("chembl")
+
+        assert isinstance(config, AdjustedClientConfig)
+        assert config.timeout_multiplier == 1.0
+        assert config.batch_size_divisor == 1
+        assert config.status == HealthStatus.HEALTHY
+
+    def test_degraded_config(self, monitor: ProviderHealthMonitor) -> None:
+        """Test get_adjusted_config returns degraded config."""
+        monitor.record_error("chembl")
+
+        config = monitor.get_adjusted_config("chembl")
+
+        assert config.timeout_multiplier == 2.0
+        assert config.batch_size_divisor == 2
+        assert config.status == HealthStatus.DEGRADED
+
+    def test_unhealthy_config(self, monitor: ProviderHealthMonitor) -> None:
+        """Test get_adjusted_config returns aggressive config when UNHEALTHY."""
+        for _ in range(3):
+            monitor.record_error("chembl")
+
+        config = monitor.get_adjusted_config("chembl")
+
+        assert config.timeout_multiplier == 4.0
+        assert config.batch_size_divisor == 4
+        assert config.status == HealthStatus.UNHEALTHY

--- a/tests/unit/infrastructure/test_config_settings.py
+++ b/tests/unit/infrastructure/test_config_settings.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from pydantic import ValidationError


### PR DESCRIPTION
Implements RULES.md §3.5 and §App A provider health monitoring:

- Add HealthCheckPort protocol and HealthCheckResult dataclass for detailed health check results with latency tracking
- Add HealthMonitorPort protocol for centralized health state tracking
- Add ProviderHealthTracker and AdjustedClientConfig for per-provider health state management with adaptive client configuration
- Add check_health() method to BaseHttpAdapter and BaseSyncAdapter returning HealthCheckResult with latency, error details, and endpoint
- Add _get_health_endpoint() to all adapters (ChEMBL, UniProt, PubChem, PubMed, CrossRef) per §App A endpoint specification
- Enhance ProviderHealthMonitor with update_from_health_check_result() and get_adjusted_config() methods
- Integrate HealthMonitorPort into HealthAggregator for pipeline pre-run validation with P2 alerting on UNHEALTHY status
- Add provider_health_status, health_check_latency_ms metrics export
- Add 17 new unit tests for ProviderHealthTracker, AdjustedClientConfig, and health check integration

Health check endpoints per §App A:
- ChEMBL: /chembl/api/data/status.json (5s timeout)
- PubChem: /rest/pug/compound/cid/962/property/MolecularFormula/JSON
- UniProt: /uniprotkb/search
- PubMed: /entrez/eutils/esearch.fcgi
- CrossRef: /works