### PR TITLE
docs(verification): align ChEMBL publication entity names and add ADR-024 note

### DIFF
--- a/docs/verification/publication-field-mapping-report.md
+++ b/docs/verification/publication-field-mapping-report.md
@@ -19,13 +19,15 @@ Systematic verification of field mapping across all publication pipeline layers 
 
 | # | Pipeline | Provider | Entity | Status |
 |---|----------|----------|--------|--------|
-| 1 | `chembl_publication` | ChEMBL | document | ⚠️ Missing Gold fields |
-| 2 | `chembl_publication_similarity` | ChEMBL | document_similarity | ✅ Correct |
-| 3 | `chembl_publication_term` | ChEMBL | document_term | ✅ Correct |
+| 1 | `chembl_publication` | ChEMBL | publication | ⚠️ Missing Gold fields |
+| 2 | `chembl_publication_similarity` | ChEMBL | publication_similarity | ✅ Correct |
+| 3 | `chembl_publication_term` | ChEMBL | publication_term | ✅ Correct |
 | 4 | `pubmed_publication` | PubMed | publication | ⚠️ Missing Gold fields (Type mismatch ✅ FIXED) |
 | 5 | `crossref_publication` | CrossRef | work | ⚠️ Missing Gold fields (Type mismatch ✅ FIXED) |
 | 6 | `openalex_publication` | OpenAlex | publication | ✅ Correct (Type mismatch ✅ FIXED) |
 | 7 | `semanticscholar_publication` | SemanticScholar | publication | ✅ Correct |
+
+Примечание: API-ресурсы остаются `document*`, но canonical `entity_type` — `publication*` (см. ADR-024).
 
 ---
 


### PR DESCRIPTION
### Motivation
- Привести таблицу в `docs/verification/publication-field-mapping-report.md` в соответствие с каноническим именованием сущностей (`publication*`) согласно ADR-024, чтобы избежать неоднозначностей между API-ресурсами и canonical `entity_type`.

### Description
- В файле `docs/verification/publication-field-mapping-report.md` для строк с `chembl_publication*` заменены `document` → `publication`, `document_similarity` → `publication_similarity`, `document_term` → `publication_term`, и добавлена краткая ремарка, что API‑ресурсы остаются `document*`, а canonical `entity_type` — `publication*` (см. ADR-024).

### Testing
- Автоматические тесты не запускались, так как изменения касаются только документации (documentation-only change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978cf7c36b8832484beb4d75d188d0a)