### PR TITLE
Fix publication schema inconsistency across providers

### DIFF
--- a/src/bioetl/application/pipelines/crossref/transformer.py
+++ b/src/bioetl/application/pipelines/crossref/transformer.py
@@ -153,6 +153,8 @@ class CrossRefPublicationTransformer(BasePublicationTransformer):
             "license_url": extract_license_url(rec),
             "subjects": rec.get("subject", []),
             "source": "crossref",
+            # Open Access (CrossRef doesn't provide this information directly)
+            "is_oa": None,
             # Cross-reference IDs (CrossRef doesn't provide PMID or PMC ID)
             "pmid": None,
             "pmc_id": None,

--- a/src/bioetl/application/pipelines/pubmed/transformer.py
+++ b/src/bioetl/application/pipelines/pubmed/transformer.py
@@ -194,6 +194,11 @@ class PubMedPublicationTransformer(BasePublicationTransformer):
                 else None
             ),
             "pmc_id": normalize_pmc_id(IdentifierExtractor.extract_pmc_id(root)),
+            # === Unified publication fields (cross-provider consistency) ===
+            "source": "pubmed",
+            "doc_type": "PUBLICATION",  # PubMed primarily contains publications
+            "citation_count": None,  # Not available from PubMed
+            "is_oa": None,  # Not available from PubMed
             # Lookup metadata (from adapter fallback handler)
             "_lookup_method": cast("dict[str, Any]", record).get(
                 "_lookup_method", "pmid"

--- a/src/bioetl/domain/schemas/chembl/publication.py
+++ b/src/bioetl/domain/schemas/chembl/publication.py
@@ -1,6 +1,6 @@
 """Pandera schema for ChEMBL Publication entity.
 
-Aligned with RULES.md v5.10 and ChEMBL 34 schema.
+Aligned with RULES.md v5.10, ChEMBL 34 schema, and Publication Schema Unification spec.
 """
 
 from __future__ import annotations
@@ -19,35 +19,44 @@ __all__ = ["DOI_REGEX_PATTERN", "LOOKUP_METHODS", "ChemblPublicationSchema"]
 
 
 class ChemblPublicationSchema(PublicationBaseSchema):
-    """ChEMBL Publication validation schema for Silver layer."""
+    """ChEMBL Publication validation schema for Silver layer.
 
-    # === Lookup metadata (ChEMBL-specific) ===
+    Inherits common fields from PublicationBaseSchema:
+    - Cross-references: pmid, doi, pmc_id
+    - Core content: title, abstract, authors
+    - Metadata: journal, year, publication_date, doc_type (overridden), language
+    - Metrics: citation_count
+    - Open Access: is_oa
+    - Lookup tracking: lookup_method (overridden), original_id, source
+    """
+
+    # === Primary Key (ChEMBL-specific) ===
+    document_chembl_id: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^CHEMBL\d+$",
+        description="ChEMBL Document ID.",
+    )
+
+    # === Override lookup_method to be non-nullable ===
     lookup_method: Series[str] = pa.Field(
         alias="_lookup_method",
         nullable=False,
         isin=LOOKUP_METHODS,
         description="How record was resolved: direct for ChEMBL ID lookup",
     )
-    original_id: Series[str] = pa.Field(
-        alias="_original_id",
-        nullable=True,
-        description="Original identifier used for lookup (document_chembl_id)",
-    )
 
