### PR TITLE
Support title-only records in fallback lookup with indexed markers

### DIFF
--- a/src/bioetl/infrastructure/adapters/common/base_title_fallback.py
+++ b/src/bioetl/infrastructure/adapters/common/base_title_fallback.py
@@ -241,10 +241,14 @@ class BaseTitleFallbackHandler(ABC):
         Phase 3 of the three-phase fallback strategy. Handles entries
         where no DOI was provided, using only the title for lookup.
 
+        Supports two entry formats:
+        - Empty strings "" (legacy): looks up fallback_mapping.get("")
+        - Markers "__title_only_N__": looks up fallback_mapping.get(marker)
+
         Args:
-            entries: List of empty/placeholder entries (typically empty strings).
+            entries: List of entries - empty strings or __title_only_N__ markers.
             fallback_mapping: Mapping {entry: title} for lookup.
-                Also checks fallback_mapping.get("") as fallback.
+                Supports both marker keys and empty string fallback.
             limit: Maximum total records to return.
             fetched: Number of records already fetched.
 
@@ -255,7 +259,8 @@ class BaseTitleFallbackHandler(ABC):
             if limit and fetched >= limit:
                 return
 
-            # Try entry key first, then empty string fallback
+            # Try entry key first (supports __title_only_N__ markers),
+            # then empty string fallback for legacy compatibility
             title = fallback_mapping.get(entry, fallback_mapping.get(""))
             if not title:
                 continue
@@ -263,6 +268,7 @@ class BaseTitleFallbackHandler(ABC):
             self._logger.info(
                 self._event_title_only_attempt,
                 title=self._truncate_title(title),
+                marker=entry if entry.startswith("__title_only_") else None,
             )
 
             result = await self._search_by_title(title)

--- a/src/bioetl/infrastructure/adapters/input/csv_filter_reader.py
+++ b/src/bioetl/infrastructure/adapters/input/csv_filter_reader.py
@@ -134,6 +134,11 @@ class CsvFilterReader:
         Loads primary filter IDs and builds a mapping from primary to fallback
         values for use when primary lookup fails (e.g., DOI → title fallback).
 
+        Handles three cases:
+        1. Records with DOI and title → DOI in filter_ids, DOI→title in mapping
+        2. Records with DOI only → DOI in filter_ids, no fallback
+        3. Records with title only → empty string in filter_ids, ""→title in mapping
+
         Args:
             source_path: Path to the CSV file.
             primary_column: Name of the primary filter column (e.g., 'doi').
@@ -142,25 +147,46 @@ class CsvFilterReader:
         Returns:
             Tuple of (FilterLoadResult, fallback_mapping).
             fallback_mapping maps primary values to fallback values.
