### PR TITLE
Replace dict with typed DTO models

### DIFF
--- a/src/bioetl/domain/entities/__init__.py
+++ b/src/bioetl/domain/entities/__init__.py
@@ -1,25 +1,39 @@
 """Domain entities for BioETL.
 
-Defines rich domain objects with invariants and business logic.
-Implements part of the Domain Layer (RULES.md §1).
+Contains two categories of domain objects:
 
-These entities are distinct from:
-- DTOs/TypedDicts (used for serialization/transport)
-- Infrastructure Schemas (PyArrow/Pandera used for validation)
+1. **Domain Entities** (dataclass): Rich domain objects with lineage fields
+   - Validated on construction (__post_init__)
+   - Include run_id, content_hash for data lineage
 
-Design Principles:
-- Immutable (frozen dataclasses with slots=True for memory efficiency)
-- Validated on construction (__post_init__)
-- Pure Python (no external dependencies)
+2. **DTO Models** (Pydantic): Type-safe data transfer objects
+   - Use extra='forbid' to detect API changes early
+   - frozen=True ensures immutability
+   - Adapters return DTOs, transformers convert to Domain Entities
+
+Implements part of the Domain Layer (RULES.md §1, §8.2).
 
 Field Classification:
-- REQUIRED: Fields validated in __post_init__ (must be non-None)
+- REQUIRED: Fields validated on construction
 - API-OPTIONAL: Fields from external APIs (may be None)
 - COMPUTED: Derived fields (calculated from other fields)
 """
 
 from bioetl.domain.entities.base import BaseEntity
 from bioetl.domain.entities.bioactivity import Bioactivity, BioactivityState
