### PR TITLE
Update pipeline configs with metadata and quality parameters

### DIFF
--- a/configs/pipelines/_base.yaml
+++ b/configs/pipelines/_base.yaml
@@ -84,8 +84,100 @@ dq_rules:
   # MUST: Default 20% error rate before failure
   hard_fail_threshold: 0.20
 
+  # Apply stricter validation rules (feature flag)
+  strict_validation: false
+
   # Deviations from defaults MUST be documented with justification
   # Example: ID mapping may have higher not_found rates (0.30/0.80)
+
+  # ---------------------------------------------------------------------------
+  # Field-Level Validations (Extended DQ)
+  # ---------------------------------------------------------------------------
+  # Define validation rules for specific fields. Types:
+  # - range: Numeric range validation (min/max)
+  # - pattern: Regex pattern matching
+  # - enum: Allowed values validation
+  # - custom: Custom validator function reference
+  #
+  # Example:
+  # field_validations:
+  #   - field: "standard_value"
+  #     type: "range"
+  #     min: 0
+  #     max: 1000000000
+  #     nullable: false
+  #   - field: "molecule_chembl_id"
+  #     type: "pattern"
+  #     pattern: "^CHEMBL\\d+$"
+  #     nullable: false
+  #   - field: "assay_type"
+  #     type: "enum"
+  #     allowed: ["B", "F", "A", "T", "P"]
+  #     nullable: true
+  #   - field: "smiles"
+  #     type: "custom"
+  #     validator: "smiles_validator"
+  #     nullable: true
+  field_validations: []
+
+  # ---------------------------------------------------------------------------
+  # Cross-Field Validations
+  # ---------------------------------------------------------------------------
+  # Validate relationships between multiple fields. Conditions:
+  # - all_present: All fields must be non-null
+  # - any_present: At least one field must be non-null
+  # - mutually_exclusive: Only one field can be non-null
+  # - conditional_required: If field A present, field B required
+  # - custom: Custom validation function
+  #
+  # Example:
+  # cross_field_validations:
+  #   - name: "activity_completeness"
+  #     fields: ["standard_value", "standard_units", "standard_type"]
+  #     condition: "all_present"
+  #   - name: "identifier_present"
+  #     fields: ["doi", "pmid", "title"]
+  #     condition: "any_present"
+  cross_field_validations: []
+
+  # ---------------------------------------------------------------------------
+  # Conditional Validations
+  # ---------------------------------------------------------------------------
+  # Apply validations only when a condition is met.
+  # Operators: eq, ne, in, not_in
+  #
+  # Example:
+  # conditional_validations:
+  #   - name: "ic50_range_check"
+  #     condition_field: "standard_type"
+  #     condition_value: "IC50"
+  #     condition_operator: "eq"
+  #     then_validations:
+  #       - field: "standard_value"
+  #         type: "range"
+  #         min: 0.001
+  #         max: 100000
+  #         nullable: false
+  conditional_validations: []
+
+  # ---------------------------------------------------------------------------
+  # Invalid Record Policy
+  # ---------------------------------------------------------------------------
+  # Policy for handling records that fail validation:
+  # - quarantine: Send to quarantine for manual review (default)
+  # - skip: Log and skip the record silently
+  # - fail: Fail the batch immediately
+  invalid_record_policy: "quarantine"
+
+  # ---------------------------------------------------------------------------
+  # DQ Report Configuration
+  # ---------------------------------------------------------------------------
+  # Configuration for DQ report generation
+  report:
+    enabled: true
+    format: "json"  # json | yaml | csv
+    include_sample_failures: true
+    sample_size: 10
 
 # -----------------------------------------------------------------------------
 # Circuit Breaker Configuration
@@ -117,6 +209,22 @@ sink:
 
     # MUST: No random elements in writes (ADR-014)
     deterministic: true
+
+    # Save _metadata.yaml sidecar file (disabled by default)
+    save_metadata: false
+
+    # Metadata configuration (when save_metadata: true)
+    # metadata:
+    #   lineage:
+    #     source_system: "<provider>"
+    #     source_version: "<version>"
+    #     extraction_method: "api"
+    #   owner: "data-team"
+    #   steward: "<pipeline>-owner"
+    #   description: "Raw <provider> <entity> data"
+    #   tags: ["<provider>", "<entity>", "raw"]
+    #   retention_days: 90
+    #   sla_freshness_hours: 24
 
     # Path template (overridden per entity)
     # path: data/output/bronze
@@ -150,6 +258,20 @@ sink:
     # MUST: No random elements in writes (ADR-014)
     deterministic: true
 
+    # Save _metadata.yaml sidecar file (disabled by default)
+    save_metadata: false
+
+    # Metadata configuration (when save_metadata: true)
+    # metadata:
+    #   lineage:
+    #     source_layer: "bronze"
+    #     transformations: ["deduplication", "normalization", "dq_validation"]
+    #   quality_expectations:
+    #     completeness: 0.95
+    #     accuracy: 0.99
+    #   description: "Cleansed <provider> <entity> data"
+    #   tags: ["<provider>", "<entity>", "silver", "validated"]
+
     # CSV export configuration
     csv_export:
       enabled: true
@@ -181,6 +303,19 @@ sink:
 
     # MUST: No random elements in writes (ADR-014)
     deterministic: true
+
+    # Save _metadata.yaml sidecar file (disabled by default)
+    save_metadata: false
+
+    # Metadata configuration (when save_metadata: true)
+    # metadata:
+    #   lineage:
+    #     source_layer: "silver"
+    #     filters_applied: true
+    #   business_domain: "drug-discovery"
+    #   use_cases: ["ml-training", "reporting", "analytics"]
+    #   description: "Business-ready <provider> <entity> data"
+    #   tags: ["<provider>", "<entity>", "gold", "ml-ready"]
 
     # CSV export configuration
     csv_export:

--- a/configs/pipelines/chembl/activity.yaml
+++ b/configs/pipelines/chembl/activity.yaml
@@ -7,7 +7,7 @@
 pipeline_name: chembl_activity
 provider: chembl
 entity_type: activity
-version: "1.1.0"
+version: "1.2.0"
 description: "Extract biological activity records from ChEMBL API"
 
 primary_keys: ["activity_id"]
@@ -16,6 +16,79 @@ gold_table: "chembl_activity"
 
 # Reference to source configuration file
 source_file: ../../sources/chembl.yaml
