### PR TITLE
Create universal pipeline launch service

### DIFF
--- a/src/bioetl/application/services/__init__.py
+++ b/src/bioetl/application/services/__init__.py
@@ -8,6 +8,7 @@ Administrative services for CLI operations:
 - QuarantineService: Quarantine inspection, replay, purge
 - LockService: Lock management
 - BronzeCleanupService: Bronze retention cleanup
+- PipelineRunnerService: Universal pipeline execution
 """
 
 from __future__ import annotations
@@ -39,6 +40,13 @@ from bioetl.application.services.shutdown_service import (
     ShutdownReason,
     ShutdownService,
 )
+from bioetl.application.services.pipeline_runner_service import (
+    PipelineNotFoundError,
+    PipelineRunnerService,
+    RunOptions,
+    RunResult,
+    RunStatus,
+)
 from bioetl.application.services.vacuum_service import (
     TableCollectorPort,
     TableVacuumResult,
@@ -55,11 +63,16 @@ __all__ = [
     "LockInfo",
     "LockService",
     "MedallionLifecycleService",
+    "PipelineNotFoundError",
+    "PipelineRunnerService",
     "PipelineShutdownError",
     "PurgeResult",
     "QuarantineRecord",
     "QuarantineService",
     "ReplayResult",
+    "RunOptions",
+    "RunResult",
+    "RunStatus",
     "ShutdownReason",
     "ShutdownService",
     "TableCollectorPort",

--- a/src/bioetl/application/services/pipeline_runner_service.py
+++ b/src/bioetl/application/services/pipeline_runner_service.py
@@ -1,0 +1,430 @@
+"""Pipeline runner service for universal pipeline execution.
+
+Provides a high-level, interface-agnostic API for running pipelines.
+Can be used from CLI, REST API, Airflow operators, or any other orchestrator.
+
+Implements RULES.md §1.1 - Application Layer depends only on Domain.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+from uuid import UUID, uuid4
+
+from bioetl.domain.context import (
+    InputFilterContext,
+    PipelineRunContext,
+    VacuumConfig,
+)
+from bioetl.domain.types import RunID, RunType
+
+if TYPE_CHECKING:
+    from bioetl.domain.ports import (
+        LoggerPort,
+        MetricsExtractorPort,
+        RunnablePort,
+        RunnerFactoryPort,
+    )
+
+
+class RunStatus(str, Enum):
+    """Pipeline run completion status.
+
+    Attributes:
+        SUCCESS: Pipeline completed successfully.
+        SHUTDOWN: Pipeline was gracefully shut down (SIGTERM/SIGINT).
+        FAILED: Pipeline failed with an error.
+        DRY_RUN: Dry-run mode, no actual execution performed.
+    """
+
+    SUCCESS = "success"
+    SHUTDOWN = "shutdown"
+    FAILED = "failed"
+    DRY_RUN = "dry_run"
+
+
+@dataclass(frozen=True)
+class RunResult:
+    """Result of pipeline execution.
+
+    Provides execution metrics and status for orchestration layers.
+    This is the unified return type for PipelineRunnerService.run()
+    and enables programmatic access to execution results.
+
+    Attributes:
+        status: Completion status (success, shutdown, failed, dry_run).
+        pipeline_name: Name of the executed pipeline.
+        run_id: Unique identifier for this run.
+        run_type: Type of run (incremental, backfill, rebuild).
+        records_fetched: Total records retrieved from source.
+        records_bronze: Records written to Bronze layer.
+        records_silver: Records written to Silver layer.
+        records_gold: Records written to Gold layer.
+        records_quarantined: Records sent to quarantine.
+        started_at: Timestamp when execution started.
+        completed_at: Timestamp when execution completed.
+        error_message: Error message if status is FAILED.
+        error_type: Exception class name if status is FAILED.
+
+    Example:
+        >>> result = await service.run("chembl_activity")
+        >>> if result.status == RunStatus.SUCCESS:
+        ...     print(f"Processed {result.records_silver} records")
+        >>> elif result.status == RunStatus.FAILED:
+        ...     print(f"Failed: {result.error_message}")
+    """
+
+    status: RunStatus
+    pipeline_name: str
+    run_id: str
+    run_type: str
+    records_fetched: int = 0
+    records_bronze: int = 0
+    records_silver: int = 0
+    records_gold: int = 0
+    records_quarantined: int = 0
+    started_at: datetime = field(default_factory=lambda: datetime.now(tz=UTC))
+    completed_at: datetime = field(default_factory=lambda: datetime.now(tz=UTC))
+    error_message: str | None = None
+    error_type: str | None = None
+
+    @property
+    def duration_seconds(self) -> float:
+        """Calculate execution duration in seconds."""
+        return (self.completed_at - self.started_at).total_seconds()
+
+    @property
+    def success_rate(self) -> float:
+        """Calculate success rate (non-quarantined / fetched)."""
+        if self.records_fetched == 0:
+            return 1.0
+        return (self.records_fetched - self.records_quarantined) / self.records_fetched
+
+    @property
+    def is_success(self) -> bool:
+        """Check if run was successful (or dry_run)."""
+        return self.status in (RunStatus.SUCCESS, RunStatus.DRY_RUN)
+
+
+@dataclass(frozen=True)
+class RunOptions:
+    """Options for running a pipeline.
+
+    These are the user-facing options that can be set via CLI, REST API,
+    or any other orchestration interface.
+
+    Attributes:
+        run_type: Type of run (incremental, backfill, rebuild). Default: incremental.
+        resume: Whether to resume from the last checkpoint.
+        limit: Maximum number of records to process.
+        dry_run: Preview mode without execution.
+        input_csv: Path to CSV file with filter IDs.
+        filter_column: Column name in CSV containing filter IDs.
+        filter_field: API field name to filter by.
+        vacuum_after_run: Enable automatic VACUUM after successful run.
+        vacuum_retention_days: Minimum age of files to remove during VACUUM.
+        log_level: Logging level (DEBUG, INFO, WARNING, ERROR). Default: INFO.
+    """
+
+    run_type: str = "incremental"
+    resume: bool = False
+    limit: int | None = None
+    dry_run: bool = False
+    input_csv: str | None = None
+    filter_column: str | None = None
+    filter_field: str | None = None
+    vacuum_after_run: bool | None = None
+    vacuum_retention_days: int | None = None
+    log_level: str = "INFO"
+
+
+class PipelineNotFoundError(ValueError):
+    """Raised when a pipeline is not found in the registry."""
+
+    def __init__(self, pipeline_name: str, available: list[str]) -> None:
+        self.pipeline_name = pipeline_name
+        self.available = available
+        super().__init__(
+            f"Unknown pipeline: {pipeline_name}. Available: {available}"
+        )
+
+
+@dataclass
+class PipelineRunnerService:
+    """Application service for running pipelines.
+
+    Provides a universal, interface-agnostic API for pipeline execution.
+    Stateless and thread-safe - creates runners per call via injected factory.
+
+    This service can be used from:
+    - CLI (Click/Typer commands)
+    - REST API (FastAPI/Flask endpoints)
+    - Schedulers (Airflow operators, Prefect flows)
+    - Python scripts (direct programmatic access)
+
+    Attributes:
+        runner_factory: Factory for creating pipeline runners (injected).
+        metrics_extractor: Extractor for runner execution metrics (injected).
+        logger: Structured logger for observability (injected).
+
+    Example:
+        >>> service = get_pipeline_runner_service()
+        >>> options = RunOptions(run_type="incremental", limit=100)
+        >>> result = await service.run("chembl_activity", options=options)
+        >>> print(f"Processed {result.records_silver} records in {result.duration_seconds}s")
+    """
+
+    runner_factory: RunnerFactoryPort
+    metrics_extractor: MetricsExtractorPort
+    logger: LoggerPort
+
+    async def run(
+        self,
+        pipeline_name: str,
+        config_path: Path | None = None,
+        overrides: dict[str, Any] | None = None,
+        dry_run: bool = False,
+        run_id: UUID | None = None,
+        options: RunOptions | None = None,
+    ) -> RunResult:
+        """Run a pipeline with the given configuration.
+
+        This is the main entry point for pipeline execution. It handles:
+        - Pipeline validation and resolution
+        - Configuration loading and merging
+        - Run ID creation
+        - Dry-run preview mode
+        - Exception classification and result building
+
+        Args:
+            pipeline_name: Name of the pipeline to run (e.g., 'chembl_activity').
+            config_path: Optional path to config file (not implemented yet).
+            overrides: Optional config overrides as dict (not implemented yet).
+            dry_run: If True, only preview what would be done.
+            run_id: Optional run ID. If None, a new UUID is generated.
+            options: Optional RunOptions for detailed configuration.
+                     If provided, takes precedence over individual parameters.
+
+        Returns:
+            RunResult with execution metrics and status.
+
+        Raises:
+            PipelineNotFoundError: If pipeline_name is not registered.
+
+        Example:
+            >>> result = await service.run("chembl_activity", dry_run=True)
+            >>> if result.status == RunStatus.DRY_RUN:
+            ...     print("Would process pipeline chembl_activity")
+        """
+        started_at = datetime.now(tz=UTC)
+
+        # Merge options with individual parameters
+        effective_options = self._merge_options(options, dry_run)
+
+        # Validate pipeline exists
+        if not self.runner_factory.contains(pipeline_name):
+            available = self.runner_factory.list_pipelines()
+            raise PipelineNotFoundError(pipeline_name, available)
+
+        # Generate run_id if not provided
+        effective_run_id: RunID = cast(RunID, run_id or uuid4())
+
+        self.logger.info(
+            "Starting pipeline run",
+            pipeline=pipeline_name,
+            run_id=str(effective_run_id),
+            run_type=effective_options.run_type,
+            dry_run=effective_options.dry_run,
+            limit=effective_options.limit,
+        )
+
+        # Handle dry-run mode
+        if effective_options.dry_run:
+            self.logger.info(
+                "Dry-run mode: no execution performed",
+                pipeline=pipeline_name,
+                run_id=str(effective_run_id),
+            )
+            return RunResult(
+                status=RunStatus.DRY_RUN,
+                pipeline_name=pipeline_name,
+                run_id=str(effective_run_id),
+                run_type=effective_options.run_type,
+                started_at=started_at,
+                completed_at=datetime.now(tz=UTC),
+            )
+
+        # Build context and create runner
+        context = self._build_context(pipeline_name, effective_run_id, effective_options)
+        runner = self.runner_factory.create(context)
+
+        # Execute pipeline
+        return await self._execute_pipeline(
+            runner=runner,
+            pipeline_name=pipeline_name,
+            run_id=effective_run_id,
+            run_type=effective_options.run_type,
+            started_at=started_at,
+        )
+
+    def list_pipelines(self) -> list[str]:
+        """List all available pipeline names.
+
+        Returns:
+            Sorted list of registered pipeline names.
+        """
+        return self.runner_factory.list_pipelines()
+
+    def validate_pipeline(self, pipeline_name: str) -> bool:
+        """Check if a pipeline is registered.
+
+        Args:
+            pipeline_name: Name of the pipeline to check.
+
+        Returns:
+            True if pipeline exists, False otherwise.
+        """
+        return self.runner_factory.contains(pipeline_name)
+
+    def _merge_options(
+        self,
+        options: RunOptions | None,
+        dry_run: bool,
+    ) -> RunOptions:
+        """Merge individual parameters with RunOptions.
+
+        Args:
+            options: Optional RunOptions object.
+            dry_run: Dry-run flag (fallback if options not provided).
+
+        Returns:
+            RunOptions with merged values.
+        """
+        if options is not None:
+            return options
+
+        return RunOptions(dry_run=dry_run)
+
+    def _build_context(
+        self,
+        pipeline_name: str,
+        run_id: RunID,
+        options: RunOptions,
+    ) -> PipelineRunContext:
+        """Build PipelineRunContext from options.
+
+        Args:
+            pipeline_name: Name of the pipeline.
+            run_id: Unique run identifier.
+            options: Run options.
+
+        Returns:
+            PipelineRunContext ready for runner creation.
+        """
+        # Build InputFilterContext
+        if options.input_csv:
+            input_filter = InputFilterContext(
+                enabled=True,
+                source_path=options.input_csv,
+                column_name=options.filter_column or "",
+                filter_field=options.filter_field or "",
+            )
+        else:
+            input_filter = InputFilterContext.disabled()
+
+        # Build VacuumConfig
+        vacuum = VacuumConfig(
+            enabled=options.vacuum_after_run,
+            retention_days=options.vacuum_retention_days or 7,
+        )
+
+        return PipelineRunContext(
+            pipeline_name=pipeline_name,
+            run_id=run_id,
+            run_type=RunType(options.run_type),
+            resume=options.resume,
+            limit=options.limit,
+            dry_run=options.dry_run,
+            input_filter=input_filter,
+            vacuum=vacuum,
+            log_level=options.log_level,
+        )
+
+    async def _execute_pipeline(
+        self,
+        runner: RunnablePort,
+        pipeline_name: str,
+        run_id: RunID,
+        run_type: str,
+        started_at: datetime,
+    ) -> RunResult:
+        """Execute pipeline and build result.
+
+        Args:
+            runner: Pipeline runner to execute.
+            pipeline_name: Name of the pipeline.
+            run_id: Run identifier.
+            run_type: Type of run.
+            started_at: Execution start time.
+
+        Returns:
+            RunResult with execution outcome.
+        """
+        # Import inside method to avoid circular import:
+        # application/services/__init__.py -> pipeline_runner_service.py
+        # -> application/core/shutdown.py -> application/services/shutdown_service.py
+        from bioetl.application.core.shutdown import PipelineShutdownError
+
+        status = RunStatus.SUCCESS
+        error_message: str | None = None
+        error_type: str | None = None
+
+        try:
+            await runner.run()
+            self.logger.info(
+                "Pipeline completed successfully",
+                pipeline=pipeline_name,
+                run_id=str(run_id),
+            )
+        except PipelineShutdownError:
+            status = RunStatus.SHUTDOWN
+            self.logger.warning(
+                "Pipeline was gracefully shut down",
+                pipeline=pipeline_name,
+                run_id=str(run_id),
+            )
+        except Exception as e:
+            status = RunStatus.FAILED
+            error_message = str(e)
+            error_type = type(e).__name__
+            self.logger.exception(
+                "Pipeline failed with exception",
+                pipeline=pipeline_name,
+                run_id=str(run_id),
+                error_type=error_type,
+            )
+
+        completed_at = datetime.now(tz=UTC)
+
+        # Extract metrics from runner
+        metrics = self.metrics_extractor.extract_metrics(runner)
+
+        return RunResult(
+            status=status,
+            pipeline_name=pipeline_name,
+            run_id=str(run_id),
+            run_type=run_type,
+            records_fetched=metrics.get("records_fetched", 0),
+            records_bronze=metrics.get("records_bronze", 0),
+            records_silver=metrics.get("records_silver", 0),
+            records_gold=metrics.get("records_gold", 0),
+            records_quarantined=metrics.get("records_quarantined", 0),
+            started_at=started_at,
+            completed_at=completed_at,
+            error_message=error_message,
+            error_type=error_type,
+        )

