### PR TITLE
Lower test coverage requirement to 80%

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -419,7 +419,7 @@ async def aclose() -> None                             # Graceful shutdown
 **Всего тестов:** ~1471+
 
 **Инструменты:** `pytest`, `pytest-asyncio`, `pytest-cov`, `hypothesis` (property-based)
-**Цель покрытия:** >85% line coverage (проверяется в CI через `--cov-fail-under=85`)
+**Цель покрытия:** >80% line coverage (проверяется в CI через `--cov-fail-under=80`)
 
 ### Тестовые Зависимости
 

--- a/Makefile
+++ b/Makefile
@@ -60,11 +60,11 @@ install-pip: ## Install dependencies using pip (fallback)
 
 test: ## Run all tests in parallel with coverage (default)
 	@echo "$(BLUE)Running tests in parallel...$(NC)"
-	$(RUN) pytest tests/ -n auto --dist loadscope --cov=src/bioetl --cov-report=term-missing --cov-fail-under=85
+	$(RUN) pytest tests/ -n auto --dist loadscope --cov=src/bioetl --cov-report=term-missing --cov-fail-under=80
 
 test-serial: ## Run all tests serially (for debugging)
 	@echo "$(BLUE)Running tests (serial mode)...$(NC)"
-	$(RUN) pytest tests/ -v --cov=src/bioetl --cov-report=term-missing --cov-report=html --cov-fail-under=85
+	$(RUN) pytest tests/ -v --cov=src/bioetl --cov-report=term-missing --cov-report=html --cov-fail-under=80
 
 test-fast: ## Run fast tests only (no slow markers, CI hypothesis profile)
 	@echo "$(BLUE)Running fast tests (parallel mode)...$(NC)"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Code Style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
-[![Coverage](https://img.shields.io/badge/coverage-%3E85%25-brightgreen)](https://github.com/SatoryKono/BioactivityDataAcquisition/actions/workflows/tests.yml)
+[![Coverage](https://img.shields.io/badge/coverage-%3E80%25-brightgreen)](https://github.com/SatoryKono/BioactivityDataAcquisition/actions/workflows/tests.yml)
 [![Version](https://img.shields.io/badge/version-5.0.5-blue)](CHANGELOG.md)
 [![Status: Active Development](https://img.shields.io/badge/Status-Active%20Development%20(55%25)-yellow)](IMPLEMENTATION_ROADMAP.md)
 [![Security Policy](https://img.shields.io/badge/Security-Policy-blue)](SECURITY.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,7 @@ exclude_lines = [
     "raise NotImplementedError",
     "@abstractmethod",
 ]
-fail_under = 85
+fail_under = 80
 show_missing = true
 precision = 2
 


### PR DESCRIPTION
Update coverage threshold in all configuration files:
- pyproject.toml: fail_under = 80
- Makefile: --cov-fail-under=80 for test and test-serial targets
- CLAUDE.md: updated documentation
- README.md: updated coverage badge