### PR TITLE
Add tests for run_all and vacuum commands

### DIFF
--- a/tests/integration/interfaces/test_cli_maintenance_vacuum.py
+++ b/tests/integration/interfaces/test_cli_maintenance_vacuum.py
@@ -296,3 +296,371 @@ class TestCliMaintenanceVacuumOutput:
 
         assert result.exit_code == 0
         assert "Would" in result.output or "would" in result.output
+
+
+# =============================================================================
+# vacuum-all Command Tests
+# =============================================================================
+
+
+class TestCliMaintenanceVacuumAllHelp:
+    """Test vacuum-all command help and argument handling."""
+
+    def test_maintenance_vacuum_all_help(self, cli_runner: CliRunner):
+        """Test that maintenance vacuum-all --help works."""
+        result = cli_runner.invoke(cli, ["maintenance", "vacuum-all", "--help"])
+
+        assert result.exit_code == 0
+        assert "vacuum" in result.output.lower()
+        assert "--retention-days" in result.output
+        assert "--dry-run" in result.output
+        assert "--layer" in result.output
+
+
+class TestCliMaintenanceVacuumAllExecution:
+    """Test vacuum-all command execution scenarios."""
+
+    @pytest.fixture
+    def mock_vacuum_service(self):
+        """Create a mock vacuum service."""
+        from bioetl.application.services.vacuum_service import (
+            TableVacuumResult,
+            VacuumAllResult,
+        )
+
+        service = MagicMock()
+        service.collect_tables = MagicMock(
+            return_value=[
+                ("chembl_activity", "silver"),
+                ("chembl_activity", "gold"),
+            ]
+        )
+        service.vacuum_all = AsyncMock(
+            return_value=VacuumAllResult(
+                results=(
+                    TableVacuumResult("chembl_activity", "silver", 20, None),
+                    TableVacuumResult("chembl_activity", "gold", 10, None),
+                ),
+                dry_run=False,
+            )
+        )
+        return service
+
+    def test_vacuum_all_success(
+        self,
+        cli_runner: CliRunner,
+        mock_vacuum_service: MagicMock,
+    ):
+        """Test successful vacuum-all operation."""
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_vacuum_service,
+        ):
+            result = cli_runner.invoke(cli, ["maintenance", "vacuum-all"])
+
+        assert result.exit_code == 0
+        assert "30" in result.output  # Total files removed (20 + 10)
+        mock_vacuum_service.collect_tables.assert_called_once_with("all")
+
+    def test_vacuum_all_with_layer_silver(
+        self,
+        cli_runner: CliRunner,
+        mock_vacuum_service: MagicMock,
+    ):
+        """Test vacuum-all filtering by silver layer."""
+        mock_vacuum_service.collect_tables.return_value = [
+            ("chembl_activity", "silver"),
+        ]
+
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_vacuum_service,
+        ):
+            result = cli_runner.invoke(
+                cli, ["maintenance", "vacuum-all", "--layer", "silver"]
+            )
+
+        assert result.exit_code == 0
+        mock_vacuum_service.collect_tables.assert_called_once_with("silver")
+
+    def test_vacuum_all_with_layer_gold(
+        self,
+        cli_runner: CliRunner,
+        mock_vacuum_service: MagicMock,
+    ):
+        """Test vacuum-all filtering by gold layer."""
+        mock_vacuum_service.collect_tables.return_value = [
+            ("chembl_activity", "gold"),
+        ]
+
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_vacuum_service,
+        ):
+            result = cli_runner.invoke(
+                cli, ["maintenance", "vacuum-all", "--layer", "gold"]
+            )
+
+        assert result.exit_code == 0
+        mock_vacuum_service.collect_tables.assert_called_once_with("gold")
+
+    def test_vacuum_all_with_custom_retention(
+        self,
+        cli_runner: CliRunner,
+        mock_vacuum_service: MagicMock,
+    ):
+        """Test vacuum-all with custom retention days."""
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_vacuum_service,
+        ):
+            result = cli_runner.invoke(
+                cli, ["maintenance", "vacuum-all", "--retention-days", "30"]
+            )
+
+        assert result.exit_code == 0
+        call_args = mock_vacuum_service.vacuum_all.call_args
+        assert call_args[1]["retention_days"] == 30
+
+
+class TestCliMaintenanceVacuumAllDryRun:
+    """Test vacuum-all command dry-run mode."""
+
+    @pytest.fixture
+    def mock_vacuum_service_dry_run(self):
+        """Create a mock vacuum service for dry-run."""
+        from bioetl.application.services.vacuum_service import (
+            TableVacuumResult,
+            VacuumAllResult,
+        )
+
+        service = MagicMock()
+        service.collect_tables = MagicMock(
+            return_value=[
+                ("chembl_activity", "silver"),
+            ]
+        )
+        service.vacuum_all = AsyncMock(
+            return_value=VacuumAllResult(
+                results=(TableVacuumResult("chembl_activity", "silver", 15, None),),
+                dry_run=True,
+            )
+        )
+        return service
+
+    def test_vacuum_all_dry_run_shows_preview(
+        self,
+        cli_runner: CliRunner,
+        mock_vacuum_service_dry_run: MagicMock,
+    ):
+        """Test that --dry-run shows what would be removed."""
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_vacuum_service_dry_run,
+        ):
+            result = cli_runner.invoke(
+                cli, ["maintenance", "vacuum-all", "--dry-run"]
+            )
+
+        assert result.exit_code == 0
+        assert "[DRY-RUN]" in result.output or "Would" in result.output
+
+    def test_vacuum_all_dry_run_passes_flag_to_service(
+        self,
+        cli_runner: CliRunner,
+        mock_vacuum_service_dry_run: MagicMock,
+    ):
+        """Test that dry_run flag is passed to vacuum service."""
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_vacuum_service_dry_run,
+        ):
+            result = cli_runner.invoke(
+                cli, ["maintenance", "vacuum-all", "--dry-run"]
+            )
+
+        assert result.exit_code == 0
+        call_args = mock_vacuum_service_dry_run.vacuum_all.call_args
+        assert call_args[1]["dry_run"] is True
+
+
+class TestCliMaintenanceVacuumAllNoTables:
+    """Test vacuum-all when no tables are found."""
+
+    @pytest.fixture
+    def mock_vacuum_service_empty(self):
+        """Create a mock vacuum service with no tables."""
+        service = MagicMock()
+        service.collect_tables = MagicMock(return_value=[])
+        return service
+
+    def test_vacuum_all_no_tables_found(
+        self,
+        cli_runner: CliRunner,
+        mock_vacuum_service_empty: MagicMock,
+    ):
+        """Test vacuum-all when no tables to vacuum."""
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_vacuum_service_empty,
+        ):
+            result = cli_runner.invoke(cli, ["maintenance", "vacuum-all"])
+
+        assert result.exit_code == 0
+        assert "No tables found" in result.output
+
+
+class TestCliMaintenanceVacuumAllErrors:
+    """Test vacuum-all command error handling."""
+
+    @pytest.fixture
+    def mock_vacuum_service_partial_failure(self):
+        """Create a mock vacuum service with partial failures."""
+        from bioetl.application.services.vacuum_service import (
+            TableVacuumResult,
+            VacuumAllResult,
+        )
+
+        service = MagicMock()
+        service.collect_tables = MagicMock(
+            return_value=[
+                ("table1", "silver"),
+                ("table2", "gold"),
+            ]
+        )
+        service.vacuum_all = AsyncMock(
+            return_value=VacuumAllResult(
+                results=(
+                    TableVacuumResult("table1", "silver", 10, None),
+                    TableVacuumResult("table2", "gold", 0, "Delta table corrupted"),
+                ),
+                dry_run=False,
+            )
+        )
+        return service
+
+    def test_vacuum_all_partial_failure_shows_errors(
+        self,
+        cli_runner: CliRunner,
+        mock_vacuum_service_partial_failure: MagicMock,
+    ):
+        """Test that partial failures show error messages."""
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_vacuum_service_partial_failure,
+        ):
+            result = cli_runner.invoke(cli, ["maintenance", "vacuum-all"])
+
+        assert result.exit_code == 0  # Partial failure still exits 0
+        assert "Error:" in result.output
+        assert "Delta table corrupted" in result.output
+
+    def test_vacuum_all_partial_failure_shows_failed_tables(
+        self,
+        cli_runner: CliRunner,
+        mock_vacuum_service_partial_failure: MagicMock,
+    ):
+        """Test that partial failures list failed table names."""
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_vacuum_service_partial_failure,
+        ):
+            result = cli_runner.invoke(cli, ["maintenance", "vacuum-all"])
+
+        assert "Failed tables:" in result.output
+        assert "gold/table2" in result.output
+
+
+class TestCliMaintenanceVacuumAllOutput:
+    """Test vacuum-all command output formatting."""
+
+    @pytest.fixture
+    def mock_vacuum_service_multi(self):
+        """Create a mock vacuum service with multiple tables."""
+        from bioetl.application.services.vacuum_service import (
+            TableVacuumResult,
+            VacuumAllResult,
+        )
+
+        service = MagicMock()
+        service.collect_tables = MagicMock(
+            return_value=[
+                ("chembl_activity", "silver"),
+                ("chembl_activity", "gold"),
+                ("chembl_assay", "silver"),
+            ]
+        )
+        service.vacuum_all = AsyncMock(
+            return_value=VacuumAllResult(
+                results=(
+                    TableVacuumResult("chembl_activity", "silver", 10, None),
+                    TableVacuumResult("chembl_activity", "gold", 5, None),
+                    TableVacuumResult("chembl_assay", "silver", 8, None),
+                ),
+                dry_run=False,
+            )
+        )
+        return service
+
+    def test_vacuum_all_shows_each_table_result(
+        self,
+        cli_runner: CliRunner,
+        mock_vacuum_service_multi: MagicMock,
+    ):
+        """Test that output shows result for each table."""
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_vacuum_service_multi,
+        ):
+            result = cli_runner.invoke(cli, ["maintenance", "vacuum-all"])
+
+        assert "silver/chembl_activity" in result.output
+        assert "gold/chembl_activity" in result.output
+        assert "silver/chembl_assay" in result.output
+
+    def test_vacuum_all_shows_total_files(
+        self,
+        cli_runner: CliRunner,
+        mock_vacuum_service_multi: MagicMock,
+    ):
+        """Test that output shows total files removed."""
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_vacuum_service_multi,
+        ):
+            result = cli_runner.invoke(cli, ["maintenance", "vacuum-all"])
+
+        assert "Total:" in result.output
+        assert "23" in result.output  # 10 + 5 + 8
+
+    def test_vacuum_all_dry_run_shows_would_remove(
+        self,
+        cli_runner: CliRunner,
+    ):
+        """Test that dry-run output says 'would remove'."""
+        from bioetl.application.services.vacuum_service import (
+            TableVacuumResult,
+            VacuumAllResult,
+        )
+
+        mock_service = MagicMock()
+        mock_service.collect_tables = MagicMock(
+            return_value=[("chembl_activity", "silver")]
+        )
+        mock_service.vacuum_all = AsyncMock(
+            return_value=VacuumAllResult(
+                results=(TableVacuumResult("chembl_activity", "silver", 10, None),),
+                dry_run=True,
+            )
+        )
+
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_service,
+        ):
+            result = cli_runner.invoke(
+                cli, ["maintenance", "vacuum-all", "--dry-run"]
+            )
+
+        assert result.exit_code == 0
+        assert "would remove" in result.output.lower()

