### PR TITLE
Create BioETL pipeline documentation for all 17 pipelines

### DIFF
--- a/docs/pipelines/README.md
+++ b/docs/pipelines/README.md
@@ -1,0 +1,181 @@
+# BioETL Pipeline Documentation
+
+*Generated: 2026-01-13 | Aligned with RULES.md v5.10*
+
+This directory contains comprehensive documentation for all 17 BioETL pipelines.
+
+---
+
+## Pipeline Index
+
+### Batch 1 — Reference Tables
+
+| # | Pipeline ID | Provider | Entity | Spec |
+|---|-------------|----------|--------|------|
+| 1 | `chembl_protein_class` | ChEMBL | protein_class | [Spec](chembl/01-protein-class-spec.md) |
+| 2 | `chembl_cell_line` | ChEMBL | cell_line | [Spec](chembl/02-cell-line-spec.md) |
+
+### Batch 2 — Base Entities
+
+| # | Pipeline ID | Provider | Entity | Spec |
+|---|-------------|----------|--------|------|
+| 3 | `chembl_molecule` | ChEMBL | molecule | [Spec](chembl/03-molecule-spec.md) |
+| 4 | `chembl_target` | ChEMBL | target | [Spec](chembl/04-target-spec.md) |
+| 5 | `chembl_target_component` | ChEMBL | target_component | [Spec](chembl/10-target-component-spec.md) |
+| 6 | `uniprot_protein` | UniProt | protein | [Spec](uniprot/01-protein-spec.md) |
+| 7 | `pubchem_compound` | PubChem | compound | [Spec](pubchem/01-compound-spec.md) |
+
+### Batch 3 — Publications
+
+| # | Pipeline ID | Provider | Entity | Spec |
+|---|-------------|----------|--------|------|
+| 8 | `chembl_publication` | ChEMBL | document | [Spec](chembl/07-publication-spec.md) |
+| 9 | `pubmed_publication` | PubMed | publication | [Spec](pubmed/01-publication-spec.md) |
+| 10 | `crossref_publication` | CrossRef | publication | [Spec](crossref/01-publication-spec.md) |
+| 11 | `openalex_publication` | OpenAlex | publication | [Spec](openalex/01-publication-spec.md) |
+| 12 | `semanticscholar_publication` | Semantic Scholar | publication | [Spec](semanticscholar/01-publication-spec.md) |
+
+### Batch 4 — Experiments
+
+| # | Pipeline ID | Provider | Entity | Spec |
+|---|-------------|----------|--------|------|
+| 13 | `chembl_assay` | ChEMBL | assay | [Spec](chembl/06-assay-spec.md) |
+| 14 | `chembl_assay_parameters` | ChEMBL | assay_parameters | [Spec](chembl/08-assay-parameters-spec.md) |
+| 15 | `chembl_compound_record` | ChEMBL | compound_record | [Spec](chembl/09-compound-record-spec.md) |
+
+### Batch 5 — Measurements & Mappings
+
+| # | Pipeline ID | Provider | Entity | Spec |
+|---|-------------|----------|--------|------|
+| 16 | `chembl_activity` | ChEMBL | activity | [Spec](chembl/05-activity-spec.md) |
+| 17 | `uniprot_idmapping` | UniProt | idmapping | [Spec](uniprot/02-idmapping-spec.md) |
+
+---
+
+## Provider Summary
+
+| Provider | Pipelines | Rate Limit | Auth |
+|----------|-----------|------------|------|
+| **ChEMBL** | 10 | None | Public |
+| **UniProt** | 2 | 100 req/sec | API Key (optional) |
+| **PubChem** | 1 | 5 req/sec | Public |
+| **PubMed** | 1 | 3 req/sec (10 with key) | API Key |
+| **CrossRef** | 1 | 50 req/sec (polite) | mailto header |
+| **OpenAlex** | 1 | 10 req/sec | email-based |
+| **Semantic Scholar** | 1 | 100 req/5min | API Key |
+
+---
+
+## Documentation Structure
+
+Each pipeline specification includes:
+
+1. **Identification** — API endpoints, libraries, rate limits
+2. **Business Context** — Purpose, use cases, relationships
+3. **Extraction (Bronze)** — Complete API fields, nested structures
+4. **Transformation** — Normalization rules, flattening strategy
+5. **Validation** — Pandera schema, DQ thresholds
+6. **Output Schemas** — Bronze/Silver/Gold structure
+7. **Dependencies** — Upstream/downstream, cross-provider mapping
+8. **Configuration** — YAML pipeline config
+9. **Testing** — Required test coverage
+
+---
+
+## Cross-Provider ID Mapping
+
+| ID Type | ChEMBL | UniProt | PubChem | PubMed | CrossRef | OpenAlex | S2 |
+|---------|--------|---------|---------|--------|----------|----------|-----|
+| **InChI Key** | `structure_standard_inchi_key` | - | `inchi_key` | - | - | - | - |
+| **DOI** | `document.doi` | - | - | `doi` | `DOI` | `doi` | `doi` |
+| **PubMed ID** | `document.pubmed_id` | - | - | `pmid` | - | - | `pmid` |
+| **UniProt** | `target_component.accession` | `accession` | - | - | - | - | - |
+| **ChEMBL** | ID | `chembl_ids` | - | - | - | - | - |
+
+---
+
+## Schema Files
+
+All Pandera schemas are located in `src/bioetl/domain/schemas/`:
+
+```
+schemas/
+├── base.py                    # ETLRecordSchema base class
+├── chembl/
+│   ├── activity.py
+│   ├── assay.py
+│   ├── assay_parameters.py
+│   ├── cell_line.py
+│   ├── compound_record.py
+│   ├── molecule.py
+│   ├── protein_classification.py
+│   ├── publication.py
+│   ├── target.py
+│   └── target_component.py
+├── uniprot/
+│   ├── protein.py
+│   └── isoform.py
+├── pubchem/
+│   └── compound.py
+├── pubmed/
+│   └── article.py
+├── crossref/
+│   └── publication.py
+├── openalex/
+│   └── publication.py
+└── semanticscholar/
+    └── publication.py
+```
+
+---
+
+## Configuration Files
+
+All pipeline configs are in `configs/pipelines/`:
+
+```
+pipelines/
+├── _base.yaml                 # Base template
+├── _defaults.yaml             # Default parameters
+├── _providers/
+│   ├── chembl.yaml
+│   ├── crossref.yaml
+│   ├── openalex.yaml
+│   ├── pubchem.yaml
+│   ├── pubmed.yaml
+│   ├── semanticscholar.yaml
+│   └── uniprot.yaml
+├── chembl/
+│   ├── activity.yaml
+│   ├── assay.yaml
+│   ├── assay_parameters.yaml
+│   ├── cell_line.yaml
+│   ├── compound_record.yaml
+│   ├── molecule.yaml
+│   ├── protein_class.yaml
+│   ├── publication.yaml
+│   ├── target.yaml
+│   └── target_component.yaml
+├── crossref/
+│   └── publication.yaml
+├── openalex/
+│   └── publication.yaml
+├── pubchem/
+│   └── compound.yaml
+├── pubmed/
+│   └── publications.yaml
+├── semanticscholar/
+│   └── publication.yaml
+└── uniprot/
+    ├── idmapping.yaml
+    └── protein.yaml
+```
+
+---
+
+## Related Documentation
+
+- [RULES.md](../../RULES.md) — Project constitution
+- [CLAUDE.md](../../CLAUDE.md) — Agent instructions
+- [ADR Directory](../02-architecture/decisions/) — Architecture Decision Records
+- [API Reference](../04-reference/api/) — API documentation

--- a/docs/pipelines/chembl/01-protein-class-spec.md
+++ b/docs/pipelines/chembl/01-protein-class-spec.md
@@ -1,0 +1,450 @@
+# ChEMBL Protein Classification Pipeline Specification
+
+*Version 1.1.0 | Aligned with RULES.md v5.10*
+
+---
+
+## 1. Identification
+
+| Parameter | Value |
+|-----------|-------|
+| **Pipeline ID** | `chembl_protein_class` |
+| **Provider** | ChEMBL (EBI) |
+| **Entity** | protein_class |
+| **API Endpoint** | `https://www.ebi.ac.uk/chembl/api/data/protein_class` |
+| **Library** | `chembl_webresource_client` |
+| **Rate Limit** | None (polite usage recommended) |
+| **Health Check** | `/chembl/api/data/status.json` |
+| **Auth Type** | None (public API) |
+
+---
+
+## 2. Business Context
+
+### 2.1. Entity Purpose
+
+Protein Classification represents a **hierarchical taxonomy** of protein families used to categorize biological targets in ChEMBL. This classification system enables:
+
+- **Target categorization**: Group targets by biological function (kinases, GPCRs, ion channels, etc.)
+- **Drug discovery insights**: Identify druggable protein families
+- **Cross-species analysis**: Compare protein classes across organisms
+- **Ontology alignment**: Map to external classification systems
+
+### 2.2. Use Cases
+
+1. **Target Class Distribution**: Analyze which protein families have the most bioactivity data
+2. **Drug Target Identification**: Find unexplored protein classes for novel therapeutics
+3. **Hierarchical Queries**: Navigate from broad classes (Enzyme) to specific subfamilies (Kinase → Tyrosine Kinase → EGFR)
+
+### 2.3. Entity Relationships
+
+```
+protein_class (self-referential hierarchy)
+    │
+    ├──FK (parent_id)──► protein_class (parent classification)
+    │
+    └──◄──FK──target_component.protein_class_id (M:N via junction)
+              │
+              └──► target (contains this protein)
+```
+
+### 2.4. Load Strategy
+
+| Parameter | Value |
+|-----------|-------|
+| **Strategy** | `full` (reference table) |
+| **Watermark Field** | N/A |
+| **Full Load Frequency** | On demand or weekly |
+| **Estimated Volume** | ~1,500 records |
+| **Batch Size** | 500 |
+
+---
+
+## 3. Extraction (Bronze Layer)
+
+### 3.1. API Request
+
+```python
+from chembl_webresource_client.new_client import new_client
+
+protein_class = new_client.protein_class
+results = protein_class.filter().only([
+    'protein_class_id',
+    'parent_id',
+    'pref_name',
+    'short_name',
+    'protein_class_desc',
+    'definition',
+    'class_level',
+    'sort_order',
+    'downgraded',
+    'replaced_by'
+])
+```
+
+### 3.2. Complete API Fields
+
+| # | API Field | JSON Type | Nullable | Description | Example Value |
+|---|-----------|-----------|----------|-------------|---------------|
+| 1 | `protein_class_id` | integer | No | Primary key (internal ID) | `1` |
+| 2 | `parent_id` | integer | Yes | FK to parent classification | `null`, `1` |
+| 3 | `pref_name` | string | Yes | Preferred name | `"Kinase"` |
+| 4 | `short_name` | string | Yes | Short name | `"Kin"` |
+| 5 | `protein_class_desc` | string | Yes | Full description | `"Protein kinases"` |
+| 6 | `definition` | string | Yes | Definition text | `"Enzymes that phosphorylate..."` |
+| 7 | `class_level` | integer | Yes | Level in hierarchy (1-8) | `1`, `2`, `3` |
+| 8 | `sort_order` | integer | Yes | Display sort order | `100` |
+| 9 | `downgraded` | integer | Yes | Deprecated flag (0/1) | `0` |
+| 10 | `replaced_by` | integer | Yes | FK to replacement record | `null`, `456` |
+
+### 3.3. Excluded Fields
+
+| Field | Reason |
+|-------|--------|
+| N/A | All fields are included |
+
+---
+
+## 4. Transformation
+
+### 4.1. Entity ID Strategy
+
+| Parameter | Value |
+|-----------|-------|
+| **Entity ID Field** | `protein_class_id` |
+| **ID Source** | `from_api` |
+| **Format** | Integer (cast to string for entity_id) |
+
+### 4.2. Field Normalization
+
+| Field | Normalization | Before | After |
+|-------|---------------|--------|-------|
+| `protein_class_id` | Cast to int | `"1"` | `1` |
+| `parent_id` | Cast to int or None | `"null"` | `None` |
+| `pref_name` | strip() | `" Kinase "` | `"Kinase"` |
+| `short_name` | strip() | `" Kin "` | `"Kin"` |
+| `protein_class_desc` | strip() | - | - |
+| `definition` | strip() | - | - |
+| `class_level` | Cast to int | `"1"` | `1` |
+| `sort_order` | Cast to int | `"100"` | `100` |
+| `downgraded` | Cast to int (0/1) | `"0"` | `0` |
+| `replaced_by` | Cast to int or None | `"null"` | `None` |
+
+### 4.3. Content Hash Specification
+
+```python
+# Fields included in hash (alphabetical order)
+hash_fields = [
+    "class_level",
+    "definition",
+    "downgraded",
+    "parent_id",
+    "pref_name",
+    "protein_class_desc",
+    "protein_class_id",
+    "replaced_by",
+    "short_name",
+    "sort_order",
+]
+
+# Fields EXCLUDED from hash (RULES.md §2.8.1)
+excluded = ["_ingestion_ts", "_run_id", "_run_type", "_dq_*"]
+
+# Algorithm
+content_hash = sha256(f"chembl{canonical_json(filtered_record)}")
+```
+
+---
+
+## 5. Validation
+
+### 5.1. Pandera Schema
+
+```python
+# src/bioetl/domain/schemas/chembl/protein_classification.py
+
+import pandera.pandas as pa
+from pandera.typing import Series
+from bioetl.domain.schemas.base import ETLRecordSchema
+
+
+class ProteinClassificationSchema(ETLRecordSchema):
+    """Protein Classification validation schema for Silver layer."""
+
+    # === Primary Key ===
+    protein_class_id: Series[int] = pa.Field(
+        nullable=False,
+        description="Primary key."
+    )
+
+    # === Foreign Keys ===
+    parent_id: Series[int] | None = pa.Field(
+        nullable=True,
+        description="FK to parent classification."
+    )
+    replaced_by: Series[int] | None = pa.Field(
+        nullable=True,
+        description="FK to replacement classification."
+    )
+
+    # === Metadata ===
+    pref_name: Series[str] | None = pa.Field(
+        nullable=True,
+        description="Preferred name."
+    )
+    short_name: Series[str] | None = pa.Field(
+        nullable=True,
+        description="Short name."
+    )
+    protein_class_desc: Series[str] | None = pa.Field(
+        nullable=True,
+        description="Description."
+    )
+    definition: Series[str] | None = pa.Field(
+        nullable=True,
+        description="Definition."
+    )
+    class_level: Series[int] | None = pa.Field(
+        nullable=True,
+        ge=1,
+        description="Class level.",
+    )
+    sort_order: Series[int] | None = pa.Field(
+        nullable=True,
+        description="Sort order."
+    )
+
+    # === Flags ===
+    downgraded: Series[int] | None = pa.Field(
+        nullable=True,
+        isin=[0, 1],
+        description="Downgraded flag.",
+    )
+
+    class Config:
+        strict = True
+        ordered = True
+        coerce = True
+```
+
+### 5.2. Field Validation Matrix
+
+| Field | Type | Nullable | Constraints | DQ Level | Failure Action |
+|-------|------|----------|-------------|----------|----------------|
+| `protein_class_id` | int | No | >= 1 | CRITICAL | Quarantine |
+| `parent_id` | int | Yes | >= 1 or None | WARNING | Log |
+| `replaced_by` | int | Yes | >= 1 or None | WARNING | Log |
+| `pref_name` | str | Yes | - | INFO | Log |
+| `short_name` | str | Yes | - | INFO | Log |
+| `protein_class_desc` | str | Yes | - | INFO | Log |
+| `definition` | str | Yes | - | INFO | Log |
+| `class_level` | int | Yes | >= 1 | WARNING | Log |
+| `sort_order` | int | Yes | - | INFO | Log |
+| `downgraded` | int | Yes | isin [0, 1] | WARNING | Log |
+
+### 5.3. Cross-Field Validation Rules
+
+| Rule Name | Fields | Condition | Failure Action |
+|-----------|--------|-----------|----------------|
+| `parent_self_ref` | `parent_id`, `protein_class_id` | parent_id != protein_class_id | Quarantine |
+| `replaced_inactive` | `downgraded`, `replaced_by` | downgraded=1 implies replaced_by is set | Warning |
+
+### 5.4. DQ Thresholds
+
+| Threshold | Value | Action |
+|-----------|-------|--------|
+| Soft | 5% | Warning, continue |
+| Hard | 20% | Fail batch |
+| Critical field null | Any protein_class_id is null | Fail immediately |
+
+---
+
+## 6. Metadata Fields (RULES.md §2.4)
+
+All records contain:
+
+| Field | Type | Source | In Hash |
+|-------|------|--------|---------|
+| `entity_id` | str | protein_class_id (cast) | N/A |
+| `content_hash` | str | Computed | N/A |
+| `_run_id` | UUID | Generated | No |
+| `_run_type` | Enum | Config | No |
+| `_source_batch_id` | UUID | Generated | No |
+| `_ingestion_ts` | datetime | Generated (UTC) | No |
+| `_dq_warn` | bool | Validation | No |
+| `_dq_error` | bool | Validation | No |
+| `_index` | int | Generated | No |
+
+---
+
+## 7. Output Schemas
+
+### 7.1. Bronze
+
+```
+Path: bronze/v1/chembl/protein_class/{YYYY-MM-DD}/
+Format: JSONL + zstd
+Mode: Append-only
+Retention: 90 days → Archive
+```
+
+### 7.2. Silver
+
+```
+Path: silver/chembl/protein_class/class_level={L}/
+Format: Delta Lake (delta-rs)
+Mode: Merge on [protein_class_id]
+Partition: [class_level]
+Retention: Permanent
+VACUUM: Weekly, 7 days retention
+```
+
+**Silver Schema Table:**
+
+| # | Column | Type | Nullable | Description |
+|---|--------|------|----------|-------------|
+| 1 | `entity_id` | string | No | = protein_class_id |
+| 2 | `content_hash` | string | No | SHA256 hash |
+| 3 | `protein_class_id` | int | No | PK |
+| 4 | `parent_id` | int | Yes | FK to parent |
+| 5 | `replaced_by` | int | Yes | FK to replacement |
+| 6 | `pref_name` | string | Yes | Preferred name |
+| 7 | `short_name` | string | Yes | Short name |
+| 8 | `protein_class_desc` | string | Yes | Description |
+| 9 | `definition` | string | Yes | Definition |
+| 10 | `class_level` | int | Yes | Hierarchy level |
+| 11 | `sort_order` | int | Yes | Sort order |
+| 12 | `downgraded` | int | Yes | Deprecated flag |
+| 13 | `_run_id` | uuid | No | Pipeline run ID |
+| 14 | `_run_type` | string | No | Run type |
+| 15 | `_source_batch_id` | uuid | Yes | Batch context |
+| 16 | `_ingestion_ts` | timestamp | No | Ingestion time |
+| 17 | `_dq_warn` | bool | No | DQ warning flag |
+| 18 | `_dq_error` | bool | No | DQ error flag |
+| 19 | `_index` | int | No | Record index |
+
+### 7.3. Gold
+
+```
+Path: gold/chembl/protein_class/
+Format: Delta Lake
+Mode: Overwrite (reference table)
+```
+
+**Gold Filter:** `downgraded = 0` AND `pref_name IS NOT NULL`
+
+---
+
+## 8. Quarantine Handling
+
+### 8.1. Error Codes
+
+| Code | Description | Typical Cause |
+|------|-------------|---------------|
+| `NULL_REQUIRED_PROTEIN_CLASS_ID` | PK is null | Source data issue |
+| `INVALID_CLASS_LEVEL` | class_level < 1 | Schema violation |
+| `SELF_REFERENTIAL_PARENT` | parent_id = protein_class_id | Data integrity issue |
+| `INVALID_DOWNGRADED` | downgraded not in [0,1] | API change |
+
+### 8.2. Recovery Procedures
+
+| Error Code | Recovery |
+|------------|----------|
+| `NULL_REQUIRED_*` | Investigate source, skip record |
+| `INVALID_*` | Log warning, coerce to valid value |
+
+---
+
+## 9. Dependencies
+
+### 9.1. Upstream
+
+| Dependency | Type | Required | Notes |
+|------------|------|----------|-------|
+| ChEMBL API | API | Yes | Source of truth |
+
+### 9.2. Downstream
+
+| Consumer | Impact |
+|----------|--------|
+| `chembl_target_component` | FK reference for protein classifications |
+| `chembl_target` | Enrichment with protein class hierarchy |
+| Analytics dashboards | Target class distribution reports |
+
+---
+
+## 10. Pipeline Configuration
+
+```yaml
+# configs/pipelines/chembl/protein_class.yaml
+
+pipeline_name: chembl_protein_class
+provider: chembl
+entity_type: protein_class
+version: "1.1.0"
+description: "ChEMBL Protein Classification hierarchy"
+
+primary_keys: ["protein_class_id"]
+silver_table: chembl_protein_class
+gold_table: chembl_protein_class
+
+source_file: ../../sources/chembl.yaml
+batch_size: 500
+checkpoint_interval: 500
+
+gold_filters:
+  required_fields:
+    - pref_name
+  columns:
+    downgraded: ["0"]
+
+sink:
+  bronze:
+    path: "data/output/bronze"
+  silver:
+    path: "data/output/silver"
+    primary_key: ["protein_class_id"]
+    partition_by: ["class_level"]
+    sort_by:
+      columns: ["protein_class_id"]
+      ascending: true
+    csv_export:
+      path: "data/output/csv/silver"
+  gold:
+    path: "data/output/gold"
+    sort_by:
+      columns: ["class_level", "sort_order", "protein_class_id"]
+      ascending: true
+    csv_export:
+      path: "data/output/csv/gold"
+
+input_filter:
+  enabled: false
+```
+
+---
+
+## 11. Testing Requirements
+
+### 11.1. Unit Tests
+
+- [x] `test_protein_class_normalization.py`
+- [x] `test_protein_class_content_hash.py`
+- [x] `test_protein_class_validation.py`
+
+### 11.2. Integration Tests (VCR)
+
+- [x] `test_protein_class_api_fetch.py`
+- [x] `test_protein_class_pagination.py`
+- [x] `test_protein_class_error_handling.py`
+
+### 11.3. Architecture Tests
+
+- [x] Schema strict mode validation
+- [x] Layer import compliance
+
+---
+
+## 12. Field Mapping CSV
+
+See `docs/pipelines/chembl/protein-class-fields.csv` for Excel-compatible field mapping.

