### PR TITLE
Extract terms from document records

### DIFF
--- a/src/bioetl/application/core/document_term_data_source.py
+++ b/src/bioetl/application/core/document_term_data_source.py
@@ -1,0 +1,313 @@
+"""Document Term Data Source wrapper.
+
+Wraps a DataSourcePort to extract terms from ChEMBL document records.
+This is a derived entity pattern - document_term entities are extracted
+from the nested mesh_terms and keywords fields in document records.
+
+Architecture:
+    ChEMBL API (document endpoint)
+           ↓
+    DocumentTermDataSource (wrapper)
+      - fetch("document_term") → wrapped.fetch("document")
+      - transforms each document → yields term records
+           ↓
+    Pipeline receives term records
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING, Any, Self
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from bioetl.domain.ports import DataSourcePort
+    from bioetl.domain.types import HealthStatus
+
+
+class DocumentTermDataSource:
+    """Wraps a DataSourcePort to extract terms from document records.
+
+    This is a Decorator pattern implementation that transforms the document
+    entity into derived document_term entities. For each document fetched
+    from the wrapped adapter, multiple term records are extracted and yielded.
+
+    Term types extracted:
+    - MESH_HEADING: MeSH descriptor terms from mesh_terms array
+    - MESH_QUALIFIER: MeSH qualifiers/subheadings from mesh_terms
+    - KEYWORD: Author-provided keywords from keywords array
+
+    The wrapper:
+    1. Intercepts fetch("document_term") calls
+    2. Fetches documents from the wrapped adapter via fetch("document")
+    3. Extracts terms from each document (1:M relationship)
+    4. Yields individual term records with computed entity_id
+    5. Delegates all other operations to the wrapped adapter
+
+    Example:
+        >>> wrapped = DocumentTermDataSource(chembl_adapter)
+        >>> async with wrapped:
+        ...     async for term in wrapped.fetch("document_term", limit=100):
+        ...         process_term(term)  # term has keys: term, term_type, etc.
+
+    """
+
+    # Source entity type to fetch from wrapped adapter
+    SOURCE_ENTITY_TYPE = "document"
+    # Target entity type this wrapper provides
+    TARGET_ENTITY_TYPE = "document_term"
+
+    def __init__(
+        self,
+        data_source: DataSourcePort,
+    ) -> None:
+        """Initialize document term data source wrapper.
+
+        Args:
+            data_source: The underlying data source adapter to wrap (ChemblAdapter).
+
+        """
+        self._data_source = data_source
+
+    @property
+    def provider_name(self) -> str:
+        """Provider name from the wrapped data source."""
+        return self._data_source.provider_name
+
+    async def __aenter__(self) -> Self:
+        """Enter async context."""
+        await self._data_source.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        """Exit async context."""
+        await self._data_source.__aexit__(exc_type, exc_val, exc_tb)
+
+    async def fetch(
+        self,
+        entity_type: str,
+        limit: int | None = None,
+        query: str | None = None,
+        filter_ids: list[str] | None = None,
+        filter_field: str | None = None,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Fetch records, extracting terms if entity_type is document_term.
+
+        For document_term entity type:
+        - Fetches documents from wrapped adapter
+        - Extracts terms from each document
+        - Yields individual term records
+
+        For other entity types:
+        - Delegates directly to wrapped adapter
+
+        Args:
+            entity_type: Type of entity to fetch.
+            limit: Maximum number of records (for document_term, limits total terms).
+            query: Optional search query.
+            filter_ids: Optional filter IDs (passed to wrapped adapter).
+            filter_field: Optional filter field (passed to wrapped adapter).
+
+        Yields:
+            Records from the data source.
+
+        """
+        if entity_type == self.TARGET_ENTITY_TYPE:
+            # Fetch documents and extract terms
+            async for term in self._fetch_document_terms(
+                limit, filter_ids, filter_field
+            ):
+                yield term
+        else:
+            # Delegate to wrapped adapter for other entity types
+            async for record in self._data_source.fetch(
+                entity_type=entity_type,
+                limit=limit,
+                query=query,
+                filter_ids=filter_ids,
+                filter_field=filter_field,
+            ):
+                yield record
+
+    async def _fetch_document_terms(
+        self,
+        limit: int | None,
+        filter_ids: list[str] | None,
+        filter_field: str | None,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Fetch documents and extract terms.
+
+        Args:
+            limit: Maximum number of term records to yield.
+            filter_ids: Optional document IDs to filter by.
+            filter_field: Optional field for filtering (typically document_chembl_id).
+
+        Yields:
+            Term records extracted from documents.
+
+        """
+        term_count = 0
+
+        async for document in self._data_source.fetch(
+            entity_type=self.SOURCE_ENTITY_TYPE,
+            limit=None,  # We limit by terms, not documents
+            filter_ids=filter_ids,
+            filter_field=filter_field,
+        ):
+            document_chembl_id = document.get("document_chembl_id")
+            if not document_chembl_id:
+                continue
+
+            # Extract terms from document
+            terms = self._extract_terms_from_document(document, document_chembl_id)
+
+            for term in terms:
+                yield term
+                term_count += 1
+
+                if limit and term_count >= limit:
+                    return
+
+    def _extract_terms_from_document(
+        self,
+        record: dict[str, Any],
+        document_chembl_id: str,
+    ) -> list[dict[str, Any]]:
+        """Extract and flatten all terms from a Document record.
+
+        Extracts multiple term records from one document (1:M relationship).
+
+        Args:
+            record: Raw document record from ChEMBL API.
+            document_chembl_id: Document ChEMBL ID.
+
+        Returns:
+            List of term dictionaries.
+
+        """
+        terms: list[dict[str, Any]] = []
+
+        # Extract MeSH terms
+        raw_mesh_terms = record.get("mesh_terms")
+        mesh_terms: list[Any] = (
+            raw_mesh_terms if isinstance(raw_mesh_terms, list) else []
+        )
+        for mesh in mesh_terms:
+            if not isinstance(mesh, dict):
+                continue
+
+            mesh_heading = mesh.get("mesh_heading")
+            if mesh_heading:
+                terms.append(
+                    self._create_term_record(
+                        document_chembl_id=document_chembl_id,
+                        term=mesh_heading,
+                        term_type="MESH_HEADING",
+                        mesh_id=mesh.get("mesh_id"),
+                        qualifier=mesh.get("mesh_qualifier"),
+                    )
+                )
+
+            # Extract qualifier as separate term if present
+            mesh_qualifier = mesh.get("mesh_qualifier")
+            if mesh_qualifier:
+                terms.append(
+                    self._create_term_record(
+                        document_chembl_id=document_chembl_id,
+                        term=mesh_qualifier,
+                        term_type="MESH_QUALIFIER",
+                        mesh_id=mesh.get("mesh_id"),
+                        qualifier=None,
+                    )
+                )
+
+        # Extract keywords
+        raw_keywords = record.get("keywords")
+        keywords: list[Any] = raw_keywords if isinstance(raw_keywords, list) else []
+        for keyword in keywords:
+            if isinstance(keyword, str):
+                stripped = keyword.strip()
+                if stripped:  # Skip empty strings
+                    terms.append(
+                        self._create_term_record(
+                            document_chembl_id=document_chembl_id,
+                            term=stripped,
+                            term_type="KEYWORD",
+                            mesh_id=None,
+                            qualifier=None,
+                        )
+                    )
+
+        return terms
+
+    def _create_term_record(
+        self,
+        document_chembl_id: str,
+        term: str,
+        term_type: str,
+        mesh_id: str | None,
+        qualifier: str | None,
+    ) -> dict[str, Any]:
+        """Create a single term record dictionary.
+
+        Computes entity_id as SHA256 hash of composite key for deduplication.
+
+        Args:
+            document_chembl_id: Parent document ChEMBL ID.
+            term: Term text.
+            term_type: Term type (MESH_HEADING, MESH_QUALIFIER, KEYWORD).
+            mesh_id: MeSH identifier if applicable.
+            qualifier: MeSH qualifier if applicable.
+
+        Returns:
+            Dictionary of term fields including computed entity_id.
+
+        """
+        # Compute entity_id from composite key
+        entity_id = self._compute_entity_id(document_chembl_id, term_type, term)
+
+        return {
+            "entity_id": entity_id,
+            "document_chembl_id": document_chembl_id,
+            "term": term.strip() if term else term,
+            "term_type": term_type,
+            "mesh_id": mesh_id,
+            "qualifier": qualifier,
+        }
+
+    def _compute_entity_id(
+        self,
+        document_chembl_id: str,
+        term_type: str,
+        term: str,
+    ) -> str:
+        """Compute entity ID for a term based on composite key.
+
+        Entity ID is SHA256 hash of: document_chembl_id:term_type:normalized_term
+
+        Args:
+            document_chembl_id: Document ChEMBL ID.
+            term_type: Term type classification.
+            term: Term text (will be normalized).
+
+        Returns:
+            Entity ID string (first 16 chars of SHA256 hex digest).
+
+        """
+        normalized_term = term.lower().strip() if term else ""
+        composite = f"{document_chembl_id}:{term_type}:{normalized_term}"
+        return hashlib.sha256(composite.encode()).hexdigest()[:16]
+
+    async def health_check(self) -> HealthStatus:
+        """Delegate health check to wrapped adapter."""
+        return await self._data_source.health_check()
+
+    async def aclose(self) -> None:
+        """Delegate close to wrapped adapter."""
+        await self._data_source.aclose()

--- a/src/bioetl/composition/providers/registration.py
+++ b/src/bioetl/composition/providers/registration.py
@@ -9,6 +9,7 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any
 
+from bioetl.application.core.document_term_data_source import DocumentTermDataSource
 from bioetl.application.core.filtered_data_source import FilteredDataSource
 from bioetl.composition.providers.provider_registry import (
     HttpConfig,
@@ -162,6 +163,9 @@ def _create_chembl_data_source(
 
     Configuration is loaded from configs/sources/chembl.yaml via AdapterConfig.
     This ensures YAML is the single source of truth (RULES.md §12.1.2).
+
+    For document_term entity type, wraps the adapter with DocumentTermDataSource
+    to extract terms from document records (derived entity pattern).
     """
     DataSourceFactory, HttpClientFactory = _get_factories()
     http_client = HttpClientFactory.create_for_provider("chembl", settings)
@@ -176,6 +180,12 @@ def _create_chembl_data_source(
         adapter_config=adapter_config,
         metrics=metrics,
     )
+
+    # Wrap with DocumentTermDataSource for derived entity extraction
+    # document_term is extracted from document records (1:M relationship)
+    if pipeline_config.entity_type == "document_term":
+        base_adapter = DocumentTermDataSource(base_adapter)
+
     return _wrap_with_filter(
         base_adapter, filter_config, logger, metrics, pipeline_name
     )

--- a/tests/unit/application/core/test_document_term_data_source.py
+++ b/tests/unit/application/core/test_document_term_data_source.py
@@ -1,0 +1,525 @@
+"""Unit tests for DocumentTermDataSource wrapper."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from bioetl.application.core.document_term_data_source import DocumentTermDataSource
+from bioetl.domain.types import HealthStatus
+
+
+class MockDataSource:
+    """Mock data source for testing DocumentTermDataSource wrapper.
+
+    Tracks method calls for test assertions.
+    """
+
+    provider_name = "chembl"
+
+    def __init__(self, documents: list[dict] | None = None):
+        """Initialize with optional list of document records."""
+        self._documents = documents or []
+        self.__aenter__ = AsyncMock(return_value=self)
+        self.__aexit__ = AsyncMock(return_value=None)
+        self.health_check = AsyncMock(return_value=HealthStatus.HEALTHY)
+        self.aclose = AsyncMock()
+
+    async def fetch(self, entity_type: str, **kwargs):
+        """Yield configured documents."""
+        for doc in self._documents:
+            yield doc
+
+
+# Sample document records for testing
+SAMPLE_DOCUMENT_WITH_TERMS = {
+    "document_chembl_id": "CHEMBL1123456",
+    "title": "Test Document",
+    "mesh_terms": [
+        {
+            "mesh_heading": "Enzyme Inhibitors",
+            "mesh_id": "D004791",
+            "mesh_qualifier": "therapeutic use",
+        },
+        {
+            "mesh_heading": "Protein Kinases",
+            "mesh_id": "D011494",
+            "mesh_qualifier": None,
+        },
+    ],
+    "keywords": ["kinase", "inhibitor", "cancer"],
+}
+
+SAMPLE_DOCUMENT_EMPTY_TERMS = {
+    "document_chembl_id": "CHEMBL9999999",
+    "title": "Document without terms",
+    "mesh_terms": [],
+    "keywords": [],
+}
+
+SAMPLE_DOCUMENT_NO_TERMS = {
+    "document_chembl_id": "CHEMBL8888888",
+    "title": "Document with no term fields",
+    # No mesh_terms or keywords fields at all
+}
+
+SAMPLE_DOCUMENT_INVALID_MESH = {
+    "document_chembl_id": "CHEMBL7777777",
+    "title": "Document with invalid mesh",
+    "mesh_terms": ["invalid", None, 123],  # Not dicts
+    "keywords": ["valid_keyword"],
+}
+
+
+@pytest.fixture
+def mock_data_source():
+    """Create a mock data source with sample documents."""
+    return MockDataSource(
+        documents=[
+            SAMPLE_DOCUMENT_WITH_TERMS,
+            SAMPLE_DOCUMENT_EMPTY_TERMS,
+        ]
+    )
+
+
+@pytest.fixture
+def mock_data_source_no_documents():
+    """Create a mock data source with no documents."""
+    return MockDataSource(documents=[])
+
+
+@pytest.fixture
+def mock_data_source_single_document():
+    """Create a mock data source with a single document."""
+    return MockDataSource(documents=[SAMPLE_DOCUMENT_WITH_TERMS])
+
+
+@pytest.mark.unit
+class TestDocumentTermDataSourceInit:
+    """Tests for DocumentTermDataSource initialization."""
+
+    def test_initialization(self, mock_data_source):
+        """Test DocumentTermDataSource initializes correctly."""
+        wrapper = DocumentTermDataSource(data_source=mock_data_source)
+
+        assert wrapper.provider_name == "chembl"
+        assert wrapper._data_source is mock_data_source
+
+    def test_provider_name_from_wrapped(self, mock_data_source):
+        """Test provider_name is delegated to wrapped data source."""
+        mock_data_source.provider_name = "pubchem"
+        wrapper = DocumentTermDataSource(data_source=mock_data_source)
+
+        assert wrapper.provider_name == "pubchem"
+
+    def test_entity_type_constants(self):
+        """Test entity type constants are set correctly."""
+        assert DocumentTermDataSource.SOURCE_ENTITY_TYPE == "document"
+        assert DocumentTermDataSource.TARGET_ENTITY_TYPE == "document_term"
+
+
+@pytest.mark.unit
+class TestDocumentTermDataSourceContextManager:
+    """Tests for async context manager behavior."""
+
+    @pytest.mark.asyncio
+    async def test_aenter_delegates(self, mock_data_source):
+        """Test __aenter__ delegates to wrapped data source."""
+        wrapper = DocumentTermDataSource(data_source=mock_data_source)
+
+        result = await wrapper.__aenter__()
+
+        assert result is wrapper
+        mock_data_source.__aenter__.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_aexit_delegates(self, mock_data_source):
+        """Test __aexit__ delegates to wrapped data source."""
+        wrapper = DocumentTermDataSource(data_source=mock_data_source)
+
+        await wrapper.__aexit__(None, None, None)
+
+        mock_data_source.__aexit__.assert_called_once_with(None, None, None)
+
+    @pytest.mark.asyncio
+    async def test_context_manager_full_cycle(self, mock_data_source):
+        """Test using DocumentTermDataSource as async context manager."""
+        wrapper = DocumentTermDataSource(data_source=mock_data_source)
+
+        async with wrapper as w:
+            assert w is wrapper
+
+        mock_data_source.__aenter__.assert_called_once()
+        mock_data_source.__aexit__.assert_called_once()
+
+
+@pytest.mark.unit
+class TestDocumentTermDataSourceFetch:
+    """Tests for fetch method."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_document_term_extracts_terms(
+        self, mock_data_source_single_document
+    ):
+        """Test fetch('document_term') extracts terms from documents."""
+        wrapper = DocumentTermDataSource(data_source=mock_data_source_single_document)
+
+        terms = []
+        async for term in wrapper.fetch("document_term"):
+            terms.append(term)
+
+        # Expected: 2 MESH_HEADING + 1 MESH_QUALIFIER + 3 KEYWORD = 6 terms
+        assert len(terms) == 6
+
+        # Check term types
+        term_types = [t["term_type"] for t in terms]
+        assert term_types.count("MESH_HEADING") == 2
+        assert term_types.count("MESH_QUALIFIER") == 1
+        assert term_types.count("KEYWORD") == 3
+
+    @pytest.mark.asyncio
+    async def test_fetch_document_term_with_limit(
+        self, mock_data_source_single_document
+    ):
+        """Test fetch('document_term') respects limit parameter."""
+        wrapper = DocumentTermDataSource(data_source=mock_data_source_single_document)
+
+        terms = []
+        async for term in wrapper.fetch("document_term", limit=3):
+            terms.append(term)
+
+        assert len(terms) == 3
+
+    @pytest.mark.asyncio
+    async def test_fetch_other_entity_delegates(self, mock_data_source):
+        """Test fetch for other entity types delegates to wrapped adapter."""
+        wrapper = DocumentTermDataSource(data_source=mock_data_source)
+
+        records = []
+        async for record in wrapper.fetch("document"):
+            records.append(record)
+
+        # Should get the original documents, not terms
+        assert len(records) == 2
+        assert all("document_chembl_id" in r for r in records)
+
+    @pytest.mark.asyncio
+    async def test_fetch_document_term_empty_result(
+        self, mock_data_source_no_documents
+    ):
+        """Test fetch('document_term') with no documents yields nothing."""
+        wrapper = DocumentTermDataSource(data_source=mock_data_source_no_documents)
+
+        terms = []
+        async for term in wrapper.fetch("document_term"):
+            terms.append(term)
+
+        assert len(terms) == 0
+
+
+@pytest.mark.unit
+class TestDocumentTermDataSourceTermExtraction:
+    """Tests for term extraction logic."""
+
+    @pytest.mark.asyncio
+    async def test_extract_mesh_headings(self):
+        """Test MeSH heading extraction."""
+        source = MockDataSource(documents=[SAMPLE_DOCUMENT_WITH_TERMS])
+        wrapper = DocumentTermDataSource(data_source=source)
+
+        terms = []
+        async for term in wrapper.fetch("document_term"):
+            if term["term_type"] == "MESH_HEADING":
+                terms.append(term)
+
+        assert len(terms) == 2
+        assert any(t["term"] == "Enzyme Inhibitors" for t in terms)
+        assert any(t["term"] == "Protein Kinases" for t in terms)
+
+    @pytest.mark.asyncio
+    async def test_extract_mesh_qualifiers(self):
+        """Test MeSH qualifier extraction as separate terms."""
+        source = MockDataSource(documents=[SAMPLE_DOCUMENT_WITH_TERMS])
+        wrapper = DocumentTermDataSource(data_source=source)
+
+        terms = []
+        async for term in wrapper.fetch("document_term"):
+            if term["term_type"] == "MESH_QUALIFIER":
+                terms.append(term)
+
+        assert len(terms) == 1
+        assert terms[0]["term"] == "therapeutic use"
+
+    @pytest.mark.asyncio
+    async def test_extract_keywords(self):
+        """Test keyword extraction."""
+        source = MockDataSource(documents=[SAMPLE_DOCUMENT_WITH_TERMS])
+        wrapper = DocumentTermDataSource(data_source=source)
+
+        terms = []
+        async for term in wrapper.fetch("document_term"):
+            if term["term_type"] == "KEYWORD":
+                terms.append(term)
+
+        assert len(terms) == 3
+        term_values = [t["term"] for t in terms]
+        assert "kinase" in term_values
+        assert "inhibitor" in term_values
+        assert "cancer" in term_values
+
+    @pytest.mark.asyncio
+    async def test_skip_empty_terms(self):
+        """Test that empty terms are skipped."""
+        source = MockDataSource(documents=[SAMPLE_DOCUMENT_EMPTY_TERMS])
+        wrapper = DocumentTermDataSource(data_source=source)
+
+        terms = []
+        async for term in wrapper.fetch("document_term"):
+            terms.append(term)
+
+        assert len(terms) == 0
+
+    @pytest.mark.asyncio
+    async def test_skip_missing_term_fields(self):
+        """Test that documents without term fields are handled gracefully."""
+        source = MockDataSource(documents=[SAMPLE_DOCUMENT_NO_TERMS])
+        wrapper = DocumentTermDataSource(data_source=source)
+
+        terms = []
+        async for term in wrapper.fetch("document_term"):
+            terms.append(term)
+
+        assert len(terms) == 0
+
+    @pytest.mark.asyncio
+    async def test_skip_invalid_mesh_entries(self):
+        """Test that invalid mesh entries (non-dicts) are skipped."""
+        source = MockDataSource(documents=[SAMPLE_DOCUMENT_INVALID_MESH])
+        wrapper = DocumentTermDataSource(data_source=source)
+
+        terms = []
+        async for term in wrapper.fetch("document_term"):
+            terms.append(term)
+
+        # Should only get the valid keyword
+        assert len(terms) == 1
+        assert terms[0]["term"] == "valid_keyword"
+
+
+@pytest.mark.unit
+class TestDocumentTermDataSourceRecordFormat:
+    """Tests for term record format and entity_id computation."""
+
+    @pytest.mark.asyncio
+    async def test_term_record_fields(self):
+        """Test that term records have all required fields."""
+        source = MockDataSource(documents=[SAMPLE_DOCUMENT_WITH_TERMS])
+        wrapper = DocumentTermDataSource(data_source=source)
+
+        terms = []
+        async for term in wrapper.fetch("document_term"):
+            terms.append(term)
+
+        for term in terms:
+            assert "entity_id" in term
+            assert "document_chembl_id" in term
+            assert "term" in term
+            assert "term_type" in term
+            assert "mesh_id" in term
+            assert "qualifier" in term
+
+    @pytest.mark.asyncio
+    async def test_entity_id_computed(self):
+        """Test that entity_id is computed for each term."""
+        source = MockDataSource(documents=[SAMPLE_DOCUMENT_WITH_TERMS])
+        wrapper = DocumentTermDataSource(data_source=source)
+
+        terms = []
+        async for term in wrapper.fetch("document_term"):
+            terms.append(term)
+
+        # All entity_ids should be 16-char hex strings
+        for term in terms:
+            assert len(term["entity_id"]) == 16
+            assert all(c in "0123456789abcdef" for c in term["entity_id"])
+
+    @pytest.mark.asyncio
+    async def test_entity_id_uniqueness(self):
+        """Test that entity_ids are unique for different terms."""
+        source = MockDataSource(documents=[SAMPLE_DOCUMENT_WITH_TERMS])
+        wrapper = DocumentTermDataSource(data_source=source)
+
+        terms = []
+        async for term in wrapper.fetch("document_term"):
+            terms.append(term)
+
+        entity_ids = [t["entity_id"] for t in terms]
+        assert len(entity_ids) == len(set(entity_ids)), "Entity IDs should be unique"
+
+    @pytest.mark.asyncio
+    async def test_entity_id_deterministic(self):
+        """Test that entity_id is deterministic for same inputs."""
+        source1 = MockDataSource(documents=[SAMPLE_DOCUMENT_WITH_TERMS])
+        source2 = MockDataSource(documents=[SAMPLE_DOCUMENT_WITH_TERMS])
+        wrapper1 = DocumentTermDataSource(data_source=source1)
+        wrapper2 = DocumentTermDataSource(data_source=source2)
+
+        terms1 = []
+        async for term in wrapper1.fetch("document_term"):
+            terms1.append(term)
+
+        terms2 = []
+        async for term in wrapper2.fetch("document_term"):
+            terms2.append(term)
+
+        # Same inputs should produce same entity_ids
+        ids1 = [t["entity_id"] for t in terms1]
+        ids2 = [t["entity_id"] for t in terms2]
+        assert ids1 == ids2
+
+    @pytest.mark.asyncio
+    async def test_mesh_id_preserved(self):
+        """Test that mesh_id is preserved in term records."""
+        source = MockDataSource(documents=[SAMPLE_DOCUMENT_WITH_TERMS])
+        wrapper = DocumentTermDataSource(data_source=source)
+
+        terms = []
+        async for term in wrapper.fetch("document_term"):
+            if term["term_type"] == "MESH_HEADING":
+                terms.append(term)
+
+        # First mesh heading should have mesh_id
+        enzyme_term = next(t for t in terms if t["term"] == "Enzyme Inhibitors")
+        assert enzyme_term["mesh_id"] == "D004791"
+
+
+@pytest.mark.unit
+class TestDocumentTermDataSourceDelegation:
+    """Tests for method delegation to wrapped data source."""
+
+    @pytest.mark.asyncio
+    async def test_health_check_delegates(self, mock_data_source):
+        """Test health_check delegates to wrapped data source."""
+        wrapper = DocumentTermDataSource(data_source=mock_data_source)
+
+        result = await wrapper.health_check()
+
+        assert result == HealthStatus.HEALTHY
+        mock_data_source.health_check.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_aclose_delegates(self, mock_data_source):
+        """Test aclose delegates to wrapped data source."""
+        wrapper = DocumentTermDataSource(data_source=mock_data_source)
+
+        await wrapper.aclose()
+
+        mock_data_source.aclose.assert_called_once()
+
+
+@pytest.mark.unit
+class TestDocumentTermDataSourceEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    @pytest.mark.asyncio
+    async def test_document_without_chembl_id_skipped(self):
+        """Test documents without document_chembl_id are skipped."""
+        source = MockDataSource(
+            documents=[
+                {"title": "No ID document", "mesh_terms": [], "keywords": ["test"]}
+            ]
+        )
+        wrapper = DocumentTermDataSource(data_source=source)
+
+        terms = []
+        async for term in wrapper.fetch("document_term"):
+            terms.append(term)
+
+        assert len(terms) == 0
+
+    @pytest.mark.asyncio
+    async def test_whitespace_keywords_stripped(self):
+        """Test that whitespace in keywords is stripped."""
+        source = MockDataSource(
+            documents=[
+                {
+                    "document_chembl_id": "CHEMBL1",
+                    "keywords": ["  spaced  ", "\ttabbed\t", "  ", ""],
+                    "mesh_terms": [],
+                }
+            ]
+        )
+        wrapper = DocumentTermDataSource(data_source=source)
+
+        terms = []
+        async for term in wrapper.fetch("document_term"):
+            terms.append(term)
+
+        # Only non-empty after stripping
+        assert len(terms) == 2
+        assert terms[0]["term"] == "spaced"
+        assert terms[1]["term"] == "tabbed"
+
+    @pytest.mark.asyncio
+    async def test_multiple_documents_combined(self):
+        """Test that terms from multiple documents are combined."""
+        source = MockDataSource(
+            documents=[
+                {
+                    "document_chembl_id": "CHEMBL1",
+                    "keywords": ["term1"],
+                    "mesh_terms": [],
+                },
+                {
+                    "document_chembl_id": "CHEMBL2",
+                    "keywords": ["term2"],
+                    "mesh_terms": [],
+                },
+            ]
+        )
+        wrapper = DocumentTermDataSource(data_source=source)
+
+        terms = []
+        async for term in wrapper.fetch("document_term"):
+            terms.append(term)
+
+        assert len(terms) == 2
+        doc_ids = {t["document_chembl_id"] for t in terms}
+        assert doc_ids == {"CHEMBL1", "CHEMBL2"}
+
+    @pytest.mark.asyncio
+    async def test_filter_ids_passed_to_wrapped(self):
+        """Test that filter_ids parameter is passed to wrapped adapter."""
+        call_args = {}
+
+        class TrackingMockDataSource(MockDataSource):
+            async def fetch(self, entity_type: str, **kwargs):
+                call_args.update(kwargs)
+                call_args["entity_type"] = entity_type
+                async for doc in super().fetch(entity_type, **kwargs):
+                    yield doc
+
+        source = TrackingMockDataSource(
+            documents=[
+                {
+                    "document_chembl_id": "CHEMBL1",
+                    "keywords": ["test"],
+                    "mesh_terms": [],
+                }
+            ]
+        )
+        wrapper = DocumentTermDataSource(data_source=source)
+
+        terms = []
+        async for term in wrapper.fetch(
+            "document_term",
+            filter_ids=["CHEMBL1", "CHEMBL2"],
+            filter_field="document_chembl_id",
+        ):
+            terms.append(term)
+
+        # Verify fetch was called with document entity type
+        assert call_args["entity_type"] == "document"
+        assert call_args["filter_ids"] == ["CHEMBL1", "CHEMBL2"]
+        assert call_args["filter_field"] == "document_chembl_id"


### PR DESCRIPTION
Add DocumentTermDataSource wrapper that extracts terms from ChEMBL document records. This implements the derived entity pattern where document_term entities are extracted from the nested mesh_terms and keywords fields in document API responses.

Key changes:
- Add DocumentTermDataSource wrapper in application/core
- Wrap ChemblAdapter when entity_type is "document_term" in registration.py
- Extract MeSH headings, qualifiers, and keywords from documents
- Compute entity_id as SHA256 hash of composite key
- Add 27 unit tests covering extraction, edge cases, and delegation