### PR TITLE
Fix failing architecture and complexity checks

### DIFF
--- a/tests/architecture/test_docs_version_sync.py
+++ b/tests/architecture/test_docs_version_sync.py
@@ -177,12 +177,12 @@ class TestDocsVersionSync:
 
         Исключения:
         - docs/archived/ - исторические документы
-        - docs/audits/ - отчёты аудитов (фиксируют версию на момент аудита)
+        - docs/audits/, docs/audit/ - отчёты аудитов (фиксируют версию на момент аудита)
         - docs/__-prompts/ - шаблоны промптов
         - Changelog/История изменений секции (версия в контексте истории)
         """
         # Директории для исключения
-        excluded_dirs = {"archived", "audits", "__-prompts", "audit-reports"}
+        excluded_dirs = {"archived", "audits", "audit", "__-prompts", "audit-reports"}
 
         outdated = []
         current_major_minor = tuple(map(int, rules_version.split(".")))


### PR DESCRIPTION
The audit directory was renamed from 'audits' to 'audit' but the test exclusion list wasn't updated, causing CI failures when checking for outdated version references in audit documentation files.