### PR TITLE
Move observability to composition layer

### DIFF
--- a/src/bioetl/composition/_bootstrap/__init__.py
+++ b/src/bioetl/composition/_bootstrap/__init__.py
@@ -25,12 +25,14 @@ from bioetl.composition._bootstrap.config import bootstrap_config_service
 from bioetl.composition._bootstrap.health import bootstrap_health_service
 from bioetl.composition._bootstrap.lock import bootstrap_lock_service
 from bioetl.composition._bootstrap.observability import (
+    MetricsServerError,
     bootstrap_dq_monitor,
     bootstrap_logger,
     bootstrap_metrics,
     bootstrap_metrics_service,
     bootstrap_observability,
     bootstrap_tracer,
+    start_metrics_server,
     validate_observability_preflight,
 )
 from bioetl.composition._bootstrap.runner import bootstrap_pipeline_runner_service
@@ -43,6 +45,7 @@ from bioetl.composition._bootstrap.storage import (
 )
 
 __all__ = [
+    "MetricsServerError",
     "bootstrap_bronze_cleanup_service",
     "bootstrap_checkpoint",
     "bootstrap_checkpoint_manager",
@@ -64,5 +67,6 @@ __all__ = [
     "bootstrap_storage",
     "bootstrap_tracer",
     "bootstrap_vacuum_service",
+    "start_metrics_server",
     "validate_observability_preflight",
 ]

--- a/src/bioetl/composition/_bootstrap/observability.py
+++ b/src/bioetl/composition/_bootstrap/observability.py
@@ -22,7 +22,10 @@ from bioetl.domain.ports import LoggerPort, MetricsPort, TracingPort
 from bioetl.infrastructure.observability.noop_metrics import NoOpMetrics
 from bioetl.infrastructure.observability.noop_tracing import NoOpTracing
 from bioetl.infrastructure.observability.prometheus_metrics import PrometheusMetrics
-from bioetl.infrastructure.observability.server import start_metrics_server
+from bioetl.infrastructure.observability.server import (
+    MetricsServerError,
+    start_metrics_server,
+)
 from bioetl.infrastructure.observability.tracing import OpenTelemetryTracer
 from bioetl.infrastructure.observability.unified_logger import UnifiedLogger
 
@@ -32,12 +35,14 @@ if TYPE_CHECKING:
     from bioetl.infrastructure.config import Settings
 
 __all__ = [
+    "MetricsServerError",
     "bootstrap_dq_monitor",
     "bootstrap_logger",
     "bootstrap_metrics",
     "bootstrap_metrics_service",
     "bootstrap_observability",
     "bootstrap_tracer",
+    "start_metrics_server",
     "validate_observability_preflight",
 ]
 

--- a/src/bioetl/interfaces/observability.py
+++ b/src/bioetl/interfaces/observability.py
@@ -1,47 +1,22 @@
 """Observability interface for BioETL.
 
-Handles the exposure of metrics and other observability signals to external systems.
+Re-exports observability components from the composition layer.
+This module exists for backward compatibility and provides a clean
+interface for external consumers.
+
+Note:
+    For architectural purity, these components are managed by the
+    composition layer and re-exported here for the interfaces layer.
 """
 
 from __future__ import annotations
 
-from bioetl.infrastructure.observability.server import (
+from bioetl.composition._bootstrap import (
     MetricsServerError,
-)
-from bioetl.infrastructure.observability.server import (
-    start_metrics_server as _start_server,
+    start_metrics_server,
 )
 
 __all__ = [
     "MetricsServerError",
     "start_metrics_server",
 ]
-
-
-def start_metrics_server(
-    port: int = 8000,
-    *,
-    fail_fast: bool = False,
-    retry_count: int = 3,
-    retry_delay: float = 1.0,
-) -> bool:
-    """Start Prometheus metrics HTTP server in a daemon thread.
-
-    Args:
-        port: Port to bind the HTTP server (default: 8000)
-        fail_fast: If True, raise MetricsServerError on failure
-        retry_count: Number of retries for transient errors (default: 3)
-        retry_delay: Delay between retries in seconds (default: 1.0)
-
-    Returns:
-        True if server started successfully, False otherwise
-
-    Raises:
-        MetricsServerError: If fail_fast=True and server cannot start
-    """
-    return _start_server(
-        port=port,
-        fail_fast=fail_fast,
-        retry_count=retry_count,
-        retry_delay=retry_delay,
-    )

--- a/tests/unit/interfaces/test_observability.py
+++ b/tests/unit/interfaces/test_observability.py
@@ -4,12 +4,13 @@ from unittest import mock
 
 import pytest
 
+from bioetl.composition._bootstrap import observability as composition_observability
 from bioetl.infrastructure.observability import server as obs_server
 from bioetl.interfaces import observability
 
 # This module tests the observability interface.
-# The observability module starts a metrics server internally by setting `_SERVER_STARTED` to `True`.
-# Below are the test functions to ensure server initialization behaviour.
+# The observability module re-exports metrics server components from composition layer,
+# which in turn imports from infrastructure.
 
 
 # Mock `_SERVER_STARTED` to isolate state among test cases.
@@ -22,7 +23,7 @@ def reset_server_started():
 
 
 def test_start_metrics_server_success():
-    """Verify metrics_server starts successfully"""
+    """Verify metrics_server starts successfully via interface."""
     with mock.patch(
         "bioetl.infrastructure.observability.server.start_http_server"
     ) as mock_start:
@@ -45,27 +46,23 @@ def test_start_metrics_server_failure():
         assert result is False
 
 
-def test_interface_passes_config_params():
-    """Verify interface layer passes all config params to server."""
-    # Patch at the module level where it's imported as _start_server
-    with mock.patch("bioetl.interfaces.observability._start_server") as mock_server:
-        mock_server.return_value = True
-        result = observability.start_metrics_server(
-            port=9090,
-            fail_fast=True,
-            retry_count=5,
-            retry_delay=2.0,
-        )
+def test_interface_re_exports_from_composition():
+    """Verify interface re-exports start_metrics_server from composition layer.
 
-        mock_server.assert_called_once_with(
-            port=9090,
-            fail_fast=True,
-            retry_count=5,
-            retry_delay=2.0,
-        )
-        assert result is True
+    After architectural refactoring, interfaces/observability.py re-exports
+    from composition/_bootstrap for architectural purity.
+    """
+    # The function should be the same object since it's a re-export
+    assert (
+        observability.start_metrics_server
+        is composition_observability.start_metrics_server
+    )
 
 
 def test_interface_exposes_metrics_server_error():
-    """Verify MetricsServerError is exported from interface."""
+    """Verify MetricsServerError is exported from interface via composition."""
+    # Interface re-exports from composition, which imports from infrastructure
     assert observability.MetricsServerError is obs_server.MetricsServerError
+    assert (
+        observability.MetricsServerError is composition_observability.MetricsServerError
+    )


### PR DESCRIPTION
… layer

For architectural purity, the observability.py functionality in the interfaces layer now re-exports from composition instead of directly importing from infrastructure. This follows the hexagonal architecture where composition is responsible for wiring infrastructure to application.

Changes:
- Add MetricsServerError and start_metrics_server exports to composition/_bootstrap/observability.py
- Update composition/_bootstrap/__init__.py to expose these exports
- Refactor interfaces/observability.py to re-export from composition
- Update tests to verify the new import chain