### PR TITLE
Implement Bronze path tracking for data lineage

### DIFF
--- a/src/bioetl/application/core/batch_executor.py
+++ b/src/bioetl/application/core/batch_executor.py
@@ -317,8 +317,8 @@ class BatchExecutor:
         span = self._tracing.start_batch_span(batch_id, len(records), start_index)
 
         try:
-            # Write to Bronze
-            await self._execute_with_span(
+            # Write to Bronze and capture result for lineage tracking (REQ-LINEAGE-001)
+            bronze_result = await self._execute_with_span(
                 "write_bronze",
                 self._writer.write_bronze(records, batch_id, ingestion_ts),
                 batch_id,
@@ -344,12 +344,16 @@ class BatchExecutor:
                 "gold", len(result.gold_records)
             )
 
-            # Write to Silver
+            # Write to Silver with bronze_refs for lineage tracking (REQ-LINEAGE-001)
+            bronze_refs = [bronze_result] if bronze_result else None
             if result.silver_records:
                 await self._execute_with_span(
                     "write_silver",
                     self._writer.write_silver(
-                        result.silver_records, batch_id, ingestion_ts
+                        result.silver_records,
+                        batch_id,
+                        ingestion_ts,
+                        bronze_refs=bronze_refs,
                     ),
                     batch_id,
                     len(result.silver_records),

--- a/src/bioetl/application/core/batch_writer.py
+++ b/src/bioetl/application/core/batch_writer.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from bioetl.domain.error_classifier import ErrorClassifier
     from bioetl.domain.ports import GoldValidatorPort, StoragePort, TracingPort
     from bioetl.domain.types import BatchID
+    from bioetl.domain.value_objects.bronze_result import BronzeWriteResult
 
 
 class BatchWriter:
@@ -181,7 +182,7 @@ class BatchWriter:
 
     async def write_bronze(
         self, records: list[dict[str, Any]], batch_id: BatchID, ingestion_ts: datetime
-    ) -> None:
+    ) -> BronzeWriteResult:
         """Write records to Bronze layer.
 
         Serializes records to JSON with deterministic key ordering,
@@ -191,6 +192,10 @@ class BatchWriter:
             records: Raw records to write.
             batch_id: Identifier for the current batch.
             ingestion_ts: Ingestion timestamp from context.
+
+        Returns:
+            BronzeWriteResult with path, record count, sizes, and checksum
+            for downstream lineage tracking (REQ-LINEAGE-001).
 
         Raises:
             LockNotHeldError: If lock is no longer held (Safety Guard §4.6).
@@ -213,7 +218,7 @@ class BatchWriter:
             # Create generator for bytes with newlines
             record_bytes = (b + b"\n" for b in json_bytes_list)
 
-            await self._storage.write_bronze(
+            bronze_result = await self._storage.write_bronze(
                 records=record_bytes,
                 provider=self._provider,
                 entity=self._entity_type,
@@ -224,12 +229,17 @@ class BatchWriter:
                 ingestion_ts=ingestion_ts,
             )
             self._end_span(span)
+            return bronze_result
         except Exception as e:
             self._end_span(span, e)
             raise
 
     async def write_silver(
-        self, records: list[dict[str, Any]], batch_id: BatchID, ingestion_ts: datetime
+        self,
+        records: list[dict[str, Any]],
+        batch_id: BatchID,
+        ingestion_ts: datetime,
+        bronze_refs: list[BronzeWriteResult] | None = None,
     ) -> None:
         """Write records to Silver layer with metadata.
 
@@ -239,6 +249,9 @@ class BatchWriter:
             records: Transformed Silver records.
             batch_id: Identifier for the source batch.
             ingestion_ts: Ingestion timestamp from context.
+            bronze_refs: Optional list of BronzeWriteResult from Bronze writes.
+                If provided, bronze_paths will be populated in Silver metadata
+                for complete lineage tracking (REQ-LINEAGE-001).
 
         Raises:
             LockNotHeldError: If lock is no longer held (Safety Guard §4.6).
@@ -269,6 +282,7 @@ class BatchWriter:
                 schema=self._silver_schema,
                 mode=self._silver_mode,
                 on_schema_mismatch=self._table_config.on_schema_mismatch,
+                bronze_refs=bronze_refs,
             )
             self._end_span(span)
         except Exception as e:

--- a/src/bioetl/application/core/record_processor.py
+++ b/src/bioetl/application/core/record_processor.py
@@ -104,8 +104,8 @@ class RecordProcessor:
         """Process batch through Bronze -> Silver -> Gold with tracing."""
         ingestion_ts = self._context.started_at
 
