### PR TITLE
Handle missing tests in BioETL project

### DIFF
--- a/tests/architecture/test_tracing_enforcement.py
+++ b/tests/architecture/test_tracing_enforcement.py
@@ -329,7 +329,8 @@ class TestTracingConfiguration:
 
     def test_tracing_in_settings(self):
         """Settings should have tracing configuration options."""
-        settings_path = Path("src/bioetl/infrastructure/config.py")
+        # RuntimeConfig is in infrastructure/config/_base.py
+        settings_path = Path("src/bioetl/infrastructure/config/_base.py")
 
         if not settings_path.exists():
             pytest.skip("Settings not found")
@@ -338,7 +339,7 @@ class TestTracingConfiguration:
 
         # Should have tracing-related settings or at least mention it
         # May be optional (via OTEL env vars)
-        any(
+        has_tracing_config = any(
             pattern in source
             for pattern in [
                 "tracing",
@@ -349,9 +350,8 @@ class TestTracingConfiguration:
             ]
         )
 
-        # Tracing config might be via environment variables only
-        # which is valid, so just verify settings exist
-        assert Path(settings_path).exists()
+        # Verify tracing configuration is present
+        assert has_tracing_config, "Settings should contain tracing configuration"
 
 
 class TestMandatorySpans:

--- a/tests/e2e/test_chembl_publication_e2e.py
+++ b/tests/e2e/test_chembl_publication_e2e.py
@@ -150,7 +150,9 @@ def vcr_config() -> dict[str, Any]:
 @pytest.mark.vcr
 @pytest.mark.asyncio
 @pytest.mark.skip(
-    reason="VCR cassette needs re-recording: batching mismatch after filter config changes"
+    reason="VCR cassette needs re-recording: pipeline now batches 100 IDs into 20-ID chunks, "
+    "but cassette expects all IDs in single request. Re-record with: "
+    "VCR_RECORD_MODE=new_episodes pytest tests/e2e/test_chembl_publication_e2e.py -v"
 )
 async def test_chembl_publication_full_cycle(e2e_data_dir: Path):
     """E2E: ChEMBL Publication pipeline from fetch to Silver.
@@ -194,7 +196,9 @@ async def test_chembl_publication_full_cycle(e2e_data_dir: Path):
 @pytest.mark.vcr
 @pytest.mark.asyncio
 @pytest.mark.skip(
-    reason="VCR cassette needs re-recording: batching mismatch after filter config changes"
+    reason="VCR cassette needs re-recording: pipeline now batches 100 IDs into 20-ID chunks, "
+    "but cassette expects all IDs in single request. Re-record with: "
+    "VCR_RECORD_MODE=new_episodes pytest tests/e2e/test_chembl_publication_e2e.py -v"
 )
 async def test_chembl_publication_metadata_fields(e2e_data_dir: Path):
     """E2E: Verify publication-related fields are extracted.


### PR DESCRIPTION
- Fix test_tracing_in_settings: update config path from src/bioetl/infrastructure/config.py to src/bioetl/infrastructure/config/_base.py (where RuntimeConfig lives)

- Improve skip messages for E2E publication tests: add clear instructions for re-recording VCR cassettes with VCR_RECORD_MODE=new_episodes

Summary of analyzed skipped tests (46 total):
- 29 Contract tests: Live API disabled (by design, P2)
- 13 Architecture tests: Schemas without DQ fields (by design, P3)
- 2 Architecture tests: Expected conditions (by design, P3)
- 2 E2E tests: VCR cassette mismatch (documented with instructions)