--- a/docs/pipelines/chembl/02-cell-line-spec.md
+++ b/docs/pipelines/chembl/02-cell-line-spec.md
@@ -1,0 +1,455 @@
+# ChEMBL Cell Line Pipeline Specification
+
+*Version 1.1.0 | Aligned with RULES.md v5.10*
+
+---
+
+## 1. Identification
+
+| Parameter | Value |
+|-----------|-------|
+| **Pipeline ID** | `chembl_cell_line` |
+| **Provider** | ChEMBL (EBI) |
+| **Entity** | cell_line |
+| **API Endpoint** | `https://www.ebi.ac.uk/chembl/api/data/cell_line` |
+| **Library** | `chembl_webresource_client` |
+| **Rate Limit** | None (polite usage recommended) |
+| **Health Check** | `/chembl/api/data/status.json` |
+| **Auth Type** | None (public API) |
+
+---
+
+## 2. Business Context
+
+### 2.1. Entity Purpose
+
+Cell Lines represent **biological cell cultures** used in experimental assays. They provide crucial context for interpreting bioactivity data:
+
+- **In vitro context**: Understanding which cell model was used for testing
+- **Tissue origin**: Tracking source tissue and organism
+- **Cross-reference**: Linking to external databases (Cellosaurus, CLO, EFO)
+- **Cancer research**: Many cell lines are derived from tumors
+
+### 2.2. Use Cases
+
+1. **Assay Context Analysis**: Determine which cell lines are most commonly used for specific target types
+2. **Tissue-Specific Studies**: Filter bioactivity data by cell line tissue origin
+3. **Cross-Database Linking**: Map ChEMBL cell lines to Cellosaurus for detailed metadata
+4. **Species Selection**: Filter by organism (human, mouse, rat cell lines)
+
+### 2.3. Entity Relationships
+
+```
+cell_line
+    │
+    └──◄──FK──assay.cell_chembl_id (1:M)
+              │
+              └──◄──activity (via assay)
+```
+
+### 2.4. Load Strategy
+
+| Parameter | Value |
+|-----------|-------|
+| **Strategy** | `incremental` with input filter |
+| **Watermark Field** | N/A (filtered by input CSV) |
+| **Full Load Frequency** | On demand |
+| **Estimated Volume** | ~2,500 records total |
+| **Batch Size** | 20 (filter batch) |
+
+---
+
+## 3. Extraction (Bronze Layer)
+
+### 3.1. API Request
+
+```python
+from chembl_webresource_client.new_client import new_client
+
+cell_line = new_client.cell_line
+# Filter by input CSV cell_chembl_ids
+results = cell_line.filter(cell_chembl_id__in=chembl_ids)
+```
+
+### 3.2. Complete API Fields
+
+| # | API Field | JSON Type | Nullable | Description | Example Value |
+|---|-----------|-----------|----------|-------------|---------------|
+| 1 | `cell_chembl_id` | string | No | Primary key (ChEMBL ID) | `"CHEMBL3307641"` |
+| 2 | `cell_name` | string | No | Cell line name | `"HeLa"` |
+| 3 | `cell_description` | string | Yes | Description | `"Cervical adenocarcinoma"` |
+| 4 | `cell_source_tissue` | string | Yes | Source tissue | `"Cervix"` |
+| 5 | `cell_source_organism` | string | Yes | Source organism | `"Homo sapiens"` |
+| 6 | `cell_source_tax_id` | integer | Yes | NCBI Taxonomy ID | `9606` |
+| 7 | `cell_type` | string | Yes | Cell type classification | `"Cancer cell line"` |
+| 8 | `cellosaurus_id` | string | Yes | Cellosaurus ID | `"CVCL_0030"` |
+| 9 | `clo_id` | string | Yes | Cell Line Ontology ID | `"CLO_0002063"` |
+| 10 | `cl_lincs_id` | string | Yes | LINCS ID | `"LCL-1024"` |
+| 11 | `efo_id` | string | Yes | EFO ontology ID | `"EFO_0002067"` |
+
+### 3.3. Excluded Fields
+
+| Field | Reason |
+|-------|--------|
+| N/A | All fields are included |
+
+---
+
+## 4. Transformation
+
+### 4.1. Entity ID Strategy
+
+| Parameter | Value |
+|-----------|-------|
+| **Entity ID Field** | `cell_chembl_id` |
+| **ID Source** | `from_api` |
+| **Format** | ChEMBL ID (CHEMBL[0-9]+) |
+
+### 4.2. Field Normalization
+
+| Field | Normalization | Before | After |
+|-------|---------------|--------|-------|
+| `cell_chembl_id` | Validate regex | `"CHEMBL3307641"` | `"CHEMBL3307641"` |
+| `cell_name` | strip() | `" HeLa "` | `"HeLa"` |
+| `cell_description` | strip() | - | - |
+| `cell_source_tissue` | strip() | - | - |
+| `cell_source_organism` | strip() | - | - |
+| `cell_source_tax_id` | Cast to int | `"9606"` | `9606` |
+| `cell_type` | strip() | - | - |
+| `cellosaurus_id` | Validate regex | `"CVCL_0030"` | `"CVCL_0030"` |
+| `clo_id` | Validate regex | `"CLO_0002063"` | `"CLO_0002063"` |
+| `cl_lincs_id` | strip() | - | - |
+| `efo_id` | Validate regex | `"EFO_0002067"` | `"EFO_0002067"` |
+
+### 4.3. Content Hash Specification
+
+```python
+# Fields included in hash (alphabetical order)
+hash_fields = [
+    "cell_chembl_id",
+    "cell_description",
+    "cell_name",
+    "cell_source_organism",
+    "cell_source_tax_id",
+    "cell_source_tissue",
+    "cell_type",
+    "cellosaurus_id",
+    "cl_lincs_id",
+    "clo_id",
+    "efo_id",
+]
+
+# Fields EXCLUDED from hash (RULES.md §2.8.1)
+excluded = ["_ingestion_ts", "_run_id", "_run_type", "_dq_*"]
+
+# Algorithm
+content_hash = sha256(f"chembl{canonical_json(filtered_record)}")
+```
+
+---
+
+## 5. Validation
+
+### 5.1. Pandera Schema
+
+```python
+# src/bioetl/domain/schemas/chembl/cell_line.py
+
+import pandera.pandas as pa
+from pandera.typing import Series
+from bioetl.domain.schemas.base import ETLRecordSchema
+
+
+class CellLineSchema(ETLRecordSchema):
+    """Cell Line validation schema for Silver layer."""
+
+    # === Primary Key ===
+    cell_chembl_id: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^CHEMBL\d+$",
+        unique=True,
+        description="ChEMBL ID for cell line (PK).",
+    )
+
+    # === Core Metadata ===
+    cell_name: Series[str] = pa.Field(
+        nullable=False,
+        description="Cell line name (e.g., HeLa, MCF7).",
+    )
+    cell_description: Series[str] | None = pa.Field(
+        nullable=True,
+        description="Cell line description.",
+    )
+
+    # === Source Information ===
+    cell_source_tissue: Series[str] | None = pa.Field(
+        nullable=True,
+        description="Source tissue (e.g., Cervix, Breast).",
+    )
+    cell_source_organism: Series[str] | None = pa.Field(
+        nullable=True,
+        description="Source organism (e.g., Homo sapiens).",
+    )
+    cell_source_tax_id: Series[int] | None = pa.Field(
+        nullable=True,
+        ge=1,
+        description="NCBI Taxonomy ID for source organism.",
+    )
+
+    # === Cell Type Classification ===
+    cell_type: Series[str] | None = pa.Field(
+        nullable=True,
+        description="Cell type classification.",
+    )
+
+    # === External Identifiers ===
+    cellosaurus_id: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^CVCL_[A-Z0-9]+$",
+        description="Cellosaurus ID.",
+    )
+    clo_id: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^CLO_\d+$",
+        description="Cell Line Ontology ID.",
+    )
+    cl_lincs_id: Series[str] | None = pa.Field(
+        nullable=True,
+        description="LINCS ID.",
+    )
+    efo_id: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^EFO_\d+$",
+        description="EFO ontology ID.",
+    )
+
+    class Config:
+        strict = True
+        ordered = False
+        coerce = True
+```
+
+### 5.2. Field Validation Matrix
+
+| Field | Type | Nullable | Constraints | DQ Level | Failure Action |
+|-------|------|----------|-------------|----------|----------------|
+| `cell_chembl_id` | str | No | regex `^CHEMBL\d+$`, unique | CRITICAL | Quarantine |
+| `cell_name` | str | No | - | CRITICAL | Quarantine |
+| `cell_description` | str | Yes | - | INFO | Log |
+| `cell_source_tissue` | str | Yes | - | INFO | Log |
+| `cell_source_organism` | str | Yes | - | INFO | Log |
+| `cell_source_tax_id` | int | Yes | >= 1 | WARNING | Log |
+| `cell_type` | str | Yes | - | INFO | Log |
+| `cellosaurus_id` | str | Yes | regex `^CVCL_[A-Z0-9]+$` | WARNING | Log |
+| `clo_id` | str | Yes | regex `^CLO_\d+$` | WARNING | Log |
+| `cl_lincs_id` | str | Yes | - | INFO | Log |
+| `efo_id` | str | Yes | regex `^EFO_\d+$` | WARNING | Log |
+
+### 5.3. Cross-Field Validation Rules
+
+| Rule Name | Fields | Condition | Failure Action |
+|-----------|--------|-----------|----------------|
+| `tax_id_organism_consistency` | `cell_source_tax_id`, `cell_source_organism` | If tax_id=9606, organism should contain "sapiens" | Warning |
+
+### 5.4. DQ Thresholds
+
+| Threshold | Value | Action |
+|-----------|-------|--------|
+| Soft | 5% | Warning, continue |
+| Hard | 20% | Fail batch |
+| Critical field null | cell_chembl_id or cell_name is null | Fail immediately |
+
+---
+
+## 6. Metadata Fields (RULES.md §2.4)
+
+All records contain:
+
+| Field | Type | Source | In Hash |
+|-------|------|--------|---------|
+| `entity_id` | str | cell_chembl_id | N/A |
+| `content_hash` | str | Computed | N/A |
+| `_run_id` | UUID | Generated | No |
+| `_run_type` | Enum | Config | No |
+| `_source_batch_id` | UUID | Generated | No |
+| `_ingestion_ts` | datetime | Generated (UTC) | No |
+| `_dq_warn` | bool | Validation | No |
+| `_dq_error` | bool | Validation | No |
+| `_index` | int | Generated | No |
+
+---
+
+## 7. Output Schemas
+
+### 7.1. Bronze
+
+```
+Path: bronze/v1/chembl/cell_line/{YYYY-MM-DD}/
+Format: JSONL + zstd
+Mode: Append-only
+Retention: 90 days → Archive
+```
+
+### 7.2. Silver
+
+```
+Path: silver/chembl/cell_line/
+Format: Delta Lake (delta-rs)
+Mode: Merge on [cell_chembl_id]
+Partition: None
+Retention: Permanent
+VACUUM: Weekly, 7 days retention
+```
+
+**Silver Schema Table:**
+
+| # | Column | Type | Nullable | Description |
+|---|--------|------|----------|-------------|
+| 1 | `entity_id` | string | No | = cell_chembl_id |
+| 2 | `content_hash` | string | No | SHA256 hash |
+| 3 | `cell_chembl_id` | string | No | PK |
+| 4 | `cell_name` | string | No | Cell line name |
+| 5 | `cell_description` | string | Yes | Description |
+| 6 | `cell_source_tissue` | string | Yes | Source tissue |
+| 7 | `cell_source_organism` | string | Yes | Source organism |
+| 8 | `cell_source_tax_id` | int | Yes | NCBI Taxonomy ID |
+| 9 | `cell_type` | string | Yes | Cell type |
+| 10 | `cellosaurus_id` | string | Yes | Cellosaurus ID |
+| 11 | `clo_id` | string | Yes | CLO ID |
+| 12 | `cl_lincs_id` | string | Yes | LINCS ID |
+| 13 | `efo_id` | string | Yes | EFO ID |
+| 14-22 | System fields | various | various | See §6 |
+
+### 7.3. Gold
+
+```
+Path: gold/chembl/cell_line/
+Format: Delta Lake
+Mode: Overwrite
+```
+
+**Gold Filter:** `cell_name IS NOT NULL`
+
+---
+
+## 8. Quarantine Handling
+
+### 8.1. Error Codes
+
+| Code | Description | Typical Cause |
+|------|-------------|---------------|
+| `NULL_REQUIRED_CELL_CHEMBL_ID` | PK is null | Source data issue |
+| `NULL_REQUIRED_CELL_NAME` | Name is null | Incomplete record |
+| `INVALID_CHEMBL_ID_FORMAT` | ID doesn't match regex | API change |
+| `INVALID_CELLOSAURUS_ID` | Cellosaurus ID format invalid | Data quality issue |
+
+### 8.2. Recovery Procedures
+
+| Error Code | Recovery |
+|------------|----------|
+| `NULL_REQUIRED_*` | Investigate source, skip record |
+| `INVALID_*` | Log warning, set field to null |
+
+---
+
+## 9. Dependencies
+
+### 9.1. Upstream
+
+| Dependency | Type | Required | Notes |
+|------------|------|----------|-------|
+| ChEMBL API | API | Yes | Source of truth |
+| Input CSV | File | Optional | Filter for specific cell lines |
+
+### 9.2. Downstream
+
+| Consumer | Impact |
+|----------|--------|
+| `chembl_assay` | FK reference (cell_chembl_id) |
+| Cell line enrichment analytics | Tissue/organism analysis |
+
+### 9.3. Cross-Provider Mapping
+
+| This Entity Field | Maps To | Provider | Field |
+|-------------------|---------|----------|-------|
+| `cellosaurus_id` | Cellosaurus | ExPASy | Accession |
+| `clo_id` | CLO | OBO Foundry | ID |
+| `efo_id` | EFO | EMBL-EBI | ID |
+
+---
+
+## 10. Pipeline Configuration
+
+```yaml
+# configs/pipelines/chembl/cell_line.yaml
+
+pipeline_name: chembl_cell_line
+provider: chembl
+entity_type: cell_line
+version: "1.1.0"
+description: "Extract cell lines from ChEMBL API"
+
+primary_keys: ["cell_chembl_id"]
+silver_table: "chembl_cell_line"
+gold_table: "chembl_cell_line"
+
+source_file: ../../sources/chembl.yaml
+
+gold_filters:
+  required_fields:
+    - cell_name
+
+sink:
+  bronze:
+    path: "data/output/bronze"
+  silver:
+    path: "data/output/silver"
+    primary_key: ["cell_chembl_id"]
+    partition_by: []
+    sort_by:
+      columns: ["cell_chembl_id"]
+      ascending: true
+    csv_export:
+      path: "data/output/csv/silver"
+  gold:
+    path: "data/output/gold"
+    sort_by:
+      columns: ["cell_chembl_id", "cell_name"]
+      ascending: true
+    csv_export:
+      path: "data/output/csv/gold"
+
+input_filter:
+  enabled: true
+  source_path: "data/input/cell.csv"
+  column_name: "cell_chembl_id"
+  filter_field: "cell_chembl_id"
+  batch_size: 20
+```
+
+---
+
+## 11. Testing Requirements
+
+### 11.1. Unit Tests
+
+- [x] `test_cell_line_normalization.py`
+- [x] `test_cell_line_content_hash.py`
+- [x] `test_cell_line_validation.py`
+
+### 11.2. Integration Tests (VCR)
+
+- [x] `test_cell_line_api_fetch.py`
+- [x] `test_cell_line_filter_batch.py`
+- [x] `test_cell_line_error_handling.py`
+
+### 11.3. Architecture Tests
+
+- [x] Schema strict mode validation
+- [x] Layer import compliance
+
+---
+
+## 12. Field Mapping CSV
+
+See `docs/pipelines/chembl/cell-line-fields.csv` for Excel-compatible field mapping.

