### PR TITLE
Add Cross-Reference ID fields to publications

### DIFF
--- a/src/bioetl/application/pipelines/openalex/extractors.py
+++ b/src/bioetl/application/pipelines/openalex/extractors.py
@@ -237,11 +237,14 @@ def extract_external_ids(ids: dict[str, Any] | None) -> dict[str, Any]:
     - pmcid: "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC123456" -> "PMC123456"
     - mag: Microsoft Academic Graph ID (integer or string)
 
+    Note: Returns intermediate keys matching API names. Transformer maps
+    pmcid -> pmc_id for schema consistency.
+
     Args:
         ids: IDs object from OpenAlex work.
 
     Returns:
-        Dictionary with pmid, pmcid, mag_id fields.
+        Dictionary with pmid, pmcid (maps to pmc_id in transformer), mag_id fields.
 
     Example:
         >>> extract_external_ids({

--- a/src/bioetl/application/pipelines/openalex/transformer.py
+++ b/src/bioetl/application/pipelines/openalex/transformer.py
@@ -150,7 +150,7 @@ class OpenAlexPublicationTransformer(BasePublicationTransformer):
         # Extract Open Access info
         oa_info = extract_open_access_info(rec.get("open_access", {}))
 
-        # Extract external IDs (pmid, pmcid, mag)
+        # Extract external IDs (pmid, pmc_id, mag)
         external_ids = extract_external_ids(rec.get("ids", {}))
 
         # Extract MeSH terms
@@ -175,7 +175,7 @@ class OpenAlexPublicationTransformer(BasePublicationTransformer):
             "openalex_id": openalex_id,
             "doi": doi,
             "pmid": external_ids.get("pmid"),
-            "pmcid": external_ids.get("pmcid"),
+            "pmc_id": external_ids.get("pmcid"),  # API uses "pmcid", we use "pmc_id"
             "mag_id": external_ids.get("mag_id"),
             "title": rec.get("title"),
             "abstract": abstract,

--- a/src/bioetl/application/pipelines/semanticscholar/extractors.py
+++ b/src/bioetl/application/pipelines/semanticscholar/extractors.py
@@ -23,7 +23,7 @@ def extract_external_ids(external_ids: dict[str, Any] | None) -> dict[str, Any]:
         external_ids: Dict of external IDs from S2 response.
 
     Returns:
-        Dict with normalized keys: doi, pmid, pmcid, arxiv, corpus_id, mag, acl.
+        Dict with normalized keys: doi, pmid, pmcid (maps to pmc_id), arxiv, corpus_id, mag, acl.
 
     Example:
         >>> ids = {"DOI": "10.1038/...", "PubMed": "12345678", "CorpusId": 123}

--- a/src/bioetl/application/pipelines/semanticscholar/transformer.py
+++ b/src/bioetl/application/pipelines/semanticscholar/transformer.py
@@ -164,7 +164,7 @@ class SemanticScholarPublicationTransformer(BasePublicationTransformer):
             "paper_id": paper_id,
             "doi": doi,
             "pmid": pmid,  # Use validated PMID from PubMedId Value Object
-            "pmcid": external_ids.get("pmcid"),
+            "pmc_id": external_ids.get("pmcid"),  # API uses "pmcid", we use "pmc_id"
             "arxiv_id": external_ids.get("arxiv"),
             "corpus_id": external_ids.get("corpus_id"),
             "title": rec.get("title"),

--- a/src/bioetl/domain/entities/openalex.py
+++ b/src/bioetl/domain/entities/openalex.py
@@ -148,8 +148,9 @@ class OpenAlexPublicationRecord(BaseModel):
     )
 
     # External identifiers
-    pmcid: str | None = PydanticField(
-        default=None, description="PubMed Central ID (e.g., PMC7095418)"
+    # pmc_id: PubMed Central ID (format: "PMC1234567")
+    pmc_id: str | None = PydanticField(
+        default=None, description="PubMed Central ID (format: PMC1234567)"
     )
     mag_id: str | None = PydanticField(
         default=None, description="Microsoft Academic Graph ID"
@@ -206,7 +207,8 @@ class OpenAlexPublicationEntity(PublicationEntityBase):
     openalex_id: str
 
     # External identifiers (in addition to inherited doi, pmid)
-    pmcid: str | None = None  # PubMed Central ID (e.g., PMC7095418)
+    # pmc_id: PubMed Central ID (format: "PMC1234567")
+    pmc_id: str | None = None
     mag_id: str | None = None  # Microsoft Academic Graph ID
 
     # OpenAlex-specific: Concepts (top-level only)

--- a/src/bioetl/domain/entities/semanticscholar.py
+++ b/src/bioetl/domain/entities/semanticscholar.py
@@ -10,7 +10,7 @@ Terminology:
 Used for DOI resolution and publication metadata enrichment via Semantic Scholar API.
 
 Note: SemanticScholarPublicationEntity inherits common fields from PublicationEntityBase.
-Provider-specific fields (paper_id, pmcid, arxiv_id, etc.) are defined here.
+Provider-specific fields (paper_id, pmc_id, arxiv_id, etc.) are defined here.
 """
 
 from __future__ import annotations
@@ -38,7 +38,7 @@ class SemanticScholarPublicationEntity(PublicationEntityBase):
 
     SemanticScholar-specific Attributes:
         paper_id: Semantic Scholar Paper ID (40-char hex S2 ID). REQUIRED.
-        pmcid: PubMed Central ID.
+        pmc_id: PubMed Central ID (format: PMC1234567).
         arxiv_id: ArXiv ID.
         corpus_id: Semantic Scholar Corpus ID.
         tldr: AI-generated summary (TL;DR).
@@ -59,7 +59,8 @@ class SemanticScholarPublicationEntity(PublicationEntityBase):
     paper_id: str
 
     # SemanticScholar-specific external identifiers
-    pmcid: str | None = None
+    # pmc_id: PubMed Central ID (format: "PMC1234567")
+    pmc_id: str | None = None
     arxiv_id: str | None = None
     corpus_id: int | None = None
 

--- a/src/bioetl/domain/schemas/chembl/publication.py
+++ b/src/bioetl/domain/schemas/chembl/publication.py
@@ -31,11 +31,20 @@ class ChemblPublicationSchema(ETLRecordSchema):
         str_matches=r"^CHEMBL\d+$",
         description="ChEMBL ID.",
     )
+    # Cross-reference IDs for linking publications across providers
+    # pmid: PubMed ID (numeric string: "12345678")
     pmid: Series[str] | None = pa.Field(
         nullable=True,
         str_matches=r"^\d+$",
-        description="PubMed identifier (numeric string). Standardized name (was pubmed_id).",
+        description="PubMed identifier (numeric string: '12345678').",
     )
+    # pmc_id: PubMed Central ID (format: "PMC1234567")
+    pmc_id: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^PMC\d+$",
+        description="PubMed Central identifier (format: 'PMC1234567').",
+    )
+    # doi: Digital Object Identifier (lowercase, without "https://doi.org/")
     doi: Series[str] | None = pa.Field(
         nullable=True,
         str_matches=DOI_REGEX_PATTERN,

--- a/src/bioetl/domain/schemas/crossref/publication.py
+++ b/src/bioetl/domain/schemas/crossref/publication.py
@@ -26,11 +26,24 @@ class PublicationEnrichedSchema(ETLRecordSchema):
     Represents publication metadata from CrossRef API with citation enrichment.
     """
 
-    # === Primary Key (DOI) ===
+    # === Cross-reference IDs for linking publications across providers ===
+    # doi: Digital Object Identifier (lowercase, without "https://doi.org/") - Primary key
     doi: Series[str] = pa.Field(
         nullable=False,
         str_matches=DOI_REGEX_PATTERN,
         description="Digital Object Identifier (normalized: lowercase, stripped)",
+    )
+    # pmid: PubMed ID (numeric string: "12345678")
+    pmid: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^\d+$",
+        description="PubMed identifier (numeric string: '12345678').",
+    )
+    # pmc_id: PubMed Central ID (format: "PMC1234567")
+    pmc_id: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^PMC\d+$",
+        description="PubMed Central identifier (format: 'PMC1234567').",
     )
 
     # === Core Metadata ===

--- a/src/bioetl/domain/schemas/openalex/publication.py
+++ b/src/bioetl/domain/schemas/openalex/publication.py
@@ -39,13 +39,27 @@ class OpenAlexPublicationSchema(ETLRecordSchema):
         description="OpenAlex Work ID (e.g., W2148763428)",
     )
 
