### PR TITLE
ADR-031: Formalize loading strategy for publication pipelines

### DIFF
--- a/configs/pipelines/chembl/publication.yaml
+++ b/configs/pipelines/chembl/publication.yaml
@@ -10,10 +10,13 @@ entity_type: publication
 version: "2.1.0"
 description: "Extract scientific publications from ChEMBL API"
 
-# Pagination strategy (ADR-030)
+# Loading strategy (ADR-030, ADR-031)
 # Publication entities require full scan on each run due to API offset instability.
 # Deduplication is handled on Silver layer via content_hash.
+# - full_scan_only: Explicit strategy disabling checkpoint resume
+# - watermark_based: Placeholder for future incremental loading (not implemented)
 force_full_scan: true
+loading_strategy: full_scan_only
 
 primary_keys: ["document_chembl_id"]
 silver_table: "chembl_publication"

--- a/configs/pipelines/chembl/publication_similarity.yaml
+++ b/configs/pipelines/chembl/publication_similarity.yaml
@@ -10,10 +10,11 @@ entity_type: publication_similarity
 version: "2.1.0"
 description: "Extract publication similarity data (Tanimoto coefficients) from ChEMBL API"
 
-# Pagination strategy (ADR-030)
+# Loading strategy (ADR-030, ADR-031)
 # Publication entities require full scan on each run due to API offset instability.
 # Deduplication is handled on Silver layer via content_hash.
 force_full_scan: true
+loading_strategy: full_scan_only
 
 primary_keys: ["sim_id"]
 silver_table: "chembl_publication_similarity"

--- a/configs/pipelines/chembl/publication_term.yaml
+++ b/configs/pipelines/chembl/publication_term.yaml
@@ -11,10 +11,11 @@ entity_type: publication_term
 version: "2.1.0"
 description: "Extract publication terms (MeSH, keywords) from ChEMBL Publication records"
 
-# Pagination strategy (ADR-030)
+# Loading strategy (ADR-030, ADR-031)
 # Publication entities require full scan on each run due to API offset instability.
 # Deduplication is handled on Silver layer via content_hash.
 force_full_scan: true
+loading_strategy: full_scan_only
 
 # Composite primary key (document_chembl_id + term_type + term)
 # entity_id is generated as SHA256 hash of composite key

--- a/configs/pipelines/crossref/publication.yaml
+++ b/configs/pipelines/crossref/publication.yaml
@@ -10,10 +10,11 @@ entity_type: work
 version: "1.2.0"
 description: "Enrich publication records with CrossRef metadata via DOI resolution"
 
-# Pagination strategy (ADR-030)
+# Loading strategy (ADR-030, ADR-031)
 # Publication entities require full scan on each run due to API offset instability.
 # Deduplication is handled on Silver layer via content_hash.
 force_full_scan: true
+loading_strategy: full_scan_only
 
 primary_keys: ["doi"]
 silver_table: "crossref_publication"

--- a/configs/pipelines/openalex/publication.yaml
+++ b/configs/pipelines/openalex/publication.yaml
@@ -12,10 +12,11 @@ entity_type: publication
 version: "1.2.0"
 description: "Batch DOI resolution via OpenAlex with title fallback"
 
-# Pagination strategy (ADR-030)
+# Loading strategy (ADR-030, ADR-031)
 # Publication entities require full scan on each run due to API offset instability.
 # Deduplication is handled on Silver layer via content_hash.
 force_full_scan: true
+loading_strategy: full_scan_only
 
 primary_keys: ["openalex_id"]
 silver_table: "openalex_publication"

--- a/configs/pipelines/pubmed/publication.yaml
+++ b/configs/pipelines/pubmed/publication.yaml
@@ -11,10 +11,11 @@ entity_type: publication
 version: "1.2.0"
 description: "Extract publication metadata from PubMed via Entrez API"
 
-# Pagination strategy (ADR-030)
+# Loading strategy (ADR-030, ADR-031)
 # Publication entities require full scan on each run due to API offset instability.
 # Deduplication is handled on Silver layer via content_hash.
 force_full_scan: true
+loading_strategy: full_scan_only
 
 primary_keys: ["pmid"]
 silver_table: "pubmed_publication"

--- a/configs/pipelines/semanticscholar/publication.yaml
+++ b/configs/pipelines/semanticscholar/publication.yaml
@@ -12,10 +12,11 @@ entity_type: publication
 version: "1.2.0"
 description: "Batch DOI resolution via Semantic Scholar with title fallback"
 
-# Pagination strategy (ADR-030)
+# Loading strategy (ADR-030, ADR-031)
 # Publication entities require full scan on each run due to API offset instability.
 # Deduplication is handled on Silver layer via content_hash.
 force_full_scan: true
+loading_strategy: full_scan_only
 
 primary_keys: ["paper_id"]
 silver_table: "semanticscholar_publication"

