### PR TITLE
Simplify column renaming to use ColumnRenamer for qualified format

### DIFF
--- a/src/bioetl/application/composite/merger.py
+++ b/src/bioetl/application/composite/merger.py
@@ -444,172 +444,6 @@ class MergeService:
         parts = pipeline.split("_", 1)
         return (parts[0], parts[1])
 
-    def _determine_prefix_strategy(
-        self,
-        seed_provider: str,
-        seed_entity: str,
-        enricher_provider: str,
-        enricher_entity: str,
-    ) -> PrefixStrategy:
-        """Determine column prefix strategy based on provider/entity relationship.
-
-        Determines how to prefix enricher columns to avoid conflicts
-        while maintaining semantic clarity.
-
-        Args:
-            seed_provider: Provider name of the seed pipeline.
-            seed_entity: Entity name of the seed pipeline.
-            enricher_provider: Provider name of the enricher pipeline.
-            enricher_entity: Entity name of the enricher pipeline.
-
-        Returns:
-            Strategy to use:
-            - "provider": Cross-provider merge (same entity, different providers).
-              Prefix with provider name. Example: "crossref.doi"
-            - "entity": Cross-entity merge (same provider, different entities).
-              Prefix with entity name. Example: "activity.chembl_id"
-            - "both": Cross-provider-entity merge (different providers AND entities).
-              Prefix with provider.entity. Example: "pubchem.compound.name"
-            - "pipeline": Fallback when same provider and entity.
-              Use full pipeline name. Example: "chembl_publication_extra.doi"
-
-        Example:
-            >>> merger._determine_prefix_strategy("chembl", "publication",
-            ...                                    "crossref", "publication")
-            'provider'
-            >>> merger._determine_prefix_strategy("chembl", "publication",
-            ...                                    "chembl", "activity")
-            'entity'
-            >>> merger._determine_prefix_strategy("chembl", "publication",
-            ...                                    "pubchem", "compound")
-            'both'
-        """
-        same_provider = seed_provider.lower() == enricher_provider.lower()
-        same_entity = seed_entity.lower() == enricher_entity.lower()
-
-        if same_entity and not same_provider:
-            # Cross-provider merge: same entity, different providers
-            return "provider"
-        elif same_provider and not same_entity:
-            # Cross-entity merge: same provider, different entities
-            return "entity"
-        elif not same_provider and not same_entity:
-            # Cross-provider-entity merge: different providers AND entities
-            return "both"
-        else:
-            # Same provider and entity - use full pipeline name
-            return "pipeline"
-
-    def _column_contains_identifier(
-        self,
-        column: str,
-        identifier: str,
-    ) -> bool:
-        """Check if column name already contains the identifier (case-insensitive).
-
-        Used to avoid redundant prefixes like "crossref.crossref_doi".
-
-        Args:
-            column: Column name to check.
-            identifier: Identifier to search for (provider or entity name).
-
-        Returns:
-            True if column contains the identifier (case-insensitive).
-
-        Example:
-            >>> merger._column_contains_identifier("crossref_doi", "crossref")
-            True
-            >>> merger._column_contains_identifier("doi", "crossref")
-            False
-            >>> merger._column_contains_identifier("CROSSREF.DOI", "crossref")
-            True
-            >>> merger._column_contains_identifier("chembl_id", "chembl")
-            True
-        """
-        return identifier.lower() in column.lower()
-
-    def _build_prefix(
-        self,
-        strategy: PrefixStrategy,
-        provider: str,
-        entity: str,
-        pipeline: str,
-    ) -> str:
-        """Build column prefix based on strategy.
-
-        Args:
-            strategy: Prefix strategy to use.
-            provider: Provider name.
-            entity: Entity name.
-            pipeline: Full pipeline name (fallback).
-
-        Returns:
-            Prefix string WITHOUT trailing dot.
-
-        Example:
-            >>> merger._build_prefix("provider", "crossref", "publication",
-            ...                       "crossref_publication")
-            'crossref'
-            >>> merger._build_prefix("entity", "chembl", "activity",
-            ...                       "chembl_activity")
-            'activity'
-            >>> merger._build_prefix("both", "pubchem", "compound",
-            ...                       "pubchem_compound")
-            'pubchem.compound'
-        """
-        match strategy:
-            case "provider":
-                return provider
-            case "entity":
-                return entity
-            case "both":
-                return f"{provider}.{entity}"
-            case "pipeline":
-                return pipeline
-
-    def _apply_column_prefix(
-        self,
-        df: pl.DataFrame,
-        columns: set[str],
-        prefix: str,
-        exclude_columns: set[str],
-    ) -> pl.DataFrame:
-        """Apply prefix to specified columns.
-
-        Renames columns by adding a prefix with dot separator.
-        Excludes join keys and columns already containing the identifier.
-
-        Args:
-            df: DataFrame to modify.
-            columns: Set of column names to potentially rename.
-            prefix: Prefix to add (WITHOUT trailing dot).
-            exclude_columns: Columns to exclude from renaming (join keys, etc.).
-
-        Returns:
-            DataFrame with renamed columns.
-
-        Example:
-            >>> df = pl.DataFrame({"doi": ["10.1/a"], "title": ["T1"]})
-            >>> result = merger._apply_column_prefix(
-            ...     df, {"title"}, "crossref", {"doi"}
-            ... )
-            >>> result.columns
-            ['doi', 'crossref.title']
-        """
-        rename_map = {}
-        for col in columns:
-            if col not in exclude_columns:
-                rename_map[col] = f"{prefix}.{col}"
-
-        if rename_map:
-            self._logger.debug(
-                "Applying column prefix",
-                prefix=prefix,
-                columns=list(rename_map.keys()),
-            )
-            return df.rename(rename_map)
-        return df
-
     def _find_next_suffix(self, base_col: str, existing_cols: set[str]) -> str:
         """Find next available suffix for a conflicting column.
 
@@ -714,12 +548,10 @@ class MergeService:
         enrichers: Sequence[EnricherConfig],
         seed_pipeline: str | None = None,
     ) -> pl.DataFrame:
-        """Apply join strategy with intelligent column renaming.
+        """Apply join strategy with qualified column renaming.
 
-        Column renaming strategy (by merge type):
-        - Cross-provider (same entity): prefix with provider name (e.g., "crossref.doi")
-        - Cross-entity (same provider): prefix with entity name (e.g., "activity.name")
-        - Cross-provider-entity: prefix with provider.entity (e.g., "pubchem.compound.name")
+        Column renaming uses ColumnRenamer to apply {provider}.{entity}.{field}
+        format to enricher columns for qualified column matching.
 
         Join keys (doi, pmid, pmc_id) are normalized to lowercase for
         case-insensitive matching across providers.
@@ -731,32 +563,19 @@ class MergeService:
             seed_df: Seed DataFrame to join to.
             enricher_dfs: Mapping of enricher pipeline name to DataFrame.
             enrichers: Sequence of enricher configurations.
-            seed_pipeline: Seed pipeline name (e.g., "chembl_publication").
-                If None, falls back to legacy underscore prefix naming.
+            seed_pipeline: Seed pipeline name (unused, kept for compatibility).
 
         Returns:
             Merged DataFrame with all enricher data joined.
 
         Example:
             >>> # Cross-provider merge: chembl_publication + crossref_publication
-            >>> # Column "title" in enricher → "crossref.title"
+            >>> # Column "title" in enricher → "crossref.publication.title"
             >>> merged = await merger._apply_joins(
             ...     seed_df, enricher_dfs, enrichers, "chembl_publication"
             ... )
         """
         merged = seed_df
