### PR TITLE
Align tracing documentation with actual architecture

### DIFF
--- a/docs/02-architecture/decisions/ADR-022-tracing-noop.md
+++ b/docs/02-architecture/decisions/ADR-022-tracing-noop.md
@@ -1,0 +1,158 @@
+# ADR-022: NoOp Tracing for Local-Only Deployment
+
+*   **Status**: Accepted
+*   **Date**: 2025-12-30
+*   **Extends**: ADR-010 (Local-Only Deployment), ADR-017 (Observability Architecture)
+
+## Context
+
+BioETL uses Local-Only Deployment (ADR-010). Distributed tracing (Jaeger, Zipkin,
+OpenTelemetry Collector) is relevant for microservice architectures but is redundant
+for a local ETL process.
+
+### Current Tracing Needs
+
+| Use Case | Local Solution |
+|----------|---------------|
+| Request correlation | `run_id` in structured logs |
+| Performance debugging | Prometheus histograms (`pipeline_duration_seconds`) |
+| Error tracking | Structured error logs with `run_id`, `stage`, `error_type` |
+| Batch traceability | `run_id` + `batch_id` in logs and metrics |
+
+### Distributed Tracing Overhead
+
+Implementing real OpenTelemetry would require:
+- Additional dependencies (`opentelemetry-api`, `opentelemetry-sdk`, exporters)
+- Running infrastructure (Jaeger/Zipkin/Tempo collector)
+- Context propagation between components
+- Memory overhead for span buffering
+
+This overhead provides no benefit for single-process local execution.
+
+## The Decision
+
+Use **Null Object Pattern** (`NoOpTracing`) as the default tracing implementation.
+Request correlation is provided via `run_id` in structured logs.
+
+### Implementation
+
+```python
+# Default: NoOpTracing (zero overhead)
+from bioetl.infrastructure.observability.noop_tracing import NoOpTracing
+tracing = NoOpTracing()
+
+# Extension point: OpenTelemetryTracer (when distributed deployment needed)
+from bioetl.infrastructure.observability.tracing import OpenTelemetryTracer
+tracing = OpenTelemetryTracer(service_name="bioetl")
+```
+
+### Correlation via run_id (RULES.md §4.5)
+
+All structured logs include `run_id`:
+
+```json
+{
+  "ts": "2025-12-30T10:00:00Z",
+  "level": "INFO",
+  "run_id": "550e8400-e29b-41d4-a716-446655440000",
+  "pipeline": "chembl_activity",
+  "stage": "transform",
+  "record_count": 1000
+}
+```
+
+This enables:
+- Log aggregation: `grep run_id=<uuid> logs/*.jsonl`
+- Metrics correlation: labels include `run_id` where appropriate
+- Batch tracing: `run_id` + `batch_id` for granular tracking
+
+## Justification
+
+### 1. Zero Overhead
+
+`NoOpTracing` operations are no-ops with negligible CPU/memory cost:
+
+```python
+class NoOpTracing:
+    def get_tracer(self, name: str) -> NoOpTracer:
+        return NoOpTracer()  # Stateless, no allocations per span
+
+    def close(self) -> None:
+        self._closed = True  # Idempotent
+```
+
+### 2. TracingPort Preserved
+
+The port interface remains unchanged, preserving the extension point:
+
+```python
+@runtime_checkable
+class TracingPort(Protocol):
+    def get_tracer(self, name: str) -> Any: ...
+    def close(self) -> None: ...
+```
+
+### 3. OpenTelemetry Ready
+
+`OpenTelemetryTracer` class exists in `tracing.py` for future use:
+- Supports OTLP export (production) and Console export (debug)
+- Graceful shutdown with span flushing
+- Compatible with TracingPort interface
+
+### 4. Consistency with ADR-010
+
+Local-Only Deployment principle:
+- No external infrastructure dependencies
+- Single-process execution model
+- File-based storage (Bronze/Silver/Gold)
+
+## Implementation Files
+
+| File | Purpose |
+|------|---------|
+| `infrastructure/observability/noop_tracing.py` | NoOpTracing, NoOpTracer (default) |
+| `infrastructure/observability/tracing.py` | OpenTelemetryTracer (extension point) |
+| `domain/ports/observability.py` | TracingPort protocol |
+| `composition/factories/observability.py` | DI wiring (returns NoOpTracing) |
+
+## Consequences
+
+### Positive
+
+- **(+) Zero overhead**: No memory/CPU cost from span collection
+- **(+) No dependencies**: OpenTelemetry packages not required for default usage
+- **(+) Simple debugging**: `run_id` in logs sufficient for local development
+- **(+) Extension point preserved**: TracingPort + OpenTelemetryTracer ready for future
+- **(+) Consistent with ADR-010**: No external infrastructure needed
+
+### Negative
+
+- **(-) No distributed tracing**: Cannot trace requests across services (not needed for local ETL)
+- **(-) No visual timeline**: No Jaeger/Zipkin UI for span visualization
+
+### Migration Path (Future)
+
+If distributed deployment becomes necessary:
+
+1. Install OpenTelemetry dependencies:
+   ```bash
+   pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp
+   ```
+
+2. Update factory in `composition/factories/observability.py`:
+   ```python
+   def create_tracing(config: Config) -> TracingPort:
+       if config.tracing_enabled:
+           return OpenTelemetryTracer(service_name="bioetl")
+       return NoOpTracing()
+   ```
+
+3. Deploy OpenTelemetry Collector or Jaeger
+
+4. This ADR should be revisited and potentially superseded
+
+## Related ADRs
+
+- **ADR-010**: Local-Only Deployment Strategy — establishes single-process model
+- **ADR-017**: Observability Architecture — defines TracingPort and NoOp pattern
+- **ADR-006**: Logger and Metrics Ports — initial observability ports design

