### PR TITLE
Handle pipeline services closure gracefully

### DIFF
--- a/src/bioetl/application/core/lock_manager.py
+++ b/src/bioetl/application/core/lock_manager.py
@@ -182,7 +182,7 @@ class LockManager:
         # Clear shared context holder
         if self._context_holder is not None:
             self._context_holder.clear()
-        self._logger.info("Lock released", extra={"stage": "cleanup"})
+        self._logger.info("Lock released", stage="cleanup")
 
     def get_context(self) -> LockContext | None:
         """Get LockContext for passing to writers.

--- a/src/bioetl/application/core/pipeline_services.py
+++ b/src/bioetl/application/core/pipeline_services.py
@@ -113,7 +113,7 @@ class PipelineServices:
 
     async def aclose(self) -> None:
         """Gracefully close all I/O resources and observability."""
-        self.logger.info("Closing pipeline services...")
+        self.logger.info("Closing pipeline services...", stage="cleanup")
 
         # Close async I/O services
         results = await asyncio.gather(
@@ -127,24 +127,26 @@ class PipelineServices:
 
         for result in results:
             if isinstance(result, Exception):
-                self.logger.error("Error during service shutdown", error=result)
+                self.logger.error(
+                    "Error during service shutdown", stage="cleanup", error=result
+                )
 
         # Close observability (sync, best-effort)
         self._close_observability()
 
-        self.logger.info("Pipeline services closed.")
+        self.logger.info("Pipeline services closed.", stage="cleanup")
 
     def _close_observability(self) -> None:
         """Close metrics and tracing resources (sync, idempotent)."""
         try:
             self.metrics.close()
         except Exception as e:
-            self.logger.warning("Error closing metrics", error=str(e))
+            self.logger.warning("Error closing metrics", stage="cleanup", error=str(e))
 
         try:
             self.tracing.close()
         except Exception as e:
-            self.logger.warning("Error closing tracing", error=str(e))
+            self.logger.warning("Error closing tracing", stage="cleanup", error=str(e))
 
 
 __all__ = ["PipelineServices"]


### PR DESCRIPTION
The log messages during pipeline closure were using the default stage="init" because the stage parameter wasn't explicitly passed. This was misleading in error scenarios where the logs showed "Pipeline services closed" with stage="init".

Changes:
- PipelineServices.aclose(): add stage="cleanup" to all log calls
- LockManager.release(): fix incorrect extra={"stage":"cleanup"} pattern to use stage="cleanup" directly (LoggerPort interface)

This ensures that cleanup-phase logs are correctly categorized for debugging pipeline failures.