### PR TITLE
Remove unused import from test file

### DIFF
--- a/tests/unit/infrastructure/storage/test_bronze_writer.py
+++ b/tests/unit/infrastructure/storage/test_bronze_writer.py
@@ -2371,7 +2371,6 @@ class TestBronzeWriterQueryString:
         from unittest.mock import AsyncMock, MagicMock
 
         from bioetl.domain.models.metadata import SourceMetadata
-        from bioetl.domain.ports.metadata_coordinator import BronzeMetadataInput
 
         mock_coordinator = MagicMock()
         mock_metadata = MagicMock()
@@ -2429,8 +2428,6 @@ class TestBronzeWriterQueryString:
     ) -> None:
         """Test query_string is None when source_metadata is not provided."""
         from unittest.mock import AsyncMock, MagicMock
-
-        from bioetl.domain.ports.metadata_coordinator import BronzeMetadataInput
 
         mock_coordinator = MagicMock()
         mock_metadata = MagicMock()


### PR DESCRIPTION
Remove two unused imports of BronzeMetadataInput in test_bronze_writer.py that were flagged by ruff F401.