### PR TITLE
Unify Publication Gold Schemas and Transformers

### DIFF
--- a/configs/schemas/gold_field_policy.yaml
+++ b/configs/schemas/gold_field_policy.yaml
@@ -1,0 +1,28 @@
+publication:
+  # Fields that are ALWAYS included in Gold
+  always_include:
+    - entity_id
+    - content_hash
+    - title
+    - doi
+    - pmid
+    - year
+    - citation_count
+    - dq_warn
+    - dq_error
+    - run_id
+    - ingestion_ts
+
+  # Fields excluded from Gold by default (PII/size)
+  exclude_by_default:
+    - affiliations           # PII: institutional data
+    - author_details         # PII: detailed information
+    - author_orcids          # PII: author identifiers
+    - references             # Size: massive data
+    - citation_contexts      # Size: text contexts
+
+  # Fields requiring explicit opt-in
+  opt_in:
+    - abstract               # Can be large
+    - authors                # PII, but often needed
+    - grants                 # Funding data

--- a/src/bioetl/application/transformers/gold/__init__.py
+++ b/src/bioetl/application/transformers/gold/__init__.py
@@ -1,0 +1,1 @@
+"""Gold layer transformers."""

--- a/src/bioetl/application/transformers/gold/field_transformer.py
+++ b/src/bioetl/application/transformers/gold/field_transformer.py
@@ -1,0 +1,103 @@
+"""Unified Silver to Gold field transformer.
+
+Implements unified transformation rules for publication entities as defined
+in the Publication Schema Unification Strategy.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import orjson
+import pandas as pd
+
+
+class GoldFieldTransformer:
+    """Unified transformation logic for Silver -> Gold."""
+
+    TRANSFORM_RULES = {
+        # Int->Float for nullable integers (Pandas nullable int -> float for compatibility)
+        "int_to_float": [
+            "year",
+            "citation_count",
+            "reference_count",
+            "author_count",
+            "mesh_heading_count",
+            "keyword_count",
+            "grant_count",
+            "chemical_count",
+            "corpus_id",
+            "pub_month",
+            "pub_day",
+            "fwci",  # Added unified metric
+        ],
+        # JSON string -> Python list (object)
+        "json_to_list": [
+            "keywords",
+            "mesh_terms",
+            "chemicals",
+            "concepts",
+            "fields_of_study",
+            "publication_types",
+            "subjects",
+            "databanks",
+            "gene_symbols",
+            "affiliations",
+            "topics",
+            "primary_topic",
+            "grants",
+            "author_orcids",
+            "author_details",
+            "references",
+            "citation_contexts",
+            "authors",  # Added authors
+            "alternative_id",
+            # issn excluded (can be str or list depending on provider)
+            "short_container_title",
+            "content_domain_domains",
+            "mesh", # OpenAlex
+        ],
+        # Rename with alias
+        "alias_mapping": {
+            "_source": "source",
+            "_lookup_method": "lookup_method",
+            "_original_id": "original_id",
+            "_dq_warn": "dq_warn",
+            "_dq_error": "dq_error",
+        },
+    }
+
+    def transform(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Apply unified transformations.
+
+        1. Renames columns based on alias_mapping.
+        2. Coerces specific integer columns to float.
+        3. Deserializes JSON string columns to Python objects (lists/dicts).
+        """
+        # Apply aliases
+        df = df.rename(columns=self.TRANSFORM_RULES["alias_mapping"])
+
+        # Apply int -> float
+        for col in self.TRANSFORM_RULES["int_to_float"]:
+            if col in df.columns:
+                # Convert to numeric, coercing errors to NaN
+                df[col] = pd.to_numeric(df[col], errors="coerce").astype(float)
+
+        # Apply json -> list
+        for col in self.TRANSFORM_RULES["json_to_list"]:
+            if col in df.columns:
+                df[col] = df[col].apply(self._safe_json_loads)
+
+        return df
+
+    def _safe_json_loads(self, val: Any) -> Any:
+        """Safely load JSON string, returning None on failure or if empty."""
+        if pd.isna(val) or val is None or val == "":
+            return None
+        if not isinstance(val, str):
+            # If it's already a list/dict, return as is
+            return val
+        try:
+            return orjson.loads(val)
+        except orjson.JSONDecodeError:
+            return None

