### PR TITLE
Fix code complexity issues in audit module

### DIFF
--- a/src/bioetl/infrastructure/adapters/openalex/client.py
+++ b/src/bioetl/infrastructure/adapters/openalex/client.py
@@ -161,6 +161,75 @@ class OpenAlexAdapter(BaseHttpAdapter):
             "Use fetch_filtered() with filter_field='doi' instead."
         )
 
+    async def _batch_doi_lookup(
+        self,
+        valid_dois: list[str],
+        found_dois: set[str],
+        limit: int | None,
+        start_count: int,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Phase 1: Batch DOI lookup for valid DOIs.
+
+        Args:
+            valid_dois: List of valid DOIs to lookup.
+            found_dois: Set to track found DOIs (mutated).
+            limit: Maximum records to fetch.
+            start_count: Number of records already fetched.
+
+        Yields:
+            Work records with _lookup_method field.
+        """
+        count = start_count
+        for i in range(0, len(valid_dois), self.batch_size):
+            if limit and count >= limit:
+                return
+
+            batch = valid_dois[i : i + self.batch_size]
+            async for work in self._fetch_by_dois(batch):
+                doi = self._extract_doi_from_record(work)
+                if doi:
+                    found_dois.add(doi.lower())
+                work["_lookup_method"] = "doi"
+                count += 1
+                yield work
+                if limit and count >= limit:
+                    return
+
+    async def _title_only_lookup(
+        self,
+        title_only_entries: list[str],
+        fallback_mapping: dict[str, str],
+        limit: int | None,
+        start_count: int,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Phase 3: Title-only entries lookup (empty DOIs).
+
+        Args:
+            title_only_entries: List of empty DOI entries.
+            fallback_mapping: Mapping from DOI to title for fallback.
+            limit: Maximum records to fetch.
+            start_count: Number of records already fetched.
+
+        Yields:
+            Work records with _lookup_method field.
+        """
+        count = start_count
+        for empty_doi in title_only_entries:
+            if limit and count >= limit:
+                return
+
+            title = fallback_mapping.get(empty_doi, fallback_mapping.get(""))
+            if not title:
+                continue
+
+            self.logger.info("openalex_title_only_search", title=title[:50])
+
+            found_work = await self._search_by_title(title, limit=1)
+            if found_work:
+                found_work["_lookup_method"] = "title_only"
+                count += 1
+                yield found_work
+
     async def fetch_filtered_with_fallback(
         self,
         entity_type: str,
@@ -194,25 +263,15 @@ class OpenAlexAdapter(BaseHttpAdapter):
         fetched = 0
         found_dois: set[str] = set()
 
-        # Separate valid DOIs from title-only entries
         valid_dois = [d for d in filter_ids if d and d.strip()]
         title_only_entries = [d for d in filter_ids if not d or not d.strip()]
 
-        # Phase 1: Batch DOI lookup for valid DOIs
-        for i in range(0, len(valid_dois), self.batch_size):
+        # Phase 1: Batch DOI lookup
+        async for work in self._batch_doi_lookup(valid_dois, found_dois, limit, fetched):
+            yield work
+            fetched += 1
             if limit and fetched >= limit:
                 return
-
-            batch = valid_dois[i : i + self.batch_size]
-            async for work in self._fetch_by_dois(batch):
-                doi = self._extract_doi_from_record(work)
-                if doi:
-                    found_dois.add(doi.lower())
-                work["_lookup_method"] = "doi"
-                yield work
-                fetched += 1
-                if limit and fetched >= limit:
-                    return
 
         # Phase 2: Fallback by title for unresolved DOIs
         async for work in self._fallback_handler.process_missing_dois(
@@ -228,26 +287,11 @@ class OpenAlexAdapter(BaseHttpAdapter):
             if limit and fetched >= limit:
                 return
 
-        # Phase 3: Title-only entries (empty DOIs)
-        for empty_doi in title_only_entries:
-            if limit and fetched >= limit:
-                return
-
-            # Get title from fallback_mapping (may use "" as key for empty DOIs)
-            title = fallback_mapping.get(empty_doi, fallback_mapping.get(""))
-            if not title:
-                continue
-
-            self.logger.info(
-                "openalex_title_only_search",
-                title=title[:50],
-            )
-
-            found_work = await self._search_by_title(title, limit=1)
-            if found_work:
-                found_work["_lookup_method"] = "title_only"
-                yield found_work
-                fetched += 1
+        # Phase 3: Title-only entries
+        async for work in self._title_only_lookup(
+            title_only_entries, fallback_mapping, limit, fetched
+        ):
+            yield work
 
     async def fetch(
         self,

--- a/src/bioetl/infrastructure/adapters/semanticscholar/adapter.py
+++ b/src/bioetl/infrastructure/adapters/semanticscholar/adapter.py
@@ -208,6 +208,109 @@ class SemanticScholarAdapter(BaseHttpAdapter):
                 if limit and fetched >= limit:
                     return
 
+    async def _batch_doi_phase(
+        self,
+        valid_dois: list[str],
+        resolved_dois: set[str],
+        limit: int | None,
+        start_count: int,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Phase 1: Batch DOI lookup via POST /paper/batch.
+
+        Args:
+            valid_dois: List of valid DOIs to lookup.
+            resolved_dois: Set to track resolved DOIs (mutated).
+            limit: Maximum records to fetch.
+            start_count: Number of records already fetched.
+
+        Yields:
+            Publication records with _lookup_method field.
+        """
+        count = start_count
+        for i in range(0, len(valid_dois), self.batch_size):
+            if limit and count >= limit:
+                return
+
+            batch = valid_dois[i : i + self.batch_size]
+            batch_results = await self._fetch_batch_with_nulls(batch)
+
+            for doi, record in zip(batch, batch_results, strict=True):
+                if record is not None:
+                    resolved_dois.add(doi.lower())
+                    record["_lookup_method"] = "doi"
+                    count += 1
+                    yield record
+                    if limit and count >= limit:
+                        return
+
+    async def _title_fallback_phase(
+        self,
+        unresolved_dois: list[str],
+        fallback_mapping: dict[str, str],
+        limit: int | None,
+        start_count: int,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Phase 2: Fallback by title for unresolved DOIs.
+
+        Args:
+            unresolved_dois: DOIs not found in batch lookup.
+            fallback_mapping: Mapping from DOI to title.
+            limit: Maximum records to fetch.
+            start_count: Number of records already fetched.
+
+        Yields:
+            Publication records with _lookup_method field.
+        """
+        count = start_count
+        for doi in unresolved_dois:
+            if limit and count >= limit:
+                return
+
+            title = fallback_mapping.get(doi)
+            if not title:
+                self.logger.warning("no_fallback_title", doi=doi)
+                continue
+
+            async for record in self._search_by_title(title):
+                record["_lookup_method"] = "title_fallback"
+                record["_original_doi"] = doi
+                count += 1
+                yield record
+                break
+
+    async def _title_only_phase(
+        self,
+        title_only_entries: list[str],
+        fallback_mapping: dict[str, str],
+        limit: int | None,
+        start_count: int,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Phase 3: Title-only entries (empty DOIs).
+
+        Args:
+            title_only_entries: List of empty DOI entries.
+            fallback_mapping: Mapping from DOI to title.
+            limit: Maximum records to fetch.
+            start_count: Number of records already fetched.
+
+        Yields:
+            Publication records with _lookup_method field.
+        """
+        count = start_count
+        for empty_doi in title_only_entries:
+            if limit and count >= limit:
+                return
+
+            title = fallback_mapping.get(empty_doi, fallback_mapping.get(""))
+            if not title:
+                continue
+
+            async for record in self._search_by_title(title):
+                record["_lookup_method"] = "title_only"
+                count += 1
+                yield record
+                break
+
     async def fetch_filtered_with_fallback(
         self,
         entity_type: str,
@@ -237,62 +340,31 @@ class SemanticScholarAdapter(BaseHttpAdapter):
         fetched = 0
         resolved_dois: set[str] = set()
 
-        # Separate DOIs from title-only entries
         valid_dois = [d for d in filter_ids if d and d.strip()]
         title_only_entries = [d for d in filter_ids if not d or not d.strip()]
 
         # Phase 1: Batch DOI lookup
-        for i in range(0, len(valid_dois), self.batch_size):
-            batch = valid_dois[i : i + self.batch_size]
-
-            # Batch returns results in same order, with null for not found
-            batch_results = await self._fetch_batch_with_nulls(batch)
-
-            for doi, record in zip(batch, batch_results, strict=True):
-                if record is not None:
-                    resolved_dois.add(doi.lower())
-                    record["_lookup_method"] = "doi"
-                    yield record
-                    fetched += 1
-                    if limit and fetched >= limit:
-                        return
+        async for record in self._batch_doi_phase(valid_dois, resolved_dois, limit, fetched):
+            yield record
+            fetched += 1
+            if limit and fetched >= limit:
+                return
 
         # Phase 2: Fallback by title for unresolved DOIs
         unresolved_dois = [d for d in valid_dois if d.lower() not in resolved_dois]
-
-        for doi in unresolved_dois:
+        async for record in self._title_fallback_phase(
+            unresolved_dois, fallback_mapping, limit, fetched
+        ):
+            yield record
+            fetched += 1
             if limit and fetched >= limit:
                 return
 
-            title = fallback_mapping.get(doi)
-            if not title:
-                self.logger.warning(
-                    "no_fallback_title",
-                    doi=doi,
-                )
-                continue
-
-            async for record in self._search_by_title(title):
-                record["_lookup_method"] = "title_fallback"
-                record["_original_doi"] = doi
-                yield record
-                fetched += 1
-                break  # Take first match only
-
-        # Phase 3: Title-only entries (empty DOIs)
-        for empty_doi in title_only_entries:
-            if limit and fetched >= limit:
-                return
-
-            title = fallback_mapping.get(empty_doi, fallback_mapping.get(""))
-            if not title:
-                continue
-
-            async for record in self._search_by_title(title):
-                record["_lookup_method"] = "title_only"
-                yield record
-                fetched += 1
-                break
+        # Phase 3: Title-only entries
+        async for record in self._title_only_phase(
+            title_only_entries, fallback_mapping, limit, fetched
+        ):
+            yield record
 
     async def fetch_multi_filtered(
         self,

--- a/src/bioetl/infrastructure/adapters/uniprot/client.py
+++ b/src/bioetl/infrastructure/adapters/uniprot/client.py
@@ -113,6 +113,65 @@ class UniProtAdapter(BaseHttpAdapter, PaginatedFetcherMixin):
             async for record in strategy(query=query, limit=limit):
                 yield record
 
+    async def _fetch_non_protein_filtered(
+        self,
+        strategy: Any,
+        filter_ids: list[str],
+        limit: int | None,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Fetch non-protein entities by iterating through individual IDs.
+
+        Args:
+            strategy: The fetch strategy function to use.
+            filter_ids: List of IDs to fetch.
+            limit: Maximum number of records to fetch.
+
+        Yields:
+            Dictionary records for each ID.
+        """
+        fetched = 0
+        for acc_id in filter_ids:
+            if limit and fetched >= limit:
+                break
+            async for record in strategy(query=acc_id, limit=1):
+                yield record
+                fetched += 1
+                if limit and fetched >= limit:
+                    break
+
+    async def _fetch_proteins_batched(
+        self,
+        strategy: Any,
+        filter_ids: list[str],
+        filter_field: str,
+        limit: int | None,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Fetch proteins using batched OR-queries.
+
+        Args:
+            strategy: The protein fetch strategy function.
+            filter_ids: List of accession IDs to fetch.
+            filter_field: Field name for filtering (typically 'accession').
+            limit: Maximum number of records to fetch.
+
+        Yields:
+            Dictionary records matching the filter criteria.
+        """
+        fetched = 0
+        for batch_start in range(0, len(filter_ids), UNIPROT_BATCH_SIZE):
+            if limit and fetched >= limit:
+                break
+
+            batch = filter_ids[batch_start : batch_start + UNIPROT_BATCH_SIZE]
+            or_query = " OR ".join(f"{filter_field}:{acc}" for acc in batch)
+
+            batch_limit = (limit - fetched) if limit else None
+            async for record in strategy(query=or_query, limit=batch_limit):
+                yield record
+                fetched += 1
+                if limit and fetched >= limit:
+                    return
+
     async def fetch_filtered(
         self,
         entity_type: str,
@@ -147,36 +206,14 @@ class UniProtAdapter(BaseHttpAdapter, PaginatedFetcherMixin):
                 f"Supported: {', '.join(self._fetch_strategies.keys())}"
             )
 
-        # For non-protein entities, delegate to strategy with accession query
         if entity_type != "protein":
-            # Feature and sequence fetches use accession directly
-            fetched = 0
-            for acc_id in filter_ids:
-                if limit and fetched >= limit:
-                    break
-                async for record in strategy(query=acc_id, limit=1):
-                    yield record
-                    fetched += 1
-                    if limit and fetched >= limit:
-                        break
-            return
-
-        # For proteins: build OR-query in batches
-        fetched = 0
-        for batch_start in range(0, len(filter_ids), UNIPROT_BATCH_SIZE):
-            if limit and fetched >= limit:
-                break
-
-            batch = filter_ids[batch_start : batch_start + UNIPROT_BATCH_SIZE]
-            # Build OR-query: accession:P12345 OR accession:Q67890
-            or_query = " OR ".join(f"{filter_field}:{acc}" for acc in batch)
-
-            batch_limit = (limit - fetched) if limit else None
-            async for record in strategy(query=or_query, limit=batch_limit):
+            async for record in self._fetch_non_protein_filtered(strategy, filter_ids, limit):
                 yield record
-                fetched += 1
-                if limit and fetched >= limit:
-                    return
+        else:
+            async for record in self._fetch_proteins_batched(
+                strategy, filter_ids, filter_field, limit
+            ):
+                yield record
 
     async def fetch_multi_filtered(
         self,
@@ -226,6 +263,45 @@ class UniProtAdapter(BaseHttpAdapter, PaginatedFetcherMixin):
         async for record in strategy(query=combined_query, limit=limit):
             yield record
 
+    async def _do_fallback_search(
+        self,
+        entity_type: str,
+        missing_ids: list[str],
+        fallback_mapping: dict[str, str],
+        limit: int | None,
+        already_fetched: int,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Search for missing IDs using fallback values.
+
+        Args:
+            entity_type: Type of entity to fetch.
+            missing_ids: IDs not found in primary lookup.
+            fallback_mapping: Mapping from primary ID to fallback value.
+            limit: Maximum total records to fetch.
+            already_fetched: Number of records already yielded.
+
+        Yields:
+            Dictionary records found via fallback search.
+        """
+        strategy = self._fetch_strategies.get(entity_type)
+        if not strategy:
+            return
+
+        fetched = already_fetched
+        for missing_id in missing_ids:
+            if limit and fetched >= limit:
+                break
+
+            fallback_value = fallback_mapping.get(missing_id)
+            if not fallback_value:
+                continue
+
+            async for record in strategy(query=fallback_value, limit=1):
+                yield record
+                fetched += 1
+                if limit and fetched >= limit:
+                    return
+
     async def fetch_filtered_with_fallback(
         self,
         entity_type: str,
@@ -259,7 +335,6 @@ class UniProtAdapter(BaseHttpAdapter, PaginatedFetcherMixin):
         fetched = 0
         found_ids: set[str] = set()
 
-        # First: try primary lookup
         async for record in self.fetch_filtered(
             entity_type=entity_type,
             filter_ids=filter_ids,
@@ -268,33 +343,19 @@ class UniProtAdapter(BaseHttpAdapter, PaginatedFetcherMixin):
         ):
             yield record
             fetched += 1
-            # Track found IDs for fallback
             if acc := record.get("accession"):
                 found_ids.add(acc)
             if limit and fetched >= limit:
                 return
 
-        # Second: fallback search for missing IDs
         missing_ids = [fid for fid in filter_ids if fid not in found_ids]
         if not missing_ids or not fallback_mapping:
             return
 
-        for missing_id in missing_ids:
-            if limit and fetched >= limit:
-                break
-
-            fallback_value = fallback_mapping.get(missing_id)
-            if not fallback_value:
-                continue
-
-            # Search by fallback value (e.g., gene name)
-            strategy = self._fetch_strategies.get(entity_type)
-            if strategy:
-                async for record in strategy(query=fallback_value, limit=1):
-                    yield record
-                    fetched += 1
-                    if limit and fetched >= limit:
-                        return
+        async for record in self._do_fallback_search(
+            entity_type, missing_ids, fallback_mapping, limit, fetched
+        ):
+            yield record
 
     def _build_protein_fetch_params(
         self, query: str, size: int, fetched: int, limit: int | None, cursor: str | None

--- a/src/bioetl/infrastructure/audit/file_audit.py
+++ b/src/bioetl/infrastructure/audit/file_audit.py
@@ -117,6 +117,83 @@ class FileAuditAdapter:
             records_count=entry.records_count,
         )
 
+    def _process_audit_line(
+        self,
+        line: str,
+        run_id: RunID | None,
+        layer: AuditLayer | None,
+        table_name: str | None,
+        start_time: datetime | None,
+        end_time: datetime | None,
+    ) -> AuditEntry | None:
+        """Process a single audit log line and return entry if it matches filters.
+
+        Args:
+            line: Raw JSON line from audit file.
+            run_id: Filter by pipeline run ID.
+            layer: Filter by Medallion layer.
+            table_name: Filter by target table name.
+            start_time: Filter entries after this time.
+            end_time: Filter entries before this time.
+
+        Returns:
+            AuditEntry if line is valid and matches filters, None otherwise.
+        """
+        if not line.strip():
+            return None
+
+        try:
+            data = deserialize_from_json(line)
+            if not isinstance(data, dict):
+                return None
+            entry = self._parse_entry(data)
+            if self._matches_filters(entry, run_id, layer, table_name, start_time, end_time):
+                return entry
+            return None
+        except (ValueError, KeyError):
+            return None
+
+    def _process_audit_file(
+        self,
+        file_path: Path,
+        run_id: RunID | None,
+        layer: AuditLayer | None,
+        table_name: str | None,
+        start_time: datetime | None,
+        end_time: datetime | None,
+        limit: int,
+        current_count: int,
+    ) -> list[AuditEntry]:
+        """Process a single audit file and return matching entries.
+
+        Args:
+            file_path: Path to the audit file.
+            run_id: Filter by pipeline run ID.
+            layer: Filter by Medallion layer.
+            table_name: Filter by target table name.
+            start_time: Filter entries after this time.
+            end_time: Filter entries before this time.
+            limit: Maximum total entries to collect.
+            current_count: Number of entries already collected.
+
+        Returns:
+            List of matching audit entries from this file.
+        """
+        entries: list[AuditEntry] = []
+        try:
+            with open(file_path, encoding="utf-8") as f:
+                for line in f:
+                    entry = self._process_audit_line(
+                        line, run_id, layer, table_name, start_time, end_time
+                    )
+                    if entry is not None:
+                        entries.append(entry)
+                        if current_count + len(entries) >= limit:
+                            break
+        except OSError:
+            pass
+        return entries
+
     def _read_entries_sync(
         self,
         run_id: RunID | None,
@@ -144,45 +221,16 @@ class FileAuditAdapter:
         if not self.base_path.exists():
             return entries
 
-        # Get all audit files sorted by date descending (newest first)
-        audit_files = sorted(
-            self.base_path.glob("audit_*.jsonl"),
-            reverse=True,
-        )
+        audit_files = sorted(self.base_path.glob("audit_*.jsonl"), reverse=True)
 
         for file_path in audit_files:
             if len(entries) >= limit:
                 break
+            file_entries = self._process_audit_file(
+                file_path, run_id, layer, table_name, start_time, end_time, limit, len(entries)
+            )
+            entries.extend(file_entries)
 
-            try:
-                with open(file_path, encoding="utf-8") as f:
-                    for line in f:
-                        if not line.strip():
-                            continue
-
-                        try:
-                            data = deserialize_from_json(line)
-                            if not isinstance(data, dict):
-                                continue
-                            entry = self._parse_entry(data)
-
-                            # Apply filters
-                            if not self._matches_filters(
-                                entry, run_id, layer, table_name, start_time, end_time
-                            ):
-                                continue
-
-                            entries.append(entry)
-                            if len(entries) >= limit:
-                                break
-                        except (ValueError, KeyError):
-                            # Skip malformed entries
-                            continue
-            except OSError:
-                # Skip files we can't read
-                continue
-
-        # Sort by timestamp descending (newest first)
         entries.sort(key=lambda e: e.timestamp, reverse=True)
         return entries[:limit]
 


### PR DESCRIPTION
Extract helper methods to reduce cyclomatic complexity below grade C threshold:

- file_audit.py: Extract _process_audit_line and _process_audit_file from _read_entries_sync to handle line parsing and file processing separately

- uniprot/client.py: Extract _fetch_non_protein_filtered, _fetch_proteins_batched, and _do_fallback_search from fetch_filtered and fetch_filtered_with_fallback

- openalex/client.py: Extract _batch_doi_lookup and _title_only_lookup from fetch_filtered_with_fallback to handle DOI and title-only phases

- semanticscholar/adapter.py: Extract _batch_doi_phase, _title_fallback_phase, and _title_only_phase from fetch_filtered_with_fallback

All changes maintain existing behavior while improving code maintainability.