### PR TITLE
Fix failing lint and type check tests

### DIFF
--- a/tests/integration/interfaces/test_cli_maintenance_vacuum.py
+++ b/tests/integration/interfaces/test_cli_maintenance_vacuum.py
@@ -458,9 +458,7 @@ class TestCliMaintenanceVacuumAllDryRun:
             "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
             return_value=mock_vacuum_service_dry_run,
         ):
-            result = cli_runner.invoke(
-                cli, ["maintenance", "vacuum-all", "--dry-run"]
-            )
+            result = cli_runner.invoke(cli, ["maintenance", "vacuum-all", "--dry-run"])
 
         assert result.exit_code == 0
         assert "[DRY-RUN]" in result.output or "Would" in result.output
@@ -475,9 +473,7 @@ class TestCliMaintenanceVacuumAllDryRun:
             "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
             return_value=mock_vacuum_service_dry_run,
         ):
-            result = cli_runner.invoke(
-                cli, ["maintenance", "vacuum-all", "--dry-run"]
-            )
+            result = cli_runner.invoke(cli, ["maintenance", "vacuum-all", "--dry-run"])
 
         assert result.exit_code == 0
         call_args = mock_vacuum_service_dry_run.vacuum_all.call_args
@@ -658,9 +654,7 @@ class TestCliMaintenanceVacuumAllOutput:
             "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
             return_value=mock_service,
         ):
-            result = cli_runner.invoke(
-                cli, ["maintenance", "vacuum-all", "--dry-run"]
-            )
+            result = cli_runner.invoke(cli, ["maintenance", "vacuum-all", "--dry-run"])
 
         assert result.exit_code == 0
         assert "would remove" in result.output.lower()

--- a/tests/unit/interfaces/test_run_all_service_mock.py
+++ b/tests/unit/interfaces/test_run_all_service_mock.py
@@ -22,7 +22,6 @@ from bioetl.application.services import (
     RunStatus,
 )
 from bioetl.interfaces.cli.commands.run_all import (
-    BatchRunResult,
     _run_all_pipelines_async,
 )
 from bioetl.interfaces.cli.exit_codes import ExitCode
@@ -618,9 +617,7 @@ class TestRunAllAsyncFunction:
     async def test_run_all_pipelines_async_handles_exception(self):
         """Test _run_all_pipelines_async handles runtime exceptions."""
         mock_service = MagicMock()
-        mock_service.run = AsyncMock(
-            side_effect=RuntimeError("Unexpected error")
-        )
+        mock_service.run = AsyncMock(side_effect=RuntimeError("Unexpected error"))
 
         with patch(
             "bioetl.interfaces.cli.commands.run_all.get_pipeline_runner_service",

--- a/tests/unit/interfaces/test_vacuum_commands.py
+++ b/tests/unit/interfaces/test_vacuum_commands.py
@@ -267,9 +267,7 @@ class TestVacuumAllCommand:
             "bioetl.interfaces.cli.commands.vacuum.get_vacuum_service",
             return_value=mock_vacuum_service,
         ):
-            result = cli_runner.invoke(
-                cli, ["maintenance", "vacuum-all", "-r", "14"]
-            )
+            result = cli_runner.invoke(cli, ["maintenance", "vacuum-all", "-r", "14"])
 
         assert result.exit_code == 0
         mock_vacuum_service.vacuum_all.assert_called_once()
@@ -439,9 +437,7 @@ class TestVacuumNegativeScenarios:
         assert "15" in result.output  # 10 + 5 files removed
         assert "Failed tables:" in result.output
 
-    def test_vacuum_all_handles_service_error(
-        self, cli_runner, mock_vacuum_service
-    ):
+    def test_vacuum_all_handles_service_error(self, cli_runner, mock_vacuum_service):
         """Test vacuum-all handles VacuumService exceptions."""
         mock_vacuum_service.collect_tables.return_value = [
             ("table1", "silver"),


### PR DESCRIPTION
- Remove unused BatchRunResult import from test_run_all_service_mock.py
- Apply black formatting to test files to fix CI formatting checks