--- a/src/bioetl/domain/contracts/gold/publication_base.py
+++ b/src/bioetl/domain/contracts/gold/publication_base.py
@@ -1,0 +1,73 @@
+"""Base Gold schema for all publication entities."""
+
+from __future__ import annotations
+
+import pandera.pandas as pa
+from pandera.typing import Series
+
+
+class PublicationGoldBaseSchema(pa.DataFrameModel):
+    """Unified base schema for Gold publication records.
+
+    All provider-specific Gold schemas inherit from this.
+    Ensures cross-provider query compatibility.
+    """
+
+    # === System Fields (non-nullable) ===
+    entity_id: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(nullable=False)
+
+    # === Cross-Reference IDs (unified across providers) ===
+    doi: Series[str] = pa.Field(nullable=True)
+    pmid: Series[str] = pa.Field(nullable=True)
+    pmc_id: Series[str] = pa.Field(nullable=True)
+
+    # === Core Content ===
+    title: Series[str] = pa.Field(nullable=True)
+    abstract: Series[str] = pa.Field(nullable=True)  # Unified: include everywhere
+    authors: Series[object] = pa.Field(nullable=True)   # JSON array (deserialized)
+
+    # === Journal/Venue ===
+    journal: Series[str] = pa.Field(nullable=True)
+    volume: Series[str] = pa.Field(nullable=True)
+    issue: Series[str] = pa.Field(nullable=True)
+    first_page: Series[str] = pa.Field(nullable=True)
+    last_page: Series[str] = pa.Field(nullable=True)
+
+    # === Dates (unified format: YYYY-MM-DD or YYYY) ===
+    year: Series[float] = pa.Field(nullable=True, ge=1450, le=2150, coerce=True)
+    publication_date: Series[str] = pa.Field(nullable=True)
+
+    # === Metadata ===
+    doc_type: Series[str] = pa.Field(nullable=True)  # Unified: nullable
+    language: Series[str] = pa.Field(nullable=True)
+
+    # === Metrics ===
+    citation_count: Series[float] = pa.Field(nullable=True, ge=0, coerce=True)
+    reference_count: Series[float] = pa.Field(nullable=True, ge=0, coerce=True)
+
+    # === Open Access ===
+    is_oa: Series[bool] = pa.Field(nullable=True, coerce=True)
+    oa_status: Series[str] = pa.Field(nullable=True)
+
+    # === Classification (always list[str] in Gold) ===
+    keywords: Series[object] = pa.Field(nullable=True)
+
+    # === Lookup Tracking ===
+    source: Series[str] = pa.Field(nullable=True, alias="_source")
+    lookup_method: Series[str] = pa.Field(nullable=True, alias="_lookup_method")
+    original_id: Series[str] = pa.Field(nullable=True, alias="_original_id")
+
+    # === DQ Fields ===
+    dq_warn: Series[bool] = pa.Field(nullable=False, default=False, alias="_dq_warn")
+    dq_error: Series[bool] = pa.Field(nullable=False, default=False, alias="_dq_error")
+
+    # === Lineage ===
+    run_id: Series[str] = pa.Field(nullable=False, alias="_run_id")
+    run_type: Series[str] = pa.Field(nullable=False, alias="_run_type")
+    source_batch_id: Series[str] = pa.Field(nullable=True, alias="_source_batch_id")
+    ingestion_ts: Series[str] = pa.Field(nullable=False, alias="_ingestion_ts")
+    index: Series[int] = pa.Field(nullable=False, alias="_index")
+
+    class Config:
+        strict = True

--- a/src/bioetl/domain/contracts/gold/publications.py
+++ b/src/bioetl/domain/contracts/gold/publications.py
@@ -18,21 +18,20 @@ from __future__ import annotations
 import pandera.pandas as pa
 from pandera.typing import Series
 
+from bioetl.domain.contracts.gold.publication_base import PublicationGoldBaseSchema
 
