### PR TITLE
Rename PubMed ArticleSchema to PubMedPublicationSchema per ADR-024

### DIFF
--- a/docs/02-architecture/decisions/ADR-024-entity-naming-unification.md
+++ b/docs/02-architecture/decisions/ADR-024-entity-naming-unification.md
@@ -67,6 +67,13 @@ Original plan (not implemented):
 | `DocumentSchema` | `ChemblPublicationSchema` |
 | `CompoundSchema` | `PubchemMoleculeSchema` |
 | `ProteinSchema` | `UniprotTargetSchema` |
+| `ArticleSchema` | `PubMedPublicationSchema` |
+
+**Note:** PubMed's `ArticleSchema` was renamed to `PubMedPublicationSchema` (2026-01-25)
+to align with `entity_type: publication` in pipeline config and maintain consistency
+with other publication schemas (`ChemblPublicationSchema`, `OpenAlexPublicationSchema`,
+`SemanticScholarPublicationSchema`). A backward-compatibility alias `ArticleSchema`
+is provided but deprecated.
 
 ## Consequences
 
@@ -127,6 +134,7 @@ Original plan (not implemented):
 - `src/bioetl/domain/schemas/chembl/document.py` → `publication.py`
 - `src/bioetl/domain/schemas/chembl/document_similarity.py` → `publication_similarity.py`
 - `src/bioetl/domain/schemas/chembl/document_term.py` → `publication_term.py`
+- `src/bioetl/domain/schemas/pubmed/article.py` → `publication.py` — `ArticleSchema` → `PubMedPublicationSchema` (2026-01-25)
 
 **Factory Updates:**
 - `transformer_factory.py` — imports and registrations updated
@@ -149,8 +157,11 @@ Original plan (not implemented):
 
 ### Migration Guide
 
-**Note:** Since aliases were never implemented, old imports will raise `ImportError`.
+**Note:** Since aliases were never implemented for domain entities, old imports will raise `ImportError`.
 All code must use canonical names directly.
