### PR TITLE
Add date validation and normalization to Semantic Scholar

### DIFF
--- a/src/bioetl/application/pipelines/semanticscholar/transformer.py
+++ b/src/bioetl/application/pipelines/semanticscholar/transformer.py
@@ -185,7 +185,9 @@ class SemanticScholarPublicationTransformer(BasePublicationTransformer):
             "last_page": last_page,  # Unified field
             "venue": rec.get("venue"),
             "year": year,
-            "publication_date": self._normalize_partial_date(rec.get("publicationDate")),
+            "publication_date": self._normalize_partial_date(
+                rec.get("publicationDate")
+            ),
             "citation_count": rec.get("citationCount"),
             "reference_count": rec.get("referenceCount"),
             "is_oa": oa_info.get("is_oa"),

--- a/tests/unit/application/pipelines/semanticscholar/test_transformer.py
+++ b/tests/unit/application/pipelines/semanticscholar/test_transformer.py
@@ -526,8 +526,8 @@ class TestSemanticScholarDateNormalization:
             "invalid",
             "2024/05/15",  # Wrong separator
             "15-05-2024",  # Wrong order
-            "2024-5-15",   # Missing zero-padding
-            "20240515",    # No separators
+            "2024-5-15",  # Missing zero-padding
+            "20240515",  # No separators
         ],
     )
     async def test_publication_date_invalid_format(


### PR DESCRIPTION
Add _normalize_partial_date method to handle partial dates from Semantic Scholar API:
- YYYY -> YYYY-12-31 (end of year)
- YYYY-MM -> YYYY-MM-30 (end of month)
- YYYY-MM-DD -> unchanged (valid ISO date)

Invalid formats and empty values return None.

Includes comprehensive unit tests for all date scenarios.