-class PubMedPublicationGoldSchema(pa.DataFrameModel):
+
+class PubMedPublicationGoldSchema(PublicationGoldBaseSchema):
     """Schema for PubMed Publication in Gold layer.
 
     Includes PubMed-specific fields for forensic retention and detailed analysis.
     See: https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_230101.dtd
     """
 
-    entity_id: Series[str] = pa.Field(nullable=False)
-    content_hash: Series[str] = pa.Field(nullable=False)
+    # === Primary Key Override ===
     pmid: Series[str] = pa.Field(nullable=False)
-    doi: Series[str] = pa.Field(nullable=True)
-    pmc_id: Series[str] = pa.Field(nullable=True)
-    title: Series[str] = pa.Field(nullable=True)
-    abstract: Series[str] = pa.Field(nullable=True)
+
+    # === PubMed-Specific Fields ===
     abstract_structured: Series[bool] = pa.Field(
         nullable=True
     )  # Whether abstract has NLM sections
@@ -41,9 +40,7 @@ class PubMedPublicationGoldSchema(pa.DataFrameModel):
     )  # Original non-English title
 
     # Journal information
-    journal: Series[str] = pa.Field(nullable=True)
     journal_abbrev: Series[str] = pa.Field(nullable=True)
-    # PubMed-specific journal fields (forensic retention)
     journal_title: Series[str] = pa.Field(nullable=True)  # Full journal name (PubMed)
     journal_iso_abbrev: Series[str] = pa.Field(nullable=True)  # ISO abbreviation
     journal_issn_type: Series[str] = pa.Field(
@@ -51,32 +48,23 @@ class PubMedPublicationGoldSchema(pa.DataFrameModel):
     )  # ISSN type: Print/Electronic/Linking
     issn: Series[str] = pa.Field(nullable=True)
     nlm_unique_id: Series[str] = pa.Field(nullable=True)  # NLM catalog ID
-    volume: Series[str] = pa.Field(nullable=True)
-    issue: Series[str] = pa.Field(nullable=True)
 
     # Page information
     pages: Series[str] = pa.Field(nullable=True)  # Legacy: medline_pgn format
     medline_pgn: Series[str] = pa.Field(nullable=True)  # Original PubMed pagination
-    first_page: Series[str] = pa.Field(nullable=True)  # Unified: parsed from pages
-    last_page: Series[str] = pa.Field(nullable=True)  # Unified: parsed from pages
-
-    # Authors (affiliations excluded per user request)
-    authors: Series[str] = pa.Field(nullable=True)  # JSON-serialized list
 
     # Date fields
     pub_date: Series[str] = pa.Field(nullable=True)
     pub_month: Series[float] = pa.Field(nullable=True, coerce=True)  # Month (1-12)
     pub_day: Series[float] = pa.Field(nullable=True, coerce=True)  # Day (1-31)
-    publication_date: Series[str] = pa.Field(nullable=True)  # Unified: YYYY-MM-DD
-    year: Series[float] = pa.Field(nullable=True, coerce=True)
     publication_year: Series[float] = pa.Field(
         nullable=True, coerce=True
     )  # Legacy alias
+
     accepted_date: Series[str] = pa.Field(nullable=True)
     received_date: Series[str] = pa.Field(nullable=True)
     revised_date: Series[str] = pa.Field(nullable=True)
     epub_date: Series[str] = pa.Field(nullable=True)
-    # MEDLINE-specific dates
     date_completed: Series[str] = pa.Field(
         nullable=True
     )  # MEDLINE processing completion
@@ -94,7 +82,6 @@ class PubMedPublicationGoldSchema(pa.DataFrameModel):
     publication_types: Series[object] = pa.Field(nullable=True)  # list[str]
 
     # Classification
-    keywords: Series[object] = pa.Field(nullable=True)  # list[str]
     mesh_terms: Series[object] = pa.Field(nullable=True)  # list[str]
     chemicals: Series[object] = pa.Field(nullable=True)  # list[str]
     databanks: Series[object] = pa.Field(nullable=True)  # list[str]
@@ -102,286 +89,103 @@ class PubMedPublicationGoldSchema(pa.DataFrameModel):
     citation_subset: Series[str] = pa.Field(
         nullable=True
     )  # Citation subset codes (e.g., 'AIM')
