### PR TITLE
Add sort_by to ChEMBL configs part one

### DIFF
--- a/configs/pipelines/chembl/activity.yaml
+++ b/configs/pipelines/chembl/activity.yaml
@@ -43,10 +43,16 @@ sink:
     path: "data/output/silver/chembl/activity"
     primary_key: ["activity_id"]
     partition_by: []
+    sort_by:
+      columns: ["activity_id"]
+      ascending: true
     csv_export:
       path: "data/output/csv/silver/chembl/activity"
   gold:
     path: "data/output/gold/chembl/activity"
+    sort_by:
+      columns: ["activity_id"]
+      ascending: true
     csv_export:
       path: "data/output/csv/gold/chembl/activity"
 

--- a/configs/pipelines/chembl/assay.yaml
+++ b/configs/pipelines/chembl/assay.yaml
@@ -33,10 +33,16 @@ sink:
     path: "data/output/silver/chembl/assay"
     primary_key: ["assay_chembl_id"]
     partition_by: ["assay_type"]
+    sort_by:
+      columns: ["assay_chembl_id"]
+      ascending: true
     csv_export:
       path: "data/output/csv/silver/chembl/assay"
   gold:
     path: "data/output/gold/chembl/assay"
+    sort_by:
+      columns: ["assay_chembl_id"]
+      ascending: true
     csv_export:
       path: "data/output/csv/gold/chembl/assay"
 

--- a/configs/pipelines/chembl/assay_parameters.yaml
+++ b/configs/pipelines/chembl/assay_parameters.yaml
@@ -30,10 +30,16 @@ sink:
     path: "data/output/silver/chembl/assay_parameters"
     primary_key: ["assay_param_id"]
     partition_by: ["type"]
+    sort_by:
+      columns: ["assay_param_id"]
+      ascending: true
     csv_export:
       path: "data/output/csv/silver/chembl/assay_parameters"
   gold:
     path: "data/output/gold/chembl/assay_parameters"
+    sort_by:
+      columns: ["assay_param_id"]
+      ascending: true
     csv_export:
       path: "data/output/csv/gold/chembl/assay_parameters"
 

--- a/configs/pipelines/chembl/molecule.yaml
+++ b/configs/pipelines/chembl/molecule.yaml
@@ -32,10 +32,16 @@ sink:
     path: "data/output/silver/chembl/molecule"
     primary_key: ["molecule_chembl_id"]
     partition_by: ["molecule_type"]
+    sort_by:
+      columns: ["molecule_chembl_id"]
+      ascending: true
     csv_export:
       path: "data/output/csv/silver/chembl/molecule"
   gold:
     path: "data/output/gold/chembl/molecule"
+    sort_by:
+      columns: ["molecule_chembl_id"]
+      ascending: true
     csv_export:
       path: "data/output/csv/gold/chembl/molecule"
 


### PR DESCRIPTION
Add sort_by configuration to silver and gold sinks for activity, assay, assay_parameters, and molecule entities. Sorting by primary_key ensures deterministic output per ADR-014.