### PR TITLE
Handle required flag in pipeline transitions

### DIFF
--- a/src/bioetl/application/composite/runner.py
+++ b/src/bioetl/application/composite/runner.py
@@ -363,6 +363,11 @@ class CompositePipelineRunner:
         # Merge with previously completed enrichers
         enrichment_results.update(state.enrichment_results)
 
+        # Step 4b: Add NOT_RUN results for optional enrichers skipped due to required_only
+        enrichment_results = self._add_not_run_results(
+            enrichment_results, enrichers_to_run, state
+        )
+
         # Step 5: Check required enrichers with FSM FAILED transition on error
         try:
             self._check_required_enrichers(enrichment_results)
@@ -410,12 +415,26 @@ class CompositePipelineRunner:
         started = self._started_at or completed_at  # Fallback if not set
         total_duration = (completed_at - started).total_seconds()
 
-        self._logger.info(
-            PipelineEvent.COMPLETE,
-            composite=self._config.name,
-            run_id=self._run_id_str,
-            duration_seconds=total_duration,
-        )
+        # Calculate if we had warnings from optional enricher failures
+        had_warnings = self._calculate_had_warnings(enrichment_results)
+
+        # Log completion with appropriate status
+        if had_warnings:
+            self._logger.info(
+                PipelineEvent.COMPLETE,
+                composite=self._config.name,
+                run_id=self._run_id_str,
+                duration_seconds=total_duration,
+                status="completed_with_warnings",
+                had_warnings=True,
+            )
+        else:
+            self._logger.info(
+                PipelineEvent.COMPLETE,
+                composite=self._config.name,
+                run_id=self._run_id_str,
+                duration_seconds=total_duration,
+            )
 
         return CompositeResult(
             composite_name=self._config.name,
@@ -426,6 +445,7 @@ class CompositePipelineRunner:
             total_duration_seconds=total_duration,
             started_at=self._started_at,
             completed_at=completed_at,
+            had_warnings=had_warnings,
             _required_enrichers=frozenset(self._config.required_enrichers),
         )
 
@@ -502,9 +522,12 @@ class CompositePipelineRunner:
             )
 
             try:
+                # Get only enrichers with data to merge (exclude SKIPPED/NOT_RUN)
+                mergeable_enrichers = self._get_mergeable_enrichers(enrichment_results)
+
                 merge_result = await self._merger.merge(
                     seed_table=self._config.seed.silver_table,
-                    enrichers=self._config.enrichers,
+                    enrichers=mergeable_enrichers,
                     enrichment_results=enrichment_results,
                     run_id=self._run_id_str,
                 )
@@ -712,6 +735,143 @@ class CompositePipelineRunner:
                     f"{result.error_message or result.status.value}"
                 )
 
+    def _add_not_run_results(
+        self,
+        enrichment_results: dict[str, EnrichmentResult],
+        enrichers_to_run: list[EnricherConfig],
+        state: CompositeCheckpointState,
+    ) -> dict[str, EnrichmentResult]:
+        """Add NOT_RUN results for optional enrichers skipped due to required_only mode.
+
+        When required_only is True, optional enrichers are not executed. This method
+        adds explicit NOT_RUN results for these enrichers so they appear in the
+        final enrichment_results for complete lineage tracking.
+
+        Args:
+            enrichment_results: Current enrichment results from executed enrichers.
+            enrichers_to_run: List of enrichers that were actually run.
+            state: Current checkpoint state.
+
+        Returns:
+            Updated enrichment_results with NOT_RUN entries for skipped optional enrichers.
+        """
+        if not self._runtime.required_only:
+            return enrichment_results
+
+        # Get set of enrichers that were actually run or previously completed
+        run_names = {e.pipeline for e in enrichers_to_run}
+        completed_names = state.completed_enrichers
+
+        # Find optional enrichers that were skipped due to required_only
+        for enricher in self._config.enrichers:
+            # Only process optional enrichers
+            if enricher.required:
+                continue
+
+            # Skip if this enricher was run or previously completed
+            if enricher.pipeline in run_names:
+                continue
+            if enricher.pipeline in completed_names:
+                continue
+
+            # Skip if already in results (shouldn't happen, but defensive)
+            if enricher.pipeline in enrichment_results:
+                continue
+
+            # Add NOT_RUN result for this skipped optional enricher
+            enrichment_results[enricher.pipeline] = EnrichmentResult.not_run(
+                enricher_name=enricher.pipeline,
+                reason="Skipped due to required_only mode",
+            )
+
+            self._logger.info(
+                "Optional enricher not run",
+                composite=self._config.name,
+                enricher=enricher.pipeline,
+                reason="required_only_mode",
+            )
+
+        return enrichment_results
+
+    def _calculate_had_warnings(
+        self, enrichment_results: dict[str, EnrichmentResult]
+    ) -> bool:
+        """Calculate if the pipeline had warnings from optional enricher failures.
+
+        A warning occurs when an optional (non-required) enricher fails but the
+        pipeline can still complete successfully. This allows users to distinguish
+        between clean completions and completions with issues.
+
+        Args:
+            enrichment_results: All enrichment results.
+
+        Returns:
+            True if any optional enricher failed (status FAILED or TIMEOUT).
+        """
+        required_enrichers = frozenset(self._config.required_enrichers)
+
+        for name, result in enrichment_results.items():
+            # Skip required enrichers - their failures would already have raised
+            if name in required_enrichers:
+                continue
+
+            # Check for failure statuses (FAILED, TIMEOUT)
+            if result.status in (EnrichmentStatus.FAILED, EnrichmentStatus.TIMEOUT):
+                self._logger.warning(
+                    "Optional enricher failed",
+                    composite=self._config.name,
+                    enricher=name,
+                    status=result.status.value,
+                    error_message=result.error_message,
+                )
+                return True
+
+        return False
+
+    def _get_mergeable_enrichers(
+        self,
+        enrichment_results: dict[str, EnrichmentResult],
+    ) -> list[EnricherConfig]:
+        """Get list of enrichers that should be included in merge.
+
+        Excludes enrichers with NOT_RUN or SKIPPED status since they have no
+        data to merge. This prevents file I/O errors when trying to read
+        non-existent or empty Silver tables.
+
+        Args:
+            enrichment_results: All enrichment results.
+
+        Returns:
+            List of EnricherConfig for enrichers that have data to merge.
+        """
+        # Statuses that indicate no data to merge
+        non_mergeable_statuses = (
+            EnrichmentStatus.SKIPPED,
+            EnrichmentStatus.NOT_RUN,
+        )
+
+        mergeable: list[EnricherConfig] = []
+        for enricher_cfg in self._config.enrichers:
+            result = enrichment_results.get(enricher_cfg.pipeline)
+
+            # If no result, don't include in merge
+            if result is None:
+                continue
+
+            # If status indicates no data, don't include in merge
+            if result.status in non_mergeable_statuses:
+                self._logger.debug(
+                    "Excluding enricher from merge",
+                    enricher=enricher_cfg.pipeline,
+                    status=result.status.value,
+                    reason="no_data_to_merge",
+                )
+                continue
+
+            mergeable.append(enricher_cfg)
+
+        return mergeable
+
     def _log_enrichment_summary(
         self, enrichment_results: dict[str, EnrichmentResult]
     ) -> None:
@@ -729,6 +889,7 @@ class CompositePipelineRunner:
         failed_count = 0
         skipped_count = 0
         timeout_count = 0
+        not_run_count = 0
 
         total_records_input = 0
         total_records_enriched = 0
@@ -736,6 +897,7 @@ class CompositePipelineRunner:
 
         failed_enrichers: list[str] = []
         successful_enrichers: list[str] = []
+        not_run_enrichers: list[str] = []
 
         for name, result in enrichment_results.items():
             total_records_input += result.records_input
@@ -756,6 +918,9 @@ class CompositePipelineRunner:
             elif result.status == EnrichmentStatus.TIMEOUT:
                 timeout_count += 1
                 failed_enrichers.append(name)
+            elif result.status == EnrichmentStatus.NOT_RUN:
+                not_run_count += 1
+                not_run_enrichers.append(name)
 
         self._logger.info(
             "Enrichment summary",
@@ -766,8 +931,10 @@ class CompositePipelineRunner:
             failed=failed_count,
             skipped=skipped_count,
             timeout=timeout_count,
+            not_run=not_run_count,
             successful_enrichers=successful_enrichers,
             failed_enrichers=failed_enrichers if failed_enrichers else None,
+            not_run_enrichers=not_run_enrichers if not_run_enrichers else None,
             total_records_input=total_records_input,
             total_records_enriched=total_records_enriched,
             total_records_errored=total_records_errored,

--- a/src/bioetl/domain/composite/result.py
+++ b/src/bioetl/domain/composite/result.py
@@ -136,6 +136,30 @@ class EnrichmentResult:
             duration_seconds=timeout_seconds,
         )
 
+    @classmethod
+    def not_run(
+        cls,
+        enricher_name: str,
+        reason: str = "Pipeline not executed (required_only mode)",
+    ) -> EnrichmentResult:
+        """Factory for not-run enrichment result.
+
+        Used when an enricher is intentionally not executed,
+        for example due to required_only mode or explicit exclusion.
+
+        Args:
+            enricher_name: Name of the enricher pipeline.
+            reason: Human-readable reason why pipeline was not run.
+
+        Returns:
+            EnrichmentResult with NOT_RUN status.
+        """
+        return cls(
+            enricher_name=enricher_name,
+            status=EnrichmentStatus.NOT_RUN,
+            error_message=reason,
+        )
+
 
 @dataclass(frozen=True, slots=True)
 class SeedResult:
@@ -186,7 +210,23 @@ class MergeResult:
 
 @dataclass(frozen=True, slots=True)
 class CompositeResult:
-    """Complete result of composite pipeline execution."""
+    """Complete result of composite pipeline execution.
+
+    Attributes:
+        composite_name: Name of the composite pipeline.
+        composite_run_id: Unique run identifier.
+        seed_result: Result of seed pipeline execution.
+        enrichment_results: Results per enricher (keyed by pipeline name).
+        merge_result: Result of merge operation (None if not completed).
+        total_duration_seconds: Total execution time.
+        started_at: Execution start timestamp.
+        completed_at: Execution end timestamp.
+        lineage: Optional lineage metadata.
+        had_warnings: True if any optional enrichers failed but pipeline completed.
+            This indicates "completed with warnings" status - the pipeline succeeded
+            but some non-required enrichments did not complete successfully.
+        _required_enrichers: Internal set of required enricher names.
+    """
 
     composite_name: str
     composite_run_id: str
