### PR TITLE
Run tests and fix errors

### DIFF
--- a/tests/architecture/test_write_mode_types.py
+++ b/tests/architecture/test_write_mode_types.py
@@ -193,7 +193,7 @@ def test_overwrite_for_silver_raises_error() -> None:
     """
     from bioetl.domain.config import TableConfig
 
-    with pytest.raises(ValueError, match="Invalid Silver write mode.*overwrite"):
+    with pytest.raises(ValueError, match=r"Invalid Silver write mode.*overwrite"):
         TableConfig(silver_write_mode="overwrite")
 
 

--- a/tests/unit/application/core/test_field_specs.py
+++ b/tests/unit/application/core/test_field_specs.py
@@ -111,14 +111,14 @@ class TestMapField:
         """Test that missing required field raises ValueError."""
         record: dict[str, str] = {}
         spec = FieldSpec("required_field", required=True)
-        with pytest.raises(ValueError, match="Required field.*missing"):
+        with pytest.raises(ValueError, match=r"Required field.*missing"):
             map_field(record, spec)
 
     def test_required_field_none_raises(self) -> None:
         """Test that None value for required field raises ValueError."""
         record = {"required_field": None}
         spec = FieldSpec("required_field", required=True)
-        with pytest.raises(ValueError, match="Required field.*missing"):
+        with pytest.raises(ValueError, match=r"Required field.*missing"):
             map_field(record, spec)
 
     def test_default_value_when_missing(self) -> None:

--- a/tests/unit/application/core/test_preflight_service.py
+++ b/tests/unit/application/core/test_preflight_service.py
@@ -712,7 +712,7 @@ class TestValidateWriteModes:
         The 'overwrite' mode is not a valid SilverWriteMode.
         PipelineConfig raises ValueError during construction.
         """
-        with pytest.raises(ValueError, match="Invalid Silver write mode.*overwrite"):
+        with pytest.raises(ValueError, match=r"Invalid Silver write mode.*overwrite"):
             PipelineConfig(
                 pipeline_name="test",
                 provider="chembl",

--- a/tests/unit/domain/test_filter_config.py
+++ b/tests/unit/domain/test_filter_config.py
@@ -147,7 +147,7 @@ class TestGoldColumnFilter:
 
     def test_empty_values_raises(self):
         """Test that empty values raises ValueError."""
-        with pytest.raises(ValueError, match="values for column .* cannot be empty"):
+        with pytest.raises(ValueError, match=r"values for column .* cannot be empty"):
             GoldColumnFilter(column="standard_type", values=frozenset())
 
     def test_filter_is_frozen(self):


### PR DESCRIPTION
Convert regex patterns in pytest.raises(match=...) to raw strings to fix RUF043 lint warnings about unescaped metacharacters.