### PR TITLE
Run tests and fix errors

### DIFF
--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -126,7 +126,7 @@ class TestLayerBoundaries:
 
     def test_domain_has_no_httpx(self) -> None:
         """Domain layer does not import httpx."""
-        import bioetl.domain as domain
+        import bioetl.domain as domain  # noqa: F401
         import sys
 
         domain_modules = [
@@ -140,7 +140,7 @@ class TestLayerBoundaries:
 
     def test_domain_has_no_polars(self) -> None:
         """Domain layer does not import polars directly."""
-        import bioetl.domain as domain
+        import bioetl.domain as domain  # noqa: F401
         import sys
 
         domain_modules = [


### PR DESCRIPTION
The domain module imports in layer boundary tests are intentionally unused - they load modules into sys.modules for inspection.