### PR TITLE
Implement ADR-024: Rename document* entities to publication* (canonical naming)

### DIFF
--- a/configs/pipelines/chembl/publication.yaml
+++ b/configs/pipelines/chembl/publication.yaml
@@ -2,11 +2,11 @@
 # Pipeline configuration for ChEMBL Publication entity.
 #
 # Inherits defaults from ../_base.yaml
-# Note: entity_type=document maps to ChEMBL API /document endpoint
+# Note: entity_type=publication maps to ChEMBL API /document endpoint (ADR-024 naming)
 
 pipeline_name: chembl_publication
 provider: chembl
-entity_type: document
+entity_type: publication
 version: "2.1.0"
 description: "Extract scientific publications from ChEMBL API"
 
@@ -33,7 +33,6 @@ dq_config_file: ../../dq/entities/chembl/publication.yaml
 #   2. configs/filter/providers/chembl.yaml (provider-specific)
 #   3. configs/filter/entities/chembl/publication.yaml (entity-specific)
 # Add inline overrides below only when extending/differing from entity filter config.
-# Note: explicit filter_config_file because entity_type=document differs from file name
 filter_config_file: ../../filter/entities/chembl/publication.yaml
 
 # Entity-specific sink overrides

--- a/configs/pipelines/chembl/publication_similarity.yaml
+++ b/configs/pipelines/chembl/publication_similarity.yaml
@@ -2,11 +2,11 @@
 # Pipeline configuration for ChEMBL Publication Similarity entity.
 #
 # Inherits defaults from ../_base.yaml
-# Note: entity_type=document_similarity maps to ChEMBL API /document_similarity endpoint
+# Note: entity_type=publication_similarity maps to ChEMBL API /document_similarity endpoint (ADR-024)
 
 pipeline_name: chembl_publication_similarity
 provider: chembl
-entity_type: document_similarity
+entity_type: publication_similarity
 version: "2.1.0"
 description: "Extract publication similarity data (Tanimoto coefficients) from ChEMBL API"
 
@@ -33,27 +33,26 @@ dq_config_file: ../../dq/entities/chembl/publication_similarity.yaml
 #   2. configs/filter/providers/chembl.yaml (provider-specific)
 #   3. configs/filter/entities/chembl/publication_similarity.yaml (entity-specific)
 # Add inline overrides below only when extending/differing from entity filter config.
-# Note: explicit filter_config_file because entity_type=document_similarity differs from file name
 filter_config_file: ../../filter/entities/chembl/publication_similarity.yaml
 
 # Entity-specific sink overrides
 sink:
   bronze:
-    path: "data/output/bronze/chembl/document_similarity"
+    path: "data/output/bronze/chembl/publication_similarity"
   silver:
-    path: "data/output/silver/chembl/document_similarity"
+    path: "data/output/silver/chembl/publication_similarity"
     primary_key: ["sim_id"]
     partition_by: []  # No good partition key
     sort_by:
       columns: ["sim_id"]
       ascending: true
     csv_export:
-      path: "data/output/silver/chembl/document_similarity"
+      path: "data/output/silver/chembl/publication_similarity"
   gold:
-    path: "data/output/gold/chembl/document_similarity"
+    path: "data/output/gold/chembl/publication_similarity"
     sort_by:
       columns: ["sim_id"]
       ascending: true
     csv_export:
-      path: "data/output/gold/chembl/document_similarity"
+      path: "data/output/gold/chembl/publication_similarity"
 

--- a/configs/pipelines/chembl/publication_term.yaml
+++ b/configs/pipelines/chembl/publication_term.yaml
@@ -3,11 +3,11 @@
 #
 # Derived entity: Extracts and flattens terms from Publication records.
 # Inherits defaults from ../_base.yaml
-# Note: entity_type=document_term maps to ChEMBL API /document endpoint (derived entity)
+# Note: entity_type=publication_term maps to ChEMBL API /document endpoint (derived entity, ADR-024)
 
 pipeline_name: chembl_publication_term
 provider: chembl
-entity_type: document_term
+entity_type: publication_term
 version: "2.1.0"
 description: "Extract publication terms (MeSH, keywords) from ChEMBL Publication records"
 
