### PR TITLE
Fix Mermaid diagram validation in docs

### DIFF
--- a/docs/02-architecture/diagrams/14-provider-health-states.mermaid
+++ b/docs/02-architecture/diagrams/14-provider-health-states.mermaid
@@ -88,26 +88,26 @@ stateDiagram-v2
 
     state ProviderSpecificBehavior {
         state "ChEMBL" as ChEMBL {
-            ChEMBL: Rate Limit: None
-            ChEMBL: Health: /status.json
-            ChEMBL: Batch: 1000 records
+            ChEMBL: Rate Limit = None
+            ChEMBL: Health = /status.json
+            ChEMBL: Batch = 1000 records
         }
 
         state "PubChem" as PubChem {
-            PubChem: Rate Limit: 5 req/sec
-            PubChem: Health: compound probe
-            PubChem: Batch: 100 compounds
+            PubChem: Rate Limit = 5 req/sec
+            PubChem: Health = compound probe
+            PubChem: Batch = 100 compounds
         }
 
         state "UniProt" as UniProt {
-            UniProt: Rate Limit: 100 req/sec (API key)
-            UniProt: Health: search probe
-            UniProt: Batch: 500 proteins
+            UniProt: Rate Limit = 100 req/sec (API key)
+            UniProt: Health = search probe
+            UniProt: Batch = 500 proteins
         }
 
         state "PubMed" as PubMed {
-            PubMed: Rate Limit: 3 req/sec (10 w/ key)
-            PubMed: Health: efetch probe
-            PubMed: Batch: 200 articles
+            PubMed: Rate Limit = 3 req/sec (10 w/ key)
+            PubMed: Health = efetch probe
+            PubMed: Batch = 200 articles
         }
     }

--- a/docs/02-architecture/diagrams/20-quarantine-record-states.mermaid
+++ b/docs/02-architecture/diagrams/20-quarantine-record-states.mermaid
@@ -10,12 +10,12 @@ stateDiagram-v2
 
         state "Record Details" as ND {
             ND1: ingestion_ts
-            ND2: pipeline: str
-            ND3: error_code: str
-            ND4: error_message: str
-            ND5: payload: str (truncated 64KB)
-            ND6: bronze_batch_id: UUID
-            ND7: bronze_file_uri: str
+            ND2: pipeline (str)
+            ND3: error_code (str)
+            ND4: error_message (str)
+            ND5: payload (str, truncated 64KB)
+            ND6: bronze_batch_id (UUID)
+            ND7: bronze_file_uri (str)
         }
     }
 
@@ -77,7 +77,7 @@ stateDiagram-v2
         ━━━━━━━━━━━━━━━━━━━━━━━━
         1. make quarantine-inspect
         2. Review error patterns
-        3. Decide: IGNORE or FIX
+        3. Decide IGNORE or FIX
         4. Document decision
 
         Weekly review recommended
@@ -110,8 +110,8 @@ stateDiagram-v2
 
     state QuarantineStats {
         state "Metrics Tracked" as MT {
-            M1: quarantine_records_total{pipeline}
-            M2: quarantine_by_error_code{code}
+            M1: quarantine_records_total
+            M2: quarantine_by_error_code
             M3: quarantine_age_days_histogram
             M4: reprocess_success_rate
         }

--- a/docs/02-architecture/diagrams/22-client-api-request-sequence.mermaid
+++ b/docs/02-architecture/diagrams/22-client-api-request-sequence.mermaid
@@ -37,16 +37,11 @@ sequenceDiagram
 
         loop Retry loop (max 3 attempts)
             Adapter->>HTTP: request(method="GET", url="/activities", params)
-            activate HTTP
-
             HTTP->>API: GET /chembl/api/data/activity.json?...
-            activate API
 
             alt 200 OK
                 API-->>HTTP: JSON response
-                deactivate API
                 HTTP-->>Adapter: Response(status=200, data)
-                deactivate HTTP
 
                 Adapter->>CB: record_success()
                 Note right of CB: failure_count = 0
@@ -55,18 +50,14 @@ sequenceDiagram
 
             else 429 Rate Limited
                 API-->>HTTP: 429 + Retry-After header
-                deactivate API
                 HTTP-->>Adapter: Response(status=429)
-                deactivate HTTP
 
                 Note right of Adapter: Extract Retry-After value<br/>Default: 60 seconds
                 Adapter->>Adapter: await asyncio.sleep(retry_after)
 
             else 5xx Server Error (500, 502, 503, 504)
                 API-->>HTTP: 5xx error
-                deactivate API
                 HTTP-->>Adapter: Response(status=5xx)
-                deactivate HTTP
 
                 Adapter->>CB: record_failure()
                 Note right of CB: failure_count += 1
@@ -78,7 +69,6 @@ sequenceDiagram
 
             else Connection Error / Timeout
                 HTTP-->>Adapter: raise ConnectionError
-                deactivate HTTP
 
                 Adapter->>CB: record_failure()
                 Adapter->>Adapter: await asyncio.sleep(delay)


### PR DESCRIPTION
- 14-provider-health-states.mermaid: Replace colons with equals signs in state descriptions to avoid parse errors with multiple colons
- 20-quarantine-record-states.mermaid: Use parentheses instead of colons for type annotations in state descriptions
- 22-client-api-request-sequence.mermaid: Remove activate/deactivate for API and HTTP participants inside alt blocks to fix inactive participant errors

These changes fix mermaid-cli validation failures in CI.