### PR TITLE
Remove hardcoded values from config files

### DIFF
--- a/src/bioetl/composition/factories/http_client_factory.py
+++ b/src/bioetl/composition/factories/http_client_factory.py
@@ -1,7 +1,12 @@
 """Factory for creating HTTP clients with standard configurations.
 
 Ensures consistent rate limiting and circuit breaker settings across providers.
-Uses ProviderRegistry for unified configuration management.
+Uses source configuration from YAML files (configs/sources/*.yaml) for settings.
+
+Configuration Priority:
+1. Source YAML config (configs/sources/{provider}.yaml) - PRIMARY
+2. Settings API key overrides (for rate limit boost with API keys)
+3. ProviderRegistry defaults (fallback only)
 
 SRP Compliance:
 - Creates UnifiedHTTPClient with injected RateLimiterPort and CircuitBreakerPort
@@ -11,17 +16,21 @@ SRP Compliance:
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from bioetl.composition.providers import ProviderRegistry, ensure_providers_loaded
 from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
 from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
 from bioetl.infrastructure.adapters.http.rate_limiter import TokenBucket
+from bioetl.infrastructure.config import load_source_config
 
 if TYPE_CHECKING:
     from bioetl.domain.ports import LoggerPort, MetricsPort, TracingPort
     from bioetl.domain.types import RunID
     from bioetl.infrastructure.config import Settings
+
+_logger = logging.getLogger(__name__)
 
 
 class HttpClientFactory:
@@ -88,7 +97,10 @@ class HttpClientFactory:
         metrics: MetricsPort | None = None,
         logger: LoggerPort | None = None,
     ) -> UnifiedHTTPClient:
-        """Create HTTP client using ProviderRegistry configuration.
+        """Create HTTP client using source YAML configuration.
+
+        Configuration is loaded from configs/sources/{provider}.yaml.
+        Falls back to ProviderRegistry defaults if source config not found.
 
         Args:
             provider: Provider name
@@ -101,26 +113,41 @@ class HttpClientFactory:
         Returns:
             Configured UnifiedHTTPClient with observability
         """
