### PR TITLE
Centralize validation configuration ranges

### DIFF
--- a/src/bioetl/application/pipelines/chembl/publication_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/publication_transformer.py
@@ -27,7 +27,7 @@ from bioetl.application.pipelines.chembl.base_chembl_transformer import (
 )
 from bioetl.domain.entities import ChemblPublication
 from bioetl.domain.services import DataNormalizationService, IdentityService
-from bioetl.domain.value_objects import DOI
+from bioetl.domain.value_objects import DOI, PublicationYear
 
 if TYPE_CHECKING:
     from bioetl.domain.filtering import GoldFilterConfig
@@ -161,6 +161,10 @@ class PublicationTransformer(BaseChemblTransformer):
         # Validate DOI using Value Object (returns None for invalid/empty)
         doi = DOI.from_raw(data.get("doi"))
         data["doi"] = str(doi) if doi else None
+
+        # Validate year using PublicationYear Value Object
+        year_vo = PublicationYear.from_raw(data.get("year"))
+        data["year"] = year_vo.value if year_vo else None
 
         # Hash PII field (RULES.md §5.4)
         # ChEMBL authors is a concatenated string - parse to list, hash, serialize to JSON

--- a/src/bioetl/application/pipelines/crossref/transformer.py
+++ b/src/bioetl/application/pipelines/crossref/transformer.py
@@ -25,8 +25,7 @@ from bioetl.domain.normalization import (
     parse_page_range,
 )
 from bioetl.domain.services import DataNormalizationService, IdentityService
-from bioetl.domain.validation import validate_year_range
-from bioetl.domain.value_objects import DOI
+from bioetl.domain.value_objects import DOI, PublicationYear
 
 if TYPE_CHECKING:
     from bioetl.domain.context import PipelineContext
@@ -124,7 +123,7 @@ class CrossRefPublicationTransformer(BasePublicationTransformer):
         """Extract publication year from date-parts.
 
         Tries published-print, then published-online, then issued.
-        Delegates validation to domain.validation.validate_year_range.
+        Validates using PublicationYear Value Object for consistent range checking.
 
         Args:
             publication: CrossRef publication record.
@@ -137,9 +136,11 @@ class CrossRefPublicationTransformer(BasePublicationTransformer):
             date_info = publication.get(date_field, {})
             date_parts = date_info.get("date-parts", [[]])
             if date_parts and date_parts[0] and len(date_parts[0]) > 0:
-                year = date_parts[0][0]
-                if isinstance(year, int) and validate_year_range(year):
-                    return year
+                raw_year = date_parts[0][0]
+                if isinstance(raw_year, int):
+                    year_vo = PublicationYear.from_raw(raw_year)
+                    if year_vo:
+                        return year_vo.value
         return None
 
     @staticmethod

--- a/src/bioetl/application/pipelines/openalex/transformer.py
+++ b/src/bioetl/application/pipelines/openalex/transformer.py
@@ -28,8 +28,7 @@ from bioetl.application.pipelines.openalex.extractors import (
 )
 from bioetl.domain.entities.openalex import OPENALEX_TYPE_MAP, OpenAlexPublicationEntity
 from bioetl.domain.services import DataNormalizationService, IdentityService
-from bioetl.domain.validation import validate_year_range
-from bioetl.domain.value_objects import DOI
+from bioetl.domain.value_objects import DOI, PublicationYear
 
 if TYPE_CHECKING:
     from bioetl.domain.filtering import GoldFilterConfig
@@ -148,10 +147,9 @@ class OpenAlexPublicationTransformer(BasePublicationTransformer):
         # Extract Open Access info
         oa_info = extract_open_access_info(rec.get("open_access", {}))
 
-        # Validate year
-        year = rec.get("publication_year")
-        if year is not None and not validate_year_range(year):
-            year = None
+        # Validate year using PublicationYear Value Object
+        year_vo = PublicationYear.from_raw(rec.get("publication_year"))
+        year = year_vo.value if year_vo else None
 
         # Map document type
         raw_type = rec.get("type", "")

--- a/src/bioetl/application/pipelines/pubmed/transformer.py
+++ b/src/bioetl/application/pipelines/pubmed/transformer.py
@@ -22,7 +22,7 @@ from bioetl.application.pipelines.pubmed.extractors import (
 from bioetl.application.pipelines.pubmed.xml_utils import get_text
 from bioetl.domain.entities import Publication
 from bioetl.domain.services import DataNormalizationService, IdentityService
-from bioetl.domain.value_objects import DOI, PubMedId
+from bioetl.domain.value_objects import DOI, PublicationYear, PubMedId
 
 if TYPE_CHECKING:
     from bioetl.domain.context import PipelineContext
@@ -251,13 +251,17 @@ class PubMedPublicationTransformer(BasePublicationTransformer):
         journal = article.find(".//Journal")
         journal_issue = journal.find("JournalIssue") if journal else None
         pub_date_node = journal_issue.find("PubDate") if journal_issue else None
-        pub_date, pub_year = DateExtractor.extract_date(pub_date_node)
+        pub_date, raw_year = DateExtractor.extract_date(pub_date_node)
         history = pubmed_data.find("History") if pubmed_data else None
+
+        # Validate year using PublicationYear Value Object
+        year_vo = PublicationYear.from_raw(raw_year)
+        validated_year = year_vo.value if year_vo else None
 
         return {
             "pub_date": pub_date,
-            "year": pub_year,
-            "publication_year": pub_year,
+            "year": validated_year,
+            "publication_year": validated_year,
             "accepted_date": DateExtractor.extract_history_date(history, "accepted"),
             "received_date": DateExtractor.extract_history_date(history, "received"),
             "revised_date": DateExtractor.extract_history_date(history, "revised"),

--- a/src/bioetl/application/pipelines/semanticscholar/extractors.py
+++ b/src/bioetl/application/pipelines/semanticscholar/extractors.py
@@ -9,7 +9,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from bioetl.domain.validation import validate_year_range
+from bioetl.domain.config import ValidationConfig
+from bioetl.domain.value_objects import PublicationYear
+
+# Semantic Scholar-specific config with min_year=1500 for historical publications
+_SS_VALIDATION_CONFIG = ValidationConfig(min_publication_year=1500)
 
 
 def extract_external_ids(external_ids: dict[str, Any] | None) -> dict[str, Any]:
@@ -227,10 +231,10 @@ def extract_fields_of_study(
 
 
 def validate_year(year: int | None) -> int | None:
-    """Validate publication year using domain validation.
+    """Validate publication year using PublicationYear Value Object.
 
-    Delegates to domain.validation.validate_year_range() with
-    Semantic Scholar-specific minimum year of 1500.
+    Uses Semantic Scholar-specific ValidationConfig with min_year=1500
+    to support historical publications.
 
     Args:
         year: Year from S2 response.
@@ -241,6 +245,5 @@ def validate_year(year: int | None) -> int | None:
     """
     if year is None:
         return None
