### PR TITLE
Add optional metadata sidecar files for Medallion layers

### DIFF
--- a/src/bioetl/domain/models/__init__.py
+++ b/src/bioetl/domain/models/__init__.py
@@ -1,0 +1,47 @@
+"""Domain models package.
+
+Contains Pydantic models for structured data that requires validation.
+These models define data contracts for metadata sidecar files.
+"""
+
+from bioetl.domain.models.metadata import (
+    BronzeMetadata,
+    ColumnMetrics,
+    DeltaMetrics,
+    DQSummary,
+    EnvironmentMetadata,
+    FileOutputMetadata,
+    GoldMetadata,
+    LayerType,
+    LineageMetadata,
+    OutputMetadata,
+    PipelineMetadata,
+    RuntimeMetadata,
+    SCDMetadata,
+    SchemaColumnMetadata,
+    SchemaDrift,
+    SchemaMetadata,
+    SilverMetadata,
+    SourceMetadata,
+)
+
+__all__ = [
+    "BronzeMetadata",
+    "ColumnMetrics",
+    "DQSummary",
+    "DeltaMetrics",
+    "EnvironmentMetadata",
+    "FileOutputMetadata",
+    "GoldMetadata",
+    "LayerType",
+    "LineageMetadata",
+    "OutputMetadata",
+    "PipelineMetadata",
+    "RuntimeMetadata",
+    "SCDMetadata",
+    "SchemaColumnMetadata",
+    "SchemaDrift",
+    "SchemaMetadata",
+    "SilverMetadata",
+    "SourceMetadata",
+]

