### PR TITLE
Add security checks for secrets and PII

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,13 +213,50 @@ def _sanitize_request(request: Request) -> Request:
 
 
 def _sanitize_response(response: dict[str, Any]) -> dict[str, Any]:
-    """Sanitize secrets from recorded responses."""
+    """Sanitize secrets and PII from recorded responses.
+
+    Removes:
+    - Sensitive headers (Set-Cookie, X-Request-Id)
+    - Email addresses from response body (PII protection)
+
+    Requirements:
+    - REQ-TEST-002: Secret sanitization in before_record hook
+    - REQ-SECRET-004: PII sanitization in VCR cassettes
+    """
     # Remove sensitive headers from response
     headers_to_remove = ["Set-Cookie", "X-Request-Id"]
     if "headers" in response:
         for header in headers_to_remove:
             response["headers"].pop(header, None)
             response["headers"].pop(header.lower(), None)
+
+    # Sanitize email addresses from response body (PII protection)
+    # Pattern matches standard email format
+    email_pattern = r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}"
+    email_pattern_bytes = rb"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}"
+
+    if "body" in response:
+        body = response["body"]
+        # Handle string body
+        if isinstance(body, str):
+            response["body"] = re.sub(email_pattern, "redacted@example.com", body)
+        # Handle bytes body
+        elif isinstance(body, bytes):
+            response["body"] = re.sub(
+                email_pattern_bytes, b"redacted@example.com", body
+            )
+        # Handle dict with 'string' key (VCR internal format)
+        elif isinstance(body, dict) and "string" in body:
+            string_body = body["string"]
+            if isinstance(string_body, str):
+                body["string"] = re.sub(
+                    email_pattern, "redacted@example.com", string_body
+                )
+            elif isinstance(string_body, bytes):
+                body["string"] = re.sub(
+                    email_pattern_bytes, b"redacted@example.com", string_body
+                )
+
     return response
 
 

--- a/tests/fixtures/vcr/integration/adapters/test_fetch_publications.yaml
+++ b/tests/fixtures/vcr/integration/adapters/test_fetch_publications.yaml
@@ -394,11 +394,11 @@ interactions:
         ValidYN="Y"><LastName>Voineagu</LastName><ForeName>Irina</ForeName><Initials>I</Initials><Identifier
         Source="ORCID">0000-0003-4162-3872</Identifier><AffiliationInfo><Affiliation>School
         of Biotechnology and Biomolecular Sciences, University of New South Wales,
-        Sydney, New South Wales, Australia. i.voineagu@unsw.edu.au.</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>Cellular
+        Sydney, New South Wales, Australia. redacted@example.com.</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>Cellular
         Genomics Futures Institute, University of New South Wales, Sydney, New South
-        Wales, Australia. i.voineagu@unsw.edu.au.</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>RNA
+        Wales, Australia. redacted@example.com.</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>RNA
         Institute, University of New South Wales, Sydney, New South Wales, Australia.
-        i.voineagu@unsw.edu.au.</Affiliation></AffiliationInfo></Author></AuthorList><Language>eng</Language><GrantList
+        redacted@example.com.</Affiliation></AffiliationInfo></Author></AuthorList><Language>eng</Language><GrantList
         CompleteYN="Y"><Grant><GrantID>2020814</GrantID><Agency>Department of Health
         | National Health and Medical Research Council (NHMRC)</Agency><Country/></Grant></GrantList><PublicationTypeList><PublicationType
         UI="D016428">Journal Article</PublicationType></PublicationTypeList><ArticleDate
@@ -876,16 +876,16 @@ interactions:
         NY, 10016, New York, USA.</Affiliation></AffiliationInfo></Author><Author
         ValidYN="Y"><LastName>Barthel</LastName><ForeName>Steven R</ForeName><Initials>SR</Initials><AffiliationInfo><Affiliation>Department
         of Dermatology, Brigham and Women''s Hospital, Harvard Medical School, Boston,
-        MA, 02115, USA. sbarthel@bwh.harvard.edu.</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>Program
+        MA, 02115, USA. redacted@example.com.</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>Program
         of Glyco-Immunology and Oncology, Brigham and Women''s Hospital, Harvard Medical
