### PR TITLE
docs: Update ADR references in decorator module docstrings

### DIFF
--- a/src/bioetl/infrastructure/adapters/decorators/circuit_breaker.py
+++ b/src/bioetl/infrastructure/adapters/decorators/circuit_breaker.py
@@ -1,7 +1,7 @@
 """Circuit Breaker Data Source Decorator.
 
 Implements the Decorator Pattern for DataSourcePort to add circuit breaker protection.
-Separates circuit breaker concerns from the core adapter logic per ADR-xxx.
+Separates circuit breaker concerns from the core adapter logic per ADR-007.
 
 This decorator wraps any DataSourcePort implementation and adds:
 - Circuit breaker state management (CLOSED -> OPEN -> HALF_OPEN -> CLOSED)

--- a/src/bioetl/infrastructure/adapters/decorators/retry.py
+++ b/src/bioetl/infrastructure/adapters/decorators/retry.py
@@ -1,7 +1,7 @@
 """Retrying Data Source Decorator.
 
 Implements the Decorator Pattern for DataSourcePort to add retry logic.
-Separates retry concerns from the core adapter logic per ADR-xxx.
+Separates retry concerns from the core adapter logic per ADR-016.
 
 This decorator wraps any DataSourcePort implementation and adds:
 - Configurable retry attempts with exponential backoff


### PR DESCRIPTION
## Summary
Updated Architecture Decision Record (ADR) references in the decorator module docstrings to point to the specific ADRs that justify the design patterns used.

## Changes
- Updated circuit breaker decorator docstring to reference ADR-007 (replacing placeholder ADR-xxx)
- Updated retry decorator docstring to reference ADR-016 (replacing placeholder ADR-xxx)

## Details
These changes complete the documentation of architectural decisions by linking the decorator implementations to their corresponding ADRs:
- **ADR-007**: Justifies the use of the Decorator Pattern for circuit breaker concerns separation
- **ADR-016**: Justifies the use of the Decorator Pattern for retry logic concerns separation

This improves code maintainability by providing clear traceability between implementation and architectural decisions.

https://claude.ai/code/session_018E9BLGzEtiUt9mMgeuYwpV