### PR TITLE
Implement intelligent column prefixing for cross-provider/entity merges

### DIFF
--- a/src/bioetl/application/composite/merger.py
+++ b/src/bioetl/application/composite/merger.py
@@ -10,6 +10,7 @@ from bioetl.domain.composite.result import EnrichmentResult, MergeResult
 from bioetl.domain.composite.strategy import ConflictResolution, MergeStrategy
 
 JoinHow = Literal["inner", "left", "right", "full", "semi", "anti", "cross", "outer"]
+PrefixStrategy = Literal["provider", "entity", "both", "pipeline"]
 
 if TYPE_CHECKING:
     import polars as pl
@@ -72,8 +73,22 @@ class MergeService:
         enrichers: Sequence[EnricherConfig],
         enrichment_results: dict[str, EnrichmentResult],
         run_id: str,
+        seed_pipeline: str | None = None,
     ) -> MergeResult:
-        """Merge seed and enricher data into unified output."""
+        """Merge seed and enricher data into unified output.
+
+        Args:
+            seed_table: Path to seed Silver table (e.g., "silver/chembl/publication").
+            enrichers: Sequence of enricher configurations.
+            enrichment_results: Results from enricher execution.
+            run_id: Composite pipeline run ID.
+            seed_pipeline: Seed pipeline name (e.g., "chembl_publication").
+                If None, will be inferred from seed_table path.
+                Used for intelligent column renaming during merge.
+
+        Returns:
+            MergeResult with statistics and output paths.
+        """
         started_at = datetime.now(tz=UTC)
 
         # Step 1: Read seed data
@@ -83,6 +98,16 @@ class MergeService:
         )
         seed_df = await self._read_silver_table(seed_table)
         records_from_seed = len(seed_df)
+
+        # Determine seed pipeline for intelligent column renaming
+        effective_seed_pipeline = seed_pipeline or self._infer_pipeline_from_table(
+            seed_table
+        )
+        if effective_seed_pipeline:
+            self._logger.debug(
+                "Using seed pipeline for column renaming",
+                seed_pipeline=effective_seed_pipeline,
+            )
 
         # Track sources used
         sources_used = ["seed"]
@@ -115,11 +140,12 @@ class MergeService:
                     error=str(e),
                 )
 
-        # Step 3: Apply joins
+        # Step 3: Apply joins with intelligent column renaming
         merged_df = await self._apply_joins(
             seed_df=seed_df,
             enricher_dfs=enricher_dfs,
             enrichers=enrichers,
+            seed_pipeline=effective_seed_pipeline,
         )
 
         # Step 4: Resolve conflicts
@@ -127,6 +153,7 @@ class MergeService:
             df=merged_df,
             enricher_dfs=enricher_dfs,
             enrichers=enrichers,
+            seed_pipeline=effective_seed_pipeline,
         )
 
         # Step 5: Add lineage metadata
@@ -139,7 +166,9 @@ class MergeService:
 
         # Calculate statistics before writing
         records_merged = len(merged_df)
