### PR TITLE
Fix architecture metrics and duplication checks

### DIFF
--- a/src/bioetl/application/services/dq/silver_analyzer.py
+++ b/src/bioetl/application/services/dq/silver_analyzer.py
@@ -380,9 +380,9 @@ class SilverDQAnalyzer:
                             max=float(max_val) if max_val is not None else None,  # type: ignore[arg-type]
                             mean=float(mean_val) if mean_val is not None else None,  # type: ignore[arg-type]
                             std=float(std_val) if std_val is not None else None,  # type: ignore[arg-type]
-                            median=float(median_val)
+                            median=float(median_val)  # type: ignore[arg-type]
                             if median_val is not None
-                            else None,  # type: ignore[arg-type]
+                            else None,
                         )
                 except Exception:
                     pass


### PR DESCRIPTION
The mypy `type: ignore[arg-type]` comment was placed on the `else None` line instead of the line containing `float(median_val)`, causing mypy to report both "incompatible type" and "unused type: ignore" errors.