### PR TITLE
Add column ordering by semantic groups in merge pipeline

### DIFF
--- a/src/bioetl/application/composite/merger.py
+++ b/src/bioetl/application/composite/merger.py
@@ -184,13 +184,20 @@ class MergeService:
             sources_used=sources_used,
         )
 
+        # Step 6: Order columns by semantic groups
+        merged_df = self._orderer.order_columns(merged_df)
+        self._logger.info(
+            "Ordered columns by semantic groups",
+            total_columns=len(merged_df.columns),
+        )
+
         # Calculate statistics before writing
         records_merged = len(merged_df)
         records_enriched = self._count_enriched_records(
             merged_df, enrichers, effective_seed_pipeline
         )
 
-        # Step 6: Write to Silver via StoragePort
+        # Step 7: Write to Silver via StoragePort
         self._logger.info(
             "Writing merged Silver table",
             path=self._config.output_silver_path,
@@ -200,7 +207,7 @@ class MergeService:
             merged_df, run_id=run_id, sources_used=sources_used
         )
 
-        # Step 7: Write to Gold via StoragePort
+        # Step 8: Write to Gold via StoragePort
         self._logger.info(
             "Writing merged Gold table",
             path=self._config.output_gold_path,


### PR DESCRIPTION
## Summary
Added a new step to the merge pipeline that orders columns by semantic groups before writing data to storage. This improves the organization and readability of the output tables.

## Key Changes
- Introduced Step 6 to order merged dataframe columns by semantic groups using the `_orderer.order_columns()` method
- Added logging to track column ordering with total column count
- Updated subsequent step numbers (Silver write is now Step 7, Gold write is now Step 8) to reflect the new ordering step

## Implementation Details
- The column ordering is performed immediately after the merge and enrichment steps, before any statistics calculations or storage writes
- This ensures both Silver and Gold output tables have consistently ordered columns
- The ordering operation is logged with the total number of columns for observability