### PR TITLE
Create and update documentation for DQ config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,7 +392,7 @@ sha256(provider + canonical_json(record))
 
 ### 4.5. Архитектурные Решения (ADR)
 
-**26 ADR** определяют ключевые архитектурные решения проекта:
+**27 ADR** определяют ключевые архитектурные решения проекта:
 
 | ADR | Название | Описание |
 |-----|----------|----------|
@@ -422,6 +422,7 @@ sha256(provider + canonical_json(record))
 | 024 | Entity Naming Unification | Унификация именования сущностей |
 | 025 | Pipeline Config Unification | Унификация конфигурации пайплайнов |
 | 026 | Composite Pipeline Pattern | Паттерн композитного пайплайна |
+| 027 | DQ Rules Externalization | Иерархическая конфигурация DQ правил |
 
 Документы: `docs/02-architecture/decisions/ADR-{NNN}-*.md`
 

--- a/configs/dq/README.md
+++ b/configs/dq/README.md
@@ -1,0 +1,129 @@
+# DQ Configuration
+
+Data Quality configuration hierarchy for BioETL pipelines.
+
+*Reference: [ADR-027: DQ Rules Externalization](../../docs/02-architecture/decisions/ADR-027-dq-rules-externalization.md)*
+
+## Structure
+
+```
+dq/
+├── _defaults.yaml       # Global defaults (REQUIRED)
+├── providers/           # Provider-level overrides
+│   └── {provider}.yaml
+└── entities/            # Entity-specific rules
+    └── {provider}/
+        └── {entity}.yaml
+```
+
+## Merge Priority
+
+1. `_defaults.yaml` (lowest)
+2. `providers/{provider}.yaml`
+3. `entities/{provider}/{entity}.yaml`
+4. Inline `dq_rules` in pipeline config (highest)
+
+## Quick Start
+
+### Add validation for new entity
+
+1. Create entity config:
+   ```yaml
+   # entities/{provider}/{entity}.yaml
+   version: "1.0.0"
+   provider: {provider}
+   entity: {entity}
+
+   entity_field_validations:
+     - field: id
+       type: required
+       nullable: false
+   ```
+
+2. Reference in pipeline:
+   ```yaml
+   # pipelines/{provider}/{entity}.yaml
+   dq_config_file: ../../dq/entities/{provider}/{entity}.yaml
+   ```
+
+### Override threshold for specific pipeline
+
+```yaml
+# pipelines/{provider}/{entity}.yaml
+dq_config_file: ../../dq/entities/{provider}/{entity}.yaml
+dq_rules:
+  thresholds:
+    hard_fail: 0.30  # Temporary override
+```
+
+## Thresholds
+
+Default thresholds from RULES.md:
+
+| Threshold | Value | Behavior |
+|-----------|-------|----------|
+| `soft_fail` | 0.05 | Warning (>5% errors) |
+| `hard_fail` | 0.20 | Batch fails (>20% errors) |
+
+## Validation Types
+
+| Type | Parameters | Description |
+|------|------------|-------------|
+| `required` | `nullable` | Field must be present |
+| `range` | `min`, `max` | Numeric bounds |
+| `pattern` | `pattern` | Regex match |
+| `enum` | `allowed` | Value whitelist |
+| `custom` | `validator` | Custom validator function |
+
+## Cross-Field Conditions
+
+| Condition | Description |
+|-----------|-------------|
+| `all_present` | All fields must have values |
+| `any_present` | At least one field must have value |
+| `mutually_exclusive` | Only one field can have value |
+| `conditional_required` | Field required when trigger present |
+| `custom` | Custom validator |
+
+## Validation
+
+```bash
+# Validate all configs
+python -c "
+from pathlib import Path
+import yaml
+from bioetl.infrastructure.schemas.dq_config import DQConfigFile
+
+for f in Path('configs/dq').rglob('*.yaml'):
+    if f.name == 'README.md':
+        continue
+    with open(f) as fp:
+        data = yaml.safe_load(fp)
+        if data:
+            DQConfigFile.model_validate(data)
+    print(f'OK {f}')
+"
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `_defaults.yaml` | Global thresholds, common validations |
+| `providers/chembl.yaml` | ChEMBL-specific overrides |
+| `providers/pubchem.yaml` | PubChem-specific overrides |
+| `providers/uniprot.yaml` | UniProt-specific overrides |
+| `entities/chembl/activity.yaml` | Activity-specific rules |
+| `entities/chembl/assay.yaml` | Assay-specific rules |
+| `entities/chembl/molecule.yaml` | Molecule-specific rules |
+| `entities/chembl/target.yaml` | Target-specific rules |
+| `entities/pubchem/compound.yaml` | Compound-specific rules |
+| `entities/uniprot/target.yaml` | UniProt target-specific rules |
+
+## Reference
+
+- [ADR-027: DQ Rules Externalization](../../docs/02-architecture/decisions/ADR-027-dq-rules-externalization.md)
+- [DQ Configuration Guide](../../docs/03-guides/dq-configuration.md)
+- RULES.md Section 3.1.2: DQ Thresholds
+- Schema: `src/bioetl/infrastructure/schemas/dq_config.py`
+- Loader: `src/bioetl/infrastructure/config/dq_config_loader.py`

--- a/docs/02-architecture/decisions/ADR-027-dq-rules-externalization.md
+++ b/docs/02-architecture/decisions/ADR-027-dq-rules-externalization.md
@@ -1,0 +1,156 @@
+# ADR-027: DQ Rules Externalization
+
+**Status**: Accepted
+**Date**: 2026-01-19
+**Authors**: Claude Code
+**Reviewers**: -
+
+## Context
+
+Data Quality (DQ) rules were embedded directly in pipeline YAML configuration files (`configs/pipelines/{provider}/{entity}.yaml`). This caused several problems:
+
+1. **Duplication**: Same thresholds and validation rules repeated across pipelines
+2. **Maintenance burden**: Changing global DQ policies required editing multiple files
+3. **No reusability**: Impossible to share validation rules across providers/entities
+4. **SRP violation**: Pipeline config mixed orchestration and DQ policy concerns
+
+Example of duplication:
+```yaml
+# configs/pipelines/chembl/activity.yaml
+dq_rules:
+  soft_fail_threshold: 0.05
+  hard_fail_threshold: 0.20
+
+# configs/pipelines/chembl/molecule.yaml
+dq_rules:
+  soft_fail_threshold: 0.05  # Duplicated
+  hard_fail_threshold: 0.20  # Duplicated
+```
+
+## Decision
+
+Extract DQ rules into a hierarchical configuration structure:
+
+```
+configs/dq/
+├── _defaults.yaml           # Global defaults (Level 1)
+├── providers/
+│   └── {provider}.yaml      # Provider overrides (Level 2)
+└── entities/
+    └── {provider}/
+        └── {entity}.yaml    # Entity-specific rules (Level 3)
+```
+
+**Merge priority** (later wins for scalars, concatenate for validations):
+1. `_defaults.yaml`
+2. `providers/{provider}.yaml`
+3. `entities/{provider}/{entity}.yaml`
+4. Inline `dq_rules` in pipeline config (for exceptional cases)
+
+Pipeline configs reference DQ config via `dq_config_file`:
+```yaml
+pipeline_name: chembl_activity
+dq_config_file: ../../dq/entities/chembl/activity.yaml
+```
+
+### Implementation Components
+
+1. **Pydantic schemas**: `src/bioetl/infrastructure/schemas/dq_config.py`
+   - `ThresholdsConfig`: Validates soft_fail < hard_fail invariant
+   - `DQConfigFile`: Complete schema with hierarchical validation support
+
+2. **Configuration loader**: `src/bioetl/infrastructure/config/dq_config_loader.py`
+   - `DQConfigLoader.load(provider, entity, inline_overrides)`: Merges configs
+   - Thread-safe caching for performance
+   - Deep merge with validation list concatenation
+
+3. **Config files**: `configs/dq/`
+   - `_defaults.yaml`: Global thresholds (0.05/0.20), common validations
+   - `providers/{provider}.yaml`: Provider-specific settings
+   - `entities/{provider}/{entity}.yaml`: Entity-specific rules
+
+## Consequences
+
+### Positive
+
+- **DRY**: Global thresholds defined once in `_defaults.yaml`
+- **Separation of Concerns**: Pipeline config focuses on orchestration
+- **Reusability**: Provider-level validations shared across entities
+- **Flexibility**: Entity-specific rules without affecting others
+- **Backward compatible**: Inline `dq_rules` still supported as Level 4 override
+- **Type safety**: Pydantic validation catches config errors early
+- **Performance**: Caching prevents repeated file reads
+
+### Negative
+
+- **More files**: Additional config files to manage (mitigated by clear structure)
+- **Indirection**: Must look at multiple files to understand full config
+- **Merge complexity**: Need to understand merge behavior
+
+### Neutral
+
+- Migration effort: Existing pipelines work without changes
+- Tooling: Config validation scripts provided
+
+## Merge Rules
+
+| Data Type | Behavior | Example |
+|-----------|----------|---------|
+| Scalars | Override (later wins) | `soft_fail: 0.10` replaces `0.05` |
+| Validation lists (`*_validations`) | Concatenate with dedup | Entity validations added to provider |
+| Nested dicts | Recursive merge | `thresholds.soft_fail` merged with `thresholds.hard_fail` |
+| Other lists | Override (later wins) | `allowed: [A, B]` replaces `[X, Y]` |
+
+**Deduplication key** for validation lists:
+- Field validations: `field` attribute
+- Cross-field validations: `name` attribute
+- Conditional validations: `name` attribute
+
+## Alternatives Considered
+
+### 1. YAML Anchors
+Using YAML anchors for reuse within a single file. Rejected because:
+- Doesn't work across files
+- Complex syntax for users
+- No tool support for validation
+
+### 2. Single DQ Config File
+One global `dq_config.yaml` with all rules. Rejected because:
+- Becomes large and hard to navigate
+- No provider/entity separation
+- Cannot override specific entity without affecting others
+
+### 3. DQ Rules in Code
+Define validation rules in Python. Rejected because:
+- Requires code changes for config updates
+- Violates configuration-driven principle
+- Less accessible to non-developers
+
+### 4. Database-stored Rules
+Store DQ rules in a database. Rejected because:
+- Adds infrastructure dependency
+- Overkill for local-only deployment (ADR-010)
+- Harder to version control
+
+## Compliance
+
+| Requirement | Status | Implementation |
+|-------------|--------|----------------|
+| RULES.md §3.1.2 DQ Thresholds | PASS | `ThresholdsConfig` enforces 0.05/0.20 defaults |
+| soft_fail < hard_fail | PASS | `ThresholdsConfig.validate_order()` |
+| Hierarchical merge | PASS | `DQConfigLoader._deep_merge()` |
+| Backward compatibility | PASS | Inline `dq_rules` supported as override |
+
+## References
+
+- RULES.md §3.1.2: DQ Thresholds
+- Domain config: `src/bioetl/domain/config.py`
+- Schema: `src/bioetl/infrastructure/schemas/dq_config.py`
+- Loader: `src/bioetl/infrastructure/config/dq_config_loader.py`
+- Config files: `configs/dq/`
+
+## Changelog
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-01-19 | Claude Code | Initial version |

--- a/docs/03-guides/dq-configuration.md
+++ b/docs/03-guides/dq-configuration.md
@@ -1,0 +1,385 @@
+# Data Quality Configuration
+
+*Reference: [ADR-027: DQ Rules Externalization](../02-architecture/decisions/ADR-027-dq-rules-externalization.md)*
+
+This guide describes how to configure Data Quality (DQ) rules in BioETL.
+
+## Overview
+
+DQ rules are organized in a hierarchical configuration structure that enables:
+- **Reusability**: Share validations across pipelines
+- **Override flexibility**: Entity-specific rules without affecting others
+- **DRY principle**: Global thresholds defined once
+
+## Hierarchical DQ Config Structure
+
+```
+configs/dq/
+├── _defaults.yaml           # Level 1: Global defaults
+├── providers/
+│   └── {provider}.yaml      # Level 2: Provider overrides
+└── entities/
+    └── {provider}/
+        └── {entity}.yaml    # Level 3: Entity-specific rules
+```
+
+## Merge Behavior
+
+Configurations are merged in order (later wins):
+
+| Level | File | Scope |
+|-------|------|-------|
+| 1 | `_defaults.yaml` | All pipelines |
+| 2 | `providers/{provider}.yaml` | All entities of provider |
+| 3 | `entities/{provider}/{entity}.yaml` | Specific entity |
+| 4 | Inline `dq_rules` in pipeline | Override for exceptions |
+
+**Merge rules**:
+- Scalars: Override (later value wins)
+- Validation lists (`*_validations`): Concatenate with deduplication by `name`/`field`
+- Nested dicts: Recursive merge
+
+## DQ Thresholds
+
+BioETL uses two-level error thresholds (RULES.md §3.1.2):
+
+| Threshold | Default | Behavior |
+|-----------|---------|----------|
+| `soft_fail` | 0.05 (5%) | Warning emitted, pipeline continues |
+| `hard_fail` | 0.20 (20%) | Batch fails, records quarantined |
+
+Configure in `_defaults.yaml`:
+
+```yaml
+thresholds:
+  soft_fail: 0.05      # >5% errors → Warning
+  hard_fail: 0.20      # >20% errors → Fail Batch
+```
+
+**Invariant**: `soft_fail` must be strictly less than `hard_fail`.
+
+## Adding DQ Rules for New Entity
+
+### Step 1: Check if provider config exists
+
+```bash
+ls configs/dq/providers/{provider}.yaml
+```
+
+If it doesn't exist, create it:
+
+```yaml
+# configs/dq/providers/{provider}.yaml
+version: "1.0.0"
+provider: {provider}
+
+# Optional: provider-wide field validations
+provider_field_validations: []
+```
+
+### Step 2: Create entity config
+
+```yaml
+# configs/dq/entities/{provider}/{entity}.yaml
+version: "1.0.0"
+provider: {provider}
+entity: {entity}
+
+# Override thresholds for this entity (optional)
+# thresholds:
+#   hard_fail: 0.10
+
+# Field-level validations
+entity_field_validations:
+  - field: primary_id
+    type: required
+    nullable: false
+    error_message: "Primary ID is required"
+
+# Cross-field validations
+entity_cross_field_validations: []
+
+# Conditional validations
+entity_conditional_validations: []
+```
+
+### Step 3: Reference in pipeline config
+
+```yaml
+# configs/pipelines/{provider}/{entity}.yaml
+pipeline_name: {provider}_{entity}
+dq_config_file: ../../dq/entities/{provider}/{entity}.yaml
+```
+
+## Validation Types
+
+### Field Validations
+
+| Type | Parameters | Description |
+|------|------------|-------------|
+| `required` | `nullable` | Field must be present (unless nullable=true) |
+| `range` | `min`, `max` | Numeric bounds check |
+| `pattern` | `pattern` | Regex match |
+| `enum` | `allowed` | Value must be in whitelist |
+| `custom` | `validator` | Custom validator function name |
+
+**Examples:**
+
+```yaml
+entity_field_validations:
+  # Required field
+  - field: activity_id
+    type: required
+    nullable: false
+    error_message: "Activity ID is required"
+
+  # Range validation
+  - field: standard_value
+    type: range
+    min: 0
+    nullable: true
+    error_message: "Standard value must be non-negative"
+
+  # Pattern validation
+  - field: smiles
+    type: pattern
+    pattern: '^[A-Za-z0-9@+\-\[\]\(\)=#%\/\\\.]+$'
+    nullable: true
+    error_message: "Invalid SMILES format"
+
+  # Enum validation
+  - field: standard_type
+    type: enum
+    allowed:
+      - IC50
+      - Ki
+      - Kd
+      - EC50
+    nullable: true
+    error_message: "Invalid standard_type value"
+```
+
+### Cross-Field Validations
+
+| Condition | Description |
+|-----------|-------------|
+| `all_present` | All specified fields must have values |
+| `any_present` | At least one field must have value |
+| `mutually_exclusive` | Only one field can have value |
+| `conditional_required` | `required_field` needed when `trigger_field` present |
+| `custom` | Custom validator function |
+
+**Examples:**
+
+```yaml
+entity_cross_field_validations:
+  # If value present, units should be present
+  - name: value_requires_units
+    fields:
+      - standard_value
+      - standard_units
+    condition: conditional_required
+    trigger_field: standard_value
+    required_field: standard_units
+    error_message: "Units required when value is present"
+
+  # At least one identifier must be present
+  - name: need_identifier
+    fields:
+      - chembl_id
+      - inchi_key
+      - smiles
+    condition: any_present
+    error_message: "At least one identifier required"
+```
+
+### Conditional Validations
+
+Apply validations only when a condition is met.
+
+| Parameter | Description |
+|-----------|-------------|
+| `condition_field` | Field to check for condition |
+| `condition_value` | Value(s) that trigger the validation |
+| `condition_operator` | Comparison operator: `eq`, `ne`, `in`, `not_in`, `gt`, `lt`, `ge`, `le` |
+| `then_validations` | List of validations to apply when condition is true |
+
+**Example:**
+
+```yaml
+entity_conditional_validations:
+  # When assay_type is 'B' (Binding), target must be present
+  - name: binding_requires_target
+    condition_field: assay_type
+    condition_value: B
+    condition_operator: eq
+    then_validations:
+      - field: target_chembl_id
+        type: required
+        nullable: false
+        error_message: "Binding assays must have a target"
+
+  # When activity_type is in [IC50, Ki], standard_value required
+  - name: potency_needs_value
+    condition_field: activity_type
+    condition_value: [IC50, Ki, Kd, EC50]
+    condition_operator: in
+    then_validations:
+      - field: standard_value
+        type: required
+        nullable: false
+        error_message: "Potency measures require a value"
+```
+
+## Complete Entity DQ Config Example
+
+```yaml
+# configs/dq/entities/chembl/activity.yaml
+version: "1.0.0"
+provider: chembl
+entity: activity
+
+# Override provider thresholds (optional)
+# thresholds:
+#   hard_fail: 0.10
+
+entity_field_validations:
+  - field: activity_id
+    type: required
+    nullable: false
+    error_message: "Activity ID is required"
+
+  - field: standard_value
+    type: range
+    min: 0
+    nullable: true
+    error_message: "Standard value must be non-negative"
+
+  - field: pchembl_value
+    type: range
+    min: 0
+    max: 15
+    nullable: true
+    error_message: "pChEMBL value must be between 0 and 15"
+
+  - field: standard_type
+    type: enum
+    allowed: [IC50, Ki, Kd, EC50, AC50, GI50, Potency, Activity, Inhibition]
+    nullable: true
+    error_message: "Invalid standard_type value"
+
+entity_cross_field_validations:
+  - name: value_requires_units
+    fields: [standard_value, standard_units]
+    condition: conditional_required
+    trigger_field: standard_value
+    required_field: standard_units
+    error_message: "standard_units required when standard_value is present"
+
+entity_conditional_validations:
+  - name: binding_requires_target
+    condition_field: assay_type
+    condition_value: B
+    condition_operator: eq
+    then_validations:
+      - field: target_chembl_id
+        type: required
+        nullable: false
+        error_message: "Binding assays must have a target"
+```
+
+## Inline Overrides (Level 4)
+
+For exceptional cases, override DQ rules directly in pipeline config:
+
+```yaml
+# configs/pipelines/chembl/activity.yaml
+pipeline_name: chembl_activity
+dq_config_file: ../../dq/entities/chembl/activity.yaml
+
+# Temporary override for migration period
+dq_rules:
+  thresholds:
+    hard_fail: 0.30  # Higher tolerance during migration
+  field_validations:
+    - field: legacy_id
+      type: required
+      nullable: false
+```
+
+**Note**: Inline overrides should be temporary. Prefer updating entity config for permanent changes.
+
+## Programmatic Access
+
+```python
+from pathlib import Path
+from bioetl.infrastructure.config.dq_config_loader import DQConfigLoader
+
+# Load merged config
+loader = DQConfigLoader(Path("configs"))
+dq_config = loader.load(
+    provider="chembl",
+    entity="activity",
+    inline_overrides=None,  # Optional Level 4 overrides
+)
+
+# Access domain objects
+print(f"Soft threshold: {dq_config.soft_fail_threshold}")
+print(f"Hard threshold: {dq_config.hard_fail_threshold}")
+print(f"Field validations: {len(dq_config.field_validations)}")
+```
+
+## Validation
+
+Validate all DQ configs:
+
+```bash
+# Validate via Python
+python -c "
+from pathlib import Path
+import yaml
+from bioetl.infrastructure.schemas.dq_config import DQConfigFile
+
+for f in Path('configs/dq').rglob('*.yaml'):
+    if f.name == 'README.md':
+        continue
+    with open(f) as fp:
+        data = yaml.safe_load(fp)
+        if data:  # Skip empty files
+            DQConfigFile.model_validate(data)
+    print(f'OK {f}')
+print('All configs valid!')
+"
+```
+
+## Troubleshooting
+
+### Error: soft_fail >= hard_fail
+
+```
+ValueError: soft_fail (0.25) must be < hard_fail (0.20)
+```
+
+**Fix**: Ensure `soft_fail` is strictly less than `hard_fail` in your config.
+
+### Error: Required field not found
+
+```
+FileNotFoundError: Required DQ defaults file not found: configs/dq/_defaults.yaml
+```
+
+**Fix**: Create `configs/dq/_defaults.yaml` with global settings.
+
+### Validation not applied
+
+**Check**:
+1. Is `dq_config_file` path correct in pipeline config?
+2. Is field name spelled correctly in validation?
+3. Is validation type correct for the field data type?
+
+## References
+
+- [ADR-027: DQ Rules Externalization](../02-architecture/decisions/ADR-027-dq-rules-externalization.md)
+- RULES.md §3.1.2: DQ Thresholds
+- Schema: `src/bioetl/infrastructure/schemas/dq_config.py`
+- Loader: `src/bioetl/infrastructure/config/dq_config_loader.py`

--- a/docs/03-guides/local-storage-layout.md
+++ b/docs/03-guides/local-storage-layout.md
@@ -162,6 +162,62 @@ print(settings.bronze_path)  # Path("data/bronze")
 print(settings.silver_path)  # Path("data/silver")
 ```
 
