### PR TITLE
Remove dead and unused code from project

### DIFF
--- a/src/bioetl/application/core/pipeline_services.py
+++ b/src/bioetl/application/core/pipeline_services.py
@@ -74,7 +74,6 @@ class PipelineServices:
         """Validate that all services are provided."""
         # Validation is implicit - dataclass requires all non-default fields
         # Runtime checks happen via Protocol structural typing
-        pass
 
     async def __aenter__(self) -> Self:
         """Enter the async context manager, initializing services."""

--- a/src/bioetl/domain/ports/noop.py
+++ b/src/bioetl/domain/ports/noop.py
@@ -46,19 +46,15 @@ class _NoOpSpan:
         exc_tb: TracebackType | None,
     ) -> None:
         """Context manager exit."""
-        pass
 
     def set_attribute(self, key: str, value: Any) -> None:
         """Set span attribute (no-op)."""
-        pass
 
     def set_status(self, status: Any) -> None:
         """Set span status (no-op)."""
-        pass
 
     def record_exception(self, exception: Exception) -> None:
         """Record exception (no-op)."""
-        pass
 
 
 class _NoOpOtelTracer:
@@ -110,7 +106,6 @@ class NoOpTracing:
 
     def close(self) -> None:
         """No-op close. Idempotent."""
-        pass
 
 
 class NoOpMetrics:
@@ -143,7 +138,6 @@ class NoOpMetrics:
             labels: A dictionary of label names to label values.
 
         """
-        pass
 
     def increment_counter(
         self,
@@ -159,7 +153,6 @@ class NoOpMetrics:
             labels: A dictionary of label names to label values.
 
         """
