### PR TITLE
Add missing fields to CrossRef Gold schema

### DIFF
--- a/src/bioetl/infrastructure/schemas/gold.py
+++ b/src/bioetl/infrastructure/schemas/gold.py
@@ -760,6 +760,12 @@ class CrossRefPublicationGoldSchema(pa.DataFrameModel):
     # Note: CrossRef uses DOI as primary key; pmid/pmc_id come from PubMed, not CrossRef
     doi: Series[str] = pa.Field(nullable=False)
 
+    # Cross-reference IDs for linking publications across providers
+    # pmid: PubMed ID (numeric string: "12345678") - null for CrossRef native records
+    pmid: Series[str] = pa.Field(nullable=True)
+    # pmc_id: PubMed Central ID (format: "PMC1234567") - null for CrossRef native records
+    pmc_id: Series[str] = pa.Field(nullable=True)
+
     # Core fields
     title: Series[str] = pa.Field(nullable=True)
     abstract: Series[str] = pa.Field(nullable=True)
@@ -792,6 +798,12 @@ class CrossRefPublicationGoldSchema(pa.DataFrameModel):
     license_url: Series[str] = pa.Field(nullable=True)
     subjects: Series[object] = pa.Field(nullable=True)  # list[str]
     source: Series[str] = pa.Field(nullable=True)
+
+    # Lookup metadata
+    # _lookup_method: "direct" | "doi" | "pmid" | "title_fallback" | "unknown"
+    # _original_id: Original identifier used for lookup
+    lookup_method: Series[str] = pa.Field(nullable=True, alias="_lookup_method")
+    original_id: Series[str] = pa.Field(nullable=True, alias="_original_id")
 
     # DQ fields
     dq_warn: Series[bool] = pa.Field(nullable=True, alias="_dq_warn")

--- a/tests/architecture/test_code_metrics.py
+++ b/tests/architecture/test_code_metrics.py
@@ -87,7 +87,7 @@ class TestFileSizeLimits:
         "silver_writer.py": 1141,  # 1126 LOC - schema drift + merge logic + MetadataCoordinator fallback + SilverWriteResult return + transform lineage + fromisoformat timezone validation
         "gold_writer.py": 930,  # 918 LOC - SCD Type 2 + MetadataCoordinator fallback + silver_refs lineage + transform lineage
         "bronze_writer.py": 760,  # 749 LOC - streaming compression + MetadataCoordinator fallback + SourceMetadata param
-        "gold.py": 975,  # 972 LOC - Gold layer Pandera schemas (+ IDMapping + cross-reference ID fields + lookup metadata comments + publication schemas + DATE_REGEX validation)
+        "gold.py": 985,  # 984 LOC - Gold layer Pandera schemas (+ IDMapping + cross-reference ID fields + CrossRef pmid/pmc_id/lookup_method fields + publication schemas + DATE_REGEX validation)
         "silver.py": 810,  # 804 LOC - Silver PyArrow schemas (+ IDMapping + taxonomy_id standardization + lookup metadata + publication schemas)
         "client.py": 700,  # 692 LOC - ChemblAdapter (complex FilterableDataSourcePort), CrossRefAdapter (DOI→title fallback)
         "adapter.py": 635,  # 632 LOC - SemanticScholarAdapter with FilterableDataSourcePort + fallback logic


### PR DESCRIPTION
Add four missing fields to CrossRefPublicationGoldSchema that exist in the Silver layer transformer:
- pmid: PubMed ID for cross-provider linking (nullable)
- pmc_id: PubMed Central ID for cross-provider linking (nullable)
- lookup_method: Resolution tracking (alias "_lookup_method")
- original_id: Original identifier used for lookup (alias "_original_id")

These fields align with other publication Gold schemas (OpenAlex, SemanticScholar, ChEMBL) and enable future cross-enrichment between providers.

Update LOC limit exemption for gold.py (975 → 985) to accommodate the new fields.