--- a/docs/02-architecture/decisions/ADR-031-loading-strategy-formalization.md
+++ b/docs/02-architecture/decisions/ADR-031-loading-strategy-formalization.md
@@ -1,0 +1,203 @@
+# ADR-031: Loading Strategy Formalization
+
+**Status:** Accepted
+**Date:** 2026-01-26
+**Decision makers:** @BioETL-Team
+**Relates to:** ADR-030 (Publication Pagination Strategy), ADR-011 (Remove Watermark)
+
+## Context
+
+### Problem Statement
+
+Publication pipelines currently have implicit loading behavior:
+1. They **look like** incremental pipelines (same config structure)
+2. They **behave as** full-scan pipelines (via `force_full_scan: true`)
+3. There is **no explicit policy** documenting this distinction
+
+This creates confusion:
+- New team members assume checkpoint resume works for publications
+- The boolean `force_full_scan` flag doesn't clearly communicate intent
+- No formalized extension point for future watermark-based loading
+
+### Current State (ADR-030)
+
+ADR-030 introduced `force_full_scan: bool` to disable checkpoint resume:
+
+```yaml
+# Publication pipeline
+force_full_scan: true  # But why? What's the strategy?
+```
+
+This works but has limitations:
+- Boolean flag doesn't scale to multiple strategies
+- No explicit documentation of loading semantics in the config
+- No type-safe validation of strategy-specific constraints
+
+## Decision
+
+Introduce explicit `LoadingStrategy` enum and formalize loading behavior:
+
+### 1. LoadingStrategy Enum
+
+```python
+class LoadingStrategy(str, Enum):
+    """Loading strategy for pipeline data extraction."""
+
+    FULL_SCAN_ONLY = "full_scan_only"
+    """Each run performs full scan. Checkpoint resume disabled."""
+
+    WATERMARK_BASED = "watermark_based"
+    """Incremental loading via watermark. PLACEHOLDER - NOT YET IMPLEMENTED."""
+```
+
+### 2. PipelineConfig Field
+
+```python
+@dataclass(frozen=True, slots=True)
+class PipelineConfig:
+    # ... existing fields ...
+
+    # Pagination strategy (ADR-030)
+    force_full_scan: bool = False
+
+    # Loading strategy (ADR-031) - explicit formalization
+    loading_strategy: LoadingStrategy | str | None = None
+```
+
+### 3. YAML Configuration
+
+```yaml
+# configs/pipelines/chembl/publication.yaml
+pipeline_name: chembl_publication
+provider: chembl
+entity_type: publication
+
+# Loading strategy (ADR-030, ADR-031)
+# Explicit strategy declaration
+force_full_scan: true
+loading_strategy: full_scan_only
+```
+
+### 4. WatermarkStrategyPort (Placeholder)
+
+```python
+@runtime_checkable
+class WatermarkStrategyPort(Protocol):
+    """Port for watermark-based incremental loading.
+
+    PLACEHOLDER - NOT YET IMPLEMENTED.
+    """
+
+    async def get_watermark(self, pipeline_name: str) -> datetime | int | str | None: ...
+    async def update_watermark(self, pipeline_name: str, watermark: ...) -> None: ...
+    async def clear_watermark(self, pipeline_name: str) -> None: ...
+```
+
+### 5. Validation Rules
+
+| Strategy | Checkpoint Resume | Watermark | Deduplication |
+|----------|------------------|-----------|---------------|
+| `full_scan_only` | BLOCKED | N/A | content_hash on Silver |
+| `watermark_based` | ALLOWED | REQUIRED | watermark field filtering |
+
+### 6. Backward Compatibility
+
+- `force_full_scan: true` continues to work
+- When `loading_strategy` is not set, it's derived from `force_full_scan`
+- Explicit `loading_strategy` takes precedence over `force_full_scan`
+
+## Consequences
+
+### Positive
+
+1. **Explicit semantics**: Config clearly states loading strategy
+2. **Type safety**: Enum prevents invalid strategy values
+3. **Extensible**: Easy to add new strategies (e.g., cursor-based)
+4. **Self-documenting**: Strategy name communicates intent
+5. **Validation**: Can enforce strategy-specific constraints
+
+### Negative
+
+1. **Migration effort**: Existing configs need `loading_strategy` field
+2. **Two fields**: Both `force_full_scan` and `loading_strategy` exist (temporary)
+3. **Unused port**: `WatermarkStrategyPort` is a placeholder
+
+### Mitigations
+
+- **Migration**: All publication configs updated with `loading_strategy: full_scan_only`
+- **Two fields**: `loading_strategy` takes precedence; `force_full_scan` maintained for compatibility
+- **Unused port**: Clearly marked as placeholder; NoOp implementation provided
+
+## Why Publication !== Activity
+
+| Aspect | Activity Pipelines | Publication Pipelines |
+|--------|-------------------|----------------------|
+| **API behavior** | Stable offset pagination | Offset shifts on updates |
+| **Update frequency** | Rare (assay data static) | Frequent (citations, metadata) |
+| **Checkpoint safety** | Safe to resume from offset | Unsafe (data loss/duplicates) |
+| **Recommended strategy** | `watermark_based` (future) | `full_scan_only` |
+
+## Implementation
+
+### Files Modified
+
+**Domain:**
+- `src/bioetl/domain/medallion.py` — Add `LoadingStrategy` enum
+- `src/bioetl/domain/config.py` — Add `loading_strategy` field to `PipelineConfig`
+- `src/bioetl/domain/ports/watermark.py` — Add `WatermarkStrategyPort` (placeholder)
+- `src/bioetl/domain/ports/__init__.py` — Export new port
+
+**Application:**
+- `src/bioetl/application/core/checkpoint_manager.py` — Use `LoadingStrategy` for validation
+
+**Infrastructure:**
+- `src/bioetl/infrastructure/schemas/pipeline_config.py` — Add `loading_strategy` to YAML schema
+- `src/bioetl/infrastructure/config/_base.py` — Pass `loading_strategy` in conversion
+
+**Composition:**
+- `src/bioetl/composition/factories/services_factory.py` — Pass `loading_strategy` to CheckpointManager
+- `src/bioetl/composition/factories/pipeline_factory.py` — Use `config.loading_strategy`
+
+**Configs:**
+- `configs/pipelines/chembl/publication.yaml` — Add `loading_strategy: full_scan_only`
+- `configs/pipelines/chembl/publication_term.yaml` — Add `loading_strategy: full_scan_only`
+- `configs/pipelines/chembl/publication_similarity.yaml` — Add `loading_strategy: full_scan_only`
+- `configs/pipelines/pubmed/publication.yaml` — Add `loading_strategy: full_scan_only`
+- `configs/pipelines/crossref/publication.yaml` — Add `loading_strategy: full_scan_only`
+- `configs/pipelines/openalex/publication.yaml` — Add `loading_strategy: full_scan_only`
+- `configs/pipelines/semanticscholar/publication.yaml` — Add `loading_strategy: full_scan_only`
+
+### Tests
+
+- `tests/unit/domain/test_medallion.py` — Test `LoadingStrategy` enum
+- `tests/unit/application/core/test_checkpoint_manager.py` — Test loading_strategy validation
+- `tests/architecture/test_force_full_scan_publication.py` — Verify publication configs
+
+## Future Work
+
+### Watermark Implementation (When Ready)
+
+Prerequisites:
+1. Confirm API provides reliable `updated_at` or version field
+2. Verify field is monotonically increasing
+3. Ensure API supports filtering by watermark
+
+Steps:
+1. Implement `LocalWatermarkStorage` adapter
+2. Add `watermark_field` to pipeline config
+3. Update fetchers to use watermark filtering
+4. Add integration tests with VCR
+
+### Strategy Migration
+
+Once watermark is implemented:
+1. Activity pipelines: Switch to `watermark_based`
+2. Publication pipelines: Keep `full_scan_only`
+3. Deprecate `force_full_scan` field
+
+## References
+
+- RULES.md §3 — Medallion Architecture
+- ADR-030 — Publication Pagination Strategy
+- ADR-011 — Remove Watermark Mechanism
+- ChEMBL API Documentation — Offset pagination behavior

