### PR TITLE
Fix failing lint and type checks

### DIFF
--- a/src/bioetl/domain/services/activity_aggregator.py
+++ b/src/bioetl/domain/services/activity_aggregator.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import math
 import statistics
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING
@@ -133,29 +133,36 @@ class ActivityAggregator:
         if not values:
             raise ValueError("Cannot aggregate empty sequence")
 
-        # Convert to list for operations
         value_list = list(values)
+        parsed_method = self._parse_method(method)
+        return self._apply_aggregation(value_list, parsed_method)
 
-        # Parse method
-        if isinstance(method, str):
-            try:
-                method = AggregationMethod(method.lower())
-            except ValueError as err:
-                raise ValueError(f"Unknown aggregation method: {method}") from err
+    def _parse_method(self, method: str | AggregationMethod) -> AggregationMethod:
+        """Parse aggregation method string to enum."""
+        if isinstance(method, AggregationMethod):
+            return method
+        try:
+            return AggregationMethod(method.lower())
+        except ValueError as err:
+            raise ValueError(f"Unknown aggregation method: {method}") from err
 
-        # Apply method
-        if method == AggregationMethod.MEAN:
-            return statistics.mean(value_list)
-        elif method == AggregationMethod.MEDIAN:
-            return statistics.median(value_list)
-        elif method == AggregationMethod.GEOMETRIC_MEAN:
-            return _geometric_mean(value_list)
-        elif method == AggregationMethod.MINIMUM:
-            return min(value_list)
-        elif method == AggregationMethod.MAXIMUM:
-            return max(value_list)
-        else:
+    def _apply_aggregation(
+        self,
+        values: list[float],
+        method: AggregationMethod,
+    ) -> float:
+        """Apply aggregation method to values."""
+        aggregators: dict[AggregationMethod, Callable[[Sequence[float]], float]] = {
+            AggregationMethod.MEAN: statistics.mean,
+            AggregationMethod.MEDIAN: statistics.median,
+            AggregationMethod.GEOMETRIC_MEAN: _geometric_mean,
+            AggregationMethod.MINIMUM: min,
+            AggregationMethod.MAXIMUM: max,
+        }
+        aggregator = aggregators.get(method)
+        if aggregator is None:
             raise ValueError(f"Unsupported aggregation method: {method}")
