### PR TITLE
Fix failing validation and architecture tests

### DIFF
--- a/tests/architecture/test_no_fstring_in_logs.py
+++ b/tests/architecture/test_no_fstring_in_logs.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-import pytest
-
 SRC_DIR = Path("src/bioetl")
 
 # Files where f-string in docstrings is acceptable (documentation examples)

--- a/tests/unit/infrastructure/storage/test_silver_writer.py
+++ b/tests/unit/infrastructure/storage/test_silver_writer.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/unit/infrastructure/test_config_dynamic.py
+++ b/tests/unit/infrastructure/test_config_dynamic.py
@@ -6,6 +6,8 @@ import yaml
 from bioetl.infrastructure.config import load_pipeline_config
 from bioetl.infrastructure.config_loader import (
     load_pipeline_config as load_pipeline_config_cached,
+)
+from bioetl.infrastructure.config_loader import (
     load_source_config,
 )
 from bioetl.infrastructure.schemas.pipeline_config import PipelineYamlConfig

--- a/tests/unit/interfaces/test_cli_run_all_vacuum_formatters.py
+++ b/tests/unit/interfaces/test_cli_run_all_vacuum_formatters.py
@@ -1247,9 +1247,7 @@ class TestRunAllCommandExceptions:
         assert "Unexpected error" in result.output or "error" in result.output.lower()
 
     @patch("bioetl.interfaces.cli.commands.run_all.asyncio.run")
-    def test_run_all_with_debug_flag(
-        self, mock_asyncio_run, cli_runner, mock_registry
-    ):
+    def test_run_all_with_debug_flag(self, mock_asyncio_run, cli_runner, mock_registry):
         """Test run-all with --debug flag."""
         mock_asyncio_run.return_value = BatchRunResult(
             total=2, succeeded=2, failed=0, skipped=0
@@ -1264,8 +1262,6 @@ class TestRunAllCommandExceptions:
             )
 
         assert result.exit_code == 0
-        # Verify options include DEBUG log level
-        call_args = mock_asyncio_run.call_args
         # The async function is called, check that it was called
         mock_asyncio_run.assert_called_once()
 


### PR DESCRIPTION
- Remove unused pytest import in test_no_fstring_in_logs.py
- Remove unused asyncio import in test_silver_writer.py
- Remove unused call_args variable in test_cli_run_all_vacuum_formatters.py
- Fix isort import grouping in test_config_dynamic.py
- Fix Black formatting in test_cli_run_all_vacuum_formatters.py