### PR TITLE
docs(pipelines): refresh pipeline reference list

### DIFF
--- a/docs/04-reference/pipelines/README.md
+++ b/docs/04-reference/pipelines/README.md
@@ -4,27 +4,90 @@ This directory contains technical reference documentation for individual pipelin
 
 ## ChEMBL Pipelines
 
-| Pipeline | Entity | Status |
-|----------|--------|--------|
-| [chembl-activity](chembl-activity.md) | Activity | Active |
-| [chembl-assay](chembl-assay.md) | Assay | Active |
+| Config | Entity |
+|--------|--------|
+| `configs/pipelines/chembl/activity.yaml` | activity |
+| `configs/pipelines/chembl/assay.yaml` | assay |
+| `configs/pipelines/chembl/assay_parameters.yaml` | assay_parameters |
+| `configs/pipelines/chembl/cell_line.yaml` | cell_line |
+| `configs/pipelines/chembl/compound_record.yaml` | compound_record |
+| `configs/pipelines/chembl/molecule.yaml` | molecule |
+| `configs/pipelines/chembl/protein_class.yaml` | protein_class |
+| `configs/pipelines/chembl/publication.yaml` | publication |
+| `configs/pipelines/chembl/publication_similarity.yaml` | publication_similarity |
+| `configs/pipelines/chembl/publication_term.yaml` | publication_term |
+| `configs/pipelines/chembl/target.yaml` | target |
+| `configs/pipelines/chembl/target_component.yaml` | target_component |
+
+## Composite Pipelines
+
+| Config | Entity |
+|--------|--------|
+| `configs/pipelines/composite/publication.yaml` | publication |
+
+## Crossref Pipelines
+
+| Config | Entity |
+|--------|--------|
+| `configs/pipelines/crossref/publication.yaml` | publication |
+
+## OpenAlex Pipelines
+
+| Config | Entity |
+|--------|--------|
+| `configs/pipelines/openalex/publication.yaml` | publication |
+
+## PubChem Pipelines
+
+| Config | Entity |
+|--------|--------|
+| `configs/pipelines/pubchem/compound.yaml` | compound |
+
+## PubMed Pipelines
+
+| Config | Entity |
+|--------|--------|
+| `configs/pipelines/pubmed/publication.yaml` | publication |
+
+## Semantic Scholar Pipelines
+
+| Config | Entity |
+|--------|--------|
+| `configs/pipelines/semanticscholar/publication.yaml` | publication |
+
+## UniProt Pipelines
+
+| Config | Entity |
+|--------|--------|
+| `configs/pipelines/uniprot/idmapping.yaml` | idmapping |
+| `configs/pipelines/uniprot/protein.yaml` | protein |
 
 ## Pipeline Configuration
 
-All pipeline configurations are in `configs/pipelines/{provider}/`:
+All pipeline configurations are in `configs/pipelines/`:
 
 ```bash
-configs/pipelines/
-├── chembl/
-│   ├── activity.yaml
-│   ├── assay.yaml
-│   ├── molecule.yaml
-│   └── target.yaml
-├── pubchem/
-│   └── compound.yaml
-├── uniprot/
-│   └── idmapping.yaml
-└── ...
+configs/pipelines/_base.yaml
+configs/pipelines/chembl/activity.yaml
+configs/pipelines/chembl/assay.yaml
+configs/pipelines/chembl/assay_parameters.yaml
+configs/pipelines/chembl/cell_line.yaml
+configs/pipelines/chembl/compound_record.yaml
+configs/pipelines/chembl/molecule.yaml
+configs/pipelines/chembl/protein_class.yaml
+configs/pipelines/chembl/publication.yaml
+configs/pipelines/chembl/publication_similarity.yaml
+configs/pipelines/chembl/publication_term.yaml
+configs/pipelines/chembl/target.yaml
+configs/pipelines/chembl/target_component.yaml
+configs/pipelines/composite/publication.yaml
+configs/pipelines/crossref/publication.yaml
+configs/pipelines/openalex/publication.yaml
+configs/pipelines/pubchem/compound.yaml
+configs/pipelines/pubmed/publication.yaml
+configs/pipelines/semanticscholar/publication.yaml
+configs/pipelines/uniprot/idmapping.yaml
+configs/pipelines/uniprot/protein.yaml
 ```
 
 ## Related Documentation


### PR DESCRIPTION
### Motivation
- Докумтация должна отражать реальные конфиги пайплайнов из `configs/pipelines/` и соответствовать источнику истины (`reports/configs_merged.md`).
- В разделе ChEMBL нужно перечислить все существующие пайплайны из `configs/pipelines/chembl/*.yaml` для удобства навигации.
- Требуется выделить отдельные секции для composite и прочих провайдеров (crossref/openalex/pubchem/pubmed/semanticscholar/uniprot) по фактическим файлам в `configs/pipelines/`.

### Description
- Заменён старый ChEMBL-табличный блок на таблицу, перечисляющую все файлы `configs/pipelines/chembl/*.yaml` (activity, assay, assay_parameters, cell_line, compound_record, molecule, protein_class, publication, publication_similarity, publication_term, target, target_component). 
- Добавлены отдельные секции и таблицы для `composite`, `crossref`, `openalex`, `pubchem`, `pubmed`, `semanticscholar` и `uniprot`, с явными путями к соответствующим конфигам. 
- В блоке «Pipeline Configuration» заменено древо на полный список путей к файлам в `configs/pipelines/`, включён `configs/pipelines/_base.yaml`. 
- Изменён файл: `docs/04-reference/pipelines/README.md`.

### Testing
- Это изменение только в документации; автоматические тесты не запускались. 
- Файл зафиксирован в локальном репозитории (`git commit`) и готов к ревью; изменений в коде нет, поэтому CI тесты не требуются для выпуска документации.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978cf70757483249af53f7867b3de8a)