### PR TITLE
Document architecture decision on interface imports

### DIFF
--- a/docs/02-architecture/decisions/ADR-005-composition-layer-separation.md
+++ b/docs/02-architecture/decisions/ADR-005-composition-layer-separation.md
@@ -46,13 +46,23 @@ From ↓ / To →        domain  application  infrastructure  composition  inter
 domain                 ✅        ❌             ❌             ❌           ❌
 application            ✅        ✅             ❌             ❌           ❌
 infrastructure         ✅        ❌             ✅             ❌           ❌
-composition            ✅        ✅             ✅             ✅           ✅
-interfaces             ✅        ✅             ❌             ✅           ✅
+composition            ✅        ✅             ✅             ✅           ❌
+interfaces             ✅        ✅             ✅             ✅           ✅
 ```
 
-Key observation: `interfaces/` must NOT import from `infrastructure/` directly. It uses `composition/bootstrap` to get fully assembled objects. If we merge composition into interfaces, we either:
-- Allow interfaces to import infrastructure (breaks Hexagonal Architecture)
-- Create an awkward sub-module that has different import rules than its parent
+> **Note (2026-01-05):** The import matrix allows `interfaces → infrastructure`. This is intentional
+> and consistent with CLAUDE.md §2.1. The `interfaces` layer (CLI, API handlers) may occasionally
+> need direct infrastructure access for:
+> - Health monitoring endpoints (`health.py` → `health_monitor`, `prometheus_metrics`)
+> - Observability setup (`observability.py` → infrastructure adapters)
+>
+> However, **best practice** is to route through Application layer services when possible
+> for better testability and consistency. See architecture tests in
+> `tests/architecture/test_interfaces_no_infrastructure.py` for tracked legacy violations.
+
+Key observation: `composition/` remains the primary DI layer. While `interfaces/` *can* import from `infrastructure/`, it *should prefer* using `composition/` to get fully assembled objects. If we merge composition into interfaces, we:
+- Lose the explicit separation of wiring concern
+- Make it harder to identify where dependency assembly happens
 
 ### 3. Multiple Consumers of Composition Root
 
@@ -163,6 +173,7 @@ src/bioetl/
 - [ADR-010](ADR-010-local-only-deployment.md): Local-Only Deployment — simplified composition factories
 - [ADR-011](ADR-011-remove-watermark-mechanism.md): Remove Watermark — removed watermark factories from composition
 - [ADR-015](ADR-015-pipeline-services-lifecycle.md): Pipeline Services Lifecycle — services assembled in composition
+- [ADR-019](ADR-019-observability-port-enforcement.md): Observability Port Enforcement — clarifies that interfaces must use LoggerPort (not structlog directly), even though interfaces→infrastructure is allowed in the import matrix
 - [ADR-020](ADR-020-basepipeline-decomposition.md): BasePipeline Decomposition — defines components that composition/ assembles
 - **RULES.md §1.1**: Ports & Adapters architecture — composition implements the "glue" layer
 


### PR DESCRIPTION
- Fix import matrix to match CLAUDE.md §2.1:
  - composition→interfaces: ❌ (was incorrectly ✅)
  - interfaces→infrastructure: ✅ (was incorrectly ❌)
- Add explanatory note clarifying that interfaces CAN import from infrastructure per project rules (health endpoints, observability setup)
- Note best practice is still to route through Application services
- Add ADR-019 (Observability Port Enforcement) to related ADRs