### PR TITLE
Fix failing duplication and complexity checks

### DIFF
--- a/src/bioetl/application/core/base_transformer.py
+++ b/src/bioetl/application/core/base_transformer.py
@@ -671,26 +671,3 @@ class BaseTransformer(ABC):
             _index=index,
             **business_data,
         )
-
-    @staticmethod
-    def _safe_get(
-        record: BronzeRecord,
-        field: str,
-        default: Any = None,
-    ) -> Any:
-        """Get a field value with default fallback.
-
-        Simple wrapper around dict.get() for consistency with other helper methods.
-        Provided for API completeness alongside _get_required_field().
-
-        Args:
-            record: Bronze record dictionary.
-            field: Name of the field to extract.
-            default: Default value if field is missing or None.
-
-        Returns:
-            Field value or default.
-
-        """
-        value = record.get(field)
-        return value if value is not None else default

--- a/src/bioetl/application/pipelines/uniprot/transformer.py
+++ b/src/bioetl/application/pipelines/uniprot/transformer.py
@@ -207,7 +207,9 @@ class UniProtProteinTransformer(BaseTransformer):
         data["organism_common"] = self._extract_by_path(
             record, self._ORGANISM_COMMON_PATH
         )
-        data["taxonomy_id"] = self._extract_by_path(record, self._ORGANISM_TAXON_ID_PATH)
+        data["taxonomy_id"] = self._extract_by_path(
+            record, self._ORGANISM_TAXON_ID_PATH
+        )
         data["lineage"] = ExtractorUtils.serialize_list(
             self._extract_by_path(record, self._ORGANISM_LINEAGE_PATH)
         )

--- a/tests/unit/application/core/test_base_transformer.py
+++ b/tests/unit/application/core/test_base_transformer.py
@@ -187,37 +187,6 @@ class TestExtractNested:
 
 
 @pytest.mark.unit
-class TestSafeGet:
-    """Tests for _safe_get helper method."""
-
-    def test_returns_value_when_present(self, transformer: ConcreteTransformer) -> None:
-        """Test returns field value when present."""
-        record = {"field": "value"}
-        result = transformer._safe_get(record, "field")
-        assert result == "value"
-
-    def test_returns_default_when_missing(
-        self, transformer: ConcreteTransformer
-    ) -> None:
-        """Test returns default when field is missing."""
-        record = {"other": "value"}
-        result = transformer._safe_get(record, "field", default="default")
-        assert result == "default"
-
-    def test_returns_default_when_none(self, transformer: ConcreteTransformer) -> None:
-        """Test returns default when field is None."""
-        record = {"field": None}
-        result = transformer._safe_get(record, "field", default="default")
-        assert result == "default"
-
-    def test_returns_none_as_default(self, transformer: ConcreteTransformer) -> None:
-        """Test returns None as default if not specified."""
-        record = {"other": "value"}
-        result = transformer._safe_get(record, "field")
-        assert result is None
-
-
-@pytest.mark.unit
 class TestCreateEntity:
     """Tests for _create_entity helper method."""
 


### PR DESCRIPTION
- Remove unused _safe_get static method from BaseTransformer (reduces file from 696 to 674 LOC, class from 633 to 610 lines)
- Fix ruff formatting in uniprot/transformer.py
- Remove tests for the removed _safe_get method

This fixes the architecture test failures for file/class size limits.