### PR TITLE
Remove unused bioetl.domain import

### DIFF
--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -126,7 +126,7 @@ class TestLayerBoundaries:
 
     def test_domain_has_no_httpx(self) -> None:
         """Domain layer does not import httpx."""
-        import bioetl.domain as domain  # noqa: F401
+        import bioetl.domain  # noqa: F401 - import for side effect
         import sys
 
         domain_modules = [
@@ -140,7 +140,7 @@ class TestLayerBoundaries:
 
     def test_domain_has_no_polars(self) -> None:
         """Domain layer does not import polars directly."""
-        import bioetl.domain as domain  # noqa: F401
+        import bioetl.domain  # noqa: F401 - import for side effect
         import sys
 
         domain_modules = [


### PR DESCRIPTION
Remove 'as domain' aliases from imports that are only used for side effects (loading modules into sys.modules). The imports are retained with noqa comments to suppress F401 since they serve a testing purpose.