### PR TITLE
docs(diagrams): update SilverWriter description

### DIFF
--- a/docs/02-architecture/diagrams/diagrams-index.md
+++ b/docs/02-architecture/diagrams/diagrams-index.md
@@ -41,7 +41,7 @@ This directory contains 34 Mermaid diagram source files documenting the BioETL a
 | 20 | `20-quarantine-record-states.mermaid` | Quarantine record states |
 | 21 | `21-activity-entity-data-flow.mermaid` | Activity entity data flow |
 | 22 | `22-client-api-request-sequence.mermaid` | Client API request sequence |
-| 23 | `23-delta-lake-writer-class.mermaid` | DeltaWriter class diagram |
+| 23 | `23-delta-lake-writer-class.mermaid` | SilverWriter class diagram |
 | 24 | `24-hash-service-class.mermaid` | Hash service class diagram |
 | 25 | `25-circuit-breaker-observer-class.mermaid` | CircuitBreaker class diagram |
 


### PR DESCRIPTION
### Motivation
- `DeltaWriter` был переименован в `SilverWriter`, поэтому запись в индексе диаграмм должна отражать актуальное имя класса.

### Description
- Обновлена строка в `docs/02-architecture/diagrams/diagrams-index.md`, заменив описание для `23-delta-lake-writer-class.mermaid` с "DeltaWriter class diagram" на "SilverWriter class diagram".

### Testing
- Документационные изменения — автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978d22678a08324830504f7be16a483)