-
-        # Parse seed pipeline for intelligent prefix strategy
-        seed_provider: str | None = None
-        seed_entity: str | None = None
-        if seed_pipeline:
-            try:
-                seed_provider, seed_entity = self._parse_pipeline_name(seed_pipeline)
-            except ValueError:
-                self._logger.warning(
-                    "Could not parse seed pipeline name, using legacy prefix",
-                    seed_pipeline=seed_pipeline,
-                )
 
         for enricher in enrichers:
             if enricher.pipeline not in enricher_dfs:
@@ -782,70 +601,19 @@ class MergeService:
             merged = self._normalize_join_key_columns(merged, join_keys_list)
             enricher_df = self._normalize_join_key_columns(enricher_df, join_keys_list)
 
-            # Find columns to prefix: all columns EXCEPT the primary join key
-            # Secondary join keys (title, doi when not primary) SHOULD be prefixed
-            # to avoid Polars adding its own suffix during join
-            non_join_cols = set(enricher_df.columns) - primary_key_set
+            # Rename enricher columns to qualified format: {provider}.{entity}.{field}
+            # Uses ColumnRenamer which excludes join keys automatically
+            enricher_df = self._renamer.rename_dataframe(
+                enricher_df,
+                enricher.pipeline,
+                exclude_join_keys=True,
+            )
 
