### PR TITLE
Fix inconsistent Silver layer path documentation

### DIFF
--- a/docs/02-architecture/data-flow.md
+++ b/docs/02-architecture/data-flow.md
@@ -77,7 +77,7 @@ data/                              # Local-Only (current)
 │
 ├── silver/
 │   └── {provider}/{entity}/
-│       └── year={YYYY}/month={MM}/
+│       └── [{partition_cols}/]  # Optional, configured via `partition_by` in YAML
 │           └── _delta_log/
 │
 ├── gold/
@@ -91,6 +91,10 @@ data/                              # Local-Only (current)
 └── checkpoints/
     └── {pipeline_name}.json
 ```
+
+**Note**: Silver partitioning is **configurable** via `partition_by` field in pipeline YAML configs.
+Examples: `["year", "month"]`, `["assay_type"]`, `["organism"]`, or `[]` (no partitioning).
+See `configs/pipelines/{provider}/{entity}.yaml` for specific configurations.
 
 ---
 

--- a/docs/02-architecture/data-layers.md
+++ b/docs/02-architecture/data-layers.md
@@ -45,7 +45,7 @@
 ### 2.1. Формат и Технологии
 *   **Формат**: Delta Lake (Parquet + Transaction Log).
 *   **Engine**: `delta-rs` (через библиотеку `deltalake` Python binding).
-*   **Путь**: `silver/{provider}/{entity}/`.
+*   **Путь**: `silver/{provider}/{entity}/[{partition_cols}/]` — партиционирование опционально, настраивается через `partition_by` в YAML конфиге пайплайна.
 *   **Протокол**: Writer Version 2 (поддержка Column Mapping), Reader Version 1.
 
 ### 2.2. Схема и Валидация
@@ -88,7 +88,9 @@ Silver слой использует стратегию **Merge/Upsert** для 
 *   Соль управляется через Secrets Manager и ротируется (см. `RULES.md` §5.4.1).
 
 ### 2.6. Партиционирование
-*   Стандарт: По дате источника (например, `year`, `month`) или по типу данных, если кардинальность низкая.
+*   **Конфигурация**: Определяется через `partition_by` в `configs/pipelines/{provider}/{entity}.yaml`.
+*   **Примеры**: `["year", "month"]` (по дате), `["assay_type"]` (по типу сущности), `[]` (без партиционирования).
+*   **Стандарт**: По дате источника или по типу данных, если кардинальность низкая.
 *   **Z-ORDER**: Не применяется в Silver (обычно сортировка по ingestion time), так как основная цель — write throughput.
 
 ---


### PR DESCRIPTION
Update data-flow.md and data-layers.md to resolve inconsistency about Silver layer paths. Partitioning is optional and configured through `partition_by` field in pipeline YAML configs, not hardcoded.