### PR TITLE
docs(architecture): fix diagrams path in Python render instructions

### DIFF
--- a/docs/02-architecture/diagrams/diagrams-index.md
+++ b/docs/02-architecture/diagrams/diagrams-index.md
@@ -70,7 +70,7 @@ done
 Use the included `render_diagrams.py` script:
 
 ```bash
-cd docs/architecture/diagrams
+cd docs/02-architecture/diagrams
 python render_diagrams.py
 ```
 


### PR DESCRIPTION
### Motivation
- Исправить путь в инструкции по рендерингу диаграмм, чтобы он соответствовал фактической структуре репозитория и предотвращал ошибки при запуске `render_diagrams.py`.

### Description
- Обновлён файл `docs/02-architecture/diagrams/diagrams-index.md`: заменён `cd docs/architecture/diagrams` на `cd docs/02-architecture/diagrams` в секции «Option 2: Python Script».

### Testing
- Нет автоматических тестов для этой документационной правки, поэтому автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978d224a8a08324912365a9cc6723d4)