### PR TITLE
Refactor quarantine module to use service layer

### DIFF
--- a/src/bioetl/application/services/__init__.py
+++ b/src/bioetl/application/services/__init__.py
@@ -50,10 +50,8 @@ from bioetl.application.services.pipeline_runner_service import (
     RunStatus,
 )
 from bioetl.application.services.quarantine_service import (
-    PurgeResult,
     QuarantineRecord,
     QuarantineService,
-    ReplayResult,
 )
 from bioetl.application.services.shutdown_service import (
     PipelineShutdownError,
@@ -85,10 +83,8 @@ __all__ = [
     "PipelineNotFoundError",
     "PipelineRunnerService",
     "PipelineShutdownError",
-    "PurgeResult",
     "QuarantineRecord",
     "QuarantineService",
-    "ReplayResult",
     "RunOptions",
     "RunResult",
     "RunStatus",

--- a/src/bioetl/application/services/quarantine_service.py
+++ b/src/bioetl/application/services/quarantine_service.py
@@ -9,9 +9,10 @@ Implements RULES.md §1.1 - Application layer depends only on Domain.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
-from uuid import UUID
+
+from bioetl.domain.types import QuarantineRecordStatus
 
 if TYPE_CHECKING:
     from bioetl.domain.ports import LoggerPort, QuarantinePort
@@ -36,36 +37,6 @@ class QuarantineRecord:
     pipeline: str
     ingestion_ts: datetime | None
     metadata: dict[str, Any]
-
-
-@dataclass(frozen=True, slots=True)
-class ReplayResult:
-    """Result of replaying quarantined records.
-
-    Attributes:
-        batch_id: Batch ID that was replayed.
-        records_replayed: Number of records attempted to replay.
-        records_succeeded: Number of successful replays.
-        records_failed: Number of failed replays.
-    """
-
-    batch_id: str
-    records_replayed: int
-    records_succeeded: int
-    records_failed: int
-
-
-@dataclass(frozen=True, slots=True)
-class PurgeResult:
-    """Result of purging old quarantine records.
-
-    Attributes:
-        records_purged: Number of records removed.
-        pipelines_affected: Pipelines that had records removed.
-    """
-
-    records_purged: int
-    pipelines_affected: list[str]
 
 
 @dataclass
@@ -160,113 +131,154 @@ class QuarantineService:
 
         return stats
 
-    async def replay(
+    def replay(
         self,
         pipeline: str,
-        batch_id: UUID,
-    ) -> ReplayResult:
-        """Replay quarantined records from a specific batch.
+        error_code: str | None = None,
+        max_age_days: int = 7,
+    ) -> list[dict[str, Any]]:
+        """Replay quarantine records for reprocessing.
 
-        This operation attempts to reprocess records that were
-        previously quarantined. The exact replay mechanism depends
-        on the pipeline configuration and error type.
-
-        Note: This is a placeholder for future implementation.
-        Full replay requires pipeline context and transformation logic.
+        Retrieves quarantined records that match the filter criteria
+        for reprocessing by the pipeline.
 
         Args:
-            pipeline: Pipeline name.
-            batch_id: Batch ID to replay.
+            pipeline: Pipeline name to filter by.
+            error_code: Optional error code to filter by.
+            max_age_days: Maximum age of records to replay (default 7).
 
         Returns:
-            ReplayResult with replay statistics.
+            List of quarantine records suitable for replay.
         """
+        now = datetime.now(tz=UTC)
         self.logger.info(
-            "Replaying quarantine batch",
+            "Replaying quarantine records",
             pipeline=pipeline,
-            batch_id=str(batch_id),
+            error_code=error_code,
+            max_age_days=max_age_days,
         )
 
-        # Get records for this batch
-        records = await self.quarantine_port.inspect(
+        records = list(
+            self.quarantine_port.replay(
+                pipeline=pipeline,
+                error_code=error_code,
+                max_age_days=max_age_days,
+                now=now,
+            )
+        )
+
+        self.logger.info(
+            "Replay records retrieved",
             pipeline=pipeline,
-            limit=10000,  # Large limit to get all batch records
+            record_count=len(records),
         )
 
-        # Filter to specific batch
-        batch_records = [
-            rec for rec in records if rec.get("bronze_batch_id") == str(batch_id)
-        ]
+        return records
 
-        # Placeholder: actual replay would require pipeline context
-        # For now, just return stats about what would be replayed
-        self.logger.warning(
-            "Replay not yet implemented - returning stats only",
-            pipeline=pipeline,
-            batch_id=str(batch_id),
-            records_found=len(batch_records),
+    def mark_as_reprocessed(
+        self,
+        records: list[dict[str, Any]],
+    ) -> int:
+        """Mark replay records as reprocessed.
+
+        Updates the status of records to REPROCESSED after successful replay.
+
+        Args:
+            records: List of records from replay() to mark as reprocessed.
+
+        Returns:
+            Number of records successfully marked.
+        """
+        count = 0
+        for rec in records:
+            payload_hash = rec.get("payload_hash")
+            if payload_hash and self.quarantine_port.update_status(
+                payload_hash, QuarantineRecordStatus.REPROCESSED
+            ):
+                count += 1
+
+        self.logger.info(
+            "Marked records as reprocessed",
+            record_count=count,
         )
+        return count
 
-        return ReplayResult(
-            batch_id=str(batch_id),
-            records_replayed=len(batch_records),
-            records_succeeded=0,
-            records_failed=len(batch_records),
-        )
-
-    async def purge(
+    def purge(
         self,
         pipeline: str,
         older_than_days: int = 30,
-    ) -> PurgeResult:
+    ) -> int:
         """Purge old quarantine records.
 
         Removes quarantine records older than the specified age.
-        This is a cleanup operation for maintaining quarantine storage.
-
-        Note: This operation requires QuarantinePort to support
-        time-based deletion, which may need to be implemented.
+        Implements RULES.md §2.6 - 30-day retention policy.
 
         Args:
-            pipeline: Pipeline name (or "*" for all pipelines).
-            older_than_days: Records older than this will be purged.
+            pipeline: Pipeline name.
+            older_than_days: Records older than this will be purged (default 30).
 
         Returns:
-            PurgeResult with purge statistics.
+            Number of records deleted.
         """
+        now = datetime.now(tz=UTC)
         self.logger.info(
             "Purging old quarantine records",
             pipeline=pipeline,
             older_than_days=older_than_days,
         )
 
-        cutoff_date = datetime.now(UTC) - timedelta(days=older_than_days)
-
-        # Placeholder: actual purge requires QuarantinePort extension
-        # For now, inspect and count what would be purged
-        records = await self.quarantine_port.inspect(
-            pipeline=pipeline,
-            limit=10000,
-        )
-
-        # Filter by date (if ingestion_ts is available)
-        records_to_purge = [
-            rec
-            for rec in records
-            if rec.get("ingestion_ts") and rec["ingestion_ts"] < cutoff_date
-        ]
-
-        self.logger.warning(
-            "Purge not yet implemented - returning stats only",
+        count = self.quarantine_port.purge(
             pipeline=pipeline,
             older_than_days=older_than_days,
-            records_found=len(records_to_purge),
+            now=now,
         )
 
-        return PurgeResult(
-            records_purged=0,  # Not implemented yet
-            pipelines_affected=[pipeline] if records_to_purge else [],
+        self.logger.info(
+            "Purged quarantine records",
+            pipeline=pipeline,
+            records_purged=count,
         )
+
+        return count
+
+    def update_status(
+        self,
+        payload_hash: str,
+        new_status: QuarantineRecordStatus,
+    ) -> bool:
+        """Update DQ status for a quarantined record.
+
+        Used to mark records as IGNORED, REVIEWED, or REPROCESSED
+        after manual inspection.
+
+        Args:
+            payload_hash: Hash of the payload to identify the record.
+            new_status: New status to set.
+
+        Returns:
+            True if record was found and updated, False otherwise.
+        """
+        self.logger.debug(
+            "Updating quarantine status",
+            payload_hash=payload_hash,
+            new_status=new_status.value,
+        )
+
+        success = self.quarantine_port.update_status(payload_hash, new_status)
+
+        if success:
+            self.logger.info(
+                "Updated quarantine status",
+                payload_hash=payload_hash,
+                new_status=new_status.value,
+            )
+        else:
+            self.logger.warning(
+                "Failed to update quarantine status - record not found",
+                payload_hash=payload_hash,
+            )
+
+        return success
 
     async def aclose(self) -> None:
         """Close the service and release resources."""

--- a/src/bioetl/domain/ports/quarantine.py
+++ b/src/bioetl/domain/ports/quarantine.py
@@ -6,10 +6,11 @@ for later analysis, preventing them from stopping the entire pipeline.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from datetime import datetime
 from typing import Any, Protocol, runtime_checkable
 
-from bioetl.domain.types import BatchID, RunID
+from bioetl.domain.types import BatchID, QuarantineRecordStatus, RunID
 
 
 @runtime_checkable
@@ -71,6 +72,73 @@ class QuarantinePort(Protocol):
 
         Returns:
             A dictionary of statistics (e.g., count by error code).
+        """
+        ...
+
+    def replay(
+        self,
+        pipeline: str,
+        error_code: str | None = None,
+        max_age_days: int = 7,
+        *,
+        now: datetime,
+    ) -> Iterator[dict[str, Any]]:
+        """Replay quarantine records for reprocessing.
+
+        Retrieves quarantined records that match the filter criteria
+        for reprocessing by the pipeline.
+
+        Args:
+            pipeline: Pipeline name to filter by.
+            error_code: Optional error code to filter by.
+            max_age_days: Maximum age of records to replay (default 7).
+            now: Current timestamp from application layer
+                 (single source of time per ADR-014). Required.
+
+        Returns:
+            Iterator of quarantine records suitable for replay.
+        """
+        ...
+
+    def purge(
+        self,
+        pipeline: str,
+        older_than_days: int = 30,
+        *,
+        now: datetime,
+    ) -> int:
+        """Purge old quarantine records.
+
+        Deletes quarantined records older than the specified age.
+        Implements RULES.md §2.6 - 30-day retention policy.
+
+        Args:
+            pipeline: Pipeline name to filter by.
+            older_than_days: Delete records older than this (default 30).
+            now: Current timestamp from application layer
+                 (single source of time per ADR-014). Required.
+
+        Returns:
+            Count of deleted records.
+        """
+        ...
+
+    def update_status(
+        self,
+        payload_hash: str,
+        new_status: QuarantineRecordStatus,
+    ) -> bool:
+        """Update DQ status for a quarantined record.
+
+        Used to mark records as IGNORED, REVIEWED, or REPROCESSED
+        after manual inspection.
+
+        Args:
+            payload_hash: Hash of the payload to identify the record.
+            new_status: New status to set.
+
+        Returns:
+            True if record was found and updated, False otherwise.
         """
         ...
 

--- a/src/bioetl/interfaces/cli/commands/quarantine.py
+++ b/src/bioetl/interfaces/cli/commands/quarantine.py
@@ -9,12 +9,14 @@ from __future__ import annotations
 import asyncio
 import json
 import sys
-from datetime import UTC, datetime
 from typing import Any
 
 import click
 
-from bioetl.composition.entrypoints import get_quarantine_manager
+from bioetl.composition.entrypoints import (
+    get_quarantine_manager,
+    get_quarantine_service,
+)
 from bioetl.domain.types import QuarantineRecordStatus
 from bioetl.interfaces.cli.exit_codes import ExitCode
 from bioetl.interfaces.cli.formatters import (
@@ -136,20 +138,12 @@ def quarantine_replay(
         bioetl quarantine replay --pipeline chembl_activity --dry-run
         bioetl quarantine replay --pipeline chembl_activity --error-code DQ_NETWORK_ERROR
     """
-    from bioetl.infrastructure.config import Settings
-    from bioetl.infrastructure.quarantine.unified import UnifiedQuarantine
+    quarantine_service = get_quarantine_service()
 
-    settings = Settings()
-    quarantine_store = UnifiedQuarantine(base_path=str(settings.quarantine_path))
-
-    now = datetime.now(tz=UTC)
-    records = list(
-        quarantine_store.replay(
-            pipeline=pipeline,
-            error_code=error_code,
-            max_age_days=max_age_days,
-            now=now,
-        )
+    records = quarantine_service.replay(
+        pipeline=pipeline,
+        error_code=error_code,
+        max_age_days=max_age_days,
     )
 
     if not records:
@@ -167,13 +161,8 @@ def quarantine_replay(
     else:
         click.echo(f"\nReplaying {len(records)} record(s)...")
         # Mark records as reprocessed
-        for rec in records:
-            payload_hash = rec.get("payload_hash")
-            if payload_hash:
-                quarantine_store.update_status(
-                    payload_hash, QuarantineRecordStatus.REPROCESSED
-                )
-        click.echo(f"Marked {len(records)} record(s) as REPROCESSED.")
+        marked_count = quarantine_service.mark_as_reprocessed(records)
+        click.echo(f"Marked {marked_count} record(s) as REPROCESSED.")
         echo_info("Records are ready for reprocessing by the pipeline.")
 
 
@@ -199,18 +188,12 @@ def quarantine_purge(
         bioetl quarantine purge --pipeline chembl_activity --dry-run
         bioetl quarantine purge --pipeline chembl_activity --older-than-days 60
     """
-    from bioetl.infrastructure.config import Settings
-    from bioetl.infrastructure.quarantine.unified import UnifiedQuarantine
-
-    settings = Settings()
-    quarantine_store = UnifiedQuarantine(base_path=str(settings.quarantine_path))
-
-    now = datetime.now(tz=UTC)
+    quarantine_service = get_quarantine_service()
 
     if dry_run:
         # Get count of records that would be purged
         async def _get_stats() -> dict[str, Any]:
-            return await quarantine_store.get_stats(pipeline)
+            return await quarantine_service.get_stats(pipeline)
 
         stats = asyncio.run(_get_stats())
         total = stats.get("total_count", 0)
@@ -225,10 +208,9 @@ def quarantine_purge(
             abort=True,
         )
 
-    count = quarantine_store.purge(
+    count = quarantine_service.purge(
         pipeline=pipeline,
         older_than_days=older_than_days,
-        now=now,
     )
 
     click.echo(f"Purged {count} record(s) from quarantine.")
@@ -254,14 +236,10 @@ def quarantine_resolve(pipeline: str, payload_hash: str, status: str) -> None:
         bioetl quarantine resolve --pipeline chembl_activity --payload-hash abc123
         bioetl quarantine resolve --pipeline chembl_activity --payload-hash abc123 --status REPROCESSED
     """
-    from bioetl.infrastructure.config import Settings
-    from bioetl.infrastructure.quarantine.unified import UnifiedQuarantine
-
-    settings = Settings()
-    quarantine_store = UnifiedQuarantine(base_path=str(settings.quarantine_path))
+    quarantine_service = get_quarantine_service()
 
     new_status = QuarantineRecordStatus[status]
-    success = quarantine_store.update_status(payload_hash, new_status)
+    success = quarantine_service.update_status(payload_hash, new_status)
 
     if success:
         click.echo(f"Record {payload_hash} marked as {status}.")

--- a/tests/architecture/test_interfaces_no_infrastructure.py
+++ b/tests/architecture/test_interfaces_no_infrastructure.py
@@ -155,11 +155,8 @@ class TestInterfacesNoDIrectInfrastructure:
             pytest.skip("CLI commands directory not found")
 
         # Expected legacy violations - keep in sync with test above
+        # Note: quarantine.py was fixed in IF-002 refactoring to use QuarantineService
         expected_violations = {
-            "quarantine.py": [
-                "bioetl.infrastructure.config",
-                "bioetl.infrastructure.quarantine.unified",
-            ],
             "health.py": [
                 "bioetl.infrastructure.adapters.http.health_monitor",
                 "bioetl.infrastructure.observability.prometheus_metrics",

--- a/tests/unit/application/services/test_quarantine_service.py
+++ b/tests/unit/application/services/test_quarantine_service.py
@@ -6,17 +6,15 @@ Tests the quarantine administrative service.
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock
-from uuid import uuid4
+from unittest.mock import MagicMock
 
 import pytest
 
 from bioetl.application.services.quarantine_service import (
-    PurgeResult,
     QuarantineRecord,
     QuarantineService,
-    ReplayResult,
 )
+from bioetl.domain.types import QuarantineRecordStatus
 
 
 @pytest.fixture
@@ -33,10 +31,16 @@ def mock_logger():
 @pytest.fixture
 def mock_quarantine_port():
     """Create a mock quarantine port."""
+    from unittest.mock import AsyncMock
+
     port = MagicMock()
     port.inspect = AsyncMock(return_value=[])
     port.get_stats = AsyncMock(return_value={})
     port.aclose = AsyncMock()
+    # New synchronous methods
+    port.replay = MagicMock(return_value=iter([]))
+    port.purge = MagicMock(return_value=0)
+    port.update_status = MagicMock(return_value=True)
     return port
 
 
@@ -70,40 +74,6 @@ class TestQuarantineRecord:
         assert record.batch_id == "batch-123"
         assert record.pipeline == "test_pipeline"
         assert record.ingestion_ts == now
-
-
-@pytest.mark.unit
-class TestReplayResult:
-    """Test ReplayResult dataclass."""
-
-    def test_replay_result_creation(self):
-        """Test ReplayResult can be created."""
-        result = ReplayResult(
-            batch_id="batch-123",
-            records_replayed=10,
-            records_succeeded=8,
-            records_failed=2,
-        )
-
-        assert result.batch_id == "batch-123"
-        assert result.records_replayed == 10
-        assert result.records_succeeded == 8
-        assert result.records_failed == 2
-
-
-@pytest.mark.unit
-class TestPurgeResult:
-    """Test PurgeResult dataclass."""
-
-    def test_purge_result_creation(self):
-        """Test PurgeResult can be created."""
-        result = PurgeResult(
-            records_purged=100,
-            pipelines_affected=["pipeline1", "pipeline2"],
-        )
-
-        assert result.records_purged == 100
-        assert result.pipelines_affected == ["pipeline1", "pipeline2"]
 
 
 @pytest.mark.unit
@@ -196,38 +166,112 @@ class TestQuarantineServiceGetStats:
 class TestQuarantineServiceReplay:
     """Test QuarantineService.replay method."""
 
-    @pytest.mark.asyncio
-    async def test_replay_returns_stats(self, quarantine_service, mock_quarantine_port):
-        """Test replay returns statistics (not yet implemented)."""
-        batch_id = uuid4()
-        mock_quarantine_port.inspect.return_value = [
-            {"bronze_batch_id": str(batch_id), "payload": {"id": 1}},
-            {"bronze_batch_id": str(batch_id), "payload": {"id": 2}},
+    def test_replay_returns_records(self, quarantine_service, mock_quarantine_port):
+        """Test replay returns records from port."""
+        records = [
+            {"payload_hash": "hash1", "error_code": "DQ_ERROR"},
+            {"payload_hash": "hash2", "error_code": "DQ_ERROR"},
+        ]
+        mock_quarantine_port.replay.return_value = iter(records)
+
+        result = quarantine_service.replay("pipeline1", max_age_days=7)
+
+        assert len(result) == 2
+        assert result[0]["payload_hash"] == "hash1"
+        mock_quarantine_port.replay.assert_called_once()
+
+    def test_replay_with_error_code_filter(
+        self, quarantine_service, mock_quarantine_port
+    ):
+        """Test replay with error code filter."""
+        mock_quarantine_port.replay.return_value = iter([])
+
+        quarantine_service.replay("pipeline1", error_code="DQ_NETWORK_ERROR")
+
+        call_kwargs = mock_quarantine_port.replay.call_args[1]
+        assert call_kwargs["error_code"] == "DQ_NETWORK_ERROR"
+
+
+@pytest.mark.unit
+class TestQuarantineServiceMarkAsReprocessed:
+    """Test QuarantineService.mark_as_reprocessed method."""
+
+    def test_mark_as_reprocessed(self, quarantine_service, mock_quarantine_port):
+        """Test marking records as reprocessed."""
+        records = [
+            {"payload_hash": "hash1"},
+            {"payload_hash": "hash2"},
         ]
 
-        result = await quarantine_service.replay("pipeline1", batch_id)
+        count = quarantine_service.mark_as_reprocessed(records)
 
-        # Replay is not fully implemented, should return failure stats
-        assert isinstance(result, ReplayResult)
-        assert result.batch_id == str(batch_id)
-        assert result.records_replayed == 2
-        assert result.records_failed == 2  # All failed since not implemented
+        assert count == 2
+        assert mock_quarantine_port.update_status.call_count == 2
+
+    def test_mark_as_reprocessed_skips_missing_hash(
+        self, quarantine_service, mock_quarantine_port
+    ):
+        """Test marking skips records without payload_hash."""
+        records = [
+            {"payload_hash": "hash1"},
+            {"other_field": "value"},  # Missing payload_hash
+        ]
+
+        count = quarantine_service.mark_as_reprocessed(records)
+
+        assert count == 1
+        assert mock_quarantine_port.update_status.call_count == 1
 
 
 @pytest.mark.unit
 class TestQuarantineServicePurge:
     """Test QuarantineService.purge method."""
 
-    @pytest.mark.asyncio
-    async def test_purge_returns_stats(self, quarantine_service, mock_quarantine_port):
-        """Test purge returns statistics (not yet implemented)."""
-        mock_quarantine_port.inspect.return_value = []
+    def test_purge_returns_count(self, quarantine_service, mock_quarantine_port):
+        """Test purge returns count from port."""
+        mock_quarantine_port.purge.return_value = 50
 
-        result = await quarantine_service.purge("pipeline1", older_than_days=30)
+        result = quarantine_service.purge("pipeline1", older_than_days=30)
 
-        # Purge is not fully implemented
-        assert isinstance(result, PurgeResult)
-        assert result.records_purged == 0
+        assert result == 50
+        mock_quarantine_port.purge.assert_called_once()
+
+    def test_purge_with_custom_retention(
+        self, quarantine_service, mock_quarantine_port
+    ):
+        """Test purge with custom retention days."""
+        quarantine_service.purge("pipeline1", older_than_days=60)
+
+        call_kwargs = mock_quarantine_port.purge.call_args[1]
+        assert call_kwargs["older_than_days"] == 60
+
+
+@pytest.mark.unit
+class TestQuarantineServiceUpdateStatus:
+    """Test QuarantineService.update_status method."""
+
+    def test_update_status_success(self, quarantine_service, mock_quarantine_port):
+        """Test successful status update."""
+        mock_quarantine_port.update_status.return_value = True
+
+        result = quarantine_service.update_status(
+            "hash123", QuarantineRecordStatus.IGNORED
+        )
+
+        assert result is True
+        mock_quarantine_port.update_status.assert_called_once_with(
+            "hash123", QuarantineRecordStatus.IGNORED
+        )
+
+    def test_update_status_not_found(self, quarantine_service, mock_quarantine_port):
+        """Test status update when record not found."""
+        mock_quarantine_port.update_status.return_value = False
+
+        result = quarantine_service.update_status(
+            "nonexistent", QuarantineRecordStatus.REPROCESSED
+        )
+
+        assert result is False
 
 
 @pytest.mark.unit

--- a/tests/unit/interfaces/cli/commands/test_quarantine.py
+++ b/tests/unit/interfaces/cli/commands/test_quarantine.py
@@ -32,22 +32,15 @@ def mock_quarantine_manager() -> MagicMock:
 
 
 @pytest.fixture
-def mock_settings() -> MagicMock:
-    """Create mock settings."""
-    settings = MagicMock()
-    settings.quarantine_path = "/tmp/quarantine"
-    return settings
-
-
-@pytest.fixture
-def mock_unified_quarantine() -> MagicMock:
-    """Create mock unified quarantine."""
-    quarantine = MagicMock()
-    quarantine.replay.return_value = iter([])
-    quarantine.purge.return_value = 0
-    quarantine.get_stats = AsyncMock(return_value={"total_count": 0})
-    quarantine.update_status.return_value = True
-    return quarantine
+def mock_quarantine_service() -> MagicMock:
+    """Create a mock quarantine service."""
+    service = MagicMock()
+    service.replay = MagicMock(return_value=[])
+    service.purge = MagicMock(return_value=0)
+    service.get_stats = AsyncMock(return_value={"total_count": 0})
+    service.update_status = MagicMock(return_value=True)
+    service.mark_as_reprocessed = MagicMock(return_value=0)
+    return service
 
 
 class TestQuarantineGroup:
@@ -362,21 +355,14 @@ class TestQuarantineReplay:
     def test_replay_no_records(
         self,
         cli_runner: CliRunner,
-        mock_settings: MagicMock,
-        mock_unified_quarantine: MagicMock,
+        mock_quarantine_service: MagicMock,
     ) -> None:
         """Test quarantine replay with no records."""
-        mock_unified_quarantine.replay.return_value = iter([])
+        mock_quarantine_service.replay.return_value = []
 
-        with (
-            patch(
-                "bioetl.infrastructure.config.Settings",
-                return_value=mock_settings,
-            ),
-            patch(
-                "bioetl.infrastructure.quarantine.unified.UnifiedQuarantine",
-                return_value=mock_unified_quarantine,
-            ),
+        with patch(
+            "bioetl.interfaces.cli.commands.quarantine.get_quarantine_service",
+            return_value=mock_quarantine_service,
         ):
             result = cli_runner.invoke(
                 cli,
@@ -389,25 +375,18 @@ class TestQuarantineReplay:
     def test_replay_dry_run(
         self,
         cli_runner: CliRunner,
-        mock_settings: MagicMock,
-        mock_unified_quarantine: MagicMock,
+        mock_quarantine_service: MagicMock,
     ) -> None:
         """Test quarantine replay in dry-run mode."""
         mock_records = [
             {"error_code": "DQ_ERROR", "payload_hash": "abc123def456"},
             {"error_code": "DQ_ERROR", "payload_hash": "xyz789uvw012"},
         ]
-        mock_unified_quarantine.replay.return_value = iter(mock_records)
+        mock_quarantine_service.replay.return_value = mock_records
 
-        with (
-            patch(
-                "bioetl.infrastructure.config.Settings",
-                return_value=mock_settings,
-            ),
-            patch(
-                "bioetl.infrastructure.quarantine.unified.UnifiedQuarantine",
-                return_value=mock_unified_quarantine,
-            ),
+        with patch(
+            "bioetl.interfaces.cli.commands.quarantine.get_quarantine_service",
+            return_value=mock_quarantine_service,
         ):
             result = cli_runner.invoke(
                 cli,
@@ -421,8 +400,7 @@ class TestQuarantineReplay:
     def test_replay_dry_run_many_records(
         self,
         cli_runner: CliRunner,
-        mock_settings: MagicMock,
-        mock_unified_quarantine: MagicMock,
+        mock_quarantine_service: MagicMock,
     ) -> None:
         """Test quarantine replay dry-run with many records shows truncation."""
         # Create 15 records to test truncation (shows first 10 + "... and N more")
@@ -430,17 +408,11 @@ class TestQuarantineReplay:
             {"error_code": f"DQ_ERROR_{i}", "payload_hash": f"hash{i:03d}"}
             for i in range(15)
         ]
-        mock_unified_quarantine.replay.return_value = iter(mock_records)
+        mock_quarantine_service.replay.return_value = mock_records
 
-        with (
-            patch(
-                "bioetl.infrastructure.config.Settings",
-                return_value=mock_settings,
-            ),
-            patch(
-                "bioetl.infrastructure.quarantine.unified.UnifiedQuarantine",
-                return_value=mock_unified_quarantine,
-            ),
+        with patch(
+            "bioetl.interfaces.cli.commands.quarantine.get_quarantine_service",
+            return_value=mock_quarantine_service,
         ):
             result = cli_runner.invoke(
                 cli,
@@ -454,26 +426,19 @@ class TestQuarantineReplay:
     def test_replay_actual_replay(
         self,
         cli_runner: CliRunner,
-        mock_settings: MagicMock,
-        mock_unified_quarantine: MagicMock,
+        mock_quarantine_service: MagicMock,
     ) -> None:
         """Test quarantine replay actually marks records as reprocessed."""
         mock_records = [
             {"error_code": "DQ_ERROR", "payload_hash": "abc123"},
             {"error_code": "DQ_ERROR", "payload_hash": "def456"},
         ]
-        mock_unified_quarantine.replay.return_value = iter(mock_records)
-        mock_unified_quarantine.update_status.return_value = True
+        mock_quarantine_service.replay.return_value = mock_records
+        mock_quarantine_service.mark_as_reprocessed.return_value = 2
 
-        with (
-            patch(
-                "bioetl.infrastructure.config.Settings",
-                return_value=mock_settings,
-            ),
-            patch(
-                "bioetl.infrastructure.quarantine.unified.UnifiedQuarantine",
-                return_value=mock_unified_quarantine,
-            ),
+        with patch(
+            "bioetl.interfaces.cli.commands.quarantine.get_quarantine_service",
+            return_value=mock_quarantine_service,
         ):
             result = cli_runner.invoke(
                 cli,
@@ -483,27 +448,21 @@ class TestQuarantineReplay:
         assert result.exit_code == 0
         assert "Replaying 2 record(s)" in result.output
         assert "Marked 2 record(s) as REPROCESSED" in result.output
-        # Verify update_status was called for each record
-        assert mock_unified_quarantine.update_status.call_count == 2
+        mock_quarantine_service.mark_as_reprocessed.assert_called_once_with(
+            mock_records
+        )
 
     def test_replay_with_error_code_filter(
         self,
         cli_runner: CliRunner,
-        mock_settings: MagicMock,
-        mock_unified_quarantine: MagicMock,
+        mock_quarantine_service: MagicMock,
     ) -> None:
         """Test quarantine replay with error code filter."""
-        mock_unified_quarantine.replay.return_value = iter([])
+        mock_quarantine_service.replay.return_value = []
 
-        with (
-            patch(
-                "bioetl.infrastructure.config.Settings",
-                return_value=mock_settings,
-            ),
-            patch(
-                "bioetl.infrastructure.quarantine.unified.UnifiedQuarantine",
-                return_value=mock_unified_quarantine,
-            ),
+        with patch(
+            "bioetl.interfaces.cli.commands.quarantine.get_quarantine_service",
+            return_value=mock_quarantine_service,
         ):
             result = cli_runner.invoke(
                 cli,
@@ -519,25 +478,23 @@ class TestQuarantineReplay:
 
         # Command should execute without error
         assert result.exit_code == 0
+        mock_quarantine_service.replay.assert_called_once_with(
+            pipeline="chembl_activity",
+            error_code="DQ_NETWORK_ERROR",
+            max_age_days=7,
+        )
 
     def test_replay_with_max_age_days(
         self,
         cli_runner: CliRunner,
-        mock_settings: MagicMock,
-        mock_unified_quarantine: MagicMock,
+        mock_quarantine_service: MagicMock,
     ) -> None:
         """Test quarantine replay with custom max-age-days."""
-        mock_unified_quarantine.replay.return_value = iter([])
+        mock_quarantine_service.replay.return_value = []
 
-        with (
-            patch(
-                "bioetl.infrastructure.config.Settings",
-                return_value=mock_settings,
-            ),
-            patch(
-                "bioetl.infrastructure.quarantine.unified.UnifiedQuarantine",
-                return_value=mock_unified_quarantine,
-            ),
+        with patch(
+            "bioetl.interfaces.cli.commands.quarantine.get_quarantine_service",
+            return_value=mock_quarantine_service,
         ):
             result = cli_runner.invoke(
                 cli,
@@ -553,8 +510,11 @@ class TestQuarantineReplay:
 
         # Command should execute without error
         assert result.exit_code == 0
-        # Verify replay was called
-        mock_unified_quarantine.replay.assert_called_once()
+        mock_quarantine_service.replay.assert_called_once_with(
+            pipeline="chembl_activity",
+            error_code=None,
+            max_age_days=14,
+        )
 
 
 class TestQuarantinePurge:
@@ -580,21 +540,14 @@ class TestQuarantinePurge:
     def test_purge_dry_run(
         self,
         cli_runner: CliRunner,
-        mock_settings: MagicMock,
-        mock_unified_quarantine: MagicMock,
+        mock_quarantine_service: MagicMock,
     ) -> None:
         """Test quarantine purge in dry-run mode."""
-        mock_unified_quarantine.get_stats = AsyncMock(return_value={"total_count": 50})
+        mock_quarantine_service.get_stats = AsyncMock(return_value={"total_count": 50})
 
-        with (
-            patch(
-                "bioetl.infrastructure.config.Settings",
-                return_value=mock_settings,
-            ),
-            patch(
-                "bioetl.infrastructure.quarantine.unified.UnifiedQuarantine",
-                return_value=mock_unified_quarantine,
-            ),
+        with patch(
+            "bioetl.interfaces.cli.commands.quarantine.get_quarantine_service",
+            return_value=mock_quarantine_service,
         ):
             result = cli_runner.invoke(
                 cli,
@@ -609,21 +562,14 @@ class TestQuarantinePurge:
     def test_purge_with_confirmation(
         self,
         cli_runner: CliRunner,
-        mock_settings: MagicMock,
-        mock_unified_quarantine: MagicMock,
+        mock_quarantine_service: MagicMock,
     ) -> None:
         """Test quarantine purge with confirmation prompt."""
-        mock_unified_quarantine.purge.return_value = 25
+        mock_quarantine_service.purge.return_value = 25
 
-        with (
-            patch(
-                "bioetl.infrastructure.config.Settings",
-                return_value=mock_settings,
-            ),
-            patch(
-                "bioetl.infrastructure.quarantine.unified.UnifiedQuarantine",
-                return_value=mock_unified_quarantine,
-            ),
+        with patch(
+            "bioetl.interfaces.cli.commands.quarantine.get_quarantine_service",
+            return_value=mock_quarantine_service,
         ):
             # Simulate user confirming with 'y'
             result = cli_runner.invoke(
@@ -638,19 +584,12 @@ class TestQuarantinePurge:
     def test_purge_confirmation_abort(
         self,
         cli_runner: CliRunner,
-        mock_settings: MagicMock,
-        mock_unified_quarantine: MagicMock,
+        mock_quarantine_service: MagicMock,
     ) -> None:
         """Test quarantine purge aborts on negative confirmation."""
-        with (
-            patch(
-                "bioetl.infrastructure.config.Settings",
-                return_value=mock_settings,
-            ),
-            patch(
-                "bioetl.infrastructure.quarantine.unified.UnifiedQuarantine",
-                return_value=mock_unified_quarantine,
-            ),
+        with patch(
+            "bioetl.interfaces.cli.commands.quarantine.get_quarantine_service",
+            return_value=mock_quarantine_service,
         ):
             # Simulate user aborting with 'n'
             result = cli_runner.invoke(
@@ -666,21 +605,14 @@ class TestQuarantinePurge:
     def test_purge_with_force(
         self,
         cli_runner: CliRunner,
-        mock_settings: MagicMock,
-        mock_unified_quarantine: MagicMock,
+        mock_quarantine_service: MagicMock,
     ) -> None:
         """Test quarantine purge with --force skips confirmation."""
-        mock_unified_quarantine.purge.return_value = 30
+        mock_quarantine_service.purge.return_value = 30
 
-        with (
-            patch(
-                "bioetl.infrastructure.config.Settings",
-                return_value=mock_settings,
-            ),
-            patch(
-                "bioetl.infrastructure.quarantine.unified.UnifiedQuarantine",
-                return_value=mock_unified_quarantine,
-            ),
+        with patch(
+            "bioetl.interfaces.cli.commands.quarantine.get_quarantine_service",
+            return_value=mock_quarantine_service,
         ):
             result = cli_runner.invoke(
                 cli,
@@ -689,27 +621,22 @@ class TestQuarantinePurge:
 
         assert result.exit_code == 0
         assert "Purged 30 record(s)" in result.output
-        # Verify purge was called
-        mock_unified_quarantine.purge.assert_called_once()
+        mock_quarantine_service.purge.assert_called_once_with(
+            pipeline="chembl_activity",
+            older_than_days=30,
+        )
 
     def test_purge_custom_older_than_days(
         self,
         cli_runner: CliRunner,
-        mock_settings: MagicMock,
-        mock_unified_quarantine: MagicMock,
+        mock_quarantine_service: MagicMock,
     ) -> None:
         """Test quarantine purge with custom --older-than-days."""
-        mock_unified_quarantine.purge.return_value = 10
+        mock_quarantine_service.purge.return_value = 10
 
-        with (
-            patch(
-                "bioetl.infrastructure.config.Settings",
-                return_value=mock_settings,
-            ),
-            patch(
-                "bioetl.infrastructure.quarantine.unified.UnifiedQuarantine",
-                return_value=mock_unified_quarantine,
-            ),
+        with patch(
+            "bioetl.interfaces.cli.commands.quarantine.get_quarantine_service",
+            return_value=mock_quarantine_service,
         ):
             result = cli_runner.invoke(
                 cli,
@@ -725,10 +652,10 @@ class TestQuarantinePurge:
             )
 
         assert result.exit_code == 0
-        # Verify purge was called with older_than_days=60
-        mock_unified_quarantine.purge.assert_called_once()
-        call_kwargs = mock_unified_quarantine.purge.call_args.kwargs
-        assert call_kwargs.get("older_than_days") == 60
+        mock_quarantine_service.purge.assert_called_once_with(
+            pipeline="chembl_activity",
+            older_than_days=60,
+        )
 
 
 class TestQuarantineResolve:
@@ -762,21 +689,14 @@ class TestQuarantineResolve:
     def test_resolve_success_default_status(
         self,
         cli_runner: CliRunner,
-        mock_settings: MagicMock,
-        mock_unified_quarantine: MagicMock,
+        mock_quarantine_service: MagicMock,
     ) -> None:
         """Test quarantine resolve with default IGNORED status."""
-        mock_unified_quarantine.update_status.return_value = True
+        mock_quarantine_service.update_status.return_value = True
 
-        with (
-            patch(
-                "bioetl.infrastructure.config.Settings",
-                return_value=mock_settings,
-            ),
-            patch(
-                "bioetl.infrastructure.quarantine.unified.UnifiedQuarantine",
-                return_value=mock_unified_quarantine,
-            ),
+        with patch(
+            "bioetl.interfaces.cli.commands.quarantine.get_quarantine_service",
+            return_value=mock_quarantine_service,
         ):
             result = cli_runner.invoke(
                 cli,
@@ -792,28 +712,21 @@ class TestQuarantineResolve:
 
         assert result.exit_code == 0
         assert "Record abc123def456 marked as IGNORED" in result.output
-        mock_unified_quarantine.update_status.assert_called_once_with(
+        mock_quarantine_service.update_status.assert_called_once_with(
             "abc123def456", QuarantineRecordStatus.IGNORED
         )
 
     def test_resolve_with_reprocessed_status(
         self,
         cli_runner: CliRunner,
-        mock_settings: MagicMock,
-        mock_unified_quarantine: MagicMock,
+        mock_quarantine_service: MagicMock,
     ) -> None:
         """Test quarantine resolve with REPROCESSED status."""
-        mock_unified_quarantine.update_status.return_value = True
+        mock_quarantine_service.update_status.return_value = True
 
-        with (
-            patch(
-                "bioetl.infrastructure.config.Settings",
-                return_value=mock_settings,
-            ),
-            patch(
-                "bioetl.infrastructure.quarantine.unified.UnifiedQuarantine",
-                return_value=mock_unified_quarantine,
-            ),
+        with patch(
+            "bioetl.interfaces.cli.commands.quarantine.get_quarantine_service",
+            return_value=mock_quarantine_service,
         ):
             result = cli_runner.invoke(
                 cli,
@@ -831,28 +744,21 @@ class TestQuarantineResolve:
 
         assert result.exit_code == 0
         assert "Record xyz789 marked as REPROCESSED" in result.output
-        mock_unified_quarantine.update_status.assert_called_once_with(
+        mock_quarantine_service.update_status.assert_called_once_with(
             "xyz789", QuarantineRecordStatus.REPROCESSED
         )
 
     def test_resolve_record_not_found(
         self,
         cli_runner: CliRunner,
-        mock_settings: MagicMock,
-        mock_unified_quarantine: MagicMock,
+        mock_quarantine_service: MagicMock,
     ) -> None:
         """Test quarantine resolve when record not found."""
-        mock_unified_quarantine.update_status.return_value = False
+        mock_quarantine_service.update_status.return_value = False
 
-        with (
-            patch(
-                "bioetl.infrastructure.config.Settings",
-                return_value=mock_settings,
-            ),
-            patch(
-                "bioetl.infrastructure.quarantine.unified.UnifiedQuarantine",
-                return_value=mock_unified_quarantine,
-            ),
+        with patch(
+            "bioetl.interfaces.cli.commands.quarantine.get_quarantine_service",
+            return_value=mock_quarantine_service,
         ):
             result = cli_runner.invoke(
                 cli,
@@ -917,53 +823,39 @@ class TestQuarantineEdgeCases:
     def test_replay_record_without_payload_hash(
         self,
         cli_runner: CliRunner,
-        mock_settings: MagicMock,
-        mock_unified_quarantine: MagicMock,
+        mock_quarantine_service: MagicMock,
     ) -> None:
         """Test replay handles records without payload_hash."""
         # Record without payload_hash
         mock_records = [{"error_code": "DQ_ERROR"}]
-        mock_unified_quarantine.replay.return_value = iter(mock_records)
-        mock_unified_quarantine.update_status.return_value = True
+        mock_quarantine_service.replay.return_value = mock_records
+        mock_quarantine_service.mark_as_reprocessed.return_value = 0
 
-        with (
-            patch(
-                "bioetl.infrastructure.config.Settings",
-                return_value=mock_settings,
-            ),
-            patch(
-                "bioetl.infrastructure.quarantine.unified.UnifiedQuarantine",
-                return_value=mock_unified_quarantine,
-            ),
+        with patch(
+            "bioetl.interfaces.cli.commands.quarantine.get_quarantine_service",
+            return_value=mock_quarantine_service,
         ):
             result = cli_runner.invoke(
                 cli,
                 ["quarantine", "replay", "--pipeline", "chembl_activity"],
             )
 
-        # Should not crash, but update_status won't be called for records without hash
+        # Should not crash
         assert result.exit_code == 0
 
     def test_replay_dry_run_shows_hash_truncated(
         self,
         cli_runner: CliRunner,
-        mock_settings: MagicMock,
-        mock_unified_quarantine: MagicMock,
+        mock_quarantine_service: MagicMock,
     ) -> None:
         """Test replay dry-run truncates long payload hashes."""
         long_hash = "a" * 64  # SHA256 hash length
         mock_records = [{"error_code": "DQ_ERROR", "payload_hash": long_hash}]
-        mock_unified_quarantine.replay.return_value = iter(mock_records)
+        mock_quarantine_service.replay.return_value = mock_records
 
-        with (
-            patch(
-                "bioetl.infrastructure.config.Settings",
-                return_value=mock_settings,
-            ),
-            patch(
-                "bioetl.infrastructure.quarantine.unified.UnifiedQuarantine",
-                return_value=mock_unified_quarantine,
-            ),
+        with patch(
+            "bioetl.interfaces.cli.commands.quarantine.get_quarantine_service",
+            return_value=mock_quarantine_service,
         ):
             result = cli_runner.invoke(
                 cli,
@@ -976,21 +868,14 @@ class TestQuarantineEdgeCases:
     def test_purge_dry_run_custom_days(
         self,
         cli_runner: CliRunner,
-        mock_settings: MagicMock,
-        mock_unified_quarantine: MagicMock,
+        mock_quarantine_service: MagicMock,
     ) -> None:
         """Test purge dry-run shows custom older-than-days."""
-        mock_unified_quarantine.get_stats = AsyncMock(return_value={"total_count": 100})
+        mock_quarantine_service.get_stats = AsyncMock(return_value={"total_count": 100})
 
-        with (
-            patch(
-                "bioetl.infrastructure.config.Settings",
-                return_value=mock_settings,
-            ),
-            patch(
-                "bioetl.infrastructure.quarantine.unified.UnifiedQuarantine",
-                return_value=mock_unified_quarantine,
-            ),
+        with patch(
+            "bioetl.interfaces.cli.commands.quarantine.get_quarantine_service",
+            return_value=mock_quarantine_service,
         ):
             result = cli_runner.invoke(
                 cli,

--- a/tests/unit/test_ports.py
+++ b/tests/unit/test_ports.py
@@ -344,6 +344,10 @@ class TestQuarantinePortProtocol:
 
     def test_valid_quarantine_implementation(self) -> None:
         """QuarantinePort should accept valid implementations."""
+        from collections.abc import Iterator
+        from datetime import datetime
+
+        from bioetl.domain.types import QuarantineRecordStatus
 
         class ValidQuarantine:
             async def write(
@@ -354,6 +358,8 @@ class TestQuarantinePortProtocol:
                 bronze_batch_id: BatchID,
                 run_id: RunID | None = None,
                 metadata: dict[str, Any] | None = None,
+                *,
+                ingestion_ts: datetime,
             ) -> None:
                 pass
 
@@ -368,6 +374,32 @@ class TestQuarantinePortProtocol:
             async def get_stats(self, pipeline: str) -> dict[str, Any]:
                 return {}
 
+            def replay(
+                self,
+                pipeline: str,
+                error_code: str | None = None,
+                max_age_days: int = 7,
+                *,
+                now: datetime,
+            ) -> Iterator[dict[str, Any]]:
+                return iter([])
+
+            def purge(
+                self,
+                pipeline: str,
+                older_than_days: int = 30,
+                *,
+                now: datetime,
+            ) -> int:
+                return 0
+
+            def update_status(
+                self,
+                payload_hash: str,
+                new_status: QuarantineRecordStatus,
+            ) -> bool:
+                return True
+
             async def aclose(self) -> None:
                 pass
 
@@ -375,6 +407,10 @@ class TestQuarantinePortProtocol:
 
     def test_missing_write_fails(self) -> None:
         """QuarantinePort should reject implementations missing write."""
+        from collections.abc import Iterator
+        from datetime import datetime
+
+        from bioetl.domain.types import QuarantineRecordStatus
 
         class InvalidQuarantine:
             # Missing write method
@@ -388,6 +424,32 @@ class TestQuarantinePortProtocol:
 
             async def get_stats(self, pipeline: str) -> dict[str, Any]:
                 return {}
+
+            def replay(
+                self,
+                pipeline: str,
+                error_code: str | None = None,
+                max_age_days: int = 7,
+                *,
+                now: datetime,
+            ) -> Iterator[dict[str, Any]]:
+                return iter([])
+
+            def purge(
+                self,
+                pipeline: str,
+                older_than_days: int = 30,
+                *,
+                now: datetime,
+            ) -> int:
+                return 0
+
+            def update_status(
+                self,
+                payload_hash: str,
+                new_status: QuarantineRecordStatus,
+            ) -> bool:
+                return True
 
             async def aclose(self) -> None:
                 pass


### PR DESCRIPTION
…Quarantine access

IF-002: Refactored CLI quarantine commands to use `get_quarantine_service()` instead of directly importing `UnifiedQuarantine` from infrastructure layer.

Changes:
- Extended `QuarantinePort` with `replay`, `purge`, and `update_status` methods
- Updated `QuarantineService` to delegate to port for replay/purge/update_status
- Refactored `quarantine_replay` to use QuarantineService
- Refactored `quarantine_purge` to use QuarantineService
- Refactored `quarantine_resolve` to use QuarantineService
- Removed unused `ReplayResult` and `PurgeResult` dataclasses
- Updated architecture test allowlist (removed quarantine.py from violations)
- Updated unit tests to mock QuarantineService instead of infrastructure

This improves architecture compliance by ensuring CLI commands use the application layer service instead of infrastructure directly.