### PR TITLE
Create DQ configuration files and directory structure

### DIFF
--- a/configs/dq/_defaults.yaml
+++ b/configs/dq/_defaults.yaml
@@ -1,0 +1,60 @@
+# configs/dq/_defaults.yaml
+# Global DQ defaults for all BioETL pipelines
+# RULES.md §3.1.2: DQ Thresholds
+#
+# Merge priority (lowest to highest):
+# 1. This file (_defaults.yaml)
+# 2. providers/{provider}.yaml
+# 3. entities/{provider}/{entity}.yaml
+# 4. Inline overrides in pipeline config
+
+version: "1.0.0"
+
+# =============================================================================
+# Threshold Configuration (RULES.md §3.1.2)
+# =============================================================================
+thresholds:
+  soft_fail: 0.05      # >5% errors → Warning
+  hard_fail: 0.20      # >20% errors → Fail Batch
+
+# =============================================================================
+# Validation Mode
+# =============================================================================
+strict_validation: false  # Feature flag for stricter rules
+
+# =============================================================================
+# Invalid Record Handling
+# =============================================================================
+invalid_record_policy: quarantine  # quarantine | skip | fail
+
+# =============================================================================
+# Report Configuration
+# =============================================================================
+report:
+  enabled: true
+  format: json           # json | yaml | csv
+  include_sample_failures: true
+  sample_size: 10
+  output_path: null      # null = use pipeline output dir
+
+# =============================================================================
+# Common Field Validations (applied to ALL entities)
+# =============================================================================
+common_field_validations:
+  # Content hash must be present after transform
+  - field: _content_hash
+    type: required
+    nullable: false
+    error_message: "Content hash is required for deduplication"
+
+  # Ingestion timestamp must be valid ISO format
+  - field: _ingestion_ts
+    type: pattern
+    pattern: '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}'
+    nullable: false
+    error_message: "Ingestion timestamp must be ISO 8601 format"
+
+# =============================================================================
+# Common Cross-Field Validations
+# =============================================================================
+common_cross_field_validations: []

--- a/configs/dq/entities/chembl/activity.yaml
+++ b/configs/dq/entities/chembl/activity.yaml
@@ -1,0 +1,92 @@
+# configs/dq/entities/chembl/activity.yaml
+# ChEMBL Activity-specific DQ rules
+# Inherits from: _defaults.yaml → providers/chembl.yaml
+
+version: "1.0.0"
+provider: chembl
+entity: activity
+
+# Thresholds: inherit from provider
+
+# =============================================================================
+# Activity-Specific Field Validations
+# =============================================================================
+entity_field_validations:
+  # Activity ID is required
+  - field: activity_id
+    type: required
+    nullable: false
+    error_message: "Activity ID is required"
+
+  # Standard value must be non-negative when present
+  - field: standard_value
+    type: range
+    min: 0
+    nullable: true
+    error_message: "Standard value must be non-negative"
+
+  # pChEMBL value must be in valid range (0-15)
+  - field: pchembl_value
+    type: range
+    min: 0
+    max: 15
+    nullable: true
+    error_message: "pChEMBL value must be between 0 and 15"
+
+  # Standard type validation
+  - field: standard_type
+    type: enum
+    allowed:
+      - IC50
+      - Ki
+      - Kd
+      - EC50
+      - AC50
+      - GI50
+      - Potency
+      - Activity
+      - Inhibition
+    nullable: true
+    error_message: "Invalid standard_type value"
+
+  # Standard units validation
+  - field: standard_units
+    type: enum
+    allowed:
+      - nM
+      - uM
+      - mM
+      - pM
+      - M
+      - "%"
+    nullable: true
+    error_message: "Invalid standard_units value"
+
+# =============================================================================
+# Cross-Field Validations
+# =============================================================================
+entity_cross_field_validations:
+  # If standard_value present, standard_units should be present
+  - name: value_requires_units
+    fields:
+      - standard_value
+      - standard_units
+    condition: conditional_required
+    trigger_field: standard_value
+    required_field: standard_units
+    error_message: "standard_units required when standard_value is present"
+
+# =============================================================================
+# Conditional Validations
+# =============================================================================
+entity_conditional_validations:
+  # When assay_type is 'B' (Binding), target should be present
+  - name: binding_requires_target
+    condition_field: assay_type
+    condition_value: B
+    condition_operator: eq
+    then_validations:
+      - field: target_chembl_id
+        type: required
+        nullable: false
+        error_message: "Binding assays must have a target"

