### PR TITLE
Fix failing architecture tests and checks

### DIFF
--- a/src/bioetl/application/core/batch_executor.py
+++ b/src/bioetl/application/core/batch_executor.py
@@ -734,7 +734,9 @@ class BatchExecutor:
             timestamp=datetime.now(UTC),
             # Bronze context
             bronze_records=self._bronze_records_for_dq or None,
-            bronze_batch_id=self._source_batch_ids[-1] if self._source_batch_ids else None,
+            bronze_batch_id=self._source_batch_ids[-1]
+            if self._source_batch_ids
+            else None,
             bronze_source_file=self._last_bronze_path,
             # Silver context
             silver_data=silver_data,

--- a/src/bioetl/application/pipelines/pubmed/extractors/classification.py
+++ b/src/bioetl/application/pipelines/pubmed/extractors/classification.py
@@ -249,9 +249,11 @@ class ClassificationExtractor(BaseFieldExtractor):
                     if acc.text and acc.text.strip()
                 ]
 
-            result.append({
-                "databank_name": name_elem.text.strip(),
-                "accession_numbers": accessions,
-            })
+            result.append(
+                {
+                    "databank_name": name_elem.text.strip(),
+                    "accession_numbers": accessions,
+                }
+            )
 
         return result

--- a/src/bioetl/application/services/dq/gold_analyzer.py
+++ b/src/bioetl/application/services/dq/gold_analyzer.py
@@ -43,6 +43,43 @@ from bioetl.domain.value_objects.dq_report import (
 )
 
 
