### PR TITLE
Expand SourceMetadata with API request details

### DIFF
--- a/src/bioetl/application/core/batch_writer.py
+++ b/src/bioetl/application/core/batch_writer.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from bioetl.application.core.config import RecordProcessorConfig
     from bioetl.domain.context import PipelineContext
     from bioetl.domain.error_classifier import ErrorClassifier
+    from bioetl.domain.models.metadata import SourceMetadata
     from bioetl.domain.ports import GoldValidatorPort, StoragePort, TracingPort
     from bioetl.domain.types import BatchID
     from bioetl.domain.value_objects.bronze_result import BronzeWriteResult
@@ -181,7 +182,11 @@ class BatchWriter:
         span.__exit__(None, None, None)
 
     async def write_bronze(
-        self, records: list[dict[str, Any]], batch_id: BatchID, ingestion_ts: datetime
+        self,
+        records: list[dict[str, Any]],
+        batch_id: BatchID,
+        ingestion_ts: datetime,
+        source_metadata: SourceMetadata | None = None,
     ) -> BronzeWriteResult:
         """Write records to Bronze layer.
 
@@ -192,6 +197,9 @@ class BatchWriter:
             records: Raw records to write.
             batch_id: Identifier for the current batch.
             ingestion_ts: Ingestion timestamp from context.
+            source_metadata: Optional pre-built SourceMetadata with API request
+                           details for rich lineage tracking. If provided,
+                           it will be included in the Bronze metadata sidecar.
 
         Returns:
             BronzeWriteResult with path, record count, sizes, and checksum
@@ -227,6 +235,7 @@ class BatchWriter:
                 run_id=self._context.run_id,
                 run_type=self._context.run_type,
                 ingestion_ts=ingestion_ts,
+                source_metadata=source_metadata,
             )
             self._end_span(span)
             return bronze_result

--- a/src/bioetl/composition/factories/storage_adapter.py
+++ b/src/bioetl/composition/factories/storage_adapter.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from datetime import datetime
 
+    from bioetl.domain.models.metadata import SourceMetadata
     from bioetl.domain.types import ArrowSchema, BatchID, RunID, RunType
 
 
@@ -62,6 +63,7 @@ class StorageAdapter:
         run_id: RunID,
         run_type: RunType,
         ingestion_ts: datetime,
+        source_metadata: SourceMetadata | None = None,
     ) -> BronzeWriteResult:
         """Write raw records to Bronze layer.
 
@@ -75,6 +77,9 @@ class StorageAdapter:
             run_type: Type of run.
             ingestion_ts: Ingestion timestamp from application layer
                          (single source of time per ADR-014). Required.
+            source_metadata: Optional pre-built SourceMetadata with API request
+                           details for rich lineage tracking. If None, a minimal
+                           SourceMetadata is created with type="api".
 
         Returns:
             BronzeWriteResult: Result containing path, record count, sizes,
@@ -93,6 +98,7 @@ class StorageAdapter:
             run_id=run_id,
             run_type=run_type,
             ingestion_ts=ingestion_ts,
