### PR TITLE
Update paths in entity config files

### DIFF
--- a/configs/pipelines/crossref/publication.yaml
+++ b/configs/pipelines/crossref/publication.yaml
@@ -29,19 +29,17 @@ gold_filters:
 # Entity-specific sink overrides
 sink:
   bronze:
-    path: "data/output/bronze"
+    path: "data/output/bronze/crossref/work"
   silver:
-    path: "data/output/silver"
+    path: "data/output/silver/crossref/work"
     primary_key: ["doi"]
     partition_by: []
     csv_export:
-      path: "data/output/csv/silver"
+      path: "data/output/csv/silver/crossref/work"
   gold:
-    path: "data/output/gold"
-
-
+    path: "data/output/gold/crossref/work"
     csv_export:
-      path: "data/output/csv/gold"
+      path: "data/output/csv/gold/crossref/work"
 
 # Entity-specific input filter for batch DOI resolution
 input_filter:

--- a/configs/pipelines/openalex/publication.yaml
+++ b/configs/pipelines/openalex/publication.yaml
@@ -36,17 +36,17 @@ gold_filters:
 # Entity-specific sink overrides
 sink:
   bronze:
-    path: "data/output/bronze"
+    path: "data/output/bronze/openalex/publication"
   silver:
-    path: "data/output/silver"
+    path: "data/output/silver/openalex/publication"
     primary_key: ["openalex_id"]
     partition_by: ["year"]
     csv_export:
-      path: "data/output/csv/silver"
+      path: "data/output/csv/silver/openalex/publication"
   gold:
-    path: "data/output/gold"
+    path: "data/output/gold/openalex/publication"
     csv_export:
-      path: "data/output/csv/gold"
+      path: "data/output/csv/gold/openalex/publication"
 
 # Input filter for batch DOI resolution with title fallback
 input_filter:

--- a/configs/pipelines/pubchem/compound.yaml
+++ b/configs/pipelines/pubchem/compound.yaml
@@ -25,17 +25,17 @@ gold_filters:
 # Entity-specific sink overrides
 sink:
   bronze:
-    path: "data/output/bronze"
+    path: "data/output/bronze/pubchem/compound"
   silver:
-    path: "data/output/silver"
+    path: "data/output/silver/pubchem/compound"
     primary_key: ["cid"]
     partition_by: ["batch_date"]
     csv_export:
-      path: "data/output/csv/silver"
+      path: "data/output/csv/silver/pubchem/compound"
   gold:
-    path: "data/output/gold"
+    path: "data/output/gold/pubchem/compound"
     csv_export:
-      path: "data/output/csv/gold"
+      path: "data/output/csv/gold/pubchem/compound"
 
 # Entity-specific input filter - SMILES-based filtering (primary mode)
 input_filter:

--- a/configs/pipelines/pubmed/publications.yaml
+++ b/configs/pipelines/pubmed/publications.yaml
@@ -31,17 +31,17 @@ gold_filters:
 # Entity-specific sink overrides
 sink:
   bronze:
-    path: "data/output/bronze"
+    path: "data/output/bronze/pubmed/publication"
   silver:
-    path: "data/output/silver"
+    path: "data/output/silver/pubmed/publication"
     primary_key: ["pmid"]
     partition_by: ["pub_year"]
     csv_export:
-      path: "data/output/csv/silver"
+      path: "data/output/csv/silver/pubmed/publication"
   gold:
-    path: "data/output/gold"
+    path: "data/output/gold/pubmed/publication"
     csv_export:
-      path: "data/output/csv/gold"
+      path: "data/output/csv/gold/pubmed/publication"
 
 # Entity-specific input filter
 # PubMed adapter implements FilterableDataSourcePort with PMID batch fetching

--- a/configs/pipelines/semanticscholar/publication.yaml
+++ b/configs/pipelines/semanticscholar/publication.yaml
@@ -31,17 +31,17 @@ gold_filters:
 # Entity-specific sink configuration
 sink:
   bronze:
-    path: "data/output/bronze"
+    path: "data/output/bronze/semanticscholar/publication"
   silver:
-    path: "data/output/silver"
+    path: "data/output/silver/semanticscholar/publication"
     primary_key: ["paper_id"]
     partition_by: ["year"]
     csv_export:
-      path: "data/output/csv/silver"
+      path: "data/output/csv/silver/semanticscholar/publication"
   gold:
-    path: "data/output/gold"
+    path: "data/output/gold/semanticscholar/publication"
     csv_export:
-      path: "data/output/csv/gold"
+      path: "data/output/csv/gold/semanticscholar/publication"
 
 # Input filter for batch DOI resolution with title fallback
 input_filter:

--- a/configs/pipelines/uniprot/idmapping.yaml
+++ b/configs/pipelines/uniprot/idmapping.yaml
@@ -45,17 +45,17 @@ sink:
   bronze:
     # ID Mapping doesn't write Bronze (data comes from API, not raw files)
     # NOTE: enabled: false is not yet implemented in code, so Bronze is still written
-    path: "data/output/bronze"
+    path: "data/output/bronze/uniprot/idmapping"
   silver:
-    path: "data/output/silver"
+    path: "data/output/silver/uniprot/idmapping"
     primary_key: ["target_chembl_id"]
     partition_by: []  # No partitioning - small dataset
     csv_export:
-      path: "data/output/csv/silver"
+      path: "data/output/csv/silver/uniprot/idmapping"
   gold:
-    path: "data/output/gold"
+    path: "data/output/gold/uniprot/idmapping"
     csv_export:
-      path: "data/output/csv/gold"
+      path: "data/output/csv/gold/uniprot/idmapping"
 
 # Gold filters - pass all records (including not_found)
 # Users may want to filter in downstream analysis

--- a/configs/pipelines/uniprot/protein.yaml
+++ b/configs/pipelines/uniprot/protein.yaml
@@ -27,17 +27,17 @@ gold_filters:
 # Entity-specific sink overrides
 sink:
   bronze:
-    path: "data/output/bronze"
+    path: "data/output/bronze/uniprot/protein"
   silver:
-    path: "data/output/silver"
+    path: "data/output/silver/uniprot/protein"
     primary_key: ["accession"]
     partition_by: ["organism"]
     csv_export:
-      path: "data/output/csv/silver"
+      path: "data/output/csv/silver/uniprot/protein"
   gold:
-    path: "data/output/gold"
+    path: "data/output/gold/uniprot/protein"
     csv_export:
-      path: "data/output/csv/gold"
+      path: "data/output/csv/gold/uniprot/protein"
 
 # Entity-specific input filter
 # UniProt adapter implements FilterableDataSourcePort with OR-query batching


### PR DESCRIPTION
…ovider/entity

Update sink paths in 7 pipeline config files to follow the unified {provider}/{entity} directory structure pattern:

- crossref/publication.yaml: crossref/work
- openalex/publication.yaml: openalex/publication
- pubchem/compound.yaml: pubchem/compound
- pubmed/publications.yaml: pubmed/publication
- semanticscholar/publication.yaml: semanticscholar/publication
- uniprot/idmapping.yaml: uniprot/idmapping
- uniprot/protein.yaml: uniprot/protein