### PR TITLE
Fix circuit breaker degradation test failure

### DIFF
--- a/tests/unit/infrastructure/test_circuit_breaker_degradation.py
+++ b/tests/unit/infrastructure/test_circuit_breaker_degradation.py
@@ -552,7 +552,9 @@ class TestTimeoutBoundaryConditions:
     @pytest.mark.unit
     async def test_request_just_before_timeout(self) -> None:
         """Timeout: Request just before recovery timeout should be blocked."""
-        recovery_timeout = 0.2
+        # Use larger timeout (1s) for robustness against timer precision variance
+        # (especially on Windows where timer resolution is ~15.6ms)
+        recovery_timeout = 1.0
         cb = CircuitBreaker(
             provider="test",
             failure_threshold=2,
@@ -567,8 +569,8 @@ class TestTimeoutBoundaryConditions:
             with pytest.raises(RuntimeError):
                 await cb.call(fail)
 
-        # Wait slightly less than recovery timeout
-        await asyncio.sleep(recovery_timeout * 0.5)
+        # Wait 25% of recovery timeout (250ms) - far from boundary
+        await asyncio.sleep(recovery_timeout * 0.25)
 
         # Should still be blocked
         async def probe() -> str:


### PR DESCRIPTION
Increase recovery_timeout from 0.2s to 1.0s and reduce sleep from 50% to 25% of timeout in test_request_just_before_timeout. This prevents flaky failures on Windows where timer resolution (~15.6ms) can cause asyncio.sleep() to overshoot significantly, potentially exceeding the recovery timeout.