### PR TITLE
Improve logging for state machine transitions

### DIFF
--- a/src/bioetl/application/composite/coordinator.py
+++ b/src/bioetl/application/composite/coordinator.py
@@ -348,15 +348,24 @@ class EnrichmentCoordinator:
 
             except Exception as e:
                 duration = (datetime.now(tz=UTC) - started_at).total_seconds()
-                self._logger.error(
-                    "Enricher failed",
+
+                # Re-raise for required enrichers (logged as error)
+                if enricher.required:
+                    self._logger.error(
+                        "Required enricher failed",
+                        enricher=enricher.pipeline,
+                        error=str(e),
+                        required=True,
+                    )
+                    raise
+
+                # Optional enricher failures are warnings (pipeline continues)
+                self._logger.warning(
+                    "Optional enricher failed",
                     enricher=enricher.pipeline,
                     error=str(e),
+                    required=False,
                 )
-
-                # Re-raise for required enrichers
-                if enricher.required:
-                    raise
 
                 return EnrichmentResult.failed(
                     enricher_name=enricher.pipeline,

--- a/src/bioetl/application/composite/runner.py
+++ b/src/bioetl/application/composite/runner.py
@@ -226,6 +226,12 @@ class CompositePipelineRunner:
                 to_state=CompositePipelineState.SEED_RUNNING,
                 stage="seed_start",
             )
+            # Log phase event for seed start
+            self._logger.info(
+                PipelineEvent.phase_started("seed"),
+                composite=self._config.name,
+                run_id=self._run_id_str,
+            )
             await self._save_checkpoint_safe(state, "seed_running")
 
             # Execute seed with error handling
@@ -258,6 +264,14 @@ class CompositePipelineRunner:
                 from_state=CompositePipelineState.SEED_RUNNING,
                 to_state=CompositePipelineState.SEED_COMPLETED,
                 stage="seed_complete",
+                records_extracted=seed_result.records_extracted,
+                records_silver=seed_result.records_silver,
+            )
+            # Log phase event for seed completion
+            self._logger.info(
+                PipelineEvent.phase_completed("seed"),
+                composite=self._config.name,
+                run_id=self._run_id_str,
                 records_extracted=seed_result.records_extracted,
                 records_silver=seed_result.records_silver,
             )
@@ -302,15 +316,25 @@ class CompositePipelineRunner:
         if enrichers_to_run:
             # Transition to ENRICHING state before starting enrichments
             enricher_names = [e.pipeline for e in enrichers_to_run]
+            previous_state = state.state
             state = state.with_state(CompositePipelineState.ENRICHING)
             await self._checkpoint_manager.save(state)
 
-            self._logger.info(
-                "Enrichment stage started",
-                composite=self._config.name,
+            # Log FSM transition to ENRICHING
+            self._log_fsm_transition(
+                from_state=previous_state,
+                to_state=CompositePipelineState.ENRICHING,
+                stage="enrichment_start",
                 enrichers=enricher_names,
                 count=len(enrichers_to_run),
-                state="ENRICHING",
+            )
+            # Log phase event for enrichment start
+            self._logger.info(
+                PipelineEvent.phase_started("enrichment"),
+                composite=self._config.name,
+                run_id=self._run_id_str,
+                enrichers=enricher_names,
+                count=len(enrichers_to_run),
             )
 
             enrichment_results = await self._coordinator.run_enrichers(
@@ -344,13 +368,24 @@ class CompositePipelineRunner:
             self._check_required_enrichers(enrichment_results)
         except RuntimeError as e:
             # Required enricher failed - transition to FAILED state
+            previous_state = state.state
             state = state.with_state(CompositePipelineState.FAILED)
+
+            # Log FSM transition to FAILED
+            self._log_fsm_transition(
+                from_state=previous_state,
+                to_state=CompositePipelineState.FAILED,
+                stage="required_enricher_failed",
+                error=str(e),
+            )
+
             try:
                 await self._checkpoint_manager.save(state)
             except Exception as save_error:
                 self._logger.warning(
                     "Failed to save FAILED state to checkpoint",
                     composite=self._config.name,
+                    run_id=self._run_id_str,
                     error=str(save_error),
                 )
 
@@ -359,7 +394,6 @@ class CompositePipelineRunner:
                 composite=self._config.name,
                 run_id=self._run_id_str,
                 error=str(e),
-                state="FAILED",
             )
             raise
 
@@ -406,15 +440,32 @@ class CompositePipelineRunner:
         from bioetl.domain.composite.state import CompositePipelineState
 
         if state.state == CompositePipelineState.SEED_COMPLETED:
-            # Must go through ENRICHING first per FSM rules
+            # Must go through ENRICHING first per FSM rules (no enrichers case)
+            previous_state = state.state
             state = state.with_state(CompositePipelineState.ENRICHING)
+            self._log_fsm_transition(
+                from_state=previous_state,
+                to_state=CompositePipelineState.ENRICHING,
+                stage="enrichment_start_empty",
+                reason="no_enrichers_to_run",
+            )
+
         if state.state == CompositePipelineState.ENRICHING:
+            enriching_state: CompositePipelineState = state.state
             state = state.with_state(CompositePipelineState.ENRICHMENT_COMPLETED)
             await self._save_checkpoint_safe(state, "enrichment_completed")
+
+            # Log FSM transition to ENRICHMENT_COMPLETED
+            self._log_fsm_transition(
+                from_state=enriching_state,
+                to_state=CompositePipelineState.ENRICHMENT_COMPLETED,
+                stage="enrichment_complete",
+            )
+            # Log phase event for enrichment completion
             self._logger.info(
-                "Enrichment stage completed",
+                PipelineEvent.phase_completed("enrichment"),
                 composite=self._config.name,
-                state="ENRICHMENT_COMPLETED",
+                run_id=self._run_id_str,
             )
         return state
 
@@ -433,12 +484,21 @@ class CompositePipelineRunner:
 
         if not self._runtime.dry_run:
             # Transition to MERGING state
+            previous_state = state.state
             state = state.with_state(CompositePipelineState.MERGING)
             await self._save_checkpoint_safe(state, "merging")
+
+            # Log FSM transition to MERGING
+            self._log_fsm_transition(
+                from_state=previous_state,
+                to_state=CompositePipelineState.MERGING,
+                stage="merge_start",
+            )
+            # Log phase event for merge start
             self._logger.info(
-                "Starting merge stage",
+                PipelineEvent.phase_started("merge"),
                 composite=self._config.name,
-                state=state.state.value,
+                run_id=self._run_id_str,
             )
 
             try:
@@ -449,9 +509,11 @@ class CompositePipelineRunner:
                     run_id=self._run_id_str,
                 )
 
