### PR TITLE
Update ChEMBL config paths to hierarchical structure

### DIFF
--- a/configs/pipelines/chembl/activity.yaml
+++ b/configs/pipelines/chembl/activity.yaml
@@ -38,17 +38,17 @@ gold_filters:
 # Entity-specific sink overrides (paths and primary_key)
 sink:
   bronze:
-    path: "data/output/bronze"
+    path: "data/output/bronze/chembl/activity"
   silver:
-    path: "data/output/silver"
+    path: "data/output/silver/chembl/activity"
     primary_key: ["activity_id"]
     partition_by: []
     csv_export:
-      path: "data/output/csv/silver"
+      path: "data/output/csv/silver/chembl/activity"
   gold:
-    path: "data/output/gold"
+    path: "data/output/gold/chembl/activity"
     csv_export:
-      path: "data/output/csv/gold"
+      path: "data/output/csv/gold/chembl/activity"
 
 # Entity-specific input filter
 input_filter:

--- a/configs/pipelines/chembl/assay.yaml
+++ b/configs/pipelines/chembl/assay.yaml
@@ -28,17 +28,17 @@ gold_filters:
 # Entity-specific sink overrides
 sink:
   bronze:
-    path: "data/output/bronze"
+    path: "data/output/bronze/chembl/assay"
   silver:
-    path: "data/output/silver"
+    path: "data/output/silver/chembl/assay"
     primary_key: ["assay_chembl_id"]
     partition_by: ["assay_type"]
     csv_export:
-      path: "data/output/csv/silver"
+      path: "data/output/csv/silver/chembl/assay"
   gold:
-    path: "data/output/gold"
+    path: "data/output/gold/chembl/assay"
     csv_export:
-      path: "data/output/csv/gold"
+      path: "data/output/csv/gold/chembl/assay"
 
 # Entity-specific input filter
 input_filter:

--- a/configs/pipelines/chembl/assay_parameters.yaml
+++ b/configs/pipelines/chembl/assay_parameters.yaml
@@ -25,17 +25,17 @@ gold_filters:
 # Entity-specific sink overrides
 sink:
   bronze:
-    path: "data/output/bronze"
+    path: "data/output/bronze/chembl/assay_parameters"
   silver:
-    path: "data/output/silver"
+    path: "data/output/silver/chembl/assay_parameters"
     primary_key: ["assay_param_id"]
     partition_by: ["type"]
     csv_export:
-      path: "data/output/csv/silver"
+      path: "data/output/csv/silver/chembl/assay_parameters"
   gold:
-    path: "data/output/gold"
+    path: "data/output/gold/chembl/assay_parameters"
     csv_export:
-      path: "data/output/csv/gold"
+      path: "data/output/csv/gold/chembl/assay_parameters"
 
 # Entity-specific input filter
 input_filter:

--- a/configs/pipelines/chembl/cell_line.yaml
+++ b/configs/pipelines/chembl/cell_line.yaml
@@ -23,23 +23,23 @@ gold_filters:
 # Entity-specific sink overrides
 sink:
   bronze:
-    path: "data/output/bronze"
+    path: "data/output/bronze/chembl/cell_line"
   silver:
-    path: "data/output/silver"
+    path: "data/output/silver/chembl/cell_line"
     primary_key: ["cell_chembl_id"]
     partition_by: []
     sort_by:
       columns: ["cell_chembl_id"]
       ascending: true
     csv_export:
-      path: "data/output/csv/silver"
+      path: "data/output/csv/silver/chembl/cell_line"
   gold:
-    path: "data/output/gold"
+    path: "data/output/gold/chembl/cell_line"
     sort_by:
       columns: ["cell_chembl_id", "cell_name"]
       ascending: true
     csv_export:
-      path: "data/output/csv/gold"
+      path: "data/output/csv/gold/chembl/cell_line"
 
 # Entity-specific input filter
 input_filter:

--- a/configs/pipelines/chembl/compound_record.yaml
+++ b/configs/pipelines/chembl/compound_record.yaml
@@ -27,23 +27,23 @@ gold_filters:
 # Entity-specific sink overrides
 sink:
   bronze:
