### PR TITLE
Fix linting errors in pull request

### DIFF
--- a/tests/architecture/test_code_metrics.py
+++ b/tests/architecture/test_code_metrics.py
@@ -233,9 +233,6 @@ class TestFunctionComplexity:
         "from_dict": 8,  # CC=6 - Dictionary parsing with type conversions
         # BatchExecutor DQ context extraction
         "get_dq_context": 13,  # CC=12 - DQ context gathering with nullable field handling
-        # Storage writer merge operations with Null/List<Null> coercion
-        "write_silver_merged": 17,  # CC=16 - Silver merge with Null type coercion
-        "write_gold_merged": 17,  # CC=16 - Gold merge with Null type coercion
     }
 
     def test_domain_complexity(self, src_dir: Path) -> None:


### PR DESCRIPTION
Remove duplicate "write_silver_merged" and "write_gold_merged" entries that were causing ruff F601 lint errors. The exemptions already exist earlier in the dictionary at lines 211-212.