### PR TITLE
docs(diagrams): update storage layer terminology to Bronze/Silver/Gold

### DIFF
--- a/docs/02-architecture/diagrams/diagrams-index.md
+++ b/docs/02-architecture/diagrams/diagrams-index.md
@@ -125,7 +125,7 @@ All diagrams use the following Mermaid theme configuration:
 ├─────────────────────────────────────────────────────────────┤
 │                   INFRASTRUCTURE LAYER                      │
 │  Adapters (ChEMBL, PubChem, UniProt, PubMed),               │
-│  Storage (Bronze, Delta, Gold), Locking, Observability      │
+│  Storage (Bronze, Silver, Gold), Locking, Observability     │
 ├─────────────────────────────────────────────────────────────┤
 │                    COMPOSITION LAYER                        │
 │  Bootstrap, Factories, Registry (DI Container)              │


### PR DESCRIPTION
### Motivation
- Привести текст диаграмм в `docs/02-architecture/diagrams/diagrams-index.md` в соответствие с терминологией Medallion и недавним переименованием `SilverWriter` в кодовой базе, заменив «Delta» на «Silver». 

### Description
- В ASCII‑блоке «Architecture Layers» файла `docs/02-architecture/diagrams/diagrams-index.md` заменено `Storage (Bronze, Delta, Gold)` на `Storage (Bronze, Silver, Gold)` (одна строка в блоке обновлена). 

### Testing
- Автоматические тесты не запускались, поскольку это изменение только в документации (documentation-only change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978d228b6c08324a1b77cf969ee14ea)