### PR TITLE
Isolate benchmark tests from coverage verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,8 @@ install-pip: ## Install dependencies using pip (fallback)
 	$(VENV_PIP) install -e ".[dev,tracing]"
 	@echo "$(GREEN)Installation complete! Activate venv with: source $(VENV_BIN)/activate$(NC)"
 
-test: ## Run all tests in parallel with coverage (default)
-	@echo "$(BLUE)Running tests in parallel...$(NC)"
+test: ## Run all tests in parallel with coverage (excludes benchmarks)
+	@echo "$(BLUE)Running tests in parallel (excluding benchmarks)...$(NC)"
 	$(RUN) pytest tests/ -n auto --dist loadscope --cov=src/bioetl --cov-report=term-missing --cov-fail-under=85
 
 test-serial: ## Run all tests serially (for debugging)
@@ -257,18 +257,29 @@ complexity-report: ## Generate detailed complexity report
 	$(RUN) radon mi src/ -s >> reports/complexity.txt
 	@echo "$(GREEN)Report saved to reports/complexity.txt$(NC)"
 
-bench: ## Run performance benchmarks
-	@echo "$(BLUE)Running benchmarks...$(NC)"
+bench: ## Run all benchmark tests (standalone + assertion-based + performance)
+	@echo "$(BLUE)Running all benchmarks...$(NC)"
 	@mkdir -p reports
-	$(RUN) pytest benchmarks/ -v --tb=short
+	$(RUN) pytest benchmarks/ tests/benchmarks/ tests/performance/ -v --tb=short -m benchmark
 	@echo "$(GREEN)Benchmarks complete!$(NC)"
 
-bench-json: ## Run benchmarks with JSON output
+bench-standalone: ## Run only pytest-benchmark standalone tests
+	@echo "$(BLUE)Running standalone benchmarks...$(NC)"
+	@mkdir -p reports
+	$(RUN) pytest benchmarks/ -v --tb=short
+	@echo "$(GREEN)Standalone benchmarks complete!$(NC)"
+
+bench-json: ## Run benchmarks with JSON output (pytest-benchmark only)
 	@echo "$(BLUE)Running benchmarks with JSON output...$(NC)"
 	@mkdir -p reports
 	$(RUN) pytest benchmarks/ -v --benchmark-only --benchmark-json=reports/benchmark.json 2>/dev/null || \
 		$(RUN) pytest benchmarks/ -v --tb=short
 	@echo "$(GREEN)Benchmarks complete! Results in reports/benchmark.json$(NC)"
+
+bench-baselines: ## Run assertion-based benchmark baseline tests
+	@echo "$(BLUE)Running baseline assertion benchmarks...$(NC)"
+	$(RUN) pytest tests/benchmarks/ tests/performance/ -v --tb=short -m benchmark
+	@echo "$(GREEN)Baseline benchmarks complete!$(NC)"
 
 mutation-test: ## Run mutation testing (slow, domain layer only)
 	@echo "$(BLUE)Running mutation testing on domain layer...$(NC)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,11 +132,13 @@ python_files = ["test_*.py"]
 python_functions = ["test_*"]
 # Base options without parallelization (compatible with pytest-benchmark)
 # For parallel execution, use: pytest -n auto --dist loadscope
+# Benchmark tests are excluded by default - run with: pytest -m benchmark
 addopts = [
     "-ra",
     "-q",
     "--strict-markers",
     "--strict-config",
+    "-m", "not benchmark",
 ]
 # required_plugins check moved to CI for compatibility
 markers = [
@@ -150,6 +152,7 @@ markers = [
     "vcr: VCR.py recorded HTTP interactions",
     "performance: Performance regression tests (optional CI stage)",
     "architecture: Architecture tests (layer boundaries, contracts)",
+    "benchmark: Benchmark tests (excluded from standard runs, run with -m benchmark)",
 ]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"

--- a/tests/benchmarks/test_baseline_assertions.py
+++ b/tests/benchmarks/test_baseline_assertions.py
@@ -7,6 +7,9 @@ Unlike regular benchmarks (test_performance.py) which measure and report,
 these tests FAIL if performance degrades below baseline thresholds.
 
 Part of architecture review refactoring plan (R5).
+
+Note: These tests are marked with @pytest.mark.benchmark and excluded from
+standard test runs. Run explicitly with: make bench or pytest -m benchmark
 """
 
 from __future__ import annotations
@@ -15,6 +18,9 @@ import time
 from typing import Any
 
 import pytest
+
+# Mark all tests in this module as benchmark tests (excluded from standard runs)
+pytestmark = pytest.mark.benchmark
 
 
 class TestContentHashBaselines:

--- a/tests/benchmarks/test_performance.py
+++ b/tests/benchmarks/test_performance.py
@@ -6,6 +6,9 @@ Or with comparison: pytest tests/benchmarks/ --benchmark-compare
 Requirements:
 - pytest-benchmark must be installed
 - Benchmarks are skipped if pytest-benchmark is not available
+
+Note: These tests are marked with @pytest.mark.benchmark and excluded from
+standard test runs. Run explicitly with: make bench or pytest -m benchmark
 """
 
 from __future__ import annotations
@@ -24,10 +27,11 @@ except ImportError:
     BenchmarkFixture = Any  # type: ignore[misc, assignment]
 
 
-pytestmark = pytest.mark.skipif(
-    not HAS_BENCHMARK,
-    reason="pytest-benchmark not installed",
-)
+# Mark all tests in this module as benchmark tests (excluded from standard runs)
+pytestmark = [
+    pytest.mark.benchmark,
+    pytest.mark.skipif(not HAS_BENCHMARK, reason="pytest-benchmark not installed"),
+]
 
 
 # =============================================================================

--- a/tests/performance/test_batching_performance.py
+++ b/tests/performance/test_batching_performance.py
@@ -7,6 +7,9 @@ Requirements:
 - REQ-PERF-001: Bronze batch write 1000 records under 1s
 - REQ-PERF-002: Silver transformation 1000 records under 2s
 - REQ-PERF-003: Content hash generation 1000 records under 0.5s
+
+Note: These tests are marked with @pytest.mark.benchmark and excluded from
+standard test runs. Run explicitly with: make bench or pytest -m benchmark
 """
 
 from __future__ import annotations
@@ -120,6 +123,7 @@ def activity_schema() -> pa.Schema:
     )
 
 
+@pytest.mark.benchmark
 @pytest.mark.performance
 class TestBatchingPerformance:
     """Performance tests for batch operations."""
@@ -342,6 +346,7 @@ class TestBatchingPerformance:
         )
 
 
+@pytest.mark.benchmark
 @pytest.mark.performance
 class TestScalabilityPerformance:
     """Scalability tests for larger batch sizes."""


### PR DESCRIPTION
- Add @pytest.mark.benchmark to all benchmark/performance tests
- Configure pyproject.toml to exclude benchmarks by default (-m "not benchmark")
- Add new Makefile targets: bench, bench-standalone, bench-baselines
- Update bench target to run all benchmark types

This addresses operational risk of long-running benchmarks hindering real-time coverage verification. Benchmarks now require explicit invocation via `make bench` or `pytest -m benchmark`.

Test isolation verified: 4338 standard tests pass, 35 benchmark tests are excluded from default runs.