### PR TITLE
Add ColumnRenamer service for unified column qualification

### DIFF
--- a/src/bioetl/application/composite/__init__.py
+++ b/src/bioetl/application/composite/__init__.py
@@ -6,6 +6,7 @@ This package contains application services for composite pipeline orchestration:
 - MergeService: Data merging with conflict resolution
 - KeyExtractorService: Extract join keys from seed Silver tables
 - CompositeCheckpointManager: Checkpoint management for resume capability
+- ColumnRenamer: Unified column renaming to qualified format
 
 See ADR-026 for architectural decisions.
 """
@@ -14,12 +15,14 @@ from bioetl.application.composite.checkpoint import (
     CompositeCheckpointManager,
     CompositeCheckpointState,
 )
+from bioetl.application.composite.column_renamer import ColumnRenamer
 from bioetl.application.composite.coordinator import EnrichmentCoordinator
 from bioetl.application.composite.key_extractor import KeyExtractorService
 from bioetl.application.composite.merger import MergeService
 from bioetl.application.composite.runner import CompositePipelineRunner
 
 __all__ = [
+    "ColumnRenamer",
     "CompositeCheckpointManager",
     "CompositeCheckpointState",
     "CompositePipelineRunner",

--- a/src/bioetl/application/composite/column_renamer.py
+++ b/src/bioetl/application/composite/column_renamer.py
@@ -1,0 +1,168 @@
+"""Column renamer service for composite pipelines.
+
+Provides unified column renaming to {provider}.{entity}.{field} format.
+See ADR-026 for rationale.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Final
+
+from bioetl.domain.value_objects.column_qualifier import ColumnQualifier
+
+if TYPE_CHECKING:
+    import polars as pl
+
+    from bioetl.domain.ports import LoggerPort
+
+__all__ = ["ColumnRenamer"]
+
+
+class ColumnRenamer:
+    """Service for renaming columns to qualified format.
+
+    Renames all business columns to {provider}.{entity}.{field} format.
+    Excludes join keys and system columns from renaming.
+
+    Example:
+        >>> renamer = ColumnRenamer(logger)
+        >>> result = renamer.rename_dataframe(df, "chembl_publication")
+        >>> # 'title' -> 'chembl.publication.title'
+        >>> # 'doi' -> 'doi' (join key, unchanged)
+        >>> # '_run_id' -> '_run_id' (system, unchanged)
+    """
+
+    # System column prefixes (not renamed)
+    SYSTEM_PREFIXES: Final[frozenset[str]] = frozenset({"_"})
+
+    # Join key columns (not renamed, case-insensitive)
+    JOIN_KEY_COLUMNS: Final[frozenset[str]] = frozenset({"doi", "pmid", "pmc_id"})
+
+    def __init__(self, logger: LoggerPort) -> None:
+        """Initialize renamer.
+
+        Args:
+            logger: Logger port for diagnostics.
+        """
+        self._logger = logger
+
+    def rename_dataframe(
+        self,
+        df: pl.DataFrame,
+        pipeline: str,
+        *,
+        exclude_join_keys: bool = True,
+    ) -> pl.DataFrame:
+        """Rename all business columns to qualified format.
+
+        Transforms column names from 'field' to '{provider}.{entity}.{field}'.
+
+        Args:
+            df: DataFrame to rename.
+            pipeline: Pipeline name in format 'provider_entity'.
+            exclude_join_keys: If True, join keys (doi, pmid, pmc_id)
+                are NOT renamed. Default: True.
+
+        Returns:
+            DataFrame with renamed columns.
+
+        Example:
+            >>> df = pl.DataFrame({"doi": ["10.1/a"], "title": ["T1"], "_run_id": ["x"]})
+            >>> result = renamer.rename_dataframe(df, "chembl_publication")
+            >>> result.columns
+            ['doi', 'chembl.publication.title', '_run_id']
+        """
+        rename_map = self.build_rename_map(
+            columns=df.columns,
+            pipeline=pipeline,
+            exclude_join_keys=exclude_join_keys,
+        )
+
+        if not rename_map:
+            return df
+
+        self._logger.debug(
+            "Renaming columns to qualified format",
+            pipeline=pipeline,
+            rename_count=len(rename_map),
+            sample_renames=dict(list(rename_map.items())[:3]),
+        )
+
+        return df.rename(rename_map)
+
+    def build_rename_map(
+        self,
+        columns: Sequence[str],
+        pipeline: str,
+        *,
+        exclude_join_keys: bool = True,
+    ) -> dict[str, str]:
+        """Build rename mapping {old_name: new_name}.
+
+        Args:
+            columns: List of column names.
+            pipeline: Pipeline name in format 'provider_entity'.
+            exclude_join_keys: If True, exclude join keys from mapping.
+
+        Returns:
+            Dictionary mapping old column names to new qualified names.
+
+        Raises:
+            ValueError: If pipeline format is invalid.
+        """
+        provider, entity = self._parse_pipeline(pipeline)
+        rename_map: dict[str, str] = {}
+
+        for col in columns:
+            # Skip system columns
+            if self._is_system_column(col):
+                self._logger.debug("Skipping system column", column=col)
+                continue
+
+            # Skip already qualified columns
+            if self._is_already_qualified(col):
+                self._logger.debug("Skipping already qualified column", column=col)
+                continue
+
+            # Skip join keys if requested
+            if exclude_join_keys and self._is_join_key(col):
+                self._logger.debug("Skipping join key column", column=col)
+                continue
+
+            # Build qualified name
+            qualifier = ColumnQualifier(provider, entity, col)
+            rename_map[col] = str(qualifier)
+
+        return rename_map
+
+    def _parse_pipeline(self, pipeline: str) -> tuple[str, str]:
+        """Parse pipeline name into (provider, entity).
+
+        Args:
+            pipeline: Pipeline name in format 'provider_entity'.
+
+        Returns:
+            Tuple of (provider, entity).
+
+        Raises:
+            ValueError: If format is invalid.
+        """
+        if "_" not in pipeline:
+            raise ValueError(
+                f"Pipeline name '{pipeline}' must be in format 'provider_entity'"
+            )
+        parts = pipeline.split("_", 1)
+        return (parts[0].lower(), parts[1].lower())
+
+    def _is_system_column(self, col: str) -> bool:
+        """Check if column is a system column (starts with '_')."""
+        return any(col.startswith(prefix) for prefix in self.SYSTEM_PREFIXES)
+
+    def _is_already_qualified(self, col: str) -> bool:
+        """Check if column is already in qualified format (x.y.z)."""
+        return ColumnQualifier.is_qualified(col)
+
+    def _is_join_key(self, col: str) -> bool:
+        """Check if column is a join key (case-insensitive)."""
+        return col.lower() in self.JOIN_KEY_COLUMNS

