### PR TITLE
Fix code complexity issues in batch executor

### DIFF
--- a/src/bioetl/application/core/batch_executor.py
+++ b/src/bioetl/application/core/batch_executor.py
@@ -680,6 +680,28 @@ class BatchExecutor:
         # Collect Gold records
         self._gold_records_for_dq.extend(gold_records)
 
+    def _build_dataframe_from_records(
+        self, records: list[dict[str, Any]]
+    ) -> Any | None:
+        """Build a Polars DataFrame from records, returning None on failure."""
+        if not records:
+            return None
+        try:
+            import polars as pl
+
+            return pl.DataFrame(records)
+        except Exception:
+            return None
+
+    def _get_dq_thresholds(self) -> tuple[float, float]:
+        """Get DQ thresholds from config or defaults."""
+        if self._config.dq_config:
+            return (
+                self._config.dq_config.soft_fail_threshold,
+                self._config.dq_config.hard_fail_threshold,
+            )
+        return (0.05, 0.20)
+
     def get_dq_context(self) -> DQReportContext | None:
         """Build DQ report context from accumulated data.
 
@@ -701,64 +723,30 @@ class BatchExecutor:
         # Import here to avoid circular dependency
         from bioetl.application.services.dq_report_service import DQReportContext
 
-        # Build Silver DataFrame if we have records
-        silver_data = None
-        if self._silver_records_for_dq:
-            try:
-                import polars as pl
-
-                silver_data = pl.DataFrame(self._silver_records_for_dq)
-            except Exception:
-                # If DataFrame creation fails, skip Silver DQ report
-                pass
-
-        # Build Gold DataFrame if we have records
-        gold_data = None
-        if self._gold_records_for_dq:
-            try:
-                import polars as pl
-
-                gold_data = pl.DataFrame(self._gold_records_for_dq)
-            except Exception:
-                # If DataFrame creation fails, skip Gold DQ report
-                pass
-
-        # Get table config for primary keys
+        silver_data = self._build_dataframe_from_records(self._silver_records_for_dq)
+        gold_data = self._build_dataframe_from_records(self._gold_records_for_dq)
         primary_keys = list(self._config.table_config.primary_keys)
+        soft_threshold, hard_threshold = self._get_dq_thresholds()
 
         return DQReportContext(
             run_id=str(self._context.run_id),
             pipeline_name=self._config.pipeline_name,
             timestamp=datetime.now(UTC),
             # Bronze context
-            bronze_records=(
-                self._bronze_records_for_dq if self._bronze_records_for_dq else None
-            ),
-            bronze_batch_id=(
-                self._source_batch_ids[-1] if self._source_batch_ids else None
-            ),
+            bronze_records=self._bronze_records_for_dq or None,
+            bronze_batch_id=self._source_batch_ids[-1] if self._source_batch_ids else None,
             bronze_source_file=self._last_bronze_path,
             # Silver context
             silver_data=silver_data,
             silver_target_table=self._config.table_config.silver_table,
-            silver_source_batch_ids=(
-                self._source_batch_ids if self._source_batch_ids else None
-            ),
-            silver_primary_keys=primary_keys if primary_keys else None,
+            silver_source_batch_ids=self._source_batch_ids or None,
+            silver_primary_keys=primary_keys or None,
             silver_input_count=self.records_fetched,
             silver_quarantined_count=self.records_quarantined,
             # Gold context
             gold_data=gold_data,
             gold_target_table=self._config.table_config.gold_table,
             # DQ thresholds from config (use defaults if not configured)
-            dq_soft_threshold=(
-                self._config.dq_config.soft_fail_threshold
-                if self._config.dq_config
-                else 0.05
-            ),
-            dq_hard_threshold=(
-                self._config.dq_config.hard_fail_threshold
-                if self._config.dq_config
-                else 0.20
-            ),
+            dq_soft_threshold=soft_threshold,
+            dq_hard_threshold=hard_threshold,
         )

--- a/src/bioetl/application/services/dq/gold_analyzer.py
+++ b/src/bioetl/application/services/dq/gold_analyzer.py
@@ -271,6 +271,69 @@ class GoldDQAnalyzer:
             status=status,
         )
 
+    def _check_not_null_rule(
+        self, df: pl.DataFrame, column: str
+    ) -> tuple[bool, int | None]:
+        """Check not_null rule for a column."""
+        violations = df[column].null_count()
+        return violations == 0, violations
+
+    def _check_range_rule(
+        self,
+        df: pl.DataFrame,
+        column: str,
+        min_val: Any | None,
+        max_val: Any | None,
+    ) -> tuple[bool, int]:
+        """Check range rule for a column."""
+        violations = 0
+        col_data = df[column].drop_nulls()
+        if min_val is not None:
+            violations += (col_data < min_val).sum()
+        if max_val is not None:
+            violations += (col_data > max_val).sum()
+        return violations == 0, violations
+
+    def _check_in_list_rule(
+        self, df: pl.DataFrame, column: str, allowed: list[Any]
+    ) -> tuple[bool, int | None]:
+        """Check in_list rule for a column."""
+        if not allowed:
+            return True, 0
+        violations = int((~df[column].is_in(allowed)).sum())
+        return violations == 0, violations
+
+    def _check_regex_rule(
+        self, df: pl.DataFrame, column: str, pattern: str
+    ) -> tuple[bool, int | None]:
+        """Check regex rule for a column."""
+        if not pattern:
+            return True, 0
+        violations = int((~df[column].str.contains(pattern, literal=False)).sum())
+        return violations == 0, violations
+
+    def _evaluate_single_rule(
+        self, df: pl.DataFrame, rule: dict[str, Any]
+    ) -> tuple[bool, int | None]:
+        """Evaluate a single business rule."""
+        column = rule.get("column")
+        condition = rule.get("condition")
+
+        if not column or column not in df.columns:
+            return True, 0
+
+        if condition == "not_null":
+            return self._check_not_null_rule(df, column)
+        if condition == "range":
+            return self._check_range_rule(
+                df, column, rule.get("min"), rule.get("max")
+            )
+        if condition == "in_list":
+            return self._check_in_list_rule(df, column, rule.get("values", []))
+        if condition == "regex":
+            return self._check_regex_rule(df, column, rule.get("pattern", ""))
+        return True, 0
+
     def _check_business_rules(
         self, df: pl.DataFrame, rules: list[dict[str, Any]]
     ) -> BusinessRulesResult:
@@ -289,44 +352,10 @@ class GoldDQAnalyzer:
         rules_failed = 0
 
         for rule in rules:
-            rule_id = rule.get("rule_id", "")
-            name = rule.get("name", "")
-            description = rule.get("description", "")
-            column = rule.get("column")
-            condition = rule.get("condition")
-
-            violations: int | None = 0
-            passed = True
-
             try:
-                if condition == "not_null" and column and column in df.columns:
-                    violations = df[column].null_count()
-                    passed = violations == 0
-                elif condition == "range" and column and column in df.columns:
-                    min_val = rule.get("min")
-                    max_val = rule.get("max")
-                    col_data = df[column].drop_nulls()
-                    if min_val is not None:
-                        violations += (col_data < min_val).sum()
-                    if max_val is not None:
-                        violations += (col_data > max_val).sum()
-                    passed = violations == 0
-                elif condition == "in_list" and column and column in df.columns:
-                    allowed = rule.get("values", [])
-                    if allowed:
-                        violations = (~df[column].is_in(allowed)).sum()
-                        passed = violations == 0
-                elif condition == "regex" and column and column in df.columns:
-                    pattern = rule.get("pattern", "")
-                    if pattern:
-                        # Check non-matching rows
-                        violations = (
-                            ~df[column].str.contains(pattern, literal=False)
-                        ).sum()
-                        passed = violations == 0
+                passed, violations = self._evaluate_single_rule(df, rule)
             except Exception:
-                passed = False
-                violations = None  # Unknown due to exception
+                passed, violations = False, None
 
             if passed:
                 rules_passed += 1
@@ -335,9 +364,9 @@ class GoldDQAnalyzer:
 
             results.append(
                 BusinessRuleResult(
-                    rule_id=rule_id,
-                    name=name,
-                    description=description,
+                    rule_id=rule.get("rule_id", ""),
+                    name=rule.get("name", ""),
+                    description=rule.get("description", ""),
                     passed=passed,
                     violations=violations,
                 )

--- a/src/bioetl/composition/factories/pipeline_factory.py
+++ b/src/bioetl/composition/factories/pipeline_factory.py
@@ -568,6 +568,33 @@ def assemble_runner(
     )
 
 
+def _extract_single_dq_config(
+    sink: Any,
+    layer_name: str,
+    config_class: Any,
+) -> Any | None:
+    """Extract DQ config for a single layer.
+
+    Args:
+        sink: Sink configuration from YAML.
+        layer_name: Name of the layer ('bronze', 'silver', 'gold').
+        config_class: Pydantic config class for validation.
+
+    Returns:
+        DQ report config if enabled, None otherwise.
+    """
+    sink_config = sink.get(layer_name)
+    if not sink_config:
+        return None
+    try:
+        validated = config_class.model_validate(sink_config.model_dump())
+        if validated.dq_report.enabled:
+            return validated.dq_report
+    except Exception:
+        pass
+    return None
+
+
 def _extract_dq_configs(
     pipeline: BasePipeline,
 ) -> tuple[
@@ -593,51 +620,16 @@ def _extract_dq_configs(
         SilverSinkConfig,
     )
 
-    bronze_config: BronzeDQConfigPort | None = None
-    silver_config: SilverDQConfigPort | None = None
-    gold_config: GoldDQConfigPort | None = None
-
-    # Access original YAML config if available through pipeline
     yaml_config = getattr(pipeline, "_yaml_config", None)
     if yaml_config is None:
-        return bronze_config, silver_config, gold_config
+        return None, None, None
 
     sink = getattr(yaml_config, "sink", None)
     if sink is None:
-        return bronze_config, silver_config, gold_config
+        return None, None, None
 
-    # Extract Bronze DQ config
-    bronze_sink_config = sink.get("bronze")
-    if bronze_sink_config:
-        try:
-            bronze_sink = BronzeSinkConfig.model_validate(
-                bronze_sink_config.model_dump()
-            )
-            if bronze_sink.dq_report.enabled:
-                bronze_config = bronze_sink.dq_report
-        except Exception:
-            pass
-
-    # Extract Silver DQ config
-    silver_sink_config = sink.get("silver")
-    if silver_sink_config:
-        try:
-            silver_sink = SilverSinkConfig.model_validate(
-                silver_sink_config.model_dump()
-            )
-            if silver_sink.dq_report.enabled:
-                silver_config = silver_sink.dq_report
-        except Exception:
-            pass
-
-    # Extract Gold DQ config
-    gold_sink_config = sink.get("gold")
-    if gold_sink_config:
-        try:
-            gold_sink = GoldSinkConfig.model_validate(gold_sink_config.model_dump())
-            if gold_sink.dq_report.enabled:
-                gold_config = gold_sink.dq_report
-        except Exception:
-            pass
+    bronze_config = _extract_single_dq_config(sink, "bronze", BronzeSinkConfig)
+    silver_config = _extract_single_dq_config(sink, "silver", SilverSinkConfig)
+    gold_config = _extract_single_dq_config(sink, "gold", GoldSinkConfig)
 
     return bronze_config, silver_config, gold_config


### PR DESCRIPTION
Extract helper methods to reduce code complexity below threshold (CC=10):

- batch_executor.py: Extract _build_dataframe_from_records and _get_dq_thresholds from get_dq_context

- pipeline_factory.py: Extract _extract_single_dq_config helper to eliminate repetitive bronze/silver/gold extraction logic

- gold_analyzer.py: Extract _check_not_null_rule, _check_range_rule, _check_in_list_rule, _check_regex_rule, and _evaluate_single_rule from _check_business_rules

All functions now pass xenon complexity check (max-absolute C, max-modules B).