### PR TITLE
Move data quality fields to BaseEntity

### DIFF
--- a/src/bioetl/domain/entities/base.py
+++ b/src/bioetl/domain/entities/base.py
@@ -46,6 +46,8 @@ class BaseEntity:
         source_batch_id: Batch context ID (OPTIONAL, may be None)
         ingestion_ts: Ingestion timestamp from context (REQUIRED)
         _index: Sequential index of the record in the pipeline run.
+        _dq_warn: Data quality warning flag (default: False)
+        _dq_error: Data quality error flag (default: False)
     """
 
     # REQUIRED: Business identity
@@ -60,6 +62,11 @@ class BaseEntity:
 
     # OPTIONAL: Batch context (None when batch context unavailable)
     source_batch_id: BatchID | None = None
+
+    # DQ flags (Data Quality flags) - applied during transformation
+    # These fields track data quality warnings and errors at the record level
+    _dq_warn: bool = False  # Record has data quality warnings
+    _dq_error: bool = False  # Record has data quality errors
 
     def __post_init__(self) -> None:
         """Validate required fields are present and non-empty."""

--- a/src/bioetl/domain/entities/chembl_structures.py
+++ b/src/bioetl/domain/entities/chembl_structures.py
@@ -57,9 +57,7 @@ class ChemblPublication(BaseEntity):
     _lookup_method: str = "direct"  # ChEMBL uses direct extraction
     _original_id: str | None = None
 
-    # DQ flags (Data Quality flags)
-    _dq_warn: bool = False
-    _dq_error: bool = False
+    # Note: _dq_warn and _dq_error are inherited from BaseEntity
 
     def __post_init__(self) -> None:
         super().__post_init__()

--- a/src/bioetl/domain/entities/publication_base.py
+++ b/src/bioetl/domain/entities/publication_base.py
@@ -56,8 +56,8 @@ class PublicationEntityBase(BaseEntity):
         oa_status: OA status (gold, green, hybrid, bronze, closed).
         _lookup_method: How record was resolved (direct, doi, pmid, title_fallback, unknown).
         _original_id: Original identifier from input (for fallback records).
-        _dq_warn: Record has data quality warnings.
-        _dq_error: Record has data quality errors.
+        _dq_warn: Record has data quality warnings (inherited from BaseEntity).
+        _dq_error: Record has data quality errors (inherited from BaseEntity).
         source: Data source identifier (e.g., "crossref", "openalex").
 
     Note:
@@ -105,9 +105,7 @@ class PublicationEntityBase(BaseEntity):
     _lookup_method: str = "unknown"  # direct | doi | pmid | title_fallback | unknown
     _original_id: str | None = None
 
-    # DQ flags (Data Quality flags)
-    _dq_warn: bool = False  # Record has data quality warnings
-    _dq_error: bool = False  # Record has data quality errors
+    # Note: _dq_warn and _dq_error are inherited from BaseEntity
 
     # Source tracking (subclasses should override default)
     source: str = ""

--- a/tests/unit/application/pipelines/__snapshots__/test_transformer_snapshots.ambr
+++ b/tests/unit/application/pipelines/__snapshots__/test_transformer_snapshots.ambr
@@ -1,6 +1,8 @@
 # serializer version: 1
 # name: TestActivityTransformerSnapshot.test_transform_snapshot
   dict({
+    '_dq_error': False,
+    '_dq_warn': False,
     '_index': 0,
     '_ingestion_ts': '<ingestion_ts>',
     '_run_id': '<run_id>',
@@ -64,6 +66,8 @@
 # ---
 # name: TestAssayTransformerSnapshot.test_transform_snapshot
   dict({
+    '_dq_error': False,
+    '_dq_warn': False,
     '_index': 0,
     '_ingestion_ts': '<ingestion_ts>',
     '_run_id': '<run_id>',
@@ -112,6 +116,8 @@
 # ---
 # name: TestMoleculeTransformerSnapshot.test_transform_snapshot
   dict({
+    '_dq_error': False,
+    '_dq_warn': False,
     '_index': 0,
     '_ingestion_ts': '<ingestion_ts>',
     '_run_id': '<run_id>',
@@ -174,6 +180,8 @@
 # ---
 # name: TestPubChemCompoundTransformerSnapshot.test_transform_snapshot
   dict({
+    '_dq_error': False,
+    '_dq_warn': False,
     '_index': 0,
     '_ingestion_ts': '<ingestion_ts>',
     '_run_id': '<run_id>',
@@ -345,6 +353,8 @@
 # ---
 # name: TestTargetComponentTransformerSnapshot.test_transform_snapshot
   dict({
+    '_dq_error': False,
+    '_dq_warn': False,
     '_index': 0,
     '_ingestion_ts': '<ingestion_ts>',
     '_run_id': '<run_id>',
@@ -366,6 +376,8 @@
 # ---
 # name: TestTargetTransformerSnapshot.test_transform_snapshot
   dict({
+    '_dq_error': False,
+    '_dq_warn': False,
     '_index': 0,
     '_ingestion_ts': '<ingestion_ts>',
     '_run_id': '<run_id>',
@@ -408,6 +420,8 @@
 # ---
 # name: TestUniProtProteinTransformerSnapshot.test_transform_snapshot
   dict({
+    '_dq_error': False,
+    '_dq_warn': False,
     '_index': 0,
     '_ingestion_ts': '<ingestion_ts>',
     '_run_id': '<run_id>',


### PR DESCRIPTION
- Add _dq_warn and _dq_error boolean fields to BaseEntity with default=False
- Remove duplicate field definitions from ChemblPublication and PublicationEntityBase
- Update docstrings to document the inherited DQ fields
- Update transformer snapshots to reflect new entity structure

This change addresses MDA-003 by ensuring consistent DQ field availability across all entity classes. Previously, these fields were defined only in some subclasses, leading to inconsistency and code duplication in transformers.

Benefits:
- All entities now have DQ fields available by default
- Transformers can rely on entities having these fields
- Reduced code duplication across entity subclasses
- Better alignment with ETLRecordSchema which already expects these fields