### PR TITLE
Replace print examples with LoggerPort

### DIFF
--- a/src/bioetl/application/core/batch_executor.py
+++ b/src/bioetl/application/core/batch_executor.py
@@ -286,7 +286,7 @@ class BatchExecutor:
         Example:
             >>> executor = BatchExecutor(...)
             >>> result = await executor.process(records, start_index=0)
-            >>> print(f"Processed: {result.silver_count} to Silver")
+            >>> logger.info("batch_processed", silver_count=result.silver_count)
 
         """
         await self._process_batch(records, start_index)

--- a/src/bioetl/application/services/bronze_cleanup_service.py
+++ b/src/bioetl/application/services/bronze_cleanup_service.py
@@ -56,7 +56,7 @@ class BronzeCleanupService:
     Example:
         >>> service = BronzeCleanupService(storage=storage, logger=logger)
         >>> result = await service.cleanup(retention_days=90)
-        >>> print(f"Removed {result.files_removed} files")
+        >>> logger.info("cleanup_complete", files_removed=result.files_removed)
     """
 
     storage: StoragePort

--- a/src/bioetl/application/services/checkpoint_service.py
+++ b/src/bioetl/application/services/checkpoint_service.py
@@ -46,7 +46,7 @@ class CheckpointService:
         >>> service = CheckpointService(checkpoint_port=port, logger=logger)
         >>> checkpoints = await service.list_checkpoints()
         >>> for cp in checkpoints:
-        ...     print(f"{cp.pipeline_name}: {cp.metadata}")
+        ...     logger.info("checkpoint", pipeline=cp.pipeline_name, metadata=cp.metadata)
     """
 
     checkpoint_port: CheckpointPort

--- a/src/bioetl/application/services/lock_service.py
+++ b/src/bioetl/application/services/lock_service.py
@@ -50,7 +50,7 @@ class LockService:
     Example:
         >>> service = LockService(lock_port=port, logger=logger)
         >>> released = await service.release_lock("chembl_activity", run_id)
-        >>> print(f"Lock released: {released}")
+        >>> logger.info("lock_released", pipeline="chembl_activity", released=released)
     """
 
     lock_port: LockPort

--- a/src/bioetl/application/services/pipeline_runner_service.py
+++ b/src/bioetl/application/services/pipeline_runner_service.py
@@ -73,9 +73,9 @@ class RunResult:
     Example:
         >>> result = await service.run("chembl_activity")
         >>> if result.status == RunStatus.SUCCESS:
-        ...     print(f"Processed {result.records_silver} records")
+        ...     logger.info("pipeline_success", records_silver=result.records_silver)
         >>> elif result.status == RunStatus.FAILED:
-        ...     print(f"Failed: {result.error_message}")
+        ...     logger.error("pipeline_failed", error_message=result.error_message)
     """
 
     status: RunStatus
@@ -173,7 +173,7 @@ class PipelineRunnerService:
         >>> service = get_pipeline_runner_service()
         >>> options = RunOptions(run_type="incremental", limit=100)
         >>> result = await service.run("chembl_activity", options=options)
-        >>> print(f"Processed {result.records_silver} records in {result.duration_seconds}s")
+        >>> logger.info("pipeline_complete", records_silver=result.records_silver, duration_s=result.duration_seconds)
     """
 
     runner_factory: RunnerFactoryPort
@@ -216,7 +216,7 @@ class PipelineRunnerService:
         Example:
             >>> result = await service.run("chembl_activity", dry_run=True)
             >>> if result.status == RunStatus.DRY_RUN:
-            ...     print("Would process pipeline chembl_activity")
+            ...     logger.info("dry_run_complete", pipeline="chembl_activity")
         """
         started_at = datetime.now(tz=UTC)
 

--- a/src/bioetl/application/services/quarantine_service.py
+++ b/src/bioetl/application/services/quarantine_service.py
@@ -84,7 +84,7 @@ class QuarantineService:
         >>> service = QuarantineService(quarantine_port=port, logger=logger)
         >>> records = await service.inspect("chembl_activity", limit=10)
         >>> for rec in records:
-        ...     print(f"{rec.error_code}: {rec.payload}")
+        ...     logger.info("quarantine_record", error_code=rec.error_code, payload=rec.payload)
     """
 
     quarantine_port: QuarantinePort

--- a/src/bioetl/application/services/vacuum_service.py
+++ b/src/bioetl/application/services/vacuum_service.py
@@ -110,7 +110,7 @@ class VacuumService:
         ... )
         >>> tables = service.collect_tables(layer="all")
         >>> result = await service.vacuum_all(tables, retention_days=7)
-        >>> print(f"Removed {result.total_files_removed} files")
+        >>> logger.info("vacuum_complete", files_removed=result.total_files_removed)
     """
 
     lifecycle: MedallionLifecycleService

--- a/src/bioetl/composition/entrypoints.py
+++ b/src/bioetl/composition/entrypoints.py
@@ -239,11 +239,11 @@ async def run_pipeline(name: str, options: RunOptions) -> RunResult:
         >>> options = RunOptions(run_type="incremental", limit=100)
         >>> result = await run_pipeline("chembl_activity", options)
         >>> if result.status == RunStatus.SUCCESS:
-        ...     print(f"Processed {result.records_silver} records")
+        ...     logger.info("pipeline_success", records_silver=result.records_silver)
         >>> elif result.status == RunStatus.SHUTDOWN:
-        ...     print("Pipeline was gracefully shut down")
+        ...     logger.info("pipeline_shutdown", pipeline="chembl_activity")
         >>> else:
-        ...     print(f"Pipeline failed: {result.error_message}")
+        ...     logger.error("pipeline_failed", error_message=result.error_message)
     """
     from bioetl.application.core.shutdown import PipelineShutdownError
 
@@ -474,7 +474,7 @@ def get_checkpoint_service() -> CheckpointService:
         >>> service = get_checkpoint_service()
         >>> checkpoints = await service.list_checkpoints()
         >>> for cp in checkpoints:
-        ...     print(f"{cp.pipeline_name}: {cp.metadata}")
+        ...     logger.info("checkpoint", pipeline=cp.pipeline_name, metadata=cp.metadata)
     """
     _ensure_registrations()
     return bootstrap_checkpoint_service()
@@ -493,7 +493,7 @@ def get_quarantine_service() -> QuarantineService:
         >>> service = get_quarantine_service()
         >>> records = await service.inspect("chembl_activity", limit=10)
         >>> for rec in records:
-        ...     print(f"{rec.error_code}: {rec.payload}")
+        ...     logger.info("quarantine_record", error_code=rec.error_code, payload=rec.payload)
     """
     _ensure_registrations()
     return bootstrap_quarantine_service()
@@ -511,7 +511,7 @@ def get_bronze_cleanup_service() -> BronzeCleanupService:
     Example:
         >>> service = get_bronze_cleanup_service()
         >>> result = await service.cleanup(retention_days=90, dry_run=True)
-        >>> print(f"Would remove {result.files_removed} files")
+        >>> logger.info("cleanup_preview", files_to_remove=result.files_removed)
     """
     _ensure_registrations()
     return bootstrap_bronze_cleanup_service()
@@ -530,7 +530,7 @@ def get_vacuum_service() -> VacuumService:
         >>> service = get_vacuum_service()
         >>> tables = service.collect_tables(layer="all")
         >>> result = await service.vacuum_all(tables, retention_days=7)
-        >>> print(f"Removed {result.total_files_removed} files")
+        >>> logger.info("vacuum_complete", files_removed=result.total_files_removed)
     """
     _ensure_registrations()
     return bootstrap_vacuum_service()
@@ -551,7 +551,7 @@ def get_lock_service() -> LockService:
     Example:
         >>> service = get_lock_service()
         >>> released = await service.release_lock("chembl_activity", run_id)
