### PR TITLE
Standardize terminology in docstrings

### DIFF
--- a/src/bioetl/application/core/batch_transformer.py
+++ b/src/bioetl/application/core/batch_transformer.py
@@ -324,9 +324,9 @@ class StreamingBatchProcessor:
 
     Usage:
         >>> processor = StreamingBatchProcessor(transformer, memory_monitor)
-        >>> async for chunk in processor.process_in_chunks(records, batch_id, chunk_size=100):
-        ...     await writer.write_silver(chunk.silver_records, batch_id, ts)
-        ...     await writer.write_gold(chunk.gold_records)
+        >>> async for sub_batch in processor.process_in_chunks(records, batch_id, chunk_size=100):
+        ...     await writer.write_silver(sub_batch.silver_records, batch_id, ts)
+        ...     await writer.write_gold(sub_batch.gold_records)
 
     """
 
@@ -352,19 +352,19 @@ class StreamingBatchProcessor:
         chunk_size: int = 100,
         start_index: int = 0,
     ) -> AsyncIterator[TransformResult]:
-        """Process records in memory-efficient chunks.
+        """Process records in memory-efficient sub-batches.
 
-        Yields TransformResult for each chunk, allowing incremental
-        writes and garbage collection between chunks.
+        Yields TransformResult for each sub-batch, allowing incremental
+        writes and garbage collection between sub-batches.
 
         Args:
             records: All records to process.
             batch_id: Batch identifier.
-            chunk_size: Initial chunk size (may be reduced under memory pressure).
+            chunk_size: Initial sub-batch size (may be reduced under memory pressure).
             start_index: Starting index for the entire batch.
 
         Yields:
-            TransformResult for each processed chunk.
+            TransformResult for each processed sub-batch.
 
         """
         current_chunk_size = chunk_size
@@ -372,7 +372,7 @@ class StreamingBatchProcessor:
         total_records = len(records)
 
         while i < total_records:
-            # Adjust chunk size based on memory pressure
+            # Adjust sub-batch size based on memory pressure
             if self._memory_monitor:
                 current_chunk_size = self._memory_monitor.get_recommended_batch_size(
                     current_chunk_size
@@ -385,7 +385,7 @@ class StreamingBatchProcessor:
 
             yield result
 
-            # Advance by actual chunk size processed
+            # Advance by actual sub-batch size processed
             i += len(chunk)
 
     def iter_records(self, records: list[dict[str, Any]]) -> Iterator[dict[str, Any]]:

--- a/src/bioetl/application/core/memory_monitor.py
+++ b/src/bioetl/application/core/memory_monitor.py
@@ -79,7 +79,7 @@ class MemoryMonitor:
     Example:
         >>> monitor = MemoryMonitor(config=MemoryConfig(), logger=logger)
         >>> batch_size = 1000
-        >>> for chunk in data_source:
+        >>> for batch in data_source:
         ...     batch_size = monitor.get_recommended_batch_size(batch_size)
         ...     # Process with adjusted batch size
 

--- a/src/bioetl/domain/medallion.py
+++ b/src/bioetl/domain/medallion.py
@@ -21,7 +21,7 @@ class Layer(str, Enum):
 
     Attributes:
         BRONZE: Raw data layer (immutable, append-only).
-        SILVER: Cleansed/normalized data layer.
+        SILVER: Normalized and validated data layer.
         GOLD: Business-ready aggregated data layer.
     """
 

--- a/src/bioetl/domain/ports/observability.py
+++ b/src/bioetl/domain/ports/observability.py
@@ -147,7 +147,7 @@ class DQMonitorPort(Protocol):
     drops, and threshold breaches in pipeline metrics.
 
     Example:
-        Basic monitoring workflow in a pipeline::
+        Basic monitoring in a pipeline::
 
             # DataQualityMonitor is injected via composition layer
             # (see: infrastructure.observability.anomaly.DataQualityMonitor)


### PR DESCRIPTION
Align docstrings with Ubiquitous Language defined in glossary.md v2.0:

- observability.py: Replace 'workflow' with 'pipeline'
- medallion.py: Replace 'Cleansed/normalized' with 'Normalized and validated' for Silver layer description
- batch_transformer.py: Replace 'chunk' with 'sub-batch' in StreamingBatchProcessor docstrings and comments (variable names kept for API stability)
- memory_monitor.py: Replace 'chunk' with 'batch' in example docstring

References: glossary.md, ADR-024