### PR TITLE
Add ADR cross-references and index

### DIFF
--- a/docs/02-architecture/decisions/ADR-001-delta-lake-vs-parquet.md
+++ b/docs/02-architecture/decisions/ADR-001-delta-lake-vs-parquet.md
@@ -34,3 +34,9 @@ While Parquet is an excellent columnar storage format, it lacks critical feature
 *   **Increased Dependency**: The project now has a hard dependency on the `delta-rs` library.
 *   **Operational Overhead**: The database requires regular maintenance (`VACUUM`, `OPTIMIZE`). This is enforced as a weekly job in `RULES.md`.
 *   **Vendor Lock-in**: While Delta Lake is an open format, it is most heavily supported by Databricks. However, the growing ecosystem and open-source Rust core (`delta-rs`) mitigate this risk.
+
+## Related ADRs
+
+- [ADR-002](ADR-002-medallion-architecture.md): Medallion Architecture — uses Delta Lake for Silver and Gold layers
+- [ADR-012](ADR-012-storage-clear-contract-and-run-id.md): Storage Clear Contract — defines clear/cleanup operations for Delta tables
+- [ADR-018](ADR-018-gold-strict-validation.md): Gold Strict Validation — schema validation for Gold layer Delta tables

--- a/docs/02-architecture/decisions/ADR-002-medallion-architecture.md
+++ b/docs/02-architecture/decisions/ADR-002-medallion-architecture.md
@@ -36,3 +36,11 @@ The Medallion Architecture provides a clear and logical separation of concerns, 
 *   **Increased Storage Costs**: Storing data in three different forms consumes more storage space. This is mitigated by using efficient storage formats (zstd-compressed JSONL, Delta Lake) and S3 lifecycle policies to archive old Bronze data.
 *   **Higher Latency**: The multi-hop process (Bronze -> Silver -> Gold) introduces latency compared to a single, monolithic ETL job. This is an acceptable trade-off for the gains in reliability and maintainability.
 *   **Development Overhead**: Requires developers to think in terms of layers and manage pipelines between them. However, this structure also simplifies individual pipeline logic.
+
+## Related ADRs
+
+- [ADR-001](ADR-001-delta-lake-vs-parquet.md): Delta Lake vs Parquet — storage format choice for Silver/Gold layers
+- [ADR-010](ADR-010-local-only-deployment.md): Local-Only Deployment — simplifies deployment while preserving Medallion architecture
+- [ADR-011](ADR-011-remove-watermark-mechanism.md): Remove Watermark — simplifies load strategy within Medallion
+- [ADR-012](ADR-012-storage-clear-contract-and-run-id.md): Storage Clear Contract — Medallion invariants for destructive operations
+- [ADR-018](ADR-018-gold-strict-validation.md): Gold Strict Validation — quality guarantees for Gold layer

--- a/docs/02-architecture/decisions/ADR-003-redis-for-distributed-locking.md
+++ b/docs/02-architecture/decisions/ADR-003-redis-for-distributed-locking.md
@@ -38,3 +38,9 @@ Several options were considered for distributed locking, including database lock
 *   **New Dependency**: The project now has a hard dependency on a running Redis instance for all pipeline executions. This is managed via Docker Compose for local development.
 *   **Single Point of Failure**: If the Redis server goes down, no pipelines can start. This risk is mitigated by using a managed, high-availability Redis instance in production.
 *   **Clock Drift**: The TTL mechanism relies on a reasonably consistent sense of time between Redis and the workers. Severe clock drift could theoretically cause issues, but this is rare in modern cloud environments.
+
+## Related ADRs
+
+- [ADR-010](ADR-010-local-only-deployment.md): Local-Only Deployment — **SUPERSEDES this ADR**, replaces Redis with MemoryLock
+- [ADR-007](ADR-007-circuit-breaker-implementation.md): Circuit Breaker — complementary resilience pattern
+- [ADR-008](ADR-008-graceful-shutdown-strategy.md): Graceful Shutdown — lock release during shutdown

