### PR TITLE
Fix DQ Report and Metadata for Silver layer

### DIFF
--- a/src/bioetl/application/services/__init__.py
+++ b/src/bioetl/application/services/__init__.py
@@ -29,6 +29,10 @@ from bioetl.application.services.config_service import (
     SettingsInfo,
 )
 from bioetl.application.services.data_quality_service import DataQualityService
+from bioetl.application.services.dq_metrics_calculator import (
+    DQMetricsCalculator,
+    DQMetricsInput,
+)
 from bioetl.application.services.dq_report_service import (
     DQReportContext,
     DQReportResult,
@@ -93,6 +97,8 @@ __all__ = [
     "ClearResult",
     "ColumnInfo",
     "ConfigService",
+    "DQMetricsCalculator",
+    "DQMetricsInput",
     "DQReportContext",
     "DQReportResult",
     "DQReportService",

--- a/src/bioetl/application/services/dq_metrics_calculator.py
+++ b/src/bioetl/application/services/dq_metrics_calculator.py
@@ -1,0 +1,116 @@
+"""Centralized DQ metrics calculation for Silver layer.
+
+Single Source of Truth for DQ metrics used by both:
+- SilverWriter (for _metadata.yaml)
+- SilverDQAnalyzer (for DQ Report)
+
+Implements REQ-DQ-001.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from bioetl.domain.value_objects.dq_metrics import BatchDQMetrics, SchemaDriftInfo
+
+
+@dataclass(frozen=True, slots=True)
+class DQMetricsInput:
+    """Input for DQ metrics calculation.
+
+    Attributes:
+        records: List of record dictionaries to analyze.
+        existing_schema_fields: Set of field names from existing table schema.
+            Used for schema drift detection. None if table doesn't exist.
+        quarantined_count: Number of records that failed validation.
+        validation_errors: List of validation error messages.
+    """
+
+    records: list[dict[str, Any]]
+    existing_schema_fields: set[str] | None = None
+    quarantined_count: int = 0
+    validation_errors: list[str] | None = None
+
+
+class DQMetricsCalculator:
+    """Calculator for Silver DQ metrics.
+
+    Provides unified calculation logic used by both
+    metadata writer and DQ report generator.
+
+    This class is stateless and thread-safe.
+    """
+
+    def calculate(self, input_data: DQMetricsInput) -> BatchDQMetrics:
+        """Calculate DQ metrics from records.
+
+        Args:
+            input_data: Records and context for calculation.
+
+        Returns:
+            BatchDQMetrics with computed statistics including:
+            - Column statistics (null rate, unique count, min/max/mean)
+            - Schema drift info
+            - Error/warning counts
+        """
+        schema_drift = self._detect_schema_drift(
+            input_data.records,
+            input_data.existing_schema_fields,
+        )
+
+        return BatchDQMetrics.from_records(
+            records=input_data.records,
+            error_count=input_data.quarantined_count,
+            warning_count=0,
+            validation_errors=input_data.validation_errors,
+            schema_drift=schema_drift,
+        )
+
+    def _detect_schema_drift(
+        self,
+        records: list[dict[str, Any]],
+        existing_fields: set[str] | None,
+    ) -> SchemaDriftInfo | None:
+        """Detect schema drift between existing and incoming schema.
+
+        Args:
+            records: Incoming records to check.
+            existing_fields: Field names from existing table schema.
+
+        Returns:
+            SchemaDriftInfo if drift detected, None otherwise.
+
+        Drift severity levels:
+        - critical: Missing required fields (non-underscore prefix)
+        - warn: More than 3 new fields
+        - info: Minor schema changes
+        """
+        if not existing_fields or not records:
+            return None
+
+        incoming_fields = set(records[0].keys())
+        new_fields = incoming_fields - existing_fields
+        missing_fields = existing_fields - incoming_fields
+
+        if not new_fields and not missing_fields:
+            return None
+
+        # Critical: missing required fields (business fields without underscore prefix)
+        critical_missing = [f for f in missing_fields if not f.startswith("_")]
+
+        if critical_missing:
+            status = "critical"
+        elif len(new_fields) > 3:
+            status = "warn"
+        else:
+            status = "info"
+
+        return SchemaDriftInfo(
+            status=status,
+            new_fields=tuple(sorted(new_fields)),
+            missing_fields=tuple(sorted(missing_fields)),
+        )
+
+
+__all__ = ["DQMetricsCalculator", "DQMetricsInput"]

--- a/src/bioetl/composition/services/metadata_coordinator.py
+++ b/src/bioetl/composition/services/metadata_coordinator.py
@@ -295,6 +295,7 @@ class MetadataCoordinator:
             dq_summary=dq_summary,
             output=output,
             environment=self._get_environment_metadata(),
+            dq_report_path=input_data.dq_report_path,
         )
 
     def create_gold_metadata(self, input_data: GoldMetadataInput) -> GoldMetadata:

--- a/src/bioetl/domain/models/metadata.py
+++ b/src/bioetl/domain/models/metadata.py
@@ -534,6 +534,11 @@ class SilverMetadata(BaseModel):
         default_factory=SilverOutputMetadata, description="Output metrics"
     )
     environment: EnvironmentMetadata = Field(description="Environment information")
+    # Cross-reference to DQ report
+    dq_report_path: str | None = Field(
+        default=None,
+        description="Path to corresponding DQ report file (if generated)",
+    )
 
 
 class GoldMetadata(BaseModel):

--- a/src/bioetl/domain/ports/metadata_coordinator.py
+++ b/src/bioetl/domain/ports/metadata_coordinator.py
@@ -63,6 +63,7 @@ class SilverMetadataInput:
         version_after: Delta table version after write.
         transform_version: Optional semver version of transform applied.
         transform_steps: Optional list of transform step names applied.
+        dq_report_path: Optional path to generated DQ report for cross-reference.
     """
 
     table_path: str
@@ -74,6 +75,7 @@ class SilverMetadataInput:
     version_after: int | None = None
     transform_version: str | None = None
     transform_steps: tuple[str, ...] | None = None
+    dq_report_path: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/bioetl/domain/value_objects/dq_report.py
+++ b/src/bioetl/domain/value_objects/dq_report.py
@@ -549,6 +549,7 @@ class SilverDQReport:
         checks: Dictionary of check type to result.
         thresholds: DQ threshold configuration.
         summary: Report summary.
+        metadata_path: Path to corresponding _metadata.yaml file (if generated).
     """
 
     layer: MedallionLayer
@@ -560,6 +561,8 @@ class SilverDQReport:
     checks: dict[str, Any]
     thresholds: DQThresholds
     summary: DQReportSummary
+    # Cross-reference to metadata
+    metadata_path: str | None = None
 
     def __post_init__(self) -> None:
         """Validate layer and convert lists."""

--- a/src/bioetl/infrastructure/export/dq_report_writer.py
+++ b/src/bioetl/infrastructure/export/dq_report_writer.py
@@ -108,16 +108,22 @@ class DQReportWriter:
         extension = self._get_extension(format)
 
         if output_path is None:
+            # Normalize target_table: replace '.' with '/' for directory structure
+            # This ensures 'chembl.activity' becomes 'chembl/activity'
+            normalized_table = report.target_table.replace(".", "/")
+
             if self._flat_structure:
                 # Flat: {base_path}/{table_name}_dq_report{ext}
+                # For flat structure, use underscore instead of slash
+                flat_table_name = report.target_table.replace(".", "_")
                 output_path = (
-                    self._base_path / f"{report.target_table}_dq_report{extension}"
+                    self._base_path / f"{flat_table_name}_dq_report{extension}"
                 )
             else:
                 # Nested: {base_path}/{table_name}/_dq_reports/{run_id}_dq_report{ext}
                 output_path = (
                     self._base_path
-                    / report.target_table
+                    / normalized_table
                     / self.DQ_REPORTS_DIR
                     / f"{report.run_id}_dq_report{extension}"
                 )
@@ -148,16 +154,22 @@ class DQReportWriter:
         extension = self._get_extension(format)
 
         if output_path is None:
+            # Normalize target_table: replace '.' with '/' for directory structure
+            # This ensures 'chembl.activity' becomes 'chembl/activity'
+            normalized_table = report.target_table.replace(".", "/")
+
             if self._flat_structure:
                 # Flat: {base_path}/{table_name}_dq_report{ext}
+                # For flat structure, use underscore instead of slash
+                flat_table_name = report.target_table.replace(".", "_")
                 output_path = (
-                    self._base_path / f"{report.target_table}_dq_report{extension}"
+                    self._base_path / f"{flat_table_name}_dq_report{extension}"
                 )
             else:
                 # Nested: {base_path}/{table_name}/_dq_reports/{run_id}_dq_report{ext}
                 output_path = (
                     self._base_path
-                    / report.target_table
+                    / normalized_table
                     / self.DQ_REPORTS_DIR
                     / f"{report.run_id}_dq_report{extension}"
                 )

--- a/src/bioetl/infrastructure/schemas/dq_report_config.py
+++ b/src/bioetl/infrastructure/schemas/dq_report_config.py
@@ -184,7 +184,8 @@ class BronzeSinkConfig(BaseModel):
 class SilverSinkConfig(BaseModel):
     """Silver sink configuration with optional DQ report.
 
-    Extends base silver sink config with DQ report generation.
+    Unified schema for Silver layer sink configuration.
+    Includes both metadata and DQ report settings.
     """
 
     path: str = Field(description="Base path for Silver data")
@@ -192,7 +193,18 @@ class SilverSinkConfig(BaseModel):
     mode: Literal["merge", "append", "overwrite"] = Field(default="merge")
     primary_key: list[str] = Field(default_factory=list)
     partition_by: list[str] = Field(default_factory=list)
+    # Metadata sidecar support
+    save_metadata: bool = Field(
+        default=False,
+        description="Save _metadata.yaml sidecar file with lineage and QC info",
+    )
+    # DQ report config
     dq_report: SilverDQReportConfig = Field(default_factory=SilverDQReportConfig)
+    # Schema drift handling
+    on_schema_mismatch: Literal["error", "evolve", "ignore"] = Field(
+        default="error",
+        description="How to handle schema drift",
+    )
 
 
 class GoldSinkConfig(BaseModel):

--- a/src/bioetl/infrastructure/storage/silver_writer.py
+++ b/src/bioetl/infrastructure/storage/silver_writer.py
@@ -647,33 +647,37 @@ class SilverWriter(BaseDeltaWriter):
         self,
         table_name: str,
         records: list[dict[str, Any]],
+        quarantined_count: int = 0,
     ) -> BatchDQMetrics:
-        """Compute DQ metrics for the batch of records.
-
-        Calculates column statistics, detects schema drift, and creates
-        a BatchDQMetrics value object for metadata persistence.
+        """Compute DQ metrics using centralized calculator.
 
         Args:
             table_name: Target table name for schema drift detection.
             records: List of records to analyze.
+            quarantined_count: Number of quarantined records.
 
         Returns:
             BatchDQMetrics with computed column stats and schema drift info.
         """
-        from bioetl.domain.value_objects.dq_metrics import BatchDQMetrics
-
-        # Detect schema drift (non-raising, for metrics only)
-        schema_drift = await self._detect_schema_drift(table_name, records)
-
-        # Create BatchDQMetrics with column statistics
-        # Currently all records passed validation (errors were quarantined earlier)
-        return BatchDQMetrics.from_records(
-            records=records,
-            error_count=0,  # Records here passed validation
-            warning_count=0,
-            validation_errors=None,
-            schema_drift=schema_drift,
+        from bioetl.application.services.dq_metrics_calculator import (
+            DQMetricsCalculator,
+            DQMetricsInput,
         )
+
+        # Get existing schema for drift detection
+        existing_schema = await self._get_table_schema(table_name)
+        existing_fields: set[str] | None = None
+        if existing_schema is not None:
+            existing_fields = set(existing_schema.names)
+
+        calculator = DQMetricsCalculator()
+        input_data = DQMetricsInput(
+            records=records,
+            existing_schema_fields=existing_fields,
+            quarantined_count=quarantined_count,
+        )
+
+        return calculator.calculate(input_data)
 
     async def _log_silver_audit(
         self,
@@ -777,6 +781,7 @@ class SilverWriter(BaseDeltaWriter):
         mode: SilverWriteMode,
         bronze_refs: list[BronzeWriteResult] | None = None,
         dq_metrics: BatchDQMetrics | None = None,
+        dq_report_path: str | None = None,
     ) -> None:
         """Write Silver layer metadata sidecar file.
 
@@ -792,6 +797,7 @@ class SilverWriter(BaseDeltaWriter):
             dq_metrics: Optional BatchDQMetrics with computed DQ metrics.
                 If provided, dq_summary will contain real column metrics,
                 schema drift info, and error rates (REQ-DQ-001).
+            dq_report_path: Optional path to generated DQ report for cross-reference.
         """
         if not records:
             return
@@ -802,161 +808,32 @@ class SilverWriter(BaseDeltaWriter):
         entity_name = path_parts[-1] if path_parts else "unknown"
         provider_name = path_parts[-2] if len(path_parts) > 1 else "unknown"
 
-        # Use MetadataCoordinator if available (centralized metadata)
-        if self._metadata_coordinator is not None:
-            from bioetl.domain.ports import SilverMetadataInput
-
-            # Get Delta version after write
-            version_after = await self._get_delta_version(table_path)
-
-            silver_input = SilverMetadataInput(
+        if self._metadata_coordinator is None:
+            self.logger.warning(
+                "silver_metadata_skipped",
+                reason="MetadataCoordinator not configured",
                 table_path=table_path,
-                records=records,
-                primary_keys=primary_keys,
-                mode=mode,
-                bronze_refs=bronze_refs,
-                dq_metrics=dq_metrics,
-                version_after=version_after,
-                transform_version=self._transform_version,
-                transform_steps=self._transform_steps,
-            )
-            metadata = self._metadata_coordinator.create_silver_metadata(silver_input)
-            await self._metadata_writer.write_silver_metadata(
-                table_path,
-                metadata,
-                table_name=table_name,
-                flat_structure=self._flat_structure,
-                provider=provider_name,
-                entity=entity_name,
             )
             return
 
-        # Fallback to local metadata building (backward compatibility)
-        from datetime import UTC, datetime
-        from importlib.metadata import version as pkg_version
-        from platform import node as hostname
-        from platform import python_version
-
-        from bioetl.domain.models.metadata import (
-            DeltaMetrics,
-            DQSummary,
-            EnvironmentMetadata,
-            LineageMetadata,
-            PipelineMetadata,
-            RuntimeMetadata,
-            RunTypeEnum,
-            SilverMetadata,
-            SilverOutputMetadata,
-        )
-
-        # Extract run context from first record
-        first_record = records[0]
-        run_id = first_record.get("_run_id", "")
-        run_type_str = first_record.get("_run_type", "incremental")
-
-        # Map run_type string to enum
-        try:
-            run_type = RunTypeEnum(run_type_str)
-        except ValueError:
-            run_type = RunTypeEnum.INCREMENTAL
+        from bioetl.domain.ports import SilverMetadataInput
 
         # Get Delta version after write
         version_after = await self._get_delta_version(table_path)
 
-        # Build runtime metadata
-        now = datetime.now(UTC)
-        runtime = RuntimeMetadata(
-            run_id=run_id,
-            run_type=run_type,
-            started_at_utc=now,
-            completed_at_utc=now,
-        )
-
-        # Use already extracted provider/entity from top of method
-        pipeline = PipelineMetadata(
-            name=f"{provider_name}_{entity_name}",
-            provider=provider_name,
-            entity=entity_name,
-        )
-
-        # Build lineage from records and bronze_refs
-        source_batch_ids = list(
-            {
-                r.get("_source_batch_id", "")
-                for r in records
-                if r.get("_source_batch_id")
-            }
-        )
-
-        # Extract bronze paths from bronze_refs for complete lineage (REQ-LINEAGE-001)
-        bronze_paths: list[str] = []
-        if bronze_refs:
-            bronze_paths = [ref.relative_path for ref in bronze_refs]
-
-        lineage = LineageMetadata(
-            source_batch_ids=source_batch_ids,
-            bronze_paths=bronze_paths,
-        )
-
-        # Build Delta metrics
-        # Map SilverWriteMode to DeltaMetrics operation (Literal type)
-        operation_map: dict[
-            SilverWriteMode, Literal["merge", "overwrite", "append"]
-        ] = {
-            SilverWriteMode.MERGE: "merge",
-            SilverWriteMode.APPEND: "append",
-            SilverWriteMode.DELETE: "overwrite",  # DELETE mode uses overwrite
-        }
-        delta = DeltaMetrics(
+        silver_input = SilverMetadataInput(
             table_path=table_path,
-            operation=operation_map[mode],
-            primary_key=primary_keys,
+            records=records,
+            primary_keys=primary_keys,
+            mode=mode,
+            bronze_refs=bronze_refs,
+            dq_metrics=dq_metrics,
             version_after=version_after,
-            rows_inserted=len(records),
+            transform_version=self._transform_version,
+            transform_steps=self._transform_steps,
+            dq_report_path=dq_report_path,
         )
-
-        # Build DQ summary from computed metrics or use basic fallback
-        if dq_metrics is not None:
-            # Use real DQ metrics with column stats, schema drift, error rates
-            dq_summary = dq_metrics.to_dq_summary()
-        else:
-            # Fallback to basic metrics (backward compatibility)
-            dq_summary = DQSummary(
-                total_records=len(records),
-                valid_records=len(records),
-            )
-
-        # Build output metrics
-        output = SilverOutputMetadata(
-            record_count=len(records),
-        )
-
-        # Build environment info
-        try:
-            bioetl_version = pkg_version("bioetl")
-        except Exception:
-            bioetl_version = "unknown"
-
-        environment = EnvironmentMetadata(
-            hostname=hostname(),
-            python_version=python_version(),
-            bioetl_version=bioetl_version,
-        )
-
-        # Build complete metadata
-        metadata = SilverMetadata(
-            runtime=runtime,
-            pipeline=pipeline,
-            lineage=lineage,
-            delta=delta,
-            dq_summary=dq_summary,
-            output=output,
-            environment=environment,
-        )
-
-        # Write metadata sidecar file
-        # Note: In fallback path, table_name is derived from table_path
-        # For flat_structure, use pipeline name as table_name
+        metadata = self._metadata_coordinator.create_silver_metadata(silver_input)
         await self._metadata_writer.write_silver_metadata(
             table_path,
             metadata,

--- a/tests/unit/application/services/test_dq_metrics_calculator.py
+++ b/tests/unit/application/services/test_dq_metrics_calculator.py
@@ -1,0 +1,223 @@
+"""Unit tests for DQMetricsCalculator."""
+
+from __future__ import annotations
+
+import pytest
+
+from bioetl.application.services.dq_metrics_calculator import (
+    DQMetricsCalculator,
+    DQMetricsInput,
+)
+from bioetl.domain.value_objects.dq_metrics import BatchDQMetrics, SchemaDriftInfo
+
+
+@pytest.fixture
+def sample_records():
+    """Create sample records for testing."""
+    return [
+        {"entity_id": "CHEMBL123", "value": 5.5, "name": "Test 1"},
+        {"entity_id": "CHEMBL456", "value": 7.2, "name": "Test 2"},
+        {"entity_id": "CHEMBL789", "value": None, "name": "Test 3"},
+    ]
+
+
+@pytest.mark.unit
+class TestDQMetricsCalculator:
+    """Tests for DQMetricsCalculator."""
+
+    def test_calculate_returns_batch_dq_metrics(self, sample_records):
+        """Test calculate returns BatchDQMetrics."""
+        calculator = DQMetricsCalculator()
+        input_data = DQMetricsInput(records=sample_records)
+
+        result = calculator.calculate(input_data)
+
+        assert isinstance(result, BatchDQMetrics)
+        assert result.total_records == 3
+        assert result.valid_records == 3
+
+    def test_calculate_with_quarantined_count(self, sample_records):
+        """Test calculate with quarantined_count."""
+        calculator = DQMetricsCalculator()
+        input_data = DQMetricsInput(
+            records=sample_records,
+            quarantined_count=2,
+        )
+
+        result = calculator.calculate(input_data)
+
+        assert result.error_records == 2
+
+    def test_calculate_with_validation_errors(self, sample_records):
+        """Test calculate with validation_errors."""
+        calculator = DQMetricsCalculator()
+        input_data = DQMetricsInput(
+            records=sample_records,
+            validation_errors=["Error 1", "Error 2"],
+        )
+
+        result = calculator.calculate(input_data)
+
+        assert len(result.validation_errors) == 2
+        assert "Error 1" in result.validation_errors
+        assert "Error 2" in result.validation_errors
+
+    def test_calculate_column_stats(self, sample_records):
+        """Test calculate computes column statistics."""
+        calculator = DQMetricsCalculator()
+        input_data = DQMetricsInput(records=sample_records)
+
+        result = calculator.calculate(input_data)
+
+        # Should have column stats
+        assert "entity_id" in result.column_stats
+        assert "value" in result.column_stats
+        assert "name" in result.column_stats
+
+        # value column should have numeric stats
+        value_stats = result.column_stats["value"]
+        assert value_stats.min_value is not None
+        assert value_stats.max_value is not None
+
+    def test_detect_schema_drift_no_existing_schema(self, sample_records):
+        """Test _detect_schema_drift returns None when no existing schema."""
+        calculator = DQMetricsCalculator()
+
+        result = calculator._detect_schema_drift(
+            records=sample_records,
+            existing_fields=None,
+        )
+
+        assert result is None
+
+    def test_detect_schema_drift_empty_records(self):
+        """Test _detect_schema_drift returns None for empty records."""
+        calculator = DQMetricsCalculator()
+
+        result = calculator._detect_schema_drift(
+            records=[],
+            existing_fields={"entity_id", "value"},
+        )
+
+        assert result is None
+
+    def test_detect_schema_drift_no_drift(self, sample_records):
+        """Test _detect_schema_drift returns None when no drift."""
+        calculator = DQMetricsCalculator()
+        existing_fields = {"entity_id", "value", "name"}
+
+        result = calculator._detect_schema_drift(
+            records=sample_records,
+            existing_fields=existing_fields,
+        )
+
+        assert result is None
+
+    def test_detect_schema_drift_info_status_for_minor_changes(self, sample_records):
+        """Test _detect_schema_drift returns 'info' for minor changes."""
+        calculator = DQMetricsCalculator()
+        # Missing one field, but it's a metadata field (starts with _)
+        existing_fields = {"entity_id", "value", "name", "_run_id"}
+
+        result = calculator._detect_schema_drift(
+            records=sample_records,
+            existing_fields=existing_fields,
+        )
+
+        assert result is not None
+        assert result.status == "info"
+        assert "_run_id" in result.missing_fields
+
+    def test_detect_schema_drift_warn_status_for_many_new_fields(self):
+        """Test _detect_schema_drift returns 'warn' for >3 new fields."""
+        calculator = DQMetricsCalculator()
+        records = [
+            {
+                "entity_id": "CHEMBL123",
+                "new_field_1": "a",
+                "new_field_2": "b",
+                "new_field_3": "c",
+                "new_field_4": "d",
+            }
+        ]
+        existing_fields = {"entity_id"}
+
+        result = calculator._detect_schema_drift(
+            records=records,
+            existing_fields=existing_fields,
+        )
+
+        assert result is not None
+        assert result.status == "warn"
+        assert len(result.new_fields) == 4
+
+    def test_detect_schema_drift_critical_status_for_missing_business_fields(self):
+        """Test _detect_schema_drift returns 'critical' for missing business fields."""
+        calculator = DQMetricsCalculator()
+        records = [{"entity_id": "CHEMBL123"}]
+        existing_fields = {"entity_id", "important_field"}  # Business field missing
+
+        result = calculator._detect_schema_drift(
+            records=records,
+            existing_fields=existing_fields,
+        )
+
+        assert result is not None
+        assert result.status == "critical"
+        assert "important_field" in result.missing_fields
+
+    def test_calculate_with_schema_drift(self):
+        """Test calculate includes schema drift info."""
+        calculator = DQMetricsCalculator()
+        records = [{"entity_id": "CHEMBL123", "new_field": "value"}]
+        existing_fields = {"entity_id"}
+
+        input_data = DQMetricsInput(
+            records=records,
+            existing_schema_fields=existing_fields,
+        )
+
+        result = calculator.calculate(input_data)
+
+        assert result.schema_drift is not None
+        assert "new_field" in result.schema_drift.new_fields
+
+
+@pytest.mark.unit
+class TestDQMetricsInput:
+    """Tests for DQMetricsInput dataclass."""
+
+    def test_dq_metrics_input_defaults(self):
+        """Test DQMetricsInput has correct defaults."""
+        records = [{"a": 1}]
+        input_data = DQMetricsInput(records=records)
+
+        assert input_data.records == records
+        assert input_data.existing_schema_fields is None
+        assert input_data.quarantined_count == 0
+        assert input_data.validation_errors is None
+
+    def test_dq_metrics_input_is_frozen(self):
+        """Test DQMetricsInput is frozen (immutable)."""
+        input_data = DQMetricsInput(records=[{"a": 1}])
+
+        with pytest.raises(AttributeError):
+            input_data.records = []  # type: ignore
+
+    def test_dq_metrics_input_all_fields(self):
+        """Test DQMetricsInput with all fields."""
+        records = [{"a": 1}]
+        existing_fields = {"a", "b"}
+        validation_errors = ["Error 1"]
+
+        input_data = DQMetricsInput(
+            records=records,
+            existing_schema_fields=existing_fields,
+            quarantined_count=5,
+            validation_errors=validation_errors,
+        )
+
+        assert input_data.records == records
+        assert input_data.existing_schema_fields == existing_fields
+        assert input_data.quarantined_count == 5
+        assert input_data.validation_errors == validation_errors

--- a/tests/unit/infrastructure/storage/test_silver_writer.py
+++ b/tests/unit/infrastructure/storage/test_silver_writer.py
@@ -39,6 +39,80 @@ def valid_records():
     ]
 
 
+@pytest.fixture
+def mock_metadata_coordinator():
+    """Create a mock MetadataCoordinator that returns proper SilverMetadata."""
+    from datetime import UTC, datetime
+
+    from bioetl.domain.models.metadata import (
+        DeltaMetrics,
+        DQSummary,
+        EnvironmentMetadata,
+        LineageMetadata,
+        PipelineMetadata,
+        RuntimeMetadata,
+        RunTypeEnum,
+        SilverMetadata,
+        SilverOutputMetadata,
+    )
+    from bioetl.domain.ports import SilverMetadataInput
+
+    coordinator = MagicMock()
+
+    def create_silver_metadata(input_data: SilverMetadataInput) -> SilverMetadata:
+        """Create a proper SilverMetadata object from input."""
+        # Extract bronze_paths from bronze_refs
+        bronze_paths = []
+        if input_data.bronze_refs:
+            bronze_paths = [ref.relative_path for ref in input_data.bronze_refs]
+
+        # Extract source_batch_ids from records
+        source_batch_ids = list(
+            {
+                r.get("_source_batch_id", "")
+                for r in input_data.records
+                if r.get("_source_batch_id")
+            }
+        )
+
+        return SilverMetadata(
+            runtime=RuntimeMetadata(
+                run_id="test-run-id",
+                run_type=RunTypeEnum.INCREMENTAL,
+                started_at_utc=datetime.now(UTC),
+            ),
+            pipeline=PipelineMetadata(
+                name="test_pipeline",
+                provider="test",
+                entity="table",
+            ),
+            lineage=LineageMetadata(
+                source_batch_ids=source_batch_ids,
+                bronze_paths=bronze_paths,
+            ),
+            delta=DeltaMetrics(
+                table_path=input_data.table_path,
+                operation="merge",
+                primary_key=input_data.primary_keys,
+            ),
+            dq_summary=input_data.dq_metrics.to_dq_summary()
+            if input_data.dq_metrics
+            else DQSummary(
+                total_records=len(input_data.records),
+                valid_records=len(input_data.records),
+            ),
+            output=SilverOutputMetadata(record_count=len(input_data.records)),
+            environment=EnvironmentMetadata(
+                hostname="test-host",
+                python_version="3.11.0",
+                bioetl_version="1.0.0",
+            ),
+        )
+
+    coordinator.create_silver_metadata = create_silver_metadata
+    return coordinator
+
+
 @pytest.mark.unit
 class TestSilverWriterInit:
     """Tests for SilverWriter initialization."""
@@ -1715,7 +1789,7 @@ class TestSilverWriterLineage:
 
     @pytest.mark.asyncio
     async def test_write_silver_metadata_includes_bronze_paths(
-        self, noop_logger, valid_records
+        self, noop_logger, valid_records, mock_metadata_coordinator
     ):
         """Test _write_silver_metadata populates bronze_paths from bronze_refs."""
         from uuid import uuid4
@@ -1767,6 +1841,7 @@ class TestSilverWriterLineage:
             base_path="/tmp/silver",
             logger=noop_logger,
             metadata_writer=mock_metadata_writer,
+            metadata_coordinator=mock_metadata_coordinator,
         )
 
         await writer._write_silver_metadata(
@@ -1792,7 +1867,7 @@ class TestSilverWriterLineage:
 
     @pytest.mark.asyncio
     async def test_write_silver_metadata_empty_bronze_paths_when_no_refs(
-        self, noop_logger, valid_records
+        self, noop_logger, valid_records, mock_metadata_coordinator
     ):
         """Test _write_silver_metadata has empty bronze_paths when bronze_refs=None."""
         from bioetl.infrastructure.storage.silver_writer import (
@@ -1820,6 +1895,7 @@ class TestSilverWriterLineage:
             base_path="/tmp/silver",
             logger=noop_logger,
             metadata_writer=mock_metadata_writer,
+            metadata_coordinator=mock_metadata_coordinator,
         )
 
         await writer._write_silver_metadata(
@@ -2042,7 +2118,7 @@ class TestSilverWriterDQMetrics:
 
     @pytest.mark.asyncio
     async def test_write_silver_metadata_with_dq_metrics(
-        self, noop_logger, valid_records
+        self, noop_logger, valid_records, mock_metadata_coordinator
     ):
         """Test _write_silver_metadata uses DQ metrics when provided."""
         from bioetl.domain.value_objects.dq_metrics import (
@@ -2092,6 +2168,7 @@ class TestSilverWriterDQMetrics:
             base_path="/tmp/silver",
             logger=noop_logger,
             metadata_writer=mock_metadata_writer,
+            metadata_coordinator=mock_metadata_coordinator,
         )
 
         await writer._write_silver_metadata(
@@ -2130,7 +2207,7 @@ class TestSilverWriterDQMetrics:
 
     @pytest.mark.asyncio
     async def test_write_silver_metadata_fallback_without_dq_metrics(
-        self, noop_logger, valid_records
+        self, noop_logger, valid_records, mock_metadata_coordinator
     ):
         """Test _write_silver_metadata uses fallback when dq_metrics is None."""
         from bioetl.infrastructure.storage.silver_writer import (
@@ -2158,6 +2235,7 @@ class TestSilverWriterDQMetrics:
             base_path="/tmp/silver",
             logger=noop_logger,
             metadata_writer=mock_metadata_writer,
+            metadata_coordinator=mock_metadata_coordinator,
         )
 
         await writer._write_silver_metadata(
@@ -2183,7 +2261,7 @@ class TestSilverWriterDQMetrics:
 
     @pytest.mark.asyncio
     async def test_write_silver_computes_and_passes_dq_metrics(
-        self, noop_logger, valid_records
+        self, noop_logger, valid_records, mock_metadata_coordinator
     ):
         """Test write_silver computes DQ metrics and passes to metadata."""
         import pyarrow as pa
@@ -2229,6 +2307,7 @@ class TestSilverWriterDQMetrics:
                 base_path="/tmp/silver",
                 logger=noop_logger,
                 metadata_writer=mock_metadata_writer,
+                metadata_coordinator=mock_metadata_coordinator,
             )
 
             await writer.write_silver(


### PR DESCRIPTION
- Create centralized DQMetricsCalculator for Single Source of Truth
- Add save_metadata and on_schema_mismatch to SilverSinkConfig
- Add dq_report_path cross-reference to SilverMetadata
- Add metadata_path cross-reference to SilverDQReport
- Add dq_report_path to SilverMetadataInput for lineage
- Remove fallback logic from SilverWriter._write_silver_metadata
- Normalize DQ report paths: replace '.' with '/' in target_table
- Update tests to use mock_metadata_coordinator fixture

Implements REQ-DQ-001: eliminates duplicate DQ metrics computation