### PR TITLE
Add transform version to metadata lineage

### DIFF
--- a/src/bioetl/composition/factories/storage_factory.py
+++ b/src/bioetl/composition/factories/storage_factory.py
@@ -96,6 +96,8 @@ class StorageFactory:
         metrics: MetricsPort,
         tracing: TracingPort | None,
         metadata_coordinator: MetadataCoordinator | None = None,
+        transform_version: str | None = None,
+        transform_steps: tuple[str, ...] | None = None,
     ) -> StorageAdapter:
         """Create StorageAdapter with all writers configured.
 
@@ -143,6 +145,8 @@ class StorageFactory:
                 csv_exporter=silver_csv_exporter,
                 metadata_writer=silver_metadata_writer,
                 metadata_coordinator=metadata_coordinator,
+                transform_version=transform_version,
+                transform_steps=transform_steps,
             ),
             gold_writer=GoldWriter(
                 base_path=gold_path,
@@ -151,6 +155,8 @@ class StorageFactory:
                 csv_exporter=gold_csv_exporter,
                 metadata_writer=gold_metadata_writer,
                 metadata_coordinator=metadata_coordinator,
+                transform_version=transform_version,
+                transform_steps=transform_steps,
             ),
         )
 
@@ -226,6 +232,10 @@ class StorageFactory:
             gold_save_metadata,
         )
 
+        # Extract transform info for lineage tracking
+        transform_version = config.transform.version
+        transform_steps = tuple(config.transform.steps)
+
         adapter = StorageFactory._create_storage_adapter(
             bronze_path=bronze_path,
             silver_path=silver_path,
@@ -239,6 +249,8 @@ class StorageFactory:
             metrics=metrics,
             tracing=tracing,
             metadata_coordinator=metadata_coordinator,
+            transform_version=transform_version,
+            transform_steps=transform_steps,
         )
 
         return StorageContext(

--- a/src/bioetl/composition/services/metadata_coordinator.py
+++ b/src/bioetl/composition/services/metadata_coordinator.py
@@ -230,9 +230,23 @@ class MetadataCoordinator:
         if input_data.bronze_refs:
             bronze_paths = [ref.relative_path for ref in input_data.bronze_refs]
 
+        # Get transform info: prioritize input_data, fallback to RunContext
+        transform_version = (
+            input_data.transform_version
+            if input_data.transform_version is not None
+            else self._context.transform_version
+        )
+        transform_steps = list(
+            input_data.transform_steps
+            if input_data.transform_steps is not None
+            else self._context.transform_steps
+        )
+
         lineage = LineageMetadata(
             source_batch_ids=source_batch_ids,
             bronze_paths=bronze_paths,
+            transform_version=transform_version,
+            transform_steps=transform_steps,
         )
 
         # Map SilverWriteMode to DeltaMetrics operation
@@ -294,7 +308,23 @@ class MetadataCoordinator:
                 ref.table_name: ref.delta_version for ref in input_data.silver_refs
             }
 
-        lineage = LineageMetadata(source_tables=source_tables)
+        # Get transform info: prioritize input_data, fallback to RunContext
+        transform_version = (
+            input_data.transform_version
+            if input_data.transform_version is not None
+            else self._context.transform_version
+        )
+        transform_steps = list(
+            input_data.transform_steps
+            if input_data.transform_steps is not None
+            else self._context.transform_steps
+        )
+
+        lineage = LineageMetadata(
+            source_tables=source_tables,
+            transform_version=transform_version,
+            transform_steps=transform_steps,
+        )
 
         # Build DQ summary (basic metrics)
         dq_summary = DQSummary(

--- a/src/bioetl/domain/config.py
+++ b/src/bioetl/domain/config.py
@@ -398,6 +398,10 @@ class PipelineConfig:
     # Data Quality
     dq: DQConfig = field(default_factory=DQConfig)
 
+    # Transform versioning (lineage tracking)
+    transform_version: str | None = None
+    transform_steps: tuple[str, ...] = ()
+
     def __post_init__(self) -> None:
         """Convert lists to tuples and validate configuration on creation."""
         self._ensure_immutability()
@@ -412,6 +416,8 @@ class PipelineConfig:
             object.__setattr__(self, "partition_cols", tuple(self.partition_cols))
         if isinstance(self.fields, list):
             object.__setattr__(self, "fields", tuple(self.fields))
+        if isinstance(self.transform_steps, list):
+            object.__setattr__(self, "transform_steps", tuple(self.transform_steps))
 
     def _convert_write_modes(self) -> None:
         """Convert string write modes to enums (backward compatibility)."""

--- a/src/bioetl/domain/ports/metadata_coordinator.py
+++ b/src/bioetl/domain/ports/metadata_coordinator.py
@@ -58,6 +58,8 @@ class SilverMetadataInput:
         bronze_refs: Optional list of BronzeWriteResult for lineage.
         dq_metrics: Optional BatchDQMetrics for DQ summary.
         version_after: Delta table version after write.
+        transform_version: Optional semver version of transform applied.
+        transform_steps: Optional list of transform step names applied.
     """
 
     table_path: str
