### PR TITLE
Audit and fix pipeline config alignment

### DIFF
--- a/configs/pipelines/chembl/assay_parameters.yaml
+++ b/configs/pipelines/chembl/assay_parameters.yaml
@@ -44,12 +44,14 @@ sink:
     partition_by: ["type"]
     sort_by:
       columns: ["assay_param_id"]
+      ascending: true
     csv_export:
       path: "data/output/silver/chembl/assay_parameters"
   gold:
     path: "data/output/gold/chembl/assay_parameters"
     sort_by:
       columns: ["assay_param_id"]
+      ascending: true
     csv_export:
       path: "data/output/gold/chembl/assay_parameters"
 

--- a/configs/pipelines/chembl/cell_line.yaml
+++ b/configs/pipelines/chembl/cell_line.yaml
@@ -42,12 +42,14 @@ sink:
     primary_key: ["cell_chembl_id"]
     sort_by:
       columns: ["cell_chembl_id"]
+      ascending: true
     csv_export:
       path: "data/output/silver/chembl/cell_line"
   gold:
     path: "data/output/gold/chembl/cell_line"
     sort_by:
       columns: ["cell_chembl_id", "cell_name"]
+      ascending: true
     csv_export:
       path: "data/output/gold/chembl/cell_line"
 

--- a/configs/pipelines/chembl/compound_record.yaml
+++ b/configs/pipelines/chembl/compound_record.yaml
@@ -45,12 +45,14 @@ sink:
     primary_key: ["record_id"]
     sort_by:
       columns: ["record_id"]
+      ascending: true
     csv_export:
       path: "data/output/silver/chembl/compound_record"
   gold:
     path: "data/output/gold/chembl/compound_record"
     sort_by:
       columns: ["molecule_chembl_id", "document_chembl_id", "record_id"]
+      ascending: true
     csv_export:
       path: "data/output/gold/chembl/compound_record"
 

--- a/configs/pipelines/chembl/molecule.yaml
+++ b/configs/pipelines/chembl/molecule.yaml
@@ -103,12 +103,14 @@ sink:
     partition_by: ["molecule_type"]
     sort_by:
       columns: ["molecule_chembl_id"]
+      ascending: true
     csv_export:
       path: "data/output/silver/chembl/molecule"
   gold:
     path: "data/output/gold/chembl/molecule"
     sort_by:
       columns: ["molecule_chembl_id"]
+      ascending: true
     csv_export:
       path: "data/output/gold/chembl/molecule"
 

--- a/configs/pipelines/chembl/protein_class.yaml
+++ b/configs/pipelines/chembl/protein_class.yaml
@@ -48,12 +48,14 @@ sink:
     partition_by: ["class_level"]
     sort_by:
       columns: ["protein_class_id"]
+      ascending: true
     csv_export:
       path: "data/output/silver/chembl/protein_class"
   gold:
     path: "data/output/gold/chembl/protein_class"
     sort_by:
       columns: ["class_level", "sort_order", "protein_class_id"]
+      ascending: true
     csv_export:
       path: "data/output/gold/chembl/protein_class"
 

--- a/configs/pipelines/chembl/publication.yaml
+++ b/configs/pipelines/chembl/publication.yaml
@@ -46,6 +46,7 @@ sink:
     partition_by: ["doc_type"]
     sort_by:
       columns: ["document_chembl_id"]
+      ascending: true
     csv_export:
       path: "data/output/silver/chembl/publication"
     dq_report:
@@ -55,6 +56,7 @@ sink:
     path: "data/output/gold/chembl/publication"
     sort_by:
       columns: ["document_chembl_id"]
+      ascending: true
     csv_export:
       path: "data/output/gold/chembl/publication"
     dq_report:

--- a/configs/pipelines/chembl/publication_similarity.yaml
+++ b/configs/pipelines/chembl/publication_similarity.yaml
@@ -44,12 +44,14 @@ sink:
     partition_by: []  # No good partition key
     sort_by:
       columns: ["sim_id"]
+      ascending: true
     csv_export:
       path: "data/output/silver/chembl/document_similarity"
   gold:
     path: "data/output/gold/chembl/document_similarity"
     sort_by:
       columns: ["sim_id"]
+      ascending: true
     csv_export:
       path: "data/output/gold/chembl/document_similarity"
 

--- a/configs/pipelines/chembl/publication_term.yaml
+++ b/configs/pipelines/chembl/publication_term.yaml
@@ -47,12 +47,14 @@ sink:
     partition_by: ["term_type"]
     sort_by:
       columns: ["entity_id"]
+      ascending: true
     csv_export:
       path: "data/output/silver/chembl/document_term"
   gold:
     path: "data/output/gold/chembl/document_term"
     sort_by:
       columns: ["entity_id"]
+      ascending: true
     csv_export:
       path: "data/output/gold/chembl/document_term"
 

--- a/configs/pipelines/chembl/target.yaml
+++ b/configs/pipelines/chembl/target.yaml
@@ -74,12 +74,14 @@ sink:
     partition_by: ["target_type"]
     sort_by:
       columns: ["target_chembl_id"]
+      ascending: true
     csv_export:
       path: "data/output/silver/chembl/target"
   gold:
     path: "data/output/gold/chembl/target"
     sort_by:
       columns: ["target_chembl_id", "pref_name"]
+      ascending: true
     csv_export:
-      path: "data/output/2gold/chembl/target"
+      path: "data/output/gold/chembl/target"
 

