### PR TITLE
docs: Add Composite Pipeline (ADR-026) and expand provider coverage

### DIFF
--- a/docs/00-map.md
+++ b/docs/00-map.md
@@ -1,12 +1,14 @@
 # BioETL Project Navigator
 
-*Synced with RULES.md v5.12 | Last updated: 2026-01-21*
+*Synced with RULES.md v5.12 | Last updated: 2026-01-26*
 
-> **Documentation Audit Completed:** 2026-01-21
-> - RULES.md updated to v5.12: ADR-021..028 added to registry with inline references
-> - REQUIREMENTS.md updated to v1.4: correct count 156 (was 139)
-> - Added ADR-028-filter-rules-externalization to 00-map.md
-> - See: [archived/audits/sync-audit-2026-01-21.md](archived/audits/sync-audit-2026-01-21.md) for details
+> **Documentation Update:** 2026-01-26
+> - Architecture diagrams updated: Composite Pipeline (ADR-026) added to layer diagrams
+> - New diagram: `26_composite_pipeline_workflow.mmd` — visualizes seed → enrich → merge flow
+> - Cross-links added between all layer documents (Domain ↔ Application ↔ Infrastructure ↔ Interfaces ↔ Composition)
+> - All 7 providers now reflected in diagrams (including CrossRef, OpenAlex, SemanticScholar)
+> - ADR-030, ADR-031 added to registry
+> - See: [02-architecture/00-overview.md](02-architecture/00-overview.md) for updated architecture overview
 
 ## Quick Links
 
@@ -68,8 +70,8 @@ docs/
 │   ├── data-layers.md           # Bronze/Silver/Gold layer details
 │   ├── observability-layers.md  # Observability architecture
 │   ├── diagrams.md              # Mermaid diagrams collection
-│   ├── decisions/               # ADR-001..029 (29 records)
-│   └── diagrams/                # 34 Mermaid diagram files + render_diagrams.py
+│   ├── decisions/               # ADR-001..031 (31 records)
+│   └── diagrams/                # 35 Mermaid diagram files + render_diagrams.py
 │
 ├── 03-guides/                   # How-to guides (13 guides)
 │   ├── quick-start.md           # Quick start guide
@@ -183,6 +185,8 @@ docs/
 | [ADR-027: DQ Rules Externalization](02-architecture/decisions/ADR-027-dq-rules-externalization.md) | Hierarchical DQ configuration | §3.1.2   |
 | [ADR-028: Filter Rules Externalization](02-architecture/decisions/ADR-028-filter-rules-externalization.md) | Hierarchical filter configuration | App D   |
 | [ADR-029: Output Metadata Unification](02-architecture/decisions/ADR-029-output-metadata-unification.md) | Unified output metadata contracts | §2.4    |
+| [ADR-030: Publication Pagination Strategy](02-architecture/decisions/ADR-030-publication-pagination-strategy.md) | Publication pagination strategy | -       |
+| [ADR-031: Loading Strategy Formalization](02-architecture/decisions/ADR-031-loading-strategy-formalization.md) | Loading strategy formalization | -       |
 
 ### Data Management
 

--- a/docs/02-architecture/00-overview.md
+++ b/docs/02-architecture/00-overview.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-*Synced with RULES.md v5.12 (2026-01-06)*
+*Synced with RULES.md v5.12 (2026-01-26)*
 
 ## Quick Navigation
 
@@ -28,15 +28,16 @@ BioETL follows a **Hexagonal Architecture** (Ports & Adapters) pattern with **Me
 
 ### Diagrams
 
-- [diagrams/](diagrams/) — 34 Mermaid diagram files
+- [diagrams/](diagrams/) — 35 Mermaid diagram files
 - [diagrams/diagrams-index.md](diagrams/diagrams-index.md) — Full diagram index
 - [diagrams.md](diagrams.md) — Inline diagram collection
+- [../diagrams/mermaid/](../diagrams/mermaid/) — Additional 26 diagrams (includes Composite Pipeline workflow)
 
 ### Architecture Decision Records (ADRs)
 
 See [decisions/README.md](decisions/README.md) for full index with categories.
 
-29 ADRs documenting key architectural decisions:
+31 ADRs documenting key architectural decisions:
 
 | ADR | Topic | RULES.md Reference |
 |-----|-------|-------------------|
@@ -69,6 +70,8 @@ See [decisions/README.md](decisions/README.md) for full index with categories.
 | [ADR-027](decisions/ADR-027-dq-rules-externalization.md) | DQ Rules Externalization | §3.1.2 |
 | [ADR-028](decisions/ADR-028-filter-rules-externalization.md) | Filter Rules Externalization | App D |
 | [ADR-029](decisions/ADR-029-output-metadata-unification.md) | Output Metadata Unification | §2.4 |
+| [ADR-030](decisions/ADR-030-publication-pagination-strategy.md) | Publication Pagination Strategy | - |
+| [ADR-031](decisions/ADR-031-loading-strategy-formalization.md) | Loading Strategy Formalization | - |
 
 ---
 
@@ -92,6 +95,17 @@ See [decisions/README.md](decisions/README.md) for full index with categories.
 2. **Ports & Adapters**: Interfaces in `domain/ports/`, implementations in `infrastructure/`
 3. **Composition Root**: Single assembly point in `composition/bootstrap.py`
 4. **Medallion Architecture**: Bronze (raw) → Silver (normalized) → Gold (curated)