@@ -67,6 +69,8 @@ class SilverMetadataInput:
     bronze_refs: Any | None = None  # list[BronzeWriteResult] | None
     dq_metrics: Any | None = None  # BatchDQMetrics | None
     version_after: int | None = None
+    transform_version: str | None = None
+    transform_steps: tuple[str, ...] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -99,6 +103,8 @@ class GoldMetadataInput:
         scd_config: SCD2 configuration if applicable.
         completed_at: UTC timestamp when write completed.
         silver_refs: List of Silver source references for lineage tracking.
+        transform_version: Optional semver version of transform applied.
+        transform_steps: Optional list of transform step names applied.
     """
 
     table_path: str
@@ -108,6 +114,8 @@ class GoldMetadataInput:
     scd_config: dict[str, Any] | None = None
     completed_at: datetime | None = None
     silver_refs: list[SilverRef] | None = None
+    transform_version: str | None = None
+    transform_steps: tuple[str, ...] | None = None
 
 
 @runtime_checkable

--- a/src/bioetl/domain/value_objects/run_context.py
+++ b/src/bioetl/domain/value_objects/run_context.py
@@ -30,6 +30,8 @@ class RunContext:
         pipeline_name: Full pipeline name (e.g., 'chembl_activity').
         provider: Data provider name (e.g., 'chembl').
         entity: Entity type (e.g., 'activity').
+        transform_version: Optional semver version of transform (e.g., '1.0.0').
+        transform_steps: Tuple of transform step names applied.
 
     Example:
         >>> from datetime import UTC, datetime
@@ -41,6 +43,8 @@ class RunContext:
         ...     pipeline_name="chembl_activity",
         ...     provider="chembl",
         ...     entity="activity",
+        ...     transform_version="1.0.0",
+        ...     transform_steps=("normalize_values", "add_metadata"),
         ... )
     """
 
@@ -50,6 +54,8 @@ class RunContext:
     pipeline_name: str
     provider: str
     entity: str
+    transform_version: str | None = None
+    transform_steps: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         """Validate run context after initialization."""
@@ -76,6 +82,8 @@ class RunContext:
         started_at: datetime,
         provider: str,
         entity: str,