-    path: "data/output/bronze"
+    path: "data/output/bronze/chembl/compound_record"
   silver:
-    path: "data/output/silver"
+    path: "data/output/silver/chembl/compound_record"
     primary_key: ["record_id"]
     partition_by: []
     sort_by:
       columns: ["record_id"]
       ascending: true
     csv_export:
-      path: "data/output/csv/silver"
+      path: "data/output/csv/silver/chembl/compound_record"
   gold:
-    path: "data/output/gold"
+    path: "data/output/gold/chembl/compound_record"
     sort_by:
       columns: ["molecule_chembl_id", "document_chembl_id", "record_id"]
       ascending: true
     csv_export:
-      path: "data/output/csv/gold"
+      path: "data/output/csv/gold/chembl/compound_record"
 
 # Entity-specific input filter
 # NOTE: Disabled because ChEMBL API doesn't support filtering by record_id.

--- a/configs/pipelines/chembl/molecule.yaml
+++ b/configs/pipelines/chembl/molecule.yaml
@@ -27,17 +27,17 @@ gold_filters:
 # Entity-specific sink overrides
 sink:
   bronze:
-    path: "data/output/bronze"
+    path: "data/output/bronze/chembl/molecule"
   silver:
-    path: "data/output/silver"
+    path: "data/output/silver/chembl/molecule"
     primary_key: ["molecule_chembl_id"]
     partition_by: ["molecule_type"]
     csv_export:
-      path: "data/output/csv/silver"
+      path: "data/output/csv/silver/chembl/molecule"
   gold:
-    path: "data/output/gold"
+    path: "data/output/gold/chembl/molecule"
     csv_export:
-      path: "data/output/csv/gold"
+      path: "data/output/csv/gold/chembl/molecule"
 
 # Entity-specific input filter
 input_filter:

--- a/configs/pipelines/chembl/protein_class.yaml
+++ b/configs/pipelines/chembl/protein_class.yaml
@@ -30,23 +30,23 @@ gold_filters:
 # Entity-specific sink overrides
 sink:
   bronze:
-    path: "data/output/bronze"
+    path: "data/output/bronze/chembl/protein_class"
   silver:
-    path: "data/output/silver"
+    path: "data/output/silver/chembl/protein_class"
     primary_key: ["protein_class_id"]
     partition_by: ["class_level"]
     sort_by:
       columns: ["protein_class_id"]
       ascending: true
     csv_export:
-      path: "data/output/csv/silver"
+      path: "data/output/csv/silver/chembl/protein_class"
   gold:
-    path: "data/output/gold"
+    path: "data/output/gold/chembl/protein_class"
     sort_by:
       columns: ["class_level", "sort_order", "protein_class_id"]
       ascending: true
     csv_export:
-      path: "data/output/csv/gold"
+      path: "data/output/csv/gold/chembl/protein_class"
 
 # No input filter for reference table (full load)
 input_filter:

--- a/configs/pipelines/chembl/publication.yaml
+++ b/configs/pipelines/chembl/publication.yaml
@@ -32,17 +32,17 @@ gold_filters:
 # Entity-specific sink overrides
 sink:
   bronze:
-    path: "data/output/bronze"
+    path: "data/output/bronze/chembl/document"
   silver:
-    path: "data/output/silver"
+    path: "data/output/silver/chembl/document"
     primary_key: ["document_chembl_id"]
     partition_by: ["doc_type"]
     csv_export:
-      path: "data/output/csv/silver"
+      path: "data/output/csv/silver/chembl/document"
   gold:
-    path: "data/output/gold"
+    path: "data/output/gold/chembl/document"
     csv_export:
-      path: "data/output/csv/gold"
+      path: "data/output/csv/gold/chembl/document"
 
 # Entity-specific input filter
 input_filter:

--- a/configs/pipelines/chembl/publication_similarity.yaml
+++ b/configs/pipelines/chembl/publication_similarity.yaml
@@ -31,17 +31,17 @@ gold_filters:
 # Entity-specific sink overrides
 sink:
   bronze:
