### PR TITLE
Implement ChEMBL CellLine and CompoundRecord pipelines

### DIFF
--- a/src/bioetl/application/pipelines/chembl/cell_line_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/cell_line_transformer.py
@@ -63,8 +63,11 @@ class CellLineTransformer(BaseChemblTransformer):
             "cell_source_tax_id": validate_positive_int(
                 record.get("cell_source_tax_id")
             ),
+            # Cell type classification
+            "cell_type": normalize_to_string(record.get("cell_type")),
             # External identifiers (strip, NULL if empty) using domain normalization
             "cellosaurus_id": normalize_to_string(record.get("cellosaurus_id")),
+            "clo_id": normalize_to_string(record.get("clo_id")),
             "cl_lincs_id": normalize_to_string(record.get("cl_lincs_id")),
             "efo_id": normalize_to_string(record.get("efo_id")),
         }

--- a/src/bioetl/domain/entities/chembl_structures.py
+++ b/src/bioetl/domain/entities/chembl_structures.py
@@ -166,8 +166,12 @@ class CellLine(BaseEntity):
     cell_source_organism: str | None = None
     cell_source_tax_id: int | None = None
 
+    # Cell type classification (API-OPTIONAL)
+    cell_type: str | None = None
+
     # External identifiers (API-OPTIONAL)
     cellosaurus_id: str | None = None
+    clo_id: str | None = None
     cl_lincs_id: str | None = None
     efo_id: str | None = None
 

--- a/src/bioetl/domain/schemas/chembl/cell_line.py
+++ b/src/bioetl/domain/schemas/chembl/cell_line.py
@@ -52,11 +52,22 @@ class CellLineSchema(ETLRecordSchema):
         description="NCBI Taxonomy ID for source organism.",
     )
 
+    # === Cell Type Classification ===
+    cell_type: Series[str] | None = pa.Field(
+        nullable=True,
+        description="Cell type classification (e.g., Cancer cell line).",
+    )
+
     # === External Identifiers ===
     cellosaurus_id: Series[str] | None = pa.Field(
         nullable=True,
         str_matches=r"^CVCL_[A-Z0-9]+$",
         description="Cellosaurus ID (external reference).",
+    )
+    clo_id: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^CLO_\d+$",
+        description="Cell Line Ontology ID.",
     )
     cl_lincs_id: Series[str] | None = pa.Field(
         nullable=True,

--- a/src/bioetl/domain/schemas/chembl/compound_record.py
+++ b/src/bioetl/domain/schemas/chembl/compound_record.py
@@ -1,11 +1,10 @@
 """Pandera schema for ChEMBL Compound Record entity.
 
-Aligned with RULES.md v5.0 and ChEMBL 34 schema.
+Aligned with RULES.md v5.0 and ChEMBL 34 API schema.
+Source: ChEMBL REST API /compound_record endpoint.
 """
 
 from __future__ import annotations
-
-from datetime import date
 
 import pandera as pa
 from pandera.typing import Series
@@ -14,64 +13,58 @@ from bioetl.domain.schemas.base import ETLRecordSchema
 
 
 class CompoundRecordSchema(ETLRecordSchema):
-    """Compound Record validation schema for Silver layer."""
+    """Compound Record validation schema for Silver layer.
+
+    Compound records link molecules to documents. Contains the original
+    compound name as it appears in the publication.
+
+    Relationships:
+    - M:1 → Molecule (molecule_chembl_id)
+    - M:1 → Publication (document_chembl_id)
+    - M:1 → Source (src_id)
+    """
 
     # === Primary Key ===
-    record_id: Series[int] = pa.Field(nullable=False, description="Primary key.")
+    record_id: Series[int] = pa.Field(
+        nullable=False,
+        ge=1,
+        description="ChEMBL record ID (PK).",
+    )
 
     # === Foreign Keys ===
-    molregno: Series[int] | None = pa.Field(
-        nullable=True, description="FK to molecule."
+    molecule_chembl_id: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^CHEMBL\d+$",
+        description="FK → Molecule.",
     )
-    doc_id: Series[int] | None = pa.Field(nullable=True, description="FK to document.")
+    document_chembl_id: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^CHEMBL\d+$",
+        description="FK → Publication.",
+    )
+    src_id: Series[int] = pa.Field(
+        nullable=False,
+        ge=1,
+        description="FK → Source (data source).",
+    )
 
-    # === Identifiers ===
+    # === Source-specific Identifiers ===
     compound_key: Series[str] | None = pa.Field(
-        nullable=True, description="Compound key."
+        nullable=True,
+        description="Original compound key in source document.",
     )
     compound_name: Series[str] | None = pa.Field(
-        nullable=True, description="Compound name."
+        nullable=True,
+        description="Original compound name in source document.",
     )
