### PR TITLE
Replace print statements with logger in services

### DIFF
--- a/src/bioetl/domain/services/activity_aggregator.py
+++ b/src/bioetl/domain/services/activity_aggregator.py
@@ -92,12 +92,12 @@ class ActivityAggregator:
         >>> aggregator = ActivityAggregator()
         >>> values = [95.0, 100.0, 105.0, 110.0]
         >>> result = aggregator.aggregate_values(values)
-        >>> print(result)
+        >>> result
         102.5
 
         >>> value, uncertainty = aggregator.aggregate_with_uncertainty(values)
-        >>> print(f"{value:.1f} +/- {uncertainty:.1f}")
-        102.5 +/- 5.0
+        >>> f"{value:.1f} +/- {uncertainty:.1f}"
+        '102.5 +/- 5.0'
     """
 
     config: NormalizationConfig | None = None
@@ -184,8 +184,8 @@ class ActivityAggregator:
             >>> aggregator = ActivityAggregator()
             >>> values = [95.0, 100.0, 105.0, 110.0]
             >>> value, uncertainty = aggregator.aggregate_with_uncertainty(values, "mean")
-            >>> print(f"{value:.1f} +/- {uncertainty:.1f}")
-            102.5 +/- 6.5
+            >>> f"{value:.1f} +/- {uncertainty:.1f}"
+            '102.5 +/- 6.5'
         """
         if not values:
             raise ValueError("Cannot aggregate empty sequence")
@@ -254,8 +254,8 @@ class ActivityAggregator:
             ...     Concentration(0.15, ConcentrationUnit.MICROMOLAR),
             ... ]
             >>> result = aggregator.aggregate_concentrations(concs)
-            >>> print(f"{result.value:.1f} {result.unit.value}")
-            100.0 nM
+            >>> f"{result.value:.1f} {result.unit.value}"
+            '100.0 nM'
         """
         if not concentrations:
             raise ValueError("Cannot aggregate empty sequence of concentrations")

--- a/src/bioetl/domain/services/normalization_config.py
+++ b/src/bioetl/domain/services/normalization_config.py
@@ -92,8 +92,8 @@ class NormalizationConfig:
         ...     strict_validation=True,
         ...     potency_threshold=6.0,
         ... )
-        >>> print(config.default_output_unit)
-        nM
+        >>> config.default_output_unit
+        'nM'
     """
 
     default_output_unit: str = "nM"

--- a/src/bioetl/domain/services/normalization_service.py
+++ b/src/bioetl/domain/services/normalization_service.py
@@ -66,13 +66,13 @@ class NormalizationService:
         >>> config = NormalizationConfig()
         >>> service = NormalizationService(config)
         >>> result = service.normalize_activity(100.0, "nM", "IC50")
-        >>> print(f"{result.value} {result.unit}, pChEMBL={result.pchembl}")
-        100.0 nM, pChEMBL=7.00
+        >>> f"{result.value} {result.unit}, pChEMBL={result.pchembl}"
+        '100.0 nM, pChEMBL=7.00'
 
         >>> # With validation
         >>> result = service.normalize_activity(-50.0, "nM", "IC50")
-        >>> print(result.is_valid, result.validation_message)
-        False Concentration cannot be negative: -50.0
+        >>> result.is_valid, result.validation_message
+        (False, 'Concentration cannot be negative: -50.0')
     """
 
     config: NormalizationConfig = field(default_factory=NormalizationConfig)
@@ -109,8 +109,8 @@ class NormalizationService:
         Example:
             >>> service = NormalizationService()
             >>> result = service.normalize_activity(1.0, "µM", "IC50")
-            >>> print(f"{result.value} {result.unit}")
-            1000.0 nM
+            >>> f"{result.value} {result.unit}"
+            '1000.0 nM'
         """
         # Validate first if requested
         if validate:
@@ -173,8 +173,8 @@ class NormalizationService:
         Example:
             >>> service = NormalizationService()
             >>> pchembl = service.normalize_to_pchembl(100.0, "nM")
-            >>> print(pchembl)
-            7.00
+            >>> str(pchembl)
+            '7.00'
         """
         try:
             pchembl = self.converter.value_to_pchembl(value, unit)
@@ -219,8 +219,8 @@ class NormalizationService:
             ...     "nM",
             ...     "IC50"
             ... )
-            >>> print(f"{result.value} {result.unit}")
-            100.0 nM
+            >>> f"{result.value} {result.unit}"
+            '100.0 nM'
         """
         # Normalize each value
         results = [

--- a/src/bioetl/domain/services/unit_converter.py
+++ b/src/bioetl/domain/services/unit_converter.py
@@ -27,13 +27,13 @@ class UnitConverter:
     Example:
         >>> converter = UnitConverter()
         >>> result = converter.convert(100.0, "nM", "µM")
-        >>> print(result)
+        >>> result
         0.1
 
         >>> conc = converter.to_concentration(100.0, "nM")
         >>> pchembl = converter.to_pchembl(conc)
-        >>> print(pchembl)
-        7.00
+        >>> str(pchembl)
+        '7.00'
     """
 
     def convert(
@@ -118,8 +118,8 @@ class UnitConverter:
             >>> converter = UnitConverter()
             >>> conc = Concentration(100.0, ConcentrationUnit.NANOMOLAR)
             >>> pchembl = converter.to_pchembl(conc)
-            >>> print(pchembl)
-            7.00
+            >>> str(pchembl)
+            '7.00'
         """
         return PChemblValue.from_concentration(concentration)
 
@@ -141,8 +141,8 @@ class UnitConverter:
             >>> converter = UnitConverter()
             >>> pchembl = PChemblValue(7.0)  # 100 nM
             >>> conc = converter.pchembl_to_concentration(pchembl)
-            >>> print(f"{conc.value:.1f} {conc.unit.value}")
-            100.0 nM
+            >>> f"{conc.value:.1f} {conc.unit.value}"
+            '100.0 nM'
         """
         if isinstance(target_unit, str):
             target_unit = ConcentrationUnit.from_string(target_unit)
@@ -214,8 +214,8 @@ class UnitConverter:
         Example:
             >>> converter = UnitConverter()
             >>> pchembl = converter.value_to_pchembl(100.0, "nM")
-            >>> print(pchembl)
-            7.00
+            >>> str(pchembl)
+            '7.00'
         """
         concentration = self.to_concentration(value, unit)
         return self.to_pchembl(concentration)

--- a/src/bioetl/domain/services/value_validator.py
+++ b/src/bioetl/domain/services/value_validator.py
@@ -51,12 +51,12 @@ class ValueValidator:
     Example:
         >>> validator = ValueValidator()
         >>> valid, error = validator.validate_concentration(100.0, "nM")
-        >>> print(valid)
+        >>> valid
         True
 
         >>> valid, error = validator.validate_pchembl(20.0)
-        >>> print(valid, error)
-        False pChEMBL value 20.00 exceeds maximum 14.00
+        >>> valid, error
+        (False, 'pChEMBL value 20.00 exceeds maximum 14.00')
     """
 
     config: NormalizationConfig | None = None


### PR DESCRIPTION
Remove print() calls from docstring examples, replacing them with direct expressions that return values. This follows the standard doctest format and aligns with the project's anti-pattern rule prohibiting print() usage.