### PR TITLE
Update transformers for new unified schema

### DIFF
--- a/src/bioetl/application/pipelines/chembl/publication_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/publication_transformer.py
@@ -181,4 +181,15 @@ class PublicationTransformer(BaseChemblTransformer):
         else:
             data["authors"] = None
 
+        # Lookup metadata (direct extraction, no enrichment)
+        data["_lookup_method"] = "direct"
+        data["_original_id"] = str(primary_id)
+
+        # Cross-reference IDs (ChEMBL API doesn't provide PMC ID)
+        data["pmc_id"] = None
+
+        # DQ flags (default: no warnings or errors)
+        data["_dq_warn"] = False
+        data["_dq_error"] = False
+
         return data

--- a/src/bioetl/application/pipelines/crossref/transformer.py
+++ b/src/bioetl/application/pipelines/crossref/transformer.py
@@ -130,6 +130,12 @@ class CrossRefPublicationTransformer(BasePublicationTransformer):
         raw_authors = extract_authors(rec)
         hashed_authors = self.hash_pii_list(raw_authors) or []
 
+        # Compute unified publication_date (prefer print over online)
+        publication_date = self._compute_publication_date(
+            dates.get("published_print"),
+            dates.get("published_online"),
+        )
+
         return {
             "doi": doi,
             "title": extract_first_string(rec.get("title", [])),
@@ -139,6 +145,7 @@ class CrossRefPublicationTransformer(BasePublicationTransformer):
             **page_info,
             **dates,
             "year": extract_year(rec),
+            "publication_date": publication_date,
             "doc_type": CROSSREF_TYPE_MAP.get(rec.get("type", ""), "PUBLICATION"),
             "citation_count": rec.get("is-referenced-by-count"),
             "reference_count": rec.get("references-count"),
@@ -146,9 +153,15 @@ class CrossRefPublicationTransformer(BasePublicationTransformer):
             "license_url": extract_license_url(rec),
             "subjects": rec.get("subject", []),
             "source": "crossref",
+            # Cross-reference IDs (CrossRef doesn't provide PMID or PMC ID)
+            "pmid": None,
+            "pmc_id": None,
             # Lookup metadata (from adapter fallback handler)
             "_lookup_method": rec.get("_lookup_method", "doi"),
             "_original_id": rec.get("_original_id"),
+            # DQ flags (default: no warnings or errors)
+            "_dq_warn": False,
+            "_dq_error": False,
         }
 
     def _get_primary_id_field(self) -> str:
@@ -192,6 +205,42 @@ class CrossRefPublicationTransformer(BasePublicationTransformer):
         doi = record.get("DOI")
         if not doi:
             raise ValueError("DOI is required for CrossRef Publication")
