### PR TITLE
Fix end-to-end pipeline test timeout

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -63,6 +63,15 @@ def e2e_environment():
     pd.set_option("display.width", 80)
     pd.set_option("display.max_columns", 20)
 
+    # Pre-import pandera engines to avoid import contention in thread pool executors.
+    # On Windows, pandera's is_geopandas_dtype() check can hang when importing
+    # during schema validation in concurrent threads. Pre-importing warms up
+    # the import cache and prevents filesystem stat hangs.
+    try:
+        import pandera.engines.pandas_engine  # noqa: F401
+    except ImportError:
+        pass  # Pandera may not have this submodule in all versions
+
     # Register all pipelines (required for bootstrap_pipeline to work)
     from bioetl.composition.factories.pipeline_factories import register_all_pipelines
 

--- a/tests/e2e/test_full_pipeline_chain_e2e.py
+++ b/tests/e2e/test_full_pipeline_chain_e2e.py
@@ -92,11 +92,16 @@ async def test_chembl_molecule_then_activity_chain(e2e_data_dir: Path):
 @pytest.mark.e2e
 @pytest.mark.vcr
 @pytest.mark.asyncio
+@pytest.mark.timeout(600)  # Extended timeout: 5 pipelines × ~60s each + Gold validation
 async def test_all_chembl_pipelines_chain(e2e_data_dir: Path):
     """E2E: Run all ChEMBL pipelines in sequence.
 
     Order: Target → Molecule → Document → Activity → Assay
     This tests the full ChEMBL data ecosystem.
+
+    Note: This test has an extended timeout (600s) because it runs 5 pipelines
+    sequentially, each with HTTP calls, Delta Lake operations, and Gold layer
+    validation with Pandera schema checks.
     """
     pipelines_in_order = [
         ("chembl_target", "chembl_target", 2),


### PR DESCRIPTION
- Add 600s timeout to test_all_chembl_pipelines_chain (runs 5 pipelines)
- Pre-import pandera.engines.pandas_engine in e2e_environment fixture to avoid import contention in thread pool executors on Windows

The test was timing out because:
1. Running 5 ChEMBL pipelines sequentially exceeds the 120s default timeout
2. Pandera's is_geopandas_dtype() check was hanging during schema validation in thread pool executors due to import lock contention on Windows