-        http_config = ProviderRegistry.get_http_config(provider)
-
-        if http_config is None:
-            # Provider doesn't use shared HTTP client
-            # Return default client
-            return UnifiedHTTPClient(
-                rate_limiter=TokenBucket(rate=5.0, capacity=10),
-                circuit_breaker=CircuitBreaker(provider=provider, metrics=metrics),
-                provider=provider,
-                run_id=run_id,
-                tracer=tracer,
-                metrics=metrics,
-                logger=logger,
+        # Try to load source config from YAML (primary source)
+        source_config = None
+        try:
+            source_config = load_source_config(provider)
+        except ValueError:
+            _logger.debug(
+                "Source config not found for %s, using ProviderRegistry defaults",
+                provider,
             )
 
-        rate = http_config.rate
-        capacity = http_config.capacity
+        # Get rate limit and circuit breaker settings
+        if source_config is not None:
+            # Use source YAML config (primary)
+            rate = source_config.rate_limit.requests_per_second
+            capacity = source_config.rate_limit.burst
+            failure_threshold = source_config.circuit_breaker.failure_threshold
+            recovery_timeout = source_config.circuit_breaker.recovery_timeout
+        else:
+            # Fallback to ProviderRegistry
+            http_config = ProviderRegistry.get_http_config(provider)
+            if http_config is None:
+                # Provider doesn't use shared HTTP client - use safe defaults
+                rate = 5.0
+                capacity = 10
+                failure_threshold = 5
+                recovery_timeout = 300
+            else:
+                rate = http_config.rate
+                capacity = http_config.capacity
+                failure_threshold = 5  # Default
+                recovery_timeout = 300  # Default
 
-        # Apply rate overrides based on settings
-        if settings and http_config.rate_overrides:
+        # Apply rate overrides based on settings (API key boosts)
+        http_config = ProviderRegistry.get_http_config(provider)
+        if settings and http_config and http_config.rate_overrides:
             for setting_name, override_rate in http_config.rate_overrides.items():
                 if cls._check_setting(settings, setting_name):
                     rate = override_rate
@@ -128,8 +155,13 @@ class HttpClientFactory:
                     break
 
         return UnifiedHTTPClient(
-            rate_limiter=TokenBucket(rate=rate, capacity=capacity),
-            circuit_breaker=CircuitBreaker(provider=provider, metrics=metrics),
+            rate_limiter=TokenBucket(rate=rate, capacity=capacity, provider=provider),
+            circuit_breaker=CircuitBreaker(
+                provider=provider,
+                failure_threshold=failure_threshold,
+                recovery_timeout=recovery_timeout,
+                metrics=metrics,
+            ),
             provider=provider,
             run_id=run_id,
             tracer=tracer,

--- a/src/bioetl/composition/providers/registration.py
+++ b/src/bioetl/composition/providers/registration.py
@@ -9,10 +9,16 @@ This module follows the Hexagonal Architecture import matrix:
 
 After registry unification, this module also contains data source creator
 functions that were previously in DataSourceRegistry.
+
+Configuration Loading:
+- Rate limits and circuit breaker settings are loaded from configs/sources/*.yaml
+- Batch sizes are loaded from source YAML configs
+- ProviderRegistry HttpConfig serves as fallback for backwards compatibility
 """
 
 from __future__ import annotations
 
+import logging
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any
 
@@ -34,6 +40,7 @@ from bioetl.infrastructure.adapters.pubmed.pubmed_client import (
     _create_pubmed_adapter,
 )
 from bioetl.infrastructure.adapters.uniprot.client import UniProtAdapter
+from bioetl.infrastructure.config import load_source_config
 
 if TYPE_CHECKING:
     from bioetl.domain.filter_config import InputFilterConfig
@@ -41,6 +48,9 @@ if TYPE_CHECKING:
     from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
     from bioetl.infrastructure.config import Settings
     from bioetl.infrastructure.schemas.pipeline_config import PipelineYamlConfig
+    from bioetl.infrastructure.schemas.source_config import SourceYamlConfig
+
+_logger = logging.getLogger(__name__)
 
 
 def _get_factories() -> tuple[Any, Any]:
@@ -57,6 +67,100 @@ def _get_factories() -> tuple[Any, Any]:
     from bioetl.composition.factories.http_client_factory import HttpClientFactory
 
     return DataSourceFactory, HttpClientFactory
+
+
+def _get_source_config(provider: str) -> SourceYamlConfig | None:
+    """Get source configuration for a provider.
+
+    Loads configuration from configs/sources/{provider}.yaml.
+    Returns None if configuration file does not exist.
+
+    Args:
+        provider: Provider name (e.g., 'chembl', 'pubchem')
+
+    Returns:
+        SourceYamlConfig or None if not found
+    """
+    try:
+        return load_source_config(provider)
+    except ValueError:
+        _logger.debug(
+            "Source config not found for %s, using defaults",
+            provider,
+        )
+        return None
+
+
+def _get_batch_size_from_config(provider: str, default: int = 100) -> int:
+    """Get batch size from source configuration.
+
+    Args:
+        provider: Provider name
+        default: Default batch size if config not found
+
+    Returns:
+        Batch size from config or default
+    """
+    source_config = _get_source_config(provider)
+    if source_config is not None:
+        return source_config.batch_size
+    return default
+
+
+def _get_rate_limit_from_config(
+    provider: str,
+) -> tuple[float, int]:
+    """Get rate limit parameters from source configuration.
+
+    Args:
+        provider: Provider name
+
+    Returns:
+        Tuple of (rate, capacity) from config or defaults (5.0, 10)
+    """
+    source_config = _get_source_config(provider)
+    if source_config is not None:
+        return (
+            source_config.rate_limit.requests_per_second,
+            source_config.rate_limit.burst,
+        )
+    return (5.0, 10)
+
+
+def _get_circuit_breaker_from_config(provider: str) -> tuple[int, int]:
+    """Get circuit breaker parameters from source configuration.
+
+    Args:
+        provider: Provider name
+
+    Returns:
+        Tuple of (failure_threshold, recovery_timeout) from config or defaults (5, 300)
+    """
+    source_config = _get_source_config(provider)
+    if source_config is not None:
+        return (
+            source_config.circuit_breaker.failure_threshold,
+            source_config.circuit_breaker.recovery_timeout,
+        )
+    return (5, 300)
+
+
+def _get_page_size_from_config(provider: str, default: int = 1000) -> int:
+    """Get page size from source configuration for paginated APIs.
+
+    Used for ChEMBL and similar APIs that use page-based pagination.
+
+    Args:
+        provider: Provider name
+        default: Default page size if config not found
+
+    Returns:
+        Page size from config or default
+    """
+    source_config = _get_source_config(provider)
+    if source_config is not None and source_config.page_size is not None:
+        return source_config.page_size
+    return default
 
 
 # =============================================================================
@@ -107,11 +211,28 @@ def _create_chembl_data_source(
     metrics: MetricsPort | None = None,
     pipeline_name: str = "unknown",
 ) -> DataSourcePort:
-    """Create ChEMBL data source with optional CSV filtering."""
+    """Create ChEMBL data source with optional CSV filtering.
+
+    Configuration is loaded from configs/sources/chembl.yaml:
+    - page_size: API pagination size (ChemblAdapter.batch_size)
+    - batch_size: Filter batch size (ChemblAdapter.filter_batch_size)
+    """
     DataSourceFactory, HttpClientFactory = _get_factories()
     http_client = HttpClientFactory.create_for_provider("chembl", settings)
+
+    # Load sizes from source config
+    # page_size is used for ChEMBL API pagination
+    page_size = _get_page_size_from_config("chembl", default=1000)
+    # batch_size is used for filter ID batching
+    filter_batch_size = _get_batch_size_from_config("chembl", default=20)
+
     base_adapter = DataSourceFactory.create(
-        "chembl", http_client=http_client, logger=logger
+        "chembl",
+        http_client=http_client,
+        logger=logger,
+        batch_size=page_size,
+        filter_batch_size=filter_batch_size,
+        metrics=metrics,
     )
     return _wrap_with_filter(
         base_adapter, filter_config, logger, metrics, pipeline_name
@@ -128,6 +249,8 @@ def _create_pubchem_adapter(
 
     This is the custom_creator for PubChem that creates all dependencies
     in the Composition Root before creating the adapter.
+
+    Configuration is loaded from configs/sources/pubchem.yaml.
 
     Args:
         http_client: Not used for PubChem (uses pubchempy).
@@ -147,11 +270,15 @@ def _create_pubchem_adapter(
             "Ensure logger is passed from Composition Root."
         )
 
-    # Get configuration parameters
-    rate = kwargs.pop("rate", 5.0)  # 5 req/sec per RULES.md
-    capacity = kwargs.pop("capacity", int(rate * 2))
-    circuit_breaker_threshold = kwargs.pop("circuit_breaker_threshold", 5)
-    circuit_breaker_timeout = kwargs.pop("circuit_breaker_timeout", 300)
+    # Load configuration from source YAML
+    rate, capacity = _get_rate_limit_from_config("pubchem")
+    cb_threshold, cb_timeout = _get_circuit_breaker_from_config("pubchem")
+
+    # Allow kwargs to override config values (for testing)
+    rate = kwargs.pop("rate", rate)
+    capacity = kwargs.pop("capacity", capacity)
+    circuit_breaker_threshold = kwargs.pop("circuit_breaker_threshold", cb_threshold)
+    circuit_breaker_timeout = kwargs.pop("circuit_breaker_timeout", cb_timeout)
     max_workers = kwargs.pop("max_workers", 4)
     strict_error_handling = kwargs.pop("strict_error_handling", False)
     metrics = kwargs.pop("metrics", None)
@@ -184,14 +311,18 @@ def _create_pubchem_data_source(
     metrics: MetricsPort | None = None,
     pipeline_name: str = "unknown",
 ) -> DataSourcePort:
-    """Create PubChem data source with optional CSV filtering."""
+    """Create PubChem data source with optional CSV filtering.
+
+    Configuration is loaded from configs/sources/pubchem.yaml.
+    """
     # Create adapter via custom creator with all dependencies injected
+    # Rate limit and circuit breaker are loaded from source config in _create_pubchem_adapter
     data_source = _create_pubchem_adapter(
         http_client=None,
         logger=logger,
         settings=settings,
-        rate=5.0,
         strict_error_handling=settings.strict_error_handling,
+        metrics=metrics,
     )
     return _wrap_with_filter(data_source, filter_config, logger, metrics, pipeline_name)
 
@@ -258,14 +389,24 @@ def register_all_providers() -> None:
     This function MUST be called from bootstrap before using ProviderRegistry.
     Idempotent - safe to call multiple times.
 
-    Provider configurations:
-    - ChEMBL: 10 req/sec, capacity 20 (async HTTP client)
-    - PubChem: 5 req/sec, capacity 10 (sync via ThreadPoolExecutor)
-    - UniProt: 10 req/sec, 100 with API key, capacity 20 (async HTTP client)
-    - PubMed: 3 req/sec, 10 with API key, capacity 6 (async HTTP client)
+    Configuration Priority:
+    1. configs/sources/{provider}.yaml - PRIMARY (rate limits, circuit breaker, batch_size)
+    2. HttpConfig in ProviderConfig - FALLBACK only
 
-    Each provider now includes a data_source_creator for unified registry access.
+    Provider configurations are now loaded from YAML files:
+    - ChEMBL: configs/sources/chembl.yaml
+    - PubChem: configs/sources/pubchem.yaml
+    - UniProt: configs/sources/uniprot.yaml
+    - PubMed: configs/sources/pubmed.yaml
+
+    Each provider includes a data_source_creator for unified registry access.
     """
+    # Load rate limits from source configs (with fallback defaults)
+    chembl_rate, chembl_capacity = _get_rate_limit_from_config("chembl")
+    pubchem_rate, pubchem_capacity = _get_rate_limit_from_config("pubchem")
+    uniprot_rate, uniprot_capacity = _get_rate_limit_from_config("uniprot")
+    pubmed_rate, pubmed_capacity = _get_rate_limit_from_config("pubmed")
+
     # ChEMBL - async HTTP adapter
     if not ProviderRegistry.is_registered("chembl"):
         ProviderRegistry.register(
@@ -273,8 +414,8 @@ def register_all_providers() -> None:
             ProviderConfig(
                 adapter_class=ChemblAdapter,
                 http_config=HttpConfig(
-                    rate=10.0,
-                    capacity=20,
+                    rate=chembl_rate,
+                    capacity=chembl_capacity,
                 ),
                 requires_http_client=True,
                 requires_logger=True,
@@ -291,8 +432,8 @@ def register_all_providers() -> None:
             ProviderConfig(
                 adapter_class=PubChemAdapter,
                 http_config=HttpConfig(
-                    rate=5.0,
-                    capacity=10,
+                    rate=pubchem_rate,
+                    capacity=pubchem_capacity,
                 ),
                 requires_http_client=False,
                 requires_logger=True,
@@ -308,8 +449,8 @@ def register_all_providers() -> None:
             ProviderConfig(
                 adapter_class=UniProtAdapter,
                 http_config=HttpConfig(
-                    rate=10.0,
-                    capacity=20,
+                    rate=uniprot_rate,
+                    capacity=uniprot_capacity,
                     rate_overrides={"uniprot_api_key": 100.0},
                 ),
                 requires_http_client=True,
@@ -325,8 +466,8 @@ def register_all_providers() -> None:
             ProviderConfig(
                 adapter_class=PubMedAdapter,
                 http_config=HttpConfig(
-                    rate=3.0,
-                    capacity=6,
+                    rate=pubmed_rate,
+                    capacity=pubmed_capacity,
                     rate_overrides={"pubmed_api_key": 10.0},
                 ),
                 requires_http_client=True,

--- a/src/bioetl/infrastructure/config.py
+++ b/src/bioetl/infrastructure/config.py
@@ -34,6 +34,7 @@ from pydantic_settings import (
 from bioetl.domain.config import PipelineConfig
 from bioetl.domain.filter_config import GoldFilterConfig
 from bioetl.infrastructure.schemas.pipeline_config import PipelineYamlConfig
+from bioetl.infrastructure.schemas.source_config import SourceYamlConfig
 
 # =============================================================================
 # Configuration Defaults Support
@@ -142,6 +143,44 @@ class YamlSettingsSource(PydanticBaseSettingsSource):
                 d[field_key] = field_value
 
         return d
+
+
+@lru_cache(maxsize=10)
+def load_source_config(provider: str) -> SourceYamlConfig:
+    """Load source configuration from YAML file.
+
+    Loads provider-specific source configuration from configs/sources/{provider}.yaml.
+    Results are cached for efficiency.
+
+    Args:
+        provider: Provider name (e.g., 'chembl', 'pubmed', 'pubchem', 'uniprot')
+
+    Returns:
+        SourceYamlConfig: Validated source configuration with rate limits,
+            circuit breaker settings, and batch sizes.
+
+    Raises:
+        ValueError: If config file is missing or validation fails.
+
+    Example:
+        >>> config = load_source_config("chembl")
+        >>> config.rate_limit.requests_per_second
+        5.0
+        >>> config.circuit_breaker.failure_threshold
+        5
+    """
+    config_path = Path(f"configs/sources/{provider}.yaml")
+
+    if not config_path.exists():
+        raise ValueError(
+            f"Source configuration file not found: {config_path}. "
+            f"Create configs/sources/{provider}.yaml with rate_limit and circuit_breaker settings."
+        )
+
+    with open(config_path, encoding="utf-8") as f:
+        raw_config = yaml.safe_load(f) or {}
+
+    return SourceYamlConfig.model_validate(raw_config)
 
 
 @lru_cache(maxsize=10)
@@ -498,8 +537,10 @@ from bioetl.domain.config import RuntimeConfig  # noqa: E402
 __all__ = [
     "RuntimeConfig",
     "Settings",
+    "SourceYamlConfig",
     "get_pipeline_config",
     "get_settings",
     "load_pipeline_config",
+    "load_source_config",
     "yaml_config_to_domain",
 ]

--- a/src/bioetl/infrastructure/schemas/source_config.py
+++ b/src/bioetl/infrastructure/schemas/source_config.py
@@ -1,0 +1,203 @@
+"""Schema validation for source configuration.
+
+Implements strict validation for source YAML configurations (configs/sources/*.yaml).
+These configs define provider-specific settings like rate limits, circuit breaker,
+and batch sizes that were previously hardcoded.
+
+Usage:
+    >>> from bioetl.infrastructure.schemas.source_config import SourceYamlConfig
+    >>> config = SourceYamlConfig.model_validate(yaml_data)
+    >>> rate_limit = config.source.rate_limit.requests_per_second
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from bioetl.domain.resilience import CircuitBreakerConfig as DomainCircuitBreakerConfig
+
+
+class RateLimitYamlConfig(BaseModel):
+    """Rate limit configuration from YAML.
+
+    Attributes:
+        requests_per_second: Maximum requests per second.
+        burst: Maximum burst capacity (token bucket).
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    requests_per_second: float = Field(default=5.0, ge=0.1, le=100.0)
+    burst: int = Field(default=10, ge=1, le=200)
+
+
+class CircuitBreakerYamlConfig(BaseModel):
+    """Circuit breaker configuration from YAML.
+
+    Attributes:
+        failure_threshold: Number of consecutive failures before opening circuit.
+        recovery_timeout: Time in seconds before attempting recovery.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    failure_threshold: int = Field(default=5, ge=1, le=20)
+    recovery_timeout: int = Field(default=300, ge=60, le=3600)
+
+    def to_domain(self) -> DomainCircuitBreakerConfig:
+        """Convert to domain CircuitBreakerConfig dataclass.
+
+        Returns:
+            DomainCircuitBreakerConfig: Immutable domain configuration.
+        """
+        return DomainCircuitBreakerConfig(
+            failure_threshold=self.failure_threshold,
+            recovery_timeout=self.recovery_timeout,
+        )
+
+
+class ClientYamlConfig(BaseModel):
+    """HTTP client configuration from YAML.
+
+    Attributes:
+        timeout_sec: Request timeout in seconds.
+        max_retries: Maximum number of retry attempts.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    timeout_sec: float = Field(default=30.0, ge=1.0, le=300.0)
+    max_retries: int = Field(default=3, ge=0, le=10)
+
+
+class ProviderConfigYaml(BaseModel):
+    """Provider-specific configuration from YAML.
+
+    Attributes:
+        provider: Provider name (chembl, pubchem, uniprot, pubmed).
+        base_url: Base URL for the API.
+        client: HTTP client settings.
+        batch_size: Provider-specific batch size for API requests.
+        page_size: Page size for paginated requests (ChEMBL specific).
+        max_url_length: Maximum URL length (ChEMBL specific).
+        default_email: Default email for NCBI APIs (PubMed specific).
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    provider: str
+    base_url: str | None = None
+    client: ClientYamlConfig = Field(default_factory=ClientYamlConfig)
+    batch_size: int | None = Field(default=None, ge=1, le=10000)
+    page_size: int | None = Field(default=None, ge=1, le=10000)
+    max_url_length: int | None = Field(default=None, ge=100, le=10000)
+    api_version: str | None = None
+    default_email: str | None = None
+
+
+class SourceSectionConfig(BaseModel):
+    """Source section configuration from YAML.
+
+    This represents the 'source' section in configs/sources/*.yaml files.
+
+    Attributes:
+        type: Source type (api, file, etc).
+        load_strategy: Loading strategy (full, incremental).
+        batch_size: Batch size for data loading.
+        provider_config: Provider-specific settings.
+        circuit_breaker: Circuit breaker configuration.
+        rate_limit: Rate limiting configuration.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    type: Literal["api", "file"] = "api"
+    load_strategy: Literal["full", "incremental"] = "full"
+    batch_size: int = Field(default=100, ge=1, le=10000)
+    provider_config: ProviderConfigYaml = Field(default_factory=ProviderConfigYaml)
+    circuit_breaker: CircuitBreakerYamlConfig = Field(
+        default_factory=CircuitBreakerYamlConfig
+    )
+    rate_limit: RateLimitYamlConfig = Field(default_factory=RateLimitYamlConfig)
+
+
+class SourceYamlConfig(BaseModel):
+    """Root schema for source configuration files.
+
+    Validates configs/sources/*.yaml files.
+
+    Example YAML:
+        source:
+            type: api
+            batch_size: 100
+            provider_config:
+                provider: chembl
+                base_url: https://www.ebi.ac.uk/chembl/api/data
+            circuit_breaker:
+                failure_threshold: 5
+                recovery_timeout: 300
+            rate_limit:
+                requests_per_second: 5.0
+                burst: 10
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    source: SourceSectionConfig = Field(default_factory=SourceSectionConfig)
+
+    @property
+    def provider(self) -> str:
+        """Get provider name from nested config."""
+        return self.source.provider_config.provider
+
+    @property
+    def rate_limit(self) -> RateLimitYamlConfig:
+        """Get rate limit config."""
+        return self.source.rate_limit
+
+    @property
+    def circuit_breaker(self) -> CircuitBreakerYamlConfig:
+        """Get circuit breaker config."""
+        return self.source.circuit_breaker
+
+    @property
+    def batch_size(self) -> int:
+        """Get batch size (provider_config takes precedence over source level)."""
+        if self.source.provider_config.batch_size is not None:
+            return self.source.provider_config.batch_size
+        return self.source.batch_size
+
+    @property
+    def page_size(self) -> int | None:
+        """Get page size for paginated APIs (e.g., ChEMBL).
+
+        Returns None if not specified, allowing adapters to use their defaults.
+        """
+        return self.source.provider_config.page_size
+
+    @property
+    def timeout_sec(self) -> float:
+        """Get timeout in seconds."""
+        return self.source.provider_config.client.timeout_sec
+
+    @property
+    def max_retries(self) -> int:
+        """Get max retries."""
+        return self.source.provider_config.client.max_retries
+
+    @property
+    def base_url(self) -> str | None:
+        """Get base URL."""
+        return self.source.provider_config.base_url
+
+
+__all__ = [
+    "CircuitBreakerYamlConfig",
+    "ClientYamlConfig",
+    "ProviderConfigYaml",
+    "RateLimitYamlConfig",
+    "SourceSectionConfig",
+    "SourceYamlConfig",
+]

--- a/tests/architecture/test_source_config_usage.py
+++ b/tests/architecture/test_source_config_usage.py
@@ -1,0 +1,245 @@
+"""Architecture tests for source configuration usage.
+
+These tests verify that source configurations from configs/sources/*.yaml
+are used instead of hardcoded values.
+
+Related to: https://github.com/SatoryKono/BioactivityDataAcquisition/issues/XXX
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+if TYPE_CHECKING:
+    pass
+
+
+class TestSourceConfigFilesExist:
+    """Verify that source configuration files exist for all providers."""
+
+    @pytest.fixture
+    def source_configs_dir(self) -> Path:
+        """Get path to source configs directory."""
+        return Path("configs/sources")
+
+    @pytest.mark.parametrize(
+        "provider",
+        ["chembl", "pubchem", "uniprot", "pubmed"],
+    )
+    def test_source_config_exists(self, source_configs_dir: Path, provider: str) -> None:
+        """Each provider MUST have a source configuration file."""
+        config_file = source_configs_dir / f"{provider}.yaml"
+        assert config_file.exists(), (
+            f"Source config missing: {config_file}. "
+            f"Create configs/sources/{provider}.yaml with rate_limit and circuit_breaker settings."
+        )
+
+    @pytest.mark.parametrize(
+        "provider",
+        ["chembl", "pubchem", "uniprot", "pubmed"],
+    )
+    def test_source_config_has_required_sections(
+        self, source_configs_dir: Path, provider: str
+    ) -> None:
+        """Source config MUST have rate_limit and circuit_breaker sections."""
+        config_file = source_configs_dir / f"{provider}.yaml"
+        if not config_file.exists():
+            pytest.skip(f"Config file {config_file} does not exist")
+
+        with open(config_file, encoding="utf-8") as f:
+            config = yaml.safe_load(f)
+
+        assert "source" in config, f"{provider}: Missing 'source' section"
+        source = config["source"]
+
+        assert "rate_limit" in source, f"{provider}: Missing 'rate_limit' section"
+        rate_limit = source["rate_limit"]
+        assert "requests_per_second" in rate_limit, (
+            f"{provider}: Missing 'rate_limit.requests_per_second'"
+        )
+        assert "burst" in rate_limit, f"{provider}: Missing 'rate_limit.burst'"
+
+        assert "circuit_breaker" in source, (
+            f"{provider}: Missing 'circuit_breaker' section"
+        )
+        cb = source["circuit_breaker"]
+        assert "failure_threshold" in cb, (
+            f"{provider}: Missing 'circuit_breaker.failure_threshold'"
+        )
+        assert "recovery_timeout" in cb, (
+            f"{provider}: Missing 'circuit_breaker.recovery_timeout'"
+        )
+
+
+class TestSourceConfigLoading:
+    """Verify that source configs are loaded and used."""
+
+    def test_load_source_config_returns_valid_model(self) -> None:
+        """load_source_config() should return validated SourceYamlConfig."""
+        from bioetl.infrastructure.config import load_source_config
+
+        config = load_source_config("chembl")
+
+        assert config.rate_limit.requests_per_second > 0
+        assert config.rate_limit.burst > 0
+        assert config.circuit_breaker.failure_threshold > 0
+        assert config.circuit_breaker.recovery_timeout >= 60
+
+    def test_load_source_config_raises_for_unknown_provider(self) -> None:
+        """load_source_config() should raise ValueError for unknown provider."""
+        from bioetl.infrastructure.config import load_source_config
+
+        with pytest.raises(ValueError, match="Source configuration file not found"):
+            load_source_config("nonexistent_provider")
+
+    @pytest.mark.parametrize(
+        "provider",
+        ["chembl", "pubchem", "uniprot", "pubmed"],
+    )
+    def test_source_config_rate_limit_matches_yaml(self, provider: str) -> None:
+        """Rate limit from SourceYamlConfig should match YAML file."""
+        from bioetl.infrastructure.config import load_source_config
+
+        config = load_source_config(provider)
+
+        # Load raw YAML for comparison
+        with open(f"configs/sources/{provider}.yaml", encoding="utf-8") as f:
+            raw = yaml.safe_load(f)
+
+        yaml_rate = raw["source"]["rate_limit"]["requests_per_second"]
+        yaml_burst = raw["source"]["rate_limit"]["burst"]
+
+        assert config.rate_limit.requests_per_second == yaml_rate, (
+            f"{provider}: rate_limit.requests_per_second mismatch"
+        )
+        assert config.rate_limit.burst == yaml_burst, (
+            f"{provider}: rate_limit.burst mismatch"
+        )
+
+
+class TestNoHardcodedRateLimits:
+    """Verify that rate limits are not hardcoded in critical files."""
+
+    def test_http_client_factory_uses_source_config(self) -> None:
+        """HttpClientFactory should use load_source_config for rate limits."""
+        import inspect
+
+        from bioetl.composition.factories.http_client_factory import HttpClientFactory
+
+        source = inspect.getsource(HttpClientFactory)
+
+        # Should import and use load_source_config
+        assert "load_source_config" in source, (
+            "HttpClientFactory should use load_source_config"
+        )
+
+    def test_registration_uses_source_config(self) -> None:
+        """registration.py should use load_source_config for rate limits."""
+        import inspect
+
+        from bioetl.composition.providers import registration
+
+        source = inspect.getsource(registration)
+
+        # Should import load_source_config
+        assert "load_source_config" in source, (
+            "registration.py should use load_source_config"
+        )
+
+        # Should have helper functions for getting config
+        assert "_get_rate_limit_from_config" in source
+        assert "_get_circuit_breaker_from_config" in source
+
+
+class TestSourceConfigSchema:
+    """Test SourceYamlConfig schema validation."""
+
+    def test_chembl_config_has_page_size(self) -> None:
+        """ChEMBL config should have page_size for API pagination."""
+        from bioetl.infrastructure.config import load_source_config
+
+        config = load_source_config("chembl")
+
+        # ChEMBL should have page_size configured
+        assert config.page_size is not None, (
+            "ChEMBL config should have page_size for API pagination"
+        )
+        assert config.page_size >= 100, "ChEMBL page_size should be at least 100"
+
+    def test_source_config_batch_size_property(self) -> None:
+        """batch_size property should return provider_config.batch_size if set."""
+        from bioetl.infrastructure.schemas.source_config import SourceYamlConfig
+
+        config = SourceYamlConfig.model_validate({
+            "source": {
+                "batch_size": 100,
+                "provider_config": {
+                    "provider": "test",
+                    "batch_size": 50,
+                },
+            }
+        })
+
+        # provider_config.batch_size takes precedence
+        assert config.batch_size == 50
+
+    def test_source_config_falls_back_to_source_batch_size(self) -> None:
+        """batch_size should fall back to source.batch_size if not in provider_config."""
+        from bioetl.infrastructure.schemas.source_config import SourceYamlConfig
+
+        config = SourceYamlConfig.model_validate({
+            "source": {
+                "batch_size": 100,
+                "provider_config": {
+                    "provider": "test",
+                },
+            }
+        })
+
+        assert config.batch_size == 100
+
+
+class TestConfigValuesNotHardcoded:
+    """Verify config values match YAML, proving they're not hardcoded."""
+
+    def test_chembl_rate_limit_from_config(self) -> None:
+        """ChEMBL rate limit should match configs/sources/chembl.yaml."""
+        from bioetl.composition.providers.registration import _get_rate_limit_from_config
+
+        rate, capacity = _get_rate_limit_from_config("chembl")
+
+        # Load expected values from YAML
+        with open("configs/sources/chembl.yaml", encoding="utf-8") as f:
+            raw = yaml.safe_load(f)
+
+        expected_rate = raw["source"]["rate_limit"]["requests_per_second"]
+        expected_capacity = raw["source"]["rate_limit"]["burst"]
+
+        assert rate == expected_rate, (
+            f"ChEMBL rate mismatch: got {rate}, expected {expected_rate}"
+        )
+        assert capacity == expected_capacity, (
+            f"ChEMBL capacity mismatch: got {capacity}, expected {expected_capacity}"
+        )
+
+    def test_chembl_circuit_breaker_from_config(self) -> None:
+        """ChEMBL circuit breaker should match configs/sources/chembl.yaml."""
+        from bioetl.composition.providers.registration import (
+            _get_circuit_breaker_from_config,
+        )
+
+        threshold, timeout = _get_circuit_breaker_from_config("chembl")
+
+        # Load expected values from YAML
+        with open("configs/sources/chembl.yaml", encoding="utf-8") as f:
+            raw = yaml.safe_load(f)
+
+        expected_threshold = raw["source"]["circuit_breaker"]["failure_threshold"]
+        expected_timeout = raw["source"]["circuit_breaker"]["recovery_timeout"]
+
+        assert threshold == expected_threshold
+        assert timeout == expected_timeout

--- a/tests/unit/composition/providers/test_provider_registry.py
+++ b/tests/unit/composition/providers/test_provider_registry.py
@@ -508,12 +508,17 @@ class TestRealProviderRegistration:
         load_providers(force=True)
 
     def test_chembl_is_registered(self):
-        """Verify ChEMBL provider is registered."""
+        """Verify ChEMBL provider is registered with values from source config."""
+        from bioetl.infrastructure.config import load_source_config
+
         assert ProviderRegistry.is_registered("chembl")
 
         config = ProviderRegistry.get("chembl")
         assert config.http_config is not None
-        assert config.http_config.rate == 10.0
+
+        # Rate should match configs/sources/chembl.yaml
+        source_config = load_source_config("chembl")
+        assert config.http_config.rate == source_config.rate_limit.requests_per_second
 
     def test_pubchem_is_registered(self):
         """Verify PubChem provider is registered."""
@@ -531,13 +536,18 @@ class TestRealProviderRegistration:
         assert "uniprot_api_key" in config.http_config.rate_overrides
 
     def test_pubmed_is_registered(self):
-        """Verify PubMed provider is registered."""
+        """Verify PubMed provider is registered with values from source config."""
+        from bioetl.infrastructure.config import load_source_config
+
         assert ProviderRegistry.is_registered("pubmed")
 
         config = ProviderRegistry.get("pubmed")
         assert config.custom_creator is not None
         assert config.http_config is not None
-        assert config.http_config.rate == 3.0
+
+        # Rate should match configs/sources/pubmed.yaml
+        source_config = load_source_config("pubmed")
+        assert config.http_config.rate == source_config.rate_limit.requests_per_second
 
     def test_all_providers_listed(self):
         """Verify all expected providers are listed."""


### PR DESCRIPTION
Previously, ~40% of parameters from config files were ignored - hardcoded values were used instead. This commit fixes this by:

1. Created SourceYamlConfig schema for configs/sources/*.yaml validation
2. Added load_source_config() function to load and cache source configs
3. Updated HttpClientFactory to use source config for:
   - rate_limit.requests_per_second -> TokenBucket rate
   - rate_limit.burst -> TokenBucket capacity
   - circuit_breaker.failure_threshold -> CircuitBreaker threshold
   - circuit_breaker.recovery_timeout -> CircuitBreaker timeout
4. Updated registration.py to load rate limits from YAML configs
5. Updated ChEMBL data source creation to use page_size and batch_size from configs/sources/chembl.yaml

Configuration priority:
1. configs/sources/{provider}.yaml - PRIMARY
2. Settings API key overrides (for rate limit boost)
3. ProviderRegistry defaults - FALLBACK only

Added architecture tests to verify source configs are used.

Fixes issue where changing YAML config values had no effect.