### PR TITLE
docs(diagrams): update storage violation example to SilverWriter

### DIFF
--- a/docs/diagrams/mermaid/04_layer_dependency_matrix.mmd
+++ b/docs/diagrams/mermaid/04_layer_dependency_matrix.mmd
@@ -70,7 +70,7 @@ graph TD
         Violation1["❌ BAD: domain/entities.py<br/>from application.services import X"]
         Fix1["✅ GOOD: domain/entities.py<br/>from domain.ports import XPort"]
 
-        Violation2["❌ BAD: application/core/runner.py<br/>from infrastructure.storage import DeltaWriter"]
+        Violation2["❌ BAD: application/core/runner.py<br/>from infrastructure.storage import SilverWriter"]
         Fix2["✅ GOOD: application/core/runner.py<br/>from domain.ports import StoragePort"]
 
         Violation3["❌ BAD: infrastructure/adapters/chembl.py<br/>from application.pipelines import ChemblPipeline"]


### PR DESCRIPTION
### Motivation
- Correct the example violation in the layer-dependency matrix to reference `SilverWriter` (which is actually exported from `src/bioetl/infrastructure/storage/__init__.py`) while preserving the intent of demonstrating an import from `infrastructure` into `application`.

### Description
- Replace the example line in `docs/diagrams/mermaid/04_layer_dependency_matrix.mmd` from `from infrastructure.storage import DeltaWriter` to `from infrastructure.storage import SilverWriter` and commit the change.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978d1fac6b483248e1957069b44f4d1)