### PR TITLE
Remove deprecated code from BioETL

### DIFF
--- a/scripts/lint_terminology.py
+++ b/scripts/lint_terminology.py
@@ -49,8 +49,8 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Project root
-PROJECT_ROOT = Path(__file__).parent.parent.parent
+# Project root (scripts/ is directly under project root)
+PROJECT_ROOT = Path(__file__).parent.parent
 
 
 # =============================================================================

--- a/src/bioetl/domain/context.py
+++ b/src/bioetl/domain/context.py
@@ -16,9 +16,6 @@ from typing import Any
 from bioetl.domain.ports import LoggerPort
 from bioetl.domain.types import RunID, RunType
 
-# Backward compatibility alias
-BoundLogger = LoggerPort
-
 
 def _now_utc() -> datetime:
     """Factory function for default started_at timestamp."""


### PR DESCRIPTION
…logy linter

Removed:
- BoundLogger alias from domain/context.py (unused, 0 usages in codebase)

Fixed:
- lint_terminology.py PROJECT_ROOT calculation (.parent.parent.parent → .parent.parent)

Verified:
- All 6297 unit tests pass
- All 989 architecture tests pass
- mypy and ruff linting pass
- Import regression test confirms alias correctly removed

Note: ADR-024 deprecated aliases (Publication, PublicationEntity) were never implemented and do not require removal. Registry methods (register_factory, list_pipelines) are primary methods, not deprecated.

See: naming-compliance-report.md (2026-01-16)