### PR TITLE
Standardize column order in BioETL

### DIFF
--- a/src/bioetl/domain/schemas/__init__.py
+++ b/src/bioetl/domain/schemas/__init__.py
@@ -1,0 +1,23 @@
+"""Domain schemas for ETL records.
+
+Provides:
+- Base Pandera schemas for validation
+- Canonical column ordering utilities
+- Provider-specific schema definitions
+"""
+
+from __future__ import annotations
+
+from bioetl.domain.schemas.column_order import (
+    ALL_SYSTEM_FIELDS,
+    DQ_FIELDS_SUFFIX,
+    SYSTEM_FIELDS_PREFIX,
+    canonical_column_order,
+)
+
+__all__ = [
+    "ALL_SYSTEM_FIELDS",
+    "DQ_FIELDS_SUFFIX",
+    "SYSTEM_FIELDS_PREFIX",
+    "canonical_column_order",
+]

--- a/src/bioetl/domain/schemas/column_order.py
+++ b/src/bioetl/domain/schemas/column_order.py
@@ -1,0 +1,91 @@
+"""Canonical column ordering for ETL records.
+
+Defines the standard order of columns across all layers (Silver, Gold).
+Per RULES.md §2.4 Metadata Fields and ADR-014 Deterministic Writes.
+
+This module provides:
+- SYSTEM_FIELDS_PREFIX: Fields that MUST appear first
+- DQ_FIELDS_SUFFIX: DQ flags that MUST appear last (if present)
+- canonical_column_order(): Function to reorder any column list
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+__all__ = [
+    "ALL_SYSTEM_FIELDS",
+    "DQ_FIELDS_SUFFIX",
+    "SYSTEM_FIELDS_PREFIX",
+    "canonical_column_order",
+]
+
+
+# System fields that MUST appear first (in order)
+# These are lineage/metadata fields per RULES.md §2.4
+SYSTEM_FIELDS_PREFIX: Final[tuple[str, ...]] = (
+    "entity_id",
+    "content_hash",
+    "_run_id",
+    "_run_type",
+    "_source_batch_id",
+    "_ingestion_ts",
+    "_index",
+)
+
+# DQ flags that MUST appear last (in order), if present
+# Not all schemas have these fields
+DQ_FIELDS_SUFFIX: Final[tuple[str, ...]] = (
+    "_dq_warn",
+    "_dq_error",
+)
+
+# All system fields (prefix + suffix) for quick membership check
+ALL_SYSTEM_FIELDS: Final[frozenset[str]] = frozenset(
+    SYSTEM_FIELDS_PREFIX + DQ_FIELDS_SUFFIX
+)
+
+
+def _filter_present(
+    ordered_fields: tuple[str, ...], present: frozenset[str]
+) -> list[str]:
+    """Filter ordered fields to those present in the column set."""
+    return [f for f in ordered_fields if f in present]
+
+
+def canonical_column_order(columns: list[str] | tuple[str, ...]) -> list[str]:
+    """Reorder columns to canonical order.
+
+    Order:
+    1. System prefix fields (entity_id, content_hash, _run_id, ...)
+    2. Business fields (sorted alphabetically)
+    3. DQ suffix fields (_dq_warn, _dq_error) if present
+
+    Args:
+        columns: Unordered list/tuple of column names.
+
+    Returns:
+        Columns in canonical order.
+
+    Example:
+        >>> canonical_column_order(["_dq_warn", "name", "entity_id", "_run_id", "content_hash"])
+        ['entity_id', 'content_hash', '_run_id', 'name', '_dq_warn']
+
+        >>> canonical_column_order(["activity_id", "_index", "entity_id", "content_hash"])
+        ['entity_id', 'content_hash', '_index', 'activity_id']
+
+        >>> canonical_column_order(["z_field", "a_field", "entity_id", "_run_type"])
+        ['entity_id', '_run_type', 'a_field', 'z_field']
+    """
+    columns_set = frozenset(columns)
+
+    # 1. System prefix fields (preserve defined order, skip missing)
+    prefix = _filter_present(SYSTEM_FIELDS_PREFIX, columns_set)
+
+    # 2. DQ suffix fields (preserve defined order, skip missing)
+    suffix = _filter_present(DQ_FIELDS_SUFFIX, columns_set)
+
+    # 3. Business fields (sorted alphabetically)
+    business = sorted(columns_set - ALL_SYSTEM_FIELDS)
+
+    return prefix + business + suffix

--- a/src/bioetl/infrastructure/schemas/silver.py
+++ b/src/bioetl/infrastructure/schemas/silver.py
@@ -1,6 +1,12 @@
 """Silver layer schemas for Delta Lake tables.
 
 Defines the PyArrow schemas for various entities in the Silver layer.
