### PR TITLE
Fix failing lint and type check tests

### DIFF
--- a/src/bioetl/application/composite/merger.py
+++ b/src/bioetl/application/composite/merger.py
@@ -471,11 +471,8 @@ class MergeService:
             return True
 
         # List types are incompatible with scalar types
-        if isinstance(type1, pl.List) != isinstance(type2, pl.List):
-            return False
-
         # Different scalar types may be compatible (Polars handles casting)
-        return True
+        return isinstance(type1, pl.List) == isinstance(type2, pl.List)
 
     def _coalesce_prefer_seed(
         self, df: pl.DataFrame, enrichers: Sequence[EnricherConfig]

--- a/tests/architecture/test_code_metrics.py
+++ b/tests/architecture/test_code_metrics.py
@@ -227,10 +227,6 @@ class TestFunctionComplexity:
         "from_dict": 8,  # CC=6 - Dictionary parsing with type conversions
         # BatchExecutor DQ context extraction
         "get_dq_context": 13,  # CC=12 - DQ context gathering with nullable field handling
-        # Domain filtering validation
-        "_validate_enabled_fields": 8,  # CC=7 - InputFilterConfig validation with multi-mode checks
-        # FilteredDataSource context manager
-        "__aenter__": 14,  # CC=13 - Data source initialization with provider/entity type dispatch
     }
 
     def test_domain_complexity(self, src_dir: Path) -> None:

--- a/tests/architecture/test_domain_purity.py
+++ b/tests/architecture/test_domain_purity.py
@@ -267,8 +267,6 @@ class TestDomainComplexity:
             # Composite pipeline domain models (ADR-026)
             "DQOverrideConfig": 10,  # CC=9 - DQ override validation with threshold checks
             "from_dict": 8,  # CC=6 - Dictionary parsing with type conversions
-            # Domain filtering validation
-            "_validate_enabled_fields": 8,  # CC=7 - InputFilterConfig validation with multi-mode checks
         }
 
         violations = []


### PR DESCRIPTION
- Simplify return logic in merger.py using SIM103 pattern
- Remove duplicate dictionary keys in test_code_metrics.py
- Remove duplicate dictionary key in test_domain_purity.py