--- a/docs/pipelines/chembl/03-molecule-spec.md
+++ b/docs/pipelines/chembl/03-molecule-spec.md
@@ -1,0 +1,407 @@
+# ChEMBL Molecule Pipeline Specification
+
+*Version 1.1.0 | Aligned with RULES.md v5.10*
+
+---
+
+## 1. Identification
+
+| Parameter | Value |
+|-----------|-------|
+| **Pipeline ID** | `chembl_molecule` |
+| **Provider** | ChEMBL (EBI) |
+| **Entity** | molecule |
+| **API Endpoint** | `https://www.ebi.ac.uk/chembl/api/data/molecule` |
+| **Library** | `chembl_webresource_client` |
+| **Rate Limit** | None (polite usage recommended) |
+| **Health Check** | `/chembl/api/data/status.json` |
+| **Auth Type** | None (public API) |
+
+---
+
+## 2. Business Context
+
+### 2.1. Entity Purpose
+
+Molecules represent **chemical compounds** in ChEMBL with their structural and pharmacological properties:
+
+- **Drug discovery**: Central entity linking compounds to biological activities
+- **Structure-activity relationships (SAR)**: Chemical structures with activity data
+- **Clinical development**: Track compounds through clinical phases
+- **Cross-database linking**: InChI Key enables mapping to PubChem, DrugBank
+
+### 2.2. Use Cases
+
+1. **Compound Search**: Find molecules by structure, name, or properties
+2. **Drug Pipeline Analysis**: Analyze compounds by clinical phase
+3. **SAR Studies**: Correlate structural features with activity profiles
+4. **Toxicity Screening**: Identify compounds with black box warnings
+5. **Natural Product Discovery**: Filter for natural product-derived compounds
+
+### 2.3. Entity Relationships
+
+```
+molecule
+    │
+    ├──◄──FK──activity.molecule_chembl_id (1:M)
+    │
+    ├──◄──FK──compound_record.molecule_chembl_id (1:M)
+    │
+    └── molecule_hierarchy (nested)
+        ├── parent_chembl_id
+        └── active_chembl_id
+```
+
+### 2.4. Load Strategy
+
+| Parameter | Value |
+|-----------|-------|
+| **Strategy** | `incremental` with input filter |
+| **Watermark Field** | N/A (filtered by input CSV) |
+| **Full Load Frequency** | On demand |
+| **Estimated Volume** | ~2.4M records total |
+| **Batch Size** | 20 (filter batch) |
+
+---
+
+## 3. Extraction (Bronze Layer)
+
+### 3.1. API Request
+
+```python
+from chembl_webresource_client.new_client import new_client
+
+molecule = new_client.molecule
+# Filter by input CSV molecule_chembl_ids
+results = molecule.filter(molecule_chembl_id__in=chembl_ids)
+```
+
+### 3.2. Complete API Fields
+
+| # | API Field | JSON Type | Nullable | Nested | Description | Example |
+|---|-----------|-----------|----------|--------|-------------|---------|
+| 1 | `molecule_chembl_id` | string | No | - | Primary key | `"CHEMBL25"` |
+| 2 | `pref_name` | string | Yes | - | Preferred name | `"ASPIRIN"` |
+| 3 | `molecule_type` | string | Yes | - | Type | `"Small molecule"` |
+| 4 | `max_phase` | number | Yes | - | Clinical phase | `4` |
+| 5 | `structure_type` | string | Yes | - | Structure type | `"MOL"` |
+| 6 | `therapeutic_flag` | boolean | Yes | - | Is therapeutic | `true` |
+| 7 | `oral` | boolean | Yes | - | Oral delivery | `true` |
+| 8 | `parenteral` | boolean | Yes | - | Parenteral delivery | `false` |
+| 9 | `topical` | boolean | Yes | - | Topical delivery | `false` |
+| 10 | `black_box_warning` | integer | Yes | - | BBW flag | `0` |
+| 11 | `natural_product` | integer | Yes | - | Natural product flag | `0` |
+| 12 | `first_in_class` | integer | Yes | - | First in class | `0` |
+| 13 | `prodrug` | integer | Yes | - | Prodrug flag | `0` |
+| 14 | `inorganic_flag` | integer | Yes | - | Inorganic flag | `0` |
+| 15 | `polymer_flag` | integer | Yes | - | Polymer flag | `0` |
+| 16 | `first_approval` | integer | Yes | - | First approval year | `1899` |
+| 17 | `withdrawn_flag` | boolean | Yes | - | Withdrawn flag | `false` |
+| 18 | `molecule_hierarchy` | object | Yes | Yes | Hierarchy | JSON |
+| 19 | `molecule_properties` | object | Yes | Yes | Properties | JSON |
+| 20 | `molecule_structures` | object | Yes | Yes | Structures | JSON |
+| 21 | `molecule_synonyms` | array | Yes | Yes | Synonyms | JSON |
+| 22 | `cross_references` | array | Yes | Yes | Cross-refs | JSON |
+| 23 | `atc_classifications` | array | Yes | Yes | ATC codes | JSON |
+
+### 3.3. Nested Structure: molecule_structures
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `canonical_smiles` | string | Canonical SMILES |
+| `standard_inchi` | string | Standard InChI |
+| `standard_inchi_key` | string | Standard InChI Key (27 chars) |
+| `molfile` | string | MOL file content |
+
+### 3.4. Nested Structure: molecule_properties
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `molecular_formula` | string | Molecular formula |
+| `full_mwt` | float | Full molecular weight |
+| `mw_freebase` | float | Freebase MW |
+| `mw_monoisotopic` | float | Monoisotopic MW |
+| `alogp` | float | ALogP |
+| `cx_logp` | float | ChemAxon LogP |
+| `cx_logd` | float | ChemAxon LogD |
+| `psa` | float | Polar surface area |
+| `hba` | integer | H-bond acceptors |
+| `hbd` | integer | H-bond donors |
+| `rtb` | integer | Rotatable bonds |
+| `num_ro5_violations` | integer | Rule of 5 violations |
+| `aromatic_rings` | integer | Aromatic rings |
+| `heavy_atoms` | integer | Heavy atoms |
+| `qed_weighted` | float | QED score |
+
+---
+
+## 4. Transformation
+
+### 4.1. Entity ID Strategy
+
+| Parameter | Value |
+|-----------|-------|
+| **Entity ID Field** | `molecule_chembl_id` |
+| **ID Source** | `from_api` |
+| **Format** | ChEMBL ID (CHEMBL[0-9]+) |
+
+### 4.2. Field Normalization
+
+| Field | Normalization | Before | After |
+|-------|---------------|--------|-------|
+| `molecule_chembl_id` | Validate regex | `"CHEMBL25"` | `"CHEMBL25"` |
+| `pref_name` | strip().upper() | `" aspirin "` | `"ASPIRIN"` |
+| `max_phase` | Cast to float | `"4"` | `4.0` |
+| `structure_standard_inchi_key` | Extract from nested | `{...}` | `"BSYNRYMUTXBXSQ-..."` |
+| Float properties | round(10) | `180.12345678901234` | `180.1234567890` |
+| Nested objects | JSON serialize | `{...}` | `'{"key": "value"}'` |
+
+### 4.3. Flattening Strategy
+
+| Nested Path | Flattened Name | Strategy |
+|-------------|----------------|----------|
+| `molecule_structures.standard_inchi_key` | `structure_standard_inchi_key` | Extract scalar |
+| `molecule_hierarchy` | `molecule_hierarchy` | JSON string |
+| `molecule_properties` | `molecule_properties` | JSON string |
+| `molecule_structures` | `molecule_structures` | JSON string |
+| `molecule_synonyms` | `molecule_synonyms` | JSON string |
+| `cross_references` | `cross_references` | JSON string |
+| `atc_classifications` | `atc_classifications` | JSON string |
+
+### 4.4. Content Hash Specification
+
+```python
+# Fields included in hash (alphabetical order)
+hash_fields = [
+    "atc_classifications",
+    "black_box_warning",
+    "cross_references",
+    "first_approval",
+    "first_in_class",
+    "inorganic_flag",
+    "max_phase",
+    "molecule_chembl_id",
+    "molecule_hierarchy",
+    "molecule_properties",
+    "molecule_structures",
+    "molecule_synonyms",
+    "molecule_type",
+    "natural_product",
+    "oral",
+    "parenteral",
+    "polymer_flag",
+    "pref_name",
+    "prodrug",
+    "structure_standard_inchi_key",
+    "structure_type",
+    "therapeutic_flag",
+    "topical",
+    "withdrawn_flag",
+]
+
+# Algorithm
+content_hash = sha256(f"chembl{canonical_json(filtered_record)}")
+```
+
+---
+
+## 5. Validation
+
+### 5.1. Pandera Schema
+
+```python
+# src/bioetl/domain/schemas/chembl/molecule.py
+
+class MoleculeSchema(ETLRecordSchema):
+    """Molecule validation schema for Silver layer."""
+
+    # === Identifiers ===
+    molecule_chembl_id: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^CHEMBL\d+$",
+        description="ChEMBL ID.",
+    )
+    structure_standard_inchi_key: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=INCHI_KEY_REGEX_PATTERN,  # ^[A-Z]{14}-[A-Z]{10}-[A-Z]$
+        description="Standard InChI Key (27 characters).",
+    )
+
+    # === Core Properties ===
+    pref_name: Series[str] | None = pa.Field(nullable=True)
+    max_phase: Series[float] | None = pa.Field(
+        nullable=True,
+        isin=[-1, 0, 0.5, 1, 2, 3, 4],
+    )
+    structure_type: Series[str] | None = pa.Field(
+        nullable=True,
+        isin=["MOL", "SEQ", "BOTH", "NONE"],
+    )
+    molecule_type: Series[str] | None = pa.Field(
+        nullable=True,
+        isin=[
+            "Small molecule", "Antibody", "Antibody drug conjugate",
+            "Protein", "Oligonucleotide", "Oligosaccharide", "Cell",
+            "Enzyme", "Unknown", "Unclassified", "Inorganic small molecule",
+            "Polymeric small molecule",
+        ],
+    )
+    first_approval: Series[int] | None = pa.Field(nullable=True)
+
+    # === Flags ===
+    therapeutic_flag: Series[bool] | None = pa.Field(nullable=True)
+    oral: Series[bool] | None = pa.Field(nullable=True)
+    parenteral: Series[bool] | None = pa.Field(nullable=True)
+    topical: Series[bool] | None = pa.Field(nullable=True)
+    black_box_warning: Series[int] | None = pa.Field(nullable=True, isin=[0, 1])
+    natural_product: Series[int] | None = pa.Field(nullable=True, isin=[-1, 0, 1])
+    first_in_class: Series[int] | None = pa.Field(nullable=True, isin=[0, 1])
+    prodrug: Series[int] | None = pa.Field(nullable=True, isin=[0, 1])
+    inorganic_flag: Series[int] | None = pa.Field(nullable=True, isin=[0, 1])
+    polymer_flag: Series[int] | None = pa.Field(nullable=True, isin=[0, 1])
+    withdrawn_flag: Series[bool] | None = pa.Field(nullable=True)
+
+    # === Complex Fields (JSON Strings) ===
+    molecule_hierarchy: Series[str] | None = pa.Field(nullable=True)
+    molecule_properties: Series[str] | None = pa.Field(nullable=True)
+    molecule_structures: Series[str] | None = pa.Field(nullable=True)
+    molecule_synonyms: Series[str] | None = pa.Field(nullable=True)
+    cross_references: Series[str] | None = pa.Field(nullable=True)
+    atc_classifications: Series[str] | None = pa.Field(nullable=True)
+
+    class Config:
+        strict = True
+        ordered = False
+        coerce = True
+```
+
+### 5.2. Field Validation Matrix
+
+| Field | Type | Nullable | Constraints | DQ Level | Failure Action |
+|-------|------|----------|-------------|----------|----------------|
+| `molecule_chembl_id` | str | No | regex `^CHEMBL\d+$` | CRITICAL | Quarantine |
+| `structure_standard_inchi_key` | str | Yes | InChI Key format | WARNING | Log |
+| `pref_name` | str | Yes | - | INFO | Log |
+| `max_phase` | float | Yes | isin [-1,0,0.5,1,2,3,4] | WARNING | Log |
+| `molecule_type` | str | Yes | isin [...] | WARNING | Log |
+| `black_box_warning` | int | Yes | isin [0,1] | WARNING | Log |
+
+### 5.3. DQ Thresholds
+
+| Threshold | Value | Action |
+|-----------|-------|--------|
+| Soft | 5% | Warning, continue |
+| Hard | 20% | Fail batch |
+| Critical field null | molecule_chembl_id is null | Fail immediately |
+
+---
+
+## 6. Output Schemas
+
+### 6.1. Bronze
+
+```
+Path: bronze/v1/chembl/molecule/{YYYY-MM-DD}/
+Format: JSONL + zstd
+Mode: Append-only
+Retention: 90 days → Archive
+```
+
+### 6.2. Silver
+
+```
+Path: silver/chembl/molecule/
+Format: Delta Lake (delta-rs)
+Mode: Merge on [molecule_chembl_id]
+Partition: None
+Retention: Permanent
+```
+
+### 6.3. Gold
+
+```
+Path: gold/chembl/molecule/
+Format: Delta Lake
+Mode: Overwrite
+```
+
+**Gold Filter:** Valid molecules with structure
+
+---
+
+## 7. Dependencies
+
+### 7.1. Upstream
+
+| Dependency | Type | Required |
+|------------|------|----------|
+| ChEMBL API | API | Yes |
+| Input CSV | File | Optional |
+
+### 7.2. Downstream
+
+| Consumer | Impact |
+|----------|--------|
+| `chembl_activity` | FK reference |
+| `chembl_compound_record` | FK reference |
+| SAR analytics | Structure-activity analysis |
+
+### 7.3. Cross-Provider Mapping
+
+| This Entity Field | Maps To | Provider | Field |
+|-------------------|---------|----------|-------|
+| `structure_standard_inchi_key` | PubChem | PubChem | `inchi_key` |
+| `cross_references[drugbank]` | DrugBank | DrugBank | ID |
+
+---
+
+## 8. Pipeline Configuration
+
+```yaml
+# configs/pipelines/chembl/molecule.yaml
+
+pipeline_name: chembl_molecule
+provider: chembl
+entity_type: molecule
+version: "1.1.0"
+description: "Extract molecules from ChEMBL API"
+
+primary_keys: ["molecule_chembl_id"]
+silver_table: "chembl_molecule"
+gold_table: "chembl_molecule"
+
+source_file: ../../sources/chembl.yaml
+
+gold_filters:
+  required_fields:
+    - molecule_chembl_id
+
+sink:
+  bronze:
+    path: "data/output/bronze"
+  silver:
+    path: "data/output/silver"
+    primary_key: ["molecule_chembl_id"]
+    partition_by: []
+    csv_export:
+      path: "data/output/csv/silver"
+  gold:
+    path: "data/output/gold"
+    csv_export:
+      path: "data/output/csv/gold"
+
+input_filter:
+  enabled: true
+  source_path: "data/input/molecule.csv"
+  column_name: "molecule_chembl_id"
+  filter_field: "molecule_chembl_id"
+  batch_size: 20
+```
+
+---
+
+## 9. Testing Requirements
+
+- [x] Unit tests for normalization and validation
+- [x] VCR integration tests
+- [x] Architecture compliance tests

--- a/docs/pipelines/chembl/04-target-spec.md
+++ b/docs/pipelines/chembl/04-target-spec.md
@@ -1,0 +1,211 @@
+# ChEMBL Target Pipeline Specification
+
+*Version 1.1.0 | Aligned with RULES.md v5.10*
+
+---
+
+## 1. Identification
+
+| Parameter | Value |
+|-----------|-------|
+| **Pipeline ID** | `chembl_target` |
+| **Provider** | ChEMBL (EBI) |
+| **Entity** | target |
+| **API Endpoint** | `https://www.ebi.ac.uk/chembl/api/data/target` |
+| **Library** | `chembl_webresource_client` |
+| **Rate Limit** | None (polite usage recommended) |
+| **Health Check** | `/chembl/api/data/status.json` |
+| **Auth Type** | None (public API) |
+
+---
+
+## 2. Business Context
+
+### 2.1. Entity Purpose
+
+Targets represent **biological entities** that drugs interact with:
+
+- **Drug targets**: Proteins, protein complexes, cell lines, organisms
+- **Target classification**: Single proteins, protein families, complexes
+- **Species context**: Organism and taxonomy information
+- **Cross-database linking**: UniProt accessions for protein targets
+
+### 2.2. Use Cases
+
+1. **Target Identification**: Find druggable targets for diseases
+2. **Target Deconvolution**: Identify off-target effects
+3. **Species Translation**: Compare targets across organisms
+4. **Target Class Analysis**: Analyze druggability by target type
+
+### 2.3. Entity Relationships
+
+```
+target
+    │
+    ├──◄──FK──activity.target_chembl_id (1:M)
+    │
+    ├──◄──FK──assay.target_chembl_id (1:M)
+    │
+    └── target_components (nested array)
+        ├── component_id
+        ├── accession (UniProt)
+        └── component_type
+```
+
+### 2.4. Load Strategy
+
+| Parameter | Value |
+|-----------|-------|
+| **Strategy** | `incremental` with input filter |
+| **Watermark Field** | N/A |
+| **Estimated Volume** | ~15,000 records total |
+| **Batch Size** | 20 (filter batch) |
+
+---
+
+## 3. Extraction (Bronze Layer)
+
+### 3.1. Complete API Fields
+
+| # | API Field | JSON Type | Nullable | Nested | Description |
+|---|-----------|-----------|----------|--------|-------------|
+| 1 | `target_chembl_id` | string | No | - | Primary key |
+| 2 | `target_type` | string | Yes | - | Type classification |
+| 3 | `pref_name` | string | Yes | - | Preferred name |
+| 4 | `organism` | string | Yes | - | Organism name |
+| 5 | `tax_id` | integer | Yes | - | NCBI Taxonomy ID |
+| 6 | `species_group_flag` | boolean | Yes | - | Species group flag |
+| 7 | `downgraded` | boolean | Yes | - | Deprecated flag |
+| 8 | `target_components` | array | Yes | Yes | Component list |
+| 9 | `cross_references` | array | Yes | Yes | External refs |
+
+### 3.2. Nested Structure: target_components
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `component_id` | integer | Component ID |
+| `component_type` | string | PROTEIN/DNA/RNA |
+| `accession` | string | UniProt accession |
+| `component_description` | string | Description |
+| `relationship` | string | Relationship type |
+
+---
+
+## 4. Transformation
+
+### 4.1. Entity ID Strategy
+
+| Parameter | Value |
+|-----------|-------|
+| **Entity ID Field** | `target_chembl_id` |
+| **ID Source** | `from_api` |
+| **Format** | ChEMBL ID (CHEMBL[0-9]+) |
+
+### 4.2. Flattening Strategy
+
+| Nested Path | Flattened Name | Strategy |
+|-------------|----------------|----------|
+| `target_components[*].accession` | `component_accessions` | Extract list |
+| `target_components[*].component_id` | `component_ids` | Extract list |
+| `target_components[*].component_type` | `component_types` | Extract list |
+| `target_components` | `target_components` | JSON string |
+| `cross_references` | `cross_references` | JSON string |
+
+---
+
+## 5. Validation
+
+### 5.1. Pandera Schema
+
+```python
+class TargetSchema(ETLRecordSchema):
+    """Target validation schema for Silver layer."""
+
+    # === Identifiers ===
+    target_chembl_id: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^CHEMBL\d+$",
+    )
+
+    # === Classification ===
+    target_type: Series[str] | None = pa.Field(
+        nullable=True,
+        isin=[
+            "SINGLE PROTEIN", "PROTEIN FAMILY", "PROTEIN COMPLEX",
+            "PROTEIN COMPLEX GROUP", "SELECTIVITY GROUP", "CHIMERIC PROTEIN",
+            "CELL-LINE", "TISSUE", "ORGANISM", "MACROMOLECULE",
+            "SMALL MOLECULE", "LIPID", "METAL", "UNKNOWN",
+        ],
+    )
+
+    # === Metadata ===
+    pref_name: Series[str] | None = pa.Field(nullable=True)
+    tax_id: Series[int] | None = pa.Field(nullable=True)
+    organism: Series[str] | None = pa.Field(nullable=True)
+    species_group_flag: Series[bool] | None = pa.Field(nullable=True)
+    downgraded: Series[bool] | None = pa.Field(nullable=True)
+
+    # === Complex Fields ===
+    target_components: Series[str] | None = pa.Field(nullable=True)
+    cross_references: Series[str] | None = pa.Field(nullable=True)
+
+    # === Flattened Lists ===
+    component_accessions: Series[object] | None = pa.Field(nullable=True)
+    component_ids: Series[object] | None = pa.Field(nullable=True)
+    component_types: Series[object] | None = pa.Field(nullable=True)
+    component_relationships: Series[object] | None = pa.Field(nullable=True)
+    component_descriptions: Series[object] | None = pa.Field(nullable=True)
+
+    class Config:
+        strict = True
+        ordered = False
+        coerce = True
+```
+
+### 5.2. Field Validation Matrix
+
+| Field | Type | Nullable | Constraints | DQ Level |
+|-------|------|----------|-------------|----------|
+| `target_chembl_id` | str | No | regex `^CHEMBL\d+$` | CRITICAL |
+| `target_type` | str | Yes | isin [...] | WARNING |
+| `tax_id` | int | Yes | >= 1 | WARNING |
+| `organism` | str | Yes | - | INFO |
+
+---
+
+## 6. Dependencies
+
+### 6.1. Cross-Provider Mapping
+
+| This Entity Field | Maps To | Provider | Field |
+|-------------------|---------|----------|-------|
+| `component_accessions[*]` | UniProt | UniProt | `accession` |
+| `target_chembl_id` | UniProt ID Mapping | UniProt | `from_id` |
+
+---
+
+## 7. Pipeline Configuration
+
+```yaml
+pipeline_name: chembl_target
+provider: chembl
+entity_type: target
+version: "1.1.0"
+
+primary_keys: ["target_chembl_id"]
+silver_table: "chembl_target"
+gold_table: "chembl_target"
+
+gold_filters:
+  required_fields:
+    - pref_name
+  columns:
+    downgraded: [false]
+
+input_filter:
+  enabled: true
+  source_path: "data/input/target.csv"
+  column_name: "target_chembl_id"
+  filter_field: "target_chembl_id"
+  batch_size: 20
+```