+
+Column Order Convention (per RULES.md §2.4 and ADR-014):
+1. System prefix fields (entity_id, content_hash, _run_id, _run_type,
+   _source_batch_id, _ingestion_ts, _index) - MUST be first
+2. Business fields - sorted alphabetically
+3. DQ suffix fields (_dq_warn, _dq_error) - MUST be last (if present)
 """
 
 from __future__ import annotations
@@ -11,83 +17,68 @@ import pyarrow as pa
 # See: https://www.ebi.ac.uk/chembl/api/data/activity
 CHEMBL_ACTIVITY_SCHEMA = pa.schema(
     [
-        # System fields
+        # === System prefix (MUST be first, per RULES.md §2.4) ===
         pa.field("entity_id", pa.string()),
         pa.field("content_hash", pa.string()),
-        # Primary identifier
-        pa.field("activity_id", pa.string()),
-        # Core identifiers
-        pa.field("molecule_chembl_id", pa.string()),
-        pa.field("target_chembl_id", pa.string()),
-        pa.field("assay_chembl_id", pa.string()),
-        pa.field("document_chembl_id", pa.string()),
-        pa.field("record_id", pa.int64()),
-        pa.field("src_id", pa.int64()),
-        # Molecule data
-        pa.field("canonical_smiles", pa.string()),
-        pa.field("molecule_pref_name", pa.string()),
-        pa.field("parent_molecule_chembl_id", pa.string()),
-        # Target data
-        pa.field("target_pref_name", pa.string()),
-        pa.field("target_organism", pa.string()),
-        pa.field(
-            "target_taxonomy_id", pa.string()
-        ),  # Standardized name (was target_tax_id)
-        # Assay data
-        pa.field("assay_type", pa.string()),
-        pa.field("assay_description", pa.string()),
-        pa.field("assay_variant_accession", pa.string()),
-        pa.field("assay_variant_mutation", pa.string()),
-        # BAO (BioAssay Ontology) annotations
-        pa.field("bao_endpoint", pa.string()),
-        pa.field("bao_format", pa.string()),
-        pa.field("bao_label", pa.string()),
-        # Raw activity values
-        pa.field("type", pa.string()),
-        pa.field("value", pa.float64()),
-        pa.field("units", pa.string()),
-        pa.field("relation", pa.string()),
-        pa.field("upper_value", pa.float64()),
-        pa.field("text_value", pa.string()),
-        # Standardized activity values
-        pa.field("standard_type", pa.string()),
-        pa.field("standard_value", pa.float64()),
-        pa.field("standard_units", pa.string()),
-        pa.field("standard_relation", pa.string()),
-        pa.field("standard_upper_value", pa.float64()),
-        pa.field("standard_text_value", pa.string()),
-        pa.field("standard_flag", pa.int64()),
-        # Derived metrics
-        pa.field("pchembl_value", pa.float64()),
-        # Ligand efficiency metrics (flattened)
-        pa.field("ligand_efficiency_bei", pa.float64()),
-        pa.field("ligand_efficiency_le", pa.float64()),
-        pa.field("ligand_efficiency_lle", pa.float64()),
-        pa.field("ligand_efficiency_sei", pa.float64()),
-        # Units ontology
-        pa.field("qudt_units", pa.string()),
-        pa.field("uo_units", pa.string()),
-        # Document/Publication data
-        pa.field("document_journal", pa.string()),
-        pa.field("document_year", pa.int64()),
-        # Quality annotations
-        pa.field("activity_comment", pa.string()),
-        pa.field("data_validity_comment", pa.string()),
-        pa.field("data_validity_description", pa.string()),
-        pa.field("potential_duplicate", pa.int64()),
-        # Action type (flattened from ChEMBL API nested structure)
-        pa.field("action_type_action_type", pa.string()),
-        pa.field("action_type_description", pa.string()),
-        pa.field("action_type_parent_type", pa.string()),
-        # Activity properties
-        pa.field("activity_properties", pa.string()),  # JSON string
-        pa.field("toid", pa.int64()),
-        # Lineage metadata
         pa.field("_run_id", pa.string()),
         pa.field("_run_type", pa.string()),
         pa.field("_source_batch_id", pa.string()),
         pa.field("_ingestion_ts", pa.string()),
         pa.field("_index", pa.int64()),
+        # === Business fields (alphabetical order) ===
+        pa.field("action_type_action_type", pa.string()),
+        pa.field("action_type_description", pa.string()),
+        pa.field("action_type_parent_type", pa.string()),
+        pa.field("activity_comment", pa.string()),
+        pa.field("activity_id", pa.string()),
+        pa.field("activity_properties", pa.string()),  # JSON string
+        pa.field("assay_chembl_id", pa.string()),
+        pa.field("assay_description", pa.string()),
+        pa.field("assay_type", pa.string()),
+        pa.field("assay_variant_accession", pa.string()),
+        pa.field("assay_variant_mutation", pa.string()),
+        pa.field("bao_endpoint", pa.string()),
+        pa.field("bao_format", pa.string()),
+        pa.field("bao_label", pa.string()),
+        pa.field("canonical_smiles", pa.string()),
+        pa.field("data_validity_comment", pa.string()),
+        pa.field("data_validity_description", pa.string()),
+        pa.field("document_chembl_id", pa.string()),
+        pa.field("document_journal", pa.string()),
+        pa.field("document_year", pa.int64()),
+        pa.field("ligand_efficiency_bei", pa.float64()),
+        pa.field("ligand_efficiency_le", pa.float64()),
+        pa.field("ligand_efficiency_lle", pa.float64()),
+        pa.field("ligand_efficiency_sei", pa.float64()),
+        pa.field("molecule_chembl_id", pa.string()),
+        pa.field("molecule_pref_name", pa.string()),
+        pa.field("parent_molecule_chembl_id", pa.string()),
+        pa.field("pchembl_value", pa.float64()),
+        pa.field("potential_duplicate", pa.int64()),
+        pa.field("qudt_units", pa.string()),
+        pa.field("record_id", pa.int64()),
+        pa.field("relation", pa.string()),
+        pa.field("src_id", pa.int64()),
+        pa.field("standard_flag", pa.int64()),
+        pa.field("standard_relation", pa.string()),
+        pa.field("standard_text_value", pa.string()),
+        pa.field("standard_type", pa.string()),
+        pa.field("standard_units", pa.string()),
+        pa.field("standard_upper_value", pa.float64()),
+        pa.field("standard_value", pa.float64()),
+        pa.field("target_chembl_id", pa.string()),
+        pa.field("target_organism", pa.string()),
+        pa.field("target_pref_name", pa.string()),
+        pa.field(
+            "target_taxonomy_id", pa.string()
+        ),  # Standardized name (was target_tax_id)
+        pa.field("text_value", pa.string()),
+        pa.field("toid", pa.int64()),
+        pa.field("type", pa.string()),
+        pa.field("units", pa.string()),
+        pa.field("uo_units", pa.string()),
+        pa.field("upper_value", pa.float64()),
+        pa.field("value", pa.float64()),
     ]
 )
 
@@ -96,42 +87,46 @@ CHEMBL_ACTIVITY_SCHEMA = pa.schema(
 # and application/pipelines/pubchem/transformer.py (PubChemCompoundTransformer)
 PUBCHEM_COMPOUND_SCHEMA = pa.schema(
     [
+        # === System prefix (MUST be first, per RULES.md §2.4) ===
         pa.field("entity_id", pa.string()),
         pa.field("content_hash", pa.string()),
-        pa.field("cid", pa.string()),  # Domain entity uses str for cid
-        pa.field("molecular_formula", pa.string()),
-        pa.field(
-            "molecular_weight", pa.float64()
-        ),  # Transformed to float by transformer
-        pa.field("canonical_smiles", pa.string()),
-        pa.field("isomeric_smiles", pa.string()),
-        pa.field("inchi", pa.string()),
-        pa.field("inchikey", pa.string()),  # Matches domain entity field name
-        pa.field("iupac_name", pa.string()),
         pa.field("_run_id", pa.string()),
         pa.field("_run_type", pa.string()),
         pa.field("_source_batch_id", pa.string()),
         pa.field("_ingestion_ts", pa.string()),
         pa.field("_index", pa.int64()),
+        # === Business fields (alphabetical order) ===
+        pa.field("canonical_smiles", pa.string()),
+        pa.field("cid", pa.string()),  # Domain entity uses str for cid
+        pa.field("inchi", pa.string()),
+        pa.field("inchikey", pa.string()),  # Matches domain entity field name
+        pa.field("isomeric_smiles", pa.string()),
+        pa.field("iupac_name", pa.string()),
+        pa.field("molecular_formula", pa.string()),
+        pa.field(
+            "molecular_weight", pa.float64()
+        ),  # Transformed to float by transformer
     ]
 )
 
 # Schema for UniProt Protein
 UNIPROT_PROTEIN_SCHEMA = pa.schema(
     [
+        # === System prefix (MUST be first, per RULES.md §2.4) ===
         pa.field("entity_id", pa.string()),
-        pa.field("accession", pa.string()),
-        pa.field("entry_name", pa.string()),
-        pa.field("protein_name", pa.string()),
-        pa.field("gene_names", pa.list_(pa.string())),
-        pa.field("organism_id", pa.int64()),
-        pa.field("sequence_length", pa.int64()),
         pa.field("content_hash", pa.string()),
         pa.field("_run_id", pa.string()),
         pa.field("_run_type", pa.string()),
         pa.field("_source_batch_id", pa.string()),
         pa.field("_ingestion_ts", pa.string()),
         pa.field("_index", pa.int64()),
+        # === Business fields (alphabetical order) ===
+        pa.field("accession", pa.string()),
+        pa.field("entry_name", pa.string()),
+        pa.field("gene_names", pa.list_(pa.string())),
+        pa.field("organism_id", pa.int64()),
+        pa.field("protein_name", pa.string()),
+        pa.field("sequence_length", pa.int64()),
     ]
 )
 
@@ -139,23 +134,24 @@ UNIPROT_PROTEIN_SCHEMA = pa.schema(
 # Maps ChEMBL target IDs to UniProt accessions
 UNIPROT_ID_MAPPING_SCHEMA = pa.schema(
     [
-        # System fields
+        # === System prefix (MUST be first, per RULES.md §2.4) ===
         pa.field("entity_id", pa.string()),
         pa.field("content_hash", pa.string()),
-        # Primary key (source identifier)
-        pa.field("target_chembl_id", pa.string()),
-        # Mapped identifier (nullable - None if not found)
-        pa.field("uniprot_accession", pa.string()),
-        # Mapping status: 'found', 'not_found', 'error'
-        pa.field("mapping_status", pa.string()),
-        # DQ warning flag (True for not_found)
-        pa.field("_dq_warn", pa.bool_()),
-        # Lineage metadata
         pa.field("_run_id", pa.string()),
         pa.field("_run_type", pa.string()),
         pa.field("_source_batch_id", pa.string()),
         pa.field("_ingestion_ts", pa.string()),
         pa.field("_index", pa.int64()),
+        # === Business fields (alphabetical order) ===
+        # Mapping status: 'found', 'not_found', 'error'
+        pa.field("mapping_status", pa.string()),
+        # Primary key (source identifier)
+        pa.field("target_chembl_id", pa.string()),
+        # Mapped identifier (nullable - None if not found)
+        pa.field("uniprot_accession", pa.string()),
+        # === DQ suffix (MUST be last, if present) ===
+        # DQ warning flag (True for not_found)
+        pa.field("_dq_warn", pa.bool_()),
     ]
 )
 
@@ -164,50 +160,50 @@ UNIPROT_ID_MAPPING_SCHEMA = pa.schema(
 # See: https://www.nlm.nih.gov/bsd/licensee/elements_descriptions.html
 PUBMED_PUBLICATION_SCHEMA = pa.schema(
     [
-        # System fields
+        # === System prefix (MUST be first, per RULES.md §2.4) ===
         pa.field("entity_id", pa.string()),
         pa.field("content_hash", pa.string()),
-        # Primary identifiers
-        pa.field("pmid", pa.string()),
-        pa.field("doi", pa.string()),
-        pa.field("pmc_id", pa.string()),
-        # Title and abstract
-        pa.field("title", pa.string()),
-        pa.field("abstract", pa.string()),
-        # Journal information
-        pa.field("journal", pa.string()),
-        pa.field("journal_abbrev", pa.string()),
-        pa.field("issn", pa.string()),
-        pa.field("volume", pa.string()),
-        pa.field("issue", pa.string()),
-        pa.field("pages", pa.string()),
-        # Authors
-        pa.field("authors", pa.string()),  # JSON-serialized list
-        # Dates (ISO format strings)
-        pa.field("pub_date", pa.string()),
-        pa.field("year", pa.int64()),
-        pa.field("publication_year", pa.int64()),  # Legacy alias for year
-        pa.field("accepted_date", pa.string()),
-        pa.field("received_date", pa.string()),
-        pa.field("revised_date", pa.string()),
-        pa.field("epub_date", pa.string()),
-        # Classification
-        pa.field("publication_types", pa.list_(pa.string())),
-        pa.field("keywords", pa.list_(pa.string())),
-        pa.field("mesh_terms", pa.list_(pa.string())),
-        # Additional metadata
-        pa.field("language", pa.string()),
-        pa.field("country", pa.string()),
-        pa.field("source", pa.string()),
-        # Lookup metadata
-        pa.field("_lookup_method", pa.string()),
-        pa.field("_original_id", pa.string()),
-        # Lineage metadata
         pa.field("_run_id", pa.string()),
         pa.field("_run_type", pa.string()),
         pa.field("_source_batch_id", pa.string()),
         pa.field("_ingestion_ts", pa.string()),
         pa.field("_index", pa.int64()),
+        # === Business fields (alphabetical order) ===
+        # Lookup metadata
+        pa.field("_lookup_method", pa.string()),
+        pa.field("_original_id", pa.string()),
+        # Title and abstract
+        pa.field("abstract", pa.string()),
+        # Dates (ISO format strings)
+        pa.field("accepted_date", pa.string()),
+        # Authors
+        pa.field("authors", pa.string()),  # JSON-serialized list
+        # Additional metadata
+        pa.field("country", pa.string()),
+        # Primary identifiers
+        pa.field("doi", pa.string()),
+        pa.field("epub_date", pa.string()),
+        # Journal information
+        pa.field("issn", pa.string()),
+        pa.field("issue", pa.string()),
+        pa.field("journal", pa.string()),
+        pa.field("journal_abbrev", pa.string()),
+        # Classification
+        pa.field("keywords", pa.list_(pa.string())),
+        pa.field("language", pa.string()),
+        pa.field("mesh_terms", pa.list_(pa.string())),
+        pa.field("pages", pa.string()),
+        pa.field("pmc_id", pa.string()),
+        pa.field("pmid", pa.string()),
+        pa.field("pub_date", pa.string()),
+        pa.field("publication_types", pa.list_(pa.string())),
+        pa.field("publication_year", pa.int64()),  # Legacy alias for year
+        pa.field("received_date", pa.string()),
+        pa.field("revised_date", pa.string()),
+        pa.field("source", pa.string()),
+        pa.field("title", pa.string()),
+        pa.field("volume", pa.string()),
+        pa.field("year", pa.int64()),
     ]
 )
 
@@ -215,66 +211,57 @@ PUBMED_PUBLICATION_SCHEMA = pa.schema(
 # See: https://www.ebi.ac.uk/chembl/api/data/assay
 CHEMBL_ASSAY_SCHEMA = pa.schema(
     [
-        # System fields
+        # === System prefix (MUST be first, per RULES.md §2.4) ===
         pa.field("entity_id", pa.string()),
         pa.field("content_hash", pa.string()),
-        # Primary identifier
-        pa.field("assay_chembl_id", pa.string()),
-        # Core identifiers
-        pa.field("target_chembl_id", pa.string()),
-        pa.field("document_chembl_id", pa.string()),
-        pa.field("cell_chembl_id", pa.string()),
-        pa.field("tissue_chembl_id", pa.string()),
-        pa.field("src_id", pa.int64()),
-        pa.field("src_assay_id", pa.string()),
+        pa.field("_run_id", pa.string()),
+        pa.field("_run_type", pa.string()),
+        pa.field("_source_batch_id", pa.string()),
+        pa.field("_ingestion_ts", pa.string()),
+        pa.field("_index", pa.int64()),
+        # === Business fields (alphabetical order) ===
         pa.field("aidx", pa.string()),
-        # Assay classification
-        pa.field("assay_type", pa.string()),
-        pa.field("assay_type_description", pa.string()),
         pa.field("assay_category", pa.string()),
-        pa.field("assay_test_type", pa.string()),
+        pa.field("assay_cell_type", pa.string()),
+        pa.field("assay_chembl_id", pa.string()),
+        pa.field("assay_classifications", pa.string()),  # JSON string
         pa.field("assay_group", pa.string()),
-        # Biological context
         pa.field("assay_organism", pa.string()),
+        pa.field("assay_parameters", pa.string()),  # JSON string
+        pa.field("assay_pref_name", pa.string()),
+        pa.field("assay_strain", pa.string()),
+        pa.field("assay_subcellular_fraction", pa.string()),
         pa.field(
             "assay_taxonomy_id", pa.int64()
         ),  # Standardized name (was assay_tax_id)
-        pa.field("assay_cell_type", pa.string()),
+        pa.field("assay_test_type", pa.string()),
         pa.field("assay_tissue", pa.string()),
-        pa.field("assay_strain", pa.string()),
-        pa.field("assay_subcellular_fraction", pa.string()),
-        # BAO (BioAssay Ontology) annotations
+        pa.field("assay_type", pa.string()),
+        pa.field("assay_type_description", pa.string()),
         pa.field("bao_format", pa.string()),
         pa.field("bao_label", pa.string()),
-        # Description and confidence
-        pa.field("description", pa.string()),
-        pa.field("confidence_score", pa.int64()),
+        pa.field("cell_chembl_id", pa.string()),
         pa.field("confidence_description", pa.string()),
-        pa.field("relationship_type", pa.string()),
+        pa.field("confidence_score", pa.int64()),
+        pa.field("description", pa.string()),
+        pa.field("document_chembl_id", pa.string()),
         pa.field("relationship_description", pa.string()),
-        # Additional metadata
-        pa.field("assay_pref_name", pa.string()),
+        pa.field("relationship_type", pa.string()),
         pa.field("score", pa.float64()),
+        pa.field("src_assay_id", pa.string()),
+        pa.field("src_id", pa.int64()),
+        pa.field("target_chembl_id", pa.string()),
+        pa.field("tissue_chembl_id", pa.string()),
         # Variant information (flattened from ChEMBL API nested structure)
         pa.field("variant_accession", pa.string()),
         pa.field("variant_isoform", pa.string()),
         pa.field("variant_mutation", pa.string()),
         pa.field("variant_organism", pa.string()),
         pa.field("variant_sequence", pa.string()),
+        pa.field("variant_sequence_json", pa.string()),  # Forensic: original JSON
         pa.field(
             "variant_taxonomy_id", pa.int64()
         ),  # Standardized name (was variant_tax_id)
-        # Forensic: original JSON
-        pa.field("variant_sequence_json", pa.string()),
-        # Complex fields (stored as JSON strings)
-        pa.field("assay_classifications", pa.string()),  # JSON string
-        pa.field("assay_parameters", pa.string()),  # JSON string
-        # Lineage metadata
-        pa.field("_run_id", pa.string()),
-        pa.field("_run_type", pa.string()),
-        pa.field("_source_batch_id", pa.string()),
-        pa.field("_ingestion_ts", pa.string()),
-        pa.field("_index", pa.int64()),
     ]
 )
 
@@ -282,44 +269,42 @@ CHEMBL_ASSAY_SCHEMA = pa.schema(
 # See: https://www.ebi.ac.uk/chembl/api/data/target
 CHEMBL_TARGET_SCHEMA = pa.schema(
     [
-        # System fields
+        # === System prefix (MUST be first, per RULES.md §2.4) ===
         pa.field("entity_id", pa.string()),
         pa.field("content_hash", pa.string()),
-        # Primary identifier
-        pa.field("target_chembl_id", pa.string()),
-        # Core metadata
-        pa.field("pref_name", pa.string()),
-        pa.field("target_type", pa.string()),
-        pa.field("organism", pa.string()),
-        pa.field("taxonomy_id", pa.int64()),  # Standardized name (was tax_id)
-        pa.field("species_group_flag", pa.bool_()),
-        pa.field("description", pa.string()),
-        pa.field("downgraded", pa.bool_()),
-        pa.field("dap_id", pa.int64()),
-        pa.field("pipeline_stages", pa.string()),
-        pa.field("target_constraints", pa.string()),
-        # Complex fields (JSON strings)
-        pa.field("target_components", pa.string()),
-        pa.field("cross_references", pa.string()),
-        pa.field("target_component_synonyms", pa.string()),
-        # Flattened component fields
-        pa.field("component_accessions", pa.list_(pa.string())),
-        pa.field("component_ids", pa.list_(pa.int64())),
-        pa.field("component_types", pa.list_(pa.string())),
-        pa.field("component_relationships", pa.list_(pa.string())),
-        pa.field("component_descriptions", pa.list_(pa.string())),
-        pa.field("component_organisms", pa.list_(pa.string())),
-        pa.field(
-            "component_taxonomy_ids", pa.list_(pa.int64())
-        ),  # Standardized name (was component_tax_ids)
-        # Note: protein_classifications not available in /target endpoint
-        # Use /target_component endpoint instead (CHEMBL_TARGET_COMPONENT_SCHEMA)
-        # Lineage metadata
         pa.field("_run_id", pa.string()),
         pa.field("_run_type", pa.string()),
         pa.field("_source_batch_id", pa.string()),
         pa.field("_ingestion_ts", pa.string()),
         pa.field("_index", pa.int64()),
+        # === Business fields (alphabetical order) ===
+        # Flattened component fields
+        pa.field("component_accessions", pa.list_(pa.string())),
+        pa.field("component_descriptions", pa.list_(pa.string())),
+        pa.field("component_ids", pa.list_(pa.int64())),
+        pa.field("component_organisms", pa.list_(pa.string())),
+        pa.field("component_relationships", pa.list_(pa.string())),
+        pa.field(
+            "component_taxonomy_ids", pa.list_(pa.int64())
+        ),  # Standardized name (was component_tax_ids)
+        pa.field("component_types", pa.list_(pa.string())),
+        # Complex fields (JSON strings)
+        pa.field("cross_references", pa.string()),
+        pa.field("dap_id", pa.int64()),
+        pa.field("description", pa.string()),
+        pa.field("downgraded", pa.bool_()),
+        pa.field("organism", pa.string()),
+        pa.field("pipeline_stages", pa.string()),
+        pa.field("pref_name", pa.string()),
+        pa.field("species_group_flag", pa.bool_()),
+        pa.field("target_chembl_id", pa.string()),
+        pa.field("target_component_synonyms", pa.string()),
+        pa.field("target_components", pa.string()),
+        pa.field("target_constraints", pa.string()),
+        pa.field("target_type", pa.string()),
+        pa.field("taxonomy_id", pa.int64()),  # Standardized name (was tax_id)
+        # Note: protein_classifications not available in /target endpoint
+        # Use /target_component endpoint instead (CHEMBL_TARGET_COMPONENT_SCHEMA)
     ]
 )
 
@@ -327,29 +312,27 @@ CHEMBL_TARGET_SCHEMA = pa.schema(
 # See: https://www.ebi.ac.uk/chembl/api/data/target_component
 CHEMBL_TARGET_COMPONENT_SCHEMA = pa.schema(
     [
-        # System fields
+        # === System prefix (MUST be first, per RULES.md §2.4) ===
         pa.field("entity_id", pa.string()),
         pa.field("content_hash", pa.string()),
-        # Primary identifier
-        pa.field("component_id", pa.int64()),
-        # Core metadata
-        pa.field("accession", pa.string()),
-        pa.field("component_type", pa.string()),
-        pa.field("description", pa.string()),
-        pa.field("organism", pa.string()),
-        pa.field("taxonomy_id", pa.int64()),  # Standardized name (was tax_id)
-        # Complex fields (JSON strings)
-        pa.field("target_component_synonyms", pa.string()),
-        pa.field("target_component_xrefs", pa.string()),
-        pa.field("protein_classifications", pa.string()),  # Forensic JSON
-        # Flattened fields (extracted from protein_classifications)
-        pa.field("protein_classification_ids", pa.list_(pa.int64())),
-        # Lineage metadata
         pa.field("_run_id", pa.string()),
         pa.field("_run_type", pa.string()),
         pa.field("_source_batch_id", pa.string()),
         pa.field("_ingestion_ts", pa.string()),
         pa.field("_index", pa.int64()),
+        # === Business fields (alphabetical order) ===
+        pa.field("accession", pa.string()),
+        pa.field("component_id", pa.int64()),
+        pa.field("component_type", pa.string()),
+        pa.field("description", pa.string()),
+        pa.field("organism", pa.string()),
+        # Flattened fields (extracted from protein_classifications)
+        pa.field("protein_classification_ids", pa.list_(pa.int64())),
+        pa.field("protein_classifications", pa.string()),  # Forensic JSON
+        # Complex fields (JSON strings)
+        pa.field("target_component_synonyms", pa.string()),
+        pa.field("target_component_xrefs", pa.string()),
+        pa.field("taxonomy_id", pa.int64()),  # Standardized name (was tax_id)
     ]
 )
 
@@ -357,30 +340,27 @@ CHEMBL_TARGET_COMPONENT_SCHEMA = pa.schema(
 # See: https://www.ebi.ac.uk/chembl/api/data/cell_line
 CHEMBL_CELL_LINE_SCHEMA = pa.schema(
     [
-        # System fields
+        # === System prefix (MUST be first, per RULES.md §2.4) ===
         pa.field("entity_id", pa.string()),
         pa.field("content_hash", pa.string()),
-        # Primary identifier
-        pa.field("cell_chembl_id", pa.string()),
-        # Core metadata
-        pa.field("cell_name", pa.string()),
-        pa.field("cell_description", pa.string()),
-        # Source information
-        pa.field("cell_source_tissue", pa.string()),
-        pa.field("cell_source_organism", pa.string()),
-        pa.field(
-            "cell_source_taxonomy_id", pa.int64()
-        ),  # Standardized name (was cell_source_tax_id)
-        # External identifiers
-        pa.field("cellosaurus_id", pa.string()),
-        pa.field("cl_lincs_id", pa.string()),
-        pa.field("efo_id", pa.string()),
-        # Lineage metadata
         pa.field("_run_id", pa.string()),
         pa.field("_run_type", pa.string()),
         pa.field("_source_batch_id", pa.string()),
         pa.field("_ingestion_ts", pa.string()),
         pa.field("_index", pa.int64()),
+        # === Business fields (alphabetical order) ===
+        pa.field("cell_chembl_id", pa.string()),
+        pa.field("cell_description", pa.string()),
+        pa.field("cell_name", pa.string()),
+        pa.field("cell_source_organism", pa.string()),
+        pa.field(
+            "cell_source_taxonomy_id", pa.int64()
+        ),  # Standardized name (was cell_source_tax_id)
+        pa.field("cell_source_tissue", pa.string()),
+        # External identifiers
+        pa.field("cellosaurus_id", pa.string()),
+        pa.field("cl_lincs_id", pa.string()),
+        pa.field("efo_id", pa.string()),
     ]
 )
 
@@ -388,38 +368,33 @@ CHEMBL_CELL_LINE_SCHEMA = pa.schema(
 # See: https://www.ebi.ac.uk/chembl/api/data/document
 CHEMBL_PUBLICATION_SCHEMA = pa.schema(
     [
-        # System fields
+        # === System prefix (MUST be first, per RULES.md §2.4) ===
         pa.field("entity_id", pa.string()),
         pa.field("content_hash", pa.string()),
-        # Primary identifier
-        pa.field("document_chembl_id", pa.string()),
-        # Publication identifiers
-        pa.field(
-            "pmid", pa.string()
-        ),  # Standardized name (was pubmed_id), numeric string for cross-provider consistency
-        pa.field("doi", pa.string()),
-        pa.field("patent_id", pa.string()),
-        # Core metadata
-        pa.field("title", pa.string()),
-        pa.field("authors", pa.string()),
-        pa.field("abstract", pa.string()),
-        pa.field("doc_type", pa.string()),
-        # Journal information
-        pa.field("journal", pa.string()),
-        pa.field("journal_full_title", pa.string()),
-        pa.field("year", pa.int64()),
-        pa.field("volume", pa.string()),
-        pa.field("issue", pa.string()),
-        pa.field("first_page", pa.string()),
-        pa.field("last_page", pa.string()),
-        # Source information
-        pa.field("src_id", pa.int64()),
-        # Lineage metadata
         pa.field("_run_id", pa.string()),
         pa.field("_run_type", pa.string()),
         pa.field("_source_batch_id", pa.string()),
         pa.field("_ingestion_ts", pa.string()),
         pa.field("_index", pa.int64()),
+        # === Business fields (alphabetical order) ===
+        pa.field("abstract", pa.string()),
+        pa.field("authors", pa.string()),
+        pa.field("doc_type", pa.string()),
+        pa.field("document_chembl_id", pa.string()),
+        pa.field("doi", pa.string()),
+        pa.field("first_page", pa.string()),
+        pa.field("issue", pa.string()),
+        pa.field("journal", pa.string()),
+        pa.field("journal_full_title", pa.string()),
+        pa.field("last_page", pa.string()),
+        pa.field("patent_id", pa.string()),
+        pa.field(
+            "pmid", pa.string()
+        ),  # Standardized name (was pubmed_id), numeric string for cross-provider consistency
+        pa.field("src_id", pa.int64()),
+        pa.field("title", pa.string()),
+        pa.field("volume", pa.string()),
+        pa.field("year", pa.int64()),
     ]
 )
 
@@ -428,22 +403,21 @@ CHEMBL_PUBLICATION_SCHEMA = pa.schema(
 # See: https://www.ebi.ac.uk/chembl/api/data/document
 CHEMBL_DOCUMENT_TERM_SCHEMA = pa.schema(
     [
-        # System fields
+        # === System prefix (MUST be first, per RULES.md §2.4) ===
         pa.field("entity_id", pa.string()),
         pa.field("content_hash", pa.string()),
-        # Composite key fields
-        pa.field("document_chembl_id", pa.string()),
-        pa.field("term", pa.string()),
-        pa.field("term_type", pa.string()),
-        # MeSH-specific fields
-        pa.field("mesh_id", pa.string()),
-        pa.field("qualifier", pa.string()),
-        # Lineage metadata
         pa.field("_run_id", pa.string()),
         pa.field("_run_type", pa.string()),
         pa.field("_source_batch_id", pa.string()),
         pa.field("_ingestion_ts", pa.string()),
         pa.field("_index", pa.int64()),
+        # === Business fields (alphabetical order) ===
+        pa.field("document_chembl_id", pa.string()),
+        # MeSH-specific fields
+        pa.field("mesh_id", pa.string()),
+        pa.field("qualifier", pa.string()),
+        pa.field("term", pa.string()),
+        pa.field("term_type", pa.string()),
     ]
 )
 
@@ -451,75 +425,72 @@ CHEMBL_DOCUMENT_TERM_SCHEMA = pa.schema(
 # See: https://www.ebi.ac.uk/chembl/api/data/molecule
 CHEMBL_MOLECULE_SCHEMA = pa.schema(
     [
-        # System fields
+        # === System prefix (MUST be first, per RULES.md §2.4) ===
         pa.field("entity_id", pa.string()),
         pa.field("content_hash", pa.string()),
-        # Primary identifier
-        pa.field("molecule_chembl_id", pa.string()),
-        # Core metadata
-        pa.field("pref_name", pa.string()),
-        pa.field("molecule_type", pa.string()),
-        pa.field("structure_type", pa.string()),
-        pa.field("max_phase", pa.int64()),
-        pa.field("first_approval", pa.int64()),
-        pa.field("chirality", pa.int64()),
-        pa.field("dosed_ingredient", pa.int64()),
-        pa.field("availability_type", pa.int64()),
-        # USAN naming
-        pa.field("usan_stem", pa.string()),
-        pa.field("usan_stem_definition", pa.string()),
-        pa.field("usan_substem", pa.string()),
-        pa.field("usan_year", pa.int64()),
-        # Other metadata
-        pa.field("helm_notation", pa.string()),
-        pa.field("molecule_species", pa.string()),
-        # Flags
-        pa.field("oral", pa.bool_()),
-        pa.field("parenteral", pa.bool_()),
-        pa.field("topical", pa.bool_()),
-        pa.field("black_box_warning", pa.int64()),
-        pa.field("natural_product", pa.int64()),
-        pa.field("first_in_class", pa.int64()),
-        pa.field("prodrug", pa.int64()),
-        pa.field("therapeutic_flag", pa.bool_()),
-        pa.field("withdrawn_flag", pa.bool_()),
-        pa.field("inorganic_flag", pa.int64()),
-        pa.field("polymer_flag", pa.int64()),
-        # Complex fields (JSON strings)
-        pa.field("molecule_hierarchy", pa.string()),
-        pa.field("molecule_properties", pa.string()),
-        pa.field("molecule_structures", pa.string()),
-        pa.field("molecule_synonyms", pa.string()),
-        pa.field("cross_references", pa.string()),
-        pa.field("atc_classifications", pa.string()),
-        # Flattened Hierarchy
-        pa.field("hierarchy_parent_chembl_id", pa.string()),
-        pa.field("hierarchy_active_chembl_id", pa.string()),
-        pa.field("hierarchy_child_chembl_id", pa.string()),
-        # Flattened Properties
-        pa.field("property_alogp", pa.float64()),
-        pa.field("property_mw_freebase", pa.float64()),
-        pa.field("property_full_mwt", pa.float64()),
-        pa.field("property_hba", pa.int64()),
-        pa.field("property_hbd", pa.int64()),
-        pa.field("property_psa", pa.float64()),
-        pa.field("property_rtb", pa.int64()),
-        pa.field("property_ro5_violations", pa.int64()),
-        pa.field("property_heavy_atoms", pa.int64()),
-        pa.field("property_aromatic_rings", pa.int64()),
-        pa.field("property_qed_weighted", pa.float64()),
-        pa.field("property_full_molformula", pa.string()),
-        pa.field("property_ro3_pass", pa.string()),
-        # Flattened Structures (unified naming without structure_ prefix)
-        pa.field("canonical_smiles", pa.string()),
-        pa.field("standard_inchi", pa.string()),
-        pa.field("inchi_key", pa.string()),
-        # Lineage metadata
         pa.field("_run_id", pa.string()),
         pa.field("_run_type", pa.string()),
         pa.field("_source_batch_id", pa.string()),
         pa.field("_ingestion_ts", pa.string()),
         pa.field("_index", pa.int64()),
+        # === Business fields (alphabetical order) ===
+        pa.field("atc_classifications", pa.string()),
+        pa.field("availability_type", pa.int64()),
+        pa.field("black_box_warning", pa.int64()),
+        # Flattened Structures (unified naming without structure_ prefix)
+        pa.field("canonical_smiles", pa.string()),
+        pa.field("chirality", pa.int64()),
+        # Complex fields (JSON strings)
+        pa.field("cross_references", pa.string()),
+        pa.field("dosed_ingredient", pa.int64()),
+        pa.field("first_approval", pa.int64()),
+        pa.field("first_in_class", pa.int64()),
+        pa.field("helm_notation", pa.string()),
+        # Flattened Hierarchy
+        pa.field("hierarchy_active_chembl_id", pa.string()),
+        pa.field("hierarchy_child_chembl_id", pa.string()),
+        pa.field("hierarchy_parent_chembl_id", pa.string()),
+        pa.field("inchi_key", pa.string()),
+        pa.field("inorganic_flag", pa.int64()),
+        pa.field("max_phase", pa.int64()),
+        pa.field("molecule_chembl_id", pa.string()),
+        pa.field("molecule_hierarchy", pa.string()),
+        pa.field("molecule_properties", pa.string()),
+        pa.field("molecule_species", pa.string()),
+        pa.field("molecule_structures", pa.string()),
+        pa.field("molecule_synonyms", pa.string()),
+        pa.field("molecule_type", pa.string()),
+        pa.field("natural_product", pa.int64()),
+        # Flags
+        pa.field("oral", pa.bool_()),
+        pa.field("parenteral", pa.bool_()),
+        pa.field("polymer_flag", pa.int64()),
+        pa.field("pref_name", pa.string()),
+        pa.field("prodrug", pa.int64()),
+        # Flattened Properties
+        pa.field("property_alogp", pa.float64()),
+        pa.field("property_aromatic_rings", pa.int64()),
+        pa.field("property_full_molformula", pa.string()),
+        pa.field("property_full_mwt", pa.float64()),
+        pa.field("property_hba", pa.int64()),
+        pa.field("property_hbd", pa.int64()),
+        pa.field("property_heavy_atoms", pa.int64()),
+        pa.field("property_mw_freebase", pa.float64()),
+        pa.field("property_psa", pa.float64()),
+        pa.field("property_qed_weighted", pa.float64()),
+        pa.field("property_ro3_pass", pa.string()),
+        pa.field("property_ro5_violations", pa.int64()),
+        pa.field("property_rtb", pa.int64()),
+        pa.field("standard_inchi", pa.string()),
+        pa.field("structure_type", pa.string()),
+        pa.field("therapeutic_flag", pa.bool_()),
+        pa.field("topical", pa.bool_()),
+        # USAN naming
+        pa.field("usan_stem", pa.string()),
+        pa.field("usan_stem_definition", pa.string()),
+        pa.field("usan_substem", pa.string()),
+        pa.field("usan_year", pa.int64()),
+        pa.field("withdrawn_flag", pa.bool_()),
     ]
 )
 
@@ -527,26 +498,25 @@ CHEMBL_MOLECULE_SCHEMA = pa.schema(
 # See: https://www.ebi.ac.uk/chembl/api/data/compound_record
 CHEMBL_COMPOUND_RECORD_SCHEMA = pa.schema(
     [
-        # System fields
+        # === System prefix (MUST be first, per RULES.md §2.4) ===
         pa.field("entity_id", pa.string()),
         pa.field("content_hash", pa.string()),
-        # Primary identifier
-        pa.field("record_id", pa.int64()),
-        # Foreign keys
-        pa.field("molecule_chembl_id", pa.string()),
-        pa.field("document_chembl_id", pa.string()),
-        # Original compound names from document
-        pa.field("compound_key", pa.string()),
-        pa.field("compound_name", pa.string()),
-        # Source information
-        pa.field("src_id", pa.int64()),
-        pa.field("src_compound_id", pa.string()),
-        # Lineage metadata
         pa.field("_run_id", pa.string()),
         pa.field("_run_type", pa.string()),
         pa.field("_source_batch_id", pa.string()),
         pa.field("_ingestion_ts", pa.string()),
         pa.field("_index", pa.int64()),
+        # === Business fields (alphabetical order) ===
+        # Original compound names from document
+        pa.field("compound_key", pa.string()),
+        pa.field("compound_name", pa.string()),
+        # Foreign keys
+        pa.field("document_chembl_id", pa.string()),
+        pa.field("molecule_chembl_id", pa.string()),
+        pa.field("record_id", pa.int64()),
+        # Source information
+        pa.field("src_compound_id", pa.string()),
+        pa.field("src_id", pa.int64()),
     ]
 )
 
@@ -554,29 +524,28 @@ CHEMBL_COMPOUND_RECORD_SCHEMA = pa.schema(
 # See: https://www.ebi.ac.uk/chembl/api/data/document_similarity
 CHEMBL_DOCUMENT_SIMILARITY_SCHEMA = pa.schema(
     [
-        # System fields
+        # === System prefix (MUST be first, per RULES.md §2.4) ===
         pa.field("entity_id", pa.string()),
         pa.field("content_hash", pa.string()),
-        # Primary key
-        pa.field("sim_id", pa.int64()),
-        # Foreign keys
-        pa.field("doc_1", pa.int64()),
-        pa.field("doc_2", pa.int64()),
-        # PubMed identifiers (numeric strings for cross-provider consistency)
-        pa.field("pubmed_id1", pa.string()),
-        pa.field("pubmed_id2", pa.string()),
-        # Tanimoto coefficients
-        pa.field("tid_tani", pa.float64()),
-        pa.field("mol_tani", pa.float64()),
-        # Derived metrics
-        pa.field("avg_tani", pa.float64()),
-        pa.field("max_tani", pa.float64()),
-        # Lineage metadata
         pa.field("_run_id", pa.string()),
         pa.field("_run_type", pa.string()),
         pa.field("_source_batch_id", pa.string()),
         pa.field("_ingestion_ts", pa.string()),
         pa.field("_index", pa.int64()),
+        # === Business fields (alphabetical order) ===
+        # Derived metrics
+        pa.field("avg_tani", pa.float64()),
+        # Foreign keys
+        pa.field("doc_1", pa.int64()),
+        pa.field("doc_2", pa.int64()),
+        pa.field("max_tani", pa.float64()),
+        # Tanimoto coefficients
+        pa.field("mol_tani", pa.float64()),
+        # PubMed identifiers (numeric strings for cross-provider consistency)
+        pa.field("pubmed_id1", pa.string()),
+        pa.field("pubmed_id2", pa.string()),
+        pa.field("sim_id", pa.int64()),
+        pa.field("tid_tani", pa.float64()),
     ]
 )
 
@@ -584,51 +553,53 @@ CHEMBL_DOCUMENT_SIMILARITY_SCHEMA = pa.schema(
 # See: https://api.semanticscholar.org/api-docs/graph
 SEMANTICSCHOLAR_PUBLICATION_SCHEMA = pa.schema(
     [
-        # System fields
+        # === System prefix (MUST be first, per RULES.md §2.4) ===
         pa.field("entity_id", pa.string()),
         pa.field("content_hash", pa.string()),
         pa.field("_run_id", pa.string()),
         pa.field("_run_type", pa.string()),
         pa.field("_source_batch_id", pa.string()),
         pa.field("_ingestion_ts", pa.string()),
-        pa.field("_dq_warn", pa.bool_()),
-        pa.field("_dq_error", pa.bool_()),
         pa.field("_index", pa.int64()),
-        # Primary key
-        pa.field("paper_id", pa.string()),
-        # External IDs
-        pa.field("doi", pa.string()),
-        pa.field("pmid", pa.string()),
-        pa.field("pmcid", pa.string()),
-        pa.field("arxiv_id", pa.string()),
-        pa.field("corpus_id", pa.int64()),
-        # Core fields
-        pa.field("title", pa.string()),
-        pa.field("abstract", pa.string()),
-        pa.field("tldr", pa.string()),
-        pa.field("year", pa.int64()),
-        pa.field("publication_date", pa.string()),
-        # Journal/Venue
-        pa.field("journal", pa.string()),
-        pa.field("volume", pa.string()),
-        pa.field("pages", pa.string()),
-        pa.field("venue", pa.string()),
-        # Metrics
-        pa.field("citation_count", pa.int64()),
-        pa.field("reference_count", pa.int64()),
-        # Open Access
-        pa.field("is_oa", pa.bool_()),
-        pa.field("open_access_url", pa.string()),
-        pa.field("oa_status", pa.string()),
-        # Classification (JSON strings)
-        pa.field("fields_of_study", pa.string()),
-        pa.field("publication_types", pa.string()),
-        pa.field("authors", pa.string()),
-        # Source tracking
-        pa.field("source", pa.string()),
+        # === Business fields (alphabetical order) ===
         # Lookup metadata
         pa.field("_lookup_method", pa.string()),
         pa.field("_original_doi", pa.string()),
+        pa.field("abstract", pa.string()),
+        # External IDs
+        pa.field("arxiv_id", pa.string()),
+        # Classification (JSON strings)
+        pa.field("authors", pa.string()),
+        # Metrics
+        pa.field("citation_count", pa.int64()),
+        pa.field("corpus_id", pa.int64()),
+        pa.field("doi", pa.string()),
+        pa.field("fields_of_study", pa.string()),
+        # Open Access
+        pa.field("is_oa", pa.bool_()),
+        # Journal/Venue
+        pa.field("journal", pa.string()),
+        pa.field("oa_status", pa.string()),
+        pa.field("open_access_url", pa.string()),
+        pa.field("pages", pa.string()),
+        # Primary key
+        pa.field("paper_id", pa.string()),
+        pa.field("pmcid", pa.string()),
+        pa.field("pmid", pa.string()),
+        pa.field("publication_date", pa.string()),
+        pa.field("publication_types", pa.string()),
+        pa.field("reference_count", pa.int64()),
+        # Source tracking
+        pa.field("source", pa.string()),
+        # Core fields
+        pa.field("title", pa.string()),
+        pa.field("tldr", pa.string()),
+        pa.field("venue", pa.string()),
+        pa.field("volume", pa.string()),
+        pa.field("year", pa.int64()),
+        # === DQ suffix (MUST be last, if present) ===
+        pa.field("_dq_warn", pa.bool_()),
+        pa.field("_dq_error", pa.bool_()),
     ]
 )
 
@@ -636,7 +607,7 @@ SEMANTICSCHOLAR_PUBLICATION_SCHEMA = pa.schema(
 # See: https://api.crossref.org/swagger-ui/index.html
 CROSSREF_PUBLICATION_SCHEMA = pa.schema(
     [
-        # System fields
+        # === System prefix (MUST be first, per RULES.md §2.4) ===
         pa.field("entity_id", pa.string()),
         pa.field("content_hash", pa.string()),
         pa.field("_run_id", pa.string()),
@@ -644,34 +615,35 @@ CROSSREF_PUBLICATION_SCHEMA = pa.schema(
         pa.field("_source_batch_id", pa.string()),
         pa.field("_ingestion_ts", pa.string()),
         pa.field("_index", pa.int64()),
-        # Primary key
-        pa.field("doi", pa.string()),
-        # Core fields
-        pa.field("title", pa.string()),
-        pa.field("abstract", pa.string()),
-        pa.field("authors", pa.string()),  # JSON-serialized list
-        pa.field("journal", pa.string()),
-        pa.field("issn", pa.list_(pa.string())),
-        pa.field("publisher", pa.string()),
-        pa.field("volume", pa.string()),
-        pa.field("issue", pa.string()),
-        pa.field("first_page", pa.string()),
-        pa.field("last_page", pa.string()),
-        # Date fields
-        pa.field("year", pa.int64()),
-        pa.field("published_print", pa.string()),
-        pa.field("published_online", pa.string()),
-        # Metadata
-        pa.field("doc_type", pa.string()),
-        pa.field("citation_count", pa.int64()),
-        pa.field("reference_count", pa.int64()),
-        pa.field("language", pa.string()),
-        pa.field("license_url", pa.string()),
-        pa.field("subjects", pa.list_(pa.string())),
-        pa.field("source", pa.string()),
+        # === Business fields (alphabetical order) ===
         # Lookup metadata
         pa.field("_lookup_method", pa.string()),
         pa.field("_original_doi", pa.string()),
+        pa.field("abstract", pa.string()),
+        pa.field("authors", pa.string()),  # JSON-serialized list
+        pa.field("citation_count", pa.int64()),
+        # Metadata
+        pa.field("doc_type", pa.string()),
+        # Primary key
+        pa.field("doi", pa.string()),
+        pa.field("first_page", pa.string()),
+        pa.field("issn", pa.list_(pa.string())),
+        pa.field("issue", pa.string()),
+        # Core fields
+        pa.field("journal", pa.string()),
+        pa.field("language", pa.string()),
+        pa.field("last_page", pa.string()),
+        pa.field("license_url", pa.string()),
+        # Date fields
+        pa.field("published_online", pa.string()),
+        pa.field("published_print", pa.string()),
+        pa.field("publisher", pa.string()),
+        pa.field("reference_count", pa.int64()),
+        pa.field("source", pa.string()),
+        pa.field("subjects", pa.list_(pa.string())),
+        pa.field("title", pa.string()),
+        pa.field("volume", pa.string()),
+        pa.field("year", pa.int64()),
     ]
 )
 
@@ -679,7 +651,7 @@ CROSSREF_PUBLICATION_SCHEMA = pa.schema(
 # See: https://docs.openalex.org/api-entities/works
 OPENALEX_PUBLICATION_SCHEMA = pa.schema(
     [
-        # System fields
+        # === System prefix (MUST be first, per RULES.md §2.4) ===
         pa.field("entity_id", pa.string()),
         pa.field("content_hash", pa.string()),
         pa.field("_run_id", pa.string()),
@@ -687,33 +659,34 @@ OPENALEX_PUBLICATION_SCHEMA = pa.schema(
         pa.field("_source_batch_id", pa.string()),
         pa.field("_ingestion_ts", pa.string()),
         pa.field("_index", pa.int64()),
-        # Primary key
-        pa.field("openalex_id", pa.string()),
-        # Core fields
-        pa.field("doi", pa.string()),
-        pa.field("title", pa.string()),
-        pa.field("abstract", pa.string()),
-        pa.field("authors", pa.string()),  # JSON-serialized list
-        pa.field("concepts", pa.list_(pa.string())),
-        # Journal info
-        pa.field("journal", pa.string()),
-        pa.field("issn", pa.string()),
-        pa.field("publisher", pa.string()),
-        # Date fields
-        pa.field("year", pa.int64()),
-        pa.field("publication_date", pa.string()),
-        # Metadata
-        pa.field("doc_type", pa.string()),
-        pa.field("is_oa", pa.bool_()),
-        pa.field("oa_status", pa.string()),
-        # OpenAlex source field: cited_by_count
-        # Unified BioETL field: citation_count (standardized across all providers)
-        pa.field("citation_count", pa.int64()),
-        pa.field("language", pa.string()),
-        pa.field("source", pa.string()),
+        # === Business fields (alphabetical order) ===
         # Lookup metadata
         pa.field("_lookup_method", pa.string()),
         pa.field("_original_doi", pa.string()),
+        pa.field("abstract", pa.string()),
+        pa.field("authors", pa.string()),  # JSON-serialized list
+        # OpenAlex source field: cited_by_count
+        # Unified BioETL field: citation_count (standardized across all providers)
+        pa.field("citation_count", pa.int64()),
+        pa.field("concepts", pa.list_(pa.string())),
+        # Metadata
+        pa.field("doc_type", pa.string()),
+        # Core fields
+        pa.field("doi", pa.string()),
+        pa.field("is_oa", pa.bool_()),
+        # Journal info
+        pa.field("issn", pa.string()),
+        pa.field("journal", pa.string()),
+        pa.field("language", pa.string()),
+        pa.field("oa_status", pa.string()),
+        # Primary key
+        pa.field("openalex_id", pa.string()),
+        # Date fields
+        pa.field("publication_date", pa.string()),
+        pa.field("publisher", pa.string()),
+        pa.field("source", pa.string()),
+        pa.field("title", pa.string()),
+        pa.field("year", pa.int64()),
     ]
 )
 
@@ -721,29 +694,28 @@ OPENALEX_PUBLICATION_SCHEMA = pa.schema(
 # See: https://www.ebi.ac.uk/chembl/api/data/protein_class
 CHEMBL_PROTEIN_CLASS_SCHEMA = pa.schema(
     [
-        # System fields
+        # === System prefix (MUST be first, per RULES.md §2.4) ===
         pa.field("entity_id", pa.string()),
         pa.field("content_hash", pa.string()),
-        # Primary identifier
-        pa.field("protein_class_id", pa.int64()),
-        # Hierarchy
-        pa.field("parent_id", pa.int64()),
-        pa.field("class_level", pa.int64()),
-        # Classification data
-        pa.field("pref_name", pa.string()),
-        pa.field("short_name", pa.string()),
-        pa.field("protein_class_desc", pa.string()),
-        pa.field("definition", pa.string()),
-        # Additional metadata
-        pa.field("sort_order", pa.int64()),
-        pa.field("replaced_by", pa.int64()),
-        pa.field("downgraded", pa.int64()),
-        # Lineage metadata
         pa.field("_run_id", pa.string()),
         pa.field("_run_type", pa.string()),
         pa.field("_source_batch_id", pa.string()),
         pa.field("_ingestion_ts", pa.string()),
         pa.field("_index", pa.int64()),
+        # === Business fields (alphabetical order) ===
+        # Hierarchy
+        pa.field("class_level", pa.int64()),
+        # Classification data
+        pa.field("definition", pa.string()),
+        # Additional metadata
+        pa.field("downgraded", pa.int64()),
+        pa.field("parent_id", pa.int64()),
+        pa.field("pref_name", pa.string()),
+        pa.field("protein_class_desc", pa.string()),
+        pa.field("protein_class_id", pa.int64()),
+        pa.field("replaced_by", pa.int64()),
+        pa.field("short_name", pa.string()),
+        pa.field("sort_order", pa.int64()),
     ]
 )
 
@@ -751,32 +723,32 @@ CHEMBL_PROTEIN_CLASS_SCHEMA = pa.schema(
 # See: https://www.ebi.ac.uk/chembl/api/data/assay_parameters
 CHEMBL_ASSAY_PARAMETERS_SCHEMA = pa.schema(
     [
-        # System fields
+        # === System prefix (MUST be first, per RULES.md §2.4) ===
         pa.field("entity_id", pa.string()),
         pa.field("content_hash", pa.string()),
-        # Primary identifier (surrogate)
-        pa.field("assay_param_id", pa.int64()),
-        # Foreign key
-        pa.field("assay_chembl_id", pa.string()),
-        # Parameter type
-        pa.field("type", pa.string()),
-        # Raw values
-        pa.field("relation", pa.string()),
-        pa.field("value", pa.float64()),
-        pa.field("units", pa.string()),
-        pa.field("text_value", pa.string()),
-        pa.field("comments", pa.string()),
-        # Standardized values
-        pa.field("standard_type", pa.string()),
-        pa.field("standard_relation", pa.string()),
-        pa.field("standard_value", pa.float64()),
-        pa.field("standard_units", pa.string()),
-        pa.field("standard_text_value", pa.string()),
-        # Lineage metadata
         pa.field("_run_id", pa.string()),
         pa.field("_run_type", pa.string()),
         pa.field("_source_batch_id", pa.string()),
         pa.field("_ingestion_ts", pa.string()),
         pa.field("_index", pa.int64()),
+        # === Business fields (alphabetical order) ===
+        # Foreign key
+        pa.field("assay_chembl_id", pa.string()),
+        # Primary identifier (surrogate)
+        pa.field("assay_param_id", pa.int64()),
+        pa.field("comments", pa.string()),
+        # Raw values
+        pa.field("relation", pa.string()),
+        # Standardized values
+        pa.field("standard_relation", pa.string()),
+        pa.field("standard_text_value", pa.string()),
+        pa.field("standard_type", pa.string()),
+        pa.field("standard_units", pa.string()),
+        pa.field("standard_value", pa.float64()),
+        pa.field("text_value", pa.string()),
+        # Parameter type
+        pa.field("type", pa.string()),
+        pa.field("units", pa.string()),
+        pa.field("value", pa.float64()),
     ]
 )

--- a/src/bioetl/infrastructure/storage/gold_writer.py
+++ b/src/bioetl/infrastructure/storage/gold_writer.py
@@ -274,6 +274,8 @@ class GoldWriter(BaseDeltaWriter):
             records: A list of dictionaries representing merged records.
             primary_keys: Optional list of column names for sorting.
         """
