### PR TITLE
Fix code formatting test failures

### DIFF
--- a/tests/security/test_security.py
+++ b/tests/security/test_security.py
@@ -242,20 +242,20 @@ class TestPrivateKeyExposure:
             ".import_linter_cache",
             "coverage.json",  # Skip large generated files
         }
-        
+
         files = []
         # Walk effectively prunes trees, unlike rglob
         for root, dirs, filenames in os.walk(PROJECT_ROOT):
             # Prune excluded directories in-place
             dirs[:] = [d for d in dirs if d not in excluded]
-            
+
             for filename in filenames:
                 if filename in excluded:
                     continue
-                    
+
                 file_path = Path(root) / filename
                 files.append(file_path)
-                
+
         return files
 
     def test_no_private_keys_in_repo(self, all_files: list[Path]) -> None:


### PR DESCRIPTION
Apply ruff formatting to fix trailing whitespace issues that were causing test_ruff_formatting_tests to fail.