--- a/docs/pipelines/chembl/05-activity-spec.md
+++ b/docs/pipelines/chembl/05-activity-spec.md
@@ -1,0 +1,449 @@
+# ChEMBL Activity Pipeline Specification
+
+*Version 1.1.0 | Aligned with RULES.md v5.10*
+
+---
+
+## 1. Identification
+
+| Parameter | Value |
+|-----------|-------|
+| **Pipeline ID** | `chembl_activity` |
+| **Provider** | ChEMBL (EBI) |
+| **Entity** | activity |
+| **API Endpoint** | `https://www.ebi.ac.uk/chembl/api/data/activity` |
+| **Library** | `chembl_webresource_client` |
+| **Rate Limit** | None (polite usage recommended) |
+| **Health Check** | `/chembl/api/data/status.json` |
+| **Auth Type** | None (public API) |
+
+---
+
+## 2. Business Context
+
+### 2.1. Entity Purpose
+
+Activities are the **core measurement data** in ChEMBL, representing bioactivity measurements of molecules against biological targets:
+
+- **Bioactivity measurements**: IC50, Ki, EC50, potency, inhibition
+- **Structure-Activity Relationships (SAR)**: Connect molecules to targets via measured values
+- **Drug discovery data**: Quantitative data from screening and assays
+- **Data quality tracking**: Standardized values with quality annotations
+
+### 2.2. Use Cases
+
+1. **SAR Analysis**: Analyze activity profiles for lead compounds
+2. **Target Druggability**: Assess targets by activity data availability
+3. **Compound Ranking**: Rank molecules by pChEMBL value
+4. **Data Quality Assessment**: Filter by standardization and validity flags
+5. **Literature Mining**: Link activities to source publications
+
+### 2.3. Entity Relationships
+
+```
+activity
+    │
+    ├──FK──► assay.assay_chembl_id (M:1, required)
+    │
+    ├──FK──► molecule.molecule_chembl_id (M:1, required)
+    │
+    ├──FK──► target.target_chembl_id (M:1, optional)
+    │
+    ├──FK──► document.document_chembl_id (M:1, optional)
+    │
+    └── ligand_efficiency (nested object)
+        ├── bei, le, lle, sei
+```
+
+### 2.4. Load Strategy
+
+| Parameter | Value |
+|-----------|-------|
+| **Strategy** | `incremental` with input filter |
+| **Watermark Field** | N/A (filtered by assay/molecule/target IDs) |
+| **Estimated Volume** | ~20M records total |
+| **Batch Size** | 20 (filter batch) |
+
+---
+
+## 3. Extraction (Bronze Layer)
+
+### 3.1. API Request
+
+```python
+from chembl_webresource_client.new_client import new_client
+
+activity = new_client.activity
+# Filter by target, molecule, or assay
+results = activity.filter(target_chembl_id__in=target_ids)
+```
+
+### 3.2. Complete API Fields
+
+| # | API Field | JSON Type | Nullable | Description | Example |
+|---|-----------|-----------|----------|-------------|---------|
+| 1 | `activity_id` | integer | No | Primary key | `12345678` |
+| 2 | `assay_chembl_id` | string | No | FK to assay | `"CHEMBL123456"` |
+| 3 | `molecule_chembl_id` | string | No | FK to molecule | `"CHEMBL25"` |
+| 4 | `target_chembl_id` | string | Yes | FK to target | `"CHEMBL240"` |
+| 5 | `document_chembl_id` | string | Yes | FK to document | `"CHEMBL1234"` |
+| 6 | `standard_type` | string | Yes | Measurement type | `"IC50"` |
+| 7 | `standard_relation` | string | Yes | Relation | `"="` |
+| 8 | `standard_value` | number | Yes | Standardized value | `50.0` |
+| 9 | `standard_units` | string | Yes | Standardized units | `"nM"` |
+| 10 | `standard_flag` | integer | Yes | Standardized flag | `1` |
+| 11 | `pchembl_value` | number | Yes | -log10 molar | `7.3` |
+| 12 | `data_validity_comment` | string | Yes | DQ comment | `"Potential author error"` |
+| 13 | `activity_comment` | string | Yes | Text comment | `"Active"` |
+| 14 | `potential_duplicate` | integer | Yes | Duplicate flag | `0` |
+| 15 | `type` | string | Yes | Original type | `"IC50"` |
+| 16 | `relation` | string | Yes | Original relation | `"="` |
+| 17 | `value` | number | Yes | Original value | `50.0` |
+| 18 | `units` | string | Yes | Original units | `"nM"` |
+| 19 | `text_value` | string | Yes | Text value | `"Active"` |
+| 20 | `standard_text_value` | string | Yes | Std text value | `"Active"` |
+| 21 | `upper_value` | number | Yes | Upper bound | `100.0` |
+| 22 | `standard_upper_value` | number | Yes | Std upper bound | `100.0` |
+| 23 | `src_id` | integer | Yes | Source ID | `1` |
+| 24 | `record_id` | integer | Yes | FK compound_record | `12345` |
+| 25 | `toid` | integer | Yes | Test Occasion ID | `1` |
+| 26 | `bao_endpoint` | string | Yes | BAO endpoint ID | `"BAO:0000190"` |
+| 27 | `uo_units` | string | Yes | UO units ID | `"UO:0000065"` |
+| 28 | `qudt_units` | string | Yes | QUDT units | `"nM"` |
+| 29 | `ligand_efficiency` | object | Yes | Efficiency metrics | JSON |
+| 30 | `activity_properties` | array | Yes | Properties | JSON |
+
+### 3.3. Nested Structure: ligand_efficiency
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `bei` | float | Binding Efficiency Index |
+| `le` | float | Ligand Efficiency |
+| `lle` | float | Lipophilic Ligand Efficiency |
+| `sei` | float | Surface Efficiency Index |
+
+### 3.4. Denormalized Fields (from related entities)
+
+The API also returns denormalized fields from related entities:
+
+| Field | Source Entity | Description |
+|-------|---------------|-------------|
+| `canonical_smiles` | molecule.structures | SMILES string |
+| `molecule_pref_name` | molecule | Molecule name |
+| `parent_molecule_chembl_id` | molecule.hierarchy | Parent molecule |
+| `target_pref_name` | target | Target name |
+| `target_organism` | target | Organism |
+| `target_tax_id` | target | Taxonomy ID |
+| `assay_type` | assay | Assay type |
+| `assay_description` | assay | Description |
+| `bao_format` | assay | BAO format |
+| `bao_label` | assay | BAO label |
+| `document_journal` | document | Journal |
+| `document_year` | document | Year |
+
+---
+
+## 4. Transformation
+
+### 4.1. Entity ID Strategy
+
+| Parameter | Value |
+|-----------|-------|
+| **Entity ID Field** | `activity_id` |
+| **ID Source** | `from_api` |
+| **Format** | Integer (cast to string) |
+
+### 4.2. Field Normalization
+
+| Field | Normalization | Before | After |
+|-------|---------------|--------|-------|
+| `activity_id` | Cast to string | `12345678` | `"12345678"` |
+| `standard_value` | round(10) | `50.123456789012` | `50.1234567890` |
+| `pchembl_value` | round(2) | `7.3456` | `7.35` |
+| `standard_relation` | Validate isin | `"="` | `"="` |
+| `standard_units` | strip() | `" nM "` | `"nM"` |
+
+### 4.3. Flattening Strategy
+
+| Nested Path | Flattened Name | Strategy |
+|-------------|----------------|----------|
+| `ligand_efficiency.bei` | `ligand_efficiency_bei` | Extract scalar |
+| `ligand_efficiency.le` | `ligand_efficiency_le` | Extract scalar |
+| `ligand_efficiency.lle` | `ligand_efficiency_lle` | Extract scalar |
+| `ligand_efficiency.sei` | `ligand_efficiency_sei` | Extract scalar |
+| `activity_properties` | `activity_properties` | JSON string |
+
+### 4.4. Content Hash Specification
+
+```python
+# Fields included in hash (primary activity data)
+hash_fields = [
+    "activity_id",
+    "assay_chembl_id",
+    "molecule_chembl_id",
+    "target_chembl_id",
+    "standard_type",
+    "standard_relation",
+    "standard_value",
+    "standard_units",
+    "pchembl_value",
+    "data_validity_comment",
+]
+
+# Fields EXCLUDED from hash
+excluded = [
+    "_ingestion_ts", "_run_id", "_run_type", "_dq_*",
+    # Denormalized fields (can change independently)
+    "molecule_pref_name", "target_pref_name", "assay_description",
+]
+
+# Algorithm
+content_hash = sha256(f"chembl{canonical_json(filtered_record)}")
+```
+
+---
+
+## 5. Validation
+
+### 5.1. Pandera Schema
+
+```python
+class ActivitySchema(ETLRecordSchema):
+    """Activity validation schema for Silver layer."""
+
+    # === Primary Key ===
+    activity_id: Series[str] = pa.Field(nullable=False)
+
+    # === Foreign Keys ===
+    assay_chembl_id: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^CHEMBL\d+$",
+    )
+    molecule_chembl_id: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^CHEMBL\d+$",
+    )
+    target_chembl_id: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^CHEMBL\d+$",
+    )
+    document_chembl_id: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^CHEMBL\d+$",
+    )
+
+    # === Standardized Values ===
+    standard_relation: Series[str] | None = pa.Field(
+        nullable=True,
+        isin=["=", "<", "<=", ">", ">="],
+    )
+    standard_value: Series[float] | None = pa.Field(
+        nullable=True,
+        ge=0,
+    )
+    standard_units: Series[str] | None = pa.Field(nullable=True)
+    standard_type: Series[str] | None = pa.Field(
+        nullable=True,
+        isin=[
+            "IC50", "EC50", "Ki", "Kd", "AC50", "GI50",
+            "Potency", "Inhibition", "% Inhibition", "Activity",
+            "Ratio", "ED50", "ID50",
+        ],
+    )
+    standard_flag: Series[int] | None = pa.Field(
+        nullable=True,
+        isin=[0, 1],
+    )
+
+    # === Derived Metrics ===
+    pchembl_value: Series[float] | None = pa.Field(
+        nullable=True,
+        ge=0,
+        le=14,
+    )
+
+    # === Comments & Quality ===
+    data_validity_comment: Series[str] | None = pa.Field(
+        nullable=True,
+        isin=[
+            "Potential missing data", "Potential author error",
+            "Manually validated", "Potential transcription error",
+            "Outside typical range", "Non standard unit for type",
+            "Author confirmed error",
+        ],
+    )
+    activity_comment: Series[str] | None = pa.Field(nullable=True)
+    potential_duplicate: Series[int] | None = pa.Field(
+        nullable=True,
+        isin=[0, 1],
+    )
+
+    # === Ontologies ===
+    bao_endpoint: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^BAO:\d+$",
+    )
+
+    # === Flattened Ligand Efficiency ===
+    ligand_efficiency_bei: Series[float] | None = pa.Field(nullable=True)
+    ligand_efficiency_le: Series[float] | None = pa.Field(nullable=True)
+    ligand_efficiency_lle: Series[float] | None = pa.Field(nullable=True)
+    ligand_efficiency_sei: Series[float] | None = pa.Field(nullable=True)
+
+    # === Denormalized Fields ===
+    canonical_smiles: Series[str] | None = pa.Field(nullable=True)
+    molecule_pref_name: Series[str] | None = pa.Field(nullable=True)
+    target_pref_name: Series[str] | None = pa.Field(nullable=True)
+    target_organism: Series[str] | None = pa.Field(nullable=True)
+    assay_type: Series[str] | None = pa.Field(nullable=True)
+    assay_description: Series[str] | None = pa.Field(nullable=True)
+
+    class Config:
+        strict = True
+        ordered = False
+        coerce = True
+```
+
+### 5.2. Field Validation Matrix
+
+| Field | Type | Nullable | Constraints | DQ Level |
+|-------|------|----------|-------------|----------|
+| `activity_id` | str | No | unique | CRITICAL |
+| `assay_chembl_id` | str | No | regex `^CHEMBL\d+$` | CRITICAL |
+| `molecule_chembl_id` | str | No | regex `^CHEMBL\d+$` | CRITICAL |
+| `target_chembl_id` | str | Yes | regex `^CHEMBL\d+$` | WARNING |
+| `standard_value` | float | Yes | >= 0 | WARNING |
+| `pchembl_value` | float | Yes | [0, 14] | WARNING |
+| `standard_type` | str | Yes | isin [...] | WARNING |
+| `standard_relation` | str | Yes | isin ["=","<","<=",">",">="] | WARNING |
+
+### 5.3. Cross-Field Validation Rules
+
+| Rule Name | Fields | Condition | Failure Action |
+|-----------|--------|-----------|----------------|
+| `value_relation_consistency` | `standard_value`, `standard_relation` | If relation is "=" then upper_value is null | Warning |
+| `pchembl_type_consistency` | `pchembl_value`, `standard_type` | pChEMBL only for binding types | Warning |
+
+### 5.4. DQ Thresholds
+
+| Threshold | Value | Action |
+|-----------|-------|--------|
+| Soft | 5% | Warning, continue |
+| Hard | 20% | Fail batch |
+| Critical field null | activity_id, assay_chembl_id, molecule_chembl_id | Fail immediately |
+
+---
+
+## 6. Output Schemas
+
+### 6.1. Bronze
+
+```
+Path: bronze/v1/chembl/activity/{YYYY-MM-DD}/
+Format: JSONL + zstd
+Mode: Append-only
+Retention: 90 days → Archive
+```
+
+### 6.2. Silver
+
+```
+Path: silver/chembl/activity/
+Format: Delta Lake (delta-rs)
+Mode: Merge on [activity_id]
+Partition: None
+Retention: Permanent
+```
+
+### 6.3. Gold
+
+```
+Path: gold/chembl/activity/
+Format: Delta Lake
+Mode: Overwrite
+```
+
+**Gold Filters:**
+- `standard_type IN ('IC50', 'Ki')` — Focus on binding data
+- `standard_units = 'nM'` — Normalized units
+- `standard_relation = '='` — Exact measurements
+- `target_chembl_id IS NOT NULL` — Target required
+
+---
+
+## 7. Dependencies
+
+### 7.1. Upstream
+
+| Dependency | Type | Required |
+|------------|------|----------|
+| ChEMBL API | API | Yes |
+| `chembl_assay` | Pipeline | Recommended |
+| `chembl_molecule` | Pipeline | Recommended |
+| `chembl_target` | Pipeline | Recommended |
+
+### 7.2. Downstream
+
+| Consumer | Impact |
+|----------|--------|
+| SAR analytics | Activity-based analysis |
+| ML training datasets | Bioactivity prediction |
+| Target prioritization | Druggability assessment |
+
+---
+
+## 8. Pipeline Configuration
+
+```yaml
+# configs/pipelines/chembl/activity.yaml
+
+pipeline_name: chembl_activity
+provider: chembl
+entity_type: activity
+version: "1.1.0"
+
+primary_keys: ["activity_id"]
+silver_table: "chembl_activity"
+gold_table: "chembl_activity"
+
+gold_filters:
+  columns:
+    standard_type: [IC50, Ki]
+    standard_units: [nM]
+    standard_relation: ["="]
+  ranges:
+    standard_value:
+      min: 0
+      include_min: false
+  required_fields:
+    - standard_type
+    - standard_value
+    - standard_units
+    - target_chembl_id
+
+sink:
+  bronze:
+    path: "data/output/bronze"
+  silver:
+    path: "data/output/silver"
+    primary_key: ["activity_id"]
+    partition_by: []
+  gold:
+    path: "data/output/gold"
+
+input_filter:
+  enabled: true
+  source_path: "data/input/target.csv"
+  column_name: "target_chembl_id"
+  filter_field: "target_chembl_id"
+  batch_size: 20
+```
+
+---
+
+## 9. Testing Requirements
+
+- [x] Unit tests for all normalizations
+- [x] Validation of pchembl_value range
+- [x] VCR integration tests
+- [x] Architecture compliance tests

--- a/docs/pipelines/chembl/06-assay-spec.md
+++ b/docs/pipelines/chembl/06-assay-spec.md
@@ -1,0 +1,261 @@
+# ChEMBL Assay Pipeline Specification
+
+*Version 1.1.0 | Aligned with RULES.md v5.10*
+
+---
+
+## 1. Identification
+
+| Parameter | Value |
+|-----------|-------|
+| **Pipeline ID** | `chembl_assay` |
+| **Provider** | ChEMBL (EBI) |
+| **Entity** | assay |
+| **API Endpoint** | `https://www.ebi.ac.uk/chembl/api/data/assay` |
+| **Library** | `chembl_webresource_client` |
+| **Rate Limit** | None (polite usage recommended) |
+| **Health Check** | `/chembl/api/data/status.json` |
+| **Auth Type** | None (public API) |
+
+---
+
+## 2. Business Context
+
+### 2.1. Entity Purpose
+
+Assays represent **experimental protocols** used to measure bioactivity:
+
+- **Experimental methods**: Binding assays, functional assays, ADMET tests
+- **Target context**: Links experiments to biological targets
+- **Data provenance**: Source publications and curators
+- **Quality metadata**: Confidence scores and relationship types
+
+### 2.2. Use Cases
+
+1. **Protocol Analysis**: Understand experimental conditions for activities
+2. **Assay Selection**: Choose appropriate assays for screening
+3. **Data Quality Assessment**: Filter by confidence and relationship type
+4. **Cell-based vs Biochemical**: Compare assay types
+
+### 2.3. Entity Relationships
+
+```
+assay
+    │
+    ├──FK──► target.target_chembl_id (M:1, optional)
+    │
+    ├──FK──► document.document_chembl_id (M:1, optional)
+    │
+    ├──FK──► cell_line.cell_chembl_id (M:1, optional)
+    │
+    ├──◄──FK──activity.assay_chembl_id (1:M)
+    │
+    └──◄──FK──assay_parameters (1:M)
+```
+
+### 2.4. Load Strategy
+
+| Parameter | Value |
+|-----------|-------|
+| **Strategy** | `incremental` with input filter |
+| **Estimated Volume** | ~1.5M records total |
+| **Batch Size** | 20 (filter batch) |
+
+---
+
+## 3. Extraction (Bronze Layer)
+
+### 3.1. Complete API Fields
+
+| # | API Field | JSON Type | Nullable | Description |
+|---|-----------|-----------|----------|-------------|
+| 1 | `assay_chembl_id` | string | No | Primary key |
+| 2 | `description` | string | Yes | Assay description |
+| 3 | `assay_type` | string | Yes | B/F/A/T/P/U |
+| 4 | `assay_test_type` | string | Yes | In vivo/vitro/ex vivo |
+| 5 | `assay_category` | string | Yes | screening/confirmatory/... |
+| 6 | `assay_organism` | string | Yes | Organism |
+| 7 | `assay_tax_id` | integer | Yes | NCBI Taxonomy ID |
+| 8 | `assay_strain` | string | Yes | Strain |
+| 9 | `assay_tissue` | string | Yes | Tissue |
+| 10 | `assay_cell_type` | string | Yes | Cell type |
+| 11 | `assay_subcellular_fraction` | string | Yes | Subcellular fraction |
+| 12 | `target_chembl_id` | string | Yes | FK to target |
+| 13 | `relationship_type` | string | Yes | D/H/M/N/S/U |
+| 14 | `relationship_description` | string | Yes | Relationship desc |
+| 15 | `confidence_score` | integer | Yes | 0-9 score |
+| 16 | `confidence_description` | string | Yes | Confidence desc |
+| 17 | `src_id` | integer | Yes | Source ID |
+| 18 | `src_assay_id` | string | Yes | Source assay ID |
+| 19 | `document_chembl_id` | string | Yes | FK to document |
+| 20 | `cell_chembl_id` | string | Yes | FK to cell_line |
+| 21 | `tissue_chembl_id` | string | Yes | FK to tissue |
+| 22 | `bao_format` | string | Yes | BAO format ID |
+| 23 | `bao_label` | string | Yes | BAO label |
+| 24 | `assay_classifications` | array | Yes | Classifications |
+| 25 | `assay_parameters` | array | Yes | Parameters |
+| 26 | `variant_sequence` | object | Yes | Variant info |
+
+---
+
+## 4. Transformation
+
+### 4.1. Entity ID Strategy
+
+| Parameter | Value |
+|-----------|-------|
+| **Entity ID Field** | `assay_chembl_id` |
+| **ID Source** | `from_api` |
+| **Format** | ChEMBL ID (CHEMBL[0-9]+) |
+
+### 4.2. Flattening Strategy
+
+| Nested Path | Flattened Name | Strategy |
+|-------------|----------------|----------|
+| `variant_sequence.accession` | `variant_accession` | Extract scalar |
+| `variant_sequence.mutation` | `variant_mutation` | Extract scalar |
+| `variant_sequence.organism` | `variant_organism` | Extract scalar |
+| `variant_sequence.tax_id` | `variant_tax_id` | Extract scalar |
+| `variant_sequence.sequence` | `variant_sequence` | Extract scalar |
+| `assay_classifications` | `assay_classifications` | JSON string |
+| `assay_parameters` | `assay_parameters` | JSON string |
+
+---
+
+## 5. Validation
+
+### 5.1. Pandera Schema
+
+```python
+class AssaySchema(ETLRecordSchema):
+    """Assay validation schema for Silver layer."""
+
+    # === Primary Key ===
+    assay_chembl_id: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^CHEMBL\d+$",
+    )
+
+    # === Description & Classification ===
+    description: Series[str] | None = pa.Field(nullable=True)
+    assay_type: Series[str] | None = pa.Field(
+        nullable=True,
+        isin=["B", "F", "A", "T", "P", "U"],
+    )
+    assay_test_type: Series[str] | None = pa.Field(
+        nullable=True,
+        isin=["In vivo", "In vitro", "Ex vivo"],
+    )
+    assay_category: Series[str] | None = pa.Field(
+        nullable=True,
+        isin=["screening", "confirmatory", "panel", "summary", "other"],
+    )
+
+    # === Biological Context ===
+    assay_organism: Series[str] | None = pa.Field(nullable=True)
+    assay_tax_id: Series[int] | None = pa.Field(nullable=True)
+    assay_strain: Series[str] | None = pa.Field(nullable=True)
+    assay_tissue: Series[str] | None = pa.Field(nullable=True)
+    assay_cell_type: Series[str] | None = pa.Field(nullable=True)
+
+    # === Target & Relationship ===
+    target_chembl_id: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^CHEMBL\d+$",
+    )
+    relationship_type: Series[str] | None = pa.Field(
+        nullable=True,
+        isin=["D", "H", "M", "N", "S", "U"],
+    )
+    confidence_score: Series[int] | None = pa.Field(
+        nullable=True,
+        ge=0,
+        le=9,
+    )
+
+    # === Foreign Keys ===
+    document_chembl_id: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^CHEMBL\d+$",
+    )
+    cell_chembl_id: Series[str] | None = pa.Field(nullable=True)
+    tissue_chembl_id: Series[str] | None = pa.Field(nullable=True)
+
+    # === Ontologies ===
+    bao_format: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^BAO:\d+$",
+    )
+    bao_label: Series[str] | None = pa.Field(nullable=True)
+
+    # === Variant Information ===
+    variant_accession: Series[str] | None = pa.Field(nullable=True)
+    variant_mutation: Series[str] | None = pa.Field(nullable=True)
+    variant_organism: Series[str] | None = pa.Field(nullable=True)
+    variant_tax_id: Series[int] | None = pa.Field(nullable=True)
+
+    # === Complex Fields ===
+    assay_classifications: Series[str] | None = pa.Field(nullable=True)
+    assay_parameters: Series[str] | None = pa.Field(nullable=True)
+
+    class Config:
+        strict = True
+        ordered = False
+        coerce = True
+```
+
+### 5.2. Field Validation Matrix
+
+| Field | Type | Nullable | Constraints | DQ Level |
+|-------|------|----------|-------------|----------|
+| `assay_chembl_id` | str | No | regex `^CHEMBL\d+$` | CRITICAL |
+| `assay_type` | str | Yes | isin [B,F,A,T,P,U] | WARNING |
+| `confidence_score` | int | Yes | [0, 9] | WARNING |
+| `target_chembl_id` | str | Yes | regex `^CHEMBL\d+$` | INFO |
+
+---
+
+## 6. Pipeline Configuration
+
+```yaml
+pipeline_name: chembl_assay
+provider: chembl
+entity_type: assay
+version: "1.1.0"
+
+primary_keys: ["assay_chembl_id"]
+silver_table: "chembl_assay"
+gold_table: "chembl_assay"
+
+gold_filters:
+  required_fields:
+    - description
+  columns:
+    confidence_score: [7, 8, 9]  # High confidence only
+
+input_filter:
+  enabled: true
+  source_path: "data/input/assay.csv"
+  column_name: "assay_chembl_id"
+  filter_field: "assay_chembl_id"
+  batch_size: 20
+```
+
+---
+
+## 7. Dependencies
+
+### 7.1. Upstream
+
+| Dependency | Type | Required |
+|------------|------|----------|
+| ChEMBL API | API | Yes |
+| `chembl_target` | Pipeline | Recommended |
+
+### 7.2. Downstream
+
+| Consumer | Impact |
+|----------|--------|
+| `chembl_activity` | FK reference |
+| `chembl_assay_parameters` | FK reference |
+| Protocol analysis | Assay type statistics |

--- a/docs/pipelines/chembl/07-publication-spec.md
+++ b/docs/pipelines/chembl/07-publication-spec.md
@@ -1,0 +1,168 @@
+# ChEMBL Publication (Document) Pipeline Specification
+
+*Version 1.1.0 | Aligned with RULES.md v5.10*
+
+---
+
+## 1. Identification
+
+| Parameter | Value |
+|-----------|-------|
+| **Pipeline ID** | `chembl_publication` |
+| **Provider** | ChEMBL (EBI) |
+| **Entity** | document |
+| **API Endpoint** | `https://www.ebi.ac.uk/chembl/api/data/document` |
+| **Library** | `chembl_webresource_client` |
+| **Rate Limit** | None |
+| **Health Check** | `/chembl/api/data/status.json` |
+| **Auth Type** | None (public API) |
+
+---
+
+## 2. Business Context
+
+### 2.1. Entity Purpose
+
+Documents represent **scientific publications** that are sources of ChEMBL data:
+
+- **Data provenance**: Track original source of bioactivity data
+- **Literature mining**: Access publication metadata
+- **Cross-database linking**: DOI and PubMed ID mapping
+- **Patent data**: Track patent-derived information
+
+### 2.2. Use Cases
+
+1. **Citation Analysis**: Track publications with most bioactivity data
+2. **Data Attribution**: Credit original data sources
+3. **Literature Review**: Access abstracts and journal information
+4. **Cross-Provider Enrichment**: Link to PubMed, CrossRef for metadata
+
+### 2.3. Entity Relationships
+
+```
+document
+    │
+    ├──◄──FK──activity.document_chembl_id (1:M)
+    │
+    ├──◄──FK──assay.document_chembl_id (1:M)
+    │
+    └──◄──FK──compound_record.document_chembl_id (1:M)
+```
+
+---
+
+## 3. Extraction (Bronze Layer)
+
+### 3.1. Complete API Fields
+
+| # | API Field | JSON Type | Nullable | Description |
+|---|-----------|-----------|----------|-------------|
+| 1 | `document_chembl_id` | string | No | Primary key |
+| 2 | `doc_type` | string | Yes | PUBLICATION/PATENT/DATASET/BOOK |
+| 3 | `src_id` | integer | Yes | Source ID |
+| 4 | `pubmed_id` | integer | Yes | PubMed ID |
+| 5 | `doi` | string | Yes | DOI |
+| 6 | `patent_id` | string | Yes | Patent ID |
+| 7 | `title` | string | Yes | Title |
+| 8 | `authors` | string | Yes | Authors string |
+| 9 | `abstract` | string | Yes | Abstract |
+| 10 | `journal` | string | Yes | Journal abbreviation |
+| 11 | `journal_full_title` | string | Yes | Full journal title |
+| 12 | `year` | integer | Yes | Publication year |
+| 13 | `volume` | string | Yes | Volume |
+| 14 | `issue` | string | Yes | Issue |
+| 15 | `first_page` | string | Yes | First page |
+| 16 | `last_page` | string | Yes | Last page |
+
+---
+
+## 4. Validation
+
+### 4.1. Pandera Schema
+
+```python
+class ChemblPublicationSchema(ETLRecordSchema):
+    """ChEMBL Publication validation schema for Silver layer."""
+
+    # === Primary Key ===
+    document_chembl_id: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^CHEMBL\d+$",
+    )
+
+    # === External Identifiers ===
+    pubmed_id: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^\d+$",
+    )
+    doi: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=DOI_REGEX_PATTERN,
+    )
+    patent_id: Series[str] | None = pa.Field(nullable=True)
+    src_id: Series[int] | None = pa.Field(nullable=True)
+
+    # === Metadata ===
+    title: Series[str] | None = pa.Field(nullable=True)
+    doc_type: Series[str] | None = pa.Field(
+        nullable=True,
+        isin=["PUBLICATION", "PATENT", "DATASET", "BOOK"],
+    )
+    authors: Series[str] | None = pa.Field(nullable=True)
+    abstract: Series[str] | None = pa.Field(nullable=True)
+    journal: Series[str] | None = pa.Field(nullable=True)
+    journal_full_title: Series[str] | None = pa.Field(nullable=True)
+    year: Series[int] | None = pa.Field(
+        nullable=True,
+        ge=MIN_PUBLICATION_YEAR,  # 1800
+        le=MAX_PUBLICATION_YEAR,  # 2100
+    )
+    volume: Series[str] | None = pa.Field(nullable=True)
+    issue: Series[str] | None = pa.Field(nullable=True)
+    first_page: Series[str] | None = pa.Field(nullable=True)
+    last_page: Series[str] | None = pa.Field(nullable=True)
+
+    class Config:
+        strict = True
+        ordered = False
+        coerce = True
+```
+
+---
+
+## 5. Cross-Provider Mapping
+
+| This Entity Field | Maps To | Provider | Field |
+|-------------------|---------|----------|-------|
+| `pubmed_id` | PubMed | PubMed | `pmid` |
+| `doi` | CrossRef | CrossRef | `DOI` |
+| `doi` | OpenAlex | OpenAlex | `doi` |
+| `doi` | Semantic Scholar | S2 | `doi` |
+
+---
+
+## 6. Pipeline Configuration
+
+```yaml
+pipeline_name: chembl_publication
+provider: chembl
+entity_type: document
+version: "1.1.0"
+
+primary_keys: ["document_chembl_id"]
+silver_table: "chembl_publication"
+gold_table: "chembl_publication"
+
+gold_filters:
+  required_fields:
+    - title
+  columns:
+    doc_type: [PUBLICATION]
+
+input_filter:
+  enabled: true
+  source_path: "data/input/document.csv"
+  column_name: "document_chembl_id"
+  filter_field: "document_chembl_id"
+  batch_size: 20
+```

