### PR TITLE
Integrate CrossRef into ports architecture

### DIFF
--- a/src/bioetl/composition/providers/registration.py
+++ b/src/bioetl/composition/providers/registration.py
@@ -18,6 +18,10 @@ from bioetl.composition.providers.provider_registry import (
 
 # Import adapter classes from Infrastructure (allowed direction)
 from bioetl.infrastructure.adapters.chembl.client import ChemblAdapter
+from bioetl.infrastructure.adapters.crossref.client import (
+    CrossRefAdapter,
+    _create_crossref_adapter,
+)
 from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
 from bioetl.infrastructure.adapters.http.rate_limiter import TokenBucket
 from bioetl.infrastructure.adapters.input.csv_filter_reader import CsvFilterReader
@@ -230,6 +234,52 @@ def _create_pubmed_data_source(
     return _wrap_with_filter(data_source, filter_config, logger, metrics, pipeline_name)
 
 
+def _create_crossref_data_source(
+    settings: Settings,
+    pipeline_config: PipelineYamlConfig,
+    logger: LoggerPort,
+    filter_config: InputFilterConfig | None = None,
+    metrics: MetricsPort | None = None,
+    pipeline_name: str = "unknown",
+) -> DataSourcePort:
+    """Create CrossRef data source with optional CSV filtering.
+
+    CrossRef requires mailto for polite pool access (50 req/sec vs 1 req/sec).
+    Email is obtained from pipeline config or settings.default_email.
+
+    Args:
+        settings: Application settings.
+        pipeline_config: Pipeline configuration from YAML.
+        logger: LoggerPort for structured logging.
+        filter_config: Optional filter configuration for CSV-based DOI filtering.
+        metrics: Optional MetricsPort for recording adapter metrics.
+        pipeline_name: Pipeline name for metrics labels.
+
+    Returns:
+        Configured DataSourcePort with optional filtering wrapper.
+
+    Raises:
+        ValueError: If mailto is not configured in settings or pipeline config.
+
+    """
+    _, HttpClientFactory = _get_factories()
+    http_client = HttpClientFactory.create_for_provider("crossref", settings)
+
+    # Get mailto from pipeline config or settings
+    mailto = pipeline_config.source.email or settings.default_email
+    batch_size = _get_batch_size_from_config("crossref", default=50)
+
+    data_source = _create_crossref_adapter(
+        http_client=http_client,
+        logger=logger,
+        settings=settings,
+        mailto=mailto,
+        batch_size=batch_size,
+        metrics=metrics,
+    )
+    return _wrap_with_filter(data_source, filter_config, logger, metrics, pipeline_name)
+
+
 # =============================================================================
 # Provider registration
 # =============================================================================
@@ -250,6 +300,7 @@ def register_all_providers() -> None:
     - PubChem: configs/sources/pubchem.yaml
     - UniProt: configs/sources/uniprot.yaml
     - PubMed: configs/sources/pubmed.yaml
+    - CrossRef: configs/sources/crossref.yaml
 
     Each provider includes a data_source_creator for unified registry access.
     """
@@ -258,6 +309,7 @@ def register_all_providers() -> None:
     pubchem_rate, pubchem_capacity = _get_rate_limit_from_config("pubchem")
     uniprot_rate, uniprot_capacity = _get_rate_limit_from_config("uniprot")
     pubmed_rate, pubmed_capacity = _get_rate_limit_from_config("pubmed")
+    crossref_rate, crossref_capacity = _get_rate_limit_from_config("crossref")
 
     # ChEMBL - async HTTP adapter
     if not ProviderRegistry.is_registered("chembl"):
@@ -326,5 +378,23 @@ def register_all_providers() -> None:
                 requires_logger=True,
                 custom_creator=_create_pubmed_adapter,
                 data_source_creator=_create_pubmed_data_source,
+            ),
+        )
+
+    # CrossRef - async HTTP adapter for DOI resolution and publication metadata
+    # Requires mailto for polite pool access (50 req/sec vs 1 req/sec without)
+    if not ProviderRegistry.is_registered("crossref"):
+        ProviderRegistry.register(
+            "crossref",
+            ProviderConfig(
+                adapter_class=CrossRefAdapter,
+                http_config=HttpConfig(
+                    rate=crossref_rate,
+                    capacity=crossref_capacity,
+                ),
+                requires_http_client=True,
+                requires_logger=True,
+                custom_creator=_create_crossref_adapter,
+                data_source_creator=_create_crossref_data_source,
             ),
         )

--- a/tests/unit/composition/providers/test_provider_registry.py
+++ b/tests/unit/composition/providers/test_provider_registry.py
@@ -549,10 +549,26 @@ class TestRealProviderRegistration:
         source_config = load_source_config("pubmed")
         assert config.http_config.rate == source_config.rate_limit.requests_per_second
 
+    def test_crossref_is_registered(self):
+        """Verify CrossRef provider is registered with values from source config."""
+        from bioetl.infrastructure.config import load_source_config
+
+        assert ProviderRegistry.is_registered("crossref")
+
+        config = ProviderRegistry.get("crossref")
+        assert config.custom_creator is not None
+        assert config.http_config is not None
+        assert config.data_source_creator is not None
+
+        # Rate should match configs/sources/crossref.yaml (50 req/sec for polite pool)
+        source_config = load_source_config("crossref")
+        assert config.http_config.rate == source_config.rate_limit.requests_per_second
+        assert config.http_config.rate == 50.0
+
     def test_all_providers_listed(self):
         """Verify all expected providers are listed."""
         providers = ProviderRegistry.list_providers()
 
-        expected = ["chembl", "pubchem", "pubmed", "uniprot"]
+        expected = ["chembl", "crossref", "pubchem", "pubmed", "uniprot"]
         for provider in expected:
             assert provider in providers, f"Missing provider: {provider}"


### PR DESCRIPTION
Add CrossRef provider registration to the unified ProviderRegistry, enabling CrossRef to be used as a standard data source alongside ChEMBL, PubChem, UniProt, and PubMed.

Changes:
- Import CrossRefAdapter and _create_crossref_adapter in registration.py
- Add _create_crossref_data_source() factory function with mailto/polite pool support
- Register CrossRef provider with HttpConfig (50 req/sec rate limit)
- Add test_crossref_is_registered() to verify provider registration
- Update test_all_providers_listed to include crossref

The CrossRef adapter was already implemented in infrastructure/adapters/crossref/ with full DataSourcePort and FilterableDataSourcePort support. This change completes the Ports & Adapters integration by adding the composition layer registration.

Configuration is loaded from configs/sources/crossref.yaml which defines:
- rate_limit: 50 req/sec (polite pool with mailto)
- batch_size: 50 DOIs per batch request
- circuit_breaker: standard 5 failures / 300s recovery