### PR TITLE
Create Value Objects for domain primitives

### DIFF
--- a/src/bioetl/domain/value_objects/__init__.py
+++ b/src/bioetl/domain/value_objects/__init__.py
@@ -4,8 +4,9 @@ Value Objects are immutable domain primitives that encapsulate validation
 and business rules. They provide type safety and self-validation.
 
 Categories:
-- Identifiers: ChemblId, UniProtId, DOI, PubMedId, PubChemCid
-- Measurements: Concentration, ActivityType, PChemblValue
+- Identifiers: ChemblId, UniProtId, DOI, PubMedId, PubChemCid, CompoundId, AssayId
+- Measurements: Concentration, ActivityType, PChemblValue, ActivityValue
+- Activity: ConfidenceScore, RelationOperator
 
 Usage:
     >>> from bioetl.domain.value_objects import ChemblId, DOI
@@ -16,12 +17,31 @@ Usage:
     >>> doi.url
     'https://doi.org/10.1038/nature12373'
 
+    >>> from bioetl.domain.value_objects import CompoundId, ConfidenceScore
+    >>> cid = CompoundId.from_chembl("CHEMBL25")
+    >>> cid.source
+    <CompoundSource.CHEMBL: 'chembl'>
+    >>> score = ConfidenceScore(9)
+    >>> score.is_high_confidence
+    True
+
 See also:
 - DDD patterns: https://martinfowler.com/bliki/ValueObject.html
 - RULES.md §2.8: Entity ID - stable identifiers
 """
 
+from bioetl.domain.value_objects.activity import (
+    ActivityValue,
+    ConfidenceScore,
+    RelationOperator,
+)
 from bioetl.domain.value_objects.base import ValueObject
+from bioetl.domain.value_objects.compound_ids import (
+    AssayId,
+    CompoundId,
+    CompoundIdUnion,
+    CompoundSource,
+)
 from bioetl.domain.value_objects.identifiers import (
     DOI,
     ChemblId,
@@ -39,12 +59,19 @@ from bioetl.domain.value_objects.measurements import (
 __all__ = [
     "DOI",
     "ActivityType",
+    "ActivityValue",
+    "AssayId",
     "ChemblId",
+    "CompoundId",
+    "CompoundIdUnion",
+    "CompoundSource",
     "Concentration",
     "ConcentrationUnit",
+    "ConfidenceScore",
     "PChemblValue",
     "PubChemCid",
     "PubMedId",
+    "RelationOperator",
     "UniProtId",
     "ValueObject",
 ]

--- a/src/bioetl/domain/value_objects/activity.py
+++ b/src/bioetl/domain/value_objects/activity.py
@@ -1,0 +1,327 @@
+"""Activity-related Value Objects for BioETL domain.
+
+Contains Value Objects for bioactivity measurements:
+- ConfidenceScore: ChEMBL assay confidence (0-9)
+- RelationOperator: Comparison operators (=, <, >, <=, >=)
+- ActivityValue: Composite value with magnitude, unit, and relation
+
+These Value Objects encapsulate validation and comparison logic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bioetl.domain.value_objects.measurements import Concentration
+
+
+class RelationOperator(str, Enum):
+    """Comparison operators for activity values.
+
+    Used to express the relationship between a measured value
+    and its reported magnitude (e.g., IC50 > 10 μM).
+
+    Invariants:
+        - Only valid comparison operators are allowed
+        - Normalized to standard symbols
+    """
+
+    EQUAL = "="
+    LESS_THAN = "<"
+    LESS_THAN_OR_EQUAL = "<="
+    GREATER_THAN = ">"
+    GREATER_THAN_OR_EQUAL = ">="
+    APPROXIMATELY = "~"
+
+    @classmethod
+    def from_string(cls, s: str | None) -> RelationOperator | None:
+        """Parse relation operator from string.
+
+        Args:
+            s: Operator string (e.g., "=", "<", ">=").
+
+        Returns:
+            Corresponding RelationOperator or None if input is None.
+
+        Raises:
+            ValueError: If operator string is not recognized.
+        """
+        if s is None:
+            return None
+
+        normalized = s.strip()
+        if not normalized:
+            return None
+
+        # Map variations to canonical forms
+        operator_map = {
+            "=": cls.EQUAL,
+            "==": cls.EQUAL,
+            "<": cls.LESS_THAN,
+            "<=": cls.LESS_THAN_OR_EQUAL,
+            "=<": cls.LESS_THAN_OR_EQUAL,
+            ">": cls.GREATER_THAN,
+            ">=": cls.GREATER_THAN_OR_EQUAL,
+            "=>": cls.GREATER_THAN_OR_EQUAL,
+            "~": cls.APPROXIMATELY,
+            "≈": cls.APPROXIMATELY,
+            "approx": cls.APPROXIMATELY,
+        }
+
+        operator = operator_map.get(normalized.lower())
+        if operator is None:
+            raise ValueError(f"Unknown relation operator: {s!r}")
+
+        return operator
+
+    def is_exact(self) -> bool:
+        """Check if this is an exact equality operator.
+
+        Returns:
+            True for "=" operator only.
+        """
+        return self == RelationOperator.EQUAL
+
+    def is_upper_bound(self) -> bool:
+        """Check if this represents an upper bound.
+
+        Returns:
+            True for "<" and "<=" operators.
+        """
+        return self in {RelationOperator.LESS_THAN, RelationOperator.LESS_THAN_OR_EQUAL}
+
+    def is_lower_bound(self) -> bool:
+        """Check if this represents a lower bound.
+
+        Returns:
+            True for ">" and ">=" operators.
+        """
+        return self in {
+            RelationOperator.GREATER_THAN,
+            RelationOperator.GREATER_THAN_OR_EQUAL,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ConfidenceScore:
+    """ChEMBL assay confidence score (0-9).
+
+    The confidence score indicates the reliability of the
+    target-activity relationship:
+    - 9: Direct single protein target assigned
+    - 8: Homologous single protein target assigned
+    - 7: Direct complex protein target assigned
+    - 6: Homologous complex target assigned
+    - 5: Multiple direct targets assigned
+    - 4: Multiple homologous targets assigned
+    - 3: Target class assigned (e.g., kinase)
+    - 2: Unchecked target assigned
+    - 1: Phenotypic (no molecular target)
+    - 0: No target assigned
+
+    Invariants:
+        - value must be integer 0-9
+    """
+
+    value: int
+
+    def __post_init__(self) -> None:
+        """Validate confidence score invariants."""
+        if not isinstance(self.value, int):
+            raise TypeError(f"ConfidenceScore must be int, got {type(self.value).__name__}")
+        if not 0 <= self.value <= 9:
+            raise ValueError(f"Confidence score must be 0-9, got {self.value}")
+
+    @classmethod
+    def from_value(cls, value: int | str | None) -> ConfidenceScore | None:
+        """Create from raw value, returning None if input is None.
+
+        Args:
+            value: Raw confidence score value.
+
+        Returns:
+            ConfidenceScore or None if input is None.
+
+        Raises:
+            ValueError: If value is invalid.
+        """
+        if value is None:
+            return None
+        if isinstance(value, str):
+            value = int(value.strip())
+        return cls(value=value)
+
+    @property
+    def is_high_confidence(self) -> bool:
+        """Check if this is a high-confidence assignment (7-9).
+
+        High confidence means direct or homologous single/complex
+        protein target has been assigned.
+
+        Returns:
+            True if confidence >= 7.
+        """
+        return self.value >= 7
+
+    @property
+    def is_molecular_target(self) -> bool:
+        """Check if a molecular target is assigned (>= 3).
+
+        Scores >= 3 indicate at least a target class was assigned,
+        vs. purely phenotypic or no target.
+
+        Returns:
+            True if confidence >= 3.
+        """
+        return self.value >= 3
+
+    @property
+    def description(self) -> str:
+        """Get human-readable description of the confidence level.
+
+        Returns:
+            Description string for the confidence score.
+        """
+        descriptions = {
+            9: "Direct single protein target",
+            8: "Homologous single protein target",
+            7: "Direct complex protein target",
+            6: "Homologous complex target",
+            5: "Multiple direct targets",
+            4: "Multiple homologous targets",
+            3: "Target class assigned",
+            2: "Unchecked target",
+            1: "Phenotypic (no molecular target)",
+            0: "No target assigned",
+        }
+        return descriptions.get(self.value, f"Unknown ({self.value})")
+
+    def __str__(self) -> str:
+        """Return string representation."""
+        return str(self.value)
+
+    def __eq__(self, other: object) -> bool:
+        """Compare equality by value."""
+        if not isinstance(other, ConfidenceScore):
+            return NotImplemented
+        return self.value == other.value
+
+    def __hash__(self) -> int:
+        """Hash based on value."""
+        return hash(self.value)
+
+    def __lt__(self, other: ConfidenceScore) -> bool:
+        """Compare for ordering."""
+        if not isinstance(other, ConfidenceScore):
+            return NotImplemented
+        return self.value < other.value
+
+
+@dataclass(frozen=True, slots=True)
+class ActivityValue:
+    """Bioactivity measurement with value, unit, and relation.
+
+    A composite Value Object representing a complete activity measurement,
+    such as "IC50 = 100 nM" or "EC50 > 10 μM".
+
+    This encapsulates:
+    - The numeric value (magnitude)
+    - The unit (concentration unit)
+    - The relation operator (exact, upper/lower bound)
+
+    Invariants:
+        - value must be non-negative
+        - unit must be a valid concentration unit string
+        - relation defaults to "=" if not specified
+    """
+
+    value: float
+    unit: str
+    relation: RelationOperator = RelationOperator.EQUAL
+
+    def __post_init__(self) -> None:
+        """Validate activity value invariants."""
+        if self.value < 0:
+            raise ValueError(f"Activity value cannot be negative: {self.value}")
+        if not self.unit:
+            raise ValueError("Activity unit cannot be empty")
+
+    @classmethod
+    def from_raw(
+        cls,
+        value: float | None,
+        unit: str | None,
+        relation: str | None = None,
+    ) -> ActivityValue | None:
+        """Create from raw values, returning None if value or unit is None.
+
+        Args:
+            value: Numeric value.
+            unit: Unit string.
+            relation: Optional relation operator string.
+
+        Returns:
+            ActivityValue or None if essential fields are missing.
+        """
+        if value is None or unit is None:
+            return None
+
+        rel = RelationOperator.from_string(relation) or RelationOperator.EQUAL
+
+        return cls(value=value, unit=unit.strip(), relation=rel)
+
+    def to_concentration(self) -> Concentration:
+        """Convert to Concentration Value Object.
+
+        Returns:
+            Concentration with the same value and unit.
+
+        Raises:
+            ValueError: If unit is not a recognized concentration unit.
+        """
+        from bioetl.domain.value_objects.measurements import (
+            Concentration,
+            ConcentrationUnit,
+        )
+
+        conc_unit = ConcentrationUnit.from_string(self.unit)
+        return Concentration(value=self.value, unit=conc_unit)
+
+    @property
+    def is_exact(self) -> bool:
+        """Check if this is an exact measurement (relation = "=").
+
+        Returns:
+            True if relation is EQUAL.
+        """
+        return self.relation.is_exact()
+
+    @property
+    def is_bounded(self) -> bool:
+        """Check if this is a bounded measurement (< or >).
+
+        Returns:
+            True if relation is an inequality.
+        """
+        return not self.is_exact
+
+    def __str__(self) -> str:
+        """Return string representation like '= 100 nM'."""
+        return f"{self.relation.value} {self.value} {self.unit}"
+
+    def __eq__(self, other: object) -> bool:
+        """Compare equality by all fields."""
+        if not isinstance(other, ActivityValue):
+            return NotImplemented
+        return (
+            self.value == other.value
+            and self.unit == other.unit
+            and self.relation == other.relation
+        )
+
+    def __hash__(self) -> int:
+        """Hash based on all fields."""
+        return hash((self.value, self.unit, self.relation))

--- a/src/bioetl/domain/value_objects/compound_ids.py
+++ b/src/bioetl/domain/value_objects/compound_ids.py
@@ -1,0 +1,272 @@
+"""Compound identifier Value Objects for BioETL domain.
+
+Contains Value Objects for compound identification across sources:
+- CompoundId: Universal compound identifier (supports ChEMBL, PubChem)
+- AssayId: Bioassay identifier (ChEMBL format)
+
+These Value Objects encapsulate source-specific validation and normalization.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal, Self
+
+from bioetl.domain.value_objects.base import ValueObject
+from bioetl.domain.value_objects.identifiers import ChemblId, PubChemCid
+
+
+class CompoundSource(str, Enum):
+    """Source database for compound identifiers.
+
+    Represents the origin database of a compound identifier.
+    """
+
+    CHEMBL = "chembl"
+    PUBCHEM = "pubchem"
+
+
+@dataclass(frozen=True, slots=True)
+class CompoundId:
+    """Universal compound identifier supporting multiple sources.
+
+    A Value Object that encapsulates compound identifiers from
+    different databases (ChEMBL, PubChem) with source-specific
+    validation.
+
+    Invariants:
+        - value is validated according to source format
+        - source is one of the supported databases
+        - immutable after creation
+
+    Examples:
+        >>> cid = CompoundId.from_chembl("CHEMBL25")
+        >>> cid.source
+        <CompoundSource.CHEMBL: 'chembl'>
+        >>> cid.value
+        'CHEMBL25'
+        >>> cid = CompoundId.from_pubchem(2244)
+        >>> cid.source
+        <CompoundSource.PUBCHEM: 'pubchem'>
+    """
+
+    value: str
+    source: CompoundSource
+    _validated_id: ChemblId | PubChemCid | None = None
+
+    def __post_init__(self) -> None:
+        """Validate compound identifier based on source."""
+        validated_id: ChemblId | PubChemCid
+        if self.source == CompoundSource.CHEMBL:
+            validated_id = ChemblId(self.value)
+            object.__setattr__(self, "_validated_id", validated_id)
+            # Normalize value to canonical form
+            object.__setattr__(self, "value", validated_id.value)
+        elif self.source == CompoundSource.PUBCHEM:
+            # For PubChem, value should be numeric string
+            try:
+                cid_int = int(self.value)
+                validated_id = PubChemCid(cid_int)
+                object.__setattr__(self, "_validated_id", validated_id)
+                object.__setattr__(self, "value", str(validated_id.value))
+            except ValueError as e:
+                raise ValueError(f"Invalid PubChem CID: {self.value}") from e
+
+    @classmethod
+    def from_chembl(cls, chembl_id: str) -> Self:
+        """Create CompoundId from ChEMBL identifier.
+
+        Args:
+            chembl_id: ChEMBL ID string (e.g., "CHEMBL25").
+
+        Returns:
+            CompoundId with CHEMBL source.
+
+        Raises:
+            ValueError: If ChEMBL ID format is invalid.
+        """
+        return cls(value=chembl_id, source=CompoundSource.CHEMBL)
+
+    @classmethod
+    def from_pubchem(cls, cid: int | str) -> Self:
+        """Create CompoundId from PubChem CID.
+
+        Args:
+            cid: PubChem compound ID (integer or numeric string).
+
+        Returns:
+            CompoundId with PUBCHEM source.
+
+        Raises:
+            ValueError: If CID is invalid.
+        """
+        return cls(value=str(cid), source=CompoundSource.PUBCHEM)
+
+    @classmethod
+    def from_raw(
+        cls,
+        value: str | int,
+        source: Literal["chembl", "pubchem"] | CompoundSource,
+    ) -> Self:
+        """Create CompoundId from raw value and source string.
+
+        Args:
+            value: Identifier value.
+            source: Source database name or enum.
+
+        Returns:
+            Validated CompoundId.
+
+        Raises:
+            ValueError: If source or value is invalid.
+        """
+        if isinstance(source, str):
+            source = CompoundSource(source.lower())
+
+        return cls(value=str(value), source=source)
+
+    @property
+    def is_chembl(self) -> bool:
+        """Check if this is a ChEMBL identifier."""
+        return self.source == CompoundSource.CHEMBL
+
+    @property
+    def is_pubchem(self) -> bool:
+        """Check if this is a PubChem identifier."""
+        return self.source == CompoundSource.PUBCHEM
+
+    @property
+    def numeric_id(self) -> int:
+        """Get the numeric part of the identifier.
+
+        For ChEMBL: extracts number from CHEMBLXXX
+        For PubChem: returns the CID as integer
+
+        Returns:
+            Numeric identifier value.
+        """
+        if self._validated_id is None:
+            raise ValueError("Identifier was not properly validated")
+
+        if isinstance(self._validated_id, ChemblId):
+            return self._validated_id.numeric_id
+        return self._validated_id.value
+
+    @property
+    def as_chembl_id(self) -> ChemblId | None:
+        """Get as ChemblId if source is ChEMBL.
+
+        Returns:
+            ChemblId or None if source is not ChEMBL.
+        """
+        if self.is_chembl and isinstance(self._validated_id, ChemblId):
+            return self._validated_id
+        return None
+
+    @property
+    def as_pubchem_cid(self) -> PubChemCid | None:
+        """Get as PubChemCid if source is PubChem.
+
+        Returns:
+            PubChemCid or None if source is not PubChem.
+        """
+        if self.is_pubchem and isinstance(self._validated_id, PubChemCid):
+            return self._validated_id
+        return None
+
+    def __str__(self) -> str:
+        """Return string representation with source prefix."""
+        return f"{self.source.value}:{self.value}"
+
+    def __eq__(self, other: object) -> bool:
+        """Compare equality by value and source."""
+        if not isinstance(other, CompoundId):
+            return NotImplemented
+        return self.value == other.value and self.source == other.source
+
+    def __hash__(self) -> int:
+        """Hash based on value and source."""
+        return hash((self.value, self.source))
+
+
+class AssayId(ValueObject[str]):
+    """ChEMBL assay identifier.
+
+    Assay IDs in ChEMBL follow the same format as other ChEMBL IDs
+    (CHEMBL followed by a positive integer), but represent bioassays
+    rather than compounds.
+
+    Format: CHEMBL followed by a positive integer.
+    Examples: CHEMBL1217643, CHEMBL829394
+
+    Invariants:
+        - Follows ChEMBL ID format (CHEMBLNNN)
+        - Normalized to uppercase
+        - No leading zeros in numeric part
+    """
+
+    __slots__ = ("_chembl_id",)
+    _value: str
+    _chembl_id: ChemblId
+
+    def __init__(self, value: str) -> None:
+        """Create AssayId with validated value.
+
+        Args:
+            value: Raw assay ID string.
+
+        Raises:
+            ValueError: If format is invalid.
+        """
+        # Validate using ChemblId
+        chembl_id = ChemblId(value)
+        object.__setattr__(self, "_chembl_id", chembl_id)
+        object.__setattr__(self, "_value", chembl_id.value)
+
+    def _validate(self, value: str) -> str:
+        """Validate using ChemblId validation.
+
+        This method exists for compatibility with ValueObject base class
+        but actual validation is done in __init__.
+        """
+        return ChemblId(value).value
+
+    @classmethod
+    def from_string(cls, value: str | None) -> AssayId | None:
+        """Create from string, returning None if input is None or empty.
+
+        Args:
+            value: Assay ID string.
+
+        Returns:
+            AssayId or None if input is None/empty.
+
+        Raises:
+            ValueError: If format is invalid.
+        """
+        if value is None or not value.strip():
+            return None
+        return cls(value)
+
+    @property
+    def numeric_id(self) -> int:
+        """Get the numeric part of the assay ID.
+
+        Returns:
+            Integer portion of the identifier (e.g., 1217643 for CHEMBL1217643).
+        """
+        return self._chembl_id.numeric_id
+
+    @property
+    def as_chembl_id(self) -> ChemblId:
+        """Get the underlying ChemblId.
+
+        Returns:
+            ChemblId representation of this assay ID.
+        """
+        return self._chembl_id
+
+
+# Type alias for compound identifier union
+CompoundIdUnion = ChemblId | PubChemCid | CompoundId

--- a/tests/unit/domain/value_objects/test_activity.py
+++ b/tests/unit/domain/value_objects/test_activity.py
@@ -1,0 +1,330 @@
+"""Tests for activity-related Value Objects.
+
+Tests for ConfidenceScore, RelationOperator, ActivityValue.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bioetl.domain.value_objects import (
+    ActivityValue,
+    ConfidenceScore,
+    RelationOperator,
+)
+
+
+class TestRelationOperator:
+    """Tests for RelationOperator enum."""
+
+    def test_equal_operator(self) -> None:
+        """Test equality operator."""
+        assert RelationOperator.EQUAL.value == "="
+        assert RelationOperator.EQUAL.is_exact() is True
+        assert RelationOperator.EQUAL.is_upper_bound() is False
+        assert RelationOperator.EQUAL.is_lower_bound() is False
+
+    def test_less_than_operator(self) -> None:
+        """Test less than operator."""
+        assert RelationOperator.LESS_THAN.value == "<"
+        assert RelationOperator.LESS_THAN.is_exact() is False
+        assert RelationOperator.LESS_THAN.is_upper_bound() is True
+        assert RelationOperator.LESS_THAN.is_lower_bound() is False
+
+    def test_greater_than_operator(self) -> None:
+        """Test greater than operator."""
+        assert RelationOperator.GREATER_THAN.value == ">"
+        assert RelationOperator.GREATER_THAN.is_exact() is False
+        assert RelationOperator.GREATER_THAN.is_upper_bound() is False
+        assert RelationOperator.GREATER_THAN.is_lower_bound() is True
+
+    def test_less_than_or_equal_operator(self) -> None:
+        """Test less than or equal operator."""
+        assert RelationOperator.LESS_THAN_OR_EQUAL.value == "<="
+        assert RelationOperator.LESS_THAN_OR_EQUAL.is_upper_bound() is True
+
+    def test_greater_than_or_equal_operator(self) -> None:
+        """Test greater than or equal operator."""
+        assert RelationOperator.GREATER_THAN_OR_EQUAL.value == ">="
+        assert RelationOperator.GREATER_THAN_OR_EQUAL.is_lower_bound() is True
+
+    def test_approximately_operator(self) -> None:
+        """Test approximately operator."""
+        assert RelationOperator.APPROXIMATELY.value == "~"
+        assert RelationOperator.APPROXIMATELY.is_exact() is False
+
+    def test_from_string_equal(self) -> None:
+        """Test parsing equality operators."""
+        assert RelationOperator.from_string("=") == RelationOperator.EQUAL
+        assert RelationOperator.from_string("==") == RelationOperator.EQUAL
+
+    def test_from_string_less_than(self) -> None:
+        """Test parsing less than operators."""
+        assert RelationOperator.from_string("<") == RelationOperator.LESS_THAN
+        assert RelationOperator.from_string("<=") == RelationOperator.LESS_THAN_OR_EQUAL
+        assert RelationOperator.from_string("=<") == RelationOperator.LESS_THAN_OR_EQUAL
+
+    def test_from_string_greater_than(self) -> None:
+        """Test parsing greater than operators."""
+        assert RelationOperator.from_string(">") == RelationOperator.GREATER_THAN
+        assert RelationOperator.from_string(">=") == RelationOperator.GREATER_THAN_OR_EQUAL
+        assert RelationOperator.from_string("=>") == RelationOperator.GREATER_THAN_OR_EQUAL
+
+    def test_from_string_approximately(self) -> None:
+        """Test parsing approximately operators."""
+        assert RelationOperator.from_string("~") == RelationOperator.APPROXIMATELY
+        assert RelationOperator.from_string("≈") == RelationOperator.APPROXIMATELY
+        assert RelationOperator.from_string("approx") == RelationOperator.APPROXIMATELY
+
+    def test_from_string_none(self) -> None:
+        """Test None input returns None."""
+        assert RelationOperator.from_string(None) is None
+
+    def test_from_string_empty(self) -> None:
+        """Test empty string returns None."""
+        assert RelationOperator.from_string("") is None
+        assert RelationOperator.from_string("   ") is None
+
+    def test_from_string_invalid(self) -> None:
+        """Test invalid string raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown relation operator"):
+            RelationOperator.from_string("!=")
+
+    def test_from_string_strips_whitespace(self) -> None:
+        """Test whitespace is stripped."""
+        assert RelationOperator.from_string("  =  ") == RelationOperator.EQUAL
+
+
+class TestConfidenceScore:
+    """Tests for ConfidenceScore Value Object."""
+
+    def test_valid_score_min(self) -> None:
+        """Test minimum valid score."""
+        score = ConfidenceScore(0)
+        assert score.value == 0
+
+    def test_valid_score_max(self) -> None:
+        """Test maximum valid score."""
+        score = ConfidenceScore(9)
+        assert score.value == 9
+
+    def test_valid_score_mid(self) -> None:
+        """Test middle score."""
+        score = ConfidenceScore(5)
+        assert score.value == 5
+
+    def test_high_confidence_property(self) -> None:
+        """Test is_high_confidence property."""
+        assert ConfidenceScore(9).is_high_confidence is True
+        assert ConfidenceScore(8).is_high_confidence is True
+        assert ConfidenceScore(7).is_high_confidence is True
+        assert ConfidenceScore(6).is_high_confidence is False
+        assert ConfidenceScore(0).is_high_confidence is False
+
+    def test_molecular_target_property(self) -> None:
+        """Test is_molecular_target property."""
+        assert ConfidenceScore(9).is_molecular_target is True
+        assert ConfidenceScore(3).is_molecular_target is True
+        assert ConfidenceScore(2).is_molecular_target is False
+        assert ConfidenceScore(1).is_molecular_target is False
+        assert ConfidenceScore(0).is_molecular_target is False
+
+    def test_description_property(self) -> None:
+        """Test description property returns appropriate text."""
+        assert ConfidenceScore(9).description == "Direct single protein target"
+        assert ConfidenceScore(1).description == "Phenotypic (no molecular target)"
+        assert ConfidenceScore(0).description == "No target assigned"
+
+    def test_negative_score_raises(self) -> None:
+        """Test negative score raises ValueError."""
+        with pytest.raises(ValueError, match="must be 0-9"):
+            ConfidenceScore(-1)
+
+    def test_score_above_9_raises(self) -> None:
+        """Test score above 9 raises ValueError."""
+        with pytest.raises(ValueError, match="must be 0-9"):
+            ConfidenceScore(10)
+
+    def test_non_integer_raises(self) -> None:
+        """Test non-integer raises TypeError."""
+        with pytest.raises(TypeError, match="must be int"):
+            ConfidenceScore(5.5)  # type: ignore[arg-type]
+
+    def test_from_value_int(self) -> None:
+        """Test from_value with integer."""
+        score = ConfidenceScore.from_value(7)
+        assert score is not None
+        assert score.value == 7
+
+    def test_from_value_string(self) -> None:
+        """Test from_value with string."""
+        score = ConfidenceScore.from_value("5")
+        assert score is not None
+        assert score.value == 5
+
+    def test_from_value_none(self) -> None:
+        """Test from_value with None returns None."""
+        assert ConfidenceScore.from_value(None) is None
+
+    def test_from_value_invalid_string(self) -> None:
+        """Test from_value with invalid string raises ValueError."""
+        with pytest.raises(ValueError):
+            ConfidenceScore.from_value("abc")
+
+    def test_immutability(self) -> None:
+        """Test ConfidenceScore is immutable (frozen dataclass)."""
+        score = ConfidenceScore(5)
+        with pytest.raises(Exception):  # FrozenInstanceError
+            score.value = 7  # type: ignore[misc]
+
+    def test_equality_by_value(self) -> None:
+        """Test equality is based on value."""
+        score1 = ConfidenceScore(7)
+        score2 = ConfidenceScore(7)
+        assert score1 == score2
+        assert score1 is not score2
+
+    def test_inequality(self) -> None:
+        """Test inequality for different values."""
+        score1 = ConfidenceScore(5)
+        score2 = ConfidenceScore(7)
+        assert score1 != score2
+
+    def test_hash_consistency(self) -> None:
+        """Test hash is consistent with equality."""
+        score1 = ConfidenceScore(7)
+        score2 = ConfidenceScore(7)
+        assert hash(score1) == hash(score2)
+
+    def test_ordering(self) -> None:
+        """Test comparison operators for ordering."""
+        low = ConfidenceScore(3)
+        high = ConfidenceScore(8)
+        assert low < high
+        assert high > low  # type: ignore[operator]
+
+    def test_can_be_used_in_set(self) -> None:
+        """Test ConfidenceScore can be used in set."""
+        scores = {ConfidenceScore(5), ConfidenceScore(5), ConfidenceScore(7)}
+        assert len(scores) == 2
+
+    def test_str(self) -> None:
+        """Test string conversion."""
+        assert str(ConfidenceScore(7)) == "7"
+
+
+class TestActivityValue:
+    """Tests for ActivityValue Value Object."""
+
+    def test_creation_basic(self) -> None:
+        """Test basic creation."""
+        av = ActivityValue(value=100.0, unit="nM")
+        assert av.value == 100.0
+        assert av.unit == "nM"
+        assert av.relation == RelationOperator.EQUAL
+
+    def test_creation_with_relation(self) -> None:
+        """Test creation with custom relation."""
+        av = ActivityValue(value=10.0, unit="μM", relation=RelationOperator.GREATER_THAN)
+        assert av.value == 10.0
+        assert av.unit == "μM"
+        assert av.relation == RelationOperator.GREATER_THAN
+
+    def test_zero_value_valid(self) -> None:
+        """Test zero value is valid."""
+        av = ActivityValue(value=0.0, unit="nM")
+        assert av.value == 0.0
+
+    def test_negative_value_raises(self) -> None:
+        """Test negative value raises ValueError."""
+        with pytest.raises(ValueError, match="cannot be negative"):
+            ActivityValue(value=-1.0, unit="nM")
+
+    def test_empty_unit_raises(self) -> None:
+        """Test empty unit raises ValueError."""
+        with pytest.raises(ValueError, match="cannot be empty"):
+            ActivityValue(value=100.0, unit="")
+
+    def test_is_exact_property(self) -> None:
+        """Test is_exact property."""
+        exact = ActivityValue(value=100.0, unit="nM", relation=RelationOperator.EQUAL)
+        bound = ActivityValue(value=100.0, unit="nM", relation=RelationOperator.GREATER_THAN)
+        assert exact.is_exact is True
+        assert bound.is_exact is False
+
+    def test_is_bounded_property(self) -> None:
+        """Test is_bounded property."""
+        exact = ActivityValue(value=100.0, unit="nM", relation=RelationOperator.EQUAL)
+        bound = ActivityValue(value=100.0, unit="nM", relation=RelationOperator.LESS_THAN)
+        assert exact.is_bounded is False
+        assert bound.is_bounded is True
+
+    def test_from_raw_complete(self) -> None:
+        """Test from_raw with all values."""
+        av = ActivityValue.from_raw(value=50.0, unit="μM", relation=">")
+        assert av is not None
+        assert av.value == 50.0
+        assert av.unit == "μM"
+        assert av.relation == RelationOperator.GREATER_THAN
+
+    def test_from_raw_no_relation(self) -> None:
+        """Test from_raw without relation defaults to EQUAL."""
+        av = ActivityValue.from_raw(value=100.0, unit="nM", relation=None)
+        assert av is not None
+        assert av.relation == RelationOperator.EQUAL
+
+    def test_from_raw_none_value(self) -> None:
+        """Test from_raw with None value returns None."""
+        assert ActivityValue.from_raw(value=None, unit="nM") is None
+
+    def test_from_raw_none_unit(self) -> None:
+        """Test from_raw with None unit returns None."""
+        assert ActivityValue.from_raw(value=100.0, unit=None) is None
+
+    def test_to_concentration(self) -> None:
+        """Test conversion to Concentration."""
+        av = ActivityValue(value=100.0, unit="nM")
+        conc = av.to_concentration()
+        assert conc.value == 100.0
+        from bioetl.domain.value_objects import ConcentrationUnit
+        assert conc.unit == ConcentrationUnit.NANOMOLAR
+
+    def test_to_concentration_invalid_unit(self) -> None:
+        """Test conversion with invalid unit raises ValueError."""
+        av = ActivityValue(value=100.0, unit="kg")
+        with pytest.raises(ValueError, match="Unknown concentration unit"):
+            av.to_concentration()
+
+    def test_immutability(self) -> None:
+        """Test ActivityValue is immutable (frozen dataclass)."""
+        av = ActivityValue(value=100.0, unit="nM")
+        with pytest.raises(Exception):  # FrozenInstanceError
+            av.value = 200.0  # type: ignore[misc]
+
+    def test_equality_by_all_fields(self) -> None:
+        """Test equality considers all fields."""
+        av1 = ActivityValue(value=100.0, unit="nM", relation=RelationOperator.EQUAL)
+        av2 = ActivityValue(value=100.0, unit="nM", relation=RelationOperator.EQUAL)
+        av3 = ActivityValue(value=100.0, unit="nM", relation=RelationOperator.LESS_THAN)
+        assert av1 == av2
+        assert av1 != av3
+
+    def test_hash_consistency(self) -> None:
+        """Test hash is consistent with equality."""
+        av1 = ActivityValue(value=100.0, unit="nM")
+        av2 = ActivityValue(value=100.0, unit="nM")
+        assert hash(av1) == hash(av2)
+
+    def test_str(self) -> None:
+        """Test string representation."""
+        av = ActivityValue(value=100.0, unit="nM", relation=RelationOperator.GREATER_THAN)
+        assert str(av) == "> 100.0 nM"
+
+    def test_can_be_used_in_set(self) -> None:
+        """Test ActivityValue can be used in set."""
+        values = {
+            ActivityValue(value=100.0, unit="nM"),
+            ActivityValue(value=100.0, unit="nM"),
+            ActivityValue(value=50.0, unit="nM"),
+        }
+        assert len(values) == 2

--- a/tests/unit/domain/value_objects/test_compound_ids.py
+++ b/tests/unit/domain/value_objects/test_compound_ids.py
@@ -1,0 +1,297 @@
+"""Tests for compound identifier Value Objects.
+
+Tests for CompoundId, CompoundSource, AssayId.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bioetl.domain.value_objects import (
+    AssayId,
+    ChemblId,
+    CompoundId,
+    CompoundSource,
+    PubChemCid,
+)
+
+
+class TestCompoundSource:
+    """Tests for CompoundSource enum."""
+
+    def test_chembl_source(self) -> None:
+        """Test ChEMBL source value."""
+        assert CompoundSource.CHEMBL.value == "chembl"
+
+    def test_pubchem_source(self) -> None:
+        """Test PubChem source value."""
+        assert CompoundSource.PUBCHEM.value == "pubchem"
+
+
+class TestCompoundId:
+    """Tests for CompoundId Value Object."""
+
+    def test_from_chembl_valid(self) -> None:
+        """Test creation from valid ChEMBL ID."""
+        cid = CompoundId.from_chembl("CHEMBL25")
+        assert cid.value == "CHEMBL25"
+        assert cid.source == CompoundSource.CHEMBL
+        assert cid.is_chembl is True
+        assert cid.is_pubchem is False
+
+    def test_from_chembl_normalizes_case(self) -> None:
+        """Test ChEMBL ID case normalization."""
+        cid = CompoundId.from_chembl("chembl123")
+        assert cid.value == "CHEMBL123"
+
+    def test_from_chembl_removes_leading_zeros(self) -> None:
+        """Test ChEMBL ID leading zero removal."""
+        cid = CompoundId.from_chembl("CHEMBL0025")
+        assert cid.value == "CHEMBL25"
+
+    def test_from_pubchem_int_valid(self) -> None:
+        """Test creation from PubChem CID integer."""
+        cid = CompoundId.from_pubchem(2244)
+        assert cid.value == "2244"
+        assert cid.source == CompoundSource.PUBCHEM
+        assert cid.is_pubchem is True
+        assert cid.is_chembl is False
+
+    def test_from_pubchem_string_valid(self) -> None:
+        """Test creation from PubChem CID string."""
+        cid = CompoundId.from_pubchem("2244")
+        assert cid.value == "2244"
+        assert cid.source == CompoundSource.PUBCHEM
+
+    def test_from_raw_chembl(self) -> None:
+        """Test from_raw with ChEMBL source."""
+        cid = CompoundId.from_raw("CHEMBL100", "chembl")
+        assert cid.value == "CHEMBL100"
+        assert cid.source == CompoundSource.CHEMBL
+
+    def test_from_raw_pubchem(self) -> None:
+        """Test from_raw with PubChem source."""
+        cid = CompoundId.from_raw(5988, "pubchem")
+        assert cid.value == "5988"
+        assert cid.source == CompoundSource.PUBCHEM
+
+    def test_from_raw_with_enum_source(self) -> None:
+        """Test from_raw with enum source."""
+        cid = CompoundId.from_raw("CHEMBL50", CompoundSource.CHEMBL)
+        assert cid.source == CompoundSource.CHEMBL
+
+    def test_numeric_id_chembl(self) -> None:
+        """Test numeric_id property for ChEMBL."""
+        cid = CompoundId.from_chembl("CHEMBL25")
+        assert cid.numeric_id == 25
+
+    def test_numeric_id_pubchem(self) -> None:
+        """Test numeric_id property for PubChem."""
+        cid = CompoundId.from_pubchem(2244)
+        assert cid.numeric_id == 2244
+
+    def test_as_chembl_id_when_chembl(self) -> None:
+        """Test as_chembl_id when source is ChEMBL."""
+        cid = CompoundId.from_chembl("CHEMBL25")
+        chembl = cid.as_chembl_id
+        assert chembl is not None
+        assert isinstance(chembl, ChemblId)
+        assert chembl.value == "CHEMBL25"
+
+    def test_as_chembl_id_when_pubchem(self) -> None:
+        """Test as_chembl_id when source is PubChem returns None."""
+        cid = CompoundId.from_pubchem(2244)
+        assert cid.as_chembl_id is None
+
+    def test_as_pubchem_cid_when_pubchem(self) -> None:
+        """Test as_pubchem_cid when source is PubChem."""
+        cid = CompoundId.from_pubchem(2244)
+        pubchem = cid.as_pubchem_cid
+        assert pubchem is not None
+        assert isinstance(pubchem, PubChemCid)
+        assert pubchem.value == 2244
+
+    def test_as_pubchem_cid_when_chembl(self) -> None:
+        """Test as_pubchem_cid when source is ChEMBL returns None."""
+        cid = CompoundId.from_chembl("CHEMBL25")
+        assert cid.as_pubchem_cid is None
+
+    def test_invalid_chembl_format_raises(self) -> None:
+        """Test invalid ChEMBL format raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid ChEMBL ID"):
+            CompoundId.from_chembl("INVALID")
+
+    def test_invalid_pubchem_raises(self) -> None:
+        """Test invalid PubChem CID raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid PubChem CID"):
+            CompoundId.from_pubchem("not-a-number")
+
+    def test_zero_pubchem_raises(self) -> None:
+        """Test zero PubChem CID raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid PubChem CID"):
+            CompoundId.from_pubchem(0)
+
+    def test_invalid_source_raises(self) -> None:
+        """Test invalid source raises ValueError."""
+        with pytest.raises(ValueError):
+            CompoundId.from_raw("123", "invalid_source")  # type: ignore[arg-type]
+
+    def test_immutability(self) -> None:
+        """Test CompoundId is immutable (frozen dataclass)."""
+        cid = CompoundId.from_chembl("CHEMBL25")
+        with pytest.raises(Exception):  # FrozenInstanceError
+            cid.value = "CHEMBL100"  # type: ignore[misc]
+
+    def test_equality_same_source(self) -> None:
+        """Test equality for same source."""
+        cid1 = CompoundId.from_chembl("CHEMBL25")
+        cid2 = CompoundId.from_chembl("chembl25")
+        assert cid1 == cid2
+
+    def test_inequality_different_sources(self) -> None:
+        """Test inequality for different sources."""
+        cid1 = CompoundId.from_chembl("CHEMBL25")
+        cid2 = CompoundId.from_pubchem(25)
+        assert cid1 != cid2
+
+    def test_inequality_different_values(self) -> None:
+        """Test inequality for different values."""
+        cid1 = CompoundId.from_chembl("CHEMBL25")
+        cid2 = CompoundId.from_chembl("CHEMBL100")
+        assert cid1 != cid2
+
+    def test_hash_consistency(self) -> None:
+        """Test hash is consistent with equality."""
+        cid1 = CompoundId.from_chembl("CHEMBL25")
+        cid2 = CompoundId.from_chembl("chembl25")
+        assert hash(cid1) == hash(cid2)
+
+    def test_str(self) -> None:
+        """Test string representation includes source."""
+        cid = CompoundId.from_chembl("CHEMBL25")
+        assert str(cid) == "chembl:CHEMBL25"
+
+        cid2 = CompoundId.from_pubchem(2244)
+        assert str(cid2) == "pubchem:2244"
+
+    def test_can_be_used_in_set(self) -> None:
+        """Test CompoundId can be used in set."""
+        ids = {
+            CompoundId.from_chembl("CHEMBL25"),
+            CompoundId.from_chembl("CHEMBL25"),
+            CompoundId.from_pubchem(2244),
+        }
+        assert len(ids) == 2
+
+    def test_can_be_used_as_dict_key(self) -> None:
+        """Test CompoundId can be used as dict key."""
+        d = {CompoundId.from_chembl("CHEMBL25"): "aspirin"}
+        assert d[CompoundId.from_chembl("chembl25")] == "aspirin"
+
+
+class TestAssayId:
+    """Tests for AssayId Value Object."""
+
+    def test_valid_assay_id(self) -> None:
+        """Test creation with valid assay ID."""
+        aid = AssayId("CHEMBL1217643")
+        assert aid.value == "CHEMBL1217643"
+        assert aid.numeric_id == 1217643
+
+    def test_normalizes_case(self) -> None:
+        """Test case normalization to uppercase."""
+        aid = AssayId("chembl829394")
+        assert aid.value == "CHEMBL829394"
+
+    def test_strips_whitespace(self) -> None:
+        """Test whitespace stripping."""
+        aid = AssayId("  CHEMBL100  ")
+        assert aid.value == "CHEMBL100"
+
+    def test_removes_leading_zeros(self) -> None:
+        """Test leading zeros are normalized."""
+        aid = AssayId("CHEMBL0025")
+        assert aid.value == "CHEMBL25"
+
+    def test_as_chembl_id_property(self) -> None:
+        """Test as_chembl_id property."""
+        aid = AssayId("CHEMBL100")
+        chembl = aid.as_chembl_id
+        assert isinstance(chembl, ChemblId)
+        assert chembl.value == "CHEMBL100"
+
+    def test_from_string_valid(self) -> None:
+        """Test from_string with valid string."""
+        aid = AssayId.from_string("CHEMBL100")
+        assert aid is not None
+        assert aid.value == "CHEMBL100"
+
+    def test_from_string_none(self) -> None:
+        """Test from_string with None returns None."""
+        assert AssayId.from_string(None) is None
+
+    def test_from_string_empty(self) -> None:
+        """Test from_string with empty string returns None."""
+        assert AssayId.from_string("") is None
+        assert AssayId.from_string("   ") is None
+
+    def test_invalid_format_raises(self) -> None:
+        """Test invalid format raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid ChEMBL ID"):
+            AssayId("INVALID")
+
+    def test_empty_raises(self) -> None:
+        """Test empty string raises ValueError."""
+        with pytest.raises(ValueError, match="cannot be empty"):
+            AssayId("")
+
+    def test_zero_id_raises(self) -> None:
+        """Test zero numeric ID raises ValueError."""
+        with pytest.raises(ValueError, match="must be positive"):
+            AssayId("CHEMBL0")
+
+    def test_immutability(self) -> None:
+        """Test AssayId is immutable."""
+        aid = AssayId("CHEMBL100")
+        with pytest.raises(AttributeError, match="immutable"):
+            aid._value = "CHEMBL200"  # type: ignore[misc]
+
+    def test_equality_by_value(self) -> None:
+        """Test equality is based on value."""
+        aid1 = AssayId("CHEMBL100")
+        aid2 = AssayId("chembl100")
+        assert aid1 == aid2
+        assert aid1 is not aid2
+
+    def test_hash_consistency(self) -> None:
+        """Test hash is consistent with equality."""
+        aid1 = AssayId("CHEMBL100")
+        aid2 = AssayId("chembl100")
+        assert hash(aid1) == hash(aid2)
+
+    def test_repr(self) -> None:
+        """Test string representation."""
+        aid = AssayId("CHEMBL100")
+        assert repr(aid) == "AssayId('CHEMBL100')"
+
+    def test_str(self) -> None:
+        """Test string conversion."""
+        aid = AssayId("CHEMBL100")
+        assert str(aid) == "CHEMBL100"
+
+    def test_can_be_used_in_set(self) -> None:
+        """Test AssayId can be used in set."""
+        ids = {AssayId("CHEMBL100"), AssayId("CHEMBL100"), AssayId("CHEMBL200")}
+        assert len(ids) == 2
+
+    def test_inequality_with_different_ids(self) -> None:
+        """Test inequality for different IDs."""
+        aid1 = AssayId("CHEMBL100")
+        aid2 = AssayId("CHEMBL200")
+        assert aid1 != aid2
+
+    def test_inequality_with_different_types(self) -> None:
+        """Test inequality with different types."""
+        aid = AssayId("CHEMBL100")
+        assert aid != "CHEMBL100"
+        assert aid != 100


### PR DESCRIPTION
Add new Value Objects to eliminate primitive obsession:
- CompoundId: Universal compound identifier (ChEMBL/PubChem)
- AssayId: ChEMBL assay identifier
- ConfidenceScore: ChEMBL confidence score (0-9)
- RelationOperator: Comparison operators (=, <, >, etc.)
- ActivityValue: Composite measurement with value/unit/relation

All VOs are immutable, self-validating, and support equality by value. Includes 99 unit tests covering edge cases and invariants.