--- a/docs/pipelines/chembl/08-assay-parameters-spec.md
+++ b/docs/pipelines/chembl/08-assay-parameters-spec.md
@@ -1,0 +1,139 @@
+# ChEMBL Assay Parameters Pipeline Specification
+
+*Version 1.1.0 | Aligned with RULES.md v5.10*
+
+---
+
+## 1. Identification
+
+| Parameter | Value |
+|-----------|-------|
+| **Pipeline ID** | `chembl_assay_parameters` |
+| **Provider** | ChEMBL (EBI) |
+| **Entity** | assay_parameters |
+| **API Endpoint** | `https://www.ebi.ac.uk/chembl/api/data/assay` (nested) |
+| **Library** | `chembl_webresource_client` |
+| **Rate Limit** | None |
+| **Health Check** | `/chembl/api/data/status.json` |
+| **Auth Type** | None (public API) |
+
+---
+
+## 2. Business Context
+
+### 2.1. Entity Purpose
+
+Assay Parameters describe **experimental conditions** for assays:
+
+- **Concentrations**: Compound concentrations used
+- **Time points**: Incubation times
+- **Conditions**: pH, temperature, media
+- **Controls**: Reference compounds
+
+### 2.2. Use Cases
+
+1. **Protocol Reproducibility**: Understand exact experimental conditions
+2. **Condition Filtering**: Find assays with specific parameters
+3. **Standardization**: Compare normalized vs original values
+4. **Quality Control**: Validate experimental setups
+
+### 2.3. Entity Relationships
+
+```
+assay_parameters
+    │
+    └──FK──► assay.assay_chembl_id (M:1)
+```
+
+---
+
+## 3. Extraction (Bronze Layer)
+
+### 3.1. API Fields
+
+| # | API Field | Type | Nullable | Description |
+|---|-----------|------|----------|-------------|
+| 1 | `assay_param_id` | int | No | Primary key |
+| 2 | `assay_chembl_id` | string | No | FK to assay |
+| 3 | `type` | string | No | Parameter type |
+| 4 | `relation` | string | Yes | Relation operator |
+| 5 | `value` | float | Yes | Numeric value |
+| 6 | `units` | string | Yes | Original units |
+| 7 | `text_value` | string | Yes | Text value |
+| 8 | `comments` | string | Yes | Comments |
+| 9 | `standard_type` | string | Yes | Standardized type |
+| 10 | `standard_relation` | string | Yes | Standardized relation |
+| 11 | `standard_value` | float | Yes | Standardized value |
+| 12 | `standard_units` | string | Yes | Standardized units |
+| 13 | `standard_text_value` | string | Yes | Standardized text |
+
+---
+
+## 4. Validation
+
+### 4.1. Pandera Schema
+
+```python
+class AssayParametersSchema(ETLRecordSchema):
+    """AssayParameters validation schema for Silver layer."""
+
+    # === Primary Key ===
+    assay_param_id: Series[int] = pa.Field(
+        nullable=False,
+        ge=1,
+    )
+
+    # === Foreign Key ===
+    assay_chembl_id: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^CHEMBL\d+$",
+    )
+
+    # === Parameter Type ===
+    type: Series[str] = pa.Field(nullable=False)
+
+    # === Raw Values ===
+    relation: Series[str] | None = pa.Field(nullable=True)
+    value: Series[float] | None = pa.Field(nullable=True)
+    units: Series[str] | None = pa.Field(nullable=True)
+    text_value: Series[str] | None = pa.Field(nullable=True)
+    comments: Series[str] | None = pa.Field(nullable=True)
+
+    # === Standardized Values ===
+    standard_type: Series[str] | None = pa.Field(nullable=True)
+    standard_relation: Series[str] | None = pa.Field(nullable=True)
+    standard_value: Series[float] | None = pa.Field(nullable=True)
+    standard_units: Series[str] | None = pa.Field(nullable=True)
+    standard_text_value: Series[str] | None = pa.Field(nullable=True)
+
+    class Config:
+        strict = True
+        ordered = False
+        coerce = True
+```
+
+---
+
+## 5. Pipeline Configuration
+
+```yaml
+pipeline_name: chembl_assay_parameters
+provider: chembl
+entity_type: assay_parameters
+version: "1.1.0"
+
+primary_keys: ["assay_param_id"]
+silver_table: "chembl_assay_parameters"
+gold_table: "chembl_assay_parameters"
+
+gold_filters:
+  required_fields:
+    - type
+
+input_filter:
+  enabled: true
+  source_path: "data/input/assay.csv"
+  column_name: "assay_chembl_id"
+  filter_field: "assay_chembl_id"
+  batch_size: 20
+```

--- a/docs/pipelines/chembl/09-compound-record-spec.md
+++ b/docs/pipelines/chembl/09-compound-record-spec.md
@@ -1,0 +1,153 @@
+# ChEMBL Compound Record Pipeline Specification
+
+*Version 1.1.0 | Aligned with RULES.md v5.10*
+
+---
+
+## 1. Identification
+
+| Parameter | Value |
+|-----------|-------|
+| **Pipeline ID** | `chembl_compound_record` |
+| **Provider** | ChEMBL (EBI) |
+| **Entity** | compound_record |
+| **API Endpoint** | `https://www.ebi.ac.uk/chembl/api/data/compound_record` |
+| **Library** | `chembl_webresource_client` |
+| **Rate Limit** | None |
+| **Health Check** | `/chembl/api/data/status.json` |
+| **Auth Type** | None (public API) |
+
+---
+
+## 2. Business Context
+
+### 2.1. Entity Purpose
+
+Compound Records link **molecules to publications** with original naming:
+
+- **Data provenance**: Connect molecules to source documents
+- **Original naming**: Preserve compound names from publications
+- **Source tracking**: Track data source databases
+- **Literature references**: Enable citation-based analysis
+
+### 2.2. Use Cases
+
+1. **Compound Name Resolution**: Find molecules by literature names
+2. **Publication Mining**: Find all compounds mentioned in a paper
+3. **Source Attribution**: Track data provenance
+4. **Name Normalization**: Map publication names to ChEMBL IDs
+
+### 2.3. Entity Relationships
+
+```
+compound_record
+    │
+    ├──FK──► molecule.molecule_chembl_id (M:1)
+    │
+    ├──FK──► document.document_chembl_id (M:1)
+    │
+    └──◄──FK──activity.record_id (1:M)
+```
+
+---
+
+## 3. Extraction (Bronze Layer)
+
+### 3.1. API Fields
+
+| # | API Field | Type | Nullable | Description |
+|---|-----------|------|----------|-------------|
+| 1 | `record_id` | int | No | Primary key |
+| 2 | `molecule_chembl_id` | string | No | FK to molecule |
+| 3 | `document_chembl_id` | string | No | FK to document |
+| 4 | `src_id` | int | No | Source ID |
+| 5 | `compound_key` | string | Yes | Compound key in document |
+| 6 | `compound_name` | string | Yes | Compound name in document |
+| 7 | `src_compound_id` | string | Yes | Source compound ID |
+
+---
+
+## 4. Validation
+
+### 4.1. Pandera Schema
+
+```python
+class CompoundRecordSchema(ETLRecordSchema):
+    """Compound Record validation schema for Silver layer."""
+
+    # === Primary Key ===
+    record_id: Series[int] = pa.Field(
+        nullable=False,
+        ge=1,
+    )
+
+    # === Foreign Keys ===
+    molecule_chembl_id: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^CHEMBL\d+$",
+    )
+    document_chembl_id: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^CHEMBL\d+$",
+    )
+    src_id: Series[int] = pa.Field(
+        nullable=False,
+        ge=1,
+    )
+
+    # === Source-specific Identifiers ===
+    compound_key: Series[str] | None = pa.Field(nullable=True)
+    compound_name: Series[str] | None = pa.Field(nullable=True)
+    src_compound_id: Series[str] | None = pa.Field(nullable=True)
+
+    class Config:
+        strict = True
+        ordered = False
+        coerce = True
+```
+
+---
+
+## 5. Pipeline Configuration
+
+```yaml
+pipeline_name: chembl_compound_record
+provider: chembl
+entity_type: compound_record
+version: "1.1.0"
+
+primary_keys: ["record_id"]
+silver_table: "chembl_compound_record"
+gold_table: "chembl_compound_record"
+
+gold_filters:
+  required_fields:
+    - molecule_chembl_id
+    - document_chembl_id
+
+input_filter:
+  enabled: true
+  source_path: "data/input/molecule.csv"
+  column_name: "molecule_chembl_id"
+  filter_field: "molecule_chembl_id"
+  batch_size: 20
+```
+
+---
+
+## 6. Dependencies
+
+### 6.1. Upstream
+
+| Dependency | Type | Required |
+|------------|------|----------|
+| ChEMBL API | API | Yes |
+| `chembl_molecule` | Pipeline | Recommended |
+| `chembl_publication` | Pipeline | Recommended |
+
+### 6.2. Downstream
+
+| Consumer | Impact |
+|----------|--------|
+| `chembl_activity` | FK reference (record_id) |
+| Compound-literature analysis | Provenance tracking |

--- a/docs/pipelines/chembl/10-target-component-spec.md
+++ b/docs/pipelines/chembl/10-target-component-spec.md
@@ -1,0 +1,148 @@
+# ChEMBL Target Component Pipeline Specification
+
+*Version 1.1.0 | Aligned with RULES.md v5.10*
+
+---
+
+## 1. Identification
+
+| Parameter | Value |
+|-----------|-------|
+| **Pipeline ID** | `chembl_target_component` |
+| **Provider** | ChEMBL (EBI) |
+| **Entity** | target_component |
+| **API Endpoint** | `https://www.ebi.ac.uk/chembl/api/data/target_component` |
+| **Library** | `chembl_webresource_client` |
+| **Rate Limit** | None |
+| **Health Check** | `/chembl/api/data/status.json` |
+| **Auth Type** | None (public API) |
+
+---
+
+## 2. Business Context
+
+### 2.1. Entity Purpose
+
+Target Components represent **subunits of biological targets**:
+
+- **Protein subunits**: Individual proteins in a complex
+- **UniProt mapping**: Direct link to UniProt accessions
+- **Sequence data**: Amino acid sequences
+- **Stoichiometry**: Component ratios in complexes
+
+### 2.2. Use Cases
+
+1. **UniProt Integration**: Map ChEMBL targets to UniProt
+2. **Complex Analysis**: Understand multi-protein targets
+3. **Sequence Analysis**: Access protein sequences
+4. **Cross-Database Linking**: Bridge to UniProt annotations
+
+### 2.3. Entity Relationships
+
+```
+target_component
+    │
+    ├──FK──► target.tid (M:1)
+    │
+    ├──FK──► component_sequences.component_id (M:1)
+    │
+    └──► uniprot.accession (via accession field)
+```
+
+---
+
+## 3. Extraction (Bronze Layer)
+
+### 3.1. API Fields
+
+| # | API Field | Type | Nullable | Description |
+|---|-----------|------|----------|-------------|
+| 1 | `targcomp_id` | int | No | Primary key |
+| 2 | `tid` | int | No | FK to target |
+| 3 | `component_id` | int | No | FK to component_sequences |
+| 4 | `relationship` | string | Yes | Relationship type |
+| 5 | `stoichiometry` | int | Yes | Stoichiometry |
+| 6 | `homologue` | int | Yes | Homologue flag |
+
+---
+
+## 4. Validation
+
+### 4.1. Pandera Schema
+
+```python
+class TargetComponentSchema(ETLRecordSchema):
+    """Target Component validation schema for Silver layer."""
+
+    # === Primary Key ===
+    targcomp_id: Series[int] = pa.Field(
+        nullable=False,
+    )
+
+    # === Foreign Keys ===
+    tid: Series[int] = pa.Field(
+        nullable=False,
+    )
+    component_id: Series[int] = pa.Field(
+        nullable=False,
+    )
+
+    # === Metadata ===
+    relationship: Series[str] | None = pa.Field(
+        nullable=True,
+        isin=[
+            "SINGLE PROTEIN",
+            "PROTEIN SUBUNIT",
+            "RNA",
+            "INTERACTING PROTEIN",
+        ],
+    )
+    stoichiometry: Series[int] | None = pa.Field(
+        nullable=True,
+        ge=1,
+    )
+    homologue: Series[int] | None = pa.Field(
+        nullable=True,
+        isin=[0, 1, 2],
+    )
+
+    class Config:
+        strict = True
+        ordered = True
+        coerce = True
+```
+
+---
+
+## 5. Cross-Provider Mapping
+
+| This Entity Field | Maps To | Provider | Field |
+|-------------------|---------|----------|-------|
+| UniProt accession (via join) | UniProt | UniProt | `accession` |
+
+---
+
+## 6. Pipeline Configuration
+
+```yaml
+pipeline_name: chembl_target_component
+provider: chembl
+entity_type: target_component
+version: "1.1.0"
+
+primary_keys: ["targcomp_id"]
+silver_table: "chembl_target_component"
+gold_table: "chembl_target_component"
+
+gold_filters:
+  required_fields:
+    - tid
+    - component_id
+
+input_filter:
+  enabled: true
+  source_path: "data/input/target.csv"
+  column_name: "target_chembl_id"
+  filter_field: "target_chembl_id"
+  batch_size: 20
+```

--- a/docs/pipelines/chembl/cell-line-fields.csv
+++ b/docs/pipelines/chembl/cell-line-fields.csv
@@ -1,0 +1,21 @@
+field_name,api_path,type,nullable,normalization,validation,dq_level,failure_action,in_hash,description
+cell_chembl_id,cell_chembl_id,str,false,validate_regex,regex ^CHEMBL\d+$ unique,CRITICAL,quarantine,true,ChEMBL ID for cell line (PK)
+cell_name,cell_name,str,false,strip,not_empty,CRITICAL,quarantine,true,Cell line name
+cell_description,cell_description,str,true,strip,none,INFO,log,true,Cell line description
+cell_source_tissue,cell_source_tissue,str,true,strip,none,INFO,log,true,Source tissue
+cell_source_organism,cell_source_organism,str,true,strip,none,INFO,log,true,Source organism
+cell_source_tax_id,cell_source_tax_id,int,true,cast_to_int,>= 1,WARNING,log,true,NCBI Taxonomy ID
+cell_type,cell_type,str,true,strip,none,INFO,log,true,Cell type classification
+cellosaurus_id,cellosaurus_id,str,true,validate_regex,regex ^CVCL_[A-Z0-9]+$,WARNING,log,true,Cellosaurus ID
+clo_id,clo_id,str,true,validate_regex,regex ^CLO_\d+$,WARNING,log,true,Cell Line Ontology ID
+cl_lincs_id,cl_lincs_id,str,true,strip,none,INFO,log,true,LINCS ID
+efo_id,efo_id,str,true,validate_regex,regex ^EFO_\d+$,WARNING,log,true,EFO ontology ID
+entity_id,derived,str,false,from cell_chembl_id,regex ^CHEMBL\d+$,CRITICAL,quarantine,false,Unique business identifier
+content_hash,derived,str,false,sha256,regex ^[a-f0-9]{64}$,CRITICAL,quarantine,false,SHA256 hash
+_run_id,system,uuid,false,generated,uuid format,CRITICAL,quarantine,false,Pipeline run ID
+_run_type,system,str,false,from config,isin [incremental backfill rebuild],CRITICAL,quarantine,false,Run type
+_source_batch_id,system,uuid,true,generated,uuid format,INFO,log,false,Batch context ID
+_ingestion_ts,system,datetime,false,generated utc,valid timestamp,CRITICAL,quarantine,false,Ingestion timestamp
+_dq_warn,system,bool,false,from validation,boolean,INFO,log,false,DQ warning flag
+_dq_error,system,bool,false,from validation,boolean,INFO,log,false,DQ error flag
+_index,system,int,false,generated,>= 0,INFO,log,false,Record index

--- a/docs/pipelines/chembl/protein-class-fields.csv
+++ b/docs/pipelines/chembl/protein-class-fields.csv
@@ -1,0 +1,20 @@
+field_name,api_path,type,nullable,normalization,validation,dq_level,failure_action,in_hash,description
+protein_class_id,protein_class_id,int,false,cast_to_int,>= 1,CRITICAL,quarantine,true,Primary key
+parent_id,parent_id,int,true,cast_to_int_or_none,>= 1 or None,WARNING,log,true,FK to parent classification
+replaced_by,replaced_by,int,true,cast_to_int_or_none,>= 1 or None,WARNING,log,true,FK to replacement classification
+pref_name,pref_name,str,true,strip,none,INFO,log,true,Preferred name
+short_name,short_name,str,true,strip,none,INFO,log,true,Short name
+protein_class_desc,protein_class_desc,str,true,strip,none,INFO,log,true,Description
+definition,definition,str,true,strip,none,INFO,log,true,Definition
+class_level,class_level,int,true,cast_to_int,>= 1,WARNING,log,true,Hierarchy level (1-8)
+sort_order,sort_order,int,true,cast_to_int,none,INFO,log,true,Display sort order
+downgraded,downgraded,int,true,cast_to_int,isin [0 1],WARNING,log,true,Deprecated flag
+entity_id,derived,str,false,from protein_class_id,regex ^[0-9]+$,CRITICAL,quarantine,false,Unique business identifier
+content_hash,derived,str,false,sha256,regex ^[a-f0-9]{64}$,CRITICAL,quarantine,false,SHA256 hash
+_run_id,system,uuid,false,generated,uuid format,CRITICAL,quarantine,false,Pipeline run ID
+_run_type,system,str,false,from config,isin [incremental backfill rebuild],CRITICAL,quarantine,false,Run type
+_source_batch_id,system,uuid,true,generated,uuid format,INFO,log,false,Batch context ID
+_ingestion_ts,system,datetime,false,generated utc,valid timestamp,CRITICAL,quarantine,false,Ingestion timestamp
+_dq_warn,system,bool,false,from validation,boolean,INFO,log,false,DQ warning flag
+_dq_error,system,bool,false,from validation,boolean,INFO,log,false,DQ error flag
+_index,system,int,false,generated,>= 0,INFO,log,false,Record index

