### PR TITLE
Fix architecture metrics and duplication checks

### DIFF
--- a/src/bioetl/application/composite/coordinator.py
+++ b/src/bioetl/application/composite/coordinator.py
@@ -123,11 +123,7 @@ class EnrichmentCoordinator:
                     filter_condition=enricher.filter_condition,
                 )
                 # Create skipped result synchronously
-                tasks.append(
-                    asyncio.create_task(
-                        self._return_skipped(enricher)
-                    )
-                )
+                tasks.append(asyncio.create_task(self._return_skipped(enricher)))
                 enricher_names.append(enricher.pipeline)
                 continue
 
@@ -327,7 +323,9 @@ class EnrichmentCoordinator:
                     status=status,
                     records_input=records_input,
                     records_enriched=records_enriched,
-                    records_not_found=records_input - records_enriched - records_errored,
+                    records_not_found=records_input
+                    - records_enriched
+                    - records_errored,
                     records_errored=records_errored,
                     dq_error_rate=dq_error_rate,
                     duration_seconds=duration,

--- a/src/bioetl/application/composite/merger.py
+++ b/src/bioetl/application/composite/merger.py
@@ -224,9 +224,9 @@ class MergeService:
 
             # Rename common columns in enricher with prefix
             prefix = f"{enricher.pipeline}_"
-            enricher_df = enricher_df.rename({
-                col: f"{prefix}{col}" for col in common_cols
-            })
+            enricher_df = enricher_df.rename(
+                {col: f"{prefix}{col}" for col in common_cols}
+            )
 
             # Apply join based on strategy
             how = self._get_polars_join_type()
@@ -302,7 +302,7 @@ class MergeService:
             prefix = f"{enricher.pipeline}_"
             for col in df.columns:
                 if col.startswith(prefix):
