### PR TITLE
Fix failing lint and type check tests

### DIFF
--- a/tests/unit/interfaces/cli/commands/test_quarantine.py
+++ b/tests/unit/interfaces/cli/commands/test_quarantine.py
@@ -6,7 +6,6 @@ Tests quarantine management CLI commands including inspect, stats, replay, purge
 from __future__ import annotations
 
 import json
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest


### PR DESCRIPTION
Removes unused `typing.Any` import that was causing ruff F401 lint failure.