### PR TITLE
Add query string to pipeline metadata

### DIFF
--- a/src/bioetl/application/core/batch_executor.py
+++ b/src/bioetl/application/core/batch_executor.py
@@ -186,6 +186,9 @@ class BatchExecutor:
             adaptive_sizing_enabled=self._adaptive_batch_size_enabled,
         )
 
+        # Query string for metadata (stored during execute())
+        self._query_string: str | None = None
+
     @property
     def entity_type(self) -> str:
         """Get entity type being processed."""
@@ -219,6 +222,9 @@ class BatchExecutor:
             - records_quarantined: Records sent to quarantine
 
         """
+        # Store query string for metadata enrichment
+        self._query_string = query
+
         root_span = self._tracing.start_execution_span()
 
         try:
@@ -320,24 +326,46 @@ class BatchExecutor:
         and calls it to retrieve accumulated API request metadata for
         Bronze layer enrichment.
 
+        Also injects the query_string from execute() if not already set
+        in the source metadata.
+
         Returns:
-            SourceMetadata with API request details, or None if not available.
+            SourceMetadata with API request details and query_string,
+            or None if not available.
 
         """
+        # Import SourceMetadata for runtime type check and creation
+        from bioetl.domain.models.metadata import SourceMetadata
+
+        source_metadata: SourceMetadata | None = None
+
+        # Try to get metadata from data source
         data_source = self._services.data_source
         get_metadata = getattr(data_source, "get_source_metadata", None)
         if get_metadata is not None and callable(get_metadata):
             try:
                 result = get_metadata()
-                # Import SourceMetadata for runtime type check
-                from bioetl.domain.models.metadata import SourceMetadata
-
                 if isinstance(result, SourceMetadata):
-                    return result
+                    source_metadata = result
             except Exception:
                 # Gracefully handle any errors in metadata collection
                 pass