-    language: Series[str] = pa.Field(nullable=True)
     country: Series[str] = pa.Field(nullable=True)
 
-    # Counts (denormalized for query efficiency)
+    # Counts
     author_count: Series[float] = pa.Field(nullable=True, coerce=True)
     mesh_heading_count: Series[float] = pa.Field(nullable=True, coerce=True)
     keyword_count: Series[float] = pa.Field(nullable=True, coerce=True)
     grant_count: Series[float] = pa.Field(nullable=True, coerce=True)
-    reference_count: Series[float] = pa.Field(nullable=True, coerce=True)
     chemical_count: Series[float] = pa.Field(nullable=True, coerce=True)
 
-    # Source tracking (maps to _source column in DataFrame)
-    source: Series[str] = pa.Field(nullable=True, alias="_source")
 
-    # Lookup metadata
-    # _lookup_method: "direct" | "doi" | "pmid" | "title_fallback" | "unknown"
-    # _original_id: Original identifier used for lookup
-    lookup_method: Series[str] = pa.Field(nullable=True, alias="_lookup_method")
-    original_id: Series[str] = pa.Field(nullable=True, alias="_original_id")
-
-    # DQ fields
-    dq_warn: Series[bool] = pa.Field(nullable=False, default=False, alias="_dq_warn")
-    dq_error: Series[bool] = pa.Field(nullable=False, default=False, alias="_dq_error")
-
-    # Metadata
-    run_id: Series[str] = pa.Field(nullable=False, alias="_run_id")
-    run_type: Series[str] = pa.Field(nullable=False, alias="_run_type")
-    source_batch_id: Series[str] = pa.Field(nullable=True, alias="_source_batch_id")
-    ingestion_ts: Series[str] = pa.Field(nullable=False, alias="_ingestion_ts")
-    index: Series[int] = pa.Field(nullable=False, alias="_index")
-
-    class Config:
-        """Pandera configuration for strict schema validation."""
-
-        strict = True
-
-
-class CrossRefPublicationGoldSchema(pa.DataFrameModel):
+class CrossRefPublicationGoldSchema(PublicationGoldBaseSchema):
     """Schema for CrossRef Publication in Gold layer.
 
     Used for enriching publication records with CrossRef metadata via DOI resolution.
     """
 
-    # System fields
-    entity_id: Series[str] = pa.Field(nullable=False)
-    content_hash: Series[str] = pa.Field(nullable=False)
-
-    # Primary identifier
-    # doi: Digital Object Identifier (lowercase, without "https://doi.org/") - Primary key
+    # === Primary Key Override ===
     doi: Series[str] = pa.Field(nullable=False)
 
-    # Cross-reference IDs for linking publications across providers
-    # pmid: PubMed ID (numeric string: "12345678") - Always NULL for CrossRef
-    pmid: Series[str] = pa.Field(nullable=True)
-    # pmc_id: PubMed Central ID (format: "PMC1234567") - Always NULL for CrossRef
-    pmc_id: Series[str] = pa.Field(nullable=True)
-
-    # Core fields
-    title: Series[str] = pa.Field(nullable=True)
-    authors: Series[str] = pa.Field(nullable=True)  # JSON-serialized list
-    journal: Series[str] = pa.Field(nullable=True)
+    # === CrossRef-Specific Fields ===
     issn: Series[object] = pa.Field(nullable=True)  # list[str]
     publisher: Series[str] = pa.Field(nullable=True)
-    volume: Series[str] = pa.Field(nullable=True)
-    issue: Series[str] = pa.Field(nullable=True)
-    first_page: Series[str] = pa.Field(nullable=True)
-    last_page: Series[str] = pa.Field(nullable=True)
 
-    # Date fields
-    year: Series[float] = pa.Field(nullable=True, ge=1900, le=2100, coerce=True)
-    publication_date: Series[str] = pa.Field(nullable=True)  # Unified: YYYY-MM-DD
     published_print: Series[str] = pa.Field(nullable=True)  # Legacy: provider-specific
     published_online: Series[str] = pa.Field(nullable=True)  # Legacy: provider-specific
 
