### PR TITLE
Add OpenAlex publication schema validation tests

### DIFF
--- a/src/bioetl/domain/schemas/openalex/publication.py
+++ b/src/bioetl/domain/schemas/openalex/publication.py
@@ -6,8 +6,6 @@ Includes lookup metadata fields for DOI/title resolution tracking.
 
 from __future__ import annotations
 
-from typing import cast
-
 import pandas as pd
 import pandera.pandas as pa
 from pandera.typing import Series
@@ -32,27 +30,16 @@ class OpenAlexPublicationSchema(ETLRecordSchema):
     # === Primary Key ===
     openalex_id: Series[str] = pa.Field(
         nullable=False,
+        str_matches=r"^W\d+$",
         description="OpenAlex Work ID (e.g., W2148763428)",
     )
-
-    # NOTE: Do not add @classmethod - Pandera requires @pa.check to be the outermost decorator
-    @pa.check("openalex_id", name="openalex_id_format")
-    def _check_openalex_id(cls, series: Series[str]) -> Series[bool]:
-        """Validate OpenAlex ID format."""
-        return cast("Series[bool]", series.str.match(r"^W\d+$"))
 
     # === Core Fields ===
     doi: Series[str] = pa.Field(
         nullable=True,
+        str_matches=r"^10\.\d{4,}/.*$",
         description="Digital Object Identifier",
     )
