### PR TITLE
Add pytest smoke target and make goal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,11 @@ test-fast: ## Run fast tests only (no slow markers, CI hypothesis profile)
 	@echo "$(BLUE)Running fast tests (parallel mode)...$(NC)"
 	HYPOTHESIS_PROFILE=fast $(RUN) pytest tests/unit/ tests/architecture/ -n auto --dist loadscope -m "not slow" --ignore=tests/benchmarks
 
+test-smoke: ## Run smoke tests (quick sanity check for local development)
+	@echo "$(BLUE)Running smoke tests...$(NC)"
+	$(RUN) pytest tests/smoke/ -v --tb=short
+	@echo "$(GREEN)Smoke tests passed!$(NC)"
+
 test-unit: ## Run only unit tests (parallel)
 	@echo "$(BLUE)Running unit tests...$(NC)"
 	$(RUN) pytest tests/unit/ -n auto --dist loadscope --ignore=tests/benchmarks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ markers = [
     "performance: Performance regression tests (optional CI stage)",
     "architecture: Architecture tests (layer boundaries, contracts)",
     "benchmark: Benchmark tests (excluded from standard runs, run with -m benchmark)",
+    "smoke: Smoke tests (quick sanity checks for local development)",
 ]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"

--- a/tests/smoke/__init__.py
+++ b/tests/smoke/__init__.py
@@ -1,0 +1,1 @@
+"""Smoke tests for quick sanity checks during local development."""

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -1,0 +1,170 @@
+"""Smoke tests for quick sanity checks during local development.
+
+These tests verify that:
+1. Core modules import successfully
+2. Basic domain objects work correctly
+3. CLI is loadable
+4. Layer boundaries are not violated
+
+Run with: make test-smoke
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.smoke
+class TestCoreImports:
+    """Verify core modules import without errors."""
+
+    def test_domain_imports(self) -> None:
+        """Domain layer imports successfully."""
+        from bioetl.domain import types, config, ports  # noqa: F401
+
+    def test_application_imports(self) -> None:
+        """Application layer imports successfully."""
+        from bioetl.application.core import runner  # noqa: F401
+        from bioetl.application.core import base_transformer  # noqa: F401
+
+    def test_infrastructure_imports(self) -> None:
+        """Infrastructure layer imports successfully."""
+        from bioetl.infrastructure.storage import bronze_writer  # noqa: F401
+        from bioetl.infrastructure.storage import silver_writer  # noqa: F401
+
+    def test_composition_imports(self) -> None:
+        """Composition layer imports successfully."""
+        from bioetl.composition import bootstrap  # noqa: F401
+        from bioetl.composition import entrypoints  # noqa: F401
+
+    def test_cli_imports(self) -> None:
+        """CLI module imports successfully."""
+        from bioetl.interfaces import cli  # noqa: F401
+
+
+@pytest.mark.smoke
+class TestDomainTypes:
+    """Verify domain types work correctly."""
+
+    def test_run_type_enum(self) -> None:
+        """RunType enum has expected values."""
+        from bioetl.domain.types import RunType
+
+        assert RunType.INCREMENTAL.value == "incremental"
+        assert RunType.BACKFILL.value == "backfill"
+        assert RunType.REBUILD.value == "rebuild"
+
+    def test_health_status_enum(self) -> None:
+        """HealthStatus enum has expected values."""
+        from bioetl.domain.types import HealthStatus
+
+        assert HealthStatus.HEALTHY.to_metric_value() == 2
+        assert HealthStatus.DEGRADED.to_metric_value() == 1
+        assert HealthStatus.UNHEALTHY.to_metric_value() == 0
+
+    def test_error_type_classification(self) -> None:
+        """ErrorType enum classifies errors correctly."""
+        from bioetl.domain.types import ErrorType
+
+        assert ErrorType.RATE_LIMIT.is_recoverable()
+        assert ErrorType.NETWORK_ERROR.is_recoverable()
+        assert not ErrorType.AUTH_FAILURE.is_recoverable()
+        assert ErrorType.AUTH_FAILURE.is_critical()
+
+
+@pytest.mark.smoke
+class TestDomainConfig:
+    """Verify domain configuration works."""
+
+    def test_dq_config_defaults(self) -> None:
+        """DQConfig has expected default thresholds."""
+        from bioetl.domain.config import DQConfig
+
+        config = DQConfig()
+        assert config.soft_fail_threshold == 0.05
+        assert config.hard_fail_threshold == 0.20
+
+    def test_runtime_config_defaults(self) -> None:
+        """RuntimeConfig has expected defaults."""
+        from bioetl.domain.config import RuntimeConfig
+        from bioetl.domain.types import RunType
+
+        config = RuntimeConfig(run_type=RunType.INCREMENTAL)
+        assert config.heartbeat_interval == 20
+        assert config.lock_ttl == 60
+        assert config.dry_run is False
+
+
+@pytest.mark.smoke
+class TestPortsExist:
+    """Verify core ports are defined."""
+
+    def test_storage_port(self) -> None:
+        """StoragePort protocol exists."""
+        from bioetl.domain.ports import StoragePort
+
+        assert hasattr(StoragePort, "write_bronze")
+
+    def test_lock_port(self) -> None:
+        """LockPort protocol exists."""
+        from bioetl.domain.ports import LockPort
+
+        assert hasattr(LockPort, "acquire")
+        assert hasattr(LockPort, "release")
+
+    def test_checkpoint_port(self) -> None:
+        """CheckpointPort protocol exists."""
+        from bioetl.domain.ports import CheckpointPort
+
+        assert hasattr(CheckpointPort, "load")
+        assert hasattr(CheckpointPort, "save")
+
+
+@pytest.mark.smoke
+class TestLayerBoundaries:
+    """Quick layer boundary sanity checks."""
+
+    def test_domain_has_no_httpx(self) -> None:
+        """Domain layer does not import httpx."""
+        import bioetl.domain as domain
+        import sys
+
+        domain_modules = [
+            name for name in sys.modules if name.startswith("bioetl.domain")
+        ]
+        for mod_name in domain_modules:
+            mod = sys.modules.get(mod_name)
+            if mod and hasattr(mod, "__file__") and mod.__file__:
+                # Check the module doesn't have httpx in its namespace
+                assert not hasattr(mod, "httpx"), f"{mod_name} imports httpx"
+
+    def test_domain_has_no_polars(self) -> None:
+        """Domain layer does not import polars directly."""
+        import bioetl.domain as domain
+        import sys
+
+        domain_modules = [
+            name for name in sys.modules if name.startswith("bioetl.domain")
+        ]
+        for mod_name in domain_modules:
+            mod = sys.modules.get(mod_name)
+            if mod and hasattr(mod, "__file__") and mod.__file__:
+                assert not hasattr(mod, "polars"), f"{mod_name} imports polars"
+
+
+@pytest.mark.smoke
+class TestCLILoadable:
+    """Verify CLI is loadable and has expected commands."""
+
+    def test_cli_main_exists(self) -> None:
+        """CLI main function exists."""
+        from bioetl.interfaces.cli import main
+
+        assert callable(main)
+
+    def test_cli_is_click_group(self) -> None:
+        """CLI group is a Click group."""
+        from bioetl.interfaces.cli import cli
+        import click
+
+        assert isinstance(cli, click.core.Group)


### PR DESCRIPTION
Add pytest marker 'smoke' and make target 'test-smoke' for fast local development verification. Smoke tests check:
- Core module imports (domain, application, infrastructure, composition)
- Domain types and configurations work correctly
- Port protocols are defined
- Layer boundaries are respected
- CLI is loadable

Run with: make test-smoke (~3 seconds)