### PR TITLE
Refactor DQ serialization: add domain `to_dict` helper and update analyzers

### DIFF
--- a/src/bioetl/application/services/dq/bronze_analyzer.py
+++ b/src/bioetl/application/services/dq/bronze_analyzer.py
@@ -20,11 +20,8 @@ from typing import Any
 
 import orjson
 
-from bioetl.application.services.dq.utils import (
-    build_summary,
-    result_to_dict,
-    update_counts,
-)
+from bioetl.application.services.dq.utils import build_summary, update_counts
+from bioetl.domain.services.dq_serializer import to_dict
 from bioetl.domain.ports import BronzeDQConfigPort
 from bioetl.domain.value_objects.dq_report import (
     BronzeDQCheckType,
@@ -82,7 +79,7 @@ class BronzeDQAnalyzer:
         # Record count check
         if BronzeDQCheckType.RECORD_COUNT in enabled_checks:
             record_count_result = self._check_record_count(record_list)
-            checks["record_count"] = result_to_dict(record_count_result)
+            checks["record_count"] = to_dict(record_count_result)
             passed, failed, warnings = update_counts(
                 record_count_result.status, passed, failed, warnings
             )
@@ -90,7 +87,7 @@ class BronzeDQAnalyzer:
         # File integrity check
         if BronzeDQCheckType.FILE_INTEGRITY in enabled_checks:
             file_integrity_result = self._check_file_integrity(record_list)
-            checks["file_integrity"] = result_to_dict(file_integrity_result)
+            checks["file_integrity"] = to_dict(file_integrity_result)
             passed, failed, warnings = update_counts(
                 file_integrity_result.status, passed, failed, warnings
             )
@@ -98,7 +95,7 @@ class BronzeDQAnalyzer:
         # Schema snapshot
         if BronzeDQCheckType.SCHEMA_SNAPSHOT in enabled_checks:
             schema_snapshot_result = self._check_schema_snapshot(record_list)
-            checks["schema_snapshot"] = result_to_dict(schema_snapshot_result)
+            checks["schema_snapshot"] = to_dict(schema_snapshot_result)
             passed, failed, warnings = update_counts(
                 schema_snapshot_result.status, passed, failed, warnings
             )
@@ -113,7 +110,7 @@ class BronzeDQAnalyzer:
         # Encoding validation
         if BronzeDQCheckType.ENCODING_VALIDATION in enabled_checks:
             encoding_result = self._check_encoding(record_list)
-            checks["encoding_validation"] = result_to_dict(encoding_result)
+            checks["encoding_validation"] = to_dict(encoding_result)
             passed, failed, warnings = update_counts(
                 encoding_result.status, passed, failed, warnings
             )

--- a/src/bioetl/application/services/dq/gold_analyzer.py
+++ b/src/bioetl/application/services/dq/gold_analyzer.py
@@ -20,11 +20,8 @@ from typing import Any
 import polars as pl
 import pyarrow as pa
 
-from bioetl.application.services.dq.utils import (
-    build_summary,
-    result_to_dict,
-    update_counts,
-)
+from bioetl.application.services.dq.utils import build_summary, update_counts
+from bioetl.domain.services.dq_serializer import to_dict
 from bioetl.domain.ports import GoldDQConfigPort
 from bioetl.domain.value_objects.dq_report import (
     AnomalyDetectionResult,
@@ -92,7 +89,7 @@ class GoldDQAnalyzer:
 
         if GoldDQCheckType.RECORD_COUNT in enabled_checks:
             record_count_result = self._check_record_count(df, baseline_stats)
-            checks["record_count"] = result_to_dict(record_count_result)
+            checks["record_count"] = to_dict(record_count_result)
             passed, failed, warnings = update_counts(
                 record_count_result.status, passed, failed, warnings
             )
@@ -101,14 +98,14 @@ class GoldDQAnalyzer:
             completeness_result = self._check_completeness(
                 df, required_fields, completeness_threshold
             )
-            checks["completeness"] = result_to_dict(completeness_result)
+            checks["completeness"] = to_dict(completeness_result)
             passed, failed, warnings = update_counts(
                 completeness_result.status, passed, failed, warnings
             )
 
         if GoldDQCheckType.BUSINESS_RULES in enabled_checks:
             business_rules_result = self._check_business_rules(df, business_rules)
-            checks["business_rules"] = result_to_dict(business_rules_result)
+            checks["business_rules"] = to_dict(business_rules_result)
             passed, failed, warnings = update_counts(
                 business_rules_result.status, passed, failed, warnings
             )
@@ -117,28 +114,28 @@ class GoldDQAnalyzer:
             ref_integrity_result = self._check_referential_integrity(
                 df, reference_tables
             )
-            checks["referential_integrity"] = result_to_dict(ref_integrity_result)
+            checks["referential_integrity"] = to_dict(ref_integrity_result)
             passed, failed, warnings = update_counts(
                 ref_integrity_result.status, passed, failed, warnings
             )
 
         if GoldDQCheckType.STATISTICAL_PROFILE in enabled_checks:
             stat_profile_result = self._check_statistical_profile(df, baseline_stats)
-            checks["statistical_profile"] = result_to_dict(stat_profile_result)
+            checks["statistical_profile"] = to_dict(stat_profile_result)
             passed, failed, warnings = update_counts(
                 stat_profile_result.status, passed, failed, warnings
             )
 
         if GoldDQCheckType.ANOMALY_DETECTION in enabled_checks:
             anomaly_result = self._check_anomaly_detection(df, baseline_stats)
-            checks["anomaly_detection"] = result_to_dict(anomaly_result)
+            checks["anomaly_detection"] = to_dict(anomaly_result)
             passed, failed, warnings = update_counts(
                 anomaly_result.status, passed, failed, warnings
             )
 
         if GoldDQCheckType.SCD_INTEGRITY in enabled_checks:
             scd_result = self._check_scd_integrity(df, scd_config)
-            checks["scd_integrity"] = result_to_dict(scd_result)
+            checks["scd_integrity"] = to_dict(scd_result)
             passed, failed, warnings = update_counts(
                 scd_result.status, passed, failed, warnings
             )

--- a/src/bioetl/application/services/dq/silver_analyzer.py
+++ b/src/bioetl/application/services/dq/silver_analyzer.py
@@ -21,11 +21,8 @@ from typing import Any
 import polars as pl
 import pyarrow as pa
 
-from bioetl.application.services.dq.utils import (
-    build_summary,
-    result_to_dict,
-    update_counts,
-)
+from bioetl.application.services.dq.utils import build_summary, update_counts
+from bioetl.domain.services.dq_serializer import to_dict
 from bioetl.domain.ports import SilverDQConfigPort
 from bioetl.domain.value_objects.dq_report import (
     CategoricalDistribution,
@@ -83,7 +80,7 @@ class SilverDQAnalyzer:
             record_count_result = self._check_record_count(
                 df, input_record_count, quarantined_count
             )
-            checks["record_count"] = result_to_dict(record_count_result)
+            checks["record_count"] = to_dict(record_count_result)
             passed, failed, warnings = update_counts(
                 record_count_result.status, passed, failed, warnings
             )
@@ -91,7 +88,7 @@ class SilverDQAnalyzer:
         if SilverDQCheckType.NULL_RATE in enabled_checks:
             null_results, overall_rate = self._check_null_rates(df)
             checks["null_rate"] = {
-                "columns": {r.column_name: result_to_dict(r) for r in null_results},
+                "columns": {r.column_name: to_dict(r) for r in null_results},
                 "overall_null_rate": overall_rate,
                 "status": DQCheckStatus.PASS.value,
             }
@@ -99,14 +96,14 @@ class SilverDQAnalyzer:
 
         if SilverDQCheckType.UNIQUENESS in enabled_checks:
             uniqueness_result = self._check_uniqueness(df, primary_keys)
-            checks["uniqueness"] = result_to_dict(uniqueness_result)
+            checks["uniqueness"] = to_dict(uniqueness_result)
             passed, failed, warnings = update_counts(
                 uniqueness_result.status, passed, failed, warnings
             )
 
         if SilverDQCheckType.TYPE_CONFORMANCE in enabled_checks:
             conformance_result = self._check_type_conformance(df)
-            checks["type_conformance"] = result_to_dict(conformance_result)
+            checks["type_conformance"] = to_dict(conformance_result)
             passed, failed, warnings = update_counts(
                 conformance_result.status, passed, failed, warnings
             )
@@ -120,7 +117,7 @@ class SilverDQAnalyzer:
 
         if SilverDQCheckType.SCHEMA_DRIFT in enabled_checks:
             drift_result = self._check_schema_drift(df, previous_schema)
-            checks["schema_drift"] = result_to_dict(drift_result)
+            checks["schema_drift"] = to_dict(drift_result)
             passed, failed, warnings = update_counts(
                 drift_result.status, passed, failed, warnings
             )
@@ -129,14 +126,14 @@ class SilverDQAnalyzer:
             dedup_result = self._check_deduplication(
                 df, primary_keys, input_record_count or len(df)
             )
-            checks["deduplication_stats"] = result_to_dict(dedup_result)
+            checks["deduplication_stats"] = to_dict(dedup_result)
             passed, failed, warnings = update_counts(
                 dedup_result.status, passed, failed, warnings
             )
 
         if SilverDQCheckType.CONTENT_HASH_INTEGRITY in enabled_checks:
             hash_result = self._check_content_hash_integrity(df)
-            checks["content_hash_integrity"] = result_to_dict(hash_result)
+            checks["content_hash_integrity"] = to_dict(hash_result)
             passed, failed, warnings = update_counts(
                 hash_result.status, passed, failed, warnings
             )
@@ -564,7 +561,7 @@ class SilverDQAnalyzer:
         }
 
         for col, numeric_dist in result.numeric_columns.items():
-            output["numeric_columns"][col] = result_to_dict(numeric_dist)
+            output["numeric_columns"][col] = to_dict(numeric_dist)
 
         for col, categorical_dist in result.categorical_columns.items():
             output["categorical_columns"][col] = {

--- a/src/bioetl/application/services/dq/utils.py
+++ b/src/bioetl/application/services/dq/utils.py
@@ -6,9 +6,6 @@ Extracted to reduce code duplication per refactoring analysis 2026-01-25.
 
 from __future__ import annotations
 
-from datetime import datetime
-from typing import Any
-
 from bioetl.domain.value_objects.dq_report import (
     DQCheckStatus,
     DQReportStatus,
@@ -38,48 +35,6 @@ def update_counts(
     if status == DQCheckStatus.FAIL:
         return passed, failed + 1, warnings
     return passed, failed, warnings + 1
-
-
-def convert_value(value: Any) -> Any:
-    """Convert a value to serializable format.
-
-    Handles nested dataclasses, enums, datetimes, and collections.
-
-    Args:
-        value: Any value to convert.
-
-    Returns:
-        JSON-serializable value.
-    """
-    if hasattr(value, "value"):  # Enum
-        return value.value
-    if hasattr(value, "__dataclass_fields__"):
-        return result_to_dict(value)
-    if isinstance(value, datetime):
-        return value.isoformat()
-    if isinstance(value, (list, tuple)):
-        return [convert_value(v) for v in value]
-    if isinstance(value, dict):
-        return {k: convert_value(v) for k, v in value.items()}
-    return value
-
-
-def result_to_dict(result: Any) -> dict[str, Any]:
-    """Convert dataclass result to dict for serialization.
-
-    Args:
-        result: Dataclass result object.
-
-    Returns:
-        Dictionary representation suitable for JSON serialization.
-    """
-    if hasattr(result, "__dataclass_fields__"):
-        return {
-            field: convert_value(getattr(result, field))
-            for field in result.__dataclass_fields__
-            if not field.startswith("_")
-        }
-    return {"value": result}
 
 
 def build_summary(
@@ -118,7 +73,5 @@ def build_summary(
 
 __all__ = [
     "build_summary",
-    "convert_value",
-    "result_to_dict",
     "update_counts",
 ]

--- a/src/bioetl/domain/services/dq_serializer.py
+++ b/src/bioetl/domain/services/dq_serializer.py
@@ -6,7 +6,7 @@ This is a domain service that handles format conversion without I/O.
 
 from __future__ import annotations
 
-from dataclasses import asdict, is_dataclass
+from dataclasses import fields, is_dataclass
 from datetime import datetime
 from enum import Enum
 from typing import Any, cast
@@ -19,6 +19,42 @@ from bioetl.domain.value_objects.dq_report import (
     GoldDQReport,
     SilverDQReport,
 )
+
+
+def to_dict(obj: Any) -> dict[str, Any]:
+    """Convert an object to a dictionary suitable for serialization.
+
+    Handles dataclasses, enums, datetimes, and collection types.
+
+    Args:
+        obj: Object to convert.
+
+    Returns:
+        Dictionary representation of the object.
+    """
+    if is_dataclass(obj) and not isinstance(obj, type):
+        return cast(dict[str, Any], _serialize_value(obj))
+    if isinstance(obj, dict):
+        return cast(dict[str, Any], _serialize_value(obj))
+    return {"value": _serialize_value(obj)}
+
+
+def _serialize_value(value: Any) -> Any:
+    """Serialize a value with dataclass/enum/datetime/collection support."""
+    if is_dataclass(value) and not isinstance(value, type):
+        return {
+            field.name: _serialize_value(getattr(value, field.name))
+            for field in fields(value)
+        }
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {key: _serialize_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_serialize_value(item) for item in value]
+    return value
 
 
 class DQReportSerializer:
@@ -61,11 +97,11 @@ class DQReportSerializer:
         Returns:
             Dictionary representation of report.
         """
-        return cast(dict[str, Any], self._dataclass_to_dict(report))
+        return to_dict(report)
 
     def _to_json(self, report: BronzeDQReport | SilverDQReport | GoldDQReport) -> str:
         """Serialize to JSON with pretty formatting."""
-        data = self._dataclass_to_dict(report)
+        data = to_dict(report)
         return orjson.dumps(
             data,
             option=orjson.OPT_INDENT_2 | orjson.OPT_SORT_KEYS,
@@ -77,7 +113,7 @@ class DQReportSerializer:
         Uses simple YAML serialization without external dependencies.
         For production use, consider using ruamel.yaml or PyYAML.
         """
-        data = self._dataclass_to_dict(report)
+        data = to_dict(report)
         return self._dict_to_yaml(data)
 
     def _to_html(self, report: BronzeDQReport | SilverDQReport | GoldDQReport) -> str:
@@ -85,30 +121,8 @@ class DQReportSerializer:
 
         Generates a simple HTML report with styling.
         """
-        data = self._dataclass_to_dict(report)
+        data = to_dict(report)
         return self._generate_html(data, report)
-
-    def _dataclass_to_dict(self, obj: Any) -> Any:
-        """Recursively convert dataclass to dict with enum/datetime handling."""
-        if is_dataclass(obj) and not isinstance(obj, type):
-            return {k: self._dataclass_to_dict(v) for k, v in asdict(obj).items()}
-        return self._convert_value(obj)
-
-    def _convert_value(self, obj: Any) -> Any:
-        """Convert a single value to serializable format."""
-        if isinstance(obj, Enum):
-            return obj.value
-        if isinstance(obj, datetime):
-            return obj.isoformat()
-        return self._convert_collection(obj)
-
-    def _convert_collection(self, obj: Any) -> Any:
-        """Convert collection types to serializable format."""
-        if isinstance(obj, (tuple, list)):
-            return [self._dataclass_to_dict(item) for item in obj]
-        if isinstance(obj, dict):
-            return {k: self._dataclass_to_dict(v) for k, v in obj.items()}
-        return obj
 
     def _dict_to_yaml(self, data: dict[str, Any], indent: int = 0) -> str:
         """Simple YAML serialization without external dependencies."""

--- a/tests/unit/domain/services/test_dq_serializer.py
+++ b/tests/unit/domain/services/test_dq_serializer.py
@@ -1,0 +1,61 @@
+"""Тесты сериализации DQ для доменного помощника."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+
+from bioetl.domain.services.dq_serializer import to_dict
+
+
+class SampleStatus(Enum):
+    """Тестовое перечисление для проверки Enum."""
+
+    OK = "ok"
+
+
+@dataclass
+class NestedSample:
+    """Вложенная датакласс-модель для проверки рекурсии."""
+
+    value: int
+    status: SampleStatus
+
+
+@dataclass
+class ContainerSample:
+    """Контейнер для проверки коллекций и словарей."""
+
+    created_at: datetime
+    nested: NestedSample
+    items: list[NestedSample]
+    mapping: dict[str, NestedSample]
+
+
+def test_to_dict_serializes_dataclass_with_nested_values() -> None:
+    """Проверяет рекурсивную сериализацию dataclass/Enum/datetime."""
+    timestamp = datetime(2024, 1, 1, 12, 30, tzinfo=timezone.utc)
+    nested = NestedSample(value=1, status=SampleStatus.OK)
+    container = ContainerSample(
+        created_at=timestamp,
+        nested=nested,
+        items=[nested],
+        mapping={"first": nested},
+    )
+
+    result = to_dict(container)
+
+    assert result == {
+        "created_at": "2024-01-01T12:30:00+00:00",
+        "nested": {"value": 1, "status": "ok"},
+        "items": [{"value": 1, "status": "ok"}],
+        "mapping": {"first": {"value": 1, "status": "ok"}},
+    }
+
+
+def test_to_dict_wraps_non_dataclass_value() -> None:
+    """Проверяет оборачивание простого значения в словарь."""
+    result = to_dict("sample")
+
+    assert result == {"value": "sample"}


### PR DESCRIPTION
### Motivation
- Свести дублирование сериализации DQ-результатов в единый доменный API и обеспечить корректную обработку `dataclass`/`Enum`/`datetime`/коллекций. 
- Оставить в уровне `application` только функции, специфичные для аналитики (счётчики и сбор summary), а общую сериализацию перенести в `domain` (application → domain разрешён). 

### Description
- Добавлен публичный доменный helper `to_dict(obj: Any) -> dict[str, Any]` с рекурсивной поддержкой `dataclass`/`Enum`/`datetime`/`list`/`tuple`/`dict` в `src/bioetl/domain/services/dq_serializer.py` и использован внутри `DQReportSerializer` via `to_dict`.
- Удалены дублирующие helpers `convert_value`/`result_to_dict` из `src/bioetl/application/services/dq/utils.py`, этот модуль теперь содержит только аналитические функции `update_counts` и `build_summary` (и соответствующее `__all__`).
- Все DQ-анализаторы обновлены для использования доменного helper-а: импорт и вызовы в `src/bioetl/application/services/dq/bronze_analyzer.py`, `src/bioetl/application/services/dq/silver_analyzer.py`, и `src/bioetl/application/services/dq/gold_analyzer.py` заменены на `from bioetl.domain.services.dq_serializer import to_dict` и `to_dict(...)` вместо `result_to_dict(...)`.
- Добавлены unit-тесты сериализации в `tests/unit/domain/services/test_dq_serializer.py` для проверки сериализации dataclass/Enum/datetime/коллекций и обёртки простых значений.

### Testing
- Запущен `pytest tests/unit/domain/services/test_dq_serializer.py`, результат: `2 passed`.
- Локальный grep/замены проверены — вызовы `result_to_dict` в приложении обновлены на `to_dict` и дубли удалены из `application`-утилит.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979213638d88324a154dceb2d4fa14d)