### PR TITLE
Add generic typing to event collection

### DIFF
--- a/src/bioetl/domain/aggregates/batch.py
+++ b/src/bioetl/domain/aggregates/batch.py
@@ -19,9 +19,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from bioetl.domain.exceptions import InvalidStateError
+
+if TYPE_CHECKING:
+    from bioetl.domain.aggregates.events import DomainEvent
 from bioetl.domain.types import BatchID, ContentHash, EntityID, RunID
 
 
@@ -158,7 +161,7 @@ class Batch:
         self._start_index = start_index
         self._created_at = created_at or datetime.now(UTC)
         self._sealed_at: datetime | None = None
-        self._events: list[Any] = []
+        self._events: list[DomainEvent] = []
         self._metadata = metadata or {}
 
     @classmethod
@@ -496,7 +499,7 @@ class Batch:
     # Domain events
     # ──────────────────────────────────────────────────────────────────────────
 
-    def collect_events(self) -> list[Any]:
+    def collect_events(self) -> list[DomainEvent]:
         """Collect and clear accumulated domain events.
 
         Returns:

--- a/src/bioetl/domain/aggregates/pipeline_run.py
+++ b/src/bioetl/domain/aggregates/pipeline_run.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from bioetl.domain.exceptions import InvalidStateError
+
+if TYPE_CHECKING:
+    from bioetl.domain.aggregates.events import DomainEvent
 from bioetl.domain.types import RunID, RunType
 
 
@@ -219,7 +222,7 @@ class PipelineRun:
         self._stages: list[StageResult] = []
         self._started_at: datetime | None = None
         self._ended_at: datetime | None = None
-        self._events: list[Any] = []
+        self._events: list[DomainEvent] = []
         self._metadata = metadata or {}
 
     @property
@@ -532,7 +535,7 @@ class PipelineRun:
             )
         )
 
-    def collect_events(self) -> list[Any]:
+    def collect_events(self) -> list[DomainEvent]:
         """Collect and clear accumulated domain events.
 
         Returns:

--- a/src/bioetl/domain/aggregates/quarantine_entry.py
+++ b/src/bioetl/domain/aggregates/quarantine_entry.py
@@ -19,9 +19,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from bioetl.domain.exceptions import InvalidStateError
+
+if TYPE_CHECKING:
+    from bioetl.domain.aggregates.events import DomainEvent
 from bioetl.domain.types import BatchID, ContentHash, RunID
 
 
@@ -183,7 +186,7 @@ class QuarantineEntry:
         self._created_at = created_at or datetime.now(UTC)
         self._metadata = dict(metadata) if metadata else {}
         self._resolution_info: ResolutionInfo | None = None
-        self._events: list[Any] = []
+        self._events: list[DomainEvent] = []
 
     @classmethod
     def create(
@@ -477,7 +480,7 @@ class QuarantineEntry:
     # Domain events
     # ──────────────────────────────────────────────────────────────────────────
 
-    def collect_events(self) -> list[Any]:
+    def collect_events(self) -> list[DomainEvent]:
         """Collect and clear accumulated domain events.
 
         Returns:


### PR DESCRIPTION
…_events()

Replace list[Any] with list[DomainEvent] for:
- _events internal storage in Batch, PipelineRun, QuarantineEntry
- collect_events() return type in all three aggregates

This improves type safety for domain event collection while avoiding circular imports via TYPE_CHECKING guard.