-    path: "data/output/bronze"
+    path: "data/output/bronze/chembl/document_similarity"
   silver:
-    path: "data/output/silver"
+    path: "data/output/silver/chembl/document_similarity"
     primary_key: ["sim_id"]
     partition_by: []  # No good partition key
     csv_export:
-      path: "data/output/csv/silver"
+      path: "data/output/csv/silver/chembl/document_similarity"
   gold:
-    path: "data/output/gold"
+    path: "data/output/gold/chembl/document_similarity"
     csv_export:
-      path: "data/output/csv/gold"
+      path: "data/output/csv/gold/chembl/document_similarity"
 
 # No input filter needed - load full dataset
 input_filter:

--- a/configs/pipelines/chembl/publication_term.yaml
+++ b/configs/pipelines/chembl/publication_term.yaml
@@ -31,17 +31,17 @@ gold_filters:
 # Entity-specific sink overrides
 sink:
   bronze:
-    path: "data/output/bronze"
+    path: "data/output/bronze/chembl/document_term"
   silver:
-    path: "data/output/silver"
+    path: "data/output/silver/chembl/document_term"
     primary_key: ["entity_id"]
     partition_by: ["term_type"]
     csv_export:
-      path: "data/output/csv/silver"
+      path: "data/output/csv/silver/chembl/document_term"
   gold:
-    path: "data/output/gold"
+    path: "data/output/gold/chembl/document_term"
     csv_export:
-      path: "data/output/csv/gold"
+      path: "data/output/csv/gold/chembl/document_term"
 
 # Entity-specific input filter
 # PublicationTermDataSource delegates FilterableDataSourcePort to wrapped ChEMBL adapter

--- a/configs/pipelines/chembl/target.yaml
+++ b/configs/pipelines/chembl/target.yaml
@@ -36,23 +36,23 @@ gold_filters:
 # Entity-specific sink overrides
 sink:
   bronze:
-    path: "data/output/bronze"
+    path: "data/output/bronze/chembl/target"
   silver:
-    path: "data/output/silver"
+    path: "data/output/silver/chembl/target"
     primary_key: ["target_chembl_id"]
     partition_by: ["target_type"]
     sort_by:
       columns: ["target_chembl_id"]
       ascending: true
     csv_export:
-      path: "data/output/csv/silver"
+      path: "data/output/csv/silver/chembl/target"
   gold:
-    path: "data/output/gold"
+    path: "data/output/gold/chembl/target"
     sort_by:
       columns: ["target_chembl_id", "pref_name"]
       ascending: true
     csv_export:
-      path: "data/output/csv/gold"
+      path: "data/output/csv/gold/chembl/target"
 
 # Entity-specific input filter
 input_filter:

--- a/configs/pipelines/chembl/target_component.yaml
+++ b/configs/pipelines/chembl/target_component.yaml
@@ -24,17 +24,17 @@ gold_filters:
 # Entity-specific sink overrides
 sink:
   bronze:
-    path: "data/output/bronze"
+    path: "data/output/bronze/chembl/target_component"
   silver:
-    path: "data/output/silver"
+    path: "data/output/silver/chembl/target_component"
     primary_key: ["component_id"]
     partition_by: ["organism"]
     csv_export:
-      path: "data/output/csv/silver"
+      path: "data/output/csv/silver/chembl/target_component"
   gold:
-    path: "data/output/gold"
+    path: "data/output/gold/chembl/target_component"
     csv_export:
-      path: "data/output/csv/gold"
+      path: "data/output/csv/gold/chembl/target_component"
 
 # Entity-specific input filter
 input_filter:


### PR DESCRIPTION
Update all 12 ChEMBL pipeline configs with provider/entity path hierarchy:
- bronze: data/output/bronze/chembl/{entity}
- silver: data/output/silver/chembl/{entity}
- gold: data/output/gold/chembl/{entity}
- csv_export: data/output/csv/{tier}/chembl/{entity}

This improves data organization by separating entities into dedicated directories instead of flat structure.