-    # === Provider-specific Primary Key ===
-    document_chembl_id: Series[str] = pa.Field(
-        nullable=False,
-        str_matches=r"^CHEMBL\d+$",
-        description="ChEMBL ID.",
+    # === Override doc_type with ChEMBL-specific values ===
+    doc_type: Series[str] = pa.Field(
+        nullable=True,
+        isin=["PUBLICATION", "PATENT", "DATASET", "BOOK"],
+        description="Document type.",
     )
 
     # === Provider-specific Identifiers ===
     patent_id: Series[str] = pa.Field(nullable=True, description="Patent ID.")
     src_id: Series[int] = pa.Field(nullable=True, description="Source ID.")
 
-    # === Provider-specific Fields ===
-    authors: Series[str] = pa.Field(nullable=True, description="Authors.")
-    journal: Series[str] = pa.Field(nullable=True, description="Journal.")
+    # === Provider-specific Journal Fields ===
     journal_full_title: Series[str] = pa.Field(
         nullable=True, description="Full journal title."
     )
@@ -55,13 +64,6 @@ class ChemblPublicationSchema(PublicationBaseSchema):
     issue: Series[str] = pa.Field(nullable=True, description="Issue.")
     first_page: Series[str] = pa.Field(nullable=True, description="First page.")
     last_page: Series[str] = pa.Field(nullable=True, description="Last page.")
-
-    # === Doc Type with ChEMBL-specific values ===
-    doc_type: Series[str] = pa.Field(
-        nullable=True,
-        isin=["PUBLICATION", "PATENT", "DATASET", "BOOK"],
-        description="Document type.",
-    )
 
     # === DQ Fields ===
     _dq_warn: Series[bool] = pa.Field(

--- a/src/bioetl/domain/schemas/common/publication_base.py
+++ b/src/bioetl/domain/schemas/common/publication_base.py
@@ -1,10 +1,12 @@
 """Base schema for all publication entities across providers.
 
 Aligned with RULES.md v5.10 and Publication Schema Unification spec.
+Provides unified field set for cross-provider publication analysis.
 """
 
 from __future__ import annotations
 
+import pandas as pd
 import pandera.pandas as pa
 from pandera.typing import Series
 
@@ -15,15 +17,26 @@ from bioetl.domain.validation import (
     MIN_PUBLICATION_YEAR,
 )
 
-# Lookup method values (used by ChEMBL, OpenAlex, SemanticScholar)
+# Lookup method values (used by all publication providers)
 LOOKUP_METHODS = ["direct", "doi", "pmid", "title_fallback", "title_only", "unknown"]
+
+# Open Access status values (normalized to lowercase for cross-provider consistency)
+OA_STATUS_VALUES = ["gold", "green", "hybrid", "bronze", "closed"]
 
 
 class PublicationBaseSchema(ETLRecordSchema):
     """Base schema with common fields for all publication entities.
 
     Provider-specific schemas inherit from this and add their own fields.
-    Only fields common to ALL providers are defined here.
+    This unified schema ensures cross-provider analysis compatibility.
+
+    Field Categories:
+    - Cross-reference IDs: pmid, doi, pmc_id
+    - Core content: title, abstract, authors
+    - Publication metadata: journal, year, publication_date, doc_type, language
+    - Metrics: citation_count
+    - Open Access: is_oa
+    - Lookup tracking: _lookup_method, _original_id, source
     """
 
     # === Cross-reference IDs (common to all providers) ===
@@ -45,14 +58,68 @@ class PublicationBaseSchema(ETLRecordSchema):
     )
 
     # === Core content (common to all providers) ===
-    title: Series[str] = pa.Field(nullable=True)
-    abstract: Series[str] = pa.Field(nullable=True)
+    title: Series[str] = pa.Field(nullable=True, description="Publication title")
+    abstract: Series[str] = pa.Field(nullable=True, description="Publication abstract")
+    authors: Series[str] = pa.Field(
+        nullable=True,
+        description="JSON array of author names (PII hashed)",
+    )
 
     # === Publication metadata (common to all providers) ===
+    journal: Series[str] = pa.Field(
+        nullable=True,
+        description="Journal name",
+    )
     year: Series[int] = pa.Field(
         nullable=True,
         ge=MIN_PUBLICATION_YEAR,
         le=MAX_PUBLICATION_YEAR,
+        description="Publication year",
+    )
+    publication_date: Series[str] = pa.Field(
+        nullable=True,
+        str_matches=r"^\d{4}-\d{2}-\d{2}$",
+        description="Publication date (YYYY-MM-DD)",
+    )
+    doc_type: Series[str] = pa.Field(
+        nullable=True,
+        description="Document type (PUBLICATION, PREPRINT, PATENT, etc.)",
+    )
+    language: Series[str] = pa.Field(
+        nullable=True,
+        description="Language code (ISO 639-1 or MARC)",
+    )
+
+    # === Metrics (common to all providers) ===
+    # Use pd.Int64Dtype for nullable integer support
+    citation_count: Series[pd.Int64Dtype] = pa.Field(
+        nullable=True,
+        ge=0,
+        description="Number of citations (provider-dependent availability)",
+    )
+
+    # === Open Access (common to all providers) ===
+    is_oa: Series[bool] = pa.Field(
+        nullable=True,
+        description="Is Open Access (provider-dependent availability)",
+    )
+
+    # === Lookup tracking (common to all providers) ===
+    # Note: alias maps Python attribute name to DataFrame column name
+    lookup_method: Series[str] = pa.Field(
+        alias="_lookup_method",
+        nullable=True,
+        isin=LOOKUP_METHODS,
+        description="How record was resolved: direct, doi, pmid, title_fallback, title_only",
+    )
+    original_id: Series[str] = pa.Field(
+        alias="_original_id",
+        nullable=True,
+        description="Original identifier from input (for fallback records)",
+    )
+    source: Series[str] = pa.Field(
+        nullable=True,
+        description="Data source identifier (e.g., pubmed, crossref, openalex)",
     )
 
     class Config:

--- a/src/bioetl/domain/schemas/crossref/publication.py
+++ b/src/bioetl/domain/schemas/crossref/publication.py
@@ -1,7 +1,7 @@
 """Pandera schema for CrossRef Publication (enriched) entity.
 
 Used for Silver layer validation of publications enriched via CrossRef API.
-Aligned with RULES.md v5.10.
+Aligned with RULES.md v5.10 and Publication Schema Unification spec.
 """
 
 from __future__ import annotations
@@ -9,8 +9,14 @@ from __future__ import annotations
 import pandera.pandas as pa
 from pandera.typing import Series
 
-from bioetl.domain.schemas.common.publication_base import PublicationBaseSchema
+from bioetl.domain.schemas.common.publication_base import (
+    LOOKUP_METHODS,
+    PublicationBaseSchema,
+)
 from bioetl.domain.validation import DOI_REGEX_PATTERN
+
+# Re-export for backwards compatibility
+__all__ = ["DOI_REGEX_PATTERN", "LOOKUP_METHODS", "PublicationEnrichedSchema"]
 
 # === Fixed Value Constants ===
 DOCUMENT_TYPES = ["PUBLICATION", "PREPRINT"]
@@ -20,6 +26,13 @@ class PublicationEnrichedSchema(PublicationBaseSchema):
     """CrossRef-enriched Publication validation schema for Silver layer.
 
     Represents publication metadata from CrossRef API with citation enrichment.
+    Inherits common fields from PublicationBaseSchema:
+    - Cross-references: pmid, doi (overridden to non-nullable), pmc_id
+    - Core content: title, abstract, authors
+    - Metadata: journal, year, publication_date, doc_type (overridden), language
+    - Metrics: citation_count
+    - Open Access: is_oa
+    - Lookup tracking: _lookup_method, _original_id, source (overridden)
     """
 
     # === Primary Key (override doi to be non-nullable) ===
@@ -48,18 +61,15 @@ class PublicationEnrichedSchema(PublicationBaseSchema):
         description="Document type: PUBLICATION or PREPRINT",
     )
 
