### PR TITLE
Integrate metadata writing with SilverWriter

### DIFF
--- a/src/bioetl/composition/factories/storage_factory.py
+++ b/src/bioetl/composition/factories/storage_factory.py
@@ -13,10 +13,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from bioetl.domain.ports.noop import NoOpMetadataWriter
 from bioetl.infrastructure.export.csv_exporter import CsvExporter
 from bioetl.infrastructure.observability.noop_tracing import NoOpTracing
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 from bioetl.infrastructure.storage.gold_writer import GoldWriter
+from bioetl.infrastructure.storage.metadata_writer import MetadataWriter
 from bioetl.infrastructure.storage.silver_writer import SilverWriter
 
 from .storage_adapter import StorageAdapter
@@ -76,6 +78,8 @@ class StorageFactory:
         silver_path: Path,
         gold_path: Path,
         bronze_config: Any,
+        silver_config: Any,
+        gold_config: Any,
         silver_csv_exporter: CsvExporter | None,
         gold_csv_exporter: CsvExporter | None,
         logger: LoggerPort,
@@ -98,6 +102,21 @@ class StorageFactory:
             tracing if tracing is not None else NoOpTracing()
         )
 
+        # Create metadata writers based on config
+        # Silver metadata writer
+        silver_metadata_writer: MetadataWriter | NoOpMetadataWriter
+        if silver_config and silver_config.save_metadata:
+            silver_metadata_writer = MetadataWriter(logger=logger)
+        else:
+            silver_metadata_writer = NoOpMetadataWriter()
+
+        # Gold metadata writer
+        gold_metadata_writer: MetadataWriter | NoOpMetadataWriter
+        if gold_config and gold_config.save_metadata:
+            gold_metadata_writer = MetadataWriter(logger=logger)
+        else:
+            gold_metadata_writer = NoOpMetadataWriter()
+
         return StorageAdapter(
             bronze_writer=BronzeWriter(
                 base_path=bronze_path,
@@ -112,12 +131,14 @@ class StorageFactory:
                 logger=logger,
                 tracing=effective_tracing,
                 csv_exporter=silver_csv_exporter,
+                metadata_writer=silver_metadata_writer,
             ),
             gold_writer=GoldWriter(
                 base_path=gold_path,
                 logger=logger,
                 tracing=effective_tracing,
                 csv_exporter=gold_csv_exporter,
+                metadata_writer=gold_metadata_writer,
             ),
         )
 
@@ -185,6 +206,8 @@ class StorageFactory:
             silver_path=silver_path,
             gold_path=gold_path,
             bronze_config=bronze_config,
+            silver_config=silver_config,
+            gold_config=gold_config,
             silver_csv_exporter=silver_csv_exporter,
             gold_csv_exporter=gold_csv_exporter,
             logger=logger,

--- a/src/bioetl/infrastructure/storage/gold_writer.py
+++ b/src/bioetl/infrastructure/storage/gold_writer.py
@@ -39,7 +39,12 @@ if TYPE_CHECKING:
 
     from pandera.polars import DataFrameSchema
 
-    from bioetl.domain.ports import AuditPort, LoggerPort, TracingPort
+    from bioetl.domain.ports import (
+        AuditPort,
+        LoggerPort,
+        MetadataWriterPort,
+        TracingPort,
+    )
     from bioetl.infrastructure.export.csv_exporter import CsvExporter
 
 
@@ -66,6 +71,7 @@ class GoldWriter(BaseDeltaWriter):
         tracing: TracingPort | None = None,
         csv_exporter: CsvExporter | None = None,
         audit: AuditPort | None = None,
