### PR TITLE
Expand data contracts for pipeline configurations

### DIFF
--- a/docs/contracts/gold/assay_parameters_v1.0.json
+++ b/docs/contracts/gold/assay_parameters_v1.0.json
@@ -1,0 +1,84 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$version": "1.0.0",
+    "title": "Assay Parameters Data Contract",
+    "description": "Defines the schema for the gold 'AssayParameters' entity, aligned with RULES.md §7.1. This contract is for data consumers.",
+    "type": "object",
+    "properties": {
+        "assay_param_id": {
+            "type": "integer",
+            "description": "Parameter ID (PK, surrogate integer).",
+            "minimum": 1
+        },
+        "assay_chembl_id": {
+            "type": "string",
+            "description": "FK to Assay (ChEMBL ID format).",
+            "pattern": "^CHEMBL\\d+$"
+        },
+        "type": {
+            "type": "string",
+            "description": "Parameter type (e.g., CONC, PH, TEMP, TIME)."
+        },
+        "relation": {
+            "type": ["string", "null"],
+            "description": "Relation operator (=, <, >, ~, >=, <=)."
+        },
+        "value": {
+            "type": ["number", "null"],
+            "description": "Numeric value."
+        },
+        "units": {
+            "type": ["string", "null"],
+            "description": "Original units (e.g., uM, nM, %)."
+        },
+        "text_value": {
+            "type": ["string", "null"],
+            "description": "Text value for non-numeric parameters."
+        },
+        "comments": {
+            "type": ["string", "null"],
+            "description": "Additional comments."
+        },
+        "standard_type": {
+            "type": ["string", "null"],
+            "description": "Standardized type."
+        },
+        "standard_relation": {
+            "type": ["string", "null"],
+            "description": "Standardized relation."
+        },
+        "standard_value": {
+            "type": ["number", "null"],
+            "description": "Standardized value."
+        },
+        "standard_units": {
+            "type": ["string", "null"],
+            "description": "Standardized units."
+        },
+        "standard_text_value": {
+            "type": ["string", "null"],
+            "description": "Standardized text value."
+        },
+        "_source_batch_id": {
+            "type": "string",
+            "description": "Internal ID linking to the source Bronze batch for lineage.",
+            "format": "uuid"
+        },
+        "_content_hash": {
+            "type": "string",
+            "description": "SHA-256 hash of the record's content for versioning and deduplication."
+        },
+        "_ingestion_ts": {
+            "type": "string",
+            "format": "date-time",
+            "description": "UTC timestamp of when the record was ingested."
+        }
+    },
+    "required": [
+        "assay_param_id",
+        "assay_chembl_id",
+        "type",
+        "_content_hash",
+        "_ingestion_ts"
+    ]
+}

--- a/docs/contracts/gold/cell_line_v1.0.json
+++ b/docs/contracts/gold/cell_line_v1.0.json
@@ -1,0 +1,78 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$version": "1.0.0",
+    "title": "Cell Line Data Contract",
+    "description": "Defines the schema for the gold 'CellLine' entity, aligned with RULES.md §7.1. This contract is for data consumers.",
+    "type": "object",
+    "properties": {
+        "cell_chembl_id": {
+            "type": "string",
+            "description": "ChEMBL ID for cell line (PK).",
+            "pattern": "^CHEMBL\\d+$"
+        },
+        "cell_name": {
+            "type": "string",
+            "description": "Cell line name (e.g., HeLa, MCF7)."
+        },
+        "cell_description": {
+            "type": ["string", "null"],
+            "description": "Cell line description."
+        },
+        "cell_source_tissue": {
+            "type": ["string", "null"],
+            "description": "Source tissue (e.g., Cervix, Breast)."
+        },
+        "cell_source_organism": {
+            "type": ["string", "null"],
+            "description": "Source organism (e.g., Homo sapiens)."
+        },
+        "cell_source_taxonomy_id": {
+            "type": ["integer", "null"],
+            "description": "NCBI Taxonomy ID for source organism.",
+            "minimum": 1
+        },
+        "cell_type": {
+            "type": ["string", "null"],
+            "description": "Cell type classification (e.g., Cancer cell line)."
+        },
+        "cellosaurus_id": {
+            "type": ["string", "null"],
+            "description": "Cellosaurus ID (external reference).",
+            "pattern": "^CVCL_[A-Z0-9]+$"
+        },
+        "clo_id": {
+            "type": ["string", "null"],
+            "description": "Cell Line Ontology ID.",
+            "pattern": "^CLO_\\d+$"
+        },
+        "cl_lincs_id": {
+            "type": ["string", "null"],
+            "description": "LINCS ID (Library of Integrated Network-Based Cellular Signatures)."
+        },
+        "efo_id": {
+            "type": ["string", "null"],
+            "description": "EFO ontology ID.",
+            "pattern": "^EFO_\\d+$"
+        },
+        "_source_batch_id": {
+            "type": "string",
+            "description": "Internal ID linking to the source Bronze batch for lineage.",
+            "format": "uuid"
+        },
+        "_content_hash": {
+            "type": "string",
+            "description": "SHA-256 hash of the record's content for versioning and deduplication."
+        },
+        "_ingestion_ts": {
+            "type": "string",
+            "format": "date-time",
+            "description": "UTC timestamp of when the record was ingested."
+        }
+    },
+    "required": [
+        "cell_chembl_id",
+        "cell_name",
+        "_content_hash",
+        "_ingestion_ts"
+    ]
+}

