### PR TITLE
Remove hardcoded entity_id in IDMappingTransformer

### DIFF
--- a/src/bioetl/application/pipelines/uniprot/idmapping_transformer.py
+++ b/src/bioetl/application/pipelines/uniprot/idmapping_transformer.py
@@ -97,8 +97,11 @@ class IDMappingTransformer(BaseTransformer):
             "mapping_status": mapping_status,
         }
 
-        # Step 4: Generate entity_id: chembl:uniprot:{target_chembl_id}
-        entity_id = f"chembl:uniprot:{target_chembl_id}"
+        # Step 4: Generate entity_id using IdentityService (RULES.md §2.8)
+        entity_id = self.compute_entity_id(
+            source_id=target_chembl_id,
+            record={"target_chembl_id": target_chembl_id},
+        )
 
         # Step 5: Compute content_hash (RULES.md §2.8.1)
         content_hash = self.compute_content_hash(business_data, exclude_none=True)

--- a/tests/unit/application/pipelines/test_idmapping_transformer.py
+++ b/tests/unit/application/pipelines/test_idmapping_transformer.py
@@ -79,7 +79,7 @@ class TestIDMappingTransformer:
         result = await transformer.transform(mock_context, record, index=0)
 
         assert result is not None
-        assert result["entity_id"] == "chembl:uniprot:CHEMBL204"
+        assert result["entity_id"] == "uniprot:CHEMBL204"
 
     @pytest.mark.asyncio
     async def test_transform_entity_id_for_not_found(self, transformer, mock_context):
@@ -92,7 +92,7 @@ class TestIDMappingTransformer:
         result = await transformer.transform(mock_context, record, index=0)
 
         assert result is not None
-        assert result["entity_id"] == "chembl:uniprot:CHEMBL12345_INVALID"
+        assert result["entity_id"] == "uniprot:CHEMBL12345_INVALID"
 
     @pytest.mark.asyncio
     async def test_transform_missing_chembl_id(self, transformer, mock_context):
@@ -294,8 +294,8 @@ class TestIDMappingTransformer:
         result = await transformer.transform(mock_context, record, index=0)
 
         assert result is not None
-        # Entity ID format doesn't change based on provider
-        assert result["entity_id"] == "chembl:uniprot:CHEMBL204"
+        # Entity ID uses provider from transformer (RULES.md §2.8)
+        assert result["entity_id"] == "custom_provider:CHEMBL204"
 
     @pytest.mark.asyncio
     async def test_transform_none_accession_vs_missing_key(


### PR DESCRIPTION
Replace hardcoded entity_id format with compute_entity_id() method call for consistency with other transformers (RULES.md §2.8).

Changes:
- IDMappingTransformer now uses self.compute_entity_id() like all other transformers in the codebase
- Entity ID format changes from 'chembl:uniprot:{id}' to 'uniprot:{id}' following the standard '{provider}:{source_id}' pattern
- Updated tests to expect the new format