--- a/tests/unit/application/composite/test_column_renamer.py
+++ b/tests/unit/application/composite/test_column_renamer.py
@@ -1,0 +1,138 @@
+"""Tests for ColumnRenamer service."""
+
+import polars as pl
+import pytest
+from unittest.mock import MagicMock
+
+from bioetl.application.composite.column_renamer import ColumnRenamer
+
+
+@pytest.fixture
+def mock_logger() -> MagicMock:
+    """Create mock logger."""
+    logger = MagicMock()
+    logger.debug = MagicMock()
+    return logger
+
+
+@pytest.fixture
+def renamer(mock_logger: MagicMock) -> ColumnRenamer:
+    """Create ColumnRenamer instance."""
+    return ColumnRenamer(mock_logger)
+
+
+class TestColumnRenamer:
+    """Tests for ColumnRenamer."""
+
+    def test_rename_all_business_columns(self, renamer: ColumnRenamer) -> None:
+        """All business columns get qualified names."""
+        df = pl.DataFrame({
+            "title": ["T1"],
+            "abstract": ["A1"],
+            "journal": ["J1"],
+        })
+        result = renamer.rename_dataframe(df, "chembl_publication")
+
+        assert "chembl.publication.title" in result.columns
+        assert "chembl.publication.abstract" in result.columns
+        assert "chembl.publication.journal" in result.columns
+
+    def test_exclude_join_keys_by_default(self, renamer: ColumnRenamer) -> None:
+        """Join keys are not renamed by default."""
+        df = pl.DataFrame({
+            "doi": ["10.1/a"],
+            "pmid": ["123"],
+            "pmc_id": ["PMC456"],
+            "title": ["T1"],
+        })
+        result = renamer.rename_dataframe(df, "chembl_publication")
+
+        assert "doi" in result.columns
+        assert "pmid" in result.columns
+        assert "pmc_id" in result.columns
+        assert "chembl.publication.title" in result.columns
+
+    def test_include_join_keys_when_disabled(self, renamer: ColumnRenamer) -> None:
+        """Join keys are renamed when exclude_join_keys=False."""
+        df = pl.DataFrame({"doi": ["10.1/a"], "title": ["T1"]})
+        result = renamer.rename_dataframe(
+            df, "chembl_publication", exclude_join_keys=False
+        )
+
+        assert "chembl.publication.doi" in result.columns
+        assert "chembl.publication.title" in result.columns
+
+    def test_skip_system_columns(self, renamer: ColumnRenamer) -> None:
+        """System columns (starting with _) are not renamed."""
+        df = pl.DataFrame({
+            "_run_id": ["r1"],
+            "_ingestion_ts": ["2025-01-01"],
+            "title": ["T1"],
+        })
+        result = renamer.rename_dataframe(df, "chembl_publication")
+
+        assert "_run_id" in result.columns
+        assert "_ingestion_ts" in result.columns
+        assert "chembl.publication.title" in result.columns
+
+    def test_skip_already_qualified(self, renamer: ColumnRenamer) -> None:
+        """Already qualified columns are not renamed."""
+        df = pl.DataFrame({
+            "crossref.publication.title": ["T1"],
+            "abstract": ["A1"],
+        })
+        result = renamer.rename_dataframe(df, "chembl_publication")
+
+        assert "crossref.publication.title" in result.columns
+        assert "chembl.publication.abstract" in result.columns
+
+    def test_empty_dataframe(self, renamer: ColumnRenamer) -> None:
+        """Empty DataFrame returns empty DataFrame."""
+        df = pl.DataFrame()
+        result = renamer.rename_dataframe(df, "chembl_publication")
+        assert len(result.columns) == 0
+
+    def test_build_rename_map(self, renamer: ColumnRenamer) -> None:
+        """Build correct rename mapping."""
+        columns = ["title", "doi", "_run_id", "chembl.activity.name"]
+        mapping = renamer.build_rename_map(columns, "chembl_publication")
+
+        assert mapping == {"title": "chembl.publication.title"}
+
+    def test_parse_pipeline_valid(self, renamer: ColumnRenamer) -> None:
+        """Parse valid pipeline name."""
+        provider, entity = renamer._parse_pipeline("chembl_publication")
+        assert provider == "chembl"
+        assert entity == "publication"
+
+    def test_parse_pipeline_invalid(self, renamer: ColumnRenamer) -> None:
+        """Reject pipeline without underscore."""
+        with pytest.raises(ValueError, match="must be in format"):
+            renamer._parse_pipeline("chemblpublication")
+
+    def test_case_insensitive_join_keys(self, renamer: ColumnRenamer) -> None:
+        """Join key detection is case-insensitive."""
+        df = pl.DataFrame({"DOI": ["10.1/a"], "PMID": ["123"]})
+        result = renamer.rename_dataframe(df, "chembl_publication")
+
+        # Original case preserved but not renamed
+        assert "DOI" in result.columns
+        assert "PMID" in result.columns
+
+    def test_data_preserved_after_rename(self, renamer: ColumnRenamer) -> None:
+        """Data values are preserved after renaming."""
+        df = pl.DataFrame({
+            "title": ["Title 1", "Title 2"],
+            "doi": ["10.1/a", "10.1/b"],
+        })
+        result = renamer.rename_dataframe(df, "chembl_publication")
+
+        assert result["chembl.publication.title"].to_list() == ["Title 1", "Title 2"]
+        assert result["doi"].to_list() == ["10.1/a", "10.1/b"]
+
+    def test_normalization_to_lowercase(self, renamer: ColumnRenamer) -> None:
+        """Provider and entity are normalized to lowercase."""
+        df = pl.DataFrame({"title": ["T1"]})
+        result = renamer.rename_dataframe(df, "ChEMBL_Publication")
+
+        assert "chembl.publication.title" in result.columns


