### PR TITLE
Remove legacy pipeline implementations from modules

### DIFF
--- a/docs/__-prompts/00-Documentation/01-Дополнение пропущенных docstrings.md
+++ b/docs/__-prompts/00-Documentation/01-Дополнение пропущенных docstrings.md
@@ -84,17 +84,15 @@ class HashService:
 
 **Pipeline (application/pipelines/):**
 ```python
-class ChemblActivityPipeline(ChemblCommonPipeline):
+class ChEMBLActivityPipeline(BasePipeline):
     """Pipeline for ChEMBL activity data extraction and loading.
-    
+
     Follows Medallion Architecture (§2.1):
         Bronze: JSONL + zstd (append-only)
         Silver: Delta Lake (merge/upsert)
         Gold: Delta Lake (strict validation)
-    
-    Attributes:
-        entity: Target entity name ('activity').
-        schema: Pandera schema for validation.
+
+    Transformer is injected via DI from GenericPipelineFactory (REQ-ARCH-DI-007).
     """
 ```
 


### PR DESCRIPTION
Update docstring template to reflect actual class names:
- ChemblActivityPipeline(ChemblCommonPipeline) → ChEMBLActivityPipeline(BasePipeline)
- Update docstring to match DI-injected transformer pattern (REQ-ARCH-DI-007)

Note: Legacy run.py files mentioned in issue do not exist in current codebase. The pipeline structure has already been modernized.