--- a/docs/contracts/gold/compound_record_v1.0.json
+++ b/docs/contracts/gold/compound_record_v1.0.json
@@ -1,0 +1,63 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$version": "1.0.0",
+    "title": "Compound Record Data Contract",
+    "description": "Defines the schema for the gold 'CompoundRecord' entity, aligned with RULES.md §7.1. This contract is for data consumers. Links molecules to documents with original compound names.",
+    "type": "object",
+    "properties": {
+        "record_id": {
+            "type": "integer",
+            "description": "ChEMBL record ID (PK).",
+            "minimum": 1
+        },
+        "molecule_chembl_id": {
+            "type": "string",
+            "description": "FK to Molecule.",
+            "pattern": "^CHEMBL\\d+$"
+        },
+        "document_chembl_id": {
+            "type": "string",
+            "description": "FK to Publication.",
+            "pattern": "^CHEMBL\\d+$"
+        },
+        "src_id": {
+            "type": "integer",
+            "description": "FK to Source (data source).",
+            "minimum": 1
+        },
+        "compound_key": {
+            "type": ["string", "null"],
+            "description": "Original compound key in source document."
+        },
+        "compound_name": {
+            "type": ["string", "null"],
+            "description": "Original compound name in source document."
+        },
+        "src_compound_id": {
+            "type": ["string", "null"],
+            "description": "Compound ID in original data source."
+        },
+        "_source_batch_id": {
+            "type": "string",
+            "description": "Internal ID linking to the source Bronze batch for lineage.",
+            "format": "uuid"
+        },
+        "_content_hash": {
+            "type": "string",
+            "description": "SHA-256 hash of the record's content for versioning and deduplication."
+        },
+        "_ingestion_ts": {
+            "type": "string",
+            "format": "date-time",
+            "description": "UTC timestamp of when the record was ingested."
+        }
+    },
+    "required": [
+        "record_id",
+        "molecule_chembl_id",
+        "document_chembl_id",
+        "src_id",
+        "_content_hash",
+        "_ingestion_ts"
+    ]
+}

--- a/docs/contracts/gold/protein_classification_v1.0.json
+++ b/docs/contracts/gold/protein_classification_v1.0.json
@@ -1,0 +1,70 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$version": "1.0.0",
+    "title": "Protein Classification Data Contract",
+    "description": "Defines the schema for the gold 'ProteinClassification' entity, aligned with RULES.md §7.1. This contract is for data consumers. Hierarchical protein classification taxonomy.",
+    "type": "object",
+    "properties": {
+        "protein_class_id": {
+            "type": "integer",
+            "description": "Primary key."
+        },
+        "parent_id": {
+            "type": ["integer", "null"],
+            "description": "FK to parent classification for hierarchy."
+        },
+        "replaced_by": {
+            "type": ["integer", "null"],
+            "description": "FK to replacement classification (if deprecated)."
+        },
+        "pref_name": {
+            "type": ["string", "null"],
+            "description": "Preferred name of the classification."
+        },
+        "short_name": {
+            "type": ["string", "null"],
+            "description": "Short name."
+        },
+        "protein_class_desc": {
+            "type": ["string", "null"],
+            "description": "Description of the protein class."
+        },
+        "definition": {
+            "type": ["string", "null"],
+            "description": "Full definition."
+        },
+        "class_level": {
+            "type": ["integer", "null"],
+            "description": "Level in the hierarchy (1 = root).",
+            "minimum": 1
+        },
+        "sort_order": {
+            "type": ["integer", "null"],
+            "description": "Sort order within the hierarchy."
+        },
+        "downgraded": {
+            "type": ["integer", "null"],
+            "description": "Downgraded flag (0 or 1).",
+            "enum": [0, 1, null]
+        },
+        "_source_batch_id": {
+            "type": "string",
+            "description": "Internal ID linking to the source Bronze batch for lineage.",
+            "format": "uuid"
+        },
+        "_content_hash": {
+            "type": "string",
+            "description": "SHA-256 hash of the record's content for versioning and deduplication."
+        },
+        "_ingestion_ts": {
+            "type": "string",
+            "format": "date-time",
+            "description": "UTC timestamp of when the record was ingested."
+        }
+    },
+    "required": [
+        "protein_class_id",
+        "_content_hash",
+        "_ingestion_ts"
+    ]
+}

