### PR TITLE
Normalize PubMed dates to YYYY-MM-DD format

### DIFF
--- a/src/bioetl/application/pipelines/pubmed/extractors/date.py
+++ b/src/bioetl/application/pipelines/pubmed/extractors/date.py
@@ -100,20 +100,33 @@ class DateExtractor(BaseFieldExtractor):
         month: str | None,
         day: str | None,
     ) -> str | None:
-        """Format date components into ISO date string (YYYY-MM-DD or partial)."""
+        """Format date components into ISO date string (YYYY-MM-DD).
+
+        Uses end-of-period strategy for partial dates:
+        - Year + Month + Day → YYYY-MM-DD
+        - Year + Month (no day) → YYYY-MM-30
+        - Year only → YYYY-12-31
+        """
         if not year:
             return None
 
-        parts = [year]
+        # Normalize month
         if month:
-            month_lower = month.lower()[:3]
-            month_num = self.MONTH_MAP.get(month_lower, month.zfill(2))
-            parts.append(month_num)
+            month_str = month.strip().lower()[:3]
+            month_num = self.MONTH_MAP.get(month_str)
+            if not month_num and month.isdigit():
+                month_num = month.zfill(2)
+            if not month_num:
+                # Unknown month format → treat as year-only
+                return f"{year}-12-31"
+        else:
+            # No month → year-only
+            return f"{year}-12-31"
 
-            if day:
-                parts.append(day.zfill(2))
+        # Normalize day (end of month if missing)
+        day_num = day.zfill(2) if day and day.isdigit() else "30"
 
