### PR TITLE
Update Silver Schemas with lookup metadata

### DIFF
--- a/src/bioetl/infrastructure/schemas/silver.py
+++ b/src/bioetl/infrastructure/schemas/silver.py
@@ -198,6 +198,10 @@ PUBMED_PUBLICATION_SCHEMA = pa.schema(
         # Additional metadata
         pa.field("language", pa.string()),
         pa.field("country", pa.string()),
+        pa.field("source", pa.string()),
+        # Lookup metadata
+        pa.field("_lookup_method", pa.string()),
+        pa.field("_original_id", pa.string()),
         # Lineage metadata
         pa.field("_run_id", pa.string()),
         pa.field("_run_type", pa.string()),
@@ -665,6 +669,9 @@ CROSSREF_PUBLICATION_SCHEMA = pa.schema(
         pa.field("license_url", pa.string()),
         pa.field("subjects", pa.list_(pa.string())),
         pa.field("source", pa.string()),
+        # Lookup metadata
+        pa.field("_lookup_method", pa.string()),
+        pa.field("_original_doi", pa.string()),
     ]
 )
 


### PR DESCRIPTION
Add _lookup_method and _original_doi/_original_id fields to publication schemas for consistency with SemanticScholar and OpenAlex schemas:

- CROSSREF_PUBLICATION_SCHEMA: add _lookup_method, _original_doi
- PUBMED_PUBLICATION_SCHEMA: add source, _lookup_method, _original_id

These fields enable tracking of DOI/ID resolution methods across all publication providers.