-        School, Boston, MA, 02115, USA. sbarthel@bwh.harvard.edu.</Affiliation></AffiliationInfo></Author><Author
+        School, Boston, MA, 02115, USA. redacted@example.com.</Affiliation></AffiliationInfo></Author><Author
         ValidYN="Y"><LastName>Schatton</LastName><ForeName>Tobias</ForeName><Initials>T</Initials><AffiliationInfo><Affiliation>Department
         of Dermatology, Brigham and Women''s Hospital, Harvard Medical School, Boston,
-        MA, 02115, USA. tschatton@bwh.harvard.edu.</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>Program
+        MA, 02115, USA. redacted@example.com.</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>Program
         of Glyco-Immunology and Oncology, Brigham and Women''s Hospital, Harvard Medical
-        School, Boston, MA, 02115, USA. tschatton@bwh.harvard.edu.</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>Department
+        School, Boston, MA, 02115, USA. redacted@example.com.</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>Department
         of Medicine, Boston Children''s Hospital, Harvard Medical School, Boston,
-        MA, 02115, USA. tschatton@bwh.harvard.edu.</Affiliation></AffiliationInfo></Author></AuthorList><Language>eng</Language><GrantList
+        MA, 02115, USA. redacted@example.com.</Affiliation></AffiliationInfo></Author></AuthorList><Language>eng</Language><GrantList
         CompleteYN="Y"><Grant><GrantID>470684420</GrantID><Agency>Walter Benjamin
         Scholarship from the German Research Foundation</Agency><Country/></Grant><Grant><GrantID>R01CA247957</GrantID><Agency>NIH/NCI
         grant</Agency><Country/></Grant><Grant><GrantID>R01CA247957</GrantID><Agency>NIH/NCI
@@ -1141,7 +1141,7 @@ interactions:
         General Hospital Cancer Center, Harvard Medical School, Boston, MA, USA.</Affiliation></AffiliationInfo></Author><Author
         ValidYN="Y"><LastName>Yeku</LastName><ForeName>Oladapo O</ForeName><Initials>OO</Initials><Identifier
         Source="ORCID">0000-0002-6319-1647</Identifier><AffiliationInfo><Affiliation>Massachusetts
-        General Hospital Cancer Center, Harvard Medical School, Boston, MA, USA. oyeku@mgh.harvard.edu.</Affiliation></AffiliationInfo></Author></AuthorList><Language>eng</Language><PublicationTypeList><PublicationType
+        General Hospital Cancer Center, Harvard Medical School, Boston, MA, USA. redacted@example.com.</Affiliation></AffiliationInfo></Author></AuthorList><Language>eng</Language><PublicationTypeList><PublicationType
         UI="D016428">Journal Article</PublicationType></PublicationTypeList><ArticleDate
         DateType="Electronic"><Year>2025</Year><Month>12</Month><Day>19</Day></ArticleDate></Article><MedlineJournalInfo><Country>England</Country><MedlineTA>Signal
         Transduct Target Ther</MedlineTA><NlmUniqueID>101676423</NlmUniqueID><ISSNLinking>2059-3635</ISSNLinking></MedlineJournalInfo><ChemicalList><Chemical><RegistryNumber>0</RegistryNumber><NameOfSubstance
@@ -1423,10 +1423,10 @@ interactions:
         Wuhan, China.</Affiliation></AffiliationInfo></Author><Author ValidYN="Y"><LastName>Sun</LastName><ForeName>Yuhui</ForeName><Initials>Y</Initials><Identifier
         Source="ORCID">0000-0001-5720-9620</Identifier><AffiliationInfo><Affiliation>School
         of Pharmacy, Huazhong University of Science and Technology, Wuhan, China.
-        sunyuhui@hust.edu.cn.</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>Key
+        redacted@example.com.</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>Key
         Laboratory of Combinatorial Biosynthesis and Drug Discovery (Wuhan University),
         Ministry of Education and Wuhan University School of Pharmaceutical Sciences,
