### PR TITLE
Unify pipeline classes to reduce duplication

### DIFF
--- a/src/bioetl/application/pipelines/__init__.py
+++ b/src/bioetl/application/pipelines/__init__.py
@@ -1,3 +1,31 @@
-"""Concrete pipeline implementations."""
+"""Concrete pipeline implementations.
+
+This package provides pipelines for extracting and processing data from
+various bioinformatics data sources.
+
+Main Components:
+- GenericPipeline: Universal pipeline class for all provider/entity combinations
+- Provider-specific transformers: Implement Bronze→Silver transformation logic
+- Deprecated aliases: ChEMBLActivityPipeline, PubChemCompoundPipeline, etc.
+
+Usage:
+    # Recommended approach - use GenericPipeline via factory
+    from bioetl.composition.factories.pipeline_factories import get_factory
+    factory = get_factory("chembl_activity")
+    runner = factory.create_runner(...)
+
+    # Direct instantiation (for testing)
+    from bioetl.application.pipelines.generic import GenericPipeline
+    pipeline = GenericPipeline.create(...)
+
+    # Deprecated aliases (emit DeprecationWarning)
+    from bioetl.application.pipelines.chembl import ChEMBLActivityPipeline
+"""
 
 from __future__ import annotations
+
+from bioetl.application.pipelines.generic import GenericPipeline
+
+__all__ = [
+    "GenericPipeline",
+]

--- a/src/bioetl/application/pipelines/chembl/__init__.py
+++ b/src/bioetl/application/pipelines/chembl/__init__.py
@@ -2,45 +2,59 @@
 
 This package provides pipelines and transformers for extracting and
 processing data from the ChEMBL database.
