### PR TITLE
Fix PMID type mismatch between entities and schemas

### DIFF
--- a/src/bioetl/domain/entities/chembl.py
+++ b/src/bioetl/domain/entities/chembl.py
@@ -539,7 +539,9 @@ class DocumentRecord(BaseModel):
     document_chembl_id: str = Field(description="Unique document ChEMBL ID")
 
     # Publication identifiers
-    pubmed_id: int | None = Field(default=None, description="PubMed ID")
+    pubmed_id: str | None = Field(
+        default=None, description="PubMed ID (numeric string)"
+    )
     doi: str | None = Field(default=None, description="Digital Object Identifier")
     patent_id: str | None = Field(default=None, description="Patent ID")
 

--- a/src/bioetl/domain/entities/chembl_structures.py
+++ b/src/bioetl/domain/entities/chembl_structures.py
@@ -26,7 +26,7 @@ class ChemblPublication(BaseEntity):
     document_chembl_id: str
 
     # Publication identifiers
-    pubmed_id: int | None = None
+    pubmed_id: str | None = None  # Numeric string for cross-provider consistency
     doi: str | None = None
     patent_id: str | None = None
 

--- a/src/bioetl/infrastructure/adapters/chembl/models.py
+++ b/src/bioetl/infrastructure/adapters/chembl/models.py
@@ -473,7 +473,9 @@ class ChemblDocumentRecord(BaseModel):
 
     # External IDs
     doi: str | None = Field(default=None, description="Digital Object Identifier")
-    pubmed_id: int | None = Field(default=None, description="PubMed ID")
+    pubmed_id: str | None = Field(
+        default=None, description="PubMed ID (numeric string)"
+    )
     patent_id: str | None = Field(default=None, description="Patent ID")
 
     # Source

--- a/tests/unit/domain/schemas/test_year_validation.py
+++ b/tests/unit/domain/schemas/test_year_validation.py
@@ -184,7 +184,7 @@ class TestChemblYearValidation:
             **base_etl_fields,
             "entity_id": "chembl:publication:CHEMBL1234567",
             "document_chembl_id": "CHEMBL1234567",
-            "pubmed_id": 12345678,
+            "pubmed_id": "12345678",
             "doi": "10.1038/nature12373",
             "patent_id": None,
             "src_id": 1,


### PR DESCRIPTION
BREAKING CHANGE: pubmed_id field type changed from int to str

- domain/entities/chembl_structures.py: ChemblPublication.pubmed_id int → str
- domain/entities/chembl.py: DocumentRecord.pubmed_id int → str
- infrastructure/adapters/chembl/models.py: ChemblDocumentRecord.pubmed_id int → str
- Updated test fixture in test_year_validation.py to use string PMID

This aligns the entities and models with the schema definitions which already expect pubmed_id as a numeric string. The pmid_fields() converter in field_specs.py handles int → str conversion from raw API responses.

Cross-provider consistency is maintained since PubMed IDs are stored as strings in Silver/Gold tables (per infrastructure/schemas/silver.py).