### PR TITLE
Set up GitHub Actions CI/CD workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,162 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+  # Allow manual triggers for testing the build process
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (build only, no publish)'
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+jobs:
+  build:
+    name: Build Distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Clean previous builds
+        run: rm -rf dist/ build/ *.egg-info
+
+      - name: Build distribution packages
+        run: python -m build
+
+      - name: Verify distribution with twine
+        run: twine check dist/*
+
+      - name: List distribution artifacts
+        run: |
+          echo "Built artifacts:"
+          ls -la dist/
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 30
+
+  test-install:
+    name: Test Installation
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Install from wheel
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+
+      - name: Verify installation
+        run: |
+          python -c "import bioetl; print(f'bioetl version: {bioetl.__version__ if hasattr(bioetl, \"__version__\") else \"unknown\"}')"
+          bioetl --help
+
+      - name: Verify CLI entrypoint
+        run: |
+          # Check that bioetl CLI is properly installed
+          which bioetl
+          bioetl --version || echo "Version command not implemented"
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: [build, test-install]
+    runs-on: ubuntu-latest
+    # Only publish on release events or manual non-dry-run
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false')
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/bioetl
+    permissions:
+      id-token: write  # Required for OIDC trusted publishing
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: [build, test-install, publish-testpypi]
+    runs-on: ubuntu-latest
+    # Only publish on release events
+    if: github.event_name == 'release'
+    environment:
+      name: pypi
+      url: https://pypi.org/p/bioetl
+    permissions:
+      id-token: write  # Required for OIDC trusted publishing
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  create-github-release-assets:
+    name: Upload Release Assets
+    needs: [build, publish-pypi]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    permissions:
+      contents: write  # Required to upload release assets
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/*.whl
+            dist/*.tar.gz


### PR DESCRIPTION
Add release.yml workflow with:
- Build distribution packages (wheel + sdist)
- Verify with twine check
- Test installation across Python 3.11/3.12/3.13
- Publish to TestPyPI (with skip-existing)
- Publish to PyPI on release events
- Upload release assets to GitHub Release
- Manual workflow dispatch for dry-run testing

Uses PyPI trusted publishing (OIDC) for secure authentication.