### PR TITLE
Unify domain terminology Work to Publication

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -13,7 +13,7 @@ This glossary defines the canonical terminology used throughout BioETL. Followin
 | **Activity** | ChEMBL: Activity | Bioactivity measurement |
 | **Molecule** | ChEMBL: Molecule, PubChem: Compound | Chemical compound |
 | **Target** | ChEMBL: Target, UniProt: Protein | Biological target |
-| **Publication** | PubMed: Publication, ChEMBL: Document, Crossref: Work | Scientific document |
+| **Publication** | PubMed: Publication, ChEMBL: Document, CrossRef: Publication | Scientific document |
 
 ---
 
@@ -51,9 +51,10 @@ This glossary defines the canonical terminology used throughout BioETL. Followin
 
 | Canonical Term | Definition | Provider-Specific Names | Avoid |
 |----------------|------------|------------------------|-------|
-| **Publication** | A scientific document (article, patent, etc.) | PubMed: `Publication` | `paper`, `article` (as class names) |
+| **Publication** | A scientific document (article, patent, etc.) | PubMed: `Publication`, CrossRef: `PublicationEntity` | `paper`, `article` (as class names), `Work` (deprecated CrossRef API term) |
 | **Document** | ChEMBL's representation of a source document | ChEMBL: `Document` | `reference`, `source` |
-| **Work** | Crossref's representation of a scholarly work | Crossref: `Work` | `record` |
+
+**Note**: CrossRef's API uses the term "Work" but our codebase uses "Publication" as the canonical term for Ubiquitous Language. The deprecated alias `Work` is kept for backward compatibility.
 
 ---
 
@@ -174,11 +175,11 @@ This glossary defines the canonical terminology used throughout BioETL. Followin
 |------|-----|-------------|
 | `Publication` | E-utilities | Article metadata |
 
-### Crossref
+### CrossRef
 
 | Term | API Endpoint | Description |
 |------|-------------|-------------|
-| `Work` | `/works` | Scholarly work metadata |
+| `Publication` | `/works` | Scholarly publication metadata (API uses "works", codebase uses "publication") |
 
 ---
 
@@ -195,6 +196,9 @@ These terms should NOT be used in new code:
 | `data_point` | `record` | Generic term |
 | `Loader` | `Adapter` (for input), `Writer` (for output) | Vague technical term |
 | `Handler` | Specific name (e.g., `Manager`, `Service`) | Vague technical term |
+| `Work` | `Publication` | CrossRef API term → Ubiquitous Language |
+| `WorkSchema` | `PublicationSchema` | CrossRef schema naming |
+| `CrossRefWorkRecord` | `CrossRefPublicationRecord` | CrossRef model naming |
 
 ---
 

--- a/src/bioetl/domain/entities/crossref.py
+++ b/src/bioetl/domain/entities/crossref.py
@@ -66,8 +66,10 @@ class PublicationRecord(BaseModel):
     doi: str = PydanticField(description="Digital Object Identifier (normalized)")
 
     # Core metadata
