### PR TITLE
Abstract HTML stripping across all providers

### DIFF
--- a/src/bioetl/application/pipelines/chembl/document_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/document_transformer.py
@@ -21,6 +21,7 @@ from bioetl.application.pipelines.chembl.base_chembl_transformer import (
     BaseChemblTransformer,
 )
 from bioetl.domain.entities import ChemblPublication
+from bioetl.domain.normalization import strip_html_tags
 
 if TYPE_CHECKING:
     from bioetl.domain.types import BronzeRecord
@@ -98,6 +99,9 @@ class DocumentTransformer(BaseChemblTransformer):
             "document_chembl_id": str(primary_id),
             **map_field_groups(record, _PUBLICATION_GROUPS),
         }
+
+        # Strip HTML from abstract field
+        data["abstract"] = strip_html_tags(data.get("abstract"))
 
         # Hash PII field (RULES.md §5.4)
         # ChEMBL authors is a single string, not a list

--- a/src/bioetl/application/pipelines/openalex/transformer.py
+++ b/src/bioetl/application/pipelines/openalex/transformer.py
@@ -28,6 +28,7 @@ from bioetl.application.pipelines.openalex.extractors import (
     reconstruct_abstract,
 )
 from bioetl.domain.entities.openalex import OPENALEX_TYPE_MAP, OpenAlexPublicationEntity
+from bioetl.domain.normalization import strip_html_tags
 from bioetl.domain.services import IdentityService
 from bioetl.domain.validation import validate_year_range
 
@@ -118,9 +119,9 @@ class OpenAlexPublicationTransformer(BaseTransformer):
         # Extract and normalize DOI
         doi = extract_doi(rec.get("doi"))
 
-        # Reconstruct abstract from inverted index
+        # Reconstruct abstract from inverted index (then strip HTML for cleaning)
         abstract_index = rec.get("abstract_inverted_index")
-        abstract = reconstruct_abstract(abstract_index)
+        abstract = strip_html_tags(reconstruct_abstract(abstract_index))
 
         # Extract and hash authors (PII)
         raw_authors = extract_authors(rec.get("authorships", []))

--- a/src/bioetl/application/pipelines/pubmed/transformer.py
+++ b/src/bioetl/application/pipelines/pubmed/transformer.py
@@ -18,6 +18,7 @@ from bioetl.application.pipelines.pubmed.extractors import (
 )
 from bioetl.application.pipelines.pubmed.xml_utils import get_text
 from bioetl.domain.entities import Publication
+from bioetl.domain.normalization import strip_html_tags
 from bioetl.domain.services import IdentityService
 
 if TYPE_CHECKING:
@@ -118,7 +119,7 @@ class PubMedPublicationTransformer(BaseTransformer):
             "pmid": pmid,
             "doi": IdentifierExtractor.extract_doi(root),
             "title": get_text(article.find(".//ArticleTitle")),
-            "abstract": AbstractExtractor.extract_abstract(article),
+            "abstract": strip_html_tags(AbstractExtractor.extract_abstract(article)),
             "authors": hashed_authors,
             **journal_data,
             **date_data,

--- a/src/bioetl/application/pipelines/semanticscholar/transformer.py
+++ b/src/bioetl/application/pipelines/semanticscholar/transformer.py
@@ -20,6 +20,7 @@ from bioetl.application.pipelines.semanticscholar.extractors import (
     validate_year,
 )
 from bioetl.domain.entities.semanticscholar import SemanticScholarPublicationEntity
+from bioetl.domain.normalization import strip_html_tags
 
 if TYPE_CHECKING:
     from bioetl.domain.context import PipelineContext
@@ -145,7 +146,7 @@ class SemanticScholarPublicationTransformer(BaseTransformer):
             "arxiv_id": external_ids.get("arxiv"),
             "corpus_id": external_ids.get("corpus_id"),
             "title": rec.get("title"),
-            "abstract": rec.get("abstract"),
+            "abstract": strip_html_tags(rec.get("abstract")),
             "tldr": tldr,
             "authors": self.serialize_json(hashed_authors),
             "journal": journal_info.get("journal_name"),

--- a/src/bioetl/domain/normalization.py
+++ b/src/bioetl/domain/normalization.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import re
 from datetime import date
+from html import unescape
 from typing import Any
 
 
@@ -57,14 +58,38 @@ def parse_date_field(value: str | None, fmt: str = "%Y-%m-%d") -> date | None:
 
 
 _HTML_TAG_PATTERN = re.compile(r"<[^>]+>")
+_WHITESPACE_PATTERN = re.compile(r"\s+")
 
 
 def strip_html_tags(text: str | None) -> str | None:
-    """Strip HTML tags from text, return None if empty."""
+    """Remove HTML tags and decode entities from text.
+
+    Performs the following normalization steps:
+    1. Remove HTML tags (including JATS tags like <jats:p>)
+    2. Decode HTML entities (&amp; → &, &lt; → <, etc.)
+    3. Normalize whitespace (collapse multiple spaces to single space)
+    4. Strip leading/trailing whitespace
+
+    Args:
+        text: Input text possibly containing HTML.
+
+    Returns:
+        Clean text without HTML tags, or None if input is None/empty.
+
+    """
     if not text:
         return None
