### PR TITLE
Actualize pipeline configuration files

### DIFF
--- a/configs/pipelines/_base.yaml
+++ b/configs/pipelines/_base.yaml
@@ -7,9 +7,9 @@
 # All entity-specific configs MUST inherit these defaults unless explicitly
 # overriding with documented justification.
 #
-# Version: 2.0.0
+# Version: 3.0.0
 # Reference: RULES.md v5.10, Appendix D
-# Last Updated: 2026-01-14
+# Last Updated: 2026-01-15
 #
 # Usage:
 #   Entity configs specify only entity-specific fields:
@@ -18,6 +18,7 @@
 #   - gold_filters
 #   - sink path overrides
 #   - input_filter configuration
+#   - column_checks (entity-specific DQ checks)
 #
 # Inheritance Chain:
 #   _base.yaml (this file) -> <provider>/<entity>.yaml
@@ -27,7 +28,7 @@
 # -----------------------------------------------------------------------------
 # Schema Version
 # -----------------------------------------------------------------------------
-schema_version: "2.0.0"
+schema_version: "3.0.0"
 
 # -----------------------------------------------------------------------------
 # Pipeline Identification (MUST be overridden in entity config)
@@ -36,6 +37,61 @@ schema_version: "2.0.0"
 # provider: <provider>                 # MUST: chembl | pubchem | uniprot | ...
 # entity_type: <entity>                # MUST: activity | assay | molecule | ...
 # version: "1.0.0"                     # MUST: Semantic version of config
+
+# -----------------------------------------------------------------------------
+# Metadata Configuration (Lineage, Provenance, Content Hash, Schema)
+# Reference: RULES.md §2.3, §2.4, §2.8.1, §7.1
+# -----------------------------------------------------------------------------
+metadata:
+  # ---------------------------------------------------------------------------
+  # Lineage Tracking (§2.3)
+  # ---------------------------------------------------------------------------
+  lineage:
+    enabled: true
+    log_table: sys.lineage_log
+    track_bronze_paths: true
+    track_transform_version: true
+
+  # ---------------------------------------------------------------------------
+  # Provenance Fields (§2.4)
+  # MUST: These fields are required for backfill and audit
+  # ---------------------------------------------------------------------------
+  provenance:
+    run_id_field: _run_id                 # MUST: UUID identifying the pipeline run
+    run_type_field: _run_type             # MUST: incremental | backfill | rebuild
+    batch_id_field: _source_batch_id      # MUST: FK to lineage_log
+    ingestion_ts_field: _ingestion_ts     # Timestamp of record ingestion
+
+  # ---------------------------------------------------------------------------
+  # Content Hash Configuration (§2.8.1)
+  # Used for deduplication and idempotent writes
+  # ---------------------------------------------------------------------------
+  content_hash:
+    algorithm: sha256
+    include_provider_prefix: true
+    excluded_fields:
+      - _ingestion_ts
+      - _run_id
+      - _run_type
+      - _source_batch_id
+      - _dq_score
+      - _dq_flags
+    normalization:
+      float_precision: 10
+      nan_to_null: true
+      inf_to_null: true
+      date_format: "YYYY-MM-DD"
+      strip_strings: true
+
+  # ---------------------------------------------------------------------------
+  # Schema Versioning (§7.1)
+  # ---------------------------------------------------------------------------
+  schema:
+    # Schema version follows semver (MUST be overridden in entity config)
+    # version: "1.0.0"
+    # contract_path: docs/contracts/gold/<entity>.json
+    deprecation_period_days: 14
+    evolution_strategy: backward_compatible
 
 # -----------------------------------------------------------------------------
 # Source Configuration
@@ -73,19 +129,106 @@ transform:
   #   - enrich_metadata      # Add computed fields
 
 # -----------------------------------------------------------------------------
-# Data Quality Rules
+# Data Quality Configuration
+# Reference: RULES.md §3.1.2, §3.4, §3.4.1, §2.6
 # -----------------------------------------------------------------------------