--- a/configs/dq/entities/chembl/assay.yaml
+++ b/configs/dq/entities/chembl/assay.yaml
@@ -1,0 +1,40 @@
+# configs/dq/entities/chembl/assay.yaml
+# ChEMBL Assay-specific DQ rules
+# Inherits from: _defaults.yaml → providers/chembl.yaml
+
+version: "1.0.0"
+provider: chembl
+entity: assay
+
+# Thresholds: inherit from provider
+
+# =============================================================================
+# Assay-Specific Field Validations
+# =============================================================================
+entity_field_validations:
+  - field: assay_chembl_id
+    type: required
+    nullable: false
+    error_message: "Assay ChEMBL ID is required"
+
+  - field: assay_type
+    type: enum
+    allowed:
+      - B  # Binding
+      - F  # Functional
+      - A  # ADMET
+      - T  # Toxicity
+      - P  # Physicochemical
+      - U  # Unclassified
+    nullable: true
+    error_message: "Invalid assay_type value"
+
+# =============================================================================
+# Cross-Field Validations
+# =============================================================================
+entity_cross_field_validations: []
+
+# =============================================================================
+# Conditional Validations
+# =============================================================================
+entity_conditional_validations: []

--- a/configs/dq/entities/chembl/molecule.yaml
+++ b/configs/dq/entities/chembl/molecule.yaml
@@ -1,0 +1,43 @@
+# configs/dq/entities/chembl/molecule.yaml
+# ChEMBL Molecule-specific DQ rules
+# Inherits from: _defaults.yaml → providers/chembl.yaml
+
+version: "1.0.0"
+provider: chembl
+entity: molecule
+
+# Thresholds: inherit from provider
+
+# =============================================================================
+# Molecule-Specific Field Validations
+# =============================================================================
+entity_field_validations:
+  - field: molecule_chembl_id
+    type: required
+    nullable: false
+    error_message: "Molecule ChEMBL ID is required"
+
+  # Molecular weight must be positive
+  - field: full_mwt
+    type: range
+    min: 0
+    nullable: true
+    error_message: "Molecular weight must be non-negative"
+
+  # ALogP typically between -10 and 10
+  - field: alogp
+    type: range
+    min: -15
+    max: 20
+    nullable: true
+    error_message: "ALogP value out of expected range"
+
+# =============================================================================
+# Cross-Field Validations
+# =============================================================================
+entity_cross_field_validations: []
+
+# =============================================================================
+# Conditional Validations
+# =============================================================================
+entity_conditional_validations: []

--- a/configs/dq/entities/chembl/target.yaml
+++ b/configs/dq/entities/chembl/target.yaml
@@ -1,0 +1,42 @@
+# configs/dq/entities/chembl/target.yaml
+# ChEMBL Target-specific DQ rules
+# Inherits from: _defaults.yaml → providers/chembl.yaml
+
+version: "1.0.0"
+provider: chembl
+entity: target
+
+# Thresholds: inherit from provider
+
+# =============================================================================
+# Target-Specific Field Validations
+# =============================================================================
+entity_field_validations:
+  - field: target_chembl_id
+    type: required
+    nullable: false
+    error_message: "Target ChEMBL ID is required"
+
+  - field: target_type
+    type: enum
+    allowed:
+      - SINGLE PROTEIN
+      - PROTEIN COMPLEX
+      - PROTEIN FAMILY
+      - ORGANISM
+      - TISSUE
+      - CELL-LINE
+      - SELECTIVITY GROUP
+      - UNKNOWN
+    nullable: true
+    error_message: "Invalid target_type value"
+
+# =============================================================================
+# Cross-Field Validations
+# =============================================================================
+entity_cross_field_validations: []
+
+# =============================================================================
+# Conditional Validations
+# =============================================================================
+entity_conditional_validations: []

