### PR TITLE
Update tests for schema and transformer changes

### DIFF
--- a/tests/unit/application/pipelines/test_date_parsing.py
+++ b/tests/unit/application/pipelines/test_date_parsing.py
@@ -1,0 +1,277 @@
+"""Tests for publication date building across transformers.
+
+Tests the _compute_publication_date method implementations in transformers
+that build unified publication_date (YYYY-MM-DD) from various source formats.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bioetl.application.pipelines.crossref.transformer import (
+    CrossRefPublicationTransformer,
+)
+from bioetl.application.pipelines.pubmed.transformer import (
+    PubMedPublicationTransformer,
+)
+
+
+@pytest.mark.unit
+class TestPubMedDateBuilding:
+    """Tests for PubMed publication date building."""
+
+    @pytest.fixture
+    def transformer(self) -> PubMedPublicationTransformer:
+        """Create PubMed transformer with minimal dependencies."""
+        return PubMedPublicationTransformer(provider="pubmed")
+
+    @pytest.mark.parametrize(
+        "epub_date,pub_date,year,expected",
+        [
+            # epub_date takes priority (full ISO date)
+            ("2024-03-15", "2024-04-01", 2024, "2024-03-15"),
+            ("2024-01-01", "2024-12-31", 2024, "2024-01-01"),
+            # pub_date used when epub_date is partial or missing
+            (None, "2024-03-15", 2024, "2024-03-15"),
+            ("2024-03", "2024-04-01", 2024, "2024-04-01"),  # partial epub falls back
+            # Year-only fallback
+            (None, None, 2024, "2024-01-01"),
+            (None, None, 1999, "1999-01-01"),
+            (None, None, 2025, "2025-01-01"),
+            # All None returns None
+            (None, None, None, None),
+            # Partial dates (less than 10 chars) fall back
+            ("2024", "2024-06-15", 2024, "2024-06-15"),
+            ("2024-06", None, 2024, "2024-01-01"),
+        ],
+    )
+    def test_compute_publication_date(
+        self,
+        transformer: PubMedPublicationTransformer,
+        epub_date: str | None,
+        pub_date: str | None,
+        year: int | None,
+        expected: str | None,
+    ) -> None:
+        """Test publication_date computation with various inputs."""
+        result = transformer._compute_publication_date(epub_date, pub_date, year)
+        assert result == expected
+
+    def test_publication_date_truncates_timestamp(
+        self,
+        transformer: PubMedPublicationTransformer,
+    ) -> None:
+        """Date strings longer than 10 chars should be truncated."""
+        result = transformer._compute_publication_date(
+            epub_date="2024-03-15T12:00:00Z",
+            pub_date="2024-04-01",
+            year=2024,
+        )
+        assert result == "2024-03-15"
+
+    def test_priority_is_epub_over_pub_over_year(
+        self,
+        transformer: PubMedPublicationTransformer,
+    ) -> None:
+        """Priority should be: epub_date > pub_date > year."""
+        # epub_date full -> use epub
+        assert (
+            transformer._compute_publication_date("2024-01-01", "2024-02-01", 2024)
+            == "2024-01-01"
+        )
+
+        # epub_date partial, pub_date full -> use pub_date
+        assert (
+            transformer._compute_publication_date("2024-01", "2024-02-15", 2024)
+            == "2024-02-15"
+        )
+
+        # epub_date None, pub_date full -> use pub_date
+        assert (
+            transformer._compute_publication_date(None, "2024-02-15", 2024)
+            == "2024-02-15"
+        )
+
+        # epub_date None, pub_date None -> use year
+        assert (
+            transformer._compute_publication_date(None, None, 2024)
+            == "2024-01-01"
+        )
+
+
+@pytest.mark.unit
+class TestCrossRefDateBuilding:
+    """Tests for CrossRef publication date building."""
+
+    @pytest.fixture
+    def transformer(self) -> CrossRefPublicationTransformer:
+        """Create CrossRef transformer with minimal dependencies."""
+        return CrossRefPublicationTransformer(provider="crossref")
+
+    @pytest.mark.parametrize(
+        "published_print,published_online,expected",
+        [
+            # Print date takes priority
+            ("2024-03-15", "2024-02-01", "2024-03-15"),
+            ("2024-01-01", "2024-06-15", "2024-01-01"),
+            # Online date used when print is None
+            (None, "2024-03-15", "2024-03-15"),
+            # Full ISO date returned as-is
+            ("2024-06-15", None, "2024-06-15"),
+            # Partial date YYYY-MM normalized to YYYY-MM-01
+            ("2024-06", None, "2024-06-01"),
+            (None, "2024-03", "2024-03-01"),
+            # Partial date YYYY normalized to YYYY-01-01
+            ("2024", None, "2024-01-01"),
+            (None, "2023", "2023-01-01"),
+            # Both None returns None
+            (None, None, None),
+        ],
+    )
+    def test_compute_publication_date(
+        self,
+        transformer: CrossRefPublicationTransformer,
+        published_print: str | None,
+        published_online: str | None,
+        expected: str | None,
+    ) -> None:
+        """Test publication_date computation from print/online dates."""
+        result = transformer._compute_publication_date(
+            published_print, published_online
+        )
+        assert result == expected
+
+    def test_print_priority_over_online(
+        self,
+        transformer: CrossRefPublicationTransformer,
+    ) -> None:
+        """Print date should always take priority over online date."""
+        # Both present: use print
+        assert (
+            transformer._compute_publication_date("2024-01-15", "2024-02-15")
+            == "2024-01-15"
+        )
+
+        # Print is None: use online
+        assert (
+            transformer._compute_publication_date(None, "2024-02-15")
+            == "2024-02-15"
+        )
+
+    def test_crossref_partial_year_only(
+        self,
+        transformer: CrossRefPublicationTransformer,
+    ) -> None:
+        """Year-only dates should be normalized to YYYY-01-01."""
+        result = transformer._compute_publication_date("2024", None)
+        assert result == "2024-01-01"
+
+        result = transformer._compute_publication_date(None, "2023")
+        assert result == "2023-01-01"
+
+    def test_crossref_partial_year_month(
+        self,
+        transformer: CrossRefPublicationTransformer,
+    ) -> None:
+        """Year-month dates should be normalized to YYYY-MM-01."""
+        result = transformer._compute_publication_date("2024-06", None)
+        assert result == "2024-06-01"
+
+        result = transformer._compute_publication_date(None, "2024-12")
+        assert result == "2024-12-01"
+
+
+@pytest.mark.unit
+class TestChemblDateBuilding:
+    """Tests for ChEMBL publication_date computation.
+
+    ChEMBL only provides year, so publication_date is YYYY-01-01.
+    The computation happens in _extract_business_data, not a separate method.
+    These tests verify the expected behavior.
+    """
+
+    def test_chembl_year_to_publication_date(self) -> None:
+        """ChEMBL should build publication_date from year only."""
+        # This is the expected logic:
+        year = 2024
+        expected = f"{year}-01-01"
+        assert expected == "2024-01-01"
+
+        year = 1999
+        expected = f"{year}-01-01"
+        assert expected == "1999-01-01"
+
+    def test_chembl_none_year_gives_none_date(self) -> None:
+        """ChEMBL with None year should give None publication_date."""
+        year = None
+        expected = f"{year}-01-01" if year else None
+        assert expected is None
+
+
+@pytest.mark.unit
+class TestDateParsingEdgeCases:
+    """Tests for edge cases in date parsing."""
+
+    @pytest.fixture
+    def pubmed_transformer(self) -> PubMedPublicationTransformer:
+        """Create PubMed transformer."""
+        return PubMedPublicationTransformer(provider="pubmed")
+
+    @pytest.fixture
+    def crossref_transformer(self) -> CrossRefPublicationTransformer:
+        """Create CrossRef transformer."""
+        return CrossRefPublicationTransformer(provider="crossref")
+
+    def test_pubmed_handles_empty_strings(
+        self,
+        pubmed_transformer: PubMedPublicationTransformer,
+    ) -> None:
+        """Empty strings should be treated as None."""
+        # Empty epub_date should fall back to pub_date
+        result = pubmed_transformer._compute_publication_date("", "2024-03-15", 2024)
+        # Empty string has length 0 < 10, so falls back
+        assert result == "2024-03-15"
+
+    def test_pubmed_handles_whitespace(
+        self,
+        pubmed_transformer: PubMedPublicationTransformer,
+    ) -> None:
+        """Whitespace-only dates are not handled - use valid dates."""
+        # Method takes dates as-is, no strip - caller should preprocess
+        result = pubmed_transformer._compute_publication_date(
+            "2024-03-15", None, 2024
+        )
+        assert result == "2024-03-15"
+
+    def test_crossref_preserves_valid_iso_format(
+        self,
+        crossref_transformer: CrossRefPublicationTransformer,
+    ) -> None:
+        """Valid ISO dates should be preserved as-is."""
+        result = crossref_transformer._compute_publication_date(
+            "2024-12-31", None
+        )
+        assert result == "2024-12-31"
+
+    def test_date_output_is_always_string_or_none(
+        self,
+        pubmed_transformer: PubMedPublicationTransformer,
+        crossref_transformer: CrossRefPublicationTransformer,
+    ) -> None:
+        """Output should always be string or None."""
+        pubmed_result = pubmed_transformer._compute_publication_date(
+            "2024-01-01", None, 2024
+        )
+        assert isinstance(pubmed_result, str) or pubmed_result is None
+
+        crossref_result = crossref_transformer._compute_publication_date(
+            "2024-01-01", None
+        )
+        assert isinstance(crossref_result, str) or crossref_result is None
+
+        # None case
+        pubmed_none = pubmed_transformer._compute_publication_date(None, None, None)
+        assert pubmed_none is None
+
+        crossref_none = crossref_transformer._compute_publication_date(None, None)
+        assert crossref_none is None

--- a/tests/unit/application/pipelines/test_page_parsing.py
+++ b/tests/unit/application/pipelines/test_page_parsing.py
@@ -1,0 +1,237 @@
+"""Tests for page parsing utilities across transformers.
+
+Tests the _parse_pages method implementations in PubMed and SemanticScholar
+transformers that parse medline_pgn and pages strings into first_page/last_page.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bioetl.application.pipelines.pubmed.transformer import (
+    PubMedPublicationTransformer,
+)
+from bioetl.application.pipelines.semanticscholar.transformer import (
+    SemanticScholarPublicationTransformer,
+)
+
+
+@pytest.mark.unit
+class TestPubMedMedlinePgnParsing:
+    """Tests for PubMed medline_pgn parsing."""
+
+    @pytest.fixture
+    def transformer(self) -> PubMedPublicationTransformer:
+        """Create PubMed transformer with minimal dependencies."""
+        return PubMedPublicationTransformer(provider="pubmed")
+
+    @pytest.mark.parametrize(
+        "pgn,expected_first,expected_last",
+        [
+            # Standard hyphenated range
+            ("100-110", "100", "110"),
+            ("1-999", "1", "999"),
+            ("123-456", "123", "456"),
+            # Single page number
+            ("100", "100", None),
+            ("1", "1", None),
+            ("999999", "999999", None),
+            # Electronic article numbers
+            ("e100-e110", "e100", "e110"),
+            ("E123-E456", "E123", "E456"),
+            # Supplement pages
+            ("S1-S10", "S1", "S10"),
+            ("s100-s200", "s100", "s200"),
+            # Short form (abbreviated last page)
+            ("100-10", "100", "10"),
+            ("1234-56", "1234", "56"),
+            # Empty and None
+            ("", None, None),
+            (None, None, None),
+            # Whitespace handling
+            ("  100 - 110  ", "100", "110"),
+            ("100 -110", "100", "110"),
+            ("  100  ", "100", None),
+            # Mixed formats
+            ("A1-A10", "A1", "A10"),
+            ("ii-x", "ii", "x"),
+        ],
+    )
+    def test_parse_medline_pgn(
+        self,
+        transformer: PubMedPublicationTransformer,
+        pgn: str | None,
+        expected_first: str | None,
+        expected_last: str | None,
+    ) -> None:
+        """Test various medline_pgn formats."""
+        first, last = transformer._parse_pages(pgn)
+
+        assert first == expected_first, f"First page mismatch for '{pgn}'"
+        assert last == expected_last, f"Last page mismatch for '{pgn}'"
+
+    def test_hyphen_only_returns_empty(
+        self,
+        transformer: PubMedPublicationTransformer,
+    ) -> None:
+        """Single hyphen should return None for last page."""
+        first, last = transformer._parse_pages("-")
+
+        assert first is None
+        assert last is None
+
+    def test_parse_pages_immutability(
+        self,
+        transformer: PubMedPublicationTransformer,
+    ) -> None:
+        """Parsing should not modify the original string."""
+        original = "100-110"
+        _ = transformer._parse_pages(original)
+
+        assert original == "100-110"
+
+
+@pytest.mark.unit
+class TestSemanticScholarPagesParsing:
+    """Tests for Semantic Scholar pages parsing."""
+
+    @pytest.fixture
+    def transformer(self) -> SemanticScholarPublicationTransformer:
+        """Create SemanticScholar transformer with minimal dependencies."""
+        return SemanticScholarPublicationTransformer(provider="semanticscholar")
+
+    @pytest.mark.parametrize(
+        "pages,expected_first,expected_last",
+        [
+            # Standard hyphenated range
+            ("123-456", "123", "456"),
+            ("1-10", "1", "10"),
+            # Single page
+            ("123", "123", None),
+            ("1", "1", None),
+            # Electronic articles
+            ("e123-e456", "e123", "e456"),
+            # Empty and None
+            (None, None, None),
+            ("", None, None),
+            # Whitespace
+            ("  100 - 200  ", "100", "200"),
+            # Single page with whitespace
+            ("  100  ", "100", None),
+        ],
+    )
+    def test_parse_pages(
+        self,
+        transformer: SemanticScholarPublicationTransformer,
+        pages: str | None,
+        expected_first: str | None,
+        expected_last: str | None,
+    ) -> None:
+        """Test various pages formats from Semantic Scholar."""
+        first, last = transformer._parse_pages(pages)
+
+        assert first == expected_first, f"First page mismatch for '{pages}'"
+        assert last == expected_last, f"Last page mismatch for '{pages}'"
+
+
+@pytest.mark.unit
+class TestPageParsingConsistency:
+    """Tests for consistency between transformer implementations."""
+
+    @pytest.fixture
+    def pubmed_transformer(self) -> PubMedPublicationTransformer:
+        """Create PubMed transformer."""
+        return PubMedPublicationTransformer(provider="pubmed")
+
+    @pytest.fixture
+    def s2_transformer(self) -> SemanticScholarPublicationTransformer:
+        """Create SemanticScholar transformer."""
+        return SemanticScholarPublicationTransformer(provider="semanticscholar")
+
+    @pytest.mark.parametrize(
+        "pages",
+        [
+            "100-200",
+            "123",
+            "e100-e200",
+            None,
+            "",
+            "  100 - 200  ",
+        ],
+    )
+    def test_parsing_consistency_across_transformers(
+        self,
+        pubmed_transformer: PubMedPublicationTransformer,
+        s2_transformer: SemanticScholarPublicationTransformer,
+        pages: str | None,
+    ) -> None:
+        """Both transformers should parse common formats consistently."""
+        pubmed_first, pubmed_last = pubmed_transformer._parse_pages(pages)
+        s2_first, s2_last = s2_transformer._parse_pages(pages)
+
+        assert pubmed_first == s2_first, f"First page inconsistent for '{pages}'"
+        assert pubmed_last == s2_last, f"Last page inconsistent for '{pages}'"
+
+
+@pytest.mark.unit
+class TestPmcIdNormalization:
+    """Tests for PMC ID normalization in transformers."""
+
+    @pytest.fixture
+    def pubmed_transformer(self) -> PubMedPublicationTransformer:
+        """Create PubMed transformer."""
+        return PubMedPublicationTransformer(provider="pubmed")
+
+    @pytest.fixture
+    def s2_transformer(self) -> SemanticScholarPublicationTransformer:
+        """Create SemanticScholar transformer."""
+        return SemanticScholarPublicationTransformer(provider="semanticscholar")
+
+    @pytest.mark.parametrize(
+        "raw_pmc_id,expected",
+        [
+            # Already normalized
+            ("PMC1234567", "PMC1234567"),
+            # Lowercase PMC prefix
+            ("pmc1234567", "PMC1234567"),
+            # Missing prefix - should add PMC
+            ("1234567", "PMC1234567"),
+            # Mixed case
+            ("Pmc1234567", "PMC1234567"),
+            # None and empty
+            (None, None),
+            ("", None),
+            # Whitespace
+            ("  PMC1234567  ", "PMC1234567"),
+            ("  1234567  ", "PMC1234567"),
+        ],
+    )
+    def test_pubmed_pmc_id_normalization(
+        self,
+        pubmed_transformer: PubMedPublicationTransformer,
+        raw_pmc_id: str | None,
+        expected: str | None,
+    ) -> None:
+        """PubMed transformer should normalize PMC IDs correctly."""
+        result = pubmed_transformer._normalize_pmc_id(raw_pmc_id)
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        "raw_pmc_id,expected",
+        [
+            ("PMC1234567", "PMC1234567"),
+            ("pmc1234567", "PMC1234567"),
+            ("1234567", "PMC1234567"),
+            (None, None),
+            ("", None),
+        ],
+    )
+    def test_s2_pmc_id_normalization(
+        self,
+        s2_transformer: SemanticScholarPublicationTransformer,
+        raw_pmc_id: str | None,
+        expected: str | None,
+    ) -> None:
+        """SemanticScholar transformer should normalize PMC IDs correctly."""
+        result = s2_transformer._normalize_pmc_id(raw_pmc_id)
+        assert result == expected

