### PR TITLE
Create universal run-all command for data sources

### DIFF
--- a/src/bioetl/interfaces/cli/commands/run_all.py
+++ b/src/bioetl/interfaces/cli/commands/run_all.py
@@ -1,0 +1,411 @@
+"""Run-all command for executing all pipelines for a specific provider.
+
+Provides a universal command to run all pipelines for a given source (provider),
+replacing the need for hardcoded provider-specific commands.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import warnings
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import click
+
+from bioetl.application.services import (
+    PipelineNotFoundError,
+    RunOptions,
+    RunResult,
+    RunStatus,
+)
+from bioetl.composition.entrypoints import get_pipeline_runner_service
+from bioetl.composition.registry import get_default_registry
+from bioetl.interfaces.cli.exit_codes import ExitCode
+from bioetl.interfaces.cli.formatters import echo_error, echo_info, echo_warning
+
+if TYPE_CHECKING:
+    from bioetl.application.services import PipelineRunnerService
+
+
+@dataclass
+class BatchRunResult:
+    """Result of running multiple pipelines.
+
+    Attributes:
+        total: Total number of pipelines.
+        succeeded: Number of successful runs.
+        failed: Number of failed runs.
+        skipped: Number of skipped runs (dry-run or shutdown).
+        results: List of individual run results.
+        failed_pipelines: Names of pipelines that failed.
+    """
+
+    total: int = 0
+    succeeded: int = 0
+    failed: int = 0
+    skipped: int = 0
+    results: list[RunResult] = field(default_factory=list)
+    failed_pipelines: list[str] = field(default_factory=list)
+
+    @property
+    def all_succeeded(self) -> bool:
+        """Check if all pipelines succeeded."""
+        return self.failed == 0 and self.total > 0
+
+
+def _get_available_providers() -> list[str]:
+    """Get list of available providers from registered pipelines.
+
+    Returns:
+        Sorted list of unique provider names.
+    """
+    registry = get_default_registry()
+    pipelines = registry.list_pipelines()
+    providers = set()
+    for pipeline in pipelines:
+        if "_" in pipeline:
+            provider = pipeline.split("_")[0]
+            providers.add(provider)
+    return sorted(providers)
+
+
+def _filter_pipelines_by_provider(provider: str) -> list[str]:
+    """Filter registered pipelines by provider prefix.
+
+    Args:
+        provider: Provider name (e.g., 'chembl', 'pubchem').
+
+    Returns:
+        List of pipeline names matching the provider.
+    """
+    registry = get_default_registry()
+    all_pipelines = registry.list_pipelines()
+    return sorted([
+        name for name in all_pipelines
+        if name.startswith(f"{provider}_")
+    ])
+
+
+def _validate_provider(provider: str) -> tuple[bool, str | None]:
+    """Validate that the provider has registered pipelines.
+
+    Args:
+        provider: Provider name to validate.
+
+    Returns:
+        Tuple of (is_valid, error_message).
+    """
+    available_providers = _get_available_providers()
+    if not available_providers:
+        return False, "No pipelines are registered."
+
+    pipelines = _filter_pipelines_by_provider(provider)
+    if not pipelines:
+        return False, (
+            f"No pipelines found for provider '{provider}'. "
+            f"Available providers: {', '.join(available_providers)}"
+        )
+
+    return True, None
+
+
+async def _run_pipeline_async(
+    service: PipelineRunnerService,
+    pipeline: str,
+    options: RunOptions,
+) -> RunResult:
+    """Run a single pipeline asynchronously.
+
+    Args:
+        service: Pipeline runner service.
+        pipeline: Pipeline name.
+        options: Run options.
+
+    Returns:
+        RunResult with execution status.
+    """
+    return await service.run(pipeline, options=options)
+
+
+async def _run_all_pipelines_async(
+    pipelines: list[str],
+    options: RunOptions,
+) -> BatchRunResult:
+    """Run all pipelines sequentially.
+
+    Args:
+        pipelines: List of pipeline names to run.
+        options: Run options.
+
+    Returns:
+        BatchRunResult with aggregated results.
+    """
+    service = get_pipeline_runner_service()
+    batch_result = BatchRunResult(total=len(pipelines))
+
+    for pipeline in pipelines:
+        try:
+            result = await _run_pipeline_async(service, pipeline, options)
+            batch_result.results.append(result)
+
+            if result.status == RunStatus.SUCCESS:
+                batch_result.succeeded += 1
+                echo_info(f"✓ {pipeline}: completed successfully")
+            elif result.status == RunStatus.DRY_RUN:
+                batch_result.skipped += 1
+                echo_info(f"○ {pipeline}: dry-run (no changes)")
+            elif result.status == RunStatus.SHUTDOWN:
+                batch_result.skipped += 1
+                echo_warning(f"⊘ {pipeline}: gracefully shut down")
+                # Stop processing remaining pipelines on shutdown
+                break
+            elif result.status == RunStatus.FAILED:
+                batch_result.failed += 1
+                batch_result.failed_pipelines.append(pipeline)
+                echo_error(
+                    f"✗ {pipeline}: failed",
+                    result.error_message or "Unknown error"
+                )
+        except PipelineNotFoundError as e:
+            batch_result.failed += 1
+            batch_result.failed_pipelines.append(pipeline)
+            echo_error(f"✗ {pipeline}: not found", str(e))
+        except Exception as e:
+            batch_result.failed += 1
+            batch_result.failed_pipelines.append(pipeline)
+            echo_error(f"✗ {pipeline}: unexpected error", str(e))
+
+    return batch_result
+
+
+def _echo_batch_summary(result: BatchRunResult, dry_run: bool) -> None:
+    """Output batch run summary.
+
+    Args:
+        result: BatchRunResult with aggregated results.
+        dry_run: Whether this was a dry run.
+    """
+    echo_info("")
+    echo_info("=" * 50)
+
+    if dry_run:
+        echo_info(f"Dry-run complete: {result.total} pipelines previewed")
+    else:
+        echo_info(f"Batch run complete: {result.total} pipelines")
+        echo_info(f"  Succeeded: {result.succeeded}")
+        if result.failed > 0:
+            echo_info(f"  Failed: {result.failed}")
+        if result.skipped > 0:
+            echo_info(f"  Skipped: {result.skipped}")
+
+    if result.failed_pipelines:
+        echo_error("Failed pipelines:", ", ".join(result.failed_pipelines))
+
+
+@click.command("run-all")
+@click.option(
+    "--source",
+    required=True,
+    help="Provider name (e.g., chembl, pubchem, uniprot)",
+)
+@click.option(
+    "--run-type",
+    type=click.Choice(["incremental", "backfill", "rebuild"]),
+    default="incremental",
+    help="Type of run for all pipelines",
+)
+@click.option("--limit", type=int, help="Maximum records per pipeline")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Preview mode - show pipelines without execution",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    help="Skip confirmation prompt for rebuild/backfill",
+)
+@click.option(
+    "--list-only",
+    is_flag=True,
+    help="List pipelines for the source without running them",
+)
+@click.option(
+    "--debug",
+    is_flag=True,
+    help="Enable DEBUG level logging",
+)
+def run_all(
+    source: str,
+    run_type: str,
+    limit: int | None,
+    dry_run: bool,
+    yes: bool,
+    list_only: bool,
+    debug: bool,
+) -> None:
+    """Run all ETL pipelines for a specific provider.
+
+    Executes all registered pipelines matching the given source (provider).
+    Pipelines are run sequentially in alphabetical order.
+
+    Examples:
+
+        bioetl run-all --source chembl
+
+        bioetl run-all --source chembl --list-only
+
+        bioetl run-all --source pubchem --dry-run
+
+        bioetl run-all --source chembl --run-type rebuild --yes
+    """
+    # Validate provider has pipelines
+    is_valid, error_msg = _validate_provider(source)
+    if not is_valid:
+        echo_error("Provider error", error_msg)
+        sys.exit(ExitCode.FAIL)
+
+    # Get pipelines for provider
+    pipelines = _filter_pipelines_by_provider(source)
+
+    # Handle --list-only mode
+    if list_only:
+        echo_info(f"Pipelines for provider '{source}':")
+        for pipeline in pipelines:
+            echo_info(f"  - {pipeline}")
+        echo_info(f"\nTotal: {len(pipelines)} pipeline(s)")
+        sys.exit(ExitCode.OK)
+
+    # Handle confirmation for destructive operations (CLI responsibility)
+    if run_type in ("rebuild", "backfill") and not dry_run and not yes:
+        echo_warning(
+            f"{run_type} will clear existing data for {len(pipelines)} pipelines."
+        )
+        echo_info("Pipelines to be affected:")
+        for pipeline in pipelines:
+            echo_info(f"  - {pipeline}")
+        if not click.confirm("\nDo you want to continue?"):
+            echo_info("Operation cancelled.")
+            sys.exit(ExitCode.OK)
+
+    # Show what we're about to do
+    if dry_run:
+        echo_info(f"[DRY-RUN] Would run {len(pipelines)} pipeline(s) for '{source}':")
+    else:
+        echo_info(f"Running {len(pipelines)} pipeline(s) for '{source}':")
+
+    for pipeline in pipelines:
+        echo_info(f"  - {pipeline}")
+    echo_info("")
+
+    # Build options
+    options = RunOptions(
+        run_type=run_type,
+        limit=limit,
+        dry_run=dry_run,
+        log_level="DEBUG" if debug else "INFO",
+    )
+
+    # Run pipelines
+    try:
+        batch_result = asyncio.run(_run_all_pipelines_async(pipelines, options))
+    except KeyboardInterrupt:
+        echo_warning("Batch run interrupted by user (Ctrl+C)")
+        sys.exit(ExitCode.SIGINT)
+    except Exception as e:
+        echo_error("Unexpected error during batch execution", str(e))
+        sys.exit(ExitCode.FAIL)
+
+    # Output summary
+    _echo_batch_summary(batch_result, dry_run)
+
+    # Determine exit code
+    if batch_result.all_succeeded:
+        sys.exit(ExitCode.OK)
+    elif batch_result.failed > 0:
+        sys.exit(ExitCode.PIPELINE_ERROR)
+    else:
+        # All skipped (shutdown)
+        sys.exit(ExitCode.SIGINT)
+
+
+@click.command("run-chembl-all")
+@click.option(
+    "--run-type",
+    type=click.Choice(["incremental", "backfill", "rebuild"]),
+    default="incremental",
+    help="Type of run for all pipelines",
+)
+@click.option("--limit", type=int, help="Maximum records per pipeline")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Preview mode - show pipelines without execution",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    help="Skip confirmation prompt for rebuild/backfill",
+)
+@click.option(
+    "--list-only",
+    is_flag=True,
+    help="List pipelines without running them",
+)
+@click.option(
+    "--debug",
+    is_flag=True,
+    help="Enable DEBUG level logging",
+)
+def run_chembl_all(
+    run_type: str,
+    limit: int | None,
+    dry_run: bool,
+    yes: bool,
+    list_only: bool,
+    debug: bool,
+) -> None:
+    """[DEPRECATED] Run all ChEMBL pipelines.
+
+    This command is deprecated. Use 'run-all --source chembl' instead.
+
+    Examples:
+
+        bioetl run-all --source chembl  # Preferred
+
+        bioetl run-chembl-all  # Deprecated
+    """
+    warnings.warn(
+        "'run-chembl-all' is deprecated. Use 'run-all --source chembl' instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    echo_warning(
+        "DEPRECATION: 'run-chembl-all' is deprecated. "
+        "Use 'run-all --source chembl' instead."
+    )
+
+    # Delegate to run_all with source=chembl
+    # We use click's Context.invoke for proper delegation
+    ctx = click.get_current_context()
+    ctx.invoke(
+        run_all,
+        source="chembl",
+        run_type=run_type,
+        limit=limit,
+        dry_run=dry_run,
+        yes=yes,
+        list_only=list_only,
+        debug=debug,
+    )
+
+
+__all__ = [
+    "BatchRunResult",
+    "run_all",
+    "run_chembl_all",
+]

--- a/src/bioetl/interfaces/cli/main.py
+++ b/src/bioetl/interfaces/cli/main.py
@@ -16,6 +16,7 @@ from bioetl.interfaces.cli.commands.lock import lock
 from bioetl.interfaces.cli.commands.maintenance import maintenance
 from bioetl.interfaces.cli.commands.quarantine import quarantine
 from bioetl.interfaces.cli.commands.run import run
+from bioetl.interfaces.cli.commands.run_all import run_all, run_chembl_all
 
 
 @click.group()
@@ -27,6 +28,8 @@ def cli() -> None:
 
 # Register commands
 cli.add_command(run)
+cli.add_command(run_all)
+cli.add_command(run_chembl_all)
 cli.add_command(quarantine)
 cli.add_command(checkpoint)
 cli.add_command(config)

--- a/tests/unit/interfaces/test_run_all_command.py
+++ b/tests/unit/interfaces/test_run_all_command.py
@@ -1,0 +1,510 @@
+"""Unit tests for run-all CLI command.
+
+Tests for the universal run-all command that runs all pipelines for a provider.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from bioetl.application.services import RunResult, RunStatus
+from bioetl.interfaces.cli.commands.run_all import (
+    BatchRunResult,
+    _filter_pipelines_by_provider,
+    _get_available_providers,
+    _validate_provider,
+)
+from bioetl.interfaces.cli.main import cli
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    """Create Click's CliRunner for testing CLI commands."""
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_registry():
+    """Mock default registry for validation tests."""
+    mock = MagicMock()
+    mock.list_pipelines.return_value = [
+        "chembl_activity",
+        "chembl_assay",
+        "chembl_molecule",
+        "chembl_target",
+        "pubchem_compound",
+        "uniprot_protein",
+    ]
+    with patch(
+        "bioetl.interfaces.cli.commands.run_all.get_default_registry",
+        return_value=mock,
+    ):
+        yield mock
+
+
+@pytest.fixture
+def mock_registry_main():
+    """Mock default registry for main.py imports."""
+    mock = MagicMock()
+    mock.list_pipelines.return_value = [
+        "chembl_activity",
+        "chembl_assay",
+        "chembl_molecule",
+        "chembl_target",
+        "pubchem_compound",
+        "uniprot_protein",
+    ]
+    with patch(
+        "bioetl.interfaces.cli.commands.run_helpers.get_default_registry",
+        return_value=mock,
+    ):
+        yield mock
+
+
+# =============================================================================
+# BatchRunResult tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestBatchRunResult:
+    """Tests for BatchRunResult dataclass."""
+
+    def test_all_succeeded_true_when_no_failures(self):
+        """Test all_succeeded is True when no failures."""
+        result = BatchRunResult(total=3, succeeded=3, failed=0)
+        assert result.all_succeeded is True
+
+    def test_all_succeeded_false_when_failures(self):
+        """Test all_succeeded is False when there are failures."""
+        result = BatchRunResult(total=3, succeeded=2, failed=1)
+        assert result.all_succeeded is False
+
+    def test_all_succeeded_false_when_zero_total(self):
+        """Test all_succeeded is False when no pipelines processed."""
+        result = BatchRunResult(total=0, succeeded=0, failed=0)
+        assert result.all_succeeded is False
+
+    def test_default_values(self):
+        """Test default values are initialized correctly."""
+        result = BatchRunResult()
+        assert result.total == 0
+        assert result.succeeded == 0
+        assert result.failed == 0
+        assert result.skipped == 0
+        assert result.results == []
+        assert result.failed_pipelines == []
+
+
+# =============================================================================
+# Helper function tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestGetAvailableProviders:
+    """Tests for _get_available_providers function."""
+
+    def test_returns_unique_providers(self, mock_registry):
+        """Test that unique providers are extracted from pipeline names."""
+        providers = _get_available_providers()
+        assert sorted(providers) == ["chembl", "pubchem", "uniprot"]
+
+    def test_empty_when_no_pipelines(self):
+        """Test that empty list returned when no pipelines registered."""
+        mock = MagicMock()
+        mock.list_pipelines.return_value = []
+        with patch(
+            "bioetl.interfaces.cli.commands.run_all.get_default_registry",
+            return_value=mock,
+        ):
+            providers = _get_available_providers()
+            assert providers == []
+
+
+@pytest.mark.unit
+class TestFilterPipelinesByProvider:
+    """Tests for _filter_pipelines_by_provider function."""
+
+    def test_filters_chembl_pipelines(self, mock_registry):
+        """Test that ChEMBL pipelines are correctly filtered."""
+        pipelines = _filter_pipelines_by_provider("chembl")
+        assert pipelines == [
+            "chembl_activity",
+            "chembl_assay",
+            "chembl_molecule",
+            "chembl_target",
+        ]
+
+    def test_filters_pubchem_pipelines(self, mock_registry):
+        """Test that PubChem pipelines are correctly filtered."""
+        pipelines = _filter_pipelines_by_provider("pubchem")
+        assert pipelines == ["pubchem_compound"]
+
+    def test_returns_empty_for_unknown_provider(self, mock_registry):
+        """Test that empty list returned for unknown provider."""
+        pipelines = _filter_pipelines_by_provider("unknown")
+        assert pipelines == []
+
+
+@pytest.mark.unit
+class TestValidateProvider:
+    """Tests for _validate_provider function."""
+
+    def test_valid_provider_returns_true(self, mock_registry):
+        """Test that valid provider returns (True, None)."""
+        is_valid, error = _validate_provider("chembl")
+        assert is_valid is True
+        assert error is None
+
+    def test_invalid_provider_returns_false(self, mock_registry):
+        """Test that invalid provider returns (False, error_message)."""
+        is_valid, error = _validate_provider("invalid")
+        assert is_valid is False
+        assert "No pipelines found for provider 'invalid'" in error
+        assert "Available providers:" in error
+
+    def test_empty_registry_returns_error(self):
+        """Test that empty registry returns appropriate error."""
+        mock = MagicMock()
+        mock.list_pipelines.return_value = []
+        with patch(
+            "bioetl.interfaces.cli.commands.run_all.get_default_registry",
+            return_value=mock,
+        ):
+            is_valid, error = _validate_provider("chembl")
+            assert is_valid is False
+            assert "No pipelines are registered" in error
+
+
+# =============================================================================
+# CLI Command Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestRunAllCommand:
+    """Tests for run-all Click command."""
+
+    def test_run_all_help(self, cli_runner):
+        """Test that run-all --help works."""
+        result = cli_runner.invoke(cli, ["run-all", "--help"])
+        assert result.exit_code == 0
+        assert "--source" in result.output
+        assert "--run-type" in result.output
+        assert "--list-only" in result.output
+        assert "--dry-run" in result.output
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    def test_run_all_requires_source(self, mock_register, cli_runner):
+        """Test that --source is required."""
+        result = cli_runner.invoke(cli, ["run-all"])
+        assert result.exit_code != 0
+        assert "Missing option '--source'" in result.output
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    def test_run_all_list_only_shows_pipelines(
+        self, mock_register, cli_runner, mock_registry
+    ):
+        """Test that --list-only shows pipelines without executing."""
+        result = cli_runner.invoke(
+            cli, ["run-all", "--source", "chembl", "--list-only"]
+        )
+        assert result.exit_code == 0
+        assert "Pipelines for provider 'chembl':" in result.output
+        assert "chembl_activity" in result.output
+        assert "chembl_assay" in result.output
+        assert "Total: 4 pipeline(s)" in result.output
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    def test_run_all_invalid_source_fails(
+        self, mock_register, cli_runner, mock_registry
+    ):
+        """Test that invalid source shows error and exits with code 1."""
+        result = cli_runner.invoke(cli, ["run-all", "--source", "invalid"])
+        assert result.exit_code == 1
+        assert "No pipelines found for provider 'invalid'" in result.output
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service")
+    @patch("bioetl.interfaces.cli.commands.run_all.asyncio.run")
+    def test_run_all_executes_all_pipelines(
+        self, mock_asyncio, mock_get_service, mock_register, cli_runner, mock_registry
+    ):
+        """Test that all pipelines for source are executed."""
+        # Setup mock service
+        mock_service = MagicMock()
+
+        async def mock_run(pipeline, options=None):
+            return RunResult(
+                status=RunStatus.SUCCESS,
+                pipeline_name=pipeline,
+                run_id="test-run-id",
+                run_type="incremental",
+            )
+
+        mock_service.run = AsyncMock(side_effect=mock_run)
+        mock_get_service.return_value = mock_service
+
+        # Make asyncio.run execute the coroutine
+        def run_coro(coro):
+            import asyncio
+            return asyncio.get_event_loop().run_until_complete(coro)
+
+        mock_asyncio.side_effect = run_coro
+
+        result = cli_runner.invoke(cli, ["run-all", "--source", "chembl"])
+
+        # Should have called the service for each chembl pipeline
+        assert mock_service.run.call_count == 4
+        assert "Running 4 pipeline(s)" in result.output
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service")
+    @patch("bioetl.interfaces.cli.commands.run_all.asyncio.run")
+    def test_run_all_dry_run_mode(
+        self, mock_asyncio, mock_get_service, mock_register, cli_runner, mock_registry
+    ):
+        """Test that --dry-run mode shows pipelines without executing."""
+        # Setup mock service
+        mock_service = MagicMock()
+
+        async def mock_run(pipeline, options=None):
+            return RunResult(
+                status=RunStatus.DRY_RUN,
+                pipeline_name=pipeline,
+                run_id="test-run-id",
+                run_type="incremental",
+            )
+
+        mock_service.run = AsyncMock(side_effect=mock_run)
+        mock_get_service.return_value = mock_service
+
+        # Make asyncio.run execute the coroutine
+        def run_coro(coro):
+            import asyncio
+            return asyncio.get_event_loop().run_until_complete(coro)
+
+        mock_asyncio.side_effect = run_coro
+
+        result = cli_runner.invoke(
+            cli, ["run-all", "--source", "chembl", "--dry-run"]
+        )
+
+        assert result.exit_code == 0
+        assert "[DRY-RUN]" in result.output
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    def test_run_all_rebuild_requires_confirmation(
+        self, mock_register, cli_runner, mock_registry
+    ):
+        """Test that rebuild requires confirmation without --yes."""
+        result = cli_runner.invoke(
+            cli, ["run-all", "--source", "chembl", "--run-type", "rebuild"],
+            input="n\n",  # Say no to confirmation
+        )
+
+        assert "Operation cancelled" in result.output
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service")
+    @patch("bioetl.interfaces.cli.commands.run_all.asyncio.run")
+    def test_run_all_rebuild_with_yes_skips_confirmation(
+        self, mock_asyncio, mock_get_service, mock_register, cli_runner, mock_registry
+    ):
+        """Test that --yes skips confirmation for rebuild."""
+        mock_service = MagicMock()
+
+        async def mock_run(pipeline, options=None):
+            return RunResult(
+                status=RunStatus.SUCCESS,
+                pipeline_name=pipeline,
+                run_id="test-run-id",
+                run_type="rebuild",
+            )
+
+        mock_service.run = AsyncMock(side_effect=mock_run)
+        mock_get_service.return_value = mock_service
+
+        def run_coro(coro):
+            import asyncio
+            return asyncio.get_event_loop().run_until_complete(coro)
+
+        mock_asyncio.side_effect = run_coro
+
+        cli_runner.invoke(
+            cli, ["run-all", "--source", "chembl", "--run-type", "rebuild", "--yes"]
+        )
+
+        # Should have called the service (no confirmation prompt)
+        assert mock_service.run.call_count == 4
+
+
+# =============================================================================
+# Deprecated run-chembl-all Command Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestRunChemblAllCommand:
+    """Tests for deprecated run-chembl-all command."""
+
+    def test_run_chembl_all_help(self, cli_runner):
+        """Test that run-chembl-all --help works."""
+        result = cli_runner.invoke(cli, ["run-chembl-all", "--help"])
+        assert result.exit_code == 0
+        assert "DEPRECATED" in result.output
+        assert "run-all --source chembl" in result.output
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    def test_run_chembl_all_shows_deprecation_warning(
+        self, mock_register, cli_runner, mock_registry
+    ):
+        """Test that run-chembl-all shows deprecation warning."""
+        result = cli_runner.invoke(cli, ["run-chembl-all", "--list-only"])
+
+        assert "DEPRECATION" in result.output
+        assert "run-all --source chembl" in result.output
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    def test_run_chembl_all_list_only_works(
+        self, mock_register, cli_runner, mock_registry
+    ):
+        """Test that run-chembl-all --list-only shows chembl pipelines."""
+        result = cli_runner.invoke(cli, ["run-chembl-all", "--list-only"])
+
+        assert result.exit_code == 0
+        assert "chembl_activity" in result.output
+        assert "Total: 4 pipeline(s)" in result.output
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service")
+    @patch("bioetl.interfaces.cli.commands.run_all.asyncio.run")
+    def test_run_chembl_all_delegates_to_run_all(
+        self, mock_asyncio, mock_get_service, mock_register, cli_runner, mock_registry
+    ):
+        """Test that run-chembl-all delegates to run-all with source=chembl."""
+        mock_service = MagicMock()
+
+        async def mock_run(pipeline, options=None):
+            return RunResult(
+                status=RunStatus.SUCCESS,
+                pipeline_name=pipeline,
+                run_id="test-run-id",
+                run_type="incremental",
+            )
+
+        mock_service.run = AsyncMock(side_effect=mock_run)
+        mock_get_service.return_value = mock_service
+
+        def run_coro(coro):
+            import asyncio
+            return asyncio.get_event_loop().run_until_complete(coro)
+
+        mock_asyncio.side_effect = run_coro
+
+        cli_runner.invoke(cli, ["run-chembl-all"])
+
+        # Should have called all chembl pipelines
+        assert mock_service.run.call_count == 4
+
+
+# =============================================================================
+# Exit Code Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestRunAllExitCodes:
+    """Tests for run-all exit codes."""
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    def test_exit_code_0_for_list_only(
+        self, mock_register, cli_runner, mock_registry
+    ):
+        """Test exit code 0 for successful --list-only."""
+        result = cli_runner.invoke(
+            cli, ["run-all", "--source", "chembl", "--list-only"]
+        )
+        assert result.exit_code == 0
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    def test_exit_code_1_for_invalid_source(
+        self, mock_register, cli_runner, mock_registry
+    ):
+        """Test exit code 1 for invalid source."""
+        result = cli_runner.invoke(cli, ["run-all", "--source", "invalid"])
+        assert result.exit_code == 1
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service")
+    @patch("bioetl.interfaces.cli.commands.run_all.asyncio.run")
+    def test_exit_code_0_for_all_success(
+        self, mock_asyncio, mock_get_service, mock_register, cli_runner, mock_registry
+    ):
+        """Test exit code 0 when all pipelines succeed."""
+        mock_service = MagicMock()
+
+        async def mock_run(pipeline, options=None):
+            return RunResult(
+                status=RunStatus.SUCCESS,
+                pipeline_name=pipeline,
+                run_id="test-run-id",
+                run_type="incremental",
+            )
+
+        mock_service.run = AsyncMock(side_effect=mock_run)
+        mock_get_service.return_value = mock_service
+
+        def run_coro(coro):
+            import asyncio
+            return asyncio.get_event_loop().run_until_complete(coro)
+
+        mock_asyncio.side_effect = run_coro
+
+        result = cli_runner.invoke(cli, ["run-all", "--source", "chembl"])
+        assert result.exit_code == 0
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service")
+    @patch("bioetl.interfaces.cli.commands.run_all.asyncio.run")
+    def test_exit_code_82_for_failures(
+        self, mock_asyncio, mock_get_service, mock_register, cli_runner, mock_registry
+    ):
+        """Test exit code 82 (PIPELINE_ERROR) when some pipelines fail."""
+        mock_service = MagicMock()
+        call_count = 0
+
+        async def mock_run(pipeline, options=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                # Second pipeline fails
+                return RunResult(
+                    status=RunStatus.FAILED,
+                    pipeline_name=pipeline,
+                    run_id="test-run-id",
+                    run_type="incremental",
+                    error_message="Test error",
+                )
+            return RunResult(
+                status=RunStatus.SUCCESS,
+                pipeline_name=pipeline,
+                run_id="test-run-id",
+                run_type="incremental",
+            )
+
+        mock_service.run = AsyncMock(side_effect=mock_run)
+        mock_get_service.return_value = mock_service
+
+        def run_coro(coro):
+            import asyncio
+            return asyncio.get_event_loop().run_until_complete(coro)
+
+        mock_asyncio.side_effect = run_coro
+
+        result = cli_runner.invoke(cli, ["run-all", "--source", "chembl"])
+        assert result.exit_code == 82  # ExitCode.PIPELINE_ERROR


### PR DESCRIPTION
Implements a universal run-all command that runs all pipelines for a given provider, replacing the need for hardcoded provider-specific commands.

Changes:
- Add run-all command with --source <provider> parameter
- Add --list-only option to preview pipelines without execution
- Add --dry-run support for entire pipeline groups
- Add proper exit codes (0 for success, 1 for invalid source, 82 for failures)
- Create deprecated run-chembl-all alias with deprecation warning
- Add batch execution with summary output

The command filters pipelines by provider prefix (e.g., chembl_*) and runs them sequentially. Supports all run-type modes (incremental, backfill, rebuild) with confirmation for destructive operations.

Usage:
  bioetl run-all --source chembl --list-only
  bioetl run-all --source pubchem --dry-run
  bioetl run-all --source chembl --run-type rebuild --yes