### PR TITLE
Remove cloud dependencies from docstring

### DIFF
--- a/src/bioetl/infrastructure/observability/lineage.py
+++ b/src/bioetl/infrastructure/observability/lineage.py
@@ -10,7 +10,7 @@ Lineage is stored in Delta Lake tables for queryability.
 
 Usage:
     tracker = LineageTracker(
-        delta_path="s3://bucket/lineage",
+        delta_path="./data/lineage",
         pipeline_name="chembl_activity"
     )
 


### PR DESCRIPTION
Replace cloud-specific s3://bucket/lineage with local ./data/lineage to align with project's local-only architecture.