@@ -36,27 +36,26 @@ dq_config_file: ../../dq/entities/chembl/publication_term.yaml
 #   2. configs/filter/providers/chembl.yaml (provider-specific)
 #   3. configs/filter/entities/chembl/publication_term.yaml (entity-specific)
 # Add inline overrides below only when extending/differing from entity filter config.
-# Note: explicit filter_config_file because entity_type=document_term differs from file name
 filter_config_file: ../../filter/entities/chembl/publication_term.yaml
 
 # Entity-specific sink overrides
 sink:
   bronze:
-    path: "data/output/bronze/chembl/document_term"
+    path: "data/output/bronze/chembl/publication_term"
   silver:
-    path: "data/output/silver/chembl/document_term"
+    path: "data/output/silver/chembl/publication_term"
     primary_key: ["entity_id"]
     partition_by: ["term_type"]
     sort_by:
       columns: ["entity_id"]
       ascending: true
     csv_export:
-      path: "data/output/silver/chembl/document_term"
+      path: "data/output/silver/chembl/publication_term"
   gold:
-    path: "data/output/gold/chembl/document_term"
+    path: "data/output/gold/chembl/publication_term"
     sort_by:
       columns: ["entity_id"]
       ascending: true
     csv_export:
-      path: "data/output/gold/chembl/document_term"
+      path: "data/output/gold/chembl/publication_term"
 

--- a/src/bioetl/application/core/publication_term_data_source.py
+++ b/src/bioetl/application/core/publication_term_data_source.py
@@ -8,13 +8,16 @@ Architecture:
     ChEMBL API (document endpoint)
            ↓
     PublicationTermDataSource (wrapper)
-      - fetch("document_term") → wrapped.fetch("document")
+      - fetch("publication_term") → wrapped.fetch("publication")
       - transforms each publication → yields term records
            ↓
     Pipeline receives term records
 
 .. versionchanged:: 2.0.0
     Renamed from DocumentTermDataSource to PublicationTermDataSource (ADR-024).
+.. versionchanged:: 2.1.0
+    Changed entity types from document/document_term to publication/publication_term
+    for naming consistency (ADR-024 naming unification).
 """
 
 from __future__ import annotations
@@ -44,8 +47,8 @@ class PublicationTermDataSource:
     - KEYWORD: Author-provided keywords from keywords array
 
     The wrapper:
-    1. Intercepts fetch("document_term") calls
-    2. Fetches publications from the wrapped adapter via fetch("document")
+    1. Intercepts fetch("publication_term") calls
+    2. Fetches publications from the wrapped adapter via fetch("publication")
     3. Extracts terms from each publication (1:M relationship)
     4. Yields individual term records with computed entity_id
     5. Delegates all other operations to the wrapped adapter
@@ -53,7 +56,7 @@ class PublicationTermDataSource:
     Example:
         >>> wrapped = PublicationTermDataSource(chembl_adapter)
         >>> async with wrapped:
-        ...     async for term in wrapped.fetch("document_term", limit=100):
+        ...     async for term in wrapped.fetch("publication_term", limit=100):
         ...         process_term(term)  # term has keys: term, term_type, etc.
 
     .. versionchanged:: 2.0.0
@@ -61,9 +64,11 @@ class PublicationTermDataSource:
     """
 
     # Source entity type to fetch from wrapped adapter
-    SOURCE_ENTITY_TYPE = "document"
+    # Uses canonical "publication" name (ADR-024 naming unification)
+    SOURCE_ENTITY_TYPE = "publication"
     # Target entity type this wrapper provides
-    TARGET_ENTITY_TYPE = "document_term"
+    # Uses canonical "publication_term" name (ADR-024 naming unification)
+    TARGET_ENTITY_TYPE = "publication_term"
     # Multiplier for publication limit estimation.
     # Not all publications have terms (mesh_terms/keywords may be empty).
     # Analysis shows ~20-30% of ChEMBL publications have terms.
@@ -109,11 +114,11 @@ class PublicationTermDataSource:
         filter_ids: list[str] | None = None,
         filter_field: str | None = None,
     ) -> AsyncIterator[dict[str, Any]]:
-        """Fetch records, extracting terms if entity_type is document_term.
+        """Fetch records, extracting terms if entity_type is publication_term.
 