--- a/docs/04-reference/api/infrastructure.md
+++ b/docs/04-reference/api/infrastructure.md
@@ -22,7 +22,7 @@ flowchart TB
 
         subgraph Observability["Observability"]
             Metrics[MetricsExporter]
-            Tracing[TracingExporter]
+            Tracing[NoOpTracing]
             Logging[StructlogLogger]
         end
 
@@ -64,9 +64,20 @@ Storage writers implementing `StoragePort`:
 Observability infrastructure:
 
 - `PrometheusMetrics` - Prometheus metrics exporter
-- `TracingExporter` - OpenTelemetry tracing
+- `NoOpTracing` - Null Object Pattern tracing (see [ADR-022](../02-architecture/decisions/ADR-022-tracing-noop.md))
 - `StructlogLogger` - Structured logging
 - `LineageTracker` - Data lineage tracking
+
+#### Tracing (NoOp)
+
+Tracing is implemented via **Null Object Pattern** (`NoOpTracing`).
+
+**Rationale** (ADR-010, ADR-022): Local-Only Deployment does not require distributed
+tracing. Request correlation is provided via `run_id` in structured logs (RULES.md §4.5).
+
+**Extension Point**: For distributed deployment, replace `NoOpTracing` with
+`OpenTelemetryTracingAdapter` implementing `TracingPort`. The `OpenTelemetryTracer`
+class in `tracing.py` provides a ready implementation.
 
 ## Key Concepts
 
@@ -79,7 +90,7 @@ Observability infrastructure:
 | `LockPort` | `MemoryLock` |
 | `CheckpointPort` | `LocalCheckpoint` |
 | `MetricsPort` | `PrometheusMetrics`, `NoOpMetrics` |
-| `TracingPort` | `TracingExporter`, `NoOpTracing` |
+| `TracingPort` | `NoOpTracing`, `OpenTelemetryTracer` |
 | `LoggerPort` | `StructlogLogger`, `NoOpLogger` |
 
 ### Medallion Storage Layers
@@ -141,7 +152,7 @@ from bioetl.infrastructure.adapters.http import UnifiedHTTPClient
 
 # Observability
 from bioetl.infrastructure.observability import PrometheusMetrics
-from bioetl.infrastructure.observability.tracing import TracingExporter
+from bioetl.infrastructure.observability.tracing import NoOpTracing, OpenTelemetryTracer
 ```
 
 ## See Also

--- a/src/bioetl/infrastructure/observability/tracing.py
+++ b/src/bioetl/infrastructure/observability/tracing.py
@@ -1,4 +1,23 @@
-"""Tracing implementations (OpenTelemetry).
+"""Tracing infrastructure — Null Object Pattern implementation.
+
+Design Decision (ADR-010, ADR-022):
+    Local-Only Deployment does not require distributed tracing.
+    NoOpTracing (default) provides:
+    - Compliance with TracingPort interface
+    - Extension point for future distributed deployment
+    - Zero overhead in current configuration
+
+Correlation:
+    Instead of trace_id, run_id is used (RULES.md §4.5).
+    All structured logs include run_id for request correlation.
+
+Extension Point:
+    To enable tracing, use OpenTelemetryTracer (provided below),
+    register in composition/factories/observability.py.
+
+Available Implementations:
+    - NoOpTracing: Null Object Pattern, default for Local-Only
+    - OpenTelemetryTracer: Real OTel implementation (requires opentelemetry deps)
 
 Implements TracingPort.
 """


### PR DESCRIPTION
- Update infrastructure.md to reflect NoOpTracing as default implementation
- Add comprehensive docstring to tracing.py explaining ADR-010/ADR-022 rationale
- Create ADR-022-tracing-noop.md documenting the architectural decision
- Replace TracingExporter references with NoOpTracing/OpenTelemetryTracer

The documentation now accurately reflects that:
- NoOpTracing is the default for Local-Only Deployment
- run_id provides request correlation instead of trace_id
- OpenTelemetryTracer remains as extension point for future use