### PR TITLE
Refactor bootstrap pipeline into pure functions

### DIFF
--- a/src/bioetl/composition/bootstrap/__init__.py
+++ b/src/bioetl/composition/bootstrap/__init__.py
@@ -62,6 +62,11 @@ from bioetl.composition.bootstrap.cli import (
 # =============================================================================
 from bioetl.composition.bootstrap.runtime import (
     MetricsServerError,
+    # Assembly (pure functions)
+    VacuumSettings,
+    assemble_filter_config,
+    assemble_runtime_config,
+    assemble_vacuum_settings,
     # Deprecated aliases
     bootstrap_composite_pipeline,
     # Canonical names
@@ -95,6 +100,11 @@ __all__ = [
     "HealthServerDependencies",
     # Runtime services
     "MetricsServerError",
+    # Runtime assembly (pure functions)
+    "VacuumSettings",
+    "assemble_filter_config",
+    "assemble_runtime_config",
+    "assemble_vacuum_settings",
     "bootstrap_bronze_cleanup_service",
     # Assembly (deprecated aliases)
     "bootstrap_checkpoint",

--- a/src/bioetl/composition/bootstrap/runtime/__init__.py
+++ b/src/bioetl/composition/bootstrap/runtime/__init__.py
@@ -9,6 +9,7 @@ IMPORTANT: This module MUST NOT import from bootstrap/cli/.
 CLI modules may import from runtime for runner access, but not vice versa.
 
 Components:
+- assembly: Pure configuration assembly functions (no I/O)
 - observability: Full observability stack bootstrap
 - pipeline: Main pipeline bootstrap entry point
 - composite: Composite pipeline bootstrap
@@ -17,6 +18,12 @@ Components:
 
 from __future__ import annotations
 
+from bioetl.composition.bootstrap.runtime.assembly import (
+    VacuumSettings,
+    assemble_filter_config,
+    assemble_runtime_config,
+    assemble_vacuum_settings,
+)
 from bioetl.composition.bootstrap.runtime.composite import (
     # Deprecated alias
     bootstrap_composite_pipeline,
@@ -55,6 +62,11 @@ from bioetl.composition.bootstrap.runtime.runner import (
 __all__ = [
     # Observability (canonical)
     "MetricsServerError",
+    # Assembly (pure functions)
+    "VacuumSettings",
+    "assemble_filter_config",
+    "assemble_runtime_config",
+    "assemble_vacuum_settings",
     # Composite (deprecated alias)
     "bootstrap_composite_pipeline",
     # Composite (canonical)

--- a/src/bioetl/composition/bootstrap/runtime/assembly.py
+++ b/src/bioetl/composition/bootstrap/runtime/assembly.py
@@ -1,0 +1,209 @@
+"""Pure assembly functions for pipeline bootstrap.
+
+Contains pure, testable functions for assembling configuration objects
+during pipeline bootstrap. These functions:
+- Accept only data (no I/O, no settings loading, no DI)
+- Return data (configuration objects or values)
+- Are deterministic and side-effect free
+
+This module reduces cognitive load in bootstrap_pipeline_runner by
+extracting configuration assembly logic into discrete, testable units.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from bioetl.composition.builders import FilterConfigBuilder
+from bioetl.domain.config import RuntimeConfig
+from bioetl.domain.types import RunType
+
+if TYPE_CHECKING:
+    from bioetl.domain.context import PipelineRunContext, VacuumConfig
+    from bioetl.domain.filtering import InputFilterConfig
+    from bioetl.infrastructure.schemas.pipeline_config import (
+        InputFilterConfig as YamlInputFilter,
+    )
+    from bioetl.infrastructure.schemas.pipeline_config import (
+        MaintenanceConfig,
+    )
+
+__all__ = [
+    "VacuumSettings",
+    "assemble_filter_config",
+    "assemble_runtime_config",
+    "assemble_vacuum_settings",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class VacuumSettings:
+    """Resolved vacuum settings after merging CLI and YAML config.
+
+    This is a pure data object representing the effective vacuum configuration
+    after applying CLI overrides to YAML defaults.
+
+    Attributes:
+        enabled: Whether vacuum should run after pipeline execution.
+        retention_days: Number of days to retain data during vacuum.
+    """
+
+    enabled: bool
+    retention_days: int
+
+
+def assemble_vacuum_settings(
+    *,
+    cli_vacuum: VacuumConfig,
+    yaml_maintenance: MaintenanceConfig,
+) -> VacuumSettings:
+    """Assemble effective vacuum settings from CLI overrides and YAML config.
+
+    Implements tri-state merge logic:
+    - CLI `enabled=None` → use YAML `auto_vacuum`
+    - CLI `enabled=True/False` → explicit CLI override takes precedence
+
+    Retention days follow same pattern: CLI override if vacuum explicitly enabled,
+    otherwise YAML default.
+
+    Args:
+        cli_vacuum: Vacuum configuration from CLI (VacuumConfig with tri-state enabled).
+        yaml_maintenance: Maintenance configuration from pipeline YAML.
+
+    Returns:
+        VacuumSettings with resolved enabled flag and retention days.
+
+    Example:
+        >>> from bioetl.domain.context import VacuumConfig
+        >>> # CLI doesn't override -> use YAML
+        >>> cli = VacuumConfig(enabled=None, retention_days=7)
+        >>> yaml = MaintenanceConfig(auto_vacuum=True, vacuum_retention_days=14)
+        >>> result = assemble_vacuum_settings(cli_vacuum=cli, yaml_maintenance=yaml)
+        >>> result.enabled
+        True
+        >>> result.retention_days
+        14
+
+        >>> # CLI explicitly overrides -> use CLI values
+        >>> cli = VacuumConfig(enabled=False, retention_days=3)
+        >>> result = assemble_vacuum_settings(cli_vacuum=cli, yaml_maintenance=yaml)
+        >>> result.enabled
+        False
+        >>> result.retention_days
+        3
+    """
+    # CLI explicit override takes precedence
+    if cli_vacuum.enabled is not None:
+        return VacuumSettings(
+            enabled=cli_vacuum.enabled,
+            retention_days=cli_vacuum.retention_days,
+        )
+
+    # No CLI override -> use YAML defaults
+    return VacuumSettings(
+        enabled=yaml_maintenance.auto_vacuum,
+        retention_days=yaml_maintenance.vacuum_retention_days,
+    )
+
+
+def assemble_runtime_config(
+    *,
+    run_type: RunType,
+    resume: bool,
+    limit: int | None,
+    query: str | None,
+    dry_run: bool,
+    heartbeat_interval: int,
+    vacuum: VacuumSettings,
+) -> RuntimeConfig:
+    """Assemble RuntimeConfig from resolved parameters.
+
+    Creates an immutable RuntimeConfig value object from pre-resolved
+    parameters. This function is pure and does not perform any I/O.
+
+    Args:
+        run_type: Type of pipeline run (incremental, backfill, rebuild).
+        resume: Whether to resume from last checkpoint.
+        limit: Optional record limit for the run.
+        query: Optional query string for filtering.
+        dry_run: Whether this is a dry run (no writes).
+        heartbeat_interval: Interval in seconds for lock heartbeat.
+        vacuum: Resolved vacuum settings.
+
+    Returns:
+        Immutable RuntimeConfig instance.
+
+    Example:
+        >>> from bioetl.domain.types import RunType
+        >>> vacuum = VacuumSettings(enabled=True, retention_days=7)
+        >>> config = assemble_runtime_config(
+        ...     run_type=RunType.INCREMENTAL,
+        ...     resume=False,
+        ...     limit=100,
+        ...     query=None,
+        ...     dry_run=False,
+        ...     heartbeat_interval=30,
+        ...     vacuum=vacuum,
+        ... )
+        >>> config.run_type
+        <RunType.INCREMENTAL: 'incremental'>
+        >>> config.vacuum_after_run
+        True
+    """
+    return RuntimeConfig(
+        run_type=run_type,
+        resume=resume,
+        limit=limit,
+        heartbeat_interval=heartbeat_interval,
+        query=query,
+        dry_run=dry_run,
+        vacuum_after_run=vacuum.enabled,
+        vacuum_retention_days=vacuum.retention_days,
+    )
+
+
+def assemble_filter_config(
+    *,
+    yaml_filter: YamlInputFilter,
+    ctx: PipelineRunContext,
+    test_mode: bool,
+) -> InputFilterConfig | None:
+    """Assemble filter configuration from YAML and CLI context.
+
+    Delegates to FilterConfigBuilder with parameters extracted from context.
+    This wrapper provides a cleaner interface and makes the filter assembly
+    logic explicit in the bootstrap pipeline.
+
+    Priority (highest to lowest):
+    1. direct_filter_ids from context (for composite mode)
+    2. CLI input_filter (if enabled)
+    3. YAML input_filter (disabled in test_mode or ignore_yaml_filter mode)
+
+    Args:
+        yaml_filter: Filter configuration from pipeline YAML.
+        ctx: Pipeline run context containing CLI filter settings.
+        test_mode: If True, YAML-based filters are disabled.
+
+    Returns:
+        Configured InputFilterConfig or None if filtering is disabled.
+
+    Example:
+        >>> # When CLI filter is enabled
+        >>> result = assemble_filter_config(
+        ...     yaml_filter=yaml_config.input_filter,
+        ...     ctx=context,
+        ...     test_mode=False,
+        ... )
+    """
+    # Determine effective test_mode (includes ignore_yaml_filter from composite mode)
+    effective_test_mode = test_mode or ctx.ignore_yaml_filter
+
+    return FilterConfigBuilder.build(
+        yaml_filter=yaml_filter,
+        cli_csv=ctx.input_filter.source_path if ctx.input_filter.enabled else None,
+        cli_column=ctx.input_filter.column_name if ctx.input_filter.enabled else None,
+        cli_field=ctx.input_filter.filter_field if ctx.input_filter.enabled else None,
+        test_mode=effective_test_mode,
+        direct_filter_ids=ctx.input_filter.filter_ids,
+    )

--- a/src/bioetl/composition/bootstrap/runtime/pipeline.py
+++ b/src/bioetl/composition/bootstrap/runtime/pipeline.py
@@ -11,14 +11,17 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from bioetl.composition.bootstrap.runtime.assembly import (
+    assemble_filter_config,
+    assemble_runtime_config,
+    assemble_vacuum_settings,
+)
 from bioetl.composition.bootstrap.runtime.observability import (
     bootstrap_observability_bundle,
 )
-from bioetl.composition.builders import FilterConfigBuilder
 from bioetl.composition.factories.pipeline_factories import register_all_pipelines
 from bioetl.composition.providers.registration import register_all_providers
 from bioetl.composition.registry import PipelineRegistry, get_default_registry
-from bioetl.domain.config import RuntimeConfig
 from bioetl.infrastructure.config import get_settings, load_pipeline_config
 
 if TYPE_CHECKING:
@@ -96,44 +99,28 @@ def bootstrap_pipeline_runner(
         log_level=ctx.log_level,
     )
 
-    # Merge YAML maintenance config with CLI overrides
-    # CLI flags take precedence over YAML config (tri-state: None/True/False)
-    # None means no CLI override -> use YAML
-    # True/False means explicit CLI override
-    vacuum_after_run = (
-        ctx.vacuum.enabled
-        if ctx.vacuum.enabled is not None
-        else yaml_config.maintenance.auto_vacuum
-    )
-    vacuum_retention_days = (
-        ctx.vacuum.retention_days
-        if ctx.vacuum.enabled is not None
-        else yaml_config.maintenance.vacuum_retention_days
+    # Assemble vacuum settings (CLI overrides YAML)
+    vacuum = assemble_vacuum_settings(
+        cli_vacuum=ctx.vacuum,
+        yaml_maintenance=yaml_config.maintenance,
     )
 
-    runtime_config = RuntimeConfig(
+    # Assemble runtime config from resolved parameters
+    runtime_config = assemble_runtime_config(
         run_type=ctx.run_type,
         resume=ctx.resume,
         limit=ctx.limit,
-        heartbeat_interval=settings.pipeline.heartbeat_interval,
         query=ctx.query,
         dry_run=ctx.dry_run,
-        vacuum_after_run=vacuum_after_run,
-        vacuum_retention_days=vacuum_retention_days,
+        heartbeat_interval=settings.pipeline.heartbeat_interval,
+        vacuum=vacuum,
     )
 
-    # Build filter config using the dedicated builder or CLI input_filter
-    # In test mode or composite mode, YAML-based filters are disabled
-    # - test_mode: E2E tests run without requiring filter CSV files
-    # - ignore_yaml_filter: composite enrichers use seed keys, not YAML filter
-    # - direct_filter_ids: composite enrichers pass DOIs directly (no CSV)
-    filter_config = FilterConfigBuilder.build(
+    # Assemble filter config (CLI/direct IDs override YAML)
+    filter_config = assemble_filter_config(
         yaml_filter=yaml_config.input_filter,
-        cli_csv=ctx.input_filter.source_path if ctx.input_filter.enabled else None,
-        cli_column=ctx.input_filter.column_name if ctx.input_filter.enabled else None,
-        cli_field=ctx.input_filter.filter_field if ctx.input_filter.enabled else None,
-        test_mode=settings.test_mode or ctx.ignore_yaml_filter,
-        direct_filter_ids=ctx.input_filter.filter_ids,
+        ctx=ctx,
+        test_mode=settings.test_mode,
     )
 
     if filter_config:

--- a/tests/unit/composition/bootstrap/runtime/__init__.py
+++ b/tests/unit/composition/bootstrap/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for composition/bootstrap/runtime module."""

--- a/tests/unit/composition/bootstrap/runtime/test_assembly.py
+++ b/tests/unit/composition/bootstrap/runtime/test_assembly.py
@@ -1,0 +1,511 @@
+"""Unit tests for composition/bootstrap/runtime/assembly.py.
+
+Tests pure assembly functions for pipeline bootstrap configuration.
+These tests verify the deterministic behavior of configuration assembly
+without requiring I/O or DI.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from bioetl.composition.bootstrap.runtime.assembly import (
+    VacuumSettings,
+    assemble_filter_config,
+    assemble_runtime_config,
+    assemble_vacuum_settings,
+)
+from bioetl.domain.context import (
+    InputFilterContext,
+    PipelineRunContext,
+    VacuumConfig,
+)
+from bioetl.domain.types import RunType
+from bioetl.infrastructure.schemas.pipeline_config import (
+    InputFilterConfig as YamlInputFilter,
+    MaintenanceConfig,
+)
+
+
+# =============================================================================
+# Test Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def yaml_maintenance_default() -> MaintenanceConfig:
+    """Create default maintenance config from YAML."""
+    return MaintenanceConfig(auto_vacuum=False, vacuum_retention_days=7)
+
+
+@pytest.fixture
+def yaml_maintenance_enabled() -> MaintenanceConfig:
+    """Create maintenance config with vacuum enabled."""
+    return MaintenanceConfig(auto_vacuum=True, vacuum_retention_days=14)
+
+
+@pytest.fixture
+def yaml_filter_disabled() -> YamlInputFilter:
+    """Create disabled filter config from YAML."""
+    return YamlInputFilter(enabled=False)
+
+
+@pytest.fixture
+def yaml_filter_enabled() -> YamlInputFilter:
+    """Create enabled filter config from YAML."""
+    return YamlInputFilter(
+        enabled=True,
+        source_path="/path/to/filter.csv",
+        column_name="compound_id",
+        filter_field="chembl_id",
+    )
+
+
+@pytest.fixture
+def base_context() -> PipelineRunContext:
+    """Create base pipeline run context for tests."""
+    return PipelineRunContext(
+        pipeline_name="test_pipeline",
+        run_id=uuid4(),
+        run_type=RunType.INCREMENTAL,
+    )
+
+
+# =============================================================================
+# Tests for VacuumSettings
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestVacuumSettings:
+    """Tests for VacuumSettings dataclass."""
+
+    def test_vacuum_settings_is_frozen(self):
+        """Test that VacuumSettings is immutable."""
+        settings = VacuumSettings(enabled=True, retention_days=7)
+        with pytest.raises(AttributeError):
+            settings.enabled = False  # type: ignore[misc]
+
+    def test_vacuum_settings_equality(self):
+        """Test that VacuumSettings supports equality comparison."""
+        s1 = VacuumSettings(enabled=True, retention_days=7)
+        s2 = VacuumSettings(enabled=True, retention_days=7)
+        s3 = VacuumSettings(enabled=False, retention_days=7)
+
+        assert s1 == s2
+        assert s1 != s3
+
+
+# =============================================================================
+# Tests for assemble_vacuum_settings
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestAssembleVacuumSettings:
+    """Tests for assemble_vacuum_settings function."""
+
+    def test_cli_none_uses_yaml_auto_vacuum_false(
+        self, yaml_maintenance_default: MaintenanceConfig
+    ):
+        """Test that CLI enabled=None uses YAML auto_vacuum=False."""
+        cli_vacuum = VacuumConfig(enabled=None, retention_days=7)
+
+        result = assemble_vacuum_settings(
+            cli_vacuum=cli_vacuum,
+            yaml_maintenance=yaml_maintenance_default,
+        )
+
+        assert result.enabled is False
+        assert result.retention_days == 7
+
+    def test_cli_none_uses_yaml_auto_vacuum_true(
+        self, yaml_maintenance_enabled: MaintenanceConfig
+    ):
+        """Test that CLI enabled=None uses YAML auto_vacuum=True."""
+        cli_vacuum = VacuumConfig(enabled=None, retention_days=3)
+
+        result = assemble_vacuum_settings(
+            cli_vacuum=cli_vacuum,
+            yaml_maintenance=yaml_maintenance_enabled,
+        )
+
+        assert result.enabled is True
+        # When CLI doesn't override, use YAML retention days
+        assert result.retention_days == 14
+
+    def test_cli_true_overrides_yaml_false(
+        self, yaml_maintenance_default: MaintenanceConfig
+    ):
+        """Test that CLI enabled=True overrides YAML auto_vacuum=False."""
+        cli_vacuum = VacuumConfig(enabled=True, retention_days=5)
+
+        result = assemble_vacuum_settings(
+            cli_vacuum=cli_vacuum,
+            yaml_maintenance=yaml_maintenance_default,
+        )
+
+        assert result.enabled is True
+        assert result.retention_days == 5
+
+    def test_cli_false_overrides_yaml_true(
+        self, yaml_maintenance_enabled: MaintenanceConfig
+    ):
+        """Test that CLI enabled=False overrides YAML auto_vacuum=True."""
+        cli_vacuum = VacuumConfig(enabled=False, retention_days=3)
+
+        result = assemble_vacuum_settings(
+            cli_vacuum=cli_vacuum,
+            yaml_maintenance=yaml_maintenance_enabled,
+        )
+
+        assert result.enabled is False
+        assert result.retention_days == 3
+
+    def test_cli_override_uses_cli_retention_days(
+        self, yaml_maintenance_enabled: MaintenanceConfig
+    ):
+        """Test that CLI override uses CLI retention_days value."""
+        cli_vacuum = VacuumConfig(enabled=True, retention_days=30)
+
+        result = assemble_vacuum_settings(
+            cli_vacuum=cli_vacuum,
+            yaml_maintenance=yaml_maintenance_enabled,
+        )
+
+        # CLI explicit override -> use CLI retention days
+        assert result.retention_days == 30
+
+    def test_returns_vacuum_settings_type(
+        self, yaml_maintenance_default: MaintenanceConfig
+    ):
+        """Test that function returns VacuumSettings type."""
+        cli_vacuum = VacuumConfig(enabled=None, retention_days=7)
+
+        result = assemble_vacuum_settings(
+            cli_vacuum=cli_vacuum,
+            yaml_maintenance=yaml_maintenance_default,
+        )
+
+        assert isinstance(result, VacuumSettings)
+
+
+# =============================================================================
+# Tests for assemble_runtime_config
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestAssembleRuntimeConfig:
+    """Tests for assemble_runtime_config function."""
+
+    def test_assembles_basic_config(self):
+        """Test that assemble_runtime_config creates basic RuntimeConfig."""
+        vacuum = VacuumSettings(enabled=False, retention_days=7)
+
+        result = assemble_runtime_config(
+            run_type=RunType.INCREMENTAL,
+            resume=False,
+            limit=None,
+            query=None,
+            dry_run=False,
+            heartbeat_interval=30,
+            vacuum=vacuum,
+        )
+
+        assert result.run_type == RunType.INCREMENTAL
+        assert result.resume is False
+        assert result.limit is None
+        assert result.query is None
+        assert result.dry_run is False
+        assert result.heartbeat_interval == 30
+        assert result.vacuum_after_run is False
+        assert result.vacuum_retention_days == 7
+
+    def test_assembles_config_with_limit(self):
+        """Test that assemble_runtime_config handles limit parameter."""
+        vacuum = VacuumSettings(enabled=False, retention_days=7)
+
+        result = assemble_runtime_config(
+            run_type=RunType.BACKFILL,
+            resume=True,
+            limit=100,
+            query="test_query",
+            dry_run=True,
+            heartbeat_interval=60,
+            vacuum=vacuum,
+        )
+
+        assert result.run_type == RunType.BACKFILL
+        assert result.resume is True
+        assert result.limit == 100
+        assert result.query == "test_query"
+        assert result.dry_run is True
+        assert result.heartbeat_interval == 60
+
+    def test_assembles_config_with_vacuum_enabled(self):
+        """Test that vacuum settings are properly transferred."""
+        vacuum = VacuumSettings(enabled=True, retention_days=14)
+
+        result = assemble_runtime_config(
+            run_type=RunType.REBUILD,
+            resume=False,
+            limit=None,
+            query=None,
+            dry_run=False,
+            heartbeat_interval=30,
+            vacuum=vacuum,
+        )
+
+        assert result.vacuum_after_run is True
+        assert result.vacuum_retention_days == 14
+
+    def test_config_is_immutable(self):
+        """Test that returned RuntimeConfig is immutable (frozen)."""
+        vacuum = VacuumSettings(enabled=False, retention_days=7)
+
+        result = assemble_runtime_config(
+            run_type=RunType.INCREMENTAL,
+            resume=False,
+            limit=None,
+            query=None,
+            dry_run=False,
+            heartbeat_interval=30,
+            vacuum=vacuum,
+        )
+
+        with pytest.raises(AttributeError):
+            result.limit = 50  # type: ignore[misc]
+
+    def test_all_run_types_supported(self):
+        """Test that all RunType values are supported."""
+        vacuum = VacuumSettings(enabled=False, retention_days=7)
+
+        for run_type in RunType:
+            result = assemble_runtime_config(
+                run_type=run_type,
+                resume=False,
+                limit=None,
+                query=None,
+                dry_run=False,
+                heartbeat_interval=30,
+                vacuum=vacuum,
+            )
+            assert result.run_type == run_type
+
+
+# =============================================================================
+# Tests for assemble_filter_config
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestAssembleFilterConfig:
+    """Tests for assemble_filter_config function."""
+
+    def test_disabled_yaml_filter_returns_none(
+        self, yaml_filter_disabled: YamlInputFilter, base_context: PipelineRunContext
+    ):
+        """Test that disabled YAML filter returns None."""
+        result = assemble_filter_config(
+            yaml_filter=yaml_filter_disabled,
+            ctx=base_context,
+            test_mode=False,
+        )
+
+        assert result is None
+
+    def test_enabled_yaml_filter_returns_config(
+        self, yaml_filter_enabled: YamlInputFilter, base_context: PipelineRunContext
+    ):
+        """Test that enabled YAML filter returns InputFilterConfig."""
+        result = assemble_filter_config(
+            yaml_filter=yaml_filter_enabled,
+            ctx=base_context,
+            test_mode=False,
+        )
+
+        assert result is not None
+        assert result.enabled is True
+        assert result.source_path == "/path/to/filter.csv"
+        assert result.column_name == "compound_id"
+        assert result.filter_field == "chembl_id"
+
+    def test_test_mode_disables_yaml_filter(
+        self, yaml_filter_enabled: YamlInputFilter, base_context: PipelineRunContext
+    ):
+        """Test that test_mode=True disables YAML-based filter."""
+        result = assemble_filter_config(
+            yaml_filter=yaml_filter_enabled,
+            ctx=base_context,
+            test_mode=True,
+        )
+
+        assert result is None
+
+    def test_cli_filter_overrides_yaml(
+        self, yaml_filter_enabled: YamlInputFilter
+    ):
+        """Test that CLI input_filter overrides YAML config."""
+        ctx = PipelineRunContext(
+            pipeline_name="test_pipeline",
+            run_id=uuid4(),
+            run_type=RunType.INCREMENTAL,
+            input_filter=InputFilterContext.from_csv(
+                source_path="/cli/path/to/filter.csv",
+                column_name="cli_column",
+                filter_field="cli_field",
+            ),
+        )
+
+        result = assemble_filter_config(
+            yaml_filter=yaml_filter_enabled,
+            ctx=ctx,
+            test_mode=False,
+        )
+
+        assert result is not None
+        assert result.source_path == "/cli/path/to/filter.csv"
+        assert result.column_name == "cli_column"
+        assert result.filter_field == "cli_field"
+
+    def test_ignore_yaml_filter_flag(
+        self, yaml_filter_enabled: YamlInputFilter
+    ):
+        """Test that ignore_yaml_filter flag disables YAML filter."""
+        ctx = PipelineRunContext(
+            pipeline_name="test_pipeline",
+            run_id=uuid4(),
+            run_type=RunType.INCREMENTAL,
+            ignore_yaml_filter=True,
+        )
+
+        result = assemble_filter_config(
+            yaml_filter=yaml_filter_enabled,
+            ctx=ctx,
+            test_mode=False,
+        )
+
+        assert result is None
+
+    def test_direct_filter_ids_takes_precedence(
+        self, yaml_filter_enabled: YamlInputFilter
+    ):
+        """Test that direct_filter_ids takes precedence over YAML."""
+        ctx = PipelineRunContext(
+            pipeline_name="test_pipeline",
+            run_id=uuid4(),
+            run_type=RunType.INCREMENTAL,
+            input_filter=InputFilterContext.from_ids(
+                filter_ids=("ID1", "ID2", "ID3"),
+                filter_field="doi",
+            ),
+        )
+
+        result = assemble_filter_config(
+            yaml_filter=yaml_filter_enabled,
+            ctx=ctx,
+            test_mode=False,
+        )
+
+        assert result is not None
+        assert result.direct_filter_ids == ("ID1", "ID2", "ID3")
+        assert result.filter_field == "doi"
+
+
+# =============================================================================
+# Integration Tests (assembly functions working together)
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestAssemblyIntegration:
+    """Integration tests for assembly functions working together."""
+
+    def test_full_assembly_flow_with_defaults(
+        self,
+        yaml_maintenance_default: MaintenanceConfig,
+        yaml_filter_disabled: YamlInputFilter,
+        base_context: PipelineRunContext,
+    ):
+        """Test full assembly flow with default configurations."""
+        # Step 1: Assemble vacuum settings
+        vacuum = assemble_vacuum_settings(
+            cli_vacuum=base_context.vacuum,
+            yaml_maintenance=yaml_maintenance_default,
+        )
+        assert vacuum.enabled is False
+
+        # Step 2: Assemble runtime config
+        runtime = assemble_runtime_config(
+            run_type=base_context.run_type,
+            resume=base_context.resume,
+            limit=base_context.limit,
+            query=base_context.query,
+            dry_run=base_context.dry_run,
+            heartbeat_interval=30,
+            vacuum=vacuum,
+        )
+        assert runtime.vacuum_after_run is False
+
+        # Step 3: Assemble filter config
+        filter_cfg = assemble_filter_config(
+            yaml_filter=yaml_filter_disabled,
+            ctx=base_context,
+            test_mode=False,
+        )
+        assert filter_cfg is None
+
+    def test_full_assembly_flow_with_overrides(
+        self,
+        yaml_maintenance_enabled: MaintenanceConfig,
+        yaml_filter_enabled: YamlInputFilter,
+    ):
+        """Test full assembly flow with CLI overrides."""
+        ctx = PipelineRunContext(
+            pipeline_name="test_pipeline",
+            run_id=uuid4(),
+            run_type=RunType.BACKFILL,
+            resume=True,
+            limit=500,
+            vacuum=VacuumConfig(enabled=False, retention_days=3),
+            input_filter=InputFilterContext.from_csv(
+                source_path="/cli/filter.csv",
+                column_name="my_col",
+                filter_field="my_field",
+            ),
+        )
+
+        # Step 1: Vacuum CLI override (False) takes precedence over YAML (True)
+        vacuum = assemble_vacuum_settings(
+            cli_vacuum=ctx.vacuum,
+            yaml_maintenance=yaml_maintenance_enabled,
+        )
+        assert vacuum.enabled is False
+        assert vacuum.retention_days == 3
+
+        # Step 2: Runtime config uses resolved vacuum
+        runtime = assemble_runtime_config(
+            run_type=ctx.run_type,
+            resume=ctx.resume,
+            limit=ctx.limit,
+            query=ctx.query,
+            dry_run=ctx.dry_run,
+            heartbeat_interval=45,
+            vacuum=vacuum,
+        )
+        assert runtime.run_type == RunType.BACKFILL
+        assert runtime.resume is True
+        assert runtime.limit == 500
+        assert runtime.vacuum_after_run is False
+
+        # Step 3: Filter CLI override takes precedence
+        filter_cfg = assemble_filter_config(
+            yaml_filter=yaml_filter_enabled,
+            ctx=ctx,
+            test_mode=False,
+        )
+        assert filter_cfg is not None
+        assert filter_cfg.source_path == "/cli/filter.csv"

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -89,12 +89,12 @@ class TestBootstrapLogger:
 class TestBootstrapPipeline:
     """Tests for bootstrap_pipeline function."""
 
-    @patch("bioetl.composition.bootstrap.runtime.pipeline.bootstrap_observability")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.bootstrap_observability_bundle")
     @patch("bioetl.infrastructure.config.get_settings")
     def test_bootstrap_pipeline_unknown_pipeline_raises(
         self,
         mock_get_settings: MagicMock,
-        mock_bootstrap_observability: MagicMock,
+        mock_bootstrap_observability_bundle: MagicMock,
         mock_settings: MagicMock,
         mock_logger: MagicMock,
     ):
@@ -131,16 +131,16 @@ class TestBootstrapPipeline:
             bootstrap_pipeline(ctx)
 
     @patch("bioetl.composition.bootstrap.runtime.pipeline.get_default_registry")
-    @patch("bioetl.composition.bootstrap.runtime.pipeline.FilterConfigBuilder")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.assemble_filter_config")
     @patch("bioetl.composition.bootstrap.runtime.pipeline.load_pipeline_config")
-    @patch("bioetl.composition.bootstrap.runtime.pipeline.bootstrap_observability")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.bootstrap_observability_bundle")
     @patch("bioetl.infrastructure.config.get_settings")
     def test_bootstrap_pipeline_creates_runner_without_starting_server(
         self,
         mock_get_settings: MagicMock,
-        mock_bootstrap_observability: MagicMock,
+        mock_bootstrap_observability_bundle: MagicMock,
         mock_load_config: MagicMock,
-        mock_filter_builder: MagicMock,
+        mock_assemble_filter: MagicMock,
         mock_get_registry: MagicMock,
         mock_logger: MagicMock,
     ) -> None:
@@ -175,9 +175,9 @@ class TestBootstrapPipeline:
         # Mock observability bundle
         mock_obs = MagicMock()
         mock_obs.logger = mock_logger
-        mock_bootstrap_observability.return_value = mock_obs
+        mock_bootstrap_observability_bundle.return_value = mock_obs
 
-        mock_filter_builder.build.return_value = None
+        mock_assemble_filter.return_value = None
 
         # Setup pipeline registry mock
         mock_config = MagicMock()
@@ -205,11 +205,11 @@ class TestBootstrapPipeline:
 
         assert result is mock_runner
         # Verify observability was bootstrapped (creates MetricsPort, but doesn't start server)
-        mock_bootstrap_observability.assert_called_once()
+        mock_bootstrap_observability_bundle.assert_called_once()
 
     @patch("bioetl.infrastructure.config.get_settings")
     @patch("bioetl.composition.bootstrap.runtime.pipeline.get_default_registry")
-    @patch("bioetl.composition.bootstrap.runtime.pipeline.bootstrap_observability")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.bootstrap_observability_bundle")
     @patch("bioetl.composition.bootstrap.runtime.pipeline.register_all_providers")
     @patch("bioetl.composition.bootstrap.runtime.pipeline.register_all_pipelines")
     @patch("bioetl.composition.bootstrap.runtime.pipeline.load_pipeline_config")
@@ -218,7 +218,7 @@ class TestBootstrapPipeline:
         mock_load_config,
         mock_register_pipelines,
         mock_register_providers,
-        mock_observability,
+        mock_observability_bundle,
         mock_get_registry,
         mock_get_settings,
         mock_settings,
@@ -244,7 +244,7 @@ class TestBootstrapPipeline:
         # Mock observability with logger
         mock_obs = MagicMock()
         mock_obs.logger = mock_logger
-        mock_observability.return_value = mock_obs
+        mock_observability_bundle.return_value = mock_obs
 
         # Mock factory and runner
         mock_runner = MagicMock(spec=PipelineRunner)
@@ -610,16 +610,16 @@ class TestBootstrapVacuumConfig:
     """Tests for bootstrap_pipeline vacuum configuration merging."""
 
     @patch("bioetl.composition.bootstrap.runtime.pipeline.get_default_registry")
-    @patch("bioetl.composition.bootstrap.runtime.pipeline.FilterConfigBuilder")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.assemble_filter_config")
     @patch("bioetl.composition.bootstrap.runtime.pipeline.load_pipeline_config")
-    @patch("bioetl.composition.bootstrap.runtime.pipeline.bootstrap_observability")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.bootstrap_observability_bundle")
     @patch("bioetl.infrastructure.config.get_settings")
     def test_bootstrap_uses_yaml_vacuum_config_when_cli_not_set(
         self,
         mock_get_settings: MagicMock,
-        mock_bootstrap_observability: MagicMock,
+        mock_bootstrap_observability_bundle: MagicMock,
         mock_load_config: MagicMock,
-        mock_filter_builder: MagicMock,
+        mock_assemble_filter: MagicMock,
         mock_get_registry: MagicMock,
     ) -> None:
         """Test that YAML auto_vacuum config is used when CLI doesn't override."""
@@ -640,8 +640,8 @@ class TestBootstrapVacuumConfig:
         logger.bind.return_value = logger
         mock_obs = MagicMock()
         mock_obs.logger = logger
-        mock_bootstrap_observability.return_value = mock_obs
-        mock_filter_builder.build.return_value = None
+        mock_bootstrap_observability_bundle.return_value = mock_obs
+        mock_assemble_filter.return_value = None
 
         # Setup YAML config with auto_vacuum enabled
         yaml_config = MagicMock()
@@ -675,16 +675,16 @@ class TestBootstrapVacuumConfig:
         assert runtime.vacuum_retention_days == 14
 
     @patch("bioetl.composition.bootstrap.runtime.pipeline.get_default_registry")
-    @patch("bioetl.composition.bootstrap.runtime.pipeline.FilterConfigBuilder")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.assemble_filter_config")
     @patch("bioetl.composition.bootstrap.runtime.pipeline.load_pipeline_config")
-    @patch("bioetl.composition.bootstrap.runtime.pipeline.bootstrap_observability")
+    @patch("bioetl.composition.bootstrap.runtime.pipeline.bootstrap_observability_bundle")
     @patch("bioetl.infrastructure.config.get_settings")
     def test_bootstrap_cli_vacuum_overrides_yaml_config(
         self,
         mock_get_settings: MagicMock,
-        mock_bootstrap_observability: MagicMock,
+        mock_bootstrap_observability_bundle: MagicMock,
         mock_load_config: MagicMock,
-        mock_filter_builder: MagicMock,
+        mock_assemble_filter: MagicMock,
         mock_get_registry: MagicMock,
     ) -> None:
         """Test that CLI vacuum options override YAML config."""
@@ -705,8 +705,8 @@ class TestBootstrapVacuumConfig:
         logger.bind.return_value = logger
         mock_obs = MagicMock()
         mock_obs.logger = logger
-        mock_bootstrap_observability.return_value = mock_obs
-        mock_filter_builder.build.return_value = None
+        mock_bootstrap_observability_bundle.return_value = mock_obs
+        mock_assemble_filter.return_value = None
 
         # Setup YAML config with auto_vacuum enabled
         yaml_config = MagicMock()


### PR DESCRIPTION
…_pipeline

Decompose bootstrap_pipeline into pure, testable assembly functions:

- Add assembly.py module with:
  - assemble_vacuum_settings(): merge CLI/YAML vacuum config
  - assemble_runtime_config(): create RuntimeConfig from parameters
  - assemble_filter_config(): wrap FilterConfigBuilder with context

- Refactor bootstrap_pipeline_runner to use assembly functions
- Export VacuumSettings and assembly functions from runtime module
- Add 21 unit tests for assembly functions
- Update existing tests to use correct patch paths

The assembly functions are pure (no I/O, no settings loading, no DI), making bootstrap_pipeline_runner easier to read and the configuration logic independently testable.