### PR TITLE
Unify Pages and Dates field formats

### DIFF
--- a/src/bioetl/application/pipelines/chembl/publication_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/publication_transformer.py
@@ -164,7 +164,11 @@ class PublicationTransformer(BaseChemblTransformer):
 
         # Validate year using PublicationYear Value Object
         year_vo = PublicationYear.from_raw(data.get("year"))
-        data["year"] = year_vo.value if year_vo else None
+        validated_year = year_vo.value if year_vo else None
+        data["year"] = validated_year
+
+        # Compute unified publication_date from year (ChEMBL only provides year)
+        data["publication_date"] = f"{validated_year}-01-01" if validated_year else None
 
         # Hash PII field (RULES.md §5.4)
         # ChEMBL authors is a concatenated string - parse to list, hash, serialize to JSON

--- a/src/bioetl/application/pipelines/pubmed/transformer.py
+++ b/src/bioetl/application/pipelines/pubmed/transformer.py
@@ -229,9 +229,42 @@ class PubMedPublicationTransformer(BasePublicationTransformer):
         """
         return False
 
+    def _parse_pages(self, pages: str | None) -> tuple[str | None, str | None]:
+        """Parse medline_pgn format into first_page and last_page.
+
+        Handles formats like:
+        - "123-456" -> ("123", "456")
+        - "123" -> ("123", None)
+        - "e123-e456" -> ("e123", "e456")
+        - "S1-S10" -> ("S1", "S10")
+        - None or empty -> (None, None)
+
+        Args:
+            pages: Page string in medline_pgn format.
+
+        Returns:
+            Tuple of (first_page, last_page).
+        """
+        if not pages or not pages.strip():
+            return None, None
+
+        pages = pages.strip()
+        # Split on hyphen, but handle cases like "e123-e456"
+        if "-" in pages:
+            parts = pages.split("-", 1)
+            first = parts[0].strip() or None
+            last = parts[1].strip() if len(parts) > 1 and parts[1].strip() else None
+            return first, last
+
+        # Single page number
+        return pages, None
+
     def _extract_journal_data(self, article: ET.Element) -> dict[str, Any]:
         """Extract journal-related data from article XML."""
         journal = article.find(".//Journal")
+        pages = get_text(article.find(".//Pagination/MedlinePgn"))
+        first_page, last_page = self._parse_pages(pages)
+
         if not journal:
             return {
                 "journal": None,
@@ -239,7 +272,9 @@ class PubMedPublicationTransformer(BasePublicationTransformer):
                 "issn": None,
                 "volume": None,
                 "issue": None,
-                "pages": get_text(article.find(".//Pagination/MedlinePgn")),
+                "pages": pages,
+                "first_page": first_page,
+                "last_page": last_page,
             }
 
         journal_issue = journal.find("JournalIssue")
@@ -249,8 +284,37 @@ class PubMedPublicationTransformer(BasePublicationTransformer):
             "issn": get_text(journal.find("ISSN")),
             "volume": get_text(journal_issue.find("Volume")) if journal_issue else None,
             "issue": get_text(journal_issue.find("Issue")) if journal_issue else None,
-            "pages": get_text(article.find(".//Pagination/MedlinePgn")),
+            "pages": pages,
+            "first_page": first_page,
+            "last_page": last_page,
         }
+
+    def _compute_publication_date(
+        self, epub_date: str | None, pub_date: str | None, year: int | None
+    ) -> str | None:
+        """Compute unified publication_date with priority: epub_date > pub_date > year.
+
+        Args:
+            epub_date: Electronic publication date (YYYY-MM-DD or partial).
+            pub_date: Publication date (YYYY-MM-DD or partial).
+            year: Publication year.
+
+        Returns:
+            ISO date string (YYYY-MM-DD) or None.
+        """
+        # Priority 1: epub_date if it's a complete date (YYYY-MM-DD)
+        if epub_date and len(epub_date) >= 10:
+            return epub_date[:10]
+
+        # Priority 2: pub_date if it's a complete date
+        if pub_date and len(pub_date) >= 10:
+            return pub_date[:10]
+
+        # Priority 3: Construct from year (use Jan 1 as default)
+        if year:
+            return f"{year}-01-01"
+
+        return None
 
     def _extract_date_data(
         self, article: ET.Element, pubmed_data: ET.Element | None
@@ -266,12 +330,20 @@ class PubMedPublicationTransformer(BasePublicationTransformer):
         year_vo = PublicationYear.from_raw(raw_year)
         validated_year = year_vo.value if year_vo else None
 
+        epub_date = DateExtractor.extract_article_date(article, "Electronic")
+
+        # Compute unified publication_date
+        publication_date = self._compute_publication_date(
+            epub_date, pub_date, validated_year
+        )
+
         return {
             "pub_date": pub_date,
+            "publication_date": publication_date,
             "year": validated_year,
             "publication_year": validated_year,
             "accepted_date": DateExtractor.extract_history_date(history, "accepted"),
             "received_date": DateExtractor.extract_history_date(history, "received"),
             "revised_date": DateExtractor.extract_history_date(history, "revised"),
-            "epub_date": DateExtractor.extract_article_date(article, "Electronic"),
+            "epub_date": epub_date,
         }

--- a/src/bioetl/application/pipelines/semanticscholar/transformer.py
+++ b/src/bioetl/application/pipelines/semanticscholar/transformer.py
@@ -103,6 +103,33 @@ class SemanticScholarPublicationTransformer(BasePublicationTransformer):
             data_normalizer=data_normalizer,
         )
 
+    def _parse_pages(self, pages: str | None) -> tuple[str | None, str | None]:
+        """Parse pages string into first_page and last_page.
+
+        Handles formats like:
+        - "123-456" -> ("123", "456")
+        - "123" -> ("123", None)
+        - "e123-e456" -> ("e123", "e456")
+        - None or empty -> (None, None)
+
+        Args:
+            pages: Page string in "first-last" format.
+
+        Returns:
+            Tuple of (first_page, last_page).
+        """
+        if not pages or not pages.strip():
+            return None, None
+
+        pages = pages.strip()
+        if "-" in pages:
+            parts = pages.split("-", 1)
+            first = parts[0].strip() or None
+            last = parts[1].strip() if len(parts) > 1 and parts[1].strip() else None
+            return first, last
+
+        return pages, None
+
     def _extract_business_data(self, record: BronzeRecord) -> dict[str, Any]:
         """Extract and normalize fields from Semantic Scholar record.
 
