### PR TITLE
Add pmid and pmc_id fields to CrossRefPublicationGoldSchema

### DIFF
--- a/src/bioetl/domain/contracts/gold/publications.py
+++ b/src/bioetl/domain/contracts/gold/publications.py
@@ -148,8 +148,13 @@ class CrossRefPublicationGoldSchema(pa.DataFrameModel):
 
     # Primary identifier
     # doi: Digital Object Identifier (lowercase, without "https://doi.org/") - Primary key
-    # Note: CrossRef uses DOI as primary key; pmid/pmc_id excluded (not available from CrossRef API)
     doi: Series[str] = pa.Field(nullable=False)
+
+    # Cross-reference IDs for linking publications across providers
+    # pmid: PubMed ID (numeric string: "12345678") - Always NULL for CrossRef
+    pmid: Series[str] = pa.Field(nullable=True)
+    # pmc_id: PubMed Central ID (format: "PMC1234567") - Always NULL for CrossRef
+    pmc_id: Series[str] = pa.Field(nullable=True)
 
     # Core fields
     title: Series[str] = pa.Field(nullable=True)

--- a/tests/unit/infrastructure/schemas/test_gold.py
+++ b/tests/unit/infrastructure/schemas/test_gold.py
@@ -122,13 +122,14 @@ class TestGoldPublicationSchemaCrossRefFields:
         "schema_class,name",
         [
             (ChEMBLDocumentGoldSchema, "ChEMBL Document"),
+            (CrossRefPublicationGoldSchema, "CrossRef Publication"),
             (OpenAlexPublicationGoldSchema, "OpenAlex Publication"),
             (PubMedPublicationGoldSchema, "PubMed Publication"),
             (SemanticScholarPublicationGoldSchema, "SemanticScholar Publication"),
         ],
     )
     def test_schema_has_pmid_field(self, schema_class, name):
-        """Gold publication schemas (except CrossRef) should have pmid field."""
+        """All Gold publication schemas should have pmid field."""
         fields = get_schema_fields(schema_class)
         assert "pmid" in fields, f"{name} missing pmid field"
 
@@ -136,13 +137,14 @@ class TestGoldPublicationSchemaCrossRefFields:
         "schema_class,name",
         [
             (ChEMBLDocumentGoldSchema, "ChEMBL Document"),
+            (CrossRefPublicationGoldSchema, "CrossRef Publication"),
             (OpenAlexPublicationGoldSchema, "OpenAlex Publication"),
             (PubMedPublicationGoldSchema, "PubMed Publication"),
             (SemanticScholarPublicationGoldSchema, "SemanticScholar Publication"),
         ],
     )
     def test_schema_has_pmc_id_field(self, schema_class, name):
-        """Gold publication schemas (except CrossRef) should have pmc_id field."""
+        """All Gold publication schemas should have pmc_id field."""
         fields = get_schema_fields(schema_class)
         assert "pmc_id" in fields, f"{name} missing pmc_id field"
 


### PR DESCRIPTION
## Summary
This PR adds `pmid` and `pmc_id` fields to the `CrossRefPublicationGoldSchema` to maintain consistency across all publication gold schemas. These fields are defined as nullable since CrossRef API does not provide PubMed identifiers.

## Changes
- **Schema Update**: Added `pmid` and `pmc_id` fields to `CrossRefPublicationGoldSchema` with nullable=True and clear documentation explaining they are always NULL for CrossRef data
- **Test Updates**: Updated test cases to include `CrossRefPublicationGoldSchema` in the `test_schema_has_pmid_field` and `test_schema_has_pmc_id_field` parametrized tests
- **Documentation**: Updated test docstrings to reflect that all publication schemas (not just some) should have these cross-reference ID fields

## Implementation Details
- Both new fields are properly documented with their format specifications (pmid as numeric string, pmc_id as "PMC" prefix format)
- Fields are marked as nullable to accurately represent that CrossRef does not supply these identifiers
- This change ensures a uniform schema interface across all publication data providers while being transparent about data availability