### PR TITLE
Add CrossRef metadata extractors for content domain, ISSN, and publication date

### DIFF
--- a/src/bioetl/application/pipelines/crossref/__init__.py
+++ b/src/bioetl/application/pipelines/crossref/__init__.py
@@ -5,10 +5,13 @@ Transformers and utilities for CrossRef data processing.
 
 from bioetl.application.pipelines.crossref.extractors import (
     extract_authors,
+    extract_content_domain,
     extract_dates,
+    extract_issn_by_type,
     extract_journal_info,
     extract_license_url,
     extract_page_info,
+    extract_published_date,
     extract_year,
 )
 from bioetl.application.pipelines.crossref.transformer import (
@@ -18,9 +21,12 @@ from bioetl.application.pipelines.crossref.transformer import (
 __all__ = [
     "CrossRefPublicationTransformer",
     "extract_authors",
+    "extract_content_domain",
     "extract_dates",
+    "extract_issn_by_type",
     "extract_journal_info",
     "extract_license_url",
     "extract_page_info",
+    "extract_published_date",
     "extract_year",
 ]

--- a/src/bioetl/application/pipelines/crossref/extractors.py
+++ b/src/bioetl/application/pipelines/crossref/extractors.py
@@ -229,3 +229,113 @@ def extract_dates(publication: dict[str, Any]) -> dict[str, Any]:
             else None
         ),
     }
+
+
+def extract_content_domain(publication: dict[str, Any]) -> dict[str, Any]:
+    """Extract content-domain metadata.
+
+    CrossRef content-domain indicates licensing/access restrictions
+    and Crossmark participation.
+
+    Args:
+        publication: CrossRef publication record.
+
+    Returns:
+        Dictionary with content_domain_domains, content_domain_crossmark_restriction.
+
+    Example:
+        >>> extract_content_domain({
+        ...     "content-domain": {"domain": ["nature.com"], "crossmark-restriction": True}
+        ... })
+        {'content_domain_domains': ['nature.com'], 'content_domain_crossmark_restriction': True}
+        >>> extract_content_domain({})
+        {'content_domain_domains': [], 'content_domain_crossmark_restriction': None}
+
+    """
+    content_domain = publication.get("content-domain", {})
+    if not isinstance(content_domain, dict):
+        content_domain = {}
+
+    return {
+        "content_domain_domains": content_domain.get("domain", []) or [],
+        "content_domain_crossmark_restriction": content_domain.get(
+            "crossmark-restriction"
+        ),
+    }
+
+
+def extract_issn_by_type(publication: dict[str, Any]) -> dict[str, Any]:
+    """Extract ISSN values by type (print/electronic).
+
+    Parses the issn-type array to separate print and electronic ISSNs.
+    Takes first occurrence of each type if duplicates exist.
+
+    Args:
+        publication: CrossRef publication record.
+
+    Returns:
+        Dictionary with issn_print and issn_electronic.
+
+    Example:
+        >>> extract_issn_by_type({
+        ...     "issn-type": [
+        ...         {"value": "0006-291X", "type": "print"},
+        ...         {"value": "1090-2104", "type": "electronic"}
+        ...     ]
+        ... })
+        {'issn_print': '0006-291X', 'issn_electronic': '1090-2104'}
+        >>> extract_issn_by_type({})
+        {'issn_print': None, 'issn_electronic': None}
+
+    """
+    issn_type_list = publication.get("issn-type", [])
+    if not isinstance(issn_type_list, list):
+        return {"issn_print": None, "issn_electronic": None}
+
+    issn_print: str | None = None
+    issn_electronic: str | None = None
+
+    for item in issn_type_list:
+        if not isinstance(item, dict):
+            continue
+        issn_value = item.get("value")
+        issn_kind = item.get("type")
+
+        if issn_kind == "print" and issn_print is None:
+            issn_print = issn_value
+        elif issn_kind == "electronic" and issn_electronic is None:
+            issn_electronic = issn_value
+
+    return {
+        "issn_print": issn_print,
+        "issn_electronic": issn_electronic,
+    }
+
+
+def extract_published_date(publication: dict[str, Any]) -> str | None:
+    """Extract 'published' date (canonical publication date).
+
+    CrossRef's 'published' field is the preferred publication date,
+    distinct from published-print and published-online which indicate
+    specific publication events.
+
+    Args:
+        publication: CrossRef publication record.
+
+    Returns:
+        ISO date string (YYYY-MM-DD) or None.
+
+    Example:
+        >>> extract_published_date({"published": {"date-parts": [[2023, 6, 15]]}})
+        '2023-06-15'
+        >>> extract_published_date({"published": {"date-parts": [[2023]]}})
+        '2023-12-31'
+        >>> extract_published_date({})
+        None
+
+    """
+    published = publication.get("published", {})
+    if not isinstance(published, dict):
+        return None
+
+    return format_date_parts(published.get("date-parts"))

