### PR TITLE
Add tests for lookup tracking fields in Gold publication schemas

### DIFF
--- a/tests/unit/infrastructure/schemas/test_gold.py
+++ b/tests/unit/infrastructure/schemas/test_gold.py
@@ -223,6 +223,48 @@ class TestGoldPublicationSchemaPrimaryKeys:
 
 
 @pytest.mark.unit
+class TestGoldPublicationSchemaLookupTrackingFields:
+    """Test that all Gold publication schemas have lookup tracking fields.
+
+    These fields track how records were resolved during data acquisition:
+    - _lookup_method: "direct" | "doi" | "pmid" | "title_fallback" | "unknown"
+    - _original_id: Original identifier used for lookup
+    """
+
+    @pytest.mark.parametrize(
+        "schema_class,name",
+        [
+            (ChEMBLDocumentGoldSchema, "ChEMBL Document"),
+            (CrossRefPublicationGoldSchema, "CrossRef Publication"),
+            (OpenAlexPublicationGoldSchema, "OpenAlex Publication"),
+            (PubMedPublicationGoldSchema, "PubMed Publication"),
+            (SemanticScholarPublicationGoldSchema, "SemanticScholar Publication"),
+        ],
+    )
+    def test_schema_has_lookup_method_field(self, schema_class, name):
+        """All Gold publication schemas must have _lookup_method field."""
+        fields = get_schema_fields(schema_class)
+        has_lookup_method = "_lookup_method" in fields or "lookup_method" in fields
+        assert has_lookup_method, f"{name} missing _lookup_method/lookup_method field"
+
+    @pytest.mark.parametrize(
+        "schema_class,name",
+        [
+            (ChEMBLDocumentGoldSchema, "ChEMBL Document"),
+            (CrossRefPublicationGoldSchema, "CrossRef Publication"),
+            (OpenAlexPublicationGoldSchema, "OpenAlex Publication"),
+            (PubMedPublicationGoldSchema, "PubMed Publication"),
+            (SemanticScholarPublicationGoldSchema, "SemanticScholar Publication"),
+        ],
+    )
+    def test_schema_has_original_id_field(self, schema_class, name):
+        """All Gold publication schemas must have _original_id field."""
+        fields = get_schema_fields(schema_class)
+        has_original_id = "_original_id" in fields or "original_id" in fields
+        assert has_original_id, f"{name} missing _original_id/original_id field"
+
+
+@pytest.mark.unit
 class TestGoldPublicationSchemaMetadataFields:
     """Test that all Gold publication schemas have required metadata fields."""
 


### PR DESCRIPTION
## Summary
Added comprehensive unit tests to verify that all Gold publication schemas include lookup tracking fields that document how records were resolved during data acquisition.

## Key Changes
- Added new test class `TestGoldPublicationSchemaLookupTrackingFields` with two test methods:
  - `test_schema_has_lookup_method_field`: Validates presence of `_lookup_method` field across all publication schemas
  - `test_schema_has_original_id_field`: Validates presence of `_original_id` field across all publication schemas
- Tests cover all five Gold publication schema types:
  - ChEMBL Document
  - CrossRef Publication
  - OpenAlex Publication
  - PubMed Publication
  - SemanticScholar Publication
- Tests accept both underscore-prefixed and non-prefixed field name variants for flexibility

## Implementation Details
- Lookup tracking fields document the resolution method ("direct", "doi", "pmid", "title_fallback", or "unknown") and the original identifier used
- Tests use parametrization to reduce code duplication and ensure consistent validation across all schema types
- Flexible field name matching allows for schema evolution without breaking tests