+dq_config:
+  # ---------------------------------------------------------------------------
+  # Thresholds (§3.1.2)
+  # ---------------------------------------------------------------------------
+  thresholds:
+    # Soft threshold - triggers WARNING but continues processing
+    # MUST: Default 5% error rate before warning
+    soft_fail_percent: 5.0
+
+    # Hard threshold - triggers FAILURE and stops batch
+    # MUST: Default 20% error rate before failure
+    hard_fail_percent: 20.0
+
+    # Scope of threshold evaluation
+    scope:
+      - record_error_rate           # % of invalid records in batch
+      - entity_error_rate           # % of invalid unique entities
+
+  # ---------------------------------------------------------------------------
+  # Anomaly Detection (§3.4.1)
+  # ---------------------------------------------------------------------------
+  anomaly_detection:
+    enabled: true
+    baseline:
+      type: moving_average
+      window_days: 30
+    alerts:
+      # Null rate thresholds (multiplier of baseline)
+      null_rate_warning_multiplier: 2.0
+      null_rate_critical_multiplier: 5.0
+      # Record count thresholds (% of baseline)
+      record_count_warning_percent: 70    # Alert if <70% of baseline
+      record_count_critical_percent: 50   # Critical if <50% of baseline
+      # Freshness thresholds
+      freshness_warning_hours: 24
+      freshness_critical_hours: 72
+    cold_start:
+      # Initial period with no alerts
+      silence_days: 7
+      # Period with warnings only (days 8-30)
+      warning_only_days: 30
+      # Full alerting after this period
+      full_alerting_after_days: 30
+
+  # ---------------------------------------------------------------------------
+  # Per-Column Checks
+  # Entity-specific column checks SHOULD be defined in entity configs
+  # ---------------------------------------------------------------------------
+  column_checks: {}
+  # Example structure:
+  #   <column_name>:
+  #     nullable: true/false
+  #     unique: true/false
+  #     pattern: "<regex>"
+  #     range:
+  #       min: <value>
+  #       max: <value>
+  #     allowed_values: [<value1>, <value2>]
+
+  # ---------------------------------------------------------------------------
+  # Quarantine Configuration (§2.6)
+  # ---------------------------------------------------------------------------
+  quarantine:
+    enabled: true
+    table: common.quarantine
+    payload_max_bytes: 65536            # 64KB truncation for large records
+    retention_days: 30
+    error_codes:
+      - SCHEMA_VIOLATION
+      - NULL_REQUIRED_FIELD
+      - PATTERN_MISMATCH
+      - RANGE_VIOLATION
+      - DUPLICATE_RECORD
+      - TRANSFORM_ERROR
+
+  # ---------------------------------------------------------------------------
+  # DQ Metrics Export (§3.4)
+  # ---------------------------------------------------------------------------
+  metrics:
+    export_format: prometheus
+    labels:
+      - pipeline
+      - entity
+      - provider
+      - column
+      - check_type
+    metrics:
+      - dq_validation_score           # Overall DQ score (0-1)
+      - data_freshness_seconds        # Time since last update
+      - quarantine_records_total      # Total quarantined records
+      - dq_soft_threshold_exceeded    # Counter for soft threshold breaches
+      - dq_check_duration_ms          # Histogram for check latency
+
+# Legacy compatibility alias (DEPRECATED - use dq_config.thresholds)
 dq_rules:
-  # Soft threshold - triggers WARNING but continues processing
-  # MUST: Default 5% error rate before warning
   soft_fail_threshold: 0.05
-
-  # Hard threshold - triggers FAILURE and stops batch
-  # MUST: Default 20% error rate before failure
   hard_fail_threshold: 0.20
-
-  # Deviations from defaults MUST be documented with justification
-  # Example: ID mapping may have higher not_found rates (0.30/0.80)
 
 # -----------------------------------------------------------------------------
 # Circuit Breaker Configuration

--- a/configs/pipelines/chembl/activity.yaml
+++ b/configs/pipelines/chembl/activity.yaml
@@ -2,12 +2,14 @@
 # Pipeline configuration for ChEMBL Activity entity.
 #
 # Inherits defaults from ../_base.yaml:
-# - dq_rules, circuit_breaker, sink structure, maintenance, input_filter
+# - metadata (lineage, provenance, content_hash)
+# - dq_config (thresholds, anomaly_detection, quarantine, metrics)
+# - circuit_breaker, sink structure, maintenance, input_filter
 
 pipeline_name: chembl_activity
 provider: chembl
 entity_type: activity
