### PR TITLE
Remove debug output from CLI

### DIFF
--- a/src/bioetl/composition/_bootstrap/observability.py
+++ b/src/bioetl/composition/_bootstrap/observability.py
@@ -229,6 +229,7 @@ def bootstrap_observability(
     pipeline: str,
     run_id: UUID,
     settings: Settings,
+    log_level: str = "INFO",
 ) -> ObservabilityBundle:
     """Bootstrap all observability components.
 
@@ -244,6 +245,7 @@ def bootstrap_observability(
         pipeline: Pipeline name for logger context.
         run_id: Unique run identifier.
         settings: Application settings.
+        log_level: Logging level (DEBUG, INFO, WARNING, ERROR). Default: INFO.
 
     Returns:
         Configured ObservabilityBundle instance with valid implementations.
@@ -252,7 +254,7 @@ def bootstrap_observability(
     Raises:
         ObservabilityContractError: If bundle creation fails validation.
     """
-    logger = bootstrap_logger(pipeline=pipeline, run_id=run_id)
+    logger = bootstrap_logger(pipeline=pipeline, run_id=run_id, log_level=log_level)
     tracer = bootstrap_tracer(settings)
     metrics = bootstrap_metrics(settings)
     dq_monitor = bootstrap_dq_monitor(settings, logger)

--- a/src/bioetl/composition/bootstrap.py
+++ b/src/bioetl/composition/bootstrap.py
@@ -123,6 +123,7 @@ def bootstrap_pipeline(
         pipeline=ctx.pipeline_name,
         run_id=ctx.run_id,
         settings=settings,
+        log_level=ctx.log_level,
     )
 
     # Merge YAML maintenance config with CLI overrides

--- a/src/bioetl/composition/entrypoints.py
+++ b/src/bioetl/composition/entrypoints.py
@@ -113,6 +113,7 @@ class RunOptions:
         dry_run: Preview mode without execution.
         vacuum_after_run: Enable automatic VACUUM after successful run (CLI override).
         vacuum_retention_days: Minimum age of files to remove during VACUUM (CLI override).
+        log_level: Logging level (DEBUG, INFO, WARNING, ERROR). Default: INFO.
     """
 
     run_type: str = "incremental"
@@ -124,6 +125,7 @@ class RunOptions:
     dry_run: bool = False
     vacuum_after_run: bool | None = None
     vacuum_retention_days: int | None = None
+    log_level: str = "INFO"
 
 
 @dataclass(frozen=True)
@@ -275,6 +277,7 @@ def build_pipeline_context(name: str, options: RunOptions) -> PipelineRunContext
         dry_run=options.dry_run,
         input_filter=input_filter,
         vacuum=vacuum,
+        log_level=options.log_level,
     )
 
 

--- a/src/bioetl/domain/context.py
+++ b/src/bioetl/domain/context.py
@@ -177,6 +177,9 @@ class PipelineRunContext:
     limit: int | None = None
     query: str | None = None
 
+    # Logging configuration
+    log_level: str = "INFO"
+
     @property
     def has_input_filter(self) -> bool:
         """Check if input filtering is enabled."""

--- a/src/bioetl/interfaces/cli/commands/run.py
+++ b/src/bioetl/interfaces/cli/commands/run.py
@@ -82,6 +82,11 @@ _preview_cleanup = show_cleanup_preview
     default=None,
     help="Minimum age of files to remove during VACUUM (days, overrides YAML config)",
 )
+@click.option(
+    "--debug",
+    is_flag=True,
+    help="Enable DEBUG level logging for detailed output",
+)
 def run(
     pipeline: str,
     run_type: str,
@@ -94,6 +99,7 @@ def run(
     yes: bool,
     vacuum_after_run: bool | None,
     vacuum_retention_days: int | None,
+    debug: bool,
 ) -> None:
     """Run an ETL pipeline."""
     if not handle_destructive_run_confirmation(pipeline, run_type, dry_run, yes):
@@ -110,6 +116,7 @@ def run(
             dry_run=dry_run,
             vacuum_after_run=vacuum_after_run if vacuum_after_run else None,
             vacuum_retention_days=vacuum_retention_days,
+            log_level="DEBUG" if debug else "INFO",
         )
         runner = create_pipeline_runner(pipeline, options)
     except (ValueError, FileNotFoundError) as e:


### PR DESCRIPTION
Add --debug flag to the run command to enable DEBUG level logging for detailed output during pipeline execution. The flag controls the log_level parameter which is passed through RunOptions, PipelineRunContext, and bootstrap_observability to configure structlog with the appropriate level.

No debug print statements were found in the codebase - it already uses proper structlog logger.debug() calls that are controlled by the log level.

Changes:
- Add log_level field to PipelineRunContext (domain/context.py)
- Add log_level field to RunOptions (composition/entrypoints.py)
- Wire log_level through build_pipeline_context and bootstrap_observability
- Add --debug flag to CLI run command that sets log_level="DEBUG"