### PR TITLE
Add validation for PMID, ArXiv, and DBLP identifiers

### DIFF
--- a/src/bioetl/application/pipelines/semanticscholar/extractors.py
+++ b/src/bioetl/application/pipelines/semanticscholar/extractors.py
@@ -7,7 +7,6 @@ Semantic Scholar API responses.
 
 from __future__ import annotations
 
-import re
 from typing import Any
 
 from bioetl.domain.config import ValidationConfig
@@ -443,88 +442,3 @@ def validate_year(year: int | None) -> int | None:
         return None
     year_vo = PublicationYear.from_raw(year, config=_SS_VALIDATION_CONFIG)
     return year_vo.value if year_vo else None
-
-
-# ArXiv ID patterns (validated based on arXiv documentation)
-# Old format (before 2007): category/YYMMNNN (e.g., hep-ph/9912271, cs.AI/0001007)
-# New format (since 2007): YYMM.NNNNN[vN] (e.g., 0704.0001, 2301.12345v2)
-_ARXIV_OLD_PATTERN = re.compile(r"^[a-z-]+(\.[A-Z]{2})?/\d{7}(v\d+)?$", re.IGNORECASE)
-_ARXIV_NEW_PATTERN = re.compile(r"^\d{4}\.\d{4,5}(v\d+)?$")
-
-
-def sanitize_arxiv_id(arxiv_id: str | None) -> str | None:
-    """Sanitize and validate ArXiv ID.
-
-    Validates against known ArXiv ID formats:
-    - Old format (pre-2007): category/YYMMNNN (e.g., "hep-ph/9912271")
-    - New format (post-2007): YYMM.NNNNN[vN] (e.g., "2301.12345v2")
-
-    Args:
-        arxiv_id: Raw ArXiv ID from S2 response.
-
-    Returns:
-        Sanitized ArXiv ID if valid, None otherwise.
-
-    Example:
-        >>> sanitize_arxiv_id("2301.12345")
-        '2301.12345'
-        >>> sanitize_arxiv_id("hep-ph/9912271")
-        'hep-ph/9912271'
-        >>> sanitize_arxiv_id("invalid-id")
-        None
-
-    """
-    if not arxiv_id or not isinstance(arxiv_id, str):
-        return None
-
-    cleaned = arxiv_id.strip()
-    if not cleaned:
-        return None
-
-    # Match against known patterns
-    if _ARXIV_NEW_PATTERN.match(cleaned) or _ARXIV_OLD_PATTERN.match(cleaned):
-        return cleaned
-
-    return None
-
-
-# DBLP ID pattern: paths with components separated by "/"
-# Examples: "conf/nips/SmithJ21", "journals/jmlr/SmithJ21", "books/daglib/0028988"
-_DBLP_PATTERN = re.compile(r"^[a-z]+(/[a-zA-Z0-9_-]+)+$")
-
-
-def sanitize_dblp_id(dblp_id: str | None) -> str | None:
-    """Sanitize and validate DBLP ID.
-
-    Validates DBLP IDs which follow a path-like format:
-    - Conference: "conf/venue/AuthorYear" (e.g., "conf/nips/SmithJ21")
-    - Journal: "journals/journal/AuthorYear" (e.g., "journals/jmlr/SmithJ21")
-    - Book: "books/publisher/id" (e.g., "books/daglib/0028988")
-
-    Args:
-        dblp_id: Raw DBLP ID from S2 response.
-
-    Returns:
-        Sanitized DBLP ID if valid, None otherwise.
-
-    Example:
-        >>> sanitize_dblp_id("conf/nips/SmithJ21")
-        'conf/nips/SmithJ21'
-        >>> sanitize_dblp_id("journals/jmlr/SmithJ21")
-        'journals/jmlr/SmithJ21'
-        >>> sanitize_dblp_id("invalid")
-        None
-
-    """
-    if not dblp_id or not isinstance(dblp_id, str):
-        return None
-
-    cleaned = dblp_id.strip()
-    if not cleaned:
-        return None
-
-    # Match against DBLP path pattern
-    if _DBLP_PATTERN.match(cleaned):
-        return cleaned
-
-    return None

