### PR TITLE
Fix failing architecture metrics checks

### DIFF
--- a/tests/architecture/test_code_metrics.py
+++ b/tests/architecture/test_code_metrics.py
@@ -76,7 +76,6 @@ class TestFileSizeLimits:
         "registration.py": 720,  # 705 LOC - provider registration with data source creators (OpenAlex + SemanticScholar + UniProt IDMapping)
         "storage_adapter.py": 610,  # 601 LOC - storage adapter with Bronze/Silver/Gold writers + read_silver, write_*_merged
         # Consolidated factory files (v5.2)
-        "storage.py": 700,  # 640 LOC - merged storage_factory + storage_adapter
         "pipeline_factory.py": 560,  # 557 LOC - merged generic_factory + runner_assembly + entity_type helper
         "pipeline_factories.py": 520,  # 505 LOC - pipeline factory configurations (OpenAlex + SemanticScholar + IDMapping)
         "services_factory.py": 600,  # 562 LOC - merged base_services + services_builder + runner_services + LockContextHolder + BatchExecutor factory

--- a/tests/unit/test_ports.py
+++ b/tests/unit/test_ports.py
@@ -153,6 +153,32 @@ class TestStoragePortProtocol:
                 schema: Any,
                 primary_keys: list[str] | None = None,
                 mode: Literal["overwrite", "append", "scd2"] = "overwrite",
+                *,
+                ingestion_ts: Any = None,
+                run_id: Any = None,
+            ) -> None:
+                pass
+
+            async def read_silver(
+                self,
+                table_name: str,
+                columns: list[str] | None = None,
+            ) -> list[dict[str, Any]]:
+                return []
+
+            async def write_silver_merged(
+                self,
+                table_name: str,
+                records: list[dict[str, Any]],
+                primary_keys: list[str] | None = None,
+            ) -> None:
+                pass
+
+            async def write_gold_merged(
+                self,
+                table_name: str,
+                records: list[dict[str, Any]],
+                primary_keys: list[str] | None = None,
             ) -> None:
                 pass
 


### PR DESCRIPTION
- Remove duplicate 'storage.py' dictionary key in test_code_metrics.py (F601)
- Add missing methods to ValidStorage in test_ports.py to match StoragePort:
  - read_silver: reads from Silver table
  - write_silver_merged: writes merged records to Silver
  - write_gold_merged: writes merged records to Gold
  - Updated write_gold signature with ingestion_ts and run_id params