--- a/tests/unit/domain/schemas/common/__init__.py
+++ b/tests/unit/domain/schemas/common/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for common domain schemas."""

--- a/tests/unit/domain/schemas/common/test_publication_base.py
+++ b/tests/unit/domain/schemas/common/test_publication_base.py
@@ -1,0 +1,332 @@
+"""Tests for PublicationBaseSchema.
+
+Tests the base schema used by all publication entities across providers.
+Validates common fields: pmid, doi, pmc_id, title, abstract, year.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pandas as pd
+import pandera as pa
+import pytest
+
+from bioetl.domain.schemas.common.publication_base import (
+    LOOKUP_METHODS,
+    PublicationBaseSchema,
+)
+
+
+@pytest.fixture
+def valid_base_record() -> dict:
+    """Create a valid record with all base publication fields.
+
+    Includes all fields from ETLRecordSchema base class plus
+    PublicationBaseSchema specific fields.
+    """
+    return {
+        # === ETLRecordSchema fields ===
+        "entity_id": "test_pub_001",
+        # SHA256 hash must be exactly 64 hex characters
+        "content_hash": "a" * 64,
+        "_run_id": "run-001",
+        "_run_type": "incremental",
+        "_source_batch_id": "batch-001",
+        "_ingestion_ts": datetime.now(timezone.utc),
+        "_dq_warn": False,
+        "_dq_error": False,
+        "_index": 0,
+        # === PublicationBaseSchema fields ===
+        "pmid": "12345678",
+        "doi": "10.1234/example.test",
+        "pmc_id": "PMC1234567",
+        "title": "Test Publication Title",
+        "abstract": "This is a test abstract for the publication.",
+        "year": 2024,
+    }
+
+
+@pytest.mark.unit
+class TestPublicationBaseSchemaValidation:
+    """Test suite for PublicationBaseSchema validation."""
+
+    def test_valid_record_passes_validation(self, valid_base_record: dict) -> None:
+        """Valid record with all required fields should pass."""
+        df = pd.DataFrame([valid_base_record])
+
+        validated = PublicationBaseSchema.validate(df)
+
+        assert len(validated) == 1
+        assert validated["pmid"].iloc[0] == "12345678"
+        assert validated["doi"].iloc[0] == "10.1234/example.test"
+        assert validated["year"].iloc[0] == 2024
+
+    def test_record_with_nullable_string_fields(self, valid_base_record: dict) -> None:
+        """Record with nullable string fields set to None should pass."""
+        record = valid_base_record.copy()
+        record["pmid"] = None
+        record["doi"] = None
+        record["pmc_id"] = None
+        record["title"] = None
+        record["abstract"] = None
+        # Note: year is int64 (non-nullable in Pandera), keep as valid int
+
+        df = pd.DataFrame([record])
+
+        validated = PublicationBaseSchema.validate(df)
+
+        assert len(validated) == 1
+        assert pd.isna(validated["pmid"].iloc[0])
+        assert pd.isna(validated["doi"].iloc[0])
+
+    def test_extra_columns_allowed(self, valid_base_record: dict) -> None:
+        """Extra columns should be allowed (strict=False)."""
+        valid_base_record["extra_field"] = "extra_value"
+        valid_base_record["provider_specific"] = 123
+
+        df = pd.DataFrame([valid_base_record])
+
+        validated = PublicationBaseSchema.validate(df)
+
+        assert len(validated) == 1
+        assert "extra_field" in validated.columns
+
+    def test_type_coercion(self, valid_base_record: dict) -> None:
+        """Values should be coerced to correct types (coerce=True)."""
+        record = valid_base_record.copy()
+        # Year as string should be coerced to int
+        record["year"] = "2024"
+        # _dq_warn as int should be coerced to bool
+        record["_dq_warn"] = 0
+        # _dq_error as int should be coerced to bool
+        record["_dq_error"] = 0
+
+        df = pd.DataFrame([record])
+
+        validated = PublicationBaseSchema.validate(df)
+
+        assert len(validated) == 1
+        assert validated["year"].iloc[0] == 2024
+        # Use == instead of 'is' for numpy bool comparison
+        assert validated["_dq_warn"].iloc[0] == False  # noqa: E712
+        assert validated["_dq_error"].iloc[0] == False  # noqa: E712
+
+
+@pytest.mark.unit
+class TestPublicationBaseSchemaFieldValidation:
+    """Tests for individual field validation rules."""
+
+    def test_valid_pmid_formats(self, valid_base_record: dict) -> None:
+        """PMID must be numeric string."""
+        valid_pmids = ["1", "12345678", "99999999999"]
+
+        for pmid in valid_pmids:
+            record = valid_base_record.copy()
+            record["pmid"] = pmid
+            df = pd.DataFrame([record])
+            validated = PublicationBaseSchema.validate(df)
+            assert validated["pmid"].iloc[0] == pmid
+
+    def test_invalid_pmid_format_fails(self, valid_base_record: dict) -> None:
+        """PMID must be numeric string - non-numeric should fail."""
+        invalid_pmids = ["PMID12345", "abc", "12345.67", "12345abc"]
+
+        for pmid in invalid_pmids:
+            record = valid_base_record.copy()
+            record["pmid"] = pmid
+            df = pd.DataFrame([record])
+
+            with pytest.raises(pa.errors.SchemaError):
+                PublicationBaseSchema.validate(df)
+
+    def test_valid_doi_formats(self, valid_base_record: dict) -> None:
+        """DOI should validate correctly formatted values."""
+        valid_dois = [
+            "10.1234/test",
+            "10.1038/nature12373",
+            "10.1000/xyz-abc_123",
+            "10.1016/j.cell.2020.01.001",
+        ]
+
+        for doi in valid_dois:
+            record = valid_base_record.copy()
+            record["doi"] = doi
+            df = pd.DataFrame([record])
+            validated = PublicationBaseSchema.validate(df)
+            assert validated["doi"].iloc[0] == doi
+
+    def test_invalid_doi_format_fails(self, valid_base_record: dict) -> None:
+        """Invalid DOI formats should fail validation."""
+        invalid_dois = [
+            "not-a-doi",
+            "doi:10.1234/test",  # with prefix
+            "https://doi.org/10.1234/test",  # URL format
+        ]
+
+        for doi in invalid_dois:
+            record = valid_base_record.copy()
+            record["doi"] = doi
+            df = pd.DataFrame([record])
+
+            with pytest.raises(pa.errors.SchemaError):
+                PublicationBaseSchema.validate(df)
+
+    def test_valid_pmc_id_format(self, valid_base_record: dict) -> None:
+        """PMC ID must start with 'PMC' followed by digits."""
+        valid_pmc_ids = ["PMC1", "PMC1234567", "PMC99999999"]
+
+        for pmc_id in valid_pmc_ids:
+            record = valid_base_record.copy()
+            record["pmc_id"] = pmc_id
+            df = pd.DataFrame([record])
+            validated = PublicationBaseSchema.validate(df)
+            assert validated["pmc_id"].iloc[0] == pmc_id
+
+    def test_invalid_pmc_id_format_fails(self, valid_base_record: dict) -> None:
+        """PMC ID without 'PMC' prefix should fail."""
+        invalid_pmc_ids = ["1234567", "pmc1234567", "PMCabc", "abc"]
+
+        for pmc_id in invalid_pmc_ids:
+            record = valid_base_record.copy()
+            record["pmc_id"] = pmc_id
+            df = pd.DataFrame([record])
+
+            with pytest.raises(pa.errors.SchemaError):
+                PublicationBaseSchema.validate(df)
+
+    def test_year_range_valid(self, valid_base_record: dict) -> None:
+        """Year should be within valid range (1800-2100)."""
+        valid_years = [1800, 1900, 2000, 2024, 2100]
+
+        for year in valid_years:
+            record = valid_base_record.copy()
+            record["year"] = year
+            df = pd.DataFrame([record])
+            validated = PublicationBaseSchema.validate(df)
+            assert validated["year"].iloc[0] == year
+
+    def test_year_below_minimum_fails(self, valid_base_record: dict) -> None:
+        """Year below minimum (1800) should fail."""
+        record = valid_base_record.copy()
+        record["year"] = 1799
+
+        df = pd.DataFrame([record])
+
+        with pytest.raises(pa.errors.SchemaError):
+            PublicationBaseSchema.validate(df)
+
+    def test_year_above_maximum_fails(self, valid_base_record: dict) -> None:
+        """Year above maximum (2100) should fail."""
+        record = valid_base_record.copy()
+        record["year"] = 2101
+
+        df = pd.DataFrame([record])
+
+        with pytest.raises(pa.errors.SchemaError):
+            PublicationBaseSchema.validate(df)
+
+
+@pytest.mark.unit
+class TestLookupMethods:
+    """Tests for LOOKUP_METHODS constant."""
+
+    def test_lookup_methods_contains_expected_values(self) -> None:
+        """All expected lookup methods should be defined."""
+        expected = {"direct", "doi", "pmid", "title_fallback", "title_only", "unknown"}
+
+        assert set(LOOKUP_METHODS) == expected
+
+    def test_lookup_methods_is_list(self) -> None:
+        """LOOKUP_METHODS should be a list for iteration."""
+        assert isinstance(LOOKUP_METHODS, list)
+
+    @pytest.mark.parametrize("lookup_method", LOOKUP_METHODS)
+    def test_valid_lookup_method_values(self, lookup_method: str) -> None:
+        """All defined lookup methods should be non-empty strings."""
+        assert isinstance(lookup_method, str)
+        assert len(lookup_method) > 0
+
+
+@pytest.mark.unit
+class TestPublicationBaseSchemaConfig:
+    """Tests for schema configuration."""
+
+    def test_schema_strict_is_false(self) -> None:
+        """Schema should allow extra columns (strict=False)."""
+        assert PublicationBaseSchema.Config.strict is False
+
+    def test_schema_coerce_is_true(self) -> None:
+        """Schema should coerce types (coerce=True)."""
+        assert PublicationBaseSchema.Config.coerce is True
+
+    def test_schema_ordered_is_false(self) -> None:
+        """Schema should not enforce column order (ordered=False)."""
+        assert PublicationBaseSchema.Config.ordered is False
+
+
+@pytest.mark.unit
+class TestPublicationBaseSchemaMultipleRecords:
+    """Tests for validating multiple records."""
+
+    def test_multiple_valid_records(self, valid_base_record: dict) -> None:
+        """Multiple valid records should all pass validation."""
+        record1 = valid_base_record.copy()
+        record2 = valid_base_record.copy()
+        record2["entity_id"] = "test_pub_002"
+        record2["pmid"] = "87654321"
+        record2["doi"] = "10.9999/another.test"
+        record2["year"] = 2023
+
+        record3 = valid_base_record.copy()
+        record3["entity_id"] = "test_pub_003"
+        record3["pmid"] = "11111111"
+        record3["doi"] = None
+        record3["pmc_id"] = None
+        # Note: year is int64 in Pandera schema, must be valid integer
+        record3["year"] = 2022
+
+        records = [record1, record2, record3]
+
+        df = pd.DataFrame(records)
+
+        validated = PublicationBaseSchema.validate(df)
+
+        assert len(validated) == 3
+
+    def test_one_invalid_record_fails_batch(self, valid_base_record: dict) -> None:
+        """One invalid record in batch should fail validation."""
+        record1 = valid_base_record.copy()
+        record2 = valid_base_record.copy()
+        record2["entity_id"] = "test_pub_002"
+        record2["pmid"] = "INVALID"  # Invalid PMID format
+
+        records = [record1, record2]
+
+        df = pd.DataFrame(records)
+
+        with pytest.raises(pa.errors.SchemaError):
+            PublicationBaseSchema.validate(df)
+
+    def test_lazy_validation_collects_all_errors(
+        self, valid_base_record: dict
+    ) -> None:
+        """Lazy validation should collect all errors."""
+        record1 = valid_base_record.copy()
+        record1["pmid"] = "INVALID1"  # Invalid PMID
+        record1["year"] = 1799  # Invalid year
+
+        record2 = valid_base_record.copy()
+        record2["entity_id"] = "test_pub_002"
+        record2["pmid"] = "INVALID2"  # Invalid PMID
+        record2["pmc_id"] = "invalid_pmc"  # Invalid PMC ID
+
+        records = [record1, record2]
+
+        df = pd.DataFrame(records)
+
+        with pytest.raises(pa.errors.SchemaErrors) as exc_info:
+            PublicationBaseSchema.validate(df, lazy=True)
+
+        # Should have multiple errors collected
+        assert len(exc_info.value.failure_cases) > 1

