### PR TITLE
Fix failing architecture metrics checks

### DIFF
--- a/tests/unit/domain/schemas/test_year_validation.py
+++ b/tests/unit/domain/schemas/test_year_validation.py
@@ -199,6 +199,8 @@ class TestChemblYearValidation:
             "issue": "1",
             "first_page": "1",
             "last_page": "10",
+            "_lookup_method": "direct",
+            "_original_id": None,
         }
 
     def test_year_boundary_values(self, valid_record: dict) -> None:


### PR DESCRIPTION
Add _lookup_method and _original_id fields to the ChemblYearValidation test fixture to match the updated ChemblPublicationSchema which now requires these lookup metadata fields.