### PR TITLE
docs(audit): уточнить scope и критерии сложности для аудита пайплайнов (промт §4.2)

### DIFF
--- a/.claude/prompts/00-Audit/02-architecture-audit.md
+++ b/.claude/prompts/00-Audit/02-architecture-audit.md
@@ -206,6 +206,43 @@ grep -r "from bioetl.application" src/bioetl/domain/
 | Нарушения слоёв | 0 | `grep` rules | Да |
 | print() в коде | 0 | `grep -r "print("` | Да |
 
+### 4.2. Scope и граф зависимостей для аудита пайплайнов
+
+При анализе архитектурной сложности и связности пайплайнов использовать **только следующий scope**:
+
+- `src/bioetl/application/pipelines/**`
+- `src/bioetl/application/core/**`
+- `src/bioetl/application/services/**`
+- `src/bioetl/infrastructure/adapters/*`
+- `src/bioetl/composition/factories/*`
+
+Провайдеры, для которых MUST выполняться явный анализ:
+
+- `chembl`
+- `pubchem`
+- `uniprot`
+- `crossref`
+- `openalex`
+- `semanticscholar`
+- `pubmed`
+
+Для каждого pipeline execution path MUST быть построен и проверен граф зависимостей между:
+
+1. `application/pipelines`
+2. `application/core`
+3. `application/services`
+4. `infrastructure/adapters/*`
+5. `composition/factories/*`
+
+Критерий сложности (кандидат на упрощение):
+
+- `>7` файлов на один `pipeline execution path`.
+
+Отчёт MUST содержать блок "было/стало" для каждого пайплайна:
+
+- количество файлов на execution path;
+- количество классов на execution path.
+
 ## Ограничения
 
 - Не выдумывай файлы или код, которых нет в проекте


### PR DESCRIPTION
### Motivation
- Устранить неоднозначности в промте архитектурного аудита §4.2 и зафиксировать однозначный scope для анализа пайплайнов. 
- Явно определить набор провайдеров и границы графа зависимостей, чтобы сделать проверки воспроизводимыми и автоматизируемыми. 
- Ввести критерий сложности и требование отчёта «было/стало» для оценки рефакторингов и кандидатов на упрощение.

### Description
- Обновлён файл `.claude/prompts/00-Audit/02-architecture-audit.md` для раздела `4.2` с новым scope: `src/bioetl/application/pipelines/**`, `src/bioetl/application/core/**`, `src/bioetl/application/services/**`, `src/bioetl/infrastructure/adapters/*`, `src/bioetl/composition/factories/*`.
- Добавлен явный список провайдеров для обязательного анализа: `chembl`, `pubchem`, `uniprot`, `crossref`, `openalex`, `semanticscholar`, `pubmed`.
- Уточнён требуемый граф зависимостей для каждого pipeline execution path (application/pipelines → application/core → application/services → infrastructure/adapters/* → composition/factories/*), добавлен критерий сложности `>7` файлов = кандидат на упрощение и требование отчёта по количеству файлов и классов ("было/стало").

### Testing
- Нет изменений кода; валидация выполнена простыми автоматизированными проверками файловой разницы и коммита: `git diff -- .claude/prompts/00-Audit/02-architecture-audit.md` (содержимое соответствует ожидаемым вставкам) и `git commit` завершился успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986892acf7c8324ba41d2f0037c1573)