### PR TITLE
Convert molecular weight to float type

### DIFF
--- a/src/bioetl/application/pipelines/pubchem/transformer.py
+++ b/src/bioetl/application/pipelines/pubchem/transformer.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any, cast
 from bioetl.application.core.base_transformer import BaseTransformer
 from bioetl.domain.entities import PubchemMolecule
 from bioetl.domain.services import IdentityService
-from bioetl.domain.transformations import safe_float
+from bioetl.domain.validation import validate_molecular_weight
 
 if TYPE_CHECKING:
     from bioetl.domain.context import PipelineContext
@@ -89,12 +89,8 @@ class PubChemCompoundTransformer(BaseTransformer):
         cid = self._get_required_field(record, "cid")
 
         # Step 2: Build business data dictionary
-        # Convert molecular_weight to float with deterministic rounding (RULES.md §2.8.1)
-        raw_mw = record.get("molecular_weight")
-        mol_weight = safe_float(raw_mw)
-        # Apply deterministic rounding and validate range (negative MW is invalid)
-        if mol_weight is not None:
-            mol_weight = None if mol_weight < 0 else round(mol_weight, 10)
+        # Validate and convert molecular_weight (handles string→float, range, precision)
+        mol_weight = validate_molecular_weight(record.get("molecular_weight"))
         business_data: dict[str, Any] = {
             "cid": str(cid),
             "molecular_formula": record.get("molecular_formula"),

--- a/src/bioetl/domain/validation.py
+++ b/src/bioetl/domain/validation.py
@@ -214,6 +214,60 @@ def validate_non_negative(value: Any) -> float | None:
 
 
 # =============================================================================
+# Molecular Weight Validation
+# =============================================================================
+
+# Molecular weight valid range:
+# - Min: > 0 (must be positive)
+# - Max: 100000 Da (covers small molecules ~100-1000 Da to large proteins ~50000 Da)
+# Reference: PubChem compound MW typically ranges from ~10 to ~5000 Da
+MIN_MOLECULAR_WEIGHT: float = 0.0
+MAX_MOLECULAR_WEIGHT: float = 100000.0
+
+
+def validate_molecular_weight(value: Any) -> float | None:
+    """Validate and convert molecular weight to float.
+
+    Handles string-to-float conversion (PubChem API may return strings)
+    and validates the range. Precision is 10 decimals per RULES.md §2.8.1.
+
+    Valid range: 0 < mw < 100000 (covers small molecules to large proteins).
+
+    Args:
+        value: Raw molecular weight value (string, int, float, or None).
+
+    Returns:
+        Valid float rounded to 10 decimals, or None if invalid/out of range.
+
+    Example:
+        >>> validate_molecular_weight(180.156)
+        180.156
+        >>> validate_molecular_weight("342.30")  # String from API
+        342.3
+        >>> validate_molecular_weight(0)  # Zero is invalid
+        None
+        >>> validate_molecular_weight(-1.0)  # Negative is invalid
+        None
+        >>> validate_molecular_weight(100001)  # Too large
+        None
+        >>> validate_molecular_weight(None)
+        None
+        >>> validate_molecular_weight("invalid")
+        None
+
+    """
+    if value is None:
+        return None
+    try:
+        mw = float(value)
+        if MIN_MOLECULAR_WEIGHT < mw < MAX_MOLECULAR_WEIGHT:
+            return round(mw, 10)
+        return None
+    except (ValueError, TypeError):
+        return None
+
+
+# =============================================================================
 # String Validation
 # =============================================================================
 

--- a/tests/unit/application/pipelines/test_pubchem_transformer.py
+++ b/tests/unit/application/pipelines/test_pubchem_transformer.py
@@ -349,7 +349,7 @@ class TestPubChemCompoundTransformer:
 
     @pytest.mark.asyncio
     async def test_transform_molecular_weight_zero(self, transformer, mock_context):
-        """Test that zero molecular_weight is preserved."""
+        """Test that zero molecular_weight returns None (invalid: must be > 0)."""
         record = {
             "cid": 2244,
             "molecular_weight": "0",
@@ -359,7 +359,8 @@ class TestPubChemCompoundTransformer:
         result = await transformer.transform(mock_context, record, index=0)
 
         assert result is not None
-        assert result["molecular_weight"] == 0.0
+        # Zero MW is invalid per validate_molecular_weight (range: 0 < mw < 100000)
+        assert result["molecular_weight"] is None
 
     @pytest.mark.asyncio
     async def test_transform_molecular_weight_precision(

--- a/tests/unit/domain/test_validation.py
+++ b/tests/unit/domain/test_validation.py
@@ -8,10 +8,13 @@ from __future__ import annotations
 import pytest
 
 from bioetl.domain.validation import (
+    MAX_MOLECULAR_WEIGHT,
     MAX_PUBLICATION_YEAR,
+    MIN_MOLECULAR_WEIGHT,
     MIN_PUBLICATION_YEAR,
     validate_doi,
     validate_inchi_key,
+    validate_molecular_weight,
     validate_non_empty_string,
     validate_non_negative,
     validate_positive_int,
@@ -249,6 +252,117 @@ class TestValidateNonNegative:
     def test_invalid_non_negative(self, value) -> None:
         """Test invalid values return None."""
         assert validate_non_negative(value) is None
+
+
+class TestMolecularWeightConstants:
+    """Tests for molecular weight constants."""
+
+    def test_min_molecular_weight_value(self) -> None:
+        """Test MIN_MOLECULAR_WEIGHT is set to 0.0."""
+        assert MIN_MOLECULAR_WEIGHT == 0.0
+
+    def test_max_molecular_weight_value(self) -> None:
+        """Test MAX_MOLECULAR_WEIGHT is set to 100000.0."""
+        assert MAX_MOLECULAR_WEIGHT == 100000.0
+
+    def test_constants_are_valid_range(self) -> None:
+        """Test that min < max for valid range."""
+        assert MIN_MOLECULAR_WEIGHT < MAX_MOLECULAR_WEIGHT
+
+
+class TestValidateMolecularWeight:
+    """Tests for validate_molecular_weight function.
+
+    Validates molecular weight with:
+    - String to float conversion (PubChem API returns strings)
+    - Range validation: 0 < mw < 100000
+    - Precision: 10 decimals per RULES.md §2.8.1
+    """
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            # Standard float values
+            (180.156, 180.156),
+            (342.3, 342.3),
+            (12.0, 12.0),
+            (99999.9, 99999.9),
+            # Integer values
+            (100, 100.0),
+            (500, 500.0),
+            # String values (PubChem API format)
+            ("180.156", 180.156),
+            ("342.30", 342.3),
+            ("100", 100.0),
+            # Edge cases near boundaries
+            (0.001, 0.001),  # Just above 0
+            (99999.999, 99999.999),  # Just below max
+        ],
+    )
+    def test_valid_molecular_weight(self, value, expected: float) -> None:
+        """Test valid molecular weights are converted and returned."""
+        assert validate_molecular_weight(value) == expected
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            # Zero and negative
+            0,
+            0.0,
+            -1,
+            -0.001,
+            -100.5,
+            # Too large (>= 100000)
+            100000,
+            100000.0,
+            100001,
+            150000.5,
+            # Invalid types
+            None,
+            "invalid",
+            "",
+            "abc",
+            # Edge cases
+            float("inf"),
+            float("-inf"),
+        ],
+    )
+    def test_invalid_molecular_weight(self, value) -> None:
+        """Test invalid values return None."""
+        assert validate_molecular_weight(value) is None
+
+    def test_nan_returns_none(self) -> None:
+        """Test NaN returns None (comparison with NaN is always False)."""
+        result = validate_molecular_weight(float("nan"))
+        assert result is None
+
+    def test_precision_10_decimals(self) -> None:
+        """Test molecular weight is rounded to 10 decimals per RULES.md §2.8.1."""
+        # Value with many decimals should be rounded
+        result = validate_molecular_weight(180.12345678901234567890)
+        assert result is not None
+        # Check precision is 10 decimals
+        assert result == round(180.12345678901234567890, 10)
+
+    def test_string_conversion_from_api(self) -> None:
+        """Test string values from PubChem API are properly converted."""
+        # PubChem may return molecular weight as string
+        assert validate_molecular_weight("180.156") == 180.156
+        assert validate_molecular_weight("  342.30  ") == 342.3  # Whitespace handled
+
+    def test_boundary_values(self) -> None:
+        """Test boundary values for molecular weight validation."""
+        # Just above 0 (valid)
+        assert validate_molecular_weight(0.0000000001) is not None
+
+        # At 0 (invalid - must be > 0)
+        assert validate_molecular_weight(0) is None
+
+        # Just below max (valid)
+        assert validate_molecular_weight(99999.9999999999) is not None
+
+        # At max (invalid - must be < 100000)
+        assert validate_molecular_weight(100000) is None
 
 
 class TestValidateNonEmptyString:


### PR DESCRIPTION
Add validation function to handle molecular weight conversion from PubChem API:
- Converts string values to float (API may return strings)
- Validates range: 0 < mw < 100000 (small molecules to large proteins)
- Applies 10 decimal precision per RULES.md §2.8.1
- Returns None for invalid/out-of-range values

Apply validation in PubChemCompoundTransformer and update tests accordingly.