### PR TITLE
Add missing docstrings to BioETL framework

### DIFF
--- a/src/bioetl/domain/ports/dq_report.py
+++ b/src/bioetl/domain/ports/dq_report.py
@@ -29,10 +29,18 @@ if TYPE_CHECKING:
         SilverDQReport,
     )
 
-# Type aliases for data containers (polars/pyarrow)
-# Using Any to avoid infrastructure imports in domain layer
-DataContainer = Any  # polars.DataFrame | pyarrow.Table
-DataContainerDict = dict[str, Any]  # dict[str, polars.DataFrame | pyarrow.Table]
+DataContainer = Any
+"""Type alias for data containers (polars.DataFrame or pyarrow.Table).
+
+Uses Any to avoid infrastructure imports in domain layer per Ports & Adapters.
+"""
+
+DataContainerDict = dict[str, Any]
+"""Type alias for dictionary of named data containers.
+
+Maps table names to polars.DataFrame or pyarrow.Table instances.
+Uses Any to avoid infrastructure imports in domain layer.
+"""
 
 
 @runtime_checkable

--- a/src/bioetl/infrastructure/storage/_atomic.py
+++ b/src/bioetl/infrastructure/storage/_atomic.py
@@ -229,6 +229,17 @@ class AtomicWriteGroup:
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
+        """Exit context manager, rolling back on exception.
+
+        If an exception occurred within the context, all pending temp files
+        are cleaned up via rollback(). If no exception, user should have
+        called commit() explicitly before exiting.
+
+        Args:
+            exc_type: Exception type if an exception was raised, None otherwise.
+            exc_val: Exception instance if an exception was raised, None otherwise.
+            exc_tb: Traceback if an exception was raised, None otherwise.
+        """
         if exc_type is not None:
             self.rollback()
         # If no exception, user should have called commit()


### PR DESCRIPTION
- Add docstring to AtomicWriteGroup.__exit__ method explaining rollback behavior on exception
- Convert type alias comments to proper docstrings in dq_report.py for DataContainer and DataContainerDict

Per RULES.md §10.3.1: public classes/functions MUST have docstrings.