-version: "1.1.0"
+version: "2.0.0"
 description: "Extract biological activity records from ChEMBL API"
 
 primary_keys: ["activity_id"]
@@ -16,6 +18,57 @@ gold_table: "chembl_activity"
 
 # Reference to source configuration file
 source_file: ../../sources/chembl.yaml
+
+# -----------------------------------------------------------------------------
+# Entity-Specific Metadata
+# -----------------------------------------------------------------------------
+metadata:
+  schema:
+    version: "1.0.0"
+    contract_path: docs/contracts/gold/chembl_activity.json
+
+# -----------------------------------------------------------------------------
+# Entity-Specific DQ Configuration
+# -----------------------------------------------------------------------------
+dq_config:
+  # Column-level validation rules
+  column_checks:
+    activity_id:
+      nullable: false
+      unique: true
+    molecule_chembl_id:
+      nullable: false
+      pattern: "^CHEMBL\\d+$"
+    target_chembl_id:
+      nullable: true
+      pattern: "^CHEMBL\\d+$"
+    assay_chembl_id:
+      nullable: false
+      pattern: "^CHEMBL\\d+$"
+    standard_value:
+      nullable: true
+      range:
+        min: 0.0
+    standard_units:
+      nullable: true
+      allowed_values: ["nM", "uM", "pM", "mM", "%", "ug.mL-1"]
+    standard_type:
+      nullable: true
+      allowed_values: ["IC50", "Ki", "EC50", "Kd", "AC50", "GI50", "MIC", "Potency"]
+    standard_relation:
+      nullable: true
+      allowed_values: ["=", ">", "<", ">=", "<=", "~"]
+    pchembl_value:
+      nullable: true
+      range:
+        min: 0.0
+        max: 15.0
+    assay_type:
+      nullable: true
+      allowed_values: ["B", "F", "A", "T", "P", "U"]
+    potential_duplicate:
+      nullable: true
+      allowed_values: ["0", "1"]
 
 # Entity-specific gold filters
 gold_filters:

--- a/configs/pipelines/chembl/assay.yaml
+++ b/configs/pipelines/chembl/assay.yaml
@@ -1,12 +1,15 @@
 # configs/pipelines/chembl/assay.yaml
 # Pipeline configuration for ChEMBL Assay entity.
 #
-# Inherits defaults from ../_base.yaml
+# Inherits defaults from ../_base.yaml:
+# - metadata (lineage, provenance, content_hash)
+# - dq_config (thresholds, anomaly_detection, quarantine, metrics)
+# - circuit_breaker, sink structure, maintenance, input_filter
 
 pipeline_name: chembl_assay
 provider: chembl
 entity_type: assay
-version: "1.1.0"
+version: "2.0.0"
 description: "Extract bioassay definitions from ChEMBL API"
 
 primary_keys: ["assay_chembl_id"]
@@ -14,6 +17,52 @@ silver_table: "chembl_assay"
 gold_table: "chembl_assay"
 
 source_file: ../../sources/chembl.yaml
+
+# -----------------------------------------------------------------------------
+# Entity-Specific Metadata
+# -----------------------------------------------------------------------------
+metadata:
+  schema:
+    version: "1.0.0"
+    contract_path: docs/contracts/gold/chembl_assay.json
+
+# -----------------------------------------------------------------------------
+# Entity-Specific DQ Configuration
+# -----------------------------------------------------------------------------
+dq_config:
+  # Column-level validation rules
+  column_checks:
+    assay_chembl_id:
+      nullable: false
+      unique: true
+      pattern: "^CHEMBL\\d+$"
+    assay_type:
+      nullable: false
+      allowed_values: ["B", "F", "A", "T", "P", "U"]
+    description:
+      nullable: false
+    confidence_score:
+      nullable: true
+      range:
+        min: 0
+        max: 9
+    relationship_type:
+      nullable: true
+      allowed_values: ["D", "H", "M", "N", "U"]
+    target_chembl_id:
+      nullable: true
+      pattern: "^CHEMBL\\d+$"
+    assay_organism:
+      nullable: true
+    assay_strain:
+      nullable: true
+    assay_tissue:
+      nullable: true
+    assay_cell_type:
+      nullable: true
+    bao_format:
+      nullable: true
+      pattern: "^BAO_\\d+$"
 
 # Entity-specific gold filters
 gold_filters:

--- a/configs/pipelines/chembl/molecule.yaml
+++ b/configs/pipelines/chembl/molecule.yaml
@@ -1,12 +1,15 @@
 # configs/pipelines/chembl/molecule.yaml
 # Pipeline configuration for ChEMBL Molecule entity.
 #
-# Inherits defaults from ../_base.yaml
+# Inherits defaults from ../_base.yaml:
+# - metadata (lineage, provenance, content_hash)
+# - dq_config (thresholds, anomaly_detection, quarantine, metrics)
+# - circuit_breaker, sink structure, maintenance, input_filter
 
 pipeline_name: chembl_molecule
 provider: chembl
 entity_type: molecule
-version: "1.1.0"
+version: "2.0.0"
 description: "Extract molecules/compounds from ChEMBL API"
 
 primary_keys: ["molecule_chembl_id"]
@@ -14,6 +17,160 @@ silver_table: "chembl_molecule"
 gold_table: "chembl_molecule"
 
 source_file: ../../sources/chembl.yaml
+
+# -----------------------------------------------------------------------------
+# Entity-Specific Metadata
+# -----------------------------------------------------------------------------
+metadata:
+  schema:
+    version: "1.0.0"
+    contract_path: docs/contracts/gold/chembl_molecule.json
+
+# -----------------------------------------------------------------------------
+# Entity-Specific DQ Configuration
+# -----------------------------------------------------------------------------
+dq_config:
+  # Column-level validation rules
+  column_checks:
+    molecule_chembl_id:
+      nullable: false
+      unique: true
+      pattern: "^CHEMBL\\d+$"
+    pref_name:
+      nullable: true
+    molecule_type:
+      nullable: true
+      allowed_values: ["Small molecule", "Protein", "Oligosaccharide", "Oligonucleotide", "Cell", "Antibody", "Enzyme", "Unknown"]
+    structure_type:
+      nullable: true
+      allowed_values: ["MOL", "NONE", "SEQ", "BOTH"]
+    canonical_smiles:
+      nullable: true
+    standard_inchi:
+      nullable: true
+    standard_inchi_key:
+      nullable: true
+      pattern: "^[A-Z]{14}-[A-Z]{10}-[A-Z]$"
+    full_mwt:
+      nullable: true
+      range:
+        min: 0.0
+    alogp:
+      nullable: true
+      range:
+        min: -10.0
+        max: 20.0
+    hba:
+      nullable: true
+      range:
+        min: 0
+    hbd:
+      nullable: true
+      range:
+        min: 0
+    psa:
+      nullable: true
+      range:
+        min: 0.0
+    rtb:
+      nullable: true
+      range:
+        min: 0
+    ro3_pass:
+      nullable: true
+      allowed_values: ["Y", "N"]
+    num_ro5_violations:
+      nullable: true
+      range:
+        min: 0
+        max: 4
+    cx_most_apka:
+      nullable: true
+    cx_most_bpka:
+      nullable: true
+    cx_logp:
+      nullable: true
+    cx_logd:
+      nullable: true
+    aromatic_rings:
+      nullable: true
+      range:
+        min: 0
+    heavy_atoms:
+      nullable: true
+      range:
+        min: 0
+    qed_weighted:
+      nullable: true
+      range:
+        min: 0.0
+        max: 1.0
+    mw_freebase:
+      nullable: true
+      range:
+        min: 0.0
+    mw_monoisotopic:
+      nullable: true
+      range:
+        min: 0.0
+    full_molformula:
+      nullable: true
+    inorganic_flag:
+      nullable: true
+      allowed_values: ["0", "1", "-1"]
+    polymer_flag:
+      nullable: true
+      allowed_values: ["0", "1"]
+    therapeutic_flag:
+      nullable: true
+      allowed_values: ["0", "1"]
+    natural_product:
+      nullable: true
+      allowed_values: ["0", "1", "-1"]
+    max_phase:
+      nullable: true
+      range:
+        min: 0
+        max: 4
+    first_approval:
+      nullable: true
+      range:
+        min: 1900
+        max: 2100
+    oral:
+      nullable: true
+      allowed_values: ["0", "1"]
+    parenteral:
+      nullable: true
+      allowed_values: ["0", "1"]
+    topical:
+      nullable: true
+      allowed_values: ["0", "1"]
+    black_box_warning:
+      nullable: true
+      allowed_values: ["0", "1"]
+    availability_type:
+      nullable: true
+      allowed_values: ["-2", "-1", "0", "1", "2"]
+    chirality:
+      nullable: true
+      allowed_values: ["-1", "0", "1", "2"]
+    prodrug:
+      nullable: true
+      allowed_values: ["0", "1", "-1"]
+    indication_class:
+      nullable: true
+    withdrawn_flag:
+      nullable: true
+      allowed_values: ["0", "1"]
+    withdrawn_year:
+      nullable: true
+    withdrawn_country:
+      nullable: true
+    withdrawn_reason:
+      nullable: true
+    withdrawn_class:
+      nullable: true
 
 # Entity-specific gold filters
 gold_filters:

