### PR TITLE
Unify domain terminology Work to Publication

### DIFF
--- a/src/bioetl/application/pipelines/crossref/transformer.py
+++ b/src/bioetl/application/pipelines/crossref/transformer.py
@@ -1,10 +1,14 @@
 """CrossRef Transformer.
 
-Transforms Bronze records to Silver format (Work entity inflation).
+Transforms Bronze records to Silver format (Publication entity inflation).
 Contains orchestration logic for CrossRef data transformation per Hexagonal Architecture.
 
 This module was refactored from infrastructure/adapters/crossref/mappers.py
 to properly separate business logic from infrastructure concerns.
+
+Terminology:
+- Uses "Publication" instead of CrossRef API term "Work" for Ubiquitous Language
+- All layers use "publication" to refer to scholarly works (articles, preprints, etc.)
 
 Note: Business logic functions are delegated to domain layer per REFACTOR-004.
 """
@@ -14,7 +18,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, cast
 
 from bioetl.application.core.base_transformer import BaseTransformer
-from bioetl.domain.entities.crossref import CROSSREF_TYPE_MAP, Work
+from bioetl.domain.entities.crossref import CROSSREF_TYPE_MAP, PublicationEntity
 from bioetl.domain.normalization import (
     extract_first_string,
     format_date_parts,
@@ -36,7 +40,7 @@ class CrossRefTransformer(BaseTransformer):
     """Transforms CrossRef bronze records to silver.
 
     Implements field extraction, normalization, and type coercion
-    according to the CrossRef → Work entity mapping specification.
+    according to the CrossRef → Publication entity mapping specification.
 
     Subclasses BaseTransformer to provide:
     - Unified error handling via Template Method
@@ -64,7 +68,7 @@ class CrossRefTransformer(BaseTransformer):
         """
         super().__init__(
             provider,
-            entity_type="work",
+            entity_type="publication",
             tracer=tracer,
             metrics=metrics,
             gold_filters=gold_filters,
@@ -76,20 +80,20 @@ class CrossRefTransformer(BaseTransformer):
     # ========================================================================
 
     @staticmethod
-    def _extract_authors(work: dict[str, Any]) -> list[str]:
+    def _extract_authors(publication: dict[str, Any]) -> list[str]:
         """Extract author names in 'given family' format.
 
         This is CrossRef-specific extraction logic (not generic normalization).
 
         Args:
-            work: CrossRef work record.
+            publication: CrossRef publication record.
 
         Returns:
             List of author names.
 
         """
         authors = []
-        for author in work.get("author", []):
+        for author in publication.get("author", []):
             given = author.get("given", "").strip()
             family = author.get("family", "").strip()
             if given and family:
@@ -101,21 +105,21 @@ class CrossRefTransformer(BaseTransformer):
         return authors
 
     @staticmethod
-    def _extract_year(work: dict[str, Any]) -> int | None:
+    def _extract_year(publication: dict[str, Any]) -> int | None:
         """Extract publication year from date-parts.
 
         Tries published-print, then published-online, then issued.
         Delegates validation to domain.validation.validate_year_range.
 
         Args:
-            work: CrossRef work record.
+            publication: CrossRef publication record.
 
         Returns:
             Publication year or None.
 
         """
         for date_field in ["published-print", "published-online", "issued"]:
-            date_info = work.get(date_field, {})
+            date_info = publication.get(date_field, {})
             date_parts = date_info.get("date-parts", [[]])
             if date_parts and date_parts[0] and len(date_parts[0]) > 0:
                 year = date_parts[0][0]
@@ -124,17 +128,17 @@ class CrossRefTransformer(BaseTransformer):
         return None
 
     @staticmethod
-    def _extract_license_url(work: dict[str, Any]) -> str | None:
-        """Extract license URL from work.
+    def _extract_license_url(publication: dict[str, Any]) -> str | None:
+        """Extract license URL from publication.
 
         Args:
-            work: CrossRef work record.
+            publication: CrossRef publication record.
 
         Returns:
             First license URL or None.
 
         """
-        licenses = work.get("license", [])
+        licenses = publication.get("license", [])
         if licenses and len(licenses) > 0:
             url: str | None = licenses[0].get("URL")
             return url
@@ -145,7 +149,7 @@ class CrossRefTransformer(BaseTransformer):
     # ========================================================================
 
     def _extract_business_data(self, record: BronzeRecord) -> dict[str, Any]:
-        """Extract Work business data from bronze record.
+        """Extract Publication business data from bronze record.
 
         Delegates normalization to domain layer per REFACTOR-004.
 
@@ -153,7 +157,7 @@ class CrossRefTransformer(BaseTransformer):
             record: Raw Bronze record from CrossRef API.
 
         Returns:
-            Dictionary of Work business fields.
+            Dictionary of Publication business fields.
 
         """
         # Cast to dict for type-safe access (BronzeRecord is an empty TypedDict marker)
@@ -223,7 +227,7 @@ class CrossRefTransformer(BaseTransformer):
         # 1. Validate required field
         doi = record.get("DOI")
         if not doi:
-            raise ValueError("DOI is required for CrossRef Work")
+            raise ValueError("DOI is required for CrossRef Publication")
 
         # 2. Extract business data
         business_data = self._extract_business_data(record)
@@ -239,7 +243,7 @@ class CrossRefTransformer(BaseTransformer):
 
         # 5. Create domain entity
         entity = self._create_entity(
-            Work,
+            PublicationEntity,
             context,
             entity_id=entity_id,
             content_hash=content_hash,

--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -48,9 +48,10 @@ from bioetl.domain.entities import (
     Molecule,
     Protein,
     Publication,
+    PublicationEntity,
     Target,
     TargetComponent,
-    Work,
+    Work,  # Deprecated: use PublicationEntity
 )
 
 # Error classifier
@@ -254,9 +255,10 @@ __all__ = [
     "Molecule",
     "Protein",
     "Publication",
+    "PublicationEntity",
     "Target",
     "TargetComponent",
-    "Work",
+    "Work",  # Deprecated: use PublicationEntity
     # Error classifier
     "ErrorClassifier",
     # Events

--- a/src/bioetl/domain/entities/__init__.py
+++ b/src/bioetl/domain/entities/__init__.py
@@ -45,7 +45,7 @@ from bioetl.domain.entities.chembl_structures import (
 )
 
 # CrossRef DTO + Entity
-from bioetl.domain.entities.crossref import PublicationRecord, Work
+from bioetl.domain.entities.crossref import PublicationEntity, PublicationRecord, Work
 
 # PubChem DTO + Entity
 from bioetl.domain.entities.pubchem import Compound, PubChemCompoundRecord
@@ -75,10 +75,11 @@ __all__ = [
     "Protein",
     "PubChemCompoundRecord",
     "Publication",
+    "PublicationEntity",
     "PublicationRecord",
     "Target",
     "TargetComponent",
     "TargetComponentRecord",
     "TargetRecord",
-    "Work",
+    "Work",  # Deprecated: use PublicationEntity
 ]

--- a/src/bioetl/domain/entities/crossref.py
+++ b/src/bioetl/domain/entities/crossref.py
@@ -2,12 +2,17 @@
 
 Contains:
 - PublicationRecord: DTO (Pydantic) for type-safe data transfer at boundaries
-- Work: Domain entity (dataclass) with lineage fields - deprecated, use PublicationRecord
+- PublicationEntity: Domain entity (dataclass) with lineage fields
+- Work: Deprecated alias for PublicationEntity (backward compatibility)
 
 DTO Design:
 - Uses extra='forbid' to detect API changes early
 - frozen=True ensures immutability
 - Adapters return DTOs, transformers convert to Domain Entities
+
+Terminology:
+- Uses "Publication" instead of CrossRef API term "Work" for Ubiquitous Language
+- All layers use "publication" to refer to scholarly works (articles, preprints, etc.)
 
 Used for enriching publication records with DOI resolution and citation metadata.
 """
@@ -117,18 +122,42 @@ class PublicationRecord(BaseModel):
     source: str = PydanticField(default="crossref", description="Data source")
 
 
-# === Dataclass Domain Entity (backward compatibility) ===
+# === Dataclass Domain Entity ===
 
 
 @dataclass(frozen=True, kw_only=True)
-class Work(BaseEntity):
-    """Represents a scholarly work from CrossRef.
+class PublicationEntity(BaseEntity):
+    """Represents a scholarly publication from CrossRef or other bibliographic sources.
 
     Domain entity with lineage fields (run_id, content_hash, etc.).
     For DTO without lineage, use PublicationRecord.
 
-    Note: This class is kept for backward compatibility.
-    New code should use PublicationRecord DTO.
+    Terminology:
+    - Uses "Publication" instead of CrossRef API term "Work" for Ubiquitous Language
+    - Business analysts can understand the model without knowing CrossRef API specifics
+
+    Attributes:
+        doi: Digital Object Identifier (normalized: lowercase, stripped).
+        title: Publication title.
+        abstract: Publication abstract (HTML tags stripped).
+        authors: List of author names in "given family" format.
+        journal: Journal name (container-title from CrossRef).
+        issn: List of ISSNs.
+        publisher: Publisher name.
+        volume: Volume number.
+        issue: Issue number.
+        first_page: First page number.
+        last_page: Last page number.
+        year: Publication year.
+        published_print: Print publication date (ISO format).
+        published_online: Online publication date (ISO format).
+        doc_type: Document type (PUBLICATION or PREPRINT).
+        citation_count: Number of citations (is-referenced-by-count from CrossRef).
+        reference_count: Number of references in the publication.
+        language: Publication language code.
+        license_url: License URL.
+        subjects: Subject areas.
+        source: Data source identifier (default: "crossref").
 
     See: https://api.crossref.org/swagger-ui/index.html
     """
@@ -178,7 +207,12 @@ class Work(BaseEntity):
         """Post-initialization validation."""
         super().__post_init__()
         if not self.doi:
-            raise ValueError("CrossRef Work DOI is required")
+            raise ValueError("Publication DOI is required")
 
 
-__all__ = ["CROSSREF_TYPE_MAP", "PublicationRecord", "Work"]
+# Deprecated alias for backward compatibility
+Work = PublicationEntity
+"""Deprecated: Use PublicationEntity instead. Kept for backward compatibility."""
+
+
+__all__ = ["CROSSREF_TYPE_MAP", "PublicationEntity", "PublicationRecord", "Work"]

--- a/src/bioetl/domain/schemas/crossref/work.py
+++ b/src/bioetl/domain/schemas/crossref/work.py
@@ -1,7 +1,11 @@
-"""Pandera schema for CrossRef Work entity.
+"""Pandera schema for CrossRef Publication entity.
 
-Aligned with RULES.md v5.0 and CrossRef REST API.
+Aligned with RULES.md v5.8 and CrossRef REST API.
 Source: https://api.crossref.org/swagger-ui/index.html
+
+Terminology:
+- Uses "Publication" instead of CrossRef API term "Work" for Ubiquitous Language
+- WorkSchema is kept as deprecated alias for backward compatibility
 """
 
 from __future__ import annotations
@@ -14,7 +18,8 @@ from pandera.typing import Series
 from bioetl.domain.schemas.base import ETLRecordSchema
 
 # === Fixed Value Constants ===
-WORK_TYPES = [
+# CrossRef publication types (from CrossRef API "type" field)
+PUBLICATION_TYPES = [
     "journal-article",
     "book-chapter",
     "proceedings-article",
@@ -46,10 +51,13 @@ WORK_TYPES = [
 ]
 
 
-class WorkSchema(ETLRecordSchema):
-    """CrossRef Work validation schema for Silver layer.
+class PublicationSchema(ETLRecordSchema):
+    """CrossRef Publication validation schema for Silver layer.
 
-    Represents a publication (article, book, dataset, etc.) with DOI.
+    Represents a scholarly publication (article, book, dataset, etc.) with DOI.
+
+    Uses "Publication" terminology instead of CrossRef API term "Work"
+    for Ubiquitous Language compliance.
     """
 
     # === Primary Key ===
@@ -62,13 +70,13 @@ class WorkSchema(ETLRecordSchema):
     # === Core Fields ===
     type: Series[str] = pa.Field(
         nullable=False,
-        isin=WORK_TYPES,
-        description="Work type (journal-article, book-chapter, etc.)",
+        isin=PUBLICATION_TYPES,
+        description="Publication type (journal-article, book-chapter, etc.)",
     )
     title: Series[str] = pa.Field(
         nullable=False,
         str_length={"min_value": 1},
-        description="Work title (first element of title array)",
+        description="Publication title (first element of title array)",
     )
 
     # === Container (Journal/Book) ===
@@ -150,5 +158,13 @@ class WorkSchema(ETLRecordSchema):
         strict = True
         ordered = True
         coerce = True
-        name = "WorkSchema"
-        description = "CrossRef Work Silver layer validation"
+        name = "PublicationSchema"
+        description = "CrossRef Publication Silver layer validation"
+
+
+# Deprecated aliases for backward compatibility
+WorkSchema = PublicationSchema
+"""Deprecated: Use PublicationSchema instead. Kept for backward compatibility."""
+
+WORK_TYPES = PUBLICATION_TYPES
+"""Deprecated: Use PUBLICATION_TYPES instead. Kept for backward compatibility."""

--- a/tests/unit/application/pipelines/crossref/test_crossref_transformer.py
+++ b/tests/unit/application/pipelines/crossref/test_crossref_transformer.py
@@ -191,6 +191,6 @@ def test_provider_is_crossref(transformer):
     assert transformer.provider == "crossref"
 
 
-def test_entity_type_is_work(transformer):
-    """Test entity type is set to work."""
-    assert transformer.entity_type == "work"
+def test_entity_type_is_publication(transformer):
+    """Test entity type is set to publication (Ubiquitous Language, not CrossRef 'work')."""
+    assert transformer.entity_type == "publication"

--- a/tests/unit/domain/test_entities.py
+++ b/tests/unit/domain/test_entities.py
@@ -12,7 +12,7 @@ from bioetl.domain.entities import (
     BioactivityState,
     Compound,
     Protein,
-    Work,
+    PublicationEntity,
 )
 from bioetl.domain.types import ContentHash, EntityID, RunType
 
@@ -460,22 +460,26 @@ class TestProtein:
 
 
 @pytest.mark.unit
-class TestWork:
-    """Tests for CrossRef Work entity."""
+class TestPublicationEntity:
+    """Tests for CrossRef PublicationEntity (formerly Work).
 
-    def test_work_creation_success(self, base_entity_kwargs):
-        """Test successful Work creation."""
-        work = Work(
+    Tests the PublicationEntity domain entity which represents scholarly
+    publications from CrossRef or other bibliographic sources.
+    """
+
+    def test_publication_creation_success(self, base_entity_kwargs):
+        """Test successful PublicationEntity creation."""
+        publication = PublicationEntity(
             **base_entity_kwargs,
             doi="10.1234/test.article",
         )
-        assert work.doi == "10.1234/test.article"
-        assert work.source == "crossref"
-        assert work.doc_type == "PUBLICATION"
+        assert publication.doi == "10.1234/test.article"
+        assert publication.source == "crossref"
+        assert publication.doc_type == "PUBLICATION"
 
-    def test_work_with_all_optional_fields(self, base_entity_kwargs):
-        """Test Work with all optional fields."""
-        work = Work(
+    def test_publication_with_all_optional_fields(self, base_entity_kwargs):
+        """Test PublicationEntity with all optional fields."""
+        publication = PublicationEntity(
             **base_entity_kwargs,
             doi="10.1038/nature12373",
             title="The complete genome sequence",
@@ -498,59 +502,59 @@ class TestWork:
             license_url="https://creativecommons.org/licenses/by/4.0/",
             subjects=["Genetics", "Genomics"],
         )
-        assert work.title == "The complete genome sequence"
-        assert work.journal == "Nature"
-        assert work.year == 2023
-        assert work.citation_count == 2847
-        assert len(work.authors) == 2
-        assert len(work.issn) == 2
+        assert publication.title == "The complete genome sequence"
+        assert publication.journal == "Nature"
+        assert publication.year == 2023
+        assert publication.citation_count == 2847
+        assert len(publication.authors) == 2
+        assert len(publication.issn) == 2
 
-    def test_work_requires_doi(self, base_entity_kwargs):
+    def test_publication_requires_doi(self, base_entity_kwargs):
         """Test that empty doi raises ValueError."""
-        with pytest.raises(ValueError, match="CrossRef Work DOI is required"):
-            Work(
+        with pytest.raises(ValueError, match="Publication DOI is required"):
+            PublicationEntity(
                 **base_entity_kwargs,
                 doi="",
             )
 
-    def test_work_preprint_doc_type(self, base_entity_kwargs):
-        """Test Work with PREPRINT doc_type."""
-        work = Work(
+    def test_publication_preprint_doc_type(self, base_entity_kwargs):
+        """Test PublicationEntity with PREPRINT doc_type."""
+        publication = PublicationEntity(
             **base_entity_kwargs,
             doi="10.1101/2023.01.01.123456",
             doc_type="PREPRINT",
         )
-        assert work.doc_type == "PREPRINT"
+        assert publication.doc_type == "PREPRINT"
 
-    def test_work_default_authors_empty_list(self, base_entity_kwargs):
+    def test_publication_default_authors_empty_list(self, base_entity_kwargs):
         """Test that authors defaults to empty list."""
-        work = Work(
+        publication = PublicationEntity(
             **base_entity_kwargs,
             doi="10.1234/test",
         )
-        assert work.authors == []
+        assert publication.authors == []
 
-    def test_work_default_issn_empty_list(self, base_entity_kwargs):
+    def test_publication_default_issn_empty_list(self, base_entity_kwargs):
         """Test that issn defaults to empty list."""
-        work = Work(
+        publication = PublicationEntity(
             **base_entity_kwargs,
             doi="10.1234/test",
         )
-        assert work.issn == []
+        assert publication.issn == []
 
-    def test_work_default_subjects_empty_list(self, base_entity_kwargs):
+    def test_publication_default_subjects_empty_list(self, base_entity_kwargs):
         """Test that subjects defaults to empty list."""
-        work = Work(
+        publication = PublicationEntity(
             **base_entity_kwargs,
             doi="10.1234/test",
         )
-        assert work.subjects == []
+        assert publication.subjects == []
 
-    def test_work_is_frozen(self, base_entity_kwargs):
-        """Test that Work is immutable."""
-        work = Work(
+    def test_publication_is_frozen(self, base_entity_kwargs):
+        """Test that PublicationEntity is immutable."""
+        publication = PublicationEntity(
             **base_entity_kwargs,
             doi="10.1234/test",
         )
         with pytest.raises(AttributeError):
-            work.doi = "10.9999/changed"
+            publication.doi = "10.9999/changed"


### PR DESCRIPTION
Rename CrossRef domain entity from Work to PublicationEntity for Ubiquitous Language compliance. Business analysts can now understand the model without knowing CrossRef API specifics.

Changes:
- Rename Work class to PublicationEntity in domain entities
- Keep Work as deprecated alias for backward compatibility
- Rename WorkSchema to PublicationSchema in schemas
- Keep WorkSchema as deprecated alias for backward compatibility
- Update CrossRefTransformer to use PublicationEntity and entity_type="publication"
- Update all tests to use new terminology
- Add PUBLICATION_TYPES constant (keep WORK_TYPES as deprecated alias)
- Update docstrings and comments throughout

The infrastructure layer (CrossRef client, models) keeps "work" terminology since it directly maps to the CrossRef API response format.