### PR TITLE
Add 3D steric quadrupole moments and monoisotopic mass to PubChem

### DIFF
--- a/src/bioetl/application/pipelines/pubchem/transformer.py
+++ b/src/bioetl/application/pipelines/pubchem/transformer.py
@@ -136,6 +136,11 @@ class PubChemCompoundTransformer(BaseTransformer):
                 record.get("effective_rotor_count_3d")
             ),
             "conformer_rmsd_3d": validate_non_negative(record.get("conformer_rmsd_3d")),
+            # Steric quadrupole moments can be negative (charge distribution)
+            "x_steric_quadrupole_3d": safe_float(record.get("x_steric_quadrupole_3d")),
+            "y_steric_quadrupole_3d": safe_float(record.get("y_steric_quadrupole_3d")),
+            "z_steric_quadrupole_3d": safe_float(record.get("z_steric_quadrupole_3d")),
+            "feature_count_3d": safe_int(record.get("feature_count_3d")),
         }
 
     async def _transform_impl(
@@ -170,6 +175,7 @@ class PubChemCompoundTransformer(BaseTransformer):
                 record.get("molecular_weight")
             ),
             "exact_mass": validate_non_negative(record.get("exact_mass")),
+            "monoisotopic_mass": validate_non_negative(record.get("monoisotopic_mass")),
             **self._extract_computed_descriptors(record),
             **self._extract_atom_bond_counts(record),
             **self._extract_stereochemistry(record),

--- a/src/bioetl/domain/entities/pubchem.py
+++ b/src/bioetl/domain/entities/pubchem.py
@@ -73,6 +73,9 @@ class PubchemMoleculeRecord(BaseModel):
     exact_mass: float | None = Field(
         default=None, description="Monoisotopic exact mass (Da)"
     )