-    # Metadata
-    doc_type: Series[str] = pa.Field(nullable=True)
-    citation_count: Series[float] = pa.Field(nullable=True, ge=0, coerce=True)
-    reference_count: Series[float] = pa.Field(nullable=True, ge=0, coerce=True)
-    language: Series[str] = pa.Field(nullable=True)
     license_url: Series[str] = pa.Field(nullable=True)
     subjects: Series[object] = pa.Field(nullable=True)  # list[str]
 
-    # Content domain (Crossmark/license restrictions)
     content_domain_domains: Series[object] = pa.Field(nullable=True)  # list[str]
     content_domain_crossmark_restriction: Series[bool] = pa.Field(
         nullable=True, coerce=True
     )
 
-    # Alternative identifiers (publisher-specific IDs, e.g., PII)
     alternative_id: Series[object] = pa.Field(nullable=True)  # list[str]
 
-    # Canonical publication date
     published: Series[str] = pa.Field(nullable=True)
 
-    # Short container title
     short_container_title: Series[object] = pa.Field(nullable=True)  # list[str]
 
-    # ISSN by type
     issn_print: Series[str] = pa.Field(nullable=True)
     issn_electronic: Series[str] = pa.Field(nullable=True)
 
-    # Source tracking (maps to _source column in DataFrame)
-    source: Series[str] = pa.Field(nullable=True, alias="_source")
 
-    # Lookup metadata
-    # _lookup_method: "direct" | "doi" | "pmid" | "title_fallback" | "unknown"
-    # _original_id: Original identifier used for lookup
-    lookup_method: Series[str] = pa.Field(nullable=True, alias="_lookup_method")
-    original_id: Series[str] = pa.Field(nullable=True, alias="_original_id")
-
-    # DQ fields
-    dq_warn: Series[bool] = pa.Field(nullable=False, default=False, alias="_dq_warn")
-    dq_error: Series[bool] = pa.Field(nullable=False, default=False, alias="_dq_error")
-
-    # Lineage metadata
-    run_id: Series[str] = pa.Field(nullable=False, alias="_run_id")
-    run_type: Series[str] = pa.Field(nullable=False, alias="_run_type")
-    source_batch_id: Series[str] = pa.Field(nullable=True, alias="_source_batch_id")
-    ingestion_ts: Series[str] = pa.Field(nullable=False, alias="_ingestion_ts")
-    index: Series[int] = pa.Field(nullable=False, alias="_index")
-
-    class Config:
-        """Pandera configuration for strict schema validation."""
-
-        strict = True
-
-
-class OpenAlexPublicationGoldSchema(pa.DataFrameModel):
+class OpenAlexPublicationGoldSchema(PublicationGoldBaseSchema):
     """Schema for OpenAlex Publication in Gold layer.
 
     Used for batch DOI resolution with title fallback via OpenAlex Works API.
     """
 
-    # System fields
-    entity_id: Series[str] = pa.Field(nullable=False)
-    content_hash: Series[str] = pa.Field(nullable=False)
-
-    # Primary key
+    # === Primary Key ===
     openalex_id: Series[str] = pa.Field(nullable=False)
 
-    # Cross-reference IDs for linking publications across providers
-    # doi: Digital Object Identifier (lowercase, without "https://doi.org/")
-    doi: Series[str] = pa.Field(nullable=True)
-    # pmid: PubMed ID (numeric string: "12345678")
-    pmid: Series[str] = pa.Field(nullable=True)
-    # pmc_id: PubMed Central ID (format: "PMC1234567")
-    pmc_id: Series[str] = pa.Field(nullable=True)
-    title: Series[str] = pa.Field(nullable=True)
-    abstract: Series[str] = pa.Field(nullable=True)
-    authors: Series[str] = pa.Field(nullable=True)  # JSON-serialized list
+    # === System Fields Override ===
+    source: Series[str] = pa.Field(nullable=False, alias="_source")
+    lookup_method: Series[str] = pa.Field(nullable=False, alias="_lookup_method")
+
+    # === OpenAlex-Specific Fields ===
     affiliations: Series[object] = pa.Field(nullable=True)  # list[str]
     concepts: Series[object] = pa.Field(nullable=True)  # list[str]
     mesh: Series[object] = pa.Field(nullable=True)  # list[str] - MeSH terms
