### PR TITLE
Add sort_by to non-ChEMBL configs

### DIFF
--- a/configs/pipelines/crossref/publication.yaml
+++ b/configs/pipelines/crossref/publication.yaml
@@ -34,10 +34,16 @@ sink:
     path: "data/output/silver/crossref/work"
     primary_key: ["doi"]
     partition_by: []
+    sort_by:
+      columns: ["doi"]
+      ascending: true
     csv_export:
       path: "data/output/csv/silver/crossref/work"
   gold:
     path: "data/output/gold/crossref/work"
+    sort_by:
+      columns: ["doi"]
+      ascending: true
     csv_export:
       path: "data/output/csv/gold/crossref/work"
 

--- a/configs/pipelines/openalex/publication.yaml
+++ b/configs/pipelines/openalex/publication.yaml
@@ -41,10 +41,16 @@ sink:
     path: "data/output/silver/openalex/publication"
     primary_key: ["openalex_id"]
     partition_by: ["year"]
+    sort_by:
+      columns: ["openalex_id"]
+      ascending: true
     csv_export:
       path: "data/output/csv/silver/openalex/publication"
   gold:
     path: "data/output/gold/openalex/publication"
+    sort_by:
+      columns: ["openalex_id"]
+      ascending: true
     csv_export:
       path: "data/output/csv/gold/openalex/publication"
 

--- a/configs/pipelines/pubchem/compound.yaml
+++ b/configs/pipelines/pubchem/compound.yaml
@@ -30,10 +30,16 @@ sink:
     path: "data/output/silver/pubchem/compound"
     primary_key: ["cid"]
     partition_by: ["batch_date"]
+    sort_by:
+      columns: ["cid"]
+      ascending: true
     csv_export:
       path: "data/output/csv/silver/pubchem/compound"
   gold:
     path: "data/output/gold/pubchem/compound"
+    sort_by:
+      columns: ["cid"]
+      ascending: true
     csv_export:
       path: "data/output/csv/gold/pubchem/compound"
 

--- a/configs/pipelines/pubmed/publications.yaml
+++ b/configs/pipelines/pubmed/publications.yaml
@@ -36,10 +36,16 @@ sink:
     path: "data/output/silver/pubmed/publication"
     primary_key: ["pmid"]
     partition_by: ["pub_year"]
+    sort_by:
+      columns: ["pmid"]
+      ascending: true
     csv_export:
       path: "data/output/csv/silver/pubmed/publication"
   gold:
     path: "data/output/gold/pubmed/publication"
+    sort_by:
+      columns: ["pmid"]
+      ascending: true
     csv_export:
       path: "data/output/csv/gold/pubmed/publication"
 

--- a/configs/pipelines/semanticscholar/publication.yaml
+++ b/configs/pipelines/semanticscholar/publication.yaml
@@ -36,10 +36,16 @@ sink:
     path: "data/output/silver/semanticscholar/publication"
     primary_key: ["paper_id"]
     partition_by: ["year"]
+    sort_by:
+      columns: ["paper_id"]
+      ascending: true
     csv_export:
       path: "data/output/csv/silver/semanticscholar/publication"
   gold:
     path: "data/output/gold/semanticscholar/publication"
+    sort_by:
+      columns: ["paper_id"]
+      ascending: true
     csv_export:
       path: "data/output/csv/gold/semanticscholar/publication"
 

--- a/configs/pipelines/uniprot/idmapping.yaml
+++ b/configs/pipelines/uniprot/idmapping.yaml
@@ -50,10 +50,16 @@ sink:
     path: "data/output/silver/uniprot/idmapping"
     primary_key: ["target_chembl_id"]
     partition_by: []  # No partitioning - small dataset
+    sort_by:
+      columns: ["target_chembl_id"]
+      ascending: true
     csv_export:
       path: "data/output/csv/silver/uniprot/idmapping"
   gold:
     path: "data/output/gold/uniprot/idmapping"
+    sort_by:
+      columns: ["target_chembl_id"]
+      ascending: true
     csv_export:
       path: "data/output/csv/gold/uniprot/idmapping"
 

--- a/configs/pipelines/uniprot/protein.yaml
+++ b/configs/pipelines/uniprot/protein.yaml
@@ -32,10 +32,16 @@ sink:
     path: "data/output/silver/uniprot/protein"
     primary_key: ["accession"]
     partition_by: ["organism"]
+    sort_by:
+      columns: ["accession"]
+      ascending: true
     csv_export:
       path: "data/output/csv/silver/uniprot/protein"
   gold:
     path: "data/output/gold/uniprot/protein"
+    sort_by:
+      columns: ["accession"]
+      ascending: true
     csv_export:
       path: "data/output/csv/gold/uniprot/protein"
 


### PR DESCRIPTION
Add sort_by configuration for deterministic output ordering to all 7 non-ChEMBL pipeline configs:

- crossref/publication.yaml: sort by doi
- openalex/publication.yaml: sort by openalex_id
- pubchem/compound.yaml: sort by cid
- pubmed/publications.yaml: sort by pmid
- semanticscholar/publication.yaml: sort by paper_id
- uniprot/idmapping.yaml: sort by target_chembl_id
- uniprot/protein.yaml: sort by accession

Each config now has sort_by in both silver and gold sink sections with ascending=true, matching the pattern established in ChEMBL configs.