### PR TITLE
Add publication enrichment composite pipeline configuration

### DIFF
--- a/configs/composite/publication_enrichment.yaml
+++ b/configs/composite/publication_enrichment.yaml
@@ -1,0 +1,94 @@
+# =============================================================================
+# Composite Pipeline: Publication Enrichment
+# =============================================================================
+# Column Naming Convention (ADR-026 v2)
+# =============================================================================
+# All business columns are renamed to: {provider}.{entity}.{field}
+#
+# Examples:
+#   - seed (chembl_publication):      chembl.publication.title
+#   - enricher (crossref_publication): crossref.publication.title
+#   - enricher (pubmed_publication):   pubmed.publication.abstract
+#
+# EXCLUDED from renaming:
+#   - Join keys: doi, pmid, pmc_id (для совместимости с join операциями)
+#   - System columns: _run_id, _ingestion_ts, etc.
+#
+# COLUMN ORDERING:
+#   Output columns are ordered by semantic groups:
+#   1. System (entity_id, content_hash, _run_id, ...)
+#   2. Identifiers (doi, pmid, document_chembl_id, ...)
+#   3. Title (chembl.publication.title, crossref.publication.title, ...)
+#   4. Abstract
+#   5. Authors
+#   6. Journal/Source
+#   7. Dates
+#   8. Metrics
+#   9. Classification
+#   10. URLs
+#   11. Other
+#
+#   Within each group, columns are ordered by provider priority:
+#   chembl → crossref → pubmed → openalex → semantic_scholar
+#
+# PRIORITY CONFIGURATION:
+#   field_priorities uses source identifiers:
+#   - 'seed' - refers to seed pipeline (resolved to chembl.publication.*)
+#   - '{provider}' - matches {provider}.{seed_entity}.{field}
+#   - '{provider}.{entity}' - explicit full match
+# =============================================================================
+
+name: composite_publication
+version: "2.0"
+
+seed:
+  pipeline: chembl_publication
+  silver_table: silver/chembl/publication
+
+enrichers:
+  - pipeline: crossref_publication
+    join_keys: [doi]
+    optional: false
+    timeout_seconds: 300
+
+  - pipeline: pubmed_publication
+    join_keys: [pmid, pmc_id]
+    optional: true
+    timeout_seconds: 180
+
+merge:
+  strategy: left_outer
+  conflict_resolution: explicit_rules
+
+  # Priority: first source wins for each field
+  # 'seed' resolves to chembl (since seed.pipeline = chembl_publication)
+  field_priorities:
+    title:
+      - seed          # chembl.publication.title
+      - crossref      # crossref.publication.title
+      - pubmed        # pubmed.publication.title
+
+    abstract:
+      - crossref
+      - pubmed
+      - seed
+
+    citation_count:
+      - crossref      # Only crossref has this
+
+    journal:
+      - seed
+      - crossref
+
+  # Column ordering configuration (optional, uses defaults if not specified)
+  column_order:
+    provider_priority:
+      - chembl
+      - crossref
+      - pubmed
+      - openalex
+      - semantic_scholar
+
+  output:
+    silver: silver/composite/publication
+    gold: gold/composite/publication


### PR DESCRIPTION
## Summary
Introduces a new composite pipeline configuration for publication enrichment that orchestrates data from multiple sources (ChEMBL, Crossref, PubMed) following ADR-026 v2 column naming conventions.

## Key Changes
- **New configuration file**: `configs/composite/publication_enrichment.yaml`
  - Defines a composite pipeline that seeds from ChEMBL publication data and enriches it with Crossref and PubMed sources
  - Implements left outer join strategy with explicit conflict resolution rules
  
- **Column naming convention** (ADR-026 v2):
  - Business columns follow `{provider}.{entity}.{field}` pattern (e.g., `chembl.publication.title`)
  - Join keys (`doi`, `pmid`, `pmc_id`) and system columns excluded from renaming for compatibility
  
- **Field priority configuration**:
  - Defines source precedence for conflicting fields (e.g., title: seed → crossref → pubmed)
  - Supports both shorthand (`seed`, `crossref`) and explicit (`{provider}.{entity}`) source identifiers
  
- **Semantic column ordering**:
  - Organizes output columns into 11 semantic groups (system, identifiers, title, abstract, authors, etc.)
  - Within groups, columns ordered by provider priority: chembl → crossref → pubmed → openalex → semantic_scholar

## Implementation Details
- Crossref enrichment is mandatory (optional: false) with 300s timeout
- PubMed enrichment is optional with 180s timeout
- Output targets both silver and gold layers for data quality progression
- Configuration supports flexible join strategies and timeout management for external API calls