### PR TITLE
Fix naive datetime in composite layer

### DIFF
--- a/src/bioetl/application/composite/checkpoint.py
+++ b/src/bioetl/application/composite/checkpoint.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -74,7 +74,7 @@ class CompositeCheckpointState:
             completed_enrichers=self.completed_enrichers,
             enrichment_results=self.enrichment_results,
             created_at=self.created_at,
-            updated_at=datetime.now(),
+            updated_at=datetime.now(tz=UTC),
         )
 
     def with_enricher_completed(
@@ -91,7 +91,7 @@ class CompositeCheckpointState:
             completed_enrichers=frozenset(new_completed),
             enrichment_results=new_results,
             created_at=self.created_at,
-            updated_at=datetime.now(),
+            updated_at=datetime.now(tz=UTC),
         )
 
     @property
@@ -294,7 +294,7 @@ class CompositeCheckpointManager:
         return CompositeCheckpointState(
             composite_name=self._composite_name,
             run_id=self._run_id,
-            created_at=datetime.now(),
+            created_at=datetime.now(tz=UTC),
         )
 
     async def save(self, state: CompositeCheckpointState) -> None:

--- a/src/bioetl/application/composite/coordinator.py
+++ b/src/bioetl/application/composite/coordinator.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable, Sequence
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from bioetl.domain.composite.result import EnrichmentResult, EnrichmentStatus
@@ -247,7 +247,7 @@ class EnrichmentCoordinator:
             EnrichmentResult with execution outcome.
         """
         async with self._semaphore:
-            started_at = datetime.now()
+            started_at = datetime.now(tz=UTC)
             records_input = len(keys)
 
             self._logger.info(
@@ -263,7 +263,7 @@ class EnrichmentCoordinator:
                     runner = runner_factory(enricher.pipeline, keys)
                     await runner.run()
 
-                completed_at = datetime.now()
+                completed_at = datetime.now(tz=UTC)
                 duration = (completed_at - started_at).total_seconds()
 
                 # Extract stats from runner
@@ -334,7 +334,7 @@ class EnrichmentCoordinator:
                 )
 
             except TimeoutError:
-                duration = (datetime.now() - started_at).total_seconds()
+                duration = (datetime.now(tz=UTC) - started_at).total_seconds()
                 self._logger.warning(
                     "Enricher timed out",
                     enricher=enricher.pipeline,
@@ -347,7 +347,7 @@ class EnrichmentCoordinator:
                 )
 
             except Exception as e:
-                duration = (datetime.now() - started_at).total_seconds()
+                duration = (datetime.now(tz=UTC) - started_at).total_seconds()
                 self._logger.error(
                     "Enricher failed",
                     enricher=enricher.pipeline,

--- a/src/bioetl/application/composite/merger.py
+++ b/src/bioetl/application/composite/merger.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Literal
 
 from bioetl.domain.composite.result import EnrichmentResult, MergeResult
@@ -39,7 +39,7 @@ class MergeService:
         run_id: str,
     ) -> MergeResult:
         """Merge seed and enricher data into unified output."""
-        started_at = datetime.now()
+        started_at = datetime.now(tz=UTC)
 
         # Step 1: Read seed data
         self._logger.info(
@@ -124,7 +124,7 @@ class MergeService:
         )
         await self._write_merged_gold(merged_df)
 
-        completed_at = datetime.now()
+        completed_at = datetime.now(tz=UTC)
         duration = (completed_at - started_at).total_seconds()
 
         self._logger.info(
@@ -404,7 +404,7 @@ class MergeService:
                 pl.lit(run_id).alias("_composite_run_id"),
                 pl.lit(str(sources_used)).alias("_source_providers"),
                 pl.lit(str(status_dict)).alias("_enrichment_status"),
-                pl.lit(datetime.now().isoformat()).alias("_lineage_created_at"),
+                pl.lit(datetime.now(tz=UTC).isoformat()).alias("_lineage_created_at"),
             ]
         )
 

--- a/src/bioetl/application/composite/runner.py
+++ b/src/bioetl/application/composite/runner.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, cast
 from uuid import UUID, uuid4
 
@@ -168,7 +168,7 @@ class CompositePipelineRunner:
         Raises:
             CriticalError: If seed or required enricher fails.
         """
-        self._started_at = datetime.now()
+        self._started_at = datetime.now(tz=UTC)
         self._logger.info(
             PipelineEvent.START,
             composite=self._config.name,
@@ -282,7 +282,7 @@ class CompositePipelineRunner:
         # Step 7: Cleanup checkpoint on success
         await self._checkpoint_manager.delete()
 
-        completed_at = datetime.now()
+        completed_at = datetime.now(tz=UTC)
         started = self._started_at or completed_at  # Fallback if not set
         total_duration = (completed_at - started).total_seconds()
 
@@ -313,10 +313,10 @@ class CompositePipelineRunner:
             seed_pipeline=self._config.seed.pipeline,
         )
 
-        started_at = datetime.now()
+        started_at = datetime.now(tz=UTC)
         runner = self._seed_runner_factory()
         await runner.run()
-        completed_at = datetime.now()
+        completed_at = datetime.now(tz=UTC)
 
         # Extract stats from runner (if available)
         records_extracted = getattr(runner, "_executor", None)


### PR DESCRIPTION
Replace 14 instances of naive datetime.now() with timezone-aware datetime.now(tz=UTC) in the composite layer to ensure consistent timestamps across pipeline runs and avoid issues in cross-timezone environments.

Files updated:
- merger.py (3 instances)
- coordinator.py (4 instances)
- checkpoint.py (3 instances)
- runner.py (4 instances)