### PR TITLE
Unify duplicate pipeline registries

### DIFF
--- a/configs/pipelines/chembl/cell_line.yaml
+++ b/configs/pipelines/chembl/cell_line.yaml
@@ -1,0 +1,48 @@
+# configs/pipelines/chembl/cell_line.yaml
+# Pipeline configuration for ChEMBL Cell Line entity.
+#
+# Inherits defaults from ../_defaults.yaml
+
+pipeline_name: chembl_cell_line
+provider: chembl
+entity_type: cell_line
+version: "1.0.0"
+description: "Extract cell lines from ChEMBL API"
+
+primary_keys: ["cell_chembl_id"]
+silver_table: "chembl_cell_line"
+
+source_file: ../../sources/chembl.yaml
+
+# Entity-specific gold filters
+gold_filters:
+  required_fields:
+    - cell_name
+
+# Entity-specific sink overrides
+sink:
+  bronze:
+    path: "data/output/bronze"
+  silver:
+    path: "data/output/silver"
+    primary_key: ["cell_chembl_id"]
+    sort_by:
+      columns: ["cell_chembl_id"]
+      ascending: true
+    csv_export:
+      path: "data/output/csv/silver"
+  gold:
+    path: "data/output/gold"
+    sort_by:
+      columns: ["cell_chembl_id", "cell_name"]
+      ascending: true
+    csv_export:
+      path: "data/output/csv/gold"
+
+# Entity-specific input filter
+input_filter:
+  enabled: true
+  source_path: "data/input/cell_line.csv"
+  column_name: "cell_chembl_id"
+  filter_field: "cell_chembl_id"
+  batch_size: 20

--- a/src/bioetl/composition/factories/pipeline_factories.py
+++ b/src/bioetl/composition/factories/pipeline_factories.py
@@ -33,6 +33,10 @@ from bioetl.application.pipelines.chembl.activity import ChEMBLActivityPipeline
 from bioetl.application.pipelines.chembl.activity_transformer import ActivityTransformer
 from bioetl.application.pipelines.chembl.assay import ChEMBLAssayPipeline
 from bioetl.application.pipelines.chembl.assay_transformer import AssayTransformer
+from bioetl.application.pipelines.chembl.cell_line import ChEMBLCellLinePipeline
+from bioetl.application.pipelines.chembl.cell_line_transformer import (
+    CellLineTransformer,
+)
 from bioetl.application.pipelines.chembl.compound_record import (
     ChEMBLCompoundRecordPipeline,
 )
@@ -62,6 +66,7 @@ from bioetl.composition.registry import PipelineRegistry, get_default_registry
 from bioetl.infrastructure.schemas.gold import (
     ChEMBLActivityGoldSchema,
     ChEMBLAssayGoldSchema,
+    ChEMBLCellLineGoldSchema,
     ChEMBLCompoundRecordGoldSchema,
     ChEMBLDocumentGoldSchema,
     ChEMBLMoleculeGoldSchema,
@@ -74,6 +79,7 @@ from bioetl.infrastructure.schemas.gold import (
 from bioetl.infrastructure.schemas.silver import (
     CHEMBL_ACTIVITY_SCHEMA,
     CHEMBL_ASSAY_SCHEMA,
+    CHEMBL_CELL_LINE_SCHEMA,
     CHEMBL_COMPOUND_RECORD_SCHEMA,
     CHEMBL_DOCUMENT_SCHEMA,
     CHEMBL_MOLECULE_SCHEMA,
@@ -161,6 +167,16 @@ chembl_compound_record_factory = GenericPipelineFactory(
     transformer_class=CompoundRecordTransformer,
 )
 
+# ChEMBL Cell Line Pipeline
+chembl_cell_line_factory = GenericPipelineFactory(
+    pipeline_name="chembl_cell_line",
+    pipeline_class=ChEMBLCellLinePipeline,
+    provider="chembl",
+    silver_schema=CHEMBL_CELL_LINE_SCHEMA,
+    gold_schema=ChEMBLCellLineGoldSchema,
+    transformer_class=CellLineTransformer,
+)
+
 # PubChem Compound Pipeline
 pubchem_compound_factory = GenericPipelineFactory(
     pipeline_name="pubchem_compound",
@@ -244,6 +260,7 @@ def _register_factories_to(registry: PipelineRegistry) -> None:
     """
     registry.register_factory(chembl_activity_factory)
     registry.register_factory(chembl_assay_factory)
+    registry.register_factory(chembl_cell_line_factory)
     registry.register_factory(chembl_compound_record_factory)
     registry.register_factory(chembl_document_factory)
     registry.register_factory(chembl_target_factory)
@@ -284,6 +301,7 @@ def reset_registration() -> None:
 __all__ = [
     "chembl_activity_factory",
     "chembl_assay_factory",
+    "chembl_cell_line_factory",
     "chembl_compound_record_factory",
     "chembl_document_factory",
     "chembl_molecule_factory",

--- a/src/bioetl/infrastructure/schemas/gold.py
+++ b/src/bioetl/infrastructure/schemas/gold.py
@@ -459,3 +459,38 @@ class ChEMBLCompoundRecordGoldSchema(pa.DataFrameModel):
 
     class Config:
         strict = True
+
+
+class ChEMBLCellLineGoldSchema(pa.DataFrameModel):
+    """Schema for ChEMBL Cell Line in Gold layer."""
+
+    # System fields
+    entity_id: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(nullable=False)
+
+    # Primary identifier
+    cell_chembl_id: Series[str] = pa.Field(nullable=False)
+
+    # Core metadata
+    cell_name: Series[str] = pa.Field(nullable=False)
+    cell_description: Series[str] = pa.Field(nullable=True)
+
+    # Source information
+    cell_source_tissue: Series[str] = pa.Field(nullable=True)
+    cell_source_organism: Series[str] = pa.Field(nullable=True)
+    cell_source_tax_id: Series[float] = pa.Field(nullable=True, coerce=True)  # int64
+
+    # External identifiers
+    cellosaurus_id: Series[str] = pa.Field(nullable=True)
+    cl_lincs_id: Series[str] = pa.Field(nullable=True)
+    efo_id: Series[str] = pa.Field(nullable=True)
+
+    # Metadata
+    run_id: Series[str] = pa.Field(nullable=False, alias="_run_id")
+    run_type: Series[str] = pa.Field(nullable=False, alias="_run_type")
+    source_batch_id: Series[str] = pa.Field(nullable=True, alias="_source_batch_id")
+    ingestion_ts: Series[str] = pa.Field(nullable=False, alias="_ingestion_ts")
+    index: Series[int] = pa.Field(nullable=False, alias="_index")
+
+    class Config:
+        strict = True


### PR DESCRIPTION
- Add ChEMBLCellLineGoldSchema to infrastructure/schemas/gold.py
- Create configs/pipelines/chembl/cell_line.yaml configuration
- Register chembl_cell_line_factory in pipeline_factories.py
- Import CellLineTransformer and ChEMBLCellLinePipeline

The pipeline now appears in CLI (bioetl config list-pipelines) and is fully integrated into the unified PipelineRegistry.

All 3710 tests pass.