### PR TITLE
Fix fallback strategy enforcement in composite pipelines

### DIFF
--- a/src/bioetl/application/composite/coordinator.py
+++ b/src/bioetl/application/composite/coordinator.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from bioetl.domain.composite.result import EnrichmentResult, EnrichmentStatus
+from bioetl.domain.composite.strategy import FallbackStrategy
 
 if TYPE_CHECKING:
     import polars as pl
@@ -150,8 +151,11 @@ class EnrichmentCoordinator:
         # Wait for all enrichers to complete
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
+        # Map name to config for strategy lookup
+        enrichers_map = {e.pipeline: e for e in enrichers}
+
         # Process results
-        return self._process_results(enricher_names, results)
+        return self._process_results(enricher_names, results, enrichers_map)
 
     def _apply_filter(
         self, keys: pl.DataFrame, enricher: EnricherConfig
@@ -349,13 +353,15 @@ class EnrichmentCoordinator:
             except Exception as e:
                 duration = (datetime.now(tz=UTC) - started_at).total_seconds()
 
-                # Re-raise for required enrichers (logged as error)
-                if enricher.required:
+                # Re-raise for required enrichers OR fail strategy (logged as error)
+                if enricher.required or enricher.fallback_strategy == FallbackStrategy.FAIL:
+                    msg = "Required enricher failed" if enricher.required else "Enricher failed"
                     self._logger.error(
-                        "Required enricher failed",
+                        msg,
                         enricher=enricher.pipeline,
                         error=str(e),
-                        required=True,
+                        required=enricher.required,
+                        strategy=enricher.fallback_strategy.value,
                     )
                     raise
 
@@ -378,6 +384,7 @@ class EnrichmentCoordinator:
         self,
         enricher_names: list[str],
         results: list[EnrichmentResult | BaseException],
+        enrichers_map: dict[str, EnricherConfig],
     ) -> dict[str, EnrichmentResult]:
         """Process gathered results, handling exceptions.
 
@@ -388,6 +395,7 @@ class EnrichmentCoordinator:
         Args:
             enricher_names: Names of enrichers in order.
             results: Results from asyncio.gather.
+            enrichers_map: Mapping of pipeline name to config.
 
         Returns:
             Mapping of enricher name to result.
@@ -396,7 +404,11 @@ class EnrichmentCoordinator:
 
         for name, result in zip(enricher_names, results, strict=True):
             if isinstance(result, BaseException):
-                # Should not happen for required (already re-raised)
+                # Check if strategy requires failure
+                config = enrichers_map.get(name)
+                if config and config.fallback_strategy == FallbackStrategy.FAIL:
+                    raise result
+
                 processed[name] = EnrichmentResult.failed(
                     enricher_name=name,
                     error_message=str(result),

--- a/tests/unit/application/composite/test_coordinator_fallback.py
+++ b/tests/unit/application/composite/test_coordinator_fallback.py
@@ -1,0 +1,153 @@
+"""Unit tests for EnrichmentCoordinator fallback strategies.
+
+Tests verify that fallback strategies (SKIP, FAIL) are respected
+regardless of the 'required' flag.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import polars as pl
+import pytest
+
+from bioetl.application.composite.coordinator import EnrichmentCoordinator
+from bioetl.domain.composite.strategy import FallbackStrategy
+
+
+@pytest.fixture
+def mock_logger() -> MagicMock:
+    """Create a mock LoggerPort."""
+    logger = MagicMock()
+    logger.info = MagicMock()
+    logger.warning = MagicMock()
+    logger.error = MagicMock()
+    logger.debug = MagicMock()
+    return logger
+
+
+@pytest.fixture
+def mock_dq_config() -> MagicMock:
+    """Create a mock CompositeDQConfig."""
+    config = MagicMock()
+    config.get_enricher_hard_threshold = MagicMock(return_value=0.20)
+    return config
+
+
+@pytest.fixture
+def sample_keys() -> pl.DataFrame:
+    """Create sample keys DataFrame."""
+    return pl.DataFrame(
+        {
+            "chembl_id": ["CHEMBL1", "CHEMBL2"],
+            "doi": ["10.1000/abc", "10.1000/def"],
+        }
+    )
+
+
+@pytest.fixture
+def coordinator(mock_logger, mock_dq_config) -> EnrichmentCoordinator:
+    """Create EnrichmentCoordinator instance."""
+    return EnrichmentCoordinator(
+        logger=mock_logger,
+        dq_config=mock_dq_config,
+        max_concurrency=4,
+    )
+
+
+@pytest.mark.unit
+class TestCoordinatorFallbackStrategy:
+    """Tests for fallback strategy application."""
+
+    @pytest.mark.asyncio
+    async def test_fallback_fail_strategy_raises_error_for_optional_enricher(
+        self, coordinator, mock_logger, sample_keys
+    ) -> None:
+        """Test that fallback_strategy=FAIL raises exception even if required=False."""
+        enricher_config = MagicMock()
+        enricher_config.pipeline = "pubmed"
+        enricher_config.required = False  # Optional
+        enricher_config.fallback_strategy = FallbackStrategy.FAIL  # But strategy is FAIL
+        enricher_config.timeout_seconds = 60
+        enricher_config.filter_condition = None
+
+        def failing_factory(name: str, keys: pl.DataFrame) -> MagicMock:
+            runner = MagicMock()
+            runner.run = AsyncMock(side_effect=RuntimeError("Critical API failure"))
+            return runner
+
+        # Should raise RuntimeError because strategy is FAIL
+        # Note: run_enrichers catches exceptions via asyncio.gather(return_exceptions=True)
+        # IF the exception is raised within the task.
+        # But let's see how _run_single_enricher behaves.
+        # If it raises, gather will catch it and return it in the list.
+        # So we expect the result for this enricher to be an exception object,
+        # or the coordinator might wrap it.
+        # Actually, `run_enrichers` returns a dict of results.
+        # If _run_single_enricher raises, `asyncio.gather` with return_exceptions=True
+        # will return the Exception object.
+        # Then `_process_results` converts Exception to EnrichmentResult.failed.
+
+        # WAIT. If I want it to "Fail the composite", simply returning a failed result
+        # for an optional enricher will NOT fail the composite (Runner only checks required enrichers).
+
+        # So, if fallback_strategy=FAIL, the coordinator must ensure that the error
+        # propagates in a way that the Runner sees it as a failure.
+        # BUT, the Runner logic is:
+        # Step 6: Check required enrichers...
+
+        # If an optional enricher fails, the Runner ignores it.
+        # Unless the Coordinator raises the exception out of `run_enrichers`.
+        # But `run_enrichers` uses `gather(return_exceptions=True)`.
+
+        # So, for `FAIL` strategy to work effectively (i.e., stop the pipeline),
+        # `_process_results` needs to identify that this optional enricher FAILED with
+        # a strategy that demands composite failure, and re-raise?
+
+        # OR, `_run_single_enricher` should raise, and `run_enrichers` should NOT
+        # return it as a failed result but let it bubble up?
+        # No, `gather` swallows it into the result list.
+
+        # So `_process_results` is the place where we should check:
+        # "If this result is an Exception, AND the strategy was FAIL, then Re-raise."
+
+        # However, `_process_results` currently doesn't have access to the config
+        # to know the strategy.
+
+        # Desired Behavior: It raises RuntimeError.
+
+        with pytest.raises(RuntimeError, match="Critical API failure"):
+             await coordinator.run_enrichers(
+                keys=sample_keys,
+                enrichers=[enricher_config],
+                completed=frozenset(),
+                runner_factory=failing_factory,
+            )
+
+    @pytest.mark.asyncio
+    async def test_fallback_skip_strategy_suppresses_error(
+        self, coordinator, mock_logger, sample_keys
+    ) -> None:
+        """Test that fallback_strategy=SKIP suppresses error (default behavior)."""
+        enricher_config = MagicMock()
+        enricher_config.pipeline = "pubmed"
+        enricher_config.required = False
+        enricher_config.fallback_strategy = FallbackStrategy.SKIP
+        enricher_config.timeout_seconds = 60
+        enricher_config.filter_condition = None
+
+        def failing_factory(name: str, keys: pl.DataFrame) -> MagicMock:
+            runner = MagicMock()
+            runner.run = AsyncMock(side_effect=RuntimeError("API error"))
+            return runner
+
+        results = await coordinator.run_enrichers(
+            keys=sample_keys,
+            enrichers=[enricher_config],
+            completed=frozenset(),
+            runner_factory=failing_factory,
+        )
+
+        assert "pubmed" in results
+        assert not results["pubmed"].is_success
+        # Should not raise


### PR DESCRIPTION
Enforced FallbackStrategy.FAIL in EnrichmentCoordinator by explicitly checking the configuration when processing results from asyncio.gather. Previously, optional enrichers with FAIL strategy were treated as skipped/failed without crashing the pipeline. Added comprehensive unit tests to verify the fix.

---
*PR created automatically by Jules for task [17289028304703943907](https://jules.google.com/task/17289028304703943907) started by @SatoryKono*