### PR TITLE
Add DQ fields to all publication schemas

### DIFF
--- a/src/bioetl/domain/schemas/chembl/publication.py
+++ b/src/bioetl/domain/schemas/chembl/publication.py
@@ -71,6 +71,10 @@ class ChemblPublicationSchema(ETLRecordSchema):
     #     nullable=True, description="Record index."
     # )
 
+    # === DQ Fields ===
+    _dq_warn: Series[bool] = pa.Field(nullable=True, default=False, description="DQ warning flag.")
+    _dq_error: Series[bool] = pa.Field(nullable=True, default=False, description="DQ error flag.")
+
     class Config:
         """Pandera configuration."""
 

--- a/src/bioetl/domain/schemas/crossref/publication.py
+++ b/src/bioetl/domain/schemas/crossref/publication.py
@@ -115,6 +115,10 @@ class PublicationEnrichedSchema(ETLRecordSchema):
         nullable=False, eq="crossref", description="Data source identifier"
     )
 
+    # === DQ Fields ===
+    _dq_warn: Series[bool] = pa.Field(nullable=True, default=False, description="DQ warning flag.")
+    _dq_error: Series[bool] = pa.Field(nullable=True, default=False, description="DQ error flag.")
+
     class Config:
         """Pandera configuration."""
 

--- a/src/bioetl/domain/schemas/openalex/publication.py
+++ b/src/bioetl/domain/schemas/openalex/publication.py
@@ -138,6 +138,10 @@ class OpenAlexPublicationSchema(ETLRecordSchema):
         description="Original DOI from input CSV (for fallback records)",
     )
 
+    # === DQ Fields ===
+    _dq_warn: Series[bool] = pa.Field(nullable=True, default=False, description="DQ warning flag.")
+    _dq_error: Series[bool] = pa.Field(nullable=True, default=False, description="DQ error flag.")
+
     class Config:
         """Pandera configuration."""
 

--- a/src/bioetl/domain/schemas/pubmed/article.py
+++ b/src/bioetl/domain/schemas/pubmed/article.py
@@ -242,6 +242,10 @@ class ArticleSchema(ETLRecordSchema):
         """Validate chemical count is non-negative."""
         return cast("Series[bool]", series.isna() | (series >= 0))
 
+    # === DQ Fields ===
+    _dq_warn: Series[bool] = pa.Field(nullable=True, default=False, description="DQ warning flag.")
+    _dq_error: Series[bool] = pa.Field(nullable=True, default=False, description="DQ error flag.")
+
     class Config:
         """Pandera configuration."""
 

--- a/src/bioetl/infrastructure/schemas/gold.py
+++ b/src/bioetl/infrastructure/schemas/gold.py
@@ -243,6 +243,10 @@ class PubMedPublicationGoldSchema(pa.DataFrameModel):
     language: Series[str] = pa.Field(nullable=True)
     country: Series[str] = pa.Field(nullable=True)
 
+    # DQ fields
+    dq_warn: Series[bool] = pa.Field(nullable=True, alias="_dq_warn")
+    dq_error: Series[bool] = pa.Field(nullable=True, alias="_dq_error")
+
     # Metadata
     run_id: Series[str] = pa.Field(nullable=False, alias="_run_id")
     run_type: Series[str] = pa.Field(nullable=False, alias="_run_type")
@@ -412,6 +416,10 @@ class ChEMBLDocumentGoldSchema(pa.DataFrameModel):
     first_page: Series[str] = pa.Field(nullable=True)
     last_page: Series[str] = pa.Field(nullable=True)
     src_id: Series[float] = pa.Field(nullable=True, coerce=True)
+
+    # DQ fields
+    dq_warn: Series[bool] = pa.Field(nullable=True, alias="_dq_warn")
+    dq_error: Series[bool] = pa.Field(nullable=True, alias="_dq_error")
 
     # Metadata
     run_id: Series[str] = pa.Field(nullable=False, alias="_run_id")
@@ -704,6 +712,10 @@ class SemanticScholarPublicationGoldSchema(pa.DataFrameModel):
     lookup_method: Series[str] = pa.Field(nullable=True, alias="_lookup_method")
     original_doi: Series[str] = pa.Field(nullable=True, alias="_original_doi")
 
