### PR TITLE
docs(diagrams): sync StoragePort methods with domain port

### DIFF
--- a/docs/02-architecture/diagrams/23-delta-lake-writer-class.mermaid
+++ b/docs/02-architecture/diagrams/23-delta-lake-writer-class.mermaid
@@ -7,11 +7,14 @@ classDiagram
         +write_bronze(records, provider, entity) BronzeWriteResult
         +write_silver(records, table, mode) WriteResult
         +write_gold(records, table, schema) WriteResult
-        +clear_silver(table) int
-        +clear_gold(table) int
+        +read_silver(table, columns) list~dict~
+        +write_silver_merged(table, records, primary_keys) None
+        +write_gold_merged(table, records, primary_keys) None
+        +clear_silver(table, dry_run: bool = False) int
+        +clear_gold(table, dry_run: bool = False) int
         +vacuum(table, retention_days) None
         +archive(source, dest) None
-        +health_check() bool
+        +health_check() HealthStatus
     }
 
     class SilverWriter {


### PR DESCRIPTION
### Motivation
- Синхронизировать диаграмму `StoragePort` в документации с текущим контрактом в `src/bioetl/domain/ports/storage.py`, добавив отсутствующие методы и уточнив сигнатуры.

### Description
- Обновлён блок `StoragePort` в `docs/02-architecture/diagrams/23-delta-lake-writer-class.mermaid`: добавлены `read_silver`, `write_silver_merged`, `write_gold_merged`; `clear_silver` и `clear_gold` теперь принимают `dry_run: bool = False`; `health_check()` обозначен как возвращающий `HealthStatus`; сохранён Mermaid-синтаксис и минимальный diff.

### Testing
- Изменение касается только документации, автоматические тесты не запускались (docs-only change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978d20065248324babd92e2fd4b0827)