### PR TITLE
Remove unused mypy ignore comments

### DIFF
--- a/src/bioetl/infrastructure/observability/tracing.py
+++ b/src/bioetl/infrastructure/observability/tracing.py
@@ -40,7 +40,7 @@ try:
 
         OTLP_AVAILABLE = True
     except ImportError:
-        OTLPSpanExporter = None  # type: ignore[misc,assignment,unused-ignore]
+        OTLPSpanExporter = None
         OTLP_AVAILABLE = False
 
     OTEL_AVAILABLE = True

--- a/tests/unit/interfaces/test_run_all_command.py
+++ b/tests/unit/interfaces/test_run_all_command.py
@@ -5,7 +5,7 @@ Tests for the universal run-all command that runs all pipelines for a provider.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner


### PR DESCRIPTION
- Remove unnecessary `# type: ignore[misc,assignment,unused-ignore]` from tracing.py:43 - mypy doesn't require it for this pattern
- Remove unused `AsyncMock` import from test_run_all_command.py