+def _convert_value(value: Any) -> Any:
+    """Convert a value to serializable format."""
+    if hasattr(value, "value"):  # Enum
+        return value.value
+    if hasattr(value, "__dataclass_fields__"):
+        return _result_to_dict(value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, (list, tuple)):
+        return [_convert_value(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _convert_value(v) for k, v in value.items()}
+    return value
+
+
+def _result_to_dict(result: Any) -> dict[str, Any]:
+    """Convert dataclass result to dict for serialization."""
+    if hasattr(result, "__dataclass_fields__"):
+        return {
+            field: _convert_value(getattr(result, field))
+            for field in result.__dataclass_fields__
+            if not field.startswith("_")
+        }
+    return {"value": result}
+
+
+def _update_counts(
+    status: DQCheckStatus, passed: int, failed: int, warnings: int
+) -> tuple[int, int, int]:
+    """Update check counts based on status."""
+    if status == DQCheckStatus.PASS:
+        return passed + 1, failed, warnings
+    if status == DQCheckStatus.FAIL:
+        return passed, failed + 1, warnings
+    return passed, failed, warnings + 1
+
+
 class GoldDQAnalyzer:
     """Analyzer for Gold layer DQ checks.
 
@@ -109,8 +146,8 @@ class GoldDQAnalyzer:
         # Record count check
         if GoldDQCheckType.RECORD_COUNT in enabled_checks:
             record_count_result = self._check_record_count(df, baseline_stats)
-            checks["record_count"] = self._result_to_dict(record_count_result)
-            passed, failed, warnings = self._update_counts(
+            checks["record_count"] = _result_to_dict(record_count_result)
+            passed, failed, warnings = _update_counts(
                 record_count_result.status, passed, failed, warnings
             )
 
@@ -119,18 +156,16 @@ class GoldDQAnalyzer:
             completeness_result = self._check_completeness(
                 df, required_fields or [], completeness_threshold
             )
-            checks["completeness"] = self._result_to_dict(completeness_result)
-            passed, failed, warnings = self._update_counts(
+            checks["completeness"] = _result_to_dict(completeness_result)
+            passed, failed, warnings = _update_counts(
                 completeness_result.status, passed, failed, warnings
             )
 
         # Business rules check
         if GoldDQCheckType.BUSINESS_RULES in enabled_checks:
             business_rules_result = self._check_business_rules(df, business_rules or [])
-            checks["business_rules"] = self._business_rules_to_dict(
-                business_rules_result
-            )
-            passed, failed, warnings = self._update_counts(
+            checks["business_rules"] = _result_to_dict(business_rules_result)
+            passed, failed, warnings = _update_counts(
                 business_rules_result.status, passed, failed, warnings
             )
 
@@ -139,36 +174,32 @@ class GoldDQAnalyzer:
             ref_integrity_result = self._check_referential_integrity(
                 df, reference_tables or {}
             )
-            checks["referential_integrity"] = self._ref_integrity_to_dict(
-                ref_integrity_result
-            )
-            passed, failed, warnings = self._update_counts(
+            checks["referential_integrity"] = _result_to_dict(ref_integrity_result)
+            passed, failed, warnings = _update_counts(
                 ref_integrity_result.status, passed, failed, warnings
             )
 
         # Statistical profile check
         if GoldDQCheckType.STATISTICAL_PROFILE in enabled_checks:
             stat_profile_result = self._check_statistical_profile(df, baseline_stats)
-            checks["statistical_profile"] = self._stat_profile_to_dict(
-                stat_profile_result
-            )
-            passed, failed, warnings = self._update_counts(
+            checks["statistical_profile"] = _result_to_dict(stat_profile_result)
+            passed, failed, warnings = _update_counts(
                 stat_profile_result.status, passed, failed, warnings
             )
 
         # Anomaly detection
         if GoldDQCheckType.ANOMALY_DETECTION in enabled_checks:
             anomaly_result = self._check_anomaly_detection(df, baseline_stats)
-            checks["anomaly_detection"] = self._anomaly_to_dict(anomaly_result)
-            passed, failed, warnings = self._update_counts(
+            checks["anomaly_detection"] = _result_to_dict(anomaly_result)
+            passed, failed, warnings = _update_counts(
                 anomaly_result.status, passed, failed, warnings
             )
 
         # SCD integrity check
         if GoldDQCheckType.SCD_INTEGRITY in enabled_checks:
             scd_result = self._check_scd_integrity(df, scd_config)
-            checks["scd_integrity"] = self._result_to_dict(scd_result)
-            passed, failed, warnings = self._update_counts(
+            checks["scd_integrity"] = _result_to_dict(scd_result)
+            passed, failed, warnings = _update_counts(
                 scd_result.status, passed, failed, warnings
             )
 
@@ -325,9 +356,7 @@ class GoldDQAnalyzer:
         if condition == "not_null":
             return self._check_not_null_rule(df, column)
         if condition == "range":
-            return self._check_range_rule(
-                df, column, rule.get("min"), rule.get("max")
-            )
+            return self._check_range_rule(df, column, rule.get("min"), rule.get("max"))
         if condition == "in_list":
             return self._check_in_list_rule(df, column, rule.get("values", []))
         if condition == "regex":
@@ -748,82 +777,6 @@ class GoldDQAnalyzer:
             freshness_lag_hours=round(lag_hours, 2),
             status=status,
         )
-
-    def _result_to_dict(self, result: Any) -> dict[str, Any]:
-        """Convert dataclass result to dict for serialization."""
-        if hasattr(result, "__dataclass_fields__"):
-            output = {}
-            for field in result.__dataclass_fields__:
-                if field.startswith("_"):
-                    continue
-                value = getattr(result, field)
-                if hasattr(value, "value"):  # Enum
-                    output[field] = value.value
-                elif hasattr(value, "__dataclass_fields__"):
-                    output[field] = self._result_to_dict(value)
-                elif isinstance(value, datetime):
-                    output[field] = value.isoformat()
-                else:
-                    output[field] = value
-            return output
-        return {"value": result}
-
-    def _business_rules_to_dict(self, result: BusinessRulesResult) -> dict[str, Any]:
-        """Convert business rules result to dict."""
-        return {
-            "rules_evaluated": result.rules_evaluated,
-            "rules_passed": result.rules_passed,
-            "rules_failed": result.rules_failed,
-            "rules": [self._result_to_dict(r) for r in result.rules],
-            "status": result.status.value,
-        }
-
-    def _ref_integrity_to_dict(
-        self, result: ReferentialIntegrityResult
-    ) -> dict[str, Any]:
-        """Convert referential integrity result to dict."""
-        return {
-            "foreign_keys": {
-                k: self._result_to_dict(v) for k, v in result.foreign_keys.items()
-            },
-            "status": result.status.value,
-        }
-
-    def _stat_profile_to_dict(self, result: StatisticalProfileResult) -> dict[str, Any]:
-        """Convert statistical profile result to dict."""
-        return {
-            "baseline_period_days": result.baseline_period_days,
-            "metrics": {k: self._result_to_dict(v) for k, v in result.metrics.items()},
-            "status": result.status.value,
-        }
-
-    def _anomaly_to_dict(self, result: AnomalyDetectionResult) -> dict[str, Any]:
-        """Convert anomaly detection result to dict."""
-        return {
-            "cold_start_days": result.cold_start_days,
-            "current_day": result.current_day,
-            "cold_start_mode": result.cold_start_mode,
-            "anomalies_detected": list(result.anomalies_detected),
-            "metrics_monitored": [
-                self._result_to_dict(m) for m in result.metrics_monitored
-            ],
-            "status": result.status.value,
-        }
-
-    def _update_counts(
-        self,
-        status: DQCheckStatus,
-        passed: int,
-        failed: int,
-        warnings: int,
-    ) -> tuple[int, int, int]:
-        """Update check counts based on status."""
-        if status == DQCheckStatus.PASS:
-            return passed + 1, failed, warnings
-        elif status == DQCheckStatus.FAIL:
-            return passed, failed + 1, warnings
-        else:  # WARN
-            return passed, failed, warnings + 1
 
 
 __all__ = ["GoldDQAnalyzer"]

--- a/tests/unit/application/pipelines/__snapshots__/test_transformer_snapshots.ambr
+++ b/tests/unit/application/pipelines/__snapshots__/test_transformer_snapshots.ambr
@@ -203,13 +203,19 @@
     'abstract': 'This is the abstract of the test article.',
     'accepted_date': '2025-01-15',
     'authors': '["Smith, John","Doe, Jane"]',
+    'chemicals': list([
+    ]),
     'citation_count': None,
     'content_hash': '<content_hash>',
     'country': 'United States',
+    'databanks': list([
+    ]),
     'doc_type': 'PUBLICATION',
     'doi': '10.1234/test.2025.001',
     'entity_id': '<entity_id>',
     'epub_date': '2025-02-28',
+    'gene_symbols': list([
+    ]),
     'is_oa': None,
     'issn': '1234-5678',
     'issue': '3',
@@ -255,13 +261,19 @@
     'abstract': None,
     'accepted_date': None,
     'authors': None,
+    'chemicals': list([
+    ]),
     'citation_count': None,
     'content_hash': '<content_hash>',
     'country': None,
+    'databanks': list([
+    ]),
     'doc_type': 'PUBLICATION',
     'doi': None,
     'entity_id': '<entity_id>',
     'epub_date': None,
+    'gene_symbols': list([
+    ]),
     'is_oa': None,
     'issn': None,
     'issue': None,

--- a/tests/unit/application/pipelines/openalex/test_extractors.py
+++ b/tests/unit/application/pipelines/openalex/test_extractors.py
@@ -386,8 +386,14 @@ class TestExtractKeywords:
     def test_extract_keywords_basic(self) -> None:
         """Should extract keyword display names."""
         keywords = [
-            {"id": "https://openalex.org/keywords/coronavirus", "display_name": "Coronavirus"},
-            {"id": "https://openalex.org/keywords/pandemic", "display_name": "Pandemic"},
+            {
+                "id": "https://openalex.org/keywords/coronavirus",
+                "display_name": "Coronavirus",
+            },
+            {
+                "id": "https://openalex.org/keywords/pandemic",
+                "display_name": "Pandemic",
+            },
         ]
         result = extract_keywords(keywords)
         assert result == ["Coronavirus", "Pandemic"]


### PR DESCRIPTION
- Extract helper conversion methods to module level (_result_to_dict, _convert_value, _update_counts) to reduce class size from 781 to 697 lines
- Apply ruff formatting to batch_executor.py, classification.py, gold_analyzer.py, and test_extractors.py
- Update PubMed transformer snapshots (pre-existing test failure)

Resolves architecture test failures:
- test_application_files_under_limit (829 -> 782 LOC)
- test_classes_under_300_lines (781 -> 697 lines)
- test_ruff_formatting_src/tests