-        records_enriched = self._count_enriched_records(merged_df, enrichers)
+        records_enriched = self._count_enriched_records(
+            merged_df, enrichers, effective_seed_pipeline
+        )
 
         # Step 6: Write to Silver via StoragePort
         self._logger.info(
@@ -295,6 +324,37 @@ class MergeService:
             return f"silver/{provider}/{entity}"
         return f"silver/{pipeline_name}"
 
+    def _infer_pipeline_from_table(self, table_path: str) -> str | None:
+        """Infer pipeline name from Silver table path.
+
+        Converts a table path like "silver/chembl/publication" to
+        pipeline name "chembl_publication".
+
+        Args:
+            table_path: Silver table path.
+
+        Returns:
+            Pipeline name or None if cannot be inferred.
+
+        Example:
+            >>> merger._infer_pipeline_from_table("silver/chembl/publication")
+            'chembl_publication'
+            >>> merger._infer_pipeline_from_table("silver/crossref/publication")
+            'crossref_publication'
+        """
+        # Check if path contains a recognized layer prefix
+        normalized = table_path.replace("\\", "/")
+        has_layer = any(layer in normalized for layer in ("silver/", "gold/", "bronze/"))
+        if not has_layer:
+            return None
+
+        table_name = _path_to_table_name(table_path)
+        # table_name is now like "chembl/publication"
+        parts = table_name.split("/")
+        if len(parts) == 2:
+            return f"{parts[0]}_{parts[1]}"
+        return None
+
     def _normalize_join_key_columns(
         self,
         df: pl.DataFrame,
@@ -335,60 +395,389 @@ class MergeService:
             [pl.col(col).str.to_lowercase().alias(col) for col in normalize_cols]
         )
 
+    def _parse_pipeline_name(self, pipeline: str) -> tuple[str, str]:
+        """Parse pipeline name into (provider, entity).
+
+        Pipeline names follow the format "{provider}_{entity}".
+        For example: 'chembl_publication' → ('chembl', 'publication').
+
+        Args:
+            pipeline: Pipeline name in format "provider_entity".
+
+        Returns:
+            Tuple of (provider, entity).
+
+        Raises:
+            ValueError: If pipeline name doesn't contain underscore separator.
+
+        Example:
+            >>> merger._parse_pipeline_name("chembl_publication")
+            ('chembl', 'publication')
+            >>> merger._parse_pipeline_name("crossref_publication")
+            ('crossref', 'publication')
+        """
+        if "_" not in pipeline:
+            raise ValueError(
+                f"Pipeline name '{pipeline}' must be in format 'provider_entity'"
+            )
+        parts = pipeline.split("_", 1)
+        return (parts[0], parts[1])
+
+    def _determine_prefix_strategy(
+        self,
+        seed_provider: str,
+        seed_entity: str,
+        enricher_provider: str,
+        enricher_entity: str,
+    ) -> PrefixStrategy:
+        """Determine column prefix strategy based on provider/entity relationship.
+
+        Determines how to prefix enricher columns to avoid conflicts
+        while maintaining semantic clarity.
+
+        Args:
+            seed_provider: Provider name of the seed pipeline.
+            seed_entity: Entity name of the seed pipeline.
+            enricher_provider: Provider name of the enricher pipeline.
+            enricher_entity: Entity name of the enricher pipeline.
+
+        Returns:
+            Strategy to use:
+            - "provider": Cross-provider merge (same entity, different providers).
+              Prefix with provider name. Example: "crossref.doi"
+            - "entity": Cross-entity merge (same provider, different entities).
+              Prefix with entity name. Example: "activity.chembl_id"
+            - "both": Cross-provider-entity merge (different providers AND entities).
+              Prefix with provider.entity. Example: "pubchem.compound.name"
+            - "pipeline": Fallback when same provider and entity.
+              Use full pipeline name. Example: "chembl_publication_extra.doi"
+
+        Example:
+            >>> merger._determine_prefix_strategy("chembl", "publication",
+            ...                                    "crossref", "publication")
+            'provider'
+            >>> merger._determine_prefix_strategy("chembl", "publication",
+            ...                                    "chembl", "activity")
+            'entity'
+            >>> merger._determine_prefix_strategy("chembl", "publication",
+            ...                                    "pubchem", "compound")
+            'both'
+        """
+        same_provider = seed_provider.lower() == enricher_provider.lower()
+        same_entity = seed_entity.lower() == enricher_entity.lower()
+
+        if same_entity and not same_provider:
+            # Cross-provider merge: same entity, different providers
+            return "provider"
+        elif same_provider and not same_entity:
+            # Cross-entity merge: same provider, different entities
+            return "entity"
+        elif not same_provider and not same_entity:
+            # Cross-provider-entity merge: different providers AND entities
+            return "both"
+        else:
+            # Same provider and entity - use full pipeline name
+            return "pipeline"
+
+    def _column_contains_identifier(
+        self,
+        column: str,
+        identifier: str,
+    ) -> bool:
+        """Check if column name already contains the identifier (case-insensitive).
+
+        Used to avoid redundant prefixes like "crossref.crossref_doi".
+
+        Args:
+            column: Column name to check.
+            identifier: Identifier to search for (provider or entity name).
+
+        Returns:
+            True if column contains the identifier (case-insensitive).
+
+        Example:
+            >>> merger._column_contains_identifier("crossref_doi", "crossref")
+            True
+            >>> merger._column_contains_identifier("doi", "crossref")
+            False
+            >>> merger._column_contains_identifier("CROSSREF.DOI", "crossref")
+            True
+            >>> merger._column_contains_identifier("chembl_id", "chembl")
+            True
+        """
+        return identifier.lower() in column.lower()
+
+    def _build_prefix(
+        self,
+        strategy: PrefixStrategy,
+        provider: str,
+        entity: str,
+        pipeline: str,
+    ) -> str:
+        """Build column prefix based on strategy.
+
+        Args:
+            strategy: Prefix strategy to use.
+            provider: Provider name.
+            entity: Entity name.
+            pipeline: Full pipeline name (fallback).
+
+        Returns:
+            Prefix string WITHOUT trailing dot.
+
+        Example:
+            >>> merger._build_prefix("provider", "crossref", "publication",
+            ...                       "crossref_publication")
+            'crossref'
+            >>> merger._build_prefix("entity", "chembl", "activity",
+            ...                       "chembl_activity")
+            'activity'
+            >>> merger._build_prefix("both", "pubchem", "compound",
+            ...                       "pubchem_compound")
+            'pubchem.compound'
+        """
+        match strategy:
+            case "provider":
+                return provider
+            case "entity":
+                return entity
+            case "both":
+                return f"{provider}.{entity}"
+            case "pipeline":
+                return pipeline
+
+    def _apply_column_prefix(
+        self,
+        df: pl.DataFrame,
+        columns: set[str],
+        prefix: str,
+        exclude_columns: set[str],
+    ) -> pl.DataFrame:
+        """Apply prefix to specified columns.
+
+        Renames columns by adding a prefix with dot separator.
+        Excludes join keys and columns already containing the identifier.
+
+        Args:
+            df: DataFrame to modify.
+            columns: Set of column names to potentially rename.
+            prefix: Prefix to add (WITHOUT trailing dot).
+            exclude_columns: Columns to exclude from renaming (join keys, etc.).
+
+        Returns:
+            DataFrame with renamed columns.
+
+        Example:
+            >>> df = pl.DataFrame({"doi": ["10.1/a"], "title": ["T1"]})
+            >>> result = merger._apply_column_prefix(
+            ...     df, {"title"}, "crossref", {"doi"}
+            ... )
+            >>> result.columns
+            ['doi', 'crossref.title']
+        """
+        rename_map = {}
+        for col in columns:
+            if col not in exclude_columns:
+                rename_map[col] = f"{prefix}.{col}"
+
+        if rename_map:
+            self._logger.debug(
+                "Applying column prefix",
+                prefix=prefix,
+                columns=list(rename_map.keys()),
+            )
+            return df.rename(rename_map)
+        return df
+
+    def _detect_and_resolve_conflicts(
+        self,
+        seed_df: pl.DataFrame,
+        enricher_df: pl.DataFrame,
+        join_keys: set[str],
+    ) -> tuple[pl.DataFrame, pl.DataFrame]:
+        """Detect and resolve column name conflicts between seed and enricher.
+
+        After prefix application, there may still be conflicts when:
+        - Seed already has a prefixed column (e.g., "crossref.title")
+        - Enricher gets the same prefix (e.g., "crossref.title")
+
+        Resolution: Add .A suffix to seed, .B suffix to enricher.
+
+        Args:
+            seed_df: Seed DataFrame.
+            enricher_df: Enricher DataFrame (already with prefixes applied).
+            join_keys: Set of join key columns to exclude from conflict resolution.
+
+        Returns:
+            Tuple of (modified_seed_df, modified_enricher_df) with conflicts resolved.
+
+        Example:
+            >>> seed = pl.DataFrame({"doi": ["10.1/a"], "crossref.title": ["T1"]})
+            >>> enricher = pl.DataFrame({"doi": ["10.1/a"], "crossref.title": ["T2"]})
+            >>> seed_out, enricher_out = merger._detect_and_resolve_conflicts(
+            ...     seed, enricher, {"doi"}
+            ... )
+            >>> seed_out.columns
+            ['doi', 'crossref.title.A']
+            >>> enricher_out.columns
+            ['doi', 'crossref.title.B']
+        """
+        seed_cols = set(seed_df.columns)
+        enricher_cols = set(enricher_df.columns)
+
+        # Find conflicts (excluding join keys)
+        conflicts = (seed_cols & enricher_cols) - join_keys
+
+        if not conflicts:
+            return seed_df, enricher_df
+
+        self._logger.warning(
+            "Column name conflicts detected after prefixing",
+            conflicts=list(conflicts),
+            resolution="Adding .A/.B suffixes",
+        )
+
+        # Rename conflicting columns
+        seed_rename = {col: f"{col}.A" for col in conflicts}
+        enricher_rename = {col: f"{col}.B" for col in conflicts}
+
+        return seed_df.rename(seed_rename), enricher_df.rename(enricher_rename)
+
     async def _apply_joins(
         self,
         seed_df: pl.DataFrame,
         enricher_dfs: dict[str, pl.DataFrame],
         enrichers: Sequence[EnricherConfig],
+        seed_pipeline: str | None = None,
     ) -> pl.DataFrame:
-        """Apply join strategy (LEFT_OUTER/INNER/UNION) to combine DataFrames.
+        """Apply join strategy with intelligent column renaming.
 
-        Note: Join keys (doi, pmid, pmc_id) are normalized to lowercase before
-        joining to ensure case-insensitive matching across providers.
+        Column renaming strategy (by merge type):
+        - Cross-provider (same entity): prefix with provider name (e.g., "crossref.doi")
+        - Cross-entity (same provider): prefix with entity name (e.g., "activity.name")
+        - Cross-provider-entity: prefix with provider.entity (e.g., "pubchem.compound.name")
+
+        Join keys (doi, pmid, pmc_id) are normalized to lowercase for
+        case-insensitive matching across providers.
+
+        Conflict resolution:
+        - After prefixing, remaining conflicts get .A/.B suffixes
+
+        Args:
+            seed_df: Seed DataFrame to join to.
+            enricher_dfs: Mapping of enricher pipeline name to DataFrame.
+            enrichers: Sequence of enricher configurations.
+            seed_pipeline: Seed pipeline name (e.g., "chembl_publication").
+                If None, falls back to legacy underscore prefix naming.
+
+        Returns:
+            Merged DataFrame with all enricher data joined.
+
+        Example:
+            >>> # Cross-provider merge: chembl_publication + crossref_publication
+            >>> # Column "title" in enricher → "crossref.title"
+            >>> merged = await merger._apply_joins(
+            ...     seed_df, enricher_dfs, enrichers, "chembl_publication"
+            ... )
         """
         merged = seed_df
+
+        # Parse seed pipeline for intelligent prefix strategy
+        seed_provider: str | None = None
+        seed_entity: str | None = None
+        if seed_pipeline:
+            try:
+                seed_provider, seed_entity = self._parse_pipeline_name(seed_pipeline)
+            except ValueError:
+                self._logger.warning(
+                    "Could not parse seed pipeline name, using legacy prefix",
+                    seed_pipeline=seed_pipeline,
+                )
 
         for enricher in enrichers:
             if enricher.pipeline not in enricher_dfs:
                 continue
 
             enricher_df = enricher_dfs[enricher.pipeline]
-            join_keys = list(enricher.join_keys)
+            join_keys = set(enricher.join_keys)
+            join_keys_list = list(join_keys)
 
             # Normalize join key columns for case-insensitive matching
             # This ensures DOIs like "10.1038/NATURE" match "10.1038/nature"
-            merged = self._normalize_join_key_columns(merged, join_keys)
-            enricher_df = self._normalize_join_key_columns(enricher_df, join_keys)
+            merged = self._normalize_join_key_columns(merged, join_keys_list)
+            enricher_df = self._normalize_join_key_columns(enricher_df, join_keys_list)
 
-            # Find common columns to avoid duplicates
-            seed_cols = set(merged.columns)
-            enricher_cols = set(enricher_df.columns)
-            common_cols = seed_cols & enricher_cols - set(join_keys)
+            # Find non-join columns in enricher
+            non_join_cols = set(enricher_df.columns) - join_keys
 
-            # Rename common columns in enricher with prefix
-            prefix = f"{enricher.pipeline}_"
-            enricher_df = enricher_df.rename(
-                {col: f"{prefix}{col}" for col in common_cols}
+            # Determine prefix strategy
+            if seed_provider is not None and seed_entity is not None:
+                try:
+                    enricher_provider, enricher_entity = self._parse_pipeline_name(
+                        enricher.pipeline
+                    )
+
+                    strategy = self._determine_prefix_strategy(
+                        seed_provider,
+                        seed_entity,
+                        enricher_provider,
+                        enricher_entity,
+                    )
+
+                    prefix = self._build_prefix(
+                        strategy,
+                        enricher_provider,
+                        enricher_entity,
+                        enricher.pipeline,
+                    )
+
+                    self._logger.debug(
+                        "Column rename strategy determined",
+                        enricher=enricher.pipeline,
+                        strategy=strategy,
+                        prefix=prefix,
+                    )
+
+                    # Find columns that already contain the identifier
+                    already_prefixed = {
+                        col
+                        for col in non_join_cols
+                        if self._column_contains_identifier(col, enricher_provider)
+                        or self._column_contains_identifier(col, enricher_entity)
+                    }
+
+                    # Apply prefix to non-join columns
+                    enricher_df = self._apply_column_prefix(
+                        enricher_df,
+                        non_join_cols - already_prefixed,
+                        prefix,
+                        join_keys,
+                    )
+
+                except ValueError:
+                    # Fallback to legacy prefix if parsing fails
+                    self._logger.warning(
+                        "Could not parse enricher pipeline, using legacy prefix",
+                        enricher=enricher.pipeline,
+                    )
+                    enricher_df = self._apply_legacy_prefix(
+                        enricher_df, enricher.pipeline, non_join_cols, join_keys
+                    )
+            else:
+                # No seed pipeline provided - use legacy prefix
+                enricher_df = self._apply_legacy_prefix(
+                    enricher_df, enricher.pipeline, non_join_cols, join_keys
+                )
+
+            # Detect and resolve remaining conflicts
+            merged, enricher_df = self._detect_and_resolve_conflicts(
+                merged, enricher_df, join_keys
             )
 
             # Apply join based on strategy
             how = self._get_polars_join_type()
+            primary_key = join_keys_list[0]
 
-            # Handle multiple join keys with fallback
-            if len(join_keys) > 1:
-                # Try primary key first
-                primary_key = join_keys[0]
-                if primary_key in merged.columns and primary_key in enricher_df.columns:
-                    merged = merged.join(
-                        enricher_df,
-                        on=primary_key,
-                        how=how,
-                        suffix=f"_{enricher.pipeline}",
-                    )
-                    continue
-
-            # Single key join
-            primary_key = join_keys[0]
             if primary_key in merged.columns and primary_key in enricher_df.columns:
                 merged = merged.join(
                     enricher_df,
@@ -398,6 +787,37 @@ class MergeService:
                 )
 
         return merged
+
+    def _apply_legacy_prefix(
+        self,
+        df: pl.DataFrame,
+        pipeline: str,
+        columns: set[str],
+        join_keys: set[str],
+    ) -> pl.DataFrame:
+        """Apply legacy underscore prefix to columns (backwards compatibility).
+
+        Args:
+            df: DataFrame to modify.
+            pipeline: Pipeline name to use as prefix.
+            columns: Columns to potentially rename.
+            join_keys: Columns to exclude (join keys).
+
+        Returns:
+            DataFrame with legacy-prefixed columns.
+        """
+        # Find common columns between seed and enricher
+        common_cols = columns - join_keys
+        rename_map = {col: f"{pipeline}_{col}" for col in common_cols}
+
+        if rename_map:
+            self._logger.debug(
+                "Applying legacy underscore prefix",
+                pipeline=pipeline,
+                columns=list(rename_map.keys()),
+            )
+            return df.rename(rename_map)
+        return df
 
     def _get_polars_join_type(self) -> JoinHow:
         """Convert MergeStrategy to Polars join type."""
@@ -411,26 +831,106 @@ class MergeService:
             case _:
                 return "left"
 
+    def _get_enricher_prefix(
+        self,
+        enricher_pipeline: str,
+        seed_pipeline: str | None,
+    ) -> str:
+        """Get the column prefix used for an enricher.
+
+        Computes the prefix that was (or would be) applied to enricher columns
+        during `_apply_joins`. Used for conflict resolution.
+
+        Args:
+            enricher_pipeline: Enricher pipeline name.
+            seed_pipeline: Seed pipeline name (may be None for legacy mode).
+
+        Returns:
+            Prefix string WITH trailing dot or underscore.
+
+        Example:
+            >>> merger._get_enricher_prefix("crossref_publication", "chembl_publication")
+            'crossref.'  # Cross-provider (same entity)
+            >>> merger._get_enricher_prefix("chembl_activity", "chembl_publication")
+            'activity.'  # Cross-entity (same provider)
+            >>> merger._get_enricher_prefix("crossref_publication", None)
+            'crossref_publication_'  # Legacy mode
+        """
+        if not seed_pipeline:
+            # Legacy mode: use full pipeline name with underscore
+            return f"{enricher_pipeline}_"
+
+        try:
+            seed_provider, seed_entity = self._parse_pipeline_name(seed_pipeline)
+            enricher_provider, enricher_entity = self._parse_pipeline_name(
+                enricher_pipeline
+            )
+
+            strategy = self._determine_prefix_strategy(
+                seed_provider, seed_entity, enricher_provider, enricher_entity
+            )
+
+            prefix = self._build_prefix(
+                strategy, enricher_provider, enricher_entity, enricher_pipeline
+            )
+            return f"{prefix}."
+
+        except ValueError:
+            # Fallback to legacy if parsing fails
+            return f"{enricher_pipeline}_"
+
+    def _extract_base_column(self, column: str, prefix: str) -> str | None:
+        """Extract base column name from a prefixed column.
+
+        Args:
+            column: Column name that may have a prefix.
+            prefix: Prefix to strip (WITH trailing dot or underscore).
+
+        Returns:
+            Base column name if column starts with prefix, None otherwise.
+
+        Example:
+            >>> merger._extract_base_column("crossref.title", "crossref.")
+            'title'
+            >>> merger._extract_base_column("activity.name", "activity.")
+            'name'
+            >>> merger._extract_base_column("title", "crossref.")
+            None
+        """
+        if column.startswith(prefix):
+            return column[len(prefix) :]
+        return None
+
     def _resolve_conflicts(
         self,
         df: pl.DataFrame,
         enricher_dfs: dict[str, pl.DataFrame],
         enrichers: Sequence[EnricherConfig],
+        seed_pipeline: str | None = None,
     ) -> pl.DataFrame:
-        """Apply conflict resolution based on configured strategy."""
+        """Apply conflict resolution based on configured strategy.
 
+        Args:
+            df: Merged DataFrame with prefixed columns.
+            enricher_dfs: Original enricher DataFrames (for reference).
+            enrichers: Enricher configurations.
+            seed_pipeline: Seed pipeline name for prefix computation.
+
+        Returns:
+            DataFrame with conflicts resolved.
+        """
         match self._config.conflict_resolution:
             case ConflictResolution.SEED_PRIORITY:
-                return self._coalesce_prefer_seed(df, enrichers)
+                return self._coalesce_prefer_seed(df, enrichers, seed_pipeline)
             case ConflictResolution.ENRICHER_PRIORITY:
-                return self._coalesce_prefer_enricher(df, enrichers)
+                return self._coalesce_prefer_enricher(df, enrichers, seed_pipeline)
             case ConflictResolution.COALESCE:
-                return self._coalesce_first_non_null(df, enrichers)
+                return self._coalesce_first_non_null(df, enrichers, seed_pipeline)
             case ConflictResolution.EXPLICIT_RULES:
-                return self._apply_explicit_rules(df, enrichers)
+                return self._apply_explicit_rules(df, enrichers, seed_pipeline)
             case ConflictResolution.LATEST_TIMESTAMP:
                 # Would require timestamp columns - fall back to seed
-                return self._coalesce_prefer_seed(df, enrichers)
+                return self._coalesce_prefer_seed(df, enrichers, seed_pipeline)
             case _:
                 return df
 
@@ -463,101 +963,139 @@ class MergeService:
         return isinstance(type1, pl.List) == isinstance(type2, pl.List)
 
     def _coalesce_prefer_seed(
-        self, df: pl.DataFrame, enrichers: Sequence[EnricherConfig]
+        self,
+        df: pl.DataFrame,
+        enrichers: Sequence[EnricherConfig],
+        seed_pipeline: str | None = None,
     ) -> pl.DataFrame:
-        """Coalesce preferring seed values."""
+        """Coalesce preferring seed values.
+
+        Args:
+            df: Merged DataFrame with prefixed columns.
+            enrichers: Enricher configurations.
+            seed_pipeline: Seed pipeline name for prefix computation.
+
+        Returns:
+            DataFrame with enricher columns coalesced into base columns.
+        """
         import polars as pl
 
         result = df
         for enricher in enrichers:
-            prefix = f"{enricher.pipeline}_"
+            prefix = self._get_enricher_prefix(enricher.pipeline, seed_pipeline)
             for col in list(
                 result.columns
             ):  # Copy list to avoid mutation during iteration
-                if col.startswith(prefix):
-                    base_col = col[len(prefix) :]
-                    if base_col in result.columns:
-                        # Check type compatibility before coalescing
-                        if self._can_coalesce(result, base_col, col):
-                            # Coalesce seed (base) over enricher
-                            result = result.with_columns(
-                                pl.coalesce(pl.col(base_col), pl.col(col)).alias(
-                                    base_col
-                                )
-                            ).drop(col)
-                        else:
-                            # Incompatible types - keep seed value, drop enricher
-                            self._logger.debug(
-                                "Skipping coalesce for incompatible types",
-                                seed_col=base_col,
-                                enricher_col=col,
-                                seed_type=str(result[base_col].dtype),
-                                enricher_type=str(result[col].dtype),
-                            )
-                            result = result.drop(col)
+                base_col = self._extract_base_column(col, prefix)
+                if base_col is not None and base_col in result.columns:
+                    # Check type compatibility before coalescing
+                    if self._can_coalesce(result, base_col, col):
+                        # Coalesce seed (base) over enricher
+                        result = result.with_columns(
+                            pl.coalesce(pl.col(base_col), pl.col(col)).alias(base_col)
+                        ).drop(col)
+                    else:
+                        # Incompatible types - keep seed value, drop enricher
+                        self._logger.debug(
+                            "Skipping coalesce for incompatible types",
+                            seed_col=base_col,
+                            enricher_col=col,
+                            seed_type=str(result[base_col].dtype),
+                            enricher_type=str(result[col].dtype),
+                        )
+                        result = result.drop(col)
         return result
 
     def _coalesce_prefer_enricher(
-        self, df: pl.DataFrame, enrichers: Sequence[EnricherConfig]
+        self,
+        df: pl.DataFrame,
+        enrichers: Sequence[EnricherConfig],
+        seed_pipeline: str | None = None,
     ) -> pl.DataFrame:
-        """Coalesce preferring enricher values."""
+        """Coalesce preferring enricher values.
+
+        Args:
+            df: Merged DataFrame with prefixed columns.
+            enrichers: Enricher configurations.
+            seed_pipeline: Seed pipeline name for prefix computation.
+
+        Returns:
+            DataFrame with enricher columns coalesced into base columns.
+        """
         import polars as pl
 
         result = df
         for enricher in enrichers:
-            prefix = f"{enricher.pipeline}_"
+            prefix = self._get_enricher_prefix(enricher.pipeline, seed_pipeline)
             for col in list(
                 result.columns
             ):  # Copy list to avoid mutation during iteration
-                if col.startswith(prefix):
-                    base_col = col[len(prefix) :]
-                    if base_col in result.columns:
-                        # Check type compatibility before coalescing
-                        if self._can_coalesce(result, base_col, col):
-                            # Coalesce enricher over seed (base)
-                            result = result.with_columns(
-                                pl.coalesce(pl.col(col), pl.col(base_col)).alias(
-                                    base_col
-                                )
-                            ).drop(col)
-                        else:
-                            # Incompatible types - prefer enricher if non-null exists
-                            self._logger.debug(
-                                "Skipping coalesce for incompatible types",
-                                seed_col=base_col,
-                                enricher_col=col,
-                                seed_type=str(result[base_col].dtype),
-                                enricher_type=str(result[col].dtype),
-                            )
-                            result = result.drop(col)
+                base_col = self._extract_base_column(col, prefix)
+                if base_col is not None and base_col in result.columns:
+                    # Check type compatibility before coalescing
+                    if self._can_coalesce(result, base_col, col):
+                        # Coalesce enricher over seed (base)
+                        result = result.with_columns(
+                            pl.coalesce(pl.col(col), pl.col(base_col)).alias(base_col)
+                        ).drop(col)
+                    else:
+                        # Incompatible types - prefer enricher if non-null exists
+                        self._logger.debug(
+                            "Skipping coalesce for incompatible types",
+                            seed_col=base_col,
+                            enricher_col=col,
+                            seed_type=str(result[base_col].dtype),
+                            enricher_type=str(result[col].dtype),
+                        )
+                        result = result.drop(col)
         return result
 
     def _coalesce_first_non_null(
-        self, df: pl.DataFrame, enrichers: Sequence[EnricherConfig]
+        self,
+        df: pl.DataFrame,
+        enrichers: Sequence[EnricherConfig],
+        seed_pipeline: str | None = None,
     ) -> pl.DataFrame:
-        """Coalesce taking first non-null value."""
+        """Coalesce taking first non-null value.
+
+        Args:
+            df: Merged DataFrame with prefixed columns.
+            enrichers: Enricher configurations.
+            seed_pipeline: Seed pipeline name for prefix computation.
+
+        Returns:
+            DataFrame with coalesced columns.
+        """
         # Same as seed priority for now
-        return self._coalesce_prefer_seed(df, enrichers)
+        return self._coalesce_prefer_seed(df, enrichers, seed_pipeline)
 
     def _collect_field_columns(
         self,
         field: str,
         enrichers: Sequence[EnricherConfig],
         available_columns: set[str],
+        seed_pipeline: str | None = None,
     ) -> list[str]:
         """Collect all columns for a field including enricher prefixed versions.
+
+        Supports both new dot-based prefixes (crossref.title) and legacy
+        underscore prefixes (crossref_publication_title).
 
         Args:
             field: Base field name.
             enrichers: Sequence of enricher configurations.
             available_columns: Set of available column names in DataFrame.
+            seed_pipeline: Seed pipeline name for prefix computation.
 
         Returns:
             List of column names including seed and enricher versions.
         """
         columns = [field] if field in available_columns else []
         for enricher in enrichers:
-            prefixed = f"{enricher.pipeline}_{field}"
+            # Get the prefix that was used for this enricher
+            prefix = self._get_enricher_prefix(enricher.pipeline, seed_pipeline)
+            # Prefix includes trailing dot/underscore, so: "crossref." + "title"
+            prefixed = f"{prefix}{field}"
             if prefixed in available_columns:
                 columns.append(prefixed)
         return columns
@@ -567,13 +1105,15 @@ class MergeService:
         field: str,
         columns: list[str],
         priorities: Sequence[str],
+        seed_pipeline: str | None = None,
     ) -> list[str]:
         """Order columns by priority list, appending any remaining columns.
 
         Args:
             field: Base field name.
             columns: List of available columns for this field.
-            priorities: Ordered list of source priorities.
+            priorities: Ordered list of source priorities (provider names or "seed").
+            seed_pipeline: Seed pipeline name for prefix computation.
 
         Returns:
             Ordered list of columns by priority.
@@ -585,9 +1125,19 @@ class MergeService:
                 if field in columns and field not in ordered_cols:
                     ordered_cols.append(field)
             else:
-                prefixed = f"{source}_{field}"
-                if prefixed in columns and prefixed not in ordered_cols:
-                    ordered_cols.append(prefixed)
+                # Try new dot-based prefix: "crossref.title"
+                dot_prefixed = f"{source}.{field}"
+                if dot_prefixed in columns and dot_prefixed not in ordered_cols:
+                    ordered_cols.append(dot_prefixed)
+                    continue
+
+                # Try legacy underscore prefix: "crossref_publication_title"
+                # The source might be just "crossref" but column is "crossref_publication_title"
+                for col in columns:
+                    if col.startswith(f"{source}_") and col.endswith(f"_{field}"):
+                        if col not in ordered_cols:
+                            ordered_cols.append(col)
+                        break
 
         # Add remaining columns not in priority list
         for col in columns:
@@ -635,11 +1185,22 @@ class MergeService:
         return compatible_cols, incompatible_cols
 
     def _apply_explicit_rules(
-        self, df: pl.DataFrame, enrichers: Sequence[EnricherConfig]
+        self,
+        df: pl.DataFrame,
+        enrichers: Sequence[EnricherConfig],
+        seed_pipeline: str | None = None,
     ) -> pl.DataFrame:
         """Apply explicit field priority rules.
 
         Coalesces columns by priority, handling type compatibility.
+
+        Args:
+            df: Merged DataFrame with prefixed columns.
+            enrichers: Enricher configurations.
+            seed_pipeline: Seed pipeline name for prefix computation.
+
+        Returns:
+            DataFrame with explicit rules applied.
         """
         import polars as pl
 
@@ -647,12 +1208,16 @@ class MergeService:
         available_columns = set(df.columns)
 
         for field, priorities in self._config.field_priorities.items():
-            columns = self._collect_field_columns(field, enrichers, available_columns)
+            columns = self._collect_field_columns(
+                field, enrichers, available_columns, seed_pipeline
+            )
 
             if len(columns) <= 1:
                 continue
 
-            ordered_cols = self._order_columns_by_priority(field, columns, priorities)
+            ordered_cols = self._order_columns_by_priority(
+                field, columns, priorities, seed_pipeline
+            )
 
             if not ordered_cols:
                 continue
@@ -704,14 +1269,26 @@ class MergeService:
         )
 
     def _count_enriched_records(
-        self, df: pl.DataFrame, enrichers: Sequence[EnricherConfig]
+        self,
+        df: pl.DataFrame,
+        enrichers: Sequence[EnricherConfig],
+        seed_pipeline: str | None = None,
     ) -> int:
-        """Count records with at least one enrichment."""
+        """Count records with at least one enrichment.
+
+        Args:
+            df: Merged DataFrame with prefixed columns.
+            enrichers: Enricher configurations.
+            seed_pipeline: Seed pipeline name for prefix computation.
+
+        Returns:
+            Count of records with at least one non-null enricher column.
+        """
         # Check if any enricher-prefixed columns are non-null
         # This is approximate - relies on column naming convention
         enriched_count = 0
         for enricher in enrichers:
-            prefix = f"{enricher.pipeline}_"
+            prefix = self._get_enricher_prefix(enricher.pipeline, seed_pipeline)
             enricher_cols = [c for c in df.columns if c.startswith(prefix)]
             if enricher_cols:
                 # Check first enricher column for non-null

--- a/tests/unit/application/composite/test_merger.py
+++ b/tests/unit/application/composite/test_merger.py
@@ -284,16 +284,19 @@ class TestMergeServiceJoinKeyNormalization:
             silver_table="silver/crossref/publication",
         )
 
+        # When seed_pipeline is provided, uses smart prefix (crossref.)
         result = await merge_service._apply_joins(
             seed_df=seed_df,
             enricher_dfs={"crossref_publication": enricher_df},
             enrichers=[enricher_config],
+            seed_pipeline="chembl_publication",
         )
 
         # Should successfully join despite case difference
         assert len(result) == 1