-                    base_col = col[len(prefix):]
+                    base_col = col[len(prefix) :]
                     if base_col in df.columns:
                         # Coalesce seed (base) over enricher
                         result = result.with_columns(
@@ -321,7 +321,7 @@ class MergeService:
             prefix = f"{enricher.pipeline}_"
             for col in df.columns:
                 if col.startswith(prefix):
-                    base_col = col[len(prefix):]
+                    base_col = col[len(prefix) :]
                     if base_col in df.columns:
                         # Coalesce enricher over seed (base)
                         result = result.with_columns(
@@ -395,17 +395,18 @@ class MergeService:
 
         # Build enrichment status dict
         status_dict = {
-            name: result.status.value
-            for name, result in enrichment_results.items()
+            name: result.status.value for name, result in enrichment_results.items()
         }
 
         # Add lineage columns
-        return df.with_columns([
-            pl.lit(run_id).alias("_composite_run_id"),
-            pl.lit(str(sources_used)).alias("_source_providers"),
-            pl.lit(str(status_dict)).alias("_enrichment_status"),
-            pl.lit(datetime.now().isoformat()).alias("_lineage_created_at"),
-        ])
+        return df.with_columns(
+            [
+                pl.lit(run_id).alias("_composite_run_id"),
+                pl.lit(str(sources_used)).alias("_source_providers"),
+                pl.lit(str(status_dict)).alias("_enrichment_status"),
+                pl.lit(datetime.now().isoformat()).alias("_lineage_created_at"),
+            ]
+        )
 
     def _count_enriched_records(
         self, df: pl.DataFrame, enrichers: Sequence[EnricherConfig]
@@ -421,8 +422,7 @@ class MergeService:
                 # Check first enricher column for non-null
                 col = enricher_cols[0]
                 enriched_count = max(
-                    enriched_count,
-                    len(df.filter(df[col].is_not_null()))
+                    enriched_count, len(df.filter(df[col].is_not_null()))
                 )
         return enriched_count
 

--- a/src/bioetl/application/composite/runner.py
+++ b/src/bioetl/application/composite/runner.py
@@ -326,7 +326,9 @@ class CompositePipelineRunner:
 
         return SeedResult(
             pipeline_name=self._config.seed.pipeline,
-            records_extracted=records_extracted.records_fetched if records_extracted else 0,
+            records_extracted=records_extracted.records_fetched
+            if records_extracted
+            else 0,
             records_silver=records_silver,
             keys_generated=records_silver,  # Approximate
             duration_seconds=(completed_at - started_at).total_seconds(),
@@ -370,9 +372,7 @@ class CompositePipelineRunner:
         for enricher_name in self._config.required_enrichers:
             result = enrichment_results.get(enricher_name)
             if result is None:
-                raise RuntimeError(
-                    f"Required enricher '{enricher_name}' did not run"
-                )
+                raise RuntimeError(f"Required enricher '{enricher_name}' did not run")
             if not result.is_success:
                 raise RuntimeError(
                     f"Required enricher '{enricher_name}' failed: "

--- a/src/bioetl/domain/composite/lineage.py
+++ b/src/bioetl/domain/composite/lineage.py
@@ -82,9 +82,7 @@ class LineageMetadata:
     @classmethod
     def from_dict(cls, data: dict[str, object]) -> LineageMetadata:
         """Create LineageMetadata from dictionary."""
-        enrichment_status = _parse_enrichment_status(
-            data.get("_enrichment_status", {})
-        )
+        enrichment_status = _parse_enrichment_status(data.get("_enrichment_status", {}))
         enrichment_timestamps = _parse_timestamps(
             data.get("_enrichment_timestamps", {})
         )

--- a/src/bioetl/domain/composite/result.py
+++ b/src/bioetl/domain/composite/result.py
@@ -46,7 +46,9 @@ class EnrichmentResult:
         if not 0.0 <= self.dq_error_rate <= 1.0:
             raise ValueError(f"dq_error_rate must be 0.0-1.0, got {self.dq_error_rate}")
         if self.duration_seconds < 0.0:
-            raise ValueError(f"duration_seconds must be >= 0, got {self.duration_seconds}")
+            raise ValueError(
+                f"duration_seconds must be >= 0, got {self.duration_seconds}"
+            )
 
     @property
     def is_success(self) -> bool:
@@ -61,50 +63,76 @@ class EnrichmentResult:
     @property
     def not_found_rate(self) -> float:
         """Calculate not-found rate (0.0-1.0)."""
-        return self.records_not_found / self.records_input if self.records_input else 0.0
+        return (
+            self.records_not_found / self.records_input if self.records_input else 0.0
+        )
 
     @classmethod
     def success(
-        cls, enricher_name: str, records_input: int, records_enriched: int,
-        records_not_found: int = 0, duration_seconds: float = 0.0,
-        started_at: datetime | None = None, completed_at: datetime | None = None,
+        cls,
+        enricher_name: str,
+        records_input: int,
+        records_enriched: int,
+        records_not_found: int = 0,
+        duration_seconds: float = 0.0,
+        started_at: datetime | None = None,
+        completed_at: datetime | None = None,
     ) -> EnrichmentResult:
         """Factory for successful enrichment result."""
         return cls(
-            enricher_name=enricher_name, status=EnrichmentStatus.SUCCESS,
-            records_input=records_input, records_enriched=records_enriched,
-            records_not_found=records_not_found, duration_seconds=duration_seconds,
-            started_at=started_at, completed_at=completed_at,
+            enricher_name=enricher_name,
+            status=EnrichmentStatus.SUCCESS,
+            records_input=records_input,
+            records_enriched=records_enriched,
+            records_not_found=records_not_found,
+            duration_seconds=duration_seconds,
+            started_at=started_at,
+            completed_at=completed_at,
         )
 
     @classmethod
     def failed(
-        cls, enricher_name: str, error_message: str,
-        records_input: int = 0, duration_seconds: float = 0.0,
+        cls,
+        enricher_name: str,
+        error_message: str,
+        records_input: int = 0,
+        duration_seconds: float = 0.0,
     ) -> EnrichmentResult:
         """Factory for failed enrichment result."""
         return cls(
-            enricher_name=enricher_name, status=EnrichmentStatus.FAILED,
-            records_input=records_input, error_message=error_message,
+            enricher_name=enricher_name,
+            status=EnrichmentStatus.FAILED,
+            records_input=records_input,
+            error_message=error_message,
             duration_seconds=duration_seconds,
         )
 
     @classmethod
     def skipped(
-        cls, enricher_name: str, reason: str = "Filter excluded all records",
+        cls,
+        enricher_name: str,
+        reason: str = "Filter excluded all records",
     ) -> EnrichmentResult:
         """Factory for skipped enrichment result."""
-        return cls(enricher_name=enricher_name, status=EnrichmentStatus.SKIPPED,
-                   error_message=reason)
+        return cls(
+            enricher_name=enricher_name,
+            status=EnrichmentStatus.SKIPPED,
+            error_message=reason,
+        )
 
     @classmethod
     def timeout(
-        cls, enricher_name: str, timeout_seconds: float, records_input: int = 0,
+        cls,
+        enricher_name: str,
+        timeout_seconds: float,
+        records_input: int = 0,
     ) -> EnrichmentResult:
         """Factory for timeout enrichment result."""
         return cls(
-            enricher_name=enricher_name, status=EnrichmentStatus.TIMEOUT,
-            records_input=records_input, error_message=f"Timeout after {timeout_seconds}s",
+            enricher_name=enricher_name,
+            status=EnrichmentStatus.TIMEOUT,
+            records_input=records_input,
+            error_message=f"Timeout after {timeout_seconds}s",
             duration_seconds=timeout_seconds,
         )
 
@@ -151,7 +179,9 @@ class MergeResult:
     @property
     def enrichment_rate(self) -> float:
         """Calculate overall enrichment rate."""
-        return self.records_enriched / self.records_merged if self.records_merged else 0.0
+        return (
+            self.records_enriched / self.records_merged if self.records_merged else 0.0
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -197,8 +227,11 @@ class CompositeResult:
     @property
     def failed_enrichers(self) -> list[str]:
         """List of enrichers that failed."""
-        return [n for n, r in self.enrichment_results.items()
-                if r.status == EnrichmentStatus.FAILED]
+        return [
+            n
+            for n, r in self.enrichment_results.items()
+            if r.status == EnrichmentStatus.FAILED
+        ]
 
     @property
     def total_records_enriched(self) -> int:
@@ -215,6 +248,8 @@ class CompositeResult:
             "enrichers_run": len(self.enrichment_results),
             "enrichers_succeeded": len(self.successful_enrichers),
             "enrichers_failed": len(self.failed_enrichers),
-            "records_merged": self.merge_result.records_merged if self.merge_result else 0,
+            "records_merged": self.merge_result.records_merged
+            if self.merge_result
+            else 0,
             "total_duration_seconds": self.total_duration_seconds,
         }

--- a/tests/architecture/test_code_metrics.py
+++ b/tests/architecture/test_code_metrics.py
@@ -476,6 +476,10 @@ class TestClassSize:
         "PubchemMoleculeSchema": 350,  # 345 lines - PubChem molecule schema with many chemical fields
         # Derived entity data source wrappers (comprehensive docstrings)
         "PublicationTermDataSource": 570,  # 566 lines - Wrapper with FilterableDataSourcePort delegation
+        # Composite pipeline services (ADR-026)
+        "MergeService": 450,  # 427 lines - Composite merge service with conflict resolution
+        "EnrichmentCoordinator": 400,  # 375 lines - Enricher orchestration service
+        "CompositePipelineRunner": 350,  # 313 lines - Composite pipeline orchestrator
     }
 
     def test_classes_under_300_lines(self, src_dir: Path) -> None:
@@ -628,6 +632,10 @@ class TestGodObjectDetection:
         "MergeService": "Cohesive service - all methods relate to merge operations and conflict resolution",
         "EnrichmentCoordinator": "Cohesive service - all methods relate to enricher orchestration",
         "CompositePipelineRunner": "Thin orchestrator - delegates to coordinator, merger, checkpoint services",
+        # DQ analyzers (cohesive data quality analysis with many validation methods)
+        "GoldDQAnalyzer": "Cohesive analyzer - all methods relate to Gold layer data quality analysis",
+        "SilverDQAnalyzer": "Cohesive analyzer - all methods relate to Silver layer data quality analysis",
+        "DQReportSerializer": "Cohesive serializer - all methods relate to DQ report serialization formats",
     }
 
     def test_large_classes_have_delegation(self, src_dir: Path) -> None:

--- a/tests/unit/domain/composite/test_composite_config.py
+++ b/tests/unit/domain/composite/test_composite_config.py
@@ -12,8 +12,6 @@ from bioetl.domain.composite.config import (
     CompositeConfig,
     DQOverrideConfig,
     EnricherConfig,
-    ExecutionConfig,
-    LineageConfig,
     MergeConfig,
     SeedConfig,
 )

--- a/tests/unit/domain/composite/test_composite_result.py
+++ b/tests/unit/domain/composite/test_composite_result.py
@@ -5,8 +5,6 @@ Tests for EnrichmentResult, MergeResult, CompositeResult.
 
 from __future__ import annotations
 
-from datetime import datetime
-
 import pytest
 
 from bioetl.domain.composite.result import (
@@ -87,7 +85,7 @@ class TestEnrichmentResult:
 
     def test_invalid_dq_error_rate_raises(self):
         """DQ error rate outside 0-1 should raise ValueError."""
-        with pytest.raises(ValueError, match="dq_error_rate must be 0.0-1.0"):
+        with pytest.raises(ValueError, match=r"dq_error_rate must be 0\.0-1\.0"):
             EnrichmentResult(
                 enricher_name="test",
                 status=EnrichmentStatus.SUCCESS,


### PR DESCRIPTION
- Remove unused imports (ExecutionConfig, LineageConfig, datetime) from tests
- Fix regex pattern in test to use raw string for pytest.raises match
- Apply ruff formatting to composite module files
- Add class size exemptions for composite services (MergeService, EnrichmentCoordinator, CompositePipelineRunner)
- Add god object exemptions for DQ analyzers (GoldDQAnalyzer, SilverDQAnalyzer, DQReportSerializer)