### PR TITLE
Fix failing lint and type checks

### DIFF
--- a/src/bioetl/application/pipelines/chembl/activity_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/activity_transformer.py
@@ -31,7 +31,7 @@ _LIGAND_EFFICIENCY_FIELDS: dict[str, Any] = {
     "bei": safe_float,
     "le": safe_float,
     "lle": safe_float,
-    "sei": safe_hthtib rjyakbrnckbzybzfloat,
+    "sei": safe_float,
 }
 
 # Mapping for action type fields extraction (nested dict)


### PR DESCRIPTION
The `sei` field in `_LIGAND_EFFICIENCY_FIELDS` had corrupted text (`safe_hthtib rjyakbrnckbzybzfloat`) which caused syntax errors and failed lint/type checks. Restored to correct value `safe_float`.