--- a/docs/pipelines/crossref/01-publication-spec.md
+++ b/docs/pipelines/crossref/01-publication-spec.md
@@ -1,0 +1,256 @@
+# CrossRef Publication Pipeline Specification
+
+*Version 1.1.0 | Aligned with RULES.md v5.10*
+
+---
+
+## 1. Identification
+
+| Parameter | Value |
+|-----------|-------|
+| **Pipeline ID** | `crossref_publication` |
+| **Provider** | CrossRef |
+| **Entity** | publication |
+| **API Endpoint** | `https://api.crossref.org/works/` |
+| **Library** | `httpx` (REST API) |
+| **Rate Limit** | 50 req/sec (polite pool with mailto) |
+| **Health Check** | `/works?rows=1` |
+| **Auth Type** | None (mailto header for polite pool) |
+
+---
+
+## 2. Business Context
+
+### 2.1. Entity Purpose
+
+CrossRef provides **authoritative DOI metadata**:
+
+- **DOI resolution**: Canonical metadata for publications
+- **Citation data**: Reference counts and cited-by counts
+- **Funder information**: Grant and funding data
+- **License data**: Open access and usage rights
+- **Type classification**: Article, preprint, book chapter, etc.
+
+### 2.2. Use Cases
+
+1. **DOI Enrichment**: Add metadata to ChEMBL documents by DOI
+2. **Citation Analysis**: Track citation counts
+3. **Funder Analysis**: Identify funding sources
+4. **Open Access Tracking**: Determine OA status
+
+---
+
+## 3. Extraction (Bronze Layer)
+
+### 3.1. API Request
+
+```python
+import httpx
+
+# Single DOI lookup
+url = f"https://api.crossref.org/works/{doi}"
+headers = {"User-Agent": "BioETL/1.0 (mailto:email@example.com)"}
+response = await client.get(url, headers=headers)
+```
+
+### 3.2. Complete API Fields
+
+| # | API Field | JSON Type | Nullable | Description |
+|---|-----------|-----------|----------|-------------|
+| 1 | `DOI` | string | No | Primary key |
+| 2 | `title` | array | Yes | Title(s) |
+| 3 | `author` | array | Yes | Authors |
+| 4 | `container-title` | array | Yes | Journal name(s) |
+| 5 | `publisher` | string | Yes | Publisher |
+| 6 | `published-print` | object | Yes | Print date |
+| 7 | `published-online` | object | Yes | Online date |
+| 8 | `volume` | string | Yes | Volume |
+| 9 | `issue` | string | Yes | Issue |
+| 10 | `page` | string | Yes | Page range |
+| 11 | `type` | string | Yes | Work type |
+| 12 | `ISSN` | array | Yes | ISSNs |
+| 13 | `subject` | array | Yes | Subjects |
+| 14 | `abstract` | string | Yes | Abstract (HTML) |
+| 15 | `is-referenced-by-count` | int | Yes | Cited by count |
+| 16 | `references-count` | int | Yes | Reference count |
+| 17 | `license` | array | Yes | License info |
+| 18 | `funder` | array | Yes | Funders |
+| 19 | `link` | array | Yes | Links |
+| 20 | `language` | string | Yes | Language code |
+
+---
+
+## 4. Transformation
+
+### 4.1. Entity ID Strategy
+
+| Parameter | Value |
+|-----------|-------|
+| **Entity ID Field** | `doi` |
+| **ID Source** | `from_api` |
+| **Format** | DOI (10.xxx/yyy) |
+
+### 4.2. Field Normalization
+
+| Field | Normalization | Before | After |
+|-------|---------------|--------|-------|
+| `doi` | lowercase, strip | `"10.1234/ABC "` | `"10.1234/abc"` |
+| `title` | Extract first | `["Title 1"]` | `"Title 1"` |
+| `author` | Format names | `[{given, family}]` | JSON array |
+| `container-title` | Extract first | `["Journal"]` | `"Journal"` |
+| `page` | Split to first/last | `"123-456"` | first=123, last=456 |
+| `published-print.date-parts` | Parse to date | `[[2024,1,15]]` | `"2024-01-15"` |
+| `abstract` | Strip HTML | `"<p>Text</p>"` | `"Text"` |
+
+### 4.3. Flattening Strategy
+
+| Nested Path | Flattened Name | Strategy |
+|-------------|----------------|----------|
+| `title[0]` | `title` | Extract first |
+| `container-title[0]` | `journal` | Extract first |
+| `author[*]` | `authors` | JSON array |
+| `published-print.date-parts[0]` | `year`, `published_print` | Parse |
+| `published-online.date-parts[0]` | `published_online` | Parse |
+| `ISSN` | `issn` | JSON array |
+| `subject` | `subjects` | JSON array |
+| `funder[*]` | `funders` | JSON array (separate table option) |
+| `license[0].URL` | `license_url` | Extract first |
+
+---
+
+## 5. Validation
+
+### 5.1. Pandera Schema
+
+```python
+class PublicationEnrichedSchema(ETLRecordSchema):
+    """CrossRef-enriched Publication validation schema."""
+
+    # === Primary Key ===
+    doi: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=DOI_REGEX_PATTERN,
+    )
+
+    # === Core Metadata ===
+    title: Series[str] | None = pa.Field(nullable=True, str_length={"min_value": 1})
+    abstract: Series[str] | None = pa.Field(nullable=True)
+
+    # === Authors ===
+    authors: Series[str] | None = pa.Field(nullable=True)  # JSON array
+
+    # === Journal Information ===
+    journal: Series[str] | None = pa.Field(nullable=True)
+    issn: Series[str] | None = pa.Field(nullable=True)  # JSON array
+    publisher: Series[str] | None = pa.Field(nullable=True)
+
+    # === Publication Details ===
+    volume: Series[str] | None = pa.Field(nullable=True)
+    issue: Series[str] | None = pa.Field(nullable=True)
+    first_page: Series[str] | None = pa.Field(nullable=True)
+    last_page: Series[str] | None = pa.Field(nullable=True)
+
+    # === Dates ===
+    year: Series[int] | None = pa.Field(
+        nullable=True,
+        ge=MIN_PUBLICATION_YEAR,
+        le=MAX_PUBLICATION_YEAR,
+    )
+    published_print: Series[str] | None = pa.Field(nullable=True)
+    published_online: Series[str] | None = pa.Field(nullable=True)
+
+    # === Document Type ===
+    doc_type: Series[str] = pa.Field(
+        nullable=False,
+        isin=["PUBLICATION", "PREPRINT"],
+    )
+
+    # === Citation Metrics ===
+    citation_count: Series[int] | None = pa.Field(nullable=True, ge=0)
+    reference_count: Series[int] | None = pa.Field(nullable=True, ge=0)
+
+    # === Additional Metadata ===
+    language: Series[str] | None = pa.Field(nullable=True)
+    license_url: Series[str] | None = pa.Field(nullable=True)
+    subjects: Series[str] | None = pa.Field(nullable=True)  # JSON array
+
+    # === Source Tracking ===
+    source: Series[str] = pa.Field(nullable=False, eq="crossref")
+
+    class Config:
+        strict = True
+        ordered = True
+        coerce = True
+```
+
+---
+
+## 6. Cross-Provider Mapping
+
+| This Entity Field | Maps To | Provider | Field |
+|-------------------|---------|----------|-------|
+| `doi` | ChEMBL | ChEMBL | `document.doi` |
+| `doi` | OpenAlex | OpenAlex | `doi` |
+| `doi` | Semantic Scholar | S2 | `externalIds.DOI` |
+| `doi` | PubMed | PubMed | ArticleIdList/DOI |
+
+---
+
+## 7. Pipeline Configuration
+
+```yaml
+pipeline_name: crossref_publication
+provider: crossref
+entity_type: publication
+version: "1.1.0"
+
+primary_keys: ["doi"]
+silver_table: "crossref_publication"
+gold_table: "crossref_publication"
+
+source:
+  type: api
+  batch_size: 50
+
+sink:
+  bronze:
+    path: "data/output/bronze"
+  silver:
+    path: "data/output/silver"
+    primary_key: ["doi"]
+    partition_by: []
+  gold:
+    path: "data/output/gold"
+
+gold_filters:
+  required_fields:
+    - title
+  columns:
+    doc_type: [PUBLICATION]
+
+input_filter:
+  enabled: true
+  source_path: "data/input/doi.csv"
+  column_name: "doi"
+  filter_field: "doi"
+  batch_size: 50
+```
+
+---
+
+## 8. Special Considerations
+
+### 8.1. Polite Pool
+
+```python
+# Use mailto header for higher rate limits
+headers = {
+    "User-Agent": "BioETL/1.0 (mailto:admin@example.com)"
+}
+```
+
+### 8.2. Rate Limiting
+
+- Without mailto: ~1 req/sec
+- With mailto: ~50 req/sec
+- Implement exponential backoff for 429 responses

--- a/docs/pipelines/openalex/01-publication-spec.md
+++ b/docs/pipelines/openalex/01-publication-spec.md
@@ -1,0 +1,309 @@
+# OpenAlex Publication Pipeline Specification
+
+*Version 1.1.0 | Aligned with RULES.md v5.10*
+
+---
+
+## 1. Identification
+
+| Parameter | Value |
+|-----------|-------|
+| **Pipeline ID** | `openalex_publication` |
+| **Provider** | OpenAlex |
+| **Entity** | publication (works) |
+| **API Endpoint** | `https://api.openalex.org/works` |
+| **Library** | `httpx` (REST API) |
+| **Rate Limit** | 10 req/sec (polite pool) |
+| **Health Check** | `/works?per_page=1` |
+| **Auth Type** | API Key (email-based, optional) |
+
+---
+
+## 2. Business Context
+
+### 2.1. Entity Purpose
+
+OpenAlex provides **comprehensive academic metadata**:
+
+- **Works catalog**: 250M+ academic works
+- **Concepts**: AI-assigned topic classifications
+- **Institutions**: Author affiliations
+- **Open Access data**: OA status and locations
+- **Citation networks**: References and cited-by
+
+### 2.2. Use Cases
+
+1. **DOI Enrichment**: Add concepts and OA data to publications
+2. **Concept Classification**: Categorize publications by topics
+3. **Institution Analysis**: Track research by institution
+4. **Open Access Tracking**: Monitor OA status
+
+---
+
+## 3. Extraction (Bronze Layer)
+
+### 3.1. API Request
+
+```python
+import httpx
+
+# By DOI
+url = f"https://api.openalex.org/works/doi:{doi}"
+
+# By OpenAlex ID
+url = f"https://api.openalex.org/works/{openalex_id}"
+
+# Batch search
+url = "https://api.openalex.org/works"
+params = {
+    "filter": f"doi:{doi1}|{doi2}|{doi3}",
+    "per_page": 200
+}
+```
+
+### 3.2. Complete API Fields
+
+| # | API Field | JSON Type | Nullable | Description |
+|---|-----------|-----------|----------|-------------|
+| 1 | `id` | string | No | OpenAlex ID (W[0-9]+) |
+| 2 | `doi` | string | Yes | DOI |
+| 3 | `title` | string | Yes | Title |
+| 4 | `display_name` | string | Yes | Display name |
+| 5 | `publication_year` | int | Yes | Year |
+| 6 | `publication_date` | string | Yes | Full date |
+| 7 | `type` | string | Yes | Work type |
+| 8 | `cited_by_count` | int | Yes | Citation count |
+| 9 | `is_oa` | boolean | Yes | Open access flag |
+| 10 | `is_retracted` | boolean | Yes | Retracted flag |
+| 11 | `open_access` | object | Yes | OA details |
+| 12 | `authorships` | array | Yes | Authors with affiliations |
+| 13 | `concepts` | array | Yes | Topic concepts |
+| 14 | `primary_location` | object | Yes | Primary source |
+| 15 | `biblio` | object | Yes | Bibliographic info |
+| 16 | `abstract_inverted_index` | object | Yes | Abstract (inverted) |
+| 17 | `language` | string | Yes | Language code |
+
+### 3.3. Nested Structure: authorships
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `author.id` | string | Author OpenAlex ID |
+| `author.display_name` | string | Author name |
+| `author.orcid` | string | ORCID |
+| `institutions[*].id` | string | Institution IDs |
+| `institutions[*].display_name` | string | Institution names |
+| `raw_affiliation_string` | string | Raw affiliation |
+
+### 3.4. Nested Structure: concepts
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Concept OpenAlex ID |
+| `display_name` | string | Concept name |
+| `level` | int | Hierarchy level (0-5) |
+| `score` | float | Relevance score (0-1) |
+
+### 3.5. Nested Structure: primary_location
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `source.id` | string | Source OpenAlex ID |
+| `source.display_name` | string | Journal/venue name |
+| `source.issn_l` | string | ISSN-L |
+| `pdf_url` | string | PDF URL |
+| `landing_page_url` | string | Landing page |
+
+---
+
+## 4. Transformation
+
+### 4.1. Entity ID Strategy
+
+| Parameter | Value |
+|-----------|-------|
+| **Entity ID Field** | `openalex_id` |
+| **ID Source** | `from_api` |
+| **Format** | OpenAlex ID (W[0-9]+) |
+
+### 4.2. Abstract Reconstruction
+
+OpenAlex stores abstracts as inverted index. Reconstruction:
+
+```python
+def reconstruct_abstract(inverted_index: dict) -> str:
+    if not inverted_index:
+        return None
+
+    # Create word position mapping
+    positions = {}
+    for word, indices in inverted_index.items():
+        for idx in indices:
+            positions[idx] = word
+
+    # Reconstruct in order
+    return " ".join(
+        positions[i] for i in sorted(positions.keys())
+    )
+```
+
+### 4.3. Flattening Strategy
+
+| Nested Path | Flattened Name | Strategy |
+|-------------|----------------|----------|
+| `id` | `openalex_id` | Extract (strip URL prefix) |
+| `open_access.is_oa` | `is_oa` | Extract boolean |
+| `open_access.oa_status` | `oa_status` | Extract string |
+| `primary_location.source.display_name` | `journal` | Extract |
+| `primary_location.source.issn_l` | `issn` | Extract |
+| `biblio.volume` | `volume` | Extract |
+| `biblio.issue` | `issue` | Extract |
+| `authorships[*]` | `authors` | JSON array |
+| `concepts[*]` | `concepts` | JSON array |
+| `abstract_inverted_index` | `abstract` | Reconstruct |
+
+---
+
+## 5. Validation
+
+### 5.1. Pandera Schema
+
+```python
+class OpenAlexPublicationSchema(ETLRecordSchema):
+    """OpenAlex Publication validation schema."""
+
+    # === Primary Key ===
+    openalex_id: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^W\d+$",
+    )
+
+    # === Core Fields ===
+    doi: Series[str] = pa.Field(
+        nullable=True,
+        str_matches=DOI_REGEX_PATTERN,
+    )
+    title: Series[str] = pa.Field(nullable=True)
+    abstract: Series[str] = pa.Field(nullable=True)
+    year: Series[pd.Int64Dtype] = pa.Field(
+        nullable=True,
+        ge=MIN_PUBLICATION_YEAR,
+        le=MAX_PUBLICATION_YEAR,
+    )
+    publication_date: Series[str] = pa.Field(
+        nullable=True,
+        str_matches=r"^\d{4}-\d{2}-\d{2}$",
+    )
+    doc_type: Series[str] = pa.Field(nullable=False)
+
+    # === Journal ===
+    journal: Series[str] = pa.Field(nullable=True)
+    issn: Series[str] = pa.Field(nullable=True)
+    publisher: Series[str] = pa.Field(nullable=True)
+
+    # === Open Access ===
+    is_oa: Series[bool] = pa.Field(nullable=True)
+    oa_status: Series[str] = pa.Field(
+        nullable=True,
+        isin=["gold", "green", "hybrid", "bronze", "closed"],
+    )
+
+    # === Metrics ===
+    citation_count: Series[pd.Int64Dtype] = pa.Field(
+        nullable=True,
+        ge=0,
+    )
+
+    # === Metadata ===
+    language: Series[str] = pa.Field(nullable=True)
+    source: Series[str] = pa.Field(nullable=False)
+
+    # === Lookup Metadata ===
+    lookup_method: Series[str] = pa.Field(
+        alias="_lookup_method",
+        nullable=False,
+        isin=["doi", "title_fallback", "title_only", "unknown"],
+    )
+    original_doi: Series[str] = pa.Field(
+        alias="_original_doi",
+        nullable=True,
+    )
+
+    class Config:
+        strict = "filter"
+        coerce = True
+```
+
+---
+
+## 6. Cross-Provider Mapping
+
+| This Entity Field | Maps To | Provider | Field |
+|-------------------|---------|----------|-------|
+| `doi` | ChEMBL | ChEMBL | `document.doi` |
+| `doi` | CrossRef | CrossRef | `DOI` |
+| `doi` | Semantic Scholar | S2 | `externalIds.DOI` |
+| `openalex_id` | OpenAlex Works | OpenAlex | `id` |
+
+---
+
+## 7. Pipeline Configuration
+
+```yaml
+pipeline_name: openalex_publication
+provider: openalex
+entity_type: publication
+version: "1.1.0"
+
+primary_keys: ["openalex_id"]
+silver_table: "openalex_publication"
+gold_table: "openalex_publication"
+
+source:
+  type: api
+  batch_size: 50
+
+sink:
+  bronze:
+    path: "data/output/bronze"
+  silver:
+    path: "data/output/silver"
+    primary_key: ["openalex_id"]
+    partition_by: []
+  gold:
+    path: "data/output/gold"
+
+gold_filters:
+  required_fields:
+    - title
+
+input_filter:
+  enabled: true
+  source_path: "data/input/doi.csv"
+  column_name: "doi"
+  filter_field: "doi"
+  batch_size: 50
+```
+
+---
+
+## 8. Special Considerations
+
+### 8.1. Polite Pool
+
+```python
+# Use email for higher rate limits
+params = {"mailto": "admin@example.com"}
+```
+
+### 8.2. DOI vs Title Fallback
+
+When DOI lookup fails, try title-based search:
+
+```python
+if not result:
+    # Fallback to title search
+    url = "https://api.openalex.org/works"
+    params = {"filter": f"title.search:{title}"}
+    result = await client.get(url, params=params)
+    # Mark as title_fallback in _lookup_method
+```

--- a/docs/pipelines/pubchem/01-compound-spec.md
+++ b/docs/pipelines/pubchem/01-compound-spec.md
@@ -1,0 +1,253 @@
+# PubChem Compound Pipeline Specification
+
+*Version 1.1.0 | Aligned with RULES.md v5.10*
+
+---
+
+## 1. Identification
+
+| Parameter | Value |
+|-----------|-------|
+| **Pipeline ID** | `pubchem_compound` |
+| **Provider** | PubChem (NCBI) |
+| **Entity** | compound |
+| **API Endpoint** | `https://pubchem.ncbi.nlm.nih.gov/rest/pug/` |
+| **Library** | `pubchempy` (sync, requires executor) |
+| **Rate Limit** | 5 req/sec |
+| **Health Check** | `/compound/cid/2244/property/MolecularFormula/JSON` |
+| **Auth Type** | None (public API) |
+
+---
+
+## 2. Business Context
+
+### 2.1. Entity Purpose
+
+PubChem compounds are **chemical structures** with computed descriptors:
+
+- **Chemical structures**: SMILES, InChI, InChI Key
+- **Molecular properties**: Weight, formula, LogP, PSA
+- **Stereochemistry**: Defined/undefined stereocenters
+- **3D properties**: Volume, conformers
+- **Cross-database linking**: InChI Key enables ChEMBL mapping
+
+### 2.2. Use Cases
+
+1. **Structure Enrichment**: Add computed properties to ChEMBL molecules
+2. **Property Calculation**: Access pre-computed descriptors
+3. **3D Modeling**: Use 3D conformer data
+4. **Compound Search**: Find by structure or property ranges
+
+### 2.3. Entity Relationships
+
+```
+pubchem_compound
+    │
+    └──► chembl_molecule (via inchi_key)
+```
+
+---
+
+## 3. Extraction (Bronze Layer)
+
+### 3.1. API Request
+
+```python
+import pubchempy as pcp
+
+# Sync library - wrapped in executor
+compound = pcp.Compound.from_cid(cid)
+# Or batch:
+compounds = pcp.get_compounds(cid_list, namespace="cid")
+```
+
+### 3.2. Complete API Fields
+
+| # | API Field | Type | Nullable | Description |
+|---|-----------|------|----------|-------------|
+| 1 | `CID` | int | No | Compound ID (PK) |
+| 2 | `CanonicalSMILES` | str | Yes | Canonical SMILES |
+| 3 | `IsomericSMILES` | str | Yes | SMILES with stereochemistry |
+| 4 | `InChI` | str | Yes | InChI identifier |
+| 5 | `InChIKey` | str | Yes | InChI Key (27 chars) |
+| 6 | `MolecularFormula` | str | Yes | Molecular formula |
+| 7 | `MolecularWeight` | float | Yes | Molecular weight |
+| 8 | `ExactMass` | float | Yes | Exact mass |
+| 9 | `MonoisotopicMass` | float | Yes | Monoisotopic mass |
+| 10 | `IUPACName` | str | Yes | IUPAC name |
+| 11 | `XLogP` | float | Yes | Computed LogP |
+| 12 | `TPSA` | float | Yes | Topological PSA |
+| 13 | `Complexity` | float | Yes | Complexity score |
+| 14 | `Charge` | int | Yes | Formal charge |
+| 15 | `HBondDonorCount` | int | Yes | H-bond donors |
+| 16 | `HBondAcceptorCount` | int | Yes | H-bond acceptors |
+| 17 | `RotatableBondCount` | int | Yes | Rotatable bonds |
+| 18 | `HeavyAtomCount` | int | Yes | Heavy atoms |
+| 19 | `AtomStereoCount` | int | Yes | Total stereocenters |
+| 20 | `DefinedAtomStereoCount` | int | Yes | Defined stereocenters |
+| 21 | `UndefinedAtomStereoCount` | int | Yes | Undefined stereocenters |
+| 22 | `BondStereoCount` | int | Yes | E/Z bonds |
+| 23 | `DefinedBondStereoCount` | int | Yes | Defined E/Z |
+| 24 | `UndefinedBondStereoCount` | int | Yes | Undefined E/Z |
+| 25 | `IsotopeAtomCount` | int | Yes | Isotopic atoms |
+| 26 | `CovalentUnitCount` | int | Yes | Covalent units |
+| 27 | `Volume3D` | float | Yes | 3D volume |
+| 28 | `ConformerCount3D` | int | Yes | 3D conformers |
+
+---
+
+## 4. Transformation
+
+### 4.1. Entity ID Strategy
+
+| Parameter | Value |
+|-----------|-------|
+| **Entity ID Field** | `cid` |
+| **ID Source** | `from_api` |
+| **Format** | Integer (positive) |
+
+### 4.2. Field Normalization
+
+| Field | Normalization | Before | After |
+|-------|---------------|--------|-------|
+| `cid` | Cast to int | `2244` | `2244` |
+| `molecular_weight` | round(10) | `180.157123456789` | `180.1571234568` |
+| `xlogp` | round(2) | `1.31456` | `1.31` |
+| `canonical_smiles` | RDKit canonical | - | Normalized SMILES |
+| `inchi_key` | Validate format | `BSYNRYMUTXBXSQ...` | Validated |
+
+---
+
+## 5. Validation
+
+### 5.1. Pandera Schema
+
+```python
+class PubchemMoleculeSchema(ETLRecordSchema):
+    """PubChem Molecule validation schema for Silver layer."""
+
+    # === Primary Key ===
+    cid: Series[int] = pa.Field(nullable=False, ge=1)
+
+    # === Structural Identifiers ===
+    canonical_smiles: Series[str] | None = pa.Field(nullable=True)
+    isomeric_smiles: Series[str] | None = pa.Field(nullable=True)
+    inchi: Series[str] | None = pa.Field(nullable=True)
+
+    @pa.check("inchi", name="inchi_format")
+    def _check_inchi(cls, series):
+        return series.isna() | series.str.startswith("InChI=")
+
+    inchi_key: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=INCHI_KEY_REGEX_PATTERN,
+    )
+
+    # === Nomenclature ===
+    molecular_formula: Series[str] | None = pa.Field(nullable=True)
+    iupac_name: Series[str] | None = pa.Field(nullable=True)
+
+    # === Physical Properties ===
+    molecular_weight: Series[float] | None = pa.Field(
+        nullable=True,
+        ge=0.0,
+        le=100000.0,
+    )
+    exact_mass: Series[float] | None = pa.Field(nullable=True, ge=0)
+
+    # === Computed Descriptors ===
+    xlogp: Series[float] | None = pa.Field(nullable=True, ge=-20, le=20)
+    tpsa: Series[float] | None = pa.Field(nullable=True, ge=0)
+    complexity: Series[float] | None = pa.Field(nullable=True, ge=0)
+    charge: Series[int] | None = pa.Field(nullable=True, ge=-10, le=10)
+
+    # === Atom/Bond Counts ===
+    heavy_atom_count: Series[int] | None = pa.Field(nullable=True, ge=1, le=500)
+    h_bond_donor_count: Series[int] | None = pa.Field(nullable=True, ge=0, le=50)
+    h_bond_acceptor_count: Series[int] | None = pa.Field(nullable=True, ge=0, le=50)
+    rotatable_bond_count: Series[int] | None = pa.Field(nullable=True, ge=0, le=100)
+
+    # === Stereochemistry ===
+    atom_stereo_count: Series[int] | None = pa.Field(nullable=True, ge=0)
+    defined_atom_stereo_count: Series[int] | None = pa.Field(nullable=True, ge=0)
+    undefined_atom_stereo_count: Series[int] | None = pa.Field(nullable=True, ge=0)
+    bond_stereo_count: Series[int] | None = pa.Field(nullable=True, ge=0)
+    covalent_unit_count: Series[int] | None = pa.Field(nullable=True, ge=1)
+
+    # === 3D Properties ===
+    volume_3d: Series[float] | None = pa.Field(nullable=True, ge=0)
+    conformer_count_3d: Series[int] | None = pa.Field(nullable=True, ge=0)
+
+    class Config:
+        strict = True
+        ordered = True
+        coerce = True
+```
+
+---
+
+## 6. Cross-Provider Mapping
+
+| This Entity Field | Maps To | Provider | Field |
+|-------------------|---------|----------|-------|
+| `inchi_key` | ChEMBL | ChEMBL | `structure_standard_inchi_key` |
+| `cid` | PubChem BioAssay | PubChem | CID |
+
+---
+
+## 7. Pipeline Configuration
+
+```yaml
+pipeline_name: pubchem_compound
+provider: pubchem
+entity_type: compound
+version: "1.1.0"
+
+primary_keys: ["cid"]
+silver_table: "pubchem_compound"
+gold_table: "pubchem_compound"
+
+source:
+  type: api
+  batch_size: 100  # PubChem allows batch requests
+
+sink:
+  bronze:
+    path: "data/output/bronze"
+  silver:
+    path: "data/output/silver"
+    primary_key: ["cid"]
+    partition_by: []
+  gold:
+    path: "data/output/gold"
+
+input_filter:
+  enabled: true
+  source_path: "data/input/compound.csv"
+  column_name: "cid"
+  filter_field: "cid"
+  batch_size: 100
+```
+
+---
+
+## 8. Special Considerations
+
+### 8.1. Sync Library Handling
+
+PubChemPy is synchronous. BioETL wraps it using `BaseSyncAdapter`:
+
+```python
+class PubChemAdapter(BaseSyncAdapter):
+    async def fetch(self, cids: list[int]) -> list[dict]:
+        # Wrapped in executor
+        return await self._run_in_executor(
+            pcp.get_compounds, cids, namespace="cid"
+        )
+```
+
+### 8.2. Rate Limiting
+
+- **Hard limit**: 5 requests/second
+- **Batch size**: Up to 100 CIDs per request
+- **Recommendation**: Use batch requests to maximize throughput

