### PR TITLE
Integrate data quality reports into pipeline

### DIFF
--- a/src/bioetl/application/core/batch_executor.py
+++ b/src/bioetl/application/core/batch_executor.py
@@ -2,12 +2,18 @@
 
 Combines extraction, transformation, and writing into a single component with
 adaptive batch sizing, checkpointing, and graceful shutdown handling.
+
+DQ Report Integration:
+- Accumulates data for DQ report generation when DQ report service is available
+- Provides get_dq_context() method for building DQ report context
 """
 
 from __future__ import annotations
 
+import json
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
@@ -31,6 +37,7 @@ if TYPE_CHECKING:
         GoldTransformCallback,
         TransformCallback,
     )
+    from bioetl.application.services.dq_report_service import DQReportContext
     from bioetl.domain.context import PipelineContext
     from bioetl.domain.error_classifier import ErrorClassifier
     from bioetl.domain.models.metadata import SourceMetadata
@@ -130,6 +137,14 @@ class BatchExecutor:
         self.records_silver = 0
         self.records_gold = 0
         self.records_quarantined = 0
+
+        # DQ Report data accumulation (only if DQ report service is available)
+        # Collecting data adds memory overhead, so only enabled when needed
+        self._bronze_records_for_dq: list[bytes] = []
+        self._silver_records_for_dq: list[dict[str, Any]] = []
+        self._gold_records_for_dq: list[dict[str, Any]] = []
+        self._source_batch_ids: list[str] = []
+        self._last_bronze_path: str | None = None
 
         # Create internal components (from RecordProcessor)
         pipeline_label = f"{config.provider}_{config.entity_type}"
@@ -412,6 +427,16 @@ class BatchExecutor:
             self.records_gold += len(result.gold_records)
             self.records_quarantined += result.quarantined_count
 
+            # Collect data for DQ reports (if enabled)
+            if self._should_collect_dq_data():
+                self._collect_dq_data(
+                    records=records,
+                    batch_id=batch_id,
+                    bronze_result=bronze_result,
+                    silver_records=result.silver_records,
+                    gold_records=result.gold_records,
+                )
+
             # Add result attributes to span
             self._tracing.set_batch_result(
                 span,
@@ -574,3 +599,138 @@ class BatchExecutor:
             query=query,
         ):
             yield record
+
+    # -------------------------------------------------------------------------
+    # DQ Report data collection
+    # -------------------------------------------------------------------------
+
+    def _should_collect_dq_data(self) -> bool:
+        """Check if DQ report service is available.
+
+        Returns:
+            True if DQ report service is configured and data should be collected.
+        """
+        return self._services.dq_report_service is not None
+
+    def _collect_dq_data(
+        self,
+        records: list[dict[str, Any]],
+        batch_id: BatchID,
+        bronze_result: Any,
+        silver_records: list[dict[str, Any]],
+        gold_records: list[dict[str, Any]],
+    ) -> None:
+        """Collect data from batch processing for DQ reports.
+
+        Args:
+            records: Raw Bronze records.
+            batch_id: Batch identifier.
+            bronze_result: Result from Bronze write operation (contains path).
+            silver_records: Transformed Silver records.
+            gold_records: Transformed Gold records.
+        """
+        # Collect Bronze records as bytes (JSON-encoded)
+        for record in records:
+            try:
+                self._bronze_records_for_dq.append(
+                    json.dumps(record, default=str).encode("utf-8")
+                )
+            except (TypeError, ValueError):
+                # Skip records that can't be serialized
+                pass
+
+        # Track batch ID
+        self._source_batch_ids.append(str(batch_id))
+
+        # Track Bronze file path if available
+        if bronze_result is not None and hasattr(bronze_result, "path"):
+            self._last_bronze_path = str(bronze_result.path)
+
+        # Collect Silver records
+        self._silver_records_for_dq.extend(silver_records)
+
+        # Collect Gold records
+        self._gold_records_for_dq.extend(gold_records)
+
+    def get_dq_context(self) -> DQReportContext | None:
+        """Build DQ report context from accumulated data.
+
+        Creates a DQReportContext containing all data collected during
+        batch processing. This context is used by PostrunService to
+        generate DQ reports for Bronze, Silver, and Gold layers.
+
+        Returns:
+            DQReportContext if DQ reporting is enabled and data is available,
+            None otherwise.
+
+        Note:
+            This method should be called after execute() completes.
+            The returned context contains snapshots of the accumulated data.
+        """
+        if not self._should_collect_dq_data():
+            return None
+
+        # Import here to avoid circular dependency
+        from bioetl.application.services.dq_report_service import DQReportContext
+
+        # Build Silver DataFrame if we have records
+        silver_data = None
+        if self._silver_records_for_dq:
+            try:
+                import polars as pl
+
+                silver_data = pl.DataFrame(self._silver_records_for_dq)
+            except Exception:
+                # If DataFrame creation fails, skip Silver DQ report
+                pass
+
+        # Build Gold DataFrame if we have records
+        gold_data = None
+        if self._gold_records_for_dq:
+            try:
+                import polars as pl
+
+                gold_data = pl.DataFrame(self._gold_records_for_dq)
+            except Exception:
+                # If DataFrame creation fails, skip Gold DQ report
+                pass
+
+        # Get table config for primary keys
+        primary_keys = list(self._config.table_config.primary_keys)
+
+        return DQReportContext(
+            run_id=str(self._context.run_id),
+            pipeline_name=self._config.pipeline_name,
+            timestamp=datetime.now(UTC),
+            # Bronze context
+            bronze_records=(
+                self._bronze_records_for_dq if self._bronze_records_for_dq else None
+            ),
+            bronze_batch_id=(
+                self._source_batch_ids[-1] if self._source_batch_ids else None
+            ),
+            bronze_source_file=self._last_bronze_path,
+            # Silver context
+            silver_data=silver_data,
+            silver_target_table=self._config.table_config.silver_table,
+            silver_source_batch_ids=(
+                self._source_batch_ids if self._source_batch_ids else None
+            ),
+            silver_primary_keys=primary_keys if primary_keys else None,
+            silver_input_count=self.records_fetched,
+            silver_quarantined_count=self.records_quarantined,
+            # Gold context
+            gold_data=gold_data,
+            gold_target_table=self._config.table_config.gold_table,
+            # DQ thresholds from config (use defaults if not configured)
+            dq_soft_threshold=(
+                self._config.dq_config.soft_fail_threshold
+                if self._config.dq_config
+                else 0.05
+            ),
+            dq_hard_threshold=(
+                self._config.dq_config.hard_fail_threshold
+                if self._config.dq_config
+                else 0.20
+            ),
+        )

--- a/src/bioetl/application/core/postrun_service.py
+++ b/src/bioetl/application/core/postrun_service.py
@@ -2,11 +2,13 @@
 
 Application Service that handles post-pipeline execution tasks:
 - Data quality checks (delegated to DataQualityService)
+- DQ report generation (delegated to DQReportService)
 - VACUUM operations (delegated to MedallionLifecycleService)
 - Tracer cleanup
 
 Extracted from PipelineRunner to follow Single Responsibility Principle.
 DQ logic further extracted to DataQualityService (SRP refactoring).
+DQ report generation added for detailed data quality analysis.
 """
 
 from __future__ import annotations