-        # Write to Bronze
-        await self._execute_with_span(
+        # Write to Bronze and capture result for lineage tracking (REQ-LINEAGE-001)
+        bronze_result = await self._execute_with_span(
             "write_bronze",
             self._writer.write_bronze(records, batch_id, ingestion_ts),
             batch_id,
@@ -127,12 +127,16 @@ class RecordProcessor:
         )
         self._batch_metrics.track_processed_records("gold", len(result.gold_records))
 
-        # Write to Silver
+        # Write to Silver with bronze_refs for lineage tracking (REQ-LINEAGE-001)
+        bronze_refs = [bronze_result] if bronze_result else None
         if result.silver_records:
             await self._execute_with_span(
                 "write_silver",
                 self._writer.write_silver(
-                    result.silver_records, batch_id, ingestion_ts
+                    result.silver_records,
+                    batch_id,
+                    ingestion_ts,
+                    bronze_refs=bronze_refs,
                 ),
                 batch_id,
                 len(result.silver_records),

--- a/src/bioetl/domain/ports/storage.py
+++ b/src/bioetl/domain/ports/storage.py
@@ -21,6 +21,7 @@ from bioetl.domain.types import (
     RunID,
     RunType,
 )
+from bioetl.domain.value_objects.bronze_result import BronzeWriteResult
 
 
 @runtime_checkable
@@ -42,7 +43,7 @@ class StoragePort(Protocol):
         run_id: RunID,
         run_type: RunType,
         ingestion_ts: datetime,
-    ) -> str:
+    ) -> BronzeWriteResult:
         """Write raw records to the Bronze layer.
 
         Args:
@@ -57,7 +58,8 @@ class StoragePort(Protocol):
                          (single source of time per ADR-014). Required.
 
         Returns:
-            str: Relative path to the written file.
+            BronzeWriteResult: Result containing path, record count, sizes,
+                and checksum for downstream lineage tracking.
 
         Note:
             Lock validation is performed at Application layer (BatchWriter)
@@ -74,6 +76,7 @@ class StoragePort(Protocol):
         mode: Literal["merge", "append", "delete"] = "merge",
         partition_cols: list[str] | None = None,
         on_schema_mismatch: Literal["error", "evolve", "ignore"] = "error",
+        bronze_refs: list[BronzeWriteResult] | None = None,
     ) -> None:
         """Write transformed records to the Silver layer.
 
@@ -88,6 +91,9 @@ class StoragePort(Protocol):
                 - 'error': Raise SchemaEvolutionError (default)
                 - 'evolve': Allow schema evolution (add new columns)
                 - 'ignore': Proceed without changes (filter to existing schema)
+            bronze_refs: Optional list of BronzeWriteResult from Bronze writes.
+                If provided, bronze_paths will be populated in Silver metadata
+                for complete lineage tracking (REQ-LINEAGE-001).
 
         Raises:
             SchemaEvolutionError: If schema drift detected and on_schema_mismatch='error'

--- a/src/bioetl/domain/value_objects/__init__.py
+++ b/src/bioetl/domain/value_objects/__init__.py
@@ -63,6 +63,7 @@ from bioetl.domain.value_objects.activity_values import (
     PChemblValue,
 )
 from bioetl.domain.value_objects.base import ValueObject
