### PR TITLE
Unify entity naming across BioETL codebase

### DIFF
--- a/src/bioetl/domain/entities/__init__.py
+++ b/src/bioetl/domain/entities/__init__.py
@@ -27,6 +27,10 @@ from bioetl.domain.entities.chembl import (
     ActivityRecord,
     AssayRecord,
     CellLineRecord,
+    # Canonical names (ADR-024)
+    ChemblPublicationRecord,
+    ChemblPublicationTermRecord,
+    # Deprecated aliases (backward compatibility)
     DocumentRecord,
     DocumentTermRecord,
     MoleculeRecord,
@@ -54,8 +58,11 @@ from bioetl.domain.entities.crossref import PublicationEntity, PublicationRecord
 
 # PubChem DTO + Entity
 from bioetl.domain.entities.pubchem import (
+    # Deprecated alias (backward compatibility)
     PubChemCompoundRecord,
     PubchemMolecule,
+    # Canonical names (ADR-024)
+    PubchemMoleculeRecord,
 )
 
 # PubMed DTO + Entity
@@ -79,7 +86,11 @@ __all__ = [
     "CellLine",
     "CellLineRecord",
     "ChemblPublication",
+    # Canonical DTO names (ADR-024)
+    "ChemblPublicationRecord",
+    "ChemblPublicationTermRecord",
     "CompoundRecord",
+    # Deprecated aliases (backward compatibility)
     "DocumentRecord",
     "DocumentSimilarity",
     "DocumentTerm",
@@ -87,8 +98,11 @@ __all__ = [
     "Molecule",
     "MoleculeRecord",
     "ProteinClassification",
+    # Deprecated alias
     "PubChemCompoundRecord",
     "PubchemMolecule",
+    # Canonical DTO name (ADR-024)
+    "PubchemMoleculeRecord",
     "Publication",
     "PublicationEntity",
     "PublicationRecord",

--- a/src/bioetl/domain/entities/chembl.py
+++ b/src/bioetl/domain/entities/chembl.py
@@ -526,11 +526,15 @@ class TargetRecord(BaseModel):
     )
 
 
-class DocumentRecord(BaseModel):
-    """Scientific document DTO from ChEMBL.
+class ChemblPublicationRecord(BaseModel):
+    """Scientific publication DTO from ChEMBL.
 
-    Represents a publication/document from ChEMBL API.
+    Represents a publication from ChEMBL API (/document endpoint).
     Required field: document_chembl_id.
+
+    Note: Previously named DocumentRecord. The ChEMBL API uses 'document'
+    as the endpoint name, but we use 'Publication' for Ubiquitous Language
+    alignment per ADR-024.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
@@ -568,14 +572,16 @@ class DocumentRecord(BaseModel):
     src_id: int | None = Field(default=None, description="Data source ID")
 
 
-class DocumentTermRecord(BaseModel):
-    """Document term DTO from ChEMBL.
+class ChemblPublicationTermRecord(BaseModel):
+    """Publication term DTO from ChEMBL.
 
     Represents a term (MeSH heading, keyword, concept) associated with
-    a ChEMBL document. This is a derived entity extracted from Document
+    a ChEMBL publication. This is a derived entity extracted from Publication
     records by flattening the 1:M relationship.
 
     Required fields: document_chembl_id, term, term_type.
+
+    Note: Previously named DocumentTermRecord per ADR-024.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
@@ -701,10 +707,20 @@ class ProteinClassRecord(BaseModel):
     )
 
 
+# === Deprecated Aliases (ADR-024 backward compatibility) ===
+# These will be removed in v3.0
+DocumentRecord = ChemblPublicationRecord
+DocumentTermRecord = ChemblPublicationTermRecord
+
+
 __all__ = [
     "ActivityRecord",
     "AssayRecord",
     "CellLineRecord",
+    # Canonical names (ADR-024)
+    "ChemblPublicationRecord",
+    "ChemblPublicationTermRecord",
+    # Deprecated aliases (backward compatibility)
     "DocumentRecord",
     "DocumentTermRecord",
     "MoleculeRecord",

--- a/src/bioetl/domain/entities/pubchem.py
+++ b/src/bioetl/domain/entities/pubchem.py
@@ -21,18 +21,18 @@ from bioetl.domain.entities.base import BaseEntity
 # === Pydantic DTO Model ===
 
 
-class PubChemCompoundRecord(BaseModel):
-    """Chemical compound DTO from PubChem.
+class PubchemMoleculeRecord(BaseModel):
+    """Chemical molecule DTO from PubChem.
 
-    Represents a compound from PubChem API via pubchempy.
+    Represents a molecule (compound) from PubChem API via pubchempy.
     Required field: cid.
     At least one structural identifier (SMILES/InChI) should be present.
 
-    Note: Named PubChemCompoundRecord to avoid conflict with
-    ChEMBL's CompoundRecord (which links molecules to documents).
+    Note: Renamed from PubChemCompoundRecord to align with Ubiquitous Language
+    (ADR-024). 'Molecule' is the canonical term for chemical compounds.
 
     Example:
-        >>> record = PubChemCompoundRecord(
+        >>> record = PubchemMoleculeRecord(
         ...     cid="2244",
         ...     molecular_formula="C9H8O4",
         ...     canonical_smiles="CC(=O)OC1=CC=CC=C1C(=O)O",
@@ -119,4 +119,15 @@ class PubchemMolecule(BaseEntity):
             )
 
 
-__all__ = ["PubChemCompoundRecord", "PubchemMolecule"]
+# === Deprecated Alias (ADR-024 backward compatibility) ===
+# Will be removed in v3.0
+PubChemCompoundRecord = PubchemMoleculeRecord
+
+
+__all__ = [
+    # Deprecated alias (backward compatibility)
+    "PubChemCompoundRecord",
+    "PubchemMolecule",
+    # Canonical names (ADR-024)
+    "PubchemMoleculeRecord",
+]

--- a/src/bioetl/infrastructure/adapters/chembl/__init__.py
+++ b/src/bioetl/infrastructure/adapters/chembl/__init__.py
@@ -14,11 +14,15 @@ from bioetl.infrastructure.adapters.chembl.models import (
     ChemblActivityResponse,
     ChemblAssayRecord,
     ChemblAssayResponse,
+    # Deprecated aliases (backward compatibility)
     ChemblDocumentRecord,
     ChemblDocumentResponse,
     ChemblMoleculeRecord,
     ChemblMoleculeResponse,
     ChemblPageMeta,
+    # Canonical names (ADR-024)
+    ChemblPublicationRecord,
+    ChemblPublicationResponse,
     ChemblTargetComponentRecord,
     ChemblTargetComponentResponse,
     ChemblTargetRecord,
@@ -37,11 +41,17 @@ __all__ = [
     "ChemblAdapter",
     "ChemblAssayRecord",
     "ChemblAssayResponse",
+    # Deprecated aliases (backward compatibility)
     "ChemblDocumentRecord",
+    # Deprecated alias
     "ChemblDocumentResponse",
     "ChemblMoleculeRecord",
     "ChemblMoleculeResponse",
     "ChemblPageMeta",
+    # Canonical names (ADR-024)
+    "ChemblPublicationRecord",
+    # Canonical name (ADR-024)
+    "ChemblPublicationResponse",
     "ChemblTargetComponentRecord",
     "ChemblTargetComponentResponse",
     "ChemblTargetRecord",

--- a/src/bioetl/infrastructure/adapters/chembl/models.py
+++ b/src/bioetl/infrastructure/adapters/chembl/models.py
@@ -445,16 +445,20 @@ class ChemblTargetResponse(BaseModel):
     )
 
 
-# === Document Models ===
+# === Publication Models (ChEMBL API: /document endpoint) ===
 
 
-class ChemblDocumentRecord(BaseModel):
-    """Individual document record from ChEMBL API."""
+class ChemblPublicationRecord(BaseModel):
+    """Individual publication record from ChEMBL API.
+
+    Note: ChEMBL API uses 'document' as the endpoint name.
+    Renamed from ChemblDocumentRecord per ADR-024 (Ubiquitous Language).
+    """
 
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     # Primary Key
-    document_chembl_id: str = Field(description="ChEMBL ID of the document")
+    document_chembl_id: str = Field(description="ChEMBL ID of the publication")
 
     # Core Fields
     doc_type: str | None = Field(default=None, description="Document type")
@@ -482,13 +486,17 @@ class ChemblDocumentRecord(BaseModel):
     src_id: int | None = Field(default=None, description="Source ID")
 
 
-class ChemblDocumentResponse(BaseModel):
-    """Complete ChEMBL Document API response."""
+class ChemblPublicationResponse(BaseModel):
+    """Complete ChEMBL Publication API response.
+
+    Note: ChEMBL API uses 'document' as the endpoint name.
+    Renamed from ChemblDocumentResponse per ADR-024.
+    """
 
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
-    documents: list[ChemblDocumentRecord] = Field(
-        default_factory=list, description="List of document records"
+    documents: list[ChemblPublicationRecord] = Field(
+        default_factory=list, description="List of publication records"
     )
     page_meta: ChemblPageMeta | None = Field(
         default=None, description="Pagination metadata"
@@ -590,9 +598,16 @@ class ChemblStatusResponse(BaseModel):
     chembl_release_date: str | None = Field(default=None)
 
 
+# === Deprecated Aliases (ADR-024 backward compatibility) ===
+# Will be removed in v3.0
+ChemblDocumentRecord = ChemblPublicationRecord
+ChemblDocumentResponse = ChemblPublicationResponse
+
+
 # === Response Type Mapping ===
 
 # Mapping from entity type to response class for factory usage
+# Note: Keys match ChEMBL API endpoint names, not Ubiquitous Language
 CHEMBL_RESPONSE_MODELS: dict[str, type[BaseModel]] = {
     "activity": ChemblActivityResponse,
     "assay": ChemblAssayResponse,
@@ -600,7 +615,7 @@ CHEMBL_RESPONSE_MODELS: dict[str, type[BaseModel]] = {
     "compound": ChemblMoleculeResponse,
     "target": ChemblTargetResponse,
     "target_component": ChemblTargetComponentResponse,
-    "document": ChemblDocumentResponse,
+    "document": ChemblPublicationResponse,  # ADR-024: Publication is canonical
     "cell_line": ChemblCellLineResponse,
 }
 
@@ -612,6 +627,6 @@ CHEMBL_RECORD_MODELS: dict[str, type[BaseModel]] = {
     "compound": ChemblMoleculeRecord,
     "target": ChemblTargetRecord,
     "target_component": ChemblTargetComponentRecord,
-    "document": ChemblDocumentRecord,
+    "document": ChemblPublicationRecord,  # ADR-024: Publication is canonical
     "cell_line": ChemblCellLineRecord,
 }

--- a/src/bioetl/infrastructure/adapters/pubchem/__init__.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/__init__.py
@@ -10,8 +10,12 @@ from bioetl.infrastructure.adapters.pubchem.models import (
     PUBCHEM_RECORD_MODELS,
     PubChemAssayRecord,
     PubChemBioactivityRecord,
+    # Deprecated aliases (backward compatibility)
     PubChemCompoundDetailRecord,
     PubChemCompoundRecord,
+    # Canonical names (ADR-024)
+    PubchemMoleculeDetailRecord,
+    PubchemMoleculeRecord,
     PubChemSubstanceRecord,
 )
 
@@ -22,8 +26,11 @@ __all__ = [
     "PubChemAdapter",
     "PubChemAssayRecord",
     "PubChemBioactivityRecord",
+    # Deprecated aliases (backward compatibility)
     "PubChemCompoundDetailRecord",
-    # Record Models
     "PubChemCompoundRecord",
     "PubChemSubstanceRecord",
+    # Canonical names (ADR-024)
+    "PubchemMoleculeDetailRecord",
+    "PubchemMoleculeRecord",
 ]

--- a/src/bioetl/infrastructure/adapters/pubchem/models.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/models.py
@@ -16,11 +16,14 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field
 
 
-class PubChemCompoundRecord(BaseModel):
-    """Normalized compound record from PubChem.
+class PubchemMoleculeRecord(BaseModel):
+    """Normalized molecule record from PubChem.
 
     Represents data extracted from a pubchempy.Compound object
     via the adapter's _compound_to_dict method.
+
+    Note: Renamed from PubChemCompoundRecord per ADR-024.
+    'Molecule' is the canonical term for chemical compounds.
     """
 
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
@@ -117,13 +120,15 @@ class PubChemAssayRecord(BaseModel):
     )
 
 
-# === Extended Compound Record with Additional Fields ===
+# === Extended Molecule Record with Additional Fields ===
 
 
-class PubChemCompoundDetailRecord(BaseModel):
-    """Extended compound record with additional computed properties.
+class PubchemMoleculeDetailRecord(BaseModel):
+    """Extended molecule record with additional computed properties.
 
     Used when fetching detailed compound information from PubChem PUG REST API.
+
+    Note: Renamed from PubChemCompoundDetailRecord per ADR-024.
     """
 
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
@@ -216,11 +221,19 @@ class PubChemBioactivityRecord(BaseModel):
     )
 
 
+# === Deprecated Aliases (ADR-024 backward compatibility) ===
+# Will be removed in v3.0
+PubChemCompoundRecord = PubchemMoleculeRecord
+PubChemCompoundDetailRecord = PubchemMoleculeDetailRecord
+
+
 # === Record Type Mapping ===
 
 # Mapping from entity type to record model
+# Note: Keys match PubChem entity types, not Ubiquitous Language
 PUBCHEM_RECORD_MODELS: dict[str, type[BaseModel]] = {
-    "compound": PubChemCompoundRecord,
+    "compound": PubchemMoleculeRecord,  # ADR-024: Molecule is canonical
+    "molecule": PubchemMoleculeRecord,  # Canonical alias
     "substance": PubChemSubstanceRecord,
     "assay": PubChemAssayRecord,
 }


### PR DESCRIPTION
Rename DTO classes to align with Ubiquitous Language:
- DocumentRecord → ChemblPublicationRecord
- DocumentTermRecord → ChemblPublicationTermRecord
- PubChemCompoundRecord → PubchemMoleculeRecord
- ChemblDocumentRecord → ChemblPublicationRecord
- ChemblDocumentResponse → ChemblPublicationResponse
- PubChemCompoundDetailRecord → PubchemMoleculeDetailRecord

Add deprecated aliases for backward compatibility (removal in v3.0). Update __all__ exports and model registry mappings. All 5312 unit tests pass, lint and mypy clean.

Refs: ADR-024 Entity Naming Unification