-    title: str | None = PydanticField(default=None, description="Work title")
-    abstract: str | None = PydanticField(default=None, description="Work abstract")
+    title: str | None = PydanticField(default=None, description="Publication title")
+    abstract: str | None = PydanticField(
+        default=None, description="Publication abstract"
+    )
 
     # Authors (list of "given family" formatted names)
     authors: list[str] = PydanticField(

--- a/src/bioetl/domain/schemas/crossref/__init__.py
+++ b/src/bioetl/domain/schemas/crossref/__init__.py
@@ -1,8 +1,26 @@
 """CrossRef Pandera schemas.
 
 Contains validation schemas for CrossRef data entities.
+
+Terminology:
+- Uses "Publication" instead of CrossRef API term "Work" for Ubiquitous Language
+- WorkSchema and WORK_TYPES are kept as deprecated aliases for backward compatibility
 """
 
 from bioetl.domain.schemas.crossref.publication import PublicationEnrichedSchema
+from bioetl.domain.schemas.crossref.work import (
+    PUBLICATION_TYPES,
+    WORK_TYPES,  # Deprecated alias
+    PublicationSchema,
+    WorkSchema,  # Deprecated alias
+)
 
-__all__ = ["PublicationEnrichedSchema"]
+__all__ = [
+    # Main schemas
+    "PublicationEnrichedSchema",
+    "PublicationSchema",
+    "PUBLICATION_TYPES",
+    # Deprecated aliases (backward compatibility)
+    "WorkSchema",
+    "WORK_TYPES",
+]

--- a/src/bioetl/domain/schemas/crossref/author.py
+++ b/src/bioetl/domain/schemas/crossref/author.py
@@ -1,7 +1,10 @@
 """Pandera schema for CrossRef Author entity.
 
 Aligned with RULES.md v5.0 and CrossRef REST API.
-Represents authors from the "author" field in Works API response.
+Represents authors from the "author" field in Publications API response.
+
+Terminology:
+- Uses "Publication" instead of CrossRef API term "Work" for Ubiquitous Language
 """
 
 from __future__ import annotations
@@ -18,7 +21,7 @@ AUTHOR_SEQUENCES = ["first", "additional"]
 class AuthorSchema(ETLRecordSchema):
     """CrossRef Author validation schema for Silver layer.
 
-    Represents an author of a CrossRef Work (1:N relationship).
+    Represents an author of a CrossRef Publication (1:N relationship).
     Composite PK: (doi, author_sequence)
     """
 
@@ -26,7 +29,7 @@ class AuthorSchema(ETLRecordSchema):
     doi: Series[str] = pa.Field(
         nullable=False,
         str_matches=r"^10\.\d{4,}/.*$",
-        description="FK to Work.doi",
+        description="FK to Publication.doi",
     )
 
     # === Composite Primary Key Component ===

--- a/src/bioetl/domain/schemas/crossref/funder.py
+++ b/src/bioetl/domain/schemas/crossref/funder.py
@@ -1,8 +1,11 @@
 """Pandera schema for CrossRef Funder entity.
 
 Aligned with RULES.md v5.0 and CrossRef REST API.
-Represents funders from the "funder" field in Works API response.
+Represents funders from the "funder" field in Publications API response.
 Integrates with CrossRef Funder Registry (DOI prefix: 10.13039/).
+
+Terminology:
+- Uses "Publication" instead of CrossRef API term "Work" for Ubiquitous Language
 """
 
 from __future__ import annotations
@@ -16,7 +19,7 @@ from bioetl.domain.schemas.base import ETLRecordSchema
 class FunderSchema(ETLRecordSchema):
     """CrossRef Funder validation schema for Silver layer.
 
-    Represents a funder of a CrossRef Work (1:N relationship).
+    Represents a funder of a CrossRef Publication (1:N relationship).
     Composite PK: (doi, funder_sequence)
     """
 
@@ -24,7 +27,7 @@ class FunderSchema(ETLRecordSchema):
     doi: Series[str] = pa.Field(
         nullable=False,
         str_matches=r"^10\.\d{4,}/.*$",
-        description="FK to Work.doi",
+        description="FK to Publication.doi",
     )
 
     # === Composite Primary Key Component ===

--- a/src/bioetl/domain/schemas/crossref/reference.py
+++ b/src/bioetl/domain/schemas/crossref/reference.py
@@ -1,7 +1,10 @@
 """Pandera schema for CrossRef Reference entity.
 
 Aligned with RULES.md v5.0 and CrossRef REST API.
-Represents bibliographic references from the "reference" field in Works API response.
+Represents bibliographic references from the "reference" field in Publications API response.
+
+Terminology:
+- Uses "Publication" instead of CrossRef API term "Work" for Ubiquitous Language
 """
 
 from __future__ import annotations
@@ -15,7 +18,7 @@ from bioetl.domain.schemas.base import ETLRecordSchema
 class ReferenceSchema(ETLRecordSchema):
     """CrossRef Reference validation schema for Silver layer.
 
-    Represents a bibliographic reference in a CrossRef Work (1:N relationship).
+    Represents a bibliographic reference in a CrossRef Publication (1:N relationship).
     Composite PK: (source_doi, reference_key)
     """
 
@@ -23,21 +26,21 @@ class ReferenceSchema(ETLRecordSchema):
     source_doi: Series[str] = pa.Field(
         nullable=False,
         str_matches=r"^10\.\d{4,}/.*$",
-        description="DOI of citing work (FK to Work.doi)",
+        description="DOI of citing publication (FK to Publication.doi)",
     )
 
     # === Composite Primary Key Component ===
     reference_key: Series[str] = pa.Field(
         nullable=False,
         str_length={"min_value": 1},
-        description="Unique reference key within source work",
+        description="Unique reference key within source publication",
     )
 
     # === Target Reference ===
     target_doi: Series[str] | None = pa.Field(
         nullable=True,
         str_matches=r"^10\.\d{4,}/.*$",
-        description="DOI of cited work (if resolved)",
+        description="DOI of cited publication (if resolved)",
     )
     unstructured: Series[str] | None = pa.Field(
         nullable=True, description="Unstructured citation string"

--- a/src/bioetl/infrastructure/adapters/crossref/client.py
+++ b/src/bioetl/infrastructure/adapters/crossref/client.py
@@ -80,14 +80,14 @@ class CrossRefAdapter(BaseHttpAdapter):
             "Accept": "application/json",
         }
 
-    async def _fetch_single_work(self, doi: str) -> dict[str, Any] | None:
-        """Fetch a single work by DOI.
+    async def _fetch_single_publication(self, doi: str) -> dict[str, Any] | None:
+        """Fetch a single publication by DOI.
 
         Args:
             doi: The DOI to fetch (will be normalized).
 
         Returns:
-            Work record or None if not found.
+            Publication record or None if not found.
 
         Raises:
             CrossRefApiError: On API errors (non-404).
@@ -116,8 +116,8 @@ class CrossRefAdapter(BaseHttpAdapter):
                 )
 
             data = response.json()