+            source_metadata=source_metadata,
         )
 
     async def write_silver(

--- a/src/bioetl/composition/services/metadata_coordinator.py
+++ b/src/bioetl/composition/services/metadata_coordinator.py
@@ -176,6 +176,13 @@ class MetadataCoordinator:
         """
         duration = (input_data.completed_at - input_data.started_at).total_seconds()
 
+        # Use provided source_metadata or create minimal default
+        source = (
+            input_data.source_metadata
+            if input_data.source_metadata is not None
+            else SourceMetadata(type="api")
+        )
+
         return BronzeMetadata(
             runtime=self._build_runtime_metadata(
                 started_at=input_data.started_at,
@@ -183,7 +190,7 @@ class MetadataCoordinator:
                 duration_seconds=duration,
             ),
             pipeline=self._build_pipeline_metadata(),
-            source=SourceMetadata(type="api"),
+            source=source,
             output=OutputMetadata(
                 files=[
                     FileOutputMetadata(

--- a/src/bioetl/domain/models/metadata.py
+++ b/src/bioetl/domain/models/metadata.py
@@ -104,8 +104,76 @@ class EnvironmentMetadata(BaseModel):
 # =============================================================================
 
 
+class RateLimitInfo(BaseModel):
+    """Rate limit information from API response headers.
+
+    Attributes:
+        remaining: Remaining requests in current window (X-RateLimit-Remaining).
+        limit: Maximum requests allowed in window (X-RateLimit-Limit).
+        reset_at: Timestamp when rate limit resets (X-RateLimit-Reset).
+        retry_after_seconds: Seconds to wait before retry (Retry-After header).
+    """
+
+    remaining: int | None = Field(
+        default=None, description="Remaining requests in current window"
+    )
+    limit: int | None = Field(
+        default=None, description="Maximum requests allowed in window"
+    )
+    reset_at: datetime | None = Field(
+        default=None, description="Timestamp when rate limit resets"
+    )
+    retry_after_seconds: float | None = Field(
+        default=None, description="Seconds to wait before retry"
+    )
+
+
+class APIRequestDetails(BaseModel):
+    """Detailed API request information for audit and debugging.
+
+    Captures per-request metadata including endpoint, parameters,
+    response size, timing, and rate limit status.
+
+    Attributes:
+        endpoint: API endpoint path (e.g., "/chembl/api/data/activity").
+        base_url: Base URL of the API (e.g., "https://www.ebi.ac.uk").
+        query_params: Query parameters used in request.
+        http_method: HTTP method (GET, POST).
+        response_size_bytes: Size of response body in bytes.
+        request_duration_ms: Request duration in milliseconds.
+        status_code: HTTP response status code.
+        rate_limit: Rate limit information from response headers.
+        timestamp: UTC timestamp when request was made.
+    """
+
+    endpoint: str = Field(description="API endpoint path")
+    base_url: str = Field(description="Base URL of the API")
+    query_params: dict[str, str | int | float | bool | None] = Field(
+        default_factory=dict, description="Query parameters"
+    )
+    http_method: Literal["GET", "POST", "HEAD"] = Field(
+        default="GET", description="HTTP method"
+    )
+    response_size_bytes: int = Field(
+        default=0, description="Size of response body in bytes"
+    )
+    request_duration_ms: float = Field(
+        default=0.0, description="Request duration in milliseconds"
+    )
+    status_code: int = Field(default=200, description="HTTP response status code")
+    rate_limit: RateLimitInfo | None = Field(
+        default=None, description="Rate limit information"
+    )
+    timestamp: datetime | None = Field(
+        default=None, description="UTC timestamp when request was made"
+    )
+
+
 class SourceMetadata(BaseModel):
     """Data source information for Bronze layer.
+
+    Extended to include detailed API request tracking for audit,
+    debugging, and monitoring purposes.
 
     Attributes:
         type: Source type (api, csv, parquet).
@@ -114,6 +182,10 @@ class SourceMetadata(BaseModel):
         watermark_before: Previous watermark timestamp.
         watermark_after: New watermark timestamp after ingestion.
         api_version: Provider API version.
+        api_requests: List of detailed API request information.
+        total_requests: Total number of API requests made.
+        total_response_bytes: Total bytes received from all requests.
+        avg_request_duration_ms: Average request duration in milliseconds.
     """
 
     type: Literal["api", "csv", "parquet"] = Field(
@@ -128,6 +200,16 @@ class SourceMetadata(BaseModel):
         default=None, description="New watermark after ingestion"
     )
     api_version: str | None = Field(default=None, description="Provider API version")
+    api_requests: list[APIRequestDetails] = Field(
+        default_factory=list, description="Detailed API request information"
+    )
+    total_requests: int = Field(default=0, description="Total number of API requests")
+    total_response_bytes: int = Field(
+        default=0, description="Total bytes received from all requests"
+    )
+    avg_request_duration_ms: float = Field(
+        default=0.0, description="Average request duration in milliseconds"
+    )
 
 
 class FileOutputMetadata(BaseModel):

--- a/src/bioetl/domain/ports/metadata_coordinator.py
+++ b/src/bioetl/domain/ports/metadata_coordinator.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
         BronzeMetadata,
         GoldMetadata,
         SilverMetadata,
+        SourceMetadata,
     )
     from bioetl.domain.types import BatchID
 
@@ -32,6 +33,8 @@ class BronzeMetadataInput:
         output_path: Relative path to the written file.
         started_at: UTC timestamp when write started.
         completed_at: UTC timestamp when write completed.
+        source_metadata: Optional pre-built SourceMetadata with API request
+                        details for rich lineage tracking.
     """
 
     batch_id: BatchID
@@ -40,6 +43,7 @@ class BronzeMetadataInput:
     output_path: str
     started_at: datetime
     completed_at: datetime
+    source_metadata: SourceMetadata | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/bioetl/domain/ports/storage.py
+++ b/src/bioetl/domain/ports/storage.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from datetime import datetime
-from typing import Any, Literal, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 from bioetl.domain.types import (
     ArrowSchema,
@@ -22,6 +22,9 @@ from bioetl.domain.types import (
     RunType,
 )
 from bioetl.domain.value_objects.bronze_result import BronzeWriteResult
+
+if TYPE_CHECKING:
+    from bioetl.domain.models.metadata import SourceMetadata
 
 
 @runtime_checkable
@@ -43,6 +46,7 @@ class StoragePort(Protocol):
         run_id: RunID,
         run_type: RunType,
         ingestion_ts: datetime,
+        source_metadata: SourceMetadata | None = None,
     ) -> BronzeWriteResult:
         """Write raw records to the Bronze layer.
 
@@ -56,6 +60,9 @@ class StoragePort(Protocol):
             run_type: The type of pipeline run (incremental, backfill, rebuild).
             ingestion_ts: Ingestion timestamp from application layer
                          (single source of time per ADR-014). Required.
+            source_metadata: Optional pre-built SourceMetadata with API request
+                           details for rich lineage tracking. If None, a minimal
+                           SourceMetadata is created with type="api".
 
         Returns:
             BronzeWriteResult: Result containing path, record count, sizes,

--- a/src/bioetl/infrastructure/adapters/common/__init__.py
+++ b/src/bioetl/infrastructure/adapters/common/__init__.py
@@ -5,6 +5,9 @@ Provides shared functionality for infrastructure adapters.
 
 from __future__ import annotations
 
+from bioetl.infrastructure.adapters.common.api_request_collector import (
+    APIRequestCollector,
+)
 from bioetl.infrastructure.adapters.common.base_title_fallback import (
     BaseTitleFallbackHandler,
 )
@@ -13,4 +16,9 @@ from bioetl.infrastructure.adapters.common.title_matching import (
     titles_match,
 )
 
-__all__ = ["BaseTitleFallbackHandler", "normalize_title", "titles_match"]
+__all__ = [
+    "APIRequestCollector",
+    "BaseTitleFallbackHandler",
+    "normalize_title",
+    "titles_match",
+]

--- a/src/bioetl/infrastructure/adapters/common/api_request_collector.py
+++ b/src/bioetl/infrastructure/adapters/common/api_request_collector.py
@@ -1,0 +1,294 @@
+"""API Request Collector for capturing detailed request metadata.
+
+Accumulates API request details for Bronze layer metadata enrichment.
+Supports audit, debugging, and rate limit monitoring use cases.
+
+Thread-safe for concurrent request recording within a single pipeline run.
+"""
+
+from __future__ import annotations
+
+import threading
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    import httpx
+
+
+from bioetl.domain.models.metadata import (
+    APIRequestDetails,
+    RateLimitInfo,
+    SourceMetadata,
+)
+
+
+class APIRequestCollector:
+    """Collects API request metadata for Bronze layer enrichment.
+
+    Thread-safe collector that accumulates request details and produces
+    a SourceMetadata instance with aggregate statistics.
+
+    Example:
+        >>> collector = APIRequestCollector()
+        >>> collector.record_request(
+        ...     url="https://api.example.com/data?limit=100",
+        ...     method="GET",
+        ...     response_size=1024,
+        ...     duration_ms=150.5,
+        ...     status_code=200,
+        ... )
+        >>> source_metadata = collector.to_source_metadata()
+
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty request collector."""
+        self._requests: list[APIRequestDetails] = []
+        self._lock = threading.Lock()
+
+    def record_request(
+        self,
+        url: str,
+        method: str = "GET",
+        response_size: int = 0,
+        duration_ms: float = 0.0,
+        status_code: int = 200,
+        params: dict[str, Any] | None = None,
+        rate_limit_remaining: int | None = None,
+        rate_limit_limit: int | None = None,
+        rate_limit_reset: datetime | None = None,
+        retry_after_seconds: float | None = None,
+        timestamp: datetime | None = None,
+    ) -> None:
+        """Record a completed API request.
+
+        Args:
+            url: Full request URL (base URL + endpoint + query string).
+            method: HTTP method (GET, POST, HEAD).
+            response_size: Size of response body in bytes.
+            duration_ms: Request duration in milliseconds.
+            status_code: HTTP response status code.
+            params: Query parameters dict (alternative to parsing from URL).
+            rate_limit_remaining: Value of X-RateLimit-Remaining header.
+            rate_limit_limit: Value of X-RateLimit-Limit header.
+            rate_limit_reset: Parsed X-RateLimit-Reset timestamp.
+            retry_after_seconds: Value of Retry-After header in seconds.
+            timestamp: UTC timestamp when request was made. Defaults to now.
+        """
+        parsed = urlparse(url)
+        base_url = f"{parsed.scheme}://{parsed.netloc}"
+        endpoint = parsed.path
+
+        # Parse query params from URL if not provided
+        if params is None:
+            params = self._parse_query_params(parsed.query)
+        # Sanitize params to ensure no sensitive data (API keys, etc.)
+        sanitized_params = self._sanitize_params(params)
+
+        # Build rate limit info if any headers present
+        rate_limit: RateLimitInfo | None = None
+        if any(
+            [
+                rate_limit_remaining,
+                rate_limit_limit,
+                rate_limit_reset,
+                retry_after_seconds,
+            ]
+        ):
+            rate_limit = RateLimitInfo(
+                remaining=rate_limit_remaining,
+                limit=rate_limit_limit,
+                reset_at=rate_limit_reset,
+                retry_after_seconds=retry_after_seconds,
+            )
+
+        request_details = APIRequestDetails(
+            endpoint=endpoint,
+            base_url=base_url,
+            query_params=sanitized_params,
+            http_method=method.upper(),  # type: ignore[arg-type]
+            response_size_bytes=response_size,
+            request_duration_ms=duration_ms,
+            status_code=status_code,
+            rate_limit=rate_limit,
+            timestamp=timestamp or datetime.now(UTC),
+        )
+
+        with self._lock:
+            self._requests.append(request_details)
+
+    def record_from_response(
+        self,
+        response: httpx.Response,
+        duration_ms: float,
+        timestamp: datetime | None = None,
+    ) -> None:
+        """Record request details from an httpx Response object.
+
+        Extracts URL, status, size, and rate limit headers automatically.
+
+        Args:
+            response: httpx.Response object after request completion.
+            duration_ms: Request duration in milliseconds.
+            timestamp: UTC timestamp when request was made. Defaults to now.
+        """
+        # Extract rate limit headers
+        rate_limit_remaining = self._parse_int_header(
+            response.headers.get("X-RateLimit-Remaining")
+        )
+        rate_limit_limit = self._parse_int_header(
+            response.headers.get("X-RateLimit-Limit")
+        )
+        rate_limit_reset = self._parse_reset_header(
+            response.headers.get("X-RateLimit-Reset")
+        )
+        retry_after = self._parse_float_header(response.headers.get("Retry-After"))
+
+        # Calculate response size
+        response_size = len(response.content)
+
+        # Get method from request
+        method = response.request.method if response.request else "GET"
+
+        self.record_request(
+            url=str(response.url),
+            method=method,
+            response_size=response_size,
+            duration_ms=duration_ms,
+            status_code=response.status_code,
+            rate_limit_remaining=rate_limit_remaining,
+            rate_limit_limit=rate_limit_limit,
+            rate_limit_reset=rate_limit_reset,
+            retry_after_seconds=retry_after,
+            timestamp=timestamp,
+        )
+
+    def to_source_metadata(
+        self,
+        source_type: str = "api",
+        url: str | None = None,
+        api_version: str | None = None,
+    ) -> SourceMetadata:
+        """Build SourceMetadata with collected request details and aggregates.
+
+        Args:
+            source_type: Source type for metadata ("api", "csv", "parquet").
+            url: Optional base API URL to include.
+            api_version: Optional API version string.
+
+        Returns:
+            SourceMetadata instance with all collected requests and statistics.
+        """
+        with self._lock:
+            requests_copy = list(self._requests)
+
+        total_requests = len(requests_copy)
+        total_response_bytes = sum(r.response_size_bytes for r in requests_copy)
+
+        if total_requests > 0:
+            avg_duration = (
+                sum(r.request_duration_ms for r in requests_copy) / total_requests
+            )
+        else:
+            avg_duration = 0.0
+
+        return SourceMetadata(
+            type=source_type,  # type: ignore[arg-type]
+            url=url,
+            api_version=api_version,
+            api_requests=requests_copy,
+            total_requests=total_requests,
+            total_response_bytes=total_response_bytes,
+            avg_request_duration_ms=round(avg_duration, 2),
+        )
+
+    def clear(self) -> None:
+        """Clear all collected requests."""
+        with self._lock:
+            self._requests.clear()
+
+    @property
+    def request_count(self) -> int:
+        """Get current number of recorded requests."""
+        with self._lock:
+            return len(self._requests)
+
+    def _parse_query_params(
+        self, query_string: str
+    ) -> dict[str, str | int | float | bool | None]:
+        """Parse query string into dict."""
+        if not query_string:
+            return {}
+        params: dict[str, str | int | float | bool | None] = {}
+        for part in query_string.split("&"):
+            if "=" in part:
+                key, value = part.split("=", 1)
+                params[key] = value
+        return params
+
+    def _sanitize_params(
+        self, params: dict[str, Any]
+    ) -> dict[str, str | int | float | bool | None]:
+        """Sanitize query parameters to exclude sensitive data.
+
+        Removes API keys, tokens, and other sensitive parameter names.
+        """
+        sensitive_keys = {
+            "api_key",
+            "apikey",
+            "key",
+            "token",
+            "access_token",
+            "secret",
+            "password",
+            "auth",
+            "authorization",
+            "x-api-key",
+            "bearer",
+        }
+        result: dict[str, str | int | float | bool | None] = {}
+        for key, value in params.items():
+            if key.lower() in sensitive_keys:
+                result[key] = "[REDACTED]"
+            elif isinstance(value, (str, int, float, bool)) or value is None:
+                result[key] = value
+            else:
+                # Convert other types to string
+                result[key] = str(value)
+        return result
+
+    def _parse_int_header(self, value: str | None) -> int | None:
+        """Parse integer header value."""
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except ValueError:
+            return None
+
+    def _parse_float_header(self, value: str | None) -> float | None:
+        """Parse float header value."""
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except ValueError:
+            return None
+
+    def _parse_reset_header(self, value: str | None) -> datetime | None:
+        """Parse X-RateLimit-Reset header (Unix timestamp or HTTP date)."""
+        if value is None:
+            return None
+        try:
+            # Try Unix timestamp first
+            timestamp = int(value)
+            return datetime.fromtimestamp(timestamp, tz=UTC)
+        except ValueError:
+            pass
+        # Could extend to parse HTTP date format if needed
+        return None
+
+
+__all__ = ["APIRequestCollector"]

--- a/src/bioetl/infrastructure/storage/bronze_writer.py
+++ b/src/bioetl/infrastructure/storage/bronze_writer.py
@@ -29,7 +29,7 @@ import orjson
 import zstandard as zstd
 
 if TYPE_CHECKING:
-    from bioetl.domain.models.metadata import BronzeMetadata
+    from bioetl.domain.models.metadata import BronzeMetadata, SourceMetadata
     from bioetl.domain.ports import (
         AuditPort,
         LoggerPort,
@@ -250,6 +250,7 @@ class BronzeWriter:
         started_at: datetime,
         completed_at: datetime,
         duration_seconds: float,
+        source_metadata: SourceMetadata | None = None,
     ) -> BronzeMetadata:
         """Build rich BronzeMetadata for sidecar file.
 
@@ -265,6 +266,8 @@ class BronzeWriter:
             started_at: UTC timestamp when write started.
             completed_at: UTC timestamp when write completed.
             duration_seconds: Duration of write operation.
+            source_metadata: Optional pre-built SourceMetadata with API request
+                           details. If None, a minimal SourceMetadata is created.
 
         Returns:
             BronzeMetadata instance for sidecar file.
@@ -281,8 +284,8 @@ class BronzeWriter:
             PipelineMetadata,
             RuntimeMetadata,
             RunTypeEnum,
-            SourceMetadata,
         )