+                # Log phase event for merge completion
                 self._logger.info(
-                    "Merge completed",
+                    PipelineEvent.phase_completed("merge"),
                     composite=self._config.name,
+                    run_id=self._run_id_str,
                     records_merged=merge_result.records_merged,
                 )
 
@@ -459,22 +521,34 @@ class CompositePipelineRunner:
                 await self._generate_dq_reports(merge_result)
 
             except Exception as merge_error:
-                # Merge failed - save FAILED state for potential resume
+                # Log FSM transition to FAILED
+                self._log_fsm_transition(
+                    from_state=CompositePipelineState.MERGING,
+                    to_state=CompositePipelineState.FAILED,
+                    stage="merge_failed",
+                    error=str(merge_error),
+                )
                 self._logger.error(
                     "Merge failed",
                     composite=self._config.name,
+                    run_id=self._run_id_str,
                     error=str(merge_error),
-                    state="FAILED",
                 )
                 state = state.with_state(CompositePipelineState.FAILED)
                 await self._save_checkpoint_safe(state, "merge_failed")
                 raise
         else:
-            # Dry run mode - skip merge, log completion
+            # Dry run mode - skip merge, transition directly to COMPLETED
+            self._log_fsm_transition(
+                from_state=state.state,
+                to_state=CompositePipelineState.COMPLETED,
+                stage="dry_run_skip_merge",
+                reason="dry_run_mode",
+            )
             self._logger.info(
-                "Dry run: merge skipped",
+                "Dry run: merge skipped, pipeline completing",
                 composite=self._config.name,
-                state="COMPLETED",
+                run_id=self._run_id_str,
             )
 
         return state, merge_result
@@ -483,8 +557,17 @@ class CompositePipelineRunner:
         """Finalize pipeline - set COMPLETED state and cleanup checkpoint."""
         from bioetl.domain.composite.state import CompositePipelineState
 
-        # Transition to COMPLETED state
-        state = state.with_state(CompositePipelineState.COMPLETED)
+        # Transition to COMPLETED state (only if not already COMPLETED from dry run)
+        if state.state != CompositePipelineState.COMPLETED:
+            previous_state = state.state
+            state = state.with_state(CompositePipelineState.COMPLETED)
+
+            # Log FSM transition to COMPLETED
+            self._log_fsm_transition(
+                from_state=previous_state,
+                to_state=CompositePipelineState.COMPLETED,
+                stage="pipeline_complete",
+            )
         await self._save_checkpoint_safe(state, "completed")
 
         # Cleanup checkpoint on success
@@ -495,6 +578,7 @@ class CompositePipelineRunner:
             self._logger.warning(
                 "Failed to delete checkpoint",
                 composite=self._config.name,
+                run_id=self._run_id_str,
                 error=str(delete_error),
             )
 