-        Wuhan, China. sunyuhui@hust.edu.cn.</Affiliation></AffiliationInfo></Author></AuthorList><Language>eng</Language><PublicationTypeList><PublicationType
+        Wuhan, China. redacted@example.com.</Affiliation></AffiliationInfo></Author></AuthorList><Language>eng</Language><PublicationTypeList><PublicationType
         UI="D016428">Journal Article</PublicationType></PublicationTypeList><ArticleDate
         DateType="Electronic"><Year>2025</Year><Month>12</Month><Day>19</Day></ArticleDate></Article><MedlineJournalInfo><Country>England</Country><MedlineTA>Nat
         Commun</MedlineTA><NlmUniqueID>101528555</NlmUniqueID><ISSNLinking>2041-1723</ISSNLinking></MedlineJournalInfo><CitationSubset>IM</CitationSubset><CoiStatement>Competing
@@ -1575,7 +1575,7 @@ interactions:
         Ltd. All rights reserved.</CopyrightInformation></Abstract><AuthorList CompleteYN="Y"><Author
         ValidYN="Y"><LastName>Mandrioli</LastName><ForeName>Mauro</ForeName><Initials>M</Initials><AffiliationInfo><Affiliation>Department
         of Life Sciences, University of Modena and Reggio Emilia, Biology Building,
-        via Campi 213/D, Modena, Italy. Electronic address: mauro.mandrioli@unimore.it.</Affiliation></AffiliationInfo></Author></AuthorList><Language>eng</Language><PublicationTypeList><PublicationType
+        via Campi 213/D, Modena, Italy. Electronic address: redacted@example.com.</Affiliation></AffiliationInfo></Author></AuthorList><Language>eng</Language><PublicationTypeList><PublicationType
         UI="D016428">Journal Article</PublicationType></PublicationTypeList><ArticleDate
         DateType="Electronic"><Year>2025</Year><Month>12</Month><Day>17</Day></ArticleDate></Article><MedlineJournalInfo><Country>England</Country><MedlineTA>Trends
         Biotechnol</MedlineTA><NlmUniqueID>8310903</NlmUniqueID><ISSNLinking>0167-7799</ISSNLinking></MedlineJournalInfo><CitationSubset>IM</CitationSubset><KeywordList

--- a/tests/fixtures/vcr/test_pubmed_publications_classification_fields.yaml
+++ b/tests/fixtures/vcr/test_pubmed_publications_classification_fields.yaml
@@ -150,7 +150,7 @@ interactions:
         acid template.</ArticleTitle><Pagination><StartPage>541</StartPage><EndPage>544</EndPage><MedlinePgn>541-4</MedlinePgn></Pagination><AuthorList
         CompleteYN="Y"><Author ValidYN="Y"><LastName>Groneberg</LastName><ForeName>R
         D</ForeName><Initials>RD</Initials><AffiliationInfo><Affiliation>Rh&#xf4;ne-Poulenc
-        Rorer, SW8, 500 Arcola Road, Collegeville, Pennsylvania 19426, USA. robert.groneberg@rp-rorer.com</Affiliation></AffiliationInfo></Author><Author
+        Rorer, SW8, 500 Arcola Road, Collegeville, Pennsylvania 19426, USA. redacted@example.com</Affiliation></AffiliationInfo></Author><Author
         ValidYN="Y"><LastName>Burns</LastName><ForeName>C J</ForeName><Initials>CJ</Initials></Author><Author
         ValidYN="Y"><LastName>Morrissette</LastName><ForeName>M M</ForeName><Initials>MM</Initials></Author><Author
         ValidYN="Y"><LastName>Ullrich</LastName><ForeName>J W</ForeName><Initials>JW</Initials></Author><Author
@@ -691,7 +691,7 @@ interactions:
         acid template.</ArticleTitle><Pagination><StartPage>541</StartPage><EndPage>544</EndPage><MedlinePgn>541-4</MedlinePgn></Pagination><AuthorList
         CompleteYN="Y"><Author ValidYN="Y"><LastName>Groneberg</LastName><ForeName>R
         D</ForeName><Initials>RD</Initials><AffiliationInfo><Affiliation>Rh&#xf4;ne-Poulenc