+
+# ChEMBL DTOs (Pydantic)
+from bioetl.domain.entities.chembl import (
+    ActivityRecord,
+    AssayRecord,
+    CellLineRecord,
+    DocumentRecord,
+    MoleculeRecord,
+    TargetComponentRecord,
+    TargetRecord,
+)
+
+# ChEMBL Domain Entities (dataclass)
 from bioetl.domain.entities.chembl_activity import Assay
 from bioetl.domain.entities.chembl_compound_record import CompoundRecord
 from bioetl.domain.entities.chembl_structures import (
@@ -29,24 +43,42 @@ from bioetl.domain.entities.chembl_structures import (
     Target,
     TargetComponent,
 )
-from bioetl.domain.entities.crossref import Work
-from bioetl.domain.entities.pubchem import Compound
-from bioetl.domain.entities.pubmed import Publication
+
+# CrossRef DTO + Entity
+from bioetl.domain.entities.crossref import PublicationRecord, Work
+
+# PubChem DTO + Entity
+from bioetl.domain.entities.pubchem import Compound, PubChemCompoundRecord
+
+# PubMed DTO + Entity
+from bioetl.domain.entities.pubmed import ArticleRecord, Publication
+
+# UniProt Entity
 from bioetl.domain.entities.uniprot import Protein
 
 __all__ = [
+    "ActivityRecord",
+    "ArticleRecord",
     "Assay",
+    "AssayRecord",
     "BaseEntity",
     "Bioactivity",
     "BioactivityState",
     "CellLine",
+    "CellLineRecord",
     "Compound",
     "CompoundRecord",
     "Document",
+    "DocumentRecord",
     "Molecule",
+    "MoleculeRecord",
     "Protein",
+    "PubChemCompoundRecord",
     "Publication",
+    "PublicationRecord",
     "Target",
     "TargetComponent",
+    "TargetComponentRecord",
+    "TargetRecord",
     "Work",
 ]

--- a/src/bioetl/domain/entities/chembl.py
+++ b/src/bioetl/domain/entities/chembl.py
@@ -1,0 +1,714 @@
+"""ChEMBL DTO models for type-safe data transfer.
+
+These Pydantic models provide strict validation at domain boundaries.
+Unlike infrastructure models (extra='ignore'), these use extra='forbid'
+to detect API changes early.
+
+Design:
+- DTOs are pure data containers (no lineage fields like run_id)
+- Adapters return DTOs, transformers convert to Domain Entities
+- frozen=True ensures immutability
+- extra='forbid' rejects unknown fields for early API change detection
+
+Usage:
+    # In adapter (with validation)
+    record = ActivityRecord.model_validate(api_response)
+
+    # For trusted data (skip validation for performance)
+    record = ActivityRecord.model_construct(**trusted_dict)
+
+    # Convert to dict for storage
+    data = record.model_dump()
+
+See RULES.md §8.2 for JSON response modeling guidelines.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ActivityRecord(BaseModel):
+    """Bioactivity measurement DTO from ChEMBL.
+
+    Represents a single activity measurement from ChEMBL API.
+    Required fields: activity_id, molecule_chembl_id.
+
+    Example:
+        >>> record = ActivityRecord(
+        ...     activity_id="12345",
+        ...     molecule_chembl_id="CHEMBL25",
+        ...     assay_chembl_id="CHEMBL1000",
+        ...     standard_type="IC50",
+        ...     standard_value=5.0,
+        ...     standard_units="nM",
+        ... )
+        >>> record.model_dump()
+        {'activity_id': '12345', 'molecule_chembl_id': 'CHEMBL25', ...}
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    # Primary identifier (REQUIRED)
+    activity_id: str = Field(description="Unique activity identifier")
+
+    # Core identifiers (REQUIRED: molecule_chembl_id)
+    molecule_chembl_id: str = Field(description="ChEMBL ID of tested molecule")
+    assay_chembl_id: str | None = Field(
+        default=None, description="ChEMBL ID of the assay"
+    )
+    target_chembl_id: str | None = Field(
+        default=None, description="ChEMBL ID of the target"
+    )
+    document_chembl_id: str | None = Field(
+        default=None, description="ChEMBL ID of the source document"
+    )
+
+    # Standardized activity values
+    standard_type: str | None = Field(
+        default=None, description="Standardized measurement type (IC50, EC50, Ki, etc.)"
+    )
+    standard_value: float | None = Field(
+        default=None, description="Standardized activity value"
+    )
+    standard_units: str | None = Field(
+        default=None, description="Standardized units (nM, uM, etc.)"
+    )
+    standard_relation: str | None = Field(
+        default=None, description="Relation operator (=, <, >, etc.)"
+    )
+    standard_upper_value: float | None = Field(
+        default=None, description="Standardized upper bound for ranges"
+    )
+    standard_text_value: str | None = Field(
+        default=None, description="Standardized text value"
+    )
+    standard_flag: int | None = Field(
+        default=None, description="Standardization flag (0 or 1)"
+    )
+
+    # Derived metrics
+    pchembl_value: float | None = Field(
+        default=None, description="-log10 of molar activity value"
+    )
+
+    # Original (non-standardized) values
+    type: str | None = Field(default=None, description="Original measurement type")
+    value: float | None = Field(default=None, description="Original activity value")
+    units: str | None = Field(default=None, description="Original units")
+    relation: str | None = Field(default=None, description="Original relation operator")
+    upper_value: float | None = Field(default=None, description="Original upper bound")
+    text_value: str | None = Field(default=None, description="Original text value")
+
+    # Molecule data (denormalized)
+    canonical_smiles: str | None = Field(
+        default=None, description="Canonical SMILES structure"
+    )
+    molecule_pref_name: str | None = Field(
+        default=None, description="Molecule preferred name"
+    )
+    parent_molecule_chembl_id: str | None = Field(
+        default=None, description="Parent molecule ChEMBL ID"
+    )
+
+    # Target data (denormalized)
+    target_pref_name: str | None = Field(
+        default=None, description="Target preferred name"
+    )
+    target_organism: str | None = Field(
+        default=None, description="Target organism name"
+    )
+    target_tax_id: str | None = Field(default=None, description="Target taxonomy ID")
+
+    # Assay data (denormalized)
+    assay_type: str | None = Field(default=None, description="Assay type code (B/F/A)")
+    assay_description: str | None = Field(
+        default=None, description="Assay description text"
+    )
+    assay_variant_accession: str | None = Field(
+        default=None, description="Variant UniProt accession"
+    )
+    assay_variant_mutation: str | None = Field(
+        default=None, description="Variant mutation description"
+    )
+
+    # BioAssay Ontology annotations
+    bao_endpoint: str | None = Field(default=None, description="BAO endpoint ID")
+    bao_format: str | None = Field(default=None, description="BAO format ID")
+    bao_label: str | None = Field(default=None, description="BAO label")
+
+    # Unit ontologies
+    qudt_units: str | None = Field(default=None, description="QUDT unit URI")
+    uo_units: str | None = Field(default=None, description="Units Ontology ID")
+
+    # Source and record info
+    src_id: int | None = Field(default=None, description="Data source ID")
+    record_id: int | None = Field(
+        default=None, description="FK to compound_record table"
+    )
+    toid: int | None = Field(default=None, description="Test Occasion ID")
+
+    # Document data (denormalized)
+    document_journal: str | None = Field(
+        default=None, description="Source journal name"
+    )
+    document_year: int | None = Field(default=None, description="Publication year")
+
+    # Data quality annotations
+    activity_comment: str | None = Field(
+        default=None, description="Activity textual comment"
+    )
+    data_validity_comment: str | None = Field(
+        default=None, description="Data quality comment"
+    )
+    data_validity_description: str | None = Field(
+        default=None, description="Data validity description"
+    )
+    potential_duplicate: int | None = Field(
+        default=None, description="Potential duplicate flag"
+    )
+
+    # Ligand efficiency metrics (flattened)
+    ligand_efficiency_bei: float | None = Field(
+        default=None, description="Binding Efficiency Index"
+    )
+    ligand_efficiency_le: float | None = Field(
+        default=None, description="Ligand Efficiency"
+    )
+    ligand_efficiency_lle: float | None = Field(
+        default=None, description="Lipophilic Ligand Efficiency"
+    )
+    ligand_efficiency_sei: float | None = Field(
+        default=None, description="Surface Efficiency Index"
+    )
+
+    # Action type (flattened)
+    action_type: str | None = Field(
+        default=None, description="Action type (INHIBITOR, AGONIST, etc.)"
+    )
+    action_type_description: str | None = Field(
+        default=None, description="Action type description"
+    )
+    action_type_parent: str | None = Field(
+        default=None, description="Parent action type"
+    )
+
+    # Complex fields (JSON serialized for forensic)
+    activity_properties_json: str | None = Field(
+        default=None, description="Activity properties as JSON string"
+    )
+
+
+class AssayRecord(BaseModel):
+    """Bioassay definition DTO from ChEMBL.
+
+    Represents a bioassay protocol from ChEMBL API.
+    Required field: assay_chembl_id.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    # Primary identifier (REQUIRED)
+    assay_chembl_id: str = Field(description="Unique assay ChEMBL ID")
+
+    # Core identifiers
+    target_chembl_id: str | None = Field(
+        default=None, description="Target ChEMBL ID"
+    )
+    document_chembl_id: str | None = Field(
+        default=None, description="Source document ChEMBL ID"
+    )
+    cell_chembl_id: str | None = Field(
+        default=None, description="Cell line ChEMBL ID"
+    )
+    tissue_chembl_id: str | None = Field(
+        default=None, description="Tissue ChEMBL ID"
+    )
+    src_id: int | None = Field(default=None, description="Data source ID")
+    src_assay_id: str | None = Field(
+        default=None, description="Original source assay ID"
+    )
+    aidx: str | None = Field(default=None, description="Assay index")
+
+    # Assay classification
+    assay_type: str | None = Field(
+        default=None, description="Assay type code (B/F/A/T/P/U)"
+    )
+    assay_type_description: str | None = Field(
+        default=None, description="Full assay type description"
+    )
+    assay_category: str | None = Field(
+        default=None, description="Assay category"
+    )
+    assay_test_type: str | None = Field(
+        default=None, description="Test type (in vivo/in vitro)"
+    )
+    assay_group: str | None = Field(default=None, description="Assay group")
+
+    # Biological context
+    assay_organism: str | None = Field(
+        default=None, description="Organism used in assay"
+    )
+    assay_tax_id: int | None = Field(
+        default=None, description="NCBI Taxonomy ID for assay organism"
+    )
+    assay_cell_type: str | None = Field(
+        default=None, description="Cell type used"
+    )
+    assay_tissue: str | None = Field(
+        default=None, description="Tissue type used"
+    )
+    assay_strain: str | None = Field(
+        default=None, description="Strain used"
+    )
+    assay_subcellular_fraction: str | None = Field(
+        default=None, description="Subcellular fraction"
+    )
+
+    # BioAssay Ontology annotations
+    bao_format: str | None = Field(default=None, description="BAO format ID")
+    bao_label: str | None = Field(default=None, description="BAO label")
+
+    # Description and confidence
+    description: str | None = Field(
+        default=None, description="Full assay description"
+    )
+    confidence_score: int | None = Field(
+        default=None, description="Target confidence score (0-9)"
+    )
+    confidence_description: str | None = Field(
+        default=None, description="Confidence level description"
+    )
+    relationship_type: str | None = Field(
+        default=None, description="Target-assay relationship type"
+    )
+    relationship_description: str | None = Field(
+        default=None, description="Relationship description"
+    )
+
+    # Additional metadata
+    assay_pref_name: str | None = Field(
+        default=None, description="Preferred assay name"
+    )
+    score: float | None = Field(
+        default=None, description="Assay score (distinct from confidence)"
+    )
+
+    # Variant information (flattened)
+    variant_accession: str | None = Field(
+        default=None, description="Variant UniProt accession"
+    )
+    variant_isoform: str | None = Field(
+        default=None, description="Variant isoform"
+    )
+    variant_mutation: str | None = Field(
+        default=None, description="Variant mutation (e.g., V600E)"
+    )
+    variant_organism: str | None = Field(
+        default=None, description="Variant organism"
+    )
+    variant_sequence: str | None = Field(
+        default=None, description="Variant amino acid sequence"
+    )
+    variant_tax_id: int | None = Field(
+        default=None, description="Variant NCBI Taxonomy ID"
+    )
+
+    # Complex fields (JSON serialized)
+    assay_classifications_json: str | None = Field(
+        default=None, description="Assay classifications as JSON"
+    )
+    assay_parameters_json: str | None = Field(
+        default=None, description="Assay parameters as JSON"
+    )
+    variant_sequence_json: str | None = Field(
+        default=None, description="Original variant sequence as JSON"
+    )
+
+
+class MoleculeRecord(BaseModel):
+    """Chemical compound DTO from ChEMBL.
+
+    Represents a molecule/compound from ChEMBL API.
+    Required field: molecule_chembl_id.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    # Primary identifier (REQUIRED)
+    molecule_chembl_id: str = Field(description="Unique molecule ChEMBL ID")
+
+    # Core metadata
+    pref_name: str | None = Field(
+        default=None, description="Preferred molecule name"
+    )
+    molecule_type: str | None = Field(
+        default=None, description="Type (Small molecule, Protein, Antibody, etc.)"
+    )
+    structure_type: str | None = Field(
+        default=None, description="Structure type (MOL, NONE, SEQ, BOTH)"
+    )
+    max_phase: int | None = Field(
+        default=None, description="Maximum clinical phase (0-4)"
+    )
+    first_approval: int | None = Field(
+        default=None, description="Year of first approval"
+    )
+
+    # Flags
+    oral: bool | None = Field(default=None, description="Oral administration flag")
+    parenteral: bool | None = Field(
+        default=None, description="Parenteral administration flag"
+    )
+    topical: bool | None = Field(
+        default=None, description="Topical administration flag"
+    )
+    black_box_warning: int | None = Field(
+        default=None, description="Black box warning flag"
+    )
+    natural_product: int | None = Field(
+        default=None, description="Natural product flag"
+    )
+    first_in_class: int | None = Field(
+        default=None, description="First in class flag"
+    )
+    prodrug: int | None = Field(default=None, description="Prodrug flag")
+    therapeutic_flag: bool | None = Field(
+        default=None, description="Therapeutic use flag"
+    )
+    withdrawn_flag: bool | None = Field(
+        default=None, description="Withdrawn drug flag"
+    )
+    inorganic_flag: int | None = Field(
+        default=None, description="Inorganic compound flag"
+    )
+    polymer_flag: int | None = Field(
+        default=None, description="Polymer flag"
+    )
+    chirality: int | None = Field(
+        default=None, description="Chirality (-1 single, 0 achiral, 1 racemic, 2 mixture)"
+    )
+    dosed_ingredient: int | None = Field(
+        default=None, description="Dosed ingredient flag"
+    )
+    availability_type: int | None = Field(
+        default=None, description="Availability type (-2 to 2)"
+    )
+
+    # USAN naming
+    usan_stem: str | None = Field(default=None, description="USAN stem")
+    usan_stem_definition: str | None = Field(
+        default=None, description="USAN stem definition"
+    )
+    usan_substem: str | None = Field(default=None, description="USAN substem")
+    usan_year: int | None = Field(default=None, description="USAN year")
+
+    # Other metadata
+    helm_notation: str | None = Field(
+        default=None, description="HELM notation for biopolymers"
+    )
+    molecule_species: str | None = Field(
+        default=None, description="Species (ACID, BASE, NEUTRAL, ZWITTERION)"
+    )
+
+    # Flattened hierarchy
+    hierarchy_parent_chembl_id: str | None = Field(
+        default=None, description="Parent molecule ChEMBL ID"
+    )
+    hierarchy_active_chembl_id: str | None = Field(
+        default=None, description="Active form ChEMBL ID"
+    )
+    hierarchy_child_chembl_id: str | None = Field(
+        default=None, description="Child molecule ChEMBL ID"
+    )
+
+    # Flattened properties
+    property_alogp: float | None = Field(default=None, description="ALogP value")
+    property_mw_freebase: float | None = Field(
+        default=None, description="Molecular weight (freebase)"
+    )
+    property_full_mwt: float | None = Field(
+        default=None, description="Full molecular weight"
+    )
+    property_hba: int | None = Field(
+        default=None, description="H-bond acceptor count"
+    )
+    property_hbd: int | None = Field(
+        default=None, description="H-bond donor count"
+    )
+    property_psa: float | None = Field(
+        default=None, description="Polar surface area"
+    )
+    property_rtb: int | None = Field(
+        default=None, description="Rotatable bond count"
+    )
+    property_ro5_violations: int | None = Field(
+        default=None, description="Rule of 5 violations"
+    )
+    property_heavy_atoms: int | None = Field(
+        default=None, description="Heavy atom count"
+    )
+    property_aromatic_rings: int | None = Field(
+        default=None, description="Aromatic ring count"
+    )
+    property_qed_weighted: float | None = Field(
+        default=None, description="QED weighted score"
+    )
+    property_full_molformula: str | None = Field(
+        default=None, description="Full molecular formula"
+    )
+    property_ro3_pass: str | None = Field(
+        default=None, description="Rule of 3 pass (Y/N)"
+    )
+
+    # Flattened structures
+    structure_canonical_smiles: str | None = Field(
+        default=None, description="Canonical SMILES"
+    )
+    structure_standard_inchi: str | None = Field(
+        default=None, description="Standard InChI"
+    )
+    structure_standard_inchi_key: str | None = Field(
+        default=None, description="Standard InChI Key"
+    )
+
+    # Complex fields (JSON serialized)
+    molecule_hierarchy_json: str | None = Field(
+        default=None, description="Molecule hierarchy as JSON"
+    )
+    molecule_properties_json: str | None = Field(
+        default=None, description="Molecule properties as JSON"
+    )
+    molecule_structures_json: str | None = Field(
+        default=None, description="Molecule structures as JSON"
+    )
+    molecule_synonyms_json: str | None = Field(
+        default=None, description="Molecule synonyms as JSON"
+    )
+    cross_references_json: str | None = Field(
+        default=None, description="Cross references as JSON"
+    )
+    atc_classifications_json: str | None = Field(
+        default=None, description="ATC classifications as JSON"
+    )
+
+
+class TargetRecord(BaseModel):
+    """Biological target DTO from ChEMBL.
+
+    Represents a drug target from ChEMBL API.
+    Required field: target_chembl_id.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    # Primary identifier (REQUIRED)
+    target_chembl_id: str = Field(description="Unique target ChEMBL ID")
+
+    # Core metadata
+    pref_name: str | None = Field(
+        default=None, description="Preferred target name"
+    )
+    target_type: str | None = Field(
+        default=None, description="Type (SINGLE PROTEIN, PROTEIN COMPLEX, ORGANISM, etc.)"
+    )
+    organism: str | None = Field(
+        default=None, description="Target organism"
+    )
+    tax_id: int | None = Field(
+        default=None, description="NCBI Taxonomy ID"
+    )
+    species_group_flag: bool | None = Field(
+        default=None, description="Species group flag"
+    )
+    description: str | None = Field(
+        default=None, description="Target description"
+    )
+    downgraded: bool | None = Field(
+        default=None, description="Deprecated/downgraded flag"
+    )
+
+    # Optional fields
+    dap_id: int | None = Field(
+        default=None, description="Drug-Affinity Panel ID"
+    )
+    pipeline_stages: str | None = Field(
+        default=None, description="Pipeline stages JSON"
+    )
+    target_constraints: str | None = Field(
+        default=None, description="Target constraints JSON"
+    )
+
+    # Flattened component fields
+    component_accessions: list[str] | None = Field(
+        default=None, description="Component UniProt accessions"
+    )
+    component_ids: list[int] | None = Field(
+        default=None, description="Component IDs"
+    )
+    component_types: list[str] | None = Field(
+        default=None, description="Component types"
+    )
+    component_relationships: list[str] | None = Field(
+        default=None, description="Component relationships"
+    )
+    component_descriptions: list[str] | None = Field(
+        default=None, description="Component descriptions"
+    )
+    component_organisms: list[str] | None = Field(
+        default=None, description="Component organisms"
+    )
+    component_tax_ids: list[int] | None = Field(
+        default=None, description="Component taxonomy IDs"
+    )
+
+    # Complex fields (JSON serialized)
+    target_components_json: str | None = Field(
+        default=None, description="Target components as JSON"
+    )
+    target_component_synonyms_json: str | None = Field(
+        default=None, description="Component synonyms as JSON"
+    )
+    cross_references_json: str | None = Field(
+        default=None, description="Cross references as JSON"
+    )
+
+
+class DocumentRecord(BaseModel):
+    """Scientific document DTO from ChEMBL.
+
+    Represents a publication/document from ChEMBL API.
+    Required field: document_chembl_id.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    # Primary identifier (REQUIRED)
+    document_chembl_id: str = Field(description="Unique document ChEMBL ID")
+
+    # Publication identifiers
+    pubmed_id: int | None = Field(default=None, description="PubMed ID")
+    doi: str | None = Field(default=None, description="Digital Object Identifier")
+    patent_id: str | None = Field(default=None, description="Patent ID")
+
+    # Core metadata
+    title: str | None = Field(default=None, description="Document title")
+    authors: str | None = Field(default=None, description="Combined authors string")
+    abstract: str | None = Field(default=None, description="Document abstract")
+    doc_type: str | None = Field(
+        default=None, description="Type (PUBLICATION, PATENT, etc.)"
+    )
+
+    # Journal information
+    journal: str | None = Field(default=None, description="Journal name")
+    journal_full_title: str | None = Field(
+        default=None, description="Full journal title"
+    )
+    year: int | None = Field(default=None, description="Publication year")
+    volume: str | None = Field(default=None, description="Volume number")
+    issue: str | None = Field(default=None, description="Issue number")
+    first_page: str | None = Field(default=None, description="First page")
+    last_page: str | None = Field(default=None, description="Last page")
+
+    # Source information
+    src_id: int | None = Field(default=None, description="Data source ID")
+
+
+class CellLineRecord(BaseModel):
+    """Cell line DTO from ChEMBL.
+
+    Represents a cell line from ChEMBL API.
+    Required fields: cell_chembl_id, cell_name.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    # Primary identifier (REQUIRED)
+    cell_chembl_id: str = Field(description="Unique cell line ChEMBL ID")
+
+    # Core metadata (REQUIRED)
+    cell_name: str = Field(description="Cell line name")
+
+    # Optional metadata
+    cell_description: str | None = Field(
+        default=None, description="Cell line description"
+    )
+
+    # Source information
+    cell_source_tissue: str | None = Field(
+        default=None, description="Source tissue"
+    )
+    cell_source_organism: str | None = Field(
+        default=None, description="Source organism"
+    )
+    cell_source_tax_id: int | None = Field(
+        default=None, description="Source organism taxonomy ID"
+    )
+
+    # External identifiers
+    cellosaurus_id: str | None = Field(
+        default=None, description="Cellosaurus ID"
+    )
+    cl_lincs_id: str | None = Field(
+        default=None, description="LINCS cell line ID"
+    )
+    efo_id: str | None = Field(
+        default=None, description="EFO ontology ID"
+    )
+
+
+class TargetComponentRecord(BaseModel):
+    """Target component DTO from ChEMBL.
+
+    Represents a target component from ChEMBL API.
+    Required field: component_id.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    # Primary identifier (REQUIRED)
+    component_id: int = Field(description="Unique component ID")
+
+    # Core metadata
+    accession: str | None = Field(
+        default=None, description="UniProt accession"
+    )
+    component_type: str | None = Field(
+        default=None, description="Component type"
+    )
+    description: str | None = Field(
+        default=None, description="Component description"
+    )
+    organism: str | None = Field(
+        default=None, description="Organism name"
+    )
+    tax_id: int | None = Field(
+        default=None, description="NCBI Taxonomy ID"
+    )
+
+    # Flattened fields
+    protein_classification_ids: list[int] | None = Field(
+        default=None, description="Protein classification IDs"
+    )
+
+    # Complex fields (JSON serialized)
+    target_component_synonyms_json: str | None = Field(
+        default=None, description="Synonyms as JSON"
+    )
+    target_component_xrefs_json: str | None = Field(
+        default=None, description="Cross references as JSON"
+    )
+    protein_classifications_json: str | None = Field(
+        default=None, description="Protein classifications as JSON"
+    )
+
+
+__all__ = [
+    "ActivityRecord",
+    "AssayRecord",
+    "CellLineRecord",
+    "DocumentRecord",
+    "MoleculeRecord",
+    "TargetComponentRecord",
+    "TargetRecord",
+]

--- a/src/bioetl/domain/entities/crossref.py
+++ b/src/bioetl/domain/entities/crossref.py
@@ -1,12 +1,23 @@
 """CrossRef domain entities.
 
-Contains entities for CrossRef data: Work (publication metadata).
+Contains:
+- PublicationRecord: DTO (Pydantic) for type-safe data transfer at boundaries
+- Work: Domain entity (dataclass) with lineage fields - deprecated, use PublicationRecord
+
+DTO Design:
+- Uses extra='forbid' to detect API changes early
+- frozen=True ensures immutability
+- Adapters return DTOs, transformers convert to Domain Entities
+
 Used for enriching publication records with DOI resolution and citation metadata.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+
+from pydantic import BaseModel, ConfigDict
+from pydantic import Field as PydanticField
 
 from bioetl.domain.entities.base import BaseEntity
 
@@ -20,12 +31,104 @@ CROSSREF_TYPE_MAP = {
 }
 
 
+# === Pydantic DTO Model ===
+
+
+class PublicationRecord(BaseModel):
+    """Scholarly work DTO from CrossRef.
+
+    Represents publication metadata from CrossRef API for DOI resolution
+    and citation enrichment.
+
+    Required field: doi.
+
+    Example:
+        >>> record = PublicationRecord(
+        ...     doi="10.1038/nature12373",
+        ...     title="Example Article",
+        ...     journal="Nature",
+        ...     year=2013,
+        ... )
+        >>> record.model_dump()
+        {'doi': '10.1038/nature12373', 'title': 'Example Article', ...}
+
+    See: https://api.crossref.org/swagger-ui/index.html
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    # Primary identifier (REQUIRED, normalized DOI - lowercase, stripped)
+    doi: str = PydanticField(description="Digital Object Identifier (normalized)")
+
+    # Core metadata
+    title: str | None = PydanticField(default=None, description="Work title")
+    abstract: str | None = PydanticField(default=None, description="Work abstract")
+
+    # Authors (list of "given family" formatted names)
+    authors: list[str] = PydanticField(
+        default_factory=list, description="Author names"
+    )
+
+    # Journal information
+    journal: str | None = PydanticField(
+        default=None, description="Container title (journal name)"
+    )
+    issn: list[str] = PydanticField(default_factory=list, description="ISSN list")
+    publisher: str | None = PydanticField(default=None, description="Publisher name")
+
+    # Publication details
+    volume: str | None = PydanticField(default=None, description="Volume number")
+    issue: str | None = PydanticField(default=None, description="Issue number")
+    first_page: str | None = PydanticField(default=None, description="First page")
+    last_page: str | None = PydanticField(default=None, description="Last page")
+
+    # Dates
+    year: int | None = PydanticField(default=None, description="Publication year")
+    published_print: str | None = PydanticField(
+        default=None, description="Print publication date (ISO format)"
+    )
+    published_online: str | None = PydanticField(
+        default=None, description="Online publication date (ISO format)"
+    )
+
+    # Document type (mapped from CrossRef type)
+    doc_type: str = PydanticField(
+        default="PUBLICATION", description="Document type (PUBLICATION or PREPRINT)"
+    )
+
+    # Citation metrics
+    citation_count: int | None = PydanticField(
+        default=None, description="Times cited (is-referenced-by-count)"
+    )
+    reference_count: int | None = PydanticField(
+        default=None, description="Number of references (references-count)"
+    )
+
+    # Additional metadata
+    language: str | None = PydanticField(
+        default=None, description="Primary language code"
+    )
+    license_url: str | None = PydanticField(default=None, description="License URL")
+    subjects: list[str] = PydanticField(
+        default_factory=list, description="Subject areas"
+    )
+
+    # Source tracking
+    source: str = PydanticField(default="crossref", description="Data source")
+
+
+# === Dataclass Domain Entity (backward compatibility) ===
+
+
 @dataclass(frozen=True, kw_only=True)
 class Work(BaseEntity):
     """Represents a scholarly work from CrossRef.
 
-    Contains metadata retrieved from CrossRef API for DOI resolution
-    and citation enrichment.
+    Domain entity with lineage fields (run_id, content_hash, etc.).
+    For DTO without lineage, use PublicationRecord.
+
+    Note: This class is kept for backward compatibility.
+    New code should use PublicationRecord DTO.
 
     See: https://api.crossref.org/swagger-ui/index.html
     """
@@ -76,3 +179,6 @@ class Work(BaseEntity):
         super().__post_init__()
         if not self.doi:
             raise ValueError("CrossRef Work DOI is required")
+
+
+__all__ = ["CROSSREF_TYPE_MAP", "PublicationRecord", "Work"]

--- a/src/bioetl/domain/entities/pubchem.py
+++ b/src/bioetl/domain/entities/pubchem.py
@@ -1,18 +1,111 @@
 """PubChem domain entities.
 
-Contains entities for PubChem data: Compound.
+Contains:
+- Compound: Domain entity (dataclass) with lineage fields
+- CompoundRecord: DTO (Pydantic) for type-safe data transfer at boundaries
+
+DTO Design:
+- Uses extra='forbid' to detect API changes early
+- frozen=True ensures immutability
+- Adapters return DTOs, transformers convert to Domain Entities
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 
+from pydantic import BaseModel, ConfigDict, Field
+
 from bioetl.domain.entities.base import BaseEntity
+
+# === Pydantic DTO Model ===
+
+
+class PubChemCompoundRecord(BaseModel):
+    """Chemical compound DTO from PubChem.
+
+    Represents a compound from PubChem API via pubchempy.
+    Required field: cid.
+    At least one structural identifier (SMILES/InChI) should be present.
+
+    Note: Named PubChemCompoundRecord to avoid conflict with
+    ChEMBL's CompoundRecord (which links molecules to documents).
+
+    Example:
+        >>> record = PubChemCompoundRecord(
+        ...     cid="2244",
+        ...     molecular_formula="C9H8O4",
+        ...     canonical_smiles="CC(=O)OC1=CC=CC=C1C(=O)O",
+        ... )
+        >>> record.model_dump()
+        {'cid': '2244', 'molecular_formula': 'C9H8O4', ...}
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    # Primary identifier (REQUIRED)
+    cid: str = Field(description="PubChem Compound ID")
+
+    # Molecular properties
+    molecular_formula: str | None = Field(
+        default=None, description="Molecular formula"
+    )
+    molecular_weight: float | None = Field(
+        default=None, description="Molecular weight in g/mol"
+    )
+
+    # Structure representations
+    canonical_smiles: str | None = Field(
+        default=None, description="Canonical SMILES (connectivity)"
+    )
+    isomeric_smiles: str | None = Field(
+        default=None, description="Isomeric SMILES (with stereochemistry)"
+    )
+    inchi: str | None = Field(
+        default=None, description="InChI string"
+    )
+    inchikey: str | None = Field(
+        default=None, description="InChI Key"
+    )
+
+    # Names
+    iupac_name: str | None = Field(
+        default=None, description="IUPAC systematic name"
+    )
+
+    # Physical/Chemical properties
+    charge: int | None = Field(
+        default=None, description="Formal charge"
+    )
+    complexity: float | None = Field(
+        default=None, description="Molecular complexity score"
+    )
+    h_bond_acceptor_count: int | None = Field(
+        default=None, description="H-bond acceptor count"
+    )
+    h_bond_donor_count: int | None = Field(
+        default=None, description="H-bond donor count"
+    )
+    rotatable_bond_count: int | None = Field(
+        default=None, description="Rotatable bond count"
+    )
+
+    # Fingerprints
+    fingerprint: str | None = Field(
+        default=None, description="PubChem fingerprint"
+    )
+
+
+# === Dataclass Domain Entity ===
 
 
 @dataclass(frozen=True, kw_only=True)
 class Compound(BaseEntity):
-    """Represents a chemical compound (PubChem Compound)."""
+    """Represents a chemical compound (PubChem Compound).
+
+    Domain entity with lineage fields (run_id, content_hash, etc.).
+    For DTO without lineage, use CompoundRecord.
+    """
 
     cid: str
     molecular_formula: str | None = None
@@ -35,3 +128,6 @@ class Compound(BaseEntity):
             raise ValueError(
                 "Compound must have at least one structural identifier (SMILES/InChI)"
             )
+
+
+__all__ = ["Compound", "PubChemCompoundRecord"]

--- a/src/bioetl/domain/entities/pubmed.py
+++ b/src/bioetl/domain/entities/pubmed.py
@@ -1,18 +1,144 @@
 """PubMed domain entities.
 
-Contains entities for PubMed data: Publication.
+Contains:
+- Publication: Domain entity (dataclass) with lineage fields
+- ArticleRecord: DTO (Pydantic) for type-safe data transfer at boundaries
+
+DTO Design:
+- Uses extra='forbid' to detect API changes early
+- frozen=True ensures immutability
+- Adapters return DTOs, transformers convert to Domain Entities
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from pydantic import BaseModel, ConfigDict
+from pydantic import Field as PydanticField
+
 from bioetl.domain.entities.base import BaseEntity
+
+# === Pydantic DTO Model ===
+
+
+class ArticleRecord(BaseModel):
+    """Scientific article DTO from PubMed.
+
+    Represents article metadata extracted from PubMed XML via Entrez API.
+    Required field: pmid.
+
+    Example:
+        >>> record = ArticleRecord(
+        ...     pmid="12345678",
+        ...     title="Example Article Title",
+        ...     journal="Nature",
+        ...     pub_year=2024,
+        ... )
+        >>> record.model_dump()
+        {'pmid': '12345678', 'title': 'Example Article Title', ...}
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    # Primary identifier (REQUIRED)
+    pmid: str = PydanticField(description="PubMed ID")
+
+    # Other identifiers
+    doi: str | None = PydanticField(
+        default=None, description="Digital Object Identifier"
+    )
+    pmc_id: str | None = PydanticField(
+        default=None, description="PubMed Central ID"
+    )
+
+    # Title and abstract
+    title: str | None = PydanticField(
+        default=None, description="Article title"
+    )
+    abstract: str | None = PydanticField(
+        default=None, description="Abstract text"
+    )
+
+    # Journal information
+    journal: str | None = PydanticField(
+        default=None, description="Full journal title"
+    )
+    journal_abbrev: str | None = PydanticField(
+        default=None, description="Journal abbreviation (ISO)"
+    )
+    issn: str | None = PydanticField(
+        default=None, description="ISSN"
+    )
+    volume: str | None = PydanticField(
+        default=None, description="Volume number"
+    )
+    issue: str | None = PydanticField(
+        default=None, description="Issue number"
+    )
+    pages: str | None = PydanticField(
+        default=None, description="Page numbers"
+    )
+
+    # Authors (list of formatted names)
+    authors: list[str] = PydanticField(
+        default_factory=list, description="Author names"
+    )
+
+    # Dates (ISO format: YYYY-MM-DD or partial)
+    pub_date: str | None = PydanticField(
+        default=None, description="Publication date (ISO format)"
+    )
+    pub_year: int | None = PydanticField(
+        default=None, description="Publication year (for partitioning)"
+    )
+    accepted_date: str | None = PydanticField(
+        default=None, description="Date accepted"
+    )
+    received_date: str | None = PydanticField(
+        default=None, description="Date received"
+    )
+    revised_date: str | None = PydanticField(
+        default=None, description="Date revised"
+    )
+    epub_date: str | None = PydanticField(
+        default=None, description="Electronic publication date"
+    )
+
+    # Classification
+    publication_types: list[str] = PydanticField(
+        default_factory=list, description="Publication types"
+    )
+    keywords: list[str] = PydanticField(
+        default_factory=list, description="Keywords"
+    )
+    mesh_terms: list[str] = PydanticField(
+        default_factory=list, description="MeSH terms"
+    )
+
+    # Additional metadata
+    language: str | None = PydanticField(
+        default=None, description="Primary language code"
+    )
+    country: str | None = PydanticField(
+        default=None, description="Country of publication"
+    )
+
+    # Raw data for forensic (optional)
+    raw_xml: str | None = PydanticField(
+        default=None, description="Raw XML content (forensic)"
+    )
+
+
+# === Dataclass Domain Entity ===
 
 
 @dataclass(frozen=True, kw_only=True)
 class Publication(BaseEntity):
     """Represents a scientific publication from PubMed.
+
+    Domain entity with lineage fields (run_id, content_hash, etc.).
+    For DTO without lineage, use ArticleRecord.
 
     Contains comprehensive metadata extracted from PubMed XML via Entrez API.
     See: https://www.nlm.nih.gov/bsd/licensee/elements_descriptions.html
@@ -63,3 +189,6 @@ class Publication(BaseEntity):
         super().__post_init__()
         if not self.pmid:
             raise ValueError("Publication PMID is required")
+
+
+__all__ = ["ArticleRecord", "Publication"]

--- a/src/bioetl/infrastructure/adapters/chembl/client.py
+++ b/src/bioetl/infrastructure/adapters/chembl/client.py
@@ -15,6 +15,11 @@ Health-Aware Fetching:
 - HEALTHY: Normal batch_size
 - DEGRADED: batch_size ÷ 2 (per RULES.md §3.5)
 - UNHEALTHY: Fail fast with clear error
+
+DTO Support:
+- fetch_as_models(): Returns typed DTO models (ActivityRecord, AssayRecord, etc.)
+- fetch(): Returns raw dicts (backward compatible)
+- Use model_construct() for trusted data (skip validation)
 """
 
 from __future__ import annotations
@@ -22,6 +27,17 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, NoReturn
 
+from pydantic import BaseModel
+
+from bioetl.domain.entities.chembl import (
+    ActivityRecord,
+    AssayRecord,
+    CellLineRecord,
+    DocumentRecord,
+    MoleculeRecord,
+    TargetComponentRecord,
+    TargetRecord,
+)
 from bioetl.domain.exceptions import CriticalError
 from bioetl.domain.ports.noop import NoOpMetrics
 from bioetl.domain.resilience import AdapterConfig
@@ -45,6 +61,19 @@ if TYPE_CHECKING:
 
     from bioetl.domain.ports import LoggerPort, MetricsPort
     from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
+
+
+# Mapping from entity_type to DTO model class
+CHEMBL_DTO_MODELS: dict[str, type[BaseModel]] = {
+    "activity": ActivityRecord,
+    "assay": AssayRecord,
+    "molecule": MoleculeRecord,
+    "compound": MoleculeRecord,  # Alias for molecule
+    "target": TargetRecord,
+    "target_component": TargetComponentRecord,
+    "document": DocumentRecord,
+    "cell_line": CellLineRecord,
+}
 
 
 @dataclass
@@ -397,6 +426,63 @@ class ChemblAdapter(BaseHttpAdapter):
             entity_type, limit, filter_ids, filter_field
         ):
             yield record