--- a/src/bioetl/application/core/checkpoint_manager.py
+++ b/src/bioetl/application/core/checkpoint_manager.py
@@ -3,14 +3,16 @@
 This module is framework-agnostic and handles checkpoint persistence
 for pipeline run tracking.
 
-Supports force_full_scan mode (ADR-030) which disables offset-based resume
-for entities where API offset pagination is unreliable (e.g., publications).
+Supports force_full_scan mode (ADR-030) and loading_strategy (ADR-031) which
+control offset-based resume behavior for entities where API offset pagination
+is unreliable (e.g., publications).
 """
 
 from __future__ import annotations
 
 from typing import Any
 
+from bioetl.domain.medallion import LoadingStrategy
 from bioetl.domain.ports import CheckpointPort, LoggerPort
 from bioetl.domain.types import RunID
 
@@ -19,8 +21,8 @@ class CheckpointManager:
     """Framework-agnostic checkpoint management.
 
     Handles checkpoint persistence for pipeline run tracking with support
-    for force_full_scan mode (ADR-030) which disables checkpoint-based
-    resume for entities with unreliable offset pagination.
+    for force_full_scan mode (ADR-030) and loading_strategy (ADR-031) which
+    disable checkpoint-based resume for entities with unreliable offset pagination.
     """
 
     def __init__(
@@ -32,6 +34,7 @@ class CheckpointManager:
         resume: bool,
         *,
         force_full_scan: bool = False,
+        loading_strategy: LoadingStrategy | None = None,
     ) -> None:
         """Initialize checkpoint manager.
 
@@ -45,6 +48,8 @@ class CheckpointManager:
                 performs a full scan. Used for entities with unreliable offset
                 pagination (e.g., publications). Deduplication is handled on
                 Silver layer via content_hash. See ADR-030.
+            loading_strategy: Explicit loading strategy (ADR-031). Takes precedence
+                over force_full_scan if provided. FULL_SCAN_ONLY disables resume.
 
         """
         self._checkpoint = checkpoint_port
@@ -53,28 +58,34 @@ class CheckpointManager:
         self._run_id = run_id
         self._resume = resume
         self._force_full_scan = force_full_scan
+        # Resolve loading_strategy: explicit value takes precedence
+        if loading_strategy is not None:
+            self._loading_strategy = loading_strategy
+        else:
+            self._loading_strategy = LoadingStrategy.from_force_full_scan(force_full_scan)
 
     async def load_checkpoint(self) -> dict[str, Any] | None:
         """Load checkpoint if resuming.
 
-        When force_full_scan is enabled (ADR-030), checkpoint loading is blocked
-        and a warning is logged. This ensures each run performs a full scan of
-        the data source, with deduplication handled on Silver layer via content_hash.
+        When loading_strategy is FULL_SCAN_ONLY (ADR-030, ADR-031), checkpoint loading
+        is blocked and a warning is logged. This ensures each run performs a full scan
+        of the data source, with deduplication handled on Silver layer via content_hash.
 
         Returns:
             Checkpoint metadata dict if resume is enabled and checkpoint exists,
-            None if resume is disabled, force_full_scan is enabled, or no checkpoint.
+            None if resume is disabled, loading_strategy forbids resume, or no checkpoint.
 
         """
-        # Block resume for force_full_scan pipelines (ADR-030)
-        if self._resume and self._force_full_scan:
+        # Block resume for FULL_SCAN_ONLY loading strategy (ADR-030, ADR-031)
+        if self._resume and not self._loading_strategy.allows_checkpoint_resume:
             self._logger.warning(
-                "Checkpoint resume blocked for force_full_scan pipeline. "
+                "Checkpoint resume blocked for full_scan_only pipeline. "
                 "Each run performs a full scan; deduplication via content_hash on Silver. "
-                "See ADR-030 for details.",
+                "See ADR-030 and ADR-031 for details.",
                 extra={
                     "pipeline": self._pipeline_name,
-                    "force_full_scan": True,
+                    "loading_strategy": self._loading_strategy.value,
+                    "force_full_scan": self._force_full_scan,
                     "resume_requested": True,
                 },
             )

--- a/src/bioetl/composition/factories/pipeline_factory.py
+++ b/src/bioetl/composition/factories/pipeline_factory.py
@@ -33,6 +33,7 @@ from bioetl.composition.services.versioning import (
     get_pipeline_version,
 )
 from bioetl.domain.locking import LockContextHolder
+from bioetl.domain.medallion import LoadingStrategy
 from bioetl.domain.value_objects.run_context import RunContext
 from bioetl.infrastructure.config import load_pipeline_config, yaml_config_to_domain
 
@@ -480,6 +481,7 @@ def assemble_runner(
     # Create Helper Components using ServicesBuilder
     logger_port = observability.logger
 
+    # Cast loading_strategy since __post_init__ converts str to LoadingStrategy enum
     checkpoint_manager = ServicesBuilder.create_checkpoint_manager(
         checkpoint_port=pipeline.services.checkpoint,
         logger=logger_port,
@@ -487,6 +489,7 @@ def assemble_runner(
         run_id=pipeline.run_id,
         resume=pipeline.runtime.resume,
         force_full_scan=pipeline.config.force_full_scan,
+        loading_strategy=cast(LoadingStrategy | None, pipeline.config.loading_strategy),
     )
 
     # Create lifecycle service (M5)

--- a/src/bioetl/composition/factories/services_factory.py
+++ b/src/bioetl/composition/factories/services_factory.py
@@ -26,6 +26,7 @@ from bioetl.composition.factories.dq_factory import DQServicesFactory
 from bioetl.composition.factories.storage import StorageContext, StorageFactory
 from bioetl.domain.config import TableConfig
 from bioetl.domain.error_classifier import ErrorClassifier
+from bioetl.domain.medallion import LoadingStrategy
 from bioetl.infrastructure.checkpoint.local_checkpoint import LocalCheckpoint
 from bioetl.infrastructure.locking.memory_lock import MemoryLock
 from bioetl.infrastructure.observability.noop_metrics import NoOpMetrics
@@ -379,6 +380,7 @@ class ServicesBuilder:
         resume: bool,
         *,
         force_full_scan: bool = False,
+        loading_strategy: LoadingStrategy | None = None,
     ) -> CheckpointManager:
         """Create configured CheckpointManager.
 
