### PR TITLE
Document ChEMBL cell line provider for production

### DIFF
--- a/docs/providers/chembl/cell-line.md
+++ b/docs/providers/chembl/cell-line.md
@@ -1,0 +1,161 @@
+# Пайплайн: ChEMBL Cell Line
+
+**Имя пайплайна:** `chembl_cell_line`
+**Провайдер:** `chembl`
+**Сущность:** `cell_line`
+**Версия схемы:** 1.0.0
+
+---
+
+## 1. Описание
+
+Пайплайн извлекает данные о клеточных линиях из API ChEMBL. Клеточные линии — это биологические объекты, используемые для in vitro экспериментов. Они имеют связь M:N с сущностью Assay (через FK `assay.cell_chembl_id`).
+
+**Источник данных:** ChEMBL REST API, таблица `cell_dictionary`
+
+---
+
+## 2. Ключевые поля
+
+### Идентификаторы
+
+| Поле | Тип | Описание |
+|------|-----|----------|
+| `cell_chembl_id` | `str` | Уникальный ChEMBL ID клеточной линии (PK) |
+| `cell_name` | `str` | Название клеточной линии (напр., HeLa, MCF7) |
+
+### Метаданные
+
+| Поле | Тип | Описание |
+|------|-----|----------|
+| `cell_description` | `str` | Описание клеточной линии |
+| `cell_type` | `str` | Тип клеточной линии (напр., Cancer cell line) |
+
+### Источник
+
+| Поле | Тип | Описание |
+|------|-----|----------|
+| `cell_source_tissue` | `str` | Ткань-источник (напр., Cervix, Breast) |
+| `cell_source_organism` | `str` | Организм-источник (напр., Homo sapiens) |
+| `cell_source_tax_id` | `int` | NCBI Taxonomy ID организма-источника |
+
+### Внешние идентификаторы
+
+| Поле | Тип | Описание |
+|------|-----|----------|
+| `cellosaurus_id` | `str` | Cellosaurus ID (формат: `CVCL_XXXX`) |
+| `clo_id` | `str` | Cell Line Ontology ID (формат: `CLO_XXXXX`) |
+| `cl_lincs_id` | `str` | LINCS ID (Library of Integrated Network-Based Cellular Signatures) |
+| `efo_id` | `str` | EFO ontology ID (формат: `EFO_XXXXX`) |
+
+---
+
+## 3. Трансформация
+
+**Файл:** `src/bioetl/application/pipelines/chembl/cell_line_transformer.py`
+
+### Нормализация данных
+
+- **cell_name:** Строка нормализуется через `normalize_to_string()` (strip whitespace)
+- **cell_source_tax_id:** Валидируется через `validate_positive_int()` (должен быть >= 1)
+- **Внешние ID:** Пустые строки и whitespace преобразуются в `NULL`
+
+### Entity ID
+
+```python
+entity_id = f"chembl:{cell_chembl_id}"
+```
+
+---
+
+## 4. Валидация
+
+### DQ-правила
+
+1. **`cell_chembl_id`** — обязательное, формат `^CHEMBL\d+$`
+2. **`cell_name`** — обязательное
+3. **`cell_source_tax_id`** — если указан, должен быть >= 1
+4. **Внешние ID** — если указаны, валидируются по regex:
+   - `cellosaurus_id`: `^CVCL_[A-Z0-9]+$`
+   - `clo_id`: `^CLO_\d+$`
+   - `efo_id`: `^EFO_\d+$`
+
+### Пороги ошибок
+
+| Порог | Условие | Действие |
+|-------|---------|----------|
+| Soft | > 5% ошибок | WARNING |
+| Hard | > 20% ошибок | FAIL BATCH |
+
+---
+
+## 5. Использование CLI
+
+```bash
+# Инкрементальная загрузка
+bioetl run chembl_cell_line
+
+# С ограничением количества записей
+bioetl run chembl_cell_line --limit 500
+
+# Полная перезагрузка
+bioetl run chembl_cell_line --run-type rebuild
+
+# С входным фильтром по списку ID
+bioetl run chembl_cell_line --input-filter data/input/cell.csv
+```
+
+---
+
+## 6. Связанные файлы
+
+| Компонент | Путь |
+|-----------|------|
+| Конфигурация | `configs/pipelines/chembl/cell_line.yaml` |
+| Трансформер | `src/bioetl/application/pipelines/chembl/cell_line_transformer.py` |
+| Пайплайн | `src/bioetl/application/pipelines/chembl/cell_line.py` |
+| Схема | `src/bioetl/domain/schemas/chembl/cell_line.py` |
+| Сущность | `src/bioetl/domain/entities.py` |
+| Фабрика | `src/bioetl/composition/factories/pipeline_factories.py` |
+
+---
+
+## 7. Связи с другими сущностями
+
+```
+Cell Line (cell_chembl_id)
+    └── Assay (cell_chembl_id FK) [M:N]
+        └── Activity [1:N]
+```
+
+---
+
+## 8. Примеры данных
+
+### Bronze (raw JSON)
+
+```json
+{
+  "cell_chembl_id": "CHEMBL3308376",
+  "cell_name": "HeLa",
+  "cell_description": "Human cervical cancer cell line",
+  "cell_source_tissue": "Cervix",
+  "cell_source_organism": "Homo sapiens",
+  "cell_source_tax_id": 9606,
+  "cell_type": "Cancer cell line",
+  "cellosaurus_id": "CVCL_0030",
+  "clo_id": "CLO_0003684",
+  "cl_lincs_id": "LCL-1234",
+  "efo_id": "EFO_0001185"
+}
+```
+
+### Silver (нормализованный)
+
+| cell_chembl_id | cell_name | cell_source_organism | cell_source_tax_id | cellosaurus_id |
+|----------------|-----------|----------------------|--------------------|----------------|
+| CHEMBL3308376 | HeLa | Homo sapiens | 9606 | CVCL_0030 |
+
+---
+
+*Последнее обновление: 2025-01-05*

