### PR TITLE
Remove composition mention from docstring

### DIFF
--- a/src/bioetl/application/pipelines/__init__.py
+++ b/src/bioetl/application/pipelines/__init__.py
@@ -9,10 +9,10 @@ Main Components:
 - Provider-specific transformers: Implement Bronze→Silver transformation logic
 
 Usage:
-    # Recommended approach - use GenericPipeline via factory
-    from bioetl.composition.factories.pipeline_factories import get_factory
-    factory = get_factory("chembl_activity")
-    runner = factory.create_runner(...)
+    # From interfaces/CLI layer - use factory for pipeline instantiation:
+    # >>> from bioetl.composition.factories.pipeline_factories import get_factory
+    # >>> factory = get_factory("chembl_activity")
+    # >>> runner = factory.create_runner(...)
 
     # Direct instantiation (for testing)
     from bioetl.application.pipelines.generic import GenericPipeline


### PR DESCRIPTION
… layer

Update docstring in application/pipelines/__init__.py to make clear that the factory import example from composition layer is intended for use from interfaces/CLI layer, not within application layer. This adheres to the layered architecture import matrix.