+from bioetl.domain.value_objects.bronze_result import BronzeWriteResult
 from bioetl.domain.value_objects.chemical import (
     SMILES,
     InChIKey,
@@ -138,6 +139,7 @@ __all__ = [
     "ORCID",
     "SMILES",
     "ActivityType",
+    "BronzeWriteResult",
     "ActivityValue",
     "AnomalyDetectionResult",
     "AnomalyMetric",

--- a/src/bioetl/domain/value_objects/bronze_result.py
+++ b/src/bioetl/domain/value_objects/bronze_result.py
@@ -1,0 +1,97 @@
+"""BronzeWriteResult value object for Bronze layer write operation results.
+
+Implements RULES.md §2.1.1 - Bronze Layer specifications.
+
+This value object encapsulates the result of a Bronze write operation,
+providing all necessary information for downstream lineage tracking
+in Silver and Gold layers.
+
+Requirements:
+- REQ-LINEAGE-001: Track Bronze paths for Silver lineage
+- REQ-DATA-004: Atomic writes verification via checksum
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from bioetl.domain.types import BatchID
+
+
+@dataclass(frozen=True, slots=True)
+class BronzeWriteResult:
+    """Result of a Bronze layer write operation.
+
+    This frozen dataclass captures all metadata from a Bronze write operation
+    needed for lineage tracking in downstream Medallion layers.
+
+    Attributes:
+        batch_id: Unique identifier for the written batch.
+        relative_path: Path relative to Bronze root (for storage references).
+        absolute_path: Full filesystem path (for lineage tracking).
+        record_count: Number of records written in this batch.
+        compressed_size: Size of compressed file in bytes.
+        uncompressed_size: Size of uncompressed data in bytes.
+        checksum_blake2: BLAKE2b checksum of compressed file for integrity verification.
+
+    Example:
+        >>> result = BronzeWriteResult(
+        ...     batch_id=BatchID(uuid4()),
+        ...     relative_path="v1/chembl/activity/2024-01-15/batch_abc.jsonl.zst",
+        ...     absolute_path="/data/bronze/v1/chembl/activity/2024-01-15/batch_abc.jsonl.zst",
+        ...     record_count=1000,
+        ...     compressed_size=50000,
+        ...     uncompressed_size=200000,
+        ...     checksum_blake2="abc123...",
+        ... )
+        >>> result.relative_path
+        'v1/chembl/activity/2024-01-15/batch_abc.jsonl.zst'
+    """
+
+    batch_id: BatchID
+    relative_path: str
+    absolute_path: str
+    record_count: int
+    compressed_size: int
+    uncompressed_size: int
+    checksum_blake2: str
+
+    def __post_init__(self) -> None:
+        """Validate fields after initialization."""
+        self._validate_non_negative_fields()
+        self._validate_required_strings()
+
+    def _validate_non_negative_fields(self) -> None:
+        """Validate that numeric fields are non-negative."""
+        if self.record_count < 0:
+            raise ValueError(
+                f"record_count must be non-negative, got {self.record_count}"
+            )
+        if self.compressed_size < 0:
+            raise ValueError(
+                f"compressed_size must be non-negative, got {self.compressed_size}"
+            )
+        if self.uncompressed_size < 0:
+            raise ValueError(
+                f"uncompressed_size must be non-negative, got {self.uncompressed_size}"
+            )
+
+    def _validate_required_strings(self) -> None:
+        """Validate that required string fields are not empty."""
+        if not self.relative_path:
+            raise ValueError("relative_path cannot be empty")
+        if not self.absolute_path:
+            raise ValueError("absolute_path cannot be empty")
+        if not self.checksum_blake2:
+            raise ValueError("checksum_blake2 cannot be empty")
+
+    @property
+    def compression_ratio(self) -> float:
+        """Calculate compression ratio (uncompressed / compressed).
+
+        Returns:
+            Compression ratio, or 1.0 if uncompressed_size is 0.
+        """
+        if self.uncompressed_size == 0:
+            return 1.0
+        return self.uncompressed_size / self.compressed_size

--- a/src/bioetl/infrastructure/storage/bronze_writer.py
+++ b/src/bioetl/infrastructure/storage/bronze_writer.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
 
 from bioetl.domain.ports.audit import AuditEntry, AuditLayer, AuditOperation
 from bioetl.domain.types import BatchID, RunID, RunType
+from bioetl.domain.value_objects.bronze_result import BronzeWriteResult
 from bioetl.infrastructure.storage._atomic import atomic_write_bytes
 
 
@@ -393,28 +394,11 @@ class BronzeWriter:
         run_id: RunID,
         run_type: RunType,
         ingestion_ts: datetime,
-    ) -> str:
+    ) -> BronzeWriteResult:
         """Write raw records to Bronze layer (JSONL + zstd).
 
-        Streams records through zstd compressor directly to disk.
-
-        Args:
-            records: Iterator of JSON-encoded record bytes.
-            provider: Provider name (e.g., 'chembl').
-            entity: Entity type (e.g., 'activity').
-            date: Date for path partitioning.
-            batch_id: Unique identifier for this batch.
-            run_id: Pipeline run identifier.
-            run_type: Type of run (incremental, backfill, etc.).
-            ingestion_ts: Ingestion timestamp from application layer
-                         (single source of time per ADR-014).
-
-        Returns:
-            Relative path to the written file.
-
-        Note:
-            Lock validation is performed at Application layer (BatchWriter)
-            per RULES.md §4.6 Safety Guard.
+        Returns BronzeWriteResult with path, sizes, and checksum for lineage.
+        Lock validation is performed at Application layer per §4.6 Safety Guard.
         """
         tracer = self._tracing.get_tracer(__name__)
         with tracer.start_as_current_span("write_bronze") as span:
@@ -571,7 +555,31 @@ class BronzeWriter:
             span.set_attribute("record_count", record_count)
             span.set_attribute("compressed_size", compressed_size)
 
-            return relative_path
+            # Calculate BLAKE2b checksum for integrity verification
+            checksum = await self._calculate_checksum(full_path)
+
+            return BronzeWriteResult(
+                batch_id=batch_id,
+                relative_path=relative_path,
+                absolute_path=str(full_path),
+                record_count=record_count,
+                compressed_size=compressed_size,
+                uncompressed_size=uncompressed_size,
+                checksum_blake2=checksum,
+            )
+
+    async def _calculate_checksum(self, file_path: Path) -> str:
+        """Calculate BLAKE2b checksum of a file asynchronously."""
+        import hashlib
+
+        def _compute() -> str:
+            h = hashlib.blake2b()
+            with open(file_path, "rb") as f:
+                for chunk in iter(lambda: f.read(65536), b""):
+                    h.update(chunk)
+            return h.hexdigest()
+
+        return await asyncio.get_running_loop().run_in_executor(None, _compute)
 
     async def _write_json_copy(
         self,
@@ -660,15 +668,7 @@ class BronzeWriter:
     async def cleanup_old_files(
         self, cutoff_date: datetime, dry_run: bool = False
     ) -> dict[str, int]:
-        """Remove Bronze files older than cutoff date (RULES.md §2.1 retention).
-
-        Args:
-            cutoff_date: Files older than this will be removed (UTC, per ADR-014).
-            dry_run: If True, only count files without removing them.
-
-        Returns:
-            Dict with files_removed, bytes_freed, directories_removed counts.
-        """
+        """Remove Bronze files older than cutoff date (RULES.md §2.1 retention)."""
         cutoff_str = cutoff_date.strftime("%Y-%m-%d")
         files, bytes_total, dirs = 0, 0, 0
 

--- a/src/bioetl/infrastructure/storage/silver_writer.py
+++ b/src/bioetl/infrastructure/storage/silver_writer.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
         SilverValidatorPort,
         TracingPort,
     )
+    from bioetl.domain.value_objects.bronze_result import BronzeWriteResult
     from bioetl.infrastructure.export.csv_exporter import CsvExporter
 
 from bioetl.domain.ports.audit import AuditEntry, AuditLayer, AuditOperation
@@ -440,6 +441,7 @@ class SilverWriter(BaseDeltaWriter):
         mode: str = "merge",
         partition_cols: list[str] | None = None,
         on_schema_mismatch: Literal["error", "evolve", "ignore"] = "error",
+        bronze_refs: list[BronzeWriteResult] | None = None,
     ) -> None:
         """Write normalized records to Silver layer (Delta Lake merge/upsert).
 
@@ -454,6 +456,9 @@ class SilverWriter(BaseDeltaWriter):
                 - 'error': Raise SchemaEvolutionError (default)
                 - 'evolve': Allow schema evolution (add new columns)
                 - 'ignore': Proceed without changes (filter to existing schema)
+            bronze_refs: Optional list of BronzeWriteResult from Bronze writes.
+                If provided, bronze_paths will be populated in Silver metadata
+                for complete lineage tracking (REQ-LINEAGE-001).
 
         Raises:
             ValueError: If mode is invalid or records are missing required fields
@@ -528,6 +533,7 @@ class SilverWriter(BaseDeltaWriter):
                 records=records,
                 primary_keys=primary_keys,
                 mode=validated_mode,
+                bronze_refs=bronze_refs,
             )
 
     async def _log_silver_audit(
@@ -627,6 +633,7 @@ class SilverWriter(BaseDeltaWriter):
         records: list[dict[str, Any]],
         primary_keys: list[str],
         mode: SilverWriteMode,
+        bronze_refs: list[BronzeWriteResult] | None = None,
     ) -> None:
         """Write Silver layer metadata sidecar file.
 
@@ -635,6 +642,9 @@ class SilverWriter(BaseDeltaWriter):
             records: List of records written.
             primary_keys: Primary key columns used.
             mode: Write mode used (merge, append, delete).
+            bronze_refs: Optional list of BronzeWriteResult for lineage tracking.
+                If provided, bronze_paths will be populated from relative_path
+                of each BronzeWriteResult (REQ-LINEAGE-001).
         """
         from datetime import UTC, datetime
         from importlib.metadata import version as pkg_version
@@ -691,7 +701,7 @@ class SilverWriter(BaseDeltaWriter):
             entity=entity,
         )
 
