### PR TITLE
Normalize open access status formats

### DIFF
--- a/src/bioetl/application/pipelines/semanticscholar/extractors.py
+++ b/src/bioetl/application/pipelines/semanticscholar/extractors.py
@@ -99,36 +99,87 @@ def extract_journal_info(
     }
 
 
+# Valid OA status values (normalized to lowercase for consistency with OpenAlex)
+VALID_OA_STATUS_VALUES = {"gold", "green", "hybrid", "bronze", "closed"}
+
+
+def normalize_oa_status(status: str | None) -> str | None:
+    """Normalize OA status to lowercase.
+
+    Converts OA status values to lowercase for consistency with OpenAlex.
+    Returns None for invalid or unknown status values.
+
+    Args:
+        status: Raw OA status string (may be uppercase, mixed case, or None).
+
+    Returns:
+        Normalized lowercase status if valid, None otherwise.
+
+    Example:
+        >>> normalize_oa_status("GOLD")
+        'gold'
+        >>> normalize_oa_status("Green")
+        'green'
+        >>> normalize_oa_status("unknown")
+        None
+        >>> normalize_oa_status(None)
+        None
+
+    """
+    if status is None:
+        return None
+    normalized = status.lower().strip()
+    return normalized if normalized in VALID_OA_STATUS_VALUES else None
+
+
 def extract_open_access_info(
     is_open_access: bool | None,
     open_access_pdf: dict[str, Any] | None,
 ) -> dict[str, Any]:
-    """Extract open access information.
+    """Extract open access information with normalized status.
+
+    Extracts OA information from S2 API response and normalizes the status
+    to lowercase for consistency with OpenAlex data.
 
     Args:
         is_open_access: Boolean flag from S2.
         open_access_pdf: PDF info object from S2.
 
     Returns:
-        Dict with is_open_access, url, status.
+        Dict with is_oa (bool), url (str|None), oa_status (str|None).
+        If is_open_access is False or None and no OA PDF, oa_status is "closed".
 
     Example:
         >>> oa_pdf = {"url": "https://example.com/paper.pdf", "status": "GREEN"}
         >>> extract_open_access_info(True, oa_pdf)