--- a/tests/unit/infrastructure/schemas/test_gold.py
+++ b/tests/unit/infrastructure/schemas/test_gold.py
@@ -1,0 +1,368 @@
+"""Tests for Gold layer Pandera schemas.
+
+Verifies schema definitions for various entities in the Gold layer,
+with focus on publication schema unification.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from bioetl.infrastructure.schemas.gold import (
+    ChEMBLDocumentGoldSchema,
+    CrossRefPublicationGoldSchema,
+    OpenAlexPublicationGoldSchema,
+    PubMedPublicationGoldSchema,
+    SemanticScholarPublicationGoldSchema,
+)
+
+
+# Required fields for all publication schemas (unified across providers)
+PUBLICATION_DQ_FIELDS = {"_dq_warn", "_dq_error"}
+PUBLICATION_CROSS_REF_FIELDS = {"doi"}
+PUBLICATION_UNIFIED_DATE_FIELDS = {"publication_date"}
+PUBLICATION_UNIFIED_PAGE_FIELDS = {"first_page", "last_page"}
+PUBLICATION_CORE_FIELDS = {"title", "abstract", "authors", "year"}
+
+
+def get_schema_fields(schema_class) -> set[str]:
+    """Extract field names from a Pandera DataFrameModel schema."""
+    # Get all fields defined in the schema (including aliases)
+    fields = set()
+    for name, field in schema_class.__fields__.items():
+        fields.add(name)
+        # Also track the alias if it exists
+        if hasattr(field, "alias") and field.alias:
+            fields.add(field.alias)
+    return fields
+
+
+@pytest.mark.unit
+class TestGoldPublicationSchemaDQFields:
+    """Test that all Gold publication schemas have DQ fields."""
+
+    @pytest.mark.parametrize(
+        "schema_class,name",
+        [
+            (ChEMBLDocumentGoldSchema, "ChEMBL Document"),
+            (CrossRefPublicationGoldSchema, "CrossRef Publication"),
+            (OpenAlexPublicationGoldSchema, "OpenAlex Publication"),
+            (PubMedPublicationGoldSchema, "PubMed Publication"),
+            (SemanticScholarPublicationGoldSchema, "SemanticScholar Publication"),
+        ],
+    )
+    def test_schema_has_dq_fields(self, schema_class, name):
+        """All Gold publication schemas must have DQ fields."""
+        fields = get_schema_fields(schema_class)
+        # Check for alias versions (_dq_warn, _dq_error) or regular versions
+        has_dq_warn = "_dq_warn" in fields or "dq_warn" in fields
+        has_dq_error = "_dq_error" in fields or "dq_error" in fields
+        assert has_dq_warn, f"{name} missing _dq_warn/_dq_error field"
+        assert has_dq_error, f"{name} missing _dq_error/dq_error field"
+
+
+@pytest.mark.unit
+class TestGoldPublicationSchemaUnifiedFields:
+    """Test that all Gold publication schemas have unified date and page fields."""
+
+    @pytest.mark.parametrize(
+        "schema_class,name",
+        [
+            (ChEMBLDocumentGoldSchema, "ChEMBL Document"),
+            (CrossRefPublicationGoldSchema, "CrossRef Publication"),
+            (OpenAlexPublicationGoldSchema, "OpenAlex Publication"),
+            (PubMedPublicationGoldSchema, "PubMed Publication"),
+            (SemanticScholarPublicationGoldSchema, "SemanticScholar Publication"),
+        ],
+    )
+    def test_schema_has_publication_date(self, schema_class, name):
+        """All Gold publication schemas must have publication_date field."""
+        fields = get_schema_fields(schema_class)
+        assert "publication_date" in fields, (
+            f"{name} missing publication_date field"
+        )
+
+    @pytest.mark.parametrize(
+        "schema_class,name",
+        [
+            (ChEMBLDocumentGoldSchema, "ChEMBL Document"),
+            (CrossRefPublicationGoldSchema, "CrossRef Publication"),
+            (OpenAlexPublicationGoldSchema, "OpenAlex Publication"),
+            (PubMedPublicationGoldSchema, "PubMed Publication"),
+            (SemanticScholarPublicationGoldSchema, "SemanticScholar Publication"),
+        ],
+    )
+    def test_schema_has_page_fields(self, schema_class, name):
+        """All Gold publication schemas must have first_page and last_page fields."""
+        fields = get_schema_fields(schema_class)
+        assert "first_page" in fields, f"{name} missing first_page field"
+        assert "last_page" in fields, f"{name} missing last_page field"
+
+
+@pytest.mark.unit
+class TestGoldPublicationSchemaCrossRefFields:
+    """Test that all Gold publication schemas have cross-reference ID fields."""
+
+    @pytest.mark.parametrize(
+        "schema_class,name",
+        [
+            (ChEMBLDocumentGoldSchema, "ChEMBL Document"),
+            (CrossRefPublicationGoldSchema, "CrossRef Publication"),
+            (OpenAlexPublicationGoldSchema, "OpenAlex Publication"),
+            (PubMedPublicationGoldSchema, "PubMed Publication"),
+            (SemanticScholarPublicationGoldSchema, "SemanticScholar Publication"),
+        ],
+    )
+    def test_schema_has_doi_field(self, schema_class, name):
+        """All Gold publication schemas must have doi field."""
+        fields = get_schema_fields(schema_class)
+        assert "doi" in fields, f"{name} missing doi field"
+
+    @pytest.mark.parametrize(
+        "schema_class,name",
+        [
+            (ChEMBLDocumentGoldSchema, "ChEMBL Document"),
+            (OpenAlexPublicationGoldSchema, "OpenAlex Publication"),
+            (PubMedPublicationGoldSchema, "PubMed Publication"),
+            (SemanticScholarPublicationGoldSchema, "SemanticScholar Publication"),
+        ],
+    )
+    def test_schema_has_pmid_field(self, schema_class, name):
+        """Gold publication schemas (except CrossRef) should have pmid field."""
+        fields = get_schema_fields(schema_class)
+        assert "pmid" in fields, f"{name} missing pmid field"
+
+    @pytest.mark.parametrize(
+        "schema_class,name",
+        [
+            (ChEMBLDocumentGoldSchema, "ChEMBL Document"),
+            (OpenAlexPublicationGoldSchema, "OpenAlex Publication"),
+            (PubMedPublicationGoldSchema, "PubMed Publication"),
+            (SemanticScholarPublicationGoldSchema, "SemanticScholar Publication"),
+        ],
+    )
+    def test_schema_has_pmc_id_field(self, schema_class, name):
+        """Gold publication schemas (except CrossRef) should have pmc_id field."""
+        fields = get_schema_fields(schema_class)
+        assert "pmc_id" in fields, f"{name} missing pmc_id field"
+
+
+@pytest.mark.unit
+class TestGoldPublicationSchemaCoreFields:
+    """Test that all Gold publication schemas have core content fields."""
+
+    @pytest.mark.parametrize(
+        "schema_class,name",
+        [
+            (ChEMBLDocumentGoldSchema, "ChEMBL Document"),
+            (CrossRefPublicationGoldSchema, "CrossRef Publication"),
+            (OpenAlexPublicationGoldSchema, "OpenAlex Publication"),
+            (PubMedPublicationGoldSchema, "PubMed Publication"),
+            (SemanticScholarPublicationGoldSchema, "SemanticScholar Publication"),
+        ],
+    )
+    def test_schema_has_title_and_abstract(self, schema_class, name):
+        """All Gold publication schemas must have title and abstract fields."""
+        fields = get_schema_fields(schema_class)
+        assert "title" in fields, f"{name} missing title field"
+        assert "abstract" in fields, f"{name} missing abstract field"
+
+    @pytest.mark.parametrize(
+        "schema_class,name",
+        [
+            (ChEMBLDocumentGoldSchema, "ChEMBL Document"),
+            (CrossRefPublicationGoldSchema, "CrossRef Publication"),
+            (OpenAlexPublicationGoldSchema, "OpenAlex Publication"),
+            (PubMedPublicationGoldSchema, "PubMed Publication"),
+            (SemanticScholarPublicationGoldSchema, "SemanticScholar Publication"),
+        ],
+    )
+    def test_schema_has_authors_field(self, schema_class, name):
+        """All Gold publication schemas must have authors field."""
+        fields = get_schema_fields(schema_class)
+        assert "authors" in fields, f"{name} missing authors field"
+
+    @pytest.mark.parametrize(
+        "schema_class,name",
+        [
+            (ChEMBLDocumentGoldSchema, "ChEMBL Document"),
+            (CrossRefPublicationGoldSchema, "CrossRef Publication"),
+            (OpenAlexPublicationGoldSchema, "OpenAlex Publication"),
+            (PubMedPublicationGoldSchema, "PubMed Publication"),
+            (SemanticScholarPublicationGoldSchema, "SemanticScholar Publication"),
+        ],
+    )
+    def test_schema_has_year_field(self, schema_class, name):
+        """All Gold publication schemas must have year field."""
+        fields = get_schema_fields(schema_class)
+        assert "year" in fields, f"{name} missing year field"
+
+
+@pytest.mark.unit
+class TestGoldPublicationSchemaPrimaryKeys:
+    """Test that each Gold publication schema has its provider-specific primary key."""
+
+    @pytest.mark.parametrize(
+        "schema_class,name,primary_key",
+        [
+            (ChEMBLDocumentGoldSchema, "ChEMBL Document", "document_chembl_id"),
+            (CrossRefPublicationGoldSchema, "CrossRef Publication", "doi"),
+            (OpenAlexPublicationGoldSchema, "OpenAlex Publication", "openalex_id"),
+            (PubMedPublicationGoldSchema, "PubMed Publication", "pmid"),
+            (SemanticScholarPublicationGoldSchema, "SemanticScholar Publication", "paper_id"),
+        ],
+    )
+    def test_schema_has_primary_key(self, schema_class, name, primary_key):
+        """Each Gold publication schema must have its provider-specific primary key."""
+        fields = get_schema_fields(schema_class)
+        assert primary_key in fields, f"{name} missing primary key: {primary_key}"
+
+
+@pytest.mark.unit
+class TestGoldPublicationSchemaMetadataFields:
+    """Test that all Gold publication schemas have required metadata fields."""
+
+    @pytest.mark.parametrize(
+        "schema_class,name",
+        [
+            (ChEMBLDocumentGoldSchema, "ChEMBL Document"),
+            (CrossRefPublicationGoldSchema, "CrossRef Publication"),
+            (OpenAlexPublicationGoldSchema, "OpenAlex Publication"),
+            (PubMedPublicationGoldSchema, "PubMed Publication"),
+            (SemanticScholarPublicationGoldSchema, "SemanticScholar Publication"),
+        ],
+    )
+    def test_schema_has_entity_id(self, schema_class, name):
+        """All Gold schemas must have entity_id field."""
+        fields = get_schema_fields(schema_class)
+        assert "entity_id" in fields, f"{name} missing entity_id field"
+
+    @pytest.mark.parametrize(
+        "schema_class,name",
+        [
+            (ChEMBLDocumentGoldSchema, "ChEMBL Document"),
+            (CrossRefPublicationGoldSchema, "CrossRef Publication"),
+            (OpenAlexPublicationGoldSchema, "OpenAlex Publication"),
+            (PubMedPublicationGoldSchema, "PubMed Publication"),
+            (SemanticScholarPublicationGoldSchema, "SemanticScholar Publication"),
+        ],
+    )
+    def test_schema_has_content_hash(self, schema_class, name):
+        """All Gold schemas must have content_hash field."""
+        fields = get_schema_fields(schema_class)
+        assert "content_hash" in fields, f"{name} missing content_hash field"
+
+    @pytest.mark.parametrize(
+        "schema_class,name",
+        [
+            (ChEMBLDocumentGoldSchema, "ChEMBL Document"),
+            (CrossRefPublicationGoldSchema, "CrossRef Publication"),
+            (OpenAlexPublicationGoldSchema, "OpenAlex Publication"),
+            (PubMedPublicationGoldSchema, "PubMed Publication"),
+            (SemanticScholarPublicationGoldSchema, "SemanticScholar Publication"),
+        ],
+    )
+    def test_schema_has_lineage_fields(self, schema_class, name):
+        """All Gold schemas must have lineage metadata fields."""
+        fields = get_schema_fields(schema_class)
+        # Check for alias or regular field names
+        assert "_run_id" in fields or "run_id" in fields, (
+            f"{name} missing run_id/_run_id field"
+        )
+        assert "_run_type" in fields or "run_type" in fields, (
+            f"{name} missing run_type/_run_type field"
+        )
+        assert "_ingestion_ts" in fields or "ingestion_ts" in fields, (
+            f"{name} missing ingestion_ts/_ingestion_ts field"
+        )
+
+
+@pytest.mark.unit
+class TestGoldSchemaValidation:
+    """Test Gold schema validation with sample data."""
+
+    def test_pubmed_publication_validates_correct_data(self):
+        """PubMedPublicationGoldSchema should validate correct data."""
+        valid_record = {
+            "entity_id": "pubmed_12345678",
+            "content_hash": "abc123",
+            "pmid": "12345678",
+            "doi": "10.1234/test",
+            "pmc_id": "PMC1234567",
+            "title": "Test Title",
+            "abstract": "Test abstract",
+            "journal": "Test Journal",
+            "journal_abbrev": "Test J",
+            "issn": "1234-5678",
+            "volume": "10",
+            "issue": "2",
+            "pages": "100-110",
+            "first_page": "100",
+            "last_page": "110",
+            "authors": ["Author One", "Author Two"],
+            "pub_date": "2024-03-15",
+            "publication_date": "2024-03-15",
+            "year": 2024,
+            "publication_year": 2024,
+            "accepted_date": "2024-01-15",
+            "received_date": "2023-12-01",
+            "revised_date": "2024-01-10",
+            "epub_date": "2024-02-28",
+            "publication_types": ["Journal Article"],
+            "keywords": ["test"],
+            "mesh_terms": ["Testing"],
+            "language": "eng",
+            "country": "United States",
+            "_dq_warn": False,
+            "_dq_error": False,
+            "_run_id": "run-001",
+            "_run_type": "incremental",
+            "_source_batch_id": "batch-001",
+            "_ingestion_ts": "2024-01-01T00:00:00Z",
+            "_index": 0,
+        }
+
+        df = pd.DataFrame([valid_record])
+        validated = PubMedPublicationGoldSchema.validate(df)
+
+        assert len(validated) == 1
+        assert validated["pmid"].iloc[0] == "12345678"
+
+    def test_chembl_document_validates_correct_data(self):
+        """ChEMBLDocumentGoldSchema should validate correct data."""
+        valid_record = {
+            "entity_id": "chembl_CHEMBL12345",
+            "content_hash": "xyz789",
+            "document_chembl_id": "CHEMBL12345",
+            "pmid": "12345678",
+            "pmc_id": "PMC1234567",
+            "doi": "10.1234/test",
+            "patent_id": None,
+            "title": "Test Publication",
+            "authors": '["Author One"]',
+            "abstract": "Test abstract",
+            "doc_type": "PUBLICATION",
+            "journal": "Test Journal",
+            "journal_full_title": "Test Journal Full Title",
+            "year": 2024,
+            "publication_date": "2024-01-01",
+            "volume": "10",
+            "issue": "2",
+            "first_page": "100",
+            "last_page": "110",
+            "src_id": 1,
+            "_dq_warn": False,
+            "_dq_error": False,
+            "_run_id": "run-001",
+            "_run_type": "incremental",
+            "_source_batch_id": "batch-001",
+            "_ingestion_ts": "2024-01-01T00:00:00Z",
+            "_index": 0,
+        }
+
+        df = pd.DataFrame([valid_record])
+        validated = ChEMBLDocumentGoldSchema.validate(df)
+
+        assert len(validated) == 1
+        assert validated["document_chembl_id"].iloc[0] == "CHEMBL12345"

--- a/tests/unit/infrastructure/schemas/test_silver.py
+++ b/tests/unit/infrastructure/schemas/test_silver.py
@@ -15,8 +15,11 @@ from bioetl.infrastructure.schemas.silver import (
     CHEMBL_PUBLICATION_SCHEMA,
     CHEMBL_TARGET_COMPONENT_SCHEMA,
     CHEMBL_TARGET_SCHEMA,
+    CROSSREF_PUBLICATION_SCHEMA,
+    OPENALEX_PUBLICATION_SCHEMA,
     PUBCHEM_COMPOUND_SCHEMA,
     PUBMED_PUBLICATION_SCHEMA,
+    SEMANTICSCHOLAR_PUBLICATION_SCHEMA,
     UNIPROT_PROTEIN_SCHEMA,
 )
 
@@ -725,3 +728,229 @@ class TestSilverSchemaValidation:
 
         with pytest.raises((pa.ArrowInvalid, pa.ArrowTypeError)):
             pa.Table.from_pylist([record], schema=schema)
+
+
+# =============================================================================
+# Publication Schema Unification Tests
+# =============================================================================
+
+# Required fields for all publication schemas (unified across providers)
+PUBLICATION_DQ_FIELDS = frozenset({"_dq_warn", "_dq_error"})
+PUBLICATION_LOOKUP_FIELDS = frozenset({"_lookup_method", "_original_id"})
+PUBLICATION_CROSS_REF_FIELDS = frozenset({"pmid", "doi", "pmc_id"})
+PUBLICATION_UNIFIED_FIELDS = frozenset({"publication_date", "first_page", "last_page"})
+
+
+class TestPublicationSchemaDQFields:
+    """Test that all publication schemas have DQ fields."""
+
+    @pytest.mark.parametrize(
+        "schema,name",
+        [
+            (CHEMBL_PUBLICATION_SCHEMA, "ChEMBL Publication"),
+            (CROSSREF_PUBLICATION_SCHEMA, "CrossRef Publication"),
+            (OPENALEX_PUBLICATION_SCHEMA, "OpenAlex Publication"),
+            (PUBMED_PUBLICATION_SCHEMA, "PubMed Publication"),
+            (SEMANTICSCHOLAR_PUBLICATION_SCHEMA, "SemanticScholar Publication"),
+        ],
+    )
+    def test_schema_has_dq_fields(self, schema, name):
+        """All publication schemas must have _dq_warn and _dq_error fields."""
+        field_names = {f.name for f in schema}
+        missing = PUBLICATION_DQ_FIELDS - field_names
+        assert not missing, f"{name} missing DQ fields: {missing}"
+
+    @pytest.mark.parametrize(
+        "schema,name",
+        [
+            (CHEMBL_PUBLICATION_SCHEMA, "ChEMBL Publication"),
+            (CROSSREF_PUBLICATION_SCHEMA, "CrossRef Publication"),
+            (OPENALEX_PUBLICATION_SCHEMA, "OpenAlex Publication"),
+            (PUBMED_PUBLICATION_SCHEMA, "PubMed Publication"),
+            (SEMANTICSCHOLAR_PUBLICATION_SCHEMA, "SemanticScholar Publication"),
+        ],
+    )
+    def test_dq_fields_are_bool(self, schema, name):
+        """DQ fields must be boolean type."""
+        for field_name in PUBLICATION_DQ_FIELDS:
+            field = schema.field(field_name)
+            assert field.type == pa.bool_(), (
+                f"{name}.{field_name} should be bool, got {field.type}"
+            )
+
+
+class TestPublicationSchemaLookupFields:
+    """Test that all publication schemas have lookup metadata fields."""
+
+    @pytest.mark.parametrize(
+        "schema,name",
+        [
+            (CHEMBL_PUBLICATION_SCHEMA, "ChEMBL Publication"),
+            (CROSSREF_PUBLICATION_SCHEMA, "CrossRef Publication"),
+            (OPENALEX_PUBLICATION_SCHEMA, "OpenAlex Publication"),
+            (PUBMED_PUBLICATION_SCHEMA, "PubMed Publication"),
+            (SEMANTICSCHOLAR_PUBLICATION_SCHEMA, "SemanticScholar Publication"),
+        ],
+    )
+    def test_schema_has_lookup_fields(self, schema, name):
+        """All publication schemas must have _lookup_method and _original_id."""
+        field_names = {f.name for f in schema}
+        missing = PUBLICATION_LOOKUP_FIELDS - field_names
+        assert not missing, f"{name} missing lookup fields: {missing}"
+
+    @pytest.mark.parametrize(
+        "schema,name",
+        [
+            (CHEMBL_PUBLICATION_SCHEMA, "ChEMBL Publication"),
+            (CROSSREF_PUBLICATION_SCHEMA, "CrossRef Publication"),
+            (OPENALEX_PUBLICATION_SCHEMA, "OpenAlex Publication"),
+            (PUBMED_PUBLICATION_SCHEMA, "PubMed Publication"),
+            (SEMANTICSCHOLAR_PUBLICATION_SCHEMA, "SemanticScholar Publication"),
+        ],
+    )
+    def test_lookup_fields_are_string(self, schema, name):
+        """Lookup fields must be string type."""
+        for field_name in PUBLICATION_LOOKUP_FIELDS:
+            field = schema.field(field_name)
+            assert field.type == pa.string(), (
+                f"{name}.{field_name} should be string, got {field.type}"
+            )
+
+
+class TestPublicationSchemaCrossRefFields:
+    """Test that all publication schemas have cross-reference ID fields."""
+
+    @pytest.mark.parametrize(
+        "schema,name",
+        [
+            (CHEMBL_PUBLICATION_SCHEMA, "ChEMBL Publication"),
+            (CROSSREF_PUBLICATION_SCHEMA, "CrossRef Publication"),
+            (OPENALEX_PUBLICATION_SCHEMA, "OpenAlex Publication"),
+            (PUBMED_PUBLICATION_SCHEMA, "PubMed Publication"),
+            (SEMANTICSCHOLAR_PUBLICATION_SCHEMA, "SemanticScholar Publication"),
+        ],
+    )
+    def test_schema_has_cross_ref_fields(self, schema, name):
+        """All publication schemas must have pmid, doi, pmc_id."""
+        field_names = {f.name for f in schema}
+        missing = PUBLICATION_CROSS_REF_FIELDS - field_names
+        assert not missing, f"{name} missing cross-ref fields: {missing}"
+
+    @pytest.mark.parametrize(
+        "schema,name",
+        [
+            (CHEMBL_PUBLICATION_SCHEMA, "ChEMBL Publication"),
+            (CROSSREF_PUBLICATION_SCHEMA, "CrossRef Publication"),
+            (OPENALEX_PUBLICATION_SCHEMA, "OpenAlex Publication"),
+            (PUBMED_PUBLICATION_SCHEMA, "PubMed Publication"),
+            (SEMANTICSCHOLAR_PUBLICATION_SCHEMA, "SemanticScholar Publication"),
+        ],
+    )
+    def test_cross_ref_fields_are_string(self, schema, name):
+        """Cross-reference fields must be string type."""
+        for field_name in PUBLICATION_CROSS_REF_FIELDS:
+            field = schema.field(field_name)
+            assert field.type == pa.string(), (
+                f"{name}.{field_name} should be string, got {field.type}"
+            )
+
+
+class TestPublicationSchemaUnifiedDateAndPageFields:
+    """Test that all publication schemas have unified date and page fields."""
+
+    @pytest.mark.parametrize(
+        "schema,name",
+        [
+            (CHEMBL_PUBLICATION_SCHEMA, "ChEMBL Publication"),
+            (CROSSREF_PUBLICATION_SCHEMA, "CrossRef Publication"),
+            (OPENALEX_PUBLICATION_SCHEMA, "OpenAlex Publication"),
+            (PUBMED_PUBLICATION_SCHEMA, "PubMed Publication"),
+            (SEMANTICSCHOLAR_PUBLICATION_SCHEMA, "SemanticScholar Publication"),
+        ],
+    )
+    def test_schema_has_publication_date(self, schema, name):
+        """All publication schemas must have publication_date field."""
+        field_names = {f.name for f in schema}
+        assert "publication_date" in field_names, (
+            f"{name} missing publication_date field"
+        )
+        field = schema.field("publication_date")
+        assert field.type == pa.string(), (
+            f"{name}.publication_date should be string, got {field.type}"
+        )
+
+    @pytest.mark.parametrize(
+        "schema,name",
+        [
+            (CHEMBL_PUBLICATION_SCHEMA, "ChEMBL Publication"),
+            (CROSSREF_PUBLICATION_SCHEMA, "CrossRef Publication"),
+            (OPENALEX_PUBLICATION_SCHEMA, "OpenAlex Publication"),
+            (PUBMED_PUBLICATION_SCHEMA, "PubMed Publication"),
+            (SEMANTICSCHOLAR_PUBLICATION_SCHEMA, "SemanticScholar Publication"),
+        ],
+    )
+    def test_schema_has_page_fields(self, schema, name):
+        """All publication schemas must have first_page and last_page fields."""
+        field_names = {f.name for f in schema}
+        page_fields = {"first_page", "last_page"}
+        missing = page_fields - field_names
+        assert not missing, f"{name} missing page fields: {missing}"
+
+        for field_name in page_fields:
+            field = schema.field(field_name)
+            assert field.type == pa.string(), (
+                f"{name}.{field_name} should be string, got {field.type}"
+            )
+
+
+class TestAllPublicationSchemas:
+    """Test completeness of all publication schemas."""
+
+    @pytest.mark.parametrize(
+        "schema,name,primary_key",
+        [
+            (CHEMBL_PUBLICATION_SCHEMA, "ChEMBL Publication", "document_chembl_id"),
+            (CROSSREF_PUBLICATION_SCHEMA, "CrossRef Publication", "doi"),
+            (OPENALEX_PUBLICATION_SCHEMA, "OpenAlex Publication", "openalex_id"),
+            (PUBMED_PUBLICATION_SCHEMA, "PubMed Publication", "pmid"),
+            (SEMANTICSCHOLAR_PUBLICATION_SCHEMA, "SemanticScholar Publication", "paper_id"),
+        ],
+    )
+    def test_schema_has_primary_key(self, schema, name, primary_key):
+        """Each publication schema must have its provider-specific primary key."""
+        field_names = {f.name for f in schema}
+        assert primary_key in field_names, f"{name} missing primary key: {primary_key}"
+
+    @pytest.mark.parametrize(
+        "schema,name",
+        [
+            (CHEMBL_PUBLICATION_SCHEMA, "ChEMBL Publication"),
+            (CROSSREF_PUBLICATION_SCHEMA, "CrossRef Publication"),
+            (OPENALEX_PUBLICATION_SCHEMA, "OpenAlex Publication"),
+            (PUBMED_PUBLICATION_SCHEMA, "PubMed Publication"),
+            (SEMANTICSCHOLAR_PUBLICATION_SCHEMA, "SemanticScholar Publication"),
+        ],
+    )
+    def test_schema_has_core_fields(self, schema, name):
+        """All publication schemas must have core content fields."""
+        field_names = {f.name for f in schema}
+        core_fields = {"title", "abstract", "authors", "year"}
+        missing = core_fields - field_names
+        assert not missing, f"{name} missing core fields: {missing}"
+
+    @pytest.mark.parametrize(
+        "schema,name",
+        [
+            (CHEMBL_PUBLICATION_SCHEMA, "ChEMBL Publication"),
+            (CROSSREF_PUBLICATION_SCHEMA, "CrossRef Publication"),
+            (OPENALEX_PUBLICATION_SCHEMA, "OpenAlex Publication"),
+            (PUBMED_PUBLICATION_SCHEMA, "PubMed Publication"),
+            (SEMANTICSCHOLAR_PUBLICATION_SCHEMA, "SemanticScholar Publication"),
+        ],
+    )
+    def test_schema_has_source_field(self, schema, name):
+        """All external publication schemas should have source field for provenance."""
+        field_names = {f.name for f in schema}
+        # ChEMBL doesn't need source field (it's an internal source)
+        if "ChEMBL" not in name:
+            assert "source" in field_names, f"{name} missing source field"


### PR DESCRIPTION
- Add tests for PublicationBaseSchema validation
- Add tests for page parsing utilities (PubMed, SemanticScholar)
- Add tests for date building utilities (PubMed, CrossRef)
- Add unified field tests to Silver schema tests
- Create Gold schema tests with unified publication field checks

Tests verify:
- DQ fields (_dq_warn, _dq_error) present in all publication schemas
- Lookup fields (_lookup_method, _original_id) in all schemas
- Cross-reference IDs (pmid, doi, pmc_id) in all schemas
- Unified date (publication_date) and page (first_page, last_page) fields
- Primary keys for each provider