+
+    def _compute_publication_date(
+        self,
+        published_print: str | None,
+        published_online: str | None,
+    ) -> str | None:
+        """Build unified publication_date, preferring print over online.
+
+        CrossRef dates from extract_dates come as partial ISO strings
+        (YYYY-MM-DD, YYYY-MM, or YYYY). We normalize to YYYY-MM-DD format.
+
+        Args:
+            published_print: Print publication date (may be partial).
+            published_online: Online publication date (may be partial).
+
+        Returns:
+            ISO date string (YYYY-MM-DD) or None.
+        """
+        date_str = published_print or published_online
+        if not date_str:
+            return None
+
+        # If already full ISO format (YYYY-MM-DD), return as-is
+        if len(date_str) == 10 and date_str[4] == "-" and date_str[7] == "-":
+            return date_str
+
+        # Partial date: YYYY-MM -> YYYY-MM-01
+        if len(date_str) == 7 and date_str[4] == "-":
+            return f"{date_str}-01"
+
+        # Partial date: YYYY -> YYYY-01-01
+        if len(date_str) == 4 and date_str.isdigit():
+            return f"{date_str}-01-01"
+
+        # Unknown format, return as-is (shouldn't happen with extract_dates)
+        return date_str
 
     def _should_log_fallback_lookup(self) -> bool:
         """Disable fallback lookup logging for CrossRef.

--- a/src/bioetl/application/pipelines/openalex/transformer.py
+++ b/src/bioetl/application/pipelines/openalex/transformer.py
@@ -195,9 +195,15 @@ class OpenAlexPublicationTransformer(BasePublicationTransformer):
             "mesh": mesh_terms,
             "keywords": keywords,
             "language": rec.get("language"),
+            # Pages (OpenAlex doesn't provide page info in standard fields)
+            "first_page": None,
+            "last_page": None,
             "_lookup_method": lookup_method,
             "_original_id": original_id,
             "source": "openalex",
+            # DQ flags (default: no warnings or errors)
+            "_dq_warn": False,
+            "_dq_error": False,
         }
 
     def _get_primary_id_field(self) -> str:

--- a/src/bioetl/application/pipelines/pubmed/transformer.py
+++ b/src/bioetl/application/pipelines/pubmed/transformer.py
@@ -192,12 +192,15 @@ class PubMedPublicationTransformer(BasePublicationTransformer):
                 if medline
                 else None
             ),
-            "pmc_id": IdentifierExtractor.extract_pmc_id(root),
+            "pmc_id": self._normalize_pmc_id(IdentifierExtractor.extract_pmc_id(root)),
             # Lookup metadata (from adapter fallback handler)
             "_lookup_method": cast("dict[str, Any]", record).get(
                 "_lookup_method", "pmid"
             ),
             "_original_id": cast("dict[str, Any]", record).get("_original_id"),
+            # DQ flags (default: no warnings or errors)
+            "_dq_warn": False,
+            "_dq_error": False,
         }
 
     def _get_primary_id_field(self) -> str:
@@ -258,6 +261,25 @@ class PubMedPublicationTransformer(BasePublicationTransformer):
 
         # Single page number
         return pages, None
+
+    def _normalize_pmc_id(self, pmc_id: str | None) -> str | None:
+        """Ensure PMC ID has 'PMC' prefix.
+
+        Normalizes PMC IDs to uppercase with 'PMC' prefix for consistency
+        across providers.
+
+        Args:
+            pmc_id: Raw PMC ID (may or may not have prefix).
+
+        Returns:
+            Normalized PMC ID with 'PMC' prefix, or None if input is empty.
+        """
+        if not pmc_id:
+            return None
+        pmc_id = pmc_id.strip()
+        if not pmc_id.upper().startswith("PMC"):
+            return f"PMC{pmc_id}"
+        return pmc_id.upper()
 
     def _extract_journal_data(self, article: ET.Element) -> dict[str, Any]:
         """Extract journal-related data from article XML."""

--- a/src/bioetl/application/pipelines/semanticscholar/transformer.py
+++ b/src/bioetl/application/pipelines/semanticscholar/transformer.py
@@ -130,6 +130,25 @@ class SemanticScholarPublicationTransformer(BasePublicationTransformer):
 
         return pages, None
 
+    def _normalize_pmc_id(self, pmc_id: str | None) -> str | None:
+        """Ensure PMC ID has 'PMC' prefix.
+
+        Normalizes PMC IDs to uppercase with 'PMC' prefix for consistency
+        across providers.
+
+        Args:
+            pmc_id: Raw PMC ID (may or may not have prefix).
+
+        Returns:
+            Normalized PMC ID with 'PMC' prefix, or None if input is empty.
+        """
+        if not pmc_id:
+            return None
+        pmc_id = pmc_id.strip()
+        if not pmc_id.upper().startswith("PMC"):
+            return f"PMC{pmc_id}"
+        return pmc_id.upper()
+
     def _extract_business_data(self, record: BronzeRecord) -> dict[str, Any]:
         """Extract and normalize fields from Semantic Scholar record.
 
@@ -195,7 +214,9 @@ class SemanticScholarPublicationTransformer(BasePublicationTransformer):
             "paper_id": paper_id,
             "doi": doi,
             "pmid": pmid,  # Use validated PMID from PubMedId Value Object
-            "pmc_id": external_ids.get("pmcid"),  # API uses "pmcid", we use "pmc_id"
+            "pmc_id": self._normalize_pmc_id(
+                external_ids.get("pmcid")
+            ),  # API uses "pmcid", we use "pmc_id"
             "arxiv_id": external_ids.get("arxiv"),
             "corpus_id": external_ids.get("corpus_id"),
             "title": rec.get("title"),
@@ -221,6 +242,9 @@ class SemanticScholarPublicationTransformer(BasePublicationTransformer):
             # Lookup metadata
             "_lookup_method": lookup_method,
             "_original_id": original_id,
+            # DQ flags (default: no warnings or errors)
+            "_dq_warn": False,
+            "_dq_error": False,
         }
 
     def _get_primary_id_field(self) -> str:

--- a/src/bioetl/domain/entities/chembl_structures.py
+++ b/src/bioetl/domain/entities/chembl_structures.py
@@ -47,8 +47,19 @@ class ChemblPublication(BaseEntity):
     first_page: str | None = None
     last_page: str | None = None
 
+    # Cross-reference IDs (ChEMBL doesn't provide PMC ID)
+    pmc_id: str | None = None
+
     # Source information
     src_id: int | None = None