--- a/src/bioetl/application/pipelines/crossref/transformer.py
+++ b/src/bioetl/application/pipelines/crossref/transformer.py
@@ -21,10 +21,13 @@ from typing import TYPE_CHECKING, Any, cast
 from bioetl.application.pipelines.common import BasePublicationTransformer
 from bioetl.application.pipelines.crossref.extractors import (
     extract_authors,
+    extract_content_domain,
     extract_dates,
+    extract_issn_by_type,
     extract_journal_info,
     extract_license_url,
     extract_page_info,
+    extract_published_date,
     extract_year,
 )
 from bioetl.domain.entities.crossref import CROSSREF_TYPE_MAP, CrossRefPublicationEntity
@@ -120,6 +123,11 @@ class CrossRefPublicationTransformer(BasePublicationTransformer):
         page_info = extract_page_info(rec)
         dates = extract_dates(rec)
 
+        # Extract additional CrossRef metadata
+        content_domain = extract_content_domain(rec)
+        issn_by_type = extract_issn_by_type(rec)
+        published_date = extract_published_date(rec)
+
         # Extract abstract with HTML stripping via normalizer service
         normalizer = self._data_normalizer
         abstract_raw = rec.get("abstract", "")
@@ -164,6 +172,12 @@ class CrossRefPublicationTransformer(BasePublicationTransformer):
             # DQ flags (default: no warnings or errors)
             "_dq_warn": False,
             "_dq_error": False,
+            # NEW: Additional CrossRef metadata fields
+            "alternative_id": rec.get("alternative-id", []) or [],
+            "short_container_title": rec.get("short-container-title", []) or [],
+            "published": published_date,
+            **content_domain,
+            **issn_by_type,
         }
 
     def _get_primary_id_field(self) -> str:

--- a/src/bioetl/domain/entities/crossref.py
+++ b/src/bioetl/domain/entities/crossref.py
@@ -122,6 +122,38 @@ class PublicationRecord(BaseModel):
         default_factory=list, description="Subject areas"
     )
 
+    # Content domain (Crossmark/license restrictions)
+    content_domain_domains: list[str] = PydanticField(
+        default_factory=list, description="Content domain domains"
+    )
+    content_domain_crossmark_restriction: bool | None = PydanticField(
+        default=None, description="Crossmark restriction flag"
+    )
+
+    # Alternative identifiers
+    alternative_id: list[str] = PydanticField(
+        default_factory=list,
+        description="Alternative IDs (publisher-specific, e.g., PII)",
+    )
+
+    # Canonical publication date
+    published: str | None = PydanticField(
+        default=None, description="Canonical publication date (ISO format)"
+    )
+
+    # Short container title
+    short_container_title: list[str] = PydanticField(
+        default_factory=list, description="Short journal/container title"
+    )
+
+    # ISSN by type
+    issn_print: str | None = PydanticField(
+        default=None, description="Print ISSN (format: XXXX-XXXX)"
+    )
+    issn_electronic: str | None = PydanticField(
+        default=None, description="Electronic ISSN (format: XXXX-XXXX)"
+    )
+
     # Source tracking
     source: str = PydanticField(default="crossref", description="Data source")
 
@@ -157,6 +189,13 @@ class CrossRefPublicationEntity(PublicationEntityBase):
         reference_count: Number of references in the publication.
         license_url: License URL.
         subjects: Subject areas.