-        # Build lineage from records
+        # Build lineage from records and bronze_refs
         source_batch_ids = list(
             {
                 r.get("_source_batch_id", "")
@@ -699,8 +709,15 @@ class SilverWriter(BaseDeltaWriter):
                 if r.get("_source_batch_id")
             }
         )
+
+        # Extract bronze paths from bronze_refs for complete lineage (REQ-LINEAGE-001)
+        bronze_paths: list[str] = []
+        if bronze_refs:
+            bronze_paths = [ref.relative_path for ref in bronze_refs]
+
         lineage = LineageMetadata(
             source_batch_ids=source_batch_ids,
+            bronze_paths=bronze_paths,
         )
 
         # Build Delta metrics

--- a/tests/unit/infrastructure/storage/test_bronze_writer.py
+++ b/tests/unit/infrastructure/storage/test_bronze_writer.py
@@ -14,6 +14,7 @@ import zstandard as zstd
 
 from bioetl.domain.ports import MetricsPort
 from bioetl.domain.types import BatchID, RunID, RunType
+from bioetl.domain.value_objects.bronze_result import BronzeWriteResult
 from bioetl.infrastructure.observability.noop_logger import NoOpLogger
 from bioetl.infrastructure.observability.noop_metrics import NoOpMetrics
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
@@ -486,7 +487,7 @@ class TestBronzeWriterWriteLocal:
         )
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
-        path = await writer.write_bronze(
+        result = await writer.write_bronze(
             records=iter(sample_records),
             provider="chembl",
             entity="activity",
@@ -497,15 +498,23 @@ class TestBronzeWriterWriteLocal:
             ingestion_ts=ingestion_ts,
         )
 
+        # Verify BronzeWriteResult structure
+        assert result.batch_id == batch_id
+        assert result.record_count == len(sample_records)
+        assert result.compressed_size > 0
+        assert result.uncompressed_size > 0
+        assert result.checksum_blake2  # Non-empty checksum
+
         # Verify path format (normalize for cross-platform)
-        path_str = str(path).replace("\\", "/")
+        path_str = result.relative_path.replace("\\", "/")
         assert "v1/chembl/activity/2024-01-15" in path_str
-        assert str(batch_id) in str(path)
-        assert str(path).endswith(".jsonl.zst")
+        assert str(batch_id) in result.relative_path
+        assert result.relative_path.endswith(".jsonl.zst")
 
         # Verify file exists
-        full_path = tmp_path / path
+        full_path = tmp_path / result.relative_path
         assert full_path.exists()
+        assert result.absolute_path == str(full_path)
 
         # Verify metadata file exists
         meta_path = full_path.with_suffix(".zst.meta.json")
@@ -529,6 +538,13 @@ class TestBronzeWriterWriteLocal:
             decompressed = reader.read()
         expected = b"".join(sample_records)
         assert decompressed == expected
+
+        # Verify checksum matches file content
+        import hashlib
+
+        h = hashlib.blake2b()
+        h.update(compressed_data)
+        assert result.checksum_blake2 == h.hexdigest()
 
     @pytest.mark.asyncio
     async def test_write_bronze_local_async(
@@ -555,7 +571,7 @@ class TestBronzeWriterWriteLocal:
             "run_in_executor",
             wraps=asyncio.get_running_loop().run_in_executor,
         ) as mock_executor:
-            path = await writer.write_bronze(
+            result = await writer.write_bronze(
                 records=iter(sample_records),
                 provider="test_provider",
                 entity="test_entity",
@@ -570,7 +586,7 @@ class TestBronzeWriterWriteLocal:
             assert mock_executor.call_count >= 1
 
             # Verify file existence and content
-            full_path = tmp_path / path
+            full_path = tmp_path / result.relative_path
             assert full_path.exists()
             assert full_path.with_suffix(".zst.meta.json").exists()
 
@@ -671,7 +687,7 @@ class TestBronzeWriterReadLocal:
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
         # Write first
-        path = await writer.write_bronze(
+        result = await writer.write_bronze(
             records=iter(sample_records),
             provider="chembl",
             entity="activity",
@@ -684,7 +700,7 @@ class TestBronzeWriterReadLocal:
 
         # Read back
         records = []
-        async for record in writer.read_bronze(str(path)):
+        async for record in writer.read_bronze(result.relative_path):
             records.append(record)
 
         assert len(records) == 3
@@ -881,7 +897,7 @@ class TestBronzeWriterAtomicWrite:
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
         # Successful write
-        path = await writer.write_bronze(
+        result = await writer.write_bronze(
             records=iter(sample_records),
             provider="chembl",
             entity="activity",
@@ -892,7 +908,7 @@ class TestBronzeWriterAtomicWrite:
             ingestion_ts=ingestion_ts,
         )
 
-        full_path = tmp_path / path
+        full_path = tmp_path / result.relative_path
         meta_path = full_path.with_suffix(".zst.meta.json")
 
         # Both files must exist
@@ -1101,7 +1117,7 @@ class TestBronzeWriterMetadataDeterminism:
         batch_id_1 = BatchID(uuid4())
         batch_id_2 = BatchID(uuid4())
 
-        path_1 = await writer.write_bronze(
+        result_1 = await writer.write_bronze(
             records=iter(sample_records),
             provider="chembl",
             entity="activity",
@@ -1112,7 +1128,7 @@ class TestBronzeWriterMetadataDeterminism:
             ingestion_ts=ingestion_ts,
         )
 
-        path_2 = await writer.write_bronze(
+        result_2 = await writer.write_bronze(
             records=iter(sample_records),
             provider="chembl",
             entity="activity",
@@ -1124,8 +1140,8 @@ class TestBronzeWriterMetadataDeterminism:
         )
 
         # Read both metadata files
-        meta_path_1 = (tmp_path / path_1).with_suffix(".zst.meta.json")
-        meta_path_2 = (tmp_path / path_2).with_suffix(".zst.meta.json")
+        meta_path_1 = (tmp_path / result_1.relative_path).with_suffix(".zst.meta.json")
+        meta_path_2 = (tmp_path / result_2.relative_path).with_suffix(".zst.meta.json")
 
         with open(meta_path_1, "rb") as f:
             meta_bytes_1 = f.read()
@@ -1664,7 +1680,7 @@ class TestBronzeWriterJsonValidation:
         ]
 
         # Should not raise - writes the bytes as-is
-        path = await writer.write_bronze(
+        result = await writer.write_bronze(
             records=iter(invalid_records),
             provider="test",
             entity="data",
@@ -1676,7 +1692,7 @@ class TestBronzeWriterJsonValidation:
         )
 
         # Verify file was written
-        full_path = tmp_path / path
+        full_path = tmp_path / result.relative_path
         assert full_path.exists()
 
     @pytest.mark.asyncio
@@ -1699,7 +1715,7 @@ class TestBronzeWriterJsonValidation:
         )
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
-        path = await writer.write_bronze(
+        result = await writer.write_bronze(
             records=iter(sample_records),
             provider="chembl",
             entity="activity",
@@ -1711,12 +1727,12 @@ class TestBronzeWriterJsonValidation:
         )
 
         # Verify file was written successfully
-        full_path = tmp_path / path
+        full_path = tmp_path / result.relative_path
         assert full_path.exists()
 
         # Verify we can read back the records
         records_read = []
-        async for record in writer.read_bronze(str(path)):
+        async for record in writer.read_bronze(result.relative_path):
             records_read.append(record)
 
         assert len(records_read) == len(sample_records)
@@ -1831,7 +1847,7 @@ class TestBronzeWriterAudit:
         date = datetime(2024, 1, 15, tzinfo=UTC)
 
         # Should not raise
-        path = await writer.write_bronze(
+        result = await writer.write_bronze(
             records=iter(sample_records),
             provider="chembl",
             entity="activity",
@@ -1842,7 +1858,8 @@ class TestBronzeWriterAudit:
             ingestion_ts=ingestion_ts,
         )
 
-        assert path is not None
+        assert result is not None
+        assert result.relative_path is not None
 
 
 @pytest.mark.unit
@@ -2167,8 +2184,8 @@ class TestBronzeWriterMetadataSidecar:
         )
 
         # Verify data was written
-        assert result.endswith(".jsonl.zst")
-        assert (tmp_path / result).exists()
+        assert result.relative_path.endswith(".jsonl.zst")
+        assert (tmp_path / result.relative_path).exists()
 
     @pytest.mark.asyncio
     async def test_build_full_bronze_metadata_structure(
@@ -2262,3 +2279,128 @@ class TestBronzeWriterMetadataSidecar:
                 duration_seconds=0.1,
             )
             assert metadata.runtime.run_type.value == expected_value
+
+
+@pytest.mark.unit
+class TestBronzeWriteResult:
+    """Tests for BronzeWriteResult value object (REQ-LINEAGE-001)."""
+
+    def test_bronze_write_result_creation(self, batch_id: BatchID) -> None:
+        """Test valid BronzeWriteResult creation."""
+        result = BronzeWriteResult(
+            batch_id=batch_id,
+            relative_path="v1/chembl/activity/2024-01-15/batch_123.jsonl.zst",
+            absolute_path="/data/bronze/v1/chembl/activity/2024-01-15/batch_123.jsonl.zst",
+            record_count=100,
+            compressed_size=5000,
+            uncompressed_size=20000,
+            checksum_blake2="abc123def456",
+        )
+
+        assert result.batch_id == batch_id
+        assert result.record_count == 100
+        assert result.compressed_size == 5000
+        assert result.uncompressed_size == 20000
+
+    def test_bronze_write_result_is_frozen(self, batch_id: BatchID) -> None:
+        """Test BronzeWriteResult is immutable (frozen dataclass)."""
+        result = BronzeWriteResult(
+            batch_id=batch_id,
+            relative_path="v1/test/path.jsonl.zst",
+            absolute_path="/data/bronze/v1/test/path.jsonl.zst",
+            record_count=10,
+            compressed_size=100,
+            uncompressed_size=500,
+            checksum_blake2="abc123",
+        )
+
+        with pytest.raises(Exception):  # FrozenInstanceError
+            result.record_count = 50  # type: ignore[misc]
+
+    def test_bronze_write_result_compression_ratio(self, batch_id: BatchID) -> None:
+        """Test compression_ratio property calculation."""
+        result = BronzeWriteResult(
+            batch_id=batch_id,
+            relative_path="v1/test/path.jsonl.zst",
+            absolute_path="/data/bronze/v1/test/path.jsonl.zst",
+            record_count=10,
+            compressed_size=1000,
+            uncompressed_size=4000,
+            checksum_blake2="abc123",
+        )
+
+        assert result.compression_ratio == 4.0  # 4000 / 1000
+
+    def test_bronze_write_result_compression_ratio_zero_uncompressed(
+        self, batch_id: BatchID
+    ) -> None:
+        """Test compression_ratio returns 1.0 for zero uncompressed_size."""
+        result = BronzeWriteResult(
+            batch_id=batch_id,
+            relative_path="v1/test/path.jsonl.zst",
+            absolute_path="/data/bronze/v1/test/path.jsonl.zst",
+            record_count=0,
+            compressed_size=100,
+            uncompressed_size=0,
+            checksum_blake2="abc123",
+        )
+
+        assert result.compression_ratio == 1.0
+
+    def test_bronze_write_result_validation_negative_record_count(
+        self, batch_id: BatchID
+    ) -> None:
+        """Test BronzeWriteResult rejects negative record_count."""
+        with pytest.raises(ValueError, match="record_count must be non-negative"):
+            BronzeWriteResult(
+                batch_id=batch_id,
+                relative_path="v1/test/path.jsonl.zst",
+                absolute_path="/data/bronze/v1/test/path.jsonl.zst",
+                record_count=-1,
+                compressed_size=100,
+                uncompressed_size=500,
+                checksum_blake2="abc123",
+            )
+
+    def test_bronze_write_result_validation_negative_compressed_size(
+        self, batch_id: BatchID
+    ) -> None:
+        """Test BronzeWriteResult rejects negative compressed_size."""
+        with pytest.raises(ValueError, match="compressed_size must be non-negative"):
+            BronzeWriteResult(
+                batch_id=batch_id,
+                relative_path="v1/test/path.jsonl.zst",
+                absolute_path="/data/bronze/v1/test/path.jsonl.zst",
+                record_count=10,
+                compressed_size=-100,
+                uncompressed_size=500,
+                checksum_blake2="abc123",
+            )
+
+    def test_bronze_write_result_validation_empty_path(self, batch_id: BatchID) -> None:
+        """Test BronzeWriteResult rejects empty paths."""
+        with pytest.raises(ValueError, match="relative_path cannot be empty"):
+            BronzeWriteResult(
+                batch_id=batch_id,
+                relative_path="",
+                absolute_path="/data/bronze/v1/test/path.jsonl.zst",
+                record_count=10,
+                compressed_size=100,
+                uncompressed_size=500,
+                checksum_blake2="abc123",
+            )
+
+    def test_bronze_write_result_validation_empty_checksum(
+        self, batch_id: BatchID
+    ) -> None:
+        """Test BronzeWriteResult rejects empty checksum."""
+        with pytest.raises(ValueError, match="checksum_blake2 cannot be empty"):
+            BronzeWriteResult(
+                batch_id=batch_id,
+                relative_path="v1/test/path.jsonl.zst",
+                absolute_path="/data/bronze/v1/test/path.jsonl.zst",
+                record_count=10,
+                compressed_size=100,
+                uncompressed_size=500,
+                checksum_blake2="",
+            )

--- a/tests/unit/infrastructure/storage/test_silver_writer.py
+++ b/tests/unit/infrastructure/storage/test_silver_writer.py
@@ -1618,3 +1618,203 @@ class TestSilverWriterCsvExport:
 
             assert len(export_calls) == 1
             assert export_calls[0]["primary_keys"] == ["entity_id"]
+
+
+@pytest.mark.unit
+class TestSilverWriterLineage:
+    """Tests for SilverWriter lineage tracking (REQ-LINEAGE-001)."""
+
+    @pytest.mark.asyncio
+    async def test_write_silver_without_bronze_refs(self, noop_logger, valid_records):
+        """Test write_silver works without bronze_refs (backward compatibility)."""
+        import pyarrow as pa
+        from deltalake.exceptions import TableNotFoundError as DeltaTableNotFoundError
+
+        from bioetl.infrastructure.storage.silver_writer import SilverWriter
+
+        schema = pa.schema(
+            [
+                pa.field("entity_id", pa.string()),
+                pa.field("value", pa.float64()),
+                pa.field("_run_id", pa.string()),
+                pa.field("_run_type", pa.string()),
+                pa.field("_source_batch_id", pa.string()),
+                pa.field("_ingestion_ts", pa.string()),
+            ]
+        )
+
+        with (
+            patch(
+                "bioetl.infrastructure.storage.base_delta_writer.DeltaTable",
+                side_effect=DeltaTableNotFoundError("Not found"),
+            ),
+            patch("bioetl.infrastructure.storage.silver_writer.write_deltalake"),
+        ):
+            writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
+
+            # Should not raise when bronze_refs not provided
+            await writer.write_silver(
+                table_name="test.table",
+                records=valid_records,
+                primary_keys=["entity_id"],
+                schema=schema,
+                mode="merge",
+            )
+
+    @pytest.mark.asyncio
+    async def test_write_silver_with_bronze_refs(self, noop_logger, valid_records):
+        """Test write_silver accepts bronze_refs parameter."""
+        from uuid import uuid4
+
+        import pyarrow as pa
+        from deltalake.exceptions import TableNotFoundError as DeltaTableNotFoundError
+
+        from bioetl.domain.types import BatchID
+        from bioetl.domain.value_objects.bronze_result import BronzeWriteResult
+        from bioetl.infrastructure.storage.silver_writer import SilverWriter
+
+        schema = pa.schema(
+            [
+                pa.field("entity_id", pa.string()),
+                pa.field("value", pa.float64()),
+                pa.field("_run_id", pa.string()),
+                pa.field("_run_type", pa.string()),
+                pa.field("_source_batch_id", pa.string()),
+                pa.field("_ingestion_ts", pa.string()),
+            ]
+        )
+
+        bronze_result = BronzeWriteResult(
+            batch_id=BatchID(uuid4()),
+            relative_path="v1/chembl/activity/2024-01-15/batch_123.jsonl.zst",
+            absolute_path="/data/bronze/v1/chembl/activity/2024-01-15/batch_123.jsonl.zst",
+            record_count=100,
+            compressed_size=5000,
+            uncompressed_size=20000,
+            checksum_blake2="abc123def456",
+        )
+
+        with (
+            patch(
+                "bioetl.infrastructure.storage.base_delta_writer.DeltaTable",
+                side_effect=DeltaTableNotFoundError("Not found"),
+            ),
+            patch("bioetl.infrastructure.storage.silver_writer.write_deltalake"),
+        ):
+            writer = SilverWriter(base_path="/tmp/silver", logger=noop_logger)
+
+            # Should not raise with bronze_refs
+            await writer.write_silver(
+                table_name="test.table",
+                records=valid_records,
+                primary_keys=["entity_id"],
+                schema=schema,
+                mode="merge",
+                bronze_refs=[bronze_result],
+            )
+
+    @pytest.mark.asyncio
+    async def test_write_silver_metadata_includes_bronze_paths(
+        self, noop_logger, valid_records
+    ):
+        """Test _write_silver_metadata populates bronze_paths from bronze_refs."""
+        from uuid import uuid4
+
+        from bioetl.domain.types import BatchID
+        from bioetl.domain.value_objects.bronze_result import BronzeWriteResult
+        from bioetl.infrastructure.storage.silver_writer import (
+            SilverWriteMode,
+            SilverWriter,
+        )
+
+        bronze_result_1 = BronzeWriteResult(
+            batch_id=BatchID(uuid4()),
+            relative_path="v1/chembl/activity/2024-01-15/batch_001.jsonl.zst",
+            absolute_path="/data/bronze/v1/chembl/activity/2024-01-15/batch_001.jsonl.zst",
+            record_count=50,
+            compressed_size=2500,
+            uncompressed_size=10000,
+            checksum_blake2="abc123",
+        )
+
+        bronze_result_2 = BronzeWriteResult(
+            batch_id=BatchID(uuid4()),
+            relative_path="v1/chembl/activity/2024-01-15/batch_002.jsonl.zst",
+            absolute_path="/data/bronze/v1/chembl/activity/2024-01-15/batch_002.jsonl.zst",
+            record_count=50,
+            compressed_size=2500,
+            uncompressed_size=10000,
+            checksum_blake2="def456",
+        )
+
+        mock_metadata_writer = MagicMock()
+        write_calls = []
+
+        async def capture_write(table_path, metadata):
+            write_calls.append({"table_path": table_path, "metadata": metadata})
+
+        mock_metadata_writer.write_silver_metadata = capture_write
+
+        writer = SilverWriter(
+            base_path="/tmp/silver",
+            logger=noop_logger,
+            metadata_writer=mock_metadata_writer,
+        )
+
+        await writer._write_silver_metadata(
+            table_path="/tmp/silver/test/table",
+            records=valid_records,
+            primary_keys=["entity_id"],
+            mode=SilverWriteMode.MERGE,
+            bronze_refs=[bronze_result_1, bronze_result_2],
+        )
+
+        # Verify metadata writer was called with bronze_paths
+        assert len(write_calls) == 1
+        metadata = write_calls[0]["metadata"]
+        lineage = metadata.lineage
+        assert len(lineage.bronze_paths) == 2
+        assert (
+            "v1/chembl/activity/2024-01-15/batch_001.jsonl.zst" in lineage.bronze_paths
+        )
+        assert (
+            "v1/chembl/activity/2024-01-15/batch_002.jsonl.zst" in lineage.bronze_paths
+        )
+
+    @pytest.mark.asyncio
+    async def test_write_silver_metadata_empty_bronze_paths_when_no_refs(
+        self, noop_logger, valid_records
+    ):
+        """Test _write_silver_metadata has empty bronze_paths when bronze_refs=None."""
+        from bioetl.infrastructure.storage.silver_writer import (
+            SilverWriteMode,
+            SilverWriter,
+        )
+
+        mock_metadata_writer = MagicMock()
+        write_calls = []
+
+        async def capture_write(table_path, metadata):
+            write_calls.append({"table_path": table_path, "metadata": metadata})
+
+        mock_metadata_writer.write_silver_metadata = capture_write
+
+        writer = SilverWriter(
+            base_path="/tmp/silver",
+            logger=noop_logger,
+            metadata_writer=mock_metadata_writer,
+        )
+
+        await writer._write_silver_metadata(
+            table_path="/tmp/silver/test/table",
+            records=valid_records,
+            primary_keys=["entity_id"],
+            mode=SilverWriteMode.MERGE,
+            bronze_refs=None,  # No bronze refs
+        )
+
+        # Verify metadata writer was called with empty bronze_paths
+        assert len(write_calls) == 1
+        metadata = write_calls[0]["metadata"]
+        lineage = metadata.lineage
+        assert lineage.bronze_paths == []


### PR DESCRIPTION
…-LINEAGE-001)

Add BronzeWriteResult value object and update storage layer to track Bronze file paths for complete data lineage from Bronze to Silver.

Changes:
- Add BronzeWriteResult frozen dataclass with batch_id, paths, sizes, checksum
- Update BronzeWriter.write_bronze() to return BronzeWriteResult
- Update StoragePort interface to reflect new return type
- Add bronze_refs parameter to SilverWriter.write_silver()
- Populate LineageMetadata.bronze_paths from bronze_refs
- Update BatchWriter/RecordProcessor to pass bronze_refs through pipeline
- Add comprehensive unit tests for new lineage tracking

This enables complete DAG reconstruction from API to Gold layer, supporting audit, compliance, and data quality debugging needs.