### PR TITLE
Run tests and fix errors

### DIFF
--- a/src/bioetl/domain/schemas/base.py
+++ b/src/bioetl/domain/schemas/base.py
@@ -6,6 +6,7 @@ Contains common metadata fields required by RULES.md §2.4.
 from __future__ import annotations
 
 from datetime import datetime
+from typing import cast
 
 import pandera.pandas as pa
 from pandera.typing import Series
@@ -26,7 +27,7 @@ class ETLRecordSchema(pa.DataFrameModel):
     @pa.check("content_hash", name="content_hash_format")
     def _check_content_hash(cls, series: Series[str]) -> Series[bool]:
         """Validate content_hash is a 64-character hex string."""
-        return series.str.match(r"^[a-f0-9]{64}$")
+        return cast("Series[bool]", series.str.match(r"^[a-f0-9]{64}$"))
 
     # === Lineage & DQ Fields (from RULES.md §2.4) ===
     run_id: Series[object] = pa.Field(
@@ -44,7 +45,7 @@ class ETLRecordSchema(pa.DataFrameModel):
     @pa.check("_run_type", name="run_type_values")
     def _check_run_type(cls, series: Series[str]) -> Series[bool]:
         """Validate _run_type values."""
-        return series.isin(["incremental", "backfill", "rebuild"])
+        return cast("Series[bool]", series.isin(["incremental", "backfill", "rebuild"]))
 
     source_batch_id: Series[object] | None = pa.Field(
         alias="_source_batch_id",
@@ -62,7 +63,7 @@ class ETLRecordSchema(pa.DataFrameModel):
     def _check_ingestion_ts(cls, series: Series[datetime]) -> Series[bool]:
         """Ensure ingestion timestamp is not in the future."""
         # Note: In practice, we just check it's a valid datetime
-        return series <= datetime.now(series.dt.tz)
+        return cast("Series[bool]", series <= datetime.now(series.dt.tz))
 
     dq_warn: Series[bool] = pa.Field(
         alias="_dq_warn",
@@ -86,7 +87,7 @@ class ETLRecordSchema(pa.DataFrameModel):
     @pa.check("_index", name="index_non_negative")
     def _check_index(cls, series: Series[int]) -> Series[bool]:
         """Validate index is non-negative."""
-        return series >= 0
+        return cast("Series[bool]", series >= 0)
 
     class Config:
         """Pandera configuration."""

--- a/src/bioetl/domain/schemas/openalex/publication.py
+++ b/src/bioetl/domain/schemas/openalex/publication.py
@@ -6,6 +6,8 @@ Includes lookup metadata fields for DOI/title resolution tracking.
 
 from __future__ import annotations
 
+from typing import cast
+
 import pandas as pd
 import pandera.pandas as pa
 from pandera.typing import Series
@@ -37,7 +39,7 @@ class OpenAlexPublicationSchema(ETLRecordSchema):
     @classmethod
     def _check_openalex_id(cls, series: Series[str]) -> Series[bool]:
         """Validate OpenAlex ID format."""
-        return series.str.match(r"^W\d+$")
+        return cast("Series[bool]", series.str.match(r"^W\d+$"))
 
     # === Core Fields ===
     doi: Series[str] = pa.Field(
@@ -49,7 +51,9 @@ class OpenAlexPublicationSchema(ETLRecordSchema):
     @classmethod
     def _check_doi(cls, series: Series[str]) -> Series[bool]:
         """Validate DOI format."""
-        return series.isna() | series.str.match(r"^10\.\d{4,}/.*$")
+        return cast(
+            "Series[bool]", series.isna() | series.str.match(r"^10\.\d{4,}/.*$")
+        )
 
     title: Series[str] = pa.Field(
         nullable=True,
@@ -70,7 +74,9 @@ class OpenAlexPublicationSchema(ETLRecordSchema):
     @classmethod
     def _check_year(cls, series: Series[pd.Int64Dtype]) -> Series[bool]:
         """Validate year range."""
-        return series.isna() | ((series >= 1500) & (series <= 2100))
+        return cast(
+            "Series[bool]", series.isna() | ((series >= 1500) & (series <= 2100))
+        )
 
     publication_date: Series[str] = pa.Field(
         nullable=True,
@@ -81,7 +87,9 @@ class OpenAlexPublicationSchema(ETLRecordSchema):
     @classmethod
     def _check_publication_date(cls, series: Series[str]) -> Series[bool]:
         """Validate publication date format."""
-        return series.isna() | series.str.match(r"^\d{4}-\d{2}-\d{2}$")
+        return cast(
+            "Series[bool]", series.isna() | series.str.match(r"^\d{4}-\d{2}-\d{2}$")
+        )
 
     doc_type: Series[str] = pa.Field(
         nullable=False,
@@ -119,7 +127,7 @@ class OpenAlexPublicationSchema(ETLRecordSchema):
     @classmethod
     def _check_oa_status(cls, series: Series[str]) -> Series[bool]:
         """Validate OA status values."""
-        return series.isna() | series.isin(OA_STATUS_VALUES)
+        return cast("Series[bool]", series.isna() | series.isin(OA_STATUS_VALUES))
 
     # === Metrics ===
     cited_by_count: Series[pd.Int64Dtype] = pa.Field(
@@ -131,7 +139,7 @@ class OpenAlexPublicationSchema(ETLRecordSchema):
     @classmethod
     def _check_cited_by_count(cls, series: Series[pd.Int64Dtype]) -> Series[bool]:
         """Validate citation count is non-negative."""
-        return series.isna() | (series >= 0)
+        return cast("Series[bool]", series.isna() | (series >= 0))
 
     # === Metadata ===
     language: Series[str] = pa.Field(
@@ -157,7 +165,7 @@ class OpenAlexPublicationSchema(ETLRecordSchema):
     @classmethod
     def _check_lookup_method(cls, series: Series[str]) -> Series[bool]:
         """Validate lookup method values."""
-        return series.isin(LOOKUP_METHODS)
+        return cast("Series[bool]", series.isin(LOOKUP_METHODS))
 
     original_doi: Series[str] = pa.Field(
         alias="_original_doi",


### PR DESCRIPTION
Add cast() calls to resolve mypy errors in Pandera schema validation methods. pandas Series operations return Any type annotations, but pandera expects Series[bool]. Using explicit casts documents the expected return type and satisfies mypy strict checks.