### PR TITLE
Remove side effects from bootstrap functions

### DIFF
--- a/src/bioetl/composition/_bootstrap/__init__.py
+++ b/src/bioetl/composition/_bootstrap/__init__.py
@@ -39,6 +39,7 @@ from bioetl.composition.bootstrap import (
     bootstrap_storage,
     bootstrap_tracer,
     bootstrap_vacuum_service,
+    maybe_start_metrics_server,
     start_metrics_server,
     validate_observability_preflight,
 )
@@ -69,6 +70,7 @@ __all__ = [
     "bootstrap_storage",
     "bootstrap_tracer",
     "bootstrap_vacuum_service",
+    "maybe_start_metrics_server",
     "start_metrics_server",
     "validate_observability_preflight",
 ]

--- a/src/bioetl/composition/_bootstrap/observability.py
+++ b/src/bioetl/composition/_bootstrap/observability.py
@@ -42,6 +42,7 @@ __all__ = [
     "bootstrap_metrics_service",
     "bootstrap_observability",
     "bootstrap_tracer",
+    "maybe_start_metrics_server",
     "start_metrics_server",
     "validate_observability_preflight",
 ]
@@ -150,13 +151,15 @@ def bootstrap_tracer(
 
 
 def bootstrap_metrics(settings: Settings) -> MetricsPort:
-    """Bootstrap metrics with optional server start.
+    """Bootstrap metrics collector.
 
     Unified Observability Contract: Always returns a valid MetricsPort.
     When metrics are disabled, returns NoOpMetrics (silent fallback).
 
-    Server is started only if explicitly enabled in settings.
-    Supports fail_fast mode for strict startup validation.
+    Note:
+        This function only creates the metrics collector.
+        Server startup is handled separately by entrypoints via
+        maybe_start_metrics_server() to keep bootstrap side-effect free.
 
     Args:
         settings: Application settings.
@@ -164,38 +167,58 @@ def bootstrap_metrics(settings: Settings) -> MetricsPort:
     Returns:
         MetricsPort instance (PrometheusMetrics or NoOpMetrics).
         Never returns None - uses NoOpMetrics as fallback.
-
-    Raises:
-        MetricsServerError: If fail_fast=True and server fails to start.
     """
     if not settings.observability.metrics_enabled:
         # Silent fallback - no warning since explicitly disabled
         return NoOpMetrics(warn_on_use=False)
 
-    metrics = PrometheusMetrics()
+    return PrometheusMetrics()
 
-    if settings.observability.metrics_server_enabled:
-        obs = settings.observability
 
-        if obs.metrics_fail_fast:
-            # In fail_fast mode, let MetricsServerError propagate
-            start_metrics_server(
-                port=settings.metrics_port,
-                fail_fast=True,
-                retry_count=obs.metrics_retry_count,
-                retry_delay=obs.metrics_retry_delay,
-            )
-        else:
-            # Lenient mode: log but don't fail - metrics collection still works
-            with contextlib.suppress(Exception):
-                start_metrics_server(
-                    port=settings.metrics_port,
-                    fail_fast=False,
-                    retry_count=obs.metrics_retry_count,
-                    retry_delay=obs.metrics_retry_delay,
-                )
+def maybe_start_metrics_server(settings: Settings) -> bool:
+    """Start metrics server if enabled in settings.
 
-    return metrics
+    This function should be called by entrypoints (CLI, REST API) after
+    bootstrap to start the Prometheus HTTP server. Separating server
+    startup from bootstrap keeps the composition layer side-effect free.
+
+    Args:
+        settings: Application settings.
+
+    Returns:
+        True if server was started or already running, False if disabled
+        or failed to start.
+
+    Raises:
+        MetricsServerError: If fail_fast=True and server fails to start.
+    """
+    if not settings.observability.metrics_enabled:
+        return False
+
+    if not settings.observability.metrics_server_enabled:
+        return False
+
+    obs = settings.observability
+
+    if obs.metrics_fail_fast:
+        # In fail_fast mode, let MetricsServerError propagate
+        return start_metrics_server(
+            port=settings.metrics_port,
+            fail_fast=True,
+            retry_count=obs.metrics_retry_count,
+            retry_delay=obs.metrics_retry_delay,
+        )
+
+    # Lenient mode: log but don't fail - metrics collection still works
+    with contextlib.suppress(Exception):
+        return start_metrics_server(
+            port=settings.metrics_port,
+            fail_fast=False,
+            retry_count=obs.metrics_retry_count,
+            retry_delay=obs.metrics_retry_delay,
+        )
+
+    return False
 
 
 def bootstrap_dq_monitor(

--- a/src/bioetl/composition/bootstrap/__init__.py
+++ b/src/bioetl/composition/bootstrap/__init__.py
@@ -63,6 +63,7 @@ from bioetl.composition.bootstrap.runtime import (
     bootstrap_pipeline_runner_service,
     bootstrap_tracer,
     load_composite_config,
+    maybe_start_metrics_server,
     start_metrics_server,
     validate_observability_preflight,
 )
@@ -106,6 +107,7 @@ __all__ = [
     "load_composite_config",
     # Config loader
     "load_pipeline_config",
+    "maybe_start_metrics_server",
     "start_metrics_server",
     "validate_observability_preflight",
 ]

--- a/src/bioetl/composition/bootstrap/runtime/__init__.py
+++ b/src/bioetl/composition/bootstrap/runtime/__init__.py
@@ -28,6 +28,7 @@ from bioetl.composition.bootstrap.runtime.observability import (
     bootstrap_metrics,
     bootstrap_observability,
     bootstrap_tracer,
+    maybe_start_metrics_server,
     start_metrics_server,
     validate_observability_preflight,
 )
@@ -51,6 +52,7 @@ __all__ = [
     "bootstrap_pipeline_runner_service",
     "bootstrap_tracer",
     "load_composite_config",
+    "maybe_start_metrics_server",
     "start_metrics_server",
     "validate_observability_preflight",
 ]

--- a/src/bioetl/composition/bootstrap/runtime/observability.py
+++ b/src/bioetl/composition/bootstrap/runtime/observability.py
@@ -45,6 +45,7 @@ __all__ = [
     "bootstrap_metrics",
     "bootstrap_observability",
     "bootstrap_tracer",
+    "maybe_start_metrics_server",
     "start_metrics_server",
     "validate_observability_preflight",
 ]
@@ -153,13 +154,15 @@ def bootstrap_tracer(
 
 
 def bootstrap_metrics(settings: Settings) -> MetricsPort:
-    """Bootstrap metrics with optional server start for runtime execution.
+    """Bootstrap metrics collector for runtime execution.
 
     Unified Observability Contract: Always returns a valid MetricsPort.
     When metrics are disabled, returns NoOpMetrics (silent fallback).
 
-    Server is started only if explicitly enabled in settings.
-    Supports fail_fast mode for strict startup validation.
+    Note:
+        This function only creates the metrics collector.
+        Server startup is handled separately by entrypoints via
+        maybe_start_metrics_server() to keep bootstrap side-effect free.
 
     Args:
         settings: Application settings.
@@ -167,38 +170,58 @@ def bootstrap_metrics(settings: Settings) -> MetricsPort:
     Returns:
         MetricsPort instance (PrometheusMetrics or NoOpMetrics).
         Never returns None - uses NoOpMetrics as fallback.
-
-    Raises:
-        MetricsServerError: If fail_fast=True and server fails to start.
     """
     if not settings.observability.metrics_enabled:
         # Silent fallback - no warning since explicitly disabled
         return NoOpMetrics(warn_on_use=False)
 
-    metrics = PrometheusMetrics()
+    return PrometheusMetrics()
 
-    if settings.observability.metrics_server_enabled:
-        obs = settings.observability
 
-        if obs.metrics_fail_fast:
-            # In fail_fast mode, let MetricsServerError propagate
-            start_metrics_server(
-                port=settings.metrics_port,
-                fail_fast=True,
-                retry_count=obs.metrics_retry_count,
-                retry_delay=obs.metrics_retry_delay,
-            )
-        else:
-            # Lenient mode: log but don't fail - metrics collection still works
-            with contextlib.suppress(Exception):
-                start_metrics_server(
-                    port=settings.metrics_port,
-                    fail_fast=False,
-                    retry_count=obs.metrics_retry_count,
-                    retry_delay=obs.metrics_retry_delay,
-                )
+def maybe_start_metrics_server(settings: Settings) -> bool:
+    """Start metrics server if enabled in settings.
 
-    return metrics
+    This function should be called by entrypoints (CLI, REST API) after
+    bootstrap to start the Prometheus HTTP server. Separating server
+    startup from bootstrap keeps the composition layer side-effect free.
+
+    Args:
+        settings: Application settings.
+
+    Returns:
+        True if server was started or already running, False if disabled
+        or failed to start.
+
+    Raises:
+        MetricsServerError: If fail_fast=True and server fails to start.
+    """
+    if not settings.observability.metrics_enabled:
+        return False
+
+    if not settings.observability.metrics_server_enabled:
+        return False
+
+    obs = settings.observability
+
+    if obs.metrics_fail_fast:
+        # In fail_fast mode, let MetricsServerError propagate
+        return start_metrics_server(
+            port=settings.metrics_port,
+            fail_fast=True,
+            retry_count=obs.metrics_retry_count,
+            retry_delay=obs.metrics_retry_delay,
+        )
+
+    # Lenient mode: log but don't fail - metrics collection still works
+    with contextlib.suppress(Exception):
+        return start_metrics_server(
+            port=settings.metrics_port,
+            fail_fast=False,
+            retry_count=obs.metrics_retry_count,
+            retry_delay=obs.metrics_retry_delay,
+        )
+
+    return False
 
 
 def bootstrap_dq_monitor(

--- a/src/bioetl/composition/entrypoints.py
+++ b/src/bioetl/composition/entrypoints.py
@@ -58,6 +58,9 @@ __all__ = [
     # Inspection
     "inspect_quarantine",
     "list_checkpoints",
+    # Metrics server entrypoint
+    "ensure_metrics_server_started",
+    "maybe_start_metrics_server",
 ]
 
 from bioetl.composition._bootstrap import (
@@ -82,6 +85,7 @@ from bioetl.composition.bootstrap import (
     bootstrap_pipeline,
     bootstrap_quarantine_manager,
     load_pipeline_config,
+    maybe_start_metrics_server,
 )
 from bioetl.composition.factories.pipeline_factories import register_all_pipelines
 from bioetl.composition.providers.registration import register_all_providers
@@ -110,6 +114,26 @@ if TYPE_CHECKING:
         MedallionLifecycleService,
     )
     from bioetl.domain.ports import QuarantinePort
+
+
+def ensure_metrics_server_started() -> bool:
+    """Ensure metrics server is started if enabled in settings.
+
+    This function should be called at the start of pipeline execution
+    to start the Prometheus HTTP server. It's idempotent - calling it
+    multiple times is safe.
+
+    Returns:
+        True if server was started or already running, False if disabled.
+
+    Example:
+        >>> ensure_metrics_server_started()
+        True  # Server started on configured port
+    """
+    from bioetl.infrastructure.config import get_settings
+
+    settings = get_settings()
+    return maybe_start_metrics_server(settings)
 
 
 @dataclass(frozen=True)
@@ -266,6 +290,11 @@ async def run_pipeline(name: str, options: RunOptions) -> RunResult:
         ...     logger.error("pipeline_failed", error_message=result.error_message)
     """
     from bioetl.application.core.shutdown import PipelineShutdownError
+    from bioetl.infrastructure.config import get_settings
+
+    # Start metrics server if enabled (side-effect in entrypoint, not bootstrap)
+    settings = get_settings()
+    maybe_start_metrics_server(settings)
 
     started_at = datetime.now(tz=UTC)
     runner = create_pipeline_runner(name, options)

--- a/src/bioetl/interfaces/cli/commands/metrics_server_integration.py
+++ b/src/bioetl/interfaces/cli/commands/metrics_server_integration.py
@@ -1,0 +1,42 @@
+"""Metrics server integration for CLI commands.
+
+Provides utilities for starting the Prometheus metrics HTTP server
+alongside pipeline operations. The metrics server exposes Prometheus-compatible
+metrics endpoint while pipelines execute.
+
+This module follows the thin controller pattern - it delegates to
+composition layer for server startup, keeping side-effects out of bootstrap.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from bioetl.composition.entrypoints import ensure_metrics_server_started
+
+__all__ = [
+    "ensure_metrics_server_started",
+    "metrics_server_context",
+]
+
+
+@contextmanager
+def metrics_server_context() -> Iterator[bool]:
+    """Context manager that ensures metrics server is started.
+
+    Starts the Prometheus metrics HTTP server before yielding.
+    The server runs as a daemon thread and doesn't need explicit shutdown.
+
+    Yields:
+        True if server was started, False if disabled.
+
+    Example:
+        with metrics_server_context():
+            # Metrics server is running
+            await run_pipeline()
+        # Server continues running (daemon thread)
+    """
+    # Re-exported from entrypoints, use directly
+    started = ensure_metrics_server_started()
+    yield started

--- a/src/bioetl/interfaces/cli/commands/run.py
+++ b/src/bioetl/interfaces/cli/commands/run.py
@@ -21,6 +21,9 @@ from bioetl.interfaces.cli.commands.health_server_integration import (
     echo_health_server_info,
     health_server_context,
 )
+from bioetl.interfaces.cli.commands.metrics_server_integration import (
+    ensure_metrics_server_started,
+)
 from bioetl.interfaces.cli.commands.run_helpers import (
     get_runner_logger,
     handle_destructive_run_confirmation,
@@ -83,6 +86,9 @@ async def _run_pipeline_async(
     Returns:
         Tuple of (status, error_message, error_type, run_id).
     """
+    # Start metrics server if enabled (side-effect in entrypoint, not bootstrap)
+    ensure_metrics_server_started()
+
     async with health_server_context(
         enabled=health_server_enabled,
         port=health_port,

--- a/src/bioetl/interfaces/cli/commands/run_all.py
+++ b/src/bioetl/interfaces/cli/commands/run_all.py
@@ -26,6 +26,9 @@ from bioetl.interfaces.cli.commands.health_server_integration import (
     echo_health_server_info,
     health_server_context,
 )
+from bioetl.interfaces.cli.commands.metrics_server_integration import (
+    ensure_metrics_server_started,
+)
 from bioetl.interfaces.cli.exit_codes import ExitCode
 from bioetl.interfaces.cli.formatters import echo_error, echo_info, echo_warning
 
@@ -134,6 +137,9 @@ async def _run_all_pipelines_async(
     health_port: int = DEFAULT_HEALTH_SERVER_PORT,
 ) -> BatchRunResult:
     """Run all pipelines sequentially with optional health server."""
+    # Start metrics server if enabled (side-effect in entrypoint, not bootstrap)
+    ensure_metrics_server_started()
+
     async with health_server_context(enabled=health_server_enabled, port=health_port):
         service = get_pipeline_runner_service()
         return await _run_pipelines_batch(service, pipelines, options)

--- a/src/bioetl/interfaces/cli/commands/run_composite.py
+++ b/src/bioetl/interfaces/cli/commands/run_composite.py
@@ -23,6 +23,9 @@ from bioetl.interfaces.cli.commands.health_server_integration import (
     echo_health_server_info,
     health_server_context,
 )
+from bioetl.interfaces.cli.commands.metrics_server_integration import (
+    ensure_metrics_server_started,
+)
 from bioetl.interfaces.cli.exit_codes import ExitCode
 from bioetl.interfaces.cli.formatters import echo_error, echo_info, echo_warning
 
@@ -88,6 +91,9 @@ async def _run_composite_async(
     Returns:
         Tuple of (success, error_message).
     """
+    # Start metrics server if enabled (side-effect in entrypoint, not bootstrap)
+    ensure_metrics_server_started()
+
     async with health_server_context(
         enabled=health_server_enabled,
         port=health_port,

--- a/tests/architecture/test_code_metrics.py
+++ b/tests/architecture/test_code_metrics.py
@@ -85,7 +85,7 @@ class TestFileSizeLimits:
         "dq_report_service.py": 565,  # 561 LOC - DQ report service with extracted helpers for CC reduction
         # Composition layer exemptions
         "bootstrap.py": 450,  # 420 LOC - main DI wiring
-        "entrypoints.py": 750,  # 736 LOC - pipeline entrypoints (run_pipeline expanded + services + export)
+        "entrypoints.py": 780,  # 775 LOC - pipeline entrypoints (run_pipeline expanded + services + export + ensure_metrics_server_started)
         "registration.py": 720,  # 705 LOC - provider registration with data source creators (OpenAlex + SemanticScholar + UniProt IDMapping)
         "storage_adapter.py": 660,  # 655 LOC - storage adapter with Bronze/Silver/Gold writers + BronzeWriteResult + SilverWriteResult + SourceMetadata param + Silver lineage
         # Consolidated factory files (v5.2)

--- a/tests/architecture/test_forbidden_imports.py
+++ b/tests/architecture/test_forbidden_imports.py
@@ -66,6 +66,7 @@ class TestObservabilityInitialization:
             r"from.*import.*start_metrics_server",  # Import is allowed
             r"#.*start_metrics_server",  # Comments are allowed
             r"\"\"\".*start_metrics_server",  # Docstrings are allowed
+            r"maybe_start_metrics_server",  # Entrypoint wrapper is allowed
         ]
 
         violations = []

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -89,16 +89,12 @@ class TestBootstrapLogger:
 class TestBootstrapPipeline:
     """Tests for bootstrap_pipeline function."""
 
-    @patch("bioetl.composition._bootstrap.observability.start_metrics_server")
-    @patch("bioetl.composition.bootstrap.bootstrap_tracer")
-    @patch("bioetl.composition.bootstrap.get_settings")
-    @patch("bioetl.composition.bootstrap.bootstrap_logger")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.bootstrap_observability")
+    @patch("bioetl.infrastructure.config.get_settings")
     def test_bootstrap_pipeline_unknown_pipeline_raises(
         self,
-        mock_bootstrap_logger: MagicMock,
         mock_get_settings: MagicMock,
-        mock_bootstrap_tracer: MagicMock,
-        mock_start_metrics: MagicMock,
+        mock_bootstrap_observability: MagicMock,
         mock_settings: MagicMock,
         mock_logger: MagicMock,
     ):
@@ -107,6 +103,7 @@ class TestBootstrapPipeline:
 
         # Configure settings with required observability attributes
         mock_settings.metrics_port = 8000
+        mock_settings.test_mode = False
         mock_settings.observability = MagicMock()
         mock_settings.observability.metrics_enabled = True
         mock_settings.observability.metrics_server_enabled = True
@@ -121,8 +118,6 @@ class TestBootstrapPipeline:
         mock_settings.observability.dq_quality_score_min = 0.80
 
         mock_get_settings.return_value = mock_settings
-        mock_bootstrap_logger.return_value = mock_logger
-        mock_bootstrap_tracer.return_value = MagicMock()
 
         # Now raises "Configuration file not found" because load_pipeline_config is called first
         ctx = PipelineRunContext(
@@ -135,30 +130,33 @@ class TestBootstrapPipeline:
         with pytest.raises(ValueError, match="Configuration file not found"):
             bootstrap_pipeline(ctx)
 
-    @patch("bioetl.composition.bootstrap.get_default_registry")
-    @patch("bioetl.composition.bootstrap.FilterConfigBuilder")
-    @patch("bioetl.composition.bootstrap.load_pipeline_config")
-    @patch("bioetl.composition._bootstrap.observability.start_metrics_server")
-    @patch("bioetl.composition.bootstrap.bootstrap_tracer")
-    @patch("bioetl.composition.bootstrap.bootstrap_logger")
-    @patch("bioetl.composition.bootstrap.get_settings")
-    def test_bootstrap_pipeline_metrics_server_failure_non_blocking(
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.get_default_registry")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.FilterConfigBuilder")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.load_pipeline_config")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.bootstrap_observability")
+    @patch("bioetl.infrastructure.config.get_settings")
+    def test_bootstrap_pipeline_creates_runner_without_starting_server(
         self,
         mock_get_settings: MagicMock,
-        mock_bootstrap_logger: MagicMock,
-        mock_bootstrap_tracer: MagicMock,
-        mock_start_metrics: MagicMock,
+        mock_bootstrap_observability: MagicMock,
         mock_load_config: MagicMock,
         mock_filter_builder: MagicMock,
         mock_get_registry: MagicMock,
         mock_logger: MagicMock,
     ) -> None:
-        """Test that metrics server failure doesn't block pipeline bootstrap."""
+        """Test that bootstrap_pipeline creates runner without starting metrics server.
+
+        After refactoring, bootstrap_metrics() no longer starts the metrics server.
+        Server startup is handled by entrypoints via maybe_start_metrics_server().
+        This test verifies that bootstrap_pipeline creates a runner successfully
+        regardless of metrics server state.
+        """
         from bioetl.composition.bootstrap import bootstrap_pipeline
 
         # Create proper mock settings with required attributes
         test_settings = MagicMock()
         test_settings.metrics_port = 8000
+        test_settings.test_mode = False
         test_settings.pipeline = MagicMock()
         test_settings.pipeline.heartbeat_interval = 30
         test_settings.pipeline.vacuum_retention_days = 7
@@ -170,23 +168,22 @@ class TestBootstrapPipeline:
         test_settings.observability.metrics_retry_count = 3
         test_settings.observability.metrics_retry_delay = 1.0
         test_settings.observability.tracing_enabled = False
-        test_settings.observability.dq_baseline_window = 7
-        test_settings.observability.dq_z_score_threshold = 2.5
-        test_settings.observability.dq_min_baseline_samples = 3
-        test_settings.observability.dq_error_rate_max = 0.10
-        test_settings.observability.dq_quality_score_min = 0.80
+        test_settings.observability.dq_monitor_enabled = False
 
         mock_get_settings.return_value = test_settings
-        mock_bootstrap_logger.return_value = mock_logger
-        mock_bootstrap_tracer.return_value = MagicMock()
-        mock_filter_builder.build.return_value = None
 
-        # Simulate metrics server failure
-        mock_start_metrics.side_effect = Exception("Port already in use")
+        # Mock observability bundle
+        mock_obs = MagicMock()
+        mock_obs.logger = mock_logger
+        mock_bootstrap_observability.return_value = mock_obs
+
+        mock_filter_builder.build.return_value = None
 
         # Setup pipeline registry mock
         mock_config = MagicMock()
+        mock_config.maintenance.auto_vacuum = False
         mock_config.maintenance.vacuum_retention_days = 7
+        mock_config.input_filter = MagicMock()
         mock_load_config.return_value = mock_config
         mock_factory = MagicMock()
         mock_runner = MagicMock()
@@ -203,24 +200,19 @@ class TestBootstrapPipeline:
             limit=None,
         )
 
-        # Should not raise, should return runner despite metrics failure
-        # (error is suppressed via contextlib.suppress in bootstrap_metrics)
+        # Should return runner - bootstrap no longer starts metrics server
         result = bootstrap_pipeline(ctx)
 
         assert result is mock_runner
-        mock_start_metrics.assert_called_once_with(
-            port=test_settings.metrics_port,
-            fail_fast=False,
-            retry_count=3,
-            retry_delay=1.0,
-        )
+        # Verify observability was bootstrapped (creates MetricsPort, but doesn't start server)
+        mock_bootstrap_observability.assert_called_once()
 
-    @patch("bioetl.composition.bootstrap.get_settings")
-    @patch("bioetl.composition.bootstrap.get_default_registry")
-    @patch("bioetl.composition.bootstrap.bootstrap_observability")
-    @patch("bioetl.composition.bootstrap.register_all_providers")
-    @patch("bioetl.composition.bootstrap.register_all_pipelines")
-    @patch("bioetl.composition.bootstrap.load_pipeline_config")
+    @patch("bioetl.infrastructure.config.get_settings")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.get_default_registry")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.bootstrap_observability")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.register_all_providers")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.register_all_pipelines")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.load_pipeline_config")
     def test_bootstrap_pipeline_chembl_activity(
         self,
         mock_load_config,
@@ -235,6 +227,7 @@ class TestBootstrapPipeline:
         """Test bootstrap_pipeline creates chembl_activity pipeline."""
         from bioetl.composition.bootstrap import bootstrap_pipeline
 
+        mock_settings.test_mode = False
         mock_get_settings.return_value = mock_settings
 
         # Mock YAML config with maintenance settings
@@ -453,26 +446,24 @@ class TestChemblActivityFactory:
 
 @pytest.mark.unit
 class TestBootstrapMetrics:
-    """Tests for bootstrap_metrics function with metrics configuration."""
+    """Tests for bootstrap_metrics function with metrics configuration.
 
-    @patch("bioetl.composition._bootstrap.observability.start_metrics_server")
-    @patch("bioetl.composition._bootstrap.observability.PrometheusMetrics")
-    def test_bootstrap_metrics_passes_config_params(
+    Note: After refactoring, bootstrap_metrics() only creates the MetricsPort
+    without starting the server. Server startup is now handled by
+    maybe_start_metrics_server() which is called by entrypoints.
+    """
+
+    @patch("bioetl.composition.bootstrap.runtime.observability.PrometheusMetrics")
+    def test_bootstrap_metrics_returns_prometheus_when_enabled(
         self,
         mock_prometheus: MagicMock,
-        mock_start_server: MagicMock,
     ) -> None:
-        """Test that bootstrap_metrics passes config params to start_metrics_server."""
+        """Test that bootstrap_metrics returns PrometheusMetrics when enabled."""
         from bioetl.composition.bootstrap import bootstrap_metrics
 
         # Create mock settings with metrics config
         settings = MagicMock()
-        settings.metrics_port = 9090
         settings.observability.metrics_enabled = True
-        settings.observability.metrics_server_enabled = True
-        settings.observability.metrics_fail_fast = False
-        settings.observability.metrics_retry_count = 5
-        settings.observability.metrics_retry_delay = 2.0
 
         mock_metrics = MagicMock()
         mock_prometheus.return_value = mock_metrics
@@ -480,71 +471,7 @@ class TestBootstrapMetrics:
         result = bootstrap_metrics(settings)
 
         assert result is mock_metrics
-        mock_start_server.assert_called_once_with(
-            port=9090,
-            fail_fast=False,
-            retry_count=5,
-            retry_delay=2.0,
-        )
-
-    @patch("bioetl.composition._bootstrap.observability.start_metrics_server")
-    @patch("bioetl.composition._bootstrap.observability.PrometheusMetrics")
-    def test_bootstrap_metrics_fail_fast_true_raises_error(
-        self,
-        mock_prometheus: MagicMock,
-        mock_start_server: MagicMock,
-    ) -> None:
-        """Test that fail_fast=True propagates MetricsServerError."""
-        from bioetl.composition.bootstrap import bootstrap_metrics
-        from bioetl.interfaces.observability import MetricsServerError
-
-        settings = MagicMock()
-        settings.metrics_port = 8000
-        settings.observability.metrics_enabled = True
-        settings.observability.metrics_server_enabled = True
-        settings.observability.metrics_fail_fast = True
-        settings.observability.metrics_retry_count = 3
-        settings.observability.metrics_retry_delay = 1.0
-
-        # Simulate server failure in fail_fast mode
-        mock_start_server.side_effect = MetricsServerError(
-            port=8000, reason="port_in_use"
-        )
-
-        with pytest.raises(MetricsServerError) as exc_info:
-            bootstrap_metrics(settings)
-
-        assert exc_info.value.port == 8000
-        assert exc_info.value.reason == "port_in_use"
-
-    @patch("bioetl.composition._bootstrap.observability.start_metrics_server")
-    @patch("bioetl.composition._bootstrap.observability.PrometheusMetrics")
-    def test_bootstrap_metrics_fail_fast_false_suppresses_error(
-        self,
-        mock_prometheus: MagicMock,
-        mock_start_server: MagicMock,
-    ) -> None:
-        """Test that fail_fast=False suppresses exceptions."""
-        from bioetl.composition.bootstrap import bootstrap_metrics
-
-        settings = MagicMock()
-        settings.metrics_port = 8000
-        settings.observability.metrics_enabled = True
-        settings.observability.metrics_server_enabled = True
-        settings.observability.metrics_fail_fast = False
-        settings.observability.metrics_retry_count = 3
-        settings.observability.metrics_retry_delay = 1.0
-
-        mock_metrics = MagicMock()
-        mock_prometheus.return_value = mock_metrics
-
-        # Simulate exception in lenient mode
-        mock_start_server.side_effect = Exception("Random failure")
-
-        # Should not raise, should return metrics
-        result = bootstrap_metrics(settings)
-
-        assert result is mock_metrics
+        mock_prometheus.assert_called_once()
 
     def test_bootstrap_metrics_disabled_returns_noop_metrics(self) -> None:
         """Test that disabled metrics returns NoOpMetrics (not None).
@@ -566,22 +493,131 @@ class TestBootstrapMetrics:
 
 
 @pytest.mark.unit
+class TestMaybeStartMetricsServer:
+    """Tests for maybe_start_metrics_server function.
+
+    This function handles metrics server startup as a side-effect
+    that was removed from bootstrap_metrics() to keep bootstrap pure.
+    """
+
+    @patch("bioetl.composition.bootstrap.runtime.observability.start_metrics_server")
+    def test_maybe_start_metrics_server_passes_config_params(
+        self,
+        mock_start_server: MagicMock,
+    ) -> None:
+        """Test that maybe_start_metrics_server passes config params correctly."""
+        from bioetl.composition.bootstrap import maybe_start_metrics_server
+
+        # Create mock settings with metrics config
+        settings = MagicMock()
+        settings.metrics_port = 9090
+        settings.observability.metrics_enabled = True
+        settings.observability.metrics_server_enabled = True
+        settings.observability.metrics_fail_fast = False
+        settings.observability.metrics_retry_count = 5
+        settings.observability.metrics_retry_delay = 2.0
+
+        mock_start_server.return_value = True
+
+        result = maybe_start_metrics_server(settings)
+
+        assert result is True
+        mock_start_server.assert_called_once_with(
+            port=9090,
+            fail_fast=False,
+            retry_count=5,
+            retry_delay=2.0,
+        )
+
+    @patch("bioetl.composition.bootstrap.runtime.observability.start_metrics_server")
+    def test_maybe_start_metrics_server_fail_fast_true_raises_error(
+        self,
+        mock_start_server: MagicMock,
+    ) -> None:
+        """Test that fail_fast=True propagates MetricsServerError."""
+        from bioetl.composition.bootstrap import maybe_start_metrics_server
+        from bioetl.interfaces.observability import MetricsServerError
+
+        settings = MagicMock()
+        settings.metrics_port = 8000
+        settings.observability.metrics_enabled = True
+        settings.observability.metrics_server_enabled = True
+        settings.observability.metrics_fail_fast = True
+        settings.observability.metrics_retry_count = 3
+        settings.observability.metrics_retry_delay = 1.0
+
+        # Simulate server failure in fail_fast mode
+        mock_start_server.side_effect = MetricsServerError(
+            port=8000, reason="port_in_use"
+        )
+
+        with pytest.raises(MetricsServerError) as exc_info:
+            maybe_start_metrics_server(settings)
+
+        assert exc_info.value.port == 8000
+        assert exc_info.value.reason == "port_in_use"
+
+    @patch("bioetl.composition.bootstrap.runtime.observability.start_metrics_server")
+    def test_maybe_start_metrics_server_fail_fast_false_suppresses_error(
+        self,
+        mock_start_server: MagicMock,
+    ) -> None:
+        """Test that fail_fast=False suppresses exceptions."""
+        from bioetl.composition.bootstrap import maybe_start_metrics_server
+
+        settings = MagicMock()
+        settings.metrics_port = 8000
+        settings.observability.metrics_enabled = True
+        settings.observability.metrics_server_enabled = True
+        settings.observability.metrics_fail_fast = False
+        settings.observability.metrics_retry_count = 3
+        settings.observability.metrics_retry_delay = 1.0
+
+        # Simulate exception in lenient mode
+        mock_start_server.side_effect = Exception("Random failure")
+
+        # Should not raise, should return False
+        result = maybe_start_metrics_server(settings)
+
+        assert result is False
+
+    def test_maybe_start_metrics_server_disabled_returns_false(self) -> None:
+        """Test that disabled metrics returns False without calling server."""
+        from bioetl.composition.bootstrap import maybe_start_metrics_server
+
+        settings = MagicMock()
+        settings.observability.metrics_enabled = False
+
+        result = maybe_start_metrics_server(settings)
+
+        assert result is False
+
+    def test_maybe_start_metrics_server_server_disabled_returns_false(self) -> None:
+        """Test that disabled metrics server returns False."""
+        from bioetl.composition.bootstrap import maybe_start_metrics_server
+
+        settings = MagicMock()
+        settings.observability.metrics_enabled = True
+        settings.observability.metrics_server_enabled = False
+
+        result = maybe_start_metrics_server(settings)
+
+        assert result is False
+
+
+@pytest.mark.unit
 class TestBootstrapVacuumConfig:
     """Tests for bootstrap_pipeline vacuum configuration merging."""
 
-    @patch("bioetl.composition.bootstrap.get_default_registry")
-    @patch("bioetl.composition.bootstrap.FilterConfigBuilder")
-    @patch("bioetl.composition.bootstrap.load_pipeline_config")
-    @patch("bioetl.composition._bootstrap.observability.start_metrics_server")
-    @patch("bioetl.composition.bootstrap.bootstrap_tracer")
-    @patch("bioetl.composition.bootstrap.bootstrap_logger")
-    @patch("bioetl.composition.bootstrap.get_settings")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.get_default_registry")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.FilterConfigBuilder")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.load_pipeline_config")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.bootstrap_observability")
+    @patch("bioetl.infrastructure.config.get_settings")
     def test_bootstrap_uses_yaml_vacuum_config_when_cli_not_set(
         self,
         mock_get_settings: MagicMock,
-        mock_bootstrap_logger: MagicMock,
-        mock_bootstrap_tracer: MagicMock,
-        mock_start_metrics: MagicMock,
+        mock_bootstrap_observability: MagicMock,
         mock_load_config: MagicMock,
         mock_filter_builder: MagicMock,
         mock_get_registry: MagicMock,
@@ -592,25 +628,19 @@ class TestBootstrapVacuumConfig:
         # Create settings with all required observability attributes
         settings = MagicMock()
         settings.metrics_port = 8000
+        settings.test_mode = False
         settings.pipeline.heartbeat_interval = 30
         settings.observability.metrics_enabled = False
         settings.observability.metrics_server_enabled = False
-        settings.observability.metrics_fail_fast = False
-        settings.observability.metrics_retry_count = 3
-        settings.observability.metrics_retry_delay = 1.0
-        settings.observability.tracing_enabled = False
-        settings.observability.dq_baseline_window = 7
-        settings.observability.dq_z_score_threshold = 2.5
-        settings.observability.dq_min_baseline_samples = 3
-        settings.observability.dq_error_rate_max = 0.10
-        settings.observability.dq_quality_score_min = 0.80
+        settings.observability.dq_monitor_enabled = False
         mock_get_settings.return_value = settings
 
         # Create logger
         logger = MagicMock()
         logger.bind.return_value = logger
-        mock_bootstrap_logger.return_value = logger
-        mock_bootstrap_tracer.return_value = MagicMock()
+        mock_obs = MagicMock()
+        mock_obs.logger = logger
+        mock_bootstrap_observability.return_value = mock_obs
         mock_filter_builder.build.return_value = None
 
         # Setup YAML config with auto_vacuum enabled
@@ -644,19 +674,15 @@ class TestBootstrapVacuumConfig:
         assert runtime.vacuum_after_run is True
         assert runtime.vacuum_retention_days == 14
 
-    @patch("bioetl.composition.bootstrap.get_default_registry")
-    @patch("bioetl.composition.bootstrap.FilterConfigBuilder")
-    @patch("bioetl.composition.bootstrap.load_pipeline_config")
-    @patch("bioetl.composition._bootstrap.observability.start_metrics_server")
-    @patch("bioetl.composition.bootstrap.bootstrap_tracer")
-    @patch("bioetl.composition.bootstrap.bootstrap_logger")
-    @patch("bioetl.composition.bootstrap.get_settings")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.get_default_registry")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.FilterConfigBuilder")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.load_pipeline_config")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.bootstrap_observability")
+    @patch("bioetl.infrastructure.config.get_settings")
     def test_bootstrap_cli_vacuum_overrides_yaml_config(
         self,
         mock_get_settings: MagicMock,
-        mock_bootstrap_logger: MagicMock,
-        mock_bootstrap_tracer: MagicMock,
-        mock_start_metrics: MagicMock,
+        mock_bootstrap_observability: MagicMock,
         mock_load_config: MagicMock,
         mock_filter_builder: MagicMock,
         mock_get_registry: MagicMock,
@@ -667,25 +693,19 @@ class TestBootstrapVacuumConfig:
         # Create settings with all required observability attributes
         settings = MagicMock()
         settings.metrics_port = 8000
+        settings.test_mode = False
         settings.pipeline.heartbeat_interval = 30
         settings.observability.metrics_enabled = False
         settings.observability.metrics_server_enabled = False
-        settings.observability.metrics_fail_fast = False
-        settings.observability.metrics_retry_count = 3
-        settings.observability.metrics_retry_delay = 1.0
-        settings.observability.tracing_enabled = False
-        settings.observability.dq_baseline_window = 7
-        settings.observability.dq_z_score_threshold = 2.5
-        settings.observability.dq_min_baseline_samples = 3
-        settings.observability.dq_error_rate_max = 0.10
-        settings.observability.dq_quality_score_min = 0.80
+        settings.observability.dq_monitor_enabled = False
         mock_get_settings.return_value = settings
 
         # Create logger
         logger = MagicMock()
         logger.bind.return_value = logger
-        mock_bootstrap_logger.return_value = logger
-        mock_bootstrap_tracer.return_value = MagicMock()
+        mock_obs = MagicMock()
+        mock_obs.logger = logger
+        mock_bootstrap_observability.return_value = mock_obs
         mock_filter_builder.build.return_value = None
 
         # Setup YAML config with auto_vacuum enabled


### PR DESCRIPTION
Remove metrics server startup from bootstrap_metrics() to keep bootstrap as a pure DI layer. The metrics server is now started explicitly by entrypoints (CLI commands) via ensure_metrics_server_started().

Key changes:
- bootstrap_metrics() now only creates MetricsPort without starting server
- New maybe_start_metrics_server() function for explicit server startup
- New ensure_metrics_server_started() in entrypoints for CLI use
- CLI commands (run, run_all, run_composite) now call ensure_metrics_server_started()
- Updated tests to reflect new behavior

This change ensures bootstrap functions only create objects and don't manage their lifecycle, aligning with clean DI principles.