### PR TITLE
Replace sentinel values with None

### DIFF
--- a/src/bioetl/application/services/dq/gold_analyzer.py
+++ b/src/bioetl/application/services/dq/gold_analyzer.py
@@ -295,7 +295,7 @@ class GoldDQAnalyzer:
             column = rule.get("column")
             condition = rule.get("condition")
 
-            violations = 0
+            violations: int | None = 0
             passed = True
 
             try:
@@ -326,7 +326,7 @@ class GoldDQAnalyzer:
                         passed = violations == 0
             except Exception:
                 passed = False
-                violations = -1  # Unknown
+                violations = None  # Unknown due to exception
 
             if passed:
                 rules_passed += 1

--- a/src/bioetl/domain/services/dq_serializer.py
+++ b/src/bioetl/domain/services/dq_serializer.py
@@ -292,9 +292,9 @@ class DQReportSerializer:
             <span class="status-badge status-{status}">{status}</span>
         </div>
         <div class="meta">
-            <span><strong>Pipeline:</strong> {data.get("pipeline", "N/A")}</span>
-            <span><strong>Run ID:</strong> {data.get("run_id", "N/A")}</span>
-            <span><strong>Timestamp:</strong> {data.get("timestamp", "N/A")}</span>
+            <span><strong>Pipeline:</strong> {data.get("pipeline") or "—"}</span>
+            <span><strong>Run ID:</strong> {data.get("run_id") or "—"}</span>
+            <span><strong>Timestamp:</strong> {data.get("timestamp") or "—"}</span>
         </div>
     </div>
 
@@ -411,14 +411,18 @@ class DQReportSerializer:
         status = thresholds.get("threshold_status", "pass")
         status_class = self._status_color(status)
 
+        soft_threshold = thresholds.get("soft_fail_threshold")
+        hard_threshold = thresholds.get("hard_fail_threshold")
+        error_rate = thresholds.get("current_error_rate")
+
         return f"""
     <div class="card">
         <h2>DQ Thresholds</h2>
         <div class="check-item {status_class}">
             <table>
-                <tr><td><strong>Soft Fail Threshold</strong></td><td>{thresholds.get("soft_fail_threshold", "N/A")}</td></tr>
-                <tr><td><strong>Hard Fail Threshold</strong></td><td>{thresholds.get("hard_fail_threshold", "N/A")}</td></tr>
-                <tr><td><strong>Current Error Rate</strong></td><td>{thresholds.get("current_error_rate", "N/A")}</td></tr>
+                <tr><td><strong>Soft Fail Threshold</strong></td><td>{soft_threshold if soft_threshold is not None else "—"}</td></tr>
+                <tr><td><strong>Hard Fail Threshold</strong></td><td>{hard_threshold if hard_threshold is not None else "—"}</td></tr>
+                <tr><td><strong>Current Error Rate</strong></td><td>{error_rate if error_rate is not None else "—"}</td></tr>
                 <tr><td><strong>Status</strong></td><td><span class="status-badge status-{status_class}">{status}</span></td></tr>
             </table>
         </div>

--- a/src/bioetl/domain/value_objects/dq_report.py
+++ b/src/bioetl/domain/value_objects/dq_report.py
@@ -342,7 +342,7 @@ class BusinessRuleResult:
     name: str
     description: str
     passed: bool
-    violations: int
+    violations: int | None  # None indicates unknown (e.g., exception during check)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/bioetl/interfaces/cli/commands/quarantine.py
+++ b/src/bioetl/interfaces/cli/commands/quarantine.py
@@ -152,8 +152,10 @@ def quarantine_replay(
     if dry_run:
         click.echo(f"\nWould replay {len(records)} record(s):\n")
         for i, rec in enumerate(records[:10], 1):
+            payload_hash = rec.get("payload_hash")
+            hash_display = payload_hash[:16] if payload_hash else "—"
             click.echo(
-                f"  {i}. Error: {rec.get('error_code')} | Hash: {rec.get('payload_hash', 'N/A')[:16]}..."
+                f"  {i}. Error: {rec.get('error_code')} | Hash: {hash_display}..."
             )
         if len(records) > 10:
             click.echo(f"  ... and {len(records) - 10} more")

--- a/src/bioetl/interfaces/cli/formatters.py
+++ b/src/bioetl/interfaces/cli/formatters.py
@@ -94,9 +94,10 @@ def echo_quarantine_record(record: dict[str, Any]) -> None:
     Args:
         record: Dictionary with quarantine record data.
     """
-    error_code = record.get("error_code", "UNKNOWN")
-    payload = record.get("payload", "N/A")
-    click.echo(f"Error: {error_code} | Payload: {payload}")
+    error_code = record.get("error_code") or "UNKNOWN"
+    payload = record.get("payload")
+    payload_display = payload if payload is not None else "—"
+    click.echo(f"Error: {error_code} | Payload: {payload_display}")
 
 
 def echo_checkpoint(checkpoint: str) -> None:

--- a/tests/unit/interfaces/test_cli_run_all_vacuum_formatters.py
+++ b/tests/unit/interfaces/test_cli_run_all_vacuum_formatters.py
@@ -745,13 +745,14 @@ class TestEchoFunctions:
         assert '{"id": 1}' in result.output
 
     def test_echo_quarantine_record_with_defaults(self, cli_runner):
-        """Test echo_quarantine_record with missing fields."""
+        """Test echo_quarantine_record with missing fields uses proper None handling."""
         record = {}
         result = cli_runner.invoke(
             click.command()(lambda: echo_quarantine_record(record)), []
         )
         assert "UNKNOWN" in result.output
-        assert "N/A" in result.output
+        # Uses em-dash for missing values instead of sentinel "N/A"
+        assert "—" in result.output
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Replace anti-pattern sentinel values (-1, "N/A") with proper None handling as required by CLAUDE.md §11 Anti-Patterns.

Changes:
- gold_analyzer.py: Replace violations = -1 with violations = None
- dq_report.py: Update BusinessRuleResult.violations type to int | None
- formatters.py: Replace "N/A" sentinel with None, display as "—"
- quarantine.py: Replace "N/A" sentinel with None, display as "—"
- dq_serializer.py: Replace 6 instances of "N/A" with proper None handling

Display layer now uses em-dash (—) for missing values instead of sentinel "N/A" string, maintaining user-friendly output while following the anti-pattern rules.