--- a/src/bioetl/domain/models/metadata.py
+++ b/src/bioetl/domain/models/metadata.py
@@ -1,0 +1,480 @@
+"""Metadata models for Medallion layer sidecar files.
+
+Defines Pydantic models for _metadata.yaml files that accompany
+data artifacts in Bronze, Silver, and Gold layers.
+
+Implements RULES.md 2.3 and 02-user-rules.md 2.4:
+- Lineage tracking
+- QC information
+- Runtime context
+
+Version: 1.0
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class LayerType(str, Enum):
+    """Medallion architecture layer type."""
+
+    BRONZE = "bronze"
+    SILVER = "silver"
+    GOLD = "gold"
+
+
+class RunTypeEnum(str, Enum):
+    """Type of pipeline run (mirrors domain.types.RunType)."""
+
+    INCREMENTAL = "incremental"
+    BACKFILL = "backfill"
+    REBUILD = "rebuild"
+
+
+# =============================================================================
+# Common Components
+# =============================================================================
+
+
+class RuntimeMetadata(BaseModel):
+    """Runtime execution context.
+
+    Attributes:
+        run_id: Unique pipeline run identifier (UUID).
+        run_type: Type of pipeline run.
+        started_at_utc: UTC timestamp when run started.
+        completed_at_utc: UTC timestamp when run completed.
+        duration_seconds: Total duration of the operation.
+    """
+
+    run_id: str = Field(description="Pipeline run UUID (correlation ID)")
+    run_type: RunTypeEnum = Field(description="Type of pipeline run")
+    started_at_utc: datetime = Field(description="Run start timestamp (ISO 8601 UTC)")
+    completed_at_utc: datetime | None = Field(
+        default=None, description="Run completion timestamp"
+    )
+    duration_seconds: float | None = Field(
+        default=None, description="Duration in seconds"
+    )
+
+
+class PipelineMetadata(BaseModel):
+    """Pipeline identification and versioning.
+
+    Attributes:
+        name: Pipeline name (e.g., 'chembl_activity').
+        provider: Data provider name (e.g., 'chembl').
+        entity: Entity type (e.g., 'activity').
+        version: Pipeline/transform version.
+        git_commit: Git commit hash for reproducibility.
+        config_hash: SHA256 hash of pipeline config.
+    """
+
+    name: str = Field(description="Pipeline name")
+    provider: str = Field(description="Data provider name")
+    entity: str = Field(description="Entity type")
+    version: str = Field(default="1.0.0", description="Pipeline version")
+    git_commit: str | None = Field(default=None, description="Git commit hash")
+    config_hash: str | None = Field(
+        default=None, description="SHA256 hash of pipeline config"
+    )
+
+
+class EnvironmentMetadata(BaseModel):
+    """Execution environment information.
+
+    Attributes:
+        hostname: Machine hostname.
+        python_version: Python version.
+        bioetl_version: BioETL package version.
+    """
+
+    hostname: str = Field(description="Machine hostname")
+    python_version: str = Field(description="Python version")
+    bioetl_version: str = Field(description="BioETL package version")
+
+
+# =============================================================================
+# Bronze Layer Components
+# =============================================================================
+
+
+class SourceMetadata(BaseModel):
+    """Data source information for Bronze layer.
+
+    Attributes:
+        type: Source type (api, csv, parquet).
+        url: API URL for API sources.
+        file_path: File path for file sources.
+        watermark_before: Previous watermark timestamp.
+        watermark_after: New watermark timestamp after ingestion.
+        api_version: Provider API version.
+    """
+
+    type: Literal["api", "csv", "parquet"] = Field(
+        default="api", description="Source type"
+    )
+    url: str | None = Field(default=None, description="API URL")
+    file_path: str | None = Field(default=None, description="Source file path")
+    watermark_before: datetime | None = Field(
+        default=None, description="Previous watermark"
+    )
+    watermark_after: datetime | None = Field(
+        default=None, description="New watermark after ingestion"
+    )
+    api_version: str | None = Field(default=None, description="Provider API version")
+
+
+class FileOutputMetadata(BaseModel):
+    """Individual file output information.
+
+    Attributes:
+        path: Relative file path.
+        size_bytes: File size in bytes.
+        record_count: Number of records in file.
+        checksum_blake2: BLAKE2 checksum for integrity.
+    """
+
+    path: str = Field(description="Relative file path")
+    size_bytes: int = Field(description="File size in bytes")
+    record_count: int = Field(description="Number of records")
+    checksum_blake2: str | None = Field(default=None, description="BLAKE2 checksum")
+
+
+class OutputMetadata(BaseModel):
+    """Bronze output information.
+
+    Attributes:
+        files: List of output files.
+        total_records: Total records across all files.
+        total_bytes: Total bytes across all files.
+        format: Output format (jsonl+zstd).
+        compression: Compression algorithm.
+    """
+
+    files: list[FileOutputMetadata] = Field(
+        default_factory=list, description="Output files"
+    )
+    total_records: int = Field(default=0, description="Total records")
+    total_bytes: int = Field(default=0, description="Total bytes")
+    format: str = Field(default="jsonl+zstd", description="Output format")
+    compression: str = Field(default="zstd", description="Compression algorithm")
+
+
+# =============================================================================
+# Silver Layer Components
+# =============================================================================
+
+
+class LineageMetadata(BaseModel):
+    """Lineage information for Silver/Gold layers.
+
+    Attributes:
+        source_batch_ids: List of source batch UUIDs.
+        bronze_paths: List of Bronze file paths.
+        transform_version: Version of transform applied.
+        transform_steps: List of transform steps applied.
+        source_tables: Source tables for Gold layer (table name -> version).
+    """
+
+    source_batch_ids: list[str] = Field(
+        default_factory=list, description="Source batch UUIDs"
+    )
+    bronze_paths: list[str] = Field(
+        default_factory=list, description="Source Bronze file paths"
+    )
+    transform_version: str | None = Field(
+        default=None, description="Transform version"
+    )
+    transform_steps: list[str] = Field(
+        default_factory=list, description="Transform steps applied"
+    )
+    source_tables: dict[str, int] = Field(
+        default_factory=dict, description="Source tables with Delta versions"
+    )
+
+
+class DeltaMetrics(BaseModel):
+    """Delta Lake operation metrics.
+
+    Attributes:
+        table_path: Delta table path.
+        operation: Delta operation (merge, overwrite, append).
+        primary_key: Primary key columns.
+        partition_by: Partition columns.
+        version_before: Delta version before write.
+        version_after: Delta version after write.
+        files_added: Number of files added.
+        files_removed: Number of files removed.
+        rows_inserted: Number of rows inserted.
+        rows_updated: Number of rows updated.
+        rows_deleted: Number of rows deleted.
+    """
+
+    table_path: str = Field(description="Delta table path")
+    operation: Literal["merge", "overwrite", "append"] = Field(
+        description="Delta operation"
+    )
+    primary_key: list[str] = Field(default_factory=list, description="Primary key")
+    partition_by: list[str] = Field(
+        default_factory=list, description="Partition columns"
+    )
+    version_before: int | None = Field(default=None, description="Version before write")
+    version_after: int | None = Field(default=None, description="Version after write")
+    files_added: int = Field(default=0, description="Files added")
+    files_removed: int = Field(default=0, description="Files removed")
+    rows_inserted: int = Field(default=0, description="Rows inserted")
+    rows_updated: int = Field(default=0, description="Rows updated")
+    rows_deleted: int = Field(default=0, description="Rows deleted")
+
+
+class ColumnMetrics(BaseModel):
+    """Per-column data quality metrics.
+
+    Attributes:
+        null_rate: Fraction of null values (0.0-1.0).
+        unique_count: Number of unique values.
+        min: Minimum value (for numeric columns).
+        max: Maximum value (for numeric columns).
+        mean: Mean value (for numeric columns).
+    """
+
+    null_rate: float = Field(default=0.0, description="Null rate (0.0-1.0)")
+    unique_count: int | None = Field(default=None, description="Unique value count")
+    min: float | None = Field(default=None, description="Minimum value")
+    max: float | None = Field(default=None, description="Maximum value")
+    mean: float | None = Field(default=None, description="Mean value")
+
+
+class SchemaDrift(BaseModel):
+    """Schema drift detection results.
+
+    Attributes:
+        status: Drift severity (info, warn, critical).
+        new_fields: List of new fields detected.
+        missing_fields: List of missing fields detected.
+    """
+
+    status: Literal["info", "warn", "critical"] = Field(
+        default="info", description="Drift severity"
+    )
+    new_fields: list[str] = Field(default_factory=list, description="New fields")
+    missing_fields: list[str] = Field(
+        default_factory=list, description="Missing fields"
+    )
+
+
+class DQSummary(BaseModel):
+    """Data quality summary metrics.
+
+    Attributes:
+        total_records: Total records processed.
+        valid_records: Records passing validation.
+        error_records: Records sent to quarantine.
+        warning_records: Records with warnings.
+        error_rate: Error rate (0.0-1.0).
+        column_metrics: Per-column metrics.
+        schema_drift: Schema drift detection.
+        validation_passed: Whether DQ validation passed.
+        data_freshness_hours: Data freshness in hours.
+    """
+
+    total_records: int = Field(default=0, description="Total records")
+    valid_records: int = Field(default=0, description="Valid records")
+    error_records: int = Field(default=0, description="Error records (quarantined)")
+    warning_records: int = Field(default=0, description="Warning records")
+    error_rate: float = Field(default=0.0, description="Error rate")
+    column_metrics: dict[str, ColumnMetrics] = Field(
+        default_factory=dict, description="Per-column metrics"
+    )
+    schema_drift: SchemaDrift | None = Field(
+        default=None, description="Schema drift info"
+    )
+    validation_passed: bool = Field(default=True, description="DQ validation passed")
+    data_freshness_hours: float | None = Field(
+        default=None, description="Data freshness in hours"
+    )
+
+    @property
+    def null_rates(self) -> dict[str, float]:
+        """Get null rates for all columns."""
+        return {col: metrics.null_rate for col, metrics in self.column_metrics.items()}
+
+
+# =============================================================================
+# Gold Layer Components
+# =============================================================================
+
+
+class SchemaColumnMetadata(BaseModel):
+    """Schema column definition.
+
+    Attributes:
+        name: Column name.
+        type: Column data type.
+        nullable: Whether column allows nulls.
+    """
+
+    name: str = Field(description="Column name")
+    type: str = Field(description="Data type")
+    nullable: bool = Field(default=True, description="Nullable")
+
+
+class SchemaMetadata(BaseModel):
+    """Schema contract metadata for Gold layer.
+
+    Attributes:
+        contract_path: Path to schema contract file.
+        version: Schema version.
+        validation: Validation mode (strict for Gold).
+        columns: Column definitions.
+    """
+
+    contract_path: str | None = Field(
+        default=None, description="Path to schema contract file"
+    )
+    version: str = Field(default="1.0", description="Schema version")
+    validation: Literal["strict", "lenient"] = Field(
+        default="strict", description="Validation mode"
+    )
+    columns: list[SchemaColumnMetadata] = Field(
+        default_factory=list, description="Column definitions"
+    )
+
+
+class SCDMetadata(BaseModel):
+    """SCD Type 2 tracking metadata.
+
+    Attributes:
+        enabled: Whether SCD2 is enabled.
+        effective_date_column: Column for effective date.
+        end_date_column: Column for end date.
+        current_flag_column: Column for current flag.
+        new_versions_created: Number of new versions created.
+        records_expired: Number of records expired.
+    """
+
+    enabled: bool = Field(default=False, description="SCD2 enabled")
+    effective_date_column: str = Field(
+        default="_valid_from", description="Effective date column"
+    )
+    end_date_column: str = Field(default="_valid_to", description="End date column")
+    current_flag_column: str = Field(
+        default="_is_current", description="Current flag column"
+    )
+    new_versions_created: int = Field(default=0, description="New versions created")
+    records_expired: int = Field(default=0, description="Records expired")
+
+
+class GoldOutputMetadata(BaseModel):
+    """Gold layer output metrics.
+
+    Attributes:
+        record_count: Number of records.
+        partition_count: Number of partitions.
+        total_bytes: Total size in bytes.
+        format: Output format (delta or parquet).
+    """
+
+    record_count: int = Field(default=0, description="Record count")
+    partition_count: int = Field(default=0, description="Partition count")
+    total_bytes: int = Field(default=0, description="Total bytes")
+    format: Literal["delta", "parquet"] = Field(
+        default="delta", description="Output format"
+    )
+
+
+class SilverOutputMetadata(BaseModel):
+    """Silver layer output metrics.
+
+    Attributes:
+        record_count: Number of records written.
+        content_hash: SHA256 hash of content for change detection.
+    """
+
+    record_count: int = Field(default=0, description="Record count")
+    content_hash: str | None = Field(
+        default=None, description="Content hash for change detection"
+    )
+
+
+# =============================================================================
+# Complete Layer Metadata Models
+# =============================================================================
+
+
+class BronzeMetadata(BaseModel):
+    """Complete metadata for Bronze layer sidecar file.
+
+    Structure follows RULES.md 2.4 lineage requirements.
+    """
+
+    version: str = Field(default="1.0", description="Metadata schema version")
+    layer: LayerType = Field(default=LayerType.BRONZE, description="Medallion layer")
+    runtime: RuntimeMetadata = Field(description="Runtime context")
+    pipeline: PipelineMetadata = Field(description="Pipeline identification")
+    source: SourceMetadata = Field(
+        default_factory=SourceMetadata, description="Source information"
+    )
+    output: OutputMetadata = Field(
+        default_factory=OutputMetadata, description="Output information"
+    )
+    environment: EnvironmentMetadata = Field(description="Environment information")
+
+
+class SilverMetadata(BaseModel):
+    """Complete metadata for Silver layer sidecar file.
+
+    Includes lineage tracking from Bronze and DQ metrics.
+    """
+
+    version: str = Field(default="1.0", description="Metadata schema version")
+    layer: LayerType = Field(default=LayerType.SILVER, description="Medallion layer")
+    runtime: RuntimeMetadata = Field(description="Runtime context")
+    pipeline: PipelineMetadata = Field(description="Pipeline identification")
+    lineage: LineageMetadata = Field(
+        default_factory=LineageMetadata, description="Lineage information"
+    )
+    delta: DeltaMetrics = Field(description="Delta Lake metrics")
+    dq_summary: DQSummary = Field(
+        default_factory=DQSummary, description="Data quality summary"
+    )
+    output: SilverOutputMetadata = Field(
+        default_factory=SilverOutputMetadata, description="Output metrics"
+    )
+    environment: EnvironmentMetadata = Field(description="Environment information")
+
+
+class GoldMetadata(BaseModel):
+    """Complete metadata for Gold layer sidecar file.
+
+    Includes schema contract and SCD tracking.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    version: str = Field(default="1.0", description="Metadata schema version")
+    layer: LayerType = Field(default=LayerType.GOLD, description="Medallion layer")
+    runtime: RuntimeMetadata = Field(description="Runtime context")
+    pipeline: PipelineMetadata = Field(description="Pipeline identification")
+    lineage: LineageMetadata = Field(
+        default_factory=LineageMetadata, description="Lineage information"
+    )
+    schema_info: SchemaMetadata = Field(
+        default_factory=SchemaMetadata,
+        description="Schema contract",
+        alias="schema",
+    )
+    dq_summary: DQSummary = Field(
+        default_factory=DQSummary, description="Data quality summary"
+    )
+    output: GoldOutputMetadata = Field(
+        default_factory=GoldOutputMetadata, description="Output metrics"
+    )
+    scd: SCDMetadata | None = Field(default=None, description="SCD Type 2 metadata")
+    environment: EnvironmentMetadata = Field(description="Environment information")