--- a/src/bioetl/application/pipelines/semanticscholar/sanitizers.py
+++ b/src/bioetl/application/pipelines/semanticscholar/sanitizers.py
@@ -1,0 +1,94 @@
+# src/bioetl/application/pipelines/semanticscholar/sanitizers.py
+"""Identifier sanitization functions for Semantic Scholar pipeline.
+
+Provides validation functions for external identifiers (ArXiv, DBLP)
+that don't have domain-level Value Objects.
+"""
+
+from __future__ import annotations
+
+import re
+
+# ArXiv ID patterns (validated based on arXiv documentation)
+# Old format (before 2007): category/YYMMNNN (e.g., hep-ph/9912271, cs.AI/0001007)
+# New format (since 2007): YYMM.NNNNN[vN] (e.g., 0704.0001, 2301.12345v2)
+_ARXIV_OLD_PATTERN = re.compile(r"^[a-z-]+(\.[A-Z]{2})?/\d{7}(v\d+)?$", re.IGNORECASE)
+_ARXIV_NEW_PATTERN = re.compile(r"^\d{4}\.\d{4,5}(v\d+)?$")
+
+
+def sanitize_arxiv_id(arxiv_id: str | None) -> str | None:
+    """Sanitize and validate ArXiv ID.
+
+    Validates against known ArXiv ID formats:
+    - Old format (pre-2007): category/YYMMNNN (e.g., "hep-ph/9912271")
+    - New format (post-2007): YYMM.NNNNN[vN] (e.g., "2301.12345v2")
+
+    Args:
+        arxiv_id: Raw ArXiv ID from S2 response.
+
+    Returns:
+        Sanitized ArXiv ID if valid, None otherwise.
+
+    Example:
+        >>> sanitize_arxiv_id("2301.12345")
+        '2301.12345'
+        >>> sanitize_arxiv_id("hep-ph/9912271")
+        'hep-ph/9912271'
+        >>> sanitize_arxiv_id("invalid-id")
+        None
+
+    """
+    if not arxiv_id or not isinstance(arxiv_id, str):
+        return None
+
+    cleaned = arxiv_id.strip()
+    if not cleaned:
+        return None
+
+    # Match against known patterns
+    if _ARXIV_NEW_PATTERN.match(cleaned) or _ARXIV_OLD_PATTERN.match(cleaned):
+        return cleaned
+
+    return None
+
+
+# DBLP ID pattern: paths with components separated by "/"
+# Examples: "conf/nips/SmithJ21", "journals/jmlr/SmithJ21", "books/daglib/0028988"
+_DBLP_PATTERN = re.compile(r"^[a-z]+(/[a-zA-Z0-9_-]+)+$")
+
+
+def sanitize_dblp_id(dblp_id: str | None) -> str | None:
+    """Sanitize and validate DBLP ID.
+
+    Validates DBLP IDs which follow a path-like format:
+    - Conference: "conf/venue/AuthorYear" (e.g., "conf/nips/SmithJ21")
+    - Journal: "journals/journal/AuthorYear" (e.g., "journals/jmlr/SmithJ21")
+    - Book: "books/publisher/id" (e.g., "books/daglib/0028988")
+
+    Args:
+        dblp_id: Raw DBLP ID from S2 response.
+
+    Returns:
+        Sanitized DBLP ID if valid, None otherwise.
+
+    Example:
+        >>> sanitize_dblp_id("conf/nips/SmithJ21")
+        'conf/nips/SmithJ21'
+        >>> sanitize_dblp_id("journals/jmlr/SmithJ21")
+        'journals/jmlr/SmithJ21'
+        >>> sanitize_dblp_id("invalid")
+        None
+
+    """
+    if not dblp_id or not isinstance(dblp_id, str):
+        return None
+
+    cleaned = dblp_id.strip()
+    if not cleaned:
+        return None
+
+    # Match against DBLP path pattern
+    if _DBLP_PATTERN.match(cleaned):
+        return cleaned
+
+    return None

