### PR TITLE
Standardize field naming across data providers

### DIFF
--- a/src/bioetl/application/pipelines/chembl/activity_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/activity_transformer.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from bioetl.application.core.field_specs import (
     FieldGroup,
+    FieldSpec,
     float_fields,
     int_fields,
     map_field_groups,
@@ -21,6 +22,14 @@ from bioetl.application.pipelines.chembl.base_chembl_transformer import (
 )
 from bioetl.domain.entities import Bioactivity
 from bioetl.domain.transformations import safe_float
+from bioetl.domain.value_objects import TaxonomyId
+
+
+def _validate_taxonomy_id_str(value: Any) -> str | None:
+    """Validate taxonomy ID using TaxonomyId Value Object, return as string."""
+    vo = TaxonomyId.from_raw(value)
+    return str(vo.value) if vo else None
+
 
 if TYPE_CHECKING:
     from bioetl.domain.types import BronzeRecord
@@ -55,20 +64,29 @@ _IDENTIFIERS = FieldGroup(
 
 _MOLECULE_TARGET_ASSAY = FieldGroup(
     name="molecule_target_assay",
-    fields=simple_fields(
-        "canonical_smiles",
-        "molecule_pref_name",
-        "parent_molecule_chembl_id",
-        "target_pref_name",
-        "target_organism",
-        "target_tax_id",
-        "assay_type",
-        "assay_description",
-        "assay_variant_accession",
-        "assay_variant_mutation",
-        "bao_endpoint",
-        "bao_format",
-        "bao_label",
+    fields=(
+        *simple_fields(
+            "canonical_smiles",
+            "molecule_pref_name",
+            "parent_molecule_chembl_id",
+            "target_pref_name",
+            "target_organism",
+        ),
+        # Standardized to 'taxonomy_id' for NCBI consistency (was 'tax_id')
+        FieldSpec(
+            "target_tax_id",
+            target="target_taxonomy_id",
+            converter=_validate_taxonomy_id_str,
+        ),
+        *simple_fields(
+            "assay_type",
+            "assay_description",
+            "assay_variant_accession",
+            "assay_variant_mutation",
+            "bao_endpoint",
+            "bao_format",
+            "bao_label",
+        ),
     ),
 )
 

--- a/src/bioetl/application/pipelines/chembl/assay_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/assay_transformer.py
@@ -22,22 +22,35 @@ from bioetl.application.pipelines.chembl.base_chembl_transformer import (
 from bioetl.domain.entities import Assay
 from bioetl.domain.transformations import (
     safe_float,
-    safe_int,
     safe_str,
 )
+from bioetl.domain.value_objects import TaxonomyId
+
+
+def _validate_taxonomy_id(value: Any) -> int | None:
+    """Validate taxonomy ID using TaxonomyId Value Object."""
+    vo = TaxonomyId.from_raw(value)
+    return vo.value if vo else None
+
 
 if TYPE_CHECKING:
     from bioetl.domain.types import BronzeRecord
 
 
 # Mapping for variant sequence fields extraction (from ChEMBL nested structure)
+# Source field is 'tax_id' from API, will be renamed to 'taxonomy_id' via renames
 _VARIANT_FIELDS: dict[str, Any] = {
     "accession": safe_str,
     "isoform": safe_str,
     "mutation": safe_str,
     "organism": safe_str,
     "sequence": safe_str,
-    "tax_id": safe_int,
+    "tax_id": _validate_taxonomy_id,  # Will be renamed to taxonomy_id
+}
+
+# Rename mapping for variant fields (tax_id -> taxonomy_id for NCBI consistency)
+_VARIANT_RENAMES: dict[str, str] = {
+    "variant_tax_id": "variant_taxonomy_id",
 }
 
 
@@ -50,9 +63,12 @@ def _extract_variant(data: dict[str, Any] | None) -> dict[str, Any]:
 
     Returns:
         Flattened dictionary with variant_ prefixed keys.
+        tax_id is renamed to taxonomy_id for NCBI consistency.
 
     """
-    return flatten_nested_dict(data, "variant_", _VARIANT_FIELDS)
+    return flatten_nested_dict(
+        data, "variant_", _VARIANT_FIELDS, renames=_VARIANT_RENAMES
+    )
 
 
 # ============================================================================
@@ -97,7 +113,10 @@ _BIOLOGICAL_CONTEXT = FieldGroup(
             "bao_format",
             "bao_label",
         ),
-        *int_fields("assay_tax_id"),
+        # Standardized to 'taxonomy_id' for NCBI consistency (was 'tax_id')
+        FieldSpec(
+            "assay_tax_id", target="assay_taxonomy_id", converter=_validate_taxonomy_id
+        ),
     ),
 )
 

--- a/src/bioetl/application/pipelines/chembl/cell_line_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/cell_line_transformer.py
@@ -7,14 +7,14 @@ Note: Business logic functions are delegated to domain layer per REFACTOR-004.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from bioetl.application.pipelines.chembl.base_chembl_transformer import (
     BaseChemblTransformer,
 )
 from bioetl.domain.entities import CellLine
 from bioetl.domain.normalization import normalize_to_string
-from bioetl.domain.validation import validate_positive_int
+from bioetl.domain.value_objects import TaxonomyId
 
 if TYPE_CHECKING:
     from bioetl.domain.types import BronzeRecord
@@ -50,6 +50,13 @@ class CellLineTransformer(BaseChemblTransformer):
         # Get cell_name with strip normalization using domain function
         cell_name = normalize_to_string(record.get("cell_name"))
 
+        # Validate taxonomy_id using TaxonomyId Value Object
+        raw_tax_id = record.get("cell_source_tax_id")
+        taxonomy_id_vo = TaxonomyId.from_raw(
+            cast("str | int | None", raw_tax_id) if raw_tax_id is not None else None
+        )
+        cell_source_taxonomy_id = taxonomy_id_vo.value if taxonomy_id_vo else None
+
         return {
             # Primary identifier
             "cell_chembl_id": str(primary_id),
@@ -59,10 +66,8 @@ class CellLineTransformer(BaseChemblTransformer):
             # Source information
             "cell_source_tissue": record.get("cell_source_tissue"),
             "cell_source_organism": record.get("cell_source_organism"),
-            # Use domain validation for tax_id (must be positive)
-            "cell_source_tax_id": validate_positive_int(
-                record.get("cell_source_tax_id")
-            ),
+            # Standardized to 'taxonomy_id' for NCBI consistency (was 'tax_id')
+            "cell_source_taxonomy_id": cell_source_taxonomy_id,
             # Cell type classification
             "cell_type": normalize_to_string(record.get("cell_type")),
             # External identifiers (strip, NULL if empty) using domain normalization

--- a/src/bioetl/application/pipelines/chembl/molecule_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/molecule_transformer.py
@@ -65,9 +65,9 @@ _STRUCTURES_FIELDS: dict[str, Any] = {
     "standard_inchi_key": None,
 }
 
-# Rename mapping for structures fields (standard_inchi_key -> inchi_key for PubChem consistency)
+# Rename mapping for structures fields (standard_inchi_key -> inchikey for IUPAC/PubChem consistency)
 _STRUCTURES_RENAMES: dict[str, str] = {
-    "standard_inchi_key": "inchi_key",
+    "standard_inchi_key": "inchikey",
 }
 
 # JSON fields to serialize
@@ -168,8 +168,8 @@ class MoleculeTransformer(BaseChemblTransformer):
         )
 
         # Validate InChI Key using Value Object (returns None for invalid/empty)
-        inchi_key = InChIKey.from_raw(structure_data.get("inchi_key"))
-        structure_data["inchi_key"] = str(inchi_key) if inchi_key else None
+        inchikey = InChIKey.from_raw(structure_data.get("inchikey"))
+        structure_data["inchikey"] = str(inchikey) if inchikey else None
 
         # Validate SMILES using Value Object (returns None for invalid/empty)
         # ChEMBL provides canonical_smiles, so mark as canonical

--- a/src/bioetl/application/pipelines/chembl/publication_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/publication_transformer.py
@@ -15,10 +15,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from bioetl.application.core.field_specs import (
+    PMID,
     FieldGroup,
+    FieldSpec,
     int_fields,
     map_field_groups,
-    pmid_fields,
     simple_fields,
 )
 from bioetl.application.pipelines.chembl.base_chembl_transformer import (
@@ -43,7 +44,8 @@ if TYPE_CHECKING:
 _PUBLICATION_IDS = FieldGroup(
     name="publication_ids",
     fields=(
-        *pmid_fields("pubmed_id"),
+        # Rename pubmed_id -> pmid for cross-provider consistency (PMID standardization)
+        FieldSpec("pubmed_id", target="pmid", converter=PMID),
         *simple_fields("doi", "patent_id"),
     ),
 )

--- a/src/bioetl/application/pipelines/chembl/target_component_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/target_component_transformer.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from bioetl.application.core.field_specs import (
     FieldGroup,
-    int_fields,
+    FieldSpec,
     map_field_groups,
     simple_fields,
 )
@@ -20,6 +20,14 @@ from bioetl.application.pipelines.chembl.base_chembl_transformer import (
 )
 from bioetl.domain.entities import TargetComponent
 from bioetl.domain.transformations import safe_int
+from bioetl.domain.value_objects import TaxonomyId
+
+
+def _validate_taxonomy_id(value: Any) -> int | None:
+    """Validate taxonomy ID using TaxonomyId Value Object."""
+    vo = TaxonomyId.from_raw(value)
+    return vo.value if vo else None
+
 
 if TYPE_CHECKING:
     from bioetl.domain.types import BronzeRecord
@@ -37,7 +45,8 @@ _CORE_METADATA = FieldGroup(
     name="core_metadata",
     fields=(
         *simple_fields("accession", "component_type", "description", "organism"),
-        *int_fields("tax_id"),
+        # Standardized to 'taxonomy_id' for NCBI consistency (was 'tax_id')
+        FieldSpec("tax_id", target="taxonomy_id", converter=_validate_taxonomy_id),
     ),
 )
 

--- a/src/bioetl/application/pipelines/chembl/target_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/target_transformer.py
@@ -16,6 +16,7 @@ from bioetl.application.pipelines.chembl.base_chembl_transformer import (
 )
 from bioetl.domain.entities import Target
 from bioetl.domain.transformations import safe_int
+from bioetl.domain.value_objects import TaxonomyId
 
 if TYPE_CHECKING:
     from bioetl.domain.types import BronzeRecord
@@ -37,7 +38,7 @@ class TargetTransformer(BaseChemblTransformer):
 
         Returns:
             Dict with aggregated lists for accessions, IDs, types, relationships,
-            descriptions, organisms, and tax_ids.
+            descriptions, organisms, and taxonomy_ids.
 
         Note:
             protein_classifications are NOT available in /target endpoint.
@@ -58,13 +59,25 @@ class TargetTransformer(BaseChemblTransformer):
             "component_relationships": None,
             "component_descriptions": None,
             "component_organisms": None,
-            "component_tax_ids": None,
+            # Standardized to 'taxonomy_ids' for NCBI consistency
+            "component_taxonomy_ids": None,
         }
 
     def _extract_basic_component_fields(
         self, components: list[dict[str, Any]]
     ) -> dict[str, list[Any] | None]:
         """Extract basic fields from component list via transform_utils."""
+        # Extract taxonomy IDs and validate using TaxonomyId Value Object
+        raw_tax_ids = extract_list_field(components, "tax_id", safe_int)
+        validated_tax_ids: list[int] | None = None
+        if raw_tax_ids:
+            validated_list: list[int] = []
+            for tid in raw_tax_ids:
+                vo = TaxonomyId.from_raw(tid)
+                if vo is not None:
+                    validated_list.append(vo.value)
+            validated_tax_ids = validated_list if validated_list else None
+
         return {
             "component_accessions": extract_list_field(components, "accession"),
             "component_ids": extract_list_field(components, "component_id", safe_int),
@@ -74,7 +87,8 @@ class TargetTransformer(BaseChemblTransformer):
                 components, "component_description"
             ),
             "component_organisms": extract_list_field(components, "organism"),
-            "component_tax_ids": extract_list_field(components, "tax_id", safe_int),
+            # Standardized to 'taxonomy_ids' for NCBI consistency
+            "component_taxonomy_ids": validated_tax_ids,
         }
 
     def _aggregate_synonyms(
@@ -142,6 +156,13 @@ class TargetTransformer(BaseChemblTransformer):
         # Default to False if missing or invalid, to ensure boolean dtype for Gold schema
         downgraded = bool(downgraded_val) if downgraded_val is not None else False
 
+        # Validate taxonomy_id using TaxonomyId Value Object
+        raw_tax_id = record.get("tax_id")
+        taxonomy_id_vo = TaxonomyId.from_raw(
+            cast("str | int | None", raw_tax_id) if raw_tax_id is not None else None
+        )
+        taxonomy_id = taxonomy_id_vo.value if taxonomy_id_vo else None
+
         return {
             # Primary identifier
             "target_chembl_id": str(primary_id),
@@ -149,7 +170,8 @@ class TargetTransformer(BaseChemblTransformer):
             "pref_name": record.get("pref_name"),
             "target_type": record.get("target_type"),
             "organism": record.get("organism"),
-            "tax_id": safe_int(record.get("tax_id")),
+            # Standardized to 'taxonomy_id' for NCBI consistency (was 'tax_id')
+            "taxonomy_id": taxonomy_id,
             "species_group_flag": record.get("species_group_flag"),
             "description": record.get("description"),
             "downgraded": downgraded,

--- a/src/bioetl/application/pipelines/crossref/transformer.py
+++ b/src/bioetl/application/pipelines/crossref/transformer.py
@@ -26,6 +26,7 @@ from bioetl.domain.normalization import (
 )
 from bioetl.domain.services import DataNormalizationService, IdentityService
 from bioetl.domain.validation import validate_year_range
+from bioetl.domain.value_objects import DOI
 
 if TYPE_CHECKING:
     from bioetl.domain.context import PipelineContext
@@ -177,9 +178,13 @@ class CrossRefPublicationTransformer(BasePublicationTransformer):
         # Cast to dict for type-safe access (BronzeRecord is an empty TypedDict marker)
         rec = cast("dict[str, Any]", record)
 
-        # Use DataNormalizationService for normalization
+        # Validate DOI using Value Object (returns None for invalid/empty)
+        # CrossRef always provides DOI, so we use empty string as fallback for type consistency
+        doi_vo = DOI.from_raw(rec.get("DOI"))
+        doi = str(doi_vo) if doi_vo else ""
+
+        # Use DataNormalizationService for other normalization tasks
         normalizer = self._data_normalizer
-        doi = normalizer.normalize_doi(rec.get("DOI", "")) or ""
         first_page, last_page = parse_page_range(rec.get("page"))
 
         # Extract date fields using normalizer service

--- a/src/bioetl/application/pipelines/openalex/transformer.py
+++ b/src/bioetl/application/pipelines/openalex/transformer.py
@@ -29,6 +29,7 @@ from bioetl.application.pipelines.openalex.extractors import (
 from bioetl.domain.entities.openalex import OPENALEX_TYPE_MAP, OpenAlexPublicationEntity
 from bioetl.domain.services import DataNormalizationService, IdentityService
 from bioetl.domain.validation import validate_year_range
+from bioetl.domain.value_objects import DOI
 
 if TYPE_CHECKING:
     from bioetl.domain.filtering import GoldFilterConfig
@@ -122,9 +123,10 @@ class OpenAlexPublicationTransformer(BasePublicationTransformer):
         # Extract OpenAlex ID from URL
         openalex_id = extract_openalex_id(rec.get("id"))
 
-        # Normalize DOI (handles URL prefix stripping + lowercase/strip)
+        # Validate DOI using Value Object (returns None for invalid/empty)
         # OpenAlex stores DOIs as full URLs (e.g., "https://doi.org/10.1038/...")
-        doi = self._data_normalizer.normalize_doi(rec.get("doi"))
+        doi_vo = DOI.from_raw(rec.get("doi"))
+        doi = str(doi_vo) if doi_vo else None
 
         # Reconstruct abstract from inverted index (then strip HTML for cleaning)
         abstract_index = rec.get("abstract_inverted_index")

--- a/src/bioetl/application/pipelines/pubchem/transformer.py
+++ b/src/bioetl/application/pipelines/pubchem/transformer.py
@@ -15,6 +15,7 @@ from bioetl.application.core.base_transformer import BaseTransformer
 from bioetl.domain.entities import PubchemMolecule
 from bioetl.domain.services import IdentityService
 from bioetl.domain.validation import validate_molecular_weight
+from bioetl.domain.value_objects import InChIKey
 
 if TYPE_CHECKING:
     from bioetl.domain.context import PipelineContext
@@ -91,6 +92,14 @@ class PubChemCompoundTransformer(BaseTransformer):
         # Step 2: Build business data dictionary
         # Validate and convert molecular_weight (handles string→float, range, precision)
         mol_weight = validate_molecular_weight(record.get("molecular_weight"))
+
+        # Validate InChI Key using Value Object (returns None for invalid/empty)
+        raw_inchikey = record.get("inchikey")
+        inchikey_vo = InChIKey.from_raw(
+            str(raw_inchikey) if raw_inchikey is not None else None
+        )
+        inchikey = str(inchikey_vo) if inchikey_vo else None
+
         business_data: dict[str, Any] = {
             "cid": str(cid),
             "molecular_formula": record.get("molecular_formula"),
@@ -98,7 +107,7 @@ class PubChemCompoundTransformer(BaseTransformer):
             "canonical_smiles": record.get("canonical_smiles"),
             "isomeric_smiles": record.get("isomeric_smiles"),
             "inchi": record.get("inchi"),
-            "inchikey": record.get("inchikey"),
+            "inchikey": inchikey,
             "iupac_name": record.get("iupac_name"),
         }
 

--- a/src/bioetl/application/pipelines/pubmed/transformer.py
+++ b/src/bioetl/application/pipelines/pubmed/transformer.py
@@ -22,7 +22,7 @@ from bioetl.application.pipelines.pubmed.extractors import (
 from bioetl.application.pipelines.pubmed.xml_utils import get_text
 from bioetl.domain.entities import Publication
 from bioetl.domain.services import DataNormalizationService, IdentityService
-from bioetl.domain.value_objects import PubMedId
+from bioetl.domain.value_objects import DOI, PubMedId
 
 if TYPE_CHECKING:
     from bioetl.domain.context import PipelineContext
@@ -163,9 +163,10 @@ class PubMedPublicationTransformer(BasePublicationTransformer):
         raw_authors = AuthorExtractor.parse_authors(article)
         hashed_authors = self.hash_pii_list(raw_authors) or []
 
-        # Extract and normalize DOI (lowercase, stripped) for cross-provider consistency
+        # Validate DOI using Value Object (returns None for invalid/empty)
         raw_doi = IdentifierExtractor.extract_doi(root)
-        normalized_doi = self._data_normalizer.normalize_doi(raw_doi)
+        doi_vo = DOI.from_raw(raw_doi)
+        normalized_doi = str(doi_vo) if doi_vo else None
 
         return {
             "pmid": pmid,

--- a/src/bioetl/application/pipelines/semanticscholar/transformer.py
+++ b/src/bioetl/application/pipelines/semanticscholar/transformer.py
@@ -21,6 +21,7 @@ from bioetl.application.pipelines.semanticscholar.extractors import (
 )
 from bioetl.domain.entities.semanticscholar import SemanticScholarPublicationEntity
 from bioetl.domain.services import DataNormalizationService
+from bioetl.domain.value_objects import DOI, PubMedId
 
 if TYPE_CHECKING:
     from bioetl.domain.filtering import GoldFilterConfig
@@ -120,9 +121,16 @@ class SemanticScholarPublicationTransformer(BasePublicationTransformer):
 
         # External identifiers
         external_ids = extract_external_ids(rec.get("externalIds"))
-        # Normalize DOI (lowercase, stripped) for cross-provider consistency
+
+        # Validate DOI using Value Object (returns None for invalid/empty)
         raw_doi = external_ids.get("doi")
-        doi = self._data_normalizer.normalize_doi(raw_doi)
+        doi_vo = DOI.from_raw(raw_doi)
+        doi = str(doi_vo) if doi_vo else None
+
+        # Validate PMID using Value Object (returns None for invalid/empty)
+        raw_pmid = external_ids.get("pmid")
+        pmid_vo = PubMedId.from_raw(raw_pmid)
+        pmid = str(pmid_vo) if pmid_vo else None
 
         # Authors with optional PII hashing
         raw_authors = extract_authors(rec.get("authors"))
@@ -156,7 +164,7 @@ class SemanticScholarPublicationTransformer(BasePublicationTransformer):
         return {
             "paper_id": paper_id,
             "doi": doi,
-            "pmid": external_ids.get("pmid"),
+            "pmid": pmid,  # Use validated PMID from PubMedId Value Object
             "pmcid": external_ids.get("pmcid"),
             "arxiv_id": external_ids.get("arxiv"),
             "corpus_id": external_ids.get("corpus_id"),

--- a/src/bioetl/domain/entities/bioactivity.py
+++ b/src/bioetl/domain/entities/bioactivity.py
@@ -94,7 +94,8 @@ class Bioactivity(BaseEntity):
     # Target data
     target_pref_name: str | None = None
     target_organism: str | None = None
-    target_tax_id: str | None = None
+    # Standardized to 'taxonomy_id' for NCBI consistency (was 'tax_id')
+    target_taxonomy_id: str | None = None
 
     # Assay data
     assay_type: str | None = None
@@ -238,7 +239,10 @@ class Bioactivity(BaseEntity):
             # Target data
             target_pref_name=_safe_str(raw_data.get("target_pref_name")),
             target_organism=_safe_str(raw_data.get("target_organism")),
-            target_tax_id=_safe_str(raw_data.get("target_tax_id")),
+            # Supports both old 'target_tax_id' and new 'target_taxonomy_id' keys
+            target_taxonomy_id=_safe_str(
+                raw_data.get("target_taxonomy_id") or raw_data.get("target_tax_id")
+            ),
             # Assay data
             assay_type=_safe_str(raw_data.get("assay_type")),
             assay_description=_safe_str(raw_data.get("assay_description")),

--- a/src/bioetl/domain/entities/chembl_activity.py
+++ b/src/bioetl/domain/entities/chembl_activity.py
@@ -54,7 +54,8 @@ class Assay(BaseEntity):
 
     # Biological context
     assay_organism: str | None = None
-    assay_tax_id: int | None = None
+    # Standardized to 'taxonomy_id' for NCBI consistency (was 'tax_id')
+    assay_taxonomy_id: int | None = None
     assay_cell_type: str | None = None
     assay_tissue: str | None = None
     assay_strain: str | None = None
@@ -81,7 +82,8 @@ class Assay(BaseEntity):
     variant_mutation: str | None = None  # Mutation description (e.g., V600E)
     variant_organism: str | None = None  # Organism name
     variant_sequence: str | None = None  # Amino acid sequence
-    variant_tax_id: int | None = None  # NCBI Taxonomy ID
+    # Standardized to 'taxonomy_id' for NCBI consistency (was 'tax_id')
+    variant_taxonomy_id: int | None = None  # NCBI Taxonomy ID
     # Forensic: original JSON
     variant_sequence_json: str | None = None
 

--- a/src/bioetl/domain/entities/chembl_structures.py
+++ b/src/bioetl/domain/entities/chembl_structures.py
@@ -26,7 +26,8 @@ class ChemblPublication(BaseEntity):
     document_chembl_id: str
 
     # Publication identifiers
-    pubmed_id: str | None = None  # Numeric string for cross-provider consistency
+    # Standardized to 'pmid' for cross-provider JOIN consistency (was 'pubmed_id')
+    pmid: str | None = None  # Numeric string for cross-provider consistency
     doi: str | None = None
     patent_id: str | None = None
 
@@ -120,7 +121,8 @@ class Target(BaseEntity):
     pref_name: str | None = None
     target_type: str | None = None  # SINGLE PROTEIN, PROTEIN COMPLEX, ORGANISM, etc.
     organism: str | None = None
-    tax_id: int | None = None
+    # Standardized to 'taxonomy_id' for NCBI consistency (was 'tax_id')
+    taxonomy_id: int | None = None
     species_group_flag: bool | None = None
     description: str | None = None  # General target description
     downgraded: bool | None = None  # Flag for deprecated/downgraded records
@@ -142,7 +144,8 @@ class Target(BaseEntity):
     component_relationships: list[str] | None = None
     component_descriptions: list[str] | None = None
     component_organisms: list[str] | None = None  # Organisms from components
-    component_tax_ids: list[int] | None = None  # Tax IDs from components
+    # Standardized to 'taxonomy_ids' for NCBI consistency (was 'tax_ids')
+    component_taxonomy_ids: list[int] | None = None  # Taxonomy IDs from components
 
     # Note: protein_classifications are NOT available in /target endpoint.
     # They are only available via /target_component endpoint (TargetComponent entity).
@@ -172,7 +175,8 @@ class TargetComponent(BaseEntity):
     component_type: str | None = None
     description: str | None = None
     organism: str | None = None
-    tax_id: int | None = None
+    # Standardized to 'taxonomy_id' for NCBI consistency (was 'tax_id')
+    taxonomy_id: int | None = None
 
     # Complex fields (JSON serialized)
     target_component_synonyms: str | None = None  # JSON string of list
@@ -214,7 +218,8 @@ class CellLine(BaseEntity):
     # Source information (API-OPTIONAL)
     cell_source_tissue: str | None = None
     cell_source_organism: str | None = None
-    cell_source_tax_id: int | None = None
+    # Standardized to 'taxonomy_id' for NCBI consistency (was 'tax_id')
+    cell_source_taxonomy_id: int | None = None
 
     # Cell type classification (API-OPTIONAL)
     cell_type: str | None = None
@@ -234,9 +239,12 @@ class CellLine(BaseEntity):
             raise ValueError("Cell ChEMBL ID is required")
         if not self.cell_name:
             raise ValueError("Cell name is required")
-        if self.cell_source_tax_id is not None and self.cell_source_tax_id < 1:
+        if (
+            self.cell_source_taxonomy_id is not None
+            and self.cell_source_taxonomy_id < 1
+        ):
             raise ValueError(
-                f"cell_source_tax_id must be >= 1, got {self.cell_source_tax_id}"
+                f"cell_source_taxonomy_id must be >= 1, got {self.cell_source_taxonomy_id}"
             )
 
 
@@ -320,7 +328,8 @@ class Molecule(BaseEntity):
     # Flattened Structures (unified naming without structure_ prefix)
     canonical_smiles: str | None = None
     standard_inchi: str | None = None
-    inchi_key: str | None = None
+    # Standardized to 'inchikey' (no underscore) for IUPAC/PubChem consistency
+    inchikey: str | None = None
 
     def __post_init__(self) -> None:
         super().__post_init__()

--- a/src/bioetl/domain/schemas/chembl/activity.py
+++ b/src/bioetl/domain/schemas/chembl/activity.py
@@ -177,7 +177,10 @@ class ActivitySchema(ETLRecordSchema):
     parent_molecule_chembl_id: Series[str] | None = pa.Field(nullable=True)
     target_pref_name: Series[str] | None = pa.Field(nullable=True)
     target_organism: Series[str] | None = pa.Field(nullable=True)
-    target_tax_id: Series[str] | None = pa.Field(nullable=True)
+    target_taxonomy_id: Series[str] | None = pa.Field(
+        nullable=True,
+        description="Target taxonomy ID. Standardized name (was target_tax_id).",
+    )
     assay_type: Series[str] | None = pa.Field(nullable=True)
     assay_description: Series[str] | None = pa.Field(nullable=True)
     assay_variant_accession: Series[str] | None = pa.Field(nullable=True)

--- a/src/bioetl/domain/schemas/chembl/assay.py
+++ b/src/bioetl/domain/schemas/chembl/assay.py
@@ -54,8 +54,9 @@ class AssaySchema(ETLRecordSchema):
     assay_organism: Series[str] | None = pa.Field(
         nullable=True, description="Organism."
     )
-    assay_tax_id: Series[int] | None = pa.Field(
-        nullable=True, description="NCBI Taxonomy ID."
+    assay_taxonomy_id: Series[int] | None = pa.Field(
+        nullable=True,
+        description="NCBI Taxonomy ID. Standardized name (was assay_tax_id).",
     )
     assay_strain: Series[str] | None = pa.Field(nullable=True, description="Strain.")
     assay_tissue: Series[str] | None = pa.Field(nullable=True, description="Tissue.")
@@ -172,7 +173,10 @@ class AssaySchema(ETLRecordSchema):
     variant_mutation: Series[str] | None = pa.Field(nullable=True)
     variant_organism: Series[str] | None = pa.Field(nullable=True)
     variant_sequence: Series[str] | None = pa.Field(nullable=True)
-    variant_tax_id: Series[int] | None = pa.Field(nullable=True)
+    variant_taxonomy_id: Series[int] | None = pa.Field(
+        nullable=True,
+        description="Variant taxonomy ID. Standardized name (was variant_tax_id).",
+    )
     variant_sequence_json: Series[str] | None = pa.Field(nullable=True)
 
     # === Complex Fields (JSON) ===

--- a/src/bioetl/domain/schemas/chembl/cell_line.py
+++ b/src/bioetl/domain/schemas/chembl/cell_line.py
@@ -46,10 +46,10 @@ class CellLineSchema(ETLRecordSchema):
         nullable=True,
         description="Source organism (e.g., Homo sapiens).",
     )
-    cell_source_tax_id: Series[int] | None = pa.Field(
+    cell_source_taxonomy_id: Series[int] | None = pa.Field(
         nullable=True,
         ge=1,
-        description="NCBI Taxonomy ID for source organism.",
+        description="NCBI Taxonomy ID for source organism. Standardized name (was cell_source_tax_id).",
     )
 
     # === Cell Type Classification ===

--- a/src/bioetl/domain/schemas/chembl/publication.py
+++ b/src/bioetl/domain/schemas/chembl/publication.py
@@ -31,10 +31,10 @@ class ChemblPublicationSchema(ETLRecordSchema):
         str_matches=r"^CHEMBL\d+$",
         description="ChEMBL ID.",
     )
-    pubmed_id: Series[str] | None = pa.Field(
+    pmid: Series[str] | None = pa.Field(
         nullable=True,
         str_matches=r"^\d+$",
-        description="PubMed identifier (numeric string).",
+        description="PubMed identifier (numeric string). Standardized name (was pubmed_id).",
     )
     doi: Series[str] | None = pa.Field(
         nullable=True,

--- a/src/bioetl/domain/schemas/chembl/target.py
+++ b/src/bioetl/domain/schemas/chembl/target.py
@@ -58,8 +58,8 @@ class TargetSchema(ETLRecordSchema):
     pref_name: Series[str] | None = pa.Field(
         nullable=True, description="Preferred name."
     )
-    tax_id: Series[int] | None = pa.Field(
-        nullable=True, description="NCBI Taxonomy ID."
+    taxonomy_id: Series[int] | None = pa.Field(
+        nullable=True, description="NCBI Taxonomy ID. Standardized name (was tax_id)."
     )
     organism: Series[str] | None = pa.Field(nullable=True, description="Organism.")
     species_group_flag: Series[bool] | None = pa.Field(

--- a/src/bioetl/domain/value_objects/__init__.py
+++ b/src/bioetl/domain/value_objects/__init__.py
@@ -6,6 +6,7 @@ and business rules. They provide type safety and self-validation.
 Categories:
 - Identifiers: ChemblId, UniProtId, DOI, PubMedId, PubChemCid, CompoundId, AssayId
 - Chemical: InChIKey, SMILES
+- Biological: TaxonomyId (NCBI Taxonomy)
 - Metadata: PublicationYear
 - Activity Values: Concentration, ActivityType, PChemblValue, ActivityValue
 - Activity: ConfidenceScore, RelationOperator
@@ -76,6 +77,7 @@ from bioetl.domain.value_objects.publications import (
     DOI,
     PubMedId,
 )
+from bioetl.domain.value_objects.taxonomy_id import TaxonomyId
 
 __all__ = [
     "DOI",
@@ -98,6 +100,7 @@ __all__ = [
     "PubMedId",
     "PublicationYear",
     "RelationOperator",
+    "TaxonomyId",
     "UniProtId",
     "ValueObject",
 ]

--- a/src/bioetl/domain/value_objects/publications.py
+++ b/src/bioetl/domain/value_objects/publications.py
@@ -66,7 +66,8 @@ class DOI(ValueObject[str]):
             raise ValueError("DOI cannot be empty")
 
         # Strip URL prefixes and normalize to lowercase
-        normalized = self._strip_url_prefix(normalized).lower()
+        # Also strip whitespace after URL prefix removal (handles "https://doi.org/  10.1000/xyz  ")
+        normalized = self._strip_url_prefix(normalized).strip().lower()
 
         if not self._PATTERN.match(normalized):
             raise ValueError(f"Invalid DOI format: {value!r}. Expected: 10.XXXX/suffix")

--- a/src/bioetl/domain/value_objects/taxonomy_id.py
+++ b/src/bioetl/domain/value_objects/taxonomy_id.py
@@ -1,0 +1,129 @@
+"""NCBI Taxonomy ID Value Object.
+
+Contains TaxonomyId Value Object for NCBI Taxonomy identifiers.
+Used across multiple providers (ChEMBL, UniProt, PubMed) for organism
+classification.
+
+See: https://www.ncbi.nlm.nih.gov/taxonomy
+"""
+
+from __future__ import annotations
+
+from bioetl.domain.value_objects.base import ValueObject
+
+
+class TaxonomyId(ValueObject[int]):
+    """NCBI Taxonomy ID.
+
+    A positive integer uniquely identifying an organism in NCBI Taxonomy.
+    Stored as integer for efficient storage and comparison.
+
+    Examples: 9606 (Homo sapiens), 10090 (Mus musculus), 562 (E. coli)
+
+    Invariants:
+        - Must be a positive integer (>= 1)
+        - Cannot exceed reasonable bounds (< 10^7)
+        - Leading zeros are stripped if provided as string
+    """
+
+    __slots__ = ()
+    _value: int
+    _MIN_VALUE = 1
+    _MAX_VALUE = 10_000_000  # Reasonable upper bound for NCBI taxonomy
+
+    def __init__(self, value: str | int) -> None:
+        """Create a TaxonomyId with validated value.
+
+        Args:
+            value: Raw value to validate and store (str or int).
+
+        Raises:
+            ValueError: If validation fails.
+        """
+        super().__init__(value)  # type: ignore[arg-type]
+
+    def _coerce_to_int(self, value: str | int) -> int:
+        """Coerce value to integer, raising ValueError on failure."""
+        # bool is a subclass of int in Python, reject explicitly
+        if isinstance(value, bool):
+            raise ValueError("TaxonomyId must be str or int, got bool")
+
+        # Handle int directly
+        if isinstance(value, int):
+            return value
+
+        # Handle string: strip and parse
+        stripped = str(value).strip()
+        if not stripped:
+            raise ValueError("TaxonomyId cannot be empty string")
+        return self._parse_int(stripped)
+
+    def _parse_int(self, value: str) -> int:
+        """Parse string to integer, raising ValueError on failure."""
+        try:
+            return int(value)
+        except ValueError as e:
+            raise ValueError(f"Invalid TaxonomyId: {value!r}. Must be integer.") from e
+
+    def _validate(self, value: str | int) -> int:
+        """Validate and normalize Taxonomy ID to integer.
+
+        Args:
+            value: Raw taxonomy ID value (int or str).
+
+        Returns:
+            Validated integer value.
+
+        Raises:
+            ValueError: If format is invalid or value out of range.
+        """
+        int_value = self._coerce_to_int(value)
+
+        if int_value < self._MIN_VALUE:
+            raise ValueError(
+                f"TaxonomyId must be >= {self._MIN_VALUE}, got {int_value}"
+            )
+        if int_value >= self._MAX_VALUE:
+            raise ValueError(f"TaxonomyId must be < {self._MAX_VALUE}, got {int_value}")
+
+        return int_value
+
+    @property
+    def as_str(self) -> str:
+        """Get the taxonomy ID as string for JOIN operations."""
+        return str(self._value)
+
+    @property
+    def ncbi_url(self) -> str:
+        """Get the NCBI Taxonomy URL for this organism.
+
+        Returns:
+            Complete NCBI URL (e.g., 'https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=9606').
+        """
+        return (
+            f"https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id={self._value}"
+        )
+
+    @classmethod
+    def from_raw(cls, raw: str | int | None) -> TaxonomyId | None:
+        """Create TaxonomyId from raw value with normalization.
+
+        Handles common formats:
+        - Integer: 9606
+        - String: "9606"
+        - String with whitespace: " 9606 "
+
+        Args:
+            raw: Raw taxonomy ID (string, integer, or None).
+
+        Returns:
+            TaxonomyId if valid, None if input is None, empty, or invalid.
+        """
+        if raw is None:
+            return None
+        if isinstance(raw, str) and not raw.strip():
+            return None
+        try:
+            return cls(raw)
+        except ValueError:
+            return None

--- a/src/bioetl/infrastructure/schemas/gold.py
+++ b/src/bioetl/infrastructure/schemas/gold.py
@@ -36,7 +36,7 @@ class ChEMBLActivityGoldSchema(pa.DataFrameModel):
     # Target data
     target_pref_name: Series[str] = pa.Field(nullable=True)
     target_organism: Series[str] = pa.Field(nullable=True)
-    target_tax_id: Series[str] = pa.Field(nullable=True)
+    target_taxonomy_id: Series[str] = pa.Field(nullable=True)  # Standardized name
 
     # Assay data
     assay_type: Series[str] = pa.Field(nullable=True)
@@ -265,7 +265,9 @@ class ChEMBLAssayGoldSchema(pa.DataFrameModel):
     assay_test_type: Series[str] = pa.Field(nullable=True)
     assay_group: Series[str] = pa.Field(nullable=True)
     assay_organism: Series[str] = pa.Field(nullable=True)
-    assay_tax_id: Series[float] = pa.Field(nullable=True, coerce=True)
+    assay_taxonomy_id: Series[float] = pa.Field(
+        nullable=True, coerce=True
+    )  # Standardized name
     assay_cell_type: Series[str] = pa.Field(nullable=True)
     assay_tissue: Series[str] = pa.Field(nullable=True)
     assay_strain: Series[str] = pa.Field(nullable=True)
@@ -284,7 +286,9 @@ class ChEMBLAssayGoldSchema(pa.DataFrameModel):
     variant_mutation: Series[str] = pa.Field(nullable=True)
     variant_organism: Series[str] = pa.Field(nullable=True)
     variant_sequence: Series[str] = pa.Field(nullable=True)
-    variant_tax_id: Series[float] = pa.Field(nullable=True, coerce=True)
+    variant_taxonomy_id: Series[float] = pa.Field(
+        nullable=True, coerce=True
+    )  # Standardized name
     variant_sequence_json: Series[str] = pa.Field(nullable=True)
     assay_classifications: Series[str] = pa.Field(nullable=True)
     assay_parameters: Series[str] = pa.Field(nullable=True)
@@ -309,7 +313,9 @@ class ChEMBLTargetGoldSchema(pa.DataFrameModel):
     pref_name: Series[str] = pa.Field(nullable=True)
     target_type: Series[str] = pa.Field(nullable=True)
     organism: Series[str] = pa.Field(nullable=True)
-    tax_id: Series[float] = pa.Field(nullable=True, coerce=True)
+    taxonomy_id: Series[float] = pa.Field(
+        nullable=True, coerce=True
+    )  # Standardized name
     species_group_flag: Series[bool] = pa.Field(nullable=True)
     description: Series[str] = pa.Field(nullable=True)
     downgraded: Series[bool] = pa.Field(nullable=True, coerce=True)
@@ -325,7 +331,9 @@ class ChEMBLTargetGoldSchema(pa.DataFrameModel):
     component_relationships: Series[object] = pa.Field(nullable=True)  # list[str]
     component_descriptions: Series[object] = pa.Field(nullable=True)  # list[str]
     component_organisms: Series[object] = pa.Field(nullable=True)  # list[str]
-    component_tax_ids: Series[object] = pa.Field(nullable=True)  # list[int]
+    component_taxonomy_ids: Series[object] = pa.Field(
+        nullable=True
+    )  # Standardized name, list[int]
 
     # Metadata
     run_id: Series[str] = pa.Field(nullable=False, alias="_run_id")
@@ -348,7 +356,9 @@ class ChEMBLTargetComponentGoldSchema(pa.DataFrameModel):
     component_type: Series[str] = pa.Field(nullable=True)
     description: Series[str] = pa.Field(nullable=True)
     organism: Series[str] = pa.Field(nullable=True)
-    tax_id: Series[float] = pa.Field(nullable=True, coerce=True)
+    taxonomy_id: Series[float] = pa.Field(
+        nullable=True, coerce=True
+    )  # Standardized name
     target_component_synonyms: Series[str] = pa.Field(nullable=True)
     target_component_xrefs: Series[str] = pa.Field(nullable=True)
     protein_classifications: Series[str] = pa.Field(nullable=True)
@@ -371,7 +381,7 @@ class ChEMBLDocumentGoldSchema(pa.DataFrameModel):
     entity_id: Series[str] = pa.Field(nullable=False)
     content_hash: Series[str] = pa.Field(nullable=False)
     document_chembl_id: Series[str] = pa.Field(nullable=False)
-    pubmed_id: Series[str] = pa.Field(nullable=True)  # Numeric string (matches Silver)
+    pmid: Series[str] = pa.Field(nullable=True)  # Standardized name, numeric string
     doi: Series[str] = pa.Field(nullable=True)
     patent_id: Series[str] = pa.Field(nullable=True)
     title: Series[str] = pa.Field(nullable=True)
@@ -552,7 +562,9 @@ class ChEMBLCellLineGoldSchema(pa.DataFrameModel):
     # Source information
     cell_source_tissue: Series[str] = pa.Field(nullable=True)
     cell_source_organism: Series[str] = pa.Field(nullable=True)
-    cell_source_tax_id: Series[float] = pa.Field(nullable=True, coerce=True)  # int64
+    cell_source_taxonomy_id: Series[float] = pa.Field(
+        nullable=True, coerce=True
+    )  # Standardized name
 
     # External identifiers
     cellosaurus_id: Series[str] = pa.Field(nullable=True)

--- a/src/bioetl/infrastructure/schemas/silver.py
+++ b/src/bioetl/infrastructure/schemas/silver.py
@@ -30,7 +30,9 @@ CHEMBL_ACTIVITY_SCHEMA = pa.schema(
         # Target data
         pa.field("target_pref_name", pa.string()),
         pa.field("target_organism", pa.string()),
-        pa.field("target_tax_id", pa.string()),
+        pa.field(
+            "target_taxonomy_id", pa.string()
+        ),  # Standardized name (was target_tax_id)
         # Assay data
         pa.field("assay_type", pa.string()),
         pa.field("assay_description", pa.string()),
@@ -230,7 +232,9 @@ CHEMBL_ASSAY_SCHEMA = pa.schema(
         pa.field("assay_group", pa.string()),
         # Biological context
         pa.field("assay_organism", pa.string()),
-        pa.field("assay_tax_id", pa.int64()),
+        pa.field(
+            "assay_taxonomy_id", pa.int64()
+        ),  # Standardized name (was assay_tax_id)
         pa.field("assay_cell_type", pa.string()),
         pa.field("assay_tissue", pa.string()),
         pa.field("assay_strain", pa.string()),
@@ -253,7 +257,9 @@ CHEMBL_ASSAY_SCHEMA = pa.schema(
         pa.field("variant_mutation", pa.string()),
         pa.field("variant_organism", pa.string()),
         pa.field("variant_sequence", pa.string()),
-        pa.field("variant_tax_id", pa.int64()),
+        pa.field(
+            "variant_taxonomy_id", pa.int64()
+        ),  # Standardized name (was variant_tax_id)
         # Forensic: original JSON
         pa.field("variant_sequence_json", pa.string()),
         # Complex fields (stored as JSON strings)
@@ -281,7 +287,7 @@ CHEMBL_TARGET_SCHEMA = pa.schema(
         pa.field("pref_name", pa.string()),
         pa.field("target_type", pa.string()),
         pa.field("organism", pa.string()),
-        pa.field("tax_id", pa.int64()),
+        pa.field("taxonomy_id", pa.int64()),  # Standardized name (was tax_id)
         pa.field("species_group_flag", pa.bool_()),
         pa.field("description", pa.string()),
         pa.field("downgraded", pa.bool_()),
@@ -299,7 +305,9 @@ CHEMBL_TARGET_SCHEMA = pa.schema(
         pa.field("component_relationships", pa.list_(pa.string())),
         pa.field("component_descriptions", pa.list_(pa.string())),
         pa.field("component_organisms", pa.list_(pa.string())),
-        pa.field("component_tax_ids", pa.list_(pa.int64())),
+        pa.field(
+            "component_taxonomy_ids", pa.list_(pa.int64())
+        ),  # Standardized name (was component_tax_ids)
         # Note: protein_classifications not available in /target endpoint
         # Use /target_component endpoint instead (CHEMBL_TARGET_COMPONENT_SCHEMA)
         # Lineage metadata
@@ -325,7 +333,7 @@ CHEMBL_TARGET_COMPONENT_SCHEMA = pa.schema(
         pa.field("component_type", pa.string()),
         pa.field("description", pa.string()),
         pa.field("organism", pa.string()),
-        pa.field("tax_id", pa.int64()),
+        pa.field("taxonomy_id", pa.int64()),  # Standardized name (was tax_id)
         # Complex fields (JSON strings)
         pa.field("target_component_synonyms", pa.string()),
         pa.field("target_component_xrefs", pa.string()),
@@ -356,7 +364,9 @@ CHEMBL_CELL_LINE_SCHEMA = pa.schema(
         # Source information
         pa.field("cell_source_tissue", pa.string()),
         pa.field("cell_source_organism", pa.string()),
-        pa.field("cell_source_tax_id", pa.int64()),
+        pa.field(
+            "cell_source_taxonomy_id", pa.int64()
+        ),  # Standardized name (was cell_source_tax_id)
         # External identifiers
         pa.field("cellosaurus_id", pa.string()),
         pa.field("cl_lincs_id", pa.string()),
@@ -381,8 +391,8 @@ CHEMBL_PUBLICATION_SCHEMA = pa.schema(
         pa.field("document_chembl_id", pa.string()),
         # Publication identifiers
         pa.field(
-            "pubmed_id", pa.string()
-        ),  # Numeric string for cross-provider consistency
+            "pmid", pa.string()
+        ),  # Standardized name (was pubmed_id), numeric string for cross-provider consistency
         pa.field("doi", pa.string()),
         pa.field("patent_id", pa.string()),
         # Core metadata

--- a/tests/architecture/test_code_metrics.py
+++ b/tests/architecture/test_code_metrics.py
@@ -76,8 +76,8 @@ class TestFileSizeLimits:
         "silver_writer.py": 900,  # 887 LOC - schema drift detection + merge logic + audit + validation
         "gold_writer.py": 770,  # 759 LOC - SCD Type 2 + audit logging + lock validation
         "bronze_writer.py": 700,  # 600+ LOC - added streaming compression + validation
-        "gold.py": 870,  # 854 LOC - Gold layer Pandera schemas (+ IDMapping)
-        "silver.py": 770,  # 757 LOC - Silver PyArrow schemas (+ IDMapping)
+        "gold.py": 880,  # 877 LOC - Gold layer Pandera schemas (+ IDMapping + taxonomy_id standardization)
+        "silver.py": 780,  # 775 LOC - Silver PyArrow schemas (+ IDMapping + taxonomy_id standardization)
         "client.py": 700,  # 692 LOC - ChemblAdapter (complex FilterableDataSourcePort), CrossRefAdapter (DOI→title fallback)
         "adapter.py": 560,  # 558 LOC - SemanticScholarAdapter with FilterableDataSourcePort + fallback logic
         # Interfaces layer exemptions

--- a/tests/unit/application/pipelines/__snapshots__/test_transformer_snapshots.ambr
+++ b/tests/unit/application/pipelines/__snapshots__/test_transformer_snapshots.ambr
@@ -52,7 +52,7 @@
     'target_chembl_id': 'CHEMBL1862',
     'target_organism': 'Homo sapiens',
     'target_pref_name': 'Cyclooxygenase-2',
-    'target_tax_id': None,
+    'target_taxonomy_id': None,
     'text_value': None,
     'toid': None,
     'type': None,
@@ -80,7 +80,7 @@
     'assay_pref_name': None,
     'assay_strain': None,
     'assay_subcellular_fraction': None,
-    'assay_tax_id': 9606,
+    'assay_taxonomy_id': 9606,
     'assay_test_type': None,
     'assay_tissue': None,
     'assay_type': 'B',
@@ -107,7 +107,7 @@
     'variant_organism': None,
     'variant_sequence': None,
     'variant_sequence_json': None,
-    'variant_tax_id': None,
+    'variant_taxonomy_id': None,
   })
 # ---
 # name: TestMoleculeTransformerSnapshot.test_transform_snapshot
@@ -132,7 +132,7 @@
     'hierarchy_active_chembl_id': 'CHEMBL25',
     'hierarchy_child_chembl_id': 'CHEMBL25',
     'hierarchy_parent_chembl_id': 'CHEMBL25',
-    'inchi_key': 'BSYNRYMUTXBXSQ-UHFFFAOYSA-N',
+    'inchikey': 'BSYNRYMUTXBXSQ-UHFFFAOYSA-N',
     'inorganic_flag': None,
     'max_phase': 4,
     'molecule_chembl_id': 'CHEMBL25',
@@ -292,7 +292,7 @@
     'journal_full_title': 'Full Test Journal Name',
     'last_page': '110',
     'patent_id': None,
-    'pubmed_id': '12345678',
+    'pmid': '12345678',
     'src_id': 1,
     'title': 'Test Document Title',
     'volume': '10',
@@ -317,7 +317,7 @@
     'protein_classifications': None,
     'target_component_synonyms': '[{"synonym":"Gene1"},{"synonym":"Protein1"}]',
     'target_component_xrefs': '{"xref_id":"P12345","xref_src_db":"UniProt"}',
-    'tax_id': 9606,
+    'taxonomy_id': 9606,
   })
 # ---
 # name: TestTargetTransformerSnapshot.test_transform_snapshot
@@ -338,7 +338,7 @@
       'Homo sapiens',
     ]),
     'component_relationships': None,
-    'component_tax_ids': list([
+    'component_taxonomy_ids': list([
       9606,
     ]),
     'component_types': list([
@@ -359,7 +359,7 @@
     'target_components': '{"accession":"P35354","component_id":123,"component_type":"PROTEIN","organism":"Homo sapiens","target_component_xrefs":[{"xref_id":"P35354","xref_src_db":"UniProt"}],"tax_id":9606}',
     'target_constraints': None,
     'target_type': 'SINGLE PROTEIN',
-    'tax_id': 9606,
+    'taxonomy_id': 9606,
   })
 # ---
 # name: TestUniProtProteinTransformerSnapshot.test_transform_snapshot

--- a/tests/unit/application/pipelines/test_activity_transformer.py
+++ b/tests/unit/application/pipelines/test_activity_transformer.py
@@ -132,7 +132,7 @@ class TestActivityTransformerTransform:
             "parent_molecule_chembl_id": "CHEMBL25",
             "target_pref_name": "Cyclooxygenase-2",
             "target_organism": "Homo sapiens",
-            "target_tax_id": 9606,
+            "target_tax_id": 9606,  # Source API field name
             "assay_type": "B",
             "assay_description": "Binding assay",
         }
@@ -144,6 +144,7 @@ class TestActivityTransformerTransform:
         assert result["molecule_pref_name"] == "ASPIRIN"
         assert result["target_pref_name"] == "Cyclooxygenase-2"
         assert result["target_organism"] == "Homo sapiens"
+        assert result["target_taxonomy_id"] == "9606"  # Standardized output (string)
         assert result["assay_type"] == "B"
 
     @pytest.mark.asyncio

--- a/tests/unit/application/pipelines/test_cell_line_transformer.py
+++ b/tests/unit/application/pipelines/test_cell_line_transformer.py
@@ -45,7 +45,7 @@ class TestCellLineTransformer:
             "cell_description": "Human cervical cancer cell line",
             "cell_source_tissue": "Cervix",
             "cell_source_organism": "Homo sapiens",
-            "cell_source_tax_id": 9606,
+            "cell_source_tax_id": 9606,  # Source API field name
             "cell_type": "Cancer cell line",
             "cellosaurus_id": "CVCL_0030",
             "clo_id": "CLO_0003684",
@@ -61,7 +61,7 @@ class TestCellLineTransformer:
         assert result["cell_description"] == "Human cervical cancer cell line"
         assert result["cell_source_tissue"] == "Cervix"
         assert result["cell_source_organism"] == "Homo sapiens"
-        assert result["cell_source_tax_id"] == 9606
+        assert result["cell_source_taxonomy_id"] == 9606
         assert result["cell_type"] == "Cancer cell line"
         assert result["cellosaurus_id"] == "CVCL_0030"
         assert result["clo_id"] == "CLO_0003684"
@@ -99,7 +99,7 @@ class TestCellLineTransformer:
         assert result["cell_description"] is None
         assert result["cell_source_tissue"] is None
         assert result["cell_source_organism"] is None
-        assert result["cell_source_tax_id"] is None
+        assert result["cell_source_taxonomy_id"] is None
         assert result["cell_type"] is None
         assert result["cellosaurus_id"] is None
         assert result["clo_id"] is None
@@ -163,21 +163,21 @@ class TestCellLineTransformer:
 
     @pytest.mark.asyncio
     async def test_transform_with_invalid_tax_id_zero(self, transformer, mock_context):
-        """Test that tax_id of 0 becomes None (must be >= 1)."""
+        """Test that taxonomy_id of 0 becomes None (must be >= 1)."""
         record = {
             "cell_chembl_id": "CHEMBL3308376",
             "cell_name": "HeLa",
-            "cell_source_tax_id": 0,
+            "cell_source_tax_id": 0,  # Source API field name
         }
 
         result = await transformer.transform(mock_context, record, index=0)
 
         assert result is not None
-        assert result["cell_source_tax_id"] is None
+        assert result["cell_source_taxonomy_id"] is None
 
     @pytest.mark.asyncio
     async def test_transform_with_negative_tax_id(self, transformer, mock_context):
-        """Test that negative tax_id becomes None (must be >= 1)."""
+        """Test that negative taxonomy_id becomes None (must be >= 1)."""
         record = {
             "cell_chembl_id": "CHEMBL3308376",
             "cell_name": "HeLa",
@@ -187,25 +187,25 @@ class TestCellLineTransformer:
         result = await transformer.transform(mock_context, record, index=0)
 
         assert result is not None
-        assert result["cell_source_tax_id"] is None
+        assert result["cell_source_taxonomy_id"] is None
 
     @pytest.mark.asyncio
     async def test_transform_with_valid_tax_id(self, transformer, mock_context):
-        """Test that valid tax_id is preserved."""
+        """Test that valid taxonomy_id is preserved."""
         record = {
             "cell_chembl_id": "CHEMBL3308376",
             "cell_name": "HeLa",
-            "cell_source_tax_id": 9606,
+            "cell_source_tax_id": 9606,  # Source API field name
         }
 
         result = await transformer.transform(mock_context, record, index=0)
 
         assert result is not None
-        assert result["cell_source_tax_id"] == 9606
+        assert result["cell_source_taxonomy_id"] == 9606
 
     @pytest.mark.asyncio
     async def test_transform_with_tax_id_as_string(self, transformer, mock_context):
-        """Test that tax_id as string is converted to int."""
+        """Test that taxonomy_id as string is converted to int."""
         record = {
             "cell_chembl_id": "CHEMBL3308376",
             "cell_name": "HeLa",
@@ -215,7 +215,7 @@ class TestCellLineTransformer:
         result = await transformer.transform(mock_context, record, index=0)
 
         assert result is not None
-        assert result["cell_source_tax_id"] == 9606
+        assert result["cell_source_taxonomy_id"] == 9606
 
     @pytest.mark.asyncio
     async def test_transform_custom_provider(self, mock_context):
@@ -288,7 +288,7 @@ class TestCellLineTransformer:
         assert result["cell_description"] is None
         assert result["cell_source_tissue"] is None
         assert result["cell_source_organism"] is None
-        assert result["cell_source_tax_id"] is None
+        assert result["cell_source_taxonomy_id"] is None
         assert result["cell_type"] is None
         assert result["cellosaurus_id"] is None
         assert result["clo_id"] is None

--- a/tests/unit/application/pipelines/test_chembl_pipelines.py
+++ b/tests/unit/application/pipelines/test_chembl_pipelines.py
@@ -155,7 +155,7 @@ class TestChEMBLPublicationPipeline:
         record = {
             "document_chembl_id": "CHEMBL789012",
             "title": "Test Document",
-            "pubmed_id": "12345678",
+            "pmid": "12345678",
         }
 
         result = await pipeline.transform_bronze_to_silver(pipeline.context, record)

--- a/tests/unit/application/pipelines/test_chembl_transformers.py
+++ b/tests/unit/application/pipelines/test_chembl_transformers.py
@@ -108,7 +108,7 @@ class TestAssayTransformer:
                 "mutation": "V600E",
                 "organism": "Homo sapiens",
                 "sequence": "MTEYKLVVVGAGGVGKSALT...",
-                "tax_id": 9606,
+                "tax_id": 9606,  # Source API field name
             },
         }
 
@@ -121,7 +121,7 @@ class TestAssayTransformer:
         assert result["variant_mutation"] == "V600E"
         assert result["variant_organism"] == "Homo sapiens"
         assert result["variant_sequence"] == "MTEYKLVVVGAGGVGKSALT..."
-        assert result["variant_tax_id"] == 9606
+        assert result["variant_taxonomy_id"] == 9606
         # Forensic JSON should also be present
         assert isinstance(result.get("variant_sequence_json"), str)
 
@@ -141,7 +141,7 @@ class TestAssayTransformer:
         assert result["variant_mutation"] is None
         assert result["variant_organism"] is None
         assert result["variant_sequence"] is None
-        assert result["variant_tax_id"] is None
+        assert result["variant_taxonomy_id"] is None
         assert result["variant_sequence_json"] is None
 
     @pytest.mark.asyncio
@@ -164,7 +164,7 @@ class TestAssayTransformer:
         assert result["variant_isoform"] is None
         assert result["variant_organism"] is None
         assert result["variant_sequence"] is None
-        assert result["variant_tax_id"] is None
+        assert result["variant_taxonomy_id"] is None
 
     @pytest.mark.asyncio
     async def test_transform_custom_provider(self, mock_context):
@@ -192,7 +192,7 @@ class TestPublicationTransformer:
         """Test transformation of valid document record."""
         record = {
             "document_chembl_id": "CHEMBL1234567",
-            "pubmed_id": "12345678",
+            "pubmed_id": "12345678",  # Source API field name
             "doi": "10.1000/test.doi",
             "title": "Test Document Title",
             "authors": "Test Author",
@@ -204,7 +204,7 @@ class TestPublicationTransformer:
 
         assert result is not None
         assert result["document_chembl_id"] == "CHEMBL1234567"
-        assert result["pubmed_id"] == "12345678"
+        assert result["pmid"] == "12345678"  # Standardized output field name
         assert result["doi"] == "10.1000/test.doi"
         assert result["year"] == 2024
         assert "entity_id" in result
@@ -215,7 +215,7 @@ class TestPublicationTransformer:
     async def test_transform_missing_document_id(self, transformer, mock_context):
         """Test transformation returns None when document_chembl_id is missing."""
         record = {
-            "pubmed_id": "12345678",
+            "pubmed_id": "12345678",  # Source API field name
             "title": "Test Document",
         }
 
@@ -228,7 +228,7 @@ class TestPublicationTransformer:
         """Test transformation with all document fields."""
         record = {
             "document_chembl_id": "CHEMBL1234567",
-            "pubmed_id": "12345678",
+            "pubmed_id": "12345678",  # Source API field name
             "doi": "10.1000/test",
             "patent_id": "US1234567",
             "title": "Full Title",
@@ -458,7 +458,7 @@ class TestTargetTransformer:
             "pref_name": "Cyclooxygenase-2",
             "target_type": "SINGLE PROTEIN",
             "organism": "Homo sapiens",
-            "tax_id": 9606,
+            "tax_id": 9606,  # Source API field name
         }
 
         result = await transformer.transform(mock_context, record, index=0)
@@ -467,7 +467,7 @@ class TestTargetTransformer:
         assert result["target_chembl_id"] == "CHEMBL1862"
         assert result["pref_name"] == "Cyclooxygenase-2"
         assert result["target_type"] == "SINGLE PROTEIN"
-        assert result["tax_id"] == 9606
+        assert result["taxonomy_id"] == 9606  # Standardized output field name
         assert "entity_id" in result
         assert "content_hash" in result
         assert "_run_id" in result
@@ -643,10 +643,10 @@ class TestTargetTransformer:
         assert stages["stage"] == "Phase 1"
 
     @pytest.mark.asyncio
-    async def test_transform_extracts_component_organisms_and_tax_ids(
+    async def test_transform_extracts_component_organisms_and_taxonomy_ids(
         self, transformer, mock_context
     ):
-        """Test transformation extracts organisms and tax_ids from components."""
+        """Test transformation extracts organisms and taxonomy_ids from components."""
         record = {
             "target_chembl_id": "CHEMBL2111431",
             "target_components": [
@@ -655,14 +655,14 @@ class TestTargetTransformer:
                     "component_id": 100,
                     "component_type": "PROTEIN",
                     "organism": "Homo sapiens",
-                    "tax_id": 9606,
+                    "tax_id": 9606,  # Source API field name
                 },
                 {
                     "accession": "P67890",
                     "component_id": 101,
                     "component_type": "PROTEIN",
                     "organism": "Mus musculus",
-                    "tax_id": 10090,
+                    "tax_id": 10090,  # Source API field name
                 },
             ],
         }
@@ -671,7 +671,7 @@ class TestTargetTransformer:
 
         assert result is not None
         assert result["component_organisms"] == ["Homo sapiens", "Mus musculus"]
-        assert result["component_tax_ids"] == [9606, 10090]
+        assert result["component_taxonomy_ids"] == [9606, 10090]  # Standardized output
 
     @pytest.mark.asyncio
     async def test_transform_handles_missing_new_fields_gracefully(
@@ -712,7 +712,7 @@ class TestTargetComponentTransformer:
             "component_type": "PROTEIN",
             "description": "Test Component",
             "organism": "Homo sapiens",
-            "tax_id": 9606,
+            "tax_id": 9606,  # Source API field name
         }
 
         result = await transformer.transform(mock_context, record, index=0)
@@ -721,7 +721,7 @@ class TestTargetComponentTransformer:
         assert result["component_id"] == 123
         assert result["accession"] == "P12345"
         assert result["component_type"] == "PROTEIN"
-        assert result["tax_id"] == 9606
+        assert result["taxonomy_id"] == 9606  # Standardized output field name
         assert "entity_id" in result
         assert "content_hash" in result
         assert "_run_id" in result

--- a/tests/unit/application/pipelines/test_transformer_snapshots.py
+++ b/tests/unit/application/pipelines/test_transformer_snapshots.py
@@ -150,7 +150,7 @@ class TestAssayTransformerSnapshot:
             "assay_type": "B",
             "assay_type_description": "Binding",
             "assay_organism": "Homo sapiens",
-            "assay_tax_id": 9606,
+            "assay_tax_id": 9606,  # Source API field name
             "description": "Test assay description",
             "confidence_score": 9,
             "bao_format": "BAO_0000357",
@@ -185,7 +185,7 @@ class TestPublicationTransformerSnapshot:
     def sample_record(self) -> dict[str, Any]:
         return {
             "document_chembl_id": "CHEMBL1234567",
-            "pubmed_id": "12345678",
+            "pubmed_id": "12345678",  # Source API field name
             "doi": "10.1000/test.doi",
             "title": "Test Document Title",
             "authors": "Test Author, Another Author",
@@ -286,7 +286,7 @@ class TestTargetTransformerSnapshot:
             "pref_name": "Cyclooxygenase-2",
             "target_type": "SINGLE PROTEIN",
             "organism": "Homo sapiens",
-            "tax_id": 9606,
+            "tax_id": 9606,  # Source API field name
             "description": "Prostaglandin G/H synthase 2",
             "target_components": [
                 {
@@ -294,7 +294,7 @@ class TestTargetTransformerSnapshot:
                     "component_id": 123,
                     "component_type": "PROTEIN",
                     "organism": "Homo sapiens",
-                    "tax_id": 9606,
+                    "tax_id": 9606,  # Source API field name
                     "target_component_xrefs": [
                         {"xref_id": "P35354", "xref_src_db": "UniProt"},
                     ],
@@ -332,7 +332,7 @@ class TestTargetComponentTransformerSnapshot:
             "component_type": "PROTEIN",
             "description": "Test protein component",
             "organism": "Homo sapiens",
-            "tax_id": 9606,
+            "tax_id": 9606,  # Source API field name
             "target_component_synonyms": [
                 {"synonym": "Gene1"},
                 {"synonym": "Protein1"},

--- a/tests/unit/domain/schemas/test_year_validation.py
+++ b/tests/unit/domain/schemas/test_year_validation.py
@@ -184,7 +184,7 @@ class TestChemblYearValidation:
             **base_etl_fields,
             "entity_id": "chembl:publication:CHEMBL1234567",
             "document_chembl_id": "CHEMBL1234567",
-            "pubmed_id": "12345678",
+            "pmid": "12345678",
             "doi": "10.1038/nature12373",
             "patent_id": None,
             "src_id": 1,

--- a/tests/unit/infrastructure/schemas/test_silver.py
+++ b/tests/unit/infrastructure/schemas/test_silver.py
@@ -212,7 +212,7 @@ class TestChemblAssaySchema:
         """Verify biological context fields exist."""
         expected = [
             "assay_organism",
-            "assay_tax_id",
+            "assay_taxonomy_id",
             "assay_cell_type",
         ]
         for field_name in expected:
@@ -301,13 +301,13 @@ class TestChemblDocumentSchema:
 
     def test_has_publication_identifiers(self):
         """Verify publication identifier fields exist."""
-        expected = ["pubmed_id", "doi", "patent_id"]
+        expected = ["pmid", "doi", "patent_id"]
         for field_name in expected:
             assert field_name in CHEMBL_PUBLICATION_SCHEMA.names
 
-    def test_pubmed_id_is_string(self):
-        """Verify pubmed_id is string (numeric string for cross-provider consistency)."""
-        field = CHEMBL_PUBLICATION_SCHEMA.field("pubmed_id")
+    def test_pmid_is_string(self):
+        """Verify pmid is string (numeric string for cross-provider consistency)."""
+        field = CHEMBL_PUBLICATION_SCHEMA.field("pmid")
         assert field.type == pa.string()
 
 
@@ -490,7 +490,7 @@ class TestSilverSchemaValidation:
             "parent_molecule_chembl_id": "CHEMBL25",
             "target_pref_name": "Cyclooxygenase-2",
             "target_organism": "Homo sapiens",
-            "target_tax_id": "9606",
+            "target_taxonomy_id": "9606",
             "assay_type": "B",
             "assay_description": "Binding assay",
             "assay_variant_accession": None,
@@ -651,7 +651,7 @@ class TestSilverSchemaValidation:
             "parent_molecule_chembl_id": None,
             "target_pref_name": None,
             "target_organism": None,
-            "target_tax_id": None,
+            "target_taxonomy_id": None,
             "assay_type": None,
             "assay_description": None,
             "assay_variant_accession": None,


### PR DESCRIPTION
Implement Phase 1 of field naming standardization across all pipelines:

1. DOI: Unify 5 publication pipelines to use DOI.from_raw() Value Object
   - CrossRef, OpenAlex, PubMed, SemanticScholar transformers
   - Fixed DOI validation to handle whitespace after URL prefix

2. PMID: Standardize field name to 'pmid'
   - ChEMBL publication: pubmed_id -> pmid
   - SemanticScholar: pubmed_id -> pmid
   - Use PubMedId.from_raw() for validation

3. InChI Key: Standardize field name to 'inchikey' (IUPAC-compliant)
   - ChEMBL molecule: inchi_key -> inchikey
   - PubChem: Added InChIKey.from_raw() validation

4. Taxonomy ID: Create TaxonomyId Value Object
   - New domain/value_objects/taxonomy_id.py
   - ChEMBL target: tax_id -> taxonomy_id
   - ChEMBL cell line: cell_source_tax_id -> cell_source_taxonomy_id
   - ChEMBL assay: assay_tax_id -> assay_taxonomy_id
   - ChEMBL activity: target_tax_id -> target_taxonomy_id
   - Updated entities, schemas (Silver/Gold), and tests

Breaking changes:
- Field names changed in Silver/Gold schemas
- Requires schema migration for existing data