### PR TITLE
Document _index field in RULES.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,7 +356,7 @@ sha256(provider + canonical_json(record))
 - Floats → `round(val, 10)`
 - Dates → ISO `YYYY-MM-DD`
 - Strings → `strip()`
-- **Исключить**: `_ingestion_ts`, `_run_id`, `_run_type`, `_dq_*`
+- **Исключить**: `_ingestion_ts`, `_run_id`, `_run_type`, `_source_batch_id`, `_index`, `_dq_*`
 
 ---
 

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -690,7 +690,7 @@ async with services:  # __aenter__ инициализирует ресурсы
 2. **Time Source**: `datetime.now()` **MUST NOT** вызываться в `infrastructure` слое (за исключением мониторинга реального времени). Все временные метки (`ingestion_ts`, `processing_ts`) **MUST** генерироваться в `Application` слое (`PipelineContext.started_at`) и передаваться вниз.
 3. **Retry Jitter**: При `deterministic=True`, jitter **MUST** вычисляться детерминистично (на основе хэша попытки и URL). Реализация: `domain/resilience.py:RetryPolicy.calculate_delay()` использует MD5-based jitter.
 4. **Ordering**: Запись в Delta Lake **MUST** происходить после сортировки данных по Primary Keys (Silver) или Business Keys (Gold).
-5. **Content Hash**: Исключать из расчёта хэша технические мета-поля: `_ingestion_ts`, `_run_id`, `_run_type`, `_dq_*`. Реализация: `domain/transformations.py:META_FIELDS`.
+5. **Content Hash**: Исключать из расчёта хэша технические мета-поля: `_ingestion_ts`, `_run_id`, `_run_type`, `_source_batch_id`, `_index`, `_dq_*`. Реализация: `domain/transformations.py:META_FIELDS`.
 
 #### Архитектурные Тесты Детерминизма
 

--- a/src/bioetl/domain/transformations.py
+++ b/src/bioetl/domain/transformations.py
@@ -33,6 +33,7 @@ META_FIELDS = {
     "_dq_warn",
     "_dq_error",
     "_source_batch_id",
+    "_index",
 }
 
 


### PR DESCRIPTION
Add _index field to META_FIELDS in transformations.py to exclude it from content hash calculation. The _index field is a technical meta-field that contains the sequential index of a record in a pipeline run and should not affect the content hash (which would change on re-runs).

Also synchronizes documentation in RULES.md §6.1 and CLAUDE.md §3.3 to list all META_FIELDS: _ingestion_ts, _run_id, _run_type, _source_batch_id, _index, and _dq_* fields.

Fixes MDA-002.