--- a/src/bioetl/domain/ports/__init__.py
+++ b/src/bioetl/domain/ports/__init__.py
@@ -42,9 +42,11 @@ from bioetl.domain.ports.health_check import (
 from bioetl.domain.ports.idmapping import IDMappingPort
 from bioetl.domain.ports.locking import LockPort
 from bioetl.domain.ports.memory import MemoryMonitorPort, MemoryStats
+from bioetl.domain.ports.metadata import MetadataWriterPort
 from bioetl.domain.ports.noop import (
     NoOpAudit,
     NoOpMemoryMonitor,
+    NoOpMetadataWriter,
     NoOpMetrics,
     NoOpPiiHasher,
     NoOpTracing,
@@ -99,10 +101,12 @@ __all__ = [
     "LoggerPort",
     "MemoryMonitorPort",
     "MemoryStats",
+    "MetadataWriterPort",
     "MetricsExtractorPort",
     "MetricsPort",
     "NoOpAudit",
     "NoOpMemoryMonitor",
+    "NoOpMetadataWriter",
     "NoOpMetrics",
     "NoOpPiiHasher",
     "NoOpTracing",

--- a/src/bioetl/domain/ports/metadata.py
+++ b/src/bioetl/domain/ports/metadata.py
@@ -1,0 +1,104 @@
+"""Metadata writer port for Medallion layer sidecar files.
+
+Defines the protocol for writing _metadata.yaml files alongside
+data artifacts in Bronze, Silver, and Gold layers.
+
+Implements RULES.md 2.3 and 02-user-rules.md 2.4:
+- Lineage tracking
+- QC information
+- Runtime context
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from bioetl.domain.models.metadata import (
+        BronzeMetadata,
+        GoldMetadata,
+        SilverMetadata,
+    )
+
+
+@runtime_checkable
+class MetadataWriterPort(Protocol):
+    """Port for writing metadata sidecar files.
+
+    Implementations write _metadata.yaml files alongside data artifacts
+    in the Medallion layers (Bronze, Silver, Gold).
+
+    Metadata files contain:
+    - Runtime context (run_id, timestamps)
+    - Pipeline identification
+    - Lineage information
+    - Data quality metrics
+    - Environment information
+    """
+
+    async def write_bronze_metadata(
+        self,
+        base_path: str | Path,
+        metadata: BronzeMetadata,
+    ) -> str:
+        """Write Bronze layer metadata sidecar file.
+
+        Args:
+            base_path: Base path where Bronze data is stored.
+                      Metadata will be written to {base_path}/_metadata.yaml
+            metadata: Bronze metadata model with lineage and source info.
+
+        Returns:
+            Absolute path to the written metadata file.
+
+        Note:
+            Uses atomic write (temp file + rename) for consistency.
+        """
+        ...
+
+    async def write_silver_metadata(
+        self,
+        base_path: str | Path,
+        metadata: SilverMetadata,
+    ) -> str:
+        """Write Silver layer metadata sidecar file.
+
+        Args:
+            base_path: Base path where Silver Delta table is stored.
+                      Metadata will be written to {base_path}/_metadata.yaml
+            metadata: Silver metadata model with lineage, DQ metrics, and Delta info.
+
+        Returns:
+            Absolute path to the written metadata file.
+
+        Note:
+            Updates existing metadata file on each pipeline run.
+            Uses atomic write (temp file + rename) for consistency.
+        """
+        ...
+
+    async def write_gold_metadata(
+        self,
+        base_path: str | Path,
+        metadata: GoldMetadata,
+    ) -> str:
+        """Write Gold layer metadata sidecar file.
+
+        Args:
+            base_path: Base path where Gold Delta/Parquet table is stored.
+                      Metadata will be written to {base_path}/_metadata.yaml
+            metadata: Gold metadata model with lineage, schema contract, and SCD info.
+
+        Returns:
+            Absolute path to the written metadata file.
+
+        Note:
+            Updates existing metadata file on each rebuild.
+            Uses atomic write (temp file + rename) for consistency.
+        """
+        ...
+
+    async def aclose(self) -> None:
+        """Release any resources held by the metadata writer."""
+        ...

--- a/src/bioetl/domain/ports/noop.py
+++ b/src/bioetl/domain/ports/noop.py
@@ -21,8 +21,14 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Self
 
 if TYPE_CHECKING:
+    from pathlib import Path
     from types import TracebackType
 
+    from bioetl.domain.models.metadata import (
+        BronzeMetadata,
+        GoldMetadata,
+        SilverMetadata,
+    )
     from bioetl.domain.ports.audit import AuditEntry, AuditLayer
     from bioetl.domain.ports.memory import MemoryStats
     from bioetl.domain.types import RunID
@@ -368,3 +374,74 @@ class NoOpMemoryMonitor:
 
         """
         return 10000
+
+
+class NoOpMetadataWriter:
+    """No-op implementation of MetadataWriterPort.
+
+    Used when save_metadata is disabled or for testing.
+    All operations are silently ignored and return empty strings.
+
+    Implements:
+        MetadataWriterPort: Domain port for metadata sidecar files.
+
+    Example:
+        >>> writer = NoOpMetadataWriter()
+        >>> await writer.write_bronze_metadata(path, metadata)  # returns ""
+        ''
+
+    """
+
+    async def write_bronze_metadata(
+        self,
+        base_path: str | Path,  # noqa: ARG002
+        metadata: BronzeMetadata,  # noqa: ARG002
+    ) -> str:
+        """Write Bronze metadata (no-op).
+
+        Args:
+            base_path: Base path (ignored).
+            metadata: Metadata (ignored).
+
+        Returns:
+            Empty string.
+
+        """
+        return ""
+
+    async def write_silver_metadata(
+        self,
+        base_path: str | Path,  # noqa: ARG002
+        metadata: SilverMetadata,  # noqa: ARG002
+    ) -> str:
+        """Write Silver metadata (no-op).
+
+        Args:
+            base_path: Base path (ignored).
+            metadata: Metadata (ignored).
+
+        Returns:
+            Empty string.
+
+        """
+        return ""
+
+    async def write_gold_metadata(
+        self,
+        base_path: str | Path,  # noqa: ARG002
+        metadata: GoldMetadata,  # noqa: ARG002
+    ) -> str:
+        """Write Gold metadata (no-op).
+
+        Args:
+            base_path: Base path (ignored).
+            metadata: Metadata (ignored).
+
+        Returns:
+            Empty string.
+
+        """
+        return ""
+
+    async def aclose(self) -> None:
+        """No-op close. Idempotent."""

--- a/src/bioetl/infrastructure/schemas/pipeline_config.py
+++ b/src/bioetl/infrastructure/schemas/pipeline_config.py
@@ -334,6 +334,10 @@ class SinkLayerConfig(BaseModel):
     format: Literal["jsonl", "delta", "parquet"] = "delta"
     mode: str | None = None
     save_json: bool = False
+    save_metadata: bool = Field(
+        default=False,
+        description="Save _metadata.yaml sidecar file with lineage and QC info",
+    )
     csv_export: CsvExportConfig = Field(default_factory=CsvExportConfig)
     # Deterministic write settings
     primary_key: list[str] = Field(default_factory=list)

--- a/src/bioetl/infrastructure/storage/metadata_writer.py
+++ b/src/bioetl/infrastructure/storage/metadata_writer.py
@@ -1,0 +1,195 @@
+"""Metadata writer implementation for Medallion layer sidecar files.
+
+Writes _metadata.yaml files alongside data artifacts in Bronze, Silver,
+and Gold layers using atomic write pattern for consistency.
+
+Implements RULES.md 2.3 and 02-user-rules.md 2.4:
+- Lineage tracking
+- QC information
+- Runtime context
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import yaml
+
+from bioetl.infrastructure.storage._atomic import atomic_write_text
+
+if TYPE_CHECKING:
+    from bioetl.domain.models.metadata import (
+        BronzeMetadata,
+        GoldMetadata,
+        SilverMetadata,
+    )
+    from bioetl.domain.ports import LoggerPort
+
+# Metadata sidecar filename
+METADATA_FILENAME = "_metadata.yaml"
+
+
+class MetadataWriter:
+    """Writer for metadata sidecar files.
+
+    Writes _metadata.yaml files alongside data artifacts in the
+    Medallion layers (Bronze, Silver, Gold).
+
+    Uses atomic write pattern (temp file + rename) to ensure
+    consistency even during crashes.
+
+    Attributes:
+        logger: Structured logger for observability.
+    """
+
+    def __init__(self, logger: LoggerPort) -> None:
+        """Initialize metadata writer.
+
+        Args:
+            logger: Structured logger for observability (MUST be injected).
+
+        Note:
+            LoggerPort is required per RULES.md DI requirements.
+        """
+        self._logger = logger
+
+    async def write_bronze_metadata(
+        self,
+        base_path: str | Path,
+        metadata: BronzeMetadata,
+    ) -> str:
+        """Write Bronze layer metadata sidecar file.
+
+        Args:
+            base_path: Base path where Bronze data is stored.
+                      Metadata will be written to {base_path}/_metadata.yaml
+            metadata: Bronze metadata model with lineage and source info.
+
+        Returns:
+            Absolute path to the written metadata file.
+        """
+        return await self._write_metadata(base_path, metadata, "bronze")
+
+    async def write_silver_metadata(
+        self,
+        base_path: str | Path,
+        metadata: SilverMetadata,
+    ) -> str:
+        """Write Silver layer metadata sidecar file.
+
+        Args:
+            base_path: Base path where Silver Delta table is stored.
+                      Metadata will be written to {base_path}/_metadata.yaml
+            metadata: Silver metadata model with lineage, DQ metrics, and Delta info.
+
+        Returns:
+            Absolute path to the written metadata file.
+        """
+        return await self._write_metadata(base_path, metadata, "silver")
+
+    async def write_gold_metadata(
+        self,
+        base_path: str | Path,
+        metadata: GoldMetadata,
+    ) -> str:
+        """Write Gold layer metadata sidecar file.
+
+        Args:
+            base_path: Base path where Gold Delta/Parquet table is stored.
+                      Metadata will be written to {base_path}/_metadata.yaml
+            metadata: Gold metadata model with lineage, schema contract, and SCD info.
+
+        Returns:
+            Absolute path to the written metadata file.
+        """
+        return await self._write_metadata(base_path, metadata, "gold")
+
+    async def _write_metadata(
+        self,
+        base_path: str | Path,
+        metadata: BronzeMetadata | SilverMetadata | GoldMetadata,
+        layer: str,
+    ) -> str:
+        """Write metadata to sidecar file.
+
+        Args:
+            base_path: Base path for metadata file.
+            metadata: Pydantic metadata model.
+            layer: Layer name for logging.
+
+        Returns:
+            Absolute path to written metadata file.
+        """
+        path = Path(base_path)
+        metadata_path = path / METADATA_FILENAME
+
+        # Serialize to dict with JSON mode for datetime handling
+        metadata_dict = metadata.model_dump(mode="json", by_alias=True)
+
+        # Convert to YAML
+        yaml_content = yaml.safe_dump(
+            metadata_dict,
+            default_flow_style=False,
+            allow_unicode=True,
+            sort_keys=False,
+        )
+
+        # Write atomically in executor
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            None,
+            lambda: atomic_write_text(metadata_path, yaml_content),
+        )
+
+        self._logger.info(
+            "metadata_written",
+            layer=layer,
+            path=str(metadata_path),
+            run_id=metadata.runtime.run_id,
+        )
+
+        return str(metadata_path.resolve())
+
+    async def aclose(self) -> None:
+        """Release any resources held by the metadata writer.
+
+        No resources to release for filesystem-based writer.
+        """
+        pass
+
+
+class NoOpMetadataWriter:
+    """No-op implementation of MetadataWriterPort.
+
+    Used when save_metadata is disabled or for testing.
+    """
+
+    async def write_bronze_metadata(
+        self,
+        base_path: str | Path,
+        metadata: BronzeMetadata,
+    ) -> str:
+        """No-op Bronze metadata write."""
+        return ""
+
+    async def write_silver_metadata(
+        self,
+        base_path: str | Path,
+        metadata: SilverMetadata,
+    ) -> str:
+        """No-op Silver metadata write."""
+        return ""
+
+    async def write_gold_metadata(
+        self,
+        base_path: str | Path,
+        metadata: GoldMetadata,
+    ) -> str:
+        """No-op Gold metadata write."""
+        return ""
+
+    async def aclose(self) -> None:
+        """No-op close."""
+        pass

--- a/tests/unit/infrastructure/storage/test_metadata_writer.py
+++ b/tests/unit/infrastructure/storage/test_metadata_writer.py
@@ -1,0 +1,513 @@
+"""Unit tests for MetadataWriter."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+import yaml
+
+from bioetl.domain.models.metadata import (
+    BronzeMetadata,
+    DeltaMetrics,
+    DQSummary,
+    EnvironmentMetadata,
+    FileOutputMetadata,
+    GoldMetadata,
+    GoldOutputMetadata,
+    LayerType,
+    LineageMetadata,
+    OutputMetadata,
+    PipelineMetadata,
+    RuntimeMetadata,
+    RunTypeEnum,
+    SchemaMetadata,
+    SilverMetadata,
+    SilverOutputMetadata,
+    SourceMetadata,
+)
+from bioetl.domain.ports.noop import NoOpMetadataWriter
+from bioetl.infrastructure.observability.noop_logger import NoOpLogger
+from bioetl.infrastructure.storage.metadata_writer import (
+    METADATA_FILENAME,
+    MetadataWriter,
+)
+
+
+@pytest.fixture
+def noop_logger() -> NoOpLogger:
+    """Provide a NoOpLogger for tests."""
+    return NoOpLogger()
+
+
+@pytest.fixture
+def metadata_writer(noop_logger: NoOpLogger) -> MetadataWriter:
+    """Create MetadataWriter instance."""
+    return MetadataWriter(logger=noop_logger)
+
+
+@pytest.fixture
+def runtime_metadata() -> RuntimeMetadata:
+    """Create sample runtime metadata."""
+    return RuntimeMetadata(
+        run_id=str(uuid4()),
+        run_type=RunTypeEnum.INCREMENTAL,
+        started_at_utc=datetime(2025, 1, 15, 10, 0, 0, tzinfo=UTC),
+        completed_at_utc=datetime(2025, 1, 15, 10, 5, 0, tzinfo=UTC),
+        duration_seconds=300.0,
+    )
+
+
+@pytest.fixture
+def pipeline_metadata() -> PipelineMetadata:
+    """Create sample pipeline metadata."""
+    return PipelineMetadata(
+        name="chembl_activity",
+        provider="chembl",
+        entity="activity",
+        version="1.2.0",
+        git_commit="abc123def",
+        config_hash="sha256:xyz789",
+    )
+
+
+@pytest.fixture
+def environment_metadata() -> EnvironmentMetadata:
+    """Create sample environment metadata."""
+    return EnvironmentMetadata(
+        hostname="worker-01",
+        python_version="3.11.5",
+        bioetl_version="5.0.5",
+    )
+
+
+@pytest.fixture
+def bronze_metadata(
+    runtime_metadata: RuntimeMetadata,
+    pipeline_metadata: PipelineMetadata,
+    environment_metadata: EnvironmentMetadata,
+) -> BronzeMetadata:
+    """Create sample Bronze metadata."""
+    return BronzeMetadata(
+        version="1.0",
+        layer=LayerType.BRONZE,
+        runtime=runtime_metadata,
+        pipeline=pipeline_metadata,
+        source=SourceMetadata(
+            type="api",
+            url="https://www.ebi.ac.uk/chembl/api/data/activity",
+            api_version="33",
+        ),
+        output=OutputMetadata(
+            files=[
+                FileOutputMetadata(
+                    path="batch_001.jsonl.zst",
+                    size_bytes=1048576,
+                    record_count=10000,
+                    checksum_blake2="abc123",
+                ),
+            ],
+            total_records=10000,
+            total_bytes=1048576,
+            format="jsonl+zstd",
+            compression="zstd",
+        ),
+        environment=environment_metadata,
+    )
+
+
+@pytest.fixture
+def silver_metadata(
+    runtime_metadata: RuntimeMetadata,
+    pipeline_metadata: PipelineMetadata,
+    environment_metadata: EnvironmentMetadata,
+) -> SilverMetadata:
+    """Create sample Silver metadata."""
+    return SilverMetadata(
+        version="1.0",
+        layer=LayerType.SILVER,
+        runtime=runtime_metadata,
+        pipeline=pipeline_metadata,
+        lineage=LineageMetadata(
+            source_batch_ids=["batch-uuid-001"],
+            bronze_paths=["bronze/v1/chembl/activity/2025-01-15/batch_001.jsonl.zst"],
+            transform_version="1.2.0",
+            transform_steps=["normalize_units", "validate_smiles"],
+        ),
+        delta=DeltaMetrics(
+            table_path="silver/chembl/activity/",
+            operation="merge",
+            primary_key=["activity_id"],
+            version_before=42,
+            version_after=43,
+            rows_inserted=5000,
+            rows_updated=2000,
+        ),
+        dq_summary=DQSummary(
+            total_records=15000,
+            valid_records=14250,
+            error_records=750,
+            error_rate=0.05,
+        ),
+        output=SilverOutputMetadata(
+            record_count=14250,
+            content_hash="sha256:abc123",
+        ),
+        environment=environment_metadata,
+    )
+
+
+@pytest.fixture
+def gold_metadata(
+    runtime_metadata: RuntimeMetadata,
+    pipeline_metadata: PipelineMetadata,
+    environment_metadata: EnvironmentMetadata,
+) -> GoldMetadata:
+    """Create sample Gold metadata."""
+    return GoldMetadata(
+        version="1.0",
+        layer=LayerType.GOLD,
+        runtime=runtime_metadata,
+        pipeline=pipeline_metadata,
+        lineage=LineageMetadata(
+            source_tables={"silver/chembl/activity": 43},
+        ),
+        schema_info=SchemaMetadata(
+            contract_path="docs/contracts/gold/activity_v1.0.json",
+            version="1.0",
+            validation="strict",
+        ),
+        dq_summary=DQSummary(
+            total_records=1250,
+            valid_records=1250,
+            validation_passed=True,
+        ),
+        output=GoldOutputMetadata(
+            record_count=1250,
+            partition_count=50,
+            total_bytes=10485760,
+            format="delta",
+        ),
+        environment=environment_metadata,
+    )
+
+
+@pytest.mark.unit
+class TestMetadataWriter:
+    """Tests for MetadataWriter."""
+
+    @pytest.mark.asyncio
+    async def test_write_bronze_metadata_creates_file(
+        self,
+        tmp_path: Path,
+        metadata_writer: MetadataWriter,
+        bronze_metadata: BronzeMetadata,
+    ) -> None:
+        """Test that write_bronze_metadata creates _metadata.yaml."""
+        base_path = tmp_path / "bronze" / "v1" / "chembl" / "activity" / "2025-01-15"
+        base_path.mkdir(parents=True)
+
+        result = await metadata_writer.write_bronze_metadata(base_path, bronze_metadata)
+
+        metadata_path = base_path / METADATA_FILENAME
+        assert metadata_path.exists()
+        assert result == str(metadata_path.resolve())
+
+    @pytest.mark.asyncio
+    async def test_write_bronze_metadata_valid_yaml(
+        self,
+        tmp_path: Path,
+        metadata_writer: MetadataWriter,
+        bronze_metadata: BronzeMetadata,
+    ) -> None:
+        """Test that Bronze metadata is valid YAML."""
+        base_path = tmp_path / "bronze"
+        base_path.mkdir(parents=True)
+
+        await metadata_writer.write_bronze_metadata(base_path, bronze_metadata)
+
+        metadata_path = base_path / METADATA_FILENAME
+        content = yaml.safe_load(metadata_path.read_text())
+
+        assert content["version"] == "1.0"
+        assert content["layer"] == "bronze"
+        assert content["pipeline"]["name"] == "chembl_activity"
+        assert content["pipeline"]["provider"] == "chembl"
+        assert content["source"]["type"] == "api"
+        assert content["output"]["total_records"] == 10000
+
+    @pytest.mark.asyncio
+    async def test_write_silver_metadata_creates_file(
+        self,
+        tmp_path: Path,
+        metadata_writer: MetadataWriter,
+        silver_metadata: SilverMetadata,
+    ) -> None:
+        """Test that write_silver_metadata creates _metadata.yaml."""
+        base_path = tmp_path / "silver" / "chembl" / "activity"
+        base_path.mkdir(parents=True)
+
+        result = await metadata_writer.write_silver_metadata(base_path, silver_metadata)
+
+        metadata_path = base_path / METADATA_FILENAME
+        assert metadata_path.exists()
+        assert result == str(metadata_path.resolve())
+
+    @pytest.mark.asyncio
+    async def test_write_silver_metadata_includes_lineage(
+        self,
+        tmp_path: Path,
+        metadata_writer: MetadataWriter,
+        silver_metadata: SilverMetadata,
+    ) -> None:
+        """Test that Silver metadata includes lineage information."""
+        base_path = tmp_path / "silver"
+        base_path.mkdir(parents=True)
+
+        await metadata_writer.write_silver_metadata(base_path, silver_metadata)
+
+        metadata_path = base_path / METADATA_FILENAME
+        content = yaml.safe_load(metadata_path.read_text())
+
+        assert "lineage" in content
+        assert "source_batch_ids" in content["lineage"]
+        assert "bronze_paths" in content["lineage"]
+        assert "transform_steps" in content["lineage"]
+
+    @pytest.mark.asyncio
+    async def test_write_silver_metadata_includes_dq_summary(
+        self,
+        tmp_path: Path,
+        metadata_writer: MetadataWriter,
+        silver_metadata: SilverMetadata,
+    ) -> None:
+        """Test that Silver metadata includes DQ summary."""
+        base_path = tmp_path / "silver"
+        base_path.mkdir(parents=True)
+
+        await metadata_writer.write_silver_metadata(base_path, silver_metadata)
+
+        metadata_path = base_path / METADATA_FILENAME
+        content = yaml.safe_load(metadata_path.read_text())
+
+        assert "dq_summary" in content
+        assert content["dq_summary"]["total_records"] == 15000
+        assert content["dq_summary"]["error_rate"] == 0.05
+
+    @pytest.mark.asyncio
+    async def test_write_gold_metadata_creates_file(
+        self,
+        tmp_path: Path,
+        metadata_writer: MetadataWriter,
+        gold_metadata: GoldMetadata,
+    ) -> None:
+        """Test that write_gold_metadata creates _metadata.yaml."""
+        base_path = tmp_path / "gold" / "chembl" / "activity_aggregated"
+        base_path.mkdir(parents=True)
+
+        result = await metadata_writer.write_gold_metadata(base_path, gold_metadata)
+
+        metadata_path = base_path / METADATA_FILENAME
+        assert metadata_path.exists()
+        assert result == str(metadata_path.resolve())
+
+    @pytest.mark.asyncio
+    async def test_write_gold_metadata_includes_schema_contract(
+        self,
+        tmp_path: Path,
+        metadata_writer: MetadataWriter,
+        gold_metadata: GoldMetadata,
+    ) -> None:
+        """Test that Gold metadata includes schema contract reference."""
+        base_path = tmp_path / "gold"
+        base_path.mkdir(parents=True)
+
+        await metadata_writer.write_gold_metadata(base_path, gold_metadata)
+
+        metadata_path = base_path / METADATA_FILENAME
+        content = yaml.safe_load(metadata_path.read_text())
+
+        assert "schema" in content
+        assert content["schema"]["contract_path"] == "docs/contracts/gold/activity_v1.0.json"
+        assert content["schema"]["validation"] == "strict"
+
+    @pytest.mark.asyncio
+    async def test_atomic_write_creates_no_temp_files(
+        self,
+        tmp_path: Path,
+        metadata_writer: MetadataWriter,
+        bronze_metadata: BronzeMetadata,
+    ) -> None:
+        """Test that atomic write leaves no temp files."""
+        base_path = tmp_path / "bronze"
+        base_path.mkdir(parents=True)
+
+        await metadata_writer.write_bronze_metadata(base_path, bronze_metadata)
+
+        # Check no .tmp files remain
+        tmp_files = list(base_path.glob("*.tmp"))
+        assert len(tmp_files) == 0
+
+    @pytest.mark.asyncio
+    async def test_write_metadata_overwrites_existing(
+        self,
+        tmp_path: Path,
+        metadata_writer: MetadataWriter,
+        bronze_metadata: BronzeMetadata,
+    ) -> None:
+        """Test that metadata can be overwritten."""
+        base_path = tmp_path / "bronze"
+        base_path.mkdir(parents=True)
+
+        # Write initial metadata
+        await metadata_writer.write_bronze_metadata(base_path, bronze_metadata)
+
+        # Modify and write again
+        updated_metadata = BronzeMetadata(
+            version="1.0",
+            layer=LayerType.BRONZE,
+            runtime=RuntimeMetadata(
+                run_id=str(uuid4()),
+                run_type=RunTypeEnum.REBUILD,
+                started_at_utc=datetime(2025, 1, 16, 10, 0, 0, tzinfo=UTC),
+                completed_at_utc=datetime(2025, 1, 16, 10, 5, 0, tzinfo=UTC),
+            ),
+            pipeline=bronze_metadata.pipeline,
+            source=bronze_metadata.source,
+            output=bronze_metadata.output,
+            environment=bronze_metadata.environment,
+        )
+
+        await metadata_writer.write_bronze_metadata(base_path, updated_metadata)
+
+        metadata_path = base_path / METADATA_FILENAME
+        content = yaml.safe_load(metadata_path.read_text())
+
+        assert content["runtime"]["run_type"] == "rebuild"
+
+    @pytest.mark.asyncio
+    async def test_aclose_is_idempotent(
+        self,
+        metadata_writer: MetadataWriter,
+    ) -> None:
+        """Test that aclose can be called multiple times."""
+        await metadata_writer.aclose()
+        await metadata_writer.aclose()
+        # No exception should be raised
+
+
+@pytest.mark.unit
+class TestNoOpMetadataWriter:
+    """Tests for NoOpMetadataWriter."""
+
+    @pytest.mark.asyncio
+    async def test_noop_write_bronze_returns_empty(
+        self,
+        bronze_metadata: BronzeMetadata,
+    ) -> None:
+        """Test NoOp Bronze write returns empty string."""
+        writer = NoOpMetadataWriter()
+        result = await writer.write_bronze_metadata("/tmp/bronze", bronze_metadata)
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_noop_write_silver_returns_empty(
+        self,
+        silver_metadata: SilverMetadata,
+    ) -> None:
+        """Test NoOp Silver write returns empty string."""
+        writer = NoOpMetadataWriter()
+        result = await writer.write_silver_metadata("/tmp/silver", silver_metadata)
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_noop_write_gold_returns_empty(
+        self,
+        gold_metadata: GoldMetadata,
+    ) -> None:
+        """Test NoOp Gold write returns empty string."""
+        writer = NoOpMetadataWriter()
+        result = await writer.write_gold_metadata("/tmp/gold", gold_metadata)
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_noop_aclose_is_idempotent(self) -> None:
+        """Test NoOp aclose can be called multiple times."""
+        writer = NoOpMetadataWriter()
+        await writer.aclose()
+        await writer.aclose()
+
+
+@pytest.mark.unit
+class TestMetadataModels:
+    """Tests for metadata Pydantic models."""
+
+    def test_bronze_metadata_serialization(
+        self,
+        bronze_metadata: BronzeMetadata,
+    ) -> None:
+        """Test Bronze metadata can be serialized to dict."""
+        data = bronze_metadata.model_dump(mode="json")
+
+        assert data["version"] == "1.0"
+        assert data["layer"] == "bronze"
+        assert data["runtime"]["run_type"] == "incremental"
+        assert "started_at_utc" in data["runtime"]
+
+    def test_silver_metadata_serialization(
+        self,
+        silver_metadata: SilverMetadata,
+    ) -> None:
+        """Test Silver metadata can be serialized to dict."""
+        data = silver_metadata.model_dump(mode="json")
+
+        assert data["version"] == "1.0"
+        assert data["layer"] == "silver"
+        assert "lineage" in data
+        assert "delta" in data
+        assert "dq_summary" in data
+
+    def test_gold_metadata_serialization(
+        self,
+        gold_metadata: GoldMetadata,
+    ) -> None:
+        """Test Gold metadata can be serialized to dict."""
+        data = gold_metadata.model_dump(mode="json", by_alias=True)
+
+        assert data["version"] == "1.0"
+        assert data["layer"] == "gold"
+        assert "schema" in data  # Uses alias
+        assert "dq_summary" in data
+
+    def test_dq_summary_null_rates_property(self) -> None:
+        """Test DQSummary null_rates property."""
+        from bioetl.domain.models.metadata import ColumnMetrics
+
+        dq = DQSummary(
+            total_records=100,
+            valid_records=95,
+            column_metrics={
+                "activity_id": ColumnMetrics(null_rate=0.0),
+                "standard_value": ColumnMetrics(null_rate=0.12),
+            },
+        )
+
+        null_rates = dq.null_rates
+        assert null_rates["activity_id"] == 0.0
+        assert null_rates["standard_value"] == 0.12
+
+    def test_runtime_metadata_datetime_serialization(self) -> None:
+        """Test datetime fields are serialized as ISO strings."""
+        runtime = RuntimeMetadata(
+            run_id=str(uuid4()),
+            run_type=RunTypeEnum.INCREMENTAL,
+            started_at_utc=datetime(2025, 1, 15, 10, 0, 0, tzinfo=UTC),
+            completed_at_utc=datetime(2025, 1, 15, 10, 5, 0, tzinfo=UTC),
+        )
+
+        data = runtime.model_dump(mode="json")
+
+        assert "2025-01-15" in data["started_at_utc"]
+        assert "10:00:00" in data["started_at_utc"]


### PR DESCRIPTION
Add support for _metadata.yaml sidecar files that capture lineage, QC metrics, and runtime context for Bronze, Silver, and Gold layers.

Changes:
- Add Pydantic models for metadata structures (domain/models/metadata.py)
- Add MetadataWriterPort protocol and implementation
- Add save_metadata option to SinkLayerConfig (default: false)
- Add NoOpMetadataWriter for disabled state
- Add unit tests for MetadataWriter

Implements RULES.md 2.3 and 02-user-rules.md 2.4 requirements.