-            work: dict[str, Any] = data.get("message", {})
-            return work
+            publication: dict[str, Any] = data.get("message", {})
+            return publication
 
         except CrossRefApiError:
             raise
@@ -140,14 +140,14 @@ class CrossRefAdapter(BaseHttpAdapter):
             dois: List of DOIs to fetch individually.
 
         Yields:
-            Work records for successfully fetched DOIs.
+            Publication records for successfully fetched DOIs.
 
         """
         for doi in dois:
             try:
-                work = await self._fetch_single_work(doi)
-                if work:
-                    yield work
+                publication = await self._fetch_single_publication(doi)
+                if publication:
+                    yield publication
             except Exception as e:
                 self.logger.debug(
                     "crossref_individual_fetch_failed",
@@ -155,10 +155,10 @@ class CrossRefAdapter(BaseHttpAdapter):
                     error=str(e),
                 )
 
-    async def _fetch_batch_works(
+    async def _fetch_batch_publications(
         self, dois: list[str]
     ) -> AsyncIterator[dict[str, Any]]:
-        """Fetch multiple works by DOI batch.
+        """Fetch multiple publications by DOI batch.
 
         Uses CrossRef filter endpoint for batch resolution.
 
@@ -166,7 +166,7 @@ class CrossRefAdapter(BaseHttpAdapter):
             dois: List of DOIs to fetch (max 100).
 
         Yields:
-            Work records for found DOIs.
+            Publication records for found DOIs.
 
         """
         if not dois:
@@ -194,8 +194,8 @@ class CrossRefAdapter(BaseHttpAdapter):
                     status_code=response.status_code,
                     doi_count=len(dois),
                 )
