### PR TITLE
Remove dead and unused code from project

### DIFF
--- a/src/bioetl/application/services/pipeline_runner_service.py
+++ b/src/bioetl/application/services/pipeline_runner_service.py
@@ -11,8 +11,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import Enum
-from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, cast
 from uuid import UUID, uuid4
 
 from bioetl.domain.context import (
@@ -187,8 +186,6 @@ class PipelineRunnerService:
     async def run(
         self,
         pipeline_name: str,
-        config_path: Path | None = None,
-        overrides: dict[str, Any] | None = None,
         dry_run: bool = False,
         run_id: UUID | None = None,
         options: RunOptions | None = None,
@@ -204,8 +201,6 @@ class PipelineRunnerService:
 
         Args:
             pipeline_name: Name of the pipeline to run (e.g., 'chembl_activity').
-            config_path: Optional path to config file (not implemented yet).
-            overrides: Optional config overrides as dict (not implemented yet).
             dry_run: If True, only preview what would be done.
             run_id: Optional run ID. If None, a new UUID is generated.
             options: Optional RunOptions for detailed configuration.

--- a/src/bioetl/infrastructure/adapters/chembl/exceptions.py
+++ b/src/bioetl/infrastructure/adapters/chembl/exceptions.py
@@ -17,10 +17,6 @@ class ChemblApiError(ExternalServiceError):
 
     Internal exception for ChEMBL adapter. On adapter boundary, this
     should be translated to domain ExternalServiceError or its subclasses.
-
-    Note:
-        This is the canonical location for ChemblApiError.
-        The version in domain.exceptions is deprecated.
     """
 
     error_type = ErrorType.NETWORK_ERROR

--- a/src/bioetl/infrastructure/adapters/crossref/exceptions.py
+++ b/src/bioetl/infrastructure/adapters/crossref/exceptions.py
@@ -17,10 +17,6 @@ class CrossRefApiError(ExternalServiceError):
 
     Internal exception for CrossRef adapter. On adapter boundary, this
     should be translated to domain ExternalServiceError or its subclasses.
-
-    Note:
-        This is the canonical location for CrossRefApiError.
-        The version in domain.exceptions is deprecated.
     """
 
     error_type = ErrorType.NETWORK_ERROR

--- a/src/bioetl/interfaces/cli/commands/run_composite.py
+++ b/src/bioetl/interfaces/cli/commands/run_composite.py
@@ -23,7 +23,7 @@ from bioetl.interfaces.cli.formatters import echo_error, echo_info, echo_warning
 
 
 def _validate_composite_name(
-    ctx: click.Context, param: click.Parameter, value: str
+    _ctx: click.Context, _param: click.Parameter, value: str
 ) -> str:
     """Validate composite pipeline name."""
     if not value:


### PR DESCRIPTION
- Remove unused `config_path` and `overrides` parameters from PipelineRunnerService.run() - documented as "not implemented yet" and never used by any caller
- Remove unused `Path` and `Any` imports from pipeline_runner_service.py
- Rename unused Click callback params to `_ctx`, `_param` in run_composite.py (standard convention for intentionally unused params)
- Remove outdated docstring notes referencing deprecated exceptions in domain.exceptions that no longer exist (ChemblApiError, CrossRefApiError)

Verified by:
- ruff check: All checks passed
- mypy --strict: No new errors (1 pre-existing unrelated error)
- pytest tests/unit/: All tests pass
- pytest tests/architecture/: All tests pass
- vulture: Unused variable warnings resolved