### PR TITLE
Fix failing architecture and complexity checks

### DIFF
--- a/src/bioetl/domain/value_objects/academic_ids.py
+++ b/src/bioetl/domain/value_objects/academic_ids.py
@@ -156,9 +156,7 @@ class ISSN(ValueObject[str]):
 
         match = self._PATTERN.match(normalized)
         if not match:
-            raise ValueError(
-                f"Invalid ISSN format: {value!r}. Expected: XXXX-XXXX"
-            )
+            raise ValueError(f"Invalid ISSN format: {value!r}. Expected: XXXX-XXXX")
 
         first_part = match.group(1)
         second_part = match.group(2).upper()
@@ -225,8 +223,7 @@ class ORCID(ValueObject[str]):
         match = self._PATTERN.match(normalized)
         if not match:
             raise ValueError(
-                f"Invalid ORCID format: {value!r}. "
-                f"Expected: XXXX-XXXX-XXXX-XXXX"
+                f"Invalid ORCID format: {value!r}. Expected: XXXX-XXXX-XXXX-XXXX"
             )
 
         parts = [match.group(i) for i in range(1, 5)]

--- a/tests/architecture/test_code_metrics.py
+++ b/tests/architecture/test_code_metrics.py
@@ -297,7 +297,6 @@ class TestFunctionLength:
         "_log_silver_audit": 75,  # Silver audit logging
         # FilterableDataSourcePort implementations
         "fetch_filtered": 70,  # Batch filtering with OR-query (UniProt)
-        "fetch_filtered_with_fallback": 70,  # Primary lookup + fallback search
         "fetch_multi_filtered": 60,  # Multi-field AND filtering
     }
 

--- a/tests/unit/domain/value_objects/test_publications.py
+++ b/tests/unit/domain/value_objects/test_publications.py
@@ -230,7 +230,10 @@ class TestSemanticScholarId:
     def test_repr(self) -> None:
         """Test string representation."""
         s2id = SemanticScholarId("649def34f8be52c8b66281af98ae884c09aef38b")
-        assert repr(s2id) == "SemanticScholarId('649def34f8be52c8b66281af98ae884c09aef38b')"
+        assert (
+            repr(s2id)
+            == "SemanticScholarId('649def34f8be52c8b66281af98ae884c09aef38b')"
+        )
 
     def test_str(self) -> None:
         """Test string conversion."""


### PR DESCRIPTION
- Remove duplicate `fetch_filtered_with_fallback` key in LENGTH_EXEMPTIONS dict (F601 ruff error - keeping the OpenAlex version with higher threshold of 90)
- Apply ruff formatting to academic_ids.py and test_publications.py