-        assert "enricher_value" in result.columns
-        assert result["enricher_value"].to_list() == ["from_enricher"]
+        # With smart prefix, enricher_value becomes crossref.enricher_value
+        assert "crossref.enricher_value" in result.columns
+        assert result["crossref.enricher_value"].to_list() == ["from_enricher"]
         # DOI should be normalized to lowercase
         assert result["doi"].to_list() == ["10.1038/nature12373"]
 
@@ -375,3 +378,448 @@ class TestMergeServiceMergeOperation:
         assert mock_storage.read_silver.call_count == 2
         assert result.records_from_seed == 1
         assert "test_enricher" in result.sources_used
+
+
+@pytest.mark.unit
+class TestParsePipelineName:
+    """Tests for _parse_pipeline_name helper."""
+
+    def test_parses_standard_pipeline_name(self, merge_service):
+        """Test parsing standard pipeline name."""
+        provider, entity = merge_service._parse_pipeline_name("chembl_publication")
+        assert provider == "chembl"
+        assert entity == "publication"
+
+    def test_parses_pipeline_with_underscore_in_entity(self, merge_service):
+        """Test parsing pipeline name with underscore in entity."""
+        provider, entity = merge_service._parse_pipeline_name("chembl_target_component")
+        assert provider == "chembl"
+        assert entity == "target_component"
+
+    def test_raises_on_invalid_format(self, merge_service):
+        """Test error on invalid pipeline name format."""
+        with pytest.raises(ValueError, match="must be in format"):
+            merge_service._parse_pipeline_name("invalidpipelinename")
+
+
+@pytest.mark.unit
+class TestDeterminePrefixStrategy:
+    """Tests for _determine_prefix_strategy helper."""
+
+    def test_cross_provider_same_entity(self, merge_service):
+        """Test cross-provider merge (same entity, different providers)."""
+        strategy = merge_service._determine_prefix_strategy(
+            "chembl", "publication", "crossref", "publication"
+        )
+        assert strategy == "provider"
+
+    def test_cross_entity_same_provider(self, merge_service):
+        """Test cross-entity merge (same provider, different entities)."""
+        strategy = merge_service._determine_prefix_strategy(
+            "chembl", "publication", "chembl", "activity"
+        )
+        assert strategy == "entity"
+
+    def test_cross_provider_and_entity(self, merge_service):
+        """Test cross-provider-entity merge (different both)."""
+        strategy = merge_service._determine_prefix_strategy(
+            "chembl", "publication", "pubchem", "compound"
+        )
+        assert strategy == "both"
+
+    def test_same_provider_and_entity(self, merge_service):
+        """Test same provider and entity uses pipeline prefix."""
+        strategy = merge_service._determine_prefix_strategy(
+            "chembl", "publication", "chembl", "publication"
+        )
+        assert strategy == "pipeline"
+
+    def test_case_insensitive_comparison(self, merge_service):
+        """Test provider/entity comparison is case-insensitive."""
+        strategy = merge_service._determine_prefix_strategy(
+            "ChEMBL", "Publication", "chembl", "publication"
+        )
+        assert strategy == "pipeline"
+
+
+@pytest.mark.unit
+class TestColumnContainsIdentifier:
+    """Tests for _column_contains_identifier helper."""
+
+    def test_contains_identifier_lowercase(self, merge_service):
+        """Test identifier match in lowercase."""
+        assert merge_service._column_contains_identifier("crossref_doi", "crossref")
+
+    def test_contains_identifier_uppercase(self, merge_service):
+        """Test identifier match in uppercase."""
+        assert merge_service._column_contains_identifier("CROSSREF.DOI", "crossref")
+
+    def test_does_not_contain_identifier(self, merge_service):
+        """Test no match when identifier not present."""
+        assert not merge_service._column_contains_identifier("doi", "crossref")
+
+    def test_partial_match(self, merge_service):
+        """Test partial match is detected."""
+        assert merge_service._column_contains_identifier("chembl_id", "chembl")
+
+
+@pytest.mark.unit
+class TestBuildPrefix:
+    """Tests for _build_prefix helper."""
+
+    def test_provider_strategy(self, merge_service):
+        """Test prefix for provider strategy."""
+        prefix = merge_service._build_prefix(
+            "provider", "crossref", "publication", "crossref_publication"
+        )
+        assert prefix == "crossref"
+
+    def test_entity_strategy(self, merge_service):
+        """Test prefix for entity strategy."""
+        prefix = merge_service._build_prefix(
+            "entity", "chembl", "activity", "chembl_activity"
+        )
+        assert prefix == "activity"
+
+    def test_both_strategy(self, merge_service):
+        """Test prefix for both strategy."""
+        prefix = merge_service._build_prefix(
+            "both", "pubchem", "compound", "pubchem_compound"
+        )
+        assert prefix == "pubchem.compound"
+
+    def test_pipeline_strategy(self, merge_service):
+        """Test prefix for pipeline strategy (fallback)."""
+        prefix = merge_service._build_prefix(
+            "pipeline", "chembl", "publication", "chembl_publication"
+        )
+        assert prefix == "chembl_publication"
+
+
+@pytest.mark.unit
+class TestApplyColumnPrefix:
+    """Tests for _apply_column_prefix helper."""
+
+    def test_applies_prefix_to_columns(self, merge_service):
+        """Test prefix is applied to specified columns."""
+        import polars as pl
+
+        df = pl.DataFrame({"doi": ["10.1/a"], "title": ["T1"], "year": [2024]})
+
+        result = merge_service._apply_column_prefix(
+            df, {"title", "year"}, "crossref", {"doi"}
+        )
+
+        assert "doi" in result.columns
+        assert "crossref.title" in result.columns
+        assert "crossref.year" in result.columns
+        assert "title" not in result.columns
+        assert "year" not in result.columns
+
+    def test_excludes_join_keys(self, merge_service):
+        """Test join keys are not renamed."""
+        import polars as pl
+
+        df = pl.DataFrame({"doi": ["10.1/a"], "title": ["T1"]})
+
+        result = merge_service._apply_column_prefix(
+            df, {"doi", "title"}, "crossref", {"doi"}
+        )
+
+        assert "doi" in result.columns
+        assert "crossref.title" in result.columns
+        # doi should NOT be renamed
+        assert "crossref.doi" not in result.columns
+
+
+@pytest.mark.unit
+class TestDetectAndResolveConflicts:
+    """Tests for _detect_and_resolve_conflicts helper."""
+
+    def test_no_conflicts(self, merge_service):
+        """Test no changes when no conflicts."""
+        import polars as pl
+
+        seed = pl.DataFrame({"doi": ["10.1/a"], "title": ["T1"]})
+        enricher = pl.DataFrame({"doi": ["10.1/a"], "crossref.author": ["A1"]})
+
+        seed_out, enricher_out = merge_service._detect_and_resolve_conflicts(
+            seed, enricher, {"doi"}
+        )
+
+        assert seed_out.columns == ["doi", "title"]
+        assert enricher_out.columns == ["doi", "crossref.author"]
+
+    def test_resolves_conflicts_with_suffixes(self, merge_service):
+        """Test conflicts are resolved with .A/.B suffixes."""
+        import polars as pl
+
+        seed = pl.DataFrame({"doi": ["10.1/a"], "crossref.title": ["T1"]})
+        enricher = pl.DataFrame({"doi": ["10.1/a"], "crossref.title": ["T2"]})
+
+        seed_out, enricher_out = merge_service._detect_and_resolve_conflicts(
+            seed, enricher, {"doi"}
+        )
+
+        assert "crossref.title.A" in seed_out.columns
+        assert "crossref.title.B" in enricher_out.columns
+        assert "crossref.title" not in seed_out.columns
+        assert "crossref.title" not in enricher_out.columns
+
+    def test_join_keys_not_affected(self, merge_service):
+        """Test join keys are not affected by conflict resolution."""
+        import polars as pl
+
+        seed = pl.DataFrame({"doi": ["10.1/a"], "value": ["V1"]})
+        enricher = pl.DataFrame({"doi": ["10.1/a"], "value": ["V2"]})
+
+        # doi is join key, value is a conflict
+        seed_out, enricher_out = merge_service._detect_and_resolve_conflicts(
+            seed, enricher, {"doi"}
+        )
+
+        # doi should remain unchanged in both
+        assert "doi" in seed_out.columns
+        assert "doi" in enricher_out.columns
+        # value should be renamed
+        assert "value.A" in seed_out.columns
+        assert "value.B" in enricher_out.columns
+
+
+@pytest.mark.unit
+class TestApplyJoinsSmartColumnRenaming:
+    """Tests for _apply_joins with smart column renaming."""
+
+    @pytest.mark.asyncio
+    async def test_cross_provider_merge_uses_provider_prefix(self, merge_service):
+        """Test cross-provider merge uses provider name as prefix."""
+        import polars as pl
+
+        seed_df = pl.DataFrame({"doi": ["10.1/a"], "title": ["Seed Title"]})
+        enricher_df = pl.DataFrame({"doi": ["10.1/a"], "title": ["Crossref Title"]})
+
+        enricher_config = EnricherConfig(
+            pipeline="crossref_publication",
+            join_keys=("doi",),
+            required=False,
+        )
+
+        result = await merge_service._apply_joins(
+            seed_df=seed_df,
+            enricher_dfs={"crossref_publication": enricher_df},
+            enrichers=[enricher_config],
+            seed_pipeline="chembl_publication",
+        )
+
+        # Should have: doi, title, crossref.title
+        assert "doi" in result.columns
+        assert "title" in result.columns
+        assert "crossref.title" in result.columns
+
+    @pytest.mark.asyncio
+    async def test_cross_entity_merge_uses_entity_prefix(self, merge_service):
+        """Test cross-entity merge uses entity name as prefix."""
+        import polars as pl
+
+        seed_df = pl.DataFrame({"chembl_id": ["C1"], "name": ["Drug A"]})
+        enricher_df = pl.DataFrame({"chembl_id": ["C1"], "name": ["Activity Name"]})
+
+        enricher_config = EnricherConfig(
+            pipeline="chembl_activity",
+            join_keys=("chembl_id",),
+            required=False,
+        )
+
+        result = await merge_service._apply_joins(
+            seed_df=seed_df,
+            enricher_dfs={"chembl_activity": enricher_df},
+            enrichers=[enricher_config],
+            seed_pipeline="chembl_publication",
+        )
+
+        # Should have: chembl_id, name, activity.name
+        assert "chembl_id" in result.columns
+        assert "name" in result.columns
+        assert "activity.name" in result.columns
+
+    @pytest.mark.asyncio
+    async def test_cross_provider_entity_merge_uses_both_prefix(self, merge_service):
+        """Test cross-provider-entity merge uses provider.entity prefix."""
+        import polars as pl
+
+        seed_df = pl.DataFrame({"id": ["1"], "name": ["Seed Name"]})
+        enricher_df = pl.DataFrame({"id": ["1"], "name": ["Compound Name"]})
+
+        enricher_config = EnricherConfig(
+            pipeline="pubchem_compound",
+            join_keys=("id",),
+            required=False,
+        )
+
+        result = await merge_service._apply_joins(
+            seed_df=seed_df,
+            enricher_dfs={"pubchem_compound": enricher_df},
+            enrichers=[enricher_config],
+            seed_pipeline="chembl_publication",
+        )
+
+        # Should have: id, name, pubchem.compound.name
+        assert "id" in result.columns
+        assert "name" in result.columns
+        assert "pubchem.compound.name" in result.columns
+
+    @pytest.mark.asyncio
+    async def test_skips_already_prefixed_columns(self, merge_service):
+        """Test columns already containing identifier are not re-prefixed."""
+        import polars as pl
+
+        seed_df = pl.DataFrame({"doi": ["10.1/a"], "title": ["Seed"]})
+        # crossref_doi already contains "crossref"
+        enricher_df = pl.DataFrame(
+            {"doi": ["10.1/a"], "crossref_doi": ["10.1/a"], "author": ["A1"]}
+        )
+
+        enricher_config = EnricherConfig(
+            pipeline="crossref_publication",
+            join_keys=("doi",),
+            required=False,
+        )
+
+        result = await merge_service._apply_joins(
+            seed_df=seed_df,
+            enricher_dfs={"crossref_publication": enricher_df},
+            enrichers=[enricher_config],
+            seed_pipeline="chembl_publication",
+        )
+
+        # crossref_doi should NOT become crossref.crossref_doi
+        assert "crossref_doi" in result.columns
+        assert "crossref.crossref_doi" not in result.columns
+        # author should become crossref.author
+        assert "crossref.author" in result.columns
+
+    @pytest.mark.asyncio
+    async def test_conflict_after_prefixing_gets_suffixes(self, merge_service):
+        """Test conflict after prefixing gets .A/.B suffixes."""
+        import polars as pl
+
+        # Seed already has crossref.title
+        seed_df = pl.DataFrame({"doi": ["10.1/a"], "crossref.title": ["Seed CT"]})
+        # Enricher title becomes crossref.title → conflict!
+        enricher_df = pl.DataFrame({"doi": ["10.1/a"], "title": ["Enricher Title"]})
+
+        enricher_config = EnricherConfig(
+            pipeline="crossref_publication",
+            join_keys=("doi",),
+            required=False,
+        )
+
+        result = await merge_service._apply_joins(
+            seed_df=seed_df,
+            enricher_dfs={"crossref_publication": enricher_df},
+            enrichers=[enricher_config],
+            seed_pipeline="chembl_publication",
+        )
+
+        # Conflict resolved with .A/.B suffixes
+        assert "crossref.title.A" in result.columns
+        assert "crossref.title.B" in result.columns
+
+    @pytest.mark.asyncio
+    async def test_legacy_prefix_when_no_seed_pipeline(self, merge_service):
+        """Test legacy prefix when seed_pipeline not provided."""
+        import polars as pl
+
+        seed_df = pl.DataFrame({"doi": ["10.1/a"], "title": ["Seed Title"]})
+        enricher_df = pl.DataFrame({"doi": ["10.1/a"], "title": ["Enricher Title"]})
+
+        enricher_config = EnricherConfig(
+            pipeline="crossref_publication",
+            join_keys=("doi",),
+            required=False,
+        )
+
+        result = await merge_service._apply_joins(
+            seed_df=seed_df,
+            enricher_dfs={"crossref_publication": enricher_df},
+            enrichers=[enricher_config],
+            seed_pipeline=None,  # No seed pipeline
+        )
+
+        # Should use legacy prefix: crossref_publication_title
+        assert "crossref_publication_title" in result.columns
+
+
+@pytest.mark.unit
+class TestGetEnricherPrefix:
+    """Tests for _get_enricher_prefix helper."""
+
+    def test_cross_provider_prefix(self, merge_service):
+        """Test cross-provider prefix ends with dot."""
+        prefix = merge_service._get_enricher_prefix(
+            "crossref_publication", "chembl_publication"
+        )
+        assert prefix == "crossref."
+
+    def test_cross_entity_prefix(self, merge_service):
+        """Test cross-entity prefix ends with dot."""
+        prefix = merge_service._get_enricher_prefix(
+            "chembl_activity", "chembl_publication"
+        )
+        assert prefix == "activity."
+
+    def test_cross_both_prefix(self, merge_service):
+        """Test cross-both prefix ends with dot."""
+        prefix = merge_service._get_enricher_prefix(
+            "pubchem_compound", "chembl_publication"
+        )
+        assert prefix == "pubchem.compound."
+
+    def test_legacy_prefix_when_no_seed(self, merge_service):
+        """Test legacy prefix when seed is None."""
+        prefix = merge_service._get_enricher_prefix("crossref_publication", None)
+        assert prefix == "crossref_publication_"
+
+
+@pytest.mark.unit
+class TestExtractBaseColumn:
+    """Tests for _extract_base_column helper."""
+
+    def test_extracts_base_from_dot_prefix(self, merge_service):
+        """Test extraction from dot-based prefix."""
+        base = merge_service._extract_base_column("crossref.title", "crossref.")
+        assert base == "title"
+
+    def test_extracts_base_from_legacy_prefix(self, merge_service):
+        """Test extraction from legacy underscore prefix."""
+        base = merge_service._extract_base_column(
+            "crossref_publication_title", "crossref_publication_"
+        )
+        assert base == "title"
+
+    def test_returns_none_for_no_match(self, merge_service):
+        """Test returns None when prefix doesn't match."""
+        base = merge_service._extract_base_column("title", "crossref.")
+        assert base is None
+
+
+@pytest.mark.unit
+class TestInferPipelineFromTable:
+    """Tests for _infer_pipeline_from_table helper."""
+
+    def test_infers_from_silver_path(self, merge_service):
+        """Test inferring pipeline from silver table path."""
+        pipeline = merge_service._infer_pipeline_from_table("silver/chembl/publication")
+        assert pipeline == "chembl_publication"
+
+    def test_infers_from_absolute_path(self, merge_service):
+        """Test inferring pipeline from absolute path."""
+        pipeline = merge_service._infer_pipeline_from_table(
+            "/data/output/silver/crossref/publication"
+        )
+        assert pipeline == "crossref_publication"
+
+    def test_returns_none_for_invalid_path(self, merge_service):
+        """Test returns None for path without layer prefix."""
+        pipeline = merge_service._infer_pipeline_from_table("invalid/path")
+        assert pipeline is None