+        from bioetl.domain.models.metadata import SourceMetadata as SourceMetadataModel
 
         # Map domain RunType to metadata RunTypeEnum
         run_type_map = {
@@ -290,6 +293,10 @@ class BronzeWriter:
             RunType.BACKFILL: RunTypeEnum.BACKFILL,
             RunType.REBUILD: RunTypeEnum.REBUILD,
         }
+
+        # Use provided source_metadata or create minimal default
+        if source_metadata is None:
+            source_metadata = SourceMetadataModel(type="api")
 
         return BronzeMetadata(
             runtime=RuntimeMetadata(
@@ -304,9 +311,7 @@ class BronzeWriter:
                 provider=provider,
                 entity=entity,
             ),
-            source=SourceMetadata(
-                type="api",
-            ),
+            source=source_metadata,
             output=OutputMetadata(
                 files=[
                     FileOutputMetadata(
@@ -403,11 +408,24 @@ class BronzeWriter:
         run_id: RunID,
         run_type: RunType,
         ingestion_ts: datetime,
+        source_metadata: SourceMetadata | None = None,
     ) -> BronzeWriteResult:
         """Write raw records to Bronze layer (JSONL + zstd).
 
         Returns BronzeWriteResult with path, sizes, and checksum for lineage.
         Lock validation is performed at Application layer per §4.6 Safety Guard.
+
+        Args:
+            records: Iterator of bytes records (JSON-encoded).
+            provider: Provider name (e.g., 'chembl').
+            entity: Entity type (e.g., 'activity').
+            date: Date for partitioning.
+            batch_id: Unique identifier for this batch.
+            run_id: Pipeline run identifier.
+            run_type: Type of run (incremental, backfill, rebuild).
+            ingestion_ts: UTC timestamp for ingestion.
+            source_metadata: Optional pre-built SourceMetadata with API request
+                           details for rich lineage tracking.
         """
         tracer = self._tracing.get_tracer(__name__)
         with tracer.start_as_current_span("write_bronze") as span:
@@ -550,6 +568,7 @@ class BronzeWriter:
                         output_path=relative_path,
                         started_at=ingestion_ts,
                         completed_at=completed_at,
+                        source_metadata=source_metadata,
                     )
                     bronze_metadata = self._metadata_coordinator.create_bronze_metadata(
                         bronze_input
@@ -568,6 +587,7 @@ class BronzeWriter:
                         started_at=ingestion_ts,
                         completed_at=completed_at,
                         duration_seconds=duration,
+                        source_metadata=source_metadata,
                     )
 
                 # Write to batch directory (same level as data file)

--- a/tests/architecture/test_code_metrics.py
+++ b/tests/architecture/test_code_metrics.py
@@ -55,9 +55,10 @@ class TestFileSizeLimits:
         "activity_values.py": 450,  # 436 LOC - Activity value objects (renamed from measurements.py)
         # Domain ports NoOp implementations
         "noop.py": 450,  # 447 LOC - NoOp implementations for Null Object Pattern (+ NoOpMetadataWriter)
-        "metadata.py": 500,  # 478 LOC - Metadata models for Medallion layer sidecar files
+        # Domain models/metadata.py (models/metadata.py 560 LOC, ports/metadata.py only 104 LOC)
+        "metadata.py": 565,  # 560 LOC - Metadata models with APIRequestDetails + RateLimitInfo for Bronze layer enrichment
         # Domain ports (Protocol definitions with comprehensive docstrings)
-        "storage.py": 380,  # 368 LOC - StoragePort with read_silver, write_*_merged for composite pipelines
+        "storage.py": 385,  # 381 LOC - StoragePort with read_silver, write_*_merged for composite pipelines + SourceMetadata param
         # Domain Pandera schemas (declarative field definitions)
         "compound.py": 380,  # 377 LOC - PubChem molecule schema + deprecated alias (v2.0)
         "protein.py": 360,  # 354 LOC - UniProt target schema + deprecated alias (v2.0)
@@ -76,7 +77,7 @@ class TestFileSizeLimits:
         "bootstrap.py": 450,  # 420 LOC - main DI wiring
         "entrypoints.py": 720,  # 703 LOC - pipeline entrypoints (run_pipeline expanded + services)
         "registration.py": 720,  # 705 LOC - provider registration with data source creators (OpenAlex + SemanticScholar + UniProt IDMapping)
-        "storage_adapter.py": 620,  # 617 LOC - storage adapter with Bronze/Silver/Gold writers + BronzeWriteResult
+        "storage_adapter.py": 625,  # 623 LOC - storage adapter with Bronze/Silver/Gold writers + BronzeWriteResult + SourceMetadata param
         # Consolidated factory files (v5.2)
         "pipeline_factory.py": 560,  # 557 LOC - merged generic_factory + runner_assembly + entity_type helper
         "pipeline_factories.py": 520,  # 505 LOC - pipeline factory configurations (OpenAlex + SemanticScholar + IDMapping)
@@ -84,7 +85,7 @@ class TestFileSizeLimits:
         # Infrastructure layer exemptions
         "silver_writer.py": 1110,  # 1095 LOC - schema drift + merge logic + MetadataCoordinator fallback
         "gold_writer.py": 900,  # 887 LOC - SCD Type 2 + MetadataCoordinator fallback
-        "bronze_writer.py": 750,  # 729 LOC - streaming compression + MetadataCoordinator fallback
+        "bronze_writer.py": 755,  # 750 LOC - streaming compression + MetadataCoordinator fallback + SourceMetadata param
         "gold.py": 920,  # 915 LOC - Gold layer Pandera schemas (+ IDMapping + taxonomy_id standardization + Config docstrings)
         "silver.py": 780,  # 775 LOC - Silver PyArrow schemas (+ IDMapping + taxonomy_id standardization)
         "client.py": 700,  # 692 LOC - ChemblAdapter (complex FilterableDataSourcePort), CrossRefAdapter (DOI→title fallback)
@@ -355,11 +356,13 @@ class TestFunctionLength:
         "classify_http_error": 55,  # HTTP error classification
         # Logging config
         "configure_logging": 70,  # Logging setup
+        # API request collector
+        "record_request": 75,  # Request metadata collection with validation and sanitization
     }
 
     # Maximum allowed violations (for tracking technical debt)
-    # Baseline updated 2026-01-15: 85 violations (DQ analyzers integration)
-    MAX_VIOLATIONS = 95  # Increased to accommodate MetadataCoordinator fallback methods
+    # Baseline updated 2026-01-16: 95 violations (MetadataCoordinator + APIRequestCollector)
+    MAX_VIOLATIONS = 95
 
     def test_functions_under_50_lines(self, src_dir: Path) -> None:
         """All functions must be under 50 lines (with exemptions)."""
@@ -431,9 +434,9 @@ class TestClassSize:
         "UniProtProteinTransformer": 800,  # 772 lines - complex protein data extraction with many fields
         "PreflightService": 545,  # 540 lines - preflight validation service
         "PostrunService": 355,  # 349 lines - postrun service
-        "BronzeWriter": 700,  # 682 lines - JSONL + zstd + MetadataCoordinator fallback
+        "BronzeWriter": 705,  # 702 lines - JSONL + zstd + MetadataCoordinator fallback + SourceMetadata
         "BatchExecutor": 600,  # 581 lines - unified executor for batch processing
-        "BatchWriter": 350,  # 338 lines - batch writing with Safety Guard §4.6 lock validation
+        "BatchWriter": 360,  # 354 lines - batch writing with Safety Guard §4.6 lock validation + SourceMetadata param
         # Application core classes
         "FilteredDataSource": 330,  # 320 lines - decorator with fallback mapping support
         # CrossRef adapter classes (similar to ChEMBL/PubMed adapters)
@@ -477,7 +480,7 @@ class TestClassSize:
         # Extracted validators (REFACTOR-003)
         "MedallionConfigValidator": 350,  # Extracted from PreflightService - cohesive validation
         # Domain ports (Protocol definitions with comprehensive docstrings)
-        "StoragePort": 350,  # 342 lines - Protocol with read_silver, write_*_merged for composite pipelines
+        "StoragePort": 355,  # 351 lines - Protocol with read_silver, write_*_merged + SourceMetadata param for Bronze write
         # Pandera schemas (declarative field definitions)
         "PubchemMoleculeSchema": 350,  # 345 lines - PubChem molecule schema with many chemical fields
         # Derived entity data source wrappers (comprehensive docstrings)

--- a/tests/architecture/test_no_datetime_now_in_infrastructure.py
+++ b/tests/architecture/test_no_datetime_now_in_infrastructure.py
@@ -48,6 +48,10 @@ ALLOWED_FILES: set[str] = {
     # infrastructure/storage/gold_writer.py
     # Uses datetime.now(UTC) for audit logging timestamps.
     "gold_writer.py",
+    # infrastructure/adapters/common/api_request_collector.py
+    # Uses datetime.now(UTC) for request timestamp when caller doesn't provide one.
+    # This is for audit/debugging metadata, not Bronze/Silver/Gold data determinism.
+    "api_request_collector.py",
 }
 
 

--- a/tests/unit/infrastructure/adapters/common/test_api_request_collector.py
+++ b/tests/unit/infrastructure/adapters/common/test_api_request_collector.py
@@ -1,0 +1,517 @@
+"""Unit tests for APIRequestCollector.
+
+Tests request recording, aggregation, and metadata generation
+for Bronze layer source metadata enrichment.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from bioetl.infrastructure.adapters.common.api_request_collector import (
+    APIRequestCollector,
+)
+
+
+class TestAPIRequestCollector:
+    """Tests for APIRequestCollector initialization and basic operations."""
+
+    def test_init_creates_empty_collector(self) -> None:
+        """Collector starts with no requests."""
+        collector = APIRequestCollector()
+        assert collector.request_count == 0
+
+    def test_clear_removes_all_requests(self) -> None:
+        """Clear removes all recorded requests."""
+        collector = APIRequestCollector()
+        collector.record_request(
+            url="https://api.example.com/data",
+            response_size=100,
+            duration_ms=50.0,
+        )
+        assert collector.request_count == 1
+
+        collector.clear()
+        assert collector.request_count == 0
+
+
+class TestRecordRequest:
+    """Tests for the record_request method."""
+
+    def test_record_request_basic(self) -> None:
+        """Basic request recording captures required fields."""
+        collector = APIRequestCollector()
+
+        collector.record_request(
+            url="https://api.example.com/v1/data?limit=100&offset=0",
+            method="GET",
+            response_size=1024,
+            duration_ms=150.5,
+            status_code=200,
+        )
+
+        assert collector.request_count == 1
+        metadata = collector.to_source_metadata()
+
+        assert len(metadata.api_requests) == 1
+        request = metadata.api_requests[0]
+
+        assert request.endpoint == "/v1/data"
+        assert request.base_url == "https://api.example.com"
+        assert request.http_method == "GET"
+        assert request.response_size_bytes == 1024
+        assert request.request_duration_ms == 150.5
+        assert request.status_code == 200
+
+    def test_record_request_with_params(self) -> None:
+        """Request recording with explicit params dict."""
+        collector = APIRequestCollector()
+
+        params = {"limit": 500, "offset": 1000, "format": "json"}
+        collector.record_request(
+            url="https://api.example.com/data",
+            params=params,
+            response_size=2048,
+            duration_ms=200.0,
+        )
+
+        metadata = collector.to_source_metadata()
+        request = metadata.api_requests[0]
+
+        assert request.query_params == {"limit": 500, "offset": 1000, "format": "json"}
+
+    def test_record_request_parses_url_params(self) -> None:
+        """Request recording parses query params from URL."""
+        collector = APIRequestCollector()
+
+        collector.record_request(
+            url="https://api.example.com/data?limit=100&offset=0",
+            response_size=1024,
+            duration_ms=100.0,
+        )
+
+        metadata = collector.to_source_metadata()
+        request = metadata.api_requests[0]
+
+        assert request.query_params == {"limit": "100", "offset": "0"}
+
+    def test_record_request_sanitizes_api_keys(self) -> None:
+        """Sensitive parameters are redacted."""
+        collector = APIRequestCollector()
+
+        params = {
+            "api_key": "secret_key_12345",
+            "token": "bearer_token_abc",
+            "limit": 100,
+            "Authorization": "Basic xyz",
+        }
+        collector.record_request(
+            url="https://api.example.com/data",
+            params=params,
+            response_size=1024,
+            duration_ms=100.0,
+        )
+
+        metadata = collector.to_source_metadata()
+        request = metadata.api_requests[0]
+
+        assert request.query_params["api_key"] == "[REDACTED]"
+        assert request.query_params["token"] == "[REDACTED]"
+        assert request.query_params["Authorization"] == "[REDACTED]"
+        assert request.query_params["limit"] == 100
+
+    def test_record_request_with_rate_limit_info(self) -> None:
+        """Request recording captures rate limit headers."""
+        collector = APIRequestCollector()
+        reset_time = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
+
+        collector.record_request(
+            url="https://api.example.com/data",
+            response_size=1024,
+            duration_ms=100.0,
+            rate_limit_remaining=95,
+            rate_limit_limit=100,
+            rate_limit_reset=reset_time,
+            retry_after_seconds=5.0,
+        )
+
+        metadata = collector.to_source_metadata()
+        request = metadata.api_requests[0]
+
+        assert request.rate_limit is not None
+        assert request.rate_limit.remaining == 95
+        assert request.rate_limit.limit == 100
+        assert request.rate_limit.reset_at == reset_time
+        assert request.rate_limit.retry_after_seconds == 5.0
+
+    def test_record_request_timestamp_default(self) -> None:
+        """Request recording uses current UTC time if not provided."""
+        collector = APIRequestCollector()
+        before = datetime.now(UTC)
+
+        collector.record_request(
+            url="https://api.example.com/data",
+            response_size=1024,
+            duration_ms=100.0,
+        )
+
+        after = datetime.now(UTC)
+        metadata = collector.to_source_metadata()
+        request = metadata.api_requests[0]
+
+        assert request.timestamp is not None
+        assert before <= request.timestamp <= after
+
+    def test_record_request_explicit_timestamp(self) -> None:
+        """Request recording uses provided timestamp."""
+        collector = APIRequestCollector()
+        custom_time = datetime(2024, 6, 15, 10, 30, 0, tzinfo=UTC)
+
+        collector.record_request(
+            url="https://api.example.com/data",
+            response_size=1024,
+            duration_ms=100.0,
+            timestamp=custom_time,
+        )
+
+        metadata = collector.to_source_metadata()
+        request = metadata.api_requests[0]
+
+        assert request.timestamp == custom_time
+
+    def test_record_multiple_requests(self) -> None:
+        """Multiple requests are accumulated."""
+        collector = APIRequestCollector()
+
+        collector.record_request(
+            url="https://api.example.com/data?page=1",
+            response_size=1000,
+            duration_ms=100.0,
+        )
+        collector.record_request(
+            url="https://api.example.com/data?page=2",
+            response_size=2000,
+            duration_ms=200.0,
+        )
+        collector.record_request(
+            url="https://api.example.com/data?page=3",
+            response_size=3000,
+            duration_ms=300.0,
+        )
+
+        assert collector.request_count == 3
+        metadata = collector.to_source_metadata()
+        assert len(metadata.api_requests) == 3
+
+    def test_record_post_request(self) -> None:
+        """POST method is recorded correctly."""
+        collector = APIRequestCollector()
+
+        collector.record_request(
+            url="https://api.example.com/search",
+            method="POST",
+            response_size=5000,
+            duration_ms=500.0,
+        )
+
+        metadata = collector.to_source_metadata()
+        request = metadata.api_requests[0]
+
+        assert request.http_method == "POST"
+
+
+class TestRecordFromResponse:
+    """Tests for the record_from_response method."""
+
+    def test_record_from_response_basic(self) -> None:
+        """Recording from httpx response extracts basic info."""
+        collector = APIRequestCollector()
+
+        # Create mock response
+        mock_response = MagicMock()
+        mock_response.url = "https://api.example.com/data?limit=100"
+        mock_response.status_code = 200
+        mock_response.content = b"x" * 1024  # 1KB response
+        mock_response.headers = {}
+        mock_response.request.method = "GET"
+
+        collector.record_from_response(mock_response, duration_ms=150.0)
+
+        metadata = collector.to_source_metadata()
+        request = metadata.api_requests[0]
+
+        assert request.base_url == "https://api.example.com"
+        assert request.endpoint == "/data"
+        assert request.status_code == 200
+        assert request.response_size_bytes == 1024
+        assert request.request_duration_ms == 150.0
+        assert request.http_method == "GET"
+
+    def test_record_from_response_with_rate_limit_headers(self) -> None:
+        """Recording extracts rate limit headers."""
+        collector = APIRequestCollector()
+
+        mock_response = MagicMock()
+        mock_response.url = "https://api.example.com/data"
+        mock_response.status_code = 200
+        mock_response.content = b"test"
+        mock_response.headers = {
+            "X-RateLimit-Remaining": "95",
+            "X-RateLimit-Limit": "100",
+            "X-RateLimit-Reset": "1705320000",  # Unix timestamp
+            "Retry-After": "5.5",
+        }
+        mock_response.request.method = "GET"
+
+        collector.record_from_response(mock_response, duration_ms=100.0)
+
+        metadata = collector.to_source_metadata()
+        request = metadata.api_requests[0]
+
+        assert request.rate_limit is not None
+        assert request.rate_limit.remaining == 95
+        assert request.rate_limit.limit == 100
+        assert request.rate_limit.reset_at is not None
+        assert request.rate_limit.retry_after_seconds == 5.5
+
+    def test_record_from_response_missing_headers(self) -> None:
+        """Recording handles missing rate limit headers gracefully."""
+        collector = APIRequestCollector()
+
+        mock_response = MagicMock()
+        mock_response.url = "https://api.example.com/data"
+        mock_response.status_code = 200
+        mock_response.content = b"test"
+        mock_response.headers = {}
+        mock_response.request.method = "GET"
+
+        collector.record_from_response(mock_response, duration_ms=100.0)
+
+        metadata = collector.to_source_metadata()
+        request = metadata.api_requests[0]
+
+        # No rate limit info when headers are missing
+        assert request.rate_limit is None
+
+
+class TestToSourceMetadata:
+    """Tests for the to_source_metadata method."""
+
+    def test_empty_collector_returns_minimal_metadata(self) -> None:
+        """Empty collector returns metadata with zero aggregates."""
+        collector = APIRequestCollector()
+
+        metadata = collector.to_source_metadata()
+
+        assert metadata.type == "api"
+        assert metadata.api_requests == []
+        assert metadata.total_requests == 0
+        assert metadata.total_response_bytes == 0
+        assert metadata.avg_request_duration_ms == 0.0
+
+    def test_aggregates_multiple_requests(self) -> None:
+        """Aggregates are computed correctly from multiple requests."""
+        collector = APIRequestCollector()
+
+        collector.record_request(
+            url="https://api.example.com/data?page=1",
+            response_size=1000,
+            duration_ms=100.0,
+        )
+        collector.record_request(
+            url="https://api.example.com/data?page=2",
+            response_size=2000,
+            duration_ms=200.0,
+        )
+        collector.record_request(
+            url="https://api.example.com/data?page=3",
+            response_size=3000,
+            duration_ms=300.0,
+        )
+
+        metadata = collector.to_source_metadata()
+
+        assert metadata.total_requests == 3
+        assert metadata.total_response_bytes == 6000
+        assert metadata.avg_request_duration_ms == 200.0  # (100 + 200 + 300) / 3
+
+    def test_to_source_metadata_with_url(self) -> None:
+        """Source metadata includes base URL when provided."""
+        collector = APIRequestCollector()
+        collector.record_request(
+            url="https://api.example.com/data",
+            response_size=1024,
+            duration_ms=100.0,
+        )
+
+        metadata = collector.to_source_metadata(url="https://api.example.com")
+
+        assert metadata.url == "https://api.example.com"
+
+    def test_to_source_metadata_with_api_version(self) -> None:
+        """Source metadata includes API version when provided."""
+        collector = APIRequestCollector()
+        collector.record_request(
+            url="https://api.example.com/data",
+            response_size=1024,
+            duration_ms=100.0,
+        )
+
+        metadata = collector.to_source_metadata(api_version="v2.1.0")
+
+        assert metadata.api_version == "v2.1.0"
+
+    def test_to_source_metadata_csv_type(self) -> None:
+        """Source type can be set to non-api values."""
+        collector = APIRequestCollector()
+
+        metadata = collector.to_source_metadata(source_type="csv")
+
+        assert metadata.type == "csv"
+
+    def test_avg_duration_rounds_to_two_decimals(self) -> None:
+        """Average duration is rounded to 2 decimal places."""
+        collector = APIRequestCollector()
+
+        collector.record_request(
+            url="https://api.example.com/data",
+            response_size=1000,
+            duration_ms=100.333333,
+        )
+        collector.record_request(
+            url="https://api.example.com/data",
+            response_size=1000,
+            duration_ms=200.666666,
+        )
+
+        metadata = collector.to_source_metadata()
+
+        # (100.333333 + 200.666666) / 2 = 150.499999... → 150.5
+        assert metadata.avg_request_duration_ms == 150.5
+
+
+class TestThreadSafety:
+    """Tests for thread-safety of the collector."""
+
+    def test_concurrent_recording(self) -> None:
+        """Collector handles concurrent access safely."""
+        import threading
+
+        collector = APIRequestCollector()
+        num_threads = 10
+        requests_per_thread = 100
+
+        def record_requests() -> None:
+            for i in range(requests_per_thread):
+                collector.record_request(
+                    url=f"https://api.example.com/data?id={i}",
+                    response_size=100,
+                    duration_ms=10.0,
+                )
+
+        threads = [threading.Thread(target=record_requests) for _ in range(num_threads)]
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert collector.request_count == num_threads * requests_per_thread
+
+
+class TestBackwardCompatibility:
+    """Tests for backward compatibility with existing SourceMetadata usage."""
+
+    def test_source_metadata_serializable(self) -> None:
+        """Generated SourceMetadata is JSON serializable."""
+        collector = APIRequestCollector()
+        collector.record_request(
+            url="https://api.example.com/data",
+            response_size=1024,
+            duration_ms=100.0,
+            rate_limit_remaining=95,
+        )
+
+        metadata = collector.to_source_metadata()
+
+        # Should not raise
+        json_dict = metadata.model_dump()
+        assert isinstance(json_dict, dict)
+        assert json_dict["type"] == "api"
+        assert json_dict["total_requests"] == 1
+
+    def test_minimal_source_metadata_compatible(self) -> None:
+        """Empty collector produces metadata compatible with old format."""
+        collector = APIRequestCollector()
+        metadata = collector.to_source_metadata()
+
+        # Old code expects these fields
+        assert hasattr(metadata, "type")
+        assert hasattr(metadata, "url")
+        assert hasattr(metadata, "file_path")
+        assert hasattr(metadata, "api_version")
+
+        # New fields have safe defaults
+        assert metadata.api_requests == []
+        assert metadata.total_requests == 0
+
+
+class TestParameterSanitization:
+    """Tests for parameter sanitization."""
+
+    @pytest.mark.parametrize(
+        "param_name",
+        [
+            "api_key",
+            "apikey",
+            "key",
+            "token",
+            "access_token",
+            "secret",
+            "password",
+            "auth",
+            "authorization",
+            "x-api-key",
+            "bearer",
+        ],
+    )
+    def test_sensitive_params_redacted(self, param_name: str) -> None:
+        """All known sensitive parameter names are redacted."""
+        collector = APIRequestCollector()
+
+        collector.record_request(
+            url="https://api.example.com/data",
+            params={param_name: "sensitive_value_123"},
+            response_size=1024,
+            duration_ms=100.0,
+        )
+
+        metadata = collector.to_source_metadata()
+        request = metadata.api_requests[0]
+
+        assert request.query_params[param_name] == "[REDACTED]"
+
+    def test_case_insensitive_sanitization(self) -> None:
+        """Sanitization is case-insensitive."""
+        collector = APIRequestCollector()
+
+        collector.record_request(
+            url="https://api.example.com/data",
+            params={
+                "API_KEY": "secret1",
+                "Token": "secret2",
+                "SECRET": "secret3",
+            },
+            response_size=1024,
+            duration_ms=100.0,
+        )
+
+        metadata = collector.to_source_metadata()
+        request = metadata.api_requests[0]
+
+        assert request.query_params["API_KEY"] == "[REDACTED]"
+        assert request.query_params["Token"] == "[REDACTED]"
+        assert request.query_params["SECRET"] == "[REDACTED]"


### PR DESCRIPTION
Add detailed API request tracking to Bronze layer metadata:

- Add RateLimitInfo model for rate limit header parsing
- Add APIRequestDetails model for per-request metadata (endpoint, params, response size, duration, status code)
- Extend SourceMetadata with api_requests list and aggregate fields (total_requests, total_response_bytes, avg_request_duration_ms)
- Create APIRequestCollector utility class for accumulating request details and generating SourceMetadata instances
- Thread source_metadata through StoragePort → StorageAdapter → BronzeWriter → BatchWriter interfaces

Features:
- Automatic URL parsing to extract base_url and endpoint
- Query parameter sanitization (redacts API keys, tokens, secrets)
- Rate limit header parsing (X-RateLimit-*, Retry-After)
- Direct httpx.Response recording via record_from_response()
- Thread-safe concurrent request recording

Testing:
- Add 35 unit tests for APIRequestCollector
- Update architecture test exemptions for file/class size limits
- All unit and architecture tests passing

Closes: #1556