### PR TITLE
Fix failing duplication and complexity checks

### DIFF
--- a/src/bioetl/application/core/lock_manager.py
+++ b/src/bioetl/application/core/lock_manager.py
@@ -66,7 +66,9 @@ class LockManager:
         self._config = config
         self._logger = logger
         self._shutdown_signal = shutdown_signal
-        self._checkpoint_manager = checkpoint_manager  # Kept for interface compatibility
+        self._checkpoint_manager = (
+            checkpoint_manager  # Kept for interface compatibility
+        )
         self._context_holder = context_holder
         self._heartbeat: HeartbeatTask | None = None
         self._acquired_at: float | None = None  # monotonic timestamp when lock acquired

--- a/src/bioetl/application/core/transform_utils.py
+++ b/src/bioetl/application/core/transform_utils.py
@@ -20,12 +20,8 @@ from collections.abc import Callable
 from datetime import date
 from typing import Any, TypeVar
 
-from bioetl.domain.normalization import (
-    normalize_string as _domain_normalize_string,
-)
-from bioetl.domain.normalization import (
-    parse_date_field as _domain_parse_date_field,
-)
+from bioetl.domain.normalization import normalize_string as _domain_normalize_string
+from bioetl.domain.normalization import parse_date_field as _domain_parse_date_field
 from bioetl.domain.transformations import safe_float, safe_int
 from bioetl.domain.validation import validate_smiles as _domain_validate_smiles
 

