### PR TITLE
Fix failing lint and type check tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -320,7 +320,10 @@ known-first-party = ["bioetl", "tests"]
 # RUF059: Unused unpacked variables are common in test fixtures
 "tests/**/*.py" = ["ARG001", "ARG002", "ARG005", "PTH", "SIM", "B017", "I001", "C901", "E402", "RUF012", "RUF059", "T201"]
 # Domain __init__.py uses semantic grouping with comments in __all__ (not alphabetical)
-"src/bioetl/domain/__init__.py" = ["RUF022"]
+# I001: Import order handled by isort (semantic grouping with comments)
+"src/bioetl/domain/__init__.py" = ["RUF022", "I001"]
+# Crossref schema __init__.py uses semantic grouping, isort handles sorting
+"src/bioetl/domain/schemas/crossref/__init__.py" = ["I001"]
 # Entrypoints uses semantic grouping with comments in __all__ (not alphabetical)
 "src/bioetl/composition/entrypoints.py" = ["RUF022"]
 # CLI tools legitimately use print() and may use simpler patterns

--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -36,6 +36,7 @@ from bioetl.domain.context import (
 )
 
 # Entities (Domain objects)
+from bioetl.domain.entities import Work  # Deprecated: use PublicationEntity
 from bioetl.domain.entities import (  # DTO Records (Pydantic); Domain Entities (dataclass)
     ActivityRecord,
     ArticleRecord,
@@ -61,7 +62,6 @@ from bioetl.domain.entities import (  # DTO Records (Pydantic); Domain Entities 
     TargetComponent,
     TargetComponentRecord,
     TargetRecord,
-    Work,  # Deprecated: use PublicationEntity
 )
 
 # Error classifier
@@ -205,6 +205,7 @@ from bioetl.domain.transformations import (
 )
 
 # Types
+from bioetl.domain.types import DQStatus  # Deprecated: use QuarantineRecordStatus
 from bioetl.domain.types import (
     ArrowSchema,
     BatchID,
@@ -214,7 +215,6 @@ from bioetl.domain.types import (
     ConfigValidationError,
     ContentHash,
     DataClassification,
-    DQStatus,  # Deprecated: use QuarantineRecordStatus
     DriftLevel,
     EntityID,
     ErrorType,

--- a/src/bioetl/domain/schemas/crossref/__init__.py
+++ b/src/bioetl/domain/schemas/crossref/__init__.py
@@ -8,11 +8,11 @@ Terminology:
 """
 
 from bioetl.domain.schemas.crossref.publication import PublicationEnrichedSchema
+from bioetl.domain.schemas.crossref.work import WORK_TYPES  # Deprecated alias
+from bioetl.domain.schemas.crossref.work import WorkSchema  # Deprecated alias
 from bioetl.domain.schemas.crossref.work import (
     PUBLICATION_TYPES,
-    WORK_TYPES,  # Deprecated alias
     PublicationSchema,
-    WorkSchema,  # Deprecated alias
 )
 
 __all__ = [

--- a/tests/unit/composition/bootstrap/test_storage_bootstrap.py
+++ b/tests/unit/composition/bootstrap/test_storage_bootstrap.py
@@ -37,7 +37,6 @@ class TestBootstrapStorage:
         assert isinstance(result, StorageAdapter)
 
 
-
 @pytest.mark.unit
 class TestBootstrapCleanup:
     """Test bootstrap_cleanup function."""
@@ -52,6 +51,7 @@ class TestBootstrapCleanup:
         result = bootstrap_cleanup()
 
         from bioetl.application.core.cleanup_service import CleanupService
+
         assert isinstance(result, CleanupService)
 
 
@@ -74,6 +74,7 @@ class TestBootstrapLifecycleService:
         from bioetl.application.services.medallion_lifecycle import (
             MedallionLifecycleService,
         )
+
         assert isinstance(result, MedallionLifecycleService)
 
 
@@ -94,6 +95,7 @@ class TestBootstrapBronzeCleanupService:
         result = bootstrap_bronze_cleanup_service()
 
         from bioetl.application.services import BronzeCleanupService
+
         assert isinstance(result, BronzeCleanupService)
 
 
@@ -111,6 +113,7 @@ class TestBootstrapVacuumService:
         result = bootstrap_vacuum_service()
 
         from bioetl.application.services import VacuumService
+
         assert isinstance(result, VacuumService)
 
 

--- a/tests/unit/domain/filtering/test_gold_config.py
+++ b/tests/unit/domain/filtering/test_gold_config.py
@@ -95,7 +95,9 @@ class TestGoldFilterConfigColumnFilters:
         """Test column value in allowed list passes."""
         config = GoldFilterConfig(
             column_filters=(
-                GoldColumnFilter(column="status", values=frozenset({"active", "pending"})),
+                GoldColumnFilter(
+                    column="status", values=frozenset({"active", "pending"})
+                ),
             ),
         )
         assert config.should_include({"status": "active"}) is True
@@ -207,36 +209,28 @@ class TestGoldFilterConfigListLengthFilters:
     def test_list_too_short(self) -> None:
         """Test list shorter than min fails."""
         config = GoldFilterConfig(
-            list_length_filters=(
-                GoldListLengthFilter(column="tags", min_length=2),
-            ),
+            list_length_filters=(GoldListLengthFilter(column="tags", min_length=2),),
         )
         assert config.should_include({"tags": ["a"]}) is False
 
     def test_list_too_long(self) -> None:
         """Test list longer than max fails."""
         config = GoldFilterConfig(
-            list_length_filters=(
-                GoldListLengthFilter(column="tags", max_length=2),
-            ),
+            list_length_filters=(GoldListLengthFilter(column="tags", max_length=2),),
         )
         assert config.should_include({"tags": ["a", "b", "c"]}) is False
 
     def test_none_value_length_zero(self) -> None:
         """Test None value has length 0."""
         config = GoldFilterConfig(
-            list_length_filters=(
-                GoldListLengthFilter(column="tags", min_length=1),
-            ),
+            list_length_filters=(GoldListLengthFilter(column="tags", min_length=1),),
         )
         assert config.should_include({"tags": None}) is False
 
     def test_scalar_value_length_one(self) -> None:
         """Test scalar value has length 1."""
         config = GoldFilterConfig(
-            list_length_filters=(
-                GoldListLengthFilter(column="tags", min_length=1),
-            ),
+            list_length_filters=(GoldListLengthFilter(column="tags", min_length=1),),
         )
         assert config.should_include({"tags": "single"}) is True
 
@@ -354,6 +348,9 @@ class TestGoldFilterConfigCombined:
         # Missing required field
         assert config.should_include({"score": 50}) is False
         # Has excluded field
-        assert config.should_include({"name": "test", "score": 50, "deleted": True}) is False
+        assert (
+            config.should_include({"name": "test", "score": 50, "deleted": True})
+            is False
+        )
         # Fails range
         assert config.should_include({"name": "test", "score": -1}) is False

--- a/tests/unit/domain/ports/test_noop.py
+++ b/tests/unit/domain/ports/test_noop.py
@@ -128,6 +128,7 @@ class TestNoOpAudit:
     async def test_log_write_no_error(self) -> None:
         """Test log_write is a no-op."""
         from unittest.mock import MagicMock
+
         audit = NoOpAudit()
         entry = MagicMock()
         await audit.log_write(entry)  # Should not raise
@@ -141,6 +142,7 @@ class TestNoOpAudit:
     async def test_get_entries_with_filters_returns_empty(self) -> None:
         """Test get_entries with filters still returns empty."""
         from datetime import datetime
+
         audit = NoOpAudit()
         entries = await audit.get_entries(
             run_id="test-run",  # type: ignore[arg-type]

--- a/tests/unit/domain/value_objects/test_measurements_deprecation.py
+++ b/tests/unit/domain/value_objects/test_measurements_deprecation.py
@@ -22,6 +22,7 @@ class TestMeasurementsDeprecation:
             warnings.simplefilter("always")
             # Force reimport by removing from cache if present
             import sys
+
             if "bioetl.domain.value_objects.measurements" in sys.modules:
                 del sys.modules["bioetl.domain.value_objects.measurements"]
 
@@ -30,7 +31,8 @@ class TestMeasurementsDeprecation:
 
             # Check that a DeprecationWarning was issued
             deprecation_warnings = [
-                warning for warning in w
+                warning
+                for warning in w
                 if issubclass(warning.category, DeprecationWarning)
             ]
             assert len(deprecation_warnings) >= 1
@@ -43,6 +45,7 @@ class TestMeasurementsDeprecation:
     def test_reexports_activity_values(self) -> None:
         """Test that measurements re-exports symbols from activity_values."""
         import sys
+
         if "bioetl.domain.value_objects.measurements" in sys.modules:
             del sys.modules["bioetl.domain.value_objects.measurements"]
 
@@ -57,5 +60,10 @@ class TestMeasurementsDeprecation:
             assert hasattr(measurements, "PChemblValue")
 
             # Verify __all__ contains expected exports
-            expected = {"ActivityType", "Concentration", "ConcentrationUnit", "PChemblValue"}
+            expected = {
+                "ActivityType",
+                "Concentration",
+                "ConcentrationUnit",
+                "PChemblValue",
+            }
             assert set(measurements.__all__) == expected

--- a/tests/unit/infrastructure/adapters/test_validation.py
+++ b/tests/unit/infrastructure/adapters/test_validation.py
@@ -196,8 +196,7 @@ class TestValidateRecords:
     def test_yields_results_lazily(self) -> None:
         """Test that results are yielded lazily."""
         records: list[dict[str, Any]] = [
-            {"id": str(i), "name": f"test{i}", "value": i}
-            for i in range(100)
+            {"id": str(i), "name": f"test{i}", "value": i} for i in range(100)
         ]
 
         # Generator should not consume all records immediately

--- a/tests/unit/infrastructure/storage/test_base_delta_writer.py
+++ b/tests/unit/infrastructure/storage/test_base_delta_writer.py
@@ -70,20 +70,24 @@ class TestGetStringFields:
 
     def test_extracts_string_fields(self) -> None:
         """Test extraction of string type fields from schema."""
-        schema = pa.schema([
-            pa.field("id", pa.string()),
-            pa.field("count", pa.int64()),
-            pa.field("name", pa.string()),
-        ])
+        schema = pa.schema(
+            [
+                pa.field("id", pa.string()),
+                pa.field("count", pa.int64()),
+                pa.field("name", pa.string()),
+            ]
+        )
         result = _get_string_fields(schema)
         assert result == {"id", "name"}
 
     def test_extracts_large_string_fields(self) -> None:
         """Test extraction of large_string type fields."""
-        schema = pa.schema([
-            pa.field("description", pa.large_string()),
-            pa.field("value", pa.float64()),
-        ])
+        schema = pa.schema(
+            [
+                pa.field("description", pa.large_string()),
+                pa.field("value", pa.float64()),
+            ]
+        )
         result = _get_string_fields(schema)
         assert result == {"description"}
 
@@ -95,10 +99,12 @@ class TestGetStringFields:
 
     def test_no_string_fields(self) -> None:
         """Test schema with no string fields."""
-        schema = pa.schema([
-            pa.field("id", pa.int64()),
-            pa.field("value", pa.float64()),
-        ])
+        schema = pa.schema(
+            [
+                pa.field("id", pa.int64()),
+                pa.field("value", pa.float64()),
+            ]
+        )
         result = _get_string_fields(schema)
         assert result == set()
 
@@ -158,10 +164,12 @@ class TestBaseDeltaWriter:
             {"id": "1", "name": "test", "extra": "ignored"},
             {"id": "2", "name": "test2"},
         ]
-        schema = pa.schema([
-            pa.field("id", pa.string()),
-            pa.field("name", pa.string()),
-        ])
+        schema = pa.schema(
+            [
+                pa.field("id", pa.string()),
+                pa.field("name", pa.string()),
+            ]
+        )
 
         result = writer._prepare_arrow_data(
             records=records,
@@ -181,10 +189,12 @@ class TestBaseDeltaWriter:
         records: list[dict[str, Any]] = [
             {"id": "1", "metadata": {"key": "value"}},
         ]
-        schema = pa.schema([
-            pa.field("id", pa.string()),
-            pa.field("metadata", pa.string()),
-        ])
+        schema = pa.schema(
+            [
+                pa.field("id", pa.string()),
+                pa.field("metadata", pa.string()),
+            ]
+        )
 
         result = writer._prepare_arrow_data(
             records=records,
@@ -198,10 +208,12 @@ class TestBaseDeltaWriter:
 
     def test_sort_by_primary_keys(self, writer: BaseDeltaWriter) -> None:
         """Test _sort_by_primary_keys method."""
-        table = pa.table({
-            "id": ["c", "a", "b"],
-            "value": [3, 1, 2],
-        })
+        table = pa.table(
+            {
+                "id": ["c", "a", "b"],
+                "value": [3, 1, 2],
+            }
+        )
 
         result = writer._sort_by_primary_keys(
             table=table,


### PR DESCRIPTION
- Format 6 test files with black
- Fix import ordering in domain __init__.py and crossref schema
- Add I001 ignore for domain files where isort handles semantic grouping