--- a/configs/pipelines/chembl/publication.yaml
+++ b/configs/pipelines/chembl/publication.yaml
@@ -1,13 +1,17 @@
 # configs/pipelines/chembl/publication.yaml
 # Pipeline configuration for ChEMBL Publication entity.
 #
-# Inherits defaults from ../_base.yaml
+# Inherits defaults from ../_base.yaml:
+# - metadata (lineage, provenance, content_hash)
+# - dq_config (thresholds, anomaly_detection, quarantine, metrics)
+# - circuit_breaker, sink structure, maintenance, input_filter
+#
 # Note: entity_type=document maps to ChEMBL API /document endpoint
 
 pipeline_name: chembl_publication
 provider: chembl
 entity_type: document
-version: "2.0.0"
+version: "3.0.0"
 description: "Extract scientific publications from ChEMBL API"
 
 primary_keys: ["document_chembl_id"]
@@ -15,6 +19,56 @@ silver_table: "chembl_publication"
 gold_table: "chembl_publication"
 
 source_file: ../../sources/chembl.yaml
+
+# -----------------------------------------------------------------------------
+# Entity-Specific Metadata
+# -----------------------------------------------------------------------------
+metadata:
+  schema:
+    version: "1.0.0"
+    contract_path: docs/contracts/gold/chembl_publication.json
+
+# -----------------------------------------------------------------------------
+# Entity-Specific DQ Configuration
+# -----------------------------------------------------------------------------
+dq_config:
+  # Column-level validation rules
+  column_checks:
+    document_chembl_id:
+      nullable: false
+      unique: true
+      pattern: "^CHEMBL\\d+$"
+    doc_type:
+      nullable: false
+      allowed_values: ["PUBLICATION", "BOOK", "DATASET", "PATENT"]
+    title:
+      nullable: false
+    pubmed_id:
+      nullable: true
+      range:
+        min: 1
+    doi:
+      nullable: true
+      pattern: "^10\\.\\d{4,}/[^\\s]+$"
+    journal:
+      nullable: true
+    year:
+      nullable: true
+      range:
+        min: 1900
+        max: 2100
+    volume:
+      nullable: true
+    issue:
+      nullable: true
+    first_page:
+      nullable: true
+    last_page:
+      nullable: true
+    authors:
+      nullable: true
+    abstract:
+      nullable: true
 
 # Entity-specific gold filters
 gold_filters:

--- a/configs/pipelines/chembl/target.yaml
+++ b/configs/pipelines/chembl/target.yaml
@@ -1,12 +1,15 @@
 # configs/pipelines/chembl/target.yaml
 # Pipeline configuration for ChEMBL Target entity.
 #
-# Inherits defaults from ../_base.yaml
+# Inherits defaults from ../_base.yaml:
+# - metadata (lineage, provenance, content_hash)
+# - dq_config (thresholds, anomaly_detection, quarantine, metrics)
+# - circuit_breaker, sink structure, maintenance, input_filter
 
 pipeline_name: chembl_target
 provider: chembl
 entity_type: target
-version: "1.1.0"
+version: "2.0.0"
 description: "Extract biological targets from ChEMBL API"
 
 primary_keys: ["target_chembl_id"]
