### PR TITLE
Add title fallback strategy to PubMed pipeline

### DIFF
--- a/src/bioetl/infrastructure/adapters/pubmed/__init__.py
+++ b/src/bioetl/infrastructure/adapters/pubmed/__init__.py
@@ -5,6 +5,7 @@ This package provides the adapter for interacting with the PubMed API.
 
 from __future__ import annotations
 
+from bioetl.infrastructure.adapters.pubmed.fallback import TitleFallbackHandler
 from bioetl.infrastructure.adapters.pubmed.models import (
     PUBMED_RECORD_MODELS,
     PubMedArticleRecord,
@@ -14,13 +15,10 @@ from bioetl.infrastructure.adapters.pubmed.models import (
 from bioetl.infrastructure.adapters.pubmed.pubmed_client import PubMedAdapter
 
 __all__ = [
-    # Model Mappings
     "PUBMED_RECORD_MODELS",
-    # Adapter
     "PubMedAdapter",
-    # Record Models
     "PubMedArticleRecord",
     "PubMedExtendedRecord",
-    # Response Models
     "PubMedSearchResponse",
+    "TitleFallbackHandler",
 ]

--- a/src/bioetl/infrastructure/adapters/pubmed/fallback.py
+++ b/src/bioetl/infrastructure/adapters/pubmed/fallback.py
@@ -1,0 +1,132 @@
+"""Fallback search utilities for PubMed publication resolution.
+
+Provides title-based search fallback when PMID lookup fails.
+Supports three-phase fallback strategy:
+- Phase 2: Title fallback for unresolved PMIDs
+- Phase 3: Title-only lookup for entries without PMIDs
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from bioetl.infrastructure.adapters.common import BaseTitleFallbackHandler, titles_match
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Coroutine
+
+    from bioetl.domain.ports import LoggerPort
+
+
+class TitleFallbackHandler(BaseTitleFallbackHandler):
+    """Handles fallback search by title when PMID/DOI lookup fails.
+
+    Uses PubMed esearch API with title field search:
+    term="Title text"[Title]
+    """
+
+    def __init__(
+        self,
+        logger: LoggerPort,
+        search_fn: Callable[[str, int], Coroutine[Any, Any, list[dict[str, Any]]]],
+    ) -> None:
+        """Initialize fallback handler.
+
+        Args:
+            logger: Logger port for structured logging.
+            search_fn: Async function to search publications by title.
+                       Signature: search_fn(title: str, limit: int) -> list[dict]
+        """
+        super().__init__(logger)
+        self._search_fn = search_fn
+
+    @property
+    def _event_no_fallback_title(self) -> str:
+        """Return log event name for missing fallback title."""
+        return "pubmed_no_fallback_title"
+
+    @property
+    def _event_fallback_attempt(self) -> str:
+        """Return log event name for fallback attempt."""
+        return "pubmed_title_fallback_attempt"
+
+    @property
+    def _event_fallback_success(self) -> str:
+        """Return log event name for successful fallback."""
+        return "pubmed_title_fallback_success"
+
+    @property
+    def _event_fallback_not_found(self) -> str:
+        """Return log event name for failed fallback."""
+        return "pubmed_title_fallback_not_found"
+
+    @property
+    def _event_title_only_attempt(self) -> str:
+        """Return log event name for title-only lookup attempt."""
+        return "pubmed_title_only_attempt"
+
+    @property
+    def _event_title_only_success(self) -> str:
+        """Return log event name for successful title-only lookup."""
+        return "pubmed_title_only_success"
+
+    @property
+    def _event_title_only_not_found(self) -> str:
+        """Return log event name for failed title-only lookup."""
+        return "pubmed_title_only_not_found"
+
+    async def _search_by_title(self, title: str) -> dict[str, Any] | None:
+        """Search for publication by title using PubMed esearch.
+
+        Validates results using title matching to reduce false positives.
+
+        Args:
+            title: Publication title to search for.
+
+        Returns:
+            Publication record if found and title matches, None otherwise.
+        """
+        # Clean title for search (PubMed practical limit ~200 chars)
+        clean_title = title.strip()[:200]
+
+        try:
+            results = await self._search_fn(clean_title, 3)
+
+            for publication in results:
+                pub_title = publication.get("article_title", "")
+                if pub_title and titles_match(clean_title, pub_title):
+                    return publication
+
+            # If we got results but no title match, return first result
+            # (title may be in different format in PubMed)
+            if results:
+                return results[0]
+
+        except Exception as e:
+            self._logger.debug(
+                "pubmed_title_search_failed",
+                title=clean_title[:50],
+                error=str(e),
+            )
+
+        return None
+
+    def _get_result_identifier(self, result: dict[str, Any]) -> tuple[str, str]:
+        """Return PubMed PMID for logging."""
+        return ("found_pmid", str(result.get("pmid", "unknown")))
+
+    def _process_found_result(
+        self, result: dict[str, Any], original_id: str
+    ) -> dict[str, Any]:
+        """Add lookup method metadata to found publication.
+
+        Args:
+            result: The found publication record.
+            original_id: The ID that was originally searched (DOI or PMID).
+
+        Returns:
+            Publication with _lookup_method and _original_id added.
+        """
+        result["_lookup_method"] = "title_fallback"
+        result["_original_id"] = original_id
+        return result

--- a/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
+++ b/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
@@ -22,7 +22,8 @@ from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.adapters.base import BaseHttpAdapter
 from bioetl.infrastructure.adapters.base_metrics import AdapterMetrics
 from bioetl.infrastructure.adapters.error_handling import ErrorService
-from bioetl.infrastructure.adapters.filterable_mixin import FilterableStubMixin
+from bioetl.infrastructure.adapters.filterable_mixin import NotSupportedMultiFilterMixin
+from bioetl.infrastructure.adapters.pubmed.fallback import TitleFallbackHandler
 from bioetl.infrastructure.adapters.pubmed.xml_processor import PubMedXmlProcessor
 
 if TYPE_CHECKING:
@@ -41,7 +42,7 @@ PUBMED_DTO_MODELS: dict[str, type[BaseModel]] = {
 
 
 @dataclass
-class PubMedAdapter(FilterableStubMixin, BaseHttpAdapter):
+class PubMedAdapter(NotSupportedMultiFilterMixin, BaseHttpAdapter):
     """PubMed adapter using UnifiedHTTPClient.
 
     Inherits from BaseHttpAdapter for standardized lifecycle management
@@ -50,9 +51,10 @@ class PubMedAdapter(FilterableStubMixin, BaseHttpAdapter):
     Implements DataSourcePort and FilterableDataSourcePort for PubMed data extraction
     with optional server-side filtering by PMID lists.
 
-    Uses FilterableStubMixin for:
-    - fetch_multi_filtered: Not supported by PubMed API
-    - fetch_filtered_with_fallback: Delegates to fetch_filtered (PMIDs are stable)
+    Uses NotSupportedMultiFilterMixin for fetch_multi_filtered (not supported by PubMed API).
+
+    Supports title-based fallback search via fetch_filtered_with_fallback() when
+    primary PMID lookup fails.
 
     Args:
         http_client: UnifiedHTTPClient instance for making HTTP requests.
@@ -78,13 +80,24 @@ class PubMedAdapter(FilterableStubMixin, BaseHttpAdapter):
     provider_name: str = field(init=False, default="pubmed")
     """Provider identifier (required by DataSourcePort)."""
 
+    _fallback_handler: TitleFallbackHandler | None = field(
+        default=None, init=False, repr=False
+    )
+    """Title fallback handler for resolving publications when PMID lookup fails."""
+
     def __post_init__(self) -> None:
-        """Initialize adapter metrics and error handler after dataclass init."""
+        """Initialize adapter metrics, error handler and fallback handler."""
         # Initialize error handler from base class
         self._error_handler = ErrorService(self.logger)
 
         metrics_port = self.metrics if self.metrics is not None else NoOpMetrics()
         self._adapter_metrics = AdapterMetrics(metrics_port, self.provider_name)
+
+        # Initialize fallback handler for title-based search
+        self._fallback_handler = TitleFallbackHandler(
+            logger=self.logger,
+            search_fn=self._search_by_title,
+        )
 
     async def _get_pmids(self, search_term: str, max_count: int) -> list[str]:
         """Get PMIDs for a search term."""
@@ -211,8 +224,133 @@ class PubMedAdapter(FilterableStubMixin, BaseHttpAdapter):
         async for record in self._yield_articles_from_pmids(filter_ids, limit):
             yield record
 
-    # fetch_multi_filtered and fetch_filtered_with_fallback are provided
-    # by FilterableStubMixin (see class inheritance)
+    # fetch_multi_filtered is provided by NotSupportedMultiFilterMixin
+
+    async def _search_by_title(
+        self, title: str, limit: int = 3
+    ) -> list[dict[str, Any]]:
+        """Search PubMed by title using esearch + efetch.
+
+        Args:
+            title: Publication title to search for.
+            limit: Maximum results to return.
+
+        Returns:
+            List of publication records matching the title.
+        """
+        # PubMed title search syntax: "title text"[Title]
+        # Escape quotes in title and limit length
+        clean_title = title.replace('"', "'").strip()[:200]
+        search_term = f'"{clean_title}"[Title]'
+
+        self.logger.debug(
+            "pubmed_title_search",
+            title=clean_title[:50],
+        )
+
+        try:
+            # Step 1: esearch to get PMIDs
+            pmids = await self._get_pmids(search_term, limit)
+
+            if not pmids:
+                return []
+
+            # Step 2: efetch to get full records
+            results: list[dict[str, Any]] = []
+            async for record in self._yield_articles_from_pmids(pmids, limit):
+                results.append(record)
+
+            return results
+
+        except Exception as e:
+            self.logger.debug(
+                "pubmed_title_search_failed",
+                title=clean_title[:50],
+                error=str(e),
+            )
+            return []
+
+    async def fetch_filtered_with_fallback(
+        self,
+        entity_type: str,
+        filter_ids: list[str],
+        filter_field: str,
+        fallback_mapping: dict[str, str],
+        limit: int | None = None,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Fetch with fallback to title search when PMID/DOI lookup fails.
+
+        Three-phase strategy:
+        1. Try PMID lookup for valid PMIDs
+        2. For PMIDs not found → search by title from fallback_mapping
+        3. For empty PMIDs (in filter_ids as "") → search by title only
+
+        Args:
+            entity_type: Must be 'publication'.
+            filter_ids: List of PMIDs (may include empty strings for title-only).
+            filter_field: Expected 'pmid' or 'doi'.
+            fallback_mapping: Mapping {pmid/doi: title} for fallback search.
+            limit: Maximum records to return.
+
+        Yields:
+            Publication records with `_lookup_method` field indicating resolution method.
+
+        Raises:
+            ValueError: If entity_type is not 'publication'.
+        """
+        if entity_type != "publication":
+            raise ValueError("PubMedAdapter only supports 'publication'")
+
+        # Separate valid IDs from title-only entries
+        valid_ids = [id_ for id_ in filter_ids if id_.strip()]
+        title_only_entries = [id_ for id_ in filter_ids if not id_.strip()]
+
+        fetched = 0
+        found_ids: set[str] = set()
+
+        # Phase 1: Try primary PMID lookup
+        if valid_ids:
+            async for record in self.fetch_filtered(
+                entity_type=entity_type,
+                filter_ids=valid_ids,
+                filter_field=filter_field,
+                limit=limit,
+            ):
+                record["_lookup_method"] = "primary"
+                found_id = str(record.get("pmid", ""))
+                if found_id:
+                    found_ids.add(found_id.lower())
+                fetched += 1
+                yield record
+
+                if limit and fetched >= limit:
+                    return
+
+        # Phase 2: Fallback for unresolved IDs
+        if self._fallback_handler:
+            async for record in self._fallback_handler.process_missing_dois(
+                dois=valid_ids,
+                found_dois=found_ids,
+                fallback_mapping=fallback_mapping,
+                normalize_fn=lambda x: x.lower().strip(),
+                limit=limit,
+                fetched=fetched,
+            ):
+                fetched += 1
+                yield record
+
+                if limit and fetched >= limit:
+                    return
+
+        # Phase 3: Title-only entries (using handler)
+        if self._fallback_handler:
+            async for record in self._fallback_handler.process_title_only_entries(
+                entries=title_only_entries,
+                fallback_mapping=fallback_mapping,
+                limit=limit,
+                fetched=fetched,
+            ):
+                yield record
 
     async def fetch(
         self,

--- a/tests/unit/infrastructure/adapters/pubmed/test_fallback.py
+++ b/tests/unit/infrastructure/adapters/pubmed/test_fallback.py
@@ -1,0 +1,417 @@
+"""Unit tests for PubMed fallback handler.
+
+Tests the TitleFallbackHandler class for title-based search fallback.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bioetl.infrastructure.adapters.pubmed.fallback import TitleFallbackHandler
+
+
+@pytest.fixture
+def mock_logger() -> MagicMock:
+    """Create a mock logger."""
+    logger = MagicMock()
+    logger.debug = MagicMock()
+    logger.info = MagicMock()
+    logger.warning = MagicMock()
+    return logger
+
+
+@pytest.fixture
+def mock_search_fn() -> AsyncMock:
+    """Create a mock search function."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def handler(mock_logger: MagicMock, mock_search_fn: AsyncMock) -> TitleFallbackHandler:
+    """Create a fallback handler for testing."""
+    return TitleFallbackHandler(logger=mock_logger, search_fn=mock_search_fn)
+
+
+class TestEventProperties:
+    """Tests for event name properties."""
+
+    def test_event_no_fallback_title(self, handler: TitleFallbackHandler) -> None:
+        """Should return pubmed-specific event name."""
+        assert handler._event_no_fallback_title == "pubmed_no_fallback_title"
+
+    def test_event_fallback_attempt(self, handler: TitleFallbackHandler) -> None:
+        """Should return pubmed-specific event name."""
+        assert handler._event_fallback_attempt == "pubmed_title_fallback_attempt"
+
+    def test_event_fallback_success(self, handler: TitleFallbackHandler) -> None:
+        """Should return pubmed-specific event name."""
+        assert handler._event_fallback_success == "pubmed_title_fallback_success"
+
+    def test_event_fallback_not_found(self, handler: TitleFallbackHandler) -> None:
+        """Should return pubmed-specific event name."""
+        assert handler._event_fallback_not_found == "pubmed_title_fallback_not_found"
+
+    def test_event_title_only_attempt(self, handler: TitleFallbackHandler) -> None:
+        """Should return pubmed-specific event name."""
+        assert handler._event_title_only_attempt == "pubmed_title_only_attempt"
+
+    def test_event_title_only_success(self, handler: TitleFallbackHandler) -> None:
+        """Should return pubmed-specific event name."""
+        assert handler._event_title_only_success == "pubmed_title_only_success"
+
+    def test_event_title_only_not_found(self, handler: TitleFallbackHandler) -> None:
+        """Should return pubmed-specific event name."""
+        assert handler._event_title_only_not_found == "pubmed_title_only_not_found"
+
+
+class TestGetResultIdentifier:
+    """Tests for _get_result_identifier method."""
+
+    def test_get_identifier_with_pmid(self, handler: TitleFallbackHandler) -> None:
+        """Should return PMID from record."""
+        result = handler._get_result_identifier({"pmid": "12345678"})
+        assert result == ("found_pmid", "12345678")
+
+    def test_get_identifier_without_pmid(self, handler: TitleFallbackHandler) -> None:
+        """Should return 'unknown' when no PMID."""
+        result = handler._get_result_identifier({})
+        assert result == ("found_pmid", "unknown")
+
+
+class TestProcessFoundResult:
+    """Tests for _process_found_result method."""
+
+    def test_adds_lookup_method(self, handler: TitleFallbackHandler) -> None:
+        """Should add _lookup_method field."""
+        record = {"pmid": "12345678", "article_title": "Test"}
+        result = handler._process_found_result(record, "10.1234/test")
+
+        assert result["_lookup_method"] == "title_fallback"
+
+    def test_adds_original_id(self, handler: TitleFallbackHandler) -> None:
+        """Should add _original_id field."""
+        record = {"pmid": "12345678", "article_title": "Test"}
+        result = handler._process_found_result(record, "10.1234/test")
+
+        assert result["_original_id"] == "10.1234/test"
+
+
+class TestSearchByTitle:
+    """Tests for _search_by_title method."""
+
+    @pytest.mark.asyncio
+    async def test_search_found_with_matching_title(
+        self, handler: TitleFallbackHandler, mock_search_fn: AsyncMock
+    ) -> None:
+        """Should return publication when title matches."""
+        mock_search_fn.return_value = [
+            {"pmid": "12345678", "article_title": "Test Publication Title"}
+        ]
+
+        result = await handler._search_by_title("Test Publication Title")
+
+        assert result is not None
+        assert result["pmid"] == "12345678"
+        mock_search_fn.assert_called_once_with("Test Publication Title", 3)
+
+    @pytest.mark.asyncio
+    async def test_search_found_with_case_insensitive_match(
+        self, handler: TitleFallbackHandler, mock_search_fn: AsyncMock
+    ) -> None:
+        """Should match titles case-insensitively."""
+        mock_search_fn.return_value = [
+            {"pmid": "12345678", "article_title": "TEST PUBLICATION TITLE"}
+        ]
+
+        result = await handler._search_by_title("test publication title")
+
+        assert result is not None
+        assert result["pmid"] == "12345678"
+
+    @pytest.mark.asyncio
+    async def test_search_found_with_substring_match(
+        self, handler: TitleFallbackHandler, mock_search_fn: AsyncMock
+    ) -> None:
+        """Should match when query is substring of found title."""
+        mock_search_fn.return_value = [
+            {
+                "pmid": "12345678",
+                "article_title": "Test Publication Title: Extended Subtitle",
+            }
+        ]
+
+        result = await handler._search_by_title("Test Publication Title")
+
+        assert result is not None
+        assert result["pmid"] == "12345678"
+
+    @pytest.mark.asyncio
+    async def test_search_empty_results(
+        self, handler: TitleFallbackHandler, mock_search_fn: AsyncMock
+    ) -> None:
+        """Should return None when no results."""
+        mock_search_fn.return_value = []
+
+        result = await handler._search_by_title("Nonexistent Title")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_search_returns_first_result_when_no_title_match(
+        self, handler: TitleFallbackHandler, mock_search_fn: AsyncMock
+    ) -> None:
+        """Should return first result when no title matches (API may vary format)."""
+        mock_search_fn.return_value = [
+            {"pmid": "12345678", "article_title": "Completely Different Title"}
+        ]
+
+        result = await handler._search_by_title("Test Publication Title")
+
+        # Returns first result even without match (PubMed title format may differ)
+        assert result is not None
+        assert result["pmid"] == "12345678"
+
+    @pytest.mark.asyncio
+    async def test_search_handles_exception(
+        self,
+        handler: TitleFallbackHandler,
+        mock_search_fn: AsyncMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        """Should return None and log on exception."""
+        mock_search_fn.side_effect = Exception("Network error")
+
+        result = await handler._search_by_title("Test Title")
+
+        assert result is None
+        mock_logger.debug.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_search_truncates_long_title(
+        self, handler: TitleFallbackHandler, mock_search_fn: AsyncMock
+    ) -> None:
+        """Should truncate titles longer than 200 chars."""
+        mock_search_fn.return_value = []
+        long_title = "A" * 300
+
+        await handler._search_by_title(long_title)
+
+        # Check that the title passed to search_fn is truncated
+        call_args = mock_search_fn.call_args[0]
+        assert len(call_args[0]) == 200
+
+
+class TestProcessMissingDois:
+    """Tests for process_missing_dois async generator (inherited from base)."""
+
+    @pytest.mark.asyncio
+    async def test_process_found_pmid_is_skipped(
+        self, handler: TitleFallbackHandler, mock_search_fn: AsyncMock
+    ) -> None:
+        """Should skip PMIDs that were already found."""
+        pmids = ["12345678"]
+        found_pmids = {"12345678"}  # Already found
+        fallback_mapping = {"12345678": "Test Title"}
+
+        results = []
+        async for pub in handler.process_missing_dois(
+            dois=pmids,
+            found_dois=found_pmids,
+            fallback_mapping=fallback_mapping,
+            normalize_fn=lambda x: x.lower().strip(),
+            limit=None,
+            fetched=0,
+        ):
+            results.append(pub)
+
+        assert len(results) == 0
+        mock_search_fn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_process_missing_pmid_with_fallback_success(
+        self,
+        handler: TitleFallbackHandler,
+        mock_search_fn: AsyncMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        """Should search by title and return publication when PMID not found."""
+        pmids = ["99999999"]
+        found_pmids: set[str] = set()
+        fallback_mapping = {"99999999": "Missing Publication Title"}
+        mock_search_fn.return_value = [
+            {"pmid": "12345678", "article_title": "Missing Publication Title"}
+        ]
+
+        results = []
+        async for pub in handler.process_missing_dois(
+            dois=pmids,
+            found_dois=found_pmids,
+            fallback_mapping=fallback_mapping,
+            normalize_fn=lambda x: x.lower().strip(),
+            limit=None,
+            fetched=0,
+        ):
+            results.append(pub)
+
+        assert len(results) == 1
+        assert results[0]["_lookup_method"] == "title_fallback"
+        assert results[0]["_original_id"] == "99999999"
+        mock_search_fn.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_process_missing_pmid_with_fallback_not_found(
+        self,
+        handler: TitleFallbackHandler,
+        mock_search_fn: AsyncMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        """Should log warning when title fallback doesn't find publication."""
+        pmids = ["99999999"]
+        found_pmids: set[str] = set()
+        fallback_mapping = {"99999999": "Not Found Title"}
+        mock_search_fn.return_value = []  # No publication found
+
+        results = []
+        async for pub in handler.process_missing_dois(
+            dois=pmids,
+            found_dois=found_pmids,
+            fallback_mapping=fallback_mapping,
+            normalize_fn=lambda x: x.lower().strip(),
+            limit=None,
+            fetched=0,
+        ):
+            results.append(pub)
+
+        assert len(results) == 0
+        mock_logger.warning.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_process_missing_pmid_without_title(
+        self,
+        handler: TitleFallbackHandler,
+        mock_search_fn: AsyncMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        """Should skip PMID when no title in fallback mapping."""
+        pmids = ["99999999"]
+        found_pmids: set[str] = set()
+        fallback_mapping = {}  # No title for PMID
+
+        results = []
+        async for pub in handler.process_missing_dois(
+            dois=pmids,
+            found_dois=found_pmids,
+            fallback_mapping=fallback_mapping,
+            normalize_fn=lambda x: x.lower().strip(),
+            limit=None,
+            fetched=0,
+        ):
+            results.append(pub)
+
+        assert len(results) == 0
+        mock_search_fn.assert_not_called()
+        mock_logger.debug.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_process_respects_limit(
+        self, handler: TitleFallbackHandler, mock_search_fn: AsyncMock
+    ) -> None:
+        """Should stop when limit is reached."""
+        pmids = ["11111111", "22222222", "33333333"]
+        found_pmids: set[str] = set()
+        fallback_mapping = {
+            "11111111": "Title 1",
+            "22222222": "Title 2",
+            "33333333": "Title 3",
+        }
+        mock_search_fn.return_value = [{"pmid": "12345678", "article_title": "Title 1"}]
+
+        results = []
+        async for pub in handler.process_missing_dois(
+            dois=pmids,
+            found_dois=found_pmids,
+            fallback_mapping=fallback_mapping,
+            normalize_fn=lambda x: x.lower().strip(),
+            limit=2,  # Only fetch 2
+            fetched=1,  # Already fetched 1
+        ):
+            results.append(pub)
+
+        # Should only get 1 more (limit=2, fetched=1, so 1 remaining)
+        assert len(results) == 1
+
+
+class TestProcessTitleOnlyEntries:
+    """Tests for process_title_only_entries async generator (inherited from base)."""
+
+    @pytest.mark.asyncio
+    async def test_process_title_only_success(
+        self,
+        handler: TitleFallbackHandler,
+        mock_search_fn: AsyncMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        """Should search by title for empty ID entries."""
+        entries = [""]  # Empty ID
+        fallback_mapping = {"": "Title-Only Publication"}
+        mock_search_fn.return_value = [
+            {"pmid": "12345678", "article_title": "Title-Only Publication"}
+        ]
+
+        results = []
+        async for pub in handler.process_title_only_entries(
+            entries=entries,
+            fallback_mapping=fallback_mapping,
+            limit=None,
+            fetched=0,
+        ):
+            results.append(pub)
+
+        assert len(results) == 1
+        assert results[0]["_lookup_method"] == "title_only"
+
+    @pytest.mark.asyncio
+    async def test_process_title_only_not_found(
+        self,
+        handler: TitleFallbackHandler,
+        mock_search_fn: AsyncMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        """Should log debug when title-only search fails."""
+        entries = [""]
+        fallback_mapping = {"": "Not Found Title"}
+        mock_search_fn.return_value = []
+
+        results = []
+        async for pub in handler.process_title_only_entries(
+            entries=entries,
+            fallback_mapping=fallback_mapping,
+            limit=None,
+            fetched=0,
+        ):
+            results.append(pub)
+
+        assert len(results) == 0
+        mock_logger.debug.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_process_title_only_no_mapping(
+        self, handler: TitleFallbackHandler, mock_search_fn: AsyncMock
+    ) -> None:
+        """Should skip when no title in mapping."""
+        entries = [""]
+        fallback_mapping = {}  # No title
+
+        results = []
+        async for pub in handler.process_title_only_entries(
+            entries=entries,
+            fallback_mapping=fallback_mapping,
+            limit=None,
+            fetched=0,
+        ):
+            results.append(pub)
+
+        assert len(results) == 0
+        mock_search_fn.assert_not_called()


### PR DESCRIPTION
…ution

Add TitleFallbackHandler to support title-based search when PMID lookup fails, following the same pattern as OpenAlex and CrossRef adapters.

Changes:
- Create fallback.py with TitleFallbackHandler extending BaseTitleFallbackHandler
- Add _search_by_title method to PubMedAdapter for esearch+efetch title queries
- Implement fetch_filtered_with_fallback with three-phase strategy:
  1. Primary PMID lookup
  2. Title fallback for unresolved IDs
  3. Title-only lookup for entries without IDs
- Replace FilterableStubMixin with NotSupportedMultiFilterMixin
- Add comprehensive unit tests for fallback handler