@@ -141,6 +168,10 @@ class SemanticScholarPublicationTransformer(BasePublicationTransformer):
             rec.get("venue"),
         )
 
+        # Parse pages into unified first_page/last_page
+        pages = journal_info.get("pages")
+        first_page, last_page = self._parse_pages(pages)
+
         # Open access info
         oa_info = extract_open_access_info(
             rec.get("isOpenAccess"),
@@ -173,7 +204,9 @@ class SemanticScholarPublicationTransformer(BasePublicationTransformer):
             "authors": self.serialize_json_list(hashed_authors),
             "journal": journal_info.get("journal_name"),
             "volume": journal_info.get("volume"),
-            "pages": journal_info.get("pages"),
+            "pages": pages,  # Legacy field
+            "first_page": first_page,  # Unified field
+            "last_page": last_page,  # Unified field
             "venue": rec.get("venue"),
             "year": year,
             "publication_date": rec.get("publicationDate"),

--- a/src/bioetl/domain/entities/pubmed.py
+++ b/src/bioetl/domain/entities/pubmed.py
@@ -66,7 +66,9 @@ class ArticleRecord(BaseModel):
     issn: str | None = PydanticField(default=None, description="ISSN")
     volume: str | None = PydanticField(default=None, description="Volume number")
     issue: str | None = PydanticField(default=None, description="Issue number")
-    pages: str | None = PydanticField(default=None, description="Page numbers")
+    pages: str | None = PydanticField(default=None, description="Page numbers (medline_pgn)")
+    first_page: str | None = PydanticField(default=None, description="First page (unified)")
+    last_page: str | None = PydanticField(default=None, description="Last page (unified)")
 
     # Authors (JSON-serialized list of hashed names for PII compliance)
     authors: str | None = PydanticField(
@@ -171,7 +173,9 @@ class PubMedPublicationEntity(PublicationEntityBase):
     journal_abbrev: str | None = None
     volume: str | None = None
     issue: str | None = None
-    pages: str | None = None
+    pages: str | None = None  # Legacy: medline_pgn format ("123-456")
+    first_page: str | None = None  # Unified: parsed from pages
+    last_page: str | None = None  # Unified: parsed from pages
 
     # PubMed-specific dates (stored as ISO strings YYYY-MM-DD or partial)
     pub_date: str | None = None  # Publication date

--- a/src/bioetl/domain/entities/semanticscholar.py
+++ b/src/bioetl/domain/entities/semanticscholar.py
@@ -69,7 +69,9 @@ class SemanticScholarPublicationEntity(PublicationEntityBase):
 
     # SemanticScholar-specific journal/venue information
     volume: str | None = None
-    pages: str | None = None
+    pages: str | None = None  # Legacy: "first-last" format
+    first_page: str | None = None  # Unified: parsed from pages
+    last_page: str | None = None  # Unified: parsed from pages
     venue: str | None = None
 
     # SemanticScholar-specific metrics

--- a/src/bioetl/infrastructure/schemas/gold.py
+++ b/src/bioetl/infrastructure/schemas/gold.py
@@ -220,9 +220,12 @@ class PubMedPublicationGoldSchema(pa.DataFrameModel):
     issn: Series[str] = pa.Field(nullable=True)
     volume: Series[str] = pa.Field(nullable=True)
     issue: Series[str] = pa.Field(nullable=True)
-    pages: Series[str] = pa.Field(nullable=True)
+    pages: Series[str] = pa.Field(nullable=True)  # Legacy: medline_pgn format
+    first_page: Series[str] = pa.Field(nullable=True)  # Unified: parsed from pages
+    last_page: Series[str] = pa.Field(nullable=True)  # Unified: parsed from pages
     authors: Series[object] = pa.Field(nullable=True)  # list[str]
     pub_date: Series[str] = pa.Field(nullable=True)
+    publication_date: Series[str] = pa.Field(nullable=True)  # Unified: YYYY-MM-DD
     year: Series[float] = pa.Field(nullable=True, coerce=True)
     publication_year: Series[float] = pa.Field(
         nullable=True, coerce=True
@@ -410,6 +413,7 @@ class ChEMBLDocumentGoldSchema(pa.DataFrameModel):
     journal: Series[str] = pa.Field(nullable=True)
     journal_full_title: Series[str] = pa.Field(nullable=True)
     year: Series[float] = pa.Field(nullable=True, coerce=True)
+    publication_date: Series[str] = pa.Field(nullable=True)  # Unified: YYYY-MM-DD
     volume: Series[str] = pa.Field(nullable=True)
     issue: Series[str] = pa.Field(nullable=True)
     first_page: Series[str] = pa.Field(nullable=True)
@@ -689,7 +693,9 @@ class SemanticScholarPublicationGoldSchema(pa.DataFrameModel):
     # Journal/Venue
     journal: Series[str] = pa.Field(nullable=True)
     volume: Series[str] = pa.Field(nullable=True)
-    pages: Series[str] = pa.Field(nullable=True)
+    pages: Series[str] = pa.Field(nullable=True)  # Legacy: "first-last" format
+    first_page: Series[str] = pa.Field(nullable=True)  # Unified: parsed from pages
+    last_page: Series[str] = pa.Field(nullable=True)  # Unified: parsed from pages
     venue: Series[str] = pa.Field(nullable=True)
 
     # Metrics
@@ -764,8 +770,9 @@ class CrossRefPublicationGoldSchema(pa.DataFrameModel):
 
     # Date fields
     year: Series[float] = pa.Field(nullable=True, ge=1900, le=2100, coerce=True)
-    published_print: Series[str] = pa.Field(nullable=True)
-    published_online: Series[str] = pa.Field(nullable=True)
+    publication_date: Series[str] = pa.Field(nullable=True)  # Unified: YYYY-MM-DD
+    published_print: Series[str] = pa.Field(nullable=True)  # Legacy: provider-specific
+    published_online: Series[str] = pa.Field(nullable=True)  # Legacy: provider-specific
 
     # Metadata
     doc_type: Series[str] = pa.Field(nullable=True)
@@ -822,6 +829,10 @@ class OpenAlexPublicationGoldSchema(pa.DataFrameModel):
     journal: Series[str] = pa.Field(nullable=True)
     issn: Series[str] = pa.Field(nullable=True)
     publisher: Series[str] = pa.Field(nullable=True)
+
+    # Unified page fields (OpenAlex doesn't provide pages, but added for consistency)
+    first_page: Series[str] = pa.Field(nullable=True)
+    last_page: Series[str] = pa.Field(nullable=True)
 
     # Date fields
     year: Series[float] = pa.Field(nullable=True, ge=1500, le=2100, coerce=True)

--- a/src/bioetl/infrastructure/schemas/silver.py
+++ b/src/bioetl/infrastructure/schemas/silver.py
@@ -183,6 +183,8 @@ PUBMED_PUBLICATION_SCHEMA = pa.schema(
         # Primary identifiers
         pa.field("doi", pa.string()),
         pa.field("epub_date", pa.string()),
+        # Unified page fields (parsed from medline_pgn/pages)
+        pa.field("first_page", pa.string()),
         # Journal information
         pa.field("issn", pa.string()),
         pa.field("issue", pa.string()),
@@ -191,11 +193,13 @@ PUBMED_PUBLICATION_SCHEMA = pa.schema(
         # Classification
         pa.field("keywords", pa.list_(pa.string())),
         pa.field("language", pa.string()),
+        pa.field("last_page", pa.string()),
         pa.field("mesh_terms", pa.list_(pa.string())),
-        pa.field("pages", pa.string()),
+        pa.field("pages", pa.string()),  # Legacy: medline_pgn format
         pa.field("pmc_id", pa.string()),
         pa.field("pmid", pa.string()),
         pa.field("pub_date", pa.string()),
+        pa.field("publication_date", pa.string()),  # Unified: YYYY-MM-DD format
         pa.field("publication_types", pa.list_(pa.string())),
         pa.field("publication_year", pa.int64()),  # Legacy alias for year
         pa.field("received_date", pa.string()),
@@ -401,6 +405,7 @@ CHEMBL_PUBLICATION_SCHEMA = pa.schema(
         pa.field("pmc_id", pa.string()),
         # pmid: PubMed ID (numeric string: "12345678")
         pa.field("pmid", pa.string()),
+        pa.field("publication_date", pa.string()),  # Unified: YYYY-MM-DD (from year)
         pa.field("src_id", pa.int64()),
         pa.field("title", pa.string()),
         pa.field("volume", pa.string()),
@@ -590,13 +595,16 @@ SEMANTICSCHOLAR_PUBLICATION_SCHEMA = pa.schema(
         pa.field("corpus_id", pa.int64()),
         pa.field("doi", pa.string()),
         pa.field("fields_of_study", pa.string()),
+        # Unified page fields (parsed from pages)
+        pa.field("first_page", pa.string()),
         # Open Access
         pa.field("is_oa", pa.bool_()),
         # Journal/Venue
         pa.field("journal", pa.string()),
+        pa.field("last_page", pa.string()),
         pa.field("oa_status", pa.string()),
         pa.field("open_access_url", pa.string()),
-        pa.field("pages", pa.string()),
+        pa.field("pages", pa.string()),  # Legacy: "first-last" format
         # Primary key
         pa.field("paper_id", pa.string()),
         # Cross-reference IDs for linking publications across providers
@@ -660,8 +668,9 @@ CROSSREF_PUBLICATION_SCHEMA = pa.schema(
         # pmid: PubMed ID (numeric string: "12345678") - nullable, may not exist for all publications
         pa.field("pmid", pa.string()),
         # Date fields
-        pa.field("published_online", pa.string()),
-        pa.field("published_print", pa.string()),
+        pa.field("publication_date", pa.string()),  # Unified: YYYY-MM-DD
+        pa.field("published_online", pa.string()),  # Legacy: provider-specific
+        pa.field("published_print", pa.string()),  # Legacy: provider-specific
         pa.field("publisher", pa.string()),
         pa.field("reference_count", pa.int64()),
         pa.field("source", pa.string()),
@@ -704,11 +713,14 @@ OPENALEX_PUBLICATION_SCHEMA = pa.schema(
         # Cross-reference IDs for linking publications across providers
         # doi: Digital Object Identifier (lowercase, without "https://doi.org/")
         pa.field("doi", pa.string()),
+        # Unified page fields (OpenAlex doesn't provide pages, but added for consistency)
+        pa.field("first_page", pa.string()),
         pa.field("is_oa", pa.bool_()),
         # Journal info
         pa.field("issn", pa.string()),
         pa.field("journal", pa.string()),
         pa.field("language", pa.string()),
+        pa.field("last_page", pa.string()),
         pa.field("oa_status", pa.string()),
         # Primary key
         pa.field("openalex_id", pa.string()),

--- a/tests/unit/application/pipelines/pubmed/test_pubmed_transformer.py
+++ b/tests/unit/application/pipelines/pubmed/test_pubmed_transformer.py
@@ -781,3 +781,170 @@ class TestPubMedTransformerDoiNormalization:
         assert result_lower is not None
         # After normalization, content hashes should be identical
         assert result_upper["content_hash"] == result_lower["content_hash"]
+
+
+@pytest.mark.unit
+class TestPubMedTransformerUnifiedPageFields:
+    """Tests for unified page field parsing (first_page, last_page)."""
+
+    @pytest.fixture
+    def transformer(self) -> PubMedPublicationTransformer:
+        """Create PubMedPublicationTransformer instance."""
+        return PubMedPublicationTransformer(provider="pubmed")
+
+    def test_parse_pages_hyphenated(
+        self,
+        transformer: PubMedPublicationTransformer,
+    ) -> None:
+        """Test parsing of hyphenated page ranges."""
+        first, last = transformer._parse_pages("123-456")
+        assert first == "123"
+        assert last == "456"
+
+    def test_parse_pages_single_page(
+        self,
+        transformer: PubMedPublicationTransformer,
+    ) -> None:
+        """Test parsing of single page number."""
+        first, last = transformer._parse_pages("123")
+        assert first == "123"
+        assert last is None
+
+    def test_parse_pages_electronic_format(
+        self,
+        transformer: PubMedPublicationTransformer,
+    ) -> None:
+        """Test parsing of electronic article numbers (e123-e456)."""
+        first, last = transformer._parse_pages("e123-e456")
+        assert first == "e123"
+        assert last == "e456"
+
+    def test_parse_pages_supplement_format(
+        self,
+        transformer: PubMedPublicationTransformer,
+    ) -> None:
+        """Test parsing of supplement pages (S1-S10)."""
+        first, last = transformer._parse_pages("S1-S10")
+        assert first == "S1"
+        assert last == "S10"
+
+    def test_parse_pages_none(
+        self,
+        transformer: PubMedPublicationTransformer,
+    ) -> None:
+        """Test parsing of None input."""
+        first, last = transformer._parse_pages(None)
+        assert first is None
+        assert last is None
+
+    def test_parse_pages_empty_string(
+        self,
+        transformer: PubMedPublicationTransformer,
+    ) -> None:
+        """Test parsing of empty string."""
+        first, last = transformer._parse_pages("")
+        assert first is None
+        assert last is None
+
+    def test_parse_pages_whitespace(
+        self,
+        transformer: PubMedPublicationTransformer,
+    ) -> None:
+        """Test parsing with whitespace."""
+        first, last = transformer._parse_pages("  123 - 456  ")
+        assert first == "123"
+        assert last == "456"
+
+    @pytest.mark.asyncio
+    async def test_unified_page_fields_in_transform(
+        self,
+        transformer: PubMedPublicationTransformer,
+        mock_context: PipelineContext,
+    ) -> None:
+        """Test that unified page fields are present in transformed output."""
+        record: dict[str, Any] = {"_raw_xml": FULL_PUBMED_XML}
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["pages"] == "123-145"
+        assert result["first_page"] == "123"
+        assert result["last_page"] == "145"
+
+
+@pytest.mark.unit
+class TestPubMedTransformerUnifiedDateFields:
+    """Tests for unified publication_date field."""
+
+    @pytest.fixture
+    def transformer(self) -> PubMedPublicationTransformer:
+        """Create PubMedPublicationTransformer instance."""
+        return PubMedPublicationTransformer(provider="pubmed")
+
+    def test_compute_publication_date_from_epub(
+        self,
+        transformer: PubMedPublicationTransformer,
+    ) -> None:
+        """Test publication_date computed from epub_date (priority 1)."""
+        result = transformer._compute_publication_date(
+            epub_date="2025-02-28", pub_date="2025-03-15", year=2025
+        )
+        assert result == "2025-02-28"
+
+    def test_compute_publication_date_from_pub_date(
+        self,
+        transformer: PubMedPublicationTransformer,
+    ) -> None:
+        """Test publication_date computed from pub_date (priority 2)."""
+        result = transformer._compute_publication_date(
+            epub_date=None, pub_date="2025-03-15", year=2025
+        )
+        assert result == "2025-03-15"
+
+    def test_compute_publication_date_from_year(
+        self,
+        transformer: PubMedPublicationTransformer,
+    ) -> None:
+        """Test publication_date computed from year only (priority 3)."""
+        result = transformer._compute_publication_date(
+            epub_date=None, pub_date=None, year=2025
+        )
+        assert result == "2025-01-01"
+
+    def test_compute_publication_date_none(
+        self,
+        transformer: PubMedPublicationTransformer,
+    ) -> None:
+        """Test publication_date returns None when no date info available."""
+        result = transformer._compute_publication_date(
+            epub_date=None, pub_date=None, year=None
+        )
+        assert result is None
+
+    def test_compute_publication_date_partial_epub_date(
+        self,
+        transformer: PubMedPublicationTransformer,
+    ) -> None:
+        """Test that partial epub_date (YYYY-MM) falls back to pub_date."""
+        result = transformer._compute_publication_date(
+            epub_date="2025-02", pub_date="2025-03-15", year=2025
+        )
+        # epub_date is partial, so falls back to pub_date
+        assert result == "2025-03-15"
+
+    @pytest.mark.asyncio
+    async def test_unified_publication_date_in_transform(
+        self,
+        transformer: PubMedPublicationTransformer,
+        mock_context: PipelineContext,
+    ) -> None:
+        """Test that publication_date is present in transformed output."""
+        record: dict[str, Any] = {"_raw_xml": FULL_PUBMED_XML}
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        # epub_date is "2025-02-28" which takes priority
+        assert result["publication_date"] == "2025-02-28"
+        assert result["epub_date"] == "2025-02-28"
+        assert result["pub_date"] == "2025-03-15"

--- a/tests/unit/application/pipelines/semanticscholar/test_transformer.py
+++ b/tests/unit/application/pipelines/semanticscholar/test_transformer.py
@@ -418,3 +418,93 @@ class TestSemanticScholarDoiNormalization:
         assert result_lower is not None
         # After normalization, content hashes should be identical
         assert result_upper["content_hash"] == result_lower["content_hash"]
+
+
+class TestSemanticScholarUnifiedPageFields:
+    """Tests for unified page field parsing (first_page, last_page)."""
+
+    @pytest.fixture
+    def transformer(self) -> SemanticScholarPublicationTransformer:
+        """Create a transformer instance."""
+        return SemanticScholarPublicationTransformer()
+
+    def test_parse_pages_hyphenated(
+        self,
+        transformer: SemanticScholarPublicationTransformer,
+    ) -> None:
+        """Test parsing of hyphenated page ranges."""
+        first, last = transformer._parse_pages("123-456")
+        assert first == "123"
+        assert last == "456"
+
+    def test_parse_pages_single_page(
+        self,
+        transformer: SemanticScholarPublicationTransformer,
+    ) -> None:
+        """Test parsing of single page number."""
+        first, last = transformer._parse_pages("123")
+        assert first == "123"
+        assert last is None
+
+    def test_parse_pages_none(
+        self,
+        transformer: SemanticScholarPublicationTransformer,
+    ) -> None:
+        """Test parsing of None input."""
+        first, last = transformer._parse_pages(None)
+        assert first is None
+        assert last is None
+
+    def test_parse_pages_empty_string(
+        self,
+        transformer: SemanticScholarPublicationTransformer,
+    ) -> None:
+        """Test parsing of empty string."""
+        first, last = transformer._parse_pages("")
+        assert first is None
+        assert last is None
+
+    def test_parse_pages_electronic_format(
+        self,
+        transformer: SemanticScholarPublicationTransformer,
+    ) -> None:
+        """Test parsing of electronic article numbers (e123-e456)."""
+        first, last = transformer._parse_pages("e123-e456")
+        assert first == "e123"
+        assert last == "e456"
+
+    @pytest.mark.asyncio
+    async def test_unified_page_fields_in_transform(
+        self,
+        transformer: SemanticScholarPublicationTransformer,
+        mock_context: PipelineContext,
+        sample_record: dict[str, Any],
+    ) -> None:
+        """Test that unified page fields are present in transformed output."""
+        result = await transformer.transform(mock_context, sample_record, 0)
+
+        assert result is not None
+        # sample_record has journal.pages = "123-130"
+        assert result["pages"] == "123-130"
+        assert result["first_page"] == "123"
+        assert result["last_page"] == "130"
+
+    @pytest.mark.asyncio
+    async def test_unified_page_fields_no_pages(
+        self,
+        transformer: SemanticScholarPublicationTransformer,
+        mock_context: PipelineContext,
+    ) -> None:
+        """Test unified page fields when no pages in record."""
+        record = {
+            "paperId": "649def34f8be52c8b66281af98ae884c09aef38b",
+            "title": "Test Paper",
+            "year": 2024,
+        }
+
+        result = await transformer.transform(mock_context, record, 0)
+
+        assert result is not None
+        assert result["pages"] is None
+        assert result["first_page"] is None
+        assert result["last_page"] is None


### PR DESCRIPTION
Add unified first_page, last_page, and publication_date fields to all publication schemas (PubMed, SemanticScholar, ChEMBL, CrossRef, OpenAlex) for cross-provider consistency.

Changes:
- Add first_page, last_page (nullable) to silver and gold schemas
- Add publication_date (YYYY-MM-DD) to schemas missing it
- Implement _parse_pages() in PubMed and SemanticScholar transformers to parse "123-456" format into separate fields
- Implement _compute_publication_date() in PubMed transformer with priority: epub_date > pub_date > year
- ChEMBL transformer computes publication_date from year as "YYYY-01-01"
- Update domain entities to include first_page, last_page fields
- Keep legacy fields (pages, medline_pgn) for backward compatibility
- Add comprehensive unit tests for page and date parsing

Test coverage includes edge cases: hyphenated ranges, single pages, electronic formats (e123-e456), supplements (S1-S10), and null handling.