### PR TITLE
Remove dead and unused code from project

### DIFF
--- a/src/bioetl/composition/providers/provider_registry.py
+++ b/src/bioetl/composition/providers/provider_registry.py
@@ -311,12 +311,3 @@ class ProviderRegistry:
     def clear(cls) -> None:
         """Очищает реестр. Используется для тестов."""
         cls._providers.clear()
-
-    @classmethod
-    def _reset_for_testing(cls) -> None:
-        """Сбрасывает реестр для изолированного тестирования.
-
-        Warning:
-            Только для использования в тестах!
-        """
-        cls.clear()

--- a/src/bioetl/composition/providers/registration.py
+++ b/src/bioetl/composition/providers/registration.py
@@ -102,17 +102,6 @@ def _get_circuit_breaker_from_config(provider: str) -> tuple[int, int]:
     return 5, 300
 
 
-def _get_page_size_from_config(provider: str, default: int = 1000) -> int:
-    """Get page size from config for paginated APIs (e.g., ChEMBL).
-
-    DEPRECATED: Use _get_adapter_config() instead.
-    """
-    source_config = _get_source_config(provider)
-    if source_config and source_config.page_size is not None:
-        return source_config.page_size
-    return default
-
-
 def _get_adapter_config(provider: str, default_page_size: int = 1000) -> AdapterConfig:
     """Get AdapterConfig from source YAML config.
 

--- a/src/bioetl/infrastructure/adapters/base.py
+++ b/src/bioetl/infrastructure/adapters/base.py
@@ -52,7 +52,6 @@ class BaseHttpAdapter(HealthCheckMixin, DataSourcePort):
 
     Error Handling:
     - _error_handler: Provides unified error classification, logging, and wrapping
-    - _handle_adapter_error(): Template method for consistent error handling
 
     Attributes:
         http_client: UnifiedHTTPClient instance for making HTTP requests.
@@ -236,36 +235,3 @@ class BaseHttpAdapter(HealthCheckMixin, DataSourcePort):
             "circuit_breaker_state": cb_state,
             "circuit_breaker_failures": cb_failures,
         }
-
-    def _handle_adapter_error(
-        self,
-        error: Exception,
-        operation: str = "fetch",
-        context: dict[str, Any] | None = None,
-    ) -> None:
-        """Handle adapter error with unified logging and wrapping.
-
-        Logs error with full context and raises appropriate exception.
-        Uses ErrorHandler for consistent behavior across all adapters.
-
-        Args:
-            error: The exception that occurred.
-            operation: Operation that failed (e.g., 'fetch', 'health_check').
-            context: Additional context (status_code, retry_count, etc.).
-
-        Raises:
-            CriticalError: For authentication failures (401, 403).
-            ExternalServiceError: For other errors.
-        """
-        ctx = self._get_error_context(operation)
-        if context:
-            ctx.update(context)
-
-        # Let ErrorHandler log and wrap the error
-        wrapped = self._error_handler.handle_error(
-            error=error,
-            provider=self.provider_name,
-            operation=operation,
-            context=ctx,
-        )
-        raise wrapped from error

--- a/src/bioetl/infrastructure/adapters/sync_base.py
+++ b/src/bioetl/infrastructure/adapters/sync_base.py
@@ -56,7 +56,6 @@ class BaseSyncAdapter(HealthCheckMixin, DataSourcePort):
 
     Error Handling:
     - _error_handler: Provides unified error classification, logging, and wrapping
-    - _handle_adapter_error(): Template method for consistent error handling
 
     Attributes:
         provider_name: Unique identifier for the data provider.
@@ -245,36 +244,3 @@ class BaseSyncAdapter(HealthCheckMixin, DataSourcePort):
             "circuit_breaker_state": cb_state,
             "circuit_breaker_failures": cb_failures,
         }
-
-    def _handle_adapter_error(
-        self,
-        error: Exception,
-        operation: str = "fetch",
-        context: dict[str, Any] | None = None,
-    ) -> None:
-        """Handle adapter error with unified logging and wrapping.
-
-        Logs error with full context and raises appropriate exception.
-        Uses ErrorHandler for consistent behavior across all adapters.
-
-        Args:
-            error: The exception that occurred.
-            operation: Operation that failed (e.g., 'fetch', 'health_check').
-            context: Additional context (status_code, retry_count, etc.).
-
-        Raises:
-            CriticalError: For authentication failures (401, 403).
-            ExternalServiceError: For other errors.
-        """
-        ctx = self._get_error_context(operation)
-        if context:
-            ctx.update(context)
-
-        # Let ErrorHandler log and wrap the error
-        wrapped = self._error_handler.handle_error(
-            error=error,
-            provider=self.provider_name,
-            operation=operation,
-            context=ctx,
-        )
-        raise wrapped from error

--- a/tests/architecture/test_code_metrics.py
+++ b/tests/architecture/test_code_metrics.py
@@ -52,7 +52,6 @@ class TestFileSizeLimits:
         "pipeline_run.py": 600,  # 581 LOC - PipelineRun aggregate with state machine
         "quarantine_entry.py": 520,  # 501 LOC - QuarantineEntry with detailed error info
         "chemical.py": 330,  # 326 LOC - Chemical structure Value Objects (InChIKey, SMILES, PublicationYear)
-        "validation.py": 330,  # 326 LOC - Domain validation utilities
         "activity_values.py": 450,  # 436 LOC - Activity value objects (renamed from measurements.py)
         # Domain ports NoOp implementations
         "noop.py": 400,  # 383 LOC - NoOp implementations for Null Object Pattern (+ NoOpPiiHasher)


### PR DESCRIPTION
Dead code removed:
- _get_page_size_from_config (deprecated, never called)
- _reset_for_testing (never called, clear() is sufficient)
- _handle_adapter_error (template method never implemented)

Also fixed duplicate validation.py key in test_code_metrics.py.

Verified:
- All lint checks pass (ruff + mypy)
- All unit and architecture tests pass
- Module imports work correctly

Removed 89 lines of dead code.