+    monoisotopic_mass: float | None = Field(
+        default=None, description="Monoisotopic mass using most abundant isotope (Da)"
+    )
 
     # === Computed Descriptors ===
     xlogp: float | None = Field(
@@ -155,6 +158,21 @@ class PubchemMoleculeRecord(BaseModel):
     conformer_rmsd_3d: float | None = Field(
         default=None, description="Conformer model RMSD"
     )
+    x_steric_quadrupole_3d: float | None = Field(
+        default=None,
+        description="X-axis steric quadrupole moment (3D charge distribution)",
+    )
+    y_steric_quadrupole_3d: float | None = Field(
+        default=None,
+        description="Y-axis steric quadrupole moment (3D charge distribution)",
+    )
+    z_steric_quadrupole_3d: float | None = Field(
+        default=None,
+        description="Z-axis steric quadrupole moment (3D charge distribution)",
+    )
+    feature_count_3d: int | None = Field(
+        default=None, description="Total count of 3D pharmacophore features"
+    )
 
     # === Fingerprints (not in schema, but available) ===
     fingerprint: str | None = Field(default=None, description="PubChem fingerprint")
@@ -196,6 +214,7 @@ class PubchemMolecule(BaseEntity):
     # === Physical Properties ===
     molecular_weight: float | None = None
     exact_mass: float | None = None
+    monoisotopic_mass: float | None = None
 
     # === Computed Descriptors ===
     xlogp: float | None = None
@@ -230,6 +249,10 @@ class PubchemMolecule(BaseEntity):
     feature_hydrophobe_count_3d: int | None = None
     effective_rotor_count_3d: float | None = None
     conformer_rmsd_3d: float | None = None
+    x_steric_quadrupole_3d: float | None = None
+    y_steric_quadrupole_3d: float | None = None
+    z_steric_quadrupole_3d: float | None = None
+    feature_count_3d: int | None = None
 
     def __post_init__(self) -> None:
         super().__post_init__()

--- a/src/bioetl/domain/schemas/pubchem/compound.py
+++ b/src/bioetl/domain/schemas/pubchem/compound.py
@@ -97,6 +97,16 @@ class PubchemMoleculeSchema(ETLRecordSchema):
         """Validate exact mass is non-negative."""
         return cast("Series[bool]", series.isna() | (series >= 0))
 
+    monoisotopic_mass: Series[float] | None = pa.Field(
+        nullable=True,
+        description="Monoisotopic mass using most abundant isotope (Da)",
+    )
+
+    @pa.check("monoisotopic_mass", name="monoisotopic_mass_non_negative")
+    def _check_monoisotopic_mass(cls, series: Series[float]) -> Series[bool]:
+        """Validate monoisotopic mass is non-negative."""
+        return cast("Series[bool]", series.isna() | (series >= 0))
+
     # === Computed Descriptors ===
     xlogp: Series[float] | None = pa.Field(
         nullable=True,
@@ -344,6 +354,32 @@ class PubchemMoleculeSchema(ETLRecordSchema):
     @pa.check("conformer_rmsd_3d", name="conformer_rmsd_3d_non_negative")
     def _check_conformer_rmsd_3d(cls, series: Series[float]) -> Series[bool]:
         """Validate 3D conformer RMSD is non-negative."""
+        return cast("Series[bool]", series.isna() | (series >= 0))
+
+    # === 3D Steric Quadrupole Moments (can be negative) ===
+    x_steric_quadrupole_3d: Series[float] | None = pa.Field(
+        nullable=True,
+        description="X-axis steric quadrupole moment (3D charge distribution)",
+    )
+
+    y_steric_quadrupole_3d: Series[float] | None = pa.Field(
+        nullable=True,
+        description="Y-axis steric quadrupole moment (3D charge distribution)",
+    )
+
+    z_steric_quadrupole_3d: Series[float] | None = pa.Field(
+        nullable=True,
+        description="Z-axis steric quadrupole moment (3D charge distribution)",
+    )
+
+    # === 3D Feature Count (total pharmacophore features) ===
+    feature_count_3d: Series[int] | None = pa.Field(
+        nullable=True, description="Total count of 3D pharmacophore features"
+    )
+
+    @pa.check("feature_count_3d", name="feature_count_3d_non_negative")
+    def _check_feature_count_3d(cls, series: Series[int]) -> Series[bool]:
+        """Validate 3D feature count is non-negative."""
         return cast("Series[bool]", series.isna() | (series >= 0))
 
     class Config:

--- a/src/bioetl/infrastructure/adapters/pubchem/entity_mapper.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/entity_mapper.py
@@ -58,6 +58,7 @@ class PubChemEntityMapper:
             # === Physical Properties ===
             "molecular_weight": getattr(compound, "molecular_weight", None),
             "exact_mass": getattr(compound, "exact_mass", None),
+            "monoisotopic_mass": getattr(compound, "monoisotopic_mass", None),
             # === Computed Descriptors ===
             "xlogp": getattr(compound, "xlogp", None),
             "tpsa": getattr(compound, "tpsa", None),
@@ -104,6 +105,11 @@ class PubChemEntityMapper:
                 compound, "effective_rotor_count_3d", None
             ),
             "conformer_rmsd_3d": getattr(compound, "conformer_rmsd_3d", None),
+            # === 3D Steric Quadrupole Moments (may not be available for all compounds) ===
+            "x_steric_quadrupole_3d": getattr(compound, "x_steric_quadrupole_3d", None),
+            "y_steric_quadrupole_3d": getattr(compound, "y_steric_quadrupole_3d", None),
+            "z_steric_quadrupole_3d": getattr(compound, "z_steric_quadrupole_3d", None),
+            "feature_count_3d": getattr(compound, "feature_count_3d", None),
             # === Fingerprints (not in schema, but available) ===
             "fingerprint": getattr(compound, "fingerprint", None),
         }

--- a/tests/architecture/test_code_metrics.py
+++ b/tests/architecture/test_code_metrics.py
@@ -68,7 +68,7 @@ class TestFileSizeLimits:
         "data_normalization.py": 330,  # 321 LOC - DataNormalizationPort with partial date normalization
         "storage.py": 405,  # 400 LOC - StoragePort with read_silver, write_*_merged for composite pipelines + SourceMetadata param + Silver lineage
         # Domain Pandera schemas (declarative field definitions)
-        "compound.py": 390,  # 387 LOC - PubChem molecule schema + deprecated alias __getattr__ (v2.0)
+        "compound.py": 400,  # 397 LOC - PubChem molecule schema with 3D steric quadrupole + feature_count_3d + monoisotopic_mass
         "protein.py": 370,  # 365 LOC - UniProt target schema + deprecated alias __getattr__ (v2.0)
         # Domain contracts/gold (Gold layer Pandera schemas)
         "publications.py": 400,  # 374 LOC - Gold layer publication schemas (PubMed, CrossRef, OpenAlex, SemanticScholar)