--- a/src/bioetl/composition/_bootstrap/__init__.py
+++ b/src/bioetl/composition/_bootstrap/__init__.py
@@ -20,6 +20,7 @@ from bioetl.composition._bootstrap.checkpoint import (
     bootstrap_quarantine_service,
 )
 from bioetl.composition._bootstrap.lock import bootstrap_lock_service
+from bioetl.composition._bootstrap.runner import bootstrap_pipeline_runner_service
 from bioetl.composition._bootstrap.observability import (
     bootstrap_dq_monitor,
     bootstrap_logger,
@@ -48,6 +49,7 @@ __all__ = [
     "bootstrap_logger",
     "bootstrap_metrics",
     "bootstrap_observability",
+    "bootstrap_pipeline_runner_service",
     "bootstrap_quarantine",
     "bootstrap_quarantine_manager",
     "bootstrap_quarantine_service",

--- a/src/bioetl/composition/_bootstrap/runner.py
+++ b/src/bioetl/composition/_bootstrap/runner.py
@@ -1,0 +1,56 @@
+"""Bootstrap functions for pipeline runner service.
+
+Provides bootstrap functions for PipelineRunnerService assembly.
+"""
+
+from __future__ import annotations
+
+from bioetl.application.services import PipelineRunnerService
+from bioetl.composition._bootstrap.observability import bootstrap_logger
+from bioetl.composition.factories.runner_factory import (
+    create_metrics_extractor,
+    create_runner_factory,
+)
+from bioetl.composition.registry import PipelineRegistry
+from bioetl.infrastructure.config import get_settings
+
+
+def bootstrap_pipeline_runner_service(
+    registry: PipelineRegistry | None = None,
+) -> PipelineRunnerService:
+    """Bootstrap the PipelineRunnerService with all dependencies.
+
+    Creates a fully configured PipelineRunnerService that can be used
+    to run pipelines from any interface (CLI, REST API, etc.).
+
+    Args:
+        registry: Optional custom registry for test isolation.
+            If None, uses the default global registry.
+
+    Returns:
+        PipelineRunnerService ready for use.
+
+    Example:
+        >>> service = bootstrap_pipeline_runner_service()
+        >>> options = RunOptions(run_type="incremental", limit=100)
+        >>> result = await service.run("chembl_activity", options=options)
+    """
+    settings = get_settings()
+
+    # Bootstrap logger for the service
+    logger = bootstrap_logger(
+        pipeline="pipeline_runner_service",
+        run_id=None,  # Service-level logger without specific run_id
+        settings=settings,
+        log_level="INFO",
+    )
+
+    # Create factory and extractor
+    runner_factory = create_runner_factory(registry=registry)
+    metrics_extractor = create_metrics_extractor()
+
+    return PipelineRunnerService(
+        runner_factory=runner_factory,
+        metrics_extractor=metrics_extractor,
+        logger=logger,
+    )

--- a/src/bioetl/composition/entrypoints.py
+++ b/src/bioetl/composition/entrypoints.py
@@ -45,6 +45,7 @@ __all__ = [
     # Resource management (services - new)
     "get_checkpoint_service",
     "get_lock_service",
+    "get_pipeline_runner_service",
     "get_quarantine_service",
     "get_bronze_cleanup_service",
     "get_vacuum_service",
@@ -62,6 +63,7 @@ from bioetl.composition._bootstrap import (
     bootstrap_bronze_cleanup_service,
     bootstrap_checkpoint_service,
     bootstrap_lock_service,
+    bootstrap_pipeline_runner_service,
     bootstrap_quarantine_service,
     bootstrap_vacuum_service,
 )
@@ -87,6 +89,7 @@ if TYPE_CHECKING:
         BronzeCleanupService,
         CheckpointService,
         CleanupResult,
+        PipelineRunnerService,
         QuarantineService,
         VacuumService,
     )
@@ -676,3 +679,25 @@ async def cleanup_bronze(
         dry_run=dry_run,
     )
     return result
+
+
+def get_pipeline_runner_service() -> PipelineRunnerService:
+    """Get a pipeline runner service for universal pipeline execution.
+
+    This is the recommended way to run pipelines programmatically from
+    any interface (CLI, REST API, Airflow, etc.). The service provides
+    a clean, stateless API for pipeline execution.
+
+    Returns:
+        PipelineRunnerService instance ready for use.
+
+    Example:
+        >>> from bioetl.application.services import RunOptions
+        >>> service = get_pipeline_runner_service()
+        >>> options = RunOptions(run_type="incremental", limit=100)
+        >>> result = await service.run("chembl_activity", options=options)
+        >>> if result.is_success:
+        ...     print(f"Processed {result.records_silver} records")
+    """
+    _ensure_registrations()
+    return bootstrap_pipeline_runner_service()

--- a/src/bioetl/composition/factories/runner_factory.py
+++ b/src/bioetl/composition/factories/runner_factory.py
@@ -1,0 +1,160 @@
+"""Runner factory implementation for composition layer.
+
+Implements RunnerFactoryPort and MetricsExtractorPort protocols
+for the PipelineRunnerService.
+
+This module provides the composition-layer implementation of runner
+creation, allowing the application layer to remain independent of
+bootstrap details.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from bioetl.composition.factories.pipeline_factories import register_all_pipelines
+from bioetl.composition.providers.registration import register_all_providers
+from bioetl.composition.registry import PipelineRegistry, get_default_registry
+
+if TYPE_CHECKING:
+    from bioetl.application.core.runner import PipelineRunner
+    from bioetl.domain.context import PipelineRunContext
+    from bioetl.domain.ports import RunnablePort
+
+
+class RunnerFactory:
+    """Factory for creating pipeline runners.
+
+    Implements RunnerFactoryPort protocol for PipelineRunnerService.
+    Delegates to bootstrap_pipeline() for actual runner creation.
+
+    Attributes:
+        registry: Optional custom registry for test isolation.
+    """
+
+    def __init__(self, registry: PipelineRegistry | None = None) -> None:
+        """Initialize the factory.
+
+        Args:
+            registry: Optional custom registry. If None, uses default.
+        """
+        self._registry = registry
+        self._registrations_done = False
+
+    def _ensure_registrations(self) -> None:
+        """Ensure all providers and pipelines are registered.
+
+        Idempotent - safe to call multiple times.
+        """
+        if not self._registrations_done:
+            register_all_providers()
+            register_all_pipelines(registry=self._registry)
+            self._registrations_done = True
+
+    @property
+    def _effective_registry(self) -> PipelineRegistry:
+        """Get the effective registry instance."""
+        return self._registry if self._registry is not None else get_default_registry()
+
+    def create(self, context: PipelineRunContext) -> RunnablePort:
+        """Create a configured pipeline runner.
+
+        Args:
+            context: Pipeline run context containing all execution parameters.
+
+        Returns:
+            PipelineRunner ready for execution.
+
+        Raises:
+            ValueError: If pipeline name is unknown or config is invalid.
+            FileNotFoundError: If pipeline config file is missing.
+        """
+        # Import inside method to avoid circular import:
+        # composition/bootstrap.py -> _bootstrap/__init__.py -> _bootstrap/runner.py
+        # -> factories/runner_factory.py -> composition/bootstrap.py
+        from bioetl.composition.bootstrap import bootstrap_pipeline
+
+        self._ensure_registrations()
+        runner: PipelineRunner = bootstrap_pipeline(context, registry=self._registry)
+        return runner
+
+    def list_pipelines(self) -> list[str]:
+        """List all available pipeline names.
+
+        Returns:
+            Sorted list of registered pipeline names.
+        """
+        self._ensure_registrations()
+        return self._effective_registry.list_pipelines()
+
+    def contains(self, pipeline_name: str) -> bool:
+        """Check if a pipeline is registered.
+
+        Args:
+            pipeline_name: Name of the pipeline to check.
+
+        Returns:
+            True if pipeline exists, False otherwise.
+        """
+        self._ensure_registrations()
+        return self._effective_registry.contains(pipeline_name)
+
+
+class MetricsExtractor:
+    """Extractor for pipeline execution metrics.
+
+    Implements MetricsExtractorPort protocol for PipelineRunnerService.
+    Extracts metrics from the runner's internal executor.
+    """
+
+    def extract_metrics(self, runner: RunnablePort) -> dict[str, int]:
+        """Extract execution metrics from a runner.
+
+        Args:
+            runner: Runner to extract metrics from.
+
+        Returns:
+            Dictionary with metric names and values.
+        """
+        # Access the internal executor if available
+        executor = getattr(runner, "_executor", None)
+
+        if executor is None:
+            return {
+                "records_fetched": 0,
+                "records_bronze": 0,
+                "records_silver": 0,
+                "records_gold": 0,
+                "records_quarantined": 0,
+            }
+
+        return {
+            "records_fetched": getattr(executor, "records_fetched", 0),
+            "records_bronze": getattr(executor, "records_bronze", 0),
+            "records_silver": getattr(executor, "records_silver", 0),
+            "records_gold": getattr(executor, "records_gold", 0),
+            "records_quarantined": getattr(executor, "records_quarantined", 0),
+        }
+
+
+def create_runner_factory(
+    registry: PipelineRegistry | None = None,
+) -> RunnerFactory:
+    """Create a new RunnerFactory instance.
+
+    Args:
+        registry: Optional custom registry for test isolation.
+
+    Returns:
+        RunnerFactory instance.
+    """
+    return RunnerFactory(registry=registry)
+
+
+def create_metrics_extractor() -> MetricsExtractor:
+    """Create a new MetricsExtractor instance.
+
+    Returns:
+        MetricsExtractor instance.
+    """
+    return MetricsExtractor()

--- a/src/bioetl/domain/ports/__init__.py
+++ b/src/bioetl/domain/ports/__init__.py
@@ -60,6 +60,11 @@ from bioetl.domain.ports.observability import (
 )
 from bioetl.domain.ports.quarantine import QuarantinePort
 from bioetl.domain.ports.resilience import CircuitBreakerPort, RateLimiterPort
+from bioetl.domain.ports.runner import (
+    MetricsExtractorPort,
+    RunnablePort,
+    RunnerFactoryPort,
+)
 from bioetl.domain.ports.serialization import JsonEncoderPort
 from bioetl.domain.ports.shutdown import ShutdownPort
 from bioetl.domain.ports.storage import StoragePort
@@ -87,6 +92,7 @@ __all__ = [
     "LoggerPort",
     "MemoryMonitorPort",
     "MemoryStats",
+    "MetricsExtractorPort",
     "MetricsPort",
     "NoOpAudit",
     "NoOpMemoryMonitor",
@@ -96,6 +102,8 @@ __all__ = [
     "OutlierFilterPort",
     "QuarantinePort",
     "RateLimiterPort",
+    "RunnablePort",
+    "RunnerFactoryPort",
     "ShutdownPort",
     "SilverValidatorPort",
     "StoragePort",

--- a/src/bioetl/domain/ports/runner.py
+++ b/src/bioetl/domain/ports/runner.py
@@ -1,0 +1,103 @@
+"""Runner port interfaces for dependency inversion.
+
+Defines protocols for pipeline runner creation and execution.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bioetl.domain.context import PipelineRunContext
+
+
+@runtime_checkable
+class RunnablePort(Protocol):
+    """Protocol for runnable objects (e.g., PipelineRunner).
+
+    This port abstracts the execution interface for pipelines.
+    """
+
+    async def run(self) -> None:
+        """Execute the pipeline."""
+        ...
+
+    @property
+    def shutdown_signal(self) -> Any | None:
+        """Optional shutdown signal for graceful termination."""
+        ...
+
+
+@runtime_checkable
+class RunnerFactoryPort(Protocol):
+    """Port for creating pipeline runners.
+
+    This port abstracts runner creation, allowing the application layer
+    to orchestrate pipeline runs without depending on composition layer.
+
+    Implements RULES.md §1.1 - Ports & Adapters architecture.
+    """
+
+    def create(
+        self,
+        context: PipelineRunContext,
+    ) -> RunnablePort:
+        """Create a configured pipeline runner.
+
+        Args:
+            context: Pipeline run context containing all execution parameters.
+
+        Returns:
+            Runnable object ready for execution.
+
+        Raises:
+            ValueError: If pipeline name is unknown or config is invalid.
+            FileNotFoundError: If pipeline config file is missing.
+        """
+        ...
+
+    def list_pipelines(self) -> list[str]:
+        """List all available pipeline names.
+
+        Returns:
+            Sorted list of registered pipeline names.
+        """
+        ...
+
+    def contains(self, pipeline_name: str) -> bool:
+        """Check if a pipeline is registered.
+
+        Args:
+            pipeline_name: Name of the pipeline to check.
+
+        Returns:
+            True if pipeline exists, False otherwise.
+        """
+        ...
+
+
+@runtime_checkable
+class MetricsExtractorPort(Protocol):
+    """Protocol for extracting execution metrics from a runner.
+
+    This port allows the service to collect metrics without
+    depending on internal runner structure.
+    """
+
+    def extract_metrics(self, runner: RunnablePort) -> dict[str, int]:
+        """Extract execution metrics from a runner.
+
+        Args:
+            runner: Runner to extract metrics from.
+
+        Returns:
+            Dictionary with metric names and values:
+            - records_fetched: Total records retrieved
+            - records_bronze: Records written to Bronze
+            - records_silver: Records written to Silver
+            - records_gold: Records written to Gold
+            - records_quarantined: Records sent to quarantine
+        """
+        ...

--- a/src/bioetl/interfaces/cli/commands/run.py
+++ b/src/bioetl/interfaces/cli/commands/run.py
@@ -1,6 +1,6 @@
 """Run command for BioETL CLI.
 
-Implements the main pipeline execution command.
+Implements the main pipeline execution command using PipelineRunnerService.
 """
 
 from __future__ import annotations
@@ -10,23 +10,73 @@ import sys
 
 import click
 
-from bioetl.application.core.shutdown import PipelineShutdownError
-from bioetl.composition.entrypoints import RunOptions, create_pipeline_runner
+from bioetl.application.services import (
+    PipelineNotFoundError,
+    RunOptions,
+    RunStatus,
+)
+from bioetl.composition.entrypoints import get_pipeline_runner_service
 from bioetl.interfaces.cli.commands.run_helpers import (
     get_runner_logger,
     handle_destructive_run_confirmation,
     show_cleanup_preview,
     validate_pipeline_name,
 )
-from bioetl.interfaces.cli.exit_codes import ExitCode, get_exit_code_for_exception
-from bioetl.interfaces.cli.formatters import echo_error
-from bioetl.interfaces.orchestration.signals import setup_shutdown_handlers
+from bioetl.interfaces.cli.exit_codes import ExitCode
+from bioetl.interfaces.cli.formatters import echo_error, echo_info, echo_warning
 
-# Re-export helpers for backward compatibility with tests
-# These are imported by tests/unit/interfaces/test_cli.py
-_get_runner_logger = get_runner_logger
-_handle_destructive_run_confirmation = handle_destructive_run_confirmation
-_preview_cleanup = show_cleanup_preview
+
+def _map_status_to_exit_code(status: RunStatus, error_type: str | None) -> ExitCode:
+    """Map RunStatus to CLI exit code.
+
+    Args:
+        status: Run status from service.
+        error_type: Exception type name if failed.
+
+    Returns:
+        Appropriate ExitCode for the status.
+    """
+    if status == RunStatus.SUCCESS:
+        return ExitCode.OK
+    if status == RunStatus.DRY_RUN:
+        return ExitCode.OK
+    if status == RunStatus.SHUTDOWN:
+        return ExitCode.SIGINT
+    # FAILED status - map based on error type
+    if error_type:
+        error_mapping = {
+            "ValueError": ExitCode.CONFIG_ERROR,
+            "FileNotFoundError": ExitCode.EX_NOINPUT,
+            "ConfigValidationError": ExitCode.CONFIG_ERROR,
+            "DataQualityError": ExitCode.DATA_QUALITY_ERROR,
+            "DataQualityThresholdError": ExitCode.DATA_QUALITY_ERROR,
+            "LockAcquisitionError": ExitCode.LOCK_ERROR,
+            "LockLostError": ExitCode.LOCK_ERROR,
+            "StorageError": ExitCode.STORAGE_ERROR,
+            "NetworkError": ExitCode.NETWORK_ERROR,
+            "RateLimitError": ExitCode.NETWORK_ERROR,
+            "CircuitBreakerOpenError": ExitCode.NETWORK_ERROR,
+        }
+        return error_mapping.get(error_type, ExitCode.PIPELINE_ERROR)
+    return ExitCode.PIPELINE_ERROR
+
+
+async def _run_pipeline_async(
+    pipeline: str,
+    options: RunOptions,
+) -> tuple[RunStatus, str | None, str | None]:
+    """Run pipeline asynchronously via service.
+
+    Args:
+        pipeline: Pipeline name.
+        options: Run options.
+
+    Returns:
+        Tuple of (status, error_message, error_type).
+    """
+    service = get_pipeline_runner_service()
+    result = await service.run(pipeline, options=options)
+    return result.status, result.error_message, result.error_type
 
 
 @click.command()
@@ -102,46 +152,56 @@ def run(
     debug: bool,
 ) -> None:
     """Run an ETL pipeline."""
+    # Handle confirmation for destructive operations (CLI responsibility)
     if not handle_destructive_run_confirmation(pipeline, run_type, dry_run, yes):
         return
 
+    # Build options using application-layer RunOptions
+    options = RunOptions(
+        run_type=run_type,
+        resume=resume,
+        limit=limit,
+        dry_run=dry_run,
+        input_csv=input_csv,
+        filter_column=filter_column,
+        filter_field=filter_field,
+        vacuum_after_run=vacuum_after_run if vacuum_after_run else None,
+        vacuum_retention_days=vacuum_retention_days,
+        log_level="DEBUG" if debug else "INFO",
+    )
+
+    # Run pipeline via service
     try:
-        options = RunOptions(
-            run_type=run_type,
-            resume=resume,
-            limit=limit,
-            input_csv=input_csv,
-            filter_column=filter_column,
-            filter_field=filter_field,
-            dry_run=dry_run,
-            vacuum_after_run=vacuum_after_run if vacuum_after_run else None,
-            vacuum_retention_days=vacuum_retention_days,
-            log_level="DEBUG" if debug else "INFO",
+        status, error_message, error_type = asyncio.run(
+            _run_pipeline_async(pipeline, options)
         )
-        runner = create_pipeline_runner(pipeline, options)
-    except (ValueError, FileNotFoundError) as e:
-        echo_error("Configuration error", str(e))
+    except PipelineNotFoundError as e:
+        echo_error("Pipeline not found", str(e))
         sys.exit(ExitCode.CONFIG_ERROR)
-    except Exception as e:
-        echo_error("Initialization failed", str(e))
-        sys.exit(ExitCode.INIT_ERROR)
-
-    logger = get_runner_logger(runner)
-    if logger is None:
-        echo_error("Critical: Logger not initialized.")
-        sys.exit(ExitCode.INIT_ERROR)
-
-    shutdown_signal = getattr(runner, "shutdown_signal", None)
-    if shutdown_signal is not None:
-        setup_shutdown_handlers(shutdown_signal, logger)
-
-    logger.info("Starting pipeline run")
-    try:
-        asyncio.run(runner.run())
-        logger.info("Pipeline completed successfully")
-    except PipelineShutdownError:
-        logger.warning("Pipeline run was gracefully shut down.")
+    except KeyboardInterrupt:
+        echo_warning("Pipeline interrupted by user (Ctrl+C)")
         sys.exit(ExitCode.SIGINT)
     except Exception as e:
-        logger.exception("Pipeline failed with an unhandled exception.")
-        sys.exit(get_exit_code_for_exception(e))
+        echo_error("Unexpected error during pipeline execution", str(e))
+        sys.exit(ExitCode.FAIL)
+
+    # Map status to exit code (CLI responsibility)
+    exit_code = _map_status_to_exit_code(status, error_type)
+
+    if status == RunStatus.SUCCESS:
+        echo_info("Pipeline completed successfully")
+    elif status == RunStatus.DRY_RUN:
+        echo_info("Dry-run completed (no changes made)")
+    elif status == RunStatus.SHUTDOWN:
+        echo_warning("Pipeline was gracefully shut down")
+    elif status == RunStatus.FAILED:
+        echo_error("Pipeline failed", error_message or "Unknown error")
+
+    sys.exit(exit_code)
+
+
+# Re-export helpers for backward compatibility with tests
+# These are imported by tests/unit/interfaces/test_cli.py
+_get_runner_logger = get_runner_logger
+_handle_destructive_run_confirmation = handle_destructive_run_confirmation
+_preview_cleanup = show_cleanup_preview

--- a/tests/unit/application/services/test_pipeline_runner_service.py
+++ b/tests/unit/application/services/test_pipeline_runner_service.py
@@ -1,0 +1,474 @@
+"""Unit tests for PipelineRunnerService.
+
+Tests the universal pipeline runner service.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from bioetl.application.core.shutdown import PipelineShutdownError
+from bioetl.application.services.pipeline_runner_service import (
+    PipelineNotFoundError,
+    PipelineRunnerService,
+    RunOptions,
+    RunResult,
+    RunStatus,
+)
+
+
+@pytest.fixture
+def mock_logger():
+    """Create a mock logger."""
+    logger = MagicMock()
+    logger.bind = MagicMock(return_value=logger)
+    logger.info = MagicMock()
+    logger.debug = MagicMock()
+    logger.warning = MagicMock()
+    logger.exception = MagicMock()
+    return logger
+
+
+@pytest.fixture
+def mock_runner():
+    """Create a mock runner that implements RunnablePort."""
+    runner = MagicMock()
+    runner.run = AsyncMock()
+    runner.shutdown_signal = None
+    return runner
+
+
+@pytest.fixture
+def mock_runner_factory(mock_runner):
+    """Create a mock runner factory."""
+    factory = MagicMock()
+    factory.create = MagicMock(return_value=mock_runner)
+    factory.list_pipelines = MagicMock(return_value=["test_pipeline", "other_pipeline"])
+    factory.contains = MagicMock(return_value=True)
+    return factory
+
+
+@pytest.fixture
+def mock_metrics_extractor():
+    """Create a mock metrics extractor."""
+    extractor = MagicMock()
+    extractor.extract_metrics = MagicMock(
+        return_value={
+            "records_fetched": 100,
+            "records_bronze": 95,
+            "records_silver": 90,
+            "records_gold": 85,
+            "records_quarantined": 5,
+        }
+    )
+    return extractor
+
+
+@pytest.fixture
+def service(mock_runner_factory, mock_metrics_extractor, mock_logger):
+    """Create a PipelineRunnerService instance."""
+    return PipelineRunnerService(
+        runner_factory=mock_runner_factory,
+        metrics_extractor=mock_metrics_extractor,
+        logger=mock_logger,
+    )
+
+
+# =============================================================================
+# Test RunOptions
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestRunOptions:
+    """Test RunOptions dataclass."""
+
+    def test_default_options(self):
+        """Test default RunOptions values."""
+        options = RunOptions()
+
+        assert options.run_type == "incremental"
+        assert options.resume is False
+        assert options.limit is None
+        assert options.dry_run is False
+        assert options.input_csv is None
+        assert options.filter_column is None
+        assert options.filter_field is None
+        assert options.vacuum_after_run is None
+        assert options.vacuum_retention_days is None
+        assert options.log_level == "INFO"
+
+    def test_custom_options(self):
+        """Test RunOptions with custom values."""
+        options = RunOptions(
+            run_type="backfill",
+            resume=True,
+            limit=100,
+            dry_run=True,
+            input_csv="ids.csv",
+            filter_column="molecule_id",
+            filter_field="chembl_id",
+            vacuum_after_run=True,
+            vacuum_retention_days=30,
+            log_level="DEBUG",
+        )
+
+        assert options.run_type == "backfill"
+        assert options.resume is True
+        assert options.limit == 100
+        assert options.dry_run is True
+        assert options.input_csv == "ids.csv"
+        assert options.filter_column == "molecule_id"
+        assert options.filter_field == "chembl_id"
+        assert options.vacuum_after_run is True
+        assert options.vacuum_retention_days == 30
+        assert options.log_level == "DEBUG"
+
+
+# =============================================================================
+# Test RunResult
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestRunResult:
+    """Test RunResult dataclass."""
+
+    def test_success_result(self):
+        """Test successful run result."""
+        result = RunResult(
+            status=RunStatus.SUCCESS,
+            pipeline_name="test_pipeline",
+            run_id="12345",
+            run_type="incremental",
+            records_fetched=100,
+            records_silver=95,
+            records_quarantined=5,
+        )
+
+        assert result.status == RunStatus.SUCCESS
+        assert result.is_success is True
+        assert result.success_rate == 0.95
+        assert result.error_message is None
+
+    def test_failed_result(self):
+        """Test failed run result."""
+        result = RunResult(
+            status=RunStatus.FAILED,
+            pipeline_name="test_pipeline",
+            run_id="12345",
+            run_type="incremental",
+            error_message="Connection refused",
+            error_type="NetworkError",
+        )
+
+        assert result.status == RunStatus.FAILED
+        assert result.is_success is False
+        assert result.error_message == "Connection refused"
+        assert result.error_type == "NetworkError"
+
+    def test_dry_run_result(self):
+        """Test dry-run result."""
+        result = RunResult(
+            status=RunStatus.DRY_RUN,
+            pipeline_name="test_pipeline",
+            run_id="12345",
+            run_type="rebuild",
+        )
+
+        assert result.status == RunStatus.DRY_RUN
+        assert result.is_success is True
+
+    def test_shutdown_result(self):
+        """Test shutdown result."""
+        result = RunResult(
+            status=RunStatus.SHUTDOWN,
+            pipeline_name="test_pipeline",
+            run_id="12345",
+            run_type="incremental",
+        )
+
+        assert result.status == RunStatus.SHUTDOWN
+        assert result.is_success is False
+
+    def test_duration_calculation(self):
+        """Test duration_seconds property."""
+        started = datetime(2024, 1, 1, 10, 0, 0, tzinfo=UTC)
+        completed = datetime(2024, 1, 1, 10, 5, 30, tzinfo=UTC)
+
+        result = RunResult(
+            status=RunStatus.SUCCESS,
+            pipeline_name="test_pipeline",
+            run_id="12345",
+            run_type="incremental",
+            started_at=started,
+            completed_at=completed,
+        )
+
+        assert result.duration_seconds == 330.0  # 5 minutes 30 seconds
+
+    def test_success_rate_zero_fetched(self):
+        """Test success_rate when no records fetched."""
+        result = RunResult(
+            status=RunStatus.SUCCESS,
+            pipeline_name="test_pipeline",
+            run_id="12345",
+            run_type="incremental",
+            records_fetched=0,
+            records_quarantined=0,
+        )
+
+        assert result.success_rate == 1.0
+
+
+# =============================================================================
+# Test PipelineNotFoundError
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestPipelineNotFoundError:
+    """Test PipelineNotFoundError exception."""
+
+    def test_error_message(self):
+        """Test error message formatting."""
+        error = PipelineNotFoundError(
+            pipeline_name="nonexistent",
+            available=["pipeline_a", "pipeline_b"],
+        )
+
+        assert error.pipeline_name == "nonexistent"
+        assert error.available == ["pipeline_a", "pipeline_b"]
+        assert "nonexistent" in str(error)
+        assert "pipeline_a" in str(error)
+
+
+# =============================================================================
+# Test PipelineRunnerService.run()
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestPipelineRunnerServiceRun:
+    """Test PipelineRunnerService.run method."""
+
+    @pytest.mark.asyncio
+    async def test_successful_run(
+        self, service, mock_runner_factory, mock_runner, mock_metrics_extractor
+    ):
+        """Test successful pipeline execution."""
+        result = await service.run("test_pipeline")
+
+        assert result.status == RunStatus.SUCCESS
+        assert result.pipeline_name == "test_pipeline"
+        assert result.records_fetched == 100
+        assert result.records_silver == 90
+        mock_runner_factory.contains.assert_called_with("test_pipeline")
+        mock_runner_factory.create.assert_called_once()
+        mock_runner.run.assert_called_once()
+        mock_metrics_extractor.extract_metrics.assert_called_once_with(mock_runner)
+
+    @pytest.mark.asyncio
+    async def test_run_with_options(self, service, mock_runner_factory):
+        """Test run with custom options."""
+        options = RunOptions(
+            run_type="backfill",
+            resume=True,
+            limit=50,
+            log_level="DEBUG",
+        )
+
+        result = await service.run("test_pipeline", options=options)
+
+        assert result.status == RunStatus.SUCCESS
+        assert result.run_type == "backfill"
+        # Verify context was built with correct options
+        call_args = mock_runner_factory.create.call_args
+        context = call_args[0][0]  # First positional arg is context
+        assert context.run_type.value == "backfill"
+        assert context.resume is True
+        assert context.limit == 50
+
+    @pytest.mark.asyncio
+    async def test_run_with_run_id(self, service, mock_runner_factory):
+        """Test run with explicit run_id."""
+        run_id = uuid4()
+
+        result = await service.run("test_pipeline", run_id=run_id)
+
+        assert result.run_id == str(run_id)
+        call_args = mock_runner_factory.create.call_args
+        context = call_args[0][0]
+        assert context.run_id == run_id
+
+    @pytest.mark.asyncio
+    async def test_dry_run(self, service, mock_runner_factory, mock_runner):
+        """Test dry-run mode."""
+        options = RunOptions(dry_run=True)
+
+        result = await service.run("test_pipeline", options=options)
+
+        assert result.status == RunStatus.DRY_RUN
+        assert result.is_success is True
+        # Runner should not be created in dry-run mode
+        mock_runner_factory.create.assert_not_called()
+        mock_runner.run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pipeline_not_found(self, service, mock_runner_factory):
+        """Test handling of unknown pipeline."""
+        mock_runner_factory.contains.return_value = False
+        mock_runner_factory.list_pipelines.return_value = ["other_pipeline"]
+
+        with pytest.raises(PipelineNotFoundError) as exc_info:
+            await service.run("unknown_pipeline")
+
+        assert exc_info.value.pipeline_name == "unknown_pipeline"
+        assert "other_pipeline" in exc_info.value.available
+
+    @pytest.mark.asyncio
+    async def test_pipeline_shutdown(
+        self, service, mock_runner, mock_metrics_extractor
+    ):
+        """Test graceful shutdown handling."""
+        mock_runner.run.side_effect = PipelineShutdownError("Signal received")
+
+        result = await service.run("test_pipeline")
+
+        assert result.status == RunStatus.SHUTDOWN
+        assert result.is_success is False
+        # Metrics should still be extracted
+        mock_metrics_extractor.extract_metrics.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_pipeline_failure(
+        self, service, mock_runner, mock_metrics_extractor
+    ):
+        """Test exception handling."""
+        mock_runner.run.side_effect = ValueError("Invalid configuration")
+
+        result = await service.run("test_pipeline")
+
+        assert result.status == RunStatus.FAILED
+        assert result.error_message == "Invalid configuration"
+        assert result.error_type == "ValueError"
+        mock_metrics_extractor.extract_metrics.assert_called_once()
+
+
+# =============================================================================
+# Test PipelineRunnerService helper methods
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestPipelineRunnerServiceHelpers:
+    """Test PipelineRunnerService helper methods."""
+
+    def test_list_pipelines(self, service, mock_runner_factory):
+        """Test listing available pipelines."""
+        result = service.list_pipelines()
+
+        assert result == ["test_pipeline", "other_pipeline"]
+        mock_runner_factory.list_pipelines.assert_called_once()
+
+    def test_validate_pipeline_exists(self, service, mock_runner_factory):
+        """Test validating existing pipeline."""
+        result = service.validate_pipeline("test_pipeline")
+
+        assert result is True
+        mock_runner_factory.contains.assert_called_with("test_pipeline")
+
+    def test_validate_pipeline_not_exists(self, service, mock_runner_factory):
+        """Test validating non-existing pipeline."""
+        mock_runner_factory.contains.return_value = False
+
+        result = service.validate_pipeline("unknown")
+
+        assert result is False
+
+
+# =============================================================================
+# Test RunOptions merging
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestRunOptionsMerging:
+    """Test RunOptions merging logic."""
+
+    @pytest.mark.asyncio
+    async def test_merge_dry_run_flag(self, service):
+        """Test merging dry_run flag from parameter."""
+        result = await service.run("test_pipeline", dry_run=True)
+
+        assert result.status == RunStatus.DRY_RUN
+
+    @pytest.mark.asyncio
+    async def test_options_override_dry_run_flag(self, service, mock_runner):
+        """Test that options takes precedence over dry_run flag."""
+        options = RunOptions(dry_run=False)
+
+        # dry_run=True in params, but options.dry_run=False
+        result = await service.run("test_pipeline", dry_run=True, options=options)
+
+        # Options should take precedence
+        assert result.status == RunStatus.SUCCESS
+        mock_runner.run.assert_called_once()
+
+
+# =============================================================================
+# Test context building
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestContextBuilding:
+    """Test PipelineRunContext building."""
+
+    @pytest.mark.asyncio
+    async def test_context_with_input_filter(self, service, mock_runner_factory):
+        """Test context building with input filter."""
+        options = RunOptions(
+            input_csv="/path/to/ids.csv",
+            filter_column="mol_id",
+            filter_field="molecule_chembl_id",
+        )
+
+        await service.run("test_pipeline", options=options)
+
+        call_args = mock_runner_factory.create.call_args
+        context = call_args[0][0]
+        assert context.input_filter.enabled is True
+        assert context.input_filter.source_path == "/path/to/ids.csv"
+        assert context.input_filter.column_name == "mol_id"
+        assert context.input_filter.filter_field == "molecule_chembl_id"
+
+    @pytest.mark.asyncio
+    async def test_context_without_input_filter(self, service, mock_runner_factory):
+        """Test context building without input filter."""
+        options = RunOptions()
+
+        await service.run("test_pipeline", options=options)
+
+        call_args = mock_runner_factory.create.call_args
+        context = call_args[0][0]
+        assert context.input_filter.enabled is False
+
+    @pytest.mark.asyncio
+    async def test_context_with_vacuum_config(self, service, mock_runner_factory):
+        """Test context building with vacuum config."""
+        options = RunOptions(
+            vacuum_after_run=True,
+            vacuum_retention_days=14,
+        )
+
+        await service.run("test_pipeline", options=options)
+
+        call_args = mock_runner_factory.create.call_args
+        context = call_args[0][0]
+        assert context.vacuum.enabled is True
+        assert context.vacuum.retention_days == 14

--- a/tests/unit/interfaces/test_cli.py
+++ b/tests/unit/interfaces/test_cli.py
@@ -6,7 +6,8 @@ Uses Click's CliRunner for command testing without real bootstrap.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import click
 import pytest
@@ -279,63 +280,90 @@ class TestCliCommands:
         assert "Unknown pipeline" in result.output or "Error" in result.output
 
     @patch("bioetl.interfaces.cli.main.register_all_pipelines")
-    @patch("bioetl.interfaces.cli.commands.run.create_pipeline_runner")
+    @patch("bioetl.interfaces.cli.commands.run.get_pipeline_runner_service")
     @patch("bioetl.interfaces.cli.commands.run.asyncio.run")
     def test_run_with_valid_pipeline(
-        self, mock_asyncio, mock_create_runner, mock_register, cli_runner, mock_registry
+        self, mock_asyncio, mock_get_service, mock_register, cli_runner, mock_registry
     ):
         """Test that valid pipeline is executed."""
-        mock_runner = MagicMock()
-        mock_runner.logger = MagicMock()
-        mock_runner.shutdown_signal = MagicMock()
-        mock_create_runner.return_value = mock_runner
+        from bioetl.application.services import RunResult, RunStatus
+
+        mock_service = MagicMock()
+        mock_service.run = AsyncMock(
+            return_value=RunResult(
+                status=RunStatus.SUCCESS,
+                pipeline_name="chembl_activity",
+                run_id="test-run-id",
+                run_type="incremental",
+            )
+        )
+        mock_get_service.return_value = mock_service
+        mock_asyncio.side_effect = lambda coro: asyncio.get_event_loop().run_until_complete(coro)
 
         cli_runner.invoke(cli, ["run", "--pipeline", "chembl_activity"])
 
-        # Should have called create_pipeline_runner
-        mock_create_runner.assert_called_once()
+        # Should have called the service
+        mock_get_service.assert_called_once()
 
     @patch("bioetl.interfaces.cli.main.register_all_pipelines")
-    @patch("bioetl.interfaces.cli.commands.run.create_pipeline_runner")
+    @patch("bioetl.interfaces.cli.commands.run.get_pipeline_runner_service")
     @patch("bioetl.interfaces.cli.commands.run.asyncio.run")
     def test_run_with_limit(
-        self, mock_asyncio, mock_create_runner, mock_register, cli_runner, mock_registry
+        self, mock_asyncio, mock_get_service, mock_register, cli_runner, mock_registry
     ):
         """Test that --limit is passed correctly."""
-        mock_runner = MagicMock()
-        mock_runner.logger = MagicMock()
-        mock_runner.shutdown_signal = MagicMock()
-        mock_create_runner.return_value = mock_runner
+        from bioetl.application.services import RunResult, RunStatus
+
+        mock_service = MagicMock()
+        mock_service.run = AsyncMock(
+            return_value=RunResult(
+                status=RunStatus.SUCCESS,
+                pipeline_name="chembl_activity",
+                run_id="test-run-id",
+                run_type="incremental",
+            )
+        )
+        mock_get_service.return_value = mock_service
+        mock_asyncio.side_effect = lambda coro: asyncio.get_event_loop().run_until_complete(coro)
 
         cli_runner.invoke(
             cli, ["run", "--pipeline", "chembl_activity", "--limit", "100"]
         )
 
         # Verify limit was passed via RunOptions
-        call_args = mock_create_runner.call_args
+        call_args = mock_service.run.call_args
         pipeline_name = call_args[0][0]
-        options = call_args[0][1]  # RunOptions
+        options = call_args[1]["options"]  # RunOptions
         assert pipeline_name == "chembl_activity"
         assert options.limit == 100
 
     @patch("bioetl.interfaces.cli.main.register_all_pipelines")
-    @patch("bioetl.interfaces.cli.commands.run.create_pipeline_runner")
+    @patch("bioetl.interfaces.cli.commands.run.get_pipeline_runner_service")
     @patch("bioetl.interfaces.cli.commands.run.asyncio.run")
     def test_run_with_resume_flag(
-        self, mock_asyncio, mock_create_runner, mock_register, cli_runner, mock_registry
+        self, mock_asyncio, mock_get_service, mock_register, cli_runner, mock_registry
     ):
         """Test that --resume flag is passed correctly."""
-        mock_runner = MagicMock()
-        mock_runner.logger = MagicMock()
-        mock_runner.shutdown_signal = MagicMock()
-        mock_create_runner.return_value = mock_runner
+        from bioetl.application.services import RunResult, RunStatus
+
+        mock_service = MagicMock()
+        mock_service.run = AsyncMock(
+            return_value=RunResult(
+                status=RunStatus.SUCCESS,
+                pipeline_name="chembl_activity",
+                run_id="test-run-id",
+                run_type="incremental",
+            )
+        )
+        mock_get_service.return_value = mock_service
+        mock_asyncio.side_effect = lambda coro: asyncio.get_event_loop().run_until_complete(coro)
 
         cli_runner.invoke(cli, ["run", "--pipeline", "chembl_activity", "--resume"])
 
         # Verify resume was passed via RunOptions
-        call_args = mock_create_runner.call_args
+        call_args = mock_service.run.call_args
         pipeline_name = call_args[0][0]
-        options = call_args[0][1]  # RunOptions
+        options = call_args[1]["options"]  # RunOptions
         assert pipeline_name == "chembl_activity"
         assert options.resume is True
 


### PR DESCRIPTION
Create PipelineRunnerService in application layer to decouple pipeline execution logic from CLI. This enables reuse from REST API, Airflow operators, and other orchestration interfaces.

Changes:
- Add RunnerFactoryPort, RunnablePort, MetricsExtractorPort in domain/ports
- Create PipelineRunnerService with run(), list_pipelines(), validate_pipeline()
- Add RunOptions, RunResult, RunStatus dataclasses
- Implement RunnerFactory and MetricsExtractor in composition layer
- Add bootstrap_pipeline_runner_service function
- Expose get_pipeline_runner_service() in entrypoints.py
- Refactor CLI run command to use PipelineRunnerService
- Add 24 unit tests for PipelineRunnerService
- Update CLI tests to work with new service-based implementation

The service is stateless, thread-safe, and interface-agnostic. CLI handles exit codes and confirmation prompts (its responsibility).