### PR TITLE
Fix code formatting architecture tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,39 @@
+# Auto detect text files and normalize line endings to LF
+* text=auto eol=lf
+
+# Python files must use LF line endings
+*.py text eol=lf
+*.pyi text eol=lf
+
+# Configuration files
+*.toml text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.rst text eol=lf
+*.txt text eol=lf
+
+# Shell scripts
+*.sh text eol=lf
+
+# Windows batch files (keep CRLF)
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Binary files (no conversion)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.whl binary
+*.gz binary
+*.zip binary
+
+# Jupyter notebooks
+*.ipynb text eol=lf
+
+# VCR cassettes
+*.json text eol=lf

--- a/tests/architecture/test_code_formatting.py
+++ b/tests/architecture/test_code_formatting.py
@@ -6,6 +6,7 @@ REQ-ARCH-051: Consistent import ordering via isort.
 
 from __future__ import annotations
 
+import platform
 import subprocess
 import sys
 from importlib.util import find_spec
@@ -16,6 +17,18 @@ import pytest
 _black_available = find_spec("black") is not None
 # Check if isort is available
 _isort_available = find_spec("isort") is not None
+
+# Platform-specific hints for line ending issues
+_LINE_ENDING_HINT = (
+    (
+        "\n\nOn Windows, line ending issues may occur. Try:\n"
+        "  git add --renormalize .\n"
+        "  git checkout -- .\n"
+        "Or run `black` to fix formatting."
+    )
+    if platform.system() == "Windows"
+    else ""
+)
 
 
 class TestCodeFormatting:
@@ -37,7 +50,7 @@ class TestCodeFormatting:
         assert result.returncode == 0, (
             "Code formatting issues found in src/:\n"
             f"{result.stdout}\n{result.stderr}\n\n"
-            "Run `black src` to fix formatting issues."
+            f"Run `black src` to fix formatting issues.{_LINE_ENDING_HINT}"
         )
 
     @pytest.mark.slow
@@ -56,7 +69,7 @@ class TestCodeFormatting:
         assert result.returncode == 0, (
             "Code formatting issues found in tests/:\n"
             f"{result.stdout}\n{result.stderr}\n\n"
-            "Run `black tests` to fix formatting issues."
+            f"Run `black tests` to fix formatting issues.{_LINE_ENDING_HINT}"
         )
 
     @pytest.mark.slow


### PR DESCRIPTION
- Add .gitattributes to normalize line endings (LF for text files)
- Add Windows-specific hints when formatting tests fail, suggesting git add --renormalize to fix line ending issues

This addresses test failures on Windows where CRLF line endings can cause black formatting checks to fail unexpectedly.