--- a/docs/02-architecture/decisions/ADR-004-pydantic-vs-dataclasses.md
+++ b/docs/02-architecture/decisions/ADR-004-pydantic-vs-dataclasses.md
@@ -35,3 +35,8 @@ While `dataclasses` provide a convenient way to create classes for storing data,
 
 *   **Dependency**: The project has a dependency on the Pydantic library.
 *   **Performance**: The runtime validation adds a small performance overhead compared to `dataclasses`. However, this is a negligible and worthwhile trade-off for the massive gains in data quality and developer productivity.
+
+## Related ADRs
+
+- [ADR-018](ADR-018-gold-strict-validation.md): Gold Strict Validation — uses Pydantic/Pandera for Gold schema validation
+- [ADR-021](ADR-021-ddd-aggregates-adoption.md): DDD Aggregates — uses dataclasses for domain aggregates (different concern)

--- a/docs/02-architecture/decisions/ADR-005-composition-layer-separation.md
+++ b/docs/02-architecture/decisions/ADR-005-composition-layer-separation.md
@@ -154,9 +154,12 @@ src/bioetl/
 - No performance impact
 - No additional dependencies
 
-## Related Decisions
+## Related ADRs
 
-- **ADR-0005**: BasePipeline Decomposition — defines components that composition/ assembles
+- [ADR-010](ADR-010-local-only-deployment.md): Local-Only Deployment — simplified composition factories
+- [ADR-011](ADR-011-remove-watermark-mechanism.md): Remove Watermark — removed watermark factories from composition
+- [ADR-015](ADR-015-pipeline-services-lifecycle.md): Pipeline Services Lifecycle — services assembled in composition
+- [ADR-020](ADR-020-basepipeline-decomposition.md): BasePipeline Decomposition — defines components that composition/ assembles
 - **RULES.md §1.1**: Ports & Adapters architecture — composition implements the "glue" layer
 
 ## References

--- a/docs/02-architecture/decisions/ADR-006-logger-metrics-ports.md
+++ b/docs/02-architecture/decisions/ADR-006-logger-metrics-ports.md
@@ -139,3 +139,11 @@ Rejected because:
 1. New code should use `LoggerPort` directly
 2. Existing code using `BoundLogger` continues to work
 3. Gradual migration as files are modified
+
+## Related ADRs
+
+- [ADR-014](ADR-014-deterministic-writes.md): Deterministic Writes — logging constraints for reproducibility
+- [ADR-015](ADR-015-pipeline-services-lifecycle.md): Pipeline Services Lifecycle — MetricsPort lifecycle management
+- [ADR-017](ADR-017-observability-architecture.md): Observability Architecture — extends this with TracingPort and full observability stack
+- [ADR-019](ADR-019-observability-port-enforcement.md): Observability Port Enforcement — enforces LoggerPort usage in all layers
+- [ADR-022](ADR-022-tracing-noop.md): NoOp Tracing — applies NoOp pattern established here to tracing

--- a/docs/02-architecture/decisions/ADR-007-circuit-breaker-implementation.md
+++ b/docs/02-architecture/decisions/ADR-007-circuit-breaker-implementation.md
@@ -147,4 +147,7 @@ async def fetch_activity(activity_id: int) -> dict:
 
 ## Related ADRs
 
-- ADR-003: Redis for Distributed Locking (complementary resilience pattern)
+- [ADR-003](ADR-003-redis-for-distributed-locking.md): Redis for Distributed Locking — complementary resilience pattern (superseded by ADR-010)
+- [ADR-008](ADR-008-graceful-shutdown-strategy.md): Graceful Shutdown Strategy — coordinates with circuit breaker during shutdown
+- [ADR-009](ADR-009-paginated-fetcher-mixin.md): PaginatedFetcherMixin — wraps fetch calls with circuit breaker
+- [ADR-016](ADR-016-error-handling-strategy.md): Error Handling Strategy — circuit breaker is part of error handling

--- a/docs/02-architecture/decisions/ADR-008-graceful-shutdown-strategy.md
+++ b/docs/02-architecture/decisions/ADR-008-graceful-shutdown-strategy.md
@@ -206,5 +206,8 @@ The 5-minute grace period allows:
 
 ## Related ADRs
 
