### PR TITLE
Normalize PII hash algorithm implementation

### DIFF
--- a/src/bioetl/domain/services/data_normalization_service.py
+++ b/src/bioetl/domain/services/data_normalization_service.py
@@ -105,8 +105,13 @@ class DefaultDataNormalizationService:
         return serialize_to_json(hashed, ensure_ascii=True)
 
     def _hash_pii(self, value: str, salt: str) -> str:
-        """Hash a PII value with salt using SHA-256."""
-        return hashlib.sha256(f"{salt}{value}".encode()).hexdigest()
+        """Hash a PII value with salt using SHA-256 per RULES.md §5.4.
+
+        Normalization: strip whitespace, lowercase before hashing.
+        Formula: sha256(lowercase(value) + SALT)
+        """
+        normalized = value.strip().lower()
+        return hashlib.sha256(f"{normalized}{salt}".encode()).hexdigest()
 
     def strip_html_tags(self, text: str | None) -> str | None:
         """Remove HTML tags, decode entities, normalize whitespace."""

--- a/tests/unit/domain/services/test_data_normalization_service.py
+++ b/tests/unit/domain/services/test_data_normalization_service.py
@@ -413,7 +413,10 @@ class TestDataNormalizationConfig:
 
 
 class TestHashPii:
-    """Tests for _hash_pii helper method."""
+    """Tests for _hash_pii helper method.
+
+    Per RULES.md §5.4: sha256(lowercase(value) + SALT)
+    """
 
     def test_hash_consistency(self) -> None:
         """Test that same input produces same hash."""
@@ -435,3 +438,41 @@ class TestHashPii:
         hash1 = service._hash_pii("John Doe", "salt")
         hash2 = service._hash_pii("Jane Smith", "salt")
         assert hash1 != hash2
+
+    def test_case_normalization(self) -> None:
+        """Test that hashing is case-insensitive per RULES.md §5.4."""
+        service = DefaultDataNormalizationService()
+        hash_lower = service._hash_pii("john doe", "salt")
+        hash_upper = service._hash_pii("JOHN DOE", "salt")
+        hash_mixed = service._hash_pii("John Doe", "salt")
+        assert hash_lower == hash_upper == hash_mixed
+
+    def test_whitespace_normalization(self) -> None:
+        """Test that leading/trailing whitespace is stripped before hashing."""
+        service = DefaultDataNormalizationService()
+        hash_clean = service._hash_pii("john doe", "salt")
+        hash_padded = service._hash_pii("  john doe  ", "salt")
+        hash_tabs = service._hash_pii("\tjohn doe\t", "salt")
+        assert hash_clean == hash_padded == hash_tabs
+
+    def test_hash_formula_matches_rules_md(self) -> None:
+        """Test hash formula matches RULES.md §5.4: sha256(lowercase(value) + SALT)."""
+        import hashlib
+
+        service = DefaultDataNormalizationService()
+        value = "  John Doe  "
+        salt = "test_salt"
+
+        # Expected: sha256(lowercase(stripped(value)) + salt)
+        normalized = value.strip().lower()
+        expected_hash = hashlib.sha256(f"{normalized}{salt}".encode()).hexdigest()
+
+        actual_hash = service._hash_pii(value, salt)
+        assert actual_hash == expected_hash
+
+    def test_empty_salt_allowed(self) -> None:
+        """Test that empty salt works (edge case)."""
+        service = DefaultDataNormalizationService()
+        # Should not raise
+        result = service._hash_pii("test", "")
+        assert len(result) == 64  # SHA-256 hex digest length


### PR DESCRIPTION
Align _hash_pii algorithm with specification:
- Add strip().lower() normalization before hashing
- Correct salt order to: sha256(lowercase(value) + SALT)

This ensures:
- Case-insensitive hashing ("John Doe" == "JOHN DOE")
- Whitespace-tolerant hashing ("  name  " == "name")

Note: This changes hash output for existing data. If hashes are used for lookup, migration may be required.

Add tests verifying:
- Case normalization
- Whitespace normalization
- Formula matches RULES.md §5.4
- Empty salt edge case