### PR TITLE
Add SemanticScholar fallback handler logic

### DIFF
--- a/src/bioetl/infrastructure/adapters/semanticscholar/adapter.py
+++ b/src/bioetl/infrastructure/adapters/semanticscholar/adapter.py
@@ -29,7 +29,9 @@ from bioetl.domain.ports.noop import NoOpMetrics
 from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.adapters.base import BaseHttpAdapter
 from bioetl.infrastructure.adapters.base_metrics import AdapterMetrics
-from bioetl.infrastructure.adapters.semanticscholar.fallback import TitleFallbackHandler
+from bioetl.infrastructure.adapters.semanticscholar.fallback import (
+    SemanticScholarTitleFallbackHandler,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -87,9 +89,12 @@ class SemanticScholarAdapter(BaseHttpAdapter):
         self._adapter_metrics = AdapterMetrics(metrics_port, self.provider_name)
 
         # Initialize helper component for fallback handling
-        self._fallback_handler = TitleFallbackHandler(
+        self._fallback_handler = SemanticScholarTitleFallbackHandler(
+            http_client=self.http_client,
             logger=self.logger,
-            search_fn=self._search_by_title,
+            metrics=self._adapter_metrics,
+            api_key=self.api_key,
+            fields=self.fields,
         )
 
     def _build_headers(self) -> dict[str, str]:
@@ -428,46 +433,6 @@ class SemanticScholarAdapter(BaseHttpAdapter):
         result: list[dict[str, Any] | None] = response.json()
         return result
 
-    async def _search_by_title(
-        self,
-        title: str,
-    ) -> AsyncIterator[dict[str, Any]]:
-        """Search publications by title (fuzzy match).
-
-        Uses GET /paper/search with query for best title match.
-
-        Args:
-            title: Publication title to search for.
-
-        Yields:
-            Publication records matching the title.
-
-        """
-        # Clean title for search
-        cleaned_title = self._escape_title_for_search(title)
-
-        params: dict[str, Any] = {
-            "query": cleaned_title,
-            "fields": self.fields,
-            "limit": 5,  # Return top matches
-        }
-
-        self.logger.debug(
-            "semanticscholar_title_search",
-            title=title[:100],
-        )
-
-        url = f"{SEMANTICSCHOLAR_BASE_URL}/paper/search"
-        with self._adapter_metrics.measure_request("/paper/search"):
-            response = await self.http_client.get_once(
-                url, params=params, headers=self._build_headers()
-            )
-
-        data = response.json()
-
-        for record in data.get("data", []):
-            yield record
-
     @staticmethod
     def _normalize_doi(doi: str) -> str:
         """Normalize DOI by removing URL prefix."""
@@ -480,14 +445,6 @@ class SemanticScholarAdapter(BaseHttpAdapter):
         if doi.startswith("DOI:"):
             return doi[4:]
         return doi
-
-    @staticmethod
-    def _escape_title_for_search(title: str) -> str:
-        """Escape title for Semantic Scholar search query."""
-        # Remove special characters that might break the query
-        cleaned = title.replace('"', " ").replace("'", " ")
-        # Normalize whitespace
-        return " ".join(cleaned.split())
 
     async def _probe_health(self) -> HealthStatus:
         """Probe Semantic Scholar API health.

--- a/src/bioetl/infrastructure/adapters/semanticscholar/fallback.py
+++ b/src/bioetl/infrastructure/adapters/semanticscholar/fallback.py
@@ -4,41 +4,78 @@ Provides title-based search fallback when DOI resolution fails.
 Supports three-phase fallback strategy:
 - Phase 2: Title fallback for unresolved DOIs
 - Phase 3: Title-only lookup for entries without DOIs
+
+Uses unified HTTP client for API requests with proper metrics tracking.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from bioetl.infrastructure.adapters.common import BaseTitleFallbackHandler, titles_match
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Callable
-
     from bioetl.domain.ports import LoggerPort
+    from bioetl.infrastructure.adapters.base_metrics import AdapterMetrics
+    from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
+
+# Re-export for backwards compatibility
+__all__ = ["SemanticScholarTitleFallbackHandler", "TitleFallbackHandler", "titles_match"]
+
+# Semantic Scholar API configuration
+SEMANTICSCHOLAR_BASE_URL = "https://api.semanticscholar.org/graph/v1"
+DEFAULT_SEARCH_FIELDS = (
+    "paperId,externalIds,title,abstract,year,publicationDate,"
+    "venue,authors,citationCount,referenceCount,isOpenAccess,"
+    "openAccessPdf,tldr,fieldsOfStudy,publicationTypes,journal"
+)
 
 
-class TitleFallbackHandler(BaseTitleFallbackHandler):
-    """Handles fallback search by title when DOI lookup fails.
+class SemanticScholarTitleFallbackHandler(BaseTitleFallbackHandler):
+    """Title fallback handler for Semantic Scholar API.
 
-    Extracts fallback logic from the Semantic Scholar provider to reduce
-    class size and cyclomatic complexity while providing unified
-    three-phase fallback strategy.
+    Handles fallback search by title when DOI lookup fails.
+    Uses direct HTTP client injection for API requests.
+
+    Attributes:
+        _http_client: UnifiedHTTPClient for making HTTP requests.
+        _metrics: Optional AdapterMetrics for recording request metrics.
+        _api_key: Optional API key for stable rate limits.
+        _fields: Comma-separated list of fields to retrieve.
     """
 
     def __init__(
         self,
+        http_client: UnifiedHTTPClient,
         logger: LoggerPort,
-        search_fn: Callable[[str], AsyncIterator[dict[str, Any]]],
+        metrics: AdapterMetrics | None = None,
+        api_key: str = "",
+        fields: str = DEFAULT_SEARCH_FIELDS,
     ) -> None:
         """Initialize fallback handler.
 
         Args:
+            http_client: UnifiedHTTPClient instance for API requests.
             logger: Logger port for structured logging.
-            search_fn: Async generator function to search publications by title.
+            metrics: Optional AdapterMetrics for tracking request metrics.
+            api_key: Optional API key for stable rate limits.
+            fields: Comma-separated list of fields to retrieve.
         """
         super().__init__(logger)
-        self._search_fn = search_fn
+        self._http_client = http_client
+        self._metrics = metrics
+        self._api_key = api_key
+        self._fields = fields
+
+    def _build_headers(self) -> dict[str, str]:
+        """Build request headers with API key if available."""
+        headers = {
+            "User-Agent": "BioETL/1.0",
+            "Accept": "application/json",
+        }
+        if self._api_key:
+            headers["x-api-key"] = self._api_key
+        return headers
 
     @property
     def _event_no_fallback_title(self) -> str:
@@ -48,22 +85,22 @@ class TitleFallbackHandler(BaseTitleFallbackHandler):
     @property
     def _event_fallback_attempt(self) -> str:
         """Return log event name for fallback attempt."""
-        return "semanticscholar_title_fallback_attempt"
+        return "title_fallback_search"
 
     @property
     def _event_fallback_success(self) -> str:
         """Return log event name for successful fallback."""
-        return "semanticscholar_title_fallback_success"
+        return "title_fallback_found"
 
     @property
     def _event_fallback_not_found(self) -> str:
         """Return log event name for failed fallback."""
-        return "semanticscholar_title_fallback_not_found"
+        return "title_fallback_not_found"
 
     @property
     def _event_title_only_attempt(self) -> str:
         """Return log event name for title-only lookup attempt."""
-        return "semanticscholar_title_only_attempt"
+        return "title_only_search"
 
     @property
     def _event_title_only_success(self) -> str:
@@ -78,8 +115,8 @@ class TitleFallbackHandler(BaseTitleFallbackHandler):
     async def _search_by_title(self, title: str) -> dict[str, Any] | None:
         """Search for publication by title.
 
-        Uses the injected search function to search Semantic Scholar
-        and validates the result using title matching.
+        Uses GET /paper/search with query for best title match.
+        Validates results using title matching to reduce false positives.
 
         Args:
             title: Publication title to search for.
@@ -88,14 +125,42 @@ class TitleFallbackHandler(BaseTitleFallbackHandler):
             First matching publication or None.
         """
         try:
-            async for record in self._search_fn(title):
+            cleaned_title = self._escape_title_for_search(title)
+
+            params: dict[str, Any] = {
+                "query": cleaned_title,
+                "fields": self._fields,
+                "limit": 5,  # Return top matches for validation
+            }
+
+            self._logger.debug(
+                "semanticscholar_title_search",
+                title=title[:100],
+            )
+
+            url = f"{SEMANTICSCHOLAR_BASE_URL}/paper/search"
+
+            if self._metrics:
+                with self._metrics.measure_request("/paper/search"):
+                    response = await self._http_client.get_once(
+                        url, params=params, headers=self._build_headers()
+                    )
+            else:
+                response = await self._http_client.get_once(
+                    url, params=params, headers=self._build_headers()
+                )
+
+            data = response.json()
+
+            for record in data.get("data", []):
                 # Validate title match to reduce false positives
                 found_title = record.get("title", "")
                 if found_title and titles_match(title, found_title):
-                    return record
+                    return cast(dict[str, Any], record)
                 # If no title in record, return first result
                 if not found_title:
-                    return record
+                    return cast(dict[str, Any], record)
+
         except Exception as e:
             self._logger.debug(
                 "semanticscholar_title_search_failed",
@@ -103,6 +168,33 @@ class TitleFallbackHandler(BaseTitleFallbackHandler):
                 error=str(e),
             )
         return None
+
+    def titles_match(self, expected: str, actual: str) -> bool:
+        """Check if titles match (case-insensitive substring).
+
+        Args:
+            expected: Expected title from the original query.
+            actual: Actual title from the search result.
+
+        Returns:
+            True if titles match, False otherwise.
+        """
+        return titles_match(expected, actual)
+
+    @staticmethod
+    def _escape_title_for_search(title: str) -> str:
+        """Escape title for Semantic Scholar search query.
+
+        Args:
+            title: Publication title to clean.
+
+        Returns:
+            Cleaned title suitable for search query.
+        """
+        # Remove special characters that might break the query
+        cleaned = title.replace('"', " ").replace("'", " ")
+        # Normalize whitespace
+        return " ".join(cleaned.split())
 
     def _get_result_identifier(self, result: dict[str, Any]) -> tuple[str, str]:
         """Return Semantic Scholar paper ID for logging."""
@@ -123,3 +215,7 @@ class TitleFallbackHandler(BaseTitleFallbackHandler):
         result["_lookup_method"] = "title_fallback"
         result["_original_doi"] = original_doi
         return result
+
+
+# Backwards compatibility alias
+TitleFallbackHandler = SemanticScholarTitleFallbackHandler

--- a/tests/unit/infrastructure/adapters/semanticscholar/test_adapter.py
+++ b/tests/unit/infrastructure/adapters/semanticscholar/test_adapter.py
@@ -106,16 +106,6 @@ class TestSemanticScholarAdapter:
         result = adapter._normalize_doi("DOI:10.1038/s41586-024-07487-w")
         assert result == "10.1038/s41586-024-07487-w"
 
-    def test_escape_title_for_search(self, adapter: SemanticScholarAdapter) -> None:
-        """Test title escaping for search."""
-        title = "A \"complex\" title with 'quotes' and   spaces"
-        result = adapter._escape_title_for_search(title)
-
-        assert '"' not in result
-        assert "'" not in result
-        assert "   " not in result
-        assert result == "A complex title with quotes and spaces"
-
 
 class TestFetchFiltered:
     """Tests for fetch_filtered method."""

--- a/tests/unit/infrastructure/adapters/semanticscholar/test_fallback.py
+++ b/tests/unit/infrastructure/adapters/semanticscholar/test_fallback.py
@@ -1,15 +1,19 @@
 """Unit tests for Semantic Scholar fallback search utilities.
 
-Tests for TitleFallbackHandler class.
+Tests for SemanticScholarTitleFallbackHandler class.
 """
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from bioetl.infrastructure.adapters.semanticscholar.fallback import TitleFallbackHandler
+from bioetl.infrastructure.adapters.semanticscholar.fallback import (
+    SemanticScholarTitleFallbackHandler,
+    TitleFallbackHandler,
+)
 
 
 # =============================================================================
@@ -23,49 +27,69 @@ def mock_logger():
     return MagicMock()
 
 
+@pytest.fixture
+def mock_http_client():
+    """Create a mock HTTP client."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_metrics():
+    """Create a mock metrics instance."""
+    metrics = MagicMock()
+    # Make measure_request return a context manager
+    metrics.measure_request.return_value.__enter__ = MagicMock()
+    metrics.measure_request.return_value.__exit__ = MagicMock()
+    return metrics
+
+
+def create_mock_response(data: list[dict[str, Any]]) -> MagicMock:
+    """Create a mock HTTP response with given data."""
+    response = MagicMock()
+    response.json.return_value = {"data": data}
+    return response
+
+
 # =============================================================================
 # TitleFallbackHandler Tests
 # =============================================================================
 
 
-class TestTitleFallbackHandler:
-    """Tests for the TitleFallbackHandler class."""
+class TestSemanticScholarTitleFallbackHandler:
+    """Tests for the SemanticScholarTitleFallbackHandler class."""
 
-    def test_event_names(self, mock_logger):
-        """Test that event names are correctly prefixed."""
-
-        async def mock_search(title):
-            return
-            yield
-
-        handler = TitleFallbackHandler(logger=mock_logger, search_fn=mock_search)
+    def test_event_names(self, mock_logger, mock_http_client):
+        """Test that event names are correctly defined."""
+        handler = SemanticScholarTitleFallbackHandler(
+            http_client=mock_http_client,
+            logger=mock_logger,
+        )
 
         assert handler._event_no_fallback_title == "semanticscholar_no_fallback_title"
-        assert (
-            handler._event_fallback_attempt == "semanticscholar_title_fallback_attempt"
-        )
-        assert (
-            handler._event_fallback_success == "semanticscholar_title_fallback_success"
-        )
-        assert (
-            handler._event_fallback_not_found
-            == "semanticscholar_title_fallback_not_found"
-        )
-        assert handler._event_title_only_attempt == "semanticscholar_title_only_attempt"
+        assert handler._event_fallback_attempt == "title_fallback_search"
+        assert handler._event_fallback_success == "title_fallback_found"
+        assert handler._event_fallback_not_found == "title_fallback_not_found"
+        assert handler._event_title_only_attempt == "title_only_search"
         assert handler._event_title_only_success == "semanticscholar_title_only_success"
         assert (
             handler._event_title_only_not_found
             == "semanticscholar_title_only_not_found"
         )
 
-    def test_get_result_identifier(self, mock_logger):
+    def test_backwards_compatibility_alias(self, mock_logger, mock_http_client):
+        """Test that TitleFallbackHandler alias works."""
+        handler = TitleFallbackHandler(
+            http_client=mock_http_client,
+            logger=mock_logger,
+        )
+        assert isinstance(handler, SemanticScholarTitleFallbackHandler)
+
+    def test_get_result_identifier(self, mock_logger, mock_http_client):
         """Test that result identifier returns paper ID."""
-
-        async def mock_search(title):
-            return
-            yield
-
-        handler = TitleFallbackHandler(logger=mock_logger, search_fn=mock_search)
+        handler = SemanticScholarTitleFallbackHandler(
+            http_client=mock_http_client,
+            logger=mock_logger,
+        )
 
         result = {"paperId": "abc123", "title": "Test Paper"}
         field_name, value = handler._get_result_identifier(result)
@@ -73,14 +97,12 @@ class TestTitleFallbackHandler:
         assert field_name == "found_paper_id"
         assert value == "abc123"
 
-    def test_get_result_identifier_missing_id(self, mock_logger):
+    def test_get_result_identifier_missing_id(self, mock_logger, mock_http_client):
         """Test result identifier with missing paper ID."""
-
-        async def mock_search(title):
-            return
-            yield
-
-        handler = TitleFallbackHandler(logger=mock_logger, search_fn=mock_search)
+        handler = SemanticScholarTitleFallbackHandler(
+            http_client=mock_http_client,
+            logger=mock_logger,
+        )
 
         result = {"title": "Test Paper"}
         field_name, value = handler._get_result_identifier(result)
@@ -88,14 +110,12 @@ class TestTitleFallbackHandler:
         assert field_name == "found_paper_id"
         assert value == "unknown"
 
-    def test_process_found_result_adds_metadata(self, mock_logger):
+    def test_process_found_result_adds_metadata(self, mock_logger, mock_http_client):
         """Test that process_found_result adds lookup method metadata."""
-
-        async def mock_search(title):
-            return
-            yield
-
-        handler = TitleFallbackHandler(logger=mock_logger, search_fn=mock_search)
+        handler = SemanticScholarTitleFallbackHandler(
+            http_client=mock_http_client,
+            logger=mock_logger,
+        )
 
         result = {"paperId": "abc123", "title": "Test Paper"}
         processed = handler._process_found_result(result, "10.1234/original")
@@ -103,86 +123,180 @@ class TestTitleFallbackHandler:
         assert processed["_lookup_method"] == "title_fallback"
         assert processed["_original_doi"] == "10.1234/original"
 
+    def test_titles_match_method(self, mock_logger, mock_http_client):
+        """Test the titles_match instance method."""
+        handler = SemanticScholarTitleFallbackHandler(
+            http_client=mock_http_client,
+            logger=mock_logger,
+        )
+
+        # Case-insensitive match
+        assert handler.titles_match("Crystal Structure", "crystal structure") is True
+        # Partial match
+        assert (
+            handler.titles_match("Crystal", "Crystal structure of rhodopsin") is True
+        )
+        # No match
+        assert handler.titles_match("Different topic", "Crystal structure") is False
+
+    def test_escape_title_for_search(self, mock_logger, mock_http_client):
+        """Test title escaping for search query."""
+        handler = SemanticScholarTitleFallbackHandler(
+            http_client=mock_http_client,
+            logger=mock_logger,
+        )
+
+        # Test quote removal
+        assert handler._escape_title_for_search('"Test" title') == "Test title"
+        assert handler._escape_title_for_search("Test's title") == "Test s title"
+
+        # Test whitespace normalization
+        assert handler._escape_title_for_search("Test   title") == "Test title"
+
+    def test_build_headers_without_api_key(self, mock_logger, mock_http_client):
+        """Test header building without API key."""
+        handler = SemanticScholarTitleFallbackHandler(
+            http_client=mock_http_client,
+            logger=mock_logger,
+        )
+
+        headers = handler._build_headers()
+        assert headers["User-Agent"] == "BioETL/1.0"
+        assert headers["Accept"] == "application/json"
+        assert "x-api-key" not in headers
+
+    def test_build_headers_with_api_key(self, mock_logger, mock_http_client):
+        """Test header building with API key."""
+        handler = SemanticScholarTitleFallbackHandler(
+            http_client=mock_http_client,
+            logger=mock_logger,
+            api_key="test-api-key",
+        )
+
+        headers = handler._build_headers()
+        assert headers["x-api-key"] == "test-api-key"
+
     @pytest.mark.asyncio
-    async def test_search_by_title_success(self, mock_logger):
+    async def test_search_by_title_success(self, mock_logger, mock_http_client):
         """Test successful title search."""
+        mock_http_client.get_once.return_value = create_mock_response(
+            [{"paperId": "abc123", "title": "Crystal structure of rhodopsin"}]
+        )
 
-        async def mock_search(title):
-            yield {"paperId": "abc123", "title": "Crystal structure of rhodopsin"}
-
-        handler = TitleFallbackHandler(logger=mock_logger, search_fn=mock_search)
+        handler = SemanticScholarTitleFallbackHandler(
+            http_client=mock_http_client,
+            logger=mock_logger,
+        )
         result = await handler._search_by_title("Crystal structure of rhodopsin")
 
         assert result is not None
         assert result["paperId"] == "abc123"
+        mock_http_client.get_once.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_search_by_title_validates_title_match(self, mock_logger):
+    async def test_search_by_title_validates_title_match(
+        self, mock_logger, mock_http_client
+    ):
         """Test that title matching validates results."""
+        mock_http_client.get_once.return_value = create_mock_response(
+            [{"paperId": "abc123", "title": "Completely different topic"}]
+        )
 
-        async def mock_search(title):
-            yield {"paperId": "abc123", "title": "Completely different topic"}
-
-        handler = TitleFallbackHandler(logger=mock_logger, search_fn=mock_search)
+        handler = SemanticScholarTitleFallbackHandler(
+            http_client=mock_http_client,
+            logger=mock_logger,
+        )
         result = await handler._search_by_title("Crystal structure of rhodopsin")
 
         # Should return None because titles don't match
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_search_by_title_no_results(self, mock_logger):
+    async def test_search_by_title_no_results(self, mock_logger, mock_http_client):
         """Test title search with no results."""
+        mock_http_client.get_once.return_value = create_mock_response([])
 
-        async def mock_search(title):
-            return
-            yield
-
-        handler = TitleFallbackHandler(logger=mock_logger, search_fn=mock_search)
+        handler = SemanticScholarTitleFallbackHandler(
+            http_client=mock_http_client,
+            logger=mock_logger,
+        )
         result = await handler._search_by_title("Nonexistent publication")
 
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_search_by_title_handles_exception(self, mock_logger):
+    async def test_search_by_title_handles_exception(
+        self, mock_logger, mock_http_client
+    ):
         """Test that search errors are caught and logged."""
+        mock_http_client.get_once.side_effect = Exception("Search failed")
 
-        async def mock_search(title):
-            raise Exception("Search failed")
-            yield
-
-        handler = TitleFallbackHandler(logger=mock_logger, search_fn=mock_search)
+        handler = SemanticScholarTitleFallbackHandler(
+            http_client=mock_http_client,
+            logger=mock_logger,
+        )
         result = await handler._search_by_title("Test title")
 
         assert result is None
-        mock_logger.debug.assert_called_once()
+        mock_logger.debug.assert_called()
 
     @pytest.mark.asyncio
-    async def test_search_by_title_returns_first_matching(self, mock_logger):
+    async def test_search_by_title_returns_first_matching(
+        self, mock_logger, mock_http_client
+    ):
         """Test that first matching result is returned."""
+        mock_http_client.get_once.return_value = create_mock_response(
+            [
+                {"paperId": "wrong1", "title": "Wrong topic"},
+                {"paperId": "correct", "title": "Crystal structure of rhodopsin"},
+                {"paperId": "wrong2", "title": "Another wrong topic"},
+            ]
+        )
 
-        async def mock_search(title):
-            yield {"paperId": "wrong1", "title": "Wrong topic"}
-            yield {"paperId": "correct", "title": "Crystal structure of rhodopsin"}
-            yield {"paperId": "wrong2", "title": "Another wrong topic"}
-
-        handler = TitleFallbackHandler(logger=mock_logger, search_fn=mock_search)
+        handler = SemanticScholarTitleFallbackHandler(
+            http_client=mock_http_client,
+            logger=mock_logger,
+        )
         result = await handler._search_by_title("Crystal structure of rhodopsin")
 
         assert result is not None
         assert result["paperId"] == "correct"
 
     @pytest.mark.asyncio
-    async def test_search_by_title_returns_result_without_title(self, mock_logger):
+    async def test_search_by_title_returns_result_without_title(
+        self, mock_logger, mock_http_client
+    ):
         """Test that result without title field is returned."""
+        mock_http_client.get_once.return_value = create_mock_response(
+            [{"paperId": "abc123"}]  # No title field
+        )
 
-        async def mock_search(title):
-            yield {"paperId": "abc123"}  # No title field
-
-        handler = TitleFallbackHandler(logger=mock_logger, search_fn=mock_search)
+        handler = SemanticScholarTitleFallbackHandler(
+            http_client=mock_http_client,
+            logger=mock_logger,
+        )
         result = await handler._search_by_title("Any title")
 
         assert result is not None
         assert result["paperId"] == "abc123"
+
+    @pytest.mark.asyncio
+    async def test_search_with_metrics(
+        self, mock_logger, mock_http_client, mock_metrics
+    ):
+        """Test that metrics are recorded when provided."""
+        mock_http_client.get_once.return_value = create_mock_response(
+            [{"paperId": "abc123", "title": "Test Paper"}]
+        )
+
+        handler = SemanticScholarTitleFallbackHandler(
+            http_client=mock_http_client,
+            logger=mock_logger,
+            metrics=mock_metrics,
+        )
+        await handler._search_by_title("Test Paper")
+
+        mock_metrics.measure_request.assert_called_once_with("/paper/search")
 
 
 # =============================================================================
@@ -194,13 +308,16 @@ class TestProcessMissingDois:
     """Tests for process_missing_dois method."""
 
     @pytest.mark.asyncio
-    async def test_process_missing_dois_success(self, mock_logger):
+    async def test_process_missing_dois_success(self, mock_logger, mock_http_client):
         """Test processing missing DOIs with successful fallback."""
+        mock_http_client.get_once.return_value = create_mock_response(
+            [{"paperId": "abc123", "title": "Crystal structure of rhodopsin"}]
+        )
 
-        async def mock_search(title):
-            yield {"paperId": "abc123", "title": "Crystal structure of rhodopsin"}
-
-        handler = TitleFallbackHandler(logger=mock_logger, search_fn=mock_search)
+        handler = SemanticScholarTitleFallbackHandler(
+            http_client=mock_http_client,
+            logger=mock_logger,
+        )
 
         fallback_mapping = {
             "10.1234/notfound": "Crystal structure of rhodopsin",
@@ -223,16 +340,14 @@ class TestProcessMissingDois:
         assert results[0]["_original_doi"] == "10.1234/notfound"
 
     @pytest.mark.asyncio
-    async def test_process_missing_dois_skips_found(self, mock_logger):
+    async def test_process_missing_dois_skips_found(
+        self, mock_logger, mock_http_client
+    ):
         """Test that already-found DOIs are skipped."""
-        search_called = []
-
-        async def mock_search(title):
-            search_called.append(title)
-            return
-            yield
-
-        handler = TitleFallbackHandler(logger=mock_logger, search_fn=mock_search)
+        handler = SemanticScholarTitleFallbackHandler(
+            http_client=mock_http_client,
+            logger=mock_logger,
+        )
 
         results = []
         async for pub in handler.process_missing_dois(
@@ -246,7 +361,8 @@ class TestProcessMissingDois:
             results.append(pub)
 
         assert len(results) == 0
-        assert len(search_called) == 0
+        # HTTP client should not be called
+        mock_http_client.get_once.assert_not_called()
 
 
 # =============================================================================
@@ -258,13 +374,16 @@ class TestProcessTitleOnlyEntries:
     """Tests for process_title_only_entries method."""
 
     @pytest.mark.asyncio
-    async def test_process_title_only_success(self, mock_logger):
+    async def test_process_title_only_success(self, mock_logger, mock_http_client):
         """Test processing title-only entries with successful search."""
+        mock_http_client.get_once.return_value = create_mock_response(
+            [{"paperId": "abc123", "title": "Crystal structure of rhodopsin"}]
+        )
 
-        async def mock_search(title):
-            yield {"paperId": "abc123", "title": "Crystal structure of rhodopsin"}
-
-        handler = TitleFallbackHandler(logger=mock_logger, search_fn=mock_search)
+        handler = SemanticScholarTitleFallbackHandler(
+            http_client=mock_http_client,
+            logger=mock_logger,
+        )
 
         fallback_mapping = {
             "": "Crystal structure of rhodopsin",
@@ -284,14 +403,12 @@ class TestProcessTitleOnlyEntries:
         assert results[0]["_lookup_method"] == "title_only"
 
     @pytest.mark.asyncio
-    async def test_process_title_only_no_mapping(self, mock_logger):
+    async def test_process_title_only_no_mapping(self, mock_logger, mock_http_client):
         """Test title-only processing with no title mapping."""
-
-        async def mock_search(title):
-            return
-            yield
-
-        handler = TitleFallbackHandler(logger=mock_logger, search_fn=mock_search)
+        handler = SemanticScholarTitleFallbackHandler(
+            http_client=mock_http_client,
+            logger=mock_logger,
+        )
 
         results = []
         async for pub in handler.process_title_only_entries(
@@ -303,15 +420,23 @@ class TestProcessTitleOnlyEntries:
             results.append(pub)
 
         assert len(results) == 0
+        # HTTP client should not be called
+        mock_http_client.get_once.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_process_title_only_respects_limit(self, mock_logger):
+    async def test_process_title_only_respects_limit(
+        self, mock_logger, mock_http_client
+    ):
         """Test that limit is respected during title-only processing."""
+        # Return different papers for different titles
+        mock_http_client.get_once.return_value = create_mock_response(
+            [{"paperId": "abc123", "title": "Title 1"}]
+        )
 
-        async def mock_search(title):
-            yield {"paperId": "abc123", "title": title}
-
-        handler = TitleFallbackHandler(logger=mock_logger, search_fn=mock_search)
+        handler = SemanticScholarTitleFallbackHandler(
+            http_client=mock_http_client,
+            logger=mock_logger,
+        )
 
         fallback_mapping = {
             "": "Title 1",


### PR DESCRIPTION
…injection

- Rename TitleFallbackHandler to SemanticScholarTitleFallbackHandler
- Change from callback-based to direct HTTP client injection pattern
- Move _search_by_title and _escape_title_for_search from adapter to handler
- Add api_key and fields parameters to handler constructor
- Unify logging events: title_fallback_search, title_fallback_found, title_fallback_not_found, title_only_search
- Add titles_match() instance method for external use
- Keep backwards compatibility alias (TitleFallbackHandler)
- Update tests to use new API with mock HTTP client

Reduces adapter.py by ~45 LOC, handler now owns all title search logic.