### PR TITLE
Fix duplication and complexity check failures

### DIFF
--- a/src/bioetl/composition/builders.py
+++ b/src/bioetl/composition/builders.py
@@ -20,6 +20,56 @@ class FilterConfigBuilder:
     """Builder for InputFilterConfig."""
 
     @staticmethod
+    def _is_filter_enabled(
+        yaml_filter: YamlInputFilter, cli_csv: str | None, test_mode: bool
+    ) -> bool:
+        """Determine if filtering should be enabled."""
+        if test_mode:
+            return bool(cli_csv)
+        return bool(cli_csv) or yaml_filter.enabled
+
+    @staticmethod
+    def _build_multi_column_config(
+        yaml_filter: YamlInputFilter, effective_csv: str
+    ) -> InputFilterConfig:
+        """Build config for multi-column filtering mode.
+
+        Caller must ensure yaml_filter.columns is not None.
+        """
+        assert yaml_filter.columns is not None  # Guaranteed by caller check
+        domain_columns = tuple(
+            FilterColumn(
+                column_name=col.column_name,
+                filter_field=col.filter_field,
+            )
+            for col in yaml_filter.columns
+        )
+        return InputFilterConfig(
+            enabled=True,
+            source_path=effective_csv,
+            columns=domain_columns,
+            batch_size=yaml_filter.batch_size,
+        )
+
+    @staticmethod
+    def _build_single_column_config(
+        yaml_filter: YamlInputFilter,
+        effective_csv: str,
+        cli_column: str | None,
+        cli_field: str | None,
+    ) -> InputFilterConfig:
+        """Build config for single-column filtering mode."""
+        effective_column = cli_column or yaml_filter.column_name
+        effective_field = cli_field or yaml_filter.filter_field
+        return InputFilterConfig(
+            enabled=True,
+            source_path=effective_csv,
+            column_name=effective_column,
+            filter_field=effective_field,
+            batch_size=yaml_filter.batch_size,
+        )
+
+    @staticmethod
     def build(
         yaml_filter: YamlInputFilter,
         cli_csv: str | None = None,
@@ -52,47 +102,20 @@ class FilterConfigBuilder:
         Returns:
             Configured InputFilterConfig or None if filtering is disabled
         """
-        # In test mode, only enable filter if CLI explicitly provides --input-csv
-        # This allows E2E tests to run without actual filter CSV files
-        if test_mode:
-            filter_enabled = bool(cli_csv)
-        else:
-            # Enable filter if: CLI provides --input-csv OR config has enabled=true
-            filter_enabled = bool(cli_csv) or yaml_filter.enabled
-
-        if not filter_enabled:
+        if not FilterConfigBuilder._is_filter_enabled(yaml_filter, cli_csv, test_mode):
             return None
 
-        # Determine effective CSV path
         effective_csv = cli_csv or yaml_filter.source_path
         if not effective_csv:
             return None
 
-        # Check for multi-column mode (columns list in YAML)
+        # Multi-column mode: use YAML config as-is
         if yaml_filter.columns and not cli_csv:
-            # Multi-column mode: use YAML config as-is
-            domain_columns = tuple(
-                FilterColumn(
-                    column_name=col.column_name,
-                    filter_field=col.filter_field,
-                )
-                for col in yaml_filter.columns
-            )
-            return InputFilterConfig(
-                enabled=True,
-                source_path=effective_csv,
-                columns=domain_columns,
-                batch_size=yaml_filter.batch_size,
+            return FilterConfigBuilder._build_multi_column_config(
+                yaml_filter, effective_csv
             )
 
         # Single-column mode: CLI > YAML config
-        effective_column = cli_column or yaml_filter.column_name
-        effective_field = cli_field or yaml_filter.filter_field
-
-        return InputFilterConfig(
-            enabled=True,
-            source_path=effective_csv,
-            column_name=effective_column,
-            filter_field=effective_field,
-            batch_size=yaml_filter.batch_size,
+        return FilterConfigBuilder._build_single_column_config(
+            yaml_filter, effective_csv, cli_column, cli_field
         )

--- a/src/bioetl/infrastructure/adapters/chembl/client.py
+++ b/src/bioetl/infrastructure/adapters/chembl/client.py
@@ -181,6 +181,38 @@ class ChemblAdapter(BaseHttpAdapter):
         for i in range(0, len(ids), batch_size):
             yield ids[i : i + batch_size]
 
+    def _build_filter_in_params(
+        self, filters: dict[str, list[str]]
+    ) -> dict[str, str]:
+        """Build __in filter parameters for multi-field filtering."""
+        return {
+            f"{filter_field}__in": ",".join(ids)
+            for filter_field, ids in filters.items()
+            if ids
+        }
+
+    def _is_duplicate_record(
+        self,
+        record: dict[str, Any],
+        pk_field: str,
+        seen_ids: set[str],
+        entity_type: str,
+    ) -> bool:
+        """Check if record is duplicate and add to seen set if not."""
+        record_id = str(record.get(pk_field, ""))
+        if not record_id:
+            return False
+        if record_id in seen_ids:
+            self.logger.debug(
+                "skipping_duplicate_record",
+                entity_type=entity_type,
+                pk_field=pk_field,
+                record_id=record_id,
+            )
+            return True
+        seen_ids.add(record_id)
+        return False
+
     async def _fetch_page(
         self, url: str, params: dict[str, Any], entity_type: str
     ) -> tuple[list[dict[str, Any]], bool]:
@@ -451,20 +483,15 @@ class ChemblAdapter(BaseHttpAdapter):
             Dictionary records matching ALL filter criteria
 
         """
+        filter_params = self._build_filter_in_params(filters)
+        if not filter_params:
+            return
+
         url = self._mapper.get_resource_url(entity_type)
+        pk_field = self._mapper.get_primary_key_field(entity_type)
         offset = 0
         total_fetched = 0
         seen_ids: set[str] = set()
-        pk_field = self._mapper.get_primary_key_field(entity_type)
-
-        # Build __in params for all filter fields
-        filter_params: dict[str, str] = {}
-        for filter_field, ids in filters.items():
-            if ids:
-                filter_params[f"{filter_field}__in"] = ",".join(ids)
-
-        if not filter_params:
-            return
 
         while True:
             params = self._build_params(offset)
@@ -475,17 +502,8 @@ class ChemblAdapter(BaseHttpAdapter):
                 break
 
             for record in records:
-                record_id = str(record.get(pk_field, ""))
-                if record_id and record_id in seen_ids:
-                    self.logger.debug(
-                        "skipping_duplicate_record",
-                        entity_type=entity_type,
-                        pk_field=pk_field,
-                        record_id=record_id,
-                    )
+                if self._is_duplicate_record(record, pk_field, seen_ids, entity_type):
                     continue
-                if record_id:
-                    seen_ids.add(record_id)
                 yield record
                 total_fetched += 1
                 if limit and total_fetched >= limit:

--- a/src/bioetl/infrastructure/adapters/input/csv_filter_reader.py
+++ b/src/bioetl/infrastructure/adapters/input/csv_filter_reader.py
@@ -71,6 +71,28 @@ class CsvFilterReader:
         duplicate_count = total_count - unique_count
         return unique_ids, unique_count, duplicate_count, duplicates
 
+    def _extract_column_ids_map(
+        self, df: pl.DataFrame, columns: list[FilterColumn]
+    ) -> dict[str, tuple[str, ...]]:
+        """Extract unique IDs per column for server-side filtering."""
+        return {
+            col.filter_field: tuple(
+                sorted(set(self._extract_column_ids(df, col.column_name)))
+            )
+            for col in columns
+        }
+
+    def _build_valid_combinations(
+        self, df: pl.DataFrame, column_names: list[str]
+    ) -> set[tuple[str, ...]]:
+        """Build valid row-wise combinations for client-side filtering."""
+        combinations: set[tuple[str, ...]] = set()
+        for row in df.select(column_names).iter_rows():
+            combo = tuple(str(val).strip() if val is not None else "" for val in row)
+            if all(combo):  # Skip rows with empty values
+                combinations.add(combo)
+        return combinations
+
     async def load_filter_ids(
         self, source_path: str, column_name: str
     ) -> FilterLoadResult:
@@ -100,6 +122,30 @@ class CsvFilterReader:
             duplicates=duplicates,
         )
 
