### PR TITLE
Extract CrossRef methods into separate module

### DIFF
--- a/src/bioetl/application/pipelines/crossref/__init__.py
+++ b/src/bioetl/application/pipelines/crossref/__init__.py
@@ -3,8 +3,24 @@
 Transformers and utilities for CrossRef data processing.
 """
 
+from bioetl.application.pipelines.crossref.extractors import (
+    extract_authors,
+    extract_dates,
+    extract_journal_info,
+    extract_license_url,
+    extract_page_info,
+    extract_year,
+)
 from bioetl.application.pipelines.crossref.transformer import (
     CrossRefPublicationTransformer,
 )
 
-__all__ = ["CrossRefPublicationTransformer"]
+__all__ = [
+    "CrossRefPublicationTransformer",
+    "extract_authors",
+    "extract_dates",
+    "extract_journal_info",
+    "extract_license_url",
+    "extract_page_info",
+    "extract_year",
+]

--- a/src/bioetl/application/pipelines/crossref/extractors.py
+++ b/src/bioetl/application/pipelines/crossref/extractors.py
@@ -1,0 +1,227 @@
+"""Field extraction functions for CrossRef records.
+
+Provides pure functions for extracting and normalizing fields from
+CrossRef Works API responses.
+
+These functions are:
+- Stateless and pure (no side effects)
+- Unit testable in isolation
+- Reusable across different transformation contexts
+
+Note: Uses domain normalization functions and Value Objects per REFACTOR-004.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from bioetl.domain.normalization import (
+    extract_first_string,
+    format_date_parts,
+    parse_page_range,
+)
+from bioetl.domain.value_objects import PublicationYear
+
+
+def extract_authors(publication: dict[str, Any]) -> list[str]:
+    """Extract author names in 'given family' format.
+
+    CrossRef stores author information in an "author" array with
+    "given" and "family" fields for each author.
+
+    Args:
+        publication: CrossRef publication record.
+
+    Returns:
+        List of author names in "given family" format.
+
+    Example:
+        >>> extract_authors({
+        ...     "author": [
+        ...         {"given": "John", "family": "Doe"},
+        ...         {"given": "Jane", "family": "Smith"},
+        ...     ]
+        ... })
+        ['John Doe', 'Jane Smith']
+        >>> extract_authors({"author": [{"family": "Anonymous"}]})
+        ['Anonymous']
+        >>> extract_authors({})
+        []
+
+    """
+    authors = []
+    for author in publication.get("author", []):
+        given = author.get("given", "").strip()
+        family = author.get("family", "").strip()
+        if given and family:
+            authors.append(f"{given} {family}")
+        elif family:
+            authors.append(family)
+        elif given:
+            authors.append(given)
+    return authors
+
+
+def extract_year(publication: dict[str, Any]) -> int | None:
+    """Extract publication year from date-parts.
+
+    Tries published-print, then published-online, then issued.
+    Validates using PublicationYear Value Object for consistent range checking.
+
+    Args:
+        publication: CrossRef publication record.
+
+    Returns:
+        Publication year if valid (1800-2100), None otherwise.
+
+    Example:
+        >>> extract_year({"published-print": {"date-parts": [[2023, 6, 15]]}})
+        2023
+        >>> extract_year({"issued": {"date-parts": [[2021]]}})
+        2021
+        >>> extract_year({})
+        None
+
+    """
+    for date_field in ["published-print", "published-online", "issued"]:
+        date_info = publication.get(date_field, {})
+        date_parts = date_info.get("date-parts", [[]])
+        if date_parts and date_parts[0] and len(date_parts[0]) > 0:
+            raw_year = date_parts[0][0]
+            if isinstance(raw_year, int):
+                year_vo = PublicationYear.from_raw(raw_year)
+                if year_vo:
+                    return year_vo.value
+    return None
+
+
+def extract_license_url(publication: dict[str, Any]) -> str | None:
+    """Extract first license URL from publication.
+
+    CrossRef may provide multiple licenses; this returns the first URL.
+
+    Args:
+        publication: CrossRef publication record.
+
+    Returns:
+        First license URL or None if not available.
+
+    Example:
+        >>> extract_license_url({
+        ...     "license": [{"URL": "https://creativecommons.org/licenses/by/4.0/"}]
+        ... })
+        'https://creativecommons.org/licenses/by/4.0/'
+        >>> extract_license_url({"license": []})
+        None
+        >>> extract_license_url({})
+        None
+
+    """
+    licenses = publication.get("license", [])
+    if licenses and len(licenses) > 0:
+        url: str | None = licenses[0].get("URL")
+        return url
+    return None
+
+
+def extract_journal_info(publication: dict[str, Any]) -> dict[str, Any]:
+    """Extract journal information from publication.
+
+    Extracts journal name (container-title), ISSN list, and publisher.
+
+    Args:
+        publication: CrossRef publication record.
+
+    Returns:
+        Dictionary with journal, issn, publisher fields.
+
+    Example:
+        >>> info = extract_journal_info({
+        ...     "container-title": ["Nature", "Nature Publishing Group"],
+        ...     "ISSN": ["0028-0836", "1476-4687"],
+        ...     "publisher": "Springer Nature"
+        ... })
+        >>> info["journal"]
+        'Nature'
+        >>> info["issn"]
+        ['0028-0836', '1476-4687']
+        >>> extract_journal_info({})
+        {'journal': None, 'issn': [], 'publisher': None}
+
+    """
+    return {
+        "journal": extract_first_string(publication.get("container-title")),
+        "issn": publication.get("ISSN", []),
+        "publisher": publication.get("publisher"),
+    }
+
+
+def extract_page_info(publication: dict[str, Any]) -> dict[str, Any]:
+    """Extract pagination information from publication.
+
+    Parses page range string (e.g., "123-145") into first_page and last_page.
+
+    Args:
+        publication: CrossRef publication record.
+
+    Returns:
+        Dictionary with volume, issue, first_page, last_page fields.
+
+    Example:
+        >>> extract_page_info({
+        ...     "volume": "42",
+        ...     "issue": "3",
+        ...     "page": "123-145"
+        ... })
+        {'volume': '42', 'issue': '3', 'first_page': '123', 'last_page': '145'}
+        >>> extract_page_info({"page": "42"})
+        {'volume': None, 'issue': None, 'first_page': '42', 'last_page': None}
+        >>> extract_page_info({})
+        {'volume': None, 'issue': None, 'first_page': None, 'last_page': None}
+
+    """
+    first_page, last_page = parse_page_range(publication.get("page"))
+    return {
+        "volume": publication.get("volume"),
+        "issue": publication.get("issue"),
+        "first_page": first_page,
+        "last_page": last_page,
+    }
+
+
+def extract_dates(publication: dict[str, Any]) -> dict[str, Any]:
+    """Extract publication dates from date-parts fields.
+
+    Formats date-parts [[year, month?, day?]] to ISO date strings.
+
+    Args:
+        publication: CrossRef publication record.
+
+    Returns:
+        Dictionary with published_print, published_online fields (ISO format).
+
+    Example:
+        >>> extract_dates({
+        ...     "published-print": {"date-parts": [[2023, 6, 15]]},
+        ...     "published-online": {"date-parts": [[2023, 5]]}
+        ... })
+        {'published_print': '2023-06-15', 'published_online': '2023-05'}
+        >>> extract_dates({})
+        {'published_print': None, 'published_online': None}
+
+    """
+    published_print = publication.get("published-print", {})
+    published_online = publication.get("published-online", {})
+
+    return {
+        "published_print": format_date_parts(
+            published_print.get("date-parts")
+            if isinstance(published_print, dict)
+            else None
+        ),
+        "published_online": format_date_parts(
+            published_online.get("date-parts")
+            if isinstance(published_online, dict)
+            else None
+        ),
+    }