+
+# -----------------------------------------------------------------------------
+# Data Quality Rules (entity-specific overrides)
+# -----------------------------------------------------------------------------
+dq_rules:
+  # Thresholds (inherit from _base.yaml defaults: soft=0.05, hard=0.20)
+
+  # Field-level validations
+  field_validations:
+    - field: "activity_id"
+      type: "range"
+      min: 1
+      nullable: false
+      error_message: "activity_id must be a positive integer"
+    - field: "molecule_chembl_id"
+      type: "pattern"
+      pattern: "^CHEMBL\\d+$"
+      nullable: false
+      error_message: "molecule_chembl_id must match CHEMBL format"
+    - field: "target_chembl_id"
+      type: "pattern"
+      pattern: "^CHEMBL\\d+$"
+      nullable: true
+      error_message: "target_chembl_id must match CHEMBL format"
+    - field: "assay_chembl_id"
+      type: "pattern"
+      pattern: "^CHEMBL\\d+$"
+      nullable: true
+      error_message: "assay_chembl_id must match CHEMBL format"
+    - field: "standard_value"
+      type: "range"
+      min: 0
+      max: 1000000000
+      nullable: true
+      error_message: "standard_value must be non-negative"
+    - field: "standard_type"
+      type: "enum"
+      allowed: ["IC50", "Ki", "Kd", "EC50", "AC50", "GI50", "ED50", "MIC", "CC50"]
+      nullable: true
+    - field: "standard_units"
+      type: "enum"
+      allowed: ["nM", "uM", "mM", "pM", "M", "ug.mL-1", "mg.kg-1"]
+      nullable: true
+    - field: "assay_type"
+      type: "enum"
+      allowed: ["B", "F", "A", "T", "P", "U"]
+      nullable: true
+    - field: "pchembl_value"
+      type: "range"
+      min: 0
+      max: 15
+      nullable: true
+      error_message: "pchembl_value must be between 0 and 15"
+
+  # Cross-field validations
+  cross_field_validations:
+    - name: "activity_completeness"
+      fields: ["standard_value", "standard_units", "standard_type"]
+      condition: "all_present"
+      error_message: "Complete activity data requires value, units, and type"
+
+  # Conditional validations
+  conditional_validations:
+    - name: "ic50_range_check"
+      condition_field: "standard_type"
+      condition_value: "IC50"
+      condition_operator: "eq"
+      then_validations:
+        - field: "standard_value"
+          type: "range"
+          min: 0.001
+          max: 100000
+          nullable: false
 
 # Entity-specific gold filters
 gold_filters:

--- a/configs/pipelines/chembl/assay.yaml
+++ b/configs/pipelines/chembl/assay.yaml
@@ -6,7 +6,7 @@
 pipeline_name: chembl_assay
 provider: chembl
 entity_type: assay
-version: "1.1.0"
+version: "1.2.0"
 description: "Extract bioassay definitions from ChEMBL API"
 
 primary_keys: ["assay_chembl_id"]
@@ -14,6 +14,45 @@ silver_table: "chembl_assay"
 gold_table: "chembl_assay"
 
 source_file: ../../sources/chembl.yaml
+
+# -----------------------------------------------------------------------------
+# Data Quality Rules (entity-specific overrides)
+# -----------------------------------------------------------------------------
+dq_rules:
+  field_validations:
+    - field: "assay_chembl_id"
+      type: "pattern"
+      pattern: "^CHEMBL\\d+$"
+      nullable: false
+      error_message: "assay_chembl_id must match CHEMBL format"
+    - field: "assay_type"
+      type: "enum"
+      allowed: ["B", "F", "A", "T", "P", "U"]
+      nullable: false
+      error_message: "assay_type must be one of B, F, A, T, P, U"
+    - field: "confidence_score"
+      type: "range"
+      min: 0
+      max: 9
+      nullable: true
+    - field: "target_chembl_id"
+      type: "pattern"
+      pattern: "^CHEMBL\\d+$"
+      nullable: true
+    - field: "document_chembl_id"
+      type: "pattern"
+      pattern: "^CHEMBL\\d+$"
+      nullable: true
+    - field: "relationship_type"
+      type: "enum"
+      allowed: ["D", "H", "M", "N", "S", "U"]
+      nullable: true
+
+  cross_field_validations:
+    - name: "assay_identifiable"
+      fields: ["assay_chembl_id", "description"]
+      condition: "all_present"
+      error_message: "Assay must have ID and description"
 
 # Entity-specific gold filters
 gold_filters:

--- a/configs/pipelines/chembl/assay_parameters.yaml
+++ b/configs/pipelines/chembl/assay_parameters.yaml
@@ -7,7 +7,7 @@
 pipeline_name: chembl_assay_parameters
 provider: chembl
 entity_type: assay_parameters
-version: "1.1.0"
+version: "1.2.0"
 description: "Extract experimental assay parameters from ChEMBL API"
 
 primary_keys: ["assay_param_id"]
@@ -15,6 +15,32 @@ silver_table: "chembl_assay_parameters"
 gold_table: "chembl_assay_parameters"
 
 source_file: ../../sources/chembl.yaml
+
+# -----------------------------------------------------------------------------
+# Data Quality Rules (entity-specific overrides)
+# -----------------------------------------------------------------------------
+dq_rules:
+  field_validations:
+    - field: "assay_param_id"
+      type: "range"
+      min: 1
+      nullable: false
+    - field: "assay_chembl_id"
+      type: "pattern"
+      pattern: "^CHEMBL\\d+$"
+      nullable: false
+      error_message: "assay_chembl_id must match CHEMBL format"
+    - field: "type"
+      type: "pattern"
+      pattern: "^.{1,100}$"
+      nullable: false
+      error_message: "type is required"
+
+  cross_field_validations:
+    - name: "param_linkage"
+      fields: ["assay_param_id", "assay_chembl_id"]
+      condition: "all_present"
+      error_message: "Both param ID and assay ID are required"
 
 # Entity-specific gold filters
 gold_filters:

--- a/configs/pipelines/chembl/cell_line.yaml
+++ b/configs/pipelines/chembl/cell_line.yaml
@@ -6,7 +6,7 @@
 pipeline_name: chembl_cell_line
 provider: chembl
 entity_type: cell_line
-version: "1.1.0"
+version: "1.2.0"
 description: "Extract cell lines from ChEMBL API"
 
 primary_keys: ["cell_chembl_id"]
@@ -14,6 +14,32 @@ silver_table: "chembl_cell_line"
 gold_table: "chembl_cell_line"
 
 source_file: ../../sources/chembl.yaml
+
+# -----------------------------------------------------------------------------
+# Data Quality Rules (entity-specific overrides)
+# -----------------------------------------------------------------------------
+dq_rules:
+  field_validations:
+    - field: "cell_chembl_id"
+      type: "pattern"
+      pattern: "^CHEMBL\\d+$"
+      nullable: false
+      error_message: "cell_chembl_id must match CHEMBL format"
+    - field: "cell_name"
+      type: "pattern"
+      pattern: "^.{1,200}$"
+      nullable: false
+      error_message: "cell_name is required and must not exceed 200 chars"
+    - field: "cellosaurus_id"
+      type: "pattern"
+      pattern: "^CVCL_[A-Z0-9]+$"
+      nullable: true
+      error_message: "cellosaurus_id must match CVCL format"
+    - field: "cell_source_tax_id"
+      type: "range"
+      min: 1
+      max: 10000000
+      nullable: true
 
 # Entity-specific gold filters
 gold_filters:

--- a/configs/pipelines/chembl/compound_record.yaml
+++ b/configs/pipelines/chembl/compound_record.yaml
@@ -9,7 +9,7 @@
 pipeline_name: chembl_compound_record
 provider: chembl
 entity_type: compound_record
-version: "1.1.0"
+version: "1.2.0"
 description: "Extract compound records from ChEMBL API"
 
 primary_keys: ["record_id"]