+        content_domain_domains: List of domains for content licensing.
+        content_domain_crossmark_restriction: Crossmark restriction flag.
+        alternative_id: Publisher-specific alternative IDs (e.g., PII).
+        published: Canonical publication date (ISO format).
+        short_container_title: Abbreviated journal/container title.
+        issn_print: Print ISSN.
+        issn_electronic: Electronic ISSN.
 
     Note: doi is required for CrossRef publications and validated in __post_init__.
 
@@ -185,6 +224,23 @@ class CrossRefPublicationEntity(PublicationEntityBase):
     # CrossRef-specific metadata
     license_url: str | None = None
     subjects: list[str] = field(default_factory=list)
+
+    # Content domain (Crossmark/license restrictions)
+    content_domain_domains: list[str] = field(default_factory=list)
+    content_domain_crossmark_restriction: bool | None = None
+
+    # Alternative identifiers (publisher-specific IDs, e.g., PII)
+    alternative_id: list[str] = field(default_factory=list)
+
+    # Canonical publication date (preferred over print/online)
+    published: str | None = None
+
+    # Short journal/container title
+    short_container_title: list[str] = field(default_factory=list)
+
+    # ISSN by type (split from generic ISSN list)
+    issn_print: str | None = None
+    issn_electronic: str | None = None
 
     # Override: Default source for CrossRef
     source: str = "crossref"

--- a/src/bioetl/domain/schemas/crossref/work.py
+++ b/src/bioetl/domain/schemas/crossref/work.py
@@ -152,6 +152,48 @@ class PublicationSchema(ETLRecordSchema):
         nullable=True, description="DOI of update policy"
     )
 
+    # === Content Domain ===
+    content_domain_domains: Series[object] = pa.Field(
+        nullable=True,
+        description="Content domain domains (list of strings)",
+    )
+    content_domain_crossmark_restriction: Series[bool] = pa.Field(
+        nullable=True,
+        coerce=True,
+        description="Crossmark restriction flag",
+    )
+
+    # === Alternative Identifiers ===
+    alternative_id: Series[object] = pa.Field(
+        nullable=True,
+        description="Alternative IDs (publisher-specific, e.g., PII)",
+    )
+
+    # === Canonical Publication Date ===
+    published: Series[str] = pa.Field(
+        nullable=True,
+        str_matches=r"^\d{4}(-\d{2}(-\d{2})?)?$",
+        description="Canonical publication date (YYYY-MM-DD or partial)",
+    )
+
+    # === Short Container Title ===
+    short_container_title: Series[object] = pa.Field(
+        nullable=True,
+        description="Short journal/container title (list of strings)",
+    )
+
+    # === ISSN by Type ===
+    issn_print: Series[str] = pa.Field(
+        nullable=True,
+        str_matches=r"^\d{4}-\d{3}[\dX]$",
+        description="Print ISSN (format: XXXX-XXXX)",
+    )
+    issn_electronic: Series[str] = pa.Field(
+        nullable=True,
+        str_matches=r"^\d{4}-\d{3}[\dX]$",
+        description="Electronic ISSN (format: XXXX-XXXX)",
+    )
+
     class Config:
         """Pandera configuration."""
 

--- a/tests/unit/application/pipelines/crossref/test_extractors.py
+++ b/tests/unit/application/pipelines/crossref/test_extractors.py
@@ -5,12 +5,17 @@ Tests the pure functions in extractors.py module.
 
 from __future__ import annotations
 
+import pytest
+
 from bioetl.application.pipelines.crossref.extractors import (
     extract_authors,
+    extract_content_domain,
     extract_dates,
+    extract_issn_by_type,
     extract_journal_info,
     extract_license_url,
     extract_page_info,
+    extract_published_date,
     extract_year,
 )
 
@@ -337,3 +342,201 @@ class TestExtractDates:
         }
         result = extract_dates(publication)
         assert result == {"published_print": None, "published_online": None}