+        transform_version: str | None = None,
+        transform_steps: tuple[str, ...] | None = None,
     ) -> RunContext:
         """Factory method to create RunContext with derived pipeline_name.
 
@@ -85,6 +93,8 @@ class RunContext:
             started_at: UTC timestamp when run started.
             provider: Data provider name.
             entity: Entity type.
+            transform_version: Optional semver version of transform.
+            transform_steps: Optional tuple of transform step names.
 
         Returns:
             RunContext with pipeline_name derived as '{provider}_{entity}'.
@@ -96,4 +106,6 @@ class RunContext:
             pipeline_name=f"{provider}_{entity}",
             provider=provider,
             entity=entity,
+            transform_version=transform_version,
+            transform_steps=transform_steps or (),
         )

--- a/src/bioetl/infrastructure/config.py
+++ b/src/bioetl/infrastructure/config.py
@@ -152,6 +152,10 @@ def yaml_config_to_domain(yaml_config: PipelineYamlConfig) -> PipelineConfig:
     # Use to_domain() method for DQConfig conversion (consolidation pattern)
     dq_config = yaml_config.dq_rules.to_domain()
 
+    # Extract transform info for lineage tracking
+    transform_version = yaml_config.transform.version
+    transform_steps = tuple(yaml_config.transform.steps)
+
     return PipelineConfig(
         pipeline_name=yaml_config.pipeline_name,
         provider=yaml_config.provider,
@@ -167,6 +171,8 @@ def yaml_config_to_domain(yaml_config: PipelineYamlConfig) -> PipelineConfig:
         fields=tuple(source_fields),
         dq=dq_config,
         on_schema_mismatch=on_schema_mismatch,
+        transform_version=transform_version,
+        transform_steps=transform_steps,
     )
 
 

--- a/src/bioetl/infrastructure/schemas/pipeline_config.py
+++ b/src/bioetl/infrastructure/schemas/pipeline_config.py
@@ -11,6 +11,7 @@ boundary between infrastructure (YAML parsing) and domain (business logic).
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Literal
 
 from pydantic import (
@@ -610,6 +611,59 @@ class GoldFiltersConfig(BaseModel):
         )
 
 
+# Regex for semver validation (allows optional 'v' prefix)
+# Matches: 1.0.0, v1.0.0, 1.2.3-beta, 1.2.3+build, etc.
+SEMVER_PATTERN = re.compile(
+    r"^v?"  # Optional 'v' prefix
+    r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"  # Major.Minor.Patch
+    r"(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"  # Pre-release
+    r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+    r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"  # Build metadata
+)
+
+
+class TransformConfig(BaseModel):
+    """Configuration for transform versioning and steps.
+
+    Tracks the version and steps of the transformation applied to data,
+    enabling full lineage tracking in Silver/Gold metadata.
+
+    Attributes:
+        version: Semver-formatted version string (e.g., "1.0.0", "v2.1.0").
+        steps: List of transformation step names applied in order.
+
+    Example YAML:
+        transform:
+          version: "1.0.0"
+          steps:
+            - normalize_values
+            - add_metadata
+            - calculate_content_hash
+    """
+
+    version: str | None = Field(
+        default=None,
+        description="Transform version in semver format (e.g., '1.0.0')",
+    )
+    steps: list[str] = Field(
+        default_factory=list,
+        description="List of transformation steps applied",
+    )
+
+    @field_validator("version")
+    @classmethod
+    def validate_semver(cls, v: str | None) -> str | None:
+        """Validate that version follows semver format."""
+        if v is None:
+            return v
+        if not SEMVER_PATTERN.match(v):
+            raise ValueError(
+                f"Invalid semver format '{v}'. "
+                "Expected format: MAJOR.MINOR.PATCH (e.g., '1.0.0', 'v2.1.0')"
+            )
+        return v
+
+
 class PipelineYamlConfig(BaseModel):
     """Strict schema for pipeline YAML configuration.
 
@@ -646,6 +700,7 @@ class PipelineYamlConfig(BaseModel):
     source: SourceConfig = Field(default_factory=SourceConfig)
     input_filter: InputFilterConfig = Field(default_factory=InputFilterConfig)
     maintenance: MaintenanceConfig = Field(default_factory=MaintenanceConfig)
+    transform: TransformConfig = Field(default_factory=TransformConfig)
 
     @field_validator("batch_size")
     @classmethod

