### PR TITLE
Update RULES.md to match Ports package structure

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -326,7 +326,7 @@ flowchart TD
 ## 7. Работа с Компонентами
 
 ### 7.1. Создание Нового Адаптера
-1.  **Порт:** Убедись, что в `domain/ports.py` есть подходящий `Protocol`.
+1.  **Порт:** Убедись, что в `domain/ports/` есть подходящий `Protocol` (импортируй из фасада: `from bioetl.domain.ports import ...`).
 2.  **Адаптер:** Создай класс в `src/bioetl/infrastructure/adapters/{provider}/`
 3.  **Реализация:**
     - Класс **MUST** реализовывать порт.

--- a/docs/02-architecture/decisions/ADR-006-logger-metrics-ports.md
+++ b/docs/02-architecture/decisions/ADR-006-logger-metrics-ports.md
@@ -15,7 +15,7 @@ Note: `domain/ports.py` was reorganized into a package `domain/ports/` with a fa
 
 We have chosen to:
 
-1. **Create `LoggerPort`** in `domain/ports.py` as a formal Protocol for logging
+1. **Create `LoggerPort`** in `domain/ports/` package as a formal Protocol for logging
 2. **Keep `MetricsPort`** as-is (already properly defined)
 3. **Use ports consistently** in `PipelineServices` for both logger and metrics
 4. **Maintain backward compatibility** via `BoundLogger` alias in `domain/context.py`
@@ -28,13 +28,13 @@ All external dependencies should be abstracted through ports:
 
 | Dependency | Port | Location |
 |------------|------|----------|
-| Data Source | `DataSourcePort` | `domain/ports.py` |
-| Storage | `StoragePort` | `domain/ports.py` |
-| Lock | `LockPort` | `domain/ports.py` |
-| Checkpoint | `CheckpointPort` | `domain/ports.py` |
-| Quarantine | `QuarantinePort` | `domain/ports.py` |
-| Metrics | `MetricsPort` | `domain/ports.py` |
-| **Logger** | **`LoggerPort`** | `domain/ports.py` |
+| Data Source | `DataSourcePort` | `domain/ports/` |
+| Storage | `StoragePort` | `domain/ports/` |
+| Lock | `LockPort` | `domain/ports/` |
+| Checkpoint | `CheckpointPort` | `domain/ports/` |
+| Quarantine | `QuarantinePort` | `domain/ports/` |
+| Metrics | `MetricsPort` | `domain/ports/` |
+| **Logger** | **`LoggerPort`** | `domain/ports/` |
 
 ### 2. Testability
 
@@ -61,7 +61,7 @@ The abstraction allows switching logging implementations without changing applic
 
 ### 4. Domain Layer Purity
 
-The domain layer should not depend on infrastructure details. By defining `LoggerPort` in `domain/ports.py`, we ensure the domain only depends on an abstract contract, not on `structlog`.
+The domain layer should not depend on infrastructure details. By defining `LoggerPort` in `domain/ports/`, we ensure the domain only depends on an abstract contract, not on `structlog`.
 
 ## Implementation Details
 
@@ -125,7 +125,7 @@ Rejected because:
 ### 3. Move LoggerPort to a separate file
 
 Rejected because:
-- All other ports are in `domain/ports.py`
+- All other ports are in `domain/ports/` package
 - Keeping them together improves discoverability
 - No circular dependency issues
 

--- a/docs/02-architecture/decisions/ADR-012-storage-clear-contract-and-run-id.md
+++ b/docs/02-architecture/decisions/ADR-012-storage-clear-contract-and-run-id.md
@@ -54,7 +54,7 @@ class BasePipeline(ABC):
 
 ### 2. Формализация API очистки в StoragePort
 
-Добавлены методы в `StoragePort` (`domain/ports.py`):
+Добавлены методы в `StoragePort` (`domain/ports/storage.py`, импорт из фасада `domain/ports/`):
 
 ```python
 def clear_silver(self, table_name: str) -> int:

--- a/docs/02-architecture/decisions/ADR-014-deterministic-writes.md
+++ b/docs/02-architecture/decisions/ADR-014-deterministic-writes.md
@@ -129,7 +129,7 @@ Application и interfaces слои **MUST NOT** импортировать `stru
 | `infrastructure/storage/gold_writer.py` | Удалён `random`, фиксированный backoff |
 | `infrastructure/storage/bronze_writer.py` | Принимает `ingestion_ts` параметр |
 | `infrastructure/quarantine/unified.py` | Принимает `ingestion_ts` параметр |
-| `domain/ports.py` | Обновлён `QuarantinePort.write()` |
+| `domain/ports/quarantine.py` | Обновлён `QuarantinePort.write()` |
 
 ### Архитектурные тесты
 

--- a/docs/__-prompts/00-Audit/02-Архитектурный аудит проекта.md
+++ b/docs/__-prompts/00-Audit/02-Архитектурный аудит проекта.md
@@ -47,7 +47,7 @@ grep -r "from bioetl.application" src/bioetl/domain/
 ```
 
 #### 2. Контракты и Ports (вес: 12%)
-**Что проверяется**: §1.1.1 — использование Protocol в domain/ports.py; реализации в infrastructure.
+**Что проверяется**: §1.1.1 — использование Protocol в domain/ports/; реализации в infrastructure.
 
 | Балл | Критерий |
 |------|----------|

--- a/docs/__-prompts/00-Documentation/01-Дополнение пропущенных docstrings.md
+++ b/docs/__-prompts/00-Documentation/01-Дополнение пропущенных docstrings.md
@@ -59,11 +59,11 @@ def fetch_batch(self, query: Query, limit: int = 100) -> Iterator[RawRecord]:
 
 ### 4. Шаблоны по типу компонента
 
-**Protocol (domain/ports.py):**
+**Protocol (domain/ports/, импорт из фасада):**
 ```python
 class DataSourcePort(Protocol):
     """Port for data source interactions.
-    
+
     Defines contract for extracting data from external providers.
     Implementations must handle rate limiting and circuit breaker (§3.1.4).
     """
@@ -119,7 +119,7 @@ grep -rL '"""' src/bioetl/**/*.py | head -20
 ```
 
 ### Шаг 2: Приоритизация
-1. Protocols в `domain/ports.py`
+1. Protocols в `domain/ports/`
 2. Публичные классы в `domain/`
 3. Pipeline классы в `application/`
 4. Adapter классы в `infrastructure/`


### PR DESCRIPTION
…cture

Updated documentation to reflect actual codebase structure where domain/ports/ is a package with facade pattern, not a single file.

Files updated:
- AGENT.md: Updated adapter creation guide
- ADR-006: Updated port location table and references
- ADR-012: Updated StoragePort location reference
- ADR-014: Updated QuarantinePort location reference
- Prompt templates: Updated Protocol location references