### PR TITLE
Add missing docstrings to BioETL framework

### DIFF
--- a/src/bioetl/application/pipelines/pubmed/xml_utils.py
+++ b/src/bioetl/application/pipelines/pubmed/xml_utils.py
@@ -9,14 +9,63 @@ import xml.etree.ElementTree as ET
 
 
 def get_text(node: ET.Element | None) -> str | None:
-    """Extract text from an XML node, returning None if node is None or empty."""
+    """Extract text content from an XML element.
+
+    Safely extracts and strips whitespace from XML element text content.
+    Handles None elements and empty text gracefully.
+
+    Args:
+        node: XML element to extract text from, or None.
+
+    Returns:
+        Stripped text content if element exists and has non-empty text,
+        None otherwise.
+
+    Example:
+        >>> import xml.etree.ElementTree as ET
+        >>> elem = ET.fromstring("<title>  PubMed Article  </title>")
+        >>> get_text(elem)
+        'PubMed Article'
+        >>> get_text(None)
+        None
+        >>> empty = ET.fromstring("<title></title>")
+        >>> get_text(empty)
+        None
+
+    """
     if node is not None and node.text:
         return node.text.strip()
     return None
 
 
 def get_int(node: ET.Element | None) -> int | None:
-    """Extract integer from a node, returning None if invalid."""
+    """Extract integer value from an XML element.
+
+    Safely parses integer from XML element text content.
+    Returns None for missing elements, empty text, or non-integer values.
+
+    Args:
+        node: XML element containing integer text, or None.
+
+    Returns:
+        Parsed integer if element exists and contains valid integer text,
+        None otherwise (including for non-numeric text).
+
+    Example:
+        >>> import xml.etree.ElementTree as ET
+        >>> year = ET.fromstring("<Year>2024</Year>")
+        >>> get_int(year)
+        2024
+        >>> get_int(None)
+        None
+        >>> invalid = ET.fromstring("<Year>invalid</Year>")
+        >>> get_int(invalid)
+        None
+        >>> empty = ET.fromstring("<Year>  </Year>")
+        >>> get_int(empty)
+        None
+
+    """
     if node is not None and node.text:
         text = node.text.strip()
         if text:

--- a/src/bioetl/infrastructure/adapters/http/health.py
+++ b/src/bioetl/infrastructure/adapters/http/health.py
@@ -1,4 +1,13 @@
-"""Health check utilities for HTTP adapters."""
+"""Health check utilities for HTTP adapters.
+
+Provides functions to assess adapter health based on circuit breaker state.
+Used by HTTP adapters to implement the health_check() method required by
+the HealthCheckPort protocol.
+
+See Also:
+    - CircuitBreakerPort: Protocol defining circuit breaker interface
+    - ADR-007: Circuit Breaker Implementation decision
+"""
 
 from __future__ import annotations
 
@@ -8,13 +17,42 @@ from bioetl.domain.types import HealthStatus
 
 
 def assess_health_from_circuit_breaker(circuit_breaker: Any) -> HealthStatus:
-    """Determine health status from circuit breaker state.
+    """Determine adapter health status from circuit breaker state.
+
+    Maps circuit breaker state and failure count to a HealthStatus value
+    for use in adapter health checks. The mapping follows these rules:
+
+    - HEALTHY: Circuit is CLOSED with zero failures (normal operation)
+    - DEGRADED: Circuit has 1-2 failures (experiencing intermittent issues)
+    - UNHEALTHY: Circuit has 3+ failures or is OPEN/HALF_OPEN
+
+    This function expects a circuit breaker implementing CircuitBreakerPort
+    with get_state() and get_failure_count() methods.
 
     Args:
-        circuit_breaker: CircuitBreaker instance
+        circuit_breaker: Instance implementing CircuitBreakerPort protocol.
+            Must have get_state() returning CircuitBreakerState and
+            get_failure_count() returning int.
 
     Returns:
-        HealthStatus based on state and failure count.
+        HealthStatus enum value:
+        - HEALTHY: Adapter is fully operational
+        - DEGRADED: Adapter is functional but experiencing issues
+        - UNHEALTHY: Adapter is not operational or has critical failures
+
+    Example:
+        >>> from bioetl.infrastructure.adapters.http import CircuitBreaker
+        >>> cb = CircuitBreaker(provider="chembl", failure_threshold=5)
+        >>> assess_health_from_circuit_breaker(cb)
+        <HealthStatus.HEALTHY: 'healthy'>
+        >>> # After some failures:
+        >>> cb._failure_count = 2  # Simulated failures
+        >>> assess_health_from_circuit_breaker(cb)
+        <HealthStatus.DEGRADED: 'degraded'>
+
+    See Also:
+        - CircuitBreakerPort: Protocol definition in domain/ports/resilience.py
+        - RULES.md §3.1.4: Circuit breaker requirements
 
     """
     cb_state = circuit_breaker.get_state()


### PR DESCRIPTION
Add complete Google-style docstrings with Args, Returns, and Example sections to functions that had minimal documentation:

- pubmed/xml_utils.py: get_text(), get_int() - XML extraction utilities
- http/health.py: assess_health_from_circuit_breaker() - health check utility

Includes module-level docstring enhancement for health.py with See Also references to ADR-007 and CircuitBreakerPort.