+
+    async def fetch_as_models(
+        self,
+        entity_type: str,
+        limit: int | None = None,
+        query: str | None = None,
+        filter_ids: list[str] | None = None,
+        filter_field: str | None = None,
+        *,
+        validate: bool = True,
+    ) -> AsyncIterator[BaseModel]:
+        """Fetch records from ChEMBL as typed DTO models.
+
+        Returns Pydantic DTO models instead of raw dicts for type safety.
+        Uses domain DTOs with extra='forbid' to detect API changes.
+
+        Args:
+            entity_type: Type of entity (activity, assay, molecule, target, etc.)
+            limit: Maximum number of records to fetch
+            query: Unused for ChEMBL
+            filter_ids: List of IDs to filter by
+            filter_field: Field name to filter on
+            validate: If True, validate with model_validate (strict).
+                     If False, use model_construct (skip validation, faster).
+
+        Yields:
+            Typed DTO models (ActivityRecord, AssayRecord, etc.)
+
+        Raises:
+            ValueError: If entity_type is not supported for DTO conversion
+            ValidationError: If validate=True and API response has unexpected fields
+
+        Example:
+            >>> async for activity in adapter.fetch_as_models("activity", limit=100):
+            ...     print(activity.activity_id, activity.pchembl_value)
+
+        """
+        model_class = CHEMBL_DTO_MODELS.get(entity_type)
+        if model_class is None:
+            raise ValueError(
+                f"No DTO model for entity_type '{entity_type}'. "
+                f"Supported: {', '.join(CHEMBL_DTO_MODELS.keys())}"
+            )
+
+        async for record in self.fetch(
+            entity_type=entity_type,
+            limit=limit,
+            query=query,
+            filter_ids=filter_ids,
+            filter_field=filter_field,
+        ):
+            if validate:
+                # Strict validation - will raise on unknown fields
+                yield model_class.model_validate(record)
+            else:
+                # Fast path - skip validation for trusted data
+                yield model_class.model_construct(**record)
 
     async def _probe_health(self) -> HealthStatus:
         """Perform ChEMBL-specific health probe.

--- a/src/bioetl/infrastructure/adapters/pubchem/client.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/client.py
@@ -8,6 +8,10 @@ Requirements:
 - Health: lightweight query
 - Entities: compounds, substances, assays, bioassays
 
+DTO Support:
+- fetch_as_models(): Returns typed DTO models (PubChemCompoundRecord)
+- fetch(): Returns raw dicts (backward compatible)
+
 Documentation: https://pubchemdocs.ncbi.nlm.nih.gov/pug-rest
 """
 
