### PR TITLE
Run tests and fix errors

### DIFF
--- a/tests/architecture/test_no_fstring_in_logs.py
+++ b/tests/architecture/test_no_fstring_in_logs.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-import pytest
-
 SRC_DIR = Path("src/bioetl")
 
 # Files where f-string in docstrings is acceptable (documentation examples)


### PR DESCRIPTION
Remove unused pytest import in test_no_fstring_in_logs.py to fix ruff F401 linting error.