-    result = _HTML_TAG_PATTERN.sub("", text).strip()
-    return result if result else None
+
+    # Remove HTML tags
+    clean = _HTML_TAG_PATTERN.sub("", text)
+
+    # Decode HTML entities (&amp; → &, &lt; → <, etc.)
+    clean = unescape(clean)
+
+    # Normalize whitespace (collapse multiple spaces/newlines to single space)
+    clean = _WHITESPACE_PATTERN.sub(" ", clean).strip()
+
+    return clean if clean else None
 
 
 def _to_none_if_empty(s: str) -> str | None:

--- a/tests/unit/domain/test_normalization.py
+++ b/tests/unit/domain/test_normalization.py
@@ -139,6 +139,7 @@ class TestStripHtmlTags:
     @pytest.mark.parametrize(
         "text,expected",
         [
+            # Basic HTML tags
             ("<p>Hello world</p>", "Hello world"),
             ("<b>Bold</b> text", "Bold text"),
             ("<jats:p>Abstract text</jats:p>", "Abstract text"),
@@ -147,15 +148,67 @@ class TestStripHtmlTags:
             ("", None),
             (None, None),
             ("<p></p>", None),  # Empty after stripping
+            # HTML entity decoding
+            ("&amp; &lt; &gt;", "& < >"),
+            ("5 &gt; 3 &amp;&amp; 2 &lt; 4", "5 > 3 && 2 < 4"),
+            ("H&auml;llo W&ouml;rld", "Hällo Wörld"),
+            ("&quot;quoted&quot;", '"quoted"'),
+            ("&apos;apostrophe&apos;", "'apostrophe'"),
+            # Note: &nbsp; is decoded to \xa0 but our whitespace normalization
+            # treats \xa0 as whitespace and collapses it
+            ("&nbsp;non-breaking&nbsp;space", "non-breaking space"),
+            # Whitespace normalization
+            ("  Multiple   spaces  ", "Multiple spaces"),
+            ("Line\nbreak", "Line break"),
+            ("Tab\there", "Tab here"),
+            ("Mixed\n\t  spaces", "Mixed spaces"),
+            # Tags between content don't add spaces
+            ("<p>Para 1</p><p>Para 2</p>", "Para 1Para 2"),
+            # But newlines between tags are normalized to spaces
+            ("<p>Para 1</p>\n\n<p>Para 2</p>", "Para 1 Para 2"),
+            # XSS script tags
+            ("<script>alert('xss')</script>Text", "alert('xss')Text"),
+            ("<SCRIPT>malicious</SCRIPT>Safe", "maliciousSafe"),
+            # Combined scenarios
+            ("<p>&amp; test &lt;value&gt;</p>", "& test <value>"),
+            (
+                "<jats:p>  Multiple &amp; spaces  </jats:p>",
+                "Multiple & spaces",
+            ),
         ],
     )
     def test_strip_html_tags(self, text: str | None, expected: str | None) -> None:
-        """Test HTML tag stripping."""
+        """Test HTML tag stripping with entity decoding and whitespace normalization."""
         assert strip_html_tags(text) == expected
 
     def test_nested_tags(self) -> None:
         """Test stripping nested HTML tags."""
         assert strip_html_tags("<div><p>Nested <b>tags</b></p></div>") == "Nested tags"
+
+    def test_complex_html_abstract(self) -> None:
+        """Test stripping complex HTML typical in scientific abstracts."""
+        html = """<jats:p>This study investigates the &alpha;-receptor
+        binding affinity of <jats:italic>compound X</jats:italic>.
+        Results show IC<jats:sub>50</jats:sub> &lt; 10 nM.</jats:p>"""
+        expected = (
+            "This study investigates the \u03b1-receptor binding affinity of compound X. "
+            "Results show IC50 < 10 nM."
+        )
+        assert strip_html_tags(html) == expected
+
+    def test_script_tag_content_preserved(self) -> None:
+        """Test that script tag content is preserved (tags removed, content kept).
+
+        Note: This function only strips tags, it doesn't sanitize for security.
+        Security-sensitive contexts should use proper HTML sanitization libraries.
+        """
+        result = strip_html_tags("<script>alert(1)</script>Safe text")
+        assert result == "alert(1)Safe text"
+
+    def test_numeric_entities(self) -> None:
+        """Test decoding of numeric HTML entities."""
+        assert strip_html_tags("&#60;tag&#62;") == "<tag>"
+        assert strip_html_tags("&#x3C;hex&#x3E;") == "<hex>"
 
 
 class TestParsePageRange:


### PR DESCRIPTION
Previously, only CrossRef transformer stripped HTML tags from abstracts. This caused inconsistent content hashes and visual noise in abstracts from other providers.

Changes:
- Enhanced strip_html_tags() with HTML entity decoding (&amp; → &, etc.)
- Added whitespace normalization (collapse multiple spaces/newlines)
- Applied strip_html_tags() to Semantic Scholar, PubMed, ChEMBL, and OpenAlex transformers
- OpenAlex applies stripping after reconstruct_abstract()
- Extended unit tests with entity decoding, whitespace, and edge cases

This ensures consistent abstract normalization across all providers, enabling reliable content hashing and cleaner text for NLP analysis.