### PR TITLE
Unify Publication Field Names

### DIFF
--- a/src/bioetl/application/pipelines/chembl/publication_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/publication_transformer.py
@@ -59,9 +59,9 @@ _CORE_METADATA = FieldGroup(
 _JOURNAL_INFO = FieldGroup(
     name="journal_info",
     fields=(
+        # Rename journal_full_title -> journal for unification
+        FieldSpec("journal_full_title", target="journal"),
         *simple_fields(
-            "journal",
-            "journal_full_title",
             "volume",
             "issue",
             "first_page",

--- a/src/bioetl/application/pipelines/crossref/transformer.py
+++ b/src/bioetl/application/pipelines/crossref/transformer.py
@@ -184,7 +184,6 @@ class CrossRefPublicationTransformer(BasePublicationTransformer):
             # NEW: Additional CrossRef fields
             "alternative_id": rec.get("alternative-id", []) or [],
             "short_container_title": rec.get("short-container-title", []) or [],
-            "published": published_date,
             **content_domain,
             **issn_by_type,
             # NEW: Author and reference data (per PROMPT 3 enhancement)

--- a/src/bioetl/application/pipelines/pubmed/transformer.py
+++ b/src/bioetl/application/pipelines/pubmed/transformer.py
@@ -512,7 +512,6 @@ class PubMedPublicationTransformer(BasePublicationTransformer):
 
         return {
             "journal": journal_name,
-            "journal_title": journal_name,  # Alias for Gold schema
             "journal_abbrev": journal_abbrev,
             "journal_iso_abbrev": journal_abbrev,  # Alias for Gold schema
             "journal_issn_type": issn_type,
@@ -520,7 +519,6 @@ class PubMedPublicationTransformer(BasePublicationTransformer):
             "volume": get_text(journal_issue.find("Volume")) if journal_issue else None,
             "issue": get_text(journal_issue.find("Issue")) if journal_issue else None,
             "pages": pages,
-            "medline_pgn": pages,  # Alias for Gold schema
             "first_page": first_page,
             "last_page": last_page,
         }

--- a/src/bioetl/domain/schemas/chembl/publication.py
+++ b/src/bioetl/domain/schemas/chembl/publication.py
@@ -79,9 +79,7 @@ class ChemblPublicationSchema(PublicationBaseSchema):
     )
 
     # === Provider-specific Journal Fields ===
-    journal_full_title: Series[str] = pa.Field(
-        nullable=True, description="Full journal title."
-    )
+    # journal field inherited from PublicationBaseSchema (renamed from journal_full_title)
     volume: Series[str] = pa.Field(nullable=True, description="Volume.")
     issue: Series[str] = pa.Field(nullable=True, description="Issue.")
     first_page: Series[str] = pa.Field(nullable=True, description="First page.")

--- a/src/bioetl/domain/schemas/crossref/publication.py
+++ b/src/bioetl/domain/schemas/crossref/publication.py
@@ -94,12 +94,6 @@ class PublicationEnrichedSchema(PublicationBaseSchema):
         description="Alternative IDs (publisher-specific, e.g., PII)",
     )
 
-    # === Canonical Publication Date ===
-    published: Series[str] = pa.Field(
-        nullable=True,
-        description="Canonical publication date (YYYY-MM-DD)",
-    )
-
     # === Short Container Title ===
     short_container_title: Series[object] = pa.Field(
         nullable=True,

--- a/src/bioetl/domain/schemas/pubmed/publication.py
+++ b/src/bioetl/domain/schemas/pubmed/publication.py
@@ -125,9 +125,7 @@ class PubMedPublicationSchema(PublicationBaseSchema):
         )
 
     # === Journal Information (PubMed-specific) ===
-    journal_title: Series[str] = pa.Field(
-        nullable=True, description="Full journal name"
-    )
+    # journal field inherited from PublicationBaseSchema (renamed from journal_title)
     journal_iso_abbrev: Series[str] = pa.Field(
         nullable=True, description="ISO journal abbreviation"
     )
@@ -156,9 +154,13 @@ class PubMedPublicationSchema(PublicationBaseSchema):
     )
 
     # === Publication Details (override year for check) ===
-    medline_pgn: Series[str] = pa.Field(
-        nullable=True, description="Page numbers (MEDLINE format)"
+    volume: Series[str] = pa.Field(nullable=True, description="Volume")
+    issue: Series[str] = pa.Field(nullable=True, description="Issue")
+    pages: Series[str] = pa.Field(
+        nullable=True, description="Page numbers (renamed from medline_pgn)"
     )
+    first_page: Series[str] = pa.Field(nullable=True, description="First page")
+    last_page: Series[str] = pa.Field(nullable=True, description="Last page")
 
     @pa.check("year", name="year_range")
     def _check_year(cls, series: Series[int]) -> Series[bool]:

--- a/tests/unit/application/pipelines/test_chembl_transformers.py
+++ b/tests/unit/application/pipelines/test_chembl_transformers.py
@@ -248,7 +248,7 @@ class TestPublicationTransformer:
         result = await transformer.transform(mock_context, record, index=0)
 
         assert result is not None
-        assert result["journal_full_title"] == "Full Journal Name"
+        assert result["journal"] == "Full Journal Name"
         assert result["src_id"] == 1
         assert result["_source"] == "chembl"  # System field
 


### PR DESCRIPTION
Renamed legacy fields to standard names in Silver schemas and transformers:
- ChEMBL: `journal_full_title` -> `journal`
- PubMed: Removed `journal_title` (use `journal`) and `medline_pgn` (use `pages`)
- CrossRef: Removed `published` (use `publication_date`)
- SemanticScholar: Verified `journal` fallback to `venue`.

Ensured schemas and transformers are aligned with `PublicationBaseSchema` standards.

---
*PR created automatically by Jules for task [17414248763488505682](https://jules.google.com/task/17414248763488505682) started by @SatoryKono*