-    # === Core Fields ===
+    # === Cross-reference IDs for linking publications across providers ===
+    # doi: Digital Object Identifier (lowercase, without "https://doi.org/")
     doi: Series[str] = pa.Field(
         nullable=True,
         str_matches=DOI_REGEX_PATTERN,
-        description="Digital Object Identifier",
+        description="Digital Object Identifier (normalized: lowercase, stripped)",
+    )
+    # pmid: PubMed ID (numeric string: "12345678")
+    pmid: Series[str] = pa.Field(
+        nullable=True,
+        str_matches=r"^\d+$",
+        description="PubMed identifier (numeric string: '12345678').",
+    )
+    # pmc_id: PubMed Central ID (format: "PMC1234567")
+    pmc_id: Series[str] = pa.Field(
+        nullable=True,
+        str_matches=r"^PMC\d+$",
+        description="PubMed Central identifier (format: 'PMC1234567').",
     )
 
+    # === Core Fields ===
     title: Series[str] = pa.Field(
         nullable=True,
         description="Publication title",

--- a/src/bioetl/domain/schemas/semanticscholar/publication.py
+++ b/src/bioetl/domain/schemas/semanticscholar/publication.py
@@ -51,10 +51,12 @@ class SemanticScholarPublicationSchema(ETLRecordSchema):
         description="PubMed ID",
     )
 
