### PR TITLE
Document email field as non-PII data

### DIFF
--- a/tests/security/test_security.py
+++ b/tests/security/test_security.py
@@ -326,6 +326,7 @@ class TestPIIHandling:
     # These are API identifiers required by external services
     KNOWN_TECHNICAL_EMAIL_FILES = frozenset(
         {
+            "_base.py",  # NCBI API tool identification (default_email in Settings)
             "config.py",  # NCBI API tool identification (default_email)
             "pubmed_client.py",  # NCBI API tool identification
             "pipeline_config.py",  # NCBI API source config


### PR DESCRIPTION
Add _base.py to KNOWN_TECHNICAL_EMAIL_FILES exclusion list to prevent false positive warnings. The default_email field is a technical API identifier required by NCBI E-utilities for tool identification and rate limit management, not user personal data.

See: https://www.ncbi.nlm.nih.gov/books/NBK25497/