@@ -19,11 +21,23 @@ from bioetl.application.services.medallion_lifecycle import VacuumResult
 from bioetl.domain.value_objects.dq_result import DQEvaluationStatus, DQResult
 
 if TYPE_CHECKING:
+    from bioetl.application.services.dq_report_service import (
+        DQReportContext,
+        DQReportResult,
+        DQReportService,
+    )
     from bioetl.application.services.medallion_lifecycle import (
         MedallionLifecycleService,
     )
     from bioetl.domain.config import PipelineConfig, RuntimeConfig
-    from bioetl.domain.ports import LoggerPort, MetricsPort, TracingPort
+    from bioetl.domain.ports import (
+        BronzeDQConfigPort,
+        GoldDQConfigPort,
+        LoggerPort,
+        MetricsPort,
+        SilverDQConfigPort,
+        TracingPort,
+    )
 
 
 @runtime_checkable
@@ -46,10 +60,12 @@ class PostrunResult:
 
     Attributes:
         dq: Data quality evaluation result.
+        dq_reports: DQ report generation result (optional).
         vacuum: VACUUM operation result.
     """
 
     dq: DQResult
+    dq_reports: DQReportResult | None
     vacuum: VacuumResult
 
 
@@ -58,6 +74,7 @@ class PostrunService:
 
     Responsibilities:
     - Orchestrating DQ checks via DataQualityService
+    - DQ report generation via DQReportService (optional)
     - VACUUM operations via MedallionLifecycleService
     - Tracer cleanup
 
@@ -68,6 +85,10 @@ class PostrunService:
         _lifecycle_service: Medallion lifecycle service for VACUUM.
         _metrics: Optional metrics port.
         _logger: Structured logger.
+        _dq_report_service: Optional DQ report service for report generation.
+        _bronze_dq_config: Optional Bronze DQ report configuration.
+        _silver_dq_config: Optional Silver DQ report configuration.
+        _gold_dq_config: Optional Gold DQ report configuration.
     """
 
     def __init__(
@@ -78,6 +99,11 @@ class PostrunService:
         lifecycle_service: MedallionLifecycleService,
         metrics: MetricsPort | None,
         logger: LoggerPort,
+        # DQ Report parameters (optional)
+        dq_report_service: DQReportService | None = None,
+        bronze_dq_config: BronzeDQConfigPort | None = None,
+        silver_dq_config: SilverDQConfigPort | None = None,
+        gold_dq_config: GoldDQConfigPort | None = None,
     ) -> None:
         """Initialize postrun service.
 
@@ -88,6 +114,10 @@ class PostrunService:
             lifecycle_service: Medallion lifecycle service for VACUUM.
             metrics: Optional metrics port.
             logger: Structured logger.
+            dq_report_service: Optional DQ report service for report generation.
+            bronze_dq_config: Optional Bronze DQ report configuration.
+            silver_dq_config: Optional Silver DQ report configuration.
+            gold_dq_config: Optional Gold DQ report configuration.
         """
         self._config = config
         self._runtime = runtime
