### PR TITLE
Clean up bootstrap layer imports and dependencies

### DIFF
--- a/src/bioetl/composition/_bootstrap/config.py
+++ b/src/bioetl/composition/_bootstrap/config.py
@@ -6,8 +6,7 @@ Used primarily by CLI configuration operations.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
+from bioetl.application.services import ConfigService
 from bioetl.composition.factories.pipeline_factories import register_all_pipelines
 from bioetl.composition.registry import get_default_registry
 from bioetl.infrastructure.config import (
@@ -16,9 +15,6 @@ from bioetl.infrastructure.config import (
     yaml_config_to_domain,
 )
 from bioetl.infrastructure.observability.noop_logger import NoOpLogger
-
-if TYPE_CHECKING:
-    from bioetl.application.services import ConfigService
 
 __all__ = [
     "bootstrap_config_service",
@@ -39,8 +35,6 @@ def bootstrap_config_service() -> ConfigService:
         >>> settings = service.get_settings()
         >>> logger.info("environment", env=settings.env)
     """
-    from bioetl.application.services import ConfigService
-
     noop_logger = NoOpLogger()
 
     # Ensure pipelines are registered for list_pipelines()

--- a/src/bioetl/composition/_bootstrap/lock.py
+++ b/src/bioetl/composition/_bootstrap/lock.py
@@ -5,13 +5,9 @@ Contains bootstrap functions for lock service used by CLI operations.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
+from bioetl.application.services.lock_service import LockService
 from bioetl.infrastructure.locking.memory_lock import MemoryLock
 from bioetl.infrastructure.observability.noop_logger import NoOpLogger
-
-if TYPE_CHECKING:
-    from bioetl.application.services.lock_service import LockService
 
 __all__ = ["bootstrap_lock_service"]
 
@@ -29,8 +25,6 @@ def bootstrap_lock_service() -> LockService:
     Returns:
         LockService configured for the current environment.
     """
-    from bioetl.application.services.lock_service import LockService
-
     lock_port = MemoryLock()
     noop_logger = NoOpLogger()
 

--- a/src/bioetl/composition/_bootstrap/observability.py
+++ b/src/bioetl/composition/_bootstrap/observability.py
@@ -15,11 +15,12 @@ from __future__ import annotations
 
 import contextlib
 from typing import TYPE_CHECKING
-from uuid import UUID
+from uuid import UUID, uuid4
 
+from bioetl.application.services.metrics_service import MetricsService
 from bioetl.composition.observability import ObservabilityBundle
 from bioetl.domain.exceptions import MetricsServerError
-from bioetl.domain.ports import LoggerPort, MetricsPort, TracingPort
+from bioetl.domain.ports import DQMonitorPort, LoggerPort, MetricsPort, TracingPort
 from bioetl.infrastructure.observability import (
     NoOpMetrics,
     NoOpTracing,
@@ -28,10 +29,13 @@ from bioetl.infrastructure.observability import (
     UnifiedLogger,
     start_metrics_server,
 )
+from bioetl.infrastructure.observability.anomaly import DataQualityMonitor
+from bioetl.infrastructure.observability.metrics_server_adapter import (
+    MetricsServerAdapter,
+)
+from bioetl.infrastructure.observability.noop_logger import NoOpLogger
 
 if TYPE_CHECKING:
-    from bioetl.application.services.metrics_service import MetricsService
-    from bioetl.domain.ports import DQMonitorPort
     from bioetl.infrastructure.config import Settings
 
 __all__ = [
@@ -112,8 +116,6 @@ def bootstrap_logger(
     Returns:
         UnifiedLogger implementing LoggerPort with Log Schema enforcement.
     """
-    from uuid import uuid4
-
     effective_run_id = run_id if run_id is not None else uuid4()
     return UnifiedLogger(
         pipeline=pipeline,
@@ -241,9 +243,6 @@ def bootstrap_dq_monitor(
     if not obs_settings.dq_monitor_enabled:
         return None
 
-    from bioetl.infrastructure.observability.anomaly import DataQualityMonitor
-    from bioetl.infrastructure.observability.noop_logger import NoOpLogger
-
     effective_logger = logger if logger is not None else NoOpLogger()
 
     monitor = DataQualityMonitor(
@@ -348,12 +347,6 @@ def bootstrap_metrics_service() -> MetricsService:
         >>> result = service.start(port=8000)
         >>> # result.success is True if server started
     """
-    from bioetl.application.services.metrics_service import MetricsService
-    from bioetl.infrastructure.observability.metrics_server_adapter import (
-        MetricsServerAdapter,
-    )
-    from bioetl.infrastructure.observability.noop_logger import NoOpLogger
-
     logger = NoOpLogger()
     server = MetricsServerAdapter(logger=logger)
 

--- a/src/bioetl/composition/bootstrap/cli/checkpoint.py
+++ b/src/bioetl/composition/bootstrap/cli/checkpoint.py
@@ -11,21 +11,19 @@ Note:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 from uuid import uuid4
 
+from bioetl.application.core.checkpoint_manager import CheckpointManager
+from bioetl.application.core.quarantine_manager import QuarantineManager
+from bioetl.application.services import CheckpointService, QuarantineService
 from bioetl.composition.bootstrap.assembly.checkpoint import (
     bootstrap_checkpoint_port,
     bootstrap_quarantine_port,
 )
 from bioetl.composition.bootstrap.cli.noop import create_noop_logger
+from bioetl.domain.types import RunID
 from bioetl.infrastructure.checkpoint.local_checkpoint import LocalCheckpoint
 from bioetl.infrastructure.config import get_settings
-
-if TYPE_CHECKING:
-    from bioetl.application.core.checkpoint_manager import CheckpointManager
-    from bioetl.application.core.quarantine_manager import QuarantineManager
-    from bioetl.application.services import CheckpointService, QuarantineService
 
 __all__ = [
     "bootstrap_checkpoint_manager",
@@ -47,8 +45,6 @@ def bootstrap_quarantine_manager(pipeline_name: str) -> QuarantineManager:
     Returns:
         QuarantineManager configured for the specified pipeline.
     """
-    from bioetl.application.core.quarantine_manager import QuarantineManager
-
     quarantine_port = bootstrap_quarantine_port()
     return QuarantineManager(
         quarantine_port=quarantine_port,
@@ -70,9 +66,6 @@ def bootstrap_checkpoint_manager(pipeline_name: str) -> CheckpointManager:
     Returns:
         CheckpointManager configured for CLI inspection.
     """
-    from bioetl.application.core.checkpoint_manager import CheckpointManager
-    from bioetl.domain.types import RunID
-
     checkpoint_port = bootstrap_checkpoint_port(pipeline_name)
     noop_logger = create_noop_logger()
 
@@ -94,8 +87,6 @@ def bootstrap_checkpoint_service() -> CheckpointService:
     Returns:
         CheckpointService configured for CLI operations.
     """
-    from bioetl.application.services import CheckpointService
-
     settings = get_settings()
     # Use empty pipeline name for global operations
     checkpoint_port = LocalCheckpoint(
@@ -118,8 +109,6 @@ def bootstrap_quarantine_service() -> QuarantineService:
     Returns:
         QuarantineService configured for CLI operations.
     """
-    from bioetl.application.services import QuarantineService
-
     quarantine_port = bootstrap_quarantine_port()
     noop_logger = create_noop_logger()
 

--- a/src/bioetl/composition/bootstrap/cli/config.py
+++ b/src/bioetl/composition/bootstrap/cli/config.py
@@ -6,8 +6,7 @@ Used primarily by CLI configuration operations.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
+from bioetl.application.services import ConfigService
 from bioetl.composition.bootstrap.cli.noop import create_noop_logger
 from bioetl.composition.factories.pipeline_factories import register_all_pipelines
 from bioetl.composition.registry import get_default_registry
@@ -16,9 +15,6 @@ from bioetl.infrastructure.config import (
     load_pipeline_config,
     yaml_config_to_domain,
 )
-
-if TYPE_CHECKING:
-    from bioetl.application.services import ConfigService
 
 __all__ = ["bootstrap_config_service"]
 
@@ -37,8 +33,6 @@ def bootstrap_config_service() -> ConfigService:
         >>> settings = service.get_settings()
         >>> logger.info("environment", env=settings.env)
     """
-    from bioetl.application.services import ConfigService
-
     noop_logger = create_noop_logger()
 
     # Ensure pipelines are registered for list_pipelines()

--- a/src/bioetl/composition/bootstrap/cli/health.py
+++ b/src/bioetl/composition/bootstrap/cli/health.py
@@ -7,17 +7,13 @@ Used primarily by CLI health operations.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 
+from bioetl.application.services import HealthService
 from bioetl.composition.bootstrap.cli.noop import create_noop_logger
 from bioetl.composition.factories.data_source_factory import DataSourceFactory
-
-if TYPE_CHECKING:
-    from bioetl.application.services import HealthService
-    from bioetl.domain.ports import MetricsPort
-    from bioetl.infrastructure.adapters.http.health_monitor import (
-        ProviderHealthMonitor,
-    )
+from bioetl.domain.ports import MetricsPort
+from bioetl.infrastructure.adapters.http.health_monitor import ProviderHealthMonitor
+from bioetl.infrastructure.observability.prometheus_metrics import PrometheusMetrics
 
 __all__ = [
     "HealthServerDependencies",
@@ -57,8 +53,6 @@ def bootstrap_health_service() -> HealthService:
         >>> if summary.all_healthy:
         ...     logger.info("All providers healthy")
     """
-    from bioetl.application.services import HealthService
-
     noop_logger = create_noop_logger()
 
     return HealthService(
@@ -85,13 +79,6 @@ def bootstrap_health_server_dependencies() -> HealthServerDependencies:
         >>> server = HealthServer(host="127.0.0.1", port=9090,
         ...                       health_monitor=deps.health_monitor)
     """
-    from bioetl.infrastructure.adapters.http.health_monitor import (
-        ProviderHealthMonitor,
-    )
-    from bioetl.infrastructure.observability.prometheus_metrics import (
-        PrometheusMetrics,
-    )
-
     # Create metrics port for health monitor
     metrics = PrometheusMetrics()
 

--- a/src/bioetl/composition/bootstrap/cli/lock.py
+++ b/src/bioetl/composition/bootstrap/cli/lock.py
@@ -5,13 +5,9 @@ Contains bootstrap functions for lock service used by CLI operations.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
+from bioetl.application.services.lock_service import LockService
 from bioetl.composition.bootstrap.cli.noop import create_noop_logger
 from bioetl.infrastructure.locking.memory_lock import MemoryLock
-
-if TYPE_CHECKING:
-    from bioetl.application.services.lock_service import LockService
 
 __all__ = ["bootstrap_lock_service"]
 
@@ -29,8 +25,6 @@ def bootstrap_lock_service() -> LockService:
     Returns:
         LockService configured for the current environment.
     """
-    from bioetl.application.services.lock_service import LockService
-
     lock_port = MemoryLock()
     noop_logger = create_noop_logger()
 

--- a/src/bioetl/composition/bootstrap/cli/metrics.py
+++ b/src/bioetl/composition/bootstrap/cli/metrics.py
@@ -10,12 +10,11 @@ Note:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
+from bioetl.application.services.metrics_service import MetricsService
 from bioetl.composition.bootstrap.cli.noop import create_noop_logger
-
-if TYPE_CHECKING:
-    from bioetl.application.services.metrics_service import MetricsService
+from bioetl.infrastructure.observability.metrics_server_adapter import (
+    MetricsServerAdapter,
+)
 
 __all__ = ["bootstrap_metrics_service"]
 
@@ -34,11 +33,6 @@ def bootstrap_metrics_service() -> MetricsService:
         >>> result = service.start(port=8000)
         >>> # result.success is True if server started
     """
-    from bioetl.application.services.metrics_service import MetricsService
-    from bioetl.infrastructure.observability.metrics_server_adapter import (
-        MetricsServerAdapter,
-    )
-
     logger = create_noop_logger()
     server = MetricsServerAdapter(logger=logger)
 

--- a/src/bioetl/composition/bootstrap/cli/noop.py
+++ b/src/bioetl/composition/bootstrap/cli/noop.py
@@ -24,11 +24,10 @@ Note:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from bioetl.domain.ports import MetricsPort, TracingPort
-    from bioetl.infrastructure.observability.noop_logger import NoOpLogger
+from bioetl.domain.ports import MetricsPort, TracingPort
+from bioetl.infrastructure.observability.noop_logger import NoOpLogger
+from bioetl.infrastructure.observability.noop_metrics import NoOpMetrics
+from bioetl.infrastructure.observability.noop_tracing import NoOpTracing
 
 __all__ = [
     "create_noop_logger",
@@ -51,8 +50,6 @@ def create_noop_logger() -> NoOpLogger:
         >>> logger = create_noop_logger()
         >>> logger.info("This will be silently ignored")
     """
-    from bioetl.infrastructure.observability.noop_logger import NoOpLogger
-
     return NoOpLogger()
 
 
@@ -69,8 +66,6 @@ def create_noop_metrics() -> MetricsPort:
         >>> metrics = create_noop_metrics()
         >>> metrics.increment_counter("test", 1, {"label": "value"})
     """
-    from bioetl.infrastructure.observability.noop_metrics import NoOpMetrics
-
     return NoOpMetrics(warn_on_use=False)
 
 
@@ -89,8 +84,6 @@ def create_noop_tracing() -> TracingPort:
         >>> with tracer.start_as_current_span("operation"):
         ...     pass  # Span is silently ignored
     """
-    from bioetl.infrastructure.observability.noop_tracing import NoOpTracing
-
     return NoOpTracing()
 
 

--- a/src/bioetl/composition/bootstrap/cli/storage.py
+++ b/src/bioetl/composition/bootstrap/cli/storage.py
@@ -17,20 +17,20 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from bioetl.application.core.cleanup_service import CleanupService
+from bioetl.application.services import (
+    BronzeCleanupService,
+    ExportService,
+    VacuumService,
+)
+from bioetl.application.services.medallion_lifecycle import MedallionLifecycleService
 from bioetl.composition.bootstrap.assembly.storage import bootstrap_storage_adapter
 from bioetl.composition.bootstrap.cli.noop import create_noop_logger
-from bioetl.infrastructure.config import get_settings
+from bioetl.composition.registry import get_default_registry
+from bioetl.infrastructure.config import get_settings, load_pipeline_config
+from bioetl.infrastructure.storage.delta_reader import DeltaReader
 
 if TYPE_CHECKING:
-    from bioetl.application.core.cleanup_service import CleanupService
-    from bioetl.application.services import (
-        BronzeCleanupService,
-        ExportService,
-        VacuumService,
-    )
-    from bioetl.application.services.medallion_lifecycle import (
-        MedallionLifecycleService,
-    )
     from bioetl.domain.ports import LoggerPort
 
 __all__ = [
@@ -56,8 +56,6 @@ def bootstrap_cleanup_service() -> CleanupService:
     Returns:
         CleanupService configured for the current environment.
     """
-    from bioetl.application.core.cleanup_service import CleanupService
-
     storage = bootstrap_storage_adapter()
     noop_logger = create_noop_logger()
 
@@ -86,10 +84,6 @@ def bootstrap_lifecycle_service() -> MedallionLifecycleService:
     Returns:
         MedallionLifecycleService configured for the current environment.
     """
-    from bioetl.application.services.medallion_lifecycle import (
-        MedallionLifecycleService,
-    )
-
     storage = bootstrap_storage_adapter()
     noop_logger = create_noop_logger()
 
@@ -105,8 +99,6 @@ def bootstrap_bronze_cleanup_service() -> BronzeCleanupService:
     Returns:
         BronzeCleanupService configured for the current environment.
     """
-    from bioetl.application.services import BronzeCleanupService
-
     storage = bootstrap_storage_adapter()
     noop_logger = create_noop_logger()
 
@@ -122,8 +114,6 @@ def bootstrap_vacuum_service() -> VacuumService:
     Returns:
         VacuumService configured for the current environment.
     """
-    from bioetl.application.services import VacuumService
-
     lifecycle = bootstrap_lifecycle_service()
     noop_logger = create_noop_logger()
 
@@ -152,9 +142,6 @@ def _create_table_collector(
     Returns:
         Callable that collects tables for a given layer.
     """
-    from bioetl.composition.registry import get_default_registry
-    from bioetl.infrastructure.config import load_pipeline_config
-
     def collect_tables(layer: str) -> list[tuple[str, str]]:
         """Collect tables from all registered pipelines.
 
@@ -203,9 +190,6 @@ def bootstrap_export_service() -> ExportService:
     Returns:
         ExportService configured for the current environment.
     """
-    from bioetl.application.services import ExportService
-    from bioetl.infrastructure.storage.delta_reader import DeltaReader
-
     settings = get_settings()
     noop_logger = create_noop_logger()
 

--- a/src/bioetl/composition/bootstrap/runtime/composite.py
+++ b/src/bioetl/composition/bootstrap/runtime/composite.py
@@ -107,8 +107,9 @@ def bootstrap_composite_runner(
     Returns:
         CompositePipelineRunner ready for execution.
     """
-    # Lazy import to avoid circular dependency with entrypoints
-    # (entrypoints -> _bootstrap -> bootstrap -> runtime -> composite -> entrypoints)
+    # CIRCULAR-DEPENDENCY: Local import required to break circular dependency.
+    # Import chain: entrypoints -> _bootstrap -> bootstrap -> runtime -> composite -> entrypoints
+    # Moving this import to module level would cause ImportError at startup.
     from bioetl.composition.entrypoints import RunOptions, build_pipeline_context
 
     effective_run_id = run_id or str(uuid4())

--- a/src/bioetl/composition/bootstrap/runtime/observability.py
+++ b/src/bioetl/composition/bootstrap/runtime/observability.py
@@ -20,11 +20,11 @@ from __future__ import annotations
 
 import contextlib
 from typing import TYPE_CHECKING
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from bioetl.composition.observability import ObservabilityBundle
 from bioetl.domain.exceptions import MetricsServerError
-from bioetl.domain.ports import LoggerPort, MetricsPort, TracingPort
+from bioetl.domain.ports import DQMonitorPort, LoggerPort, MetricsPort, TracingPort
 from bioetl.infrastructure.observability import (
     NoOpMetrics,
     NoOpTracing,
@@ -33,9 +33,10 @@ from bioetl.infrastructure.observability import (
     UnifiedLogger,
     start_metrics_server,
 )
+from bioetl.infrastructure.observability.anomaly import DataQualityMonitor
+from bioetl.infrastructure.observability.noop_logger import NoOpLogger
 
 if TYPE_CHECKING:
-    from bioetl.domain.ports import DQMonitorPort
     from bioetl.infrastructure.config import Settings
 
 __all__ = [
@@ -124,8 +125,6 @@ def bootstrap_logger_port(
     Returns:
         UnifiedLogger implementing LoggerPort with Log Schema enforcement.
     """
-    from uuid import uuid4
-
     effective_run_id = run_id if run_id is not None else uuid4()
     return UnifiedLogger(
         pipeline=pipeline,
@@ -319,9 +318,6 @@ def bootstrap_dq_monitor_port(
 
     if not obs_settings.dq_monitor_enabled:
         return None
-
-    from bioetl.infrastructure.observability.anomaly import DataQualityMonitor
-    from bioetl.infrastructure.observability.noop_logger import NoOpLogger
 
     effective_logger = logger if logger is not None else NoOpLogger()
 

--- a/src/bioetl/composition/entrypoints.py
+++ b/src/bioetl/composition/entrypoints.py
@@ -17,7 +17,9 @@ from uuid import uuid4
 
 # Re-export canonical DTO classes from application.services (H1 refactoring)
 # These are the single source of truth for pipeline execution interfaces.
+from bioetl.application.core.shutdown import PipelineShutdownError
 from bioetl.application.services import RunOptions, RunResult, RunStatus
+from bioetl.infrastructure.config import get_settings
 
 __all__ = [
     # Configuration
@@ -130,8 +132,6 @@ def ensure_metrics_server_started() -> bool:
         >>> ensure_metrics_server_started()
         True  # Server started on configured port
     """
-    from bioetl.infrastructure.config import get_settings
-
     settings = get_settings()
     return maybe_start_metrics_server(settings)
 
@@ -289,9 +289,6 @@ async def run_pipeline(name: str, options: RunOptions) -> RunResult:
         >>> else:
         ...     logger.error("pipeline_failed", error_message=result.error_message)
     """
-    from bioetl.application.core.shutdown import PipelineShutdownError
-    from bioetl.infrastructure.config import get_settings
-
     # Start metrics server if enabled (side-effect in entrypoint, not bootstrap)
     settings = get_settings()
     maybe_start_metrics_server(settings)


### PR DESCRIPTION
Move local imports from function bodies to module level to make dependencies statically visible and predictable per RULES.md.

Changes:
- bootstrap/cli/*.py: Move all service/manager imports to module level
- bootstrap/runtime/observability.py: Move uuid4, DQ, NoOpLogger imports
- _bootstrap/*.py: Move local imports in deprecated modules
- entrypoints.py: Move get_settings, PipelineShutdownError imports

Circular dependency in composite.py is documented with CIRCULAR-DEPENDENCY comment explaining the import chain that requires lazy import.

All contracts verified with import-linter (5 kept, 0 broken).