@@ -14,6 +17,39 @@ silver_table: "chembl_target"
 gold_table: "chembl_target"
 
 source_file: ../../sources/chembl.yaml
+
+# -----------------------------------------------------------------------------
+# Entity-Specific Metadata
+# -----------------------------------------------------------------------------
+metadata:
+  schema:
+    version: "1.0.0"
+    contract_path: docs/contracts/gold/chembl_target.json
+
+# -----------------------------------------------------------------------------
+# Entity-Specific DQ Configuration
+# -----------------------------------------------------------------------------
+dq_config:
+  # Column-level validation rules
+  column_checks:
+    target_chembl_id:
+      nullable: false
+      unique: true
+      pattern: "^CHEMBL\\d+$"
+    pref_name:
+      nullable: false
+    organism:
+      nullable: false
+    target_type:
+      nullable: false
+      allowed_values: ["SINGLE PROTEIN", "PROTEIN COMPLEX", "PROTEIN FAMILY", "SELECTIVITY GROUP", "CELL-LINE", "TISSUE", "ORGANISM", "UNCHECKED", "NO TARGET", "CHIMERIC PROTEIN", "PROTEIN-PROTEIN INTERACTION", "LIPID", "METAL", "NUCLEIC-ACID", "SUBCELLULAR", "UNKNOWN"]
+    tax_id:
+      nullable: true
+      range:
+        min: 1
+    species_group_flag:
+      nullable: true
+      allowed_values: ["0", "1"]
 
 # Entity-specific gold filters
 gold_filters:

--- a/configs/pipelines/pubchem/compound.yaml
+++ b/configs/pipelines/pubchem/compound.yaml
@@ -1,12 +1,15 @@
 # configs/pipelines/pubchem/compound.yaml
 # Pipeline configuration for PubChem Compound entity.
 #
-# Inherits defaults from ../_base.yaml
+# Inherits defaults from ../_base.yaml:
+# - metadata (lineage, provenance, content_hash)
+# - dq_config (thresholds, anomaly_detection, quarantine, metrics)
+# - circuit_breaker, sink structure, maintenance, input_filter
 
 pipeline_name: pubchem_compound
 provider: pubchem
 entity_type: compound
-version: "1.1.0"
+version: "2.0.0"
 description: "Pipeline for ingesting PubChem compounds"
 
 primary_keys: ["cid"]
@@ -14,6 +17,107 @@ silver_table: "pubchem_compound"
 gold_table: "pubchem_compound"
 
 source_file: ../../sources/pubchem.yaml
+
+# -----------------------------------------------------------------------------
+# Entity-Specific Metadata
+# -----------------------------------------------------------------------------
+metadata:
+  schema:
+    version: "1.0.0"
+    contract_path: docs/contracts/gold/pubchem_compound.json
+
+# -----------------------------------------------------------------------------
+# Entity-Specific DQ Configuration
+# -----------------------------------------------------------------------------
+dq_config:
+  # Column-level validation rules
+  column_checks:
+    cid:
+      nullable: false
+      unique: true
+      range:
+        min: 1
+    molecular_formula:
+      nullable: false
+    molecular_weight:
+      nullable: true
+      range:
+        min: 0.0
+    canonical_smiles:
+      nullable: true
+    isomeric_smiles:
+      nullable: true
+    inchi:
+      nullable: true
+      pattern: "^InChI=.*$"
+    inchikey:
+      nullable: true
+      pattern: "^[A-Z]{14}-[A-Z]{10}-[A-Z]$"
+    iupac_name:
+      nullable: true
+    xlogp:
+      nullable: true
+      range:
+        min: -10.0
+        max: 20.0
+    exact_mass:
+      nullable: true
+      range:
+        min: 0.0
+    monoisotopic_mass:
+      nullable: true
+      range:
+        min: 0.0
+    tpsa:
+      nullable: true
+      range:
+        min: 0.0
+    complexity:
+      nullable: true
+      range:
+        min: 0.0
+    charge:
+      nullable: true
+    h_bond_donor_count:
+      nullable: true
+      range:
+        min: 0
+    h_bond_acceptor_count:
+      nullable: true
+      range:
+        min: 0
+    rotatable_bond_count:
+      nullable: true
+      range:
+        min: 0
+    heavy_atom_count:
+      nullable: true
+      range:
+        min: 0
+    isotope_atom_count:
+      nullable: true
+      range:
+        min: 0
+    atom_stereo_count:
+      nullable: true
+      range:
+        min: 0
+    defined_atom_stereo_count:
+      nullable: true
+      range:
+        min: 0
+    undefined_atom_stereo_count:
+      nullable: true
+      range:
+        min: 0
+    bond_stereo_count:
+      nullable: true
+      range:
+        min: 0
+    covalent_unit_count:
+      nullable: true
+      range:
+        min: 0
 
 # Entity-specific gold filters
 gold_filters:

--- a/configs/pipelines/uniprot/protein.yaml
+++ b/configs/pipelines/uniprot/protein.yaml
@@ -1,12 +1,15 @@
 # configs/pipelines/uniprot/protein.yaml
 # Pipeline configuration for UniProt Protein entity.
 #
-# Inherits defaults from ../_base.yaml
+# Inherits defaults from ../_base.yaml:
+# - metadata (lineage, provenance, content_hash)
+# - dq_config (thresholds, anomaly_detection, quarantine, metrics)
+# - circuit_breaker, sink structure, maintenance, input_filter
 
 pipeline_name: uniprot_protein
 provider: uniprot
 entity_type: protein
-version: "1.1.0"
+version: "2.0.0"
 description: "Pipeline for ingesting UniProt proteins"
 
 primary_keys: ["accession"]
@@ -14,6 +17,71 @@ silver_table: "uniprot_protein"
 gold_table: "uniprot_protein"
 
 source_file: ../../sources/uniprot.yaml
+
+# -----------------------------------------------------------------------------
+# Entity-Specific Metadata
+# -----------------------------------------------------------------------------
+metadata:
+  schema:
+    version: "1.0.0"
+    contract_path: docs/contracts/gold/uniprot_protein.json
+
+# -----------------------------------------------------------------------------
+# Entity-Specific DQ Configuration
+# -----------------------------------------------------------------------------
+dq_config:
+  # Column-level validation rules
+  column_checks:
+    accession:
+      nullable: false
+      unique: true
+      pattern: "^[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}$"
+    entry_name:
+      nullable: false
+      pattern: "^[A-Z0-9]+_[A-Z0-9]+$"
+    organism:
+      nullable: false
+    organism_id:
+      nullable: true
+      range:
+        min: 1
+    protein_name:
+      nullable: true
+    gene_names:
+      nullable: true
+    ec_number:
+      nullable: true
+      pattern: "^\\d+\\.\\d+\\.\\d+\\.\\d+$"
+    reviewed:
+      nullable: false
+      allowed_values: ["true", "false"]
+    sequence:
+      nullable: true
+    sequence_length:
+      nullable: true
+      range:
+        min: 1
+    mass:
+      nullable: true
+      range:
+        min: 0
+    existence:
+      nullable: true
+      allowed_values: ["1", "2", "3", "4", "5"]
+    go_terms:
+      nullable: true
+    keywords:
+      nullable: true
+    features:
+      nullable: true
+    cross_references:
+      nullable: true
+    date_created:
+      nullable: true
+    date_modified:
+      nullable: true
+    date_sequence_modified:
+      nullable: true
 
 # Entity-specific gold filters
 gold_filters:


### PR DESCRIPTION
Add comprehensive metadata and DQ configuration to pipeline YAML configs:

metadata section:
- lineage: tracking bronze paths and transform versions
- provenance: _run_id, _run_type, _source_batch_id fields (MUST)
- content_hash: sha256 with normalization rules for deduplication
- schema: versioning with contract paths and deprecation periods

dq_config section (replaces dq_rules):
- thresholds: soft_fail_percent (5%), hard_fail_percent (20%)
- anomaly_detection: moving average baseline, cold start handling
- column_checks: entity-specific validation (nullable, unique, patterns, ranges)
- quarantine: error routing with 30-day retention
- metrics: Prometheus export with labeled DQ metrics

Updated configs:
- _base.yaml (schema v3.0.0 with defaults)
- chembl: activity, assay, molecule, target, publication
- pubchem: compound
- uniprot: protein

References: RULES.md §2.3, §2.4, §2.6, §2.8.1, §3.1.2, §3.4, §3.4.1, §7.1