+        metadata_writer: MetadataWriterPort | None = None,
     ) -> None:
         """Initialize Gold writer.
 
@@ -78,6 +84,8 @@ class GoldWriter(BaseDeltaWriter):
             csv_exporter: Optional CsvExporter for CSV output (None to disable)
             audit: Optional AuditPort for write operation traceability.
                   Use NoOpAudit from composition layer if audit disabled.
+            metadata_writer: Optional MetadataWriterPort for writing _metadata.yaml
+                           sidecar files. Use NoOpMetadataWriter if disabled.
 
         Note:
             LoggerPort is required per RULES.md DI requirements.
@@ -97,6 +105,13 @@ class GoldWriter(BaseDeltaWriter):
         self.csv_exporter = csv_exporter
         self._audit = audit
         self._tracing: TracingPort = tracing
+
+        # Use NoOpMetadataWriter if not provided (metadata is optional)
+        if metadata_writer is None:
+            from bioetl.domain.ports.noop import NoOpMetadataWriter
+
+            metadata_writer = NoOpMetadataWriter()
+        self._metadata_writer: MetadataWriterPort = metadata_writer
 
     async def write_gold(
         self,
@@ -168,6 +183,17 @@ class GoldWriter(BaseDeltaWriter):
                     ingestion_ts=ingestion_ts,
                     run_id=run_id,
                 )
+
+            # Write metadata sidecar file if configured
+            await self._write_gold_metadata(
+                table_path=table_path,
+                table_name=table_name,
+                records=records,
+                mode=validated_mode,
+                scd_config=scd_config,
+                ingestion_ts=ingestion_ts,
+                run_id=run_id,
+            )
 
     def _validate_write_mode(self, mode: str) -> GoldWriteMode:
         """Validate and return the write mode enum."""
@@ -324,6 +350,138 @@ class GoldWriter(BaseDeltaWriter):
             "_log_gold_audit called without audit configured"
         )
         await self._audit.log_write(audit_entry)
+
+    async def _get_delta_version(self, table_path: str) -> int | None:
+        """Get current Delta table version.
+
+        Args:
+            table_path: Full path to the Delta table.
+
+        Returns:
+            Current version number, or None if table doesn't exist.
+        """
+        try:
+            dt = await self._run_in_executor(lambda: DeltaTable(table_path))
+            version: int = dt.version()
+            return version
+        except TableNotFoundError:
+            return None
+
+    async def _write_gold_metadata(
+        self,
+        table_path: str,
+        table_name: str,
+        records: list[dict[str, Any]],
+        mode: GoldWriteMode,
+        scd_config: dict[str, Any] | None,
+        ingestion_ts: datetime | None,
+        run_id: RunID | None,
+    ) -> None:
+        """Write Gold layer metadata sidecar file.
+
+        Args:
+            table_path: Full path to the Delta table.
+            table_name: Table name.
+            records: List of records written.
+            mode: Write mode used (overwrite, append, scd2).
+            scd_config: SCD2 configuration if applicable.
+            ingestion_ts: Ingestion timestamp.
+            run_id: Run identifier.
+        """
+        from datetime import UTC
+        from importlib.metadata import version as pkg_version
+        from platform import node as hostname
+        from platform import python_version
+
+        from bioetl.domain.models.metadata import (
+            DQSummary,
+            EnvironmentMetadata,
+            GoldMetadata,
+            GoldOutputMetadata,
+            LineageMetadata,
+            PipelineMetadata,
+            RuntimeMetadata,
+            RunTypeEnum,
+            SCDMetadata,
+        )
+
+        if not records:
+            return
+
+        # Build runtime metadata
+        now = ingestion_ts or datetime.now(UTC)
+        runtime = RuntimeMetadata(
+            run_id=str(run_id) if run_id else "",
+            run_type=RunTypeEnum.INCREMENTAL,  # Gold is always incremental
+            started_at_utc=now,
+            completed_at_utc=now,
+        )
+
+        # Extract pipeline info from table name
+        # table_name format: {provider}.{entity} or just {entity}
+        parts = table_name.split(".")
+        if len(parts) >= 2:
+            provider = parts[0]
+            entity = parts[1]
+        else:
+            provider = "unknown"
+            entity = parts[0] if parts else "unknown"
+
+        pipeline = PipelineMetadata(
+            name=f"{provider}_{entity}",
+            provider=provider,
+            entity=entity,
+        )
+
+        # Build lineage (Gold layer sources from Silver)
+        lineage = LineageMetadata()
+
+        # Build DQ summary (basic metrics)
+        dq_summary = DQSummary(
+            total_records=len(records),
+            valid_records=len(records),
+        )
+
+        # Build output metrics
+        output = GoldOutputMetadata(
+            record_count=len(records),
+        )
+
+        # Build SCD metadata if applicable
+        scd = None
+        if mode == GoldWriteMode.SCD2 and scd_config:
+            scd = SCDMetadata(
+                enabled=True,
+                effective_date_column=scd_config.get("valid_from_col", "_valid_from"),
+                end_date_column=scd_config.get("valid_to_col", "_valid_to"),
+                current_flag_column=scd_config.get("current_flag_col", "_is_current"),
+            )
+
+        # Build environment info
+        try:
+            bioetl_version = pkg_version("bioetl")
+        except Exception:
+            bioetl_version = "unknown"
+
+        environment = EnvironmentMetadata(
+            hostname=hostname(),
+            python_version=python_version(),
+            bioetl_version=bioetl_version,
+        )
+
+        # Build complete metadata
+        metadata = GoldMetadata(
+            runtime=runtime,
+            pipeline=pipeline,
+            lineage=lineage,
+            dq_summary=dq_summary,
+            output=output,
+            scd=scd,
+            environment=environment,
+        )
+
+        # Write metadata sidecar file
+        await self._metadata_writer.write_gold_metadata(table_path, metadata)
 
     async def _run_in_executor(self, func: Callable[..., T], *args: Any) -> T:
         """Run a function in the executor."""

--- a/src/bioetl/infrastructure/storage/silver_writer.py
+++ b/src/bioetl/infrastructure/storage/silver_writer.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
     from bioetl.domain.ports import (
         AuditPort,
         LoggerPort,
+        MetadataWriterPort,
         MetricsPort,
         SilverValidatorPort,
         TracingPort,
@@ -85,6 +86,7 @@ class SilverWriter(BaseDeltaWriter):
         metrics: MetricsPort | None = None,
         audit: AuditPort | None = None,
         silver_validator: SilverValidatorPort | None = None,
+        metadata_writer: MetadataWriterPort | None = None,
     ) -> None:
         """Initialize Silver writer.
 
