### PR TITLE
Run ChEMBL activity data pipeline

### DIFF
--- a/src/bioetl/infrastructure/schemas/source_config.py
+++ b/src/bioetl/infrastructure/schemas/source_config.py
@@ -153,6 +153,14 @@ class SourceYamlConfig(BaseModel):
     source: SourceSectionConfig = Field(default_factory=SourceSectionConfig)
 
     @property
+    def provider_config(self) -> ProviderConfigYaml:
+        """Get provider config from nested source config.
+
+        Convenience property for consistent API access.
+        """
+        return self.source.provider_config
+
+    @property
     def provider(self) -> str:
         """Get provider name from nested config."""
         return self.source.provider_config.provider


### PR DESCRIPTION
Add convenience property `provider_config` to SourceYamlConfig that returns `self.source.provider_config`. This makes the API consistent with other convenience properties already defined on the class (provider, rate_limit, batch_size, etc.) and fixes AttributeError when code accesses .provider_config directly on SourceYamlConfig.