@@ -17,6 +17,36 @@ silver_table: "chembl_compound_record"
 gold_table: "chembl_compound_record"
 
 source_file: ../../sources/chembl.yaml
+
+# -----------------------------------------------------------------------------
+# Data Quality Rules (entity-specific overrides)
+# -----------------------------------------------------------------------------
+dq_rules:
+  field_validations:
+    - field: "record_id"
+      type: "range"
+      min: 1
+      nullable: false
+    - field: "molecule_chembl_id"
+      type: "pattern"
+      pattern: "^CHEMBL\\d+$"
+      nullable: false
+      error_message: "molecule_chembl_id must match CHEMBL format"
+    - field: "document_chembl_id"
+      type: "pattern"
+      pattern: "^CHEMBL\\d+$"
+      nullable: false
+      error_message: "document_chembl_id must match CHEMBL format"
+    - field: "src_id"
+      type: "range"
+      min: 1
+      nullable: true
+
+  cross_field_validations:
+    - name: "record_linkage"
+      fields: ["molecule_chembl_id", "document_chembl_id"]
+      condition: "all_present"
+      error_message: "Both molecule and document IDs are required"
 
 # Entity-specific gold filters
 gold_filters:

--- a/configs/pipelines/chembl/molecule.yaml
+++ b/configs/pipelines/chembl/molecule.yaml
@@ -6,7 +6,7 @@
 pipeline_name: chembl_molecule
 provider: chembl
 entity_type: molecule
-version: "1.1.0"
+version: "1.2.0"
 description: "Extract molecules/compounds from ChEMBL API"
 
 primary_keys: ["molecule_chembl_id"]
@@ -14,6 +14,61 @@ silver_table: "chembl_molecule"
 gold_table: "chembl_molecule"
 
 source_file: ../../sources/chembl.yaml
+
+# -----------------------------------------------------------------------------
+# Data Quality Rules (entity-specific overrides)
+# -----------------------------------------------------------------------------
+dq_rules:
+  field_validations:
+    - field: "molecule_chembl_id"
+      type: "pattern"
+      pattern: "^CHEMBL\\d+$"
+      nullable: false
+      error_message: "molecule_chembl_id must match CHEMBL format"
+    - field: "molecule_type"
+      type: "enum"
+      allowed: ["Small molecule", "Protein", "Antibody", "Oligosaccharide", "Oligonucleotide", "Cell", "Enzyme", "Unknown"]
+      nullable: true
+    - field: "structure_type"
+      type: "enum"
+      allowed: ["MOL", "SEQ", "NONE", "BOTH"]
+      nullable: true
+    - field: "full_mwt"
+      type: "range"
+      min: 10
+      max: 10000
+      nullable: true
+      error_message: "Molecular weight must be between 10 and 10000 Da"
+    - field: "canonical_smiles"
+      type: "custom"
+      validator: "smiles_validator"
+      nullable: true
+    - field: "alogp"
+      type: "range"
+      min: -10
+      max: 20
+      nullable: true
+    - field: "hba"
+      type: "range"
+      min: 0
+      max: 50
+      nullable: true
+    - field: "hbd"
+      type: "range"
+      min: 0
+      max: 30
+      nullable: true
+    - field: "psa"
+      type: "range"
+      min: 0
+      max: 1000
+      nullable: true
+
+  cross_field_validations:
+    - name: "structure_completeness"
+      fields: ["canonical_smiles", "standard_inchi", "standard_inchi_key"]
+      condition: "any_present"
+      error_message: "At least one structure identifier required"
 
 # Entity-specific gold filters
 gold_filters:

--- a/configs/pipelines/chembl/protein_class.yaml
+++ b/configs/pipelines/chembl/protein_class.yaml
@@ -7,7 +7,7 @@
 pipeline_name: chembl_protein_class
 provider: chembl
 entity_type: protein_class
-version: "1.1.0"
+version: "1.2.0"
 description: "ChEMBL Protein Classification hierarchy (enzyme classes, receptor types, etc.)"
 
 primary_keys: ["protein_class_id"]
@@ -19,6 +19,37 @@ source_file: ../../sources/chembl.yaml
 # Full load for reference table
 batch_size: 500  # Reference table (~1.5K records), full load
 checkpoint_interval: 500
+
+# -----------------------------------------------------------------------------
+# Data Quality Rules (entity-specific overrides)
+# -----------------------------------------------------------------------------
+dq_rules:
+  field_validations:
+    - field: "protein_class_id"
+      type: "range"
+      min: 1
+      nullable: false
+    - field: "class_level"
+      type: "range"
+      min: 1
+      max: 10
+      nullable: true
+    - field: "pref_name"
+      type: "pattern"
+      pattern: "^.{1,500}$"
+      nullable: false
+      error_message: "pref_name is required"
+    - field: "parent_id"
+      type: "range"
+      min: 1
+      nullable: true
+
+  cross_field_validations:
+    - name: "hierarchy_valid"
+      fields: ["protein_class_id", "parent_id"]
+      condition: "custom"
+      validator: "validate_hierarchy_no_self_reference"
+      error_message: "parent_id cannot equal protein_class_id"
 
 # Entity-specific gold filters - exclude deprecated records
 gold_filters:

--- a/configs/pipelines/chembl/publication.yaml
+++ b/configs/pipelines/chembl/publication.yaml
@@ -7,7 +7,7 @@
 pipeline_name: chembl_publication
 provider: chembl
 entity_type: document
-version: "2.0.0"
+version: "2.1.0"
 description: "Extract scientific publications from ChEMBL API"
 
 primary_keys: ["document_chembl_id"]
@@ -15,6 +15,42 @@ silver_table: "chembl_publication"
 gold_table: "chembl_publication"
 
 source_file: ../../sources/chembl.yaml
+
+# -----------------------------------------------------------------------------
+# Data Quality Rules (entity-specific overrides)
+# -----------------------------------------------------------------------------
+dq_rules:
+  field_validations:
+    - field: "document_chembl_id"
+      type: "pattern"
+      pattern: "^CHEMBL\\d+$"
+      nullable: false
+      error_message: "document_chembl_id must match CHEMBL format"
+    - field: "doc_type"
+      type: "enum"
+      allowed: ["PUBLICATION", "BOOK", "DATASET", "PATENT"]
+      nullable: true
+    - field: "year"
+      type: "range"
+      min: 1800
+      max: 2100
+      nullable: true
+    - field: "pubmed_id"
+      type: "range"
+      min: 1
+      max: 100000000
+      nullable: true
+    - field: "doi"
+      type: "pattern"
+      pattern: "^10\\.\\d{4,}/.*$"
+      nullable: true
+      error_message: "DOI must start with 10. prefix"
+
+  cross_field_validations:
+    - name: "publication_identifiable"
+      fields: ["pubmed_id", "doi", "title"]
+      condition: "any_present"
+      error_message: "Publication must have at least one identifier"
 
 # Entity-specific gold filters
 gold_filters:

--- a/configs/pipelines/chembl/publication_similarity.yaml
+++ b/configs/pipelines/chembl/publication_similarity.yaml
@@ -7,7 +7,7 @@
 pipeline_name: chembl_publication_similarity
 provider: chembl
 entity_type: document_similarity