+5. **Composite Pipeline** (ADR-026): Multi-source data enrichment with seed → enrich (fan-out) → merge workflow
+
+### Key Diagrams
+
+| Diagram | Description | File |
+|---------|-------------|------|
+| Five Layer Architecture | Complete system architecture with all 5 layers | [01_five_layer_architecture.mmd](../diagrams/mermaid/01_five_layer_architecture.mmd) |
+| Layers Interaction | How layers communicate | [05-layers-interaction.mermaid](diagrams/05-layers-interaction.mermaid) |
+| Composite Pipeline | ADR-026 workflow: seed → enrich → merge | [26_composite_pipeline_workflow.mmd](../diagrams/mermaid/26_composite_pipeline_workflow.mmd) |
+| Provider Adapters | 7 providers with rate limits | [23_provider_adapters_overview.mmd](../diagrams/mermaid/23_provider_adapters_overview.mmd) |
+| Pipeline Hierarchy | Pipeline/Transformer inheritance | [17-pipeline-hierarchy.mermaid](diagrams/17-pipeline-hierarchy.mermaid) |
 
 ---
 

--- a/docs/02-architecture/01-domain-layer.md
+++ b/docs/02-architecture/01-domain-layer.md
@@ -142,3 +142,36 @@ events = batch.collect_events()  # [BatchCreated, BatchSealed, BatchWritten]
 - **Никакого I/O:** В этом слое запрещены любые операции, связанные с сетью, файловой системой или базами данных.
 - **Валидация данных:** Логика валидации бизнес-сущностей (например, проверка SMILES-строк) может находиться здесь, если она не требует внешних зависимостей.
 - **Иммутабельность:** Предпочтение отдаётся иммутабельным структурам данных (например, `NamedTuple`, `dataclasses(frozen=True)`).
+
+---
+
+## 4. Связанные Материалы
+
+### Навигация по Слоям
+
+| ← Предыдущий | Текущий | Следующий → |
+|--------------|---------|-------------|
+| — | **Domain** | [Application Layer](02-application-layer.md) |
+
+### Связанные Диаграммы
+
+| Диаграмма | Файл | Описание |
+|-----------|------|----------|
+| Domain Layer Classes | [04-domain-layer-class-diagram.mermaid](diagrams/04-domain-layer-class-diagram.mermaid) | Классы портов, сущностей, конфигурации |
+| Domain DDD | [08-domain-ddd.mermaid](diagrams/08-domain-ddd.mermaid) | DDD-структура домена |
+| Domain Models | [13-domain-models-relationship.mermaid](diagrams/13-domain-models-relationship.mermaid) | Связи доменных моделей |
+| DDD Aggregates | [../diagrams/mermaid/09_ddd_aggregates.mmd](../diagrams/mermaid/09_ddd_aggregates.mmd) | DDD агрегаты: Batch, PipelineRun, QuarantineEntry |
+| Ports Architecture | [../diagrams/mermaid/07_ports_architecture.mmd](../diagrams/mermaid/07_ports_architecture.mmd) | Архитектура 26 портов |
+
+### Связанные ADR
+
+| ADR | Тема |
+|-----|------|
+| [ADR-004](decisions/ADR-004-pydantic-vs-dataclasses.md) | Pydantic vs Dataclasses — выбор dataclasses |
+| [ADR-021](decisions/ADR-021-ddd-aggregates-adoption.md) | DDD Aggregates — внедрение агрегатов |
+
+### Смежные Разделы Документации
+
+- [RULES.md §1 "Архитектура и Слои"](../RULES.md) — матрица импортов, правила слоёв
+- [API Reference: Domain](../04-reference/api/domain.md) — API документация слоя
+- [Glossary](../glossary.md) — терминология Ubiquitous Language

