### PR TITLE
Integrate FSM with checkpoint and resume mechanism

### DIFF
--- a/src/bioetl/application/composite/checkpoint.py
+++ b/src/bioetl/application/composite/checkpoint.py
@@ -324,11 +324,45 @@ class CompositeCheckpointManager:
         # Sort by modification time, return newest
         return max(checkpoints, key=lambda p: p.stat().st_mtime)
 
+    def _warn_if_checkpoint_exists_with_progress(self) -> None:
+        """Warn if an existing checkpoint with progress will be overwritten.
+
+        Called when resume=False to notify user that previous progress exists
+        and will be lost. This helps prevent accidental data loss when user
+        forgets to pass --resume flag.
+        """
+        checkpoint_path = self._get_latest_checkpoint_path()
+        if checkpoint_path is None or not checkpoint_path.exists():
+            return
+
+        try:
+            data = json.loads(checkpoint_path.read_text())
+            state = CompositeCheckpointState.from_dict(data)
+
+            # Only warn if checkpoint has actual progress
+            if state.is_resumable:
+                self._logger.warning(
+                    "Existing checkpoint with progress will be overwritten",
+                    composite=self._composite_name,
+                    checkpoint_path=str(checkpoint_path),
+                    checkpoint_state=state.state.value,
+                    seed_completed=state.seed_completed,
+                    completed_enrichers=len(state.completed_enrichers),
+                    hint="Use --resume flag to continue from previous progress",
+                )
+        except Exception:
+            # Silently ignore if we can't read the checkpoint
+            # (corrupted file will be overwritten anyway)
+            pass
+
     async def load(self) -> CompositeCheckpointState:
         """Load checkpoint state.
 
         If resume=True and checkpoint exists, load it.
         Otherwise, create fresh state.
+
+        When resume=False but a checkpoint with progress exists, logs a warning
+        that the checkpoint will be overwritten.
 
         Returns:
             Checkpoint state (loaded or fresh).
@@ -370,6 +404,9 @@ class CompositeCheckpointManager:
                         composite=self._composite_name,
                         error=str(e),
                     )
+        else:
+            # resume=False: check if existing checkpoint with progress will be overwritten
+            self._warn_if_checkpoint_exists_with_progress()
 
         # Create fresh state
         return CompositeCheckpointState(

--- a/src/bioetl/application/composite/runner.py
+++ b/src/bioetl/application/composite/runner.py
@@ -211,6 +211,14 @@ class CompositePipelineRunner:
         # Load checkpoint (for resume)
         state = await self._checkpoint_manager.load()
 
+        # Handle resume from FAILED state - determine correct phase to continue from
+        if self._runtime.resume and state.state == CompositePipelineState.FAILED:
+            state = self._handle_resume_from_failed(state)
+
+        # Log resume context if resuming with progress
+        if self._runtime.resume and state.is_resumable:
+            self._log_resume_context(state)
+
         # Track results
         seed_result: SeedResult | None = None
         enrichment_results: dict[str, EnrichmentResult] = {}
@@ -628,6 +636,85 @@ class CompositePipelineRunner:
             run_id=self._run_id_str,
             stage=stage,
             **extra,
+        )
+
+    def _handle_resume_from_failed(
+        self, state: CompositeCheckpointState
+    ) -> CompositeCheckpointState:
+        """Handle resuming from FAILED state by determining correct phase.
+
+        When checkpoint has state=FAILED, we need to determine the actual phase
+        to resume from based on seed_completed and completed_enrichers flags.
+
+        Args:
+            state: Checkpoint state with FAILED status.
+
+        Returns:
+            Updated state with corrected FSM state for resumption.
+        """
+        total_enrichers = len(self._config.enrichers)
+        completed_count = len(state.completed_enrichers)
+
+        if not state.seed_completed:
+            # Seed failed - resume from NOT_STARTED (will re-run seed)
+            resume_phase = CompositePipelineState.NOT_STARTED
+            phase_description = "seed (seed not completed)"
+        elif completed_count < total_enrichers:
+            # Enrichment failed - resume from ENRICHING (will run remaining enrichers)
+            resume_phase = CompositePipelineState.ENRICHING
+            phase_description = (
+                f"enrichment ({completed_count}/{total_enrichers} enrichers completed)"
+            )
+        else:
+            # Merge failed - resume from ENRICHMENT_COMPLETED (will re-run merge)
+            resume_phase = CompositePipelineState.ENRICHMENT_COMPLETED
+            phase_description = "merge (all enrichers completed)"
+
+        self._logger.info(
+            "Checkpoint indicates previous failure, resuming from phase",
+            composite=self._config.name,
+            run_id=self._run_id_str,
+            previous_state=state.state.value,
+            resume_phase=resume_phase.value,
+            phase_description=phase_description,
+            seed_completed=state.seed_completed,
+            completed_enrichers=completed_count,
+            total_enrichers=total_enrichers,
+        )
+
+        # Log FSM transition from FAILED to resume phase
+        self._log_fsm_transition(
+            from_state=state.state,
+            to_state=resume_phase,
+            stage="resume_from_failed",
+            phase_description=phase_description,
+        )
+
+        return state.with_state(resume_phase)
+
+    def _log_resume_context(self, state: CompositeCheckpointState) -> None:
+        """Log detailed resume context when resuming from checkpoint.
+
+        Provides visibility into what was completed previously and what
+        will be executed in this run.
+
+        Args:
+            state: Current checkpoint state being resumed from.
+        """
+        total_enrichers = len(self._config.enrichers)
+        completed_count = len(state.completed_enrichers)
+        remaining_count = total_enrichers - completed_count
+
+        self._logger.info(
+            "Resuming from checkpoint",
+            composite=self._config.name,
+            run_id=self._run_id_str,
+            last_state=state.state.value,
+            seed_completed=state.seed_completed,
+            completed_enrichers_count=completed_count,
+            total_enrichers_count=total_enrichers,
+            remaining_enrichers_count=remaining_count,
+            completed_enrichers=list(state.completed_enrichers) if completed_count > 0 else None,
         )
 
     async def _save_checkpoint_safe(

--- a/tests/unit/application/composite/test_runner_checkpoint_resume.py
+++ b/tests/unit/application/composite/test_runner_checkpoint_resume.py
@@ -1,0 +1,668 @@
+"""Unit tests for CompositePipelineRunner FSM checkpoint resume integration.
+
+Tests for resuming from FAILED state and checkpoint resume context logging.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import polars as pl
+import pytest
+
+from bioetl.application.composite.checkpoint import (
+    CompositeCheckpointManager,
+    CompositeCheckpointState,
+)
+from bioetl.application.composite.runner import (
+    CompositePipelineRunner,
+    CompositeRuntimeConfig,
+)
+from bioetl.domain.composite.result import (
+    EnrichmentResult,
+    MergeResult,
+    SeedResult,
+)
+from bioetl.domain.composite.state import CompositePipelineState
+
+
+@dataclass
+class MockEnricherConfig:
+    """Mock enricher configuration."""
+
+    pipeline: str
+    required: bool = False
+
+
+@dataclass
+class MockCompositeConfig:
+    """Mock composite configuration for testing."""
+
+    name: str = "test_composite"
+    lock_key: str = "lock:test_composite"
+
+    @dataclass
+    class SeedConfig:
+        pipeline: str = "chembl_activity"
+        silver_table: str = "chembl_activity"
+        output_keys: tuple[str, ...] = ("chembl_id",)
+
+    @dataclass
+    class MergeConfig:
+        output_silver_path: str = "silver/composite"
+        output_gold_path: str = "gold/composite"
+
+    @dataclass
+    class DQConfig:
+        soft_fail_threshold: float = 0.05
+        hard_fail_threshold: float = 0.20
+
+    seed: SeedConfig = None  # type: ignore[assignment]
+    merge: MergeConfig = None  # type: ignore[assignment]
+    dq: DQConfig = None  # type: ignore[assignment]
+    enrichers: tuple = ()
+    required_enrichers: frozenset = frozenset()
+
+    def __post_init__(self):
+        if self.seed is None:
+            self.seed = self.SeedConfig()
+        if self.merge is None:
+            self.merge = self.MergeConfig()
+        if self.dq is None:
+            self.dq = self.DQConfig()
+
+
+class MockPipelineRunner:
+    """Mock PipelineRunner for testing."""
+
+    def __init__(self, should_fail: bool = False, error_message: str = "Pipeline failed"):
+        self._should_fail = should_fail
+        self._error_message = error_message
+        self.run_called = False
+        self._executor = MagicMock()
+        self._executor.records_fetched = 100
+        self._executor.records_silver = 95
+
+    async def run(self):
+        self.run_called = True
+        if self._should_fail:
+            raise RuntimeError(self._error_message)
+
+
+def create_mock_logger() -> MagicMock:
+    """Create a mock logger."""
+    logger = MagicMock()
+    logger.info = MagicMock()
+    logger.error = MagicMock()
+    logger.warning = MagicMock()
+    logger.debug = MagicMock()
+    return logger
+
+
+def create_mock_lock() -> AsyncMock:
+    """Create a mock lock."""
+    lock = AsyncMock()
+    lock.acquire = AsyncMock(return_value=True)
+    lock.release = AsyncMock(return_value=True)
+    return lock
+
+
+def create_mock_checkpoint_manager(
+    initial_state: CompositeCheckpointState | None = None,
+) -> AsyncMock:
+    """Create a mock checkpoint manager."""
+    manager = AsyncMock()
+    if initial_state is None:
+        initial_state = CompositeCheckpointState(
+            composite_name="test_composite",
+            run_id=str(uuid4()),
+            created_at=datetime.now(tz=UTC),
+        )
+    manager.load = AsyncMock(return_value=initial_state)
+    manager.save = AsyncMock()
+    manager.delete = AsyncMock()
+    return manager
+
+
+def create_mock_key_extractor() -> AsyncMock:
+    """Create a mock key extractor."""
+    extractor = AsyncMock()
+    extractor.extract = AsyncMock(
+        return_value=pl.DataFrame({"chembl_id": ["CHEMBL123"]})
+    )
+    return extractor
+
+
+def create_mock_coordinator() -> AsyncMock:
+    """Create a mock enrichment coordinator."""
+    coordinator = AsyncMock()
+    coordinator.run_enrichers = AsyncMock(return_value={})
+    return coordinator
+
+
+def create_mock_merger() -> AsyncMock:
+    """Create a mock merger."""
+    merger = AsyncMock()
+    merger.merge = AsyncMock(
+        return_value=MergeResult(
+            records_merged=100,
+            records_from_seed=100,
+            records_enriched=0,
+            records_fully_enriched=0,
+            duration_seconds=1.0,
+        )
+    )
+    return merger
+
+
+class TestResumeFromFailedState:
+    """Tests for resuming from FAILED state."""
+
+    @pytest.mark.asyncio
+    async def test_resume_from_failed_seed_phase(self):
+        """Resume from FAILED state when seed failed should re-run seed."""
+        # Create checkpoint in FAILED state with seed not completed
+        failed_state = CompositeCheckpointState(
+            composite_name="test_composite",
+            run_id=str(uuid4()),
+            state=CompositePipelineState.FAILED,
+            seed_completed=False,  # Seed failed
+            created_at=datetime.now(tz=UTC),
+        )
+
+        checkpoint_manager = create_mock_checkpoint_manager(failed_state)
+        seed_runner = MockPipelineRunner()
+        logger = create_mock_logger()
+
+        runner = CompositePipelineRunner(
+            config=MockCompositeConfig(),
+            runtime=CompositeRuntimeConfig(resume=True),
+            seed_runner_factory=lambda: seed_runner,
+            enricher_runner_factory=lambda name, df: MockPipelineRunner(),
+            key_extractor=create_mock_key_extractor(),
+            coordinator=create_mock_coordinator(),
+            merger=create_mock_merger(),
+            checkpoint_manager=checkpoint_manager,
+            logger=logger,
+            lock=create_mock_lock(),
+        )
+
+        await runner.run()
+
+        # Seed should be run since it wasn't completed
+        assert seed_runner.run_called is True
+
+        # Should log the resume from failed
+        info_calls = [str(c) for c in logger.info.call_args_list]
+        assert any("resume_from_failed" in c for c in info_calls)
+        assert any("seed (seed not completed)" in c for c in info_calls)
+
+    @pytest.mark.asyncio
+    async def test_resume_from_failed_enrichment_phase(self):
+        """Resume from FAILED state when enrichment failed should run remaining enrichers."""
+        config = MockCompositeConfig()
+        config.enrichers = (
+            MockEnricherConfig(pipeline="crossref"),
+            MockEnricherConfig(pipeline="pubmed"),
+            MockEnricherConfig(pipeline="openalex"),
+        )
+
+        # Create checkpoint in FAILED state with seed completed and 1 of 3 enrichers done
+        failed_state = CompositeCheckpointState(
+            composite_name="test_composite",
+            run_id=str(uuid4()),
+            state=CompositePipelineState.FAILED,
+            seed_completed=True,
+            seed_result=SeedResult(
+                pipeline_name="chembl_activity",
+                records_extracted=100,
+                records_silver=95,
+                keys_generated=90,
+                duration_seconds=10.0,
+            ),
+            completed_enrichers=frozenset({"crossref"}),
+            enrichment_results={
+                "crossref": EnrichmentResult.success(
+                    enricher_name="crossref",
+                    records_input=100,
+                    records_enriched=95,
+                    records_not_found=5,
+                    duration_seconds=10.0,
+                ),
+            },
+            created_at=datetime.now(tz=UTC),
+        )
+
+        checkpoint_manager = create_mock_checkpoint_manager(failed_state)
+        seed_runner = MockPipelineRunner()
+        logger = create_mock_logger()
+
+        runner = CompositePipelineRunner(
+            config=config,
+            runtime=CompositeRuntimeConfig(resume=True),
+            seed_runner_factory=lambda: seed_runner,
+            enricher_runner_factory=lambda name, df: MockPipelineRunner(),
+            key_extractor=create_mock_key_extractor(),
+            coordinator=create_mock_coordinator(),
+            merger=create_mock_merger(),
+            checkpoint_manager=checkpoint_manager,
+            logger=logger,
+            lock=create_mock_lock(),
+        )
+
+        await runner.run()
+
+        # Seed should NOT be run since it was completed
+        assert seed_runner.run_called is False
+
+        # Should log the resume from failed with enrichment phase
+        info_calls = [str(c) for c in logger.info.call_args_list]
+        assert any("resume_from_failed" in c for c in info_calls)
+        assert any("enrichment" in c for c in info_calls)
+        assert any("1/3 enrichers completed" in c for c in info_calls)
+
+    @pytest.mark.asyncio
+    async def test_resume_from_failed_merge_phase(self):
+        """Resume from FAILED state when merge failed should skip to merge."""
+        config = MockCompositeConfig()
+        config.enrichers = (
+            MockEnricherConfig(pipeline="crossref"),
+            MockEnricherConfig(pipeline="pubmed"),
+        )
+
+        # Create checkpoint in FAILED state with all enrichers completed
+        failed_state = CompositeCheckpointState(
+            composite_name="test_composite",
+            run_id=str(uuid4()),
+            state=CompositePipelineState.FAILED,
+            seed_completed=True,
+            seed_result=SeedResult(
+                pipeline_name="chembl_activity",
+                records_extracted=100,
+                records_silver=95,
+                keys_generated=90,
+                duration_seconds=10.0,
+            ),
+            completed_enrichers=frozenset({"crossref", "pubmed"}),
+            enrichment_results={
+                "crossref": EnrichmentResult.success(
+                    enricher_name="crossref",
+                    records_input=100,
+                    records_enriched=95,
+                    records_not_found=5,
+                    duration_seconds=10.0,
+                ),
+                "pubmed": EnrichmentResult.success(
+                    enricher_name="pubmed",
+                    records_input=100,
+                    records_enriched=80,
+                    records_not_found=20,
+                    duration_seconds=15.0,
+                ),
+            },
+            created_at=datetime.now(tz=UTC),
+        )
+
+        checkpoint_manager = create_mock_checkpoint_manager(failed_state)
+        seed_runner = MockPipelineRunner()
+        merger = create_mock_merger()
+        logger = create_mock_logger()
+
+        runner = CompositePipelineRunner(
+            config=config,
+            runtime=CompositeRuntimeConfig(resume=True),
+            seed_runner_factory=lambda: seed_runner,
+            enricher_runner_factory=lambda name, df: MockPipelineRunner(),
+            key_extractor=create_mock_key_extractor(),
+            coordinator=create_mock_coordinator(),
+            merger=merger,
+            checkpoint_manager=checkpoint_manager,
+            logger=logger,
+            lock=create_mock_lock(),
+        )
+
+        await runner.run()
+
+        # Seed should NOT be run
+        assert seed_runner.run_called is False
+
+        # Merge should be called
+        merger.merge.assert_called_once()
+
+        # Should log the resume from failed with merge phase
+        info_calls = [str(c) for c in logger.info.call_args_list]
+        assert any("resume_from_failed" in c for c in info_calls)
+        assert any("merge (all enrichers completed)" in c for c in info_calls)
+
+
+class TestResumeContextLogging:
+    """Tests for resume context logging."""
+
+    @pytest.mark.asyncio
+    async def test_logs_resume_context_with_completed_enrichers(self):
+        """Should log detailed resume context when resuming."""
+        config = MockCompositeConfig()
+        config.enrichers = (
+            MockEnricherConfig(pipeline="crossref"),
+            MockEnricherConfig(pipeline="pubmed"),
+            MockEnricherConfig(pipeline="openalex"),
+        )
+
+        # Create checkpoint with partial progress
+        partial_state = CompositeCheckpointState(
+            composite_name="test_composite",
+            run_id=str(uuid4()),
+            state=CompositePipelineState.ENRICHING,
+            seed_completed=True,
+            seed_result=SeedResult(
+                pipeline_name="chembl_activity",
+                records_extracted=100,
+                records_silver=95,
+                keys_generated=90,
+                duration_seconds=10.0,
+            ),
+            completed_enrichers=frozenset({"crossref", "pubmed"}),
+            enrichment_results={
+                "crossref": EnrichmentResult.success(
+                    enricher_name="crossref",
+                    records_input=100,
+                    records_enriched=95,
+                    records_not_found=5,
+                    duration_seconds=10.0,
+                ),
+                "pubmed": EnrichmentResult.success(
+                    enricher_name="pubmed",
+                    records_input=100,
+                    records_enriched=80,
+                    records_not_found=20,
+                    duration_seconds=15.0,
+                ),
+            },
+            created_at=datetime.now(tz=UTC),
+        )
+
+        checkpoint_manager = create_mock_checkpoint_manager(partial_state)
+        logger = create_mock_logger()
+
+        runner = CompositePipelineRunner(
+            config=config,
+            runtime=CompositeRuntimeConfig(resume=True),
+            seed_runner_factory=lambda: MockPipelineRunner(),
+            enricher_runner_factory=lambda name, df: MockPipelineRunner(),
+            key_extractor=create_mock_key_extractor(),
+            coordinator=create_mock_coordinator(),
+            merger=create_mock_merger(),
+            checkpoint_manager=checkpoint_manager,
+            logger=logger,
+            lock=create_mock_lock(),
+        )
+
+        await runner.run()
+
+        # Should log resume context
+        info_calls = [str(c) for c in logger.info.call_args_list]
+        assert any("Resuming from checkpoint" in c for c in info_calls)
+        assert any("completed_enrichers_count" in c and "2" in c for c in info_calls)
+        assert any("remaining_enrichers_count" in c and "1" in c for c in info_calls)
+
+    @pytest.mark.asyncio
+    async def test_no_resume_logging_without_resume_flag(self):
+        """Should not log resume context when resume=False."""
+        checkpoint_manager = create_mock_checkpoint_manager()
+        logger = create_mock_logger()
+
+        runner = CompositePipelineRunner(
+            config=MockCompositeConfig(),
+            runtime=CompositeRuntimeConfig(resume=False),
+            seed_runner_factory=lambda: MockPipelineRunner(),
+            enricher_runner_factory=lambda name, df: MockPipelineRunner(),
+            key_extractor=create_mock_key_extractor(),
+            coordinator=create_mock_coordinator(),
+            merger=create_mock_merger(),
+            checkpoint_manager=checkpoint_manager,
+            logger=logger,
+            lock=create_mock_lock(),
+        )
+
+        await runner.run()
+
+        # Should NOT log resume context
+        info_calls = [str(c) for c in logger.info.call_args_list]
+        assert not any("Resuming from checkpoint" in c for c in info_calls)
+
+
+class TestCheckpointExistsWarning:
+    """Tests for warning when checkpoint exists but resume=False."""
+
+    @pytest.mark.asyncio
+    async def test_warns_when_checkpoint_exists_without_resume(self, tmp_path):
+        """Should warn when checkpoint with progress exists but resume=False."""
+        logger = create_mock_logger()
+        run_id = str(uuid4())
+
+        # Create a real checkpoint manager and save a state with progress
+        manager = CompositeCheckpointManager(
+            composite_name="test_composite",
+            run_id=run_id,
+            checkpoint_dir=tmp_path,
+            logger=logger,
+            resume=False,  # No resume
+        )
+
+        # Create and save a checkpoint with progress
+        existing_state = CompositeCheckpointState(
+            composite_name="test_composite",
+            run_id=run_id,
+            state=CompositePipelineState.ENRICHING,
+            seed_completed=True,
+            seed_result=SeedResult(
+                pipeline_name="chembl_activity",
+                records_extracted=100,
+                records_silver=95,
+                keys_generated=90,
+                duration_seconds=10.0,
+            ),
+            completed_enrichers=frozenset({"crossref"}),
+            enrichment_results={
+                "crossref": EnrichmentResult.success(
+                    enricher_name="crossref",
+                    records_input=100,
+                    records_enriched=95,
+                    records_not_found=5,
+                    duration_seconds=10.0,
+                ),
+            },
+            created_at=datetime.now(tz=UTC),
+        )
+
+        # Save checkpoint directly to file
+        await manager.save(existing_state)
+
+        # Create new manager without resume flag (should warn)
+        manager_no_resume = CompositeCheckpointManager(
+            composite_name="test_composite",
+            run_id=str(uuid4()),  # New run
+            checkpoint_dir=tmp_path,
+            logger=logger,
+            resume=False,
+        )
+
+        # Load should warn about existing checkpoint
+        await manager_no_resume.load()
+
+        # Verify warning was logged
+        warning_calls = [str(c) for c in logger.warning.call_args_list]
+        assert any("Existing checkpoint with progress will be overwritten" in c for c in warning_calls)
+        assert any("--resume flag" in c for c in warning_calls)
+
+    @pytest.mark.asyncio
+    async def test_no_warning_when_no_checkpoint_exists(self, tmp_path):
+        """Should not warn when no checkpoint exists."""
+        logger = create_mock_logger()
+
+        manager = CompositeCheckpointManager(
+            composite_name="test_composite",
+            run_id=str(uuid4()),
+            checkpoint_dir=tmp_path,
+            logger=logger,
+            resume=False,
+        )
+
+        await manager.load()
+
+        # No warning should be logged
+        warning_calls = [str(c) for c in logger.warning.call_args_list]
+        assert not any("Existing checkpoint with progress will be overwritten" in c for c in warning_calls)
+
+    @pytest.mark.asyncio
+    async def test_no_warning_when_checkpoint_has_no_progress(self, tmp_path):
+        """Should not warn when checkpoint exists but has no progress."""
+        logger = create_mock_logger()
+        run_id = str(uuid4())
+
+        # Save a fresh checkpoint with no progress
+        manager_setup = CompositeCheckpointManager(
+            composite_name="test_composite",
+            run_id=run_id,
+            checkpoint_dir=tmp_path,
+            logger=MagicMock(),
+            resume=False,
+        )
+
+        fresh_state = CompositeCheckpointState(
+            composite_name="test_composite",
+            run_id=run_id,
+            state=CompositePipelineState.NOT_STARTED,
+            seed_completed=False,
+            created_at=datetime.now(tz=UTC),
+        )
+        await manager_setup.save(fresh_state)
+
+        # Create new manager without resume flag
+        manager_no_resume = CompositeCheckpointManager(
+            composite_name="test_composite",
+            run_id=str(uuid4()),
+            checkpoint_dir=tmp_path,
+            logger=logger,
+            resume=False,
+        )
+
+        await manager_no_resume.load()
+
+        # No warning should be logged (checkpoint has no progress)
+        warning_calls = [str(c) for c in logger.warning.call_args_list]
+        assert not any("Existing checkpoint with progress will be overwritten" in c for c in warning_calls)
+
+
+class TestFSMStateTransitionOnResume:
+    """Tests for FSM state transitions when resuming from FAILED."""
+
+    @pytest.mark.asyncio
+    async def test_fsm_transition_logged_on_resume_from_failed(self):
+        """FSM transition from FAILED should be logged."""
+        failed_state = CompositeCheckpointState(
+            composite_name="test_composite",
+            run_id=str(uuid4()),
+            state=CompositePipelineState.FAILED,
+            seed_completed=True,
+            seed_result=SeedResult(
+                pipeline_name="chembl_activity",
+                records_extracted=100,
+                records_silver=95,
+                keys_generated=90,
+                duration_seconds=10.0,
+            ),
+            completed_enrichers=frozenset(),
+            created_at=datetime.now(tz=UTC),
+        )
+
+        checkpoint_manager = create_mock_checkpoint_manager(failed_state)
+        logger = create_mock_logger()
+
+        runner = CompositePipelineRunner(
+            config=MockCompositeConfig(),
+            runtime=CompositeRuntimeConfig(resume=True),
+            seed_runner_factory=lambda: MockPipelineRunner(),
+            enricher_runner_factory=lambda name, df: MockPipelineRunner(),
+            key_extractor=create_mock_key_extractor(),
+            coordinator=create_mock_coordinator(),
+            merger=create_mock_merger(),
+            checkpoint_manager=checkpoint_manager,
+            logger=logger,
+            lock=create_mock_lock(),
+        )
+
+        await runner.run()
+
+        # Should log FSM transition
+        info_calls = [str(c) for c in logger.info.call_args_list]
+        assert any(
+            "FSM state transition" in c and "from_state" in c and "failed" in c
+            for c in info_calls
+        )
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_state_updated_on_resume_from_failed(self):
+        """Checkpoint state should be updated when resuming from FAILED."""
+        config = MockCompositeConfig()
+        config.enrichers = (MockEnricherConfig(pipeline="crossref"),)
+
+        # All enrichers completed, merge failed
+        failed_state = CompositeCheckpointState(
+            composite_name="test_composite",
+            run_id=str(uuid4()),
+            state=CompositePipelineState.FAILED,
+            seed_completed=True,
+            seed_result=SeedResult(
+                pipeline_name="chembl_activity",
+                records_extracted=100,
+                records_silver=95,
+                keys_generated=90,
+                duration_seconds=10.0,
+            ),
+            completed_enrichers=frozenset({"crossref"}),
+            enrichment_results={
+                "crossref": EnrichmentResult.success(
+                    enricher_name="crossref",
+                    records_input=100,
+                    records_enriched=95,
+                    records_not_found=5,
+                    duration_seconds=10.0,
+                ),
+            },
+            created_at=datetime.now(tz=UTC),
+        )
+
+        checkpoint_manager = create_mock_checkpoint_manager(failed_state)
+        saved_states: list[CompositePipelineState] = []
+        original_save = checkpoint_manager.save
+
+        async def tracking_save(state: CompositeCheckpointState) -> None:
+            saved_states.append(state.state)
+            await original_save(state)
+
+        checkpoint_manager.save = tracking_save  # type: ignore[method-assign]
+
+        runner = CompositePipelineRunner(
+            config=config,
+            runtime=CompositeRuntimeConfig(resume=True),
+            seed_runner_factory=lambda: MockPipelineRunner(),
+            enricher_runner_factory=lambda name, df: MockPipelineRunner(),
+            key_extractor=create_mock_key_extractor(),
+            coordinator=create_mock_coordinator(),
+            merger=create_mock_merger(),
+            checkpoint_manager=checkpoint_manager,
+            logger=create_mock_logger(),
+            lock=create_mock_lock(),
+        )
+
+        await runner.run()
+
+        # Should transition through states after FAILED
+        # ENRICHMENT_COMPLETED -> MERGING -> COMPLETED
+        assert CompositePipelineState.ENRICHMENT_COMPLETED in saved_states
+        assert CompositePipelineState.MERGING in saved_states
+        assert CompositePipelineState.COMPLETED in saved_states


### PR DESCRIPTION
Add intelligent resume handling for composite pipelines:

- Handle FAILED state at checkpoint load by determining correct phase to resume from (seed, enrichment, or merge) based on seed_completed and completed_enrichers flags

- Add detailed resume context logging with counts of completed and remaining enrichers when resuming from checkpoint

- Warn users when checkpoint with progress exists but resume=False, helping prevent accidental data loss

- Add comprehensive tests for resume scenarios:
  - Resume from failed seed phase
  - Resume from failed enrichment phase (partial enrichers)
  - Resume from failed merge phase (all enrichers complete)
  - Resume context logging verification
  - Warning when checkpoint exists without resume flag

This ensures the FSM complements the resume functionality by providing clear context about where to continue execution.