### PR TITLE
Unify pipeline configuration file structures

### DIFF
--- a/configs/pipelines/chembl/activity.yaml
+++ b/configs/pipelines/chembl/activity.yaml
@@ -12,6 +12,7 @@ description: "Extract biological activity records from ChEMBL API"
 
 primary_keys: ["activity_id"]
 silver_table: "chembl_activity"
+gold_table: "chembl_activity"
 
 # Reference to source configuration file
 source_file: ../../sources/chembl.yaml
@@ -41,6 +42,7 @@ sink:
   silver:
     path: "data/output/silver"
     primary_key: ["activity_id"]
+    partition_by: []
     csv_export:
       path: "data/output/csv/silver"
   gold:

--- a/configs/pipelines/chembl/assay.yaml
+++ b/configs/pipelines/chembl/assay.yaml
@@ -11,6 +11,7 @@ description: "Extract bioassay definitions from ChEMBL API"
 
 primary_keys: ["assay_chembl_id"]
 silver_table: "chembl_assay"
+gold_table: "chembl_assay"
 
 source_file: ../../sources/chembl.yaml
 

--- a/configs/pipelines/chembl/assay_parameters.yaml
+++ b/configs/pipelines/chembl/assay_parameters.yaml
@@ -12,6 +12,7 @@ description: "Extract experimental assay parameters from ChEMBL API"
 
 primary_keys: ["assay_param_id"]
 silver_table: "chembl_assay_parameters"
+gold_table: "chembl_assay_parameters"
 
 source_file: ../../sources/chembl.yaml
 

--- a/configs/pipelines/chembl/cell_line.yaml
+++ b/configs/pipelines/chembl/cell_line.yaml
@@ -11,6 +11,7 @@ description: "Extract cell lines from ChEMBL API"
 
 primary_keys: ["cell_chembl_id"]
 silver_table: "chembl_cell_line"
+gold_table: "chembl_cell_line"
 
 source_file: ../../sources/chembl.yaml
 
@@ -26,6 +27,7 @@ sink:
   silver:
     path: "data/output/silver"
     primary_key: ["cell_chembl_id"]
+    partition_by: []
     sort_by:
       columns: ["cell_chembl_id"]
       ascending: true

--- a/configs/pipelines/chembl/compound_record.yaml
+++ b/configs/pipelines/chembl/compound_record.yaml
@@ -14,6 +14,7 @@ description: "Extract compound records from ChEMBL API"
 
 primary_keys: ["record_id"]
 silver_table: "chembl_compound_record"
+gold_table: "chembl_compound_record"
 
 source_file: ../../sources/chembl.yaml
 

--- a/configs/pipelines/chembl/document.yaml
+++ b/configs/pipelines/chembl/document.yaml
@@ -11,6 +11,7 @@ description: "Extract scientific documents from ChEMBL API"
 
 primary_keys: ["document_chembl_id"]
 silver_table: "chembl_document"
+gold_table: "chembl_document"
 
 source_file: ../../sources/chembl.yaml
 

--- a/configs/pipelines/chembl/document_similarity.yaml
+++ b/configs/pipelines/chembl/document_similarity.yaml
@@ -11,6 +11,7 @@ description: "Extract document similarity data (Tanimoto coefficients) from ChEM
 
 primary_keys: ["sim_id"]
 silver_table: "chembl_document_similarity"
+gold_table: "chembl_document_similarity"
 
 source_file: ../../sources/chembl.yaml
 

--- a/configs/pipelines/chembl/document_term.yaml
+++ b/configs/pipelines/chembl/document_term.yaml
@@ -14,6 +14,7 @@ description: "Extract document terms (MeSH, keywords) from ChEMBL Document recor
 # entity_id is generated as SHA256 hash of composite key
 primary_keys: ["entity_id"]
 silver_table: "chembl_document_term"
+gold_table: "chembl_document_term"
 
 source_file: ../../sources/chembl.yaml
 

--- a/configs/pipelines/chembl/molecule.yaml
+++ b/configs/pipelines/chembl/molecule.yaml
@@ -11,6 +11,7 @@ description: "Extract molecules/compounds from ChEMBL API"
 
 primary_keys: ["molecule_chembl_id"]
 silver_table: "chembl_molecule"
+gold_table: "chembl_molecule"
 
 source_file: ../../sources/chembl.yaml
 

--- a/configs/pipelines/chembl/protein_class.yaml
+++ b/configs/pipelines/chembl/protein_class.yaml
@@ -33,6 +33,7 @@ sink:
     path: data/bronze/chembl/protein_class
   silver:
     path: data/silver/chembl/protein_class
+    primary_key: ["protein_class_id"]
     partition_by: ["class_level"]
     sort_by:
       columns: ["protein_class_id"]

--- a/configs/pipelines/chembl/target.yaml
+++ b/configs/pipelines/chembl/target.yaml
@@ -11,6 +11,7 @@ description: "Extract biological targets from ChEMBL API"
 
 primary_keys: ["target_chembl_id"]
 silver_table: "chembl_target"
+gold_table: "chembl_target"
 
 source_file: ../../sources/chembl.yaml
 

--- a/configs/pipelines/chembl/target_component.yaml
+++ b/configs/pipelines/chembl/target_component.yaml
@@ -31,6 +31,7 @@ sink:
     path: data/bronze/chembl/target_component
   silver:
     path: data/silver/chembl/target_component
+    primary_key: ["component_id"]
     partition_by: ["organism"]
     csv_export:
       path: "data/output/csv/silver"

--- a/configs/pipelines/crossref/publication_enrichment.yaml
+++ b/configs/pipelines/crossref/publication_enrichment.yaml
@@ -12,6 +12,7 @@ description: "Enrich publication records with CrossRef metadata via DOI resoluti
 
 primary_keys: ["doi"]
 silver_table: "crossref_publication"
+gold_table: "crossref_publication"
 
 source_file: ../../sources/crossref.yaml
 
@@ -25,16 +26,6 @@ gold_filters:
       min: 1900
       max: 2100
 
-# Entity-specific transform steps
-transform:
-  version: "1.0.0"
-  steps:
-    - normalize_doi
-    - extract_metadata
-    - strip_html_abstract
-    - add_metadata
-    - calculate_content_hash
-
 # Entity-specific sink overrides
 sink:
   bronze:
@@ -42,6 +33,7 @@ sink:
   silver:
     path: "data/output/silver"
     primary_key: ["doi"]
+    partition_by: []
     csv_export:
       path: "data/output/csv/silver"
   gold:

--- a/configs/pipelines/openalex/publication.yaml
+++ b/configs/pipelines/openalex/publication.yaml
@@ -33,19 +33,6 @@ gold_filters:
       min: 1900
       max: 2100
 
-# Entity-specific transform steps
-transform:
-  version: "1.0.0"
-  steps:
-    - extract_openalex_id
-    - extract_doi
-    - reconstruct_abstract
-    - extract_authors
-    - extract_concepts
-    - normalize_dates
-    - add_metadata
-    - calculate_content_hash
-
 # Entity-specific sink overrides
 sink:
   bronze:

--- a/configs/pipelines/pubchem/compound.yaml
+++ b/configs/pipelines/pubchem/compound.yaml
@@ -22,13 +22,6 @@ gold_filters:
     - molecular_formula
   columns: {}
 
-# Entity-specific transform steps (different from ChEMBL)
-transform:
-  version: "1.0.0"
-  steps:
-    - normalize_fields
-    - generate_content_hash
-
 # Entity-specific sink overrides (custom paths)
 sink:
   bronze:

--- a/configs/pipelines/pubmed/publications.yaml
+++ b/configs/pipelines/pubmed/publications.yaml
@@ -28,14 +28,6 @@ gold_filters:
     - title
   columns: {}
 
-# Entity-specific transform steps
-transform:
-  version: "1.0.0"
-  steps:
-    - parse_xml
-    - extract_metadata
-    - normalize_dates
-
 # Entity-specific sink overrides
 sink:
   bronze:

--- a/configs/pipelines/semanticscholar/publication.yaml
+++ b/configs/pipelines/semanticscholar/publication.yaml
@@ -28,19 +28,6 @@ gold_filters:
       min: 1900
       max: 2100
 
-# Entity-specific transform steps
-transform:
-  version: "1.0.0"
-  steps:
-    - extract_external_ids
-    - extract_authors
-    - extract_journal_info
-    - extract_open_access_info
-    - extract_tldr
-    - normalize_dates
-    - add_metadata
-    - calculate_content_hash
-
 # Entity-specific sink configuration
 sink:
   bronze:

--- a/configs/pipelines/uniprot/idmapping.yaml
+++ b/configs/pipelines/uniprot/idmapping.yaml
@@ -31,14 +31,6 @@ source:
     from_db: ChEMBL
     to_db: UniProtKB
 
-# Transform configuration
-transform:
-  version: "1.0.0"
-  steps:
-    - map_ids
-    - validate_schema
-    - generate_content_hash
-
 # DQ rules - elevated thresholds for ID mapping
 # Many ChEMBL targets may not have UniProt mappings (expected behavior)
 dq_rules:

--- a/configs/pipelines/uniprot/protein.yaml
+++ b/configs/pipelines/uniprot/protein.yaml
@@ -24,14 +24,6 @@ gold_filters:
   columns:
     reviewed: ["true"]  # Swiss-Prot (reviewed) only
 
-# Entity-specific transform steps (different from ChEMBL)
-transform:
-  version: "1.0.0"
-  steps:
-    - normalize_fields
-    - extract_features
-    - generate_content_hash
-
 # Entity-specific sink overrides (custom paths)
 sink:
   bronze:

--- a/docs/config-unification-plan.md
+++ b/docs/config-unification-plan.md
@@ -1,0 +1,375 @@
+# Config Unification Plan
+
+**Version:** 1.0
+**Date:** 2026-01-06
+**Status:** In Progress
+
+## Executive Summary
+
+Analysis of 20 pipeline configs (1 defaults + 19 entity configs) revealed:
+- **129 unique parameters** across all configs
+- **21 parameters** present in ALL entity configs (consistent)
+- **~50 parameters** with inconsistent presence (partial coverage)
+- **16 parameters** only in `_defaults.yaml` (never overridden)
+
+### Key Structural Issues
+
+| Issue | Severity | Configs Affected |
+|-------|----------|------------------|
+| Missing `gold_table` | Medium | 11/19 entity configs |
+| Missing `sink.silver.partition_by` | Low | 3/19 (activity, cell_line, crossref) |
+| Missing `sink.silver.primary_key` | Medium | 2/19 (protein_class, target_component) |
+| `source` vs `source_file` inconsistency | High | 3 use inline `source` |
+| `transform` block presence | Info | 7/19 have it (non-ChEMBL) |
+| `dq_rules`/`circuit_breaker` override | Info | Only 1 config (idmapping) |
+
+---
+
+## Discrepancy Categories
+
+### Category A: Missing in _defaults (Entity-Specific - Expected)
+
+These parameters are intentionally entity-specific and should NOT be in defaults:
+
+| Parameter | Reason |
+|-----------|--------|
+| `pipeline_name` | Unique per entity |
+| `provider` | Varies by provider |
+| `entity_type` | Unique per entity |
+| `description` | Entity-specific description |
+| `primary_keys` | Different PKs per entity |
+| `silver_table` | Named per entity |
+| `gold_table` | Named per entity |
+| `source_file` | Reference to provider source |
+| `gold_filters.*` | Entity-specific filtering rules |
+
+### Category B: Entity-Specific Overrides (Expected)
+
+These overrides are legitimate and should remain:
+
+| Override | Configs | Reason |
+|----------|---------|--------|
+| `dq_rules` | uniprot/idmapping | Higher thresholds for ID mapping |
+| `circuit_breaker` | uniprot/idmapping | Custom settings |
+| `rate_limit` | uniprot/idmapping | UniProt API limits |
+| `batch_size` | protein_class, target_component | Full-load strategy |
+| `sink.bronze.enabled: false` | uniprot/idmapping | No Bronze for API-only source |
+
+### Category C: Inconsistent Presence (Needs Unification)
+
+| Parameter | Current State | Target State |
+|-----------|---------------|--------------|
+| `gold_table` | 8/19 have it | ALL should have it (default = silver_table) |
+| `sink.silver.partition_by` | 16/19 have it | ALL should have it ([] if none) |
+| `sink.silver.primary_key` | 17/19 have it | ALL should have it |
+| `transform` | 7/19 have it | REMOVE (not used by code) |
+| `source` (inline) | 3/19 have it | Consolidate with source_file |
+
+### Category D: Value Inconsistency (Needs Review)
+
+| Parameter | Variation | Resolution |
+|-----------|-----------|------------|
+| `sink.bronze.path` | Mixed formats | Standardize to `data/output/bronze` |
+| `sink.silver.path` | Mixed formats | Standardize to `data/output/silver` |
+| `sink.gold.path` | Mixed formats | Standardize to `data/output/gold` |
+| `input_filter.batch_size` | 1-1000 | Keep varied (API-specific) |
+
+### Category E: Structural Inconsistency
+
+#### E1: `source` vs `source_file`
+
+**Current state:**
+- 18 configs use `source_file: ../../sources/{provider}.yaml`
+- 3 configs have inline `source` block (openalex, pubmed, uniprot/idmapping)
+- 2 configs have BOTH (openalex, pubmed)
+
+**Resolution:**
+- Keep `source_file` as reference to provider source config
+- Inline `source` should be for pipeline-specific overrides only
+- Configs with both should use `source` for overrides only
+
+#### E2: `transform` block
+
+**Current state:**
+- Only 7 configs have `transform` (non-ChEMBL providers)
+- Transform steps are NOT currently used by application code
+
+**Resolution:**
+- REMOVE `transform` from all configs (Phase 2)
+- If needed later, add to _defaults with empty steps
+
+### Category F: Unused Parameters in _defaults
+
+These are in _defaults but never overridden (verify if used by code):
+
+| Parameter | Status |
+|-----------|--------|
+| `defaults_version` | Keep (documentation) |
+| `maintenance.*` | Keep (future use) |
+| `sink.bronze.deterministic` | Keep (code uses) |
+| `sink.bronze.format` | Keep (code uses) |
+| `sink.bronze.save_json` | Keep (code uses) |
+| `sink.silver.forensic_retention` | Keep (code uses) |
+| `sink.silver.on_schema_mismatch` | Keep (code uses) |
+| `sink.gold.validation.strict` | Keep (code uses) |
+
+---
+
+## Canonical Structure
+
+### Required Parameters (MUST be in every entity config)
+
+```yaml
+# Metadata (REQUIRED)
+pipeline_name: str          # Unique pipeline identifier
+provider: str               # Provider name (chembl, pubchem, uniprot, etc.)
+entity_type: str            # Entity type
+version: str                # Config version (semver)
+description: str            # Human-readable description
+
+# Schema (REQUIRED)
+primary_keys: list[str]     # Primary key fields
+silver_table: str           # Silver table name
+gold_table: str             # Gold table name (defaults to silver_table if omitted)
+
+# Source (REQUIRED - one of these)
+source_file: str            # Reference to source config (preferred)
+# OR
+source: {}                  # Inline source config (for special cases)
+
+# Filters (REQUIRED)
+gold_filters:
+  required_fields: list[str]  # REQUIRED: fields that must be non-null
+  columns: {}                 # OPTIONAL: column value filters
+  ranges: {}                  # OPTIONAL: numeric range filters
+  list_lengths: {}            # OPTIONAL: list length constraints
+  list_contains: {}           # OPTIONAL: list containment checks
+
+# Sink (REQUIRED - paths)
+sink:
+  bronze:
+    path: str               # Bronze output path
+  silver:
+    path: str               # Silver output path
+    primary_key: list[str]  # Primary key for merge
+    partition_by: list[str] # Partition columns ([] if none)
+    csv_export:
+      path: str             # CSV export path
+  gold:
+    path: str               # Gold output path
+    csv_export:
+      path: str             # CSV export path
+
+# Input Filter (REQUIRED)
+input_filter:
+  enabled: bool             # Whether filtering is enabled
+  source_path: str          # Input CSV path (if enabled)
+  column_name: str          # Column in CSV (if enabled)
+  filter_field: str         # Field to filter by (if enabled)
+  batch_size: int           # Batch size (from _defaults if not specified)
+```
+
+### Optional Parameters (MAY override _defaults)
+
+```yaml
+# Override DQ thresholds (rare)
+dq_rules:
+  soft_fail_threshold: float  # Default: 0.05
+  hard_fail_threshold: float  # Default: 0.20
+
+# Override circuit breaker (rare)
+circuit_breaker:
+  failure_threshold: int      # Default: 5
+  recovery_timeout: int       # Default: 300
+
+# Override rate limits (rare)
+rate_limit:
+  requests_per_second: float
+  burst: int
+
+# Entity-specific batch settings
+batch_size: int
+checkpoint_interval: int
+
+# Sort configuration (optional)
+sink:
+  silver:
+    sort_by:
+      columns: list[str]
+      ascending: bool
+  gold:
+    sort_by:
+      columns: list[str]
+      ascending: bool
+```
+
+### Parameters to Remove
+
+These should be removed from entity configs (redundant with _defaults):
+
+```yaml
+# REMOVE - use _defaults
+sink.silver.format: delta
+sink.silver.mode: merge
+sink.silver.classification: public
+sink.silver.csv_export.enabled: true
+sink.silver.csv_export.delimiter: ","
+sink.silver.csv_export.header: true
+sink.silver.csv_export.encoding: "utf-8"
+sink.gold.enabled: true
+sink.gold.format: delta
+sink.gold.mode: overwrite
+sink.gold.csv_export.enabled: true
+sink.gold.csv_export.delimiter: ","
+sink.gold.csv_export.header: true
+sink.gold.csv_export.encoding: "utf-8"
+
+# REMOVE - not used by code
+transform: {}
+```
+
+---
+
+## Migration Plan
+
+### Phase 1: Add Missing Required Parameters
+
+For each config, add missing required parameters:
+
+| Config | Add `gold_table` | Add `partition_by` | Add `primary_key` |
+|--------|------------------|-------------------|-------------------|
+| chembl/activity | ✓ `chembl_activity` | ✓ `[]` | — |
+| chembl/assay | ✓ `chembl_assay` | — | — |
+| chembl/assay_parameters | ✓ `chembl_assay_parameters` | — | — |
+| chembl/cell_line | ✓ `chembl_cell_line` | ✓ `[]` | — |
+| chembl/compound_record | ✓ `chembl_compound_record` | — | — |
+| chembl/document | ✓ `chembl_document` | — | — |
+| chembl/document_similarity | ✓ `chembl_document_similarity` | — | — |
+| chembl/document_term | ✓ `chembl_document_term` | — | — |
+| chembl/molecule | ✓ `chembl_molecule` | — | — |
+| chembl/protein_class | — | — | ✓ `[protein_class_id]` |
+| chembl/target | ✓ `chembl_target` | — | — |
+| chembl/target_component | — | — | ✓ `[component_id]` |
+| crossref/publication_enrichment | ✓ `crossref_publication` | ✓ `[]` | — |
+| openalex/publication | — | — | — |
+| pubchem/compound | — | — | — |
+| pubmed/publications | — | — | — |
+| semanticscholar/publication | — | — | — |
+| uniprot/idmapping | — | — | — |
+| uniprot/protein | — | — | — |
+
+### Phase 2: Remove Redundant Parameters
+
+Remove parameters that duplicate _defaults:
+- `sink.silver.format`
+- `sink.silver.mode`
+- `sink.silver.classification`
+- `sink.gold.format`
+- `sink.gold.mode`
+- `sink.silver.csv_export.enabled/delimiter/header/encoding`
+- `sink.gold.csv_export.enabled/delimiter/header/encoding`
+
+**Exception:** Keep in uniprot/idmapping (has legitimate overrides)
+
+### Phase 3: Remove Unused Parameters
+
+Remove `transform` block from all configs (not used by code).
+
+### Phase 4: Standardize Paths
+
+Standardize sink paths to consistent format:
+- Bronze: `data/output/bronze`
+- Silver: `data/output/silver`
+- Gold: `data/output/gold`
+
+**Exception:** Keep custom paths where provider-specific (protein_class, target_component, etc.)
+
+### Phase 5: Consolidate `source` vs `source_file`
+
+For configs with both:
+- openalex/publication: Keep `source` only for email/batch_size overrides
+- pubmed/publications: Keep `source` only for search_term/email/api_key overrides
+- uniprot/idmapping: Keep `source` (no source_file reference)
+
+---
+
+## Validation Checklist
+
+After migration, validate each config:
+
+- [ ] Has `pipeline_name`, `provider`, `entity_type`, `version`, `description`
+- [ ] Has `primary_keys`, `silver_table`, `gold_table`
+- [ ] Has `source_file` OR `source` (not both unless override)
+- [ ] Has `gold_filters.required_fields`
+- [ ] Has `sink.bronze.path`
+- [ ] Has `sink.silver.path`, `sink.silver.primary_key`, `sink.silver.partition_by`
+- [ ] Has `sink.gold.path`
+- [ ] Has `input_filter.enabled`
+- [ ] No duplicate parameters from `_defaults`
+- [ ] No `transform` block (removed)
+
+---
+
+## Implementation Order
+
+1. **Backup** all configs
+2. **Update _defaults.yaml** (if needed)
+3. **Migrate chembl/* configs** (12 files)
+4. **Migrate pubchem/compound** (1 file)
+5. **Migrate uniprot/* configs** (2 files)
+6. **Migrate crossref/* config** (1 file)
+7. **Migrate openalex/* config** (1 file)
+8. **Migrate pubmed/* config** (1 file)
+9. **Migrate semanticscholar/* config** (1 file)
+10. **Run validation script**
+11. **Run tests**: `make test`
+
+---
+
+## Appendix: Config Template
+
+```yaml
+# configs/pipelines/{provider}/{entity}.yaml
+# Pipeline configuration for {Provider} {Entity} entity.
+#
+# Inherits defaults from ../_defaults.yaml
+
+pipeline_name: {provider}_{entity}
+provider: {provider}
+entity_type: {entity}
+version: "1.0.0"
+description: "Extract {entity} records from {Provider}"
+
+primary_keys: ["{entity}_id"]
+silver_table: "{provider}_{entity}"
+gold_table: "{provider}_{entity}"
+
+source_file: ../../sources/{provider}.yaml
+
+gold_filters:
+  required_fields:
+    - {entity}_id
+  columns: {}
+  ranges: {}
+
+sink:
+  bronze:
+    path: "data/output/bronze"
+  silver:
+    path: "data/output/silver"
+    primary_key: ["{entity}_id"]
+    partition_by: []
+    csv_export:
+      path: "data/output/csv/silver"
+  gold:
+    path: "data/output/gold"
+    csv_export:
+      path: "data/output/csv/gold"
+
+input_filter:
+  enabled: true
+  source_path: "data/input/{entity}.csv"
+  column_name: "{entity}_id"
+  filter_field: "{entity}_id"
+  batch_size: 100
+```

--- a/docs/config_comparison_matrix.csv
+++ b/docs/config_comparison_matrix.csv
@@ -1,0 +1,130 @@
+Parameter Path,_defaults,chembl/activity,chembl/assay,chembl/assay_parameters,chembl/cell_line,chembl/compound_record,chembl/document,chembl/document_similarity,chembl/document_term,chembl/molecule,chembl/protein_class,chembl/target,chembl/target_component,crossref/publication_enrichment,openalex/publication,pubchem/compound,pubmed/publications,semanticscholar/publication,uniprot/idmapping,uniprot/protein
+batch_size,—,—,—,—,—,—,—,—,—,—,500,—,1000,—,—,—,—,—,—,—
+checkpoint_interval,—,—,—,—,—,—,—,—,—,—,500,—,1000,—,—,—,—,—,—,—
+circuit_breaker,(dict),—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,(dict),—
+defaults_version,1.0.0,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+description,—,Extract biological activity records from ChEMBL API,Extract bioassay definitions from ChEMBL API,Extract experimental assay parameters from ChEMBL API,Extract cell lines from ChEMBL API,Extract compound records from ChEMBL API,Extract scientific documents from ChEMBL API,Extract document similarity data (Tanimoto coefficients) from ChEMBL API,"Extract document terms (MeSH, keywords) from ChEMBL Document records",Extract molecules/compounds from ChEMBL API,"ChEMBL Protein Classification hierarchy (enzyme classes, receptor types, etc.)",Extract biological targets from ChEMBL API,"ChEMBL Target Components (protein sequences, etc.)",Enrich publication records with CrossRef metadata via DOI resolution,Batch DOI resolution via OpenAlex with title fallback,Pipeline for ingesting PubChem compounds,Extract publication metadata from PubMed via Entrez API,Batch DOI resolution via Semantic Scholar with title fallback,Maps ChEMBL target IDs to UniProt accessions via UniProt ID Mapping API,Pipeline for ingesting UniProt proteins
+dq_rules,(dict),—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,(dict),—
+entity_type,—,activity,assay,assay_parameters,cell_line,compound_record,document,document_similarity,document_term,molecule,protein_class,target,target_component,work,publication,compound,publication,publication,idmapping,protein
+gold_filters,—,(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict)
+gold_table,—,—,—,—,—,—,—,—,—,—,chembl_protein_class,—,chembl_target_component,—,openalex_publication,pubchem_compound,pubmed_publication,semanticscholar_publication,uniprot_idmapping,uniprot_protein
+input_filter,(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict)
+maintenance,(dict),—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+pipeline_name,—,chembl_activity,chembl_assay,chembl_assay_parameters,chembl_cell_line,chembl_compound_record,chembl_document,chembl_document_similarity,chembl_document_term,chembl_molecule,chembl_protein_class,chembl_target,chembl_target_component,crossref_publication_enrichment,openalex_publication,pubchem_compound,pubmed_publications,semanticscholar_publication,uniprot_idmapping,uniprot_protein
+primary_keys,—,"[""activity_id""]","[""assay_chembl_id""]","[""assay_param_id""]","[""cell_chembl_id""]","[""record_id""]","[""document_chembl_id""]","[""sim_id""]","[""entity_id""]","[""molecule_chembl_id""]","[""protein_class_id""]","[""target_chembl_id""]","[""component_id""]","[""doi""]","[""openalex_id""]","[""cid""]","[""pmid""]","[""paper_id""]","[""target_chembl_id""]","[""accession""]"
+provider,—,chembl,chembl,chembl,chembl,chembl,chembl,chembl,chembl,chembl,chembl,chembl,chembl,crossref,openalex,pubchem,pubmed,semanticscholar,uniprot,uniprot
+rate_limit,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,(dict),—
+silver_table,—,chembl_activity,chembl_assay,chembl_assay_parameters,chembl_cell_line,chembl_compound_record,chembl_document,chembl_document_similarity,chembl_document_term,chembl_molecule,chembl_protein_class,chembl_target,chembl_target_component,crossref_publication,openalex_publication,pubchem_compound,pubmed_publication,semanticscholar_publication,uniprot_idmapping,uniprot_protein
+sink,(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict)
+source,—,—,—,—,—,—,—,—,—,—,—,—,—,—,(dict),—,(dict),—,(dict),—
+source_file,—,../../sources/chembl.yaml,../../sources/chembl.yaml,../../sources/chembl.yaml,../../sources/chembl.yaml,../../sources/chembl.yaml,../../sources/chembl.yaml,../../sources/chembl.yaml,../../sources/chembl.yaml,../../sources/chembl.yaml,../../sources/chembl.yaml,../../sources/chembl.yaml,../../sources/chembl.yaml,../../sources/crossref.yaml,../../sources/openalex.yaml,../../sources/pubchem.yaml,../../sources/pubmed.yaml,../../sources/semanticscholar.yaml,—,../../sources/uniprot.yaml
+transform,—,—,—,—,—,—,—,—,—,—,—,—,—,(dict),(dict),(dict),(dict),(dict),(dict),(dict)
+version,—,1.0.0,1.0.0,1.0.0,1.0.0,1.0.0,1.0.0,1.0.0,1.0.0,1.0.0,1.0.0,1.0.0,1.0.0,1.0.0,1.0.0,1.0.0,1.0.0,1.0.0,1.0.0,1.0.0
+circuit_breaker.failure_threshold,5,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,5,—
+circuit_breaker.recovery_timeout,300,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,300,—
+dq_rules.hard_fail_threshold,0.2,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,0.8,—
+dq_rules.soft_fail_threshold,0.05,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,0.3,—
+gold_filters.columns,—,(dict),(dict),—,—,—,(dict),—,(dict),(dict),(dict),(dict),(dict),—,—,(dict),(dict),—,—,(dict)
+gold_filters.list_contains,—,—,—,—,—,—,—,—,—,—,—,(dict),—,—,—,—,—,—,—,—
+gold_filters.list_lengths,—,—,—,—,—,—,—,—,—,—,—,(dict),—,—,—,—,—,—,—,—
+gold_filters.ranges,—,(dict),—,—,—,—,(dict),(dict),—,—,—,—,—,(dict),(dict),—,—,(dict),—,—
+gold_filters.required_fields,—,"[""standard_type"", ""standard_value"", ""standard_units"", ""target_chembl_id""]","[""assay_type"", ""description""]","[""assay_chembl_id"", ""type""]","[""cell_name""]","[""molecule_chembl_id"", ""document_chembl_id""]","[""title"", ""pubmed_id"", ""doi""]","[""sim_id"", ""doc_1"", ""doc_2""]","[""document_chembl_id"", ""term"", ""term_type""]","[""molecule_chembl_id""]","[""pref_name""]","[""pref_name"", ""organism""]","[""accession""]","[""doi"", ""title""]","[""openalex_id"", ""title""]","[""cid"", ""molecular_formula""]","[""pmid"", ""title""]","[""paper_id"", ""title""]","[""target_chembl_id"", ""mapping_status""]","[""accession"", ""entry_name"", ""organism""]"
+input_filter.batch_size,100,20,20,1000,20,20,20,—,20,20,—,20,100,50,50,1,100,100,—,100
+input_filter.column_name,—,activity_id,assay_chembl_id,assay_param_id,cell_chembl_id,molecule_chembl_id,document_chembl_id,—,document_chembl_id,molecule_chembl_id,—,target_chembl_id,component_id,doi,doi,canonical_smiles,pubmed_id,doi,—,accession
+input_filter.enabled,False,True,True,True,True,False,True,False,True,True,False,True,True,True,True,True,False,True,False,False
+input_filter.fallback_column,—,—,—,—,—,—,—,—,—,—,—,—,—,title,title,—,—,title,—,—
+input_filter.filter_field,—,activity_id,assay_chembl_id,assay_param_id,cell_chembl_id,molecule_chembl_id,document_chembl_id,—,document_chembl_id,molecule_chembl_id,—,target_chembl_id,component_id,doi,doi,smiles,pmid,doi,—,accession
+input_filter.source_path,—,data/input/activity.csv,data/input/assay.csv,data/input/assay_parameters.csv,data/input/cell.csv,data/input/molecule.csv,data/input/publication.csv,—,data/input/documents.csv,data/input/molecule.csv,—,data/input/target.csv,data/input/target_component.csv,data/input/dois.csv,data/input/dois.csv,data/input/molecule.csv,data/input/pubmed.csv,data/input/dois.csv,—,data/input/protein.csv
+maintenance.auto_vacuum,False,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+maintenance.vacuum_retention_days,7,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+rate_limit.burst,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,20,—
+rate_limit.requests_per_second,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,10.0,—
+sink.bronze,(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict)
+sink.gold,(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict)
+sink.silver,(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict)
+source.api,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,(dict),—
+source.api_key,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,${BIOETL_NCBI_API_KEY},—,—,—
+source.batch_size,—,—,—,—,—,—,—,—,—,—,—,—,—,—,50,—,—,—,—,—
+source.email,—,—,—,—,—,—,—,—,—,—,—,—,—,—,${BIOETL_OPENALEX_EMAIL},—,${BIOETL_NCBI_EMAIL},—,—,—
+source.input_path,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,data/input/target.csv,—
+source.load_strategy,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,full,—
+source.search_term,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,bioinformatics[Title/Abstract] AND drug discovery[Title/Abstract],—,—,—
+source.type,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,file,—
+transform.steps,—,—,—,—,—,—,—,—,—,—,—,—,—,"[""normalize_doi"", ""extract_metadata"", ""strip_html_abstract"", ""add_metadata"", ""calculate_content_hash""]","[""extract_openalex_id"", ""extract_doi"", ""reconstruct_abstract"", ""extract_authors"", ""extract_concepts"", ""normalize_dates"", ""add_metadata"", ""calculate_content_hash""]","[""normalize_fields"", ""generate_content_hash""]","[""parse_xml"", ""extract_metadata"", ""normalize_dates""]","[""extract_external_ids"", ""extract_authors"", ""extract_journal_info"", ""extract_open_access_info"", ""extract_tldr"", ""normalize_dates"", ""add_metadata"", ""calculate_content_hash""]","[""map_ids"", ""validate_schema"", ""generate_content_hash""]","[""normalize_fields"", ""extract_features"", ""generate_content_hash""]"
+transform.version,—,—,—,—,—,—,—,—,—,—,—,—,—,1.0.0,1.0.0,1.0.0,1.0.0,1.0.0,1.0.0,1.0.0
+gold_filters.columns.assay_type,—,"[""B"", ""F""]","[""B"", ""F""]",—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+gold_filters.columns.component_type,—,—,—,—,—,—,—,—,—,—,—,—,"[""PROTEIN""]",—,—,—,—,—,—,—
+gold_filters.columns.confidence_score,—,—,"[""8"", ""9""]",—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+gold_filters.columns.doc_type,—,—,—,—,—,—,"[""PUBLICATION""]",—,—,—,—,—,—,—,—,—,—,—,—,—
+gold_filters.columns.downgraded,—,—,—,—,—,—,—,—,—,—,"[""0""]",—,—,—,—,—,—,—,—,—
+gold_filters.columns.inorganic_flag,—,—,—,—,—,—,—,—,—,"[""0""]",—,—,—,—,—,—,—,—,—,—
+gold_filters.columns.molecule_type,—,—,—,—,—,—,—,—,—,"[""Small molecule""]",—,—,—,—,—,—,—,—,—,—
+gold_filters.columns.potential_duplicate,—,"[""0""]",—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+gold_filters.columns.relationship_type,—,—,"[""D""]",—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+gold_filters.columns.reviewed,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,"[""true""]"
+gold_filters.columns.standard_relation,—,"[""=""]",—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+gold_filters.columns.standard_type,—,"[""IC50"", ""Ki""]",—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+gold_filters.columns.standard_units,—,"[""nM""]",—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+gold_filters.columns.structure_type,—,—,—,—,—,—,—,—,—,"[""MOL""]",—,—,—,—,—,—,—,—,—,—
+gold_filters.columns.target_type,—,—,—,—,—,—,—,—,—,—,—,"[""SINGLE PROTEIN""]",—,—,—,—,—,—,—,—
+gold_filters.columns.term_type,—,—,—,—,—,—,—,—,"[""MESH_HEADING"", ""KEYWORD""]",—,—,—,—,—,—,—,—,—,—,—
+gold_filters.list_contains.component_types,—,—,—,—,—,—,—,—,—,—,—,(dict),—,—,—,—,—,—,—,—
+gold_filters.list_lengths.component_accessions,—,—,—,—,—,—,—,—,—,—,—,(dict),—,—,—,—,—,—,—,—
+gold_filters.list_lengths.component_ids,—,—,—,—,—,—,—,—,—,—,—,(dict),—,—,—,—,—,—,—,—
+gold_filters.ranges.max_tani,—,—,—,—,—,—,—,(dict),—,—,—,—,—,—,—,—,—,—,—,—
+gold_filters.ranges.standard_value,—,(dict),—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+gold_filters.ranges.year,—,—,—,—,—,—,(dict),—,—,—,—,—,—,(dict),(dict),—,—,(dict),—,—
+sink.bronze.deterministic,True,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+sink.bronze.enabled,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,False,—
+sink.bronze.format,jsonl,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+sink.bronze.path,—,data/output/bronze,data/output/bronze,data/output/bronze,data/output/bronze,data/output/bronze,data/output/bronze,data/output/bronze,data/output/bronze,data/output/bronze,data/bronze/chembl/protein_class,data/output/bronze,data/bronze/chembl/target_component,data/output/bronze,data/bronze/openalex/publication,data/output/bronze/pubchem/compound,data/output/bronze/pubmed/publication,data/bronze/semanticscholar/publication,—,data/output/bronze/uniprot/protein
+sink.bronze.save_json,True,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+sink.gold.csv_export,(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict)
+sink.gold.deterministic,True,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+sink.gold.enabled,True,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,True,—
+sink.gold.format,delta,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,delta,—
+sink.gold.mode,overwrite,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,overwrite,—
+sink.gold.path,—,data/output/gold,data/output/gold,data/output/gold,data/output/gold,data/output/gold,data/output/gold,data/output/gold,data/output/gold,data/output/gold,data/gold/chembl/protein_class,data/output/gold,data/gold/chembl/target_component,data/output/gold,data/gold/openalex/publication,data/output/gold/pubchem/compound,data/output/gold/pubmed/publication,data/gold/semanticscholar/publication,data/output/gold/uniprot/idmapping,data/output/gold/uniprot/protein
+sink.gold.sort_by,—,—,—,—,(dict),(dict),—,—,—,—,(dict),(dict),—,—,—,—,—,—,—,—
+sink.gold.validation,(dict),—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+sink.silver.classification,public,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,public,—
+sink.silver.csv_export,(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict),(dict)
+sink.silver.deterministic,True,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+sink.silver.forensic_retention,True,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+sink.silver.format,delta,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,delta,—
+sink.silver.mode,merge,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,merge,—
+sink.silver.on_schema_mismatch,evolve,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+sink.silver.partition_by,—,—,"[""assay_type""]","[""type""]",—,[],"[""doc_type""]",[],"[""term_type""]","[""molecule_type""]","[""class_level""]","[""target_type""]","[""organism""]",—,"[""year""]","[""batch_date""]","[""pub_year""]","[""year""]",[],"[""organism""]"
+sink.silver.path,—,data/output/silver,data/output/silver,data/output/silver,data/output/silver,data/output/silver,data/output/silver,data/output/silver,data/output/silver,data/output/silver,data/silver/chembl/protein_class,data/output/silver,data/silver/chembl/target_component,data/output/silver,data/silver/openalex/publication,data/output/silver/pubchem/compound,data/output/silver/pubmed/publication,data/silver/semanticscholar/publication,data/output/silver/uniprot/idmapping,data/output/silver/uniprot/protein
+sink.silver.primary_key,—,"[""activity_id""]","[""assay_chembl_id""]","[""assay_param_id""]","[""cell_chembl_id""]","[""record_id""]","[""document_chembl_id""]","[""sim_id""]","[""entity_id""]","[""molecule_chembl_id""]",—,"[""target_chembl_id""]",—,"[""doi""]","[""openalex_id""]","[""cid""]","[""pmid""]","[""paper_id""]","[""target_chembl_id""]","[""accession""]"
+sink.silver.sort_by,—,—,—,—,(dict),(dict),—,—,—,—,(dict),(dict),—,—,—,—,—,—,—,—
+source.api.base_url,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,https://rest.uniprot.org,—
+source.api.from_db,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,ChEMBL,—
+source.api.to_db,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,UniProtKB,—
+gold_filters.list_contains.component_types.mode,—,—,—,—,—,—,—,—,—,—,—,all,—,—,—,—,—,—,—,—
+gold_filters.list_contains.component_types.values,—,—,—,—,—,—,—,—,—,—,—,"[""PROTEIN""]",—,—,—,—,—,—,—,—
+gold_filters.list_lengths.component_accessions.max,—,—,—,—,—,—,—,—,—,—,—,1,—,—,—,—,—,—,—,—
+gold_filters.list_lengths.component_accessions.min,—,—,—,—,—,—,—,—,—,—,—,1,—,—,—,—,—,—,—,—
+gold_filters.list_lengths.component_ids.min,—,—,—,—,—,—,—,—,—,—,—,1,—,—,—,—,—,—,—,—
+gold_filters.ranges.max_tani.include_min,—,—,—,—,—,—,—,True,—,—,—,—,—,—,—,—,—,—,—,—
+gold_filters.ranges.max_tani.min,—,—,—,—,—,—,—,0.5,—,—,—,—,—,—,—,—,—,—,—,—
+gold_filters.ranges.standard_value.include_min,—,False,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+gold_filters.ranges.standard_value.min,—,0,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+gold_filters.ranges.year.include_min,—,—,—,—,—,—,False,—,—,—,—,—,—,—,—,—,—,—,—,—
+gold_filters.ranges.year.max,—,—,—,—,—,—,—,—,—,—,—,—,—,2100,2100,—,—,2100,—,—
+gold_filters.ranges.year.min,—,—,—,—,—,—,1950,—,—,—,—,—,—,1900,1900,—,—,1900,—,—
+sink.gold.csv_export.delimiter,",",—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+sink.gold.csv_export.enabled,True,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,True,—
+sink.gold.csv_export.encoding,utf-8,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+sink.gold.csv_export.header,True,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+sink.gold.csv_export.path,—,data/output/csv/gold,data/output/csv/gold,data/output/csv/gold,data/output/csv/gold,data/output/csv/gold,data/output/csv/gold,data/output/csv/gold,data/output/csv/gold,data/output/csv/gold,data/output/csv/gold,data/output/csv/gold,data/output/csv/gold,data/output/csv/gold,data/output/csv/gold,data/output/csv/gold,data/output/csv/gold,data/output/csv/gold,data/output/csv/gold,data/output/csv/gold
+sink.gold.sort_by.ascending,—,—,—,—,True,True,—,—,—,—,True,True,—,—,—,—,—,—,—,—
+sink.gold.sort_by.columns,—,—,—,—,"[""cell_chembl_id"", ""cell_name""]","[""molecule_chembl_id"", ""document_chembl_id"", ""record_id""]",—,—,—,—,"[""class_level"", ""sort_order"", ""protein_class_id""]","[""target_chembl_id"", ""pref_name""]",—,—,—,—,—,—,—,—
+sink.gold.validation.strict,True,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—
+sink.silver.csv_export.delimiter,",",—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,",",—
+sink.silver.csv_export.enabled,True,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,True,—
+sink.silver.csv_export.encoding,utf-8,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,utf-8,—
+sink.silver.csv_export.header,True,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,—,True,—
+sink.silver.csv_export.path,—,data/output/csv/silver,data/output/csv/silver,data/output/csv/silver,data/output/csv/silver,data/output/csv/silver,data/output/csv/silver,data/output/csv/silver,data/output/csv/silver,data/output/csv/silver,data/output/csv/silver,data/output/csv/silver,data/output/csv/silver,data/output/csv/silver,data/output/csv/silver,data/output/csv/silver,data/output/csv/silver,data/output/csv/silver,data/output/csv/silver,data/output/csv/silver
+sink.silver.sort_by.ascending,—,—,—,—,True,True,—,—,—,—,True,True,—,—,—,—,—,—,—,—
+sink.silver.sort_by.columns,—,—,—,—,"[""cell_chembl_id""]","[""record_id""]",—,—,—,—,"[""protein_class_id""]","[""target_chembl_id""]",—,—,—,—,—,—,—,—

--- a/docs/config_discrepancies_report.md
+++ b/docs/config_discrepancies_report.md
@@ -1,0 +1,408 @@
+# Config Discrepancies Report
+
+Generated: 2026-01-06T18:30:06.183527
+
+Total configs: 20
+Total unique parameters: 129
+
+## 1. Parameters by Category
+
+### batch_size
+
+| Parameter | Presence |
+|-----------|----------|
+| `batch_size` | 2/20 |
+
+### checkpoint_interval
+
+| Parameter | Presence |
+|-----------|----------|
+| `checkpoint_interval` | 2/20 |
+
+### circuit_breaker
+
+| Parameter | Presence |
+|-----------|----------|
+| `circuit_breaker` | 2/20 |
+| `circuit_breaker.failure_threshold` | 2/20 |
+| `circuit_breaker.recovery_timeout` | 2/20 |
+
+### defaults_version
+
+| Parameter | Presence |
+|-----------|----------|
+| `defaults_version` | 1/20 |
+
+### description
+
+| Parameter | Presence |
+|-----------|----------|
+| `description` | 19/20 |
+
+### dq_rules
+
+| Parameter | Presence |
+|-----------|----------|
+| `dq_rules` | 2/20 |
+| `dq_rules.hard_fail_threshold` | 2/20 |
+| `dq_rules.soft_fail_threshold` | 2/20 |
+
+### entity_type
+
+| Parameter | Presence |
+|-----------|----------|
+| `entity_type` | 19/20 |
+
+### gold_filters
+
+| Parameter | Presence |
+|-----------|----------|
+| `gold_filters` | 19/20 |
+| `gold_filters.columns` | 11/20 |
+| `gold_filters.list_contains` | 1/20 |
+| `gold_filters.list_lengths` | 1/20 |
+| `gold_filters.ranges` | 6/20 |
+| `gold_filters.required_fields` | 19/20 |
+| `gold_filters.columns.assay_type` | 2/20 |
+| `gold_filters.columns.component_type` | 1/20 |
+| `gold_filters.columns.confidence_score` | 1/20 |
+| `gold_filters.columns.doc_type` | 1/20 |
+| `gold_filters.columns.downgraded` | 1/20 |
+| `gold_filters.columns.inorganic_flag` | 1/20 |
+| `gold_filters.columns.molecule_type` | 1/20 |
+| `gold_filters.columns.potential_duplicate` | 1/20 |
+| `gold_filters.columns.relationship_type` | 1/20 |
+| `gold_filters.columns.reviewed` | 1/20 |
+| `gold_filters.columns.standard_relation` | 1/20 |
+| `gold_filters.columns.standard_type` | 1/20 |
+| `gold_filters.columns.standard_units` | 1/20 |
+| `gold_filters.columns.structure_type` | 1/20 |
+| `gold_filters.columns.target_type` | 1/20 |
+| `gold_filters.columns.term_type` | 1/20 |
+| `gold_filters.list_contains.component_types` | 1/20 |
+| `gold_filters.list_lengths.component_accessions` | 1/20 |
+| `gold_filters.list_lengths.component_ids` | 1/20 |
+| `gold_filters.ranges.max_tani` | 1/20 |
+| `gold_filters.ranges.standard_value` | 1/20 |
+| `gold_filters.ranges.year` | 4/20 |
+| `gold_filters.list_contains.component_types.mode` | 1/20 |
+| `gold_filters.list_contains.component_types.values` | 1/20 |
+| `gold_filters.list_lengths.component_accessions.max` | 1/20 |
+| `gold_filters.list_lengths.component_accessions.min` | 1/20 |
+| `gold_filters.list_lengths.component_ids.min` | 1/20 |
+| `gold_filters.ranges.max_tani.include_min` | 1/20 |
+| `gold_filters.ranges.max_tani.min` | 1/20 |
+| `gold_filters.ranges.standard_value.include_min` | 1/20 |
+| `gold_filters.ranges.standard_value.min` | 1/20 |
+| `gold_filters.ranges.year.include_min` | 1/20 |
+| `gold_filters.ranges.year.max` | 3/20 |
+| `gold_filters.ranges.year.min` | 4/20 |
+
+### gold_table
+
+| Parameter | Presence |
+|-----------|----------|
+| `gold_table` | 8/20 |
+
+### input_filter
+
+| Parameter | Presence |
+|-----------|----------|
+| `input_filter` | 20/20 |
+| `input_filter.batch_size` | 17/20 |
+| `input_filter.column_name` | 16/20 |
+| `input_filter.enabled` | 20/20 |
+| `input_filter.fallback_column` | 3/20 |
+| `input_filter.filter_field` | 16/20 |
+| `input_filter.source_path` | 16/20 |
+
+### maintenance
+
+| Parameter | Presence |
+|-----------|----------|
+| `maintenance` | 1/20 |
+| `maintenance.auto_vacuum` | 1/20 |
+| `maintenance.vacuum_retention_days` | 1/20 |
+
+### pipeline_name
+
+| Parameter | Presence |
+|-----------|----------|
+| `pipeline_name` | 19/20 |
+
+### primary_keys
+
+| Parameter | Presence |
+|-----------|----------|
+| `primary_keys` | 19/20 |
+
+### provider
+
+| Parameter | Presence |
+|-----------|----------|
+| `provider` | 19/20 |
+
+### rate_limit
+
+| Parameter | Presence |
+|-----------|----------|
+| `rate_limit` | 1/20 |
+| `rate_limit.burst` | 1/20 |
+| `rate_limit.requests_per_second` | 1/20 |
+
+### silver_table
+
+| Parameter | Presence |
+|-----------|----------|
+| `silver_table` | 19/20 |
+
+### sink
+
+| Parameter | Presence |
+|-----------|----------|
+| `sink` | 20/20 |
+| `sink.bronze` | 20/20 |
+| `sink.gold` | 20/20 |
+| `sink.silver` | 20/20 |
+| `sink.bronze.deterministic` | 1/20 |
+| `sink.bronze.enabled` | 1/20 |
+| `sink.bronze.format` | 1/20 |
+| `sink.bronze.path` | 18/20 |
+| `sink.bronze.save_json` | 1/20 |
+| `sink.gold.csv_export` | 20/20 |
+| `sink.gold.deterministic` | 1/20 |
+| `sink.gold.enabled` | 2/20 |
+| `sink.gold.format` | 2/20 |
+| `sink.gold.mode` | 2/20 |
+| `sink.gold.path` | 19/20 |
+| `sink.gold.sort_by` | 4/20 |
+| `sink.gold.validation` | 1/20 |
+| `sink.silver.classification` | 2/20 |
+| `sink.silver.csv_export` | 20/20 |
+| `sink.silver.deterministic` | 1/20 |
+| `sink.silver.forensic_retention` | 1/20 |
+| `sink.silver.format` | 2/20 |
+| `sink.silver.mode` | 2/20 |
+| `sink.silver.on_schema_mismatch` | 1/20 |
+| `sink.silver.partition_by` | 16/20 |
+| `sink.silver.path` | 19/20 |
+| `sink.silver.primary_key` | 17/20 |
+| `sink.silver.sort_by` | 4/20 |
+| `sink.gold.csv_export.delimiter` | 1/20 |
+| `sink.gold.csv_export.enabled` | 2/20 |
+| `sink.gold.csv_export.encoding` | 1/20 |
+| `sink.gold.csv_export.header` | 1/20 |
+| `sink.gold.csv_export.path` | 19/20 |
+| `sink.gold.sort_by.ascending` | 4/20 |
+| `sink.gold.sort_by.columns` | 4/20 |
+| `sink.gold.validation.strict` | 1/20 |
+| `sink.silver.csv_export.delimiter` | 2/20 |
+| `sink.silver.csv_export.enabled` | 2/20 |
+| `sink.silver.csv_export.encoding` | 2/20 |
+| `sink.silver.csv_export.header` | 2/20 |
+| `sink.silver.csv_export.path` | 19/20 |
+| `sink.silver.sort_by.ascending` | 4/20 |
+| `sink.silver.sort_by.columns` | 4/20 |
+
+### source
+
+| Parameter | Presence |
+|-----------|----------|
+| `source` | 3/20 |
+| `source.api` | 1/20 |
+| `source.api_key` | 1/20 |
+| `source.batch_size` | 1/20 |
+| `source.email` | 2/20 |
+| `source.input_path` | 1/20 |
+| `source.load_strategy` | 1/20 |
+| `source.search_term` | 1/20 |
+| `source.type` | 1/20 |
+| `source.api.base_url` | 1/20 |
+| `source.api.from_db` | 1/20 |
+| `source.api.to_db` | 1/20 |
+
+### source_file
+
+| Parameter | Presence |
+|-----------|----------|
+| `source_file` | 18/20 |
+
+### transform
+
+| Parameter | Presence |
+|-----------|----------|
+| `transform` | 7/20 |
+| `transform.steps` | 7/20 |
+| `transform.version` | 7/20 |
+
+### version
+
+| Parameter | Presence |
+|-----------|----------|
+| `version` | 19/20 |
+
+## 2. Entity Config Comparison
+
+| Config | pipeline_name | provider | entity_type | version | description | primary_keys | silver_table | gold_table | source_file | source | transform | dq_rules | circuit_breaker | rate_limit | gold_filters | sink | input_filter |
+|--------|--------|--------|--------|--------|--------|--------|--------|--------|--------|--------|--------|--------|--------|--------|--------|--------|--------|
+| chembl/activity | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | ✓ | — | — | — | — | — | ✓ | ✓ | ✓ |
+| chembl/assay | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | ✓ | — | — | — | — | — | ✓ | ✓ | ✓ |
+| chembl/assay_parameters | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | ✓ | — | — | — | — | — | ✓ | ✓ | ✓ |
+| chembl/cell_line | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | ✓ | — | — | — | — | — | ✓ | ✓ | ✓ |
+| chembl/compound_record | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | ✓ | — | — | — | — | — | ✓ | ✓ | ✓ |
+| chembl/document | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | ✓ | — | — | — | — | — | ✓ | ✓ | ✓ |
+| chembl/document_similarity | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | ✓ | — | — | — | — | — | ✓ | ✓ | ✓ |
+| chembl/document_term | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | ✓ | — | — | — | — | — | ✓ | ✓ | ✓ |
+| chembl/molecule | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | ✓ | — | — | — | — | — | ✓ | ✓ | ✓ |
+| chembl/protein_class | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | — | — | — | — | ✓ | ✓ | ✓ |
+| chembl/target | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | ✓ | — | — | — | — | — | ✓ | ✓ | ✓ |
+| chembl/target_component | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | — | — | — | — | ✓ | ✓ | ✓ |
+| crossref/publication_enrichment | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | ✓ | — | ✓ | — | — | — | ✓ | ✓ | ✓ |
+| openalex/publication | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | — | — | ✓ | ✓ | ✓ |
+| pubchem/compound | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | ✓ | — | — | — | ✓ | ✓ | ✓ |
+| pubmed/publications | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | — | — | ✓ | ✓ | ✓ |
+| semanticscholar/publication | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | ✓ | — | — | — | ✓ | ✓ | ✓ |
+| uniprot/idmapping | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| uniprot/protein | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | ✓ | — | — | — | ✓ | ✓ | ✓ |
+
+## 3. Discrepancy Categories
+
+### A. Missing in _defaults (should be added)
+
+- `batch_size` - present in: chembl/protein_class, chembl/target_component
+- `checkpoint_interval` - present in: chembl/protein_class, chembl/target_component
+- `description` - present in: chembl/activity, chembl/assay, chembl/assay_parameters, chembl/cell_line, chembl/compound_record, chembl/document, chembl/document_similarity, chembl/document_term, chembl/molecule, chembl/protein_class, chembl/target, chembl/target_component, crossref/publication_enrichment, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/idmapping, uniprot/protein
+- `entity_type` - present in: chembl/activity, chembl/assay, chembl/assay_parameters, chembl/cell_line, chembl/compound_record, chembl/document, chembl/document_similarity, chembl/document_term, chembl/molecule, chembl/protein_class, chembl/target, chembl/target_component, crossref/publication_enrichment, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/idmapping, uniprot/protein
+- `gold_filters` - present in: chembl/activity, chembl/assay, chembl/assay_parameters, chembl/cell_line, chembl/compound_record, chembl/document, chembl/document_similarity, chembl/document_term, chembl/molecule, chembl/protein_class, chembl/target, chembl/target_component, crossref/publication_enrichment, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/idmapping, uniprot/protein
+- `gold_table` - present in: chembl/protein_class, chembl/target_component, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/idmapping, uniprot/protein
+- `pipeline_name` - present in: chembl/activity, chembl/assay, chembl/assay_parameters, chembl/cell_line, chembl/compound_record, chembl/document, chembl/document_similarity, chembl/document_term, chembl/molecule, chembl/protein_class, chembl/target, chembl/target_component, crossref/publication_enrichment, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/idmapping, uniprot/protein
+- `primary_keys` - present in: chembl/activity, chembl/assay, chembl/assay_parameters, chembl/cell_line, chembl/compound_record, chembl/document, chembl/document_similarity, chembl/document_term, chembl/molecule, chembl/protein_class, chembl/target, chembl/target_component, crossref/publication_enrichment, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/idmapping, uniprot/protein
+- `provider` - present in: chembl/activity, chembl/assay, chembl/assay_parameters, chembl/cell_line, chembl/compound_record, chembl/document, chembl/document_similarity, chembl/document_term, chembl/molecule, chembl/protein_class, chembl/target, chembl/target_component, crossref/publication_enrichment, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/idmapping, uniprot/protein
+- `rate_limit` - present in: uniprot/idmapping
+- `rate_limit.burst` - present in: uniprot/idmapping
+- `rate_limit.requests_per_second` - present in: uniprot/idmapping
+- `silver_table` - present in: chembl/activity, chembl/assay, chembl/assay_parameters, chembl/cell_line, chembl/compound_record, chembl/document, chembl/document_similarity, chembl/document_term, chembl/molecule, chembl/protein_class, chembl/target, chembl/target_component, crossref/publication_enrichment, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/idmapping, uniprot/protein
+- `source` - present in: openalex/publication, pubmed/publications, uniprot/idmapping
+- `source.api` - present in: uniprot/idmapping
+- `source.api.base_url` - present in: uniprot/idmapping
+- `source.api.from_db` - present in: uniprot/idmapping
+- `source.api.to_db` - present in: uniprot/idmapping
+- `source.api_key` - present in: pubmed/publications
+- `source.batch_size` - present in: openalex/publication
+- `source.email` - present in: openalex/publication, pubmed/publications
+- `source.input_path` - present in: uniprot/idmapping
+- `source.load_strategy` - present in: uniprot/idmapping
+- `source.search_term` - present in: pubmed/publications
+- `source.type` - present in: uniprot/idmapping
+- `source_file` - present in: chembl/activity, chembl/assay, chembl/assay_parameters, chembl/cell_line, chembl/compound_record, chembl/document, chembl/document_similarity, chembl/document_term, chembl/molecule, chembl/protein_class, chembl/target, chembl/target_component, crossref/publication_enrichment, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/protein
+- `transform` - present in: crossref/publication_enrichment, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/idmapping, uniprot/protein
+- `transform.steps` - present in: crossref/publication_enrichment, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/idmapping, uniprot/protein
+- `transform.version` - present in: crossref/publication_enrichment, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/idmapping, uniprot/protein
+- `version` - present in: chembl/activity, chembl/assay, chembl/assay_parameters, chembl/cell_line, chembl/compound_record, chembl/document, chembl/document_similarity, chembl/document_term, chembl/molecule, chembl/protein_class, chembl/target, chembl/target_component, crossref/publication_enrichment, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/idmapping, uniprot/protein
+
+### B. Inconsistent presence across entity configs
+
+- `batch_size`
+  - Present in (2): chembl/protein_class, chembl/target_component
+  - Missing in (17): chembl/document_similarity, pubchem/compound, crossref/publication_enrichment, chembl/document_term, chembl/assay_parameters, semanticscholar/publication, chembl/target, chembl/activity, chembl/molecule, openalex/publication, pubmed/publications, chembl/assay, chembl/cell_line, chembl/document, chembl/compound_record, uniprot/idmapping, uniprot/protein
+- `checkpoint_interval`
+  - Present in (2): chembl/protein_class, chembl/target_component
+  - Missing in (17): chembl/document_similarity, pubchem/compound, crossref/publication_enrichment, chembl/document_term, chembl/assay_parameters, semanticscholar/publication, chembl/target, chembl/activity, chembl/molecule, openalex/publication, pubmed/publications, chembl/assay, chembl/cell_line, chembl/document, chembl/compound_record, uniprot/idmapping, uniprot/protein
+- `gold_filters.columns`
+  - Present in (11): chembl/activity, chembl/assay, chembl/document, chembl/document_term, chembl/molecule, chembl/protein_class, chembl/target, chembl/target_component, pubchem/compound, pubmed/publications, uniprot/protein
+  - Missing in (8): openalex/publication, chembl/document_similarity, crossref/publication_enrichment, chembl/cell_line, chembl/compound_record, chembl/assay_parameters, uniprot/idmapping, semanticscholar/publication
+- `gold_filters.columns.assay_type`
+  - Present in (2): chembl/activity, chembl/assay
+  - Missing in (17): chembl/protein_class, chembl/document_similarity, pubchem/compound, crossref/publication_enrichment, chembl/document_term, chembl/assay_parameters, semanticscholar/publication, chembl/target, chembl/molecule, openalex/publication, pubmed/publications, chembl/target_component, chembl/cell_line, chembl/document, chembl/compound_record, uniprot/idmapping, uniprot/protein
+- `gold_filters.ranges`
+  - Present in (6): chembl/activity, chembl/document, chembl/document_similarity, crossref/publication_enrichment, openalex/publication, semanticscholar/publication
+  - Missing in (13): pubmed/publications, chembl/assay, chembl/protein_class, chembl/target_component, pubchem/compound, chembl/document_term, chembl/cell_line, chembl/compound_record, chembl/assay_parameters, uniprot/idmapping, uniprot/protein, chembl/target, chembl/molecule
+- `gold_filters.ranges.year`
+  - Present in (4): chembl/document, crossref/publication_enrichment, openalex/publication, semanticscholar/publication
+  - Missing in (15): pubmed/publications, chembl/assay, chembl/protein_class, chembl/document_similarity, chembl/target_component, pubchem/compound, chembl/document_term, chembl/cell_line, chembl/compound_record, chembl/assay_parameters, uniprot/idmapping, uniprot/protein, chembl/target, chembl/activity, chembl/molecule
+- `gold_filters.ranges.year.max`
+  - Present in (3): crossref/publication_enrichment, openalex/publication, semanticscholar/publication
+  - Missing in (16): chembl/protein_class, chembl/document_similarity, pubchem/compound, chembl/document_term, chembl/assay_parameters, chembl/target, chembl/activity, chembl/molecule, pubmed/publications, chembl/assay, chembl/target_component, chembl/cell_line, chembl/document, chembl/compound_record, uniprot/idmapping, uniprot/protein
+- `gold_filters.ranges.year.min`
+  - Present in (4): chembl/document, crossref/publication_enrichment, openalex/publication, semanticscholar/publication
+  - Missing in (15): pubmed/publications, chembl/assay, chembl/protein_class, chembl/document_similarity, chembl/target_component, pubchem/compound, chembl/document_term, chembl/cell_line, chembl/compound_record, chembl/assay_parameters, uniprot/idmapping, uniprot/protein, chembl/target, chembl/activity, chembl/molecule
+- `gold_table`
+  - Present in (8): chembl/protein_class, chembl/target_component, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/idmapping, uniprot/protein
+  - Missing in (11): chembl/assay, chembl/document_similarity, crossref/publication_enrichment, chembl/document_term, chembl/cell_line, chembl/document, chembl/compound_record, chembl/assay_parameters, chembl/target, chembl/activity, chembl/molecule
+- `input_filter.batch_size`
+  - Present in (16): chembl/activity, chembl/assay, chembl/assay_parameters, chembl/cell_line, chembl/compound_record, chembl/document, chembl/document_term, chembl/molecule, chembl/target, chembl/target_component, crossref/publication_enrichment, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/protein
+  - Missing in (3): uniprot/idmapping, chembl/protein_class, chembl/document_similarity
+- `input_filter.column_name`
+  - Present in (16): chembl/activity, chembl/assay, chembl/assay_parameters, chembl/cell_line, chembl/compound_record, chembl/document, chembl/document_term, chembl/molecule, chembl/target, chembl/target_component, crossref/publication_enrichment, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/protein
+  - Missing in (3): uniprot/idmapping, chembl/protein_class, chembl/document_similarity
+- `input_filter.fallback_column`
+  - Present in (3): crossref/publication_enrichment, openalex/publication, semanticscholar/publication
+  - Missing in (16): chembl/protein_class, chembl/document_similarity, pubchem/compound, chembl/document_term, chembl/assay_parameters, chembl/target, chembl/activity, chembl/molecule, pubmed/publications, chembl/assay, chembl/target_component, chembl/cell_line, chembl/document, chembl/compound_record, uniprot/idmapping, uniprot/protein
+- `input_filter.filter_field`
+  - Present in (16): chembl/activity, chembl/assay, chembl/assay_parameters, chembl/cell_line, chembl/compound_record, chembl/document, chembl/document_term, chembl/molecule, chembl/target, chembl/target_component, crossref/publication_enrichment, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/protein
+  - Missing in (3): uniprot/idmapping, chembl/protein_class, chembl/document_similarity
+- `input_filter.source_path`
+  - Present in (16): chembl/activity, chembl/assay, chembl/assay_parameters, chembl/cell_line, chembl/compound_record, chembl/document, chembl/document_term, chembl/molecule, chembl/target, chembl/target_component, crossref/publication_enrichment, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/protein
+  - Missing in (3): uniprot/idmapping, chembl/protein_class, chembl/document_similarity
+- `sink.bronze.path`
+  - Present in (18): chembl/activity, chembl/assay, chembl/assay_parameters, chembl/cell_line, chembl/compound_record, chembl/document, chembl/document_similarity, chembl/document_term, chembl/molecule, chembl/protein_class, chembl/target, chembl/target_component, crossref/publication_enrichment, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/protein
+  - Missing in (1): uniprot/idmapping
+- `sink.gold.sort_by`
+  - Present in (4): chembl/cell_line, chembl/compound_record, chembl/protein_class, chembl/target
+  - Missing in (15): openalex/publication, pubmed/publications, chembl/assay, chembl/document_similarity, chembl/target_component, pubchem/compound, crossref/publication_enrichment, chembl/document_term, chembl/document, chembl/assay_parameters, uniprot/idmapping, uniprot/protein, semanticscholar/publication, chembl/activity, chembl/molecule
+- `sink.gold.sort_by.ascending`
+  - Present in (4): chembl/cell_line, chembl/compound_record, chembl/protein_class, chembl/target
+  - Missing in (15): openalex/publication, pubmed/publications, chembl/assay, chembl/document_similarity, chembl/target_component, pubchem/compound, crossref/publication_enrichment, chembl/document_term, chembl/document, chembl/assay_parameters, uniprot/idmapping, uniprot/protein, semanticscholar/publication, chembl/activity, chembl/molecule
+- `sink.gold.sort_by.columns`
+  - Present in (4): chembl/cell_line, chembl/compound_record, chembl/protein_class, chembl/target
+  - Missing in (15): openalex/publication, pubmed/publications, chembl/assay, chembl/document_similarity, chembl/target_component, pubchem/compound, crossref/publication_enrichment, chembl/document_term, chembl/document, chembl/assay_parameters, uniprot/idmapping, uniprot/protein, semanticscholar/publication, chembl/activity, chembl/molecule
+- `sink.silver.partition_by`
+  - Present in (16): chembl/assay, chembl/assay_parameters, chembl/compound_record, chembl/document, chembl/document_similarity, chembl/document_term, chembl/molecule, chembl/protein_class, chembl/target, chembl/target_component, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/idmapping, uniprot/protein
+  - Missing in (3): crossref/publication_enrichment, chembl/cell_line, chembl/activity
+- `sink.silver.primary_key`
+  - Present in (17): chembl/activity, chembl/assay, chembl/assay_parameters, chembl/cell_line, chembl/compound_record, chembl/document, chembl/document_similarity, chembl/document_term, chembl/molecule, chembl/target, crossref/publication_enrichment, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/idmapping, uniprot/protein
+  - Missing in (2): chembl/protein_class, chembl/target_component
+- `sink.silver.sort_by`
+  - Present in (4): chembl/cell_line, chembl/compound_record, chembl/protein_class, chembl/target
+  - Missing in (15): openalex/publication, pubmed/publications, chembl/assay, chembl/document_similarity, chembl/target_component, pubchem/compound, crossref/publication_enrichment, chembl/document_term, chembl/document, chembl/assay_parameters, uniprot/idmapping, uniprot/protein, semanticscholar/publication, chembl/activity, chembl/molecule
+- `sink.silver.sort_by.ascending`
+  - Present in (4): chembl/cell_line, chembl/compound_record, chembl/protein_class, chembl/target
+  - Missing in (15): openalex/publication, pubmed/publications, chembl/assay, chembl/document_similarity, chembl/target_component, pubchem/compound, crossref/publication_enrichment, chembl/document_term, chembl/document, chembl/assay_parameters, uniprot/idmapping, uniprot/protein, semanticscholar/publication, chembl/activity, chembl/molecule
+- `sink.silver.sort_by.columns`
+  - Present in (4): chembl/cell_line, chembl/compound_record, chembl/protein_class, chembl/target
+  - Missing in (15): openalex/publication, pubmed/publications, chembl/assay, chembl/document_similarity, chembl/target_component, pubchem/compound, crossref/publication_enrichment, chembl/document_term, chembl/document, chembl/assay_parameters, uniprot/idmapping, uniprot/protein, semanticscholar/publication, chembl/activity, chembl/molecule
+- `source`
+  - Present in (3): openalex/publication, pubmed/publications, uniprot/idmapping
+  - Missing in (16): chembl/protein_class, chembl/document_similarity, pubchem/compound, crossref/publication_enrichment, chembl/document_term, chembl/assay_parameters, semanticscholar/publication, chembl/target, chembl/activity, chembl/molecule, chembl/assay, chembl/target_component, chembl/cell_line, chembl/document, chembl/compound_record, uniprot/protein
+- `source.email`
+  - Present in (2): openalex/publication, pubmed/publications
+  - Missing in (17): chembl/protein_class, chembl/document_similarity, pubchem/compound, crossref/publication_enrichment, chembl/document_term, chembl/assay_parameters, semanticscholar/publication, chembl/target, chembl/activity, chembl/molecule, chembl/assay, chembl/target_component, chembl/cell_line, chembl/document, chembl/compound_record, uniprot/idmapping, uniprot/protein
+- `source_file`
+  - Present in (18): chembl/activity, chembl/assay, chembl/assay_parameters, chembl/cell_line, chembl/compound_record, chembl/document, chembl/document_similarity, chembl/document_term, chembl/molecule, chembl/protein_class, chembl/target, chembl/target_component, crossref/publication_enrichment, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/protein
+  - Missing in (1): uniprot/idmapping
+- `transform`
+  - Present in (7): crossref/publication_enrichment, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/idmapping, uniprot/protein
+  - Missing in (12): chembl/assay, chembl/protein_class, chembl/document_similarity, chembl/target_component, chembl/document_term, chembl/cell_line, chembl/document, chembl/compound_record, chembl/assay_parameters, chembl/target, chembl/activity, chembl/molecule
+- `transform.steps`
+  - Present in (7): crossref/publication_enrichment, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/idmapping, uniprot/protein
+  - Missing in (12): chembl/assay, chembl/protein_class, chembl/document_similarity, chembl/target_component, chembl/document_term, chembl/cell_line, chembl/document, chembl/compound_record, chembl/assay_parameters, chembl/target, chembl/activity, chembl/molecule
+- `transform.version`
+  - Present in (7): crossref/publication_enrichment, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/idmapping, uniprot/protein
+  - Missing in (12): chembl/assay, chembl/protein_class, chembl/document_similarity, chembl/target_component, chembl/document_term, chembl/cell_line, chembl/document, chembl/compound_record, chembl/assay_parameters, chembl/target, chembl/activity, chembl/molecule
+
+### C. Structural inconsistencies
+
+#### source vs source_file
+
+- Using `source`: openalex/publication, pubmed/publications, uniprot/idmapping
+- Using `source_file`: chembl/activity, chembl/assay, chembl/assay_parameters, chembl/cell_line, chembl/compound_record, chembl/document, chembl/document_similarity, chembl/document_term, chembl/molecule, chembl/protein_class, chembl/target, chembl/target_component, crossref/publication_enrichment, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/protein
+
+#### transform block
+
+- Has `transform`: crossref/publication_enrichment, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/idmapping, uniprot/protein
+- No `transform`: chembl/assay, chembl/protein_class, chembl/document_similarity, chembl/target_component, chembl/document_term, chembl/cell_line, chembl/document, chembl/compound_record, chembl/assay_parameters, chembl/target, chembl/activity, chembl/molecule
+
+#### gold_table presence
+
+- Has `gold_table`: chembl/protein_class, chembl/target_component, openalex/publication, pubchem/compound, pubmed/publications, semanticscholar/publication, uniprot/idmapping, uniprot/protein
+- Missing `gold_table`: chembl/assay, chembl/document_similarity, crossref/publication_enrichment, chembl/document_term, chembl/cell_line, chembl/document, chembl/compound_record, chembl/assay_parameters, chembl/target, chembl/activity, chembl/molecule

--- a/scripts/config_matrix_generator.py
+++ b/scripts/config_matrix_generator.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""
+Generate comparison matrix for pipeline configs.
+
+This script analyzes all pipeline config files and produces:
+1. A CSV matrix showing which parameters exist in which configs
+2. A summary of discrepancies categorized by type
+"""
+
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def flatten_dict(d: dict, parent_key: str = "") -> dict[str, Any]:
+    """Flatten nested dict to dot-notation keys."""
+    items = {}
+    for k, v in d.items():
+        new_key = f"{parent_key}.{k}" if parent_key else k
+        if isinstance(v, dict):
+            items[new_key] = "(dict)"
+            items.update(flatten_dict(v, new_key))
+        elif isinstance(v, list):
+            items[new_key] = json.dumps(v) if v else "[]"
+        else:
+            items[new_key] = str(v) if v is not None else "null"
+    return items
+
+
+def load_config(path: Path) -> dict:
+    """Load YAML config file."""
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
+
+
+def get_config_name(yaml_file: Path, configs_dir: Path) -> str:
+    """Generate readable config name from path."""
+    rel_path = yaml_file.relative_to(configs_dir)
+    parts = list(rel_path.parts)
+    # Remove .yaml extension
+    parts[-1] = parts[-1].replace(".yaml", "")
+    return "/".join(parts)
+
+
+def main():
+    configs_dir = Path("configs/pipelines")
+
+    # Collect all configs
+    configs: dict[str, dict[str, Any]] = {}
+    all_keys: set[str] = set()
+
+    for yaml_file in sorted(configs_dir.rglob("*.yaml")):
+        config_name = get_config_name(yaml_file, configs_dir)
+
+        data = load_config(yaml_file)
+        flat = flatten_dict(data)
+        configs[config_name] = flat
+        all_keys.update(flat.keys())
+
+    # Sort keys hierarchically
+    def sort_key(x: str) -> tuple:
+        parts = x.split(".")
+        return (len(parts), parts)
+
+    sorted_keys = sorted(all_keys, key=sort_key)
+
+    # Write CSV matrix
+    output_path = Path("docs/config_comparison_matrix.csv")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(output_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+
+        # Header
+        config_names = sorted(configs.keys())
+        writer.writerow(["Parameter Path"] + config_names)
+
+        # Data rows
+        for key in sorted_keys:
+            row = [key]
+            for cfg_name in config_names:
+                value = configs[cfg_name].get(key)
+                if value is None:
+                    row.append("—")
+                else:
+                    row.append(value)
+            writer.writerow(row)
+
+    print(f"Matrix saved to {output_path}")
+    print(f"Total parameters: {len(sorted_keys)}")
+    print(f"Total configs: {len(configs)}")
+
+    # Generate summary statistics
+    print("\n" + "=" * 80)
+    print("PARAMETER PRESENCE SUMMARY")
+    print("=" * 80)
+
+    # Categorize parameters
+    defaults_keys = set(configs.get("_defaults", {}).keys())
+    entity_configs = {k: v for k, v in configs.items() if k != "_defaults"}
+
+    # Parameters only in defaults
+    only_defaults = defaults_keys - set().union(
+        *[set(v.keys()) for v in entity_configs.values()]
+    )
+
+    # Parameters in ALL entity configs
+    if entity_configs:
+        common_entity = set.intersection(
+            *[set(v.keys()) for v in entity_configs.values()]
+        )
+    else:
+        common_entity = set()
+
+    # Parameters only in SOME entity configs
+    any_entity = set().union(*[set(v.keys()) for v in entity_configs.values()])
+    partial_entity = any_entity - common_entity
+
+    # Parameters missing in defaults but present in entities
+    missing_defaults = any_entity - defaults_keys
+
+    print(f"\n1. Parameters ONLY in _defaults (not used in entity configs):")
+    for k in sorted(only_defaults):
+        print(f"   - {k}")
+
+    print(f"\n2. Parameters in ALL entity configs ({len(common_entity)}):")
+    for k in sorted(common_entity):
+        print(f"   - {k}")
+
+    print(f"\n3. Parameters in SOME entity configs (inconsistent):")
+    partial_by_key = {}
+    for k in sorted(partial_entity):
+        present_in = [cfg for cfg, data in entity_configs.items() if k in data]
+        partial_by_key[k] = present_in
+        count = len(present_in)
+        print(f"   - {k} ({count}/{len(entity_configs)} configs)")
+
+    print(f"\n4. Parameters MISSING in _defaults (candidates for addition):")
+    for k in sorted(missing_defaults - set(flatten_dict({"sink": {}, "input_filter": {}}).keys())):
+        if not any(skip in k for skip in ["sink.", "input_filter.", "gold_filters."]):
+            print(f"   - {k}")
+
+    # Write detailed report
+    report_path = Path("docs/config_discrepancies_report.md")
+    with open(report_path, "w", encoding="utf-8") as f:
+        f.write("# Config Discrepancies Report\n\n")
+        f.write(f"Generated: {__import__('datetime').datetime.now().isoformat()}\n\n")
+        f.write(f"Total configs: {len(configs)}\n")
+        f.write(f"Total unique parameters: {len(sorted_keys)}\n\n")
+
+        f.write("## 1. Parameters by Category\n\n")
+
+        # Group parameters by top-level key
+        by_category = {}
+        for key in sorted_keys:
+            category = key.split(".")[0]
+            by_category.setdefault(category, []).append(key)
+
+        for category, keys in sorted(by_category.items()):
+            f.write(f"### {category}\n\n")
+            f.write("| Parameter | Presence |\n")
+            f.write("|-----------|----------|\n")
+            for key in keys:
+                present_count = sum(1 for cfg in configs.values() if key in cfg)
+                f.write(f"| `{key}` | {present_count}/{len(configs)} |\n")
+            f.write("\n")
+
+        f.write("## 2. Entity Config Comparison\n\n")
+
+        # Key structural parameters
+        structural_keys = [
+            "pipeline_name", "provider", "entity_type", "version", "description",
+            "primary_keys", "silver_table", "gold_table", "source_file", "source",
+            "transform", "dq_rules", "circuit_breaker", "rate_limit",
+            "gold_filters", "sink", "input_filter"
+        ]
+
+        f.write("| Config | " + " | ".join(structural_keys) + " |\n")
+        f.write("|" + "--------|" * (len(structural_keys) + 1) + "\n")
+
+        for cfg_name in sorted(entity_configs.keys()):
+            cfg_data = entity_configs[cfg_name]
+            row = [cfg_name]
+            for key in structural_keys:
+                if key in cfg_data or any(k.startswith(f"{key}.") for k in cfg_data):
+                    row.append("✓")
+                else:
+                    row.append("—")
+            f.write("| " + " | ".join(row) + " |\n")
+
+        f.write("\n## 3. Discrepancy Categories\n\n")
+
+        f.write("### A. Missing in _defaults (should be added)\n\n")
+        for k in sorted(missing_defaults):
+            if not any(skip in k for skip in ["sink.", "gold_filters.", "input_filter."]):
+                present_in = [cfg for cfg, data in entity_configs.items() if k in data]
+                f.write(f"- `{k}` - present in: {', '.join(present_in)}\n")
+
+        f.write("\n### B. Inconsistent presence across entity configs\n\n")
+        for k, present_in in sorted(partial_by_key.items()):
+            if len(present_in) > 1 and len(present_in) < len(entity_configs):
+                f.write(f"- `{k}`\n")
+                f.write(f"  - Present in ({len(present_in)}): {', '.join(present_in)}\n")
+                missing = set(entity_configs.keys()) - set(present_in)
+                f.write(f"  - Missing in ({len(missing)}): {', '.join(missing)}\n")
+
+        f.write("\n### C. Structural inconsistencies\n\n")
+
+        # Check for source vs source_file
+        source_configs = [cfg for cfg, data in entity_configs.items() if "source" in data]
+        source_file_configs = [cfg for cfg, data in entity_configs.items() if "source_file" in data]
+
+        f.write("#### source vs source_file\n\n")
+        f.write(f"- Using `source`: {', '.join(source_configs) or 'none'}\n")
+        f.write(f"- Using `source_file`: {', '.join(source_file_configs) or 'none'}\n\n")
+
+        # Check for transform presence
+        transform_configs = [cfg for cfg, data in entity_configs.items()
+                           if "transform" in data or any(k.startswith("transform.") for k in data)]
+        f.write("#### transform block\n\n")
+        f.write(f"- Has `transform`: {', '.join(transform_configs) or 'none'}\n")
+        f.write(f"- No `transform`: {', '.join(set(entity_configs.keys()) - set(transform_configs))}\n\n")
+
+        # Check for gold_table presence
+        gold_table_configs = [cfg for cfg, data in entity_configs.items() if "gold_table" in data]
+        f.write("#### gold_table presence\n\n")
+        f.write(f"- Has `gold_table`: {', '.join(gold_table_configs) or 'none'}\n")
+        f.write(f"- Missing `gold_table`: {', '.join(set(entity_configs.keys()) - set(gold_table_configs))}\n")
+
+    print(f"\nDetailed report saved to {report_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_unified_configs.py
+++ b/scripts/validate_unified_configs.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Validate unified config structure across all pipeline configs."""
+
+import sys
+from pathlib import Path
+
+import yaml
+
+
+REQUIRED_TOP_LEVEL = {
+    "pipeline_name",
+    "provider",
+    "entity_type",
+    "version",
+    "description",
+    "primary_keys",
+    "silver_table",
+    "gold_table",
+    "sink",
+    "input_filter",
+    "gold_filters",
+}
+
+REQUIRED_SINK_LAYERS = {"bronze", "silver", "gold"}
+REQUIRED_SINK_SILVER = {"path", "primary_key", "partition_by", "csv_export"}
+REQUIRED_INPUT_FILTER = {"enabled"}
+REQUIRED_GOLD_FILTERS = {"required_fields"}
+
+
+def validate_config(path: Path) -> list[str]:
+    """Validate config structure, return list of errors."""
+    errors = []
+
+    with open(path) as f:
+        config = yaml.safe_load(f)
+
+    if config is None:
+        return [f"{path}: Empty config"]
+
+    # Skip _defaults.yaml
+    if path.name == "_defaults.yaml":
+        return []
+
+    rel_path = path.relative_to(Path("configs/pipelines"))
+
+    # Check top-level keys
+    missing_top = REQUIRED_TOP_LEVEL - set(config.keys())
+
+    # source_file OR source is required
+    if "source_file" not in config and "source" not in config:
+        missing_top.add("source_file (or source)")
+    missing_top.discard("source_file")  # Remove if checking both
+
+    if missing_top:
+        errors.append(f"{rel_path}: Missing required keys: {sorted(missing_top)}")
+
+    # Check sink structure
+    sink = config.get("sink", {})
+    missing_sink = REQUIRED_SINK_LAYERS - set(sink.keys())
+    if missing_sink:
+        errors.append(f"{rel_path}: Missing sink layers: {sorted(missing_sink)}")
+
+    # Check sink.silver
+    silver = sink.get("silver", {})
+    missing_silver = REQUIRED_SINK_SILVER - set(silver.keys())
+    if missing_silver:
+        errors.append(f"{rel_path}: Missing sink.silver keys: {sorted(missing_silver)}")
+
+    # Check sink.gold
+    gold = sink.get("gold", {})
+    if "path" not in gold:
+        errors.append(f"{rel_path}: Missing sink.gold.path")
+    if "csv_export" not in gold:
+        errors.append(f"{rel_path}: Missing sink.gold.csv_export")
+
+    # Check input_filter
+    input_filter = config.get("input_filter", {})
+    if "enabled" not in input_filter:
+        errors.append(f"{rel_path}: Missing input_filter.enabled")
+
+    # Check gold_filters
+    gold_filters = config.get("gold_filters", {})
+    missing_gf = REQUIRED_GOLD_FILTERS - set(gold_filters.keys())
+    if missing_gf:
+        errors.append(f"{rel_path}: Missing gold_filters keys: {sorted(missing_gf)}")
+
+    # Check for deprecated/redundant keys
+    deprecated_keys = []
+    if "transform" in config:
+        deprecated_keys.append("transform (removed - not used by code)")
+
+    # Check for redundant sink parameters that should use defaults
+    redundant_sink = []
+    if silver.get("format") == "delta":
+        redundant_sink.append("sink.silver.format")
+    if silver.get("mode") == "merge":
+        redundant_sink.append("sink.silver.mode")
+    if gold.get("format") == "delta":
+        redundant_sink.append("sink.gold.format")
+    if gold.get("mode") == "overwrite":
+        redundant_sink.append("sink.gold.mode")
+
+    # Only warn, don't error on redundant (they work, just unnecessary)
+    if deprecated_keys:
+        errors.append(f"{rel_path}: Deprecated keys: {deprecated_keys}")
+
+    return errors
+
+
+def main():
+    configs_dir = Path("configs/pipelines")
+    all_errors = []
+    configs_validated = 0
+    configs_with_errors = 0
+
+    print("=" * 80)
+    print("CONFIG VALIDATION REPORT")
+    print("=" * 80)
+    print()
+
+    for yaml_file in sorted(configs_dir.rglob("*.yaml")):
+        errors = validate_config(yaml_file)
+        configs_validated += 1
+
+        if errors:
+            configs_with_errors += 1
+            for e in errors:
+                all_errors.append(e)
+                print(f"  [ERROR] {e}")
+        else:
+            rel_path = yaml_file.relative_to(configs_dir)
+            if yaml_file.name != "_defaults.yaml":
+                print(f"  [OK] {rel_path}")
+
+    print()
+    print("=" * 80)
+    print(f"Configs validated: {configs_validated}")
+    print(f"Configs with errors: {configs_with_errors}")
+    print(f"Total errors: {len(all_errors)}")
+    print("=" * 80)
+
+    if all_errors:
+        print("\nValidation FAILED")
+        return 1
+    else:
+        print("\nValidation PASSED: All configs have unified structure")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/snapshots/pipeline_configs.json
+++ b/tests/snapshots/pipeline_configs.json
@@ -63,7 +63,7 @@
         "target_chembl_id"
       ]
     },
-    "gold_table": null,
+    "gold_table": "chembl_activity",
     "gold_write_mode": "overwrite",
     "on_schema_mismatch": "evolve",
     "partition_cols": [],


### PR DESCRIPTION
- Add `gold_table` to all 19 entity configs (was missing in 11)
- Add `sink.silver.partition_by` to configs missing it (3 configs)
- Add `sink.silver.primary_key` to protein_class and target_component
- Remove unused `transform` blocks from 7 non-ChEMBL configs
- Update golden master snapshots for affected pipelines

New documentation:
- docs/config-unification-plan.md: Migration plan and canonical structure
- docs/config_comparison_matrix.csv: Parameter presence matrix (129 params x 20 configs)
- docs/config_discrepancies_report.md: Analysis of discrepancy categories

New validation tooling:
- scripts/validate_unified_configs.py: Validates config structure
- scripts/config_matrix_generator.py: Generates comparison matrix

All 6049 tests pass. Validated with:
- make lint (ruff + mypy)
- make test (unit + integration + architecture)