### PR TITLE
Migrate UniProt data quality rules to external config

### DIFF
--- a/configs/pipelines/uniprot/idmapping.yaml
+++ b/configs/pipelines/uniprot/idmapping.yaml
@@ -35,49 +35,18 @@ source:
     to_db: UniProtKB
 
 # -----------------------------------------------------------------------------
-# Data Quality Configuration
+# Data Quality Configuration (ADR-027)
 # -----------------------------------------------------------------------------
 # DQ config is loaded from hierarchical files:
 #   1. configs/dq/_defaults.yaml (global defaults)
 #   2. configs/dq/providers/uniprot.yaml (provider-specific)
 #   3. configs/dq/entities/uniprot/idmapping.yaml (entity-specific)
 #
-# Reference to DQ config file (enables hierarchical loading)
+# Entity-specific config contains:
+#   - Elevated thresholds: soft_fail=0.30, hard_fail=0.80 (ID mapping may have many not_found)
+#   - Field validations: target_chembl_id, mapping_status, uniprot_accession
+#   - Conditional validations: found_has_accession
 dq_config_file: ../../dq/entities/uniprot/idmapping.yaml
-
-# -----------------------------------------------------------------------------
-# Inline DQ Overrides (optional, applied on top of dq_config_file)
-# -----------------------------------------------------------------------------
-# Elevated thresholds for ID mapping defined in dq_config_file:
-# - soft_fail: 0.30 (30% not_found is acceptable)
-# - hard_fail: 0.80 (80% not_found triggers hard failure)
-dq_rules:
-  field_validations:
-    - field: "target_chembl_id"
-      type: "pattern"
-      pattern: "^CHEMBL\\d+$"
-      nullable: false
-      error_message: "target_chembl_id must match CHEMBL format"
-    - field: "mapping_status"
-      type: "enum"
-      allowed: ["found", "not_found", "error"]
-      nullable: false
-    - field: "uniprot_accession"
-      type: "pattern"
-      pattern: "^[A-Z0-9]{6,10}$"
-      nullable: true
-      error_message: "UniProt accession must be 6-10 alphanumeric chars"
-
-  conditional_validations:
-    - name: "found_has_accession"
-      condition_field: "mapping_status"
-      condition_value: "found"
-      condition_operator: "eq"
-      then_validations:
-        - field: "uniprot_accession"
-          type: "pattern"
-          pattern: "^[A-Z0-9]{6,10}$"
-          nullable: false
 
 # Sink configuration
 sink:


### PR DESCRIPTION
…apping.yaml (ADR-027)

Remove duplicate inline dq_rules thresholds and validations from pipeline config. The entity-specific DQ config file (configs/dq/entities/uniprot/idmapping.yaml) already contains all required validations:
- Elevated thresholds: soft_fail=0.30, hard_fail=0.80
- Field validations: target_chembl_id, mapping_status, uniprot_accession
- Conditional validation: found_has_accession

Kept only the dq_config_file reference per ADR-027 compliance.