-    keywords: Series[object] = pa.Field(nullable=True)  # list[str]
-    mag_id: Series[str] = pa.Field(nullable=True)  # Microsoft Academic Graph ID
+    mag_id: Series[str] = pa.Field(nullable=True)
 
-    # Journal info
-    journal: Series[str] = pa.Field(nullable=True)
     issn: Series[str] = pa.Field(nullable=True)
     publisher: Series[str] = pa.Field(nullable=True)
 
-    # Page fields (nullable - OpenAlex API doesn't typically provide page information)
-    # Added for schema consistency across all publication providers
-    first_page: Series[str] = pa.Field(nullable=True)
-    last_page: Series[str] = pa.Field(nullable=True)
-
-    # Date fields
-    year: Series[float] = pa.Field(nullable=True, ge=1500, le=2100, coerce=True)
-    publication_date: Series[str] = pa.Field(nullable=True)
-
-    # Metadata
-    doc_type: Series[str] = pa.Field(nullable=False)
-    is_oa: Series[bool] = pa.Field(nullable=True, coerce=True)
-    oa_status: Series[str] = pa.Field(nullable=True)
-    # OpenAlex source field: cited_by_count
-    # Unified BioETL field: citation_count (standardized across all providers)
-    citation_count: Series[float] = pa.Field(nullable=True, ge=0, coerce=True)
-    language: Series[str] = pa.Field(nullable=True)
-
-    # Source tracking (maps to _source column in DataFrame)
-    source: Series[str] = pa.Field(nullable=False, alias="_source")
-
-    # Lookup metadata
-    # _lookup_method: "direct" | "doi" | "pmid" | "title_fallback" | "unknown"
-    # _original_id: Original identifier used for lookup
-    lookup_method: Series[str] = pa.Field(nullable=False, alias="_lookup_method")
-    original_id: Series[str] = pa.Field(nullable=True, alias="_original_id")
-
-    # DQ fields
-    dq_warn: Series[bool] = pa.Field(nullable=False, default=False, alias="_dq_warn")
-    dq_error: Series[bool] = pa.Field(nullable=False, default=False, alias="_dq_error")
-
-    # Lineage metadata
-    run_id: Series[str] = pa.Field(nullable=False, alias="_run_id")
-    run_type: Series[str] = pa.Field(nullable=False, alias="_run_type")
-    source_batch_id: Series[str] = pa.Field(nullable=True, alias="_source_batch_id")
-    ingestion_ts: Series[str] = pa.Field(nullable=False, alias="_ingestion_ts")
-    index: Series[int] = pa.Field(nullable=False, alias="_index")
-
-    class Config:
-        """Pandera configuration for strict schema validation."""
-
-        strict = True
+    # New metrics/status fields (Phase 2 & 5)
+    fwci: Series[float] = pa.Field(nullable=True, ge=0, coerce=True)
+    is_retracted: Series[bool] = pa.Field(nullable=True, coerce=True)
+    primary_topic: Series[object] = pa.Field(nullable=True)
+    topics: Series[object] = pa.Field(nullable=True)
+    grants: Series[object] = pa.Field(nullable=True)
 
 
-class SemanticScholarPublicationGoldSchema(pa.DataFrameModel):
+class SemanticScholarPublicationGoldSchema(PublicationGoldBaseSchema):
     """Schema for Semantic Scholar Publication in Gold layer.
 
     Used for enriching publication records with Semantic Scholar metadata.
     """
 
-    # System fields
-    entity_id: Series[str] = pa.Field(nullable=False)
-    content_hash: Series[str] = pa.Field(nullable=False)
-
-    # Primary key
+    # === Primary Key ===
     paper_id: Series[str] = pa.Field(nullable=False)
 
-    # External IDs
-    doi: Series[str] = pa.Field(nullable=True)
-    pmid: Series[str] = pa.Field(nullable=True)
-    # Cross-reference IDs for linking publications across providers
-    # pmc_id: PubMed Central ID (format: "PMC1234567")
-    pmc_id: Series[str] = pa.Field(nullable=True)
+    # === Semantic Scholar Specific Fields ===
     arxiv_id: Series[str] = pa.Field(nullable=True)
