### PR TITLE
Standardize citation count field names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Migration**: Added `scripts/migrations/migrate_pmid_to_string.py` for existing data conversion
   - **Rationale**: Enables consistent cross-provider JOINs (PubMed, ChEMBL, SemanticScholar) and matches PubMed API behavior
 
+- **OpenAlex Citation Count Field Renamed**: Standardized citation count field naming across all providers:
+  - Renamed `cited_by_count` to `citation_count` in OpenAlex publication schema
+  - Aligns with CrossRef and SemanticScholar naming convention
+  - Affected files:
+    - `domain/schemas/openalex/publication.py`
+    - `domain/entities/openalex.py`
+    - `application/pipelines/openalex/transformer.py`
+    - `infrastructure/schemas/silver.py`
+    - `infrastructure/schemas/gold.py`
+  - **Migration Required**: Run `scripts/migrate_openalex_citation_count.py` for existing Delta Lake tables
+  - Source field from OpenAlex API remains `cited_by_count`; only BioETL unified field name changed
+
 ### Added
 
 - **`normalize_pmid()` function**: New helper in `application/core/field_specs.py` for safe PMID normalization:

--- a/scripts/migrate_openalex_citation_count.py
+++ b/scripts/migrate_openalex_citation_count.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Migration script: Rename cited_by_count to citation_count in OpenAlex tables.
+
+This script renames the `cited_by_count` column to `citation_count` in OpenAlex
+Silver and Gold Delta Lake tables to align with the unified citation count
+naming convention used by CrossRef and SemanticScholar providers.
+
+BREAKING CHANGE: This migration modifies the schema of existing Delta Lake tables.
+
+Usage:
+    python scripts/migrate_openalex_citation_count.py --data-dir /path/to/data
+
+    # Dry-run mode (default, shows what would be done):
+    python scripts/migrate_openalex_citation_count.py --data-dir /path/to/data --dry-run
+
+    # Execute the migration:
+    python scripts/migrate_openalex_citation_count.py --data-dir /path/to/data --execute
+
+Requirements:
+    - deltalake>=0.14.0
+    - polars>=0.20.0
+
+See also:
+    - RULES.md §2.4 (Schema Standards)
+    - OpenAlex API documentation: https://docs.openalex.org/api-entities/works
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+try:
+    import polars as pl
+    from deltalake import DeltaTable, write_deltalake
+except ImportError as e:
+    print(f"Error: Required dependencies not installed: {e}")
+    print("Install with: pip install deltalake polars")
+    sys.exit(1)
+
+
+def migrate_table(table_path: Path, dry_run: bool = True) -> bool:
+    """Migrate a single Delta Lake table.
+
+    Args:
+        table_path: Path to the Delta Lake table.
+        dry_run: If True, only show what would be done without making changes.
+
+    Returns:
+        True if migration was successful or skipped (no changes needed).
+        False if an error occurred.
+    """
+    if not table_path.exists():
+        print(f"  Table not found: {table_path}")
+        return True  # Not an error, table just doesn't exist yet
+
+    try:
+        dt = DeltaTable(str(table_path))
+        schema = dt.schema()
+        column_names = [field.name for field in schema.fields]
+
+        # Check if migration is needed
+        if "cited_by_count" not in column_names:
+            if "citation_count" in column_names:
+                print(f"  Already migrated: {table_path}")
+                return True
+            print(f"  No citation count column found: {table_path}")
+            return True
+
+        print(f"  Found cited_by_count column in: {table_path}")
+
+        if dry_run:
+            print("  [DRY-RUN] Would rename cited_by_count -> citation_count")
+            return True
+
+        # Read the table
+        df = pl.read_delta(str(table_path))
+
+        # Rename the column
+        df = df.rename({"cited_by_count": "citation_count"})
+
+        # Write back with overwrite mode
+        write_deltalake(
+            str(table_path),
+            df.to_arrow(),
+            mode="overwrite",
+            overwrite_schema=True,
+        )
+
+        print(f"  Successfully migrated: {table_path}")
+        return True
+
+    except Exception as e:
+        print(f"  Error migrating {table_path}: {e}")
+        return False
+
+
+def main() -> int:
+    """Run the migration script.
+
+    Returns:
+        Exit code: 0 for success, 1 for failure.
+    """
+    parser = argparse.ArgumentParser(
+        description="Migrate OpenAlex cited_by_count to citation_count",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        required=True,
+        help="Path to the data directory containing Silver/Gold tables",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="Show what would be done without making changes (default)",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Actually execute the migration (disables dry-run)",
+    )
+    args = parser.parse_args()
+
+    dry_run = not args.execute
+
+    print("=" * 60)
+    print("OpenAlex Citation Count Migration")
+    print("=" * 60)
+    print(f"Data directory: {args.data_dir}")
+    print(f"Mode: {'DRY-RUN' if dry_run else 'EXECUTE'}")
+    print()
+
+    if dry_run:
+        print("NOTE: This is a dry-run. Use --execute to apply changes.")
+        print()
+
+    # Define table paths to migrate
+    tables_to_migrate = [
+        args.data_dir / "silver" / "openalex_publication",
+        args.data_dir / "gold" / "openalex_publication",
+    ]
+
+    success = True
+    for table_path in tables_to_migrate:
+        print(f"\nProcessing: {table_path}")
+        if not migrate_table(table_path, dry_run):
+            success = False
+
+    print()
+    print("=" * 60)
+    if dry_run:
+        print("Dry-run complete. Use --execute to apply changes.")
+    elif success:
+        print("Migration completed successfully.")
+    else:
+        print("Migration completed with errors.")
+    print("=" * 60)
+
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/bioetl/application/pipelines/openalex/transformer.py
+++ b/src/bioetl/application/pipelines/openalex/transformer.py
@@ -162,7 +162,9 @@ class OpenAlexPublicationTransformer(BaseTransformer):
             "doc_type": doc_type,
             "is_oa": oa_info.get("is_oa"),
             "oa_status": oa_info.get("oa_status"),