-- ADR-003: Redis for Distributed Locking (lock safety)
-- ADR-007: Circuit Breaker Implementation (failure handling)
+- [ADR-003](ADR-003-redis-for-distributed-locking.md): Redis for Distributed Locking — lock safety (superseded by ADR-010)
+- [ADR-007](ADR-007-circuit-breaker-implementation.md): Circuit Breaker Implementation — failure handling coordination
+- [ADR-010](ADR-010-local-only-deployment.md): Local-Only Deployment — MemoryLock shutdown behavior
+- [ADR-015](ADR-015-pipeline-services-lifecycle.md): Pipeline Services Lifecycle — aclose() during shutdown
+- [ADR-016](ADR-016-error-handling-strategy.md): Error Handling Strategy — shutdown on critical errors

--- a/docs/02-architecture/decisions/ADR-010-local-only-deployment.md
+++ b/docs/02-architecture/decisions/ADR-010-local-only-deployment.md
@@ -185,9 +185,12 @@ class Settings:
 
 ## Related ADRs
 
-- **ADR-003**: Superseded — Redis больше не используется
-- **ADR-002**: Medallion Architecture — сохраняется, меняется только storage backend
-- **ADR-005**: Composition Layer — упрощён, удалены cloud factories
+- [ADR-002](ADR-002-medallion-architecture.md): Medallion Architecture — сохраняется, меняется только storage backend
+- [ADR-003](ADR-003-redis-for-distributed-locking.md): **Superseded** — Redis больше не используется
+- [ADR-005](ADR-005-composition-layer-separation.md): Composition Layer — упрощён, удалены cloud factories
+- [ADR-008](ADR-008-graceful-shutdown-strategy.md): Graceful Shutdown — MemoryLock shutdown behavior
+- [ADR-011](ADR-011-remove-watermark-mechanism.md): Remove Watermark — simplification aligned with Local-Only
+- [ADR-022](ADR-022-tracing-noop.md): NoOp Tracing — NoOp pattern consistent with Local-Only (no external infra)
 
 ## Migration Notes
 

--- a/docs/02-architecture/decisions/ADR-012-storage-clear-contract-and-run-id.md
+++ b/docs/02-architecture/decisions/ADR-012-storage-clear-contract-and-run-id.md
@@ -107,8 +107,13 @@ should_clear = self._runtime.run_type in (RunType.REBUILD, RunType.BACKFILL)
 | Чекпоинты со старым форматом | Низкая | `load()` игнорирует `run_id` в файле |
 | Дубликаты при incremental | Средняя | Merge по `content_hash` предотвращает дубли |
 
+## Related ADRs
+
+- [ADR-001](ADR-001-delta-lake-vs-parquet.md): Delta Lake vs Parquet — storage format being cleared
+- [ADR-002](ADR-002-medallion-architecture.md): Medallion Architecture — Medallion invariants for clear operations
+- [ADR-013](ADR-013-async-storage-cleanup.md): Async Storage Cleanup — async implementation of clear methods
+
 ## References
 
 - RULES.md §1.1 — Ports & Adapters architecture
-- ADR-002 — Medallion Architecture
 - CLAUDE.md §3.2 — Content Hash нормализация

