### PR TITLE
Fix YAML config files being ignored in adapters

### DIFF
--- a/src/bioetl/composition/factories/http_client_factory.py
+++ b/src/bioetl/composition/factories/http_client_factory.py
@@ -7,6 +7,11 @@ SRP Compliance:
 - Creates UnifiedHTTPClient with injected RateLimiterPort and CircuitBreakerPort
 - RetryPolicy is configured via domain value object
 - Observability components (tracer, metrics, logger) are injected for correlation
+
+Configuration Priority:
+1. Pipeline-specific config from YAML (source.rate_limit, source.circuit_breaker)
+2. Provider defaults from ProviderRegistry (HttpConfig)
+3. Fallback defaults (rate=5.0, capacity=10, failure_threshold=5, recovery_timeout=300)
 """
 
 from __future__ import annotations
@@ -22,6 +27,7 @@ if TYPE_CHECKING:
     from bioetl.domain.ports import LoggerPort, MetricsPort, TracingPort
     from bioetl.domain.types import RunID
     from bioetl.infrastructure.config import Settings
+    from bioetl.infrastructure.schemas.pipeline_config import PipelineYamlConfig
 
 
 class HttpClientFactory:
@@ -37,6 +43,7 @@ class HttpClientFactory:
         provider: str,
         settings: Settings | None = None,
         *,
+        pipeline_config: PipelineYamlConfig | None = None,
         run_id: RunID | None = None,
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
@@ -44,11 +51,14 @@ class HttpClientFactory:
     ) -> UnifiedHTTPClient:
         """Create a configured HTTP client for the given provider.
 
-        Uses ProviderRegistry for configuration lookup.
+        Uses pipeline_config for rate limits and circuit breaker settings,
+        falling back to ProviderRegistry defaults if not specified.
 
         Args:
             provider: Provider name (e.g., 'chembl', 'pubmed')
             settings: Optional settings to override defaults (e.g., API keys)
+            pipeline_config: Optional pipeline config with source-specific settings.
+                If provided, uses source.rate_limit and source.circuit_breaker.
             run_id: Optional run ID for correlation headers
             tracer: Optional TracingPort for distributed tracing
             metrics: Optional MetricsPort for metrics collection
@@ -71,6 +81,7 @@ class HttpClientFactory:
         return cls._create_from_registry(
             provider,
             settings,
+            pipeline_config=pipeline_config,
             run_id=run_id,
             tracer=tracer,
             metrics=metrics,
@@ -83,16 +94,23 @@ class HttpClientFactory:
         provider: str,
         settings: Settings | None,
         *,
+        pipeline_config: PipelineYamlConfig | None = None,
         run_id: RunID | None = None,
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
         logger: LoggerPort | None = None,
     ) -> UnifiedHTTPClient:
-        """Create HTTP client using ProviderRegistry configuration.
+        """Create HTTP client using configuration from pipeline config and registry.
+
+        Configuration priority:
+        1. Pipeline-specific config (source.rate_limit, source.circuit_breaker)
+        2. Provider defaults from ProviderRegistry (HttpConfig)
+        3. Fallback defaults
 
         Args:
             provider: Provider name
             settings: Application settings
+            pipeline_config: Optional pipeline config with source-specific settings
             run_id: Optional run ID for correlation headers
             tracer: Optional TracingPort for distributed tracing
             metrics: Optional MetricsPort for metrics collection
