### PR TITLE
Run tests and fix errors

### DIFF
--- a/tests/architecture/test_port_contracts_hypothesis.py
+++ b/tests/architecture/test_port_contracts_hypothesis.py
@@ -269,7 +269,12 @@ class TestRateLimiterPortProperties:
             f"Initial tokens ({available}) != capacity ({capacity})"
         )
 
-    @given(rate=rate_strategy, capacity=capacity_strategy)
+    @given(
+        # Limit rate to avoid token refill during test execution.
+        # At rate=10.0, only 0.1 tokens refill in 10ms - not enough for a whole token.
+        rate=st.floats(min_value=0.1, max_value=10.0),
+        capacity=capacity_strategy,
+    )
     @settings(max_examples=50, deadline=5000)
     def test_try_acquire_respects_capacity(self, rate: float, capacity: int) -> None:
         """Property: try_acquire() MUST fail after capacity tokens acquired."""


### PR DESCRIPTION
Limit rate strategy to max 10.0 tokens/sec to prevent token refill during test execution. At higher rates (up to 1000/sec), tokens could refill between try_acquire() calls, causing intermittent failures.