--- a/docs/02-architecture/decisions/ADR-013-async-storage-cleanup.md
+++ b/docs/02-architecture/decisions/ADR-013-async-storage-cleanup.md
@@ -106,8 +106,12 @@ async def test_clear_exports(...):
     services.storage.clear_silver = AsyncMock(return_value=0)
 ```
 
+## Related ADRs
+
+- [ADR-012](ADR-012-storage-clear-contract-and-run-id.md): Storage Clear Contract — defines the contract being implemented
+- [ADR-015](ADR-015-pipeline-services-lifecycle.md): Pipeline Services Lifecycle — async cleanup coordination
+
 ## References
 
-- ADR-012: Storage Clear Contract and Run ID Consistency
 - CLAUDE.md §3: Medallion Architecture
 - tests/integration/test_runner_lifecycle.py — Тесты инвариантов

--- a/docs/02-architecture/decisions/ADR-015-pipeline-services-lifecycle.md
+++ b/docs/02-architecture/decisions/ADR-015-pipeline-services-lifecycle.md
@@ -137,6 +137,9 @@ class TestObservabilityPortLifecycle:
 
 ## Related ADRs
 
-- [ADR-006: Logger and Metrics as Ports](ADR-006-logger-metrics-ports.md)
-- [ADR-008: Graceful Shutdown Strategy](ADR-008-graceful-shutdown-strategy.md)
-- [ADR-020: BasePipeline Decomposition](ADR-020-basepipeline-decomposition.md)
+- [ADR-005](ADR-005-composition-layer-separation.md): Composition Layer — services assembled in composition
+- [ADR-006](ADR-006-logger-metrics-ports.md): Logger and Metrics Ports — defines observability ports
+- [ADR-008](ADR-008-graceful-shutdown-strategy.md): Graceful Shutdown Strategy — shutdown coordination
+- [ADR-013](ADR-013-async-storage-cleanup.md): Async Storage Cleanup — async cleanup methods
+- [ADR-020](ADR-020-basepipeline-decomposition.md): BasePipeline Decomposition — PipelineServices design
+- [ADR-021](ADR-021-ddd-aggregates-adoption.md): DDD Aggregates — uses PipelineServices lifecycle

--- a/docs/02-architecture/decisions/ADR-017-observability-architecture.md
+++ b/docs/02-architecture/decisions/ADR-017-observability-architecture.md
@@ -263,6 +263,9 @@ Rejected because:
 
 ## Related ADRs
 
-- [ADR-006](ADR-006-logger-metrics-ports.md): Logger and Metrics Ports (initial decision)
-- [ADR-014](ADR-014-deterministic-writes.md): Deterministic Writes (logging constraints)
-- [ADR-016](ADR-016-error-handling-strategy.md): Error Handling Strategy (metric integration)
+- [ADR-006](ADR-006-logger-metrics-ports.md): Logger and Metrics Ports — initial decision for LoggerPort/MetricsPort
+- [ADR-014](ADR-014-deterministic-writes.md): Deterministic Writes — logging constraints for reproducibility
+- [ADR-016](ADR-016-error-handling-strategy.md): Error Handling Strategy — metric integration
+- [ADR-018](ADR-018-gold-strict-validation.md): Gold Strict Validation — logging integration
+- [ADR-019](ADR-019-observability-port-enforcement.md): Observability Port Enforcement — enforces this architecture
+- [ADR-022](ADR-022-tracing-noop.md): NoOp Tracing — NoOp pattern for tracing defined here

--- a/docs/02-architecture/decisions/ADR-018-gold-strict-validation.md
+++ b/docs/02-architecture/decisions/ADR-018-gold-strict-validation.md
@@ -326,6 +326,8 @@ def test_non_strict_validation_warns_without_schema(caplog):
 
 ## Related ADRs
 
-- [ADR-002](ADR-002-medallion-architecture.md): Medallion Architecture (Gold layer definition)
-- [ADR-016](ADR-016-error-handling-strategy.md): Error Handling Strategy (error classification)
-- [ADR-017](ADR-017-observability-architecture.md): Observability Architecture (logging integration)
+- [ADR-001](ADR-001-delta-lake-vs-parquet.md): Delta Lake vs Parquet — Gold layer uses Delta Lake
+- [ADR-002](ADR-002-medallion-architecture.md): Medallion Architecture — Gold layer definition
+- [ADR-004](ADR-004-pydantic-vs-dataclasses.md): Pydantic vs Dataclasses — Pydantic/Pandera for validation
+- [ADR-016](ADR-016-error-handling-strategy.md): Error Handling Strategy — error classification for validation errors
+- [ADR-017](ADR-017-observability-architecture.md): Observability Architecture — logging integration

--- a/docs/02-architecture/decisions/ADR-020-basepipeline-decomposition.md
+++ b/docs/02-architecture/decisions/ADR-020-basepipeline-decomposition.md
@@ -291,6 +291,13 @@ async def run_pipeline_flow(
                     (uses CHEMBL_ACTIVITY_CONFIG)
 ```
 