@@ -197,6 +237,7 @@ class CompositeResult:
     started_at: datetime | None = None
     completed_at: datetime | None = None
     lineage: LineageMetadata | None = None
+    had_warnings: bool = False
     _required_enrichers: frozenset[str] = field(default_factory=frozenset)
 
     @property
@@ -234,6 +275,37 @@ class CompositeResult:
         ]
 
     @property
+    def skipped_enrichers(self) -> list[str]:
+        """List of enrichers that were skipped (filter excluded all records)."""
+        return [
+            n
+            for n, r in self.enrichment_results.items()
+            if r.status == EnrichmentStatus.SKIPPED
+        ]
+
+    @property
+    def not_run_enrichers(self) -> list[str]:
+        """List of enrichers that were not run (e.g., required_only mode)."""
+        return [
+            n
+            for n, r in self.enrichment_results.items()
+            if r.status == EnrichmentStatus.NOT_RUN
+        ]
+
+    @property
+    def optional_failed_enrichers(self) -> list[str]:
+        """List of optional enrichers that failed.
+
+        These are enrichers that failed but are not required,
+        so the pipeline can still complete successfully.
+        """
+        return [
+            n
+            for n, r in self.enrichment_results.items()
+            if r.status == EnrichmentStatus.FAILED and n not in self._required_enrichers
+        ]
+
+    @property
     def total_records_enriched(self) -> int:
         """Total records enriched across all enrichers."""
         return sum(r.records_enriched for r in self.enrichment_results.values())
@@ -244,10 +316,14 @@ class CompositeResult:
             "composite_name": self.composite_name,
             "composite_run_id": self.composite_run_id,
             "is_success": self.is_success,
+            "had_warnings": self.had_warnings,
             "seed_records": self.seed_result.records_silver,
             "enrichers_run": len(self.enrichment_results),
             "enrichers_succeeded": len(self.successful_enrichers),
             "enrichers_failed": len(self.failed_enrichers),
+            "enrichers_skipped": len(self.skipped_enrichers),
+            "enrichers_not_run": len(self.not_run_enrichers),
+            "optional_failures": self.optional_failed_enrichers or None,
             "records_merged": self.merge_result.records_merged
             if self.merge_result
             else 0,