-    if validate_year_range(year, min_year=1500):
-        return year
-    return None
+    year_vo = PublicationYear.from_raw(year, config=_SS_VALIDATION_CONFIG)
+    return year_vo.value if year_vo else None

--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -16,10 +16,12 @@ from __future__ import annotations
 
 # Configuration objects
 from bioetl.domain.config import (
+    DEFAULT_VALIDATION_CONFIG,
     DQConfig,
     PipelineConfig,
     RuntimeConfig,
     TableConfig,
+    ValidationConfig,
 )
 
 # Base configuration classes (consolidated DTOs per RULES.md §12.1.6)
@@ -256,19 +258,23 @@ from bioetl.domain.value_objects import (
     Concentration,
     ConcentrationUnit,
     DQEvaluationStatus,
+    MolecularWeight,
     PChemblValue,
     PubChemCid,
     PubMedId,
+    PublicationYear,
     UniProtId,
     ValueObject,
 )
 
 __all__ = [
     # Configuration
+    "DEFAULT_VALIDATION_CONFIG",
     "DQConfig",
     "PipelineConfig",
     "RuntimeConfig",
     "TableConfig",
+    "ValidationConfig",
     # Base configuration classes (consolidated DTOs)
     "BaseClientConfig",
     "BaseProviderConfig",
@@ -475,9 +481,11 @@ __all__ = [
     "ConcentrationUnit",
     "DOI",
     "DQEvaluationStatus",
+    "MolecularWeight",
     "PChemblValue",
     "PubChemCid",
     "PubMedId",
+    "PublicationYear",
     "UniProtId",
     "ValueObject",
 ]

--- a/src/bioetl/domain/config.py
+++ b/src/bioetl/domain/config.py
@@ -5,6 +5,7 @@ These are distinct from Infrastructure configuration schemas (Pydantic) to maint
 strict layer separation.
 
 Consolidated configuration classes (post-refactoring):
+- ValidationConfig: Centralized validation ranges for domain value objects
 - DQConfig: Data Quality thresholds
 - TableConfig: Database tables and keys
 - PipelineConfig: Complete immutable pipeline configuration
@@ -21,6 +22,96 @@ from bioetl.domain.types import RunType
 
 if TYPE_CHECKING:
     from bioetl.domain.filtering import GoldFilterConfig
+
+
+# =============================================================================
+# Validation Configuration
+# =============================================================================
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationConfig:
+    """Centralized configuration for validation ranges.
+
+    Provides configurable validation parameters for domain value objects
+    and validation functions. This enables:
+    - Consistent validation across all components
+    - Override capability via pipeline config
+    - Single source of truth for validation rules
+
+    Attributes:
+        min_publication_year: Minimum valid publication year. Default 1800
+            covers modern scientific publications. Use 1500 for historical
+            databases like Semantic Scholar.
+        max_publication_year: Maximum valid publication year. Default 2100.
+        min_molecular_weight: Minimum molecular weight in Daltons. Default 10.0.
+        max_molecular_weight: Maximum molecular weight in Daltons. Default 10000.0
+            covers small molecules to large peptides.
+        max_pmid: Maximum valid PubMed ID. Default 10_000_000_000.
+        max_taxonomy_id: Maximum valid NCBI Taxonomy ID. Default 10_000_000.
+        min_pchembl_value: Minimum pChEMBL value. Default 0.0.
+        max_pchembl_value: Maximum pChEMBL value. Default 15.0 (-log10(10^-15 M)).
+        molecular_weight_precision: Decimal precision for MW rounding. Default 10.
+
+    Example:
+        >>> config = ValidationConfig()
+        >>> config.min_publication_year
+        1800
+        >>> # Override for Semantic Scholar (older publications)
+        >>> ss_config = ValidationConfig(min_publication_year=1500)
+        >>> ss_config.min_publication_year
+        1500
+
+    """
+
+    # Publication year range
+    min_publication_year: int = 1800
+    max_publication_year: int = 2100
+
+    # Molecular properties
+    min_molecular_weight: float = 10.0
+    max_molecular_weight: float = 10_000.0
+    molecular_weight_precision: int = 10
+
+    # Identifiers
+    max_pmid: int = 10_000_000_000
+    max_taxonomy_id: int = 10_000_000
+
+    # Activity values
+    min_pchembl_value: float = 0.0
+    max_pchembl_value: float = 15.0
+
+    def __post_init__(self) -> None:
+        """Validate configuration invariants."""
+        self._validate_ranges()
+
+    def _validate_ranges(self) -> None:
+        """Validate that min/max ranges are valid."""
+        validations = [
+            (
+                self.min_publication_year >= self.max_publication_year,
+                "min_publication_year must be less than max_publication_year",
+            ),
+            (
+                self.min_molecular_weight >= self.max_molecular_weight,
+                "min_molecular_weight must be less than max_molecular_weight",
+            ),
+            (
+                self.min_pchembl_value >= self.max_pchembl_value,
+                "min_pchembl_value must be less than max_pchembl_value",
+            ),
+            (
+                self.molecular_weight_precision < 0,
+                "molecular_weight_precision must be non-negative",
+            ),
+        ]
+        for condition, message in validations:
+            if condition:
+                raise ValueError(message)
+
+
+# Default singleton instance for use when no custom config is provided
+DEFAULT_VALIDATION_CONFIG = ValidationConfig()
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/bioetl/domain/validation.py
+++ b/src/bioetl/domain/validation.py
@@ -15,9 +15,12 @@ See also:
 from __future__ import annotations
 
 import re
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .transformations import safe_int
+
+if TYPE_CHECKING:
+    from bioetl.domain.config import ValidationConfig
 
 # =============================================================================
 # SMILES Validation (Chemical Structure)
@@ -70,8 +73,21 @@ def validate_smiles(smiles: str | None) -> bool:
 # Standard publication year range for scientific publications.
 # First scientific journals appeared in XVII century, but systematic
 # publications began in XIX century.
-MIN_PUBLICATION_YEAR: int = 1800
-MAX_PUBLICATION_YEAR: int = 2100
+#
+# These constants use DEFAULT_VALIDATION_CONFIG for the authoritative values.
+# For custom ranges, use ValidationConfig directly or PublicationYear Value Object.
+
+
+def _get_default_config() -> ValidationConfig:
+    """Get default validation config (lazy import to avoid circular deps)."""
+    from bioetl.domain.config import DEFAULT_VALIDATION_CONFIG
+
+    return DEFAULT_VALIDATION_CONFIG
+
+
+# Backward-compatible constants that reference DEFAULT_VALIDATION_CONFIG
+MIN_PUBLICATION_YEAR: int = 1800  # DEFAULT_VALIDATION_CONFIG.min_publication_year
+MAX_PUBLICATION_YEAR: int = 2100  # DEFAULT_VALIDATION_CONFIG.max_publication_year
 
 
 # =============================================================================
@@ -142,14 +158,19 @@ def validate_year_range(
     return min_year <= year <= max_year
 
 
-def validate_publication_year(year: int | None) -> tuple[int | None, bool]:
+def validate_publication_year(
+    year: int | None,
+    config: ValidationConfig | None = None,
+) -> tuple[int | None, bool]:
     """Validate publication year and flag if out of range.
 
-    Uses standard publication year range [MIN_PUBLICATION_YEAR, MAX_PUBLICATION_YEAR].
+    Uses validation range from config or DEFAULT_VALIDATION_CONFIG.
     Values outside this range are preserved but flagged for DQ warnings.
 
     Args:
         year: Publication year to validate.
+        config: Optional ValidationConfig for custom ranges.
+            If None, uses DEFAULT_VALIDATION_CONFIG.
 
     Returns:
         Tuple of (year, is_warning) where:
@@ -171,11 +192,19 @@ def validate_publication_year(year: int | None) -> tuple[int | None, bool]:
         (1500, True)
         >>> validate_publication_year(None)
         (None, False)
+        >>> # With custom config
+        >>> from bioetl.domain.config import ValidationConfig
+        >>> ss_config = ValidationConfig(min_publication_year=1500)
+        >>> validate_publication_year(1600, config=ss_config)
+        (1600, False)
 
     """
     if year is None:
         return None, False
-    if MIN_PUBLICATION_YEAR <= year <= MAX_PUBLICATION_YEAR:
+    resolved_config = config or _get_default_config()
+    min_year = resolved_config.min_publication_year
+    max_year = resolved_config.max_publication_year
+    if min_year <= year <= max_year:
         return year, False
     return year, True  # Keep value but flag as warning
 
@@ -218,26 +247,38 @@ def validate_non_negative(value: Any) -> float | None:
 # =============================================================================
 
 # Molecular weight valid range:
-# - Min: > 0 (must be positive)
-# - Max: 100000 Da (covers small molecules ~100-1000 Da to large proteins ~50000 Da)
+# - Min: > 10.0 Da (DEFAULT_VALIDATION_CONFIG)
+# - Max: < 10000.0 Da (DEFAULT_VALIDATION_CONFIG)
 # Reference: PubChem compound MW typically ranges from ~10 to ~5000 Da
-MIN_MOLECULAR_WEIGHT: float = 0.0
-MAX_MOLECULAR_WEIGHT: float = 100000.0
+#
+# For backward compatibility, these constants use broader ranges than
+# DEFAULT_VALIDATION_CONFIG. Use MolecularWeight Value Object for strict validation.
+MIN_MOLECULAR_WEIGHT: float = 0.0  # Legacy: 0.0 (exclusive bound)
+MAX_MOLECULAR_WEIGHT: float = 100000.0  # Legacy: 100000.0 (exclusive bound)
 
 
-def validate_molecular_weight(value: Any) -> float | None:
+def validate_molecular_weight(
+    value: Any,
+    config: ValidationConfig | None = None,
+) -> float | None:
     """Validate and convert molecular weight to float.
 
     Handles string-to-float conversion (PubChem API may return strings)
-    and validates the range. Precision is 10 decimals per RULES.md §2.8.1.
+    and validates the range. Precision from config (default 10 decimals)
+    per RULES.md §2.8.1.
 
-    Valid range: 0 < mw < 100000 (covers small molecules to large proteins).
+    When config is provided, uses config.min_molecular_weight and
+    config.max_molecular_weight (exclusive bounds).
+
+    When config is None, uses legacy bounds (0, 100000) for backward
+    compatibility. For stricter validation, use MolecularWeight Value Object.
 
     Args:
         value: Raw molecular weight value (string, int, float, or None).
+        config: Optional ValidationConfig for custom ranges and precision.
 
     Returns:
-        Valid float rounded to 10 decimals, or None if invalid/out of range.
+        Valid float rounded to precision, or None if invalid/out of range.
 
     Example:
         >>> validate_molecular_weight(180.156)
@@ -248,7 +289,7 @@ def validate_molecular_weight(value: Any) -> float | None:
         None
         >>> validate_molecular_weight(-1.0)  # Negative is invalid
         None
-        >>> validate_molecular_weight(100001)  # Too large
+        >>> validate_molecular_weight(100001)  # Too large (legacy bounds)
         None
         >>> validate_molecular_weight(None)
         None
@@ -260,8 +301,17 @@ def validate_molecular_weight(value: Any) -> float | None:
         return None
     try:
         mw = float(value)
-        if MIN_MOLECULAR_WEIGHT < mw < MAX_MOLECULAR_WEIGHT:
-            return round(mw, 10)
+        # Use config bounds if provided, otherwise legacy bounds
+        if config is not None:
+            min_mw = config.min_molecular_weight
+            max_mw = config.max_molecular_weight
+            precision = config.molecular_weight_precision
+        else:
+            min_mw = MIN_MOLECULAR_WEIGHT
+            max_mw = MAX_MOLECULAR_WEIGHT
+            precision = 10
+        if min_mw < mw < max_mw:
+            return round(mw, precision)
         return None
     except (ValueError, TypeError):
         return None

--- a/src/bioetl/domain/value_objects/__init__.py
+++ b/src/bioetl/domain/value_objects/__init__.py
@@ -5,7 +5,7 @@ and business rules. They provide type safety and self-validation.
 
 Categories:
 - Identifiers: ChemblId, UniProtId, DOI, PubMedId, PubChemCid, CompoundId, AssayId
-- Chemical: InChIKey, SMILES
+- Chemical: InChIKey, SMILES, MolecularWeight
 - Biological: TaxonomyId (NCBI Taxonomy)
 - Metadata: PublicationYear
 - Activity Values: Concentration, ActivityType, PChemblValue, ActivityValue
@@ -59,6 +59,7 @@ from bioetl.domain.value_objects.base import ValueObject
 from bioetl.domain.value_objects.chemical import (
     SMILES,
     InChIKey,
+    MolecularWeight,
     PublicationYear,
 )
 from bioetl.domain.value_objects.compound_ids import (
@@ -95,6 +96,7 @@ __all__ = [
     "DQEvaluationStatus",
     "DQResult",
     "InChIKey",
+    "MolecularWeight",
     "PChemblValue",
     "PubChemCid",
     "PubMedId",

--- a/src/bioetl/domain/value_objects/chemical.py
+++ b/src/bioetl/domain/value_objects/chemical.py
@@ -4,15 +4,21 @@ Contains Value Objects for chemical structure identifiers:
 - InChIKey: InChI Key identifiers (BSYNRYMUTXBXSQ-UHFFFAOYSA-N)
 - SMILES: SMILES notation strings
 - PublicationYear: Publication year with validation
+- MolecularWeight: Molecular weight with validation and precision
 
 These Value Objects encapsulate validation and normalization rules.
 """
 
 from __future__ import annotations
 
+import math
 import re
+from typing import TYPE_CHECKING
 
 from bioetl.domain.value_objects.base import ValueObject
+
+if TYPE_CHECKING:
+    from bioetl.domain.config import ValidationConfig
 
 
 class InChIKey(ValueObject[str]):
@@ -238,37 +244,99 @@ class SMILES(ValueObject[str]):
 class PublicationYear(ValueObject[int]):
     """Publication year value object with validation.
 
-    Validates that the year falls within a reasonable range for
+    Validates that the year falls within a configurable range for
     scientific publications.
+
+    The validation range can be customized via ValidationConfig:
+    - Default range: [1800, 2100] for standard scientific publications
+    - Semantic Scholar: [1500, 2100] for historical publications
 
     Examples: 1953 (Watson & Crick), 2020 (COVID papers)
 
     Invariants:
-        - Must be between MIN_YEAR (1800) and MAX_YEAR (2100)
+        - Must be between config.min_publication_year and config.max_publication_year
         - Must be a positive integer
+
+    Attributes:
+        _config: ValidationConfig for year range validation.
     """
 
-    __slots__ = ()
+    __slots__ = ("_config",)
     _value: int
+    _config: ValidationConfig
 
-    _MIN_YEAR = 1800  # Reasonable minimum for scientific publications
-    _MAX_YEAR = 2100  # Reasonable maximum allowing for future publications
+    # Class-level defaults for backward compatibility
+    _DEFAULT_MIN_YEAR = 1800
+    _DEFAULT_MAX_YEAR = 2100
+
+    def __init__(
+        self,
+        value: int | str,
+        *,
+        config: ValidationConfig | None = None,
+    ) -> None:
+        """Create PublicationYear with validated value.
+
+        Args:
+            value: Raw year value (int or string).
+            config: Optional ValidationConfig for custom ranges.
+                If None, uses DEFAULT_VALIDATION_CONFIG.
+
+        Raises:
+            ValueError: If year is outside valid range.
+
+        Example:
+            >>> year = PublicationYear(2020)
+            >>> year.value
+            2020
+            >>> # With custom config for Semantic Scholar
+            >>> from bioetl.domain.config import ValidationConfig
+            >>> ss_config = ValidationConfig(min_publication_year=1500)
+            >>> year = PublicationYear(1600, config=ss_config)
+
+        """
+        # Import here to avoid circular dependency
+        from bioetl.domain.config import DEFAULT_VALIDATION_CONFIG
+
+        resolved_config = config or DEFAULT_VALIDATION_CONFIG
+        object.__setattr__(self, "_config", resolved_config)
+        validated = self._validate(value)
+        object.__setattr__(self, "_value", validated)
 
     def _coerce_to_int(self, value: int | str) -> int:
-        """Coerce value to int, raising ValueError on failure."""
+        """Coerce value to int, raising ValueError on failure.
+
+        Also supports extracting year from date string format (YYYY-MM-DD).
+
+        Args:
+            value: Raw value to coerce.
+
+        Returns:
+            Integer year value.
+
+        Raises:
+            ValueError: If coercion fails.
+        """
         if isinstance(value, bool):
             raise ValueError(f"PublicationYear must be int, got {type(value).__name__}")
         if isinstance(value, int):
             return value
         if isinstance(value, str):
+            stripped = value.strip()
+            # Support date string format: "2024-01-15" → 2024
+            if len(stripped) >= 4 and stripped[4:5] in ("-", "/", ""):
+                try:
+                    return int(stripped[:4])
+                except ValueError:
+                    pass
             try:
-                return int(value.strip())
+                return int(stripped)
             except ValueError:
                 raise ValueError(f"Invalid publication year: {value!r}") from None
         raise ValueError(f"PublicationYear must be int, got {type(value).__name__}")
 
-    def _validate(self, value: int) -> int:
-        """Validate publication year.
+    def _validate(self, value: int | str) -> int:
+        """Validate publication year against config range.
 
         Args:
             value: Raw year value.
@@ -280,12 +348,23 @@ class PublicationYear(ValueObject[int]):
             ValueError: If year is outside valid range.
         """
         int_value = self._coerce_to_int(value)
-        if not self._MIN_YEAR <= int_value <= self._MAX_YEAR:
+        min_year = self._config.min_publication_year
+        max_year = self._config.max_publication_year
+        if not min_year <= int_value <= max_year:
             raise ValueError(
-                f"Year {int_value} outside valid range "
-                f"[{self._MIN_YEAR}, {self._MAX_YEAR}]"
+                f"Year {int_value} outside valid range [{min_year}, {max_year}]"
             )
         return int_value
+
+    @property
+    def min_year(self) -> int:
+        """Get the minimum valid year from config."""
+        return self._config.min_publication_year
+
+    @property
+    def max_year(self) -> int:
+        """Get the maximum valid year from config."""
+        return self._config.max_publication_year
 
     @property
     def decade(self) -> int:
@@ -306,21 +385,191 @@ class PublicationYear(ValueObject[int]):
         return (self._value // 100) + 1
 
     @classmethod
-    def from_raw(cls, raw: int | str | None) -> PublicationYear | None:
+    def from_raw(
+        cls,
+        raw: int | str | None,
+        *,
+        config: ValidationConfig | None = None,
+    ) -> PublicationYear | None:
         """Create PublicationYear from raw value with normalization.
 
         Args:
             raw: Raw year integer, string, or None.
+            config: Optional ValidationConfig for custom ranges.
 
         Returns:
             PublicationYear if valid, None if input is None, empty, or invalid.
+
+        Example:
+            >>> PublicationYear.from_raw("2020")
+            PublicationYear(2020)
+            >>> PublicationYear.from_raw("2024-01-15")  # Date string
+            PublicationYear(2024)
+            >>> PublicationYear.from_raw(None)
+            None
+
         """
         if raw is None:
             return None
         if isinstance(raw, str) and not raw.strip():
             return None
         try:
-            # int() is idempotent on ints, converts str to int
-            return cls(int(raw))
+            return cls(raw, config=config)
         except ValueError:
             return None
+
+    def __eq__(self, other: object) -> bool:
+        """Compare by value only (ignoring config)."""
+        if not isinstance(other, PublicationYear):
+            return NotImplemented
+        return bool(self._value == other._value)
+
+    def __hash__(self) -> int:
+        """Hash based on class and value only (ignoring config)."""
+        return hash((self.__class__.__name__, self._value))
+
+
+class MolecularWeight(ValueObject[float]):
+    """Molecular weight value object with validation.
+
+    Validates molecular weight against configurable range and rounds
+    to specified precision per RULES.md §2.8.1.
+
+    Default validation range: (10.0, 10000.0) Da - covers small molecules
+    to large peptides. Range is exclusive (open interval).
+
+    Attributes:
+        _config: ValidationConfig for range and precision.
+
+    Invariants:
+        - Must be between config.min_molecular_weight and max_molecular_weight
+        - Rounded to config.molecular_weight_precision decimals
+        - Cannot be NaN or Inf
+
+    Example:
+        >>> mw = MolecularWeight(180.156)
+        >>> mw.value
+        180.156
+        >>> # Rounding to precision
+        >>> mw = MolecularWeight(180.15600000001)
+        >>> mw.value
+        180.156
+
+    """
+
+    __slots__ = ("_config",)
+    _value: float
+    _config: ValidationConfig
+
+    def __init__(
+        self,
+        value: float | int | str,
+        *,
+        config: ValidationConfig | None = None,
+    ) -> None:
+        """Create MolecularWeight with validated value.
+
+        Args:
+            value: Raw molecular weight value.
+            config: Optional ValidationConfig for custom ranges.
+                If None, uses DEFAULT_VALIDATION_CONFIG.
+
+        Raises:
+            ValueError: If MW is outside valid range or invalid.
+
+        """
+        # Import here to avoid circular dependency
+        from bioetl.domain.config import DEFAULT_VALIDATION_CONFIG
+
+        resolved_config = config or DEFAULT_VALIDATION_CONFIG
+        object.__setattr__(self, "_config", resolved_config)
+        validated = self._validate(value)
+        object.__setattr__(self, "_value", validated)
+
+    def _validate(self, value: float | int | str) -> float:
+        """Validate and normalize molecular weight.
+
+        Args:
+            value: Raw molecular weight value.
+
+        Returns:
+            Validated and rounded float.
+
+        Raises:
+            ValueError: If MW is invalid or outside range.
+        """
+        # Convert to float
+        try:
+            float_value = float(value)
+        except (ValueError, TypeError) as e:
+            raise ValueError(f"Invalid molecular weight: {value!r}") from e
+
+        # Check for NaN/Inf
+        if math.isnan(float_value) or math.isinf(float_value):
+            raise ValueError(f"Invalid molecular weight: {value} (NaN or Inf)")
+
+        # Validate range (exclusive bounds)
+        min_mw = self._config.min_molecular_weight
+        max_mw = self._config.max_molecular_weight
+        if not min_mw < float_value < max_mw:
+            raise ValueError(
+                f"Molecular weight {float_value} outside range ({min_mw}, {max_mw})"
+            )
+
+        # Round to precision
+        precision = self._config.molecular_weight_precision
+        return round(float_value, precision)
+
+    @property
+    def min_weight(self) -> float:
+        """Get the minimum valid molecular weight from config."""
+        return self._config.min_molecular_weight
+
+    @property
+    def max_weight(self) -> float:
+        """Get the maximum valid molecular weight from config."""
+        return self._config.max_molecular_weight
+
+    @classmethod
+    def from_raw(
+        cls,
+        raw: float | int | str | None,
+        *,
+        config: ValidationConfig | None = None,
+    ) -> MolecularWeight | None:
+        """Create MolecularWeight from raw value with normalization.
+
+        Args:
+            raw: Raw molecular weight value or None.
+            config: Optional ValidationConfig for custom ranges.
+
+        Returns:
+            MolecularWeight if valid, None if input is None or invalid.
+
+        Example:
+            >>> MolecularWeight.from_raw(180.156)
+            MolecularWeight(180.156)
+            >>> MolecularWeight.from_raw("342.30")  # String from API
+            MolecularWeight(342.3)
+            >>> MolecularWeight.from_raw(None)
+            None
+
+        """
+        if raw is None:
+            return None
+        if isinstance(raw, str) and not raw.strip():
+            return None
+        try:
+            return cls(raw, config=config)
+        except ValueError:
+            return None
+
+    def __eq__(self, other: object) -> bool:
+        """Compare by value only (ignoring config)."""
+        if not isinstance(other, MolecularWeight):
+            return NotImplemented
+        return bool(self._value == other._value)
+
+    def __hash__(self) -> int:
+        """Hash based on class and value only (ignoring config)."""
+        return hash((self.__class__.__name__, self._value))

--- a/tests/unit/domain/test_config.py
+++ b/tests/unit/domain/test_config.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import pytest
 
-from bioetl.domain.config import DQConfig, TableConfig
+from bioetl.domain.config import (
+    DEFAULT_VALIDATION_CONFIG,
+    DQConfig,
+    TableConfig,
+    ValidationConfig,
+)
 
 
 @pytest.mark.unit
@@ -178,3 +183,115 @@ class TestTableConfig:
         assert config.primary_keys == ("activity_id", "assay_chembl_id")
         assert config.silver_table == "chembl_activity_silver"
         assert config.gold_table == "chembl_activity_gold"
+
+
+@pytest.mark.unit
+class TestValidationConfig:
+    """Tests for ValidationConfig dataclass."""
+
+    def test_default_values(self) -> None:
+        """Test default validation range values."""
+        config = ValidationConfig()
+
+        assert config.min_publication_year == 1800
+        assert config.max_publication_year == 2100
+        assert config.min_molecular_weight == 10.0
+        assert config.max_molecular_weight == 10_000.0
+        assert config.molecular_weight_precision == 10
+        assert config.max_pmid == 10_000_000_000
+        assert config.max_taxonomy_id == 10_000_000
+        assert config.min_pchembl_value == 0.0
+        assert config.max_pchembl_value == 15.0
+
+    def test_custom_publication_year_range(self) -> None:
+        """Test custom publication year range (e.g., for Semantic Scholar)."""
+        config = ValidationConfig(
+            min_publication_year=1500, max_publication_year=2100
+        )
+
+        assert config.min_publication_year == 1500
+        assert config.max_publication_year == 2100
+
+    def test_custom_molecular_weight_range(self) -> None:
+        """Test custom molecular weight range."""
+        config = ValidationConfig(
+            min_molecular_weight=1.0, max_molecular_weight=50_000.0
+        )
+
+        assert config.min_molecular_weight == 1.0
+        assert config.max_molecular_weight == 50_000.0
+
+    def test_immutability(self) -> None:
+        """Test that ValidationConfig is frozen (immutable)."""
+        config = ValidationConfig()
+
+        with pytest.raises(AttributeError):
+            config.min_publication_year = 1500  # type: ignore[misc]
+
+    def test_equality(self) -> None:
+        """Test equality between ValidationConfig instances."""
+        config1 = ValidationConfig()
+        config2 = ValidationConfig()
+        config3 = ValidationConfig(min_publication_year=1500)
+
+        assert config1 == config2
+        assert config1 != config3
+
+    def test_hashable(self) -> None:
+        """Test that ValidationConfig is hashable."""
+        config1 = ValidationConfig()
+        config2 = ValidationConfig()
+
+        config_set = {config1, config2}
+        assert len(config_set) == 1
+
+    def test_invalid_year_range_raises(self) -> None:
+        """Test that invalid year range (min >= max) raises ValueError."""
+        with pytest.raises(ValueError, match="min_publication_year"):
+            ValidationConfig(
+                min_publication_year=2100, max_publication_year=1800
+            )
+
+    def test_invalid_year_range_equal_raises(self) -> None:
+        """Test that equal year range raises ValueError."""
+        with pytest.raises(ValueError, match="min_publication_year"):
+            ValidationConfig(
+                min_publication_year=2000, max_publication_year=2000
+            )
+
+    def test_invalid_mw_range_raises(self) -> None:
+        """Test that invalid MW range (min >= max) raises ValueError."""
+        with pytest.raises(ValueError, match="min_molecular_weight"):
+            ValidationConfig(
+                min_molecular_weight=10000.0, max_molecular_weight=10.0
+            )
+
+    def test_invalid_pchembl_range_raises(self) -> None:
+        """Test that invalid pChEMBL range raises ValueError."""
+        with pytest.raises(ValueError, match="min_pchembl_value"):
+            ValidationConfig(min_pchembl_value=15.0, max_pchembl_value=0.0)
+
+    def test_negative_precision_raises(self) -> None:
+        """Test that negative precision raises ValueError."""
+        with pytest.raises(ValueError, match="molecular_weight_precision"):
+            ValidationConfig(molecular_weight_precision=-1)
+
+    def test_zero_precision_valid(self) -> None:
+        """Test that zero precision is valid (rounds to integers)."""
+        config = ValidationConfig(molecular_weight_precision=0)
+        assert config.molecular_weight_precision == 0
+
+    def test_default_singleton_available(self) -> None:
+        """Test that DEFAULT_VALIDATION_CONFIG singleton is available."""
+        assert DEFAULT_VALIDATION_CONFIG is not None
+        assert isinstance(DEFAULT_VALIDATION_CONFIG, ValidationConfig)
+        assert DEFAULT_VALIDATION_CONFIG.min_publication_year == 1800
+
+    def test_semantic_scholar_config(self) -> None:
+        """Test Semantic Scholar-specific config with min_year=1500."""
+        ss_config = ValidationConfig(min_publication_year=1500)
+
+        assert ss_config.min_publication_year == 1500
+        # Other values remain at defaults
+        assert ss_config.max_publication_year == 2100
+        assert ss_config.min_molecular_weight == 10.0

--- a/tests/unit/domain/value_objects/test_identifiers.py
+++ b/tests/unit/domain/value_objects/test_identifiers.py
@@ -1,16 +1,19 @@
 """Tests for identifier Value Objects.
 
-Tests for ChemblId, UniProtId, DOI, PubMedId, PubChemCid, InChIKey, SMILES, PublicationYear.
+Tests for ChemblId, UniProtId, DOI, PubMedId, PubChemCid, InChIKey, SMILES,
+PublicationYear, MolecularWeight.
 """
 
 from __future__ import annotations
 
 import pytest
 
+from bioetl.domain.config import ValidationConfig
 from bioetl.domain.value_objects import (
     DOI,
     ChemblId,
     InChIKey,
+    MolecularWeight,
     PubChemCid,
     PubMedId,
     PublicationYear,
@@ -960,3 +963,242 @@ class TestPublicationYear:
         """Test repr output."""
         year = PublicationYear(2020)
         assert repr(year) == "PublicationYear(2020)"
+
+    def test_with_custom_config(self) -> None:
+        """Test PublicationYear with custom ValidationConfig."""
+        config = ValidationConfig(min_publication_year=1500)
+        year = PublicationYear(1600, config=config)
+        assert year.value == 1600
+
+    def test_custom_config_rejects_out_of_range(self) -> None:
+        """Test that custom config enforces its range."""
+        config = ValidationConfig(min_publication_year=1500, max_publication_year=2000)
+        with pytest.raises(ValueError, match="outside valid range"):
+            PublicationYear(2001, config=config)
+
+    def test_from_raw_with_config(self) -> None:
+        """Test from_raw with custom config."""
+        config = ValidationConfig(min_publication_year=1500)
+        year = PublicationYear.from_raw(1600, config=config)
+        assert year is not None
+        assert year.value == 1600
+
+    def test_from_raw_with_config_invalid(self) -> None:
+        """Test from_raw with config and invalid value returns None."""
+        config = ValidationConfig(min_publication_year=1500, max_publication_year=2000)
+        assert PublicationYear.from_raw(2001, config=config) is None
+
+    def test_date_string_extraction(self) -> None:
+        """Test year extraction from date string."""
+        # ISO date format: YYYY-MM-DD
+        year = PublicationYear("2024-01-15")  # type: ignore[arg-type]
+        assert year.value == 2024
+
+    def test_date_string_extraction_slash(self) -> None:
+        """Test year extraction from date string with slash."""
+        year = PublicationYear("2023/06/20")  # type: ignore[arg-type]
+        assert year.value == 2023
+
+    def test_from_raw_date_string(self) -> None:
+        """Test from_raw with date string."""
+        year = PublicationYear.from_raw("2024-01-15")
+        assert year is not None
+        assert year.value == 2024
+
+    def test_min_year_property(self) -> None:
+        """Test min_year property returns config value."""
+        year = PublicationYear(2020)
+        assert year.min_year == 1800
+
+    def test_max_year_property(self) -> None:
+        """Test max_year property returns config value."""
+        year = PublicationYear(2020)
+        assert year.max_year == 2100
+
+    def test_equality_ignores_config(self) -> None:
+        """Test that equality compares by value, ignoring config."""
+        config1 = ValidationConfig(min_publication_year=1800)
+        config2 = ValidationConfig(min_publication_year=1500)
+        year1 = PublicationYear(2020, config=config1)
+        year2 = PublicationYear(2020, config=config2)
+        assert year1 == year2
+
+    def test_hash_ignores_config(self) -> None:
+        """Test that hash is consistent with equality (ignoring config)."""
+        config1 = ValidationConfig(min_publication_year=1800)
+        config2 = ValidationConfig(min_publication_year=1500)
+        year1 = PublicationYear(2020, config=config1)
+        year2 = PublicationYear(2020, config=config2)
+        assert hash(year1) == hash(year2)
+
+
+class TestMolecularWeight:
+    """Tests for MolecularWeight Value Object."""
+
+    def test_valid_molecular_weight(self) -> None:
+        """Test creation with valid molecular weight."""
+        mw = MolecularWeight(180.156)
+        assert mw.value == 180.156
+
+    def test_from_int(self) -> None:
+        """Test creation from integer."""
+        mw = MolecularWeight(180)
+        assert mw.value == 180.0
+
+    def test_from_string(self) -> None:
+        """Test creation from string (e.g., from PubChem API)."""
+        mw = MolecularWeight("342.30")
+        assert mw.value == 342.3
+
+    def test_precision_rounding(self) -> None:
+        """Test rounding to configured precision (default 10 decimals)."""
+        mw = MolecularWeight(180.12345678901234)
+        # Should round to 10 decimal places
+        assert mw.value == 180.1234567890
+
+    def test_below_minimum_raises(self) -> None:
+        """Test that MW below minimum raises ValueError."""
+        with pytest.raises(ValueError, match="outside range"):
+            MolecularWeight(5.0)  # Below default min of 10.0
+
+    def test_at_minimum_raises(self) -> None:
+        """Test that MW at minimum raises ValueError (exclusive bound)."""
+        with pytest.raises(ValueError, match="outside range"):
+            MolecularWeight(10.0)  # At bound, but bounds are exclusive
+
+    def test_above_maximum_raises(self) -> None:
+        """Test that MW above maximum raises ValueError."""
+        with pytest.raises(ValueError, match="outside range"):
+            MolecularWeight(15000.0)  # Above default max of 10000.0
+
+    def test_at_maximum_raises(self) -> None:
+        """Test that MW at maximum raises ValueError (exclusive bound)."""
+        with pytest.raises(ValueError, match="outside range"):
+            MolecularWeight(10000.0)  # At bound, but bounds are exclusive
+
+    def test_zero_raises(self) -> None:
+        """Test that zero MW raises ValueError."""
+        with pytest.raises(ValueError, match="outside range"):
+            MolecularWeight(0.0)
+
+    def test_negative_raises(self) -> None:
+        """Test that negative MW raises ValueError."""
+        with pytest.raises(ValueError, match="outside range"):
+            MolecularWeight(-100.0)
+
+    def test_nan_raises(self) -> None:
+        """Test that NaN raises ValueError."""
+        with pytest.raises(ValueError, match="NaN or Inf"):
+            MolecularWeight(float("nan"))
+
+    def test_inf_raises(self) -> None:
+        """Test that Infinity raises ValueError."""
+        with pytest.raises(ValueError, match="NaN or Inf"):
+            MolecularWeight(float("inf"))
+
+    def test_invalid_string_raises(self) -> None:
+        """Test that invalid string raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid molecular weight"):
+            MolecularWeight("not-a-number")
+
+    def test_immutability(self) -> None:
+        """Test Value Object is immutable."""
+        mw = MolecularWeight(180.156)
+        with pytest.raises(AttributeError, match="immutable"):
+            mw._value = 200.0  # type: ignore[misc]
+
+    def test_equality_by_value(self) -> None:
+        """Test equality is based on value."""
+        mw1 = MolecularWeight(180.156)
+        mw2 = MolecularWeight(180.156)
+        assert mw1 == mw2
+
+    def test_inequality(self) -> None:
+        """Test inequality for different values."""
+        mw1 = MolecularWeight(180.156)
+        mw2 = MolecularWeight(200.0)
+        assert mw1 != mw2
+
+    def test_hash_consistency(self) -> None:
+        """Test hash is consistent with equality."""
+        mw1 = MolecularWeight(180.156)
+        mw2 = MolecularWeight(180.156)
+        assert hash(mw1) == hash(mw2)
+
+    def test_from_raw_valid(self) -> None:
+        """Test from_raw with valid value."""
+        mw = MolecularWeight.from_raw(180.156)
+        assert mw is not None
+        assert mw.value == 180.156
+
+    def test_from_raw_valid_string(self) -> None:
+        """Test from_raw with valid string."""
+        mw = MolecularWeight.from_raw("342.30")
+        assert mw is not None
+        assert mw.value == 342.3
+
+    def test_from_raw_none(self) -> None:
+        """Test from_raw with None."""
+        assert MolecularWeight.from_raw(None) is None
+
+    def test_from_raw_empty_string(self) -> None:
+        """Test from_raw with empty string."""
+        assert MolecularWeight.from_raw("") is None
+        assert MolecularWeight.from_raw("   ") is None
+
+    def test_from_raw_invalid(self) -> None:
+        """Test from_raw with invalid value returns None."""
+        assert MolecularWeight.from_raw("abc") is None
+        assert MolecularWeight.from_raw(5.0) is None  # Below min
+        assert MolecularWeight.from_raw(15000.0) is None  # Above max
+
+    def test_str(self) -> None:
+        """Test string conversion."""
+        mw = MolecularWeight(180.156)
+        assert str(mw) == "180.156"
+
+    def test_repr(self) -> None:
+        """Test repr output."""
+        mw = MolecularWeight(180.156)
+        assert repr(mw) == "MolecularWeight(180.156)"
+
+    def test_with_custom_config(self) -> None:
+        """Test MolecularWeight with custom ValidationConfig."""
+        config = ValidationConfig(
+            min_molecular_weight=1.0, max_molecular_weight=50000.0
+        )
+        mw = MolecularWeight(5.0, config=config)
+        assert mw.value == 5.0
+
+    def test_from_raw_with_config(self) -> None:
+        """Test from_raw with custom config."""
+        config = ValidationConfig(
+            min_molecular_weight=1.0, max_molecular_weight=50000.0
+        )
+        mw = MolecularWeight.from_raw(5.0, config=config)
+        assert mw is not None
+        assert mw.value == 5.0
+
+    def test_min_weight_property(self) -> None:
+        """Test min_weight property returns config value."""
+        mw = MolecularWeight(100.0)
+        assert mw.min_weight == 10.0
+
+    def test_max_weight_property(self) -> None:
+        """Test max_weight property returns config value."""
+        mw = MolecularWeight(100.0)
+        assert mw.max_weight == 10000.0
+
+    def test_equality_ignores_config(self) -> None:
+        """Test that equality compares by value, ignoring config."""
+        config1 = ValidationConfig(min_molecular_weight=1.0, max_molecular_weight=50000.0)
+        config2 = ValidationConfig(min_molecular_weight=10.0, max_molecular_weight=10000.0)
+        mw1 = MolecularWeight(100.0, config=config1)
+        mw2 = MolecularWeight(100.0, config=config2)
+        assert mw1 == mw2
+
+    def test_custom_precision(self) -> None:
+        """Test custom precision via config."""
+        config = ValidationConfig(molecular_weight_precision=2)
+        mw = MolecularWeight(180.12345, config=config)
+        assert mw.value == 180.12


### PR DESCRIPTION
Implement centralized validation configuration system for domain value objects and validation functions. This enables consistent validation ranges across all transformers with provider-specific overrides.

Changes:
- Add ValidationConfig dataclass to domain/config.py with:
  - Publication year range (default 1800-2100)
  - Molecular weight range (default 10-10000 Da)
  - pChEMBL value range and precision settings
  - Identifier limits (PMID, taxonomy ID)
- Update PublicationYear Value Object:
  - Accept optional ValidationConfig parameter
  - Support date string extraction (YYYY-MM-DD → year)
  - Add min_year/max_year properties
- Add MolecularWeight Value Object:
  - Validate range against config (exclusive bounds)
  - Round to configurable precision (default 10 decimals)
  - Reject NaN/Inf values
- Update validation.py functions:
  - validate_publication_year() accepts optional config
  - validate_molecular_weight() accepts optional config
- Update publication transformers:
  - OpenAlex, CrossRef: Use PublicationYear.from_raw()
  - SemanticScholar: Use custom config (min_year=1500)
  - PubMed, ChEMBL: Validate year with PublicationYear VO
- Add comprehensive tests:
  - TestValidationConfig: 16 tests
  - TestPublicationYear: 12 new tests for config support
  - TestMolecularWeight: 33 tests

This centralizes validation rules that were previously scattered across transformers with different minimum year values (1500 vs 1800).