### PR TITLE
docs(diagrams): привести диаграмму захвата блокировки в соответствие с API LockManager

### DIFF
--- a/docs/diagrams/mermaid/21_lock_acquisition_flow.mmd
+++ b/docs/diagrams/mermaid/21_lock_acquisition_flow.mmd
@@ -6,21 +6,21 @@ sequenceDiagram
     participant Heartbeat
     participant Logger
 
-    PipelineRunner->>LockManager: acquire_lock(key, owner_id)
+    PipelineRunner->>LockManager: acquire(lock_key, owner_id, ttl, wait, wait_timeout, exclusive)
 
     LockManager->>Logger: log("Attempting lock acquisition")
 
-    LockManager->>MemoryLock: acquire(key, owner_id, ttl=90s)
+    LockManager->>MemoryLock: acquire(lock_key, owner_id, ttl=90s, wait, wait_timeout, exclusive)
 
     alt Lock Available
-        MemoryLock->>MemoryLock: _locks[key] = {owner, expiry, timestamp}
+        MemoryLock->>MemoryLock: _locks[lock_key] = {owner, expiry, timestamp}
         MemoryLock-->>LockManager: success=True
 
-        LockManager->>Heartbeat: start_heartbeat(key, owner_id, interval=30s)
+        LockManager->>Heartbeat: start_heartbeat(lock_key, owner_id, interval=30s)
 
         loop Every 30 seconds
-            Heartbeat->>MemoryLock: heartbeat(key, owner_id)
-            MemoryLock->>MemoryLock: refresh_ttl(key, +90s)
+            Heartbeat->>MemoryLock: heartbeat(lock_key, owner_id, exclusive)
+            MemoryLock->>MemoryLock: refresh_ttl(lock_key, +90s)
             MemoryLock-->>Heartbeat: success=True
             Heartbeat->>Logger: log("Heartbeat sent")
         end
@@ -32,17 +32,17 @@ sequenceDiagram
 
         Note over PipelineRunner,Logger: Pipeline Execution
 
-        PipelineRunner->>LockManager: release_lock(key, owner_id)
+        PipelineRunner->>LockManager: release(lock_key, owner_id, exclusive)
 
         LockManager->>Heartbeat: stop_heartbeat()
         Heartbeat->>Heartbeat: Cancel heartbeat loop
 
-        LockManager->>MemoryLock: release(key, owner_id)
+        LockManager->>MemoryLock: release(lock_key, owner_id, exclusive)
 
-        MemoryLock->>MemoryLock: validate_owner(key, owner_id)
+        MemoryLock->>MemoryLock: validate_owner(lock_key, owner_id)
 
         alt Owner Valid
-            MemoryLock->>MemoryLock: del _locks[key]
+            MemoryLock->>MemoryLock: del _locks[lock_key]
             MemoryLock-->>LockManager: success=True
             LockManager->>Logger: log("Lock released")
             LockManager-->>PipelineRunner: Lock released
@@ -60,11 +60,11 @@ sequenceDiagram
 
             loop Until timeout
                 LockManager->>LockManager: sleep(1s)
-                LockManager->>MemoryLock: acquire(key, owner_id, ttl)
+                LockManager->>MemoryLock: acquire(lock_key, owner_id, ttl, wait, wait_timeout, exclusive)
 
                 alt Lock becomes available
                     MemoryLock-->>LockManager: success=True
-                    LockManager->>Heartbeat: start_heartbeat()
+                    LockManager->>Heartbeat: start_heartbeat(lock_key, owner_id, interval=30s)
                     LockManager-->>PipelineRunner: Lock acquired
                 end
             end
@@ -82,10 +82,10 @@ sequenceDiagram
 
     MemoryLock->>MemoryLock: _ttl_checker_loop()
 
-    loop Every 5 seconds
+    loop Every 1 second
         MemoryLock->>MemoryLock: Check all locks
         alt Lock expired (now > expiry)
-            MemoryLock->>MemoryLock: del _locks[key]
+            MemoryLock->>MemoryLock: del _locks[lock_key]
             MemoryLock->>Logger: log("Lock auto-released (TTL)")
         end
     end


### PR DESCRIPTION
### Motivation
- Диаграмма использовала устаревшие подписи `acquire_lock`/`release_lock`, некорректные имена параметров и устаревший интервал TTL‑проверки, что вводило в заблуждение относительно реального API `LockManager`.
- Требовалось синхронизировать визуальное представление с реализацией в `src/bioetl/infrastructure/locking/memory_lock.py` (например, `_TTL_CHECK_INTERVAL = 1.0`).

### Description
- Заменил вызовы `acquire_lock`/`release_lock` на `acquire`/`release` и включил параметры `lock_key`, `owner_id`, `ttl`, `wait`, `wait_timeout`, `exclusive` в соответствующие шаги диаграммы.
- Заменил внутренние вхождения `key` на `lock_key` в местах создания, проверки и автосброса замков, а также при обновлении TTL (`_locks[lock_key]`).
- Обновил интервал цикла TTL‑проверки с `5` секунд на `1` секунду в соответствии с реализацией `MemoryLock`.
- Изменён файл: `docs/diagrams/mermaid/21_lock_acquisition_flow.mmd`.

### Testing
- Автоматические тесты не запускались, так как это изменение только в документации (docs-only change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978d21937b88324b3e149e4d0081a33)