@@ -102,6 +104,8 @@ class SilverWriter(BaseDeltaWriter):
                   Use NoOpAudit from composition layer if audit disabled.
             silver_validator: Optional SilverValidatorPort for Pandera validation.
                             Use NoOpSilverValidator if validation is not required.
+            metadata_writer: Optional MetadataWriterPort for writing _metadata.yaml
+                           sidecar files. Use NoOpMetadataWriter if disabled.
 
         Note:
             LoggerPort is required per RULES.md DI requirements.
@@ -131,6 +135,13 @@ class SilverWriter(BaseDeltaWriter):
 
             silver_validator = NoOpSilverValidator()
         self._silver_validator: SilverValidatorPort = silver_validator
+
+        # Use NoOpMetadataWriter if not provided (metadata is optional)
+        if metadata_writer is None:
+            from bioetl.domain.ports.noop import NoOpMetadataWriter
+
+            metadata_writer = NoOpMetadataWriter()
+        self._metadata_writer: MetadataWriterPort = metadata_writer
 
     def _prepare_arrow_data(
         self,
@@ -511,6 +522,14 @@ class SilverWriter(BaseDeltaWriter):
                     mode=validated_mode,
                 )
 
+            # Write metadata sidecar file if configured
+            await self._write_silver_metadata(
+                table_path=table_path,
+                records=records,
+                primary_keys=primary_keys,
+                mode=validated_mode,
+            )
+
     async def _log_silver_audit(
         self,
         table_name: str,
@@ -581,6 +600,156 @@ class SilverWriter(BaseDeltaWriter):
             },
         )
         await self._audit.log_write(audit_entry)