--- a/docs/contracts/gold/pubchem_compound_v1.0.json
+++ b/docs/contracts/gold/pubchem_compound_v1.0.json
@@ -1,0 +1,208 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$version": "1.0.0",
+    "title": "PubChem Compound Data Contract",
+    "description": "Defines the schema for the gold 'PubChemCompound' entity, aligned with RULES.md §7.1. This contract is for data consumers. Chemical compound data from PubChem.",
+    "type": "object",
+    "properties": {
+        "cid": {
+            "type": "integer",
+            "description": "PubChem Compound ID (PK).",
+            "minimum": 1
+        },
+        "canonical_smiles": {
+            "type": ["string", "null"],
+            "description": "Canonical SMILES string.",
+            "maxLength": 10000
+        },
+        "isomeric_smiles": {
+            "type": ["string", "null"],
+            "description": "SMILES with stereochemistry.",
+            "maxLength": 10000
+        },
+        "inchi": {
+            "type": ["string", "null"],
+            "description": "IUPAC InChI identifier.",
+            "pattern": "^InChI=.*$"
+        },
+        "inchi_key": {
+            "type": ["string", "null"],
+            "description": "InChI hash key (27 chars).",
+            "pattern": "^[A-Z]{14}-[A-Z]{10}-[A-Z]$"
+        },
+        "molecular_formula": {
+            "type": ["string", "null"],
+            "description": "Molecular formula (e.g., C6H12O6)."
+        },
+        "iupac_name": {
+            "type": ["string", "null"],
+            "description": "IUPAC systematic name."
+        },
+        "molecular_weight": {
+            "type": ["number", "null"],
+            "description": "Molecular weight in g/mol.",
+            "minimum": 0,
+            "maximum": 100000
+        },
+        "exact_mass": {
+            "type": ["number", "null"],
+            "description": "Monoisotopic exact mass (Da).",
+            "minimum": 0
+        },
+        "xlogp": {
+            "type": ["number", "null"],
+            "description": "Computed octanol-water partition coefficient.",
+            "minimum": -20,
+            "maximum": 20
+        },
+        "tpsa": {
+            "type": ["number", "null"],
+            "description": "Topological polar surface area (A^2).",
+            "minimum": 0
+        },
+        "complexity": {
+            "type": ["number", "null"],
+            "description": "Structural complexity score.",
+            "minimum": 0
+        },
+        "charge": {
+            "type": ["integer", "null"],
+            "description": "Formal charge.",
+            "minimum": -10,
+            "maximum": 10
+        },
+        "heavy_atom_count": {
+            "type": ["integer", "null"],
+            "description": "Non-hydrogen atom count.",
+            "minimum": 1,
+            "maximum": 500
+        },
+        "h_bond_donor_count": {
+            "type": ["integer", "null"],
+            "description": "Hydrogen bond donor count.",
+            "minimum": 0,
+            "maximum": 50
+        },
+        "h_bond_acceptor_count": {
+            "type": ["integer", "null"],
+            "description": "Hydrogen bond acceptor count.",
+            "minimum": 0,
+            "maximum": 50
+        },
+        "rotatable_bond_count": {
+            "type": ["integer", "null"],
+            "description": "Rotatable bond count.",
+            "minimum": 0,
+            "maximum": 100
+        },
+        "atom_stereo_count": {
+            "type": ["integer", "null"],
+            "description": "Total stereocenters.",
+            "minimum": 0
+        },
+        "defined_atom_stereo_count": {
+            "type": ["integer", "null"],
+            "description": "Defined stereocenters.",
+            "minimum": 0
+        },
+        "undefined_atom_stereo_count": {
+            "type": ["integer", "null"],
+            "description": "Undefined stereocenters.",
+            "minimum": 0
+        },
+        "bond_stereo_count": {
+            "type": ["integer", "null"],
+            "description": "Total E/Z bonds.",
+            "minimum": 0
+        },
+        "defined_bond_stereo_count": {
+            "type": ["integer", "null"],
+            "description": "Defined E/Z bonds.",
+            "minimum": 0
+        },
+        "undefined_bond_stereo_count": {
+            "type": ["integer", "null"],
+            "description": "Undefined E/Z bonds.",
+            "minimum": 0
+        },
+        "isotope_atom_count": {
+            "type": ["integer", "null"],
+            "description": "Isotopic atom count.",
+            "minimum": 0
+        },
+        "covalent_unit_count": {
+            "type": ["integer", "null"],
+            "description": "Number of covalent units.",
+            "minimum": 1
+        },
+        "volume_3d": {
+            "type": ["number", "null"],
+            "description": "3D molecular volume (A^3).",
+            "minimum": 0
+        },
+        "conformer_count_3d": {
+            "type": ["integer", "null"],
+            "description": "Number of 3D conformers.",
+            "minimum": 0
+        },
+        "feature_acceptor_count_3d": {
+            "type": ["integer", "null"],
+            "description": "3D H-bond acceptor features.",
+            "minimum": 0
+        },
+        "feature_donor_count_3d": {
+            "type": ["integer", "null"],
+            "description": "3D H-bond donor features.",
+            "minimum": 0
+        },
+        "feature_anion_count_3d": {
+            "type": ["integer", "null"],
+            "description": "3D anion features.",
+            "minimum": 0
+        },
+        "feature_cation_count_3d": {
+            "type": ["integer", "null"],
+            "description": "3D cation features.",
+            "minimum": 0
+        },
+        "feature_ring_count_3d": {
+            "type": ["integer", "null"],
+            "description": "3D ring features.",
+            "minimum": 0
+        },
+        "feature_hydrophobe_count_3d": {
+            "type": ["integer", "null"],
+            "description": "3D hydrophobic features.",
+            "minimum": 0
+        },
+        "effective_rotor_count_3d": {
+            "type": ["number", "null"],
+            "description": "Effective rotatable bonds (3D).",
+            "minimum": 0
+        },
+        "conformer_rmsd_3d": {
+            "type": ["number", "null"],
+            "description": "Conformer model RMSD.",
+            "minimum": 0
+        },
+        "_source_batch_id": {
+            "type": "string",
+            "description": "Internal ID linking to the source Bronze batch for lineage.",
+            "format": "uuid"
+        },
+        "_content_hash": {
+            "type": "string",
+            "description": "SHA-256 hash of the record's content for versioning and deduplication."
+        },
+        "_ingestion_ts": {
+            "type": "string",
+            "format": "date-time",
+            "description": "UTC timestamp of when the record was ingested."
+        }
+    },
+    "required": [
+        "cid",
+        "_content_hash",
+        "_ingestion_ts"
+    ]
+}

