### PR TITLE
Support dry-run mode and resumable enrichment in composite pipeline

### DIFF
--- a/src/bioetl/application/composite/runner.py
+++ b/src/bioetl/application/composite/runner.py
@@ -470,23 +470,35 @@ class CompositePipelineRunner:
 
         # Step 5: Run enrichers (fan-out) with FSM state management
         if enrichers_to_run:
-            # Validate and transition to ENRICHING state before starting enrichments
             enricher_names = [e.pipeline for e in enrichers_to_run]
-            previous_state = state.state
-            self._fsm.validate_fsm_transition(
-                previous_state, CompositePipelineState.ENRICHING
-            )
-            state = state.with_state(CompositePipelineState.ENRICHING)
-            await self._checkpoint_manager.save(state)
 
-            # Log FSM transition to ENRICHING
-            self._fsm.log_fsm_transition(
-                from_state=previous_state,
-                to_state=CompositePipelineState.ENRICHING,
-                stage="enrichment_start",
-                enrichers=enricher_names,
-                count=len(enrichers_to_run),
-            )
+            # Guard: skip transition if already in ENRICHING state (resume path)
+            if state.state != CompositePipelineState.ENRICHING:
+                # Validate and transition to ENRICHING state before starting enrichments
+                previous_state = state.state
+                self._fsm.validate_fsm_transition(
+                    previous_state, CompositePipelineState.ENRICHING
+                )
+                state = state.with_state(CompositePipelineState.ENRICHING)
+                await self._checkpoint_manager.save(state)
+
+                # Log FSM transition to ENRICHING
+                self._fsm.log_fsm_transition(
+                    from_state=previous_state,
+                    to_state=CompositePipelineState.ENRICHING,
+                    stage="enrichment_start",
+                    enrichers=enricher_names,
+                    count=len(enrichers_to_run),
+                )
+            else:
+                # Already in ENRICHING state (resume from partial enrichment)
+                self._logger.info(
+                    "Already in ENRICHING state, continuing enrichment",
+                    composite=self._config.name,
+                    run_id=self._run_id_str,
+                    enrichers=enricher_names,
+                    count=len(enrichers_to_run),
+                )
             # Log phase event for enrichment start
             self._logger.info(
                 PipelineEvent.phase_started("enrichment"),
@@ -749,8 +761,14 @@ class CompositePipelineRunner:
                 raise
         else:
             # Dry run mode - skip merge, transition directly to COMPLETED
+            # ENRICHMENT_COMPLETED -> COMPLETED is a valid FSM transition for dry_run
+            previous_state = state.state
+            self._fsm.validate_fsm_transition(
+                previous_state, CompositePipelineState.COMPLETED
+            )
+            state = state.with_state(CompositePipelineState.COMPLETED)
             self._fsm.log_fsm_transition(
-                from_state=state.state,
+                from_state=previous_state,
                 to_state=CompositePipelineState.COMPLETED,
                 stage="dry_run_skip_merge",
                 reason="dry_run_mode",

--- a/src/bioetl/domain/composite/state.py
+++ b/src/bioetl/domain/composite/state.py
@@ -11,6 +11,9 @@ ENRICHMENT_COMPLETED -> MERGING -> COMPLETED. Any active state can -> FAILED.
 Note: Dependencies are optional. If no dependencies, SEED_COMPLETED transitions
 directly to ENRICHING (or DEPENDENCIES_RUNNING which immediately transitions to
 DEPENDENCIES_COMPLETED).
+
+Note: ENRICHMENT_COMPLETED can also transition directly to COMPLETED for dry_run
+mode, where the merge stage is intentionally skipped.
 """
 
 from __future__ import annotations
@@ -143,7 +146,7 @@ _STATE_TRANSITIONS: Mapping[str, frozenset[str]] = {
     "dependencies_running": frozenset({"dependencies_completed", "failed"}),
     "dependencies_completed": frozenset({"enriching"}),
     "enriching": frozenset({"enrichment_completed", "failed"}),
-    "enrichment_completed": frozenset({"merging"}),
+    "enrichment_completed": frozenset({"merging", "completed"}),
     "merging": frozenset({"completed", "failed"}),
     "completed": frozenset(),  # Terminal state
     "failed": frozenset(),  # Terminal state

--- a/tests/unit/domain/composite/test_state.py
+++ b/tests/unit/domain/composite/test_state.py
@@ -168,6 +168,10 @@ class TestValidTransitions:
                 CompositePipelineState.ENRICHMENT_COMPLETED,
                 CompositePipelineState.MERGING,
             ),
+            (
+                CompositePipelineState.ENRICHMENT_COMPLETED,
+                CompositePipelineState.COMPLETED,
+            ),
             (CompositePipelineState.MERGING, CompositePipelineState.COMPLETED),
             (CompositePipelineState.MERGING, CompositePipelineState.FAILED),
         ],
@@ -342,6 +346,13 @@ class TestAllowedTransitions:
             {CompositePipelineState.ENRICHMENT_COMPLETED, CompositePipelineState.FAILED}
         )
 
+    def test_enrichment_completed_allowed_transitions(self):
+        """ENRICHMENT_COMPLETED should allow MERGING or COMPLETED (dry_run)."""
+        allowed = CompositePipelineState.ENRICHMENT_COMPLETED.allowed_transitions
+        assert allowed == frozenset(
+            {CompositePipelineState.MERGING, CompositePipelineState.COMPLETED}
+        )
+
     def test_merging_allowed_transitions(self):
         """MERGING should allow COMPLETED or FAILED."""
         allowed = CompositePipelineState.MERGING.allowed_transitions
@@ -489,6 +500,29 @@ class TestHappyPathScenario:
 
         assert state.is_terminal is True
         assert state.is_success is False
+
+    def test_dry_run_path_skips_merge(self):
+        """Dry run should transition directly from ENRICHMENT_COMPLETED to COMPLETED."""
+        state = CompositePipelineState.NOT_STARTED
+
+        # Seed phase
+        state.validate_transition(CompositePipelineState.SEED_RUNNING)
+        state = CompositePipelineState.SEED_RUNNING
+        state.validate_transition(CompositePipelineState.SEED_COMPLETED)
+        state = CompositePipelineState.SEED_COMPLETED
+
+        # Enrichment phase
+        state.validate_transition(CompositePipelineState.ENRICHING)
+        state = CompositePipelineState.ENRICHING
+        state.validate_transition(CompositePipelineState.ENRICHMENT_COMPLETED)
+        state = CompositePipelineState.ENRICHMENT_COMPLETED
+
+        # Dry run: skip merge, go directly to COMPLETED
+        state.validate_transition(CompositePipelineState.COMPLETED)
+        state = CompositePipelineState.COMPLETED
+
+        assert state.is_terminal is True
+        assert state.is_success is True
 
 
 class TestResumableStates:


### PR DESCRIPTION
## Summary
This PR enhances the composite pipeline FSM to support two important scenarios:
1. **Dry-run mode**: Allow skipping the merge stage and transitioning directly from ENRICHMENT_COMPLETED to COMPLETED
2. **Resumable enrichment**: Handle resumption from partial enrichment without re-validating the ENRICHING state transition

## Key Changes

- **FSM State Transitions**: Updated `ENRICHMENT_COMPLETED` state to allow transitions to both `MERGING` (normal path) and `COMPLETED` (dry-run path)

- **Enrichment Resume Logic**: Added a guard condition in `_run_with_lock()` to skip FSM validation and state transition when already in the `ENRICHING` state, enabling graceful resumption from partial enrichment failures

- **Dry-run Merge Handling**: Modified `_execute_merge_stage()` to properly validate and transition to `COMPLETED` state when skipping merge in dry-run mode, rather than logging an unvalidated transition

- **Documentation**: Updated state machine documentation to clarify that `ENRICHMENT_COMPLETED` can transition directly to `COMPLETED` for dry-run scenarios

- **Test Coverage**: Added comprehensive tests for:
  - Valid transition from `ENRICHMENT_COMPLETED` to `COMPLETED`
  - Allowed transitions for `ENRICHMENT_COMPLETED` state
  - Complete dry-run path validation

## Implementation Details

The enrichment resume path uses a conditional guard (`if state.state != CompositePipelineState.ENRICHING`) to detect when resuming from a checkpoint, avoiding duplicate FSM validation while still logging the resumption event for observability.

The dry-run path now properly validates the state transition before updating state, maintaining FSM integrity across all execution paths.

https://claude.ai/code/session_01V7F77wRbfiLR55LHuQ1ruU