### PR TITLE
Add ColumnQualifier value object for unified column naming

### DIFF
--- a/src/bioetl/domain/value_objects/__init__.py
+++ b/src/bioetl/domain/value_objects/__init__.py
@@ -64,6 +64,7 @@ from bioetl.domain.value_objects.activity_values import (
 )
 from bioetl.domain.value_objects.base import ValueObject
 from bioetl.domain.value_objects.bronze_result import BronzeWriteResult
+from bioetl.domain.value_objects.column_qualifier import ColumnQualifier
 from bioetl.domain.value_objects.chemical import (
     SMILES,
     InChIKey,
@@ -158,6 +159,7 @@ __all__ = [
     "BusinessRulesResult",
     "CategoricalDistribution",
     "ChemblId",
+    "ColumnQualifier",
     "ColumnStats",
     "CompletenessResult",
     "CompoundId",

--- a/src/bioetl/domain/value_objects/column_qualifier.py
+++ b/src/bioetl/domain/value_objects/column_qualifier.py
@@ -1,0 +1,133 @@
+"""Column qualifier value object for unified naming.
+
+Implements {provider}.{entity}.{field} naming convention.
+See ADR-026 for rationale.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+__all__ = ["ColumnQualifier"]
+
+# Join keys excluded from renaming (case-insensitive)
+JOIN_KEY_COLUMNS: Final[frozenset[str]] = frozenset({"doi", "pmid", "pmc_id"})
+
+
+@dataclass(frozen=True, slots=True)
+class ColumnQualifier:
+    """Qualified column name in format {provider}.{entity}.{field}.
+
+    Immutable value object representing a fully qualified column name.
+    Used for consistent naming across composite pipelines.
+
+    Attributes:
+        provider: Data provider name (e.g., 'chembl', 'crossref').
+        entity: Entity type (e.g., 'publication', 'activity').
+        field: Field name (e.g., 'title', 'abstract').
+
+    Example:
+        >>> q = ColumnQualifier("chembl", "publication", "title")
+        >>> str(q)
+        'chembl.publication.title'
+        >>> q.is_join_key
+        False
+    """
+
+    provider: str
+    entity: str
+    field: str
+
+    def __post_init__(self) -> None:
+        """Validate and normalize fields."""
+        if not self.provider or not self.provider.strip():
+            raise ValueError("provider cannot be empty")
+        if not self.entity or not self.entity.strip():
+            raise ValueError("entity cannot be empty")
+        if not self.field or not self.field.strip():
+            raise ValueError("field cannot be empty")
+
+        # Normalize to lowercase
+        object.__setattr__(self, "provider", self.provider.strip().lower())
+        object.__setattr__(self, "entity", self.entity.strip().lower())
+        object.__setattr__(self, "field", self.field.strip().lower())
+
+    def __str__(self) -> str:
+        """Return qualified name: {provider}.{entity}.{field}."""
+        return f"{self.provider}.{self.entity}.{self.field}"
+
+    @property
+    def prefix(self) -> str:
+        """Return prefix without field: {provider}.{entity}."""
+        return f"{self.provider}.{self.entity}"
+
+    @property
+    def is_join_key(self) -> bool:
+        """Check if field is a join key (doi, pmid, pmc_id)."""
+        return self.field.lower() in JOIN_KEY_COLUMNS
+
+    @classmethod
+    def from_pipeline(cls, pipeline: str, field: str) -> ColumnQualifier:
+        """Create from pipeline name and field.
+
+        Args:
+            pipeline: Pipeline name in format 'provider_entity'.
+            field: Column field name.
+
+        Returns:
+            ColumnQualifier instance.
+
+        Raises:
+            ValueError: If pipeline format is invalid.
+
+        Example:
+            >>> q = ColumnQualifier.from_pipeline("chembl_publication", "title")
+            >>> str(q)
+            'chembl.publication.title'
+        """
+        if "_" not in pipeline:
+            raise ValueError(
+                f"Pipeline '{pipeline}' must be in format 'provider_entity'"
+            )
+        provider, entity = pipeline.split("_", 1)
+        return cls(provider=provider, entity=entity, field=field)
+
+    @classmethod
+    def parse(cls, qualified_name: str) -> ColumnQualifier:
+        """Parse qualified name back to ColumnQualifier.
+
+        Args:
+            qualified_name: Qualified name in format 'provider.entity.field'.
+
+        Returns:
+            ColumnQualifier instance.
+
+        Raises:
+            ValueError: If format is invalid.
+
+        Example:
+            >>> q = ColumnQualifier.parse("chembl.publication.title")
+            >>> q.provider
+            'chembl'
+        """
+        parts = qualified_name.split(".")
+        if len(parts) != 3:
+            raise ValueError(
+                f"Qualified name '{qualified_name}' must have exactly 3 parts "
+                "(provider.entity.field)"
+            )
+        return cls(provider=parts[0], entity=parts[1], field=parts[2])
+
+    @staticmethod
+    def is_qualified(column: str) -> bool:
+        """Check if column name is already in qualified format.
+
+        Args:
+            column: Column name to check.
+
+        Returns:
+            True if column has format x.y.z (3 dot-separated parts).
+        """
+        parts = column.split(".")
+        return len(parts) == 3 and all(p.strip() for p in parts)

--- a/tests/unit/domain/value_objects/test_column_qualifier.py
+++ b/tests/unit/domain/value_objects/test_column_qualifier.py
@@ -1,0 +1,108 @@
+"""Tests for ColumnQualifier value object."""
+
+import pytest
+from bioetl.domain.value_objects.column_qualifier import ColumnQualifier
+
+
+class TestColumnQualifier:
+    """Tests for ColumnQualifier."""
+
+    def test_str_representation(self) -> None:
+        """String representation is provider.entity.field."""
+        q = ColumnQualifier("chembl", "publication", "title")
+        assert str(q) == "chembl.publication.title"
+
+    def test_prefix_property(self) -> None:
+        """Prefix is provider.entity without field."""
+        q = ColumnQualifier("crossref", "publication", "abstract")
+        assert q.prefix == "crossref.publication"
+
+    def test_from_pipeline_valid(self) -> None:
+        """Parse valid pipeline name."""
+        q = ColumnQualifier.from_pipeline("chembl_publication", "title")
+        assert q.provider == "chembl"
+        assert q.entity == "publication"
+        assert q.field == "title"
+
+    def test_from_pipeline_invalid_format(self) -> None:
+        """Reject pipeline without underscore."""
+        with pytest.raises(ValueError, match="must be in format"):
+            ColumnQualifier.from_pipeline("chemblpublication", "title")
+
+    def test_parse_qualified_name(self) -> None:
+        """Parse qualified name back to object."""
+        q = ColumnQualifier.parse("chembl.publication.title")
+        assert q.provider == "chembl"
+        assert q.entity == "publication"
+        assert q.field == "title"
+
+    def test_parse_invalid_format(self) -> None:
+        """Reject name without 3 parts."""
+        with pytest.raises(ValueError, match="exactly 3 parts"):
+            ColumnQualifier.parse("chembl.title")
+
+    def test_is_join_key_true(self) -> None:
+        """DOI is a join key."""
+        q = ColumnQualifier("chembl", "publication", "doi")
+        assert q.is_join_key is True
+
+    def test_is_join_key_false(self) -> None:
+        """Title is not a join key."""
+        q = ColumnQualifier("chembl", "publication", "title")
+        assert q.is_join_key is False
+
+    def test_is_join_key_case_insensitive(self) -> None:
+        """Join key check is case-insensitive."""
+        q = ColumnQualifier("chembl", "publication", "DOI")
+        assert q.is_join_key is True
+
+    def test_immutability(self) -> None:
+        """ColumnQualifier is immutable."""
+        q = ColumnQualifier("chembl", "publication", "title")
+        with pytest.raises(AttributeError):
+            q.provider = "crossref"  # type: ignore[misc]
+
+    def test_normalization_lowercase(self) -> None:
+        """Fields are normalized to lowercase."""
+        q = ColumnQualifier("ChEMBL", "Publication", "TITLE")
+        assert q.provider == "chembl"
+        assert q.entity == "publication"
+        assert q.field == "title"
+
+    def test_normalization_strips_whitespace(self) -> None:
+        """Fields are stripped of whitespace."""
+        q = ColumnQualifier("  chembl  ", "  publication  ", "  title  ")
+        assert q.provider == "chembl"
+        assert q.entity == "publication"
+        assert q.field == "title"
+
+    def test_empty_provider_raises(self) -> None:
+        """Empty provider raises ValueError."""
+        with pytest.raises(ValueError, match="provider cannot be empty"):
+            ColumnQualifier("", "publication", "title")
+
+    def test_empty_entity_raises(self) -> None:
+        """Empty entity raises ValueError."""
+        with pytest.raises(ValueError, match="entity cannot be empty"):
+            ColumnQualifier("chembl", "", "title")
+
+    def test_empty_field_raises(self) -> None:
+        """Empty field raises ValueError."""
+        with pytest.raises(ValueError, match="field cannot be empty"):
+            ColumnQualifier("chembl", "publication", "")
+
+    def test_is_qualified_true(self) -> None:
+        """Detect qualified column name."""
+        assert ColumnQualifier.is_qualified("chembl.publication.title") is True
+
+    def test_is_qualified_false_two_parts(self) -> None:
+        """Reject column with 2 parts."""
+        assert ColumnQualifier.is_qualified("chembl.title") is False
+
+    def test_is_qualified_false_no_dots(self) -> None:
+        """Reject column without dots."""
+        assert ColumnQualifier.is_qualified("title") is False
+
+    def test_is_qualified_false_empty_parts(self) -> None:
+        """Reject column with empty parts."""
+        assert ColumnQualifier.is_qualified("chembl..title") is False


### PR DESCRIPTION
## Summary
Introduces a new `ColumnQualifier` value object that implements a unified naming convention for columns across composite pipelines, following the `{provider}.{entity}.{field}` format as specified in ADR-026.

## Changes
- **New value object**: `ColumnQualifier` in `src/bioetl/domain/value_objects/column_qualifier.py`
  - Immutable, frozen dataclass with automatic normalization (lowercase, whitespace trimming)
  - String representation: `provider.entity.field`
  - Factory methods: `from_pipeline()` and `parse()` for flexible instantiation
  - Join key detection for common identifiers (DOI, PMID, PMC_ID)
  - Validation to ensure all fields are non-empty

- **Export**: Added `ColumnQualifier` to the value objects `__init__.py` for public API access

- **Comprehensive test suite**: 18 unit tests covering:
  - String representation and prefix property
  - Factory method parsing (valid and invalid formats)
  - Join key detection (case-insensitive)
  - Immutability enforcement
  - Field normalization (lowercase and whitespace handling)
  - Validation of empty fields
  - Qualified name detection utility

## Implementation Details
- Uses `@dataclass(frozen=True, slots=True)` for memory efficiency and immutability
- Custom `__post_init__()` for validation and normalization via `object.__setattr__()` (required for frozen dataclasses)
- `is_qualified()` static method provides a lightweight check without instantiation
- Join key columns stored in a `frozenset` for O(1) lookup performance