@@ -101,26 +119,30 @@ class HttpClientFactory:
         Returns:
             Configured UnifiedHTTPClient with observability
         """
+        # Get circuit breaker settings from pipeline config or use defaults
+        failure_threshold = 5
+        recovery_timeout = 300
+
+        if pipeline_config:
+            # Use source.circuit_breaker from configs/sources/*.yaml
+            source_cb = pipeline_config.source.circuit_breaker
+            failure_threshold = source_cb.failure_threshold
+            recovery_timeout = source_cb.recovery_timeout
+
+        # Get rate limit settings
+        rate: float = 5.0
+        capacity: int = 10
+
+        if pipeline_config:
+            # Use source.rate_limit from configs/sources/*.yaml
+            source_rl = pipeline_config.source.rate_limit
+            rate = source_rl.requests_per_second
+            capacity = source_rl.burst
+
+        # Check ProviderRegistry for rate overrides based on settings (e.g., API key)
         http_config = ProviderRegistry.get_http_config(provider)
 
-        if http_config is None:
-            # Provider doesn't use shared HTTP client
-            # Return default client
-            return UnifiedHTTPClient(
-                rate_limiter=TokenBucket(rate=5.0, capacity=10),
-                circuit_breaker=CircuitBreaker(provider=provider, metrics=metrics),
-                provider=provider,
-                run_id=run_id,
-                tracer=tracer,
-                metrics=metrics,
-                logger=logger,
-            )
-
-        rate = http_config.rate
-        capacity = http_config.capacity
-
-        # Apply rate overrides based on settings
-        if settings and http_config.rate_overrides:
+        if http_config is not None and settings and http_config.rate_overrides:
             for setting_name, override_rate in http_config.rate_overrides.items():
                 if cls._check_setting(settings, setting_name):
                     rate = override_rate
@@ -128,8 +150,13 @@ class HttpClientFactory:
                     break
 
         return UnifiedHTTPClient(
-            rate_limiter=TokenBucket(rate=rate, capacity=capacity),
-            circuit_breaker=CircuitBreaker(provider=provider, metrics=metrics),
+            rate_limiter=TokenBucket(rate=rate, capacity=capacity, provider=provider),
+            circuit_breaker=CircuitBreaker(
+                provider=provider,
+                failure_threshold=failure_threshold,
+                recovery_timeout=recovery_timeout,
+                metrics=metrics,
+            ),
             provider=provider,
             run_id=run_id,
             tracer=tracer,

--- a/src/bioetl/composition/providers/registration.py
+++ b/src/bioetl/composition/providers/registration.py
@@ -107,11 +107,24 @@ def _create_chembl_data_source(
     metrics: MetricsPort | None = None,
     pipeline_name: str = "unknown",
 ) -> DataSourcePort:
-    """Create ChEMBL data source with optional CSV filtering."""
+    """Create ChEMBL data source with optional CSV filtering.
+
+    Uses rate_limit and circuit_breaker settings from pipeline_config.source
+    (loaded from configs/sources/chembl.yaml).
+    """
     DataSourceFactory, HttpClientFactory = _get_factories()
-    http_client = HttpClientFactory.create_for_provider("chembl", settings)
+    http_client = HttpClientFactory.create_for_provider(
+        "chembl",
+        settings,
+        pipeline_config=pipeline_config,
+    )
+    # Pass batch_size from config to adapter
+    batch_size = pipeline_config.source.batch_size
     base_adapter = DataSourceFactory.create(
-        "chembl", http_client=http_client, logger=logger
+        "chembl",
+        http_client=http_client,
+        logger=logger,
+        batch_size=batch_size,
     )
     return _wrap_with_filter(
         base_adapter, filter_config, logger, metrics, pipeline_name
@@ -184,14 +197,26 @@ def _create_pubchem_data_source(
     metrics: MetricsPort | None = None,
     pipeline_name: str = "unknown",
 ) -> DataSourcePort:
-    """Create PubChem data source with optional CSV filtering."""
-    # Create adapter via custom creator with all dependencies injected
+    """Create PubChem data source with optional CSV filtering.
+
+    Uses rate_limit, circuit_breaker, and batch_size settings from
+    pipeline_config.source (loaded from configs/sources/pubchem.yaml).
+    """
+    # Get config values from source config
+    source_rl = pipeline_config.source.rate_limit
+    source_cb = pipeline_config.source.circuit_breaker
+
+    # Create adapter via custom creator with config-driven dependencies
     data_source = _create_pubchem_adapter(
         http_client=None,
         logger=logger,
         settings=settings,
-        rate=5.0,
+        rate=source_rl.requests_per_second,
+        capacity=source_rl.burst,
+        circuit_breaker_threshold=source_cb.failure_threshold,
+        circuit_breaker_timeout=source_cb.recovery_timeout,
         strict_error_handling=settings.strict_error_handling,
+        metrics=metrics,
     )
     return _wrap_with_filter(data_source, filter_config, logger, metrics, pipeline_name)
 
@@ -204,9 +229,20 @@ def _create_uniprot_data_source(
     metrics: MetricsPort | None = None,
     pipeline_name: str = "unknown",
 ) -> DataSourcePort:
-    """Create UniProt data source with optional CSV filtering."""
+    """Create UniProt data source with optional CSV filtering.
+
+    Uses rate_limit and circuit_breaker settings from pipeline_config.source
+    (loaded from configs/sources/uniprot.yaml).
+
+    Note: UniProtAdapter doesn't accept batch_size in constructor, it's handled
+    differently via page_size in API calls.
+    """
     DataSourceFactory, HttpClientFactory = _get_factories()
-    http_client = HttpClientFactory.create_for_provider("uniprot", settings)
+    http_client = HttpClientFactory.create_for_provider(
+        "uniprot",
+        settings,
+        pipeline_config=pipeline_config,
+    )
     data_source = DataSourceFactory.create(
         "uniprot",
         http_client=http_client,
@@ -225,9 +261,17 @@ def _create_pubmed_data_source(
     metrics: MetricsPort | None = None,
     pipeline_name: str = "unknown",
 ) -> DataSourcePort:
-    """Create PubMed data source with optional CSV filtering."""
+    """Create PubMed data source with optional CSV filtering.
+
+    Uses rate_limit and circuit_breaker settings from pipeline_config.source
+    (loaded from configs/sources/pubmed.yaml).
+    """
     _, HttpClientFactory = _get_factories()
-    http_client = HttpClientFactory.create_for_provider("pubmed", settings)
+    http_client = HttpClientFactory.create_for_provider(
+        "pubmed",
+        settings,
+        pipeline_config=pipeline_config,
+    )
 
     # Determine API key: config takes precedence over settings
     configured_api_key = pipeline_config.source.api_key
@@ -238,11 +282,15 @@ def _create_pubmed_data_source(
 
     email = pipeline_config.source.email or settings.default_email
 
+    # Get batch_size from config
+    batch_size = pipeline_config.source.batch_size
+
     data_source = PubMedAdapter(
         http_client=http_client,
         logger=logger,
         email=email,
         api_key=api_key,
+        batch_size=batch_size,
     )
     return _wrap_with_filter(data_source, filter_config, logger, metrics, pipeline_name)
 

--- a/src/bioetl/infrastructure/schemas/pipeline_config.py
+++ b/src/bioetl/infrastructure/schemas/pipeline_config.py
@@ -199,15 +199,61 @@ class ApiConfig(BaseModel):
         )
 
 
-class SourceConfig(BaseModel):
-    """Configuration for the data source."""
+class RateLimitSourceConfig(BaseModel):
+    """Rate limit configuration from source YAML.
 
