### PR TITLE
Remove deprecated code from BioETL

### DIFF
--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -57,14 +57,11 @@ from bioetl.domain.entities import (  # DTO Records (Pydantic); Domain Entities 
     ChemblPublicationRecord,
     ChemblPublicationTermRecord,
     CompoundRecord,
-    DocumentRecord,
     DocumentSimilarity,
     DocumentTerm,
-    DocumentTermRecord,
     Molecule,
     MoleculeRecord,
     ProteinClassification,
-    PubChemCompoundRecord,
     PubchemMolecule,
     PubchemMoleculeRecord,
     Publication,
@@ -313,16 +310,9 @@ __all__ = [
     "ArticleRecord",
     "AssayRecord",
     "CellLineRecord",
-    # Canonical DTO names (ADR-024)
     "ChemblPublicationRecord",
     "ChemblPublicationTermRecord",
-    # Deprecated aliases (backward compatibility)
-    "DocumentRecord",
-    "DocumentTermRecord",
     "MoleculeRecord",
-    # Deprecated alias
-    "PubChemCompoundRecord",
-    # Canonical DTO name (ADR-024)
     "PubchemMoleculeRecord",
     "PublicationRecord",
     "TargetComponentRecord",

--- a/src/bioetl/domain/entities/__init__.py
+++ b/src/bioetl/domain/entities/__init__.py
@@ -27,12 +27,8 @@ from bioetl.domain.entities.chembl import (
     ActivityRecord,
     AssayRecord,
     CellLineRecord,
-    # Canonical names (ADR-024)
     ChemblPublicationRecord,
     ChemblPublicationTermRecord,
-    # Deprecated aliases (backward compatibility)
-    DocumentRecord,
-    DocumentTermRecord,
     MoleculeRecord,
     TargetComponentRecord,
     TargetRecord,
@@ -58,10 +54,7 @@ from bioetl.domain.entities.crossref import PublicationEntity, PublicationRecord
 
 # PubChem DTO + Entity
 from bioetl.domain.entities.pubchem import (
-    # Deprecated alias (backward compatibility)
-    PubChemCompoundRecord,
     PubchemMolecule,
-    # Canonical names (ADR-024)
     PubchemMoleculeRecord,
 )
 
@@ -86,22 +79,15 @@ __all__ = [
     "CellLine",
     "CellLineRecord",
     "ChemblPublication",
-    # Canonical DTO names (ADR-024)
     "ChemblPublicationRecord",
     "ChemblPublicationTermRecord",
     "CompoundRecord",
-    # Deprecated aliases (backward compatibility)
-    "DocumentRecord",
     "DocumentSimilarity",
     "DocumentTerm",
-    "DocumentTermRecord",
     "Molecule",
     "MoleculeRecord",
     "ProteinClassification",
-    # Deprecated alias
-    "PubChemCompoundRecord",
     "PubchemMolecule",
-    # Canonical DTO name (ADR-024)
     "PubchemMoleculeRecord",
     "Publication",
     "PublicationEntity",

--- a/src/bioetl/domain/entities/chembl.py
+++ b/src/bioetl/domain/entities/chembl.py
@@ -692,22 +692,12 @@ class ProteinClassRecord(BaseModel):
     )
 
 
-# === Deprecated Aliases (ADR-024 backward compatibility) ===
-# These will be removed in v3.0
-DocumentRecord = ChemblPublicationRecord
-DocumentTermRecord = ChemblPublicationTermRecord
-
-
 __all__ = [
     "ActivityRecord",
     "AssayRecord",
     "CellLineRecord",
-    # Canonical names (ADR-024)
     "ChemblPublicationRecord",
     "ChemblPublicationTermRecord",
-    # Deprecated aliases (backward compatibility)
-    "DocumentRecord",
-    "DocumentTermRecord",
     "MoleculeRecord",
     "ProteinClassRecord",
     "TargetComponentRecord",

--- a/src/bioetl/domain/entities/pubchem.py
+++ b/src/bioetl/domain/entities/pubchem.py
@@ -119,15 +119,7 @@ class PubchemMolecule(BaseEntity):
             )
 
 
-# === Deprecated Alias (ADR-024 backward compatibility) ===
-# Will be removed in v3.0
-PubChemCompoundRecord = PubchemMoleculeRecord
-
-
 __all__ = [
-    # Deprecated alias (backward compatibility)
-    "PubChemCompoundRecord",
     "PubchemMolecule",
-    # Canonical names (ADR-024)
     "PubchemMoleculeRecord",
 ]

--- a/src/bioetl/infrastructure/adapters/chembl/__init__.py
+++ b/src/bioetl/infrastructure/adapters/chembl/__init__.py
@@ -14,13 +14,9 @@ from bioetl.infrastructure.adapters.chembl.models import (
     ChemblActivityResponse,
     ChemblAssayRecord,
     ChemblAssayResponse,
-    # Deprecated aliases (backward compatibility)
-    ChemblDocumentRecord,
-    ChemblDocumentResponse,
     ChemblMoleculeRecord,
     ChemblMoleculeResponse,
     ChemblPageMeta,
-    # Canonical names (ADR-024)
     ChemblPublicationRecord,
     ChemblPublicationResponse,
     ChemblTargetComponentRecord,
@@ -30,27 +26,17 @@ from bioetl.infrastructure.adapters.chembl.models import (
 )
 
 __all__ = [
-    # Model Mappings
     "CHEMBL_RECORD_MODELS",
     "CHEMBL_RESPONSE_MODELS",
-    # Record Models
     "ChemblActivityRecord",
-    # Response Models
     "ChemblActivityResponse",
-    # Adapter
     "ChemblAdapter",
     "ChemblAssayRecord",
     "ChemblAssayResponse",
-    # Deprecated aliases (backward compatibility)
-    "ChemblDocumentRecord",
-    # Deprecated alias
-    "ChemblDocumentResponse",
     "ChemblMoleculeRecord",
     "ChemblMoleculeResponse",
     "ChemblPageMeta",
-    # Canonical names (ADR-024)
     "ChemblPublicationRecord",
-    # Canonical name (ADR-024)
     "ChemblPublicationResponse",
     "ChemblTargetComponentRecord",
     "ChemblTargetComponentResponse",

--- a/src/bioetl/infrastructure/adapters/chembl/client.py
+++ b/src/bioetl/infrastructure/adapters/chembl/client.py
@@ -16,7 +16,7 @@ from bioetl.domain.entities.chembl import (
     ActivityRecord,
     AssayRecord,
     CellLineRecord,
-    DocumentRecord,
+    ChemblPublicationRecord,
     MoleculeRecord,
     ProteinClassRecord,
     TargetComponentRecord,
@@ -55,7 +55,7 @@ CHEMBL_DTO_MODELS: dict[str, type[BaseModel]] = {
     "compound": MoleculeRecord,  # Alias for molecule
     "target": TargetRecord,
     "target_component": TargetComponentRecord,
-    "document": DocumentRecord,
+    "document": ChemblPublicationRecord,
     "cell_line": CellLineRecord,
     "protein_class": ProteinClassRecord,
 }

--- a/src/bioetl/infrastructure/adapters/chembl/models.py
+++ b/src/bioetl/infrastructure/adapters/chembl/models.py
@@ -598,12 +598,6 @@ class ChemblStatusResponse(BaseModel):
     chembl_release_date: str | None = Field(default=None)
 
 
-# === Deprecated Aliases (ADR-024 backward compatibility) ===
-# Will be removed in v3.0
-ChemblDocumentRecord = ChemblPublicationRecord
-ChemblDocumentResponse = ChemblPublicationResponse
-
-
 # === Response Type Mapping ===
 
 # Mapping from entity type to response class for factory usage

--- a/src/bioetl/infrastructure/adapters/pubchem/__init__.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/__init__.py
@@ -10,10 +10,6 @@ from bioetl.infrastructure.adapters.pubchem.models import (
     PUBCHEM_RECORD_MODELS,
     PubChemAssayRecord,
     PubChemBioactivityRecord,
-    # Deprecated aliases (backward compatibility)
-    PubChemCompoundDetailRecord,
-    PubChemCompoundRecord,
-    # Canonical names (ADR-024)
     PubchemMoleculeDetailRecord,
     PubchemMoleculeRecord,
     PubChemSubstanceRecord,
@@ -24,13 +20,10 @@ __all__ = [
     "PUBCHEM_RECORD_MODELS",
     # Adapter
     "PubChemAdapter",
+    # Record Models
     "PubChemAssayRecord",
     "PubChemBioactivityRecord",
-    # Deprecated aliases (backward compatibility)
-    "PubChemCompoundDetailRecord",
-    "PubChemCompoundRecord",
     "PubChemSubstanceRecord",
-    # Canonical names (ADR-024)
     "PubchemMoleculeDetailRecord",
     "PubchemMoleculeRecord",
 ]

--- a/src/bioetl/infrastructure/adapters/pubchem/client.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/client.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Any
 import pubchempy as pcp
 from pydantic import BaseModel
 
-from bioetl.domain.entities.pubchem import PubChemCompoundRecord
+from bioetl.domain.entities.pubchem import PubchemMoleculeRecord
 from bioetl.domain.exceptions import CircuitBreakerOpenError
 from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.adapters.filterable_mixin import FilterableStubMixin
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
 
 # Mapping from entity_type to DTO model class
 PUBCHEM_DTO_MODELS: dict[str, type[BaseModel]] = {
-    "compound": PubChemCompoundRecord,
+    "compound": PubchemMoleculeRecord,
 }
 
 

--- a/src/bioetl/infrastructure/adapters/pubchem/models.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/models.py
@@ -221,12 +221,6 @@ class PubChemBioactivityRecord(BaseModel):
     )
 
 
-# === Deprecated Aliases (ADR-024 backward compatibility) ===
-# Will be removed in v3.0
-PubChemCompoundRecord = PubchemMoleculeRecord
-PubChemCompoundDetailRecord = PubchemMoleculeDetailRecord
-
-
 # === Record Type Mapping ===
 
 # Mapping from entity type to record model


### PR DESCRIPTION
BREAKING CHANGE: Removed deprecated backward-compatibility aliases.

Removed from domain/entities/chembl.py:
- DocumentRecord → use ChemblPublicationRecord
- DocumentTermRecord → use ChemblPublicationTermRecord

Removed from domain/entities/pubchem.py:
- PubChemCompoundRecord → use PubchemMoleculeRecord

Removed from infrastructure/adapters/chembl/models.py:
- ChemblDocumentRecord → use ChemblPublicationRecord
- ChemblDocumentResponse → use ChemblPublicationResponse

Removed from infrastructure/adapters/pubchem/models.py:
- PubChemCompoundRecord → use PubchemMoleculeRecord
- PubChemCompoundDetailRecord → use PubchemMoleculeDetailRecord

Migrated internal usages:
- chembl/client.py: DocumentRecord → ChemblPublicationRecord
- pubchem/client.py: PubChemCompoundRecord → PubchemMoleculeRecord

All 895 architecture tests pass.
All 501 pipeline unit tests pass.
Mypy strict: Success (411 source files).
Ruff: All checks passed.

See: ADR-024 (Entity Naming Unification)