--- a/tests/unit/application/composite/test_runner_required_flag.py
+++ b/tests/unit/application/composite/test_runner_required_flag.py
@@ -1,0 +1,640 @@
+"""Unit tests for CompositePipelineRunner required flag handling.
+
+Tests for:
+- Optional enricher failure handling (had_warnings)
+- NOT_RUN status for skipped optional enrichers (required_only mode)
+- Mergeable enricher filtering
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import polars as pl
+import pytest
+
+from bioetl.application.composite.checkpoint import CompositeCheckpointState
+from bioetl.application.composite.runner import (
+    CompositePipelineRunner,
+    CompositeRuntimeConfig,
+)
+from bioetl.domain.composite.result import (
+    EnrichmentResult,
+    EnrichmentStatus,
+    MergeResult,
+    SeedResult,
+)
+from bioetl.domain.composite.state import CompositePipelineState
+
+
+@dataclass
+class MockEnricherConfig:
+    """Mock enricher configuration."""
+
+    pipeline: str
+    join_keys: tuple[str, ...] = ("doi",)
+    required: bool = False
+    filter_condition: str | None = None
+    timeout_seconds: int = 600
+    silver_table: str | None = None
+
+
+@dataclass
+class MockCompositeConfig:
+    """Mock composite configuration for testing."""
+
+    name: str = "test_composite"
+    lock_key: str = "lock:test_composite"
+
+    @dataclass
+    class SeedConfig:
+        pipeline: str = "chembl_activity"
+        silver_table: str = "chembl_activity"
+        output_keys: tuple[str, ...] = ("chembl_id", "doi")
+
+    @dataclass
+    class MergeConfig:
+        output_silver_path: str = "silver/composite"
+        output_gold_path: str = "gold/composite"
+
+    @dataclass
+    class DQConfig:
+        soft_fail_threshold: float = 0.05
+        hard_fail_threshold: float = 0.20
+
+    seed: SeedConfig = None  # type: ignore[assignment]
+    merge: MergeConfig = None  # type: ignore[assignment]
+    dq: DQConfig = None  # type: ignore[assignment]
+    enrichers: tuple[MockEnricherConfig, ...] = ()
+
+    def __post_init__(self):
+        if self.seed is None:
+            self.seed = self.SeedConfig()
+        if self.merge is None:
+            self.merge = self.MergeConfig()
+        if self.dq is None:
+            self.dq = self.DQConfig()
+        if not self.enrichers:
+            # Default: one required, one optional enricher
+            self.enrichers = (
+                MockEnricherConfig(pipeline="crossref", required=True),
+                MockEnricherConfig(pipeline="pubmed", required=False),
+            )
+
+    @property
+    def required_enrichers(self) -> tuple[str, ...]:
+        return tuple(e.pipeline for e in self.enrichers if e.required)
+
+
+class MockPipelineRunner:
+    """Mock PipelineRunner for testing."""
+
+    def __init__(self, should_fail: bool = False, error_message: str = "Failed"):
+        self._should_fail = should_fail
+        self._error_message = error_message
+        self.run_called = False
+        self._executor = MagicMock()
+        self._executor.records_fetched = 100
+        self._executor.records_silver = 95
+
+    async def run(self):
+        self.run_called = True
+        if self._should_fail:
+            raise RuntimeError(self._error_message)
+
+
+def create_mock_logger() -> MagicMock:
+    """Create a mock logger."""
+    logger = MagicMock()
+    logger.info = MagicMock()
+    logger.error = MagicMock()
+    logger.warning = MagicMock()
+    logger.debug = MagicMock()
+    return logger
+
+
+def create_mock_lock() -> AsyncMock:
+    """Create a mock lock."""
+    lock = AsyncMock()
+    lock.acquire = AsyncMock(return_value=True)
+    lock.release = AsyncMock(return_value=True)
+    return lock
+
+
+def create_mock_checkpoint_manager(
+    initial_state: CompositeCheckpointState | None = None,
+) -> AsyncMock:
+    """Create a mock checkpoint manager."""
+    manager = AsyncMock()
+    if initial_state is None:
+        initial_state = CompositeCheckpointState(
+            composite_name="test_composite",
+            run_id=str(uuid4()),
+            created_at=datetime.now(tz=UTC),
+        )
+    manager.load = AsyncMock(return_value=initial_state)
+    manager.save = AsyncMock()
+    manager.delete = AsyncMock()
+    return manager
+
+
+def create_mock_key_extractor() -> AsyncMock:
+    """Create a mock key extractor."""
+    extractor = AsyncMock()
+    extractor.extract = AsyncMock(
+        return_value=pl.DataFrame({"chembl_id": ["CHEMBL123"], "doi": ["10.1234/test"]})
+    )
+    return extractor
+
+
+def create_mock_coordinator(
+    enrichment_results: dict[str, EnrichmentResult] | None = None,
+) -> AsyncMock:
+    """Create a mock enrichment coordinator."""
+    coordinator = AsyncMock()
+    if enrichment_results is None:
+        enrichment_results = {}
+    coordinator.run_enrichers = AsyncMock(return_value=enrichment_results)
+    return coordinator
+
+
+def create_mock_merger() -> AsyncMock:
+    """Create a mock merger."""
+    merger = AsyncMock()
+    merger.merge = AsyncMock(
+        return_value=MergeResult(
+            records_merged=100,
+            records_from_seed=100,
+            records_enriched=0,
+            records_fully_enriched=0,
+            duration_seconds=1.0,
+        )
+    )
+    return merger
+
+
+def create_runner(
+    config: MockCompositeConfig | None = None,
+    seed_runner: MockPipelineRunner | None = None,
+    checkpoint_manager: AsyncMock | None = None,
+    coordinator: AsyncMock | None = None,
+    merger: AsyncMock | None = None,
+    logger: MagicMock | None = None,
+    runtime: CompositeRuntimeConfig | None = None,
+) -> CompositePipelineRunner:
+    """Create a CompositePipelineRunner for testing."""
+    if config is None:
+        config = MockCompositeConfig()
+    if seed_runner is None:
+        seed_runner = MockPipelineRunner()
+    if checkpoint_manager is None:
+        checkpoint_manager = create_mock_checkpoint_manager()
+    if coordinator is None:
+        coordinator = create_mock_coordinator()
+    if merger is None:
+        merger = create_mock_merger()
+    if logger is None:
+        logger = create_mock_logger()
+    if runtime is None:
+        runtime = CompositeRuntimeConfig()
+
+    return CompositePipelineRunner(
+        config=config,
+        runtime=runtime,
+        seed_runner_factory=lambda: seed_runner,
+        enricher_runner_factory=lambda name, df: MockPipelineRunner(),
+        key_extractor=create_mock_key_extractor(),
+        coordinator=coordinator,
+        merger=merger,
+        checkpoint_manager=checkpoint_manager,
+        logger=logger,
+        lock=create_mock_lock(),
+    )
+
+
+class TestOptionalEnricherFailure:
+    """Tests for optional enricher failure handling."""
+
+    @pytest.mark.asyncio
+    async def test_optional_failure_does_not_raise(self):
+        """Pipeline should complete when optional enricher fails."""
+        # Create coordinator that returns failed optional enricher
+        enrichment_results = {
+            "crossref": EnrichmentResult.success(
+                enricher_name="crossref",
+                records_input=100,
+                records_enriched=90,
+            ),
+            "pubmed": EnrichmentResult.failed(
+                enricher_name="pubmed",
+                error_message="API error",
+            ),
+        }
+        coordinator = create_mock_coordinator(enrichment_results)
+
+        runner = create_runner(coordinator=coordinator)
+
+        # Should not raise
+        result = await runner.run()
+
+        assert result is not None
+        assert result.is_success is True
+
+    @pytest.mark.asyncio
+    async def test_optional_failure_sets_had_warnings(self):
+        """had_warnings should be True when optional enricher fails."""
+        enrichment_results = {
+            "crossref": EnrichmentResult.success(
+                enricher_name="crossref",
+                records_input=100,
+                records_enriched=90,
+            ),
+            "pubmed": EnrichmentResult.failed(
+                enricher_name="pubmed",
+                error_message="Connection timeout",
+            ),
+        }
+        coordinator = create_mock_coordinator(enrichment_results)
+
+        runner = create_runner(coordinator=coordinator)
+        result = await runner.run()
+
+        assert result.had_warnings is True
+
+    @pytest.mark.asyncio
+    async def test_no_warnings_when_all_succeed(self):
+        """had_warnings should be False when all enrichers succeed."""
+        enrichment_results = {
+            "crossref": EnrichmentResult.success(
+                enricher_name="crossref",
+                records_input=100,
+                records_enriched=90,
+            ),
+            "pubmed": EnrichmentResult.success(
+                enricher_name="pubmed",
+                records_input=100,
+                records_enriched=80,
+            ),
+        }
+        coordinator = create_mock_coordinator(enrichment_results)
+
+        runner = create_runner(coordinator=coordinator)
+        result = await runner.run()
+
+        assert result.had_warnings is False
+
+    @pytest.mark.asyncio
+    async def test_required_failure_raises(self):
+        """Pipeline should fail when required enricher fails."""
+        enrichment_results = {
+            "crossref": EnrichmentResult.failed(
+                enricher_name="crossref",
+                error_message="Critical failure",
+            ),
+            "pubmed": EnrichmentResult.success(
+                enricher_name="pubmed",
+                records_input=100,
+                records_enriched=80,
+            ),
+        }
+        coordinator = create_mock_coordinator(enrichment_results)
+
+        runner = create_runner(coordinator=coordinator)
+
+        with pytest.raises(RuntimeError, match="crossref"):
+            await runner.run()
+
+    @pytest.mark.asyncio
+    async def test_optional_timeout_sets_had_warnings(self):
+        """had_warnings should be True when optional enricher times out."""
+        enrichment_results = {
+            "crossref": EnrichmentResult.success(
+                enricher_name="crossref",
+                records_input=100,
+                records_enriched=90,
+            ),
+            "pubmed": EnrichmentResult.timeout(
+                enricher_name="pubmed",
+                timeout_seconds=600,
+                records_input=100,
+            ),
+        }
+        coordinator = create_mock_coordinator(enrichment_results)
+
+        runner = create_runner(coordinator=coordinator)
+        result = await runner.run()
+
+        assert result.had_warnings is True
+
+    @pytest.mark.asyncio
+    async def test_optional_failure_logged_as_warning(self):
+        """Optional enricher failure should be logged as warning."""
+        enrichment_results = {
+            "crossref": EnrichmentResult.success(
+                enricher_name="crossref",
+                records_input=100,
+                records_enriched=90,
+            ),
+            "pubmed": EnrichmentResult.failed(
+                enricher_name="pubmed",
+                error_message="API error",
+            ),
+        }
+        coordinator = create_mock_coordinator(enrichment_results)
+        logger = create_mock_logger()
+
+        runner = create_runner(coordinator=coordinator, logger=logger)
+        await runner.run()
+
+        # Check that warning was logged for optional failure
+        warning_calls = [
+            c for c in logger.warning.call_args_list if "Optional enricher failed" in str(c)
+        ]
+        assert len(warning_calls) >= 1
+
+
+class TestRequiredOnlyMode:
+    """Tests for required_only mode and NOT_RUN status."""
+
+    @pytest.mark.asyncio
+    async def test_optional_enrichers_not_run_in_required_only_mode(self):
+        """Optional enrichers should not be executed in required_only mode."""
+        # Create coordinator that returns only required enricher result
+        enrichment_results = {
+            "crossref": EnrichmentResult.success(
+                enricher_name="crossref",
+                records_input=100,
+                records_enriched=90,
+            ),
+        }
+        coordinator = create_mock_coordinator(enrichment_results)
+
+        runner = create_runner(
+            coordinator=coordinator,
+            runtime=CompositeRuntimeConfig(required_only=True),
+        )
+        result = await runner.run()
+
+        # pubmed should have NOT_RUN status
+        assert "pubmed" in result.enrichment_results
+        assert result.enrichment_results["pubmed"].status == EnrichmentStatus.NOT_RUN
+        assert "required_only" in result.enrichment_results["pubmed"].error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_not_run_enrichers_in_result(self):
+        """NOT_RUN enrichers should appear in enrichment_results."""
+        enrichment_results = {
+            "crossref": EnrichmentResult.success(
+                enricher_name="crossref",
+                records_input=100,
+                records_enriched=90,
+            ),
+        }
+        coordinator = create_mock_coordinator(enrichment_results)
+
+        runner = create_runner(
+            coordinator=coordinator,
+            runtime=CompositeRuntimeConfig(required_only=True),
+        )
+        result = await runner.run()
+
+        assert "pubmed" in result.not_run_enrichers
+
+    @pytest.mark.asyncio
+    async def test_not_run_does_not_affect_success(self):
+        """NOT_RUN enrichers should not affect pipeline success."""
+        enrichment_results = {
+            "crossref": EnrichmentResult.success(
+                enricher_name="crossref",
+                records_input=100,
+                records_enriched=90,
+            ),
+        }
+        coordinator = create_mock_coordinator(enrichment_results)
+
+        runner = create_runner(
+            coordinator=coordinator,
+            runtime=CompositeRuntimeConfig(required_only=True),
+        )
+        result = await runner.run()
+
+        assert result.is_success is True
+        assert result.had_warnings is False
+
+    @pytest.mark.asyncio
+    async def test_not_run_logged_as_info(self):
+        """NOT_RUN enrichers should be logged as info."""
+        enrichment_results = {
+            "crossref": EnrichmentResult.success(
+                enricher_name="crossref",
+                records_input=100,
+                records_enriched=90,
+            ),
+        }
+        coordinator = create_mock_coordinator(enrichment_results)
+        logger = create_mock_logger()
+
+        runner = create_runner(
+            coordinator=coordinator,
+            logger=logger,
+            runtime=CompositeRuntimeConfig(required_only=True),
+        )
+        await runner.run()
+
+        # Check that info was logged for skipped enricher
+        info_calls = [
+            c for c in logger.info.call_args_list if "Optional enricher not run" in str(c)
+        ]
+        assert len(info_calls) >= 1
+
+
+class TestMergeableEnrichers:
+    """Tests for mergeable enricher filtering."""
+
+    @pytest.mark.asyncio
+    async def test_not_run_enrichers_excluded_from_merge(self):
+        """NOT_RUN enrichers should not be passed to merger."""
+        enrichment_results = {
+            "crossref": EnrichmentResult.success(
+                enricher_name="crossref",
+                records_input=100,
+                records_enriched=90,
+            ),
+        }
+        coordinator = create_mock_coordinator(enrichment_results)
+        merger = create_mock_merger()
+
+        runner = create_runner(
+            coordinator=coordinator,
+            merger=merger,
+            runtime=CompositeRuntimeConfig(required_only=True),
+        )
+        await runner.run()
+
+        # Check merger.merge was called
+        merger.merge.assert_called_once()
+        call_kwargs = merger.merge.call_args
+        passed_enrichers = call_kwargs.kwargs.get("enrichers") or call_kwargs.args[1]
+
+        # Only crossref should be passed (pubmed is NOT_RUN)
+        enricher_names = [e.pipeline for e in passed_enrichers]
+        assert "crossref" in enricher_names
+        assert "pubmed" not in enricher_names
+
+    @pytest.mark.asyncio
+    async def test_skipped_enrichers_excluded_from_merge(self):
+        """SKIPPED enrichers should not be passed to merger."""
+        enrichment_results = {
+            "crossref": EnrichmentResult.success(
+                enricher_name="crossref",
+                records_input=100,
+                records_enriched=90,
+            ),
+            "pubmed": EnrichmentResult.skipped(
+                enricher_name="pubmed",
+                reason="No pmid keys",
+            ),
+        }
+        coordinator = create_mock_coordinator(enrichment_results)
+        merger = create_mock_merger()
+
+        runner = create_runner(
+            coordinator=coordinator,
+            merger=merger,
+        )
+        await runner.run()
+
+        # Check merger.merge was called
+        merger.merge.assert_called_once()
+        call_kwargs = merger.merge.call_args
+        passed_enrichers = call_kwargs.kwargs.get("enrichers") or call_kwargs.args[1]
+
+        # Only crossref should be passed (pubmed is SKIPPED)
+        enricher_names = [e.pipeline for e in passed_enrichers]
+        assert "crossref" in enricher_names
+        assert "pubmed" not in enricher_names
+
+    @pytest.mark.asyncio
+    async def test_failed_enrichers_still_passed_to_merge(self):
+        """FAILED enrichers should still be passed to merger (may have partial data)."""
+        enrichment_results = {
+            "crossref": EnrichmentResult.success(
+                enricher_name="crossref",
+                records_input=100,
+                records_enriched=90,
+            ),
+            "pubmed": EnrichmentResult.failed(
+                enricher_name="pubmed",
+                error_message="API error",
+            ),
+        }
+        coordinator = create_mock_coordinator(enrichment_results)
+        merger = create_mock_merger()
+
+        runner = create_runner(
+            coordinator=coordinator,
+            merger=merger,
+        )
+        await runner.run()
+
+        # Check merger.merge was called
+        merger.merge.assert_called_once()
+        call_kwargs = merger.merge.call_args
+        passed_enrichers = call_kwargs.kwargs.get("enrichers") or call_kwargs.args[1]
+
+        # Both should be passed (FAILED may have partial data)
+        enricher_names = [e.pipeline for e in passed_enrichers]
+        assert "crossref" in enricher_names
+        assert "pubmed" in enricher_names
+
+
+class TestCompletionLogging:
+    """Tests for completion logging with warnings."""
+
+    @pytest.mark.asyncio
+    async def test_completed_with_warnings_logged(self):
+        """Completion with warnings should be logged with status."""
+        enrichment_results = {
+            "crossref": EnrichmentResult.success(
+                enricher_name="crossref",
+                records_input=100,
+                records_enriched=90,
+            ),
+            "pubmed": EnrichmentResult.failed(
+                enricher_name="pubmed",
+                error_message="API error",
+            ),
+        }
+        coordinator = create_mock_coordinator(enrichment_results)
+        logger = create_mock_logger()
+
+        runner = create_runner(coordinator=coordinator, logger=logger)
+        await runner.run()
+
+        # Check that completion was logged with warnings status
+        complete_calls = [
+            c for c in logger.info.call_args_list
+            if "completed_with_warnings" in str(c) or "had_warnings" in str(c)
+        ]
+        assert len(complete_calls) >= 1
+
+    @pytest.mark.asyncio
+    async def test_clean_completion_no_warning_status(self):
+        """Clean completion should not log warning status."""
+        enrichment_results = {
+            "crossref": EnrichmentResult.success(
+                enricher_name="crossref",
+                records_input=100,
+                records_enriched=90,
+            ),
+            "pubmed": EnrichmentResult.success(
+                enricher_name="pubmed",
+                records_input=100,
+                records_enriched=80,
+            ),
+        }
+        coordinator = create_mock_coordinator(enrichment_results)
+        logger = create_mock_logger()
+
+        runner = create_runner(coordinator=coordinator, logger=logger)
+        await runner.run()
+
+        # Check that "completed_with_warnings" is NOT in any log call
+        all_calls_str = str(logger.info.call_args_list)
+        assert "completed_with_warnings" not in all_calls_str
+
+
+class TestEnrichmentSummary:
+    """Tests for enrichment summary logging."""
+
+    @pytest.mark.asyncio
+    async def test_summary_includes_not_run_count(self):
+        """Enrichment summary should include NOT_RUN count."""
+        enrichment_results = {
+            "crossref": EnrichmentResult.success(
+                enricher_name="crossref",
+                records_input=100,
+                records_enriched=90,
+            ),
+        }
+        coordinator = create_mock_coordinator(enrichment_results)
+        logger = create_mock_logger()
+
+        runner = create_runner(
+            coordinator=coordinator,
+            logger=logger,
+            runtime=CompositeRuntimeConfig(required_only=True),
+        )
+        await runner.run()
+
+        # Check enrichment summary includes not_run count
+        summary_calls = [
+            c for c in logger.info.call_args_list if "Enrichment summary" in str(c)
+        ]
+        # Summary may be called, check if not_run is logged somewhere
+        all_info_str = str(logger.info.call_args_list)
+        # NOT_RUN enrichers should be mentioned
+        assert "not_run" in all_info_str.lower() or "pubmed" in all_info_str

--- a/tests/unit/domain/composite/test_composite_result.py
+++ b/tests/unit/domain/composite/test_composite_result.py
@@ -64,6 +64,25 @@ class TestEnrichmentResult:
         assert result.is_success is False
         assert "600" in result.error_message
 
+    def test_not_run_factory(self):
+        """not_run factory should create NOT_RUN result."""
+        result = EnrichmentResult.not_run(
+            enricher_name="openalex",
+            reason="Skipped due to required_only mode",
+        )
+        assert result.status == EnrichmentStatus.NOT_RUN
+        assert result.is_success is False
+        assert "required_only" in result.error_message
+        assert result.records_input == 0
+        assert result.records_enriched == 0
+
+    def test_not_run_factory_default_reason(self):
+        """not_run factory should use default reason."""
+        result = EnrichmentResult.not_run(enricher_name="openalex")
+        assert result.status == EnrichmentStatus.NOT_RUN
+        assert result.error_message is not None
+        assert "required_only" in result.error_message
+
     def test_enrichment_rate_with_zero_input(self):
         """enrichment_rate should return 0 for zero input."""
         result = EnrichmentResult(
@@ -232,3 +251,142 @@ class TestCompositeResult:
         assert summary["enrichers_run"] == 2
         assert summary["enrichers_succeeded"] == 1
         assert summary["enrichers_failed"] == 1
+
+    def test_had_warnings_default_false(self):
+        """had_warnings should default to False."""
+        result = CompositeResult(
+            composite_name="test",
+            composite_run_id="test-123",
+            seed_result=SeedResult(pipeline_name="seed", records_silver=100),
+            enrichment_results={},
+            merge_result=MergeResult(records_merged=100),
+        )
+        assert result.had_warnings is False
+
+    def test_had_warnings_set_true(self):
+        """had_warnings should be settable to True."""
+        result = CompositeResult(
+            composite_name="test",
+            composite_run_id="test-123",
+            seed_result=SeedResult(pipeline_name="seed", records_silver=100),
+            enrichment_results={
+                "optional_enricher": EnrichmentResult.failed(
+                    enricher_name="optional_enricher",
+                    error_message="API error",
+                ),
+            },
+            merge_result=MergeResult(records_merged=100),
+            had_warnings=True,
+            _required_enrichers=frozenset(),  # No required enrichers
+        )
+        assert result.had_warnings is True
+        assert result.is_success is True  # Still successful as no required failed
+
+    def test_skipped_enrichers(self):
+        """skipped_enrichers should list enrichers with SKIPPED status."""
+        result = CompositeResult(
+            composite_name="test",
+            composite_run_id="test-123",
+            seed_result=SeedResult(pipeline_name="seed", records_silver=100),
+            enrichment_results={
+                "crossref": EnrichmentResult.success(
+                    enricher_name="crossref", records_input=100, records_enriched=90
+                ),
+                "pubmed": EnrichmentResult.skipped(
+                    enricher_name="pubmed", reason="No pmid keys"
+                ),
+            },
+            merge_result=MergeResult(records_merged=100),
+        )
+        assert "pubmed" in result.skipped_enrichers
+        assert "crossref" not in result.skipped_enrichers
+        assert len(result.skipped_enrichers) == 1
+
+    def test_not_run_enrichers(self):
+        """not_run_enrichers should list enrichers with NOT_RUN status."""
+        result = CompositeResult(
+            composite_name="test",
+            composite_run_id="test-123",
+            seed_result=SeedResult(pipeline_name="seed", records_silver=100),
+            enrichment_results={
+                "crossref": EnrichmentResult.success(
+                    enricher_name="crossref", records_input=100, records_enriched=90
+                ),
+                "openalex": EnrichmentResult.not_run(
+                    enricher_name="openalex", reason="required_only mode"
+                ),
+            },
+            merge_result=MergeResult(records_merged=100),
+        )
+        assert "openalex" in result.not_run_enrichers
+        assert "crossref" not in result.not_run_enrichers
+        assert len(result.not_run_enrichers) == 1
+
+    def test_optional_failed_enrichers(self):
+        """optional_failed_enrichers should list non-required failed enrichers."""
+        result = CompositeResult(
+            composite_name="test",
+            composite_run_id="test-123",
+            seed_result=SeedResult(pipeline_name="seed", records_silver=100),
+            enrichment_results={
+                "crossref": EnrichmentResult.success(
+                    enricher_name="crossref", records_input=100, records_enriched=90
+                ),
+                "pubmed": EnrichmentResult.failed(
+                    enricher_name="pubmed", error_message="API error"
+                ),
+                "openalex": EnrichmentResult.failed(
+                    enricher_name="openalex", error_message="Connection error"
+                ),
+            },
+            merge_result=MergeResult(records_merged=100),
+            _required_enrichers=frozenset({"crossref"}),  # Only crossref required
+        )
+        # pubmed and openalex are optional and failed
+        assert "pubmed" in result.optional_failed_enrichers
+        assert "openalex" in result.optional_failed_enrichers
+        assert "crossref" not in result.optional_failed_enrichers
+        assert len(result.optional_failed_enrichers) == 2
+
+    def test_optional_failed_excludes_required(self):
+        """optional_failed_enrichers should not include required enrichers."""
+        result = CompositeResult(
+            composite_name="test",
+            composite_run_id="test-123",
+            seed_result=SeedResult(pipeline_name="seed", records_silver=100),
+            enrichment_results={
+                "crossref": EnrichmentResult.failed(
+                    enricher_name="crossref", error_message="Failed"
+                ),
+            },
+            merge_result=MergeResult(records_merged=0),
+            _required_enrichers=frozenset({"crossref"}),
+        )
+        # crossref is required and failed, so not in optional_failed
+        assert "crossref" not in result.optional_failed_enrichers
+        assert result.is_success is False  # Pipeline should fail
+
+    def test_summary_includes_new_fields(self):
+        """summary should include had_warnings and new counts."""
+        result = CompositeResult(
+            composite_name="test",
+            composite_run_id="test-123",
+            seed_result=SeedResult(pipeline_name="seed", records_silver=100),
+            enrichment_results={
+                "crossref": EnrichmentResult.success(
+                    enricher_name="crossref", records_input=100, records_enriched=90
+                ),
+                "pubmed": EnrichmentResult.skipped(
+                    enricher_name="pubmed", reason="No keys"
+                ),
+                "openalex": EnrichmentResult.not_run(
+                    enricher_name="openalex", reason="required_only"
+                ),
+            },
+            merge_result=MergeResult(records_merged=100),
+            had_warnings=True,
+        )
+        summary = result.summary()
+        assert summary["had_warnings"] is True
+        assert summary["enrichers_skipped"] == 1
+        assert summary["enrichers_not_run"] == 1


### PR DESCRIPTION
Add comprehensive support for the `required` flag in composite pipeline enrichers, ensuring proper FSM state transitions and result tracking:

Result Models:
- Add `had_warnings` field to CompositeResult to indicate optional enricher failures
- Add `not_run` factory method to EnrichmentResult for NOT_RUN status
- Add properties: `skipped_enrichers`, `not_run_enrichers`, `optional_failed_enrichers`
- Update `summary()` to include new fields

Runner Logic:
- Add `_add_not_run_results()` to mark optional enrichers skipped in required_only mode
- Add `_calculate_had_warnings()` to detect optional enricher failures
- Add `_get_mergeable_enrichers()` to exclude SKIPPED/NOT_RUN from merge
- Update logging to include NOT_RUN counts and completion with warnings status

Behavior:
- Optional enricher failures set `had_warnings=True` but pipeline completes
- Required enricher failures transition FSM to FAILED state
- NOT_RUN enrichers (required_only mode) appear in results for lineage tracking
- SKIPPED/NOT_RUN enrichers excluded from merge to avoid file I/O errors

Tests:
- Add tests for NOT_RUN factory method
- Add tests for had_warnings field and related properties
- Add test_runner_required_flag.py with 16 tests for new functionality