-    corpus_id: Series[float] = pa.Field(nullable=True, coerce=True)  # int64
+    corpus_id: Series[float] = pa.Field(nullable=True, coerce=True)
 
-    # Core fields
-    title: Series[str] = pa.Field(nullable=True)
-    # abstract excluded per user request
     tldr: Series[str] = pa.Field(nullable=True)
-    year: Series[float] = pa.Field(nullable=True, coerce=True)  # int64
-    publication_date: Series[str] = pa.Field(nullable=True)
 
-    # Journal/Venue
-    journal: Series[str] = pa.Field(nullable=True)
-    volume: Series[str] = pa.Field(nullable=True)
     pages: Series[str] = pa.Field(nullable=True)  # Legacy: "first-last" format
-    first_page: Series[str] = pa.Field(nullable=True)  # Unified: parsed from pages
-    last_page: Series[str] = pa.Field(nullable=True)  # Unified: parsed from pages
     venue: Series[str] = pa.Field(nullable=True)
 
-    # Metrics
-    citation_count: Series[float] = pa.Field(nullable=True, ge=0, coerce=True)  # int64
-    reference_count: Series[float] = pa.Field(nullable=True, ge=0, coerce=True)  # int64
-
-    # Open Access
-    is_oa: Series[bool] = pa.Field(nullable=True, coerce=True)
     open_access_url: Series[str] = pa.Field(nullable=True)
-    oa_status: Series[str] = pa.Field(nullable=True)
 