--- a/src/bioetl/infrastructure/storage/gold_writer.py
+++ b/src/bioetl/infrastructure/storage/gold_writer.py
@@ -74,6 +74,8 @@ class GoldWriter(BaseDeltaWriter):
         audit: AuditPort | None = None,
         metadata_writer: MetadataWriterPort | None = None,
         metadata_coordinator: MetadataCoordinatorPort | None = None,
+        transform_version: str | None = None,
+        transform_steps: tuple[str, ...] | None = None,
     ) -> None:
         """Initialize Gold writer.
 
@@ -92,6 +94,9 @@ class GoldWriter(BaseDeltaWriter):
                                 metadata creation. If provided, uses coordinator
                                 instead of local _write_gold_metadata() logic.
                                 Ensures consistent run_id across layers.
+            transform_version: Optional semver version of transform (e.g., '1.0.0')
+                             for lineage tracking in metadata.
+            transform_steps: Optional tuple of transform step names for lineage.
 
         Note:
             LoggerPort is required per RULES.md DI requirements.
@@ -121,6 +126,10 @@ class GoldWriter(BaseDeltaWriter):
         self._metadata_coordinator: MetadataCoordinatorPort | None = (
             metadata_coordinator
         )
+
+        # Transform version tracking for lineage metadata
+        self._transform_version = transform_version
+        self._transform_steps = transform_steps or ()
 
     async def write_gold(
         self,
@@ -484,6 +493,8 @@ class GoldWriter(BaseDeltaWriter):
                 scd_config=scd_config,
                 completed_at=ingestion_ts,
                 silver_refs=converted_refs,
+                transform_version=self._transform_version,
+                transform_steps=self._transform_steps,
             )
             metadata = self._metadata_coordinator.create_gold_metadata(gold_input)
             await self._metadata_writer.write_gold_metadata(table_path, metadata)

--- a/src/bioetl/infrastructure/storage/silver_writer.py
+++ b/src/bioetl/infrastructure/storage/silver_writer.py
@@ -95,6 +95,8 @@ class SilverWriter(BaseDeltaWriter):
         silver_validator: SilverValidatorPort | None = None,
         metadata_writer: MetadataWriterPort | None = None,
         metadata_coordinator: MetadataCoordinatorPort | None = None,
+        transform_version: str | None = None,
+        transform_steps: tuple[str, ...] | None = None,
     ) -> None:
         """Initialize Silver writer.
 
@@ -118,6 +120,9 @@ class SilverWriter(BaseDeltaWriter):
                                 metadata creation. If provided, uses coordinator
                                 instead of local _write_silver_metadata() logic.
                                 Ensures consistent run_id across layers.
+            transform_version: Optional semver version of transform (e.g., '1.0.0')
+                             for lineage tracking in metadata.
+            transform_steps: Optional tuple of transform step names for lineage.
 
         Note:
             LoggerPort is required per RULES.md DI requirements.
@@ -157,6 +162,10 @@ class SilverWriter(BaseDeltaWriter):
         self._metadata_coordinator: MetadataCoordinatorPort | None = (
             metadata_coordinator
         )
+
+        # Transform version tracking for lineage metadata
+        self._transform_version = transform_version
+        self._transform_steps = transform_steps or ()
 
     def _prepare_arrow_data(
         self,
@@ -786,6 +795,8 @@ class SilverWriter(BaseDeltaWriter):
                 bronze_refs=bronze_refs,
                 dq_metrics=dq_metrics,
                 version_after=version_after,
+                transform_version=self._transform_version,
+                transform_steps=self._transform_steps,
             )
             metadata = self._metadata_coordinator.create_silver_metadata(silver_input)
             await self._metadata_writer.write_silver_metadata(table_path, metadata)

--- a/tests/architecture/test_code_metrics.py
+++ b/tests/architecture/test_code_metrics.py
@@ -83,14 +83,14 @@ class TestFileSizeLimits:
         "pipeline_factories.py": 520,  # 505 LOC - pipeline factory configurations (OpenAlex + SemanticScholar + IDMapping)
         "services_factory.py": 630,  # 623 LOC - merged base_services + services_builder + runner_services + LockContextHolder + BatchExecutor factory
         # Infrastructure layer exemptions
