### PR TITLE
Fix failing architecture metrics checks

### DIFF
--- a/tests/unit/cli/__snapshots__/test_registry_consistency.ambr
+++ b/tests/unit/cli/__snapshots__/test_registry_consistency.ambr
@@ -7,11 +7,11 @@
     - chembl_assay_parameters
     - chembl_cell_line
     - chembl_compound_record
-    - chembl_document
-    - chembl_document_similarity
-    - chembl_document_term
     - chembl_molecule
     - chembl_protein_class
+    - chembl_publication
+    - chembl_publication_similarity
+    - chembl_publication_term
     - chembl_target
     - chembl_target_component
     - crossref_publication

--- a/tests/unit/cli/test_registry_consistency.py
+++ b/tests/unit/cli/test_registry_consistency.py
@@ -62,15 +62,37 @@ class TestChemblPipelinesRegistered:
 
         If this test fails, add the new pipeline to PIPELINE_CONFIGS in
         src/bioetl/composition/factories/pipeline_factories.py.
+
+        Note: Deprecated aliases (ADR-024) like ChEMBLDocumentPipeline that
+        point to the same class as their canonical counterpart (ChEMBLPublicationPipeline)
+        are excluded from the count to avoid double-counting.
         """
         # Import the chembl module to introspect exports
         from bioetl.application.pipelines import chembl as chembl_module
 
         # Get all exported names that end with 'Pipeline'
         chembl_exports = getattr(chembl_module, "__all__", [])
-        pipeline_classes = [
+        pipeline_class_names = [
             name for name in chembl_exports if name.endswith("Pipeline")
         ]
+
+        # Get unique pipeline classes (exclude aliases pointing to same class)
+        # This handles ADR-024 deprecated aliases like ChEMBLDocumentPipeline
+        # When the same class has multiple names, prefer the canonical name
+        # (Publication vs Document per ADR-024)
+        unique_classes: dict[type, str] = {}
+        for name in pipeline_class_names:
+            cls = getattr(chembl_module, name)
+            if cls not in unique_classes:
+                unique_classes[cls] = name
+            else:
+                # Prefer canonical names (Publication) over deprecated (Document)
+                existing_name = unique_classes[cls]
+                if "Document" in existing_name and "Publication" in name:
+                    unique_classes[cls] = name
+
+        # Use unique class names for counting
+        pipeline_classes = list(unique_classes.values())
 
         # Get registered ChEMBL pipelines
         registered_names = [

--- a/tests/unit/domain/schemas/test_doi_validation.py
+++ b/tests/unit/domain/schemas/test_doi_validation.py
@@ -137,13 +137,13 @@ class TestDoiRegexEdgeCases:
 class TestDoiSchemaIntegration:
     """Integration tests verifying DOI_REGEX_PATTERN is correctly imported in schemas."""
 
-    def test_chembl_document_uses_doi_regex_pattern(self) -> None:
+    def test_chembl_publication_uses_doi_regex_pattern(self) -> None:
         """Test ChEMBL ChemblPublicationSchema uses DOI_REGEX_PATTERN constant."""
-        from bioetl.domain.schemas.chembl import document
+        from bioetl.domain.schemas.chembl import publication
 
         # Verify the import exists
-        assert hasattr(document, "DOI_REGEX_PATTERN")
-        assert document.DOI_REGEX_PATTERN == DOI_REGEX_PATTERN
+        assert hasattr(publication, "DOI_REGEX_PATTERN")
+        assert publication.DOI_REGEX_PATTERN == DOI_REGEX_PATTERN
 
     def test_pubmed_article_uses_doi_regex_pattern(self) -> None:
         """Test PubMed ArticleSchema uses DOI_REGEX_PATTERN constant."""
@@ -187,7 +187,7 @@ class TestDoiSchemaIntegration:
 
     def test_all_schemas_use_consistent_pattern(self) -> None:
         """Test all schemas use the same DOI pattern value."""
-        from bioetl.domain.schemas.chembl import document
+        from bioetl.domain.schemas.chembl import publication as chembl_pub
         from bioetl.domain.schemas.crossref import publication as crossref_pub
         from bioetl.domain.schemas.crossref import work
         from bioetl.domain.schemas.openalex import publication as openalex_pub
@@ -195,7 +195,7 @@ class TestDoiSchemaIntegration:
         from bioetl.domain.schemas.semanticscholar import publication as s2_pub
 
         patterns = [
-            document.DOI_REGEX_PATTERN,
+            chembl_pub.DOI_REGEX_PATTERN,
             article.DOI_REGEX_PATTERN,
             s2_pub.DOI_REGEX_PATTERN,
             openalex_pub.DOI_REGEX_PATTERN,

--- a/tests/unit/domain/schemas/test_year_validation.py
+++ b/tests/unit/domain/schemas/test_year_validation.py
@@ -203,7 +203,7 @@ class TestChemblYearValidation:
 
     def test_year_boundary_values(self, valid_record: dict) -> None:
         """Should accept year at boundaries (1800 and 2100)."""
-        from bioetl.domain.schemas.chembl.document import ChemblPublicationSchema
+        from bioetl.domain.schemas.chembl.publication import ChemblPublicationSchema
 
         for year in [MIN_PUBLICATION_YEAR, MAX_PUBLICATION_YEAR]:
             valid_record["year"] = year
@@ -213,7 +213,7 @@ class TestChemblYearValidation:
 
     def test_year_outside_range_fails(self, valid_record: dict) -> None:
         """Should reject year outside valid range."""
-        from bioetl.domain.schemas.chembl.document import ChemblPublicationSchema
+        from bioetl.domain.schemas.chembl.publication import ChemblPublicationSchema
 
         # Year below minimum
         valid_record["year"] = MIN_PUBLICATION_YEAR - 1


### PR DESCRIPTION
…R-024)

- Update test_doi_validation.py to import from publication module
- Update test_year_validation.py to import from publication module
- Update registry consistency test to handle deprecated pipeline aliases
- Update snapshot for new pipeline names (chembl_publication_*)