-version: "2.0.0"
+version: "2.1.0"
 description: "Extract publication similarity data (Tanimoto coefficients) from ChEMBL API"
 
 primary_keys: ["sim_id"]
@@ -15,6 +15,42 @@ silver_table: "chembl_publication_similarity"
 gold_table: "chembl_publication_similarity"
 
 source_file: ../../sources/chembl.yaml
+
+# -----------------------------------------------------------------------------
+# Data Quality Rules (entity-specific overrides)
+# -----------------------------------------------------------------------------
+dq_rules:
+  field_validations:
+    - field: "sim_id"
+      type: "range"
+      min: 1
+      nullable: false
+    - field: "doc_1"
+      type: "range"
+      min: 1
+      nullable: false
+    - field: "doc_2"
+      type: "range"
+      min: 1
+      nullable: false
+    - field: "max_tani"
+      type: "range"
+      min: 0
+      max: 1
+      nullable: true
+      error_message: "Tanimoto coefficient must be between 0 and 1"
+    - field: "avg_tani"
+      type: "range"
+      min: 0
+      max: 1
+      nullable: true
+      error_message: "Average Tanimoto must be between 0 and 1"
+
+  cross_field_validations:
+    - name: "similarity_pair"
+      fields: ["doc_1", "doc_2"]
+      condition: "all_present"
+      error_message: "Both document IDs are required"
 
 # Entity-specific gold filters
 gold_filters:

--- a/configs/pipelines/chembl/publication_term.yaml
+++ b/configs/pipelines/chembl/publication_term.yaml
@@ -8,7 +8,7 @@
 pipeline_name: chembl_publication_term
 provider: chembl
 entity_type: document_term
-version: "2.0.0"
+version: "2.1.0"
 description: "Extract publication terms (MeSH, keywords) from ChEMBL Publication records"
 
 # Composite primary key (document_chembl_id + term_type + term)
@@ -18,6 +18,37 @@ silver_table: "chembl_publication_term"
 gold_table: "chembl_publication_term"
 
 source_file: ../../sources/chembl.yaml
+
+# -----------------------------------------------------------------------------
+# Data Quality Rules (entity-specific overrides)
+# -----------------------------------------------------------------------------
+dq_rules:
+  field_validations:
+    - field: "entity_id"
+      type: "pattern"
+      pattern: "^[a-f0-9]{64}$"
+      nullable: false
+      error_message: "entity_id must be a 64-char SHA256 hash"
+    - field: "document_chembl_id"
+      type: "pattern"
+      pattern: "^CHEMBL\\d+$"
+      nullable: false
+      error_message: "document_chembl_id must match CHEMBL format"
+    - field: "term_type"
+      type: "enum"
+      allowed: ["MESH_HEADING", "KEYWORD", "AUTHOR", "INSTITUTION"]
+      nullable: false
+    - field: "term"
+      type: "pattern"
+      pattern: "^.{1,500}$"
+      nullable: false
+      error_message: "term is required"
+
+  cross_field_validations:
+    - name: "term_completeness"
+      fields: ["document_chembl_id", "term", "term_type"]
+      condition: "all_present"
+      error_message: "All term fields are required"
 
 # Entity-specific gold filters
 gold_filters:

--- a/configs/pipelines/chembl/target.yaml
+++ b/configs/pipelines/chembl/target.yaml
@@ -6,7 +6,7 @@
 pipeline_name: chembl_target
 provider: chembl
 entity_type: target
-version: "1.1.0"
+version: "1.2.0"
 description: "Extract biological targets from ChEMBL API"
 
 primary_keys: ["target_chembl_id"]
@@ -14,6 +14,37 @@ silver_table: "chembl_target"
 gold_table: "chembl_target"
 
 source_file: ../../sources/chembl.yaml
+
+# -----------------------------------------------------------------------------
+# Data Quality Rules (entity-specific overrides)
+# -----------------------------------------------------------------------------
+dq_rules:
+  field_validations:
+    - field: "target_chembl_id"
+      type: "pattern"
+      pattern: "^CHEMBL\\d+$"
+      nullable: false
+      error_message: "target_chembl_id must match CHEMBL format"
+    - field: "target_type"
+      type: "enum"
+      allowed: ["SINGLE PROTEIN", "PROTEIN COMPLEX", "PROTEIN FAMILY", "SELECTIVITY GROUP", "ORGANISM", "TISSUE", "CELL-LINE", "SUBCELLULAR", "UNKNOWN", "CHIMERIC PROTEIN", "PROTEIN-PROTEIN INTERACTION", "NUCLEIC-ACID", "METAL", "LIPID", "MACROMOLECULE", "PHENOTYPE", "ADMET"]
+      nullable: true
+    - field: "organism"
+      type: "pattern"
+      pattern: "^[A-Z][a-z]+ [a-z]+.*$"
+      nullable: true
+      error_message: "organism should be in binomial nomenclature"
+    - field: "tax_id"
+      type: "range"
+      min: 1
+      max: 10000000
+      nullable: true
+
+  cross_field_validations:
+    - name: "target_identifiable"
+      fields: ["target_chembl_id", "pref_name"]
+      condition: "all_present"
+      error_message: "Target must have ID and preferred name"
 
 # Entity-specific gold filters
 gold_filters:

--- a/configs/pipelines/chembl/target_component.yaml
+++ b/configs/pipelines/chembl/target_component.yaml
@@ -6,7 +6,7 @@
 pipeline_name: chembl_target_component
 provider: chembl
 entity_type: target_component
-version: "1.1.0"
+version: "1.2.0"
 description: "ChEMBL Target Components (protein sequences, etc.)"
 
 primary_keys: ["component_id"]
@@ -14,6 +14,36 @@ silver_table: chembl_target_component
 gold_table: chembl_target_component
 
 source_file: ../../sources/chembl.yaml
+
+# -----------------------------------------------------------------------------
+# Data Quality Rules (entity-specific overrides)
+# -----------------------------------------------------------------------------
+dq_rules:
+  field_validations:
+    - field: "component_id"
+      type: "range"
+      min: 1
+      nullable: false
+    - field: "component_type"
+      type: "enum"
+      allowed: ["PROTEIN", "DNA", "RNA"]
+      nullable: true
+    - field: "accession"
+      type: "pattern"
+      pattern: "^[A-Z0-9]{6,10}$"
+      nullable: true
+      error_message: "accession should be UniProt format"
+    - field: "tax_id"
+      type: "range"
+      min: 1
+      max: 10000000
+      nullable: true
+
+  cross_field_validations:
+    - name: "component_identifiable"
+      fields: ["component_id", "accession"]
+      condition: "any_present"
+      error_message: "Component must have ID or accession"
 
 # Entity-specific gold filters
 gold_filters:

--- a/configs/pipelines/crossref/publication.yaml
+++ b/configs/pipelines/crossref/publication.yaml
@@ -7,7 +7,7 @@
 pipeline_name: crossref_publication
 provider: crossref
 entity_type: work
-version: "1.1.0"
+version: "1.2.0"
 description: "Enrich publication records with CrossRef metadata via DOI resolution"
 
 primary_keys: ["doi"]
@@ -15,6 +15,40 @@ silver_table: "crossref_publication"
 gold_table: "crossref_publication"
 
 source_file: ../../sources/crossref.yaml
