### PR TITLE
Unify Quarantine implementation in pipeline builder

### DIFF
--- a/src/bioetl/composition/_bootstrap/checkpoint.py
+++ b/src/bioetl/composition/_bootstrap/checkpoint.py
@@ -30,10 +30,13 @@ __all__ = [
 
 
 def bootstrap_quarantine() -> QuarantinePort:
-    """Bootstrap the quarantine service for CLI inspection."""
+    """Bootstrap the quarantine service for CLI inspection.
+
+    Uses centralized quarantine_path from settings (data_dir/quarantine)
+    for unified quarantine storage independent of entity paths.
+    """
     settings = get_settings()
-    base_path = str(settings.silver_path / "common" / "quarantine")
-    return UnifiedQuarantine(base_path=base_path)
+    return UnifiedQuarantine(base_path=str(settings.quarantine_path))
 
 
 def bootstrap_checkpoint(pipeline_name: str) -> CheckpointPort:

--- a/src/bioetl/composition/factories/services_factory.py
+++ b/src/bioetl/composition/factories/services_factory.py
@@ -152,7 +152,7 @@ class BaseServicesFactory:
 
         lock = cls._create_lock()
         checkpoint = cls._create_checkpoint(storage_ctx)
-        quarantine = cls._create_quarantine(storage_ctx)
+        quarantine = cls._create_quarantine(settings)
 
         # Use provided tracer or fallback to NoOpTracing
         # Tracer should be created via bootstrap_tracer() for consistent configuration
@@ -196,13 +196,14 @@ class BaseServicesFactory:
         return LocalCheckpoint(base_path=storage_ctx.checkpoints_path)
 
     @staticmethod
-    def _create_quarantine(storage_ctx: StorageContext) -> QuarantinePort:
-        """Create local quarantine storage."""
-        silver_path = storage_ctx.silver_path
-        if isinstance(silver_path, str):
-            silver_path = Path(silver_path)
+    def _create_quarantine(settings: Settings) -> QuarantinePort:
+        """Create unified quarantine storage independent of entity paths.
+
+        Quarantine storage is centralized at data_dir/quarantine to avoid
+        coupling with Silver path structure and simplify management.
+        """
         return UnifiedQuarantine(
-            base_path=str(silver_path / "common" / "quarantine"),
+            base_path=str(settings.quarantine_path),
         )
 
     @staticmethod
@@ -210,6 +211,40 @@ class BaseServicesFactory:
         if settings.metrics_enabled:
             return PrometheusMetrics()
         return NoOpMetrics()
+
+    @staticmethod
+    def _get_output_root(
+        settings: Settings,
+        pipeline_config: PipelineYamlConfig,
+    ) -> Path:
+        """Derive output root from pipeline config or fall back to settings.
+
+        DQ reports should be written alongside the data. This method extracts
+        the output root from the bronze sink path configuration when available.
+
+        For paths like 'data/output/bronze/chembl/activity':
+        - parent = 'data/output/bronze/chembl'
+        - parent.parent = 'data/output/bronze'
+        - parent.parent.parent = 'data/output' (output root)
+
+        Args:
+            settings: Application settings.
+            pipeline_config: Pipeline YAML configuration.
+
+        Returns:
+            Path to the output root directory.
+        """
+        bronze_config = pipeline_config.sink.get("bronze")
+
+        # Use bronze path from config if available and not in test mode
+        if not settings.test_mode and bronze_config and bronze_config.path:
+            bronze_path = Path(bronze_config.path)
+            # Go up 3 levels: bronze/provider/entity -> output root
+            # e.g., data/output/bronze/chembl/activity -> data/output
+            return bronze_path.parent.parent.parent
+
+        # Fall back to settings data_dir
+        return settings.data_dir
 
     @classmethod
     def _create_dq_services(
@@ -239,9 +274,10 @@ class BaseServicesFactory:
         silver_analyzer = DQServicesFactory.create_silver_analyzer()
         gold_analyzer = DQServicesFactory.create_gold_analyzer()
 
-        # Create report writer with data directory from settings
+        # DQ reports should be written alongside the data
+        output_root = cls._get_output_root(settings, pipeline_config)
         report_writer = DQServicesFactory.create_report_writer(
-            base_path=settings.data_dir,
+            base_path=output_root,
             logger=logger,
         )
 

--- a/tests/unit/composition/bootstrap/test_checkpoint_bootstrap.py
+++ b/tests/unit/composition/bootstrap/test_checkpoint_bootstrap.py
@@ -37,7 +37,9 @@ class TestBootstrapQuarantine:
         with patch(
             "bioetl.composition._bootstrap.checkpoint.get_settings"
         ) as mock_settings:
-            mock_settings.return_value = MagicMock(silver_path=Path("/tmp/silver"))
+            mock_settings.return_value = MagicMock(
+                quarantine_path=Path("/tmp/quarantine")
+            )
             result = bootstrap_quarantine()
 
         assert isinstance(result, QuarantinePort)
@@ -48,13 +50,15 @@ class TestBootstrapQuarantine:
         with patch(
             "bioetl.composition._bootstrap.checkpoint.get_settings"
         ) as mock_settings:
-            mock_settings.return_value = MagicMock(silver_path=Path("/custom/silver"))
+            mock_settings.return_value = MagicMock(
+                quarantine_path=Path("/custom/quarantine")
+            )
             result = bootstrap_quarantine()
 
         # Verify it's a valid UnifiedQuarantine instance with correct path
         assert isinstance(result, UnifiedQuarantine)
-        # Use Path for cross-platform comparison (Windows uses backslashes)
-        assert Path(result.base_path).match("*/common/quarantine")
+        # Now uses centralized quarantine_path from settings
+        assert result.base_path == "/custom/quarantine"
 
 
 @pytest.mark.unit
@@ -108,7 +112,9 @@ class TestBootstrapQuarantineManager:
         with patch(
             "bioetl.composition._bootstrap.checkpoint.get_settings"
         ) as mock_settings:
-            mock_settings.return_value = MagicMock(silver_path=Path("/tmp/silver"))
+            mock_settings.return_value = MagicMock(
+                quarantine_path=Path("/tmp/quarantine")
+            )
             result = bootstrap_quarantine_manager("test_pipeline")
 
         assert isinstance(result, QuarantineManager)
@@ -118,7 +124,9 @@ class TestBootstrapQuarantineManager:
         with patch(
             "bioetl.composition._bootstrap.checkpoint.get_settings"
         ) as mock_settings:
-            mock_settings.return_value = MagicMock(silver_path=Path("/tmp/silver"))
+            mock_settings.return_value = MagicMock(
+                quarantine_path=Path("/tmp/quarantine")
+            )
             result = bootstrap_quarantine_manager("chembl_activity")
 
         assert result._pipeline_name == "chembl_activity"
@@ -128,7 +136,9 @@ class TestBootstrapQuarantineManager:
         with patch(
             "bioetl.composition._bootstrap.checkpoint.get_settings"
         ) as mock_settings:
-            mock_settings.return_value = MagicMock(silver_path=Path("/tmp/silver"))
+            mock_settings.return_value = MagicMock(
+                quarantine_path=Path("/tmp/quarantine")
+            )
             result = bootstrap_quarantine_manager("test_pipeline")
 
         # QuarantineManager uses _quarantine attribute
@@ -254,7 +264,9 @@ class TestBootstrapQuarantineService:
         with patch(
             "bioetl.composition._bootstrap.checkpoint.get_settings"
         ) as mock_settings:
-            mock_settings.return_value = MagicMock(silver_path=Path("/tmp/silver"))
+            mock_settings.return_value = MagicMock(
+                quarantine_path=Path("/tmp/quarantine")
+            )
             result = bootstrap_quarantine_service()
 
         assert isinstance(result, QuarantineService)
@@ -264,7 +276,9 @@ class TestBootstrapQuarantineService:
         with patch(
             "bioetl.composition._bootstrap.checkpoint.get_settings"
         ) as mock_settings:
-            mock_settings.return_value = MagicMock(silver_path=Path("/tmp/silver"))
+            mock_settings.return_value = MagicMock(
+                quarantine_path=Path("/tmp/quarantine")
+            )
             result = bootstrap_quarantine_service()
 
         # QuarantineService uses quarantine_port attribute (dataclass)


### PR DESCRIPTION
Phase 1: Unify quarantine storage
- Change _create_quarantine to use settings.quarantine_path instead of silver_path/common/quarantine
- Update bootstrap_quarantine to use centralized quarantine_path
- Quarantine storage is now independent of entity paths, simplifying management and discovery

Phase 2: Fix DQ reports base_path
- Add _get_output_root helper to derive output root from pipeline config
- DQ reports now written alongside data (e.g., data/output/dq_reports) instead of settings.data_dir
- Respects test mode by falling back to settings.data_dir

Updates related tests to mock quarantine_path instead of silver_path.