### PR TITLE
Add missing _index field to META_FIELDS

### DIFF
--- a/src/bioetl/domain/services/identity_service.py
+++ b/src/bioetl/domain/services/identity_service.py
@@ -30,6 +30,7 @@ META_FIELDS: frozenset[str] = frozenset(
         "_dq_warn",
         "_dq_error",
         "_source_batch_id",
+        "_index",
     }
 )
 

--- a/src/bioetl/domain/transformations.py
+++ b/src/bioetl/domain/transformations.py
@@ -33,6 +33,7 @@ META_FIELDS = {
     "_dq_warn",
     "_dq_error",
     "_source_batch_id",
+    "_index",
 }
 
 

--- a/tests/unit/domain/services/test_identity_service.py
+++ b/tests/unit/domain/services/test_identity_service.py
@@ -117,6 +117,7 @@ class TestMetaFieldExclusion:
             "_dq_warn",
             "_dq_error",
             "_source_batch_id",
+            "_index",
         ],
     )
     def test_meta_field_excluded_from_hash(self, meta_field: str) -> None:
@@ -140,6 +141,7 @@ class TestMetaFieldExclusion:
             "_dq_warn",
             "_dq_error",
             "_source_batch_id",
+            "_index",
         }
         assert META_FIELDS == expected
 


### PR DESCRIPTION
…t hash

The _index field was missing from META_FIELDS in both transformations.py and identity_service.py, causing the content hash to vary based on a record's position within a batch. This led to false duplicates in the Silver layer during reprocessing.

Changes:
- Add _index to META_FIELDS in domain/transformations.py
- Add _index to META_FIELDS in domain/services/identity_service.py
- Update test_identity_service.py to verify _index exclusion