### PR TITLE
Add schema inventory CI check for root schemas + medallion generation mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,3 +376,8 @@ check-mermaid: ## Check that vendored mermaid files exist (fails if missing)
 	done; \
 	if [ $$missing -eq 1 ]; then echo "Mermaid vendored assets missing; run 'make vendor-mermaid' locally or add the files to the PR"; exit 1; fi; \
 	echo "Mermaid vendored assets present."
+
+schema-inventory-check: ## CI check: schema roots inventory + medallion generation map
+	@echo "$(BLUE)Running schema inventory check...$(NC)"
+	$(RUN) python scripts/check_schema_inventory.py --fail-on-orphans --report-json reports/schema_inventory_report.json
+	@echo "$(GREEN)Schema inventory check passed!$(NC)"

--- a/configs/schema_roots.yaml
+++ b/configs/schema_roots.yaml
@@ -1,0 +1,15 @@
+root_schema_globs:
+  - src/bioetl/infrastructure/schemas/**/*.py
+  - src/bioetl/domain/**/*.py
+  - src/bioetl/application/**/*.py
+
+usage_globs:
+  - src/**/*.py
+  - tests/**/*.py
+
+pipeline_config_glob: configs/pipelines/**/*.yaml
+
+medallion_generators:
+  bronze_template: configs/data_schema/{provider}/{entity}.yaml
+  silver_template: src/bioetl/infrastructure/schemas/silver.py#{provider}_{entity}
+  gold_template: src/bioetl/domain/schemas/{provider}/{entity}.py

--- a/docs/05-operations/verification/schema-inventory-ci.md
+++ b/docs/05-operations/verification/schema-inventory-ci.md
@@ -1,0 +1,52 @@
+# Schema Inventory CI Check
+
+## Root schema paths
+
+Inventory and orphan checks are executed on these roots (replacing legacy `application/transformers/schemas` scope):
+
+- `src/bioetl/infrastructure/schemas/**`
+- `src/bioetl/domain/**` (entities/types/exceptions and other model containers)
+- `src/bioetl/application/**` (DTO and typed service structures)
+
+Source of truth: `configs/schema_roots.yaml`.
+
+## Model type inventory
+
+`python scripts/check_schema_inventory.py` builds inventory by model kind:
+
+- `BaseModel`
+- `dataclass`
+- `TypedDict`
+- `Protocol`
+- Pandera models (`DataFrameModel` descendants)
+
+## Orphan schema detection (including tests)
+
+Orphan detection scans usages in:
+
+- `src/**/*.py`
+- `tests/**/*.py`
+
+This explicitly treats references in `tests/**` as valid usage.
+
+## Medallion schema generation block
+
+The check also emits `medallion_schema_generation` entries bound to real pipeline configs under:
+
+- `configs/pipelines/**/*.yaml`
+
+Each entry links pipeline config to generator targets for Bronze/Silver/Gold schema surfaces.
+
+## CI check script
+
+- Strict CI mode:
+  - `make schema-inventory-check`
+  - runs: `python scripts/check_schema_inventory.py --fail-on-orphans --report-json reports/schema_inventory_report.json`
+- Local audit mode (non-blocking):
+  - `python scripts/check_schema_inventory.py --report-json reports/schema_inventory_report.json`
+
+Output artifact:
+
+- `reports/schema_inventory_report.json`
+
+This closes the scope as: **root schemas + generators + CI check script**.

