### PR TITLE
Unify YAML configuration structure

### DIFF
--- a/configs/pipelines/pubmed/publications.yaml
+++ b/configs/pipelines/pubmed/publications.yaml
@@ -102,3 +102,4 @@ input_filter:
   column_name: "pubmed_id"
   filter_field: "pmid"
   batch_size: 100
+  fallback_column: "title"  # Search by title if PMID not found or empty


### PR DESCRIPTION
Unify YAML configs for publication pipelines by adding missing fallback_column: "title" to PubMed config. All 4 publication pipelines (CrossRef, PubMed, OpenAlex, SemanticScholar) now have consistent input_filter configuration with title fallback support.