### PR TITLE
Standardize naming for storage writer classes

### DIFF
--- a/docs/04-reference/api/infrastructure.md
+++ b/docs/04-reference/api/infrastructure.md
@@ -16,7 +16,7 @@ flowchart TB
 
         subgraph Storage["Storage Writers"]
             Bronze[BronzeWriter]
-            Silver[DeltaWriter]
+            Silver[SilverWriter]
             Gold[GoldWriter]
         end
 
@@ -56,8 +56,10 @@ Data source adapters implementing `DataSourcePort`:
 Storage writers implementing `StoragePort`:
 
 - `BronzeWriter` - JSONL + zstd compression
-- `DeltaWriter` - Delta Lake Silver layer
+- `SilverWriter` - Delta Lake Silver layer (formerly DeltaWriter)
 - `GoldWriter` - Delta Lake Gold layer with SCD Type 2
+
+> **Note**: `DeltaWriter` is deprecated and will be removed after a 14-day deprecation period. Use `SilverWriter` instead.
 
 ### [Observability](infrastructure/observability.md)
 
@@ -86,7 +88,7 @@ class in `tracing.py` provides a ready implementation.
 | Domain Port | Infrastructure Adapter |
 |-------------|----------------------|
 | `DataSourcePort` | `ChemblAdapter`, `PubChemAdapter` |
-| `StoragePort` | `BronzeWriter`, `DeltaWriter`, `GoldWriter` |
+| `StoragePort` | `BronzeWriter`, `SilverWriter`, `GoldWriter` |
 | `LockPort` | `MemoryLock` |
 | `CheckpointPort` | `LocalCheckpoint` |
 | `MetricsPort` | `PrometheusMetrics`, `NoOpMetrics` |