-                async for work in self._fallback_individual_fetch(dois):
-                    yield work
+                async for publication in self._fallback_individual_fetch(dois):
+                    yield publication
                 return
 
             data = response.json()
@@ -209,8 +209,8 @@ class CrossRefAdapter(BaseHttpAdapter):
                 error=str(e),
                 doi_count=len(dois),
             )
-            async for work in self._fallback_individual_fetch(dois):
-                yield work
+            async for publication in self._fallback_individual_fetch(dois):
+                yield publication
 
     async def _fetch_search_page(
         self,
@@ -276,13 +276,13 @@ class CrossRefAdapter(BaseHttpAdapter):
             return False
         return bool(next_cursor and next_cursor != current_cursor)
 
-    async def _search_works(
+    async def _search_publications(
         self,
         query: str,
         limit: int | None = None,
         cursor: str = "*",
     ) -> AsyncIterator[dict[str, Any]]:
-        """Search for works using cursor-based pagination.
+        """Search for publications using cursor-based pagination.
 
         Args:
             query: Search query string.
@@ -290,7 +290,7 @@ class CrossRefAdapter(BaseHttpAdapter):
             cursor: Pagination cursor (* for first page).
 
         Yields:
-            Work records matching the query.
+            Publication records matching the query.
 
         """
         rows = min(limit, 100) if limit else 100
@@ -323,7 +323,7 @@ class CrossRefAdapter(BaseHttpAdapter):
         filter_field: str,
         limit: int | None = None,
     ) -> AsyncIterator[dict[str, Any]]:
-        """Fetch CrossRef works by DOI list (batch resolution).
+        """Fetch CrossRef publications by DOI list (batch resolution).
 
         Implements FilterableDataSourcePort.fetch_filtered().
 
@@ -334,7 +334,7 @@ class CrossRefAdapter(BaseHttpAdapter):
             limit: Maximum number of records to fetch.
 
         Yields:
-            Dictionary records for each resolved work.
+            Dictionary records for each resolved publication.
 
         Raises:
             ValueError: If entity_type is not 'work' or 'publication'.
@@ -358,8 +358,8 @@ class CrossRefAdapter(BaseHttpAdapter):
         # Process DOIs in batches (max 100 per request)
         for i in range(0, len(dois), self.batch_size):
             batch = dois[i : i + self.batch_size]
-            async for work in self._fetch_batch_works(batch):
-                yield work
+            async for publication in self._fetch_batch_publications(batch):
+                yield publication
                 fetched += 1
                 if limit and fetched >= limit:
                     return
@@ -372,7 +372,7 @@ class CrossRefAdapter(BaseHttpAdapter):
         filter_ids: list[str] | None = None,
         filter_field: str | None = None,
     ) -> AsyncIterator[dict[str, Any]]:
-        """Fetch CrossRef works.
+        """Fetch CrossRef publications.
 
         Implements DataSourcePort.fetch().
 
@@ -393,10 +393,10 @@ class CrossRefAdapter(BaseHttpAdapter):
         """
         if filter_ids:
             effective_filter_field = filter_field or "doi"
-            async for work in self.fetch_filtered(
+            async for publication in self.fetch_filtered(
                 entity_type, filter_ids, effective_filter_field, limit
             ):
-                yield work
+                yield publication
             return
 
         if entity_type not in ("work", "publication"):
@@ -409,8 +409,8 @@ class CrossRefAdapter(BaseHttpAdapter):
                 "CrossRef requires either filter_ids (DOIs) or query parameter"
             )
 
-        async for work in self._search_works(query, limit):
-            yield work
+        async for publication in self._search_publications(query, limit):
+            yield publication
 
     async def _probe_health(self) -> HealthStatus:
         """Probe CrossRef API health. Returns DEGRADED if response >5 sec."""

--- a/src/bioetl/infrastructure/adapters/crossref/models.py
+++ b/src/bioetl/infrastructure/adapters/crossref/models.py
@@ -154,13 +154,17 @@ class CrossRefDateParts(BaseModel):
     )
 
 
-# === Work Record Model ===
+# === Publication Record Model ===
 
 
-class CrossRefWorkRecord(BaseModel):
-    """Individual work record from CrossRef API.
+class CrossRefPublicationRecord(BaseModel):
+    """Individual publication record from CrossRef API.
 
-    Represents a publication (article, book, dataset, etc.) with DOI.
+    Represents a scholarly publication (article, book, dataset, etc.) with DOI.
+
+    Terminology:
+    - Uses "Publication" instead of CrossRef API term "Work" for Ubiquitous Language
+    - Business analysts can understand the model without knowing CrossRef API specifics
     """
 
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
@@ -168,12 +172,16 @@ class CrossRefWorkRecord(BaseModel):
     # Primary Identifier
     doi: str = Field(alias="DOI", description="Digital Object Identifier")
 
-    # Type
-    type: str = Field(description="Work type (journal-article, book-chapter, etc.)")
-    subtype: str | None = Field(default=None, description="Work subtype")
+    # Type (CrossRef API type field - kept as-is for API compatibility)
+    type: str = Field(
+        description="Publication type (journal-article, book-chapter, etc.)"
+    )
+    subtype: str | None = Field(default=None, description="Publication subtype")
 
     # Titles
-    title: list[str] | None = Field(default_factory=list, description="Work titles")
+    title: list[str] | None = Field(
+        default_factory=list, description="Publication titles"
+    )
     subtitle: list[str] | None = Field(default_factory=list, description="Subtitles")
     short_title: list[str] | None = Field(
         default_factory=list, alias="short-title", description="Short titles"
@@ -343,13 +351,13 @@ class CrossRefMessage(BaseModel):
     )
 
     # Items (for list responses)
-    items: list[CrossRefWorkRecord] | None = Field(
-        default_factory=list, description="Work records"
+    items: list[CrossRefPublicationRecord] | None = Field(
+        default_factory=list, description="Publication records"
     )
 
 
-class CrossRefWorksResponse(BaseModel):
-    """Complete CrossRef works API response (list endpoint)."""
+class CrossRefPublicationsResponse(BaseModel):
+    """Complete CrossRef publications API response (list endpoint)."""
 
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
@@ -361,8 +369,8 @@ class CrossRefWorksResponse(BaseModel):
     message: CrossRefMessage = Field(description="Response message")
 
 
-class CrossRefWorkResponse(BaseModel):
-    """Complete CrossRef work API response (single work endpoint)."""
+class CrossRefPublicationResponse(BaseModel):
+    """Complete CrossRef publication API response (single publication endpoint)."""
 
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
@@ -371,12 +379,24 @@ class CrossRefWorkResponse(BaseModel):
     message_version: str | None = Field(
         default=None, alias="message-version", description="API version"
     )
-    message: CrossRefWorkRecord = Field(description="Work record")
+    message: CrossRefPublicationRecord = Field(description="Publication record")
+
+
+# === Deprecated Aliases (backward compatibility) ===
+
+CrossRefWorkRecord = CrossRefPublicationRecord
+"""Deprecated: Use CrossRefPublicationRecord instead."""
+
+CrossRefWorksResponse = CrossRefPublicationsResponse
+"""Deprecated: Use CrossRefPublicationsResponse instead."""
+
+CrossRefWorkResponse = CrossRefPublicationResponse
+"""Deprecated: Use CrossRefPublicationResponse instead."""
 
 
 # === Record Type Mapping ===
 
 CROSSREF_RECORD_MODELS: dict[str, type[BaseModel]] = {
-    "work": CrossRefWorkRecord,
-    "publication": CrossRefWorkRecord,
+    "work": CrossRefPublicationRecord,
+    "publication": CrossRefPublicationRecord,
 }

--- a/tests/architecture/test_code_metrics.py
+++ b/tests/architecture/test_code_metrics.py
@@ -241,7 +241,7 @@ class TestFunctionLength:
         "_clear_exports_legacy": 70,
         "create_logger": 55,  # Logger setup with many handlers
         "vacuum_all_command": 90,  # CLI command with multiple suboperations
-        "_fetch_batch_works": 75,  # CrossRef batch DOI resolution with fallback
+        "_fetch_batch_publications": 75,  # CrossRef batch DOI resolution with fallback
         # Extracted validators (REFACTOR-003)
         "validate_medallion_config": 55,  # MedallionConfigValidator method
         "validate_write_modes": 75,  # MedallionConfigValidator method with multiple checks

--- a/tests/unit/application/pipelines/crossref/test_crossref_transformer.py
+++ b/tests/unit/application/pipelines/crossref/test_crossref_transformer.py
@@ -37,8 +37,8 @@ def pipeline_context(noop_logger):
 
 
 @pytest.fixture
-def sample_work():
-    """Create a sample CrossRef work response."""
+def sample_publication():
+    """Create a sample CrossRef publication response."""
     return {
         "DOI": "10.1234/test.article",
         "title": ["Test Article Title"],
@@ -66,8 +66,8 @@ def sample_work():
 
 
 @pytest.fixture
-def minimal_work():
-    """Create a minimal CrossRef work response."""
+def minimal_publication():
+    """Create a minimal CrossRef publication response."""
     return {
         "DOI": "10.5678/minimal",
         "type": "posted-content",
@@ -85,21 +85,21 @@ def test_normalize_doi():
     assert normalize_doi("  10.1234/test  ") == "10.1234/test"
 
 
-def test_extract_title(sample_work):
+def test_extract_title(sample_publication):
     """Test title extraction using domain function."""
-    assert extract_first_string(sample_work.get("title", [])) == "Test Article Title"
+    assert extract_first_string(sample_publication.get("title", [])) == "Test Article Title"
     assert extract_first_string([]) is None
 
 
-def test_extract_authors(transformer, sample_work):
+def test_extract_authors(transformer, sample_publication):
     """Test author extraction (CrossRef-specific logic)."""
-    authors = transformer._extract_authors(sample_work)
+    authors = transformer._extract_authors(sample_publication)
     assert authors == ["John Doe", "Jane Smith", "Anonymous"]
 
 
-def test_extract_year(transformer, sample_work):
+def test_extract_year(transformer, sample_publication):
     """Test year extraction (CrossRef-specific logic)."""
-    assert transformer._extract_year(sample_work) == 2023
+    assert transformer._extract_year(sample_publication) == 2023
     assert transformer._extract_year({}) is None
 
 
@@ -115,9 +115,9 @@ def test_map_doc_type():
 # =============================================================================
 
 
-def test_extract_business_data_full(transformer, sample_work):
+def test_extract_business_data_full(transformer, sample_publication):
     """Test extracting business data from full work record."""
-    data = transformer._extract_business_data(sample_work)
+    data = transformer._extract_business_data(sample_publication)
 
     assert data["doi"] == "10.1234/test.article"
     assert data["title"] == "Test Article Title"
@@ -130,9 +130,9 @@ def test_extract_business_data_full(transformer, sample_work):
     assert data["source"] == "crossref"
 
 
-def test_extract_business_data_minimal(transformer, minimal_work):
+def test_extract_business_data_minimal(transformer, minimal_publication):
     """Test extracting business data from minimal work record."""
-    data = transformer._extract_business_data(minimal_work)
+    data = transformer._extract_business_data(minimal_publication)
 
     assert data["doi"] == "10.5678/minimal"
     assert data["title"] is None
@@ -146,9 +146,9 @@ def test_extract_business_data_minimal(transformer, minimal_work):
 
 
 @pytest.mark.asyncio
-async def test_transform_full_record(transformer, pipeline_context, sample_work):
+async def test_transform_full_record(transformer, pipeline_context, sample_publication):
     """Test transforming full work record to SilverRecord."""
-    result = await transformer.transform(pipeline_context, sample_work, index=0)
+    result = await transformer.transform(pipeline_context, sample_publication, index=0)
 
     assert result is not None
     assert result["doi"] == "10.1234/test.article"
@@ -163,9 +163,9 @@ async def test_transform_full_record(transformer, pipeline_context, sample_work)
 
 
 @pytest.mark.asyncio
-async def test_transform_minimal_record(transformer, pipeline_context, minimal_work):
+async def test_transform_minimal_record(transformer, pipeline_context, minimal_publication):
     """Test transforming minimal work record to SilverRecord."""
-    result = await transformer.transform(pipeline_context, minimal_work, index=1)
+    result = await transformer.transform(pipeline_context, minimal_publication, index=1)
 
     assert result is not None
     assert result["doi"] == "10.5678/minimal"

--- a/tests/unit/infrastructure/adapters/crossref/test_crossref_client.py
+++ b/tests/unit/infrastructure/adapters/crossref/test_crossref_client.py
@@ -199,13 +199,13 @@ async def test_health_check_returns_degraded_on_slow_response(
 
 
 # =============================================================================
-# Fetch single work tests
+# Fetch single publication tests
 # =============================================================================
 
 
 @pytest.mark.asyncio
-async def test_fetch_single_work_success(adapter, mock_http_client):
-    """Test successful single work fetch."""
+async def test_fetch_single_publication_success(adapter, mock_http_client):
+    """Test successful single publication fetch."""
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_response.json.return_value = {
@@ -216,34 +216,34 @@ async def test_fetch_single_work_success(adapter, mock_http_client):
     }
     mock_http_client.get = AsyncMock(return_value=mock_response)
 
-    result = await adapter._fetch_single_work("10.1234/test")
+    result = await adapter._fetch_single_publication("10.1234/test")
 
     assert result is not None
     assert result["DOI"] == "10.1234/test"
 
 
 @pytest.mark.asyncio
-async def test_fetch_single_work_not_found(adapter, mock_http_client, mock_logger):
+async def test_fetch_single_publication_not_found(adapter, mock_http_client, mock_logger):
     """Test fetch returns None for 404."""
     mock_response = MagicMock()
     mock_response.status_code = 404
     mock_http_client.get = AsyncMock(return_value=mock_response)
 
-    result = await adapter._fetch_single_work("10.1234/nonexistent")
+    result = await adapter._fetch_single_publication("10.1234/nonexistent")
 
     assert result is None
     mock_logger.debug.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_fetch_single_work_api_error(adapter, mock_http_client):
+async def test_fetch_single_publication_api_error(adapter, mock_http_client):
     """Test fetch raises CrossRefApiError on non-200/404."""
     mock_response = MagicMock()
     mock_response.status_code = 500
     mock_http_client.get = AsyncMock(return_value=mock_response)
 
     with pytest.raises(CrossRefApiError):
-        await adapter._fetch_single_work("10.1234/test")
+        await adapter._fetch_single_publication("10.1234/test")
 
 
 # =============================================================================


### PR DESCRIPTION
Ubiquitous Language compliance: Replace CrossRef API term "Work" with "Publication" across codebase for consistent domain terminology.

Changes:
- Domain entities: Update PublicationRecord/PublicationEntity field descriptions
- Infrastructure: Rename CrossRefWorkRecord → CrossRefPublicationRecord
- Adapters: Rename internal methods (_fetch_single_work → _fetch_single_publication)
- Schemas: Update docstrings to use "Publication" terminology
- Tests: Update fixture names and test function names
- Documentation: Update glossary with terminology guidance

Backward compatibility preserved via deprecated aliases:
- Work = PublicationEntity
- WorkSchema = PublicationSchema
- CrossRefWorkRecord = CrossRefPublicationRecord

The model remains flat per RULES.md §8.2.2 requirements.