--- a/docs/contracts/gold/publication_similarity_v1.0.json
+++ b/docs/contracts/gold/publication_similarity_v1.0.json
@@ -1,0 +1,76 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$version": "1.0.0",
+    "title": "Publication Similarity Data Contract",
+    "description": "Defines the schema for the gold 'PublicationSimilarity' entity, aligned with RULES.md §7.1. This contract is for data consumers. Tanimoto similarity scores between document pairs.",
+    "type": "object",
+    "properties": {
+        "sim_id": {
+            "type": "integer",
+            "description": "Primary key."
+        },
+        "doc_1": {
+            "type": "integer",
+            "description": "FK to document 1 (internal ChEMBL doc_id)."
+        },
+        "doc_2": {
+            "type": "integer",
+            "description": "FK to document 2 (internal ChEMBL doc_id)."
+        },
+        "pubmed_id1": {
+            "type": ["string", "null"],
+            "description": "PubMed identifier for document 1 (numeric string).",
+            "pattern": "^\\d+$"
+        },
+        "pubmed_id2": {
+            "type": ["string", "null"],
+            "description": "PubMed identifier for document 2 (numeric string).",
+            "pattern": "^\\d+$"
+        },
+        "tid_tani": {
+            "type": ["number", "null"],
+            "description": "Tanimoto coefficient based on target IDs.",
+            "minimum": 0,
+            "maximum": 1
+        },
+        "mol_tani": {
+            "type": ["number", "null"],
+            "description": "Tanimoto coefficient based on molecule fingerprints.",
+            "minimum": 0,
+            "maximum": 1
+        },
+        "avg_tani": {
+            "type": ["number", "null"],
+            "description": "Average Tanimoto coefficient.",
+            "minimum": 0,
+            "maximum": 1
+        },
+        "max_tani": {
+            "type": ["number", "null"],
+            "description": "Maximum Tanimoto coefficient.",
+            "minimum": 0,
+            "maximum": 1
+        },
+        "_source_batch_id": {
+            "type": "string",
+            "description": "Internal ID linking to the source Bronze batch for lineage.",
+            "format": "uuid"
+        },
+        "_content_hash": {
+            "type": "string",
+            "description": "SHA-256 hash of the record's content for versioning and deduplication."
+        },
+        "_ingestion_ts": {
+            "type": "string",
+            "format": "date-time",
+            "description": "UTC timestamp of when the record was ingested."
+        }
+    },
+    "required": [
+        "sim_id",
+        "doc_1",
+        "doc_2",
+        "_content_hash",
+        "_ingestion_ts"
+    ]
+}

--- a/docs/contracts/gold/publication_term_v1.0.json
+++ b/docs/contracts/gold/publication_term_v1.0.json
@@ -1,0 +1,53 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$version": "1.0.0",
+    "title": "Publication Term Data Contract",
+    "description": "Defines the schema for the gold 'PublicationTerm' entity, aligned with RULES.md §7.1. This contract is for data consumers. Terms (MeSH, keywords, concepts) associated with documents.",
+    "type": "object",
+    "properties": {
+        "document_chembl_id": {
+            "type": "string",
+            "description": "FK to Document ChEMBL ID (part of composite key).",
+            "pattern": "^CHEMBL\\d+$"
+        },
+        "term": {
+            "type": "string",
+            "description": "Term text (e.g., 'Aspirin', 'kinase inhibitor').",
+            "minLength": 1
+        },
+        "term_type": {
+            "type": "string",
+            "description": "Term type classification.",
+            "enum": ["MESH_HEADING", "MESH_QUALIFIER", "KEYWORD", "CONCEPT"]
+        },
+        "mesh_id": {
+            "type": ["string", "null"],
+            "description": "MeSH identifier (e.g., 'D001241')."
+        },
+        "qualifier": {
+            "type": ["string", "null"],
+            "description": "MeSH qualifier (e.g., 'pharmacology')."
+        },
+        "_source_batch_id": {
+            "type": "string",
+            "description": "Internal ID linking to the source Bronze batch for lineage.",
+            "format": "uuid"
+        },
+        "_content_hash": {
+            "type": "string",
+            "description": "SHA-256 hash of the record's content for versioning and deduplication."
+        },
+        "_ingestion_ts": {
+            "type": "string",
+            "format": "date-time",
+            "description": "UTC timestamp of when the record was ingested."
+        }
+    },
+    "required": [
+        "document_chembl_id",
+        "term",
+        "term_type",
+        "_content_hash",
+        "_ingestion_ts"
+    ]
+}

