### PR TITLE
Change pmid field type from int to str for cross-provider consistency

### DIFF
--- a/tests/unit/domain/schemas/test_year_validation.py
+++ b/tests/unit/domain/schemas/test_year_validation.py
@@ -293,8 +293,8 @@ class TestPubMedYearValidation:
         return {
             **base_etl_fields,
             "entity_id": "pubmed:article:12345678",
-            # Cross-reference IDs (pmid is int for PubMed)
-            "pmid": 12345678,
+            # Cross-reference IDs (pmid is str for cross-provider consistency)
+            "pmid": "12345678",
             "doi": "10.1038/nature12373",
             "pmc_id": None,
             # Core content


### PR DESCRIPTION
## Summary
Updated the test fixture to represent `pmid` as a string instead of an integer to ensure consistency across different data providers.

## Changes
- Modified `valid_record` fixture in `test_year_validation.py` to use `"12345678"` (string) instead of `12345678` (integer) for the `pmid` field
- Updated the corresponding comment to reflect that pmid should be a string for cross-provider consistency rather than noting it as an int for PubMed

## Rationale
This change aligns the test data with a standardized approach where cross-reference identifiers like `pmid` are represented as strings. This provides better consistency when integrating data from multiple providers and avoids type conversion issues that can arise from treating identifiers as numeric values.