+        from bioetl.domain.schemas.column_order import canonical_column_order
+
         if not records:
             self.logger.warning(
                 "No records to write for merged Gold",
@@ -281,8 +283,12 @@ class GoldWriter(BaseDeltaWriter):
             )
             return
 
-        # Convert to Arrow and sort if primary keys provided
+        # Convert to Arrow and apply canonical column order
         arrow_table = pa.Table.from_pylist(records)
+
+        # Enforce canonical column order (ADR-014, RULES.md §2.4)
+        ordered_columns = canonical_column_order(list(arrow_table.column_names))
+        arrow_table = arrow_table.select(ordered_columns)
 
         if primary_keys:
             valid_keys = [pk for pk in primary_keys if pk in arrow_table.schema.names]
@@ -626,11 +632,14 @@ class GoldWriter(BaseDeltaWriter):
         Delta Lake doesn't support null type, so we convert null columns to string.
         This includes nested null types (e.g., list<null>).
         """
+        from bioetl.domain.schemas.column_order import canonical_column_order
+
         arrow_data = pa.Table.from_pylist(records)
 
-        # Enforce deterministic column order
-        column_names = sorted(arrow_data.column_names)
-        arrow_data = arrow_data.select(column_names)
+        # Enforce canonical column order (not alphabetical!)
+        # Per ADR-014 Deterministic Writes and RULES.md §2.4
+        ordered_columns = canonical_column_order(list(arrow_data.column_names))
+        arrow_data = arrow_data.select(ordered_columns)
 
         # Check if schema needs sanitization (contains null types anywhere)
         # Use lowercase check since PyArrow may print "null" or "Null"

--- a/src/bioetl/infrastructure/storage/silver_writer.py
+++ b/src/bioetl/infrastructure/storage/silver_writer.py
@@ -174,6 +174,8 @@ class SilverWriter(BaseDeltaWriter):
         primary_keys: list[str],
     ) -> pa.Table:
         """Prepare Arrow table from records with schema filtering and sorting."""
+        from bioetl.domain.schemas.column_order import canonical_column_order
+
         schema_fields = set(schema.names)
         string_fields = {
             field.name
@@ -210,6 +212,11 @@ class SilverWriter(BaseDeltaWriter):
         ]
         arrow_data = pa.Table.from_pylist(filtered_records, schema=schema)
 
+        # Enforce canonical column order (ADR-014, RULES.md §2.4)
+        ordered_columns = canonical_column_order(list(arrow_data.column_names))
+        arrow_data = arrow_data.select(ordered_columns)
+
+        # Sort rows by primary keys for deterministic writes
         if primary_keys:
             arrow_data = arrow_data.sort_by([(pk, "ascending") for pk in primary_keys])
         return arrow_data
@@ -1086,6 +1093,8 @@ class SilverWriter(BaseDeltaWriter):
             records: A list of dictionaries representing merged records.
             primary_keys: Optional list of column names for sorting.
         """