+
+
+class TestExtractContentDomain:
+    """Tests for extract_content_domain function."""
+
+    def test_full_content_domain(self) -> None:
+        """Should extract both domain list and crossmark restriction."""
+        record = {
+            "content-domain": {
+                "domain": ["nature.com", "springernature.com"],
+                "crossmark-restriction": True,
+            }
+        }
+        result = extract_content_domain(record)
+        assert result["content_domain_domains"] == ["nature.com", "springernature.com"]
+        assert result["content_domain_crossmark_restriction"] is True
+
+    def test_empty_record(self) -> None:
+        """Should return empty list and None for empty record."""
+        result = extract_content_domain({})
+        assert result["content_domain_domains"] == []
+        assert result["content_domain_crossmark_restriction"] is None
+
+    def test_empty_domain_list(self) -> None:
+        """Should handle empty domain list with crossmark false."""
+        record = {"content-domain": {"domain": [], "crossmark-restriction": False}}
+        result = extract_content_domain(record)
+        assert result["content_domain_domains"] == []
+        assert result["content_domain_crossmark_restriction"] is False
+
+    def test_invalid_content_domain_type(self) -> None:
+        """Should handle non-dict content-domain gracefully."""
+        record = {"content-domain": "invalid"}
+        result = extract_content_domain(record)
+        assert result["content_domain_domains"] == []
+        assert result["content_domain_crossmark_restriction"] is None
+
+    def test_none_domain_list(self) -> None:
+        """Should handle None domain list."""
+        record = {"content-domain": {"domain": None}}
+        result = extract_content_domain(record)
+        assert result["content_domain_domains"] == []
+
+    def test_missing_crossmark_restriction(self) -> None:
+        """Should return None for missing crossmark-restriction."""
+        record = {"content-domain": {"domain": ["example.com"]}}
+        result = extract_content_domain(record)
+        assert result["content_domain_domains"] == ["example.com"]
+        assert result["content_domain_crossmark_restriction"] is None
+
+
+class TestExtractIssnByType:
+    """Tests for extract_issn_by_type function."""
+
+    @pytest.mark.parametrize(
+        ("input_data", "expected"),
+        [
+            pytest.param(
+                {"issn-type": [{"value": "0006-291X", "type": "print"}]},
+                {"issn_print": "0006-291X", "issn_electronic": None},
+                id="print_only",
+            ),
+            pytest.param(
+                {"issn-type": [{"value": "1090-2104", "type": "electronic"}]},
+                {"issn_print": None, "issn_electronic": "1090-2104"},
+                id="electronic_only",
+            ),
+            pytest.param(
+                {
+                    "issn-type": [
+                        {"value": "0006-291X", "type": "print"},
+                        {"value": "1090-2104", "type": "electronic"},
+                    ]
+                },
+                {"issn_print": "0006-291X", "issn_electronic": "1090-2104"},
+                id="both_types",
+            ),
+            pytest.param(
+                {},
+                {"issn_print": None, "issn_electronic": None},
+                id="empty_record",
+            ),
+            pytest.param(
+                {"issn-type": "invalid"},
+                {"issn_print": None, "issn_electronic": None},
+                id="invalid_type",
+            ),
+            pytest.param(
+                {"issn-type": [{"value": "1234-5678"}]},
+                {"issn_print": None, "issn_electronic": None},
+                id="missing_type_field",
+            ),
+            pytest.param(
+                {"issn-type": [None, {"value": "0006-291X", "type": "print"}]},
+                {"issn_print": "0006-291X", "issn_electronic": None},
+                id="none_in_list",
+            ),
+        ],
+    )
+    def test_extract_issn_by_type(
+        self,
+        input_data: dict,
+        expected: dict,
+    ) -> None:
+        """Should extract ISSNs correctly based on type field."""
+        result = extract_issn_by_type(input_data)
+        assert result == expected
+
+    def test_duplicate_types_takes_first(self) -> None:
+        """Should take first occurrence when duplicate types exist."""
+        record = {
+            "issn-type": [
+                {"value": "1111-1111", "type": "print"},
+                {"value": "2222-2222", "type": "print"},
+            ]
+        }
+        result = extract_issn_by_type(record)
+        assert result["issn_print"] == "1111-1111"
+
+    def test_order_independence(self) -> None:
+        """Should work regardless of item order in list."""
+        record = {
+            "issn-type": [
+                {"value": "1090-2104", "type": "electronic"},
+                {"value": "0006-291X", "type": "print"},
+            ]
+        }
+        result = extract_issn_by_type(record)
+        assert result["issn_print"] == "0006-291X"
+        assert result["issn_electronic"] == "1090-2104"
+
+
+class TestExtractPublishedDate:
+    """Tests for extract_published_date function.
+
+    Uses end-of-period normalization for partial dates:
+    - Month-only dates use last day of month
+    - Year-only dates use December 31st
+    """
+
+    def test_full_date(self) -> None:
+        """Should extract complete date."""
+        record = {"published": {"date-parts": [[2023, 6, 15]]}}
+        result = extract_published_date(record)
+        assert result == "2023-06-15"
+
+    def test_year_month_only(self) -> None:
+        """Should use last day of month for partial date."""
+        record = {"published": {"date-parts": [[2023, 6]]}}
+        result = extract_published_date(record)
+        assert result == "2023-06-30"  # Last day of June
+
+    def test_year_only(self) -> None:
+        """Should use December 31st for year-only date."""
+        record = {"published": {"date-parts": [[2023]]}}
+        result = extract_published_date(record)
+        assert result == "2023-12-31"  # Last day of year
+
+    def test_empty_record(self) -> None:
+        """Should return None for empty record."""
+        result = extract_published_date({})
+        assert result is None
+
+    def test_invalid_published_type(self) -> None:
+        """Should return None for non-dict published field."""
+        record = {"published": "2023-06-15"}
+        result = extract_published_date(record)
+        assert result is None
+
+    def test_missing_date_parts(self) -> None:
+        """Should return None when date-parts is missing."""
+        record = {"published": {}}
+        result = extract_published_date(record)
+        assert result is None
+
+    def test_february_leap_year(self) -> None:
+        """Should handle leap year February correctly."""
+        record = {"published": {"date-parts": [[2024, 2]]}}
+        result = extract_published_date(record)
+        assert result == "2024-02-29"  # Leap year
+
+    def test_february_non_leap_year(self) -> None:
+        """Should handle non-leap year February correctly."""
+        record = {"published": {"date-parts": [[2023, 2]]}}
+        result = extract_published_date(record)
+        assert result == "2023-02-28"  # Not a leap year
+
+    def test_empty_date_parts_list(self) -> None:
+        """Should return None for empty date-parts list."""
+        record = {"published": {"date-parts": [[]]}}
+        result = extract_published_date(record)
+        assert result is None
+
+    def test_null_date_parts(self) -> None:
+        """Should return None for null date-parts."""
+        record = {"published": {"date-parts": None}}
+        result = extract_published_date(record)
+        assert result is None