--- a/tests/unit/interfaces/test_run_all_service_mock.py
+++ b/tests/unit/interfaces/test_run_all_service_mock.py
@@ -1,0 +1,635 @@
+"""Unit tests for run_all CLI command with PipelineRunnerService mocking.
+
+Tests the run-all command with mocked PipelineRunnerService for:
+- Positive scenarios (successful pipeline execution)
+- Negative scenarios (service errors, failures)
+- Dry-run mode
+- CLI formatter output verification
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from bioetl.application.services import (
+    PipelineNotFoundError,
+    RunOptions,
+    RunResult,
+    RunStatus,
+)
+from bioetl.interfaces.cli.commands.run_all import (
+    BatchRunResult,
+    _run_all_pipelines_async,
+)
+from bioetl.interfaces.cli.exit_codes import ExitCode
+from bioetl.interfaces.cli.main import cli
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    """Create Click's CliRunner for testing CLI commands."""
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_registry():
+    """Mock default registry with test pipelines."""
+    mock = MagicMock()
+    mock.list_pipelines.return_value = [
+        "chembl_activity",
+        "chembl_assay",
+        "pubchem_compound",
+    ]
+    return mock
+
+
+@pytest.fixture
+def mock_pipeline_runner_service():
+    """Create a mock PipelineRunnerService."""
+    service = MagicMock()
+    service.run = AsyncMock()
+    service.list_pipelines = MagicMock(return_value=["chembl_activity", "chembl_assay"])
+    service.validate_pipeline = MagicMock(return_value=True)
+    return service
+
+
+def _create_run_result(
+    pipeline_name: str,
+    status: RunStatus = RunStatus.SUCCESS,
+    run_type: str = "incremental",
+    error_message: str | None = None,
+) -> RunResult:
+    """Helper to create RunResult objects for tests."""
+    return RunResult(
+        status=status,
+        pipeline_name=pipeline_name,
+        run_id="test-run-id",
+        run_type=run_type,
+        records_fetched=100,
+        records_bronze=95,
+        records_silver=90,
+        records_gold=85,
+        records_quarantined=5,
+        started_at=datetime.now(tz=UTC),
+        completed_at=datetime.now(tz=UTC),
+        error_message=error_message,
+    )
+
+
+# =============================================================================
+# PipelineRunnerService Mock Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestRunAllWithMockedService:
+    """Tests for run-all using mocked PipelineRunnerService."""
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_default_registry")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service")
+    def test_run_all_calls_service_for_each_pipeline(
+        self,
+        mock_get_service,
+        mock_get_registry,
+        mock_register,
+        cli_runner,
+        mock_registry,
+        mock_pipeline_runner_service,
+    ):
+        """Test that PipelineRunnerService.run is called for each pipeline."""
+        mock_get_registry.return_value = mock_registry
+        mock_get_service.return_value = mock_pipeline_runner_service
+
+        # Setup successful results for each pipeline
+        mock_pipeline_runner_service.run.side_effect = [
+            _create_run_result("chembl_activity"),
+            _create_run_result("chembl_assay"),
+        ]
+
+        result = cli_runner.invoke(cli, ["run-all", "--source", "chembl"])
+
+        assert result.exit_code == 0
+        assert mock_pipeline_runner_service.run.call_count == 2
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_default_registry")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service")
+    def test_run_all_passes_correct_options(
+        self,
+        mock_get_service,
+        mock_get_registry,
+        mock_register,
+        cli_runner,
+        mock_registry,
+        mock_pipeline_runner_service,
+    ):
+        """Test that RunOptions are correctly passed to service."""
+        mock_get_registry.return_value = mock_registry
+        mock_get_service.return_value = mock_pipeline_runner_service
+        mock_pipeline_runner_service.run.return_value = _create_run_result(
+            "chembl_activity"
+        )
+
+        # Filter registry to single pipeline for easier assertion
+        mock_registry.list_pipelines.return_value = ["chembl_activity"]
+
+        # Backfill requires confirmation with --yes
+        result = cli_runner.invoke(
+            cli,
+            [
+                "run-all",
+                "--source",
+                "chembl",
+                "--run-type",
+                "backfill",
+                "--limit",
+                "50",
+                "--yes",  # Skip confirmation prompt
+            ],
+        )
+
+        assert result.exit_code == 0
+        call_args = mock_pipeline_runner_service.run.call_args
+        options = call_args[1]["options"]
+        assert isinstance(options, RunOptions)
+        assert options.run_type == "backfill"
+        assert options.limit == 50
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_default_registry")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service")
+    def test_run_all_handles_service_failure(
+        self,
+        mock_get_service,
+        mock_get_registry,
+        mock_register,
+        cli_runner,
+        mock_registry,
+        mock_pipeline_runner_service,
+    ):
+        """Test handling when PipelineRunnerService.run fails with exception."""
+        mock_get_registry.return_value = mock_registry
+        mock_get_service.return_value = mock_pipeline_runner_service
+        mock_registry.list_pipelines.return_value = ["chembl_activity"]
+
+        mock_pipeline_runner_service.run.side_effect = RuntimeError("Service failure")
+
+        result = cli_runner.invoke(cli, ["run-all", "--source", "chembl"])
+
+        assert result.exit_code == ExitCode.PIPELINE_ERROR
+        assert "unexpected error" in result.output.lower()
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_default_registry")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service")
+    def test_run_all_handles_pipeline_not_found(
+        self,
+        mock_get_service,
+        mock_get_registry,
+        mock_register,
+        cli_runner,
+        mock_registry,
+        mock_pipeline_runner_service,
+    ):
+        """Test handling PipelineNotFoundError from service."""
+        mock_get_registry.return_value = mock_registry
+        mock_get_service.return_value = mock_pipeline_runner_service
+        mock_registry.list_pipelines.return_value = ["chembl_activity"]
+
+        mock_pipeline_runner_service.run.side_effect = PipelineNotFoundError(
+            "chembl_activity", ["other_pipeline"]
+        )
+
+        result = cli_runner.invoke(cli, ["run-all", "--source", "chembl"])
+
+        assert result.exit_code == ExitCode.PIPELINE_ERROR
+        assert "not found" in result.output.lower()
+
+
+# =============================================================================
+# Dry-Run Mode Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestRunAllDryRunMode:
+    """Tests for run-all dry-run mode with PipelineRunnerService."""
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_default_registry")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service")
+    def test_dry_run_passes_flag_to_service(
+        self,
+        mock_get_service,
+        mock_get_registry,
+        mock_register,
+        cli_runner,
+        mock_registry,
+        mock_pipeline_runner_service,
+    ):
+        """Test that --dry-run flag is passed to service options."""
+        mock_get_registry.return_value = mock_registry
+        mock_get_service.return_value = mock_pipeline_runner_service
+        mock_registry.list_pipelines.return_value = ["chembl_activity"]
+
+        mock_pipeline_runner_service.run.return_value = _create_run_result(
+            "chembl_activity", status=RunStatus.DRY_RUN
+        )
+
+        result = cli_runner.invoke(cli, ["run-all", "--source", "chembl", "--dry-run"])
+
+        assert result.exit_code == 0
+        call_args = mock_pipeline_runner_service.run.call_args
+        options = call_args[1]["options"]
+        assert options.dry_run is True
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_default_registry")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service")
+    def test_dry_run_shows_dry_run_prefix_in_output(
+        self,
+        mock_get_service,
+        mock_get_registry,
+        mock_register,
+        cli_runner,
+        mock_registry,
+        mock_pipeline_runner_service,
+    ):
+        """Test that dry-run output contains [DRY-RUN] prefix."""
+        mock_get_registry.return_value = mock_registry
+        mock_get_service.return_value = mock_pipeline_runner_service
+        mock_registry.list_pipelines.return_value = ["chembl_activity"]
+
+        mock_pipeline_runner_service.run.return_value = _create_run_result(
+            "chembl_activity", status=RunStatus.DRY_RUN
+        )
+
+        result = cli_runner.invoke(cli, ["run-all", "--source", "chembl", "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "[DRY-RUN]" in result.output
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_default_registry")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service")
+    def test_dry_run_reports_skipped_count(
+        self,
+        mock_get_service,
+        mock_get_registry,
+        mock_register,
+        cli_runner,
+        mock_registry,
+        mock_pipeline_runner_service,
+    ):
+        """Test that dry-run summary shows correct preview count."""
+        mock_get_registry.return_value = mock_registry
+        mock_get_service.return_value = mock_pipeline_runner_service
+        mock_registry.list_pipelines.return_value = [
+            "chembl_activity",
+            "chembl_assay",
+        ]
+
+        mock_pipeline_runner_service.run.side_effect = [
+            _create_run_result("chembl_activity", status=RunStatus.DRY_RUN),
+            _create_run_result("chembl_assay", status=RunStatus.DRY_RUN),
+        ]
+
+        result = cli_runner.invoke(cli, ["run-all", "--source", "chembl", "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "2 pipelines previewed" in result.output
+
+
+# =============================================================================
+# CLI Formatter Output Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestRunAllFormatterOutput:
+    """Tests for run-all CLI output formatting."""
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_default_registry")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service")
+    def test_success_output_contains_checkmark(
+        self,
+        mock_get_service,
+        mock_get_registry,
+        mock_register,
+        cli_runner,
+        mock_registry,
+        mock_pipeline_runner_service,
+    ):
+        """Test successful run shows checkmark in output."""
+        mock_get_registry.return_value = mock_registry
+        mock_get_service.return_value = mock_pipeline_runner_service
+        mock_registry.list_pipelines.return_value = ["chembl_activity"]
+
+        mock_pipeline_runner_service.run.return_value = _create_run_result(
+            "chembl_activity"
+        )
+
+        result = cli_runner.invoke(cli, ["run-all", "--source", "chembl"])
+
+        assert "✓" in result.output
+        assert "completed successfully" in result.output
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_default_registry")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service")
+    def test_failure_output_contains_x_mark(
+        self,
+        mock_get_service,
+        mock_get_registry,
+        mock_register,
+        cli_runner,
+        mock_registry,
+        mock_pipeline_runner_service,
+    ):
+        """Test failed run shows X mark in output."""
+        mock_get_registry.return_value = mock_registry
+        mock_get_service.return_value = mock_pipeline_runner_service
+        mock_registry.list_pipelines.return_value = ["chembl_activity"]
+
+        mock_pipeline_runner_service.run.return_value = _create_run_result(
+            "chembl_activity",
+            status=RunStatus.FAILED,
+            error_message="Connection timeout",
+        )
+
+        result = cli_runner.invoke(cli, ["run-all", "--source", "chembl"])
+
+        assert "✗" in result.output
+        assert "failed" in result.output.lower()
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_default_registry")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service")
+    def test_summary_shows_succeeded_count(
+        self,
+        mock_get_service,
+        mock_get_registry,
+        mock_register,
+        cli_runner,
+        mock_registry,
+        mock_pipeline_runner_service,
+    ):
+        """Test summary output shows correct succeeded count."""
+        mock_get_registry.return_value = mock_registry
+        mock_get_service.return_value = mock_pipeline_runner_service
+        mock_registry.list_pipelines.return_value = [
+            "chembl_activity",
+            "chembl_assay",
+        ]
+
+        mock_pipeline_runner_service.run.side_effect = [
+            _create_run_result("chembl_activity"),
+            _create_run_result("chembl_assay"),
+        ]
+
+        result = cli_runner.invoke(cli, ["run-all", "--source", "chembl"])
+
+        assert "Succeeded: 2" in result.output
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_default_registry")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service")
+    def test_summary_shows_failed_count(
+        self,
+        mock_get_service,
+        mock_get_registry,
+        mock_register,
+        cli_runner,
+        mock_registry,
+        mock_pipeline_runner_service,
+    ):
+        """Test summary output shows failed count when failures occur."""
+        mock_get_registry.return_value = mock_registry
+        mock_get_service.return_value = mock_pipeline_runner_service
+        mock_registry.list_pipelines.return_value = [
+            "chembl_activity",
+            "chembl_assay",
+        ]
+
+        mock_pipeline_runner_service.run.side_effect = [
+            _create_run_result("chembl_activity"),
+            _create_run_result("chembl_assay", status=RunStatus.FAILED),
+        ]
+
+        result = cli_runner.invoke(cli, ["run-all", "--source", "chembl"])
+
+        assert "Failed: 1" in result.output
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_default_registry")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service")
+    def test_summary_shows_failed_pipeline_names(
+        self,
+        mock_get_service,
+        mock_get_registry,
+        mock_register,
+        cli_runner,
+        mock_registry,
+        mock_pipeline_runner_service,
+    ):
+        """Test summary lists names of failed pipelines."""
+        mock_get_registry.return_value = mock_registry
+        mock_get_service.return_value = mock_pipeline_runner_service
+        mock_registry.list_pipelines.return_value = [
+            "chembl_activity",
+            "chembl_assay",
+        ]
+
+        mock_pipeline_runner_service.run.side_effect = [
+            _create_run_result("chembl_activity"),
+            _create_run_result("chembl_assay", status=RunStatus.FAILED),
+        ]
+
+        result = cli_runner.invoke(cli, ["run-all", "--source", "chembl"])
+
+        assert "chembl_assay" in result.output
+
+
+# =============================================================================
+# Shutdown Scenario Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestRunAllShutdownScenarios:
+    """Tests for run-all shutdown handling."""
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_default_registry")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service")
+    def test_shutdown_stops_remaining_pipelines(
+        self,
+        mock_get_service,
+        mock_get_registry,
+        mock_register,
+        cli_runner,
+        mock_registry,
+        mock_pipeline_runner_service,
+    ):
+        """Test that shutdown status stops processing remaining pipelines."""
+        mock_get_registry.return_value = mock_registry
+        mock_get_service.return_value = mock_pipeline_runner_service
+        mock_registry.list_pipelines.return_value = [
+            "chembl_activity",
+            "chembl_assay",
+            "chembl_molecule",
+        ]
+
+        # First succeeds, second gets shutdown, third should not run
+        mock_pipeline_runner_service.run.side_effect = [
+            _create_run_result("chembl_activity"),
+            _create_run_result("chembl_assay", status=RunStatus.SHUTDOWN),
+            _create_run_result("chembl_molecule"),  # Should not be called
+        ]
+
+        result = cli_runner.invoke(cli, ["run-all", "--source", "chembl"])
+
+        # Only 2 calls should have been made (third pipeline skipped)
+        assert mock_pipeline_runner_service.run.call_count == 2
+        assert "gracefully shut down" in result.output.lower()
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_default_registry")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service")
+    def test_shutdown_shows_warning_symbol(
+        self,
+        mock_get_service,
+        mock_get_registry,
+        mock_register,
+        cli_runner,
+        mock_registry,
+        mock_pipeline_runner_service,
+    ):
+        """Test shutdown status shows proper warning symbol."""
+        mock_get_registry.return_value = mock_registry
+        mock_get_service.return_value = mock_pipeline_runner_service
+        mock_registry.list_pipelines.return_value = ["chembl_activity"]
+
+        mock_pipeline_runner_service.run.return_value = _create_run_result(
+            "chembl_activity", status=RunStatus.SHUTDOWN
+        )
+
+        result = cli_runner.invoke(cli, ["run-all", "--source", "chembl"])
+
+        assert "⊘" in result.output
+        assert "WARNING:" in result.output
+
+    @patch("bioetl.interfaces.cli.main.register_all_pipelines")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_default_registry")
+    @patch("bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service")
+    def test_shutdown_exit_code_with_no_failures(
+        self,
+        mock_get_service,
+        mock_get_registry,
+        mock_register,
+        cli_runner,
+        mock_registry,
+        mock_pipeline_runner_service,
+    ):
+        """Test shutdown without failures returns OK exit code.
+
+        Note: Current logic considers no failures as success, even if
+        all pipelines were shutdown. This is intentional - SIGINT is only
+        returned when succeeded=0 and skipped>0.
+        """
+        mock_get_registry.return_value = mock_registry
+        mock_get_service.return_value = mock_pipeline_runner_service
+        mock_registry.list_pipelines.return_value = ["chembl_activity"]
+
+        mock_pipeline_runner_service.run.return_value = _create_run_result(
+            "chembl_activity", status=RunStatus.SHUTDOWN
+        )
+
+        result = cli_runner.invoke(cli, ["run-all", "--source", "chembl"])
+
+        # No failures means OK (all_succeeded returns True when failed=0)
+        assert result.exit_code == ExitCode.OK
+
+
+# =============================================================================
+# Async Function Direct Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestRunAllAsyncFunction:
+    """Direct tests for _run_all_pipelines_async function."""
+
+    async def test_run_all_pipelines_async_success(self):
+        """Test _run_all_pipelines_async with all successful runs."""
+        mock_service = MagicMock()
+        mock_service.run = AsyncMock(
+            side_effect=[
+                _create_run_result("pipeline1"),
+                _create_run_result("pipeline2"),
+            ]
+        )
+
+        with patch(
+            "bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service",
+            return_value=mock_service,
+        ):
+            result = await _run_all_pipelines_async(
+                pipelines=["pipeline1", "pipeline2"],
+                options=RunOptions(),
+            )
+
+        assert result.total == 2
+        assert result.succeeded == 2
+        assert result.failed == 0
+        assert result.all_succeeded is True
+
+    async def test_run_all_pipelines_async_partial_failure(self):
+        """Test _run_all_pipelines_async with some failures."""
+        mock_service = MagicMock()
+        mock_service.run = AsyncMock(
+            side_effect=[
+                _create_run_result("pipeline1"),
+                _create_run_result("pipeline2", status=RunStatus.FAILED),
+            ]
+        )
+
+        with patch(
+            "bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service",
+            return_value=mock_service,
+        ):
+            result = await _run_all_pipelines_async(
+                pipelines=["pipeline1", "pipeline2"],
+                options=RunOptions(),
+            )
+
+        assert result.succeeded == 1
+        assert result.failed == 1
+        assert result.failed_pipelines == ["pipeline2"]
+        assert result.all_succeeded is False
+
+    async def test_run_all_pipelines_async_handles_exception(self):
+        """Test _run_all_pipelines_async handles runtime exceptions."""
+        mock_service = MagicMock()
+        mock_service.run = AsyncMock(
+            side_effect=RuntimeError("Unexpected error")
+        )
+
+        with patch(
+            "bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service",
+            return_value=mock_service,
+        ):
+            result = await _run_all_pipelines_async(
+                pipelines=["pipeline1"],
+                options=RunOptions(),
+            )
+
+        assert result.failed == 1
+        assert result.failed_pipelines == ["pipeline1"]