+
+Main Components:
+- Transformers: ActivityTransformer, AssayTransformer, etc.
+- BaseChemblTransformer: Base class for ChEMBL-specific transformers
+- Deprecated pipeline aliases: ChEMBLActivityPipeline, etc.
+
+Usage:
+    # Recommended - use transformers directly
+    from bioetl.application.pipelines.chembl import ActivityTransformer
+    transformer = ActivityTransformer(provider="chembl")
+
+    # Deprecated - pipeline classes (will emit DeprecationWarning)
+    from bioetl.application.pipelines.chembl import ChEMBLActivityPipeline
 """
 
 from __future__ import annotations
 
-from bioetl.application.pipelines.chembl.activity import ChEMBLActivityPipeline
+# Transformers (actively used)
 from bioetl.application.pipelines.chembl.activity_transformer import (
     ActivityTransformer,
 )
-from bioetl.application.pipelines.chembl.assay import ChEMBLAssayPipeline
 from bioetl.application.pipelines.chembl.assay_transformer import AssayTransformer
 from bioetl.application.pipelines.chembl.base_chembl_transformer import (
     BaseChemblTransformer,
 )
-from bioetl.application.pipelines.chembl.cell_line import ChEMBLCellLinePipeline
 from bioetl.application.pipelines.chembl.cell_line_transformer import (
     CellLineTransformer,
-)
-from bioetl.application.pipelines.chembl.compound_record import (
-    ChEMBLCompoundRecordPipeline,
 )
 from bioetl.application.pipelines.chembl.compound_record_transformer import (
     CompoundRecordTransformer,
 )
-from bioetl.application.pipelines.chembl.document import ChEMBLDocumentPipeline
 from bioetl.application.pipelines.chembl.document_transformer import (
     DocumentTransformer,
 )
-from bioetl.application.pipelines.chembl.molecule import ChEMBLMoleculePipeline
 from bioetl.application.pipelines.chembl.molecule_transformer import (
     MoleculeTransformer,
-)
-from bioetl.application.pipelines.chembl.target import ChEMBLTargetPipeline
-from bioetl.application.pipelines.chembl.target_component import (
-    ChEMBLTargetComponentPipeline,
 )
 from bioetl.application.pipelines.chembl.target_component_transformer import (
     TargetComponentTransformer,
 )
 from bioetl.application.pipelines.chembl.target_transformer import TargetTransformer
+
+# Deprecated pipeline classes (for backward compatibility)
+from bioetl.application.pipelines.compat import (
+    ChEMBLActivityPipeline,
+    ChEMBLAssayPipeline,
+    ChEMBLCellLinePipeline,
+    ChEMBLCompoundRecordPipeline,
+    ChEMBLDocumentPipeline,
+    ChEMBLMoleculePipeline,
+    ChEMBLTargetComponentPipeline,
+    ChEMBLTargetPipeline,
+)
 
 __all__ = [
     "ActivityTransformer",

--- a/src/bioetl/application/pipelines/compat.py
+++ b/src/bioetl/application/pipelines/compat.py
@@ -1,0 +1,162 @@
+"""Backward compatibility module for deprecated pipeline classes.
+
+This module provides deprecated aliases for provider-specific pipeline classes
+that have been replaced by GenericPipeline.
+
+All pipeline classes now use GenericPipeline directly. The old class names
+are kept as type aliases with deprecation warnings.
+
+Usage:
+    # Old (deprecated):
+    from bioetl.application.pipelines.chembl import ChEMBLActivityPipeline
+    pipeline = ChEMBLActivityPipeline(...)  # Warning emitted
+
+    # New (recommended):
+    from bioetl.application.pipelines.generic import GenericPipeline
+    pipeline = GenericPipeline(...)
+
+The deprecated aliases will be removed in a future version.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING
+
+from bioetl.application.pipelines.generic import GenericPipeline
+
+if TYPE_CHECKING:
+    from bioetl.application.core.base_transformer import BaseTransformer
+    from bioetl.application.core.pipeline_services import PipelineServices
+    from bioetl.domain.config import PipelineConfig, RuntimeConfig
+    from bioetl.domain.types import RunID
+
+
+def _create_deprecated_alias(
+    class_name: str,
+    provider: str,
+    entity_type: str,
+) -> type[GenericPipeline]:
+    """Create a deprecated class alias for a pipeline.
+
+    Args:
+        class_name: Original class name (e.g., "ChEMBLActivityPipeline")
+        provider: Provider name (e.g., "chembl")
+        entity_type: Entity type (e.g., "activity")
+
+    Returns:
+        A class that behaves like GenericPipeline but emits a deprecation warning
+    """
+
+    class DeprecatedPipelineAlias(GenericPipeline):
+        """Deprecated pipeline class - use GenericPipeline instead."""
+
+        __doc__ = f"""Deprecated: {class_name} is deprecated.
+
+        Use GenericPipeline directly instead. This class will be removed in a future version.
+
+        Provider: {provider}
+        Entity: {entity_type}
+        """
+
+        def __init__(
+            self,
+            config: PipelineConfig,
+            runtime: RuntimeConfig,
+            services: PipelineServices,
+            run_id: RunID,
+            transformer: BaseTransformer | None = None,
+        ) -> None:
+            warnings.warn(
+                f"{class_name} is deprecated and will be removed in a future version. "
+                "Use GenericPipeline directly instead. All pipeline-specific behavior "
+                "is now configured via YAML configs and injected transformers.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            super().__init__(config, runtime, services, run_id, transformer)
+
+    # Set the class name for better error messages
+    DeprecatedPipelineAlias.__name__ = class_name
+    DeprecatedPipelineAlias.__qualname__ = class_name
+
+    return DeprecatedPipelineAlias
+
+
+# =============================================================================
+# ChEMBL Pipeline Aliases
+# =============================================================================
+
+ChEMBLActivityPipeline: type[GenericPipeline] = _create_deprecated_alias(
+    "ChEMBLActivityPipeline", "chembl", "activity"
+)
+
+ChEMBLAssayPipeline: type[GenericPipeline] = _create_deprecated_alias(
+    "ChEMBLAssayPipeline", "chembl", "assay"
+)
+
+ChEMBLDocumentPipeline: type[GenericPipeline] = _create_deprecated_alias(
+    "ChEMBLDocumentPipeline", "chembl", "document"
+)
+
+ChEMBLMoleculePipeline: type[GenericPipeline] = _create_deprecated_alias(
+    "ChEMBLMoleculePipeline", "chembl", "molecule"
+)
+
+ChEMBLTargetPipeline: type[GenericPipeline] = _create_deprecated_alias(
+    "ChEMBLTargetPipeline", "chembl", "target"
+)
+
+ChEMBLTargetComponentPipeline: type[GenericPipeline] = _create_deprecated_alias(
+    "ChEMBLTargetComponentPipeline", "chembl", "target_component"
+)
+
+ChEMBLCompoundRecordPipeline: type[GenericPipeline] = _create_deprecated_alias(
+    "ChEMBLCompoundRecordPipeline", "chembl", "compound_record"
+)
+
+ChEMBLCellLinePipeline: type[GenericPipeline] = _create_deprecated_alias(
+    "ChEMBLCellLinePipeline", "chembl", "cell_line"
+)
+
+
+# =============================================================================
+# PubChem Pipeline Aliases
+# =============================================================================
+
+PubChemCompoundPipeline: type[GenericPipeline] = _create_deprecated_alias(
+    "PubChemCompoundPipeline", "pubchem", "compound"
+)
+
+
+# =============================================================================
+# UniProt Pipeline Aliases
+# =============================================================================
+
+UniProtProteinPipeline: type[GenericPipeline] = _create_deprecated_alias(
+    "UniProtProteinPipeline", "uniprot", "protein"
+)
+
+
+# =============================================================================
+# PubMed Pipeline Aliases
+# =============================================================================
+
+PubMedPublicationsPipeline: type[GenericPipeline] = _create_deprecated_alias(
+    "PubMedPublicationsPipeline", "pubmed", "publications"
+)
+
+
+__all__ = [
+    "ChEMBLActivityPipeline",
+    "ChEMBLAssayPipeline",
+    "ChEMBLCellLinePipeline",
+    "ChEMBLCompoundRecordPipeline",
+    "ChEMBLDocumentPipeline",
+    "ChEMBLMoleculePipeline",
+    "ChEMBLTargetComponentPipeline",
+    "ChEMBLTargetPipeline",
+    "PubChemCompoundPipeline",
+    "PubMedPublicationsPipeline",
+    "UniProtProteinPipeline",
+]

--- a/src/bioetl/application/pipelines/generic.py
+++ b/src/bioetl/application/pipelines/generic.py
@@ -1,0 +1,73 @@
+"""Generic Pipeline Implementation.
+
+Provides a universal pipeline class that can be used for any provider/entity
+combination. Replaces provider-specific empty pipeline subclasses.
+
+All pipelines are now configured via YAML and DI, eliminating the need for
+separate class files per entity type.
+
+Usage:
+    # Via factory (recommended)
+    factory = GenericPipelineFactory(
+        pipeline_name="chembl_activity",
+        pipeline_class=GenericPipeline,  # Use directly
+        provider="chembl",
+        ...
+    )
+
+    # Direct instantiation (for testing)
+    pipeline = GenericPipeline.create(
+        run_id=run_id,
+        runtime=runtime,
+        services=services,
+        config=config,
+        transformer=transformer,
+    )
+"""
+
+from __future__ import annotations
+
+from bioetl.application.core.base import BasePipeline
+
+
+class GenericPipeline(BasePipeline):
+    """Universal pipeline for all provider/entity combinations.
+
+    This class provides a concrete implementation of BasePipeline that works
+    with any data source. All entity-specific logic is encapsulated in:
+
+    - **Configuration**: YAML configs in `configs/pipelines/{provider}/{entity}.yaml`
+    - **Transformation**: Transformer classes injected via DI
+    - **Schemas**: Silver/Gold schemas for validation
+
+    GenericPipeline eliminates the need for empty pipeline subclasses like
+    ChEMBLActivityPipeline, PubChemCompoundPipeline, etc.
+
+    Benefits:
+    - DRY: No code duplication across pipeline classes
+    - Extensibility: Add new pipelines via YAML config only
+    - Consistency: All pipelines use identical orchestration logic
+    - Testability: Single class to test, well-understood behavior
+
+    Transformer Injection:
+        Transformer is injected via DI from GenericPipelineFactory.
+        If no transformer is provided, transform_bronze_to_silver() raises
+        NotImplementedError (per BasePipeline contract).
+
+    Example YAML Config:
+        ```yaml
+        pipeline_name: chembl_activity
+        provider: chembl
+        entity_type: activity
+        primary_keys: ["activity_id"]
+        silver_table: "chembl_activity"
+        ```
+    """
+
+    # Inherits all behavior from BasePipeline:
+    # - transform_bronze_to_silver() delegates to injected transformer
+    # - Properties: config, runtime, services, run_id, context, logger, etc.
+    # - Lifecycle: shutdown_signal
+
+
+__all__ = ["GenericPipeline"]

--- a/src/bioetl/application/pipelines/pubchem/__init__.py
+++ b/src/bioetl/application/pipelines/pubchem/__init__.py
@@ -2,11 +2,15 @@
 
 This package provides pipelines and transformers for extracting and
 processing data from the PubChem database.
+
+Main Components:
+- PubChemCompoundTransformer: Transformer for compound data
+- PubChemCompoundPipeline: Deprecated alias (use GenericPipeline)
 """
 
 from __future__ import annotations
 
-from bioetl.application.pipelines.pubchem.compound import PubChemCompoundPipeline
+from bioetl.application.pipelines.compat import PubChemCompoundPipeline
 from bioetl.application.pipelines.pubchem.transformer import PubChemCompoundTransformer
 
 __all__ = [

--- a/src/bioetl/application/pipelines/pubmed/__init__.py
+++ b/src/bioetl/application/pipelines/pubmed/__init__.py
@@ -1,0 +1,20 @@
+"""PubMed pipeline components.
+
+This package provides pipelines and transformers for extracting and
+processing data from the PubMed database.
+
+Main Components:
+- PubMedPublicationTransformer: Transformer for publication data
+- PubMedPublicationsPipeline: Deprecated alias (use GenericPipeline)
+"""
+
+from __future__ import annotations
+
+from bioetl.application.pipelines.compat import PubMedPublicationsPipeline
+from bioetl.application.pipelines.pubmed.transformer import PubMedPublicationTransformer
+
+__all__ = [
+    "PubMedPublicationTransformer",
+    # Deprecated
+    "PubMedPublicationsPipeline",
+]

--- a/src/bioetl/application/pipelines/uniprot/__init__.py
+++ b/src/bioetl/application/pipelines/uniprot/__init__.py
@@ -2,11 +2,15 @@
 
 This package provides pipelines and transformers for extracting and
 processing data from the UniProt database.
+
+Main Components:
+- UniProtProteinTransformer: Transformer for protein data
+- UniProtProteinPipeline: Deprecated alias (use GenericPipeline)
 """
 
 from __future__ import annotations
 
-from bioetl.application.pipelines.uniprot.protein import UniProtProteinPipeline
+from bioetl.application.pipelines.compat import UniProtProteinPipeline
 from bioetl.application.pipelines.uniprot.transformer import UniProtProteinTransformer
 
 __all__ = [

--- a/src/bioetl/composition/factories/pipeline_factories.py
+++ b/src/bioetl/composition/factories/pipeline_factories.py
@@ -2,17 +2,24 @@
 """Consolidated pipeline factory definitions.
 
 This module creates all pipeline factories using the GenericPipelineFactory
-pattern. Registration is explicit via register_all_pipelines().
+pattern with GenericPipeline as the unified pipeline class.
+
+All pipeline-specific behavior is encapsulated in:
+- YAML configs (configs/pipelines/{provider}/{entity}.yaml)
+- Transformer classes (injected via DI)
+- Silver/Gold schemas
 
 Thread-safety: Registration uses a module-level lock to prevent TOCTOU race conditions.
-
-Updated: Transformer injection via DI (Phase 1 refactoring).
-All factories now include transformer_class for proper DI.
 
 Instance-level registry support (2025-12):
 - register_all_pipelines() accepts optional registry parameter
 - Default behavior uses global registry for backward compatibility
 - Tests can use isolated registries for parallel execution
+
+Refactored (2025-12):
+- All pipelines now use GenericPipeline instead of provider-specific subclasses
+- Pipeline definitions consolidated into PIPELINE_CONFIGS for loop-based registration
+- Provider-specific pipeline classes are deprecated (backward-compat aliases available)
 
 Usage:
     >>> from bioetl.composition.factories.pipeline_factories import register_all_pipelines
@@ -27,42 +34,31 @@ Usage:
 from __future__ import annotations
 
 import threading
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, NamedTuple
 
-from bioetl.application.pipelines.chembl.activity import ChEMBLActivityPipeline
+# Transformers (all DI-injected)
 from bioetl.application.pipelines.chembl.activity_transformer import ActivityTransformer
-from bioetl.application.pipelines.chembl.assay import ChEMBLAssayPipeline
 from bioetl.application.pipelines.chembl.assay_transformer import AssayTransformer
-from bioetl.application.pipelines.chembl.cell_line import ChEMBLCellLinePipeline
 from bioetl.application.pipelines.chembl.cell_line_transformer import (
     CellLineTransformer,
-)
-from bioetl.application.pipelines.chembl.compound_record import (
-    ChEMBLCompoundRecordPipeline,
 )
 from bioetl.application.pipelines.chembl.compound_record_transformer import (
     CompoundRecordTransformer,
 )
-from bioetl.application.pipelines.chembl.document import ChEMBLDocumentPipeline
 from bioetl.application.pipelines.chembl.document_transformer import DocumentTransformer
-from bioetl.application.pipelines.chembl.molecule import ChEMBLMoleculePipeline
 from bioetl.application.pipelines.chembl.molecule_transformer import MoleculeTransformer
-from bioetl.application.pipelines.chembl.target import ChEMBLTargetPipeline
-from bioetl.application.pipelines.chembl.target_component import (
-    ChEMBLTargetComponentPipeline,
-)
 from bioetl.application.pipelines.chembl.target_component_transformer import (
     TargetComponentTransformer,
 )
 from bioetl.application.pipelines.chembl.target_transformer import TargetTransformer
-from bioetl.application.pipelines.pubchem.compound import PubChemCompoundPipeline
+from bioetl.application.pipelines.generic import GenericPipeline
 from bioetl.application.pipelines.pubchem.transformer import PubChemCompoundTransformer
-from bioetl.application.pipelines.pubmed.publications import PubMedPublicationsPipeline
 from bioetl.application.pipelines.pubmed.transformer import PubMedPublicationTransformer
-from bioetl.application.pipelines.uniprot.protein import UniProtProteinPipeline
 from bioetl.application.pipelines.uniprot.transformer import UniProtProteinTransformer
 from bioetl.composition.factories.pipeline_factory import GenericPipelineFactory
 from bioetl.composition.registry import PipelineRegistry, get_default_registry
+
+# Gold schemas (required for all pipelines)
 from bioetl.infrastructure.schemas.gold import (
     ChEMBLActivityGoldSchema,
     ChEMBLAssayGoldSchema,
@@ -76,6 +72,8 @@ from bioetl.infrastructure.schemas.gold import (
     PubMedPublicationGoldSchema,
     UniProtProteinGoldSchema,
 )
+
+# Silver schemas (optional PyArrow schemas)
 from bioetl.infrastructure.schemas.silver import (
     CHEMBL_ACTIVITY_SCHEMA,
     CHEMBL_ASSAY_SCHEMA,
@@ -91,121 +89,172 @@ from bioetl.infrastructure.schemas.silver import (
 )
 
 if TYPE_CHECKING:
-    pass
+    import pyarrow as pa
+
+    from bioetl.application.core.base_transformer import BaseTransformer
+
+
+# =============================================================================
+# Pipeline Configuration Registry
+# =============================================================================
+
+
+class PipelineFactoryConfig(NamedTuple):
+    """Configuration for creating a pipeline factory.
+
+    This is a value object that holds all metadata needed to create a
+    GenericPipelineFactory instance.
+
+    Attributes:
+        pipeline_name: Unique identifier for the pipeline (e.g., "chembl_activity")
+        provider: Data provider name (e.g., "chembl", "pubchem")
+        transformer_class: Transformer class for Bronze→Silver transformation
+        silver_schema: PyArrow schema for Silver layer validation
+        gold_schema: Pandera schema for Gold layer validation (required)
+    """
+
+    pipeline_name: str
+    provider: str
+    transformer_class: type[BaseTransformer]
+    silver_schema: pa.Schema | None
+    gold_schema: Any  # Pandera schema class
+
+
+# Consolidated pipeline definitions - single source of truth
+PIPELINE_CONFIGS: tuple[PipelineFactoryConfig, ...] = (
+    # ChEMBL pipelines
+    PipelineFactoryConfig(
+        pipeline_name="chembl_activity",
+        provider="chembl",
+        transformer_class=ActivityTransformer,
+        silver_schema=CHEMBL_ACTIVITY_SCHEMA,
+        gold_schema=ChEMBLActivityGoldSchema,
+    ),
+    PipelineFactoryConfig(
+        pipeline_name="chembl_assay",
+        provider="chembl",
+        transformer_class=AssayTransformer,
+        silver_schema=CHEMBL_ASSAY_SCHEMA,
+        gold_schema=ChEMBLAssayGoldSchema,
+    ),
+    PipelineFactoryConfig(
+        pipeline_name="chembl_cell_line",
+        provider="chembl",
+        transformer_class=CellLineTransformer,
+        silver_schema=CHEMBL_CELL_LINE_SCHEMA,
+        gold_schema=ChEMBLCellLineGoldSchema,
+    ),
+    PipelineFactoryConfig(
+        pipeline_name="chembl_compound_record",
+        provider="chembl",
+        transformer_class=CompoundRecordTransformer,
+        silver_schema=CHEMBL_COMPOUND_RECORD_SCHEMA,
+        gold_schema=ChEMBLCompoundRecordGoldSchema,
+    ),
+    PipelineFactoryConfig(
+        pipeline_name="chembl_document",
+        provider="chembl",
+        transformer_class=DocumentTransformer,
+        silver_schema=CHEMBL_DOCUMENT_SCHEMA,
+        gold_schema=ChEMBLDocumentGoldSchema,
+    ),
+    PipelineFactoryConfig(
+        pipeline_name="chembl_molecule",
+        provider="chembl",
+        transformer_class=MoleculeTransformer,
+        silver_schema=CHEMBL_MOLECULE_SCHEMA,
+        gold_schema=ChEMBLMoleculeGoldSchema,
+    ),
+    PipelineFactoryConfig(
+        pipeline_name="chembl_target",
+        provider="chembl",
+        transformer_class=TargetTransformer,
+        silver_schema=CHEMBL_TARGET_SCHEMA,
+        gold_schema=ChEMBLTargetGoldSchema,
+    ),
+    PipelineFactoryConfig(
+        pipeline_name="chembl_target_component",
+        provider="chembl",
+        transformer_class=TargetComponentTransformer,
+        silver_schema=CHEMBL_TARGET_COMPONENT_SCHEMA,
+        gold_schema=ChEMBLTargetComponentGoldSchema,
+    ),
+    # PubChem pipeline
+    PipelineFactoryConfig(
+        pipeline_name="pubchem_compound",
+        provider="pubchem",
+        transformer_class=PubChemCompoundTransformer,
+        silver_schema=PUBCHEM_COMPOUND_SCHEMA,
+        gold_schema=PubChemCompoundGoldSchema,
+    ),
+    # UniProt pipeline
+    PipelineFactoryConfig(
+        pipeline_name="uniprot_protein",
+        provider="uniprot",
+        transformer_class=UniProtProteinTransformer,
+        silver_schema=UNIPROT_PROTEIN_SCHEMA,
+        gold_schema=UniProtProteinGoldSchema,
+    ),
+    # PubMed pipeline
+    PipelineFactoryConfig(
+        pipeline_name="pubmed_publications",
+        provider="pubmed",
+        transformer_class=PubMedPublicationTransformer,
+        silver_schema=PUBMED_PUBLICATION_SCHEMA,
+        gold_schema=PubMedPublicationGoldSchema,
+    ),
+)
+
+
+def _create_factory(config: PipelineFactoryConfig) -> GenericPipelineFactory[GenericPipeline]:
+    """Create a GenericPipelineFactory from configuration.
+
+    Args:
+        config: Pipeline factory configuration
+
+    Returns:
+        Configured GenericPipelineFactory instance
+    """
+    return GenericPipelineFactory(
+        pipeline_name=config.pipeline_name,
+        pipeline_class=GenericPipeline,
+        provider=config.provider,
+        silver_schema=config.silver_schema,
+        gold_schema=config.gold_schema,
+        transformer_class=config.transformer_class,
+    )
+
+
+# =============================================================================
+# Factory Instances (created from PIPELINE_CONFIGS)
+# =============================================================================
+
+# Create all factories using loop over configurations
+_factories: dict[str, GenericPipelineFactory[GenericPipeline]] = {
+    config.pipeline_name: _create_factory(config) for config in PIPELINE_CONFIGS
+}
+
+# Export individual factories for backward compatibility
+chembl_activity_factory = _factories["chembl_activity"]
+chembl_assay_factory = _factories["chembl_assay"]
+chembl_cell_line_factory = _factories["chembl_cell_line"]
+chembl_compound_record_factory = _factories["chembl_compound_record"]
+chembl_document_factory = _factories["chembl_document"]
+chembl_molecule_factory = _factories["chembl_molecule"]
+chembl_target_factory = _factories["chembl_target"]
+chembl_target_component_factory = _factories["chembl_target_component"]
+pubchem_compound_factory = _factories["pubchem_compound"]
+uniprot_protein_factory = _factories["uniprot_protein"]
+pubmed_publications_factory = _factories["pubmed_publications"]
+
+
+# =============================================================================
+# Registration Functions
+# =============================================================================
 
 # Thread-safe registration state
 _registration_lock = threading.Lock()
 _factories_registered = False
-
-# ChEMBL Activity Pipeline
-chembl_activity_factory = GenericPipelineFactory(
-    pipeline_name="chembl_activity",
-    pipeline_class=ChEMBLActivityPipeline,
-    provider="chembl",
-    silver_schema=CHEMBL_ACTIVITY_SCHEMA,
-    gold_schema=ChEMBLActivityGoldSchema,
-    transformer_class=ActivityTransformer,
-)
-
-# ChEMBL Assay Pipeline
-chembl_assay_factory = GenericPipelineFactory(
-    pipeline_name="chembl_assay",
-    pipeline_class=ChEMBLAssayPipeline,
-    provider="chembl",
-    silver_schema=CHEMBL_ASSAY_SCHEMA,
-    gold_schema=ChEMBLAssayGoldSchema,
-    transformer_class=AssayTransformer,
-)
-
-# ChEMBL Document Pipeline
-chembl_document_factory = GenericPipelineFactory(
-    pipeline_name="chembl_document",
-    pipeline_class=ChEMBLDocumentPipeline,
-    provider="chembl",
-    silver_schema=CHEMBL_DOCUMENT_SCHEMA,
-    gold_schema=ChEMBLDocumentGoldSchema,
-    transformer_class=DocumentTransformer,
-)
-
-# ChEMBL Target Pipeline
-chembl_target_factory = GenericPipelineFactory(
-    pipeline_name="chembl_target",
-    pipeline_class=ChEMBLTargetPipeline,
-    provider="chembl",
-    silver_schema=CHEMBL_TARGET_SCHEMA,
-    gold_schema=ChEMBLTargetGoldSchema,
-    transformer_class=TargetTransformer,
-)
-
-# ChEMBL Target Component Pipeline
-chembl_target_component_factory = GenericPipelineFactory(
-    pipeline_name="chembl_target_component",
-    pipeline_class=ChEMBLTargetComponentPipeline,
-    provider="chembl",
-    silver_schema=CHEMBL_TARGET_COMPONENT_SCHEMA,
-    gold_schema=ChEMBLTargetComponentGoldSchema,
-    transformer_class=TargetComponentTransformer,
-)
-
-# ChEMBL Molecule Pipeline
-chembl_molecule_factory = GenericPipelineFactory(
-    pipeline_name="chembl_molecule",
-    pipeline_class=ChEMBLMoleculePipeline,
-    provider="chembl",
-    silver_schema=CHEMBL_MOLECULE_SCHEMA,
-    gold_schema=ChEMBLMoleculeGoldSchema,
-    transformer_class=MoleculeTransformer,
-)
-
-# ChEMBL Compound Record Pipeline
-chembl_compound_record_factory = GenericPipelineFactory(
-    pipeline_name="chembl_compound_record",
-    pipeline_class=ChEMBLCompoundRecordPipeline,
-    provider="chembl",
-    silver_schema=CHEMBL_COMPOUND_RECORD_SCHEMA,
-    gold_schema=ChEMBLCompoundRecordGoldSchema,
-    transformer_class=CompoundRecordTransformer,
-)
-
-# ChEMBL Cell Line Pipeline
-chembl_cell_line_factory = GenericPipelineFactory(
-    pipeline_name="chembl_cell_line",
-    pipeline_class=ChEMBLCellLinePipeline,
-    provider="chembl",
-    silver_schema=CHEMBL_CELL_LINE_SCHEMA,
-    gold_schema=ChEMBLCellLineGoldSchema,
-    transformer_class=CellLineTransformer,
-)
-
-# PubChem Compound Pipeline
-pubchem_compound_factory = GenericPipelineFactory(
-    pipeline_name="pubchem_compound",
-    pipeline_class=PubChemCompoundPipeline,
-    provider="pubchem",
-    silver_schema=PUBCHEM_COMPOUND_SCHEMA,
-    gold_schema=PubChemCompoundGoldSchema,
-    transformer_class=PubChemCompoundTransformer,
-)
-
-# UniProt Protein Pipeline
-uniprot_protein_factory = GenericPipelineFactory(
-    pipeline_name="uniprot_protein",
-    pipeline_class=UniProtProteinPipeline,
-    provider="uniprot",
-    silver_schema=UNIPROT_PROTEIN_SCHEMA,
-    gold_schema=UniProtProteinGoldSchema,
-    transformer_class=UniProtProteinTransformer,
-)
-
-# PubMed Publications Pipeline
-pubmed_publications_factory = GenericPipelineFactory(
-    pipeline_name="pubmed_publications",
-    pipeline_class=PubMedPublicationsPipeline,
-    provider="pubmed",
-    silver_schema=PUBMED_PUBLICATION_SCHEMA,
-    gold_schema=PubMedPublicationGoldSchema,
-    transformer_class=PubMedPublicationTransformer,
-)
 
 
 def register_all_pipelines(registry: PipelineRegistry | None = None) -> None:
@@ -254,21 +303,13 @@ def _register_factories_to(registry: PipelineRegistry) -> None:
     """Register all factory instances to the given registry.
 
     Internal helper for register_all_pipelines().
+    Uses loop over _factories dict for DRY registration.
 
     Args:
         registry: Target registry instance.
     """
-    registry.register_factory(chembl_activity_factory)
-    registry.register_factory(chembl_assay_factory)
-    registry.register_factory(chembl_cell_line_factory)
-    registry.register_factory(chembl_compound_record_factory)
-    registry.register_factory(chembl_document_factory)
-    registry.register_factory(chembl_target_factory)
-    registry.register_factory(chembl_target_component_factory)
-    registry.register_factory(chembl_molecule_factory)
-    registry.register_factory(pubchem_compound_factory)
-    registry.register_factory(uniprot_protein_factory)
-    registry.register_factory(pubmed_publications_factory)
+    for factory in _factories.values():
+        registry.register_factory(factory)
 
 
 def is_registered() -> bool:
@@ -298,7 +339,40 @@ def reset_registration() -> None:
         _factories_registered = False
 
 
+def get_factory(pipeline_name: str) -> GenericPipelineFactory[GenericPipeline]:
+    """Get a pipeline factory by name.
+
+    Convenience function for accessing factories without going through registry.
+
+    Args:
+        pipeline_name: Name of the pipeline (e.g., "chembl_activity")
+
+    Returns:
+        GenericPipelineFactory instance
+
+    Raises:
+        KeyError: If pipeline_name is not found
+    """
+    if pipeline_name not in _factories:
+        available = sorted(_factories.keys())
+        raise KeyError(
+            f"Unknown pipeline: {pipeline_name}. Available: {available}"
+        )
+    return _factories[pipeline_name]
+
+
+def list_available_pipelines() -> list[str]:
+    """List all available pipeline names.
+
+    Returns:
+        Sorted list of pipeline names
+    """
+    return sorted(_factories.keys())
+
+
 __all__ = [
+    "PIPELINE_CONFIGS",
+    "PipelineFactoryConfig",
     "chembl_activity_factory",
     "chembl_assay_factory",
     "chembl_cell_line_factory",
@@ -307,7 +381,9 @@ __all__ = [
     "chembl_molecule_factory",
     "chembl_target_component_factory",
     "chembl_target_factory",
+    "get_factory",
     "is_registered",
+    "list_available_pipelines",
     "pubchem_compound_factory",
     "pubmed_publications_factory",
     "register_all_pipelines",


### PR DESCRIPTION
Eliminates code duplication by replacing provider-specific pipeline subclasses (ChEMBLActivityPipeline, PubChemCompoundPipeline, etc.) with a single GenericPipeline class.

Changes:
- Add GenericPipeline class that works with any provider/entity
- Create PipelineFactoryConfig for declarative factory definitions
- Refactor pipeline_factories.py to use loop-based registration
- Add deprecated aliases in compat.py with DeprecationWarning
- Update package __init__.py files to re-export from compat module

Benefits:
- DRY: ~10 empty pipeline classes replaced with 1 generic class
- Extensibility: Add new pipelines via YAML config only (no new class)
- Consistency: All pipelines use identical orchestration logic
- Backward compatibility: Old class names still work (with warning)

The original pipeline class files remain for now but are no longer imported by the factory system. Deprecated aliases emit warnings when instantiated, guiding users to migrate to GenericPipeline.