-    # === Additional Metadata ===
-    language: Series[str] = pa.Field(
-        nullable=True, description="Publication language code"
+    # === Override source to be non-nullable with fixed value ===
+    source: Series[str] = pa.Field(
+        nullable=False, eq="crossref", description="Data source identifier"
     )
+
+    # === Additional Metadata (CrossRef-specific) ===
     license_url: Series[str] = pa.Field(nullable=True, description="License URL")
     subjects: Series[str] = pa.Field(
         nullable=True, description="JSON array of subject areas"
-    )
-
-    # === Source Tracking ===
-    source: Series[str] = pa.Field(
-        nullable=False, eq="crossref", description="Data source identifier"
     )
 
     class Config:

--- a/src/bioetl/domain/schemas/openalex/publication.py
+++ b/src/bioetl/domain/schemas/openalex/publication.py
@@ -1,6 +1,6 @@
 """Pandera schema for OpenAlex Publication entity.
 
-Aligned with RULES.md v5.10.
+Aligned with RULES.md v5.10 and Publication Schema Unification spec.
 Includes lookup metadata fields for DOI/title resolution tracking.
 """
 
@@ -12,6 +12,7 @@ from pandera.typing import Series
 
 from bioetl.domain.schemas.common.publication_base import (
     LOOKUP_METHODS,
+    OA_STATUS_VALUES,
     PublicationBaseSchema,
 )
 from bioetl.domain.validation import DOI_REGEX_PATTERN
@@ -24,36 +25,33 @@ __all__ = [
     "OpenAlexPublicationSchema",
 ]
 
-# Valid OA status values
-OA_STATUS_VALUES = ["gold", "green", "hybrid", "bronze", "closed"]
-
 
 class OpenAlexPublicationSchema(PublicationBaseSchema):
     """OpenAlex Publication validation schema for Silver layer.
 
     Validates publication records from OpenAlex Works API.
-    Includes both core publication fields and lookup metadata
-    for batch DOI resolution tracking.
+    Inherits common fields from PublicationBaseSchema:
+    - Cross-references: pmid, doi, pmc_id
+    - Core content: title, abstract, authors
+    - Metadata: journal, year (overridden), publication_date, doc_type (overridden), language
+    - Metrics: citation_count (overridden for nullable int)
+    - Open Access: is_oa
+    - Lookup tracking: lookup_method (overridden), original_id, source (overridden)
     """
 
-    # === Lookup metadata (OpenAlex-specific) ===
+    # === Primary Key (OpenAlex-specific) ===
+    openalex_id: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^W\d+$",
+        description="OpenAlex Work ID (e.g., W2148763428)",
+    )
+
+    # === Override lookup_method to be non-nullable ===
     lookup_method: Series[str] = pa.Field(
         alias="_lookup_method",
         nullable=False,
         isin=LOOKUP_METHODS,
         description="How record was resolved: doi, title_fallback, title_only",
-    )
-    original_id: Series[str] = pa.Field(
-        alias="_original_id",
-        nullable=True,
-        description="Original identifier from input (for fallback records)",
-    )
-
-    # === Primary Key ===
-    openalex_id: Series[str] = pa.Field(
-        nullable=False,
-        str_matches=r"^W\d+$",
-        description="OpenAlex Work ID (e.g., W2148763428)",
     )
 
     # === Override year with pd.Int64Dtype for nullable int ===
