### PR TITLE
Unify error handling in bootstrap layer

### DIFF
--- a/src/bioetl/composition/_bootstrap/observability.py
+++ b/src/bioetl/composition/_bootstrap/observability.py
@@ -13,7 +13,6 @@ Unified Observability Contract:
 
 from __future__ import annotations
 
-import contextlib
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
@@ -131,9 +130,8 @@ def bootstrap_tracer(
 ) -> TracingPort:
     """Bootstrap distributed tracing.
 
-    Unified Observability Contract: Always returns a valid TracingPort.
-    When tracing is disabled or OpenTelemetry is not installed,
-    returns NoOpTracing (silent fallback).
+    When tracing is disabled, returns NoOpTracing.
+    When tracing is enabled, returns OpenTelemetryTracer.
 
     Args:
         settings: Application settings (MUST be injected, not loaded globally).
@@ -141,14 +139,12 @@ def bootstrap_tracer(
 
     Returns:
         TracingPort instance (OpenTelemetryTracer or NoOpTracing).
-        Never returns None - uses NoOpTracing as fallback.
+
+    Raises:
+        ImportError: If tracing is enabled but OpenTelemetry is not installed.
     """
     if settings.observability.tracing_enabled:
-        try:
-            return OpenTelemetryTracer(service_name=service_name)
-        except ImportError:
-            # OpenTelemetry not installed, fall back to no-op
-            pass
+        return OpenTelemetryTracer(service_name=service_name)
     return NoOpTracing()
 
 
@@ -202,25 +198,13 @@ def maybe_start_metrics_server(settings: Settings) -> bool:
 
     obs = settings.observability
 
