### PR TITLE
Implement BaseTitleFallbackHandler for OpenAlex

### DIFF
--- a/src/bioetl/infrastructure/adapters/common/__init__.py
+++ b/src/bioetl/infrastructure/adapters/common/__init__.py
@@ -1,0 +1,12 @@
+"""Common adapter utilities and base classes.
+
+Provides shared functionality for infrastructure adapters.
+"""
+
+from __future__ import annotations
+
+from bioetl.infrastructure.adapters.common.base_title_fallback import (
+    BaseTitleFallbackHandler,
+)
+
+__all__ = ["BaseTitleFallbackHandler"]

--- a/src/bioetl/infrastructure/adapters/common/base_title_fallback.py
+++ b/src/bioetl/infrastructure/adapters/common/base_title_fallback.py
@@ -1,0 +1,181 @@
+"""Base fallback handler for title-based DOI resolution.
+
+Provides common utilities for fallback search across different providers.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Callable
+
+    from bioetl.domain.ports import LoggerPort
+
+
+class BaseTitleFallbackHandler(ABC):
+    """Base class for title-based fallback search handlers.
+
+    Provides common utilities for fallback title lookup when DOI resolution fails.
+    Subclasses implement provider-specific search logic.
+    """
+
+    def __init__(self, logger: LoggerPort) -> None:
+        """Initialize base fallback handler.
+
+        Args:
+            logger: Logger port for structured logging.
+        """
+        self._logger = logger
+
+    @property
+    @abstractmethod
+    def _event_no_fallback_title(self) -> str:
+        """Return log event name for missing fallback title."""
+        ...
+
+    @property
+    @abstractmethod
+    def _event_fallback_attempt(self) -> str:
+        """Return log event name for fallback attempt."""
+        ...
+
+    @property
+    @abstractmethod
+    def _event_fallback_success(self) -> str:
+        """Return log event name for successful fallback."""
+        ...
+
+    @property
+    @abstractmethod
+    def _event_fallback_not_found(self) -> str:
+        """Return log event name for failed fallback."""
+        ...
+
+    @abstractmethod
+    async def _search_by_title(self, title: str) -> dict[str, Any] | None:
+        """Search for publication by title.
+
+        Args:
+            title: Publication title to search for.
+
+        Returns:
+            Publication record if found, None otherwise.
+        """
+        ...
+
+    def _get_result_identifier(self, result: dict[str, Any]) -> tuple[str, str]:
+        """Return (field_name, value) for logging the found result.
+
+        Args:
+            result: The found publication record.
+
+        Returns:
+            Tuple of (log_field_name, identifier_value).
+        """
+        return ("found_id", str(result.get("id", "unknown")))
+
+    def _process_found_result(
+        self, result: dict[str, Any], original_doi: str
+    ) -> dict[str, Any]:
+        """Process found result before yielding.
+
+        Override to add metadata like _lookup_method.
+
+        Args:
+            result: The found publication record.
+            original_doi: The DOI that was originally searched.
+
+        Returns:
+            Processed result (may be modified or returned as-is).
+        """
+        return result
+
+    def _get_fallback_title(
+        self, doi: str, normalized_doi: str | None, fallback_mapping: dict[str, str]
+    ) -> str | None:
+        """Get fallback title for a DOI from mapping.
+
+        Args:
+            doi: Original DOI string.
+            normalized_doi: Normalized DOI string (lowercase, without URL prefix).
+            fallback_mapping: Mapping from DOI to title.
+
+        Returns:
+            Title if found in mapping, None otherwise.
+        """
+        if normalized_doi:
+            return fallback_mapping.get(doi) or fallback_mapping.get(normalized_doi)
+        return fallback_mapping.get(doi)
+
+    def _truncate_title(self, title: str, max_len: int = 50) -> str:
+        """Truncate title for logging.
+
+        Args:
+            title: Title to truncate.
+            max_len: Maximum length before truncation.
+
+        Returns:
+            Truncated title with ellipsis if needed.
+        """
+        return title[:max_len] + "..." if len(title) > max_len else title
+
+    async def process_missing_dois(
+        self,
+        dois: list[str],
+        found_dois: set[str],
+        fallback_mapping: dict[str, str],
+        normalize_fn: Callable[[str], str | None],
+        limit: int | None,
+        fetched: int,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Process DOIs not found via batch fetch using title fallback.
+
+        Args:
+            dois: List of DOIs that were requested.
+            found_dois: Set of DOIs that were successfully resolved (lowercase).
+            fallback_mapping: Mapping {doi: title} for fallback search.
+            normalize_fn: Function to normalize DOI strings.
+            limit: Maximum total records to return.
+            fetched: Number of records already fetched.
+
+        Yields:
+            Publication records found via title search.
+        """
+        for doi in dois:
+            if limit and fetched >= limit:
+                return
+
+            normalized_doi = (normalize_fn(doi) or "").lower()
+            if normalized_doi in found_dois:
+                continue
+
+            title = self._get_fallback_title(doi, normalized_doi, fallback_mapping)
+            if not title:
+                self._logger.debug(self._event_no_fallback_title, doi=doi)
+                continue
+
+            self._logger.info(
+                self._event_fallback_attempt,
+                doi=doi,
+                title=self._truncate_title(title),
+            )
+
+            result = await self._search_by_title(title)
+            if result:
+                id_field, id_value = self._get_result_identifier(result)
+                self._logger.info(
+                    self._event_fallback_success,
+                    original_doi=doi,
+                    title=title[:50],
+                    **{id_field: id_value},
+                )
+                yield self._process_found_result(result, doi)
+                fetched += 1
+            else:
+                self._logger.warning(
+                    self._event_fallback_not_found,
+                    doi=doi,
+                    title=title[:50],
+                )