-    pmcid: Series[str] = pa.Field(
+    # Cross-reference IDs for linking publications across providers
+    # pmc_id: PubMed Central ID (format: "PMC1234567")
+    pmc_id: Series[str] = pa.Field(
         nullable=True,
         str_matches=r"^PMC\d+$",
-        description="PubMed Central ID",
+        description="PubMed Central ID (format: PMC1234567)",
     )
 
     arxiv_id: Series[str] = pa.Field(

--- a/src/bioetl/infrastructure/schemas/gold.py
+++ b/src/bioetl/infrastructure/schemas/gold.py
@@ -395,7 +395,12 @@ class ChEMBLDocumentGoldSchema(pa.DataFrameModel):
     entity_id: Series[str] = pa.Field(nullable=False)
     content_hash: Series[str] = pa.Field(nullable=False)
     document_chembl_id: Series[str] = pa.Field(nullable=False)
-    pmid: Series[str] = pa.Field(nullable=True)  # Standardized name, numeric string
+    # Cross-reference IDs for linking publications across providers
+    # pmid: PubMed ID (numeric string: "12345678")
+    pmid: Series[str] = pa.Field(nullable=True)
+    # pmc_id: PubMed Central ID (format: "PMC1234567")
+    pmc_id: Series[str] = pa.Field(nullable=True)
+    # doi: Digital Object Identifier (lowercase, without "https://doi.org/")
     doi: Series[str] = pa.Field(nullable=True)
     patent_id: Series[str] = pa.Field(nullable=True)
     title: Series[str] = pa.Field(nullable=True)
@@ -668,7 +673,9 @@ class SemanticScholarPublicationGoldSchema(pa.DataFrameModel):
     # External IDs
     doi: Series[str] = pa.Field(nullable=True)
     pmid: Series[str] = pa.Field(nullable=True)
-    pmcid: Series[str] = pa.Field(nullable=True)
+    # Cross-reference IDs for linking publications across providers
+    # pmc_id: PubMed Central ID (format: "PMC1234567")
+    pmc_id: Series[str] = pa.Field(nullable=True)
     arxiv_id: Series[str] = pa.Field(nullable=True)
     corpus_id: Series[float] = pa.Field(nullable=True, coerce=True)  # int64
 
@@ -735,8 +742,13 @@ class CrossRefPublicationGoldSchema(pa.DataFrameModel):
     entity_id: Series[str] = pa.Field(nullable=False)
     content_hash: Series[str] = pa.Field(nullable=False)
 
-    # Primary key
+    # Cross-reference IDs for linking publications across providers
+    # doi: Digital Object Identifier (lowercase, without "https://doi.org/") - Primary key
     doi: Series[str] = pa.Field(nullable=False)
+    # pmid: PubMed ID (numeric string: "12345678")
+    pmid: Series[str] = pa.Field(nullable=True)
+    # pmc_id: PubMed Central ID (format: "PMC1234567")
+    pmc_id: Series[str] = pa.Field(nullable=True)
 
     # Core fields
     title: Series[str] = pa.Field(nullable=True)
@@ -794,8 +806,13 @@ class OpenAlexPublicationGoldSchema(pa.DataFrameModel):
     # Primary key
     openalex_id: Series[str] = pa.Field(nullable=False)
 
-    # Core fields
+    # Cross-reference IDs for linking publications across providers
+    # doi: Digital Object Identifier (lowercase, without "https://doi.org/")
     doi: Series[str] = pa.Field(nullable=True)
+    # pmid: PubMed ID (numeric string: "12345678")
+    pmid: Series[str] = pa.Field(nullable=True)
+    # pmc_id: PubMed Central ID (format: "PMC1234567")
+    pmc_id: Series[str] = pa.Field(nullable=True)
     title: Series[str] = pa.Field(nullable=True)
     abstract: Series[str] = pa.Field(nullable=True)
     authors: Series[object] = pa.Field(nullable=True)  # list[str]

--- a/src/bioetl/infrastructure/schemas/silver.py
+++ b/src/bioetl/infrastructure/schemas/silver.py
@@ -396,9 +396,11 @@ CHEMBL_PUBLICATION_SCHEMA = pa.schema(
         pa.field("journal_full_title", pa.string()),
         pa.field("last_page", pa.string()),
         pa.field("patent_id", pa.string()),
-        pa.field(
-            "pmid", pa.string()
-        ),  # Standardized name (was pubmed_id), numeric string for cross-provider consistency
+        # Cross-reference IDs for linking publications across providers
+        # pmc_id: PubMed Central ID (format: "PMC1234567") - nullable, may not exist for all publications
+        pa.field("pmc_id", pa.string()),
+        # pmid: PubMed ID (numeric string: "12345678")
+        pa.field("pmid", pa.string()),
         pa.field("src_id", pa.int64()),
         pa.field("title", pa.string()),
         pa.field("volume", pa.string()),
@@ -597,7 +599,10 @@ SEMANTICSCHOLAR_PUBLICATION_SCHEMA = pa.schema(
         pa.field("pages", pa.string()),
         # Primary key
         pa.field("paper_id", pa.string()),
-        pa.field("pmcid", pa.string()),
+        # Cross-reference IDs for linking publications across providers
+        # pmc_id: PubMed Central ID (format: "PMC1234567")
+        pa.field("pmc_id", pa.string()),
+        # pmid: PubMed ID (numeric string: "12345678")
         pa.field("pmid", pa.string()),
         pa.field("publication_date", pa.string()),
         pa.field("publication_types", pa.string()),
@@ -639,7 +644,8 @@ CROSSREF_PUBLICATION_SCHEMA = pa.schema(
         pa.field("citation_count", pa.int64()),
         # Metadata
         pa.field("doc_type", pa.string()),
-        # Primary key
+        # Cross-reference IDs for linking publications across providers
+        # doi: Digital Object Identifier (lowercase, without "https://doi.org/") - Primary key
         pa.field("doi", pa.string()),
         pa.field("first_page", pa.string()),
         pa.field("issn", pa.list_(pa.string())),
@@ -649,6 +655,10 @@ CROSSREF_PUBLICATION_SCHEMA = pa.schema(
         pa.field("language", pa.string()),
         pa.field("last_page", pa.string()),
         pa.field("license_url", pa.string()),
+        # pmc_id: PubMed Central ID (format: "PMC1234567") - nullable, may not exist for all publications
+        pa.field("pmc_id", pa.string()),
+        # pmid: PubMed ID (numeric string: "12345678") - nullable, may not exist for all publications
+        pa.field("pmid", pa.string()),
         # Date fields
         pa.field("published_online", pa.string()),
         pa.field("published_print", pa.string()),
@@ -691,7 +701,8 @@ OPENALEX_PUBLICATION_SCHEMA = pa.schema(
         pa.field("concepts", pa.list_(pa.string())),
         # Metadata
         pa.field("doc_type", pa.string()),
-        # Core fields
+        # Cross-reference IDs for linking publications across providers
+        # doi: Digital Object Identifier (lowercase, without "https://doi.org/")
         pa.field("doi", pa.string()),
         pa.field("is_oa", pa.bool_()),
         # Journal info
@@ -701,6 +712,10 @@ OPENALEX_PUBLICATION_SCHEMA = pa.schema(
         pa.field("oa_status", pa.string()),
         # Primary key
         pa.field("openalex_id", pa.string()),
+        # pmc_id: PubMed Central ID (format: "PMC1234567") - nullable, may not exist for all publications
+        pa.field("pmc_id", pa.string()),
+        # pmid: PubMed ID (numeric string: "12345678") - nullable, may not exist for all publications
+        pa.field("pmid", pa.string()),
         # Date fields
         pa.field("publication_date", pa.string()),
         pa.field("publisher", pa.string()),

--- a/tests/architecture/test_code_metrics.py
+++ b/tests/architecture/test_code_metrics.py
@@ -86,7 +86,7 @@ class TestFileSizeLimits:
         "silver_writer.py": 1140,  # 1126 LOC - schema drift + merge logic + MetadataCoordinator fallback + SilverWriteResult return + transform lineage
         "gold_writer.py": 930,  # 918 LOC - SCD Type 2 + MetadataCoordinator fallback + silver_refs lineage + transform lineage
         "bronze_writer.py": 760,  # 749 LOC - streaming compression + MetadataCoordinator fallback + SourceMetadata param
-        "gold.py": 940,  # 933 LOC - Gold layer Pandera schemas (+ IDMapping + taxonomy_id standardization + Config docstrings + lookup metadata comments)
+        "gold.py": 960,  # 950 LOC - Gold layer Pandera schemas (+ IDMapping + cross-reference ID fields + lookup metadata comments)
         "silver.py": 795,  # 782 LOC - Silver PyArrow schemas (+ IDMapping + taxonomy_id standardization + lookup metadata)
         "client.py": 700,  # 692 LOC - ChemblAdapter (complex FilterableDataSourcePort), CrossRefAdapter (DOI→title fallback)
         "adapter.py": 635,  # 632 LOC - SemanticScholarAdapter with FilterableDataSourcePort + fallback logic

--- a/tests/unit/domain/schemas/openalex/test_publication_schema.py
+++ b/tests/unit/domain/schemas/openalex/test_publication_schema.py
@@ -37,7 +37,10 @@ def valid_record() -> dict:
         "_dq_error": False,
         "_index": 0,
         "openalex_id": "W2148763428",
+        # Cross-reference IDs for linking publications across providers
         "doi": "10.1038/s41586-024-07487-w",
+        "pmid": "12345678",  # PubMed ID (numeric string)
+        "pmc_id": "PMC1234567",  # PubMed Central ID (format: PMC1234567)
         "title": "Example Publication",
         "abstract": "This is an abstract",
         "year": 2024,

--- a/tests/unit/domain/schemas/semanticscholar/test_publication_schema.py
+++ b/tests/unit/domain/schemas/semanticscholar/test_publication_schema.py
@@ -76,17 +76,17 @@ class TestPmidValidation:
 class TestPmcidValidation:
     """Tests for PMCID field validation."""
 
-    def test_valid_pmcid_format(self) -> None:
+    def test_valid_pmc_id_format(self) -> None:
         """Test valid PMCID with PMC prefix."""
-        valid_pmcid = "PMC1234567"
+        valid_pmc_id = "PMC1234567"
         pattern = r"^PMC\d+$"
-        assert re.match(pattern, valid_pmcid) is not None
+        assert re.match(pattern, valid_pmc_id) is not None
 
-    def test_invalid_pmcid_no_prefix(self) -> None:
+    def test_invalid_pmc_id_no_prefix(self) -> None:
         """Test PMCID without PMC prefix fails."""
-        invalid_pmcid = "1234567"
+        invalid_pmc_id = "1234567"
         pattern = r"^PMC\d+$"
-        assert re.match(pattern, invalid_pmcid) is None
+        assert re.match(pattern, invalid_pmc_id) is None
 
 
 class TestYearValidation:
@@ -233,7 +233,7 @@ class TestSchemaFieldDefinitions:
             "paper_id",
             "doi",
             "pmid",
-            "pmcid",
+            "pmc_id",
             "arxiv_id",
             "corpus_id",
             "title",
@@ -280,7 +280,7 @@ class TestSchemaFieldDefinitions:
         nullable_fields = [
             "doi",
             "pmid",
-            "pmcid",
+            "pmc_id",
             "arxiv_id",
             "title",
             "abstract",

--- a/tests/unit/domain/schemas/test_year_validation.py
+++ b/tests/unit/domain/schemas/test_year_validation.py
@@ -117,7 +117,7 @@ class TestSemanticScholarYearValidation:
             "paper_id": "a" * 40,  # 40-char hex
             "doi": "10.1038/nature12373",
             "pmid": None,
-            "pmcid": None,
+            "pmc_id": None,
             "arxiv_id": None,
             "corpus_id": 12345,
             "title": "Test Publication",


### PR DESCRIPTION
Add pmid, pmc_id, and doi fields consistently across all publication schemas for linking publications between providers.

Changes:
- Rename pmcid → pmc_id in SemanticScholar schemas for consistency
- Add pmc_id to ChEMBL Publication (silver, gold, domain schemas)
- Add pmid and pmc_id to CrossRef Publication (silver, gold, domain)
- Add pmid and pmc_id to OpenAlex Publication (silver, gold, domain)
- Update OpenAlex and SemanticScholar entities to use pmc_id
- Update transformers to map API field names to internal schema names
- Fix test fixtures to include new fields
- Update gold.py LOC limit in code metrics test

Field formats:
- pmid: numeric string ("12345678")
- pmc_id: format "PMC1234567"
- doi: lowercase, without "https://doi.org/"