@@ -390,6 +392,8 @@ class ServicesBuilder:
             resume: Whether to resume from previous checkpoint
             force_full_scan: If True, checkpoint resume is disabled (ADR-030).
                 Used for entities with unreliable offset pagination like publications.
+            loading_strategy: Explicit loading strategy (ADR-031). Takes precedence
+                over force_full_scan if provided. FULL_SCAN_ONLY disables resume.
 
         Returns:
             Configured CheckpointManager instance
@@ -401,6 +405,7 @@ class ServicesBuilder:
             run_id=run_id,
             resume=resume,
             force_full_scan=force_full_scan,
+            loading_strategy=loading_strategy,
         )
 
     @staticmethod

--- a/src/bioetl/domain/config.py
+++ b/src/bioetl/domain/config.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal
 
-from bioetl.domain.medallion import GoldWriteMode, SilverWriteMode
+from bioetl.domain.medallion import GoldWriteMode, LoadingStrategy, SilverWriteMode
 from bioetl.domain.types import RunType
 
 if TYPE_CHECKING:
@@ -320,6 +320,31 @@ def _convert_gold_write_mode(mode: GoldWriteMode | str) -> GoldWriteMode:
     return GoldWriteMode.from_string(mode)
 
 
+def _resolve_loading_strategy(
+    loading_strategy: LoadingStrategy | str | None,
+    force_full_scan: bool,
+) -> LoadingStrategy:
+    """Resolve loading_strategy from explicit value or force_full_scan flag.
+
+    Priority:
+    1. Explicit loading_strategy if provided
+    2. Derived from force_full_scan for backward compatibility
+
+    Args:
+        loading_strategy: Explicit strategy value or None
+        force_full_scan: Legacy boolean flag
+
+    Returns:
+        Resolved LoadingStrategy enum value
+    """
+    if loading_strategy is not None:
+        if isinstance(loading_strategy, LoadingStrategy):
+            return loading_strategy
+        return LoadingStrategy.from_string(loading_strategy)
+    # Derive from force_full_scan for backward compatibility
+    return LoadingStrategy.from_force_full_scan(force_full_scan)
+
+
 @dataclass(frozen=True, slots=True)
 class TableConfig:
     """Configuration for database tables and keys.
@@ -403,16 +428,24 @@ class PipelineConfig:
     transform_version: str | None = None
     transform_steps: tuple[str, ...] = ()
 
-    # Pagination strategy (ADR-030)
+    # Pagination strategy (ADR-030, ADR-031)
     # When True, checkpoint-based resume is disabled and each run performs a full scan.
     # Deduplication is handled on Silver layer via content_hash.
     # Required for publication entities due to API offset instability.
     force_full_scan: bool = False
 
+    # Loading strategy (ADR-031)
+    # Explicit formalization of data loading approach.
+    # - FULL_SCAN_ONLY: Each run performs full scan, checkpoint resume disabled
+    # - WATERMARK_BASED: Incremental loading via watermark (placeholder, not implemented)
+    # If not specified, derived from force_full_scan for backward compatibility.
+    loading_strategy: LoadingStrategy | str | None = None
+
     def __post_init__(self) -> None:
         """Convert lists to tuples and validate configuration on creation."""
         self._ensure_immutability()
         self._convert_write_modes()
+        self._resolve_loading_strategy()
         self._validate_config()
 
     def _ensure_immutability(self) -> None:
@@ -434,6 +467,20 @@ class PipelineConfig:
         object.__setattr__(
             self, "gold_write_mode", _convert_gold_write_mode(self.gold_write_mode)
         )
+
+    def _resolve_loading_strategy(self) -> None:
+        """Resolve loading_strategy from explicit value or force_full_scan.
+
+        Ensures consistency between loading_strategy and force_full_scan fields.
+        Validates that explicit loading_strategy matches force_full_scan when both set.
+        """
+        resolved = _resolve_loading_strategy(self.loading_strategy, self.force_full_scan)
+        object.__setattr__(self, "loading_strategy", resolved)
+
+        # Validate consistency: if both explicit and force_full_scan conflict
+        if self.loading_strategy == LoadingStrategy.FULL_SCAN_ONLY and not self.force_full_scan:
+            # Update force_full_scan to match explicit loading_strategy
+            object.__setattr__(self, "force_full_scan", True)
 
     def _validate_config(self) -> None:
         """Validate configuration values."""

--- a/src/bioetl/domain/medallion.py
+++ b/src/bioetl/domain/medallion.py
@@ -165,6 +165,86 @@ class WriteModePolicy:
             )
 
 
+class LoadingStrategy(str, Enum):
+    """Loading strategy for pipeline data extraction.
+
+    Determines how the pipeline handles incremental vs full data loading.
+    This formalizes the implicit behavior previously controlled by force_full_scan.
+
+    Attributes:
+        FULL_SCAN_ONLY: Each run performs a full scan of the data source.
+            Checkpoint-based resume is disabled. Deduplication is handled
+            on Silver layer via content_hash. Required for entities with
+            unstable API pagination (e.g., publications).
+        WATERMARK_BASED: Incremental loading based on watermark field.
+            NOT YET IMPLEMENTED - placeholder for future watermark support.
+            Requires confirmed watermark field availability in source API.
+
+    Example:
+        >>> strategy = LoadingStrategy.FULL_SCAN_ONLY
+        >>> strategy.allows_checkpoint_resume
+        False
+        >>> strategy = LoadingStrategy.WATERMARK_BASED
+        >>> strategy.allows_checkpoint_resume
+        True
+
+    See Also:
+        ADR-030: Publication pagination strategy (force_full_scan)
+        ADR-031: Loading strategy formalization
+    """
+
+    FULL_SCAN_ONLY = "full_scan_only"
+    """Full scan on each run. No checkpoint resume. Deduplication via content_hash."""
+
+    WATERMARK_BASED = "watermark_based"
+    """Incremental loading via watermark. Placeholder - NOT YET IMPLEMENTED."""
+
+    @property
+    def allows_checkpoint_resume(self) -> bool:
+        """Check if this strategy allows checkpoint-based resume.
+
+        Returns:
+            True if checkpoint resume is allowed, False otherwise.
+        """
+        return self != LoadingStrategy.FULL_SCAN_ONLY
+
+    @classmethod
+    def from_string(cls, value: str) -> LoadingStrategy:
+        """Convert string to LoadingStrategy with validation.
+
+        Args:
+            value: String value (e.g., "full_scan_only", "watermark_based")
+
+        Returns:
+            Corresponding LoadingStrategy enum value
+
+        Raises:
+            ValueError: If value is not a valid loading strategy
+        """
+        try:
+            return cls(value.lower())
+        except ValueError:
+            valid = ", ".join(s.value for s in cls)
+            raise ValueError(
+                f"Invalid loading strategy: '{value}'. Valid strategies: {valid}"
+            ) from None
+
+    @classmethod
+    def from_force_full_scan(cls, force_full_scan: bool) -> LoadingStrategy:
+        """Convert legacy force_full_scan flag to LoadingStrategy.
+
+        Provides backward compatibility with existing configs using
+        force_full_scan: true/false.
+
+        Args:
+            force_full_scan: Legacy boolean flag
+
+        Returns:
+            FULL_SCAN_ONLY if force_full_scan is True, WATERMARK_BASED otherwise
+        """
+        return cls.FULL_SCAN_ONLY if force_full_scan else cls.WATERMARK_BASED
+
+
 class ClearPolicy(str, Enum):
     """Policy for clearing medallion layers.
 