--- a/docs/02-architecture/02-application-layer.md
+++ b/docs/02-architecture/02-application-layer.md
@@ -113,8 +113,69 @@ class RunnerServices:
     observer: PipelineObserver
 ```
 
+### 2.5. `composite/` — Composite Pipeline (ADR-026)
+
+**Расположение:** `src/bioetl/application/composite/`
+
+Содержит компоненты для **композитных пайплайнов** — оркестрации нескольких пайплайнов для обогащения данных из разных источников.
+
+**Ключевые компоненты:**
+
+| Файл | Компонент | Назначение |
+|------|-----------|------------|
+| `runner.py` | `CompositePipelineRunner` | Оркестрирует: seed → enrich (fan-out) → merge |
+| `coordinator.py` | `EnrichmentCoordinator` | Параллельный запуск enrichers через asyncio.gather |
+| `merger.py` | `MergeService` | Объединение данных из разных источников (LEFT OUTER JOIN) |
+| `key_extractor.py` | `KeyExtractorService` | Извлечение join keys из seed pipeline |
+| `checkpoint.py` | `CompositeCheckpointManager` | Resume после сбоя |
+
+**Workflow Composite Pipeline:**
+```
+Seed Pipeline → Extract Keys → [CrossRef, OpenAlex, PubMed, SemanticScholar] → Merge → Gold
+                                     ↑ Fan-Out (parallel)
+```
+
+См. [ADR-026: Composite Pipeline Pattern](decisions/ADR-026-composite-pipeline-pattern.md) для деталей.
+
 ## 3. Принципы Работы
 
 - **Dependency Injection:** Пайплайны никогда не создают зависимости сами (`S3Storage()`). Они получают уже созданные экземпляры адаптеров в конструкторе. Это делает их легко тестируемыми и гибкими.
 - **Минимум логики:** Слой `Application` должен быть "тонким". Вся сложная бизнес-логика выносится в `Domain`, а детали реализации — в `Infrastructure`.
 - **Управление транзакциями:** Этот слой отвечает за управление жизненным циклом операций, включая обработку ошибок, повторные попытки и откат в случае сбоя.
+
+---
+
+## 4. Связанные Материалы
+
+### Навигация по Слоям
+
+| ← Предыдущий | Текущий | Следующий → |
+|--------------|---------|-------------|
+| [Domain Layer](01-domain-layer.md) | **Application** | [Infrastructure Layer](03-infrastructure-layer.md) |
+
+### Связанные Диаграммы
+
+| Диаграмма | Файл | Описание |
+|-----------|------|----------|
+| Application Layer Classes | [06-application-layer-class-diagram.mermaid](diagrams/06-application-layer-class-diagram.mermaid) | Классы слоя Application |
+| Pipeline Execution | [06-pipeline-execution.mermaid](diagrams/06-pipeline-execution.mermaid) | Поток выполнения пайплайна |
+| Pipeline Hierarchy | [17-pipeline-hierarchy.mermaid](diagrams/17-pipeline-hierarchy.mermaid) | Иерархия Pipeline/Transformer |
+| Layers Interaction | [05-layers-interaction.mermaid](diagrams/05-layers-interaction.mermaid) | Взаимодействие слоёв (включая Composite) |
+| Composite Pipeline | [../diagrams/mermaid/26_composite_pipeline_workflow.mmd](../diagrams/mermaid/26_composite_pipeline_workflow.mmd) | Workflow Composite Pipeline |
+| Pipeline Core | [../diagrams/mermaid/10_pipeline_core_components.mmd](../diagrams/mermaid/10_pipeline_core_components.mmd) | Ядро пайплайнов |
+| BaseTransformer | [../diagrams/mermaid/19_base_transformer_template_method.mmd](../diagrams/mermaid/19_base_transformer_template_method.mmd) | Template Method паттерн |
+
+### Связанные ADR
+
+| ADR | Тема |
+|-----|------|
+| [ADR-015](decisions/ADR-015-pipeline-services-lifecycle.md) | Pipeline Services Lifecycle |
+| [ADR-020](decisions/ADR-020-basepipeline-decomposition.md) | BasePipeline Decomposition |
+| [ADR-026](decisions/ADR-026-composite-pipeline-pattern.md) | Composite Pipeline Pattern |
+
+### Смежные Разделы Документации
+
+- [Domain Layer](01-domain-layer.md) — порты, используемые Application
+- [Composition Layer](05-composition-layer.md) — сборка и DI пайплайнов
+- [API Reference: Application](../04-reference/api/application.md) — API документация слоя
+- [RULES.md §1 "Архитектура и Слои"](../RULES.md) — матрица импортов

--- a/docs/02-architecture/03-infrastructure-layer.md
+++ b/docs/02-architecture/03-infrastructure-layer.md
@@ -35,10 +35,13 @@
 
 | Адаптер | Базовый класс | HTTP-клиент | Примечание |
 |---------|---------------|-------------|------------|
-| **ChemblAdapter** | `BaseHttpAdapter` | `UnifiedHTTPClient` | Async HTTP |
-| **UniProtAdapter** | `BaseHttpAdapter` | `UnifiedHTTPClient` | Async HTTP |
-| **PubMedAdapter** | `@dataclass` | `UnifiedHTTPClient` | Async HTTP |
-| **PubChemAdapter** | `BaseSyncAdapter` | `pubchempy` + ThreadPool | Legacy sync библиотека |
+| **ChemblAdapter** | `BaseHttpAdapter` | `UnifiedHTTPClient` | Async HTTP, 13 entities |
+| **UniProtAdapter** | `BaseHttpAdapter` | `UnifiedHTTPClient` | Async HTTP, 100 req/sec |
+| **PubMedAdapter** | `@dataclass` | `UnifiedHTTPClient` | Async HTTP, 3 req/sec |
+| **PubChemAdapter** | `BaseSyncAdapter` | `pubchempy` + ThreadPool | Legacy sync, 5 req/sec |
+| **CrossRefAdapter** | `BaseHttpAdapter` | `UnifiedHTTPClient` | Async HTTP, polite pool |
+| **OpenAlexAdapter** | `BaseHttpAdapter` | `UnifiedHTTPClient` | Async HTTP, 10 req/sec |
+| **SemanticScholarAdapter** | `BaseHttpAdapter` | `UnifiedHTTPClient` | Async HTTP, 100 req/5min |
 
 **Архитектура HTTP-адаптеров:**
 
@@ -114,3 +117,40 @@ Redis-адаптер без изменения domain/application слоёв.
 - **Запрет на бизнес-логику:** В этом слое не должно быть бизнес-правил. Его задача — получить данные "как есть" или записать их "как сказано".
 - **Инверсия зависимостей:** Классы из `Infrastructure` зависят от абстракций (`Protocol`) из `Domain`, а не наоборот. Это позволяет подменять реализации без изменения ядра системы.
 - **Конфигурация:** Все необходимые параметры (API-ключи, пути, адреса серверов) адаптеры получают через DI из конфигурационных объектов.
+
+---
+
+## 4. Связанные Материалы
+
+### Навигация по Слоям
+
+| ← Предыдущий | Текущий | Следующий → |
+|--------------|---------|-------------|
+| [Application Layer](02-application-layer.md) | **Infrastructure** | [Interfaces Layer](04-interfaces-layer.md) |
+
+### Связанные Диаграммы
+
+| Диаграмма | Файл | Описание |
+|-----------|------|----------|
+| Infrastructure Classes | [10-infrastructure-layer-class-diagram.mermaid](diagrams/10-infrastructure-layer-class-diagram.mermaid) | Классы слоя Infrastructure |
+| Provider Adapters | [../diagrams/mermaid/23_provider_adapters_overview.mmd](../diagrams/mermaid/23_provider_adapters_overview.mmd) | Обзор 7 провайдеров и их rate limits |
+| HTTP Infrastructure | [../diagrams/mermaid/14_http_infrastructure.mmd](../diagrams/mermaid/14_http_infrastructure.mmd) | UnifiedHTTPClient, Rate Limiter, Circuit Breaker |
+| Circuit Breaker | [07-circuit-breaker-states.mermaid](diagrams/07-circuit-breaker-states.mermaid) | Состояния Circuit Breaker |
+| Storage Architecture | [../diagrams/mermaid/13_storage_architecture.mmd](../diagrams/mermaid/13_storage_architecture.mmd) | Bronze, Silver, Gold writers |
+| MemoryLock | [16-memory-lock-class.mermaid](diagrams/16-memory-lock-class.mermaid) | Класс MemoryLock |
+
+### Связанные ADR
+
+| ADR | Тема |
+|-----|------|
+| [ADR-003](decisions/ADR-003-in-memory-locking-strategy.md) | In-Memory Locking Strategy |
+| [ADR-007](decisions/ADR-007-circuit-breaker-implementation.md) | Circuit Breaker Implementation |
+| [ADR-010](decisions/ADR-010-local-only-deployment.md) | Local-Only Deployment |
+| [ADR-017](decisions/ADR-017-observability-architecture.md) | Observability Architecture |
+
+### Смежные Разделы Документации
+
+- [Domain Layer](01-domain-layer.md) — порты, реализуемые адаптерами
+- [Composition Layer](05-composition-layer.md) — фабрики создания адаптеров
+- [API Reference: Infrastructure](../04-reference/api/infrastructure.md) — API документация слоя
+- [RULES.md §3 "Ошибки"](../RULES.md) — классификация ошибок, retry logic

--- a/docs/02-architecture/04-interfaces-layer.md
+++ b/docs/02-architecture/04-interfaces-layer.md
@@ -15,15 +15,32 @@
 
 ## 2. Ключевые Компоненты
 
-### 2.1. `cli.py` — Интерфейс Командной Строки
+### 2.1. `cli/` — Интерфейс Командной Строки
 
-**Расположение:** `src/bioetl/interfaces/cli.py`
+**Расположение:** `src/bioetl/interfaces/cli/`
 
-Реализует CLI для взаимодействия с пользователем. Использует библиотеку `Click` для определения команд.
+Реализует CLI для взаимодействия с пользователем. Использует библиотеку **Click** для определения команд.
 
-**Пример команды:**
+**Доступные команды:**
+
+| Команда | Описание |
+|---------|----------|
+| `run` | Запуск одного пайплайна |
+| `run_all` | Запуск всех пайплайнов провайдера |
+| `export` | Экспорт данных из Gold |
+| `quarantine` | Управление карантинными записями |
+| `health` | Проверка здоровья провайдеров |
+
+**Примеры использования:**
 ```bash