--- a/tests/unit/interfaces/test_vacuum_commands.py
+++ b/tests/unit/interfaces/test_vacuum_commands.py
@@ -1,0 +1,574 @@
+"""Unit tests for vacuum CLI commands with VacuumService mocking.
+
+Tests the vacuum and vacuum-all commands with mocked VacuumService for:
+- Positive scenarios (successful vacuum operations)
+- Negative scenarios (service errors, failures)
+- Dry-run mode
+- CLI formatter output verification (echo_vacuum_result, echo_vacuum_all_summary)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from bioetl.application.services.vacuum_service import (
+    TableVacuumResult,
+    VacuumAllResult,
+)
+from bioetl.interfaces.cli.main import cli
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    """Create Click's CliRunner for testing CLI commands."""
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_vacuum_service():
+    """Create a mock VacuumService."""
+    service = MagicMock()
+    service.collect_tables = MagicMock()
+    service.vacuum_all = AsyncMock()
+    service.vacuum_table = AsyncMock()
+    return service
+
+
+@pytest.fixture
+def mock_lifecycle_service():
+    """Create a mock MedallionLifecycleService."""
+    service = MagicMock()
+    service.vacuum = AsyncMock(return_value=10)
+    return service
+
+
+def _create_table_result(
+    table_name: str,
+    layer: str = "silver",
+    files_removed: int = 5,
+    error: str | None = None,
+) -> TableVacuumResult:
+    """Helper to create TableVacuumResult objects."""
+    return TableVacuumResult(
+        table_name=table_name,
+        layer=layer,
+        files_removed=files_removed,
+        error=error,
+    )
+
+
+def _create_vacuum_all_result(
+    results: list[TableVacuumResult],
+    dry_run: bool = False,
+) -> VacuumAllResult:
+    """Helper to create VacuumAllResult objects."""
+    return VacuumAllResult(
+        results=tuple(results),
+        dry_run=dry_run,
+    )
+
+
+# =============================================================================
+# vacuum Command Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestVacuumCommand:
+    """Tests for the vacuum command."""
+
+    def test_vacuum_help(self, cli_runner):
+        """Test vacuum --help shows correct options."""
+        result = cli_runner.invoke(cli, ["maintenance", "vacuum", "--help"])
+
+        assert result.exit_code == 0
+        assert "TABLE" in result.output
+        assert "--retention-days" in result.output
+        assert "--dry-run" in result.output
+
+    def test_vacuum_success(self, cli_runner, mock_lifecycle_service):
+        """Test successful vacuum operation."""
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_lifecycle_service",
+            return_value=mock_lifecycle_service,
+        ):
+            result = cli_runner.invoke(
+                cli, ["maintenance", "vacuum", "chembl.activity"]
+            )
+
+        assert result.exit_code == 0
+        assert "10" in result.output  # files_removed
+        assert "Removed" in result.output
+        mock_lifecycle_service.vacuum.assert_called_once_with(
+            table="chembl.activity",
+            retention_days=7,
+            dry_run=False,
+        )
+
+    def test_vacuum_with_custom_retention(self, cli_runner, mock_lifecycle_service):
+        """Test vacuum with custom retention days."""
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_lifecycle_service",
+            return_value=mock_lifecycle_service,
+        ):
+            result = cli_runner.invoke(
+                cli, ["maintenance", "vacuum", "chembl.activity", "-r", "30"]
+            )
+
+        assert result.exit_code == 0
+        mock_lifecycle_service.vacuum.assert_called_once_with(
+            table="chembl.activity",
+            retention_days=30,
+            dry_run=False,
+        )
+
+    def test_vacuum_dry_run(self, cli_runner, mock_lifecycle_service):
+        """Test vacuum dry-run mode."""
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_lifecycle_service",
+            return_value=mock_lifecycle_service,
+        ):
+            result = cli_runner.invoke(
+                cli, ["maintenance", "vacuum", "chembl.activity", "--dry-run"]
+            )
+
+        assert result.exit_code == 0
+        assert "[DRY-RUN]" in result.output
+        assert "Would" in result.output
+        mock_lifecycle_service.vacuum.assert_called_once_with(
+            table="chembl.activity",
+            retention_days=7,
+            dry_run=True,
+        )
+
+    def test_vacuum_error_handling(self, cli_runner, mock_lifecycle_service):
+        """Test vacuum handles service errors."""
+        mock_lifecycle_service.vacuum.side_effect = RuntimeError("Table not found")
+
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_lifecycle_service",
+            return_value=mock_lifecycle_service,
+        ):
+            result = cli_runner.invoke(
+                cli, ["maintenance", "vacuum", "nonexistent.table"]
+            )
+
+        assert result.exit_code != 0
+
+
+# =============================================================================
+# vacuum-all Command Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestVacuumAllCommand:
+    """Tests for the vacuum-all command."""
+
+    def test_vacuum_all_help(self, cli_runner):
+        """Test vacuum-all --help shows correct options."""
+        result = cli_runner.invoke(cli, ["maintenance", "vacuum-all", "--help"])
+
+        assert result.exit_code == 0
+        assert "--retention-days" in result.output
+        assert "--dry-run" in result.output
+        assert "--layer" in result.output
+
+    def test_vacuum_all_success(self, cli_runner, mock_vacuum_service):
+        """Test successful vacuum-all operation."""
+        mock_vacuum_service.collect_tables.return_value = [
+            ("chembl_activity", "silver"),
+            ("chembl_activity", "gold"),
+        ]
+        mock_vacuum_service.vacuum_all.return_value = _create_vacuum_all_result(
+            results=[
+                _create_table_result("chembl_activity", "silver", 10),
+                _create_table_result("chembl_activity", "gold", 5),
+            ]
+        )
+
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_vacuum_service,
+        ):
+            result = cli_runner.invoke(cli, ["maintenance", "vacuum-all"])
+
+        assert result.exit_code == 0
+        assert "15" in result.output  # total files removed
+        mock_vacuum_service.collect_tables.assert_called_once_with("all")
+
+    def test_vacuum_all_with_layer_filter(self, cli_runner, mock_vacuum_service):
+        """Test vacuum-all with layer filter."""
+        mock_vacuum_service.collect_tables.return_value = [
+            ("chembl_activity", "silver"),
+        ]
+        mock_vacuum_service.vacuum_all.return_value = _create_vacuum_all_result(
+            results=[_create_table_result("chembl_activity", "silver", 10)]
+        )
+
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_vacuum_service,
+        ):
+            result = cli_runner.invoke(
+                cli, ["maintenance", "vacuum-all", "--layer", "silver"]
+            )
+
+        assert result.exit_code == 0
+        mock_vacuum_service.collect_tables.assert_called_once_with("silver")
+
+    def test_vacuum_all_dry_run(self, cli_runner, mock_vacuum_service):
+        """Test vacuum-all dry-run mode."""
+        mock_vacuum_service.collect_tables.return_value = [
+            ("chembl_activity", "silver"),
+        ]
+        mock_vacuum_service.vacuum_all.return_value = _create_vacuum_all_result(
+            results=[_create_table_result("chembl_activity", "silver", 10)],
+            dry_run=True,
+        )
+
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_vacuum_service,
+        ):
+            result = cli_runner.invoke(cli, ["maintenance", "vacuum-all", "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "[DRY-RUN]" in result.output
+        assert "Would" in result.output
+
+    def test_vacuum_all_no_tables(self, cli_runner, mock_vacuum_service):
+        """Test vacuum-all with no tables to vacuum."""
+        mock_vacuum_service.collect_tables.return_value = []
+
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_vacuum_service,
+        ):
+            result = cli_runner.invoke(cli, ["maintenance", "vacuum-all"])
+
+        assert result.exit_code == 0
+        assert "No tables found" in result.output
+        mock_vacuum_service.vacuum_all.assert_not_called()
+
+    def test_vacuum_all_with_custom_retention(self, cli_runner, mock_vacuum_service):
+        """Test vacuum-all with custom retention days."""
+        mock_vacuum_service.collect_tables.return_value = [
+            ("chembl_activity", "silver"),
+        ]
+        mock_vacuum_service.vacuum_all.return_value = _create_vacuum_all_result(
+            results=[_create_table_result("chembl_activity", "silver", 10)]
+        )
+
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_vacuum_service,
+        ):
+            result = cli_runner.invoke(
+                cli, ["maintenance", "vacuum-all", "-r", "14"]
+            )
+
+        assert result.exit_code == 0
+        mock_vacuum_service.vacuum_all.assert_called_once()
+        call_args = mock_vacuum_service.vacuum_all.call_args
+        assert call_args[1]["retention_days"] == 14
+
+
+# =============================================================================
+# Formatter Output Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestVacuumFormatterOutput:
+    """Tests for vacuum CLI formatter output verification."""
+
+    def test_vacuum_all_shows_table_results(self, cli_runner, mock_vacuum_service):
+        """Test vacuum-all shows individual table results."""
+        mock_vacuum_service.collect_tables.return_value = [
+            ("table1", "silver"),
+            ("table2", "gold"),
+        ]
+        mock_vacuum_service.vacuum_all.return_value = _create_vacuum_all_result(
+            results=[
+                _create_table_result("table1", "silver", 10),
+                _create_table_result("table2", "gold", 5),
+            ]
+        )
+
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_vacuum_service,
+        ):
+            result = cli_runner.invoke(cli, ["maintenance", "vacuum-all"])
+
+        assert "silver/table1" in result.output
+        assert "gold/table2" in result.output
+
+    def test_vacuum_all_shows_error_for_failed_tables(
+        self, cli_runner, mock_vacuum_service
+    ):
+        """Test vacuum-all shows errors for failed tables."""
+        mock_vacuum_service.collect_tables.return_value = [
+            ("table1", "silver"),
+            ("table2", "gold"),
+        ]
+        mock_vacuum_service.vacuum_all.return_value = _create_vacuum_all_result(
+            results=[
+                _create_table_result("table1", "silver", 10),
+                _create_table_result(
+                    "table2", "gold", 0, error="Delta table corrupted"
+                ),
+            ]
+        )
+
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_vacuum_service,
+        ):
+            result = cli_runner.invoke(cli, ["maintenance", "vacuum-all"])
+
+        assert "Error:" in result.output
+        assert "Delta table corrupted" in result.output
+
+    def test_vacuum_all_summary_shows_total(self, cli_runner, mock_vacuum_service):
+        """Test vacuum-all summary shows total files removed."""
+        mock_vacuum_service.collect_tables.return_value = [
+            ("table1", "silver"),
+            ("table2", "gold"),
+        ]
+        mock_vacuum_service.vacuum_all.return_value = _create_vacuum_all_result(
+            results=[
+                _create_table_result("table1", "silver", 10),
+                _create_table_result("table2", "gold", 5),
+            ]
+        )
+
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_vacuum_service,
+        ):
+            result = cli_runner.invoke(cli, ["maintenance", "vacuum-all"])
+
+        assert "Total:" in result.output
+        assert "15" in result.output
+
+    def test_vacuum_all_summary_shows_failed_tables(
+        self, cli_runner, mock_vacuum_service
+    ):
+        """Test vacuum-all summary lists failed tables."""
+        mock_vacuum_service.collect_tables.return_value = [
+            ("table1", "silver"),
+            ("table2", "gold"),
+        ]
+        mock_vacuum_service.vacuum_all.return_value = _create_vacuum_all_result(
+            results=[
+                _create_table_result("table1", "silver", 10),
+                _create_table_result("table2", "gold", 0, error="Failed"),
+            ]
+        )
+
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_vacuum_service,
+        ):
+            result = cli_runner.invoke(cli, ["maintenance", "vacuum-all"])
+
+        assert "Failed tables:" in result.output
+        assert "gold/table2" in result.output
+
+    def test_vacuum_all_dry_run_shows_would_remove(
+        self, cli_runner, mock_vacuum_service
+    ):
+        """Test vacuum-all dry-run shows 'would remove' in output."""
+        mock_vacuum_service.collect_tables.return_value = [
+            ("table1", "silver"),
+        ]
+        mock_vacuum_service.vacuum_all.return_value = _create_vacuum_all_result(
+            results=[_create_table_result("table1", "silver", 10)],
+            dry_run=True,
+        )
+
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_vacuum_service,
+        ):
+            result = cli_runner.invoke(cli, ["maintenance", "vacuum-all", "--dry-run"])
+
+        assert "Would" in result.output or "would" in result.output
+
+
+# =============================================================================
+# Negative Scenarios
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestVacuumNegativeScenarios:
+    """Tests for vacuum command error handling."""
+
+    def test_vacuum_all_partial_failure_continues(
+        self, cli_runner, mock_vacuum_service
+    ):
+        """Test vacuum-all continues even if some tables fail."""
+        mock_vacuum_service.collect_tables.return_value = [
+            ("table1", "silver"),
+            ("table2", "silver"),
+            ("table3", "gold"),
+        ]
+        mock_vacuum_service.vacuum_all.return_value = _create_vacuum_all_result(
+            results=[
+                _create_table_result("table1", "silver", 10),
+                _create_table_result("table2", "silver", 0, error="Failed"),
+                _create_table_result("table3", "gold", 5),
+            ]
+        )
+
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_vacuum_service,
+        ):
+            result = cli_runner.invoke(cli, ["maintenance", "vacuum-all"])
+
+        # Should complete successfully (exit 0) even with partial failures
+        assert result.exit_code == 0
+        # Should show summary with both successes and failures
+        assert "15" in result.output  # 10 + 5 files removed
+        assert "Failed tables:" in result.output
+
+    def test_vacuum_all_handles_service_error(
+        self, cli_runner, mock_vacuum_service
+    ):
+        """Test vacuum-all handles VacuumService exceptions."""
+        mock_vacuum_service.collect_tables.return_value = [
+            ("table1", "silver"),
+        ]
+        mock_vacuum_service.vacuum_all.side_effect = RuntimeError("Service error")
+
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_vacuum_service,
+        ):
+            result = cli_runner.invoke(cli, ["maintenance", "vacuum-all"])
+
+        # Should fail with non-zero exit code
+        assert result.exit_code != 0
+
+    def test_vacuum_all_with_all_failures(self, cli_runner, mock_vacuum_service):
+        """Test vacuum-all when all tables fail."""
+        mock_vacuum_service.collect_tables.return_value = [
+            ("table1", "silver"),
+            ("table2", "gold"),
+        ]
+        mock_vacuum_service.vacuum_all.return_value = _create_vacuum_all_result(
+            results=[
+                _create_table_result("table1", "silver", 0, error="Error 1"),
+                _create_table_result("table2", "gold", 0, error="Error 2"),
+            ]
+        )
+
+        with patch(
+            "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
+            return_value=mock_vacuum_service,
+        ):
+            result = cli_runner.invoke(cli, ["maintenance", "vacuum-all"])
+
+        # Still exits 0 (operation completed, just with failures)
+        assert result.exit_code == 0
+        assert "Failed tables:" in result.output
+
+
+# =============================================================================
+# Integration with formatters.py Functions
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestFormatterFunctions:
+    """Direct tests for CLI formatter functions used by vacuum commands."""
+
+    def test_echo_vacuum_result_success(self, capsys):
+        """Test echo_vacuum_result formats successful result correctly."""
+        from bioetl.interfaces.cli.formatters import echo_vacuum_result
+
+        result = _create_table_result("test_table", "silver", 42)
+        echo_vacuum_result(result, dry_run=False)
+
+        captured = capsys.readouterr()
+        assert "Vacuuming silver/test_table" in captured.out
+        assert "Removed 42 files" in captured.out
+
+    def test_echo_vacuum_result_dry_run(self, capsys):
+        """Test echo_vacuum_result formats dry-run result correctly."""
+        from bioetl.interfaces.cli.formatters import echo_vacuum_result
+
+        result = _create_table_result("test_table", "gold", 10)
+        echo_vacuum_result(result, dry_run=True)
+
+        captured = capsys.readouterr()
+        assert "[DRY-RUN]" in captured.out
+        assert "Would vacuum" in captured.out
+        assert "Would remove 10 files" in captured.out
+
+    def test_echo_vacuum_result_error(self, capsys):
+        """Test echo_vacuum_result formats error result correctly."""
+        from bioetl.interfaces.cli.formatters import echo_vacuum_result
+
+        result = _create_table_result(
+            "test_table", "silver", 0, error="Delta table not found"
+        )
+        echo_vacuum_result(result, dry_run=False)
+
+        captured = capsys.readouterr()
+        # Error messages go to stderr
+        assert "Error:" in captured.err
+        assert "Delta table not found" in captured.err
+
+    def test_echo_vacuum_all_summary_success(self, capsys):
+        """Test echo_vacuum_all_summary formats summary correctly."""
+        from bioetl.interfaces.cli.formatters import echo_vacuum_all_summary
+
+        result = _create_vacuum_all_result(
+            results=[
+                _create_table_result("t1", "silver", 10),
+                _create_table_result("t2", "gold", 5),
+            ]
+        )
+        echo_vacuum_all_summary(result)
+
+        captured = capsys.readouterr()
+        assert "Total:" in captured.out
+        assert "15" in captured.out
+
+    def test_echo_vacuum_all_summary_with_failures(self, capsys):
+        """Test echo_vacuum_all_summary shows failed tables."""
+        from bioetl.interfaces.cli.formatters import echo_vacuum_all_summary
+
+        result = _create_vacuum_all_result(
+            results=[
+                _create_table_result("t1", "silver", 10),
+                _create_table_result("t2", "gold", 0, error="Failed"),
+            ]
+        )
+        echo_vacuum_all_summary(result)
+
+        captured = capsys.readouterr()
+        # Failed tables list goes to stderr
+        assert "Failed tables:" in captured.err
+        assert "gold/t2" in captured.err
+
+    def test_echo_vacuum_all_summary_dry_run(self, capsys):
+        """Test echo_vacuum_all_summary formats dry-run summary correctly."""
+        from bioetl.interfaces.cli.formatters import echo_vacuum_all_summary
+
+        result = _create_vacuum_all_result(
+            results=[_create_table_result("t1", "silver", 10)],
+            dry_run=True,
+        )
+        echo_vacuum_all_summary(result)
+
+        captured = capsys.readouterr()
+        assert "would remove" in captured.out


### PR DESCRIPTION
Add comprehensive unit and integration tests for run_all and vacuum CLI commands:

- Unit tests for run_all with mocked PipelineRunnerService:
  - Positive scenarios (successful batch execution)
  - Negative scenarios (service errors, PipelineNotFoundError)
  - Dry-run mode validation
  - Exit code verification
  - Shutdown handling

- Unit tests for vacuum/vacuum-all with mocked VacuumService:
  - Positive scenarios (single table and batch operations)
  - Negative scenarios (service errors, partial failures)
  - Dry-run mode validation
  - Layer filtering (silver/gold/all)
  - Custom retention days

- Integration tests for vacuum-all command:
  - Batch vacuum execution
  - No tables found scenario
  - Partial failure handling
  - Output formatting verification

- CLI formatter output verification:
  - echo_vacuum_result (success/dry-run/error)
  - echo_vacuum_all_summary (total/failed tables)
  - Correct stderr/stdout separation

Total: 68 new tests (109 tests including existing)