--- a/src/bioetl/domain/ports/__init__.py
+++ b/src/bioetl/domain/ports/__init__.py
@@ -19,6 +19,7 @@ This package contains all port definitions organized by domain:
 - normalization: UnitConverterPort, ValueValidatorPort, ActivityAggregatorPort
 - data_normalization: DataNormalizationPort for text/data normalization
 - delta_reader: DeltaReaderPort for read-only Delta table access
+- watermark: WatermarkStrategyPort for incremental loading (ADR-031, placeholder)
 """
 
 from bioetl.domain.ports.audit import (
@@ -97,6 +98,7 @@ from bioetl.domain.ports.serialization import JsonEncoderPort
 from bioetl.domain.ports.shutdown import ShutdownPort
 from bioetl.domain.ports.storage import StoragePort
 from bioetl.domain.ports.validation import GoldValidatorPort, SilverValidatorPort
+from bioetl.domain.ports.watermark import NoOpWatermarkStrategy, WatermarkStrategyPort
 
 __all__ = [
     "ActivityAggregatorPort",
@@ -141,6 +143,7 @@ __all__ = [
     "NoOpMetrics",
     "NoOpPiiHasher",
     "NoOpTracing",
+    "NoOpWatermarkStrategy",
     "NormalizationServicePort",
     "OutlierFilterPort",
     "PiiHasherPort",
@@ -158,4 +161,5 @@ __all__ = [
     "TracingPort",
     "UnitConverterPort",
     "ValueValidatorPort",
+    "WatermarkStrategyPort",
 ]

--- a/src/bioetl/domain/ports/watermark.py
+++ b/src/bioetl/domain/ports/watermark.py
@@ -1,0 +1,129 @@
+"""Watermark strategy port for incremental data loading.
+
+This module defines the interface for watermark-based incremental loading.
+Currently a placeholder for future implementation (ADR-031).
+
+IMPORTANT: Watermark-based loading requires:
+1. Confirmed watermark field availability in source API
+2. Reliable timestamp/version tracking on the source side
+3. Proper handling of late-arriving data
+
+Do NOT implement without confirming API support for watermark fields.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from datetime import datetime
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class WatermarkStrategyPort(Protocol):
+    """Port for watermark-based incremental loading strategy.
+
+    Defines the interface for managing watermarks that track the progress
+    of incremental data extraction. Watermarks are typically timestamps
+    or version numbers that identify the last successfully processed record.
+
+    This is a PLACEHOLDER interface for future implementation.
+    Current status: NOT IMPLEMENTED.
+
+    Requirements for implementation:
+    1. Source API must provide a reliable watermark field (e.g., updated_at)
+    2. Watermark field must be monotonically increasing
+    3. Source must support filtering by watermark (e.g., WHERE updated_at > watermark)
+
+    Example usage (future):
+        >>> strategy = WatermarkStrategy(checkpoint_port, "updated_at")
+        >>> last_watermark = await strategy.get_watermark("chembl_activity")
+        >>> # Fetch records WHERE updated_at > last_watermark
+        >>> await strategy.update_watermark("chembl_activity", new_watermark)
+
+    See Also:
+        ADR-030: Publication pagination strategy (full_scan_only)
+        ADR-031: Loading strategy formalization
+        LoadingStrategy: Enum controlling which strategy is used
+    """
+
+    @abstractmethod
+    async def get_watermark(self, pipeline_name: str) -> datetime | int | str | None:
+        """Get the current watermark for a pipeline.
+
+        Args:
+            pipeline_name: Name of the pipeline to get watermark for.
+
+        Returns:
+            The current watermark value (timestamp, version number, or ID),
+            or None if no watermark exists (first run).
+        """
+        ...
+
+    @abstractmethod
+    async def update_watermark(
+        self,
+        pipeline_name: str,
+        watermark: datetime | int | str,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Update the watermark after successful processing.
+
+        Args:
+            pipeline_name: Name of the pipeline to update watermark for.
+            watermark: New watermark value to store.
+            metadata: Optional metadata about the processing run.
+        """
+        ...
+
+    @abstractmethod
+    async def clear_watermark(self, pipeline_name: str) -> None:
+        """Clear the watermark for a pipeline (triggers full reload).
+
+        Args:
+            pipeline_name: Name of the pipeline to clear watermark for.
+        """
+        ...
+
+
+class NoOpWatermarkStrategy:
+    """No-operation implementation of WatermarkStrategyPort.
+
+    Used as a placeholder when watermark-based loading is not available.
+    Always returns None for watermark and does nothing on update.
+
+    This is the DEFAULT implementation until watermark support is added.
+    """
+
+    async def get_watermark(self, _pipeline_name: str) -> None:
+        """Always returns None (no watermark available).
+
+        Args:
+            _pipeline_name: Ignored (intentionally unused in no-op).
+
+        Returns:
+            None, indicating no watermark support.
+        """
+        return None
+
+    async def update_watermark(
+        self,
+        _pipeline_name: str,
+        _watermark: datetime | int | str,
+        _metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """No-op: does nothing.
+
+        Args:
+            _pipeline_name: Ignored (intentionally unused in no-op).
+            _watermark: Ignored (intentionally unused in no-op).
+            _metadata: Ignored (intentionally unused in no-op).
+        """
+        pass
+
+    async def clear_watermark(self, _pipeline_name: str) -> None:
+        """No-op: does nothing.
+
+        Args:
+            _pipeline_name: Ignored (intentionally unused in no-op).
+        """
+        pass

--- a/src/bioetl/infrastructure/config/_base.py
+++ b/src/bioetl/infrastructure/config/_base.py
@@ -184,6 +184,7 @@ def yaml_config_to_domain(
         transform_version=transform_version,
         transform_steps=transform_steps,
         force_full_scan=yaml_config.force_full_scan,
+        loading_strategy=yaml_config.loading_strategy,
     )
 
 

--- a/src/bioetl/infrastructure/schemas/pipeline_config.py
+++ b/src/bioetl/infrastructure/schemas/pipeline_config.py
@@ -978,6 +978,17 @@ class PipelineYamlConfig(BaseModel):
         "API offset instability. See ADR-030.",
     )
 
+    # Loading strategy (ADR-031)
+    # Explicit formalization of data loading approach.
+    loading_strategy: Literal["full_scan_only", "watermark_based"] | None = Field(
+        default=None,
+        description="Explicit loading strategy for the pipeline. "
+        "'full_scan_only': Each run performs full scan, checkpoint resume disabled. "
+        "'watermark_based': Incremental loading via watermark (placeholder, not implemented). "
+        "If not specified, derived from force_full_scan for backward compatibility. "
+        "See ADR-031.",
+    )
+
     @field_validator("batch_size")
     @classmethod
     def validate_batch_size(cls, v: int) -> int:

--- a/tests/architecture/test_force_full_scan_publication.py
+++ b/tests/architecture/test_force_full_scan_publication.py
@@ -1,9 +1,13 @@
-"""Architecture test: force_full_scan enforcement for publication pipelines.
+"""Architecture test: force_full_scan and loading_strategy enforcement for publication pipelines.
 
-Tests that all publication pipeline configs have force_full_scan=true
-to ensure reproducible extraction (ADR-030).
+Tests that all publication pipeline configs have:
+- force_full_scan=true (ADR-030)
+- loading_strategy=full_scan_only (ADR-031)
+
+This ensures reproducible extraction via full scans with deduplication on Silver.
 
 REQ-ARCH-050: Publication pipelines MUST use force_full_scan=true.
+REQ-ARCH-051: Publication pipelines MUST use loading_strategy=full_scan_only.
 """
 
 from __future__ import annotations
@@ -63,6 +67,13 @@ class TestForceFullScanPublicationConfigs:
         assert force_full_scan is True, (
             f"{config_path} MUST have 'force_full_scan: true' per ADR-030. "
             f"Found: force_full_scan={force_full_scan}"
+        )
+
+        # Verify loading_strategy is explicitly set to full_scan_only (ADR-031)
+        loading_strategy = config.get("loading_strategy")
+        assert loading_strategy == "full_scan_only", (
+            f"{config_path} MUST have 'loading_strategy: full_scan_only' per ADR-031. "
+            f"Found: loading_strategy={loading_strategy}"
         )
 
     def test_all_publication_configs_are_tested(self) -> None:

--- a/tests/unit/application/core/test_checkpoint_manager.py
+++ b/tests/unit/application/core/test_checkpoint_manager.py
@@ -190,7 +190,8 @@ class TestCheckpointManagerForceFullScan:
         # Warning should be logged
         mock_logger.warning.assert_called_once()
         warning_call = mock_logger.warning.call_args
-        assert "force_full_scan" in warning_call[0][0].lower()
+        # Message uses "full_scan_only" since ADR-031 loading_strategy formalization
+        assert "full_scan_only" in warning_call[0][0].lower()
 
     async def test_load_checkpoint_warning_contains_adr_reference(
         self, mock_checkpoint_port, mock_logger
@@ -306,3 +307,167 @@ class TestCheckpointManagerForceFullScan:
         # Should work normally (default force_full_scan=False)
         mock_checkpoint_port.load.assert_called_once()
         assert result is not None
+
+
+@pytest.mark.unit
+class TestCheckpointManagerLoadingStrategy:
+    """Tests for CheckpointManager loading_strategy behavior (ADR-031)."""
+
+    async def test_load_checkpoint_blocked_when_loading_strategy_full_scan_only(
+        self, mock_checkpoint_port, mock_logger
+    ):
+        """Test load_checkpoint returns None when loading_strategy=FULL_SCAN_ONLY."""
+        from bioetl.domain.medallion import LoadingStrategy
+
+        saved_run_id = uuid4()
+        mock_checkpoint_port.load.return_value = (
+            saved_run_id,
+            {"records_processed": 1000},
+        )
+
+        run_id = uuid4()
+        manager = CheckpointManager(
+            checkpoint_port=mock_checkpoint_port,
+            logger=mock_logger,
+            pipeline_name="chembl_publication",
+            run_id=run_id,
+            resume=True,
+            loading_strategy=LoadingStrategy.FULL_SCAN_ONLY,
+        )
+
+        result = await manager.load_checkpoint()
+
+        # Checkpoint load should NOT be called - blocked immediately
+        mock_checkpoint_port.load.assert_not_called()
+        assert result is None
+        mock_logger.warning.assert_called_once()
+
+    async def test_load_checkpoint_allowed_when_loading_strategy_watermark_based(
+        self, mock_checkpoint_port, mock_logger
+    ):
+        """Test load_checkpoint works when loading_strategy=WATERMARK_BASED."""
+        from bioetl.domain.medallion import LoadingStrategy
+
+        saved_run_id = uuid4()
+        mock_checkpoint_port.load.return_value = (
+            saved_run_id,
+            {"records_processed": 1000},
+        )
+
+        run_id = uuid4()
+        manager = CheckpointManager(
+            checkpoint_port=mock_checkpoint_port,
+            logger=mock_logger,
+            pipeline_name="chembl_activity",
+            run_id=run_id,
+            resume=True,
+            loading_strategy=LoadingStrategy.WATERMARK_BASED,
+        )
+
+        result = await manager.load_checkpoint()
+
+        mock_checkpoint_port.load.assert_called_once()
+        assert result is not None
+        mock_logger.warning.assert_not_called()
+
+    async def test_loading_strategy_takes_precedence_over_force_full_scan(
+        self, mock_checkpoint_port, mock_logger
+    ):
+        """Test that explicit loading_strategy overrides force_full_scan."""
+        from bioetl.domain.medallion import LoadingStrategy
+
+        saved_run_id = uuid4()
+        mock_checkpoint_port.load.return_value = (
+            saved_run_id,
+            {"records_processed": 1000},
+        )
+
+        run_id = uuid4()
+        # force_full_scan=True but loading_strategy=WATERMARK_BASED
+        manager = CheckpointManager(
+            checkpoint_port=mock_checkpoint_port,
+            logger=mock_logger,
+            pipeline_name="test_pipeline",
+            run_id=run_id,
+            resume=True,
+            force_full_scan=True,
+            loading_strategy=LoadingStrategy.WATERMARK_BASED,
+        )
+
+        result = await manager.load_checkpoint()
+
+        # loading_strategy takes precedence: WATERMARK_BASED allows resume
+        mock_checkpoint_port.load.assert_called_once()
+        assert result is not None
+        mock_logger.warning.assert_not_called()
+
+    async def test_loading_strategy_derived_from_force_full_scan_when_none(
+        self, mock_checkpoint_port, mock_logger
+    ):
+        """Test loading_strategy is derived from force_full_scan when not specified."""
+        from bioetl.domain.medallion import LoadingStrategy
+
+        saved_run_id = uuid4()
+        mock_checkpoint_port.load.return_value = (
+            saved_run_id,
+            {"records_processed": 1000},
+        )
+
+        run_id = uuid4()
+        # No loading_strategy, force_full_scan=True
+        manager = CheckpointManager(
+            checkpoint_port=mock_checkpoint_port,
+            logger=mock_logger,
+            pipeline_name="test_pipeline",
+            run_id=run_id,
+            resume=True,
+            force_full_scan=True,
+            loading_strategy=None,  # Will be derived
+        )
+
+        # Internal loading_strategy should be FULL_SCAN_ONLY
+        assert manager._loading_strategy == LoadingStrategy.FULL_SCAN_ONLY
+
+        result = await manager.load_checkpoint()
+        assert result is None
+
+    async def test_loading_strategy_warning_references_adr_031(
+        self, mock_checkpoint_port, mock_logger
+    ):
+        """Test that warning message references ADR-031."""
+        from bioetl.domain.medallion import LoadingStrategy
+
+        run_id = uuid4()
+        manager = CheckpointManager(
+            checkpoint_port=mock_checkpoint_port,
+            logger=mock_logger,
+            pipeline_name="chembl_publication",
+            run_id=run_id,
+            resume=True,
+            loading_strategy=LoadingStrategy.FULL_SCAN_ONLY,
+        )
+
+        await manager.load_checkpoint()
+
+        warning_call = mock_logger.warning.call_args
+        assert "ADR-031" in warning_call[0][0]
+
+    async def test_loading_strategy_string_conversion(
+        self, mock_checkpoint_port, mock_logger
+    ):
+        """Test that string loading_strategy is converted to enum."""
+        from bioetl.domain.medallion import LoadingStrategy
+
+        run_id = uuid4()
+        # Note: CheckpointManager receives LoadingStrategy enum from PipelineConfig
+        # This test verifies the enum-based behavior
+        manager = CheckpointManager(
+            checkpoint_port=mock_checkpoint_port,
+            logger=mock_logger,
+            pipeline_name="test_pipeline",
+            run_id=run_id,
+            resume=True,
+            loading_strategy=LoadingStrategy.FULL_SCAN_ONLY,
+        )
+
+        assert manager._loading_strategy == LoadingStrategy.FULL_SCAN_ONLY

--- a/tests/unit/domain/test_medallion.py
+++ b/tests/unit/domain/test_medallion.py
@@ -1,13 +1,13 @@
 """Unit tests for medallion layer policies.
 
-Tests MedallionPolicy and ClearPolicy domain objects.
+Tests MedallionPolicy, ClearPolicy, and LoadingStrategy domain objects.
 """
 
 from __future__ import annotations
 
 import pytest
 
-from bioetl.domain.medallion import ClearPolicy, MedallionPolicy
+from bioetl.domain.medallion import ClearPolicy, LoadingStrategy, MedallionPolicy
 from bioetl.domain.types import RunType
 
 
@@ -107,3 +107,56 @@ class TestMedallionPolicyShouldClear:
 
         assert policy.should_clear_silver is True
         assert policy.should_clear_gold is True
+
+
+@pytest.mark.unit
+class TestLoadingStrategy:
+    """Test LoadingStrategy enum (ADR-031)."""
+
+    def test_enum_values(self):
+        """Test LoadingStrategy enum has correct string values."""
+        assert LoadingStrategy.FULL_SCAN_ONLY.value == "full_scan_only"
+        assert LoadingStrategy.WATERMARK_BASED.value == "watermark_based"
+
+    def test_from_string_valid_values(self):
+        """Test from_string converts valid string values."""
+        assert LoadingStrategy.from_string("full_scan_only") == LoadingStrategy.FULL_SCAN_ONLY
+        assert LoadingStrategy.from_string("watermark_based") == LoadingStrategy.WATERMARK_BASED
+
+    def test_from_string_case_insensitive(self):
+        """Test from_string is case insensitive."""
+        assert LoadingStrategy.from_string("FULL_SCAN_ONLY") == LoadingStrategy.FULL_SCAN_ONLY
+        assert LoadingStrategy.from_string("Watermark_Based") == LoadingStrategy.WATERMARK_BASED
+
+    def test_from_string_invalid_raises_value_error(self):
+        """Test from_string raises ValueError for invalid values."""
+        with pytest.raises(ValueError) as exc_info:
+            LoadingStrategy.from_string("invalid_strategy")
+
+        assert "Invalid loading strategy" in str(exc_info.value)
+        assert "invalid_strategy" in str(exc_info.value)
+
+    def test_allows_checkpoint_resume_full_scan_only(self):
+        """Test FULL_SCAN_ONLY does not allow checkpoint resume."""
+        assert LoadingStrategy.FULL_SCAN_ONLY.allows_checkpoint_resume is False
+
+    def test_allows_checkpoint_resume_watermark_based(self):
+        """Test WATERMARK_BASED allows checkpoint resume."""
+        assert LoadingStrategy.WATERMARK_BASED.allows_checkpoint_resume is True
+
+    def test_from_force_full_scan_true(self):
+        """Test from_force_full_scan with True returns FULL_SCAN_ONLY."""
+        assert (
+            LoadingStrategy.from_force_full_scan(True) == LoadingStrategy.FULL_SCAN_ONLY
+        )
+
+    def test_from_force_full_scan_false(self):
+        """Test from_force_full_scan with False returns WATERMARK_BASED."""
+        assert (
+            LoadingStrategy.from_force_full_scan(False) == LoadingStrategy.WATERMARK_BASED
+        )
+
+    def test_string_enum_comparison(self):
+        """Test LoadingStrategy can be compared with strings."""
+        assert LoadingStrategy.FULL_SCAN_ONLY == "full_scan_only"
+        assert LoadingStrategy.WATERMARK_BASED == "watermark_based"


### PR DESCRIPTION
## Summary

This PR formalizes the implicit loading behavior of publication pipelines by introducing an explicit `LoadingStrategy` enum and configuration field. Previously, publication pipelines used a boolean `force_full_scan` flag that didn't clearly communicate intent or provide extensibility for future strategies.

## Changes

### Domain Layer
- **New `LoadingStrategy` enum** (`src/bioetl/domain/medallion.py`):
  - `FULL_SCAN_ONLY`: Each run performs full scan, checkpoint resume disabled (for publications)
  - `WATERMARK_BASED`: Placeholder for future incremental loading via watermark
  - Helper methods: `from_string()`, `from_force_full_scan()`, `allows_checkpoint_resume` property

- **New `WatermarkStrategyPort`** (`src/bioetl/domain/ports/watermark.py`):
  - Protocol interface for watermark-based incremental loading (placeholder, not implemented)
  - `NoOpWatermarkStrategy` default implementation

- **Updated `PipelineConfig`** (`src/bioetl/domain/config.py`):
  - Added `loading_strategy: LoadingStrategy | str | None` field
  - Added `_resolve_loading_strategy()` method for backward compatibility
  - Explicit strategy takes precedence over legacy `force_full_scan` flag

### Application Layer
- **Updated `CheckpointManager`** (`src/bioetl/application/core/checkpoint_manager.py`):
  - Now accepts `loading_strategy` parameter
  - Uses `loading_strategy.allows_checkpoint_resume` instead of `force_full_scan` boolean
  - Updated warning messages to reference ADR-031

### Infrastructure Layer
- **Updated YAML schema** (`src/bioetl/infrastructure/schemas/pipeline_config.py`):
  - Added `loading_strategy` field with validation for `"full_scan_only"` or `"watermark_based"`

- **Updated config conversion** (`src/bioetl/infrastructure/config/_base.py`):
  - Passes `loading_strategy` from YAML to domain config

### Composition Layer
- **Updated factories** (`src/bioetl/composition/factories/`):
  - `pipeline_factory.py`: Passes `loading_strategy` to `CheckpointManager`
  - `services_factory.py`: Updated `create_checkpoint_manager()` signature

### Configuration Files
- **All publication pipeline configs** updated with explicit `loading_strategy: full_scan_only`:
  - `configs/pipelines/chembl/publication.yaml`
  - `configs/pipelines/chembl/publication_term.yaml`
  - `configs/pipelines/chembl/publication_similarity.yaml`
  - `configs/pipelines/pubmed/publication.yaml`
  - `configs/pipelines/crossref/publication.yaml`
  - `configs/pipelines/openalex/publication.yaml`
  - `configs/pipelines/semanticscholar/publication.yaml`

### Tests
- **New tests** for `LoadingStrategy` enum (`tests/unit/domain/test_medallion.py`):
  - Enum value validation
  - String conversion with case-insensitivity
  - `allows_checkpoint_resume` property
  - `from_force_full_scan()` conversion

- **Enhanced checkpoint manager tests** (`tests/unit/application/core/test_checkpoint_manager.py`):
  - Tests for `loading_strategy` parameter
  - Precedence of explicit strategy over `force_full_scan`
  - Derivation from `force_full_scan` when strategy not specified

- **Architecture test updates** (`tests/architecture/test_force_full_scan_publication.py`):
  - Now verifies both `force_full_scan=true` and `loading_strategy=full_scan_only`
  - Added REQ-ARCH-051 requirement

### Documentation
- **New ADR-031** (`docs/02-architecture/decisions/ADR-031-loading-strategy-formalization.md`):
  - Comprehensive decision record explaining the formalization
  - Rationale for explicit strategy declaration
  -