+# Запуск пайплайна с лимитом
 python -m bioetl run --pipeline chembl_activity --limit 100
+
+# Запуск композитного пайплайна (ADR-026)
+python -m bioetl run --pipeline composite_publication
+
+# Проверка здоровья провайдеров
+python -m bioetl health --provider chembl
 ```
 
 `cli.py` парсит эти аргументы, вызывает функции из `src/bioetl/composition/bootstrap.py` для инициализации системы и запускает выполнение пайплайна.
@@ -43,3 +60,34 @@ python -m bioetl run --pipeline chembl_activity --limit 100
 - **Максимальная простота:** Этот слой должен быть как можно более "глупым". Его задача — делегировать работу другим слоям, а не выполнять её самому.
 - **Единственная ответственность:** Единственная ответственность этого слоя — запуск приложения и управление его жизненным циклом на самом верхнем уровне.
 - **Импорт из всех слоёв:** Это единственный слой, которому разрешено импортировать модули из `domain`, `application` и `infrastructure` для того, чтобы "собрать" приложение воедино.
+
+---
+
+## 4. Связанные Материалы
+
+### Навигация по Слоям
+
+| ← Предыдущий | Текущий | Следующий → |
+|--------------|---------|-------------|
+| [Infrastructure Layer](03-infrastructure-layer.md) | **Interfaces** | [Composition Layer](05-composition-layer.md) |
+
+### Связанные Диаграммы
+
+| Диаграмма | Файл | Описание |
+|-----------|------|----------|
+| Five Layer Architecture | [../diagrams/mermaid/01_five_layer_architecture.mmd](../diagrams/mermaid/01_five_layer_architecture.mmd) | Полная архитектура с Interfaces слоем |
+| Layers Interaction | [05-layers-interaction.mermaid](diagrams/05-layers-interaction.mermaid) | Взаимодействие слоёв |
+| Graceful Shutdown | [../diagrams/mermaid/24_graceful_shutdown.mmd](../diagrams/mermaid/24_graceful_shutdown.mmd) | Sequence diagram graceful shutdown |
+
+### Связанные ADR
+
+| ADR | Тема |
+|-----|------|
+| [ADR-008](decisions/ADR-008-graceful-shutdown-strategy.md) | Graceful Shutdown Strategy |
+| [ADR-026](decisions/ADR-026-composite-pipeline-pattern.md) | Composite Pipeline — расширения CLI |
+
+### Смежные Разделы Документации
+
+- [Composition Layer](05-composition-layer.md) — bootstrap_pipeline, фабрики
+- [CLI Reference](../04-reference/cli.md) — полная документация CLI команд
+- [RULES.md §1 "Архитектура и Слои"](../RULES.md) — матрица импортов (interfaces может импортировать всё)

--- a/docs/02-architecture/05-composition-layer.md
+++ b/docs/02-architecture/05-composition-layer.md
@@ -51,13 +51,16 @@ data_source = ProviderRegistry.create_data_source(
 )
 ```
 