--- a/configs/dq/entities/pubchem/compound.yaml
+++ b/configs/dq/entities/pubchem/compound.yaml
@@ -1,0 +1,35 @@
+# configs/dq/entities/pubchem/compound.yaml
+# PubChem Compound-specific DQ rules
+# Inherits from: _defaults.yaml → providers/pubchem.yaml
+
+version: "1.0.0"
+provider: pubchem
+entity: compound
+
+# Thresholds: inherit from provider
+
+# =============================================================================
+# Compound-Specific Field Validations
+# =============================================================================
+entity_field_validations:
+  - field: cid
+    type: required
+    nullable: false
+    error_message: "CID is required"
+
+  # Molecular weight validation
+  - field: molecular_weight
+    type: range
+    min: 0
+    nullable: true
+    error_message: "Molecular weight must be non-negative"
+
+# =============================================================================
+# Cross-Field Validations
+# =============================================================================
+entity_cross_field_validations: []
+
+# =============================================================================
+# Conditional Validations
+# =============================================================================
+entity_conditional_validations: []

--- a/configs/dq/entities/uniprot/target.yaml
+++ b/configs/dq/entities/uniprot/target.yaml
@@ -1,0 +1,34 @@
+# configs/dq/entities/uniprot/target.yaml
+# UniProt Target-specific DQ rules
+# Inherits from: _defaults.yaml → providers/uniprot.yaml
+
+version: "1.0.0"
+provider: uniprot
+entity: target
+
+# Thresholds: inherit from provider
+
+# =============================================================================
+# Target-Specific Field Validations
+# =============================================================================
+entity_field_validations:
+  - field: accession
+    type: required
+    nullable: false
+    error_message: "UniProt accession is required"
+
+  - field: sequence_length
+    type: range
+    min: 1
+    nullable: true
+    error_message: "Sequence length must be positive"
+
+# =============================================================================
+# Cross-Field Validations
+# =============================================================================
+entity_cross_field_validations: []
+
+# =============================================================================
+# Conditional Validations
+# =============================================================================
+entity_conditional_validations: []

--- a/configs/dq/providers/chembl.yaml
+++ b/configs/dq/providers/chembl.yaml
@@ -1,0 +1,42 @@
+# configs/dq/providers/chembl.yaml
+# ChEMBL-specific DQ rules
+# Inherits from: _defaults.yaml
+
+version: "1.0.0"
+provider: chembl
+
+# =============================================================================
+# Provider-Specific Thresholds
+# =============================================================================
+thresholds:
+  soft_fail: 0.05
+  hard_fail: 0.15      # Stricter: ChEMBL data should be cleaner
+
+# =============================================================================
+# ChEMBL Common Field Validations
+# =============================================================================
+provider_field_validations:
+  # ChEMBL ID format validation (applies to all ChEMBL entities)
+  - field: molecule_chembl_id
+    type: pattern
+    pattern: '^CHEMBL\d+$'
+    nullable: true
+    error_message: "Invalid ChEMBL molecule ID format"
+
+  - field: target_chembl_id
+    type: pattern
+    pattern: '^CHEMBL\d+$'
+    nullable: true
+    error_message: "Invalid ChEMBL target ID format"
+
+  - field: assay_chembl_id
+    type: pattern
+    pattern: '^CHEMBL\d+$'
+    nullable: true
+    error_message: "Invalid ChEMBL assay ID format"
+
+  - field: document_chembl_id
+    type: pattern
+    pattern: '^CHEMBL\d+$'
+    nullable: true
+    error_message: "Invalid ChEMBL document ID format"