@@ -17,7 +21,9 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any
 
 import pubchempy as pcp
+from pydantic import BaseModel
 
+from bioetl.domain.entities.pubchem import PubChemCompoundRecord
 from bioetl.domain.exceptions import CircuitBreakerOpenError
 from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.adapters.sync_base import BaseSyncAdapter
@@ -28,6 +34,12 @@ if TYPE_CHECKING:
     from bioetl.domain.ports import LoggerPort
     from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
     from bioetl.infrastructure.adapters.http.rate_limiter import TokenBucket
+
+
+# Mapping from entity_type to DTO model class
+PUBCHEM_DTO_MODELS: dict[str, type[BaseModel]] = {
+    "compound": PubChemCompoundRecord,
+}
 
 
 class PubChemAdapter(BaseSyncAdapter):
@@ -232,6 +244,64 @@ class PubChemAdapter(BaseSyncAdapter):
             "protocol": assay.get("protocol"),
             "target": assay.get("target"),
         }
+
+    async def fetch_as_models(
+        self,
+        entity_type: str,
+        limit: int | None = None,
+        query: str | None = None,
+        filter_ids: list[str] | None = None,
+        filter_field: str | None = None,
+        *,
+        validate: bool = True,
+    ) -> AsyncIterator[BaseModel]:
+        """Fetch records from PubChem as typed DTO models.
+
+        Returns Pydantic DTO models instead of raw dicts for type safety.
+        Uses domain DTOs with extra='forbid' to detect API changes.
+
+        Args:
+            entity_type: Type of entity (compound, substance, assay)
+            limit: Maximum number of records to fetch
+            query: Search query string
+            filter_ids: Unused for PubChem
+            filter_field: Unused for PubChem
+            validate: If True, validate with model_validate (strict).
+                     If False, use model_construct (skip validation, faster).
+
+        Yields:
+            Typed DTO models (PubChemCompoundRecord for compound)
+
+        Raises:
+            ValueError: If entity_type is not supported for DTO conversion
+
+        Example:
+            >>> async for compound in adapter.fetch_as_models("compound", query="aspirin"):
+            ...     print(compound.cid, compound.canonical_smiles)
+
+        """
+        model_class = PUBCHEM_DTO_MODELS.get(entity_type)
+        if model_class is None:
+            raise ValueError(
+                f"No DTO model for entity_type '{entity_type}'. "
+                f"Supported: {', '.join(PUBCHEM_DTO_MODELS.keys())}"
+            )
+
+        async for record in self.fetch(
+            entity_type=entity_type,
+            limit=limit,
+            query=query,
+            filter_ids=filter_ids,
+            filter_field=filter_field,
+        ):
+            # Convert CID to string for DTO (domain DTOs use str for IDs)
+            if "cid" in record and record["cid"] is not None:
+                record["cid"] = str(record["cid"])
+
+            if validate:
+                yield model_class.model_validate(record)
+            else:
+                yield model_class.model_construct(**record)
 
     async def _probe_health(self) -> HealthStatus:
         """Perform PubChem health probe using lightweight water query (CID 962)."""