-        Rorer, SW8, 500 Arcola Road, Collegeville, Pennsylvania 19426, USA. robert.groneberg@rp-rorer.com</Affiliation></AffiliationInfo></Author><Author
+        Rorer, SW8, 500 Arcola Road, Collegeville, Pennsylvania 19426, USA. redacted@example.com</Affiliation></AffiliationInfo></Author><Author
         ValidYN="Y"><LastName>Burns</LastName><ForeName>C J</ForeName><Initials>CJ</Initials></Author><Author
         ValidYN="Y"><LastName>Morrissette</LastName><ForeName>M M</ForeName><Initials>MM</Initials></Author><Author
         ValidYN="Y"><LastName>Ullrich</LastName><ForeName>J W</ForeName><Initials>JW</Initials></Author><Author

--- a/tests/fixtures/vcr/test_pubmed_publications_date_fields.yaml
+++ b/tests/fixtures/vcr/test_pubmed_publications_date_fields.yaml
@@ -150,7 +150,7 @@ interactions:
         acid template.</ArticleTitle><Pagination><StartPage>541</StartPage><EndPage>544</EndPage><MedlinePgn>541-4</MedlinePgn></Pagination><AuthorList
         CompleteYN="Y"><Author ValidYN="Y"><LastName>Groneberg</LastName><ForeName>R
         D</ForeName><Initials>RD</Initials><AffiliationInfo><Affiliation>Rh&#xf4;ne-Poulenc
-        Rorer, SW8, 500 Arcola Road, Collegeville, Pennsylvania 19426, USA. robert.groneberg@rp-rorer.com</Affiliation></AffiliationInfo></Author><Author
+        Rorer, SW8, 500 Arcola Road, Collegeville, Pennsylvania 19426, USA. redacted@example.com</Affiliation></AffiliationInfo></Author><Author
         ValidYN="Y"><LastName>Burns</LastName><ForeName>C J</ForeName><Initials>CJ</Initials></Author><Author
         ValidYN="Y"><LastName>Morrissette</LastName><ForeName>M M</ForeName><Initials>MM</Initials></Author><Author
         ValidYN="Y"><LastName>Ullrich</LastName><ForeName>J W</ForeName><Initials>JW</Initials></Author><Author
@@ -691,7 +691,7 @@ interactions:
         acid template.</ArticleTitle><Pagination><StartPage>541</StartPage><EndPage>544</EndPage><MedlinePgn>541-4</MedlinePgn></Pagination><AuthorList
         CompleteYN="Y"><Author ValidYN="Y"><LastName>Groneberg</LastName><ForeName>R
         D</ForeName><Initials>RD</Initials><AffiliationInfo><Affiliation>Rh&#xf4;ne-Poulenc
-        Rorer, SW8, 500 Arcola Road, Collegeville, Pennsylvania 19426, USA. robert.groneberg@rp-rorer.com</Affiliation></AffiliationInfo></Author><Author
+        Rorer, SW8, 500 Arcola Road, Collegeville, Pennsylvania 19426, USA. redacted@example.com</Affiliation></AffiliationInfo></Author><Author
         ValidYN="Y"><LastName>Burns</LastName><ForeName>C J</ForeName><Initials>CJ</Initials></Author><Author
         ValidYN="Y"><LastName>Morrissette</LastName><ForeName>M M</ForeName><Initials>MM</Initials></Author><Author
         ValidYN="Y"><LastName>Ullrich</LastName><ForeName>J W</ForeName><Initials>JW</Initials></Author><Author

--- a/tests/fixtures/vcr/test_pubmed_publications_full_cycle.yaml
+++ b/tests/fixtures/vcr/test_pubmed_publications_full_cycle.yaml
@@ -150,7 +150,7 @@ interactions:
         acid template.</ArticleTitle><Pagination><StartPage>541</StartPage><EndPage>544</EndPage><MedlinePgn>541-4</MedlinePgn></Pagination><AuthorList
         CompleteYN="Y"><Author ValidYN="Y"><LastName>Groneberg</LastName><ForeName>R
         D</ForeName><Initials>RD</Initials><AffiliationInfo><Affiliation>Rh&#xf4;ne-Poulenc