-        For document_term entity type:
-        - Fetches documents from wrapped adapter
-        - Extracts terms from each document
+        For publication_term entity type:
+        - Fetches publications from wrapped adapter
+        - Extracts terms from each publication
         - Yields individual term records
 
         For other entity types:
@@ -121,7 +126,7 @@ class PublicationTermDataSource:
 
         Args:
             entity_type: Type of entity to fetch.
-            limit: Maximum number of records (for document_term, limits total terms).
+            limit: Maximum number of records (for publication_term, limits total terms).
             query: Optional search query.
             filter_ids: Optional filter IDs (passed to wrapped adapter).
             filter_field: Optional filter field (passed to wrapped adapter).
@@ -362,20 +367,20 @@ class PublicationTermDataSource:
         filter_field: str,
         limit: int | None = None,
     ) -> AsyncIterator[dict[str, Any]]:
-        """Fetch filtered records, extracting terms if entity_type is document_term.
+        """Fetch filtered records, extracting terms if entity_type is publication_term.
 
         Implements FilterableDataSourcePort.fetch_filtered().
 
-        For document_term entity type:
-        - Delegates to wrapped adapter's fetch_filtered("document", ...)
-        - Extracts terms from each document
+        For publication_term entity type:
+        - Delegates to wrapped adapter's fetch_filtered("publication", ...)
+        - Extracts terms from each publication
 
         For other entity types:
         - Delegates directly to wrapped adapter
 
         Args:
             entity_type: Type of entity to fetch.
-            filter_ids: List of IDs to filter by (document_chembl_id for document_term).
+            filter_ids: List of IDs to filter by (document_chembl_id for publication_term).
             filter_field: Field name to filter on.
             limit: Maximum number of records to fetch.
 

--- a/src/bioetl/composition/providers/registration.py
+++ b/src/bioetl/composition/providers/registration.py
@@ -202,8 +202,8 @@ def _create_chembl_data_source(
     )
 
     # Wrap with PublicationTermDataSource for derived entity extraction