-        >>> print(f"Lock released: {released}")
+        >>> logger.info("lock_released", pipeline="chembl_activity", released=released)
     """
     _ensure_registrations()
     return bootstrap_lock_service()
@@ -575,7 +575,7 @@ async def cleanup_bronze(
 
     Example:
         >>> result = await cleanup_bronze(retention_days=90, dry_run=True)
-        >>> print(f"Would remove {result.files_removed} files")
+        >>> logger.info("cleanup_preview", files_to_remove=result.files_removed)
     """
     service = get_bronze_cleanup_service()
     result: CleanupResult = await service.cleanup(
@@ -601,7 +601,7 @@ def get_pipeline_runner_service() -> PipelineRunnerService:
         >>> options = RunOptions(run_type="incremental", limit=100)
         >>> result = await service.run("chembl_activity", options=options)
         >>> if result.is_success:
-        ...     print(f"Processed {result.records_silver} records")
+        ...     logger.info("pipeline_success", records_silver=result.records_silver)
     """
     _ensure_registrations()
     return bootstrap_pipeline_runner_service()

--- a/src/bioetl/infrastructure/adapters/chembl/client.py
+++ b/src/bioetl/infrastructure/adapters/chembl/client.py
@@ -460,7 +460,7 @@ class ChemblAdapter(BaseHttpAdapter):
 
         Example:
             >>> async for activity in adapter.fetch_as_models("activity", limit=100):
-            ...     print(activity.activity_id, activity.pchembl_value)
+            ...     logger.debug("activity_fetched", activity_id=activity.activity_id, pchembl=activity.pchembl_value)
 
         """
         model_class = CHEMBL_DTO_MODELS.get(entity_type)

--- a/src/bioetl/infrastructure/adapters/pubchem/client.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/client.py
@@ -277,7 +277,7 @@ class PubChemAdapter(BaseSyncAdapter):
 
         Example:
             >>> async for compound in adapter.fetch_as_models("compound", query="aspirin"):
-            ...     print(compound.cid, compound.canonical_smiles)
+            ...     logger.debug("compound_fetched", cid=compound.cid, smiles=compound.canonical_smiles)
 
         """
         model_class = PUBCHEM_DTO_MODELS.get(entity_type)

--- a/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
+++ b/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
@@ -268,7 +268,7 @@ class PubMedAdapter(BaseHttpAdapter):
 
         Example:
             >>> async for article in adapter.fetch_as_models("publication", limit=10):
-            ...     print(article.pmid, article.title)
+            ...     logger.debug("article_fetched", pmid=article.pmid, title=article.title)
 
         """
         model_class = PUBMED_DTO_MODELS.get(entity_type)

--- a/tests/architecture/test_no_print_in_docstrings.py
+++ b/tests/architecture/test_no_print_in_docstrings.py
@@ -1,0 +1,138 @@
+"""Architecture test: no print() in docstring examples in non-domain layers.
+
+REQ-ARCH-034: Application, composition, interfaces, and infrastructure layers
+MUST use LoggerPort in docstring examples instead of print().
+
+Domain layer is exempt since pure function examples conventionally show
+return values with print() in Python doctests.
+
+See CLAUDE.md §11 Anti-Patterns: ❌ `print()` → `structlog` с `run_id`
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+# Layers that should use LoggerPort in docstring examples
+CHECKED_DIRS = [
+    Path("src/bioetl/application"),
+    Path("src/bioetl/composition"),
+    Path("src/bioetl/interfaces"),
+    Path("src/bioetl/infrastructure"),
+]
+
+# Pattern to detect print() calls in docstrings
+# Matches: print(, print (, but not logger.print or _print
+PRINT_PATTERN = re.compile(r"(?<![a-zA-Z_])print\s*\(")
+
+
+def _extract_docstrings(source: str) -> list[tuple[int, str]]:
+    """Extract all docstrings from Python source with line numbers.
+
+    Args:
+        source: Python source code.
+
+    Returns:
+        List of (line_number, docstring_content) tuples.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    docstrings: list[tuple[int, str]] = []
+
+    for node in ast.walk(tree):
+        # Module, class, and function docstrings
+        if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            if (
+                node.body
+                and isinstance(node.body[0], ast.Expr)
+                and isinstance(node.body[0].value, ast.Constant)
+                and isinstance(node.body[0].value.value, str)
+            ):
+                docstring = node.body[0].value.value
+                lineno = node.body[0].lineno
+                docstrings.append((lineno, docstring))
+
+    return docstrings
+
+
+def _check_print_in_docstrings(directory: Path) -> list[str]:
+    """Check for print() in docstring examples in a directory.
+
+    Args:
+        directory: Directory to scan for Python files.
+
+    Returns:
+        List of violation messages with file path and line number.
+    """
+    violations = []
+
+    if not directory.exists():
+        return violations
+
+    for py_file in directory.rglob("*.py"):
+        rel_path = py_file.relative_to(Path("src"))
+
+        try:
+            source = py_file.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+
+        for lineno, docstring in _extract_docstrings(source):
+            # Check if docstring contains Example: section with print()
+            if ">>>" in docstring and PRINT_PATTERN.search(docstring):
+                # Find which line in docstring has print
+                for i, line in enumerate(docstring.splitlines()):
+                    if PRINT_PATTERN.search(line):
+                        violations.append(
+                            f"{rel_path}:{lineno + i}: print() in docstring example"
+                        )
+
+    return violations
+
+
+class TestNoPrintInDocstrings:
+    """Test that non-domain layers use LoggerPort in docstring examples."""
+
+    @pytest.mark.parametrize(
+        "layer_dir",
+        CHECKED_DIRS,
+        ids=lambda p: p.name,
+    )
+    def test_no_print_in_docstring_examples(self, layer_dir: Path) -> None:
+        """Non-domain layers MUST use LoggerPort in docstring examples.
+
+        REQ-ARCH-034: Docstring examples should demonstrate proper
+        structured logging patterns, not print() statements.
+
+        Domain layer is exempt since pure functions conventionally
+        show return values with print() in Python doctests.
+        """
+        violations = _check_print_in_docstrings(layer_dir)
+
+        assert not violations, (
+            f"print() in docstring examples found in {layer_dir.name} layer:\n"
+            + "\n".join(f"  - {v}" for v in violations)
+            + "\n\nUse logger.info/debug/warning/error instead of print()."
+            + "\nExample: logger.info('event_name', key=value)"
+            + "\nSee CLAUDE.md §11 Anti-Patterns."
+        )
+
+
+def test_all_layers_checked() -> None:
+    """Verify all non-domain layers are included in the check.
+
+    This test ensures we don't miss adding new layers to the check.
+    """
+    expected_layers = {"application", "composition", "interfaces", "infrastructure"}
+    checked_layers = {d.name for d in CHECKED_DIRS}
+
+    assert checked_layers == expected_layers, (
+        f"Layer mismatch. Expected: {expected_layers}, Got: {checked_layers}"
+    )


### PR DESCRIPTION
Update docstring examples in application, composition, and infrastructure layers to use LoggerPort methods (logger.info/debug/error) instead of print() statements.

Changes:
- application/core/batch_executor.py: batch_processed logging
- application/services/*: structured logging for service examples
- composition/entrypoints.py: pipeline status and service logging
- infrastructure/adapters/*: activity/article/compound fetch logging
- New architecture test: test_no_print_in_docstrings.py (REQ-ARCH-034)

The new test ensures non-domain layers use LoggerPort patterns in documentation. Domain layer is exempt since pure functions conventionally show return values with print() in Python doctests.

See CLAUDE.md §11 Anti-Patterns: ❌ `print()` → `structlog` с `run_id`