@@ -64,17 +62,23 @@ class OpenAlexPublicationSchema(PublicationBaseSchema):
         description="Publication year (1800-2100).",
     )
 
-    # === Publication date ===
-    publication_date: Series[str] = pa.Field(
-        nullable=True,
-        str_matches=r"^\d{4}-\d{2}-\d{2}$",
-        description="Publication date (YYYY-MM-DD)",
-    )
-
     # === Override doc_type to be non-nullable ===
     doc_type: Series[str] = pa.Field(
         nullable=False,
         description="Publication type (PUBLICATION, PREPRINT, etc.)",
+    )
+
+    # === Override citation_count with pd.Int64Dtype for nullable int ===
+    citation_count: Series[pd.Int64Dtype] = pa.Field(
+        nullable=True,
+        ge=0,
+        description="Number of citations (from OpenAlex cited_by_count).",
+    )
+
+    # === Override source to be non-nullable ===
+    source: Series[str] = pa.Field(
+        nullable=False,
+        description="Data source identifier",
     )
 
     # === Provider-specific Fields ===
@@ -88,34 +92,10 @@ class OpenAlexPublicationSchema(PublicationBaseSchema):
         description="Publisher name",
     )
 
-    # === Open Access ===
-    is_oa: Series[bool] = pa.Field(
-        nullable=True,
-        description="Is Open Access",
-    )
-
     oa_status: Series[str] = pa.Field(
         nullable=True,
         isin=OA_STATUS_VALUES,
-        description="OA status",
-    )
-
-    # === Override citation_count with pd.Int64Dtype for nullable int ===
-    citation_count: Series[pd.Int64Dtype] = pa.Field(
-        nullable=True,
-        ge=0,
-        description="Number of citations (from OpenAlex cited_by_count).",
-    )
-
-    # === Metadata ===
-    language: Series[str] = pa.Field(
-        nullable=True,
-        description="Language code",
-    )
-
-    source: Series[str] = pa.Field(
-        nullable=False,
-        description="Data source identifier",
+        description="OA status (gold, green, hybrid, bronze, closed)",
     )
 
     class Config:

--- a/src/bioetl/domain/schemas/pubmed/article.py
+++ b/src/bioetl/domain/schemas/pubmed/article.py
@@ -12,12 +12,18 @@ from typing import cast
 import pandera.pandas as pa
 from pandera.typing import Series
 