--- a/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
+++ b/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
@@ -1,10 +1,21 @@
 # src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
+"""PubMed adapter for Entrez E-utilities API.
+
+Implements DataSourcePort for PubMed article metadata extraction.
+
+DTO Support:
+- fetch_as_models(): Returns typed DTO models (ArticleRecord)
+- fetch(): Returns raw dicts (backward compatible)
+"""
 from __future__ import annotations
 
 import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from pydantic import BaseModel
+
+from bioetl.domain.entities.pubmed import ArticleRecord
 from bioetl.domain.ports.noop import NoOpMetrics
 from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.adapters.base import BaseHttpAdapter
@@ -20,6 +31,11 @@ if TYPE_CHECKING:
     from bioetl.infrastructure.config import Settings
 
 ENTREZ_API_BASE = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/"
+
+# Mapping from entity_type to DTO model class
+PUBMED_DTO_MODELS: dict[str, type[BaseModel]] = {
+    "publication": ArticleRecord,
+}
 
 
 @dataclass
@@ -219,6 +235,67 @@ class PubMedAdapter(BaseHttpAdapter):
 
         async for record in self._yield_articles_from_pmids(pmids, limit):
             yield record
+
+    async def fetch_as_models(
+        self,
+        entity_type: str,
+        limit: int | None = None,
+        query: str | None = None,
+        filter_ids: list[str] | None = None,
+        filter_field: str | None = None,
+        *,
+        validate: bool = True,
+    ) -> AsyncIterator[BaseModel]:
+        """Fetch PubMed records as typed DTO models.
+
+        Returns Pydantic DTO models instead of raw dicts for type safety.
+        Uses domain DTOs with extra='forbid' to detect API changes.
+
+        Args:
+            entity_type: Type of entity (publication)
+            limit: Maximum number of records to fetch
+            query: Search query string
+            filter_ids: List of PMIDs to filter by
+            filter_field: Field name to filter on
+            validate: If True, validate with model_validate (strict).
+                     If False, use model_construct (skip validation, faster).
+
+        Yields:
+            Typed DTO models (ArticleRecord for publication)
+
+        Raises:
+            ValueError: If entity_type is not supported for DTO conversion
+
+        Example:
+            >>> async for article in adapter.fetch_as_models("publication", limit=10):
+            ...     print(article.pmid, article.title)
+
+        """
+        model_class = PUBMED_DTO_MODELS.get(entity_type)
+        if model_class is None:
+            raise ValueError(
+                f"No DTO model for entity_type '{entity_type}'. "
+                f"Supported: {', '.join(PUBMED_DTO_MODELS.keys())}"
+            )
+
+        async for record in self.fetch(
+            entity_type=entity_type,
+            limit=limit,
+            query=query,
+            filter_ids=filter_ids,
+            filter_field=filter_field,
+        ):
+            # Map field names from XML processor output to ArticleRecord DTO
+            dto_data = {
+                "pmid": record.get("pmid"),
+                "title": record.get("article_title"),
+                "raw_xml": record.get("_raw_xml"),
+            }
+
+            if validate:
+                yield model_class.model_validate(dto_data)
+            else:
+                yield model_class.model_construct(**dto_data)
 
     async def _probe_health(self) -> HealthStatus:
         """Perform PubMed-specific health probe.


### PR DESCRIPTION
Introduce typed DTO models with extra='forbid' for strict API boundary validation. This enables IDE autocomplete, catches field typos at compile time, and detects API changes early.

New DTOs:
- ChEMBL: ActivityRecord, AssayRecord, MoleculeRecord, TargetRecord, DocumentRecord, CellLineRecord, TargetComponentRecord
- PubChem: PubChemCompoundRecord
- PubMed: ArticleRecord
- CrossRef: PublicationRecord (Work kept for backward compat)

Adapter updates:
- Add fetch_as_models() method to ChEMBL, PubChem, PubMed adapters
- Support validate=True/False for strict/fast mode
- Backward compatible: fetch() still returns dict[str, Any]

Design:
- frozen=True ensures immutability
- extra='forbid' rejects unknown fields for early API change detection
- model_construct() available for trusted data (skip validation)

See RULES.md §8.2 for JSON response modeling guidelines.