### PR TITLE
Fix document_year type annotation in ActivitySchema

### DIFF
--- a/src/bioetl/domain/schemas/chembl/activity.py
+++ b/src/bioetl/domain/schemas/chembl/activity.py
@@ -188,7 +188,7 @@ class ActivitySchema(ETLRecordSchema):
     bao_format: Series[str] | None = pa.Field(nullable=True)
     bao_label: Series[str] | None = pa.Field(nullable=True)
     document_journal: Series[str] | None = pa.Field(nullable=True)
-    document_year: Series[float] | None = pa.Field(nullable=True)
+    document_year: Series[int] | None = pa.Field(nullable=True)
 
     class Config:
         """Pandera configuration."""


### PR DESCRIPTION
## Summary
Changed the `document_year` field type annotation from `Series[float]` to `Series[int]` in the ActivitySchema to correctly represent year data as integers rather than floating-point numbers.

## Changes
- Updated `document_year` field type in `ActivitySchema` from `Series[float] | None` to `Series[int] | None`

## Details
Years are naturally represented as integers and should not be stored as floating-point values. This change corrects the type annotation to accurately reflect the semantic meaning of the data and prevents potential issues with float precision when working with year values.