@@ -585,7 +585,7 @@ class TestClassSize:
         # Domain ports (Protocol definitions with comprehensive docstrings)
         "StoragePort": 370,  # 365 lines - Protocol with read_silver, write_*_merged + SourceMetadata param for Bronze write + SilverWriteResult return + silver_refs param
         # Pandera schemas (declarative field definitions)
-        "PubchemMoleculeSchema": 350,  # 345 lines - PubChem molecule schema with many chemical fields
+        "PubchemMoleculeSchema": 380,  # 375 lines - PubChem molecule schema with 3D steric quadrupole + feature_count_3d + monoisotopic_mass
         # Derived entity data source wrappers (comprehensive docstrings)
         "PublicationTermDataSource": 585,  # 579 lines - Wrapper with FilterableDataSourcePort delegation + get_source_metadata
         # Composition services

--- a/tests/infrastructure/adapters/test_pubchem.py
+++ b/tests/infrastructure/adapters/test_pubchem.py
@@ -61,6 +61,8 @@ def mock_pcp_compound():
     compound.cid = 123
     compound.molecular_formula = "C9H8O4"
     compound.molecular_weight = 180.16
+    compound.exact_mass = 180.042259
+    compound.monoisotopic_mass = 180.042259
     # connectivity_smiles replaces deprecated canonical_smiles (pubchempy 1.0.5)
     compound.connectivity_smiles = "CC(=O)OC1=CC=CC=C1C(=O)O"
     # smiles replaces deprecated isomeric_smiles (pubchempy 1.0.5)
@@ -75,6 +77,11 @@ def mock_pcp_compound():
     compound.h_bond_acceptor_count = 4
     compound.h_bond_donor_count = 1
     compound.rotatable_bond_count = 3
+    # 3D steric quadrupole moments
+    compound.x_steric_quadrupole_3d = 1.23
+    compound.y_steric_quadrupole_3d = -0.45
+    compound.z_steric_quadrupole_3d = 0.78
+    compound.feature_count_3d = 7
     compound.fingerprint = "mock_fingerprint"
     return compound
 

--- a/tests/unit/application/pipelines/__snapshots__/test_transformer_snapshots.ambr
+++ b/tests/unit/application/pipelines/__snapshots__/test_transformer_snapshots.ambr
@@ -205,6 +205,7 @@
     'feature_acceptor_count_3d': None,
     'feature_anion_count_3d': None,
     'feature_cation_count_3d': None,
+    'feature_count_3d': None,
     'feature_donor_count_3d': None,
     'feature_hydrophobe_count_3d': None,
     'feature_ring_count_3d': None,
@@ -218,12 +219,16 @@
     'iupac_name': '2-acetyloxybenzoic acid',
     'molecular_formula': 'C9H8O4',
     'molecular_weight': 180.16,
+    'monoisotopic_mass': None,
     'rotatable_bond_count': None,
     'tpsa': None,
     'undefined_atom_stereo_count': None,
     'undefined_bond_stereo_count': None,
     'volume_3d': None,
+    'x_steric_quadrupole_3d': None,
     'xlogp': None,
+    'y_steric_quadrupole_3d': None,
+    'z_steric_quadrupole_3d': None,
   })
 # ---
 # name: TestPubMedPublicationTransformerSnapshot.test_transform_full_snapshot

--- a/tests/unit/application/pipelines/test_pubchem_transformer.py
+++ b/tests/unit/application/pipelines/test_pubchem_transformer.py
@@ -407,6 +407,7 @@ class TestPubChemCompoundTransformer:
             # Physical properties
             "molecular_weight": 180.16,
             "exact_mass": 180.042259,
+            "monoisotopic_mass": 180.042259,
             # Computed descriptors
             "xlogp": 1.2,
             "tpsa": 63.6,
@@ -437,6 +438,11 @@ class TestPubChemCompoundTransformer:
             "feature_hydrophobe_count_3d": 1,
             "effective_rotor_count_3d": 2.4,
             "conformer_rmsd_3d": 0.4,
+            # 3D steric quadrupole moments (can be negative)
+            "x_steric_quadrupole_3d": 1.23,
+            "y_steric_quadrupole_3d": -0.45,
+            "z_steric_quadrupole_3d": 0.78,
+            "feature_count_3d": 7,
         }
 
         result = await transformer.transform(mock_context, record, index=0)
@@ -455,6 +461,7 @@ class TestPubChemCompoundTransformer:
         # Physical properties
         assert result["molecular_weight"] == 180.16
         assert result["exact_mass"] == 180.042259
