### PR TITLE
Remove deprecated code from BioETL

### DIFF
--- a/src/bioetl/composition/factories/http_client_factory.py
+++ b/src/bioetl/composition/factories/http_client_factory.py
@@ -10,7 +10,7 @@ Configuration Priority:
 
 SRP Compliance:
 - Creates UnifiedHTTPClient with injected RateLimiterPort and CircuitBreakerPort
-- RetryPolicy is configured via domain value object
+- RetryConfig is configured via domain value object
 - Observability components (tracer, metrics, logger) are injected for correlation
 """
 

--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -197,7 +197,7 @@ from bioetl.domain.ports import (
 )
 
 # Resilience (domain value objects)
-from bioetl.domain.resilience import CircuitBreakerConfig, RetryConfig, RetryPolicy
+from bioetl.domain.resilience import CircuitBreakerConfig, RetryConfig
 
 # Serialization (centralized JSON per RULES.md §2.8.1)
 from bioetl.domain.serialization import (
@@ -430,7 +430,6 @@ __all__ = [
     # Resilience
     "CircuitBreakerConfig",
     "RetryConfig",
-    "RetryPolicy",
     # Services
     "IdentityService",
     # Serialization (centralized JSON)

--- a/src/bioetl/domain/resilience.py
+++ b/src/bioetl/domain/resilience.py
@@ -143,10 +143,6 @@ class CircuitBreakerConfig:
     recovery_timeout: int = 300  # 5 minutes
 
 
-# Backward compatibility alias
-RetryPolicy = RetryConfig
-
-
 @dataclass(frozen=True, slots=True)
 class AdapterConfig:
     """Configuration for data source adapters.

--- a/src/bioetl/infrastructure/adapters/http/__init__.py
+++ b/src/bioetl/infrastructure/adapters/http/__init__.py
@@ -4,7 +4,7 @@ Provides:
 - TokenBucket: Rate limiting (implements RateLimiterPort)
 - CircuitBreaker: Fault tolerance (implements CircuitBreakerPort)
 - UnifiedHTTPClient: Async HTTP client with rate limiting and circuit breaker
-- RetryConfig: Backward compatibility alias for RetryPolicy
+- RetryConfig: Configuration for retry strategies
 - ProviderHealthMonitor: Centralized provider health monitoring (RULES.md §3.5)
 - ProviderHealthTracker: Per-provider health state machine wrapper
 - HealthAdjustedConfig: Health-based client configuration adjustments
@@ -22,11 +22,7 @@ from bioetl.infrastructure.adapters.http.health_monitor import (
 )
 from bioetl.infrastructure.adapters.http.rate_limiter import TokenBucket
 
-# Backward compatibility alias
-AdjustedClientConfig = HealthAdjustedConfig
-
 __all__ = [
-    "AdjustedClientConfig",  # Backward compatibility alias
     "CircuitBreaker",
     "HealthAdjustedConfig",
     "ProviderHealthMonitor",

--- a/src/bioetl/infrastructure/adapters/http/client.py
+++ b/src/bioetl/infrastructure/adapters/http/client.py
@@ -4,12 +4,12 @@ Implements RULES.md Section 4.1 HTTP client requirements:
 - Async support (httpx)
 - Rate limiting (RateLimiterPort)
 - Circuit breaker (CircuitBreakerPort)
-- Exponential backoff with jitter (RetryPolicy)
+- Exponential backoff with jitter (RetryConfig)
 
 SRP Compliance:
 - RateLimiterPort: Handles rate limiting (injected)
 - CircuitBreakerPort: Handles fault tolerance (injected)
-- RetryPolicy: Handles retry configuration (domain value object)
+- RetryConfig: Handles retry configuration (domain value object)
 - UnifiedHTTPClient: Coordinates HTTP communication
 """
 
@@ -38,12 +38,8 @@ if TYPE_CHECKING:
     from bioetl.domain.types import RunID
 
 
-# Backward compatibility aliases
-RetryPolicy = RetryConfig
-
 __all__ = [
     "RetryConfig",
-    "RetryPolicy",
     "UnifiedHTTPClient",
 ]
 

--- a/src/bioetl/infrastructure/adapters/http/health_monitor.py
+++ b/src/bioetl/infrastructure/adapters/http/health_monitor.py
@@ -77,10 +77,6 @@ class HealthAdjustedConfig:
         return max(minimum, base_batch_size // self.batch_size_divisor)
 
 
-# Backward compatibility alias (used by tests importing directly from module)
-AdjustedClientConfig = HealthAdjustedConfig
-
-
 @dataclass
 class ProviderHealthState:
     """Tracks health state for a single provider.

--- a/tests/e2e/test_resilience_scenarios_e2e.py
+++ b/tests/e2e/test_resilience_scenarios_e2e.py
@@ -326,9 +326,9 @@ async def test_retry_policy_deterministic_jitter():
     - Jitter should be deterministic for debugging
     - Same inputs should produce same delay
     """
-    from bioetl.domain.resilience import RetryPolicy
+    from bioetl.domain.resilience import RetryConfig
 
-    policy = RetryPolicy(
+    policy = RetryConfig(
         max_attempts=3,
         base_delay=1.0,
         multiplier=2.0,
@@ -350,9 +350,9 @@ async def test_retry_policy_exponential_backoff():
 
     Delays should increase exponentially with each attempt.
     """
-    from bioetl.domain.resilience import RetryPolicy
+    from bioetl.domain.resilience import RetryConfig
 
-    policy = RetryPolicy(
+    policy = RetryConfig(
         max_attempts=5,
         base_delay=1.0,
         multiplier=2.0,


### PR DESCRIPTION
Remove deprecated aliases that were kept for backward compatibility:

Removed:
- RetryPolicy alias → use RetryConfig directly (domain/resilience.py)
- RetryPolicy re-exports from domain/__init__.py and http/client.py
- AdjustedClientConfig alias → use HealthAdjustedConfig directly

Migrated:
- Updated e2e tests to use RetryConfig instead of RetryPolicy

Note: DataSourceRegistry was NOT removed as it still has active production usage in pipeline_factory.py. It remains as a facade over ProviderRegistry.