-    src_id: Series[int] | None = pa.Field(nullable=True, description="Source ID.")
     src_compound_id: Series[str] | None = pa.Field(
-        nullable=True, description="Source compound ID."
-    )
-    src_compound_id_version: Series[int] | None = pa.Field(
-        nullable=True, description="Source compound ID version."
-    )
-
-    # === Metadata ===
-    filename: Series[str] | None = pa.Field(nullable=True, description="Filename.")
-    load_date: Series[date] | None = pa.Field(nullable=True, description="Load date.")
-    ridx: Series[str] | None = pa.Field(nullable=True, description="Record index.")
-    cidx: Series[str] | None = pa.Field(nullable=True, description="Compound index.")
-    molregno_comment: Series[str] | None = pa.Field(
-        nullable=True, description="Molregno comment."
-    )
-    molregno_sv: Series[float] | None = pa.Field(
-        nullable=True, description="Molregno SV."
-    )
-
-    # === Flags ===
-    removed: Series[int] | None = pa.Field(
         nullable=True,
-        isin=[0, 1],
-        description="Removed flag.",
-    )
-    curated: Series[int] | None = pa.Field(
-        nullable=True,
-        isin=[0, 1],
-        description="Curated flag.",
-    )
-    molregno_fixed: Series[int] | None = pa.Field(
-        nullable=True,
-        isin=[0, 1],
-        description="Molregno fixed flag.",
+        description="Compound ID in original data source.",
     )
 
     class Config:
         """Pandera configuration."""
 
         strict = True
-        ordered = True
+        ordered = False
         coerce = True

--- a/tests/unit/application/pipelines/test_cell_line_transformer.py
+++ b/tests/unit/application/pipelines/test_cell_line_transformer.py
@@ -46,7 +46,9 @@ class TestCellLineTransformer:
             "cell_source_tissue": "Cervix",
             "cell_source_organism": "Homo sapiens",
             "cell_source_tax_id": 9606,
+            "cell_type": "Cancer cell line",
             "cellosaurus_id": "CVCL_0030",
+            "clo_id": "CLO_0003684",
             "cl_lincs_id": "LCL-1234",
             "efo_id": "EFO_0001185",
         }
@@ -60,7 +62,9 @@ class TestCellLineTransformer:
         assert result["cell_source_tissue"] == "Cervix"
         assert result["cell_source_organism"] == "Homo sapiens"
         assert result["cell_source_tax_id"] == 9606
+        assert result["cell_type"] == "Cancer cell line"
         assert result["cellosaurus_id"] == "CVCL_0030"
+        assert result["clo_id"] == "CLO_0003684"
         assert result["cl_lincs_id"] == "LCL-1234"
         assert result["efo_id"] == "EFO_0001185"
         assert "entity_id" in result
@@ -96,7 +100,9 @@ class TestCellLineTransformer:
         assert result["cell_source_tissue"] is None
         assert result["cell_source_organism"] is None
         assert result["cell_source_tax_id"] is None
+        assert result["cell_type"] is None
         assert result["cellosaurus_id"] is None
+        assert result["clo_id"] is None
         assert result["cl_lincs_id"] is None
         assert result["efo_id"] is None
 
@@ -122,6 +128,7 @@ class TestCellLineTransformer:
             "cell_chembl_id": "CHEMBL3308376",
             "cell_name": "HeLa",
             "cellosaurus_id": "",
+            "clo_id": "   ",
             "cl_lincs_id": "   ",
             "efo_id": None,
         }
@@ -130,6 +137,7 @@ class TestCellLineTransformer:
 
         assert result is not None
         assert result["cellosaurus_id"] is None
+        assert result["clo_id"] is None
         assert result["cl_lincs_id"] is None
         assert result["efo_id"] is None
 
@@ -142,6 +150,7 @@ class TestCellLineTransformer:
             "cell_chembl_id": "CHEMBL3308376",
             "cell_name": "HeLa",
             "cellosaurus_id": "  CVCL_0030  ",
+            "clo_id": "\tCLO_0003684\n",
             "cl_lincs_id": "\tLCL-1234\n",
         }
 
@@ -149,6 +158,7 @@ class TestCellLineTransformer:
 
         assert result is not None
         assert result["cellosaurus_id"] == "CVCL_0030"
+        assert result["clo_id"] == "CLO_0003684"
         assert result["cl_lincs_id"] == "LCL-1234"
 
     @pytest.mark.asyncio
@@ -265,7 +275,9 @@ class TestCellLineTransformer:
             "cell_source_tissue": None,
             "cell_source_organism": None,
             "cell_source_tax_id": None,
+            "cell_type": None,
             "cellosaurus_id": None,
+            "clo_id": None,
             "cl_lincs_id": None,
             "efo_id": None,
         }
@@ -277,6 +289,8 @@ class TestCellLineTransformer:
         assert result["cell_source_tissue"] is None
         assert result["cell_source_organism"] is None
         assert result["cell_source_tax_id"] is None
+        assert result["cell_type"] is None
         assert result["cellosaurus_id"] is None
+        assert result["clo_id"] is None
         assert result["cl_lincs_id"] is None
         assert result["efo_id"] is None


### PR DESCRIPTION
…ndRecord schema

CellLine:
- Added cell_type field (cell type classification)
- Added clo_id field (Cell Line Ontology ID)
- Updated entity, schema, transformer, and tests

CompoundRecord:
- Fixed schema to use API field names (molecule_chembl_id, document_chembl_id) instead of database column names (molregno, doc_id)
- Aligned schema with entity and transformer