--- a/docs/pipelines/pubmed/01-publication-spec.md
+++ b/docs/pipelines/pubmed/01-publication-spec.md
@@ -1,0 +1,262 @@
+# PubMed Publication Pipeline Specification
+
+*Version 1.1.0 | Aligned with RULES.md v5.10*
+
+---
+
+## 1. Identification
+
+| Parameter | Value |
+|-----------|-------|
+| **Pipeline ID** | `pubmed_publication` |
+| **Provider** | PubMed (NCBI) |
+| **Entity** | publication |
+| **API Endpoint** | `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/` |
+| **Library** | `httpx` (E-utilities API) |
+| **Rate Limit** | 3 req/sec (10 with API key) |
+| **Health Check** | `/einfo.fcgi` |
+| **Auth Type** | API Key (NCBI_API_KEY) |
+
+---
+
+## 2. Business Context
+
+### 2.1. Entity Purpose
+
+PubMed publications are **biomedical literature** with MeSH indexing:
+
+- **MEDLINE citations**: Curated biomedical literature
+- **MeSH terms**: Medical Subject Headings for categorization
+- **Author affiliations**: Institution data
+- **Grant information**: Funding sources
+- **Cross-database links**: DOI, PMC, ChEMBL
+
+### 2.2. Use Cases
+
+1. **Literature Mining**: Search biomedical publications
+2. **MeSH-based Filtering**: Find papers by medical terms
+3. **Citation Enrichment**: Add metadata to ChEMBL documents
+4. **Funding Analysis**: Track grant-supported research
+
+---
+
+## 3. Extraction (Bronze Layer)
+
+### 3.1. API Request
+
+```python
+import httpx
+
+# Step 1: Search for PMIDs (esearch)
+search_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+params = {
+    "db": "pubmed",
+    "term": f"{pmid}[uid]",
+    "retmode": "json",
+    "api_key": api_key
+}
+
+# Step 2: Fetch full records (efetch)
+fetch_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+params = {
+    "db": "pubmed",
+    "id": ",".join(pmids),
+    "rettype": "xml",
+    "retmode": "xml",
+    "api_key": api_key
+}
+```
+
+### 3.2. Complete API Fields (from XML)
+
+| # | XML Path | Type | Nullable | Description |
+|---|----------|------|----------|-------------|
+| 1 | `PMID` | int | No | PubMed ID (PK) |
+| 2 | `ArticleTitle` | str | No | Title |
+| 3 | `Abstract/AbstractText` | str | Yes | Abstract |
+| 4 | `AuthorList/Author` | array | Yes | Authors |
+| 5 | `Journal/Title` | str | Yes | Journal name |
+| 6 | `Journal/ISOAbbreviation` | str | Yes | ISO abbreviation |
+| 7 | `Journal/ISSN` | str | Yes | ISSN |
+| 8 | `PubDate/Year` | int | Yes | Publication year |
+| 9 | `PubDate/Month` | str | Yes | Publication month |
+| 10 | `Volume` | str | Yes | Volume |
+| 11 | `Issue` | str | Yes | Issue |
+| 12 | `MedlinePgn` | str | Yes | Page numbers |
+| 13 | `ArticleIdList/DOI` | str | Yes | DOI |
+| 14 | `ArticleIdList/PMC` | str | Yes | PMC ID |
+| 15 | `MeshHeadingList` | array | Yes | MeSH terms |
+| 16 | `KeywordList` | array | Yes | Keywords |
+| 17 | `PublicationTypeList` | array | Yes | Publication types |
+| 18 | `Language` | str | Yes | Language code |
+| 19 | `GrantList` | array | Yes | Grants |
+
+---
+
+## 4. Transformation
+
+### 4.1. Entity ID Strategy
+
+| Parameter | Value |
+|-----------|-------|
+| **Entity ID Field** | `pmid` |
+| **ID Source** | `from_api` |
+| **Format** | Integer (positive) |
+
+### 4.2. XML Parsing Notes
+
+PubMed returns XML. Key transformations:
+
+| XML Element | Silver Field | Transformation |
+|-------------|--------------|----------------|
+| `PMID` | `pmid` | Parse as int |
+| `Abstract/AbstractText[@Label]` | `abstract_structured` | Check for structured |
+| `AuthorList/Author/ForeName + LastName` | `authors` | Concatenate |
+| `MeshHeadingList/MeshHeading` | `mesh_headings` | JSON array |
+| `PubDate/Year + Month + Day` | `publication_date` | Parse to date |
+
+---
+
+## 5. Validation
+
+### 5.1. Pandera Schema
+
+```python
+class ArticleSchema(ETLRecordSchema):
+    """PubMed Article validation schema for Silver layer."""
+
+    # === Primary Key ===
+    pmid: Series[int] = pa.Field(nullable=False, ge=1)
+
+    # === External Identifiers ===
+    doi: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=DOI_REGEX_PATTERN,
+    )
+    pmc_id: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^PMC\d+$",
+    )
+
+    # === Article Content ===
+    title: Series[str] = pa.Field(nullable=False, str_length={"min_value": 1})
+    abstract: Series[str] | None = pa.Field(nullable=True)
+    abstract_structured: Series[bool] | None = pa.Field(nullable=True)
+    vernacular_title: Series[str] | None = pa.Field(nullable=True)
+    language: Series[str] | None = pa.Field(nullable=True)
+
+    # === Journal Information ===
+    journal_title: Series[str] | None = pa.Field(nullable=True)
+    journal_iso_abbrev: Series[str] | None = pa.Field(nullable=True)
+    journal_issn: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^\d{4}-\d{3}[\dX]$",
+    )
+    country: Series[str] | None = pa.Field(nullable=True)
+
+    # === Publication Details ===
+    volume: Series[str] | None = pa.Field(nullable=True)
+    issue: Series[str] | None = pa.Field(nullable=True)
+    medline_pgn: Series[str] | None = pa.Field(nullable=True)
+    year: Series[int] | None = pa.Field(
+        nullable=True,
+        ge=MIN_PUBLICATION_YEAR,
+        le=MAX_PUBLICATION_YEAR,
+    )
+    pub_month: Series[int] | None = pa.Field(nullable=True, ge=1, le=12)
+    pub_day: Series[int] | None = pa.Field(nullable=True, ge=1, le=31)
+    publication_status: Series[str] | None = pa.Field(
+        nullable=True,
+        isin=["ppublish", "epublish", "aheadofprint"],
+    )
+
+    # === Dates ===
+    date_completed: Series[date] | None = pa.Field(nullable=True)
+    date_revised: Series[date] | None = pa.Field(nullable=True)
+
+    # === Counts ===
+    author_count: Series[int] | None = pa.Field(nullable=True, ge=0)
+    mesh_heading_count: Series[int] | None = pa.Field(nullable=True, ge=0)
+    keyword_count: Series[int] | None = pa.Field(nullable=True, ge=0)
+    grant_count: Series[int] | None = pa.Field(nullable=True, ge=0)
+    reference_count: Series[int] | None = pa.Field(nullable=True, ge=0)
+
+    class Config:
+        strict = True
+        ordered = True
+        coerce = True
+```
+
+---
+
+## 6. Cross-Provider Mapping
+
+| This Entity Field | Maps To | Provider | Field |
+|-------------------|---------|----------|-------|
+| `pmid` | ChEMBL | ChEMBL | `document.pubmed_id` |
+| `doi` | CrossRef | CrossRef | `DOI` |
+| `doi` | OpenAlex | OpenAlex | `doi` |
+| `pmc_id` | PMC | PMC | PMCID |
+
+---
+
+## 7. Pipeline Configuration
+
+```yaml
+pipeline_name: pubmed_publication
+provider: pubmed
+entity_type: publications
+version: "1.1.0"
+
+primary_keys: ["pmid"]
+silver_table: "pubmed_publication"
+gold_table: "pubmed_publication"
+
+source:
+  type: api
+  batch_size: 200  # E-utilities limit
+
+dq_rules:
+  soft_fail_threshold: 0.05
+  hard_fail_threshold: 0.20
+
+sink:
+  bronze:
+    path: "data/output/bronze"
+  silver:
+    path: "data/output/silver"
+    primary_key: ["pmid"]
+    partition_by: []
+  gold:
+    path: "data/output/gold"
+
+gold_filters:
+  required_fields:
+    - title
+
+input_filter:
+  enabled: true
+  source_path: "data/input/pubmed.csv"
+  column_name: "pmid"
+  filter_field: "pmid"
+  batch_size: 200
+```
+
+---
+
+## 8. Special Considerations
+
+### 8.1. API Key Configuration
+
+```bash
+# Environment variable
+export NCBI_API_KEY=your_api_key
+
+# Increases rate limit from 3 to 10 req/sec
+```
+
+### 8.2. XML Parsing
+
+- Use robust XML parser (lxml)
+- Handle missing elements gracefully
+- Extract structured abstracts by Label attribute

--- a/docs/pipelines/semanticscholar/01-publication-spec.md
+++ b/docs/pipelines/semanticscholar/01-publication-spec.md
@@ -1,0 +1,314 @@
+# Semantic Scholar Publication Pipeline Specification
+
+*Version 1.1.0 | Aligned with RULES.md v5.10*
+
+---
+
+## 1. Identification
+
+| Parameter | Value |
+|-----------|-------|
+| **Pipeline ID** | `semanticscholar_publication` |
+| **Provider** | Semantic Scholar |
+| **Entity** | publication (paper) |
+| **API Endpoint** | `https://api.semanticscholar.org/graph/v1/paper/` |
+| **Library** | `httpx` (REST API) |
+| **Rate Limit** | 100 req/5min (public), higher with API key |
+| **Health Check** | `/paper/search?query=test&limit=1` |
+| **Auth Type** | API Key (recommended) |
+
+---
+
+## 2. Business Context
+
+### 2.1. Entity Purpose
+
+Semantic Scholar provides **AI-enhanced academic data**:
+
+- **Paper metadata**: Titles, abstracts, authors
+- **Citation graph**: References and citations with context
+- **TLDR summaries**: AI-generated paper summaries
+- **Influential citations**: Quality-weighted citation metrics
+- **Fields of Study**: AI-assigned research areas
+
+### 2.2. Use Cases
+
+1. **Citation Impact**: Track influential citations (not just counts)
+2. **TLDR Summaries**: Quick paper understanding
+3. **Research Area Analysis**: Classify by fields of study
+4. **Cross-Database Linking**: Maps to DOI, PubMed, arXiv
+
+---
+
+## 3. Extraction (Bronze Layer)
+
+### 3.1. API Request
+
+```python
+import httpx
+
+# By Paper ID
+url = f"https://api.semanticscholar.org/graph/v1/paper/{paper_id}"
+
+# By DOI
+url = f"https://api.semanticscholar.org/graph/v1/paper/DOI:{doi}"
+
+# By PubMed ID
+url = f"https://api.semanticscholar.org/graph/v1/paper/PMID:{pmid}"
+
+# Common params
+params = {
+    "fields": "paperId,corpusId,externalIds,title,abstract,tldr,"
+              "year,referenceCount,citationCount,influentialCitationCount,"
+              "isOpenAccess,openAccessPdf,fieldsOfStudy,s2FieldsOfStudy,"
+              "publicationTypes,publicationDate,journal,authors"
+}
+headers = {"x-api-key": api_key}  # Optional but recommended
+```
+
+### 3.2. Complete API Fields
+
+| # | API Field | JSON Type | Nullable | Description |
+|---|-----------|-----------|----------|-------------|
+| 1 | `paperId` | string | No | S2 Paper ID (40-char hex) |
+| 2 | `corpusId` | int | Yes | S2 Corpus ID |
+| 3 | `externalIds` | object | Yes | External IDs (DOI, PMID, etc.) |
+| 4 | `title` | string | Yes | Paper title |
+| 5 | `abstract` | string | Yes | Abstract text |
+| 6 | `tldr` | object | Yes | AI-generated summary |
+| 7 | `year` | int | Yes | Publication year |
+| 8 | `referenceCount` | int | Yes | Number of references |
+| 9 | `citationCount` | int | Yes | Number of citations |
+| 10 | `influentialCitationCount` | int | Yes | Influential citations |
+| 11 | `isOpenAccess` | boolean | Yes | OA flag |
+| 12 | `openAccessPdf` | object | Yes | OA PDF info |
+| 13 | `fieldsOfStudy` | array | Yes | Research fields |
+| 14 | `s2FieldsOfStudy` | array | Yes | S2-specific fields |
+| 15 | `publicationTypes` | array | Yes | Publication types |
+| 16 | `publicationDate` | string | Yes | Full date |
+| 17 | `journal` | object | Yes | Journal info |
+| 18 | `authors` | array | Yes | Author list |
+
+### 3.3. Nested Structure: externalIds
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `DOI` | string | DOI |
+| `PubMed` | string | PubMed ID |
+| `PMCID` | string | PMC ID |
+| `ArXiv` | string | arXiv ID |
+| `MAG` | string | Microsoft Academic Graph ID |
+| `CorpusId` | int | S2 Corpus ID |
+
+### 3.4. Nested Structure: tldr
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `model` | string | Model used |
+| `text` | string | TLDR summary text |
+
+### 3.5. Nested Structure: journal
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Journal name |
+| `volume` | string | Volume |
+| `pages` | string | Page range |
+
+---
+
+## 4. Transformation
+
+### 4.1. Entity ID Strategy
+
+| Parameter | Value |
+|-----------|-------|
+| **Entity ID Field** | `paper_id` |
+| **ID Source** | `from_api` |
+| **Format** | 40-character hex string |
+
+### 4.2. Flattening Strategy
+
+| Nested Path | Flattened Name | Strategy |
+|-------------|----------------|----------|
+| `paperId` | `paper_id` | Direct |
+| `externalIds.DOI` | `doi` | Extract |
+| `externalIds.PubMed` | `pmid` | Extract |
+| `externalIds.PMCID` | `pmcid` | Extract |
+| `externalIds.ArXiv` | `arxiv_id` | Extract |
+| `tldr.text` | `tldr` | Extract |
+| `journal.name` | `journal` | Extract |
+| `journal.volume` | `volume` | Extract |
+| `journal.pages` | `pages` | Extract |
+| `openAccessPdf.url` | `open_access_url` | Extract |
+| `fieldsOfStudy` | `fields_of_study` | JSON array |
+| `publicationTypes` | `publication_types` | JSON array |
+| `authors[*]` | `authors` | JSON array |
+
+---
+
+## 5. Validation
+
+### 5.1. Pandera Schema
+
+```python
+class SemanticScholarPublicationSchema(ETLRecordSchema):
+    """Semantic Scholar Publication validation schema."""
+
+    # === Primary Key ===
+    paper_id: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^[a-f0-9]{40}$",
+    )
+
+    # === External Identifiers ===
+    doi: Series[str] = pa.Field(
+        nullable=True,
+        str_matches=DOI_REGEX_PATTERN,
+    )
+    pmid: Series[str] = pa.Field(
+        nullable=True,
+        str_matches=r"^\d+$",
+    )
+    pmcid: Series[str] = pa.Field(
+        nullable=True,
+        str_matches=r"^PMC\d+$",
+    )
+    arxiv_id: Series[str] = pa.Field(nullable=True)
+    corpus_id: Series[int] = pa.Field(nullable=True, ge=0)
+
+    # === Core Fields ===
+    title: Series[str] = pa.Field(nullable=True)
+    abstract: Series[str] = pa.Field(nullable=True)
+    tldr: Series[str] = pa.Field(nullable=True)
+    year: Series[int] = pa.Field(
+        nullable=True,
+        ge=MIN_PUBLICATION_YEAR,
+        le=MAX_PUBLICATION_YEAR,
+    )
+    publication_date: Series[str] = pa.Field(
+        nullable=True,
+        str_matches=r"^\d{4}-\d{2}-\d{2}$",
+    )
+
+    # === Journal/Venue ===
+    journal: Series[str] = pa.Field(nullable=True)
+    volume: Series[str] = pa.Field(nullable=True)
+    pages: Series[str] = pa.Field(nullable=True)
+    venue: Series[str] = pa.Field(nullable=True)
+
+    # === Metrics ===
+    citation_count: Series[int] = pa.Field(nullable=True, ge=0)
+    reference_count: Series[int] = pa.Field(nullable=True, ge=0)
+
+    # === Open Access ===
+    is_oa: Series[bool] = pa.Field(nullable=True)
+    open_access_url: Series[str] = pa.Field(nullable=True)
+    oa_status: Series[str] = pa.Field(
+        nullable=True,
+        isin=["gold", "green", "hybrid", "bronze", "closed"],
+    )
+
+    # === Classification ===
+    fields_of_study: Series[str] = pa.Field(nullable=True)  # JSON
+    publication_types: Series[str] = pa.Field(nullable=True)  # JSON
+
+    # === Authors ===
+    authors: Series[str] = pa.Field(nullable=True)  # JSON
+
+    # === Source Tracking ===
+    source: Series[str] = pa.Field(
+        nullable=False,
+        eq="semanticscholar",
+    )
+
+    # === Lookup Metadata ===
+    lookup_method: Series[str] = pa.Field(
+        alias="_lookup_method",
+        nullable=False,
+        isin=["doi", "title_fallback", "title_only", "unknown"],
+    )
+    original_doi: Series[str] = pa.Field(
+        alias="_original_doi",
+        nullable=True,
+    )
+
+    class Config:
+        strict = "filter"
+        coerce = True
+```
+
+---
+
+## 6. Cross-Provider Mapping
+
+| This Entity Field | Maps To | Provider | Field |
+|-------------------|---------|----------|-------|
+| `doi` | ChEMBL | ChEMBL | `document.doi` |
+| `doi` | CrossRef | CrossRef | `DOI` |
+| `doi` | OpenAlex | OpenAlex | `doi` |
+| `pmid` | PubMed | PubMed | `pmid` |
+| `arxiv_id` | arXiv | arXiv | ID |
+
+---
+
+## 7. Pipeline Configuration
+
+```yaml
+pipeline_name: semanticscholar_publication
+provider: semanticscholar
+entity_type: publication
+version: "1.1.0"
+
+primary_keys: ["paper_id"]
+silver_table: "semanticscholar_publication"
+gold_table: "semanticscholar_publication"
+
+source:
+  type: api
+  batch_size: 100
+
+sink:
+  bronze:
+    path: "data/output/bronze"
+  silver:
+    path: "data/output/silver"
+    primary_key: ["paper_id"]
+    partition_by: []
+  gold:
+    path: "data/output/gold"
+
+gold_filters:
+  required_fields:
+    - title
+
+input_filter:
+  enabled: true
+  source_path: "data/input/doi.csv"
+  column_name: "doi"
+  filter_field: "doi"
+  batch_size: 100
+```
+
+---
+
+## 8. Special Considerations
+
+### 8.1. Rate Limiting
+
+- **Public**: 100 requests per 5 minutes
+- **With API key**: Higher limits (varies)
+- **Batch endpoint**: Use for multiple papers
+
+### 8.2. Batch Requests
+
+```python
+# Batch lookup (up to 500 papers)
+url = "https://api.semanticscholar.org/graph/v1/paper/batch"
+body = {"ids": paper_ids}
+params = {"fields": "paperId,title,abstract,..."}
+```
+
+### 8.3. DOI Resolution Fallback
+
+When DOI lookup fails, try other identifiers or title search.

