### PR TITLE
Fix transformer_factory documentation inconsistency

### DIFF
--- a/src/bioetl/composition/factories/transformer_factory.py
+++ b/src/bioetl/composition/factories/transformer_factory.py
@@ -15,7 +15,9 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from bioetl.application.core.base_transformer import BaseTransformer
-    from bioetl.domain.ports import MetricsPort, TracingPort
+    from bioetl.domain.filtering import GoldFilterConfig
+    from bioetl.domain.ports import MetricsPort, PiiHasherPort, TracingPort
+    from bioetl.domain.services import IdentityService
 
 # Mapping of (provider, entity_type) to transformer class
 _TRANSFORMER_REGISTRY: dict[tuple[str, str], type[BaseTransformer]] = {}
@@ -42,6 +44,9 @@ def create_transformer(
     entity_type: str,
     tracer: TracingPort | None = None,
     metrics: MetricsPort | None = None,
+    gold_filters: GoldFilterConfig | None = None,
+    identity_service: IdentityService | None = None,
+    pii_hasher: PiiHasherPort | None = None,
 ) -> BaseTransformer:
     """Create a transformer instance for the given provider and entity type.
 
@@ -53,6 +58,11 @@ def create_transformer(
         entity_type: Entity type (e.g., 'activity', 'compound').
         tracer: Optional tracing port for distributed tracing (O1 observability).
         metrics: Optional metrics port for duration/error tracking (O1 observability).
+        gold_filters: Optional filter configuration for Gold layer.
+        identity_service: Service for computing entity IDs and content hashes.
+            Defaults to a new IdentityService instance in BaseTransformer.
+        pii_hasher: Optional PII hasher for hashing author names and other PII.
+            Defaults to NoOpPiiHasher (no hashing) in BaseTransformer.
 
     Returns:
         Configured transformer instance with observability.
@@ -75,7 +85,15 @@ def create_transformer(
         )
 
     transformer_class = _TRANSFORMER_REGISTRY[key]
-    return transformer_class(provider=provider, tracer=tracer, metrics=metrics)
+    return transformer_class(
+        provider=provider,
+        entity_type=entity_type,
+        tracer=tracer,
+        metrics=metrics,
+        gold_filters=gold_filters,
+        identity_service=identity_service,
+        pii_hasher=pii_hasher,
+    )
 
 
 def get_transformer_class(

--- a/tests/unit/composition/factories/test_transformer_factory.py
+++ b/tests/unit/composition/factories/test_transformer_factory.py
@@ -33,12 +33,20 @@ class MockTransformer:
     def __init__(
         self,
         provider: str,
+        entity_type: str | None = None,
         tracer: Any = None,
         metrics: Any = None,
+        gold_filters: Any = None,
+        identity_service: Any = None,
+        pii_hasher: Any = None,
     ):
         self.provider = provider
+        self.entity_type = entity_type
         self.tracer = tracer
         self.metrics = metrics
+        self.gold_filters = gold_filters
+        self.identity_service = identity_service
+        self.pii_hasher = pii_hasher
 
 
 class TestRegisterTransformer:
@@ -135,6 +143,74 @@ class TestCreateTransformer:
 
         assert transformer.tracer is mock_tracer
         assert transformer.metrics is mock_metrics
+
+    def test_create_transformer_passes_entity_type(self) -> None:
+        """create_transformer passes entity_type to transformer."""
+        register_transformer("chembl", "activity", MockTransformer)
+
+        transformer = create_transformer("chembl", "activity")
+
+        assert transformer.entity_type == "activity"
+
+    def test_create_transformer_with_gold_filters(self) -> None:
+        """create_transformer passes gold_filters."""
+        mock_gold_filters = MagicMock()
+        register_transformer("chembl", "activity", MockTransformer)
+
+        transformer = create_transformer(
+            "chembl", "activity", gold_filters=mock_gold_filters
+        )
+
+        assert transformer.gold_filters is mock_gold_filters
+
+    def test_create_transformer_with_identity_service(self) -> None:
+        """create_transformer passes identity_service."""
+        mock_identity_service = MagicMock()
+        register_transformer("chembl", "activity", MockTransformer)
+
+        transformer = create_transformer(
+            "chembl", "activity", identity_service=mock_identity_service
+        )
+
+        assert transformer.identity_service is mock_identity_service
+
+    def test_create_transformer_with_pii_hasher(self) -> None:
+        """create_transformer passes pii_hasher."""
+        mock_pii_hasher = MagicMock()
+        register_transformer("chembl", "activity", MockTransformer)
+
+        transformer = create_transformer(
+            "chembl", "activity", pii_hasher=mock_pii_hasher
+        )
+
+        assert transformer.pii_hasher is mock_pii_hasher
+
+    def test_create_transformer_with_all_parameters(self) -> None:
+        """create_transformer passes all parameters correctly."""
+        mock_tracer = MagicMock()
+        mock_metrics = MagicMock()
+        mock_gold_filters = MagicMock()
+        mock_identity_service = MagicMock()
+        mock_pii_hasher = MagicMock()
+        register_transformer("pubchem", "compound", MockTransformer)
+
+        transformer = create_transformer(
+            "pubchem",
+            "compound",
+            tracer=mock_tracer,
+            metrics=mock_metrics,
+            gold_filters=mock_gold_filters,
+            identity_service=mock_identity_service,
+            pii_hasher=mock_pii_hasher,
+        )
+
+        assert transformer.provider == "pubchem"
+        assert transformer.entity_type == "compound"
+        assert transformer.tracer is mock_tracer
+        assert transformer.metrics is mock_metrics
+        assert transformer.gold_filters is mock_gold_filters
+        assert transformer.identity_service is mock_identity_service
+        assert transformer.pii_hasher is mock_pii_hasher
 
     def test_create_transformer_unregistered_raises(self) -> None:
         """create_transformer raises KeyError for unregistered."""


### PR DESCRIPTION
…PipelineFactory

Extend create_transformer() signature to pass all BaseTransformer parameters:
- entity_type (was received but not passed through)
- gold_filters
- identity_service
- pii_hasher

This aligns the standalone factory API with GenericPipelineFactory.create_transformer() for consistency. Added comprehensive tests for all new parameters.