-        "silver_writer.py": 1120,  # 1115 LOC - schema drift + merge logic + MetadataCoordinator fallback + SilverWriteResult return
-        "gold_writer.py": 915,  # 907 LOC - SCD Type 2 + MetadataCoordinator fallback + silver_refs lineage
+        "silver_writer.py": 1130,  # 1126 LOC - schema drift + merge logic + MetadataCoordinator fallback + SilverWriteResult return + transform lineage
+        "gold_writer.py": 920,  # 918 LOC - SCD Type 2 + MetadataCoordinator fallback + silver_refs lineage + transform lineage
         "bronze_writer.py": 755,  # 750 LOC - streaming compression + MetadataCoordinator fallback + SourceMetadata param
         "gold.py": 920,  # 915 LOC - Gold layer Pandera schemas (+ IDMapping + taxonomy_id standardization + Config docstrings)
         "silver.py": 780,  # 775 LOC - Silver PyArrow schemas (+ IDMapping + taxonomy_id standardization)
         "client.py": 700,  # 692 LOC - ChemblAdapter (complex FilterableDataSourcePort), CrossRefAdapter (DOI→title fallback)
         "adapter.py": 635,  # 632 LOC - SemanticScholarAdapter with FilterableDataSourcePort + fallback logic
-        "pipeline_config.py": 730,  # 716 LOC - Pipeline configuration loading and validation
+        "pipeline_config.py": 775,  # 771 LOC - Pipeline configuration loading and validation + TransformConfig
         # Interfaces layer exemptions
         "cli.py": 550,  # 536 LOC - CLI commands, options, vacuum-all
         # New exemptions for split storage factory
@@ -647,6 +647,8 @@ class TestGodObjectDetection:
         "FileAuditAdapter": "Cohesive adapter - all methods relate to audit file operations (read/write JSONL)",
         # Composite pipeline services (ADR-026)
         "MergeService": "Cohesive service - all methods relate to merge operations and conflict resolution",
+        # Metadata coordination service
+        "MetadataCoordinator": "Cohesive service - all methods relate to metadata creation for Medallion layers",
         "EnrichmentCoordinator": "Cohesive service - all methods relate to enricher orchestration",
         "CompositePipelineRunner": "Thin orchestrator - delegates to coordinator, merger, checkpoint services",
         # DQ analyzers (cohesive data quality analysis with many validation methods)

--- a/tests/snapshots/pipeline_configs.json
+++ b/tests/snapshots/pipeline_configs.json
@@ -243,6 +243,8 @@
     ],
     "provider": "chembl",
     "silver_table": "chembl_activity",
+    "transform_steps": [],
+    "transform_version": null,
     "write_mode": "merge"
   },
   "chembl_document": {
@@ -508,6 +510,8 @@
     ],
     "provider": "pubchem",
     "silver_table": "pubchem_compound",
+    "transform_steps": [],
+    "transform_version": null,
     "write_mode": "merge"
   },
   "pubmed_publications": {
@@ -655,6 +659,8 @@
     ],
     "provider": "pubmed",
     "silver_table": "pubmed_publication",
+    "transform_steps": [],
+    "transform_version": null,
     "write_mode": "merge"
   },
   "uniprot_protein": {
@@ -787,6 +793,8 @@
     ],
     "provider": "uniprot",
     "silver_table": "uniprot_protein",
+    "transform_steps": [],
+    "transform_version": null,
     "write_mode": "merge"
   }
 }

--- a/tests/unit/application/services/test_metadata_coordinator.py
+++ b/tests/unit/application/services/test_metadata_coordinator.py
@@ -527,6 +527,175 @@ class TestGoldMetadata:
         }
 
 