+
+    async def _get_delta_version(self, table_path: str) -> int | None:
+        """Get current Delta table version.
+
+        Args:
+            table_path: Full path to the Delta table.
+
+        Returns:
+            Current version number, or None if table doesn't exist.
+        """
+        loop = asyncio.get_running_loop()
+        try:
+            dt = await loop.run_in_executor(
+                None,
+                lambda: DeltaTable(table_path),
+            )
+            version: int = dt.version()
+            return version
+        except DeltaTableNotFoundError:
+            return None
+
+    async def _write_silver_metadata(
+        self,
+        table_path: str,
+        records: list[dict[str, Any]],
+        primary_keys: list[str],
+        mode: SilverWriteMode,
+    ) -> None:
+        """Write Silver layer metadata sidecar file.
+
+        Args:
+            table_path: Full path to the Delta table.
+            records: List of records written.
+            primary_keys: Primary key columns used.
+            mode: Write mode used (merge, append, delete).
+        """
+        from datetime import UTC, datetime
+        from importlib.metadata import version as pkg_version
+        from platform import node as hostname
+        from platform import python_version
+
+        from bioetl.domain.models.metadata import (
+            DeltaMetrics,
+            DQSummary,
+            EnvironmentMetadata,
+            LineageMetadata,
+            PipelineMetadata,
+            RuntimeMetadata,
+            RunTypeEnum,
+            SilverMetadata,
+            SilverOutputMetadata,
+        )
+
+        if not records:
+            return
+
+        # Extract run context from first record
+        first_record = records[0]
+        run_id = first_record.get("_run_id", "")
+        run_type_str = first_record.get("_run_type", "incremental")
+
+        # Map run_type string to enum
+        try:
+            run_type = RunTypeEnum(run_type_str)
+        except ValueError:
+            run_type = RunTypeEnum.INCREMENTAL
+
+        # Get Delta version after write
+        version_after = await self._get_delta_version(table_path)
+
+        # Build runtime metadata
+        now = datetime.now(UTC)
+        runtime = RuntimeMetadata(
+            run_id=run_id,
+            run_type=run_type,
+            started_at_utc=now,
+            completed_at_utc=now,
+        )
+
+        # Extract pipeline info from table path
+        # table_path format: {base_path}/{provider}/{entity}
+        path_parts = table_path.rstrip("/").split("/")
+        entity = path_parts[-1] if path_parts else "unknown"
+        provider = path_parts[-2] if len(path_parts) > 1 else "unknown"
+
+        pipeline = PipelineMetadata(
+            name=f"{provider}_{entity}",
+            provider=provider,
+            entity=entity,
+        )
+
+        # Build lineage from records
+        source_batch_ids = list(
+            {r.get("_source_batch_id", "") for r in records if r.get("_source_batch_id")}
+        )
+        lineage = LineageMetadata(
+            source_batch_ids=source_batch_ids,
+        )
+
+        # Build Delta metrics
+        # Map SilverWriteMode to DeltaMetrics operation (Literal type)
+        operation_map: dict[SilverWriteMode, Literal["merge", "overwrite", "append"]] = {
+            SilverWriteMode.MERGE: "merge",
+            SilverWriteMode.APPEND: "append",
+            SilverWriteMode.DELETE: "overwrite",  # DELETE mode uses overwrite
+        }
+        delta = DeltaMetrics(
+            table_path=table_path,
+            operation=operation_map[mode],
+            primary_key=primary_keys,
+            version_after=version_after,
+            rows_inserted=len(records),
+        )
+
+        # Build DQ summary (basic metrics)
+        dq_summary = DQSummary(
+            total_records=len(records),
+            valid_records=len(records),
+        )
+
+        # Build output metrics
+        output = SilverOutputMetadata(
+            record_count=len(records),
+        )
+
+        # Build environment info
+        try:
+            bioetl_version = pkg_version("bioetl")
+        except Exception:
+            bioetl_version = "unknown"
+
+        environment = EnvironmentMetadata(
+            hostname=hostname(),
+            python_version=python_version(),
+            bioetl_version=bioetl_version,
+        )
+
+        # Build complete metadata
+        metadata = SilverMetadata(
+            runtime=runtime,
+            pipeline=pipeline,
+            lineage=lineage,
+            delta=delta,
+            dq_summary=dq_summary,
+            output=output,
+            environment=environment,
+        )
+
+        # Write metadata sidecar file
+        await self._metadata_writer.write_silver_metadata(table_path, metadata)
 
     async def _merge_records(
         self,

--- a/tests/unit/infrastructure/storage/test_metadata_integration.py
+++ b/tests/unit/infrastructure/storage/test_metadata_integration.py
@@ -1,0 +1,321 @@
+"""Unit tests for metadata writing integration with Silver and Gold writers.
+
+Tests that SilverWriter and GoldWriter correctly delegate to MetadataWriterPort
+when configured to write metadata sidecar files.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pyarrow as pa
+import pytest
+
+from bioetl.domain.models.metadata import GoldMetadata, SilverMetadata
+from bioetl.domain.ports.noop import NoOpMetadataWriter
+from bioetl.domain.types import RunID
+from bioetl.infrastructure.storage.gold_writer import GoldWriter
+from bioetl.infrastructure.storage.silver_writer import SilverWriter
+
+
+class MockMetadataWriter:
+    """Mock MetadataWriter that records calls."""
+
+    def __init__(self) -> None:
+        """Initialize mock writer."""
+        self.silver_calls: list[tuple[str | Path, SilverMetadata]] = []
+        self.gold_calls: list[tuple[str | Path, GoldMetadata]] = []
+
+    async def write_bronze_metadata(
+        self, base_path: str | Path, metadata: Any
+    ) -> str:
+        """Mock Bronze metadata write."""
+        return ""
+
+    async def write_silver_metadata(
+        self, base_path: str | Path, metadata: SilverMetadata
+    ) -> str:
+        """Record Silver metadata write."""
+        self.silver_calls.append((base_path, metadata))
+        return str(Path(base_path) / "_metadata.yaml")
+
+    async def write_gold_metadata(
+        self, base_path: str | Path, metadata: GoldMetadata
+    ) -> str:
+        """Record Gold metadata write."""
+        self.gold_calls.append((base_path, metadata))
+        return str(Path(base_path) / "_metadata.yaml")
+
+    async def aclose(self) -> None:
+        """No-op close."""
+        pass
+
+
+@pytest.fixture
+def mock_logger() -> MagicMock:
+    """Create a mock logger."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_metadata_writer() -> MockMetadataWriter:
+    """Create a mock metadata writer."""
+    return MockMetadataWriter()
+
+
+@pytest.fixture
+def sample_records() -> list[dict[str, Any]]:
+    """Create sample records for testing."""
+    run_id = str(uuid4())
+    batch_id = str(uuid4())
+    return [
+        {
+            "id": "record1",
+            "value": 42,
+            "_run_id": run_id,
+            "_run_type": "incremental",
+            "_source_batch_id": batch_id,
+            "_ingestion_ts": datetime.now(UTC).isoformat(),
+        },
+        {
+            "id": "record2",
+            "value": 43,
+            "_run_id": run_id,
+            "_run_type": "incremental",
+            "_source_batch_id": batch_id,
+            "_ingestion_ts": datetime.now(UTC).isoformat(),
+        },
+    ]
+
+
+@pytest.fixture
+def silver_schema() -> pa.Schema:
+    """Create sample PyArrow schema for Silver layer."""
+    return pa.schema([
+        pa.field("id", pa.string()),
+        pa.field("value", pa.int64()),
+        pa.field("_run_id", pa.string()),
+        pa.field("_run_type", pa.string()),
+        pa.field("_source_batch_id", pa.string()),
+        pa.field("_ingestion_ts", pa.string()),
+    ])
+
+
+class TestSilverWriterMetadataIntegration:
+    """Tests for SilverWriter metadata integration."""
+
+    @pytest.mark.asyncio
+    async def test_silver_writer_calls_metadata_writer(
+        self,
+        tmp_path: Path,
+        mock_logger: MagicMock,
+        mock_metadata_writer: MockMetadataWriter,
+        sample_records: list[dict[str, Any]],
+        silver_schema: pa.Schema,
+    ) -> None:
+        """Test that SilverWriter calls metadata writer after write."""
+        writer = SilverWriter(
+            base_path=tmp_path,
+            logger=mock_logger,
+            metadata_writer=mock_metadata_writer,
+        )
+
+        await writer.write_silver(
+            table_name="test.table",
+            records=sample_records,
+            primary_keys=["id"],
+            schema=silver_schema,
+            mode="merge",
+        )
+
+        # Verify metadata writer was called
+        assert len(mock_metadata_writer.silver_calls) == 1
+        table_path, metadata = mock_metadata_writer.silver_calls[0]
+
+        # Verify path
+        assert str(table_path) == f"{tmp_path}/test/table"
+
+        # Verify metadata content
+        assert metadata.runtime.run_id == sample_records[0]["_run_id"]
+        assert metadata.delta.rows_inserted == 2
+        assert metadata.delta.operation == "merge"
+        assert metadata.delta.primary_key == ["id"]
+
+    @pytest.mark.asyncio
+    async def test_silver_writer_uses_noop_when_no_metadata_writer(
+        self,
+        tmp_path: Path,
+        mock_logger: MagicMock,
+        sample_records: list[dict[str, Any]],
+        silver_schema: pa.Schema,
+    ) -> None:
+        """Test that SilverWriter uses NoOpMetadataWriter when not provided."""
+        writer = SilverWriter(
+            base_path=tmp_path,
+            logger=mock_logger,
+            # No metadata_writer provided
+        )
+
+        # Should not raise an error
+        await writer.write_silver(
+            table_name="test.table",
+            records=sample_records,
+            primary_keys=["id"],
+            schema=silver_schema,
+            mode="merge",
+        )
+
+        # Verify NoOp was used (no metadata file created)
+        metadata_file = tmp_path / "test" / "table" / "_metadata.yaml"
+        assert not metadata_file.exists()
+
+
+class TestGoldWriterMetadataIntegration:
+    """Tests for GoldWriter metadata integration."""
+
+    @pytest.mark.asyncio
+    async def test_gold_writer_calls_metadata_writer(
+        self,
+        tmp_path: Path,
+        mock_logger: MagicMock,
+        mock_metadata_writer: MockMetadataWriter,
+    ) -> None:
+        """Test that GoldWriter calls metadata writer after write."""
+        import pandera as pa_pandera
+
+        # Create strict Pandera schema
+        class GoldSchema(pa_pandera.DataFrameSchema):
+            """Test Gold schema."""
+
+            class Config:
+                strict = True
+
+        schema = pa_pandera.DataFrameSchema(
+            columns={
+                "id": pa_pandera.Column(str),
+                "value": pa_pandera.Column(int),
+            },
+            strict=True,
+        )
+
+        writer = GoldWriter(
+            base_path=tmp_path,
+            logger=mock_logger,
+            metadata_writer=mock_metadata_writer,
+        )
+
+        records = [
+            {"id": "record1", "value": 42},
+            {"id": "record2", "value": 43},
+        ]
+
+        ingestion_ts = datetime.now(UTC)
+        run_id = RunID(uuid4())
+
+        await writer.write_gold(
+            table_name="test.gold_table",
+            records=records,
+            schema=schema,
+            primary_keys=["id"],
+            mode="overwrite",
+            ingestion_ts=ingestion_ts,
+            run_id=run_id,
+        )
+
+        # Verify metadata writer was called
+        assert len(mock_metadata_writer.gold_calls) == 1
+        table_path, metadata = mock_metadata_writer.gold_calls[0]
+
+        # Verify path
+        assert str(table_path) == f"{tmp_path}/test/gold_table"
+
+        # Verify metadata content
+        assert metadata.output.record_count == 2
+        assert metadata.pipeline.provider == "test"
+        assert metadata.pipeline.entity == "gold_table"
+
+    @pytest.mark.asyncio
+    async def test_gold_writer_uses_noop_when_no_metadata_writer(
+        self,
+        tmp_path: Path,
+        mock_logger: MagicMock,
+    ) -> None:
+        """Test that GoldWriter uses NoOpMetadataWriter when not provided."""
+        import pandera as pa_pandera
+
+        schema = pa_pandera.DataFrameSchema(
+            columns={
+                "id": pa_pandera.Column(str),
+                "value": pa_pandera.Column(int),
+            },
+            strict=True,
+        )
+
+        writer = GoldWriter(
+            base_path=tmp_path,
+            logger=mock_logger,
+            # No metadata_writer provided
+        )
+
+        records = [{"id": "record1", "value": 42}]
+        ingestion_ts = datetime.now(UTC)
+        run_id = RunID(uuid4())
+
+        # Should not raise an error
+        await writer.write_gold(
+            table_name="test.gold_table",
+            records=records,
+            schema=schema,
+            primary_keys=["id"],
+            mode="overwrite",
+            ingestion_ts=ingestion_ts,
+            run_id=run_id,
+        )
+
+        # Verify NoOp was used (no metadata file created)
+        metadata_file = tmp_path / "test" / "gold_table" / "_metadata.yaml"
+        assert not metadata_file.exists()
+
+
+class TestNoOpMetadataWriter:
+    """Tests for NoOpMetadataWriter behavior."""
+
+    @pytest.mark.asyncio
+    async def test_noop_returns_empty_string(self) -> None:
+        """Test that NoOpMetadataWriter returns empty strings."""
+        noop = NoOpMetadataWriter()
+
+        # Create minimal metadata objects for testing
+        from bioetl.domain.models.metadata import (
+            EnvironmentMetadata,
+            PipelineMetadata,
+            RuntimeMetadata,
+            RunTypeEnum,
+            SilverMetadata,
+            DeltaMetrics,
+        )
+
+        runtime = RuntimeMetadata(
+            run_id="test",
+            run_type=RunTypeEnum.INCREMENTAL,
+            started_at_utc=datetime.now(UTC),
+        )
+        pipeline = PipelineMetadata(name="test", provider="test", entity="test")
+        environment = EnvironmentMetadata(
+            hostname="test", python_version="3.11", bioetl_version="1.0"
+        )
+        delta = DeltaMetrics(table_path="/test", operation="merge")
+
+        metadata = SilverMetadata(
+            runtime=runtime,
+            pipeline=pipeline,
+            delta=delta,
+            environment=environment,
+        )
+
+        result = await noop.write_silver_metadata("/tmp/test", metadata)
+        assert result == ""


### PR DESCRIPTION
Wire MetadataWriterPort into SilverWriter and GoldWriter to automatically write _metadata.yaml sidecar files when save_metadata is enabled in config.

Changes:
- SilverWriter: Accept MetadataWriterPort, build and write SilverMetadata after successful Delta writes (with lineage, DQ summary, Delta metrics)
- GoldWriter: Accept MetadataWriterPort, build and write GoldMetadata after successful Delta writes (with SCD metadata support)
- StorageFactory: Create MetadataWriter or NoOpMetadataWriter based on save_metadata config setting for each layer

The integration uses NoOpMetadataWriter as default for backward compatibility.