--- a/src/bioetl/infrastructure/adapters/crossref/fallback.py
+++ b/src/bioetl/infrastructure/adapters/crossref/fallback.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from bioetl.infrastructure.adapters.common import BaseTitleFallbackHandler
+
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable
 
@@ -35,7 +37,7 @@ def titles_match(query_title: str, found_title: str, threshold: float = 0.8) -> 
     return q in f or f in q
 
 
-class TitleFallbackHandler:
+class TitleFallbackHandler(BaseTitleFallbackHandler):
     """Handles fallback search by title when DOI lookup fails.
 
     Extracts fallback logic to reduce main class size and cyclomatic complexity.
@@ -52,8 +54,43 @@ class TitleFallbackHandler:
             logger: Logger port for structured logging.
             search_fn: Async function to search publications by query.
         """
-        self._logger = logger
+        super().__init__(logger)
         self._search_fn = search_fn
+
+    @property
+    def _event_no_fallback_title(self) -> str:
+        """Return log event name for missing fallback title."""
+        return "crossref_no_fallback_title"
+
+    @property
+    def _event_fallback_attempt(self) -> str:
+        """Return log event name for fallback attempt."""
+        return "crossref_title_fallback_attempt"
+
+    @property
+    def _event_fallback_success(self) -> str:
+        """Return log event name for successful fallback."""
+        return "crossref_title_fallback_success"
+
+    @property
+    def _event_fallback_not_found(self) -> str:
+        """Return log event name for failed fallback."""
+        return "crossref_title_fallback_not_found"
+
+    async def _search_by_title(self, title: str) -> dict[str, Any] | None:
+        """Search for a publication by title.
+
+        Args:
+            title: Publication title to search for.
+
+        Returns:
+            First relevant publication or None.
+        """
+        return await self.search_by_title(title)
+
+    def _get_result_identifier(self, result: dict[str, Any]) -> tuple[str, str]:
+        """Return CrossRef DOI for logging."""
+        return ("found_doi", str(result.get("DOI", "unknown")))
 
     async def search_by_title(
         self,
@@ -90,53 +127,3 @@ class TitleFallbackHandler:
             )
 
         return None