+class TestTransformVersionTracking:
+    """Tests for transform version and steps tracking in metadata."""
+
+    def test_silver_lineage_includes_transform_version_from_input(
+        self, coordinator: MetadataCoordinator
+    ) -> None:
+        """Test Silver lineage includes transform_version from SilverMetadataInput."""
+        records = [{"id": 1}]
+
+        input_data = SilverMetadataInput(
+            table_path="/data/silver/chembl/activity",
+            records=records,
+            primary_keys=["id"],
+            mode=SilverWriteMode.MERGE,
+            transform_version="1.0.0",
+            transform_steps=("normalize_values", "add_metadata"),
+        )
+
+        metadata = coordinator.create_silver_metadata(input_data)
+
+        assert metadata.lineage.transform_version == "1.0.0"
+        assert metadata.lineage.transform_steps == ["normalize_values", "add_metadata"]
+
+    def test_gold_lineage_includes_transform_version_from_input(
+        self, coordinator: MetadataCoordinator
+    ) -> None:
+        """Test Gold lineage includes transform_version from GoldMetadataInput."""
+        records = [{"id": 1}]
+
+        input_data = GoldMetadataInput(
+            table_path="/data/gold/chembl/activity",
+            table_name="chembl.activity",
+            records=records,
+            mode=GoldWriteMode.OVERWRITE,
+            transform_version="2.1.0",
+            transform_steps=("flatten_json", "validate_schema"),
+        )
+
+        metadata = coordinator.create_gold_metadata(input_data)
+
+        assert metadata.lineage.transform_version == "2.1.0"
+        assert metadata.lineage.transform_steps == ["flatten_json", "validate_schema"]
+
+    def test_silver_uses_run_context_transform_when_input_none(self) -> None:
+        """Test Silver falls back to RunContext transform info when input is None."""
+        MetadataCoordinator.reset_environment_cache()
+
+        context = RunContext.create(
+            run_id=RunID(uuid4()),
+            run_type=RunType.INCREMENTAL,
+            started_at=datetime.now(UTC),
+            provider="chembl",
+            entity="activity",
+            transform_version="3.0.0",
+            transform_steps=("step1", "step2", "step3"),
+        )
+        coord = MetadataCoordinator(context)
+
+        records = [{"id": 1}]
+        input_data = SilverMetadataInput(
+            table_path="/data/silver/chembl/activity",
+            records=records,
+            primary_keys=["id"],
+            mode=SilverWriteMode.MERGE,
+            # transform_version and transform_steps are None
+        )
+
+        metadata = coord.create_silver_metadata(input_data)
+
+        # Should fall back to RunContext values
+        assert metadata.lineage.transform_version == "3.0.0"
+        assert metadata.lineage.transform_steps == ["step1", "step2", "step3"]
+
+    def test_gold_uses_run_context_transform_when_input_none(self) -> None:
+        """Test Gold falls back to RunContext transform info when input is None."""
+        MetadataCoordinator.reset_environment_cache()
+
+        context = RunContext.create(
+            run_id=RunID(uuid4()),
+            run_type=RunType.INCREMENTAL,
+            started_at=datetime.now(UTC),
+            provider="chembl",
+            entity="activity",
+            transform_version="4.0.0",
+            transform_steps=("transform_step_a", "transform_step_b"),
+        )
+        coord = MetadataCoordinator(context)
+
+        records = [{"id": 1}]
+        input_data = GoldMetadataInput(
+            table_path="/data/gold/chembl/activity",
+            table_name="chembl.activity",
+            records=records,
+            mode=GoldWriteMode.OVERWRITE,
+            # transform_version and transform_steps are None
+        )
+
+        metadata = coord.create_gold_metadata(input_data)
+
+        # Should fall back to RunContext values
+        assert metadata.lineage.transform_version == "4.0.0"
+        assert metadata.lineage.transform_steps == [
+            "transform_step_a",
+            "transform_step_b",
+        ]
+
+    def test_run_context_with_transform_info(self) -> None:
+        """Test RunContext can be created with transform version and steps."""
+        run_id = RunID(uuid4())
+        started_at = datetime.now(UTC)
+
+        context = RunContext.create(
+            run_id=run_id,
+            run_type=RunType.INCREMENTAL,
+            started_at=started_at,
+            provider="chembl",
+            entity="activity",
+            transform_version="1.2.3",
+            transform_steps=("step1", "step2"),
+        )
+
+        assert context.transform_version == "1.2.3"
+        assert context.transform_steps == ("step1", "step2")
+
+    def test_run_context_defaults_empty_transform(self) -> None:
+        """Test RunContext defaults to None/empty for transform fields."""
+        context = RunContext.create(
+            run_id=RunID(uuid4()),
+            run_type=RunType.INCREMENTAL,
+            started_at=datetime.now(UTC),
+            provider="chembl",
+            entity="activity",
+        )
+
+        assert context.transform_version is None
+        assert context.transform_steps == ()
+
+    def test_silver_input_takes_precedence_over_run_context(self) -> None:
+        """Test that SilverMetadataInput values take precedence over RunContext."""
+        MetadataCoordinator.reset_environment_cache()
+
+        context = RunContext.create(
+            run_id=RunID(uuid4()),
+            run_type=RunType.INCREMENTAL,
+            started_at=datetime.now(UTC),
+            provider="chembl",
+            entity="activity",
+            transform_version="1.0.0",
+            transform_steps=("context_step",),
+        )
+        coord = MetadataCoordinator(context)
+
+        records = [{"id": 1}]
+        input_data = SilverMetadataInput(
+            table_path="/data/silver/chembl/activity",
+            records=records,
+            primary_keys=["id"],
+            mode=SilverWriteMode.MERGE,
+            transform_version="2.0.0",  # Different from context
+            transform_steps=("input_step1", "input_step2"),  # Different from context
+        )
+
+        metadata = coord.create_silver_metadata(input_data)
+
+        # Input values should take precedence
+        assert metadata.lineage.transform_version == "2.0.0"
+        assert metadata.lineage.transform_steps == ["input_step1", "input_step2"]
+
+
 class TestRunTypeMappings:
     """Tests for RunType to RunTypeEnum mapping."""
 

