### PR TITLE
Add missing flattened fields to ChEMBL molecule

### DIFF
--- a/src/bioetl/domain/schemas/chembl/molecule.py
+++ b/src/bioetl/domain/schemas/chembl/molecule.py
@@ -125,45 +125,109 @@ class MoleculeSchema(ETLRecordSchema):
     # )
 
     # === Other Properties ===
-    # availability_type: Optional[Series[int]] = pa.Field(
-    #     nullable=True, isin=[0, 1, 2], description="Availability type."
-    # )
-    # usan_year: Optional[Series[int]] = pa.Field(
-    #     nullable=True, description="USAN year."
-    # )
-    # usan_stem: Optional[Series[str]] = pa.Field(
-    #     nullable=True, description="USAN stem."
-    # )
-    # usan_substem: Optional[Series[str]] = pa.Field(
-    #     nullable=True, description="USAN substem."
-    # )
-    # usan_stem_definition: Optional[Series[str]] = pa.Field(
-    #     nullable=True, description="USAN stem definition."
-    # )
-    # indication_class: Optional[Series[str]] = pa.Field(
-    #     nullable=True, description="Indication class."
-    # )
-    # withdrawn_year: Optional[Series[int]] = pa.Field(
-    #     nullable=True, description="Withdrawn year."
-    # )
-    # withdrawn_country: Optional[Series[str]] = pa.Field(
-    #     nullable=True, description="Withdrawn country."
-    # )
-    # withdrawn_reason: Optional[Series[str]] = pa.Field(
-    #     nullable=True, description="Withdrawn reason."
-    # )
-    # withdrawn_class: Optional[Series[str]] = pa.Field(
-    #     nullable=True, description="Withdrawn class."
-    # )
-    # downgrade_reason: Optional[Series[str]] = pa.Field(
-    #     nullable=True, description="Downgrade reason."
-    # )
-    # replacement_mrn: Optional[Series[int]] = pa.Field(
-    #     nullable=True, description="Replacement molregno."
-    # )
-    # nomerge_reason: Optional[Series[str]] = pa.Field(
-    #     nullable=True, description="No merge reason."
-    # )
+    chirality: Series[int] | None = pa.Field(
+        nullable=True,
+        isin=[-1, 0, 1, 2],
+        description="Chirality flag: -1=unknown, 0=achiral, 1=single, 2=racemic.",
+    )
+    dosed_ingredient: Series[int] | None = pa.Field(
+        nullable=True, isin=[0, 1], description="Dosed ingredient flag."
+    )
+    availability_type: Series[int] | None = pa.Field(
+        nullable=True, isin=[-2, -1, 0, 1, 2], description="Availability type."
+    )
+    usan_year: Series[int] | None = pa.Field(
+        nullable=True, description="USAN approval year."
+    )
+    usan_stem: Series[str] | None = pa.Field(
+        nullable=True, description="USAN stem name."
+    )
+    usan_substem: Series[str] | None = pa.Field(
+        nullable=True, description="USAN substem name."
+    )
+    usan_stem_definition: Series[str] | None = pa.Field(
+        nullable=True, description="USAN stem definition."
+    )
+    helm_notation: Series[str] | None = pa.Field(
+        nullable=True, description="HELM notation for biopolymers."
+    )
+    molecule_species: Series[str] | None = pa.Field(
+        nullable=True, description="Species for biologics."
+    )
+
+    # === Hierarchy Fields (flattened from molecule_hierarchy) ===
+    hierarchy_parent_chembl_id: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^CHEMBL\d+$",
+        description="Parent molecule ChEMBL ID in hierarchy.",
+    )
+    hierarchy_active_chembl_id: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^CHEMBL\d+$",
+        description="Active molecule ChEMBL ID in hierarchy.",
+    )
+    hierarchy_child_chembl_id: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=r"^CHEMBL\d+$",
+        description="Child molecule ChEMBL ID in hierarchy.",
+    )
+
+    # === Property Fields (flattened from molecule_properties) ===
+    property_alogp: Series[float] | None = pa.Field(
+        nullable=True, description="Calculated ALogP (partition coefficient)."
+    )
+    property_mw_freebase: Series[float] | None = pa.Field(
+        nullable=True, description="Molecular weight of parent compound."
+    )
+    property_full_mwt: Series[float] | None = pa.Field(
+        nullable=True, description="Full molecular weight including salts."
+    )
+    property_hba: Series[int] | None = pa.Field(
+        nullable=True, ge=0, description="Hydrogen bond acceptors count."
+    )
+    property_hbd: Series[int] | None = pa.Field(
+        nullable=True, ge=0, description="Hydrogen bond donors count."
+    )
+    property_psa: Series[float] | None = pa.Field(
+        nullable=True, ge=0, description="Polar surface area (PSA)."
+    )
+    property_rtb: Series[int] | None = pa.Field(
+        nullable=True, ge=0, description="Rotatable bonds count."
+    )
+    property_ro5_violations: Series[int] | None = pa.Field(
+        nullable=True,
+        ge=0,
+        le=4,
+        description="Number of Lipinski rule-of-5 violations.",
+    )
+    property_heavy_atoms: Series[int] | None = pa.Field(
+        nullable=True, ge=0, description="Heavy (non-hydrogen) atoms count."
+    )
+    property_aromatic_rings: Series[int] | None = pa.Field(
+        nullable=True, ge=0, description="Aromatic rings count."
+    )
+    property_qed_weighted: Series[float] | None = pa.Field(
+        nullable=True, ge=0, le=1, description="Quantitative Estimate of Drug-likeness."
+    )
+    property_full_molformula: Series[str] | None = pa.Field(
+        nullable=True, description="Full molecular formula."
+    )
+    property_ro3_pass: Series[str] | None = pa.Field(
+        nullable=True, isin=["Y", "N"], description="Rule-of-3 compliance (Y/N)."
+    )
+
+    # === Structure Fields (flattened from molecule_structures) ===
+    canonical_smiles: Series[str] | None = pa.Field(
+        nullable=True, description="Canonical SMILES representation."
+    )
+    standard_inchi: Series[str] | None = pa.Field(
+        nullable=True, description="Standard InChI representation."
+    )
+    inchikey: Series[str] | None = pa.Field(
+        nullable=True,
+        str_matches=INCHI_KEY_REGEX_PATTERN,
+        description="Standard InChI Key (27 characters, XXXX-YYYY-Z format).",
+    )
 
     # === Complex Fields (JSON Strings) ===
     molecule_hierarchy: Series[str] | None = pa.Field(


### PR DESCRIPTION
Add validation for flattened nested structure fields that are extracted by MoleculeTransformer but were previously missing from Silver schema:

Hierarchy fields (3):
- hierarchy_parent_chembl_id, hierarchy_active_chembl_id, hierarchy_child_chembl_id

Property fields (13):
- property_alogp, property_mw_freebase, property_full_mwt
- property_hba, property_hbd, property_psa, property_rtb
- property_ro5_violations, property_heavy_atoms, property_aromatic_rings
- property_qed_weighted, property_full_molformula, property_ro3_pass

Structure fields (3):
- canonical_smiles, standard_inchi, inchikey

Additional metadata fields (7):
- chirality, dosed_ingredient, availability_type
- usan_stem, usan_stem_definition, usan_substem, usan_year
- helm_notation, molecule_species

This ensures complete Silver-level validation coverage and prevents schema drift at the Silver layer.