+    def _log_multi_column_filter(
+        self,
+        source_path: str,
+        columns: list[FilterColumn],
+        filter_fields: tuple[str, ...],
+        total_count: int,
+        valid_combinations: set[tuple[str, ...]],
+        column_ids: dict[str, tuple[str, ...]],
+    ) -> None:
+        """Log multi-column filter load statistics."""
+        if not self._logger:
+            return
+        self._logger.info(
+            "multi_column_filter_loaded",
+            source_path=source_path,
+            columns=[col.column_name for col in columns],
+            filter_fields=list(filter_fields),
+            total_rows=total_count,
+            valid_combinations=len(valid_combinations),
+            unique_ids_per_field={
+                field: len(ids) for field, ids in column_ids.items()
+            },
+        )
+
     async def load_multi_column_filter(
         self,
         source_path: str,
@@ -118,40 +164,21 @@ class CsvFilterReader:
             FilterLoadResult with column_ids and valid_combinations.
         """
         df = self._read_csv_dataframe(source_path)
+        column_ids = self._extract_column_ids_map(df, columns)
 
-        # Extract unique IDs per column for server-side filtering
-        column_ids: dict[str, tuple[str, ...]] = {}
-        for col in columns:
-            ids = self._extract_column_ids(df, col.column_name)
-            column_ids[col.filter_field] = tuple(sorted(set(ids)))
-
-        # Extract exact row-wise combinations for client-side filtering
         column_names = [col.column_name for col in columns]
         filter_fields = tuple(col.filter_field for col in columns)
-
-        # Build valid combinations from each row
-        valid_combinations: set[tuple[str, ...]] = set()
-        for row in df.select(column_names).iter_rows():
-            # Convert all values to strings and strip whitespace
-            combo = tuple(str(val).strip() if val is not None else "" for val in row)
-            # Skip rows with empty values
-            if all(combo):
-                valid_combinations.add(combo)
-
+        valid_combinations = self._build_valid_combinations(df, column_names)
         total_count = len(df)
 
-        if self._logger:
-            self._logger.info(
-                "multi_column_filter_loaded",
-                source_path=source_path,
-                columns=[col.column_name for col in columns],
-                filter_fields=list(filter_fields),
-                total_rows=total_count,
-                valid_combinations=len(valid_combinations),
-                unique_ids_per_field={
-                    field: len(ids) for field, ids in column_ids.items()
-                },
-            )
+        self._log_multi_column_filter(
+            source_path,
+            columns,
+            filter_fields,
+            total_count,
+            valid_combinations,
+            column_ids,
+        )
 
         return FilterLoadResult(
             total_count=total_count,


### PR DESCRIPTION
Extract helper methods to reduce complexity below threshold (CC ≤ 10):

- builders.py: FilterConfigBuilder.build() CC=11→6
  - Extract _is_filter_enabled(), _build_multi_column_config(), _build_single_column_config()

- chembl/client.py: fetch_multi_filtered() CC=13→9
  - Extract _build_filter_in_params(), _is_duplicate_record()

- csv_filter_reader.py: load_multi_column_filter() CC=11→3
  - Extract _extract_column_ids_map(), _build_valid_combinations(), _log_multi_column_filter()