+## Configs Structure
+
+*Reference: [ADR-027: DQ Rules Externalization](../02-architecture/decisions/ADR-027-dq-rules-externalization.md)*
+
+```
+configs/
+├── dq/                                # DQ Configuration Hierarchy (ADR-027)
+│   ├── _defaults.yaml                 # Global defaults (thresholds, common validations)
+│   ├── providers/
+│   │   ├── chembl.yaml                # ChEMBL provider overrides
+│   │   ├── pubchem.yaml               # PubChem provider overrides
+│   │   └── uniprot.yaml               # UniProt provider overrides
+│   └── entities/
+│       ├── chembl/
+│       │   ├── activity.yaml          # Activity-specific rules
+│       │   ├── assay.yaml
+│       │   ├── molecule.yaml
+│       │   └── target.yaml
+│       ├── pubchem/
+│       │   └── compound.yaml
+│       └── uniprot/
+│           └── target.yaml
+│
+├── pipelines/                         # Pipeline orchestration configs
+│   ├── _defaults.yaml                 # Base pipeline defaults
+│   ├── chembl/
+│   │   ├── activity.yaml              # References dq_config_file
+│   │   ├── assay.yaml
+│   │   ├── molecule.yaml
+│   │   └── target.yaml
+│   ├── pubchem/
+│   │   └── compound.yaml
+│   └── uniprot/
+│       └── target.yaml
+│
+├── sources/                           # Source connection configs
+│   ├── chembl.yaml
+│   ├── pubchem.yaml
+│   └── uniprot.yaml
+│
+└── env/
+    └── .env.example
+```
+
+### DQ Config Hierarchy
+
+| Level | Path | Purpose |
+|-------|------|---------|
+| Global | `dq/_defaults.yaml` | Base thresholds (0.05/0.20), common validations |
+| Provider | `dq/providers/{provider}.yaml` | Provider-specific overrides |
+| Entity | `dq/entities/{provider}/{entity}.yaml` | Entity-specific rules |
+
+**Merge order**: defaults → provider → entity → inline overrides
+
+See [DQ Configuration Guide](dq-configuration.md) for details.
+
 ## Migration from S3
 
 If migrating from a previous S3-based deployment:


### PR DESCRIPTION
Add comprehensive documentation for the hierarchical DQ configuration:

- ADR-027: DQ Rules Externalization - architectural decision record
- docs/03-guides/dq-configuration.md - detailed guide for DQ config
- docs/03-guides/local-storage-layout.md - add configs structure section
- configs/dq/README.md - quick reference for DQ config directory
- CLAUDE.md - add ADR-027 to the ADR list (now 27 ADRs)

Implements RULES.md §3.1.2 DQ Thresholds documentation requirements.