### PR TITLE
Fix authors field type inconsistency across pipelines

### DIFF
--- a/src/bioetl/infrastructure/schemas/gold.py
+++ b/src/bioetl/infrastructure/schemas/gold.py
@@ -226,7 +226,7 @@ class PubMedPublicationGoldSchema(pa.DataFrameModel):
     pages: Series[str] = pa.Field(nullable=True)  # Legacy: medline_pgn format
     first_page: Series[str] = pa.Field(nullable=True)  # Unified: parsed from pages
     last_page: Series[str] = pa.Field(nullable=True)  # Unified: parsed from pages
-    authors: Series[object] = pa.Field(nullable=True)  # list[str]
+    authors: Series[str] = pa.Field(nullable=True)  # JSON-serialized list
     pub_date: Series[str] = pa.Field(nullable=True)
     publication_date: Series[str] = pa.Field(
         nullable=True, str_matches=DATE_REGEX
@@ -763,7 +763,7 @@ class CrossRefPublicationGoldSchema(pa.DataFrameModel):
     # Core fields
     title: Series[str] = pa.Field(nullable=True)
     abstract: Series[str] = pa.Field(nullable=True)
-    authors: Series[object] = pa.Field(nullable=True)  # list[str]
+    authors: Series[str] = pa.Field(nullable=True)  # JSON-serialized list
     journal: Series[str] = pa.Field(nullable=True)
     issn: Series[object] = pa.Field(nullable=True)  # list[str]
     publisher: Series[str] = pa.Field(nullable=True)
@@ -832,7 +832,7 @@ class OpenAlexPublicationGoldSchema(pa.DataFrameModel):
     pmc_id: Series[str] = pa.Field(nullable=True)
     title: Series[str] = pa.Field(nullable=True)
     abstract: Series[str] = pa.Field(nullable=True)
-    authors: Series[object] = pa.Field(nullable=True)  # list[str]
+    authors: Series[str] = pa.Field(nullable=True)  # JSON-serialized list
     concepts: Series[object] = pa.Field(nullable=True)  # list[str]
 
     # Journal info

--- a/tests/unit/infrastructure/schemas/test_gold.py
+++ b/tests/unit/infrastructure/schemas/test_gold.py
@@ -302,7 +302,7 @@ class TestGoldSchemaValidation:
             "pages": "100-110",
             "first_page": "100",
             "last_page": "110",
-            "authors": ["Author One", "Author Two"],
+            "authors": '["Author One", "Author Two"]',
             "pub_date": "2024-03-15",
             "publication_date": "2024-03-15",
             "year": 2024,


### PR DESCRIPTION
…ssRef, OpenAlex

The authors field in Gold schemas was inconsistent - using Series[object] for PubMed, CrossRef, and OpenAlex while ChEMBL and SemanticScholar correctly used Series[str]. Since all transformers serialize authors to JSON strings via serialize_json_list(), the schema should reflect this.

Changes:
- PubMedPublicationGoldSchema.authors: Series[object] -> Series[str]
- CrossRefPublicationGoldSchema.authors: Series[object] -> Series[str]
- OpenAlexPublicationGoldSchema.authors: Series[object] -> Series[str]
- Updated test to use JSON string instead of Python list