-from bioetl.domain.schemas.common.publication_base import PublicationBaseSchema
+from bioetl.domain.schemas.common.publication_base import (
+    LOOKUP_METHODS,
+    PublicationBaseSchema,
+)
 from bioetl.domain.validation import (
     DOI_REGEX_PATTERN,
     MAX_PUBLICATION_YEAR,
     MIN_PUBLICATION_YEAR,
 )
+
+# Re-export for backwards compatibility
+__all__ = ["LOOKUP_METHODS", "ArticleSchema"]
 
 # === Fixed Value Constants ===
 PUBLICATION_STATUSES = ["ppublish", "epublish", "aheadofprint"]

--- a/src/bioetl/domain/schemas/semanticscholar/publication.py
+++ b/src/bioetl/domain/schemas/semanticscholar/publication.py
@@ -1,7 +1,7 @@
 # src/bioetl/domain/schemas/semanticscholar/publication.py
 """Pandera schema for Semantic Scholar Publication entity.
 
-Aligned with RULES.md v5.10.
+Aligned with RULES.md v5.10 and Publication Schema Unification spec.
 Includes lookup metadata fields for DOI/title resolution tracking.
 """
 
@@ -12,6 +12,7 @@ from pandera.typing import Series
 
 from bioetl.domain.schemas.common.publication_base import (
     LOOKUP_METHODS,
+    OA_STATUS_VALUES,
     PublicationBaseSchema,
 )
 from bioetl.domain.validation import DOI_REGEX_PATTERN
@@ -24,35 +25,40 @@ __all__ = [
     "SemanticScholarPublicationSchema",
 ]
 
-# Open Access status values (normalized to lowercase for consistency with OpenAlex)
-OA_STATUS_VALUES = ["gold", "green", "hybrid", "bronze", "closed"]
-
 
 class SemanticScholarPublicationSchema(PublicationBaseSchema):
     """Semantic Scholar Publication validation schema for Silver layer.
 
     Validates publication records from Semantic Scholar Academic Graph API.
-    Includes lookup metadata for tracking DOI vs title resolution.
+    Inherits common fields from PublicationBaseSchema:
+    - Cross-references: pmid, doi, pmc_id
+    - Core content: title, abstract, authors
+    - Metadata: journal, year, publication_date, doc_type, language
+    - Metrics: citation_count
+    - Open Access: is_oa
+    - Lookup tracking: lookup_method (overridden), original_id, source (overridden)
     """
 
-    # === Lookup metadata (SemanticScholar-specific) ===
+    # === Primary Key (SemanticScholar-specific) ===
+    paper_id: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=r"^[a-f0-9]{40}$",
+        description="Semantic Scholar Paper ID (40-char hex)",
+    )
+
+    # === Override lookup_method to be non-nullable ===
     lookup_method: Series[str] = pa.Field(
         alias="_lookup_method",
         nullable=False,
         isin=LOOKUP_METHODS,
         description="How record was resolved: doi, title_fallback, title_only",
     )
-    original_id: Series[str] = pa.Field(
-        alias="_original_id",
-        nullable=True,
-        description="Original identifier from input (for fallback records)",
-    )
 
-    # === Primary Key ===
-    paper_id: Series[str] = pa.Field(
+    # === Override source to be non-nullable with fixed value ===
+    source: Series[str] = pa.Field(
         nullable=False,
-        str_matches=r"^[a-f0-9]{40}$",
-        description="Semantic Scholar Paper ID (40-char hex)",
+        eq="semanticscholar",
+        description="Data source identifier",
     )
 
     # === Provider-specific Identifiers ===
@@ -72,27 +78,8 @@ class SemanticScholarPublicationSchema(PublicationBaseSchema):
         nullable=True,
         description="AI-generated summary (TLDR)",
     )
-    authors: Series[str] = pa.Field(
-        nullable=True,
-        description="JSON array of author names",
-    )
 
-    # === Publication metadata ===
-    publication_date: Series[str] = pa.Field(
-        nullable=True,
-        str_matches=r"^\d{4}-\d{2}-\d{2}$",
-        description="Publication date (YYYY-MM-DD)",
-    )
-    doc_type: Series[str] = pa.Field(
-        nullable=True,
-        description="Publication type",
-    )
-
-    # === Journal/Venue (provider-specific) ===
-    journal: Series[str] = pa.Field(
-        nullable=True,
-        description="Journal name",
-    )
+    # === Provider-specific Journal/Venue Fields ===
     volume: Series[str] = pa.Field(
         nullable=True,
         description="Volume",
@@ -101,30 +88,19 @@ class SemanticScholarPublicationSchema(PublicationBaseSchema):
         nullable=True,
         description="Page range",
     )
