### PR TITLE
Fix failing lint and type checks

### DIFF
--- a/src/bioetl/application/core/executor.py
+++ b/src/bioetl/application/core/executor.py
@@ -37,7 +37,9 @@ __all__ = ["BatchExecutor", "BatchResult", "Executor", "execute", "process"]
 Executor = BatchExecutor
 
 
-async def execute(executor: BatchExecutor, limit: int | None, query: str | None = None) -> None:
+async def execute(
+    executor: BatchExecutor, limit: int | None, query: str | None = None
+) -> None:
     """Execute the pipeline with the given executor.
 
     Convenience function for executing a pipeline with tracing.

--- a/src/bioetl/application/core/postrun_service.py
+++ b/src/bioetl/application/core/postrun_service.py
@@ -171,7 +171,9 @@ class PostrunService:
                     error=str(e),
                 )
 
-    def _collect_batch_metrics(self, executor: ExecutorMetricsProtocol) -> dict[str, float]:
+    def _collect_batch_metrics(
+        self, executor: ExecutorMetricsProtocol
+    ) -> dict[str, float]:
         """Collect batch metrics from executor.
 
         Args:

--- a/src/bioetl/application/services/pipeline_runner_service.py
+++ b/src/bioetl/application/services/pipeline_runner_service.py
@@ -148,9 +148,7 @@ class PipelineNotFoundError(ValueError):
     def __init__(self, pipeline_name: str, available: list[str]) -> None:
         self.pipeline_name = pipeline_name
         self.available = available
-        super().__init__(
-            f"Unknown pipeline: {pipeline_name}. Available: {available}"
-        )
+        super().__init__(f"Unknown pipeline: {pipeline_name}. Available: {available}")
 
 
 @dataclass
@@ -259,7 +257,9 @@ class PipelineRunnerService:
             )
 
         # Build context and create runner
-        context = self._build_context(pipeline_name, effective_run_id, effective_options)
+        context = self._build_context(
+            pipeline_name, effective_run_id, effective_options
+        )
         runner = self.runner_factory.create(context)
 
         # Execute pipeline

--- a/src/bioetl/composition/factories/pipeline_factories.py
+++ b/src/bioetl/composition/factories/pipeline_factories.py
@@ -206,7 +206,9 @@ PIPELINE_CONFIGS: tuple[PipelineFactoryConfig, ...] = (
 )
 
 
-def _create_factory(config: PipelineFactoryConfig) -> GenericPipelineFactory[GenericPipeline]:
+def _create_factory(
+    config: PipelineFactoryConfig,
+) -> GenericPipelineFactory[GenericPipeline]:
     """Create a GenericPipelineFactory from configuration.
 
     Args:
@@ -355,9 +357,7 @@ def get_factory(pipeline_name: str) -> GenericPipelineFactory[GenericPipeline]:
     """
     if pipeline_name not in _factories:
         available = sorted(_factories.keys())
-        raise KeyError(
-            f"Unknown pipeline: {pipeline_name}. Available: {available}"
-        )
+        raise KeyError(f"Unknown pipeline: {pipeline_name}. Available: {available}")
     return _factories[pipeline_name]
 
 

--- a/src/bioetl/composition/factories/services_factory.py
+++ b/src/bioetl/composition/factories/services_factory.py
@@ -436,7 +436,9 @@ class ServicesBuilder:
         )
 
         # Create Gold validator