-        return None
+
+        # Inject query_string if we have one and it's not already set
+        if self._query_string:
+            if source_metadata is not None:
+                if source_metadata.query_string is None:
+                    source_metadata = source_metadata.model_copy(
+                        update={"query_string": self._query_string}
+                    )
+            else:
+                # Create minimal SourceMetadata with query_string
+                source_metadata = SourceMetadata(
+                    type="api",
+                    query_string=self._query_string,
+                )
+
+        return source_metadata
 
     async def _process_batch(
         self, records: list[dict[str, Any]], start_index: int

--- a/src/bioetl/composition/services/metadata_coordinator.py
+++ b/src/bioetl/composition/services/metadata_coordinator.py
@@ -176,12 +176,20 @@ class MetadataCoordinator:
         """
         duration = (input_data.completed_at - input_data.started_at).total_seconds()
 
-        # Use provided source_metadata or create minimal default
-        source = (
-            input_data.source_metadata
-            if input_data.source_metadata is not None
-            else SourceMetadata(type="api")
-        )
+        # Build source metadata with query_string
+        if input_data.source_metadata is not None:
+            source = input_data.source_metadata
+            # Inject query_string if provided and not already set in source_metadata
+            if input_data.query_string and source.query_string is None:
+                source = source.model_copy(
+                    update={"query_string": input_data.query_string}
+                )
+        else:
+            # Create minimal SourceMetadata with query_string
+            source = SourceMetadata(
+                type="api",
+                query_string=input_data.query_string,
+            )
 
         return BronzeMetadata(
             runtime=self._build_runtime_metadata(

--- a/src/bioetl/domain/models/metadata.py
+++ b/src/bioetl/domain/models/metadata.py
@@ -179,6 +179,8 @@ class SourceMetadata(BaseModel):
         type: Source type (api, csv, parquet).
         url: API URL for API sources.
         file_path: File path for file sources.
+        query_string: Query string used for data source filtering
+            (e.g., 'assay_type=B&standard_type=IC50').
         watermark_before: Previous watermark timestamp.
         watermark_after: New watermark timestamp after ingestion.
         api_version: Provider API version.
@@ -193,6 +195,10 @@ class SourceMetadata(BaseModel):
     )
     url: str | None = Field(default=None, description="API URL")
     file_path: str | None = Field(default=None, description="Source file path")
+    query_string: str | None = Field(
+        default=None,
+        description="Query string used for data source filtering (e.g., 'assay_type=B')",
+    )
     watermark_before: datetime | None = Field(
         default=None, description="Previous watermark"
     )

--- a/src/bioetl/domain/ports/metadata_coordinator.py
+++ b/src/bioetl/domain/ports/metadata_coordinator.py
@@ -35,6 +35,8 @@ class BronzeMetadataInput:
         completed_at: UTC timestamp when write completed.
         source_metadata: Optional pre-built SourceMetadata with API request
                         details for rich lineage tracking.
+        query_string: Query string from PipelineRunContext used for data
+                     source filtering (e.g., 'assay_type=B').
     """
 
     batch_id: BatchID
@@ -44,6 +46,7 @@ class BronzeMetadataInput:
     started_at: datetime
     completed_at: datetime
     source_metadata: SourceMetadata | None = None
+    query_string: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/unit/application/services/test_metadata_coordinator.py
+++ b/tests/unit/application/services/test_metadata_coordinator.py
@@ -24,6 +24,7 @@ from bioetl.domain.models.metadata import (
     LayerType,
     RunTypeEnum,
     SilverMetadata,
+    SourceMetadata,
 )
 from bioetl.domain.types import BatchID, RunID, RunType
 from bioetl.domain.value_objects.run_context import RunContext
@@ -224,6 +225,128 @@ class TestBronzeMetadata:
         assert len(metadata.output.files) == 1
         assert metadata.output.files[0].path == input_data.output_path
         assert metadata.output.files[0].record_count == 500
+
+    def test_bronze_metadata_includes_query_string_from_input(
+        self, coordinator: MetadataCoordinator
+    ) -> None:
+        """Bronze metadata should include query_string from BronzeMetadataInput."""
+        input_data = BronzeMetadataInput(
+            batch_id=BatchID(uuid4()),
+            record_count=100,
+            compressed_size=5000,
+            output_path="v1/chembl/activity/2024-01-15/batch.jsonl.zst",
+            started_at=datetime.now(UTC),
+            completed_at=datetime.now(UTC),
+            query_string="assay_type=B&standard_type=IC50",
+        )
+
+        metadata = coordinator.create_bronze_metadata(input_data)
+
+        assert metadata.source.query_string == "assay_type=B&standard_type=IC50"
+
+    def test_bronze_metadata_preserves_source_query_string(
+        self, coordinator: MetadataCoordinator
+    ) -> None:
+        """Should preserve query_string from source_metadata if already set."""
+        source = SourceMetadata(
+            type="api",
+            url="https://www.ebi.ac.uk/chembl/api/data/activity",
+            query_string="original_query=value",
+        )
+        input_data = BronzeMetadataInput(
+            batch_id=BatchID(uuid4()),
+            record_count=100,
+            compressed_size=5000,
+            output_path="v1/chembl/activity/2024-01-15/batch.jsonl.zst",
+            started_at=datetime.now(UTC),
+            completed_at=datetime.now(UTC),
+            source_metadata=source,
+            query_string="override_query=should_be_ignored",
+        )
+
+        metadata = coordinator.create_bronze_metadata(input_data)
+
+        # Original query_string from source_metadata should be preserved
+        assert metadata.source.query_string == "original_query=value"
+
+    def test_bronze_metadata_injects_query_string_when_source_has_none(
+        self, coordinator: MetadataCoordinator
+    ) -> None:
+        """Should inject query_string into source_metadata if source has query_string=None."""
+        source = SourceMetadata(
+            type="api",
+            url="https://www.ebi.ac.uk/chembl/api/data/activity",
+            # query_string is None by default
+        )
+        input_data = BronzeMetadataInput(
+            batch_id=BatchID(uuid4()),
+            record_count=100,
+            compressed_size=5000,
+            output_path="v1/chembl/activity/2024-01-15/batch.jsonl.zst",
+            started_at=datetime.now(UTC),
+            completed_at=datetime.now(UTC),
+            source_metadata=source,
+            query_string="injected_query=value",
+        )
+
+        metadata = coordinator.create_bronze_metadata(input_data)
+
+        # query_string should be injected from input_data
+        assert metadata.source.query_string == "injected_query=value"
+        # Other source_metadata fields should be preserved
+        assert metadata.source.url == "https://www.ebi.ac.uk/chembl/api/data/activity"
+
+    def test_bronze_metadata_query_string_defaults_to_none(
+        self, coordinator: MetadataCoordinator
+    ) -> None:
+        """Bronze metadata query_string should default to None when not provided."""
+        input_data = BronzeMetadataInput(
+            batch_id=BatchID(uuid4()),
+            record_count=100,
+            compressed_size=5000,
+            output_path="v1/chembl/activity/2024-01-15/batch.jsonl.zst",
+            started_at=datetime.now(UTC),
+            completed_at=datetime.now(UTC),
+            # No query_string provided
+        )
+
+        metadata = coordinator.create_bronze_metadata(input_data)
+
+        assert metadata.source.query_string is None
+
+
+class TestSourceMetadataQueryString:
+    """Tests for SourceMetadata query_string field."""
+
+    def test_source_metadata_with_query_string(self) -> None:
+        """SourceMetadata should store query_string."""
+        source = SourceMetadata(
+            type="api",
+            url="https://www.ebi.ac.uk/chembl/api/data/activity",
+            query_string="assay_type=B&standard_type=IC50",
+        )
+
+        assert source.query_string == "assay_type=B&standard_type=IC50"
+        assert source.type == "api"
+
+    def test_source_metadata_query_string_default_none(self) -> None:
+        """SourceMetadata.query_string defaults to None."""
+        source = SourceMetadata(type="api")
+
+        assert source.query_string is None
+
+    def test_source_metadata_model_copy_with_query_string(self) -> None:
+        """SourceMetadata.model_copy should work with query_string update."""
+        source = SourceMetadata(
+            type="api",
+            url="https://example.com",
+        )
+
+        updated = source.model_copy(update={"query_string": "new_query=value"})
+
+        assert updated.query_string == "new_query=value"
+        assert updated.url == "https://example.com"  # Original preserved
+        assert source.query_string is None  # Original unchanged
 
 
 class TestSilverMetadata:


### PR DESCRIPTION
Add support for storing the query parameter used for data filtering in Bronze layer _metadata.yaml files for audit and reproducibility.

Changes:
- Add query_string field to SourceMetadata model
- Add query_string field to BronzeMetadataInput dataclass
- Update MetadataCoordinator.create_bronze_metadata to handle query_string
- Store query in BatchExecutor and inject into SourceMetadata
- Add comprehensive unit tests for query_string functionality

The query_string is injected into source_metadata when:
1. No source_metadata exists - creates new SourceMetadata with query_string
2. source_metadata.query_string is None - copies and injects query_string
3. source_metadata.query_string is set - preserves original value