### PR TITLE
Use constants for year validation in entity

### DIFF
--- a/src/bioetl/application/pipelines/openalex/transformer.py
+++ b/src/bioetl/application/pipelines/openalex/transformer.py
@@ -21,7 +21,6 @@ from bioetl.application.pipelines.common import BasePublicationTransformer
 from bioetl.application.pipelines.openalex.extractors import (
     extract_authors,
     extract_concepts,
-    extract_doi,
     extract_journal_info,
     extract_open_access_info,
     extract_openalex_id,
@@ -123,10 +122,9 @@ class OpenAlexPublicationTransformer(BasePublicationTransformer):
         # Extract OpenAlex ID from URL
         openalex_id = extract_openalex_id(rec.get("id"))
 
-        # Extract bare DOI from URL, then normalize (lowercase, stripped)
-        # for cross-provider consistency
-        raw_doi = extract_doi(rec.get("doi"))
-        doi = self._data_normalizer.normalize_doi(raw_doi)
+        # Normalize DOI (handles URL prefix stripping + lowercase/strip)
+        # OpenAlex stores DOIs as full URLs (e.g., "https://doi.org/10.1038/...")
+        doi = self._data_normalizer.normalize_doi(rec.get("doi"))
 
         # Reconstruct abstract from inverted index (then strip HTML for cleaning)
         abstract_index = rec.get("abstract_inverted_index")

--- a/src/bioetl/domain/entities/chembl_structures.py
+++ b/src/bioetl/domain/entities/chembl_structures.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from bioetl.domain.entities.base import BaseEntity
+from bioetl.domain.validation import MAX_PUBLICATION_YEAR, MIN_PUBLICATION_YEAR
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -54,8 +55,13 @@ class ChemblPublication(BaseEntity):
     def _validate_invariants(self) -> None:
         if not self.document_chembl_id:
             raise ValueError("ChemblPublication document_chembl_id is required")
-        if self.year is not None and (self.year < 1800 or self.year > 2100):
-            raise ValueError(f"Year must be between 1800-2100, got {self.year}")
+        if self.year is not None and not (
+            MIN_PUBLICATION_YEAR <= self.year <= MAX_PUBLICATION_YEAR
+        ):
+            raise ValueError(
+                f"Year must be between {MIN_PUBLICATION_YEAR}-{MAX_PUBLICATION_YEAR}, "
+                f"got {self.year}"
+            )
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/bioetl/domain/ports/data_normalization.py
+++ b/src/bioetl/domain/ports/data_normalization.py
@@ -47,14 +47,22 @@ class DataNormalizationPort(Protocol):
     def normalize_doi(self, doi: str | None) -> str | None:
         """Normalize DOI identifier to lowercase, stripped format.
 
+        Handles DOIs in various formats:
+        - Bare DOI: "10.1038/nature12373"
+        - HTTPS URL: "https://doi.org/10.1038/nature12373"
+        - HTTP URL: "http://doi.org/10.1038/nature12373"
+        - doi: prefix: "doi:10.1038/nature12373"
+
         Args:
-            doi: DOI string to normalize.
+            doi: DOI string in any supported format.
 
         Returns:
-            Normalized DOI (lowercase, stripped) or None if input is None/empty.
+            Normalized bare DOI (lowercase, stripped) or None if input is None/empty.
 
         Example:
             >>> normalize_doi("10.1038/NATURE12373")
+            '10.1038/nature12373'
+            >>> normalize_doi("https://doi.org/10.1038/nature12373")
             '10.1038/nature12373'
             >>> normalize_doi("  10.1038/nature12373  ")
             '10.1038/nature12373'

--- a/src/bioetl/domain/services/data_normalization_service.py
+++ b/src/bioetl/domain/services/data_normalization_service.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 _HTML_TAG_PATTERN = re.compile(r"<[^>]+>")
 _WHITESPACE_PATTERN = re.compile(r"\s+")
 _DATE_FORMATS = {3: "{0:04d}-{1:02d}-{2:02d}", 2: "{0:04d}-{1:02d}", 1: "{0:04d}"}
+_DOI_URL_PREFIXES = ("https://doi.org/", "http://doi.org/", "doi:")
 
 
 @dataclass(frozen=True, slots=True)
@@ -32,8 +33,32 @@ class DefaultDataNormalizationService:
     config: DataNormalizationConfig = field(default_factory=DataNormalizationConfig)
 
     def normalize_doi(self, doi: str | None) -> str | None:
-        """Normalize DOI to lowercase, stripped format."""
-        return doi.strip().lower() if doi else None
+        """Normalize DOI to lowercase, stripped format.
+
+        Handles DOIs in various formats:
+        - Bare DOI: "10.1038/nature12373"
+        - HTTPS URL: "https://doi.org/10.1038/nature12373"
+        - HTTP URL: "http://doi.org/10.1038/nature12373"
+        - doi: prefix: "doi:10.1038/nature12373"
+
+        Args:
+            doi: DOI string in any supported format.
+
+        Returns:
+            Normalized bare DOI (lowercase, stripped) or None if input is None/empty.
+        """
+        if not doi:
+            return None
+        stripped = self._strip_doi_prefix(doi)
+        result = stripped.strip().lower()
+        return result if result else None
+
+    def _strip_doi_prefix(self, doi: str) -> str:
+        """Strip known DOI URL prefixes (https://doi.org/, http://doi.org/, doi:)."""
+        for prefix in _DOI_URL_PREFIXES:
+            if doi.startswith(prefix):
+                return doi[len(prefix) :]
+        return doi
 
     def normalize_pmid(self, pmid: str | int | None) -> str | None:
         """Normalize PubMed ID to string format. Returns None for invalid inputs."""


### PR DESCRIPTION
…zation

- Use MIN_PUBLICATION_YEAR and MAX_PUBLICATION_YEAR constants in ChemblPublication entity instead of hardcoded 1800/2100 values
- Extend DataNormalizationService.normalize_doi() to handle URL prefix stripping (https://doi.org/, http://doi.org/, doi:) in addition to lowercase/strip normalization
- Update OpenAlex transformer to delegate DOI normalization entirely to DataNormalizationService instead of using extract_doi() + normalize_doi()
- Update DataNormalizationPort docstring to document new capabilities