-
-    def _get_fallback_title(
-        self, doi: str, normalized_doi: str, fallback_mapping: dict[str, str]
-    ) -> str | None:
-        """Get fallback title for a DOI from mapping."""
-        return fallback_mapping.get(doi) or fallback_mapping.get(normalized_doi)
-
-    def _truncate_title(self, title: str, max_len: int = 50) -> str:
-        """Truncate title for logging."""
-        return title[:max_len] + "..." if len(title) > max_len else title
-
-    async def process_missing_dois(
-        self,
-        dois: list[str],
-        found_dois: set[str],
-        fallback_mapping: dict[str, str],
-        normalize_fn: Callable[[str], str | None],
-        limit: int | None,
-        fetched: int,
-    ) -> AsyncIterator[dict[str, Any]]:
-        """Process DOIs not found via batch fetch using title fallback."""
-        for doi in dois:
-            if limit and fetched >= limit:
-                return
-            normalized_doi = (normalize_fn(doi) or "").lower()
-            if normalized_doi in found_dois:
-                continue
-            title = self._get_fallback_title(doi, normalized_doi, fallback_mapping)
-            if not title:
-                self._logger.debug("crossref_no_fallback_title", doi=doi)
-                continue
-            self._logger.info(
-                "crossref_title_fallback_attempt",
-                doi=doi,
-                title=self._truncate_title(title),
-            )
-            publication = await self.search_by_title(title)
-            if publication:
-                self._logger.info(
-                    "crossref_title_fallback_success",
-                    original_doi=doi,
-                    found_doi=publication.get("DOI"),
-                    title=title[:50],
-                )
-                yield publication
-                fetched += 1
-            else:
-                self._logger.warning(
-                    "crossref_title_fallback_not_found", doi=doi, title=title[:50]
-                )

--- a/src/bioetl/infrastructure/adapters/openalex/fallback.py
+++ b/src/bioetl/infrastructure/adapters/openalex/fallback.py
@@ -5,15 +5,17 @@ Provides title-based search fallback when DOI resolution fails.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
+
+from bioetl.infrastructure.adapters.common import BaseTitleFallbackHandler
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Callable
+    from collections.abc import Callable
 
     from bioetl.domain.ports import LoggerPort
 
 
-class TitleFallbackHandler:
+class TitleFallbackHandler(BaseTitleFallbackHandler):
     """Handles fallback search by title when DOI lookup fails.
 
     Extracts fallback logic to reduce main class size and cyclomatic complexity.
@@ -30,77 +32,57 @@ class TitleFallbackHandler:
             logger: Logger port for structured logging.
             search_fn: Async function to search works by title.
         """
-        self._logger = logger
+        super().__init__(logger)
         self._search_fn = search_fn
 
-    def _get_fallback_title(
-        self, doi: str, normalized_doi: str | None, fallback_mapping: dict[str, str]
-    ) -> str | None:
-        """Get fallback title for a DOI from mapping."""
-        if normalized_doi:
-            return fallback_mapping.get(doi) or fallback_mapping.get(normalized_doi)
-        return fallback_mapping.get(doi)
+    @property
+    def _event_no_fallback_title(self) -> str:
+        """Return log event name for missing fallback title."""
+        return "openalex_no_fallback_title"
 
-    def _truncate_title(self, title: str, max_len: int = 50) -> str:
-        """Truncate title for logging."""
-        return title[:max_len] + "..." if len(title) > max_len else title
+    @property
+    def _event_fallback_attempt(self) -> str:
+        """Return log event name for fallback attempt."""
+        return "openalex_title_fallback_attempt"
 
-    async def process_missing_dois(
-        self,
-        dois: list[str],
-        found_dois: set[str],
-        fallback_mapping: dict[str, str],
-        normalize_fn: Callable[[str], str | None],
-        limit: int | None,
-        fetched: int,
-    ) -> AsyncIterator[dict[str, Any]]:
-        """Process DOIs not found via batch fetch using title fallback.
+    @property
+    def _event_fallback_success(self) -> str:
+        """Return log event name for successful fallback."""
+        return "openalex_title_fallback_success"
+
+    @property
+    def _event_fallback_not_found(self) -> str:
+        """Return log event name for failed fallback."""
+        return "openalex_title_fallback_not_found"
+
+    async def _search_by_title(self, title: str) -> dict[str, Any] | None:
+        """Search for work by title using OpenAlex API.
 
         Args:
-            dois: List of DOIs that were requested.
-            found_dois: Set of DOIs that were successfully resolved (lowercase).
-            fallback_mapping: Mapping {doi: title} for fallback search.
-            normalize_fn: Function to normalize DOI strings.
-            limit: Maximum total records to return.
-            fetched: Number of records already fetched.
+            title: Publication title to search for.
 
-        Yields:
-            Work records found via title search with _lookup_method set.
+        Returns:
+            Work record if found, None otherwise.
         """
-        for doi in dois:
-            if limit and fetched >= limit:
-                return
+        result = await self._search_fn(title, 3)
+        return cast(dict[str, Any] | None, result)
 
-            normalized_doi = (normalize_fn(doi) or "").lower()
-            if normalized_doi in found_dois:
-                continue
+    def _get_result_identifier(self, result: dict[str, Any]) -> tuple[str, str]:
+        """Return OpenAlex work ID for logging."""
+        return ("found_id", str(result.get("id", "unknown")))
 
-            title = self._get_fallback_title(doi, normalized_doi, fallback_mapping)
-            if not title:
-                self._logger.debug("openalex_no_fallback_title", doi=doi)
-                continue
+    def _process_found_result(
+        self, result: dict[str, Any], original_doi: str
+    ) -> dict[str, Any]:
+        """Add lookup method metadata to found work.
 
-            self._logger.info(
-                "openalex_title_fallback_attempt",
-                doi=doi,
-                title=self._truncate_title(title),
-            )
+        Args:
+            result: The found work record.
+            original_doi: The DOI that was originally searched.
 
-            work = await self._search_fn(title, 3)
-            if work:
-                self._logger.info(
-                    "openalex_title_fallback_success",
-                    original_doi=doi,
-                    found_id=work.get("id"),
-                    title=title[:50],
-                )
-                work["_lookup_method"] = "title_fallback"
-                work["_original_doi"] = doi
-                yield work
-                fetched += 1
-            else:
-                self._logger.warning(
-                    "openalex_title_fallback_not_found",
-                    doi=doi,
-                    title=title[:50],
-                )
+        Returns:
+            Work with _lookup_method and _original_doi added.
+        """
+        result["_lookup_method"] = "title_fallback"
+        result["_original_doi"] = original_doi
+        return result

--- a/tests/architecture/test_code_metrics.py
+++ b/tests/architecture/test_code_metrics.py
@@ -52,7 +52,6 @@ class TestFileSizeLimits:
         "pipeline_run.py": 600,  # 581 LOC - PipelineRun aggregate with state machine
         "quarantine_entry.py": 520,  # 501 LOC - QuarantineEntry with detailed error info
         "chemical.py": 330,  # 326 LOC - Chemical structure Value Objects (InChIKey, SMILES, PublicationYear)
-        "validation.py": 330,  # 326 LOC - Domain validation utilities
         "activity_values.py": 450,  # 436 LOC - Activity value objects (renamed from measurements.py)
         # Domain ports NoOp implementations
         "noop.py": 400,  # 383 LOC - NoOp implementations for Null Object Pattern (+ NoOpPiiHasher)


### PR DESCRIPTION
…ation

Create common module with BaseTitleFallbackHandler that provides shared functionality for title-based DOI resolution fallback. Both OpenAlex and CrossRef TitleFallbackHandler classes now inherit from this base class, eliminating code duplication of utility methods and process_missing_dois template method.

Changes:
- Create src/bioetl/infrastructure/adapters/common/ module
- Implement BaseTitleFallbackHandler with template method pattern
- Refactor OpenAlex TitleFallbackHandler to inherit from base
- Refactor CrossRef TitleFallbackHandler to inherit from base