### PR TITLE
Deprecate AWS deployment diagram (mark as historical, reference ADR-010)

### DIFF
--- a/docs/02-architecture/diagrams/12-full-aws-deployment.mermaid
+++ b/docs/02-architecture/diagrams/12-full-aws-deployment.mermaid
@@ -1,5 +1,7 @@
 %%{init: {'theme': 'neutral', 'themeVariables': {'fontFamily': 'Inter, system-ui', 'lineWidth': '2'}}}%%
+%% DEPRECATED: Historical/Reference only. See ADR-010 (Local-Only Deployment): ../decisions/ADR-010-local-only-deployment.md
 flowchart TB
+    ReferenceNote["Historical/Reference only<br/>See ADR-010 (Local-Only Deployment)"]
     subgraph External["External APIs"]
         ChEMBL_API["🌐 ChEMBL API<br/>ebi.ac.uk/chembl"]
         PubChem_API["🌐 PubChem API<br/>pubchem.ncbi.nlm.nih.gov"]
@@ -106,3 +108,4 @@ flowchart TB
     style Gold fill:#FFD700,color:#000
     style Quarantine fill:#FF6B6B,color:#fff
     style Redis fill:#DC382D,color:#fff
+    style ReferenceNote fill:#F5F5F5,color:#333,stroke:#999,stroke-dasharray: 5 5

--- a/docs/02-architecture/diagrams/diagrams-index.md
+++ b/docs/02-architecture/diagrams/diagrams-index.md
@@ -30,7 +30,6 @@ This directory contains 34 Mermaid diagram source files documenting the BioETL a
 | 09 | `09-full-er-diagram.mermaid` | Entity-relationship diagram |
 | 10 | `10-infrastructure-layer-class-diagram.mermaid` | Infrastructure layer classes |
 | 11 | `11-lock-acquisition-sequence.mermaid` | Lock acquisition sequence |
-| 12 | `12-full-aws-deployment.mermaid` | AWS deployment architecture (reference) |
 | 13 | `13-domain-models-relationship.mermaid` | Domain model relationships |
 | 14 | `14-provider-health-states.mermaid` | Provider health states |
 | 15 | `15-dq-check-workflow.mermaid` | Data quality check workflow |


### PR DESCRIPTION
### Motivation
- The project follows the Local-Only deployment decision (ADR-010), so the previously included AWS deployment diagram is outdated and should be marked as historical/reference-only.

### Description
- Add a deprecation banner and a `Historical/Reference only` note linking to `ADR-010` in `docs/02-architecture/diagrams/12-full-aws-deployment.mermaid`.
- Remove the `12-full-aws-deployment.mermaid` entry from `docs/02-architecture/diagrams/diagrams-index.md` to avoid listing the deprecated diagram.
- Add a small visual style for the deprecation note inside the mermaid diagram file.

### Testing
- Documentation-only change; no automated tests were run for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978d1de7ae08324a0343e58beb2e89c)