--- a/src/bioetl/application/pipelines/chembl/activity_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/activity_transformer.py
@@ -49,9 +49,7 @@ _ACTION_TYPE_FIELDS: dict[str, Any] = {
 _IDENTIFIERS = FieldGroup(
     name="identifiers",
     fields=(
-        *simple_fields(
-            "target_chembl_id", "assay_chembl_id", "document_chembl_id"
-        ),
+        *simple_fields("target_chembl_id", "assay_chembl_id", "document_chembl_id"),
         *int_fields("record_id", "src_id"),
     ),
 )
@@ -86,7 +84,12 @@ _RAW_VALUES = FieldGroup(
 _STANDARD_VALUES = FieldGroup(
     name="standard_values",
     fields=(
-        *simple_fields("standard_type", "standard_units", "standard_relation", "standard_text_value"),
+        *simple_fields(
+            "standard_type",
+            "standard_units",
+            "standard_relation",
+            "standard_text_value",
+        ),
         *float_fields("standard_value", "standard_upper_value", "pchembl_value"),
         *int_fields("standard_flag"),
     ),

--- a/src/bioetl/application/pipelines/chembl/document_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/document_transformer.py
@@ -41,7 +41,12 @@ _JOURNAL_INFO = FieldGroup(
     name="journal_info",
     fields=(
         *simple_fields(
-            "journal", "journal_full_title", "volume", "issue", "first_page", "last_page"
+            "journal",
+            "journal_full_title",
+            "volume",
+            "issue",
+            "first_page",
+            "last_page",
         ),
         *int_fields("year"),
     ),

--- a/src/bioetl/application/pipelines/chembl/molecule_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/molecule_transformer.py
@@ -99,7 +99,9 @@ _CORE_METADATA = FieldGroup(
 _MOLECULE_FLAGS = FieldGroup(
     name="molecule_flags",
     fields=(
-        *simple_fields("oral", "parenteral", "topical", "therapeutic_flag", "withdrawn_flag"),
+        *simple_fields(
+            "oral", "parenteral", "topical", "therapeutic_flag", "withdrawn_flag"
+        ),
         *int_fields(
             "black_box_warning",
             "natural_product",
@@ -118,7 +120,11 @@ _ADDITIONAL_METADATA = FieldGroup(
     name="additional_metadata",
     fields=(
         *simple_fields(
-            "usan_stem", "usan_stem_definition", "usan_substem", "helm_notation", "molecule_species"
+            "usan_stem",
+            "usan_stem_definition",
+            "usan_substem",
+            "helm_notation",
+            "molecule_species",
         ),
         *int_fields("usan_year"),
     ),

--- a/src/bioetl/application/pipelines/chembl/target_component_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/target_component_transformer.py
@@ -76,9 +76,7 @@ class TargetComponentTransformer(BaseChemblTransformer):
             **self.serialize_json_fields(rec, _JSON_FIELDS),
             # Flattened fields (extracted from protein_classifications)
             "protein_classification_ids": extract_list_field(
-                cast(
-                    "list[dict[str, Any]] | None", rec.get("protein_classifications")
-                ),
+                cast("list[dict[str, Any]] | None", rec.get("protein_classifications")),
                 "protein_classification_id",
                 safe_int,
             ),

--- a/src/bioetl/application/pipelines/crossref/transformer.py
+++ b/src/bioetl/application/pipelines/crossref/transformer.py
@@ -61,7 +61,11 @@ class CrossRefTransformer(BaseTransformer):
 
         """
         super().__init__(
-            provider, entity_type="work", tracer=tracer, metrics=metrics, gold_filters=gold_filters
+            provider,
+            entity_type="work",
+            tracer=tracer,
+            metrics=metrics,
+            gold_filters=gold_filters,
         )
 
     # ========================================================================
@@ -178,10 +182,14 @@ class CrossRefTransformer(BaseTransformer):
             "last_page": last_page,
             "year": self._extract_year(rec),
             "published_print": format_date_parts(
-                published_print.get("date-parts") if isinstance(published_print, dict) else None
+                published_print.get("date-parts")
+                if isinstance(published_print, dict)
+                else None
             ),
             "published_online": format_date_parts(
-                published_online.get("date-parts") if isinstance(published_online, dict) else None
+                published_online.get("date-parts")
+                if isinstance(published_online, dict)
+                else None
             ),
             "doc_type": CROSSREF_TYPE_MAP.get(rec.get("type", ""), "PUBLICATION"),
             "citation_count": rec.get("is-referenced-by-count"),

--- a/src/bioetl/application/services/checkpoint_service.py
+++ b/src/bioetl/application/services/checkpoint_service.py
@@ -134,7 +134,9 @@ class CheckpointService:
         # Check if checkpoint exists first
         existing = await self.checkpoint_port.load(pipeline_name)
         if existing is None:
-            self.logger.debug("Checkpoint not found for deletion", pipeline=pipeline_name)
+            self.logger.debug(
+                "Checkpoint not found for deletion", pipeline=pipeline_name
+            )
             return False
 
         await self.checkpoint_port.delete(pipeline_name)

--- a/src/bioetl/application/services/quarantine_service.py
+++ b/src/bioetl/application/services/quarantine_service.py
@@ -195,8 +195,7 @@ class QuarantineService:
 
         # Filter to specific batch
         batch_records = [
-            rec for rec in records
-            if rec.get("bronze_batch_id") == str(batch_id)
+            rec for rec in records if rec.get("bronze_batch_id") == str(batch_id)
         ]
 
         # Placeholder: actual replay would require pipeline context
@@ -252,7 +251,8 @@ class QuarantineService:
 
         # Filter by date (if ingestion_ts is available)
         records_to_purge = [
-            rec for rec in records
+            rec
+            for rec in records
             if rec.get("ingestion_ts") and rec["ingestion_ts"] < cutoff_date
         ]
 

--- a/src/bioetl/composition/_bootstrap/storage.py
+++ b/src/bioetl/composition/_bootstrap/storage.py
@@ -156,7 +156,9 @@ def bootstrap_vacuum_service() -> VacuumService:
     )
 
 
-def _create_table_collector(logger: NoOpLogger) -> Callable[[str], list[tuple[str, str]]]:
+def _create_table_collector(
+    logger: NoOpLogger,
+) -> Callable[[str], list[tuple[str, str]]]:
     """Create a table collector function for VacuumService.
 
     This function queries the pipeline registry and config loader

--- a/src/bioetl/composition/providers/registration.py
+++ b/src/bioetl/composition/providers/registration.py
@@ -67,7 +67,10 @@ def _get_rate_limit_from_config(provider: str) -> tuple[float, int]:
     """Get (rate, capacity) from source config or defaults (5.0, 10)."""
     source_config = _get_source_config(provider)
     if source_config:
-        return source_config.rate_limit.requests_per_second, source_config.rate_limit.burst
+        return (
+            source_config.rate_limit.requests_per_second,
+            source_config.rate_limit.burst,
+        )
     return 5.0, 10
 
 
@@ -75,7 +78,10 @@ def _get_circuit_breaker_from_config(provider: str) -> tuple[int, int]:
     """Get (failure_threshold, recovery_timeout) from config or defaults (5, 300)."""
     source_config = _get_source_config(provider)
     if source_config:
-        return source_config.circuit_breaker.failure_threshold, source_config.circuit_breaker.recovery_timeout
+        return (
+            source_config.circuit_breaker.failure_threshold,
+            source_config.circuit_breaker.recovery_timeout,
+        )
     return 5, 300
 
 
@@ -127,7 +133,9 @@ def _create_chembl_data_source(
         filter_batch_size=filter_batch_size,
         metrics=metrics,
     )
-    return _wrap_with_filter(base_adapter, filter_config, logger, metrics, pipeline_name)
+    return _wrap_with_filter(
+        base_adapter, filter_config, logger, metrics, pipeline_name
+    )
 
 
 def _create_pubchem_adapter(
@@ -155,8 +163,10 @@ def _create_pubchem_adapter(
         logger=logger,
         rate_limiter=TokenBucket(rate=rate, capacity=capacity, provider="pubchem"),
         circuit_breaker=CircuitBreaker(
-            provider="pubchem", failure_threshold=cb_threshold,
-            recovery_timeout=cb_timeout, metrics=metrics,
+            provider="pubchem",
+            failure_threshold=cb_threshold,
+            recovery_timeout=cb_timeout,
+            metrics=metrics,
         ),
         thread_pool=ThreadPoolExecutor(max_workers=max_workers),
         strict_error_handling=strict_error_handling,
@@ -173,8 +183,10 @@ def _create_pubchem_data_source(
 ) -> DataSourcePort:
     """Create PubChem data source with optional CSV filtering."""
     data_source = _create_pubchem_adapter(
-        logger=logger, settings=settings,
-        strict_error_handling=settings.strict_error_handling, metrics=metrics,
+        logger=logger,
+        settings=settings,
+        strict_error_handling=settings.strict_error_handling,
+        metrics=metrics,
     )
     return _wrap_with_filter(data_source, filter_config, logger, metrics, pipeline_name)
 

--- a/src/bioetl/domain/aggregates/batch.py
+++ b/src/bioetl/domain/aggregates/batch.py
@@ -455,7 +455,9 @@ class Batch:
             )
         )
 
-    def mark_failed(self, layer: str, error: str, error_type: str | None = None) -> None:
+    def mark_failed(
+        self, layer: str, error: str, error_type: str | None = None
+    ) -> None:
         """Mark batch write as failed.
 
         Transitions: WRITING -> FAILED

--- a/src/bioetl/domain/aggregates/pipeline_run.py
+++ b/src/bioetl/domain/aggregates/pipeline_run.py
@@ -74,6 +74,40 @@ class RunStatus(str, Enum):
         return self in {RunStatus.COMPLETED, RunStatus.FAILED, RunStatus.SHUTDOWN}
 
 
+def _validate_stage_name(stage: str) -> None:
+    """Validate stage name is not empty."""
+    if not stage:
+        raise ValueError("Stage name cannot be empty")
+
+
+def _validate_stage_completion(
+    status: StageStatus, error: str | None, completed_at: datetime | None
+) -> None:
+    """Validate stage completion invariants."""
+    if status == StageStatus.FAILED and not error:
+        raise ValueError("Failed stage must have an error message")
+    needs_timestamp = status in {StageStatus.SUCCESS, StageStatus.FAILED}
+    if needs_timestamp and not completed_at:
+        raise ValueError(
+            f"Completed/Failed stage must have completed_at timestamp, "
+            f"got status={status.value}"
+        )
+
+
+def _validate_stage_result(
+    stage: str,
+    status: StageStatus,
+    error: str | None,
+    completed_at: datetime | None,
+    records_processed: int,
+) -> None:
+    """Validate stage result invariants (extracted for lower CC)."""
+    _validate_stage_name(stage)
+    _validate_stage_completion(status, error, completed_at)
+    if records_processed < 0:
+        raise ValueError(f"records_processed cannot be negative: {records_processed}")
+
+
 @dataclass(frozen=True, slots=True)
 class StageResult:
     """Immutable value object representing the result of a pipeline stage.
@@ -100,17 +134,13 @@ class StageResult:
 
     def __post_init__(self) -> None:
         """Validate stage result invariants."""
-        if not self.stage:
-            raise ValueError("Stage name cannot be empty")
-        if self.status == StageStatus.FAILED and not self.error:
-            raise ValueError("Failed stage must have an error message")
-        if self.status in {StageStatus.SUCCESS, StageStatus.FAILED} and not self.completed_at:
-            raise ValueError(
-                f"Completed/Failed stage must have completed_at timestamp, "
-                f"got status={self.status.value}"
-            )
-        if self.records_processed < 0:
-            raise ValueError(f"records_processed cannot be negative: {self.records_processed}")
+        _validate_stage_result(
+            self.stage,
+            self.status,
+            self.error,
+            self.completed_at,
+            self.records_processed,
+        )
 
     @property
     def duration_seconds(self) -> float | None:
@@ -322,7 +352,9 @@ class PipelineRun:
         self._status = RunStatus.RUNNING
         self._started_at = started_at or datetime.now(UTC)
 
-    def record_stage_start(self, stage: str, started_at: datetime | None = None) -> None:
+    def record_stage_start(
+        self, stage: str, started_at: datetime | None = None
+    ) -> None:
         """Record the start of a pipeline stage.
 
         Args:
@@ -429,6 +461,22 @@ class PipelineRun:
             )
         )
 
+    def _assert_can_complete(self) -> None:
+        """Check invariants required for successful completion."""
+        if self.failed_stages:
+            failed_names = [s.stage for s in self.failed_stages]
+            raise InvalidStateError(
+                f"Cannot complete run: {len(self.failed_stages)} stages failed: {failed_names}",
+                current_state=self._status.value,
+                attempted_operation="complete",
+            )
+        if not self._stages:
+            raise InvalidStateError(
+                "Cannot complete run: no stages recorded",
+                current_state=self._status.value,
+                attempted_operation="complete",
+            )
+
     def complete(self, completed_at: datetime | None = None) -> None:
         """Mark the run as completed successfully.
 
@@ -446,23 +494,7 @@ class PipelineRun:
                              or has no stages.
         """
         self._assert_running("complete")
-
-        # Invariant: Cannot complete with failed stages
-        if self.failed_stages:
-            failed_names = [s.stage for s in self.failed_stages]
-            raise InvalidStateError(
-                f"Cannot complete run: {len(self.failed_stages)} stages failed: {failed_names}",
-                current_state=self._status.value,
-                attempted_operation="complete",
-            )
-
-        # Invariant: Must have at least one stage
-        if not self._stages:
-            raise InvalidStateError(
-                "Cannot complete run: no stages recorded",
-                current_state=self._status.value,
-                attempted_operation="complete",
-            )
+        self._assert_can_complete()
 
         now = completed_at or datetime.now(UTC)
         self._status = RunStatus.COMPLETED
@@ -482,7 +514,12 @@ class PipelineRun:
             )
         )
 
-    def fail(self, error: str, error_type: str | None = None, failed_at: datetime | None = None) -> None:
+    def fail(
+        self,
+        error: str,
+        error_type: str | None = None,
+        failed_at: datetime | None = None,
+    ) -> None:
         """Mark the run as failed without recording a specific stage.
 
         Transitions: RUNNING -> FAILED

--- a/src/bioetl/domain/aggregates/quarantine_entry.py
+++ b/src/bioetl/domain/aggregates/quarantine_entry.py
@@ -83,6 +83,26 @@ class ResolutionInfo:
             )
 
 
+def _validate_quarantine_required_fields(
+    entry_id: str,
+    pipeline_name: str,
+    error_code: str,
+    payload: dict[str, Any],
+    payload_hash: ContentHash,
+) -> None:
+    """Validate required quarantine entry fields (extracted for lower CC)."""
+    _required = [
+        (entry_id, "entry_id is required"),
+        (pipeline_name, "pipeline_name is required"),
+        (error_code, "error_code is required"),
+        (payload, "payload cannot be empty"),
+        (payload_hash, "payload_hash is required"),
+    ]
+    for field, msg in _required:
+        if not field:
+            raise ValueError(msg)
+
+
 class QuarantineEntry:
     """Aggregate Root for a quarantined record.
 
@@ -148,17 +168,9 @@ class QuarantineEntry:
         Raises:
             ValueError: If required fields are empty.
         """
-        if not entry_id:
-            raise ValueError("entry_id is required")
-        if not pipeline_name:
-            raise ValueError("pipeline_name is required")
-        if not error_code:
-            raise ValueError("error_code is required")
-        if not payload:
-            raise ValueError("payload cannot be empty")
-        if not payload_hash:
-            raise ValueError("payload_hash is required")
-
+        _validate_quarantine_required_fields(
+            entry_id, pipeline_name, error_code, payload, payload_hash
+        )
         self._entry_id = entry_id
         self._pipeline_name = pipeline_name
         self._error_code = error_code

--- a/src/bioetl/domain/normalization.py
+++ b/src/bioetl/domain/normalization.py
@@ -49,6 +49,7 @@ def parse_date_field(value: str | None, fmt: str = "%Y-%m-%d") -> date | None:
     if value is None:
         return None
     from datetime import datetime
+
     try:
         return datetime.strptime(value.strip(), fmt).date()
     except (ValueError, AttributeError):

--- a/src/bioetl/domain/ports/noop.py
+++ b/src/bioetl/domain/ports/noop.py
@@ -310,11 +310,13 @@ class NoOpMemoryMonitor:
         overhead_factor = 2.5
         return (record_count * avg_record_size_bytes * overhead_factor) / (1024 * 1024)
 
-    def calculate_max_batch_size(self, avg_record_size_bytes: int = 1024) -> int:  # noqa: ARG002
+    def calculate_max_batch_size(
+        self, _avg_record_size_bytes: int = 1024
+    ) -> int:
         """Return a high max batch size (no constraints).
 
         Args:
-            avg_record_size_bytes: Average size per record in bytes.
+            _avg_record_size_bytes: Average size per record in bytes (unused).
 
         Returns:
             Large max batch size (10000).

--- a/src/bioetl/domain/schemas/crossref/author.py
+++ b/src/bioetl/domain/schemas/crossref/author.py
@@ -62,7 +62,8 @@ class AuthorSchema(ETLRecordSchema):
         nullable=True, description="Primary affiliation (first from affiliations list)"
     )
     affiliation_ids: Series[str] | None = pa.Field(
-        nullable=True, description="Affiliation identifiers (ROR, ISNI; joined with '; ')"
+        nullable=True,
+        description="Affiliation identifiers (ROR, ISNI; joined with '; ')",
     )
 
     # === Metadata ===

--- a/src/bioetl/domain/schemas/crossref/publication.py
+++ b/src/bioetl/domain/schemas/crossref/publication.py
@@ -97,9 +97,7 @@ class PublicationEnrichedSchema(ETLRecordSchema):
     language: Series[str] | None = pa.Field(
         nullable=True, description="Publication language code"
     )
-    license_url: Series[str] | None = pa.Field(
-        nullable=True, description="License URL"
-    )
+    license_url: Series[str] | None = pa.Field(nullable=True, description="License URL")
     subjects: Series[str] | None = pa.Field(
         nullable=True, description="JSON array of subject areas"
     )

--- a/src/bioetl/domain/schemas/crossref/reference.py
+++ b/src/bioetl/domain/schemas/crossref/reference.py
@@ -75,9 +75,7 @@ class ReferenceSchema(ETLRecordSchema):
         str_matches=r"^\d{4}-\d{3}[\dX]$",
         description="ISSN",
     )
-    component: Series[str] | None = pa.Field(
-        nullable=True, description="Component DOI"
-    )
+    component: Series[str] | None = pa.Field(nullable=True, description="Component DOI")
 
     # === Additional Metadata ===
     edition: Series[str] | None = pa.Field(nullable=True, description="Edition number")

--- a/src/bioetl/domain/value_objects/identifiers.py
+++ b/src/bioetl/domain/value_objects/identifiers.py
@@ -97,9 +97,14 @@ class UniProtId(ValueObject[str]):
     _PRIMARY_PATTERN = re.compile(r"^[OPQ][0-9][A-Z0-9]{3}[0-9]$")
 
     # Secondary accession pattern for other letters (6 or 10 characters)
-    _SECONDARY_PATTERN = re.compile(
-        r"^[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}$"
-    )
+    _SECONDARY_PATTERN = re.compile(r"^[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}$")
+
+    def _validate_format(self, normalized: str) -> bool:
+        """Check if normalized string matches UniProt format."""
+        return bool(
+            self._PRIMARY_PATTERN.match(normalized)
+            or self._SECONDARY_PATTERN.match(normalized)
+        )
 
     def _validate(self, value: str) -> str:
         """Validate and normalize UniProt accession.
@@ -117,7 +122,6 @@ class UniProtId(ValueObject[str]):
             raise ValueError(f"UniProtId must be str, got {type(value).__name__}")
 
         normalized = value.strip().upper()
-
         if not normalized:
             raise ValueError("UniProtId cannot be empty")
 
@@ -127,13 +131,9 @@ class UniProtId(ValueObject[str]):
                 f"Expected 6 or 10 characters."
             )
 
-        if self._PRIMARY_PATTERN.match(normalized):
-            return normalized
-
-        if self._SECONDARY_PATTERN.match(normalized):
-            return normalized
-
-        raise ValueError(f"Invalid UniProt accession format: {value!r}")
+        if not self._validate_format(normalized):
+            raise ValueError(f"Invalid UniProt accession format: {value!r}")
+        return normalized
 
     @property
     def is_primary_format(self) -> bool:
@@ -173,6 +173,13 @@ class DOI(ValueObject[str]):
         "DOI:",
     )
 
+    def _strip_url_prefix(self, value: str) -> str:
+        """Strip URL prefix from DOI if present."""
+        for prefix in self._URL_PREFIXES:
+            if value.lower().startswith(prefix.lower()):
+                return value[len(prefix) :]
+        return value
+
     def _validate(self, value: str) -> str:
         """Validate and normalize DOI.
 
@@ -189,23 +196,14 @@ class DOI(ValueObject[str]):
             raise ValueError(f"DOI must be str, got {type(value).__name__}")
 
         normalized = value.strip()
-
         if not normalized:
             raise ValueError("DOI cannot be empty")
 
-        # Strip URL prefixes
-        for prefix in self._URL_PREFIXES:
-            if normalized.lower().startswith(prefix.lower()):
-                normalized = normalized[len(prefix):]
-                break
-
-        # DOIs are case-insensitive, normalize to lowercase
-        normalized = normalized.lower()
+        # Strip URL prefixes and normalize to lowercase
+        normalized = self._strip_url_prefix(normalized).lower()
 
         if not self._PATTERN.match(normalized):
-            raise ValueError(
-                f"Invalid DOI format: {value!r}. Expected: 10.XXXX/suffix"
-            )
+            raise ValueError(f"Invalid DOI format: {value!r}. Expected: 10.XXXX/suffix")
 
         return normalized
 
@@ -248,6 +246,19 @@ class PubMedId(ValueObject[int]):
 
     _MAX_PMID = 10_000_000_000  # Reasonable upper bound
 
+    def _coerce_to_int(self, value: int | str) -> int:
+        """Coerce value to int, raising ValueError on failure."""
+        if isinstance(value, bool):
+            raise ValueError(f"PubMedId must be int, got {type(value).__name__}")
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str):
+            try:
+                return int(value.strip())
+            except ValueError:
+                raise ValueError(f"Invalid PubMed ID: {value!r}") from None
+        raise ValueError(f"PubMedId must be int, got {type(value).__name__}")
+
     def _validate(self, value: int) -> int:
         """Validate PubMed ID.
 
@@ -260,26 +271,12 @@ class PubMedId(ValueObject[int]):
         Raises:
             ValueError: If PMID is invalid.
         """
-        if isinstance(value, bool):
-            raise ValueError(f"PubMedId must be int, got {type(value).__name__}")
-
-        if not isinstance(value, int):
-            # Try to parse string
-            if isinstance(value, str):
-                try:
-                    value = int(value.strip())
-                except ValueError:
-                    raise ValueError(f"Invalid PubMed ID: {value!r}") from None
-            else:
-                raise ValueError(f"PubMedId must be int, got {type(value).__name__}")
-
-        if value <= 0:
-            raise ValueError(f"PubMed ID must be positive: {value}")
-
-        if value >= self._MAX_PMID:
-            raise ValueError(f"PubMed ID too large: {value}")
-
-        return value
+        int_value = self._coerce_to_int(value)
+        if int_value <= 0:
+            raise ValueError(f"PubMed ID must be positive: {int_value}")
+        if int_value >= self._MAX_PMID:
+            raise ValueError(f"PubMed ID too large: {int_value}")
+        return int_value
 
 
 class PubChemCid(ValueObject[int]):
@@ -298,6 +295,19 @@ class PubChemCid(ValueObject[int]):
 
     _MAX_CID = 100_000_000_000  # Reasonable upper bound
 
+    def _coerce_to_int(self, value: int | str) -> int:
+        """Coerce value to int, raising ValueError on failure."""
+        if isinstance(value, bool):
+            raise ValueError(f"PubChemCid must be int, got {type(value).__name__}")
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str):
+            try:
+                return int(value.strip())
+            except ValueError:
+                raise ValueError(f"Invalid PubChem CID: {value!r}") from None
+        raise ValueError(f"PubChemCid must be int, got {type(value).__name__}")
+
     def _validate(self, value: int) -> int:
         """Validate PubChem CID.
 
@@ -310,23 +320,9 @@ class PubChemCid(ValueObject[int]):
         Raises:
             ValueError: If CID is invalid.
         """
-        if isinstance(value, bool):
-            raise ValueError(f"PubChemCid must be int, got {type(value).__name__}")
-
-        if not isinstance(value, int):
-            # Try to parse string
-            if isinstance(value, str):
-                try:
-                    value = int(value.strip())
-                except ValueError:
-                    raise ValueError(f"Invalid PubChem CID: {value!r}") from None
-            else:
-                raise ValueError(f"PubChemCid must be int, got {type(value).__name__}")
-
-        if value <= 0:
-            raise ValueError(f"PubChem CID must be positive: {value}")
-
-        if value >= self._MAX_CID:
-            raise ValueError(f"PubChem CID too large: {value}")
-
-        return value
+        int_value = self._coerce_to_int(value)
+        if int_value <= 0:
+            raise ValueError(f"PubChem CID must be positive: {int_value}")
+        if int_value >= self._MAX_CID:
+            raise ValueError(f"PubChem CID too large: {int_value}")
+        return int_value

--- a/src/bioetl/domain/value_objects/measurements.py
+++ b/src/bioetl/domain/value_objects/measurements.py
@@ -154,7 +154,9 @@ class Concentration:
             ValueError: If string cannot be parsed.
         """
         # Pattern: number (optional whitespace) unit
-        match = re.match(r"([+-]?[\d.]+(?:[eE][+-]?\d+)?)\s*([a-zμ]+)", s.strip(), re.IGNORECASE)
+        match = re.match(
+            r"([+-]?[\d.]+(?:[eE][+-]?\d+)?)\s*([a-zμ]+)", s.strip(), re.IGNORECASE
+        )
         if not match:
             raise ValueError(f"Cannot parse concentration: {s!r}")
 
@@ -188,8 +190,8 @@ class ActivityType(str, Enum):
     # Inhibition constants
     IC50 = "IC50"  # Half-maximal inhibitory concentration
     IC90 = "IC90"  # 90% inhibitory concentration
-    KI = "Ki"      # Inhibition constant
-    KD = "Kd"      # Dissociation constant
+    KI = "Ki"  # Inhibition constant
+    KD = "Kd"  # Dissociation constant
 
     # Activation constants
     EC50 = "EC50"  # Half-maximal effective concentration
@@ -303,9 +305,7 @@ class PChemblValue:
         if self.value < 0:
             raise ValueError(f"pChEMBL value cannot be negative: {self.value}")
         if self.value > 14:
-            raise ValueError(
-                f"pChEMBL value exceeds physical limit (14): {self.value}"
-            )
+            raise ValueError(f"pChEMBL value exceeds physical limit (14): {self.value}")
 
     def to_molar(self) -> float:
         """Convert to molar concentration.
@@ -315,7 +315,9 @@ class PChemblValue:
         """
         return 10 ** (-self.value)
 
-    def to_concentration(self, unit: ConcentrationUnit = ConcentrationUnit.NANOMOLAR) -> Concentration:
+    def to_concentration(
+        self, unit: ConcentrationUnit = ConcentrationUnit.NANOMOLAR
+    ) -> Concentration:
         """Convert to Concentration value object.
 
         Args:
@@ -347,6 +349,7 @@ class PChemblValue:
             )
 
         import math
+
         pchembl = -math.log10(molar_concentration)
         return cls(value=pchembl)
 

--- a/src/bioetl/infrastructure/adapters/chembl/models.py
+++ b/src/bioetl/infrastructure/adapters/chembl/models.py
@@ -156,9 +156,7 @@ class ChemblActivityRecord(BaseModel):
     toid: int | None = Field(default=None, description="Test Occasion ID")
 
     # Assay Details (denormalized)
-    assay_description: str | None = Field(
-        default=None, description="Assay description"
-    )
+    assay_description: str | None = Field(default=None, description="Assay description")
     assay_type: str | None = Field(default=None, description="Assay type code")
     assay_variant_accession: str | None = Field(
         default=None, description="Assay variant accession"
@@ -185,17 +183,13 @@ class ChemblActivityRecord(BaseModel):
     target_organism: str | None = Field(
         default=None, description="Target organism name"
     )
-    target_tax_id: str | None = Field(
-        default=None, description="Target taxonomy ID"
-    )
+    target_tax_id: str | None = Field(default=None, description="Target taxonomy ID")
 
     # Document Details (denormalized)
     document_journal: str | None = Field(
         default=None, description="Source journal name"
     )
-    document_year: int | None = Field(
-        default=None, description="Publication year"
-    )
+    document_year: int | None = Field(default=None, description="Publication year")
 
     # Activity Properties (complex field)
     activity_properties: list[dict[str, Any]] | None = Field(
@@ -252,15 +246,9 @@ class ChemblAssayRecord(BaseModel):
     document_chembl_id: str | None = Field(
         default=None, description="Source document ChEMBL ID"
     )
-    target_chembl_id: str | None = Field(
-        default=None, description="Target ChEMBL ID"
-    )
-    cell_chembl_id: str | None = Field(
-        default=None, description="Cell line ChEMBL ID"
-    )
-    tissue_chembl_id: str | None = Field(
-        default=None, description="Tissue ChEMBL ID"
-    )
+    target_chembl_id: str | None = Field(default=None, description="Target ChEMBL ID")
+    cell_chembl_id: str | None = Field(default=None, description="Cell line ChEMBL ID")
+    tissue_chembl_id: str | None = Field(default=None, description="Tissue ChEMBL ID")
 
     # Ontology
     bao_format: str | None = Field(default=None, description="BAO format ID")
@@ -365,7 +353,9 @@ class ChemblMoleculeRecord(BaseModel):
     max_phase: float | None = Field(default=None, description="Maximum clinical phase")
     structure_type: str | None = Field(default=None, description="Structure type")
     molecule_type: str | None = Field(default=None, description="Molecule type")
-    first_approval: int | None = Field(default=None, description="Year of first approval")
+    first_approval: int | None = Field(
+        default=None, description="Year of first approval"
+    )
 
     # Flags
     therapeutic_flag: bool | None = Field(default=None)

--- a/src/bioetl/infrastructure/adapters/crossref/mappers.py
+++ b/src/bioetl/infrastructure/adapters/crossref/mappers.py
@@ -306,10 +306,14 @@ class CrossRefFieldExtractor:
             "last_page": last_page,
             "year": self.extract_year(work_data),
             "published_print": self.format_date_parts(
-                published_print.get("date-parts") if isinstance(published_print, dict) else None
+                published_print.get("date-parts")
+                if isinstance(published_print, dict)
+                else None
             ),
             "published_online": self.format_date_parts(
-                published_online.get("date-parts") if isinstance(published_online, dict) else None
+                published_online.get("date-parts")
+                if isinstance(published_online, dict)
+                else None
             ),
             "doc_type": self.map_doc_type(work_data.get("type", "")),
             "citation_count": work_data.get("is-referenced-by-count"),

--- a/src/bioetl/infrastructure/adapters/crossref/models.py
+++ b/src/bioetl/infrastructure/adapters/crossref/models.py
@@ -24,9 +24,7 @@ class CrossRefAuthor(BaseModel):
 
     given: str | None = Field(default=None, description="Given (first) name")
     family: str | None = Field(default=None, description="Family (last) name")
-    name: str | None = Field(
-        default=None, description="Full name (for organizations)"
-    )
+    name: str | None = Field(default=None, description="Full name (for organizations)")
     suffix: str | None = Field(default=None, description="Name suffix")
     sequence: str | None = Field(
         default=None, description="Author sequence (first, additional)"
@@ -37,7 +35,7 @@ class CrossRefAuthor(BaseModel):
     authenticated_orcid: bool | None = Field(
         default=None,
         alias="authenticated-orcid",
-        description="Whether ORCID is authenticated"
+        description="Whether ORCID is authenticated",
     )
     affiliation: list[dict[str, Any]] | None = Field(
         default_factory=list, description="Author affiliations"
@@ -49,13 +47,9 @@ class CrossRefFunder(BaseModel):
 
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
-    doi: str | None = Field(
-        default=None, alias="DOI", description="Funder DOI"
-    )
+    doi: str | None = Field(default=None, alias="DOI", description="Funder DOI")
     name: str | None = Field(default=None, description="Funder name")
-    award: list[str] | None = Field(
-        default_factory=list, description="Award numbers"
-    )
+    award: list[str] | None = Field(default_factory=list, description="Award numbers")
     doi_asserted_by: str | None = Field(
         default=None, alias="doi-asserted-by", description="Who asserted the DOI"
     )
@@ -73,9 +67,7 @@ class CrossRefLicense(BaseModel):
     delay_in_days: int | None = Field(
         default=None, alias="delay-in-days", description="Embargo delay"
     )
-    start: dict[str, Any] | None = Field(
-        default=None, description="License start date"
-    )
+    start: dict[str, Any] | None = Field(default=None, description="License start date")
 
 
 class CrossRefLink(BaseModel):
@@ -131,9 +123,7 @@ class CrossRefAssertion(BaseModel):
     name: str | None = Field(default=None, description="Assertion name")
     value: str | None = Field(default=None, description="Assertion value")
     label: str | None = Field(default=None, description="Assertion label")
-    group: dict[str, Any] | None = Field(
-        default=None, description="Assertion group"
-    )
+    group: dict[str, Any] | None = Field(default=None, description="Assertion group")
 
 
 class CrossRefClinicalTrial(BaseModel):
@@ -183,12 +173,8 @@ class CrossRefWorkRecord(BaseModel):
     subtype: str | None = Field(default=None, description="Work subtype")
 
     # Titles
-    title: list[str] | None = Field(
-        default_factory=list, description="Work titles"
-    )
-    subtitle: list[str] | None = Field(
-        default_factory=list, description="Subtitles"
-    )
+    title: list[str] | None = Field(default_factory=list, description="Work titles")
+    subtitle: list[str] | None = Field(default_factory=list, description="Subtitles")
     short_title: list[str] | None = Field(
         default_factory=list, alias="short-title", description="Short titles"
     )
@@ -203,7 +189,7 @@ class CrossRefWorkRecord(BaseModel):
     short_container_title: list[str] | None = Field(
         default_factory=list,
         alias="short-container-title",
-        description="Short container title"
+        description="Short container title",
     )
     publisher: str | None = Field(default=None, description="Publisher name")
     publisher_location: str | None = Field(
@@ -266,9 +252,7 @@ class CrossRefWorkRecord(BaseModel):
     # Content
     abstract: str | None = Field(default=None, description="Abstract text")
     language: str | None = Field(default=None, description="Language code")
-    subject: list[str] | None = Field(
-        default_factory=list, description="Subject areas"
-    )
+    subject: list[str] | None = Field(default_factory=list, description="Subject areas")
 
     # Funding
     funder: list[CrossRefFunder] | None = Field(
@@ -286,9 +270,7 @@ class CrossRefWorkRecord(BaseModel):
     )
 
     # Relations
-    relation: dict[str, Any] | None = Field(
-        default=None, description="Related works"
-    )
+    relation: dict[str, Any] | None = Field(default=None, description="Related works")
     update_to: list[dict[str, Any]] | None = Field(
         default_factory=list, alias="update-to", description="Updates to other works"
     )
@@ -313,7 +295,7 @@ class CrossRefWorkRecord(BaseModel):
     clinical_trial_number: list[CrossRefClinicalTrial] | None = Field(
         default_factory=list,
         alias="clinical-trial-number",
-        description="Clinical trial numbers"
+        description="Clinical trial numbers",
     )
 
     # Assertions
@@ -344,9 +326,7 @@ class CrossRefMessage(BaseModel):
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     # Facets
-    facets: dict[str, Any] | None = Field(
-        default=None, description="Search facets"
-    )
+    facets: dict[str, Any] | None = Field(default=None, description="Search facets")
 
     # Pagination
     total_results: int | None = Field(
@@ -355,9 +335,7 @@ class CrossRefMessage(BaseModel):
     items_per_page: int | None = Field(
         default=None, alias="items-per-page", description="Items per page"
     )
-    query: dict[str, Any] | None = Field(
-        default=None, description="Query information"
-    )
+    query: dict[str, Any] | None = Field(default=None, description="Query information")
 
     # Cursor
     next_cursor: str | None = Field(

--- a/src/bioetl/infrastructure/adapters/http/client.py
+++ b/src/bioetl/infrastructure/adapters/http/client.py
@@ -310,7 +310,9 @@ class UnifiedHTTPClient:
         configured retryable_exceptions.
         """
         # Check httpx-specific exceptions (connection/timeout errors)
-        if isinstance(exc, httpx.ConnectError | httpx.ConnectTimeout | httpx.ReadTimeout):
+        if isinstance(
+            exc, httpx.ConnectError | httpx.ConnectTimeout | httpx.ReadTimeout
+        ):
             return True
         # Check httpx status errors using configured retryable statuses
         if isinstance(exc, httpx.HTTPStatusError):

--- a/src/bioetl/infrastructure/adapters/pubchem/models.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/models.py
@@ -29,9 +29,7 @@ class PubChemCompoundRecord(BaseModel):
     cid: int = Field(description="PubChem Compound ID")
 
     # Molecular Properties
-    molecular_formula: str | None = Field(
-        default=None, description="Molecular formula"
-    )
+    molecular_formula: str | None = Field(default=None, description="Molecular formula")
     molecular_weight: float | None = Field(
         default=None, description="Molecular weight in g/mol"
     )
@@ -43,22 +41,14 @@ class PubChemCompoundRecord(BaseModel):
     isomeric_smiles: str | None = Field(
         default=None, description="Isomeric SMILES (from smiles property)"
     )
-    inchi: str | None = Field(
-        default=None, description="InChI string"
-    )
-    inchikey: str | None = Field(
-        default=None, description="InChI Key"
-    )
+    inchi: str | None = Field(default=None, description="InChI string")
+    inchikey: str | None = Field(default=None, description="InChI Key")
 
     # Names
-    iupac_name: str | None = Field(
-        default=None, description="IUPAC systematic name"
-    )
+    iupac_name: str | None = Field(default=None, description="IUPAC systematic name")
 
     # Physical/Chemical Properties
-    charge: int | None = Field(
-        default=None, description="Formal charge"
-    )
+    charge: int | None = Field(default=None, description="Formal charge")
     complexity: float | None = Field(
         default=None, description="Molecular complexity score"
     )
@@ -73,9 +63,7 @@ class PubChemCompoundRecord(BaseModel):
     )
 
     # Fingerprints
-    fingerprint: str | None = Field(
-        default=None, description="PubChem fingerprint"
-    )
+    fingerprint: str | None = Field(default=None, description="PubChem fingerprint")
 
 
 class PubChemSubstanceRecord(BaseModel):
@@ -118,20 +106,12 @@ class PubChemAssayRecord(BaseModel):
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     # Primary Key
-    aid: int | None = Field(
-        default=None, description="PubChem Assay ID"
-    )
+    aid: int | None = Field(default=None, description="PubChem Assay ID")
 
     # Core Fields
-    name: str | None = Field(
-        default=None, description="Assay name"
-    )
-    description: str | None = Field(
-        default=None, description="Assay description"
-    )
-    protocol: str | None = Field(
-        default=None, description="Assay protocol"
-    )
+    name: str | None = Field(default=None, description="Assay name")
+    description: str | None = Field(default=None, description="Assay description")
+    protocol: str | None = Field(default=None, description="Assay protocol")
     target: dict[str, Any] | None = Field(
         default=None, description="Target information"
     )
@@ -224,17 +204,11 @@ class PubChemBioactivityRecord(BaseModel):
     activity_outcome: str | None = Field(
         default=None, description="Activity outcome (Active, Inactive, etc.)"
     )
-    activity_score: float | None = Field(
-        default=None, description="Activity score"
-    )
+    activity_score: float | None = Field(default=None, description="Activity score")
 
     # Target Info
-    target_gi: int | None = Field(
-        default=None, description="Target GI number"
-    )
-    target_name: str | None = Field(
-        default=None, description="Target name"
-    )
+    target_gi: int | None = Field(default=None, description="Target GI number")
+    target_name: str | None = Field(default=None, description="Target name")
 
     # Activity Values
     activity_values: list[dict[str, Any]] | None = Field(

--- a/src/bioetl/infrastructure/adapters/pubmed/models.py
+++ b/src/bioetl/infrastructure/adapters/pubmed/models.py
@@ -29,14 +29,10 @@ class PubMedArticleRecord(BaseModel):
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     # Primary Key
-    pmid: str | None = Field(
-        default=None, description="PubMed ID"
-    )
+    pmid: str | None = Field(default=None, description="PubMed ID")
 
     # Article Content
-    article_title: str = Field(
-        default="No title found", description="Article title"
-    )
+    article_title: str = Field(default="No title found", description="Article title")
 
     # Raw XML for forensic analysis (uses underscore prefix in source data)
     raw_xml: str | None = Field(
@@ -181,9 +177,7 @@ class PubMedExtendedRecord(BaseModel):
     )
 
     # Publication Details
-    pub_date: PubMedPubDate | None = Field(
-        default=None, description="Publication date"
-    )
+    pub_date: PubMedPubDate | None = Field(default=None, description="Publication date")
     medline_pgn: str | None = Field(
         default=None, description="Page numbers (MEDLINE format)"
     )
@@ -203,18 +197,14 @@ class PubMedExtendedRecord(BaseModel):
     )
 
     # Keywords
-    keywords: list[str] | None = Field(
-        default_factory=list, description="Keywords"
-    )
+    keywords: list[str] | None = Field(default_factory=list, description="Keywords")
     keyword_count: int | None = Field(default=None, description="Number of keywords")
 
     # Chemicals
     chemicals: list[PubMedChemical] | None = Field(
         default_factory=list, description="Chemical substances"
     )
-    chemical_count: int | None = Field(
-        default=None, description="Number of chemicals"
-    )
+    chemical_count: int | None = Field(default=None, description="Number of chemicals")
 
     # Grants
     grants: list[PubMedGrant] | None = Field(
@@ -234,9 +224,7 @@ class PubMedExtendedRecord(BaseModel):
     date_completed: str | None = Field(
         default=None, description="MEDLINE processing completion date"
     )
-    date_revised: str | None = Field(
-        default=None, description="Record revision date"
-    )
+    date_revised: str | None = Field(default=None, description="Record revision date")
 
     # Citation
     citation_subset: str | None = Field(

--- a/src/bioetl/infrastructure/adapters/uniprot/models.py
+++ b/src/bioetl/infrastructure/adapters/uniprot/models.py
@@ -22,9 +22,7 @@ class UniProtOrganism(BaseModel):
 
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
-    scientific_name: str = Field(
-        alias="scientificName", description="Scientific name"
-    )
+    scientific_name: str = Field(alias="scientificName", description="Scientific name")
     common_name: str | None = Field(
         default=None, alias="commonName", description="Common name"
     )
@@ -210,8 +208,7 @@ class UniProtProteinRecord(BaseModel):
 
     # Entry Type
     entry_type: str = Field(
-        alias="entryType",
-        description="Entry type (UniProtKB reviewed/unreviewed)"
+        alias="entryType", description="Entry type (UniProtKB reviewed/unreviewed)"
     )
 
     # Primary Identifiers
@@ -251,7 +248,7 @@ class UniProtProteinRecord(BaseModel):
     uniprot_kb_cross_references: list[UniProtCrossReference] | None = Field(
         default_factory=list,
         alias="uniProtKBCrossReferences",
-        description="External database cross-references"
+        description="External database cross-references",
     )
 
     # Sequence
@@ -266,7 +263,9 @@ class UniProtProteinRecord(BaseModel):
 
     # Secondary Accessions
     secondary_accessions: list[str] | None = Field(
-        default_factory=list, alias="secondaryAccessions", description="Secondary accessions"
+        default_factory=list,
+        alias="secondaryAccessions",
+        description="Secondary accessions",
     )
 
 

--- a/src/bioetl/infrastructure/config.py
+++ b/src/bioetl/infrastructure/config.py
@@ -61,11 +61,7 @@ def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any
     result = base.copy()
 
     for key, value in override.items():
-        if (
-            key in result
-            and isinstance(result[key], dict)
-            and isinstance(value, dict)
-        ):
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
             # Recursively merge nested dicts
             result[key] = _deep_merge(result[key], value)
         else:

--- a/src/bioetl/infrastructure/observability/unified_logger.py
+++ b/src/bioetl/infrastructure/observability/unified_logger.py
@@ -41,11 +41,34 @@ StageType = Literal["extract", "transform", "load", "validate", "init", "cleanup
 
 # Patterns for secret detection in log values
 _SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
-    (re.compile(r"(?i)(api[_-]?key|apikey)['\"]?\s*[:=]\s*['\"]?[\w-]+", re.IGNORECASE), "[REDACTED_API_KEY]"),
-    (re.compile(r"(?i)(auth|authorization)['\"]?\s*[:=]\s*['\"]?[\w-]+", re.IGNORECASE), "[REDACTED_AUTH]"),
-    (re.compile(r"(?i)(token|bearer)['\"]?\s*[:=]\s*['\"]?[\w-]+", re.IGNORECASE), "[REDACTED_TOKEN]"),
-    (re.compile(r"(?i)(password|passwd|pwd)['\"]?\s*[:=]\s*['\"]?[\w-]+", re.IGNORECASE), "[REDACTED_PASSWORD]"),
-    (re.compile(r"(?i)(secret|private[_-]?key)['\"]?\s*[:=]\s*['\"]?[\w-]+", re.IGNORECASE), "[REDACTED_SECRET]"),
+    (
+        re.compile(
+            r"(?i)(api[_-]?key|apikey)['\"]?\s*[:=]\s*['\"]?[\w-]+", re.IGNORECASE
+        ),
+        "[REDACTED_API_KEY]",
+    ),
+    (
+        re.compile(
+            r"(?i)(auth|authorization)['\"]?\s*[:=]\s*['\"]?[\w-]+", re.IGNORECASE
+        ),
+        "[REDACTED_AUTH]",
+    ),
+    (
+        re.compile(r"(?i)(token|bearer)['\"]?\s*[:=]\s*['\"]?[\w-]+", re.IGNORECASE),
+        "[REDACTED_TOKEN]",
+    ),
+    (
+        re.compile(
+            r"(?i)(password|passwd|pwd)['\"]?\s*[:=]\s*['\"]?[\w-]+", re.IGNORECASE
+        ),
+        "[REDACTED_PASSWORD]",
+    ),
+    (
+        re.compile(
+            r"(?i)(secret|private[_-]?key)['\"]?\s*[:=]\s*['\"]?[\w-]+", re.IGNORECASE
+        ),
+        "[REDACTED_SECRET]",
+    ),
     # Bearer tokens in headers
     (re.compile(r"Bearer\s+[\w.-]+", re.IGNORECASE), "Bearer [REDACTED]"),
     # AWS-style keys

--- a/src/bioetl/infrastructure/storage/bronze_writer.py
+++ b/src/bioetl/infrastructure/storage/bronze_writer.py
@@ -624,7 +624,15 @@ class BronzeWriter:
                     date_dir.rmdir()
 
         self.logger.info(
-            "bronze_cleanup_complete", cutoff=cutoff_str, dry_run=dry_run,
-            files_removed=files, bytes_freed=bytes_total, dirs_removed=dirs,
+            "bronze_cleanup_complete",
+            cutoff=cutoff_str,
+            dry_run=dry_run,
+            files_removed=files,
+            bytes_freed=bytes_total,
+            dirs_removed=dirs,
         )
-        return {"files_removed": files, "bytes_freed": bytes_total, "directories_removed": dirs}
+        return {
+            "files_removed": files,
+            "bytes_freed": bytes_total,
+            "directories_removed": dirs,
+        }

--- a/src/bioetl/interfaces/cli/commands/cleanup.py
+++ b/src/bioetl/interfaces/cli/commands/cleanup.py
@@ -49,7 +49,9 @@ def bronze_cleanup_command(retention_days: int, dry_run: bool) -> None:
             )
         result = await service.cleanup(retention_days=retention_days, dry_run=dry_run)
         action = "Would remove" if dry_run else "Removed"
-        echo_info(f"{action} {result.files_removed} files ({format_bytes(result.bytes_freed)})")
+        echo_info(
+            f"{action} {result.files_removed} files ({format_bytes(result.bytes_freed)})"
+        )
         echo_info(f"{action} {result.directories_removed} empty directories")
 
     asyncio.run(_run())

--- a/src/bioetl/interfaces/cli/commands/config.py
+++ b/src/bioetl/interfaces/cli/commands/config.py
@@ -71,6 +71,7 @@ def show_command(pipeline: str, output_format: str) -> None:
         echo_info(json.dumps(config_dict, indent=2, default=str))
     else:
         import yaml
+
         echo_info(yaml.dump(config_dict, default_flow_style=False, sort_keys=False))
 
 
@@ -129,6 +130,7 @@ def show_settings_command(output_format: str) -> None:
         echo_info(json.dumps(settings_dict, indent=2, default=str))
     else:
         import yaml
+
         echo_info(yaml.dump(settings_dict, default_flow_style=False, sort_keys=False))
 
 

--- a/src/bioetl/interfaces/cli/formatters.py
+++ b/src/bioetl/interfaces/cli/formatters.py
@@ -48,9 +48,7 @@ def echo_cleanup_preview(preview: CleanupPreview) -> None:
 
     if preview.gold:
         if preview.gold.exists:
-            click.echo(
-                f"  Gold: {preview.gold.path} ({preview.gold.file_count} files)"
-            )
+            click.echo(f"  Gold: {preview.gold.path} ({preview.gold.file_count} files)")
         else:
             click.echo(f"  Gold: {preview.gold.path} (does not exist)")
 

--- a/tests/architecture/test_code_metrics.py
+++ b/tests/architecture/test_code_metrics.py
@@ -541,7 +541,10 @@ class TestGodObjectDetection:
                     # Check if it's self._component.method()
                     value = node.func.value
                     if isinstance(value, ast.Attribute):
-                        if isinstance(value.value, ast.Name) and value.value.id == "self":
+                        if (
+                            isinstance(value.value, ast.Name)
+                            and value.value.id == "self"
+                        ):
                             if value.attr.startswith("_"):
                                 # Found delegation: self._component.method()
                                 delegations.add(f"{value.attr}.{node.func.attr}")

--- a/tests/architecture/test_interfaces_no_infrastructure.py
+++ b/tests/architecture/test_interfaces_no_infrastructure.py
@@ -61,8 +61,7 @@ class TestInterfacesNoDIrectInfrastructure:
         imports = get_imports_from_file(cli_path)
 
         infrastructure_imports = [
-            imp for imp in imports
-            if "bioetl.infrastructure" in imp
+            imp for imp in imports if "bioetl.infrastructure" in imp
         ]
 
         assert infrastructure_imports == [], (
@@ -84,10 +83,7 @@ class TestInterfacesNoDIrectInfrastructure:
 
         imports = get_imports_from_file(cli_path)
 
-        bootstrap_imports = [
-            imp for imp in imports
-            if "composition._bootstrap" in imp
-        ]
+        bootstrap_imports = [imp for imp in imports if "composition._bootstrap" in imp]
 
         assert bootstrap_imports == [], (
             f"CLI should not import from _bootstrap. "
@@ -105,8 +101,7 @@ class TestInterfacesNoDIrectInfrastructure:
         imports = get_imports_from_file(init_path)
 
         infrastructure_imports = [
-            imp for imp in imports
-            if "bioetl.infrastructure" in imp
+            imp for imp in imports if "bioetl.infrastructure" in imp
         ]
 
         # Note: observability.py may still import from infrastructure
@@ -132,8 +127,7 @@ class TestInterfacesNoDIrectInfrastructure:
         imports = get_imports_from_file(obs_path)
 
         infrastructure_imports = [
-            imp for imp in imports
-            if "bioetl.infrastructure" in imp
+            imp for imp in imports if "bioetl.infrastructure" in imp
         ]
 
         # This is allowed but documented for future refactoring consideration
@@ -178,15 +172,15 @@ class TestEntrypointsExportServices:
         from bioetl.composition import entrypoints
 
         # Check that getter functions exist
-        assert hasattr(entrypoints, "get_checkpoint_service"), (
-            "entrypoints should export get_checkpoint_service"
-        )
-        assert hasattr(entrypoints, "get_quarantine_service"), (
-            "entrypoints should export get_quarantine_service"
-        )
-        assert hasattr(entrypoints, "get_bronze_cleanup_service"), (
-            "entrypoints should export get_bronze_cleanup_service"
-        )
+        assert hasattr(
+            entrypoints, "get_checkpoint_service"
+        ), "entrypoints should export get_checkpoint_service"
+        assert hasattr(
+            entrypoints, "get_quarantine_service"
+        ), "entrypoints should export get_quarantine_service"
+        assert hasattr(
+            entrypoints, "get_bronze_cleanup_service"
+        ), "entrypoints should export get_bronze_cleanup_service"
 
     def test_entrypoints_all_includes_services(self):
         """Test that __all__ includes service getters."""

--- a/tests/architecture/test_no_logging_getlogger_in_infrastructure.py
+++ b/tests/architecture/test_no_logging_getlogger_in_infrastructure.py
@@ -80,7 +80,9 @@ def _check_logging_getlogger_imports(
     return violations
 
 
-def _check_getlogger_calls(directory: Path, allowed: set[str] | None = None) -> list[str]:
+def _check_getlogger_calls(
+    directory: Path, allowed: set[str] | None = None
+) -> list[str]:
     """Check for logging.getLogger() or getLogger() calls in source code.
 
     Args:
@@ -124,9 +126,7 @@ def _check_getlogger_calls(directory: Path, allowed: set[str] | None = None) -> 
                         )
                 # Check for direct getLogger() call
                 elif isinstance(node.func, ast.Name) and node.func.id == "getLogger":
-                    violations.append(
-                        f"{rel_path}:{node.lineno}: getLogger() call"
-                    )
+                    violations.append(f"{rel_path}:{node.lineno}: getLogger() call")
 
     return violations
 
@@ -140,9 +140,7 @@ class TestNoLoggingGetLoggerInInfrastructure:
         REQ-ARCH-033: Use LoggerPort injection instead of logging.getLogger()
         to ensure all logs include run_id and other context fields.
         """
-        violations = _check_logging_getlogger_imports(
-            INFRASTRUCTURE_DIR, ALLOWED_FILES
-        )
+        violations = _check_logging_getlogger_imports(INFRASTRUCTURE_DIR, ALLOWED_FILES)
 
         assert not violations, (
             "logging.getLogger usage found in infrastructure layer:\n"
@@ -174,9 +172,7 @@ class TestNoLoggingGetLoggerInInfrastructure:
         (_check_getlogger_calls, "getLogger calls"),
     ],
 )
-def test_no_logging_getlogger_parametrized(
-    check_fn: callable, check_name: str
-) -> None:
+def test_no_logging_getlogger_parametrized(check_fn: callable, check_name: str) -> None:
     """Parametrized test for logging.getLogger detection.
 
     Args:

--- a/tests/architecture/test_source_config_usage.py
+++ b/tests/architecture/test_source_config_usage.py
@@ -30,7 +30,9 @@ class TestSourceConfigFilesExist:
         "provider",
         ["chembl", "pubchem", "uniprot", "pubmed"],
     )
-    def test_source_config_exists(self, source_configs_dir: Path, provider: str) -> None:
+    def test_source_config_exists(
+        self, source_configs_dir: Path, provider: str
+    ) -> None:
         """Each provider MUST have a source configuration file."""
         config_file = source_configs_dir / f"{provider}.yaml"
         assert config_file.exists(), (
@@ -58,21 +60,21 @@ class TestSourceConfigFilesExist:
 
         assert "rate_limit" in source, f"{provider}: Missing 'rate_limit' section"
         rate_limit = source["rate_limit"]
-        assert "requests_per_second" in rate_limit, (
-            f"{provider}: Missing 'rate_limit.requests_per_second'"
-        )
+        assert (
+            "requests_per_second" in rate_limit
+        ), f"{provider}: Missing 'rate_limit.requests_per_second'"
         assert "burst" in rate_limit, f"{provider}: Missing 'rate_limit.burst'"
 
-        assert "circuit_breaker" in source, (
-            f"{provider}: Missing 'circuit_breaker' section"
-        )
+        assert (
+            "circuit_breaker" in source
+        ), f"{provider}: Missing 'circuit_breaker' section"
         cb = source["circuit_breaker"]
-        assert "failure_threshold" in cb, (
-            f"{provider}: Missing 'circuit_breaker.failure_threshold'"
-        )
-        assert "recovery_timeout" in cb, (
-            f"{provider}: Missing 'circuit_breaker.recovery_timeout'"
-        )
+        assert (
+            "failure_threshold" in cb
+        ), f"{provider}: Missing 'circuit_breaker.failure_threshold'"
+        assert (
+            "recovery_timeout" in cb
+        ), f"{provider}: Missing 'circuit_breaker.recovery_timeout'"
 
 
 class TestSourceConfigLoading:
@@ -113,12 +115,12 @@ class TestSourceConfigLoading:
         yaml_rate = raw["source"]["rate_limit"]["requests_per_second"]
         yaml_burst = raw["source"]["rate_limit"]["burst"]
 
-        assert config.rate_limit.requests_per_second == yaml_rate, (
-            f"{provider}: rate_limit.requests_per_second mismatch"
-        )
-        assert config.rate_limit.burst == yaml_burst, (
-            f"{provider}: rate_limit.burst mismatch"
-        )
+        assert (
+            config.rate_limit.requests_per_second == yaml_rate
+        ), f"{provider}: rate_limit.requests_per_second mismatch"
+        assert (
+            config.rate_limit.burst == yaml_burst
+        ), f"{provider}: rate_limit.burst mismatch"
 
 
 class TestNoHardcodedRateLimits:
@@ -133,9 +135,9 @@ class TestNoHardcodedRateLimits:
         source = inspect.getsource(HttpClientFactory)
 
         # Should import and use load_source_config
-        assert "load_source_config" in source, (
-            "HttpClientFactory should use load_source_config"
-        )
+        assert (
+            "load_source_config" in source
+        ), "HttpClientFactory should use load_source_config"
 
     def test_registration_uses_source_config(self) -> None:
         """registration.py should use load_source_config for rate limits."""
@@ -146,9 +148,9 @@ class TestNoHardcodedRateLimits:
         source = inspect.getsource(registration)
 
         # Should import load_source_config
-        assert "load_source_config" in source, (
-            "registration.py should use load_source_config"
-        )
+        assert (
+            "load_source_config" in source
+        ), "registration.py should use load_source_config"
 
         # Should have helper functions for getting config
         assert "_get_rate_limit_from_config" in source
@@ -165,24 +167,26 @@ class TestSourceConfigSchema:
         config = load_source_config("chembl")
 
         # ChEMBL should have page_size configured
-        assert config.page_size is not None, (
-            "ChEMBL config should have page_size for API pagination"
-        )
+        assert (
+            config.page_size is not None
+        ), "ChEMBL config should have page_size for API pagination"
         assert config.page_size >= 100, "ChEMBL page_size should be at least 100"
 
     def test_source_config_batch_size_property(self) -> None:
         """batch_size property should return provider_config.batch_size if set."""
         from bioetl.infrastructure.schemas.source_config import SourceYamlConfig
 
-        config = SourceYamlConfig.model_validate({
-            "source": {
-                "batch_size": 100,
-                "provider_config": {
-                    "provider": "test",
-                    "batch_size": 50,
-                },
+        config = SourceYamlConfig.model_validate(
+            {
+                "source": {
+                    "batch_size": 100,
+                    "provider_config": {
+                        "provider": "test",
+                        "batch_size": 50,
+                    },
+                }
             }
-        })
+        )
 
         # provider_config.batch_size takes precedence
         assert config.batch_size == 50
@@ -191,14 +195,16 @@ class TestSourceConfigSchema:
         """batch_size should fall back to source.batch_size if not in provider_config."""
         from bioetl.infrastructure.schemas.source_config import SourceYamlConfig
 
-        config = SourceYamlConfig.model_validate({
-            "source": {
-                "batch_size": 100,
-                "provider_config": {
-                    "provider": "test",
-                },
+        config = SourceYamlConfig.model_validate(
+            {
+                "source": {
+                    "batch_size": 100,
+                    "provider_config": {
+                        "provider": "test",
+                    },
+                }
             }
-        })
+        )
 
         assert config.batch_size == 100
 
@@ -208,7 +214,9 @@ class TestConfigValuesNotHardcoded:
 
     def test_chembl_rate_limit_from_config(self) -> None:
         """ChEMBL rate limit should match configs/sources/chembl.yaml."""
-        from bioetl.composition.providers.registration import _get_rate_limit_from_config
+        from bioetl.composition.providers.registration import (
+            _get_rate_limit_from_config,
+        )
 
         rate, capacity = _get_rate_limit_from_config("chembl")
 
@@ -219,12 +227,12 @@ class TestConfigValuesNotHardcoded:
         expected_rate = raw["source"]["rate_limit"]["requests_per_second"]
         expected_capacity = raw["source"]["rate_limit"]["burst"]
 
-        assert rate == expected_rate, (
-            f"ChEMBL rate mismatch: got {rate}, expected {expected_rate}"
-        )
-        assert capacity == expected_capacity, (
-            f"ChEMBL capacity mismatch: got {capacity}, expected {expected_capacity}"
-        )
+        assert (
+            rate == expected_rate
+        ), f"ChEMBL rate mismatch: got {rate}, expected {expected_rate}"
+        assert (
+            capacity == expected_capacity
+        ), f"ChEMBL capacity mismatch: got {capacity}, expected {expected_capacity}"
 
     def test_chembl_circuit_breaker_from_config(self) -> None:
         """ChEMBL circuit breaker should match configs/sources/chembl.yaml."""

--- a/tests/benchmarks/test_baseline_assertions.py
+++ b/tests/benchmarks/test_baseline_assertions.py
@@ -368,7 +368,9 @@ class TestMemoryMonitorBaseline:
     """
 
     MEMORY_STATS_THRESHOLD_MS = 10  # Increased from 5ms to 10ms for CI variability
-    BATCH_SIZE_THRESHOLD_US = 10000  # Increased from 500us to 10000us for CI variability
+    BATCH_SIZE_THRESHOLD_US = (
+        10000  # Increased from 500us to 10000us for CI variability
+    )
 
     def test_memory_stats_baseline(self) -> None:
         """Memory stats retrieval must complete under threshold."""

--- a/tests/contract/conftest.py
+++ b/tests/contract/conftest.py
@@ -6,6 +6,7 @@ Provides common fixtures for live API contract testing.
 from __future__ import annotations
 
 import os
+
 import pytest
 
 
@@ -15,7 +16,9 @@ def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line("markers", "pubchem: PubChem API contract tests")
     config.addinivalue_line("markers", "uniprot: UniProt API contract tests")
     config.addinivalue_line("markers", "pubmed: PubMed API contract tests")
-    config.addinivalue_line("markers", "slow: Tests that may be slow due to rate limits")
+    config.addinivalue_line(
+        "markers", "slow: Tests that may be slow due to rate limits"
+    )
 
 
 def pytest_collection_modifyitems(
@@ -56,28 +59,38 @@ def uniprot_api_key() -> str | None:
 
 
 # Common expected schema fields for contract verification
-CHEMBL_ACTIVITY_REQUIRED_FIELDS = frozenset({
-    "activity_id",
-    "assay_chembl_id",
-    "molecule_chembl_id",
-})
+CHEMBL_ACTIVITY_REQUIRED_FIELDS = frozenset(
+    {
+        "activity_id",
+        "assay_chembl_id",
+        "molecule_chembl_id",
+    }
+)
 
-CHEMBL_MOLECULE_REQUIRED_FIELDS = frozenset({
-    "molecule_chembl_id",
-    "molecule_type",
-})
+CHEMBL_MOLECULE_REQUIRED_FIELDS = frozenset(
+    {
+        "molecule_chembl_id",
+        "molecule_type",
+    }
+)
 
-CHEMBL_TARGET_REQUIRED_FIELDS = frozenset({
-    "target_chembl_id",
-    "target_type",
-})
+CHEMBL_TARGET_REQUIRED_FIELDS = frozenset(
+    {
+        "target_chembl_id",
+        "target_type",
+    }
+)
 
-UNIPROT_PROTEIN_REQUIRED_FIELDS = frozenset({
-    "primaryAccession",
-    "uniProtkbId",
-    "entryType",
-})
+UNIPROT_PROTEIN_REQUIRED_FIELDS = frozenset(
+    {
+        "primaryAccession",
+        "uniProtkbId",
+        "entryType",
+    }
+)
 
-PUBCHEM_COMPOUND_REQUIRED_FIELDS = frozenset({
-    "cid",
-})
+PUBCHEM_COMPOUND_REQUIRED_FIELDS = frozenset(
+    {
+        "cid",
+    }
+)

--- a/tests/e2e/test_advanced_scenarios_e2e.py
+++ b/tests/e2e/test_advanced_scenarios_e2e.py
@@ -12,6 +12,7 @@ Part of architecture review refactoring plan (R2).
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC
 from pathlib import Path
 from uuid import uuid4
 
@@ -26,8 +27,6 @@ from .conftest import (
     create_test_context,
     get_silver_records,
 )
-from datetime import UTC
-
 
 # ============================================================================
 # VACUUM After Run Tests
@@ -90,7 +89,9 @@ async def test_vacuum_respects_retention_days(e2e_data_dir: Path):
         await asyncio.sleep(0.1)  # Small delay between runs
 
     # Verify table has records
-    count = assert_silver_table_has_records(e2e_data_dir, "chembl_activity", expected_min=1)
+    count = assert_silver_table_has_records(
+        e2e_data_dir, "chembl_activity", expected_min=1
+    )
     assert count >= 1
 
     # VACUUM with 7 day retention shouldn't delete anything recent
@@ -118,10 +119,11 @@ async def test_quarantine_records_are_persisted(e2e_data_dir: Path):
     - Data quality errors should quarantine records
     - Quarantine location: data_dir/quarantine/{pipeline}/
     """
-    from bioetl.application.core.quarantine_manager import QuarantineManager
-    from bioetl.infrastructure.quarantine.unified import UnifiedQuarantine
-    from bioetl.domain.types import ErrorType
     from datetime import datetime
+
+    from bioetl.application.core.quarantine_manager import QuarantineManager
+    from bioetl.domain.types import ErrorType
+    from bioetl.infrastructure.quarantine.unified import UnifiedQuarantine
 
     # Setup quarantine
     quarantine_path = e2e_data_dir / "quarantine"
@@ -131,7 +133,9 @@ async def test_quarantine_records_are_persisted(e2e_data_dir: Path):
         base_path=str(quarantine_path),
     )
 
-    manager = QuarantineManager(quarantine_port=quarantine, pipeline_name="test_pipeline")
+    manager = QuarantineManager(
+        quarantine_port=quarantine, pipeline_name="test_pipeline"
+    )
 
     # Write a quarantine record
     test_record = {
@@ -150,7 +154,9 @@ async def test_quarantine_records_are_persisted(e2e_data_dir: Path):
     # Verify quarantine Delta table exists (base_path IS the table path)
     # Delta Lake creates _delta_log directory in the table path
     delta_log = quarantine_path / "_delta_log"
-    assert delta_log.exists(), f"Quarantine Delta table should exist at {quarantine_path}"
+    assert (
+        delta_log.exists()
+    ), f"Quarantine Delta table should exist at {quarantine_path}"
 
 
 @pytest.mark.e2e
@@ -342,17 +348,11 @@ async def test_rebuild_clears_existing_data(e2e_data_dir: Path):
     - Bronze is append-only (never cleared)
     """
     # First run - create initial data
-    ctx1 = create_test_context(
-        "chembl_activity",
-        limit=3,
-        run_type=RunType.INCREMENTAL
-    )
+    ctx1 = create_test_context("chembl_activity", limit=3, run_type=RunType.INCREMENTAL)
     runner1 = bootstrap_pipeline(ctx1)
     await runner1.run()
 
-    assert_silver_table_has_records(
-        e2e_data_dir, "chembl_activity", expected_min=1
-    )
+    assert_silver_table_has_records(e2e_data_dir, "chembl_activity", expected_min=1)
 
     # Rebuild run - should clear and recreate
     ctx2 = create_test_context(

--- a/tests/e2e/test_resilience_scenarios_e2e.py
+++ b/tests/e2e/test_resilience_scenarios_e2e.py
@@ -19,7 +19,6 @@ import pytest
 
 from bioetl.domain.types import RunID, RunType
 
-
 # ============================================================================
 # Memory Pressure Tests
 # ============================================================================
@@ -255,8 +254,8 @@ async def test_circuit_breaker_opens_on_failures():
     - 5 consecutive failures should open the circuit
     - Open circuit should reject requests immediately
     """
-    from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
     from bioetl.domain.types import CircuitBreakerState
+    from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
 
     breaker = CircuitBreaker(
         provider="test",
@@ -269,7 +268,9 @@ async def test_circuit_breaker_opens_on_failures():
     # Simulate failures via force_open (circuit breaker uses internal _on_failure)
     breaker.force_open()
 
-    assert breaker.get_state() == CircuitBreakerState.OPEN, "Should be OPEN after force_open()"
+    assert (
+        breaker.get_state() == CircuitBreakerState.OPEN
+    ), "Should be OPEN after force_open()"
 
 
 @pytest.mark.e2e
@@ -282,8 +283,8 @@ async def test_circuit_breaker_half_open_recovery():
     - Single success should close circuit
     - Single failure should re-open circuit
     """
-    from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
     from bioetl.domain.types import CircuitBreakerState
+    from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
 
     breaker = CircuitBreaker(
         provider="test",
@@ -418,7 +419,6 @@ async def test_bronze_writer_atomic_writes(e2e_data_dir: Path):
         b'{"id": 1, "value": "test1"}',
         b'{"id": 2, "value": "test2"}',
     ]
-
 
     path_str = await writer.write_bronze(
         records=iter(records),

--- a/tests/integration/interfaces/test_cli_shutdown_integration.py
+++ b/tests/integration/interfaces/test_cli_shutdown_integration.py
@@ -256,7 +256,9 @@ class TestRunnerShutdownIntegration:
                 "bioetl.interfaces.cli.commands.run.create_pipeline_runner",
                 return_value=mock_runner,
             ),
-            patch("bioetl.interfaces.cli.commands.run.setup_shutdown_handlers") as mock_setup,
+            patch(
+                "bioetl.interfaces.cli.commands.run.setup_shutdown_handlers"
+            ) as mock_setup,
         ):
             cli_runner.invoke(
                 cli,

--- a/tests/test_data_storage.py
+++ b/tests/test_data_storage.py
@@ -36,7 +36,8 @@ def get_all_pipeline_configs():
         return []
     # Exclude files in 'sources/' subdirectories and _defaults.yaml
     return [
-        p for p in PIPELINE_CONFIG_PATH.glob("**/*.yaml")
+        p
+        for p in PIPELINE_CONFIG_PATH.glob("**/*.yaml")
         if "sources" not in p.parts and p.name != "_defaults.yaml"
     ]
 

--- a/tests/unit/application/core/test_medallion_policy.py
+++ b/tests/unit/application/core/test_medallion_policy.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 
 import pytest
 
-from bioetl.domain.medallion import Layer, WriteMode, WriteModePolicy
 from bioetl.domain.exceptions import PolicyViolationError
+from bioetl.domain.medallion import Layer, WriteMode, WriteModePolicy
 
 
 @pytest.mark.unit

--- a/tests/unit/application/core/test_medallion_validator.py
+++ b/tests/unit/application/core/test_medallion_validator.py
@@ -220,9 +220,7 @@ class TestMedallionConfigValidator:
 class TestWriteModeValidation:
     """Tests for write mode validation."""
 
-    def test_valid_silver_merge(
-        self, mock_logger: Mock
-    ) -> None:
+    def test_valid_silver_merge(self, mock_logger: Mock) -> None:
         """Test validation passes for merge mode in silver."""
         config = Mock()
         config.write_mode = "merge"
@@ -232,9 +230,7 @@ class TestWriteModeValidation:
         errors = validator.validate_write_modes()
         assert len(errors) == 0
 
-    def test_valid_silver_append(
-        self, mock_logger: Mock
-    ) -> None:
+    def test_valid_silver_append(self, mock_logger: Mock) -> None:
         """Test validation passes for append mode in silver."""
         config = Mock()
         config.write_mode = "append"
@@ -244,9 +240,7 @@ class TestWriteModeValidation:
         errors = validator.validate_write_modes()
         assert len(errors) == 0
 
-    def test_invalid_silver_overwrite(
-        self, mock_logger: Mock
-    ) -> None:
+    def test_invalid_silver_overwrite(self, mock_logger: Mock) -> None:
         """Test validation fails for overwrite mode in silver."""
         config = Mock()
         config.write_mode = "overwrite"  # Not allowed for silver
@@ -257,9 +251,7 @@ class TestWriteModeValidation:
         assert len(errors) == 1
         assert errors[0].field == "write_mode"
 
-    def test_valid_gold_merge(
-        self, mock_logger: Mock
-    ) -> None:
+    def test_valid_gold_merge(self, mock_logger: Mock) -> None:
         """Test validation passes for merge mode in gold."""
         config = Mock()
         config.write_mode = "merge"
@@ -269,9 +261,7 @@ class TestWriteModeValidation:
         errors = validator.validate_write_modes()
         assert len(errors) == 0
 
-    def test_valid_gold_overwrite(
-        self, mock_logger: Mock
-    ) -> None:
+    def test_valid_gold_overwrite(self, mock_logger: Mock) -> None:
         """Test validation passes for overwrite mode in gold."""
         config = Mock()
         config.write_mode = "merge"
@@ -281,9 +271,7 @@ class TestWriteModeValidation:
         errors = validator.validate_write_modes()
         assert len(errors) == 0
 
-    def test_valid_gold_scd2(
-        self, mock_logger: Mock
-    ) -> None:
+    def test_valid_gold_scd2(self, mock_logger: Mock) -> None:
         """Test validation passes for scd2 mode in gold."""
         config = Mock()
         config.write_mode = "merge"
@@ -293,9 +281,7 @@ class TestWriteModeValidation:
         errors = validator.validate_write_modes()
         assert len(errors) == 0
 
-    def test_valid_gold_append(
-        self, mock_logger: Mock
-    ) -> None:
+    def test_valid_gold_append(self, mock_logger: Mock) -> None:
         """Test validation passes for append mode in gold."""
         config = Mock()
         config.write_mode = "merge"
@@ -305,9 +291,7 @@ class TestWriteModeValidation:
         errors = validator.validate_write_modes()
         assert len(errors) == 0
 
-    def test_invalid_gold_mode(
-        self, mock_logger: Mock
-    ) -> None:
+    def test_invalid_gold_mode(self, mock_logger: Mock) -> None:
         """Test validation fails for invalid gold mode."""
         config = Mock()
         config.write_mode = "merge"
@@ -318,9 +302,7 @@ class TestWriteModeValidation:
         assert len(errors) == 1
         assert errors[0].field == "gold_write_mode"
 
-    def test_invalid_both_modes(
-        self, mock_logger: Mock
-    ) -> None:
+    def test_invalid_both_modes(self, mock_logger: Mock) -> None:
         """Test validation fails for both invalid modes."""
         config = Mock()
         config.write_mode = "invalid_mode"

--- a/tests/unit/application/pipelines/test_cell_line_transformer.py
+++ b/tests/unit/application/pipelines/test_cell_line_transformer.py
@@ -152,9 +152,7 @@ class TestCellLineTransformer:
         assert result["cl_lincs_id"] == "LCL-1234"
 
     @pytest.mark.asyncio
-    async def test_transform_with_invalid_tax_id_zero(
-        self, transformer, mock_context
-    ):
+    async def test_transform_with_invalid_tax_id_zero(self, transformer, mock_context):
         """Test that tax_id of 0 becomes None (must be >= 1)."""
         record = {
             "cell_chembl_id": "CHEMBL3308376",

--- a/tests/unit/application/services/test_bronze_cleanup_service.py
+++ b/tests/unit/application/services/test_bronze_cleanup_service.py
@@ -91,9 +91,7 @@ class TestBronzeCleanupServiceCleanup:
     """Test BronzeCleanupService.cleanup method."""
 
     @pytest.mark.asyncio
-    async def test_cleanup_with_defaults(
-        self, bronze_cleanup_service, mock_storage
-    ):
+    async def test_cleanup_with_defaults(self, bronze_cleanup_service, mock_storage):
         """Test cleanup with default retention (90 days)."""
         mock_storage.cleanup_bronze.return_value = {
             "files_removed": 10,

--- a/tests/unit/application/services/test_checkpoint_service.py
+++ b/tests/unit/application/services/test_checkpoint_service.py
@@ -79,7 +79,9 @@ class TestCheckpointServiceListCheckpoints:
     """Test CheckpointService.list_checkpoints method."""
 
     @pytest.mark.asyncio
-    async def test_list_checkpoints_empty(self, checkpoint_service, mock_checkpoint_port):
+    async def test_list_checkpoints_empty(
+        self, checkpoint_service, mock_checkpoint_port
+    ):
         """Test listing checkpoints when none exist."""
         mock_checkpoint_port.list_all.return_value = []
 
@@ -145,9 +147,7 @@ class TestCheckpointServiceGetCheckpoint:
         mock_checkpoint_port.load.assert_called_once_with("nonexistent")
 
     @pytest.mark.asyncio
-    async def test_get_checkpoint_found(
-        self, checkpoint_service, mock_checkpoint_port
-    ):
+    async def test_get_checkpoint_found(self, checkpoint_service, mock_checkpoint_port):
         """Test getting an existing checkpoint."""
         run_id = uuid4()
         mock_checkpoint_port.load.return_value = (run_id, {"records_processed": 100})

--- a/tests/unit/application/services/test_lock_service.py
+++ b/tests/unit/application/services/test_lock_service.py
@@ -128,9 +128,7 @@ class TestLockServiceReleaseLock:
         owner_id = RunID(uuid4())
         mock_lock_port.release.return_value = True
 
-        result = await lock_service.release_lock(
-            "pipeline1", owner_id, exclusive=True
-        )
+        result = await lock_service.release_lock("pipeline1", owner_id, exclusive=True)
 
         assert result is True
         mock_lock_port.release.assert_called_once_with(

--- a/tests/unit/application/services/test_quarantine_service.py
+++ b/tests/unit/application/services/test_quarantine_service.py
@@ -125,9 +125,7 @@ class TestQuarantineServiceInspect:
         )
 
     @pytest.mark.asyncio
-    async def test_inspect_with_records(
-        self, quarantine_service, mock_quarantine_port
-    ):
+    async def test_inspect_with_records(self, quarantine_service, mock_quarantine_port):
         """Test inspecting quarantine with records."""
         now = datetime.now(UTC)
         mock_quarantine_port.inspect.return_value = [
@@ -199,9 +197,7 @@ class TestQuarantineServiceReplay:
     """Test QuarantineService.replay method."""
 
     @pytest.mark.asyncio
-    async def test_replay_returns_stats(
-        self, quarantine_service, mock_quarantine_port
-    ):
+    async def test_replay_returns_stats(self, quarantine_service, mock_quarantine_port):
         """Test replay returns statistics (not yet implemented)."""
         batch_id = uuid4()
         mock_quarantine_port.inspect.return_value = [
@@ -223,9 +219,7 @@ class TestQuarantineServicePurge:
     """Test QuarantineService.purge method."""
 
     @pytest.mark.asyncio
-    async def test_purge_returns_stats(
-        self, quarantine_service, mock_quarantine_port
-    ):
+    async def test_purge_returns_stats(self, quarantine_service, mock_quarantine_port):
         """Test purge returns statistics (not yet implemented)."""
         mock_quarantine_port.inspect.return_value = []
 

--- a/tests/unit/application/services/test_shutdown_service.py
+++ b/tests/unit/application/services/test_shutdown_service.py
@@ -68,9 +68,7 @@ class TestShutdownService:
         assert shutdown_service.reason == ShutdownReason.UNKNOWN
 
     @pytest.mark.asyncio
-    async def test_initiate_shutdown_sets_flag(
-        self, shutdown_service: ShutdownService
-    ):
+    async def test_initiate_shutdown_sets_flag(self, shutdown_service: ShutdownService):
         """Test initiate_shutdown sets the shutdown flag."""
         await shutdown_service.initiate_shutdown("test reason")
         assert shutdown_service.is_shutting_down() is True
@@ -119,6 +117,7 @@ class TestShutdownService:
     @pytest.mark.asyncio
     async def test_wait_blocks_until_shutdown(self, shutdown_service: ShutdownService):
         """Test wait() blocks until shutdown is initiated."""
+
         async def initiate_after_delay():
             await asyncio.sleep(0.05)
             await shutdown_service.initiate_shutdown("delayed shutdown")
@@ -130,18 +129,15 @@ class TestShutdownService:
         await task
 
     @pytest.mark.asyncio
-    async def test_wait_for_completion_timeout(
-        self, shutdown_service: ShutdownService
-    ):
+    async def test_wait_for_completion_timeout(self, shutdown_service: ShutdownService):
         """Test wait_for_completion returns False on timeout."""
         result = await shutdown_service.wait_for_completion(timeout=0.01)
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_wait_for_completion_success(
-        self, shutdown_service: ShutdownService
-    ):
+    async def test_wait_for_completion_success(self, shutdown_service: ShutdownService):
         """Test wait_for_completion returns True when marked complete."""
+
         async def mark_complete_after_delay():
             await asyncio.sleep(0.05)
             shutdown_service.mark_completed()
@@ -213,9 +209,7 @@ class TestPipelineShutdownError:
 
     def test_with_reason(self):
         """Test exception with reason."""
-        error = PipelineShutdownError(
-            "Lock lost", reason=ShutdownReason.LOCK_LOST
-        )
+        error = PipelineShutdownError("Lock lost", reason=ShutdownReason.LOCK_LOST)
         assert error.reason == ShutdownReason.LOCK_LOST
         assert "Lock lost" in str(error)
 

--- a/tests/unit/composition/test_entrypoints.py
+++ b/tests/unit/composition/test_entrypoints.py
@@ -344,9 +344,7 @@ class TestRunPipelineIntegration:
             "bioetl.composition.entrypoints.create_pipeline_runner",
             return_value=mock_runner,
         ):
-            result = await run_pipeline(
-                "test_pipeline", RunOptions(run_type="rebuild")
-            )
+            result = await run_pipeline("test_pipeline", RunOptions(run_type="rebuild"))
 
         assert result.status == RunStatus.FAILED
         assert result.error_message == "Connection failed"

--- a/tests/unit/domain/aggregates/test_batch.py
+++ b/tests/unit/domain/aggregates/test_batch.py
@@ -22,7 +22,6 @@ from bioetl.domain.aggregates.batch import (
 from bioetl.domain.exceptions import InvalidStateError
 from bioetl.domain.types import BatchID, ContentHash, EntityID, RunID
 
-
 # ──────────────────────────────────────────────────────────────────────────────
 # Fixtures
 # ──────────────────────────────────────────────────────────────────────────────
@@ -208,11 +207,13 @@ class TestBatchRecordManagement:
 
     def test_add_multiple_records(self, batch: Batch) -> None:
         """Should add multiple records at once."""
-        records = batch.add_records([
-            {"id": "1"},
-            {"id": "2"},
-            {"id": "3"},
-        ])
+        records = batch.add_records(
+            [
+                {"id": "1"},
+                {"id": "2"},
+                {"id": "3"},
+            ]
+        )
 
         assert len(records) == 3
         assert batch.record_count == 3
@@ -255,7 +256,9 @@ class TestBatchQuarantine:
         with pytest.raises(InvalidStateError, match="Cannot quarantine"):
             batch.quarantine_record(record, "Error", "ERR")
 
-    def test_cannot_quarantine_foreign_record(self, batch: Batch, run_id: RunID) -> None:
+    def test_cannot_quarantine_foreign_record(
+        self, batch: Batch, run_id: RunID
+    ) -> None:
         """Invariant: Cannot quarantine record from another batch."""
         other_batch = Batch.create(run_id=run_id)
         foreign_record = other_batch.add_record({"id": "1"})

--- a/tests/unit/domain/aggregates/test_pipeline_run.py
+++ b/tests/unit/domain/aggregates/test_pipeline_run.py
@@ -24,7 +24,6 @@ from bioetl.domain.aggregates.pipeline_run import (
 from bioetl.domain.exceptions import InvalidStateError
 from bioetl.domain.types import RunID, RunType
 
-
 # ──────────────────────────────────────────────────────────────────────────────
 # Fixtures
 # ──────────────────────────────────────────────────────────────────────────────
@@ -175,7 +174,9 @@ class TestPipelineRunStageRecording:
         assert started_run.stages[0].stage == "preflight"
         assert started_run.stages[0].status == StageStatus.SUCCESS
 
-    def test_cannot_record_stage_on_pending_run(self, pipeline_run: PipelineRun) -> None:
+    def test_cannot_record_stage_on_pending_run(
+        self, pipeline_run: PipelineRun
+    ) -> None:
         """Invariant: Cannot record stages on PENDING run."""
         with pytest.raises(InvalidStateError, match="run is in status pending"):
             pipeline_run.record_stage_success("test")
@@ -220,7 +221,9 @@ class TestPipelineRunCompletionInvariants:
         with pytest.raises(InvalidStateError, match="no stages recorded"):
             started_run.complete()
 
-    def test_complete_with_all_successful_stages(self, started_run: PipelineRun) -> None:
+    def test_complete_with_all_successful_stages(
+        self, started_run: PipelineRun
+    ) -> None:
         """Should complete when all stages succeeded."""
         started_run.record_stage_success("preflight")
         started_run.record_stage_success("execution", records_processed=1000)
@@ -259,7 +262,9 @@ class TestPipelineRunEncapsulation:
         with pytest.raises((TypeError, AttributeError)):
             stages.append(None)  # type: ignore
 
-    def test_run_id_is_immutable(self, run_id: RunID, pipeline_run: PipelineRun) -> None:
+    def test_run_id_is_immutable(
+        self, run_id: RunID, pipeline_run: PipelineRun
+    ) -> None:
         """Invariant: run_id cannot be changed after creation."""
         assert pipeline_run.run_id == run_id
 

--- a/tests/unit/domain/aggregates/test_quarantine_entry.py
+++ b/tests/unit/domain/aggregates/test_quarantine_entry.py
@@ -23,7 +23,6 @@ from bioetl.domain.aggregates.quarantine_entry import (
 from bioetl.domain.exceptions import InvalidStateError
 from bioetl.domain.types import BatchID, ContentHash, RunID
 
-
 # ──────────────────────────────────────────────────────────────────────────────
 # Fixtures
 # ──────────────────────────────────────────────────────────────────────────────
@@ -106,9 +105,7 @@ class TestResolutionInfoInvariants:
 class TestQuarantineEntryConstructorValidation:
     """Tests for constructor validation."""
 
-    def test_entry_id_required(
-        self, run_id: RunID, batch_id: BatchID
-    ) -> None:
+    def test_entry_id_required(self, run_id: RunID, batch_id: BatchID) -> None:
         """Invariant: entry_id is required."""
         with pytest.raises(ValueError, match="entry_id is required"):
             QuarantineEntry(
@@ -121,9 +118,7 @@ class TestQuarantineEntryConstructorValidation:
                 batch_id=batch_id,
             )
 
-    def test_pipeline_name_required(
-        self, run_id: RunID, batch_id: BatchID
-    ) -> None:
+    def test_pipeline_name_required(self, run_id: RunID, batch_id: BatchID) -> None:
         """Invariant: pipeline_name is required."""
         with pytest.raises(ValueError, match="pipeline_name is required"):
             QuarantineEntry(
@@ -136,9 +131,7 @@ class TestQuarantineEntryConstructorValidation:
                 batch_id=batch_id,
             )
 
-    def test_error_code_required(
-        self, run_id: RunID, batch_id: BatchID
-    ) -> None:
+    def test_error_code_required(self, run_id: RunID, batch_id: BatchID) -> None:
         """Invariant: error_code is required."""
         with pytest.raises(ValueError, match="error_code is required"):
             QuarantineEntry(
@@ -151,9 +144,7 @@ class TestQuarantineEntryConstructorValidation:
                 batch_id=batch_id,
             )
 
-    def test_payload_cannot_be_empty(
-        self, run_id: RunID, batch_id: BatchID
-    ) -> None:
+    def test_payload_cannot_be_empty(self, run_id: RunID, batch_id: BatchID) -> None:
         """Invariant: payload cannot be empty."""
         with pytest.raises(ValueError, match="payload cannot be empty"):
             QuarantineEntry(
@@ -187,18 +178,14 @@ class TestQuarantineEntryStateTransitions:
         quarantine_entry.start_review()
         assert quarantine_entry.status == QuarantineStatus.UNDER_REVIEW
 
-    def test_cannot_start_review_twice(
-        self, quarantine_entry: QuarantineEntry
-    ) -> None:
+    def test_cannot_start_review_twice(self, quarantine_entry: QuarantineEntry) -> None:
         """Invariant: Cannot start review on non-NEW entry."""
         quarantine_entry.start_review()
 
         with pytest.raises(InvalidStateError, match="Cannot start review"):
             quarantine_entry.start_review()
 
-    def test_mark_ignored_from_new(
-        self, quarantine_entry: QuarantineEntry
-    ) -> None:
+    def test_mark_ignored_from_new(self, quarantine_entry: QuarantineEntry) -> None:
         """Should transition NEW -> IGNORED."""
         quarantine_entry.mark_ignored(reason="Known bad data")
 
@@ -215,9 +202,7 @@ class TestQuarantineEntryStateTransitions:
 
         assert quarantine_entry.status == QuarantineStatus.IGNORED
 
-    def test_mark_reprocessed_from_new(
-        self, quarantine_entry: QuarantineEntry
-    ) -> None:
+    def test_mark_reprocessed_from_new(self, quarantine_entry: QuarantineEntry) -> None:
         """Should transition NEW -> REPROCESSED."""
         quarantine_entry.mark_reprocessed(new_record_id="silver:456")
 
@@ -285,9 +270,7 @@ class TestQuarantineEntryTerminalStates:
 class TestQuarantineEntryExpiration:
     """Tests for expiration behavior."""
 
-    def test_mark_expired_from_new(
-        self, quarantine_entry: QuarantineEntry
-    ) -> None:
+    def test_mark_expired_from_new(self, quarantine_entry: QuarantineEntry) -> None:
         """Should transition NEW -> EXPIRED."""
         quarantine_entry.mark_expired()
 
@@ -312,39 +295,29 @@ class TestQuarantineEntryExpiration:
 class TestQuarantineEntryEncapsulation:
     """Tests for field encapsulation."""
 
-    def test_entry_id_is_immutable(
-        self, quarantine_entry: QuarantineEntry
-    ) -> None:
+    def test_entry_id_is_immutable(self, quarantine_entry: QuarantineEntry) -> None:
         """Invariant: entry_id cannot be changed."""
         with pytest.raises(AttributeError):
             quarantine_entry.entry_id = "new-id"  # type: ignore
 
-    def test_error_code_is_immutable(
-        self, quarantine_entry: QuarantineEntry
-    ) -> None:
+    def test_error_code_is_immutable(self, quarantine_entry: QuarantineEntry) -> None:
         """Invariant: error_code cannot be changed."""
         with pytest.raises(AttributeError):
             quarantine_entry.error_code = "NEW_ERROR"  # type: ignore
 
-    def test_payload_returns_copy(
-        self, quarantine_entry: QuarantineEntry
-    ) -> None:
+    def test_payload_returns_copy(self, quarantine_entry: QuarantineEntry) -> None:
         """Invariant: payload returns a copy, not the original."""
         payload = quarantine_entry.payload
         payload["new_key"] = "new_value"
 
         assert "new_key" not in quarantine_entry.payload
 
-    def test_payload_hash_is_immutable(
-        self, quarantine_entry: QuarantineEntry
-    ) -> None:
+    def test_payload_hash_is_immutable(self, quarantine_entry: QuarantineEntry) -> None:
         """Invariant: payload_hash cannot be changed."""
         with pytest.raises(AttributeError):
             quarantine_entry.payload_hash = ContentHash("newhash")  # type: ignore
 
-    def test_metadata_returns_copy(
-        self, quarantine_entry: QuarantineEntry
-    ) -> None:
+    def test_metadata_returns_copy(self, quarantine_entry: QuarantineEntry) -> None:
         """Invariant: metadata returns a copy."""
         metadata = quarantine_entry.metadata
         metadata["new_key"] = "new_value"
@@ -434,9 +407,7 @@ class TestQuarantineStatus:
 class TestQuarantineEntryFactory:
     """Tests for factory method behavior."""
 
-    def test_create_generates_entry_id(
-        self, run_id: RunID, batch_id: BatchID
-    ) -> None:
+    def test_create_generates_entry_id(self, run_id: RunID, batch_id: BatchID) -> None:
         """create() should generate unique entry_id."""
         entry = QuarantineEntry.create(
             pipeline_name="test",

--- a/tests/unit/domain/value_objects/test_identifiers.py
+++ b/tests/unit/domain/value_objects/test_identifiers.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 import pytest
 
 from bioetl.domain.value_objects import (
-    ChemblId,
     DOI,
+    ChemblId,
     PubChemCid,
     PubMedId,
     UniProtId,

--- a/tests/unit/domain/value_objects/test_measurements.py
+++ b/tests/unit/domain/value_objects/test_measurements.py
@@ -5,7 +5,6 @@ Tests for Concentration, ConcentrationUnit, ActivityType, PChemblValue.
 
 from __future__ import annotations
 
-
 import pytest
 
 from bioetl.domain.value_objects import (
@@ -247,8 +246,12 @@ class TestActivityType:
 
     def test_from_string_percent_inhibition(self) -> None:
         """Test parsing % Inhibition from string."""
-        assert ActivityType.from_string("% Inhibition") == ActivityType.PERCENT_INHIBITION
-        assert ActivityType.from_string("% INHIBITION") == ActivityType.PERCENT_INHIBITION
+        assert (
+            ActivityType.from_string("% Inhibition") == ActivityType.PERCENT_INHIBITION
+        )
+        assert (
+            ActivityType.from_string("% INHIBITION") == ActivityType.PERCENT_INHIBITION
+        )
 
     def test_from_string_invalid_raises(self) -> None:
         """Test invalid type string raises ValueError."""

--- a/tests/unit/infrastructure/adapters/chembl/test_chembl_client.py
+++ b/tests/unit/infrastructure/adapters/chembl/test_chembl_client.py
@@ -312,7 +312,9 @@ class TestChemblAdapterHealthAwareBatchSize:
         """Test that HEALTHY status uses full batch size."""
         # Configure circuit breaker for HEALTHY state
         mock_http_client.circuit_breaker = MagicMock()
-        mock_http_client.circuit_breaker.get_state.return_value = CircuitBreakerState.CLOSED
+        mock_http_client.circuit_breaker.get_state.return_value = (
+            CircuitBreakerState.CLOSED
+        )
         mock_http_client.circuit_breaker.get_failure_count.return_value = 0
 
         adapter = ChemblAdapter(
@@ -329,7 +331,9 @@ class TestChemblAdapterHealthAwareBatchSize:
         """Test that DEGRADED status halves batch size."""
         # Configure circuit breaker for DEGRADED state (1-2 failures)
         mock_http_client.circuit_breaker = MagicMock()
-        mock_http_client.circuit_breaker.get_state.return_value = CircuitBreakerState.CLOSED
+        mock_http_client.circuit_breaker.get_state.return_value = (
+            CircuitBreakerState.CLOSED
+        )
         mock_http_client.circuit_breaker.get_failure_count.return_value = 1
 
         adapter = ChemblAdapter(
@@ -354,7 +358,9 @@ class TestChemblAdapterHealthAwareBatchSize:
         """Test that DEGRADED status respects minimum batch size of 100."""
         # Configure circuit breaker for DEGRADED state
         mock_http_client.circuit_breaker = MagicMock()
-        mock_http_client.circuit_breaker.get_state.return_value = CircuitBreakerState.CLOSED
+        mock_http_client.circuit_breaker.get_state.return_value = (
+            CircuitBreakerState.CLOSED
+        )
         mock_http_client.circuit_breaker.get_failure_count.return_value = 1
 
         adapter = ChemblAdapter(
@@ -371,7 +377,9 @@ class TestChemblAdapterHealthAwareBatchSize:
         """Test that UNHEALTHY status raises CriticalError."""
         # Configure circuit breaker for UNHEALTHY state (failure_count > 2)
         mock_http_client.circuit_breaker = MagicMock()
-        mock_http_client.circuit_breaker.get_state.return_value = CircuitBreakerState.CLOSED
+        mock_http_client.circuit_breaker.get_state.return_value = (
+            CircuitBreakerState.CLOSED
+        )
         mock_http_client.circuit_breaker.get_failure_count.return_value = 3
 
         adapter = ChemblAdapter(
@@ -392,7 +400,9 @@ class TestChemblAdapterHealthAwareBatchSize:
         """Test that _build_params uses health-aware batch size."""
         # Configure circuit breaker for HEALTHY state
         mock_http_client.circuit_breaker = MagicMock()
-        mock_http_client.circuit_breaker.get_state.return_value = CircuitBreakerState.CLOSED
+        mock_http_client.circuit_breaker.get_state.return_value = (
+            CircuitBreakerState.CLOSED
+        )
         mock_http_client.circuit_breaker.get_failure_count.return_value = 0
 
         adapter = ChemblAdapter(
@@ -424,7 +434,9 @@ class TestChemblAdapterHealthTransitions:
         """
         # Configure circuit breaker for DEGRADED state
         mock_http_client.circuit_breaker = MagicMock()
-        mock_http_client.circuit_breaker.get_state.return_value = CircuitBreakerState.CLOSED
+        mock_http_client.circuit_breaker.get_state.return_value = (
+            CircuitBreakerState.CLOSED
+        )
         mock_http_client.circuit_breaker.get_failure_count.return_value = 1
 
         adapter = ChemblAdapter(

--- a/tests/unit/infrastructure/adapters/crossref/test_crossref_client.py
+++ b/tests/unit/infrastructure/adapters/crossref/test_crossref_client.py
@@ -265,9 +265,7 @@ async def test_fetch_filtered_valid_entity_types(adapter, mock_http_client):
     mock_http_client.get = AsyncMock(return_value=mock_response)
 
     results = []
-    async for work in adapter.fetch_filtered(
-        "work", ["10.1234/test"], "doi", limit=10
-    ):
+    async for work in adapter.fetch_filtered("work", ["10.1234/test"], "doi", limit=10):
         results.append(work)
 
     assert results == []
@@ -277,9 +275,7 @@ async def test_fetch_filtered_valid_entity_types(adapter, mock_http_client):
 async def test_fetch_filtered_invalid_entity_type(adapter):
     """Test fetch_filtered raises ValueError for invalid entity type."""
     with pytest.raises(ValueError, match="supports 'work' or 'publication'"):
-        async for _ in adapter.fetch_filtered(
-            "invalid", ["10.1234/test"], "doi"
-        ):
+        async for _ in adapter.fetch_filtered("invalid", ["10.1234/test"], "doi"):
             pass
 
 

--- a/tests/unit/infrastructure/adapters/http/test_health_monitor.py
+++ b/tests/unit/infrastructure/adapters/http/test_health_monitor.py
@@ -458,9 +458,7 @@ class TestProviderHealthTracker:
         # Should recover from DEGRADED if clear window passed
         assert status in (HealthStatus.HEALTHY, HealthStatus.DEGRADED)
 
-    def test_record_error_delegates(
-        self, tracker: ProviderHealthTracker
-    ) -> None:
+    def test_record_error_delegates(self, tracker: ProviderHealthTracker) -> None:
         """Test record_error delegates to monitor."""
         status = tracker.record_error()
 
@@ -526,9 +524,7 @@ class TestProviderHealthMonitorUpdateFromResult:
             labels={"provider": "chembl"},
         )
 
-    def test_logs_p2_alert_on_unhealthy(
-        self, monitor: ProviderHealthMonitor
-    ) -> None:
+    def test_logs_p2_alert_on_unhealthy(self, monitor: ProviderHealthMonitor) -> None:
         """Test P2 alert is logged when status becomes UNHEALTHY."""
         from bioetl.domain.ports.health_check import HealthCheckResult
 

--- a/tests/unit/infrastructure/adapters/http/test_http_client.py
+++ b/tests/unit/infrastructure/adapters/http/test_http_client.py
@@ -698,10 +698,7 @@ class TestUnifiedHTTPClientObservability:
         # Check that logger.warning was called at least once for retry
         mock_logger.warning.assert_called()
         call_args_list = mock_logger.warning.call_args_list
-        retry_calls = [
-            c for c in call_args_list
-            if c.args and "Retry" in c.args[0]
-        ]
+        retry_calls = [c for c in call_args_list if c.args and "Retry" in c.args[0]]
         assert len(retry_calls) >= 1, (
             f"Expected at least 1 retry warning call, got {len(retry_calls)}. "
             f"All warning calls: {call_args_list}"

--- a/tests/unit/infrastructure/export/test_csv_exporter.py
+++ b/tests/unit/infrastructure/export/test_csv_exporter.py
@@ -258,9 +258,7 @@ class TestCsvExporterExport:
 class TestCsvExporterClear:
     """Tests for CsvExporter.clear() method."""
 
-    def test_clear_specific_table(
-        self, tmp_path: Path, mock_logger: MagicMock
-    ) -> None:
+    def test_clear_specific_table(self, tmp_path: Path, mock_logger: MagicMock) -> None:
         """Test clearing a specific table's CSV file."""
         exporter = CsvExporter(base_path=str(tmp_path), logger=mock_logger)
 
@@ -274,9 +272,7 @@ class TestCsvExporterClear:
         assert not (tmp_path / "table1.csv").exists()
         assert (tmp_path / "table2.csv").exists()
 
-    def test_clear_all_csv_files(
-        self, tmp_path: Path, mock_logger: MagicMock
-    ) -> None:
+    def test_clear_all_csv_files(self, tmp_path: Path, mock_logger: MagicMock) -> None:
         """Test clearing all CSV files."""
         exporter = CsvExporter(base_path=str(tmp_path), logger=mock_logger)
 

--- a/tests/unit/infrastructure/test_config_settings.py
+++ b/tests/unit/infrastructure/test_config_settings.py
@@ -284,7 +284,10 @@ class TestYamlConfigToDomain:
         assert isinstance(result_method, PipelineConfig)
         assert result_method.pipeline_name == result_function.pipeline_name
         assert result_method.provider == result_function.provider
-        assert result_method.dq.soft_fail_threshold == result_function.dq.soft_fail_threshold
+        assert (
+            result_method.dq.soft_fail_threshold
+            == result_function.dq.soft_fail_threshold
+        )
 
     def test_gold_filters_config_to_domain_method(self) -> None:
         """Test GoldFiltersConfig.to_domain() method."""

--- a/tests/unit/interfaces/test_cli.py
+++ b/tests/unit/interfaces/test_cli.py
@@ -120,7 +120,9 @@ class TestHandleDestructiveRunConfirmation:
         assert result is False
         mock_preview.assert_called_once_with("pubchem_compound")
 
-    @patch("bioetl.interfaces.cli.commands.run_helpers.click.confirm", return_value=True)
+    @patch(
+        "bioetl.interfaces.cli.commands.run_helpers.click.confirm", return_value=True
+    )
     def test_rebuild_with_confirmation_returns_true(self, mock_confirm):
         """Test that rebuild with user confirmation returns True."""
         result = _handle_destructive_run_confirmation(

--- a/tests/unit/interfaces/test_exit_codes.py
+++ b/tests/unit/interfaces/test_exit_codes.py
@@ -168,7 +168,9 @@ class TestExitCodeIntegration:
 
                 assert ConfigValidationError is not None
             else:
-                pytest.skip(f"Exception {exc_name} not found - may be defined elsewhere")
+                pytest.skip(
+                    f"Exception {exc_name} not found - may be defined elsewhere"
+                )
 
     def test_exit_codes_are_unique(self) -> None:
         """BioETL-specific exit codes must be unique (no collisions)."""
@@ -182,4 +184,6 @@ class TestExitCodeIntegration:
             ExitCode.NETWORK_ERROR,
             ExitCode.CHECKPOINT_ERROR,
         ]
-        assert len(bioetl_codes) == len(set(bioetl_codes)), "BioETL codes must be unique"
+        assert len(bioetl_codes) == len(
+            set(bioetl_codes)
+        ), "BioETL codes must be unique"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -270,7 +270,6 @@ class TestRunCommandAdvanced:
         """Test run command handles ValueError during bootstrap."""
         mock_create_runner.side_effect = ValueError("Invalid config")
 
-
         result = runner.invoke(cli, ["run", "--pipeline", "chembl_activity"])
 
         assert result.exit_code == ExitCode.CONFIG_ERROR


### PR DESCRIPTION
- Apply black and isort formatting fixes to 67 files
- Reduce domain layer CC to <= 5 by extracting validation helpers:
  - identifiers.py: Extract _coerce_to_int, _validate_format, _strip_url_prefix
  - pipeline_run.py: Extract _validate_stage_name, _validate_stage_completion, _validate_stage_result, _assert_can_complete
  - quarantine_entry.py: Extract _validate_quarantine_required_fields
- Fix unused argument warning in NoOpMemoryMonitor.calculate_max_batch_size