### PR TITLE
Fix missing BioETL test coverage

### DIFF
--- a/tests/security/test_security.py
+++ b/tests/security/test_security.py
@@ -330,6 +330,7 @@ class TestPIIHandling:
             "pipeline_config.py",  # NCBI API source config
             "client.py",  # User-Agent header identification
             "source_config.py",  # NCBI API default_email for PubMed
+            "batch.py",  # CrossRef mailto for polite pool access (higher rate limits)
         }
     )
 


### PR DESCRIPTION
Add CrossRef batch.py to KNOWN_TECHNICAL_EMAIL_FILES in security test. The mailto parameter in batch.py is used for API identification (polite pool access for higher rate limits), not user PII.

This fixes a false positive skip in test_silver_layer_uses_hashing.