+
+# -----------------------------------------------------------------------------
+# Data Quality Rules (entity-specific overrides)
+# -----------------------------------------------------------------------------
+dq_rules:
+  field_validations:
+    - field: "doi"
+      type: "pattern"
+      pattern: "^10\\.\\d{4,}/.*$"
+      nullable: false
+      error_message: "DOI must start with 10. prefix"
+    - field: "title"
+      type: "pattern"
+      pattern: "^.{1,2000}$"
+      nullable: true
+    - field: "year"
+      type: "range"
+      min: 1800
+      max: 2100
+      nullable: true
+    - field: "type"
+      type: "enum"
+      allowed: ["journal-article", "book-chapter", "proceedings-article", "posted-content", "book", "report", "dataset", "standard"]
+      nullable: true
+    - field: "is_referenced_by_count"
+      type: "range"
+      min: 0
+      nullable: true
+
+  cross_field_validations:
+    - name: "publication_identifiable"
+      fields: ["doi", "title"]
+      condition: "all_present"
+      error_message: "Publication must have DOI and title"
 
 # Entity-specific gold filters
 gold_filters:

--- a/configs/pipelines/openalex/publication.yaml
+++ b/configs/pipelines/openalex/publication.yaml
@@ -9,7 +9,7 @@
 pipeline_name: openalex_publication
 provider: openalex
 entity_type: publication
-version: "1.1.0"
+version: "1.2.0"
 description: "Batch DOI resolution via OpenAlex with title fallback"
 
 primary_keys: ["openalex_id"]
@@ -22,6 +22,45 @@ source_file: ../../sources/openalex.yaml
 source:
   email: "${BIOETL_OPENALEX_EMAIL}"  # Required for polite pool
   batch_size: 50  # Polite pool API - conservative batch size
+
+# -----------------------------------------------------------------------------
+# Data Quality Rules (entity-specific overrides)
+# -----------------------------------------------------------------------------
+dq_rules:
+  field_validations:
+    - field: "openalex_id"
+      type: "pattern"
+      pattern: "^W\\d+$"
+      nullable: false
+      error_message: "OpenAlex ID must start with W followed by digits"
+    - field: "doi"
+      type: "pattern"
+      pattern: "^10\\.\\d{4,}/.*$"
+      nullable: true
+      error_message: "DOI must start with 10. prefix"
+    - field: "title"
+      type: "pattern"
+      pattern: "^.{1,2000}$"
+      nullable: true
+    - field: "year"
+      type: "range"
+      min: 1500
+      max: 2100
+      nullable: true
+    - field: "type"
+      type: "enum"
+      allowed: ["article", "book-chapter", "book", "dataset", "dissertation", "editorial", "letter", "review", "preprint", "other"]
+      nullable: true
+    - field: "cited_by_count"
+      type: "range"
+      min: 0
+      nullable: true
+
+  cross_field_validations:
+    - name: "publication_identifiable"
+      fields: ["openalex_id", "title"]
+      condition: "all_present"
+      error_message: "Publication must have OpenAlex ID and title"
 
 # Entity-specific gold filters
 gold_filters:

--- a/configs/pipelines/pubchem/compound.yaml
+++ b/configs/pipelines/pubchem/compound.yaml
@@ -6,7 +6,7 @@
 pipeline_name: pubchem_compound
 provider: pubchem
 entity_type: compound
-version: "1.1.0"
+version: "1.2.0"
 description: "Pipeline for ingesting PubChem compounds"
 
 primary_keys: ["cid"]
@@ -14,6 +14,61 @@ silver_table: "pubchem_compound"
 gold_table: "pubchem_compound"
 
 source_file: ../../sources/pubchem.yaml
+
+# -----------------------------------------------------------------------------
+# Data Quality Rules (entity-specific overrides)
+# -----------------------------------------------------------------------------
+dq_rules:
+  field_validations:
+    - field: "cid"
+      type: "range"
+      min: 1
+      nullable: false
+      error_message: "CID must be a positive integer"
+    - field: "molecular_formula"
+      type: "pattern"
+      pattern: "^[A-Z][A-Za-z0-9]*$"
+      nullable: true
+      error_message: "Molecular formula must start with uppercase letter"
+    - field: "molecular_weight"
+      type: "range"
+      min: 10
+      max: 10000
+      nullable: true
+    - field: "canonical_smiles"
+      type: "custom"
+      validator: "smiles_validator"
+      nullable: true
+    - field: "isomeric_smiles"
+      type: "custom"
+      validator: "smiles_validator"
+      nullable: true
+    - field: "xlogp"
+      type: "range"
+      min: -20
+      max: 30
+      nullable: true
+    - field: "tpsa"
+      type: "range"
+      min: 0
+      max: 1000
+      nullable: true
+    - field: "h_bond_donor_count"
+      type: "range"
+      min: 0
+      max: 50
+      nullable: true
+    - field: "h_bond_acceptor_count"
+      type: "range"
+      min: 0
+      max: 50
+      nullable: true
+
+  cross_field_validations:
+    - name: "structure_present"
+      fields: ["canonical_smiles", "inchi", "inchikey"]
+      condition: "any_present"
+      error_message: "At least one structure identifier required"
 
 # Entity-specific gold filters
 gold_filters:

--- a/configs/pipelines/pubmed/publications.yaml
+++ b/configs/pipelines/pubmed/publications.yaml
@@ -6,7 +6,7 @@
 pipeline_name: pubmed_publications
 provider: pubmed
 entity_type: publication
-version: "1.1.0"
+version: "1.2.0"
 description: "Extract publication metadata from PubMed via Entrez API"
 
 primary_keys: ["pmid"]
@@ -20,6 +20,51 @@ source:
   search_term: "bioinformatics[Title/Abstract] AND drug discovery[Title/Abstract]"
   email: "${BIOETL_NCBI_EMAIL}"
   api_key: "${BIOETL_NCBI_API_KEY}"
+
+# -----------------------------------------------------------------------------
+# Data Quality Rules (entity-specific overrides)
+# -----------------------------------------------------------------------------
+dq_rules:
+  field_validations:
+    - field: "pmid"
+      type: "range"
+      min: 1
+      max: 100000000
+      nullable: false
+      error_message: "PMID must be a positive integer"
+    - field: "title"
+      type: "pattern"
+      pattern: "^.{1,2000}$"
+      nullable: true
+    - field: "doi"
+      type: "pattern"
+      pattern: "^10\\.\\d{4,}/.*$"
+      nullable: true
+      error_message: "DOI must start with 10. prefix"
+    - field: "pub_year"
+      type: "range"
+      min: 1800
+      max: 2100
+      nullable: true
+    - field: "pub_type"
+      type: "enum"
+      allowed: ["Journal Article", "Review", "Letter", "Editorial", "Clinical Trial", "Meta-Analysis", "Case Reports", "Comparative Study", "Evaluation Study"]
+      nullable: true
+    - field: "pmc_id"
+      type: "pattern"
+      pattern: "^PMC\\d+$"
+      nullable: true
+      error_message: "PMC ID must start with PMC followed by digits"
+
+  cross_field_validations:
+    - name: "publication_identifiable"
+      fields: ["pmid", "title"]
+      condition: "all_present"
+      error_message: "Publication must have PMID and title"
+    - name: "has_identifier"
+      fields: ["pmid", "doi", "pmc_id"]
+      condition: "any_present"
+      error_message: "At least one identifier required"
 
 # Entity-specific gold filters
 gold_filters:

--- a/configs/pipelines/semanticscholar/publication.yaml
+++ b/configs/pipelines/semanticscholar/publication.yaml
@@ -9,7 +9,7 @@
 pipeline_name: semanticscholar_publication
 provider: semanticscholar
 entity_type: publication
-version: "1.1.0"
+version: "1.2.0"
 description: "Batch DOI resolution via Semantic Scholar with title fallback"
 
 primary_keys: ["paper_id"]
@@ -17,6 +17,49 @@ silver_table: "semanticscholar_publication"
 gold_table: "semanticscholar_publication"
 
 source_file: ../../sources/semanticscholar.yaml
+
+# -----------------------------------------------------------------------------
+# Data Quality Rules (entity-specific overrides)
+# -----------------------------------------------------------------------------
+dq_rules:
+  field_validations:
+    - field: "paper_id"
+      type: "pattern"
+      pattern: "^[a-f0-9]{40}$"
+      nullable: false
+      error_message: "paper_id must be a 40-char hex string"
+    - field: "doi"
+      type: "pattern"
+      pattern: "^10\\.\\d{4,}/.*$"
+      nullable: true
+      error_message: "DOI must start with 10. prefix"
+    - field: "title"
+      type: "pattern"
+      pattern: "^.{1,2000}$"
+      nullable: true
+    - field: "year"
+      type: "range"
+      min: 1500
+      max: 2100
+      nullable: true
+    - field: "citation_count"
+      type: "range"
+      min: 0
+      nullable: true
+    - field: "reference_count"
+      type: "range"
+      min: 0
+      nullable: true
+    - field: "influential_citation_count"
+      type: "range"
+      min: 0
+      nullable: true
+
+  cross_field_validations:
+    - name: "publication_identifiable"
+      fields: ["paper_id", "title"]
+      condition: "all_present"
+      error_message: "Publication must have paper_id and title"
 
 # Entity-specific gold filters
 gold_filters:

--- a/configs/pipelines/uniprot/idmapping.yaml
+++ b/configs/pipelines/uniprot/idmapping.yaml
@@ -34,11 +34,40 @@ source:
     from_db: ChEMBL
     to_db: UniProtKB
 
-# DQ rules - elevated thresholds for ID mapping
+# -----------------------------------------------------------------------------
+# Data Quality Rules - elevated thresholds for ID mapping
 # Many ChEMBL targets may not have UniProt mappings (expected behavior)
+# -----------------------------------------------------------------------------
 dq_rules:
   soft_fail_threshold: 0.30  # 30% not_found is acceptable
   hard_fail_threshold: 0.80  # 80% not_found triggers hard failure
+
+  field_validations:
+    - field: "target_chembl_id"
+      type: "pattern"
+      pattern: "^CHEMBL\\d+$"
+      nullable: false
+      error_message: "target_chembl_id must match CHEMBL format"
+    - field: "mapping_status"
+      type: "enum"
+      allowed: ["found", "not_found", "error"]
+      nullable: false
+    - field: "uniprot_accession"
+      type: "pattern"
+      pattern: "^[A-Z0-9]{6,10}$"
+      nullable: true
+      error_message: "UniProt accession must be 6-10 alphanumeric chars"
+
+  conditional_validations:
+    - name: "found_has_accession"
+      condition_field: "mapping_status"
+      condition_value: "found"
+      condition_operator: "eq"
+      then_validations:
+        - field: "uniprot_accession"
+          type: "pattern"
+          pattern: "^[A-Z0-9]{6,10}$"
+          nullable: false
 
 # Sink configuration
 sink:

--- a/configs/pipelines/uniprot/protein.yaml
+++ b/configs/pipelines/uniprot/protein.yaml
@@ -6,7 +6,7 @@
 pipeline_name: uniprot_protein
 provider: uniprot
 entity_type: protein
-version: "1.1.0"
+version: "1.2.0"
 description: "Pipeline for ingesting UniProt proteins"
 
 primary_keys: ["accession"]
@@ -14,6 +14,47 @@ silver_table: "uniprot_protein"
 gold_table: "uniprot_protein"
 
 source_file: ../../sources/uniprot.yaml
+
+# -----------------------------------------------------------------------------
+# Data Quality Rules (entity-specific overrides)
+# -----------------------------------------------------------------------------
+dq_rules:
+  field_validations:
+    - field: "accession"
+      type: "pattern"
+      pattern: "^[A-Z0-9]{6,10}$"
+      nullable: false
+      error_message: "UniProt accession must be 6-10 alphanumeric chars"
+    - field: "entry_name"
+      type: "pattern"
+      pattern: "^[A-Z0-9_]+$"
+      nullable: true
+    - field: "organism"
+      type: "pattern"
+      pattern: "^[A-Z][a-z]+ [a-z]+.*$"
+      nullable: true
+      error_message: "Organism should be in binomial nomenclature"
+    - field: "taxonomy_id"
+      type: "range"
+      min: 1
+      max: 10000000
+      nullable: true
+    - field: "sequence_length"
+      type: "range"
+      min: 1
+      max: 100000
+      nullable: true
+    - field: "mass"
+      type: "range"
+      min: 100
+      max: 10000000
+      nullable: true
+
+  cross_field_validations:
+    - name: "protein_identifiable"
+      fields: ["accession", "entry_name"]
+      condition: "all_present"
+      error_message: "Protein must have accession and entry name"
 
 # Entity-specific gold filters
 gold_filters:

--- a/src/bioetl/domain/config.py
+++ b/src/bioetl/domain/config.py
@@ -115,19 +115,155 @@ DEFAULT_VALIDATION_CONFIG = ValidationConfig()
 
 
 @dataclass(frozen=True, slots=True)
