### PR TITLE
Remove duplicate META_FIELDS definitions

### DIFF
--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -18,6 +18,9 @@ from __future__ import annotations
 # Composite pipeline subpackage (ADR-026)
 from bioetl.domain import composite
 
+# Domain constants module
+from bioetl.domain import constants
+
 # Configuration objects
 from bioetl.domain.config import (
     DEFAULT_VALIDATION_CONFIG,
@@ -238,9 +241,11 @@ from bioetl.domain.serialization import (
 # Domain services
 from bioetl.domain.services import IdentityService
 
+# Domain constants
+from bioetl.domain.constants import META_FIELDS
+
 # Pure domain transformations
 from bioetl.domain.transformations import (
-    META_FIELDS,
     calculate_dq_score,
     canonical_json_dumps,
     detect_hash_collision,
@@ -306,6 +311,8 @@ from bioetl.domain.value_objects import (
 __all__ = [
     # Composite pipeline (subpackage)
     "composite",
+    # Constants
+    "constants",
     # Configuration
     "DEFAULT_VALIDATION_CONFIG",
     "DQConfig",

--- a/src/bioetl/domain/constants.py
+++ b/src/bioetl/domain/constants.py
@@ -1,0 +1,25 @@
+"""Domain layer constants.
+
+Centralized constants shared across domain modules.
+This module contains only immutable values with no external dependencies.
+
+Requirements:
+- REQ-ARCH-003: No I/O in domain layer
+- REQ-ID-001 to REQ-ID-008: Content hash algorithm (meta-field exclusion)
+"""
+
+from __future__ import annotations
+
+# Meta-fields to exclude from hash calculation (RULES.md §2.8.1)
+# These are system/ingestion fields that should not affect content identity.
+META_FIELDS: frozenset[str] = frozenset(
+    {
+        "_ingestion_ts",
+        "_run_id",
+        "_run_type",
+        "_dq_warn",
+        "_dq_error",
+        "_source_batch_id",
+        "_index",
+    }
+)

--- a/src/bioetl/domain/services/identity_service.py
+++ b/src/bioetl/domain/services/identity_service.py
@@ -18,21 +18,9 @@ import math
 from datetime import date, datetime
 from typing import Any
 
+from bioetl.domain.constants import META_FIELDS
 from bioetl.domain.serialization import serialize_to_json_canonical
 from bioetl.domain.types import ContentHash, EntityID
-
-# Meta-fields to exclude from hash calculation (RULES.md §2.8.1)
-META_FIELDS: frozenset[str] = frozenset(
-    {
-        "_ingestion_ts",
-        "_run_id",
-        "_run_type",
-        "_dq_warn",
-        "_dq_error",
-        "_source_batch_id",
-        "_index",
-    }
-)
 
 
 class IdentityService:

--- a/src/bioetl/domain/transformations.py
+++ b/src/bioetl/domain/transformations.py
@@ -18,23 +18,13 @@ from datetime import date, datetime
 from functools import singledispatch
 from typing import Any
 
+from .constants import META_FIELDS
 from .serialization import serialize_to_json_canonical
 from .types import ContentHash, DriftLevel, EntityID
 
 # =============================================================================
 # Content Hash Generation (RULES.md §2.8)
 # =============================================================================
-
-# Meta-fields to exclude from hash calculation
-META_FIELDS = {
-    "_ingestion_ts",
-    "_run_id",
-    "_run_type",
-    "_dq_warn",
-    "_dq_error",
-    "_source_batch_id",
-    "_index",
-}
 
 
 @singledispatch


### PR DESCRIPTION
Move duplicate META_FIELDS definition from transformations.py and identity_service.py into a shared constants module to eliminate code duplication and ensure single source of truth.

- Create src/bioetl/domain/constants.py with META_FIELDS frozenset
- Update transformations.py to import from constants
- Update identity_service.py to import from constants
- Update domain/__init__.py to export from constants module