-    # document_term is extracted from publication records (1:M relationship)
-    if pipeline_config.entity_type == "document_term":
+    # publication_term is extracted from publication records (1:M relationship)
+    if pipeline_config.entity_type == "publication_term":
         base_adapter = PublicationTermDataSource(base_adapter)
 
     return _wrap_with_filter(

--- a/src/bioetl/infrastructure/adapters/chembl/entity_mapper.py
+++ b/src/bioetl/infrastructure/adapters/chembl/entity_mapper.py
@@ -12,6 +12,9 @@ CHEMBL_API_BASE = "https://www.ebi.ac.uk/chembl/api/data"
 CHEMBL_STATUS_URL = f"{CHEMBL_API_BASE}/status"
 
 # Entity type to ChEMBL resource mapping
+# Note: publication/publication_term/publication_similarity are canonical names (ADR-024)
+# that map to the same ChEMBL API resources as document/document_term/document_similarity.
+# The document* aliases are kept for backward compatibility.
 ENTITY_MAPPING: dict[str, str] = {
     "activity": "activity",
     "assay": "assay",
@@ -20,6 +23,11 @@ ENTITY_MAPPING: dict[str, str] = {
     "molecule": "molecule",
     "target": "target",
     "target_component": "target_component",
+    # Canonical publication names (ADR-024)
+    "publication": "document",
+    "publication_similarity": "document_similarity",
+    "publication_term": "document",
+    # Legacy document aliases (backward compatibility)
     "document": "document",
     "document_similarity": "document_similarity",
     "document_term": "document",
@@ -30,6 +38,8 @@ ENTITY_MAPPING: dict[str, str] = {
 }
 
 # Plural forms for API response keys (ChEMBL uses irregular plurals)
+# Note: These map to ChEMBL API response keys, not entity_type values.
+# publication* entity types map to document* API resources.
 ENTITY_PLURAL: dict[str, str] = {
     "activity": "activities",
     "assay": "assays",
@@ -45,11 +55,17 @@ ENTITY_PLURAL: dict[str, str] = {
 }
 
 # Primary key field overrides by entity type
+# Note: publication* entity types use the same PK fields as document* entities
 PK_FIELD_OVERRIDES: dict[str, str] = {
     "assay": "assay_chembl_id",
     "assay_parameters": "assay_param_id",
     "molecule": "molecule_chembl_id",
     "compound": "molecule_chembl_id",
+    # Canonical publication names (ADR-024)
+    "publication": "document_chembl_id",
+    "publication_similarity": "sim_id",
+    "publication_term": "document_chembl_id",
+    # Legacy document aliases (backward compatibility)
     "document": "document_chembl_id",
     "document_similarity": "sim_id",
     "document_term": "document_chembl_id",

--- a/tests/e2e/test_chembl_publication_term_e2e.py
+++ b/tests/e2e/test_chembl_publication_term_e2e.py
@@ -62,8 +62,8 @@ async def test_chembl_publication_term_full_cycle(e2e_data_dir: Path):
     runner = bootstrap_pipeline(ctx)
     await runner.run()
 
-    # Assert - Bronze layer (uses document entity from parent)
-    bronze_files = assert_bronze_files_exist(e2e_data_dir, "chembl", "document_term")
+    # Assert - Bronze layer (uses publication_term path per ADR-024 naming)
+    bronze_files = assert_bronze_files_exist(e2e_data_dir, "chembl", "publication_term")
     assert len(bronze_files) >= 1
 
     # Assert - Silver layer

--- a/tests/unit/application/core/test_publication_term_data_source.py
+++ b/tests/unit/application/core/test_publication_term_data_source.py
@@ -117,8 +117,8 @@ class TestPublicationTermDataSourceInit:
 
     def test_entity_type_constants(self):
         """Test entity type constants are set correctly."""
-        assert PublicationTermDataSource.SOURCE_ENTITY_TYPE == "document"
-        assert PublicationTermDataSource.TARGET_ENTITY_TYPE == "document_term"
+        assert PublicationTermDataSource.SOURCE_ENTITY_TYPE == "publication"
+        assert PublicationTermDataSource.TARGET_ENTITY_TYPE == "publication_term"
 
 
 @pytest.mark.unit
@@ -161,16 +161,16 @@ class TestPublicationTermDataSourceFetch:
     """Tests for fetch method."""
 
     @pytest.mark.asyncio
-    async def test_fetch_document_term_extracts_terms(
+    async def test_fetch_publication_term_extracts_terms(
         self, mock_data_source_single_document
     ):
-        """Test fetch('document_term') extracts terms from documents."""
+        """Test fetch('publication_term') extracts terms from documents."""
         wrapper = PublicationTermDataSource(
             data_source=mock_data_source_single_document
         )
 
         terms = []
-        async for term in wrapper.fetch("document_term"):
+        async for term in wrapper.fetch("publication_term"):
             terms.append(term)
 
         # Expected: 2 MESH_HEADING + 1 MESH_QUALIFIER + 3 KEYWORD = 6 terms
@@ -183,16 +183,16 @@ class TestPublicationTermDataSourceFetch:
         assert term_types.count("KEYWORD") == 3
 
     @pytest.mark.asyncio
-    async def test_fetch_document_term_with_limit(
+    async def test_fetch_publication_term_with_limit(
         self, mock_data_source_single_document
     ):
-        """Test fetch('document_term') respects limit parameter."""
+        """Test fetch('publication_term') respects limit parameter."""
         wrapper = PublicationTermDataSource(
             data_source=mock_data_source_single_document
         )
 
         terms = []
-        async for term in wrapper.fetch("document_term", limit=3):
+        async for term in wrapper.fetch("publication_term", limit=3):
             terms.append(term)
 
         assert len(terms) == 3
@@ -211,14 +211,14 @@ class TestPublicationTermDataSourceFetch:
         assert all("document_chembl_id" in r for r in records)
 
     @pytest.mark.asyncio
-    async def test_fetch_document_term_empty_result(
+    async def test_fetch_publication_term_empty_result(
         self, mock_data_source_no_documents
     ):
-        """Test fetch('document_term') with no documents yields nothing."""
+        """Test fetch('publication_term') with no documents yields nothing."""
         wrapper = PublicationTermDataSource(data_source=mock_data_source_no_documents)
 
         terms = []
-        async for term in wrapper.fetch("document_term"):
+        async for term in wrapper.fetch("publication_term"):
             terms.append(term)
 
         assert len(terms) == 0
@@ -235,7 +235,7 @@ class TestPublicationTermDataSourceTermExtraction:
         wrapper = PublicationTermDataSource(data_source=source)
 
         terms = []
-        async for term in wrapper.fetch("document_term"):
+        async for term in wrapper.fetch("publication_term"):
             if term["term_type"] == "MESH_HEADING":
                 terms.append(term)
 
@@ -250,7 +250,7 @@ class TestPublicationTermDataSourceTermExtraction:
         wrapper = PublicationTermDataSource(data_source=source)
 
         terms = []
-        async for term in wrapper.fetch("document_term"):
+        async for term in wrapper.fetch("publication_term"):
             if term["term_type"] == "MESH_QUALIFIER":
                 terms.append(term)
 
@@ -264,7 +264,7 @@ class TestPublicationTermDataSourceTermExtraction:
         wrapper = PublicationTermDataSource(data_source=source)
 
         terms = []
-        async for term in wrapper.fetch("document_term"):
+        async for term in wrapper.fetch("publication_term"):
             if term["term_type"] == "KEYWORD":
                 terms.append(term)
 
@@ -281,7 +281,7 @@ class TestPublicationTermDataSourceTermExtraction:
         wrapper = PublicationTermDataSource(data_source=source)
 
         terms = []
-        async for term in wrapper.fetch("document_term"):
+        async for term in wrapper.fetch("publication_term"):
             terms.append(term)
 
         assert len(terms) == 0
@@ -293,7 +293,7 @@ class TestPublicationTermDataSourceTermExtraction:
         wrapper = PublicationTermDataSource(data_source=source)
 
         terms = []
-        async for term in wrapper.fetch("document_term"):
+        async for term in wrapper.fetch("publication_term"):
             terms.append(term)
 
         assert len(terms) == 0
@@ -305,7 +305,7 @@ class TestPublicationTermDataSourceTermExtraction:
         wrapper = PublicationTermDataSource(data_source=source)
 
         terms = []
-        async for term in wrapper.fetch("document_term"):
+        async for term in wrapper.fetch("publication_term"):
             terms.append(term)
 
         # Should only get the valid keyword
@@ -324,7 +324,7 @@ class TestPublicationTermDataSourceRecordFormat:
         wrapper = PublicationTermDataSource(data_source=source)
 
         terms = []
-        async for term in wrapper.fetch("document_term"):
+        async for term in wrapper.fetch("publication_term"):
             terms.append(term)
 
         for term in terms:
@@ -342,7 +342,7 @@ class TestPublicationTermDataSourceRecordFormat:
         wrapper = PublicationTermDataSource(data_source=source)
 
         terms = []
-        async for term in wrapper.fetch("document_term"):
+        async for term in wrapper.fetch("publication_term"):
             terms.append(term)
 
         # All entity_ids should be 16-char hex strings
@@ -357,7 +357,7 @@ class TestPublicationTermDataSourceRecordFormat:
         wrapper = PublicationTermDataSource(data_source=source)
 
         terms = []
-        async for term in wrapper.fetch("document_term"):
+        async for term in wrapper.fetch("publication_term"):
             terms.append(term)
 
         entity_ids = [t["entity_id"] for t in terms]
@@ -372,11 +372,11 @@ class TestPublicationTermDataSourceRecordFormat:
         wrapper2 = PublicationTermDataSource(data_source=source2)
 
         terms1 = []
-        async for term in wrapper1.fetch("document_term"):
+        async for term in wrapper1.fetch("publication_term"):
             terms1.append(term)
 
         terms2 = []
-        async for term in wrapper2.fetch("document_term"):
+        async for term in wrapper2.fetch("publication_term"):
             terms2.append(term)
 
         # Same inputs should produce same entity_ids
@@ -391,7 +391,7 @@ class TestPublicationTermDataSourceRecordFormat:
         wrapper = PublicationTermDataSource(data_source=source)
 
         terms = []
-        async for term in wrapper.fetch("document_term"):
+        async for term in wrapper.fetch("publication_term"):
             if term["term_type"] == "MESH_HEADING":
                 terms.append(term)
 
@@ -439,7 +439,7 @@ class TestPublicationTermDataSourceEdgeCases:
         wrapper = PublicationTermDataSource(data_source=source)
 
         terms = []
-        async for term in wrapper.fetch("document_term"):
+        async for term in wrapper.fetch("publication_term"):
             terms.append(term)
 
         assert len(terms) == 0
@@ -459,7 +459,7 @@ class TestPublicationTermDataSourceEdgeCases:
         wrapper = PublicationTermDataSource(data_source=source)
 
         terms = []
-        async for term in wrapper.fetch("document_term"):
+        async for term in wrapper.fetch("publication_term"):
             terms.append(term)
 
         # Only non-empty after stripping
@@ -487,7 +487,7 @@ class TestPublicationTermDataSourceEdgeCases:
         wrapper = PublicationTermDataSource(data_source=source)
 
         terms = []
-        async for term in wrapper.fetch("document_term"):
+        async for term in wrapper.fetch("publication_term"):
             terms.append(term)
 
         assert len(terms) == 2
@@ -519,13 +519,13 @@ class TestPublicationTermDataSourceEdgeCases:
 
         terms = []
         async for term in wrapper.fetch(
-            "document_term",
+            "publication_term",
             filter_ids=["CHEMBL1", "CHEMBL2"],
             filter_field="document_chembl_id",
         ):
             terms.append(term)
 
-        # Verify fetch was called with document entity type
-        assert call_args["entity_type"] == "document"
+        # Verify fetch was called with publication entity type (ADR-024 naming)
+        assert call_args["entity_type"] == "publication"
         assert call_args["filter_ids"] == ["CHEMBL1", "CHEMBL2"]
         assert call_args["filter_field"] == "document_chembl_id"

--- a/tests/unit/application/pipelines/test_chembl_pipelines.py
+++ b/tests/unit/application/pipelines/test_chembl_pipelines.py
@@ -129,11 +129,11 @@ class TestChEMBLPublicationPipeline:
 
     @pytest.fixture
     def pipeline(self, mock_services, runtime_config, run_id):
-        """Create document pipeline instance."""
+        """Create publication pipeline instance."""
         config = create_pipeline_config(
-            pipeline_name="chembl_document",
-            entity_type="document",
-            silver_table="chembl.document",
+            pipeline_name="chembl_publication",
+            entity_type="publication",
+            silver_table="chembl.publication",
             primary_keys=["document_chembl_id"],
         )
         return ChEMBLPublicationPipeline(


### PR DESCRIPTION
## Summary
Implements ADR-024 by renaming ChEMBL document-related entities to their canonical "publication" names throughout the codebase. The ChEMBL API resources remain unchanged (still use `/document` endpoint), but the internal entity type naming is now consistent and more semantically accurate.

## Key Changes

### Configuration Files
- Updated `publication.yaml`, `publication_similarity.yaml`, and `publication_term.yaml` pipeline configs:
  - Changed `entity_type` from `document*` to `publication*` (e.g., `document` → `publication`)
  - Updated all output paths to use `publication*` directory names
  - Removed obsolete comments about entity_type/filename mismatches (no longer needed with canonical naming)

### Core Application Logic
- **PublicationTermDataSource**: Updated entity type constants and documentation:
  - `SOURCE_ENTITY_TYPE`: `"document"` → `"publication"`
  - `TARGET_ENTITY_TYPE`: `"document_term"` → `"publication_term"`
  - Updated all docstrings and comments to reference publication terminology

- **Registration/Composition**: Updated pipeline creation logic to check for `publication_term` entity type

### Infrastructure Mapping
- **entity_mapper.py**: Added canonical publication entity mappings while maintaining backward compatibility:
  - `publication` → `document` (ChEMBL API resource)
  - `publication_similarity` → `document_similarity`
  - `publication_term` → `document`
  - Kept legacy `document*` aliases for backward compatibility
  - Added explanatory comments about ADR-024 naming unification

### Tests
- Updated all test cases to use canonical `publication*` entity types
- Updated test method names and assertions to reflect new naming
- Updated E2E test to expect `publication_term` output paths
- Updated fixture documentation to reference publication terminology

## Implementation Details
- **Backward Compatibility**: Legacy `document*` entity types are still supported through the entity mapper, allowing gradual migration
- **API Compatibility**: No changes to ChEMBL API calls—the mapper transparently converts canonical names to API resource names
- **Naming Consistency**: All internal references now use "publication" terminology, improving code clarity and maintainability
- **Documentation**: Added version change notes (2.1.0) documenting the naming unification

## Related
- ADR-024: Canonical entity naming for ChEMBL publication entities