### PR TITLE
Simplify documentation in composite pipeline state module

### DIFF
--- a/src/bioetl/domain/composite/state.py
+++ b/src/bioetl/domain/composite/state.py
@@ -1,33 +1,11 @@
 """Composite pipeline finite state machine.
 
 Defines states and transition rules for composite pipeline execution lifecycle.
-
 The FSM ensures predictable execution flow and prevents invalid operations.
-For example, merging cannot start before all enrichments complete.
-
 See ADR-026 for architectural decisions.
 
-State Transition Diagram::
-
-    NOT_STARTED ─────► SEED_RUNNING
-                            │
-              ┌─────────────┴─────────────┐
-              ▼                           ▼
-         SEED_COMPLETED                 FAILED
-              │
-              ▼
-          ENRICHING
-              │
-    ┌─────────┴─────────┐
-    ▼                   ▼
- ENRICHMENT_COMPLETED FAILED
-    │
-    ▼
-  MERGING
-    │
-    ┌───────┴───────┐
-    ▼               ▼
- COMPLETED        FAILED
+Transition flow: NOT_STARTED -> SEED_RUNNING -> SEED_COMPLETED -> ENRICHING
+-> ENRICHMENT_COMPLETED -> MERGING -> COMPLETED. Any active state can -> FAILED.
 """
 
 from __future__ import annotations
@@ -39,46 +17,11 @@ from enum import Enum
 class CompositePipelineState(str, Enum):
     """State of composite pipeline execution.
 
-    Represents the current stage in the composite pipeline lifecycle.
-    Each state has specific semantics and allowed transitions.
+    States: NOT_STARTED, SEED_RUNNING, SEED_COMPLETED, ENRICHING,
+    ENRICHMENT_COMPLETED, MERGING, COMPLETED, FAILED.
 
-    States:
-        NOT_STARTED: Initial state before any execution. The pipeline has been
-            configured but not yet started.
-
-        SEED_RUNNING: The seed pipeline is currently executing. This is the
-            first active state where data extraction begins.
-
-        SEED_COMPLETED: The seed pipeline finished successfully. Ready to
-            proceed with enrichment stage.
-
-        ENRICHING: One or more enrichment pipelines are executing in parallel.
-            This stage may run multiple enrichers concurrently.
-
-        ENRICHMENT_COMPLETED: All enrichment pipelines have finished. This
-            includes successful, failed (optional), and skipped enrichers.
-            Ready for merge stage.
-
-        MERGING: The merge operation is in progress, combining seed and
-            enriched data into the final output.
-
-        COMPLETED: The composite pipeline finished successfully. Gold table
-            has been created with merged data.
-
-        FAILED: The composite pipeline terminated due to a critical error.
-            This is a terminal state. Errors include: seed failure,
-            required enricher failure, or merge failure.
-
-    Example:
-        >>> state = CompositePipelineState.NOT_STARTED
-        >>> state.is_terminal
-        False
-        >>> CompositePipelineState.FAILED.is_terminal
-        True
-        >>> state.can_transition_to(CompositePipelineState.SEED_RUNNING)
-        True
-        >>> state.can_transition_to(CompositePipelineState.MERGING)
-        False
+    Terminal states: COMPLETED, FAILED (no transitions allowed).
+    Active states: SEED_RUNNING, ENRICHING, MERGING (work in progress).
     """
 
     NOT_STARTED = "not_started"
@@ -92,38 +35,12 @@ class CompositePipelineState(str, Enum):
 
     @property
     def is_terminal(self) -> bool:
-        """Check if this is a terminal (final) state.
-
-        Terminal states are COMPLETED and FAILED. No transitions
-        are allowed from these states.
-
-        Returns:
-            True if this state is terminal, False otherwise.
-
-        Example:
-            >>> CompositePipelineState.COMPLETED.is_terminal
-            True
-            >>> CompositePipelineState.ENRICHING.is_terminal
-            False
-        """
+        """Check if this is a terminal state (COMPLETED or FAILED)."""
         return self in {CompositePipelineState.COMPLETED, CompositePipelineState.FAILED}
 
     @property
     def is_active(self) -> bool:
-        """Check if this is an active (in-progress) state.
-
-        Active states indicate that work is currently being performed:
-        SEED_RUNNING, ENRICHING, MERGING.
-
-        Returns:
-            True if this state represents active execution.
-
-        Example:
-            >>> CompositePipelineState.SEED_RUNNING.is_active
-            True
-            >>> CompositePipelineState.SEED_COMPLETED.is_active
-            False
-        """
+        """Check if this is an active state (SEED_RUNNING, ENRICHING, MERGING)."""
         return self in {
             CompositePipelineState.SEED_RUNNING,
             CompositePipelineState.ENRICHING,
@@ -132,71 +49,21 @@ class CompositePipelineState(str, Enum):
 
     @property
     def is_success(self) -> bool:
-        """Check if this state represents successful completion.
-
-        Returns:
-            True only for COMPLETED state.
-
-        Example:
-            >>> CompositePipelineState.COMPLETED.is_success
-            True
-            >>> CompositePipelineState.FAILED.is_success
-            False
-        """
+        """Check if this state represents successful completion (COMPLETED only)."""
         return self == CompositePipelineState.COMPLETED
 
     @property
     def allowed_transitions(self) -> frozenset[CompositePipelineState]:
-        """Get the set of states that can be transitioned to from this state.
-
-        Returns:
-            Frozenset of allowed target states.
-
-        Example:
-            >>> CompositePipelineState.SEED_RUNNING.allowed_transitions
-            frozenset({<CompositePipelineState.SEED_COMPLETED: 'seed_completed'>,
-                      <CompositePipelineState.FAILED: 'failed'>})
-        """
+        """Get the set of states that can be transitioned to from this state."""
         allowed_values = _STATE_TRANSITIONS.get(self.value, frozenset())
         return frozenset(CompositePipelineState(v) for v in allowed_values)
 
     def can_transition_to(self, target: CompositePipelineState) -> bool:
-        """Check if transition to target state is valid.
-
-        Args:
-            target: The target state to transition to.
-
-        Returns:
-            True if transition is allowed, False otherwise.
-
-        Example:
-            >>> state = CompositePipelineState.SEED_COMPLETED
-            >>> state.can_transition_to(CompositePipelineState.ENRICHING)
-            True
-            >>> state.can_transition_to(CompositePipelineState.MERGING)
-            False
-        """
+        """Check if transition to target state is valid."""
         return target in self.allowed_transitions
 
     def validate_transition(self, target: CompositePipelineState) -> None:
-        """Validate transition to target state, raising on invalid.
-
-        Use this method when transitioning states to ensure the FSM
-        rules are enforced.
-
-        Args:
-            target: The target state to transition to.
-
-        Raises:
-            InvalidStateError: If transition is not allowed.
-
-        Example:
-            >>> state = CompositePipelineState.NOT_STARTED
-            >>> state.validate_transition(CompositePipelineState.SEED_RUNNING)
-            >>> # No exception raised
-            >>> state.validate_transition(CompositePipelineState.MERGING)
-            InvalidStateError: Invalid state transition: not_started -> merging
-        """
+        """Validate transition to target state, raising InvalidStateError if invalid."""
         if not self.can_transition_to(target):
             from bioetl.domain.exceptions import InvalidStateError
 
@@ -208,21 +75,7 @@ class CompositePipelineState(str, Enum):
 
     @classmethod
     def from_string(cls, value: str) -> CompositePipelineState:
-        """Create CompositePipelineState from string value.
-
-        Args:
-            value: String representation of state.
-
-        Returns:
-            CompositePipelineState enum value.
-
-        Raises:
-            ValueError: If value is not a valid state.
-
-        Example:
-            >>> CompositePipelineState.from_string("seed_running")
-            <CompositePipelineState.SEED_RUNNING: 'seed_running'>
-        """
+        """Create CompositePipelineState from string value (case-insensitive)."""
         try:
             return cls(value.lower())
         except ValueError:
@@ -232,21 +85,7 @@ class CompositePipelineState(str, Enum):
             ) from None
 
     def to_metric_value(self) -> int:
-        """Convert state to numeric value for metrics.
-
-        Returns integer representation suitable for Prometheus gauge.
-        Values progress from 0 (NOT_STARTED) through pipeline stages,
-        with terminal states at the end.
-
-        Returns:
-            Integer metric value (0-7).
-
-        Example:
-            >>> CompositePipelineState.NOT_STARTED.to_metric_value()
-            0
-            >>> CompositePipelineState.COMPLETED.to_metric_value()
-            6
-        """
+        """Convert state to numeric value (0-7) for Prometheus metrics."""
         return _STATE_METRIC_VALUES[self]
 
 
@@ -280,25 +119,7 @@ def can_transition(
     current: CompositePipelineState,
     target: CompositePipelineState,
 ) -> bool:
-    """Check if a state transition is valid.
-
-    Module-level function for transition validation without accessing
-    the enum instance directly.
-
-    Args:
-        current: Current pipeline state.
-        target: Target state to transition to.
-
-    Returns:
-        True if transition is allowed, False otherwise.
-
-    Example:
-        >>> can_transition(
-        ...     CompositePipelineState.SEED_COMPLETED,
-        ...     CompositePipelineState.ENRICHING
-        ... )
-        True
-    """
+    """Check if a state transition is valid (module-level function)."""
     return current.can_transition_to(target)
 
 
@@ -306,25 +127,7 @@ def validate_transition(
     current: CompositePipelineState,
     target: CompositePipelineState,
 ) -> None:
-    """Validate a state transition, raising on invalid.
-
-    Module-level function for transition validation that raises
-    InvalidStateError on invalid transitions.
-
-    Args:
-        current: Current pipeline state.
-        target: Target state to transition to.
-
-    Raises:
-        InvalidStateError: If transition is not allowed.
-
-    Example:
-        >>> validate_transition(
-        ...     CompositePipelineState.NOT_STARTED,
-        ...     CompositePipelineState.SEED_RUNNING
-        ... )
-        >>> # No exception - transition is valid
-    """
+    """Validate a state transition, raising InvalidStateError if invalid."""
     current.validate_transition(target)
 
 
