### PR TITLE
Fix failing duplication and complexity checks

### DIFF
--- a/tests/architecture/test_column_order.py
+++ b/tests/architecture/test_column_order.py
@@ -188,5 +188,5 @@ class TestSchemaColumnOrder:
             f"{schema_name}: Column order does not match canonical.\n"
             f"Use canonical_column_order() to reorder.\n"
             f"First mismatch at position "
-            f"{next(i for i, (a, b) in enumerate(zip(column_names, expected)) if a != b)}"
+            f"{next(i for i, (a, b) in enumerate(zip(column_names, expected, strict=True)) if a != b)}"
         )


### PR DESCRIPTION
Add `strict=True` to the `zip()` call in test_column_order.py to satisfy ruff B905 lint rule requiring explicit strict parameter for zip().