### PR TITLE
Remove unused domain layer components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Improves test reliability by testing real integration
 ## [Unreleased]
 
+### Removed
+
+- **Deprecated Domain Classes Cleanup**: Removed 3 deprecated classes from domain layer:
+  - `Activity` class (deprecated alias for `Bioactivity`) - use `Bioactivity` instead
+  - `ChemblApiError` in `domain.exceptions` - use `infrastructure.adapters.chembl.exceptions.ChemblApiError` instead
+  - `CrossRefApiError` in `domain.exceptions` - use `infrastructure.adapters.crossref.exceptions.CrossRefApiError` instead
+  - Updated tools (`verify_schema_parity.py`, `naming_audit.py`) to use `Bioactivity`
+  - Removed corresponding test classes (`TestActivityDeprecatedAlias`, deprecated exception tests)
+  - Net reduction: 3 classes removed from domain layer
+
 ### Verified (No Action Required)
 
 - **ThinPipeline Classes**: Verified absence of `ThinPipeline`, `ChemblPipelineProtocol`, and `bioetl.pipelines.chembl.base` module:

--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -37,7 +37,6 @@ from bioetl.domain.context import (
 
 # Entities (Domain objects)
 from bioetl.domain.entities import (
-    Activity,
     Assay,
     BaseEntity,
     Bioactivity,
@@ -68,10 +67,8 @@ from bioetl.domain.exceptions import (
     BronzeValidationError,
     BucketNotFoundError,
     CheckpointConflictError,
-    ChemblApiError,
     CircuitBreakerOpenError,
     CriticalError,
-    CrossRefApiError,
     DataQualityError,
     DataQualityThresholdError,
     DataValidationError,
@@ -243,7 +240,6 @@ __all__ = [
     "PipelineContext",
     "PipelineRunContext",
     # Entities
-    "Activity",
     "Assay",
     "BaseEntity",
     "Bioactivity",
@@ -295,9 +291,6 @@ __all__ = [
     "TableNotFoundError",
     "TimeoutError",
     "UploadError",
-    # Exceptions - Deprecated provider-specific (backward compatibility)
-    "ChemblApiError",
-    "CrossRefApiError",
     # Exceptions - Data Quality
     "DataQualityThresholdError",
     "InvalidDataFormatError",

--- a/src/bioetl/domain/entities/__init__.py
+++ b/src/bioetl/domain/entities/__init__.py
@@ -20,7 +20,7 @@ Field Classification:
 
 from bioetl.domain.entities.base import BaseEntity
 from bioetl.domain.entities.bioactivity import Bioactivity, BioactivityState
-from bioetl.domain.entities.chembl_activity import Activity, Assay
+from bioetl.domain.entities.chembl_activity import Assay
 from bioetl.domain.entities.chembl_compound_record import CompoundRecord
 from bioetl.domain.entities.chembl_structures import (
     CellLine,
@@ -35,7 +35,6 @@ from bioetl.domain.entities.pubmed import Publication
 from bioetl.domain.entities.uniprot import Protein
 
 __all__ = [
-    "Activity",  # Deprecated: use Bioactivity instead
     "Assay",
     "BaseEntity",
     "Bioactivity",

--- a/src/bioetl/domain/entities/chembl_activity.py
+++ b/src/bioetl/domain/entities/chembl_activity.py
@@ -1,11 +1,6 @@
 """ChEMBL bioactivity domain entities.
 
-Contains Activity (deprecated alias for Bioactivity) and Assay entities.
-
-Migration Note:
-    The `Activity` class is deprecated in favor of `Bioactivity`.
-    Use `from bioetl.domain.entities import Bioactivity` for new code.
-    The `Activity` alias will be removed after 14 days.
+Contains Assay entity for bioassay definitions.
 
 Field Classification:
     - REQUIRED: Validated in __post_init__, will raise ValueError if empty
@@ -15,9 +10,7 @@ Field Classification:
 
 from __future__ import annotations
 
-import warnings
 from dataclasses import dataclass
-from typing import Any
 
 from bioetl.domain.entities.base import BaseEntity
 from bioetl.domain.entities.bioactivity import (
@@ -26,40 +19,10 @@ from bioetl.domain.entities.bioactivity import (
 )
 
 __all__ = [
-    "Activity",
     "Assay",
     "Bioactivity",
     "BioactivityState",
 ]
-
-
-class Activity(Bioactivity):
-    """Deprecated alias for Bioactivity.
-
-    .. deprecated:: 1.0.0
-        Use :class:`Bioactivity` instead. This alias will be removed in 14 days.
-
-    This class exists for backward compatibility during migration.
-    All functionality is inherited from Bioactivity.
-
-    Example:
-        >>> # Old code (deprecated):
-        >>> from bioetl.domain.entities import Activity
-        >>> activity = Activity(...)  # Will emit DeprecationWarning
-
-        >>> # New code (recommended):
-        >>> from bioetl.domain.entities import Bioactivity
-        >>> bioactivity = Bioactivity(...)
-    """
-
-    def __init__(self, **kwargs: Any) -> None:
-        warnings.warn(
-            "Activity is deprecated, use Bioactivity instead. "
-            "This alias will be removed in 14 days.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        super().__init__(**kwargs)
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/bioetl/domain/exceptions/__init__.py
+++ b/src/bioetl/domain/exceptions/__init__.py
@@ -19,10 +19,10 @@ External Service Exceptions (RULES.md §7.2):
     - ServiceAuthenticationError: Auth failed (401/403)
     - DataValidationError: Invalid data from external source
 
-Deprecated Exceptions:
-    ChemblApiError and CrossRefApiError are deprecated in domain layer.
-    Use infrastructure.adapters.{provider}.exceptions instead, and catch
-    ExternalServiceError in application layer.
+Provider-Specific Exceptions:
+    Provider-specific API errors (ChemblApiError, CrossRefApiError, etc.) are
+    defined in infrastructure.adapters.{provider}.exceptions. Application layer
+    should catch ExternalServiceError instead.
 """
 
 from bioetl.domain.exceptions.base import (
@@ -56,9 +56,7 @@ from bioetl.domain.exceptions.external_service import (
 )
 from bioetl.domain.exceptions.recoverable import (
     ApiError,
-    ChemblApiError,
     CircuitBreakerOpenError,
-    CrossRefApiError,
     NetworkError,
     RateLimitError,
     RetryExhaustedError,
@@ -80,10 +78,8 @@ __all__ = [
     "BronzeValidationError",
     "BucketNotFoundError",
     "CheckpointConflictError",
-    "ChemblApiError",
     "CircuitBreakerOpenError",
     "CriticalError",
-    "CrossRefApiError",
     "DataQualityError",
     "DataQualityThresholdError",
     "DataValidationError",

--- a/src/bioetl/domain/exceptions/recoverable.py
+++ b/src/bioetl/domain/exceptions/recoverable.py
@@ -6,10 +6,7 @@ Examples: network timeouts, rate limits, temporary service unavailability.
 
 from __future__ import annotations
 
-import warnings
-
 from bioetl.domain.exceptions.base import RecoverableError
-from bioetl.domain.exceptions.external_service import ExternalServiceError
 from bioetl.domain.types import ErrorType
 
 
@@ -81,66 +78,6 @@ class ApiError(RecoverableError):
         if status_code:
             msg = f"[{status_code}] {message}"
         super().__init__(msg)
-
-
-class ChemblApiError(ExternalServiceError):
-    """Raised when ChEMBL API returns an error.
-
-    .. deprecated::
-        Use infrastructure.adapters.chembl.exceptions.ChemblApiError instead.
-        This class remains for backward compatibility and will emit a
-        DeprecationWarning when instantiated.
-
-        Application layer should catch ExternalServiceError instead.
-    """
-
-    error_type = ErrorType.NETWORK_ERROR
-
-    def __init__(self, message: str, status_code: int | None = None) -> None:
-        """Initialize ChemblApiError with deprecation warning.
-
-        Args:
-            message: Error message.
-            status_code: Optional HTTP status code.
-        """
-        warnings.warn(
-            "ChemblApiError in domain.exceptions is deprecated. "
-            "Use infrastructure.adapters.chembl.exceptions.ChemblApiError "
-            "or catch ExternalServiceError instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        super().__init__(message, service_name="chembl", status_code=status_code)
-
-
-class CrossRefApiError(ExternalServiceError):
-    """Raised when CrossRef API returns an error.
-
-    .. deprecated::
-        Use infrastructure.adapters.crossref.exceptions.CrossRefApiError instead.
-        This class remains for backward compatibility and will emit a
-        DeprecationWarning when instantiated.
-
-        Application layer should catch ExternalServiceError instead.
-    """
-
-    error_type = ErrorType.NETWORK_ERROR
-
-    def __init__(self, message: str, status_code: int | None = None) -> None:
-        """Initialize CrossRefApiError with deprecation warning.
-
-        Args:
-            message: Error message.
-            status_code: Optional HTTP status code.
-        """
-        warnings.warn(
-            "CrossRefApiError in domain.exceptions is deprecated. "
-            "Use infrastructure.adapters.crossref.exceptions.CrossRefApiError "
-            "or catch ExternalServiceError instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        super().__init__(message, service_name="crossref", status_code=status_code)
 
 
 class TimeoutError(RecoverableError):

--- a/src/tools/naming_audit.py
+++ b/src/tools/naming_audit.py
@@ -84,7 +84,7 @@ ROLE_SUFFIXES = {
 # Допустимые классы без суффиксов (domain entities, enums, etc.)
 ALLOWED_NO_SUFFIX = {
     # Domain entities
-    "Activity",
+    "Bioactivity",
     "Assay",
     "Target",
     "TargetComponent",

--- a/src/tools/verify_schema_parity.py
+++ b/src/tools/verify_schema_parity.py
@@ -2,7 +2,8 @@
 
 import dataclasses
 
-from bioetl.domain.entities.chembl_activity import Activity, Assay
+from bioetl.domain.entities.bioactivity import Bioactivity
+from bioetl.domain.entities.chembl_activity import Assay
 from bioetl.domain.entities.chembl_structures import Molecule, Target
 from bioetl.infrastructure.schemas.gold import (
     ChEMBLActivityGoldSchema,
@@ -82,5 +83,7 @@ def check_parity(name, domain_cls, silver_schema, gold_model):
 if __name__ == "__main__":
     check_parity("Molecule", Molecule, CHEMBL_MOLECULE_SCHEMA, ChEMBLMoleculeGoldSchema)
     check_parity("Target", Target, CHEMBL_TARGET_SCHEMA, ChEMBLTargetGoldSchema)
-    check_parity("Activity", Activity, CHEMBL_ACTIVITY_SCHEMA, ChEMBLActivityGoldSchema)
+    check_parity(
+        "Bioactivity", Bioactivity, CHEMBL_ACTIVITY_SCHEMA, ChEMBLActivityGoldSchema
+    )
     check_parity("Assay", Assay, CHEMBL_ASSAY_SCHEMA, ChEMBLAssayGoldSchema)

--- a/tests/unit/application/pipelines/__snapshots__/test_transformer_snapshots.ambr
+++ b/tests/unit/application/pipelines/__snapshots__/test_transformer_snapshots.ambr
@@ -6,6 +6,7 @@
     '_run_id': '<run_id>',
     '_run_type': 'incremental',
     '_source_batch_id': None,
+    '_state': <BioactivityState.VALIDATED: 'validated'>,
     'action_type_action_type': None,
     'action_type_description': None,
     'action_type_parent_type': None,

--- a/tests/unit/domain/test_entities.py
+++ b/tests/unit/domain/test_entities.py
@@ -7,10 +7,7 @@ from uuid import uuid4
 
 import pytest
 
-import warnings
-
 from bioetl.domain.entities import (
-    Activity,
     Bioactivity,
     BioactivityState,
     Compound,
@@ -271,29 +268,6 @@ class TestBioactivityState:
         assert not BioactivityState.RAW.is_fully_validated()
         assert not BioactivityState.NORMALIZED.is_fully_validated()
         assert BioactivityState.VALIDATED.is_fully_validated()
-
-
-@pytest.mark.unit
-class TestActivityDeprecatedAlias:
-    """Tests for deprecated Activity alias."""
-
-    def test_activity_emits_deprecation_warning(self, base_entity_kwargs):
-        """Test that Activity emits DeprecationWarning."""
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            Activity(
-                **base_entity_kwargs,
-                activity_id="ACT1",
-                molecule_chembl_id="CHEMBL1",
-            )
-            assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
-            assert "Activity is deprecated" in str(w[0].message)
-            assert "Bioactivity" in str(w[0].message)
-
-    def test_activity_is_subclass_of_bioactivity(self):
-        """Test that Activity is subclass of Bioactivity."""
-        assert issubclass(Activity, Bioactivity)
 
 
 @pytest.mark.unit

--- a/tests/unit/domain/test_exceptions.py
+++ b/tests/unit/domain/test_exceptions.py
@@ -10,7 +10,6 @@ from bioetl.domain.exceptions import (
     BioETLError,
     BucketNotFoundError,
     CheckpointConflictError,
-    ChemblApiError,
     CircuitBreakerOpenError,
     CriticalError,
     DataQualityError,
@@ -82,27 +81,6 @@ class TestExceptions:
         assert e.record_id is None
         assert "Missing required field: activity_id" in str(e)
         assert "record_id" not in str(e)
-
-    def test_chembl_api_error_inheritance(self) -> None:
-        """Test ChemblApiError inherits from ExternalServiceError.
-
-        Note: ChemblApiError in domain is deprecated. The canonical version
-        is in infrastructure.adapters.chembl.exceptions.
-        """
-        import warnings
-
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            e = ChemblApiError("ChEMBL service unavailable", 503)
-            # Check deprecation warning was issued
-            assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
-            assert "deprecated" in str(w[0].message).lower()
-
-        assert isinstance(e, ExternalServiceError)
-        assert isinstance(e, RecoverableError)
-        assert e.status_code == 503
-        assert e.service_name == "chembl"
 
     def test_storage_error_inheritance(self) -> None:
         """Test StorageError inheritance."""
@@ -387,15 +365,14 @@ class TestErrorContext:
 
     def test_context_inheritance(self) -> None:
         """Subclass context should include parent class attributes."""
-        import warnings
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            err = ChemblApiError("Service unavailable", status_code=503)
+        # ServiceUnavailableError inherits from ExternalServiceError
+        err = ServiceUnavailableError(
+            "Service unavailable", service_name="chembl", status_code=503
+        )
 
         ctx = err.context
 
-        # ChemblApiError inherits from ExternalServiceError which sets service_name and status_code
+        # ExternalServiceError sets service_name and status_code
         assert ctx["service_name"] == "chembl"
         assert ctx["status_code"] == 503
 


### PR DESCRIPTION
…fApiError

Removed 3 deprecated classes from the domain layer:

- Activity class (deprecated alias for Bioactivity)
  - Users should use Bioactivity directly
  - Updated tools/verify_schema_parity.py to use Bioactivity
  - Updated tools/naming_audit.py to use Bioactivity

- ChemblApiError in domain.exceptions
  - Canonical version is in infrastructure.adapters.chembl.exceptions
  - Application layer should catch ExternalServiceError

- CrossRefApiError in domain.exceptions
  - Canonical version is in infrastructure.adapters.crossref.exceptions
  - Application layer should catch ExternalServiceError

Updated exports in:
- src/bioetl/domain/__init__.py
- src/bioetl/domain/entities/__init__.py
- src/bioetl/domain/exceptions/__init__.py
- src/bioetl/domain/exceptions/recoverable.py
- src/bioetl/domain/entities/chembl_activity.py

Test updates:
- Removed TestActivityDeprecatedAlias class
- Updated test_context_inheritance to use ServiceUnavailableError
- Updated snapshot for ActivityTransformer

All tests pass: 1612 passed, 1 skipped
Mypy strict check: Success (89 files)