### PR TITLE
Fix failing architecture metrics tests

### DIFF
--- a/src/bioetl/infrastructure/adapters/semanticscholar/fallback.py
+++ b/src/bioetl/infrastructure/adapters/semanticscholar/fallback.py
@@ -20,7 +20,11 @@ if TYPE_CHECKING:
     from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
 
 # Re-export for backwards compatibility
-__all__ = ["SemanticScholarTitleFallbackHandler", "TitleFallbackHandler", "titles_match"]
+__all__ = [
+    "SemanticScholarTitleFallbackHandler",
+    "TitleFallbackHandler",
+    "titles_match",
+]
 
 # Semantic Scholar API configuration
 SEMANTICSCHOLAR_BASE_URL = "https://api.semanticscholar.org/graph/v1"

--- a/tests/architecture/test_adapter_contracts.py
+++ b/tests/architecture/test_adapter_contracts.py
@@ -48,6 +48,8 @@ class TestAdapterHealthCheck:
             "circuit_breaker.py",  # Circuit breaker utility
             "health_monitor.py",  # Health state utility, not a DataSourcePort adapter
             "error_handling.py",  # Error handling utility, not a DataSourcePort adapter
+            "fallback.py",  # Title fallback handler utility, not a DataSourcePort adapter
+            "base_title_fallback.py",  # Base class for title fallback handlers
         }
         adapter_files = []
         for py_file in adapters_path.rglob("*.py"):

--- a/tests/unit/infrastructure/adapters/semanticscholar/test_fallback.py
+++ b/tests/unit/infrastructure/adapters/semanticscholar/test_fallback.py
@@ -133,9 +133,7 @@ class TestSemanticScholarTitleFallbackHandler:
         # Case-insensitive match
         assert handler.titles_match("Crystal Structure", "crystal structure") is True
         # Partial match
-        assert (
-            handler.titles_match("Crystal", "Crystal structure of rhodopsin") is True
-        )
+        assert handler.titles_match("Crystal", "Crystal structure of rhodopsin") is True
         # No match
         assert handler.titles_match("Different topic", "Crystal structure") is False
 


### PR DESCRIPTION
- Add fallback.py and base_title_fallback.py to excluded_files in test_adapter_contracts.py since they are utility classes, not DataSourcePort adapters
- Apply ruff formatting to semanticscholar/fallback.py and its tests

The fallback handlers are helper utilities for title-based DOI resolution, not main adapters that implement DataSourcePort.