--- a/docs/contracts/gold/pubmed_publication_v1.0.json
+++ b/docs/contracts/gold/pubmed_publication_v1.0.json
@@ -1,0 +1,208 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$version": "1.0.0",
+    "title": "PubMed Publication Data Contract",
+    "description": "Defines the schema for the gold 'PubMedPublication' entity, aligned with RULES.md §7.1. This contract is for data consumers. MEDLINE/PubMed citation records.",
+    "type": "object",
+    "properties": {
+        "pmid": {
+            "type": "string",
+            "description": "PubMed ID (PK, numeric string).",
+            "pattern": "^[1-9]\\d*$"
+        },
+        "doi": {
+            "type": ["string", "null"],
+            "description": "Digital Object Identifier.",
+            "pattern": "^10\\.\\d{4,}/.*$"
+        },
+        "pmc_id": {
+            "type": ["string", "null"],
+            "description": "PubMed Central ID.",
+            "pattern": "^PMC\\d+$"
+        },
+        "title": {
+            "type": "string",
+            "description": "Article title (required).",
+            "minLength": 1
+        },
+        "abstract": {
+            "type": ["string", "null"],
+            "description": "Publication abstract."
+        },
+        "abstract_structured": {
+            "type": ["boolean", "null"],
+            "description": "Whether abstract has NLM sections."
+        },
+        "vernacular_title": {
+            "type": ["string", "null"],
+            "description": "Original non-English title."
+        },
+        "language": {
+            "type": ["string", "null"],
+            "description": "MARC language code (e.g., 'eng').",
+            "minLength": 2,
+            "maxLength": 3
+        },
+        "authors": {
+            "type": ["string", "null"],
+            "description": "JSON array of author names."
+        },
+        "journal": {
+            "type": ["string", "null"],
+            "description": "Journal name."
+        },
+        "journal_title": {
+            "type": ["string", "null"],
+            "description": "Full journal name."
+        },
+        "journal_iso_abbrev": {
+            "type": ["string", "null"],
+            "description": "ISO journal abbreviation."
+        },
+        "journal_issn": {
+            "type": ["string", "null"],
+            "description": "ISSN (print or electronic).",
+            "pattern": "^\\d{4}-\\d{3}[\\dX]$"
+        },
+        "journal_issn_type": {
+            "type": ["string", "null"],
+            "description": "ISSN type.",
+            "enum": ["Print", "Electronic", "Linking", null]
+        },
+        "nlm_unique_id": {
+            "type": ["string", "null"],
+            "description": "NLM catalog ID."
+        },
+        "country": {
+            "type": ["string", "null"],
+            "description": "Journal country of publication."
+        },
+        "year": {
+            "type": ["integer", "null"],
+            "description": "Publication year.",
+            "minimum": 1800,
+            "maximum": 2100
+        },
+        "pub_month": {
+            "type": ["integer", "null"],
+            "description": "Publication month.",
+            "minimum": 1,
+            "maximum": 12
+        },
+        "pub_day": {
+            "type": ["integer", "null"],
+            "description": "Publication day.",
+            "minimum": 1,
+            "maximum": 31
+        },
+        "publication_date": {
+            "type": ["string", "null"],
+            "description": "Publication date (YYYY-MM-DD).",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+        },
+        "medline_pgn": {
+            "type": ["string", "null"],
+            "description": "Page numbers (MEDLINE format)."
+        },
+        "publication_status": {
+            "type": ["string", "null"],
+            "description": "Publication status.",
+            "enum": ["ppublish", "epublish", "aheadofprint", null]
+        },
+        "publication_type_list": {
+            "type": ["string", "null"],
+            "description": "JSON array of publication types."
+        },
+        "doc_type": {
+            "type": ["string", "null"],
+            "description": "Document type classification."
+        },
+        "date_completed": {
+            "type": ["string", "null"],
+            "description": "MEDLINE processing completion date.",
+            "format": "date"
+        },
+        "date_revised": {
+            "type": ["string", "null"],
+            "description": "Record revision date.",
+            "format": "date"
+        },
+        "citation_subset": {
+            "type": ["string", "null"],
+            "description": "Citation subset codes (e.g., 'AIM')."
+        },
+        "citation_count": {
+            "type": ["integer", "null"],
+            "description": "Number of citations.",
+            "minimum": 0
+        },
+        "is_oa": {
+            "type": ["boolean", "null"],
+            "description": "Is Open Access."
+        },
+        "author_count": {
+            "type": ["integer", "null"],
+            "description": "Number of authors.",
+            "minimum": 0
+        },
+        "mesh_heading_count": {
+            "type": ["integer", "null"],
+            "description": "Number of MeSH headings.",
+            "minimum": 0
+        },
+        "keyword_count": {
+            "type": ["integer", "null"],
+            "description": "Number of keywords.",
+            "minimum": 0
+        },
+        "grant_count": {
+            "type": ["integer", "null"],
+            "description": "Number of grants.",
+            "minimum": 0
+        },
+        "reference_count": {
+            "type": ["integer", "null"],
+            "description": "Number of references.",
+            "minimum": 0
+        },
+        "chemical_count": {
+            "type": ["integer", "null"],
+            "description": "Number of chemicals.",
+            "minimum": 0
+        },
+        "_lookup_method": {
+            "type": ["string", "null"],
+            "description": "How record was resolved.",
+            "enum": ["direct", "doi", "pmid", "title_fallback", "title_only", "unknown", null]
+        },
+        "_original_id": {
+            "type": ["string", "null"],
+            "description": "Original identifier from input (for fallback records)."
+        },
+        "source": {
+            "type": ["string", "null"],
+            "description": "Data source identifier.",
+            "const": "pubmed"
+        },
+        "_source_batch_id": {
+            "type": "string",
+            "description": "Internal ID linking to the source Bronze batch for lineage.",
+            "format": "uuid"
+        },
+        "_content_hash": {
+            "type": "string",
+            "description": "SHA-256 hash of the record's content for versioning and deduplication."
+        },
+        "_ingestion_ts": {
+            "type": "string",
+            "format": "date-time",
+            "description": "UTC timestamp of when the record was ingested."
+        }
+    },
+    "required": [
+        "pmid",
+        "title",
+        "_content_hash",
+        "_ingestion_ts"
+    ]
+}