--- a/reports/schema_inventory_report.json
+++ b/reports/schema_inventory_report.json
@@ -1,0 +1,6137 @@
+{
+  "root_schema_globs": [
+    "src/bioetl/infrastructure/schemas/**/*.py",
+    "src/bioetl/domain/**/*.py",
+    "src/bioetl/application/**/*.py"
+  ],
+  "inventory": {
+    "BaseModel": [
+      {
+        "name": "ActivityRecord",
+        "file": "src/bioetl/domain/entities/chembl.py",
+        "line": 16,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "src/bioetl/infrastructure/adapters/chembl/client.py",
+          "tests/unit/infrastructure/adapters/chembl/test_chembl_client_coverage.py"
+        ]
+      },
+      {
+        "name": "AssayRecord",
+        "file": "src/bioetl/domain/entities/chembl.py",
+        "line": 187,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "src/bioetl/infrastructure/adapters/chembl/client.py"
+        ]
+      },
+      {
+        "name": "MoleculeRecord",
+        "file": "src/bioetl/domain/entities/chembl.py",
+        "line": 294,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "src/bioetl/infrastructure/adapters/chembl/client.py"
+        ]
+      },
+      {
+        "name": "TargetRecord",
+        "file": "src/bioetl/domain/entities/chembl.py",
+        "line": 444,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "src/bioetl/infrastructure/adapters/chembl/client.py"
+        ]
+      },
+      {
+        "name": "ChemblPublicationRecord",
+        "file": "src/bioetl/domain/entities/chembl.py",
+        "line": 511,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "src/bioetl/infrastructure/adapters/chembl/__init__.py",
+          "src/bioetl/infrastructure/adapters/chembl/client.py",
+          "src/bioetl/infrastructure/adapters/chembl/models.py"
+        ]
+      },
+      {
+        "name": "ChemblPublicationTermRecord",
+        "file": "src/bioetl/domain/entities/chembl.py",
+        "line": 562,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/entities/__init__.py"
+        ]
+      },
+      {
+        "name": "CellLineRecord",
+        "file": "src/bioetl/domain/entities/chembl.py",
+        "line": 592,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "src/bioetl/infrastructure/adapters/chembl/client.py"
+        ]
+      },
+      {
+        "name": "TargetComponentRecord",
+        "file": "src/bioetl/domain/entities/chembl.py",
+        "line": 627,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "src/bioetl/infrastructure/adapters/chembl/client.py"
+        ]
+      },
+      {
+        "name": "ProteinClassRecord",
+        "file": "src/bioetl/domain/entities/chembl.py",
+        "line": 663,
+        "usages": [
+          "src/bioetl/infrastructure/adapters/chembl/client.py"
+        ]
+      },
+      {
+        "name": "PublicationRecord",
+        "file": "src/bioetl/domain/entities/crossref.py",
+        "line": 96,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "tests/unit/domain/test_entities.py"
+        ]
+      },
+      {
+        "name": "OpenAlexPublicationRecord",
+        "file": "src/bioetl/domain/entities/openalex.py",
+        "line": 46,
+        "usages": []
+      },
+      {
+        "name": "PubchemMoleculeRecord",
+        "file": "src/bioetl/domain/entities/pubchem.py",
+        "line": 24,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "src/bioetl/infrastructure/adapters/pubchem/__init__.py",
+          "src/bioetl/infrastructure/adapters/pubchem/client.py",
+          "src/bioetl/infrastructure/adapters/pubchem/models.py"
+        ]
+      },
+      {
+        "name": "ArticleRecord",
+        "file": "src/bioetl/domain/entities/pubmed.py",
+        "line": 29,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py"
+        ]
+      },
+      {
+        "name": "GovernanceLineageConfig",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 46,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/pipeline_config.py",
+          "tests/unit/application/services/test_metadata_coordinator.py"
+        ]
+      },
+      {
+        "name": "QualityExpectations",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 85,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/pipeline_config.py",
+          "tests/unit/application/services/test_metadata_coordinator.py"
+        ]
+      },
+      {
+        "name": "GovernanceMetadata",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 103,
+        "usages": [
+          "src/bioetl/domain/ports/metadata_coordinator.py",
+          "src/bioetl/infrastructure/schemas/pipeline_config.py",
+          "tests/unit/application/services/test_metadata_coordinator.py"
+        ]
+      },
+      {
+        "name": "RuntimeMetadata",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 150,
+        "usages": [
+          "src/bioetl/composition/services/metadata_coordinator.py",
+          "src/bioetl/domain/models/__init__.py",
+          "src/bioetl/infrastructure/storage/bronze_writer.py",
+          "src/bioetl/infrastructure/storage/metadata_builder.py",
+          "tests/unit/domain/models/test_metadata_output.py",
+          "tests/unit/infrastructure/storage/test_metadata_integration.py",
+          "tests/unit/infrastructure/storage/test_metadata_writer.py",
+          "tests/unit/infrastructure/storage/test_silver_writer.py"
+        ]
+      },
+      {
+        "name": "PipelineMetadata",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 172,
+        "usages": [
+          "src/bioetl/composition/services/metadata_coordinator.py",
+          "src/bioetl/composition/services/versioning.py",
+          "src/bioetl/domain/models/__init__.py",
+          "src/bioetl/infrastructure/storage/bronze_writer.py",
+          "src/bioetl/infrastructure/storage/metadata_builder.py",
+          "tests/unit/domain/models/test_metadata_output.py",
+          "tests/unit/infrastructure/storage/test_metadata_integration.py",
+          "tests/unit/infrastructure/storage/test_metadata_writer.py",
+          "tests/unit/infrastructure/storage/test_silver_writer.py"
+        ]
+      },
+      {
+        "name": "EnvironmentMetadata",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 194,
+        "usages": [
+          "src/bioetl/composition/services/metadata_coordinator.py",
+          "src/bioetl/domain/models/__init__.py",
+          "src/bioetl/infrastructure/storage/bronze_writer.py",
+          "src/bioetl/infrastructure/storage/metadata_builder.py",
+          "tests/unit/domain/models/test_metadata_output.py",
+          "tests/unit/infrastructure/storage/test_metadata_integration.py",
+          "tests/unit/infrastructure/storage/test_metadata_writer.py",
+          "tests/unit/infrastructure/storage/test_silver_writer.py"
+        ]
+      },
+      {
+        "name": "RateLimitInfo",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 213,
+        "usages": [
+          "src/bioetl/infrastructure/adapters/common/api_request_collector.py",
+          "tests/architecture/test_code_metrics.py"
+        ]
+      },
+      {
+        "name": "APIRequestDetails",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 237,
+        "usages": [
+          "src/bioetl/infrastructure/adapters/common/api_request_collector.py",
+          "tests/architecture/test_code_metrics.py"
+        ]
+      },
+      {
+        "name": "SourceMetadata",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 278,
+        "usages": [
+          "src/bioetl/application/core/batch_executor.py",
+          "src/bioetl/application/core/batch_writer.py",
+          "src/bioetl/application/core/filtered_data_source.py",
+          "src/bioetl/application/core/publication_term_data_source.py",
+          "src/bioetl/application/core/subcellular_fraction_data_source.py",
+          "src/bioetl/composition/factories/storage_adapter.py",
+          "src/bioetl/composition/services/metadata_coordinator.py",
+          "src/bioetl/domain/models/__init__.py",
+          "src/bioetl/domain/ports/metadata_coordinator.py",
+          "src/bioetl/domain/ports/storage.py",
+          "src/bioetl/infrastructure/adapters/chembl/client.py",
+          "src/bioetl/infrastructure/adapters/common/api_request_collector.py",
+          "src/bioetl/infrastructure/adapters/crossref/client.py",
+          "src/bioetl/infrastructure/adapters/openalex/client.py",
+          "src/bioetl/infrastructure/adapters/pubchem/client.py",
+          "src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py",
+          "src/bioetl/infrastructure/adapters/semanticscholar/adapter.py",
+          "src/bioetl/infrastructure/adapters/uniprot/client.py",
+          "src/bioetl/infrastructure/storage/bronze_writer.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/unit/application/services/test_metadata_coordinator.py",
+          "tests/unit/infrastructure/adapters/chembl/test_chembl_client.py",
+          "tests/unit/infrastructure/adapters/common/test_api_request_collector.py",
+          "tests/unit/infrastructure/storage/test_bronze_writer.py",
+          "tests/unit/infrastructure/storage/test_metadata_writer.py"
+        ]
+      },
+      {
+        "name": "FileOutputMetadata",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 327,
+        "usages": [
+          "src/bioetl/composition/services/metadata_coordinator.py",
+          "src/bioetl/domain/models/__init__.py",
+          "src/bioetl/infrastructure/storage/bronze_writer.py",
+          "tests/unit/domain/models/test_metadata_output.py",
+          "tests/unit/infrastructure/storage/test_metadata_writer.py"
+        ]
+      },
+      {
+        "name": "BaseOutputMetadata",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 348,
+        "usages": [
+          "src/bioetl/composition/services/metadata_coordinator.py",
+          "src/bioetl/infrastructure/storage/bronze_writer.py",
+          "src/bioetl/infrastructure/storage/metadata_builder.py",
+          "tests/architecture/test_metadata_output_contract.py",
+          "tests/unit/domain/models/test_metadata_output.py",
+          "tests/unit/infrastructure/storage/test_metadata_integration.py",
+          "tests/unit/infrastructure/storage/test_metadata_writer.py",
+          "tests/unit/infrastructure/storage/test_silver_writer.py"
+        ]
+      },
+      {
+        "name": "BronzeOutputExt",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 404,
+        "usages": [
+          "src/bioetl/composition/services/metadata_coordinator.py",
+          "src/bioetl/infrastructure/storage/bronze_writer.py",
+          "tests/architecture/test_metadata_output_contract.py",
+          "tests/unit/domain/models/test_metadata_output.py",
+          "tests/unit/infrastructure/storage/test_metadata_writer.py"
+        ]
+      },
+      {
+        "name": "SilverOutputExt",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 429,
+        "usages": [
+          "src/bioetl/composition/services/metadata_coordinator.py",
+          "src/bioetl/infrastructure/storage/metadata_builder.py",
+          "tests/architecture/test_metadata_output_contract.py",
+          "tests/unit/domain/models/test_metadata_output.py",
+          "tests/unit/infrastructure/storage/test_metadata_writer.py",
+          "tests/unit/infrastructure/storage/test_silver_writer.py"
+        ]
+      },
+      {
+        "name": "GoldOutputExt",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 449,
+        "usages": [
+          "src/bioetl/composition/services/metadata_coordinator.py",
+          "src/bioetl/infrastructure/storage/metadata_builder.py",
+          "tests/architecture/test_metadata_output_contract.py",
+          "tests/unit/domain/models/test_metadata_output.py",
+          "tests/unit/infrastructure/storage/test_metadata_integration.py",
+          "tests/unit/infrastructure/storage/test_metadata_writer.py"
+        ]
+      },
+      {
+        "name": "LineageMetadata",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 475,
+        "usages": [
+          "src/bioetl/composition/services/metadata_coordinator.py",
+          "src/bioetl/domain/composite/__init__.py",
+          "src/bioetl/domain/composite/result.py",
+          "src/bioetl/domain/models/__init__.py",
+          "src/bioetl/infrastructure/storage/metadata_builder.py",
+          "tests/unit/domain/composite/test_lineage.py",
+          "tests/unit/infrastructure/storage/test_metadata_writer.py",
+          "tests/unit/infrastructure/storage/test_silver_writer.py"
+        ]
+      },
+      {
+        "name": "DeltaMetrics",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 501,
+        "usages": [
+          "src/bioetl/composition/services/metadata_coordinator.py",
+          "src/bioetl/domain/models/__init__.py",
+          "src/bioetl/infrastructure/storage/metadata_builder.py",
+          "tests/unit/domain/models/test_metadata_output.py",
+          "tests/unit/infrastructure/storage/test_metadata_integration.py",
+          "tests/unit/infrastructure/storage/test_metadata_writer.py",
+          "tests/unit/infrastructure/storage/test_silver_writer.py"
+        ]
+      },
+      {
+        "name": "ColumnMetrics",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 535,
+        "usages": [
+          "src/bioetl/domain/models/__init__.py",
+          "src/bioetl/domain/value_objects/dq_metrics.py",
+          "tests/unit/domain/value_objects/test_dq_metrics.py",
+          "tests/unit/infrastructure/storage/test_metadata_writer.py"
+        ]
+      },
+      {
+        "name": "SchemaDrift",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 553,
+        "usages": [
+          "src/bioetl/domain/models/__init__.py",
+          "src/bioetl/domain/value_objects/dq_metrics.py",
+          "tests/unit/domain/value_objects/test_dq_metrics.py"
+        ]
+      },
+      {
+        "name": "DQSummary",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 571,
+        "usages": [
+          "src/bioetl/composition/services/metadata_coordinator.py",
+          "src/bioetl/domain/models/__init__.py",
+          "src/bioetl/domain/value_objects/dq_metrics.py",
+          "src/bioetl/infrastructure/storage/metadata_builder.py",
+          "tests/unit/domain/value_objects/test_dq_metrics.py",
+          "tests/unit/infrastructure/storage/test_metadata_writer.py",
+          "tests/unit/infrastructure/storage/test_silver_writer.py"
+        ]
+      },
+      {
+        "name": "SchemaColumnMetadata",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 613,
+        "usages": [
+          "src/bioetl/composition/services/metadata_coordinator.py",
+          "src/bioetl/domain/models/__init__.py",
+          "src/bioetl/infrastructure/storage/metadata_builder.py"
+        ]
+      },
+      {
+        "name": "SchemaMetadata",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 627,
+        "usages": [
+          "src/bioetl/composition/services/metadata_coordinator.py",
+          "src/bioetl/domain/models/__init__.py",
+          "src/bioetl/infrastructure/storage/metadata_builder.py",
+          "tests/unit/infrastructure/storage/test_metadata_writer.py"
+        ]
+      },
+      {
+        "name": "SCDMetadata",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 649,
+        "usages": [
+          "src/bioetl/composition/services/metadata_coordinator.py",
+          "src/bioetl/domain/models/__init__.py",
+          "src/bioetl/infrastructure/storage/metadata_builder.py"
+        ]
+      },
+      {
+        "name": "BronzeMetadata",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 678,
+        "usages": [
+          "src/bioetl/composition/services/metadata_coordinator.py",
+          "src/bioetl/domain/models/__init__.py",
+          "src/bioetl/domain/ports/metadata.py",
+          "src/bioetl/domain/ports/metadata_coordinator.py",
+          "src/bioetl/domain/ports/noop.py",
+          "src/bioetl/infrastructure/storage/bronze_writer.py",
+          "src/bioetl/infrastructure/storage/metadata_writer.py",
+          "tests/architecture/test_domain_public_api.py",
+          "tests/architecture/test_metadata_output_contract.py",
+          "tests/unit/application/services/test_metadata_coordinator.py",
+          "tests/unit/domain/models/test_metadata_output.py",
+          "tests/unit/infrastructure/storage/test_metadata_writer.py"
+        ]
+      },
+      {
+        "name": "SilverMetadata",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 706,
+        "usages": [
+          "src/bioetl/composition/services/metadata_coordinator.py",
+          "src/bioetl/domain/models/__init__.py",
+          "src/bioetl/domain/ports/metadata.py",
+          "src/bioetl/domain/ports/metadata_coordinator.py",
+          "src/bioetl/domain/ports/noop.py",
+          "src/bioetl/infrastructure/storage/metadata_builder.py",
+          "src/bioetl/infrastructure/storage/metadata_writer.py",
+          "tests/architecture/test_metadata_output_contract.py",
+          "tests/unit/application/services/test_metadata_coordinator.py",
+          "tests/unit/domain/models/test_metadata_output.py",
+          "tests/unit/infrastructure/storage/test_metadata_builder.py",
+          "tests/unit/infrastructure/storage/test_metadata_integration.py",
+          "tests/unit/infrastructure/storage/test_metadata_writer.py",
+          "tests/unit/infrastructure/storage/test_silver_writer.py"
+        ]
+      },
+      {
+        "name": "GoldMetadata",
+        "file": "src/bioetl/domain/models/metadata.py",
+        "line": 742,
+        "usages": [
+          "src/bioetl/composition/services/metadata_coordinator.py",
+          "src/bioetl/domain/models/__init__.py",
+          "src/bioetl/domain/ports/metadata.py",
+          "src/bioetl/domain/ports/metadata_coordinator.py",
+          "src/bioetl/domain/ports/noop.py",
+          "src/bioetl/infrastructure/storage/metadata_builder.py",
+          "src/bioetl/infrastructure/storage/metadata_writer.py",
+          "tests/architecture/test_metadata_output_contract.py",
+          "tests/unit/application/services/test_metadata_coordinator.py",
+          "tests/unit/domain/models/test_metadata_output.py",
+          "tests/unit/infrastructure/storage/test_metadata_builder.py",
+          "tests/unit/infrastructure/storage/test_metadata_integration.py",
+          "tests/unit/infrastructure/storage/test_metadata_writer.py"
+        ]
+      },
+      {
+        "name": "BaseDQThresholds",
+        "file": "src/bioetl/infrastructure/schemas/base_schemas.py",
+        "line": 32,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/__init__.py",
+          "tests/unit/infrastructure/schemas/test_base_schemas.py"
+        ]
+      },
+      {
+        "name": "BaseCircuitBreakerConfig",
+        "file": "src/bioetl/infrastructure/schemas/base_schemas.py",
+        "line": 88,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/__init__.py",
+          "src/bioetl/infrastructure/schemas/source_config.py",
+          "tests/unit/infrastructure/schemas/test_base_schemas.py"
+        ]
+      },
+      {
+        "name": "BaseRateLimitConfig",
+        "file": "src/bioetl/infrastructure/schemas/base_schemas.py",
+        "line": 125,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/__init__.py",
+          "src/bioetl/infrastructure/schemas/source_config.py",
+          "tests/unit/infrastructure/schemas/test_base_schemas.py"
+        ]
+      },
+      {
+        "name": "BaseClientConfig",
+        "file": "src/bioetl/infrastructure/schemas/base_schemas.py",
+        "line": 151,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/configs/__init__.py",
+          "src/bioetl/infrastructure/schemas/__init__.py",
+          "src/bioetl/infrastructure/schemas/pipeline_config.py",
+          "src/bioetl/infrastructure/schemas/source_config.py",
+          "tests/architecture/test_domain_public_api.py",
+          "tests/unit/domain/configs/test_base_configs.py",
+          "tests/unit/infrastructure/schemas/test_base_schemas.py"
+        ]
+      },
+      {
+        "name": "BaseApiConfig",
+        "file": "src/bioetl/infrastructure/schemas/base_schemas.py",
+        "line": 177,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/__init__.py",
+          "tests/unit/infrastructure/schemas/test_base_schemas.py"
+        ]
+      },
+      {
+        "name": "BaseCsvExportConfig",
+        "file": "src/bioetl/infrastructure/schemas/base_schemas.py",
+        "line": 222,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/__init__.py",
+          "tests/unit/infrastructure/schemas/test_base_schemas.py"
+        ]
+      },
+      {
+        "name": "BaseFilterColumnSchema",
+        "file": "src/bioetl/infrastructure/schemas/base_schemas.py",
+        "line": 259,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/__init__.py",
+          "src/bioetl/infrastructure/schemas/filter_config.py",
+          "tests/unit/infrastructure/schemas/test_base_schemas.py"
+        ]
+      },
+      {
+        "name": "BaseInputFilterConfig",
+        "file": "src/bioetl/infrastructure/schemas/base_schemas.py",
+        "line": 275,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/__init__.py",
+          "src/bioetl/infrastructure/schemas/filter_config.py",
+          "tests/unit/infrastructure/schemas/test_base_schemas.py"
+        ]
+      },
+      {
+        "name": "BaseMaintenanceConfig",
+        "file": "src/bioetl/infrastructure/schemas/base_schemas.py",
+        "line": 385,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/__init__.py",
+          "tests/unit/infrastructure/schemas/test_base_schemas.py"
+        ]
+      },
+      {
+        "name": "BaseGoldRangeFilterConfig",
+        "file": "src/bioetl/infrastructure/schemas/base_schemas.py",
+        "line": 409,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/__init__.py",
+          "src/bioetl/infrastructure/schemas/filter_config.py",
+          "tests/unit/infrastructure/schemas/test_base_schemas.py"
+        ]
+      },
+      {
+        "name": "BaseGoldListLengthFilterConfig",
+        "file": "src/bioetl/infrastructure/schemas/base_schemas.py",
+        "line": 439,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/__init__.py",
+          "src/bioetl/infrastructure/schemas/filter_config.py",
+          "tests/unit/infrastructure/schemas/test_base_schemas.py"
+        ]
+      },
+      {
+        "name": "BaseGoldListContainsFilterConfig",
+        "file": "src/bioetl/infrastructure/schemas/base_schemas.py",
+        "line": 459,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/__init__.py",
+          "src/bioetl/infrastructure/schemas/filter_config.py",
+          "tests/unit/infrastructure/schemas/test_base_schemas.py"
+        ]
+      },
+      {
+        "name": "BaseGoldColumnFilterConfig",
+        "file": "src/bioetl/infrastructure/schemas/base_schemas.py",
+        "line": 478,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/__init__.py",
+          "src/bioetl/infrastructure/schemas/filter_config.py",
+          "tests/unit/infrastructure/schemas/test_base_schemas.py"
+        ]
+      },
+      {
+        "name": "BaseGoldFiltersConfig",
+        "file": "src/bioetl/infrastructure/schemas/base_schemas.py",
+        "line": 520,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/__init__.py",
+          "src/bioetl/infrastructure/schemas/filter_config.py",
+          "tests/unit/infrastructure/schemas/test_base_schemas.py"
+        ]
+      },
+      {
+        "name": "AggregationFieldSchema",
+        "file": "src/bioetl/infrastructure/schemas/composite_config.py",
+        "line": 42,
+        "usages": []
+      },
+      {
+        "name": "AggregationSchema",
+        "file": "src/bioetl/infrastructure/schemas/composite_config.py",
+        "line": 76,
+        "usages": []
+      },
+      {
+        "name": "SeedSchema",
+        "file": "src/bioetl/infrastructure/schemas/composite_config.py",
+        "line": 97,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/__init__.py"
+        ]
+      },
+      {
+        "name": "DependencySchema",
+        "file": "src/bioetl/infrastructure/schemas/composite_config.py",
+        "line": 132,
+        "usages": []
+      },
+      {
+        "name": "EnricherSchema",
+        "file": "src/bioetl/infrastructure/schemas/composite_config.py",
+        "line": 208,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/__init__.py"
+        ]
+      },
+      {
+        "name": "MergeOutputSchema",
+        "file": "src/bioetl/infrastructure/schemas/composite_config.py",
+        "line": 281,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/__init__.py"
+        ]
+      },
+      {
+        "name": "ColumnGroupSchema",
+        "file": "src/bioetl/infrastructure/schemas/composite_config.py",
+        "line": 288,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/pipeline_config.py"
+        ]
+      },
+      {
+        "name": "MergeSchema",
+        "file": "src/bioetl/infrastructure/schemas/composite_config.py",
+        "line": 322,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/__init__.py"
+        ]
+      },
+      {
+        "name": "DQOverrideSchema",
+        "file": "src/bioetl/infrastructure/schemas/composite_config.py",
+        "line": 400,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/__init__.py"
+        ]
+      },
+      {
+        "name": "CompositeDQSchema",
+        "file": "src/bioetl/infrastructure/schemas/composite_config.py",
+        "line": 431,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/__init__.py"
+        ]
+      },
+      {
+        "name": "RetrySchema",
+        "file": "src/bioetl/infrastructure/schemas/composite_config.py",
+        "line": 471,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/__init__.py"
+        ]
+      },
+      {
+        "name": "ExecutionSchema",
+        "file": "src/bioetl/infrastructure/schemas/composite_config.py",
+        "line": 482,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/__init__.py"
+        ]
+      },
+      {
+        "name": "LineageSchema",
+        "file": "src/bioetl/infrastructure/schemas/composite_config.py",
+        "line": 505,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/__init__.py"
+        ]
+      },
+      {
+        "name": "CompositeConfigSchema",
+        "file": "src/bioetl/infrastructure/schemas/composite_config.py",
+        "line": 527,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/__init__.py"
+        ]
+      },
+      {
+        "name": "CompositeConfigFileSchema",
+        "file": "src/bioetl/infrastructure/schemas/composite_config.py",
+        "line": 637,
+        "usages": [
+          "src/bioetl/composition/bootstrap/runtime/composite.py",
+          "src/bioetl/infrastructure/schemas/__init__.py"
+        ]
+      },
+      {
+        "name": "ThresholdsConfig",
+        "file": "src/bioetl/infrastructure/schemas/dq_config.py",
+        "line": 37,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/__init__.py",
+          "tests/unit/infrastructure/schemas/test_dq_config.py"
+        ]
+      },
+      {
+        "name": "DQConfigFile",
+        "file": "src/bioetl/infrastructure/schemas/dq_config.py",
+        "line": 84,
+        "usages": [
+          "src/bioetl/infrastructure/config/dq_config_loader.py",
+          "src/bioetl/infrastructure/config/pipeline_config_loader.py",
+          "src/bioetl/infrastructure/schemas/__init__.py",
+          "tests/unit/infrastructure/schemas/test_dq_config.py"
+        ]
+      },
+      {
+        "name": "BronzeDQReportConfig",
+        "file": "src/bioetl/infrastructure/schemas/dq_report_config.py",
+        "line": 24,
+        "usages": [
+          "tests/integration/test_dq_report_integration.py",
+          "tests/unit/application/services/dq/test_bronze_analyzer.py"
+        ]
+      },
+      {
+        "name": "SilverDQReportConfig",
+        "file": "src/bioetl/infrastructure/schemas/dq_report_config.py",
+        "line": 71,
+        "usages": [
+          "tests/integration/test_dq_report_integration.py"
+        ]
+      },
+      {
+        "name": "GoldDQReportConfig",
+        "file": "src/bioetl/infrastructure/schemas/dq_report_config.py",
+        "line": 122,
+        "usages": [
+          "tests/integration/test_dq_report_integration.py"
+        ]
+      },
+      {
+        "name": "BronzeSinkConfig",
+        "file": "src/bioetl/infrastructure/schemas/dq_report_config.py",
+        "line": 172,
+        "usages": [
+          "src/bioetl/composition/factories/pipeline_factory.py"
+        ]
+      },
+      {
+        "name": "SilverSinkConfig",
+        "file": "src/bioetl/infrastructure/schemas/dq_report_config.py",
+        "line": 184,
+        "usages": [
+          "src/bioetl/composition/factories/pipeline_factory.py"
+        ]
+      },
+      {
+        "name": "GoldSinkConfig",
+        "file": "src/bioetl/infrastructure/schemas/dq_report_config.py",
+        "line": 210,
+        "usages": [
+          "src/bioetl/composition/factories/pipeline_factory.py"
+        ]
+      },
+      {
+        "name": "FilterConfigFile",
+        "file": "src/bioetl/infrastructure/schemas/filter_config.py",
+        "line": 114,
+        "usages": [
+          "src/bioetl/infrastructure/config/filter_config_loader.py",
+          "src/bioetl/infrastructure/schemas/__init__.py",
+          "tests/unit/infrastructure/config/test_filter_config_loader.py"
+        ]
+      },
+      {
+        "name": "FieldValidationConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 40,
+        "usages": [
+          "src/bioetl/infrastructure/config/pipeline_config_loader.py",
+          "src/bioetl/infrastructure/schemas/dq_config.py",
+          "tests/unit/infrastructure/schemas/test_dq_config.py"
+        ]
+      },
+      {
+        "name": "CrossFieldValidationConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 64,
+        "usages": [
+          "src/bioetl/infrastructure/config/pipeline_config_loader.py",
+          "src/bioetl/infrastructure/schemas/dq_config.py",
+          "tests/unit/infrastructure/schemas/test_dq_config.py"
+        ]
+      },
+      {
+        "name": "ConditionalValidationConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 86,
+        "usages": [
+          "src/bioetl/infrastructure/config/pipeline_config_loader.py",
+          "src/bioetl/infrastructure/schemas/dq_config.py",
+          "tests/unit/infrastructure/schemas/test_dq_config.py"
+        ]
+      },
+      {
+        "name": "DQReportConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 100,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/dq_config.py",
+          "tests/unit/infrastructure/schemas/test_dq_config.py"
+        ]
+      },
+      {
+        "name": "DQConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 116,
+        "usages": [
+          "src/bioetl/application/core/config.py",
+          "src/bioetl/application/services/data_quality_service.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/composite/config.py",
+          "src/bioetl/infrastructure/config/_base.py",
+          "src/bioetl/infrastructure/config/dq_config_loader.py",
+          "src/bioetl/infrastructure/config/pipeline_config_loader.py",
+          "src/bioetl/infrastructure/schemas/base_schemas.py",
+          "src/bioetl/infrastructure/schemas/dq_config.py",
+          "tests/e2e/test_pipeline_with_dq_errors_e2e.py",
+          "tests/integration/test_dq_monitor_integration.py",
+          "tests/smoke/test_smoke.py",
+          "tests/unit/application/composite/test_runner.py",
+          "tests/unit/application/composite/test_runner_checkpoint_resume.py",
+          "tests/unit/application/composite/test_runner_required_flag.py",
+          "tests/unit/application/core/test_batch_transformer.py",
+          "tests/unit/application/core/test_run_id_propagation.py",
+          "tests/unit/application/services/test_data_quality_service.py",
+          "tests/unit/domain/configs/test_base_configs.py",
+          "tests/unit/domain/test_config.py",
+          "tests/unit/domain/test_config_validation.py",
+          "tests/unit/domain/test_pipeline_config.py",
+          "tests/unit/infrastructure/test_config.py",
+          "tests/unit/infrastructure/test_config_settings.py"
+        ]
+      },
+      {
+        "name": "CircuitBreakerConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 260,
+        "usages": [
+          "src/bioetl/composition/bootstrap_contexts.py",
+          "src/bioetl/composition/providers/registration.py",
+          "src/bioetl/composition/types.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/infrastructure/schemas/base_schemas.py",
+          "src/bioetl/infrastructure/schemas/source_config.py",
+          "tests/unit/composition/test_types.py",
+          "tests/unit/domain/configs/test_base_configs.py"
+        ]
+      },
+      {
+        "name": "CsvExportConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 281,
+        "usages": []
+      },
+      {
+        "name": "FilterColumnSchema",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 291,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/filter_config.py"
+        ]
+      },
+      {
+        "name": "InputFilterConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 298,
+        "usages": [
+          "src/bioetl/application/core/filtered_data_source.py",
+          "src/bioetl/composition/bootstrap/runtime/assembly.py",
+          "src/bioetl/composition/builders.py",
+          "src/bioetl/composition/factories/data_source_factory.py",
+          "src/bioetl/composition/factories/pipeline_factory.py",
+          "src/bioetl/composition/providers/provider_registry.py",
+          "src/bioetl/composition/providers/registration.py",
+          "src/bioetl/composition/registry.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/filtering/__init__.py",
+          "src/bioetl/infrastructure/config/filter_config_loader.py",
+          "src/bioetl/infrastructure/schemas/base_schemas.py",
+          "src/bioetl/infrastructure/schemas/filter_config.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/architecture/test_domain_purity.py",
+          "tests/unit/application/core/test_filtered_data_source.py",
+          "tests/unit/composition/bootstrap/runtime/test_assembly.py",
+          "tests/unit/composition/test_builders.py",
+          "tests/unit/domain/configs/test_base_configs.py",
+          "tests/unit/domain/test_filter_config.py"
+        ]
+      },
+      {
+        "name": "MaintenanceConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 393,
+        "usages": [
+          "src/bioetl/composition/bootstrap/runtime/assembly.py",
+          "tests/unit/composition/bootstrap/runtime/test_assembly.py",
+          "tests/unit/infrastructure/test_config.py"
+        ]
+      },
+      {
+        "name": "ApiConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 415,
+        "usages": [
+          "src/bioetl/domain/configs/base.py",
+          "tests/unit/domain/configs/test_base_configs.py"
+        ]
+      },
+      {
+        "name": "RateLimitSourceConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 440,
+        "usages": []
+      },
+      {
+        "name": "ClientSourceConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 450,
+        "usages": []
+      },
+      {
+        "name": "ProviderSourceConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 457,
+        "usages": []
+      },
+      {
+        "name": "SourceConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 473,
+        "usages": [
+          "tests/unit/infrastructure/test_config_settings.py"
+        ]
+      },
+      {
+        "name": "SortByConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 497,
+        "usages": [
+          "tests/unit/infrastructure/storage/test_deterministic_write.py"
+        ]
+      },
+      {
+        "name": "SinkDQReportConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 510,
+        "usages": []
+      },
+      {
+        "name": "SinkLineageConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 527,
+        "usages": [
+          "tests/unit/infrastructure/schemas/test_sink_metadata_config.py"
+        ]
+      },
+      {
+        "name": "SinkQualityExpectationsConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 557,
+        "usages": [
+          "tests/unit/infrastructure/schemas/test_sink_metadata_config.py"
+        ]
+      },
+      {
+        "name": "SinkMetadataConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 568,
+        "usages": [
+          "tests/unit/infrastructure/schemas/test_sink_metadata_config.py"
+        ]
+      },
+      {
+        "name": "SinkLayerConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 653,
+        "usages": [
+          "tests/unit/infrastructure/schemas/test_sink_metadata_config.py",
+          "tests/unit/infrastructure/storage/test_deterministic_write.py",
+          "tests/unit/infrastructure/test_config.py"
+        ]
+      },
+      {
+        "name": "GoldRangeFilterConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 696,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/filter_config.py",
+          "tests/unit/infrastructure/test_config_settings.py"
+        ]
+      },
+      {
+        "name": "GoldListLengthFilterConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 705,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/filter_config.py",
+          "tests/unit/infrastructure/test_config_settings.py"
+        ]
+      },
+      {
+        "name": "GoldListContainsFilterConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 712,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/filter_config.py",
+          "tests/unit/infrastructure/test_config_settings.py"
+        ]
+      },
+      {
+        "name": "GoldColumnFilterConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 719,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/base_schemas.py",
+          "src/bioetl/infrastructure/schemas/filter_config.py",
+          "tests/architecture/test_code_metrics.py"
+        ]
+      },
+      {
+        "name": "GoldFiltersConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 757,
+        "usages": [
+          "src/bioetl/infrastructure/config/_base.py",
+          "src/bioetl/infrastructure/schemas/filter_config.py",
+          "tests/unit/infrastructure/test_config_settings.py"
+        ]
+      },
+      {
+        "name": "TransformConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 862,
+        "usages": [
+          "tests/architecture/test_code_metrics.py",
+          "tests/unit/infrastructure/test_config.py"
+        ]
+      },
+      {
+        "name": "PipelineYamlConfig",
+        "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+        "line": 904,
+        "usages": [
+          "src/bioetl/application/services/config_service.py",
+          "src/bioetl/composition/factories/data_source_factory.py",
+          "src/bioetl/composition/factories/pipeline_factory.py",
+          "src/bioetl/composition/factories/services_factory.py",
+          "src/bioetl/composition/factories/storage_factory.py",
+          "src/bioetl/composition/providers/provider_registry.py",
+          "src/bioetl/composition/providers/registration.py",
+          "src/bioetl/composition/registry.py",
+          "src/bioetl/composition/services/versioning.py",
+          "src/bioetl/infrastructure/config/_base.py",
+          "src/bioetl/infrastructure/config/pipeline_config_loader.py",
+          "src/bioetl/infrastructure/config_loader.py",
+          "src/bioetl/infrastructure/schemas/__init__.py",
+          "tests/integration/interfaces/conftest.py",
+          "tests/integration/pipelines/base.py",
+          "tests/test_architecture.py",
+          "tests/unit/infrastructure/test_config.py",
+          "tests/unit/infrastructure/test_config_dynamic.py",
+          "tests/unit/infrastructure/test_config_settings.py"
+        ]
+      },
+      {
+        "name": "ProviderConfigYaml",
+        "file": "src/bioetl/infrastructure/schemas/source_config.py",
+        "line": 76,
+        "usages": []
+      },
+      {
+        "name": "SourceSectionConfig",
+        "file": "src/bioetl/infrastructure/schemas/source_config.py",
+        "line": 101,
+        "usages": []
+      },
+      {
+        "name": "SourceYamlConfig",
+        "file": "src/bioetl/infrastructure/schemas/source_config.py",
+        "line": 131,
+        "usages": [
+          "src/bioetl/composition/providers/registration.py",
+          "src/bioetl/infrastructure/config/__init__.py",
+          "src/bioetl/infrastructure/config/_base.py",
+          "src/bioetl/infrastructure/config_loader.py",
+          "tests/architecture/test_source_config_usage.py"
+        ]
+      }
+    ],
+    "dataclass": [
+      {
+        "name": "CompositeCheckpointState",
+        "file": "src/bioetl/application/composite/checkpoint.py",
+        "line": 31,
+        "usages": [
+          "src/bioetl/application/composite/__init__.py",
+          "src/bioetl/application/composite/fsm_helper.py",
+          "src/bioetl/application/composite/runner.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/architecture/test_composite_layer_boundaries.py",
+          "tests/unit/application/composite/test_checkpoint.py",
+          "tests/unit/application/composite/test_fsm_helper.py",
+          "tests/unit/application/composite/test_fsm_pipeline_scenarios.py",
+          "tests/unit/application/composite/test_runner.py",
+          "tests/unit/application/composite/test_runner_checkpoint_resume.py",
+          "tests/unit/application/composite/test_runner_enrichment_fsm.py",
+          "tests/unit/application/composite/test_runner_fsm.py",
+          "tests/unit/application/composite/test_runner_fsm_logging.py",
+          "tests/unit/application/composite/test_runner_required_flag.py",
+          "tests/unit/application/composite/test_runner_robustness.py"
+        ]
+      },
+      {
+        "name": "FieldInfo",
+        "file": "src/bioetl/application/composite/preflight_validator.py",
+        "line": 21,
+        "usages": [
+          "src/bioetl/infrastructure/config/_base.py",
+          "tests/unit/application/composite/test_preflight_validator.py"
+        ]
+      },
+      {
+        "name": "ValidationIssue",
+        "file": "src/bioetl/application/composite/preflight_validator.py",
+        "line": 38,
+        "usages": [
+          "tests/unit/application/composite/test_preflight_validator.py"
+        ]
+      },
+      {
+        "name": "PreflightValidationResult",
+        "file": "src/bioetl/application/composite/preflight_validator.py",
+        "line": 57,
+        "usages": [
+          "src/bioetl/application/composite/__init__.py",
+          "tests/unit/application/composite/test_preflight_validator.py"
+        ]
+      },
+      {
+        "name": "CompositeRuntimeConfig",
+        "file": "src/bioetl/application/composite/runner.py",
+        "line": 57,
+        "usages": [
+          "src/bioetl/composition/bootstrap/runtime/composite.py",
+          "src/bioetl/interfaces/cli/commands/run_composite.py",
+          "tests/unit/application/composite/test_fsm_pipeline_scenarios.py",
+          "tests/unit/application/composite/test_runner.py",
+          "tests/unit/application/composite/test_runner_checkpoint_resume.py",
+          "tests/unit/application/composite/test_runner_enrichment_fsm.py",
+          "tests/unit/application/composite/test_runner_fsm.py",
+          "tests/unit/application/composite/test_runner_fsm_logging.py",
+          "tests/unit/application/composite/test_runner_required_flag.py",
+          "tests/unit/application/composite/test_runner_robustness.py",
+          "tests/unit/interfaces/cli/commands/test_run_composite.py"
+        ]
+      },
+      {
+        "name": "BatchResult",
+        "file": "src/bioetl/application/core/batch_executor.py",
+        "line": 53,
+        "usages": [
+          "src/bioetl/application/core/record_processor.py",
+          "tests/unit/application/core/test_batch_executor.py"
+        ]
+      },
+      {
+        "name": "TransformResult",
+        "file": "src/bioetl/application/core/batch_transformer.py",
+        "line": 35,
+        "usages": [
+          "src/bioetl/application/core/__init__.py",
+          "src/bioetl/application/core/batch_executor.py",
+          "src/bioetl/application/core/record_processor.py",
+          "tests/unit/application/core/test_batch_transformer.py",
+          "tests/unit/application/core/test_streaming_batch.py"
+        ]
+      },
+      {
+        "name": "TransformedRecord",
+        "file": "src/bioetl/application/core/batch_transformer.py",
+        "line": 44,
+        "usages": [
+          "src/bioetl/application/core/__init__.py",
+          "tests/unit/application/core/test_streaming_batch.py"
+        ]
+      },
+      {
+        "name": "LayerInfo",
+        "file": "src/bioetl/application/core/cleanup_service.py",
+        "line": 17,
+        "usages": [
+          "src/bioetl/application/core/__init__.py",
+          "tests/unit/application/core/test_cleanup_service.py",
+          "tests/unit/interfaces/test_cli_run_all_vacuum_formatters.py",
+          "tests/unit/test_cli.py"
+        ]
+      },
+      {
+        "name": "CleanupPreview",
+        "file": "src/bioetl/application/core/cleanup_service.py",
+        "line": 32,
+        "usages": [
+          "src/bioetl/application/core/__init__.py",
+          "src/bioetl/composition/entrypoints.py",
+          "src/bioetl/interfaces/cli/formatters.py",
+          "tests/integration/interfaces/test_cli_run_dry_run.py",
+          "tests/unit/application/core/test_cleanup_service.py",
+          "tests/unit/interfaces/test_cli_run_all_vacuum_formatters.py",
+          "tests/unit/test_cli.py"
+        ]
+      },
+      {
+        "name": "CleanupResult",
+        "file": "src/bioetl/application/core/cleanup_service.py",
+        "line": 47,
+        "usages": [
+          "src/bioetl/application/core/__init__.py",
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/composition/entrypoints.py",
+          "tests/unit/application/core/test_cleanup_service.py",
+          "tests/unit/application/services/test_bronze_cleanup_service.py",
+          "tests/unit/interfaces/test_cli_commands.py"
+        ]
+      },
+      {
+        "name": "RecordProcessorConfig",
+        "file": "src/bioetl/application/core/config.py",
+        "line": 16,
+        "usages": [
+          "src/bioetl/application/core/batch_executor.py",
+          "src/bioetl/application/core/batch_tracing.py",
+          "src/bioetl/application/core/batch_transformer.py",
+          "src/bioetl/application/core/batch_writer.py",
+          "src/bioetl/application/core/record_processor.py",
+          "src/bioetl/composition/factories/services_factory.py",
+          "tests/e2e/test_pipeline_with_dq_errors_e2e.py",
+          "tests/unit/application/core/test_batch_executor.py",
+          "tests/unit/application/core/test_batch_executor_memory.py",
+          "tests/unit/application/core/test_batch_transformer.py",
+          "tests/unit/application/core/test_batch_writer.py",
+          "tests/unit/application/core/test_record_processor.py",
+          "tests/unit/application/core/test_record_processor_metrics.py",
+          "tests/unit/application/core/test_run_id_propagation.py",
+          "tests/unit/application/core/test_streaming_batch.py"
+        ]
+      },
+      {
+        "name": "LockConfig",
+        "file": "src/bioetl/application/core/config.py",
+        "line": 36,
+        "usages": [
+          "src/bioetl/application/core/lock_manager.py",
+          "tests/integration/interfaces/test_cli_shutdown_integration.py",
+          "tests/unit/application/core/test_lock_manager.py"
+        ]
+      },
+      {
+        "name": "FieldSpec",
+        "file": "src/bioetl/application/core/field_specs.py",
+        "line": 93,
+        "usages": [
+          "src/bioetl/application/pipelines/chembl/activity_transformer.py",
+          "src/bioetl/application/pipelines/chembl/assay_parameters_transformer.py",
+          "src/bioetl/application/pipelines/chembl/assay_transformer.py",
+          "src/bioetl/application/pipelines/chembl/publication_transformer.py",
+          "src/bioetl/application/pipelines/chembl/target_component_transformer.py",
+          "tests/unit/application/core/test_field_specs.py"
+        ]
+      },
+      {
+        "name": "FieldGroup",
+        "file": "src/bioetl/application/core/field_specs.py",
+        "line": 117,
+        "usages": [
+          "src/bioetl/application/pipelines/chembl/activity_transformer.py",
+          "src/bioetl/application/pipelines/chembl/assay_parameters_transformer.py",
+          "src/bioetl/application/pipelines/chembl/assay_transformer.py",
+          "src/bioetl/application/pipelines/chembl/molecule_transformer.py",
+          "src/bioetl/application/pipelines/chembl/protein_class_transformer.py",
+          "src/bioetl/application/pipelines/chembl/publication_transformer.py",
+          "src/bioetl/application/pipelines/chembl/target_component_transformer.py",
+          "tests/unit/application/core/test_field_specs.py"
+        ]
+      },
+      {
+        "name": "PipelineServices",
+        "file": "src/bioetl/application/core/pipeline_services.py",
+        "line": 40,
+        "usages": [
+          "src/bioetl/application/core/__init__.py",
+          "src/bioetl/application/core/base.py",
+          "src/bioetl/application/core/batch_executor.py",
+          "src/bioetl/application/core/preflight_service.py",
+          "src/bioetl/application/core/record_processor.py",
+          "src/bioetl/application/core/runner.py",
+          "src/bioetl/composition/factories/pipeline_factory.py",
+          "src/bioetl/composition/factories/services_factory.py",
+          "tests/architecture/test_di_constructors.py",
+          "tests/architecture/test_tracing_enforcement.py",
+          "tests/integration/test_pubchem_pipeline.py",
+          "tests/integration/test_uniprot_pipeline.py",
+          "tests/unit/application/core/test_batch_executor.py",
+          "tests/unit/application/core/test_batch_executor_memory.py",
+          "tests/unit/application/core/test_health_aggregator.py",
+          "tests/unit/application/core/test_pipeline_services.py",
+          "tests/unit/application/core/test_record_processor.py",
+          "tests/unit/application/core/test_record_processor_metrics.py",
+          "tests/unit/application/core/test_run_id_propagation.py",
+          "tests/unit/application/core/test_runner.py",
+          "tests/unit/application/pipelines/test_chembl_activity_unit.py",
+          "tests/unit/application/pipelines/test_chembl_pipelines.py",
+          "tests/unit/application/test_base_pipeline.py",
+          "tests/unit/interfaces/factories/test_pipeline_factories.py",
+          "tests/unit/pipelines/chembl/test_activity_schema_gap.py",
+          "tests/unit/pipelines/test_chembl_ddd.py",
+          "tests/unit/test_bootstrap.py"
+        ]
+      },
+      {
+        "name": "PostrunResult",
+        "file": "src/bioetl/application/core/postrun_service.py",
+        "line": 58,
+        "usages": [
+          "src/bioetl/application/core/__init__.py",
+          "tests/integration/test_runner_lifecycle.py",
+          "tests/unit/application/core/test_postrun_service.py",
+          "tests/unit/application/core/test_runner.py"
+        ]
+      },
+      {
+        "name": "ShutdownSignal",
+        "file": "src/bioetl/application/core/shutdown.py",
+        "line": 28,
+        "usages": [
+          "src/bioetl/application/core/__init__.py",
+          "src/bioetl/application/core/base.py",
+          "src/bioetl/application/core/batch_executor.py",
+          "src/bioetl/application/core/heartbeat.py",
+          "src/bioetl/application/core/lock_manager.py",
+          "src/bioetl/application/core/runner.py",
+          "src/bioetl/application/services/shutdown_service.py",
+          "src/bioetl/composition/factories/services_factory.py",
+          "src/bioetl/domain/ports/shutdown.py",
+          "tests/e2e/test_pipeline_graceful_shutdown_e2e.py",
+          "tests/integration/interfaces/test_cli_shutdown_integration.py",
+          "tests/unit/application/core/test_batch_executor.py",
+          "tests/unit/application/core/test_batch_executor_memory.py",
+          "tests/unit/application/core/test_heartbeat.py",
+          "tests/unit/application/core/test_lock_manager.py",
+          "tests/unit/application/core/test_runner.py",
+          "tests/unit/application/core/test_shutdown.py",
+          "tests/unit/domain/test_locking.py"
+        ]
+      },
+      {
+        "name": "CleanupResult",
+        "file": "src/bioetl/application/services/bronze_cleanup_service.py",
+        "line": 21,
+        "usages": [
+          "src/bioetl/application/core/__init__.py",
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/composition/entrypoints.py",
+          "tests/unit/application/core/test_cleanup_service.py",
+          "tests/unit/application/services/test_bronze_cleanup_service.py",
+          "tests/unit/interfaces/test_cli_commands.py"
+        ]
+      },
+      {
+        "name": "BronzeCleanupService",
+        "file": "src/bioetl/application/services/bronze_cleanup_service.py",
+        "line": 40,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/composition/bootstrap/cli/storage.py",
+          "src/bioetl/composition/entrypoints.py",
+          "tests/architecture/test_interfaces_no_infrastructure.py",
+          "tests/unit/application/services/test_bronze_cleanup_service.py",
+          "tests/unit/composition/bootstrap/test_storage_bootstrap.py",
+          "tests/unit/interfaces/test_cli_commands.py"
+        ]
+      },
+      {
+        "name": "CheckpointInfo",
+        "file": "src/bioetl/application/services/checkpoint_service.py",
+        "line": 19,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "tests/unit/application/services/test_checkpoint_service.py"
+        ]
+      },
+      {
+        "name": "CheckpointService",
+        "file": "src/bioetl/application/services/checkpoint_service.py",
+        "line": 34,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/composition/bootstrap/cli/checkpoint.py",
+          "src/bioetl/composition/entrypoints.py",
+          "tests/architecture/test_interfaces_no_infrastructure.py",
+          "tests/unit/application/services/test_checkpoint_service.py",
+          "tests/unit/composition/bootstrap/test_checkpoint_bootstrap.py"
+        ]
+      },
+      {
+        "name": "PipelineInfo",
+        "file": "src/bioetl/application/services/config_service.py",
+        "line": 21,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "tests/unit/interfaces/test_cli_commands.py"
+        ]
+      },
+      {
+        "name": "SettingsInfo",
+        "file": "src/bioetl/application/services/config_service.py",
+        "line": 40,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/interfaces/cli/commands/config.py",
+          "tests/unit/interfaces/test_cli_commands.py"
+        ]
+      },
+      {
+        "name": "ConfigService",
+        "file": "src/bioetl/application/services/config_service.py",
+        "line": 75,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/composition/bootstrap/cli/__init__.py",
+          "src/bioetl/composition/bootstrap/cli/config.py",
+          "src/bioetl/composition/entrypoints.py",
+          "src/bioetl/interfaces/cli/commands/config.py",
+          "tests/unit/interfaces/test_cli_commands.py"
+        ]
+      },
+      {
+        "name": "DQReportResult",
+        "file": "src/bioetl/application/services/dq_report_service.py",
+        "line": 31,
+        "usages": [
+          "src/bioetl/application/core/postrun_service.py",
+          "src/bioetl/application/services/__init__.py",
+          "tests/unit/application/core/test_dq_report_integration.py",
+          "tests/unit/application/services/test_dq_report_service.py"
+        ]
+      },
+      {
+        "name": "DQReportContext",
+        "file": "src/bioetl/application/services/dq_report_service.py",
+        "line": 74,
+        "usages": [
+          "src/bioetl/application/composite/runner.py",
+          "src/bioetl/application/core/batch_executor.py",
+          "src/bioetl/application/core/postrun_service.py",
+          "src/bioetl/application/services/__init__.py",
+          "tests/integration/test_dq_report_integration.py",
+          "tests/unit/application/core/test_dq_report_integration.py",
+          "tests/unit/application/services/test_dq_report_service.py",
+          "tests/unit/application/services/test_dq_report_service_coverage.py"
+        ]
+      },
+      {
+        "name": "ColumnInfo",
+        "file": "src/bioetl/application/services/export_service.py",
+        "line": 23,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "tests/unit/interfaces/cli/commands/test_export.py"
+        ]
+      },
+      {
+        "name": "TablePreview",
+        "file": "src/bioetl/application/services/export_service.py",
+        "line": 38,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/interfaces/cli/formatters.py",
+          "tests/unit/application/services/test_export_service.py",
+          "tests/unit/interfaces/cli/commands/test_export.py"
+        ]
+      },
+      {
+        "name": "TableInfo",
+        "file": "src/bioetl/application/services/export_service.py",
+        "line": 57,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/interfaces/cli/formatters.py",
+          "tests/unit/interfaces/cli/commands/test_export.py"
+        ]
+      },
+      {
+        "name": "ExportOptions",
+        "file": "src/bioetl/application/services/export_service.py",
+        "line": 72,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/interfaces/cli/commands/export.py",
+          "tests/unit/application/services/test_export_service.py"
+        ]
+      },
+      {
+        "name": "ExportResult",
+        "file": "src/bioetl/application/services/export_service.py",
+        "line": 89,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/interfaces/cli/formatters.py",
+          "tests/unit/interfaces/cli/commands/test_export.py"
+        ]
+      },
+      {
+        "name": "ExportService",
+        "file": "src/bioetl/application/services/export_service.py",
+        "line": 210,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/composition/bootstrap/cli/storage.py",
+          "src/bioetl/composition/entrypoints.py",
+          "tests/unit/application/services/test_export_service.py",
+          "tests/unit/interfaces/cli/commands/test_export.py"
+        ]
+      },
+      {
+        "name": "HealthResult",
+        "file": "src/bioetl/application/services/health_service.py",
+        "line": 40,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "tests/unit/application/services/test_health_service.py",
+          "tests/unit/interfaces/cli/commands/test_health.py"
+        ]
+      },
+      {
+        "name": "HealthCheckSummary",
+        "file": "src/bioetl/application/services/health_service.py",
+        "line": 89,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "tests/unit/application/services/test_health_service.py",
+          "tests/unit/interfaces/cli/commands/test_health.py"
+        ]
+      },
+      {
+        "name": "HealthService",
+        "file": "src/bioetl/application/services/health_service.py",
+        "line": 118,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/composition/bootstrap/cli/__init__.py",
+          "src/bioetl/composition/bootstrap/cli/health.py",
+          "src/bioetl/composition/entrypoints.py",
+          "tests/unit/application/services/test_health_service.py",
+          "tests/unit/composition/bootstrap/test_health_bootstrap.py",
+          "tests/unit/interfaces/cli/commands/test_health.py"
+        ]
+      },
+      {
+        "name": "LockInfo",
+        "file": "src/bioetl/application/services/lock_service.py",
+        "line": 20,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "tests/unit/application/services/test_lock_service.py"
+        ]
+      },
+      {
+        "name": "LockService",
+        "file": "src/bioetl/application/services/lock_service.py",
+        "line": 35,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/composition/bootstrap/cli/__init__.py",
+          "src/bioetl/composition/bootstrap/cli/lock.py",
+          "src/bioetl/composition/entrypoints.py",
+          "tests/architecture/test_interfaces_no_infrastructure.py",
+          "tests/unit/application/services/test_lock_service.py",
+          "tests/unit/composition/bootstrap/test_lock_bootstrap.py",
+          "tests/unit/interfaces/test_cli_commands.py"
+        ]
+      },
+      {
+        "name": "MedallionLifecycleService",
+        "file": "src/bioetl/application/services/medallion_lifecycle.py",
+        "line": 32,
+        "usages": [
+          "src/bioetl/application/core/__init__.py",
+          "src/bioetl/application/core/postrun_service.py",
+          "src/bioetl/application/core/runner.py",
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/application/services/data_quality_service.py",
+          "src/bioetl/application/services/vacuum_service.py",
+          "src/bioetl/composition/bootstrap/cli/storage.py",
+          "src/bioetl/composition/entrypoints.py",
+          "src/bioetl/composition/factories/pipeline_factory.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/architecture/test_di_constructors.py",
+          "tests/architecture/test_di_discipline.py",
+          "tests/integration/test_runner_lifecycle.py",
+          "tests/unit/application/core/test_dq_report_integration.py",
+          "tests/unit/application/core/test_postrun_service.py",
+          "tests/unit/application/core/test_runner.py",
+          "tests/unit/application/services/test_medallion_lifecycle.py",
+          "tests/unit/application/services/test_vacuum_service.py",
+          "tests/unit/composition/bootstrap/test_storage_bootstrap.py",
+          "tests/unit/interfaces/test_cli_commands.py",
+          "tests/unit/interfaces/test_vacuum_commands.py"
+        ]
+      },
+      {
+        "name": "ClearResult",
+        "file": "src/bioetl/application/services/medallion_types.py",
+        "line": 16,
+        "usages": [
+          "src/bioetl/application/core/__init__.py",
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/application/services/medallion_lifecycle.py",
+          "tests/integration/test_runner_lifecycle.py",
+          "tests/unit/application/core/test_runner.py",
+          "tests/unit/application/services/test_medallion_lifecycle.py"
+        ]
+      },
+      {
+        "name": "VacuumResult",
+        "file": "src/bioetl/application/services/medallion_types.py",
+        "line": 40,
+        "usages": [
+          "src/bioetl/application/core/__init__.py",
+          "src/bioetl/application/core/postrun_service.py",
+          "src/bioetl/application/services/medallion_lifecycle.py",
+          "tests/integration/test_runner_lifecycle.py",
+          "tests/unit/application/core/test_dq_report_integration.py",
+          "tests/unit/application/core/test_postrun_service.py",
+          "tests/unit/application/core/test_runner.py"
+        ]
+      },
+      {
+        "name": "PrepareResult",
+        "file": "src/bioetl/application/services/medallion_types.py",
+        "line": 55,
+        "usages": [
+          "src/bioetl/application/core/__init__.py",
+          "src/bioetl/application/services/medallion_lifecycle.py",
+          "tests/integration/test_runner_lifecycle.py",
+          "tests/unit/application/core/test_runner.py"
+        ]
+      },
+      {
+        "name": "MetricsServerStatus",
+        "file": "src/bioetl/application/services/metrics_service.py",
+        "line": 72,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "tests/unit/application/services/test_metrics_service.py"
+        ]
+      },
+      {
+        "name": "StartResult",
+        "file": "src/bioetl/application/services/metrics_service.py",
+        "line": 89,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "tests/unit/application/services/test_metrics_service.py"
+        ]
+      },
+      {
+        "name": "MetricsService",
+        "file": "src/bioetl/application/services/metrics_service.py",
+        "line": 106,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/composition/bootstrap/cli/__init__.py",
+          "src/bioetl/composition/bootstrap/cli/metrics.py",
+          "src/bioetl/composition/entrypoints.py",
+          "src/bioetl/infrastructure/observability/metrics_server_adapter.py",
+          "tests/unit/application/services/test_metrics_service.py"
+        ]
+      },
+      {
+        "name": "RunResult",
+        "file": "src/bioetl/application/services/pipeline_runner_service.py",
+        "line": 51,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/composition/entrypoints.py",
+          "src/bioetl/interfaces/cli/commands/run_all.py",
+          "tests/unit/application/services/test_pipeline_runner_service.py",
+          "tests/unit/composition/test_entrypoints.py",
+          "tests/unit/interfaces/test_cli.py",
+          "tests/unit/interfaces/test_cli_commands.py",
+          "tests/unit/interfaces/test_cli_run_all_vacuum_formatters.py",
+          "tests/unit/interfaces/test_run_all_command.py",
+          "tests/unit/interfaces/test_run_all_service_mock.py"
+        ]
+      },
+      {
+        "name": "RunOptions",
+        "file": "src/bioetl/application/services/pipeline_runner_service.py",
+        "line": 114,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/composition/bootstrap/runtime/assembly.py",
+          "src/bioetl/composition/bootstrap/runtime/composite.py",
+          "src/bioetl/composition/bootstrap/runtime/runner.py",
+          "src/bioetl/composition/entrypoints.py",
+          "src/bioetl/interfaces/cli/commands/run.py",
+          "src/bioetl/interfaces/cli/commands/run_all.py",
+          "tests/unit/application/services/test_pipeline_runner_service.py",
+          "tests/unit/composition/test_entrypoints.py",
+          "tests/unit/interfaces/test_cli.py",
+          "tests/unit/interfaces/test_cli_run_all_vacuum_formatters.py",
+          "tests/unit/interfaces/test_run_all_service_mock.py",
+          "tests/unit/test_cli.py"
+        ]
+      },
+      {
+        "name": "PipelineRunnerService",
+        "file": "src/bioetl/application/services/pipeline_runner_service.py",
+        "line": 168,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/composition/bootstrap/runtime/__init__.py",
+          "src/bioetl/composition/bootstrap/runtime/runner.py",
+          "src/bioetl/composition/entrypoints.py",
+          "src/bioetl/composition/factories/runner_factory.py",
+          "src/bioetl/interfaces/cli/commands/run.py",
+          "src/bioetl/interfaces/cli/commands/run_all.py",
+          "tests/architecture/test_layer_dependencies.py",
+          "tests/unit/application/services/test_pipeline_runner_service.py",
+          "tests/unit/composition/bootstrap/test_runner_bootstrap.py",
+          "tests/unit/composition/factories/test_runner_factory.py",
+          "tests/unit/interfaces/test_run_all_service_mock.py"
+        ]
+      },
+      {
+        "name": "QuarantineRecord",
+        "file": "src/bioetl/application/services/quarantine_service.py",
+        "line": 22,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "tests/unit/application/services/test_quarantine_service.py"
+        ]
+      },
+      {
+        "name": "QuarantineService",
+        "file": "src/bioetl/application/services/quarantine_service.py",
+        "line": 43,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/composition/bootstrap/cli/checkpoint.py",
+          "src/bioetl/composition/entrypoints.py",
+          "tests/architecture/test_interfaces_no_infrastructure.py",
+          "tests/unit/application/services/test_quarantine_service.py",
+          "tests/unit/composition/bootstrap/test_checkpoint_bootstrap.py"
+        ]
+      },
+      {
+        "name": "ShutdownService",
+        "file": "src/bioetl/application/services/shutdown_service.py",
+        "line": 38,
+        "usages": [
+          "src/bioetl/application/core/__init__.py",
+          "src/bioetl/application/core/shutdown.py",
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/domain/ports/shutdown.py",
+          "tests/unit/application/services/test_shutdown_service.py"
+        ]
+      },
+      {
+        "name": "TableVacuumResult",
+        "file": "src/bioetl/application/services/vacuum_service.py",
+        "line": 34,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/interfaces/cli/formatters.py",
+          "tests/integration/interfaces/test_cli_maintenance_vacuum.py",
+          "tests/unit/application/services/test_vacuum_service.py",
+          "tests/unit/interfaces/test_cli_run_all_vacuum_formatters.py",
+          "tests/unit/interfaces/test_vacuum_commands.py"
+        ]
+      },
+      {
+        "name": "VacuumAllResult",
+        "file": "src/bioetl/application/services/vacuum_service.py",
+        "line": 56,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/interfaces/cli/formatters.py",
+          "tests/integration/interfaces/test_cli_maintenance_vacuum.py",
+          "tests/unit/application/services/test_vacuum_service.py",
+          "tests/unit/interfaces/test_cli_run_all_vacuum_formatters.py",
+          "tests/unit/interfaces/test_vacuum_commands.py"
+        ]
+      },
+      {
+        "name": "VacuumService",
+        "file": "src/bioetl/application/services/vacuum_service.py",
+        "line": 86,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/composition/bootstrap/cli/storage.py",
+          "src/bioetl/composition/entrypoints.py",
+          "tests/unit/application/services/test_vacuum_service.py",
+          "tests/unit/composition/bootstrap/test_storage_bootstrap.py",
+          "tests/unit/interfaces/test_vacuum_commands.py"
+        ]
+      },
+      {
+        "name": "BatchRecord",
+        "file": "src/bioetl/domain/aggregates/batch.py",
+        "line": 55,
+        "usages": [
+          "src/bioetl/domain/aggregates/__init__.py",
+          "tests/architecture/test_aggregate_boundaries.py",
+          "tests/unit/domain/aggregates/test_batch.py"
+        ]
+      },
+      {
+        "name": "DomainEvent",
+        "file": "src/bioetl/domain/aggregates/events.py",
+        "line": 29,
+        "usages": [
+          "src/bioetl/domain/aggregates/batch.py",
+          "src/bioetl/domain/aggregates/pipeline_run.py",
+          "src/bioetl/domain/aggregates/quarantine_entry.py"
+        ]
+      },
+      {
+        "name": "PipelineStarted",
+        "file": "src/bioetl/domain/aggregates/events.py",
+        "line": 48,
+        "usages": []
+      },
+      {
+        "name": "PipelineCompleted",
+        "file": "src/bioetl/domain/aggregates/events.py",
+        "line": 60,
+        "usages": [
+          "src/bioetl/domain/aggregates/pipeline_run.py",
+          "tests/architecture/test_aggregate_boundaries.py",
+          "tests/unit/domain/aggregates/test_pipeline_run.py"
+        ]
+      },
+      {
+        "name": "PipelineFailed",
+        "file": "src/bioetl/domain/aggregates/events.py",
+        "line": 75,
+        "usages": [
+          "src/bioetl/domain/aggregates/pipeline_run.py",
+          "tests/architecture/test_aggregate_boundaries.py",
+          "tests/unit/domain/aggregates/test_pipeline_run.py"
+        ]
+      },
+      {
+        "name": "PipelineShutdown",
+        "file": "src/bioetl/domain/aggregates/events.py",
+        "line": 90,
+        "usages": [
+          "src/bioetl/domain/aggregates/pipeline_run.py",
+          "tests/unit/domain/aggregates/test_pipeline_run.py"
+        ]
+      },
+      {
+        "name": "StageCompleted",
+        "file": "src/bioetl/domain/aggregates/events.py",
+        "line": 103,
+        "usages": []
+      },
+      {
+        "name": "BatchCreated",
+        "file": "src/bioetl/domain/aggregates/events.py",
+        "line": 123,
+        "usages": [
+          "src/bioetl/domain/aggregates/batch.py",
+          "tests/architecture/test_aggregate_boundaries.py",
+          "tests/unit/domain/aggregates/test_batch.py"
+        ]
+      },
+      {
+        "name": "BatchSealed",
+        "file": "src/bioetl/domain/aggregates/events.py",
+        "line": 135,
+        "usages": [
+          "src/bioetl/domain/aggregates/batch.py",
+          "tests/architecture/test_aggregate_boundaries.py",
+          "tests/unit/domain/aggregates/test_batch.py"
+        ]
+      },
+      {
+        "name": "BatchWritten",
+        "file": "src/bioetl/domain/aggregates/events.py",
+        "line": 150,
+        "usages": [
+          "src/bioetl/domain/aggregates/batch.py",
+          "tests/architecture/test_aggregate_boundaries.py",
+          "tests/unit/domain/aggregates/test_batch.py"
+        ]
+      },
+      {
+        "name": "BatchFailed",
+        "file": "src/bioetl/domain/aggregates/events.py",
+        "line": 163,
+        "usages": [
+          "src/bioetl/domain/aggregates/batch.py"
+        ]
+      },
+      {
+        "name": "RecordQuarantined",
+        "file": "src/bioetl/domain/aggregates/events.py",
+        "line": 183,
+        "usages": [
+          "src/bioetl/domain/aggregates/batch.py",
+          "tests/unit/domain/aggregates/test_batch.py"
+        ]
+      },
+      {
+        "name": "QuarantineEntryCreated",
+        "file": "src/bioetl/domain/aggregates/events.py",
+        "line": 199,
+        "usages": [
+          "src/bioetl/domain/aggregates/quarantine_entry.py",
+          "tests/architecture/test_aggregate_boundaries.py",
+          "tests/unit/domain/aggregates/test_quarantine_entry.py"
+        ]
+      },
+      {
+        "name": "QuarantineEntryResolved",
+        "file": "src/bioetl/domain/aggregates/events.py",
+        "line": 214,
+        "usages": [
+          "src/bioetl/domain/aggregates/quarantine_entry.py",
+          "tests/architecture/test_aggregate_boundaries.py",
+          "tests/unit/domain/aggregates/test_quarantine_entry.py"
+        ]
+      },
+      {
+        "name": "DQThresholdExceeded",
+        "file": "src/bioetl/domain/aggregates/events.py",
+        "line": 233,
+        "usages": []
+      },
+      {
+        "name": "SchemaEvolutionDetected",
+        "file": "src/bioetl/domain/aggregates/events.py",
+        "line": 249,
+        "usages": []
+      },
+      {
+        "name": "StageResult",
+        "file": "src/bioetl/domain/aggregates/pipeline_run.py",
+        "line": 76,
+        "usages": [
+          "src/bioetl/domain/aggregates/__init__.py",
+          "tests/architecture/test_aggregate_boundaries.py",
+          "tests/unit/domain/aggregates/test_pipeline_run.py"
+        ]
+      },
+      {
+        "name": "ResolutionInfo",
+        "file": "src/bioetl/domain/aggregates/quarantine_entry.py",
+        "line": 63,
+        "usages": [
+          "tests/architecture/test_aggregate_boundaries.py",
+          "tests/unit/domain/aggregates/test_quarantine_entry.py"
+        ]
+      },
+      {
+        "name": "AggregationFieldSpec",
+        "file": "src/bioetl/domain/composite/aggregation.py",
+        "line": 100,
+        "usages": [
+          "src/bioetl/application/composite/aggregator.py",
+          "src/bioetl/domain/composite/config.py",
+          "src/bioetl/infrastructure/schemas/composite_config.py",
+          "tests/unit/application/composite/test_merger.py",
+          "tests/unit/domain/composite/test_composite_config.py"
+        ]
+      },
+      {
+        "name": "AggregationConfig",
+        "file": "src/bioetl/domain/composite/aggregation.py",
+        "line": 140,
+        "usages": [
+          "src/bioetl/application/composite/aggregator.py",
+          "src/bioetl/domain/composite/config.py",
+          "src/bioetl/infrastructure/schemas/composite_config.py",
+          "tests/unit/application/composite/test_merger.py",
+          "tests/unit/domain/composite/test_composite_config.py"
+        ]
+      },
+      {
+        "name": "SeedConfig",
+        "file": "src/bioetl/domain/composite/config.py",
+        "line": 52,
+        "usages": [
+          "src/bioetl/domain/composite/__init__.py",
+          "src/bioetl/infrastructure/schemas/composite_config.py",
+          "tests/integration/composite/test_molecule_pipeline.py",
+          "tests/unit/application/composite/test_composite_activity.py",
+          "tests/unit/application/composite/test_preflight_validator.py",
+          "tests/unit/application/composite/test_runner.py",
+          "tests/unit/application/composite/test_runner_checkpoint_resume.py",
+          "tests/unit/application/composite/test_runner_required_flag.py",
+          "tests/unit/domain/composite/test_composite_config.py"
+        ]
+      },
+      {
+        "name": "DependencyConfig",
+        "file": "src/bioetl/domain/composite/config.py",
+        "line": 92,
+        "usages": [
+          "src/bioetl/application/composite/dependency_coordinator.py",
+          "src/bioetl/application/composite/merger.py",
+          "src/bioetl/application/composite/runner_helpers.py",
+          "src/bioetl/domain/composite/__init__.py",
+          "src/bioetl/infrastructure/schemas/composite_config.py",
+          "tests/unit/application/composite/test_composite_activity.py",
+          "tests/unit/application/composite/test_dependency_coordinator.py"
+        ]
+      },
+      {
+        "name": "EnricherConfig",
+        "file": "src/bioetl/domain/composite/config.py",
+        "line": 175,
+        "usages": [
+          "src/bioetl/application/composite/coordinator.py",
+          "src/bioetl/application/composite/merger.py",
+          "src/bioetl/application/composite/runner.py",
+          "src/bioetl/application/composite/runner_helpers.py",
+          "src/bioetl/composition/bootstrap/runtime/composite.py",
+          "src/bioetl/domain/composite/__init__.py",
+          "src/bioetl/infrastructure/schemas/composite_config.py",
+          "tests/integration/composite/test_molecule_pipeline.py",
+          "tests/unit/application/composite/test_merger.py",
+          "tests/unit/application/composite/test_preflight_validator.py",
+          "tests/unit/domain/composite/test_composite_config.py"
+        ]
+      },
+      {
+        "name": "LayerColumnConfig",
+        "file": "src/bioetl/domain/composite/config.py",
+        "line": 290,
+        "usages": [
+          "src/bioetl/application/composite/column_orderer.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/architecture/test_domain_purity.py",
+          "tests/unit/application/composite/test_column_orderer_renames.py",
+          "tests/unit/domain/composite/test_data_schema_config.py"
+        ]
+      },
+      {
+        "name": "DataSchemaConfig",
+        "file": "src/bioetl/domain/composite/config.py",
+        "line": 366,
+        "usages": [
+          "src/bioetl/application/core/batch_writer.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/architecture/test_domain_purity.py",
+          "tests/unit/domain/composite/test_data_schema_config.py"
+        ]
+      },
+      {
+        "name": "ColumnGroupConfig",
+        "file": "src/bioetl/domain/composite/config.py",
+        "line": 445,
+        "usages": [
+          "src/bioetl/application/composite/column_orderer.py",
+          "src/bioetl/application/core/config.py",
+          "src/bioetl/composition/factories/services_factory.py",
+          "src/bioetl/domain/config.py",
+          "src/bioetl/infrastructure/config/_base.py",
+          "src/bioetl/infrastructure/schemas/composite_config.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/integration/composite/test_molecule_pipeline.py",
+          "tests/unit/application/composite/test_column_orderer.py",
+          "tests/unit/application/composite/test_column_orderer_renames.py",
+          "tests/unit/application/composite/test_publication_schema_columns.py",
+          "tests/unit/domain/composite/test_data_schema_config.py"
+        ]
+      },
+      {
+        "name": "MergeConfig",
+        "file": "src/bioetl/domain/composite/config.py",
+        "line": 498,
+        "usages": [
+          "src/bioetl/application/composite/merger.py",
+          "src/bioetl/domain/composite/__init__.py",
+          "src/bioetl/infrastructure/schemas/composite_config.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/integration/composite/test_molecule_pipeline.py",
+          "tests/unit/application/composite/test_coalesce_qualified.py",
+          "tests/unit/application/composite/test_merger.py",
+          "tests/unit/application/composite/test_preflight_validator.py",
+          "tests/unit/application/composite/test_runner.py",
+          "tests/unit/application/composite/test_runner_checkpoint_resume.py",
+          "tests/unit/application/composite/test_runner_required_flag.py",
+          "tests/unit/domain/composite/test_composite_config.py"
+        ]
+      },
+      {
+        "name": "DQOverrideConfig",
+        "file": "src/bioetl/domain/composite/config.py",
+        "line": 615,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/composite_config.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/architecture/test_domain_purity.py",
+          "tests/unit/domain/composite/test_composite_config.py"
+        ]
+      },
+      {
+        "name": "CompositeDQConfig",
+        "file": "src/bioetl/domain/composite/config.py",
+        "line": 637,
+        "usages": [
+          "src/bioetl/application/composite/coordinator.py",
+          "src/bioetl/infrastructure/schemas/composite_config.py",
+          "tests/unit/application/composite/test_coordinator_logging.py",
+          "tests/unit/application/composite/test_preflight_validator.py",
+          "tests/unit/domain/composite/test_composite_config.py"
+        ]
+      },
+      {
+        "name": "ExecutionConfig",
+        "file": "src/bioetl/domain/composite/config.py",
+        "line": 693,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/composite_config.py"
+        ]
+      },
+      {
+        "name": "LineageConfig",
+        "file": "src/bioetl/domain/composite/config.py",
+        "line": 726,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/composite_config.py"
+        ]
+      },
+      {
+        "name": "CompositeConfig",
+        "file": "src/bioetl/domain/composite/config.py",
+        "line": 741,
+        "usages": [
+          "src/bioetl/application/composite/fsm_helper.py",
+          "src/bioetl/application/composite/preflight_validator.py",
+          "src/bioetl/application/composite/runner.py",
+          "src/bioetl/composition/bootstrap/runtime/composite.py",
+          "src/bioetl/domain/composite/__init__.py",
+          "src/bioetl/infrastructure/schemas/composite_config.py",
+          "tests/architecture/test_domain_purity.py",
+          "tests/integration/composite/test_molecule_pipeline.py",
+          "tests/unit/application/composite/test_preflight_validator.py",
+          "tests/unit/application/composite/test_runner_enrichment_fsm.py",
+          "tests/unit/application/composite/test_runner_fsm_logging.py",
+          "tests/unit/domain/composite/test_composite_config.py"
+        ]
+      },
+      {
+        "name": "FieldMapping",
+        "file": "src/bioetl/domain/composite/field_groups.py",
+        "line": 47,
+        "usages": [
+          "src/bioetl/domain/composite/__init__.py",
+          "src/bioetl/infrastructure/config/field_group_loader.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/unit/domain/composite/test_field_groups.py"
+        ]
+      },
+      {
+        "name": "FieldGroupDefinition",
+        "file": "src/bioetl/domain/composite/field_groups.py",
+        "line": 112,
+        "usages": [
+          "src/bioetl/domain/composite/__init__.py",
+          "src/bioetl/infrastructure/config/field_group_loader.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/unit/domain/composite/test_field_groups.py"
+        ]
+      },
+      {
+        "name": "FieldSource",
+        "file": "src/bioetl/domain/composite/lineage.py",
+        "line": 14,
+        "usages": [
+          "src/bioetl/domain/composite/__init__.py",
+          "tests/unit/domain/composite/test_lineage.py"
+        ]
+      },
+      {
+        "name": "EnrichmentStatusRecord",
+        "file": "src/bioetl/domain/composite/lineage.py",
+        "line": 24,
+        "usages": [
+          "src/bioetl/domain/composite/__init__.py",
+          "tests/unit/domain/composite/test_lineage.py"
+        ]
+      },
+      {
+        "name": "LineageMetadata",
+        "file": "src/bioetl/domain/composite/lineage.py",
+        "line": 34,
+        "usages": [
+          "src/bioetl/composition/services/metadata_coordinator.py",
+          "src/bioetl/domain/composite/__init__.py",
+          "src/bioetl/domain/composite/result.py",
+          "src/bioetl/domain/models/__init__.py",
+          "src/bioetl/infrastructure/storage/metadata_builder.py",
+          "tests/unit/domain/composite/test_lineage.py",
+          "tests/unit/infrastructure/storage/test_metadata_writer.py",
+          "tests/unit/infrastructure/storage/test_silver_writer.py"
+        ]
+      },
+      {
+        "name": "EnrichmentResult",
+        "file": "src/bioetl/domain/composite/result.py",
+        "line": 29,
+        "usages": [
+          "src/bioetl/application/composite/checkpoint.py",
+          "src/bioetl/application/composite/coordinator.py",
+          "src/bioetl/application/composite/merger.py",
+          "src/bioetl/application/composite/runner.py",
+          "src/bioetl/application/composite/runner_helpers.py",
+          "src/bioetl/domain/composite/__init__.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/unit/application/composite/test_checkpoint.py",
+          "tests/unit/application/composite/test_fsm_pipeline_scenarios.py",
+          "tests/unit/application/composite/test_merger.py",
+          "tests/unit/application/composite/test_runner_checkpoint_resume.py",
+          "tests/unit/application/composite/test_runner_enrichment_fsm.py",
+          "tests/unit/application/composite/test_runner_fsm.py",
+          "tests/unit/application/composite/test_runner_fsm_logging.py",
+          "tests/unit/application/composite/test_runner_required_flag.py",
+          "tests/unit/application/composite/test_runner_robustness.py",
+          "tests/unit/domain/composite/test_composite_result.py",
+          "tests/unit/interfaces/cli/commands/test_run_composite.py"
+        ]
+      },
+      {
+        "name": "SeedResult",
+        "file": "src/bioetl/domain/composite/result.py",
+        "line": 165,
+        "usages": [
+          "src/bioetl/application/composite/checkpoint.py",
+          "src/bioetl/application/composite/runner.py",
+          "src/bioetl/domain/composite/__init__.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/unit/application/composite/test_checkpoint.py",
+          "tests/unit/application/composite/test_fsm_pipeline_scenarios.py",
+          "tests/unit/application/composite/test_runner.py",
+          "tests/unit/application/composite/test_runner_checkpoint_resume.py",
+          "tests/unit/application/composite/test_runner_fsm.py",
+          "tests/unit/application/composite/test_runner_robustness.py",
+          "tests/unit/domain/composite/test_composite_result.py",
+          "tests/unit/interfaces/cli/commands/test_run_composite.py"
+        ]
+      },
+      {
+        "name": "DependencyResult",
+        "file": "src/bioetl/domain/composite/result.py",
+        "line": 193,
+        "usages": [
+          "src/bioetl/application/composite/checkpoint.py",
+          "src/bioetl/application/composite/dependency_coordinator.py",
+          "src/bioetl/application/composite/merger.py",
+          "src/bioetl/application/composite/runner.py",
+          "src/bioetl/application/composite/runner_helpers.py",
+          "src/bioetl/domain/composite/__init__.py",
+          "tests/architecture/test_code_metrics.py"
+        ]
+      },
+      {
+        "name": "MergeResult",
+        "file": "src/bioetl/domain/composite/result.py",
+        "line": 280,
+        "usages": [
+          "src/bioetl/application/composite/merger.py",
+          "src/bioetl/application/composite/runner.py",
+          "src/bioetl/domain/composite/__init__.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/unit/application/composite/test_fsm_pipeline_scenarios.py",
+          "tests/unit/application/composite/test_runner.py",
+          "tests/unit/application/composite/test_runner_checkpoint_resume.py",
+          "tests/unit/application/composite/test_runner_enrichment_fsm.py",
+          "tests/unit/application/composite/test_runner_fsm.py",
+          "tests/unit/application/composite/test_runner_fsm_logging.py",
+          "tests/unit/application/composite/test_runner_required_flag.py",
+          "tests/unit/application/composite/test_runner_robustness.py",
+          "tests/unit/domain/composite/test_composite_result.py",
+          "tests/unit/interfaces/cli/commands/test_run_composite.py"
+        ]
+      },
+      {
+        "name": "CompositeResult",
+        "file": "src/bioetl/domain/composite/result.py",
+        "line": 308,
+        "usages": [
+          "src/bioetl/application/composite/runner.py",
+          "src/bioetl/domain/composite/__init__.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/unit/application/composite/test_fsm_pipeline_scenarios.py",
+          "tests/unit/domain/composite/test_composite_result.py",
+          "tests/unit/interfaces/cli/commands/test_run_composite.py"
+        ]
+      },
+      {
+        "name": "ValidationConfig",
+        "file": "src/bioetl/domain/config.py",
+        "line": 34,
+        "usages": [
+          "src/bioetl/application/pipelines/semanticscholar/extractors.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/validation.py",
+          "src/bioetl/domain/value_objects/chemical.py",
+          "tests/unit/domain/test_config.py",
+          "tests/unit/domain/value_objects/test_identifiers.py"
+        ]
+      },
+      {
+        "name": "FieldValidation",
+        "file": "src/bioetl/domain/config.py",
+        "line": 119,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/dq_config.py",
+          "src/bioetl/infrastructure/schemas/pipeline_config.py"
+        ]
+      },
+      {
+        "name": "CrossFieldValidation",
+        "file": "src/bioetl/domain/config.py",
+        "line": 163,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/dq_config.py",
+          "src/bioetl/infrastructure/schemas/pipeline_config.py"
+        ]
+      },
+      {
+        "name": "ConditionalValidation",
+        "file": "src/bioetl/domain/config.py",
+        "line": 198,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/dq_config.py",
+          "src/bioetl/infrastructure/schemas/pipeline_config.py"
+        ]
+      },
+      {
+        "name": "DQReportConfig",
+        "file": "src/bioetl/domain/config.py",
+        "line": 226,
+        "usages": [
+          "src/bioetl/infrastructure/schemas/dq_config.py",
+          "tests/unit/infrastructure/schemas/test_dq_config.py"
+        ]
+      },
+      {
+        "name": "DQConfig",
+        "file": "src/bioetl/domain/config.py",
+        "line": 245,
+        "usages": [
+          "src/bioetl/application/core/config.py",
+          "src/bioetl/application/services/data_quality_service.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/composite/config.py",
+          "src/bioetl/infrastructure/config/_base.py",
+          "src/bioetl/infrastructure/config/dq_config_loader.py",
+          "src/bioetl/infrastructure/config/pipeline_config_loader.py",
+          "src/bioetl/infrastructure/schemas/base_schemas.py",
+          "src/bioetl/infrastructure/schemas/dq_config.py",
+          "tests/e2e/test_pipeline_with_dq_errors_e2e.py",
+          "tests/integration/test_dq_monitor_integration.py",
+          "tests/smoke/test_smoke.py",
+          "tests/unit/application/composite/test_runner.py",
+          "tests/unit/application/composite/test_runner_checkpoint_resume.py",
+          "tests/unit/application/composite/test_runner_required_flag.py",
+          "tests/unit/application/core/test_batch_transformer.py",
+          "tests/unit/application/core/test_run_id_propagation.py",
+          "tests/unit/application/services/test_data_quality_service.py",
+          "tests/unit/domain/configs/test_base_configs.py",
+          "tests/unit/domain/test_config.py",
+          "tests/unit/domain/test_config_validation.py",
+          "tests/unit/domain/test_pipeline_config.py",
+          "tests/unit/infrastructure/test_config.py",
+          "tests/unit/infrastructure/test_config_settings.py"
+        ]
+      },
+      {
+        "name": "TableConfig",
+        "file": "src/bioetl/domain/config.py",
+        "line": 350,
+        "usages": [
+          "src/bioetl/application/core/config.py",
+          "src/bioetl/composition/factories/services_factory.py",
+          "src/bioetl/domain/__init__.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/architecture/test_domain_purity.py",
+          "tests/architecture/test_write_mode_types.py",
+          "tests/e2e/test_pipeline_with_schema_drift_e2e.py",
+          "tests/unit/application/core/test_batch_executor.py",
+          "tests/unit/application/core/test_batch_executor_memory.py",
+          "tests/unit/application/core/test_batch_writer.py",
+          "tests/unit/application/core/test_record_processor.py",
+          "tests/unit/application/core/test_run_id_propagation.py",
+          "tests/unit/domain/test_config.py"
+        ]
+      },
+      {
+        "name": "PipelineConfig",
+        "file": "src/bioetl/domain/config.py",
+        "line": 390,
+        "usages": [
+          "src/bioetl/application/core/__init__.py",
+          "src/bioetl/application/core/base.py",
+          "src/bioetl/application/core/postrun_service.py",
+          "src/bioetl/application/core/preflight_service.py",
+          "src/bioetl/application/core/runner.py",
+          "src/bioetl/application/services/config_service.py",
+          "src/bioetl/application/services/medallion_lifecycle.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/infrastructure/config/_base.py",
+          "src/bioetl/infrastructure/config/pipeline_config_loader.py",
+          "src/bioetl/infrastructure/schemas/pipeline_config.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/architecture/test_config_golden_master.py",
+          "tests/architecture/test_domain_purity.py",
+          "tests/architecture/test_layer_dependencies.py",
+          "tests/architecture/test_write_mode_types.py",
+          "tests/integration/test_pubchem_pipeline.py",
+          "tests/integration/test_runner_lifecycle.py",
+          "tests/integration/test_uniprot_pipeline.py",
+          "tests/unit/application/core/test_checkpoint_manager.py",
+          "tests/unit/application/core/test_dq_report_integration.py",
+          "tests/unit/application/core/test_postrun_service.py",
+          "tests/unit/application/core/test_preflight_service.py",
+          "tests/unit/application/core/test_runner.py",
+          "tests/unit/application/pipelines/test_chembl_pipelines.py",
+          "tests/unit/application/services/test_medallion_lifecycle.py",
+          "tests/unit/application/test_base_pipeline.py",
+          "tests/unit/application/test_pipeline_config.py",
+          "tests/unit/domain/test_config_validation.py",
+          "tests/unit/domain/test_pipeline_config.py",
+          "tests/unit/infrastructure/test_config.py",
+          "tests/unit/infrastructure/test_config_dynamic.py",
+          "tests/unit/infrastructure/test_config_settings.py",
+          "tests/unit/interfaces/test_cli_commands.py",
+          "tests/unit/pipelines/chembl/test_activity_schema_gap.py",
+          "tests/unit/pipelines/test_chembl_ddd.py"
+        ]
+      },
+      {
+        "name": "RuntimeConfig",
+        "file": "src/bioetl/domain/config.py",
+        "line": 534,
+        "usages": [
+          "src/bioetl/application/core/__init__.py",
+          "src/bioetl/application/core/base.py",
+          "src/bioetl/application/core/postrun_service.py",
+          "src/bioetl/application/core/preflight_service.py",
+          "src/bioetl/application/core/runner.py",
+          "src/bioetl/application/services/medallion_lifecycle.py",
+          "src/bioetl/composition/bootstrap/runtime/assembly.py",
+          "src/bioetl/composition/factories/pipeline_factory.py",
+          "src/bioetl/composition/registry.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/infrastructure/config/_base.py",
+          "tests/architecture/test_tracing_enforcement.py",
+          "tests/integration/pipelines/base.py",
+          "tests/integration/pipelines/test_chembl_activity.py",
+          "tests/integration/pipelines/test_chembl_compound_record.py",
+          "tests/integration/test_pubchem_pipeline.py",
+          "tests/integration/test_runner_lifecycle.py",
+          "tests/integration/test_uniprot_pipeline.py",
+          "tests/smoke/test_smoke.py",
+          "tests/unit/application/core/test_dq_report_integration.py",
+          "tests/unit/application/core/test_postrun_service.py",
+          "tests/unit/application/core/test_preflight_service.py",
+          "tests/unit/application/core/test_runner.py",
+          "tests/unit/application/pipelines/test_chembl_activity_unit.py",
+          "tests/unit/application/pipelines/test_chembl_pipelines.py",
+          "tests/unit/application/services/test_medallion_lifecycle.py",
+          "tests/unit/application/test_base_pipeline.py",
+          "tests/unit/application/test_pipeline_config.py",
+          "tests/unit/composition/bootstrap/runtime/test_assembly.py",
+          "tests/unit/domain/test_runtime_config.py",
+          "tests/unit/pipelines/chembl/test_activity_schema_gap.py",
+          "tests/unit/pipelines/test_chembl_ddd.py",
+          "tests/unit/test_bootstrap.py"
+        ]
+      },
+      {
+        "name": "MemoryConfig",
+        "file": "src/bioetl/domain/config.py",
+        "line": 615,
+        "usages": [
+          "src/bioetl/application/core/__init__.py",
+          "src/bioetl/application/core/batch_executor.py",
+          "src/bioetl/application/core/config.py",
+          "src/bioetl/composition/factories/services_factory.py",
+          "src/bioetl/infrastructure/system/memory_monitor.py",
+          "tests/architecture/test_port_contracts.py",
+          "tests/architecture/test_port_contracts_hypothesis.py",
+          "tests/benchmarks/test_baseline_assertions.py",
+          "tests/e2e/test_resilience_scenarios_e2e.py",
+          "tests/unit/application/core/test_batch_executor_memory.py",
+          "tests/unit/application/core/test_memory_monitor.py",
+          "tests/unit/application/core/test_streaming_batch.py"
+        ]
+      },
+      {
+        "name": "RateLimitConfig",
+        "file": "src/bioetl/domain/configs/base.py",
+        "line": 20,
+        "usages": [
+          "src/bioetl/composition/bootstrap_contexts.py",
+          "src/bioetl/composition/providers/registration.py",
+          "src/bioetl/composition/types.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/configs/__init__.py",
+          "src/bioetl/infrastructure/schemas/base_schemas.py",
+          "src/bioetl/infrastructure/schemas/pipeline_config.py",
+          "tests/unit/composition/test_types.py",
+          "tests/unit/domain/configs/test_base_configs.py"
+        ]
+      },
+      {
+        "name": "BaseClientConfig",
+        "file": "src/bioetl/domain/configs/base.py",
+        "line": 56,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/configs/__init__.py",
+          "src/bioetl/infrastructure/schemas/__init__.py",
+          "src/bioetl/infrastructure/schemas/pipeline_config.py",
+          "src/bioetl/infrastructure/schemas/source_config.py",
+          "tests/architecture/test_domain_public_api.py",
+          "tests/unit/domain/configs/test_base_configs.py",
+          "tests/unit/infrastructure/schemas/test_base_schemas.py"
+        ]
+      },
+      {
+        "name": "BaseProviderConfig",
+        "file": "src/bioetl/domain/configs/base.py",
+        "line": 91,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/configs/__init__.py",
+          "tests/architecture/test_domain_public_api.py",
+          "tests/unit/domain/configs/test_base_configs.py"
+        ]
+      },
+      {
+        "name": "CachedBronzeContext",
+        "file": "src/bioetl/domain/context.py",
+        "line": 27,
+        "usages": [
+          "src/bioetl/application/services/pipeline_runner_service.py",
+          "src/bioetl/composition/bootstrap/runtime/assembly.py",
+          "src/bioetl/composition/factories/pipeline_factory.py"
+        ]
+      },
+      {
+        "name": "InputFilterContext",
+        "file": "src/bioetl/domain/context.py",
+        "line": 105,
+        "usages": [
+          "src/bioetl/application/services/pipeline_runner_service.py",
+          "src/bioetl/composition/entrypoints.py",
+          "tests/e2e/conftest.py",
+          "tests/unit/composition/bootstrap/runtime/test_assembly.py"
+        ]
+      },
+      {
+        "name": "VacuumConfig",
+        "file": "src/bioetl/domain/context.py",
+        "line": 199,
+        "usages": [
+          "src/bioetl/application/services/pipeline_runner_service.py",
+          "src/bioetl/composition/bootstrap/runtime/assembly.py",
+          "src/bioetl/composition/entrypoints.py",
+          "tests/e2e/test_advanced_scenarios_e2e.py",
+          "tests/unit/composition/bootstrap/runtime/test_assembly.py",
+          "tests/unit/test_bootstrap.py"
+        ]
+      },
+      {
+        "name": "PipelineContext",
+        "file": "src/bioetl/domain/context.py",
+        "line": 222,
+        "usages": [
+          "src/bioetl/application/core/base.py",
+          "src/bioetl/application/core/base_transformer.py",
+          "src/bioetl/application/core/batch_executor.py",
+          "src/bioetl/application/core/batch_tracing.py",
+          "src/bioetl/application/core/batch_transformer.py",
+          "src/bioetl/application/core/batch_writer.py",
+          "src/bioetl/application/core/preflight_service.py",
+          "src/bioetl/application/core/protocols.py",
+          "src/bioetl/application/core/record_processor.py",
+          "src/bioetl/application/core/runner.py",
+          "src/bioetl/application/pipelines/chembl/base_chembl_transformer.py",
+          "src/bioetl/application/pipelines/chembl/publication_term_transformer.py",
+          "src/bioetl/application/pipelines/chembl/subcellular_fraction_transformer.py",
+          "src/bioetl/application/pipelines/common/base_publication_transformer.py",
+          "src/bioetl/application/pipelines/crossref/transformer.py",
+          "src/bioetl/application/pipelines/pubchem/transformer.py",
+          "src/bioetl/application/pipelines/pubmed/transformer.py",
+          "src/bioetl/application/pipelines/uniprot/idmapping_transformer.py",
+          "src/bioetl/application/pipelines/uniprot/transformer.py",
+          "src/bioetl/composition/factories/services_factory.py",
+          "src/bioetl/domain/__init__.py",
+          "src/tools/create_pipeline.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/architecture/test_domain_public_api.py",
+          "tests/architecture/test_no_datetime_now_in_infrastructure.py",
+          "tests/e2e/test_network_failure_e2e.py",
+          "tests/e2e/test_pipeline_with_dq_errors_e2e.py",
+          "tests/e2e/test_run_types_e2e.py",
+          "tests/integration/pipelines/test_crossref_date_normalization.py",
+          "tests/integration/pipelines/test_pubmed_date_normalization.py",
+          "tests/integration/test_cross_provider_doi_normalization.py",
+          "tests/integration/test_pubchem_pipeline.py",
+          "tests/integration/test_runner_lifecycle.py",
+          "tests/integration/test_uniprot_pipeline.py",
+          "tests/unit/application/core/test_base_transformer.py",
+          "tests/unit/application/core/test_batch_executor.py",
+          "tests/unit/application/core/test_batch_executor_memory.py",
+          "tests/unit/application/core/test_batch_transformer.py",
+          "tests/unit/application/core/test_batch_writer.py",
+          "tests/unit/application/core/test_preflight_service.py",
+          "tests/unit/application/core/test_protocols.py",
+          "tests/unit/application/core/test_record_processor.py",
+          "tests/unit/application/core/test_record_processor_metrics.py",
+          "tests/unit/application/core/test_run_id_propagation.py",
+          "tests/unit/application/core/test_runner.py",
+          "tests/unit/application/core/test_streaming_batch.py",
+          "tests/unit/application/pipelines/chembl/test_subcellular_fraction_transformer.py",
+          "tests/unit/application/pipelines/common/test_base_publication_transformer.py",
+          "tests/unit/application/pipelines/crossref/test_crossref_transformer.py",
+          "tests/unit/application/pipelines/openalex/test_transformer.py",
+          "tests/unit/application/pipelines/pubmed/test_pubmed_transformer.py",
+          "tests/unit/application/pipelines/semanticscholar/test_transformer.py",
+          "tests/unit/application/pipelines/test_activity_transformer.py",
+          "tests/unit/application/pipelines/test_cell_line_transformer.py",
+          "tests/unit/application/pipelines/test_chembl_activity_unit.py",
+          "tests/unit/application/pipelines/test_chembl_assay_parameters.py",
+          "tests/unit/application/pipelines/test_chembl_transformers.py",
+          "tests/unit/application/pipelines/test_compound_record_transformer.py",
+          "tests/unit/application/pipelines/test_idmapping_transformer.py",
+          "tests/unit/application/pipelines/test_protein_class_transformer.py",
+          "tests/unit/application/pipelines/test_pubchem_transformer.py",
+          "tests/unit/application/pipelines/test_publication_similarity_transformer.py",
+          "tests/unit/application/pipelines/test_transformations.py",
+          "tests/unit/application/pipelines/test_transformer_snapshots.py",
+          "tests/unit/application/pipelines/test_uniprot_transformer.py",
+          "tests/unit/application/test_base_pipeline.py",
+          "tests/unit/pipelines/chembl/test_activity_schema_gap.py",
+          "tests/unit/pipelines/pubmed/test_pubmed_publication.py",
+          "tests/unit/pipelines/pubmed/test_pubmed_transformer.py",
+          "tests/unit/pipelines/test_chembl_ddd.py",
+          "tests/unit/test_context.py"
+        ]
+      },
+      {
+        "name": "PipelineRunContext",
+        "file": "src/bioetl/domain/context.py",
+        "line": 276,
+        "usages": [
+          "src/bioetl/application/services/pipeline_runner_service.py",
+          "src/bioetl/composition/bootstrap/runtime/assembly.py",
+          "src/bioetl/composition/bootstrap/runtime/pipeline.py",
+          "src/bioetl/composition/entrypoints.py",
+          "src/bioetl/composition/factories/runner_factory.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/metadata_coordinator.py",
+          "src/bioetl/domain/ports/runner.py",
+          "tests/architecture/test_domain_public_api.py",
+          "tests/e2e/conftest.py",
+          "tests/e2e/test_advanced_scenarios_e2e.py",
+          "tests/unit/application/services/test_pipeline_runner_service.py",
+          "tests/unit/composition/bootstrap/runtime/test_assembly.py",
+          "tests/unit/composition/factories/test_runner_factory.py",
+          "tests/unit/test_bootstrap.py"
+        ]
+      },
+      {
+        "name": "BaseEntity",
+        "file": "src/bioetl/domain/entities/base.py",
+        "line": 30,
+        "usages": [
+          "src/bioetl/application/core/base_transformer.py",
+          "src/bioetl/application/pipelines/chembl/base_chembl_transformer.py",
+          "src/bioetl/application/pipelines/common/base_publication_transformer.py",
+          "src/bioetl/application/pipelines/pubmed/transformer.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "src/bioetl/domain/entities/bioactivity.py",
+          "src/bioetl/domain/entities/chembl_activity.py",
+          "src/bioetl/domain/entities/chembl_assay_parameters.py",
+          "src/bioetl/domain/entities/chembl_compound_record.py",
+          "src/bioetl/domain/entities/chembl_structures.py",
+          "src/bioetl/domain/entities/chembl_subcellular_fraction.py",
+          "src/bioetl/domain/entities/chembl_tissue.py",
+          "src/bioetl/domain/entities/pubchem.py",
+          "src/bioetl/domain/entities/publication_base.py",
+          "src/bioetl/domain/entities/uniprot.py",
+          "src/tools/verify_schema_parity.py",
+          "tests/test_architecture.py",
+          "tests/unit/application/pipelines/common/test_base_publication_transformer.py",
+          "tests/unit/domain/test_entities.py"
+        ]
+      },
+      {
+        "name": "Bioactivity",
+        "file": "src/bioetl/domain/entities/bioactivity.py",
+        "line": 72,
+        "usages": [
+          "src/bioetl/__init__.py",
+          "src/bioetl/application/pipelines/chembl/activity.py",
+          "src/bioetl/application/pipelines/chembl/activity_transformer.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "src/bioetl/domain/entities/chembl.py",
+          "src/bioetl/domain/entities/chembl_activity.py",
+          "src/bioetl/domain/value_objects/activity.py",
+          "src/bioetl/infrastructure/adapters/pubchem/models.py",
+          "src/bioetl/interfaces/cli/main.py",
+          "src/tools/verify_schema_parity.py",
+          "tests/test_architecture.py",
+          "tests/unit/application/core/test_base_transformer.py",
+          "tests/unit/application/core/test_filtered_data_source.py",
+          "tests/unit/domain/test_entities.py",
+          "tests/unit/interfaces/test_cli.py"
+        ]
+      },
+      {
+        "name": "Assay",
+        "file": "src/bioetl/domain/entities/chembl_activity.py",
+        "line": 29,
+        "usages": [
+          "src/bioetl/application/core/subcellular_fraction_data_source.py",
+          "src/bioetl/application/pipelines/chembl/assay.py",
+          "src/bioetl/application/pipelines/chembl/assay_parameters.py",
+          "src/bioetl/application/pipelines/chembl/assay_transformer.py",
+          "src/bioetl/application/pipelines/chembl/cell_line.py",
+          "src/bioetl/application/pipelines/chembl/cell_line_transformer.py",
+          "src/bioetl/application/pipelines/chembl/subcellular_fraction.py",
+          "src/bioetl/application/pipelines/chembl/subcellular_fraction_transformer.py",
+          "src/bioetl/application/pipelines/chembl/tissue.py",
+          "src/bioetl/application/pipelines/chembl/tissue_transformer.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/contracts/__init__.py",
+          "src/bioetl/domain/contracts/gold/chembl.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "src/bioetl/domain/entities/bioactivity.py",
+          "src/bioetl/domain/entities/chembl.py",
+          "src/bioetl/domain/entities/chembl_assay_parameters.py",
+          "src/bioetl/domain/entities/chembl_structures.py",
+          "src/bioetl/domain/entities/chembl_subcellular_fraction.py",
+          "src/bioetl/domain/entities/chembl_tissue.py",
+          "src/bioetl/domain/schemas/__init__.py",
+          "src/bioetl/domain/schemas/chembl/assay.py",
+          "src/bioetl/domain/schemas/chembl/assay_parameters.py",
+          "src/bioetl/domain/schemas/chembl/cell_line.py",
+          "src/bioetl/domain/schemas/constants.py",
+          "src/bioetl/domain/value_objects/compound_ids.py",
+          "src/bioetl/infrastructure/adapters/chembl/models.py",
+          "src/bioetl/infrastructure/adapters/pubchem/models.py",
+          "src/bioetl/infrastructure/schemas/silver.py",
+          "src/tools/verify_schema_parity.py",
+          "tests/contract/test_pubchem_contract.py",
+          "tests/e2e/test_chembl_assay_e2e.py",
+          "tests/e2e/test_full_pipeline_chain_e2e.py",
+          "tests/infrastructure/adapters/test_pubchem.py",
+          "tests/unit/application/pipelines/chembl/test_subcellular_fraction_transformer.py",
+          "tests/unit/application/pipelines/test_chembl_pipelines.py",
+          "tests/unit/application/pipelines/test_chembl_transformers.py",
+          "tests/unit/pipelines/chembl/test_activity_schema_gap.py"
+        ]
+      },
+      {
+        "name": "AssayParameters",
+        "file": "src/bioetl/domain/entities/chembl_assay_parameters.py",
+        "line": 15,
+        "usages": [
+          "src/bioetl/application/pipelines/chembl/assay_parameters_transformer.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/contracts/gold/chembl.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "src/bioetl/domain/schemas/chembl/assay_parameters.py",
+          "src/bioetl/infrastructure/schemas/silver.py",
+          "tests/unit/application/pipelines/test_chembl_assay_parameters.py"
+        ]
+      },
+      {
+        "name": "CompoundRecord",
+        "file": "src/bioetl/domain/entities/chembl_compound_record.py",
+        "line": 14,
+        "usages": [
+          "src/bioetl/application/pipelines/chembl/compound_record_transformer.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/contracts/gold/chembl.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "tests/unit/application/composite/test_composite_activity.py"
+        ]
+      },
+      {
+        "name": "ChemblPublication",
+        "file": "src/bioetl/domain/entities/chembl_structures.py",
+        "line": 16,
+        "usages": [
+          "src/bioetl/application/core/base_transformer.py",
+          "src/bioetl/application/pipelines/chembl/publication_transformer.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/entities/__init__.py"
+        ]
+      },
+      {
+        "name": "DocumentTerm",
+        "file": "src/bioetl/domain/entities/chembl_structures.py",
+        "line": 51,
+        "usages": [
+          "src/bioetl/application/pipelines/chembl/publication_term_transformer.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/contracts/gold/chembl.py",
+          "src/bioetl/domain/entities/__init__.py"
+        ]
+      },
+      {
+        "name": "Target",
+        "file": "src/bioetl/domain/entities/chembl_structures.py",
+        "line": 92,
+        "usages": [
+          "src/bioetl/application/composite/fsm_helper.py",
+          "src/bioetl/application/core/field_specs.py",
+          "src/bioetl/application/core/idmapping_data_source.py",
+          "src/bioetl/application/core/publication_term_data_source.py",
+          "src/bioetl/application/core/subcellular_fraction_data_source.py",
+          "src/bioetl/application/pipelines/chembl/target.py",
+          "src/bioetl/application/pipelines/chembl/target_component.py",
+          "src/bioetl/application/pipelines/chembl/target_component_transformer.py",
+          "src/bioetl/application/pipelines/chembl/target_transformer.py",
+          "src/bioetl/application/pipelines/uniprot/transformer.py",
+          "src/bioetl/composition/factories/pipeline_factories.py",
+          "src/bioetl/composition/factories/storage_adapter.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/composite/config.py",
+          "src/bioetl/domain/contracts/__init__.py",
+          "src/bioetl/domain/contracts/gold/chembl.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "src/bioetl/domain/entities/bioactivity.py",
+          "src/bioetl/domain/entities/chembl.py",
+          "src/bioetl/domain/medallion.py",
+          "src/bioetl/domain/models/metadata.py",
+          "src/bioetl/domain/ports/audit.py",
+          "src/bioetl/domain/ports/idmapping.py",
+          "src/bioetl/domain/ports/normalization.py",
+          "src/bioetl/domain/ports/storage.py",
+          "src/bioetl/domain/schemas/__init__.py",
+          "src/bioetl/domain/schemas/chembl/activity.py",
+          "src/bioetl/domain/schemas/chembl/assay.py",
+          "src/bioetl/domain/schemas/chembl/target.py",
+          "src/bioetl/domain/schemas/chembl/target_component.py",
+          "src/bioetl/domain/schemas/chembl/target_relation.py",
+          "src/bioetl/domain/schemas/constants.py",
+          "src/bioetl/domain/schemas/crossref/reference.py",
+          "src/bioetl/domain/schemas/uniprot/protein.py",
+          "src/bioetl/domain/services/unit_converter.py",
+          "src/bioetl/domain/value_objects/activity.py",
+          "src/bioetl/domain/value_objects/activity_values.py",
+          "src/bioetl/domain/value_objects/publication_field_groups.py",
+          "src/bioetl/infrastructure/adapters/chembl/models.py",
+          "src/bioetl/infrastructure/adapters/pubchem/models.py",
+          "src/bioetl/infrastructure/adapters/uniprot/idmapping_client.py",
+          "src/bioetl/infrastructure/export/csv_exporter.py",
+          "src/bioetl/infrastructure/export/dq_report_writer.py",
+          "src/bioetl/infrastructure/schemas/pipeline_config.py",
+          "src/bioetl/infrastructure/schemas/silver.py",
+          "src/bioetl/infrastructure/storage/gold_writer.py",
+          "src/bioetl/infrastructure/storage/retention_manager.py",
+          "src/bioetl/infrastructure/storage/silver_writer.py",
+          "src/tools/scripts/migrations/rename_structure_fields.py",
+          "src/tools/verify_schema_parity.py",
+          "tests/e2e/test_advanced_scenarios_e2e.py",
+          "tests/e2e/test_chembl_target_e2e.py",
+          "tests/e2e/test_full_pipeline_chain_e2e.py",
+          "tests/infrastructure/adapters/test_pubchem.py",
+          "tests/integration/pipelines/test_chembl_target_component.py",
+          "tests/unit/application/core/test_idmapping_data_source.py",
+          "tests/unit/application/pipelines/test_chembl_pipelines.py",
+          "tests/unit/application/pipelines/test_chembl_transformers.py",
+          "tests/unit/infrastructure/adapters/chembl/test_chembl_client.py",
+          "tests/unit/infrastructure/storage/test_atomic.py"
+        ]
+      },
+      {
+        "name": "TargetComponent",
+        "file": "src/bioetl/domain/entities/chembl_structures.py",
+        "line": 138,
+        "usages": [
+          "src/bioetl/application/pipelines/chembl/target_component_transformer.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/contracts/gold/chembl.py",
+          "src/bioetl/domain/entities/__init__.py"
+        ]
+      },
+      {
+        "name": "CellLine",
+        "file": "src/bioetl/domain/entities/chembl_structures.py",
+        "line": 177,
+        "usages": [
+          "src/bioetl/application/pipelines/chembl/cell_line_transformer.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/contracts/gold/chembl.py",
+          "src/bioetl/domain/entities/__init__.py"
+        ]
+      },
+      {
+        "name": "Molecule",
+        "file": "src/bioetl/domain/entities/chembl_structures.py",
+        "line": 230,
+        "usages": [
+          "src/bioetl/application/pipelines/chembl/molecule.py",
+          "src/bioetl/application/pipelines/chembl/molecule_transformer.py",
+          "src/bioetl/application/pipelines/pubchem/transformer.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/contracts/__init__.py",
+          "src/bioetl/domain/contracts/gold/chembl.py",
+          "src/bioetl/domain/contracts/gold/composite.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "src/bioetl/domain/entities/bioactivity.py",
+          "src/bioetl/domain/entities/chembl.py",
+          "src/bioetl/domain/entities/pubchem.py",
+          "src/bioetl/domain/schemas/__init__.py",
+          "src/bioetl/domain/schemas/chembl/compound_record.py",
+          "src/bioetl/domain/schemas/chembl/molecule.py",
+          "src/bioetl/domain/schemas/chembl/molecule_form.py",
+          "src/bioetl/domain/schemas/constants.py",
+          "src/bioetl/domain/schemas/pubchem/compound.py",
+          "src/bioetl/infrastructure/adapters/chembl/models.py",
+          "src/bioetl/infrastructure/adapters/pubchem/models.py",
+          "src/bioetl/infrastructure/adapters/uniprot/models.py",
+          "src/bioetl/infrastructure/schemas/silver.py",
+          "src/tools/verify_schema_parity.py",
+          "tests/benchmarks/test_performance.py",
+          "tests/e2e/test_chembl_molecule_e2e.py",
+          "tests/e2e/test_full_pipeline_chain_e2e.py",
+          "tests/unit/application/pipelines/test_chembl_pipelines.py",
+          "tests/unit/application/pipelines/test_chembl_transformers.py"
+        ]
+      },
+      {
+        "name": "DocumentSimilarity",
+        "file": "src/bioetl/domain/entities/chembl_structures.py",
+        "line": 330,
+        "usages": [
+          "src/bioetl/application/pipelines/chembl/publication_similarity_transformer.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/contracts/gold/chembl.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "tests/unit/application/pipelines/test_publication_similarity_transformer.py",
+          "tests/unit/domain/test_entities.py"
+        ]
+      },
+      {
+        "name": "ProteinClassification",
+        "file": "src/bioetl/domain/entities/chembl_structures.py",
+        "line": 378,
+        "usages": [
+          "src/bioetl/application/pipelines/chembl/protein_class_transformer.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "tests/unit/application/pipelines/test_protein_class_transformer.py",
+          "tests/unit/domain/test_entities.py"
+        ]
+      },
+      {
+        "name": "SubcellularFraction",
+        "file": "src/bioetl/domain/entities/chembl_subcellular_fraction.py",
+        "line": 17,
+        "usages": [
+          "src/bioetl/application/pipelines/chembl/subcellular_fraction_transformer.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "tests/architecture/test_code_metrics.py"
+        ]
+      },
+      {
+        "name": "Tissue",
+        "file": "src/bioetl/domain/entities/chembl_tissue.py",
+        "line": 15,
+        "usages": [
+          "src/bioetl/application/pipelines/chembl/tissue.py",
+          "src/bioetl/application/pipelines/chembl/tissue_transformer.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/contracts/gold/chembl.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "src/bioetl/domain/entities/chembl.py",
+          "src/bioetl/domain/schemas/chembl/assay.py",
+          "src/bioetl/domain/schemas/uniprot/protein.py",
+          "src/bioetl/infrastructure/adapters/chembl/models.py",
+          "src/bioetl/infrastructure/schemas/silver.py",
+          "tests/unit/application/pipelines/chembl/test_tissue_transformer.py",
+          "tests/unit/domain/entities/test_tissue.py"
+        ]
+      },
+      {
+        "name": "CrossRefPublicationEntity",
+        "file": "src/bioetl/domain/entities/crossref.py",
+        "line": 184,
+        "usages": [
+          "src/bioetl/application/pipelines/crossref/transformer.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "src/bioetl/domain/entities/publication_base.py",
+          "tests/unit/domain/test_entities.py"
+        ]
+      },
+      {
+        "name": "OpenAlexPublicationEntity",
+        "file": "src/bioetl/domain/entities/openalex.py",
+        "line": 205,
+        "usages": [
+          "src/bioetl/application/pipelines/common/base_publication_transformer.py",
+          "src/bioetl/application/pipelines/openalex/transformer.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "src/bioetl/domain/entities/publication_base.py"
+        ]
+      },
+      {
+        "name": "PubchemMolecule",
+        "file": "src/bioetl/domain/entities/pubchem.py",
+        "line": 185,
+        "usages": [
+          "src/bioetl/application/pipelines/pubchem/transformer.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/contracts/gold/pubchem.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "src/bioetl/infrastructure/schemas/silver.py",
+          "tests/test_architecture.py",
+          "tests/unit/domain/test_entities.py"
+        ]
+      },
+      {
+        "name": "PublicationEntityBase",
+        "file": "src/bioetl/domain/entities/publication_base.py",
+        "line": 31,
+        "usages": [
+          "src/bioetl/application/core/base_transformer.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "src/bioetl/domain/entities/chembl_structures.py",
+          "src/bioetl/domain/entities/crossref.py",
+          "src/bioetl/domain/entities/openalex.py",
+          "src/bioetl/domain/entities/pubmed.py",
+          "src/bioetl/domain/entities/semanticscholar.py"
+        ]
+      },
+      {
+        "name": "PubMedPublicationEntity",
+        "file": "src/bioetl/domain/entities/pubmed.py",
+        "line": 134,
+        "usages": [
+          "src/bioetl/application/pipelines/pubmed/transformer.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "src/bioetl/domain/entities/publication_base.py"
+        ]
+      },
+      {
+        "name": "SemanticScholarPublicationEntity",
+        "file": "src/bioetl/domain/entities/semanticscholar.py",
+        "line": 24,
+        "usages": [
+          "src/bioetl/application/pipelines/semanticscholar/transformer.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "src/bioetl/domain/entities/publication_base.py"
+        ]
+      },
+      {
+        "name": "IDMappingResult",
+        "file": "src/bioetl/domain/entities/uniprot.py",
+        "line": 17,
+        "usages": [
+          "src/bioetl/application/pipelines/uniprot/idmapping_transformer.py"
+        ]
+      },
+      {
+        "name": "UniprotTarget",
+        "file": "src/bioetl/domain/entities/uniprot.py",
+        "line": 107,
+        "usages": [
+          "src/bioetl/application/pipelines/uniprot/transformer.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/entities/__init__.py",
+          "tests/test_architecture.py",
+          "tests/unit/domain/test_entities.py"
+        ]
+      },
+      {
+        "name": "GoldColumnFilter",
+        "file": "src/bioetl/domain/filtering/column_filter.py",
+        "line": 39,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/filtering/__init__.py",
+          "src/bioetl/domain/filtering/gold_config.py",
+          "src/bioetl/infrastructure/schemas/base_schemas.py",
+          "src/bioetl/infrastructure/schemas/pipeline_config.py",
+          "tests/unit/application/core/test_base_transformer.py",
+          "tests/unit/domain/filtering/test_column_filter.py",
+          "tests/unit/domain/filtering/test_gold_config.py",
+          "tests/unit/domain/test_filter_config.py"
+        ]
+      },
+      {
+        "name": "GoldFilterConfig",
+        "file": "src/bioetl/domain/filtering/gold_config.py",
+        "line": 21,
+        "usages": [
+          "src/bioetl/application/core/base_transformer.py",
+          "src/bioetl/application/pipelines/chembl/base_chembl_transformer.py",
+          "src/bioetl/application/pipelines/chembl/publication_transformer.py",
+          "src/bioetl/application/pipelines/crossref/transformer.py",
+          "src/bioetl/application/pipelines/openalex/transformer.py",
+          "src/bioetl/application/pipelines/pubchem/transformer.py",
+          "src/bioetl/application/pipelines/pubmed/transformer.py",
+          "src/bioetl/application/pipelines/semanticscholar/transformer.py",
+          "src/bioetl/application/pipelines/uniprot/idmapping_transformer.py",
+          "src/bioetl/application/pipelines/uniprot/transformer.py",
+          "src/bioetl/composition/factories/pipeline_factory.py",
+          "src/bioetl/composition/factories/transformer_factory.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/config.py",
+          "src/bioetl/domain/filtering/__init__.py",
+          "src/bioetl/infrastructure/config/_base.py",
+          "src/bioetl/infrastructure/config/filter_config_loader.py",
+          "src/bioetl/infrastructure/schemas/base_schemas.py",
+          "src/bioetl/infrastructure/schemas/filter_config.py",
+          "src/bioetl/infrastructure/schemas/pipeline_config.py",
+          "tests/unit/application/core/test_base_transformer.py",
+          "tests/unit/domain/filtering/test_gold_config.py",
+          "tests/unit/domain/test_filter_config.py",
+          "tests/unit/infrastructure/test_config_settings.py"
+        ]
+      },
+      {
+        "name": "FilterColumn",
+        "file": "src/bioetl/domain/filtering/input_config.py",
+        "line": 12,
+        "usages": [
+          "src/bioetl/composition/builders.py",
+          "src/bioetl/domain/filtering/__init__.py",
+          "src/bioetl/domain/ports/filtering.py",
+          "src/bioetl/infrastructure/adapters/input/csv_filter_reader.py",
+          "src/bioetl/infrastructure/schemas/base_schemas.py",
+          "src/bioetl/infrastructure/schemas/pipeline_config.py",
+          "tests/unit/infrastructure/adapters/test_csv_filter_reader.py"
+        ]
+      },
+      {
+        "name": "InputFilterConfig",
+        "file": "src/bioetl/domain/filtering/input_config.py",
+        "line": 25,
+        "usages": [
+          "src/bioetl/application/core/filtered_data_source.py",
+          "src/bioetl/composition/bootstrap/runtime/assembly.py",
+          "src/bioetl/composition/builders.py",
+          "src/bioetl/composition/factories/data_source_factory.py",
+          "src/bioetl/composition/factories/pipeline_factory.py",
+          "src/bioetl/composition/providers/provider_registry.py",
+          "src/bioetl/composition/providers/registration.py",
+          "src/bioetl/composition/registry.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/filtering/__init__.py",
+          "src/bioetl/infrastructure/config/filter_config_loader.py",
+          "src/bioetl/infrastructure/schemas/base_schemas.py",
+          "src/bioetl/infrastructure/schemas/filter_config.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/architecture/test_domain_purity.py",
+          "tests/unit/application/core/test_filtered_data_source.py",
+          "tests/unit/composition/bootstrap/runtime/test_assembly.py",
+          "tests/unit/composition/test_builders.py",
+          "tests/unit/domain/configs/test_base_configs.py",
+          "tests/unit/domain/test_filter_config.py"
+        ]
+      },
+      {
+        "name": "GoldListLengthFilter",
+        "file": "src/bioetl/domain/filtering/list_filters.py",
+        "line": 12,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/filtering/__init__.py",
+          "src/bioetl/domain/filtering/gold_config.py",
+          "src/bioetl/infrastructure/schemas/base_schemas.py",
+          "src/bioetl/infrastructure/schemas/pipeline_config.py",
+          "tests/unit/domain/filtering/test_gold_config.py",
+          "tests/unit/domain/filtering/test_list_filters.py"
+        ]
+      },
+      {
+        "name": "GoldListContainsFilter",
+        "file": "src/bioetl/domain/filtering/list_filters.py",
+        "line": 36,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/filtering/__init__.py",
+          "src/bioetl/domain/filtering/gold_config.py",
+          "src/bioetl/infrastructure/schemas/base_schemas.py",
+          "src/bioetl/infrastructure/schemas/pipeline_config.py",
+          "tests/unit/domain/filtering/test_gold_config.py",
+          "tests/unit/domain/filtering/test_list_filters.py"
+        ]
+      },
+      {
+        "name": "FilterLoadResult",
+        "file": "src/bioetl/domain/filtering/load_result.py",
+        "line": 13,
+        "usages": [
+          "src/bioetl/application/core/filtered_data_source.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/filtering/__init__.py",
+          "src/bioetl/domain/ports/filtering.py",
+          "src/bioetl/infrastructure/adapters/input/csv_filter_reader.py",
+          "tests/unit/application/core/test_filtered_data_source.py",
+          "tests/unit/domain/filtering/test_load_result.py",
+          "tests/unit/infrastructure/adapters/test_csv_filter_reader.py",
+          "tests/unit/infrastructure/storage/test_deterministic_write.py"
+        ]
+      },
+      {
+        "name": "GoldRangeFilter",
+        "file": "src/bioetl/domain/filtering/range_filter.py",
+        "line": 12,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/filtering/__init__.py",
+          "src/bioetl/domain/filtering/gold_config.py",
+          "src/bioetl/infrastructure/schemas/base_schemas.py",
+          "src/bioetl/infrastructure/schemas/pipeline_config.py",
+          "tests/unit/domain/filtering/test_gold_config.py",
+          "tests/unit/domain/filtering/test_range_filter.py"
+        ]
+      },
+      {
+        "name": "LockContext",
+        "file": "src/bioetl/domain/locking.py",
+        "line": 44,
+        "usages": [
+          "src/bioetl/application/core/lock_manager.py",
+          "src/bioetl/domain/__init__.py",
+          "tests/unit/domain/test_locking.py"
+        ]
+      },
+      {
+        "name": "MedallionPolicy",
+        "file": "src/bioetl/domain/medallion.py",
+        "line": 270,
+        "usages": [
+          "src/bioetl/application/core/preflight_service.py",
+          "src/bioetl/application/services/medallion_lifecycle.py",
+          "src/bioetl/application/services/medallion_types.py",
+          "src/bioetl/domain/__init__.py",
+          "tests/e2e/test_run_types_e2e.py",
+          "tests/integration/test_runner_lifecycle.py",
+          "tests/unit/application/core/test_medallion_validator.py",
+          "tests/unit/application/core/test_preflight_service.py",
+          "tests/unit/application/core/test_runner.py",
+          "tests/unit/application/services/test_medallion_lifecycle.py",
+          "tests/unit/domain/test_medallion.py"
+        ]
+      },
+      {
+        "name": "AuditEntry",
+        "file": "src/bioetl/domain/ports/audit.py",
+        "line": 54,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/domain/ports/noop.py",
+          "src/bioetl/infrastructure/audit/file_audit.py",
+          "src/bioetl/infrastructure/storage/bronze_writer.py",
+          "src/bioetl/infrastructure/storage/gold_writer.py",
+          "src/bioetl/infrastructure/storage/silver_writer.py",
+          "tests/unit/domain/ports/test_noop_audit.py",
+          "tests/unit/infrastructure/audit/test_file_audit.py"
+        ]
+      },
+      {
+        "name": "HealthCheckResult",
+        "file": "src/bioetl/domain/ports/health_check.py",
+        "line": 23,
+        "usages": [
+          "src/bioetl/application/core/preflight_service.py",
+          "src/bioetl/application/services/health_service.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/infrastructure/adapters/health_check_mixin.py",
+          "src/bioetl/infrastructure/adapters/http/health_monitor.py",
+          "tests/unit/application/core/test_health_aggregator.py",
+          "tests/unit/application/services/test_health_service.py",
+          "tests/unit/infrastructure/adapters/http/test_health_monitor.py"
+        ]
+      },
+      {
+        "name": "MemoryStats",
+        "file": "src/bioetl/domain/ports/memory.py",
+        "line": 14,
+        "usages": [
+          "src/bioetl/application/core/__init__.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/domain/ports/noop.py",
+          "src/bioetl/infrastructure/system/memory_monitor.py",
+          "tests/unit/application/core/test_memory_monitor.py"
+        ]
+      },
+      {
+        "name": "BronzeMetadataInput",
+        "file": "src/bioetl/domain/ports/metadata_coordinator.py",
+        "line": 27,
+        "usages": [
+          "src/bioetl/composition/services/__init__.py",
+          "src/bioetl/composition/services/metadata_coordinator.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/infrastructure/storage/bronze_writer.py",
+          "tests/unit/application/services/test_metadata_coordinator.py",
+          "tests/unit/infrastructure/storage/test_bronze_writer.py"
+        ]
+      },
+      {
+        "name": "SilverMetadataInput",
+        "file": "src/bioetl/domain/ports/metadata_coordinator.py",
+        "line": 56,
+        "usages": [
+          "src/bioetl/composition/services/__init__.py",
+          "src/bioetl/composition/services/metadata_coordinator.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/infrastructure/storage/silver_writer.py",
+          "tests/unit/application/services/test_metadata_coordinator.py",
+          "tests/unit/infrastructure/storage/test_silver_writer.py"
+        ]
+      },
+      {
+        "name": "SilverRef",
+        "file": "src/bioetl/domain/ports/metadata_coordinator.py",
+        "line": 97,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/infrastructure/storage/gold_writer.py",
+          "tests/unit/application/services/test_metadata_coordinator.py",
+          "tests/unit/domain/value_objects/test_silver_result.py"
+        ]
+      },
+      {
+        "name": "GoldMetadataInput",
+        "file": "src/bioetl/domain/ports/metadata_coordinator.py",
+        "line": 115,
+        "usages": [
+          "src/bioetl/composition/services/__init__.py",
+          "src/bioetl/composition/services/metadata_coordinator.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/infrastructure/storage/gold_writer.py",
+          "tests/unit/application/services/test_metadata_coordinator.py"
+        ]
+      },
+      {
+        "name": "PublicationMapping",
+        "file": "src/bioetl/domain/registry/publication.py",
+        "line": 40,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/registry/__init__.py",
+          "tests/unit/domain/registry/test_publication_registry.py"
+        ]
+      },
+      {
+        "name": "RetryConfig",
+        "file": "src/bioetl/domain/resilience.py",
+        "line": 18,
+        "usages": [
+          "src/bioetl/composition/factories/http_client_factory.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/infrastructure/adapters/decorators/__init__.py",
+          "src/bioetl/infrastructure/adapters/decorators/retry.py",
+          "src/bioetl/infrastructure/adapters/http/__init__.py",
+          "src/bioetl/infrastructure/adapters/http/client.py",
+          "tests/e2e/test_resilience_scenarios_e2e.py",
+          "tests/unit/infrastructure/adapters/decorators/test_retry_decorator.py",
+          "tests/unit/infrastructure/adapters/decorators/test_wrap_with_resilience.py",
+          "tests/unit/infrastructure/adapters/http/test_http_client.py"
+        ]
+      },
+      {
+        "name": "CircuitBreakerConfig",
+        "file": "src/bioetl/domain/resilience.py",
+        "line": 124,
+        "usages": [
+          "src/bioetl/composition/bootstrap_contexts.py",
+          "src/bioetl/composition/providers/registration.py",
+          "src/bioetl/composition/types.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/infrastructure/schemas/base_schemas.py",
+          "src/bioetl/infrastructure/schemas/source_config.py",
+          "tests/unit/composition/test_types.py",
+          "tests/unit/domain/configs/test_base_configs.py"
+        ]
+      },
+      {
+        "name": "AdapterConfig",
+        "file": "src/bioetl/domain/resilience.py",
+        "line": 147,
+        "usages": [
+          "src/bioetl/composition/providers/registration.py",
+          "src/bioetl/infrastructure/adapters/chembl/client.py",
+          "src/bioetl/infrastructure/schemas/source_config.py",
+          "tests/integration/adapters/test_chembl.py",
+          "tests/unit/infrastructure/adapters/chembl/test_chembl_client.py",
+          "tests/unit/infrastructure/test_adapters.py"
+        ]
+      },
+      {
+        "name": "ActivityAggregator",
+        "file": "src/bioetl/domain/services/activity_aggregator.py",
+        "line": 80,
+        "usages": [
+          "src/bioetl/domain/services/__init__.py",
+          "src/bioetl/domain/services/normalization_service.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/architecture/test_domain_purity.py",
+          "tests/unit/domain/services/test_activity_aggregator.py"
+        ]
+      },
+      {
+        "name": "DataNormalizationConfig",
+        "file": "src/bioetl/domain/services/data_normalization_config.py",
+        "line": 15,
+        "usages": [
+          "src/bioetl/composition/factories/services_factory.py",
+          "src/bioetl/domain/services/__init__.py",
+          "src/bioetl/domain/services/data_normalization_service.py",
+          "tests/unit/domain/services/test_data_normalization_service.py"
+        ]
+      },
+      {
+        "name": "DefaultDataNormalizationService",
+        "file": "src/bioetl/domain/services/data_normalization_service.py",
+        "line": 32,
+        "usages": [
+          "src/bioetl/composition/factories/services_factory.py",
+          "src/bioetl/domain/services/__init__.py",
+          "tests/unit/domain/services/test_data_normalization_service.py"
+        ]
+      },
+      {
+        "name": "DQMetricsInput",
+        "file": "src/bioetl/domain/services/dq_metrics_calculator.py",
+        "line": 21,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/application/services/dq_metrics_calculator.py",
+          "src/bioetl/domain/services/__init__.py",
+          "src/bioetl/infrastructure/storage/silver_writer.py",
+          "tests/unit/application/services/test_dq_metrics_calculator.py"
+        ]
+      },
+      {
+        "name": "ConcentrationRangeConfig",
+        "file": "src/bioetl/domain/services/normalization_config.py",
+        "line": 17,
+        "usages": [
+          "tests/unit/domain/services/test_normalization_config.py"
+        ]
+      },
+      {
+        "name": "PChemblRangeConfig",
+        "file": "src/bioetl/domain/services/normalization_config.py",
+        "line": 39,
+        "usages": [
+          "tests/architecture/test_code_metrics.py",
+          "tests/architecture/test_domain_purity.py",
+          "tests/unit/domain/services/test_normalization_config.py"
+        ]
+      },
+      {
+        "name": "NormalizationConfig",
+        "file": "src/bioetl/domain/services/normalization_config.py",
+        "line": 75,
+        "usages": [
+          "src/bioetl/domain/services/__init__.py",
+          "src/bioetl/domain/services/activity_aggregator.py",
+          "src/bioetl/domain/services/normalization_service.py",
+          "src/bioetl/domain/services/value_validator.py",
+          "tests/unit/domain/services/test_normalization_config.py",
+          "tests/unit/domain/services/test_normalization_service.py"
+        ]
+      },
+      {
+        "name": "NormalizationResult",
+        "file": "src/bioetl/domain/services/normalization_service.py",
+        "line": 27,
+        "usages": [
+          "tests/architecture/test_domain_purity.py",
+          "tests/unit/domain/services/test_normalization_service.py"
+        ]
+      },
+      {
+        "name": "NormalizationService",
+        "file": "src/bioetl/domain/services/normalization_service.py",
+        "line": 48,
+        "usages": [
+          "src/bioetl/domain/services/__init__.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/architecture/test_domain_purity.py",
+          "tests/unit/domain/services/test_normalization_service.py"
+        ]
+      },
+      {
+        "name": "UnitConverter",
+        "file": "src/bioetl/domain/services/unit_converter.py",
+        "line": 21,
+        "usages": [
+          "src/bioetl/domain/services/__init__.py",
+          "src/bioetl/domain/services/normalization_service.py",
+          "tests/unit/domain/services/test_unit_converter.py"
+        ]
+      },
+      {
+        "name": "ValueValidator",
+        "file": "src/bioetl/domain/services/value_validator.py",
+        "line": 41,
+        "usages": [
+          "src/bioetl/domain/services/__init__.py",
+          "src/bioetl/domain/services/normalization_service.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/architecture/test_domain_purity.py",
+          "tests/unit/domain/services/test_value_validator.py"
+        ]
+      },
+      {
+        "name": "ValidationResult",
+        "file": "src/bioetl/domain/types.py",
+        "line": 273,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/validation.py",
+          "src/bioetl/infrastructure/adapters/__init__.py",
+          "src/bioetl/infrastructure/adapters/validation.py",
+          "src/bioetl/infrastructure/validation/pandera_validator.py",
+          "tests/unit/application/core/test_batch_executor.py",
+          "tests/unit/application/core/test_batch_executor_memory.py",
+          "tests/unit/application/core/test_batch_writer.py",
+          "tests/unit/application/core/test_record_processor.py",
+          "tests/unit/application/core/test_record_processor_metrics.py",
+          "tests/unit/application/core/test_run_id_propagation.py",
+          "tests/unit/infrastructure/adapters/test_validation.py",
+          "tests/unit/infrastructure/validation/test_pandera_validator.py"
+        ]
+      },
+      {
+        "name": "ConfigValidationError",
+        "file": "src/bioetl/domain/types.py",
+        "line": 286,
+        "usages": [
+          "src/bioetl/application/core/preflight_service.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/interfaces/cli/commands/run.py",
+          "src/bioetl/interfaces/cli/exit_codes.py",
+          "tests/unit/application/core/test_preflight_service.py",
+          "tests/unit/interfaces/test_exit_codes.py"
+        ]
+      },
+      {
+        "name": "ComponentHealthResult",
+        "file": "src/bioetl/domain/types.py",
+        "line": 305,
+        "usages": [
+          "src/bioetl/application/core/preflight_service.py",
+          "src/bioetl/domain/__init__.py",
+          "tests/unit/application/core/test_health_aggregator.py"
+        ]
+      },
+      {
+        "name": "HealthReport",
+        "file": "src/bioetl/domain/types.py",
+        "line": 322,
+        "usages": [
+          "src/bioetl/application/core/preflight_service.py",
+          "src/bioetl/domain/__init__.py",
+          "tests/unit/application/core/test_health_aggregator.py",
+          "tests/unit/application/core/test_preflight_service.py",
+          "tests/unit/application/core/test_runner.py"
+        ]
+      },
+      {
+        "name": "PreflightReport",
+        "file": "src/bioetl/domain/types.py",
+        "line": 357,
+        "usages": [
+          "src/bioetl/application/core/preflight_service.py",
+          "tests/unit/application/core/test_preflight_service.py"
+        ]
+      },
+      {
+        "name": "ConfidenceScore",
+        "file": "src/bioetl/domain/value_objects/activity.py",
+        "line": 109,
+        "usages": [
+          "src/bioetl/domain/value_objects/__init__.py",
+          "tests/unit/domain/value_objects/test_activity.py"
+        ]
+      },
+      {
+        "name": "ActivityValue",
+        "file": "src/bioetl/domain/value_objects/activity.py",
+        "line": 226,
+        "usages": [
+          "src/bioetl/domain/value_objects/__init__.py",
+          "tests/unit/domain/value_objects/test_activity.py"
+        ]
+      },
+      {
+        "name": "Concentration",
+        "file": "src/bioetl/domain/value_objects/activity_values.py",
+        "line": 81,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/entities/chembl_assay_parameters.py",
+          "src/bioetl/domain/ports/normalization.py",
+          "src/bioetl/domain/services/activity_aggregator.py",
+          "src/bioetl/domain/services/normalization_service.py",
+          "src/bioetl/domain/services/unit_converter.py",
+          "src/bioetl/domain/services/value_validator.py",
+          "src/bioetl/domain/value_objects/__init__.py",
+          "src/bioetl/domain/value_objects/activity.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/architecture/test_domain_purity.py",
+          "tests/unit/domain/services/test_activity_aggregator.py",
+          "tests/unit/domain/services/test_normalization_service.py",
+          "tests/unit/domain/services/test_unit_converter.py",
+          "tests/unit/domain/value_objects/test_activity.py",
+          "tests/unit/domain/value_objects/test_measurements.py"
+        ]
+      },
+      {
+        "name": "PChemblValue",
+        "file": "src/bioetl/domain/value_objects/activity_values.py",
+        "line": 291,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/normalization.py",
+          "src/bioetl/domain/services/normalization_service.py",
+          "src/bioetl/domain/services/unit_converter.py",
+          "src/bioetl/domain/value_objects/__init__.py",
+          "tests/unit/domain/services/test_normalization_service.py",
+          "tests/unit/domain/services/test_unit_converter.py",
+          "tests/unit/domain/value_objects/test_measurements.py"
+        ]
+      },
+      {
+        "name": "BronzeWriteResult",
+        "file": "src/bioetl/domain/value_objects/bronze_result.py",
+        "line": 22,
+        "usages": [
+          "src/bioetl/application/core/batch_writer.py",
+          "src/bioetl/composition/factories/storage_adapter.py",
+          "src/bioetl/domain/ports/metadata_coordinator.py",
+          "src/bioetl/domain/ports/storage.py",
+          "src/bioetl/domain/value_objects/__init__.py",
+          "src/bioetl/infrastructure/storage/bronze_writer.py",
+          "src/bioetl/infrastructure/storage/silver_writer.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/e2e/test_resilience_scenarios_e2e.py",
+          "tests/unit/infrastructure/storage/test_bronze_writer.py",
+          "tests/unit/infrastructure/storage/test_silver_writer.py",
+          "tests/unit/test_ports.py"
+        ]
+      },
+      {
+        "name": "ColumnOrderConfig",
+        "file": "src/bioetl/domain/value_objects/column_order.py",
+        "line": 134,
+        "usages": [
+          "src/bioetl/application/composite/column_orderer.py",
+          "src/bioetl/domain/value_objects/__init__.py",
+          "tests/unit/application/composite/test_column_orderer.py",
+          "tests/unit/domain/value_objects/test_column_order.py"
+        ]
+      },
+      {
+        "name": "ColumnQualifier",
+        "file": "src/bioetl/domain/value_objects/column_qualifier.py",
+        "line": 19,
+        "usages": [
+          "src/bioetl/application/composite/column_orderer.py",
+          "src/bioetl/application/composite/column_renamer.py",
+          "src/bioetl/domain/value_objects/__init__.py",
+          "tests/unit/domain/value_objects/test_column_qualifier.py"
+        ]
+      },
+      {
+        "name": "CompoundId",
+        "file": "src/bioetl/domain/value_objects/compound_ids.py",
+        "line": 31,
+        "usages": [
+          "src/bioetl/domain/value_objects/__init__.py",
+          "tests/unit/domain/value_objects/test_compound_ids.py"
+        ]
+      },
+      {
+        "name": "ColumnStats",
+        "file": "src/bioetl/domain/value_objects/dq_metrics.py",
+        "line": 19,
+        "usages": [
+          "src/bioetl/domain/value_objects/__init__.py",
+          "tests/unit/domain/value_objects/test_dq_metrics.py",
+          "tests/unit/infrastructure/storage/test_silver_writer.py"
+        ]
+      },
+      {
+        "name": "SchemaDriftInfo",
+        "file": "src/bioetl/domain/value_objects/dq_metrics.py",
+        "line": 54,
+        "usages": [
+          "src/bioetl/domain/services/dq_metrics_calculator.py",
+          "src/bioetl/domain/value_objects/__init__.py",
+          "src/bioetl/infrastructure/storage/silver_writer.py",
+          "tests/unit/domain/value_objects/test_dq_metrics.py",
+          "tests/unit/infrastructure/storage/test_silver_writer.py"
+        ]
+      },
+      {
+        "name": "BatchDQMetrics",
+        "file": "src/bioetl/domain/value_objects/dq_metrics.py",
+        "line": 95,
+        "usages": [
+          "src/bioetl/domain/ports/metadata_coordinator.py",
+          "src/bioetl/domain/services/dq_metrics_calculator.py",
+          "src/bioetl/domain/value_objects/__init__.py",
+          "src/bioetl/infrastructure/storage/silver_writer.py",
+          "tests/unit/application/services/test_dq_metrics_calculator.py",
+          "tests/unit/domain/value_objects/test_dq_metrics.py",
+          "tests/unit/infrastructure/storage/test_silver_writer.py"
+        ]
+      },
+      {
+        "name": "DQCheckResult",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 113,
+        "usages": [
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "RecordCountResult",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 138,
+        "usages": [
+          "src/bioetl/application/services/dq/bronze_analyzer.py",
+          "src/bioetl/application/services/dq/gold_analyzer.py",
+          "src/bioetl/application/services/dq/silver_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "FileIntegrityResult",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 151,
+        "usages": [
+          "src/bioetl/application/services/dq/bronze_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "SchemaSnapshotResult",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 161,
+        "usages": [
+          "src/bioetl/application/services/dq/bronze_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "FieldPresenceResult",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 185,
+        "usages": [
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "EncodingValidationResult",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 194,
+        "usages": [
+          "src/bioetl/application/services/dq/bronze_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "NullRateResult",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 210,
+        "usages": [
+          "src/bioetl/application/services/dq/silver_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "UniquenessResult",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 220,
+        "usages": [
+          "src/bioetl/application/services/dq/silver_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "TypeConformanceResult",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 232,
+        "usages": [
+          "src/bioetl/application/services/dq/silver_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "NumericDistribution",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 248,
+        "usages": [
+          "src/bioetl/application/services/dq/silver_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "CategoricalDistribution",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 263,
+        "usages": [
+          "src/bioetl/application/services/dq/silver_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "ValueDistributionResult",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 276,
+        "usages": [
+          "src/bioetl/application/services/dq/silver_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "SchemaDriftResult",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 287,
+        "usages": [
+          "src/bioetl/application/services/dq/silver_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "DeduplicationStatsResult",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 307,
+        "usages": [
+          "src/bioetl/application/services/dq/silver_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "ContentHashIntegrityResult",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 318,
+        "usages": [
+          "src/bioetl/application/services/dq/silver_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "CompletenessResult",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 328,
+        "usages": [
+          "src/bioetl/application/services/dq/gold_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "BusinessRuleResult",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 338,
+        "usages": [
+          "src/bioetl/application/services/dq/gold_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "BusinessRulesResult",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 349,
+        "usages": [
+          "src/bioetl/application/services/dq/gold_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "ForeignKeyResult",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 365,
+        "usages": [
+          "src/bioetl/application/services/dq/gold_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "ReferentialIntegrityResult",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 377,
+        "usages": [
+          "src/bioetl/application/services/dq/gold_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "StatisticalMetric",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 385,
+        "usages": [
+          "src/bioetl/application/services/dq/gold_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "StatisticalProfileResult",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 397,
+        "usages": [
+          "src/bioetl/application/services/dq/gold_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "AnomalyMetric",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 406,
+        "usages": [
+          "src/bioetl/application/services/dq/gold_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "AnomalyDetectionResult",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 419,
+        "usages": [
+          "src/bioetl/application/services/dq/gold_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "SCDIntegrityResult",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 440,
+        "usages": [
+          "src/bioetl/application/services/dq/gold_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "DataFreshnessResult",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 454,
+        "usages": [
+          "src/bioetl/application/services/dq/gold_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "DQReportSummary",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 469,
+        "usages": [
+          "src/bioetl/application/services/dq/utils.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "DQThresholds",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 480,
+        "usages": [
+          "src/bioetl/application/services/dq/silver_analyzer.py",
+          "src/bioetl/domain/value_objects/__init__.py"
+        ]
+      },
+      {
+        "name": "BaseDQReport",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 495,
+        "usages": []
+      },
+      {
+        "name": "BronzeDQReport",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 509,
+        "usages": [
+          "src/bioetl/application/services/dq/bronze_analyzer.py",
+          "src/bioetl/domain/ports/dq_report.py",
+          "src/bioetl/domain/services/dq_serializer.py",
+          "src/bioetl/domain/value_objects/__init__.py",
+          "src/bioetl/infrastructure/export/dq_report_writer.py"
+        ]
+      },
+      {
+        "name": "SilverDQReport",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 539,
+        "usages": [
+          "src/bioetl/application/services/dq/silver_analyzer.py",
+          "src/bioetl/domain/ports/dq_report.py",
+          "src/bioetl/domain/services/dq_serializer.py",
+          "src/bioetl/domain/value_objects/__init__.py",
+          "src/bioetl/infrastructure/export/dq_report_writer.py"
+        ]
+      },
+      {
+        "name": "GoldDQReport",
+        "file": "src/bioetl/domain/value_objects/dq_report.py",
+        "line": 576,
+        "usages": [
+          "src/bioetl/application/services/dq/gold_analyzer.py",
+          "src/bioetl/domain/ports/dq_report.py",
+          "src/bioetl/domain/services/dq_serializer.py",
+          "src/bioetl/domain/value_objects/__init__.py",
+          "src/bioetl/infrastructure/export/dq_report_writer.py"
+        ]
+      },
+      {
+        "name": "DQResult",
+        "file": "src/bioetl/domain/value_objects/dq_result.py",
+        "line": 46,
+        "usages": [
+          "src/bioetl/application/core/__init__.py",
+          "src/bioetl/application/core/postrun_service.py",
+          "src/bioetl/application/services/data_quality_service.py",
+          "src/bioetl/domain/value_objects/__init__.py",
+          "tests/integration/test_runner_lifecycle.py",
+          "tests/unit/application/core/test_dq_report_integration.py",
+          "tests/unit/application/core/test_postrun_service.py",
+          "tests/unit/application/core/test_runner.py",
+          "tests/unit/application/services/test_data_quality_service.py"
+        ]
+      },
+      {
+        "name": "FieldGroupConfig",
+        "file": "src/bioetl/domain/value_objects/publication_field_groups.py",
+        "line": 229,
+        "usages": [
+          "src/bioetl/domain/value_objects/__init__.py",
+          "tests/unit/domain/value_objects/test_publication_field_groups.py"
+        ]
+      },
+      {
+        "name": "RunContext",
+        "file": "src/bioetl/domain/value_objects/run_context.py",
+        "line": 19,
+        "usages": [
+          "src/bioetl/composition/bootstrap/assembly/storage.py",
+          "src/bioetl/composition/factories/pipeline_factory.py",
+          "src/bioetl/composition/services/metadata_coordinator.py",
+          "src/bioetl/domain/value_objects/__init__.py",
+          "tests/unit/application/services/test_metadata_coordinator.py"
+        ]
+      },
+      {
+        "name": "SilverWriteResult",
+        "file": "src/bioetl/domain/value_objects/silver_result.py",
+        "line": 19,
+        "usages": [
+          "src/bioetl/application/core/batch_writer.py",
+          "src/bioetl/composition/factories/storage_adapter.py",
+          "src/bioetl/domain/ports/storage.py",
+          "src/bioetl/domain/value_objects/__init__.py",
+          "src/bioetl/infrastructure/storage/gold_writer.py",
+          "src/bioetl/infrastructure/storage/silver_writer.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/unit/domain/value_objects/test_silver_result.py",
+          "tests/unit/infrastructure/test_storage.py",
+          "tests/unit/test_ports.py"
+        ]
+      }
+    ],
+    "TypedDict": [
+      {
+        "name": "StructuredAffiliation",
+        "file": "src/bioetl/application/pipelines/pubmed/extractors/author.py",
+        "line": 20,
+        "usages": [
+          "src/bioetl/application/pipelines/pubmed/extractors/__init__.py",
+          "src/bioetl/application/pipelines/pubmed/transformer.py"
+        ]
+      },
+      {
+        "name": "RawAuthor",
+        "file": "src/bioetl/application/pipelines/pubmed/extractors/author.py",
+        "line": 43,
+        "usages": [
+          "src/bioetl/application/pipelines/pubmed/extractors/__init__.py",
+          "src/bioetl/application/pipelines/pubmed/transformer.py"
+        ]
+      },
+      {
+        "name": "RawClassification",
+        "file": "src/bioetl/application/pipelines/pubmed/extractors/classification.py",
+        "line": 14,
+        "usages": []
+      },
+      {
+        "name": "NormalizedClassification",
+        "file": "src/bioetl/application/pipelines/pubmed/extractors/classification.py",
+        "line": 22,
+        "usages": []
+      },
+      {
+        "name": "RawDate",
+        "file": "src/bioetl/application/pipelines/pubmed/extractors/date.py",
+        "line": 25,
+        "usages": []
+      },
+      {
+        "name": "NormalizedDate",
+        "file": "src/bioetl/application/pipelines/pubmed/extractors/date.py",
+        "line": 33,
+        "usages": [
+          "tests/unit/pipelines/pubmed/extractors/test_extractor_edge_cases.py"
+        ]
+      },
+      {
+        "name": "RawIdentifiers",
+        "file": "src/bioetl/application/pipelines/pubmed/extractors/identifier.py",
+        "line": 15,
+        "usages": []
+      },
+      {
+        "name": "NormalizedIdentifiers",
+        "file": "src/bioetl/application/pipelines/pubmed/extractors/identifier.py",
+        "line": 22,
+        "usages": []
+      },
+      {
+        "name": "AllArticleIds",
+        "file": "src/bioetl/application/pipelines/pubmed/extractors/identifier.py",
+        "line": 29,
+        "usages": [
+          "src/bioetl/application/pipelines/pubmed/extractors/__init__.py"
+        ]
+      },
+      {
+        "name": "ELocationIds",
+        "file": "src/bioetl/application/pipelines/pubmed/extractors/identifier.py",
+        "line": 54,
+        "usages": [
+          "src/bioetl/application/pipelines/pubmed/extractors/__init__.py"
+        ]
+      },
+      {
+        "name": "GoldColumnFilterDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 19,
+        "usages": []
+      },
+      {
+        "name": "GoldRangeDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 27,
+        "usages": [
+          "tests/unit/domain/test_config_types.py"
+        ]
+      },
+      {
+        "name": "GoldFiltersDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 36,
+        "usages": [
+          "tests/unit/domain/test_config_types.py"
+        ]
+      },
+      {
+        "name": "CsvExportDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 52,
+        "usages": [
+          "tests/unit/domain/test_config_types.py"
+        ]
+      },
+      {
+        "name": "BronzeSinkDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 62,
+        "usages": [
+          "tests/unit/domain/test_config_types.py"
+        ]
+      },
+      {
+        "name": "SilverSinkDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 74,
+        "usages": [
+          "tests/unit/domain/test_config_types.py"
+        ]
+      },
+      {
+        "name": "GoldValidationDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 91,
+        "usages": []
+      },
+      {
+        "name": "GoldSinkDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 97,
+        "usages": [
+          "tests/unit/domain/test_config_types.py"
+        ]
+      },
+      {
+        "name": "SinkDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 108,
+        "usages": [
+          "tests/unit/domain/test_config_types.py"
+        ]
+      },
+      {
+        "name": "TransformDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 121,
+        "usages": [
+          "tests/unit/domain/test_config_types.py"
+        ]
+      },
+      {
+        "name": "ColumnGroupDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 133,
+        "usages": []
+      },
+      {
+        "name": "DQThresholdsDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 147,
+        "usages": [
+          "tests/unit/domain/test_config_types.py"
+        ]
+      },
+      {
+        "name": "DQReportDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 154,
+        "usages": [
+          "tests/unit/domain/test_config_types.py"
+        ]
+      },
+      {
+        "name": "FieldValidationDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 164,
+        "usages": []
+      },
+      {
+        "name": "CrossFieldValidationDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 178,
+        "usages": [
+          "tests/unit/domain/test_config_types.py"
+        ]
+      },
+      {
+        "name": "ConditionalValidationDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 198,
+        "usages": [
+          "tests/unit/domain/test_config_types.py"
+        ]
+      },
+      {
+        "name": "DQRulesDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 208,
+        "usages": [
+          "tests/unit/domain/test_config_types.py"
+        ]
+      },
+      {
+        "name": "DQConfigFileDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 231,
+        "usages": [
+          "tests/unit/domain/test_config_types.py"
+        ]
+      },
+      {
+        "name": "CircuitBreakerDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 265,
+        "usages": [
+          "tests/unit/domain/test_config_types.py"
+        ]
+      },
+      {
+        "name": "InputFilterDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 277,
+        "usages": [
+          "tests/unit/domain/test_config_types.py"
+        ]
+      },
+      {
+        "name": "ClientConfigDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 292,
+        "usages": [
+          "tests/unit/domain/test_config_types.py"
+        ]
+      },
+      {
+        "name": "RateLimitDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 299,
+        "usages": [
+          "src/bioetl/domain/configs/base.py",
+          "tests/unit/domain/test_config_types.py"
+        ]
+      },
+      {
+        "name": "ProviderConfigDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 306,
+        "usages": [
+          "tests/unit/domain/test_config_types.py"
+        ]
+      },
+      {
+        "name": "SourceConfigDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 318,
+        "usages": [
+          "tests/unit/domain/test_config_types.py"
+        ]
+      },
+      {
+        "name": "SourceFileDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 329,
+        "usages": [
+          "tests/unit/domain/test_config_types.py"
+        ]
+      },
+      {
+        "name": "PipelineConfigDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 340,
+        "usages": [
+          "tests/unit/domain/test_config_types.py"
+        ]
+      },
+      {
+        "name": "RuntimeArgsDict",
+        "file": "src/bioetl/domain/config_types.py",
+        "line": 390,
+        "usages": [
+          "tests/unit/domain/test_config_types.py"
+        ]
+      },
+      {
+        "name": "BronzeRecord",
+        "file": "src/bioetl/domain/types.py",
+        "line": 42,
+        "usages": [
+          "src/bioetl/application/core/base.py",
+          "src/bioetl/application/core/base_transformer.py",
+          "src/bioetl/application/core/field_specs.py",
+          "src/bioetl/application/core/protocols.py",
+          "src/bioetl/application/pipelines/chembl/activity_transformer.py",
+          "src/bioetl/application/pipelines/chembl/assay_parameters_transformer.py",
+          "src/bioetl/application/pipelines/chembl/assay_transformer.py",
+          "src/bioetl/application/pipelines/chembl/base_chembl_transformer.py",
+          "src/bioetl/application/pipelines/chembl/cell_line_transformer.py",
+          "src/bioetl/application/pipelines/chembl/compound_record_transformer.py",
+          "src/bioetl/application/pipelines/chembl/molecule_transformer.py",
+          "src/bioetl/application/pipelines/chembl/protein_class_transformer.py",
+          "src/bioetl/application/pipelines/chembl/publication_similarity_transformer.py",
+          "src/bioetl/application/pipelines/chembl/publication_term_transformer.py",
+          "src/bioetl/application/pipelines/chembl/publication_transformer.py",
+          "src/bioetl/application/pipelines/chembl/subcellular_fraction_transformer.py",
+          "src/bioetl/application/pipelines/chembl/target_component_transformer.py",
+          "src/bioetl/application/pipelines/chembl/target_transformer.py",
+          "src/bioetl/application/pipelines/chembl/tissue_transformer.py",
+          "src/bioetl/application/pipelines/common/base_publication_transformer.py",
+          "src/bioetl/application/pipelines/crossref/transformer.py",
+          "src/bioetl/application/pipelines/openalex/transformer.py",
+          "src/bioetl/application/pipelines/pubchem/transformer.py",
+          "src/bioetl/application/pipelines/pubmed/transformer.py",
+          "src/bioetl/application/pipelines/semanticscholar/transformer.py",
+          "src/bioetl/application/pipelines/uniprot/idmapping_transformer.py",
+          "src/bioetl/application/pipelines/uniprot/transformer.py",
+          "src/bioetl/composition/bootstrap_contexts.py",
+          "src/bioetl/domain/__init__.py",
+          "tests/unit/application/core/test_protocols.py",
+          "tests/unit/application/pipelines/common/test_base_publication_transformer.py",
+          "tests/unit/pipelines/pubmed/test_pubmed_publication.py",
+          "tests/unit/pipelines/pubmed/test_pubmed_transformer.py"
+        ]
+      },
+      {
+        "name": "SilverRecord",
+        "file": "src/bioetl/domain/types.py",
+        "line": 50,
+        "usages": [
+          "src/bioetl/application/core/base.py",
+          "src/bioetl/application/core/base_transformer.py",
+          "src/bioetl/application/core/protocols.py",
+          "src/bioetl/application/pipelines/chembl/base_chembl_transformer.py",
+          "src/bioetl/application/pipelines/chembl/publication_term_transformer.py",
+          "src/bioetl/application/pipelines/chembl/publication_transformer.py",
+          "src/bioetl/application/pipelines/chembl/subcellular_fraction_transformer.py",
+          "src/bioetl/application/pipelines/common/base_publication_transformer.py",
+          "src/bioetl/application/pipelines/crossref/transformer.py",
+          "src/bioetl/application/pipelines/openalex/transformer.py",
+          "src/bioetl/application/pipelines/pubchem/transformer.py",
+          "src/bioetl/application/pipelines/pubmed/transformer.py",
+          "src/bioetl/application/pipelines/semanticscholar/transformer.py",
+          "src/bioetl/application/pipelines/uniprot/idmapping_transformer.py",
+          "src/bioetl/application/pipelines/uniprot/transformer.py",
+          "src/bioetl/composition/bootstrap_contexts.py",
+          "src/bioetl/domain/__init__.py",
+          "tests/architecture/test_transformer_signatures.py",
+          "tests/unit/application/core/test_protocols.py",
+          "tests/unit/application/pipelines/crossref/test_crossref_transformer.py",
+          "tests/unit/pipelines/chembl/test_activity_schema_gap.py"
+        ]
+      }
+    ],
+    "Protocol": [
+      {
+        "name": "ExecutorMetricsProtocol",
+        "file": "src/bioetl/application/core/postrun_service.py",
+        "line": 44,
+        "usages": []
+      },
+      {
+        "name": "TransformCallback",
+        "file": "src/bioetl/application/core/protocols.py",
+        "line": 18,
+        "usages": [
+          "src/bioetl/application/core/batch_executor.py",
+          "src/bioetl/application/core/batch_transformer.py",
+          "src/bioetl/application/core/record_processor.py",
+          "src/bioetl/composition/bootstrap_contexts.py",
+          "tests/unit/application/core/test_protocols.py"
+        ]
+      },
+      {
+        "name": "GoldFilterCallback",
+        "file": "src/bioetl/application/core/protocols.py",
+        "line": 28,
+        "usages": [
+          "src/bioetl/application/core/batch_executor.py",
+          "src/bioetl/application/core/batch_transformer.py",
+          "src/bioetl/application/core/record_processor.py",
+          "src/bioetl/composition/bootstrap_contexts.py",
+          "tests/unit/application/core/test_protocols.py"
+        ]
+      },
+      {
+        "name": "GoldTransformCallback",
+        "file": "src/bioetl/application/core/protocols.py",
+        "line": 36,
+        "usages": [
+          "src/bioetl/application/core/batch_executor.py",
+          "src/bioetl/application/core/batch_transformer.py",
+          "src/bioetl/application/core/record_processor.py",
+          "src/bioetl/composition/bootstrap_contexts.py",
+          "tests/unit/application/core/test_protocols.py"
+        ]
+      },
+      {
+        "name": "TransformerPort",
+        "file": "src/bioetl/application/core/protocols.py",
+        "line": 49,
+        "usages": [
+          "tests/unit/application/core/test_protocols.py"
+        ]
+      },
+      {
+        "name": "DataSourceFactoryPort",
+        "file": "src/bioetl/application/services/health_service.py",
+        "line": 22,
+        "usages": [
+          "tests/unit/application/services/test_health_service.py"
+        ]
+      },
+      {
+        "name": "MetricsServerPort",
+        "file": "src/bioetl/application/services/metrics_service.py",
+        "line": 35,
+        "usages": [
+          "src/bioetl/application/services/__init__.py",
+          "src/bioetl/infrastructure/observability/metrics_server_adapter.py",
+          "tests/unit/application/services/test_metrics_service.py"
+        ]
+      },
+      {
+        "name": "AuditPort",
+        "file": "src/bioetl/domain/ports/audit.py",
+        "line": 96,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/domain/ports/noop.py",
+          "src/bioetl/infrastructure/audit/__init__.py",
+          "src/bioetl/infrastructure/audit/file_audit.py",
+          "src/bioetl/infrastructure/storage/bronze_writer.py",
+          "src/bioetl/infrastructure/storage/gold_writer.py",
+          "src/bioetl/infrastructure/storage/silver_writer.py",
+          "tests/architecture/test_code_metrics.py"
+        ]
+      },
+      {
+        "name": "CheckpointPort",
+        "file": "src/bioetl/domain/ports/checkpoint.py",
+        "line": 15,
+        "usages": [
+          "src/bioetl/application/core/checkpoint_manager.py",
+          "src/bioetl/application/core/pipeline_services.py",
+          "src/bioetl/application/services/checkpoint_service.py",
+          "src/bioetl/composition/bootstrap/assembly/checkpoint.py",
+          "src/bioetl/composition/factories/services_factory.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/infrastructure/checkpoint/local_checkpoint.py",
+          "tests/architecture/test_domain_public_api.py",
+          "tests/architecture/test_port_contracts.py",
+          "tests/architecture/test_port_contracts_hypothesis.py",
+          "tests/fakes/checkpoint_fake.py",
+          "tests/smoke/test_smoke.py",
+          "tests/test_architecture.py",
+          "tests/unit/composition/bootstrap/test_checkpoint_bootstrap.py",
+          "tests/unit/test_ports.py"
+        ]
+      },
+      {
+        "name": "DataNormalizationPort",
+        "file": "src/bioetl/domain/ports/data_normalization.py",
+        "line": 26,
+        "usages": [
+          "src/bioetl/application/core/base_transformer.py",
+          "src/bioetl/application/pipelines/chembl/base_chembl_transformer.py",
+          "src/bioetl/application/pipelines/chembl/publication_transformer.py",
+          "src/bioetl/application/pipelines/crossref/transformer.py",
+          "src/bioetl/application/pipelines/openalex/transformer.py",
+          "src/bioetl/application/pipelines/pubchem/transformer.py",
+          "src/bioetl/application/pipelines/pubmed/transformer.py",
+          "src/bioetl/application/pipelines/semanticscholar/transformer.py",
+          "src/bioetl/application/pipelines/uniprot/idmapping_transformer.py",
+          "src/bioetl/application/pipelines/uniprot/transformer.py",
+          "src/bioetl/composition/factories/services_factory.py",
+          "src/bioetl/composition/factories/transformer_factory.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "tests/architecture/test_code_metrics.py"
+        ]
+      },
+      {
+        "name": "DataSourcePort",
+        "file": "src/bioetl/domain/ports/data_source.py",
+        "line": 16,
+        "usages": [
+          "src/bioetl/application/core/filtered_data_source.py",
+          "src/bioetl/application/core/idmapping_data_source.py",
+          "src/bioetl/application/core/pipeline_services.py",
+          "src/bioetl/application/core/publication_term_data_source.py",
+          "src/bioetl/application/core/subcellular_fraction_data_source.py",
+          "src/bioetl/composition/factories/data_source_factory.py",
+          "src/bioetl/composition/factories/pipeline_factory.py",
+          "src/bioetl/composition/factories/services_factory.py",
+          "src/bioetl/composition/providers/decorators.py",
+          "src/bioetl/composition/providers/provider_registry.py",
+          "src/bioetl/composition/providers/registration.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/infrastructure/adapters/base.py",
+          "src/bioetl/infrastructure/adapters/cached_bronze_data_source.py",
+          "src/bioetl/infrastructure/adapters/chembl/__init__.py",
+          "src/bioetl/infrastructure/adapters/chembl/client.py",
+          "src/bioetl/infrastructure/adapters/crossref/client.py",
+          "src/bioetl/infrastructure/adapters/decorators/__init__.py",
+          "src/bioetl/infrastructure/adapters/decorators/circuit_breaker.py",
+          "src/bioetl/infrastructure/adapters/decorators/retry.py",
+          "src/bioetl/infrastructure/adapters/error_handling.py",
+          "src/bioetl/infrastructure/adapters/health_check_mixin.py",
+          "src/bioetl/infrastructure/adapters/openalex/client.py",
+          "src/bioetl/infrastructure/adapters/pubchem/client.py",
+          "src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py",
+          "src/bioetl/infrastructure/adapters/semanticscholar/adapter.py",
+          "src/bioetl/infrastructure/adapters/sync_base.py",
+          "src/bioetl/infrastructure/adapters/uniprot/client.py",
+          "src/bioetl/infrastructure/adapters/uniprot/idmapping_client.py",
+          "tests/architecture/test_adapter_contracts.py",
+          "tests/architecture/test_di_compliance.py",
+          "tests/architecture/test_domain_public_api.py",
+          "tests/architecture/test_port_contracts.py",
+          "tests/test_architecture.py",
+          "tests/unit/application/core/test_runner.py",
+          "tests/unit/infrastructure/adapters/test_error_handling.py",
+          "tests/unit/test_ports.py"
+        ]
+      },
+      {
+        "name": "FilterableDataSourcePort",
+        "file": "src/bioetl/domain/ports/data_source.py",
+        "line": 82,
+        "usages": [
+          "src/bioetl/application/core/filtered_data_source.py",
+          "src/bioetl/application/core/publication_term_data_source.py",
+          "src/bioetl/application/core/subcellular_fraction_data_source.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/infrastructure/adapters/chembl/client.py",
+          "src/bioetl/infrastructure/adapters/crossref/client.py",
+          "src/bioetl/infrastructure/adapters/filterable_mixin.py",
+          "src/bioetl/infrastructure/adapters/openalex/__init__.py",
+          "src/bioetl/infrastructure/adapters/openalex/client.py",
+          "src/bioetl/infrastructure/adapters/pubchem/client.py",
+          "src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py",
+          "src/bioetl/infrastructure/adapters/semanticscholar/adapter.py",
+          "src/bioetl/infrastructure/adapters/uniprot/client.py",
+          "tests/architecture/test_adapter_contracts.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/architecture/test_layer_dependencies.py",
+          "tests/architecture/test_port_contracts.py",
+          "tests/unit/application/core/test_filtered_data_source.py"
+        ]
+      },
+      {
+        "name": "DeltaReaderPort",
+        "file": "src/bioetl/domain/ports/delta_reader.py",
+        "line": 16,
+        "usages": [
+          "src/bioetl/application/composite/dependency_coordinator.py",
+          "src/bioetl/application/composite/key_extractor.py",
+          "src/bioetl/application/composite/merger.py",
+          "src/bioetl/application/services/export_service.py",
+          "src/bioetl/composition/bootstrap/runtime/composite.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/infrastructure/storage/delta_reader.py",
+          "tests/architecture/test_domain_public_api.py",
+          "tests/unit/application/composite/test_composite_activity.py",
+          "tests/unit/application/composite/test_dependency_coordinator.py",
+          "tests/unit/application/services/test_export_service.py"
+        ]
+      },
+      {
+        "name": "BronzeDQConfigPort",
+        "file": "src/bioetl/domain/ports/dq_config.py",
+        "line": 24,
+        "usages": [
+          "src/bioetl/application/core/postrun_service.py",
+          "src/bioetl/application/services/dq/bronze_analyzer.py",
+          "src/bioetl/application/services/dq_report_service.py",
+          "src/bioetl/composition/bootstrap_contexts.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/domain/ports/dq_report.py",
+          "tests/unit/application/services/test_dq_report_service_coverage.py"
+        ]
+      },
+      {
+        "name": "SilverDQConfigPort",
+        "file": "src/bioetl/domain/ports/dq_config.py",
+        "line": 59,
+        "usages": [
+          "src/bioetl/application/core/postrun_service.py",
+          "src/bioetl/application/services/dq/silver_analyzer.py",
+          "src/bioetl/application/services/dq_report_service.py",
+          "src/bioetl/composition/bootstrap_contexts.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/domain/ports/dq_report.py"
+        ]
+      },
+      {
+        "name": "GoldDQConfigPort",
+        "file": "src/bioetl/domain/ports/dq_config.py",
+        "line": 94,
+        "usages": [
+          "src/bioetl/application/core/postrun_service.py",
+          "src/bioetl/application/services/dq/gold_analyzer.py",
+          "src/bioetl/application/services/dq_report_service.py",
+          "src/bioetl/composition/bootstrap_contexts.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/domain/ports/dq_report.py"
+        ]
+      },
+      {
+        "name": "BronzeDQAnalyzerPort",
+        "file": "src/bioetl/domain/ports/dq_report.py",
+        "line": 47,
+        "usages": [
+          "src/bioetl/application/core/pipeline_services.py",
+          "src/bioetl/application/services/dq/bronze_analyzer.py",
+          "src/bioetl/application/services/dq_report_service.py",
+          "src/bioetl/composition/factories/dq_factory.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "tests/unit/application/services/test_dq_report_service_coverage.py",
+          "tests/unit/composition/factories/test_dq_factory.py"
+        ]
+      },
+      {
+        "name": "SilverDQAnalyzerPort",
+        "file": "src/bioetl/domain/ports/dq_report.py",
+        "line": 83,
+        "usages": [
+          "src/bioetl/application/core/pipeline_services.py",
+          "src/bioetl/application/services/dq/silver_analyzer.py",
+          "src/bioetl/application/services/dq_report_service.py",
+          "src/bioetl/composition/factories/dq_factory.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "tests/unit/application/services/test_dq_report_service_coverage.py",
+          "tests/unit/composition/factories/test_dq_factory.py"
+        ]
+      },
+      {
+        "name": "GoldDQAnalyzerPort",
+        "file": "src/bioetl/domain/ports/dq_report.py",
+        "line": 131,
+        "usages": [
+          "src/bioetl/application/core/pipeline_services.py",
+          "src/bioetl/application/services/dq/gold_analyzer.py",
+          "src/bioetl/application/services/dq_report_service.py",
+          "src/bioetl/composition/factories/dq_factory.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "tests/unit/application/services/test_dq_report_service_coverage.py",
+          "tests/unit/composition/factories/test_dq_factory.py"
+        ]
+      },
+      {
+        "name": "DQReportWriterPort",
+        "file": "src/bioetl/domain/ports/dq_report.py",
+        "line": 177,
+        "usages": [
+          "src/bioetl/application/core/pipeline_services.py",
+          "src/bioetl/application/services/dq_report_service.py",
+          "src/bioetl/composition/factories/dq_factory.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/infrastructure/export/dq_report_writer.py",
+          "tests/architecture/test_domain_public_api.py",
+          "tests/unit/application/services/test_dq_report_service_coverage.py",
+          "tests/unit/composition/factories/test_dq_factory.py"
+        ]
+      },
+      {
+        "name": "InputFilterPort",
+        "file": "src/bioetl/domain/ports/filtering.py",
+        "line": 18,
+        "usages": [
+          "src/bioetl/application/core/filtered_data_source.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/infrastructure/adapters/input/csv_filter_reader.py",
+          "tests/architecture/test_port_contracts.py",
+          "tests/unit/application/core/test_filtered_data_source.py"
+        ]
+      },
+      {
+        "name": "HealthCheckPort",
+        "file": "src/bioetl/domain/ports/health_check.py",
+        "line": 103,
+        "usages": [
+          "src/bioetl/application/services/health_service.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/infrastructure/adapters/http/health.py",
+          "tests/unit/application/services/test_health_service.py",
+          "tests/unit/interfaces/cli/commands/test_health.py"
+        ]
+      },
+      {
+        "name": "HealthStatePort",
+        "file": "src/bioetl/domain/ports/health_check.py",
+        "line": 150,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py"
+        ]
+      },
+      {
+        "name": "HealthMonitorPort",
+        "file": "src/bioetl/domain/ports/health_check.py",
+        "line": 168,
+        "usages": [
+          "src/bioetl/application/core/preflight_service.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/interfaces/http/health_server.py",
+          "tests/architecture/test_interfaces_no_infrastructure.py"
+        ]
+      },
+      {
+        "name": "IDMappingPort",
+        "file": "src/bioetl/domain/ports/idmapping.py",
+        "line": 16,
+        "usages": [
+          "src/bioetl/application/core/idmapping_data_source.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py"
+        ]
+      },
+      {
+        "name": "LockPort",
+        "file": "src/bioetl/domain/ports/locking.py",
+        "line": 15,
+        "usages": [
+          "src/bioetl/application/composite/runner.py",
+          "src/bioetl/application/core/heartbeat.py",
+          "src/bioetl/application/core/lock_manager.py",
+          "src/bioetl/application/core/pipeline_services.py",
+          "src/bioetl/application/services/lock_service.py",
+          "src/bioetl/composition/factories/services_factory.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/infrastructure/locking/memory_lock.py",
+          "tests/architecture/test_lock_safety_guard.py",
+          "tests/architecture/test_port_contracts.py",
+          "tests/architecture/test_port_contracts_hypothesis.py",
+          "tests/smoke/test_smoke.py",
+          "tests/test_architecture.py",
+          "tests/unit/application/composite/test_runner_enrichment_fsm.py",
+          "tests/unit/application/composite/test_runner_fsm_logging.py",
+          "tests/unit/application/core/test_heartbeat.py",
+          "tests/unit/application/core/test_lock_manager.py",
+          "tests/unit/application/services/test_lock_service.py",
+          "tests/unit/domain/test_locking.py",
+          "tests/unit/test_ports.py"
+        ]
+      },
+      {
+        "name": "MemoryMonitorPort",
+        "file": "src/bioetl/domain/ports/memory.py",
+        "line": 39,
+        "usages": [
+          "src/bioetl/application/core/batch_executor.py",
+          "src/bioetl/application/core/batch_transformer.py",
+          "src/bioetl/composition/factories/services_factory.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/domain/ports/noop.py",
+          "src/bioetl/infrastructure/system/memory_monitor.py",
+          "tests/architecture/test_port_contracts.py",
+          "tests/architecture/test_port_contracts_hypothesis.py",
+          "tests/unit/application/core/test_batch_executor_memory.py"
+        ]
+      },
+      {
+        "name": "MetadataWriterPort",
+        "file": "src/bioetl/domain/ports/metadata.py",
+        "line": 26,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/domain/ports/noop.py",
+          "src/bioetl/infrastructure/storage/bronze_writer.py",
+          "src/bioetl/infrastructure/storage/gold_writer.py",
+          "src/bioetl/infrastructure/storage/metadata_writer.py",
+          "src/bioetl/infrastructure/storage/silver_writer.py",
+          "tests/architecture/test_domain_public_api.py",
+          "tests/unit/infrastructure/storage/test_metadata_integration.py"
+        ]
+      },
+      {
+        "name": "MetadataCoordinatorPort",
+        "file": "src/bioetl/domain/ports/metadata_coordinator.py",
+        "line": 153,
+        "usages": [
+          "src/bioetl/composition/services/metadata_coordinator.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/infrastructure/storage/bronze_writer.py",
+          "src/bioetl/infrastructure/storage/gold_writer.py",
+          "src/bioetl/infrastructure/storage/silver_writer.py"
+        ]
+      },
+      {
+        "name": "UnitConverterPort",
+        "file": "src/bioetl/domain/ports/normalization.py",
+        "line": 29,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py"
+        ]
+      },
+      {
+        "name": "ValueValidatorPort",
+        "file": "src/bioetl/domain/ports/normalization.py",
+        "line": 111,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py"
+        ]
+      },
+      {
+        "name": "OutlierFilterPort",
+        "file": "src/bioetl/domain/ports/normalization.py",
+        "line": 171,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py"
+        ]
+      },
+      {
+        "name": "ActivityAggregatorPort",
+        "file": "src/bioetl/domain/ports/normalization.py",
+        "line": 213,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py"
+        ]
+      },
+      {
+        "name": "NormalizationServicePort",
+        "file": "src/bioetl/domain/ports/normalization.py",
+        "line": 279,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/domain/ports/data_normalization.py"
+        ]
+      },
+      {
+        "name": "TracingPort",
+        "file": "src/bioetl/domain/ports/observability.py",
+        "line": 13,
+        "usages": [
+          "src/bioetl/application/core/base_transformer.py",
+          "src/bioetl/application/core/batch_executor.py",
+          "src/bioetl/application/core/batch_tracing.py",
+          "src/bioetl/application/core/batch_writer.py",
+          "src/bioetl/application/core/pipeline_services.py",
+          "src/bioetl/application/core/postrun_service.py",
+          "src/bioetl/application/core/record_processor.py",
+          "src/bioetl/application/core/runner.py",
+          "src/bioetl/application/observability/observer.py",
+          "src/bioetl/application/observability/span_helpers.py",
+          "src/bioetl/application/pipelines/chembl/base_chembl_transformer.py",
+          "src/bioetl/application/pipelines/chembl/publication_transformer.py",
+          "src/bioetl/application/pipelines/crossref/transformer.py",
+          "src/bioetl/application/pipelines/openalex/transformer.py",
+          "src/bioetl/application/pipelines/pubchem/transformer.py",
+          "src/bioetl/application/pipelines/pubmed/transformer.py",
+          "src/bioetl/application/pipelines/semanticscholar/transformer.py",
+          "src/bioetl/application/pipelines/uniprot/idmapping_transformer.py",
+          "src/bioetl/application/pipelines/uniprot/transformer.py",
+          "src/bioetl/composition/bootstrap/cli/noop.py",
+          "src/bioetl/composition/bootstrap/runtime/observability.py",
+          "src/bioetl/composition/factories/http_client_factory.py",
+          "src/bioetl/composition/factories/pipeline_factory.py",
+          "src/bioetl/composition/factories/services_factory.py",
+          "src/bioetl/composition/factories/storage_factory.py",
+          "src/bioetl/composition/factories/transformer_factory.py",
+          "src/bioetl/composition/observability.py",
+          "src/bioetl/composition/registry.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/domain/ports/noop.py",
+          "src/bioetl/infrastructure/adapters/http/client.py",
+          "src/bioetl/infrastructure/observability/noop_tracing.py",
+          "src/bioetl/infrastructure/observability/tracing.py",
+          "src/bioetl/infrastructure/storage/bronze_writer.py",
+          "src/bioetl/infrastructure/storage/gold_writer.py",
+          "src/bioetl/infrastructure/storage/silver_writer.py",
+          "tests/architecture/test_layer_dependencies.py",
+          "tests/architecture/test_port_contracts.py",
+          "tests/architecture/test_tracing_enforcement.py"
+        ]
+      },
+      {
+        "name": "MetricsPort",
+        "file": "src/bioetl/domain/ports/observability.py",
+        "line": 34,
+        "usages": [
+          "src/bioetl/application/core/base_transformer.py",
+          "src/bioetl/application/core/batch_metrics.py",
+          "src/bioetl/application/core/filtered_data_source.py",
+          "src/bioetl/application/core/pipeline_services.py",
+          "src/bioetl/application/core/postrun_service.py",
+          "src/bioetl/application/core/preflight_service.py",
+          "src/bioetl/application/core/shutdown.py",
+          "src/bioetl/application/observability/observer.py",
+          "src/bioetl/application/pipelines/chembl/base_chembl_transformer.py",
+          "src/bioetl/application/pipelines/chembl/publication_transformer.py",
+          "src/bioetl/application/pipelines/crossref/transformer.py",
+          "src/bioetl/application/pipelines/openalex/transformer.py",
+          "src/bioetl/application/pipelines/pubchem/transformer.py",
+          "src/bioetl/application/pipelines/pubmed/transformer.py",
+          "src/bioetl/application/pipelines/semanticscholar/transformer.py",
+          "src/bioetl/application/pipelines/uniprot/idmapping_transformer.py",
+          "src/bioetl/application/pipelines/uniprot/transformer.py",
+          "src/bioetl/application/services/data_quality_service.py",
+          "src/bioetl/application/services/medallion_lifecycle.py",
+          "src/bioetl/application/services/shutdown_service.py",
+          "src/bioetl/composition/bootstrap/cli/health.py",
+          "src/bioetl/composition/bootstrap/cli/noop.py",
+          "src/bioetl/composition/bootstrap/runtime/observability.py",
+          "src/bioetl/composition/factories/data_source_factory.py",
+          "src/bioetl/composition/factories/http_client_factory.py",
+          "src/bioetl/composition/factories/pipeline_factory.py",
+          "src/bioetl/composition/factories/services_factory.py",
+          "src/bioetl/composition/factories/storage_factory.py",
+          "src/bioetl/composition/factories/transformer_factory.py",
+          "src/bioetl/composition/observability.py",
+          "src/bioetl/composition/providers/provider_registry.py",
+          "src/bioetl/composition/providers/registration.py",
+          "src/bioetl/composition/registry.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/domain/ports/noop.py",
+          "src/bioetl/infrastructure/adapters/base.py",
+          "src/bioetl/infrastructure/adapters/base_metrics.py",
+          "src/bioetl/infrastructure/adapters/chembl/client.py",
+          "src/bioetl/infrastructure/adapters/crossref/client.py",
+          "src/bioetl/infrastructure/adapters/decorators/__init__.py",
+          "src/bioetl/infrastructure/adapters/decorators/circuit_breaker.py",
+          "src/bioetl/infrastructure/adapters/decorators/retry.py",
+          "src/bioetl/infrastructure/adapters/health_check_mixin.py",
+          "src/bioetl/infrastructure/adapters/http/circuit_breaker.py",
+          "src/bioetl/infrastructure/adapters/http/client.py",
+          "src/bioetl/infrastructure/adapters/http/health_monitor.py",
+          "src/bioetl/infrastructure/adapters/http/rate_limiter.py",
+          "src/bioetl/infrastructure/adapters/openalex/client.py",
+          "src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py",
+          "src/bioetl/infrastructure/adapters/semanticscholar/adapter.py",
+          "src/bioetl/infrastructure/adapters/sync_base.py",
+          "src/bioetl/infrastructure/adapters/uniprot/client.py",
+          "src/bioetl/infrastructure/adapters/uniprot/idmapping_client.py",
+          "src/bioetl/infrastructure/observability/noop_metrics.py",
+          "src/bioetl/infrastructure/observability/prometheus_metrics.py",
+          "src/bioetl/infrastructure/storage/bronze_writer.py",
+          "src/bioetl/infrastructure/storage/silver_writer.py",
+          "tests/architecture/test_domain_public_api.py",
+          "tests/architecture/test_layer_dependencies.py",
+          "tests/architecture/test_port_contracts.py",
+          "tests/architecture/test_port_contracts_hypothesis.py",
+          "tests/architecture/test_tracing_enforcement.py",
+          "tests/integration/pipelines/base.py",
+          "tests/integration/test_dq_monitor_integration.py",
+          "tests/test_architecture.py",
+          "tests/unit/composition/bootstrap/test_health_bootstrap.py",
+          "tests/unit/composition/test_observability_contract.py",
+          "tests/unit/infrastructure/adapters/http/test_health_monitor.py",
+          "tests/unit/infrastructure/storage/test_bronze_writer.py",
+          "tests/unit/infrastructure/storage/test_silver_writer.py",
+          "tests/unit/infrastructure/test_circuit_breaker.py",
+          "tests/unit/infrastructure/test_circuit_breaker_degradation.py",
+          "tests/unit/infrastructure/test_rate_limiter.py",
+          "tests/unit/test_bootstrap.py",
+          "tests/unit/test_ports.py"
+        ]
+      },
+      {
+        "name": "LoggerPort",
+        "file": "src/bioetl/domain/ports/observability.py",
+        "line": 102,
+        "usages": [
+          "src/bioetl/application/composite/aggregator.py",
+          "src/bioetl/application/composite/checkpoint.py",
+          "src/bioetl/application/composite/column_orderer.py",
+          "src/bioetl/application/composite/column_renamer.py",
+          "src/bioetl/application/composite/coordinator.py",
+          "src/bioetl/application/composite/deduplication.py",
+          "src/bioetl/application/composite/dependency_coordinator.py",
+          "src/bioetl/application/composite/fsm_helper.py",
+          "src/bioetl/application/composite/key_extractor.py",
+          "src/bioetl/application/composite/merger.py",
+          "src/bioetl/application/composite/preflight_validator.py",
+          "src/bioetl/application/composite/runner.py",
+          "src/bioetl/application/composite/runner_helpers.py",
+          "src/bioetl/application/core/base.py",
+          "src/bioetl/application/core/batch_executor.py",
+          "src/bioetl/application/core/checkpoint_manager.py",
+          "src/bioetl/application/core/cleanup_service.py",
+          "src/bioetl/application/core/filtered_data_source.py",
+          "src/bioetl/application/core/heartbeat.py",
+          "src/bioetl/application/core/idmapping_data_source.py",
+          "src/bioetl/application/core/lock_manager.py",
+          "src/bioetl/application/core/pipeline_services.py",
+          "src/bioetl/application/core/postrun_service.py",
+          "src/bioetl/application/core/preflight_service.py",
+          "src/bioetl/application/core/runner.py",
+          "src/bioetl/application/core/shutdown.py",
+          "src/bioetl/application/observability/observer.py",
+          "src/bioetl/application/services/bronze_cleanup_service.py",
+          "src/bioetl/application/services/checkpoint_service.py",
+          "src/bioetl/application/services/config_service.py",
+          "src/bioetl/application/services/data_quality_service.py",
+          "src/bioetl/application/services/dq_report_service.py",
+          "src/bioetl/application/services/export_service.py",
+          "src/bioetl/application/services/health_service.py",
+          "src/bioetl/application/services/lock_service.py",
+          "src/bioetl/application/services/medallion_lifecycle.py",
+          "src/bioetl/application/services/metrics_service.py",
+          "src/bioetl/application/services/pipeline_runner_service.py",
+          "src/bioetl/application/services/quarantine_service.py",
+          "src/bioetl/application/services/shutdown_service.py",
+          "src/bioetl/application/services/vacuum_service.py",
+          "src/bioetl/composition/bootstrap/cli/noop.py",
+          "src/bioetl/composition/bootstrap/runtime/composite.py",
+          "src/bioetl/composition/bootstrap/runtime/observability.py",
+          "src/bioetl/composition/bootstrap_logger.py",
+          "src/bioetl/composition/factories/data_source_factory.py",
+          "src/bioetl/composition/factories/dq_factory.py",
+          "src/bioetl/composition/factories/http_client_factory.py",
+          "src/bioetl/composition/factories/pipeline_factory.py",
+          "src/bioetl/composition/factories/services_factory.py",
+          "src/bioetl/composition/factories/storage_factory.py",
+          "src/bioetl/composition/observability.py",
+          "src/bioetl/composition/providers/provider_registry.py",
+          "src/bioetl/composition/providers/registration.py",
+          "src/bioetl/composition/registry.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/context.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/domain/ports/health_check.py",
+          "src/bioetl/infrastructure/adapters/base.py",
+          "src/bioetl/infrastructure/adapters/cached_bronze_data_source.py",
+          "src/bioetl/infrastructure/adapters/chembl/client.py",
+          "src/bioetl/infrastructure/adapters/common/base_title_fallback.py",
+          "src/bioetl/infrastructure/adapters/crossref/batch.py",
+          "src/bioetl/infrastructure/adapters/crossref/client.py",
+          "src/bioetl/infrastructure/adapters/crossref/fallback.py",
+          "src/bioetl/infrastructure/adapters/decorators/__init__.py",
+          "src/bioetl/infrastructure/adapters/decorators/circuit_breaker.py",
+          "src/bioetl/infrastructure/adapters/decorators/retry.py",
+          "src/bioetl/infrastructure/adapters/error_handling.py",
+          "src/bioetl/infrastructure/adapters/health_check_mixin.py",
+          "src/bioetl/infrastructure/adapters/http/client.py",
+          "src/bioetl/infrastructure/adapters/http/health_monitor.py",
+          "src/bioetl/infrastructure/adapters/input/csv_filter_reader.py",
+          "src/bioetl/infrastructure/adapters/logging_utils.py",
+          "src/bioetl/infrastructure/adapters/openalex/client.py",
+          "src/bioetl/infrastructure/adapters/openalex/fallback.py",
+          "src/bioetl/infrastructure/adapters/pubchem/client.py",
+          "src/bioetl/infrastructure/adapters/pubchem/fetch_strategies.py",
+          "src/bioetl/infrastructure/adapters/pubmed/fallback.py",
+          "src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py",
+          "src/bioetl/infrastructure/adapters/semanticscholar/adapter.py",
+          "src/bioetl/infrastructure/adapters/semanticscholar/fallback.py",
+          "src/bioetl/infrastructure/adapters/sync_base.py",
+          "src/bioetl/infrastructure/adapters/uniprot/client.py",
+          "src/bioetl/infrastructure/adapters/uniprot/idmapping_client.py",
+          "src/bioetl/infrastructure/adapters/validation.py",
+          "src/bioetl/infrastructure/audit/file_audit.py",
+          "src/bioetl/infrastructure/export/csv_exporter.py",
+          "src/bioetl/infrastructure/export/dq_report_writer.py",
+          "src/bioetl/infrastructure/observability/anomaly/monitor.py",
+          "src/bioetl/infrastructure/observability/logging.py",
+          "src/bioetl/infrastructure/observability/metrics_server_adapter.py",
+          "src/bioetl/infrastructure/observability/noop_logger.py",
+          "src/bioetl/infrastructure/observability/server.py",
+          "src/bioetl/infrastructure/observability/unified_logger.py",
+          "src/bioetl/infrastructure/storage/arrow_converter.py",
+          "src/bioetl/infrastructure/storage/base_delta_writer.py",
+          "src/bioetl/infrastructure/storage/bronze_writer.py",
+          "src/bioetl/infrastructure/storage/delta_reader.py",
+          "src/bioetl/infrastructure/storage/gold_writer.py",
+          "src/bioetl/infrastructure/storage/metadata_writer.py",
+          "src/bioetl/infrastructure/storage/silver_writer.py",
+          "src/bioetl/infrastructure/system/memory_monitor.py",
+          "src/bioetl/interfaces/cli/commands/run_helpers.py",
+          "src/bioetl/interfaces/http/health_server.py",
+          "tests/architecture/test_no_logging_getlogger_in_infrastructure.py",
+          "tests/architecture/test_no_print_in_docstrings.py",
+          "tests/architecture/test_no_structlog_in_application_interfaces.py",
+          "tests/architecture/test_port_contracts.py",
+          "tests/architecture/test_port_contracts_hypothesis.py",
+          "tests/integration/composite/test_molecule_pipeline.py",
+          "tests/integration/test_dq_monitor_integration.py",
+          "tests/unit/application/composite/test_composite_activity.py",
+          "tests/unit/application/composite/test_coordinator_logging.py",
+          "tests/unit/application/composite/test_dependency_coordinator.py",
+          "tests/unit/application/composite/test_merger.py",
+          "tests/unit/application/composite/test_runner_enrichment_fsm.py",
+          "tests/unit/application/composite/test_runner_fsm_logging.py",
+          "tests/unit/application/core/test_dq_report_integration.py",
+          "tests/unit/application/services/test_export_service.py",
+          "tests/unit/infrastructure/adapters/pubchem/test_fetch_strategies.py",
+          "tests/unit/infrastructure/adapters/test_csv_filter_reader.py",
+          "tests/unit/infrastructure/observability/test_logging.py",
+          "tests/unit/infrastructure/observability/test_unified_logger.py"
+        ]
+      },
+      {
+        "name": "DQMonitorPort",
+        "file": "src/bioetl/domain/ports/observability.py",
+        "line": 142,
+        "usages": [
+          "src/bioetl/application/core/pipeline_services.py",
+          "src/bioetl/application/services/data_quality_service.py",
+          "src/bioetl/composition/bootstrap/runtime/observability.py",
+          "src/bioetl/composition/factories/pipeline_factory.py",
+          "src/bioetl/composition/factories/services_factory.py",
+          "src/bioetl/composition/observability.py",
+          "src/bioetl/composition/registry.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "tests/architecture/test_port_contracts.py"
+        ]
+      },
+      {
+        "name": "PiiHasherPort",
+        "file": "src/bioetl/domain/ports/pii.py",
+        "line": 16,
+        "usages": [
+          "src/bioetl/application/core/base_transformer.py",
+          "src/bioetl/application/pipelines/chembl/base_chembl_transformer.py",
+          "src/bioetl/application/pipelines/chembl/publication_transformer.py",
+          "src/bioetl/application/pipelines/crossref/transformer.py",
+          "src/bioetl/application/pipelines/openalex/transformer.py",
+          "src/bioetl/application/pipelines/pubchem/transformer.py",
+          "src/bioetl/application/pipelines/pubmed/transformer.py",
+          "src/bioetl/application/pipelines/semanticscholar/transformer.py",
+          "src/bioetl/application/pipelines/uniprot/idmapping_transformer.py",
+          "src/bioetl/application/pipelines/uniprot/transformer.py",
+          "src/bioetl/composition/factories/pipeline_factory.py",
+          "src/bioetl/composition/factories/transformer_factory.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/domain/ports/noop.py",
+          "src/bioetl/infrastructure/security/pii_hasher.py",
+          "tests/architecture/test_pii_hashing.py",
+          "tests/unit/infrastructure/security/test_pii_hasher.py"
+        ]
+      },
+      {
+        "name": "QuarantinePort",
+        "file": "src/bioetl/domain/ports/quarantine.py",
+        "line": 17,
+        "usages": [
+          "src/bioetl/application/core/pipeline_services.py",
+          "src/bioetl/application/core/quarantine_manager.py",
+          "src/bioetl/application/services/quarantine_service.py",
+          "src/bioetl/composition/bootstrap/assembly/checkpoint.py",
+          "src/bioetl/composition/entrypoints.py",
+          "src/bioetl/composition/factories/services_factory.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/infrastructure/quarantine/unified.py",
+          "tests/architecture/test_port_contracts.py",
+          "tests/fakes/quarantine_fake.py",
+          "tests/test_architecture.py",
+          "tests/unit/composition/bootstrap/test_checkpoint_bootstrap.py",
+          "tests/unit/test_ports.py"
+        ]
+      },
+      {
+        "name": "RateLimiterPort",
+        "file": "src/bioetl/domain/ports/resilience.py",
+        "line": 21,
+        "usages": [
+          "src/bioetl/composition/factories/http_client_factory.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/infrastructure/adapters/http/__init__.py",
+          "src/bioetl/infrastructure/adapters/http/client.py",
+          "tests/architecture/test_port_contracts.py",
+          "tests/architecture/test_port_contracts_hypothesis.py"
+        ]
+      },
+      {
+        "name": "CircuitBreakerPort",
+        "file": "src/bioetl/domain/ports/resilience.py",
+        "line": 68,
+        "usages": [
+          "src/bioetl/composition/factories/http_client_factory.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/infrastructure/adapters/base.py",
+          "src/bioetl/infrastructure/adapters/decorators/__init__.py",
+          "src/bioetl/infrastructure/adapters/decorators/circuit_breaker.py",
+          "src/bioetl/infrastructure/adapters/health_check_mixin.py",
+          "src/bioetl/infrastructure/adapters/http/__init__.py",
+          "src/bioetl/infrastructure/adapters/http/client.py",
+          "src/bioetl/infrastructure/adapters/http/health.py",
+          "src/bioetl/infrastructure/adapters/sync_base.py",
+          "tests/architecture/test_port_contracts.py",
+          "tests/architecture/test_port_contracts_hypothesis.py"
+        ]
+      },
+      {
+        "name": "RunnablePort",
+        "file": "src/bioetl/domain/ports/runner.py",
+        "line": 15,
+        "usages": [
+          "src/bioetl/application/services/pipeline_runner_service.py",
+          "src/bioetl/composition/factories/runner_factory.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "tests/unit/application/services/test_pipeline_runner_service.py"
+        ]
+      },
+      {
+        "name": "RunnerFactoryPort",
+        "file": "src/bioetl/domain/ports/runner.py",
+        "line": 32,
+        "usages": [
+          "src/bioetl/application/services/pipeline_runner_service.py",
+          "src/bioetl/composition/factories/runner_factory.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py"
+        ]
+      },
+      {
+        "name": "MetricsExtractorPort",
+        "file": "src/bioetl/domain/ports/runner.py",
+        "line": 80,
+        "usages": [
+          "src/bioetl/application/services/pipeline_runner_service.py",
+          "src/bioetl/composition/factories/runner_factory.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py"
+        ]
+      },
+      {
+        "name": "JsonEncoderPort",
+        "file": "src/bioetl/domain/ports/serialization.py",
+        "line": 21,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/domain/serialization.py",
+          "src/bioetl/infrastructure/serialization/encoders.py",
+          "tests/architecture/test_port_contracts.py",
+          "tests/architecture/test_port_contracts_hypothesis.py",
+          "tests/unit/infrastructure/serialization/test_json_encoders.py"
+        ]
+      },
+      {
+        "name": "ShutdownPort",
+        "file": "src/bioetl/domain/ports/shutdown.py",
+        "line": 13,
+        "usages": [
+          "src/bioetl/application/core/shutdown.py",
+          "src/bioetl/application/services/shutdown_service.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "tests/unit/application/core/test_shutdown.py"
+        ]
+      },
+      {
+        "name": "StoragePort",
+        "file": "src/bioetl/domain/ports/storage.py",
+        "line": 32,
+        "usages": [
+          "src/bioetl/application/composite/merger.py",
+          "src/bioetl/application/core/batch_writer.py",
+          "src/bioetl/application/core/cleanup_service.py",
+          "src/bioetl/application/core/pipeline_services.py",
+          "src/bioetl/application/services/bronze_cleanup_service.py",
+          "src/bioetl/application/services/medallion_lifecycle.py",
+          "src/bioetl/composition/factories/storage_adapter.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/domain/ports/delta_reader.py",
+          "tests/architecture/test_code_metrics.py",
+          "tests/architecture/test_di_compliance.py",
+          "tests/architecture/test_domain_public_api.py",
+          "tests/architecture/test_forbidden_imports.py",
+          "tests/architecture/test_layer_dependencies.py",
+          "tests/architecture/test_port_contracts.py",
+          "tests/fakes/storage_fake.py",
+          "tests/integration/memory_storage.py",
+          "tests/smoke/test_smoke.py",
+          "tests/test_architecture.py",
+          "tests/unit/application/composite/test_merger.py",
+          "tests/unit/application/core/test_runner.py",
+          "tests/unit/infrastructure/factories/test_storage_adapter.py",
+          "tests/unit/test_ports.py"
+        ]
+      },
+      {
+        "name": "SilverValidatorPort",
+        "file": "src/bioetl/domain/ports/validation.py",
+        "line": 17,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/infrastructure/storage/silver_writer.py",
+          "src/bioetl/infrastructure/validation/__init__.py",
+          "src/bioetl/infrastructure/validation/pandera_validator.py",
+          "tests/unit/infrastructure/storage/test_silver_writer_validation.py",
+          "tests/unit/infrastructure/validation/test_pandera_validator.py"
+        ]
+      },
+      {
+        "name": "GoldValidatorPort",
+        "file": "src/bioetl/domain/ports/validation.py",
+        "line": 41,
+        "usages": [
+          "src/bioetl/application/core/batch_executor.py",
+          "src/bioetl/application/core/batch_writer.py",
+          "src/bioetl/application/core/record_processor.py",
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py",
+          "src/bioetl/infrastructure/validation/__init__.py",
+          "src/bioetl/infrastructure/validation/pandera_validator.py",
+          "tests/architecture/test_port_contracts.py",
+          "tests/unit/infrastructure/validation/test_pandera_validator.py"
+        ]
+      },
+      {
+        "name": "WatermarkStrategyPort",
+        "file": "src/bioetl/domain/ports/watermark.py",
+        "line": 22,
+        "usages": [
+          "src/bioetl/domain/__init__.py",
+          "src/bioetl/domain/ports/__init__.py"
+        ]
+      }
+    ],
+    "Pandera": [
+      {
+        "name": "ChEMBLActivityGoldSchema",
+        "file": "src/bioetl/domain/contracts/gold/chembl.py",
+        "line": 29,
+        "usages": [
+          "src/bioetl/composition/factories/pipeline_factories.py",
+          "src/bioetl/domain/contracts/__init__.py",
+          "src/bioetl/domain/contracts/gold/__init__.py",
+          "src/tools/scripts/generate_contracts.py",
+          "src/tools/verify_schema_parity.py",
+          "tests/unit/contracts/test_contracts_exports.py"
+        ]
+      },
+      {
+        "name": "ChEMBLAssayGoldSchema",
+        "file": "src/bioetl/domain/contracts/gold/chembl.py",
+        "line": 130,
+        "usages": [
+          "src/bioetl/composition/factories/pipeline_factories.py",
+          "src/bioetl/domain/contracts/__init__.py",
+          "src/bioetl/domain/contracts/gold/__init__.py",
+          "src/tools/verify_schema_parity.py",
+          "tests/unit/contracts/test_contracts_exports.py"
+        ]
+      },
+      {
+        "name": "ChEMBLAssayParametersGoldSchema",
+        "file": "src/bioetl/domain/contracts/gold/chembl.py",
+        "line": 190,
+        "usages": [
+          "src/bioetl/composition/factories/pipeline_factories.py",
+          "src/bioetl/domain/contracts/__init__.py",
+          "src/bioetl/domain/contracts/gold/__init__.py",
+          "tests/unit/contracts/test_contracts_exports.py"
+        ]
+      },
+      {
+        "name": "ChEMBLCellLineGoldSchema",
+        "file": "src/bioetl/domain/contracts/gold/chembl.py",
+        "line": 238,
+        "usages": [
+          "src/bioetl/composition/factories/pipeline_factories.py",
+          "src/bioetl/domain/contracts/__init__.py",
+          "src/bioetl/domain/contracts/gold/__init__.py",
+          "tests/unit/contracts/test_contracts_exports.py"
+        ]
+      },
+      {
+        "name": "ChEMBLCompoundRecordGoldSchema",
+        "file": "src/bioetl/domain/contracts/gold/chembl.py",
+        "line": 277,
+        "usages": [
+          "src/bioetl/composition/factories/pipeline_factories.py",
+          "src/bioetl/domain/contracts/__init__.py",
+          "src/bioetl/domain/contracts/gold/__init__.py",
+          "tests/unit/contracts/test_contracts_exports.py"
+        ]
+      },
+      {
+        "name": "ChEMBLDocumentGoldSchema",
+        "file": "src/bioetl/domain/contracts/gold/chembl.py",
+        "line": 312,
+        "usages": [
+          "src/bioetl/composition/factories/pipeline_factories.py",
+          "src/bioetl/domain/contracts/__init__.py",
+          "src/bioetl/domain/contracts/gold/__init__.py",
+          "tests/unit/contracts/test_contracts_exports.py",
+          "tests/unit/infrastructure/schemas/test_gold.py"
+        ]
+      },
+      {
+        "name": "ChEMBLDocumentSimilarityGoldSchema",
+        "file": "src/bioetl/domain/contracts/gold/chembl.py",
+        "line": 370,
+        "usages": [
+          "src/bioetl/composition/factories/pipeline_factories.py",
+          "src/bioetl/domain/contracts/__init__.py",
+          "src/bioetl/domain/contracts/gold/__init__.py",
+          "tests/unit/contracts/test_contracts_exports.py"
+        ]
+      },
+      {
+        "name": "ChEMBLDocumentTermGoldSchema",
+        "file": "src/bioetl/domain/contracts/gold/chembl.py",
+        "line": 412,
+        "usages": [
+          "src/bioetl/composition/factories/pipeline_factories.py",
+          "src/bioetl/domain/contracts/__init__.py",
+          "src/bioetl/domain/contracts/gold/__init__.py",
+          "tests/unit/contracts/test_contracts_exports.py"
+        ]
+      },
+      {
+        "name": "ChEMBLMoleculeGoldSchema",
+        "file": "src/bioetl/domain/contracts/gold/chembl.py",
+        "line": 445,
+        "usages": [
+          "src/bioetl/composition/factories/pipeline_factories.py",
+          "src/bioetl/domain/contracts/__init__.py",
+          "src/bioetl/domain/contracts/gold/__init__.py",
+          "src/tools/verify_schema_parity.py",
+          "tests/unit/contracts/test_contracts_exports.py"
+        ]
+      },
+      {
+        "name": "ChEMBLProteinClassGoldSchema",
+        "file": "src/bioetl/domain/contracts/gold/chembl.py",
+        "line": 520,
+        "usages": [
+          "src/bioetl/composition/factories/pipeline_factories.py",
+          "src/bioetl/domain/contracts/__init__.py",
+          "src/bioetl/domain/contracts/gold/__init__.py",
+          "tests/unit/contracts/test_contracts_exports.py"
+        ]
+      },
+      {
+        "name": "ChEMBLTargetGoldSchema",
+        "file": "src/bioetl/domain/contracts/gold/chembl.py",
+        "line": 562,
+        "usages": [
+          "src/bioetl/composition/factories/pipeline_factories.py",
+          "src/bioetl/domain/contracts/__init__.py",
+          "src/bioetl/domain/contracts/gold/__init__.py",
+          "src/tools/verify_schema_parity.py",
+          "tests/unit/contracts/test_contracts_exports.py"
+        ]
+      },
+      {
+        "name": "ChEMBLTargetComponentGoldSchema",
+        "file": "src/bioetl/domain/contracts/gold/chembl.py",
+        "line": 601,
+        "usages": [
+          "src/bioetl/composition/factories/pipeline_factories.py",
+          "src/bioetl/domain/contracts/__init__.py",
+          "src/bioetl/domain/contracts/gold/__init__.py",
+          "tests/unit/contracts/test_contracts_exports.py"
+        ]
+      },
+      {
+        "name": "ChEMBLTissueGoldSchema",
+        "file": "src/bioetl/domain/contracts/gold/chembl.py",
+        "line": 635,
+        "usages": [
+          "src/bioetl/composition/factories/pipeline_factories.py",
+          "src/bioetl/domain/contracts/__init__.py",
+          "src/bioetl/domain/contracts/gold/__init__.py"
+        ]
+      },
+      {
+        "name": "ChEMBLSubcellularFractionGoldSchema",
+        "file": "src/bioetl/domain/contracts/gold/chembl.py",
+        "line": 693,
+        "usages": [
+          "src/bioetl/composition/factories/pipeline_factories.py",
+          "src/bioetl/domain/contracts/__init__.py",
+          "src/bioetl/domain/contracts/gold/__init__.py"
+        ]
+      },
+      {
+        "name": "CompositePublicationGoldSchema",
+        "file": "src/bioetl/domain/contracts/gold/composite.py",
+        "line": 27,
+        "usages": [
+          "src/bioetl/domain/contracts/gold/__init__.py"
+        ]
+      },
+      {
+        "name": "CompositeMoleculeGoldSchema",
+        "file": "src/bioetl/domain/contracts/gold/composite.py",
+        "line": 124,
+        "usages": []
+      },
+      {
+        "name": "PubChemCompoundGoldSchema",
+        "file": "src/bioetl/domain/contracts/gold/pubchem.py",
+        "line": 18,
+        "usages": [
+          "src/bioetl/composition/factories/pipeline_factories.py",
+          "src/bioetl/domain/contracts/__init__.py",
+          "src/bioetl/domain/contracts/gold/__init__.py",
+          "src/tools/scripts/generate_contracts.py",
+          "tests/unit/contracts/test_contracts_exports.py"
+        ]
+      },
+      {
+        "name": "PubMedPublicationGoldSchema",
+        "file": "src/bioetl/domain/contracts/gold/publications.py",
+        "line": 22,
+        "usages": [
+          "src/bioetl/composition/factories/pipeline_factories.py",
+          "src/bioetl/domain/contracts/__init__.py",
+          "src/bioetl/domain/contracts/gold/__init__.py",
+          "src/tools/scripts/generate_contracts.py",
+          "tests/unit/contracts/test_contracts_exports.py",
+          "tests/unit/infrastructure/schemas/test_gold.py"
+        ]
+      },
+      {
+        "name": "CrossRefPublicationGoldSchema",
+        "file": "src/bioetl/domain/contracts/gold/publications.py",
+        "line": 148,
+        "usages": [
+          "src/bioetl/composition/factories/pipeline_factories.py",
+          "src/bioetl/domain/contracts/__init__.py",
+          "src/bioetl/domain/contracts/gold/__init__.py",
+          "tests/unit/contracts/test_contracts_exports.py",
+          "tests/unit/infrastructure/schemas/test_gold.py"
+        ]
+      },
+      {
+        "name": "OpenAlexPublicationGoldSchema",
+        "file": "src/bioetl/domain/contracts/gold/publications.py",
+        "line": 254,
+        "usages": [
+          "src/bioetl/composition/factories/pipeline_factories.py",
+          "src/bioetl/domain/contracts/__init__.py",
+          "src/bioetl/domain/contracts/gold/__init__.py",
+          "tests/unit/contracts/test_contracts_exports.py",
+          "tests/unit/infrastructure/schemas/test_gold.py"
+        ]
+      },
+      {
+        "name": "SemanticScholarPublicationGoldSchema",
+        "file": "src/bioetl/domain/contracts/gold/publications.py",
+        "line": 364,
+        "usages": [
+          "src/bioetl/composition/factories/pipeline_factories.py",
+          "src/bioetl/domain/contracts/__init__.py",
+          "src/bioetl/domain/contracts/gold/__init__.py",
+          "tests/unit/contracts/test_contracts_exports.py",
+          "tests/unit/infrastructure/schemas/test_gold.py"
+        ]
+      },
+      {
+        "name": "UniProtProteinGoldSchema",
+        "file": "src/bioetl/domain/contracts/gold/uniprot.py",
+        "line": 19,
+        "usages": [
+          "src/bioetl/composition/factories/pipeline_factories.py",
+          "src/bioetl/domain/contracts/__init__.py",
+          "src/bioetl/domain/contracts/gold/__init__.py",
+          "src/tools/scripts/generate_contracts.py",
+          "tests/unit/contracts/test_contracts_exports.py"
+        ]
+      },
+      {
+        "name": "UniProtIDMappingGoldSchema",
+        "file": "src/bioetl/domain/contracts/gold/uniprot.py",
+        "line": 89,
+        "usages": [
+          "src/bioetl/composition/factories/pipeline_factories.py",
+          "src/bioetl/domain/contracts/__init__.py",
+          "src/bioetl/domain/contracts/gold/__init__.py",
+          "tests/unit/contracts/test_contracts_exports.py"
+        ]
+      },
+      {
+        "name": "ETLRecordSchema",
+        "file": "src/bioetl/domain/schemas/base.py",
+        "line": 18,
+        "usages": [
+          "src/bioetl/domain/schemas/chembl/activity.py",
+          "src/bioetl/domain/schemas/chembl/assay.py",
+          "src/bioetl/domain/schemas/chembl/assay_parameters.py",
+          "src/bioetl/domain/schemas/chembl/cell_line.py",
+          "src/bioetl/domain/schemas/chembl/compound_record.py",
+          "src/bioetl/domain/schemas/chembl/molecule.py",
+          "src/bioetl/domain/schemas/chembl/molecule_form.py",
+          "src/bioetl/domain/schemas/chembl/protein_classification.py",
+          "src/bioetl/domain/schemas/chembl/publication_similarity.py",
+          "src/bioetl/domain/schemas/chembl/publication_term.py",
+          "src/bioetl/domain/schemas/chembl/target.py",
+          "src/bioetl/domain/schemas/chembl/target_component.py",
+          "src/bioetl/domain/schemas/chembl/target_relation.py",
+          "src/bioetl/domain/schemas/common/publication_base.py",
+          "src/bioetl/domain/schemas/crossref/author.py",
+          "src/bioetl/domain/schemas/crossref/funder.py",
+          "src/bioetl/domain/schemas/crossref/reference.py",
+          "src/bioetl/domain/schemas/crossref/work.py",
+          "src/bioetl/domain/schemas/pubchem/compound.py",
+          "src/bioetl/domain/schemas/uniprot/idmapping.py",
+          "src/bioetl/domain/schemas/uniprot/isoform.py",
+          "src/bioetl/domain/schemas/uniprot/protein.py",
+          "tests/unit/domain/schemas/common/test_publication_base.py"
+        ]
+      }
+    ]
+  },
+  "summary": {
+    "BaseModel": 107,
+    "dataclass": 221,
+    "TypedDict": 39,
+    "Protocol": 51,
+    "Pandera": 24
+  },
+  "orphans": [
+    {
+      "name": "OpenAlexPublicationRecord",
+      "file": "src/bioetl/domain/entities/openalex.py",
+      "line": 46,
+      "usages": []
+    },
+    {
+      "name": "AggregationFieldSchema",
+      "file": "src/bioetl/infrastructure/schemas/composite_config.py",
+      "line": 42,
+      "usages": []
+    },
+    {
+      "name": "AggregationSchema",
+      "file": "src/bioetl/infrastructure/schemas/composite_config.py",
+      "line": 76,
+      "usages": []
+    },
+    {
+      "name": "DependencySchema",
+      "file": "src/bioetl/infrastructure/schemas/composite_config.py",
+      "line": 132,
+      "usages": []
+    },
+    {
+      "name": "CsvExportConfig",
+      "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+      "line": 281,
+      "usages": []
+    },
+    {
+      "name": "RateLimitSourceConfig",
+      "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+      "line": 440,
+      "usages": []
+    },
+    {
+      "name": "ClientSourceConfig",
+      "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+      "line": 450,
+      "usages": []
+    },
+    {
+      "name": "ProviderSourceConfig",
+      "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+      "line": 457,
+      "usages": []
+    },
+    {
+      "name": "SinkDQReportConfig",
+      "file": "src/bioetl/infrastructure/schemas/pipeline_config.py",
+      "line": 510,
+      "usages": []
+    },
+    {
+      "name": "ProviderConfigYaml",
+      "file": "src/bioetl/infrastructure/schemas/source_config.py",
+      "line": 76,
+      "usages": []
+    },
+    {
+      "name": "SourceSectionConfig",
+      "file": "src/bioetl/infrastructure/schemas/source_config.py",
+      "line": 101,
+      "usages": []
+    },
+    {
+      "name": "PipelineStarted",
+      "file": "src/bioetl/domain/aggregates/events.py",
+      "line": 48,
+      "usages": []
+    },
+    {
+      "name": "StageCompleted",
+      "file": "src/bioetl/domain/aggregates/events.py",
+      "line": 103,
+      "usages": []
+    },
+    {
+      "name": "DQThresholdExceeded",
+      "file": "src/bioetl/domain/aggregates/events.py",
+      "line": 233,
+      "usages": []
+    },
+    {
+      "name": "SchemaEvolutionDetected",
+      "file": "src/bioetl/domain/aggregates/events.py",
+      "line": 249,
+      "usages": []
+    },
+    {
+      "name": "BaseDQReport",
+      "file": "src/bioetl/domain/value_objects/dq_report.py",
+      "line": 495,
+      "usages": []
+    },
+    {
+      "name": "RawClassification",
+      "file": "src/bioetl/application/pipelines/pubmed/extractors/classification.py",
+      "line": 14,
+      "usages": []
+    },
+    {
+      "name": "NormalizedClassification",
+      "file": "src/bioetl/application/pipelines/pubmed/extractors/classification.py",
+      "line": 22,
+      "usages": []
+    },
+    {
+      "name": "RawDate",
+      "file": "src/bioetl/application/pipelines/pubmed/extractors/date.py",
+      "line": 25,
+      "usages": []
+    },
+    {
+      "name": "RawIdentifiers",
+      "file": "src/bioetl/application/pipelines/pubmed/extractors/identifier.py",
+      "line": 15,
+      "usages": []
+    },
+    {
+      "name": "NormalizedIdentifiers",
+      "file": "src/bioetl/application/pipelines/pubmed/extractors/identifier.py",
+      "line": 22,
+      "usages": []
+    },
+    {
+      "name": "GoldColumnFilterDict",
+      "file": "src/bioetl/domain/config_types.py",
+      "line": 19,
+      "usages": []
+    },
+    {
+      "name": "GoldValidationDict",
+      "file": "src/bioetl/domain/config_types.py",
+      "line": 91,
+      "usages": []
+    },
+    {
+      "name": "ColumnGroupDict",
+      "file": "src/bioetl/domain/config_types.py",
+      "line": 133,
+      "usages": []
+    },
+    {
+      "name": "FieldValidationDict",
+      "file": "src/bioetl/domain/config_types.py",
+      "line": 164,
+      "usages": []
+    },
+    {
+      "name": "ExecutorMetricsProtocol",
+      "file": "src/bioetl/application/core/postrun_service.py",
+      "line": 44,
+      "usages": []
+    },
+    {
+      "name": "CompositeMoleculeGoldSchema",
+      "file": "src/bioetl/domain/contracts/gold/composite.py",
+      "line": 124,
+      "usages": []
+    }
+  ],
+  "medallion_schema_generation": [
+    {
+      "pipeline": "chembl_activity",
+      "config": "configs/pipelines/chembl/activity.yaml",
+      "bronze_generator": "configs/data_schema/chembl/activity.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#chembl_activity",
+      "gold_generator": "src/bioetl/domain/schemas/chembl/activity.py"
+    },
+    {
+      "pipeline": "chembl_assay",
+      "config": "configs/pipelines/chembl/assay.yaml",
+      "bronze_generator": "configs/data_schema/chembl/assay.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#chembl_assay",
+      "gold_generator": "src/bioetl/domain/schemas/chembl/assay.py"
+    },
+    {
+      "pipeline": "chembl_assay_parameters",
+      "config": "configs/pipelines/chembl/assay_parameters.yaml",
+      "bronze_generator": "configs/data_schema/chembl/assay_parameters.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#chembl_assay_parameters",
+      "gold_generator": "src/bioetl/domain/schemas/chembl/assay_parameters.py"
+    },
+    {
+      "pipeline": "chembl_cell_line",
+      "config": "configs/pipelines/chembl/cell_line.yaml",
+      "bronze_generator": "configs/data_schema/chembl/cell_line.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#chembl_cell_line",
+      "gold_generator": "src/bioetl/domain/schemas/chembl/cell_line.py"
+    },
+    {
+      "pipeline": "chembl_compound_record",
+      "config": "configs/pipelines/chembl/compound_record.yaml",
+      "bronze_generator": "configs/data_schema/chembl/compound_record.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#chembl_compound_record",
+      "gold_generator": "src/bioetl/domain/schemas/chembl/compound_record.py"
+    },
+    {
+      "pipeline": "chembl_molecule",
+      "config": "configs/pipelines/chembl/molecule.yaml",
+      "bronze_generator": "configs/data_schema/chembl/molecule.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#chembl_molecule",
+      "gold_generator": "src/bioetl/domain/schemas/chembl/molecule.py"
+    },
+    {
+      "pipeline": "chembl_protein_class",
+      "config": "configs/pipelines/chembl/protein_class.yaml",
+      "bronze_generator": "configs/data_schema/chembl/protein_class.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#chembl_protein_class",
+      "gold_generator": "src/bioetl/domain/schemas/chembl/protein_class.py"
+    },
+    {
+      "pipeline": "chembl_publication",
+      "config": "configs/pipelines/chembl/publication.yaml",
+      "bronze_generator": "configs/data_schema/chembl/publication.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#chembl_publication",
+      "gold_generator": "src/bioetl/domain/schemas/chembl/publication.py"
+    },
+    {
+      "pipeline": "chembl_publication_similarity",
+      "config": "configs/pipelines/chembl/publication_similarity.yaml",
+      "bronze_generator": "configs/data_schema/chembl/publication_similarity.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#chembl_publication_similarity",
+      "gold_generator": "src/bioetl/domain/schemas/chembl/publication_similarity.py"
+    },
+    {
+      "pipeline": "chembl_publication_term",
+      "config": "configs/pipelines/chembl/publication_term.yaml",
+      "bronze_generator": "configs/data_schema/chembl/publication_term.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#chembl_publication_term",
+      "gold_generator": "src/bioetl/domain/schemas/chembl/publication_term.py"
+    },
+    {
+      "pipeline": "chembl_subcellular_fraction",
+      "config": "configs/pipelines/chembl/subcellular_fraction.yaml",
+      "bronze_generator": "configs/data_schema/chembl/subcellular_fraction.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#chembl_subcellular_fraction",
+      "gold_generator": "src/bioetl/domain/schemas/chembl/subcellular_fraction.py"
+    },
+    {
+      "pipeline": "chembl_target",
+      "config": "configs/pipelines/chembl/target.yaml",
+      "bronze_generator": "configs/data_schema/chembl/target.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#chembl_target",
+      "gold_generator": "src/bioetl/domain/schemas/chembl/target.py"
+    },
+    {
+      "pipeline": "chembl_target_component",
+      "config": "configs/pipelines/chembl/target_component.yaml",
+      "bronze_generator": "configs/data_schema/chembl/target_component.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#chembl_target_component",
+      "gold_generator": "src/bioetl/domain/schemas/chembl/target_component.py"
+    },
+    {
+      "pipeline": "chembl_tissue",
+      "config": "configs/pipelines/chembl/tissue.yaml",
+      "bronze_generator": "configs/data_schema/chembl/tissue.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#chembl_tissue",
+      "gold_generator": "src/bioetl/domain/schemas/chembl/tissue.py"
+    },
+    {
+      "pipeline": "composite_activity",
+      "config": "configs/pipelines/composite/activity.yaml",
+      "bronze_generator": "configs/data_schema/composite/activity.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#composite_activity",
+      "gold_generator": "src/bioetl/domain/schemas/composite/activity.py"
+    },
+    {
+      "pipeline": "composite_assay",
+      "config": "configs/pipelines/composite/assay.yaml",
+      "bronze_generator": "configs/data_schema/composite/assay.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#composite_assay",
+      "gold_generator": "src/bioetl/domain/schemas/composite/assay.py"
+    },
+    {
+      "pipeline": "composite_molecule",
+      "config": "configs/pipelines/composite/molecule.yaml",
+      "bronze_generator": "configs/data_schema/composite/molecule.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#composite_molecule",
+      "gold_generator": "src/bioetl/domain/schemas/composite/molecule.py"
+    },
+    {
+      "pipeline": "composite_publication",
+      "config": "configs/pipelines/composite/publication.yaml",
+      "bronze_generator": "configs/data_schema/composite/publication.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#composite_publication",
+      "gold_generator": "src/bioetl/domain/schemas/composite/publication.py"
+    },
+    {
+      "pipeline": "composite_target",
+      "config": "configs/pipelines/composite/target.yaml",
+      "bronze_generator": "configs/data_schema/composite/target.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#composite_target",
+      "gold_generator": "src/bioetl/domain/schemas/composite/target.py"
+    },
+    {
+      "pipeline": "crossref_publication",
+      "config": "configs/pipelines/crossref/publication.yaml",
+      "bronze_generator": "configs/data_schema/crossref/publication.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#crossref_publication",
+      "gold_generator": "src/bioetl/domain/schemas/crossref/publication.py"
+    },
+    {
+      "pipeline": "openalex_publication",
+      "config": "configs/pipelines/openalex/publication.yaml",
+      "bronze_generator": "configs/data_schema/openalex/publication.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#openalex_publication",
+      "gold_generator": "src/bioetl/domain/schemas/openalex/publication.py"
+    },
+    {
+      "pipeline": "pubchem_compound",
+      "config": "configs/pipelines/pubchem/compound.yaml",
+      "bronze_generator": "configs/data_schema/pubchem/compound.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#pubchem_compound",
+      "gold_generator": "src/bioetl/domain/schemas/pubchem/compound.py"
+    },
+    {
+      "pipeline": "pubmed_publication",
+      "config": "configs/pipelines/pubmed/publication.yaml",
+      "bronze_generator": "configs/data_schema/pubmed/publication.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#pubmed_publication",
+      "gold_generator": "src/bioetl/domain/schemas/pubmed/publication.py"
+    },
+    {
+      "pipeline": "semanticscholar_publication",
+      "config": "configs/pipelines/semanticscholar/publication.yaml",
+      "bronze_generator": "configs/data_schema/semanticscholar/publication.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#semanticscholar_publication",
+      "gold_generator": "src/bioetl/domain/schemas/semanticscholar/publication.py"
+    },
+    {
+      "pipeline": "uniprot_idmapping",
+      "config": "configs/pipelines/uniprot/idmapping.yaml",
+      "bronze_generator": "configs/data_schema/uniprot/idmapping.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#uniprot_idmapping",
+      "gold_generator": "src/bioetl/domain/schemas/uniprot/idmapping.py"
+    },
+    {
+      "pipeline": "uniprot_protein",
+      "config": "configs/pipelines/uniprot/protein.yaml",
+      "bronze_generator": "configs/data_schema/uniprot/protein.yaml",
+      "silver_generator": "src/bioetl/infrastructure/schemas/silver.py#uniprot_protein",
+      "gold_generator": "src/bioetl/domain/schemas/uniprot/protein.py"
+    }
+  ]
+}

--- a/scripts/check_schema_inventory.py
+++ b/scripts/check_schema_inventory.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""CI check for root schema inventory, generators, and orphan detection.
+
+Checks model-like schema definitions in configured roots and validates that each
+schema has at least one usage in runtime code or tests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+DEFAULT_CONFIG = Path("configs/schema_roots.yaml")
+
+MODEL_TYPES = ("BaseModel", "dataclass", "TypedDict", "Protocol", "Pandera")
+
+
+@dataclass(frozen=True)
+class SchemaSymbol:
+    name: str
+    model_type: str
+    file: Path
+    line: int
+
+
+def _is_name(node: ast.expr, *targets: str) -> bool:
+    if isinstance(node, ast.Name):
+        return node.id in targets
+    if isinstance(node, ast.Attribute):
+        return node.attr in targets
+    return False
+
+
+def classify_class(node: ast.ClassDef) -> set[str]:
+    types: set[str] = set()
+
+    if any(_is_name(base, "BaseModel") for base in node.bases):
+        types.add("BaseModel")
+    if any(_is_name(base, "TypedDict") for base in node.bases):
+        types.add("TypedDict")
+    if any(_is_name(base, "Protocol") for base in node.bases):
+        types.add("Protocol")
+    if any(_is_name(base, "DataFrameModel") for base in node.bases):
+        types.add("Pandera")
+
+    for deco in node.decorator_list:
+        if isinstance(deco, ast.Call):
+            if _is_name(deco.func, "dataclass"):
+                types.add("dataclass")
+        elif _is_name(deco, "dataclass"):
+            types.add("dataclass")
+
+    return types
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def iter_python_files(globs: list[str]) -> list[Path]:
+    files: set[Path] = set()
+    for pattern in globs:
+        files.update(Path().glob(pattern))
+    return sorted(f for f in files if f.is_file() and f.suffix == ".py")
+
+
+def collect_symbols(files: list[Path]) -> list[SchemaSymbol]:
+    result: list[SchemaSymbol] = []
+    for file in files:
+        tree = ast.parse(file.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef):
+                for model_type in classify_class(node):
+                    result.append(
+                        SchemaSymbol(
+                            name=node.name,
+                            model_type=model_type,
+                            file=file,
+                            line=node.lineno,
+                        )
+                    )
+    return result
+
+
+def collect_usages(symbols: list[SchemaSymbol], usage_globs: list[str]) -> dict[str, set[Path]]:
+    all_files = iter_python_files(usage_globs)
+    by_name: dict[str, set[Path]] = defaultdict(set)
+
+    symbol_names = {symbol.name for symbol in symbols}
+    defining_files: dict[str, set[Path]] = defaultdict(set)
+    for symbol in symbols:
+        defining_files[symbol.name].add(symbol.file)
+
+    for file in all_files:
+        identifiers = set(re.findall(r"[A-Za-z_][A-Za-z0-9_]*", file.read_text(encoding="utf-8")))
+        for name in identifiers.intersection(symbol_names):
+            if file not in defining_files[name]:
+                by_name[name].add(file)
+
+    return by_name
+
+
+def build_medallion_generation_block(config_glob: str, generators: dict[str, Any]) -> list[dict[str, str]]:
+    block: list[dict[str, str]] = []
+    for cfg in sorted(Path().glob(config_glob)):
+        if cfg.name.startswith("_"):
+            continue
+        rel = cfg.as_posix()
+        parts = cfg.parts
+        try:
+            i = parts.index("pipelines")
+            provider, entity = parts[i + 1], cfg.stem
+        except (ValueError, IndexError):
+            continue
+
+        block.append(
+            {
+                "pipeline": f"{provider}_{entity}",
+                "config": rel,
+                "bronze_generator": generators["bronze_template"].format(
+                    provider=provider, entity=entity
+                ),
+                "silver_generator": generators["silver_template"].format(
+                    provider=provider, entity=entity
+                ),
+                "gold_generator": generators["gold_template"].format(
+                    provider=provider, entity=entity
+                ),
+            }
+        )
+    return block
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--report-json", type=Path)
+    parser.add_argument("--fail-on-orphans", action="store_true")
+    args = parser.parse_args()
+
+    cfg = load_config(args.config)
+    schema_files = iter_python_files(cfg["root_schema_globs"])
+    symbols = collect_symbols(schema_files)
+    usages = collect_usages(symbols, cfg["usage_globs"])
+
+    inventory: dict[str, list[dict[str, Any]]] = {k: [] for k in MODEL_TYPES}
+    for symbol in symbols:
+        inventory[symbol.model_type].append(
+            {
+                "name": symbol.name,
+                "file": symbol.file.as_posix(),
+                "line": symbol.line,
+                "usages": sorted(path.as_posix() for path in usages.get(symbol.name, set())),
+            }
+        )
+
+    orphans = [
+        item
+        for t in MODEL_TYPES
+        for item in inventory[t]
+        if not item["usages"]
+    ]
+
+    medallion_block = build_medallion_generation_block(
+        cfg["pipeline_config_glob"], cfg["medallion_generators"]
+    )
+
+    report = {
+        "root_schema_globs": cfg["root_schema_globs"],
+        "inventory": inventory,
+        "summary": {k: len(v) for k, v in inventory.items()},
+        "orphans": orphans,
+        "medallion_schema_generation": medallion_block,
+    }
+
+    print("Schema inventory summary:")
+    for k in MODEL_TYPES:
+        print(f"  - {k}: {report['summary'][k]}")
+    print(f"  - Orphans: {len(orphans)} (usage includes tests/**)")
+    print(
+        "  - Medallion generation entries: "
+        f"{len(report['medallion_schema_generation'])} from {cfg['pipeline_config_glob']}"
+    )
+
+    if args.report_json:
+        args.report_json.parent.mkdir(parents=True, exist_ok=True)
+        args.report_json.write_text(
+            json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+        print(f"Report written to: {args.report_json}")
+
+    if orphans:
+        print("\nOrphan schemas:")
+        for orphan in orphans:
+            print(f"  - {orphan['name']} ({orphan['file']}:{orphan['line']})")
+        if args.fail_on_orphans:
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Replace the legacy `application/transformers/schemas` scope with explicit root paths for schema discovery to centralize schema ownership and detection. 
- Provide a deterministic inventory of model-like schema definitions and surface orphan schemas so CI can enforce cleanup and prevent drift. 
- Tie medallion schema generation targets to the actual pipeline configs under `configs/pipelines/**` to keep generation mapping current. 
- Expose a strict CI gate that fails when new orphans are introduced while allowing local, non-blocking audits.

### Description

- Added `scripts/check_schema_inventory.py`, a CI/audit script that scans configured root globs and inventories model types `BaseModel`, `dataclass`, `TypedDict`, `Protocol`, and Pandera (`DataFrameModel`).
- Introduced `configs/schema_roots.yaml` as the single source of truth with `root_schema_globs`, `usage_globs` (includes `tests/**`), `pipeline_config_glob`, and medallion generator templates.
- The script performs orphan detection by scanning usages across `src/**/*.py` and `tests/**/*.py`, emits an `inventory` with per-type entries and a `medallion_schema_generation` block built from `configs/pipelines/**/*.yaml`.
- Added documentation `docs/05-operations/verification/schema-inventory-ci.md` describing roots, model kinds, orphan rules (tests count as valid usage), medallion mapping, and CI usage; added `Makefile` target `schema-inventory-check` to run strict CI mode.
- Committed a baseline artifact `reports/schema_inventory_report.json` produced by the script to make the current inventory and orphan list visible for follow-up.

### Testing

- Ran the script in non-blocking/report mode: `python scripts/check_schema_inventory.py --report-json reports/schema_inventory_report.json` and it produced `reports/schema_inventory_report.json` (succeeded). 
- Verified strict mode behaviour: `python scripts/check_schema_inventory.py --fail-on-orphans --report-json reports/schema_inventory_report.json` returned non-zero as expected and listed current orphan schemas (items surfaced for remediation). 
- Syntax/byte-compile check: `python -m compileall scripts/check_schema_inventory.py` succeeded. 
- The new `Makefile` target `schema-inventory-check` runs the strict mode (`python scripts/check_schema_inventory.py --fail-on-orphans --report-json reports/schema_inventory_report.json`) and can be used in CI to enforce no-orphans policy.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986892bf7ec83249508e96bc117402e)