-        {'is_open_access': True, 'url': 'https://...', 'status': 'GREEN'}
+        {'is_oa': True, 'url': 'https://...', 'oa_status': 'green'}
+        >>> extract_open_access_info(False, None)
+        {'is_oa': False, 'url': None, 'oa_status': 'closed'}
 
     """
-    result: dict[str, Any] = {
-        "is_open_access": is_open_access or False,
-        "url": None,
-        "status": None,
-    }
+    # Determine if open access
+    is_oa = is_open_access or False
+
+    # Extract URL and status from PDF info
+    url: str | None = None
+    raw_status: str | None = None
 
     if open_access_pdf:
-        result["url"] = open_access_pdf.get("url")
-        result["status"] = open_access_pdf.get("status")
+        url = open_access_pdf.get("url")
+        raw_status = open_access_pdf.get("status")
 
-    return result
+    # Normalize status to lowercase
+    oa_status = normalize_oa_status(raw_status)
+
+    # If not open access and no status, set to "closed"
+    if not is_oa and oa_status is None:
+        oa_status = "closed"
+
+    return {
+        "is_oa": is_oa,
+        "url": url,
+        "oa_status": oa_status,
+    }
 
 
 def extract_tldr(tldr: dict[str, Any] | None) -> str | None:

--- a/src/bioetl/application/pipelines/semanticscholar/transformer.py
+++ b/src/bioetl/application/pipelines/semanticscholar/transformer.py
@@ -46,7 +46,8 @@ class SemanticScholarPublicationTransformer(BaseTransformer):
     - publication_date: publicationDate
     - citation_count: citationCount
     - reference_count: referenceCount
-    - is_open_access: isOpenAccess
+    - is_oa: isOpenAccess (normalized)
+    - oa_status: openAccessPdf.status (normalized to lowercase)
     - open_access_url: openAccessPdf.url
     - fields_of_study: fieldsOfStudy
     - publication_types: publicationTypes
@@ -156,9 +157,9 @@ class SemanticScholarPublicationTransformer(BaseTransformer):
             "publication_date": rec.get("publicationDate"),
             "citation_count": rec.get("citationCount"),
             "reference_count": rec.get("referenceCount"),
-            "is_open_access": oa_info.get("is_open_access"),
+            "is_oa": oa_info.get("is_oa"),
             "open_access_url": oa_info.get("url"),
-            "open_access_status": oa_info.get("status"),
+            "oa_status": oa_info.get("oa_status"),
             "fields_of_study": self.serialize_json(fields_of_study),
             "publication_types": self.serialize_json(rec.get("publicationTypes")),
             "source": "semanticscholar",

--- a/src/bioetl/domain/entities/semanticscholar.py
+++ b/src/bioetl/domain/entities/semanticscholar.py
@@ -46,9 +46,9 @@ class SemanticScholarPublicationEntity(BaseEntity):
         publication_date: Publication date (YYYY-MM-DD).
         citation_count: Number of citations.
         reference_count: Number of references.
-        is_open_access: Whether the work is Open Access.
+        is_oa: Whether the work is Open Access.
         open_access_url: URL to open access PDF.
-        open_access_status: OA status string.
+        oa_status: OA status (gold, green, hybrid, bronze, closed).
         fields_of_study: JSON string of fields of study.
         publication_types: JSON string of publication types.
         _lookup_method: How record was resolved (doi, title_fallback, title_only).
@@ -91,9 +91,9 @@ class SemanticScholarPublicationEntity(BaseEntity):
     reference_count: int | None = None
 
     # Open Access status
-    is_open_access: bool | None = None
+    is_oa: bool | None = None
     open_access_url: str | None = None
-    open_access_status: str | None = None
+    oa_status: str | None = None
 
     # Classification (JSON strings)
     fields_of_study: str | None = None

--- a/src/bioetl/domain/schemas/semanticscholar/publication.py
+++ b/src/bioetl/domain/schemas/semanticscholar/publication.py
@@ -16,8 +16,8 @@ from bioetl.domain.validation import DOI_REGEX_PATTERN
 # Lookup method values for batch DOI resolution
 LOOKUP_METHODS = ["doi", "title_fallback", "title_only", "unknown"]
 
-# Open Access status values (from S2 API)
-OA_STATUS_VALUES = ["GREEN", "GOLD", "HYBRID", "BRONZE"]
+# Open Access status values (normalized to lowercase for consistency with OpenAlex)
+OA_STATUS_VALUES = ["gold", "green", "hybrid", "bronze", "closed"]
 
 
 class SemanticScholarPublicationSchema(ETLRecordSchema):
@@ -128,7 +128,7 @@ class SemanticScholarPublicationSchema(ETLRecordSchema):
     )
 
     # === Open Access ===
-    is_open_access: Series[bool] = pa.Field(
+    is_oa: Series[bool] = pa.Field(
         nullable=True,
         description="Is Open Access",
     )
@@ -138,10 +138,10 @@ class SemanticScholarPublicationSchema(ETLRecordSchema):
         description="Direct link to OA PDF",
     )
 
-    open_access_status: Series[str] = pa.Field(
+    oa_status: Series[str] = pa.Field(
         nullable=True,
         isin=OA_STATUS_VALUES,
-        description="OA status (GREEN, GOLD, HYBRID, BRONZE)",
+        description="Open Access status (normalized to lowercase).",
     )
 
     # === Classification ===

--- a/src/bioetl/infrastructure/schemas/gold.py
+++ b/src/bioetl/infrastructure/schemas/gold.py
@@ -639,9 +639,9 @@ class SemanticScholarPublicationGoldSchema(pa.DataFrameModel):
     reference_count: Series[float] = pa.Field(nullable=True, ge=0, coerce=True)  # int64
 
     # Open Access
-    is_open_access: Series[bool] = pa.Field(nullable=True)
+    is_oa: Series[bool] = pa.Field(nullable=True)
     open_access_url: Series[str] = pa.Field(nullable=True)
-    open_access_status: Series[str] = pa.Field(nullable=True)
+    oa_status: Series[str] = pa.Field(nullable=True)
 
     # Classification (JSON strings)
     fields_of_study: Series[str] = pa.Field(nullable=True)

--- a/src/bioetl/infrastructure/schemas/silver.py
+++ b/src/bioetl/infrastructure/schemas/silver.py
@@ -597,9 +597,9 @@ SEMANTICSCHOLAR_PUBLICATION_SCHEMA = pa.schema(
         pa.field("citation_count", pa.int64()),
         pa.field("reference_count", pa.int64()),
         # Open Access
-        pa.field("is_open_access", pa.bool_()),
+        pa.field("is_oa", pa.bool_()),
         pa.field("open_access_url", pa.string()),
-        pa.field("open_access_status", pa.string()),
+        pa.field("oa_status", pa.string()),
         # Classification (JSON strings)
         pa.field("fields_of_study", pa.string()),
         pa.field("publication_types", pa.string()),

--- a/tests/unit/application/pipelines/semanticscholar/test_extractors.py
+++ b/tests/unit/application/pipelines/semanticscholar/test_extractors.py
@@ -10,6 +10,7 @@ from bioetl.application.pipelines.semanticscholar.extractors import (
     extract_journal_info,
     extract_open_access_info,
     extract_tldr,
+    normalize_oa_status,
     validate_year,
 )
 
@@ -164,7 +165,7 @@ class TestExtractOpenAccessInfo:
     """Tests for extract_open_access_info function."""
 
     def test_extract_open_access(self) -> None:
-        """Test extracting open access information."""
+        """Test extracting open access information with normalized status."""
         oa_pdf = {
             "url": "https://example.com/paper.pdf",
             "status": "GREEN",
@@ -172,30 +173,50 @@ class TestExtractOpenAccessInfo:
 
         result = extract_open_access_info(True, oa_pdf)
 
-        assert result["is_open_access"] is True
+        assert result["is_oa"] is True
         assert result["url"] == "https://example.com/paper.pdf"
-        assert result["status"] == "GREEN"
+        assert result["oa_status"] == "green"  # Normalized to lowercase
 
     def test_closed_access(self) -> None:
-        """Test closed access publication."""
+        """Test closed access publication gets 'closed' status."""
         result = extract_open_access_info(False, None)
 
-        assert result["is_open_access"] is False
+        assert result["is_oa"] is False
         assert result["url"] is None
-        assert result["status"] is None
+        assert result["oa_status"] == "closed"  # Now returns "closed" instead of None
 
     def test_none_is_open_access(self) -> None:
-        """Test when is_open_access is None."""
+        """Test when is_open_access is None, defaults to closed."""
         result = extract_open_access_info(None, None)
 
-        assert result["is_open_access"] is False
+        assert result["is_oa"] is False
+        assert result["oa_status"] == "closed"
 
     def test_open_access_without_pdf(self) -> None:
         """Test open access without PDF info."""
         result = extract_open_access_info(True, None)
 
-        assert result["is_open_access"] is True
+        assert result["is_oa"] is True
         assert result["url"] is None
+        assert result["oa_status"] is None  # No status available
+
+    def test_uppercase_gold_normalized(self) -> None:
+        """Test that GOLD status is normalized to lowercase."""
+        oa_pdf = {"url": "https://example.com/paper.pdf", "status": "GOLD"}
+        result = extract_open_access_info(True, oa_pdf)
+        assert result["oa_status"] == "gold"
+
+    def test_mixed_case_hybrid_normalized(self) -> None:
+        """Test that mixed case status is normalized."""
+        oa_pdf = {"url": "https://example.com/paper.pdf", "status": "Hybrid"}
+        result = extract_open_access_info(True, oa_pdf)
+        assert result["oa_status"] == "hybrid"
+
+    def test_unknown_status_returns_none(self) -> None:
+        """Test that unknown OA status returns None."""
+        oa_pdf = {"url": "https://example.com/paper.pdf", "status": "UNKNOWN"}
+        result = extract_open_access_info(True, oa_pdf)
+        assert result["oa_status"] is None
 
 
 class TestExtractTldr:
@@ -273,3 +294,56 @@ class TestValidateYear:
     def test_none_year(self) -> None:
         """Test None year."""
         assert validate_year(None) is None
+
+
+class TestNormalizeOaStatus:
+    """Tests for normalize_oa_status function."""
+
+    def test_uppercase_gold(self) -> None:
+        """Test GOLD is normalized to gold."""
+        assert normalize_oa_status("GOLD") == "gold"
+
+    def test_lowercase_gold(self) -> None:
+        """Test gold stays lowercase."""
+        assert normalize_oa_status("gold") == "gold"
+
+    def test_mixed_case_green(self) -> None:
+        """Test Green is normalized to green."""
+        assert normalize_oa_status("Green") == "green"
+
+    def test_uppercase_hybrid(self) -> None:
+        """Test HYBRID is normalized to hybrid."""
+        assert normalize_oa_status("HYBRID") == "hybrid"
+
+    def test_uppercase_bronze(self) -> None:
+        """Test BRONZE is normalized to bronze."""
+        assert normalize_oa_status("BRONZE") == "bronze"
+
+    def test_closed_status(self) -> None:
+        """Test closed status is valid."""
+        assert normalize_oa_status("closed") == "closed"
+
+    def test_uppercase_closed(self) -> None:
+        """Test CLOSED is normalized to closed."""
+        assert normalize_oa_status("CLOSED") == "closed"
+
+    def test_unknown_returns_none(self) -> None:
+        """Test unknown status returns None."""
+        assert normalize_oa_status("unknown") is None
+
+    def test_invalid_status_returns_none(self) -> None:
+        """Test invalid status returns None."""
+        assert normalize_oa_status("invalid") is None
+
+    def test_empty_string_returns_none(self) -> None:
+        """Test empty string returns None."""
+        assert normalize_oa_status("") is None
+
+    def test_none_returns_none(self) -> None:
+        """Test None returns None."""
+        assert normalize_oa_status(None) is None
+
+    def test_whitespace_trimmed(self) -> None:
+        """Test whitespace is trimmed before normalization."""
+        assert normalize_oa_status("  GOLD  ") == "gold"
+        assert normalize_oa_status("\tgreen\n") == "green"

--- a/tests/unit/application/pipelines/semanticscholar/test_transformer.py
+++ b/tests/unit/application/pipelines/semanticscholar/test_transformer.py
@@ -107,9 +107,9 @@ class TestSemanticScholarPublicationTransformer:
         assert result["pages"] == "123-130"
         assert result["citation_count"] == 42
         assert result["reference_count"] == 85
-        assert result["is_open_access"] is True
+        assert result["is_oa"] is True
         assert result["open_access_url"] == "https://example.com/paper.pdf"
-        assert result["open_access_status"] == "GREEN"
+        assert result["oa_status"] == "green"  # Normalized to lowercase
         assert result["source"] == "semanticscholar"
         assert result["_lookup_method"] == "doi"
 
@@ -311,9 +311,9 @@ class TestSemanticScholarPublicationTransformer:
         result = await transformer.transform(mock_context, sample_record, 0)
 
         assert result is not None
-        assert result["is_open_access"] is False
+        assert result["is_oa"] is False
         assert result["open_access_url"] is None
-        assert result["open_access_status"] is None
+        assert result["oa_status"] == "closed"  # Now returns "closed" for non-OA
 
 
 class TestTransformerWithPiiHasher:

--- a/tests/unit/domain/schemas/semanticscholar/test_publication_schema.py
+++ b/tests/unit/domain/schemas/semanticscholar/test_publication_schema.py
@@ -166,8 +166,8 @@ class TestCorpusIdValidation:
         assert not (invalid_id >= 0)
 
 
-class TestOpenAccessStatusValidation:
-    """Tests for open_access_status enum validation."""
+class TestOaStatusValidation:
+    """Tests for oa_status enum validation (normalized to lowercase)."""
 
     @pytest.mark.parametrize("status", OA_STATUS_VALUES)
     def test_valid_oa_status(self, status: str) -> None:
@@ -178,6 +178,15 @@ class TestOpenAccessStatusValidation:
         """Test invalid open access status."""
         invalid_status = "INVALID"
         assert invalid_status not in OA_STATUS_VALUES
+
+    def test_oa_status_values_are_lowercase(self) -> None:
+        """Test that all OA status values are lowercase."""
+        for status in OA_STATUS_VALUES:
+            assert status == status.lower(), f"Status {status} should be lowercase"
+
+    def test_oa_status_includes_closed(self) -> None:
+        """Test that 'closed' is included in valid OA status values."""
+        assert "closed" in OA_STATUS_VALUES
 
 
 class TestLookupMethodValidation:
@@ -238,9 +247,9 @@ class TestSchemaFieldDefinitions:
             "venue",
             "citation_count",
             "reference_count",
-            "is_open_access",
+            "is_oa",
             "open_access_url",
-            "open_access_status",
+            "oa_status",
             "fields_of_study",
             "publication_types",
             "authors",
@@ -282,7 +291,7 @@ class TestSchemaFieldDefinitions:
             "pages",
             "venue",
             "open_access_url",
-            "open_access_status",
+            "oa_status",
             "fields_of_study",
             "publication_types",
             "authors",


### PR DESCRIPTION
…consistency

Unify Open Access status representation across providers:

- Rename `is_open_access` → `is_oa` for Semantic Scholar entity
- Rename `open_access_status` → `oa_status` for Semantic Scholar entity
- Normalize OA status values to lowercase (gold, green, hybrid, bronze, closed)
- Add `normalize_oa_status()` function for case-insensitive normalization
- Add "closed" status for non-OA publications (when isOpenAccess=False)
- Update Pandera schemas (domain and infrastructure layers)
- Update PyArrow schemas for Silver/Gold storage

This aligns Semantic Scholar OA data with OpenAlex format, enabling consistent aggregation in Gold layer. OpenAlex uses lowercase values (gold, green, hybrid, bronze, closed), and now Semantic Scholar does too.