-        gold_validator = PanderaGoldValidator(gold_schema, strict=strict_gold_validation)
+        gold_validator = PanderaGoldValidator(
+            gold_schema, strict=strict_gold_validation
+        )
 
         return BatchExecutor(
             services=pipeline.services,

--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -36,11 +36,9 @@ from bioetl.domain.context import (
 )
 
 # Entities (Domain objects)
-from bioetl.domain.entities import (
-    # DTO Records (Pydantic)
+from bioetl.domain.entities import (  # DTO Records (Pydantic); Domain Entities (dataclass)
     ActivityRecord,
     ArticleRecord,
-    # Domain Entities (dataclass)
     Assay,
     AssayRecord,
     BaseEntity,

--- a/src/bioetl/domain/aggregates/pipeline_run.py
+++ b/src/bioetl/domain/aggregates/pipeline_run.py
@@ -13,6 +13,7 @@ from bioetl.domain.types import RunID, RunType
 
 class StageStatus(str, Enum):
     """Status of a pipeline stage."""
+
     PENDING = "pending"
     RUNNING = "running"
     SUCCESS = "success"
@@ -22,6 +23,7 @@ class StageStatus(str, Enum):
 
 class RunStatus(str, Enum):
     """Status of a pipeline run."""
+
     PENDING = "pending"
     RUNNING = "running"
     COMPLETED = "completed"

--- a/src/bioetl/domain/entities/bioactivity.py
+++ b/src/bioetl/domain/entities/bioactivity.py
@@ -48,6 +48,7 @@ def _require_field(raw_data: dict[str, Any], field: str) -> Any:
 def _safe_json(val: Any) -> str | None:
     """Convert to JSON string if not None/empty."""
     import json
+
     return json.dumps(val) if val else None
 
 

--- a/src/bioetl/domain/entities/chembl.py
+++ b/src/bioetl/domain/entities/chembl.py
@@ -212,18 +212,12 @@ class AssayRecord(BaseModel):
     assay_chembl_id: str = Field(description="Unique assay ChEMBL ID")
 
     # Core identifiers
-    target_chembl_id: str | None = Field(
-        default=None, description="Target ChEMBL ID"
-    )
+    target_chembl_id: str | None = Field(default=None, description="Target ChEMBL ID")
     document_chembl_id: str | None = Field(
         default=None, description="Source document ChEMBL ID"
     )
-    cell_chembl_id: str | None = Field(
-        default=None, description="Cell line ChEMBL ID"
-    )
-    tissue_chembl_id: str | None = Field(
-        default=None, description="Tissue ChEMBL ID"
-    )
+    cell_chembl_id: str | None = Field(default=None, description="Cell line ChEMBL ID")
+    tissue_chembl_id: str | None = Field(default=None, description="Tissue ChEMBL ID")
     src_id: int | None = Field(default=None, description="Data source ID")
     src_assay_id: str | None = Field(
         default=None, description="Original source assay ID"
@@ -237,9 +231,7 @@ class AssayRecord(BaseModel):
     assay_type_description: str | None = Field(
         default=None, description="Full assay type description"
     )
-    assay_category: str | None = Field(
-        default=None, description="Assay category"
-    )
+    assay_category: str | None = Field(default=None, description="Assay category")
     assay_test_type: str | None = Field(
         default=None, description="Test type (in vivo/in vitro)"
     )
@@ -252,15 +244,9 @@ class AssayRecord(BaseModel):
     assay_tax_id: int | None = Field(
         default=None, description="NCBI Taxonomy ID for assay organism"
     )
-    assay_cell_type: str | None = Field(
-        default=None, description="Cell type used"
-    )
-    assay_tissue: str | None = Field(
-        default=None, description="Tissue type used"
-    )
-    assay_strain: str | None = Field(
-        default=None, description="Strain used"
-    )
+    assay_cell_type: str | None = Field(default=None, description="Cell type used")
+    assay_tissue: str | None = Field(default=None, description="Tissue type used")
+    assay_strain: str | None = Field(default=None, description="Strain used")
     assay_subcellular_fraction: str | None = Field(
         default=None, description="Subcellular fraction"
     )
@@ -270,9 +256,7 @@ class AssayRecord(BaseModel):
     bao_label: str | None = Field(default=None, description="BAO label")
 
     # Description and confidence
-    description: str | None = Field(
-        default=None, description="Full assay description"
-    )
+    description: str | None = Field(default=None, description="Full assay description")
     confidence_score: int | None = Field(
         default=None, description="Target confidence score (0-9)"
     )
@@ -298,15 +282,11 @@ class AssayRecord(BaseModel):
     variant_accession: str | None = Field(
         default=None, description="Variant UniProt accession"
     )
-    variant_isoform: str | None = Field(
-        default=None, description="Variant isoform"
-    )
+    variant_isoform: str | None = Field(default=None, description="Variant isoform")
     variant_mutation: str | None = Field(
         default=None, description="Variant mutation (e.g., V600E)"
     )
-    variant_organism: str | None = Field(
-        default=None, description="Variant organism"
-    )
+    variant_organism: str | None = Field(default=None, description="Variant organism")
     variant_sequence: str | None = Field(
         default=None, description="Variant amino acid sequence"
     )
@@ -339,9 +319,7 @@ class MoleculeRecord(BaseModel):
     molecule_chembl_id: str = Field(description="Unique molecule ChEMBL ID")
 
     # Core metadata
-    pref_name: str | None = Field(
-        default=None, description="Preferred molecule name"
-    )
+    pref_name: str | None = Field(default=None, description="Preferred molecule name")
     molecule_type: str | None = Field(
         default=None, description="Type (Small molecule, Protein, Antibody, etc.)"
     )
@@ -369,24 +347,19 @@ class MoleculeRecord(BaseModel):
     natural_product: int | None = Field(
         default=None, description="Natural product flag"
     )
-    first_in_class: int | None = Field(
-        default=None, description="First in class flag"
-    )
+    first_in_class: int | None = Field(default=None, description="First in class flag")
     prodrug: int | None = Field(default=None, description="Prodrug flag")
     therapeutic_flag: bool | None = Field(
         default=None, description="Therapeutic use flag"
     )
-    withdrawn_flag: bool | None = Field(
-        default=None, description="Withdrawn drug flag"
-    )
+    withdrawn_flag: bool | None = Field(default=None, description="Withdrawn drug flag")
     inorganic_flag: int | None = Field(
         default=None, description="Inorganic compound flag"
     )
-    polymer_flag: int | None = Field(
-        default=None, description="Polymer flag"
-    )
+    polymer_flag: int | None = Field(default=None, description="Polymer flag")
     chirality: int | None = Field(
-        default=None, description="Chirality (-1 single, 0 achiral, 1 racemic, 2 mixture)"
+        default=None,
+        description="Chirality (-1 single, 0 achiral, 1 racemic, 2 mixture)",
     )
     dosed_ingredient: int | None = Field(
         default=None, description="Dosed ingredient flag"
@@ -430,18 +403,10 @@ class MoleculeRecord(BaseModel):
     property_full_mwt: float | None = Field(
         default=None, description="Full molecular weight"
     )
-    property_hba: int | None = Field(
-        default=None, description="H-bond acceptor count"
-    )
-    property_hbd: int | None = Field(
-        default=None, description="H-bond donor count"
-    )
-    property_psa: float | None = Field(
-        default=None, description="Polar surface area"
-    )
-    property_rtb: int | None = Field(
-        default=None, description="Rotatable bond count"
-    )
+    property_hba: int | None = Field(default=None, description="H-bond acceptor count")
+    property_hbd: int | None = Field(default=None, description="H-bond donor count")
+    property_psa: float | None = Field(default=None, description="Polar surface area")
+    property_rtb: int | None = Field(default=None, description="Rotatable bond count")
     property_ro5_violations: int | None = Field(
         default=None, description="Rule of 5 violations"
     )
@@ -506,32 +471,23 @@ class TargetRecord(BaseModel):
     target_chembl_id: str = Field(description="Unique target ChEMBL ID")
 
     # Core metadata
-    pref_name: str | None = Field(
-        default=None, description="Preferred target name"
-    )
+    pref_name: str | None = Field(default=None, description="Preferred target name")
     target_type: str | None = Field(
-        default=None, description="Type (SINGLE PROTEIN, PROTEIN COMPLEX, ORGANISM, etc.)"
+        default=None,
+        description="Type (SINGLE PROTEIN, PROTEIN COMPLEX, ORGANISM, etc.)",
     )
-    organism: str | None = Field(
-        default=None, description="Target organism"
-    )
-    tax_id: int | None = Field(
-        default=None, description="NCBI Taxonomy ID"
-    )
+    organism: str | None = Field(default=None, description="Target organism")
+    tax_id: int | None = Field(default=None, description="NCBI Taxonomy ID")
     species_group_flag: bool | None = Field(
         default=None, description="Species group flag"
     )
-    description: str | None = Field(
-        default=None, description="Target description"
-    )
+    description: str | None = Field(default=None, description="Target description")
     downgraded: bool | None = Field(
         default=None, description="Deprecated/downgraded flag"
     )
 
     # Optional fields
-    dap_id: int | None = Field(
-        default=None, description="Drug-Affinity Panel ID"
-    )
+    dap_id: int | None = Field(default=None, description="Drug-Affinity Panel ID")
     pipeline_stages: str | None = Field(
         default=None, description="Pipeline stages JSON"
     )
@@ -543,9 +499,7 @@ class TargetRecord(BaseModel):
     component_accessions: list[str] | None = Field(
         default=None, description="Component UniProt accessions"
     )
-    component_ids: list[int] | None = Field(
-        default=None, description="Component IDs"
-    )
+    component_ids: list[int] | None = Field(default=None, description="Component IDs")
     component_types: list[str] | None = Field(
         default=None, description="Component types"
     )
@@ -635,9 +589,7 @@ class CellLineRecord(BaseModel):
     )
 
     # Source information
-    cell_source_tissue: str | None = Field(
-        default=None, description="Source tissue"
-    )
+    cell_source_tissue: str | None = Field(default=None, description="Source tissue")
     cell_source_organism: str | None = Field(
         default=None, description="Source organism"
     )
@@ -646,15 +598,9 @@ class CellLineRecord(BaseModel):
     )
 
     # External identifiers
-    cellosaurus_id: str | None = Field(
-        default=None, description="Cellosaurus ID"
-    )
-    cl_lincs_id: str | None = Field(
-        default=None, description="LINCS cell line ID"
-    )
-    efo_id: str | None = Field(
-        default=None, description="EFO ontology ID"
-    )
+    cellosaurus_id: str | None = Field(default=None, description="Cellosaurus ID")
+    cl_lincs_id: str | None = Field(default=None, description="LINCS cell line ID")
+    efo_id: str | None = Field(default=None, description="EFO ontology ID")
 
 
 class TargetComponentRecord(BaseModel):
@@ -670,21 +616,11 @@ class TargetComponentRecord(BaseModel):
     component_id: int = Field(description="Unique component ID")
 
     # Core metadata
-    accession: str | None = Field(
-        default=None, description="UniProt accession"
-    )
-    component_type: str | None = Field(
-        default=None, description="Component type"
-    )
-    description: str | None = Field(
-        default=None, description="Component description"
-    )
-    organism: str | None = Field(
-        default=None, description="Organism name"
-    )
-    tax_id: int | None = Field(
-        default=None, description="NCBI Taxonomy ID"
-    )
+    accession: str | None = Field(default=None, description="UniProt accession")
+    component_type: str | None = Field(default=None, description="Component type")
+    description: str | None = Field(default=None, description="Component description")
+    organism: str | None = Field(default=None, description="Organism name")
+    tax_id: int | None = Field(default=None, description="NCBI Taxonomy ID")
 
     # Flattened fields
     protein_classification_ids: list[int] | None = Field(

--- a/src/bioetl/domain/entities/crossref.py
+++ b/src/bioetl/domain/entities/crossref.py
@@ -72,9 +72,7 @@ class PublicationRecord(BaseModel):
     )
 
     # Authors (list of "given family" formatted names)
-    authors: list[str] = PydanticField(
-        default_factory=list, description="Author names"
-    )
+    authors: list[str] = PydanticField(default_factory=list, description="Author names")
 
     # Journal information
     journal: str | None = PydanticField(

--- a/src/bioetl/domain/entities/pubchem.py
+++ b/src/bioetl/domain/entities/pubchem.py
@@ -47,9 +47,7 @@ class PubChemCompoundRecord(BaseModel):
     cid: str = Field(description="PubChem Compound ID")
 
     # Molecular properties
-    molecular_formula: str | None = Field(
-        default=None, description="Molecular formula"
-    )
+    molecular_formula: str | None = Field(default=None, description="Molecular formula")
     molecular_weight: float | None = Field(
         default=None, description="Molecular weight in g/mol"
     )
@@ -61,22 +59,14 @@ class PubChemCompoundRecord(BaseModel):
     isomeric_smiles: str | None = Field(
         default=None, description="Isomeric SMILES (with stereochemistry)"
     )
-    inchi: str | None = Field(
-        default=None, description="InChI string"
-    )
-    inchikey: str | None = Field(
-        default=None, description="InChI Key"
-    )
+    inchi: str | None = Field(default=None, description="InChI string")
+    inchikey: str | None = Field(default=None, description="InChI Key")
 
     # Names
-    iupac_name: str | None = Field(
-        default=None, description="IUPAC systematic name"
-    )
+    iupac_name: str | None = Field(default=None, description="IUPAC systematic name")
 
     # Physical/Chemical properties
-    charge: int | None = Field(
-        default=None, description="Formal charge"
-    )
+    charge: int | None = Field(default=None, description="Formal charge")
     complexity: float | None = Field(
         default=None, description="Molecular complexity score"
     )
@@ -91,9 +81,7 @@ class PubChemCompoundRecord(BaseModel):
     )
 
     # Fingerprints
-    fingerprint: str | None = Field(
-        default=None, description="PubChem fingerprint"
-    )
+    fingerprint: str | None = Field(default=None, description="PubChem fingerprint")
 
 
 # === Dataclass Domain Entity ===

--- a/src/bioetl/domain/entities/pubmed.py
+++ b/src/bioetl/domain/entities/pubmed.py
@@ -48,42 +48,24 @@ class ArticleRecord(BaseModel):
     doi: str | None = PydanticField(
         default=None, description="Digital Object Identifier"
     )
-    pmc_id: str | None = PydanticField(
-        default=None, description="PubMed Central ID"
-    )
+    pmc_id: str | None = PydanticField(default=None, description="PubMed Central ID")
 
     # Title and abstract
-    title: str | None = PydanticField(
-        default=None, description="Article title"
-    )
-    abstract: str | None = PydanticField(
-        default=None, description="Abstract text"
-    )
+    title: str | None = PydanticField(default=None, description="Article title")
+    abstract: str | None = PydanticField(default=None, description="Abstract text")
 
     # Journal information
-    journal: str | None = PydanticField(
-        default=None, description="Full journal title"
-    )
+    journal: str | None = PydanticField(default=None, description="Full journal title")
     journal_abbrev: str | None = PydanticField(
         default=None, description="Journal abbreviation (ISO)"
     )
-    issn: str | None = PydanticField(
-        default=None, description="ISSN"
-    )
-    volume: str | None = PydanticField(
-        default=None, description="Volume number"
-    )
-    issue: str | None = PydanticField(
-        default=None, description="Issue number"
-    )
-    pages: str | None = PydanticField(
-        default=None, description="Page numbers"
-    )
+    issn: str | None = PydanticField(default=None, description="ISSN")
+    volume: str | None = PydanticField(default=None, description="Volume number")
+    issue: str | None = PydanticField(default=None, description="Issue number")
+    pages: str | None = PydanticField(default=None, description="Page numbers")
 
     # Authors (list of formatted names)
-    authors: list[str] = PydanticField(
-        default_factory=list, description="Author names"
-    )
+    authors: list[str] = PydanticField(default_factory=list, description="Author names")
 
     # Dates (ISO format: YYYY-MM-DD or partial)
     pub_date: str | None = PydanticField(
@@ -92,15 +74,9 @@ class ArticleRecord(BaseModel):
     pub_year: int | None = PydanticField(
         default=None, description="Publication year (for partitioning)"
     )
-    accepted_date: str | None = PydanticField(
-        default=None, description="Date accepted"
-    )
-    received_date: str | None = PydanticField(
-        default=None, description="Date received"
-    )
-    revised_date: str | None = PydanticField(
-        default=None, description="Date revised"
-    )
+    accepted_date: str | None = PydanticField(default=None, description="Date accepted")
+    received_date: str | None = PydanticField(default=None, description="Date received")
+    revised_date: str | None = PydanticField(default=None, description="Date revised")
     epub_date: str | None = PydanticField(
         default=None, description="Electronic publication date"
     )
@@ -109,9 +85,7 @@ class ArticleRecord(BaseModel):
     publication_types: list[str] = PydanticField(
         default_factory=list, description="Publication types"
     )
-    keywords: list[str] = PydanticField(
-        default_factory=list, description="Keywords"
-    )
+    keywords: list[str] = PydanticField(default_factory=list, description="Keywords")
     mesh_terms: list[str] = PydanticField(
         default_factory=list, description="MeSH terms"
     )

--- a/src/bioetl/domain/ports/noop.py
+++ b/src/bioetl/domain/ports/noop.py
@@ -368,9 +368,7 @@ class NoOpMemoryMonitor:
         overhead_factor = 2.5
         return (record_count * avg_record_size_bytes * overhead_factor) / (1024 * 1024)
 
-    def calculate_max_batch_size(
-        self, _avg_record_size_bytes: int = 1024
-    ) -> int:
+    def calculate_max_batch_size(self, _avg_record_size_bytes: int = 1024) -> int:
         """Return a high max batch size (no constraints).
 
         Args:

--- a/src/bioetl/domain/services/activity_aggregator.py
+++ b/src/bioetl/domain/services/activity_aggregator.py
@@ -51,9 +51,7 @@ def _geometric_mean(values: Sequence[float]) -> float:
 
     for v in values:
         if v <= 0:
-            raise ValueError(
-                f"Geometric mean requires positive values, got {v}"
-            )
+            raise ValueError(f"Geometric mean requires positive values, got {v}")
 
     log_sum = sum(math.log(v) for v in values)
     return math.exp(log_sum / len(values))
@@ -375,10 +373,7 @@ class ActivityAggregator:
         max_value: float | None,
     ) -> list[float]:
         """Filter values to those within the specified range."""
-        return [
-            v for v in values
-            if self._is_in_range(v, min_value, max_value)
-        ]
+        return [v for v in values if self._is_in_range(v, min_value, max_value)]
 
     def _is_in_range(
         self,

--- a/src/bioetl/domain/services/normalization_config.py
+++ b/src/bioetl/domain/services/normalization_config.py
@@ -102,9 +102,7 @@ class NormalizationConfig:
     concentration_range: ConcentrationRangeConfig = field(
         default_factory=ConcentrationRangeConfig
     )
-    pchembl_range: PChemblRangeConfig = field(
-        default_factory=PChemblRangeConfig
-    )
+    pchembl_range: PChemblRangeConfig = field(default_factory=PChemblRangeConfig)
     potency_threshold: float = 5.0  # pChEMBL >= 5 = active at 10 µM
     high_potency_threshold: float = 7.0  # pChEMBL >= 7 = active at 100 nM
 
@@ -113,9 +111,7 @@ class NormalizationConfig:
         if self.potency_threshold < 0:
             raise ValueError("potency_threshold cannot be negative")
         if self.high_potency_threshold < self.potency_threshold:
-            raise ValueError(
-                "high_potency_threshold must be >= potency_threshold"
-            )
+            raise ValueError("high_potency_threshold must be >= potency_threshold")
         valid_methods = {"mean", "median", "geometric_mean"}
         if self.default_aggregation_method not in valid_methods:
             raise ValueError(

--- a/src/bioetl/domain/services/value_validator.py
+++ b/src/bioetl/domain/services/value_validator.py
@@ -126,13 +126,11 @@ class ValueValidator:
         """Check if value is within min/max range."""
         if value < min_val:
             return False, (
-                f"Concentration {value} {unit} below minimum "
-                f"({min_val} {unit})"
+                f"Concentration {value} {unit} below minimum " f"({min_val} {unit})"
             )
         if value > max_val:
             return False, (
-                f"Concentration {value} {unit} exceeds maximum "
-                f"({max_val} {unit})"
+                f"Concentration {value} {unit} exceeds maximum " f"({max_val} {unit})"
             )
         return True, None
 

--- a/src/bioetl/domain/value_objects/activity.py
+++ b/src/bioetl/domain/value_objects/activity.py
@@ -131,7 +131,9 @@ class ConfidenceScore:
     def __post_init__(self) -> None:
         """Validate confidence score invariants."""
         if not isinstance(self.value, int):
-            raise TypeError(f"ConfidenceScore must be int, got {type(self.value).__name__}")
+            raise TypeError(
+                f"ConfidenceScore must be int, got {type(self.value).__name__}"
+            )
         if not 0 <= self.value <= 9:
             raise ValueError(f"Confidence score must be 0-9, got {self.value}")
 

--- a/src/bioetl/infrastructure/adapters/error_handling.py
+++ b/src/bioetl/infrastructure/adapters/error_handling.py
@@ -251,8 +251,17 @@ class ErrorService:
             error_type=error_type,
             error_category=error_category,
             retry_after=context.get("retry_after"),
-            extra={k: v for k, v in context.items()
-                   if k not in {"status_code", "retry_count", "circuit_breaker_state", "retry_after"}},
+            extra={
+                k: v
+                for k, v in context.items()
+                if k
+                not in {
+                    "status_code",
+                    "retry_count",
+                    "circuit_breaker_state",
+                    "retry_after",
+                }
+            },
         )
 
         # Log with unified format

--- a/src/bioetl/infrastructure/quarantine/unified.py
+++ b/src/bioetl/infrastructure/quarantine/unified.py
@@ -182,7 +182,9 @@ class UnifiedQuarantine:
         """
         return purge_records(self.base_path, None, pipeline, older_than_days, now=now)
 
-    def update_status(self, payload_hash: str, new_status: QuarantineRecordStatus) -> bool:
+    def update_status(
+        self, payload_hash: str, new_status: QuarantineRecordStatus
+    ) -> bool:
         """Update DQ status for a quarantined record."""
         try:
             dt = DeltaTable(self.base_path)

--- a/src/bioetl/infrastructure/schemas/source_config.py
+++ b/src/bioetl/infrastructure/schemas/source_config.py
@@ -218,7 +218,9 @@ class SourceYamlConfig(BaseModel):
         """
         return DomainAdapterConfig(
             batch_size=self.batch_size,
-            page_size=self.page_size if self.page_size is not None else default_page_size,
+            page_size=(
+                self.page_size if self.page_size is not None else default_page_size
+            ),
             timeout_sec=self.timeout_sec,
             max_retries=self.max_retries,
         )

--- a/src/bioetl/infrastructure/storage/base_delta_writer.py
+++ b/src/bioetl/infrastructure/storage/base_delta_writer.py
@@ -18,6 +18,24 @@ if TYPE_CHECKING:
     from bioetl.domain.ports import LoggerPort
 
 
+def _serialize_value(value: Any, is_string_field: bool) -> Any:
+    """Serialize a value for Arrow storage."""
+    if value is None:
+        return None
+    if is_string_field and isinstance(value, (dict, list)):
+        return orjson.dumps(value, option=orjson.OPT_SORT_KEYS).decode("utf-8")
+    return value
+
+
+def _get_string_fields(schema: pa.Schema) -> set[str]:
+    """Extract field names that are string types."""
+    return {
+        field.name
+        for field in schema
+        if pa.types.is_string(field.type) or pa.types.is_large_string(field.type)
+    }
+
+
 class BaseDeltaWriter:
     """Base class with common functionality for Delta Lake writers."""
 
@@ -38,36 +56,39 @@ class BaseDeltaWriter:
     ) -> pa.Table:
         """Prepare Arrow table from records with schema filtering and sorting."""
         schema_fields = set(schema.names)
-        string_fields = {
-            field.name
-            for field in schema
-            if pa.types.is_string(field.type) or pa.types.is_large_string(field.type)
-        }
-
-        def serialize_value(key: str, value: Any) -> Any:
-            if value is None:
-                return None
-            if key in string_fields and isinstance(value, (dict, list)):
-                return orjson.dumps(value, option=orjson.OPT_SORT_KEYS).decode("utf-8")
-            return value
+        string_fields = _get_string_fields(schema)
 
         filtered_records = [
-            {k: serialize_value(k, v) for k, v in rec.items() if k in schema_fields}
+            {
+                k: _serialize_value(v, k in string_fields)
+                for k, v in rec.items()
+                if k in schema_fields
+            }
             for rec in records
         ]
         arrow_data = pa.Table.from_pylist(filtered_records, schema=schema)
+        return self._sort_by_primary_keys(arrow_data, primary_keys, schema.names)
 
-        if primary_keys:
-            valid_keys = [pk for pk in primary_keys if pk in schema.names]
-            if valid_keys:
-                arrow_data = arrow_data.sort_by([(pk, "ascending") for pk in valid_keys])
-            elif primary_keys:
-                self.logger.warning(
-                    "Primary keys not found in schema, skipping sort",
-                    primary_keys=primary_keys,
-                    schema_fields=schema.names,
-                )
-        return arrow_data
+    def _sort_by_primary_keys(
+        self,
+        table: pa.Table,
+        primary_keys: list[str],
+        schema_names: list[str],
+    ) -> pa.Table:
+        """Sort Arrow table by primary keys if valid."""
+        if not primary_keys:
+            return table
+
+        valid_keys = [pk for pk in primary_keys if pk in schema_names]
+        if valid_keys:
+            return table.sort_by([(pk, "ascending") for pk in valid_keys])
+
+        self.logger.warning(
+            "Primary keys not found in schema, skipping sort",
+            primary_keys=primary_keys,
+            schema_fields=schema_names,
+        )
+        return table
 
     async def _get_table_schema(self, table_name: str) -> pa.Schema | None:
         """Get existing table schema if table exists."""
@@ -85,6 +106,7 @@ class BaseDeltaWriter:
     def get_table_path(self, table_name: str) -> Path:
         """Get the filesystem path for a table."""
         from pathlib import Path
+
         return Path(self.base_path) / table_name.replace(".", "/")
 
     def clear(self, table_name: str | None = None, dry_run: bool = False) -> int:

--- a/src/bioetl/interfaces/cli/commands/run.py
+++ b/src/bioetl/interfaces/cli/commands/run.py
@@ -79,6 +79,21 @@ async def _run_pipeline_async(
     return result.status, result.error_message, result.error_type
 
 
+def _echo_run_result(status: RunStatus, error_message: str | None) -> None:
+    """Output run result message based on status."""
+    status_handlers = {
+        RunStatus.SUCCESS: lambda: echo_info("Pipeline completed successfully"),
+        RunStatus.DRY_RUN: lambda: echo_info("Dry-run completed (no changes made)"),
+        RunStatus.SHUTDOWN: lambda: echo_warning("Pipeline was gracefully shut down"),
+        RunStatus.FAILED: lambda: echo_error(
+            "Pipeline failed", error_message or "Unknown error"
+        ),
+    }
+    handler = status_handlers.get(status)
+    if handler:
+        handler()
+
+
 @click.command()
 @click.option(
     "--pipeline",
@@ -185,18 +200,9 @@ def run(
         echo_error("Unexpected error during pipeline execution", str(e))
         sys.exit(ExitCode.FAIL)
 
-    # Map status to exit code (CLI responsibility)
+    # Map status to exit code and output result
     exit_code = _map_status_to_exit_code(status, error_type)
-
-    if status == RunStatus.SUCCESS:
-        echo_info("Pipeline completed successfully")
-    elif status == RunStatus.DRY_RUN:
-        echo_info("Dry-run completed (no changes made)")
-    elif status == RunStatus.SHUTDOWN:
-        echo_warning("Pipeline was gracefully shut down")
-    elif status == RunStatus.FAILED:
-        echo_error("Pipeline failed", error_message or "Unknown error")
-
+    _echo_run_result(status, error_message)
     sys.exit(exit_code)
 
 

--- a/src/bioetl/interfaces/cli/commands/run_all.py
+++ b/src/bioetl/interfaces/cli/commands/run_all.py
@@ -81,10 +81,7 @@ def _filter_pipelines_by_provider(provider: str) -> list[str]:
     """
     registry = get_default_registry()
     all_pipelines = registry.list_pipelines()
-    return sorted([
-        name for name in all_pipelines
-        if name.startswith(f"{provider}_")
-    ])
+    return sorted([name for name in all_pipelines if name.startswith(f"{provider}_")])
 
 
 def _validate_provider(provider: str) -> tuple[bool, str | None]:
@@ -164,8 +161,7 @@ async def _run_all_pipelines_async(
                 batch_result.failed += 1
                 batch_result.failed_pipelines.append(pipeline)
                 echo_error(
-                    f"✗ {pipeline}: failed",
-                    result.error_message or "Unknown error"
+                    f"✗ {pipeline}: failed", result.error_message or "Unknown error"
                 )
         except PipelineNotFoundError as e:
             batch_result.failed += 1
@@ -201,6 +197,59 @@ def _echo_batch_summary(result: BatchRunResult, dry_run: bool) -> None:
 
     if result.failed_pipelines:
         echo_error("Failed pipelines:", ", ".join(result.failed_pipelines))
+
+
+def _handle_list_only(source: str, pipelines: list[str]) -> None:
+    """Handle --list-only mode and exit."""
+    echo_info(f"Pipelines for provider '{source}':")
+    for pipeline in pipelines:
+        echo_info(f"  - {pipeline}")
+    echo_info(f"\nTotal: {len(pipelines)} pipeline(s)")
+    sys.exit(ExitCode.OK)
+
+
+def _handle_destructive_confirmation(
+    run_type: str, pipelines: list[str], dry_run: bool, yes: bool
+) -> bool:
+    """Handle confirmation for destructive operations.
+
+    Returns:
+        True if should continue, False if cancelled.
+    """
+    if run_type not in ("rebuild", "backfill") or dry_run or yes:
+        return True
+
+    echo_warning(f"{run_type} will clear existing data for {len(pipelines)} pipelines.")
+    echo_info("Pipelines to be affected:")
+    for pipeline in pipelines:
+        echo_info(f"  - {pipeline}")
+
+    if not click.confirm("\nDo you want to continue?"):
+        echo_info("Operation cancelled.")
+        sys.exit(ExitCode.OK)
+    return True
+
+
+def _show_run_preview(source: str, pipelines: list[str], dry_run: bool) -> None:
+    """Show what pipelines will be run."""
+    if dry_run:
+        echo_info(f"[DRY-RUN] Would run {len(pipelines)} pipeline(s) for '{source}':")
+    else:
+        echo_info(f"Running {len(pipelines)} pipeline(s) for '{source}':")
+
+    for pipeline in pipelines:
+        echo_info(f"  - {pipeline}")
+    echo_info("")
+
+
+def _determine_exit_code(batch_result: BatchRunResult) -> ExitCode:
+    """Determine exit code from batch result."""
+    if batch_result.all_succeeded:
+        return ExitCode.OK
+    if batch_result.failed > 0:
+        return ExitCode.PIPELINE_ERROR
+    # All skipped (shutdown)
+    return ExitCode.SIGINT
 
 
 @click.command("run-all")
@@ -272,35 +321,15 @@ def run_all(
 
     # Handle --list-only mode
     if list_only:
-        echo_info(f"Pipelines for provider '{source}':")
-        for pipeline in pipelines:
-            echo_info(f"  - {pipeline}")
-        echo_info(f"\nTotal: {len(pipelines)} pipeline(s)")
-        sys.exit(ExitCode.OK)
+        _handle_list_only(source, pipelines)
 
     # Handle confirmation for destructive operations (CLI responsibility)
-    if run_type in ("rebuild", "backfill") and not dry_run and not yes:
-        echo_warning(
-            f"{run_type} will clear existing data for {len(pipelines)} pipelines."
-        )
-        echo_info("Pipelines to be affected:")
-        for pipeline in pipelines:
-            echo_info(f"  - {pipeline}")
-        if not click.confirm("\nDo you want to continue?"):
-            echo_info("Operation cancelled.")
-            sys.exit(ExitCode.OK)
+    _handle_destructive_confirmation(run_type, pipelines, dry_run, yes)
 
     # Show what we're about to do
-    if dry_run:
-        echo_info(f"[DRY-RUN] Would run {len(pipelines)} pipeline(s) for '{source}':")
-    else:
-        echo_info(f"Running {len(pipelines)} pipeline(s) for '{source}':")
+    _show_run_preview(source, pipelines, dry_run)
 
-    for pipeline in pipelines:
-        echo_info(f"  - {pipeline}")
-    echo_info("")
-
-    # Build options
+    # Build options and run pipelines
     options = RunOptions(
         run_type=run_type,
         limit=limit,
@@ -308,7 +337,6 @@ def run_all(
         log_level="DEBUG" if debug else "INFO",
     )
 
-    # Run pipelines
     try:
         batch_result = asyncio.run(_run_all_pipelines_async(pipelines, options))
     except KeyboardInterrupt:
@@ -318,17 +346,9 @@ def run_all(
         echo_error("Unexpected error during batch execution", str(e))
         sys.exit(ExitCode.FAIL)
 
-    # Output summary
+    # Output summary and exit
     _echo_batch_summary(batch_result, dry_run)
-
-    # Determine exit code
-    if batch_result.all_succeeded:
-        sys.exit(ExitCode.OK)
-    elif batch_result.failed > 0:
-        sys.exit(ExitCode.PIPELINE_ERROR)
-    else:
-        # All skipped (shutdown)
-        sys.exit(ExitCode.SIGINT)
+    sys.exit(_determine_exit_code(batch_result))
 
 
 __all__ = [

--- a/tests/architecture/test_aggregate_boundaries.py
+++ b/tests/architecture/test_aggregate_boundaries.py
@@ -40,7 +40,12 @@ class TestAggregateBoundaryIsolation:
         # Map of aggregate file -> aggregate classes defined
         aggregate_classes = {
             "batch.py": {"Batch", "BatchRecord", "BatchStatus"},
-            "pipeline_run.py": {"PipelineRun", "StageResult", "StageStatus", "RunStatus"},
+            "pipeline_run.py": {
+                "PipelineRun",
+                "StageResult",
+                "StageStatus",
+                "RunStatus",
+            },
             "quarantine_entry.py": {
                 "QuarantineEntry",
                 "QuarantineStatus",
@@ -139,7 +144,10 @@ class TestAggregateBoundaryIsolation:
                 if isinstance(node, ast.ClassDef):
                     for item in node.body:
                         # Check __init__ parameters
-                        if isinstance(item, ast.FunctionDef) and item.name == "__init__":
+                        if (
+                            isinstance(item, ast.FunctionDef)
+                            and item.name == "__init__"
+                        ):
                             for arg in item.args.args:
                                 if arg.annotation:
                                     ann_str = ast.unparse(arg.annotation)
@@ -325,9 +333,7 @@ class TestDomainEventsForCoordination:
 class TestAggregateConsistencyBoundary:
     """Tests ensuring aggregates are units of consistency."""
 
-    def test_aggregate_state_changes_through_methods_only(
-        self, src_dir: Path
-    ) -> None:
+    def test_aggregate_state_changes_through_methods_only(self, src_dir: Path) -> None:
         """Aggregate state should only change through defined methods.
 
         REQ-ARCH-026: State changes only via aggregate methods.
@@ -383,9 +389,9 @@ class TestAggregateConsistencyBoundary:
 
             for prop in properties:
                 # Should have @property but not setter
-                assert f"def {prop}(self)" in content, (
-                    f"{filename}: {prop} should be a property"
-                )
-                assert f"@{prop}.setter" not in content, (
-                    f"{filename}: {prop} should not have a setter (immutable)"
-                )
+                assert (
+                    f"def {prop}(self)" in content
+                ), f"{filename}: {prop} should be a property"
+                assert (
+                    f"@{prop}.setter" not in content
+                ), f"{filename}: {prop} should not have a setter (immutable)"

--- a/tests/architecture/test_pii_hashing.py
+++ b/tests/architecture/test_pii_hashing.py
@@ -44,29 +44,27 @@ class TestPiiHasherPortContract:
 
         for method in required_methods:
             assert hasattr(port, method), (
-                f"PiiHasherPort MUST define {method}() method "
-                f"per RULES.md §5.4"
+                f"PiiHasherPort MUST define {method}() method " f"per RULES.md §5.4"
             )
 
     def test_pii_hasher_port_exported_in_all(self) -> None:
         """PiiHasherPort MUST be in domain.ports.__all__."""
-        assert "PiiHasherPort" in ports.__all__, (
-            "PiiHasherPort MUST be exported in domain.ports.__all__"
-        )
+        assert (
+            "PiiHasherPort" in ports.__all__
+        ), "PiiHasherPort MUST be exported in domain.ports.__all__"
 
     def test_noop_pii_hasher_exists(self) -> None:
         """NoOpPiiHasher MUST exist for testing and backward compatibility."""
         assert hasattr(ports, "NoOpPiiHasher"), (
-            "NoOpPiiHasher MUST be defined for testing "
-            "and backward compatibility"
+            "NoOpPiiHasher MUST be defined for testing " "and backward compatibility"
         )
 
     def test_noop_pii_hasher_implements_port(self) -> None:
         """NoOpPiiHasher MUST implement PiiHasherPort."""
         hasher = ports.NoOpPiiHasher()
-        assert isinstance(hasher, ports.PiiHasherPort), (
-            "NoOpPiiHasher MUST implement PiiHasherPort"
-        )
+        assert isinstance(
+            hasher, ports.PiiHasherPort
+        ), "NoOpPiiHasher MUST implement PiiHasherPort"
 
 
 class TestBaseTransformerPiiSupport:
@@ -88,12 +86,12 @@ class TestBaseTransformerPiiSupport:
         """BaseTransformer MUST provide hash_pii_value and hash_pii_list methods."""
         from bioetl.application.core.base_transformer import BaseTransformer
 
-        assert hasattr(BaseTransformer, "hash_pii_value"), (
-            "BaseTransformer MUST provide hash_pii_value() method"
-        )
-        assert hasattr(BaseTransformer, "hash_pii_list"), (
-            "BaseTransformer MUST provide hash_pii_list() method"
-        )
+        assert hasattr(
+            BaseTransformer, "hash_pii_value"
+        ), "BaseTransformer MUST provide hash_pii_value() method"
+        assert hasattr(
+            BaseTransformer, "hash_pii_list"
+        ), "BaseTransformer MUST provide hash_pii_list() method"
 
 
 class TestTransformersWithPii:
@@ -144,9 +142,9 @@ class TestPiiHasherImplementation:
         config = SaltConfig(current_salt="x" * 64)
         hasher = Sha256PiiHasher(salt_config=config)
 
-        assert isinstance(hasher, ports.PiiHasherPort), (
-            "Sha256PiiHasher MUST implement PiiHasherPort"
-        )
+        assert isinstance(
+            hasher, ports.PiiHasherPort
+        ), "Sha256PiiHasher MUST implement PiiHasherPort"
 
 
 class TestPiiFieldsInTransformers:
@@ -160,9 +158,9 @@ class TestPiiFieldsInTransformers:
         content = transformer_path.read_text()
 
         # Check that hash_pii_list is called for authors
-        assert "hash_pii_list" in content, (
-            "CrossRefTransformer MUST use hash_pii_list() for authors field"
-        )
+        assert (
+            "hash_pii_list" in content
+        ), "CrossRefTransformer MUST use hash_pii_list() for authors field"
 
     def test_pubmed_transformer_hashes_authors(self) -> None:
         """PubMedPublicationTransformer MUST hash authors field."""
@@ -171,9 +169,9 @@ class TestPiiFieldsInTransformers:
         )
         content = transformer_path.read_text()
 
-        assert "hash_pii_list" in content, (
-            "PubMedPublicationTransformer MUST use hash_pii_list() for authors field"
-        )
+        assert (
+            "hash_pii_list" in content
+        ), "PubMedPublicationTransformer MUST use hash_pii_list() for authors field"
 
     def test_chembl_document_transformer_hashes_authors(self) -> None:
         """DocumentTransformer MUST hash authors field."""
@@ -183,6 +181,6 @@ class TestPiiFieldsInTransformers:
         content = transformer_path.read_text()
 
         # ChEMBL uses single string authors, so hash_pii_value
-        assert "hash_pii_value" in content, (
-            "ChEMBL DocumentTransformer MUST use hash_pii_value() for authors field"
-        )
+        assert (
+            "hash_pii_value" in content
+        ), "ChEMBL DocumentTransformer MUST use hash_pii_value() for authors field"

--- a/tests/architecture/test_port_contracts.py
+++ b/tests/architecture/test_port_contracts.py
@@ -1055,9 +1055,9 @@ class TestLockPortErrorConditions:
 
             # Owner2 tries to release - should fail
             released = await lock.release("test_key", owner2)
-            assert not released, (
-                "LockPort.release() MUST return False when owner does not match"
-            )
+            assert (
+                not released
+            ), "LockPort.release() MUST return False when owner does not match"
 
             # Lock should still be held by owner1
             is_owner = await lock.validate_owner("test_key", owner1)
@@ -1076,9 +1076,9 @@ class TestLockPortErrorConditions:
 
         try:
             result = await lock.heartbeat("non_existent_key", uuid4())
-            assert not result, (
-                "LockPort.heartbeat() MUST return False for non-existent locks"
-            )
+            assert (
+                not result
+            ), "LockPort.heartbeat() MUST return False for non-existent locks"
         finally:
             await lock.aclose()
 
@@ -1096,9 +1096,9 @@ class TestLockPortErrorConditions:
         try:
             await lock.acquire("test_key", owner1)
             result = await lock.heartbeat("test_key", owner2)
-            assert not result, (
-                "LockPort.heartbeat() MUST return False when owner does not match"
-            )
+            assert (
+                not result
+            ), "LockPort.heartbeat() MUST return False when owner does not match"
         finally:
             await lock.aclose()
 
@@ -1113,9 +1113,9 @@ class TestLockPortErrorConditions:
 
         try:
             result = await lock.validate_owner("non_existent_key", uuid4())
-            assert not result, (
-                "LockPort.validate_owner() MUST return False for non-existent locks"
-            )
+            assert (
+                not result
+            ), "LockPort.validate_owner() MUST return False for non-existent locks"
         finally:
             await lock.aclose()
 
@@ -1135,12 +1135,10 @@ class TestLockPortErrorConditions:
             await lock.acquire("test_key", owner1)
 
             # Owner2 tries to acquire with short timeout
-            acquired = await lock.acquire(
-                "test_key", owner2, wait=True, wait_timeout=1
-            )
-            assert not acquired, (
-                "LockPort.acquire() MUST return False when wait times out"
-            )
+            acquired = await lock.acquire("test_key", owner2, wait=True, wait_timeout=1)
+            assert (
+                not acquired
+            ), "LockPort.acquire() MUST return False when wait times out"
         finally:
             await lock.aclose()
 
@@ -1165,9 +1163,9 @@ class TestCheckpointPortErrorConditions:
 
         try:
             result = await checkpoint.load("non_existent_pipeline")
-            assert result is None, (
-                "CheckpointPort.load() MUST return None for non-existent checkpoints"
-            )
+            assert (
+                result is None
+            ), "CheckpointPort.load() MUST return None for non-existent checkpoints"
         finally:
             await checkpoint.aclose()
 
@@ -1197,9 +1195,9 @@ class TestCheckpointPortErrorConditions:
 
         try:
             result = await checkpoint.list_all()
-            assert result == [], (
-                "CheckpointPort.list_all() MUST return empty list when no checkpoints"
-            )
+            assert (
+                result == []
+            ), "CheckpointPort.list_all() MUST return empty list when no checkpoints"
         finally:
             await checkpoint.aclose()
 
@@ -1235,9 +1233,9 @@ class TestCircuitBreakerPortErrorConditions:
         with pytest.raises(CircuitBreakerOpenError) as exc_info:
             await breaker.call(failing_func)
 
-        assert exc_info.value.provider == "test", (
-            "CircuitBreakerOpenError MUST include provider name"
-        )
+        assert (
+            exc_info.value.provider == "test"
+        ), "CircuitBreakerOpenError MUST include provider name"
 
     @pytest.mark.asyncio
     async def test_circuit_breaker_propagates_exceptions(self) -> None:
@@ -1265,12 +1263,12 @@ class TestCircuitBreakerPortErrorConditions:
 
         breaker.reset()
 
-        assert breaker.get_failure_count() == 0, (
-            "CircuitBreakerPort.reset() MUST clear failure count"
-        )
-        assert breaker.get_state() == CircuitBreakerState.CLOSED, (
-            "CircuitBreakerPort.reset() MUST set state to CLOSED"
-        )
+        assert (
+            breaker.get_failure_count() == 0
+        ), "CircuitBreakerPort.reset() MUST clear failure count"
+        assert (
+            breaker.get_state() == CircuitBreakerState.CLOSED
+        ), "CircuitBreakerPort.reset() MUST set state to CLOSED"
 
 
 class TestRateLimiterPortErrorConditions:
@@ -1302,9 +1300,9 @@ class TestRateLimiterPortErrorConditions:
             bucket.try_acquire()
 
         result = bucket.try_acquire()
-        assert not result, (
-            "RateLimiterPort.try_acquire() MUST return False when insufficient tokens"
-        )
+        assert (
+            not result
+        ), "RateLimiterPort.try_acquire() MUST return False when insufficient tokens"
 
     def test_rate_limiter_available_tokens_non_negative(self) -> None:
         """RateLimiterPort.available_tokens() MUST return non-negative value."""
@@ -1317,9 +1315,9 @@ class TestRateLimiterPortErrorConditions:
             pass
 
         result = bucket.available_tokens()
-        assert result >= 0, (
-            "RateLimiterPort.available_tokens() MUST return non-negative value"
-        )
+        assert (
+            result >= 0
+        ), "RateLimiterPort.available_tokens() MUST return non-negative value"
 
 
 # ============================================================================
@@ -1358,9 +1356,9 @@ class TestLockPortConcurrentAccess:
             results = await asyncio.gather(*tasks)
 
             successful_acquires = sum(results)
-            assert successful_acquires == 1, (
-                f"Only one concurrent acquire MUST succeed, got {successful_acquires}"
-            )
+            assert (
+                successful_acquires == 1
+            ), f"Only one concurrent acquire MUST succeed, got {successful_acquires}"
         finally:
             await lock.aclose()
 
@@ -1390,9 +1388,9 @@ class TestLockPortConcurrentAccess:
             ]
             results = await asyncio.gather(*tasks)
 
-            assert all(results), (
-                "All concurrent operations on different keys MUST succeed"
-            )
+            assert all(
+                results
+            ), "All concurrent operations on different keys MUST succeed"
         finally:
             await lock.aclose()
 
@@ -1416,9 +1414,9 @@ class TestLockPortConcurrentAccess:
             tasks = [heartbeat() for _ in range(10)]
             results = await asyncio.gather(*tasks)
 
-            assert all(results), (
-                "Concurrent heartbeat operations from owner MUST all succeed"
-            )
+            assert all(
+                results
+            ), "Concurrent heartbeat operations from owner MUST all succeed"
         finally:
             await lock.aclose()
 
@@ -1454,9 +1452,9 @@ class TestCheckpointPortConcurrentAccess:
             tasks = [save_checkpoint(p) for p in pipelines]
             results = await asyncio.gather(*tasks)
 
-            assert all(results), (
-                "Concurrent saves to different pipelines MUST all succeed"
-            )
+            assert all(
+                results
+            ), "Concurrent saves to different pipelines MUST all succeed"
 
             # Verify all saved
             saved_pipelines = await checkpoint.list_all()
@@ -1558,9 +1556,9 @@ class TestCircuitBreakerPortConcurrentAccess:
         tasks = [success_call() for _ in range(5)]
         await asyncio.gather(*tasks)
 
-        assert breaker.get_failure_count() == 0, (
-            "Concurrent successful calls MUST reset failure count to 0"
-        )
+        assert (
+            breaker.get_failure_count() == 0
+        ), "Concurrent successful calls MUST reset failure count to 0"
 
 
 class TestRateLimiterPortConcurrentAccess:
@@ -1594,9 +1592,9 @@ class TestRateLimiterPortConcurrentAccess:
         tasks = [try_acquire_token() for _ in range(20)]
         await asyncio.gather(*tasks)
 
-        assert acquired_count <= 10, (
-            f"Concurrent acquires MUST respect capacity, got {acquired_count}"
-        )
+        assert (
+            acquired_count <= 10
+        ), f"Concurrent acquires MUST respect capacity, got {acquired_count}"
 
     def test_token_count_never_negative(self) -> None:
         """Token count MUST never go negative after concurrent try_acquire."""
@@ -1608,6 +1606,4 @@ class TestRateLimiterPortConcurrentAccess:
         for _ in range(10):
             bucket.try_acquire()
 
-        assert bucket.available_tokens() >= 0, (
-            "Token count MUST never go negative"
-        )
+        assert bucket.available_tokens() >= 0, "Token count MUST never go negative"

--- a/tests/architecture/test_port_contracts_hypothesis.py
+++ b/tests/architecture/test_port_contracts_hypothesis.py
@@ -17,7 +17,8 @@ from typing import Any
 from uuid import uuid4
 
 import pytest
-from hypothesis import given, settings, strategies as st
+from hypothesis import given, settings
+from hypothesis import strategies as st
 
 from bioetl.domain import ports
 
@@ -198,7 +199,9 @@ class TestCheckpointPortProperties:
                     loaded_run_id, loaded_metadata = result
 
                     assert loaded_run_id == run_id, "Run ID mismatch after roundtrip"
-                    assert loaded_metadata == metadata, "Metadata mismatch after roundtrip"
+                    assert (
+                        loaded_metadata == metadata
+                    ), "Metadata mismatch after roundtrip"
                 finally:
                     await checkpoint.aclose()
 
@@ -208,9 +211,7 @@ class TestCheckpointPortProperties:
         pipelines=st.lists(pipeline_name_strategy, min_size=1, max_size=10, unique=True)
     )
     @settings(max_examples=20, deadline=None)
-    def test_list_all_returns_all_saved_pipelines(
-        self, pipelines: list[str]
-    ) -> None:
+    def test_list_all_returns_all_saved_pipelines(self, pipelines: list[str]) -> None:
         """Property: list_all() MUST return all saved pipeline names."""
         import tempfile
 
@@ -227,9 +228,9 @@ class TestCheckpointPortProperties:
 
                     # List should return all pipelines
                     listed = await checkpoint.list_all()
-                    assert set(listed) == set(pipelines), (
-                        f"list_all() mismatch: expected {set(pipelines)}, got {set(listed)}"
-                    )
+                    assert set(listed) == set(
+                        pipelines
+                    ), f"list_all() mismatch: expected {set(pipelines)}, got {set(listed)}"
                 finally:
                     await checkpoint.aclose()
 
@@ -237,9 +238,7 @@ class TestCheckpointPortProperties:
 
     @given(pipeline=pipeline_name_strategy)
     @settings(max_examples=30, deadline=None)
-    def test_delete_makes_load_return_none(
-        self, pipeline: str
-    ) -> None:
+    def test_delete_makes_load_return_none(self, pipeline: str) -> None:
         """Property: delete() followed by load() MUST return None."""
         import tempfile
 
@@ -256,7 +255,9 @@ class TestCheckpointPortProperties:
 
                     # Load should return None
                     result = await checkpoint.load(pipeline)
-                    assert result is None, f"Load returned data after delete: {pipeline}"
+                    assert (
+                        result is None
+                    ), f"Load returned data after delete: {pipeline}"
                 finally:
                     await checkpoint.aclose()
 
@@ -281,9 +282,9 @@ class TestRateLimiterPortProperties:
 
         # Available tokens should equal capacity at start
         available = bucket.available_tokens()
-        assert available == capacity, (
-            f"Initial tokens ({available}) != capacity ({capacity})"
-        )
+        assert (
+            available == capacity
+        ), f"Initial tokens ({available}) != capacity ({capacity})"
 
     @given(
         # Low rate to prevent token replenishment during test execution
@@ -303,7 +304,9 @@ class TestRateLimiterPortProperties:
         # Acquire all tokens
         for i in range(capacity):
             result = bucket.try_acquire()
-            assert result, f"try_acquire() failed at iteration {i} for capacity {capacity}"
+            assert (
+                result
+            ), f"try_acquire() failed at iteration {i} for capacity {capacity}"
 
         # Next attempt should fail (rate is low enough that no replenishment occurs)
         result = bucket.try_acquire()
@@ -329,9 +332,9 @@ class TestRateLimiterPortProperties:
             await bucket.acquire(tokens=tokens)
             # Should succeed without exception
             remaining = bucket.available_tokens()
-            assert remaining == capacity - tokens, (
-                f"Wrong remaining tokens: {remaining} != {capacity - tokens}"
-            )
+            assert (
+                remaining == capacity - tokens
+            ), f"Wrong remaining tokens: {remaining} != {capacity - tokens}"
 
         asyncio.run(test_acquire())
 
@@ -350,9 +353,9 @@ class TestRateLimiterPortProperties:
         bucket._refill()
 
         available = bucket.available_tokens()
-        assert available <= capacity, (
-            f"Tokens ({available}) exceeded capacity ({capacity})"
-        )
+        assert (
+            available <= capacity
+        ), f"Tokens ({available}) exceeded capacity ({capacity})"
 
 
 # ============================================================================
@@ -381,9 +384,9 @@ class TestCircuitBreakerPortProperties:
             recovery_timeout=recovery_timeout,
         )
 
-        assert breaker.get_state() == CircuitBreakerState.CLOSED, (
-            f"Initial state is not CLOSED for threshold={failure_threshold}"
-        )
+        assert (
+            breaker.get_state() == CircuitBreakerState.CLOSED
+        ), f"Initial state is not CLOSED for threshold={failure_threshold}"
 
     @given(
         failure_threshold=failure_threshold_strategy,
@@ -435,9 +438,9 @@ class TestCircuitBreakerPortProperties:
                 except RuntimeError:
                     pass
 
-            assert breaker.get_state() == CircuitBreakerState.OPEN, (
-                f"Circuit not open after {failure_threshold} failures"
-            )
+            assert (
+                breaker.get_state() == CircuitBreakerState.OPEN
+            ), f"Circuit not open after {failure_threshold} failures"
 
         asyncio.run(test_threshold())
 
@@ -476,9 +479,7 @@ class TestMetricsPortProperties:
         )
     )
     @settings(max_examples=30, deadline=None)
-    def test_noop_metrics_accepts_various_labels(
-        self, labels: dict[str, str]
-    ) -> None:
+    def test_noop_metrics_accepts_various_labels(self, labels: dict[str, str]) -> None:
         """Property: NoOpMetrics MUST accept various label combinations."""
         from bioetl.domain.ports.noop import NoOpMetrics
 
@@ -502,7 +503,9 @@ class TestLoggerPortProperties:
         message=st.text(max_size=200),
         context=st.dictionaries(
             keys=st.text(min_size=1, max_size=20).filter(lambda x: x.strip() != ""),
-            values=st.one_of(st.text(max_size=50), st.integers(), st.floats(allow_nan=False)),
+            values=st.one_of(
+                st.text(max_size=50), st.integers(), st.floats(allow_nan=False)
+            ),
             max_size=5,
         ),
     )
@@ -529,18 +532,16 @@ class TestLoggerPortProperties:
         )
     )
     @settings(max_examples=30, deadline=None)
-    def test_logger_bind_returns_logger_port(
-        self, bindings: dict[str, Any]
-    ) -> None:
+    def test_logger_bind_returns_logger_port(self, bindings: dict[str, Any]) -> None:
         """Property: LoggerPort.bind() MUST return LoggerPort instance."""
         from bioetl.infrastructure.observability.noop_logger import NoOpLogger
 
         logger = NoOpLogger()
         bound = logger.bind(**bindings)
 
-        assert isinstance(bound, ports.LoggerPort), (
-            "bind() MUST return LoggerPort instance"
-        )
+        assert isinstance(
+            bound, ports.LoggerPort
+        ), "bind() MUST return LoggerPort instance"
 
 
 # ============================================================================
@@ -556,7 +557,9 @@ class TestJsonEncoderPortProperties:
         st.none(),
         st.booleans(),
         st.integers(min_value=-10000, max_value=10000),
-        st.floats(allow_nan=False, allow_infinity=False, min_value=-1e10, max_value=1e10),
+        st.floats(
+            allow_nan=False, allow_infinity=False, min_value=-1e10, max_value=1e10
+        ),
         st.text(max_size=100),
     )
 
@@ -590,9 +593,9 @@ class TestJsonEncoderPortProperties:
 
         # Handle float comparison (floats may have small precision differences)
         if isinstance(data, float):
-            assert abs(data - loaded) < 1e-10, (
-                f"Float roundtrip failed: {data} != {loaded}"
-            )
+            assert (
+                abs(data - loaded) < 1e-10
+            ), f"Float roundtrip failed: {data} != {loaded}"
         else:
             assert data == loaded, f"Roundtrip failed: {data} != {loaded}"
 
@@ -618,9 +621,9 @@ class TestJsonEncoderPortProperties:
         result1 = encoder.dumps_canonical(data)
         result2 = encoder.dumps_canonical(data)
 
-        assert result1 == result2, (
-            f"dumps_canonical() not deterministic:\n{result1}\n!=\n{result2}"
-        )
+        assert (
+            result1 == result2
+        ), f"dumps_canonical() not deterministic:\n{result1}\n!=\n{result2}"
 
     @pytest.mark.skipif(
         PYTHON_314,
@@ -648,9 +651,9 @@ class TestJsonEncoderPortProperties:
         expected_keys = sorted(data.keys())
         actual_keys = list(loaded.keys())
 
-        assert actual_keys == expected_keys, (
-            f"Keys not sorted: {actual_keys} != {expected_keys}"
-        )
+        assert (
+            actual_keys == expected_keys
+        ), f"Keys not sorted: {actual_keys} != {expected_keys}"
 
 
 # ============================================================================
@@ -670,9 +673,9 @@ class TestMemoryMonitorPortProperties:
         monitor = MemoryMonitor(config=MemoryConfig())
 
         recommended = monitor.get_recommended_batch_size(batch_size)
-        assert recommended > 0, (
-            f"Recommended batch size must be positive, got {recommended}"
-        )
+        assert (
+            recommended > 0
+        ), f"Recommended batch size must be positive, got {recommended}"
 
     @given(batch_size=st.integers(min_value=1, max_value=10000))
     @settings(max_examples=50, deadline=None)
@@ -683,9 +686,9 @@ class TestMemoryMonitorPortProperties:
         monitor = NoOpMemoryMonitor()
 
         recommended = monitor.get_recommended_batch_size(batch_size)
-        assert recommended == batch_size, (
-            f"NoOpMemoryMonitor changed batch size: {batch_size} -> {recommended}"
-        )
+        assert (
+            recommended == batch_size
+        ), f"NoOpMemoryMonitor changed batch size: {batch_size} -> {recommended}"
 
     @given(
         records_count=st.integers(min_value=0, max_value=100000),

--- a/tests/benchmarks/test_baseline_assertions.py
+++ b/tests/benchmarks/test_baseline_assertions.py
@@ -27,9 +27,15 @@ class TestContentHashBaselines:
     """
 
     # Baseline thresholds in microseconds (with safety margin for CI/Python 3.14 variability)
-    SMALL_RECORD_THRESHOLD_US = 1000  # 20x of 50 µs target (accounts for Python 3.14 variance)
-    MEDIUM_RECORD_THRESHOLD_US = 5000  # ~33x of 150 µs target (accounts for Python 3.14 variance)
-    LARGE_RECORD_THRESHOLD_US = 10000  # 20x of 500 µs target (accounts for CI/Python 3.14 variance)
+    SMALL_RECORD_THRESHOLD_US = (
+        1000  # 20x of 50 µs target (accounts for Python 3.14 variance)
+    )
+    MEDIUM_RECORD_THRESHOLD_US = (
+        5000  # ~33x of 150 µs target (accounts for Python 3.14 variance)
+    )
+    LARGE_RECORD_THRESHOLD_US = (
+        10000  # 20x of 500 µs target (accounts for CI/Python 3.14 variance)
+    )
 
     # Number of operations to average over
     NUM_OPS = 1000
@@ -173,8 +179,12 @@ class TestBatchProcessingBaselines:
     - 1000 records: < 100 ms
     """
 
-    SMALL_BATCH_THRESHOLD_MS = 100  # 10x of 10 ms target (accounts for Python 3.14 variance)
-    MEDIUM_BATCH_THRESHOLD_MS = 500  # 5x of 100 ms target (accounts for Python 3.14 variance)
+    SMALL_BATCH_THRESHOLD_MS = (
+        100  # 10x of 10 ms target (accounts for Python 3.14 variance)
+    )
+    MEDIUM_BATCH_THRESHOLD_MS = (
+        500  # 5x of 100 ms target (accounts for Python 3.14 variance)
+    )
 
     @pytest.fixture
     def small_batch(self) -> list[dict[str, Any]]:
@@ -261,9 +271,13 @@ class TestPolarsBaselines:
     - Group + Aggregate: < 10 ms
     """
 
-    DF_CREATION_THRESHOLD_MS = 100  # 5x of 20 ms target (accounts for Python 3.14 variance)
+    DF_CREATION_THRESHOLD_MS = (
+        100  # 5x of 20 ms target (accounts for Python 3.14 variance)
+    )
     FILTER_THRESHOLD_MS = 30  # 6x of 5 ms target (accounts for Python 3.14 variance)
-    GROUP_AGG_THRESHOLD_MS = 150  # 15x of 10 ms target (accounts for Python 3.14 variance)
+    GROUP_AGG_THRESHOLD_MS = (
+        150  # 15x of 10 ms target (accounts for Python 3.14 variance)
+    )
 
     @pytest.fixture
     def records_for_df(self) -> list[dict[str, Any]]:
@@ -368,9 +382,7 @@ class TestMemoryMonitorBaseline:
     """
 
     MEMORY_STATS_THRESHOLD_MS = 50  # Increased for Python 3.14/CI variability
-    BATCH_SIZE_THRESHOLD_US = (
-        50000  # Increased for Python 3.14/CI variability
-    )
+    BATCH_SIZE_THRESHOLD_US = 50000  # Increased for Python 3.14/CI variability
 
     def test_memory_stats_baseline(self) -> None:
         """Memory stats retrieval must complete under threshold."""

--- a/tests/e2e/test_cli_safety.py
+++ b/tests/e2e/test_cli_safety.py
@@ -50,12 +50,8 @@ def test_cli_rebuild_with_yes(cli_runner, mock_registry):
     from bioetl.application.services import RunStatus
 
     with (
-        patch(
-            "bioetl.interfaces.cli.commands.run.get_pipeline_runner_service"
-        ),
-        patch(
-            "bioetl.interfaces.cli.commands.run.asyncio.run"
-        ) as mock_asyncio_run,
+        patch("bioetl.interfaces.cli.commands.run.get_pipeline_runner_service"),
+        patch("bioetl.interfaces.cli.commands.run.asyncio.run") as mock_asyncio_run,
         patch(
             "bioetl.interfaces.cli.commands.run_helpers.get_default_registry",
             return_value=mock_registry,

--- a/tests/e2e/test_full_pipeline.py
+++ b/tests/e2e/test_full_pipeline.py
@@ -46,19 +46,16 @@ class TestChEMBLPipelineE2E:
             metrics=AsyncMock(),
             save_json=True,
             json_path=str(storage_paths["bronze"] / "json"),
-
         )
 
         silver_writer = SilverWriter(
             base_path=str(storage_paths["silver"]),
             logger=logger,
-
         )
 
         gold_writer = GoldWriter(
             base_path=str(storage_paths["gold"]),
             logger=logger,
-
         )
 
         return StorageAdapter(
@@ -148,19 +145,16 @@ async def test_pubchem_compound_pipeline(
         metrics=AsyncMock(),
         save_json=True,
         json_path=str(e2e_temp_storage["bronze"] / "json"),
-
     )
 
     silver_writer = SilverWriter(
         base_path=str(e2e_temp_storage["silver"]),
         logger=logger,
-
     )
 
     gold_writer = GoldWriter(
         base_path=str(e2e_temp_storage["gold"]),
         logger=logger,
-
     )
 
     storage_adapter = StorageAdapter(
@@ -231,19 +225,16 @@ async def test_pipeline_resume_after_failure(
         metrics=AsyncMock(),
         save_json=True,
         json_path=str(e2e_temp_storage["bronze"] / "json"),
-
     )
 
     silver_writer = SilverWriter(
         base_path=str(e2e_temp_storage["silver"]),
         logger=logger,
-
     )
 
     gold_writer = GoldWriter(
         base_path=str(e2e_temp_storage["gold"]),
         logger=logger,
-
     )
 
     storage_adapter = StorageAdapter(
@@ -325,19 +316,16 @@ async def test_pipeline_idempotency(
         metrics=AsyncMock(),
         save_json=True,
         json_path=str(e2e_temp_storage["bronze"] / "json"),
-
     )
 
     silver_writer = SilverWriter(
         base_path=str(e2e_temp_storage["silver"]),
         logger=logger,
-
     )
 
     gold_writer = GoldWriter(
         base_path=str(e2e_temp_storage["gold"]),
         logger=logger,
-
     )
 
     storage_adapter = StorageAdapter(

--- a/tests/e2e/test_pipeline_with_schema_drift_e2e.py
+++ b/tests/e2e/test_pipeline_with_schema_drift_e2e.py
@@ -136,7 +136,6 @@ class TestSchemaEvolutionErrorMode:
         writer = SilverWriter(
             base_path=str(e2e_data_dir / "silver"),
             logger=logger,
-
         )
 
         # First write establishes the schema
@@ -177,7 +176,6 @@ class TestSchemaEvolutionErrorMode:
         writer = SilverWriter(
             base_path=str(e2e_data_dir / "silver"),
             logger=logger,
-
         )
 
         # First write establishes the schema
@@ -233,7 +231,6 @@ class TestSchemaEvolutionEvolveMode:
         writer = SilverWriter(
             base_path=str(e2e_data_dir / "silver"),
             logger=logger,
-
         )
 
         # First write establishes the base schema
@@ -283,7 +280,6 @@ class TestSchemaEvolutionEvolveMode:
         writer = SilverWriter(
             base_path=str(e2e_data_dir / "silver"),
             logger=mock_logger,
-
         )
 
         # First write
@@ -339,7 +335,6 @@ class TestSchemaEvolutionIgnoreMode:
         writer = SilverWriter(
             base_path=str(e2e_data_dir / "silver"),
             logger=logger,
-
         )
 
         # First write
@@ -391,7 +386,6 @@ class TestSchemaEvolutionEdgeCases:
         writer = SilverWriter(
             base_path=str(e2e_data_dir / "silver"),
             logger=logger,
-
         )
 
         # Table doesn't exist yet
@@ -426,7 +420,6 @@ class TestSchemaEvolutionEdgeCases:
         writer = SilverWriter(
             base_path=str(e2e_data_dir / "silver"),
             logger=mock_logger,
-
         )
 
         # First write
@@ -485,7 +478,6 @@ class TestSchemaEvolutionEdgeCases:
         writer = SilverWriter(
             base_path=str(e2e_data_dir / "silver"),
             logger=logger,
-
         )
 
         # First write - base schema

--- a/tests/infrastructure/storage/test_gold_writer_integration.py
+++ b/tests/infrastructure/storage/test_gold_writer_integration.py
@@ -23,9 +23,7 @@ def noop_logger():
 
 @pytest.fixture
 def gold_writer(noop_logger):
-    return GoldWriter(
-        base_path="s3://test-bucket/gold", logger=noop_logger
-    )
+    return GoldWriter(base_path="s3://test-bucket/gold", logger=noop_logger)
 
 
 @pytest.fixture

--- a/tests/integration/infrastructure/storage/test_silver_writer.py
+++ b/tests/integration/infrastructure/storage/test_silver_writer.py
@@ -27,9 +27,7 @@ def temp_delta_path(tmp_path):
 
 @pytest.fixture
 def silver_writer(temp_delta_path, noop_logger):
-    return SilverWriter(
-        base_path=temp_delta_path, logger=noop_logger
-    )
+    return SilverWriter(base_path=temp_delta_path, logger=noop_logger)
 
 
 @pytest.fixture

--- a/tests/integration/interfaces/test_cli_shutdown_integration.py
+++ b/tests/integration/interfaces/test_cli_shutdown_integration.py
@@ -233,7 +233,9 @@ class TestRunnerShutdownIntegration:
 
         # CLI should output shutdown warning message
         assert result.exit_code == 130
-        assert "shut down" in result.output.lower() or "graceful" in result.output.lower()
+        assert (
+            "shut down" in result.output.lower() or "graceful" in result.output.lower()
+        )
 
     def test_runner_shutdown_signal_passed_to_setup(
         self,

--- a/tests/integration/test_runner_lifecycle.py
+++ b/tests/integration/test_runner_lifecycle.py
@@ -19,14 +19,14 @@ from uuid import uuid4
 import pytest
 
 from bioetl.application.core.postrun_service import PostrunService
+from bioetl.application.core.preflight_service import PreflightService
+from bioetl.application.core.runner import PipelineRunner
+from bioetl.application.observability.observer import PipelineObserver
 from bioetl.application.services.medallion_lifecycle import (
     MedallionLifecycleService,
     PrepareResult,
     VacuumResult,
 )
-from bioetl.application.core.preflight_service import PreflightService
-from bioetl.application.core.runner import PipelineRunner
-from bioetl.application.observability.observer import PipelineObserver
 from bioetl.domain.config import PipelineConfig, RuntimeConfig
 from bioetl.domain.context import PipelineContext
 from bioetl.domain.types import RunType
@@ -418,12 +418,16 @@ class TestPipelineRunnerLifecycle:
         lifecycle_service_no_clear = MagicMock(spec=MedallionLifecycleService)
         lifecycle_service_no_clear.prepare_for_run = AsyncMock(
             return_value=PrepareResult(
-                clear_result=ClearResult(silver_cleared=0, gold_cleared=0, dry_run=False),
+                clear_result=ClearResult(
+                    silver_cleared=0, gold_cleared=0, dry_run=False
+                ),
                 policy=MedallionPolicy.for_run_type(RunType.INCREMENTAL),
             )
         )
         lifecycle_service_no_clear.finalize_run = AsyncMock(
-            return_value=VacuumResult(silver_files_removed=0, gold_files_removed=0, skipped=True)
+            return_value=VacuumResult(
+                silver_files_removed=0, gold_files_removed=0, skipped=True
+            )
         )
 
         lock_manager = MagicMock()
@@ -568,11 +572,15 @@ class TestPipelineRunnerLifecycle:
             call_recorder.record("storage.clear_silver")
             call_recorder.record("storage.clear_gold")
             return PrepareResult(
-                clear_result=ClearResult(silver_cleared=0, gold_cleared=0, dry_run=False),
+                clear_result=ClearResult(
+                    silver_cleared=0, gold_cleared=0, dry_run=False
+                ),
                 policy=MedallionPolicy.for_run_type(runtime.run_type),
             )
 
-        mock_lifecycle_service.prepare_for_run = AsyncMock(side_effect=prepare_for_run_with_recording)
+        mock_lifecycle_service.prepare_for_run = AsyncMock(
+            side_effect=prepare_for_run_with_recording
+        )
 
         lock_manager = MagicMock()
         lock_manager.__aenter__ = AsyncMock(return_value=lock_manager)

--- a/tests/performance/test_batching_performance.py
+++ b/tests/performance/test_batching_performance.py
@@ -77,9 +77,7 @@ def logger() -> NoOpLogger:
 @pytest.fixture
 def bronze_writer(tmp_path: Path, logger: NoOpLogger) -> BronzeWriter:
     """Create BronzeWriter for performance tests."""
-    return BronzeWriter(
-        base_path=tmp_path, logger=logger, metrics=NoOpMetrics()
-    )
+    return BronzeWriter(base_path=tmp_path, logger=logger, metrics=NoOpMetrics())
 
 
 @pytest.fixture

--- a/tests/unit/application/core/test_batch_executor.py
+++ b/tests/unit/application/core/test_batch_executor.py
@@ -303,7 +303,9 @@ class TestBatchExecutorExecute:
 
         mock_checkpoint_manager.save_checkpoint.assert_called()
 
-    async def test_execute_empty_data(self, batch_executor, mock_services, mock_storage):
+    async def test_execute_empty_data(
+        self, batch_executor, mock_services, mock_storage
+    ):
         """Test execute with no data."""
 
         async def mock_fetch(**kwargs):

--- a/tests/unit/application/core/test_health_aggregator.py
+++ b/tests/unit/application/core/test_health_aggregator.py
@@ -11,7 +11,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from bioetl.application.core.preflight_service import _HealthAggregator as HealthAggregator
+from bioetl.application.core.preflight_service import (
+    _HealthAggregator as HealthAggregator,
+)
 from bioetl.domain.exceptions import InfrastructureError
 from bioetl.domain.ports.health_check import HealthCheckResult
 from bioetl.domain.types import ComponentHealthResult, HealthReport, HealthStatus

--- a/tests/unit/application/core/test_postrun_service.py
+++ b/tests/unit/application/core/test_postrun_service.py
@@ -81,7 +81,9 @@ def mock_lifecycle_service():
     service = MagicMock()
     service.vacuum = AsyncMock(return_value=10)
     service.finalize_run = AsyncMock(
-        return_value=VacuumResult(silver_files_removed=10, gold_files_removed=5, skipped=False)
+        return_value=VacuumResult(
+            silver_files_removed=10, gold_files_removed=5, skipped=False
+        )
     )
     return service
 
@@ -104,7 +106,12 @@ def mock_dq_service():
 
 @pytest.fixture
 def postrun_service(
-    pipeline_config, runtime_config, mock_dq_service, mock_lifecycle_service, mock_metrics, mock_logger
+    pipeline_config,
+    runtime_config,
+    mock_dq_service,
+    mock_lifecycle_service,
+    mock_metrics,
+    mock_logger,
 ):
     """Create a PostrunService instance."""
     return PostrunService(
@@ -240,7 +247,9 @@ class TestPostrunServiceVacuum:
         from bioetl.application.services.medallion_lifecycle import VacuumResult
 
         mock_lifecycle_service.finalize_run = AsyncMock(
-            return_value=VacuumResult(silver_files_removed=0, gold_files_removed=0, skipped=True)
+            return_value=VacuumResult(
+                silver_files_removed=0, gold_files_removed=0, skipped=True
+            )
         )
 
         runtime = RuntimeConfig(

--- a/tests/unit/application/core/test_runner.py
+++ b/tests/unit/application/core/test_runner.py
@@ -9,16 +9,16 @@ import pytest
 
 from bioetl.application.core.checkpoint_manager import CheckpointManager
 from bioetl.application.core.lock_manager import LockManager
-from bioetl.application.services.medallion_lifecycle import (
-    MedallionLifecycleService,
-    PrepareResult,
-)
 from bioetl.application.core.pipeline_services import PipelineServices
 from bioetl.application.core.postrun_service import PostrunService
 from bioetl.application.core.preflight_service import PreflightService
 from bioetl.application.core.runner import PipelineRunner
 from bioetl.application.core.shutdown import PipelineShutdownError, ShutdownSignal
 from bioetl.application.observability.observer import PipelineObserver
+from bioetl.application.services.medallion_lifecycle import (
+    MedallionLifecycleService,
+    PrepareResult,
+)
 from bioetl.domain.config import PipelineConfig, RuntimeConfig
 from bioetl.domain.context import PipelineContext
 from bioetl.domain.types import RunType
@@ -87,8 +87,6 @@ def create_mock_services():
     services.logger.warning = MagicMock()
     services.logger.error = MagicMock()
     return services
-
-
 
 
 @pytest.fixture
@@ -195,7 +193,9 @@ def mock_lifecycle_service():
         )
     )
     service.finalize_run = AsyncMock(
-        return_value=VacuumResult(silver_files_removed=0, gold_files_removed=0, skipped=True)
+        return_value=VacuumResult(
+            silver_files_removed=0, gold_files_removed=0, skipped=True
+        )
     )
     service.clear = AsyncMock(
         return_value=ClearResult(silver_cleared=0, gold_cleared=0, dry_run=False)
@@ -596,7 +596,9 @@ class TestPipelineRunnerClearViaLifecycle:
         lifecycle_service = MagicMock(spec=MedallionLifecycleService)
         lifecycle_service.prepare_for_run = AsyncMock(
             return_value=PrepareResult(
-                clear_result=ClearResult(silver_cleared=5, gold_cleared=3, dry_run=False),
+                clear_result=ClearResult(
+                    silver_cleared=5, gold_cleared=3, dry_run=False
+                ),
                 policy=MedallionPolicy.for_run_type(RunType.REBUILD),
             )
         )
@@ -651,12 +653,16 @@ class TestPipelineRunnerClearViaLifecycle:
         lifecycle_service = MagicMock(spec=MedallionLifecycleService)
         lifecycle_service.prepare_for_run = AsyncMock(
             return_value=PrepareResult(
-                clear_result=ClearResult(silver_cleared=0, gold_cleared=0, dry_run=False),
+                clear_result=ClearResult(
+                    silver_cleared=0, gold_cleared=0, dry_run=False
+                ),
                 policy=MedallionPolicy.for_run_type(RunType.INCREMENTAL),
             )
         )
         lifecycle_service.finalize_run = AsyncMock(
-            return_value=VacuumResult(silver_files_removed=0, gold_files_removed=0, skipped=True)
+            return_value=VacuumResult(
+                silver_files_removed=0, gold_files_removed=0, skipped=True
+            )
         )
 
         mock_observer = MagicMock(spec=PipelineObserver)
@@ -717,7 +723,11 @@ class TestPipelineRunnerCheckDataQuality:
         mock_lifecycle_service,
     ):
         """Test _check_data_quality delegates to PostrunService."""
-        from bioetl.application.core.postrun_service import DQResult, DQStatus, VacuumResult
+        from bioetl.application.core.postrun_service import (
+            DQResult,
+            DQStatus,
+            VacuumResult,
+        )
 
         services = create_mock_services()
 
@@ -778,7 +788,11 @@ class TestPipelineRunnerCheckDataQuality:
         mock_lifecycle_service,
     ):
         """Test _check_data_quality is invoked during run()."""
-        from bioetl.application.core.postrun_service import DQResult, DQStatus, VacuumResult
+        from bioetl.application.core.postrun_service import (
+            DQResult,
+            DQStatus,
+            VacuumResult,
+        )
 
         services = create_mock_services()
 

--- a/tests/unit/application/pipelines/crossref/test_crossref_transformer.py
+++ b/tests/unit/application/pipelines/crossref/test_crossref_transformer.py
@@ -87,7 +87,10 @@ def test_normalize_doi():
 
 def test_extract_title(sample_publication):
     """Test title extraction using domain function."""
-    assert extract_first_string(sample_publication.get("title", [])) == "Test Article Title"
+    assert (
+        extract_first_string(sample_publication.get("title", []))
+        == "Test Article Title"
+    )
     assert extract_first_string([]) is None
 
 
@@ -163,7 +166,9 @@ async def test_transform_full_record(transformer, pipeline_context, sample_publi
 
 
 @pytest.mark.asyncio
-async def test_transform_minimal_record(transformer, pipeline_context, minimal_publication):
+async def test_transform_minimal_record(
+    transformer, pipeline_context, minimal_publication
+):
     """Test transforming minimal work record to SilverRecord."""
     result = await transformer.transform(pipeline_context, minimal_publication, index=1)
 

--- a/tests/unit/application/services/test_data_quality_service.py
+++ b/tests/unit/application/services/test_data_quality_service.py
@@ -57,9 +57,7 @@ def dq_service(mock_logger, mock_metrics, dq_config):
 class TestDataQualityServiceInit:
     """Tests for DataQualityService initialization."""
 
-    def test_initialization_without_monitor(
-        self, mock_logger, mock_metrics, dq_config
-    ):
+    def test_initialization_without_monitor(self, mock_logger, mock_metrics, dq_config):
         """Test service initializes correctly without dq_monitor."""
         service = DataQualityService(
             dq_monitor=None,
@@ -75,9 +73,7 @@ class TestDataQualityServiceInit:
         assert service._metrics == mock_metrics
         assert service._pipeline_name == "test_pipeline"
 
-    def test_initialization_with_monitor(
-        self, mock_logger, mock_metrics, dq_config
-    ):
+    def test_initialization_with_monitor(self, mock_logger, mock_metrics, dq_config):
         """Test service initializes correctly with dq_monitor."""
         mock_dq_monitor = MagicMock()
 
@@ -257,9 +253,7 @@ class TestDataQualityServiceGracefulDegradation:
         assert result.anomalies == ()
 
     @pytest.mark.asyncio
-    async def test_no_metrics_port_still_logs_warning(
-        self, mock_logger, dq_config
-    ):
+    async def test_no_metrics_port_still_logs_warning(self, mock_logger, dq_config):
         """Test that soft threshold logs warning even when metrics port is None."""
         service = DataQualityService(
             dq_monitor=None,

--- a/tests/unit/application/services/test_medallion_lifecycle.py
+++ b/tests/unit/application/services/test_medallion_lifecycle.py
@@ -421,7 +421,11 @@ class TestMedallionLifecycleServicePrepareForRun:
 
     @pytest.mark.asyncio
     async def test_prepare_for_incremental_uses_never_policy(
-        self, lifecycle_service, mock_storage, pipeline_config, runtime_config_incremental
+        self,
+        lifecycle_service,
+        mock_storage,
+        pipeline_config,
+        runtime_config_incremental,
     ):
         """prepare_for_run uses NEVER policy for incremental runs."""
         result = await lifecycle_service.prepare_for_run(
@@ -471,7 +475,9 @@ class TestMedallionLifecycleServicePrepareForRun:
 
         await service.prepare_for_run(config=config, runtime=runtime_config_rebuild)
 
-        mock_storage.clear_gold.assert_called_once_with("chembl.activity", dry_run=False)
+        mock_storage.clear_gold.assert_called_once_with(
+            "chembl.activity", dry_run=False
+        )
 
     @pytest.mark.asyncio
     async def test_prepare_uses_configured_gold_table(
@@ -492,7 +498,9 @@ class TestMedallionLifecycleServicePrepareForRun:
 
         await service.prepare_for_run(config=config, runtime=runtime_config_rebuild)
 
-        mock_storage.clear_gold.assert_called_once_with("custom_gold_table", dry_run=False)
+        mock_storage.clear_gold.assert_called_once_with(
+            "custom_gold_table", dry_run=False
+        )
 
     @pytest.mark.asyncio
     async def test_prepare_passes_dry_run_flag(
@@ -564,7 +572,11 @@ class TestMedallionLifecycleServiceFinalizeRun:
 
     @pytest.mark.asyncio
     async def test_finalize_skipped_when_vacuum_disabled(
-        self, mock_storage_with_vacuum, mock_logger, pipeline_config, runtime_config_vacuum_disabled
+        self,
+        mock_storage_with_vacuum,
+        mock_logger,
+        pipeline_config,
+        runtime_config_vacuum_disabled,
     ):
         """finalize_run skips vacuum when disabled."""
         service = MedallionLifecycleService(
@@ -605,7 +617,11 @@ class TestMedallionLifecycleServiceFinalizeRun:
 
     @pytest.mark.asyncio
     async def test_finalize_vacuums_both_tables(
-        self, mock_storage_with_vacuum, mock_logger, pipeline_config, runtime_config_vacuum_enabled
+        self,
+        mock_storage_with_vacuum,
+        mock_logger,
+        pipeline_config,
+        runtime_config_vacuum_enabled,
     ):
         """finalize_run vacuums both Silver and Gold tables."""
         service = MedallionLifecycleService(
@@ -623,7 +639,11 @@ class TestMedallionLifecycleServiceFinalizeRun:
 
     @pytest.mark.asyncio
     async def test_finalize_handles_vacuum_error_gracefully(
-        self, mock_storage_with_vacuum, mock_logger, pipeline_config, runtime_config_vacuum_enabled
+        self,
+        mock_storage_with_vacuum,
+        mock_logger,
+        pipeline_config,
+        runtime_config_vacuum_enabled,
     ):
         """finalize_run handles vacuum errors gracefully."""
         mock_storage_with_vacuum.vacuum.side_effect = RuntimeError("Vacuum failed")
@@ -642,7 +662,11 @@ class TestMedallionLifecycleServiceFinalizeRun:
 
     @pytest.mark.asyncio
     async def test_finalize_emits_metrics(
-        self, mock_storage_with_vacuum, mock_logger, pipeline_config, runtime_config_vacuum_enabled
+        self,
+        mock_storage_with_vacuum,
+        mock_logger,
+        pipeline_config,
+        runtime_config_vacuum_enabled,
     ):
         """finalize_run emits metrics when provided."""
         mock_metrics = MagicMock()

--- a/tests/unit/application/services/test_pipeline_runner_service.py
+++ b/tests/unit/application/services/test_pipeline_runner_service.py
@@ -345,9 +345,7 @@ class TestPipelineRunnerServiceRun:
         mock_metrics_extractor.extract_metrics.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_pipeline_failure(
-        self, service, mock_runner, mock_metrics_extractor
-    ):
+    async def test_pipeline_failure(self, service, mock_runner, mock_metrics_extractor):
         """Test exception handling."""
         mock_runner.run.side_effect = ValueError("Invalid configuration")
 

--- a/tests/unit/cli/test_registry_consistency.py
+++ b/tests/unit/cli/test_registry_consistency.py
@@ -24,7 +24,6 @@ from bioetl.composition.factories.pipeline_factories import (
 )
 from bioetl.composition.registry import PipelineRegistry, create_registry
 
-
 # =============================================================================
 # Fixtures
 # =============================================================================
@@ -204,9 +203,7 @@ class TestRegistryNameUniqueness:
 
         assert not duplicates, f"Duplicate pipeline names found: {duplicates}"
 
-    def test_registry_has_unique_names(
-        self, test_registry: PipelineRegistry
-    ) -> None:
+    def test_registry_has_unique_names(self, test_registry: PipelineRegistry) -> None:
         """Verify registered pipelines have unique names.
 
         This test validates the registry's enforcement of uniqueness.
@@ -214,9 +211,9 @@ class TestRegistryNameUniqueness:
         registered = test_registry.list_pipelines()
 
         # list_pipelines returns a list, check for duplicates
-        assert len(registered) == len(set(registered)), (
-            "Registry contains duplicate pipeline names"
-        )
+        assert len(registered) == len(
+            set(registered)
+        ), "Registry contains duplicate pipeline names"
 
     def test_duplicate_registration_raises_error(self) -> None:
         """Verify that registering a duplicate pipeline raises ValueError."""
@@ -245,21 +242,21 @@ class TestFactoryValidity:
         from bioetl.composition.factories.pipeline_factories import _factories
 
         for name, factory in _factories.items():
-            assert hasattr(factory, "pipeline_name"), (
-                f"Factory {name} missing pipeline_name attribute"
-            )
-            assert factory.pipeline_name == name, (
-                f"Factory pipeline_name mismatch: {factory.pipeline_name} != {name}"
-            )
+            assert hasattr(
+                factory, "pipeline_name"
+            ), f"Factory {name} missing pipeline_name attribute"
+            assert (
+                factory.pipeline_name == name
+            ), f"Factory pipeline_name mismatch: {factory.pipeline_name} != {name}"
 
     def test_all_factories_have_silver_schema(self) -> None:
         """Verify each factory has a silver_schema attribute (can be None)."""
         from bioetl.composition.factories.pipeline_factories import _factories
 
         for name, factory in _factories.items():
-            assert hasattr(factory, "silver_schema"), (
-                f"Factory {name} missing silver_schema attribute"
-            )
+            assert hasattr(
+                factory, "silver_schema"
+            ), f"Factory {name} missing silver_schema attribute"
 
     def test_all_factories_have_gold_schema(self) -> None:
         """Verify each factory has a non-None gold_schema attribute.
@@ -269,9 +266,9 @@ class TestFactoryValidity:
         from bioetl.composition.factories.pipeline_factories import _factories
 
         for name, factory in _factories.items():
-            assert hasattr(factory, "gold_schema"), (
-                f"Factory {name} missing gold_schema attribute"
-            )
+            assert hasattr(
+                factory, "gold_schema"
+            ), f"Factory {name} missing gold_schema attribute"
             assert factory.gold_schema is not None, (
                 f"Factory {name} has None gold_schema. "
                 "All pipelines require a Gold schema for validation."
@@ -282,24 +279,24 @@ class TestFactoryValidity:
         from bioetl.composition.factories.pipeline_factories import _factories
 
         for name, factory in _factories.items():
-            assert hasattr(factory, "create_with_services"), (
-                f"Factory {name} missing create_with_services method"
-            )
-            assert callable(factory.create_with_services), (
-                f"Factory {name}.create_with_services is not callable"
-            )
+            assert hasattr(
+                factory, "create_with_services"
+            ), f"Factory {name} missing create_with_services method"
+            assert callable(
+                factory.create_with_services
+            ), f"Factory {name}.create_with_services is not callable"
 
     def test_all_factories_have_create_runner(self) -> None:
         """Verify each factory has create_runner method."""
         from bioetl.composition.factories.pipeline_factories import _factories
 
         for name, factory in _factories.items():
-            assert hasattr(factory, "create_runner"), (
-                f"Factory {name} missing create_runner method"
-            )
-            assert callable(factory.create_runner), (
-                f"Factory {name}.create_runner is not callable"
-            )
+            assert hasattr(
+                factory, "create_runner"
+            ), f"Factory {name} missing create_runner method"
+            assert callable(
+                factory.create_runner
+            ), f"Factory {name}.create_runner is not callable"
 
     def test_factory_count_matches_config_count(self) -> None:
         """Verify factory count matches PIPELINE_CONFIGS count."""
@@ -341,9 +338,7 @@ class TestRegistryConfigConsistency:
                     f"Create configs/pipelines/<provider>/<entity>.yaml"
                 )
             except ValueError as e:
-                pytest.fail(
-                    f"Pipeline '{pipeline_name}' config is invalid: {e}"
-                )
+                pytest.fail(f"Pipeline '{pipeline_name}' config is invalid: {e}")
 
 
 # =============================================================================
@@ -417,6 +412,6 @@ class TestListAvailablePipelinesFunction:
         function_result = list_available_pipelines()
         registry_result = test_registry.list_pipelines()
 
-        assert function_result == registry_result, (
-            "list_available_pipelines() should match registry.list_pipelines()"
-        )
+        assert (
+            function_result == registry_result
+        ), "list_available_pipelines() should match registry.list_pipelines()"

--- a/tests/unit/domain/services/test_identity_service.py
+++ b/tests/unit/domain/services/test_identity_service.py
@@ -14,7 +14,7 @@ from datetime import date, datetime
 
 import pytest
 
-from bioetl.domain.services.identity_service import IdentityService, META_FIELDS
+from bioetl.domain.services.identity_service import META_FIELDS, IdentityService
 
 
 class TestIdentityServiceDeterminism:

--- a/tests/unit/domain/services/test_normalization_service.py
+++ b/tests/unit/domain/services/test_normalization_service.py
@@ -129,9 +129,7 @@ class TestNormalizationServiceNormalizeMultiple:
     def service(self) -> NormalizationService:
         return NormalizationService()
 
-    def test_normalize_multiple_aggregates(
-        self, service: NormalizationService
-    ) -> None:
+    def test_normalize_multiple_aggregates(self, service: NormalizationService) -> None:
         """Test aggregation of multiple values."""
         result = service.normalize_multiple(
             [90.0, 100.0, 110.0], "nM", "IC50", aggregate=True

--- a/tests/unit/domain/value_objects/test_activity.py
+++ b/tests/unit/domain/value_objects/test_activity.py
@@ -67,8 +67,12 @@ class TestRelationOperator:
     def test_from_string_greater_than(self) -> None:
         """Test parsing greater than operators."""
         assert RelationOperator.from_string(">") == RelationOperator.GREATER_THAN
-        assert RelationOperator.from_string(">=") == RelationOperator.GREATER_THAN_OR_EQUAL
-        assert RelationOperator.from_string("=>") == RelationOperator.GREATER_THAN_OR_EQUAL
+        assert (
+            RelationOperator.from_string(">=") == RelationOperator.GREATER_THAN_OR_EQUAL
+        )
+        assert (
+            RelationOperator.from_string("=>") == RelationOperator.GREATER_THAN_OR_EQUAL
+        )
 
     def test_from_string_approximately(self) -> None:
         """Test parsing approximately operators."""
@@ -225,7 +229,9 @@ class TestActivityValue:
 
     def test_creation_with_relation(self) -> None:
         """Test creation with custom relation."""
-        av = ActivityValue(value=10.0, unit="μM", relation=RelationOperator.GREATER_THAN)
+        av = ActivityValue(
+            value=10.0, unit="μM", relation=RelationOperator.GREATER_THAN
+        )
         assert av.value == 10.0
         assert av.unit == "μM"
         assert av.relation == RelationOperator.GREATER_THAN
@@ -248,14 +254,18 @@ class TestActivityValue:
     def test_is_exact_property(self) -> None:
         """Test is_exact property."""
         exact = ActivityValue(value=100.0, unit="nM", relation=RelationOperator.EQUAL)
-        bound = ActivityValue(value=100.0, unit="nM", relation=RelationOperator.GREATER_THAN)
+        bound = ActivityValue(
+            value=100.0, unit="nM", relation=RelationOperator.GREATER_THAN
+        )
         assert exact.is_exact is True
         assert bound.is_exact is False
 
     def test_is_bounded_property(self) -> None:
         """Test is_bounded property."""
         exact = ActivityValue(value=100.0, unit="nM", relation=RelationOperator.EQUAL)
-        bound = ActivityValue(value=100.0, unit="nM", relation=RelationOperator.LESS_THAN)
+        bound = ActivityValue(
+            value=100.0, unit="nM", relation=RelationOperator.LESS_THAN
+        )
         assert exact.is_bounded is False
         assert bound.is_bounded is True
 
@@ -287,6 +297,7 @@ class TestActivityValue:
         conc = av.to_concentration()
         assert conc.value == 100.0
         from bioetl.domain.value_objects import ConcentrationUnit
+
         assert conc.unit == ConcentrationUnit.NANOMOLAR
 
     def test_to_concentration_invalid_unit(self) -> None:
@@ -317,7 +328,9 @@ class TestActivityValue:
 
     def test_str(self) -> None:
         """Test string representation."""
-        av = ActivityValue(value=100.0, unit="nM", relation=RelationOperator.GREATER_THAN)
+        av = ActivityValue(
+            value=100.0, unit="nM", relation=RelationOperator.GREATER_THAN
+        )
         assert str(av) == "> 100.0 nM"
 
     def test_can_be_used_in_set(self) -> None:

--- a/tests/unit/infrastructure/adapters/crossref/test_crossref_client.py
+++ b/tests/unit/infrastructure/adapters/crossref/test_crossref_client.py
@@ -38,7 +38,9 @@ async def test_fetch_by_doi_success(adapter, mock_http_client):
     """Test successful fetch by DOI."""
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {"message": {"items": [{"title": ["Test Title"]}]}}
+    mock_response.json.return_value = {
+        "message": {"items": [{"title": ["Test Title"]}]}
+    }
     mock_http_client.get.return_value = mock_response
 
     results = [
@@ -170,12 +172,15 @@ async def test_health_check_returns_degraded_on_slow_response(
 
     mock_monotonic = MagicMock(side_effect=mock_monotonic_func)
 
-    with patch(
-        "bioetl.infrastructure.adapters.crossref.client.time.monotonic",
-        new=mock_monotonic,
-    ), patch(
-        "bioetl.infrastructure.adapters.health_check_mixin.time.monotonic",
-        new=mock_monotonic,
+    with (
+        patch(
+            "bioetl.infrastructure.adapters.crossref.client.time.monotonic",
+            new=mock_monotonic,
+        ),
+        patch(
+            "bioetl.infrastructure.adapters.health_check_mixin.time.monotonic",
+            new=mock_monotonic,
+        ),
     ):
         result = await adapter.health_check()
 

--- a/tests/unit/infrastructure/observability/test_unified_logger.py
+++ b/tests/unit/infrastructure/observability/test_unified_logger.py
@@ -7,10 +7,8 @@ from uuid import uuid4
 import pytest
 
 from bioetl.infrastructure.observability.logging_config import (
-    secret_filter_processor,
-)
-from bioetl.infrastructure.observability.logging_config import (
     _mask_secrets,
+    secret_filter_processor,
 )
 from bioetl.infrastructure.observability.unified_logger import (
     UnifiedLogger,

--- a/tests/unit/infrastructure/storage/test_bronze_writer.py
+++ b/tests/unit/infrastructure/storage/test_bronze_writer.py
@@ -76,7 +76,6 @@ class TestBronzeWriterNameValidation:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         # Should not raise for valid names (alphanumeric + underscore only)
@@ -93,7 +92,6 @@ class TestBronzeWriterNameValidation:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         with pytest.raises(ValueError, match="Invalid provider name"):
@@ -118,7 +116,6 @@ class TestBronzeWriterNameValidation:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         with pytest.raises(ValueError, match="Invalid entity name"):
@@ -153,7 +150,6 @@ class TestBronzeWriterNameValidation:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
@@ -185,7 +181,6 @@ class TestBronzeWriterNameValidation:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
@@ -207,7 +202,6 @@ class TestBronzeWriterNameValidation:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         # Should not raise for valid iterators
@@ -221,7 +215,6 @@ class TestBronzeWriterNameValidation:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         with pytest.raises(TypeError, match="records cannot be None"):
@@ -235,7 +228,6 @@ class TestBronzeWriterNameValidation:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         # List is an iterable (valid now)
@@ -265,7 +257,6 @@ class TestBronzeWriterNameValidation:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
@@ -293,7 +284,6 @@ class TestBronzeWriterUTCValidation:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         # Should not raise for UTC datetime
@@ -306,7 +296,6 @@ class TestBronzeWriterUTCValidation:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         naive_dt = datetime(2024, 1, 15, 12, 0, 0)  # No tzinfo
@@ -321,7 +310,6 @@ class TestBronzeWriterUTCValidation:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         # Create datetime with non-UTC timezone (e.g., UTC+3)
@@ -347,7 +335,6 @@ class TestBronzeWriterUTCValidation:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
         naive_date = datetime(2024, 1, 15)  # No tzinfo
 
@@ -378,7 +365,6 @@ class TestBronzeWriterUTCValidation:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
         utc_date = datetime(2024, 1, 15, tzinfo=UTC)
         naive_ingestion = datetime(2024, 1, 15, 12, 0, 0)  # No tzinfo
@@ -413,7 +399,6 @@ class TestBronzeWriterUTCValidation:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
         non_utc_tz = timezone(timedelta(hours=5))
         non_utc_date = datetime(2024, 1, 15, tzinfo=non_utc_tz)
@@ -441,7 +426,6 @@ class TestBronzeWriterInit:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         assert writer.base_path == tmp_path
@@ -455,7 +439,6 @@ class TestBronzeWriterInit:
             logger=noop_logger,
             metrics=NoOpMetrics(),
             save_json=True,
-
         )
 
         assert writer.save_json is True
@@ -470,7 +453,6 @@ class TestBronzeWriterInit:
             metrics=NoOpMetrics(),
             save_json=True,
             json_path=custom_path,
-
         )
 
         assert writer.json_path == custom_path
@@ -493,7 +475,6 @@ class TestBronzeWriterCompress:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         compressed, record_count, uncompressed_size = writer._compress_records(
@@ -518,7 +499,6 @@ class TestBronzeWriterCompress:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         with pytest.raises(ValueError, match="No records provided"):
@@ -530,7 +510,6 @@ class TestBronzeWriterCompress:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         # Create large records
@@ -569,7 +548,6 @@ class TestBronzeWriterWriteLocal:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
@@ -633,7 +611,6 @@ class TestBronzeWriterWriteLocal:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
         date = datetime(2023, 1, 1, tzinfo=UTC)
 
@@ -679,7 +656,6 @@ class TestBronzeWriterWriteLocal:
             logger=noop_logger,
             metrics=NoOpMetrics(),
             save_json=True,
-
         )
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
@@ -720,7 +696,6 @@ class TestBronzeWriterWriteLocal:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
@@ -757,7 +732,6 @@ class TestBronzeWriterReadLocal:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
@@ -803,7 +777,6 @@ class TestBronzeWriterListBatches:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         # Write multiple batches
@@ -850,7 +823,6 @@ class TestBronzeWriterListBatches:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         date1 = datetime(2024, 1, 15, tzinfo=UTC)
@@ -889,7 +861,6 @@ class TestBronzeWriterListBatches:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         batches = await writer.list_batches("nonexistent", "entity")
@@ -920,7 +891,6 @@ class TestBronzeWriterAtomicWrite:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
@@ -972,7 +942,6 @@ class TestBronzeWriterAtomicWrite:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
@@ -1011,7 +980,6 @@ class TestBronzeWriterAtomicWrite:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
@@ -1046,7 +1014,6 @@ class TestBronzeWriterAtomicWrite:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
@@ -1090,7 +1057,6 @@ class TestBronzeWriterAtomicWrite:
             logger=noop_logger,
             metrics=NoOpMetrics(),
             save_json=True,
-
         )
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
@@ -1135,7 +1101,6 @@ class TestBronzeWriterLoggerInjection:
             base_path=tmp_path,
             logger=mock_logger,
             metrics=NoOpMetrics(),
-
         )
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
@@ -1166,7 +1131,6 @@ class TestBronzeWriterLoggerInjection:
             base_path=tmp_path,
             logger=mock_logger,
             metrics=NoOpMetrics(),
-
         )
 
         assert writer.logger is mock_logger
@@ -1195,7 +1159,6 @@ class TestBronzeWriterMetadataDeterminism:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
@@ -1268,7 +1231,6 @@ class TestBronzeWriterMetadataDeterminism:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         metadata = writer._build_bronze_metadata(
@@ -1307,7 +1269,6 @@ class TestBronzeWriterMetadataDeterminism:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         metadata = writer._build_bronze_metadata(
@@ -1340,7 +1301,6 @@ class TestBronzeWriterMetrics:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=mock_metrics,
-
         )
 
         assert writer._metrics is mock_metrics
@@ -1353,7 +1313,6 @@ class TestBronzeWriterMetrics:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         assert isinstance(writer._metrics, NoOpMetrics)
@@ -1375,7 +1334,6 @@ class TestBronzeWriterMetrics:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=mock_metrics,
-
         )
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
@@ -1421,7 +1379,6 @@ class TestBronzeWriterMetrics:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=mock_metrics,
-
         )
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
@@ -1466,7 +1423,6 @@ class TestBronzeWriterMetrics:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=mock_metrics,
-
         )
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
@@ -1511,7 +1467,6 @@ class TestBronzeWriterMetrics:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=mock_metrics,
-
         )
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
@@ -1560,7 +1515,6 @@ class TestBronzeWriterMetrics:
             base_path=tmp_path,
             logger=mock_logger,
             metrics=NoOpMetrics(),
-
         )
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
@@ -1597,7 +1551,6 @@ class TestBronzeWriterJsonValidation:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
         assert writer.validate_json is True
 
@@ -1608,7 +1561,6 @@ class TestBronzeWriterJsonValidation:
             logger=noop_logger,
             metrics=NoOpMetrics(),
             validate_json=False,
-
         )
         assert writer.validate_json is False
 
@@ -1618,7 +1570,6 @@ class TestBronzeWriterJsonValidation:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         valid_records = [
@@ -1641,7 +1592,6 @@ class TestBronzeWriterJsonValidation:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         invalid_records = [
@@ -1665,7 +1615,6 @@ class TestBronzeWriterJsonValidation:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         with pytest.raises(BronzeValidationError) as exc_info:
@@ -1681,7 +1630,6 @@ class TestBronzeWriterJsonValidation:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         truncated_records = [
@@ -1699,7 +1647,6 @@ class TestBronzeWriterJsonValidation:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         valid_records = [
@@ -1732,7 +1679,6 @@ class TestBronzeWriterJsonValidation:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
@@ -1772,7 +1718,6 @@ class TestBronzeWriterJsonValidation:
             logger=noop_logger,
             metrics=NoOpMetrics(),
             validate_json=False,
-
         )
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
@@ -1816,7 +1761,6 @@ class TestBronzeWriterJsonValidation:
             logger=noop_logger,
             metrics=NoOpMetrics(),
             validate_json=True,
-
         )
         date = datetime(2024, 1, 15, tzinfo=UTC)
 

--- a/tests/unit/infrastructure/storage/test_gold_writer.py
+++ b/tests/unit/infrastructure/storage/test_gold_writer.py
@@ -23,9 +23,7 @@ def noop_logger():
 @pytest.fixture
 def gold_writer(noop_logger):
     """Create a GoldWriter instance."""
-    return GoldWriter(
-        base_path="s3://test-bucket/gold", logger=noop_logger
-    )
+    return GoldWriter(base_path="s3://test-bucket/gold", logger=noop_logger)
 
 
 @pytest.fixture
@@ -106,9 +104,7 @@ class TestGoldWriterInit:
 
     def test_init_strips_trailing_slash(self, noop_logger):
         """Test that trailing slash is stripped from base_path."""
-        writer = GoldWriter(
-            base_path="s3://bucket/gold/", logger=noop_logger
-        )
+        writer = GoldWriter(base_path="s3://bucket/gold/", logger=noop_logger)
         assert writer.base_path == "s3://bucket/gold"
 
     def test_init_with_csv_exporter(self, noop_logger):
@@ -120,15 +116,12 @@ class TestGoldWriterInit:
             base_path="/tmp/gold",
             logger=noop_logger,
             csv_exporter=mock_exporter,
-
         )
         assert writer.csv_exporter is mock_exporter
 
     def test_init_without_csv_exporter(self, noop_logger):
         """Test initialization without CSV exporter."""
-        writer = GoldWriter(
-            base_path="/tmp/gold", logger=noop_logger
-        )
+        writer = GoldWriter(base_path="/tmp/gold", logger=noop_logger)
         assert writer.csv_exporter is None
 
 

--- a/tests/unit/infrastructure/storage/test_silver_writer.py
+++ b/tests/unit/infrastructure/storage/test_silver_writer.py
@@ -47,9 +47,7 @@ class TestSilverWriterInit:
         """Test that trailing slash is stripped from base_path."""
         from bioetl.infrastructure.storage.silver_writer import SilverWriter
 
-        writer = SilverWriter(
-            base_path="s3://bucket/path/", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="s3://bucket/path/", logger=noop_logger)
         assert writer.base_path == "s3://bucket/path"
 
     def test_init_with_csv_exporter(self, noop_logger):
@@ -63,7 +61,6 @@ class TestSilverWriterInit:
             base_path="/tmp/silver",
             logger=noop_logger,
             csv_exporter=mock_exporter,
-
         )
         assert writer.csv_exporter is mock_exporter
 
@@ -71,9 +68,7 @@ class TestSilverWriterInit:
         """Test initialization without CSV exporter."""
         from bioetl.infrastructure.storage.silver_writer import SilverWriter
 
-        writer = SilverWriter(
-            base_path="/tmp/silver", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
         assert writer.csv_exporter is None
 
 
@@ -88,9 +83,7 @@ class TestSilverWriterValidation:
 
         from bioetl.infrastructure.storage.silver_writer import SilverWriter
 
-        writer = SilverWriter(
-            base_path="s3://bucket", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="s3://bucket", logger=noop_logger)
         schema = pa.schema(
             [
                 pa.field("entity_id", pa.string()),
@@ -118,9 +111,7 @@ class TestSilverWriterValidation:
 
         from bioetl.infrastructure.storage.silver_writer import SilverWriter
 
-        writer = SilverWriter(
-            base_path="s3://bucket", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="s3://bucket", logger=noop_logger)
 
         dummy_schema = pa.schema([pa.field("entity_id", pa.string())])
 
@@ -137,9 +128,7 @@ class TestSilverWriterValidation:
         """Test write_silver raises ValueError for missing metadata."""
         from bioetl.infrastructure.storage.silver_writer import SilverWriter
 
-        writer = SilverWriter(
-            base_path="s3://bucket", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="s3://bucket", logger=noop_logger)
         records = [{"entity_id": "CHEMBL123", "value": 5.5}]
 
         import pyarrow as pa
@@ -159,9 +148,7 @@ class TestSilverWriterValidation:
         """Test write_silver raises ValueError when _run_id is missing."""
         from bioetl.infrastructure.storage.silver_writer import SilverWriter
 
-        writer = SilverWriter(
-            base_path="s3://bucket", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="s3://bucket", logger=noop_logger)
         records = [
             {
                 "entity_id": "CHEMBL123",
@@ -221,9 +208,7 @@ class TestSilverWriterWriteModeEnum:
             SilverWriter,
         )
 
-        writer = SilverWriter(
-            base_path="/tmp/silver", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
 
         assert writer._validate_write_mode("merge") == SilverWriteMode.MERGE
         assert writer._validate_write_mode("append") == SilverWriteMode.APPEND
@@ -244,9 +229,7 @@ class TestSilverWriterTablePath:
         """Test table path is constructed correctly."""
         from bioetl.infrastructure.storage.silver_writer import SilverWriter
 
-        writer = SilverWriter(
-            base_path="s3://bucket/silver", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="s3://bucket/silver", logger=noop_logger)
 
         # Access internal path construction
         table_name = "chembl.activity"
@@ -259,9 +242,7 @@ class TestSilverWriterTablePath:
         """Test table path with nested table name."""
         from bioetl.infrastructure.storage.silver_writer import SilverWriter
 
-        writer = SilverWriter(
-            base_path="s3://bucket/silver", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="s3://bucket/silver", logger=noop_logger)
 
         table_name = "provider.schema.table"
         expected_path = "s3://bucket/silver/provider/schema/table"
@@ -321,9 +302,7 @@ class TestSilverWriterVacuum:
             "file2.parquet",
         ]
 
-        writer = SilverWriter(
-            base_path="s3://bucket/silver", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="s3://bucket/silver", logger=noop_logger)
         result = await writer.vacuum("test.table", retention_hours=168)
 
         assert len(result) == 2
@@ -341,9 +320,7 @@ class TestSilverWriterVacuum:
         mock_delta_table.return_value = mock_table_instance
         mock_table_instance.vacuum.return_value = ["file1.parquet"]
 
-        writer = SilverWriter(
-            base_path="s3://bucket/silver", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="s3://bucket/silver", logger=noop_logger)
         await writer.vacuum("test.table", retention_hours=24, dry_run=True)
 
         mock_table_instance.vacuum.assert_called_once_with(
@@ -362,9 +339,7 @@ class TestSilverWriterVacuum:
             "bioetl.infrastructure.storage.retention_manager.DeltaTable",
             side_effect=DeltaTableNotFoundError("Not found"),
         ):
-            writer = SilverWriter(
-                base_path="s3://bucket/silver", logger=noop_logger
-            )
+            writer = SilverWriter(base_path="s3://bucket/silver", logger=noop_logger)
 
             with pytest.raises(TableNotFoundError):
                 await writer.vacuum("nonexistent.table")
@@ -389,9 +364,7 @@ class TestSilverWriterOptimize:
             "numFilesRemoved": 5,
         }
 
-        writer = SilverWriter(
-            base_path="s3://bucket/silver", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="s3://bucket/silver", logger=noop_logger)
         result = await writer.optimize("test.table")
 
         assert result["numFilesRemoved"] == 5
@@ -409,9 +382,7 @@ class TestSilverWriterOptimize:
         mock_table_instance.optimize = mock_optimize
         mock_optimize.compact.return_value = {}
 
-        writer = SilverWriter(
-            base_path="s3://bucket/silver", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="s3://bucket/silver", logger=noop_logger)
         await writer.optimize("test.table", partition_filters=[("year", "=", 2025)])
 
         mock_optimize.compact.assert_called_once_with(
@@ -430,9 +401,7 @@ class TestSilverWriterOptimize:
             "bioetl.infrastructure.storage.retention_manager.DeltaTable",
             side_effect=DeltaTableNotFoundError("Not found"),
         ):
-            writer = SilverWriter(
-                base_path="s3://bucket/silver", logger=noop_logger
-            )
+            writer = SilverWriter(base_path="s3://bucket/silver", logger=noop_logger)
 
             with pytest.raises(TableNotFoundError):
                 await writer.optimize("nonexistent.table")
@@ -457,9 +426,7 @@ class TestSilverWriterGetTableInfo:
         mock_table_instance.schema.return_value = mock_schema
         mock_table_instance.metadata.return_value = {"id": "test-table"}
 
-        writer = SilverWriter(
-            base_path="s3://bucket/silver", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="s3://bucket/silver", logger=noop_logger)
         result = await writer.get_table_info("test.table")
 
         assert result["version"] == 10
@@ -477,9 +444,7 @@ class TestSilverWriterGetTableInfo:
             "bioetl.infrastructure.storage.retention_manager.DeltaTable",
             side_effect=DeltaTableNotFoundError("Not found"),
         ):
-            writer = SilverWriter(
-                base_path="s3://bucket/silver", logger=noop_logger
-            )
+            writer = SilverWriter(base_path="s3://bucket/silver", logger=noop_logger)
 
             with pytest.raises(TableNotFoundError):
                 await writer.get_table_info("nonexistent.table")
@@ -498,9 +463,7 @@ class TestSilverWriterTimeTravel:
         mock_table_instance = MagicMock()
         mock_delta_table.return_value = mock_table_instance
 
-        writer = SilverWriter(
-            base_path="s3://bucket/silver", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="s3://bucket/silver", logger=noop_logger)
         result = await writer.time_travel("test.table", version=5)
 
         assert result == mock_table_instance
@@ -517,9 +480,7 @@ class TestSilverWriterTimeTravel:
         mock_table_instance = MagicMock()
         mock_delta_table.return_value = mock_table_instance
 
-        writer = SilverWriter(
-            base_path="s3://bucket/silver", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="s3://bucket/silver", logger=noop_logger)
         ts = datetime(2025, 1, 1, 12, 0, 0)
         result = await writer.time_travel("test.table", timestamp=ts)
 
@@ -532,9 +493,7 @@ class TestSilverWriterTimeTravel:
 
         from bioetl.infrastructure.storage.silver_writer import SilverWriter
 
-        writer = SilverWriter(
-            base_path="s3://bucket/silver", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="s3://bucket/silver", logger=noop_logger)
 
         with pytest.raises(ValueError, match="Specify either version or timestamp"):
             await writer.time_travel(
@@ -546,9 +505,7 @@ class TestSilverWriterTimeTravel:
         """Test time_travel raises ValueError when neither version nor timestamp given."""
         from bioetl.infrastructure.storage.silver_writer import SilverWriter
 
-        writer = SilverWriter(
-            base_path="s3://bucket/silver", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="s3://bucket/silver", logger=noop_logger)
 
         with pytest.raises(
             ValueError, match="Must specify either version or timestamp"
@@ -567,9 +524,7 @@ class TestSilverWriterTimeTravel:
             "bioetl.infrastructure.storage.retention_manager.DeltaTable",
             side_effect=DeltaTableNotFoundError("Not found"),
         ):
-            writer = SilverWriter(
-                base_path="s3://bucket/silver", logger=noop_logger
-            )
+            writer = SilverWriter(base_path="s3://bucket/silver", logger=noop_logger)
 
             with pytest.raises(TableNotFoundError):
                 await writer.time_travel("nonexistent.table", version=1)
@@ -614,9 +569,7 @@ class TestSilverWriterErrorHandling:
             "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             delta_table_mock,
         ):
-            writer = SilverWriter(
-                base_path="s3://bucket/silver", logger=noop_logger
-            )
+            writer = SilverWriter(base_path="s3://bucket/silver", logger=noop_logger)
 
             with pytest.raises(SchemaViolationError):
                 await writer.write_silver(
@@ -669,9 +622,7 @@ class TestSilverWriterErrorHandling:
             "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             delta_table_mock,
         ):
-            writer = SilverWriter(
-                base_path="s3://bucket/silver", logger=noop_logger
-            )
+            writer = SilverWriter(base_path="s3://bucket/silver", logger=noop_logger)
 
             with pytest.raises(MergeConflictError):
                 await writer.write_silver(
@@ -697,9 +648,7 @@ class TestSilverWriterSchemaDrift:
             "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             side_effect=DeltaTableNotFoundError("Not found"),
         ):
-            writer = SilverWriter(
-                base_path="/tmp/silver", logger=noop_logger
-            )
+            writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
             result = await writer._get_table_schema("test.table")
             assert result is None
 
@@ -723,9 +672,7 @@ class TestSilverWriterSchemaDrift:
             "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             return_value=mock_table,
         ):
-            writer = SilverWriter(
-                base_path="/tmp/silver", logger=noop_logger
-            )
+            writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
             result = await writer._get_table_schema("test.table")
             assert result == expected_schema
 
@@ -751,9 +698,7 @@ class TestSilverWriterSchemaDrift:
             "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             return_value=mock_table,
         ):
-            writer = SilverWriter(
-                base_path="/tmp/silver", logger=noop_logger
-            )
+            writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
 
             with pytest.raises(SchemaEvolutionError) as exc_info:
                 await writer._check_schema_drift("test.table", valid_records, "error")
@@ -800,9 +745,7 @@ class TestSilverWriterSchemaDrift:
             "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             return_value=mock_table,
         ):
-            writer = SilverWriter(
-                base_path="/tmp/silver", logger=noop_logger
-            )
+            writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
 
             with pytest.raises(SchemaEvolutionError) as exc_info:
                 await writer._check_schema_drift("test.table", records, "error")
@@ -830,9 +773,7 @@ class TestSilverWriterSchemaDrift:
             "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             return_value=mock_table,
         ):
-            writer = SilverWriter(
-                base_path="/tmp/silver", logger=noop_logger
-            )
+            writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
 
             # Should not raise
             await writer._check_schema_drift("test.table", valid_records, "evolve")
@@ -857,9 +798,7 @@ class TestSilverWriterSchemaDrift:
             "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             return_value=mock_table,
         ):
-            writer = SilverWriter(
-                base_path="/tmp/silver", logger=noop_logger
-            )
+            writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
 
             # Should not raise
             await writer._check_schema_drift("test.table", valid_records, "ignore")
@@ -894,9 +833,7 @@ class TestSilverWriterSchemaDrift:
             "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             return_value=mock_table,
         ):
-            writer = SilverWriter(
-                base_path="/tmp/silver", logger=noop_logger
-            )
+            writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
 
             # Should not raise even in error mode
             await writer._check_schema_drift("test.table", valid_records, "error")
@@ -912,9 +849,7 @@ class TestSilverWriterSchemaDrift:
             "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             side_effect=DeltaTableNotFoundError("Not found"),
         ):
-            writer = SilverWriter(
-                base_path="/tmp/silver", logger=noop_logger
-            )
+            writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
 
             # Should not raise for new table
             await writer._check_schema_drift("test.table", valid_records, "error")
@@ -937,9 +872,7 @@ class TestSilverWriterSchemaDrift:
             "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             return_value=mock_table,
         ):
-            writer = SilverWriter(
-                base_path="/tmp/silver", logger=noop_logger
-            )
+            writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
 
             # Should not raise for empty records
             await writer._check_schema_drift("test.table", [], "error")
@@ -989,9 +922,7 @@ class TestSilverWriterSchemaDrift:
             "bioetl.infrastructure.storage.silver_writer.DeltaTable",
             return_value=mock_table,
         ):
-            writer = SilverWriter(
-                base_path="/tmp/silver", logger=noop_logger
-            )
+            writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
 
             # write_silver with on_schema_mismatch="error" should raise
             with pytest.raises(SchemaEvolutionError) as exc_info:
@@ -1018,9 +949,7 @@ class TestSilverWriterWriteModePolicy:
         from bioetl.domain.medallion import WriteModePolicy
         from bioetl.infrastructure.storage.silver_writer import SilverWriter
 
-        writer = SilverWriter(
-            base_path="/tmp/silver", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
         assert isinstance(writer._write_policy, WriteModePolicy)
 
     def test_init_with_custom_policy(self, noop_logger):
@@ -1033,7 +962,6 @@ class TestSilverWriterWriteModePolicy:
             base_path="/tmp/silver",
             logger=noop_logger,
             write_policy=custom_policy,
-
         )
         assert writer._write_policy is custom_policy
 
@@ -1046,7 +974,6 @@ class TestSilverWriterWriteModePolicy:
             base_path="/tmp/silver",
             logger=noop_logger,
             metrics=mock_metrics,
-
         )
         assert writer._metrics is mock_metrics
 
@@ -1058,9 +985,7 @@ class TestSilverWriterWriteModePolicy:
             SilverWriter,
         )
 
-        writer = SilverWriter(
-            base_path="/tmp/silver", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
         result = writer._to_policy_write_mode(SilverWriteMode.MERGE)
         assert result == WriteMode.MERGE
 
@@ -1072,9 +997,7 @@ class TestSilverWriterWriteModePolicy:
             SilverWriter,
         )
 
-        writer = SilverWriter(
-            base_path="/tmp/silver", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
         result = writer._to_policy_write_mode(SilverWriteMode.APPEND)
         assert result == WriteMode.APPEND
 
@@ -1086,9 +1009,7 @@ class TestSilverWriterWriteModePolicy:
             SilverWriter,
         )
 
-        writer = SilverWriter(
-            base_path="/tmp/silver", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
         result = writer._to_policy_write_mode(SilverWriteMode.DELETE)
         assert result == WriteMode.OVERWRITE
 
@@ -1099,9 +1020,7 @@ class TestSilverWriterWriteModePolicy:
             SilverWriter,
         )
 
-        writer = SilverWriter(
-            base_path="/tmp/silver", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
         # Should not raise
         writer._enforce_write_policy(SilverWriteMode.MERGE, "test.table")
 
@@ -1112,9 +1031,7 @@ class TestSilverWriterWriteModePolicy:
             SilverWriter,
         )
 
-        writer = SilverWriter(
-            base_path="/tmp/silver", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
         # Should not raise
         writer._enforce_write_policy(SilverWriteMode.APPEND, "test.table")
 
@@ -1126,9 +1043,7 @@ class TestSilverWriterWriteModePolicy:
             SilverWriter,
         )
 
-        writer = SilverWriter(
-            base_path="/tmp/silver", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
         with pytest.raises(PolicyViolationError) as exc_info:
             writer._enforce_write_policy(SilverWriteMode.DELETE, "test.table")
         assert "silver does not allow overwrite" in str(exc_info.value)
@@ -1146,7 +1061,6 @@ class TestSilverWriterWriteModePolicy:
             base_path="/tmp/silver",
             logger=noop_logger,
             metrics=mock_metrics,
-
         )
 
         with pytest.raises(PolicyViolationError):
@@ -1167,9 +1081,7 @@ class TestSilverWriterWriteModePolicy:
         )
 
         mock_logger = MagicMock()
-        writer = SilverWriter(
-            base_path="/tmp/silver", logger=mock_logger
-        )
+        writer = SilverWriter(base_path="/tmp/silver", logger=mock_logger)
 
         with pytest.raises(PolicyViolationError):
             writer._enforce_write_policy(SilverWriteMode.DELETE, "test.table")
@@ -1208,9 +1120,7 @@ class TestSilverWriterWriteModePolicy:
             ]
         )
 
-        writer = SilverWriter(
-            base_path="/tmp/silver", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
 
         with pytest.raises(PolicyViolationError) as exc_info:
             await writer.write_silver(
@@ -1252,9 +1162,7 @@ class TestSilverWriterWriteModePolicy:
                 "bioetl.infrastructure.storage.silver_writer.write_deltalake"
             ) as mock_write,
         ):
-            writer = SilverWriter(
-                base_path="/tmp/silver", logger=noop_logger
-            )
+            writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
 
             # Should not raise PolicyViolationError
             await writer.write_silver(
@@ -1298,9 +1206,7 @@ class TestSilverWriterWriteModePolicy:
                 "bioetl.infrastructure.storage.silver_writer.write_deltalake"
             ) as mock_write,
         ):
-            writer = SilverWriter(
-                base_path="/tmp/silver", logger=noop_logger
-            )
+            writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
 
             # Should not raise PolicyViolationError
             await writer.write_silver(
@@ -1340,7 +1246,6 @@ class TestSilverWriterWriteModePolicy:
             base_path="/tmp/silver",
             logger=noop_logger,
             metrics=mock_metrics,
-
         )
 
         with pytest.raises(PolicyViolationError):

--- a/tests/unit/infrastructure/storage/test_silver_writer_validation.py
+++ b/tests/unit/infrastructure/storage/test_silver_writer_validation.py
@@ -67,9 +67,7 @@ class TestSilverWriterSilverValidatorInit:
         """Test SilverWriter creates NoOpSilverValidator when not provided."""
         from bioetl.infrastructure.storage.silver_writer import SilverWriter
 
-        writer = SilverWriter(
-            base_path="/tmp/silver", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
         assert isinstance(writer._silver_validator, NoOpSilverValidator)
 
     def test_init_with_custom_validator(self, noop_logger):
@@ -81,7 +79,6 @@ class TestSilverWriterSilverValidatorInit:
             base_path="/tmp/silver",
             logger=noop_logger,
             silver_validator=custom_validator,
-
         )
         assert writer._silver_validator is custom_validator
 
@@ -102,7 +99,6 @@ class TestSilverWriterSilverValidatorInit:
             base_path="/tmp/silver",
             logger=noop_logger,
             silver_validator=validator,
-
         )
         assert writer._silver_validator is validator
 
@@ -119,7 +115,6 @@ class TestSilverWriterValidateSilverPandera:
             base_path="/tmp/silver",
             logger=noop_logger,
             silver_validator=NoOpSilverValidator(),
-
         )
         records = [{"entity_id": "CHEMBL123", "value": 5.5}]
         # Should not raise
@@ -142,7 +137,6 @@ class TestSilverWriterValidateSilverPandera:
             base_path="/tmp/silver",
             logger=noop_logger,
             silver_validator=validator,
-
         )
         records = [{"entity_id": "CHEMBL123", "value": 5.5}]
         # Should not raise
@@ -169,7 +163,6 @@ class TestSilverWriterValidateSilverPandera:
             base_path="/tmp/silver",
             logger=noop_logger,
             silver_validator=validator,
-
         )
         records = [{"entity_id": "CHEMBL123", "value": -5.5}]  # Negative value fails
 
@@ -201,7 +194,6 @@ class TestSilverWriterValidateSilverPandera:
             base_path="/tmp/silver",
             logger=mock_logger,
             silver_validator=validator,
-
         )
         records = [{"entity_id": "CHEMBL123", "value": -5.5}]
 
@@ -236,7 +228,6 @@ class TestSilverWriterValidateSilverPandera:
             logger=NoOpLogger(),
             silver_validator=validator,
             metrics=mock_metrics,
-
         )
         records = [{"entity_id": "CHEMBL123", "value": -5.5}]
 
@@ -291,7 +282,6 @@ class TestSilverWriterWriteSilverWithPanderaValidation:
             base_path="/tmp/silver",
             logger=noop_logger,
             silver_validator=validator,
-
         )
 
         with pytest.raises(SchemaViolationError) as exc_info:
@@ -352,7 +342,6 @@ class TestSilverWriterWriteSilverWithPanderaValidation:
                 base_path="/tmp/silver",
                 logger=noop_logger,
                 silver_validator=validator,
-
             )
 
             # Should not raise
@@ -401,7 +390,6 @@ class TestSilverWriterWriteSilverWithPanderaValidation:
             writer = SilverWriter(
                 base_path="/tmp/silver",
                 logger=noop_logger,
-
             )
 
             # Should not raise

--- a/tests/unit/infrastructure/storage/test_storage_exceptions.py
+++ b/tests/unit/infrastructure/storage/test_storage_exceptions.py
@@ -53,9 +53,7 @@ class TestSilverWriterExceptions:
             TableNotFoundError("Not found"),  # Schema check
             SchemaMismatchError("Invalid schema"),  # Write attempt
         ]
-        writer = SilverWriter(
-            base_path="/fake/path", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="/fake/path", logger=noop_logger)
 
         import pyarrow as pa
 
@@ -92,9 +90,7 @@ class TestSilverWriterExceptions:
             mock_table_instance,  # Write attempt
         ]
 
-        writer = SilverWriter(
-            base_path="/fake/path", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="/fake/path", logger=noop_logger)
 
         import pyarrow as pa
 
@@ -123,9 +119,7 @@ class TestSilverWriterExceptions:
     ):
         """Test SchemaViolationError on table creation."""
         mock_write_deltalake.side_effect = ArrowTypeError("Arrow type error")
-        writer = SilverWriter(
-            base_path="/fake/path", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="/fake/path", logger=noop_logger)
 
         import pyarrow as pa
 
@@ -150,9 +144,7 @@ class TestSilverWriterExceptions:
             "bioetl.infrastructure.storage.retention_manager.DeltaTable",
             side_effect=TableNotFoundError,
         ):
-            writer = SilverWriter(
-                base_path="/fake/path", logger=noop_logger
-            )
+            writer = SilverWriter(base_path="/fake/path", logger=noop_logger)
 
             with pytest.raises(CustomTableNotFoundError):
                 await writer.vacuum("test.table")

--- a/tests/unit/infrastructure/test_storage.py
+++ b/tests/unit/infrastructure/test_storage.py
@@ -55,7 +55,6 @@ class TestBronzeWriter:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
         assert writer.base_path == tmp_path
 
@@ -65,7 +64,6 @@ class TestBronzeWriter:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         records = [b'{"id": 1, "data": "test"}\n']
@@ -92,7 +90,6 @@ class TestBronzeWriter:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         records = [b'{"id": 1}\n']
@@ -124,7 +121,6 @@ class TestBronzeWriter:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         records = [b'{"id": 1, "data": "test"}\n']
@@ -162,7 +158,6 @@ class TestBronzeWriter:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         records = []
@@ -190,7 +185,6 @@ class TestBronzeWriter:
             logger=noop_logger,
             metrics=NoOpMetrics(),
             save_json=True,
-
         )
 
         records = [b'{"id": 1}\n']
@@ -241,7 +235,6 @@ class TestBronzeWriter:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         # Read it back
@@ -260,7 +253,6 @@ class TestBronzeWriter:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         # Write two batches
@@ -289,7 +281,6 @@ class TestBronzeWriter:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         batches = await writer.list_batches("nonexistent", "entity", datetime.now())
@@ -302,7 +293,6 @@ class TestBronzeWriter:
             base_path=tmp_path,
             logger=noop_logger,
             metrics=NoOpMetrics(),
-
         )
 
         records = [b'{"id": 1}\n']
@@ -338,21 +328,19 @@ class TestSilverWriter:
 
     def test_silver_writer_initialization(self, noop_logger):
         """Test SilverWriter can be initialized."""
-        writer = SilverWriter(
-            base_path="/tmp/delta", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="/tmp/delta", logger=noop_logger)
         assert writer.base_path == "/tmp/delta"
 
-    async def test_write_silver_creates_new_table(self, mock_silver_writer, noop_logger):
+    async def test_write_silver_creates_new_table(
+        self, mock_silver_writer, noop_logger
+    ):
         """Test write_silver creates table if not exists."""
         from deltalake.exceptions import TableNotFoundError
 
         mock_delta_table, mock_write_deltalake = mock_silver_writer
         mock_delta_table.side_effect = TableNotFoundError("Not found")
 
-        writer = SilverWriter(
-            base_path="/tmp/delta", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="/tmp/delta", logger=noop_logger)
 
         records = [
             {
@@ -414,9 +402,7 @@ class TestSilverWriter:
         mock_merge.when_matched_update_all.return_value = mock_merge
         mock_merge.when_not_matched_insert_all.return_value = mock_merge
 
-        writer = SilverWriter(
-            base_path="/tmp/delta", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="/tmp/delta", logger=noop_logger)
 
         records = [
             {
@@ -441,9 +427,7 @@ class TestSilverWriter:
 
     @pytest.mark.usefixtures("mock_silver_writer")
     async def test_write_silver_empty_records_raises_error(self, noop_logger):
-        writer = SilverWriter(
-            base_path="/tmp/delta", logger=noop_logger
-        )
+        writer = SilverWriter(base_path="/tmp/delta", logger=noop_logger)
 
         with pytest.raises(ValueError, match="No records to write"):
             await writer.write_silver(
@@ -477,9 +461,7 @@ class TestGoldWriter:
 
         _mock_delta_table, mock_write_deltalake = mock_gold_writer_deps
 
-        writer = GoldWriter(
-            base_path="/tmp/gold", logger=noop_logger
-        )
+        writer = GoldWriter(base_path="/tmp/gold", logger=noop_logger)
 
         # Records with mixed key order
         records = [

--- a/tests/unit/interfaces/test_run_all_command.py
+++ b/tests/unit/interfaces/test_run_all_command.py
@@ -280,9 +280,7 @@ class TestRunAllCommand:
             ],
         )
 
-        result = cli_runner.invoke(
-            cli, ["run-all", "--source", "chembl", "--dry-run"]
-        )
+        result = cli_runner.invoke(cli, ["run-all", "--source", "chembl", "--dry-run"])
 
         assert result.exit_code == 0
         assert "[DRY-RUN]" in result.output
@@ -293,7 +291,8 @@ class TestRunAllCommand:
     ):
         """Test that rebuild requires confirmation without --yes."""
         result = cli_runner.invoke(
-            cli, ["run-all", "--source", "chembl", "--run-type", "rebuild"],
+            cli,
+            ["run-all", "--source", "chembl", "--run-type", "rebuild"],
             input="n\n",  # Say no to confirmation
         )
 
@@ -340,9 +339,7 @@ class TestRunAllExitCodes:
     """Tests for run-all exit codes."""
 
     @patch("bioetl.interfaces.cli.main.register_all_pipelines")
-    def test_exit_code_0_for_list_only(
-        self, mock_register, cli_runner, mock_registry
-    ):
+    def test_exit_code_0_for_list_only(self, mock_register, cli_runner, mock_registry):
         """Test exit code 0 for successful --list-only."""
         result = cli_runner.invoke(
             cli, ["run-all", "--source", "chembl", "--list-only"]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -239,12 +239,17 @@ class TestRunCommandAdvanced:
         from bioetl.application.services import PipelineNotFoundError
 
         # PipelineNotFoundError is caught at the CLI level when asyncio.run raises it
-        mock_asyncio_run.side_effect = PipelineNotFoundError("chembl_activity", "Invalid config")
+        mock_asyncio_run.side_effect = PipelineNotFoundError(
+            "chembl_activity", "Invalid config"
+        )
 
         result = runner.invoke(cli, ["run", "--pipeline", "chembl_activity"])
 
         assert result.exit_code == ExitCode.CONFIG_ERROR
-        assert "Pipeline not found" in result.output or "not found" in result.output.lower()
+        assert (
+            "Pipeline not found" in result.output
+            or "not found" in result.output.lower()
+        )
 
     @patch("bioetl.interfaces.cli.commands.run.asyncio.run")
     def test_run_command_bootstrap_file_not_found(self, mock_asyncio_run, runner):
@@ -265,7 +270,9 @@ class TestRunCommandAdvanced:
 
     @patch("bioetl.interfaces.cli.commands.run.get_pipeline_runner_service")
     @patch("bioetl.interfaces.cli.commands.run.asyncio.run")
-    def test_run_command_bootstrap_generic_error(self, mock_asyncio_run, mock_get_service, runner):
+    def test_run_command_bootstrap_generic_error(
+        self, mock_asyncio_run, mock_get_service, runner
+    ):
         """Test run command handles generic Exception during execution."""
         mock_get_service.side_effect = RuntimeError("Unexpected error")
 


### PR DESCRIPTION
- Apply Black code formatter to 54 files for consistent formatting
- Apply isort import ordering to 8 files
- Reduce cyclomatic complexity in base_delta_writer.py:
  - Extract _serialize_value and _get_string_fields helpers
  - Extract _sort_by_primary_keys method
- Reduce cyclomatic complexity in run.py:
  - Extract _echo_run_result helper function
- Reduce cyclomatic complexity in run_all.py:
  - Extract _handle_list_only helper
  - Extract _handle_destructive_confirmation helper
  - Extract _show_run_preview helper
  - Extract _determine_exit_code helper

All functions now have CC <= 10 (Grade B or better).