### PR TITLE
Fix failing architecture and lint checks

### DIFF
--- a/src/bioetl/infrastructure/checkpoint/local_checkpoint.py
+++ b/src/bioetl/infrastructure/checkpoint/local_checkpoint.py
@@ -60,9 +60,7 @@ class LocalCheckpoint:
         Uses run_in_executor to avoid blocking the event loop.
         """
         loop = asyncio.get_running_loop()
-        await loop.run_in_executor(
-            None, self._save_sync, pipeline, run_id, metadata
-        )
+        await loop.run_in_executor(None, self._save_sync, pipeline, run_id, metadata)
 
     def _save_sync(
         self,

--- a/tests/architecture/test_interfaces_no_infrastructure.py
+++ b/tests/architecture/test_interfaces_no_infrastructure.py
@@ -428,29 +428,27 @@ class TestHttpInterfaceNoInfrastructure:
             "Use TYPE_CHECKING for type hints or Application services instead."
         )
 
-    def test_http_type_checking_imports_documented(self):
-        """Document TYPE_CHECKING imports from infrastructure in http/.
+    def test_http_type_checking_imports_use_domain_ports(self):
+        """Verify TYPE_CHECKING imports use domain ports, not infrastructure.
 
-        TYPE_CHECKING imports are allowed for type hints.
-        This test documents them for awareness and tracking.
+        health_server.py should import from domain.ports for type hints,
+        following correct layer dependencies (interfaces -> domain).
         """
         server_path = SRC_PATH / "interfaces" / "http" / "health_server.py"
 
         if not server_path.exists():
             pytest.skip("health_server.py not found")
 
-        # Expected TYPE_CHECKING imports from infrastructure
-        # These are allowed because they're only used for type hints
-        expected_type_checking_imports = [
-            "bioetl.infrastructure.adapters.http.health_monitor",
-        ]
-
         with open(server_path) as f:
             content = f.read()
 
-        # Verify expected TYPE_CHECKING imports exist
-        for expected in expected_type_checking_imports:
-            assert expected in content, (
-                f"Expected TYPE_CHECKING import '{expected}' not found. "
-                f"Was it refactored? Update this test if intentional."
-            )
+        # Verify correct domain port imports are used
+        assert "from bioetl.domain.ports import" in content, (
+            "health_server.py should import from bioetl.domain.ports for type hints"
+        )
+
+        # Verify no infrastructure imports in TYPE_CHECKING block
+        assert "bioetl.infrastructure.adapters.http.health_monitor" not in content, (
+            "health_server.py should not import from infrastructure. "
+            "Use domain ports instead."
+        )


### PR DESCRIPTION
- Apply ruff formatting to local_checkpoint.py
- Update test to reflect correct domain port imports in health_server.py

The test was checking for infrastructure imports that were correctly refactored to use domain.ports (proper layer dependencies).