-
     venue: Series[str] = pa.Field(
         nullable=True,
         description="Publication venue",
     )
 
-    # === Metrics ===
-    citation_count: Series[int] = pa.Field(
-        nullable=True,
-        ge=0,
-        description="Number of citations",
-    )
+    # === Provider-specific Metrics ===
     reference_count: Series[int] = pa.Field(
         nullable=True,
         ge=0,
         description="Number of references",
     )
 
-    # === Open Access ===
-    is_oa: Series[bool] = pa.Field(
-        nullable=True,
-        description="Is Open Access",
-    )
-
+    # === Provider-specific Open Access ===
     open_access_url: Series[str] = pa.Field(
         nullable=True,
         description="Direct link to OA PDF",
@@ -136,7 +112,7 @@ class SemanticScholarPublicationSchema(PublicationBaseSchema):
         description="Open Access status (normalized to lowercase).",
     )
 
-    # === Classification ===
+    # === Provider-specific Classification ===
     fields_of_study: Series[str] = pa.Field(
         nullable=True,
         description="Fields of study (JSON array)",
@@ -145,13 +121,6 @@ class SemanticScholarPublicationSchema(PublicationBaseSchema):
     publication_types: Series[str] = pa.Field(
         nullable=True,
         description="Publication types (JSON array)",
-    )
-
-    # === Source Tracking ===
-    source: Series[str] = pa.Field(
-        nullable=False,
-        eq="semanticscholar",
-        description="Data source identifier",
     )
 
     class Config:

--- a/tests/unit/domain/schemas/common/test_publication_base.py
+++ b/tests/unit/domain/schemas/common/test_publication_base.py
@@ -1,7 +1,8 @@
 """Tests for PublicationBaseSchema.
 
 Tests the base schema used by all publication entities across providers.
-Validates common fields: pmid, doi, pmc_id, title, abstract, year.
+Validates common fields: pmid, doi, pmc_id, title, abstract, authors, journal,
+year, publication_date, citation_count, is_oa, lookup_method, source, doc_type, language.
 """
 
 from __future__ import annotations
@@ -23,7 +24,7 @@ def valid_base_record() -> dict:
     """Create a valid record with all base publication fields.
 
     Includes all fields from ETLRecordSchema base class plus
-    PublicationBaseSchema specific fields.
+    PublicationBaseSchema specific fields for unified cross-provider analysis.
     """
     return {
         # === ETLRecordSchema fields ===
@@ -37,13 +38,28 @@ def valid_base_record() -> dict:
         "_dq_warn": False,
         "_dq_error": False,
         "_index": 0,
-        # === PublicationBaseSchema fields ===
+        # === Cross-reference IDs ===
         "pmid": "12345678",
         "doi": "10.1234/example.test",
         "pmc_id": "PMC1234567",
+        # === Core content ===
         "title": "Test Publication Title",
         "abstract": "This is a test abstract for the publication.",
+        "authors": '["John Doe", "Jane Smith"]',  # JSON array
+        # === Publication metadata ===
+        "journal": "Journal of Testing",
         "year": 2024,
+        "publication_date": "2024-06-15",
+        "doc_type": "PUBLICATION",
+        "language": "en",
+        # === Metrics ===
+        "citation_count": 10,
+        # === Open Access ===
+        "is_oa": True,
+        # === Lookup tracking (note: column names use _ prefix) ===
+        "_lookup_method": "doi",
+        "_original_id": "10.1234/example.test",
+        "source": "test_provider",
     }
 
 

--- a/tests/unit/domain/schemas/openalex/test_publication_schema.py
+++ b/tests/unit/domain/schemas/openalex/test_publication_schema.py
@@ -41,18 +41,25 @@ def valid_record() -> dict:
         "doi": "10.1038/s41586-024-07487-w",
         "pmid": "12345678",  # PubMed ID (numeric string)
         "pmc_id": "PMC1234567",  # PubMed Central ID (format: PMC1234567)
+        # Core content
         "title": "Example Publication",
         "abstract": "This is an abstract",
+        "authors": '["John Doe", "Jane Smith"]',  # JSON array (unified format)
+        # Publication metadata
         "year": 2024,
         "publication_date": "2024-05-15",
         "doc_type": "PUBLICATION",
+        "language": "en",
+        # Journal info
         "journal": "Nature",
         "issn": "0028-0836",
         "publisher": "Springer Nature",
+        # Open Access
         "is_oa": True,
         "oa_status": "gold",
+        # Metrics
         "citation_count": 42,  # Unified field name (from OpenAlex cited_by_count)
-        "language": "en",
+        # Lookup tracking
         "source": "openalex",
         "_lookup_method": "doi",
         "_original_id": None,

--- a/tests/unit/domain/schemas/test_year_validation.py
+++ b/tests/unit/domain/schemas/test_year_validation.py
@@ -50,29 +50,40 @@ class TestCrossRefYearValidation:
         return {
             **base_etl_fields,
             "entity_id": "crossref:publication:10.1038/nature12373",
-            "pmid": None,  # Added for base schema compatibility
+            # Cross-reference IDs
+            "pmid": None,
             "doi": "10.1038/nature12373",
-            "pmc_id": None,  # Added for base schema compatibility
+            "pmc_id": None,
+            # Core content
             "title": "Test Publication",
             "abstract": None,
-            "authors": None,
+            "authors": '["Author A", "Author B"]',  # JSON array
+            # Publication metadata
             "journal": "Nature",
+            "year": 2020,
+            "publication_date": "2020-06-15",  # Unified date field
+            "doc_type": DOCUMENT_TYPES[0],
+            "language": "en",
+            # Metrics
+            "citation_count": 100,
+            # Open Access
+            "is_oa": None,
+            # Lookup tracking
+            "_lookup_method": "doi",
+            "_original_id": "10.1038/nature12373",
+            "source": "crossref",
+            # CrossRef-specific fields
             "issn": None,
             "publisher": "Nature Publishing Group",
             "volume": "1",
             "issue": "1",
             "first_page": "1",
             "last_page": "10",
-            "year": 2020,
             "published_print": None,
             "published_online": None,
-            "doc_type": DOCUMENT_TYPES[0],
-            "citation_count": 100,
             "reference_count": 50,
-            "language": "en",
             "license_url": None,
             "subjects": None,
-            "source": "crossref",
         }
 
     def test_year_boundary_values(self, valid_record: dict) -> None:
@@ -116,33 +127,41 @@ class TestSemanticScholarYearValidation:
         return {
             **base_etl_fields,
             "entity_id": "semanticscholar:publication:abc123",
-            "paper_id": "a" * 40,  # 40-char hex
-            "doi": "10.1038/nature12373",
+            # Cross-reference IDs
             "pmid": None,
+            "doi": "10.1038/nature12373",
             "pmc_id": None,
-            "arxiv_id": None,
-            "corpus_id": 12345,
+            # Core content
             "title": "Test Publication",
             "abstract": None,
-            "tldr": None,
-            "year": 2020,
-            "publication_date": None,
-            "doc_type": None,  # Added for schema compatibility
+            "authors": '["Author A", "Author B"]',  # JSON array
+            # Publication metadata
             "journal": "Nature",
+            "year": 2020,
+            "publication_date": "2020-06-15",  # Unified date field
+            "doc_type": "PUBLICATION",
+            "language": None,
+            # Metrics
+            "citation_count": 100,
+            # Open Access
+            "is_oa": True,
+            # Lookup tracking
+            "_lookup_method": "doi",
+            "_original_id": None,
+            "source": "semanticscholar",
+            # SemanticScholar-specific fields
+            "paper_id": "a" * 40,  # 40-char hex
+            "arxiv_id": None,
+            "corpus_id": 12345,
+            "tldr": None,
             "volume": None,
             "pages": None,
             "venue": None,
-            "citation_count": 100,
             "reference_count": 50,
-            "is_oa": True,
             "open_access_url": None,
             "oa_status": None,
             "fields_of_study": None,
             "publication_types": None,
-            "authors": None,
-            "source": "semanticscholar",
-            "_lookup_method": "doi",
-            "_original_id": None,
         }
 
     def test_year_boundary_values(self, valid_record: dict) -> None:
@@ -186,27 +205,37 @@ class TestChemblYearValidation:
         return {
             **base_etl_fields,
             "entity_id": "chembl:publication:CHEMBL1234567",
-            "document_chembl_id": "CHEMBL1234567",
+            # Cross-reference IDs
             "pmid": "12345678",
             "doi": "10.1038/nature12373",
-            "pmc_id": None,  # Added for base schema compatibility
+            "pmc_id": None,
+            # Core content
+            "title": "Test Publication",
+            "abstract": "Abstract text",
+            "authors": '["Author A", "Author B"]',  # JSON array
+            # Publication metadata
+            "journal": "Nature",
+            "year": 2020,
+            "publication_date": "2020-01-01",  # Unified date field
+            "doc_type": "PUBLICATION",
+            "language": None,
+            # Metrics
+            "citation_count": None,  # Not available from ChEMBL
+            # Open Access
+            "is_oa": None,
+            # Lookup tracking
+            "_lookup_method": "direct",
+            "_original_id": None,
+            "source": "chembl",
+            # ChEMBL-specific fields
+            "document_chembl_id": "CHEMBL1234567",
             "patent_id": None,
             "src_id": 1,
-            "title": "Test Publication",
-            "doc_type": "PUBLICATION",
-            "authors": "Author A, Author B",
-            "abstract": "Abstract text",
-            "journal": "Nature",
             "journal_full_title": "Nature Journal",
-            "year": 2020,
             "volume": "1",
             "issue": "1",
             "first_page": "1",
             "last_page": "10",
-            "_lookup_method": "direct",
-            "_original_id": None,
-            "_dq_warn": False,
-            "_dq_error": False,
         }
 
     def test_year_boundary_values(self, valid_record: dict) -> None:
@@ -249,24 +278,38 @@ class TestPubMedYearValidation:
         return {
             **base_etl_fields,
             "entity_id": "pubmed:article:12345678",
+            # Cross-reference IDs (pmid is int for PubMed)
             "pmid": 12345678,
             "doi": "10.1038/nature12373",
             "pmc_id": None,
+            # Core content
             "title": "Test Article",
             "abstract": None,
+            "authors": '["Author A", "Author B"]',  # JSON array
+            # Publication metadata
+            "journal": "Nature",  # Unified journal field
+            "year": 2020,
+            "publication_date": "2020-05-15",  # Unified date field
+            "doc_type": "PUBLICATION",
+            "language": "eng",
+            # Metrics
+            "citation_count": None,  # Not available from PubMed
+            # Open Access
+            "is_oa": None,
+            # Lookup tracking
+            "_lookup_method": "pmid",
+            "_original_id": "12345678",
+            "source": "pubmed",
+            # PubMed-specific fields
             "abstract_structured": None,
             "vernacular_title": None,
-            "language": "eng",
             "journal_title": "Nature",
             "journal_iso_abbrev": "Nature",
             "journal_issn": "0028-0836",
             "journal_issn_type": "Print",
             "nlm_unique_id": None,
             "country": "United States",
-            "volume": "1",
-            "issue": "1",
             "medline_pgn": "1-10",
-            "year": 2020,
             "pub_month": 5,
             "pub_day": 15,
             "publication_status": "ppublish",


### PR DESCRIPTION
This change addresses the publication schema inconsistency issue across providers (PubMed, CrossRef, OpenAlex, SemanticScholar, ChEMBL) by creating a unified field set in PublicationBaseSchema.

Changes:
- Extend PublicationBaseSchema with common fields:
  - authors (JSON array of PII-hashed names)
  - journal, publication_date, doc_type, language
  - citation_count (pd.Int64Dtype for nullable int)
  - is_oa (Open Access flag)
  - lookup_method, original_id, source (lookup tracking)

- Update provider-specific schemas to inherit common fields:
  - ChemblPublicationSchema
  - PublicationEnrichedSchema (CrossRef)
  - OpenAlexPublicationSchema
  - SemanticScholarPublicationSchema
  - ArticleSchema (PubMed)

- Update transformers to populate common fields:
  - PubMed: add source, doc_type, citation_count, is_oa
  - CrossRef: add is_oa

- Update test fixtures to include new common fields

This enables consistent cross-provider publication analysis.