### PR DESCRIPTION
## Summary
This PR introduces intelligent column prefixing strategies for the merge operation, replacing the legacy underscore-based naming scheme with semantic, context-aware prefixes. The system now automatically determines the most appropriate prefix (provider, entity, or both) based on the relationship between seed and enricher pipelines.

## Key Changes

### New Prefix Strategy System
- Added `PrefixStrategy` type with four strategies: `"provider"`, `"entity"`, `"both"`, and `"pipeline"`
- Implemented `_determine_prefix_strategy()` to intelligently select prefixes based on provider/entity relationships:
  - **Cross-provider** (same entity, different providers): prefix with provider name (e.g., `"crossref.doi"`)
  - **Cross-entity** (same provider, different entities): prefix with entity name (e.g., `"activity.name"`)
  - **Cross-provider-entity** (different both): prefix with provider.entity (e.g., `"pubchem.compound.name"`)
  - **Fallback**: use full pipeline name when same provider and entity

### Pipeline Name Parsing
- Added `_parse_pipeline_name()` to extract provider and entity from pipeline names (format: `"provider_entity"`)
- Added `_infer_pipeline_from_table()` to derive pipeline name from Silver table paths (e.g., `"silver/chembl/publication"` → `"chembl_publication"`)

### Enhanced Join Logic
- Refactored `_apply_joins()` to use new prefix strategies instead of legacy underscore prefixes
- Added `_apply_column_prefix()` for semantic prefix application with exclusion support
- Added `_detect_and_resolve_conflicts()` to handle remaining column conflicts with `.A`/`.B` suffixes
- Added `_apply_legacy_prefix()` for backwards compatibility when seed pipeline is unavailable