-**Зарегистрированные провайдеры:**
-| Provider | Data Sources | Pipelines |
-|----------|--------------|-----------|
-| chembl | ChemblAdapter | activity, assay, molecule, target, document, target_component |
-| pubchem | PubChemAdapter | compound |
-| uniprot | UniProtAdapter | protein |
-| pubmed | PubMedAdapter | publications |
+**Зарегистрированные провайдеры (7 шт):**
+| Provider | Data Sources | Pipelines | Rate Limit |
+|----------|--------------|-----------|------------|
+| chembl | ChemblAdapter | activity, assay, molecule, target, document, target_component (13) | None |
+| pubchem | PubChemAdapter | compound | 5 req/sec |
+| uniprot | UniProtAdapter | protein | 100 req/sec |
+| pubmed | PubMedAdapter | publications | 3 req/sec |
+| crossref | CrossRefAdapter | publication | Polite pool |
+| openalex | OpenAlexAdapter | publication | 10 req/sec |
+| semanticscholar | SemanticScholarAdapter | publication | 100 req/5min |
 
 ### 2.3. `registry.py` — Реестр пайплайнов
 
@@ -68,3 +71,53 @@ data_source = ProviderRegistry.create_data_source(
 - **Composition Root:** Вся логика создания объектов должна находиться как можно ближе к точке входа в приложение. В BioETL это `src/bioetl/composition/`.
 - **Dependency Injection (DI):** Объекты никогда не создают свои зависимости сами. Если пайплайну нужен доступ к базе данных, он запрашивает `StoragePort` в конструкторе, а фабрика из слоя Composition предоставляет ему конкретную реализацию.
 - **Декларативность:** Использование `GenericPipelineFactory` позволяет добавлять новые пайплайны простым объявлением в `pipeline_factories.py` без написания шаблонного кода сборки.
+
+### 3.1. Composite Pipeline Bootstrap (ADR-026)
+
+Для композитных пайплайнов доступна функция `bootstrap_composite_pipeline()`:
+
+```python
+from bioetl.composition.composite.bootstrap import bootstrap_composite_pipeline
+
+runner = await bootstrap_composite_pipeline(
+    "composite_publication",
+    limit=1000,
+)
+result = await runner.run()
+```
+
+См. [ADR-026: Composite Pipeline Pattern](decisions/ADR-026-composite-pipeline-pattern.md) для деталей.
+
+---
+
+## 4. Связанные Материалы
+
+### Навигация по Слоям
+
+| ← Предыдущий | Текущий | Следующий → |
+|--------------|---------|-------------|
+| [Interfaces Layer](04-interfaces-layer.md) | **Composition** | — |
+
+### Связанные Диаграммы
+
+| Диаграмма | Файл | Описание |
+|-----------|------|----------|
+| Composition Root | [../diagrams/mermaid/11_composition_root.mmd](../diagrams/mermaid/11_composition_root.mmd) | DI container, factories, bootstrap |
+| Factory Pattern | [../diagrams/mermaid/20_factory_pattern_usage.mmd](../diagrams/mermaid/20_factory_pattern_usage.mmd) | Использование Factory паттерна |
+| Five Layer Architecture | [../diagrams/mermaid/01_five_layer_architecture.mmd](../diagrams/mermaid/01_five_layer_architecture.mmd) | Composition слой в архитектуре |
+| Layers Interaction | [05-layers-interaction.mermaid](diagrams/05-layers-interaction.mermaid) | Bootstrap → Factories → Runner |
+
+### Связанные ADR
+
+| ADR | Тема |
+|-----|------|
+| [ADR-005](decisions/ADR-005-composition-layer-separation.md) | Composition Layer Separation |
+| [ADR-025](decisions/ADR-025-pipeline-config-unification.md) | Pipeline Config Unification |
+| [ADR-026](decisions/ADR-026-composite-pipeline-pattern.md) | Composite Pipeline Pattern |
+
+### Смежные Разделы Документации
+
+- [Interfaces Layer](04-interfaces-layer.md) — CLI использует bootstrap
+- [Application Layer](02-application-layer.md) — пайплайны, создаваемые фабриками
+- [Infrastructure Layer](03-infrastructure-layer.md) — адаптеры, регистрируемые в ProviderRegistry
+- [API Reference: Composition](../04-reference/api/composition.md) — API документация слоя

--- a/docs/02-architecture/diagrams/05-layers-interaction.mermaid
+++ b/docs/02-architecture/diagrams/05-layers-interaction.mermaid
@@ -21,9 +21,18 @@ flowchart TB
         Transformer[BaseTransformer]
         Services[PipelineServices]
 
+        subgraph Composite["Composite Pipeline (ADR-026)"]
+            CompositeRunner[CompositePipelineRunner]
+            Coordinator[EnrichmentCoordinator]
+            Merger[MergeService]
+        end
+
         Runner --> Executor
         Executor --> Transformer
         Runner --> Services
+        CompositeRunner --> Coordinator
+        CompositeRunner --> Merger
+        CompositeRunner -.->|"delegates"| Runner
     end
 
     subgraph Domain["Domain Layer"]

--- a/docs/02-architecture/diagrams/diagrams-index.md
+++ b/docs/02-architecture/diagrams/diagrams-index.md
@@ -1,8 +1,8 @@
 # BioETL Architecture Diagrams
 
-*Updated: 2026-01-05*
+*Updated: 2026-01-26*
 
-This directory contains 34 Mermaid diagram source files documenting the BioETL architecture.
+This directory contains 35 Mermaid diagram source files documenting the BioETL architecture.
 
 > **Note**: `DeltaWriter` was renamed to `SilverWriter` (see `silver_writer.py`). Some older diagrams may reference the old name.
 
@@ -44,6 +44,14 @@ This directory contains 34 Mermaid diagram source files documenting the BioETL a
 | 23 | `23-delta-lake-writer-class.mermaid` | DeltaWriter class diagram |
 | 24 | `24-hash-service-class.mermaid` | Hash service class diagram |
 | 25 | `25-circuit-breaker-observer-class.mermaid` | CircuitBreaker class diagram |
+
+### New: Composite Pipeline Diagrams
+
+Additional diagrams for Composite Pipeline (ADR-026) are available in `/docs/diagrams/mermaid/`:
+
+| File | Description |
+|------|-------------|
+| `26_composite_pipeline_workflow.mmd` | Composite Pipeline workflow: seed → enrich (fan-out) → merge |
 
 ## Rendering to PNG
 

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -1,6 +1,6 @@
 # BioETL Architecture Diagrams
 
-*Версия: 1.0 | Дата: 2026-01-20*
+*Версия: 1.1 | Дата: 2026-01-26*
 
 Этот каталог содержит комплексную систему архитектурных диаграмм для проекта BioETL.
 
@@ -8,12 +8,12 @@
 
 - **DIAGRAM_CATALOG.md** - Каталог из 500 предложенных диаграмм
 - **TOP_50_DIAGRAMS.md** - Таблица 50 наиболее важных диаграмм с приоритетами
-- **mermaid/** - 25 Mermaid диаграмм (`.mmd` files)
+- **mermaid/** - 26 Mermaid диаграмм (`.mmd` files)
 - **images/** - Отрендеренные PNG диаграммы (создаются при рендеринге)
 
 ## Структура Диаграмм
 
-### TOP-25 Диаграммы (Priority ≥ 7.75)
+### TOP-26 Диаграммы (Priority ≥ 7.75)
 
 | # | Файл | Название | Тип |
 |---|------|----------|-----|
@@ -42,6 +42,7 @@
 | 23 | `23_provider_adapters_overview.mmd` | Provider Adapters Overview | Component |
 | 24 | `24_graceful_shutdown.mmd` | Graceful Shutdown | Sequence Diagram |
 | 25 | `25_pipeline_config_structure.mmd` | PipelineConfig Structure | Class Diagram |
+| 26 | `26_composite_pipeline_workflow.mmd` | Composite Pipeline Workflow (ADR-026) | Flowchart |
 
 ## Рендеринг Диаграмм в PNG
 

--- a/docs/diagrams/mermaid/01_five_layer_architecture.mmd
+++ b/docs/diagrams/mermaid/01_five_layer_architecture.mmd
@@ -26,6 +26,7 @@ graph TB
             Core["Core Components"]
             Pipelines["Pipeline Implementations"]
             Services["Application Services"]
+            Composite["Composite Pipeline<br/>(ADR-026)"]
 
             PipelineRunner["PipelineRunner"]
             BatchExecutor["BatchExecutor"]
@@ -33,9 +34,14 @@ graph TB
             BatchTransformer["BatchTransformer"]
             BatchWriter["BatchWriter"]
 
+            CompositePipelineRunner["CompositePipelineRunner"]
+            EnrichmentCoordinator["EnrichmentCoordinator"]
+            MergeService["MergeService"]
+
             ChemblPipelines["ChEMBL Pipelines (13)"]
             PubChemPipeline["PubChem Pipeline"]
             UniProtPipeline["UniProt Pipeline"]
+            PublicationPipelines["Publication Pipelines<br/>(CrossRef, OpenAlex,<br/>PubMed, SemanticScholar)"]
 
             MedallionService["MedallionLifecycleService"]
             PostrunService["PostrunService"]
@@ -84,6 +90,9 @@ graph TB
             PubChemAdapter["PubChemAdapter"]
             UniProtAdapter["UniProtAdapter"]
             CrossRefAdapter["CrossRefAdapter"]
+            OpenAlexAdapter["OpenAlexAdapter"]
+            PubMedAdapter["PubMedAdapter"]
+            SemanticScholarAdapter["SemanticScholarAdapter"]
         end
 
     end
@@ -119,7 +128,7 @@ graph TB
     classDef interfaceStyle fill:#fce4ec,stroke:#880e4f,stroke-width:3px,color:#000
 
     class domain,Aggregates,Ports,Entities,ValueObjects,DomainServices,PipelineRun,Batch,QuarantineEntry,StoragePort,DataSourcePort,LockPort,TracingPort,MetricsPort,Activity,DQMetrics,RunContext,DataNormService,IdentityService domainStyle
-    class application,Core,Pipelines,Services,PipelineRunner,BatchExecutor,RecordProcessor,BatchTransformer,BatchWriter,ChemblPipelines,PubChemPipeline,UniProtPipeline,MedallionService,PostrunService,DQReportService appStyle
+    class application,Core,Pipelines,Services,Composite,PipelineRunner,BatchExecutor,RecordProcessor,BatchTransformer,BatchWriter,CompositePipelineRunner,EnrichmentCoordinator,MergeService,ChemblPipelines,PubChemPipeline,UniProtPipeline,PublicationPipelines,MedallionService,PostrunService,DQReportService appStyle
     class composition,Bootstrap,Factories,Registry,PipelineFactory,RunnerFactory,ServicesFactory,StorageFactory compStyle
-    class infrastructure,Storage,HTTPClient,ProviderAdapters,BronzeWriter,SilverWriter,GoldWriter,UnifiedHTTPClient,RateLimiter,CircuitBreaker,ChemblAdapter,PubChemAdapter,UniProtAdapter,CrossRefAdapter infraStyle
+    class infrastructure,Storage,HTTPClient,ProviderAdapters,BronzeWriter,SilverWriter,GoldWriter,UnifiedHTTPClient,RateLimiter,CircuitBreaker,ChemblAdapter,PubChemAdapter,UniProtAdapter,CrossRefAdapter,OpenAlexAdapter,PubMedAdapter,SemanticScholarAdapter infraStyle
     class interfaces,CLI,RunCmd,RunAllCmd,ExportCmd,QuarantineCmd,HealthCmd interfaceStyle

--- a/docs/diagrams/mermaid/26_composite_pipeline_workflow.mmd
+++ b/docs/diagrams/mermaid/26_composite_pipeline_workflow.mmd
@@ -1,0 +1,108 @@
+%%{init: {'theme':'base', 'themeVariables': { 'fontSize':'14px'}}}%%
+flowchart TB
+    subgraph composite["Composite Pipeline Pattern (ADR-026)"]
+        direction TB
+
+        subgraph seed["1. SEED PHASE"]
+            SeedPipeline["Seed Pipeline<br/>(chembl_publication)"]
+            SeedSilver["Silver/chembl/publication"]
+            KeyExtractor["KeyExtractorService<br/>Extract: doi, pmid"]
+
+            SeedPipeline --> SeedSilver
+            SeedSilver --> KeyExtractor
+        end
+
+        subgraph enrich["2. ENRICHMENT PHASE (Fan-Out)"]
+            direction LR
+
+            CrossRef["CrossRef<br/>(required)"]
+            OpenAlex["OpenAlex<br/>(optional)"]
+            PubMed["PubMed<br/>(optional)"]
+            SemanticScholar["SemanticScholar<br/>(optional)"]
+
+            CrossRefSilver["Silver/crossref/pub"]
+            OpenAlexSilver["Silver/openalex/pub"]
+            PubMedSilver["Silver/pubmed/pub"]
+            SSSilver["Silver/ss/pub"]
+
+            CrossRef --> CrossRefSilver
+            OpenAlex --> OpenAlexSilver
+            PubMed --> PubMedSilver
+            SemanticScholar --> SSSilver
+        end
+
+        subgraph merge["3. MERGE PHASE"]
+            MergeService["MergeService<br/>- LEFT OUTER JOIN<br/>- Conflict Resolution<br/>- Lineage Tracking"]
+            GoldOutput["Gold/publication_enriched"]
+
+            MergeService --> GoldOutput
+        end
+
+        %% Connections
+        KeyExtractor --> CrossRef
+        KeyExtractor --> OpenAlex
+        KeyExtractor --> PubMed
+        KeyExtractor --> SemanticScholar
+
+        CrossRefSilver --> MergeService
+        OpenAlexSilver --> MergeService
+        PubMedSilver --> MergeService
+        SSSilver --> MergeService
+        SeedSilver -.->|"Base records"| MergeService
+    end
+
+    subgraph orchestration["Orchestration Components"]
+        direction TB
+
+        CompositePipelineRunner["CompositePipelineRunner"]
+        EnrichmentCoordinator["EnrichmentCoordinator<br/>- asyncio.gather()<br/>- Timeout handling<br/>- Error handling"]
+        CheckpointManager["CompositeCheckpointManager<br/>- Resume support"]
+
+        CompositePipelineRunner --> EnrichmentCoordinator
+        CompositePipelineRunner --> CheckpointManager
+    end
+
+    subgraph fsm["FSM States"]
+        direction LR
+
+        NotStarted["NOT_STARTED"]
+        SeedRunning["SEED_RUNNING"]
+        SeedCompleted["SEED_COMPLETED"]
+        Enriching["ENRICHING"]
+        EnrichCompleted["ENRICHMENT_COMPLETED"]
+        Merging["MERGING"]
+        Completed["COMPLETED"]
+        Failed["FAILED"]
+
+        NotStarted --> SeedRunning
+        SeedRunning --> SeedCompleted
+        SeedCompleted --> Enriching
+        Enriching --> EnrichCompleted
+        EnrichCompleted --> Merging
+        Merging --> Completed
+
+        SeedRunning -.->|"Error"| Failed
+        Enriching -.->|"Required failed"| Failed
+        Merging -.->|"Error"| Failed
+    end
+
+    %% Main flow connection
+    CompositePipelineRunner -.->|"Manages"| seed
+    EnrichmentCoordinator -.->|"Coordinates"| enrich
+    MergeService -.->|"Executes"| merge
+
+    classDef seedStyle fill:#e3f2fd,stroke:#1565c0,stroke-width:2px
+    classDef enrichStyle fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px
+    classDef mergeStyle fill:#fff3e0,stroke:#e65100,stroke-width:2px
+    classDef orchStyle fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px
+    classDef fsmStyle fill:#fce4ec,stroke:#c2185b,stroke-width:2px
+    classDef requiredStyle fill:#ffebee,stroke:#c62828,stroke-width:2px
+    classDef optionalStyle fill:#f5f5f5,stroke:#616161,stroke-width:2px
+
+    class seed,SeedPipeline,SeedSilver,KeyExtractor seedStyle
+    class enrich,CrossRefSilver,OpenAlexSilver,PubMedSilver,SSSilver enrichStyle
+    class merge,MergeService,GoldOutput mergeStyle
+    class orchestration,CompositePipelineRunner,EnrichmentCoordinator,CheckpointManager orchStyle
+    class fsm,NotStarted,SeedRunning,SeedCompleted,Enriching,EnrichCompleted,Merging,Completed,Failed fsmStyle
+    class CrossRef requiredStyle
+    class OpenAlex,PubMed,SemanticScholar optionalStyle

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,15 +27,30 @@ To build a robust, scalable, and maintainable data pipeline for acquiring and pr
 | **Circuit Breaker** | Fault tolerance for API failures | [ADR-007](02-architecture/decisions/ADR-007-circuit-breaker-implementation.md) |
 | **Deterministic Writes** | Reproducible SCD2 with ingestion_ts | [ADR-014](02-architecture/decisions/ADR-014-deterministic-writes.md) |
 | **Gold Validation** | Pandera strict schema validation | [ADR-018](02-architecture/decisions/ADR-018-gold-strict-validation.md) |
+| **Composite Pipeline** | Multi-source data enrichment (seed → enrich → merge) | [ADR-026](02-architecture/decisions/ADR-026-composite-pipeline-pattern.md) |
 
-## Supported Providers
+## Supported Providers (7)
 
-| Provider | Entities | Status |
-|----------|----------|--------|
-| **ChEMBL** | Activity, Assay, Molecule, Target, Target Component, Document | Production |
-| **PubChem** | Compound | Production |
-| **UniProt** | Protein | Production |
-| **PubMed** | Publication | Production |
+| Provider | Entities | Status | Rate Limit |
+|----------|----------|--------|------------|
+| **ChEMBL** | Activity, Assay, Molecule, Target, Target Component, Document (13 entities) | Production | None |
+| **PubChem** | Compound | Production | 5 req/sec |
+| **UniProt** | Protein | Production | 100 req/sec |
+| **PubMed** | Publication | Production | 3 req/sec |
+| **CrossRef** | Publication | Production | Polite pool |
+| **OpenAlex** | Publication | Production | 10 req/sec |
+| **SemanticScholar** | Publication | Production | 100 req/5min |
+
+### Composite Pipeline (ADR-026)
+
+BioETL supports multi-source data enrichment through Composite Pipelines:
+
+```bash
+# Run composite publication pipeline (seed from ChEMBL, enrich from CrossRef, OpenAlex, PubMed)
+bioetl run --pipeline composite_publication --limit 1000
+```
+
+See [Composite Pipeline Diagram](diagrams/mermaid/26_composite_pipeline_workflow.mmd) for workflow visualization.
 
 ## Current Version
 
@@ -58,4 +73,4 @@ make test
 
 ---
 
-*Last updated: 2026-01-07*
+*Last updated: 2026-01-26*


### PR DESCRIPTION
## Summary

This PR updates the BioETL documentation to reflect the addition of Composite Pipeline pattern (ADR-026) and expands provider coverage from 4 to 7 providers. Architecture diagrams have been enhanced with cross-layer navigation and new workflow visualizations.

## Key Changes

### Documentation Updates
- **Updated sync dates**: All architecture documents now reflect 2026-01-26 sync with RULES.md v5.12
- **ADR registry expansion**: Added ADR-030 (Publication Pagination Strategy) and ADR-031 (Loading Strategy Formalization) to decision records
- **Provider count**: Expanded from 4 to 7 providers with rate limit documentation:
  - Added: CrossRef, OpenAlex, SemanticScholar (publication providers)
  - Updated all provider tables with rate limits and entity counts

### Architecture Documentation
- **Composite Pipeline (ADR-026)**: Added comprehensive section to Application Layer documenting:
  - `CompositePipelineRunner`, `EnrichmentCoordinator`, `MergeService`, `KeyExtractorService`
  - Seed → Enrich (fan-out) → Merge workflow
  - Checkpoint/resume support
  
- **Layer cross-linking**: Added "Related Materials" sections to all 5 layer documents with:
  - Layer navigation tables (← Previous | Current | Next →)
  - Related diagrams with file references
  - Related ADRs
  - Cross-references to other documentation

### Diagrams
- **New diagram**: `26_composite_pipeline_workflow.mmd` - Comprehensive flowchart showing:
  - Seed phase (ChEMBL publication extraction)
  - Enrichment phase (parallel fan-out to 4 providers)
  - Merge phase (LEFT OUTER JOIN with conflict resolution)
  - FSM states and orchestration components
  
- **Updated diagrams**:
  - `01_five_layer_architecture.mmd`: Added Composite Pipeline components and 7 providers
  - `05-layers-interaction.mermaid`: Added Composite Pipeline subgraph with delegation flow
  - `diagrams-index.md`: Updated count from 34 to 35 diagrams

### CLI Documentation
- **Interfaces Layer**: Expanded CLI section with command table and usage examples
- Added composite pipeline execution example: `bioetl run --pipeline composite_publication`
- Added health check command example

### Index & Navigation
- Updated main `index.md` with Composite Pipeline feature and 7-provider table
- Updated `00-map.md` with ADR-030/031 entries and diagram count
- Updated `diagrams/README.md` version to 1.1 with 26 TOP diagrams

## Implementation Details

- All layer documents now follow consistent structure with navigation and cross-references
- Diagram references use both local (`diagrams/`) and external (`../diagrams/mermaid/`) paths
- Provider adapters documented with specific rate limits and async/sync implementation details
- Composite Pipeline FSM includes error handling paths and checkpoint recovery
- Documentation maintains Russian language sections where appropriate (Domain/Application/Infrastructure layers)

## Files Modified

- `docs/00-map.md` - Updated sync date, ADR registry, diagram counts
- `docs/index.md` - Added Composite Pipeline feature, 7-provider table
- `docs/02-architecture/00-overview.md` - Updated ADR count, added Key Diagrams table
- `docs/02-architecture/01-domain-layer.md` - Added Related Materials section
- `docs/02-architecture/02-application-layer.md` - Added Composite Pipeline section (2.5)
- `docs/02-architecture/03-infrastructure-layer.md` - Updated provider table, added Related Materials
- `docs/02-architecture/04-interfaces-layer.md` - Expanded CLI documentation, added Related Materials
- `docs/02-architecture/05-composition-layer.md` - Updated provider registry, added Composite bootstrap, Related Materials
- `docs/02-architecture/diagrams/05-layers-interaction.mermaid` - Added Composite Pipeline subgraph
- `docs/02-architecture/diagrams/diagrams-index.md` - Updated diagram