### PR TITLE
Move content hash logic to domain service

### DIFF
--- a/src/bioetl/application/core/base_transformer.py
+++ b/src/bioetl/application/core/base_transformer.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
 import orjson
 
 from bioetl.domain.ports import MetricsPort, NoOpMetrics, NoOpTracing, TracingPort
-from bioetl.domain.transformations import generate_content_hash
+from bioetl.domain.services import IdentityService
 from bioetl.domain.types import ContentHash, EntityID
 
 if TYPE_CHECKING:
@@ -89,6 +89,7 @@ class BaseTransformer(ABC):
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
         gold_filters: GoldFilterConfig | None = None,
+        identity_service: IdentityService | None = None,
     ) -> None:
         """Initialize transformer with provider name and observability.
 
@@ -98,6 +99,8 @@ class BaseTransformer(ABC):
             tracer: Tracing port for distributed tracing. Defaults to NoOpTracing.
             metrics: Metrics port for duration/error tracking. Defaults to NoOpMetrics.
             gold_filters: Optional filter configuration for Gold layer.
+            identity_service: Service for computing entity IDs and content hashes.
+                Defaults to a new IdentityService instance.
 
         """
         self.provider = provider
@@ -105,6 +108,9 @@ class BaseTransformer(ABC):
         self._tracer: TracingPort = tracer if tracer is not None else NoOpTracing()
         self._metrics: MetricsPort = metrics if metrics is not None else NoOpMetrics()
         self._gold_filters = gold_filters
+        self._identity: IdentityService = (
+            identity_service if identity_service is not None else IdentityService()
+        )
 
     async def transform(
         self,
@@ -280,6 +286,8 @@ class BaseTransformer(ABC):
     ) -> ContentHash:
         """Generate canonical content hash for record versioning.
 
+        Delegates to IdentityService for computation.
+
         Implements RULES.md §2.8.1:
         - sha256(provider + canonical_json(record))
         - Normalizes NaN/Inf → null, floats → round(val, 10), dates → ISO
@@ -292,10 +300,37 @@ class BaseTransformer(ABC):
             ContentHash: SHA256 hash of normalized record.
 
         """