--- a/tests/unit/application/composite/test_coordinator_logging.py
+++ b/tests/unit/application/composite/test_coordinator_logging.py
@@ -1,0 +1,262 @@
+"""Unit tests for EnrichmentCoordinator logging.
+
+Tests verify that:
+1. Optional enricher failures are logged as warnings
+2. Required enricher failures are logged as errors
+3. Enricher success is logged as info
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import polars as pl
+import pytest
+
+from bioetl.application.composite.coordinator import EnrichmentCoordinator
+
+
+@pytest.fixture
+def mock_logger() -> MagicMock:
+    """Create a mock LoggerPort."""
+    logger = MagicMock()
+    logger.info = MagicMock()
+    logger.warning = MagicMock()
+    logger.error = MagicMock()
+    logger.debug = MagicMock()
+    return logger
+
+
+@pytest.fixture
+def mock_dq_config() -> MagicMock:
+    """Create a mock CompositeDQConfig."""
+    config = MagicMock()
+    config.get_enricher_hard_threshold = MagicMock(return_value=0.20)
+    return config
+
+
+@pytest.fixture
+def sample_keys() -> pl.DataFrame:
+    """Create sample keys DataFrame."""
+    return pl.DataFrame(
+        {
+            "chembl_id": ["CHEMBL1", "CHEMBL2"],
+            "doi": ["10.1000/abc", "10.1000/def"],
+        }
+    )
+
+
+@pytest.fixture
+def coordinator(mock_logger, mock_dq_config) -> EnrichmentCoordinator:
+    """Create EnrichmentCoordinator instance."""
+    return EnrichmentCoordinator(
+        logger=mock_logger,
+        dq_config=mock_dq_config,
+        max_concurrency=4,
+    )
+
+
+@pytest.mark.unit
+class TestCoordinatorOptionalEnricherLogging:
+    """Tests for optional enricher failure logging."""
+
+    @pytest.mark.asyncio
+    async def test_logs_warning_for_optional_enricher_failure(
+        self, coordinator, mock_logger, sample_keys
+    ) -> None:
+        """Test that optional enricher failures are logged as warnings."""
+        enricher_config = MagicMock()
+        enricher_config.pipeline = "pubmed"
+        enricher_config.required = False
+        enricher_config.timeout_seconds = 60
+        enricher_config.filter_condition = None
+
+        # Create a factory that returns a failing runner
+        def failing_factory(name: str, keys: pl.DataFrame) -> MagicMock:
+            runner = MagicMock()
+            runner.run = AsyncMock(side_effect=RuntimeError("API error"))
+            return runner
+
+        await coordinator.run_enrichers(
+            keys=sample_keys,
+            enrichers=[enricher_config],
+            completed=frozenset(),
+            runner_factory=failing_factory,
+        )
+
+        # Verify warning was logged
+        warning_calls = [
+            c
+            for c in mock_logger.warning.call_args_list
+            if c.args and "Optional enricher failed" in str(c.args[0])
+        ]
+        assert len(warning_calls) >= 1, "Should log warning for optional enricher failure"
+
+        # Verify warning includes required=False
+        assert any(
+            c.kwargs.get("required") is False for c in warning_calls
+        ), "Warning should indicate required=False"
+
+    @pytest.mark.asyncio
+    async def test_does_not_log_error_for_optional_enricher_failure(
+        self, coordinator, mock_logger, sample_keys
+    ) -> None:
+        """Test that optional enricher failures do not log errors."""
+        enricher_config = MagicMock()
+        enricher_config.pipeline = "pubmed"
+        enricher_config.required = False
+        enricher_config.timeout_seconds = 60
+        enricher_config.filter_condition = None
+
+        def failing_factory(name: str, keys: pl.DataFrame) -> MagicMock:
+            runner = MagicMock()
+            runner.run = AsyncMock(side_effect=RuntimeError("API error"))
+            return runner
+
+        await coordinator.run_enrichers(
+            keys=sample_keys,
+            enrichers=[enricher_config],
+            completed=frozenset(),
+            runner_factory=failing_factory,
+        )
+
+        # Verify no error was logged for optional enricher
+        error_calls = [
+            c
+            for c in mock_logger.error.call_args_list
+            if "pubmed" in str(c)
+        ]
+        assert len(error_calls) == 0, "Should not log error for optional enricher failure"
+
+
+@pytest.mark.unit
+class TestCoordinatorRequiredEnricherLogging:
+    """Tests for required enricher failure logging."""
+
+    @pytest.mark.asyncio
+    async def test_logs_error_for_required_enricher_failure(
+        self, coordinator, mock_logger, sample_keys
+    ) -> None:
+        """Test that required enricher failures are logged as errors.
+
+        Note: asyncio.gather(return_exceptions=True) catches exceptions,
+        so coordinator returns failed result instead of raising.
+        The actual exception raise happens in runner's _check_required_enrichers.
+        """
+        enricher_config = MagicMock()
+        enricher_config.pipeline = "crossref"
+        enricher_config.required = True
+        enricher_config.timeout_seconds = 60
+        enricher_config.filter_condition = None
+
+        def failing_factory(name: str, keys: pl.DataFrame) -> MagicMock:
+            runner = MagicMock()
+            runner.run = AsyncMock(side_effect=RuntimeError("API error"))
+            return runner
+
+        # Coordinator catches exceptions via asyncio.gather(return_exceptions=True)
+        # and returns failed results - doesn't raise
+        results = await coordinator.run_enrichers(
+            keys=sample_keys,
+            enrichers=[enricher_config],
+            completed=frozenset(),
+            runner_factory=failing_factory,
+        )
+
+        # Verify error was logged before exception was caught
+        error_calls = [
+            c
+            for c in mock_logger.error.call_args_list
+            if c.args and "Required enricher failed" in str(c.args[0])
+        ]
+        assert len(error_calls) >= 1, "Should log error for required enricher failure"
+
+        # Verify error includes required=True
+        assert any(
+            c.kwargs.get("required") is True for c in error_calls
+        ), "Error should indicate required=True"
+
+        # Verify result is failed
+        assert "crossref" in results
+        assert not results["crossref"].is_success
+
+
+@pytest.mark.unit
+class TestCoordinatorSuccessLogging:
+    """Tests for successful enricher logging."""
+
+    @pytest.mark.asyncio
+    async def test_logs_info_for_enricher_success(
+        self, coordinator, mock_logger, sample_keys
+    ) -> None:
+        """Test that enricher success is logged as info."""
+        enricher_config = MagicMock()
+        enricher_config.pipeline = "crossref"
+        enricher_config.required = True
+        enricher_config.timeout_seconds = 60
+        enricher_config.filter_condition = None
+
+        def success_factory(name: str, keys: pl.DataFrame) -> MagicMock:
+            runner = MagicMock()
+            runner.run = AsyncMock()
+            executor = MagicMock()
+            executor.records_silver = len(keys)
+            executor.records_quarantined = 0
+            runner._executor = executor
+            return runner
+
+        await coordinator.run_enrichers(
+            keys=sample_keys,
+            enrichers=[enricher_config],
+            completed=frozenset(),
+            runner_factory=success_factory,
+        )
+
+        # Verify info was logged for completion
+        info_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and "Enricher completed" in str(c.args[0])
+        ]
+        assert len(info_calls) >= 1, "Should log info for enricher completion"
+
+
+@pytest.mark.unit
+class TestCoordinatorTimeoutLogging:
+    """Tests for enricher timeout logging."""
+
+    @pytest.mark.asyncio
+    async def test_logs_warning_for_timeout(
+        self, coordinator, mock_logger, sample_keys
+    ) -> None:
+        """Test that enricher timeout is logged as warning."""
+        import asyncio
+
+        enricher_config = MagicMock()
+        enricher_config.pipeline = "slow_enricher"
+        enricher_config.required = False
+        enricher_config.timeout_seconds = 0.01  # Very short timeout
+        enricher_config.filter_condition = None
+
+        async def slow_run() -> None:
+            await asyncio.sleep(1.0)  # Will timeout
+
+        def slow_factory(name: str, keys: pl.DataFrame) -> MagicMock:
+            runner = MagicMock()
+            runner.run = slow_run
+            return runner
+
+        await coordinator.run_enrichers(
+            keys=sample_keys,
+            enrichers=[enricher_config],
+            completed=frozenset(),
+            runner_factory=slow_factory,
+        )
+
+        # Verify warning was logged for timeout
+        warning_calls = [
+            c
+            for c in mock_logger.warning.call_args_list
+            if c.args and "timed out" in str(c.args[0]).lower()
+        ]
+        assert len(warning_calls) >= 1, "Should log warning for enricher timeout"

--- a/tests/unit/application/composite/test_runner_enrichment_fsm.py
+++ b/tests/unit/application/composite/test_runner_enrichment_fsm.py
@@ -689,11 +689,11 @@ class TestEnrichmentLogging:
         """Test logging when enrichment stage starts."""
         await runner.run()
 
-        # Find log call with ENRICHING state
+        # Find log call with enriching state (lowercase) or phase event
         enriching_calls = [
             c
             for c in mock_logger.info.call_args_list
-            if "ENRICHING" in str(c) or "Enrichment stage started" in str(c)
+            if "enriching" in str(c).lower() or "enrichment_started" in str(c)
         ]
         assert len(enriching_calls) >= 1
 
@@ -702,12 +702,11 @@ class TestEnrichmentLogging:
         """Test logging when enrichment stage completes."""
         await runner.run()
 
-        # Find log call with ENRICHMENT_COMPLETED
+        # Find log call with enrichment_completed (lowercase) or phase event
         completed_calls = [
             c
             for c in mock_logger.info.call_args_list
-            if "ENRICHMENT_COMPLETED" in str(c)
-            or "Enrichment stage completed" in str(c)
+            if "enrichment_completed" in str(c).lower()
         ]
         assert len(completed_calls) >= 1
 

--- a/tests/unit/application/composite/test_runner_fsm_logging.py
+++ b/tests/unit/application/composite/test_runner_fsm_logging.py
@@ -1,0 +1,729 @@
+"""Unit tests for FSM state transition logging in CompositePipelineRunner.
+
+Tests verify that:
+1. FSM transitions are logged with structured context (from_state, to_state, stage)
+2. PipelineEvent.phase_started/phase_completed events are emitted
+3. All transitions are covered with appropriate log levels
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import polars as pl
+import pytest
+
+from bioetl.application.composite.checkpoint import CompositeCheckpointState
+from bioetl.application.composite.runner import (
+    CompositePipelineRunner,
+    CompositeRuntimeConfig,
+)
+from bioetl.domain.composite.result import (
+    EnrichmentResult,
+    MergeResult,
+)
+from bioetl.domain.composite.state import CompositePipelineState
+from bioetl.domain.events import PipelineEvent
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class TestPipelineEventPhaseHelpers:
+    """Tests for PipelineEvent.phase_started and phase_completed helpers."""
+
+    def test_phase_started_generates_correct_string(self) -> None:
+        """Test phase_started generates expected event string."""
+        assert PipelineEvent.phase_started("seed") == "seed_started"
+        assert PipelineEvent.phase_started("enrichment") == "enrichment_started"
+        assert PipelineEvent.phase_started("merge") == "merge_started"
+
+    def test_phase_completed_generates_correct_string(self) -> None:
+        """Test phase_completed generates expected event string."""
+        assert PipelineEvent.phase_completed("seed") == "seed_completed"
+        assert PipelineEvent.phase_completed("enrichment") == "enrichment_completed"
+        assert PipelineEvent.phase_completed("merge") == "merge_completed"
+
+
+@pytest.fixture
+def mock_logger() -> MagicMock:
+    """Create a mock LoggerPort that tracks all calls."""
+    logger = MagicMock()
+    logger.info = MagicMock()
+    logger.warning = MagicMock()
+    logger.error = MagicMock()
+    logger.debug = MagicMock()
+    return logger
+
+
+@pytest.fixture
+def mock_lock() -> AsyncMock:
+    """Create a mock LockPort."""
+    lock = AsyncMock()
+    lock.acquire = AsyncMock(return_value=True)
+    lock.release = AsyncMock()
+    return lock
+
+
+@pytest.fixture
+def mock_key_extractor() -> AsyncMock:
+    """Create a mock KeyExtractorService."""
+    extractor = AsyncMock()
+    extractor.extract = AsyncMock(
+        return_value=pl.DataFrame(
+            {
+                "chembl_id": ["CHEMBL1", "CHEMBL2"],
+                "doi": ["10.1000/abc", "10.1000/def"],
+            }
+        )
+    )
+    return extractor
+
+
+@pytest.fixture
+def mock_coordinator() -> AsyncMock:
+    """Create a mock EnrichmentCoordinator."""
+    coordinator = AsyncMock()
+    coordinator.run_enrichers = AsyncMock(
+        return_value={
+            "crossref": EnrichmentResult.success(
+                enricher_name="crossref",
+                records_input=2,
+                records_enriched=2,
+                records_not_found=0,
+                duration_seconds=5.0,
+            ),
+        }
+    )
+    return coordinator
+
+
+@pytest.fixture
+def mock_merger() -> AsyncMock:
+    """Create a mock MergeService."""
+    merger = AsyncMock()
+    merger.merge = AsyncMock(
+        return_value=MergeResult(
+            records_merged=2,
+            records_from_seed=2,
+            records_enriched=2,
+            records_fully_enriched=2,
+            sources_used=("seed", "crossref"),
+        )
+    )
+    return merger
+
+
+@pytest.fixture
+def mock_checkpoint_manager() -> AsyncMock:
+    """Create a mock CompositeCheckpointManager."""
+    manager = AsyncMock()
+    manager._saved_states: list[CompositeCheckpointState] = []
+
+    async def load_impl() -> CompositeCheckpointState:
+        return CompositeCheckpointState(
+            composite_name="test_composite",
+            run_id="00000000-0000-0000-0000-000000000123",
+            state=CompositePipelineState.NOT_STARTED,
+            created_at=datetime.now(tz=UTC),
+        )
+
+    async def save_impl(state: CompositeCheckpointState) -> None:
+        manager._saved_states.append(state)
+
+    manager.load = AsyncMock(side_effect=load_impl)
+    manager.save = AsyncMock(side_effect=save_impl)
+    manager.delete = AsyncMock()
+
+    return manager
+
+
+@pytest.fixture
+def mock_seed_runner_factory() -> Callable[[], MagicMock]:
+    """Create a mock seed runner factory."""
+
+    def factory() -> MagicMock:
+        runner = MagicMock()
+        runner.run = AsyncMock()
+        executor = MagicMock()
+        executor.records_fetched = 100
+        executor.records_silver = 95
+        runner._executor = executor
+        return runner
+
+    return factory
+
+
+@pytest.fixture
+def mock_enricher_runner_factory() -> Callable[[str, pl.DataFrame], MagicMock]:
+    """Create a mock enricher runner factory."""
+
+    def factory(name: str, keys: pl.DataFrame) -> MagicMock:
+        runner = MagicMock()
+        runner.run = AsyncMock()
+        executor = MagicMock()
+        executor.records_silver = len(keys)
+        executor.records_quarantined = 0
+        runner._executor = executor
+        return runner
+
+    return factory
+
+
+@pytest.fixture
+def sample_composite_config() -> MagicMock:
+    """Create a sample CompositeConfig."""
+    config = MagicMock()
+    config.name = "test_composite"
+    config.lock_key = "composite:test_composite"
+
+    config.seed = MagicMock()
+    config.seed.pipeline = "chembl_activity"
+    config.seed.silver_table = "silver/chembl/activity"
+    config.seed.output_keys = ("chembl_id", "doi")
+
+    enricher = MagicMock()
+    enricher.pipeline = "crossref"
+    enricher.required = True
+    enricher.silver_table = "silver/crossref/publication"
+    config.enrichers = [enricher]
+    config.required_enrichers = ["crossref"]
+
+    config.merge = MagicMock()
+    config.merge.output_silver_path = "silver/composite/test"
+    config.merge.output_gold_path = "gold/test_composite"
+
+    config.dq = MagicMock()
+    config.dq.soft_fail_threshold = 0.05
+    config.dq.hard_fail_threshold = 0.20
+
+    return config
+
+
+@pytest.fixture
+def runner(
+    sample_composite_config,
+    mock_seed_runner_factory,
+    mock_enricher_runner_factory,
+    mock_key_extractor,
+    mock_coordinator,
+    mock_merger,
+    mock_checkpoint_manager,
+    mock_logger,
+    mock_lock,
+) -> CompositePipelineRunner:
+    """Create a CompositePipelineRunner instance for testing."""
+    return CompositePipelineRunner(
+        config=sample_composite_config,
+        runtime=CompositeRuntimeConfig(resume=False, dry_run=False),
+        seed_runner_factory=mock_seed_runner_factory,
+        enricher_runner_factory=mock_enricher_runner_factory,
+        key_extractor=mock_key_extractor,
+        coordinator=mock_coordinator,
+        merger=mock_merger,
+        checkpoint_manager=mock_checkpoint_manager,
+        logger=mock_logger,
+        lock=mock_lock,
+        run_id="00000000-0000-0000-0000-000000000123",
+    )
+
+
+@pytest.mark.unit
+class TestFSMTransitionLogging:
+    """Tests for FSM state transition logging."""
+
+    @pytest.mark.asyncio
+    async def test_logs_fsm_transition_to_seed_running(
+        self, runner, mock_logger
+    ) -> None:
+        """Test FSM transition to SEED_RUNNING is logged."""
+        await runner.run()
+
+        # Find FSM transition log for SEED_RUNNING
+        fsm_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and "FSM state transition" in str(c.args[0])
+        ]
+        seed_running_calls = [
+            c for c in fsm_calls if "seed_running" in str(c.kwargs.get("to_state", ""))
+        ]
+        assert len(seed_running_calls) >= 1, "Should log FSM transition to SEED_RUNNING"
+
+    @pytest.mark.asyncio
+    async def test_logs_fsm_transition_to_seed_completed(
+        self, runner, mock_logger
+    ) -> None:
+        """Test FSM transition to SEED_COMPLETED is logged."""
+        await runner.run()
+
+        fsm_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and "FSM state transition" in str(c.args[0])
+        ]
+        seed_completed_calls = [
+            c
+            for c in fsm_calls
+            if "seed_completed" in str(c.kwargs.get("to_state", ""))
+        ]
+        assert (
+            len(seed_completed_calls) >= 1
+        ), "Should log FSM transition to SEED_COMPLETED"
+
+    @pytest.mark.asyncio
+    async def test_logs_fsm_transition_to_enriching(
+        self, runner, mock_logger
+    ) -> None:
+        """Test FSM transition to ENRICHING is logged."""
+        await runner.run()
+
+        fsm_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and "FSM state transition" in str(c.args[0])
+        ]
+        enriching_calls = [
+            c for c in fsm_calls if "enriching" in str(c.kwargs.get("to_state", ""))
+        ]
+        assert len(enriching_calls) >= 1, "Should log FSM transition to ENRICHING"
+
+    @pytest.mark.asyncio
+    async def test_logs_fsm_transition_to_enrichment_completed(
+        self, runner, mock_logger
+    ) -> None:
+        """Test FSM transition to ENRICHMENT_COMPLETED is logged."""
+        await runner.run()
+
+        fsm_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and "FSM state transition" in str(c.args[0])
+        ]
+        completed_calls = [
+            c
+            for c in fsm_calls
+            if "enrichment_completed" in str(c.kwargs.get("to_state", ""))
+        ]
+        assert (
+            len(completed_calls) >= 1
+        ), "Should log FSM transition to ENRICHMENT_COMPLETED"
+
+    @pytest.mark.asyncio
+    async def test_logs_fsm_transition_to_merging(
+        self, runner, mock_logger
+    ) -> None:
+        """Test FSM transition to MERGING is logged."""
+        await runner.run()
+
+        fsm_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and "FSM state transition" in str(c.args[0])
+        ]
+        merging_calls = [
+            c for c in fsm_calls if "merging" in str(c.kwargs.get("to_state", ""))
+        ]
+        assert len(merging_calls) >= 1, "Should log FSM transition to MERGING"
+
+    @pytest.mark.asyncio
+    async def test_logs_fsm_transition_to_completed(
+        self, runner, mock_logger
+    ) -> None:
+        """Test FSM transition to COMPLETED is logged."""
+        await runner.run()
+
+        fsm_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and "FSM state transition" in str(c.args[0])
+        ]
+        completed_calls = [
+            c
+            for c in fsm_calls
+            if c.kwargs.get("to_state") == "completed"
+        ]
+        assert len(completed_calls) >= 1, "Should log FSM transition to COMPLETED"
+
+    @pytest.mark.asyncio
+    async def test_fsm_transition_includes_context_fields(
+        self, runner, mock_logger
+    ) -> None:
+        """Test FSM transition logs include required context fields."""
+        await runner.run()
+
+        # Find any FSM transition log
+        fsm_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and "FSM state transition" in str(c.args[0])
+        ]
+        assert len(fsm_calls) > 0, "Should have FSM transition logs"
+
+        # Check that required fields are present in at least one call
+        for fsm_call in fsm_calls:
+            kwargs = fsm_call.kwargs
+            assert "from_state" in kwargs, "FSM log should include from_state"
+            assert "to_state" in kwargs, "FSM log should include to_state"
+            assert "composite" in kwargs, "FSM log should include composite"
+            assert "run_id" in kwargs, "FSM log should include run_id"
+            assert "stage" in kwargs, "FSM log should include stage"
+
+
+@pytest.mark.unit
+class TestPhaseEventLogging:
+    """Tests for PipelineEvent.phase_started/phase_completed logging."""
+
+    @pytest.mark.asyncio
+    async def test_logs_seed_started_phase_event(
+        self, runner, mock_logger
+    ) -> None:
+        """Test seed_started phase event is logged."""
+        await runner.run()
+
+        seed_started_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and "seed_started" in str(c.args[0])
+        ]
+        assert len(seed_started_calls) >= 1, "Should log seed_started phase event"
+
+    @pytest.mark.asyncio
+    async def test_logs_seed_completed_phase_event(
+        self, runner, mock_logger
+    ) -> None:
+        """Test seed_completed phase event is logged."""
+        await runner.run()
+
+        seed_completed_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and "seed_completed" in str(c.args[0])
+        ]
+        assert len(seed_completed_calls) >= 1, "Should log seed_completed phase event"
+
+    @pytest.mark.asyncio
+    async def test_logs_enrichment_started_phase_event(
+        self, runner, mock_logger
+    ) -> None:
+        """Test enrichment_started phase event is logged."""
+        await runner.run()
+
+        enrichment_started_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and "enrichment_started" in str(c.args[0])
+        ]
+        assert (
+            len(enrichment_started_calls) >= 1
+        ), "Should log enrichment_started phase event"
+
+    @pytest.mark.asyncio
+    async def test_logs_enrichment_completed_phase_event(
+        self, runner, mock_logger
+    ) -> None:
+        """Test enrichment_completed phase event is logged."""
+        await runner.run()
+
+        enrichment_completed_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and "enrichment_completed" in str(c.args[0])
+        ]
+        assert (
+            len(enrichment_completed_calls) >= 1
+        ), "Should log enrichment_completed phase event"
+
+    @pytest.mark.asyncio
+    async def test_logs_merge_started_phase_event(
+        self, runner, mock_logger
+    ) -> None:
+        """Test merge_started phase event is logged."""
+        await runner.run()
+
+        merge_started_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and "merge_started" in str(c.args[0])
+        ]
+        assert len(merge_started_calls) >= 1, "Should log merge_started phase event"
+
+    @pytest.mark.asyncio
+    async def test_logs_merge_completed_phase_event(
+        self, runner, mock_logger
+    ) -> None:
+        """Test merge_completed phase event is logged."""
+        await runner.run()
+
+        merge_completed_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and "merge_completed" in str(c.args[0])
+        ]
+        assert len(merge_completed_calls) >= 1, "Should log merge_completed phase event"
+
+
+@pytest.mark.unit
+class TestFSMFailureLogging:
+    """Tests for FSM FAILED state transition logging."""
+
+    @pytest.mark.asyncio
+    async def test_logs_fsm_transition_to_failed_on_merge_error(
+        self,
+        sample_composite_config,
+        mock_seed_runner_factory,
+        mock_enricher_runner_factory,
+        mock_key_extractor,
+        mock_coordinator,
+        mock_checkpoint_manager,
+        mock_logger,
+        mock_lock,
+    ) -> None:
+        """Test FSM transition to FAILED is logged when merge fails."""
+        mock_merger = AsyncMock()
+        mock_merger.merge.side_effect = RuntimeError("Merge failed: disk full")
+
+        runner = CompositePipelineRunner(
+            config=sample_composite_config,
+            runtime=CompositeRuntimeConfig(resume=False, dry_run=False),
+            seed_runner_factory=mock_seed_runner_factory,
+            enricher_runner_factory=mock_enricher_runner_factory,
+            key_extractor=mock_key_extractor,
+            coordinator=mock_coordinator,
+            merger=mock_merger,
+            checkpoint_manager=mock_checkpoint_manager,
+            logger=mock_logger,
+            lock=mock_lock,
+            run_id="00000000-0000-0000-0000-000000000123",
+        )
+
+        with pytest.raises(RuntimeError, match="Merge failed"):
+            await runner.run()
+
+        # Check for FSM transition to FAILED
+        fsm_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and "FSM state transition" in str(c.args[0])
+        ]
+        failed_calls = [
+            c for c in fsm_calls if c.kwargs.get("to_state") == "failed"
+        ]
+        assert len(failed_calls) >= 1, "Should log FSM transition to FAILED"
+
+    @pytest.mark.asyncio
+    async def test_logs_fsm_transition_to_failed_on_required_enricher_failure(
+        self,
+        sample_composite_config,
+        mock_seed_runner_factory,
+        mock_enricher_runner_factory,
+        mock_key_extractor,
+        mock_merger,
+        mock_checkpoint_manager,
+        mock_logger,
+        mock_lock,
+    ) -> None:
+        """Test FSM transition to FAILED logged when required enricher fails."""
+        mock_coordinator = AsyncMock()
+        mock_coordinator.run_enrichers = AsyncMock(
+            return_value={
+                "crossref": EnrichmentResult.failed(
+                    enricher_name="crossref",
+                    error_message="Connection timeout",
+                    records_input=2,
+                ),
+            }
+        )
+
+        runner = CompositePipelineRunner(
+            config=sample_composite_config,
+            runtime=CompositeRuntimeConfig(resume=False, dry_run=False),
+            seed_runner_factory=mock_seed_runner_factory,
+            enricher_runner_factory=mock_enricher_runner_factory,
+            key_extractor=mock_key_extractor,
+            coordinator=mock_coordinator,
+            merger=mock_merger,
+            checkpoint_manager=mock_checkpoint_manager,
+            logger=mock_logger,
+            lock=mock_lock,
+            run_id="00000000-0000-0000-0000-000000000123",
+        )
+
+        with pytest.raises(RuntimeError, match="Required enricher"):
+            await runner.run()
+
+        # Check for FSM transition to FAILED
+        fsm_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and "FSM state transition" in str(c.args[0])
+        ]
+        failed_calls = [
+            c for c in fsm_calls if c.kwargs.get("to_state") == "failed"
+        ]
+        assert len(failed_calls) >= 1, "Should log FSM transition to FAILED"
+
+        # Check that stage indicates required enricher failure
+        assert any(
+            c.kwargs.get("stage") == "required_enricher_failed" for c in failed_calls
+        ), "Stage should indicate required_enricher_failed"
+
+    @pytest.mark.asyncio
+    async def test_logs_fsm_transition_to_failed_on_seed_error(
+        self,
+        sample_composite_config,
+        mock_enricher_runner_factory,
+        mock_key_extractor,
+        mock_coordinator,
+        mock_merger,
+        mock_checkpoint_manager,
+        mock_logger,
+        mock_lock,
+    ) -> None:
+        """Test FSM transition to FAILED is logged when seed fails."""
+
+        def failing_seed_factory() -> MagicMock:
+            runner = MagicMock()
+            runner.run = AsyncMock(side_effect=RuntimeError("Seed failed: API error"))
+            return runner
+
+        runner = CompositePipelineRunner(
+            config=sample_composite_config,
+            runtime=CompositeRuntimeConfig(resume=False, dry_run=False),
+            seed_runner_factory=failing_seed_factory,
+            enricher_runner_factory=mock_enricher_runner_factory,
+            key_extractor=mock_key_extractor,
+            coordinator=mock_coordinator,
+            merger=mock_merger,
+            checkpoint_manager=mock_checkpoint_manager,
+            logger=mock_logger,
+            lock=mock_lock,
+            run_id="00000000-0000-0000-0000-000000000123",
+        )
+
+        with pytest.raises(RuntimeError, match="Seed failed"):
+            await runner.run()
+
+        # Check for FSM transition to FAILED
+        fsm_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and "FSM state transition" in str(c.args[0])
+        ]
+        failed_calls = [
+            c for c in fsm_calls if c.kwargs.get("to_state") == "failed"
+        ]
+        assert len(failed_calls) >= 1, "Should log FSM transition to FAILED"
+
+        # Check that stage indicates seed failure
+        assert any(
+            c.kwargs.get("stage") == "seed_failed" for c in failed_calls
+        ), "Stage should indicate seed_failed"
+
+
+@pytest.mark.unit
+class TestDryRunLogging:
+    """Tests for dry run mode FSM logging."""
+
+    @pytest.mark.asyncio
+    async def test_logs_dry_run_skip_merge_transition(
+        self,
+        sample_composite_config,
+        mock_seed_runner_factory,
+        mock_enricher_runner_factory,
+        mock_key_extractor,
+        mock_coordinator,
+        mock_merger,
+        mock_checkpoint_manager,
+        mock_logger,
+        mock_lock,
+    ) -> None:
+        """Test dry run logs FSM transition directly to COMPLETED."""
+        runner = CompositePipelineRunner(
+            config=sample_composite_config,
+            runtime=CompositeRuntimeConfig(resume=False, dry_run=True),
+            seed_runner_factory=mock_seed_runner_factory,
+            enricher_runner_factory=mock_enricher_runner_factory,
+            key_extractor=mock_key_extractor,
+            coordinator=mock_coordinator,
+            merger=mock_merger,
+            checkpoint_manager=mock_checkpoint_manager,
+            logger=mock_logger,
+            lock=mock_lock,
+            run_id="00000000-0000-0000-0000-000000000123",
+        )
+
+        await runner.run()
+
+        # Check for dry run skip merge FSM transition
+        fsm_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and "FSM state transition" in str(c.args[0])
+        ]
+        dry_run_calls = [
+            c for c in fsm_calls if c.kwargs.get("stage") == "dry_run_skip_merge"
+        ]
+        assert len(dry_run_calls) >= 1, "Should log FSM transition for dry run skip"
+
+        # Verify merge was NOT called
+        mock_merger.merge.assert_not_called()
+
+
+@pytest.mark.unit
+class TestNoEnrichersLogging:
+    """Tests for FSM logging when no enrichers to run."""
+
+    @pytest.mark.asyncio
+    async def test_logs_enrichment_empty_transition(
+        self,
+        sample_composite_config,
+        mock_seed_runner_factory,
+        mock_enricher_runner_factory,
+        mock_key_extractor,
+        mock_coordinator,
+        mock_merger,
+        mock_checkpoint_manager,
+        mock_logger,
+        mock_lock,
+    ) -> None:
+        """Test FSM logs transition for empty enrichment stage."""
+        sample_composite_config.enrichers = []
+        sample_composite_config.required_enrichers = []
+
+        runner = CompositePipelineRunner(
+            config=sample_composite_config,
+            runtime=CompositeRuntimeConfig(resume=False, dry_run=False),
+            seed_runner_factory=mock_seed_runner_factory,
+            enricher_runner_factory=mock_enricher_runner_factory,
+            key_extractor=mock_key_extractor,
+            coordinator=mock_coordinator,
+            merger=mock_merger,
+            checkpoint_manager=mock_checkpoint_manager,
+            logger=mock_logger,
+            lock=mock_lock,
+            run_id="00000000-0000-0000-0000-000000000123",
+        )
+
+        await runner.run()
+
+        # Check for FSM transition with empty enrichment stage
+        fsm_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and "FSM state transition" in str(c.args[0])
+        ]
+        empty_enrichment_calls = [
+            c for c in fsm_calls if c.kwargs.get("stage") == "enrichment_start_empty"
+        ]
+        assert (
+            len(empty_enrichment_calls) >= 1
+        ), "Should log FSM transition for empty enrichment"
+
+        # Verify reason is included
+        assert any(
+            c.kwargs.get("reason") == "no_enrichers_to_run"
+            for c in empty_enrichment_calls
+        ), "Should include reason for empty enrichment"


### PR DESCRIPTION
Improves logging and observability for composite pipeline FSM state transitions:

Runner changes (runner.py):
- Add _log_fsm_transition() calls for ALL state transitions with structured context:
  - from_state, to_state, stage, composite, run_id fields
  - Additional context like error, enrichers list, records counts
- Integrate PipelineEvent.phase_started/phase_completed for phases:
  - seed_started/seed_completed with records info
  - enrichment_started/enrichment_completed with enricher list
  - merge_started/merge_completed with records merged
- Add FSM transition logging for failure scenarios:
  - seed_failed, required_enricher_failed, merge_failed
  - dry_run_skip_merge, enrichment_start_empty (no enrichers case)
- Ensure all state changes are traceable for debugging

Coordinator changes (coordinator.py):
- Use warning level for optional enricher failures (pipeline continues)
- Use error level for required enricher failures (will stop pipeline)
- Add required=True/False field to distinguish enricher types in logs

Test changes:
- Add test_runner_fsm_logging.py with 20 tests for FSM transition logging
- Add test_coordinator_logging.py with 5 tests for enricher failure logging
- Update test_runner_enrichment_fsm.py to match new lowercase state values

This improves operational observability by ensuring every FSM state change is logged with sufficient context for debugging and monitoring.