-            "cited_by_count": rec.get("cited_by_count"),
+            # OpenAlex source field: cited_by_count
+            # Unified BioETL field: citation_count (standardized across all providers)
+            "citation_count": rec.get("cited_by_count"),
             "concepts": concepts,
             "language": rec.get("language"),
             "_lookup_method": lookup_method,

--- a/src/bioetl/domain/entities/openalex.py
+++ b/src/bioetl/domain/entities/openalex.py
@@ -123,8 +123,10 @@ class OpenAlexPublicationRecord(BaseModel):
     )
 
     # Citation metrics
-    cited_by_count: int | None = PydanticField(
-        default=None, description="Number of citations"
+    # OpenAlex source field: cited_by_count
+    # Unified BioETL field: citation_count (standardized across all providers)
+    citation_count: int | None = PydanticField(
+        default=None, description="Number of citations (from OpenAlex cited_by_count)"
     )
 
     # Concepts (top-level only)
@@ -178,7 +180,7 @@ class OpenAlexPublicationEntity(BaseEntity):
         doc_type: Document type (PUBLICATION, PREPRINT, etc.).
         is_oa: Whether the work is Open Access.
         oa_status: OA status (gold, green, hybrid, bronze, closed).
-        cited_by_count: Number of citations.
+        citation_count: Number of citations (from OpenAlex cited_by_count).
         concepts: Top concept names from OpenAlex.
         language: Publication language code.
         _lookup_method: How record was resolved (doi, title_fallback, title_only).
@@ -218,7 +220,9 @@ class OpenAlexPublicationEntity(BaseEntity):
     oa_status: str | None = None
 
     # Citation metrics
-    cited_by_count: int | None = None
+    # OpenAlex source field: cited_by_count
+    # Unified BioETL field: citation_count (standardized across all providers)
+    citation_count: int | None = None
 
     # Concepts (top-level only)
     concepts: list[str] = field(default_factory=list)

--- a/src/bioetl/domain/schemas/openalex/publication.py
+++ b/src/bioetl/domain/schemas/openalex/publication.py
@@ -99,10 +99,12 @@ class OpenAlexPublicationSchema(ETLRecordSchema):
     )
 
     # === Metrics ===
