### PR TITLE
Add health check for ChEMBL publication pipeline

### DIFF
--- a/src/bioetl/domain/error_classifier.py
+++ b/src/bioetl/domain/error_classifier.py
@@ -34,7 +34,20 @@ _ERROR_KEYWORDS: list[tuple[tuple[str, ...], ErrorType]] = [
         ("CircuitBreakerOpen", "Timeout", "TimeoutError", "504", "502"),
         ErrorType.TIMEOUT,
     ),
-    (("Upload", "NetworkError", "RetryExhausted"), ErrorType.NETWORK_ERROR),
+    (
+        (
+            "Upload",
+            "NetworkError",
+            "RetryExhausted",
+            "ReadError",
+            "WriteError",
+            "ConnectError",
+            "DecodingError",
+            "TransportError",
+            "StreamError",
+        ),
+        ErrorType.NETWORK_ERROR,
+    ),
     # Data quality errors (skip record)
     (("Schema", "Validation", "SchemaValidation"), ErrorType.SCHEMA_VIOLATION),
     (("Missing", "Required", "MissingRequired"), ErrorType.MISSING_REQUIRED_FIELD),


### PR DESCRIPTION
ReadError, DecodingError, ConnectError, WriteError, TransportError, and StreamError from httpx are now properly classified as NETWORK_ERROR (recoverable) instead of defaulting to INVALID_DATA (data quality).

This fixes an issue where ChEMBL health checks pass but fetch operations fail with ReadError, causing the pipeline to abort instead of retrying.