+            Empty string key "" maps to titles for records without primary ID.
         """
         df = await asyncio.to_thread(self._read_csv_dataframe, source_path)
 
-        # Standard loading of primary IDs
-        all_ids = self._extract_column_ids(df, primary_column)
-        unique_ids, unique_count, duplicate_count, duplicates = (
-            self._compute_duplicate_stats(all_ids)
-        )
-
-        # Build fallback mapping
+        # Build fallback mapping and collect IDs (including empty placeholders)
         fallback_mapping: dict[str, str] = {}
-        if fallback_column in df.columns:
+        all_ids: list[str] = []
+        title_only_count = 0
+
+        if fallback_column not in df.columns:
+            if self._logger:
+                self._logger.warning(
+                    "fallback_column_not_found",
+                    source_path=source_path,
+                    fallback_column=fallback_column,
+                    available_columns=df.columns,
+                )
+            # Fall back to standard extraction without fallback support
+            all_ids = self._extract_column_ids(df, primary_column)
+        else:
+            # Process all rows, handling empty primary values
             for row in df.iter_rows(named=True):
                 primary_val = row.get(primary_column)
                 fallback_val = row.get(fallback_column)
-                if primary_val and fallback_val:
-                    fallback_mapping[str(primary_val).strip()] = str(
-                        fallback_val
-                    ).strip()
+
+                primary_str = str(primary_val).strip() if primary_val else ""
+                fallback_str = str(fallback_val).strip() if fallback_val else ""
+
+                if primary_str:
+                    # Case 1 & 2: Record has DOI
+                    all_ids.append(primary_str)
+                    if fallback_str:
+                        fallback_mapping[primary_str] = fallback_str
+                elif fallback_str:
+                    # Case 3: Record has title only (empty DOI)
+                    # Use indexed marker for title-only lookup (Phase 3)
+                    marker = f"__title_only_{title_only_count}__"
+                    all_ids.append(marker)
+                    fallback_mapping[marker] = fallback_str
+                    title_only_count += 1
 
             if self._logger:
                 self._logger.info(
@@ -169,14 +195,13 @@ class CsvFilterReader:
                     primary_column=primary_column,
                     fallback_column=fallback_column,
                     mapping_count=len(fallback_mapping),
+                    title_only_count=title_only_count,
                 )
-        elif self._logger:
-            self._logger.warning(
-                "fallback_column_not_found",
-                source_path=source_path,
-                fallback_column=fallback_column,
-                available_columns=df.columns,
-            )
+
+        # Compute stats (markers __title_only_N__ are included as they are non-empty)
+        unique_ids, unique_count, duplicate_count, duplicates = (
+            self._compute_duplicate_stats([id_ for id_ in all_ids if id_])
+        )
 
         result = FilterLoadResult(
             ids=unique_ids,

--- a/src/bioetl/infrastructure/adapters/openalex/client.py
+++ b/src/bioetl/infrastructure/adapters/openalex/client.py
@@ -239,8 +239,15 @@ class OpenAlexAdapter(BaseHttpAdapter):
         fetched = 0
         found_dois: set[str] = set()
 
-        valid_dois = [d for d in filter_ids if d and d.strip()]
-        title_only_entries = [d for d in filter_ids if not d or not d.strip()]
+        # Separate DOIs from title-only markers (__title_only_N__ format)
+        valid_dois = [
+            d for d in filter_ids
+            if d and d.strip() and not d.startswith("__title_only_")
+        ]
+        title_only_entries = [
+            d for d in filter_ids
+            if not d or not d.strip() or d.startswith("__title_only_")
+        ]
 
         # Phase 1: Batch DOI lookup
         async for work in self._batch_doi_lookup(

--- a/tests/unit/infrastructure/adapters/test_csv_filter_reader.py
+++ b/tests/unit/infrastructure/adapters/test_csv_filter_reader.py
@@ -402,7 +402,7 @@ class TestCsvFilterReaderLoadFilterWithFallback:
         with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
             f.write("doi,title\n")
             f.write("10.1000/valid,Valid Title\n")
-            f.write(",Empty DOI\n")  # Empty primary
+            f.write(",Empty DOI Title\n")  # Empty primary (title-only)
             f.write("10.1000/notitle,\n")  # Empty fallback
             path = f.name
 
@@ -411,11 +411,49 @@ class TestCsvFilterReaderLoadFilterWithFallback:
                 path, "doi", "title"
             )
 
-            # Empty DOI should be excluded from IDs
+            # Empty DOI should be represented as marker in IDs
             assert "" not in result.ids
-            # Mapping should only include rows with both values
+            # Title-only entry should have a marker
+            assert "__title_only_0__" in result.ids
+            # Mapping should include DOI→title and marker→title
             assert "10.1000/valid" in mapping
+            assert mapping["10.1000/valid"] == "Valid Title"
+            assert "__title_only_0__" in mapping
+            assert mapping["__title_only_0__"] == "Empty DOI Title"
             assert "10.1000/notitle" not in mapping  # No fallback value
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    async def test_load_filter_with_fallback_multiple_title_only_entries(
+        self, csv_reader
+    ):
+        """Test that multiple title-only entries get unique markers."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            f.write("doi,title\n")
+            f.write("10.1000/valid,Valid Title\n")
+            f.write(",First Title Only\n")
+            f.write(",Second Title Only\n")
+            f.write(",Third Title Only\n")
+            path = f.name
+
+        try:
+            result, mapping = await csv_reader.load_filter_with_fallback(
+                path, "doi", "title"
+            )
+
+            # Should have markers for all title-only entries
+            assert "__title_only_0__" in result.ids
+            assert "__title_only_1__" in result.ids
+            assert "__title_only_2__" in result.ids
+
+            # Mapping should have all titles
+            assert mapping["__title_only_0__"] == "First Title Only"
+            assert mapping["__title_only_1__"] == "Second Title Only"
+            assert mapping["__title_only_2__"] == "Third Title Only"
+
+            # Total count should include all entries
+            assert result.total_count == 4
+            assert len(result.ids) == 4  # 1 DOI + 3 markers
         finally:
             Path(path).unlink(missing_ok=True)
 


### PR DESCRIPTION
## Summary
This PR enhances the fallback lookup strategy to properly handle records that have titles but no primary identifiers (DOIs). Instead of discarding these records, they are now tracked using indexed markers (`__title_only_N__`) and processed in Phase 3 of the three-phase fallback strategy.

## Key Changes

- **CSV Filter Reader** (`csv_filter_reader.py`):
  - Modified `load_filter_with_fallback()` to generate unique `__title_only_N__` markers for records with empty primary IDs but valid fallback values
  - Records are now categorized into three cases: DOI+title, DOI only, and title only
  - Title-only entries are added to filter IDs as markers and mapped to their titles in the fallback mapping
  - Added logging to track the count of title-only records processed

- **Base Title Fallback** (`base_title_fallback.py`):
  - Updated `process_title_only_entries()` to support both legacy empty string entries and new `__title_only_N__` markers
  - Enhanced documentation to clarify the two supported entry formats
  - Added marker logging to distinguish between legacy and new marker-based lookups

- **OpenAlex Client** (`client.py`):
  - Updated filter ID separation logic to correctly identify `__title_only_N__` markers as title-only entries
  - Ensures markers are routed to Phase 3 processing instead of being treated as invalid DOIs

- **Tests** (`test_csv_filter_reader.py`):
  - Updated existing test to verify marker generation for title-only entries
  - Added new test to verify multiple title-only entries receive unique sequential markers

## Implementation Details

- Title-only markers follow the format `__title_only_N__` where N is a zero-indexed counter
- The fallback mapping now supports both DOI keys and marker keys, enabling flexible lookup strategies
- Backward compatibility is maintained: empty string fallback still works for legacy code paths
- All title-only records are now included in the total count and processing pipeline