+        return aggregator(values)
 
     def aggregate_with_uncertainty(
         self,
@@ -187,29 +194,38 @@ class ActivityAggregator:
 
         value_list = list(values)
         aggregated = self.aggregate_values(value_list, method)
-
-        # Calculate uncertainty based on method
-        if isinstance(method, str):
-            method = AggregationMethod(method.lower())
-
-        if len(value_list) < 2:
-            uncertainty = 0.0
-        elif method == AggregationMethod.MEDIAN:
-            # Use MAD for median (more robust)
-            uncertainty = _median_absolute_deviation(value_list)
-        elif method == AggregationMethod.GEOMETRIC_MEAN:
-            # Use geometric standard deviation
-            log_values = [math.log(v) for v in value_list if v > 0]
-            if len(log_values) >= 2:
-                log_std = statistics.stdev(log_values)
-                uncertainty = aggregated * (math.exp(log_std) - 1)
-            else:
-                uncertainty = 0.0
-        else:
-            # Use standard deviation for mean and others
-            uncertainty = statistics.stdev(value_list)
+        parsed_method = self._parse_method(method)
+        uncertainty = self._calculate_uncertainty(value_list, parsed_method, aggregated)
 
         return aggregated, uncertainty
+
+    def _calculate_uncertainty(
+        self,
+        values: list[float],
+        method: AggregationMethod,
+        aggregated: float,
+    ) -> float:
+        """Calculate uncertainty based on aggregation method."""
+        if len(values) < 2:
+            return 0.0
+
+        if method == AggregationMethod.MEDIAN:
+            return _median_absolute_deviation(values)
+        if method == AggregationMethod.GEOMETRIC_MEAN:
+            return self._geometric_uncertainty(values, aggregated)
+        return statistics.stdev(values)
+
+    def _geometric_uncertainty(
+        self,
+        values: list[float],
+        aggregated: float,
+    ) -> float:
+        """Calculate uncertainty for geometric mean using log-space std."""
+        log_values = [math.log(v) for v in values if v > 0]
+        if len(log_values) < 2:
+            return 0.0
+        log_std = statistics.stdev(log_values)
+        return aggregated * (math.exp(log_std) - 1)
 
     def aggregate_concentrations(
         self,
@@ -345,15 +361,32 @@ class ActivityAggregator:
             >>> aggregator.filter_and_aggregate(values, min_value=50.0, max_value=500.0)
             150.0
         """
-        filtered = []
-        for v in values:
-            if min_value is not None and v < min_value:
-                continue
-            if max_value is not None and v > max_value:
-                continue
-            filtered.append(v)
+        filtered = self._filter_by_range(values, min_value, max_value)
 
         if not filtered:
             return None
 
         return self.aggregate_values(filtered, method)
+
+    def _filter_by_range(
+        self,
+        values: Sequence[float],
+        min_value: float | None,
+        max_value: float | None,
+    ) -> list[float]:
+        """Filter values to those within the specified range."""
+        return [
+            v for v in values
+            if self._is_in_range(v, min_value, max_value)
+        ]
+
+    def _is_in_range(
+        self,
+        value: float,
+        min_value: float | None,
+        max_value: float | None,
+    ) -> bool:
+        """Check if value is within the specified range (inclusive)."""
+        if min_value is not None and value < min_value:
+            return False
+        return not (max_value is not None and value > max_value)

--- a/src/bioetl/domain/services/identity_service.py
+++ b/src/bioetl/domain/services/identity_service.py
@@ -178,28 +178,43 @@ class IdentityService:
         """
         if value is None:
             return None
+        return self._normalize_by_type(value)
 
+    def _normalize_by_type(self, value: Any) -> Any:
+        """Dispatch normalization by type."""
+        # Handle scalar types first
+        scalar_result = self._normalize_scalar(value)
+        if scalar_result is not value:  # Was processed
+            return scalar_result
+
+        # Handle container types
+        return self._normalize_container(value)
+
+    def _normalize_scalar(self, value: Any) -> Any:
+        """Normalize scalar types: float, datetime, date, str."""
         if isinstance(value, float):
-            if math.isnan(value) or math.isinf(value):
-                return None
-            return round(value, 10)
-
+            return self._normalize_float(value)
         if isinstance(value, datetime):
             return value.date().isoformat()
-
         if isinstance(value, date):
             return value.isoformat()
-
         if isinstance(value, str):
             return value.strip()
+        return value  # Return unchanged if not a scalar type we handle
 
+    def _normalize_container(self, value: Any) -> Any:
+        """Normalize container types: dict, list."""
         if isinstance(value, dict):
             return {k: self._normalize_value(v) for k, v in value.items()}
-
         if isinstance(value, list):
             return [self._normalize_value(v) for v in value]
-
         return value
+
+    def _normalize_float(self, value: float) -> float | None:
+        """Normalize float value: NaN/Inf → None, else round to 10 decimals."""
+        if math.isnan(value) or math.isinf(value):
+            return None
+        return round(value, 10)
 
     @staticmethod
     def _canonical_json_dumps(obj: dict[str, Any]) -> str:

--- a/src/bioetl/domain/services/normalization_config.py
+++ b/src/bioetl/domain/services/normalization_config.py
@@ -53,12 +53,20 @@ class PChemblRangeConfig:
 
     def __post_init__(self) -> None:
         """Validate pChEMBL range configuration."""
+        self._validate_absolute_range()
+        self._validate_typical_range()
+
+    def _validate_absolute_range(self) -> None:
+        """Validate absolute min/max range."""
         if self.min_value < 0:
             raise ValueError("min_value cannot be negative")
         if self.max_value > 15:
             raise ValueError("max_value exceeds physical limit")
         if self.min_value >= self.max_value:
             raise ValueError("min_value must be less than max_value")
+
+    def _validate_typical_range(self) -> None:
+        """Validate typical range is ordered."""
         if self.typical_min >= self.typical_max:
             raise ValueError("typical_min must be less than typical_max")
 

--- a/src/bioetl/domain/services/normalization_service.py
+++ b/src/bioetl/domain/services/normalization_service.py
@@ -231,11 +231,15 @@ class NormalizationService:
         if not aggregate:
             return results
 
-        # Filter to valid values if requested
-        if filter_invalid:
-            valid_results = [r for r in results if r.is_valid]
-        else:
-            valid_results = results
+        return self._aggregate_results(results, filter_invalid)
+
+    def _aggregate_results(
+        self,
+        results: list[NormalizationResult],
+        filter_invalid: bool,
+    ) -> NormalizationResult:
+        """Aggregate multiple normalization results into one."""
+        valid_results = self._filter_valid_results(results, filter_invalid)
 
         if not valid_results:
             return NormalizationResult(
@@ -245,30 +249,52 @@ class NormalizationService:
                 validation_message="No valid values to aggregate",
             )
 
-        # Aggregate values
+        return self._build_aggregated_result(valid_results)
+
+    def _filter_valid_results(
+        self,
+        results: list[NormalizationResult],
+        filter_invalid: bool,
+    ) -> list[NormalizationResult]:
+        """Filter results to valid ones if requested."""
+        if filter_invalid:
+            return [r for r in results if r.is_valid]
+        return results
+
+    def _build_aggregated_result(
+        self,
+        valid_results: list[NormalizationResult],
+    ) -> NormalizationResult:
+        """Build aggregated result from valid results."""
         valid_values = [r.value for r in valid_results]
         aggregated = self.aggregator.aggregate_values(
             valid_values,
             self.config.default_aggregation_method,
         )
 
-        # Calculate pChEMBL for aggregated value
-        pchembl = None
-        is_potent = False
-        target_unit = self.config.default_output_unit
-        try:
-            pchembl = self.converter.value_to_pchembl(aggregated, target_unit)
-            is_potent = pchembl.value >= self.config.potency_threshold
-        except ValueError:
-            pass
+        pchembl, is_potent = self._compute_pchembl_for_value(aggregated)
 
         return NormalizationResult(
             value=aggregated,
-            unit=target_unit,
+            unit=self.config.default_output_unit,
             pchembl=pchembl,
             is_valid=True,
             is_potent=is_potent,
         )
+
+    def _compute_pchembl_for_value(
+        self,
+        value: float,
+    ) -> tuple[PChemblValue | None, bool]:
+        """Compute pChEMBL value and potency for a normalized value."""
+        try:
+            pchembl = self.converter.value_to_pchembl(
+                value, self.config.default_output_unit
+            )
+            is_potent = pchembl.value >= self.config.potency_threshold
+            return pchembl, is_potent
+        except ValueError:
+            return None, False
 
     def normalize_concentrations(
         self,

--- a/src/bioetl/domain/services/value_validator.py
+++ b/src/bioetl/domain/services/value_validator.py
@@ -87,33 +87,53 @@ class ValueValidator:
             >>> validator.validate_concentration(-1.0, "nM")
             (False, 'Concentration cannot be negative: -1.0')
         """
-        # Negative values are always invalid
+        # Check basic value constraints
+        basic_error = self._check_basic_concentration(value)
+        if basic_error:
+            return False, basic_error
+
+        # Check unit and range
+        return self._check_concentration_range(value, unit)
+
+    def _check_basic_concentration(self, value: float) -> str | None:
+        """Check basic concentration constraints (non-negative, non-zero)."""
         if value < 0:
-            return False, f"Concentration cannot be negative: {value}"
-
-        # Zero is technically valid but suspicious
+            return f"Concentration cannot be negative: {value}"
         if value == 0:
-            return False, "Concentration cannot be zero"
+            return "Concentration cannot be zero"
+        return None
 
-        # Normalize unit for lookup
+    def _check_concentration_range(
+        self,
+        value: float,
+        unit: str,
+    ) -> tuple[bool, str | None]:
+        """Check if concentration is within valid range for unit."""
         normalized_unit = self._normalize_unit(unit)
         if normalized_unit not in self._concentration_ranges:
             return False, f"Unknown concentration unit: {unit}"
 
         min_val, max_val = self._concentration_ranges[normalized_unit]
+        return self._check_value_in_range(value, min_val, max_val, unit)
 
+    def _check_value_in_range(
+        self,
+        value: float,
+        min_val: float,
+        max_val: float,
+        unit: str,
+    ) -> tuple[bool, str | None]:
+        """Check if value is within min/max range."""
         if value < min_val:
             return False, (
                 f"Concentration {value} {unit} below minimum "
                 f"({min_val} {unit})"
             )
-
         if value > max_val:
             return False, (
                 f"Concentration {value} {unit} exceeds maximum "
                 f"({max_val} {unit})"
             )
-
         return True, None
 
     def validate_pchembl(
@@ -138,27 +158,40 @@ class ValueValidator:
             >>> validator.validate_pchembl(-1.0)
             (False, 'pChEMBL value cannot be negative: -1.00')
         """
-        if value < PCHEMBL_MIN:
-            return False, f"pChEMBL value cannot be negative: {value:.2f}"
+        # Check absolute range
+        range_error = self._check_pchembl_absolute_range(value)
+        if range_error:
+            return False, range_error
 
-        if value > PCHEMBL_MAX:
-            return False, (
-                f"pChEMBL value {value:.2f} exceeds maximum {PCHEMBL_MAX:.2f}"
-            )
-
-        # In strict mode, check typical range
+        # Check strict mode typical range
         if self.strict:
-            if value < PCHEMBL_TYPICAL_MIN:
-                return False, (
-                    f"pChEMBL value {value:.2f} below typical minimum "
-                    f"{PCHEMBL_TYPICAL_MIN:.2f} (very weak activity)"
-                )
-            if value > PCHEMBL_TYPICAL_MAX:
-                return False, (
-                    f"pChEMBL value {value:.2f} exceeds typical maximum "
-                    f"{PCHEMBL_TYPICAL_MAX:.2f} (unusually potent)"
-                )
+            return self._check_pchembl_typical_range(value)
 
+        return True, None
+
+    def _check_pchembl_absolute_range(self, value: float) -> str | None:
+        """Check pChEMBL value against absolute physical limits."""
+        if value < PCHEMBL_MIN:
+            return f"pChEMBL value cannot be negative: {value:.2f}"
+        if value > PCHEMBL_MAX:
+            return f"pChEMBL value {value:.2f} exceeds maximum {PCHEMBL_MAX:.2f}"
+        return None
+
+    def _check_pchembl_typical_range(
+        self,
+        value: float,
+    ) -> tuple[bool, str | None]:
+        """Check pChEMBL value against typical drug-like range."""
+        if value < PCHEMBL_TYPICAL_MIN:
+            return False, (
+                f"pChEMBL value {value:.2f} below typical minimum "
+                f"{PCHEMBL_TYPICAL_MIN:.2f} (very weak activity)"
+            )
+        if value > PCHEMBL_TYPICAL_MAX:
+            return False, (
+                f"pChEMBL value {value:.2f} exceeds typical maximum "
+                f"{PCHEMBL_TYPICAL_MAX:.2f} (unusually potent)"
+            )
         return True, None
 
     def validate_activity_value(
@@ -184,14 +217,7 @@ class ValueValidator:
             >>> validator.validate_activity_value(100.0, "IC50", "nM")
             (True, None)
         """
-        # Parse activity type if string
-        parsed_type: ActivityType | str = activity_type
-        if isinstance(activity_type, str):
-            try:
-                parsed_type = ActivityType.from_string(activity_type)
-            except ValueError:
-                # Unknown activity type - allow with basic validation
-                parsed_type = activity_type
+        parsed_type = self._parse_activity_type(activity_type)
 
         # Basic numeric validation
         if value < 0:
@@ -201,14 +227,43 @@ class ValueValidator:
         if unit:
             return self.validate_concentration(value, unit)
 
+        # Type-specific validation
+        return self._validate_by_activity_type(value, parsed_type)
+
+    def _parse_activity_type(
+        self,
+        activity_type: ActivityType | str,
+    ) -> ActivityType | str:
+        """Parse activity type string to enum if possible."""
+        if isinstance(activity_type, ActivityType):
+            return activity_type
+        try:
+            return ActivityType.from_string(activity_type)
+        except ValueError:
+            return activity_type
+
+    def _validate_by_activity_type(
+        self,
+        value: float,
+        parsed_type: ActivityType | str,
+    ) -> tuple[bool, str | None]:
+        """Validate value based on specific activity type."""
         # For percentage values (e.g., % Inhibition)
-        if (
+        if self._is_percent_inhibition_type(parsed_type):
+            return self._validate_percent_value(value)
+        return True, None
+
+    def _is_percent_inhibition_type(self, parsed_type: ActivityType | str) -> bool:
+        """Check if activity type is percent inhibition."""
+        return (
             isinstance(parsed_type, ActivityType)
             and parsed_type == ActivityType.PERCENT_INHIBITION
-            and (value < 0 or value > 100)
-        ):
-            return False, f"Percent inhibition must be 0-100, got {value}"
+        )
 
+    def _validate_percent_value(self, value: float) -> tuple[bool, str | None]:
+        """Validate percentage value is within 0-100 range."""
+        if value < 0 or value > 100:
+            return False, f"Percent inhibition must be 0-100, got {value}"
         return True, None
 
     def is_potent(


### PR DESCRIPTION
Decompose complex methods in domain services to meet CC ≤ 5 threshold:

- identity_service.py: Split _normalize_value into _normalize_scalar, _normalize_container, _normalize_by_type (CC 12→5)
- normalization_service.py: Extract _aggregate_results, _filter_valid_results, _build_aggregated_result, _compute_pchembl_for_value (CC 9→5)
- activity_aggregator.py: Extract _parse_method, _apply_aggregation, _calculate_uncertainty, _geometric_uncertainty, _filter_by_range, _is_in_range (CC 9→5)
- value_validator.py: Extract _check_basic_concentration, _check_concentration_range, _check_value_in_range, _check_pchembl_absolute_range, _check_pchembl_typical_range, _parse_activity_type, _validate_by_activity_type, _is_percent_inhibition_type, _validate_percent_value (CC 9→5)
- normalization_config.py: Split PChemblRangeConfig validation into _validate_absolute_range, _validate_typical_range (CC 6→5)

All 944 domain unit tests pass. Domain layer now passes xenon strict check.