+## Related ADRs
+
+- [ADR-005](ADR-005-composition-layer-separation.md): Composition Layer — assembles decomposed components
+- [ADR-006](ADR-006-logger-metrics-ports.md): Logger and Metrics Ports — LoggerPort in PipelineServices
+- [ADR-015](ADR-015-pipeline-services-lifecycle.md): Pipeline Services Lifecycle — PipelineServices design
+- [ADR-021](ADR-021-ddd-aggregates-adoption.md): DDD Aggregates — further domain layer improvements
+
 ## Связанные документы
 
 - `docs/refactoring/basepipeline-dependency-map.md`

--- a/docs/02-architecture/decisions/README.md
+++ b/docs/02-architecture/decisions/README.md
@@ -1,0 +1,192 @@
+# Architecture Decision Records (ADR)
+
+This directory contains Architecture Decision Records documenting significant architectural decisions for the BioETL project.
+
+## ADR Index
+
+| ADR | Title | Status | Category | Date |
+|-----|-------|--------|----------|------|
+| [ADR-001](ADR-001-delta-lake-vs-parquet.md) | Delta Lake vs Parquet | Accepted | Storage | 2025-05-20 |
+| [ADR-002](ADR-002-medallion-architecture.md) | Medallion Architecture | Accepted | Architecture | 2025-05-20 |
+| [ADR-003](ADR-003-redis-for-distributed-locking.md) | Redis for Distributed Locking | **Superseded** | Locking | 2025-05-20 |
+| [ADR-004](ADR-004-pydantic-vs-dataclasses.md) | Pydantic vs Dataclasses | Accepted | Data Modeling | 2025-05-20 |
+| [ADR-005](ADR-005-composition-layer-separation.md) | Composition Layer Separation | Accepted | Architecture | 2025-12-15 |
+| [ADR-006](ADR-006-logger-metrics-ports.md) | Logger and Metrics Ports | Accepted | Observability | 2025-12-18 |
+| [ADR-007](ADR-007-circuit-breaker-implementation.md) | Circuit Breaker Implementation | Accepted | Resilience | 2025-12-22 |
+| [ADR-008](ADR-008-graceful-shutdown-strategy.md) | Graceful Shutdown Strategy | Accepted | Lifecycle | 2025-12-22 |
+| [ADR-009](ADR-009-paginated-fetcher-mixin.md) | PaginatedFetcherMixin Design | Accepted | Data Fetching | 2025-12-22 |
+| [ADR-010](ADR-010-local-only-deployment.md) | Local-Only Deployment | Accepted | Deployment | 2025-12-23 |
+| [ADR-011](ADR-011-remove-watermark-mechanism.md) | Remove Watermark Mechanism | Accepted | Data Loading | 2025-12-23 |
+| [ADR-012](ADR-012-storage-clear-contract-and-run-id.md) | Storage Clear Contract and Run ID | Accepted | Storage | 2025-12-23 |
+| [ADR-013](ADR-013-async-storage-cleanup.md) | Async Storage Cleanup | Accepted | Storage | 2025-12-24 |
+| [ADR-014](ADR-014-deterministic-writes.md) | Deterministic Writes and Retries | Accepted | Reproducibility | 2025-12-24 |
+| [ADR-015](ADR-015-pipeline-services-lifecycle.md) | Pipeline Services Lifecycle | Accepted | Lifecycle | 2025-12-24 |
+| [ADR-016](ADR-016-error-handling-strategy.md) | Error Handling Strategy | Accepted | Resilience | 2025-12-26 |
+| [ADR-017](ADR-017-observability-architecture.md) | Observability Architecture | Accepted | Observability | 2025-12-26 |
+| [ADR-018](ADR-018-gold-strict-validation.md) | Gold Strict Validation | Accepted | Data Quality | 2025-12-26 |
+| [ADR-019](ADR-019-observability-port-enforcement.md) | Observability Port Enforcement | Accepted | Observability | 2025-12-26 |
+| [ADR-020](ADR-020-basepipeline-decomposition.md) | BasePipeline Decomposition | Accepted | Architecture | 2025-12-16 |
+| [ADR-021](ADR-021-ddd-aggregates-adoption.md) | DDD Aggregates Adoption | Accepted | Domain Model | 2025-12-29 |
+| [ADR-022](ADR-022-tracing-noop.md) | NoOp Tracing for Local-Only | Accepted | Observability | 2025-12-30 |
+
+## ADRs by Category
+
+### Architecture (Core Patterns)
+- [ADR-002](ADR-002-medallion-architecture.md): Medallion Architecture (Bronze/Silver/Gold)
+- [ADR-005](ADR-005-composition-layer-separation.md): Composition Layer Separation (DI)
+- [ADR-020](ADR-020-basepipeline-decomposition.md): BasePipeline Decomposition (God Object removal)
+
+### Storage
+- [ADR-001](ADR-001-delta-lake-vs-parquet.md): Delta Lake vs Parquet
+- [ADR-012](ADR-012-storage-clear-contract-and-run-id.md): Storage Clear Contract and Run ID
+- [ADR-013](ADR-013-async-storage-cleanup.md): Async Storage Cleanup
+
+### Resilience & Error Handling
+- [ADR-007](ADR-007-circuit-breaker-implementation.md): Circuit Breaker Implementation
+- [ADR-016](ADR-016-error-handling-strategy.md): Error Handling Strategy
+
+### Observability
+- [ADR-006](ADR-006-logger-metrics-ports.md): Logger and Metrics Ports
+- [ADR-017](ADR-017-observability-architecture.md): Observability Architecture
+- [ADR-019](ADR-019-observability-port-enforcement.md): Observability Port Enforcement
+- [ADR-022](ADR-022-tracing-noop.md): NoOp Tracing for Local-Only
+
+### Lifecycle Management
+- [ADR-008](ADR-008-graceful-shutdown-strategy.md): Graceful Shutdown Strategy
+- [ADR-015](ADR-015-pipeline-services-lifecycle.md): Pipeline Services Lifecycle
+
+### Data Quality
+- [ADR-018](ADR-018-gold-strict-validation.md): Gold Strict Validation
+
+### Domain Model
+- [ADR-004](ADR-004-pydantic-vs-dataclasses.md): Pydantic vs Dataclasses
+- [ADR-021](ADR-021-ddd-aggregates-adoption.md): DDD Aggregates Adoption
+
+### Data Fetching
+- [ADR-009](ADR-009-paginated-fetcher-mixin.md): PaginatedFetcherMixin Design
+- [ADR-011](ADR-011-remove-watermark-mechanism.md): Remove Watermark Mechanism
+
+### Deployment
+- [ADR-010](ADR-010-local-only-deployment.md): Local-Only Deployment
+
+### Locking (Superseded)
+- [ADR-003](ADR-003-redis-for-distributed-locking.md): Redis for Distributed Locking — **Superseded by ADR-010**
+
+### Reproducibility
+- [ADR-014](ADR-014-deterministic-writes.md): Deterministic Writes and Retries
+
+## ADR Relationships Graph
+
+```
+                    ┌─────────────────────────────────────────┐
+                    │            Core Architecture            │
+                    └─────────────────────────────────────────┘
+                                        │
+         ┌──────────────────────────────┼──────────────────────────────┐
+         ▼                              ▼                              ▼
+   ┌───────────┐                 ┌───────────┐                  ┌───────────┐
+   │  ADR-001  │                 │  ADR-002  │                  │  ADR-005  │
+   │ Delta Lake│ ◄───────────────┤ Medallion │──────────────────► Composition│
+   └───────────┘                 └───────────┘                  └───────────┘
+         │                              │                              │
+         │                              │                              │
+         ▼                              ▼                              ▼
+   ┌───────────┐                 ┌───────────┐                  ┌───────────┐
+   │  ADR-012  │                 │  ADR-018  │                  │  ADR-020  │
+   │Storage Clr│────────────────►│Gold Valid │                  │ BasePipe  │
+   └───────────┘                 └───────────┘                  └───────────┘
+         │                                                             │
+         ▼                                                             ▼
+   ┌───────────┐                                                ┌───────────┐
+   │  ADR-013  │                                                │  ADR-015  │
+   │Async Clean│◄───────────────────────────────────────────────┤ Services  │
+   └───────────┘                                                └───────────┘
+                                                                       │
+         ┌─────────────────────────────────────────────────────────────┤
+         ▼                              ▼                              ▼
+   ┌───────────┐                 ┌───────────┐                  ┌───────────┐
+   │  ADR-006  │                 │  ADR-008  │                  │  ADR-021  │
+   │Logger/Metr│                 │ Shutdown  │                  │DDD Aggreg │
+   └───────────┘                 └───────────┘                  └───────────┘
+         │                              │
+         ▼                              ▼
+   ┌───────────┐                 ┌───────────┐
+   │  ADR-017  │                 │  ADR-007  │
+   │Observabil.│                 │Circuit Brk│
+   └───────────┘                 └───────────┘
+         │                              │
+         ├──────────────────────────────┤
+         ▼                              ▼
+   ┌───────────┐                 ┌───────────┐
+   │  ADR-019  │                 │  ADR-016  │
+   │Port Enforc│                 │Error Handl│
+   └───────────┘                 └───────────┘
+         │
+         ▼
+   ┌───────────┐
+   │  ADR-022  │
+   │ NoOp Trac │◄───────────────────────┐
+   └───────────┘                        │
+                                        │
+                                 ┌───────────┐
+                                 │  ADR-010  │
+                                 │Local-Only │──────► ADR-003 (Superseded)
+                                 └───────────┘
+                                        │
+                                        ▼
+                                 ┌───────────┐
+                                 │  ADR-011  │
+                                 │Rm Watermark│
+                                 └───────────┘
+```
+
+## Writing New ADRs
+
+### Template
+
+```markdown
+# ADR-XXX: [Title]
+
+*   **Status**: Proposed | Accepted | Superseded | Deprecated
+*   **Date**: YYYY-MM-DD
+*   **Supersedes**: ADR-NNN (if applicable)
+*   **Related**: ADR-NNN, ADR-NNN (brief context)
+
+## Context
+
+[Describe the issue and why a decision is needed]
+
+## The Decision
+
+[Describe the chosen solution]
+
+## Justification
+
+[Explain why this decision was made]
+
+## Consequences
+
+### Positive
+- [benefit]
+
+### Negative
+- [tradeoff]
+
+## Related ADRs
+
+- [ADR-NNN](ADR-NNN-title.md): Description — how it relates
+```
+
+### Naming Convention
+
+ADR files follow the pattern: `ADR-NNN-kebab-case-title.md`
+
+- Numbers are sequential (001, 002, 003...)
+- Titles use kebab-case
+- Status should be in the header metadata
+
+## References
+
+- [RULES.md](../../RULES.md) — Project rules referencing these ADRs
+- [CLAUDE.md](../../../CLAUDE.md) — Developer guide with ADR context
+- [Michael Nygard's ADR format](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -43,9 +43,11 @@
 **Философия**: "Прагматичная инженерия". Избегаем избыточной сложности (Over-engineering), архитектура должна ускорять вывод продукта на рынок (time-to-market). 
 **Паттерн**: Слоистая архитектура с инверсией зависимостей (Ports & Adapters). 
  
-### 1.1. Слои и Контракты 
-- **Infrastructure (Инфраструктура/Адаптеры)**: Реализация взаимодействия с внешним миром (HTTP, БД, файловая система). 
-- **Application (Приложение/Пайплайны)**: Оркестрация потоков данных. Определяет *когда* и *в каком порядке* вызываются порты. 
+### 1.1. Слои и Контракты
+См. также [ADR-005](02-architecture/decisions/ADR-005-composition-layer-separation.md) для Composition Layer и [ADR-020](02-architecture/decisions/ADR-020-basepipeline-decomposition.md) для BasePipeline архитектуры.
+
+- **Infrastructure (Инфраструктура/Адаптеры)**: Реализация взаимодействия с внешним миром (HTTP, БД, файловая система).
+- **Application (Приложение/Пайплайны)**: Оркестрация потоков данных. Определяет *когда* и *в каком порядке* вызываются порты.
 - **Domain (Домен/Чистая логика)**: Чистые функции и контракты (Protocols). Никакого ввода-вывода (I/O). 
  
 ### 1.1.1. Обеспечение Контрактов (Enforcement)
@@ -87,8 +89,10 @@ class MyAdapter:
 **Проверка:** Архитектурный тест `tests/architecture/` валидирует сигнатуры.
 
 ## 2. Поток Данных и Стратегия Medallion
-Пайплайны реализуются как направленные ациклические графы (**DAG**). 
- 
+Пайплайны реализуются как направленные ациклические графы (**DAG**).
+
+См. [ADR-002](02-architecture/decisions/ADR-002-medallion-architecture.md).
+
 ### 2.1. Архитектура Medallion 
 | Уровень | Формат | Валидация | Хранение (Retention) | Идемпотентность | 
 |---------|--------|-----------|----------------------|-----------------| 
@@ -117,6 +121,8 @@ class MyAdapter:
 - **SCD2**: Slowly Changing Dimensions Type 2 (историчность). Требует `scd_config` (ключи, valid_from/to).
 
 ### 2.1.3. Инфраструктура Delta Lake
+См. [ADR-001](02-architecture/decisions/ADR-001-delta-lake-vs-parquet.md).
+
 - **Engine**: Использовать `delta-rs` (Rust core) для Python-воркеров для производительности. 
 - **Protocol**: Writer Version 2 (поддержка Column Mapping), Reader Version 1. 
 - **Maintenance**: Обязательный запуск `VACUUM` с `retention_period=7 days` еженедельно для очистки старых файлов и уменьшения стоимости хранения. **VACUUM MUST** запускаться еженедельно.
@@ -387,10 +393,12 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
  
 ## 4. Стандарты Кода и Тестирование 
  
-### 4.1. Стек и Матрица Решений 
-| Задача | Инструмент | Альтернатива | Критерий выбора | 
-|--------|------------|--------------|-----------------| 
-| **Оркестрация** | **PipelineRunner** | Prefect/Airflow | Используем собственный легковесный Runner. Внешние фреймворки при >5 DAG-ов. | 
+### 4.1. Стек и Матрица Решений
+См. также [ADR-004](02-architecture/decisions/ADR-004-pydantic-vs-dataclasses.md) для решения Pydantic vs Dataclasses.
+
+| Задача | Инструмент | Альтернатива | Критерий выбора |
+|--------|------------|--------------|-----------------|
+| **Оркестрация** | **PipelineRunner** | Prefect/Airflow | Используем собственный легковесный Runner. Внешние фреймворки при >5 DAG-ов. |
 | **Валидация** | **Pandera** | Great Expectations | Pandera нативна для DataFrames, легче интегрируется в CI. | 
 | **HTTP Клиент** | **httpx** via `UnifiedHTTPClient` | requests | Поддержка `async`. Все адаптеры **MUST** использовать `UnifiedHTTPClient` (см. §4.1.1). **Legacy Wrappers**: Для библиотек без async поддержки (pubchempy) — `BaseSyncAdapter` с `ThreadPoolExecutor`. | 
 | **Линтер** | **Ruff** | Flake8/Black | Скорость и решение "все-в-одном". |


### PR DESCRIPTION
- Add Related ADRs section to 15 ADRs
- Create ADR index README.md with:
  - Complete index table with status and category
  - ADRs grouped by category
  - ASCII relationship graph
  - Template for new ADRs
- Link ADRs from RULES.md sections:
  - §1.1 → ADR-005, ADR-020
  - §2 → ADR-002
  - §2.1.3 → ADR-001
  - §4.1 → ADR-004