@@ -95,27 +125,35 @@ class PostrunService:
         self._lifecycle_service = lifecycle_service
         self._metrics = metrics
         self._logger = logger
+        # DQ Report services
+        self._dq_report_service = dq_report_service
+        self._bronze_dq_config = bronze_dq_config
+        self._silver_dq_config = silver_dq_config
+        self._gold_dq_config = gold_dq_config
 
     async def run(
         self,
         executor: ExecutorMetricsProtocol,
+        dq_context: DQReportContext | None = None,
     ) -> PostrunResult:
         """Run all post-execution operations.
 
-        Performs DQ checks and VACUUM in sequence.
+        Performs DQ checks, DQ report generation, and VACUUM in sequence.
 
         Args:
             executor: Pipeline executor with batch metrics.
+            dq_context: Optional DQ report context with data and metadata.
 
         Returns:
-            PostrunResult with DQ and VACUUM results.
+            PostrunResult with DQ, DQ reports, and VACUUM results.
 
         Raises:
             DataQualityThresholdError: If error rate exceeds hard threshold.
         """
         dq_result = await self.run_dq_checks(executor)
+        dq_reports = await self._generate_dq_reports(dq_context)
         vacuum_result = await self.run_vacuum_if_enabled()
-        return PostrunResult(dq=dq_result, vacuum=vacuum_result)
+        return PostrunResult(dq=dq_result, dq_reports=dq_reports, vacuum=vacuum_result)
 
     async def run_dq_checks(self, executor: ExecutorMetricsProtocol) -> DQResult:
         """Check data quality metrics and report anomalies.
@@ -170,6 +208,61 @@ class PostrunService:
                     "Failed to close tracer",
                     error=str(e),
                 )
+
+    async def _generate_dq_reports(
+        self,
+        context: DQReportContext | None,
+    ) -> DQReportResult | None:
+        """Generate DQ reports if enabled.
+
+        Delegates to DQReportService for generating Bronze, Silver, and Gold
+        DQ reports based on configuration.
+
+        Args:
+            context: DQ report context with data and metadata.
+
+        Returns:
+            DQReportResult with paths to generated reports, or None if:
+            - DQ report service is not available
+            - No context provided
+            - No reports are enabled in configuration
+        """
+        if self._dq_report_service is None:
+            return None
+
+        if context is None:
+            self._logger.debug(
+                "dq_report_skipped",
+                reason="no context provided",
+            )
+            return None
+
+        try:
+            result = await self._dq_report_service.generate_reports(
+                context=context,
+                bronze_config=self._bronze_dq_config,
+                silver_config=self._silver_dq_config,
+                gold_config=self._gold_dq_config,
+            )
+
+            if result.any_generated:
+                self._logger.info(
+                    "dq_reports_completed",
+                    reports_count=result.reports_count,
+                    bronze_enabled=result.bronze_enabled,
+                    silver_enabled=result.silver_enabled,
+                    gold_enabled=result.gold_enabled,
+                )
+
+            return result
+
+        except Exception as e:
+            # Log error but don't fail the pipeline
+            self._logger.error(
+                "dq_report_generation_failed",
+                error=str(e),
+            )
+            return None
 
     def _collect_batch_metrics(
         self, executor: ExecutorMetricsProtocol

--- a/src/bioetl/application/core/runner.py
+++ b/src/bioetl/application/core/runner.py
@@ -148,9 +148,12 @@ class PipelineRunner:
                         query=self._runtime.query,
                     )
 
-                    # Post-run: DQ checks and VACUUM
-                    await self._postrun_service.run_dq_checks(self._executor)
-                    await self._postrun_service.run_vacuum_if_enabled()
+                    # Post-run: DQ checks, DQ reports, and VACUUM
+                    dq_context = self._executor.get_dq_context()
+                    await self._postrun_service.run(
+                        executor=self._executor,
+                        dq_context=dq_context,
+                    )
 
                     await self._checkpoint_manager.delete_checkpoint()
 

--- a/src/bioetl/composition/factories/pipeline_factory.py
+++ b/src/bioetl/composition/factories/pipeline_factory.py
@@ -45,11 +45,14 @@ if TYPE_CHECKING:
     from bioetl.domain.config import RuntimeConfig
     from bioetl.domain.filtering import GoldFilterConfig, InputFilterConfig
     from bioetl.domain.ports import (
+        BronzeDQConfigPort,
         DataSourcePort,
         DQMonitorPort,
+        GoldDQConfigPort,
         LoggerPort,
         MetricsPort,
         PiiHasherPort,
+        SilverDQConfigPort,
         TracingPort,
     )
     from bioetl.domain.services import IdentityService
@@ -506,6 +509,9 @@ def assemble_runner(
         pipeline_name=pipeline.config.pipeline_name,
     )
 
+    # Extract DQ configs from pipeline for DQ report generation
+    bronze_dq_config, silver_dq_config, gold_dq_config = _extract_dq_configs(pipeline)
+
     postrun_service = PostrunService(
         config=pipeline.config,
         runtime=pipeline.runtime,
@@ -513,6 +519,11 @@ def assemble_runner(
         lifecycle_service=lifecycle_service,
         metrics=pipeline.services.metrics,
         logger=logger_port,
+        # DQ Report parameters
+        dq_report_service=pipeline.services.dq_report_service,
+        bronze_dq_config=bronze_dq_config,
+        silver_dq_config=silver_dq_config,
+        gold_dq_config=gold_dq_config,
     )
 
     observer = PipelineObserver(
@@ -555,3 +566,78 @@ def assemble_runner(
         pipeline=pipeline,
         tracer=observability.tracer,
     )
+
+
+def _extract_dq_configs(
+    pipeline: BasePipeline,
+) -> tuple[
+    BronzeDQConfigPort | None,
+    SilverDQConfigPort | None,
+    GoldDQConfigPort | None,
+]:
+    """Extract DQ report configs for each layer from pipeline.
+
+    DQ configs are stored in the pipeline's original YAML config reference
+    if available. This function retrieves them for use in PostrunService.
+
+    Args:
+        pipeline: Pipeline instance with potential DQ config reference.
+
+    Returns:
+        Tuple of (bronze_config, silver_config, gold_config).
+        All values may be None if DQ reports are not configured.
+    """
+    from bioetl.infrastructure.schemas.dq_report_config import (
+        BronzeSinkConfig,
+        GoldSinkConfig,
+        SilverSinkConfig,
+    )
+
+    bronze_config: BronzeDQConfigPort | None = None
+    silver_config: SilverDQConfigPort | None = None
+    gold_config: GoldDQConfigPort | None = None
+
+    # Access original YAML config if available through pipeline
+    yaml_config = getattr(pipeline, "_yaml_config", None)
+    if yaml_config is None:
+        return bronze_config, silver_config, gold_config
+
+    sink = getattr(yaml_config, "sink", None)
+    if sink is None:
+        return bronze_config, silver_config, gold_config
+
+    # Extract Bronze DQ config
+    bronze_sink_config = sink.get("bronze")
+    if bronze_sink_config:
+        try:
+            bronze_sink = BronzeSinkConfig.model_validate(
+                bronze_sink_config.model_dump()
+            )
+            if bronze_sink.dq_report.enabled:
+                bronze_config = bronze_sink.dq_report
+        except Exception:
+            pass
+
+    # Extract Silver DQ config
+    silver_sink_config = sink.get("silver")
+    if silver_sink_config:
+        try:
+            silver_sink = SilverSinkConfig.model_validate(
+                silver_sink_config.model_dump()
+            )
+            if silver_sink.dq_report.enabled:
+                silver_config = silver_sink.dq_report
+        except Exception:
+            pass
+
+    # Extract Gold DQ config
+    gold_sink_config = sink.get("gold")
+    if gold_sink_config:
+        try:
+            gold_sink = GoldSinkConfig.model_validate(gold_sink_config.model_dump())
+            if gold_sink.dq_report.enabled:
+                gold_config = gold_sink.dq_report
+        except Exception:
+            pass
+
+    return bronze_config, silver_config, gold_config

--- a/tests/unit/application/core/test_dq_report_integration.py
+++ b/tests/unit/application/core/test_dq_report_integration.py
@@ -1,0 +1,436 @@
+"""Unit tests for DQ report integration in pipeline flow.
+
+Tests the integration of DQ report generation into the pipeline execution flow:
+- BatchExecutor DQ data collection
+- PostrunService DQ report generation
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bioetl.application.core.postrun_service import PostrunService
+from bioetl.application.services.dq_report_service import (
+    DQReportContext,
+    DQReportResult,
+)
+from bioetl.domain.value_objects.dq_result import DQEvaluationStatus, DQResult
+
+if TYPE_CHECKING:
+    from bioetl.domain.ports import LoggerPort
+
+
+@pytest.fixture
+def mock_logger() -> LoggerPort:
+    """Create a mock logger."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_dq_service() -> MagicMock:
+    """Create mock DataQualityService."""
+    service = MagicMock()
+    service.evaluate = AsyncMock(
+        return_value=DQResult(
+            error_rate=0.01,
+            status=DQEvaluationStatus.PASSED,
+            anomalies=(),
+            has_critical=False,
+            check_duration_ms=1.0,
+        )
+    )
+    return service
+
+
+@pytest.fixture
+def mock_lifecycle_service() -> MagicMock:
+    """Create mock MedallionLifecycleService."""
+    from bioetl.application.services.medallion_lifecycle import VacuumResult
+
+    service = MagicMock()
+    service.finalize_run = AsyncMock(
+        return_value=VacuumResult(
+            silver_files_removed=0,
+            gold_files_removed=0,
+            skipped=True,
+        )
+    )
+    return service
+
+
+@pytest.fixture
+def mock_dq_report_service() -> MagicMock:
+    """Create mock DQReportService."""
+    service = MagicMock()
+    service.generate_reports = AsyncMock(
+        return_value=DQReportResult(
+            bronze_report_path=Path("/tmp/bronze_dq.json"),
+            silver_report_path=Path("/tmp/silver_dq.json"),
+            gold_report_path=None,
+            bronze_enabled=True,
+            silver_enabled=True,
+            gold_enabled=False,
+        )
+    )
+    return service
+
+
+@pytest.fixture
+def sample_dq_context() -> DQReportContext:
+    """Create sample DQ context."""
+    return DQReportContext(
+        run_id="test-run-123",
+        pipeline_name="chembl_activity",
+        timestamp=datetime.now(UTC),
+        bronze_records=[b'{"id": 1}', b'{"id": 2}'],
+        bronze_batch_id="batch-001",
+        bronze_source_file="/tmp/bronze/file.jsonl.zst",
+        silver_data=None,
+        silver_target_table="chembl_activity",
+        silver_source_batch_ids=["batch-001"],
+        silver_primary_keys=["activity_id"],
+        silver_input_count=100,
+        silver_quarantined_count=2,
+        gold_data=None,
+        gold_target_table="chembl_activity_gold",
+        dq_soft_threshold=0.05,
+        dq_hard_threshold=0.20,
+    )
+
+
+@pytest.fixture
+def mock_pipeline_config() -> MagicMock:
+    """Create mock PipelineConfig."""
+    config = MagicMock()
+    config.pipeline_name = "chembl_activity"
+    return config
+
+
+@pytest.fixture
+def mock_runtime_config() -> MagicMock:
+    """Create mock RuntimeConfig."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_executor() -> MagicMock:
+    """Create mock executor with metrics."""
+    executor = MagicMock()
+    executor.records_fetched = 100
+    executor.records_bronze = 100
+    executor.records_silver = 98
+    executor.records_gold = 95
+    executor.records_quarantined = 2
+    return executor
+
+
+@pytest.mark.unit
+class TestPostrunServiceDQReports:
+    """Tests for DQ report generation in PostrunService."""
+
+    async def test_dq_reports_generated_when_service_available(
+        self,
+        mock_pipeline_config: MagicMock,
+        mock_runtime_config: MagicMock,
+        mock_dq_service: MagicMock,
+        mock_lifecycle_service: MagicMock,
+        mock_logger: LoggerPort,
+        mock_dq_report_service: MagicMock,
+        mock_executor: MagicMock,
+        sample_dq_context: DQReportContext,
+    ) -> None:
+        """DQ reports should be generated when service is available."""
+        service = PostrunService(
+            config=mock_pipeline_config,
+            runtime=mock_runtime_config,
+            dq_service=mock_dq_service,
+            lifecycle_service=mock_lifecycle_service,
+            metrics=None,
+            logger=mock_logger,
+            dq_report_service=mock_dq_report_service,
+        )
+
+        result = await service.run(
+            executor=mock_executor,
+            dq_context=sample_dq_context,
+        )
+
+        assert result.dq_reports is not None
+        assert result.dq_reports.bronze_report_path is not None
+        assert result.dq_reports.silver_report_path is not None
+        assert result.dq_reports.bronze_enabled is True
+        mock_dq_report_service.generate_reports.assert_called_once()
+
+    async def test_dq_reports_skipped_when_no_context(
+        self,
+        mock_pipeline_config: MagicMock,
+        mock_runtime_config: MagicMock,
+        mock_dq_service: MagicMock,
+        mock_lifecycle_service: MagicMock,
+        mock_logger: LoggerPort,
+        mock_dq_report_service: MagicMock,
+        mock_executor: MagicMock,
+    ) -> None:
+        """DQ reports should be skipped when no context provided."""
+        service = PostrunService(
+            config=mock_pipeline_config,
+            runtime=mock_runtime_config,
+            dq_service=mock_dq_service,
+            lifecycle_service=mock_lifecycle_service,
+            metrics=None,
+            logger=mock_logger,
+            dq_report_service=mock_dq_report_service,
+        )
+
+        result = await service.run(
+            executor=mock_executor,
+            dq_context=None,
+        )
+
+        assert result.dq_reports is None
+        mock_dq_report_service.generate_reports.assert_not_called()
+
+    async def test_dq_reports_skipped_when_no_service(
+        self,
+        mock_pipeline_config: MagicMock,
+        mock_runtime_config: MagicMock,
+        mock_dq_service: MagicMock,
+        mock_lifecycle_service: MagicMock,
+        mock_logger: LoggerPort,
+        mock_executor: MagicMock,
+        sample_dq_context: DQReportContext,
+    ) -> None:
+        """DQ reports should be skipped when service not available."""
+        service = PostrunService(
+            config=mock_pipeline_config,
+            runtime=mock_runtime_config,
+            dq_service=mock_dq_service,
+            lifecycle_service=mock_lifecycle_service,
+            metrics=None,
+            logger=mock_logger,
+            dq_report_service=None,  # No service
+        )
+
+        result = await service.run(
+            executor=mock_executor,
+            dq_context=sample_dq_context,
+        )
+
+        assert result.dq_reports is None
+
+    async def test_dq_reports_error_handling(
+        self,
+        mock_pipeline_config: MagicMock,
+        mock_runtime_config: MagicMock,
+        mock_dq_service: MagicMock,
+        mock_lifecycle_service: MagicMock,
+        mock_logger: LoggerPort,
+        mock_executor: MagicMock,
+        sample_dq_context: DQReportContext,
+    ) -> None:
+        """DQ report errors should not fail the pipeline."""
+        mock_dq_report_service = MagicMock()
+        mock_dq_report_service.generate_reports = AsyncMock(
+            side_effect=Exception("Report generation failed")
+        )
+
+        service = PostrunService(
+            config=mock_pipeline_config,
+            runtime=mock_runtime_config,
+            dq_service=mock_dq_service,
+            lifecycle_service=mock_lifecycle_service,
+            metrics=None,
+            logger=mock_logger,
+            dq_report_service=mock_dq_report_service,
+        )
+
+        # Should not raise, just return None for dq_reports
+        result = await service.run(
+            executor=mock_executor,
+            dq_context=sample_dq_context,
+        )
+
+        assert result.dq_reports is None
+        # Error should be logged
+        mock_logger.error.assert_called()
+
+    async def test_dq_configs_passed_to_service(
+        self,
+        mock_pipeline_config: MagicMock,
+        mock_runtime_config: MagicMock,
+        mock_dq_service: MagicMock,
+        mock_lifecycle_service: MagicMock,
+        mock_logger: LoggerPort,
+        mock_dq_report_service: MagicMock,
+        mock_executor: MagicMock,
+        sample_dq_context: DQReportContext,
+    ) -> None:
+        """DQ configs should be passed to generate_reports."""
+        bronze_config = MagicMock()
+        bronze_config.enabled = True
+        silver_config = MagicMock()
+        silver_config.enabled = True
+        gold_config = None
+
+        service = PostrunService(
+            config=mock_pipeline_config,
+            runtime=mock_runtime_config,
+            dq_service=mock_dq_service,
+            lifecycle_service=mock_lifecycle_service,
+            metrics=None,
+            logger=mock_logger,
+            dq_report_service=mock_dq_report_service,
+            bronze_dq_config=bronze_config,
+            silver_dq_config=silver_config,
+            gold_dq_config=gold_config,
+        )
+
+        await service.run(
+            executor=mock_executor,
+            dq_context=sample_dq_context,
+        )
+
+        # Verify configs were passed
+        mock_dq_report_service.generate_reports.assert_called_once_with(
+            context=sample_dq_context,
+            bronze_config=bronze_config,
+            silver_config=silver_config,
+            gold_config=gold_config,
+        )
+
+
+@pytest.mark.unit
+class TestBatchExecutorDQCollection:
+    """Tests for DQ data collection in BatchExecutor."""
+
+    def test_should_collect_dq_data_returns_true_when_service_available(
+        self,
+    ) -> None:
+        """_should_collect_dq_data returns True when dq_report_service is set."""
+        # Create mock services with dq_report_service
+        services = MagicMock()
+        services.dq_report_service = MagicMock()
+
+        # Create executor (partial mock)
+        executor = MagicMock()
+        executor._services = services
+        executor._should_collect_dq_data = (
+            lambda: executor._services.dq_report_service is not None
+        )
+
+        assert executor._should_collect_dq_data() is True
+
+    def test_should_collect_dq_data_returns_false_when_no_service(
+        self,
+    ) -> None:
+        """_should_collect_dq_data returns False when dq_report_service is None."""
+        services = MagicMock()
+        services.dq_report_service = None
+
+        executor = MagicMock()
+        executor._services = services
+        executor._should_collect_dq_data = (
+            lambda: executor._services.dq_report_service is not None
+        )
+
+        assert executor._should_collect_dq_data() is False
+
+    def test_get_dq_context_returns_none_when_disabled(
+        self,
+    ) -> None:
+        """get_dq_context returns None when DQ collection is disabled."""
+        services = MagicMock()
+        services.dq_report_service = None
+
+        executor = MagicMock()
+        executor._services = services
+        executor._should_collect_dq_data = (
+            lambda: executor._services.dq_report_service is not None
+        )
+        executor.get_dq_context = lambda: (
+            None if not executor._should_collect_dq_data() else MagicMock()
+        )
+
+        assert executor.get_dq_context() is None
+
+
+@pytest.mark.unit
+class TestDQReportContext:
+    """Tests for DQReportContext dataclass."""
+
+    def test_dq_report_context_creation(self) -> None:
+        """Test DQReportContext creation with all fields."""
+        context = DQReportContext(
+            run_id="test-123",
+            pipeline_name="chembl_activity",
+            timestamp=datetime.now(UTC),
+            bronze_records=[b'{"id": 1}'],
+            bronze_batch_id="batch-001",
+            silver_data=None,
+            silver_target_table="chembl_activity",
+        )
+
+        assert context.run_id == "test-123"
+        assert context.pipeline_name == "chembl_activity"
+        assert context.bronze_batch_id == "batch-001"
+        assert context.silver_target_table == "chembl_activity"
+        assert context.dq_soft_threshold == 0.05  # Default
+        assert context.dq_hard_threshold == 0.20  # Default
+
+    def test_dq_report_context_with_custom_thresholds(self) -> None:
+        """Test DQReportContext creation with custom thresholds."""
+        context = DQReportContext(
+            run_id="test-123",
+            pipeline_name="chembl_activity",
+            timestamp=datetime.now(UTC),
+            dq_soft_threshold=0.10,
+            dq_hard_threshold=0.30,
+        )
+
+        assert context.dq_soft_threshold == 0.10
+        assert context.dq_hard_threshold == 0.30
+
+
+@pytest.mark.unit
+class TestDQReportResult:
+    """Tests for DQReportResult dataclass."""
+
+    def test_dq_report_result_no_reports(self) -> None:
+        """Test DQReportResult with no reports generated."""
+        result = DQReportResult()
+
+        assert result.any_generated is False
+        assert result.reports_count == 0
+
+    def test_dq_report_result_with_reports(self) -> None:
+        """Test DQReportResult with reports generated."""
+        result = DQReportResult(
+            bronze_report_path=Path("/tmp/bronze_dq.json"),
+            silver_report_path=Path("/tmp/silver_dq.json"),
+            gold_report_path=None,
+            bronze_enabled=True,
+            silver_enabled=True,
+            gold_enabled=False,
+        )
+
+        assert result.any_generated is True
+        assert result.reports_count == 2
+
+    def test_dq_report_result_all_enabled(self) -> None:
+        """Test DQReportResult with all reports generated."""
+        result = DQReportResult(
+            bronze_report_path=Path("/tmp/bronze_dq.json"),
+            silver_report_path=Path("/tmp/silver_dq.json"),
+            gold_report_path=Path("/tmp/gold_dq.json"),
+            bronze_enabled=True,
+            silver_enabled=True,
+            gold_enabled=True,
+        )
+
+        assert result.any_generated is True
+        assert result.reports_count == 3