### PR DESCRIPTION
## Summary
Introduces a new `ColumnRenamer` service that provides unified column renaming to the qualified format `{provider}.{entity}.{field}` across composite pipelines. This implements part of ADR-026 architectural decisions.

## Key Changes
- **New `ColumnRenamer` service** (`column_renamer.py`):
  - Renames business columns to qualified format while preserving system columns and join keys
  - Supports configurable exclusion of join keys (doi, pmid, pmc_id)
  - Skips already-qualified columns and system columns (prefixed with `_`)
  - Provides both `rename_dataframe()` for direct DataFrame transformation and `build_rename_map()` for mapping inspection
  - Includes comprehensive logging for diagnostics

- **Module exports**: Added `ColumnRenamer` to `__init__.py` public API

- **Comprehensive test coverage** (`test_column_renamer.py`):
  - Tests for business column qualification
  - Join key exclusion/inclusion behavior
  - System column preservation
  - Already-qualified column handling
  - Pipeline name parsing and validation
  - Case-insensitive join key detection
  - Data integrity verification

## Implementation Details
- Uses `ColumnQualifier` value object for qualified name construction
- Pipeline names parsed in `provider_entity` format (e.g., `chembl_publication`)
- Configurable behavior via `exclude_join_keys` parameter (default: True)
- Logging includes rename counts and sample transformations for observability
- All column name comparisons for join keys are case-insensitive while preserving original case in output