### PR TITLE
Refactor transformers to use DataNormalizationService

### DIFF
--- a/src/bioetl/application/pipelines/openalex/transformer.py
+++ b/src/bioetl/application/pipelines/openalex/transformer.py
@@ -28,7 +28,6 @@ from bioetl.application.pipelines.openalex.extractors import (
     reconstruct_abstract,
 )
 from bioetl.domain.entities.openalex import OPENALEX_TYPE_MAP, OpenAlexPublicationEntity
-from bioetl.domain.normalization import strip_html_tags
 from bioetl.domain.services import DataNormalizationService, IdentityService
 from bioetl.domain.validation import validate_year_range
 
@@ -131,7 +130,9 @@ class OpenAlexPublicationTransformer(BasePublicationTransformer):
 
         # Reconstruct abstract from inverted index (then strip HTML for cleaning)
         abstract_index = rec.get("abstract_inverted_index")
-        abstract = strip_html_tags(reconstruct_abstract(abstract_index))
+        abstract = self._data_normalizer.strip_html_tags(
+            reconstruct_abstract(abstract_index)
+        )
 
         # Extract and hash authors (PII)
         # Authors stored as JSON-serialized list for unified format across providers

--- a/src/bioetl/application/pipelines/pubmed/transformer.py
+++ b/src/bioetl/application/pipelines/pubmed/transformer.py
@@ -21,7 +21,6 @@ from bioetl.application.pipelines.pubmed.extractors import (
 )
 from bioetl.application.pipelines.pubmed.xml_utils import get_text
 from bioetl.domain.entities import Publication
-from bioetl.domain.normalization import strip_html_tags
 from bioetl.domain.services import DataNormalizationService, IdentityService
 
 if TYPE_CHECKING:
@@ -168,7 +167,9 @@ class PubMedPublicationTransformer(BasePublicationTransformer):
             "pmid": pmid,
             "doi": normalized_doi,
             "title": get_text(article.find(".//ArticleTitle")),
-            "abstract": strip_html_tags(AbstractExtractor.extract_abstract(article)),
+            "abstract": self._data_normalizer.strip_html_tags(
+                AbstractExtractor.extract_abstract(article)
+            ),
             "authors": self.serialize_json_list(hashed_authors),
             **journal_data,
             **date_data,

--- a/src/bioetl/application/pipelines/semanticscholar/transformer.py
+++ b/src/bioetl/application/pipelines/semanticscholar/transformer.py
@@ -20,7 +20,6 @@ from bioetl.application.pipelines.semanticscholar.extractors import (
     validate_year,
 )
 from bioetl.domain.entities.semanticscholar import SemanticScholarPublicationEntity
-from bioetl.domain.normalization import strip_html_tags
 from bioetl.domain.services import DataNormalizationService
 
 if TYPE_CHECKING:
@@ -162,7 +161,7 @@ class SemanticScholarPublicationTransformer(BasePublicationTransformer):
             "arxiv_id": external_ids.get("arxiv"),
             "corpus_id": external_ids.get("corpus_id"),
             "title": rec.get("title"),
-            "abstract": strip_html_tags(rec.get("abstract")),
+            "abstract": self._data_normalizer.strip_html_tags(rec.get("abstract")),
             "tldr": tldr,
             "authors": self.serialize_json_list(hashed_authors),
             "journal": journal_info.get("journal_name"),


### PR DESCRIPTION
…_tags

Replace direct imports of strip_html_tags from domain.normalization with calls through DataNormalizationService via DI in three transformers:

- OpenAlex: use self._data_normalizer.strip_html_tags()
- SemanticScholar: use self._data_normalizer.strip_html_tags()
- PubMed: use self._data_normalizer.strip_html_tags()

This aligns with Hexagonal Architecture by using dependency injection instead of direct function imports, matching the pattern already established in CrossRef transformer.