+
+**Exception:** `ArticleSchema` is provided as a deprecated alias for `PubMedPublicationSchema`
+for backward compatibility. Prefer `PubMedPublicationSchema` in new code.
 
 **Domain Entities:**
 ```python

--- a/src/bioetl/domain/schemas/pubmed/publication.py
+++ b/src/bioetl/domain/schemas/pubmed/publication.py
@@ -1,7 +1,10 @@
-"""Pandera schema for PubMed Article entity.
+"""Pandera schema for PubMed Publication entity.
 
 Aligned with RULES.md v5.10 and MEDLINE DTD.
 Source: https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_230101.dtd
+
+Note: File renamed from article.py to publication.py per ADR-024 Entity Naming Unification.
+PubMedPublicationSchema replaces ArticleSchema for consistency with other providers.
 """
 
 from __future__ import annotations
@@ -23,17 +26,20 @@ from bioetl.domain.validation import (
 )
 
 # Re-export for backwards compatibility
-__all__ = ["LOOKUP_METHODS", "ArticleSchema"]
+__all__ = ["LOOKUP_METHODS", "ArticleSchema", "PubMedPublicationSchema"]
 
 # === Fixed Value Constants ===
 PUBLICATION_STATUSES = ["ppublish", "epublish", "aheadofprint"]
 ISSN_TYPES = ["Print", "Electronic", "Linking"]
 
 
-class ArticleSchema(PublicationBaseSchema):
-    """PubMed Article validation schema for Silver layer.
+class PubMedPublicationSchema(PublicationBaseSchema):
+    """PubMed Publication validation schema for Silver layer.
 
     Represents a MEDLINE/PubMed citation record.
+
+    Note: Renamed from ArticleSchema per ADR-024 for consistency with
+    entity_type='publication' in pipeline configs and other providers.
     """
 
     # === Primary Key (str for cross-provider consistency) ===
@@ -236,5 +242,13 @@ class ArticleSchema(PublicationBaseSchema):
         strict = False  # Allow missing columns and extra columns
         ordered = False  # Changed to False for inheritance compatibility
         coerce = True
-        name = "ArticleSchema"
-        description = "PubMed Article Silver layer validation"
+        name = "PubMedPublicationSchema"
+        description = "PubMed Publication Silver layer validation"
+
+
+# Backward compatibility alias (deprecated)
+ArticleSchema = PubMedPublicationSchema
+"""Deprecated alias for PubMedPublicationSchema.
+
+Use PubMedPublicationSchema instead. This alias will be removed in v3.0.
+"""

--- a/tests/unit/domain/schemas/test_doi_validation.py
+++ b/tests/unit/domain/schemas/test_doi_validation.py
@@ -145,13 +145,13 @@ class TestDoiSchemaIntegration:
         assert hasattr(publication, "DOI_REGEX_PATTERN")
         assert publication.DOI_REGEX_PATTERN == DOI_REGEX_PATTERN
 
-    def test_pubmed_article_uses_doi_regex_pattern(self) -> None:
-        """Test PubMed ArticleSchema uses DOI_REGEX_PATTERN constant."""
-        from bioetl.domain.schemas.pubmed import article
+    def test_pubmed_publication_uses_doi_regex_pattern(self) -> None:
+        """Test PubMed PubMedPublicationSchema uses DOI_REGEX_PATTERN constant."""
+        from bioetl.domain.schemas.pubmed import publication
 
         # Verify the import exists
-        assert hasattr(article, "DOI_REGEX_PATTERN")
-        assert article.DOI_REGEX_PATTERN == DOI_REGEX_PATTERN
+        assert hasattr(publication, "DOI_REGEX_PATTERN")
+        assert publication.DOI_REGEX_PATTERN == DOI_REGEX_PATTERN
 
     def test_semanticscholar_publication_uses_doi_regex_pattern(self) -> None:
         """Test SemanticScholar PublicationSchema uses DOI_REGEX_PATTERN constant."""
@@ -191,12 +191,12 @@ class TestDoiSchemaIntegration:
         from bioetl.domain.schemas.crossref import publication as crossref_pub
         from bioetl.domain.schemas.crossref import work
         from bioetl.domain.schemas.openalex import publication as openalex_pub
-        from bioetl.domain.schemas.pubmed import article
+        from bioetl.domain.schemas.pubmed import publication as pubmed_pub
         from bioetl.domain.schemas.semanticscholar import publication as s2_pub
 
         patterns = [
             chembl_pub.DOI_REGEX_PATTERN,
-            article.DOI_REGEX_PATTERN,
+            pubmed_pub.DOI_REGEX_PATTERN,
             s2_pub.DOI_REGEX_PATTERN,
             openalex_pub.DOI_REGEX_PATTERN,
             crossref_pub.DOI_REGEX_PATTERN,

--- a/tests/unit/domain/schemas/test_year_validation.py
+++ b/tests/unit/domain/schemas/test_year_validation.py
@@ -281,9 +281,10 @@ class TestChemblYearValidation:
 
 @PANDERA_PYTHON314_SKIP
 class TestPubMedYearValidation:
-    """Year validation tests for ArticleSchema (PubMed).
+    """Year validation tests for PubMedPublicationSchema.
 
     Note: PubMed uses 'year' field (renamed from 'pub_year').
+    Schema renamed from ArticleSchema per ADR-024.
     """
 
     @pytest.fixture
@@ -341,38 +342,38 @@ class TestPubMedYearValidation:
 
     def test_year_boundary_values(self, valid_record: dict) -> None:
         """Should accept year at boundaries (1800 and 2100)."""
-        from bioetl.domain.schemas.pubmed.article import ArticleSchema
+        from bioetl.domain.schemas.pubmed.publication import PubMedPublicationSchema
 
         for year in [MIN_PUBLICATION_YEAR, MAX_PUBLICATION_YEAR]:
             valid_record["year"] = year
             df = pd.DataFrame([valid_record])
-            validated = ArticleSchema.validate(df)
+            validated = PubMedPublicationSchema.validate(df)
             assert validated["year"].iloc[0] == year
 
     def test_year_outside_range_fails(self, valid_record: dict) -> None:
         """Should reject year outside valid range."""
-        from bioetl.domain.schemas.pubmed.article import ArticleSchema
+        from bioetl.domain.schemas.pubmed.publication import PubMedPublicationSchema
 
         # Year below minimum
         valid_record["year"] = MIN_PUBLICATION_YEAR - 1
         df = pd.DataFrame([valid_record])
         with pytest.raises(SchemaError):
-            ArticleSchema.validate(df)
+            PubMedPublicationSchema.validate(df)
 
         # Year above maximum
         valid_record["year"] = MAX_PUBLICATION_YEAR + 1
         df = pd.DataFrame([valid_record])
         with pytest.raises(SchemaError):
-            ArticleSchema.validate(df)
+            PubMedPublicationSchema.validate(df)
 
     def test_year_field_renamed_from_pub_year(self, valid_record: dict) -> None:
         """Verify 'year' field is used instead of legacy 'pub_year'."""
-        from bioetl.domain.schemas.pubmed.article import ArticleSchema
+        from bioetl.domain.schemas.pubmed.publication import PubMedPublicationSchema
 
         # Record with 'year' should work
         valid_record["year"] = 2020
         df = pd.DataFrame([valid_record])
-        validated = ArticleSchema.validate(df)
+        validated = PubMedPublicationSchema.validate(df)
         assert "year" in validated.columns
 
         # Verify there's no 'pub_year' column in schema


### PR DESCRIPTION
## Summary
Implements the entity naming unification for PubMed schemas as specified in ADR-024. Renames `ArticleSchema` to `PubMedPublicationSchema` to align with the `entity_type: publication` in pipeline configurations and maintain consistency with other publication schemas from different providers (ChemblPublicationSchema, OpenAlexPublicationSchema, SemanticScholarPublicationSchema).

## Key Changes
- **Schema Rename**: `ArticleSchema` → `PubMedPublicationSchema` in `src/bioetl/domain/schemas/pubmed/publication.py`
- **File Rename**: `article.py` → `publication.py` in the pubmed schemas directory
- **Backward Compatibility**: Provides `ArticleSchema` as a deprecated alias pointing to `PubMedPublicationSchema`
- **Documentation**: Updated ADR-024 with the new mapping and migration notes
- **Test Updates**: Updated all test imports and references to use the new schema name and module path
- **Config Updates**: Updated Pandera schema config name and description to reflect the new canonical name

## Implementation Details
- The deprecated `ArticleSchema` alias is maintained for backward compatibility but marked for removal in v3.0
- All internal references updated to use `PubMedPublicationSchema` directly
- Test suite updated to import from `publication` module instead of `article`
- Documentation clarifies that this is an exception to the "no aliases" rule due to the need for backward compatibility during the transition period
- Maintains all existing validation logic and field definitions unchanged