-    cited_by_count: Series[pd.Int64Dtype] = pa.Field(
+    # OpenAlex source field: cited_by_count
+    # Unified BioETL field: citation_count (standardized across all providers)
+    citation_count: Series[pd.Int64Dtype] = pa.Field(
         nullable=True,
         ge=0,
-        description="Citation count",
+        description="Number of citations (from OpenAlex cited_by_count).",
     )
 
     # === Metadata ===

--- a/src/bioetl/infrastructure/schemas/gold.py
+++ b/src/bioetl/infrastructure/schemas/gold.py
@@ -749,7 +749,9 @@ class OpenAlexPublicationGoldSchema(pa.DataFrameModel):
     doc_type: Series[str] = pa.Field(nullable=False)
     is_oa: Series[bool] = pa.Field(nullable=True)
     oa_status: Series[str] = pa.Field(nullable=True)
-    cited_by_count: Series[float] = pa.Field(nullable=True, ge=0, coerce=True)
+    # OpenAlex source field: cited_by_count
+    # Unified BioETL field: citation_count (standardized across all providers)
+    citation_count: Series[float] = pa.Field(nullable=True, ge=0, coerce=True)
     language: Series[str] = pa.Field(nullable=True)
     source: Series[str] = pa.Field(nullable=False)
 

--- a/src/bioetl/infrastructure/schemas/silver.py
+++ b/src/bioetl/infrastructure/schemas/silver.py
@@ -685,7 +685,9 @@ OPENALEX_PUBLICATION_SCHEMA = pa.schema(
         pa.field("doc_type", pa.string()),
         pa.field("is_oa", pa.bool_()),
         pa.field("oa_status", pa.string()),
-        pa.field("cited_by_count", pa.int64()),
+        # OpenAlex source field: cited_by_count
+        # Unified BioETL field: citation_count (standardized across all providers)
+        pa.field("citation_count", pa.int64()),
         pa.field("language", pa.string()),
         pa.field("source", pa.string()),
         # Lookup metadata

--- a/tests/unit/application/pipelines/openalex/test_transformer.py
+++ b/tests/unit/application/pipelines/openalex/test_transformer.py
@@ -67,7 +67,8 @@ def sample_openalex_record() -> dict[str, Any]:
             "is_oa": True,
             "oa_status": "gold",
         },
-        "cited_by_count": 42,
+        # Note: OpenAlex API returns cited_by_count, transformed to citation_count
+        "cited_by_count": 42,  # Source field name from OpenAlex API
         "concepts": [
             {"display_name": "Chemistry", "score": 0.9},
             {"display_name": "Biology", "score": 0.7},
@@ -105,7 +106,7 @@ class TestOpenAlexPublicationTransformer:
         assert result["publisher"] == "Springer Nature"
         assert result["is_oa"] is True
         assert result["oa_status"] == "gold"
-        assert result["cited_by_count"] == 42
+        assert result["citation_count"] == 42  # Unified field name
         assert result["language"] == "en"
         assert result["source"] == "openalex"
         assert result["_lookup_method"] == "doi"

--- a/tests/unit/domain/schemas/openalex/test_publication_schema.py
+++ b/tests/unit/domain/schemas/openalex/test_publication_schema.py
@@ -48,7 +48,7 @@ def valid_record() -> dict:
         "publisher": "Springer Nature",
         "is_oa": True,
         "oa_status": "gold",
-        "cited_by_count": 42,
+        "citation_count": 42,  # Unified field name (from OpenAlex cited_by_count)
         "language": "en",
         "source": "openalex",
         "_lookup_method": "doi",
@@ -167,16 +167,20 @@ class TestOpenAlexPublicationSchema:
         validated = OpenAlexPublicationSchema.validate(df)
         assert pd.isna(validated["oa_status"].iloc[0])
 
-    def test_cited_by_count_non_negative(self, valid_record: dict) -> None:
-        """Should validate cited_by_count is non-negative."""
+    def test_citation_count_non_negative(self, valid_record: dict) -> None:
+        """Should validate citation_count is non-negative.
+
+        Note: OpenAlex source field is 'cited_by_count', but we use the
+        unified field name 'citation_count' for cross-provider consistency.
+        """
         # Valid count
-        valid_record["cited_by_count"] = 0
+        valid_record["citation_count"] = 0
         df = pd.DataFrame([valid_record])
         validated = OpenAlexPublicationSchema.validate(df)
-        assert validated["cited_by_count"].iloc[0] == 0
+        assert validated["citation_count"].iloc[0] == 0
 
         # Negative count
-        valid_record["cited_by_count"] = -1
+        valid_record["citation_count"] = -1
         df = pd.DataFrame([valid_record])
         with pytest.raises(SchemaError):
             OpenAlexPublicationSchema.validate(df)


### PR DESCRIPTION
BREAKING CHANGE: Renamed `cited_by_count` to `citation_count` in OpenAlex publication schema to align with CrossRef and SemanticScholar providers.

Changes:
- Renamed field in domain schema (publication.py)
- Renamed field in domain entity (openalex.py)
- Updated transformer to map OpenAlex cited_by_count to citation_count
- Updated infrastructure schemas (silver.py, gold.py)
- Updated unit tests for transformer and schema
- Added migration script for existing Delta Lake tables
- Added CHANGELOG entry with breaking change notice

Migration: Run scripts/migrate_openalex_citation_count.py for existing data.