### PR TITLE
Fix PMID type alignment in BioETL

### DIFF
--- a/src/bioetl/domain/entities/chembl_structures.py
+++ b/src/bioetl/domain/entities/chembl_structures.py
@@ -359,8 +359,8 @@ class DocumentSimilarity(BaseEntity):
     doc_2: int
 
     # === PubMed Identifiers ===
-    pubmed_id1: int | None = None
-    pubmed_id2: int | None = None
+    pubmed_id1: str | None = None  # Numeric string for cross-provider consistency
+    pubmed_id2: str | None = None  # Numeric string for cross-provider consistency
 
     # === Tanimoto Coefficients ===
     tid_tani: float | None = None  # Target-based


### PR DESCRIPTION
…rity

Completes the PMID type alignment by updating DocumentSimilarity entity fields to match Pandera/PyArrow schemas that expect string type.

- pubmed_id1: int | None → str | None
- pubmed_id2: int | None → str | None

This ensures consistency with:
- Pandera schemas (gold.py, document_similarity.py): Series[str]
- PyArrow schemas (silver.py): pa.string()
- Transformer normalize_pmid() output