### PR TITLE
ADR-029: Unify output metadata across Medallion layers

### DIFF
--- a/docs/02-architecture/decisions/ADR-029-output-metadata-unification.md
+++ b/docs/02-architecture/decisions/ADR-029-output-metadata-unification.md
@@ -1,0 +1,191 @@
+# ADR-029: Output Metadata Unification
+
+**Status:** Accepted
+**Date:** 2026-01-23
+**Decision makers:** @BioETL-Team
+**Relates to:** RULES.md §2.4 (Lineage Requirements), ADR-014 (Deterministic Writes)
+
+## Context
+
+Bronze/Silver/Gold Medallion layers использовали разные структуры для `output`-метаданных в sidecar-файлах:
+
+| Layer | Класс | Поля |
+|-------|-------|------|
+| Bronze | `OutputMetadata` | `total_records`, `total_bytes`, `files`, `format`, `compression` |
+| Silver | `SilverOutputMetadata` | `record_count`, `content_hash` |
+| Gold | `GoldOutputMetadata` | `record_count`, `partition_count`, `total_bytes`, `format` |
+
+### Проблемы
+
+1. **Несогласованное именование**: `total_records` vs `record_count`
+2. **Отсутствует общий контракт**: Усложняет downstream-аналитику и мониторинг
+3. **Пропущенные поля**: `total_bytes` отсутствует в Silver
+4. **Нет timestamps записи**: Отсутствуют `write_started_at`/`write_completed_at`
+5. **Дублирование delta_version**: В Silver версии есть в `DeltaMetrics`, но не в output
+
+## Decision
+
+Унифицировать output-метаданные через паттерн **Base + Extension**:
+
+### BaseOutputMetadata (Общий контракт)
+
+```python
+class BaseOutputMetadata(BaseModel):
+    """Base output metadata contract for all Medallion layers."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    record_count: int = Field(ge=0, description="Total records written")
+    total_bytes: int = Field(ge=0, description="Total size in bytes")
+    content_hash: str | None = Field(description="SHA256 hash for change detection")
+    write_started_at: datetime | None = Field(description="Write start timestamp")
+    write_completed_at: datetime | None = Field(description="Write completion timestamp")
+
+    @computed_field
+    @property
+    def write_duration_ms(self) -> int | None:
+        """Calculate write duration in milliseconds."""
+```
+
+### Layer-Specific Extensions
+
+```python
+class BronzeOutputExt(BaseModel):
+    files: list[FileOutputMetadata]
+    format: str = "jsonl+zstd"
+    compression: str = "zstd"
+
+class SilverOutputExt(BaseModel):
+    delta_version_before: int | None
+    delta_version_after: int | None
+
+class GoldOutputExt(BaseModel):
+    partition_count: int = 0
+    format: Literal["delta", "parquet"] = "delta"
+```
+
+### Layer Metadata Composition
+
+```python
+class BronzeMetadata(BaseModel):
+    output: BaseOutputMetadata          # Unified base
+    output_ext: BronzeOutputExt         # Layer-specific
+
+class SilverMetadata(BaseModel):
+    output: BaseOutputMetadata          # Unified base
+    output_ext: SilverOutputExt         # Layer-specific
+
+class GoldMetadata(BaseModel):
+    output: BaseOutputMetadata          # Unified base
+    output_ext: GoldOutputExt           # Layer-specific
+```
+
+### Metadata Schema Version Bump
+
+Версия metadata schema увеличена с `1.0` до `1.1` для всех слоёв.
+
+### Backward Compatibility
+
+Старые классы (`OutputMetadata`, `SilverOutputMetadata`, `GoldOutputMetadata`) сохранены как deprecated:
+
+```python
+class OutputMetadata(BaseModel):
+    """Bronze output information (DEPRECATED).
+
+    .. deprecated:: 5.10.0
+        Use BaseOutputMetadata + BronzeOutputExt composition instead.
+        Will be removed in v6.0.
+    """
+
+    def __init__(self, **data: object) -> None:
+        warnings.warn(
+            "OutputMetadata is deprecated, use BaseOutputMetadata + BronzeOutputExt...",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(**data)
+```
+
+## Consequences
+
+### Positive
+
+1. **Unified analytics**: Все слои экспортируют одинаковые базовые метрики
+2. **Duration tracking**: `write_duration_ms` доступен через computed field
+3. **Change detection**: `content_hash` доступен на всех слоях
+4. **Monitoring consistency**: Prometheus/Grafana dashboards могут использовать единый набор метрик
+5. **Type safety**: `extra="forbid"` предотвращает случайные поля
+
+### Negative
+
+1. **Breaking change**: Существующий код использующий `output.total_records` (Bronze) требует обновления
+2. **Schema migration**: Существующие sidecar-файлы v1.0 не совместимы с v1.1
+
+### Neutral
+
+- Delta versions дублируются в Silver: `DeltaMetrics.version_*` и `SilverOutputExt.delta_version_*`
+- Это осознанное решение для полноты output-контракта
+
+## Implementation
+
+### Files Modified
+
+**Domain Models:**
+- `src/bioetl/domain/models/metadata.py` — BaseOutputMetadata, *OutputExt классы
+
+**DTOs:**
+- `src/bioetl/domain/ports/metadata_coordinator.py` — Добавлены `version_before`, `total_bytes`, `partition_count`
+
+**Services:**
+- `src/bioetl/composition/services/metadata_coordinator.py` — Обновлены create_*_metadata методы
+
+**Infrastructure:**
+- `src/bioetl/infrastructure/storage/bronze_writer.py` — _build_full_bronze_metadata
+- `src/bioetl/infrastructure/storage/metadata_builder.py` — Silver/Gold builders
+
+### JSON Output Format
+
+**Before (v1.0):**
+```json
+{
+  "output": {
+    "total_records": 1000,
+    "total_bytes": 50000,
+    "files": [...]
+  }
+}
+```
+
+**After (v1.1):**
+```json
+{
+  "output": {
+    "record_count": 1000,
+    "total_bytes": 50000,
+    "content_hash": "sha256:...",
+    "write_started_at": "2026-01-23T12:00:00Z",
+    "write_completed_at": "2026-01-23T12:00:05Z"
+  },
+  "output_ext": {
+    "files": [...],
+    "format": "jsonl+zstd",
+    "compression": "zstd"
+  }
+}
+```
+
+## Tests
+
+### Unit Tests
+
+- `tests/unit/domain/models/test_metadata_output.py` — BaseOutputMetadata, *OutputExt
+
+### Architecture Tests
+
+- `tests/architecture/test_metadata_output_contract.py` — Contract validation
+
+## References
+
+- RULES.md §2.4 — Lineage Requirements
+- ADR-014 — Deterministic Writes (content hash)
+- glossary.md — Ubiquitous Language definitions

