### PR TITLE
Merge duplicate bioactivity models in domain layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Improves test reliability by testing real integration
 ## [Unreleased]
 
+### Added
+
+- **Unified Bioactivity Entity**: Introduced `Bioactivity` class as the canonical domain entity for bioactivity data:
+  - New `domain/entities/bioactivity.py` module with unified representation
+  - `BioactivityState` enum for tracking processing lifecycle (RAW → NORMALIZED → VALIDATED)
+  - `from_raw()` factory method for creating entities from API data
+  - `with_state()` method for immutable state transitions
+  - Helper methods: `is_ready_for_silver()`, `is_fully_validated()`
+
+### Changed
+
+- **Activity Deprecated**: `Activity` class is now a deprecated alias for `Bioactivity`:
+  - Emits `DeprecationWarning` when instantiated
+  - Will be removed in 14 days
+  - All existing code continues to work via backward-compatible alias
+
+- **ActivityTransformer**: Updated to use `Bioactivity` instead of `Activity`:
+  - Entity class reference updated in `activity_transformer.py:130`
+  - No functional changes to transformation logic
+
+### Tests
+
+- **New Bioactivity Tests**: Added comprehensive tests for new functionality:
+  - `TestBioactivity`: 12 tests for entity creation, validation, state transitions
+  - `TestBioactivityState`: 3 tests for enum behavior
+  - `TestActivityDeprecatedAlias`: 2 tests for deprecation warning
+
 ### Removed
 
 - **Dead Code Cleanup (infrastructure)**: Removed unused import in `infrastructure/config.py`:

--- a/src/bioetl/application/pipelines/chembl/activity_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/activity_transformer.py
@@ -19,7 +19,7 @@ from bioetl.application.core.transform_utils import flatten_nested_dict
 from bioetl.application.pipelines.chembl.base_chembl_transformer import (
     BaseChemblTransformer,
 )
-from bioetl.domain.entities import Activity
+from bioetl.domain.entities import Bioactivity
 from bioetl.domain.transformations import safe_float
 
 if TYPE_CHECKING:
@@ -122,9 +122,12 @@ _ACTIVITY_GROUPS: tuple[FieldGroup, ...] = (
 
 
 class ActivityTransformer(BaseChemblTransformer):
-    """Transforms ChEMBL bronze records to silver."""
+    """Transforms ChEMBL bronze records to silver.
 
-    entity_class = Activity
+    Uses the unified Bioactivity entity for domain representation.
+    """
+
+    entity_class = Bioactivity
     primary_id_field = "activity_id"
 
     def _extract_ligand_efficiency(

--- a/src/bioetl/domain/entities/__init__.py
+++ b/src/bioetl/domain/entities/__init__.py
@@ -19,6 +19,7 @@ Field Classification:
 """
 
 from bioetl.domain.entities.base import BaseEntity
+from bioetl.domain.entities.bioactivity import Bioactivity, BioactivityState
 from bioetl.domain.entities.chembl_activity import Activity, Assay
 from bioetl.domain.entities.chembl_compound_record import CompoundRecord
 from bioetl.domain.entities.chembl_structures import (
@@ -34,9 +35,11 @@ from bioetl.domain.entities.pubmed import Publication
 from bioetl.domain.entities.uniprot import Protein
 
 __all__ = [
-    "Activity",
+    "Activity",  # Deprecated: use Bioactivity instead
     "Assay",
     "BaseEntity",
+    "Bioactivity",
+    "BioactivityState",
     "CellLine",
     "Compound",
     "CompoundRecord",

--- a/src/bioetl/domain/entities/bioactivity.py
+++ b/src/bioetl/domain/entities/bioactivity.py
@@ -1,0 +1,449 @@
+"""Unified Bioactivity domain entity.
+
+Contains the Bioactivity entity and associated types for ChEMBL/PubChem bioactivity data.
+This module consolidates bioactivity representation into a single domain model.
+
+Design Rationale:
+    - Single source of truth for bioactivity representation in domain layer
+    - State tracking via BioactivityState enum for processing lifecycle
+    - Factory method from_raw() for creating from API data
+    - Immutable (frozen dataclass) for thread safety
+
+Field Classification:
+    - REQUIRED: Validated in __post_init__, will raise ValueError if empty
+    - API-OPTIONAL: May or may not be present in API response, defaults to None
+    - COMPUTED: Derived from other fields, may be None if source data missing
+
+Migration Note:
+    The `Activity` class is now deprecated in favor of `Bioactivity`.
+    Use `from bioetl.domain.entities import Bioactivity` for new code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Any
+from uuid import UUID
+
+from bioetl.domain.entities.base import BaseEntity
+from bioetl.domain.types import BatchID, ContentHash, EntityID, RunID, RunType
+
+
+class BioactivityState(str, Enum):
+    """Processing state of a bioactivity record.
+
+    Tracks the lifecycle of a bioactivity record through the ETL pipeline.
+
+    States:
+        RAW: Initial state from API/Bronze layer, minimal validation
+        NORMALIZED: Data normalized (types converted, nulls handled)
+        VALIDATED: Full domain validation passed, ready for Silver/Gold
+
+    Transitions:
+        RAW -> NORMALIZED -> VALIDATED
+
+    Note:
+        State is informational and does not affect entity behavior.
+        Use for observability and debugging of pipeline stages.
+    """
+
+    RAW = "raw"
+    """Initial state from API/Bronze layer."""
+
+    NORMALIZED = "normalized"
+    """Data normalized and types converted."""
+
+    VALIDATED = "validated"
+    """Full validation passed, ready for persistence."""
+
+    def is_ready_for_silver(self) -> bool:
+        """Check if record is ready for Silver layer.
+
+        Returns:
+            True if state is NORMALIZED or VALIDATED.
+        """
+        return self in (BioactivityState.NORMALIZED, BioactivityState.VALIDATED)
+
+    def is_fully_validated(self) -> bool:
+        """Check if record passed full validation.
+
+        Returns:
+            True if state is VALIDATED.
+        """
+        return self == BioactivityState.VALIDATED
+
+
+@dataclass(frozen=True, kw_only=True)
+class Bioactivity(BaseEntity):
+    """Unified bioactivity measurement entity.
+
+    Represents a single bioactivity measurement from ChEMBL or similar sources.
+    Contains all fields from ChEMBL activity API endpoint.
+    See: https://www.ebi.ac.uk/chembl/api/data/activity
+
+    Required Fields (validated):
+        activity_id: Primary identifier (from BaseEntity fields + this)
+        molecule_chembl_id: Molecule identifier (required for drug discovery)
+        + All BaseEntity fields (entity_id, content_hash, run_id, etc.)
+
+    API-Optional Fields:
+        All other fields may be None depending on the activity record.
+        Gold layer filters should be used to ensure required fields for analysis.
+
+    State Tracking:
+        _state: Processing state for observability (default: VALIDATED)
+
+    Validation:
+        - activity_id and molecule_chembl_id must be non-empty
+        - pchembl_value must be non-negative if present
+
+    Example:
+        >>> # Create from raw API data
+        >>> bioactivity = Bioactivity.from_raw(
+        ...     raw_data={"activity_id": 123, "molecule_chembl_id": "CHEMBL1"},
+        ...     run_id=run_id,
+        ...     ingestion_ts=datetime.now(UTC),
+        ... )
+        >>> bioactivity.state  # BioactivityState.RAW
+
+        >>> # Create validated entity directly
+        >>> bioactivity = Bioactivity(
+        ...     entity_id=EntityID("ACT123"),
+        ...     content_hash=ContentHash("abc123"),
+        ...     run_id=run_id,
+        ...     run_type=RunType.INCREMENTAL,
+        ...     ingestion_ts=datetime.now(UTC),
+        ...     _index=0,
+        ...     activity_id="ACT123",
+        ...     molecule_chembl_id="CHEMBL1",
+        ... )
+    """
+
+    # Processing state (informational, does not affect behavior)
+    _state: BioactivityState = BioactivityState.VALIDATED
+
+    # REQUIRED: Primary identifier (validated in __post_init__)
+    activity_id: str
+
+    # REQUIRED: Core identifiers (validated in __post_init__)
+    molecule_chembl_id: str
+    target_chembl_id: str | None = None
+    assay_chembl_id: str | None = None
+    document_chembl_id: str | None = None
+    record_id: int | None = None
+    src_id: int | None = None
+
+    # Molecule data
+    canonical_smiles: str | None = None
+    molecule_pref_name: str | None = None
+    parent_molecule_chembl_id: str | None = None
+
+    # Target data
+    target_pref_name: str | None = None
+    target_organism: str | None = None
+    target_tax_id: str | None = None
+
+    # Assay data
+    assay_type: str | None = None
+    assay_description: str | None = None
+    assay_variant_accession: str | None = None
+    assay_variant_mutation: str | None = None
+
+    # BAO (BioAssay Ontology) annotations
+    bao_endpoint: str | None = None
+    bao_format: str | None = None
+    bao_label: str | None = None
+
+    # Raw activity values
+    type: str | None = None
+    value: float | None = None
+    units: str | None = None
+    relation: str | None = None
+    upper_value: float | None = None
+    text_value: str | None = None
+
+    # Standardized activity values
+    standard_type: str | None = None
+    standard_value: float | None = None
+    standard_units: str | None = None
+    standard_relation: str | None = None
+    standard_upper_value: float | None = None
+    standard_text_value: str | None = None
+    standard_flag: int | None = None
+
+    # Derived metrics
+    pchembl_value: float | None = None
+
+    # Ligand efficiency metrics (flattened from ChEMBL API dict)
+    ligand_efficiency_bei: float | None = None  # Binding Efficiency Index
+    ligand_efficiency_le: float | None = None  # Ligand Efficiency
+    ligand_efficiency_lle: float | None = None  # Lipophilic Ligand Efficiency
+    ligand_efficiency_sei: float | None = None  # Surface Efficiency Index
+
+    # Units ontology
+    qudt_units: str | None = None
+    uo_units: str | None = None
+
+    # Document/Publication data
+    document_journal: str | None = None
+    document_year: int | None = None
+
+    # Quality annotations
+    activity_comment: str | None = None
+    data_validity_comment: str | None = None
+    data_validity_description: str | None = None
+    potential_duplicate: int | None = None
+
+    # Action type (flattened from ChEMBL API nested structure)
+    action_type_action_type: str | None = (
+        None  # Type of action (INHIBITOR, AGONIST, etc.)
+    )
+    action_type_description: str | None = None  # Description of the action type
+    action_type_parent_type: str | None = None  # Higher-level grouping (nullable)
+
+    # Activity properties
+    activity_properties: str | None = None  # JSON string of list
+    toid: int | None = None
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self._validate_invariants()
+
+    def _validate_invariants(self) -> None:
+        """Validate business invariants.
+
+        Raises:
+            ValueError: If required fields are missing or invalid.
+        """
+        if not self.activity_id:
+            raise ValueError("Activity ID is required")
+        if not self.molecule_chembl_id:
+            raise ValueError("Molecule ID is required")
+        self._validate_pchembl_value()
+
+    def _validate_pchembl_value(self) -> None:
+        """Validate pchembl_value is non-negative if present.
+
+        Raises:
+            ValueError: If pchembl_value is negative.
+        """
+        if self.pchembl_value is not None and self.pchembl_value < 0:
+            raise ValueError(
+                f"pChemBL value must be non-negative, got {self.pchembl_value}"
+            )
+
+    @property
+    def state(self) -> BioactivityState:
+        """Current processing state of the bioactivity record.
+
+        Returns:
+            Processing state enum value.
+        """
+        return self._state
+
+    @classmethod
+    def from_raw(
+        cls,
+        *,
+        raw_data: dict[str, Any],
+        run_id: RunID | UUID,
+        run_type: RunType = RunType.INCREMENTAL,
+        ingestion_ts: datetime,
+        index: int = 0,
+        source_batch_id: UUID | None = None,
+    ) -> Bioactivity:
+        """Factory method to create Bioactivity from raw API data.
+
+        Creates a Bioactivity entity from raw API response data with minimal
+        processing. The entity is created in RAW state.
+
+        Args:
+            raw_data: Raw dictionary from API response.
+            run_id: Pipeline run identifier.
+            run_type: Type of pipeline run.
+            ingestion_ts: Ingestion timestamp.
+            index: Record index in the batch.
+            source_batch_id: Optional batch identifier.
+
+        Returns:
+            Bioactivity entity in RAW state.
+
+        Raises:
+            ValueError: If required fields are missing in raw_data.
+
+        Example:
+            >>> bioactivity = Bioactivity.from_raw(
+            ...     raw_data=api_response,
+            ...     run_id=uuid4(),
+            ...     ingestion_ts=datetime.now(UTC),
+            ... )
+        """
+        import hashlib
+        import json
+
+        # Extract required fields
+        activity_id = raw_data.get("activity_id")
+        if activity_id is None:
+            raise ValueError("raw_data must contain 'activity_id'")
+
+        molecule_chembl_id = raw_data.get("molecule_chembl_id")
+        if molecule_chembl_id is None:
+            raise ValueError("raw_data must contain 'molecule_chembl_id'")
+
+        # Generate entity_id and content_hash
+        entity_id = EntityID(str(activity_id))
+        content_hash_str = hashlib.sha256(
+            json.dumps(raw_data, sort_keys=True, default=str).encode()
+        ).hexdigest()
+
+        # Extract optional fields with safe type conversion
+        def safe_int(val: Any) -> int | None:
+            if val is None:
+                return None
+            try:
+                return int(val)
+            except (ValueError, TypeError):
+                return None
+
+        def safe_float(val: Any) -> float | None:
+            if val is None:
+                return None
+            try:
+                return float(val)
+            except (ValueError, TypeError):
+                return None
+
+        def safe_str(val: Any) -> str | None:
+            if val is None:
+                return None
+            return str(val)
+
+        return cls(
+            # BaseEntity fields
+            entity_id=entity_id,
+            content_hash=ContentHash(content_hash_str),
+            run_id=RunID(run_id) if isinstance(run_id, UUID) else run_id,
+            run_type=run_type,
+            ingestion_ts=ingestion_ts,
+            _index=index,
+            source_batch_id=BatchID(source_batch_id) if source_batch_id else None,
+            # State
+            _state=BioactivityState.RAW,
+            # Required fields
+            activity_id=str(activity_id),
+            molecule_chembl_id=str(molecule_chembl_id),
+            # Optional identifiers
+            target_chembl_id=safe_str(raw_data.get("target_chembl_id")),
+            assay_chembl_id=safe_str(raw_data.get("assay_chembl_id")),
+            document_chembl_id=safe_str(raw_data.get("document_chembl_id")),
+            record_id=safe_int(raw_data.get("record_id")),
+            src_id=safe_int(raw_data.get("src_id")),
+            # Molecule data
+            canonical_smiles=safe_str(raw_data.get("canonical_smiles")),
+            molecule_pref_name=safe_str(raw_data.get("molecule_pref_name")),
+            parent_molecule_chembl_id=safe_str(
+                raw_data.get("parent_molecule_chembl_id")
+            ),
+            # Target data
+            target_pref_name=safe_str(raw_data.get("target_pref_name")),
+            target_organism=safe_str(raw_data.get("target_organism")),
+            target_tax_id=safe_str(raw_data.get("target_tax_id")),
+            # Assay data
+            assay_type=safe_str(raw_data.get("assay_type")),
+            assay_description=safe_str(raw_data.get("assay_description")),
+            assay_variant_accession=safe_str(raw_data.get("assay_variant_accession")),
+            assay_variant_mutation=safe_str(raw_data.get("assay_variant_mutation")),
+            # BAO annotations
+            bao_endpoint=safe_str(raw_data.get("bao_endpoint")),
+            bao_format=safe_str(raw_data.get("bao_format")),
+            bao_label=safe_str(raw_data.get("bao_label")),
+            # Raw activity values
+            type=safe_str(raw_data.get("type")),
+            value=safe_float(raw_data.get("value")),
+            units=safe_str(raw_data.get("units")),
+            relation=safe_str(raw_data.get("relation")),
+            upper_value=safe_float(raw_data.get("upper_value")),
+            text_value=safe_str(raw_data.get("text_value")),
+            # Standardized values
+            standard_type=safe_str(raw_data.get("standard_type")),
+            standard_value=safe_float(raw_data.get("standard_value")),
+            standard_units=safe_str(raw_data.get("standard_units")),
+            standard_relation=safe_str(raw_data.get("standard_relation")),
+            standard_upper_value=safe_float(raw_data.get("standard_upper_value")),
+            standard_text_value=safe_str(raw_data.get("standard_text_value")),
+            standard_flag=safe_int(raw_data.get("standard_flag")),
+            # Derived metrics
+            pchembl_value=safe_float(raw_data.get("pchembl_value")),
+            # Document data
+            document_journal=safe_str(raw_data.get("document_journal")),
+            document_year=safe_int(raw_data.get("document_year")),
+            # Quality annotations
+            activity_comment=safe_str(raw_data.get("activity_comment")),
+            data_validity_comment=safe_str(raw_data.get("data_validity_comment")),
+            data_validity_description=safe_str(
+                raw_data.get("data_validity_description")
+            ),
+            potential_duplicate=safe_int(raw_data.get("potential_duplicate")),
+            # Activity properties
+            activity_properties=(
+                json.dumps(raw_data.get("activity_properties"))
+                if raw_data.get("activity_properties")
+                else None
+            ),
+            toid=safe_int(raw_data.get("toid")),
+        )
+
+    def with_state(self, new_state: BioactivityState) -> Bioactivity:
+        """Create a copy with a new processing state.
+
+        Since Bioactivity is immutable (frozen dataclass), this method
+        creates a new instance with the updated state.
+
+        Args:
+            new_state: The new processing state.
+
+        Returns:
+            New Bioactivity instance with updated state.
+
+        Example:
+            >>> raw = Bioactivity.from_raw(...)
+            >>> normalized = raw.with_state(BioactivityState.NORMALIZED)
+        """
+        from dataclasses import asdict
+
+        data = asdict(self)
+        data["_state"] = new_state
+        return Bioactivity(**data)
+
+
+# Backward compatibility alias with deprecation warning
+def _create_activity_alias() -> type[Bioactivity]:
+    """Create deprecated Activity alias.
+
+    Returns:
+        Bioactivity class with deprecation warning on instantiation.
+    """
+    import warnings
+
+    class Activity(Bioactivity):
+        """Deprecated alias for Bioactivity.
+
+        .. deprecated:: 1.0.0
+            Use :class:`Bioactivity` instead. This alias will be removed in 14 days.
+        """
+
+        def __init__(self, **kwargs: Any) -> None:
+            warnings.warn(
+                "Activity is deprecated, use Bioactivity instead. "
+                "This alias will be removed in 14 days.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            super().__init__(**kwargs)
+
+    return Activity
+
+
+# Note: Activity alias is created in chembl_activity.py for backward compatibility

--- a/src/bioetl/domain/entities/chembl_activity.py
+++ b/src/bioetl/domain/entities/chembl_activity.py
@@ -1,141 +1,65 @@
 """ChEMBL bioactivity domain entities.
 
-Contains Activity and Assay entities for ChEMBL bioactivity data.
+Contains Activity (deprecated alias for Bioactivity) and Assay entities.
+
+Migration Note:
+    The `Activity` class is deprecated in favor of `Bioactivity`.
+    Use `from bioetl.domain.entities import Bioactivity` for new code.
+    The `Activity` alias will be removed after 14 days.
 
 Field Classification:
-- REQUIRED: Validated in __post_init__, will raise ValueError if empty
-- API-OPTIONAL: May or may not be present in API response, defaults to None
-- COMPUTED: Derived from other fields, may be None if source data missing
+    - REQUIRED: Validated in __post_init__, will raise ValueError if empty
+    - API-OPTIONAL: May or may not be present in API response, defaults to None
+    - COMPUTED: Derived from other fields, may be None if source data missing
 """
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
+from typing import Any
 
 from bioetl.domain.entities.base import BaseEntity
+from bioetl.domain.entities.bioactivity import (
+    Bioactivity,
+    BioactivityState,
+)
+
+__all__ = [
+    "Activity",
+    "Assay",
+    "Bioactivity",
+    "BioactivityState",
+]
 
 
-@dataclass(frozen=True, kw_only=True)
-class Activity(BaseEntity):
-    """Represents a bioactivity measurement (ChEMBL Activity).
+class Activity(Bioactivity):
+    """Deprecated alias for Bioactivity.
 
-    Contains all fields from ChEMBL activity API endpoint.
-    See: https://www.ebi.ac.uk/chembl/api/data/activity
+    .. deprecated:: 1.0.0
+        Use :class:`Bioactivity` instead. This alias will be removed in 14 days.
 
-    Required Fields (validated):
-        activity_id: Primary identifier (from BaseEntity fields + this)
-        molecule_chembl_id: Molecule identifier (required for drug discovery)
-        + All BaseEntity fields (entity_id, content_hash, run_id, etc.)
+    This class exists for backward compatibility during migration.
+    All functionality is inherited from Bioactivity.
 
-    API-Optional Fields:
-        All other fields may be None depending on the activity record.
-        Gold layer filters should be used to ensure required fields for analysis.
+    Example:
+        >>> # Old code (deprecated):
+        >>> from bioetl.domain.entities import Activity
+        >>> activity = Activity(...)  # Will emit DeprecationWarning
 
-    Validation:
-        - activity_id and molecule_chembl_id must be non-empty
-        - pchembl_value must be non-negative if present
+        >>> # New code (recommended):
+        >>> from bioetl.domain.entities import Bioactivity
+        >>> bioactivity = Bioactivity(...)
     """
 
-    # REQUIRED: Primary identifier (validated in __post_init__)
-    activity_id: str
-
-    # REQUIRED: Core identifiers (validated in __post_init__)
-    molecule_chembl_id: str
-    target_chembl_id: str | None = None
-    assay_chembl_id: str | None = None
-    document_chembl_id: str | None = None
-    record_id: int | None = None
-    src_id: int | None = None
-
-    # Molecule data
-    canonical_smiles: str | None = None
-    molecule_pref_name: str | None = None
-    parent_molecule_chembl_id: str | None = None
-
-    # Target data
-    target_pref_name: str | None = None
-    target_organism: str | None = None
-    target_tax_id: str | None = None
-
-    # Assay data
-    assay_type: str | None = None
-    assay_description: str | None = None
-    assay_variant_accession: str | None = None
-    assay_variant_mutation: str | None = None
-
-    # BAO (BioAssay Ontology) annotations
-    bao_endpoint: str | None = None
-    bao_format: str | None = None
-    bao_label: str | None = None
-
-    # Raw activity values
-    type: str | None = None
-    value: float | None = None
-    units: str | None = None
-    relation: str | None = None
-    upper_value: float | None = None
-    text_value: str | None = None
-
-    # Standardized activity values
-    standard_type: str | None = None
-    standard_value: float | None = None
-    standard_units: str | None = None
-    standard_relation: str | None = None
-    standard_upper_value: float | None = None
-    standard_text_value: str | None = None
-    standard_flag: int | None = None
-
-    # Derived metrics
-    pchembl_value: float | None = None
-
-    # Ligand efficiency metrics (flattened from ChEMBL API dict)
-    ligand_efficiency_bei: float | None = None  # Binding Efficiency Index
-    ligand_efficiency_le: float | None = None  # Ligand Efficiency
-    ligand_efficiency_lle: float | None = None  # Lipophilic Ligand Efficiency
-    ligand_efficiency_sei: float | None = None  # Surface Efficiency Index
-
-    # Units ontology
-    qudt_units: str | None = None
-    uo_units: str | None = None
-
-    # Document/Publication data
-    document_journal: str | None = None
-    document_year: int | None = None
-
-    # Quality annotations
-    activity_comment: str | None = None
-    data_validity_comment: str | None = None
-    data_validity_description: str | None = None
-    potential_duplicate: int | None = None
-
-    # Action type (flattened from ChEMBL API nested structure)
-    action_type_action_type: str | None = (
-        None  # Type of action (INHIBITOR, AGONIST, etc.)
-    )
-    action_type_description: str | None = None  # Description of the action type
-    action_type_parent_type: str | None = None  # Higher-level grouping (nullable)
-
-    # Activity properties
-    activity_properties: str | None = None  # JSON string of list
-    toid: int | None = None
-
-    def __post_init__(self) -> None:
-        super().__post_init__()
-        self._validate_invariants()
-
-    def _validate_invariants(self) -> None:
-        if not self.activity_id:
-            raise ValueError("Activity ID is required")
-        if not self.molecule_chembl_id:
-            raise ValueError("Molecule ID is required")
-        self._validate_pchembl_value()
-
-    def _validate_pchembl_value(self) -> None:
-        """Validate pchembl_value is non-negative if present."""
-        if self.pchembl_value is not None and self.pchembl_value < 0:
-            raise ValueError(
-                f"pChemBL value must be non-negative, got {self.pchembl_value}"
-            )
+    def __init__(self, **kwargs: Any) -> None:
+        warnings.warn(
+            "Activity is deprecated, use Bioactivity instead. "
+            "This alias will be removed in 14 days.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(**kwargs)
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -266,7 +266,7 @@ def test_silver_schemas_match_domain_entities(src_dir: Path):
 
     # Import schemas and entities
     try:
-        from bioetl.domain.entities import Activity, Compound, Protein
+        from bioetl.domain.entities import Bioactivity, Compound, Protein
         from bioetl.infrastructure.schemas.silver import (
             CHEMBL_ACTIVITY_SCHEMA,
             PUBCHEM_COMPOUND_SCHEMA,
@@ -277,7 +277,7 @@ def test_silver_schemas_match_domain_entities(src_dir: Path):
 
     # Map Schema -> Entity
     pairs = [
-        (CHEMBL_ACTIVITY_SCHEMA, Activity),
+        (CHEMBL_ACTIVITY_SCHEMA, Bioactivity),
         (PUBCHEM_COMPOUND_SCHEMA, Compound),
         (UNIPROT_PROTEIN_SCHEMA, Protein),
     ]

--- a/tests/unit/application/core/test_base_transformer.py
+++ b/tests/unit/application/core/test_base_transformer.py
@@ -22,7 +22,7 @@ from bioetl.application.core.base_transformer import (
     TransformationError,
 )
 from bioetl.domain.context import PipelineContext
-from bioetl.domain.entities import Activity
+from bioetl.domain.entities import Bioactivity
 from bioetl.domain.filtering import GoldFilterConfig
 from bioetl.domain.types import RunType
 
@@ -226,7 +226,7 @@ class TestCreateEntity:
     ) -> None:
         """Test creates entity with lineage fields from context."""
         entity = transformer._create_entity(
-            Activity,
+            Bioactivity,
             mock_context,
             entity_id="test:activity:123",
             content_hash="abc123",
@@ -250,7 +250,7 @@ class TestCreateEntity:
         """Test raises ValueError when entity validation fails."""
         with pytest.raises(ValueError):
             transformer._create_entity(
-                Activity,
+                Bioactivity,
                 mock_context,
                 entity_id="test:activity:123",
                 content_hash="abc123",

--- a/tests/unit/domain/test_entities.py
+++ b/tests/unit/domain/test_entities.py
@@ -7,7 +7,16 @@ from uuid import uuid4
 
 import pytest
 
-from bioetl.domain.entities import Activity, Compound, Protein, Work
+import warnings
+
+from bioetl.domain.entities import (
+    Activity,
+    Bioactivity,
+    BioactivityState,
+    Compound,
+    Protein,
+    Work,
+)
 from bioetl.domain.types import ContentHash, EntityID, RunType
 
 
@@ -33,7 +42,7 @@ class TestBaseEntity:
         """Test that empty entity_id raises ValueError."""
         base_entity_kwargs["entity_id"] = EntityID("")
         with pytest.raises(ValueError, match="Entity ID cannot be empty"):
-            Activity(
+            Bioactivity(
                 **base_entity_kwargs,
                 activity_id="ACT1",
                 molecule_chembl_id="CHEMBL123",
@@ -45,7 +54,7 @@ class TestBaseEntity:
         """Test that empty content_hash raises ValueError."""
         base_entity_kwargs["content_hash"] = ContentHash("")
         with pytest.raises(ValueError, match="Content hash cannot be empty"):
-            Activity(
+            Bioactivity(
                 **base_entity_kwargs,
                 activity_id="ACT1",
                 molecule_chembl_id="CHEMBL123",
@@ -60,7 +69,7 @@ class TestBaseEntity:
             k: v for k, v in base_entity_kwargs.items() if k != "ingestion_ts"
         }
         with pytest.raises(TypeError, match="ingestion_ts"):
-            Activity(
+            Bioactivity(
                 **kwargs_without_ts,
                 activity_id="ACT1",
                 molecule_chembl_id="CHEMBL123",
@@ -70,39 +79,39 @@ class TestBaseEntity:
 
     def test_base_entity_accepts_explicit_ingestion_ts(self, base_entity_kwargs):
         """Test that explicitly passed ingestion_ts is used."""
-        activity = Activity(
+        bioactivity = Bioactivity(
             **base_entity_kwargs,
             activity_id="ACT1",
             molecule_chembl_id="CHEMBL123",
             target_chembl_id="CHEMBL456",
             assay_chembl_id="CHEMBL789",
         )
-        assert activity.ingestion_ts is not None
-        assert isinstance(activity.ingestion_ts, datetime)
-        assert activity.ingestion_ts.tzinfo == UTC
+        assert bioactivity.ingestion_ts is not None
+        assert isinstance(bioactivity.ingestion_ts, datetime)
+        assert bioactivity.ingestion_ts.tzinfo == UTC
 
 
 @pytest.mark.unit
-class TestActivity:
-    """Tests for Activity entity."""
+class TestBioactivity:
+    """Tests for Bioactivity entity."""
 
-    def test_activity_creation_success(self, base_entity_kwargs):
-        """Test successful Activity creation with required fields."""
-        activity = Activity(
+    def test_bioactivity_creation_success(self, base_entity_kwargs):
+        """Test successful Bioactivity creation with required fields."""
+        bioactivity = Bioactivity(
             **base_entity_kwargs,
             activity_id="ACT123",
             molecule_chembl_id="CHEMBL1",
             target_chembl_id="CHEMBL2",
             assay_chembl_id="CHEMBL3",
         )
-        assert activity.activity_id == "ACT123"
-        assert activity.molecule_chembl_id == "CHEMBL1"
-        assert activity.target_chembl_id == "CHEMBL2"
-        assert activity.assay_chembl_id == "CHEMBL3"
+        assert bioactivity.activity_id == "ACT123"
+        assert bioactivity.molecule_chembl_id == "CHEMBL1"
+        assert bioactivity.target_chembl_id == "CHEMBL2"
+        assert bioactivity.assay_chembl_id == "CHEMBL3"
 
-    def test_activity_with_optional_fields(self, base_entity_kwargs):
-        """Test Activity with all optional fields."""
-        activity = Activity(
+    def test_bioactivity_with_optional_fields(self, base_entity_kwargs):
+        """Test Bioactivity with all optional fields."""
+        bioactivity = Bioactivity(
             **base_entity_kwargs,
             activity_id="ACT456",
             molecule_chembl_id="CHEMBL100",
@@ -116,18 +125,18 @@ class TestActivity:
             activity_comment="High quality",
             data_validity_comment="Valid",
         )
-        assert activity.standard_type == "IC50"
-        assert activity.standard_value == 10.5
-        assert activity.standard_units == "nM"
-        assert activity.standard_relation == "="
-        assert activity.pchembl_value == 7.5
-        assert activity.activity_comment == "High quality"
-        assert activity.data_validity_comment == "Valid"
+        assert bioactivity.standard_type == "IC50"
+        assert bioactivity.standard_value == 10.5
+        assert bioactivity.standard_units == "nM"
+        assert bioactivity.standard_relation == "="
+        assert bioactivity.pchembl_value == 7.5
+        assert bioactivity.activity_comment == "High quality"
+        assert bioactivity.data_validity_comment == "Valid"
 
-    def test_activity_requires_activity_id(self, base_entity_kwargs):
+    def test_bioactivity_requires_activity_id(self, base_entity_kwargs):
         """Test that empty activity_id raises ValueError."""
         with pytest.raises(ValueError, match="Activity ID is required"):
-            Activity(
+            Bioactivity(
                 **base_entity_kwargs,
                 activity_id="",
                 molecule_chembl_id="CHEMBL1",
@@ -135,10 +144,10 @@ class TestActivity:
                 assay_chembl_id="CHEMBL3",
             )
 
-    def test_activity_pchembl_must_be_nonnegative(self, base_entity_kwargs):
+    def test_bioactivity_pchembl_must_be_nonnegative(self, base_entity_kwargs):
         """Test that negative pchembl_value raises ValueError."""
         with pytest.raises(ValueError, match="pChemBL value must be non-negative"):
-            Activity(
+            Bioactivity(
                 **base_entity_kwargs,
                 activity_id="ACT1",
                 molecule_chembl_id="CHEMBL1",
@@ -147,9 +156,9 @@ class TestActivity:
                 pchembl_value=-1.0,
             )
 
-    def test_activity_pchembl_zero_is_valid(self, base_entity_kwargs):
+    def test_bioactivity_pchembl_zero_is_valid(self, base_entity_kwargs):
         """Test that zero pchembl_value is valid."""
-        activity = Activity(
+        bioactivity = Bioactivity(
             **base_entity_kwargs,
             activity_id="ACT1",
             molecule_chembl_id="CHEMBL1",
@@ -157,11 +166,11 @@ class TestActivity:
             assay_chembl_id="CHEMBL3",
             pchembl_value=0.0,
         )
-        assert activity.pchembl_value == 0.0
+        assert bioactivity.pchembl_value == 0.0
 
-    def test_activity_is_frozen(self, base_entity_kwargs):
-        """Test that Activity is immutable."""
-        activity = Activity(
+    def test_bioactivity_is_frozen(self, base_entity_kwargs):
+        """Test that Bioactivity is immutable."""
+        bioactivity = Bioactivity(
             **base_entity_kwargs,
             activity_id="ACT1",
             molecule_chembl_id="CHEMBL1",
@@ -169,7 +178,122 @@ class TestActivity:
             assay_chembl_id="CHEMBL3",
         )
         with pytest.raises(AttributeError):
-            activity.activity_id = "NEW_ID"
+            bioactivity.activity_id = "NEW_ID"
+
+    def test_bioactivity_default_state_is_validated(self, base_entity_kwargs):
+        """Test that default state is VALIDATED."""
+        bioactivity = Bioactivity(
+            **base_entity_kwargs,
+            activity_id="ACT1",
+            molecule_chembl_id="CHEMBL1",
+        )
+        assert bioactivity.state == BioactivityState.VALIDATED
+
+    def test_bioactivity_with_state(self, base_entity_kwargs):
+        """Test creating bioactivity with explicit state."""
+        bioactivity = Bioactivity(
+            **base_entity_kwargs,
+            activity_id="ACT1",
+            molecule_chembl_id="CHEMBL1",
+            _state=BioactivityState.RAW,
+        )
+        assert bioactivity.state == BioactivityState.RAW
+
+    def test_bioactivity_with_state_transition(self, base_entity_kwargs):
+        """Test with_state creates new instance with updated state."""
+        bioactivity = Bioactivity(
+            **base_entity_kwargs,
+            activity_id="ACT1",
+            molecule_chembl_id="CHEMBL1",
+            _state=BioactivityState.RAW,
+        )
+        normalized = bioactivity.with_state(BioactivityState.NORMALIZED)
+        assert normalized.state == BioactivityState.NORMALIZED
+        assert bioactivity.state == BioactivityState.RAW  # Original unchanged
+
+    def test_bioactivity_from_raw_factory(self, base_entity_kwargs):
+        """Test from_raw factory method creates entity in RAW state."""
+        raw_data = {
+            "activity_id": 12345,
+            "molecule_chembl_id": "CHEMBL1",
+            "target_chembl_id": "CHEMBL2",
+            "standard_value": "10.5",
+            "pchembl_value": 7.5,
+        }
+        bioactivity = Bioactivity.from_raw(
+            raw_data=raw_data,
+            run_id=base_entity_kwargs["run_id"],
+            ingestion_ts=base_entity_kwargs["ingestion_ts"],
+        )
+        assert bioactivity.state == BioactivityState.RAW
+        assert bioactivity.activity_id == "12345"
+        assert bioactivity.molecule_chembl_id == "CHEMBL1"
+        assert bioactivity.standard_value == 10.5
+        assert bioactivity.pchembl_value == 7.5
+
+    def test_bioactivity_from_raw_missing_activity_id(self):
+        """Test from_raw raises ValueError if activity_id missing."""
+        with pytest.raises(ValueError, match="activity_id"):
+            Bioactivity.from_raw(
+                raw_data={"molecule_chembl_id": "CHEMBL1"},
+                run_id=uuid4(),
+                ingestion_ts=datetime.now(UTC),
+            )
+
+    def test_bioactivity_from_raw_missing_molecule_id(self):
+        """Test from_raw raises ValueError if molecule_chembl_id missing."""
+        with pytest.raises(ValueError, match="molecule_chembl_id"):
+            Bioactivity.from_raw(
+                raw_data={"activity_id": 123},
+                run_id=uuid4(),
+                ingestion_ts=datetime.now(UTC),
+            )
+
+
+@pytest.mark.unit
+class TestBioactivityState:
+    """Tests for BioactivityState enum."""
+
+    def test_state_values(self):
+        """Test state enum values."""
+        assert BioactivityState.RAW.value == "raw"
+        assert BioactivityState.NORMALIZED.value == "normalized"
+        assert BioactivityState.VALIDATED.value == "validated"
+
+    def test_is_ready_for_silver(self):
+        """Test is_ready_for_silver returns True for NORMALIZED and VALIDATED."""
+        assert not BioactivityState.RAW.is_ready_for_silver()
+        assert BioactivityState.NORMALIZED.is_ready_for_silver()
+        assert BioactivityState.VALIDATED.is_ready_for_silver()
+
+    def test_is_fully_validated(self):
+        """Test is_fully_validated returns True only for VALIDATED."""
+        assert not BioactivityState.RAW.is_fully_validated()
+        assert not BioactivityState.NORMALIZED.is_fully_validated()
+        assert BioactivityState.VALIDATED.is_fully_validated()
+
+
+@pytest.mark.unit
+class TestActivityDeprecatedAlias:
+    """Tests for deprecated Activity alias."""
+
+    def test_activity_emits_deprecation_warning(self, base_entity_kwargs):
+        """Test that Activity emits DeprecationWarning."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            Activity(
+                **base_entity_kwargs,
+                activity_id="ACT1",
+                molecule_chembl_id="CHEMBL1",
+            )
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "Activity is deprecated" in str(w[0].message)
+            assert "Bioactivity" in str(w[0].message)
+
+    def test_activity_is_subclass_of_bioactivity(self):
+        """Test that Activity is subclass of Bioactivity."""
+        assert issubclass(Activity, Bioactivity)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
- Add Bioactivity class as canonical bioactivity domain entity
- Add BioactivityState enum (RAW, NORMALIZED, VALIDATED) for lifecycle
- Add from_raw() factory and with_state() for state transitions
- Deprecate Activity class with DeprecationWarning (14-day migration)
- Update ActivityTransformer to use Bioactivity
- Add comprehensive tests for new functionality

Note: RawBioactivityDTO did not exist in codebase - this refactoring improves the existing Activity entity with state tracking and factory.

Closes: domain model unification task