### PR TITLE
Fix Bronze configuration to enforce JSONL/Delta

### DIFF
--- a/src/bioetl/domain/config_types.py
+++ b/src/bioetl/domain/config_types.py
@@ -60,10 +60,14 @@ class CsvExportDict(TypedDict, total=False):
 
 
 class BronzeSinkDict(TypedDict, total=False):
-    """YAML structure for Bronze layer sink configuration."""
+    """YAML structure for Bronze layer sink configuration.
+
+    Note: Bronze format MUST be "jsonl" per RULES.md §2.1 and Medallion Architecture.
+    Parquet is not allowed for Bronze layer - only JSONL + zstd compression.
+    """
 
     path: str
-    format: Literal["jsonl", "parquet"]
+    format: Literal["jsonl"]  # RULES.md §2.1: Bronze MUST use JSONL + zstd
     save_json: bool
 
 

--- a/src/bioetl/infrastructure/schemas/pipeline_config.py
+++ b/src/bioetl/infrastructure/schemas/pipeline_config.py
@@ -428,26 +428,33 @@ class PipelineYamlConfig(BaseModel):
     def validate_medallion_formats(self) -> PipelineYamlConfig:
         """Validate Medallion Architecture format constraints.
 
-        RULES.md §2.1: Silver and Gold MUST use Delta Lake format.
-        Bronze MAY use JSONL (preferred) or Delta.
+        RULES.md §2.1:
+        - Bronze MUST use JSONL + zstd format (not parquet, not delta)
+        - Silver MUST use Delta Lake format (not parquet)
+        - Gold MAY use Delta Lake or Parquet
 
         Raises:
-            ValueError: If Silver or Gold layer uses Parquet format.
+            ValueError: If layer format violates Medallion Architecture constraints.
         """
+        bronze_config = self.sink.get("bronze")
         silver_config = self.sink.get("silver")
-        gold_config = self.sink.get("gold")
 
+        # Bronze MUST use JSONL only (RULES.md §2.1)
+        if bronze_config and bronze_config.format != "jsonl":
+            raise ValueError(
+                f"Bronze layer MUST use 'jsonl' format (RULES.md §2.1). "
+                f"Got '{bronze_config.format}'. "
+                "Parquet and Delta are not allowed for Bronze layer."
+            )
+
+        # Silver MUST use Delta Lake (RULES.md §2.1)
         if silver_config and silver_config.format == "parquet":
             raise ValueError(
                 "Silver layer MUST use 'delta' format (RULES.md §2.1). "
                 "Parquet is not allowed for Silver layer."
             )
 
-        if gold_config and gold_config.format == "parquet":
-            raise ValueError(
-                "Gold layer MUST use 'delta' format (RULES.md §2.1). "
-                "Parquet is not allowed for Gold layer."
-            )
+        # Gold MAY use delta or parquet (RULES.md §2.1) - no validation needed
 
         return self
 


### PR DESCRIPTION
Bronze layer was incorrectly allowing parquet format in BronzeSinkDict, violating RULES.md §2.1 Medallion Architecture requirements.

Changes:
- BronzeSinkDict: Restrict format to Literal["jsonl"] only
- PipelineYamlConfig: Add validation for Bronze format (must be jsonl)
- Remove incorrect Gold parquet restriction (Gold MAY use parquet per RULES.md)

Per RULES.md §2.1:
- Bronze MUST use JSONL + zstd
- Silver MUST use Delta Lake
- Gold MAY use Delta/Parquet