### PR TITLE
Update locking diagram to MemoryLock (TTL 90s, heartbeat 30s)

### DIFF
--- a/docs/02-architecture/diagrams/00-diagramming-policy.md
+++ b/docs/02-architecture/diagrams/00-diagramming-policy.md
@@ -227,25 +227,25 @@ flowchart TD
 
 ```plantuml
 @startuml
-title Pipeline Lock Acquisition (§3.3)
+title Pipeline Lock Acquisition (MemoryLock, TTL 90s, heartbeat 30s) (§3.3)
 
 participant Worker
-participant Redis
+participant MemoryLock
 participant DeltaLake
 
-Worker -> Redis: SETNX lock:chembl_activity
-Redis --> Worker: OK
+Worker -> MemoryLock: acquire lock:chembl_activity (TTL 90s)
+MemoryLock --> Worker: OK
 
-loop Every 30s
-    Worker -> Redis: EXPIRE (heartbeat)
+loop Every 30s (heartbeat)
+    Worker -> MemoryLock: refresh TTL (90s)
 end
 
-Worker -> Redis: GET lock (validate owner)
-Redis --> Worker: owner_id matches
+Worker -> MemoryLock: get lock (validate owner)
+MemoryLock --> Worker: owner_id matches
 
 Worker -> DeltaLake: write()
 
-Worker -> Redis: DEL lock
+Worker -> MemoryLock: release lock
 @enduml
 ```
 


### PR DESCRIPTION
### Motivation
- Align the diagrams with ADR-010 local-only deployment by documenting the in-process `MemoryLock` semantics and explicit timing parameters (TTL 90s, heartbeat 30s).

### Description
- Replace `Redis` with `MemoryLock` in the PlantUML pipeline lock acquisition sequence in `docs/02-architecture/diagrams/00-diagramming-policy.md`, update the diagram title to include "MemoryLock, TTL 90s, heartbeat 30s", and change the acquire/refresh/validate/release steps and heartbeat annotation accordingly.

### Testing
- Docs-only change; no automated tests were run for this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978d1e06a4083248004a8b22310047a)