@@ -139,7 +141,7 @@ client = UnifiedHTTPClient(
 # Storage writers
 from bioetl.infrastructure.storage import (
     BronzeWriter,
-    DeltaWriter,
+    SilverWriter,  # Preferred (was DeltaWriter)
     GoldWriter,
 )
 

--- a/docs/04-reference/api/infrastructure/adapters.md
+++ b/docs/04-reference/api/infrastructure/adapters.md
@@ -58,19 +58,21 @@ Mixin for handling paginated API responses.
 
 ## Storage Adapters
 
-### DeltaWriter
+### SilverWriter
 
-Storage adapter for Delta Lake (Silver/Gold layers).
+Storage adapter for Delta Lake (Silver layer).
 
-::: bioetl.infrastructure.storage.delta_writer.DeltaWriter
+> **Note**: `DeltaWriter` is deprecated and will be removed after a 14-day deprecation period. Use `SilverWriter` instead.
+
+::: bioetl.infrastructure.storage.silver_writer.SilverWriter
     options:
         show_root_heading: true
         show_source: false
         members:
             - write_silver
-            - write_gold
-            - read_table
-            - table_exists
+            - vacuum
+            - optimize
+            - get_table_info
 
 ### BronzeWriter
 

--- a/docs/04-reference/api/infrastructure/storage.md
+++ b/docs/04-reference/api/infrastructure/storage.md
@@ -12,7 +12,7 @@ flowchart LR
     end
 
     subgraph Silver["Silver Layer"]
-        DW[DeltaWriter]
+        SW[SilverWriter]
         SF["Delta Lake<br/>Merge/Upsert"]
     end
 
@@ -22,9 +22,9 @@ flowchart LR
     end
 
     BW --> BF
-    DW --> SF
+    SW --> SF
     GW --> GF
-    BF --> DW
+    BF --> SW
     SF --> GW
 ```
 
@@ -57,21 +57,22 @@ Writer for Bronze layer (raw data in JSONL + zstd compression).
 
 ## Silver Layer
 
-### DeltaWriter
+### SilverWriter
 
 Writer for Silver layer (Delta Lake with merge/upsert).
 
-::: bioetl.infrastructure.storage.delta_writer.DeltaWriter
+> **Note**: `DeltaWriter` is deprecated and will be removed after a 14-day deprecation period. Use `SilverWriter` instead. The class was renamed to follow the Medallion layer naming convention (BronzeWriter, SilverWriter, GoldWriter).
+
+::: bioetl.infrastructure.storage.silver_writer.SilverWriter
     options:
         show_root_heading: true
         show_source: false
         members:
             - __init__
-            - write
-            - merge
+            - write_silver
             - vacuum
             - optimize
-            - get_table_stats
+            - get_table_info
 
 **Features**:
 - ACID transactions via Delta Lake
@@ -129,16 +130,16 @@ elif mode == WriteMode.OVERWRITE:
 
 ## Schema Evolution
 
-DeltaWriter handles schema evolution:
+SilverWriter handles schema evolution:
 
 ```python
 try:
-    await writer.write(records)
+    await writer.write_silver(records, ...)
 except SchemaEvolutionError as e:
     # New columns detected
-    logger.warning(f"Schema drift: {e.new_columns}")
+    logger.warning(f"Schema drift: {e.new_fields}")
     # Auto-evolve schema if enabled
-    await writer.write(records, schema_mode="merge")
+    await writer.write_silver(records, ..., on_schema_mismatch="evolve")
 ```
 
 ## VACUUM Operations
@@ -147,16 +148,16 @@ Periodic cleanup of old data files:
 
 ```python
 # Silver layer: 7-day retention
-await delta_writer.vacuum(retention_hours=168)
+await silver_writer.vacuum(table_name="chembl_activity", retention_hours=168)
 
 # Gold layer: 30-day retention (forensic)
-await gold_writer.vacuum(retention_hours=720)
+await gold_writer.vacuum(table_name="chembl_activity", retention_hours=720)
 ```
 
 ## Usage Example
 
 ```python
-from bioetl.infrastructure.storage import BronzeWriter, DeltaWriter, GoldWriter
+from bioetl.infrastructure.storage import BronzeWriter, SilverWriter, GoldWriter
 from bioetl.domain.medallion import SilverWriteMode
 
 # Bronze: raw data storage
@@ -165,38 +166,40 @@ bronze = BronzeWriter(
     logger=logger,
     metrics=metrics,
 )
-await bronze.write(
+await bronze.write_bronze(
     records=raw_records,
     provider="chembl",
-    entity_type="activity",
+    entity="activity",
+    date=date,
     batch_id=batch_id,
     run_id=run_id,
+    run_type=run_type,
+    ingestion_ts=ingestion_ts,
 )
 
-# Silver: normalized data
-silver = DeltaWriter(
+# Silver: normalized data (using SilverWriter, formerly DeltaWriter)
+silver = SilverWriter(
     base_path="/data/silver",
-    table_name="chembl_activity",
-    primary_keys=["activity_id"],
     logger=logger,
 )
-await silver.write(
+await silver.write_silver(
+    table_name="chembl_activity",
     records=silver_records,
-    run_id=run_id,
-    mode=SilverWriteMode.MERGE,
+    primary_keys=["activity_id"],
+    schema=arrow_schema,
+    mode=SilverWriteMode.MERGE.value,
 )
 
 # Gold: validated data
 gold = GoldWriter(
     base_path="/data/gold",
-    table_name="chembl_activity",
-    primary_keys=["activity_id"],
-    schema=activity_schema,
     logger=logger,
 )
-await gold.write(
+await gold.write_gold(
+    table_name="chembl_activity",
     records=gold_records,
-    run_id=run_id,
+    schema=pandera_schema,
+    primary_keys=["activity_id"],
 )
 ```
 

--- a/src/bioetl/composition/_bootstrap/storage.py
+++ b/src/bioetl/composition/_bootstrap/storage.py
@@ -15,8 +15,8 @@ from bioetl.infrastructure.observability.noop_logger import NoOpLogger
 from bioetl.infrastructure.observability.noop_metrics import NoOpMetrics
 from bioetl.infrastructure.observability.noop_tracing import NoOpTracing
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
-from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 from bioetl.infrastructure.storage.gold_writer import GoldWriter
+from bioetl.infrastructure.storage.silver_writer import SilverWriter
 
 if TYPE_CHECKING:
     from bioetl.application.core.cleanup_service import CleanupService
@@ -62,7 +62,7 @@ def bootstrap_storage() -> StorageAdapter:
             save_json=False,
             json_path=None,
         ),
-        silver_writer=DeltaWriter(
+        silver_writer=SilverWriter(
             base_path=settings.silver_path,
             logger=noop_logger,
             tracing=noop_tracing,

--- a/src/bioetl/composition/factories/storage.py
+++ b/src/bioetl/composition/factories/storage.py
@@ -18,8 +18,11 @@ from __future__ import annotations
 
 # Re-export writers for test patching compatibility
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
+
+# DeltaWriter is deprecated, use SilverWriter instead
 from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 from bioetl.infrastructure.storage.gold_writer import GoldWriter
+from bioetl.infrastructure.storage.silver_writer import SilverWriter
 
 # Re-export from split modules for backward compatibility
 from .storage_adapter import StorageAdapter
@@ -27,8 +30,9 @@ from .storage_factory import StorageContext, StorageFactory
 
 __all__ = [
     "BronzeWriter",
-    "DeltaWriter",
+    "DeltaWriter",  # Deprecated: use SilverWriter instead
     "GoldWriter",
+    "SilverWriter",
     "StorageAdapter",
     "StorageContext",
     "StorageFactory",

--- a/src/bioetl/composition/factories/storage_adapter.py
+++ b/src/bioetl/composition/factories/storage_adapter.py
@@ -18,8 +18,8 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
-from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 from bioetl.infrastructure.storage.gold_writer import GoldWriter
+from bioetl.infrastructure.storage.silver_writer import SilverWriter
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -44,7 +44,7 @@ class StorageAdapter:
     def __init__(
         self,
         bronze_writer: BronzeWriter,
-        silver_writer: DeltaWriter,
+        silver_writer: SilverWriter,
         gold_writer: GoldWriter,
     ):
         self.bronze = bronze_writer
@@ -308,7 +308,7 @@ class StorageAdapter:
 
     def _preview_layer(
         self,
-        writer: DeltaWriter | GoldWriter,
+        writer: SilverWriter | GoldWriter,
         table_name: str,
     ) -> dict[str, Any]:
         """Count files in a layer without deletion.

--- a/src/bioetl/composition/factories/storage_factory.py
+++ b/src/bioetl/composition/factories/storage_factory.py
@@ -16,8 +16,8 @@ from typing import TYPE_CHECKING
 from bioetl.infrastructure.export.csv_exporter import CsvExporter
 from bioetl.infrastructure.observability.noop_tracing import NoOpTracing
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
-from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 from bioetl.infrastructure.storage.gold_writer import GoldWriter
+from bioetl.infrastructure.storage.silver_writer import SilverWriter
 
 from .storage_adapter import StorageAdapter
 
@@ -107,7 +107,7 @@ class StorageFactory:
                 save_json=save_json,
                 json_path=json_path,
             ),
-            silver_writer=DeltaWriter(
+            silver_writer=SilverWriter(
                 base_path=silver_path,
                 logger=logger,
                 tracing=effective_tracing,

--- a/src/bioetl/infrastructure/storage/__init__.py
+++ b/src/bioetl/infrastructure/storage/__init__.py
@@ -3,8 +3,14 @@
 Implements RULES.md §2.1 - Medallion Architecture.
 
 This package provides:
-- Writers: BronzeWriter, DeltaWriter (Silver), GoldWriter
+- Writers: BronzeWriter, SilverWriter (formerly DeltaWriter), GoldWriter
 - Utilities: RetentionManager (VACUUM, optimize, time travel)
+- Deprecated: DeltaWriter (use SilverWriter instead)
+
+Naming Convention (unified with Medallion layers):
+- BronzeWriter - writes to Bronze layer (JSONL + zstd)
+- SilverWriter - writes to Silver layer (Delta Lake)
+- GoldWriter - writes to Gold layer (Delta Lake with SCD Type 2)
 
 Note:
     Lock validation is now performed at Application layer (BatchWriter)
@@ -22,18 +28,22 @@ from bioetl.domain.exceptions import (
     UploadError,
 )
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
+
+# DeltaWriter is deprecated, use SilverWriter instead
 from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 from bioetl.infrastructure.storage.gold_writer import GoldWriter
 from bioetl.infrastructure.storage.retention_manager import RetentionManager
+from bioetl.infrastructure.storage.silver_writer import SilverWriter
 
 __all__ = [
     "BronzeWriter",
     "BucketNotFoundError",
-    "DeltaWriter",
+    "DeltaWriter",  # Deprecated: use SilverWriter instead
     "GoldWriter",
     "MergeConflictError",
     "RetentionManager",
     "SchemaViolationError",
+    "SilverWriter",
     "StorageError",
     "TableNotFoundError",
     "UploadError",

--- a/src/bioetl/infrastructure/storage/delta_writer.py
+++ b/src/bioetl/infrastructure/storage/delta_writer.py
@@ -1,55 +1,40 @@
-"""Silver layer writer (Delta Lake with merge/upsert).
+"""Deprecated alias for SilverWriter (backward compatibility).
 
-Implements RULES.md §2.1.1 - Silver Layer specifications.
+.. deprecated:: 1.0.0
+    Use :class:`~bioetl.infrastructure.storage.silver_writer.SilverWriter` instead.
+    DeltaWriter was renamed to SilverWriter to follow the Medallion layer naming
+    convention (BronzeWriter, SilverWriter, GoldWriter).
+    This alias will be removed after a 14-day deprecation period (RULES.md §6.2).
 
-Requirements:
-- REQ-DATA-006: Delta Lake format (ACID transactions)
-- REQ-DATA-007: Merge/Upsert strategy
-- REQ-DATA-008: Time Travel support
-- REQ-DELTA-001: Protocol Version (Writer 2, Reader 1)
-- REQ-DELTA-002: VACUUM scheduler (7-day retention)
-- REQ-DELTA-003: Forensic retention (7-30 days configurable)
-- REQ-LINEAGE-001: Records contain _source_batch_id
+Migration guide:
+    Replace::
 
-Architecture:
-- Uses deltalake (delta-rs) for Python
-- Local filesystem storage
-- Supports partitioning for query optimization
-- Implements merge/upsert based on primary keys
-- ACID guarantees for concurrent writes
-- CSV export delegated to CsvExporter (composition)
+        from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+        writer = DeltaWriter(...)
+
+    With::
+
+        from bioetl.infrastructure.storage.silver_writer import SilverWriter
+        writer = SilverWriter(...)
+
+Note:
+    SilverWriteMode is re-exported here for backward compatibility.
+    Import it from silver_writer or domain.medallion instead.
 """
 
 from __future__ import annotations
 
-import asyncio
-from typing import TYPE_CHECKING, Any, Literal
+import warnings
+from typing import TYPE_CHECKING
 
-import orjson
-import pyarrow as pa
-from deltalake import DeltaTable, write_deltalake
-from deltalake.exceptions import DeltaError, SchemaMismatchError
-from deltalake.exceptions import TableNotFoundError as DeltaTableNotFoundError
-from pyarrow import ArrowTypeError
-
-from bioetl.domain.exceptions import (
-    MergeConflictError,
-    PolicyViolationError,
-    SchemaEvolutionError,
-    SchemaViolationError,
-)
-from bioetl.domain.medallion import (
-    Layer,
-    SilverWriteMode,
-    WriteMode,
-    WriteModePolicy,
-)
-from bioetl.infrastructure.storage.retention_manager import RetentionManager
+# Re-export SilverWriteMode for backward compatibility
+from bioetl.domain.medallion import SilverWriteMode
+from bioetl.infrastructure.storage.silver_writer import SilverWriter
 
 if TYPE_CHECKING:
-    from datetime import datetime
     from pathlib import Path
 
+    from bioetl.domain.medallion import WriteModePolicy
     from bioetl.domain.ports import (
         AuditPort,
         LoggerPort,
@@ -59,18 +44,19 @@ if TYPE_CHECKING:
     )
     from bioetl.infrastructure.export.csv_exporter import CsvExporter
 
-from bioetl.domain.ports.audit import AuditEntry, AuditLayer, AuditOperation
 
-# Re-export SilverWriteMode for backward compatibility
-# Consumers importing from delta_writer will still work
 __all__ = ["DeltaWriter", "SilverWriteMode"]
 
 
-class DeltaWriter:
-    """Writer for Silver layer (normalized data in Delta Lake).
+class DeltaWriter(SilverWriter):
+    """Deprecated: Use SilverWriter instead.
 
-    Implements merge/upsert strategy to handle updates and deduplication.
-    CSV export is delegated to an optional CsvExporter (composition pattern).
+    This class is a deprecated alias for SilverWriter. It was renamed to follow
+    the Medallion layer naming convention (BronzeWriter, SilverWriter, GoldWriter).
+
+    .. deprecated:: 1.0.0
+        DeltaWriter will be removed after a 14-day deprecation period.
+        Use SilverWriter instead.
     """
 
     def __init__(
@@ -84,685 +70,34 @@ class DeltaWriter:
         audit: AuditPort | None = None,
         silver_validator: SilverValidatorPort | None = None,
     ) -> None:
-        """Initialize Delta writer.
+        """Initialize DeltaWriter (deprecated, use SilverWriter instead).
 
         Args:
             base_path: Base path for Delta tables (local filesystem)
             logger: Structured logger for observability (MUST be injected)
-            tracing: TracingPort for distributed tracing. Use NoOpTracing from
-                    composition layer if tracing is disabled. If None, NoOpTracing
-                    is used automatically (for test convenience).
-            csv_exporter: Optional CsvExporter for CSV output (None to disable)
-            write_policy: Optional WriteModePolicy for medallion layer validation.
-                If None, a default WriteModePolicy is created.
-            metrics: Optional MetricsPort for recording policy violation metrics.
-            audit: Optional AuditPort for write operation traceability.
-                  Use NoOpAudit from composition layer if audit disabled.
-            silver_validator: Optional SilverValidatorPort for Pandera validation.
-                            Use NoOpSilverValidator if validation is not required.
+            tracing: TracingPort for distributed tracing
+            csv_exporter: Optional CsvExporter for CSV output
+            write_policy: Optional WriteModePolicy for medallion layer validation
+            metrics: Optional MetricsPort for recording policy violation metrics
+            audit: Optional AuditPort for write operation traceability
+            silver_validator: Optional SilverValidatorPort for Pandera validation
 
-        Note:
-            LoggerPort is required per RULES.md DI requirements.
-            Lock validation is now performed at Application layer (BatchWriter)
-            per RULES.md §4.6 Safety Guard. Infrastructure writers are pure I/O.
+        .. deprecated:: 1.0.0
+            Use SilverWriter instead.
         """
-        # Use NoOpTracing if not provided (test convenience, production uses composition)
-        if tracing is None:
-            from bioetl.infrastructure.observability.noop_tracing import NoOpTracing
-
-            tracing = NoOpTracing()
-
-        self.base_path = str(base_path).rstrip("/")
-        self.csv_exporter = csv_exporter
-        self.logger = logger
-        self._write_policy = write_policy or WriteModePolicy()
-        self._metrics = metrics
-        self._audit = audit
-        self._tracing: TracingPort = tracing
-
-        # Use NoOpSilverValidator if not provided (validation is optional)
-        if silver_validator is None:
-            from bioetl.infrastructure.validation.pandera_validator import (
-                NoOpSilverValidator,
-            )
-
-            silver_validator = NoOpSilverValidator()
-        self._silver_validator: SilverValidatorPort = silver_validator
-
-        # Delegate retention operations to RetentionManager
-        self._retention_manager = RetentionManager(base_path)
-
-    def _prepare_arrow_data(
-        self,
-        records: list[dict[str, Any]],
-        schema: pa.Schema,
-        primary_keys: list[str],
-    ) -> pa.Table:
-        """Prepare Arrow table from records with schema filtering and sorting."""
-        schema_fields = set(schema.names)
-        string_fields = {
-            field.name
-            for field in schema
-            if pa.types.is_string(field.type) or pa.types.is_large_string(field.type)
-        }
-
-        def serialize_value(key: str, value: Any) -> Any:
-            """Serialize complex values to JSON strings for PyArrow compatibility.
-
-            Args:
-                key: Field name to check against string_fields.
-                value: Value to potentially serialize.
-
-            Returns:
-                JSON string if value is dict/list and field is string type,
-                otherwise the original value unchanged.
-
-            Note:
-                Uses OPT_SORT_KEYS for deterministic serialization (§2.8.1).
-                Complex objects in Gold layer are flattened; Silver preserves
-                JSON for forensic purposes.
-            """
-            if value is None:
-                return None
-            if key in string_fields and isinstance(value, (dict, list)):
-                # orjson.dumps returns bytes, but PyArrow string columns expect str
-                return orjson.dumps(value, option=orjson.OPT_SORT_KEYS).decode("utf-8")
-            return value
-
-        filtered_records = [
-            {k: serialize_value(k, v) for k, v in rec.items() if k in schema_fields}
-            for rec in records
-        ]
-        arrow_data = pa.Table.from_pylist(filtered_records, schema=schema)
-
-        if primary_keys:
-            arrow_data = arrow_data.sort_by([(pk, "ascending") for pk in primary_keys])
-        return arrow_data
-
-    async def _write_delete(
-        self, table_path: str, data: pa.Table, partition_cols: list[str] | None
-    ) -> None:
-        """Write data in delete mode (replace all existing data)."""
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(
-            None,
-            lambda: write_deltalake(
-                table_or_uri=table_path,
-                data=data,
-                mode="overwrite",
-                partition_by=partition_cols,
-                schema_mode="overwrite",
-            ),
+        warnings.warn(
+            "DeltaWriter is deprecated, use SilverWriter instead. "
+            "DeltaWriter will be removed after a 14-day deprecation period.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-
-    async def _write_append(
-        self, table_path: str, data: pa.Table, partition_cols: list[str] | None
-    ) -> None:
-        """Write data in append mode."""
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(
-            None,
-            lambda: write_deltalake(
-                table_or_uri=table_path,
-                data=data,
-                mode="append",
-                partition_by=partition_cols,
-            ),
-        )
-
-    async def _write_merge(
-        self,
-        table_path: str,
-        data: pa.Table,
-        primary_keys: list[str],
-        partition_cols: list[str] | None,
-    ) -> None:
-        """Write data using merge/upsert strategy."""
-        loop = asyncio.get_running_loop()
-        try:
-            dt = await loop.run_in_executor(
-                None,
-                lambda: DeltaTable(table_path),
-            )
-            await self._merge_records(dt, data, primary_keys)
-        except DeltaTableNotFoundError:
-            await self._write_append(table_path, data, partition_cols)
-
-    def _validate_write_mode(self, mode: str) -> SilverWriteMode:
-        """Validate and convert write mode string to enum."""
-        try:
-            return SilverWriteMode(mode)
-        except ValueError:
-            valid_modes = [m.value for m in SilverWriteMode]
-            raise ValueError(
-                f"Invalid Silver write mode '{mode}'. Allowed: {valid_modes}"
-            ) from None
-
-    def _deduplicate_by_primary_keys(
-        self, records: list[dict[str, Any]], primary_keys: list[str]
-    ) -> list[dict[str, Any]]:
-        """Deduplicate records based on primary keys to prevent duplicates in batch."""
-        if not primary_keys or not records:
-            return records
-        unique_records: dict[tuple[Any, ...], dict[str, Any]] = {}
-        for record in records:
-            key = tuple(record.get(pk) for pk in primary_keys)
-            unique_records[key] = record
-        return list(unique_records.values())
-
-    def _to_policy_write_mode(self, mode: SilverWriteMode) -> WriteMode:
-        """Map SilverWriteMode to WriteMode for policy validation.
-
-        Args:
-            mode: The SilverWriteMode to convert.
-
-        Returns:
-            The corresponding WriteMode for policy validation.
-
-        Note:
-            SilverWriteMode.DELETE maps to WriteMode.OVERWRITE because
-            the delete operation replaces all existing data.
-        """
-        mapping = {
-            SilverWriteMode.MERGE: WriteMode.MERGE,
-            SilverWriteMode.APPEND: WriteMode.APPEND,
-            SilverWriteMode.DELETE: WriteMode.OVERWRITE,
-        }
-        return mapping[mode]
-
-    def _enforce_write_policy(
-        self,
-        mode: SilverWriteMode,
-        table_name: str,
-    ) -> None:
-        """Enforce write mode policy for Silver layer.
-
-        Args:
-            mode: The validated SilverWriteMode.
-            table_name: Target table name for logging/metrics context.
-
-        Raises:
-            PolicyViolationError: If mode is not allowed for Silver layer.
-        """
-        policy_mode = self._to_policy_write_mode(mode)
-        try:
-            self._write_policy.validate(Layer.SILVER, policy_mode)
-        except PolicyViolationError:
-            self.logger.error(
-                "Write mode policy violation",
-                layer="silver",
-                mode=mode.value,
-                policy_mode=policy_mode.value,
-                table=table_name,
-            )
-            if self._metrics:
-                self._metrics.increment_counter(
-                    "policy_violations_total",
-                    1,
-                    {"layer": "silver", "mode": policy_mode.value},
-                )
-            raise
-
-    def _validate_records(
-        self, records: list[dict[str, Any]], table_name: str, schema: pa.Schema
-    ) -> None:
-        """Validate records have required metadata fields."""
-        if not records:
-            raise ValueError("No records to write")
-
-        required_fields = {"_run_id", "_run_type", "_source_batch_id", "_ingestion_ts"}
-        if missing_fields := required_fields - set(records[0].keys()):
-            raise ValueError(
-                f"Records missing required metadata fields: {missing_fields}"
-            )
-
-        if self.logger:
-            keys = set(records[0].keys())
-            optional_missing = [k for k in schema.names if k not in keys]
-            if optional_missing:
-                self.logger.debug(
-                    "Optional fields missing in batch",
-                    table=table_name,
-                    missing=optional_missing,
-                )
-
-    def _validate_silver_pandera(
-        self, records: list[dict[str, Any]], table_name: str
-    ) -> None:
-        """Validate records using Pandera schema before writing to Silver.
-
-        Args:
-            records: List of record dictionaries to validate.
-            table_name: Target table name for error context.
-
-        Raises:
-            SchemaViolationError: If Pandera validation fails.
-        """
-        result = self._silver_validator.validate(records)
-        if not result.valid:
-            self.logger.error(
-                "Silver Pandera validation failed",
-                table=table_name,
-                errors=result.errors,
-            )
-            if self._metrics:
-                self._metrics.increment_counter(
-                    "silver_validation_failures_total",
-                    1,
-                    {"table": table_name},
-                )
-            raise SchemaViolationError(table_name, result.errors)
-
-    async def _dispatch_write(
-        self,
-        validated_mode: SilverWriteMode,
-        table_path: str,
-        arrow_data: pa.Table,
-        primary_keys: list[str],
-        partition_cols: list[str] | None,
-    ) -> None:
-        """Dispatch write to appropriate method based on mode."""
-        if validated_mode == SilverWriteMode.DELETE:
-            await self._write_delete(table_path, arrow_data, partition_cols)
-        elif validated_mode == SilverWriteMode.APPEND:
-            await self._write_append(table_path, arrow_data, partition_cols)
-        else:  # SilverWriteMode.MERGE
-            await self._write_merge(
-                table_path, arrow_data, primary_keys, partition_cols
-            )
-
-    async def _get_table_schema(self, table_name: str) -> pa.Schema | None:
-        """Get existing table schema if table exists.
-
-        Args:
-            table_name: Target table name
-
-        Returns:
-            PyArrow schema if table exists, None otherwise
-        """
-        table_path = f"{self.base_path}/{table_name.replace('.', '/')}"
-        loop = asyncio.get_running_loop()
-        try:
-            dt = await loop.run_in_executor(
-                None,
-                lambda: DeltaTable(table_path),
-            )
-            return dt.schema().to_arrow()
-        except DeltaTableNotFoundError:
-            return None
-
-    async def _check_schema_drift(
-        self,
-        table_name: str,
-        records: list[dict[str, Any]],
-        on_schema_mismatch: Literal["error", "evolve", "ignore"],
-    ) -> None:
-        """Check for schema drift and handle according to policy.
-
-        Args:
-            table_name: Target table name
-            records: List of records to write
-            on_schema_mismatch: How to handle schema drift
-
-        Raises:
-            SchemaEvolutionError: If on_schema_mismatch='error' and drift detected
-        """
-        existing_schema = await self._get_table_schema(table_name)
-        if existing_schema is None or not records:
-            return
-
-        incoming_fields = set(records[0].keys())
-        existing_fields = set(existing_schema.names)
-
-        new_fields = incoming_fields - existing_fields
-        removed_fields = existing_fields - incoming_fields
-
-        if not new_fields and not removed_fields:
-            return
-
-        self.logger.warning(
-            "Schema drift detected",
-            table=table_name,
-            new_fields=sorted(new_fields) if new_fields else None,
-            removed_fields=sorted(removed_fields) if removed_fields else None,
-            action=on_schema_mismatch,
-        )
-
-        if on_schema_mismatch == "error":
-            raise SchemaEvolutionError(
-                table=table_name,
-                new_fields=new_fields,
-                removed_fields=removed_fields,
-            )
-        # "evolve" and "ignore" proceed without error
-        # "evolve" will let Delta Lake handle schema evolution via schema_mode
-        # "ignore" will filter records to match existing schema
-
-    async def write_silver(
-        self,
-        table_name: str,
-        records: list[dict[str, Any]],
-        primary_keys: list[str],
-        schema: pa.Schema,
-        mode: str = "merge",
-        partition_cols: list[str] | None = None,
-        on_schema_mismatch: Literal["error", "evolve", "ignore"] = "error",
-    ) -> None:
-        """Write normalized records to Silver layer (Delta Lake merge/upsert).
-
-        Args:
-            table_name: Target table name
-            records: List of records to write
-            primary_keys: Primary key columns for merge
-            schema: PyArrow schema for the table
-            mode: Write mode - 'merge', 'append', or 'delete'
-            partition_cols: Optional partition columns
-            on_schema_mismatch: How to handle schema drift:
-                - 'error': Raise SchemaEvolutionError (default)
-                - 'evolve': Allow schema evolution (add new columns)
-                - 'ignore': Proceed without changes (filter to existing schema)
-
-        Raises:
-            ValueError: If mode is invalid or records are missing required fields
-            PolicyViolationError: If mode is not allowed for Silver layer
-            SchemaEvolutionError: If schema drift detected and on_schema_mismatch='error'
-            SchemaViolationError: If Pandera validation fails
-
-        Note:
-            Lock validation is performed at Application layer (BatchWriter)
-            per RULES.md §4.6 Safety Guard.
-        """
-        tracer = self._tracing.get_tracer(__name__)
-        with tracer.start_as_current_span("write_silver") as span:
-            span.set_attribute("table_name", table_name)
-            span.set_attribute("mode", mode)
-            span.set_attribute("record_count", len(records))
-
-            records = self._deduplicate_by_primary_keys(records, primary_keys)
-            span.set_attribute("record_count", len(records))
-
-            validated_mode = self._validate_write_mode(mode)
-
-            # Enforce medallion layer write mode policy (Silver allows only merge/append)
-            self._enforce_write_policy(validated_mode, table_name)
-
-            self._validate_records(records, table_name, schema)
-
-            # Validate records using Pandera schema (if configured)
-            self._validate_silver_pandera(records, table_name)
-
-            # Check for schema drift before writing
-            await self._check_schema_drift(table_name, records, on_schema_mismatch)
-
-            table_path = f"{self.base_path}/{table_name.replace('.', '/')}"
-            arrow_data = self._prepare_arrow_data(records, schema, primary_keys)
-
-            try:
-                await self._dispatch_write(
-                    validated_mode, table_path, arrow_data, primary_keys, partition_cols
-                )
-            except (SchemaMismatchError, ArrowTypeError) as e:
-                raise SchemaViolationError(table_name, errors=[str(e)]) from e
-            except DeltaError as e:
-                if "Merge-conflict" in str(e):
-                    raise MergeConflictError(table_name, conflicts=1) from e
-                raise
-
-            if self.csv_exporter:
-                csv_append = mode != "delete"
-                # Pass primary_keys to CSV exporter for deduplication if mode is merge
-                csv_primary_keys = (
-                    primary_keys if validated_mode == SilverWriteMode.MERGE else None
-                )
-                await self.csv_exporter.export(
-                    table_name,
-                    arrow_data,
-                    append=csv_append,
-                    primary_keys=csv_primary_keys,
-                )
-
-            # Log audit entry for write operation
-            if self._audit and records:
-                await self._log_silver_audit(
-                    table_name=table_name,
-                    records=records,
-                    mode=validated_mode,
-                )
-
-    async def _log_silver_audit(
-        self,
-        table_name: str,
-        records: list[dict[str, Any]],
-        mode: SilverWriteMode,
-    ) -> None:
-        """Log audit entry for Silver write operation.
-
-        Args:
-            table_name: Target table name
-            records: List of records written
-            mode: Write mode used
-        """
-        # Skip audit if no audit port configured
-        if self._audit is None:
-            return
-
-        from datetime import datetime
-        from uuid import UUID
-
-        from bioetl.domain.types import RunID
-
-        # Extract run_id and timestamp from first record
-        first_record = records[0]
-        run_id_str = first_record.get("_run_id", "")
-        ingestion_ts_str = first_record.get("_ingestion_ts")
-
-        # Parse run_id (UUID string)
-        try:
-            run_id = RunID(UUID(run_id_str))
-        except (ValueError, TypeError):
-            # If run_id is not a valid UUID, skip audit logging
-            self.logger.warning(
-                "audit_skipped_invalid_run_id",
-                table=table_name,
-                run_id=run_id_str,
-            )
-            return
-
-        # Parse timestamp
-        if isinstance(ingestion_ts_str, str):
-            timestamp = datetime.fromisoformat(ingestion_ts_str)
-        elif isinstance(ingestion_ts_str, datetime):
-            timestamp = ingestion_ts_str
-        else:
-            from datetime import UTC
-
-            timestamp = datetime.now(UTC)
-
-        # Map SilverWriteMode to AuditOperation
-        operation_map = {
-            SilverWriteMode.MERGE: AuditOperation.MERGE,
-            SilverWriteMode.APPEND: AuditOperation.APPEND,
-            SilverWriteMode.DELETE: AuditOperation.DELETE,
-        }
-        operation = operation_map[mode]
-
-        audit_entry = AuditEntry(
-            run_id=run_id,
-            timestamp=timestamp,
-            layer=AuditLayer.SILVER,
-            table_name=table_name,
-            operation=operation,
-            records_count=len(records),
-            metadata={
-                "run_type": first_record.get("_run_type", ""),
-                "source_batch_id": first_record.get("_source_batch_id", ""),
-            },
-        )
-        await self._audit.log_write(audit_entry)
-
-    async def _merge_records(
-        self,
-        dt: DeltaTable,
-        records: pa.Table | pa.RecordBatchReader,
-        primary_keys: list[str],
-    ) -> None:
-        """Merge records into existing Delta table."""
-        merge_condition = " AND ".join(
-            f"target.{key} = source.{key}" for key in primary_keys
-        )
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(
-            None,
-            lambda: (
-                dt.merge(
-                    source=records,
-                    predicate=merge_condition,
-                    source_alias="source",
-                    target_alias="target",
-                )
-                .when_matched_update_all(
-                    predicate=(
-                        "CASE "
-                        "WHEN source._run_type = 'rebuild' THEN 3 "
-                        "WHEN source._run_type = 'backfill' THEN 2 "
-                        "ELSE 1 END >= "
-                        "CASE "
-                        "WHEN target._run_type = 'rebuild' THEN 3 "
-                        "WHEN target._run_type = 'backfill' THEN 2 "
-                        "ELSE 1 END"
-                    )
-                )
-                .when_not_matched_insert_all()
-                .execute()
-            ),
-        )
-
-    def get_table_path(self, table_name: str) -> Path:
-        """Get the filesystem path for a table.
-
-        Args:
-            table_name: Table name (e.g., 'chembl.activity')
-
-        Returns:
-            Path to the table directory.
-
-        """
-        from pathlib import Path
-
-        return Path(self.base_path) / table_name.replace(".", "/")
-
-    def clear(self, table_name: str | None = None, dry_run: bool = False) -> int:
-        """Clear Delta table(s) at the start of a pipeline run.
-
-        Args:
-            table_name: If provided, only clear this table.
-                       If None, clear all tables in base_path.
-            dry_run: If True, only count what would be deleted.
-
-        Returns:
-            Number of tables cleared (or would be cleared).
-
-        """
-        import shutil
-        from pathlib import Path
-
-        base = Path(self.base_path)
-        if not base.exists():
-            return 0
-
-        cleared = 0
-        if table_name:
-            # Clear specific table
-            table_path = self.get_table_path(table_name)
-            if table_path.exists():
-                if not dry_run:
-                    shutil.rmtree(table_path)
-                cleared = 1
-        else:
-            # Clear all Delta tables (directories with _delta_log)
-            for item in base.iterdir():
-                if item.is_dir() and (item / "_delta_log").exists():
-                    if not dry_run:
-                        shutil.rmtree(item)
-                    cleared += 1
-
-        return cleared
-
-    async def vacuum(
-        self,
-        table_name: str,
-        retention_hours: int | None = None,
-        dry_run: bool = False,
-    ) -> list[str]:
-        """Remove old files that are no longer referenced by the Delta log.
-
-        Delegates to RetentionManager for maintenance operations.
-
-        Args:
-            table_name: Table name.
-            retention_hours: Hours of retention.
-            dry_run: If True, only list files to be deleted.
-
-        Returns:
-            List of files deleted (or to be deleted).
-        """
-        return await self._retention_manager.vacuum(
-            table_name, retention_hours=retention_hours, dry_run=dry_run
-        )
-
-    async def optimize(
-        self,
-        table_name: str,
-        target_size: int | None = None,
-        partition_filters: list[tuple[str, str, Any]] | None = None,
-    ) -> dict[str, Any]:
-        """Optimize table layout (compaction).
-
-        Delegates to RetentionManager for maintenance operations.
-
-        Args:
-            table_name: Table name.
-            target_size: Target file size in bytes (currently unused, reserved for future).
-            partition_filters: Optional filters to limit optimization to specific partitions.
-
-        Returns:
-            Optimization metrics.
-        """
-        return await self._retention_manager.optimize(
-            table_name, target_size=target_size, partition_filters=partition_filters
-        )
-
-    async def get_table_info(self, table_name: str) -> dict[str, Any]:
-        """Get metadata about a Delta table.
-
-        Delegates to RetentionManager for maintenance operations.
-
-        Args:
-            table_name: Table name.
-
-        Returns:
-            Dictionary with table metadata (version, files, history).
-        """
-        return await self._retention_manager.get_table_info(table_name)
-
-    async def time_travel(
-        self,
-        table_name: str,
-        version: int | None = None,
-        timestamp: datetime | None = None,
-    ) -> DeltaTable:
-        """Read a previous version of the table.
-
-        Delegates to RetentionManager for maintenance operations.
-
-        Args:
-            table_name: Table name.
-            version: Version number.
-            timestamp: Timestamp string.
-
-        Returns:
-            PyArrow table or equivalent of the snapshot.
-        """
-        return await self._retention_manager.time_travel(
-            table_name, version=version, timestamp=timestamp
+        super().__init__(
+            base_path=base_path,
+            logger=logger,
+            tracing=tracing,
+            csv_exporter=csv_exporter,
+            write_policy=write_policy,
+            metrics=metrics,
+            audit=audit,
+            silver_validator=silver_validator,
         )

--- a/src/bioetl/infrastructure/storage/silver_writer.py
+++ b/src/bioetl/infrastructure/storage/silver_writer.py
@@ -1,0 +1,777 @@
+"""Silver layer writer (Delta Lake with merge/upsert).
+
+Implements RULES.md §2.1.1 - Silver Layer specifications.
+
+Requirements:
+- REQ-DATA-006: Delta Lake format (ACID transactions)
+- REQ-DATA-007: Merge/Upsert strategy
+- REQ-DATA-008: Time Travel support
+- REQ-DELTA-001: Protocol Version (Writer 2, Reader 1)
+- REQ-DELTA-002: VACUUM scheduler (7-day retention)
+- REQ-DELTA-003: Forensic retention (7-30 days configurable)
+- REQ-LINEAGE-001: Records contain _source_batch_id
+
+Architecture:
+- Uses deltalake (delta-rs) for Python
+- Local filesystem storage
+- Supports partitioning for query optimization
+- Implements merge/upsert based on primary keys
+- ACID guarantees for concurrent writes
+- CSV export delegated to CsvExporter (composition)
+
+Note:
+    This class was renamed from DeltaWriter to SilverWriter to follow
+    the Medallion layer naming convention (BronzeWriter, SilverWriter, GoldWriter).
+    DeltaWriter is preserved as a deprecated alias for backward compatibility.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any, Literal
+
+import orjson
+import pyarrow as pa
+from deltalake import DeltaTable, write_deltalake
+from deltalake.exceptions import DeltaError, SchemaMismatchError
+from deltalake.exceptions import TableNotFoundError as DeltaTableNotFoundError
+from pyarrow import ArrowTypeError
+
+from bioetl.domain.exceptions import (
+    MergeConflictError,
+    PolicyViolationError,
+    SchemaEvolutionError,
+    SchemaViolationError,
+)
+from bioetl.domain.medallion import (
+    Layer,
+    SilverWriteMode,
+    WriteMode,
+    WriteModePolicy,
+)
+from bioetl.infrastructure.storage.retention_manager import RetentionManager
+
+if TYPE_CHECKING:
+    from datetime import datetime
+    from pathlib import Path
+
+    from bioetl.domain.ports import (
+        AuditPort,
+        LoggerPort,
+        MetricsPort,
+        SilverValidatorPort,
+        TracingPort,
+    )
+    from bioetl.infrastructure.export.csv_exporter import CsvExporter
+
+from bioetl.domain.ports.audit import AuditEntry, AuditLayer, AuditOperation
+
+# Re-export SilverWriteMode for backward compatibility
+# Consumers importing from silver_writer will still work
+__all__ = ["SilverWriteMode", "SilverWriter"]
+
+
+class SilverWriter:
+    """Writer for Silver layer (normalized data in Delta Lake).
+
+    Implements merge/upsert strategy to handle updates and deduplication.
+    CSV export is delegated to an optional CsvExporter (composition pattern).
+
+    Note:
+        This class was renamed from DeltaWriter to follow the Medallion
+        layer naming convention: BronzeWriter, SilverWriter, GoldWriter.
+    """
+
+    def __init__(
+        self,
+        base_path: str | Path,
+        logger: LoggerPort,
+        tracing: TracingPort | None = None,
+        csv_exporter: CsvExporter | None = None,
+        write_policy: WriteModePolicy | None = None,
+        metrics: MetricsPort | None = None,
+        audit: AuditPort | None = None,
+        silver_validator: SilverValidatorPort | None = None,
+    ) -> None:
+        """Initialize Silver writer.
+
+        Args:
+            base_path: Base path for Delta tables (local filesystem)
+            logger: Structured logger for observability (MUST be injected)
+            tracing: TracingPort for distributed tracing. Use NoOpTracing from
+                    composition layer if tracing is disabled. If None, NoOpTracing
+                    is used automatically (for test convenience).
+            csv_exporter: Optional CsvExporter for CSV output (None to disable)
+            write_policy: Optional WriteModePolicy for medallion layer validation.
+                If None, a default WriteModePolicy is created.
+            metrics: Optional MetricsPort for recording policy violation metrics.
+            audit: Optional AuditPort for write operation traceability.
+                  Use NoOpAudit from composition layer if audit disabled.
+            silver_validator: Optional SilverValidatorPort for Pandera validation.
+                            Use NoOpSilverValidator if validation is not required.
+
+        Note:
+            LoggerPort is required per RULES.md DI requirements.
+            Lock validation is now performed at Application layer (BatchWriter)
+            per RULES.md §4.6 Safety Guard. Infrastructure writers are pure I/O.
+        """
+        # Use NoOpTracing if not provided (test convenience, production uses composition)
+        if tracing is None:
+            from bioetl.infrastructure.observability.noop_tracing import NoOpTracing
+
+            tracing = NoOpTracing()
+
+        self.base_path = str(base_path).rstrip("/")
+        self.csv_exporter = csv_exporter
+        self.logger = logger
+        self._write_policy = write_policy or WriteModePolicy()
+        self._metrics = metrics
+        self._audit = audit
+        self._tracing: TracingPort = tracing
+
+        # Use NoOpSilverValidator if not provided (validation is optional)
+        if silver_validator is None:
+            from bioetl.infrastructure.validation.pandera_validator import (
+                NoOpSilverValidator,
+            )
+
+            silver_validator = NoOpSilverValidator()
+        self._silver_validator: SilverValidatorPort = silver_validator
+
+        # Delegate retention operations to RetentionManager
+        self._retention_manager = RetentionManager(base_path)
+
+    def _prepare_arrow_data(
+        self,
+        records: list[dict[str, Any]],
+        schema: pa.Schema,
+        primary_keys: list[str],
+    ) -> pa.Table:
+        """Prepare Arrow table from records with schema filtering and sorting."""
+        schema_fields = set(schema.names)
+        string_fields = {
+            field.name
+            for field in schema
+            if pa.types.is_string(field.type) or pa.types.is_large_string(field.type)
+        }
+
+        def serialize_value(key: str, value: Any) -> Any:
+            """Serialize complex values to JSON strings for PyArrow compatibility.
+
+            Args:
+                key: Field name to check against string_fields.
+                value: Value to potentially serialize.
+
+            Returns:
+                JSON string if value is dict/list and field is string type,
+                otherwise the original value unchanged.
+
+            Note:
+                Uses OPT_SORT_KEYS for deterministic serialization (§2.8.1).
+                Complex objects in Gold layer are flattened; Silver preserves
+                JSON for forensic purposes.
+            """
+            if value is None:
+                return None
+            if key in string_fields and isinstance(value, (dict, list)):
+                # orjson.dumps returns bytes, but PyArrow string columns expect str
+                return orjson.dumps(value, option=orjson.OPT_SORT_KEYS).decode("utf-8")
+            return value
+
+        filtered_records = [
+            {k: serialize_value(k, v) for k, v in rec.items() if k in schema_fields}
+            for rec in records
+        ]
+        arrow_data = pa.Table.from_pylist(filtered_records, schema=schema)
+
+        if primary_keys:
+            arrow_data = arrow_data.sort_by([(pk, "ascending") for pk in primary_keys])
+        return arrow_data
+
+    async def _write_delete(
+        self, table_path: str, data: pa.Table, partition_cols: list[str] | None
+    ) -> None:
+        """Write data in delete mode (replace all existing data)."""
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            None,
+            lambda: write_deltalake(
+                table_or_uri=table_path,
+                data=data,
+                mode="overwrite",
+                partition_by=partition_cols,
+                schema_mode="overwrite",
+            ),
+        )
+
+    async def _write_append(
+        self, table_path: str, data: pa.Table, partition_cols: list[str] | None
+    ) -> None:
+        """Write data in append mode."""
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            None,
+            lambda: write_deltalake(
+                table_or_uri=table_path,
+                data=data,
+                mode="append",
+                partition_by=partition_cols,
+            ),
+        )
+
+    async def _write_merge(
+        self,
+        table_path: str,
+        data: pa.Table,
+        primary_keys: list[str],
+        partition_cols: list[str] | None,
+    ) -> None:
+        """Write data using merge/upsert strategy."""
+        loop = asyncio.get_running_loop()
+        try:
+            dt = await loop.run_in_executor(
+                None,
+                lambda: DeltaTable(table_path),
+            )
+            await self._merge_records(dt, data, primary_keys)
+        except DeltaTableNotFoundError:
+            await self._write_append(table_path, data, partition_cols)
+
+    def _validate_write_mode(self, mode: str) -> SilverWriteMode:
+        """Validate and convert write mode string to enum."""
+        try:
+            return SilverWriteMode(mode)
+        except ValueError:
+            valid_modes = [m.value for m in SilverWriteMode]
+            raise ValueError(
+                f"Invalid Silver write mode '{mode}'. Allowed: {valid_modes}"
+            ) from None
+
+    def _deduplicate_by_primary_keys(
+        self, records: list[dict[str, Any]], primary_keys: list[str]
+    ) -> list[dict[str, Any]]:
+        """Deduplicate records based on primary keys to prevent duplicates in batch."""
+        if not primary_keys or not records:
+            return records
+        unique_records: dict[tuple[Any, ...], dict[str, Any]] = {}
+        for record in records:
+            key = tuple(record.get(pk) for pk in primary_keys)
+            unique_records[key] = record
+        return list(unique_records.values())
+
+    def _to_policy_write_mode(self, mode: SilverWriteMode) -> WriteMode:
+        """Map SilverWriteMode to WriteMode for policy validation.
+
+        Args:
+            mode: The SilverWriteMode to convert.
+
+        Returns:
+            The corresponding WriteMode for policy validation.
+
+        Note:
+            SilverWriteMode.DELETE maps to WriteMode.OVERWRITE because
+            the delete operation replaces all existing data.
+        """
+        mapping = {
+            SilverWriteMode.MERGE: WriteMode.MERGE,
+            SilverWriteMode.APPEND: WriteMode.APPEND,
+            SilverWriteMode.DELETE: WriteMode.OVERWRITE,
+        }
+        return mapping[mode]
+
+    def _enforce_write_policy(
+        self,
+        mode: SilverWriteMode,
+        table_name: str,
+    ) -> None:
+        """Enforce write mode policy for Silver layer.
+
+        Args:
+            mode: The validated SilverWriteMode.
+            table_name: Target table name for logging/metrics context.
+
+        Raises:
+            PolicyViolationError: If mode is not allowed for Silver layer.
+        """
+        policy_mode = self._to_policy_write_mode(mode)
+        try:
+            self._write_policy.validate(Layer.SILVER, policy_mode)
+        except PolicyViolationError:
+            self.logger.error(
+                "Write mode policy violation",
+                layer="silver",
+                mode=mode.value,
+                policy_mode=policy_mode.value,
+                table=table_name,
+            )
+            if self._metrics:
+                self._metrics.increment_counter(
+                    "policy_violations_total",
+                    1,
+                    {"layer": "silver", "mode": policy_mode.value},
+                )
+            raise
+
+    def _validate_records(
+        self, records: list[dict[str, Any]], table_name: str, schema: pa.Schema
+    ) -> None:
+        """Validate records have required metadata fields."""
+        if not records:
+            raise ValueError("No records to write")
+
+        required_fields = {"_run_id", "_run_type", "_source_batch_id", "_ingestion_ts"}
+        if missing_fields := required_fields - set(records[0].keys()):
+            raise ValueError(
+                f"Records missing required metadata fields: {missing_fields}"
+            )
+
+        if self.logger:
+            keys = set(records[0].keys())
+            optional_missing = [k for k in schema.names if k not in keys]
+            if optional_missing:
+                self.logger.debug(
+                    "Optional fields missing in batch",
+                    table=table_name,
+                    missing=optional_missing,
+                )
+
+    def _validate_silver_pandera(
+        self, records: list[dict[str, Any]], table_name: str
+    ) -> None:
+        """Validate records using Pandera schema before writing to Silver.
+
+        Args:
+            records: List of record dictionaries to validate.
+            table_name: Target table name for error context.
+
+        Raises:
+            SchemaViolationError: If Pandera validation fails.
+        """
+        result = self._silver_validator.validate(records)
+        if not result.valid:
+            self.logger.error(
+                "Silver Pandera validation failed",
+                table=table_name,
+                errors=result.errors,
+            )
+            if self._metrics:
+                self._metrics.increment_counter(
+                    "silver_validation_failures_total",
+                    1,
+                    {"table": table_name},
+                )
+            raise SchemaViolationError(table_name, result.errors)
+
+    async def _dispatch_write(
+        self,
+        validated_mode: SilverWriteMode,
+        table_path: str,
+        arrow_data: pa.Table,
+        primary_keys: list[str],
+        partition_cols: list[str] | None,
+    ) -> None:
+        """Dispatch write to appropriate method based on mode."""
+        if validated_mode == SilverWriteMode.DELETE:
+            await self._write_delete(table_path, arrow_data, partition_cols)
+        elif validated_mode == SilverWriteMode.APPEND:
+            await self._write_append(table_path, arrow_data, partition_cols)
+        else:  # SilverWriteMode.MERGE
+            await self._write_merge(
+                table_path, arrow_data, primary_keys, partition_cols
+            )
+
+    async def _get_table_schema(self, table_name: str) -> pa.Schema | None:
+        """Get existing table schema if table exists.
+
+        Args:
+            table_name: Target table name
+
+        Returns:
+            PyArrow schema if table exists, None otherwise
+        """
+        table_path = f"{self.base_path}/{table_name.replace('.', '/')}"
+        loop = asyncio.get_running_loop()
+        try:
+            dt = await loop.run_in_executor(
+                None,
+                lambda: DeltaTable(table_path),
+            )
+            return dt.schema().to_arrow()
+        except DeltaTableNotFoundError:
+            return None
+
+    async def _check_schema_drift(
+        self,
+        table_name: str,
+        records: list[dict[str, Any]],
+        on_schema_mismatch: Literal["error", "evolve", "ignore"],
+    ) -> None:
+        """Check for schema drift and handle according to policy.
+
+        Args:
+            table_name: Target table name
+            records: List of records to write
+            on_schema_mismatch: How to handle schema drift
+
+        Raises:
+            SchemaEvolutionError: If on_schema_mismatch='error' and drift detected
+        """
+        existing_schema = await self._get_table_schema(table_name)
+        if existing_schema is None or not records:
+            return
+
+        incoming_fields = set(records[0].keys())
+        existing_fields = set(existing_schema.names)
+
+        new_fields = incoming_fields - existing_fields
+        removed_fields = existing_fields - incoming_fields
+
+        if not new_fields and not removed_fields:
+            return
+
+        self.logger.warning(
+            "Schema drift detected",
+            table=table_name,
+            new_fields=sorted(new_fields) if new_fields else None,
+            removed_fields=sorted(removed_fields) if removed_fields else None,
+            action=on_schema_mismatch,
+        )
+
+        if on_schema_mismatch == "error":
+            raise SchemaEvolutionError(
+                table=table_name,
+                new_fields=new_fields,
+                removed_fields=removed_fields,
+            )
+        # "evolve" and "ignore" proceed without error
+        # "evolve" will let Delta Lake handle schema evolution via schema_mode
+        # "ignore" will filter records to match existing schema
+
+    async def write_silver(
+        self,
+        table_name: str,
+        records: list[dict[str, Any]],
+        primary_keys: list[str],
+        schema: pa.Schema,
+        mode: str = "merge",
+        partition_cols: list[str] | None = None,
+        on_schema_mismatch: Literal["error", "evolve", "ignore"] = "error",
+    ) -> None:
+        """Write normalized records to Silver layer (Delta Lake merge/upsert).
+
+        Args:
+            table_name: Target table name
+            records: List of records to write
+            primary_keys: Primary key columns for merge
+            schema: PyArrow schema for the table
+            mode: Write mode - 'merge', 'append', or 'delete'
+            partition_cols: Optional partition columns
+            on_schema_mismatch: How to handle schema drift:
+                - 'error': Raise SchemaEvolutionError (default)
+                - 'evolve': Allow schema evolution (add new columns)
+                - 'ignore': Proceed without changes (filter to existing schema)
+
+        Raises:
+            ValueError: If mode is invalid or records are missing required fields
+            PolicyViolationError: If mode is not allowed for Silver layer
+            SchemaEvolutionError: If schema drift detected and on_schema_mismatch='error'
+            SchemaViolationError: If Pandera validation fails
+
+        Note:
+            Lock validation is performed at Application layer (BatchWriter)
+            per RULES.md §4.6 Safety Guard.
+        """
+        tracer = self._tracing.get_tracer(__name__)
+        with tracer.start_as_current_span("write_silver") as span:
+            span.set_attribute("table_name", table_name)
+            span.set_attribute("mode", mode)
+            span.set_attribute("record_count", len(records))
+
+            records = self._deduplicate_by_primary_keys(records, primary_keys)
+            span.set_attribute("record_count", len(records))
+
+            validated_mode = self._validate_write_mode(mode)
+
+            # Enforce medallion layer write mode policy (Silver allows only merge/append)
+            self._enforce_write_policy(validated_mode, table_name)
+
+            self._validate_records(records, table_name, schema)
+
+            # Validate records using Pandera schema (if configured)
+            self._validate_silver_pandera(records, table_name)
+
+            # Check for schema drift before writing
+            await self._check_schema_drift(table_name, records, on_schema_mismatch)
+
+            table_path = f"{self.base_path}/{table_name.replace('.', '/')}"
+            arrow_data = self._prepare_arrow_data(records, schema, primary_keys)
+
+            try:
+                await self._dispatch_write(
+                    validated_mode, table_path, arrow_data, primary_keys, partition_cols
+                )
+            except (SchemaMismatchError, ArrowTypeError) as e:
+                raise SchemaViolationError(table_name, errors=[str(e)]) from e
+            except DeltaError as e:
+                if "Merge-conflict" in str(e):
+                    raise MergeConflictError(table_name, conflicts=1) from e
+                raise
+
+            if self.csv_exporter:
+                csv_append = mode != "delete"
+                # Pass primary_keys to CSV exporter for deduplication if mode is merge
+                csv_primary_keys = (
+                    primary_keys if validated_mode == SilverWriteMode.MERGE else None
+                )
+                await self.csv_exporter.export(
+                    table_name,
+                    arrow_data,
+                    append=csv_append,
+                    primary_keys=csv_primary_keys,
+                )
+
+            # Log audit entry for write operation
+            if self._audit and records:
+                await self._log_silver_audit(
+                    table_name=table_name,
+                    records=records,
+                    mode=validated_mode,
+                )
+
+    async def _log_silver_audit(
+        self,
+        table_name: str,
+        records: list[dict[str, Any]],
+        mode: SilverWriteMode,
+    ) -> None:
+        """Log audit entry for Silver write operation.
+
+        Args:
+            table_name: Target table name
+            records: List of records written
+            mode: Write mode used
+        """
+        # Skip audit if no audit port configured
+        if self._audit is None:
+            return
+
+        from datetime import datetime
+        from uuid import UUID
+
+        from bioetl.domain.types import RunID
+
+        # Extract run_id and timestamp from first record
+        first_record = records[0]
+        run_id_str = first_record.get("_run_id", "")
+        ingestion_ts_str = first_record.get("_ingestion_ts")
+
+        # Parse run_id (UUID string)
+        try:
+            run_id = RunID(UUID(run_id_str))
+        except (ValueError, TypeError):
+            # If run_id is not a valid UUID, skip audit logging
+            self.logger.warning(
+                "audit_skipped_invalid_run_id",
+                table=table_name,
+                run_id=run_id_str,
+            )
+            return
+
+        # Parse timestamp
+        if isinstance(ingestion_ts_str, str):
+            timestamp = datetime.fromisoformat(ingestion_ts_str)
+        elif isinstance(ingestion_ts_str, datetime):
+            timestamp = ingestion_ts_str
+        else:
+            from datetime import UTC
+
+            timestamp = datetime.now(UTC)
+
+        # Map SilverWriteMode to AuditOperation
+        operation_map = {
+            SilverWriteMode.MERGE: AuditOperation.MERGE,
+            SilverWriteMode.APPEND: AuditOperation.APPEND,
+            SilverWriteMode.DELETE: AuditOperation.DELETE,
+        }
+        operation = operation_map[mode]
+
+        audit_entry = AuditEntry(
+            run_id=run_id,
+            timestamp=timestamp,
+            layer=AuditLayer.SILVER,
+            table_name=table_name,
+            operation=operation,
+            records_count=len(records),
+            metadata={
+                "run_type": first_record.get("_run_type", ""),
+                "source_batch_id": first_record.get("_source_batch_id", ""),
+            },
+        )
+        await self._audit.log_write(audit_entry)
+
+    async def _merge_records(
+        self,
+        dt: DeltaTable,
+        records: pa.Table | pa.RecordBatchReader,
+        primary_keys: list[str],
+    ) -> None:
+        """Merge records into existing Delta table."""
+        merge_condition = " AND ".join(
+            f"target.{key} = source.{key}" for key in primary_keys
+        )
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            None,
+            lambda: (
+                dt.merge(
+                    source=records,
+                    predicate=merge_condition,
+                    source_alias="source",
+                    target_alias="target",
+                )
+                .when_matched_update_all(
+                    predicate=(
+                        "CASE "
+                        "WHEN source._run_type = 'rebuild' THEN 3 "
+                        "WHEN source._run_type = 'backfill' THEN 2 "
+                        "ELSE 1 END >= "
+                        "CASE "
+                        "WHEN target._run_type = 'rebuild' THEN 3 "
+                        "WHEN target._run_type = 'backfill' THEN 2 "
+                        "ELSE 1 END"
+                    )
+                )
+                .when_not_matched_insert_all()
+                .execute()
+            ),
+        )
+
+    def get_table_path(self, table_name: str) -> Path:
+        """Get the filesystem path for a table.
+
+        Args:
+            table_name: Table name (e.g., 'chembl.activity')
+
+        Returns:
+            Path to the table directory.
+
+        """
+        from pathlib import Path
+
+        return Path(self.base_path) / table_name.replace(".", "/")
+
+    def clear(self, table_name: str | None = None, dry_run: bool = False) -> int:
+        """Clear Delta table(s) at the start of a pipeline run.
+
+        Args:
+            table_name: If provided, only clear this table.
+                       If None, clear all tables in base_path.
+            dry_run: If True, only count what would be deleted.
+
+        Returns:
+            Number of tables cleared (or would be cleared).
+
+        """
+        import shutil
+        from pathlib import Path
+
+        base = Path(self.base_path)
+        if not base.exists():
+            return 0
+
+        cleared = 0
+        if table_name:
+            # Clear specific table
+            table_path = self.get_table_path(table_name)
+            if table_path.exists():
+                if not dry_run:
+                    shutil.rmtree(table_path)
+                cleared = 1
+        else:
+            # Clear all Delta tables (directories with _delta_log)
+            for item in base.iterdir():
+                if item.is_dir() and (item / "_delta_log").exists():
+                    if not dry_run:
+                        shutil.rmtree(item)
+                    cleared += 1
+
+        return cleared
+
+    async def vacuum(
+        self,
+        table_name: str,
+        retention_hours: int | None = None,
+        dry_run: bool = False,
+    ) -> list[str]:
+        """Remove old files that are no longer referenced by the Delta log.
+
+        Delegates to RetentionManager for maintenance operations.
+
+        Args:
+            table_name: Table name.
+            retention_hours: Hours of retention.
+            dry_run: If True, only list files to be deleted.
+
+        Returns:
+            List of files deleted (or to be deleted).
+        """
+        return await self._retention_manager.vacuum(
+            table_name, retention_hours=retention_hours, dry_run=dry_run
+        )
+
+    async def optimize(
+        self,
+        table_name: str,
+        target_size: int | None = None,
+        partition_filters: list[tuple[str, str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        """Optimize table layout (compaction).
+
+        Delegates to RetentionManager for maintenance operations.
+
+        Args:
+            table_name: Table name.
+            target_size: Target file size in bytes (currently unused, reserved for future).
+            partition_filters: Optional filters to limit optimization to specific partitions.
+
+        Returns:
+            Optimization metrics.
+        """
+        return await self._retention_manager.optimize(
+            table_name, target_size=target_size, partition_filters=partition_filters
+        )
+
+    async def get_table_info(self, table_name: str) -> dict[str, Any]:
+        """Get metadata about a Delta table.
+
+        Delegates to RetentionManager for maintenance operations.
+
+        Args:
+            table_name: Table name.
+
+        Returns:
+            Dictionary with table metadata (version, files, history).
+        """
+        return await self._retention_manager.get_table_info(table_name)
+
+    async def time_travel(
+        self,
+        table_name: str,
+        version: int | None = None,
+        timestamp: datetime | None = None,
+    ) -> DeltaTable:
+        """Read a previous version of the table.
+
+        Delegates to RetentionManager for maintenance operations.
+
+        Args:
+            table_name: Table name.
+            version: Version number.
+            timestamp: Timestamp string.
+
+        Returns:
+            PyArrow table or equivalent of the snapshot.
+        """
+        return await self._retention_manager.time_travel(
+            table_name, version=version, timestamp=timestamp
+        )

--- a/tests/unit/infrastructure/storage/test_delta_writer.py
+++ b/tests/unit/infrastructure/storage/test_delta_writer.py
@@ -611,7 +611,7 @@ class TestDeltaWriterErrorHandling:
         )
 
         with patch(
-            "bioetl.infrastructure.storage.delta_writer.DeltaTable",
+            "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             delta_table_mock,
         ):
             writer = DeltaWriter(
@@ -666,7 +666,7 @@ class TestDeltaWriterErrorHandling:
         )
 
         with patch(
-            "bioetl.infrastructure.storage.delta_writer.DeltaTable",
+            "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             delta_table_mock,
         ):
             writer = DeltaWriter(
@@ -694,7 +694,7 @@ class TestDeltaWriterSchemaDrift:
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
         with patch(
-            "bioetl.infrastructure.storage.delta_writer.DeltaTable",
+            "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             side_effect=DeltaTableNotFoundError("Not found"),
         ):
             writer = DeltaWriter(
@@ -720,7 +720,7 @@ class TestDeltaWriterSchemaDrift:
         mock_table.schema.return_value = mock_delta_schema
 
         with patch(
-            "bioetl.infrastructure.storage.delta_writer.DeltaTable",
+            "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             return_value=mock_table,
         ):
             writer = DeltaWriter(
@@ -748,7 +748,7 @@ class TestDeltaWriterSchemaDrift:
         mock_table.schema.return_value = mock_delta_schema
 
         with patch(
-            "bioetl.infrastructure.storage.delta_writer.DeltaTable",
+            "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             return_value=mock_table,
         ):
             writer = DeltaWriter(
@@ -797,7 +797,7 @@ class TestDeltaWriterSchemaDrift:
         ]
 
         with patch(
-            "bioetl.infrastructure.storage.delta_writer.DeltaTable",
+            "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             return_value=mock_table,
         ):
             writer = DeltaWriter(
@@ -827,7 +827,7 @@ class TestDeltaWriterSchemaDrift:
         mock_table.schema.return_value = mock_delta_schema
 
         with patch(
-            "bioetl.infrastructure.storage.delta_writer.DeltaTable",
+            "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             return_value=mock_table,
         ):
             writer = DeltaWriter(
@@ -854,7 +854,7 @@ class TestDeltaWriterSchemaDrift:
         mock_table.schema.return_value = mock_delta_schema
 
         with patch(
-            "bioetl.infrastructure.storage.delta_writer.DeltaTable",
+            "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             return_value=mock_table,
         ):
             writer = DeltaWriter(
@@ -891,7 +891,7 @@ class TestDeltaWriterSchemaDrift:
         mock_table.schema.return_value = mock_delta_schema
 
         with patch(
-            "bioetl.infrastructure.storage.delta_writer.DeltaTable",
+            "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             return_value=mock_table,
         ):
             writer = DeltaWriter(
@@ -909,7 +909,7 @@ class TestDeltaWriterSchemaDrift:
         from bioetl.infrastructure.storage.delta_writer import DeltaWriter
 
         with patch(
-            "bioetl.infrastructure.storage.delta_writer.DeltaTable",
+            "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             side_effect=DeltaTableNotFoundError("Not found"),
         ):
             writer = DeltaWriter(
@@ -934,7 +934,7 @@ class TestDeltaWriterSchemaDrift:
         mock_table.schema.return_value = mock_delta_schema
 
         with patch(
-            "bioetl.infrastructure.storage.delta_writer.DeltaTable",
+            "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             return_value=mock_table,
         ):
             writer = DeltaWriter(
@@ -986,7 +986,7 @@ class TestDeltaWriterSchemaDrift:
         mock_table.schema.return_value = mock_delta_schema
 
         with patch(
-            "bioetl.infrastructure.storage.delta_writer.DeltaTable",
+            "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             return_value=mock_table,
         ):
             writer = DeltaWriter(
@@ -1245,11 +1245,11 @@ class TestDeltaWriterWriteModePolicy:
 
         with (
             patch(
-                "bioetl.infrastructure.storage.delta_writer.DeltaTable",
+                "bioetl.infrastructure.storage.silver_writer.DeltaTable",
                 side_effect=DeltaTableNotFoundError("Not found"),
             ),
             patch(
-                "bioetl.infrastructure.storage.delta_writer.write_deltalake"
+                "bioetl.infrastructure.storage.silver_writer.write_deltalake"
             ) as mock_write,
         ):
             writer = DeltaWriter(
@@ -1291,11 +1291,11 @@ class TestDeltaWriterWriteModePolicy:
 
         with (
             patch(
-                "bioetl.infrastructure.storage.delta_writer.DeltaTable",
+                "bioetl.infrastructure.storage.silver_writer.DeltaTable",
                 side_effect=DeltaTableNotFoundError("Not found"),
             ),
             patch(
-                "bioetl.infrastructure.storage.delta_writer.write_deltalake"
+                "bioetl.infrastructure.storage.silver_writer.write_deltalake"
             ) as mock_write,
         ):
             writer = DeltaWriter(

--- a/tests/unit/infrastructure/storage/test_delta_writer_silver_validation.py
+++ b/tests/unit/infrastructure/storage/test_delta_writer_silver_validation.py
@@ -317,11 +317,11 @@ class TestDeltaWriterWriteSilverWithPanderaValidation:
 
         with (
             patch(
-                "bioetl.infrastructure.storage.delta_writer.DeltaTable",
+                "bioetl.infrastructure.storage.silver_writer.DeltaTable",
                 side_effect=DeltaTableNotFoundError("Not found"),
             ),
             patch(
-                "bioetl.infrastructure.storage.delta_writer.write_deltalake"
+                "bioetl.infrastructure.storage.silver_writer.write_deltalake"
             ) as mock_write,
         ):
             writer = DeltaWriter(
@@ -366,11 +366,11 @@ class TestDeltaWriterWriteSilverWithPanderaValidation:
 
         with (
             patch(
-                "bioetl.infrastructure.storage.delta_writer.DeltaTable",
+                "bioetl.infrastructure.storage.silver_writer.DeltaTable",
                 side_effect=DeltaTableNotFoundError("Not found"),
             ),
             patch(
-                "bioetl.infrastructure.storage.delta_writer.write_deltalake"
+                "bioetl.infrastructure.storage.silver_writer.write_deltalake"
             ) as mock_write,
         ):
             # Default NoOp validator

--- a/tests/unit/infrastructure/storage/test_storage_exceptions.py
+++ b/tests/unit/infrastructure/storage/test_storage_exceptions.py
@@ -55,7 +55,7 @@ class TestDeltaWriterExceptions:
     """Tests for exception handling in DeltaWriter."""
 
     @pytest.mark.asyncio
-    @patch("bioetl.infrastructure.storage.delta_writer.DeltaTable")
+    @patch("bioetl.infrastructure.storage.silver_writer.DeltaTable")
     async def test_write_silver_raises_schema_violation_error_on_merge(
         self, mock_delta_table, valid_record, noop_logger
     ):
@@ -90,7 +90,7 @@ class TestDeltaWriterExceptions:
             )
 
     @pytest.mark.asyncio
-    @patch("bioetl.infrastructure.storage.delta_writer.DeltaTable")
+    @patch("bioetl.infrastructure.storage.silver_writer.DeltaTable")
     async def test_write_silver_raises_merge_conflict_error(
         self, mock_delta_table, valid_record, noop_logger
     ):
@@ -132,9 +132,9 @@ class TestDeltaWriterExceptions:
             )
 
     @pytest.mark.asyncio
-    @patch("bioetl.infrastructure.storage.delta_writer.write_deltalake")
+    @patch("bioetl.infrastructure.storage.silver_writer.write_deltalake")
     @patch(
-        "bioetl.infrastructure.storage.delta_writer.DeltaTable",
+        "bioetl.infrastructure.storage.silver_writer.DeltaTable",
         side_effect=TableNotFoundError,
     )
     async def test_write_silver_raises_schema_error_on_create(
@@ -169,7 +169,7 @@ class TestDeltaWriterExceptions:
     async def test_vacuum_raises_table_not_found(self, noop_logger):
         """Test that vacuum raises CustomTableNotFoundError."""
         with patch(
-            "bioetl.infrastructure.storage.delta_writer.DeltaTable",
+            "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             side_effect=TableNotFoundError,
         ):
             writer = DeltaWriter(

--- a/tests/unit/infrastructure/test_storage.py
+++ b/tests/unit/infrastructure/test_storage.py
@@ -36,10 +36,10 @@ def mock_delta_writer():
     """Fixture for mocking delta_writer module."""
     with (
         patch(
-            "bioetl.infrastructure.storage.delta_writer.DeltaTable"
+            "bioetl.infrastructure.storage.silver_writer.DeltaTable"
         ) as mock_delta_table,
         patch(
-            "bioetl.infrastructure.storage.delta_writer.write_deltalake"
+            "bioetl.infrastructure.storage.silver_writer.write_deltalake"
         ) as mock_write_deltalake,
     ):
         yield mock_delta_table, mock_write_deltalake

--- a/tests/unit/infrastructure/test_storage_factory.py
+++ b/tests/unit/infrastructure/test_storage_factory.py
@@ -151,7 +151,7 @@ class TestStorageFactoryLocal:
         """Test that local runs use paths from settings."""
         with (
             patch("bioetl.composition.factories.storage_factory.BronzeWriter"),
-            patch("bioetl.composition.factories.storage_factory.DeltaWriter"),
+            patch("bioetl.composition.factories.storage_factory.SilverWriter"),
             patch("bioetl.composition.factories.storage_factory.GoldWriter"),
         ):
             result = StorageFactory.create(
@@ -189,7 +189,7 @@ class TestStorageFactoryLocal:
                 "bioetl.composition.factories.storage_factory.BronzeWriter"
             ) as mock_bronze,
             patch(
-                "bioetl.composition.factories.storage_factory.DeltaWriter"
+                "bioetl.composition.factories.storage_factory.SilverWriter"
             ) as mock_delta,
             patch(
                 "bioetl.composition.factories.storage_factory.GoldWriter"
@@ -229,7 +229,7 @@ class TestStorageFactoryLocal:
             patch(
                 "bioetl.composition.factories.storage_factory.BronzeWriter"
             ) as mock_bronze,
-            patch("bioetl.composition.factories.storage_factory.DeltaWriter"),
+            patch("bioetl.composition.factories.storage_factory.SilverWriter"),
             patch("bioetl.composition.factories.storage_factory.GoldWriter"),
         ):
             StorageFactory.create(
@@ -257,7 +257,7 @@ class TestStorageFactoryLocal:
         with (
             patch("bioetl.composition.factories.storage_factory.BronzeWriter"),
             patch(
-                "bioetl.composition.factories.storage_factory.DeltaWriter"
+                "bioetl.composition.factories.storage_factory.SilverWriter"
             ) as mock_delta,
             patch(
                 "bioetl.composition.factories.storage_factory.GoldWriter"
@@ -305,7 +305,7 @@ class TestStorageFactoryEdgeCases:
             patch(
                 "bioetl.composition.factories.storage_factory.BronzeWriter"
             ) as mock_bronze,
-            patch("bioetl.composition.factories.storage_factory.DeltaWriter"),
+            patch("bioetl.composition.factories.storage_factory.SilverWriter"),
             patch("bioetl.composition.factories.storage_factory.GoldWriter"),
         ):
             result = StorageFactory.create(
@@ -339,7 +339,7 @@ class TestStorageFactoryEdgeCases:
                 "bioetl.composition.factories.storage_factory.BronzeWriter"
             ) as mock_bronze,
             patch(
-                "bioetl.composition.factories.storage_factory.DeltaWriter"
+                "bioetl.composition.factories.storage_factory.SilverWriter"
             ) as mock_delta,
             patch(
                 "bioetl.composition.factories.storage_factory.GoldWriter"


### PR DESCRIPTION
…aming consistency

Unifies Writer class naming with Medallion architecture layer convention:
- BronzeWriter - writes to Bronze layer (JSONL + zstd)
- SilverWriter - writes to Silver layer (Delta Lake) [NEW NAME]
- GoldWriter - writes to Gold layer (Delta Lake with SCD Type 2)

Changes:
- Create new SilverWriter class with identical functionality
- Convert DeltaWriter to deprecated subclass with DeprecationWarning
- Update composition layer to use SilverWriter directly
- Update documentation and tests to reference SilverWriter
- Maintain backward compatibility: DeltaWriter alias still works

The deprecation follows RULES.md §6.2 (14-day deprecation period).