### PR TITLE
Add sort_by to ChEMBL config files

### DIFF
--- a/configs/pipelines/chembl/publication.yaml
+++ b/configs/pipelines/chembl/publication.yaml
@@ -37,10 +37,16 @@ sink:
     path: "data/output/silver/chembl/document"
     primary_key: ["document_chembl_id"]
     partition_by: ["doc_type"]
+    sort_by:
+      columns: ["document_chembl_id"]
+      ascending: true
     csv_export:
       path: "data/output/csv/silver/chembl/document"
   gold:
     path: "data/output/gold/chembl/document"
+    sort_by:
+      columns: ["document_chembl_id"]
+      ascending: true
     csv_export:
       path: "data/output/csv/gold/chembl/document"
 

--- a/configs/pipelines/chembl/publication_similarity.yaml
+++ b/configs/pipelines/chembl/publication_similarity.yaml
@@ -36,10 +36,16 @@ sink:
     path: "data/output/silver/chembl/document_similarity"
     primary_key: ["sim_id"]
     partition_by: []  # No good partition key
+    sort_by:
+      columns: ["sim_id"]
+      ascending: true
     csv_export:
       path: "data/output/csv/silver/chembl/document_similarity"
   gold:
     path: "data/output/gold/chembl/document_similarity"
+    sort_by:
+      columns: ["sim_id"]
+      ascending: true
     csv_export:
       path: "data/output/csv/gold/chembl/document_similarity"
 

--- a/configs/pipelines/chembl/publication_term.yaml
+++ b/configs/pipelines/chembl/publication_term.yaml
@@ -36,10 +36,16 @@ sink:
     path: "data/output/silver/chembl/document_term"
     primary_key: ["entity_id"]
     partition_by: ["term_type"]
+    sort_by:
+      columns: ["entity_id"]
+      ascending: true
     csv_export:
       path: "data/output/csv/silver/chembl/document_term"
   gold:
     path: "data/output/gold/chembl/document_term"
+    sort_by:
+      columns: ["entity_id"]
+      ascending: true
     csv_export:
       path: "data/output/csv/gold/chembl/document_term"
 

--- a/configs/pipelines/chembl/target_component.yaml
+++ b/configs/pipelines/chembl/target_component.yaml
@@ -29,10 +29,16 @@ sink:
     path: "data/output/silver/chembl/target_component"
     primary_key: ["component_id"]
     partition_by: ["organism"]
+    sort_by:
+      columns: ["component_id"]
+      ascending: true
     csv_export:
       path: "data/output/csv/silver/chembl/target_component"
   gold:
     path: "data/output/gold/chembl/target_component"
+    sort_by:
+      columns: ["component_id"]
+      ascending: true
     csv_export:
       path: "data/output/csv/gold/chembl/target_component"
 


### PR DESCRIPTION
Add deterministic sort_by configuration to:
- publication.yaml (document_chembl_id)
- publication_similarity.yaml (sim_id)
- publication_term.yaml (entity_id)
- target_component.yaml (component_id)

Sort columns match primary_keys for consistent output ordering.