--- a/tests/unit/application/core/test_postrun_service.py
+++ b/tests/unit/application/core/test_postrun_service.py
@@ -398,9 +398,10 @@ class TestPostrunResult:
             skipped=False,
         )
 
-        result = PostrunResult(dq=dq_result, vacuum=vacuum_result)
+        result = PostrunResult(dq=dq_result, dq_reports=None, vacuum=vacuum_result)
 
         assert result.dq == dq_result
+        assert result.dq_reports is None
         assert result.vacuum == vacuum_result
 
 

--- a/tests/unit/application/core/test_runner.py
+++ b/tests/unit/application/core/test_runner.py
@@ -798,21 +798,24 @@ class TestPipelineRunnerCheckDataQuality:
             VacuumResult,
         )
 
+        from bioetl.application.core.postrun_service import PostrunResult
+
         services = create_mock_services()
 
         postrun_service = MagicMock(spec=PostrunService)
-        postrun_service.run_dq_checks = AsyncMock(
-            return_value=DQResult(
-                error_rate=0.0,
-                status=DQEvaluationStatus.PASSED,
-                anomalies=(),
-                has_critical=False,
-                check_duration_ms=0.0,
-            )
-        )
-        postrun_service.run_vacuum_if_enabled = AsyncMock(
-            return_value=VacuumResult(
-                silver_files_removed=0, gold_files_removed=0, skipped=True
+        postrun_service.run = AsyncMock(
+            return_value=PostrunResult(
+                dq=DQResult(
+                    error_rate=0.0,
+                    status=DQEvaluationStatus.PASSED,
+                    anomalies=(),
+                    has_critical=False,
+                    check_duration_ms=0.0,
+                ),
+                dq_reports=None,
+                vacuum=VacuumResult(
+                    silver_files_removed=0, gold_files_removed=0, skipped=True
+                ),
             )
         )
         postrun_service.cleanup = AsyncMock()
@@ -839,5 +842,5 @@ class TestPipelineRunnerCheckDataQuality:
 
         await runner.run()
 
-        # PostrunService.run_dq_checks should be called during run()
-        postrun_service.run_dq_checks.assert_called_once()
+        # PostrunService.run should be called during run() (includes DQ checks, DQ reports, and VACUUM)
+        postrun_service.run.assert_called_once()


### PR DESCRIPTION
Integrate DQReportService.generate_reports() into the pipeline execution flow to enable automatic generation of DQ reports for Bronze, Silver, and Gold layers.

Changes:
- Add DQ data accumulation in BatchExecutor:
  - Collect Bronze records as bytes (JSON-encoded)
  - Collect Silver/Gold records for DataFrame creation
  - Track batch IDs and Bronze file paths
  - Add get_dq_context() method to build DQReportContext

- Update PostrunService with DQ report generation:
  - Add dq_report_service and DQ config parameters to __init__
  - Add _generate_dq_reports() method with error handling
  - Update PostrunResult to include dq_reports field
  - Update run() to call DQ report generation

- Update PipelineRunner:
  - Call postrun_service.run() with dq_context
  - Remove separate calls to run_dq_checks/run_vacuum_if_enabled

- Update assemble_runner() in pipeline_factory:
  - Add _extract_dq_configs() helper to extract DQ configs from YAML
  - Pass DQ configs and service to PostrunService

- Add unit tests for DQ report integration:
  - PostrunService DQ report generation tests
  - BatchExecutor DQ data collection tests
  - DQReportContext and DQReportResult tests

DQ reports are only generated when dq_report.enabled: true in YAML config.
By default, all DQ reports are disabled (enabled: false).