### Conflict Resolution Updates
- Updated all conflict resolution methods (`_coalesce_prefer_seed()`, `_coalesce_prefer_enricher()`, etc.) to accept `seed_pipeline` parameter
- Added `_get_enricher_prefix()` to compute the prefix used for an enricher during joins
- Added `_extract_base_column()` to extract base column names from prefixed columns
- Updated `_collect_field_columns()` and `_order_columns_by_priority()` to support both dot-based and legacy underscore prefixes

### API Changes
- Added optional `seed_pipeline` parameter to `merge()` method with automatic inference from table path
- Updated `_apply_joins()`, `_resolve_conflicts()`, and related methods to accept and use `seed_pipeline`
- Enhanced docstrings with detailed examples and parameter descriptions

## Implementation Details

- **Backwards Compatibility**: Legacy underscore prefixing is preserved when `seed_pipeline` is `None`
- **Conflict Detection**: After prefix application, remaining column name conflicts are resolved with `.A`/`.B` suffixes
- **Redundancy Prevention**: Columns already containing provider/entity identifiers are excluded from prefixing to avoid redundant names like `"crossref.crossref_doi"`
- **Case-Insensitive Matching**: Join keys continue to be normalized to lowercase for cross-provider matching
- **Comprehensive Logging**: Added debug logging for prefix strategy selection and column renaming operations

## Testing Considerations
- Verify cross-provider merges use provider-only prefixes
- Verify cross-entity merges use entity-only prefixes
- Verify cross-provider-entity merges use combined prefixes
- Test conflict resolution with `.A`/`.B` suffixes
- Ensure legacy mode works when seed_pipeline is None
- Validate that join keys are properly excluded from prefixing