+
+    # Lookup metadata (tracks resolution strategy)
+    _lookup_method: str = "direct"  # ChEMBL uses direct extraction
+    _original_id: str | None = None
+
+    # DQ flags (Data Quality flags)
+    _dq_warn: bool = False
+    _dq_error: bool = False
 
     def __post_init__(self) -> None:
         super().__post_init__()

--- a/src/bioetl/domain/entities/crossref.py
+++ b/src/bioetl/domain/entities/crossref.py
@@ -173,8 +173,7 @@ class CrossRefPublicationEntity(PublicationEntityBase):
     # CrossRef-specific publication details
     volume: str | None = None
     issue: str | None = None
-    first_page: str | None = None
-    last_page: str | None = None
+    # first_page and last_page inherited from PublicationEntityBase
 
     # CrossRef-specific dates
     published_print: str | None = None  # ISO date: YYYY-MM-DD or YYYY-MM or YYYY

--- a/src/bioetl/domain/entities/openalex.py
+++ b/src/bioetl/domain/entities/openalex.py
@@ -206,9 +206,7 @@ class OpenAlexPublicationEntity(PublicationEntityBase):
     # Primary identifier (OpenAlex Work ID) - REQUIRED
     openalex_id: str
 
-    # External identifiers (in addition to inherited doi, pmid)
-    # pmc_id: PubMed Central ID (format: "PMC1234567")
-    pmc_id: str | None = None
+    # External identifiers (in addition to inherited doi, pmid, pmc_id)
     mag_id: str | None = None  # Microsoft Academic Graph ID
 
     # OpenAlex-specific: Concepts (top-level only)

--- a/src/bioetl/domain/entities/publication_base.py
+++ b/src/bioetl/domain/entities/publication_base.py
@@ -38,12 +38,15 @@ class PublicationEntityBase(BaseEntity):
     Attributes:
         doi: Digital Object Identifier (normalized: lowercase, stripped).
         pmid: PubMed ID for biomedical literature.
+        pmc_id: PubMed Central ID (with PMC prefix).
         title: Publication title.
         abstract: Publication abstract (HTML tags stripped).
         authors: JSON-serialized list of author names (hashed for PII compliance).
         journal: Journal/venue name.
         issn: International Standard Serial Number.
         publisher: Publisher name.
+        first_page: First page number (unified across providers).
+        last_page: Last page number (unified across providers).
         year: Publication year.
         publication_date: Publication date (ISO format: YYYY-MM-DD).
         citation_count: Number of citations.
@@ -53,6 +56,8 @@ class PublicationEntityBase(BaseEntity):
         oa_status: OA status (gold, green, hybrid, bronze, closed).
         _lookup_method: How record was resolved (direct, doi, pmid, title_fallback, unknown).
         _original_id: Original identifier from input (for fallback records).
+        _dq_warn: Record has data quality warnings.
+        _dq_error: Record has data quality errors.
         source: Data source identifier (e.g., "crossref", "openalex").
 
     Note:
@@ -65,6 +70,7 @@ class PublicationEntityBase(BaseEntity):
     # Identifiers (all nullable - subclasses define their required primary key)
     doi: str | None = None
     pmid: str | None = None
+    pmc_id: str | None = None  # PubMed Central ID (with PMC prefix)
 
     # Core metadata
     title: str | None = None
@@ -76,9 +82,13 @@ class PublicationEntityBase(BaseEntity):
     issn: str | None = None
     publisher: str | None = None
 
+    # Pagination (unified across providers)
+    first_page: str | None = None
+    last_page: str | None = None
+
     # Dates
     year: int | None = None
-    publication_date: str | None = None
+    publication_date: str | None = None  # ISO format: YYYY-MM-DD
 
     # Metrics
     citation_count: int | None = None
@@ -94,6 +104,10 @@ class PublicationEntityBase(BaseEntity):
     # Lookup metadata (tracks resolution strategy)
     _lookup_method: str = "unknown"  # direct | doi | pmid | title_fallback | unknown
     _original_id: str | None = None
+
+    # DQ flags (Data Quality flags)
+    _dq_warn: bool = False  # Record has data quality warnings
+    _dq_error: bool = False  # Record has data quality errors
 
     # Source tracking (subclasses should override default)
     source: str = ""

--- a/src/bioetl/domain/entities/pubmed.py
+++ b/src/bioetl/domain/entities/pubmed.py
@@ -172,16 +172,14 @@ class PubMedPublicationEntity(PublicationEntityBase):
     # Override: PMID is REQUIRED for PubMed (base has Optional)
     pmid: str
 