+        assert result["monoisotopic_mass"] == 180.042259
         # Computed descriptors
         assert result["xlogp"] == 1.2
         assert result["tpsa"] == 63.6
@@ -485,6 +492,11 @@ class TestPubChemCompoundTransformer:
         assert result["feature_hydrophobe_count_3d"] == 1
         assert result["effective_rotor_count_3d"] == 2.4
         assert result["conformer_rmsd_3d"] == 0.4
+        # 3D steric quadrupole moments
+        assert result["x_steric_quadrupole_3d"] == 1.23
+        assert result["y_steric_quadrupole_3d"] == -0.45
+        assert result["z_steric_quadrupole_3d"] == 0.78
+        assert result["feature_count_3d"] == 7
 
     @pytest.mark.asyncio
     async def test_transform_xlogp_negative_value(self, transformer, mock_context):
@@ -513,6 +525,70 @@ class TestPubChemCompoundTransformer:
 
         assert result is not None
         assert result["charge"] == -2
+
+    @pytest.mark.asyncio
+    async def test_transform_steric_quadrupole_negative_values(
+        self, transformer, mock_context
+    ):
+        """Test that negative steric quadrupole values are preserved (can be negative)."""
+        record = {
+            "cid": 123,
+            "canonical_smiles": "C",
+            "x_steric_quadrupole_3d": -2.5,
+            "y_steric_quadrupole_3d": -1.8,
+            "z_steric_quadrupole_3d": -0.3,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["x_steric_quadrupole_3d"] == -2.5
+        assert result["y_steric_quadrupole_3d"] == -1.8
+        assert result["z_steric_quadrupole_3d"] == -0.3
+
+    @pytest.mark.asyncio
+    async def test_transform_monoisotopic_mass(self, transformer, mock_context):
+        """Test that monoisotopic mass is validated as non-negative float."""
+        record = {
+            "cid": 123,
+            "canonical_smiles": "C",
+            "monoisotopic_mass": "16.031",
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["monoisotopic_mass"] == 16.031
+
+    @pytest.mark.asyncio
+    async def test_transform_monoisotopic_mass_negative_rejected(
+        self, transformer, mock_context
+    ):
+        """Test that negative monoisotopic mass becomes None."""
+        record = {
+            "cid": 123,
+            "canonical_smiles": "C",
+            "monoisotopic_mass": -100.0,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result.get("monoisotopic_mass") is None
+
+    @pytest.mark.asyncio
+    async def test_transform_feature_count_3d(self, transformer, mock_context):
+        """Test that feature_count_3d is validated as non-negative integer."""
+        record = {
+            "cid": 123,
+            "canonical_smiles": "C",
+            "feature_count_3d": 10,
+        }
+
+        result = await transformer.transform(mock_context, record, index=0)
+
+        assert result is not None
+        assert result["feature_count_3d"] == 10
 
     @pytest.mark.asyncio
     async def test_transform_tpsa_invalid_negative(self, transformer, mock_context):


### PR DESCRIPTION
## Summary
Extends the PubChem molecule data model to capture additional 3D molecular properties and mass measurements that are available from the PubChem API but were previously not extracted or validated.

## Key Changes

- **Added monoisotopic mass field**: New `monoisotopic_mass` property to capture the mass using the most abundant isotope (Da), validated as non-negative
- **Added 3D steric quadrupole moments**: Three new fields (`x_steric_quadrupole_3d`, `y_steric_quadrupole_3d`, `z_steric_quadrupole_3d`) to represent 3D charge distribution, allowing negative values since quadrupole moments can be negative
- **Added 3D feature count**: New `feature_count_3d` field to track total count of 3D pharmacophore features, validated as non-negative
- **Updated all layers**:
  - Domain entities (`PubchemMolecule`, `PubchemMoleculeRecord`)
  - Pandera schema with appropriate validation rules
  - Infrastructure adapter to extract these fields from PubChem API
  - Transformer to properly validate and transform the data
- **Comprehensive test coverage**: Added unit tests validating negative values for quadrupole moments, non-negative validation for mass and feature count, and snapshot tests

## Implementation Details

- Steric quadrupole moments use `safe_float()` conversion without non-negative validation, as these values can legitimately be negative due to charge distribution
- Monoisotopic mass and feature count use standard non-negative validators (`validate_non_negative`, `safe_int`)
- All new fields are optional (nullable) to maintain backward compatibility
- Updated code metrics thresholds to reflect the expanded schema (compound.py: 390→400 LOC, PubchemMoleculeSchema: 350→380 lines)