### PR TITLE
Fix timeout in advanced scenarios end-to-end test

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -24,6 +24,29 @@ from deltalake import DeltaTable
 from bioetl.domain.context import PipelineRunContext
 from bioetl.domain.types import RunType
 
+# Default timeout for E2E tests (seconds)
+# E2E tests run full pipelines with HTTP calls, Delta Lake operations,
+# and PyArrow imports which can be slow, especially on Python 3.14
+E2E_DEFAULT_TIMEOUT = 120
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Automatically apply default timeout to all E2E tests.
+
+    This hook runs after test collection and adds a timeout marker
+    to E2E tests that don't already have one. This ensures pipeline
+    tests have enough time to complete without timing out during
+    Delta Lake/PyArrow operations.
+    """
+    for item in items:
+        # Only apply to tests in this directory (e2e)
+        if "e2e" in str(item.fspath):
+            # Check if test already has a timeout marker
+            existing_timeout = item.get_closest_marker("timeout")
+            if existing_timeout is None:
+                # Add default E2E timeout
+                item.add_marker(pytest.mark.timeout(E2E_DEFAULT_TIMEOUT))
+
 
 @pytest.fixture(scope="session", autouse=True)
 def e2e_environment():

--- a/tests/e2e/test_advanced_scenarios_e2e.py
+++ b/tests/e2e/test_advanced_scenarios_e2e.py
@@ -37,6 +37,7 @@ from .conftest import (
 @pytest.mark.e2e
 @pytest.mark.vcr
 @pytest.mark.asyncio
+@pytest.mark.timeout(120)  # Pipeline + Delta table operations need more time
 async def test_vacuum_runs_after_successful_pipeline(e2e_data_dir: Path):
     """E2E: VACUUM is triggered after successful pipeline run when enabled.
 
@@ -75,6 +76,7 @@ async def test_vacuum_runs_after_successful_pipeline(e2e_data_dir: Path):
 @pytest.mark.e2e
 @pytest.mark.vcr
 @pytest.mark.asyncio
+@pytest.mark.timeout(120)  # Multiple pipeline runs need more time
 async def test_vacuum_respects_retention_days(e2e_data_dir: Path):
     """E2E: VACUUM retention period is respected.
 
@@ -199,6 +201,7 @@ async def test_quarantine_can_be_inspected(e2e_data_dir: Path):
 @pytest.mark.e2e
 @pytest.mark.vcr
 @pytest.mark.asyncio
+@pytest.mark.timeout(180)  # Two sequential pipelines (ChEMBL + UniProt) need more time
 async def test_chembl_and_uniprot_sequential_run(e2e_data_dir: Path):
     """E2E: ChEMBL and UniProt pipelines can run sequentially.
 
@@ -238,6 +241,7 @@ async def test_chembl_and_uniprot_sequential_run(e2e_data_dir: Path):
 @pytest.mark.e2e
 @pytest.mark.vcr
 @pytest.mark.asyncio
+@pytest.mark.timeout(180)  # Three sequential pipelines need more time
 async def test_multiple_chembl_entities_parallel_safe(e2e_data_dir: Path):
     """E2E: Multiple ChEMBL entity pipelines can run without conflicts.
 
@@ -303,6 +307,7 @@ async def test_pipeline_resumes_from_checkpoint(e2e_data_dir: Path):
 @pytest.mark.e2e
 @pytest.mark.vcr
 @pytest.mark.asyncio
+@pytest.mark.timeout(120)  # Two pipeline runs need more time
 async def test_failed_run_preserves_partial_data(e2e_data_dir: Path):
     """E2E: Partial data is preserved when pipeline fails mid-run.
 
@@ -337,6 +342,7 @@ async def test_failed_run_preserves_partial_data(e2e_data_dir: Path):
 @pytest.mark.e2e
 @pytest.mark.vcr
 @pytest.mark.asyncio
+@pytest.mark.timeout(120)  # Two pipeline runs need more time
 async def test_rebuild_clears_existing_data(e2e_data_dir: Path):
     """E2E: REBUILD run type clears existing Silver/Gold data.
 
@@ -372,6 +378,7 @@ async def test_rebuild_clears_existing_data(e2e_data_dir: Path):
 @pytest.mark.e2e
 @pytest.mark.vcr
 @pytest.mark.asyncio
+@pytest.mark.timeout(120)  # Two pipeline runs need more time
 async def test_backfill_clears_silver_only(e2e_data_dir: Path):
     """E2E: BACKFILL run type clears Silver but keeps Gold unchanged.
 


### PR DESCRIPTION
The default pytest timeout of 60 seconds is insufficient for E2E tests that run full pipelines with HTTP calls, Delta Lake operations, and PyArrow imports (especially slow on Python 3.14).

Changes:
- Add pytest_collection_modifyitems hook in e2e/conftest.py to apply default 120s timeout to all E2E tests without explicit timeout marker
- Add explicit timeout markers (120s-180s) to tests in test_advanced_scenarios_e2e.py that run multiple pipelines

This fixes timeout issues like the one seen in test_vacuum_runs_after_successful_pipeline where the pipeline completed in ~42s but PyArrow import chain during assertion exceeded the remaining time.