### PR TITLE
Centralize NoOp dependencies for CLI

### DIFF
--- a/src/bioetl/composition/bootstrap/cli/__init__.py
+++ b/src/bioetl/composition/bootstrap/cli/__init__.py
@@ -37,6 +37,12 @@ from bioetl.composition.bootstrap.cli.health import (
 )
 from bioetl.composition.bootstrap.cli.lock import bootstrap_lock_service
 from bioetl.composition.bootstrap.cli.metrics import bootstrap_metrics_service
+from bioetl.composition.bootstrap.cli.noop import (
+    create_noop_logger,
+    create_noop_metrics,
+    create_noop_observability_bundle,
+    create_noop_tracing,
+)
 from bioetl.composition.bootstrap.cli.storage import (
     bootstrap_bronze_cleanup_service,
     # Deprecated alias
@@ -72,4 +78,9 @@ __all__ = [
     "bootstrap_quarantine_manager",
     "bootstrap_quarantine_service",
     "bootstrap_vacuum_service",
+    # NoOp factories (centralized)
+    "create_noop_logger",
+    "create_noop_metrics",
+    "create_noop_observability_bundle",
+    "create_noop_tracing",
 ]

--- a/src/bioetl/composition/bootstrap/cli/checkpoint.py
+++ b/src/bioetl/composition/bootstrap/cli/checkpoint.py
@@ -18,9 +18,9 @@ from bioetl.composition.bootstrap.assembly.checkpoint import (
     bootstrap_checkpoint_port,
     bootstrap_quarantine_port,
 )
+from bioetl.composition.bootstrap.cli.noop import create_noop_logger
 from bioetl.infrastructure.checkpoint.local_checkpoint import LocalCheckpoint
 from bioetl.infrastructure.config import get_settings
-from bioetl.infrastructure.observability.noop_logger import NoOpLogger
 
 if TYPE_CHECKING:
     from bioetl.application.core.checkpoint_manager import CheckpointManager
@@ -74,7 +74,7 @@ def bootstrap_checkpoint_manager(pipeline_name: str) -> CheckpointManager:
     from bioetl.domain.types import RunID
 
     checkpoint_port = bootstrap_checkpoint_port(pipeline_name)
-    noop_logger = NoOpLogger()
+    noop_logger = create_noop_logger()
 
     return CheckpointManager(
         checkpoint_port=checkpoint_port,
@@ -102,7 +102,7 @@ def bootstrap_checkpoint_service() -> CheckpointService:
         base_path=settings.checkpoint_path,
         pipeline_name="",
     )
-    noop_logger = NoOpLogger()
+    noop_logger = create_noop_logger()
 
     return CheckpointService(
         checkpoint_port=checkpoint_port,
@@ -121,7 +121,7 @@ def bootstrap_quarantine_service() -> QuarantineService:
     from bioetl.application.services import QuarantineService
 
     quarantine_port = bootstrap_quarantine_port()
-    noop_logger = NoOpLogger()
+    noop_logger = create_noop_logger()
 
     return QuarantineService(
         quarantine_port=quarantine_port,

--- a/src/bioetl/composition/bootstrap/cli/config.py
+++ b/src/bioetl/composition/bootstrap/cli/config.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from bioetl.composition.bootstrap.cli.noop import create_noop_logger
 from bioetl.composition.factories.pipeline_factories import register_all_pipelines
 from bioetl.composition.registry import get_default_registry
 from bioetl.infrastructure.config import (
@@ -15,7 +16,6 @@ from bioetl.infrastructure.config import (
     load_pipeline_config,
     yaml_config_to_domain,
 )
-from bioetl.infrastructure.observability.noop_logger import NoOpLogger
 
 if TYPE_CHECKING:
     from bioetl.application.services import ConfigService
@@ -39,7 +39,7 @@ def bootstrap_config_service() -> ConfigService:
     """
     from bioetl.application.services import ConfigService
 
-    noop_logger = NoOpLogger()
+    noop_logger = create_noop_logger()
 
     # Ensure pipelines are registered for list_pipelines()
     register_all_pipelines()

--- a/src/bioetl/composition/bootstrap/cli/health.py
+++ b/src/bioetl/composition/bootstrap/cli/health.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from bioetl.composition.bootstrap.cli.noop import create_noop_logger
 from bioetl.composition.factories.data_source_factory import DataSourceFactory
-from bioetl.infrastructure.observability.noop_logger import NoOpLogger
 
 if TYPE_CHECKING:
     from bioetl.application.services import HealthService
@@ -59,7 +59,7 @@ def bootstrap_health_service() -> HealthService:
     """
     from bioetl.application.services import HealthService
 
-    noop_logger = NoOpLogger()
+    noop_logger = create_noop_logger()
 
     return HealthService(
         logger=noop_logger,

--- a/src/bioetl/composition/bootstrap/cli/lock.py
+++ b/src/bioetl/composition/bootstrap/cli/lock.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from bioetl.composition.bootstrap.cli.noop import create_noop_logger
 from bioetl.infrastructure.locking.memory_lock import MemoryLock
-from bioetl.infrastructure.observability.noop_logger import NoOpLogger
 
 if TYPE_CHECKING:
     from bioetl.application.services.lock_service import LockService
@@ -32,6 +32,6 @@ def bootstrap_lock_service() -> LockService:
     from bioetl.application.services.lock_service import LockService
 
     lock_port = MemoryLock()
-    noop_logger = NoOpLogger()
+    noop_logger = create_noop_logger()
 
     return LockService(lock_port=lock_port, logger=noop_logger)

--- a/src/bioetl/composition/bootstrap/cli/metrics.py
+++ b/src/bioetl/composition/bootstrap/cli/metrics.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from bioetl.infrastructure.observability.noop_logger import NoOpLogger
+from bioetl.composition.bootstrap.cli.noop import create_noop_logger
 
 if TYPE_CHECKING:
     from bioetl.application.services.metrics_service import MetricsService
@@ -39,7 +39,7 @@ def bootstrap_metrics_service() -> MetricsService:
         MetricsServerAdapter,
     )
 
-    logger = NoOpLogger()
+    logger = create_noop_logger()
     server = MetricsServerAdapter(logger=logger)
 
     return MetricsService(

--- a/src/bioetl/composition/bootstrap/cli/noop.py
+++ b/src/bioetl/composition/bootstrap/cli/noop.py
@@ -1,0 +1,118 @@
+"""Centralized NoOp dependency factory functions for CLI bootstrap.
+
+Contains pure factory functions for creating NoOp implementations used by
+CLI-specific bootstrap functions. These provide silent/null implementations
+for observability dependencies when full observability is not needed.
+
+Usage:
+    # In CLI bootstrap modules
+    from bioetl.composition.bootstrap.cli.noop import create_noop_logger
+
+    logger = create_noop_logger()
+
+Design Decisions:
+    - Pure functions, not singletons or factory objects
+    - Each call creates a new instance (no hidden state sharing)
+    - CLI-specific: warn_on_use=False for metrics (intentional opt-out)
+    - MUST NOT be imported by runtime code
+
+Note:
+    This module centralizes NoOp creation to eliminate duplication across
+    CLI bootstrap modules. Runtime observability uses different bootstrap
+    functions from composition/bootstrap/runtime/observability.py.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bioetl.domain.ports import MetricsPort, TracingPort
+    from bioetl.infrastructure.observability.noop_logger import NoOpLogger
+
+__all__ = [
+    "create_noop_logger",
+    "create_noop_metrics",
+    "create_noop_observability_bundle",
+    "create_noop_tracing",
+]
+
+
+def create_noop_logger() -> NoOpLogger:
+    """Create a NoOpLogger instance for CLI operations.
+
+    Returns a logger that silently ignores all logging calls.
+    Used by CLI bootstrap functions that don't require full observability.
+
+    Returns:
+        NoOpLogger instance implementing LoggerPort interface.
+
+    Example:
+        >>> logger = create_noop_logger()
+        >>> logger.info("This will be silently ignored")
+    """
+    from bioetl.infrastructure.observability.noop_logger import NoOpLogger
+
+    return NoOpLogger()
+
+
+def create_noop_metrics() -> MetricsPort:
+    """Create a NoOpMetrics instance for CLI operations.
+
+    Returns a metrics collector that silently ignores all metrics.
+    Uses warn_on_use=False since CLI intentionally opts out of metrics.
+
+    Returns:
+        NoOpMetrics instance implementing MetricsPort interface.
+
+    Example:
+        >>> metrics = create_noop_metrics()
+        >>> metrics.increment_counter("test", 1, {"label": "value"})
+    """
+    from bioetl.infrastructure.observability.noop_metrics import NoOpMetrics
+
+    return NoOpMetrics(warn_on_use=False)
+
+
+def create_noop_tracing() -> TracingPort:
+    """Create a NoOpTracing instance for CLI operations.
+
+    Returns a tracer that does nothing when spans are created.
+    Used when distributed tracing is not needed for CLI commands.
+
+    Returns:
+        NoOpTracing instance implementing TracingPort interface.
+
+    Example:
+        >>> tracing = create_noop_tracing()
+        >>> tracer = tracing.get_tracer("cli")
+        >>> with tracer.start_as_current_span("operation"):
+        ...     pass  # Span is silently ignored
+    """
+    from bioetl.infrastructure.observability.noop_tracing import NoOpTracing
+
+    return NoOpTracing()
+
+
+def create_noop_observability_bundle() -> (
+    tuple[NoOpLogger, MetricsPort, TracingPort]
+):
+    """Create a complete NoOp observability bundle for CLI operations.
+
+    Convenience function that creates all three NoOp implementations
+    in a single call. Useful when a CLI bootstrap function needs
+    multiple observability dependencies.
+
+    Returns:
+        Tuple of (NoOpLogger, NoOpMetrics, NoOpTracing) instances.
+
+    Example:
+        >>> logger, metrics, tracing = create_noop_observability_bundle()
+        >>> # Use in service construction
+        >>> service = SomeService(logger=logger, metrics=metrics)
+    """
+    return (
+        create_noop_logger(),
+        create_noop_metrics(),
+        create_noop_tracing(),
+    )

--- a/src/bioetl/composition/bootstrap/cli/storage.py
+++ b/src/bioetl/composition/bootstrap/cli/storage.py
@@ -18,8 +18,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from bioetl.composition.bootstrap.assembly.storage import bootstrap_storage_adapter
+from bioetl.composition.bootstrap.cli.noop import create_noop_logger
 from bioetl.infrastructure.config import get_settings
-from bioetl.infrastructure.observability.noop_logger import NoOpLogger
 
 if TYPE_CHECKING:
     from bioetl.application.core.cleanup_service import CleanupService
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from bioetl.application.services.medallion_lifecycle import (
         MedallionLifecycleService,
     )
+    from bioetl.domain.ports import LoggerPort
 
 __all__ = [
     "bootstrap_bronze_cleanup_service",
@@ -58,7 +59,7 @@ def bootstrap_cleanup_service() -> CleanupService:
     from bioetl.application.core.cleanup_service import CleanupService
 
     storage = bootstrap_storage_adapter()
-    noop_logger = NoOpLogger()
+    noop_logger = create_noop_logger()
 
     return CleanupService(storage=storage, logger=noop_logger)
 
@@ -90,7 +91,7 @@ def bootstrap_lifecycle_service() -> MedallionLifecycleService:
     )
 
     storage = bootstrap_storage_adapter()
-    noop_logger = NoOpLogger()
+    noop_logger = create_noop_logger()
 
     return MedallionLifecycleService(storage=storage, logger=noop_logger)
 
@@ -107,7 +108,7 @@ def bootstrap_bronze_cleanup_service() -> BronzeCleanupService:
     from bioetl.application.services import BronzeCleanupService
 
     storage = bootstrap_storage_adapter()
-    noop_logger = NoOpLogger()
+    noop_logger = create_noop_logger()
 
     return BronzeCleanupService(storage=storage, logger=noop_logger)
 
@@ -124,7 +125,7 @@ def bootstrap_vacuum_service() -> VacuumService:
     from bioetl.application.services import VacuumService
 
     lifecycle = bootstrap_lifecycle_service()
-    noop_logger = NoOpLogger()
+    noop_logger = create_noop_logger()
 
     # Create table collector that queries the registry (DI pattern)
     table_collector = _create_table_collector(noop_logger)
@@ -137,7 +138,7 @@ def bootstrap_vacuum_service() -> VacuumService:
 
 
 def _create_table_collector(
-    logger: NoOpLogger,
+    logger: LoggerPort,
 ) -> Callable[[str], list[tuple[str, str]]]:
     """Create a table collector function for VacuumService.
 
@@ -206,7 +207,7 @@ def bootstrap_export_service() -> ExportService:
     from bioetl.infrastructure.storage.delta_reader import DeltaReader
 
     settings = get_settings()
-    noop_logger = NoOpLogger()
+    noop_logger = create_noop_logger()
 
     # Use data/output/ subdirectory for actual data paths (matches pipeline configs)
     # The pipeline configs use data/output/silver, data/output/gold


### PR DESCRIPTION
Add composition/bootstrap/cli/noop.py with pure factory functions:
- create_noop_logger(): Creates NoOpLogger for CLI operations
- create_noop_metrics(): Creates NoOpMetrics with warn_on_use=False
- create_noop_tracing(): Creates NoOpTracing for CLI operations
- create_noop_observability_bundle(): Convenience function for all three

Replace all direct NoOp*() calls in CLI bootstrap modules:
- metrics.py: Use create_noop_logger()
- storage.py: Use create_noop_logger() in 5 bootstrap functions
- checkpoint.py: Use create_noop_logger() in 2 bootstrap functions
- health.py: Use create_noop_logger()
- config.py: Use create_noop_logger()
- lock.py: Use create_noop_logger()

Benefits:
- Eliminates duplication of NoOp instance creation
- Centralizes CLI-specific NoOp configuration (warn_on_use=False)
- Makes observability dependencies explicit and testable
- Runtime code does not import this module