### PR TITLE
Align PMID type across entity and schema

### DIFF
--- a/tests/unit/application/pipelines/test_chembl_pipelines.py
+++ b/tests/unit/application/pipelines/test_chembl_pipelines.py
@@ -153,7 +153,7 @@ class TestChEMBLDocumentPipeline:
         record = {
             "document_chembl_id": "CHEMBL789012",
             "title": "Test Document",
-            "pubmed_id": 12345678,
+            "pubmed_id": "12345678",
         }
 
         result = await pipeline.transform_bronze_to_silver(pipeline.context, record)

--- a/tests/unit/application/pipelines/test_chembl_transformers.py
+++ b/tests/unit/application/pipelines/test_chembl_transformers.py
@@ -190,7 +190,7 @@ class TestDocumentTransformer:
         """Test transformation of valid document record."""
         record = {
             "document_chembl_id": "CHEMBL1234567",
-            "pubmed_id": 12345678,
+            "pubmed_id": "12345678",
             "doi": "10.1000/test.doi",
             "title": "Test Document Title",
             "authors": "Test Author",
@@ -202,7 +202,6 @@ class TestDocumentTransformer:
 
         assert result is not None
         assert result["document_chembl_id"] == "CHEMBL1234567"
-        # PMID is normalized to string for cross-provider consistency
         assert result["pubmed_id"] == "12345678"
         assert result["doi"] == "10.1000/test.doi"
         assert result["year"] == 2024
@@ -214,7 +213,7 @@ class TestDocumentTransformer:
     async def test_transform_missing_document_id(self, transformer, mock_context):
         """Test transformation returns None when document_chembl_id is missing."""
         record = {
-            "pubmed_id": 12345678,
+            "pubmed_id": "12345678",
             "title": "Test Document",
         }
 
@@ -227,7 +226,7 @@ class TestDocumentTransformer:
         """Test transformation with all document fields."""
         record = {
             "document_chembl_id": "CHEMBL1234567",
-            "pubmed_id": 12345678,
+            "pubmed_id": "12345678",
             "doi": "10.1000/test",
             "patent_id": "US1234567",
             "title": "Full Title",

--- a/tests/unit/application/pipelines/test_transformer_snapshots.py
+++ b/tests/unit/application/pipelines/test_transformer_snapshots.py
@@ -183,7 +183,7 @@ class TestDocumentTransformerSnapshot:
     def sample_record(self) -> dict[str, Any]:
         return {
             "document_chembl_id": "CHEMBL1234567",
-            "pubmed_id": 12345678,
+            "pubmed_id": "12345678",
             "doi": "10.1000/test.doi",
             "title": "Test Document Title",
             "authors": "Test Author, Another Author",


### PR DESCRIPTION
Update test fixtures to use string values for pubmed_id to match the aligned str | None type in entity/DTO definitions. The PMID converter test in test_field_specs.py is preserved with integer input as it explicitly tests int→str conversion behavior.

Files updated:
- test_chembl_transformers.py: 3 fixtures
- test_chembl_pipelines.py: 1 fixture
- test_transformer_snapshots.py: 1 fixture