--- a/src/bioetl/application/pipelines/semanticscholar/transformer.py
+++ b/src/bioetl/application/pipelines/semanticscholar/transformer.py
@@ -22,9 +22,11 @@ from bioetl.application.pipelines.semanticscholar.extractors import (
     extract_journal_info,
     extract_open_access_info,
     extract_tldr,
+    validate_year,
+)
+from bioetl.application.pipelines.semanticscholar.sanitizers import (
     sanitize_arxiv_id,
     sanitize_dblp_id,
-    validate_year,
 )
 from bioetl.domain.entities.semanticscholar import SemanticScholarPublicationEntity
 from bioetl.domain.normalization import normalize_pmc_id, parse_page_range

--- a/tests/unit/application/pipelines/semanticscholar/test_extractors.py
+++ b/tests/unit/application/pipelines/semanticscholar/test_extractors.py
@@ -16,9 +16,11 @@ from bioetl.application.pipelines.semanticscholar.extractors import (
     extract_open_access_info,
     extract_tldr,
     normalize_oa_status,
+    validate_year,
+)
+from bioetl.application.pipelines.semanticscholar.sanitizers import (
     sanitize_arxiv_id,
     sanitize_dblp_id,
-    validate_year,
 )
 
 
@@ -798,7 +800,10 @@ class TestSanitizeDblpId:
         """Test valid journal paper DBLP IDs."""
         assert sanitize_dblp_id("journals/jmlr/SmithJ21") == "journals/jmlr/SmithJ21"
         assert sanitize_dblp_id("journals/nature/DoeA22") == "journals/nature/DoeA22"
-        assert sanitize_dblp_id("journals/corr/abs-2301-12345") == "journals/corr/abs-2301-12345"
+        assert (
+            sanitize_dblp_id("journals/corr/abs-2301-12345")
+            == "journals/corr/abs-2301-12345"
+        )
 
     def test_valid_book_format(self) -> None:
         """Test valid book DBLP IDs."""
@@ -811,7 +816,10 @@ class TestSanitizeDblpId:
 
     def test_valid_with_hyphens(self) -> None:
         """Test valid DBLP IDs with hyphens."""
-        assert sanitize_dblp_id("journals/corr/abs-2301-12345") == "journals/corr/abs-2301-12345"
+        assert (
+            sanitize_dblp_id("journals/corr/abs-2301-12345")
+            == "journals/corr/abs-2301-12345"
+        )
 
     def test_invalid_format_returns_none(self) -> None:
         """Test invalid formats return None."""


### PR DESCRIPTION
## Summary
This PR adds validation and sanitization for external identifiers (PMID, ArXiv ID, and DBLP ID) across the OpenAlex and Semantic Scholar pipelines to ensure data quality and consistency.

## Key Changes

- **OpenAlex Pipeline**: Integrated `PubMedId` value object validation for PMID extraction, replacing raw string assignment with validated value object conversion that returns `None` for invalid/empty PMIDs.

- **Semantic Scholar Pipeline**: Added two new sanitization functions with comprehensive regex-based validation:
  - `sanitize_arxiv_id()`: Validates ArXiv IDs against both old (pre-2007: `category/YYMMNNN`) and new (post-2007: `YYMM.NNNNN[vN]`) formats
  - `sanitize_dblp_id()`: Validates DBLP IDs against path-like format (`type/venue/id`) used for conferences, journals, and books

- **Transformer Updates**: Updated Semantic Scholar transformer to use the new sanitization functions for ArXiv and DBLP ID extraction.

- **Test Coverage**: Added comprehensive unit tests for both new sanitization functions covering valid formats, edge cases, whitespace handling, and invalid inputs.

## Implementation Details

- ArXiv validation uses two regex patterns to handle the format change that occurred in 2007
- DBLP validation enforces lowercase starting character and path-like structure with alphanumeric, underscore, and hyphen characters
- All sanitization functions follow consistent patterns: strip whitespace, validate format, return `None` for invalid inputs
- PMID validation leverages existing `PubMedId` value object for consistency with domain model

https://claude.ai/code/session_01U4pHdwWdWt48WsyxHy2jFk