+    # DQ fields
+    dq_warn: Series[bool] = pa.Field(nullable=True, alias="_dq_warn")
+    dq_error: Series[bool] = pa.Field(nullable=True, alias="_dq_error")
+
     # Lineage metadata
     run_id: Series[str] = pa.Field(nullable=False, alias="_run_id")
     run_type: Series[str] = pa.Field(nullable=False, alias="_run_type")
@@ -755,6 +767,10 @@ class CrossRefPublicationGoldSchema(pa.DataFrameModel):
     license_url: Series[str] = pa.Field(nullable=True)
     subjects: Series[object] = pa.Field(nullable=True)  # list[str]
     source: Series[str] = pa.Field(nullable=True)
+
+    # DQ fields
+    dq_warn: Series[bool] = pa.Field(nullable=True, alias="_dq_warn")
+    dq_error: Series[bool] = pa.Field(nullable=True, alias="_dq_error")
 
     # Lineage metadata
     run_id: Series[str] = pa.Field(nullable=False, alias="_run_id")
@@ -811,6 +827,10 @@ class OpenAlexPublicationGoldSchema(pa.DataFrameModel):
     # Lookup metadata
     lookup_method: Series[str] = pa.Field(nullable=False, alias="_lookup_method")
     original_doi: Series[str] = pa.Field(nullable=True, alias="_original_doi")
+
+    # DQ fields
+    dq_warn: Series[bool] = pa.Field(nullable=True, alias="_dq_warn")
+    dq_error: Series[bool] = pa.Field(nullable=True, alias="_dq_error")
 
     # Lineage metadata
     run_id: Series[str] = pa.Field(nullable=False, alias="_run_id")

--- a/src/bioetl/infrastructure/schemas/silver.py
+++ b/src/bioetl/infrastructure/schemas/silver.py
@@ -204,6 +204,9 @@ PUBMED_PUBLICATION_SCHEMA = pa.schema(
         pa.field("title", pa.string()),
         pa.field("volume", pa.string()),
         pa.field("year", pa.int64()),
+        # === DQ suffix (MUST be last, per RULES.md §2.4) ===
+        pa.field("_dq_warn", pa.bool_()),
+        pa.field("_dq_error", pa.bool_()),
     ]
 )
 
@@ -395,6 +398,9 @@ CHEMBL_PUBLICATION_SCHEMA = pa.schema(
         pa.field("title", pa.string()),
         pa.field("volume", pa.string()),
         pa.field("year", pa.int64()),
+        # === DQ suffix (MUST be last, per RULES.md §2.4) ===
+        pa.field("_dq_warn", pa.bool_()),
+        pa.field("_dq_error", pa.bool_()),
     ]
 )
 
@@ -644,6 +650,9 @@ CROSSREF_PUBLICATION_SCHEMA = pa.schema(
         pa.field("title", pa.string()),
         pa.field("volume", pa.string()),
         pa.field("year", pa.int64()),
+        # === DQ suffix (MUST be last, per RULES.md §2.4) ===
+        pa.field("_dq_warn", pa.bool_()),
+        pa.field("_dq_error", pa.bool_()),
     ]
 )
 
@@ -687,6 +696,9 @@ OPENALEX_PUBLICATION_SCHEMA = pa.schema(
         pa.field("source", pa.string()),
         pa.field("title", pa.string()),
         pa.field("year", pa.int64()),
+        # === DQ suffix (MUST be last, per RULES.md §2.4) ===
+        pa.field("_dq_warn", pa.bool_()),
+        pa.field("_dq_error", pa.bool_()),
     ]
 )
 


### PR DESCRIPTION
Add _dq_warn and _dq_error fields to all publication schemas for unified data quality tracking across providers:

Silver schemas (PyArrow):
- CHEMBL_PUBLICATION_SCHEMA
- PUBMED_PUBLICATION_SCHEMA
- CROSSREF_PUBLICATION_SCHEMA
- OPENALEX_PUBLICATION_SCHEMA (SEMANTICSCHOLAR_PUBLICATION_SCHEMA already had these fields)

Gold schemas (Pandera):
- ChEMBLDocumentGoldSchema
- PubMedPublicationGoldSchema
- SemanticScholarPublicationGoldSchema
- CrossRefPublicationGoldSchema
- OpenAlexPublicationGoldSchema

Domain schemas (Pandera):
- ChemblPublicationSchema
- ArticleSchema (PubMed)
- PublicationEnrichedSchema (CrossRef)
- OpenAlexPublicationSchema

All fields are placed at the end of schemas as per RULES.md §2.4.