--- a/docs/contracts/gold/target_component_v1.0.json
+++ b/docs/contracts/gold/target_component_v1.0.json
@@ -1,0 +1,57 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$version": "1.0.0",
+    "title": "Target Component Data Contract",
+    "description": "Defines the schema for the gold 'TargetComponent' entity, aligned with RULES.md §7.1. This contract is for data consumers. Links targets to their component sequences.",
+    "type": "object",
+    "properties": {
+        "targcomp_id": {
+            "type": "integer",
+            "description": "Primary key."
+        },
+        "tid": {
+            "type": "integer",
+            "description": "FK to target (internal ChEMBL target ID)."
+        },
+        "component_id": {
+            "type": "integer",
+            "description": "FK to component_sequences table."
+        },
+        "relationship": {
+            "type": ["string", "null"],
+            "description": "Relationship type between target and component.",
+            "enum": ["SINGLE PROTEIN", "PROTEIN SUBUNIT", "RNA", "INTERACTING PROTEIN", null]
+        },
+        "stoichiometry": {
+            "type": ["integer", "null"],
+            "description": "Stoichiometry of the component in the target complex.",
+            "minimum": 1
+        },
+        "homologue": {
+            "type": ["integer", "null"],
+            "description": "Homologue flag (0 = exact, 1 = ortholog, 2 = paralog).",
+            "enum": [0, 1, 2, null]
+        },
+        "_source_batch_id": {
+            "type": "string",
+            "description": "Internal ID linking to the source Bronze batch for lineage.",
+            "format": "uuid"
+        },
+        "_content_hash": {
+            "type": "string",
+            "description": "SHA-256 hash of the record's content for versioning and deduplication."
+        },
+        "_ingestion_ts": {
+            "type": "string",
+            "format": "date-time",
+            "description": "UTC timestamp of when the record was ingested."
+        }
+    },
+    "required": [
+        "targcomp_id",
+        "tid",
+        "component_id",
+        "_content_hash",
+        "_ingestion_ts"
+    ]
+}

