### PR TITLE
2Fix failing lint and type check tests

### DIFF
--- a/tests/unit/application/core/test_idmapping_data_source.py
+++ b/tests/unit/application/core/test_idmapping_data_source.py
@@ -6,7 +6,6 @@ Coverage target: ≥80%
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest

--- a/tests/unit/application/services/test_health_service.py
+++ b/tests/unit/application/services/test_health_service.py
@@ -180,7 +180,7 @@ class TestDataSourceFactoryPort:
                 return ["chembl"]
 
             @staticmethod
-            def create(provider_name: str) -> Any:
+            def create(_provider_name: str) -> Any:
                 return MagicMock()
 
         assert isinstance(MockFactory(), DataSourceFactoryPort)


### PR DESCRIPTION
- Remove unused `Any` import from test_idmapping_data_source.py
- Prefix unused parameter with underscore in test_health_service.py