+class FieldValidation:
+    """Configuration for a single field validation rule.
+
+    Supports multiple validation types:
+    - range: Numeric range validation (min/max)
+    - pattern: Regex pattern matching
+    - enum: Allowed values validation
+    - custom: Custom validator function reference
+
+    Attributes:
+        field: Field name to validate.
+        validation_type: Type of validation (range, pattern, enum, custom).
+        nullable: Whether field can be null/None. Default: True.
+        min_value: Minimum value for range validation.
+        max_value: Maximum value for range validation.
+        pattern: Regex pattern for pattern validation.
+        allowed: Allowed values for enum validation.
+        validator: Validator function name for custom validation.
+        error_message: Custom error message template.
+    """
+
+    field: str
+    validation_type: Literal["range", "pattern", "enum", "custom"]
+    nullable: bool = True
+    # Range validation
+    min_value: float | None = None
+    max_value: float | None = None
+    # Pattern validation
+    pattern: str | None = None
+    # Enum validation
+    allowed: tuple[str, ...] = ()
+    # Custom validation
+    validator: str | None = None
+    # Custom error message
+    error_message: str | None = None
+
+    def __post_init__(self) -> None:
+        """Convert lists to tuples for immutability."""
+        if isinstance(self.allowed, list):
+            object.__setattr__(self, "allowed", tuple(self.allowed))
+
+
+@dataclass(frozen=True, slots=True)
+class CrossFieldValidation:
+    """Configuration for cross-field validation rule.
+
+    Validates relationships between multiple fields.
+
+    Attributes:
+        name: Unique name for the validation rule.
+        fields: Fields involved in the validation.
+        condition: Validation condition type.
+        error_message: Custom error message template.
+    """
+
+    name: str
+    fields: tuple[str, ...]
+    condition: Literal[
+        "all_present",  # All fields must be non-null
+        "any_present",  # At least one field must be non-null
+        "mutually_exclusive",  # Only one field can be non-null
+        "conditional_required",  # If field A present, field B required
+        "custom",  # Custom validation function
+    ]
+    # For conditional_required: (trigger_field, required_field)
+    trigger_field: str | None = None
+    required_field: str | None = None
+    # Custom validation
+    validator: str | None = None
+    error_message: str | None = None
+
+    def __post_init__(self) -> None:
+        """Convert lists to tuples for immutability."""
+        if isinstance(self.fields, list):
+            object.__setattr__(self, "fields", tuple(self.fields))
+
+
+@dataclass(frozen=True, slots=True)
+class ConditionalValidation:
+    """Configuration for conditional validation rule.
+
+    Applies validation only when a condition is met.
+
+    Attributes:
+        name: Unique name for the validation rule.
+        condition_field: Field to check for condition.
+        condition_value: Value that triggers the validation.
+        condition_operator: Comparison operator (eq, ne, in, not_in).
+        then_validations: Field validations to apply when condition is true.
+    """
+
+    name: str
+    condition_field: str
+    condition_value: str | tuple[str, ...]
+    condition_operator: Literal["eq", "ne", "in", "not_in"] = "eq"
+    then_validations: tuple[FieldValidation, ...] = ()
+
+    def __post_init__(self) -> None:
+        """Convert lists to tuples for immutability."""
+        if isinstance(self.condition_value, list):
+            object.__setattr__(self, "condition_value", tuple(self.condition_value))
+        if isinstance(self.then_validations, list):
+            object.__setattr__(self, "then_validations", tuple(self.then_validations))
+
+
+@dataclass(frozen=True, slots=True)
+class DQReportConfig:
+    """Configuration for DQ report generation.
+
+    Attributes:
+        enabled: Whether to generate DQ reports. Default: True.
+        format: Report format (json, yaml, csv). Default: json.
+        include_sample_failures: Include sample failed records. Default: True.
+        sample_size: Number of sample failures to include. Default: 10.
+        output_path: Path for report output. None = use pipeline output dir.
+    """
+
+    enabled: bool = True
+    format: Literal["json", "yaml", "csv"] = "json"
+    include_sample_failures: bool = True
+    sample_size: int = 10
+    output_path: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class DQConfig:
-    """Configuration for Data Quality thresholds.
+    """Configuration for Data Quality thresholds and validations.
 
     Attributes:
         soft_fail_threshold: Error rate threshold for warnings (0.0-1.0).
         hard_fail_threshold: Error rate threshold for failures (0.0-1.0).
         strict_validation: If True, apply stricter validation rules that may
             reject more records. Use with caution in production. Default: False.
+        field_validations: Field-level validation rules.
+        cross_field_validations: Cross-field validation rules.
+        conditional_validations: Conditional validation rules.
+        invalid_record_policy: Policy for handling invalid records.
+        report: DQ report configuration.
     """
 
     soft_fail_threshold: float = 0.05
     hard_fail_threshold: float = 0.20
     strict_validation: bool = False
+    # Extended DQ configuration
+    field_validations: tuple[FieldValidation, ...] = ()
+    cross_field_validations: tuple[CrossFieldValidation, ...] = ()
+    conditional_validations: tuple[ConditionalValidation, ...] = ()
+    invalid_record_policy: Literal["quarantine", "skip", "fail"] = "quarantine"
+    report: DQReportConfig = field(default_factory=DQReportConfig)
 
     def __post_init__(self) -> None:
         """Validate threshold invariants on creation."""
@@ -135,6 +271,20 @@ class DQConfig:
             soft_fail_threshold=self.soft_fail_threshold,
             hard_fail_threshold=self.hard_fail_threshold,
         )
+        self._ensure_immutability()
+
+    def _ensure_immutability(self) -> None:
+        """Convert lists to tuples for immutability."""
+        if isinstance(self.field_validations, list):
+            object.__setattr__(self, "field_validations", tuple(self.field_validations))
+        if isinstance(self.cross_field_validations, list):
+            object.__setattr__(
+                self, "cross_field_validations", tuple(self.cross_field_validations)
+            )
+        if isinstance(self.conditional_validations, list):
+            object.__setattr__(
+                self, "conditional_validations", tuple(self.conditional_validations)
+            )
 
     @staticmethod
     def validate_thresholds(

--- a/src/bioetl/infrastructure/schemas/pipeline_config.py
+++ b/src/bioetl/infrastructure/schemas/pipeline_config.py
@@ -34,6 +34,82 @@ if TYPE_CHECKING:
     )
 
 
+class FieldValidationConfig(BaseModel):
+    """Configuration for a single field validation rule.
+
+    Supports: range, pattern, enum, custom validation types.
+    """
+
+    field: str = Field(description="Field name to validate")
+    type: Literal["range", "pattern", "enum", "custom"] = Field(
+        description="Validation type"
+    )
+    nullable: bool = Field(default=True, description="Whether field can be null")
+    # Range validation
+    min: float | None = Field(default=None, description="Minimum value (range)")
+    max: float | None = Field(default=None, description="Maximum value (range)")
+    # Pattern validation
+    pattern: str | None = Field(default=None, description="Regex pattern")
+    # Enum validation
+    allowed: list[str] = Field(default_factory=list, description="Allowed values")
+    # Custom validation
+    validator: str | None = Field(default=None, description="Custom validator name")
+    # Error message
+    error_message: str | None = Field(default=None, description="Custom error message")
+
+
+class CrossFieldValidationConfig(BaseModel):
+    """Configuration for cross-field validation rule."""
+
+    name: str = Field(description="Unique validation rule name")
+    fields: list[str] = Field(description="Fields involved in validation")
+    condition: Literal[
+        "all_present",
+        "any_present",
+        "mutually_exclusive",
+        "conditional_required",
+        "custom",
+    ] = Field(description="Validation condition type")
+    trigger_field: str | None = Field(
+        default=None, description="Field that triggers conditional requirement"
+    )
+    required_field: str | None = Field(
+        default=None, description="Field required when trigger is present"
+    )
+    validator: str | None = Field(default=None, description="Custom validator name")
+    error_message: str | None = Field(default=None, description="Custom error message")
+
+
+class ConditionalValidationConfig(BaseModel):
+    """Configuration for conditional validation rule."""
+
+    name: str = Field(description="Unique validation rule name")
+    condition_field: str = Field(description="Field to check for condition")
+    condition_value: str | list[str] = Field(description="Value(s) that trigger")
+    condition_operator: Literal["eq", "ne", "in", "not_in"] = Field(
+        default="eq", description="Comparison operator"
+    )
+    then_validations: list[FieldValidationConfig] = Field(
+        default_factory=list, description="Validations to apply when condition is true"
+    )
+
+
+class DQReportConfig(BaseModel):
+    """Configuration for DQ report generation."""
+
+    enabled: bool = Field(default=True, description="Generate DQ reports")
+    format: Literal["json", "yaml", "csv"] = Field(
+        default="json", description="Report format"
+    )
+    include_sample_failures: bool = Field(
+        default=True, description="Include sample failed records"
+    )
+    sample_size: int = Field(
+        default=10, ge=1, le=100, description="Number of sample failures"
+    )
+    output_path: str | None = Field(default=None, description="Custom output path")
+
+
 class DQConfig(BaseModel):
     """Data Quality configuration.
 