-        Rorer, SW8, 500 Arcola Road, Collegeville, Pennsylvania 19426, USA. robert.groneberg@rp-rorer.com</Affiliation></AffiliationInfo></Author><Author
+        Rorer, SW8, 500 Arcola Road, Collegeville, Pennsylvania 19426, USA. redacted@example.com</Affiliation></AffiliationInfo></Author><Author
         ValidYN="Y"><LastName>Burns</LastName><ForeName>C J</ForeName><Initials>CJ</Initials></Author><Author
         ValidYN="Y"><LastName>Morrissette</LastName><ForeName>M M</ForeName><Initials>MM</Initials></Author><Author
         ValidYN="Y"><LastName>Ullrich</LastName><ForeName>J W</ForeName><Initials>JW</Initials></Author><Author
@@ -691,7 +691,7 @@ interactions:
         acid template.</ArticleTitle><Pagination><StartPage>541</StartPage><EndPage>544</EndPage><MedlinePgn>541-4</MedlinePgn></Pagination><AuthorList
         CompleteYN="Y"><Author ValidYN="Y"><LastName>Groneberg</LastName><ForeName>R
         D</ForeName><Initials>RD</Initials><AffiliationInfo><Affiliation>Rh&#xf4;ne-Poulenc
-        Rorer, SW8, 500 Arcola Road, Collegeville, Pennsylvania 19426, USA. robert.groneberg@rp-rorer.com</Affiliation></AffiliationInfo></Author><Author
+        Rorer, SW8, 500 Arcola Road, Collegeville, Pennsylvania 19426, USA. redacted@example.com</Affiliation></AffiliationInfo></Author><Author
         ValidYN="Y"><LastName>Burns</LastName><ForeName>C J</ForeName><Initials>CJ</Initials></Author><Author
         ValidYN="Y"><LastName>Morrissette</LastName><ForeName>M M</ForeName><Initials>MM</Initials></Author><Author
         ValidYN="Y"><LastName>Ullrich</LastName><ForeName>J W</ForeName><Initials>JW</Initials></Author><Author

--- a/tests/fixtures/vcr/test_pubmed_publications_identifier_fields.yaml
+++ b/tests/fixtures/vcr/test_pubmed_publications_identifier_fields.yaml
@@ -150,7 +150,7 @@ interactions:
         acid template.</ArticleTitle><Pagination><StartPage>541</StartPage><EndPage>544</EndPage><MedlinePgn>541-4</MedlinePgn></Pagination><AuthorList
         CompleteYN="Y"><Author ValidYN="Y"><LastName>Groneberg</LastName><ForeName>R
         D</ForeName><Initials>RD</Initials><AffiliationInfo><Affiliation>Rh&#xf4;ne-Poulenc
-        Rorer, SW8, 500 Arcola Road, Collegeville, Pennsylvania 19426, USA. robert.groneberg@rp-rorer.com</Affiliation></AffiliationInfo></Author><Author
+        Rorer, SW8, 500 Arcola Road, Collegeville, Pennsylvania 19426, USA. redacted@example.com</Affiliation></AffiliationInfo></Author><Author
         ValidYN="Y"><LastName>Burns</LastName><ForeName>C J</ForeName><Initials>CJ</Initials></Author><Author
         ValidYN="Y"><LastName>Morrissette</LastName><ForeName>M M</ForeName><Initials>MM</Initials></Author><Author
         ValidYN="Y"><LastName>Ullrich</LastName><ForeName>J W</ForeName><Initials>JW</Initials></Author><Author
@@ -691,7 +691,7 @@ interactions:
         acid template.</ArticleTitle><Pagination><StartPage>541</StartPage><EndPage>544</EndPage><MedlinePgn>541-4</MedlinePgn></Pagination><AuthorList
         CompleteYN="Y"><Author ValidYN="Y"><LastName>Groneberg</LastName><ForeName>R
         D</ForeName><Initials>RD</Initials><AffiliationInfo><Affiliation>Rh&#xf4;ne-Poulenc
