### PR TITLE
Fix primary key and partition parameters in Delta

### DIFF
--- a/src/bioetl/composition/services/metadata_coordinator.py
+++ b/src/bioetl/composition/services/metadata_coordinator.py
@@ -269,6 +269,7 @@ class MetadataCoordinator:
             table_path=input_data.table_path,
             operation=operation_map[input_data.mode],
             primary_key=input_data.primary_keys,
+            partition_by=input_data.partition_by or [],
             version_after=input_data.version_after,
             rows_inserted=len(input_data.records),
         )

--- a/src/bioetl/domain/ports/metadata_coordinator.py
+++ b/src/bioetl/domain/ports/metadata_coordinator.py
@@ -64,6 +64,7 @@ class SilverMetadataInput:
         transform_version: Optional semver version of transform applied.
         transform_steps: Optional list of transform step names applied.
         dq_report_path: Optional path to generated DQ report for cross-reference.
+        partition_by: Partition columns used for the Delta table.
     """
 
     table_path: str
@@ -76,6 +77,7 @@ class SilverMetadataInput:
     transform_version: str | None = None
     transform_steps: tuple[str, ...] | None = None
     dq_report_path: str | None = None
+    partition_by: list[str] | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/bioetl/infrastructure/storage/metadata_builder.py
+++ b/src/bioetl/infrastructure/storage/metadata_builder.py
@@ -92,6 +92,7 @@ class SilverMetadataBuilder:
         run_id: str | None = None,
         sources_used: list[str] | None = None,
         version_after: int | None = None,
+        partition_by: list[str] | None = None,
     ) -> SilverMetadata:
         """Build Silver metadata for merged composite data.
 
@@ -103,6 +104,7 @@ class SilverMetadataBuilder:
             run_id: Composite run ID.
             sources_used: List of source pipelines (e.g., ['seed', 'crossref']).
             version_after: Delta table version after write.
+            partition_by: Partition columns used for the Delta table.
 
         Returns:
             SilverMetadata object ready for serialization.
@@ -148,6 +150,7 @@ class SilverMetadataBuilder:
             table_path=table_path,
             operation="overwrite",
             primary_key=primary_keys,
+            partition_by=partition_by or [],
             version_after=version_after,
             rows_inserted=len(records),
         )

--- a/src/bioetl/infrastructure/storage/silver_writer.py
+++ b/src/bioetl/infrastructure/storage/silver_writer.py
@@ -619,6 +619,7 @@ class SilverWriter(BaseDeltaWriter):
                 mode=validated_mode,
                 bronze_refs=bronze_refs,
                 dq_metrics=dq_metrics,
+                partition_by=partition_cols,
             )
 
             # Return SilverWriteResult for Gold lineage tracking (REQ-LINEAGE-002)
@@ -772,6 +773,7 @@ class SilverWriter(BaseDeltaWriter):
         bronze_refs: list[BronzeWriteResult] | None = None,
         dq_metrics: BatchDQMetrics | None = None,
         dq_report_path: str | None = None,
+        partition_by: list[str] | None = None,
     ) -> None:
         """Write Silver layer metadata sidecar file.
 
@@ -788,6 +790,7 @@ class SilverWriter(BaseDeltaWriter):
                 If provided, dq_summary will contain real column metrics,
                 schema drift info, and error rates (REQ-DQ-001).
             dq_report_path: Optional path to generated DQ report for cross-reference.
+            partition_by: Partition columns used for the Delta table.
         """
         if not records:
             return
@@ -819,6 +822,7 @@ class SilverWriter(BaseDeltaWriter):
             transform_version=self._transform_version,
             transform_steps=self._transform_steps,
             dq_report_path=dq_report_path,
+            partition_by=partition_by,
         )
         metadata = self._metadata_coordinator.create_silver_metadata(silver_input)
         await self._metadata_writer.write_silver_metadata(


### PR DESCRIPTION
- Add partition_by field to SilverMetadataInput dataclass
- Pass partition_by from SilverMetadataInput to DeltaMetrics in MetadataCoordinator.create_silver_metadata()
- Update SilverWriter._write_silver_metadata() to accept partition_by
- Pass partition_cols to _write_silver_metadata() in write_silver()
- Update SilverMetadataBuilder.build_merged_metadata() for consistency

This ensures that partition_by columns are properly recorded in Silver layer metadata sidecar files for lineage and documentation purposes.