-        return "-".join(parts)
+        return f"{year}-{month_num}-{day_num}"
 
     @classmethod
     def format_date(

--- a/src/bioetl/application/pipelines/pubmed/transformer.py
+++ b/src/bioetl/application/pipelines/pubmed/transformer.py
@@ -270,7 +270,10 @@ class PubMedPublicationTransformer(BasePublicationTransformer):
     def _compute_publication_date(
         self, epub_date: str | None, pub_date: str | None, year: int | None
     ) -> str | None:
-        """Compute unified publication_date with priority: epub_date > pub_date > year.
+        """Compute unified publication_date (YYYY-MM-DD).
+
+        Priority: epub_date > pub_date > year
+        All outputs normalized to full YYYY-MM-DD format using end-of-period strategy.
 
         Args:
             epub_date: Electronic publication date (YYYY-MM-DD or partial).
@@ -280,18 +283,39 @@ class PubMedPublicationTransformer(BasePublicationTransformer):
         Returns:
             ISO date string (YYYY-MM-DD) or None.
         """
-        # Priority 1: epub_date if it's a complete date (YYYY-MM-DD)
+        # Priority 1: epub_date if it's a complete date
         if epub_date and len(epub_date) >= 10:
             return epub_date[:10]
 
-        # Priority 2: pub_date if it's a complete date
-        if pub_date and len(pub_date) >= 10:
-            return pub_date[:10]
+        # Priority 2: pub_date (may be partial, normalize it)
+        if pub_date:
+            return self._normalize_partial_date(pub_date)
 
-        # Priority 3: Construct from year (use Jan 1 as default)
+        # Priority 3: Construct from year (end of year)
         if year:
-            return f"{year}-01-01"
+            return f"{year}-12-31"
 
+        return None
+
+    def _normalize_partial_date(self, date_str: str | None) -> str | None:
+        """Normalize partial date to YYYY-MM-DD (end of period).
+
+        Args:
+            date_str: Date string (YYYY, YYYY-MM, or YYYY-MM-DD).
+
+        Returns:
+            Full YYYY-MM-DD date or None.
+        """
+        if not date_str:
+            return None
+        if len(date_str) >= 10:
+            return date_str[:10]
+        if len(date_str) == 7:
+            # YYYY-MM → YYYY-MM-30
+            return f"{date_str}-30"
+        if len(date_str) == 4:
+            # YYYY → YYYY-12-31
+            return f"{date_str}-12-31"
         return None
 
     def _extract_date_data(

--- a/tests/unit/application/pipelines/pubmed/test_pubmed_transformer.py
+++ b/tests/unit/application/pipelines/pubmed/test_pubmed_transformer.py
@@ -495,7 +495,8 @@ class TestPubMedTransformerDateExtraction:
         result = await transformer.transform(mock_context, record, index=0)
 
         assert result is not None
-        assert result["pub_date"] == "2024"
+        # End-of-period strategy: year-only → YYYY-12-31
+        assert result["pub_date"] == "2024-12-31"
         assert result["year"] == 2024
 
     @pytest.mark.asyncio
@@ -528,7 +529,8 @@ class TestPubMedTransformerDateExtraction:
         result = await transformer.transform(mock_context, record, index=0)
 
         assert result is not None
-        assert result["pub_date"] == "2024-12"
+        # End-of-period strategy: year+month → YYYY-MM-30
+        assert result["pub_date"] == "2024-12-30"
         assert result["year"] == 2024
 
     @pytest.mark.asyncio
@@ -850,7 +852,8 @@ class TestPubMedTransformerUnifiedDateFields:
         result = transformer._compute_publication_date(
             epub_date=None, pub_date=None, year=2025
         )
-        assert result == "2025-01-01"
+        # End-of-period strategy: year-only → YYYY-12-31
+        assert result == "2025-12-31"
 
     def test_compute_publication_date_none(
         self,

--- a/tests/unit/application/pipelines/test_date_parsing.py
+++ b/tests/unit/application/pipelines/test_date_parsing.py
@@ -34,15 +34,16 @@ class TestPubMedDateBuilding:
             # pub_date used when epub_date is partial or missing
             (None, "2024-03-15", 2024, "2024-03-15"),
             ("2024-03", "2024-04-01", 2024, "2024-04-01"),  # partial epub falls back
-            # Year-only fallback
-            (None, None, 2024, "2024-01-01"),
-            (None, None, 1999, "1999-01-01"),
-            (None, None, 2025, "2025-01-01"),
+            # Year-only fallback (end of year)
+            (None, None, 2024, "2024-12-31"),
+            (None, None, 1999, "1999-12-31"),
+            (None, None, 2025, "2025-12-31"),
             # All None returns None
             (None, None, None, None),
-            # Partial dates (less than 10 chars) fall back
+            # Partial dates (less than 10 chars) fall back to pub_date normalization
             ("2024", "2024-06-15", 2024, "2024-06-15"),
-            ("2024-06", None, 2024, "2024-01-01"),
+            # Partial pub_date gets normalized (YYYY-MM → YYYY-MM-30)
+            ("2024-06", None, 2024, "2024-12-31"),  # partial epub, no pub_date → year
         ],
     )
     def test_compute_publication_date(
@@ -92,8 +93,8 @@ class TestPubMedDateBuilding:
             == "2024-02-15"
         )
 
-        # epub_date None, pub_date None -> use year
-        assert transformer._compute_publication_date(None, None, 2024) == "2024-01-01"
+        # epub_date None, pub_date None -> use year (end of year)
+        assert transformer._compute_publication_date(None, None, 2024) == "2024-12-31"
 
 
 @pytest.mark.unit

--- a/tests/unit/pipelines/pubmed/extractors/test_date_extractor.py
+++ b/tests/unit/pipelines/pubmed/extractors/test_date_extractor.py
@@ -28,14 +28,14 @@ class TestFormatDate:
         assert result == "2023-01-01"
 
     def test_year_month_only(self):
-        """Test formatting with year and month only."""
+        """Test formatting with year and month only (end-of-period: day 30)."""
         result = DateExtractor.format_date("2023", "06", None)
-        assert result == "2023-06"
+        assert result == "2023-06-30"
 
     def test_year_only(self):
-        """Test formatting with year only."""
+        """Test formatting with year only (end-of-period: Dec 31)."""
         result = DateExtractor.format_date("2023", None, None)
-        assert result == "2023"
+        assert result == "2023-12-31"
 
     def test_no_year_returns_none(self):
         """Test that missing year returns None."""
@@ -100,19 +100,19 @@ class TestExtractDate:
         assert year_int == 2023
 
     def test_year_month_only_element(self):
-        """Test extracting year-month date."""
+        """Test extracting year-month date (end-of-period: day 30)."""
         xml = "<PubDate><Year>2023</Year><Month>06</Month></PubDate>"
         node = ET.fromstring(xml)
         date_str, year_int = DateExtractor.extract_date(node)
-        assert date_str == "2023-06"
+        assert date_str == "2023-06-30"
         assert year_int == 2023
 
     def test_year_only_element(self):
-        """Test extracting year-only date."""
+        """Test extracting year-only date (end-of-period: Dec 31)."""
         xml = "<PubDate><Year>2023</Year></PubDate>"
         node = ET.fromstring(xml)
         date_str, year_int = DateExtractor.extract_date(node)
-        assert date_str == "2023"
+        assert date_str == "2023-12-31"
         assert year_int == 2023
 
     def test_none_node_returns_none_tuple(self):

--- a/tests/unit/pipelines/pubmed/extractors/test_extractor_edge_cases.py
+++ b/tests/unit/pipelines/pubmed/extractors/test_extractor_edge_cases.py
@@ -142,7 +142,7 @@ class TestDateExtractorEdgeCases:
         assert date_str == "2023-01" or date_str.startswith("2023")
 
     def test_year_with_invalid_text(self):
-        """Test handling of non-numeric year."""
+        """Test handling of non-numeric year (end-of-period: day 30)."""
         xml = """
         <PubDate>
             <Year>TBD</Year>
@@ -152,7 +152,8 @@ class TestDateExtractorEdgeCases:
         node = ET.fromstring(xml)
         date_str, year_int = DateExtractor.extract_date(node)
         # Year is not numeric, but it's still used in date_str
-        assert date_str == "TBD-03"
+        # End-of-period strategy adds day 30 for year+month without day
+        assert date_str == "TBD-03-30"
         assert year_int is None
 
     def test_partial_date_month_only_no_year(self):

--- a/tests/unit/pipelines/pubmed/test_pubmed_transformer.py
+++ b/tests/unit/pipelines/pubmed/test_pubmed_transformer.py
@@ -335,7 +335,7 @@ class TestExtractDateData:
         assert result["epub_date"] == "2023-03-10"
 
     def test_extract_date_data_year_only(self, transformer):
-        """Test extraction with year-only publication date."""
+        """Test extraction with year-only publication date (end-of-period: Dec 31)."""
         import xml.etree.ElementTree as ET
 
         article_xml = """
@@ -353,7 +353,8 @@ class TestExtractDateData:
 
         result = transformer._extract_date_data(article, None)
 
-        assert result["pub_date"] == "2023"
+        # End-of-period strategy: year-only → YYYY-12-31
+        assert result["pub_date"] == "2023-12-31"
         assert result["year"] == 2023
         assert result["publication_year"] == 2023
         assert result["accepted_date"] is None


### PR DESCRIPTION
…trategy

Updated PubMed date handling to always output full YYYY-MM-DD format using end-of-period strategy for partial dates:
- Year only → YYYY-12-31
- Year + Month (no day) → YYYY-MM-30
- Year + Month + Day → YYYY-MM-DD (unchanged)

Changes:
- DateExtractor._format_date(): Apply end-of-period for partial dates
- PubMedPublicationTransformer._compute_publication_date(): Normalize all outputs to YYYY-MM-DD format
- Added _normalize_partial_date() helper method for pub_date handling
- Updated all related tests to expect new output format