--- a/docs/contracts/gold/uniprot_idmapping_v1.0.json
+++ b/docs/contracts/gold/uniprot_idmapping_v1.0.json
@@ -1,0 +1,60 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$version": "1.0.0",
+    "title": "UniProt ID Mapping (Isoform) Data Contract",
+    "description": "Defines the schema for the gold 'UniProtIdMapping' entity, aligned with RULES.md §7.1. This contract is for data consumers. Alternative protein isoforms from alternative splicing.",
+    "type": "object",
+    "properties": {
+        "accession": {
+            "type": "string",
+            "description": "FK to parent protein accession."
+        },
+        "isoform_id": {
+            "type": "string",
+            "description": "Isoform accession (PK, e.g., P12345-2)."
+        },
+        "isoform_name": {
+            "type": ["string", "null"],
+            "description": "Isoform name."
+        },
+        "sequence_status": {
+            "type": ["string", "null"],
+            "description": "Sequence display status.",
+            "enum": ["displayed", "described", "not described", "external", null]
+        },
+        "sequence": {
+            "type": ["string", "null"],
+            "description": "Isoform amino acid sequence.",
+            "pattern": "^[ACDEFGHIKLMNPQRSTVWY]+$"
+        },
+        "sequence_length": {
+            "type": ["integer", "null"],
+            "description": "Isoform sequence length.",
+            "minimum": 1
+        },
+        "note": {
+            "type": ["string", "null"],
+            "description": "Isoform description/note."
+        },
+        "_source_batch_id": {
+            "type": "string",
+            "description": "Internal ID linking to the source Bronze batch for lineage.",
+            "format": "uuid"
+        },
+        "_content_hash": {
+            "type": "string",
+            "description": "SHA-256 hash of the record's content for versioning and deduplication."
+        },
+        "_ingestion_ts": {
+            "type": "string",
+            "format": "date-time",
+            "description": "UTC timestamp of when the record was ingested."
+        }
+    },
+    "required": [
+        "accession",
+        "isoform_id",
+        "_content_hash",
+        "_ingestion_ts"
+    ]
+}

