### PR TITLE
Add test and run code formatter check

### DIFF
--- a/tests/architecture/test_code_formatting.py
+++ b/tests/architecture/test_code_formatting.py
@@ -1,0 +1,51 @@
+"""Architecture test: проверка форматирования кода с помощью black.
+
+REQ-ARCH-050: Consistent code formatting across the codebase.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+
+class TestCodeFormatting:
+    """Tests ensuring code follows black formatting standards."""
+
+    @pytest.mark.slow
+    def test_black_formatting_src(self) -> None:
+        """Source code MUST be formatted with black.
+
+        Run `black src` to fix formatting issues.
+        """
+        result = subprocess.run(
+            [sys.executable, "-m", "black", "--check", "src"],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, (
+            "Code formatting issues found in src/:\n"
+            f"{result.stdout}\n{result.stderr}\n\n"
+            "Run `black src` to fix formatting issues."
+        )
+
+    @pytest.mark.slow
+    def test_black_formatting_tests(self) -> None:
+        """Test code MUST be formatted with black.
+
+        Run `black tests` to fix formatting issues.
+        """
+        result = subprocess.run(
+            [sys.executable, "-m", "black", "--check", "tests"],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, (
+            "Code formatting issues found in tests/:\n"
+            f"{result.stdout}\n{result.stderr}\n\n"
+            "Run `black tests` to fix formatting issues."
+        )

--- a/tests/integration/test_dq_monitor_integration.py
+++ b/tests/integration/test_dq_monitor_integration.py
@@ -337,7 +337,9 @@ class TestDataQualityServiceMetricsEmission:
         assert result.status == DQStatus.WARNING
 
         # Verify counter was emitted
-        counter_calls = recording_metrics.get_counter_calls("dq_soft_threshold_exceeded")
+        counter_calls = recording_metrics.get_counter_calls(
+            "dq_soft_threshold_exceeded"
+        )
         assert len(counter_calls) == 1
         name, value, labels = counter_calls[0]
         assert name == "dq_soft_threshold_exceeded"
@@ -455,11 +457,13 @@ class TestDataQualityServiceMetricsEmission:
         )
 
         # Evaluate with multiple metrics
-        await service.evaluate({
-            "error_rate": 0.01,
-            "record_count": 100.0,
-            "silver_yield": 0.95,
-        })
+        await service.evaluate(
+            {
+                "error_rate": 0.01,
+                "record_count": 100.0,
+                "silver_yield": 0.95,
+            }
+        )
 
         # Verify baseline_updated counter was emitted for each metric
         counter_calls = recording_metrics.get_counter_calls("dq_baseline_updated")
@@ -506,7 +510,9 @@ class TestDataQualityServiceMetricsEmission:
         assert result.status == DQStatus.PASSED
 
         # Verify NO counter was emitted
-        counter_calls = recording_metrics.get_counter_calls("dq_soft_threshold_exceeded")
+        counter_calls = recording_metrics.get_counter_calls(
+            "dq_soft_threshold_exceeded"
+        )
         assert len(counter_calls) == 0
 
     @pytest.mark.asyncio
@@ -542,10 +548,12 @@ class TestDataQualityServiceMetricsEmission:
         )
 
         # Trigger soft threshold warning
-        await service.evaluate({
-            "error_rate": 0.10,      # Above soft threshold (5%)
-            "record_count": 1000.0,
-        })
+        await service.evaluate(
+            {
+                "error_rate": 0.10,  # Above soft threshold (5%)
+                "record_count": 1000.0,
+            }
+        )
 
         # Verify soft threshold counter
         soft_calls = recording_metrics.get_counter_calls("dq_soft_threshold_exceeded")
@@ -557,4 +565,6 @@ class TestDataQualityServiceMetricsEmission:
 
         # Verify baseline update counters
         baseline_calls = recording_metrics.get_counter_calls("dq_baseline_updated")
-        assert len(baseline_calls) == 2, "dq_baseline_updated should be emitted for each metric"
+        assert (
+            len(baseline_calls) == 2
+        ), "dq_baseline_updated should be emitted for each metric"

--- a/tests/unit/interfaces/test_cli_run_all_vacuum_formatters.py
+++ b/tests/unit/interfaces/test_cli_run_all_vacuum_formatters.py
@@ -325,11 +325,10 @@ class TestEchoBatchSummary:
             failed_pipelines=["pipeline_a", "pipeline_b"],
         )
 
-        with patch(
-            "bioetl.interfaces.cli.commands.run_all.echo_info"
-        ) as mock_info, patch(
-            "bioetl.interfaces.cli.commands.run_all.echo_error"
-        ) as mock_error:
+        with (
+            patch("bioetl.interfaces.cli.commands.run_all.echo_info") as mock_info,
+            patch("bioetl.interfaces.cli.commands.run_all.echo_error") as mock_error,
+        ):
             _echo_batch_summary(result, dry_run=False)
 
         # Check that failure count was output
@@ -422,9 +421,7 @@ class TestRunAllCommand:
             "bioetl.interfaces.cli.commands.run_all.get_default_registry",
             return_value=mock_registry,
         ):
-            result = cli_runner.invoke(
-                cli, ["run-all", "--source", "chembl", "--yes"]
-            )
+            result = cli_runner.invoke(cli, ["run-all", "--source", "chembl", "--yes"])
 
         assert result.exit_code == 0
         mock_asyncio_run.assert_called_once()
@@ -462,9 +459,7 @@ class TestRunAllCommand:
             "bioetl.interfaces.cli.commands.run_all.get_default_registry",
             return_value=mock_registry,
         ):
-            result = cli_runner.invoke(
-                cli, ["run-all", "--source", "chembl", "--yes"]
-            )
+            result = cli_runner.invoke(cli, ["run-all", "--source", "chembl", "--yes"])
 
         # Should exit with pipeline error code
         assert result.exit_code == ExitCode.PIPELINE_ERROR
@@ -480,9 +475,7 @@ class TestRunAllCommand:
             "bioetl.interfaces.cli.commands.run_all.get_default_registry",
             return_value=mock_registry,
         ):
-            result = cli_runner.invoke(
-                cli, ["run-all", "--source", "chembl", "--yes"]
-            )
+            result = cli_runner.invoke(cli, ["run-all", "--source", "chembl", "--yes"])
 
         assert result.exit_code == ExitCode.SIGINT
         assert "interrupted" in result.output.lower()


### PR DESCRIPTION
Add architecture test to verify code follows black formatting standards. Fix formatting issues in two test files that were not properly formatted.