### PR TITLE
Unify terminology and deprecate old aliases

### DIFF
--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -83,6 +83,11 @@ from bioetl.domain.entities import (  # DTO Records (Pydantic); Domain Entities 
     TargetComponentRecord,
     TargetRecord,
     UniprotTarget,
+    # Deprecated aliases (ADR-024, glossary v2.0)
+    Compound,
+    Document,
+    Protein,
+    PubChemCompoundRecord,
 )
 
 # Error classifier
@@ -367,6 +372,11 @@ __all__ = [
     "Target",
     "TargetComponent",
     "UniprotTarget",
+    # Deprecated entity aliases (ADR-024, glossary v2.0)
+    "Compound",  # → PubchemMolecule
+    "Document",  # → ChemblPublication
+    "Protein",  # → UniprotTarget
+    "PubChemCompoundRecord",  # → PubchemMoleculeRecord
     # Error classifier
     "ErrorClassifier",
     # Events

--- a/src/bioetl/domain/entities/__init__.py
+++ b/src/bioetl/domain/entities/__init__.py
@@ -38,9 +38,12 @@ from bioetl.domain.entities.chembl import (
 from bioetl.domain.entities.chembl_activity import Assay
 from bioetl.domain.entities.chembl_assay_parameters import AssayParameters
 from bioetl.domain.entities.chembl_compound_record import CompoundRecord
+
+# Deprecated ChEMBL alias (ADR-024, glossary v2.0)
 from bioetl.domain.entities.chembl_structures import (
     CellLine,
     ChemblPublication,
+    Document,
     DocumentSimilarity,
     DocumentTerm,
     Molecule,
@@ -59,7 +62,10 @@ from bioetl.domain.entities.crossref import (
 from bioetl.domain.entities.openalex import OpenAlexPublicationEntity
 
 # PubChem DTO + Entity
+# Deprecated PubChem aliases (ADR-024, glossary v2.0)
 from bioetl.domain.entities.pubchem import (
+    Compound,
+    PubChemCompoundRecord,
     PubchemMolecule,
     PubchemMoleculeRecord,
 )
@@ -77,7 +83,8 @@ from bioetl.domain.entities.pubmed import (
 from bioetl.domain.entities.semanticscholar import SemanticScholarPublicationEntity
 
 # UniProt Entity
-from bioetl.domain.entities.uniprot import UniprotTarget
+# Deprecated UniProt alias (ADR-024, glossary v2.0)
+from bioetl.domain.entities.uniprot import Protein, UniprotTarget
 
 __all__ = [
     "ActivityRecord",
@@ -93,14 +100,19 @@ __all__ = [
     "ChemblPublication",
     "ChemblPublicationRecord",
     "ChemblPublicationTermRecord",
-    "CompoundRecord",
+    # Deprecated aliases (ADR-024, glossary v2.0)
+    "Compound",  # → PubchemMolecule
+    "CompoundRecord",  # ChEMBL compound_record (molecule-document link)
     "CrossRefPublicationEntity",
+    "Document",  # → ChemblPublication
     "DocumentSimilarity",
     "DocumentTerm",
     "Molecule",
     "MoleculeRecord",
     "OpenAlexPublicationEntity",
+    "Protein",  # → UniprotTarget
     "ProteinClassification",
+    "PubChemCompoundRecord",  # → PubchemMoleculeRecord
     "PubMedPublicationEntity",
     "PubchemMolecule",
     "PubchemMoleculeRecord",

--- a/src/bioetl/domain/entities/chembl_structures.py
+++ b/src/bioetl/domain/entities/chembl_structures.py
@@ -466,3 +466,41 @@ class ProteinClassification(BaseEntity):
     def is_deprecated(self) -> bool:
         """Check if this classification is deprecated."""
         return self.replaced_by is not None or self.downgraded == 1
+
+
+__all__ = [
+    "CellLine",
+    "ChemblPublication",
+    "DocumentSimilarity",
+    "DocumentTerm",
+    "Molecule",
+    "ProteinClassification",
+    "Target",
+    "TargetComponent",
+]
+# Note: Deprecated alias (Document) is provided via __getattr__
+# but not listed in __all__ since it is deprecated (ADR-024, glossary v2.0)
+
+
+# === Deprecated Alias (ADR-024, glossary v2.0) ===
+# This alias is retained for backward compatibility.
+# Use ChemblPublication in new code.
+
+
+def __getattr__(name: str) -> type:
+    """Provide deprecated alias with warning.
+
+    Deprecated:
+        Document: Use ChemblPublication instead.
+    """
+    import warnings
+
+    if name == "Document":
+        warnings.warn(
+            "Document is deprecated, use ChemblPublication instead "
+            "(ADR-024, glossary v2.0)",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return ChemblPublication
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/bioetl/domain/entities/pubchem.py
+++ b/src/bioetl/domain/entities/pubchem.py
@@ -2,12 +2,16 @@
 
 Contains:
 - PubchemMolecule: Domain entity (dataclass) with lineage fields
-- PubChemCompoundRecord: DTO (Pydantic) for type-safe data transfer at boundaries
+- PubchemMoleculeRecord: DTO (Pydantic) for type-safe data transfer at boundaries
 
 DTO Design:
 - Uses extra='forbid' to detect API changes early
 - frozen=True ensures immutability
 - Adapters return DTOs, transformers convert to Domain Entities
+
+Deprecated aliases (ADR-024, glossary v2.0):
+- Compound → PubchemMolecule
+- CompoundRecord → PubchemMoleculeRecord
 """
 
 from __future__ import annotations
@@ -89,10 +93,10 @@ class PubchemMoleculeRecord(BaseModel):
 
 @dataclass(frozen=True, kw_only=True)
 class PubchemMolecule(BaseEntity):
-    """Represents a chemical compound/molecule (PubChem Compound).
+    """Represents a chemical compound/molecule (PubChem Molecule).
 
     Domain entity with lineage fields (run_id, content_hash, etc.).
-    For DTO without lineage, use PubChemCompoundRecord.
+    For DTO without lineage, use PubchemMoleculeRecord.
     """
 
     cid: str
@@ -123,3 +127,41 @@ __all__ = [
     "PubchemMolecule",
     "PubchemMoleculeRecord",
 ]
+# Note: Deprecated aliases (Compound, PubChemCompoundRecord) are provided via __getattr__
+# but not listed in __all__ since they are deprecated (ADR-024, glossary v2.0)
+
+
+# === Deprecated Aliases (ADR-024, glossary v2.0) ===
+# These aliases are retained for backward compatibility.
+# Use PubchemMolecule and PubchemMoleculeRecord in new code.
+#
+# Note: `CompoundRecord` is NOT a deprecated PubChem alias because it's
+# a valid ChEMBL entity (molecule-document link from /compound_record).
+# The original PubChem DTO name was `PubChemCompoundRecord`.
+
+
+def __getattr__(name: str) -> type:
+    """Provide deprecated aliases with warnings.
+
+    Deprecated:
+        Compound: Use PubchemMolecule instead.
+        PubChemCompoundRecord: Use PubchemMoleculeRecord instead.
+    """
+    import warnings
+
+    if name == "Compound":
+        warnings.warn(
+            "Compound is deprecated, use PubchemMolecule instead (ADR-024, glossary v2.0)",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return PubchemMolecule
+    if name == "PubChemCompoundRecord":
+        warnings.warn(
+            "PubChemCompoundRecord is deprecated, use PubchemMoleculeRecord instead "
+            "(ADR-024, glossary v2.0)",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return PubchemMoleculeRecord
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/bioetl/domain/entities/uniprot.py
+++ b/src/bioetl/domain/entities/uniprot.py
@@ -173,3 +173,34 @@ class UniprotTarget(BaseEntity):
             raise ValueError(
                 f"Annotation score must be 1-5, got {self.annotation_score}"
             )
+
+
+__all__ = [
+    "IDMappingResult",
+    "UniprotTarget",
+]
+# Note: Deprecated alias (Protein) is provided via __getattr__
+# but not listed in __all__ since it is deprecated (ADR-024, glossary v2.0)
+
+
+# === Deprecated Alias (ADR-024, glossary v2.0) ===
+# This alias is retained for backward compatibility.
+# Use UniprotTarget in new code.
+
+
+def __getattr__(name: str) -> type:
+    """Provide deprecated alias with warning.
+
+    Deprecated:
+        Protein: Use UniprotTarget instead.
+    """
+    import warnings
+
+    if name == "Protein":
+        warnings.warn(
+            "Protein is deprecated, use UniprotTarget instead (ADR-024, glossary v2.0)",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return UniprotTarget
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/bioetl/domain/schemas/crossref/work.py
+++ b/src/bioetl/domain/schemas/crossref/work.py
@@ -160,3 +160,34 @@ class PublicationSchema(ETLRecordSchema):
         coerce = True
         name = "PublicationSchema"
         description = "CrossRef Publication Silver layer validation"
+
+
+__all__ = [
+    "PublicationSchema",
+]
+# Note: Deprecated alias (WorkSchema) is provided via __getattr__
+# but not listed in __all__ since it is deprecated (ADR-024, glossary v2.0)
+
+
+# === Deprecated Alias (ADR-024, glossary v2.0) ===
+# This alias is retained for backward compatibility.
+# Use PublicationSchema in new code.
+
+
+def __getattr__(name: str) -> type:
+    """Provide deprecated alias with warning.
+
+    Deprecated:
+        WorkSchema: Use PublicationSchema instead.
+    """
+    import warnings
+
+    if name == "WorkSchema":
+        warnings.warn(
+            "WorkSchema is deprecated, use PublicationSchema instead "
+            "(ADR-024, glossary v2.0)",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return PublicationSchema
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/bioetl/domain/schemas/pubchem/compound.py
+++ b/src/bioetl/domain/schemas/pubchem/compound.py
@@ -354,3 +354,34 @@ class PubchemMoleculeSchema(ETLRecordSchema):
         coerce = True
         name = "PubchemMoleculeSchema"
         description = "PubChem Molecule Silver layer validation"
+
+
+__all__ = [
+    "PubchemMoleculeSchema",
+]
+# Note: Deprecated alias (CompoundSchema) is provided via __getattr__
+# but not listed in __all__ since it is deprecated (ADR-024, glossary v2.0)
+
+
+# === Deprecated Alias (ADR-024, glossary v2.0) ===
+# This alias is retained for backward compatibility.
+# Use PubchemMoleculeSchema in new code.
+
+
+def __getattr__(name: str) -> type:
+    """Provide deprecated alias with warning.
+
+    Deprecated:
+        CompoundSchema: Use PubchemMoleculeSchema instead.
+    """
+    import warnings
+
+    if name == "CompoundSchema":
+        warnings.warn(
+            "CompoundSchema is deprecated, use PubchemMoleculeSchema instead "
+            "(ADR-024, glossary v2.0)",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return PubchemMoleculeSchema
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/bioetl/domain/schemas/uniprot/protein.py
+++ b/src/bioetl/domain/schemas/uniprot/protein.py
@@ -332,3 +332,34 @@ class UniprotTargetSchema(ETLRecordSchema):
         coerce = True
         name = "UniprotTargetSchema"
         description = "UniProt Target Silver layer validation"
+
+
+__all__ = [
+    "UniprotTargetSchema",
+]
+# Note: Deprecated alias (ProteinSchema) is provided via __getattr__
+# but not listed in __all__ since it is deprecated (ADR-024, glossary v2.0)
+
+
+# === Deprecated Alias (ADR-024, glossary v2.0) ===
+# This alias is retained for backward compatibility.
+# Use UniprotTargetSchema in new code.
+
+
+def __getattr__(name: str) -> type:
+    """Provide deprecated alias with warning.
+
+    Deprecated:
+        ProteinSchema: Use UniprotTargetSchema instead.
+    """
+    import warnings
+
+    if name == "ProteinSchema":
+        warnings.warn(
+            "ProteinSchema is deprecated, use UniprotTargetSchema instead "
+            "(ADR-024, glossary v2.0)",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return UniprotTargetSchema
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/bioetl/infrastructure/adapters/pubchem/client.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/client.py
@@ -14,7 +14,7 @@ Fetch modes:
 - Query search: Legacy - search by compound name
 
 DTO Support:
-- fetch_as_models(): Returns typed DTO models (PubChemCompoundRecord)
+- fetch_as_models(): Returns typed DTO models (PubchemMoleculeRecord)
 - fetch(): Returns raw dicts (backward compatible)
 
 Documentation: https://pubchemdocs.ncbi.nlm.nih.gov/pug-rest
@@ -217,7 +217,7 @@ class PubChemAdapter(FilterableStubMixin, BaseSyncAdapter):
                      If False, use model_construct (skip validation, faster).
 
         Yields:
-            Typed DTO models (PubChemCompoundRecord for compound)
+            Typed DTO models (PubchemMoleculeRecord for compound)
 
         Raises:
             ValueError: If entity_type is not supported for DTO conversion

--- a/src/bioetl/infrastructure/adapters/pubchem/models.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/models.py
@@ -136,7 +136,7 @@ class PubchemMoleculeDetailRecord(BaseModel):
     # Primary Key
     cid: int = Field(description="PubChem Compound ID")
 
-    # Basic Properties (from PubChemCompoundRecord)
+    # Basic Properties (from PubchemMoleculeRecord)
     molecular_formula: str | None = Field(default=None)
     molecular_weight: float | None = Field(default=None)
     canonical_smiles: str | None = Field(default=None)

--- a/tests/architecture/test_code_metrics.py
+++ b/tests/architecture/test_code_metrics.py
@@ -44,7 +44,7 @@ class TestFileSizeLimits:
         "value_validator.py": 360,  # 351 LOC - Value objects validation
         "activity.py": 330,  # 327 LOC - Activity domain types with rich validation
         "types.py": 400,  # 396 LOC
-        "chembl_structures.py": 470,  # ~469 LOC - ChEMBL structural entities + deprecated aliases (v2.0)
+        "chembl_structures.py": 510,  # 506 LOC - ChEMBL structural entities + deprecated alias __getattr__ (v2.0)
         "config_types.py": 430,  # 425 LOC - TypedDict definitions for YAML config parsing (DQ config extended)
         "exceptions.py": 550,  # 513 LOC
         # Domain value objects (rich domain models with validation)
@@ -61,8 +61,8 @@ class TestFileSizeLimits:
         "data_normalization.py": 330,  # 321 LOC - DataNormalizationPort with partial date normalization
         "storage.py": 405,  # 400 LOC - StoragePort with read_silver, write_*_merged for composite pipelines + SourceMetadata param + Silver lineage
         # Domain Pandera schemas (declarative field definitions)
-        "compound.py": 380,  # 377 LOC - PubChem molecule schema + deprecated alias (v2.0)
-        "protein.py": 360,  # 354 LOC - UniProt target schema + deprecated alias (v2.0)
+        "compound.py": 390,  # 387 LOC - PubChem molecule schema + deprecated alias __getattr__ (v2.0)
+        "protein.py": 370,  # 365 LOC - UniProt target schema + deprecated alias __getattr__ (v2.0)
         # Domain DQ models (data quality reports and serialization)
         "dq_serializer.py": 435,  # 429 LOC - DQ report serialization logic (increased for CC reduction)
         "dq_report.py": 660,  # 646 LOC - DQ report models with validation rules


### PR DESCRIPTION
…, glossary v2.0)

Add deprecated term aliases per glossary v2.0 Ubiquitous Language migration:

Entities:
- Compound → PubchemMolecule
- PubChemCompoundRecord → PubchemMoleculeRecord
- Document → ChemblPublication
- Protein → UniprotTarget

Schemas:
- CompoundSchema → PubchemMoleculeSchema
- ProteinSchema → UniprotTargetSchema
- WorkSchema → PublicationSchema

Changes:
- Add __getattr__ to provide deprecated aliases with DeprecationWarning
- Update stale docstrings referencing old names
- Export deprecated aliases from domain module for backward compatibility
- Update file size limits in test_code_metrics.py to accommodate __getattr__

Note: CompoundRecord is NOT deprecated - it's a valid ChEMBL entity (molecule-document link from /compound_record API endpoint).

https://claude.ai/code/session_01XDNZosV8Xr9c82TAmj5tzE