### PR TITLE
docs(architecture): update local storage adapters to Silver/Bronze/GoldWriter

### DIFF
--- a/docs/02-architecture/system-context.md
+++ b/docs/02-architecture/system-context.md
@@ -106,7 +106,7 @@ BioETL использует **Ports & Adapters** (Hexagonal Architecture):
 
 - **Ports**: Protocol interfaces в Domain layer (`DataSourcePort`, `StoragePort`, `LockPort`)
 - **Adapters**: Infrastructure implementations
-  - **Local-Only**: `ChemblClient`, `LocalDeltaWriter`, `MemoryLock`
+  - **Local-Only**: `ChemblClient`, `SilverWriter`, `BronzeWriter`, `GoldWriter`, `MemoryLock`
   - **Distributed (Future)**: `S3Writer`, `RedisLock`
 
 Это обеспечивает:


### PR DESCRIPTION
### Motivation
- Align the System Context documentation with the actual storage writer classes in `src/bioetl/infrastructure/storage` by replacing the obsolete `LocalDeltaWriter` reference with the real writers and avoid introducing new entities.

### Description
- Updated `docs/02-architecture/system-context.md` to list `SilverWriter`, `BronzeWriter`, and `GoldWriter` (alongside `ChemblClient` and `MemoryLock`) in the "Adapters" → "Local-Only" section.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978d1f7b1f883249a8597065319dec6)