+    Pydantic model for parsing rate_limit section from configs/sources/*.yaml.
+    """
+
+    requests_per_second: float = Field(default=5.0, ge=0.1, le=100.0)
+    burst: int = Field(default=10, ge=1, le=200)
+
+
+class ClientSourceConfig(BaseModel):
+    """HTTP client configuration from source YAML."""
+
+    timeout_sec: float = Field(default=30.0, ge=1.0, le=300.0)
+    max_retries: int = Field(default=3, ge=0, le=10)
+
+
+class ProviderSourceConfig(BaseModel):
+    """Provider-specific configuration from source YAML.
+
+    Pydantic model for parsing provider_config section from configs/sources/*.yaml.
+    """
+
+    provider: str | None = None
+    base_url: str | None = None
+    client: ClientSourceConfig = Field(default_factory=ClientSourceConfig)
+    max_url_length: int = Field(default=2000, ge=500, le=8000)
+    batch_size: int = Field(default=100, ge=1, le=5000)
+    page_size: int = Field(default=1000, ge=100, le=10000)
+    api_version: str | None = None
+    default_email: str | None = None
+
+
+class SourceConfig(BaseModel):
+    """Configuration for the data source.
+
+    Parses both pipeline source settings and configs/sources/*.yaml structure.
+    The `rate_limit`, `circuit_breaker`, and `provider_config` fields capture
+    settings from source configuration files that were previously ignored.
+    """
+
+    # Common fields
     load_strategy: Literal["full", "incremental"] = "full"
     search_term: str | None = None
     email: str | None = None
     api_key: str | None = None
     fields: list[dict[str, str]] = Field(default_factory=list)
     api: ApiConfig = Field(default_factory=ApiConfig)
+
+    # Source file fields (from configs/sources/*.yaml)
+    type: Literal["api", "file"] = "api"
+    batch_size: int = Field(default=100, ge=1, le=5000)
+    rate_limit: RateLimitSourceConfig = Field(default_factory=RateLimitSourceConfig)
+    circuit_breaker: CircuitBreakerConfig = Field(default_factory=CircuitBreakerConfig)
+    provider_config: ProviderSourceConfig = Field(default_factory=ProviderSourceConfig)
 
 
 class SortByConfig(BaseModel):


### PR DESCRIPTION
…ource configs

Previously, configs/sources/*.yaml files were loaded but their rate_limit, circuit_breaker, and provider_config parameters were ignored. Adapters used hardcoded defaults instead of config values.

Changes:
- Add RateLimitSourceConfig, ClientSourceConfig, ProviderSourceConfig models to SourceConfig in pipeline_config.py for parsing source YAML files
- Update HttpClientFactory.create_for_provider() to accept pipeline_config and use source.rate_limit and source.circuit_breaker values
- Update data source creator functions in registration.py to pass pipeline_config to HttpClientFactory and use source.batch_size

Now when a pipeline is bootstrapped:
- ChEMBL uses 5 req/sec from configs/sources/chembl.yaml (was 10.0 hardcoded)
- CircuitBreaker uses failure_threshold and recovery_timeout from YAML
- Adapters receive batch_size from source config (ChemblAdapter, PubMedAdapter)

Config priority: YAML source config → ProviderRegistry rate_overrides → defaults