--- a/src/bioetl/composition/services/metadata_coordinator.py
+++ b/src/bioetl/composition/services/metadata_coordinator.py
@@ -27,15 +27,16 @@ from typing import Any, Literal
 
 from bioetl.domain.medallion import GoldWriteMode, SilverWriteMode
 from bioetl.domain.models.metadata import (
+    BaseOutputMetadata,
     BronzeMetadata,
+    BronzeOutputExt,
     DeltaMetrics,
     DQSummary,
     EnvironmentMetadata,
     FileOutputMetadata,
     GoldMetadata,
-    GoldOutputMetadata,
+    GoldOutputExt,
     LineageMetadata,
-    OutputMetadata,
     PipelineMetadata,
     RuntimeMetadata,
     RunTypeEnum,
@@ -43,7 +44,7 @@ from bioetl.domain.models.metadata import (
     SchemaColumnMetadata,
     SchemaMetadata,
     SilverMetadata,
-    SilverOutputMetadata,
+    SilverOutputExt,
     SourceMetadata,
 )
 from bioetl.domain.ports import (
@@ -192,6 +193,13 @@ class MetadataCoordinator:
                 query_string=input_data.query_string,
             )
 
+        # Build file metadata for output_ext
+        file_metadata = FileOutputMetadata(
+            path=input_data.output_path,
+            size_bytes=input_data.compressed_size,
+            record_count=input_data.record_count,
+        )
+
         return BronzeMetadata(
             runtime=self._build_runtime_metadata(
                 started_at=input_data.started_at,
@@ -200,16 +208,14 @@ class MetadataCoordinator:
             ),
             pipeline=self._build_pipeline_metadata(),
             source=source,
-            output=OutputMetadata(
-                files=[
-                    FileOutputMetadata(
-                        path=input_data.output_path,
-                        size_bytes=input_data.compressed_size,
-                        record_count=input_data.record_count,
-                    )
-                ],
-                total_records=input_data.record_count,
+            output=BaseOutputMetadata(
+                record_count=input_data.record_count,
                 total_bytes=input_data.compressed_size,
+                write_started_at=input_data.started_at,
+                write_completed_at=input_data.completed_at,
+            ),
+            output_ext=BronzeOutputExt(
+                files=[file_metadata],
             ),
             environment=self._get_environment_metadata(),
             governance=input_data.governance,
@@ -284,13 +290,28 @@ class MetadataCoordinator:
             if input_data.dq_metrics
             else DQSummary(total_records=rec_count, valid_records=rec_count)
         )
-        output = SilverOutputMetadata(record_count=rec_count)
+
         # Calculate duration if both timestamps provided
         duration_seconds = (
             (input_data.completed_at - input_data.started_at).total_seconds()
             if input_data.started_at and input_data.completed_at
             else None
         )
+
+        # Build unified output metadata (ADR-029)
+        output = BaseOutputMetadata(
+            record_count=rec_count,
+            total_bytes=getattr(input_data, "total_bytes", 0),
+            write_started_at=input_data.started_at,
+            write_completed_at=input_data.completed_at,
+        )
+
+        # Build Silver-specific output extension with delta versions
+        output_ext = SilverOutputExt(
+            delta_version_before=getattr(input_data, "version_before", None),
+            delta_version_after=input_data.version_after,
+        )
+
         return SilverMetadata(
             runtime=self._build_runtime_metadata(
                 started_at=input_data.started_at,
@@ -302,6 +323,7 @@ class MetadataCoordinator:
             delta=delta,
             dq_summary=dq_summary,
             output=output,
+            output_ext=output_ext,
             environment=self._get_environment_metadata(),
             dq_report_path=input_data.dq_report_path,
             governance=input_data.governance,
@@ -425,14 +447,23 @@ class MetadataCoordinator:
         )
 
         # Build DQ summary (basic metrics)
+        rec_count = len(input_data.records)
         dq_summary = DQSummary(
-            total_records=len(input_data.records),
-            valid_records=len(input_data.records),
+            total_records=rec_count,
+            valid_records=rec_count,
         )
 
-        # Build output metrics
-        output = GoldOutputMetadata(
-            record_count=len(input_data.records),
+        # Build unified output metadata (ADR-029)
+        output = BaseOutputMetadata(
+            record_count=rec_count,
+            total_bytes=getattr(input_data, "total_bytes", 0),
+            write_started_at=getattr(input_data, "started_at", None),
+            write_completed_at=input_data.completed_at,
+        )
+
+        # Build Gold-specific output extension
+        output_ext = GoldOutputExt(
+            partition_count=getattr(input_data, "partition_count", 0),
         )
 
         # Build SCD metadata if applicable
@@ -463,6 +494,7 @@ class MetadataCoordinator:
             schema_info=schema_info,
             dq_summary=dq_summary,
             output=output,
+            output_ext=output_ext,
             scd=scd,
             environment=self._get_environment_metadata(),
             governance=input_data.governance,

--- a/src/bioetl/domain/models/metadata.py
+++ b/src/bioetl/domain/models/metadata.py
@@ -8,16 +8,19 @@ Implements RULES.md 2.3 and 02-user-rules.md 2.4:
 - QC information
 - Runtime context
 
-Version: 1.0
+ADR-029: Output metadata unification across Medallion layers.
+
+Version: 1.1
 """
 
 from __future__ import annotations
 
+import warnings
 from datetime import datetime
 from enum import Enum
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 
 class LayerType(str, Enum):
@@ -338,8 +341,144 @@ class FileOutputMetadata(BaseModel):
     checksum_blake2: str | None = Field(default=None, description="BLAKE2 checksum")
 
 
+# =============================================================================
+# Unified Output Metadata (ADR-029)
+# =============================================================================
+
+
+class BaseOutputMetadata(BaseModel):
+    """Base output metadata contract for all Medallion layers.
+
+    Provides common fields required for downstream analytics,
+    monitoring, and data lineage tracking. All layer-specific
+    output metadata classes use this as the common output field.
+
+    ADR-029: Output metadata unification.
+
+    Attributes:
+        record_count: Total records written to layer.
+        total_bytes: Total size in bytes (compressed for Bronze, on-disk for Delta).
+        content_hash: SHA256 hash of content for change detection.
+        write_started_at: UTC timestamp when write operation started.
+        write_completed_at: UTC timestamp when write operation completed.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    record_count: int = Field(
+        default=0,
+        ge=0,
+        description="Total records written to layer",
+    )
+    total_bytes: int = Field(
+        default=0,
+        ge=0,
+        description="Total size in bytes (compressed for Bronze, on-disk for Delta)",
+    )
+    content_hash: str | None = Field(
+        default=None,
+        description="SHA256 hash of content for change detection",
+    )
+    write_started_at: datetime | None = Field(
+        default=None,
+        description="UTC timestamp when write operation started",
+    )
+    write_completed_at: datetime | None = Field(
+        default=None,
+        description="UTC timestamp when write operation completed",
+    )
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def write_duration_ms(self) -> int | None:
+        """Calculate write duration in milliseconds.
+
+        Returns:
+            Duration in milliseconds, or None if timestamps missing.
+        """
+        if self.write_started_at and self.write_completed_at:
+            delta = self.write_completed_at - self.write_started_at
+            return int(delta.total_seconds() * 1000)
+        return None
+
+
+class BronzeOutputExt(BaseModel):
+    """Bronze-specific output metadata extension.
+
+    Tracks individual files for append-only Bronze layer.
+
+    Attributes:
+        files: List of output files with per-file metrics.
+        format: Output format (jsonl+zstd, jsonl, etc.).
+        compression: Compression algorithm.
+    """
+
+    files: list[FileOutputMetadata] = Field(
+        default_factory=list,
+        description="List of output files with per-file metrics",
+    )
+    format: str = Field(
+        default="jsonl+zstd",
+        description="Output format (jsonl+zstd, jsonl, etc.)",
+    )
+    compression: str = Field(
+        default="zstd",
+        description="Compression algorithm",
+    )
+
+
+class SilverOutputExt(BaseModel):
+    """Silver-specific output metadata extension.
+
+    Tracks Delta Lake versioning for merge operations.
+
+    Attributes:
+        delta_version_before: Delta table version before write.
+        delta_version_after: Delta table version after write.
+    """
+
+    delta_version_before: int | None = Field(
+        default=None,
+        description="Delta table version before write",
+    )
+    delta_version_after: int | None = Field(
+        default=None,
+        description="Delta table version after write",
+    )
+
+
+class GoldOutputExt(BaseModel):
+    """Gold-specific output metadata extension.
+
+    Tracks partitioning and format for consumption layer.
+
+    Attributes:
+        partition_count: Number of partitions.
+        format: Output format (delta or parquet).
+    """
+
+    partition_count: int = Field(
+        default=0,
+        ge=0,
+        description="Number of partitions",
+    )
+    format: Literal["delta", "parquet"] = Field(
+        default="delta",
+        description="Output format",
+    )
+
+
+# =============================================================================
+# Legacy Output Metadata (Deprecated - ADR-029)
+# =============================================================================
+
+
 class OutputMetadata(BaseModel):
-    """Bronze output information.
+    """Bronze output information (DEPRECATED).
+
+    .. deprecated:: 5.10.0
+        Use BaseOutputMetadata + BronzeOutputExt composition instead.
+        Will be removed in v6.0.
 
     Attributes:
         files: List of output files.
@@ -356,6 +495,16 @@ class OutputMetadata(BaseModel):
     total_bytes: int = Field(default=0, description="Total bytes")
     format: str = Field(default="jsonl+zstd", description="Output format")
     compression: str = Field(default="zstd", description="Compression algorithm")
+
+    def __init__(self, **data: object) -> None:
+        """Initialize with deprecation warning."""
+        warnings.warn(
+            "OutputMetadata is deprecated, use BaseOutputMetadata + BronzeOutputExt "
+            "composition instead. Will be removed in v6.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(**data)
 
 
 # =============================================================================
@@ -562,7 +711,11 @@ class SCDMetadata(BaseModel):
 
 
 class GoldOutputMetadata(BaseModel):
-    """Gold layer output metrics.
+    """Gold layer output metrics (DEPRECATED).
+
+    .. deprecated:: 5.10.0
+        Use BaseOutputMetadata + GoldOutputExt composition instead.
+        Will be removed in v6.0.
 
     Attributes:
         record_count: Number of records.
@@ -578,9 +731,23 @@ class GoldOutputMetadata(BaseModel):
         default="delta", description="Output format"
     )
 
+    def __init__(self, **data: object) -> None:
+        """Initialize with deprecation warning."""
+        warnings.warn(
+            "GoldOutputMetadata is deprecated, use BaseOutputMetadata + "
+            "GoldOutputExt composition instead. Will be removed in v6.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(**data)
+
 
 class SilverOutputMetadata(BaseModel):
-    """Silver layer output metrics.
+    """Silver layer output metrics (DEPRECATED).
+
+    .. deprecated:: 5.10.0
+        Use BaseOutputMetadata + SilverOutputExt composition instead.
+        Will be removed in v6.0.
 
     Attributes:
         record_count: Number of records written.
@@ -591,6 +758,16 @@ class SilverOutputMetadata(BaseModel):
     content_hash: str | None = Field(
         default=None, description="Content hash for change detection"
     )
+
+    def __init__(self, **data: object) -> None:
+        """Initialize with deprecation warning."""
+        warnings.warn(
+            "SilverOutputMetadata is deprecated, use BaseOutputMetadata + "
+            "SilverOutputExt composition instead. Will be removed in v6.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(**data)
 
 
 # =============================================================================
@@ -603,17 +780,22 @@ class BronzeMetadata(BaseModel):
 
     Structure follows RULES.md 2.4 lineage requirements.
     Includes governance metadata block for data stewardship.
+
+    ADR-029: Uses unified BaseOutputMetadata + BronzeOutputExt composition.
     """
 
-    version: str = Field(default="1.0", description="Metadata schema version")
+    version: str = Field(default="1.1", description="Metadata schema version")
     layer: LayerType = Field(default=LayerType.BRONZE, description="Medallion layer")
     runtime: RuntimeMetadata = Field(description="Runtime context")
     pipeline: PipelineMetadata = Field(description="Pipeline identification")
     source: SourceMetadata = Field(
         default_factory=SourceMetadata, description="Source information"
     )
-    output: OutputMetadata = Field(
-        default_factory=OutputMetadata, description="Output information"
+    output: BaseOutputMetadata = Field(
+        default_factory=BaseOutputMetadata, description="Base output metrics"
+    )
+    output_ext: BronzeOutputExt = Field(
+        default_factory=BronzeOutputExt, description="Bronze-specific output metrics"
     )
     environment: EnvironmentMetadata = Field(description="Environment information")
     governance: GovernanceMetadata | None = Field(
@@ -625,9 +807,11 @@ class SilverMetadata(BaseModel):
     """Complete metadata for Silver layer sidecar file.
 
     Includes lineage tracking from Bronze, DQ metrics, and governance metadata.
+
+    ADR-029: Uses unified BaseOutputMetadata + SilverOutputExt composition.
     """
 
-    version: str = Field(default="1.0", description="Metadata schema version")
+    version: str = Field(default="1.1", description="Metadata schema version")
     layer: LayerType = Field(default=LayerType.SILVER, description="Medallion layer")
     runtime: RuntimeMetadata = Field(description="Runtime context")
     pipeline: PipelineMetadata = Field(description="Pipeline identification")
@@ -638,8 +822,11 @@ class SilverMetadata(BaseModel):
     dq_summary: DQSummary = Field(
         default_factory=DQSummary, description="Data quality summary"
     )
-    output: SilverOutputMetadata = Field(
-        default_factory=SilverOutputMetadata, description="Output metrics"
+    output: BaseOutputMetadata = Field(
+        default_factory=BaseOutputMetadata, description="Base output metrics"
+    )
+    output_ext: SilverOutputExt = Field(
+        default_factory=SilverOutputExt, description="Silver-specific output metrics"
     )
     environment: EnvironmentMetadata = Field(description="Environment information")
     # Cross-reference to DQ report
@@ -656,11 +843,13 @@ class GoldMetadata(BaseModel):
     """Complete metadata for Gold layer sidecar file.
 
     Includes schema contract, SCD tracking, and governance metadata.
+
+    ADR-029: Uses unified BaseOutputMetadata + GoldOutputExt composition.
     """
 
     model_config = ConfigDict(populate_by_name=True)
 
-    version: str = Field(default="1.0", description="Metadata schema version")
+    version: str = Field(default="1.1", description="Metadata schema version")
     layer: LayerType = Field(default=LayerType.GOLD, description="Medallion layer")
     runtime: RuntimeMetadata = Field(description="Runtime context")
     pipeline: PipelineMetadata = Field(description="Pipeline identification")
@@ -675,8 +864,11 @@ class GoldMetadata(BaseModel):
     dq_summary: DQSummary = Field(
         default_factory=DQSummary, description="Data quality summary"
     )
-    output: GoldOutputMetadata = Field(
-        default_factory=GoldOutputMetadata, description="Output metrics"
+    output: BaseOutputMetadata = Field(
+        default_factory=BaseOutputMetadata, description="Base output metrics"
+    )
+    output_ext: GoldOutputExt = Field(
+        default_factory=GoldOutputExt, description="Gold-specific output metrics"
     )
     scd: SCDMetadata | None = Field(default=None, description="SCD Type 2 metadata")
     environment: EnvironmentMetadata = Field(description="Environment information")

--- a/src/bioetl/domain/ports/metadata_coordinator.py
+++ b/src/bioetl/domain/ports/metadata_coordinator.py
@@ -63,6 +63,7 @@ class SilverMetadataInput:
         mode: Write mode (merge, append, delete).
         bronze_refs: Optional list of BronzeWriteResult for lineage.
         dq_metrics: Optional BatchDQMetrics for DQ summary.
+        version_before: Delta table version before write (ADR-029).
         version_after: Delta table version after write.
         transform_version: Optional semver version of transform applied.
         transform_steps: Optional list of transform step names applied.
@@ -71,6 +72,7 @@ class SilverMetadataInput:
         governance: Optional governance metadata from pipeline config.
         started_at: UTC timestamp when Silver write started.
         completed_at: UTC timestamp when Silver write completed.
+        total_bytes: Total size in bytes (ADR-029).
     """
 
     table_path: str
@@ -79,6 +81,7 @@ class SilverMetadataInput:
     mode: Any  # SilverWriteMode - avoid circular import
     bronze_refs: Any | None = None  # list[BronzeWriteResult] | None
     dq_metrics: Any | None = None  # BatchDQMetrics | None
+    version_before: int | None = None  # ADR-029: Delta version before write
     version_after: int | None = None
     transform_version: str | None = None
     transform_steps: tuple[str, ...] | None = None
@@ -87,6 +90,7 @@ class SilverMetadataInput:
     governance: GovernanceMetadata | None = None
     started_at: datetime | None = None
     completed_at: datetime | None = None
+    total_bytes: int = 0  # ADR-029: Total size in bytes
 
 
 @dataclass(frozen=True, slots=True)
@@ -117,6 +121,7 @@ class GoldMetadataInput:
         records: List of records written.
         mode: Write mode (overwrite, append, scd2).
         scd_config: SCD2 configuration if applicable.
+        started_at: UTC timestamp when write started (ADR-029).
         completed_at: UTC timestamp when write completed.
         silver_refs: List of Silver source references for lineage tracking.
         transform_version: Optional semver version of transform applied.
@@ -124,6 +129,8 @@ class GoldMetadataInput:
         gold_schema: Optional Pandera schema class for extracting schema metadata
                     (contract_path, version, columns).
         governance: Optional governance metadata from pipeline config.
+        total_bytes: Total size in bytes (ADR-029).
+        partition_count: Number of partitions (ADR-029).
     """
 
     table_path: str
@@ -131,12 +138,15 @@ class GoldMetadataInput:
     records: list[dict[str, Any]]
     mode: Any  # GoldWriteMode - avoid circular import
     scd_config: dict[str, Any] | None = None
+    started_at: datetime | None = None  # ADR-029: Write start timestamp
     completed_at: datetime | None = None
     silver_refs: list[SilverRef] | None = None
     transform_version: str | None = None
     transform_steps: tuple[str, ...] | None = None
     gold_schema: Any | None = None  # Pandera DataFrameModel class
     governance: GovernanceMetadata | None = None
+    total_bytes: int = 0  # ADR-029: Total size in bytes
+    partition_count: int = 0  # ADR-029: Number of partitions
 
 
 @runtime_checkable

--- a/src/bioetl/infrastructure/storage/bronze_writer.py
+++ b/src/bioetl/infrastructure/storage/bronze_writer.py
@@ -279,10 +279,11 @@ class BronzeWriter:
 
         from bioetl import __version__
         from bioetl.domain.models.metadata import (
+            BaseOutputMetadata,
             BronzeMetadata,
+            BronzeOutputExt,
             EnvironmentMetadata,
             FileOutputMetadata,
-            OutputMetadata,
             PipelineMetadata,
             RuntimeMetadata,
             RunTypeEnum,
@@ -300,6 +301,13 @@ class BronzeWriter:
         if source_metadata is None:
             source_metadata = SourceMetadataModel(type="api")
 
+        # Build file metadata for output_ext
+        file_metadata = FileOutputMetadata(
+            path=output_path,
+            size_bytes=compressed_size,
+            record_count=record_count,
+        )
+
         return BronzeMetadata(
             runtime=RuntimeMetadata(
                 run_id=str(run_id),
@@ -314,16 +322,14 @@ class BronzeWriter:
                 entity=entity,
             ),
             source=source_metadata,
-            output=OutputMetadata(
-                files=[
-                    FileOutputMetadata(
-                        path=output_path,
-                        size_bytes=compressed_size,
-                        record_count=record_count,
-                    )
-                ],
-                total_records=record_count,
+            output=BaseOutputMetadata(
+                record_count=record_count,
                 total_bytes=compressed_size,
+                write_started_at=started_at,
+                write_completed_at=completed_at,
+            ),
+            output_ext=BronzeOutputExt(
+                files=[file_metadata],
             ),
             environment=EnvironmentMetadata(
                 hostname=socket.gethostname(),

--- a/src/bioetl/infrastructure/storage/metadata_builder.py
+++ b/src/bioetl/infrastructure/storage/metadata_builder.py
@@ -223,6 +223,7 @@ class SilverMetadataBuilder:
             SilverMetadata object ready for serialization.
         """
         from bioetl.domain.models.metadata import (
+            BaseOutputMetadata,
             DeltaMetrics,
             DQSummary,
             EnvironmentMetadata,
@@ -231,7 +232,7 @@ class SilverMetadataBuilder:
             RuntimeMetadata,
             RunTypeEnum,
             SilverMetadata,
-            SilverOutputMetadata,
+            SilverOutputExt,
         )
 
         provider_name, entity_name = _parse_table_name(table_name)
@@ -277,8 +278,15 @@ class SilverMetadataBuilder:
             error_rate=0.0,
         )
 
-        output = SilverOutputMetadata(
+        # Use unified output structure (ADR-029)
+        output = BaseOutputMetadata(
             record_count=len(records),
+            write_started_at=now,
+            write_completed_at=now,
+        )
+
+        output_ext = SilverOutputExt(
+            delta_version_after=version_after,
         )
 
         environment = EnvironmentMetadata(
@@ -294,6 +302,7 @@ class SilverMetadataBuilder:
             delta=delta,
             dq_summary=dq_summary,
             output=output,
+            output_ext=output_ext,
             environment=environment,
         )
 
@@ -349,10 +358,11 @@ class GoldMetadataBuilder:
         """
         from bioetl.domain.medallion import GoldWriteMode
         from bioetl.domain.models.metadata import (
+            BaseOutputMetadata,
             DQSummary,
             EnvironmentMetadata,
             GoldMetadata,
-            GoldOutputMetadata,
+            GoldOutputExt,
             LineageMetadata,
             PipelineMetadata,
             RuntimeMetadata,
@@ -385,9 +395,14 @@ class GoldMetadataBuilder:
             valid_records=len(records),
         )
 
-        output = GoldOutputMetadata(
+        # Use unified output structure (ADR-029)
+        output = BaseOutputMetadata(
             record_count=len(records),
+            write_started_at=now,
+            write_completed_at=now,
         )
+
+        output_ext = GoldOutputExt()
 
         scd = None
         if mode == GoldWriteMode.SCD2 and scd_config:
@@ -416,6 +431,7 @@ class GoldMetadataBuilder:
             schema_info=schema_info,
             dq_summary=dq_summary,
             output=output,
+            output_ext=output_ext,
             scd=scd,
             environment=environment,
         )
@@ -445,10 +461,11 @@ class GoldMetadataBuilder:
             GoldMetadata object ready for serialization.
         """
         from bioetl.domain.models.metadata import (
+            BaseOutputMetadata,
             DQSummary,
             EnvironmentMetadata,
             GoldMetadata,
-            GoldOutputMetadata,
+            GoldOutputExt,
             LineageMetadata,
             PipelineMetadata,
             RuntimeMetadata,
@@ -489,9 +506,14 @@ class GoldMetadataBuilder:
             error_rate=0.0,
         )
 
-        output = GoldOutputMetadata(
+        # Use unified output structure (ADR-029)
+        output = BaseOutputMetadata(
             record_count=len(records),
+            write_started_at=now,
+            write_completed_at=now,
         )
+
+        output_ext = GoldOutputExt()
 
         environment = EnvironmentMetadata(
             hostname=hostname(),
@@ -510,6 +532,7 @@ class GoldMetadataBuilder:
             schema_info=schema_info,
             dq_summary=dq_summary,
             output=output,
+            output_ext=output_ext,
             environment=environment,
         )
 

--- a/tests/architecture/test_metadata_output_contract.py
+++ b/tests/architecture/test_metadata_output_contract.py
@@ -1,0 +1,119 @@
+"""Architecture tests for unified output metadata contract (ADR-029).
+
+Verifies that all layer metadata classes follow the unified
+output metadata pattern.
+"""
+
+from __future__ import annotations
+
+from bioetl.domain.models.metadata import (
+    BaseOutputMetadata,
+    BronzeMetadata,
+    BronzeOutputExt,
+    GoldMetadata,
+    GoldOutputExt,
+    SilverMetadata,
+    SilverOutputExt,
+)
+
+
+def test_all_layer_metadata_have_base_output() -> None:
+    """GIVEN layer metadata classes THEN all have BaseOutputMetadata output field."""
+    for cls in [BronzeMetadata, SilverMetadata, GoldMetadata]:
+        assert hasattr(cls, "model_fields"), f"{cls.__name__} is not a Pydantic model"
+        assert "output" in cls.model_fields, f"{cls.__name__} missing 'output' field"
+
+        field_info = cls.model_fields["output"]
+        assert (
+            field_info.annotation == BaseOutputMetadata
+        ), f"{cls.__name__}.output should be BaseOutputMetadata, got {field_info.annotation}"
+
+
+def test_all_layer_metadata_have_output_ext() -> None:
+    """GIVEN layer metadata classes THEN all have layer-specific output_ext field."""
+    expected = {
+        BronzeMetadata: BronzeOutputExt,
+        SilverMetadata: SilverOutputExt,
+        GoldMetadata: GoldOutputExt,
+    }
+
+    for cls, ext_cls in expected.items():
+        assert hasattr(cls, "model_fields"), f"{cls.__name__} is not a Pydantic model"
+        assert (
+            "output_ext" in cls.model_fields
+        ), f"{cls.__name__} missing 'output_ext' field"
+
+        field_info = cls.model_fields["output_ext"]
+        assert (
+            field_info.annotation == ext_cls
+        ), f"{cls.__name__}.output_ext should be {ext_cls.__name__}, got {field_info.annotation}"
+
+
+def test_base_output_metadata_has_required_fields() -> None:
+    """GIVEN BaseOutputMetadata THEN has all required common fields."""
+    required_fields = [
+        "record_count",
+        "total_bytes",
+        "content_hash",
+        "write_started_at",
+        "write_completed_at",
+    ]
+
+    for field_name in required_fields:
+        assert (
+            field_name in BaseOutputMetadata.model_fields
+        ), f"BaseOutputMetadata missing field: {field_name}"
+
+
+def test_base_output_metadata_has_computed_duration() -> None:
+    """GIVEN BaseOutputMetadata THEN has computed write_duration_ms property."""
+    # Check for computed field
+    computed_fields = BaseOutputMetadata.model_computed_fields
+    assert (
+        "write_duration_ms" in computed_fields
+    ), "BaseOutputMetadata missing computed field: write_duration_ms"
+
+
+def test_bronze_output_ext_has_required_fields() -> None:
+    """GIVEN BronzeOutputExt THEN has required Bronze-specific fields."""
+    required_fields = ["files", "format", "compression"]
+
+    for field_name in required_fields:
+        assert (
+            field_name in BronzeOutputExt.model_fields
+        ), f"BronzeOutputExt missing field: {field_name}"
+
+
+def test_silver_output_ext_has_required_fields() -> None:
+    """GIVEN SilverOutputExt THEN has required Silver-specific fields."""
+    required_fields = ["delta_version_before", "delta_version_after"]
+
+    for field_name in required_fields:
+        assert (
+            field_name in SilverOutputExt.model_fields
+        ), f"SilverOutputExt missing field: {field_name}"
+
+
+def test_gold_output_ext_has_required_fields() -> None:
+    """GIVEN GoldOutputExt THEN has required Gold-specific fields."""
+    required_fields = ["partition_count", "format"]
+
+    for field_name in required_fields:
+        assert (
+            field_name in GoldOutputExt.model_fields
+        ), f"GoldOutputExt missing field: {field_name}"
+
+
+def test_metadata_version_reflects_adr029() -> None:
+    """GIVEN layer metadata classes THEN version is 1.1 for ADR-029."""
+    for cls in [BronzeMetadata, SilverMetadata, GoldMetadata]:
+        field_info = cls.model_fields["version"]
+        assert (
+            field_info.default == "1.1"
+        ), f"{cls.__name__}.version should default to '1.1' for ADR-029"
+
+
+def test_base_output_forbids_extra_fields() -> None:
+    """GIVEN BaseOutputMetadata THEN extra fields are forbidden."""
+    config = BaseOutputMetadata.model_config
+    assert config.get("extra") == "forbid", "BaseOutputMetadata should forbid extra fields"

--- a/tests/unit/application/services/test_metadata_coordinator.py
+++ b/tests/unit/application/services/test_metadata_coordinator.py
@@ -169,7 +169,7 @@ class TestBronzeMetadata:
 
         assert isinstance(metadata, BronzeMetadata)
         assert metadata.layer == LayerType.BRONZE
-        assert metadata.version == "1.0"
+        assert metadata.version == "1.1"  # ADR-029 version bump
 
     def test_bronze_runtime_metadata(self, coordinator: MetadataCoordinator) -> None:
         """Test Bronze runtime metadata contains correct values."""
@@ -211,23 +211,31 @@ class TestBronzeMetadata:
         assert metadata.pipeline.entity == "activity"
 
     def test_bronze_output_metadata(self, coordinator: MetadataCoordinator) -> None:
-        """Test Bronze output metadata contains file info."""
+        """Test Bronze output metadata contains file info (ADR-029 unified structure)."""
+        started_at = datetime.now(UTC)
+        completed_at = started_at
+
         input_data = BronzeMetadataInput(
             batch_id=BatchID(uuid4()),
             record_count=500,
             compressed_size=25000,
             output_path="v1/chembl/activity/2024-01-15/batch_abc.jsonl.zst",
-            started_at=datetime.now(UTC),
-            completed_at=datetime.now(UTC),
+            started_at=started_at,
+            completed_at=completed_at,
         )
 
         metadata = coordinator.create_bronze_metadata(input_data)
 
-        assert metadata.output.total_records == 500
+        # Unified output (ADR-029)
+        assert metadata.output.record_count == 500
         assert metadata.output.total_bytes == 25000
-        assert len(metadata.output.files) == 1
-        assert metadata.output.files[0].path == input_data.output_path
-        assert metadata.output.files[0].record_count == 500
+        assert metadata.output.write_started_at == started_at
+        assert metadata.output.write_completed_at == completed_at
+
+        # Bronze-specific extension
+        assert len(metadata.output_ext.files) == 1
+        assert metadata.output_ext.files[0].path == input_data.output_path
+        assert metadata.output_ext.files[0].record_count == 500
 
     def test_bronze_metadata_includes_query_string_from_input(
         self, coordinator: MetadataCoordinator
@@ -379,7 +387,7 @@ class TestSilverMetadata:
 
         assert isinstance(metadata, SilverMetadata)
         assert metadata.layer == LayerType.SILVER
-        assert metadata.version == "1.0"
+        assert metadata.version == "1.1"  # ADR-029 version bump
 
     def test_silver_with_empty_records_raises(
         self, coordinator: MetadataCoordinator
@@ -497,7 +505,7 @@ class TestGoldMetadata:
 
         assert isinstance(metadata, GoldMetadata)
         assert metadata.layer == LayerType.GOLD
-        assert metadata.version == "1.0"
+        assert metadata.version == "1.1"  # ADR-029 version bump
 
     def test_gold_with_empty_records_raises(
         self, coordinator: MetadataCoordinator

--- a/tests/unit/domain/models/test_metadata_output.py
+++ b/tests/unit/domain/models/test_metadata_output.py
@@ -1,0 +1,480 @@
+"""Unit tests for unified output metadata classes (ADR-029).
+
+Tests BaseOutputMetadata and layer-specific output extensions.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pydantic import ValidationError
+
+from bioetl.domain.models.metadata import (
+    BaseOutputMetadata,
+    BronzeMetadata,
+    BronzeOutputExt,
+    EnvironmentMetadata,
+    FileOutputMetadata,
+    GoldMetadata,
+    GoldOutputExt,
+    OutputMetadata,
+    PipelineMetadata,
+    RuntimeMetadata,
+    RunTypeEnum,
+    SilverMetadata,
+    SilverOutputExt,
+    DeltaMetrics,
+)
+
+
+class TestBaseOutputMetadata:
+    """Test base output metadata contract."""
+
+    def test_default_values(self) -> None:
+        """GIVEN no arguments WHEN creating BaseOutputMetadata THEN defaults applied."""
+        output = BaseOutputMetadata()
+
+        assert output.record_count == 0
+        assert output.total_bytes == 0
+        assert output.content_hash is None
+        assert output.write_started_at is None
+        assert output.write_completed_at is None
+        assert output.write_duration_ms is None
+
+    def test_with_all_fields(self) -> None:
+        """GIVEN all fields WHEN creating BaseOutputMetadata THEN all stored."""
+        started = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+        completed = datetime(2025, 1, 1, 12, 0, 5, 500000, tzinfo=UTC)
+
+        output = BaseOutputMetadata(
+            record_count=1000,
+            total_bytes=50000,
+            content_hash="sha256:abc123",
+            write_started_at=started,
+            write_completed_at=completed,
+        )
+
+        assert output.record_count == 1000
+        assert output.total_bytes == 50000
+        assert output.content_hash == "sha256:abc123"
+        assert output.write_started_at == started
+        assert output.write_completed_at == completed
+
+    def test_write_duration_calculation(self) -> None:
+        """GIVEN started and completed timestamps WHEN accessing write_duration_ms THEN returns correct duration."""
+        started = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+        completed = datetime(2025, 1, 1, 12, 0, 5, 500000, tzinfo=UTC)  # 5.5 seconds
+
+        output = BaseOutputMetadata(
+            record_count=100,
+            total_bytes=1024,
+            write_started_at=started,
+            write_completed_at=completed,
+        )
+
+        assert output.write_duration_ms == 5500
+
+    def test_write_duration_none_when_missing_started(self) -> None:
+        """GIVEN missing started_at WHEN accessing write_duration_ms THEN returns None."""
+        output = BaseOutputMetadata(
+            record_count=100,
+            write_completed_at=datetime.now(UTC),
+        )
+        assert output.write_duration_ms is None
+
+    def test_write_duration_none_when_missing_completed(self) -> None:
+        """GIVEN missing completed_at WHEN accessing write_duration_ms THEN returns None."""
+        output = BaseOutputMetadata(
+            record_count=100,
+            write_started_at=datetime.now(UTC),
+        )
+        assert output.write_duration_ms is None
+
+    def test_write_duration_none_when_both_missing(self) -> None:
+        """GIVEN missing timestamps WHEN accessing write_duration_ms THEN returns None."""
+        output = BaseOutputMetadata(record_count=100, total_bytes=1024)
+        assert output.write_duration_ms is None
+
+    def test_negative_record_count_rejected(self) -> None:
+        """GIVEN negative record_count WHEN creating THEN validation error."""
+        with pytest.raises(ValidationError):
+            BaseOutputMetadata(record_count=-1)
+
+    def test_negative_total_bytes_rejected(self) -> None:
+        """GIVEN negative total_bytes WHEN creating THEN validation error."""
+        with pytest.raises(ValidationError):
+            BaseOutputMetadata(total_bytes=-1)
+
+    def test_extra_fields_forbidden(self) -> None:
+        """GIVEN extra field WHEN creating THEN validation error (extra=forbid)."""
+        with pytest.raises(ValidationError):
+            BaseOutputMetadata(unknown_field="value")  # type: ignore[call-arg]
+
+
+class TestBronzeOutputExt:
+    """Test Bronze-specific output extension."""
+
+    def test_default_values(self) -> None:
+        """GIVEN no arguments WHEN creating BronzeOutputExt THEN defaults applied."""
+        ext = BronzeOutputExt()
+
+        assert ext.files == []
+        assert ext.format == "jsonl+zstd"
+        assert ext.compression == "zstd"
+
+    def test_with_files(self) -> None:
+        """GIVEN file list WHEN creating BronzeOutputExt THEN files stored."""
+        files = [
+            FileOutputMetadata(
+                path="batch_001.jsonl.zst",
+                size_bytes=10000,
+                record_count=100,
+            ),
+            FileOutputMetadata(
+                path="batch_002.jsonl.zst",
+                size_bytes=15000,
+                record_count=150,
+            ),
+        ]
+
+        ext = BronzeOutputExt(files=files)
+
+        assert len(ext.files) == 2
+        assert ext.files[0].path == "batch_001.jsonl.zst"
+        assert ext.files[1].record_count == 150
+
+    def test_custom_format(self) -> None:
+        """GIVEN custom format WHEN creating BronzeOutputExt THEN format stored."""
+        ext = BronzeOutputExt(format="jsonl", compression="gzip")
+
+        assert ext.format == "jsonl"
+        assert ext.compression == "gzip"
+
+
+class TestSilverOutputExt:
+    """Test Silver-specific output extension."""
+
+    def test_default_values(self) -> None:
+        """GIVEN no arguments WHEN creating SilverOutputExt THEN defaults applied."""
+        ext = SilverOutputExt()
+
+        assert ext.delta_version_before is None
+        assert ext.delta_version_after is None
+
+    def test_with_delta_versions(self) -> None:
+        """GIVEN delta versions WHEN creating SilverOutputExt THEN both tracked."""
+        ext = SilverOutputExt(delta_version_before=5, delta_version_after=6)
+
+        assert ext.delta_version_before == 5
+        assert ext.delta_version_after == 6
+        assert ext.delta_version_after - ext.delta_version_before == 1
+
+    def test_only_version_after(self) -> None:
+        """GIVEN only version_after WHEN creating SilverOutputExt THEN valid."""
+        ext = SilverOutputExt(delta_version_after=10)
+
+        assert ext.delta_version_before is None
+        assert ext.delta_version_after == 10
+
+
+class TestGoldOutputExt:
+    """Test Gold-specific output extension."""
+
+    def test_default_values(self) -> None:
+        """GIVEN no arguments WHEN creating GoldOutputExt THEN defaults applied."""
+        ext = GoldOutputExt()
+
+        assert ext.partition_count == 0
+        assert ext.format == "delta"
+
+    def test_with_partition_count(self) -> None:
+        """GIVEN partition count WHEN creating GoldOutputExt THEN stored."""
+        ext = GoldOutputExt(partition_count=4)
+
+        assert ext.partition_count == 4
+
+    def test_parquet_format(self) -> None:
+        """GIVEN parquet format WHEN creating GoldOutputExt THEN valid."""
+        ext = GoldOutputExt(format="parquet")
+
+        assert ext.format == "parquet"
+
+    def test_invalid_format_rejected(self) -> None:
+        """GIVEN invalid format WHEN creating GoldOutputExt THEN validation error."""
+        with pytest.raises(ValidationError):
+            GoldOutputExt(format="csv")  # type: ignore[arg-type]
+
+    def test_negative_partition_count_rejected(self) -> None:
+        """GIVEN negative partition_count WHEN creating THEN validation error."""
+        with pytest.raises(ValidationError):
+            GoldOutputExt(partition_count=-1)
+
+
+class TestLayerMetadataComposition:
+    """Test layer metadata classes with output composition."""
+
+    @pytest.fixture
+    def runtime(self) -> RuntimeMetadata:
+        """Create test RuntimeMetadata."""
+        return RuntimeMetadata(
+            run_id="test-run-123",
+            run_type=RunTypeEnum.INCREMENTAL,
+            started_at_utc=datetime.now(UTC),
+        )
+
+    @pytest.fixture
+    def pipeline(self) -> PipelineMetadata:
+        """Create test PipelineMetadata."""
+        return PipelineMetadata(
+            name="test_pipeline",
+            provider="test",
+            entity="activity",
+        )
+
+    @pytest.fixture
+    def environment(self) -> EnvironmentMetadata:
+        """Create test EnvironmentMetadata."""
+        return EnvironmentMetadata(
+            hostname="test-host",
+            python_version="3.11.0",
+            bioetl_version="5.10.0",
+        )
+
+    def test_bronze_metadata_has_unified_output(
+        self,
+        runtime: RuntimeMetadata,
+        pipeline: PipelineMetadata,
+        environment: EnvironmentMetadata,
+    ) -> None:
+        """GIVEN BronzeMetadata WHEN accessing output THEN BaseOutputMetadata returned."""
+        metadata = BronzeMetadata(
+            runtime=runtime,
+            pipeline=pipeline,
+            environment=environment,
+        )
+
+        assert isinstance(metadata.output, BaseOutputMetadata)
+        assert isinstance(metadata.output_ext, BronzeOutputExt)
+
+    def test_bronze_metadata_output_fields(
+        self,
+        runtime: RuntimeMetadata,
+        pipeline: PipelineMetadata,
+        environment: EnvironmentMetadata,
+    ) -> None:
+        """GIVEN BronzeMetadata with output data THEN fields accessible."""
+        started = datetime.now(UTC)
+        completed = started + timedelta(seconds=5)
+
+        metadata = BronzeMetadata(
+            runtime=runtime,
+            pipeline=pipeline,
+            environment=environment,
+            output=BaseOutputMetadata(
+                record_count=1000,
+                total_bytes=50000,
+                write_started_at=started,
+                write_completed_at=completed,
+            ),
+            output_ext=BronzeOutputExt(
+                files=[
+                    FileOutputMetadata(
+                        path="batch_001.jsonl.zst",
+                        size_bytes=50000,
+                        record_count=1000,
+                    )
+                ],
+            ),
+        )
+
+        assert metadata.output.record_count == 1000
+        assert metadata.output.total_bytes == 50000
+        assert metadata.output.write_duration_ms == 5000
+        assert len(metadata.output_ext.files) == 1
+        assert metadata.output_ext.format == "jsonl+zstd"
+
+    def test_silver_metadata_has_unified_output(
+        self,
+        runtime: RuntimeMetadata,
+        pipeline: PipelineMetadata,
+        environment: EnvironmentMetadata,
+    ) -> None:
+        """GIVEN SilverMetadata WHEN accessing output THEN BaseOutputMetadata returned."""
+        metadata = SilverMetadata(
+            runtime=runtime,
+            pipeline=pipeline,
+            delta=DeltaMetrics(table_path="/silver/test", operation="merge"),
+            environment=environment,
+        )
+
+        assert isinstance(metadata.output, BaseOutputMetadata)
+        assert isinstance(metadata.output_ext, SilverOutputExt)
+
+    def test_silver_metadata_output_fields(
+        self,
+        runtime: RuntimeMetadata,
+        pipeline: PipelineMetadata,
+        environment: EnvironmentMetadata,
+    ) -> None:
+        """GIVEN SilverMetadata with output data THEN fields accessible."""
+        metadata = SilverMetadata(
+            runtime=runtime,
+            pipeline=pipeline,
+            delta=DeltaMetrics(table_path="/silver/test", operation="merge"),
+            environment=environment,
+            output=BaseOutputMetadata(
+                record_count=950,
+                total_bytes=48000,
+                content_hash="sha256:abc123",
+            ),
+            output_ext=SilverOutputExt(
+                delta_version_before=5,
+                delta_version_after=6,
+            ),
+        )
+
+        assert metadata.output.record_count == 950
+        assert metadata.output.total_bytes == 48000
+        assert metadata.output.content_hash == "sha256:abc123"
+        assert metadata.output_ext.delta_version_before == 5
+        assert metadata.output_ext.delta_version_after == 6
+
+    def test_gold_metadata_has_unified_output(
+        self,
+        runtime: RuntimeMetadata,
+        pipeline: PipelineMetadata,
+        environment: EnvironmentMetadata,
+    ) -> None:
+        """GIVEN GoldMetadata WHEN accessing output THEN BaseOutputMetadata returned."""
+        metadata = GoldMetadata(
+            runtime=runtime,
+            pipeline=pipeline,
+            environment=environment,
+        )
+
+        assert isinstance(metadata.output, BaseOutputMetadata)
+        assert isinstance(metadata.output_ext, GoldOutputExt)
+
+    def test_gold_metadata_output_fields(
+        self,
+        runtime: RuntimeMetadata,
+        pipeline: PipelineMetadata,
+        environment: EnvironmentMetadata,
+    ) -> None:
+        """GIVEN GoldMetadata with output data THEN fields accessible."""
+        metadata = GoldMetadata(
+            runtime=runtime,
+            pipeline=pipeline,
+            environment=environment,
+            output=BaseOutputMetadata(
+                record_count=900,
+                total_bytes=45000,
+            ),
+            output_ext=GoldOutputExt(
+                partition_count=4,
+                format="delta",
+            ),
+        )
+
+        assert metadata.output.record_count == 900
+        assert metadata.output.total_bytes == 45000
+        assert metadata.output_ext.partition_count == 4
+        assert metadata.output_ext.format == "delta"
+
+
+class TestDeprecatedOutputMetadata:
+    """Test deprecated output metadata classes emit warnings."""
+
+    def test_output_metadata_deprecated(self) -> None:
+        """GIVEN OutputMetadata usage WHEN creating THEN deprecation warning raised."""
+        with pytest.warns(DeprecationWarning, match="OutputMetadata is deprecated"):
+            OutputMetadata(total_records=100, total_bytes=5000)
+
+    def test_deprecated_output_metadata_still_works(self) -> None:
+        """GIVEN OutputMetadata WHEN using THEN still functional during deprecation period."""
+        with pytest.warns(DeprecationWarning):
+            output = OutputMetadata(
+                total_records=100,
+                total_bytes=5000,
+                format="jsonl+zstd",
+            )
+
+        # Legacy fields still work (deprecated class maintains old API)
+        assert output.total_records == 100
+        assert output.total_bytes == 5000
+        assert output.format == "jsonl+zstd"
+
+
+class TestMetadataVersionBump:
+    """Test metadata version is updated for ADR-029."""
+
+    @pytest.fixture
+    def runtime(self) -> RuntimeMetadata:
+        """Create test RuntimeMetadata."""
+        return RuntimeMetadata(
+            run_id="test-run-123",
+            run_type=RunTypeEnum.INCREMENTAL,
+            started_at_utc=datetime.now(UTC),
+        )
+
+    @pytest.fixture
+    def pipeline(self) -> PipelineMetadata:
+        """Create test PipelineMetadata."""
+        return PipelineMetadata(
+            name="test_pipeline",
+            provider="test",
+            entity="activity",
+        )
+
+    @pytest.fixture
+    def environment(self) -> EnvironmentMetadata:
+        """Create test EnvironmentMetadata."""
+        return EnvironmentMetadata(
+            hostname="test-host",
+            python_version="3.11.0",
+            bioetl_version="5.10.0",
+        )
+
+    def test_bronze_metadata_version(
+        self,
+        runtime: RuntimeMetadata,
+        pipeline: PipelineMetadata,
+        environment: EnvironmentMetadata,
+    ) -> None:
+        """GIVEN BronzeMetadata WHEN checking version THEN 1.1 for ADR-029."""
+        metadata = BronzeMetadata(
+            runtime=runtime,
+            pipeline=pipeline,
+            environment=environment,
+        )
+        assert metadata.version == "1.1"
+
+    def test_silver_metadata_version(
+        self,
+        runtime: RuntimeMetadata,
+        pipeline: PipelineMetadata,
+        environment: EnvironmentMetadata,
+    ) -> None:
+        """GIVEN SilverMetadata WHEN checking version THEN 1.1 for ADR-029."""
+        metadata = SilverMetadata(
+            runtime=runtime,
+            pipeline=pipeline,
+            delta=DeltaMetrics(table_path="/silver/test", operation="merge"),
+            environment=environment,
+        )
+        assert metadata.version == "1.1"
+
+    def test_gold_metadata_version(
+        self,
+        runtime: RuntimeMetadata,
+        pipeline: PipelineMetadata,
+        environment: EnvironmentMetadata,
+    ) -> None:
+        """GIVEN GoldMetadata WHEN checking version THEN 1.1 for ADR-029."""
+        metadata = GoldMetadata(
+            runtime=runtime,
+            pipeline=pipeline,
+            environment=environment,
+        )
+        assert metadata.version == "1.1"

--- a/tests/unit/infrastructure/storage/test_bronze_writer.py
+++ b/tests/unit/infrastructure/storage/test_bronze_writer.py
@@ -2141,7 +2141,7 @@ class TestBronzeWriterMetadataSidecar:
         assert metadata.runtime.run_id == str(run_id)
         assert metadata.pipeline.provider == "chembl"
         assert metadata.pipeline.entity == "activity"
-        assert metadata.output.total_records == len(sample_records)
+        assert metadata.output.record_count == len(sample_records)
 
     @pytest.mark.asyncio
     async def test_metadata_writer_not_called_when_save_metadata_disabled(
@@ -2262,12 +2262,16 @@ class TestBronzeWriterMetadataSidecar:
         assert metadata.pipeline.provider == "chembl"
         assert metadata.pipeline.entity == "activity"
 
-        # Verify output metadata
-        assert metadata.output.total_records == 100
+        # Verify output metadata (ADR-029 unified structure)
+        assert metadata.output.record_count == 100
         assert metadata.output.total_bytes == 5000
-        assert len(metadata.output.files) == 1
-        assert metadata.output.files[0].record_count == 100
-        assert metadata.output.files[0].size_bytes == 5000
+        assert metadata.output.write_started_at == ingestion_ts
+        assert metadata.output.write_completed_at == ingestion_ts
+
+        # Verify Bronze-specific output extension
+        assert len(metadata.output_ext.files) == 1
+        assert metadata.output_ext.files[0].record_count == 100
+        assert metadata.output_ext.files[0].size_bytes == 5000
 
         # Verify environment metadata exists
         assert metadata.environment.hostname is not None

--- a/tests/unit/infrastructure/storage/test_metadata_integration.py
+++ b/tests/unit/infrastructure/storage/test_metadata_integration.py
@@ -61,7 +61,7 @@ class MockMetadataCoordinator:
 
     def create_gold_metadata(self, input_data: Any) -> GoldMetadata:
         """Create minimal GoldMetadata for testing."""
-        from bioetl.domain.models.metadata import GoldOutputMetadata
+        from bioetl.domain.models.metadata import BaseOutputMetadata, GoldOutputExt
 
         runtime = RuntimeMetadata(
             run_id="test-run-id",
@@ -72,15 +72,15 @@ class MockMetadataCoordinator:
         environment = EnvironmentMetadata(
             hostname="test", python_version="3.11", bioetl_version="1.0"
         )
-        output = GoldOutputMetadata(
-            table_path=str(input_data.table_path),
+        output = BaseOutputMetadata(
             record_count=len(input_data.records),
-            operation="overwrite",
         )
+        output_ext = GoldOutputExt()
         return GoldMetadata(
             runtime=runtime,
             pipeline=pipeline,
             output=output,
+            output_ext=output_ext,
             environment=environment,
         )
 

--- a/tests/unit/infrastructure/storage/test_metadata_writer.py
+++ b/tests/unit/infrastructure/storage/test_metadata_writer.py
@@ -10,22 +10,23 @@ import pytest
 import yaml
 
 from bioetl.domain.models.metadata import (
+    BaseOutputMetadata,
     BronzeMetadata,
+    BronzeOutputExt,
     DeltaMetrics,
     DQSummary,
     EnvironmentMetadata,
     FileOutputMetadata,
     GoldMetadata,
-    GoldOutputMetadata,
+    GoldOutputExt,
     LayerType,
     LineageMetadata,
-    OutputMetadata,
     PipelineMetadata,
     RuntimeMetadata,
     RunTypeEnum,
     SchemaMetadata,
     SilverMetadata,
-    SilverOutputMetadata,
+    SilverOutputExt,
     SourceMetadata,
 )
 from bioetl.domain.ports.noop import NoOpMetadataWriter
@@ -91,7 +92,7 @@ def bronze_metadata(
 ) -> BronzeMetadata:
     """Create sample Bronze metadata."""
     return BronzeMetadata(
-        version="1.0",
+        version="1.1",
         layer=LayerType.BRONZE,
         runtime=runtime_metadata,
         pipeline=pipeline_metadata,
@@ -100,7 +101,11 @@ def bronze_metadata(
             url="https://www.ebi.ac.uk/chembl/api/data/activity",
             api_version="33",
         ),
-        output=OutputMetadata(
+        output=BaseOutputMetadata(
+            record_count=10000,
+            total_bytes=1048576,
+        ),
+        output_ext=BronzeOutputExt(
             files=[
                 FileOutputMetadata(
                     path="batch_001.jsonl.zst",
@@ -109,8 +114,6 @@ def bronze_metadata(
                     checksum_blake2="abc123",
                 ),
             ],
-            total_records=10000,
-            total_bytes=1048576,
             format="jsonl+zstd",
             compression="zstd",
         ),
@@ -126,7 +129,7 @@ def silver_metadata(
 ) -> SilverMetadata:
     """Create sample Silver metadata."""
     return SilverMetadata(
-        version="1.0",
+        version="1.1",
         layer=LayerType.SILVER,
         runtime=runtime_metadata,
         pipeline=pipeline_metadata,
@@ -151,9 +154,13 @@ def silver_metadata(
             error_records=750,
             error_rate=0.05,
         ),
-        output=SilverOutputMetadata(
+        output=BaseOutputMetadata(
             record_count=14250,
             content_hash="sha256:abc123",
+        ),
+        output_ext=SilverOutputExt(
+            delta_version_before=42,
+            delta_version_after=43,
         ),
         environment=environment_metadata,
     )
@@ -167,7 +174,7 @@ def gold_metadata(
 ) -> GoldMetadata:
     """Create sample Gold metadata."""
     return GoldMetadata(
-        version="1.0",
+        version="1.1",
         layer=LayerType.GOLD,
         runtime=runtime_metadata,
         pipeline=pipeline_metadata,
@@ -184,10 +191,12 @@ def gold_metadata(
             valid_records=1250,
             validation_passed=True,
         ),
-        output=GoldOutputMetadata(
+        output=BaseOutputMetadata(
             record_count=1250,
-            partition_count=50,
             total_bytes=10485760,
+        ),
+        output_ext=GoldOutputExt(
+            partition_count=50,
             format="delta",
         ),
         environment=environment_metadata,
@@ -231,12 +240,12 @@ class TestMetadataWriter:
         metadata_path = base_path / METADATA_FILENAME
         content = yaml.safe_load(metadata_path.read_text())
 
-        assert content["version"] == "1.0"
+        assert content["version"] == "1.1"  # ADR-029 version bump
         assert content["layer"] == "bronze"
         assert content["pipeline"]["name"] == "chembl_activity"
         assert content["pipeline"]["provider"] == "chembl"
         assert content["source"]["type"] == "api"
-        assert content["output"]["total_records"] == 10000
+        assert content["output"]["record_count"] == 10000  # ADR-029: unified field name
 
     @pytest.mark.asyncio
     async def test_write_silver_metadata_creates_file(
@@ -454,7 +463,7 @@ class TestMetadataModels:
         """Test Bronze metadata can be serialized to dict."""
         data = bronze_metadata.model_dump(mode="json")
 
-        assert data["version"] == "1.0"
+        assert data["version"] == "1.1"  # ADR-029 version bump
         assert data["layer"] == "bronze"
         assert data["runtime"]["run_type"] == "incremental"
         assert "started_at_utc" in data["runtime"]
@@ -466,7 +475,7 @@ class TestMetadataModels:
         """Test Silver metadata can be serialized to dict."""
         data = silver_metadata.model_dump(mode="json")
 
-        assert data["version"] == "1.0"
+        assert data["version"] == "1.1"  # ADR-029 version bump
         assert data["layer"] == "silver"
         assert "lineage" in data
         assert "delta" in data
@@ -479,7 +488,7 @@ class TestMetadataModels:
         """Test Gold metadata can be serialized to dict."""
         data = gold_metadata.model_dump(mode="json", by_alias=True)
 
-        assert data["version"] == "1.0"
+        assert data["version"] == "1.1"  # ADR-029 version bump
         assert data["layer"] == "gold"
         assert "schema" in data  # Uses alias
         assert "dq_summary" in data

--- a/tests/unit/infrastructure/storage/test_silver_writer.py
+++ b/tests/unit/infrastructure/storage/test_silver_writer.py
@@ -45,6 +45,7 @@ def mock_metadata_coordinator():
     from datetime import UTC, datetime
 
     from bioetl.domain.models.metadata import (
+        BaseOutputMetadata,
         DeltaMetrics,
         DQSummary,
         EnvironmentMetadata,
@@ -53,7 +54,7 @@ def mock_metadata_coordinator():
         RuntimeMetadata,
         RunTypeEnum,
         SilverMetadata,
-        SilverOutputMetadata,
+        SilverOutputExt,
     )
     from bioetl.domain.ports import SilverMetadataInput
 
@@ -101,7 +102,10 @@ def mock_metadata_coordinator():
                 total_records=len(input_data.records),
                 valid_records=len(input_data.records),
             ),
-            output=SilverOutputMetadata(record_count=len(input_data.records)),
+            output=BaseOutputMetadata(record_count=len(input_data.records)),
+            output_ext=SilverOutputExt(
+                delta_version_after=input_data.version_after,
+            ),
             environment=EnvironmentMetadata(
                 hostname="test-host",
                 python_version="3.11.0",


### PR DESCRIPTION
## Summary

Implements ADR-029 to unify output metadata structure across Bronze, Silver, and Gold layers. Replaces layer-specific output metadata classes with a common `BaseOutputMetadata` contract plus layer-specific extensions, improving consistency for downstream analytics and monitoring.

## Key Changes

- **New unified metadata structure**: Introduces `BaseOutputMetadata` with common fields (`record_count`, `total_bytes`, `content_hash`, `write_started_at`, `write_completed_at`) and computed `write_duration_ms` property
- **Layer-specific extensions**: 
  - `BronzeOutputExt`: tracks files, format, compression
  - `SilverOutputExt`: tracks delta versions before/after
  - `GoldOutputExt`: tracks partition count and format
- **Metadata schema version bump**: Updated from `1.0` to `1.1` across all layer metadata classes
- **Backward compatibility**: Deprecated old classes (`OutputMetadata`, `SilverOutputMetadata`, `GoldOutputMetadata`) with warnings; will be removed in v6.0
- **Updated all metadata builders**: Modified `MetadataCoordinator`, `BronzeWriter`, and `MetadataBuilder` to use new unified structure
- **Architecture tests**: Added contract validation tests to ensure all layers follow the unified pattern

## Implementation Details

- All layer metadata now uses composition: `output: BaseOutputMetadata` + `output_ext: LayerSpecificExt`
- `BaseOutputMetadata` enforces `extra="forbid"` for type safety
- Timestamps (`write_started_at`, `write_completed_at`) now tracked consistently across all layers
- Silver layer now includes `total_bytes` field (previously missing)
- Gold layer now includes `started_at` field (previously missing)
- Deprecation warnings guide users to new structure

## Breaking Changes

- Existing code accessing `output.total_records` (Bronze) must change to `output.record_count`
- Existing sidecar files (v1.0) are not compatible with v1.1 schema
- Layer-specific output fields moved to `output_ext` (e.g., `output.files` → `output_ext.files`)

## Testing

- Updated existing unit tests to use new unified structure
- Added architecture tests validating contract compliance across all layers
- All metadata coordinator tests updated for v1.1 schema