-        pass
 
     def set_gauge(
         self,
@@ -175,11 +168,9 @@ class NoOpMetrics:
             labels: A dictionary of label names to label values.
 
         """
-        pass
 
     def close(self) -> None:
         """No-op close. Idempotent."""
-        pass
 
 
 class NoOpAudit:
@@ -205,7 +196,6 @@ class NoOpAudit:
             entry: The audit entry (ignored).
 
         """
-        pass
 
     async def get_entries(
         self,
@@ -234,7 +224,6 @@ class NoOpAudit:
 
     async def aclose(self) -> None:
         """No-op close. Idempotent."""
-        pass
 
 
 class NoOpPiiHasher:

--- a/src/bioetl/domain/types.py
+++ b/src/bioetl/domain/types.py
@@ -45,7 +45,6 @@ class BronzeRecord(TypedDict):
     # We use NotRequired for dynamic fields, but TypedDict doesn't allow mixing optional/required well in old python
     # For now, we assume keys are strings and values Any
     # This is a marker type for clarity in signatures
-    pass
 
 
 class SilverRecord(TypedDict, total=False):

--- a/src/bioetl/infrastructure/adapters/base.py
+++ b/src/bioetl/infrastructure/adapters/base.py
@@ -114,7 +114,6 @@ class BaseHttpAdapter(HealthCheckMixin, DataSourcePort):
         Base implementation is a no-op as HTTP client is managed by context.
         Subclasses can override if they manage additional resources.
         """
-        pass
 
     async def health_check(self) -> HealthStatus:
         """Check API health status using Template Method pattern.

--- a/src/bioetl/infrastructure/adapters/uniprot/idmapping_client.py
+++ b/src/bioetl/infrastructure/adapters/uniprot/idmapping_client.py
@@ -435,12 +435,14 @@ class UniProtIDMappingClient(BaseHttpAdapter):
         Raises:
             NotImplementedError: Always, as this is not a data source.
         """
+        # AsyncIterator requires yield before raise for proper generator creation
+        if False:  # pragma: no cover
+            yield {}  # Required for AsyncIterator type signature
         raise NotImplementedError(
             "UniProtIDMappingClient is not a DataSourcePort. "
             "Use IDMappingDataSource for pipeline integration, "
             "or call map_ids() directly for ID mapping operations."
         )
-        yield  # pragma: no cover  # Make this an async generator
 
     def __repr__(self) -> str:
         """Return string representation."""

--- a/src/bioetl/infrastructure/checkpoint/local_checkpoint.py
+++ b/src/bioetl/infrastructure/checkpoint/local_checkpoint.py
@@ -132,4 +132,3 @@ class LocalCheckpoint:
 
     async def aclose(self) -> None:
         """Close checkpoint storage (no-op for local filesystem)."""
-        pass

--- a/src/bioetl/infrastructure/observability/noop_logger.py
+++ b/src/bioetl/infrastructure/observability/noop_logger.py
@@ -37,20 +37,15 @@ class NoOpLogger:
 
     def info(self, _event: str, **_kwargs: Any) -> None:
         """Log info message (no-op)."""
-        pass
 
     def warning(self, _event: str, **_kwargs: Any) -> None:
         """Log warning message (no-op)."""
-        pass
 
     def error(self, _event: str, **_kwargs: Any) -> None:
         """Log error message (no-op)."""
-        pass
 
     def debug(self, _event: str, **_kwargs: Any) -> None:
         """Log debug message (no-op)."""
-        pass
 
     def exception(self, _event: str, **_kwargs: Any) -> None:
         """Log exception with traceback (no-op)."""
-        pass

--- a/src/bioetl/infrastructure/observability/noop_metrics.py
+++ b/src/bioetl/infrastructure/observability/noop_metrics.py
@@ -62,7 +62,6 @@ class NoOpMetrics(MetricsPort):
         labels: dict[str, str],
     ) -> None:
         """No-op histogram observation."""
-        pass
 
     def increment_counter(
         self,
@@ -71,7 +70,6 @@ class NoOpMetrics(MetricsPort):
         labels: dict[str, str],
     ) -> None:
         """No-op counter increment."""
-        pass
 
     def set_gauge(
         self,
@@ -80,11 +78,9 @@ class NoOpMetrics(MetricsPort):
         labels: dict[str, str],
     ) -> None:
         """No-op gauge set."""
-        pass
 
     def close(self) -> None:
         """No-op close. Idempotent."""
-        pass
 
     @classmethod
     def reset_warning(cls) -> None:

--- a/src/bioetl/infrastructure/observability/noop_tracing.py
+++ b/src/bioetl/infrastructure/observability/noop_tracing.py
@@ -22,7 +22,6 @@ class NoOpTracer:
         exc_tb: TracebackType | None,
     ) -> None:
         """Context manager exit."""
-        pass
 
     def start_as_current_span(self, *args: Any, **kwargs: Any) -> Self:
         """Start a new span (no-op).
@@ -33,15 +32,12 @@ class NoOpTracer:
 
     def set_attribute(self, key: str, value: Any) -> None:
         """Set span attribute (no-op)."""
-        pass
 
     def set_status(self, status: Any) -> None:
         """Set span status (no-op)."""
-        pass
 
     def record_exception(self, exception: Exception) -> None:
         """Record exception (no-op)."""
-        pass
 
 
 class NoOpTracing:

--- a/src/bioetl/infrastructure/quarantine/unified.py
+++ b/src/bioetl/infrastructure/quarantine/unified.py
@@ -209,7 +209,6 @@ class UnifiedQuarantine:
 
     async def aclose(self) -> None:
         """Close resources."""
-        pass
 
     def _calculate_hash(self, payload_json: str) -> str:
         """Calculate SHA256 hash of payload for deduplication."""

--- a/src/bioetl/interfaces/cli/commands/checkpoint.py
+++ b/src/bioetl/interfaces/cli/commands/checkpoint.py
@@ -16,7 +16,6 @@ from bioetl.interfaces.cli.formatters import echo_checkpoint, echo_info
 @click.group()
 def checkpoint() -> None:
     """Manage checkpoints."""
-    pass
 
 
 @checkpoint.command("list")

--- a/src/bioetl/interfaces/cli/commands/config.py
+++ b/src/bioetl/interfaces/cli/commands/config.py
@@ -33,7 +33,6 @@ def _config_to_dict(config: Any) -> dict[str, Any]:
 @click.group()
 def config() -> None:
     """View and validate configuration."""
-    pass
 
 
 @config.command("show")

--- a/src/bioetl/interfaces/cli/commands/health.py
+++ b/src/bioetl/interfaces/cli/commands/health.py
@@ -21,7 +21,6 @@ from bioetl.interfaces.cli.exit_codes import ExitCode
 @click.group()
 def health() -> None:
     """Health check and monitoring operations."""
-    pass
 
 
 @health.command("server")

--- a/src/bioetl/interfaces/cli/commands/lock.py
+++ b/src/bioetl/interfaces/cli/commands/lock.py
@@ -20,7 +20,6 @@ from bioetl.interfaces.cli.formatters import echo_error, echo_info, echo_warning
 @click.group()
 def lock() -> None:
     """Manage pipeline locks."""
-    pass
 
 
 @lock.command("release")

--- a/src/bioetl/interfaces/cli/commands/maintenance.py
+++ b/src/bioetl/interfaces/cli/commands/maintenance.py
@@ -16,7 +16,6 @@ from bioetl.interfaces.cli.commands.vacuum import vacuum_all_command, vacuum_com
 @click.group()
 def maintenance() -> None:
     """Maintenance operations for Delta tables."""
-    pass
 
 
 # Register all maintenance subcommands

--- a/src/bioetl/interfaces/cli/commands/quarantine.py
+++ b/src/bioetl/interfaces/cli/commands/quarantine.py
@@ -33,7 +33,6 @@ def quarantine() -> None:
     Error recovery dashboard commands for inspecting, analyzing,
     and recovering from pipeline failures.
     """
-    pass
 
 
 @quarantine.command("inspect")

--- a/src/bioetl/interfaces/cli/main.py
+++ b/src/bioetl/interfaces/cli/main.py
@@ -24,7 +24,6 @@ from bioetl.interfaces.cli.commands.run_all import run_all
 @click.version_option(version=__version__)
 def cli() -> None:
     """BioETL - Bioactivity Data ETL Pipeline."""
-    pass
 
 
 # Register commands


### PR DESCRIPTION
…code

- Remove 34 redundant `pass` statements after docstrings (autoflake)
- Fix unreachable code in idmapping_client.py:443 - move yield before raise
- All linting and tests pass

Metrics:
- LOC: 66,735 → 66,701 (-34 lines)
- 17 files modified across domain, infrastructure, interfaces layers