--- a/docs/contracts/gold/uniprot_protein_v1.0.json
+++ b/docs/contracts/gold/uniprot_protein_v1.0.json
@@ -1,0 +1,263 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$version": "1.0.0",
+    "title": "UniProt Protein Data Contract",
+    "description": "Defines the schema for the gold 'UniProtProtein' entity, aligned with RULES.md §7.1. This contract is for data consumers. Comprehensive protein information from UniProtKB.",
+    "type": "object",
+    "properties": {
+        "accession": {
+            "type": "string",
+            "description": "UniProt primary accession (PK).",
+            "pattern": "^[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}$"
+        },
+        "entry_name": {
+            "type": "string",
+            "description": "Entry name (e.g., MK01_HUMAN).",
+            "pattern": "^\\w+_\\w+$"
+        },
+        "entry_type": {
+            "type": ["string", "null"],
+            "description": "Entry type (Swiss-Prot reviewed / TrEMBL unreviewed).",
+            "enum": [
+                "UniProtKB reviewed (Swiss-Prot)",
+                "UniProtKB unreviewed (TrEMBL)",
+                null
+            ]
+        },
+        "secondary_accessions": {
+            "type": ["string", "null"],
+            "description": "JSON array of secondary accessions."
+        },
+        "protein_name": {
+            "type": ["string", "null"],
+            "description": "Recommended protein name."
+        },
+        "protein_short_names": {
+            "type": ["string", "null"],
+            "description": "JSON array of short names."
+        },
+        "protein_alternative_names": {
+            "type": ["string", "null"],
+            "description": "JSON array of alternative protein names."
+        },
+        "protein_ec_numbers": {
+            "type": ["string", "null"],
+            "description": "JSON array of EC numbers."
+        },
+        "flag": {
+            "type": ["string", "null"],
+            "description": "Protein sequence completeness flag.",
+            "enum": ["Fragment", "Precursor", "Fragments", null]
+        },
+        "gene_primary": {
+            "type": ["string", "null"],
+            "description": "Primary gene name."
+        },
+        "gene_synonyms": {
+            "type": ["string", "null"],
+            "description": "JSON array of gene synonyms."
+        },
+        "gene_orf_names": {
+            "type": ["string", "null"],
+            "description": "JSON array of ORF names."
+        },
+        "organism_scientific": {
+            "type": ["string", "null"],
+            "description": "Scientific organism name."
+        },
+        "organism_common": {
+            "type": ["string", "null"],
+            "description": "Common organism name."
+        },
+        "taxonomy_id": {
+            "type": ["integer", "null"],
+            "description": "NCBI Taxonomy ID.",
+            "minimum": 1
+        },
+        "lineage": {
+            "type": ["string", "null"],
+            "description": "JSON array of taxonomic lineage."
+        },
+        "protein_existence": {
+            "type": ["string", "null"],
+            "description": "Evidence level for existence.",
+            "enum": [
+                "Evidence at protein level",
+                "Evidence at transcript level",
+                "Inferred from homology",
+                "Predicted",
+                "Uncertain",
+                null
+            ]
+        },
+        "annotation_score": {
+            "type": ["integer", "null"],
+            "description": "Annotation quality (1-5 stars).",
+            "minimum": 1,
+            "maximum": 5
+        },
+        "reviewed": {
+            "type": "boolean",
+            "description": "Swiss-Prot (true) vs TrEMBL (false)."
+        },
+        "sequence": {
+            "type": "string",
+            "description": "Amino acid sequence.",
+            "pattern": "^[ACDEFGHIKLMNPQRSTVWY]+$"
+        },
+        "sequence_length": {
+            "type": "integer",
+            "description": "Sequence length.",
+            "minimum": 1
+        },
+        "sequence_mass": {
+            "type": ["integer", "null"],
+            "description": "Molecular mass (Da).",
+            "minimum": 1
+        },
+        "sequence_checksum": {
+            "type": ["string", "null"],
+            "description": "CRC64 checksum."
+        },
+        "sequence_modified": {
+            "type": ["string", "null"],
+            "description": "Sequence last modified date.",
+            "format": "date"
+        },
+        "entry_version": {
+            "type": ["integer", "null"],
+            "description": "Entry version number.",
+            "minimum": 1
+        },
+        "entry_created": {
+            "type": ["string", "null"],
+            "description": "Entry creation date.",
+            "format": "date"
+        },
+        "entry_modified": {
+            "type": ["string", "null"],
+            "description": "Entry last modified date.",
+            "format": "date"
+        },
+        "function_comment": {
+            "type": ["string", "null"],
+            "description": "JSON array of function descriptions."
+        },
+        "catalytic_activity": {
+            "type": ["string", "null"],
+            "description": "JSON array of catalytic reactions."
+        },
+        "activity_regulation": {
+            "type": ["string", "null"],
+            "description": "JSON array of activity regulation info."
+        },
+        "subunit": {
+            "type": ["string", "null"],
+            "description": "JSON array of subunit structure info."
+        },
+        "pathway": {
+            "type": ["string", "null"],
+            "description": "JSON array of pathways."
+        },
+        "subcellular_location": {
+            "type": ["string", "null"],
+            "description": "JSON array of subcellular locations."
+        },
+        "tissue_specificity": {
+            "type": ["string", "null"],
+            "description": "Tissue expression pattern."
+        },
+        "alternative_products": {
+            "type": ["string", "null"],
+            "description": "JSON array of alternative splicing/isoforms."
+        },
+        "disease_involvement": {
+            "type": ["string", "null"],
+            "description": "JSON array of disease associations."
+        },
+        "pharmaceutical_use": {
+            "type": ["string", "null"],
+            "description": "Pharmaceutical applications."
+        },
+        "similarity_comment": {
+            "type": ["string", "null"],
+            "description": "Family and domain information."
+        },
+        "caution": {
+            "type": ["string", "null"],
+            "description": "Warnings about this entry."
+        },
+        "go_terms": {
+            "type": ["string", "null"],
+            "description": "JSON array of GO terms with evidence codes."
+        },
+        "drugbank_ids": {
+            "type": ["string", "null"],
+            "description": "JSON array of DrugBank identifiers."
+        },
+        "chembl_ids": {
+            "type": ["string", "null"],
+            "description": "JSON array of ChEMBL target identifiers."
+        },
+        "guidetopharmacology_ids": {
+            "type": ["string", "null"],
+            "description": "JSON array of Guide to Pharmacology identifiers."
+        },
+        "features": {
+            "type": ["string", "null"],
+            "description": "JSON array of sequence features."
+        },
+        "keywords": {
+            "type": ["string", "null"],
+            "description": "JSON array of UniProt keywords."
+        },
+        "cross_reference_count": {
+            "type": ["integer", "null"],
+            "description": "Number of database cross-references.",
+            "minimum": 0
+        },
+        "feature_count": {
+            "type": ["integer", "null"],
+            "description": "Number of sequence features.",
+            "minimum": 0
+        },
+        "keyword_count": {
+            "type": ["integer", "null"],
+            "description": "Number of keywords.",
+            "minimum": 0
+        },
+        "publication_count": {
+            "type": ["integer", "null"],
+            "description": "Number of publications.",
+            "minimum": 0
+        },
+        "isoform_count": {
+            "type": ["integer", "null"],
+            "description": "Number of isoforms.",
+            "minimum": 0
+        },
+        "_source_batch_id": {
+            "type": "string",
+            "description": "Internal ID linking to the source Bronze batch for lineage.",
+            "format": "uuid"
+        },
+        "_content_hash": {
+            "type": "string",
+            "description": "SHA-256 hash of the record's content for versioning and deduplication."
+        },
+        "_ingestion_ts": {
+            "type": "string",
+            "format": "date-time",
+            "description": "UTC timestamp of when the record was ingested."
+        }
+    },
+    "required": [
+        "accession",
+        "entry_name",
+        "reviewed",
+        "sequence",
+        "sequence_length",
+        "_content_hash",
+        "_ingestion_ts"
+    ]
+}


### PR DESCRIPTION
Add JSON Schema Draft-07 data contracts for all Gold entities:

ChEMBL (7 new):
- assay_parameters_v1.0.json
- cell_line_v1.0.json
- compound_record_v1.0.json
- protein_classification_v1.0.json
- publication_similarity_v1.0.json
- publication_term_v1.0.json
- target_component_v1.0.json

UniProt (2 new):
- uniprot_protein_v1.0.json
- uniprot_idmapping_v1.0.json

PubChem (1 new):
- pubchem_compound_v1.0.json

PubMed (1 new):
- pubmed_publication_v1.0.json

All contracts follow the v1.0 format with:
- Full field definitions with types and constraints
- Pattern validation for identifiers (CHEMBL, UniProt accession, etc.)
- Required fields including _content_hash, _ingestion_ts
- Comprehensive descriptions aligned with RULES.md §7.1

Total contracts: 16 (covering all 19 pipeline configurations)