### PR TITLE
Fix duplication and complexity checks

### DIFF
--- a/src/bioetl/domain/context.py
+++ b/src/bioetl/domain/context.py
@@ -84,14 +84,18 @@ class InputFilterContext:
         """Validate filter configuration."""
         if not self.enabled:
             return
-
-        # Direct IDs mode: only need filter_field
         if self.filter_ids is not None:
-            if not self.filter_field:
-                raise ValueError("filter_field is required when filter_ids is set")
-            return
+            self._validate_direct_ids_mode()
+        else:
+            self._validate_csv_mode()
 
-        # CSV mode: need all fields
+    def _validate_direct_ids_mode(self) -> None:
+        """Validate direct IDs mode configuration."""
+        if not self.filter_field:
+            raise ValueError("filter_field is required when filter_ids is set")
+
+    def _validate_csv_mode(self) -> None:
+        """Validate CSV mode configuration."""
         if not self.source_path:
             raise ValueError("source_path is required when filter is enabled")
         if not self.column_name:

--- a/src/bioetl/domain/filtering/input_config.py
+++ b/src/bioetl/domain/filtering/input_config.py
@@ -62,19 +62,22 @@ class InputFilterConfig:
         """Validate fields required when filtering is enabled."""
         if not self.enabled:
             return
-
-        # Direct filter IDs mode: only need filter_field
         if self.direct_filter_ids is not None:
-            if not self.filter_field:
-                raise ValueError(
-                    "filter_field is required when using direct_filter_ids"
-                )
-            return
+            self._validate_direct_filter_mode()
+        else:
+            self._validate_csv_filter_mode()
 
-        # CSV-based mode: need source_path
+    def _validate_direct_filter_mode(self) -> None:
+        """Validate direct filter IDs mode configuration."""
+        if not self.filter_field:
+            raise ValueError(
+                "filter_field is required when using direct_filter_ids"
+            )
+
+    def _validate_csv_filter_mode(self) -> None:
+        """Validate CSV-based filter mode configuration."""
         if not self.source_path:
             raise ValueError("source_path is required when filter is enabled")
-        # Either columns list or single column_name/filter_field must be provided
         if self.columns:
             self._validate_columns()
         elif not self._has_single_column_config():


### PR DESCRIPTION
Extract validation logic into smaller focused methods to meet domain layer complexity threshold (CC ≤ 5):

- InputFilterContext.__post_init__: CC=7 → CC=3
  - Extracted _validate_direct_ids_mode()
  - Extracted _validate_csv_mode()

- InputFilterConfig._validate_enabled_fields: CC=7 → CC=3
  - Extracted _validate_direct_filter_mode()
  - Extracted _validate_csv_filter_mode()

This fixes the failing "Strict complexity check for domain layer" CI check.