### PR TITLE
Standardize error handling across data adapters

### DIFF
--- a/src/bioetl/infrastructure/adapters/base.py
+++ b/src/bioetl/infrastructure/adapters/base.py
@@ -1,11 +1,19 @@
 """Base HTTP adapter for BioETL infrastructure.
 
 Provides common functionality for adapters interacting with HTTP APIs,
-including lifecycle management (context manager) and health checks.
+including lifecycle management (context manager), health checks, and
+unified error handling.
 
 Uses Template Method pattern for health checks: subclasses implement
 _probe_health() for provider-specific probes, with automatic fallback
 to circuit breaker assessment on failure.
+
+Error Handling (RULES.md §4.1):
+All adapters use AdapterErrorHandler for unified error classification,
+logging, and exception wrapping. This ensures consistent behavior:
+- CRITICAL errors (401, 403): Fail immediately
+- RECOVERABLE errors (429, 5xx): Retry with exponential backoff
+- DATA_QUALITY errors: Log and skip record
 """
 
 from __future__ import annotations
@@ -17,6 +25,7 @@ from typing import TYPE_CHECKING, Self
 from bioetl.domain.ports import DataSourcePort, LoggerPort
 from bioetl.domain.ports.health_check import HealthCheckResult
 from bioetl.domain.types import HealthStatus
+from bioetl.infrastructure.adapters.error_handling import AdapterErrorHandler
 from bioetl.infrastructure.adapters.http.health import (
     assess_health_from_circuit_breaker,
 )
@@ -35,6 +44,10 @@ class BaseHttpAdapter(DataSourcePort):
     - _probe_health(): Override for provider-specific health probe
     - _fallback_health_status(): Fallback using circuit breaker state
 
+    Provides unified error handling via AdapterErrorHandler:
+    - _error_handler: Lazily initialized error handler
+    - Use _error_handler.handle_error() in catch blocks
+
     Attributes:
         http_client: UnifiedHTTPClient instance for making HTTP requests.
         provider_name: Unique identifier for the data provider.
@@ -46,6 +59,9 @@ class BaseHttpAdapter(DataSourcePort):
     provider_name: str
     logger: LoggerPort
 
+    # Lazily initialized error handler
+    _error_handler_instance: AdapterErrorHandler | None = None
+
     def __init__(self, http_client: UnifiedHTTPClient, logger: LoggerPort) -> None:
         """Initialize BaseAdapter.
 
@@ -56,6 +72,22 @@ class BaseHttpAdapter(DataSourcePort):
         """
         self.http_client = http_client
         self.logger = logger
+        self._error_handler_instance = None
+
+    @property
+    def _error_handler(self) -> AdapterErrorHandler:
+        """Get or create error handler (lazy initialization).
+
+        Returns:
+            AdapterErrorHandler configured for this adapter.
+        """
+        if self._error_handler_instance is None:
+            self._error_handler_instance = AdapterErrorHandler(
+                logger=self.logger,
+                provider=self.provider_name,
+                circuit_breaker=getattr(self.http_client, "circuit_breaker", None),
+            )
+        return self._error_handler_instance
 
     async def __aenter__(self) -> Self:
         """Enter async context manager.

--- a/src/bioetl/infrastructure/adapters/chembl/client.py
+++ b/src/bioetl/infrastructure/adapters/chembl/client.py
@@ -5,10 +5,11 @@ See RULES.md Appendix A for rate limits and retry strategy.
 
 Uses chembl_webresource_client library for API access.
 
-Error Handling (RULES.md §3.1):
-- Critical errors: Fail immediately (401, 403)
-- Recoverable errors: Handled by UnifiedHTTPClient retry
-- Data quality errors: Log and skip record
+Error Handling (RULES.md §4.1):
+Uses unified AdapterErrorHandler for consistent error classification:
+- CRITICAL errors (401, 403): Fail immediately with AuthFailureError
+- RECOVERABLE errors (429, 5xx): Retry with exponential backoff
+- DATA_QUALITY errors: Log and skip record
 
 Health-Aware Fetching:
 - Uses circuit breaker state for health-aware batch sizing
@@ -22,8 +23,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, NoReturn
 
-from bioetl.domain.error_classifier import ErrorClassifier
-from bioetl.domain.exceptions import ChemblApiError, CriticalError
+from bioetl.domain.exceptions import CriticalError
 from bioetl.domain.ports.noop import NoOpMetrics
 from bioetl.domain.resilience import AdapterConfig
 from bioetl.domain.types import HealthStatus
@@ -103,11 +103,6 @@ class ChemblAdapter(BaseHttpAdapter):
     # Resolved configuration values (computed in __post_init__)
     _page_size: int = field(init=False, default=1000)
     _filter_batch_size: int = field(init=False, default=20)
-
-    # Error classifier for logging purposes (no state tracking)
-    _error_classifier: ErrorClassifier = field(
-        init=False, default_factory=ErrorClassifier
-    )
 
     # Entity mapper for URL and key resolution
     _mapper: ChemblEntityMapper = field(init=False, default_factory=ChemblEntityMapper)
@@ -299,46 +294,27 @@ class ChemblAdapter(BaseHttpAdapter):
                 break
 
     def _handle_error(self, e: Exception, context: str = "fetch") -> NoReturn:
-        """Handle fetch errors with classification and logging.
+        """Handle fetch errors with unified error handling.
 
-        Error tracking is handled by the circuit breaker in UnifiedHTTPClient,
-        so this method focuses on classification and logging only.
+        Uses AdapterErrorHandler for consistent error classification, logging,
+        and exception wrapping across all adapters.
 
         Args:
             e: The exception that occurred
             context: Operation context for logging (e.g., "fetch", "health_check")
 
         Raises:
-            CriticalError: For auth failures and other critical errors
-            ChemblApiError: For recoverable and other errors
-
+            AuthFailureError: For 401/403 authentication failures (CRITICAL)
+            RateLimitError: For 429 rate limit errors (RECOVERABLE)
+            TimeoutError: For 502/504 gateway errors (RECOVERABLE)
+            NetworkError: For other server errors (RECOVERABLE)
         """
