### PR TITLE
docs(diagrams): привести в соответствие количество ChEMBL pipelines и список сущностей

### DIFF
--- a/docs/diagrams/mermaid/01_five_layer_architecture.mmd
+++ b/docs/diagrams/mermaid/01_five_layer_architecture.mmd
@@ -38,7 +38,7 @@ graph TB
             EnrichmentCoordinator["EnrichmentCoordinator"]
             MergeService["MergeService"]
 
-            ChemblPipelines["ChEMBL Pipelines (13)"]
+            ChemblPipelines["ChEMBL Pipelines (12)"]
             PubChemPipeline["PubChem Pipeline"]
             UniProtPipeline["UniProt Pipeline"]
             PublicationPipelines["Publication Pipelines<br/>(CrossRef, OpenAlex,<br/>PubMed, SemanticScholar)"]

--- a/docs/diagrams/mermaid/23_provider_adapters_overview.mmd
+++ b/docs/diagrams/mermaid/23_provider_adapters_overview.mmd
@@ -3,7 +3,7 @@ graph TB
     subgraph providers["7 Provider Adapters"]
         direction LR
 
-        ChEMBL["ChEMBL<br/>13 pipelines<br/>694 LOC"]
+        ChEMBL["ChEMBL<br/>12 pipelines<br/>694 LOC"]
         PubChem["PubChem<br/>1 pipeline<br/>~400 LOC"]
         UniProt["UniProt<br/>2 pipelines<br/>~500 LOC"]
         CrossRef["CrossRef<br/>1 pipeline<br/>~350 LOC"]
@@ -22,14 +22,14 @@ graph TB
         UnifiedClient["UnifiedHTTPClient<br/>- RateLimiter<br/>- CircuitBreaker<br/>- Retry logic"]
     end
 
-    subgraph chembl["ChEMBL Adapter (13 entities)"]
+    subgraph chembl["ChEMBL Adapter (12 entities)"]
         direction TB
 
         ChemblAdapter["ChemblAdapter (694 LOC)"]
         ChemblMapper["ChemblEntityMapper<br/>URL/entity mapping"]
         ChemblDTO["DTO Models:<br/>- ActivityDTO<br/>- MoleculeDTO<br/>- TargetDTO<br/>- AssayDTO<br/>etc."]
 
-        ChemblEntities["Entities:<br/>activity, molecule, target,<br/>assay, assay_parameters,<br/>compound_record, cell_line,<br/>protein_class, publication,<br/>publication_term,<br/>publication_similarity,<br/>target_component, mechanism"]
+        ChemblEntities["Entities:<br/>activity, assay, assay_parameters,<br/>cell_line, compound_record,<br/>molecule, protein_class,<br/>publication, publication_term,<br/>publication_similarity, target,<br/>target_component"]
 
         ChemblAdapter --> ChemblMapper
         ChemblMapper --> ChemblDTO


### PR DESCRIPTION
### Motivation
- Обновить архитектурные диаграммы, чтобы отражали актуальное состояние реализации ChEMBL — 12 пайплайнов и отсутствие сущности `mechanism` в конфигурациях и коде.

### Description
- Изменён текст в `docs/diagrams/mermaid/01_five_layer_architecture.mmd`, заменив `ChEMBL Pipelines (13)` на `ChEMBL Pipelines (12)`.
- Обновлён `docs/diagrams/mermaid/23_provider_adapters_overview.mmd`, заменив `13 pipelines`→`12 pipelines`, удалив `mechanism` и зафиксировав список из 12 сущностей: `activity, assay, assay_parameters, cell_line, compound_record, molecule, protein_class, publication, publication_term, publication_similarity, target, target_component`.

### Testing
- Автоматические тесты не запускались, так как это изменения только в документации (doc-only change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978d21297308324844e09b39075538d)