### PR TITLE
Add parameters to UniProtProteinTransformer constructor

### DIFF
--- a/src/bioetl/application/pipelines/uniprot/transformer.py
+++ b/src/bioetl/application/pipelines/uniprot/transformer.py
@@ -18,7 +18,7 @@ from bioetl.domain.services import IdentityService
 if TYPE_CHECKING:
     from bioetl.domain.context import PipelineContext
     from bioetl.domain.filtering import GoldFilterConfig
-    from bioetl.domain.ports import MetricsPort, TracingPort
+    from bioetl.domain.ports import MetricsPort, PiiHasherPort, TracingPort
     from bioetl.domain.types import BronzeRecord, SilverRecord
 
 
@@ -33,27 +33,33 @@ class UniProtProteinTransformer(BaseTransformer):
     def __init__(
         self,
         provider: str = "uniprot",
+        entity_type: str = "protein",
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
+        pii_hasher: PiiHasherPort | None = None,
     ):
         """Initialize UniProt protein transformer.
 
         Args:
             provider: Data provider identifier.
+            entity_type: Entity type for metrics labels. Defaults to 'protein'.
             tracer: Optional tracing port for distributed tracing (O1 observability).
             metrics: Optional metrics port for duration/error tracking (O1 observability).
             gold_filters: Optional filter configuration for Gold layer.
             identity_service: Service for computing entity IDs and content hashes.
+            pii_hasher: Optional PII hasher for hashing author names and other PII.
 
         """
         super().__init__(
             provider,
+            entity_type=entity_type,
             tracer=tracer,
             metrics=metrics,
             gold_filters=gold_filters,
             identity_service=identity_service,
+            pii_hasher=pii_hasher,
         )
 
     async def _transform_impl(

--- a/tests/unit/application/pipelines/test_uniprot_transformer.py
+++ b/tests/unit/application/pipelines/test_uniprot_transformer.py
@@ -366,3 +366,33 @@ class TestUniProtProteinTransformer:
 
         assert result is not None
         assert result["organism_id"] == 10090
+
+    def test_transformer_accepts_entity_type(self):
+        """Transformer MUST accept entity_type parameter."""
+        transformer = UniProtProteinTransformer(entity_type="protein")
+        assert transformer.entity_type == "protein"
+
+    def test_transformer_default_entity_type(self):
+        """Transformer SHOULD default entity_type to 'protein'."""
+        transformer = UniProtProteinTransformer()
+        assert transformer.entity_type == "protein"
+
+    def test_transformer_custom_entity_type(self):
+        """Transformer MUST accept custom entity_type."""
+        transformer = UniProtProteinTransformer(entity_type="custom_entity")
+        assert transformer.entity_type == "custom_entity"
+
+    def test_transformer_accepts_pii_hasher(self):
+        """Transformer MUST accept pii_hasher parameter."""
+        from bioetl.domain.ports import NoOpPiiHasher
+
+        hasher = NoOpPiiHasher()
+        transformer = UniProtProteinTransformer(pii_hasher=hasher)
+        assert transformer._pii_hasher is hasher
+
+    def test_transformer_default_pii_hasher(self):
+        """Transformer SHOULD default pii_hasher to NoOpPiiHasher."""
+        from bioetl.domain.ports import NoOpPiiHasher
+
+        transformer = UniProtProteinTransformer()
+        assert isinstance(transformer._pii_hasher, NoOpPiiHasher)


### PR DESCRIPTION
…nsformer

Add entity_type and pii_hasher parameters to UniProtProteinTransformer constructor to match the BaseTransformer contract:

- Add entity_type parameter with default="protein"
- Add pii_hasher parameter with default=None
- Update super().__init__() to pass both new parameters
- Add PiiHasherPort import in TYPE_CHECKING block
- Add tests for new parameters (entity_type, pii_hasher)

This ensures consistent transformer signatures across all pipeline transformers for metrics labels and PII hashing support.