--- a/tests/unit/infrastructure/test_config.py
+++ b/tests/unit/infrastructure/test_config.py
@@ -249,3 +249,136 @@ class TestMedallionFormatValidation:
         # Bronze format is auto-corrected to jsonl (RULES.md §2.1)
         yaml_config = PipelineYamlConfig.model_validate(config_dict)
         assert yaml_config.sink["bronze"].format == "jsonl"
+
+
+@pytest.mark.unit
+class TestTransformConfig:
+    """Tests for TransformConfig schema validation (lineage tracking)."""
+
+    def test_transform_config_defaults(self):
+        """Test TransformConfig has correct defaults (None/empty)."""
+        from bioetl.infrastructure.schemas.pipeline_config import TransformConfig
+
+        config = TransformConfig()
+
+        assert config.version is None
+        assert config.steps == []
+
+    def test_transform_config_with_version_and_steps(self):
+        """Test TransformConfig accepts version and steps."""
+        from bioetl.infrastructure.schemas.pipeline_config import TransformConfig
+
+        config = TransformConfig(
+            version="1.0.0",
+            steps=["normalize_values", "add_metadata", "calculate_hash"],
+        )
+
+        assert config.version == "1.0.0"
+        assert config.steps == ["normalize_values", "add_metadata", "calculate_hash"]
+
+    def test_transform_config_semver_validation_valid(self):
+        """Test valid semver versions are accepted."""
+        from bioetl.infrastructure.schemas.pipeline_config import TransformConfig
+
+        valid_versions = [
+            "1.0.0",
+            "v1.0.0",
+            "2.1.3",
+            "0.0.1",
+            "10.20.30",
+            "1.0.0-alpha",
+            "1.0.0-beta.1",
+            "1.0.0+build.123",
+            "1.2.3-alpha.1+build.456",
+        ]
+
+        for version in valid_versions:
+            config = TransformConfig(version=version)
+            assert config.version == version
+
+    def test_transform_config_semver_validation_invalid(self):
+        """Test invalid semver versions are rejected."""
+        from pydantic import ValidationError
+
+        from bioetl.infrastructure.schemas.pipeline_config import TransformConfig
+
+        invalid_versions = [
+            "1.0",  # Missing patch
+            "1",  # Missing minor and patch
+            "a.b.c",  # Non-numeric
+            "1.0.0.0",  # Too many segments
+            "1.0.0-",  # Incomplete pre-release
+        ]
+
+        for version in invalid_versions:
+            with pytest.raises(ValidationError, match="Invalid semver format"):
+                TransformConfig(version=version)
+
+    def test_pipeline_yaml_config_has_transform_field(self):
+        """Test PipelineYamlConfig includes transform field with defaults."""
+        yaml_config = PipelineYamlConfig(
+            pipeline_name="test_pipeline",
+            provider="test",
+            entity_type="entity",
+            primary_keys=["id"],
+            silver_table="silver.test",
+        )
+
+        assert yaml_config.transform is not None
+        assert yaml_config.transform.version is None
+        assert yaml_config.transform.steps == []
+
+    def test_pipeline_yaml_config_transform_from_yaml(self):
+        """Test PipelineYamlConfig parses transform from YAML dict."""
+        config_dict = {
+            "pipeline_name": "test_pipeline",
+            "provider": "test",
+            "entity_type": "entity",
+            "primary_keys": ["id"],
+            "silver_table": "silver.test",
+            "transform": {
+                "version": "1.0.0",
+                "steps": ["step1", "step2"],
+            },
+        }
+
+        yaml_config = PipelineYamlConfig.model_validate(config_dict)
+
+        assert yaml_config.transform.version == "1.0.0"
+        assert yaml_config.transform.steps == ["step1", "step2"]
+
+    def test_yaml_config_to_domain_includes_transform(self):
+        """Test that yaml_config_to_domain extracts transform info."""
+        from bioetl.infrastructure.schemas.pipeline_config import TransformConfig
+
+        yaml_config = PipelineYamlConfig(
+            pipeline_name="test_pipeline",
+            provider="test",
+            entity_type="entity",
+            primary_keys=["id"],
+            silver_table="silver.test",
+            transform=TransformConfig(
+                version="2.0.0",
+                steps=["normalize", "validate", "hash"],
+            ),
+        )
+
+        domain_config = yaml_config_to_domain(yaml_config)
+
+        assert domain_config.transform_version == "2.0.0"
+        assert domain_config.transform_steps == ("normalize", "validate", "hash")
+
+    def test_yaml_config_to_domain_handles_empty_transform(self):
+        """Test yaml_config_to_domain handles empty transform config."""
+        yaml_config = PipelineYamlConfig(
+            pipeline_name="test_pipeline",
+            provider="test",
+            entity_type="entity",
+            primary_keys=["id"],
+            silver_table="silver.test",
+        )
+
+        domain_config = yaml_config_to_domain(yaml_config)
+
+        assert domain_config.transform_version is None
+        assert domain_config.transform_steps == ()


### PR DESCRIPTION
Implement transform version tracking in Silver/Gold metadata lineage:

- Add TransformConfig to PipelineYamlConfig schema with semver validation
- Extend SilverMetadataInput and GoldMetadataInput with transform_version and transform_steps fields
- Extend RunContext with transform_version and transform_steps
- Update MetadataCoordinator to populate LineageMetadata.transform_* fields from input or RunContext (fallback)
- Pass transform info from YAML config through StorageFactory to writers
- Add comprehensive tests for transform version functionality

The transform info flows from YAML config → domain config → writers → metadata coordinator → LineageMetadata, enabling full traceability of which transform version was applied to data.

Example result in _metadata.yaml:
  lineage:
    transform_version: "1.0.0"
    transform_steps:
      - normalize_values
      - add_metadata - calculate_content_hash