-    # PubMed-specific identifiers
-    pmc_id: str | None = None  # PubMed Central ID
+    # PubMed-specific identifiers (pmc_id is now inherited from PublicationEntityBase)
 
     # PubMed-specific journal information
     journal_abbrev: str | None = None
     volume: str | None = None
     issue: str | None = None
     pages: str | None = None  # Legacy: medline_pgn format ("123-456")
-    first_page: str | None = None  # Unified: parsed from pages
-    last_page: str | None = None  # Unified: parsed from pages
+    # first_page and last_page inherited from PublicationEntityBase
 
     # PubMed-specific dates (stored as ISO strings YYYY-MM-DD or partial)
     pub_date: str | None = None  # Publication date

--- a/src/bioetl/domain/entities/semanticscholar.py
+++ b/src/bioetl/domain/entities/semanticscholar.py
@@ -58,9 +58,7 @@ class SemanticScholarPublicationEntity(PublicationEntityBase):
     # Primary identifier (Semantic Scholar Paper ID) - REQUIRED
     paper_id: str
 
-    # SemanticScholar-specific external identifiers
-    # pmc_id: PubMed Central ID (format: "PMC1234567")
-    pmc_id: str | None = None
+    # SemanticScholar-specific external identifiers (in addition to inherited pmc_id)
     arxiv_id: str | None = None
     corpus_id: int | None = None
 
@@ -70,8 +68,7 @@ class SemanticScholarPublicationEntity(PublicationEntityBase):
     # SemanticScholar-specific journal/venue information
     volume: str | None = None
     pages: str | None = None  # Legacy: "first-last" format
-    first_page: str | None = None  # Unified: parsed from pages
-    last_page: str | None = None  # Unified: parsed from pages
+    # first_page and last_page inherited from PublicationEntityBase
     venue: str | None = None
 
     # SemanticScholar-specific metrics

--- a/tests/unit/application/pipelines/__snapshots__/test_transformer_snapshots.ambr
+++ b/tests/unit/application/pipelines/__snapshots__/test_transformer_snapshots.ambr
@@ -193,6 +193,8 @@
 # ---
 # name: TestPubMedPublicationTransformerSnapshot.test_transform_full_snapshot
   dict({
+    '_dq_error': False,
+    '_dq_warn': False,
     '_index': 0,
     '_ingestion_ts': '<ingestion_ts>',
     '_lookup_method': 'pmid',
@@ -253,6 +255,8 @@
 # ---
 # name: TestPubMedPublicationTransformerSnapshot.test_transform_minimal_snapshot
   dict({
+    '_dq_error': False,
+    '_dq_warn': False,
     '_index': 0,
     '_ingestion_ts': '<ingestion_ts>',
     '_lookup_method': 'pmid',
@@ -308,8 +312,12 @@
 # ---
 # name: TestPublicationTransformerSnapshot.test_transform_snapshot
   dict({
+    '_dq_error': False,
+    '_dq_warn': False,
     '_index': 0,
     '_ingestion_ts': '<ingestion_ts>',
+    '_lookup_method': 'direct',
+    '_original_id': 'CHEMBL1234567',
     '_run_id': '<run_id>',
     '_run_type': 'incremental',
     '_source_batch_id': None,
@@ -326,6 +334,7 @@
     'journal_full_title': 'Full Test Journal Name',
     'last_page': '110',
     'patent_id': None,
+    'pmc_id': None,
     'pmid': '12345678',
     'publication_date': '2024-01-01',
     'src_id': 1,


### PR DESCRIPTION
Update all publication transformers to include:
- _lookup_method field for tracking resolution strategy
- _original_id for original identifier
- pmc_id for PubMed Central ID
- _dq_warn and _dq_error flags for data quality
- publication_date in YYYY-MM-DD format
- first_page/last_page parsed from page strings

Updated transformers:
- ChEMBL: Added _lookup_method="direct", pmc_id, DQ flags
- PubMed: Added _normalize_pmc_id(), DQ flags
- CrossRef: Added pmid, pmc_id, _compute_publication_date(), DQ flags
- OpenAlex: Added first_page, last_page, DQ flags
- SemanticScholar: Added _normalize_pmc_id(), DQ flags

Updated domain entities:
- PublicationEntityBase: Added pmc_id, first_page, last_page, _dq_warn, _dq_error
- ChemblPublication: Added pmc_id, _lookup_method, _original_id, DQ flags
- Removed duplicate fields from CrossRef, OpenAlex, SemanticScholar, PubMed entities

Updated snapshots to reflect new fields.