-
-    @pa.check("doi", name="doi_format")
-    def _check_doi(cls, series: Series[str]) -> Series[bool]:
-        """Validate DOI format."""
-        return cast(
-            "Series[bool]", series.isna() | series.str.match(r"^10\.\d{4,}/.*$")
-        )
 
     title: Series[str] = pa.Field(
         nullable=True,
@@ -66,27 +53,16 @@ class OpenAlexPublicationSchema(ETLRecordSchema):
 
     year: Series[pd.Int64Dtype] = pa.Field(
         nullable=True,
+        ge=1500,
+        le=2100,
         description="Publication year",
     )
 
-    @pa.check("year", name="year_range")
-    def _check_year(cls, series: Series[pd.Int64Dtype]) -> Series[bool]:
-        """Validate year range."""
-        return cast(
-            "Series[bool]", series.isna() | ((series >= 1500) & (series <= 2100))
-        )
-
     publication_date: Series[str] = pa.Field(
         nullable=True,
+        str_matches=r"^\d{4}-\d{2}-\d{2}$",
         description="Publication date (YYYY-MM-DD)",
     )
-
-    @pa.check("publication_date", name="publication_date_format")
-    def _check_publication_date(cls, series: Series[str]) -> Series[bool]:
-        """Validate publication date format."""
-        return cast(
-            "Series[bool]", series.isna() | series.str.match(r"^\d{4}-\d{2}-\d{2}$")
-        )
 
     doc_type: Series[str] = pa.Field(
         nullable=False,
@@ -117,24 +93,16 @@ class OpenAlexPublicationSchema(ETLRecordSchema):
 
     oa_status: Series[str] = pa.Field(
         nullable=True,
+        isin=OA_STATUS_VALUES,
         description="OA status",
     )
-
-    @pa.check("oa_status", name="oa_status_values")
-    def _check_oa_status(cls, series: Series[str]) -> Series[bool]:
-        """Validate OA status values."""
-        return cast("Series[bool]", series.isna() | series.isin(OA_STATUS_VALUES))
 
     # === Metrics ===
     cited_by_count: Series[pd.Int64Dtype] = pa.Field(
         nullable=True,
+        ge=0,
         description="Citation count",
     )
-
-    @pa.check("cited_by_count", name="cited_by_count_non_negative")
-    def _check_cited_by_count(cls, series: Series[pd.Int64Dtype]) -> Series[bool]:
-        """Validate citation count is non-negative."""
-        return cast("Series[bool]", series.isna() | (series >= 0))
 
     # === Metadata ===
     language: Series[str] = pa.Field(
@@ -153,13 +121,9 @@ class OpenAlexPublicationSchema(ETLRecordSchema):
     lookup_method: Series[str] = pa.Field(
         alias="_lookup_method",
         nullable=False,
+        isin=LOOKUP_METHODS,
         description="How record was resolved: doi, title_fallback, title_only",
     )
-
-    @pa.check("_lookup_method", name="lookup_method_values")
-    def _check_lookup_method(cls, series: Series[str]) -> Series[bool]:
-        """Validate lookup method values."""
-        return cast("Series[bool]", series.isin(LOOKUP_METHODS))
 
     original_doi: Series[str] = pa.Field(
         alias="_original_doi",

--- a/src/bioetl/domain/schemas/semanticscholar/publication.py
+++ b/src/bioetl/domain/schemas/semanticscholar/publication.py
@@ -7,8 +7,6 @@ Includes lookup metadata fields for DOI/title resolution tracking.
 
 from __future__ import annotations
 
-from typing import cast
-
 import pandera.pandas as pa
 from pandera.typing import Series
 
@@ -31,46 +29,28 @@ class SemanticScholarPublicationSchema(ETLRecordSchema):
     # === Primary Key ===
     paper_id: Series[str] = pa.Field(
         nullable=False,
+        str_matches=r"^[a-f0-9]{40}$",
         description="Semantic Scholar Paper ID (40-char hex)",
     )
-
-    @pa.check("paper_id", name="paper_id_format")
-    def _check_paper_id(cls, series: Series[str]) -> Series[bool]:
-        """Validate Semantic Scholar paper ID format."""
-        return cast("Series[bool]", series.str.match(r"^[a-f0-9]{40}$"))
 
     # === External Identifiers ===
     doi: Series[str] = pa.Field(
         nullable=True,
+        str_matches=r"^10\.\d{4,}/.*$",
         description="Digital Object Identifier",
     )
 
-    @pa.check("doi", name="doi_format")
-    def _check_doi(cls, series: Series[str]) -> Series[bool]:
-        """Validate DOI format."""
-        return cast(
-            "Series[bool]", series.isna() | series.str.match(r"^10\.\d{4,}/.*$")
-        )
-
     pmid: Series[str] = pa.Field(
         nullable=True,
+        str_matches=r"^\d+$",
         description="PubMed ID",
     )
 
-    @pa.check("pmid", name="pmid_format")
-    def _check_pmid(cls, series: Series[str]) -> Series[bool]:
-        """Validate PMID format."""
-        return cast("Series[bool]", series.isna() | series.str.match(r"^\d+$"))
-
     pmcid: Series[str] = pa.Field(
         nullable=True,
+        str_matches=r"^PMC\d+$",
         description="PubMed Central ID",
     )
-
-    @pa.check("pmcid", name="pmcid_format")
-    def _check_pmcid(cls, series: Series[str]) -> Series[bool]:
-        """Validate PMCID format."""
-        return cast("Series[bool]", series.isna() | series.str.match(r"^PMC\d+$"))
 
     arxiv_id: Series[str] = pa.Field(
         nullable=True,
@@ -79,13 +59,9 @@ class SemanticScholarPublicationSchema(ETLRecordSchema):
 
     corpus_id: Series[int] = pa.Field(
         nullable=True,
+        ge=0,
         description="S2 Corpus ID",
     )
-
-    @pa.check("corpus_id", name="corpus_id_non_negative")
-    def _check_corpus_id(cls, series: Series[int]) -> Series[bool]:
-        """Validate corpus ID is non-negative."""
-        return cast("Series[bool]", series.isna() | (series >= 0))
 
     # === Core Fields ===
     title: Series[str] = pa.Field(
@@ -105,27 +81,16 @@ class SemanticScholarPublicationSchema(ETLRecordSchema):
 
     year: Series[int] = pa.Field(
         nullable=True,
+        ge=1500,
+        le=2100,
         description="Publication year",
     )
 
-    @pa.check("year", name="year_range")
-    def _check_year(cls, series: Series[int]) -> Series[bool]:
-        """Validate year range."""
-        return cast(
-            "Series[bool]", series.isna() | ((series >= 1500) & (series <= 2100))
-        )
-
     publication_date: Series[str] = pa.Field(
         nullable=True,
+        str_matches=r"^\d{4}-\d{2}-\d{2}$",
         description="Publication date (YYYY-MM-DD)",
     )
-
-    @pa.check("publication_date", name="publication_date_format")
-    def _check_publication_date(cls, series: Series[str]) -> Series[bool]:
-        """Validate publication date format."""
-        return cast(
-            "Series[bool]", series.isna() | series.str.match(r"^\d{4}-\d{2}-\d{2}$")
-        )
 
     # === Journal/Venue ===
     journal: Series[str] = pa.Field(
@@ -151,23 +116,15 @@ class SemanticScholarPublicationSchema(ETLRecordSchema):
     # === Metrics ===
     citation_count: Series[int] = pa.Field(
         nullable=True,
+        ge=0,
         description="Number of citations",
     )
 
-    @pa.check("citation_count", name="citation_count_non_negative")
-    def _check_citation_count(cls, series: Series[int]) -> Series[bool]:
-        """Validate citation count is non-negative."""
-        return cast("Series[bool]", series.isna() | (series >= 0))
-
     reference_count: Series[int] = pa.Field(
         nullable=True,
+        ge=0,
         description="Number of references",
     )
-
-    @pa.check("reference_count", name="reference_count_non_negative")
-    def _check_reference_count(cls, series: Series[int]) -> Series[bool]:
-        """Validate reference count is non-negative."""
-        return cast("Series[bool]", series.isna() | (series >= 0))
 
     # === Open Access ===
     is_open_access: Series[bool] = pa.Field(
@@ -182,13 +139,9 @@ class SemanticScholarPublicationSchema(ETLRecordSchema):
 
     open_access_status: Series[str] = pa.Field(
         nullable=True,
+        isin=OA_STATUS_VALUES,
         description="OA status (GREEN, GOLD, HYBRID, BRONZE)",
     )
-
-    @pa.check("open_access_status", name="open_access_status_values")
-    def _check_open_access_status(cls, series: Series[str]) -> Series[bool]:
-        """Validate OA status values."""
-        return cast("Series[bool]", series.isna() | series.isin(OA_STATUS_VALUES))
 
     # === Classification ===
     fields_of_study: Series[str] = pa.Field(
@@ -210,25 +163,17 @@ class SemanticScholarPublicationSchema(ETLRecordSchema):
     # === Source Tracking ===
     source: Series[str] = pa.Field(
         nullable=False,
+        eq="semanticscholar",
         description="Data source identifier",
     )
-
-    @pa.check("source", name="source_values")
-    def _check_source(cls, series: Series[str]) -> Series[bool]:
-        """Validate source values."""
-        return cast("Series[bool]", series.isin(["semanticscholar"]))
 
     # === Lookup Metadata (batch DOI resolution) ===
     lookup_method: Series[str] = pa.Field(
         alias="_lookup_method",
         nullable=False,
+        isin=LOOKUP_METHODS,
         description="How record was resolved: doi, title_fallback, title_only",
     )
-
-    @pa.check("_lookup_method", name="lookup_method_values")
-    def _check_lookup_method(cls, series: Series[str]) -> Series[bool]:
-        """Validate lookup method values."""
-        return cast("Series[bool]", series.isin(LOOKUP_METHODS))
 
     original_doi: Series[str] = pa.Field(
         alias="_original_doi",


### PR DESCRIPTION
…ompatibility

Convert OpenAlex and SemanticScholar publication schemas from using @pa.check decorators to inline Field constraints (str_matches, isin, ge, le, eq) for better compatibility with pandera's function dispatch.

This fixes KeyError: <class 'pandas.core.series.Series'> in validation and SchemaInitError for lookup_method field reference.