### PR TITLE
Fix ChEMBL Publication DTO missing term fields

### DIFF
--- a/src/bioetl/infrastructure/adapters/chembl/models.py
+++ b/src/bioetl/infrastructure/adapters/chembl/models.py
@@ -464,6 +464,16 @@ class ChemblReleaseInfo(BaseModel):
     )
 
 
+class ChemblMeshTerm(BaseModel):
+    """MeSH term record from ChEMBL API."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    mesh_heading: str | None = Field(default=None, description="MeSH heading")
+    mesh_id: str | None = Field(default=None, description="MeSH ID")
+    mesh_qualifier: str | None = Field(default=None, description="MeSH qualifier")
+
+
 class ChemblPublicationRecord(BaseModel):
     """Individual publication record from ChEMBL API.
 
@@ -497,6 +507,12 @@ class ChemblPublicationRecord(BaseModel):
         default=None, description="PubMed ID (numeric string)"
     )
     patent_id: str | None = Field(default=None, description="Patent ID")
+
+    # Keywords and Terms
+    keywords: list[str] | None = Field(default_factory=list, description="Keywords")
+    mesh_terms: list[ChemblMeshTerm] | None = Field(
+        default_factory=list, description="MeSH terms"
+    )
 
     # Source
     src_id: int | None = Field(default=None, description="Source ID")


### PR DESCRIPTION
Updated `ChemblPublicationRecord` in `src/bioetl/infrastructure/adapters/chembl/models.py` to include `mesh_terms` and `keywords` fields. This fixes a discrepancy where the DTO model was dropping these fields (due to `extra='ignore'`), which are required for the `publication_term` pipeline extraction. Defined a new `ChemblMeshTerm` model to support the structured MeSH data. Verified with a reproduction script and existing tests.

---
*PR created automatically by Jules for task [9496869033038260303](https://jules.google.com/task/9496869033038260303) started by @SatoryKono*