-    if obs.metrics_fail_fast:
-        # In fail_fast mode, let MetricsServerError propagate
-        return start_metrics_server(
-            port=settings.metrics_port,
-            fail_fast=True,
-            retry_count=obs.metrics_retry_count,
-            retry_delay=obs.metrics_retry_delay,
-        )
-
-    # Lenient mode: log but don't fail - metrics collection still works
-    with contextlib.suppress(Exception):
-        return start_metrics_server(
-            port=settings.metrics_port,
-            fail_fast=False,
-            retry_count=obs.metrics_retry_count,
-            retry_delay=obs.metrics_retry_delay,
-        )
-
-    return False
+    # Start metrics server - let exceptions propagate to entrypoints
+    return start_metrics_server(
+        port=settings.metrics_port,
+        fail_fast=obs.metrics_fail_fast,
+        retry_count=obs.metrics_retry_count,
+        retry_delay=obs.metrics_retry_delay,
+    )
 
 
 def bootstrap_dq_monitor(

--- a/src/bioetl/composition/_bootstrap/storage.py
+++ b/src/bioetl/composition/_bootstrap/storage.py
@@ -198,7 +198,7 @@ def bootstrap_vacuum_service() -> VacuumService:
     noop_logger = NoOpLogger()
 
     # Create table collector that queries the registry (DI pattern)
-    table_collector = _create_table_collector(noop_logger)
+    table_collector = _create_table_collector()
 
     return VacuumService(
         lifecycle=lifecycle,
@@ -207,20 +207,18 @@ def bootstrap_vacuum_service() -> VacuumService:
     )
 
 
-def _create_table_collector(
-    logger: NoOpLogger,
-) -> Callable[[str], list[tuple[str, str]]]:
+def _create_table_collector() -> Callable[[str], list[tuple[str, str]]]:
     """Create a table collector function for VacuumService.
 
     This function queries the pipeline registry and config loader
     to collect silver/gold tables. It lives in composition layer
     to maintain proper dependency direction (application -> domain <- composition).
 
-    Args:
-        logger: Logger for warnings when configs are not found.
-
     Returns:
         Callable that collects tables for a given layer.
+
+    Raises:
+        ValueError: If config file for a registered pipeline is not found.
     """
     from bioetl.composition.entrypoints import load_pipeline_config
     from bioetl.composition.registry import get_default_registry
@@ -233,6 +231,9 @@ def _create_table_collector(
 
         Returns:
             List of (table_name, layer) tuples sorted alphabetically.
+
+        Raises:
+            ValueError: If config file for a registered pipeline is not found.
         """
         registry = get_default_registry()
         pipelines = registry.list_pipelines()
@@ -241,17 +242,11 @@ def _create_table_collector(
         gold_tables: set[str] = set()
 
         for pipeline_name in pipelines:
-            try:
-                config = load_pipeline_config(pipeline_name)
-                if config.silver_table:
-                    silver_tables.add(config.silver_table)
-                if config.gold_table:
-                    gold_tables.add(config.gold_table)
-            except FileNotFoundError:
-                logger.warning(
-                    "Config not found for pipeline",
-                    pipeline_name=pipeline_name,
-                )
+            config = load_pipeline_config(pipeline_name)
+            if config.silver_table:
+                silver_tables.add(config.silver_table)
+            if config.gold_table:
+                gold_tables.add(config.gold_table)
 
         tables: list[tuple[str, str]] = []
         if layer in ("all", "silver"):

--- a/src/bioetl/composition/bootstrap/cli/storage.py
+++ b/src/bioetl/composition/bootstrap/cli/storage.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from bioetl.application.core.cleanup_service import CleanupService
 from bioetl.application.services import (
@@ -29,9 +28,6 @@ from bioetl.composition.bootstrap.cli.noop import create_noop_logger
 from bioetl.composition.registry import get_default_registry
 from bioetl.infrastructure.config import get_settings, load_pipeline_config
 from bioetl.infrastructure.storage.delta_reader import DeltaReader
-
-if TYPE_CHECKING:
-    from bioetl.domain.ports import LoggerPort
 
 __all__ = [
     "bootstrap_bronze_cleanup_service",
@@ -118,7 +114,7 @@ def bootstrap_vacuum_service() -> VacuumService:
     noop_logger = create_noop_logger()
 
     # Create table collector that queries the registry (DI pattern)
-    table_collector = _create_table_collector(noop_logger)
+    table_collector = _create_table_collector()
 
     return VacuumService(
         lifecycle=lifecycle,
@@ -127,20 +123,18 @@ def bootstrap_vacuum_service() -> VacuumService:
     )
 
 
-def _create_table_collector(
-    logger: LoggerPort,
-) -> Callable[[str], list[tuple[str, str]]]:
+def _create_table_collector() -> Callable[[str], list[tuple[str, str]]]:
     """Create a table collector function for VacuumService.
 
     This function queries the pipeline registry and config loader
     to collect silver/gold tables. It lives in composition layer
     to maintain proper dependency direction (application -> domain <- composition).
 
-    Args:
-        logger: Logger for warnings when configs are not found.
-
     Returns:
         Callable that collects tables for a given layer.
+
+    Raises:
+        ValueError: If config file for a registered pipeline is not found.
     """
     def collect_tables(layer: str) -> list[tuple[str, str]]:
         """Collect tables from all registered pipelines.
@@ -150,6 +144,9 @@ def _create_table_collector(
 
         Returns:
             List of (table_name, layer) tuples sorted alphabetically.
+
+        Raises:
+            ValueError: If config file for a registered pipeline is not found.
         """
         registry = get_default_registry()
         pipelines = registry.list_pipelines()
@@ -158,17 +155,11 @@ def _create_table_collector(
         gold_tables: set[str] = set()
 
         for pipeline_name in pipelines:
-            try:
-                config = load_pipeline_config(pipeline_name)
-                if config.silver_table:
-                    silver_tables.add(config.silver_table)
-                if config.gold_table:
-                    gold_tables.add(config.gold_table)
-            except FileNotFoundError:
-                logger.warning(
-                    "Config not found for pipeline",
-                    pipeline_name=pipeline_name,
-                )
+            config = load_pipeline_config(pipeline_name)
+            if config.silver_table:
+                silver_tables.add(config.silver_table)
+            if config.gold_table:
+                gold_tables.add(config.gold_table)
 
         tables: list[tuple[str, str]] = []
         if layer in ("all", "silver"):

--- a/src/bioetl/composition/bootstrap/runtime/composite.py
+++ b/src/bioetl/composition/bootstrap/runtime/composite.py
@@ -246,7 +246,7 @@ def bootstrap_composite_runner(
         resume=runtime.resume,
     )
 
-    # Create DQ report service for composite (optional)
+    # Create DQ report service for composite
     dq_report_service = _create_dq_report_service(logger, settings)
 
     return CompositePipelineRunner(
@@ -290,38 +290,30 @@ def bootstrap_composite_pipeline(
 def _create_dq_report_service(
     logger: LoggerPort,
     settings: Settings,
-) -> DQReportService | None:
+) -> DQReportService:
     """Create DQ report service for composite pipelines.
-
-    Returns None if DQ reporting is not configured.
 
     Args:
         logger: Structured logger.
         settings: Application settings.
 
     Returns:
-        DQReportService instance or None.
+        DQReportService instance.
+
+    Raises:
+        ImportError: If required modules are not available.
     """
-    try:
-        from bioetl.application.services.dq_report_service import DQReportService
-        from bioetl.infrastructure.export.dq_report_writer import DQReportWriter
+    from bioetl.application.services.dq_report_service import DQReportService
+    from bioetl.infrastructure.export.dq_report_writer import DQReportWriter
 
-        # Create DQ report writer
-        reports_base_path = Path(settings.data_dir) / "output" / "reports" / "dq"
-        report_writer = DQReportWriter(
-            base_path=reports_base_path,
-            logger=logger,
-        )
+    # Create DQ report writer
+    reports_base_path = Path(settings.data_dir) / "output" / "reports" / "dq"
+    report_writer = DQReportWriter(
+        base_path=reports_base_path,
+        logger=logger,
+    )
 
-        return DQReportService(
-            logger=logger,
-            report_writer=report_writer,
-            # Analyzers are optional - reports will be generated
-            # for layers where analyzers are available
-        )
-    except Exception as e:
-        logger.debug(
-            "dq_report_service_creation_failed",
-            error=str(e),
-        )
-        return None
+    return DQReportService(
+        logger=logger,
+        report_writer=report_writer,
+    )

--- a/src/bioetl/composition/bootstrap/runtime/observability.py
+++ b/src/bioetl/composition/bootstrap/runtime/observability.py
@@ -18,7 +18,6 @@ Note:
 
 from __future__ import annotations
 
-import contextlib
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
@@ -162,9 +161,8 @@ def bootstrap_tracer_port(
 ) -> TracingPort:
     """Create a tracing port implementation for distributed tracing.
 
-    Unified Observability Contract: Always returns a valid TracingPort.
-    When tracing is disabled or OpenTelemetry is not installed,
-    returns NoOpTracing (silent fallback).
+    When tracing is disabled, returns NoOpTracing.
+    When tracing is enabled, returns OpenTelemetryTracer.
 
     Layer: Returns domain port implementation (TracingPort).
 
@@ -174,14 +172,12 @@ def bootstrap_tracer_port(
 
     Returns:
         TracingPort instance (OpenTelemetryTracer or NoOpTracing).
-        Never returns None - uses NoOpTracing as fallback.
+
+    Raises:
+        ImportError: If tracing is enabled but OpenTelemetry is not installed.
     """
     if settings.observability.tracing_enabled:
-        try:
-            return OpenTelemetryTracer(service_name=service_name)
-        except ImportError:
-            # OpenTelemetry not installed, fall back to no-op
-            pass
+        return OpenTelemetryTracer(service_name=service_name)
     return NoOpTracing()
 
 
@@ -257,25 +253,13 @@ def maybe_start_metrics_server(settings: Settings) -> bool:
 
     obs = settings.observability
 
-    if obs.metrics_fail_fast:
-        # In fail_fast mode, let MetricsServerError propagate
-        return start_metrics_server(
-            port=settings.metrics_port,
-            fail_fast=True,
-            retry_count=obs.metrics_retry_count,
-            retry_delay=obs.metrics_retry_delay,
-        )
-
-    # Lenient mode: log but don't fail - metrics collection still works
-    with contextlib.suppress(Exception):
-        return start_metrics_server(
-            port=settings.metrics_port,
-            fail_fast=False,
-            retry_count=obs.metrics_retry_count,
-            retry_delay=obs.metrics_retry_delay,
-        )
-
-    return False
+    # Start metrics server - let exceptions propagate to entrypoints
+    return start_metrics_server(
+        port=settings.metrics_port,
+        fail_fast=obs.metrics_fail_fast,
+        retry_count=obs.metrics_retry_count,
+        retry_delay=obs.metrics_retry_delay,
+    )
 
 
 def bootstrap_metrics(settings: Settings) -> MetricsPort:

--- a/src/bioetl/composition/factories/http_client_factory.py
+++ b/src/bioetl/composition/factories/http_client_factory.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from bioetl.composition.bootstrap_logger import BootstrapLogger
 from bioetl.composition.providers import ProviderRegistry, ensure_providers_loaded
 from bioetl.domain.resilience import RetryConfig
 from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
@@ -30,8 +29,6 @@ if TYPE_CHECKING:
     from bioetl.domain.ports import LoggerPort, MetricsPort, TracingPort
     from bioetl.domain.types import RunID
     from bioetl.infrastructure.config import Settings
-
-_logger = BootstrapLogger()
 
 
 class HttpClientFactory:
@@ -114,16 +111,11 @@ class HttpClientFactory:
         Returns:
             Configured UnifiedHTTPClient with observability
         """
-        # Try to load source config from YAML (primary source)
-        source_config = None
-        try:
-            source_config = load_source_config(provider)
-        except ValueError:
-            _logger.debug(
-                "source_config_not_found",
-                provider=provider,
-                fallback="ProviderRegistry defaults",
-            )
+        # Load source config from YAML (primary source) if exists
+        from pathlib import Path
+
+        config_path = Path(f"configs/sources/{provider}.yaml")
+        source_config = load_source_config(provider) if config_path.exists() else None
 
         # Get rate limit, circuit breaker, and client settings
         if source_config is not None:

--- a/src/bioetl/composition/factories/pipeline_factory.py
+++ b/src/bioetl/composition/factories/pipeline_factory.py
@@ -621,16 +621,21 @@ def _extract_single_dq_config(
 
     Returns:
         DQ report config if enabled, None otherwise.
+
+    Raises:
+        ValidationError: If sink config exists but is invalid.
     """
     sink_config = sink.get(layer_name)
     if not sink_config:
         return None
-    try:
-        validated = config_class.model_validate(sink_config.model_dump())
-        if validated.dq_report.enabled:
-            return validated.dq_report
-    except Exception:
-        pass
+
+    # Check if sink_config has model_dump (is a Pydantic model)
+    if not hasattr(sink_config, "model_dump"):
+        return None
+
+    validated = config_class.model_validate(sink_config.model_dump())
+    if hasattr(validated, "dq_report") and validated.dq_report.enabled:
+        return validated.dq_report
     return None
 
 

--- a/src/bioetl/composition/factories/storage_adapter.py
+++ b/src/bioetl/composition/factories/storage_adapter.py
@@ -504,42 +504,31 @@ class StorageAdapter:
         """
         total_removed = 0
 
-        # Vacuum Silver
-        try:
+        # Vacuum Silver (only if table exists)
+        silver_table_path = self.silver.get_table_path(table_name)
+        if silver_table_path.exists():
             removed = await self.silver.vacuum(
                 table_name=table_name,
                 retention_hours=retention_hours,
                 dry_run=dry_run,
             )
             total_removed += len(removed)
-        except Exception:
-            # Log but continue to Gold (table may not exist)
-            pass
 
-        # Vacuum Gold (GoldWriter uses SilverWriter internally, need to add vacuum)
-        # Gold layer uses same Delta format, so we can vacuum via path
-        try:
-            gold_table_path = f"{self.gold.base_path}/{table_name.replace('.', '/')}"
-            loop = asyncio.get_running_loop()
+        # Vacuum Gold (only if table exists)
+        gold_table_path = self.gold.get_table_path(table_name)
+        if gold_table_path.exists():
             from deltalake import DeltaTable
-            from deltalake.exceptions import (
-                TableNotFoundError as DeltaTableNotFoundError,
-            )
 
-            try:
-                dt = await loop.run_in_executor(
-                    None,
-                    lambda: DeltaTable(gold_table_path),
-                )
-                removed = await loop.run_in_executor(
-                    None,
-                    lambda: dt.vacuum(retention_hours=retention_hours, dry_run=dry_run),
-                )
-                total_removed += len(removed)
-            except DeltaTableNotFoundError:
-                pass
-        except Exception:
-            pass
+            loop = asyncio.get_running_loop()
+            dt = await loop.run_in_executor(
+                None,
+                lambda: DeltaTable(str(gold_table_path)),
+            )
+            removed = await loop.run_in_executor(
+                None,
+                lambda: dt.vacuum(retention_hours=retention_hours, dry_run=dry_run),
+            )
+            total_removed += len(removed)
 
         return total_removed
 

--- a/src/bioetl/composition/providers/registration.py
+++ b/src/bioetl/composition/providers/registration.py
@@ -13,7 +13,6 @@ from bioetl.application.core.idmapping_data_source import IDMappingDataSource
 from bioetl.application.core.publication_term_data_source import (
     PublicationTermDataSource,
 )
-from bioetl.composition.bootstrap_logger import BootstrapLogger
 from bioetl.composition.providers.provider_registry import (
     HttpConfig,
     ProviderConfig,
@@ -56,8 +55,6 @@ if TYPE_CHECKING:
     from bioetl.infrastructure.schemas.pipeline_config import PipelineYamlConfig
     from bioetl.infrastructure.schemas.source_config import SourceYamlConfig
 
-_logger = BootstrapLogger()
-
 
 def _get_factories() -> tuple[Any, Any]:
     """Lazy import factories to avoid circular imports."""
@@ -68,12 +65,20 @@ def _get_factories() -> tuple[Any, Any]:
 
 
 def _get_source_config(provider: str) -> SourceYamlConfig | None:
-    """Load config from configs/sources/{provider}.yaml or return None."""
-    try:
-        return load_source_config(provider)
-    except ValueError:
-        _logger.debug("source_config_not_found", provider=provider, fallback="defaults")
+    """Load config from configs/sources/{provider}.yaml or return None.
+
+    Returns:
+        SourceYamlConfig if found, None if config file does not exist.
+
+    Raises:
+        ValueError: If config file exists but is invalid.
+    """
+    from pathlib import Path
+
+    config_path = Path(f"configs/sources/{provider}.yaml")
+    if not config_path.exists():
         return None
+    return load_source_config(provider)
 
 
 def _get_batch_size_from_config(provider: str, default: int = 100) -> int:
@@ -118,19 +123,13 @@ def _get_adapter_config(provider: str, default_page_size: int = 1000) -> Adapter
         AdapterConfig: Immutable adapter configuration
 
     Raises:
-        ValueError: If source config is missing and fail_fast is True
+        ValueError: If source config file exists but is invalid.
     """
     source_config = _get_source_config(provider)
     if source_config is not None:
         return source_config.to_adapter_config(default_page_size=default_page_size)
 
-    # Fallback to domain defaults
-    _logger.warning(
-        "source_config_missing",
-        provider=provider,
-        fallback="AdapterConfig defaults",
-        recommendation=f"Create configs/sources/{provider}.yaml to configure adapter parameters",
-    )
+    # Fallback to domain defaults when config file does not exist
     return AdapterConfig(page_size=default_page_size)
 
 

--- a/src/bioetl/composition/services/metadata_coordinator.py
+++ b/src/bioetl/composition/services/metadata_coordinator.py
@@ -53,18 +53,17 @@ from bioetl.domain.value_objects.run_context import RunContext
 
 
 def _get_bioetl_version() -> str:
-    """Get BioETL package version safely."""
-    try:
-        from bioetl import __version__
+    """Get BioETL package version.
 
-        return __version__
-    except ImportError:
-        try:
-            from importlib.metadata import version as pkg_version
+    Returns:
+        Package version string.
 
-            return pkg_version("bioetl")
-        except Exception:
-            return "unknown"
+    Raises:
+        PackageNotFoundError: If bioetl package is not installed.
+    """
+    from importlib.metadata import version as pkg_version
+
+    return pkg_version("bioetl")
 
 
 class MetadataCoordinator:

--- a/tests/unit/composition/bootstrap/test_storage_bootstrap.py
+++ b/tests/unit/composition/bootstrap/test_storage_bootstrap.py
@@ -18,7 +18,6 @@ from bioetl.composition._bootstrap.storage import (
     bootstrap_vacuum_service,
 )
 from bioetl.composition.factories.storage import StorageAdapter
-from bioetl.infrastructure.observability.noop_logger import NoOpLogger
 
 
 @pytest.mark.unit
@@ -123,8 +122,7 @@ class TestCreateTableCollector:
 
     def test_returns_callable(self) -> None:
         """Test that _create_table_collector returns a callable."""
-        logger = NoOpLogger()
-        collector = _create_table_collector(logger)
+        collector = _create_table_collector()
 
         assert callable(collector)
 
@@ -143,8 +141,7 @@ class TestCreateTableCollector:
         mock_config.gold_table = "gold.table1"
         mock_load_config.return_value = mock_config
 
-        logger = NoOpLogger()
-        collector = _create_table_collector(logger)
+        collector = _create_table_collector()
 
         tables = collector("silver")
 
@@ -165,8 +162,7 @@ class TestCreateTableCollector:
         mock_config.gold_table = "gold.table1"
         mock_load_config.return_value = mock_config
 
-        logger = NoOpLogger()
-        collector = _create_table_collector(logger)
+        collector = _create_table_collector()
 
         tables = collector("gold")
 
@@ -187,8 +183,7 @@ class TestCreateTableCollector:
         mock_config.gold_table = "gold.table1"
         mock_load_config.return_value = mock_config
 
-        logger = NoOpLogger()
-        collector = _create_table_collector(logger)
+        collector = _create_table_collector()
 
         tables = collector("all")
 
@@ -199,23 +194,20 @@ class TestCreateTableCollector:
 
     @patch("bioetl.composition.entrypoints.load_pipeline_config")
     @patch("bioetl.composition.registry.get_default_registry")
-    def test_handles_missing_config(
+    def test_raises_on_missing_config(
         self,
         mock_registry: MagicMock,
         mock_load_config: MagicMock,
     ) -> None:
-        """Test handling of missing pipeline config."""
+        """Test that missing pipeline config raises ValueError."""
         mock_registry.return_value.list_pipelines.return_value = ["pipeline1"]
-        mock_load_config.side_effect = FileNotFoundError("Config not found")
+        mock_load_config.side_effect = ValueError("Config not found")
 
-        logger = MagicMock()
-        collector = _create_table_collector(logger)
+        collector = _create_table_collector()
 
-        tables = collector("all")
-
-        # Should return empty list and log warning
-        assert tables == []
-        logger.warning.assert_called_once()
+        # Should raise ValueError instead of silently failing
+        with pytest.raises(ValueError, match="Config not found"):
+            collector("all")
 
     @patch("bioetl.composition.entrypoints.load_pipeline_config")
     @patch("bioetl.composition.registry.get_default_registry")
@@ -235,8 +227,7 @@ class TestCreateTableCollector:
         mock_config.gold_table = "shared.gold"
         mock_load_config.return_value = mock_config
 
-        logger = NoOpLogger()
-        collector = _create_table_collector(logger)
+        collector = _create_table_collector()
 
         tables = collector("all")
 
@@ -257,8 +248,7 @@ class TestCreateTableCollector:
         mock_config.gold_table = None
         mock_load_config.return_value = mock_config
 
-        logger = NoOpLogger()
-        collector = _create_table_collector(logger)
+        collector = _create_table_collector()
 
         tables = collector("all")
 
@@ -290,8 +280,7 @@ class TestCreateTableCollector:
 
         mock_load_config.side_effect = config_for_pipeline
 
-        logger = NoOpLogger()
-        collector = _create_table_collector(logger)
+        collector = _create_table_collector()
 
         tables = collector("silver")
 

--- a/tests/unit/infrastructure/test_storage_factory.py
+++ b/tests/unit/infrastructure/test_storage_factory.py
@@ -613,9 +613,18 @@ class TestStorageAdapterVacuum:
         return bronze, silver, gold
 
     @pytest.mark.asyncio
-    async def test_vacuum_calls_silver_vacuum(self, mock_writers):
+    async def test_vacuum_calls_silver_vacuum(self, mock_writers, tmp_path):
         """Test vacuum delegates to silver writer."""
         bronze, silver, gold = mock_writers
+
+        # Create mock path that exists for silver but not gold
+        silver_path = tmp_path / "silver" / "chembl_activity"
+        silver_path.mkdir(parents=True)
+        gold_path = tmp_path / "gold" / "chembl_activity"
+        # Don't create gold_path so it doesn't exist
+
+        silver.get_table_path = MagicMock(return_value=silver_path)
+        gold.get_table_path = MagicMock(return_value=gold_path)
 
         adapter = StorageAdapter(
             bronze_writer=bronze,
@@ -631,8 +640,8 @@ class TestStorageAdapterVacuum:
 
         result = await adapter.vacuum("chembl_activity", retention_hours=168)
 
-        # Should have vacuumed at least silver (2 files)
-        assert result >= 2
+        # Should have vacuumed silver (2 files), gold skipped (doesn't exist)
+        assert result == 2
 
 
 @pytest.mark.unit

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -558,11 +558,11 @@ class TestMaybeStartMetricsServer:
         assert exc_info.value.reason == "port_in_use"
 
     @patch("bioetl.composition.bootstrap.runtime.observability.start_metrics_server")
-    def test_maybe_start_metrics_server_fail_fast_false_suppresses_error(
+    def test_maybe_start_metrics_server_fail_fast_false_propagates_error(
         self,
         mock_start_server: MagicMock,
     ) -> None:
-        """Test that fail_fast=False suppresses exceptions."""
+        """Test that fail_fast=False still propagates exceptions to entrypoints."""
         from bioetl.composition.bootstrap import maybe_start_metrics_server
 
         settings = MagicMock()
@@ -573,13 +573,12 @@ class TestMaybeStartMetricsServer:
         settings.observability.metrics_retry_count = 3
         settings.observability.metrics_retry_delay = 1.0
 
-        # Simulate exception in lenient mode
+        # Simulate exception - should propagate to entrypoints for handling
         mock_start_server.side_effect = Exception("Random failure")
 
-        # Should not raise, should return False
-        result = maybe_start_metrics_server(settings)
-
-        assert result is False
+        # Exceptions now propagate instead of being suppressed
+        with pytest.raises(Exception, match="Random failure"):
+            maybe_start_metrics_server(settings)
 
     def test_maybe_start_metrics_server_disabled_returns_false(self) -> None:
         """Test that disabled metrics returns False without calling server."""


### PR DESCRIPTION
Remove try/except blocks, exception suppression, and soft fallback paths from the bootstrap layer. Bootstrap functions now either succeed or propagate exceptions to entrypoints for handling.

Changes:
- registration.py: Check file existence instead of catching ValueError
- http_client_factory.py: Check file existence instead of catching ValueError
- storage_adapter.py: Check table existence before vacuum operations
- pipeline_factory.py: Check model attributes instead of catching Exception
- metadata_coordinator.py: Use importlib.metadata directly, remove fallback
- _bootstrap/storage.py: Remove try/except in table collector
- bootstrap/cli/storage.py: Remove try/except in table collector
- _bootstrap/observability.py: Remove ImportError suppression and contextlib.suppress
- bootstrap/runtime/observability.py: Remove ImportError suppression and contextlib.suppress
- bootstrap/runtime/composite.py: Remove try/except in DQ report service creation

Test updates:
- Update _create_table_collector tests for new signature
- Update vacuum test to mock path existence
- Update metrics server test to expect exception propagation