--- a/configs/dq/providers/pubchem.yaml
+++ b/configs/dq/providers/pubchem.yaml
@@ -1,0 +1,24 @@
+# configs/dq/providers/pubchem.yaml
+# PubChem-specific DQ rules
+# Inherits from: _defaults.yaml
+
+version: "1.0.0"
+provider: pubchem
+
+# =============================================================================
+# Provider-Specific Thresholds
+# =============================================================================
+thresholds:
+  soft_fail: 0.08      # PubChem has more variability
+  hard_fail: 0.25
+
+# =============================================================================
+# PubChem Common Field Validations
+# =============================================================================
+provider_field_validations:
+  # CID must be positive integer
+  - field: cid
+    type: range
+    min: 1
+    nullable: true
+    error_message: "CID must be a positive integer"

--- a/configs/dq/providers/uniprot.yaml
+++ b/configs/dq/providers/uniprot.yaml
@@ -1,0 +1,24 @@
+# configs/dq/providers/uniprot.yaml
+# UniProt-specific DQ rules
+# Inherits from: _defaults.yaml
+
+version: "1.0.0"
+provider: uniprot
+
+# =============================================================================
+# Provider-Specific Thresholds
+# =============================================================================
+thresholds:
+  soft_fail: 0.03      # UniProt data is high quality
+  hard_fail: 0.10
+
+# =============================================================================
+# UniProt Common Field Validations
+# =============================================================================
+provider_field_validations:
+  # UniProt accession format
+  - field: accession
+    type: pattern
+    pattern: '^[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}$'
+    nullable: true
+    error_message: "Invalid UniProt accession format"

--- a/src/bioetl/domain/config.py
+++ b/src/bioetl/domain/config.py
@@ -119,6 +119,7 @@ class FieldValidation:
     """Configuration for a single field validation rule.
 
     Supports multiple validation types:
+    - required: Field must be present and non-null
     - range: Numeric range validation (min/max)
     - pattern: Regex pattern matching
     - enum: Allowed values validation
@@ -126,7 +127,7 @@ class FieldValidation:
 
     Attributes:
         field: Field name to validate.
-        validation_type: Type of validation (range, pattern, enum, custom).
+        validation_type: Type of validation (required, range, pattern, enum, custom).
         nullable: Whether field can be null/None. Default: True.
         min_value: Minimum value for range validation.
         max_value: Maximum value for range validation.
@@ -137,7 +138,7 @@ class FieldValidation:
     """
 
     field: str
-    validation_type: Literal["range", "pattern", "enum", "custom"]
+    validation_type: Literal["required", "range", "pattern", "enum", "custom"]
     nullable: bool = True
     # Range validation
     min_value: float | None = None

--- a/src/bioetl/infrastructure/schemas/pipeline_config.py
+++ b/src/bioetl/infrastructure/schemas/pipeline_config.py
@@ -38,11 +38,11 @@ if TYPE_CHECKING:
 class FieldValidationConfig(BaseModel):
     """Configuration for a single field validation rule.
 
-    Supports: range, pattern, enum, custom validation types.
+    Supports: required, range, pattern, enum, custom validation types.
     """
 
     field: str = Field(description="Field name to validate")
-    type: Literal["range", "pattern", "enum", "custom"] = Field(
+    type: Literal["required", "range", "pattern", "enum", "custom"] = Field(
         description="Validation type"
     )
     nullable: bool = Field(default=True, description="Whether field can be null")


### PR DESCRIPTION
Create YAML configuration structure for Data Quality validation:

- _defaults.yaml: Global DQ thresholds and common field validations
- providers/: Provider-specific configs (chembl, pubchem, uniprot)
- entities/: Entity-specific configs with field, cross-field, and conditional validations

Add 'required' validation type to FieldValidation schema to support mandatory field checks in DQ configs.

Structure supports merge priority: defaults → provider → entity. All configs validated against Pydantic schemas from #1606.

RULES.md §3.1.2: DQ Thresholds compliance.