### PR TITLE
Fix import sorting in source files

### DIFF
--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -36,6 +36,7 @@ from bioetl.domain.context import (
 )
 
 # Entities (Domain objects)
+from bioetl.domain.entities import Work  # Deprecated: use PublicationEntity
 from bioetl.domain.entities import (  # DTO Records (Pydantic); Domain Entities (dataclass)
     ActivityRecord,
     ArticleRecord,
@@ -61,7 +62,6 @@ from bioetl.domain.entities import (  # DTO Records (Pydantic); Domain Entities 
     TargetComponent,
     TargetComponentRecord,
     TargetRecord,
-    Work,  # Deprecated: use PublicationEntity
 )
 
 # Error classifier
@@ -205,6 +205,7 @@ from bioetl.domain.transformations import (
 )
 
 # Types
+from bioetl.domain.types import DQStatus  # Deprecated: use QuarantineRecordStatus
 from bioetl.domain.types import (
     ArrowSchema,
     BatchID,
@@ -214,7 +215,6 @@ from bioetl.domain.types import (
     ConfigValidationError,
     ContentHash,
     DataClassification,
-    DQStatus,  # Deprecated: use QuarantineRecordStatus
     DriftLevel,
     EntityID,
     ErrorType,

--- a/src/bioetl/domain/schemas/crossref/__init__.py
+++ b/src/bioetl/domain/schemas/crossref/__init__.py
@@ -8,11 +8,11 @@ Terminology:
 """
 
 from bioetl.domain.schemas.crossref.publication import PublicationEnrichedSchema
+from bioetl.domain.schemas.crossref.work import WORK_TYPES  # Deprecated alias
+from bioetl.domain.schemas.crossref.work import WorkSchema  # Deprecated alias
 from bioetl.domain.schemas.crossref.work import (
     PUBLICATION_TYPES,
-    WORK_TYPES,  # Deprecated alias
     PublicationSchema,
-    WorkSchema,  # Deprecated alias
 )
 
 __all__ = [


### PR DESCRIPTION
Move deprecated imports with inline comments to separate import lines to satisfy isort's formatting requirements.