### PR TITLE
Document ChEMBL compound record provider

### DIFF
--- a/docs/providers/chembl/compound-record.md
+++ b/docs/providers/chembl/compound-record.md
@@ -1,0 +1,187 @@
+# Пайплайн: ChEMBL Compound Record
+
+**Имя пайплайна:** `chembl_compound_record`
+**Провайдер:** `chembl`
+**Сущность:** `compound_record`
+**Версия схемы:** 1.0.0
+
+---
+
+## 1. Описание
+
+Пайплайн извлекает записи соединений (compound records) из API ChEMBL. Compound record связывает молекулу с документом (публикацией), содержа оригинальное название соединения, как оно упоминается в первоисточнике.
+
+**Назначение:** Сопоставление молекул с публикациями и отслеживание оригинальных наименований соединений в научной литературе.
+
+---
+
+## 2. Ключевые поля
+
+### Первичный ключ
+
+| Поле | Тип | Описание |
+|------|-----|----------|
+| `record_id` | `int` | Уникальный идентификатор записи (суррогатный ключ ChEMBL) |
+
+### Внешние ключи
+
+| Поле | Тип | Описание |
+|------|-----|----------|
+| `molecule_chembl_id` | `str` | FK → Molecule (например, `CHEMBL25`) |
+| `document_chembl_id` | `str` | FK → Publication (например, `CHEMBL1121421`) |
+| `src_id` | `int` | FK → Source (источник данных) |
+
+### Данные из источника
+
+| Поле | Тип | Описание |
+|------|-----|----------|
+| `compound_key` | `str \| None` | Оригинальный ключ соединения в документе |
+| `compound_name` | `str \| None` | Оригинальное название соединения в документе |
+| `src_compound_id` | `str \| None` | ID соединения в исходной базе данных |
+
+---
+
+## 3. Связи с другими сущностями
+
+```
+Compound Record (M:1) → Molecule
+Compound Record (M:1) → Document (Publication)
+Compound Record (M:1) → Source
+```
+
+**Граф зависимостей:**
+- Для полного анализа рекомендуется сначала загрузить `chembl_molecule` и `chembl_document`
+- `src_id` ссылается на источник данных ChEMBL (1 = ChEMBL)
+
+---
+
+## 4. Трансформация
+
+**Файл:** `src/bioetl/application/pipelines/chembl/compound_record_transformer.py`
+
+### Логика трансформации
+
+1. **Primary ID:** `record_id` (int, обязательный)
+2. **Нормализация строк:** Все строковые поля обрабатываются через `normalize_to_string()` — trim whitespace, NULL для пустых строк
+3. **Преобразование типов:** `record_id` и `src_id` преобразуются через `safe_int()`
+
+### Entity ID
+
+```python
+entity_id = f"chembl:{record_id}"
+```
+
+---
+
+## 5. Валидация
+
+### DQ-правила
+
+| Поле | Правило | Описание |
+|------|---------|----------|
+| `record_id` | `>= 1` | Положительное целое число |
+| `molecule_chembl_id` | `^CHEMBL\d+$` | Regex для формата ChEMBL ID |
+| `document_chembl_id` | `^CHEMBL\d+$` | Regex для формата ChEMBL ID |
+| `src_id` | `>= 1` | Положительное целое число |
+
+### Пороги ошибок
+
+| Порог | Условие | Действие |
+|-------|---------|----------|
+| Soft | > 5% ошибок | WARNING |
+| Hard | > 20% ошибок | FAIL BATCH |
+
+---
+
+## 6. Использование CLI
+
+```bash
+# Инкрементальная загрузка
+bioetl run chembl_compound_record
+
+# С ограничением количества записей
+bioetl run chembl_compound_record --limit 1000
+
+# Полная перезагрузка
+bioetl run chembl_compound_record --run-type rebuild
+
+# Dry-run (без записи)
+bioetl run chembl_compound_record --dry-run
+```
+
+---
+
+## 7. Фильтрация по Gold
+
+### Обязательные поля для Gold
+
+Записи проходят в Gold слой только при наличии:
+- `molecule_chembl_id`
+- `document_chembl_id`
+
+Конфигурируется в `configs/pipelines/chembl/compound_record.yaml`:
+
+```yaml
+gold_filters:
+  required_fields:
+    - molecule_chembl_id
+    - document_chembl_id
+```
+
+---
+
+## 8. Сортировка
+
+### Silver
+
+| Столбец | Порядок |
+|---------|---------|
+| `record_id` | ASC |
+
+### Gold
+
+| Столбец | Порядок |
+|---------|---------|
+| `molecule_chembl_id` | ASC |
+| `document_chembl_id` | ASC |
+| `record_id` | ASC |
+
+---
+
+## 9. Связанные файлы
+
+| Компонент | Путь |
+|-----------|------|
+| Конфигурация | `configs/pipelines/chembl/compound_record.yaml` |
+| Трансформер | `src/bioetl/application/pipelines/chembl/compound_record_transformer.py` |
+| Пайплайн | `src/bioetl/application/pipelines/chembl/compound_record.py` |
+| Сущность | `src/bioetl/domain/entities/chembl_compound_record.py` |
+| Схема | `src/bioetl/domain/schemas/chembl/compound_record.py` |
+
+---
+
+## 10. Примеры данных
+
+### Bronze (сырые данные из API)
+
+```json
+{
+  "record_id": 1234567,
+  "molecule_chembl_id": "CHEMBL25",
+  "document_chembl_id": "CHEMBL1121421",
+  "compound_key": "Aspirin",
+  "compound_name": "acetylsalicylic acid",
+  "src_id": 1,
+  "src_compound_id": null
+}
+```
+
+### Silver (нормализованные данные)
+
+| record_id | molecule_chembl_id | document_chembl_id | compound_key | compound_name | src_id |
+|-----------|--------------------|--------------------|--------------|---------------|--------|
+| 1234567 | CHEMBL25 | CHEMBL1121421 | Aspirin | acetylsalicylic acid | 1 |
+
+---
+
+*Последнее обновление: 2025-01-05*

