### PR TITLE
Fix failing lint and type check tests

### DIFF
--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -126,8 +126,10 @@ class TestLayerBoundaries:
 
     def test_domain_has_no_httpx(self) -> None:
         """Domain layer does not import httpx."""
-        import bioetl.domain as domain
+        import bioetl.domain as _domain
         import sys
+
+        del _domain  # Import for side effect only
 
         domain_modules = [
             name for name in sys.modules if name.startswith("bioetl.domain")
@@ -140,8 +142,10 @@ class TestLayerBoundaries:
 
     def test_domain_has_no_polars(self) -> None:
         """Domain layer does not import polars directly."""
-        import bioetl.domain as domain
+        import bioetl.domain as _domain
         import sys
+
+        del _domain  # Import for side effect only
 
         domain_modules = [
             name for name in sys.modules if name.startswith("bioetl.domain")


### PR DESCRIPTION
The domain layer boundary tests import bioetl.domain solely for its side effect of populating sys.modules. Rename to _domain and add explicit del to clarify intent while satisfying ruff's F401 check.