-    # Classification (JSON strings)
-    fields_of_study: Series[str] = pa.Field(nullable=True)
-    publication_types: Series[str] = pa.Field(nullable=True)
-    # authors, affiliations excluded per user request
-
-    # Source tracking (maps to _source column in DataFrame)
-    source: Series[str] = pa.Field(nullable=True, alias="_source")
-
-    # Lookup metadata
-    # _lookup_method: "direct" | "doi" | "pmid" | "title_fallback" | "unknown"
-    # _original_id: Original identifier used for lookup
-    lookup_method: Series[str] = pa.Field(nullable=True, alias="_lookup_method")
-    original_id: Series[str] = pa.Field(nullable=True, alias="_original_id")
-
-    # DQ fields
-    dq_warn: Series[bool] = pa.Field(nullable=False, default=False, alias="_dq_warn")
-    dq_error: Series[bool] = pa.Field(nullable=False, default=False, alias="_dq_error")
-
-    # Lineage metadata
-    run_id: Series[str] = pa.Field(nullable=False, alias="_run_id")
-    run_type: Series[str] = pa.Field(nullable=False, alias="_run_type")
-    source_batch_id: Series[str] = pa.Field(nullable=True, alias="_source_batch_id")
-    ingestion_ts: Series[str] = pa.Field(nullable=False, alias="_ingestion_ts")
-    index: Series[int] = pa.Field(nullable=False, alias="_index")
-
-    class Config:
-        """Pandera configuration for strict schema validation."""
-
-        strict = True
+    # Updated to object (list) for unification
+    fields_of_study: Series[object] = pa.Field(nullable=True)
+    publication_types: Series[object] = pa.Field(nullable=True)
 
 
 __all__ = [

--- a/tests/architecture/test_publication_schema_unification.py
+++ b/tests/architecture/test_publication_schema_unification.py
@@ -1,0 +1,106 @@
+"""Tests for Publication Silver/Gold Schema Unification Strategy."""
+
+import pandera.pandas as pa
+import pytest
+
+from bioetl.domain.contracts.gold.publication_base import PublicationGoldBaseSchema
+from bioetl.domain.contracts.gold.publications import (
+    CrossRefPublicationGoldSchema,
+    OpenAlexPublicationGoldSchema,
+    PubMedPublicationGoldSchema,
+    SemanticScholarPublicationGoldSchema,
+)
+
+GOLD_SCHEMAS = [
+    PubMedPublicationGoldSchema,
+    CrossRefPublicationGoldSchema,
+    OpenAlexPublicationGoldSchema,
+    SemanticScholarPublicationGoldSchema,
+]
+
+NULLABLE_POLICY = {
+    # Non-nullable in Gold (guaranteed by system)
+    "entity_id": False,
+    "content_hash": False,
+    "run_id": False,
+    "ingestion_ts": False,
+    "index": False,
+    "dq_warn": False,
+    "dq_error": False,
+    # Nullable (not all providers provide)
+    "doi": True,
+    "abstract": True,
+    "authors": True,
+    "citation_count": True,
+    "doc_type": True,
+}
+
+
+class TestPublicationSchemaUnification:
+    """Verify unified schema rules across providers."""
+
+    def test_all_gold_schemas_inherit_base(self):
+        """All Gold publication schemas must inherit PublicationGoldBaseSchema."""
+        for schema in GOLD_SCHEMAS:
+            assert issubclass(schema, PublicationGoldBaseSchema)
+
+    def test_unified_fields_present_in_all(self):
+        """Core unified fields must be present in all Gold schemas."""
+        required_fields = {
+            "entity_id",
+            "content_hash",
+            "title",
+            "doi",
+            "year",
+            "citation_count",
+            "_dq_warn",
+            "_dq_error",
+            "_run_id",
+        }
+        for schema in GOLD_SCHEMAS:
+            schema_fields = set(schema.to_schema().columns.keys())
+            missing = required_fields - schema_fields
+            assert not missing, f"{schema.__name__} missing: {missing}"
+
+    def test_year_range_unified(self):
+        """Year field must have unified range 1450-2150."""
+        for schema in GOLD_SCHEMAS:
+            year_field = schema.to_schema().columns["year"]
+
+            # Find the checks for ge and le
+            ge_check = next(
+                (c for c in year_field.checks if c.name == "greater_than_or_equal_to"),
+                None,
+            )
+            le_check = next(
+                (c for c in year_field.checks if c.name == "less_than_or_equal_to"),
+                None,
+            )
+
+            assert ge_check is not None, f"{schema.__name__} year missing ge check"
+            assert le_check is not None, f"{schema.__name__} year missing le check"
+
+            # Check statistics
+            assert (
+                ge_check.statistics["min_value"] == 1450
+            ), f"{schema.__name__} year ge != 1450"
+            assert (
+                le_check.statistics["max_value"] == 2150
+            ), f"{schema.__name__} year le != 2150"
+
+    def test_nullable_policy_consistent(self):
+        """Nullable policy must match NULLABLE_POLICY spec."""
+        for schema in GOLD_SCHEMAS:
+            for field_name, expected_nullable in NULLABLE_POLICY.items():
+                if field_name in schema.to_schema().columns:
+                    # Special case: CrossRef uses DOI as PK (non-nullable)
+                    if (
+                        schema == CrossRefPublicationGoldSchema
+                        and field_name == "doi"
+                    ):
+                        continue
+
+                    actual = schema.to_schema().columns[field_name].nullable
+                    assert (
+                        actual == expected_nullable
+                    ), f"{schema.__name__}.{field_name} nullable should be {expected_nullable}, got {actual}"


### PR DESCRIPTION
Implemented a unified strategy for Publication Gold schemas to reduce duplication and enforce consistency across providers (PubMed, CrossRef, OpenAlex, Semantic Scholar).

Key changes:
1.  **Base Schema**: Introduced `PublicationGoldBaseSchema` with common fields (`title`, `year`, `authors`, etc.) and unified constraints (e.g., year range 1450-2150).
2.  **Schema Refactoring**: Updated existing Gold schemas to inherit from the base schema, removing duplicated field definitions.
3.  **Unified Transformer**: Created `GoldFieldTransformer` to handle common transformations like `int` to `float` coercion and JSON string deserialization for list fields.
4.  **Field Policy**: Added a configuration file `gold_field_policy.yaml` to document and control field inclusion/exclusion.
5.  **Testing**: Added architecture tests to ensure all Gold schemas adhere to the unification rules.

Note: The `authors` field in Gold is now consistently `Series[object]` (list of strings/objects), whereas it remains a JSON string in Silver. The `issn` field handling was adjusted to prevent data loss for providers where it is a simple string.

---
*PR created automatically by Jules for task [18165415016871609864](https://jules.google.com/task/18165415016871609864) started by @SatoryKono*