### PR TITLE
Remove Infrastructure imports from Application layer

### DIFF
--- a/scripts/check_application_deps.py
+++ b/scripts/check_application_deps.py
@@ -21,9 +21,8 @@ FORBIDDEN_PREFIXES = [
 ]
 
 # Allowed exceptions (factory classes that wire up dependencies)
-ALLOWED_FILES = [
-    "chembl_activity.py",  # Factory needs to import infrastructure
-]
+# NOTE: Empty list - all application layer files must follow architecture rules
+ALLOWED_FILES: list[str] = []
 
 
 def get_imports(filepath: Path) -> list[str]:


### PR DESCRIPTION
The exception for chembl_activity.py in check_application_deps.py was stale - the file doesn't exist (actual file is activity.py) and the application layer already follows Hexagonal Architecture rules with no infrastructure imports.

This removes the unnecessary exception and enforces strict layer boundaries for all application layer files.