--- a/tests/fixtures/vcr/TestChemblCompoundRecordPipeline.test_chembl_compound_record_error_handling.yaml
+++ b/tests/fixtures/vcr/TestChemblCompoundRecordPipeline.test_chembl_compound_record_error_handling.yaml
@@ -1,0 +1,40 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Host:
+      - www.ebi.ac.uk
+      User-Agent:
+      - BioETL/5.0.0
+    method: GET
+    uri: https://www.ebi.ac.uk/chembl/api/data/status.json
+  response:
+    body:
+      string: '{"activities": 24267312, "chembl_db_version": "ChEMBL_36", "chembl_release_date":
+        "2025-07-28", "compound_records": 3774137, "disinct_compounds": 2878135, "publications":
+        99142, "status": "UP", "targets": 17803}'
+    headers:
+      cache-control:
+      - max-age=30000000, s-maxage=30000000
+      content-length:
+      - '211'
+      content-type:
+      - application/json
+      date:
+      - Mon, 05 Jan 2026 23:22:25 GMT
+      server:
+      - gunicorn/20.0.4
+      strict-transport-security:
+      - max-age=0
+      vary:
+      - Accept, Origin
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/vcr/TestChemblCompoundRecordPipeline.test_chembl_compound_record_happy_path.yaml
+++ b/tests/fixtures/vcr/TestChemblCompoundRecordPipeline.test_chembl_compound_record_happy_path.yaml
@@ -1,0 +1,103 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Host:
+      - www.ebi.ac.uk
+      User-Agent:
+      - BioETL/5.0.0
+    method: GET
+    uri: https://www.ebi.ac.uk/chembl/api/data/status.json
+  response:
+    body:
+      string: '{"activities": 24267312, "chembl_db_version": "ChEMBL_36", "chembl_release_date":
+        "2025-07-28", "compound_records": 3774137, "disinct_compounds": 2878135, "publications":
+        99142, "status": "UP", "targets": 17803}'
+    headers:
+      cache-control:
+      - max-age=30000000, s-maxage=30000000
+      content-length:
+      - '211'
+      content-type:
+      - application/json
+      date:
+      - Mon, 05 Jan 2026 23:21:09 GMT
+      server:
+      - gunicorn/20.0.4
+      strict-transport-security:
+      - max-age=0
+      vary:
+      - Accept, Origin
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Host:
+      - www.ebi.ac.uk
+      User-Agent:
+      - BioETL/5.0.0
+    method: GET
+    uri: https://www.ebi.ac.uk/chembl/api/data/compound_record.json?limit=10&offset=0&format=json
+  response:
+    body:
+      string: '{"compound_records": [{"compound_key": "X", "compound_name": "Bis(3-[14-Benzyl-11-(1H-indol-3-ylmethyl)-2-isobutyl-13-methyl-5-(2-methylsulfanyl-ethyl)-3,6,9,12,15,20-hexaoxo-1,4,7,10,13,16-hexaaza-bicyclo[15.2.1]icos-18-en-8-yl]-propionamide)",
+        "document_chembl_id": "CHEMBL1126670", "molecule_chembl_id": "CHEMBL3349687",
+        "record_id": 1, "src_id": 1}, {"compound_key": "V", "compound_name": "3-[11,14-Dibenzyl-2-isobutyl-5-(2-methylsulfanyl-ethyl)-3,6,9,12,15,20-hexaoxo-1,4,7,10,13,16-hexaaza-bicyclo[15.2.1]icos-18-en-8-yl]-propionamide",
+        "document_chembl_id": "CHEMBL1126670", "molecule_chembl_id": "CHEMBL3349799",
+        "record_id": 2, "src_id": 1}, {"compound_key": "IX", "compound_name": "3-[14-Benzyl-11-(1H-indol-3-ylmethyl)-2-isobutyl-13-methyl-5-(2-methylsulfanyl-ethyl)-3,6,9,12,15,20-hexaoxo-1,4,7,10,13,16-hexaaza-bicyclo[15.2.1]icos-18-en-8-yl]-propionamide",
+        "document_chembl_id": "CHEMBL1126670", "molecule_chembl_id": "CHEMBL3349688",
+        "record_id": 3, "src_id": 1}, {"compound_key": "IV", "compound_name": "11,14-Dibenzyl-2-isobutyl-8-methyl-5-(2-methylsulfanyl-ethyl)-1,4,7,10,13,16-hexaaza-bicyclo[15.2.1]icos-18-ene-3,6,9,12,15,20-hexaone",
+        "document_chembl_id": "CHEMBL1126670", "molecule_chembl_id": "CHEMBL3349660",
+        "record_id": 4, "src_id": 1}, {"compound_key": "XVI", "compound_name": "3-[17-Benzyl-14-(1H-indol-3-ylmethyl)-2-isobutyl-5-(2-methylsulfanyl-ethyl)-3,6,9,12,15,18,23-heptaoxo-1,4,7,10,13,16,19-heptaaza-bicyclo[18.2.1]tricos-21-en-11-yl]-propionamide",
+        "document_chembl_id": "CHEMBL1126670", "molecule_chembl_id": "CHEMBL3350012",
+        "record_id": 5, "src_id": 1}, {"compound_key": "XIX", "compound_name": "3-[5-Benzyl-8-(1H-indol-3-ylmethyl)-17-isobutyl-14-(2-methylsulfanyl-ethyl)-4,7,10,13,16,19-hexaoxo-octadecahydro-3a,6,9,12,15,18-hexaaza-cyclopentacyclooctadecen-11-yl]-propionamide",
+        "document_chembl_id": "CHEMBL1126670", "molecule_chembl_id": "CHEMBL3349619",
+        "record_id": 6, "src_id": 1}, {"compound_key": "III", "compound_name": "11,14-Dibenzyl-2-isobutyl-5-(2-methylsulfanyl-ethyl)-1,4,7,10,13,16-hexaaza-bicyclo[15.2.1]icos-18-ene-3,6,9,12,15,20-hexaone",
+        "document_chembl_id": "CHEMBL1126670", "molecule_chembl_id": "CHEMBL3350013",
+        "record_id": 7, "src_id": 1}, {"compound_key": "VII", "compound_name": "14-Benzyl-2-isobutyl-11-methyl-5-(2-methylsulfanyl-ethyl)-11-naphthalen-1-yl-1,4,7,10,13,16-hexaaza-bicyclo[15.2.1]icos-18-ene-3,6,9,12,15,20-hexaone",
+        "document_chembl_id": "CHEMBL1126670", "molecule_chembl_id": "CHEMBL3350016",
+        "record_id": 8, "src_id": 1}, {"compound_key": "XII", "compound_name": "3-[17,20-Dibenzyl-2-isobutyl-5-(2-methylsulfanyl-ethyl)-3,6,12,15,18,21,26-heptaoxo-1,4,7,13,16,19,22-heptaaza-tricyclo[21.2.1.0*7,11*]hexacos-24-en-14-yl]-propionamide",
+        "document_chembl_id": "CHEMBL1126670", "molecule_chembl_id": "CHEMBL3349462",
+        "record_id": 9, "src_id": 1}, {"compound_key": "XIV", "compound_name": "3-[17-Benzyl-14-(4-hydroxy-benzyl)-2-isobutyl-5-(2-methylsulfanyl-ethyl)-3,6,9,12,15,18,23-heptaoxo-1,4,7,10,13,16,19-heptaaza-bicyclo[18.2.1]tricos-21-en-11-yl]-propionamide",
+        "document_chembl_id": "CHEMBL1126670", "molecule_chembl_id": "CHEMBL3349511",
+        "record_id": 10, "src_id": 1}], "page_meta": {"limit": 10, "next": "/chembl/api/data/compound_record.json?limit=10&offset=10",
+        "offset": 0, "previous": null, "total_count": 3774137}}'
+    headers:
+      cache-control:
+      - max-age=30000000, s-maxage=30000000
+      content-disposition:
+      - inline
+      content-length:
+      - '3310'
+      content-type:
+      - application/json
+      date:
+      - Mon, 05 Jan 2026 23:21:35 GMT
+      server:
+      - gunicorn/20.0.4
+      strict-transport-security:
+      - max-age=0
+      vary:
+      - Accept, Origin
+      x-chembl-in-cache:
+      - 'True'
+      x-chembl-retrieval-time:
+      - '0.03172707557678223'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/pipelines/test_chembl_compound_record.py
+++ b/tests/integration/pipelines/test_chembl_compound_record.py
@@ -1,0 +1,111 @@
+"""Integration tests for ChEMBL Compound Record Pipeline."""
+
+from __future__ import annotations
+
+import glob
+import os
+from dataclasses import replace
+
+import pytest
+import structlog
+from deltalake import DeltaTable
+
+from bioetl.composition.factories.pipeline_factories import (
+    chembl_compound_record_factory,
+)
+from bioetl.domain.exceptions import ApiError
+from tests.integration.pipelines.base import IntegrationPipelineTestCase
+
+logger = structlog.get_logger()
+
+
+class TestChemblCompoundRecordPipeline(IntegrationPipelineTestCase):
+    """Integration tests for chembl_compound_record pipeline."""
+
+    @pytest.mark.vcr
+    async def test_chembl_compound_record_happy_path(
+        self, settings, runtime_config, run_id
+    ):
+        """Test happy path: Bronze -> Silver -> Gold."""
+        # Override limit via config override since RuntimeConfig is frozen
+        runtime_config = replace(runtime_config, limit=10)
+
+        runner = self.create_runner(
+            factory=chembl_compound_record_factory,
+            settings=settings,
+            runtime_config=runtime_config,
+            run_id=run_id,
+        )
+
+        # Run the pipeline
+        await runner.run()
+
+        # Debug: list all files in storage root
+        for root, _dirs, files in os.walk(self.storage_root):
+            for file in files:
+                logger.debug("file_found", path=os.path.join(root, file))
+
+        # Verify Bronze files exist
+        bronze_files = glob.glob(f"{self.bronze_path}/**/*.jsonl.zst", recursive=True)
+        if not bronze_files:
+            bronze_files = glob.glob(
+                f"{self.bronze_path}/**/*.jsonl.zstd", recursive=True
+            )
+
+        assert len(bronze_files) > 0, f"No bronze files found in {self.bronze_path}"
+
+        # Verify Silver Delta Table
+        silver_table_name = runner.pipeline.config.silver_table
+        silver_table_path = f"{self.silver_path}/{silver_table_name}"
+
+        dt_silver = DeltaTable(silver_table_path)
+        silver_df = dt_silver.to_pyarrow_table()
+        assert len(silver_df) > 0, "Silver table is empty"
+
+        # Verify lineage fields in Silver
+        assert "_run_id" in silver_df.column_names
+        assert "_run_type" in silver_df.column_names
+        assert "_ingestion_ts" in silver_df.column_names
+
+        # Verify business fields in Silver
+        assert "record_id" in silver_df.column_names
+        assert "molecule_chembl_id" in silver_df.column_names
+        assert "document_chembl_id" in silver_df.column_names
+        assert "src_id" in silver_df.column_names
+
+        # Verify Gold Delta Table
+        gold_table_name = runner.pipeline.config.gold_table
+        if not gold_table_name:
+            gold_table_name = (
+                f"{runner.pipeline.config.provider}."
+                f"{runner.pipeline.config.entity_type}"
+            )
+
+        gold_table_path = f"{self.gold_path}/{gold_table_name.replace('.', '/')}"
+
+        dt_gold = DeltaTable(gold_table_path)
+        gold_df = dt_gold.to_pyarrow_table()
+        assert len(gold_df) > 0, "Gold table is empty"
+
+    @pytest.mark.vcr
+    async def test_chembl_compound_record_error_handling(
+        self, settings, runtime_config, run_id
+    ):
+        """Test error handling when API fails."""
+        runner = self.create_runner(
+            factory=chembl_compound_record_factory,
+            settings=settings,
+            runtime_config=runtime_config,
+            run_id=run_id,
+        )
+
+        async def mock_async_gen(*args, **kwargs):
+            if False:
+                yield  # make it a generator
+            raise ApiError("Simulated API Failure")
+
+        # Patch the instance method on the adapter object
+        runner.services.data_source.fetch = mock_async_gen
+
+        with pytest.raises(ApiError, match="Simulated API Failure"):
+            await runner.run()


### PR DESCRIPTION
Add documentation for chembl_compound_record pipeline and integration tests with VCR cassettes to promote the pipeline from Beta to Production status.

- Add docs/providers/chembl/compound-record.md with full pipeline documentation
- Add integration tests in tests/integration/pipelines/test_chembl_compound_record.py
- Record VCR cassettes for happy_path and error_handling scenarios