### PR TITLE
Apply Black formatting to crossref/batch.py

### DIFF
--- a/src/bioetl/infrastructure/adapters/crossref/batch.py
+++ b/src/bioetl/infrastructure/adapters/crossref/batch.py
@@ -260,7 +260,9 @@ class SearchPaginator:
                 # Check if pagination should continue
                 if not self._should_continue_pagination(items, next_cursor, cursor):
                     break
-                assert next_cursor is not None  # Guaranteed by _should_continue_pagination
+                assert (
+                    next_cursor is not None
+                )  # Guaranteed by _should_continue_pagination
                 cursor = next_cursor
 
         except CrossRefApiError:


### PR DESCRIPTION
Fix code formatting to pass architecture test
tests/architecture/test_code_formatting.py::TestCodeFormatting::test_black_formatting_src