-        Rorer, SW8, 500 Arcola Road, Collegeville, Pennsylvania 19426, USA. robert.groneberg@rp-rorer.com</Affiliation></AffiliationInfo></Author><Author
+        Rorer, SW8, 500 Arcola Road, Collegeville, Pennsylvania 19426, USA. redacted@example.com</Affiliation></AffiliationInfo></Author><Author
         ValidYN="Y"><LastName>Burns</LastName><ForeName>C J</ForeName><Initials>CJ</Initials></Author><Author
         ValidYN="Y"><LastName>Morrissette</LastName><ForeName>M M</ForeName><Initials>MM</Initials></Author><Author
         ValidYN="Y"><LastName>Ullrich</LastName><ForeName>J W</ForeName><Initials>JW</Initials></Author><Author

--- a/tests/fixtures/vcr/test_pubmed_publications_journal_fields.yaml
+++ b/tests/fixtures/vcr/test_pubmed_publications_journal_fields.yaml
@@ -150,7 +150,7 @@ interactions:
         acid template.</ArticleTitle><Pagination><StartPage>541</StartPage><EndPage>544</EndPage><MedlinePgn>541-4</MedlinePgn></Pagination><AuthorList
         CompleteYN="Y"><Author ValidYN="Y"><LastName>Groneberg</LastName><ForeName>R
         D</ForeName><Initials>RD</Initials><AffiliationInfo><Affiliation>Rh&#xf4;ne-Poulenc
-        Rorer, SW8, 500 Arcola Road, Collegeville, Pennsylvania 19426, USA. robert.groneberg@rp-rorer.com</Affiliation></AffiliationInfo></Author><Author
+        Rorer, SW8, 500 Arcola Road, Collegeville, Pennsylvania 19426, USA. redacted@example.com</Affiliation></AffiliationInfo></Author><Author
         ValidYN="Y"><LastName>Burns</LastName><ForeName>C J</ForeName><Initials>CJ</Initials></Author><Author
         ValidYN="Y"><LastName>Morrissette</LastName><ForeName>M M</ForeName><Initials>MM</Initials></Author><Author
         ValidYN="Y"><LastName>Ullrich</LastName><ForeName>J W</ForeName><Initials>JW</Initials></Author><Author
@@ -691,7 +691,7 @@ interactions:
         acid template.</ArticleTitle><Pagination><StartPage>541</StartPage><EndPage>544</EndPage><MedlinePgn>541-4</MedlinePgn></Pagination><AuthorList
         CompleteYN="Y"><Author ValidYN="Y"><LastName>Groneberg</LastName><ForeName>R
         D</ForeName><Initials>RD</Initials><AffiliationInfo><Affiliation>Rh&#xf4;ne-Poulenc
-        Rorer, SW8, 500 Arcola Road, Collegeville, Pennsylvania 19426, USA. robert.groneberg@rp-rorer.com</Affiliation></AffiliationInfo></Author><Author
+        Rorer, SW8, 500 Arcola Road, Collegeville, Pennsylvania 19426, USA. redacted@example.com</Affiliation></AffiliationInfo></Author><Author
         ValidYN="Y"><LastName>Burns</LastName><ForeName>C J</ForeName><Initials>CJ</Initials></Author><Author
         ValidYN="Y"><LastName>Morrissette</LastName><ForeName>M M</ForeName><Initials>MM</Initials></Author><Author
         ValidYN="Y"><LastName>Ullrich</LastName><ForeName>J W</ForeName><Initials>JW</Initials></Author><Author


### PR DESCRIPTION
Add email sanitization to _sanitize_response() function in VCR configuration to prevent leaking PII from API responses (e.g., author emails from PubMed).

Changes:
- Handle string, bytes, and dict body formats in response sanitization
- Sanitize existing VCR cassettes containing real email addresses
- Replace real emails with redacted@example.com placeholder

Addresses REQ-SECRET-004 (PII sanitization in VCR cassettes)