-        return generate_content_hash(
-            business_data,
+        return self._identity.compute_content_hash(
             self.provider,
+            business_data,
             exclude_none=exclude_none,
+        )
+
+    def compute_entity_id(
+        self,
+        source_id: str | None,
+        record: dict[str, Any],
+    ) -> EntityID:
+        """Generate stable entity identifier.
+
+        Delegates to IdentityService for computation.
+
+        If source_id is provided, uses it for stable identification.
+        Otherwise, generates identifier from content hash prefix.
+
+        Args:
+            source_id: Source system identifier (e.g., activity_id from API).
+            record: Record for fallback hash-based identification.
+
+        Returns:
+            EntityID in format "{provider}:{id}" or "{provider}:{hash_prefix}".
+
+        """
+        return self._identity.compute_entity_id(
+            provider=self.provider,
+            entity_type=self.entity_type,
+            source_id=source_id,
+            record=record,
         )
 
     @staticmethod

--- a/src/bioetl/application/pipelines/chembl/base_chembl_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/base_chembl_transformer.py
@@ -16,7 +16,7 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from bioetl.application.core.base_transformer import BaseTransformer
-from bioetl.domain.transformations import generate_entity_id
+from bioetl.domain.services import IdentityService
 
 if TYPE_CHECKING:
     from bioetl.domain.context import PipelineContext
@@ -59,6 +59,7 @@ class BaseChemblTransformer(BaseTransformer):
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
         gold_filters: GoldFilterConfig | None = None,
+        identity_service: IdentityService | None = None,
     ) -> None:
         """Initialize ChEMBL transformer.
 
@@ -67,10 +68,15 @@ class BaseChemblTransformer(BaseTransformer):
             tracer: Optional tracing port for distributed tracing (O1 observability).
             metrics: Optional metrics port for duration/error tracking (O1 observability).
             gold_filters: Optional filter configuration for Gold layer.
+            identity_service: Service for computing entity IDs and content hashes.
 
         """
         super().__init__(
-            provider, tracer=tracer, metrics=metrics, gold_filters=gold_filters
+            provider,
+            tracer=tracer,
+            metrics=metrics,
+            gold_filters=gold_filters,
+            identity_service=identity_service,
         )
 
     async def _transform_impl(
@@ -101,11 +107,10 @@ class BaseChemblTransformer(BaseTransformer):
         # 1. Validate primary ID
         primary_id = self._get_required_field(record, self.primary_id_field)
 
-        # 2. Generate entity ID
-        entity_id = generate_entity_id(
+        # 2. Generate entity ID using IdentityService
+        entity_id = self.compute_entity_id(
+            source_id=str(primary_id),
             record={self.primary_id_field: str(primary_id)},
-            provider=self.provider,
-            id_field=self.primary_id_field,
         )
 
         # 3. Extract business data (delegated to subclass)

--- a/src/bioetl/application/pipelines/crossref/transformer.py
+++ b/src/bioetl/application/pipelines/crossref/transformer.py
@@ -22,7 +22,7 @@ from bioetl.domain.normalization import (
     parse_page_range,
     strip_html_tags,
 )
-from bioetl.domain.transformations import generate_entity_id
+from bioetl.domain.services import IdentityService
 from bioetl.domain.validation import validate_year_range
 
 if TYPE_CHECKING:
@@ -50,6 +50,7 @@ class CrossRefTransformer(BaseTransformer):
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
         gold_filters: GoldFilterConfig | None = None,
+        identity_service: IdentityService | None = None,
     ) -> None:
         """Initialize CrossRef transformer.
 
@@ -58,6 +59,7 @@ class CrossRefTransformer(BaseTransformer):
             tracer: Optional tracing port for distributed tracing.
             metrics: Optional metrics port for duration/error tracking.
             gold_filters: Optional filter configuration for Gold layer.
+            identity_service: Service for computing entity IDs and content hashes.
 
         """
         super().__init__(
@@ -66,6 +68,7 @@ class CrossRefTransformer(BaseTransformer):
             tracer=tracer,
             metrics=metrics,
             gold_filters=gold_filters,
+            identity_service=identity_service,
         )
 
     # ========================================================================
@@ -225,11 +228,10 @@ class CrossRefTransformer(BaseTransformer):
         # 2. Extract business data
         business_data = self._extract_business_data(record)
 
-        # 3. Generate entity ID (normalized DOI)
-        entity_id = generate_entity_id(
+        # 3. Generate entity ID using IdentityService (normalized DOI)
+        entity_id = self.compute_entity_id(
+            source_id=business_data["doi"],
             record={"doi": business_data["doi"]},
-            provider=self.provider,
-            id_field="doi",
         )
 
         # 4. Compute content hash

--- a/src/bioetl/application/pipelines/pubchem/transformer.py
+++ b/src/bioetl/application/pipelines/pubchem/transformer.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from bioetl.application.core.base_transformer import BaseTransformer
 from bioetl.domain.entities import Compound
-from bioetl.domain.transformations import generate_entity_id
+from bioetl.domain.services import IdentityService
 
 if TYPE_CHECKING:
     from bioetl.domain.context import PipelineContext
@@ -33,6 +33,7 @@ class PubChemCompoundTransformer(BaseTransformer):
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
         gold_filters: GoldFilterConfig | None = None,
+        identity_service: IdentityService | None = None,
     ):
         """Initialize PubChem compound transformer.
 
@@ -41,10 +42,15 @@ class PubChemCompoundTransformer(BaseTransformer):
             tracer: Optional tracing port for distributed tracing (O1 observability).
             metrics: Optional metrics port for duration/error tracking (O1 observability).
             gold_filters: Optional filter configuration for Gold layer.
+            identity_service: Service for computing entity IDs and content hashes.
 
         """
         super().__init__(
-            provider, tracer=tracer, metrics=metrics, gold_filters=gold_filters
+            provider,
+            tracer=tracer,
+            metrics=metrics,
+            gold_filters=gold_filters,
+            identity_service=identity_service,
         )
 
     async def _transform_impl(
@@ -85,11 +91,10 @@ class PubChemCompoundTransformer(BaseTransformer):
             "iupac_name": record.get("iupac_name"),
         }
 
-        # Step 3: Generate entity_id (RULES.md §2.8)
-        entity_id = generate_entity_id(
+        # Step 3: Generate entity_id using IdentityService (RULES.md §2.8)
+        entity_id = self.compute_entity_id(
+            source_id=str(cid),
             record={"cid": cid},
-            provider=self.provider,
-            id_field="cid",
         )
 
         # Step 4: Compute content_hash (RULES.md §2.8.1)

--- a/src/bioetl/application/pipelines/pubmed/transformer.py
+++ b/src/bioetl/application/pipelines/pubmed/transformer.py
@@ -18,7 +18,7 @@ from bioetl.application.pipelines.pubmed.extractors import (
 )
 from bioetl.application.pipelines.pubmed.xml_utils import get_text
 from bioetl.domain.entities import Publication
-from bioetl.domain.transformations import generate_entity_id
+from bioetl.domain.services import IdentityService
 
 if TYPE_CHECKING:
     from bioetl.domain.context import PipelineContext
@@ -36,6 +36,7 @@ class PubMedPublicationTransformer(BaseTransformer):
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
         gold_filters: GoldFilterConfig | None = None,
+        identity_service: IdentityService | None = None,
     ):
         """Initialize PubMed publication transformer.
 
@@ -44,10 +45,15 @@ class PubMedPublicationTransformer(BaseTransformer):
             tracer: Optional tracing port for distributed tracing (O1 observability).
             metrics: Optional metrics port for duration/error tracking (O1 observability).
             gold_filters: Optional filter configuration for Gold layer.
+            identity_service: Service for computing entity IDs and content hashes.
 
         """
         super().__init__(
-            provider, tracer=tracer, metrics=metrics, gold_filters=gold_filters
+            provider,
+            tracer=tracer,
+            metrics=metrics,
+            gold_filters=gold_filters,
+            identity_service=identity_service,
         )
 
     async def _transform_impl(
@@ -65,8 +71,9 @@ class PubMedPublicationTransformer(BaseTransformer):
                 return None
 
             business_data = self._extract_business_data(root, pmid)
-            entity_id = generate_entity_id(
-                record={"pmid": pmid}, provider=self.provider, id_field="pmid"
+            entity_id = self.compute_entity_id(
+                source_id=pmid,
+                record={"pmid": pmid},
             )
             content_hash = self.compute_content_hash(business_data, exclude_none=False)
             entity = self._create_entity(

--- a/src/bioetl/application/pipelines/uniprot/transformer.py
+++ b/src/bioetl/application/pipelines/uniprot/transformer.py
@@ -13,7 +13,7 @@ from bioetl.application.core.base_transformer import (
     TransformationError,
 )
 from bioetl.domain.entities import Protein
-from bioetl.domain.transformations import generate_entity_id
+from bioetl.domain.services import IdentityService
 
 if TYPE_CHECKING:
     from bioetl.domain.context import PipelineContext
@@ -36,6 +36,7 @@ class UniProtProteinTransformer(BaseTransformer):
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
         gold_filters: GoldFilterConfig | None = None,
+        identity_service: IdentityService | None = None,
     ):
         """Initialize UniProt protein transformer.
 
@@ -44,10 +45,15 @@ class UniProtProteinTransformer(BaseTransformer):
             tracer: Optional tracing port for distributed tracing (O1 observability).
             metrics: Optional metrics port for duration/error tracking (O1 observability).
             gold_filters: Optional filter configuration for Gold layer.
+            identity_service: Service for computing entity IDs and content hashes.
 
         """
         super().__init__(
-            provider, tracer=tracer, metrics=metrics, gold_filters=gold_filters
+            provider,
+            tracer=tracer,
+            metrics=metrics,
+            gold_filters=gold_filters,
+            identity_service=identity_service,
         )
 
     async def _transform_impl(
@@ -86,11 +92,10 @@ class UniProtProteinTransformer(BaseTransformer):
             "sequence_length": self._extract_nested(record, "sequence.length"),
         }
 
-        # Step 3: Generate entity_id (RULES.md §2.8)
-        entity_id = generate_entity_id(
+        # Step 3: Generate entity_id using IdentityService (RULES.md §2.8)
+        entity_id = self.compute_entity_id(
+            source_id=accession,
             record={"accession": accession},
-            provider=self.provider,
-            id_field="accession",
         )
 
         # Step 4: Compute content_hash (RULES.md §2.8.1)

--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -164,6 +164,9 @@ from bioetl.domain.ports import (
 # Resilience (domain value objects)
 from bioetl.domain.resilience import CircuitBreakerConfig, RetryConfig, RetryPolicy
 
+# Domain services
+from bioetl.domain.services import IdentityService
+
 # Pure domain transformations
 from bioetl.domain.transformations import (
     META_FIELDS,
@@ -346,6 +349,8 @@ __all__ = [
     "CircuitBreakerConfig",
     "RetryConfig",
     "RetryPolicy",
+    # Services
+    "IdentityService",
     # Normalization (pure functions, REFACTOR-004)
     "extract_first_item",
     "extract_first_string",

--- a/src/bioetl/domain/services/__init__.py
+++ b/src/bioetl/domain/services/__init__.py
@@ -1,24 +1,29 @@
-"""Domain services for bioactivity data normalization.
+"""Domain services for bioactivity data processing.
 
-This package provides specialized services for normalizing bioactivity data:
+This package provides specialized services for domain operations:
 
+- IdentityService: Entity ID and content hash generation (RULES.md §2.8)
 - UnitConverter: Conversion between concentration units (nM, µM, mM)
 - ValueValidator: Validation of bioactivity value ranges
 - ActivityAggregator: Aggregation of multiple measurements
-- NormalizationService: Orchestrator facade combining all services
+- NormalizationService: Orchestrator facade combining normalization services
 
 Services are pure domain logic (no I/O) per RULES.md §1.1.
 
 Usage:
+    >>> from bioetl.domain.services import IdentityService
+    >>> identity = IdentityService()
+    >>> entity_id = identity.compute_entity_id("chembl", "activity", "12345", {})
+    >>> content_hash = identity.compute_content_hash("chembl", {"value": 100})
+
     >>> from bioetl.domain.services import NormalizationService, NormalizationConfig
     >>> config = NormalizationConfig()
     >>> service = NormalizationService(config)
     >>> result = service.normalize_activity(100.0, "nM", "IC50")
-    >>> print(result)
-    (100.0, 'nM')
 """
 
 from bioetl.domain.services.activity_aggregator import ActivityAggregator
+from bioetl.domain.services.identity_service import IdentityService
 from bioetl.domain.services.normalization_config import NormalizationConfig
 from bioetl.domain.services.normalization_service import NormalizationService
 from bioetl.domain.services.unit_converter import UnitConverter
@@ -26,6 +31,7 @@ from bioetl.domain.services.value_validator import ValueValidator
 
 __all__ = [
     "ActivityAggregator",
+    "IdentityService",
     "NormalizationConfig",
     "NormalizationService",
     "UnitConverter",

--- a/src/bioetl/domain/services/identity_service.py
+++ b/src/bioetl/domain/services/identity_service.py
@@ -1,0 +1,222 @@
+"""Identity Service for entity identification and content hashing.
+
+Provides centralized logic for computing entity identifiers and content hashes
+according to RULES.md §2.8.
+
+This is a pure domain service with no external dependencies (only stdlib).
+All methods are deterministic and side-effect free.
+
+Requirements:
+- REQ-ID-001 to REQ-ID-008: Content hash algorithm
+- REQ-ARCH-003: No I/O in domain layer
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from datetime import date, datetime
+from typing import Any
+
+from bioetl.domain.types import ContentHash, EntityID
+
+# Meta-fields to exclude from hash calculation (RULES.md §2.8.1)
+META_FIELDS: frozenset[str] = frozenset(
+    {
+        "_ingestion_ts",
+        "_run_id",
+        "_run_type",
+        "_dq_warn",
+        "_dq_error",
+        "_source_batch_id",
+    }
+)
+
+
+class IdentityService:
+    """Service for generating entity identifiers and content hashes.
+
+    Implements RULES.md §2.8 entity identification:
+    - Stable entity_id from business keys or content hash
+    - SHA256 content hash with canonical JSON normalization
+    - Meta-field exclusion for deterministic hashing
+
+    This service is stateless and can be safely shared across transformers.
+    All methods are pure (deterministic, side-effect free).
+
+    Example:
+        >>> identity = IdentityService()
+        >>> entity_id = identity.compute_entity_id(
+        ...     provider="chembl",
+        ...     entity_type="activity",
+        ...     source_id="12345",
+        ...     record={"activity_id": "12345", "value": 100.0},
+        ... )
+        >>> content_hash = identity.compute_content_hash(
+        ...     provider="chembl",
+        ...     record={"activity_id": "12345", "value": 100.0},
+        ... )
+
+    """
+
+    def compute_entity_id(
+        self,
+        provider: str,
+        entity_type: str,  # noqa: ARG002 - reserved for future use
+        source_id: str | None,
+        record: dict[str, Any],
+    ) -> EntityID:
+        """Compute stable entity identifier.
+
+        If source_id is provided, uses it directly for stable identification.
+        Otherwise, generates identifier from content hash prefix.
+
+        Args:
+            provider: Data provider identifier (e.g., 'chembl', 'pubchem').
+            entity_type: Entity type (e.g., 'activity', 'compound'). Reserved for future.
+            source_id: Source system identifier (e.g., activity_id from API).
+            record: Full record for fallback hash-based identification.
+
+        Returns:
+            EntityID in format "{provider}:{id}" or "{provider}:{hash_prefix}".
+
+        Example:
+            >>> identity.compute_entity_id("chembl", "activity", "12345", {})
+            EntityID("chembl:12345")
+            >>> identity.compute_entity_id("chembl", "activity", None, {"val": 1})
+            EntityID("chembl:a1b2c3d4e5f6...")  # hash-based
+
+        """
+        if source_id:
+            return EntityID(f"{provider}:{source_id}")
+
+        # Fallback: generate from content hash prefix
+        content_hash = self.compute_content_hash(provider, record)
+        return EntityID(f"{provider}:{content_hash[:16]}")
+
+    def compute_content_hash(
+        self,
+        provider: str,
+        record: dict[str, Any],
+        *,
+        exclude_none: bool = False,
+    ) -> ContentHash:
+        """Compute SHA256 content hash for record versioning.
+
+        Implements RULES.md §2.8.1:
+        - sha256(provider + canonical_json(record))
+        - Normalizes values before hashing for consistency
+
+        Args:
+            provider: Data provider identifier (e.g., 'chembl', 'pubchem').
+            record: Business data dictionary (meta fields auto-excluded).
+            exclude_none: Whether to exclude None values from hash.
+
+        Returns:
+            ContentHash (SHA256 hex digest, 64 characters).
+
+        Example:
+            >>> identity.compute_content_hash("chembl", {"id": "123", "val": 1.0})
+            ContentHash("abc123...")
+
+        """
+        normalized = self._normalize_for_hash(record, exclude_none=exclude_none)
+        canonical = self._canonical_json_dumps(normalized)
+        data = f"{provider}{canonical}"
+        hash_digest = hashlib.sha256(data.encode("utf-8")).hexdigest()
+        return ContentHash(hash_digest)
+
+    def _normalize_for_hash(
+        self,
+        record: dict[str, Any],
+        *,
+        exclude_none: bool = False,
+    ) -> dict[str, Any]:
+        """Normalize record before hashing for consistency.
+
+        Applies normalization rules from RULES.md §2.8.1:
+        - NaN/Inf floats → null
+        - Floats → round(val, 10)
+        - Dates → ISO YYYY-MM-DD
+        - Strings → strip()
+        - Meta-fields (_ingestion_ts, _run_id, etc.) → excluded
+
+        Args:
+            record: Input record dictionary.
+            exclude_none: Whether to exclude None values.
+
+        Returns:
+            Normalized dictionary suitable for hashing.
+
+        """
+        result: dict[str, Any] = {}
+
+        for key, value in record.items():
+            # Skip meta-fields
+            if key in META_FIELDS:
+                continue
+
+            # Optionally skip None values
+            if exclude_none and value is None:
+                continue
+
+            # Normalize and include
+            result[key] = self._normalize_value(value)
+
+        return result
+
+    def _normalize_value(self, value: Any) -> Any:
+        """Normalize a single value for hashing.
+
+        Args:
+            value: Input value of any type.
+
+        Returns:
+            Normalized value.
+
+        """
+        if value is None:
+            return None
+
+        if isinstance(value, float):
+            if math.isnan(value) or math.isinf(value):
+                return None
+            return round(value, 10)
+
+        if isinstance(value, datetime):
+            return value.date().isoformat()
+
+        if isinstance(value, date):
+            return value.isoformat()
+
+        if isinstance(value, str):
+            return value.strip()
+
+        if isinstance(value, dict):
+            return {k: self._normalize_value(v) for k, v in value.items()}
+
+        if isinstance(value, list):
+            return [self._normalize_value(v) for v in value]
+
+        return value
+
+    @staticmethod
+    def _canonical_json_dumps(obj: dict[str, Any]) -> str:
+        """Convert object to canonical JSON representation.
+
+        Uses sorted keys and minimal separators for deterministic output.
+
+        Args:
+            obj: Dictionary to serialize.
+
+        Returns:
+            Canonical JSON string.
+
+        """
+        return json.dumps(
+            obj,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        )

--- a/tests/architecture/test_domain_public_api.py
+++ b/tests/architecture/test_domain_public_api.py
@@ -48,6 +48,7 @@ def test_domain_all_is_complete(src_dir: Path) -> None:
         "ports",
         "resilience",
         "serialization",
+        "services",  # Submodule for domain services (IdentityService)
         "transformations",
         "types",
         "validation",  # REFACTOR-004: functions are re-exported, not module

--- a/tests/unit/domain/services/test_identity_service.py
+++ b/tests/unit/domain/services/test_identity_service.py
@@ -1,0 +1,362 @@
+"""Unit tests for IdentityService.
+
+Tests cover:
+- Determinism (same input → same hash)
+- Float normalization (round to 10 decimals)
+- Meta-field exclusion
+- Canonical JSON (sorted keys)
+- Entity ID generation from source_id and hash fallback
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+import pytest
+
+from bioetl.domain.services.identity_service import IdentityService, META_FIELDS
+
+
+class TestIdentityServiceDeterminism:
+    """Test determinism of content hash generation."""
+
+    def test_same_input_produces_same_hash(self) -> None:
+        """Same input should always produce the same content hash."""
+        service = IdentityService()
+        record = {"field_a": "value1", "field_b": 42, "field_c": 3.14}
+
+        hash1 = service.compute_content_hash("chembl", record)
+        hash2 = service.compute_content_hash("chembl", record)
+
+        assert hash1 == hash2
+        # ContentHash is a NewType (str alias), check it's a valid hex string
+        assert isinstance(hash1, str)
+        assert len(hash1) == 64
+
+    def test_different_providers_produce_different_hashes(self) -> None:
+        """Different providers should produce different hashes for same data."""
+        service = IdentityService()
+        record = {"id": "123", "value": 100}
+
+        hash_chembl = service.compute_content_hash("chembl", record)
+        hash_pubchem = service.compute_content_hash("pubchem", record)
+
+        assert hash_chembl != hash_pubchem
+
+    def test_field_order_does_not_affect_hash(self) -> None:
+        """Field order should not affect hash (canonical JSON uses sorted keys)."""
+        service = IdentityService()
+        record1 = {"a": 1, "b": 2, "c": 3}
+        record2 = {"c": 3, "a": 1, "b": 2}
+
+        hash1 = service.compute_content_hash("test", record1)
+        hash2 = service.compute_content_hash("test", record2)
+
+        assert hash1 == hash2
+
+
+class TestFloatNormalization:
+    """Test float normalization for consistent hashing."""
+
+    def test_float_rounded_to_10_decimals(self) -> None:
+        """Floats should be rounded to 10 decimal places."""
+        service = IdentityService()
+
+        # These should produce the same hash after rounding
+        record1 = {"value": 3.14159265358979323846}
+        record2 = {"value": 3.1415926536}  # Rounded to 10 decimals
+
+        hash1 = service.compute_content_hash("test", record1)
+        hash2 = service.compute_content_hash("test", record2)
+
+        assert hash1 == hash2
+
+    def test_nan_normalized_to_none(self) -> None:
+        """NaN values should be normalized to None."""
+        service = IdentityService()
+        record_with_nan = {"value": float("nan")}
+        record_with_none = {"value": None}
+
+        hash1 = service.compute_content_hash("test", record_with_nan)
+        hash2 = service.compute_content_hash("test", record_with_none)
+
+        assert hash1 == hash2
+
+    def test_inf_normalized_to_none(self) -> None:
+        """Infinity values should be normalized to None."""
+        service = IdentityService()
+        record_with_inf = {"value": float("inf")}
+        record_with_none = {"value": None}
+
+        hash1 = service.compute_content_hash("test", record_with_inf)
+        hash2 = service.compute_content_hash("test", record_with_none)
+
+        assert hash1 == hash2
+
+    def test_negative_inf_normalized_to_none(self) -> None:
+        """Negative infinity values should be normalized to None."""
+        service = IdentityService()
+        record_with_neg_inf = {"value": float("-inf")}
+        record_with_none = {"value": None}
+
+        hash1 = service.compute_content_hash("test", record_with_neg_inf)
+        hash2 = service.compute_content_hash("test", record_with_none)
+
+        assert hash1 == hash2
+
+
+class TestMetaFieldExclusion:
+    """Test that meta-fields are excluded from hash calculation."""
+
+    @pytest.mark.parametrize(
+        "meta_field",
+        [
+            "_ingestion_ts",
+            "_run_id",
+            "_run_type",
+            "_dq_warn",
+            "_dq_error",
+            "_source_batch_id",
+        ],
+    )
+    def test_meta_field_excluded_from_hash(self, meta_field: str) -> None:
+        """Meta-fields should not affect content hash."""
+        service = IdentityService()
+        base_record = {"id": "123", "value": 100}
+
+        record_with_meta = {**base_record, meta_field: "should_be_ignored"}
+
+        hash_base = service.compute_content_hash("test", base_record)
+        hash_with_meta = service.compute_content_hash("test", record_with_meta)
+
+        assert hash_base == hash_with_meta
+
+    def test_all_meta_fields_in_constant(self) -> None:
+        """Verify META_FIELDS constant contains expected fields."""
+        expected = {
+            "_ingestion_ts",
+            "_run_id",
+            "_run_type",
+            "_dq_warn",
+            "_dq_error",
+            "_source_batch_id",
+        }
+        assert META_FIELDS == expected
+
+
+class TestCanonicalJSON:
+    """Test canonical JSON serialization."""
+
+    def test_nested_dicts_sorted(self) -> None:
+        """Nested dictionaries should also have sorted keys."""
+        service = IdentityService()
+        record1 = {"outer": {"z": 1, "a": 2}}
+        record2 = {"outer": {"a": 2, "z": 1}}
+
+        hash1 = service.compute_content_hash("test", record1)
+        hash2 = service.compute_content_hash("test", record2)
+
+        assert hash1 == hash2
+
+    def test_list_order_preserved(self) -> None:
+        """List order should be preserved (not sorted)."""
+        service = IdentityService()
+        record1 = {"items": [1, 2, 3]}
+        record2 = {"items": [3, 2, 1]}
+
+        hash1 = service.compute_content_hash("test", record1)
+        hash2 = service.compute_content_hash("test", record2)
+
+        # Different order should produce different hashes
+        assert hash1 != hash2
+
+
+class TestDateNormalization:
+    """Test date/datetime normalization."""
+
+    def test_datetime_normalized_to_date_iso(self) -> None:
+        """Datetime should be normalized to date ISO string."""
+        service = IdentityService()
+
+        # Different times on same date should produce same hash
+        dt1 = datetime(2024, 1, 15, 10, 30, 0)
+        dt2 = datetime(2024, 1, 15, 23, 59, 59)
+
+        record1 = {"timestamp": dt1}
+        record2 = {"timestamp": dt2}
+
+        hash1 = service.compute_content_hash("test", record1)
+        hash2 = service.compute_content_hash("test", record2)
+
+        assert hash1 == hash2
+
+    def test_date_normalized_to_iso(self) -> None:
+        """Date should be normalized to ISO string."""
+        service = IdentityService()
+        d = date(2024, 1, 15)
+
+        record = {"date_field": d}
+        normalized = service._normalize_for_hash(record)
+
+        assert normalized["date_field"] == "2024-01-15"
+
+
+class TestStringNormalization:
+    """Test string normalization."""
+
+    def test_string_stripped(self) -> None:
+        """Strings should be stripped of whitespace."""
+        service = IdentityService()
+        record1 = {"name": "  test  "}
+        record2 = {"name": "test"}
+
+        hash1 = service.compute_content_hash("test", record1)
+        hash2 = service.compute_content_hash("test", record2)
+
+        assert hash1 == hash2
+
+
+class TestEntityIdGeneration:
+    """Test entity ID generation."""
+
+    def test_entity_id_with_source_id(self) -> None:
+        """Entity ID should use source_id when provided."""
+        service = IdentityService()
+
+        entity_id = service.compute_entity_id(
+            provider="chembl",
+            entity_type="activity",
+            source_id="12345",
+            record={"any": "data"},
+        )
+
+        assert entity_id == "chembl:12345"
+
+    def test_entity_id_without_source_id_uses_hash(self) -> None:
+        """Entity ID should use hash prefix when source_id is None."""
+        service = IdentityService()
+
+        entity_id = service.compute_entity_id(
+            provider="chembl",
+            entity_type="activity",
+            source_id=None,
+            record={"field": "value"},
+        )
+
+        # Should start with provider and be based on hash
+        assert str(entity_id).startswith("chembl:")
+        # Hash prefix should be 16 characters
+        assert len(str(entity_id)) == len("chembl:") + 16
+
+    def test_entity_id_format(self) -> None:
+        """Entity ID should have correct format."""
+        service = IdentityService()
+
+        entity_id = service.compute_entity_id(
+            provider="pubchem",
+            entity_type="compound",
+            source_id="CID123",
+            record={},
+        )
+
+        # EntityID is a NewType (str alias)
+        assert isinstance(entity_id, str)
+        assert entity_id == "pubchem:CID123"
+
+    def test_entity_id_deterministic_without_source(self) -> None:
+        """Entity ID without source_id should be deterministic."""
+        service = IdentityService()
+        record = {"stable": "data"}
+
+        id1 = service.compute_entity_id("test", "entity", None, record)
+        id2 = service.compute_entity_id("test", "entity", None, record)
+
+        assert id1 == id2
+
+
+class TestExcludeNone:
+    """Test exclude_none parameter behavior."""
+
+    def test_exclude_none_true(self) -> None:
+        """When exclude_none=True, None values should be excluded."""
+        service = IdentityService()
+        record_with_none = {"a": 1, "b": None}
+        record_without_none = {"a": 1}
+
+        hash1 = service.compute_content_hash(
+            "test", record_with_none, exclude_none=True
+        )
+        hash2 = service.compute_content_hash(
+            "test", record_without_none, exclude_none=True
+        )
+
+        assert hash1 == hash2
+
+    def test_exclude_none_false(self) -> None:
+        """When exclude_none=False, None values should be included."""
+        service = IdentityService()
+        record_with_none = {"a": 1, "b": None}
+        record_without_none = {"a": 1}
+
+        hash1 = service.compute_content_hash(
+            "test", record_with_none, exclude_none=False
+        )
+        hash2 = service.compute_content_hash(
+            "test", record_without_none, exclude_none=False
+        )
+
+        assert hash1 != hash2
+
+
+class TestNestedStructures:
+    """Test normalization of nested structures."""
+
+    def test_nested_dict_normalized(self) -> None:
+        """Nested dicts should be normalized recursively."""
+        service = IdentityService()
+        record = {"outer": {"inner": {"value": 3.14159265358979}}}
+
+        normalized = service._normalize_for_hash(record)
+
+        # Float should be rounded
+        assert normalized["outer"]["inner"]["value"] == round(3.14159265358979, 10)
+
+    def test_nested_list_normalized(self) -> None:
+        """Lists should have elements normalized recursively."""
+        service = IdentityService()
+        record = {"items": [1.23456789012345, "  text  ", {"key": float("nan")}]}
+
+        normalized = service._normalize_for_hash(record)
+
+        assert normalized["items"][0] == round(1.23456789012345, 10)
+        assert normalized["items"][1] == "text"
+        assert normalized["items"][2]["key"] is None
+
+
+class TestHashFormat:
+    """Test hash output format."""
+
+    def test_hash_is_sha256_hex(self) -> None:
+        """Hash should be SHA256 hex digest (64 characters)."""
+        service = IdentityService()
+        content_hash = service.compute_content_hash("test", {"id": "123"})
+
+        assert len(str(content_hash)) == 64
+        assert all(c in "0123456789abcdef" for c in str(content_hash))
+
+
+class TestServiceStateless:
+    """Test that service is stateless and reusable."""
+
+    def test_multiple_calls_independent(self) -> None:
+        """Multiple calls should be independent (no state)."""
+        service = IdentityService()
+
+        hash1 = service.compute_content_hash("provider1", {"a": 1})
+        hash2 = service.compute_content_hash("provider2", {"b": 2})
+        hash3 = service.compute_content_hash("provider1", {"a": 1})
+
+        # First and third should be equal (same input)
+        assert hash1 == hash3
+        # Different inputs should be different
+        assert hash1 != hash2


### PR DESCRIPTION
Extract entity_id and content_hash computation from Application layer transformers into a dedicated Domain service for proper DDD alignment.

Changes:
- Add IdentityService in domain/services with methods:
  - compute_entity_id(): stable ID from source or hash fallback
  - compute_content_hash(): SHA256 with canonical JSON normalization
  - _normalize_for_hash(): meta-field exclusion, float rounding
- Update BaseTransformer to use IdentityService via DI
- Update all concrete transformers (ChEMBL, PubChem, PubMed, UniProt, CrossRef) to use compute_entity_id() method
- Add comprehensive unit tests (29 tests) for IdentityService
- Update domain/__init__.py exports

Benefits:
- Identity logic centralized in Domain layer per DDD
- Transformers in Application layer are thinner
- Hash computation logic is reusable across contexts
- Full backward compatibility maintained