### PR TITLE
Rename PipelineExecutor to BatchExecutor and DeltaWriter to SilverWriter

### DIFF
--- a/docs/04-reference/api/application.md
+++ b/docs/04-reference/api/application.md
@@ -9,7 +9,7 @@ flowchart TB
     subgraph Application["Application Layer"]
         subgraph Core["Core"]
             Runner[PipelineRunner]
-            Executor[PipelineExecutor]
+            Executor[BatchExecutor]
             Services[PipelineServices]
         end
 
@@ -49,7 +49,7 @@ flowchart TB
 Pipeline execution infrastructure:
 
 - `PipelineRunner` - Lifecycle orchestrator for pipeline execution
-- `PipelineExecutor` - Data flow orchestrator (fetch → transform → write)
+- `BatchExecutor` - Data flow orchestrator (fetch → transform → write)
 - `PipelineServices` - Service bundle for dependency injection
 - `CheckpointManager` - Checkpoint persistence for resume capability
 - `LockManager` - Distributed locking coordination
@@ -117,7 +117,7 @@ PipelineRunner delegates to specialized services:
 | Service | Responsibility |
 |---------|---------------|
 | `PreflightService` | Health checks, lock acquisition |
-| `PipelineExecutor` | Data flow orchestration |
+| `BatchExecutor` | Data flow orchestration |
 | `PostrunService` | DQ validation, VACUUM |
 | `MedallionLifecycleService` | Layer clearing policies |
 

--- a/docs/04-reference/api/composition/factories.md
+++ b/docs/04-reference/api/composition/factories.md
@@ -235,7 +235,7 @@ Factory for PubMed publication pipeline.
 classDiagram
     class GenericPipelineFactory {
         +create_runner() PipelineRunner
-        +create_executor() PipelineExecutor
+        +create_executor() BatchExecutor
     }
 
     class DataSourceFactory {

--- a/docs/04-reference/api/domain.md
+++ b/docs/04-reference/api/domain.md
@@ -34,7 +34,7 @@ classDiagram
         +histogram()
     }
 
-    StoragePort <|.. DeltaWriter
+    StoragePort <|.. SilverWriter
     DataSourcePort <|.. ChemblAdapter
     LockPort <|.. MemoryLock
 ```
@@ -103,10 +103,10 @@ class StoragePort(Protocol):
 Infrastructure provides **Adapters** that implement these ports:
 
 ```python
-from bioetl.infrastructure.storage.delta_writer import DeltaWriter
+from bioetl.infrastructure.storage.silver_writer import SilverWriter
 
-# DeltaWriter implements StoragePort
-writer: StoragePort = DeltaWriter(...)
+# SilverWriter implements StoragePort
+writer: StoragePort = SilverWriter(...)
 ```
 
 ### Content Hash

--- a/docs/04-reference/api/index.md
+++ b/docs/04-reference/api/index.md
@@ -19,7 +19,7 @@ flowchart TB
 
     subgraph Application["Application Layer"]
         Runner[PipelineRunner]
-        Executor[PipelineExecutor]
+        Executor[BatchExecutor]
         Transformer[BaseTransformer]
     end
 
@@ -69,7 +69,7 @@ Pipeline orchestration and use cases:
 External system adapters and I/O:
 
 - **[Adapters](infrastructure/adapters.md)** - ChEMBL, PubChem, UniProt clients
-- **[Storage](infrastructure/storage.md)** - BronzeWriter, DeltaWriter, GoldWriter
+- **[Storage](infrastructure/storage.md)** - BronzeWriter, SilverWriter, GoldWriter
 - **[Observability](infrastructure/observability.md)** - Logging, Metrics, Tracing
 
 ### [Composition Layer](composition.md)
@@ -88,7 +88,7 @@ Dependency injection and bootstrapping:
 | `BaseTransformer` | `bioetl.application.core.base_transformer` | Template Method for data transformation |
 | `StoragePort` | `bioetl.domain.ports` | Storage interface contract |
 | `DataSourcePort` | `bioetl.domain.ports` | Data fetching interface contract |
-| `DeltaWriter` | `bioetl.infrastructure.storage.delta_writer` | Silver layer Delta Lake writer |
+| `SilverWriter` | `bioetl.infrastructure.storage.silver_writer` | Silver layer Delta Lake writer |
 | `BronzeWriter` | `bioetl.infrastructure.storage.bronze_writer` | Bronze layer JSONL writer |
 
 ## Usage Example


### PR DESCRIPTION
## Summary
This PR updates documentation and references to reflect naming changes in the codebase, renaming `PipelineExecutor` to `BatchExecutor` and `DeltaWriter` to `SilverWriter` for improved clarity and consistency with the medallion architecture.

## Key Changes

- **Renamed `PipelineExecutor` → `BatchExecutor`**: Updated all documentation references to reflect the new class name that better describes its role in orchestrating batch data flow (extraction → transformation → writing)
  - Updated module path from `bioetl.application.core.executor` to `bioetl.application.core.batch_executor`
  - Updated documented members to reflect the new API (`execute_batch` instead of `batch_size` and `checkpoint_interval`)

- **Renamed `DeltaWriter` → `SilverWriter`**: Updated all documentation references to align with the medallion architecture terminology
  - Updated module path from `bioetl.infrastructure.storage.delta_writer` to `bioetl.infrastructure.storage.silver_writer`
  - Updated example code and class diagrams to use the new name

- **Updated documentation across multiple files**:
  - `docs/04-reference/api/application.md` - Architecture diagrams and service descriptions
  - `docs/04-reference/api/application/core.md` - Core component documentation
  - `docs/04-reference/api/composition/factories.md` - Factory method signatures
  - `docs/04-reference/api/domain.md` - Port implementations and examples
  - `docs/04-reference/api/index.md` - Index and quick reference tables

## Implementation Details

All changes are documentation-only updates to maintain consistency with the actual codebase implementation. The renaming improves semantic clarity:
- `BatchExecutor` explicitly indicates it handles batch processing workflows
- `SilverWriter` aligns with the medallion architecture (Bronze → Silver → Gold layers)