### PR TITLE
Fix Mermaid diagram validation in docs

### DIFF
--- a/docs/02-architecture/diagrams/05-locking.mermaid
+++ b/docs/02-architecture/diagrams/05-locking.mermaid
@@ -5,8 +5,8 @@ sequenceDiagram
     Note right of Worker: Local-Only Deployment (ADR-010):<br/>Используется MemoryLock для локального<br/>процесса. Redis-блокировки отложены<br/>для будущего распределённого развёртывания.
 
     participant Worker as Pipeline Worker
-    participant LockManager as MemoryLock<br/>(In-Process)
-    participant Lake as Data Lake<br/>(Local FS)
+    participant LockManager as MemoryLock (In-Process)
+    participant Lake as Data Lake (Local FS)
 
     rect rgb(240, 248, 255)
         Note over Worker,Lake: == Incremental Run ==

--- a/docs/02-architecture/diagrams/11-lock-acquisition-sequence.mermaid
+++ b/docs/02-architecture/diagrams/11-lock-acquisition-sequence.mermaid
@@ -1,8 +1,8 @@
 %%{init: {'theme': 'neutral', 'themeVariables': {'fontFamily': 'Inter, system-ui', 'lineWidth': '2'}}}%%
 sequenceDiagram
     autonumber
-    participant WorkerA as Worker A<br/>(owner=worker_a_uuid)
-    participant WorkerB as Worker B<br/>(owner=worker_b_uuid)
+    participant WorkerA as Worker A (owner_a_uuid)
+    participant WorkerB as Worker B (owner_b_uuid)
     participant Lock as MemoryLock
     participant HeartbeatA as Heartbeat Thread A
     participant Storage as DeltaWriter

--- a/docs/02-architecture/diagrams/22-client-api-request-sequence.mermaid
+++ b/docs/02-architecture/diagrams/22-client-api-request-sequence.mermaid
@@ -4,7 +4,7 @@ sequenceDiagram
     participant Executor as PipelineExecutor
     participant Adapter as ChemblAdapter
     participant CB as CircuitBreaker
-    participant RL as TokenBucket<br/>(RateLimiter)
+    participant RL as TokenBucket (RateLimiter)
     participant HTTP as UnifiedHTTPClient
     participant API as ChEMBL API
 


### PR DESCRIPTION
Mermaid sequence diagram participant aliases do not support HTML tags. Replaced <br/> with plain spaces in participant definitions.

Affected diagrams:
- 05-locking.mermaid
- 11-lock-acquisition-sequence.mermaid
- 22-client-api-request-sequence.mermaid