### PR TITLE
Document batch size variations and rationale

### DIFF
--- a/configs/pipelines/chembl/assay_parameters.yaml
+++ b/configs/pipelines/chembl/assay_parameters.yaml
@@ -49,4 +49,4 @@ input_filter:
   source_path: "data/input/assay_parameters.csv"
   column_name: "assay_param_id"
   filter_field: "assay_param_id"
-  batch_size: 1000
+  batch_size: 1000  # Reference table, full load - high batch for speed

--- a/configs/pipelines/chembl/protein_class.yaml
+++ b/configs/pipelines/chembl/protein_class.yaml
@@ -17,7 +17,7 @@ gold_table: chembl_protein_class
 source_file: ../../sources/chembl.yaml
 
 # Full load for reference table
-batch_size: 500
+batch_size: 500  # Reference table (~1.5K records), full load
 checkpoint_interval: 500
 
 # Entity-specific gold filters - exclude deprecated records

--- a/configs/pipelines/crossref/publication.yaml
+++ b/configs/pipelines/crossref/publication.yaml
@@ -47,6 +47,6 @@ input_filter:
   source_path: "data/input/dois.csv"
   column_name: "doi"
   filter_field: "doi"
-  batch_size: 50
+  batch_size: 50  # Polite pool API - conservative batch size
   fallback_column: "title"  # Search by title if DOI not found (404)
 

--- a/configs/pipelines/openalex/publication.yaml
+++ b/configs/pipelines/openalex/publication.yaml
@@ -21,7 +21,7 @@ source_file: ../../sources/openalex.yaml
 # Pipeline-specific source configuration
 source:
   email: "${BIOETL_OPENALEX_EMAIL}"  # Required for polite pool
-  batch_size: 50
+  batch_size: 50  # Polite pool API - conservative batch size
 
 # Entity-specific gold filters
 gold_filters:
@@ -54,5 +54,5 @@ input_filter:
   source_path: "data/input/dois.csv"
   column_name: "doi"
   filter_field: "doi"
-  batch_size: 50
+  batch_size: 50  # Polite pool API - conservative batch size
   fallback_column: "title"  # Search by title if DOI not found or empty

--- a/configs/pipelines/pubchem/compound.yaml
+++ b/configs/pipelines/pubchem/compound.yaml
@@ -43,4 +43,4 @@ input_filter:
   source_path: "data/input/molecule.csv"
   column_name: "canonical_smiles"
   filter_field: "smiles"
-  batch_size: 1  # SMILES search is per-compound due to API limitations
+  batch_size: 1  # SMILES search is per-compound due to PubChem API limitations


### PR DESCRIPTION
Add inline comments explaining non-standard batch_size values:
- chembl/assay_parameters: 1000 (reference table, full load)
- chembl/protein_class: 500 (~1.5K records, full load)
- pubchem/compound: 1 (PubChem API SMILES limitation)
- crossref/publication: 50 (polite pool API)
- openalex/publication: 50 (polite pool API)