### PR TITLE
docs(architecture): refresh mermaid count wording

### DIFF
--- a/docs/00-map.md
+++ b/docs/00-map.md
@@ -70,7 +70,7 @@ docs/
 │   ├── observability-layers.md  # Observability architecture
 │   ├── diagrams.md              # Mermaid diagrams collection
 │   ├── decisions/               # ADR-001..031 (31 records)
-│   └── diagrams/                # 34 .mermaid diagrams + supporting docs (index/policy) + render_diagrams.py
+│   └── diagrams/                # 34 диаграммы .mermaid + supporting docs (index/policy) + render_diagrams.py
 │
 ├── 03-guides/                   # How-to guides (16 guides)
 │   ├── add-new-source.md        # Adding new provider
@@ -413,7 +413,7 @@ graph TD
 | 05-operations/runbooks/  | 2026-01-04   | 16 active runbooks           |
 | domain/schemas/          | 2025-12-28   | ChEMBL schemas (4 entities)  |
 | archived/audits/         | 2026-01-21   | Historical audit files       |
-| 02-architecture/diagrams/| 2025-12-31   | 34 Mermaid diagrams          |
+| 02-architecture/diagrams/| 2025-12-31   | 34 диаграммы Mermaid         |
 
 ---
 

--- a/docs/02-architecture/diagrams/diagrams-index.md
+++ b/docs/02-architecture/diagrams/diagrams-index.md
@@ -2,7 +2,7 @@
 
 *Updated: 2026-01-26*
 
-This directory contains 34 Mermaid diagram source files documenting the BioETL architecture.
+В каталоге 34 исходных файла диаграмм Mermaid, документирующих архитектуру BioETL.
 
 > **Note**: `DeltaWriter` was renamed to `SilverWriter` (see `silver_writer.py`). Some older diagrams may reference the old name.
 


### PR DESCRIPTION
### Motivation
- Пересчитано количество файлов в `docs/02-architecture/diagrams/*.mermaid` (34) и синхронизировать текстовую документацию, чтобы она точно отражала текущее состояние репозитория.

### Description
- Обновлены формулировки в `docs/02-architecture/diagrams/diagrams-index.md` и `docs/00-map.md` для согласованного упоминания количества диаграмм (замена строки описания на актуальную формулировку).

### Testing
- Автоматические тесты не запускались, поскольку изменения носят документационный характер (documentation-only changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978d1dd15988324ad09986d90ad4814)