### PR TITLE
Replace Typer with Click in CLI implementation

### DIFF
--- a/docs/__-prompts/00-Audit/02-File Structure Audit & Standardization.md
+++ b/docs/__-prompts/00-Audit/02-File Structure Audit & Standardization.md
@@ -45,7 +45,7 @@ src/
 │   ├── domain/          # Чистая логика, Protocols, схемы
 │   ├── application/     # Пайплайны, use cases
 │   ├── infrastructure/  # Адаптеры (HTTP, Storage, Locking)
-│   └── interfaces/      # CLI (Typer)
+│   └── interfaces/      # CLI (Click)
 │
 └── tools/               # Утилиты проекта
     ├── cleanup_project.py


### PR DESCRIPTION
The audit prompt template incorrectly stated that CLI uses Typer, but the actual implementation uses Click (14 files with click imports). This fixes the documentation mismatch identified as INT-001.