--- a/tests/fixtures/vcr/TestChemblCellLinePipeline.test_chembl_cell_line_happy_path.yaml
+++ b/tests/fixtures/vcr/TestChemblCellLinePipeline.test_chembl_cell_line_happy_path.yaml
@@ -1,0 +1,361 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Host:
+      - www.ebi.ac.uk
+      User-Agent:
+      - BioETL/5.0.0
+    method: GET
+    uri: https://www.ebi.ac.uk/chembl/api/data/status.json
+  response:
+    body:
+      string: "<!doctype html>\n<html lang=\"en\" class=\"vf-no-js\">\n  <head>\n
+        \   <script>\n// Detect if JS is on and swap vf-no-js for vf-js on the html
+        element\n(function(H){H.className=H.className.replace(/\\bvf-no-js\\b/,'vf-js')})(document.documentElement);\n</script>\n\n
+        \   <meta charset=\"utf-8\">\n    <meta name=\"viewport\" content=\"width=device-width,
+        initial-scale=1.0\">\n    <!-- <link rel=\"stylesheet\" media=\"all\" href=\"/css/styles.css?\"
+        /> -->\n    <title>Error: 500 | EMBL\u2019s European Bionformatics Institute</title>\n\n\n\n
+        \   <link rel=\"icon\" type=\"image/x-icon\"\n  href=\"https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/images/logos/EMBL-EBI/favicons/favicon.ico\"
+        />\n<link rel=\"icon\" type=\"image/png\"\n  href=\"https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/images/logos/EMBL-EBI/favicons/favicon-32x32.png\"
+        />\n<link rel=\"icon\" type=\"image/png\" sizes=\"192\xD7192\"\n  href=\"https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/images/logos/EMBL-EBI/favicons/android-chrome-192x192.png\"
+        />\n<!-- Android (192px) -->\n<link rel=\"apple-touch-icon-precomposed\" sizes=\"114x114\"\n
+        \ href=\"https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/images/logos/EMBL-EBI/favicons/apple-icon-114x114.png\"
+        />\n<!-- For iPhone 4 Retina display (114px) -->\n<link rel=\"apple-touch-icon-precomposed\"
+        sizes=\"72x72\"\n  href=\"https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/images/logos/EMBL-EBI/favicons/apple-icon-72x72.png\"
+        />\n<!-- For iPad (72px) -->\n<link rel=\"apple-touch-icon-precomposed\" sizes=\"144x144\"\n
+        \ href=\"https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/images/logos/EMBL-EBI/favicons/apple-icon-144x144.png\"
+        />\n<!-- For iPad retinat (144px) -->\n<link rel=\"apple-touch-icon-precomposed\"\n
+        \ href=\"https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/images/logos/EMBL-EBI/favicons/apple-icon-57x57.png\"
+        />\n<!-- For iPhone (57px) -->\n<link rel=\"mask-icon\"\n  href=\"https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/images/logos/EMBL-EBI/favicons/safari-pinned-tab.svg\"\n
+        \ color=\"#ffffff\" /> <!-- Safari icon for pinned tab -->\n<meta name=\"msapplication-TileColor\"
+        content=\"#2b5797\" /> <!-- MS Icons -->\n<meta name=\"msapplication-TileImage\"\n
+        \ content=\"https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/images/logos/EMBL-EBI/favicons/mstile-144x144.png\"
+        />\n\n\n\n\n\n\n    <!-- Search indexing optimisations -->\n    <meta class=\"swiftype\"
+        name=\"what\" data-type=\"string\" content=\"none\" />\n    <meta class=\"swiftype\"
+        name=\"where\" data-type=\"string\" content=\"EMBL-EBI\" />\n\n\n    <!--
+        Descriptive meta -->\n    <meta name=\"title\" content=\"Error: 500\">\n    <meta
+        name=\"author\" content=\"European Bioinformatics Institute\">\n    <meta
+        name=\"robots\" content=\"index, follow\">\n    <meta name=\"keywords\" content=\"\">\n
+        \   <meta name=\"description\" content=\"\">\n\n    <!-- Open Graph / Facebook
+        -->\n    <meta property=\"og:type\" content=\"website\">\n    <meta property=\"og:url\"
+        content=\"https://www.ebi.ac.uk/info/error-pages/500-standalone/\">\n    <meta
+        property=\"og:title\" content=\"Error: 500\">\n    <meta property=\"og:description\"
+        content=\"\">\n\n\n    <!-- Twitter -->\n    <meta property=\"twitter:card\"
+        content=\"summary_large_image\">\n    <meta property=\"og:url\" content=\"https://www.ebi.ac.uk/info/error-pages/500-standalone/\">\n
+        \   <meta property=\"twitter:title\" content=\"Error: 500\">\n    <meta property=\"twitter:description\"
+        content=\"\">\n\n\n    <!-- Content descriptors -->\n    <meta name=\"embl:who\"
+        content=\"EMBL-EBI Web Dev\">\n    <meta name=\"embl:where\" content=\"EMBL-EBI\">\n
+        \   <meta name=\"embl:what\" content=\"none\">\n    <meta name=\"embl:active\"
+        content=\"where\">\n\n    <!-- Content role -->\n    <meta name=\"embl:utility\"
+        content=\"10\">\n    <meta name=\"embl:reach\" content=\"0\">\n\n    <!--
+        Page infromation -->\n    <meta name=\"embl:maintainer\" content=\"EMBL-EBI
+        Web Dev\">\n    <meta name=\"embl:last-review\" content=\"2021.04.01\">\n
+        \   <meta name=\"embl:review-cycle\" content=\"365\">\n    <meta name=\"embl:expiry\"
+        content=\"never\">\n\n    <!-- analytics -->\n    <meta name=\"vf:page-type\"
+        content=\"404;dimension1\">\n\n    <!-- CSS only -->\n<link rel=\"stylesheet\"
+        href=\"https://assets.emblstatic.net/vf/v2.5.7/css/styles.css\">\n<!-- JS
+        -->\n<script src=\"https://assets.emblstatic.net/vf/v2.5.7/scripts/scripts.js\"></script>\n<head>\n
+        \ <body class=\"vf-body vf-stack vf-stack--400\">\n    <style>head, title,
+        link, meta, style, script {--vf-stack-margin--custom: 0; }</style>\n\n    <!--
+        See the EBI Header Footer docs: https://stable.visual-framework.dev/components/ebi-header-footer
+        -->\n\n    <link rel=\"stylesheet\" href=\"https://assets.emblstatic.net/vf/v2.4.5/assets/ebi-header-footer/ebi-header-footer.css\"
+        type=\"text/css\" media=\"all\">\n    <header id=\"masthead-black-bar\" class=\"clearfix
+        masthead-black-bar | ebi-header-footer vf-content vf-u-fullbleed\"></header>\n\n\n\n\n<style>\n
+        \ .embl-grid {\n    margin-bottom: 48px;\n  }\n</style>\n\n<section class=\"vf-intro\"
+        id=\"500\">\n\n  <div><!-- empty --></div>\n\n  <div class=\"vf-stack\">\n\n
+        \ <h1 class=\"vf-intro__heading \">Error: 500</h1>\n<p class=\"vf-lede\">There
+        was a technical error.</p>\n\n\n<p class=\"vf-intro__text\">Something has
+        gone wrong with our web server when attempting to make this page.</p><p class=\"vf-intro__text\">Unfortunately,
+        the service you are trying to access is currently unavailable. <br>Please
+        try again later.</p>\n  </div>\n</section>\n\n\n<section class=\"embl-grid
+        embl-grid--has-centered-content\">\n  <div></div>\n <section>\n      <form
+        id=\"ebi_search\" action=\"/ebisearch/search.ebi\" class=\"vf-form vf-form--search
+        vf-form--search--mini | vf-sidebar vf-sidebar--end\">\n        <div class=\"vf-sidebar__inner\"
+        style=\"flex-wrap: nowrap;\">\n          <div class=\"vf-form__item\">\n            <label
+        class=\"vf-form__label vf-u-sr-only | vf-search__label\" for=\"searchitem\">Search</label>\n
+        \           <input name=\"query\" type=\"search\" placeholder=\"Find a gene,
+        protein or chemical\" id=\"searchitem\" class=\"vf-form__input\" required=\"\"
+        spellcheck=\"false\" data-ms-editor=\"true\">\n            <input name=\"requestFrom\"
+        id=\"requestFrom\" type=\"hidden\" class=\"vf-form__input\" value=\"ebi_index\">\n
+        \         </div>\n          <div class=\"vf-form__item\">\n            <select
+        name=\"db\" id=\"db\" tabindex=\"1\" class=\"vf-form__select\" style=\"max-width:
+        150px\">\n              <option value=\"allebi\">All</option>\n              <optgroup
+        label=\"Science search\">\n                <option value=\"genomes\">Genomes
+        &amp; metagenomes</option>\n                <option value=\"nucleotideSequences\">Nucleotide
+        sequences</option>\n                <option value=\"proteinSequences\">Protein
+        sequences</option>\n                <option value=\"smallMolecules\">Small
+        molecules</option>\n                <option value=\"geneExpression\">Gene
+        expression</option>\n                <option value=\"geneDiseaseAssociations\">Gene-Disease
+        Associations</option>\n                <option value=\"diseases\">Diseases</option>\n
+        \               <option value=\"molecularInteractions\">Molecular interactions</option>\n
+        \               <option value=\"reactionsPathways\">Reactions &amp; pathways</option>\n
+        \               <option value=\"proteinFamilies\">Protein families</option>\n
+        \               <option value=\"literature\">Literature</option>\n                <option
+        value=\"ontologies\">Samples &amp; ontologies</option>\n              </optgroup>\n
+        \             <optgroup label=\"Search web content\">\n                <option
+        value=\"ebiweb_people\">EMBL-EBI People</option>\n                <option
+        value=\"ebiweb\">EMBL-EBI web</option>\n                <!-- <option value=\"ebiweb\">EMBL
+        web</option> -->\n              </optgroup>\n            </select>\n          </div>\n\n\n
+        \         <button type=\"submit\" class=\"vf-search__button | vf-button vf-button--primary\">\n
+        \           <span class=\"vf-button__text\">Search</span>\n          </button>\n
+        \       </div>\n      </form>\n      <p class=\"vf-text-body--5 vf-u-margin__bottom--0\">\n
+        \       Example searches: <a class=\"vf-link\" href=\"/ebisearch/search.ebi?db=allebi&amp;requestFrom=ebi_index&amp;query=blast\">blast</a>\n
+        \       <a class=\"vf-link\" href=\"/ebisearch/search.ebi?db=allebi&amp;query=keratin&amp;requestFrom=ebi_index\">keratin</a>\n
+        \       <a class=\"vf-link\" href=\"/ebisearch/search.ebi?db=allebi&amp;query=bfl1&amp;requestFrom=ebi_index\">bfl1</a>\n
+        \       | <a class=\"vf-link\" href=\"https://www.ebi.ac.uk/ebisearch/overview.ebi/about\">About
+        EBI Search</a>\n      </p>\n    </section>\n</section>\n\n<section class=\"embl-grid\">\n
+        \ <div></div>\n  <div class=\"vf-content\">\n    <h3>Need assistance?</h3>\n
+        \   <a class=\"vf-button vf-button--primary\" href=\"https://www.ebi.ac.uk/support/error\">Contact
+        our support team</a>\n  </div>\n</section>\n\n    <!-- embl global footer
+        -->\n\n\n<!-- embl-ebi global footer -->\n<link rel=\"import\" href=\"https://www.embl.org/api/v1/pattern.html?filter-content-type=article&filter-id=106902&pattern=node-body&source=contenthub\"
+        data-target=\"self\" data-embl-js-content-hub-loader>\n\n    <script src=\"https://assets.emblstatic.net/vf/v2.4.9/scripts/scripts.js\"></script>\n<!--\n
+        \ When using legacy EBI 1.x JS, we disable the old cookie banner.\n  https://stable.visual-framework.dev/components/ebi-header-footer/\n
+        \ -->\n<div class=\"vf-u-display-none\" data-protection-message-disable=\"true\"></div>\n\n<!--
+        IE11 polyfill JS -->\n<script nomodule crossorigin=\"anonymous\" src=\"https://polyfill.io/v3/polyfill.min.js?flags=gated&features=default\"></script>\n<!--
+        <script src=\"/scripts/scripts.js?\"></script> -->\n<script defer=\"defer\"
+        src=\"https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/js/script.js\"></script>\n<link
+        rel=\"stylesheet\" href=\"//ebi.emblstatic.net/web_guidelines/EBI-Icon-fonts/v1.3/fonts.css\"
+        type=\"text/css\" media=\"all\" />\n\n<!-- Google Analytics -->\n<script>\nwindow.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new
+        Date;\nga('create', 'UA-629242-1', 'auto');\n</script>\n<script async src='https://www.google-analytics.com/analytics.js'></script>\n<!--
+        End Google Analytics -->\n\n<script type=\"text/javascript\">\n  document.addEventListener(\"DOMContentLoaded\",
+        function(event) {\n\n        //- Code to execute when only the HTML document
+        is loaded.\n        //- This doesn't wait for stylesheets,\n        // images,
+        and subframes to finish loading.\n  });\n</script>\n\n  </body>\n</html>\n"
+    headers:
+      content-length:
+      - '10135'
+      content-type:
+      - text/html
+      date:
+      - Mon, 05 Jan 2026 23:18:18 GMT
+    status:
+      code: 500
+      message: Internal Server Error
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Host:
+      - www.ebi.ac.uk
+      User-Agent:
+      - BioETL/5.0.0
+    method: GET
+    uri: https://www.ebi.ac.uk/chembl/api/data/cell_line.json?limit=10&offset=0&format=json
+  response:
+    body:
+      string: "<!doctype html>\n<html lang=\"en\" class=\"vf-no-js\">\n  <head>\n
+        \   <script>\n// Detect if JS is on and swap vf-no-js for vf-js on the html
+        element\n(function(H){H.className=H.className.replace(/\\bvf-no-js\\b/,'vf-js')})(document.documentElement);\n</script>\n\n
+        \   <meta charset=\"utf-8\">\n    <meta name=\"viewport\" content=\"width=device-width,
+        initial-scale=1.0\">\n    <!-- <link rel=\"stylesheet\" media=\"all\" href=\"/css/styles.css?\"
+        /> -->\n    <title>Error: 500 | EMBL\u2019s European Bionformatics Institute</title>\n\n\n\n
+        \   <link rel=\"icon\" type=\"image/x-icon\"\n  href=\"https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/images/logos/EMBL-EBI/favicons/favicon.ico\"
+        />\n<link rel=\"icon\" type=\"image/png\"\n  href=\"https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/images/logos/EMBL-EBI/favicons/favicon-32x32.png\"
+        />\n<link rel=\"icon\" type=\"image/png\" sizes=\"192\xD7192\"\n  href=\"https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/images/logos/EMBL-EBI/favicons/android-chrome-192x192.png\"
+        />\n<!-- Android (192px) -->\n<link rel=\"apple-touch-icon-precomposed\" sizes=\"114x114\"\n
+        \ href=\"https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/images/logos/EMBL-EBI/favicons/apple-icon-114x114.png\"
+        />\n<!-- For iPhone 4 Retina display (114px) -->\n<link rel=\"apple-touch-icon-precomposed\"
+        sizes=\"72x72\"\n  href=\"https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/images/logos/EMBL-EBI/favicons/apple-icon-72x72.png\"
+        />\n<!-- For iPad (72px) -->\n<link rel=\"apple-touch-icon-precomposed\" sizes=\"144x144\"\n
+        \ href=\"https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/images/logos/EMBL-EBI/favicons/apple-icon-144x144.png\"
+        />\n<!-- For iPad retinat (144px) -->\n<link rel=\"apple-touch-icon-precomposed\"\n
+        \ href=\"https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/images/logos/EMBL-EBI/favicons/apple-icon-57x57.png\"
+        />\n<!-- For iPhone (57px) -->\n<link rel=\"mask-icon\"\n  href=\"https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/images/logos/EMBL-EBI/favicons/safari-pinned-tab.svg\"\n
+        \ color=\"#ffffff\" /> <!-- Safari icon for pinned tab -->\n<meta name=\"msapplication-TileColor\"
+        content=\"#2b5797\" /> <!-- MS Icons -->\n<meta name=\"msapplication-TileImage\"\n
+        \ content=\"https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/images/logos/EMBL-EBI/favicons/mstile-144x144.png\"
+        />\n\n\n\n\n\n\n    <!-- Search indexing optimisations -->\n    <meta class=\"swiftype\"
+        name=\"what\" data-type=\"string\" content=\"none\" />\n    <meta class=\"swiftype\"
+        name=\"where\" data-type=\"string\" content=\"EMBL-EBI\" />\n\n\n    <!--
+        Descriptive meta -->\n    <meta name=\"title\" content=\"Error: 500\">\n    <meta
+        name=\"author\" content=\"European Bioinformatics Institute\">\n    <meta
+        name=\"robots\" content=\"index, follow\">\n    <meta name=\"keywords\" content=\"\">\n
+        \   <meta name=\"description\" content=\"\">\n\n    <!-- Open Graph / Facebook
+        -->\n    <meta property=\"og:type\" content=\"website\">\n    <meta property=\"og:url\"
+        content=\"https://www.ebi.ac.uk/info/error-pages/500-standalone/\">\n    <meta
+        property=\"og:title\" content=\"Error: 500\">\n    <meta property=\"og:description\"
+        content=\"\">\n\n\n    <!-- Twitter -->\n    <meta property=\"twitter:card\"
+        content=\"summary_large_image\">\n    <meta property=\"og:url\" content=\"https://www.ebi.ac.uk/info/error-pages/500-standalone/\">\n
+        \   <meta property=\"twitter:title\" content=\"Error: 500\">\n    <meta property=\"twitter:description\"
+        content=\"\">\n\n\n    <!-- Content descriptors -->\n    <meta name=\"embl:who\"
+        content=\"EMBL-EBI Web Dev\">\n    <meta name=\"embl:where\" content=\"EMBL-EBI\">\n
+        \   <meta name=\"embl:what\" content=\"none\">\n    <meta name=\"embl:active\"
+        content=\"where\">\n\n    <!-- Content role -->\n    <meta name=\"embl:utility\"
+        content=\"10\">\n    <meta name=\"embl:reach\" content=\"0\">\n\n    <!--
+        Page infromation -->\n    <meta name=\"embl:maintainer\" content=\"EMBL-EBI
+        Web Dev\">\n    <meta name=\"embl:last-review\" content=\"2021.04.01\">\n
+        \   <meta name=\"embl:review-cycle\" content=\"365\">\n    <meta name=\"embl:expiry\"
+        content=\"never\">\n\n    <!-- analytics -->\n    <meta name=\"vf:page-type\"
+        content=\"404;dimension1\">\n\n    <!-- CSS only -->\n<link rel=\"stylesheet\"
+        href=\"https://assets.emblstatic.net/vf/v2.5.7/css/styles.css\">\n<!-- JS
+        -->\n<script src=\"https://assets.emblstatic.net/vf/v2.5.7/scripts/scripts.js\"></script>\n<head>\n
+        \ <body class=\"vf-body vf-stack vf-stack--400\">\n    <style>head, title,
+        link, meta, style, script {--vf-stack-margin--custom: 0; }</style>\n\n    <!--
+        See the EBI Header Footer docs: https://stable.visual-framework.dev/components/ebi-header-footer
+        -->\n\n    <link rel=\"stylesheet\" href=\"https://assets.emblstatic.net/vf/v2.4.5/assets/ebi-header-footer/ebi-header-footer.css\"
+        type=\"text/css\" media=\"all\">\n    <header id=\"masthead-black-bar\" class=\"clearfix
+        masthead-black-bar | ebi-header-footer vf-content vf-u-fullbleed\"></header>\n\n\n\n\n<style>\n
+        \ .embl-grid {\n    margin-bottom: 48px;\n  }\n</style>\n\n<section class=\"vf-intro\"
+        id=\"500\">\n\n  <div><!-- empty --></div>\n\n  <div class=\"vf-stack\">\n\n
+        \ <h1 class=\"vf-intro__heading \">Error: 500</h1>\n<p class=\"vf-lede\">There
+        was a technical error.</p>\n\n\n<p class=\"vf-intro__text\">Something has
+        gone wrong with our web server when attempting to make this page.</p><p class=\"vf-intro__text\">Unfortunately,
+        the service you are trying to access is currently unavailable. <br>Please
+        try again later.</p>\n  </div>\n</section>\n\n\n<section class=\"embl-grid
+        embl-grid--has-centered-content\">\n  <div></div>\n <section>\n      <form
+        id=\"ebi_search\" action=\"/ebisearch/search.ebi\" class=\"vf-form vf-form--search
+        vf-form--search--mini | vf-sidebar vf-sidebar--end\">\n        <div class=\"vf-sidebar__inner\"
+        style=\"flex-wrap: nowrap;\">\n          <div class=\"vf-form__item\">\n            <label
+        class=\"vf-form__label vf-u-sr-only | vf-search__label\" for=\"searchitem\">Search</label>\n
+        \           <input name=\"query\" type=\"search\" placeholder=\"Find a gene,
+        protein or chemical\" id=\"searchitem\" class=\"vf-form__input\" required=\"\"
+        spellcheck=\"false\" data-ms-editor=\"true\">\n            <input name=\"requestFrom\"
+        id=\"requestFrom\" type=\"hidden\" class=\"vf-form__input\" value=\"ebi_index\">\n
+        \         </div>\n          <div class=\"vf-form__item\">\n            <select
+        name=\"db\" id=\"db\" tabindex=\"1\" class=\"vf-form__select\" style=\"max-width:
+        150px\">\n              <option value=\"allebi\">All</option>\n              <optgroup
+        label=\"Science search\">\n                <option value=\"genomes\">Genomes
+        &amp; metagenomes</option>\n                <option value=\"nucleotideSequences\">Nucleotide
+        sequences</option>\n                <option value=\"proteinSequences\">Protein
+        sequences</option>\n                <option value=\"smallMolecules\">Small
+        molecules</option>\n                <option value=\"geneExpression\">Gene
+        expression</option>\n                <option value=\"geneDiseaseAssociations\">Gene-Disease
+        Associations</option>\n                <option value=\"diseases\">Diseases</option>\n
+        \               <option value=\"molecularInteractions\">Molecular interactions</option>\n
+        \               <option value=\"reactionsPathways\">Reactions &amp; pathways</option>\n
+        \               <option value=\"proteinFamilies\">Protein families</option>\n
+        \               <option value=\"literature\">Literature</option>\n                <option
+        value=\"ontologies\">Samples &amp; ontologies</option>\n              </optgroup>\n
+        \             <optgroup label=\"Search web content\">\n                <option
+        value=\"ebiweb_people\">EMBL-EBI People</option>\n                <option
+        value=\"ebiweb\">EMBL-EBI web</option>\n                <!-- <option value=\"ebiweb\">EMBL
+        web</option> -->\n              </optgroup>\n            </select>\n          </div>\n\n\n
+        \         <button type=\"submit\" class=\"vf-search__button | vf-button vf-button--primary\">\n
+        \           <span class=\"vf-button__text\">Search</span>\n          </button>\n
+        \       </div>\n      </form>\n      <p class=\"vf-text-body--5 vf-u-margin__bottom--0\">\n
+        \       Example searches: <a class=\"vf-link\" href=\"/ebisearch/search.ebi?db=allebi&amp;requestFrom=ebi_index&amp;query=blast\">blast</a>\n
+        \       <a class=\"vf-link\" href=\"/ebisearch/search.ebi?db=allebi&amp;query=keratin&amp;requestFrom=ebi_index\">keratin</a>\n
+        \       <a class=\"vf-link\" href=\"/ebisearch/search.ebi?db=allebi&amp;query=bfl1&amp;requestFrom=ebi_index\">bfl1</a>\n
+        \       | <a class=\"vf-link\" href=\"https://www.ebi.ac.uk/ebisearch/overview.ebi/about\">About
+        EBI Search</a>\n      </p>\n    </section>\n</section>\n\n<section class=\"embl-grid\">\n
+        \ <div></div>\n  <div class=\"vf-content\">\n    <h3>Need assistance?</h3>\n
+        \   <a class=\"vf-button vf-button--primary\" href=\"https://www.ebi.ac.uk/support/error\">Contact
+        our support team</a>\n  </div>\n</section>\n\n    <!-- embl global footer
+        -->\n\n\n<!-- embl-ebi global footer -->\n<link rel=\"import\" href=\"https://www.embl.org/api/v1/pattern.html?filter-content-type=article&filter-id=106902&pattern=node-body&source=contenthub\"
+        data-target=\"self\" data-embl-js-content-hub-loader>\n\n    <script src=\"https://assets.emblstatic.net/vf/v2.4.9/scripts/scripts.js\"></script>\n<!--\n
+        \ When using legacy EBI 1.x JS, we disable the old cookie banner.\n  https://stable.visual-framework.dev/components/ebi-header-footer/\n
+        \ -->\n<div class=\"vf-u-display-none\" data-protection-message-disable=\"true\"></div>\n\n<!--
+        IE11 polyfill JS -->\n<script nomodule crossorigin=\"anonymous\" src=\"https://polyfill.io/v3/polyfill.min.js?flags=gated&features=default\"></script>\n<!--
+        <script src=\"/scripts/scripts.js?\"></script> -->\n<script defer=\"defer\"
+        src=\"https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/js/script.js\"></script>\n<link
+        rel=\"stylesheet\" href=\"//ebi.emblstatic.net/web_guidelines/EBI-Icon-fonts/v1.3/fonts.css\"
+        type=\"text/css\" media=\"all\" />\n\n<!-- Google Analytics -->\n<script>\nwindow.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new
+        Date;\nga('create', 'UA-629242-1', 'auto');\n</script>\n<script async src='https://www.google-analytics.com/analytics.js'></script>\n<!--
+        End Google Analytics -->\n\n<script type=\"text/javascript\">\n  document.addEventListener(\"DOMContentLoaded\",
+        function(event) {\n\n        //- Code to execute when only the HTML document
+        is loaded.\n        //- This doesn't wait for stylesheets,\n        // images,
+        and subframes to finish loading.\n  });\n</script>\n\n  </body>\n</html>\n"
+    headers:
+      content-length:
+      - '10135'
+      content-type:
+      - text/html
+      date:
+      - Mon, 05 Jan 2026 23:18:23 GMT
+    status:
+      code: 500
+      message: Internal Server Error
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Host:
+      - www.ebi.ac.uk
+      User-Agent:
+      - BioETL/5.0.0
+    method: GET
+    uri: https://www.ebi.ac.uk/chembl/api/data/cell_line.json?limit=10&offset=0&format=json
+  response:
+    body:
+      string: '{"cell_lines": [{"cell_chembl_id": "CHEMBL3307241", "cell_description":
+        "DC3F", "cell_id": 1, "cell_name": "DC3F", "cell_source_organism": "Cricetulus
+        griseus", "cell_source_tax_id": 10029, "cell_source_tissue": "Lung", "cellosaurus_id":
+        "CVCL_4704", "cl_lincs_id": null, "clo_id": null, "efo_id": null}, {"cell_chembl_id":
+        "CHEMBL3307242", "cell_description": "P3HR-1", "cell_id": 2, "cell_name":
+        "P3HR-1", "cell_source_organism": "Homo sapiens", "cell_source_tax_id": 9606,
+        "cell_source_tissue": "Lyphoma", "cellosaurus_id": "CVCL_2676", "cl_lincs_id":
+        "LCL-2024", "clo_id": "CLO_0008331", "efo_id": "EFO_0002312"}, {"cell_chembl_id":
+        "CHEMBL3307243", "cell_description": "UCLA P-3", "cell_id": 3, "cell_name":
+        "UCLA P-3", "cell_source_organism": "Homo sapiens", "cell_source_tax_id":
+        9606, "cell_source_tissue": "Lung Adenocarcinoma", "cellosaurus_id": "CVCL_N513",
+        "cl_lincs_id": null, "clo_id": null, "efo_id": null}, {"cell_chembl_id": "CHEMBL3307244",
+        "cell_description": "UMSCC22B", "cell_id": 4, "cell_name": "UMSCC22B", "cell_source_organism":
+        "Homo sapiens", "cell_source_tax_id": 9606, "cell_source_tissue": "Carcinoma",
+        "cellosaurus_id": "CVCL_7732", "cl_lincs_id": null, "clo_id": null, "efo_id":
+        null}, {"cell_chembl_id": "CHEMBL3307245", "cell_description": "UMUC3", "cell_id":
+        5, "cell_name": "UMUC3", "cell_source_organism": "Homo sapiens", "cell_source_tax_id":
+        9606, "cell_source_tissue": "Bladder Carcinoma", "cellosaurus_id": "CVCL_1783",
+        "cl_lincs_id": "LCL-1721", "clo_id": "CLO_0009487", "efo_id": "EFO_0002387"},
+        {"cell_chembl_id": "CHEMBL3307246", "cell_description": "V79-4", "cell_id":
+        6, "cell_name": "V79-4", "cell_source_organism": "Cricetulus griseus", "cell_source_tax_id":
+        10029, "cell_source_tissue": "Lung", "cellosaurus_id": "CVCL_2796", "cl_lincs_id":
+        null, "clo_id": "CLO_0009504", "efo_id": null}, {"cell_chembl_id": "CHEMBL3307247",
+        "cell_description": "VCR100", "cell_id": 7, "cell_name": "VCR100", "cell_source_organism":
+        "Mus musculus", "cell_source_tax_id": 10090, "cell_source_tissue": "Leukaemia",
+        "cellosaurus_id": null, "cl_lincs_id": null, "clo_id": null, "efo_id": null},
+        {"cell_chembl_id": "CHEMBL3307248", "cell_description": "W256", "cell_id":
+        8, "cell_name": "W256", "cell_source_organism": "Rattus norvegicus", "cell_source_tax_id":
+        10116, "cell_source_tissue": "Monocytic Carcinosarcoma", "cellosaurus_id":
+        "CVCL_3537", "cl_lincs_id": null, "clo_id": "CLO_0007335", "efo_id": null},
+        {"cell_chembl_id": "CHEMBL3307249", "cell_description": "WEHI265.1", "cell_id":
+        9, "cell_name": "WEHI265.1", "cell_source_organism": "Mus musculus", "cell_source_tax_id":
+        10090, "cell_source_tissue": "Macrophage", "cellosaurus_id": "CVCL_3620",
+        "cl_lincs_id": null, "clo_id": "CLO_0009576", "efo_id": null}, {"cell_chembl_id":
+        "CHEMBL3307250", "cell_description": "WiDr-NTR", "cell_id": 10, "cell_name":
+        "WiDr-NTR", "cell_source_organism": "Homo sapiens", "cell_source_tax_id":
+        9606, "cell_source_tissue": "Colon Adenocarcinoma", "cellosaurus_id": null,
+        "cl_lincs_id": null, "clo_id": null, "efo_id": null}], "page_meta": {"limit":
+        10, "next": "/chembl/api/data/cell_line.json?limit=10&offset=10", "offset":
+        0, "previous": null, "total_count": 2215}}'
+    headers:
+      cache-control:
+      - max-age=30000000, s-maxage=30000000
+      content-disposition:
+      - inline
+      content-length:
+      - '3191'
+      content-type:
+      - application/json
+      date:
+      - Mon, 05 Jan 2026 23:18:56 GMT
+      server:
+      - gunicorn/20.0.4
+      strict-transport-security:
+      - max-age=0
+      vary:
+      - Accept, Origin
+      x-chembl-in-cache:
+      - 'True'
+      x-chembl-retrieval-time:
+      - '0.008122682571411133'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/vcr/TestChemblCellLinePipeline.test_chembl_cell_line_source_fields.yaml
+++ b/tests/fixtures/vcr/TestChemblCellLinePipeline.test_chembl_cell_line_source_fields.yaml
@@ -1,0 +1,271 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Host:
+      - www.ebi.ac.uk
+      User-Agent:
+      - BioETL/5.0.0
+    method: GET
+    uri: https://www.ebi.ac.uk/chembl/api/data/status.json
+  response:
+    body:
+      string: '{"activities": 24267312, "chembl_db_version": "ChEMBL_36", "chembl_release_date":
+        "2025-07-28", "compound_records": 3774137, "disinct_compounds": 2878135, "publications":
+        99142, "status": "UP", "targets": 17803}'
+    headers:
+      cache-control:
+      - max-age=30000000, s-maxage=30000000
+      content-length:
+      - '211'
+      content-type:
+      - application/json
+      date:
+      - Mon, 05 Jan 2026 23:19:44 GMT
+      server:
+      - gunicorn/20.0.4
+      strict-transport-security:
+      - max-age=0
+      vary:
+      - Accept, Origin
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Host:
+      - www.ebi.ac.uk
+      User-Agent:
+      - BioETL/5.0.0
+    method: GET
+    uri: https://www.ebi.ac.uk/chembl/api/data/cell_line.json?limit=50&offset=0&format=json
+  response:
+    body:
+      string: '{"cell_lines": [{"cell_chembl_id": "CHEMBL3307241", "cell_description":
+        "DC3F", "cell_id": 1, "cell_name": "DC3F", "cell_source_organism": "Cricetulus
+        griseus", "cell_source_tax_id": 10029, "cell_source_tissue": "Lung", "cellosaurus_id":
+        "CVCL_4704", "cl_lincs_id": null, "clo_id": null, "efo_id": null}, {"cell_chembl_id":
+        "CHEMBL3307242", "cell_description": "P3HR-1", "cell_id": 2, "cell_name":
+        "P3HR-1", "cell_source_organism": "Homo sapiens", "cell_source_tax_id": 9606,
+        "cell_source_tissue": "Lyphoma", "cellosaurus_id": "CVCL_2676", "cl_lincs_id":
+        "LCL-2024", "clo_id": "CLO_0008331", "efo_id": "EFO_0002312"}, {"cell_chembl_id":
+        "CHEMBL3307243", "cell_description": "UCLA P-3", "cell_id": 3, "cell_name":
+        "UCLA P-3", "cell_source_organism": "Homo sapiens", "cell_source_tax_id":
+        9606, "cell_source_tissue": "Lung Adenocarcinoma", "cellosaurus_id": "CVCL_N513",
+        "cl_lincs_id": null, "clo_id": null, "efo_id": null}, {"cell_chembl_id": "CHEMBL3307244",
+        "cell_description": "UMSCC22B", "cell_id": 4, "cell_name": "UMSCC22B", "cell_source_organism":
+        "Homo sapiens", "cell_source_tax_id": 9606, "cell_source_tissue": "Carcinoma",
+        "cellosaurus_id": "CVCL_7732", "cl_lincs_id": null, "clo_id": null, "efo_id":
+        null}, {"cell_chembl_id": "CHEMBL3307245", "cell_description": "UMUC3", "cell_id":
+        5, "cell_name": "UMUC3", "cell_source_organism": "Homo sapiens", "cell_source_tax_id":
+        9606, "cell_source_tissue": "Bladder Carcinoma", "cellosaurus_id": "CVCL_1783",
+        "cl_lincs_id": "LCL-1721", "clo_id": "CLO_0009487", "efo_id": "EFO_0002387"},
+        {"cell_chembl_id": "CHEMBL3307246", "cell_description": "V79-4", "cell_id":
+        6, "cell_name": "V79-4", "cell_source_organism": "Cricetulus griseus", "cell_source_tax_id":
+        10029, "cell_source_tissue": "Lung", "cellosaurus_id": "CVCL_2796", "cl_lincs_id":
+        null, "clo_id": "CLO_0009504", "efo_id": null}, {"cell_chembl_id": "CHEMBL3307247",
+        "cell_description": "VCR100", "cell_id": 7, "cell_name": "VCR100", "cell_source_organism":
+        "Mus musculus", "cell_source_tax_id": 10090, "cell_source_tissue": "Leukaemia",
+        "cellosaurus_id": null, "cl_lincs_id": null, "clo_id": null, "efo_id": null},
+        {"cell_chembl_id": "CHEMBL3307248", "cell_description": "W256", "cell_id":
+        8, "cell_name": "W256", "cell_source_organism": "Rattus norvegicus", "cell_source_tax_id":
+        10116, "cell_source_tissue": "Monocytic Carcinosarcoma", "cellosaurus_id":
+        "CVCL_3537", "cl_lincs_id": null, "clo_id": "CLO_0007335", "efo_id": null},
+        {"cell_chembl_id": "CHEMBL3307249", "cell_description": "WEHI265.1", "cell_id":
+        9, "cell_name": "WEHI265.1", "cell_source_organism": "Mus musculus", "cell_source_tax_id":
+        10090, "cell_source_tissue": "Macrophage", "cellosaurus_id": "CVCL_3620",
+        "cl_lincs_id": null, "clo_id": "CLO_0009576", "efo_id": null}, {"cell_chembl_id":
+        "CHEMBL3307250", "cell_description": "WiDr-NTR", "cell_id": 10, "cell_name":
+        "WiDr-NTR", "cell_source_organism": "Homo sapiens", "cell_source_tax_id":
+        9606, "cell_source_tissue": "Colon Adenocarcinoma", "cellosaurus_id": null,
+        "cl_lincs_id": null, "clo_id": null, "efo_id": null}, {"cell_chembl_id": "CHEMBL3307251",
+        "cell_description": "XC", "cell_id": 11, "cell_name": "XC", "cell_source_organism":
+        "Rattus norvegicus", "cell_source_tax_id": 10116, "cell_source_tissue": "Sarcoma",
+        "cellosaurus_id": "CVCL_1891", "cl_lincs_id": null, "clo_id": "CLO_0009645",
+        "efo_id": null}, {"cell_chembl_id": "CHEMBL3307253", "cell_description": "YAPC",
+        "cell_id": 13, "cell_name": "YAPC", "cell_source_organism": "Homo sapiens",
+        "cell_source_tax_id": 9606, "cell_source_tissue": "Pancreas Carcinoma", "cellosaurus_id":
+        "CVCL_1794", "cl_lincs_id": "LCL-1792", "clo_id": "CLO_0009711", "efo_id":
+        "EFO_0006778"}, {"cell_chembl_id": "CHEMBL3307254", "cell_description": "YT-NU",
+        "cell_id": 14, "cell_name": "YT-NU", "cell_source_organism": "Homo sapiens",
+        "cell_source_tax_id": 9606, "cell_source_tissue": "Neuroblastoma", "cellosaurus_id":
+        "CVCL_H524", "cl_lincs_id": null, "clo_id": null, "efo_id": null}, {"cell_chembl_id":
+        "CHEMBL3307255", "cell_description": "T6400", "cell_id": 15, "cell_name":
+        "T6400", "cell_source_organism": "Mus musculus", "cell_source_tax_id": 10090,
+        "cell_source_tissue": "Fibroblasts", "cellosaurus_id": "CVCL_R998", "cl_lincs_id":
+        null, "clo_id": null, "efo_id": null}, {"cell_chembl_id": "CHEMBL3307256",
+        "cell_description": "T78-1", "cell_id": 16, "cell_name": "T78-1", "cell_source_organism":
+        "Cricetulus griseus", "cell_source_tax_id": 10029, "cell_source_tissue": "Lung",
+        "cellosaurus_id": "CVCL_X527", "cl_lincs_id": null, "clo_id": null, "efo_id":
+        null}, {"cell_chembl_id": "CHEMBL3307257", "cell_description": "T78-1/T79-A3",
+        "cell_id": 17, "cell_name": "T78-1/T79-A3", "cell_source_organism": "Cricetulus
+        griseus", "cell_source_tax_id": 10029, "cell_source_tissue": "Lung", "cellosaurus_id":
+        null, "cl_lincs_id": null, "clo_id": null, "efo_id": null}, {"cell_chembl_id":
+        "CHEMBL3307258", "cell_description": "TA3", "cell_id": 18, "cell_name": "TA3",
+        "cell_source_organism": "Mus musculus", "cell_source_tax_id": 10090, "cell_source_tissue":
+        "Mammary Carcinoma", "cellosaurus_id": "CVCL_4315", "cl_lincs_id": null, "clo_id":
+        null, "efo_id": null}, {"cell_chembl_id": "CHEMBL3307259", "cell_description":
+        "UMR106-06", "cell_id": 19, "cell_name": "UMR106-06", "cell_source_organism":
+        "Rattus norvegicus", "cell_source_tax_id": 10116, "cell_source_tissue": "Osteosarcoma",
+        "cellosaurus_id": "CVCL_S477", "cl_lincs_id": null, "clo_id": null, "efo_id":
+        null}, {"cell_chembl_id": "CHEMBL3308406", "cell_description": "AIK-T8", "cell_id":
+        20, "cell_name": "AIK-T8", "cell_source_organism": "Homo sapiens", "cell_source_tax_id":
+        9606, "cell_source_tissue": "Lymphocyte", "cellosaurus_id": "CVCL_1B43", "cl_lincs_id":
+        null, "clo_id": null, "efo_id": null}, {"cell_chembl_id": "CHEMBL3308394",
+        "cell_description": "G-401", "cell_id": 21, "cell_name": "G-401", "cell_source_organism":
+        "Homo sapiens", "cell_source_tax_id": 9606, "cell_source_tissue": "Kidney
+        Wilm''s tumor", "cellosaurus_id": "CVCL_0270", "cl_lincs_id": "LCL-1511",
+        "clo_id": "CLO_0003434", "efo_id": "EFO_0002179"}, {"cell_chembl_id": "CHEMBL3307260",
+        "cell_description": "Jensen sarcoma", "cell_id": 22, "cell_name": "Jensen
+        sarcoma", "cell_source_organism": "Rattus norvegicus", "cell_source_tax_id":
+        10116, "cell_source_tissue": "fibroblast sarcoma", "cellosaurus_id": "CVCL_3531",
+        "cl_lincs_id": null, "clo_id": "CLO_0007018", "efo_id": null}, {"cell_chembl_id":
+        "CHEMBL3307261", "cell_description": "MDA-MB-238", "cell_id": 23, "cell_name":
+        "MDA-MB-238", "cell_source_organism": "Homo sapiens", "cell_source_tax_id":
+        9606, "cell_source_tissue": "Breast Adenocarcinoma", "cellosaurus_id": null,
+        "cl_lincs_id": null, "clo_id": null, "efo_id": null}, {"cell_chembl_id": "CHEMBL3307263",
+        "cell_description": "MOLT-4F", "cell_id": 25, "cell_name": "MOLT-4F", "cell_source_organism":
+        "Homo sapiens", "cell_source_tax_id": 9606, "cell_source_tissue": "Leukaemia",
+        "cellosaurus_id": "CVCL_2792", "cl_lincs_id": "LCL-1031", "clo_id": "CLO_0050994",
+        "efo_id": null}, {"cell_chembl_id": "CHEMBL3307264", "cell_description": "N9",
+        "cell_id": 26, "cell_name": "N9", "cell_source_organism": "Homo sapiens",
+        "cell_source_tax_id": 9606, "cell_source_tissue": "Hepatocyte", "cellosaurus_id":
+        null, "cl_lincs_id": null, "clo_id": null, "efo_id": null}, {"cell_chembl_id":
+        "CHEMBL3307265", "cell_description": "NCI-H417", "cell_id": 27, "cell_name":
+        "NCI-H417", "cell_source_organism": "Homo sapiens", "cell_source_tax_id":
+        9606, "cell_source_tissue": "Lung Carcinoma", "cellosaurus_id": "CVCL_1602",
+        "cl_lincs_id": null, "clo_id": null, "efo_id": null}, {"cell_chembl_id": "CHEMBL3307266",
+        "cell_description": "NRK", "cell_id": 28, "cell_name": "NRK", "cell_source_organism":
+        "Rattus norvegicus", "cell_source_tax_id": 10116, "cell_source_tissue": "Kidney
+        ", "cellosaurus_id": "CVCL_3758", "cl_lincs_id": null, "clo_id": "CLO_0008195",
+        "efo_id": null}, {"cell_chembl_id": "CHEMBL3307267", "cell_description": "NUGC-4",
+        "cell_id": 29, "cell_name": "NUGC-4", "cell_source_organism": "Homo sapiens",
+        "cell_source_tax_id": 9606, "cell_source_tissue": "gastric lymph node, adenocarcinoma",
+        "cellosaurus_id": "CVCL_3082", "cl_lincs_id": "LCL-2001", "clo_id": "CLO_0050789",
+        "efo_id": "EFO_0006703"}, {"cell_chembl_id": "CHEMBL3307268", "cell_description":
+        "P388/VCR", "cell_id": 30, "cell_name": "P388/VCR", "cell_source_organism":
+        "Mus musculus", "cell_source_tax_id": 10090, "cell_source_tissue": "Leukaemia",
+        "cellosaurus_id": null, "cl_lincs_id": null, "clo_id": null, "efo_id": null},
+        {"cell_chembl_id": "CHEMBL3307269", "cell_description": "PAXF546", "cell_id":
+        31, "cell_name": "PAXF546", "cell_source_organism": "Homo sapiens", "cell_source_tax_id":
+        9606, "cell_source_tissue": "Panreatic Carcinoma", "cellosaurus_id": null,
+        "cl_lincs_id": null, "clo_id": null, "efo_id": null}, {"cell_chembl_id": "CHEMBL3307270",
+        "cell_description": "PLC", "cell_id": 32, "cell_name": "PLC", "cell_source_organism":
+        "Homo sapiens", "cell_source_tax_id": 9606, "cell_source_tissue": "Hepatoma",
+        "cellosaurus_id": null, "cl_lincs_id": null, "clo_id": null, "efo_id": null},
+        {"cell_chembl_id": "CHEMBL3307271", "cell_description": "SCC-38", "cell_id":
+        34, "cell_name": "SCC-38", "cell_source_organism": "Homo sapiens", "cell_source_tax_id":
+        9606, "cell_source_tissue": "Squamous Carcinoma", "cellosaurus_id": null,
+        "cl_lincs_id": null, "clo_id": null, "efo_id": null}, {"cell_chembl_id": "CHEMBL3307272",
+        "cell_description": "SISO", "cell_id": 35, "cell_name": "SISO", "cell_source_organism":
+        "Homo sapiens", "cell_source_tax_id": 9606, "cell_source_tissue": "Cervical
+        Adenocarcinoma", "cellosaurus_id": "CVCL_2193", "cl_lincs_id": "LCL-1514",
+        "clo_id": "CLO_0009021", "efo_id": null}, {"cell_chembl_id": "CHEMBL3307273",
+        "cell_description": "SNU-16", "cell_id": 37, "cell_name": "SNU-16", "cell_source_organism":
+        "Homo sapiens", "cell_source_tax_id": 9606, "cell_source_tissue": "Gastric
+        Carcinoma", "cellosaurus_id": "CVCL_0076", "cl_lincs_id": "LCL-1889", "clo_id":
+        "CLO_0009095", "efo_id": "EFO_0002344"}, {"cell_chembl_id": "CHEMBL3307274",
+        "cell_description": "SW 962", "cell_id": 38, "cell_name": "SW 962", "cell_source_organism":
+        "Homo sapiens", "cell_source_tax_id": 9606, "cell_source_tissue": "Vulva Lymphoid
+        Carcinoma", "cellosaurus_id": "CVCL_1733", "cl_lincs_id": null, "clo_id":
+        "CLO_0009205", "efo_id": "EFO_0002377"}, {"cell_chembl_id": "CHEMBL3307275",
+        "cell_description": "T84", "cell_id": 39, "cell_name": "T84", "cell_source_organism":
+        "Homo sapiens", "cell_source_tax_id": 9606, "cell_source_tissue": "Colon carcinoma",
+        "cellosaurus_id": "CVCL_0555", "cl_lincs_id": "LCL-1166", "clo_id": "CLO_0009254",
+        "efo_id": "EFO_0002084"}, {"cell_chembl_id": "CHEMBL3307276", "cell_description":
+        "AIK-T4", "cell_id": 40, "cell_name": "AIK-T4", "cell_source_organism": "Homo
+        sapiens", "cell_source_tax_id": 9606, "cell_source_tissue": "Lymphocyte",
+        "cellosaurus_id": "CVCL_1B42", "cl_lincs_id": null, "clo_id": null, "efo_id":
+        null}, {"cell_chembl_id": "CHEMBL3307277", "cell_description": "B104", "cell_id":
+        41, "cell_name": "B104", "cell_source_organism": "Rattus norvegicus", "cell_source_tax_id":
+        10116, "cell_source_tissue": "Neuroblastoma", "cellosaurus_id": "CVCL_0154",
+        "cl_lincs_id": null, "clo_id": "CLO_0001783", "efo_id": null}, {"cell_chembl_id":
+        "CHEMBL3307278", "cell_description": "CCRF S-180", "cell_id": 42, "cell_name":
+        "CCRF S-180", "cell_source_organism": "Mus musculus", "cell_source_tax_id":
+        10090, "cell_source_tissue": "Fibroblast Sarcoma", "cellosaurus_id": "CVCL_2874",
+        "cl_lincs_id": null, "clo_id": "CLO_0002333", "efo_id": null}, {"cell_chembl_id":
+        "CHEMBL3307279", "cell_description": "CEM-TK(+)", "cell_id": 43, "cell_name":
+        "CEM-TK(+)", "cell_source_organism": "Homo sapiens", "cell_source_tax_id":
+        9606, "cell_source_tissue": "Blood", "cellosaurus_id": null, "cl_lincs_id":
+        null, "clo_id": null, "efo_id": null}, {"cell_chembl_id": "CHEMBL3307280",
+        "cell_description": "COLO 480", "cell_id": 44, "cell_name": "COLO 480", "cell_source_organism":
+        "Homo sapiens", "cell_source_tax_id": 9606, "cell_source_tissue": "Colon adenocarcinoma",
+        "cellosaurus_id": null, "cl_lincs_id": null, "clo_id": null, "efo_id": null},
+        {"cell_chembl_id": "CHEMBL3307281", "cell_description": "DAN-G", "cell_id":
+        45, "cell_name": "DAN-G", "cell_source_organism": "Homo sapiens", "cell_source_tax_id":
+        9606, "cell_source_tissue": "Pancreas adenocarcinoma", "cellosaurus_id": "CVCL_0243",
+        "cl_lincs_id": "LCL-1734", "clo_id": "CLO_0002698", "efo_id": "EFO_0006562"},
+        {"cell_chembl_id": "CHEMBL3307282", "cell_description": "HOS-TE85", "cell_id":
+        46, "cell_name": "HOS-TE85", "cell_source_organism": "Homo sapiens", "cell_source_tax_id":
+        9606, "cell_source_tissue": "Oesteosarcoma", "cellosaurus_id": "CVCL_0439",
+        "cl_lincs_id": null, "clo_id": "CLO_0007814", "efo_id": "EFO_0002866"}, {"cell_chembl_id":
+        "CHEMBL3308408", "cell_description": "L1210 (DACH)", "cell_id": 47, "cell_name":
+        "L1210 (DACH)", "cell_source_organism": "Mus musculus", "cell_source_tax_id":
+        10090, "cell_source_tissue": "lymphoblast, lymphocytic, leukemia (DACH resistant",
+        "cellosaurus_id": "CVCL_Y419", "cl_lincs_id": null, "clo_id": null, "efo_id":
+        null}, {"cell_chembl_id": "CHEMBL3307283", "cell_description": "MAC13", "cell_id":
+        48, "cell_name": "MAC13", "cell_source_organism": "Mus musculus", "cell_source_tax_id":
+        10090, "cell_source_tissue": "colon adenocarcinoma", "cellosaurus_id": "CVCL_S000",
+        "cl_lincs_id": null, "clo_id": null, "efo_id": null}, {"cell_chembl_id": "CHEMBL3307285",
+        "cell_description": "CEM-TK(-)", "cell_id": 50, "cell_name": "CEM-TK(-)",
+        "cell_source_organism": "Homo sapiens", "cell_source_tax_id": 9606, "cell_source_tissue":
+        "Blood", "cellosaurus_id": null, "cl_lincs_id": null, "clo_id": null, "efo_id":
+        null}, {"cell_chembl_id": "CHEMBL3307286", "cell_description": "M96", "cell_id":
+        52, "cell_name": "M96", "cell_source_organism": "Homo sapiens", "cell_source_tax_id":
+        9606, "cell_source_tissue": "Melanoma", "cellosaurus_id": null, "cl_lincs_id":
+        null, "clo_id": null, "efo_id": null}, {"cell_chembl_id": "CHEMBL3307287",
+        "cell_description": "MKN-74", "cell_id": 53, "cell_name": "MKN-74", "cell_source_organism":
+        "Homo sapiens", "cell_source_tax_id": 9606, "cell_source_tissue": "Stomach
+        Adenocarcinoma", "cellosaurus_id": "CVCL_2791", "cl_lincs_id": null, "clo_id":
+        "CLO_0050798", "efo_id": "EFO_0002834"}, {"cell_chembl_id": "CHEMBL3307288",
+        "cell_description": "NAMALVA", "cell_id": 54, "cell_name": "NAMALVA", "cell_source_organism":
+        "Homo sapiens", "cell_source_tax_id": 9606, "cell_source_tissue": "Leukocyte/lymphoblastoid",
+        "cellosaurus_id": "CVCL_0067", "cl_lincs_id": null, "clo_id": "CLO_0007939",
+        "efo_id": "EFO_0002246"}, {"cell_chembl_id": "CHEMBL3307289", "cell_description":
+        "NCI-H46", "cell_id": 55, "cell_name": "NCI-H46", "cell_source_organism":
+        "Homo sapiens", "cell_source_tax_id": 9606, "cell_source_tissue": "Lung Carcinoma",
+        "cellosaurus_id": null, "cl_lincs_id": null, "clo_id": null, "efo_id": null},
+        {"cell_chembl_id": "CHEMBL3307290", "cell_description": "QG-95", "cell_id":
+        56, "cell_name": "QG-95", "cell_source_organism": "Homo sapiens", "cell_source_tax_id":
+        9606, "cell_source_tissue": "Lung Carcinoma", "cellosaurus_id": "CVCL_S847",
+        "cl_lincs_id": null, "clo_id": null, "efo_id": null}], "page_meta": {"limit":
+        50, "next": "/chembl/api/data/cell_line.json?limit=50&offset=50", "offset":
+        0, "previous": null, "total_count": 2215}}'
+    headers:
+      cache-control:
+      - max-age=30000000, s-maxage=30000000
+      content-disposition:
+      - inline
+      content-length:
+      - '15414'
+      content-type:
+      - application/json
+      date:
+      - Mon, 05 Jan 2026 23:21:09 GMT
+      server:
+      - gunicorn/20.0.4
+      strict-transport-security:
+      - max-age=0
+      vary:
+      - Accept, Origin
+      x-chembl-in-cache:
+      - 'True'
+      x-chembl-retrieval-time:
+      - '0.008199453353881836'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/pipelines/test_chembl_cell_line.py
+++ b/tests/integration/pipelines/test_chembl_cell_line.py
@@ -1,0 +1,106 @@
+"""Integration tests for ChEMBL Cell Line Pipeline."""
+
+from __future__ import annotations
+
+import pytest
+import structlog
+
+from bioetl.composition.factories.pipeline_factories import (
+    chembl_cell_line_factory,
+)
+from tests.integration.pipelines.base import IntegrationPipelineTestCase
+
+logger = structlog.get_logger()
+
+
+class TestChemblCellLinePipeline(IntegrationPipelineTestCase):
+    @pytest.mark.vcr
+    async def test_chembl_cell_line_happy_path(self, settings, runtime_config, run_id):
+        """Test happy path: Bronze -> Silver -> Gold."""
+        from dataclasses import replace
+
+        runtime_config = replace(runtime_config, limit=10)
+
+        runner = self.create_runner(
+            factory=chembl_cell_line_factory,
+            settings=settings,
+            runtime_config=runtime_config,
+            run_id=run_id,
+        )
+
+        await runner.run()
+
+        # Verify Bronze files exist
+        import glob
+
+        bronze_files = glob.glob(f"{self.bronze_path}/**/*.jsonl.zst", recursive=True)
+        if not bronze_files:
+            bronze_files = glob.glob(
+                f"{self.bronze_path}/**/*.jsonl.zstd", recursive=True
+            )
+
+        assert len(bronze_files) > 0, f"No bronze files found in {self.bronze_path}"
+
+        # Verify Silver Delta Table
+        from deltalake import DeltaTable
+
+        silver_table_name = runner.pipeline.config.silver_table
+        silver_table_path = f"{self.silver_path}/{silver_table_name}"
+
+        dt_silver = DeltaTable(silver_table_path)
+        silver_df = dt_silver.to_pyarrow_table()
+        assert len(silver_df) > 0
+
+        # Verify lineage fields in Silver
+        assert "_run_id" in silver_df.column_names
+        assert "_run_type" in silver_df.column_names
+        assert "_ingestion_ts" in silver_df.column_names
+
+        # Verify cell_line specific fields
+        assert "cell_chembl_id" in silver_df.column_names
+        assert "cell_name" in silver_df.column_names
+
+        # Verify Gold Delta Table
+        gold_table_name = runner.pipeline.config.gold_table
+        if not gold_table_name:
+            gold_table_name = f"{runner.pipeline.config.provider}.{runner.pipeline.config.entity_type}"
+
+        gold_table_path = f"{self.gold_path}/{gold_table_name.replace('.', '/')}"
+
+        dt_gold = DeltaTable(gold_table_path)
+        gold_df = dt_gold.to_pyarrow_table()
+        assert len(gold_df) > 0
+
+    @pytest.mark.vcr
+    async def test_chembl_cell_line_source_fields(
+        self, settings, runtime_config, run_id
+    ):
+        """Test that source and metadata fields are correctly captured."""
+        from dataclasses import replace
+
+        runtime_config = replace(runtime_config, limit=50)
+
+        runner = self.create_runner(
+            factory=chembl_cell_line_factory,
+            settings=settings,
+            runtime_config=runtime_config,
+            run_id=run_id,
+        )
+
+        await runner.run()
+
+        # Verify Silver Delta Table has source columns
+        from deltalake import DeltaTable
+
+        silver_table_name = runner.pipeline.config.silver_table
+        silver_table_path = f"{self.silver_path}/{silver_table_name}"
+
+        dt_silver = DeltaTable(silver_table_path)
+        silver_df = dt_silver.to_pyarrow_table()
+
+        # Core source fields should be present
+        assert "cell_source_tissue" in silver_df.column_names
+        assert "cell_source_organism" in silver_df.column_names
+        # External references
+        assert "cellosaurus_id" in silver_df.column_names
+        assert "cl_lincs_id" in silver_df.column_names


### PR DESCRIPTION
Add comprehensive documentation for the chembl_cell_line pipeline to move it from Beta to Production status. This includes:

- Documentation at docs/providers/chembl/cell-line.md covering:
  - Schema fields (identifiers, metadata, source, external IDs)
  - Transformation rules and normalization
  - DQ validation and error thresholds
  - CLI usage examples
  - Entity relationships

- Integration tests with VCR cassettes:
  - Happy path test (Bronze → Silver → Gold)
  - Source fields verification test