--- a/src/bioetl/application/pipelines/crossref/transformer.py
+++ b/src/bioetl/application/pipelines/crossref/transformer.py
@@ -19,13 +19,18 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, cast
 
 from bioetl.application.pipelines.common import BasePublicationTransformer
-from bioetl.domain.entities.crossref import CROSSREF_TYPE_MAP, CrossRefPublicationEntity
-from bioetl.domain.normalization import (
-    extract_first_string,
-    parse_page_range,
+from bioetl.application.pipelines.crossref.extractors import (
+    extract_authors,
+    extract_dates,
+    extract_journal_info,
+    extract_license_url,
+    extract_page_info,
+    extract_year,
 )
+from bioetl.domain.entities.crossref import CROSSREF_TYPE_MAP, CrossRefPublicationEntity
+from bioetl.domain.normalization import extract_first_string
 from bioetl.domain.services import IdentityService
-from bioetl.domain.value_objects import DOI, PublicationYear
+from bioetl.domain.value_objects import DOI
 
 if TYPE_CHECKING:
     from bioetl.domain.context import PipelineContext
@@ -89,85 +94,11 @@ class CrossRefPublicationTransformer(BasePublicationTransformer):
             data_normalizer=data_normalizer,
         )
 
-    # ========================================================================
-    # Field Extraction Methods (Orchestration - delegates to domain)
-    # ========================================================================
-
-    @staticmethod
-    def _extract_authors(publication: dict[str, Any]) -> list[str]:
-        """Extract author names in 'given family' format.
-
-        This is CrossRef-specific extraction logic (not generic normalization).
-
-        Args:
-            publication: CrossRef publication record.
-
-        Returns:
-            List of author names.
-
-        """
-        authors = []
-        for author in publication.get("author", []):
-            given = author.get("given", "").strip()
-            family = author.get("family", "").strip()
-            if given and family:
-                authors.append(f"{given} {family}")
-            elif family:
-                authors.append(family)
-            elif given:
-                authors.append(given)
-        return authors
-
-    @staticmethod
-    def _extract_year(publication: dict[str, Any]) -> int | None:
-        """Extract publication year from date-parts.
-
-        Tries published-print, then published-online, then issued.
-        Validates using PublicationYear Value Object for consistent range checking.
-
-        Args:
-            publication: CrossRef publication record.
-
-        Returns:
-            Publication year or None.
-
-        """
-        for date_field in ["published-print", "published-online", "issued"]:
-            date_info = publication.get(date_field, {})
-            date_parts = date_info.get("date-parts", [[]])
-            if date_parts and date_parts[0] and len(date_parts[0]) > 0:
-                raw_year = date_parts[0][0]
-                if isinstance(raw_year, int):
-                    year_vo = PublicationYear.from_raw(raw_year)
-                    if year_vo:
-                        return year_vo.value
-        return None
-
-    @staticmethod
-    def _extract_license_url(publication: dict[str, Any]) -> str | None:
-        """Extract license URL from publication.
-
-        Args:
-            publication: CrossRef publication record.
-
-        Returns:
-            First license URL or None.
-
-        """
-        licenses = publication.get("license", [])
-        if licenses and len(licenses) > 0:
-            url: str | None = licenses[0].get("URL")
-            return url
-        return None
-
-    # ========================================================================
-    # Main Transformation
-    # ========================================================================
-
     def _extract_business_data(self, record: BronzeRecord) -> dict[str, Any]:
         """Extract Publication business data from bronze record.
 
-        Delegates normalization to DataNormalizationService per DI pattern.
+        Delegates field extraction to extractors module and normalization
+        to DataNormalizationService per DI pattern.
 
         Args:
             record: Raw Bronze record from CrossRef API.
@@ -184,21 +115,19 @@ class CrossRefPublicationTransformer(BasePublicationTransformer):
         doi_vo = DOI.from_raw(rec.get("DOI"))
         doi = str(doi_vo) if doi_vo else ""
 
-        # Use DataNormalizationService for other normalization tasks
-        normalizer = self._data_normalizer
-        first_page, last_page = parse_page_range(rec.get("page"))
-
-        # Extract date fields using normalizer service
-        published_print = rec.get("published-print", {})
-        published_online = rec.get("published-online", {})
+        # Use extractors for structured field extraction
+        journal_info = extract_journal_info(rec)
+        page_info = extract_page_info(rec)
+        dates = extract_dates(rec)
 
         # Extract abstract with HTML stripping via normalizer service
+        normalizer = self._data_normalizer
         abstract_raw = rec.get("abstract", "")
         abstract = normalizer.strip_html_tags(abstract_raw) if abstract_raw else None
 
         # Extract and hash PII fields (RULES.md §5.4)
         # Authors stored as JSON-serialized list for unified format across providers
-        raw_authors = self._extract_authors(rec)
+        raw_authors = extract_authors(rec)
         hashed_authors = self.hash_pii_list(raw_authors) or []
 
         return {
@@ -206,29 +135,15 @@ class CrossRefPublicationTransformer(BasePublicationTransformer):
             "title": extract_first_string(rec.get("title", [])),
             "abstract": abstract,
             "authors": self.serialize_json_list(hashed_authors),
-            "journal": extract_first_string(rec.get("container-title", [])),
-            "issn": rec.get("ISSN", []),
-            "publisher": rec.get("publisher"),
-            "volume": rec.get("volume"),
-            "issue": rec.get("issue"),
-            "first_page": first_page,
-            "last_page": last_page,
-            "year": self._extract_year(rec),
-            "published_print": normalizer.format_date_parts(
-                published_print.get("date-parts")
-                if isinstance(published_print, dict)
-                else None
-            ),
-            "published_online": normalizer.format_date_parts(
-                published_online.get("date-parts")
-                if isinstance(published_online, dict)
-                else None
-            ),
+            **journal_info,
+            **page_info,
+            **dates,
+            "year": extract_year(rec),
             "doc_type": CROSSREF_TYPE_MAP.get(rec.get("type", ""), "PUBLICATION"),
             "citation_count": rec.get("is-referenced-by-count"),
             "reference_count": rec.get("references-count"),
             "language": rec.get("language"),
-            "license_url": self._extract_license_url(rec),
+            "license_url": extract_license_url(rec),
             "subjects": rec.get("subject", []),
             "source": "crossref",
         }

--- a/tests/unit/application/pipelines/crossref/test_crossref_transformer.py
+++ b/tests/unit/application/pipelines/crossref/test_crossref_transformer.py
@@ -12,8 +12,11 @@ from uuid import uuid4
 
 import pytest
 
-from bioetl.application.pipelines.crossref.transformer import (
+from bioetl.application.pipelines.crossref import (
     CrossRefPublicationTransformer,
+    extract_authors,
+    extract_license_url,
+    extract_year,
 )
 from bioetl.domain.context import PipelineContext
 from bioetl.domain.entities.crossref import CROSSREF_TYPE_MAP
@@ -96,16 +99,16 @@ def test_extract_title(sample_publication):
     assert extract_first_string([]) is None
 
 
-def test_extract_authors(transformer, sample_publication):
+def test_extract_authors(sample_publication):
     """Test author extraction (CrossRef-specific logic)."""
-    authors = transformer._extract_authors(sample_publication)
+    authors = extract_authors(sample_publication)
     assert authors == ["John Doe", "Jane Smith", "Anonymous"]
 
 
-def test_extract_year(transformer, sample_publication):
+def test_extract_year(sample_publication):
     """Test year extraction (CrossRef-specific logic)."""
-    assert transformer._extract_year(sample_publication) == 2023
-    assert transformer._extract_year({}) is None
+    assert extract_year(sample_publication) == 2023
+    assert extract_year({}) is None
 
 
 def test_map_doc_type():
@@ -211,80 +214,80 @@ def test_entity_type_is_publication(transformer):
 # =============================================================================
 
 
-def test_extract_authors_with_only_given_name(transformer):
+def test_extract_authors_with_only_given_name():
     """Test author extraction with only given name (no family)."""
     publication = {"author": [{"given": "Madonna"}]}
-    authors = transformer._extract_authors(publication)
+    authors = extract_authors(publication)
     assert authors == ["Madonna"]
 
 
-def test_extract_authors_empty_list(transformer):
+def test_extract_authors_empty_list():
     """Test author extraction with empty author list."""
     publication = {"author": []}
-    authors = transformer._extract_authors(publication)
+    authors = extract_authors(publication)
     assert authors == []
 
 
-def test_extract_authors_missing_key(transformer):
+def test_extract_authors_missing_key():
     """Test author extraction when 'author' key is missing."""
     publication = {}
-    authors = transformer._extract_authors(publication)
+    authors = extract_authors(publication)
     assert authors == []
 
 
-def test_extract_authors_with_whitespace(transformer):
+def test_extract_authors_with_whitespace():
     """Test author extraction strips whitespace from names."""
     publication = {"author": [{"given": "  John  ", "family": "  Doe  "}]}
-    authors = transformer._extract_authors(publication)
+    authors = extract_authors(publication)
     assert authors == ["John Doe"]
 
 
-def test_extract_year_from_published_online(transformer):
+def test_extract_year_from_published_online():
     """Test year extraction falls back to published-online."""
     publication = {"published-online": {"date-parts": [[2022, 3, 15]]}}
-    assert transformer._extract_year(publication) == 2022
+    assert extract_year(publication) == 2022
 
 
-def test_extract_year_from_issued(transformer):
+def test_extract_year_from_issued():
     """Test year extraction falls back to issued field."""
     publication = {"issued": {"date-parts": [[2021, 1, 1]]}}
-    assert transformer._extract_year(publication) == 2021
+    assert extract_year(publication) == 2021
 
 
-def test_extract_year_priority_order(transformer):
+def test_extract_year_priority_order():
     """Test year extraction prefers published-print over others."""
     publication = {
         "published-print": {"date-parts": [[2023, 6, 1]]},
         "published-online": {"date-parts": [[2023, 5, 1]]},
         "issued": {"date-parts": [[2023, 4, 1]]},
     }
-    assert transformer._extract_year(publication) == 2023
+    assert extract_year(publication) == 2023
 
 
-def test_extract_year_invalid_year_format(transformer):
+def test_extract_year_invalid_year_format():
     """Test year extraction with invalid year format."""
     publication = {"published-print": {"date-parts": [[]]}}
-    assert transformer._extract_year(publication) is None
+    assert extract_year(publication) is None
 
 
-def test_extract_year_non_integer_year(transformer):
+def test_extract_year_non_integer_year():
     """Test year extraction with non-integer year."""
     publication = {"published-print": {"date-parts": [["2023"]]}}
-    assert transformer._extract_year(publication) is None
+    assert extract_year(publication) is None
 
 
-def test_extract_year_out_of_range(transformer):
+def test_extract_year_out_of_range():
     """Test year extraction with year out of valid range."""
     # Year 1799 is below min_year=1800 in validate_year_range
     publication = {"published-print": {"date-parts": [[1799]]}}
-    assert transformer._extract_year(publication) is None
+    assert extract_year(publication) is None
 
     # Year 2101 is above max_year=2100
     publication2 = {"published-print": {"date-parts": [[2101]]}}
-    assert transformer._extract_year(publication2) is None
+    assert extract_year(publication2) is None
 
 
-def test_extract_license_url_multiple_licenses(transformer):
+def test_extract_license_url_multiple_licenses():
     """Test license URL extraction returns first license."""
     publication = {
         "license": [
@@ -292,19 +295,19 @@ def test_extract_license_url_multiple_licenses(transformer):
             {"URL": "https://license2.com"},
         ]
     }
-    assert transformer._extract_license_url(publication) == "https://license1.com"
+    assert extract_license_url(publication) == "https://license1.com"
 
 
-def test_extract_license_url_missing_url(transformer):
+def test_extract_license_url_missing_url():
     """Test license URL extraction when URL is missing."""
     publication = {"license": [{"other": "data"}]}
-    assert transformer._extract_license_url(publication) is None
+    assert extract_license_url(publication) is None
 
 
-def test_extract_license_url_empty_list(transformer):
+def test_extract_license_url_empty_list():
     """Test license URL extraction with empty license list."""
     publication = {"license": []}
-    assert transformer._extract_license_url(publication) is None
+    assert extract_license_url(publication) is None
 
 
 def test_extract_business_data_page_range(transformer):

--- a/tests/unit/application/pipelines/crossref/test_extractors.py
+++ b/tests/unit/application/pipelines/crossref/test_extractors.py
@@ -1,0 +1,334 @@
+"""Unit tests for CrossRef field extractors.
+
+Tests the pure functions in extractors.py module.
+"""
+
+from __future__ import annotations
+
+from bioetl.application.pipelines.crossref.extractors import (
+    extract_authors,
+    extract_dates,
+    extract_journal_info,
+    extract_license_url,
+    extract_page_info,
+    extract_year,
+)
+
+
+class TestExtractAuthors:
+    """Tests for extract_authors function."""
+
+    def test_extract_authors_given_and_family(self) -> None:
+        """Should extract authors with both given and family names."""
+        publication = {
+            "author": [
+                {"given": "John", "family": "Doe"},
+                {"given": "Jane", "family": "Smith"},
+            ]
+        }
+        result = extract_authors(publication)
+        assert result == ["John Doe", "Jane Smith"]
+
+    def test_extract_authors_family_only(self) -> None:
+        """Should extract authors with only family name."""
+        publication = {"author": [{"family": "Anonymous"}]}
+        result = extract_authors(publication)
+        assert result == ["Anonymous"]
+
+    def test_extract_authors_given_only(self) -> None:
+        """Should extract authors with only given name (mononym)."""
+        publication = {"author": [{"given": "Madonna"}]}
+        result = extract_authors(publication)
+        assert result == ["Madonna"]
+
+    def test_extract_authors_empty_list(self) -> None:
+        """Should return empty list for empty author list."""
+        publication = {"author": []}
+        result = extract_authors(publication)
+        assert result == []
+
+    def test_extract_authors_missing_key(self) -> None:
+        """Should return empty list when author key is missing."""
+        publication = {}
+        result = extract_authors(publication)
+        assert result == []
+
+    def test_extract_authors_strips_whitespace(self) -> None:
+        """Should strip whitespace from author names."""
+        publication = {"author": [{"given": "  John  ", "family": "  Doe  "}]}
+        result = extract_authors(publication)
+        assert result == ["John Doe"]
+
+    def test_extract_authors_skips_empty_names(self) -> None:
+        """Should skip authors with empty given and family names."""
+        publication = {
+            "author": [
+                {"given": "", "family": ""},
+                {"given": "Valid", "family": "Author"},
+            ]
+        }
+        result = extract_authors(publication)
+        assert result == ["Valid Author"]
+
+    def test_extract_authors_mixed_formats(self) -> None:
+        """Should handle mixed author formats in same list."""
+        publication = {
+            "author": [
+                {"given": "First", "family": "Last"},
+                {"family": "OnlyFamily"},
+                {"given": "OnlyGiven"},
+            ]
+        }
+        result = extract_authors(publication)
+        assert result == ["First Last", "OnlyFamily", "OnlyGiven"]
+
+
+class TestExtractYear:
+    """Tests for extract_year function."""
+
+    def test_extract_year_from_published_print(self) -> None:
+        """Should extract year from published-print field."""
+        publication = {"published-print": {"date-parts": [[2023, 6, 15]]}}
+        result = extract_year(publication)
+        assert result == 2023
+
+    def test_extract_year_from_published_online(self) -> None:
+        """Should fall back to published-online field."""
+        publication = {"published-online": {"date-parts": [[2022, 3, 1]]}}
+        result = extract_year(publication)
+        assert result == 2022
+
+    def test_extract_year_from_issued(self) -> None:
+        """Should fall back to issued field."""
+        publication = {"issued": {"date-parts": [[2021, 1, 1]]}}
+        result = extract_year(publication)
+        assert result == 2021
+
+    def test_extract_year_priority_order(self) -> None:
+        """Should prefer published-print over other date fields."""
+        publication = {
+            "published-print": {"date-parts": [[2023, 6, 1]]},
+            "published-online": {"date-parts": [[2023, 5, 1]]},
+            "issued": {"date-parts": [[2023, 4, 1]]},
+        }
+        result = extract_year(publication)
+        assert result == 2023
+
+    def test_extract_year_year_only(self) -> None:
+        """Should extract year from date-parts with only year."""
+        publication = {"published-print": {"date-parts": [[2020]]}}
+        result = extract_year(publication)
+        assert result == 2020
+
+    def test_extract_year_empty_dict(self) -> None:
+        """Should return None for empty publication dict."""
+        result = extract_year({})
+        assert result is None
+
+    def test_extract_year_empty_date_parts(self) -> None:
+        """Should return None for empty date-parts."""
+        publication = {"published-print": {"date-parts": [[]]}}
+        result = extract_year(publication)
+        assert result is None
+
+    def test_extract_year_non_integer(self) -> None:
+        """Should return None for non-integer year."""
+        publication = {"published-print": {"date-parts": [["2023"]]}}
+        result = extract_year(publication)
+        assert result is None
+
+    def test_extract_year_out_of_range_low(self) -> None:
+        """Should return None for year below valid range (1800)."""
+        publication = {"published-print": {"date-parts": [[1799]]}}
+        result = extract_year(publication)
+        assert result is None
+
+    def test_extract_year_out_of_range_high(self) -> None:
+        """Should return None for year above valid range (2100)."""
+        publication = {"published-print": {"date-parts": [[2101]]}}
+        result = extract_year(publication)
+        assert result is None
+
+    def test_extract_year_valid_boundary_low(self) -> None:
+        """Should accept year at lower boundary (1800)."""
+        publication = {"published-print": {"date-parts": [[1800]]}}
+        result = extract_year(publication)
+        assert result == 1800
+
+    def test_extract_year_valid_boundary_high(self) -> None:
+        """Should accept year at upper boundary (2100)."""
+        publication = {"published-print": {"date-parts": [[2100]]}}
+        result = extract_year(publication)
+        assert result == 2100
+
+
+class TestExtractLicenseUrl:
+    """Tests for extract_license_url function."""
+
+    def test_extract_license_url_single(self) -> None:
+        """Should extract license URL from single license."""
+        publication = {
+            "license": [{"URL": "https://creativecommons.org/licenses/by/4.0/"}]
+        }
+        result = extract_license_url(publication)
+        assert result == "https://creativecommons.org/licenses/by/4.0/"
+
+    def test_extract_license_url_multiple(self) -> None:
+        """Should return first license URL when multiple present."""
+        publication = {
+            "license": [
+                {"URL": "https://license1.com"},
+                {"URL": "https://license2.com"},
+            ]
+        }
+        result = extract_license_url(publication)
+        assert result == "https://license1.com"
+
+    def test_extract_license_url_empty_list(self) -> None:
+        """Should return None for empty license list."""
+        publication = {"license": []}
+        result = extract_license_url(publication)
+        assert result is None
+
+    def test_extract_license_url_missing_key(self) -> None:
+        """Should return None when license key is missing."""
+        publication = {}
+        result = extract_license_url(publication)
+        assert result is None
+
+    def test_extract_license_url_missing_url_field(self) -> None:
+        """Should return None when URL field is missing."""
+        publication = {"license": [{"other": "data"}]}
+        result = extract_license_url(publication)
+        assert result is None
+
+
+class TestExtractJournalInfo:
+    """Tests for extract_journal_info function."""
+
+    def test_extract_journal_info_complete(self) -> None:
+        """Should extract all journal fields."""
+        publication = {
+            "container-title": ["Nature", "Nature Publishing Group"],
+            "ISSN": ["0028-0836", "1476-4687"],
+            "publisher": "Springer Nature",
+        }
+        result = extract_journal_info(publication)
+        assert result == {
+            "journal": "Nature",
+            "issn": ["0028-0836", "1476-4687"],
+            "publisher": "Springer Nature",
+        }
+
+    def test_extract_journal_info_partial(self) -> None:
+        """Should handle missing fields gracefully."""
+        publication = {"container-title": ["Nature"]}
+        result = extract_journal_info(publication)
+        assert result["journal"] == "Nature"
+        assert result["issn"] == []
+        assert result["publisher"] is None
+
+    def test_extract_journal_info_empty(self) -> None:
+        """Should return defaults for empty publication."""
+        result = extract_journal_info({})
+        assert result == {"journal": None, "issn": [], "publisher": None}
+
+    def test_extract_journal_info_empty_container_title(self) -> None:
+        """Should return None for empty container-title list."""
+        publication = {"container-title": []}
+        result = extract_journal_info(publication)
+        assert result["journal"] is None
+
+
+class TestExtractPageInfo:
+    """Tests for extract_page_info function."""
+
+    def test_extract_page_info_complete(self) -> None:
+        """Should extract all page fields."""
+        publication = {"volume": "42", "issue": "3", "page": "123-145"}
+        result = extract_page_info(publication)
+        assert result == {
+            "volume": "42",
+            "issue": "3",
+            "first_page": "123",
+            "last_page": "145",
+        }
+
+    def test_extract_page_info_single_page(self) -> None:
+        """Should handle single page number."""
+        publication = {"page": "42"}
+        result = extract_page_info(publication)
+        assert result["first_page"] == "42"
+        assert result["last_page"] is None
+
+    def test_extract_page_info_missing_fields(self) -> None:
+        """Should return None for missing fields."""
+        result = extract_page_info({})
+        assert result == {
+            "volume": None,
+            "issue": None,
+            "first_page": None,
+            "last_page": None,
+        }
+
+    def test_extract_page_info_partial(self) -> None:
+        """Should handle partial page info."""
+        publication = {"volume": "10", "page": "1-50"}
+        result = extract_page_info(publication)
+        assert result["volume"] == "10"
+        assert result["issue"] is None
+        assert result["first_page"] == "1"
+        assert result["last_page"] == "50"
+
+    def test_extract_page_info_article_number(self) -> None:
+        """Should handle article numbers (e-pages)."""
+        publication = {"page": "e12345"}
+        result = extract_page_info(publication)
+        assert result["first_page"] == "e12345"
+        assert result["last_page"] is None
+
+
+class TestExtractDates:
+    """Tests for extract_dates function."""
+
+    def test_extract_dates_complete(self) -> None:
+        """Should extract both date fields."""
+        publication = {
+            "published-print": {"date-parts": [[2023, 6, 15]]},
+            "published-online": {"date-parts": [[2023, 5, 1]]},
+        }
+        result = extract_dates(publication)
+        assert result == {
+            "published_print": "2023-06-15",
+            "published_online": "2023-05-01",
+        }
+
+    def test_extract_dates_partial_date(self) -> None:
+        """Should handle partial dates (year-month only)."""
+        publication = {
+            "published-print": {"date-parts": [[2023, 6]]},
+            "published-online": {"date-parts": [[2023]]},
+        }
+        result = extract_dates(publication)
+        assert result["published_print"] == "2023-06"
+        assert result["published_online"] == "2023"
+
+    def test_extract_dates_empty(self) -> None:
+        """Should return None for empty publication."""
+        result = extract_dates({})
+        assert result == {"published_print": None, "published_online": None}
+
+    def test_extract_dates_missing_date_parts(self) -> None:
+        """Should handle missing date-parts."""
+        publication = {"published-print": {}, "published-online": {}}
+        result = extract_dates(publication)
+        assert result == {"published_print": None, "published_online": None}
+
+    def test_extract_dates_invalid_format(self) -> None:
+        """Should handle non-dict date fields gracefully."""
+        publication = {
+            "published-print": "invalid",
+            "published-online": ["also invalid"],
+        }
+        result = extract_dates(publication)
+        assert result == {"published_print": None, "published_online": None}


### PR DESCRIPTION
- Create extractors.py with pure extraction functions:
  - extract_authors: parse author names in 'given family' format
  - extract_year: extract year with PublicationYear VO validation
  - extract_license_url: get first license URL
  - extract_journal_info: extract journal, ISSN, publisher
  - extract_page_info: extract volume, issue, first/last page
  - extract_dates: extract published_print/online dates

- Update transformer.py to use extractors module
- Export extractors from __init__.py
- Add 39 unit tests for extractors
- Update existing transformer tests to use module functions

Follows patterns from OpenAlex/SemanticScholar extractors.