### PR TITLE
Run composite bioactivity data pipeline

### DIFF
--- a/src/bioetl/infrastructure/adapters/http/client.py
+++ b/src/bioetl/infrastructure/adapters/http/client.py
@@ -106,7 +106,10 @@ class UnifiedHTTPClient:
         user_agent = self.user_agent
         if self.contact_email:
             user_agent = f"{user_agent} ({self.contact_email})"
-        headers: dict[str, str] = {"User-Agent": user_agent}
+        headers: dict[str, str] = {
+            "User-Agent": user_agent,
+            "Accept": "application/json",
+        }
         if self.run_id:
             headers["X-Correlation-ID"] = str(self.run_id)
 


### PR DESCRIPTION
ChEMBL API returns 500 errors when Accept header is missing. Other adapters (CrossRef, OpenAlex, SemanticScholar) already set this header explicitly. This fix adds "Accept: application/json" to the default headers in UnifiedHTTPClient.