-            # Determine prefix strategy
-            if seed_provider is not None and seed_entity is not None:
-                try:
-                    enricher_provider, enricher_entity = self._parse_pipeline_name(
-                        enricher.pipeline
-                    )
-
-                    strategy = self._determine_prefix_strategy(
-                        seed_provider,
-                        seed_entity,
-                        enricher_provider,
-                        enricher_entity,
-                    )
-
-                    prefix = self._build_prefix(
-                        strategy,
-                        enricher_provider,
-                        enricher_entity,
-                        enricher.pipeline,
-                    )
-
-                    self._logger.debug(
-                        "Column rename strategy determined",
-                        enricher=enricher.pipeline,
-                        strategy=strategy,
-                        prefix=prefix,
-                    )
-
-                    # Find columns that already contain the identifier
-                    already_prefixed = {
-                        col
-                        for col in non_join_cols
-                        if self._column_contains_identifier(col, enricher_provider)
-                        or self._column_contains_identifier(col, enricher_entity)
-                    }
-
-                    # Apply prefix to non-join columns
-                    # Only exclude primary key, secondary keys get prefixed
-                    enricher_df = self._apply_column_prefix(
-                        enricher_df,
-                        non_join_cols - already_prefixed,
-                        prefix,
-                        primary_key_set,
-                    )
-
-                except ValueError:
-                    # Fallback to legacy prefix if parsing fails
-                    self._logger.warning(
-                        "Could not parse enricher pipeline, using legacy prefix",
-                        enricher=enricher.pipeline,
-                    )
-                    enricher_df = self._apply_legacy_prefix(
-                        enricher_df, enricher.pipeline, non_join_cols, primary_key_set
-                    )
-            else:
-                # No seed pipeline provided - use legacy prefix
-                enricher_df = self._apply_legacy_prefix(
-                    enricher_df, enricher.pipeline, non_join_cols, primary_key_set
-                )
+            self._logger.debug(
+                "Renamed enricher columns to qualified format",
+                enricher=enricher.pipeline,
+                qualified_count=len([c for c in enricher_df.columns if "." in c and not c.startswith("_")]),
+            )
 
             # Detect and resolve remaining conflicts
             # Only exclude primary key - secondary keys should be checked for conflicts
@@ -866,37 +634,6 @@ class MergeService:
 
         return merged
 
-    def _apply_legacy_prefix(
-        self,
-        df: pl.DataFrame,
-        pipeline: str,
-        columns: set[str],
-        join_keys: set[str],
-    ) -> pl.DataFrame:
-        """Apply legacy underscore prefix to columns (backwards compatibility).
-
-        Args:
-            df: DataFrame to modify.
-            pipeline: Pipeline name to use as prefix.
-            columns: Columns to potentially rename.
-            join_keys: Columns to exclude (join keys).
-
-        Returns:
-            DataFrame with legacy-prefixed columns.
-        """
-        # Find common columns between seed and enricher
-        common_cols = columns - join_keys
-        rename_map = {col: f"{pipeline}_{col}" for col in common_cols}
-
-        if rename_map:
-            self._logger.debug(
-                "Applying legacy underscore prefix",
-                pipeline=pipeline,
-                columns=list(rename_map.keys()),
-            )
-            return df.rename(rename_map)
-        return df
-
     def _get_polars_join_type(self) -> JoinHow:
         """Convert MergeStrategy to Polars join type."""
         match self._config.strategy:
@@ -912,49 +649,24 @@ class MergeService:
     def _get_enricher_prefix(
         self,
         enricher_pipeline: str,
-        seed_pipeline: str | None,
+        seed_pipeline: str | None = None,
     ) -> str:
-        """Get the column prefix used for an enricher.
+        """Get column prefix for enricher.
 
-        Computes the prefix that was (or would be) applied to enricher columns
-        during `_apply_joins`. Used for conflict resolution.
+        Returns {provider}.{entity}. format for qualified column matching.
 
         Args:
             enricher_pipeline: Enricher pipeline name.
-            seed_pipeline: Seed pipeline name (may be None for legacy mode).
+            seed_pipeline: Unused, kept for backward compatibility.
 
         Returns:
-            Prefix string WITH trailing dot or underscore.
-
-        Example:
-            >>> merger._get_enricher_prefix("crossref_publication", "chembl_publication")
-            'crossref.'  # Cross-provider (same entity)
-            >>> merger._get_enricher_prefix("chembl_activity", "chembl_publication")
-            'activity.'  # Cross-entity (same provider)
-            >>> merger._get_enricher_prefix("crossref_publication", None)
-            'crossref_publication_'  # Legacy mode
+            Prefix string WITH trailing dot: '{provider}.{entity}.'
         """
-        if not seed_pipeline:
-            # Legacy mode: use full pipeline name with underscore
-            return f"{enricher_pipeline}_"
-
         try:
-            seed_provider, seed_entity = self._parse_pipeline_name(seed_pipeline)
-            enricher_provider, enricher_entity = self._parse_pipeline_name(
-                enricher_pipeline
-            )
-
-            strategy = self._determine_prefix_strategy(
-                seed_provider, seed_entity, enricher_provider, enricher_entity
-            )
-
-            prefix = self._build_prefix(
-                strategy, enricher_provider, enricher_entity, enricher_pipeline
-            )
-            return f"{prefix}."
-
+            provider, entity = self._parse_pipeline_name(enricher_pipeline)
+            return f"{provider}.{entity}."
         except ValueError:
-            # Fallback to legacy if parsing fails
+            # Fallback for non-standard pipeline names
             return f"{enricher_pipeline}_"
 
     def _extract_base_column(self, column: str, prefix: str) -> str | None:


### PR DESCRIPTION
## Summary
Refactored the column renaming logic in the merger to use a centralized `ColumnRenamer` component instead of implementing intelligent prefix strategy selection. This simplifies the codebase by removing complex strategy logic and standardizing on a single qualified column format: `{provider}.{entity}.{field}`.

## Key Changes
- **Removed intelligent prefix strategy logic**: Deleted `_determine_prefix_strategy()`, `_column_contains_identifier()`, `_build_prefix()`, and `_apply_column_prefix()` methods that implemented cross-provider, cross-entity, and cross-provider-entity merge strategies
- **Removed legacy prefix support**: Deleted `_apply_legacy_prefix()` method that provided backwards-compatible underscore-based prefixing
- **Simplified `_apply_joins()`**: Now delegates all column renaming to `self._renamer.rename_dataframe()` with a single call, removing ~70 lines of strategy determination and fallback logic
- **Updated `_get_enricher_prefix()`**: Simplified to always return `{provider}.{entity}.` format, removing strategy-based prefix computation and legacy mode support
- **Updated documentation**: Modified docstrings to reflect the new unified approach using qualified column format

## Implementation Details
- The `ColumnRenamer` component handles all column renaming with automatic join key exclusion via the `exclude_join_keys=True` parameter
- Qualified column format (`provider.entity.field`) provides better semantic clarity and avoids ambiguity compared to variable-length prefixes
- Maintains the same join key normalization and conflict resolution behavior
- Kept `seed_pipeline` parameter in `_apply_joins()` for backward compatibility but it's no longer used for strategy determination