### PR TITLE
Fix failing lint and type check tests

### DIFF
--- a/tests/unit/domain/filtering/test_gold_config.py
+++ b/tests/unit/domain/filtering/test_gold_config.py
@@ -5,8 +5,6 @@ Tests the complete Gold layer filter configuration and evaluation.
 
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 
 from bioetl.domain.filtering.column_filter import GoldColumnFilter

--- a/tests/unit/domain/filtering/test_list_filters.py
+++ b/tests/unit/domain/filtering/test_list_filters.py
@@ -93,7 +93,7 @@ class TestGoldListContainsFilter:
 
     def test_empty_values_raises_error(self) -> None:
         """Test that empty values set raises ValueError."""
-        with pytest.raises(ValueError, match="values .* cannot be empty"):
+        with pytest.raises(ValueError, match=r"values .* cannot be empty"):
             GoldListContainsFilter(column="tags", values=frozenset())
 
     def test_invalid_mode_raises_error(self) -> None:

--- a/tests/unit/domain/filtering/test_load_result.py
+++ b/tests/unit/domain/filtering/test_load_result.py
@@ -46,7 +46,7 @@ class TestFilterLoadResult:
 
     def test_unique_count_mismatch_raises_error(self) -> None:
         """Test that unique_count must match len(ids)."""
-        with pytest.raises(ValueError, match="unique_count .* must match len\\(ids\\)"):
+        with pytest.raises(ValueError, match=r"unique_count .* must match len\(ids\)"):
             FilterLoadResult(
                 ids=("id1", "id2"),
                 total_count=2,
@@ -57,7 +57,7 @@ class TestFilterLoadResult:
 
     def test_duplicate_count_mismatch_raises_error(self) -> None:
         """Test that duplicate_count must equal total - unique."""
-        with pytest.raises(ValueError, match="duplicate_count .* must equal"):
+        with pytest.raises(ValueError, match=r"duplicate_count .* must equal"):
             FilterLoadResult(
                 ids=("id1", "id2"),
                 total_count=5,


### PR DESCRIPTION
- Remove unused `Any` import from test_gold_config.py
- Use raw strings for regex patterns in pytest.raises match parameters to fix RUF043 warnings