@@ -333,20 +136,5 @@ TransitionRules = Mapping[CompositePipelineState, frozenset[CompositePipelineSta
 
 
 def get_transition_rules() -> TransitionRules:
-    """Get the complete state transition rules as a mapping.
-
-    Returns a dictionary mapping each state to its allowed target states.
-    Useful for visualization or external validation.
-
-    Returns:
-        Mapping of state -> allowed target states.
-
-    Example:
-        >>> rules = get_transition_rules()
-        >>> CompositePipelineState.MERGING in rules[CompositePipelineState.ENRICHMENT_COMPLETED]
-        True
-    """
-    return {
-        state: state.allowed_transitions
-        for state in CompositePipelineState
-    }
+    """Get the complete state transition rules as a mapping."""
+    return {state: state.allowed_transitions for state in CompositePipelineState}

--- a/tests/unit/domain/composite/test_state.py
+++ b/tests/unit/domain/composite/test_state.py
@@ -148,12 +148,21 @@ class TestValidTransitions:
         "current,target",
         [
             (CompositePipelineState.NOT_STARTED, CompositePipelineState.SEED_RUNNING),
-            (CompositePipelineState.SEED_RUNNING, CompositePipelineState.SEED_COMPLETED),
+            (
+                CompositePipelineState.SEED_RUNNING,
+                CompositePipelineState.SEED_COMPLETED,
+            ),
             (CompositePipelineState.SEED_RUNNING, CompositePipelineState.FAILED),
             (CompositePipelineState.SEED_COMPLETED, CompositePipelineState.ENRICHING),
-            (CompositePipelineState.ENRICHING, CompositePipelineState.ENRICHMENT_COMPLETED),
+            (
+                CompositePipelineState.ENRICHING,
+                CompositePipelineState.ENRICHMENT_COMPLETED,
+            ),
             (CompositePipelineState.ENRICHING, CompositePipelineState.FAILED),
-            (CompositePipelineState.ENRICHMENT_COMPLETED, CompositePipelineState.MERGING),
+            (
+                CompositePipelineState.ENRICHMENT_COMPLETED,
+                CompositePipelineState.MERGING,
+            ),
             (CompositePipelineState.MERGING, CompositePipelineState.COMPLETED),
             (CompositePipelineState.MERGING, CompositePipelineState.FAILED),
         ],
@@ -170,10 +179,19 @@ class TestValidTransitions:
         "current,target",
         [
             (CompositePipelineState.NOT_STARTED, CompositePipelineState.SEED_RUNNING),
-            (CompositePipelineState.SEED_RUNNING, CompositePipelineState.SEED_COMPLETED),
+            (
+                CompositePipelineState.SEED_RUNNING,
+                CompositePipelineState.SEED_COMPLETED,
+            ),
             (CompositePipelineState.SEED_COMPLETED, CompositePipelineState.ENRICHING),
-            (CompositePipelineState.ENRICHING, CompositePipelineState.ENRICHMENT_COMPLETED),
-            (CompositePipelineState.ENRICHMENT_COMPLETED, CompositePipelineState.MERGING),
+            (
+                CompositePipelineState.ENRICHING,
+                CompositePipelineState.ENRICHMENT_COMPLETED,
+            ),
+            (
+                CompositePipelineState.ENRICHMENT_COMPLETED,
+                CompositePipelineState.MERGING,
+            ),
             (CompositePipelineState.MERGING, CompositePipelineState.COMPLETED),
         ],
     )


### PR DESCRIPTION
## Summary
Reduced verbosity in the composite pipeline state module by condensing extensive docstrings and removing redundant documentation while preserving all essential information.

## Key Changes
- **Simplified module docstring**: Replaced detailed ASCII state transition diagram with a concise text description of the transition flow
- **Condensed class docstring**: Reduced `CompositePipelineState` enum documentation from detailed state descriptions to a brief summary listing all states and categorizing them as terminal or active
- **Streamlined method docstrings**: Shortened docstrings for all properties and methods (`is_terminal`, `is_active`, `is_success`, `allowed_transitions`, `can_transition_to`, `validate_transition`, `from_string`, `to_metric_value`) to single-line descriptions
- **Removed examples**: Eliminated inline docstring examples (e.g., `>>>` code blocks) that duplicated information already covered by type hints and method names
- **Simplified module-level functions**: Condensed docstrings for `can_transition()`, `validate_transition()`, and `get_transition_rules()` functions
- **Updated test formatting**: Reformatted test parameter tuples for consistency with line length limits

## Implementation Details
- All functional code remains unchanged; this is purely a documentation refactoring
- Type hints and method signatures are preserved, making the code self-documenting
- The ADR-026 reference is maintained for architectural context
- Test coverage and assertions remain identical