### PR TITLE
Fix import sorting in test files

### DIFF
--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -126,9 +126,9 @@ class TestLayerBoundaries:
 
     def test_domain_has_no_httpx(self) -> None:
         """Domain layer does not import httpx."""
-        import bioetl.domain  # noqa: F401 - import for side effect
         import sys
 
+        import bioetl.domain  # noqa: F401 - import for side effect
         import bioetl.domain as domain  # noqa: F401
 
         domain_modules = [
@@ -142,9 +142,9 @@ class TestLayerBoundaries:
 
     def test_domain_has_no_polars(self) -> None:
         """Domain layer does not import polars directly."""
-        import bioetl.domain  # noqa: F401 - import for side effect
         import sys
 
+        import bioetl.domain  # noqa: F401 - import for side effect
         import bioetl.domain as domain  # noqa: F401
 
         domain_modules = [


### PR DESCRIPTION
Move stdlib imports (sys) before local imports (bioetl.domain) to satisfy isort ordering requirements.