### PR TITLE
Refactor PostrunService data quality logic

### DIFF
--- a/src/bioetl/application/core/__init__.py
+++ b/src/bioetl/application/core/__init__.py
@@ -29,12 +29,6 @@ from bioetl.application.core.cleanup_service import (
     LayerInfo,
 )
 from bioetl.application.core.lock_manager import LockManager
-from bioetl.application.services.medallion_lifecycle import (
-    ClearResult,
-    MedallionLifecycleService,
-    PrepareResult,
-    VacuumResult as MedallionVacuumResult,
-)
 from bioetl.application.core.memory_monitor import (
     MemoryConfig,
     MemoryMonitor,
@@ -43,6 +37,8 @@ from bioetl.application.core.memory_monitor import (
 from bioetl.application.core.pipeline_services import PipelineServices
 from bioetl.application.core.postrun_service import (
     DQResult,
+    DQStatus,
+    PostrunResult,
     PostrunService,
     VacuumResult,
 )
@@ -65,6 +61,11 @@ from bioetl.application.core.transform_utils import (
     safe_extract,
     validate_smiles,
 )
+from bioetl.application.services.medallion_lifecycle import (
+    ClearResult,
+    MedallionLifecycleService,
+    PrepareResult,
+)
 from bioetl.domain.config import PipelineConfig, RuntimeConfig
 from bioetl.domain.medallion import (
     Layer,
@@ -84,6 +85,7 @@ __all__ = [
     "CleanupService",
     "ClearResult",
     "DQResult",
+    "DQStatus",
     "Layer",
     "LayerInfo",
     "LockManager",
@@ -95,6 +97,7 @@ __all__ = [
     "PipelineRunner",
     "PipelineServices",
     "PipelineShutdownError",
+    "PostrunResult",
     "PostrunService",
     "PreflightService",
     "PrepareResult",

--- a/src/bioetl/application/core/postrun_service.py
+++ b/src/bioetl/application/core/postrun_service.py
@@ -1,27 +1,29 @@
 """Postrun Service for post-execution operations.
 
-Application Service that handles DQ checks, VACUUM, and cleanup after pipeline execution.
-Extracted from PipelineRunner to follow Single Responsibility Principle.
+Application Service that handles post-pipeline execution tasks:
+- Data quality checks (delegated to DataQualityService)
+- VACUUM operations (delegated to MedallionLifecycleService)
+- Tracer cleanup
 
-VACUUM operations are delegated to MedallionLifecycleService.finalize_run().
+Extracted from PipelineRunner to follow Single Responsibility Principle.
+DQ logic further extracted to DataQualityService (SRP refactoring).
 """
 
 from __future__ import annotations
 
-import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
+from bioetl.application.services.data_quality_service import DataQualityService
 from bioetl.application.services.medallion_lifecycle import VacuumResult
-from bioetl.domain.exceptions.data_quality import DataQualityThresholdError
+from bioetl.domain.value_objects.dq_result import DQResult, DQStatus
 
 if TYPE_CHECKING:
-    from bioetl.application.core.pipeline_services import PipelineServices
     from bioetl.application.services.medallion_lifecycle import (
         MedallionLifecycleService,
     )
     from bioetl.domain.config import PipelineConfig, RuntimeConfig
-    from bioetl.domain.ports import LoggerPort, TracingPort
+    from bioetl.domain.ports import LoggerPort, MetricsPort, TracingPort
 
 
 @runtime_checkable
@@ -39,208 +41,98 @@ class ExecutorMetricsProtocol(Protocol):
 
 
 @dataclass(frozen=True, slots=True)
-class DQResult:
-    """Result of data quality check.
+class PostrunResult:
+    """Combined result of all post-run operations.
 
     Attributes:
-        anomalies_count: Number of anomalies detected.
-        has_critical: Whether any critical anomalies were found.
-        check_duration_ms: Duration of the check in milliseconds.
+        dq: Data quality evaluation result.
+        vacuum: VACUUM operation result.
     """
 
-    anomalies_count: int
-    has_critical: bool
-    check_duration_ms: float
+    dq: DQResult
+    vacuum: VacuumResult
 
 
 class PostrunService:
     """Handles post-execution operations.
 
     Responsibilities:
-    - Data quality checks and anomaly detection
-    - VACUUM operations on Delta tables
+    - Orchestrating DQ checks via DataQualityService
+    - VACUUM operations via MedallionLifecycleService
     - Tracer cleanup
 
     Attributes:
         _config: Pipeline configuration.
         _runtime: Runtime configuration.
-        _services: Pipeline services.
-        _logger: Structured logger.
+        _dq_service: Data quality service for DQ checks.
         _lifecycle_service: Medallion lifecycle service for VACUUM.
+        _metrics: Optional metrics port.
+        _logger: Structured logger.
     """
 
     def __init__(
         self,
         config: PipelineConfig,
         runtime: RuntimeConfig,
-        services: PipelineServices,
-        logger: LoggerPort,
+        dq_service: DataQualityService,
         lifecycle_service: MedallionLifecycleService,
+        metrics: MetricsPort | None,
+        logger: LoggerPort,
     ) -> None:
         """Initialize postrun service.
 
         Args:
             config: Pipeline configuration.
             runtime: Runtime configuration.
-            services: Pipeline services.
-            logger: Structured logger.
+            dq_service: Data quality service for DQ checks.
             lifecycle_service: Medallion lifecycle service for VACUUM.
+            metrics: Optional metrics port.
+            logger: Structured logger.
         """
         self._config = config
         self._runtime = runtime
-        self._services = services
-        self._logger = logger
+        self._dq_service = dq_service
         self._lifecycle_service = lifecycle_service
+        self._metrics = metrics
+        self._logger = logger
 
-    async def run_dq_checks(self, executor: ExecutorMetricsProtocol) -> DQResult:
-        """Check data quality metrics and report anomalies.
+    async def run(
+        self,
+        executor: ExecutorMetricsProtocol,
+    ) -> PostrunResult:
+        """Run all post-execution operations.
 
-        Performs threshold checks before anomaly detection:
-        1. If error_rate >= hard_fail_threshold: raises DataQualityThresholdError
-        2. If error_rate >= soft_fail_threshold: logs warning + emits metric
-        3. Then runs anomaly detection if dq_monitor is available
+        Performs DQ checks and VACUUM in sequence.
 
         Args:
             executor: Pipeline executor with batch metrics.
 
         Returns:
-            DQResult with anomaly detection results.
+            PostrunResult with DQ and VACUUM results.
+
+        Raises:
+            DataQualityThresholdError: If error rate exceeds hard threshold.
+        """
+        dq_result = await self.run_dq_checks(executor)
+        vacuum_result = await self.run_vacuum_if_enabled()
+        return PostrunResult(dq=dq_result, vacuum=vacuum_result)
+
+    async def run_dq_checks(self, executor: ExecutorMetricsProtocol) -> DQResult:
+        """Check data quality metrics and report anomalies.
+
+        Delegates to DataQualityService for threshold checks and anomaly detection.
+
+        Args:
+            executor: Pipeline executor with batch metrics.
+
+        Returns:
+            DQResult with evaluation results.
 
         Raises:
             DataQualityThresholdError: If error rate exceeds hard threshold.
         """
         batch_metrics = self._collect_batch_metrics(executor)
-        error_rate = batch_metrics["error_rate"]
-
-        self._check_hard_threshold(error_rate)
-        self._check_soft_threshold(error_rate)
-
-        if self._services.dq_monitor is None:
-            return DQResult(anomalies_count=0, has_critical=False, check_duration_ms=0)
-
-        return self._run_anomaly_detection(batch_metrics)
-
-    def _check_hard_threshold(self, error_rate: float) -> None:
-        """Check if error rate exceeds hard threshold.
-
-        Args:
-            error_rate: Current error rate.
-
-        Raises:
-            DataQualityThresholdError: If threshold exceeded.
-        """
-        if error_rate >= self._config.dq.hard_fail_threshold:
-            self._logger.error(
-                "DQ hard threshold exceeded",
-                error_rate=error_rate,
-                threshold=self._config.dq.hard_fail_threshold,
-                pipeline=self._config.pipeline_name,
-            )
-            raise DataQualityThresholdError(
-                error_rate=error_rate,
-                threshold=self._config.dq.hard_fail_threshold,
-            )
-
-    def _check_soft_threshold(self, error_rate: float) -> None:
-        """Check if error rate exceeds soft threshold and log warning.
-
-        Args:
-            error_rate: Current error rate.
-        """
-        if error_rate < self._config.dq.soft_fail_threshold:
-            return
-
-        self._logger.warning(
-            "DQ soft threshold exceeded",
-            error_rate=error_rate,
-            threshold=self._config.dq.soft_fail_threshold,
-            pipeline=self._config.pipeline_name,
-        )
-        if self._services.metrics:
-            self._services.metrics.increment_counter(
-                "dq_soft_threshold_exceeded",
-                1,
-                {"pipeline": self._config.pipeline_name},
-            )
-
-    def _run_anomaly_detection(self, batch_metrics: dict[str, float]) -> DQResult:
-        """Run anomaly detection and process results.
-
-        Args:
-            batch_metrics: Metrics to check for anomalies.
-
-        Returns:
-            DQResult with anomaly detection results.
-
-        Note:
-            Caller must ensure dq_monitor is not None before calling.
-        """
-        # Caller ensures dq_monitor is not None (checked in run_dq_checks)
-        assert self._services.dq_monitor is not None
-        start_time = time.monotonic()
-        anomalies = self._services.dq_monitor.check_quality(batch_metrics)
-        check_duration_ms = (time.monotonic() - start_time) * 1000
-
-        self._record_check_duration(check_duration_ms)
-
-        has_critical = self._process_anomalies(anomalies)
-
-        self._services.dq_monitor.update_baseline_from_metrics(batch_metrics)
-        self._update_baseline_metrics(batch_metrics, has_critical)
-
-        return DQResult(
-            anomalies_count=len(anomalies),
-            has_critical=has_critical,
-            check_duration_ms=check_duration_ms,
-        )
-
-    def _record_check_duration(self, duration_ms: float) -> None:
-        """Record DQ check duration metric.
-
-        Args:
-            duration_ms: Duration in milliseconds.
-        """
-        if self._services.metrics:
-            self._services.metrics.observe_histogram(
-                "dq_check_duration_ms",
-                duration_ms,
-                {"pipeline": self._config.pipeline_name},
-            )
-
-    def _process_anomalies(self, anomalies: list[Any]) -> bool:
-        """Process detected anomalies and check for critical ones.
-
-        Args:
-            anomalies: List of detected anomalies.
-
-        Returns:
-            True if any critical anomalies found.
-        """
-        has_critical = False
-        for anomaly in anomalies:
-            self._process_anomaly(anomaly)
-            if anomaly.severity.value == "critical":
-                has_critical = True
-        return has_critical
-
-    def _update_baseline_metrics(
-        self, batch_metrics: dict[str, float], has_critical: bool
-    ) -> None:
-        """Update baseline metrics counters.
-
-        Args:
-            batch_metrics: Metrics used for baseline.
-            has_critical: Whether critical anomalies were found.
-        """
-        if not self._services.metrics or has_critical:
-            return
-
-        for metric_name in batch_metrics:
-            self._services.metrics.increment_counter(
-                "dq_baseline_updated",
-                1,
-                {"pipeline": self._config.pipeline_name, "metric": metric_name},
-            )
+        return await self._dq_service.evaluate(batch_metrics)
 
     async def run_vacuum_if_enabled(self) -> VacuumResult:
         """Run VACUUM on Silver and Gold tables if enabled.
@@ -257,7 +149,7 @@ class PostrunService:
         return await self._lifecycle_service.finalize_run(
             config=self._config,
             runtime=self._runtime,
-            metrics=self._services.metrics,
+            metrics=self._metrics,
         )
 
     async def cleanup(self, tracer: TracingPort | None) -> None:
@@ -300,42 +192,12 @@ class PostrunService:
             "gold_yield": executor.records_gold / total_records,
         }
 
-    def _process_anomaly(self, anomaly: Any) -> None:
-        """Log and track a single anomaly.
 
-        Args:
-            anomaly: Detected anomaly to process.
-        """
-        self._logger.warning(
-            "dq_anomaly_detected",
-            anomaly_type=anomaly.anomaly_type.value,
-            severity=anomaly.severity.value,
-            metric=anomaly.metric_name,
-            current_value=anomaly.current_value,
-            baseline_mean=anomaly.baseline_mean,
-            baseline_stddev=anomaly.baseline_stddev,
-            z_score=anomaly.z_score,
-            message=anomaly.message,
-        )
-
-        if self._services.metrics:
-            self._services.metrics.increment_counter(
-                "dq_anomaly_detected",
-                1,
-                {
-                    "pipeline": self._config.pipeline_name,
-                    "metric": anomaly.metric_name,
-                    "severity": anomaly.severity.value,
-                    "anomaly_type": anomaly.anomaly_type.value,
-                },
-            )
-
-        if anomaly.severity.value == "critical":
-            self._logger.error(
-                "critical_dq_anomaly",
-                metric=anomaly.metric_name,
-                message=anomaly.message,
-            )
-
-
-__all__ = ["DQResult", "ExecutorMetricsProtocol", "PostrunService", "VacuumResult"]
+__all__ = [
+    "DQResult",
+    "DQStatus",
+    "ExecutorMetricsProtocol",
+    "PostrunResult",
+    "PostrunService",
+    "VacuumResult",
+]

--- a/src/bioetl/application/services/__init__.py
+++ b/src/bioetl/application/services/__init__.py
@@ -20,6 +20,7 @@ from bioetl.application.services.checkpoint_service import (
     CheckpointInfo,
     CheckpointService,
 )
+from bioetl.application.services.data_quality_service import DataQualityService
 from bioetl.application.services.lock_service import (
     LockInfo,
     LockService,
@@ -52,6 +53,7 @@ __all__ = [
     "CheckpointService",
     "CleanupResult",
     "ClearResult",
+    "DataQualityService",
     "LockInfo",
     "LockService",
     "MedallionLifecycleService",

--- a/src/bioetl/application/services/data_quality_service.py
+++ b/src/bioetl/application/services/data_quality_service.py
@@ -1,0 +1,292 @@
+"""Data Quality Service for centralized DQ evaluation.
+
+Application Service that handles all data quality checks and anomaly detection.
+Extracted from PostrunService to follow Single Responsibility Principle.
+
+Responsibilities:
+- Threshold checks (soft/hard fail)
+- Anomaly detection via DQMonitorPort
+- DQ metrics emission
+- Baseline updates
+
+Does NOT handle:
+- VACUUM operations (MedallionLifecycleService)
+- Tracer cleanup (PostrunService)
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+
+from bioetl.domain.exceptions.data_quality import DataQualityThresholdError
+from bioetl.domain.value_objects.dq_result import DQResult, DQStatus
+
+if TYPE_CHECKING:
+    from bioetl.domain.config import DQConfig
+    from bioetl.domain.ports import DQMonitorPort, LoggerPort, MetricsPort
+
+
+class DataQualityService:
+    """Centralized service for data quality evaluation.
+
+    Performs threshold checks, anomaly detection, and metrics emission.
+    Designed to be injected into PostrunService or used standalone.
+
+    Attributes:
+        _dq_monitor: Optional DQ monitor for anomaly detection.
+        _config: DQ configuration with thresholds.
+        _logger: Structured logger for DQ events.
+        _metrics: Optional metrics port for observability.
+        _pipeline_name: Pipeline name for metric labels.
+    """
+
+    def __init__(
+        self,
+        dq_monitor: DQMonitorPort | None,
+        config: DQConfig,
+        logger: LoggerPort,
+        metrics: MetricsPort | None,
+        pipeline_name: str,
+    ) -> None:
+        """Initialize DataQualityService.
+
+        Args:
+            dq_monitor: Optional DQ monitor for anomaly detection.
+            config: DQ configuration with soft/hard thresholds.
+            logger: Structured logger for DQ events.
+            metrics: Optional metrics port for observability.
+            pipeline_name: Pipeline name for metric labels.
+        """
+        self._dq_monitor = dq_monitor
+        self._config = config
+        self._logger = logger
+        self._metrics = metrics
+        self._pipeline_name = pipeline_name
+
+    async def evaluate(
+        self,
+        metrics: dict[str, float],
+    ) -> DQResult:
+        """Evaluate data quality based on metrics.
+
+        Performs threshold checks before anomaly detection:
+        1. If error_rate >= hard_fail_threshold: raises DataQualityThresholdError
+        2. If error_rate >= soft_fail_threshold: logs warning + emits metric
+        3. Then runs anomaly detection if dq_monitor is available
+
+        Args:
+            metrics: Dictionary of metric names to values.
+                     Must contain 'error_rate' key.
+
+        Returns:
+            DQResult with evaluation outcome.
+
+        Raises:
+            DataQualityThresholdError: If error rate exceeds hard threshold.
+        """
+        error_rate = metrics.get("error_rate", 0.0)
+
+        # Check hard threshold first - raises if exceeded
+        self._check_hard_threshold(error_rate)
+
+        # Determine status based on soft threshold
+        status = self._determine_status(error_rate)
+
+        # Log warning and emit metric if soft threshold exceeded
+        if status == DQStatus.WARNING:
+            self._emit_soft_threshold_warning(error_rate)
+
+        # Run anomaly detection if monitor available
+        if self._dq_monitor is None:
+            return DQResult(
+                error_rate=error_rate,
+                status=status,
+                anomalies=(),
+                has_critical=False,
+                check_duration_ms=0.0,
+            )
+
+        return self._run_anomaly_detection(metrics, error_rate, status)
+
+    def _check_hard_threshold(self, error_rate: float) -> None:
+        """Check if error rate exceeds hard threshold.
+
+        Args:
+            error_rate: Current error rate.
+
+        Raises:
+            DataQualityThresholdError: If threshold exceeded.
+        """
+        if error_rate >= self._config.hard_fail_threshold:
+            self._logger.error(
+                "DQ hard threshold exceeded",
+                error_rate=error_rate,
+                threshold=self._config.hard_fail_threshold,
+                pipeline=self._pipeline_name,
+            )
+            raise DataQualityThresholdError(
+                error_rate=error_rate,
+                threshold=self._config.hard_fail_threshold,
+            )
+
+    def _determine_status(self, error_rate: float) -> DQStatus:
+        """Determine DQ status based on error rate.
+
+        Args:
+            error_rate: Current error rate.
+
+        Returns:
+            DQStatus based on threshold comparison.
+        """
+        if error_rate >= self._config.soft_fail_threshold:
+            return DQStatus.WARNING
+        return DQStatus.PASSED
+
+    def _emit_soft_threshold_warning(self, error_rate: float) -> None:
+        """Log warning and emit metric for soft threshold breach.
+
+        Args:
+            error_rate: Current error rate.
+        """
+        self._logger.warning(
+            "DQ soft threshold exceeded",
+            error_rate=error_rate,
+            threshold=self._config.soft_fail_threshold,
+            pipeline=self._pipeline_name,
+        )
+        if self._metrics:
+            self._metrics.increment_counter(
+                "dq_soft_threshold_exceeded",
+                1,
+                {"pipeline": self._pipeline_name},
+            )
+
+    def _run_anomaly_detection(
+        self,
+        metrics: dict[str, float],
+        error_rate: float,
+        status: DQStatus,
+    ) -> DQResult:
+        """Run anomaly detection and process results.
+
+        Args:
+            metrics: Metrics to check for anomalies.
+            error_rate: Calculated error rate.
+            status: Determined DQ status.
+
+        Returns:
+            DQResult with anomaly detection results.
+
+        Note:
+            Caller must ensure dq_monitor is not None before calling.
+        """
+        assert self._dq_monitor is not None
+
+        start_time = time.monotonic()
+        anomalies = self._dq_monitor.check_quality(metrics)
+        check_duration_ms = (time.monotonic() - start_time) * 1000
+
+        self._record_check_duration(check_duration_ms)
+
+        has_critical = self._process_anomalies(anomalies)
+
+        # Update baseline only if no critical anomalies
+        self._dq_monitor.update_baseline_from_metrics(metrics)
+        self._update_baseline_metrics(metrics, has_critical)
+
+        return DQResult(
+            error_rate=error_rate,
+            status=status,
+            anomalies=tuple(anomalies),
+            has_critical=has_critical,
+            check_duration_ms=check_duration_ms,
+        )
+
+    def _record_check_duration(self, duration_ms: float) -> None:
+        """Record DQ check duration metric.
+
+        Args:
+            duration_ms: Duration in milliseconds.
+        """
+        if self._metrics:
+            self._metrics.observe_histogram(
+                "dq_check_duration_ms",
+                duration_ms,
+                {"pipeline": self._pipeline_name},
+            )
+
+    def _process_anomalies(self, anomalies: list[Any]) -> bool:
+        """Process detected anomalies and check for critical ones.
+
+        Args:
+            anomalies: List of detected anomalies.
+
+        Returns:
+            True if any critical anomalies found.
+        """
+        has_critical = False
+        for anomaly in anomalies:
+            self._process_single_anomaly(anomaly)
+            if anomaly.severity.value == "critical":
+                has_critical = True
+        return has_critical
+
+    def _process_single_anomaly(self, anomaly: Any) -> None:
+        """Log and track a single anomaly.
+
+        Args:
+            anomaly: Detected anomaly to process.
+        """
+        self._logger.warning(
+            "dq_anomaly_detected",
+            anomaly_type=anomaly.anomaly_type.value,
+            severity=anomaly.severity.value,
+            metric=anomaly.metric_name,
+            current_value=anomaly.current_value,
+            baseline_mean=anomaly.baseline_mean,
+            baseline_stddev=anomaly.baseline_stddev,
+            z_score=anomaly.z_score,
+            message=anomaly.message,
+        )
+
+        if self._metrics:
+            self._metrics.increment_counter(
+                "dq_anomaly_detected",
+                1,
+                {
+                    "pipeline": self._pipeline_name,
+                    "metric": anomaly.metric_name,
+                    "severity": anomaly.severity.value,
+                    "anomaly_type": anomaly.anomaly_type.value,
+                },
+            )
+
+        if anomaly.severity.value == "critical":
+            self._logger.error(
+                "critical_dq_anomaly",
+                metric=anomaly.metric_name,
+                message=anomaly.message,
+            )
+
+    def _update_baseline_metrics(
+        self, metrics: dict[str, float], has_critical: bool
+    ) -> None:
+        """Update baseline metrics counters.
+
+        Args:
+            metrics: Metrics used for baseline.
+            has_critical: Whether critical anomalies were found.
+        """
+        if not self._metrics or has_critical:
+            return
+
+        for metric_name in metrics:
+            self._metrics.increment_counter(
+                "dq_baseline_updated",
+                1,
+                {"pipeline": self._pipeline_name, "metric": metric_name},
+            )
+
+
+__all__ = ["DataQualityService"]

--- a/src/bioetl/composition/factories/pipeline_factory.py
+++ b/src/bioetl/composition/factories/pipeline_factory.py
@@ -22,6 +22,7 @@ from bioetl.application.core.postrun_service import PostrunService
 from bioetl.application.core.preflight_service import PreflightService
 from bioetl.application.core.runner import PipelineRunner
 from bioetl.application.observability.observer import PipelineObserver
+from bioetl.application.services.data_quality_service import DataQualityService
 from bioetl.application.services.medallion_lifecycle import MedallionLifecycleService
 from bioetl.composition.factories.data_source_factory import (
     DataSourceCreator,
@@ -459,12 +460,22 @@ def assemble_runner(
         metrics=pipeline.services.metrics,
     )
 
+    # Create DataQualityService for DQ evaluation
+    dq_service = DataQualityService(
+        dq_monitor=pipeline.services.dq_monitor,
+        config=pipeline.config.dq,
+        logger=logger_port,
+        metrics=pipeline.services.metrics,
+        pipeline_name=pipeline.config.pipeline_name,
+    )
+
     postrun_service = PostrunService(
         config=pipeline.config,
         runtime=pipeline.runtime,
-        services=pipeline.services,
-        logger=logger_port,
+        dq_service=dq_service,
         lifecycle_service=lifecycle_service,
+        metrics=pipeline.services.metrics,
+        logger=logger_port,
     )
 
     observer = PipelineObserver(

--- a/src/bioetl/domain/value_objects/__init__.py
+++ b/src/bioetl/domain/value_objects/__init__.py
@@ -42,6 +42,7 @@ from bioetl.domain.value_objects.compound_ids import (
     CompoundIdUnion,
     CompoundSource,
 )
+from bioetl.domain.value_objects.dq_result import DQResult, DQStatus
 from bioetl.domain.value_objects.identifiers import (
     DOI,
     ChemblId,
@@ -68,6 +69,8 @@ __all__ = [
     "Concentration",
     "ConcentrationUnit",
     "ConfidenceScore",
+    "DQResult",
+    "DQStatus",
     "PChemblValue",
     "PubChemCid",
     "PubMedId",

--- a/src/bioetl/domain/value_objects/dq_result.py
+++ b/src/bioetl/domain/value_objects/dq_result.py
@@ -1,0 +1,80 @@
+"""Data Quality result value objects.
+
+Immutable value objects representing Data Quality evaluation results.
+Part of the domain layer - no I/O dependencies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    pass
+
+
+class DQStatus(str, Enum):
+    """Status of Data Quality evaluation.
+
+    Represents the outcome of DQ threshold checks.
+
+    Attributes:
+        PASSED: Error rate is below soft_fail_threshold.
+        WARNING: Error rate is between soft and hard thresholds.
+        FAILED: Error rate exceeds hard_fail_threshold.
+    """
+
+    PASSED = "passed"
+    WARNING = "warning"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True, slots=True)
+class DQResult:
+    """Result of Data Quality evaluation.
+
+    Immutable value object containing the results of DQ checks
+    including threshold evaluation and anomaly detection.
+
+    Attributes:
+        error_rate: Calculated error rate (0.0-1.0).
+        status: Overall DQ status based on thresholds.
+        anomalies: List of detected anomalies (empty if dq_monitor not available).
+        has_critical: Whether any critical anomalies were found.
+        check_duration_ms: Duration of anomaly detection in milliseconds.
+    """
+
+    error_rate: float
+    status: DQStatus
+    anomalies: tuple[Any, ...] = field(default_factory=tuple)
+    has_critical: bool = False
+    check_duration_ms: float = 0.0
+
+    def __post_init__(self) -> None:
+        """Validate and ensure immutability of anomalies."""
+        if isinstance(self.anomalies, list):
+            object.__setattr__(self, "anomalies", tuple(self.anomalies))
+
+    @property
+    def is_passed(self) -> bool:
+        """Check if DQ evaluation passed (no threshold violations)."""
+        return self.status == DQStatus.PASSED
+
+    @property
+    def is_warning(self) -> bool:
+        """Check if DQ evaluation resulted in warning."""
+        return self.status == DQStatus.WARNING
+
+    @property
+    def is_failed(self) -> bool:
+        """Check if DQ evaluation failed."""
+        return self.status == DQStatus.FAILED
+
+    @property
+    def anomalies_count(self) -> int:
+        """Count of detected anomalies."""
+        return len(self.anomalies)
+
+
+__all__ = ["DQResult", "DQStatus"]

--- a/tests/integration/test_runner_lifecycle.py
+++ b/tests/integration/test_runner_lifecycle.py
@@ -209,9 +209,7 @@ def mock_lifecycle_service_with_recorder(call_recorder, mock_services_with_recor
 @pytest.fixture
 def mock_lifecycle_service(call_recorder, mock_lifecycle_service_with_recorder):
     """Create a mock lifecycle service for runner tests."""
-    from bioetl.application.services.medallion_lifecycle import ClearResult
     from bioetl.domain.medallion import MedallionPolicy
-    from bioetl.domain.types import RunType
 
     service = MagicMock(spec=MedallionLifecycleService)
 

--- a/tests/unit/application/core/test_postrun_service.py
+++ b/tests/unit/application/core/test_postrun_service.py
@@ -2,19 +2,20 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from bioetl.application.core.postrun_service import (
-    DQResult,
+    PostrunResult,
     PostrunService,
     VacuumResult,
 )
-from bioetl.domain.config import DQConfig, PipelineConfig, RuntimeConfig
+from bioetl.application.services.data_quality_service import DataQualityService
+from bioetl.domain.config import PipelineConfig, RuntimeConfig
 from bioetl.domain.exceptions.data_quality import DataQualityThresholdError
 from bioetl.domain.types import RunType
+from bioetl.domain.value_objects.dq_result import DQResult, DQStatus
 
 
 @pytest.fixture
@@ -61,15 +62,6 @@ def runtime_config():
 
 
 @pytest.fixture
-def mock_services(mock_metrics):
-    """Create mock pipeline services."""
-    services = MagicMock()
-    services.metrics = mock_metrics
-    services.dq_monitor = None
-    return services
-
-
-@pytest.fixture
 def mock_executor():
     """Create a mock executor."""
     executor = MagicMock()
@@ -95,16 +87,33 @@ def mock_lifecycle_service():
 
 
 @pytest.fixture
+def mock_dq_service():
+    """Create a mock DataQualityService."""
+    service = MagicMock(spec=DataQualityService)
+    service.evaluate = AsyncMock(
+        return_value=DQResult(
+            error_rate=0.05,
+            status=DQStatus.PASSED,
+            anomalies=(),
+            has_critical=False,
+            check_duration_ms=10.0,
+        )
+    )
+    return service
+
+
+@pytest.fixture
 def postrun_service(
-    pipeline_config, runtime_config, mock_services, mock_logger, mock_lifecycle_service
+    pipeline_config, runtime_config, mock_dq_service, mock_lifecycle_service, mock_metrics, mock_logger
 ):
     """Create a PostrunService instance."""
     return PostrunService(
         config=pipeline_config,
         runtime=runtime_config,
-        services=mock_services,
-        logger=mock_logger,
+        dq_service=mock_dq_service,
         lifecycle_service=mock_lifecycle_service,
+        metrics=mock_metrics,
+        logger=mock_logger,
     )
 
 
@@ -116,24 +125,58 @@ class TestPostrunServiceInit:
         self,
         pipeline_config,
         runtime_config,
-        mock_services,
-        mock_logger,
+        mock_dq_service,
         mock_lifecycle_service,
+        mock_metrics,
+        mock_logger,
     ):
         """Test postrun service initializes correctly."""
         service = PostrunService(
             config=pipeline_config,
             runtime=runtime_config,
-            services=mock_services,
-            logger=mock_logger,
+            dq_service=mock_dq_service,
             lifecycle_service=mock_lifecycle_service,
+            metrics=mock_metrics,
+            logger=mock_logger,
         )
 
         assert service._config == pipeline_config
         assert service._runtime == runtime_config
-        assert service._services == mock_services
-        assert service._logger == mock_logger
+        assert service._dq_service == mock_dq_service
         assert service._lifecycle_service == mock_lifecycle_service
+        assert service._metrics == mock_metrics
+        assert service._logger == mock_logger
+
+
+@pytest.mark.unit
+class TestPostrunServiceRun:
+    """Tests for PostrunService.run method."""
+
+    @pytest.mark.asyncio
+    async def test_run_returns_postrun_result(
+        self, postrun_service, mock_executor, mock_dq_service, mock_lifecycle_service
+    ):
+        """Test run method returns PostrunResult with DQ and VACUUM results."""
+        result = await postrun_service.run(mock_executor)
+
+        assert isinstance(result, PostrunResult)
+        assert isinstance(result.dq, DQResult)
+        assert isinstance(result.vacuum, VacuumResult)
+
+        mock_dq_service.evaluate.assert_called_once()
+        mock_lifecycle_service.finalize_run.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_propagates_dq_error(
+        self, postrun_service, mock_executor, mock_dq_service
+    ):
+        """Test run method propagates DataQualityThresholdError from DQ service."""
+        mock_dq_service.evaluate = AsyncMock(
+            side_effect=DataQualityThresholdError(error_rate=0.25, threshold=0.20)
+        )
+
+        with pytest.raises(DataQualityThresholdError):
+            await postrun_service.run(mock_executor)
 
 
 @pytest.mark.unit
@@ -141,151 +184,39 @@ class TestPostrunServiceDQChecks:
     """Tests for PostrunService.run_dq_checks method."""
 
     @pytest.mark.asyncio
-    async def test_dq_checks_skips_without_monitor(
-        self, postrun_service, mock_executor
+    async def test_dq_checks_delegates_to_dq_service(
+        self, postrun_service, mock_executor, mock_dq_service
     ):
-        """Test run_dq_checks returns early when dq_monitor is None."""
+        """Test run_dq_checks delegates to DataQualityService."""
         result = await postrun_service.run_dq_checks(mock_executor)
 
-        assert result.anomalies_count == 0
-        assert result.has_critical is False
-        assert result.check_duration_ms == 0
+        assert isinstance(result, DQResult)
+        mock_dq_service.evaluate.assert_called_once()
+
+        # Verify metrics dict was passed
+        call_args = mock_dq_service.evaluate.call_args
+        metrics_dict = call_args[0][0]
+        assert "error_rate" in metrics_dict
+        assert "record_count" in metrics_dict
 
     @pytest.mark.asyncio
-    async def test_dq_checks_with_no_anomalies(
-        self,
-        pipeline_config,
-        runtime_config,
-        mock_logger,
-        mock_lifecycle_service,
-        mock_executor,
-        mock_metrics,
+    async def test_dq_checks_collects_batch_metrics(
+        self, postrun_service, mock_executor, mock_dq_service
     ):
-        """Test run_dq_checks with no anomalies detected."""
-        mock_dq_monitor = MagicMock()
-        mock_dq_monitor.check_quality = MagicMock(return_value=[])
-        mock_dq_monitor.update_baseline_from_metrics = MagicMock()
+        """Test run_dq_checks collects correct batch metrics."""
+        await postrun_service.run_dq_checks(mock_executor)
 
-        services = MagicMock()
-        services.dq_monitor = mock_dq_monitor
-        services.metrics = mock_metrics
+        call_args = mock_dq_service.evaluate.call_args
+        metrics_dict = call_args[0][0]
 
-        service = PostrunService(
-            config=pipeline_config,
-            runtime=runtime_config,
-            services=services,
-            logger=mock_logger,
-            lifecycle_service=mock_lifecycle_service,
-        )
-
-        result = await service.run_dq_checks(mock_executor)
-
-        assert result.anomalies_count == 0
-        assert result.has_critical is False
-        mock_dq_monitor.check_quality.assert_called_once()
-        mock_dq_monitor.update_baseline_from_metrics.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_dq_checks_with_anomalies(
-        self,
-        pipeline_config,
-        runtime_config,
-        mock_logger,
-        mock_lifecycle_service,
-        mock_executor,
-        mock_metrics,
-    ):
-        """Test run_dq_checks with anomalies detected."""
-        from bioetl.infrastructure.observability.anomaly.types import (
-            Anomaly,
-            AnomalySeverity,
-            AnomalyType,
-        )
-
-        anomaly = Anomaly(
-            metric_name="error_rate",
-            current_value=0.25,
-            baseline_mean=0.05,
-            baseline_stddev=0.02,
-            anomaly_type=AnomalyType.SPIKE,
-            severity=AnomalySeverity.HIGH,
-            z_score=10.0,
-            timestamp=datetime.now(UTC),
-            message="Error rate spike detected",
-        )
-
-        mock_dq_monitor = MagicMock()
-        mock_dq_monitor.check_quality = MagicMock(return_value=[anomaly])
-        mock_dq_monitor.update_baseline_from_metrics = MagicMock()
-
-        services = MagicMock()
-        services.dq_monitor = mock_dq_monitor
-        services.metrics = mock_metrics
-
-        service = PostrunService(
-            config=pipeline_config,
-            runtime=runtime_config,
-            services=services,
-            logger=mock_logger,
-            lifecycle_service=mock_lifecycle_service,
-        )
-
-        result = await service.run_dq_checks(mock_executor)
-
-        assert result.anomalies_count == 1
-        assert result.has_critical is False
-        mock_logger.warning.assert_called()
-
-    @pytest.mark.asyncio
-    async def test_dq_checks_with_critical_anomaly(
-        self,
-        pipeline_config,
-        runtime_config,
-        mock_logger,
-        mock_lifecycle_service,
-        mock_executor,
-        mock_metrics,
-    ):
-        """Test run_dq_checks with critical anomaly."""
-        from bioetl.infrastructure.observability.anomaly.types import (
-            Anomaly,
-            AnomalySeverity,
-            AnomalyType,
-        )
-
-        critical_anomaly = Anomaly(
-            metric_name="error_rate",
-            current_value=0.50,
-            baseline_mean=0.05,
-            baseline_stddev=0.02,
-            anomaly_type=AnomalyType.THRESHOLD_EXCEEDED,
-            severity=AnomalySeverity.CRITICAL,
-            z_score=22.5,
-            timestamp=datetime.now(UTC),
-            message="Error rate critical",
-        )
-
-        mock_dq_monitor = MagicMock()
-        mock_dq_monitor.check_quality = MagicMock(return_value=[critical_anomaly])
-        mock_dq_monitor.update_baseline_from_metrics = MagicMock()
-
-        services = MagicMock()
-        services.dq_monitor = mock_dq_monitor
-        services.metrics = mock_metrics
-
-        service = PostrunService(
-            config=pipeline_config,
-            runtime=runtime_config,
-            services=services,
-            logger=mock_logger,
-            lifecycle_service=mock_lifecycle_service,
-        )
-
-        result = await service.run_dq_checks(mock_executor)
-
-        assert result.anomalies_count == 1
-        assert result.has_critical is True
-        mock_logger.error.assert_called()
+        assert metrics_dict["record_count"] == 100.0
+        assert metrics_dict["bronze_count"] == 100.0
+        assert metrics_dict["silver_count"] == 95.0
+        assert metrics_dict["gold_count"] == 90.0
+        assert metrics_dict["quarantined_count"] == 5.0
+        assert metrics_dict["error_rate"] == 0.05
+        assert metrics_dict["silver_yield"] == 0.95
+        assert metrics_dict["gold_yield"] == 0.90
 
 
 @pytest.mark.unit
@@ -300,9 +231,10 @@ class TestPostrunServiceVacuum:
     async def test_vacuum_delegates_to_finalize_run(
         self,
         pipeline_config,
-        mock_services,
+        mock_dq_service,
         mock_logger,
         mock_lifecycle_service,
+        mock_metrics,
     ):
         """Test run_vacuum_if_enabled delegates to lifecycle service."""
         from bioetl.application.services.medallion_lifecycle import VacuumResult
@@ -320,9 +252,10 @@ class TestPostrunServiceVacuum:
         service = PostrunService(
             config=pipeline_config,
             runtime=runtime,
-            services=mock_services,
-            logger=mock_logger,
+            dq_service=mock_dq_service,
             lifecycle_service=mock_lifecycle_service,
+            metrics=mock_metrics,
+            logger=mock_logger,
         )
 
         result = await service.run_vacuum_if_enabled()
@@ -331,7 +264,7 @@ class TestPostrunServiceVacuum:
         mock_lifecycle_service.finalize_run.assert_called_once_with(
             config=pipeline_config,
             runtime=runtime,
-            metrics=mock_services.metrics,
+            metrics=mock_metrics,
         )
         assert result.skipped is True
 
@@ -339,9 +272,10 @@ class TestPostrunServiceVacuum:
     async def test_vacuum_returns_finalize_run_result(
         self,
         pipeline_config,
-        mock_services,
+        mock_dq_service,
         mock_logger,
         mock_lifecycle_service,
+        mock_metrics,
     ):
         """Test run_vacuum_if_enabled returns finalize_run result."""
         from bioetl.application.services.medallion_lifecycle import VacuumResult
@@ -360,9 +294,10 @@ class TestPostrunServiceVacuum:
         service = PostrunService(
             config=pipeline_config,
             runtime=runtime,
-            services=mock_services,
-            logger=mock_logger,
+            dq_service=mock_dq_service,
             lifecycle_service=mock_lifecycle_service,
+            metrics=mock_metrics,
+            logger=mock_logger,
         )
 
         result = await service.run_vacuum_if_enabled()
@@ -439,20 +374,25 @@ class TestPostrunServiceBatchMetrics:
 
 
 @pytest.mark.unit
-class TestDQResult:
-    """Tests for DQResult dataclass."""
+class TestPostrunResult:
+    """Tests for PostrunResult dataclass."""
 
-    def test_dq_result_creation(self):
-        """Test DQResult creation."""
-        result = DQResult(
-            anomalies_count=2,
-            has_critical=True,
-            check_duration_ms=123.45,
+    def test_postrun_result_creation(self):
+        """Test PostrunResult creation."""
+        dq_result = DQResult(
+            error_rate=0.05,
+            status=DQStatus.PASSED,
+        )
+        vacuum_result = VacuumResult(
+            silver_files_removed=10,
+            gold_files_removed=5,
+            skipped=False,
         )
 
-        assert result.anomalies_count == 2
-        assert result.has_critical is True
-        assert result.check_duration_ms == 123.45
+        result = PostrunResult(dq=dq_result, vacuum=vacuum_result)
+
+        assert result.dq == dq_result
+        assert result.vacuum == vacuum_result
 
 
 @pytest.mark.unit
@@ -473,29 +413,57 @@ class TestVacuumResult:
 
 
 @pytest.mark.unit
-class TestPostrunServiceDQThresholds:
-    """Tests for DQ threshold checking in PostrunService."""
+class TestPostrunServiceIntegrationWithDataQualityService:
+    """Integration tests for PostrunService with real DataQualityService."""
 
     @pytest.mark.asyncio
-    async def test_hard_threshold_exceeded_raises_error(
+    async def test_full_flow_with_real_dq_service(
         self,
+        pipeline_config,
         runtime_config,
-        mock_services,
-        mock_logger,
         mock_lifecycle_service,
+        mock_metrics,
+        mock_logger,
+        mock_executor,
     ):
-        """Test that error rate exceeding hard threshold raises DataQualityThresholdError."""
-        # Config with hard_fail_threshold=0.20 (default)
-        config = PipelineConfig(
-            pipeline_name="test_pipeline",
-            provider="chembl",
-            entity_type="activity",
-            primary_keys=["activity_id"],
-            silver_table="test_silver",
-            dq=DQConfig(soft_fail_threshold=0.05, hard_fail_threshold=0.20),
+        """Test full flow using real DataQualityService (no dq_monitor)."""
+        # Create real DataQualityService
+        dq_service = DataQualityService(
+            dq_monitor=None,
+            config=pipeline_config.dq,
+            logger=mock_logger,
+            metrics=mock_metrics,
+            pipeline_name=pipeline_config.pipeline_name,
         )
 
-        # Executor with 25% error rate (25/100 quarantined)
+        service = PostrunService(
+            config=pipeline_config,
+            runtime=runtime_config,
+            dq_service=dq_service,
+            lifecycle_service=mock_lifecycle_service,
+            metrics=mock_metrics,
+            logger=mock_logger,
+        )
+
+        result = await service.run(mock_executor)
+
+        assert isinstance(result, PostrunResult)
+        # 5% error rate exactly equals soft threshold (5%), so status is WARNING
+        assert result.dq.status == DQStatus.WARNING
+        assert result.dq.error_rate == 0.05
+        assert result.vacuum.skipped is False
+
+    @pytest.mark.asyncio
+    async def test_hard_threshold_raised_with_real_dq_service(
+        self,
+        pipeline_config,
+        runtime_config,
+        mock_lifecycle_service,
+        mock_metrics,
+        mock_logger,
+    ):
+        """Test hard threshold error with real DataQualityService."""
+        # Create executor with 25% error rate
         executor = MagicMock()
         executor.records_fetched = 100
         executor.records_bronze = 100
@@ -503,280 +471,26 @@ class TestPostrunServiceDQThresholds:
         executor.records_gold = 70
         executor.records_quarantined = 25
 
-        service = PostrunService(
-            config=config,
-            runtime=runtime_config,
-            services=mock_services,
+        # Create real DataQualityService
+        dq_service = DataQualityService(
+            dq_monitor=None,
+            config=pipeline_config.dq,
             logger=mock_logger,
+            metrics=mock_metrics,
+            pipeline_name=pipeline_config.pipeline_name,
+        )
+
+        service = PostrunService(
+            config=pipeline_config,
+            runtime=runtime_config,
+            dq_service=dq_service,
             lifecycle_service=mock_lifecycle_service,
+            metrics=mock_metrics,
+            logger=mock_logger,
         )
 
         with pytest.raises(DataQualityThresholdError) as exc_info:
-            await service.run_dq_checks(executor)
+            await service.run(executor)
 
         assert exc_info.value.error_rate == 0.25
         assert exc_info.value.threshold == 0.20
-        mock_logger.error.assert_called_once()
-        # Verify error log includes expected details
-        error_call = mock_logger.error.call_args
-        assert error_call[0][0] == "DQ hard threshold exceeded"
-
-    @pytest.mark.asyncio
-    async def test_hard_threshold_exactly_at_limit_raises_error(
-        self,
-        runtime_config,
-        mock_services,
-        mock_logger,
-        mock_lifecycle_service,
-    ):
-        """Test that error rate exactly at hard threshold raises DataQualityThresholdError."""
-        config = PipelineConfig(
-            pipeline_name="test_pipeline",
-            provider="chembl",
-            entity_type="activity",
-            primary_keys=["activity_id"],
-            silver_table="test_silver",
-            dq=DQConfig(soft_fail_threshold=0.05, hard_fail_threshold=0.20),
-        )
-
-        # Executor with exactly 20% error rate (20/100 quarantined)
-        executor = MagicMock()
-        executor.records_fetched = 100
-        executor.records_bronze = 100
-        executor.records_silver = 80
-        executor.records_gold = 75
-        executor.records_quarantined = 20
-
-        service = PostrunService(
-            config=config,
-            runtime=runtime_config,
-            services=mock_services,
-            logger=mock_logger,
-            lifecycle_service=mock_lifecycle_service,
-        )
-
-        with pytest.raises(DataQualityThresholdError):
-            await service.run_dq_checks(executor)
-
-    @pytest.mark.asyncio
-    async def test_soft_threshold_exceeded_logs_warning_and_emits_metric(
-        self,
-        runtime_config,
-        mock_logger,
-        mock_lifecycle_service,
-        mock_metrics,
-    ):
-        """Test that error rate exceeding soft threshold logs warning and emits metric."""
-        config = PipelineConfig(
-            pipeline_name="test_pipeline",
-            provider="chembl",
-            entity_type="activity",
-            primary_keys=["activity_id"],
-            silver_table="test_silver",
-            dq=DQConfig(soft_fail_threshold=0.05, hard_fail_threshold=0.20),
-        )
-
-        # Executor with 10% error rate (10/100 quarantined) - above soft, below hard
-        executor = MagicMock()
-        executor.records_fetched = 100
-        executor.records_bronze = 100
-        executor.records_silver = 90
-        executor.records_gold = 85
-        executor.records_quarantined = 10
-
-        services = MagicMock()
-        services.dq_monitor = None
-        services.metrics = mock_metrics
-
-        service = PostrunService(
-            config=config,
-            runtime=runtime_config,
-            services=services,
-            logger=mock_logger,
-            lifecycle_service=mock_lifecycle_service,
-        )
-
-        # Should not raise, but should log warning
-        result = await service.run_dq_checks(executor)
-
-        assert result.anomalies_count == 0
-        mock_logger.warning.assert_called_once()
-        warning_call = mock_logger.warning.call_args
-        assert warning_call[0][0] == "DQ soft threshold exceeded"
-
-        # Verify metric was emitted
-        mock_metrics.increment_counter.assert_called_once_with(
-            "dq_soft_threshold_exceeded",
-            1,
-            {"pipeline": "test_pipeline"},
-        )
-
-    @pytest.mark.asyncio
-    async def test_soft_threshold_exactly_at_limit_logs_warning(
-        self,
-        runtime_config,
-        mock_logger,
-        mock_lifecycle_service,
-        mock_metrics,
-    ):
-        """Test that error rate exactly at soft threshold logs warning."""
-        config = PipelineConfig(
-            pipeline_name="test_pipeline",
-            provider="chembl",
-            entity_type="activity",
-            primary_keys=["activity_id"],
-            silver_table="test_silver",
-            dq=DQConfig(soft_fail_threshold=0.05, hard_fail_threshold=0.20),
-        )
-
-        # Executor with exactly 5% error rate (5/100 quarantined)
-        executor = MagicMock()
-        executor.records_fetched = 100
-        executor.records_bronze = 100
-        executor.records_silver = 95
-        executor.records_gold = 90
-        executor.records_quarantined = 5
-
-        services = MagicMock()
-        services.dq_monitor = None
-        services.metrics = mock_metrics
-
-        service = PostrunService(
-            config=config,
-            runtime=runtime_config,
-            services=services,
-            logger=mock_logger,
-            lifecycle_service=mock_lifecycle_service,
-        )
-
-        await service.run_dq_checks(executor)
-
-        mock_logger.warning.assert_called_once()
-        mock_metrics.increment_counter.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_below_soft_threshold_no_warning(
-        self,
-        runtime_config,
-        mock_logger,
-        mock_lifecycle_service,
-        mock_metrics,
-    ):
-        """Test that error rate below soft threshold does not log warning."""
-        config = PipelineConfig(
-            pipeline_name="test_pipeline",
-            provider="chembl",
-            entity_type="activity",
-            primary_keys=["activity_id"],
-            silver_table="test_silver",
-            dq=DQConfig(soft_fail_threshold=0.05, hard_fail_threshold=0.20),
-        )
-
-        # Executor with 3% error rate (3/100 quarantined) - below soft threshold
-        executor = MagicMock()
-        executor.records_fetched = 100
-        executor.records_bronze = 100
-        executor.records_silver = 97
-        executor.records_gold = 95
-        executor.records_quarantined = 3
-
-        services = MagicMock()
-        services.dq_monitor = None
-        services.metrics = mock_metrics
-
-        service = PostrunService(
-            config=config,
-            runtime=runtime_config,
-            services=services,
-            logger=mock_logger,
-            lifecycle_service=mock_lifecycle_service,
-        )
-
-        await service.run_dq_checks(executor)
-
-        mock_logger.warning.assert_not_called()
-        mock_logger.error.assert_not_called()
-        mock_metrics.increment_counter.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_soft_threshold_without_metrics_still_logs_warning(
-        self,
-        runtime_config,
-        mock_logger,
-        mock_lifecycle_service,
-    ):
-        """Test that soft threshold logs warning even when metrics port is None."""
-        config = PipelineConfig(
-            pipeline_name="test_pipeline",
-            provider="chembl",
-            entity_type="activity",
-            primary_keys=["activity_id"],
-            silver_table="test_silver",
-            dq=DQConfig(soft_fail_threshold=0.05, hard_fail_threshold=0.20),
-        )
-
-        # Executor with 10% error rate
-        executor = MagicMock()
-        executor.records_fetched = 100
-        executor.records_bronze = 100
-        executor.records_silver = 90
-        executor.records_gold = 85
-        executor.records_quarantined = 10
-
-        services = MagicMock()
-        services.dq_monitor = None
-        services.metrics = None  # No metrics port
-
-        service = PostrunService(
-            config=config,
-            runtime=runtime_config,
-            services=services,
-            logger=mock_logger,
-            lifecycle_service=mock_lifecycle_service,
-        )
-
-        # Should not raise
-        result = await service.run_dq_checks(executor)
-
-        assert result.anomalies_count == 0
-        mock_logger.warning.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_zero_records_does_not_fail(
-        self,
-        runtime_config,
-        mock_services,
-        mock_logger,
-        mock_lifecycle_service,
-    ):
-        """Test that zero records processed does not trigger threshold errors."""
-        config = PipelineConfig(
-            pipeline_name="test_pipeline",
-            provider="chembl",
-            entity_type="activity",
-            primary_keys=["activity_id"],
-            silver_table="test_silver",
-        )
-
-        # Executor with zero records
-        executor = MagicMock()
-        executor.records_fetched = 0
-        executor.records_bronze = 0
-        executor.records_silver = 0
-        executor.records_gold = 0
-        executor.records_quarantined = 0
-
-        service = PostrunService(
-            config=config,
-            runtime=runtime_config,
-            services=mock_services,
-            logger=mock_logger,
-            lifecycle_service=mock_lifecycle_service,
-        )
-
-        # Should not raise - error_rate is 0/1=0 which is below thresholds
-        result = await service.run_dq_checks(executor)
-
-        assert result.anomalies_count == 0
-        mock_logger.warning.assert_not_called()
-        mock_logger.error.assert_not_called()

--- a/tests/unit/application/core/test_runner.py
+++ b/tests/unit/application/core/test_runner.py
@@ -156,12 +156,16 @@ def mock_preflight_service():
 @pytest.fixture
 def mock_postrun_service():
     """Create a mock PostrunService (injected via DI)."""
-    from bioetl.application.core.postrun_service import DQResult, VacuumResult
+    from bioetl.application.core.postrun_service import DQResult, DQStatus, VacuumResult
 
     service = MagicMock(spec=PostrunService)
     service.run_dq_checks = AsyncMock(
         return_value=DQResult(
-            anomalies_count=0, has_critical=False, check_duration_ms=0
+            error_rate=0.0,
+            status=DQStatus.PASSED,
+            anomalies=(),
+            has_critical=False,
+            check_duration_ms=0.0,
         )
     )
     service.run_vacuum_if_enabled = AsyncMock(
@@ -178,7 +182,6 @@ def mock_lifecycle_service():
     """Create a mock MedallionLifecycleService (injected via DI)."""
     from bioetl.application.services.medallion_lifecycle import (
         ClearResult,
-        PrepareResult,
         VacuumResult,
     )
     from bioetl.domain.medallion import MedallionPolicy
@@ -585,7 +588,6 @@ class TestPipelineRunnerClearViaLifecycle:
         """Test _prepare_medallion_layers delegates to lifecycle service."""
         from bioetl.application.services.medallion_lifecycle import (
             ClearResult,
-            PrepareResult,
         )
         from bioetl.domain.medallion import MedallionPolicy
 
@@ -640,7 +642,6 @@ class TestPipelineRunnerClearViaLifecycle:
         """Test _prepare_medallion_layers is called as part of run() execution."""
         from bioetl.application.services.medallion_lifecycle import (
             ClearResult,
-            PrepareResult,
             VacuumResult,
         )
         from bioetl.domain.medallion import MedallionPolicy
@@ -716,14 +717,18 @@ class TestPipelineRunnerCheckDataQuality:
         mock_lifecycle_service,
     ):
         """Test _check_data_quality delegates to PostrunService."""
-        from bioetl.application.core.postrun_service import DQResult, VacuumResult
+        from bioetl.application.core.postrun_service import DQResult, DQStatus, VacuumResult
 
         services = create_mock_services()
 
         postrun_service = MagicMock(spec=PostrunService)
         postrun_service.run_dq_checks = AsyncMock(
             return_value=DQResult(
-                anomalies_count=0, has_critical=False, check_duration_ms=5.0
+                error_rate=0.0,
+                status=DQStatus.PASSED,
+                anomalies=(),
+                has_critical=False,
+                check_duration_ms=5.0,
             )
         )
         postrun_service.run_vacuum_if_enabled = AsyncMock(
@@ -773,14 +778,18 @@ class TestPipelineRunnerCheckDataQuality:
         mock_lifecycle_service,
     ):
         """Test _check_data_quality is invoked during run()."""
-        from bioetl.application.core.postrun_service import DQResult, VacuumResult
+        from bioetl.application.core.postrun_service import DQResult, DQStatus, VacuumResult
 
         services = create_mock_services()
 
         postrun_service = MagicMock(spec=PostrunService)
         postrun_service.run_dq_checks = AsyncMock(
             return_value=DQResult(
-                anomalies_count=0, has_critical=False, check_duration_ms=0
+                error_rate=0.0,
+                status=DQStatus.PASSED,
+                anomalies=(),
+                has_critical=False,
+                check_duration_ms=0.0,
             )
         )
         postrun_service.run_vacuum_if_enabled = AsyncMock(

--- a/tests/unit/application/services/test_data_quality_service.py
+++ b/tests/unit/application/services/test_data_quality_service.py
@@ -1,0 +1,600 @@
+"""Unit tests for the DataQualityService class."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from bioetl.application.services.data_quality_service import DataQualityService
+from bioetl.domain.config import DQConfig
+from bioetl.domain.exceptions.data_quality import DataQualityThresholdError
+from bioetl.domain.value_objects.dq_result import DQResult, DQStatus
+
+
+@pytest.fixture
+def mock_logger():
+    """Create a mock logger."""
+    logger = MagicMock()
+    logger.bind = MagicMock(return_value=logger)
+    logger.info = MagicMock()
+    logger.warning = MagicMock()
+    logger.error = MagicMock()
+    logger.debug = MagicMock()
+    return logger
+
+
+@pytest.fixture
+def mock_metrics():
+    """Create a mock metrics port."""
+    metrics = MagicMock()
+    metrics.set_gauge = MagicMock()
+    metrics.observe_histogram = MagicMock()
+    metrics.increment_counter = MagicMock()
+    return metrics
+
+
+@pytest.fixture
+def dq_config():
+    """Create a DQ config with default thresholds."""
+    return DQConfig(soft_fail_threshold=0.05, hard_fail_threshold=0.20)
+
+
+@pytest.fixture
+def dq_service(mock_logger, mock_metrics, dq_config):
+    """Create a DataQualityService instance without dq_monitor."""
+    return DataQualityService(
+        dq_monitor=None,
+        config=dq_config,
+        logger=mock_logger,
+        metrics=mock_metrics,
+        pipeline_name="test_pipeline",
+    )
+
+
+@pytest.mark.unit
+class TestDataQualityServiceInit:
+    """Tests for DataQualityService initialization."""
+
+    def test_initialization_without_monitor(
+        self, mock_logger, mock_metrics, dq_config
+    ):
+        """Test service initializes correctly without dq_monitor."""
+        service = DataQualityService(
+            dq_monitor=None,
+            config=dq_config,
+            logger=mock_logger,
+            metrics=mock_metrics,
+            pipeline_name="test_pipeline",
+        )
+
+        assert service._dq_monitor is None
+        assert service._config == dq_config
+        assert service._logger == mock_logger
+        assert service._metrics == mock_metrics
+        assert service._pipeline_name == "test_pipeline"
+
+    def test_initialization_with_monitor(
+        self, mock_logger, mock_metrics, dq_config
+    ):
+        """Test service initializes correctly with dq_monitor."""
+        mock_dq_monitor = MagicMock()
+
+        service = DataQualityService(
+            dq_monitor=mock_dq_monitor,
+            config=dq_config,
+            logger=mock_logger,
+            metrics=mock_metrics,
+            pipeline_name="test_pipeline",
+        )
+
+        assert service._dq_monitor == mock_dq_monitor
+
+
+@pytest.mark.unit
+class TestDataQualityServiceThresholds:
+    """Tests for threshold checking in DataQualityService."""
+
+    @pytest.mark.asyncio
+    async def test_hard_threshold_exceeded_raises_error(
+        self, mock_logger, mock_metrics, dq_config
+    ):
+        """Test that error rate exceeding hard threshold raises DataQualityThresholdError."""
+        service = DataQualityService(
+            dq_monitor=None,
+            config=dq_config,
+            logger=mock_logger,
+            metrics=mock_metrics,
+            pipeline_name="test_pipeline",
+        )
+
+        # Metrics with 25% error rate (above hard threshold of 20%)
+        metrics = {
+            "record_count": 100.0,
+            "error_rate": 0.25,
+        }
+
+        with pytest.raises(DataQualityThresholdError) as exc_info:
+            await service.evaluate(metrics)
+
+        assert exc_info.value.error_rate == 0.25
+        assert exc_info.value.threshold == 0.20
+        mock_logger.error.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_hard_threshold_exactly_at_limit_raises_error(
+        self, mock_logger, mock_metrics, dq_config
+    ):
+        """Test that error rate exactly at hard threshold raises DataQualityThresholdError."""
+        service = DataQualityService(
+            dq_monitor=None,
+            config=dq_config,
+            logger=mock_logger,
+            metrics=mock_metrics,
+            pipeline_name="test_pipeline",
+        )
+
+        # Metrics with exactly 20% error rate
+        metrics = {
+            "record_count": 100.0,
+            "error_rate": 0.20,
+        }
+
+        with pytest.raises(DataQualityThresholdError):
+            await service.evaluate(metrics)
+
+    @pytest.mark.asyncio
+    async def test_soft_threshold_exceeded_logs_warning_and_emits_metric(
+        self, mock_logger, mock_metrics, dq_config
+    ):
+        """Test that error rate exceeding soft threshold logs warning and emits metric."""
+        service = DataQualityService(
+            dq_monitor=None,
+            config=dq_config,
+            logger=mock_logger,
+            metrics=mock_metrics,
+            pipeline_name="test_pipeline",
+        )
+
+        # Metrics with 10% error rate (above soft 5%, below hard 20%)
+        metrics = {
+            "record_count": 100.0,
+            "error_rate": 0.10,
+        }
+
+        result = await service.evaluate(metrics)
+
+        assert result.status == DQStatus.WARNING
+        assert result.error_rate == 0.10
+        mock_logger.warning.assert_called_once()
+        mock_metrics.increment_counter.assert_called_once_with(
+            "dq_soft_threshold_exceeded",
+            1,
+            {"pipeline": "test_pipeline"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_soft_threshold_exactly_at_limit_logs_warning(
+        self, mock_logger, mock_metrics, dq_config
+    ):
+        """Test that error rate exactly at soft threshold logs warning."""
+        service = DataQualityService(
+            dq_monitor=None,
+            config=dq_config,
+            logger=mock_logger,
+            metrics=mock_metrics,
+            pipeline_name="test_pipeline",
+        )
+
+        # Metrics with exactly 5% error rate
+        metrics = {
+            "record_count": 100.0,
+            "error_rate": 0.05,
+        }
+
+        result = await service.evaluate(metrics)
+
+        assert result.status == DQStatus.WARNING
+        mock_logger.warning.assert_called_once()
+        mock_metrics.increment_counter.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_below_soft_threshold_passes(
+        self, mock_logger, mock_metrics, dq_config
+    ):
+        """Test that error rate below soft threshold passes without warning."""
+        service = DataQualityService(
+            dq_monitor=None,
+            config=dq_config,
+            logger=mock_logger,
+            metrics=mock_metrics,
+            pipeline_name="test_pipeline",
+        )
+
+        # Metrics with 3% error rate (below soft threshold)
+        metrics = {
+            "record_count": 100.0,
+            "error_rate": 0.03,
+        }
+
+        result = await service.evaluate(metrics)
+
+        assert result.status == DQStatus.PASSED
+        assert result.error_rate == 0.03
+        mock_logger.warning.assert_not_called()
+        mock_logger.error.assert_not_called()
+        mock_metrics.increment_counter.assert_not_called()
+
+
+@pytest.mark.unit
+class TestDataQualityServiceGracefulDegradation:
+    """Tests for graceful degradation without dq_monitor."""
+
+    @pytest.mark.asyncio
+    async def test_no_monitor_returns_result_without_anomalies(
+        self, mock_logger, mock_metrics, dq_config
+    ):
+        """Test that without dq_monitor, service returns result without anomalies."""
+        service = DataQualityService(
+            dq_monitor=None,
+            config=dq_config,
+            logger=mock_logger,
+            metrics=mock_metrics,
+            pipeline_name="test_pipeline",
+        )
+
+        metrics = {
+            "record_count": 100.0,
+            "error_rate": 0.03,
+        }
+
+        result = await service.evaluate(metrics)
+
+        assert result.anomalies_count == 0
+        assert result.has_critical is False
+        assert result.check_duration_ms == 0.0
+        assert result.anomalies == ()
+
+    @pytest.mark.asyncio
+    async def test_no_metrics_port_still_logs_warning(
+        self, mock_logger, dq_config
+    ):
+        """Test that soft threshold logs warning even when metrics port is None."""
+        service = DataQualityService(
+            dq_monitor=None,
+            config=dq_config,
+            logger=mock_logger,
+            metrics=None,  # No metrics port
+            pipeline_name="test_pipeline",
+        )
+
+        metrics = {
+            "record_count": 100.0,
+            "error_rate": 0.10,
+        }
+
+        result = await service.evaluate(metrics)
+
+        assert result.status == DQStatus.WARNING
+        mock_logger.warning.assert_called_once()
+
+
+@pytest.mark.unit
+class TestDataQualityServiceAnomalyDetection:
+    """Tests for anomaly detection with dq_monitor."""
+
+    @pytest.mark.asyncio
+    async def test_anomaly_detection_with_no_anomalies(
+        self, mock_logger, mock_metrics, dq_config
+    ):
+        """Test anomaly detection with no anomalies detected."""
+        mock_dq_monitor = MagicMock()
+        mock_dq_monitor.check_quality = MagicMock(return_value=[])
+        mock_dq_monitor.update_baseline_from_metrics = MagicMock()
+
+        service = DataQualityService(
+            dq_monitor=mock_dq_monitor,
+            config=dq_config,
+            logger=mock_logger,
+            metrics=mock_metrics,
+            pipeline_name="test_pipeline",
+        )
+
+        metrics = {
+            "record_count": 100.0,
+            "error_rate": 0.03,
+        }
+
+        result = await service.evaluate(metrics)
+
+        assert result.anomalies_count == 0
+        assert result.has_critical is False
+        mock_dq_monitor.check_quality.assert_called_once_with(metrics)
+        mock_dq_monitor.update_baseline_from_metrics.assert_called_once_with(metrics)
+
+    @pytest.mark.asyncio
+    async def test_anomaly_detection_with_anomalies(
+        self, mock_logger, mock_metrics, dq_config
+    ):
+        """Test anomaly detection with anomalies detected."""
+        from bioetl.infrastructure.observability.anomaly.types import (
+            Anomaly,
+            AnomalySeverity,
+            AnomalyType,
+        )
+
+        anomaly = Anomaly(
+            metric_name="error_rate",
+            current_value=0.15,
+            baseline_mean=0.05,
+            baseline_stddev=0.02,
+            anomaly_type=AnomalyType.SPIKE,
+            severity=AnomalySeverity.HIGH,
+            z_score=5.0,
+            timestamp=datetime.now(UTC),
+            message="Error rate spike detected",
+        )
+
+        mock_dq_monitor = MagicMock()
+        mock_dq_monitor.check_quality = MagicMock(return_value=[anomaly])
+        mock_dq_monitor.update_baseline_from_metrics = MagicMock()
+
+        service = DataQualityService(
+            dq_monitor=mock_dq_monitor,
+            config=dq_config,
+            logger=mock_logger,
+            metrics=mock_metrics,
+            pipeline_name="test_pipeline",
+        )
+
+        metrics = {
+            "record_count": 100.0,
+            "error_rate": 0.03,
+        }
+
+        result = await service.evaluate(metrics)
+
+        assert result.anomalies_count == 1
+        assert result.has_critical is False
+        assert len(result.anomalies) == 1
+        mock_logger.warning.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_anomaly_detection_with_critical_anomaly(
+        self, mock_logger, mock_metrics, dq_config
+    ):
+        """Test anomaly detection with critical anomaly."""
+        from bioetl.infrastructure.observability.anomaly.types import (
+            Anomaly,
+            AnomalySeverity,
+            AnomalyType,
+        )
+
+        critical_anomaly = Anomaly(
+            metric_name="error_rate",
+            current_value=0.50,
+            baseline_mean=0.05,
+            baseline_stddev=0.02,
+            anomaly_type=AnomalyType.THRESHOLD_EXCEEDED,
+            severity=AnomalySeverity.CRITICAL,
+            z_score=22.5,
+            timestamp=datetime.now(UTC),
+            message="Error rate critical",
+        )
+
+        mock_dq_monitor = MagicMock()
+        mock_dq_monitor.check_quality = MagicMock(return_value=[critical_anomaly])
+        mock_dq_monitor.update_baseline_from_metrics = MagicMock()
+
+        service = DataQualityService(
+            dq_monitor=mock_dq_monitor,
+            config=dq_config,
+            logger=mock_logger,
+            metrics=mock_metrics,
+            pipeline_name="test_pipeline",
+        )
+
+        metrics = {
+            "record_count": 100.0,
+            "error_rate": 0.03,
+        }
+
+        result = await service.evaluate(metrics)
+
+        assert result.anomalies_count == 1
+        assert result.has_critical is True
+        mock_logger.error.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_check_duration_metric_emitted(
+        self, mock_logger, mock_metrics, dq_config
+    ):
+        """Test that check duration metric is emitted."""
+        mock_dq_monitor = MagicMock()
+        mock_dq_monitor.check_quality = MagicMock(return_value=[])
+        mock_dq_monitor.update_baseline_from_metrics = MagicMock()
+
+        service = DataQualityService(
+            dq_monitor=mock_dq_monitor,
+            config=dq_config,
+            logger=mock_logger,
+            metrics=mock_metrics,
+            pipeline_name="test_pipeline",
+        )
+
+        metrics = {
+            "record_count": 100.0,
+            "error_rate": 0.03,
+        }
+
+        result = await service.evaluate(metrics)
+
+        assert result.check_duration_ms >= 0
+        mock_metrics.observe_histogram.assert_called_once()
+        call_args = mock_metrics.observe_histogram.call_args
+        assert call_args[0][0] == "dq_check_duration_ms"
+
+
+@pytest.mark.unit
+class TestDataQualityServiceBaselineUpdates:
+    """Tests for baseline update logic."""
+
+    @pytest.mark.asyncio
+    async def test_baseline_updated_counter_incremented(
+        self, mock_logger, mock_metrics, dq_config
+    ):
+        """Test that baseline update counter is incremented for each metric."""
+        mock_dq_monitor = MagicMock()
+        mock_dq_monitor.check_quality = MagicMock(return_value=[])
+        mock_dq_monitor.update_baseline_from_metrics = MagicMock()
+
+        service = DataQualityService(
+            dq_monitor=mock_dq_monitor,
+            config=dq_config,
+            logger=mock_logger,
+            metrics=mock_metrics,
+            pipeline_name="test_pipeline",
+        )
+
+        metrics = {
+            "record_count": 100.0,
+            "error_rate": 0.03,
+            "silver_yield": 0.95,
+        }
+
+        await service.evaluate(metrics)
+
+        # Should be called 3 times, once per metric
+        baseline_calls = [
+            call
+            for call in mock_metrics.increment_counter.call_args_list
+            if call[0][0] == "dq_baseline_updated"
+        ]
+        assert len(baseline_calls) == 3
+
+    @pytest.mark.asyncio
+    async def test_baseline_not_updated_on_critical_anomaly(
+        self, mock_logger, mock_metrics, dq_config
+    ):
+        """Test that baseline is not updated when critical anomaly detected."""
+        from bioetl.infrastructure.observability.anomaly.types import (
+            Anomaly,
+            AnomalySeverity,
+            AnomalyType,
+        )
+
+        critical_anomaly = Anomaly(
+            metric_name="error_rate",
+            current_value=0.50,
+            baseline_mean=0.05,
+            baseline_stddev=0.02,
+            anomaly_type=AnomalyType.THRESHOLD_EXCEEDED,
+            severity=AnomalySeverity.CRITICAL,
+            z_score=22.5,
+            timestamp=datetime.now(UTC),
+            message="Error rate critical",
+        )
+
+        mock_dq_monitor = MagicMock()
+        mock_dq_monitor.check_quality = MagicMock(return_value=[critical_anomaly])
+        mock_dq_monitor.update_baseline_from_metrics = MagicMock()
+
+        service = DataQualityService(
+            dq_monitor=mock_dq_monitor,
+            config=dq_config,
+            logger=mock_logger,
+            metrics=mock_metrics,
+            pipeline_name="test_pipeline",
+        )
+
+        metrics = {
+            "record_count": 100.0,
+            "error_rate": 0.03,
+        }
+
+        await service.evaluate(metrics)
+
+        # dq_baseline_updated should NOT be called
+        baseline_calls = [
+            call
+            for call in mock_metrics.increment_counter.call_args_list
+            if call[0][0] == "dq_baseline_updated"
+        ]
+        assert len(baseline_calls) == 0
+
+
+@pytest.mark.unit
+class TestDQResult:
+    """Tests for DQResult dataclass."""
+
+    def test_dq_result_creation(self):
+        """Test DQResult creation with all fields."""
+        result = DQResult(
+            error_rate=0.05,
+            status=DQStatus.WARNING,
+            anomalies=(),
+            has_critical=False,
+            check_duration_ms=123.45,
+        )
+
+        assert result.error_rate == 0.05
+        assert result.status == DQStatus.WARNING
+        assert result.anomalies == ()
+        assert result.has_critical is False
+        assert result.check_duration_ms == 123.45
+
+    def test_dq_result_list_to_tuple_conversion(self):
+        """Test that DQResult converts list anomalies to tuple."""
+        result = DQResult(
+            error_rate=0.05,
+            status=DQStatus.PASSED,
+            anomalies=["anomaly1", "anomaly2"],  # type: ignore
+        )
+
+        assert isinstance(result.anomalies, tuple)
+        assert result.anomalies == ("anomaly1", "anomaly2")
+
+    def test_dq_result_properties(self):
+        """Test DQResult property methods."""
+        passed = DQResult(error_rate=0.01, status=DQStatus.PASSED)
+        warning = DQResult(error_rate=0.10, status=DQStatus.WARNING)
+        failed = DQResult(error_rate=0.25, status=DQStatus.FAILED)
+
+        assert passed.is_passed is True
+        assert passed.is_warning is False
+        assert passed.is_failed is False
+
+        assert warning.is_passed is False
+        assert warning.is_warning is True
+        assert warning.is_failed is False
+
+        assert failed.is_passed is False
+        assert failed.is_warning is False
+        assert failed.is_failed is True
+
+    def test_dq_result_anomalies_count(self):
+        """Test anomalies_count property."""
+        result = DQResult(
+            error_rate=0.05,
+            status=DQStatus.PASSED,
+            anomalies=("a", "b", "c"),
+        )
+
+        assert result.anomalies_count == 3
+
+
+@pytest.mark.unit
+class TestDQStatus:
+    """Tests for DQStatus enum."""
+
+    def test_status_values(self):
+        """Test DQStatus enum values."""
+        assert DQStatus.PASSED.value == "passed"
+        assert DQStatus.WARNING.value == "warning"
+        assert DQStatus.FAILED.value == "failed"
+
+    def test_status_is_string(self):
+        """Test that DQStatus is a string enum."""
+        assert isinstance(DQStatus.PASSED, str)
+        assert DQStatus.PASSED == "passed"


### PR DESCRIPTION
Extract data quality logic from PostrunService into dedicated DataQualityService following Single Responsibility Principle.

Changes:
- Create DataQualityService with DQ threshold checks and anomaly detection
- Create DQResult and DQStatus value objects in domain layer
- Simplify PostrunService to delegate DQ checks to DataQualityService
- Add PostrunResult for combined DQ and VACUUM results
- Update Composition Root to inject DataQualityService
- Add comprehensive unit tests for DataQualityService

PostrunService reduced from ~340 to ~180 lines.
DQ logic is now isolated and independently testable.