### PR TITLE
Move I/O logic from domain to infrastructure

### DIFF
--- a/docs/verification-reports/domain-io-purity-2025-12-30.md
+++ b/docs/verification-reports/domain-io-purity-2025-12-30.md
@@ -1,0 +1,91 @@
+# Domain Layer I/O Purity Verification Report
+
+**Date:** 2025-12-30
+**Verified by:** Claude Code Agent
+**Status:** ✅ COMPLIANT
+
+## Purpose
+
+Verify that the domain layer contains no I/O operations and only defines Protocol interfaces (ports), adhering to the Ports & Adapters architecture.
+
+## Verification Methods
+
+### 1. Static Analysis - Grep Searches
+
+```bash
+# HTTP libraries - No matches
+grep -rn "requests\.\|httpx\.\|urllib\." src/bioetl/domain/ --include="*.py"
+
+# File I/O - No matches
+grep -rn "open(\|Path(\|os\.path\." src/bioetl/domain/ --include="*.py"
+
+# External services - No matches
+grep -rn "redis\.\|boto3\.\|psycopg" src/bioetl/domain/ --include="*.py"
+```
+
+### 2. Import Analysis
+
+Comprehensive scan of all imports in `src/bioetl/domain/**/*.py` found only:
+
+- Standard library: `dataclasses`, `datetime`, `typing`, `enum`, `uuid`, `hashlib`, `json`, `math`, `re`, `statistics`
+- Internal: `bioetl.domain.*`
+- Validation: `pandera`, `pydantic`
+
+### 3. Architecture Tests
+
+All relevant tests passed:
+
+| Test                                                | Status  |
+| --------------------------------------------------- | ------- |
+| `test_domain_layer_no_infrastructure_imports`       | ✅ PASS |
+| `test_domain_layer_no_application_imports`          | ✅ PASS |
+| `test_domain_layer_no_infrastructure_layer_imports` | ✅ PASS |
+| `test_no_direct_io_in_domain`                       | ✅ PASS |
+
+## Domain Layer Structure
+
+```
+src/bioetl/domain/
+├── ports/                    # Protocol interfaces (ports)
+│   ├── data_source.py       # DataSourcePort
+│   ├── storage.py           # StoragePort
+│   ├── locking.py           # LockPort
+│   ├── checkpoint.py        # CheckpointPort
+│   ├── quarantine.py        # QuarantinePort
+│   ├── observability.py     # MetricsPort, TracingPort
+│   └── ...
+├── entities/                 # Domain entities
+├── value_objects/           # Value objects
+├── services/                # Domain services (pure logic)
+├── exceptions/              # Domain exceptions
+├── schemas/                 # Pandera validation schemas
+├── aggregates/              # Domain aggregates
+└── ...
+```
+
+## Enforcement Mechanisms
+
+The following architecture tests prevent I/O from entering domain layer:
+
+1. **test_layer_dependencies.py** - Blocks imports of `httpx`, `requests`, `sqlalchemy`, `psycopg2`, `deltalake`, `polars`, `asyncpg`, `motor`, `pymongo`
+
+1. **test_domain_purity.py** - Checks for I/O patterns:
+
+   - `open()` file access
+   - `Path().read/write/mkdir/unlink` methods
+   - `os.read/write/mkdir/remove/rename` calls
+   - `shutil.copy/move/rmtree` operations
+
+1. **import-linter** - Enforces layer contracts via `.importlinter` config
+
+## Conclusion
+
+The domain layer is **fully compliant** with Ports & Adapters architecture:
+
+- ✅ No HTTP client imports
+- ✅ No file I/O operations
+- ✅ No external service clients
+- ✅ Only Protocol interfaces in `domain/ports/`
+- ✅ All I/O implementations in `infrastructure/adapters/`
+
+No refactoring was required.


### PR DESCRIPTION
Verify that domain layer is already compliant with Ports & Adapters:
- No HTTP libraries (requests, httpx, urllib) imported
- No file I/O (open, Path, os.path) operations
- No external services (redis, boto3, psycopg) clients
- All architecture layer boundary tests pass

The domain layer only contains Protocol interfaces in domain/ports/ with all I/O implementations correctly located in infrastructure/.

No refactoring was needed - codebase is already properly architected.