--- a/configs/pipelines/chembl/target_component.yaml
+++ b/configs/pipelines/chembl/target_component.yaml
@@ -43,12 +43,14 @@ sink:
     partition_by: ["organism"]
     sort_by:
       columns: ["component_id"]
+      ascending: true
     csv_export:
       path: "data/output/silver/chembl/target_component"
   gold:
     path: "data/output/gold/chembl/target_component"
     sort_by:
       columns: ["component_id"]
+      ascending: true
     csv_export:
       path: "data/output/gold/chembl/target_component"
 

--- a/configs/pipelines/crossref/publication.yaml
+++ b/configs/pipelines/crossref/publication.yaml
@@ -43,12 +43,14 @@ sink:
     primary_key: ["doi"]
     sort_by:
       columns: ["doi"]
+      ascending: true
     csv_export:
       path: "data/output/silver/crossref/"
   gold:
     path: "data/output/gold/crossref/"
     sort_by:
       columns: ["doi"]
+      ascending: true
     csv_export:
       path: "data/output/gold/crossref/"
 

--- a/configs/pipelines/openalex/publication.yaml
+++ b/configs/pipelines/openalex/publication.yaml
@@ -51,12 +51,14 @@ sink:
     partition_by: ["year"]
     sort_by:
       columns: ["openalex_id"]
+      ascending: true
     csv_export:
       path: "data/output/silver/openalex/publication"
   gold:
     path: "data/output/gold/openalex/publication"
     sort_by:
       columns: ["openalex_id"]
+      ascending: true
     csv_export:
       path: "data/output/gold/openalex/publication"
 

--- a/configs/pipelines/pubchem/compound.yaml
+++ b/configs/pipelines/pubchem/compound.yaml
@@ -103,12 +103,14 @@ sink:
     partition_by: ["batch_date"]
     sort_by:
       columns: ["cid"]
+      ascending: true
     csv_export:
       path: "data/output/silver/pubchem/compound"
   gold:
     path: "data/output/gold/pubchem/compound"
     sort_by:
       columns: ["cid"]
+      ascending: true
     csv_export:
       path: "data/output/gold/pubchem/compound"
 

--- a/configs/pipelines/semanticscholar/publication.yaml
+++ b/configs/pipelines/semanticscholar/publication.yaml
@@ -46,12 +46,14 @@ sink:
     partition_by: ["year"]
     sort_by:
       columns: ["paper_id"]
+      ascending: true
     csv_export:
       path: "data/output/silver/semanticscholar/publication"
   gold:
     path: "data/output/gold/semanticscholar/publication"
     sort_by:
       columns: ["paper_id"]
+      ascending: true
     csv_export:
       path: "data/output/gold/semanticscholar/publication"
 

--- a/configs/pipelines/uniprot/idmapping.yaml
+++ b/configs/pipelines/uniprot/idmapping.yaml
@@ -69,12 +69,14 @@ sink:
     partition_by: []  # No partitioning - small dataset
     sort_by:
       columns: ["target_chembl_id"]
+      ascending: true
     csv_export:
       path: "data/output/silver/uniprot/idmapping"
   gold:
     path: "data/output/gold/uniprot/idmapping"
     sort_by:
       columns: ["target_chembl_id"]
+      ascending: true
     csv_export:
       path: "data/output/gold/uniprot/idmapping"
 

--- a/reports/config_alignment_report.json
+++ b/reports/config_alignment_report.json
@@ -1,0 +1,37 @@
+{
+  "date": "2026-01-21T10:12:00.017209",
+  "total_configs": 20,
+  "configs_with_issues": 0,
+  "total_issues": 0,
+  "issues_by_file": {},
+  "intentional_differences": [
+    {
+      "file": "chembl/publication.yaml",
+      "reason": "pipeline_name 'chembl_publication' differs from entity_type 'document' - API endpoint mapping"
+    },
+    {
+      "file": "chembl/publication_similarity.yaml",
+      "reason": "pipeline_name 'chembl_publication_similarity' differs from entity_type 'document_similarity' - API endpoint mapping"
+    },
+    {
+      "file": "chembl/publication_term.yaml",
+      "reason": "pipeline_name 'chembl_publication_term' differs from entity_type 'document_term' - API endpoint mapping"
+    },
+    {
+      "file": "composite/publication.yaml",
+      "reason": "Composite pipeline (ADR-026) uses different schema structure"
+    },
+    {
+      "file": "crossref/publication.yaml",
+      "reason": "pipeline_name 'crossref_publication' differs from entity_type 'work' - API endpoint mapping"
+    },
+    {
+      "file": "pubmed/publications.yaml",
+      "reason": "pipeline_name 'pubmed_publications' differs from entity_type 'publication' - API endpoint mapping"
+    }
+  ],
+  "changes_made": [
+    "Fixed typo in chembl/target.yaml: 'data/output/2gold/chembl/target' -> 'data/output/gold/chembl/target'",
+    "Added 'ascending: true' to sort_by in 30 silver/gold layer configurations across 15 files (ADR-014 compliance)"
+  ]
+}


### PR DESCRIPTION
- Add ascending: true to sort_by in 30 silver/gold layer configurations across 15 entity configs (ADR-014 compliance for deterministic writes)
- Fix typo in chembl/target.yaml: 'data/output/2gold/...' -> 'data/output/gold/...'

Modified configs:
- chembl: assay_parameters, cell_line, compound_record, molecule, protein_class, publication, publication_similarity, publication_term, target, target_component
- crossref: publication
- openalex: publication
- pubchem: compound
- semanticscholar: publication
- uniprot: idmapping

All 20 pipeline configs now pass ADR-014 compliance validation.