### PR TITLE
Fix bootstrap_logger call arguments

### DIFF
--- a/tests/unit/interfaces/test_run_all_command.py
+++ b/tests/unit/interfaces/test_run_all_command.py
@@ -5,7 +5,7 @@ Tests for the universal run-all command that runs all pipelines for a provider.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner


### PR DESCRIPTION
Remove unused AsyncMock import from test_run_all_command.py to fix ruff F401 lint error.