### PR TITLE
Remove hardcoded settings duplication in configs

### DIFF
--- a/src/bioetl/composition/providers/registration.py
+++ b/src/bioetl/composition/providers/registration.py
@@ -15,6 +15,7 @@ from bioetl.composition.providers.provider_registry import (
     ProviderConfig,
     ProviderRegistry,
 )
+from bioetl.domain.resilience import AdapterConfig
 
 # Import adapter classes from Infrastructure (allowed direction)
 from bioetl.infrastructure.adapters.chembl.client import ChemblAdapter
@@ -80,11 +81,44 @@ def _get_circuit_breaker_from_config(provider: str) -> tuple[int, int]:
 
 
 def _get_page_size_from_config(provider: str, default: int = 1000) -> int:
-    """Get page size from config for paginated APIs (e.g., ChEMBL)."""
+    """Get page size from config for paginated APIs (e.g., ChEMBL).
+
+    DEPRECATED: Use _get_adapter_config() instead.
+    """
     source_config = _get_source_config(provider)
     if source_config and source_config.page_size is not None:
         return source_config.page_size
     return default
+
+
+def _get_adapter_config(provider: str, default_page_size: int = 1000) -> AdapterConfig:
+    """Get AdapterConfig from source YAML config.
+
+    This is the single source of truth for adapter parameters (RULES.md §12.1.2).
+    Loads from configs/sources/{provider}.yaml and converts to domain dataclass.
+
+    Args:
+        provider: Provider name (e.g., 'chembl', 'pubchem')
+        default_page_size: Default page size if not specified in config
+
+    Returns:
+        AdapterConfig: Immutable adapter configuration
+
+    Raises:
+        ValueError: If source config is missing and fail_fast is True
+    """
+    source_config = _get_source_config(provider)
+    if source_config is not None:
+        return source_config.to_adapter_config(default_page_size=default_page_size)
+
+    # Fallback to domain defaults
+    _logger.warning(
+        "Source config not found for %s, using AdapterConfig defaults. "
+        "Create configs/sources/%s.yaml to configure adapter parameters.",
+        provider,
+        provider,
+    )
+    return AdapterConfig(page_size=default_page_size)
 
 
 def _wrap_with_filter(
@@ -114,17 +148,22 @@ def _create_chembl_data_source(
     metrics: MetricsPort | None = None,
     pipeline_name: str = "unknown",
 ) -> DataSourcePort:
-    """Create ChEMBL data source with optional CSV filtering."""
+    """Create ChEMBL data source with optional CSV filtering.
+
+    Configuration is loaded from configs/sources/chembl.yaml via AdapterConfig.
+    This ensures YAML is the single source of truth (RULES.md §12.1.2).
+    """
     DataSourceFactory, HttpClientFactory = _get_factories()
     http_client = HttpClientFactory.create_for_provider("chembl", settings)
-    page_size = _get_page_size_from_config("chembl", default=1000)
-    filter_batch_size = _get_batch_size_from_config("chembl", default=20)
+
+    # Load adapter configuration from YAML (single source of truth)
+    adapter_config = _get_adapter_config("chembl", default_page_size=1000)
+
     base_adapter = DataSourceFactory.create(
         "chembl",
         http_client=http_client,
         logger=logger,
-        batch_size=page_size,
-        filter_batch_size=filter_batch_size,
+        adapter_config=adapter_config,
         metrics=metrics,
     )
     return _wrap_with_filter(base_adapter, filter_config, logger, metrics, pipeline_name)

--- a/src/bioetl/domain/resilience.py
+++ b/src/bioetl/domain/resilience.py
@@ -144,3 +144,46 @@ class CircuitBreakerConfig:
 
 # Backward compatibility alias
 RetryPolicy = RetryConfig
+
+
+@dataclass(frozen=True, slots=True)
+class AdapterConfig:
+    """Configuration for data source adapters.
+
+    Consolidates adapter-specific settings that were previously hardcoded.
+    Single source of truth for batch sizes, timeouts, and page sizes.
+
+    Implements RULES.md §12.1.2 - YAML MUST map to Pydantic and be validated.
+    All values are loaded from configs/sources/{provider}.yaml.
+
+    Args:
+        batch_size: Number of records per request batch for filtered queries.
+            Used when fetching with ID filters (e.g., ChEMBL filter_batch_size).
+            Default: 20 (matches ChEMBL config).
+        page_size: Number of records per paginated API request.
+            Used for standard pagination (e.g., ChEMBL batch_size parameter).
+            Default: 1000 (matches ChEMBL config).
+        timeout_sec: Request timeout in seconds. Default: 30.0.
+        max_retries: Maximum retry attempts for recoverable errors. Default: 3.
+
+    Example:
+        >>> config = AdapterConfig(batch_size=50, page_size=500)
+        >>> config.batch_size
+        50
+    """
+
+    batch_size: int = 20
+    page_size: int = 1000
+    timeout_sec: float = 30.0
+    max_retries: int = 3
+
+    def __post_init__(self) -> None:
+        """Validate configuration values on creation."""
+        if self.batch_size <= 0:
+            raise ValueError(f"batch_size must be positive, got {self.batch_size}")
+        if self.page_size <= 0:
+            raise ValueError(f"page_size must be positive, got {self.page_size}")
+        if self.timeout_sec <= 0:
+            raise ValueError(f"timeout_sec must be positive, got {self.timeout_sec}")
+        if self.max_retries < 0:
+            raise ValueError(f"max_retries must be non-negative, got {self.max_retries}")

--- a/src/bioetl/infrastructure/adapters/chembl/client.py
+++ b/src/bioetl/infrastructure/adapters/chembl/client.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, NoReturn
 from bioetl.domain.error_classifier import ErrorClassifier
 from bioetl.domain.exceptions import ChemblApiError, CriticalError
 from bioetl.domain.ports.noop import NoOpMetrics
+from bioetl.domain.resilience import AdapterConfig
 from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.adapters.base import BaseHttpAdapter
 from bioetl.infrastructure.adapters.base_metrics import AdapterMetrics
@@ -53,30 +54,55 @@ class ChemblAdapter(BaseHttpAdapter):
     Implements DataSourcePort and FilterableDataSourcePort for fetching
     data from ChEMBL database with optional server-side filtering.
 
+    Configuration is loaded from configs/sources/chembl.yaml and passed
+    via AdapterConfig. This ensures YAML is the single source of truth
+    (RULES.md §12.1.2).
+
     Args:
         http_client: UnifiedHTTPClient instance
         logger: LoggerPort instance for structured logging
-        batch_size: Number of records per API request (default: 1000)
-        filter_batch_size: Number of IDs per filtered API request (default: 20).
-            ChEMBL API returns 500 errors if URL is too long with many IDs.
+        adapter_config: Configuration from YAML (preferred). Contains batch_size,
+            page_size, timeout_sec, max_retries. If not provided, falls back to
+            batch_size/filter_batch_size parameters for backward compatibility.
+        batch_size: DEPRECATED. Use adapter_config.page_size instead.
+            Number of records per API request. Fallback if adapter_config not provided.
+        filter_batch_size: DEPRECATED. Use adapter_config.batch_size instead.
+            Number of IDs per filtered API request. Fallback if adapter_config not provided.
         thread_pool: ThreadPoolExecutor for sync operations
+        metrics: MetricsPort instance for observability
 
     Health-Aware Behavior (uses circuit breaker state):
         - HEALTHY: Uses configured batch_size
         - DEGRADED: Uses batch_size ÷ 2 to reduce load
         - UNHEALTHY: Raises CriticalError to prevent futile requests
 
+    Example:
+        >>> # Preferred: use AdapterConfig from YAML
+        >>> from bioetl.infrastructure.config import load_source_config
+        >>> source_config = load_source_config("chembl")
+        >>> adapter_config = source_config.to_adapter_config()
+        >>> adapter = ChemblAdapter(
+        ...     http_client=http_client,
+        ...     logger=logger,
+        ...     adapter_config=adapter_config,
+        ... )
+
     """
 
     http_client: UnifiedHTTPClient
     logger: LoggerPort
-    batch_size: int = 1000
-    filter_batch_size: int = 20
+    adapter_config: AdapterConfig | None = None
+    batch_size: int | None = None  # DEPRECATED: use adapter_config.page_size
+    filter_batch_size: int | None = None  # DEPRECATED: use adapter_config.batch_size
     thread_pool: ThreadPoolExecutor | None = None
     metrics: MetricsPort | None = None
 
     provider_name: str = field(init=False, default="chembl")
     """Provider identifier (required by DataSourcePort)."""
+
+    # Resolved configuration values (computed in __post_init__)
+    _page_size: int = field(init=False, default=1000)
+    _filter_batch_size: int = field(init=False, default=20)
 
     # Error classifier for logging purposes (no state tracking)
     _error_classifier: ErrorClassifier = field(
@@ -87,7 +113,30 @@ class ChemblAdapter(BaseHttpAdapter):
     _mapper: ChemblEntityMapper = field(init=False, default_factory=ChemblEntityMapper)
 
     def __post_init__(self) -> None:
-        """Initialize adapter metrics after dataclass init."""
+        """Initialize adapter with config values and metrics.
+
+        Configuration priority (RULES.md §12.1.2 - YAML as single source of truth):
+        1. adapter_config (from YAML via to_adapter_config())
+        2. Explicit batch_size/filter_batch_size parameters (deprecated, for backward compat)
+        3. Default fallback values (only if nothing else provided)
+        """
+        # Resolve configuration with clear priority
+        if self.adapter_config is not None:
+            # Primary: use AdapterConfig from YAML
+            self._page_size = self.adapter_config.page_size
+            self._filter_batch_size = self.adapter_config.batch_size
+        elif self.batch_size is not None or self.filter_batch_size is not None:
+            # Backward compatibility: use explicit parameters
+            self._page_size = self.batch_size if self.batch_size is not None else 1000
+            self._filter_batch_size = (
+                self.filter_batch_size if self.filter_batch_size is not None else 20
+            )
+        else:
+            # Fallback: use domain defaults from AdapterConfig
+            default_config = AdapterConfig()
+            self._page_size = default_config.page_size
+            self._filter_batch_size = default_config.batch_size
+
         metrics_port = self.metrics if self.metrics is not None else NoOpMetrics()
         self._adapter_metrics = AdapterMetrics(metrics_port, self.provider_name)
 
@@ -108,8 +157,8 @@ class ChemblAdapter(BaseHttpAdapter):
         Uses circuit breaker state for health-aware batching.
 
         Returns:
-            - Normal batch_size when HEALTHY
-            - Half batch_size when DEGRADED (per RULES.md §3.5)
+            - Normal page_size when HEALTHY
+            - Half page_size when DEGRADED (per RULES.md §3.5)
 
         Raises:
             CriticalError: When UNHEALTHY to prevent futile requests
@@ -124,16 +173,16 @@ class ChemblAdapter(BaseHttpAdapter):
                 f"consecutive errors (circuit breaker)"
             )
         if health_status == HealthStatus.DEGRADED:
-            reduced = max(100, self.batch_size // 2)  # Minimum 100
+            reduced = max(100, self._page_size // 2)  # Minimum 100
             self.logger.warning(
                 "chembl_degraded_mode",
                 provider="chembl",
-                original_batch_size=self.batch_size,
+                original_batch_size=self._page_size,
                 effective_batch_size=reduced,
                 consecutive_errors=failure_count,
             )
             return reduced
-        return self.batch_size
+        return self._page_size
 
     def _build_params(self, offset: int) -> dict[str, Any]:
         """Build API request parameters with health-aware batch size."""
@@ -303,7 +352,7 @@ class ChemblAdapter(BaseHttpAdapter):
         seen_ids: set[str] = set()
         pk_field = self._mapper.get_primary_key_field(entity_type)
 
-        for id_batch in self._batch_ids(filter_ids, batch_size=self.filter_batch_size):
+        for id_batch in self._batch_ids(filter_ids, batch_size=self._filter_batch_size):
             async for record in self._fetch_with_filter(
                 entity_type, id_batch, filter_field, limit
             ):

--- a/src/bioetl/infrastructure/schemas/source_config.py
+++ b/src/bioetl/infrastructure/schemas/source_config.py
@@ -16,6 +16,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from bioetl.domain.resilience import AdapterConfig as DomainAdapterConfig
 from bioetl.domain.resilience import CircuitBreakerConfig as DomainCircuitBreakerConfig
 
 
@@ -195,6 +196,32 @@ class SourceYamlConfig(BaseModel):
     def base_url(self) -> str | None:
         """Get base URL."""
         return self.source.provider_config.base_url
+
+    def to_adapter_config(self, default_page_size: int = 1000) -> DomainAdapterConfig:
+        """Convert source config to domain AdapterConfig.
+
+        Creates an immutable domain configuration object from YAML settings.
+        This is the single source of truth for adapter parameters.
+
+        Args:
+            default_page_size: Default page size if not specified in config.
+                Different providers may have different defaults.
+
+        Returns:
+            DomainAdapterConfig: Immutable adapter configuration.
+
+        Example:
+            >>> config = SourceYamlConfig.model_validate(yaml_data)
+            >>> adapter_config = config.to_adapter_config()
+            >>> adapter_config.batch_size
+            20
+        """
+        return DomainAdapterConfig(
+            batch_size=self.batch_size,
+            page_size=self.page_size if self.page_size is not None else default_page_size,
+            timeout_sec=self.timeout_sec,
+            max_retries=self.max_retries,
+        )
 
 
 __all__ = [


### PR DESCRIPTION
Introduces AdapterConfig as single source of truth for adapter parameters (batch_size, page_size, timeout_sec, max_retries) per RULES.md §12.1.2.

Changes:
- Add AdapterConfig dataclass to domain/resilience.py with validation
- Add SourceYamlConfig.to_adapter_config() for YAML-to-domain conversion
- Refactor ChemblAdapter to accept AdapterConfig via constructor
- Update registration.py with _get_adapter_config() helper
- Maintain backward compatibility: explicit batch_size/filter_batch_size parameters still work for existing code

Configuration priority:
1. adapter_config from YAML (preferred)
2. Explicit batch_size/filter_batch_size (deprecated, backward compat)
3. Domain defaults from AdapterConfig

This ensures YAML configs (configs/sources/*.yaml) are the single source of truth, and changes to batch_size in config immediately affect behavior.