--- a/docs/pipelines/uniprot/01-protein-spec.md
+++ b/docs/pipelines/uniprot/01-protein-spec.md
@@ -1,0 +1,311 @@
+# UniProt Protein Pipeline Specification
+
+*Version 1.1.0 | Aligned with RULES.md v5.10*
+
+---
+
+## 1. Identification
+
+| Parameter | Value |
+|-----------|-------|
+| **Pipeline ID** | `uniprot_protein` |
+| **Provider** | UniProt (EBI/SIB/PIR) |
+| **Entity** | protein |
+| **API Endpoint** | `https://rest.uniprot.org/uniprotkb/` |
+| **Library** | `unipressed` (async) |
+| **Rate Limit** | 100 req/sec (with API key) |
+| **Health Check** | `/rest/beta/health` |
+| **Auth Type** | API Key (optional) |
+
+---
+
+## 2. Business Context
+
+### 2.1. Entity Purpose
+
+UniProt proteins are **curated protein entries** with comprehensive annotations:
+
+- **Protein sequences**: Primary amino acid sequences
+- **Functional annotations**: Function, pathway, subcellular location
+- **Cross-references**: Links to ChEMBL, DrugBank, GO terms
+- **Species context**: Organism and taxonomy information
+- **Quality tiers**: Swiss-Prot (reviewed) vs TrEMBL (unreviewed)
+
+### 2.2. Use Cases
+
+1. **Target Identification**: Find drug targets with ChEMBL links
+2. **Sequence Analysis**: Access protein sequences for alignment
+3. **Functional Annotation**: Understand protein functions
+4. **Drug-Target Networks**: Build networks via cross-references
+5. **Species Translation**: Compare orthologs across organisms
+
+### 2.3. Entity Relationships
+
+```
+uniprot_protein
+    │
+    ├──► chembl_target (via chembl_ids cross-ref)
+    │
+    ├──► drugbank (via drugbank_ids cross-ref)
+    │
+    └──► GO terms (via go_terms)
+```
+
+---
+
+## 3. Extraction (Bronze Layer)
+
+### 3.1. API Request
+
+```python
+from unipressed import UniProtkbClient
+
+client = UniProtkbClient()
+# Search by accession or query
+results = await client.search(
+    query="accession:P00533",
+    fields=[
+        "accession", "id", "protein_name", "gene_names",
+        "organism_name", "organism_id", "sequence", "length",
+        "cc_function", "cc_pathway", "xref_chembl", "xref_drugbank"
+    ]
+)
+```
+
+### 3.2. Complete API Fields
+
+| # | API Field | JSON Type | Nullable | Description |
+|---|-----------|-----------|----------|-------------|
+| 1 | `primaryAccession` | string | No | Primary accession (PK) |
+| 2 | `uniProtkbId` | string | No | Entry name |
+| 3 | `entryType` | string | Yes | Swiss-Prot/TrEMBL |
+| 4 | `secondaryAccessions` | array | Yes | Secondary accessions |
+| 5 | `proteinDescription` | object | Yes | Protein names |
+| 6 | `genes` | array | Yes | Gene names |
+| 7 | `organism` | object | Yes | Organism info |
+| 8 | `sequence` | object | Yes | Sequence data |
+| 9 | `features` | array | Yes | Sequence features |
+| 10 | `comments` | array | Yes | Functional annotations |
+| 11 | `dbreferences` | array | Yes | Cross-references |
+| 12 | `keywords` | array | Yes | UniProt keywords |
+
+### 3.3. Nested Structure: proteinDescription
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `recommendedName.fullName.value` | string | Recommended protein name |
+| `alternativeNames[*].fullName.value` | array | Alternative names |
+| `ecNumbers[*].value` | array | EC numbers |
+
+### 3.4. Nested Structure: organism
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `scientificName` | string | Scientific name |
+| `commonName` | string | Common name |
+| `taxonId` | integer | NCBI Taxonomy ID |
+| `lineage` | array | Taxonomic lineage |
+
+### 3.5. Nested Structure: sequence
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `value` | string | Amino acid sequence |
+| `length` | integer | Sequence length |
+| `molWeight` | integer | Molecular weight |
+| `crc64` | string | CRC64 checksum |
+
+---
+
+## 4. Transformation
+
+### 4.1. Entity ID Strategy
+
+| Parameter | Value |
+|-----------|-------|
+| **Entity ID Field** | `accession` (primaryAccession) |
+| **ID Source** | `from_api` |
+| **Format** | UniProt accession pattern |
+
+### 4.2. Flattening Strategy
+
+| Nested Path | Flattened Name | Strategy |
+|-------------|----------------|----------|
+| `proteinDescription.recommendedName.fullName.value` | `protein_name` | Extract scalar |
+| `proteinDescription.ecNumbers[*].value` | `protein_ec_numbers` | JSON array |
+| `genes[0].geneName.value` | `gene_primary` | Extract first |
+| `genes[*].synonyms[*].value` | `gene_synonyms` | JSON array |
+| `organism.scientificName` | `organism_scientific` | Extract scalar |
+| `organism.commonName` | `organism_common` | Extract scalar |
+| `organism.taxonId` | `taxonomy_id` | Extract scalar |
+| `sequence.value` | `sequence` | Extract scalar |
+| `sequence.length` | `sequence_length` | Extract scalar |
+| `sequence.molWeight` | `sequence_mass` | Extract scalar |
+| `dbreferences[type=ChEMBL]` | `chembl_ids` | Filter & extract |
+| `dbreferences[type=DrugBank]` | `drugbank_ids` | Filter & extract |
+
+---
+
+## 5. Validation
+
+### 5.1. Pandera Schema
+
+```python
+class UniprotTargetSchema(ETLRecordSchema):
+    """UniProt Target validation schema for Silver layer."""
+
+    # === Primary Key ===
+    accession: Series[str] = pa.Field(
+        nullable=False,
+        description="UniProt primary accession (PK)",
+    )
+
+    @pa.check("accession", name="accession_format")
+    def _check_accession(cls, series):
+        pattern = r"^[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}$"
+        return series.str.match(pattern)
+
+    entry_name: Series[str] = pa.Field(nullable=False)
+    entry_type: Series[str] | None = pa.Field(
+        nullable=True,
+        isin=ENTRY_TYPES,  # Swiss-Prot/TrEMBL
+    )
+
+    # === Protein Names ===
+    protein_name: Series[str] | None = pa.Field(nullable=True)
+    protein_ec_numbers: Series[str] | None = pa.Field(nullable=True)  # JSON
+
+    # === Gene Names ===
+    gene_primary: Series[str] | None = pa.Field(nullable=True)
+    gene_synonyms: Series[str] | None = pa.Field(nullable=True)  # JSON
+
+    # === Organism ===
+    organism_scientific: Series[str] | None = pa.Field(nullable=True)
+    organism_common: Series[str] | None = pa.Field(nullable=True)
+    taxonomy_id: Series[int] | None = pa.Field(nullable=True, ge=1)
+
+    # === Sequence ===
+    sequence: Series[str] = pa.Field(nullable=False)
+
+    @pa.check("sequence", name="sequence_format")
+    def _check_sequence(cls, series):
+        return series.str.match(r"^[ACDEFGHIKLMNPQRSTVWY]+$")
+
+    sequence_length: Series[int] = pa.Field(nullable=False, ge=1)
+    sequence_mass: Series[int] | None = pa.Field(nullable=True, ge=1)
+
+    # === Evidence ===
+    protein_existence: Series[str] | None = pa.Field(
+        nullable=True,
+        isin=PROTEIN_EXISTENCE_LEVELS,
+    )
+    annotation_score: Series[int] | None = pa.Field(
+        nullable=True,
+        ge=1,
+        le=5,
+    )
+    reviewed: Series[bool] = pa.Field(nullable=False)
+
+    # === Functional Annotation ===
+    function_comment: Series[str] | None = pa.Field(nullable=True)  # JSON
+    catalytic_activity: Series[str] | None = pa.Field(nullable=True)  # JSON
+    pathway: Series[str] | None = pa.Field(nullable=True)  # JSON
+    subcellular_location: Series[str] | None = pa.Field(nullable=True)  # JSON
+    disease_involvement: Series[str] | None = pa.Field(nullable=True)  # JSON
+
+    # === Cross-References ===
+    go_terms: Series[str] | None = pa.Field(nullable=True)  # JSON
+    chembl_ids: Series[str] | None = pa.Field(nullable=True)  # JSON
+    drugbank_ids: Series[str] | None = pa.Field(nullable=True)  # JSON
+
+    # === Features & Keywords ===
+    features: Series[str] | None = pa.Field(nullable=True)  # JSON
+    keywords: Series[str] | None = pa.Field(nullable=True)  # JSON
+
+    class Config:
+        strict = True
+        ordered = True
+        coerce = True
+```
+
+### 5.2. Field Validation Matrix
+
+| Field | Type | Nullable | Constraints | DQ Level |
+|-------|------|----------|-------------|----------|
+| `accession` | str | No | UniProt format | CRITICAL |
+| `entry_name` | str | No | format `XXX_SPECIES` | CRITICAL |
+| `sequence` | str | No | amino acid chars only | CRITICAL |
+| `sequence_length` | int | No | >= 1 | CRITICAL |
+| `taxonomy_id` | int | Yes | >= 1 | WARNING |
+| `reviewed` | bool | No | - | INFO |
+
+---
+
+## 6. Cross-Provider Mapping
+
+| This Entity Field | Maps To | Provider | Field |
+|-------------------|---------|----------|-------|
+| `accession` | ChEMBL | ChEMBL | `target_component.accession` |
+| `chembl_ids[*]` | ChEMBL | ChEMBL | `target_chembl_id` |
+| `drugbank_ids[*]` | DrugBank | DrugBank | `drugbank_id` |
+| `taxonomy_id` | NCBI Taxonomy | NCBI | `tax_id` |
+
+---
+
+## 7. Pipeline Configuration
+
+```yaml
+pipeline_name: uniprot_protein
+provider: uniprot
+entity_type: protein
+version: "1.1.0"
+
+primary_keys: ["accession"]
+silver_table: "uniprot_protein"
+gold_table: "uniprot_protein"
+
+source_file: ../../sources/uniprot.yaml
+
+gold_filters:
+  required_fields:
+    - protein_name
+    - sequence
+  columns:
+    reviewed: [true]  # Swiss-Prot only
+
+sink:
+  bronze:
+    path: "data/output/bronze"
+  silver:
+    path: "data/output/silver"
+    primary_key: ["accession"]
+    partition_by: []
+  gold:
+    path: "data/output/gold"
+
+input_filter:
+  enabled: true
+  source_path: "data/input/protein.csv"
+  column_name: "accession"
+  filter_field: "accession"
+  batch_size: 100  # Higher for UniProt
+```
+
+---
+
+## 8. Dependencies
+
+### 8.1. Upstream
+
+| Dependency | Type | Required |
+|------------|------|----------|
+| UniProt REST API | API | Yes |
+| `uniprot_idmapping` | Pipeline | Optional (for ChEMBL→UniProt) |
+
+### 8.2. Downstream
+
+| Consumer | Impact |
+|----------|--------|
+| Target annotation | Protein function/pathway data |
+| Cross-database linking | ChEMBL/DrugBank integration |
+| Sequence analysis | Protein sequences for alignment |

--- a/docs/pipelines/uniprot/02-idmapping-spec.md
+++ b/docs/pipelines/uniprot/02-idmapping-spec.md
@@ -1,0 +1,309 @@
+# UniProt ID Mapping Pipeline Specification
+
+*Version 1.1.0 | Aligned with RULES.md v5.10*
+
+---
+
+## 1. Identification
+
+| Parameter | Value |
+|-----------|-------|
+| **Pipeline ID** | `uniprot_idmapping` |
+| **Provider** | UniProt (EBI/SIB/PIR) |
+| **Entity** | idmapping |
+| **API Endpoint** | `https://rest.uniprot.org/idmapping/` |
+| **Library** | `httpx` (async) |
+| **Rate Limit** | 100 req/sec |
+| **Health Check** | Submit test job |
+| **Auth Type** | None (public API) |
+
+---
+
+## 2. Business Context
+
+### 2.1. Entity Purpose
+
+ID Mapping enables **cross-database identifier translation**:
+
+- **ChEMBL → UniProt**: Map ChEMBL target IDs to UniProt accessions
+- **Gene → Protein**: Map gene names to protein accessions
+- **External DBs**: Map to/from EMBL, RefSeq, PDB, etc.
+- **Batch processing**: Efficient bulk mapping
+
+### 2.2. Use Cases
+
+1. **Target Integration**: Link ChEMBL targets to UniProt annotations
+2. **ID Harmonization**: Standardize identifiers across databases
+3. **Enrichment Pipelines**: Fetch UniProt data for ChEMBL targets
+4. **Cross-Provider Linking**: Build unified identifier mappings
+
+### 2.3. Supported Mapping Types
+
+| From Database | To Database | Use Case |
+|---------------|-------------|----------|
+| ChEMBL | UniProtKB | Target enrichment |
+| UniProtKB_AC-ID | PDB | Structure data |
+| UniProtKB_AC-ID | RefSeq_Protein | Sequence data |
+| Gene_Name | UniProtKB | Gene-based search |
+| EMBL | UniProtKB | Sequence→Protein |
+
+---
+
+## 3. Extraction (Bronze Layer)
+
+### 3.1. API Request Flow
+
+```python
+import httpx
+
+# Step 1: Submit mapping job
+submit_url = "https://rest.uniprot.org/idmapping/run"
+job_response = await client.post(submit_url, data={
+    "from": "ChEMBL",
+    "to": "UniProtKB",
+    "ids": ",".join(chembl_target_ids)  # Max 100,000 IDs
+})
+job_id = job_response.json()["jobId"]
+
+# Step 2: Poll for results
+status_url = f"https://rest.uniprot.org/idmapping/status/{job_id}"
+while True:
+    status = await client.get(status_url)
+    if status.json().get("results"):
+        break
+    await asyncio.sleep(1)
+
+# Step 3: Fetch results with pagination
+results_url = f"https://rest.uniprot.org/idmapping/results/{job_id}"
+results = await client.get(results_url)
+```
+
+### 3.2. Response Fields
+
+| # | Field | JSON Type | Nullable | Description |
+|---|-------|-----------|----------|-------------|
+| 1 | `from` | string | No | Source ID |
+| 2 | `to` | object | Yes | Mapped UniProt entry (full) |
+| 3 | `to.primaryAccession` | string | Yes | UniProt accession |
+| 4 | `to.uniProtkbId` | string | Yes | Entry name |
+| 5 | `to.organism.taxonId` | int | Yes | Taxonomy ID |
+
+### 3.3. Special Cases
+
+| Case | Response | Handling |
+|------|----------|----------|
+| ID found | Full UniProt entry | Extract accession |
+| ID not found | Empty results | Set `mapping_status = "not_found"` |
+| Multiple matches | Array of entries | Store as JSON array |
+| Obsolete ID | May have redirect | Follow redirect |
+
+---
+
+## 4. Transformation
+
+### 4.1. Entity ID Strategy
+
+| Parameter | Value |
+|-----------|-------|
+| **Entity ID Field** | `target_chembl_id` (input ID) |
+| **ID Source** | `from_input` |
+| **Format** | ChEMBL ID (CHEMBL[0-9]+) |
+
+### 4.2. Output Fields
+
+| Field | Type | Source | Description |
+|-------|------|--------|-------------|
+| `target_chembl_id` | str | Input | Source ChEMBL ID |
+| `uniprot_accession` | str | API | Mapped UniProt accession |
+| `uniprot_entry_name` | str | API | Entry name |
+| `mapping_status` | str | Derived | found/not_found/multiple |
+| `uniprot_organism` | str | API | Organism name |
+| `uniprot_tax_id` | int | API | Taxonomy ID |
+| `all_mappings` | str | API | JSON array if multiple |
+
+### 4.3. Content Hash Specification
+
+```python
+# Fields included in hash
+hash_fields = [
+    "target_chembl_id",
+    "uniprot_accession",
+    "mapping_status",
+]
+
+# Algorithm
+content_hash = sha256(f"uniprot{canonical_json(filtered_record)}")
+```
+
+---
+
+## 5. Validation
+
+### 5.1. Schema
+
+```python
+class UniprotIdMappingSchema(ETLRecordSchema):
+    """UniProt ID Mapping validation schema for Silver layer."""
+
+    # === Primary Key (Input ID) ===
+    target_chembl_id: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^CHEMBL\d+$",
+        description="Source ChEMBL target ID",
+    )
+
+    # === Mapping Result ===
+    uniprot_accession: Series[str] | None = pa.Field(
+        nullable=True,
+        description="Mapped UniProt accession (null if not_found)",
+    )
+    uniprot_entry_name: Series[str] | None = pa.Field(
+        nullable=True,
+        description="UniProt entry name",
+    )
+    mapping_status: Series[str] = pa.Field(
+        nullable=False,
+        isin=["found", "not_found", "multiple", "error"],
+        description="Mapping result status",
+    )
+
+    # === Additional Metadata ===
+    uniprot_organism: Series[str] | None = pa.Field(nullable=True)
+    uniprot_tax_id: Series[int] | None = pa.Field(nullable=True, ge=1)
+    all_mappings: Series[str] | None = pa.Field(
+        nullable=True,
+        description="JSON array for multiple mappings",
+    )
+
+    class Config:
+        strict = True
+        ordered = False
+        coerce = True
+```
+
+### 5.2. DQ Thresholds
+
+| Threshold | Value | Action |
+|-----------|-------|--------|
+| Soft | 30% not_found | Warning, continue |
+| Hard | 80% not_found | Fail batch |
+
+**Note:** Higher thresholds because many ChEMBL targets may not have UniProt mappings (organism targets, cell lines, etc.)
+
+---
+
+## 6. Output Schemas
+
+### 6.1. Bronze
+
+**Note:** ID Mapping doesn't write Bronze (data comes from API, not raw files).
+
+### 6.2. Silver
+
+```
+Path: silver/uniprot/idmapping/
+Format: Delta Lake (delta-rs)
+Mode: Merge on [target_chembl_id]
+Partition: None
+Retention: Permanent
+```
+
+### 6.3. Gold
+
+```
+Path: gold/uniprot/idmapping/
+Format: Delta Lake
+Mode: Overwrite
+```
+
+**Gold Filter:** All records pass (including not_found for tracking)
+
+---
+
+## 7. Pipeline Configuration
+
+```yaml
+# configs/pipelines/uniprot/idmapping.yaml
+
+pipeline_name: uniprot_idmapping
+provider: uniprot
+entity_type: idmapping
+version: "1.1.0"
+description: "Maps ChEMBL target IDs to UniProt accessions"
+
+primary_keys: ["target_chembl_id"]
+silver_table: "uniprot_idmapping"
+gold_table: "uniprot_idmapping"
+
+source:
+  type: file
+  load_strategy: full
+  input_path: data/input/target.csv
+  api:
+    base_url: https://rest.uniprot.org
+    from_db: ChEMBL
+    to_db: UniProtKB
+
+dq_rules:
+  soft_fail_threshold: 0.30  # 30% not_found acceptable
+  hard_fail_threshold: 0.80  # 80% not_found triggers failure
+
+sink:
+  bronze:
+    enabled: false  # No Bronze for ID mapping
+  silver:
+    path: "data/output/silver"
+    primary_key: ["target_chembl_id"]
+    partition_by: []
+  gold:
+    path: "data/output/gold"
+
+gold_filters:
+  required_fields:
+    - target_chembl_id
+    - mapping_status
+
+input_filter:
+  enabled: false  # Input CSV IS the source
+```
+
+---
+
+## 8. Dependencies
+
+### 8.1. Upstream
+
+| Dependency | Type | Required |
+|------------|------|----------|
+| UniProt ID Mapping API | API | Yes |
+| Input CSV with ChEMBL IDs | File | Yes |
+
+### 8.2. Downstream
+
+| Consumer | Impact |
+|----------|--------|
+| `uniprot_protein` | Provides accessions for protein fetch |
+| Target enrichment | Enables ChEMBL→UniProt linking |
+| Cross-provider analytics | ID harmonization |
+
+---
+
+## 9. Error Handling
+
+### 9.1. API Errors
+
+| Error | Handling |
+|-------|----------|
+| 400 Bad Request | Log, retry with smaller batch |
+| 429 Too Many Requests | Exponential backoff |
+| 500 Server Error | Retry up to 3 times |
+| Job timeout | Retry with smaller batch |
+
+### 9.2. Mapping Failures
+
+| Scenario | `mapping_status` | Notes |
+|----------|------------------|-------|
+| ID found | `found` | Normal case |
+| ID not in DB | `not_found` | Expected for non-protein targets |
+| Multiple matches | `multiple` | Store all in `all_mappings` |
+| API error | `error` | Retry or quarantine |


### PR DESCRIPTION
…ETL pipelines

Add detailed documentation for all BioETL pipelines including:

ChEMBL (10 pipelines):
- protein_class, cell_line, molecule, target, target_component
- activity, assay, assay_parameters, compound_record, publication

UniProt (2 pipelines):
- protein, idmapping

Other providers (5 pipelines):
- pubchem_compound, pubmed_publication, crossref_publication
- openalex_publication, semanticscholar_publication

Each specification includes:
- API endpoints, rate limits, authentication
- Business context and entity relationships
- Complete API field mappings
- Transformation and normalization rules
- Pandera validation schemas
- Bronze/Silver/Gold output schemas
- Cross-provider ID mappings
- Pipeline configuration examples
- Field mapping CSVs for Excel import