+        from bioetl.domain.schemas.column_order import canonical_column_order
+
         if not records:
             self.logger.warning(
                 "No records to write for merged Silver",
@@ -1096,6 +1105,10 @@ class SilverWriter(BaseDeltaWriter):
         # Infer schema from records using PyArrow
         arrow_table = pa.Table.from_pylist(records)
         schema = arrow_table.schema
+
+        # Enforce canonical column order (ADR-014, RULES.md §2.4)
+        ordered_columns = canonical_column_order(list(arrow_table.column_names))
+        arrow_table = arrow_table.select(ordered_columns)
 
         # Sort by primary keys if provided for deterministic writes
         if primary_keys:

--- a/tests/architecture/test_column_order.py
+++ b/tests/architecture/test_column_order.py
@@ -1,0 +1,192 @@
+"""Architecture tests for canonical column ordering.
+
+Verifies that all PyArrow schemas follow the canonical column order
+defined in domain/schemas/column_order.py.
+
+Per RULES.md §2.4 and ADR-014.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pyarrow as pa
+
+from bioetl.domain.schemas.column_order import (
+    ALL_SYSTEM_FIELDS,
+    DQ_FIELDS_SUFFIX,
+    SYSTEM_FIELDS_PREFIX,
+    canonical_column_order,
+)
+from bioetl.infrastructure.schemas import silver as silver_schemas
+
+
+def get_all_pyarrow_schemas() -> list[tuple[str, pa.Schema]]:
+    """Collect all PyArrow schema constants from silver module."""
+    schemas = []
+    for name in dir(silver_schemas):
+        obj = getattr(silver_schemas, name)
+        if name.endswith("_SCHEMA") and isinstance(obj, pa.Schema):
+            schemas.append((name, obj))
+    return schemas
+
+
+class TestCanonicalColumnOrderFunction:
+    """Unit tests for canonical_column_order function."""
+
+    def test_reorders_prefix_first(self) -> None:
+        """System prefix fields should come first."""
+        columns = ["name", "_run_id", "entity_id", "content_hash"]
+        result = canonical_column_order(columns)
+        assert result[:3] == ["entity_id", "content_hash", "_run_id"]
+
+    def test_business_fields_sorted(self) -> None:
+        """Business fields should be sorted alphabetically."""
+        columns = ["entity_id", "zebra", "alpha", "content_hash"]
+        result = canonical_column_order(columns)
+        business = [c for c in result if c not in ALL_SYSTEM_FIELDS]
+        assert business == ["alpha", "zebra"]
+
+    def test_dq_suffix_last(self) -> None:
+        """DQ fields should come last."""
+        columns = ["_dq_warn", "name", "entity_id", "_dq_error"]
+        result = canonical_column_order(columns)
+        assert result[-2:] == ["_dq_warn", "_dq_error"]
+
+    def test_preserves_all_columns(self) -> None:
+        """All input columns should be in output."""
+        columns = ["a", "b", "entity_id", "_run_id", "_dq_warn"]
+        result = canonical_column_order(columns)
+        assert set(result) == set(columns)
+
+    def test_handles_tuple_input(self) -> None:
+        """Should accept tuple input."""
+        columns = ("entity_id", "name", "_run_id")
+        result = canonical_column_order(columns)
+        assert isinstance(result, list)
+        assert result == ["entity_id", "_run_id", "name"]
+
+    def test_empty_input(self) -> None:
+        """Should handle empty input."""
+        assert canonical_column_order([]) == []
+
+    def test_only_system_fields(self) -> None:
+        """Should handle input with only system fields."""
+        columns = ["_run_id", "entity_id", "_dq_warn"]
+        result = canonical_column_order(columns)
+        assert result == ["entity_id", "_run_id", "_dq_warn"]
+
+    def test_full_system_fields_order(self) -> None:
+        """Test complete ordering with all system fields."""
+        columns = [
+            "_dq_error",
+            "business_field",
+            "_index",
+            "_run_type",
+            "entity_id",
+            "_dq_warn",
+            "content_hash",
+            "_run_id",
+            "_source_batch_id",
+            "_ingestion_ts",
+        ]
+        result = canonical_column_order(columns)
+        expected = [
+            "entity_id",
+            "content_hash",
+            "_run_id",
+            "_run_type",
+            "_source_batch_id",
+            "_ingestion_ts",
+            "_index",
+            "business_field",
+            "_dq_warn",
+            "_dq_error",
+        ]
+        assert result == expected
+
+
+class TestSchemaColumnOrder:
+    """Tests for PyArrow schema column ordering."""
+
+    @pytest.mark.parametrize("schema_name,schema", get_all_pyarrow_schemas())
+    def test_prefix_fields_in_correct_order(
+        self, schema_name: str, schema: pa.Schema
+    ) -> None:
+        """System prefix fields MUST be in correct relative order."""
+        column_names = schema.names
+
+        # Get prefix fields that exist in this schema
+        prefix_in_schema = [c for c in column_names if c in SYSTEM_FIELDS_PREFIX]
+        expected_order = [c for c in SYSTEM_FIELDS_PREFIX if c in column_names]
+
+        # Check they appear in the right relative order
+        assert prefix_in_schema == expected_order, (
+            f"{schema_name}: System prefix fields out of order.\n"
+            f"Expected: {expected_order}\n"
+            f"Got: {prefix_in_schema}"
+        )
+
+    @pytest.mark.parametrize("schema_name,schema", get_all_pyarrow_schemas())
+    def test_prefix_fields_at_start(self, schema_name: str, schema: pa.Schema) -> None:
+        """System prefix fields MUST be at the start of schema."""
+        column_names = schema.names
+
+        prefix_in_schema = [c for c in SYSTEM_FIELDS_PREFIX if c in column_names]
+        if not prefix_in_schema:
+            pytest.skip(f"{schema_name} has no system prefix fields")
+
+        # First N columns should be the prefix fields
+        first_n = column_names[: len(prefix_in_schema)]
+        assert set(first_n) == set(prefix_in_schema), (
+            f"{schema_name}: System prefix fields not at start.\n"
+            f"Expected first {len(prefix_in_schema)} columns to be: {prefix_in_schema}\n"
+            f"Got: {first_n}"
+        )
+
+    @pytest.mark.parametrize("schema_name,schema", get_all_pyarrow_schemas())
+    def test_suffix_fields_at_end(self, schema_name: str, schema: pa.Schema) -> None:
+        """DQ suffix fields MUST be last (if present)."""
+        column_names = schema.names
+
+        suffix_in_schema = [c for c in column_names if c in DQ_FIELDS_SUFFIX]
+        if not suffix_in_schema:
+            pytest.skip(f"{schema_name} has no DQ suffix fields")
+
+        expected_suffix = [c for c in DQ_FIELDS_SUFFIX if c in column_names]
+        actual_suffix = column_names[-len(suffix_in_schema) :]
+
+        assert actual_suffix == expected_suffix, (
+            f"{schema_name}: DQ suffix fields not at end.\n"
+            f"Expected last columns: {expected_suffix}\n"
+            f"Got: {actual_suffix}"
+        )
+
+    @pytest.mark.parametrize("schema_name,schema", get_all_pyarrow_schemas())
+    def test_business_fields_sorted(self, schema_name: str, schema: pa.Schema) -> None:
+        """Business fields SHOULD be sorted alphabetically."""
+        column_names = schema.names
+
+        # Extract business fields (excluding system fields)
+        business_fields = [c for c in column_names if c not in ALL_SYSTEM_FIELDS]
+        sorted_business = sorted(business_fields)
+
+        assert business_fields == sorted_business, (
+            f"{schema_name}: Business fields not sorted alphabetically.\n"
+            f"Expected: {sorted_business[:5]}...\n"
+            f"Got: {business_fields[:5]}..."
+        )
+
+    @pytest.mark.parametrize("schema_name,schema", get_all_pyarrow_schemas())
+    def test_schema_matches_canonical_order(
+        self, schema_name: str, schema: pa.Schema
+    ) -> None:
+        """Schema column order MUST match canonical_column_order() output."""
+        column_names = schema.names
+        expected = canonical_column_order(column_names)
+
+        assert list(column_names) == expected, (
+            f"{schema_name}: Column order does not match canonical.\n"
+            f"Use canonical_column_order() to reorder.\n"
+            f"First mismatch at position "
+            f"{next(i for i, (a, b) in enumerate(zip(column_names, expected)) if a != b)}"
+        )


### PR DESCRIPTION
This implements a canonical column ordering convention for all ETL records:
1. System prefix fields first (entity_id, content_hash, _run_id, etc.)
2. Business fields sorted alphabetically
3. DQ suffix fields last (_dq_warn, _dq_error if present)

Changes:
- Add domain/schemas/column_order.py with canonical_column_order() function
- Add domain/schemas/__init__.py to export column ordering utilities
- Update GoldWriter to use canonical_column_order instead of sorted()
- Update SilverWriter to apply canonical column order
- Reorder all 19 PyArrow schemas in infrastructure/schemas/silver.py
- Add comprehensive architecture tests in test_column_order.py

This ensures deterministic, consistent column ordering across all layers, per RULES.md §2.4 and ADR-014 Deterministic Writes.