### PR DESCRIPTION
## Summary
This PR adds three new metadata extractors for CrossRef publications to capture additional bibliographic information: content domain/licensing restrictions, ISSN values by type (print/electronic), and canonical publication dates.

## Key Changes

### New Extractors
- **`extract_content_domain()`**: Extracts content domain information including licensing domains and Crossmark restriction flags
- **`extract_issn_by_type()`**: Parses issn-type array to separate print and electronic ISSNs, taking the first occurrence of each type
- **`extract_published_date()`**: Extracts the canonical publication date with end-of-period normalization for partial dates (e.g., year-only dates use December 31st)

### Schema & Entity Updates
- Added 8 new fields to `CrossRefPublicationEntity` and `PublicationRecord`:
  - `content_domain_domains`: List of content domain strings
  - `content_domain_crossmark_restriction`: Boolean flag for Crossmark restrictions
  - `alternative_id`: Publisher-specific alternative identifiers (e.g., PII)
  - `published`: Canonical publication date (ISO format)
  - `short_container_title`: Abbreviated journal/container title
  - `issn_print` & `issn_electronic`: Separated ISSN values by type

- Updated Pandera schema with validation rules for new fields including ISSN format validation (XXXX-XXXX)

### Transformer Integration
- Integrated new extractors into `CrossRefPublicationTransformer._extract_business_data()`
- New fields are now populated during the ETL transformation pipeline

### Test Coverage
- Added comprehensive test suite with 20+ test cases covering:
  - Normal cases (full data, partial data)
  - Edge cases (empty records, invalid types, None values)
  - Parametrized tests for ISSN extraction
  - Leap year handling for date normalization
  - Duplicate type handling (takes first occurrence)

## Implementation Details
- All extractors follow existing patterns with defensive programming (type checking, None handling)
- Date normalization uses `format_date_parts()` utility for consistency
- ISSN extraction is order-independent and handles malformed data gracefully
- Content domain extraction handles both missing and invalid data types