@@ -44,7 +120,11 @@ class DQConfig(BaseModel):
         hard_fail_threshold: Error rate threshold for failures (0.0-1.0).
         strict_validation: If True, apply stricter validation rules.
             Use with caution as it may reject more records.
-
+        field_validations: Field-level validation rules.
+        cross_field_validations: Cross-field validation rules.
+        conditional_validations: Conditional validation rules.
+        invalid_record_policy: Policy for invalid records (quarantine/skip/fail).
+        report: DQ report configuration.
     """
 
     soft_fail_threshold: float = Field(default=0.05)
@@ -52,6 +132,22 @@ class DQConfig(BaseModel):
     strict_validation: bool = Field(
         default=False,
         description="Apply stricter validation rules (feature flag)",
+    )
+    # Extended DQ configuration
+    field_validations: list[FieldValidationConfig] = Field(
+        default_factory=list, description="Field-level validation rules"
+    )
+    cross_field_validations: list[CrossFieldValidationConfig] = Field(
+        default_factory=list, description="Cross-field validation rules"
+    )
+    conditional_validations: list[ConditionalValidationConfig] = Field(
+        default_factory=list, description="Conditional validation rules"
+    )
+    invalid_record_policy: Literal["quarantine", "skip", "fail"] = Field(
+        default="quarantine", description="Policy for invalid records"
+    )
+    report: DQReportConfig = Field(
+        default_factory=DQReportConfig, description="DQ report configuration"
     )
 
     @model_validator(mode="after")
@@ -69,10 +165,92 @@ class DQConfig(BaseModel):
         Returns:
             DomainDQConfig: Immutable domain configuration.
         """
+        from bioetl.domain.config import (
+            ConditionalValidation as DomainConditionalValidation,
+        )
+        from bioetl.domain.config import (
+            CrossFieldValidation as DomainCrossFieldValidation,
+        )
+        from bioetl.domain.config import DQReportConfig as DomainDQReportConfig
+        from bioetl.domain.config import FieldValidation as DomainFieldValidation
+
+        # Convert field validations
+        field_validations = tuple(
+            DomainFieldValidation(
+                field=fv.field,
+                validation_type=fv.type,
+                nullable=fv.nullable,
+                min_value=fv.min,
+                max_value=fv.max,
+                pattern=fv.pattern,
+                allowed=tuple(fv.allowed),
+                validator=fv.validator,
+                error_message=fv.error_message,
+            )
+            for fv in self.field_validations
+        )
+
+        # Convert cross-field validations
+        cross_field_validations = tuple(
+            DomainCrossFieldValidation(
+                name=cfv.name,
+                fields=tuple(cfv.fields),
+                condition=cfv.condition,
+                trigger_field=cfv.trigger_field,
+                required_field=cfv.required_field,
+                validator=cfv.validator,
+                error_message=cfv.error_message,
+            )
+            for cfv in self.cross_field_validations
+        )
+
+        # Convert conditional validations
+        conditional_validations = tuple(
+            DomainConditionalValidation(
+                name=cv.name,
+                condition_field=cv.condition_field,
+                condition_value=(
+                    tuple(cv.condition_value)
+                    if isinstance(cv.condition_value, list)
+                    else cv.condition_value
+                ),
+                condition_operator=cv.condition_operator,
+                then_validations=tuple(
+                    DomainFieldValidation(
+                        field=tv.field,
+                        validation_type=tv.type,
+                        nullable=tv.nullable,
+                        min_value=tv.min,
+                        max_value=tv.max,
+                        pattern=tv.pattern,
+                        allowed=tuple(tv.allowed),
+                        validator=tv.validator,
+                        error_message=tv.error_message,
+                    )
+                    for tv in cv.then_validations
+                ),
+            )
+            for cv in self.conditional_validations
+        )
+
+        # Convert report config
+        report_config = DomainDQReportConfig(
+            enabled=self.report.enabled,
+            format=self.report.format,
+            include_sample_failures=self.report.include_sample_failures,
+            sample_size=self.report.sample_size,
+            output_path=self.report.output_path,
+        )
+
         return DomainDQConfig(
             soft_fail_threshold=self.soft_fail_threshold,
             hard_fail_threshold=self.hard_fail_threshold,
             strict_validation=self.strict_validation,
+            field_validations=field_validations,
+            cross_field_validations=cross_field_validations,
+            conditional_validations=conditional_validations,
+            invalid_record_policy=self.invalid_record_policy,
+            report=report_config,
         )
 
 


### PR DESCRIPTION
…configs

This commit extends the pipeline configuration system with:

1. Extended DQ (Data Quality) Configuration:
   - field_validations: Field-level validation rules (range, pattern, enum, custom)
   - cross_field_validations: Validation of relationships between fields
   - conditional_validations: Apply validations only when conditions are met
   - invalid_record_policy: quarantine/skip/fail policy for invalid records
   - DQ report configuration with sample failures

2. Domain Layer (domain/config.py):
   - Added FieldValidation dataclass for field-level rules
   - Added CrossFieldValidation dataclass for cross-field rules
   - Added ConditionalValidation dataclass for conditional rules
   - Added DQReportConfig dataclass for report settings
   - Extended DQConfig with all new validation types

3. Infrastructure Layer (schemas/pipeline_config.py):
   - Added Pydantic models for all new validation types
   - Extended DQConfig with to_domain() conversion
   - Full support for YAML parsing and domain conversion

4. Base Configuration (_base.yaml):
   - Extended dq_rules with field_validations, cross_field_validations, conditional_validations, invalid_record_policy, and report sections
   - Added save_metadata configuration for Bronze/Silver/Gold layers
   - Metadata is disabled by default (save_metadata: false)

5. Entity Configs (19 pipelines updated):
   - ChEMBL: activity, assay, molecule, target, publication, cell_line, protein_class, compound_record, assay_parameters, publication_term, publication_similarity, target_component
   - UniProt: protein, idmapping
   - PubChem: compound
   - CrossRef, OpenAlex, PubMed, SemanticScholar: publication

Each entity config now includes entity-specific DQ rules:
- Pattern validation for IDs (CHEMBL format, DOI format, etc.)
- Range validation for numeric fields
- Enum validation for categorical fields
- Cross-field validations for data completeness

Version bumped to 1.2.0 (or 2.1.0 for derived entities) across all configs.