### PR TITLE
Fix failing architecture metrics checks

### DIFF
--- a/tests/unit/domain/test_config_types.py
+++ b/tests/unit/domain/test_config_types.py
@@ -383,5 +383,5 @@ class TestModuleExports:
         from bioetl.domain import config_types
 
         # Verify we have the expected TypedDicts
-        expected_count = 20  # 20 TypedDicts defined in config_types.py
+        expected_count = 26  # 26 TypedDicts defined in config_types.py
         assert len(config_types.__all__) == expected_count


### PR DESCRIPTION
Update test_expected_exports_count assertion to match the actual number of TypedDicts after recent additions for DQ config file support.