-        # Classify the error for logging
-        error_type = self._error_classifier.classify(e)
-        failure_count = self.http_client.circuit_breaker.get_failure_count()
-        health_status = self._get_health_status()
-
-        # Log with full context
-        self.logger.error(
-            "chembl_error",
-            provider="chembl",
-            operation=context,
-            error=str(e),
-            error_type=error_type.value,
-            is_critical=error_type.is_critical(),
-            is_recoverable=error_type.is_recoverable(),
-            circuit_breaker_failures=failure_count,
-            health_status=health_status.value,
+        # Use unified error handler for consistent behavior
+        self._error_handler.handle_error(
+            e,
+            context,
+            health_status=self._get_health_status().value,
         )
-
-        # Critical errors should fail immediately
-        if error_type.is_critical():
-            raise CriticalError(
-                f"Critical ChEMBL error ({error_type.value}): {e}"
-            ) from e
-
-        # Wrap in ChemblApiError for consistent handling
-        raise ChemblApiError(str(e)) from e
 
     async def _fetch_filtered(
         self,
@@ -474,13 +450,8 @@ class ChemblAdapter(BaseHttpAdapter):
                 response = await self.http_client.get(CHEMBL_STATUS_URL)
             return self._handle_health_response(response)
         except Exception as e:
-            error_type = self._error_classifier.classify(e)
-            self.logger.warning(
-                "health_check_failed",
-                provider=self.provider_name,
-                error_type=error_type.value,
-                error=str(e),
-            )
+            # Use unified error handler for consistent logging
+            self._error_handler.log_error("health_check", e)
             raise  # Let base class handle via _fallback_health_status()
 
     def _fallback_health_status(self) -> HealthStatus:

--- a/src/bioetl/infrastructure/adapters/error_handling.py
+++ b/src/bioetl/infrastructure/adapters/error_handling.py
@@ -1,0 +1,422 @@
+"""Unified error handling for BioETL adapters.
+
+Provides standardized error classification, logging, and wrapping
+for all DataSourcePort adapters. Implements RULES.md §4.1 error categories.
+
+Error Categories (§4.1):
+- CRITICAL: Fail pipeline immediately (401, 403, auth failures)
+- RECOVERABLE: Retry with exponential backoff (429, 5xx, timeouts)
+- DATA_QUALITY: Log and skip record (validation errors)
+
+Usage:
+    >>> handler = AdapterErrorHandler(logger, provider="chembl")
+    >>> try:
+    ...     response = await http_client.get(url)
+    >>> except Exception as e:
+    ...     handler.handle_error(e, operation="fetch_activities")
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import TYPE_CHECKING, Any, NoReturn
+
+from bioetl.domain.error_classifier import ErrorClassifier
+from bioetl.domain.exceptions import (
+    AuthFailureError,
+    NetworkError,
+    RateLimitError,
+    TimeoutError,
+)
+from bioetl.domain.types import ErrorType
+
+if TYPE_CHECKING:
+    from httpx import Response
+
+    from bioetl.domain.ports import LoggerPort
+    from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
+
+
+class ErrorCategory(str, Enum):
+    """Error category for adapter error handling (RULES.md §4.1).
+
+    Determines pipeline behavior on error:
+    - CRITICAL: Fail pipeline immediately
+    - RECOVERABLE: Retry with exponential backoff
+    - DATA_QUALITY: Log and skip record (quarantine)
+    """
+
+    CRITICAL = "CRITICAL"
+    """Fail pipeline immediately. Examples: 401, 403, auth failures."""
+
+    RECOVERABLE = "RECOVERABLE"
+    """Retry with exponential backoff. Examples: 429, 5xx, timeouts."""
+
+    DATA_QUALITY = "DATA_QUALITY"
+    """Log and skip record. Examples: validation errors, malformed data."""
+
+
+# HTTP status code to category mapping
+_HTTP_STATUS_CATEGORIES: dict[int, ErrorCategory] = {
+    # Authentication errors (CRITICAL)
+    401: ErrorCategory.CRITICAL,
+    403: ErrorCategory.CRITICAL,
+    # Rate limit (RECOVERABLE)
+    429: ErrorCategory.RECOVERABLE,
+    # Server errors (RECOVERABLE)
+    500: ErrorCategory.RECOVERABLE,
+    502: ErrorCategory.RECOVERABLE,
+    503: ErrorCategory.RECOVERABLE,
+    504: ErrorCategory.RECOVERABLE,
+}
+
+
+def classify_http_status(status_code: int) -> ErrorCategory:
+    """Classify HTTP status code into error category.
+
+    Args:
+        status_code: HTTP response status code.
+
+    Returns:
+        ErrorCategory based on status code.
+        - 401, 403 → CRITICAL (auth failures)
+        - 429 → RECOVERABLE (rate limit)
+        - 5xx → RECOVERABLE (server errors)
+        - 4xx (other) → DATA_QUALITY (client errors, bad requests)
+    """
+    if status_code in _HTTP_STATUS_CATEGORIES:
+        return _HTTP_STATUS_CATEGORIES[status_code]
+
+    # Default classification by range
+    if 400 <= status_code < 500:
+        return ErrorCategory.DATA_QUALITY
+    if status_code >= 500:
+        return ErrorCategory.RECOVERABLE
+
+    # Success codes shouldn't be classified as errors
+    return ErrorCategory.DATA_QUALITY
+
+
+def extract_retry_after(response: Response) -> float | None:
+    """Extract Retry-After value from response headers.
+
+    Args:
+        response: HTTP response object.
+
+    Returns:
+        Retry-After value in seconds, or None if not present.
+    """
+    retry_after = response.headers.get("Retry-After")
+    if retry_after is None:
+        return None
+
+    try:
+        return float(retry_after)
+    except ValueError:
+        # Retry-After might be a date string, ignore for now
+        return None
+
+
+class AdapterErrorHandler:
+    """Unified error handler for DataSourcePort adapters.
+
+    Provides standardized error classification, logging, and exception wrapping.
+    All adapters MUST use this handler to ensure consistent behavior.
+
+    Attributes:
+        logger: LoggerPort for structured logging.
+        provider: Provider name for log context.
+        error_classifier: Domain error classifier.
+
+    Example:
+        >>> handler = AdapterErrorHandler(logger, provider="chembl")
+        >>> # In adapter fetch method:
+        >>> try:
+        ...     response = await self.http_client.get(url)
+        >>> except Exception as e:
+        ...     handler.handle_error(e, "fetch_activities")
+    """
+
+    def __init__(
+        self,
+        logger: LoggerPort,
+        provider: str,
+        circuit_breaker: CircuitBreaker | None = None,
+    ) -> None:
+        """Initialize error handler.
+
+        Args:
+            logger: LoggerPort for structured logging.
+            provider: Provider name (e.g., "chembl", "uniprot").
+            circuit_breaker: Optional circuit breaker for state reporting.
+        """
+        self._logger = logger
+        self._provider = provider
+        self._circuit_breaker = circuit_breaker
+        self._error_classifier = ErrorClassifier()
+
+    @property
+    def provider(self) -> str:
+        """Get provider name."""
+        return self._provider
+
+    def classify_error(self, error: Exception) -> ErrorCategory:
+        """Classify exception into error category.
+
+        Uses domain ErrorClassifier to determine error type, then maps
+        to ErrorCategory for adapter-level handling.
+
+        Args:
+            error: Exception to classify.
+
+        Returns:
+            ErrorCategory for the exception.
+        """
+        error_type = self._error_classifier.classify(error)
+        return self._error_type_to_category(error_type)
+
+    def classify_http_error(
+        self, status_code: int, response: Response | None = None
+    ) -> ErrorCategory:
+        """Classify HTTP error by status code.
+
+        Args:
+            status_code: HTTP response status code.
+            response: Optional response object for additional context.
+
+        Returns:
+            ErrorCategory based on status code.
+        """
+        return classify_http_status(status_code)
+
+    def should_retry(self, error: Exception) -> bool:
+        """Check if error should trigger a retry.
+
+        Args:
+            error: Exception to check.
+
+        Returns:
+            True if error is recoverable and should be retried.
+        """
+        category = self.classify_error(error)
+        return category == ErrorCategory.RECOVERABLE
+
+    def log_error(
+        self,
+        operation: str,
+        error: Exception,
+        *,
+        status_code: int | None = None,
+        retry_count: int | None = None,
+        **extra_context: Any,
+    ) -> None:
+        """Log error with unified structured format.
+
+        Logs error in JSON format suitable for parsing and monitoring.
+        Includes provider context, error classification, and circuit breaker state.
+
+        Args:
+            operation: Operation that failed (e.g., "fetch_activities").
+            error: Exception that occurred.
+            status_code: Optional HTTP status code.
+            retry_count: Optional retry attempt number.
+            **extra_context: Additional context to include in log.
+        """
+        error_type = self._error_classifier.classify(error)
+        category = self._error_type_to_category(error_type)
+
+        # Build log context
+        log_context: dict[str, Any] = {
+            "provider": self._provider,
+            "operation": operation,
+            "error_category": category.value,
+            "error_type": error_type.value,
+            "error_message": str(error),
+            "error_class": type(error).__name__,
+        }
+
+        if status_code is not None:
+            log_context["status_code"] = status_code
+
+        if retry_count is not None:
+            log_context["retry_count"] = retry_count
+
+        # Add circuit breaker state if available
+        if self._circuit_breaker is not None:
+            try:
+                log_context["circuit_breaker_state"] = (
+                    self._circuit_breaker.get_state().value
+                )
+                log_context["circuit_breaker_failures"] = (
+                    self._circuit_breaker.get_failure_count()
+                )
+            except Exception:
+                pass
+
+        # Add extra context
+        log_context.update(extra_context)
+
+        # Log at appropriate level based on category
+        if category == ErrorCategory.CRITICAL:
+            self._logger.error("external_api_error", **log_context)
+        else:
+            self._logger.warning("external_api_error", **log_context)
+
+    def wrap_error(
+        self,
+        error: Exception,
+        operation: str,
+        *,
+        status_code: int | None = None,
+        response: Response | None = None,
+    ) -> Exception:
+        """Wrap error in appropriate domain exception.
+
+        Converts generic exceptions to domain exceptions based on classification.
+        Used for consistent exception types across all adapters.
+
+        Args:
+            error: Original exception.
+            operation: Operation context for error message.
+            status_code: HTTP status code if available.
+            response: HTTP response if available.
+
+        Returns:
+            Wrapped domain exception.
+        """
+        # Determine status code from response if not provided
+        if status_code is None and response is not None:
+            status_code = response.status_code
+
+        # If already a domain exception, return as-is
+        from bioetl.domain.exceptions import BioETLError
+
+        if isinstance(error, BioETLError):
+            return error
+
+        # Wrap based on status code or error classification
+        if status_code is not None:
+            return self._wrap_http_error(error, status_code, response)
+
+        # Classify and wrap
+        category = self.classify_error(error)
+        return self._wrap_by_category(error, category)
+
+    def handle_error(
+        self,
+        error: Exception,
+        operation: str,
+        *,
+        status_code: int | None = None,
+        response: Response | None = None,
+        retry_count: int | None = None,
+        **extra_context: Any,
+    ) -> NoReturn:
+        """Handle error with logging and re-raise as wrapped exception.
+
+        This is the main entry point for adapter error handling.
+        Logs the error with full context, then raises wrapped exception.
+
+        Args:
+            error: Exception that occurred.
+            operation: Operation that failed.
+            status_code: Optional HTTP status code.
+            response: Optional HTTP response.
+            retry_count: Optional retry attempt number.
+            **extra_context: Additional context for logging.
+
+        Raises:
+            AuthFailureError: For 401/403 errors (CRITICAL).
+            RateLimitError: For 429 errors (RECOVERABLE).
+            TimeoutError: For 502/504 errors (RECOVERABLE).
+            NetworkError: For other server errors (RECOVERABLE).
+        """
+        # Determine status code
+        effective_status_code = status_code
+        if effective_status_code is None and response is not None:
+            effective_status_code = response.status_code
+
+        # Log the error
+        self.log_error(
+            operation,
+            error,
+            status_code=effective_status_code,
+            retry_count=retry_count,
+            **extra_context,
+        )
+
+        # Wrap and raise
+        wrapped = self.wrap_error(
+            error, operation, status_code=effective_status_code, response=response
+        )
+        raise wrapped from error
+
+    def _error_type_to_category(self, error_type: ErrorType) -> ErrorCategory:
+        """Map ErrorType to ErrorCategory."""
+        if error_type.is_critical():
+            return ErrorCategory.CRITICAL
+        if error_type.is_recoverable():
+            return ErrorCategory.RECOVERABLE
+        return ErrorCategory.DATA_QUALITY
+
+    def _wrap_http_error(
+        self,
+        error: Exception,
+        status_code: int,
+        response: Response | None,
+    ) -> Exception:
+        """Wrap HTTP error based on status code."""
+        # Authentication errors (401, 403)
+        if status_code in (401, 403):
+            return AuthFailureError(
+                provider=self._provider,
+                status_code=status_code,
+            )
+
+        # Rate limit (429)
+        if status_code == 429:
+            retry_after = 60.0  # Default retry after
+            if response is not None:
+                extracted = extract_retry_after(response)
+                if extracted is not None:
+                    retry_after = extracted
+            return RateLimitError(
+                provider=self._provider,
+                retry_after=retry_after,
+            )
+
+        # Gateway errors (502, 504)
+        if status_code in (502, 504):
+            return TimeoutError(
+                f"{self._provider} gateway error: {status_code}",
+                timeout_seconds=None,
+            )
+
+        # Other server errors (5xx)
+        if status_code >= 500:
+            return NetworkError(
+                f"{self._provider} server error: {status_code}",
+                cause=error,
+            )
+
+        # Client errors (4xx) - return as-is or wrap in NetworkError
+        return NetworkError(
+            f"{self._provider} client error: {status_code}",
+            cause=error,
+        )
+
+    def _wrap_by_category(
+        self, error: Exception, category: ErrorCategory
+    ) -> Exception:
+        """Wrap error based on category."""
+        if category == ErrorCategory.CRITICAL:
+            return AuthFailureError(
+                provider=self._provider,
+                status_code=None,
+            )
+
+        # Default to NetworkError for recoverable/unknown
+        return NetworkError(
+            f"{self._provider} error: {error}",
+            cause=error,
+        )

--- a/src/bioetl/infrastructure/adapters/pubchem/client.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/client.py
@@ -8,6 +8,12 @@ Requirements:
 - Health: lightweight query
 - Entities: compounds, substances, assays, bioassays
 
+Error Handling (RULES.md §4.1):
+Uses unified AdapterErrorHandler for consistent error classification:
+- CRITICAL errors (401, 403): Fail immediately with AuthFailureError
+- RECOVERABLE errors (429, 5xx): Retry with exponential backoff
+- DATA_QUALITY errors: Log and skip record
+
 Documentation: https://pubchemdocs.ncbi.nlm.nih.gov/pug-rest
 """
 
@@ -18,7 +24,6 @@ from typing import TYPE_CHECKING, Any
 
 import pubchempy as pcp
 
-from bioetl.domain.error_classifier import ErrorClassifier
 from bioetl.domain.exceptions import CircuitBreakerOpenError
 from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.adapters.sync_base import BaseSyncAdapter
@@ -266,14 +271,8 @@ class PubChemAdapter(BaseSyncAdapter):
             return HealthStatus.UNHEALTHY
 
         except Exception as e:
-            error_classifier = ErrorClassifier()
-            error_type = error_classifier.classify(e)
-            self.logger.warning(
-                "health_check_failed",
-                provider=self.provider_name,
-                error_type=error_type.value,
-                error=str(e),
-            )
+            # Use unified error handler for consistent logging
+            self._error_handler.log_error("health_check", e)
             raise  # Let base class handle via _fallback_health_status()
 
     def _get_health_endpoint(self) -> str:

--- a/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
+++ b/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
@@ -1,11 +1,22 @@
-# src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
+"""PubMed API client adapter.
+
+Implements RULES.md Appendix A - PubMed/NCBI Entrez specifications.
+
+Error Handling (RULES.md §4.1):
+Uses unified AdapterErrorHandler for consistent error classification:
+- CRITICAL errors (401, 403): Fail immediately with AuthFailureError
+- RECOVERABLE errors (429, 5xx): Retry with exponential backoff
+- DATA_QUALITY errors: Log and skip record
+
+Documentation: https://www.ncbi.nlm.nih.gov/books/NBK25497/
+"""
+
 from __future__ import annotations
 
 import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from bioetl.domain.exceptions import ApiError
 from bioetl.domain.ports.noop import NoOpMetrics
 from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.adapters.base import BaseHttpAdapter
@@ -83,8 +94,10 @@ class PubMedAdapter(BaseHttpAdapter):
             idlist: list[str] = data.get("esearchresult", {}).get("idlist", [])
             return idlist
         except Exception as e:
-            self.logger.error("Failed to fetch PMIDs", error=str(e))
-            raise ApiError(f"PubMed search failed: {e}") from e
+            # Use unified error handler for consistent behavior
+            self._error_handler.handle_error(
+                e, "search", search_term=search_term, max_count=max_count
+            )
 
     def _build_fetch_params(self, id_batch: list[str]) -> dict[str, str]:
         """Build parameters for efetch API call."""
@@ -114,8 +127,10 @@ class PubMedAdapter(BaseHttpAdapter):
                 return []
             return PubMedXmlProcessor.extract_all_records(root)
         except Exception as e:
-            self.logger.error("Batch fetch failed", error=str(e))
-            raise ApiError(f"PubMed fetch failed: {e}") from e
+            # Use unified error handler for consistent behavior
+            self._error_handler.handle_error(
+                e, "fetch_batch", batch_size=len(id_batch)
+            )
 
     async def _yield_articles_from_pmids(
         self, pmids: list[str], limit: int | None
@@ -252,10 +267,8 @@ class PubMedAdapter(BaseHttpAdapter):
             return HealthStatus.HEALTHY
 
         except Exception as e:
-            self.logger.warning(
-                "pubmed_health_check_failed",
-                error=str(e),
-            )
+            # Use unified error handler for consistent logging
+            self._error_handler.log_error("health_check", e)
             raise  # Let health_check() return _fallback_health_status()
 
     def _fallback_health_status(self) -> HealthStatus:

--- a/src/bioetl/infrastructure/adapters/sync_base.py
+++ b/src/bioetl/infrastructure/adapters/sync_base.py
@@ -6,6 +6,13 @@ Provides common functionality for adapters that must use synchronous libraries
 Uses Template Method pattern for health checks: subclasses implement
 _probe_health() for provider-specific probes, with automatic fallback
 to circuit breaker assessment on failure.
+
+Error Handling (RULES.md §4.1):
+All adapters use AdapterErrorHandler for unified error classification,
+logging, and exception wrapping. This ensures consistent behavior:
+- CRITICAL errors (401, 403): Fail immediately
+- RECOVERABLE errors (429, 5xx): Retry with exponential backoff
+- DATA_QUALITY errors: Log and skip record
 """
 
 from __future__ import annotations
@@ -19,6 +26,7 @@ from typing import TYPE_CHECKING, Any, Self
 from bioetl.domain.ports import DataSourcePort, LoggerPort, MetricsPort, NoOpMetrics
 from bioetl.domain.ports.health_check import HealthCheckResult
 from bioetl.domain.types import HealthStatus
+from bioetl.infrastructure.adapters.error_handling import AdapterErrorHandler
 from bioetl.infrastructure.adapters.http.health import (
     assess_health_from_circuit_breaker,
 )
@@ -39,6 +47,10 @@ class BaseSyncAdapter(DataSourcePort):
     - _probe_health(): Override for provider-specific health probe
     - _fallback_health_status(): Fallback using circuit breaker state
 
+    Provides unified error handling via AdapterErrorHandler:
+    - _error_handler: Lazily initialized error handler
+    - Use _error_handler.handle_error() in catch blocks
+
     Attributes:
         provider_name: Unique identifier for the data provider.
         logger: LoggerPort instance for structured logging.
@@ -55,6 +67,9 @@ class BaseSyncAdapter(DataSourcePort):
     rate_limiter: TokenBucket
     circuit_breaker: CircuitBreaker
     thread_pool: ThreadPoolExecutor
+
+    # Lazily initialized error handler
+    _error_handler_instance: AdapterErrorHandler | None = None
 
     def __init__(
         self,
@@ -84,9 +99,25 @@ class BaseSyncAdapter(DataSourcePort):
         self.circuit_breaker = circuit_breaker
         self.thread_pool = thread_pool
         self.strict_error_handling = strict_error_handling
+        self._error_handler_instance = None
 
         # Safety: ensure shutdown if aclose/context manager is misused
         self._finalizer = weakref.finalize(self, self.thread_pool.shutdown, wait=False)
+
+    @property
+    def _error_handler(self) -> AdapterErrorHandler:
+        """Get or create error handler (lazy initialization).
+
+        Returns:
+            AdapterErrorHandler configured for this adapter.
+        """
+        if self._error_handler_instance is None:
+            self._error_handler_instance = AdapterErrorHandler(
+                logger=self.logger,
+                provider=self.provider_name,
+                circuit_breaker=self.circuit_breaker,
+            )
+        return self._error_handler_instance
 
     async def __aenter__(self) -> Self:
         """Enter async context manager."""

--- a/src/bioetl/infrastructure/adapters/uniprot/client.py
+++ b/src/bioetl/infrastructure/adapters/uniprot/client.py
@@ -8,6 +8,12 @@ Requirements:
 - Health check: Search probe (Ubiquitin)
 - Entities: proteins, features, sequences
 
+Error Handling (RULES.md §4.1):
+Uses unified AdapterErrorHandler for consistent error classification:
+- CRITICAL errors (401, 403): Fail immediately with AuthFailureError
+- RECOVERABLE errors (429, 5xx): Retry with exponential backoff
+- DATA_QUALITY errors: Log and skip record
+
 Documentation: https://www.uniprot.org/help/api
 """
 
@@ -18,7 +24,6 @@ from typing import TYPE_CHECKING, Any
 
 from typing_extensions import override
 
-from bioetl.domain.error_classifier import ErrorClassifier
 from bioetl.domain.ports.noop import NoOpMetrics
 from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.adapters.base import BaseHttpAdapter
@@ -160,26 +165,47 @@ class UniProtAdapter(BaseHttpAdapter, PaginatedFetcherMixin):
                         f"{self.base_url}/uniprotkb/search", params=params
                     )
                 return self._parse_response(response)
-            except Exception:
-                self._handle_fetch_error("protein", query, cursor)
+            except Exception as e:
+                self._handle_fetch_error("protein", query, cursor, error=e)
                 return [], None
 
         async for item in self.paginated_fetch(_pagination_callback, limit=limit):
             yield item
 
     def _handle_fetch_error(
-        self, entity_type: str, query: str | None, cursor: str | None = None
+        self,
+        entity_type: str,
+        query: str | None,
+        cursor: str | None = None,
+        error: Exception | None = None,
     ) -> None:
-        """Handle fetch errors centrally."""
-        self.logger.error(
-            f"uniprot {entity_type} fetch failed",
-            provider="uniprot",
-            operation=f"{entity_type} fetch",
+        """Handle fetch errors with unified error handling.
+
+        Uses AdapterErrorHandler for consistent error classification, logging,
+        and exception wrapping across all adapters.
+
+        Args:
+            entity_type: Type of entity being fetched (protein, feature, sequence)
+            query: Query string used for fetch
+            cursor: Pagination cursor if applicable
+            error: The exception that occurred (optional for backward compat)
+
+        Raises:
+            Exception: In strict mode, re-raises the original exception
+        """
+        # Create a synthetic error if none provided
+        if error is None:
+            error = RuntimeError(f"UniProt {entity_type} fetch failed")
+
+        # Use unified error handler for consistent logging
+        self._error_handler.log_error(
+            f"{entity_type}_fetch",
+            error,
             query=query,
             cursor=cursor,
         )
         if self.strict_error_handling:
-            raise
+            raise error
 
     async def _get_features_json(self, query: str) -> list[dict[str, Any]]:
         """Retrieve features JSON."""
@@ -192,8 +218,8 @@ class UniProtAdapter(BaseHttpAdapter, PaginatedFetcherMixin):
                 features: list[dict[str, Any]] = response.json().get("features", [])
                 return features
             return []
-        except Exception:
-            self._handle_fetch_error("feature", query)
+        except Exception as e:
+            self._handle_fetch_error("feature", query, error=e)
             return []
 
     async def _fetch_features(
@@ -232,8 +258,8 @@ class UniProtAdapter(BaseHttpAdapter, PaginatedFetcherMixin):
                 text: str = response.text
                 return text
             return None
-        except Exception:
-            self._handle_fetch_error("sequence", query)
+        except Exception as e:
+            self._handle_fetch_error("sequence", query, error=e)
             return None
 
     async def _get_parsed_sequences(self, query: str) -> AsyncIterator[dict[str, Any]]:
@@ -290,14 +316,8 @@ class UniProtAdapter(BaseHttpAdapter, PaginatedFetcherMixin):
             # On success, return circuit breaker assessment (original behavior)
             return self._fallback_health_status()
         except Exception as e:
-            error_classifier = ErrorClassifier()
-            error_type = error_classifier.classify(e)
-            self.logger.warning(
-                "health_check_failed",
-                provider=self.provider_name,
-                error_type=error_type.value,
-                error=str(e),
-            )
+            # Use unified error handler for consistent logging
+            self._error_handler.log_error("health_check", e)
             raise  # Base class catches and returns _fallback_health_status()
 
     def _get_health_endpoint(self) -> str:

--- a/tests/unit/infrastructure/adapters/chembl/test_chembl_client.py
+++ b/tests/unit/infrastructure/adapters/chembl/test_chembl_client.py
@@ -6,7 +6,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from bioetl.domain.exceptions import ChemblApiError, CriticalError, RateLimitError
+from bioetl.domain.exceptions import (
+    CriticalError,
+    NetworkError,
+    RateLimitError,
+)
 from bioetl.domain.types import CircuitBreakerState, ErrorType, HealthStatus
 from bioetl.infrastructure.adapters.chembl.client import ChemblAdapter
 
@@ -190,10 +194,13 @@ async def test_fetch_with_filter_deduplicates_across_pages(adapter, mock_http_cl
 
 @pytest.mark.asyncio
 async def test_fetch_error(adapter, mock_http_client):
-    """Test API error handling."""
+    """Test API error handling.
+
+    Uses unified error handler which wraps generic exceptions in NetworkError.
+    """
     mock_http_client.get.side_effect = Exception("API Error")
 
-    with pytest.raises(ChemblApiError):
+    with pytest.raises(NetworkError):
         async for _ in adapter.fetch("activity"):
             pass
 
@@ -272,18 +279,22 @@ class TestChemblAdapterErrorClassification:
     async def test_error_classification_logged(
         self, adapter, mock_http_client, mock_logger
     ):
-        """Test that error type is classified and logged."""
+        """Test that error type is classified and logged.
+
+        Uses unified error handler which logs at warning level for
+        recoverable errors (RULES.md §4.1).
+        """
         mock_http_client.get.side_effect = RateLimitError("chembl", 60.0)
 
-        with pytest.raises(ChemblApiError):
+        with pytest.raises(RateLimitError):
             async for _ in adapter.fetch("activity"):
                 pass
 
-        # Verify error was logged with classification
-        mock_logger.error.assert_called()
-        call_kwargs = mock_logger.error.call_args.kwargs
+        # Verify error was logged with unified format
+        mock_logger.warning.assert_called()
+        call_kwargs = mock_logger.warning.call_args.kwargs
         assert call_kwargs["error_type"] == ErrorType.RATE_LIMIT.value
-        assert call_kwargs["is_recoverable"] is True
+        assert call_kwargs["error_category"] == "RECOVERABLE"
 
     @pytest.mark.asyncio
     async def test_circuit_breaker_failure_count_accessed(
@@ -295,7 +306,7 @@ class TestChemblAdapterErrorClassification:
         """
         mock_http_client.get.side_effect = RateLimitError("chembl", 60.0)
 
-        with pytest.raises(ChemblApiError):
+        with pytest.raises(RateLimitError):
             async for _ in adapter.fetch("activity"):
                 pass
 

--- a/tests/unit/infrastructure/adapters/pubmed/test_pubmed_client.py
+++ b/tests/unit/infrastructure/adapters/pubmed/test_pubmed_client.py
@@ -194,12 +194,16 @@ async def test_health_check_returns_degraded_on_slow_response(
 async def test_health_check_logs_error_on_exception(
     adapter, mock_http_client, mock_logger
 ):
-    """Test health_check logs error details on exception."""
+    """Test health_check logs error details on exception.
+
+    Uses unified error handler for consistent log format (RULES.md §4.1).
+    """
     mock_http_client.get = AsyncMock(side_effect=Exception("Network timeout"))
 
     await adapter.health_check()
 
     mock_logger.warning.assert_called_once()
     call_args = mock_logger.warning.call_args
-    assert call_args[0][0] == "pubmed_health_check_failed"
-    assert "Network timeout" in call_args[1]["error"]
+    # Unified error handler logs as "external_api_error"
+    assert call_args[0][0] == "external_api_error"
+    assert "Network timeout" in call_args[1]["error_message"]

--- a/tests/unit/infrastructure/adapters/test_client_error_paths.py
+++ b/tests/unit/infrastructure/adapters/test_client_error_paths.py
@@ -79,7 +79,11 @@ class TestUniProtAdapterErrorPaths:
     async def test_fetch_proteins_logs_error_on_failure(
         self, mock_http_client, mock_logger
     ):
-        """Test that _fetch_proteins logs error when fetch fails."""
+        """Test that _fetch_proteins logs error when fetch fails.
+
+        Uses unified error handler which logs at warning level for
+        recoverable errors (RULES.md §4.1).
+        """
         from bioetl.infrastructure.adapters.uniprot.client import UniProtAdapter
 
         with patch.dict(
@@ -99,12 +103,12 @@ class TestUniProtAdapterErrorPaths:
             # Should return empty results on failure
             assert results == []
 
-            # Should have logged the error via injected logger
-            mock_logger.error.assert_called()
+            # Should have logged the error via unified error handler (warning level)
+            mock_logger.warning.assert_called()
             # Verify the error message contains expected context
-            call_args = mock_logger.error.call_args
+            call_args = mock_logger.warning.call_args
             assert (
-                "protein fetch" in str(call_args).lower()
+                "protein_fetch" in str(call_args).lower()
                 or "network error" in str(call_args).lower()
             )
 
@@ -126,7 +130,11 @@ class TestUniProtAdapterErrorPaths:
     async def test_fetch_features_logs_error_on_failure(
         self, mock_http_client, mock_logger
     ):
-        """Test that _fetch_features logs error when fetch fails."""
+        """Test that _fetch_features logs error when fetch fails.
+
+        Uses unified error handler which logs at warning level for
+        recoverable errors (RULES.md §4.1).
+        """
         from bioetl.infrastructure.adapters.uniprot.client import UniProtAdapter
 
         with patch.dict(
@@ -148,12 +156,12 @@ class TestUniProtAdapterErrorPaths:
             # Should return empty results on failure
             assert results == []
 
-            # Should have logged the error via injected logger
-            mock_logger.error.assert_called()
+            # Should have logged the error via unified error handler (warning level)
+            mock_logger.warning.assert_called()
             # Verify the error message contains expected context
-            call_args = mock_logger.error.call_args
+            call_args = mock_logger.warning.call_args
             assert (
-                "feature fetch" in str(call_args).lower()
+                "feature_fetch" in str(call_args).lower()
                 or "timeout" in str(call_args).lower()
             )
 
@@ -175,7 +183,11 @@ class TestUniProtAdapterErrorPaths:
     async def test_fetch_sequences_logs_error_on_failure(
         self, mock_http_client, mock_logger
     ):
-        """Test that _fetch_sequences logs error when fetch fails."""
+        """Test that _fetch_sequences logs error when fetch fails.
+
+        Uses unified error handler which logs at warning level for
+        recoverable errors (RULES.md §4.1).
+        """
         from bioetl.infrastructure.adapters.uniprot.client import UniProtAdapter
 
         with patch.dict(
@@ -201,12 +213,12 @@ class TestUniProtAdapterErrorPaths:
             # Should return empty results on failure
             assert results == []
 
-            # Should have logged the error via injected logger
-            mock_logger.error.assert_called()
+            # Should have logged the error via unified error handler (warning level)
+            mock_logger.warning.assert_called()
             # Verify the error message contains expected context
-            call_args = mock_logger.error.call_args
+            call_args = mock_logger.warning.call_args
             assert (
-                "sequence fetch" in str(call_args).lower()
+                "sequence_fetch" in str(call_args).lower()
                 or "server error" in str(call_args).lower()
             )
 

--- a/tests/unit/infrastructure/adapters/test_error_handling.py
+++ b/tests/unit/infrastructure/adapters/test_error_handling.py
@@ -1,0 +1,349 @@
+"""Tests for unified adapter error handling.
+
+Tests that AdapterErrorHandler provides consistent error classification,
+logging, and exception wrapping across all adapters (RULES.md §4.1).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from bioetl.domain.exceptions import (
+    AuthFailureError,
+    NetworkError,
+    RateLimitError,
+    TimeoutError,
+)
+from bioetl.infrastructure.adapters.error_handling import (
+    AdapterErrorHandler,
+    ErrorCategory,
+    classify_http_status,
+    extract_retry_after,
+)
+
+
+class TestErrorCategory:
+    """Tests for ErrorCategory enum."""
+
+    def test_critical_value(self):
+        """Test CRITICAL category value."""
+        assert ErrorCategory.CRITICAL.value == "CRITICAL"
+
+    def test_recoverable_value(self):
+        """Test RECOVERABLE category value."""
+        assert ErrorCategory.RECOVERABLE.value == "RECOVERABLE"
+
+    def test_data_quality_value(self):
+        """Test DATA_QUALITY category value."""
+        assert ErrorCategory.DATA_QUALITY.value == "DATA_QUALITY"
+
+
+class TestClassifyHttpStatus:
+    """Tests for HTTP status code classification."""
+
+    @pytest.mark.parametrize(
+        "status_code,expected_category",
+        [
+            # Critical errors (auth failures)
+            (401, ErrorCategory.CRITICAL),
+            (403, ErrorCategory.CRITICAL),
+            # Recoverable errors (rate limit, server errors)
+            (429, ErrorCategory.RECOVERABLE),
+            (500, ErrorCategory.RECOVERABLE),
+            (502, ErrorCategory.RECOVERABLE),
+            (503, ErrorCategory.RECOVERABLE),
+            (504, ErrorCategory.RECOVERABLE),
+            # Data quality errors (client errors)
+            (400, ErrorCategory.DATA_QUALITY),
+            (404, ErrorCategory.DATA_QUALITY),
+            (422, ErrorCategory.DATA_QUALITY),
+        ],
+    )
+    def test_classify_http_status(
+        self, status_code: int, expected_category: ErrorCategory
+    ):
+        """Test HTTP status code classification."""
+        assert classify_http_status(status_code) == expected_category
+
+    def test_unknown_5xx_is_recoverable(self):
+        """Test that unknown 5xx codes are classified as RECOVERABLE."""
+        assert classify_http_status(599) == ErrorCategory.RECOVERABLE
+
+    def test_unknown_4xx_is_data_quality(self):
+        """Test that unknown 4xx codes are classified as DATA_QUALITY."""
+        assert classify_http_status(418) == ErrorCategory.DATA_QUALITY  # I'm a teapot
+
+
+class TestExtractRetryAfter:
+    """Tests for Retry-After header extraction."""
+
+    def test_extract_numeric_retry_after(self):
+        """Test extraction of numeric Retry-After value."""
+        response = MagicMock(spec=httpx.Response)
+        response.headers = {"Retry-After": "60"}
+        assert extract_retry_after(response) == 60.0
+
+    def test_extract_float_retry_after(self):
+        """Test extraction of float Retry-After value."""
+        response = MagicMock(spec=httpx.Response)
+        response.headers = {"Retry-After": "30.5"}
+        assert extract_retry_after(response) == 30.5
+
+    def test_no_retry_after_header(self):
+        """Test when Retry-After header is missing."""
+        response = MagicMock(spec=httpx.Response)
+        response.headers = {}
+        assert extract_retry_after(response) is None
+
+    def test_invalid_retry_after_header(self):
+        """Test when Retry-After header is not a number."""
+        response = MagicMock(spec=httpx.Response)
+        response.headers = {"Retry-After": "Wed, 21 Oct 2015 07:28:00 GMT"}
+        assert extract_retry_after(response) is None
+
+
+class TestAdapterErrorHandler:
+    """Tests for AdapterErrorHandler class."""
+
+    @pytest.fixture
+    def mock_logger(self):
+        """Create a mock logger."""
+        logger = MagicMock()
+        return logger
+
+    @pytest.fixture
+    def mock_circuit_breaker(self):
+        """Create a mock circuit breaker."""
+        from bioetl.infrastructure.adapters.http.circuit_breaker import (
+            CircuitBreaker,
+            CircuitBreakerState,
+        )
+
+        cb = MagicMock(spec=CircuitBreaker)
+        cb.get_state.return_value = CircuitBreakerState.CLOSED
+        cb.get_failure_count.return_value = 0
+        return cb
+
+    @pytest.fixture
+    def handler(self, mock_logger, mock_circuit_breaker):
+        """Create an error handler for testing."""
+        return AdapterErrorHandler(
+            logger=mock_logger,
+            provider="test_provider",
+            circuit_breaker=mock_circuit_breaker,
+        )
+
+    def test_provider_property(self, handler):
+        """Test provider property returns correct value."""
+        assert handler.provider == "test_provider"
+
+    def test_classify_error_with_domain_exception(self, handler):
+        """Test error classification with domain exceptions."""
+        from bioetl.domain.exceptions import RateLimitError
+
+        error = RateLimitError(provider="test", retry_after=60.0)
+        category = handler.classify_error(error)
+        assert category == ErrorCategory.RECOVERABLE
+
+    def test_classify_http_error(self, handler):
+        """Test HTTP status code classification."""
+        assert handler.classify_http_error(401) == ErrorCategory.CRITICAL
+        assert handler.classify_http_error(429) == ErrorCategory.RECOVERABLE
+        assert handler.classify_http_error(400) == ErrorCategory.DATA_QUALITY
+
+    def test_should_retry_recoverable(self, handler):
+        """Test that recoverable errors should be retried."""
+        from bioetl.domain.exceptions import RateLimitError
+
+        error = RateLimitError(provider="test", retry_after=60.0)
+        assert handler.should_retry(error) is True
+
+    def test_should_not_retry_critical(self, handler):
+        """Test that critical errors should not be retried."""
+        from bioetl.domain.exceptions import AuthFailureError
+
+        error = AuthFailureError(provider="test", status_code=401)
+        assert handler.should_retry(error) is False
+
+    def test_log_error_includes_context(self, handler, mock_logger):
+        """Test that log_error includes all context."""
+        error = RuntimeError("Test error")
+        handler.log_error("fetch", error, status_code=500, retry_count=2)
+
+        # Verify logger was called
+        mock_logger.warning.assert_called_once()
+        call_kwargs = mock_logger.warning.call_args[1]
+
+        # Verify context fields
+        assert call_kwargs["provider"] == "test_provider"
+        assert call_kwargs["operation"] == "fetch"
+        assert call_kwargs["status_code"] == 500
+        assert call_kwargs["retry_count"] == 2
+        assert "error_category" in call_kwargs
+        assert "error_type" in call_kwargs
+
+    def test_log_error_critical_uses_error_level(self, handler, mock_logger):
+        """Test that critical errors are logged at error level."""
+        error = AuthFailureError(provider="test", status_code=401)
+        handler.log_error("auth", error)
+
+        mock_logger.error.assert_called_once()
+
+    def test_wrap_error_returns_domain_exception_unchanged(self, handler):
+        """Test that domain exceptions are returned unchanged."""
+        original = RateLimitError(provider="test", retry_after=60.0)
+        wrapped = handler.wrap_error(original, "fetch")
+        assert wrapped is original
+
+    def test_wrap_error_401_returns_auth_failure(self, handler):
+        """Test that 401 errors are wrapped as AuthFailureError."""
+        error = RuntimeError("Unauthorized")
+        wrapped = handler.wrap_error(error, "fetch", status_code=401)
+
+        assert isinstance(wrapped, AuthFailureError)
+        assert wrapped.provider == "test_provider"
+        assert wrapped.status_code == 401
+
+    def test_wrap_error_403_returns_auth_failure(self, handler):
+        """Test that 403 errors are wrapped as AuthFailureError."""
+        error = RuntimeError("Forbidden")
+        wrapped = handler.wrap_error(error, "fetch", status_code=403)
+
+        assert isinstance(wrapped, AuthFailureError)
+        assert wrapped.status_code == 403
+
+    def test_wrap_error_429_returns_rate_limit(self, handler):
+        """Test that 429 errors are wrapped as RateLimitError."""
+        error = RuntimeError("Too Many Requests")
+        response = MagicMock(spec=httpx.Response)
+        response.status_code = 429
+        response.headers = {"Retry-After": "120"}
+
+        wrapped = handler.wrap_error(error, "fetch", status_code=429, response=response)
+
+        assert isinstance(wrapped, RateLimitError)
+        assert wrapped.provider == "test_provider"
+        assert wrapped.retry_after == 120.0
+
+    def test_wrap_error_502_returns_timeout(self, handler):
+        """Test that 502 errors are wrapped as TimeoutError."""
+        error = RuntimeError("Bad Gateway")
+        wrapped = handler.wrap_error(error, "fetch", status_code=502)
+
+        assert isinstance(wrapped, TimeoutError)
+
+    def test_wrap_error_504_returns_timeout(self, handler):
+        """Test that 504 errors are wrapped as TimeoutError."""
+        error = RuntimeError("Gateway Timeout")
+        wrapped = handler.wrap_error(error, "fetch", status_code=504)
+
+        assert isinstance(wrapped, TimeoutError)
+
+    def test_wrap_error_500_returns_network_error(self, handler):
+        """Test that 500 errors are wrapped as NetworkError."""
+        error = RuntimeError("Internal Server Error")
+        wrapped = handler.wrap_error(error, "fetch", status_code=500)
+
+        assert isinstance(wrapped, NetworkError)
+
+    def test_handle_error_raises_wrapped_exception(self, handler, mock_logger):
+        """Test that handle_error logs and raises wrapped exception."""
+        error = RuntimeError("Test error")
+
+        with pytest.raises(NetworkError):
+            handler.handle_error(error, "fetch", status_code=500)
+
+        # Verify logging occurred
+        mock_logger.warning.assert_called_once()
+
+    def test_handle_error_with_response(self, handler, mock_logger):
+        """Test handle_error extracts status_code from response."""
+        error = RuntimeError("Unauthorized")
+        response = MagicMock(spec=httpx.Response)
+        response.status_code = 401
+
+        with pytest.raises(AuthFailureError):
+            handler.handle_error(error, "fetch", response=response)
+
+
+class TestUnifiedErrorBehavior:
+    """Tests for unified error behavior across adapters."""
+
+    @pytest.fixture
+    def mock_logger(self):
+        """Create a mock logger."""
+        return MagicMock()
+
+    def test_all_adapters_handle_401_the_same(self, mock_logger):
+        """Test that 401 is handled consistently across providers."""
+        providers = ["chembl", "uniprot", "pubchem", "pubmed"]
+
+        for provider in providers:
+            handler = AdapterErrorHandler(logger=mock_logger, provider=provider)
+            error = RuntimeError("Unauthorized")
+            wrapped = handler.wrap_error(error, "fetch", status_code=401)
+
+            assert isinstance(wrapped, AuthFailureError), f"Failed for {provider}"
+            assert wrapped.provider == provider
+
+    def test_all_adapters_handle_429_the_same(self, mock_logger):
+        """Test that 429 is handled consistently across providers."""
+        providers = ["chembl", "uniprot", "pubchem", "pubmed"]
+
+        for provider in providers:
+            handler = AdapterErrorHandler(logger=mock_logger, provider=provider)
+            error = RuntimeError("Rate limited")
+            wrapped = handler.wrap_error(error, "fetch", status_code=429)
+
+            assert isinstance(wrapped, RateLimitError), f"Failed for {provider}"
+            assert wrapped.provider == provider
+
+    def test_all_adapters_handle_5xx_the_same(self, mock_logger):
+        """Test that 5xx errors are handled consistently across providers."""
+        providers = ["chembl", "uniprot", "pubchem", "pubmed"]
+        status_codes = [500, 502, 503, 504]
+
+        for provider in providers:
+            handler = AdapterErrorHandler(logger=mock_logger, provider=provider)
+
+            for status_code in status_codes:
+                error = RuntimeError(f"Server error {status_code}")
+                wrapped = handler.wrap_error(error, "fetch", status_code=status_code)
+
+                # 502 and 504 should be TimeoutError, others NetworkError
+                if status_code in (502, 504):
+                    assert isinstance(
+                        wrapped, TimeoutError
+                    ), f"Failed for {provider}/{status_code}"
+                else:
+                    assert isinstance(
+                        wrapped, NetworkError
+                    ), f"Failed for {provider}/{status_code}"
+
+    def test_log_format_is_consistent(self, mock_logger):
+        """Test that log format is consistent across all providers."""
+        providers = ["chembl", "uniprot", "pubchem", "pubmed"]
+        required_fields = {
+            "provider",
+            "operation",
+            "error_category",
+            "error_type",
+            "error_message",
+            "error_class",
+        }
+
+        for provider in providers:
+            mock_logger.reset_mock()
+            handler = AdapterErrorHandler(logger=mock_logger, provider=provider)
+            error = RuntimeError("Test error")
+            handler.log_error("fetch", error)
+
+            # Get the logged kwargs
+            call_kwargs = mock_logger.warning.call_args[1]
+
+            # Verify all required fields are present
+            for field in required_fields:
+                assert field in call_kwargs, f"Missing {field} for {provider}"

--- a/tests/unit/infrastructure/test_adapters.py
+++ b/tests/unit/infrastructure/test_adapters.py
@@ -35,7 +35,8 @@ class TestChemblAdapter:
         adapter = ChemblAdapter(http_client=http_client, logger=mock_logger)
 
         assert adapter.provider_name == "chembl"
-        assert adapter.batch_size == 1000
+        # Use internal _page_size (batch_size is deprecated, defaults to None)
+        assert adapter._page_size == 1000
 
     def test_adapter_with_custom_batch_size(self, mock_logger):
         """Test ChEMBL adapter with custom batch size."""
@@ -46,7 +47,8 @@ class TestChemblAdapter:
             http_client=http_client, logger=mock_logger, batch_size=500
         )
 
-        assert adapter.batch_size == 500
+        # Use internal _page_size (batch_size is deprecated constructor param)
+        assert adapter._page_size == 500
 
     def test_entity_mapping(self, mock_logger):
         """Test entity type to resource URL mapping."""


### PR DESCRIPTION
Implement unified error handling across all DataSourcePort adapters per RULES.md §4.1. All adapters now use AdapterErrorHandler for consistent error classification, logging, and exception wrapping.

Changes:
- Create error_handling.py with ErrorCategory enum and AdapterErrorHandler
- Add _error_handler property to BaseHttpAdapter and BaseSyncAdapter
- Update ChemblAdapter to use unified handler (replace _error_classifier)
- Update UniProtAdapter with consistent error logging
- Update PubChemAdapter with unified error handler in health check
- Update PubMedAdapter with unified handler for search/fetch errors

Error handling behavior (RULES.md §4.1):
- HTTP 401/403 → AuthFailureError (CRITICAL, no retry)
- HTTP 429 → RateLimitError (RECOVERABLE, uses Retry-After header)
- HTTP 5xx → TimeoutError/NetworkError (RECOVERABLE, exponential backoff)

Unified log format:
- All errors logged as "external_api_error" event
- Consistent fields: provider, operation, error_category, error_type, error_message, error_class, circuit_breaker_state
- Critical errors logged at ERROR level, recoverable at WARNING

Tests:
- Add 39 new tests for error_handling module
- Update existing tests to match new error handling behavior