### PR TITLE
Add mandatory module consolidation migration requirements (3-layer / 2-layer / hybrid)

### DIFF
--- a/docs/02-architecture/module-consolidation-migration-requirements.md
+++ b/docs/02-architecture/module-consolidation-migration-requirements.md
@@ -1,0 +1,163 @@
+# Требования к плану консолидации модулей BioETL
+
+*Статус: Draft (обязательные критерии для RFC/ADR и implementation plan).*  
+*Область: `src/bioetl/**`.*
+
+## 1) Обязательная карта перемещения модулей по каждому варианту
+
+Для каждого варианта (`3-layer`, `2-layer`, `hybrid`) план **MUST** содержать явную карту:
+- исходный путь `src/bioetl/...`
+- целевой путь
+- тип изменения (`move`, `split`, `merge`, `re-export shim`)
+- критерий готовности (тест/линт/арх-тест)
+
+### 1.1 Вариант A — 3-layer (core / adapters / entrypoints)
+
+| Source (`src/bioetl/...`) | Target (`src/bioetl/...`) | Change type | Done when |
+|---|---|---|---|
+| `domain/**` | `core/domain/**` | move | architecture tests pass |
+| `application/**` | `core/application/**` | move | unit + integration pass |
+| `infrastructure/**` | `adapters/infrastructure/**` | move | adapter contract tests pass |
+| `composition/**` | `entrypoints/composition/**` | move | bootstrap smoke tests pass |
+| `interfaces/**` | `entrypoints/interfaces/**` | move | CLI e2e pass |
+| `domain/ports/**` | `core/ports/**` | split (stable API) | Protocol imports updated |
+
+### 1.2 Вариант B — 2-layer (core / runtime)
+
+| Source (`src/bioetl/...`) | Target (`src/bioetl/...`) | Change type | Done when |
+|---|---|---|---|
+| `domain/**` | `core/domain/**` | move | domain purity tests pass |
+| `application/**` | `core/usecases/**` | move+rename | pipeline tests pass |
+| `infrastructure/**` | `runtime/infrastructure/**` | move | storage+adapter tests pass |
+| `composition/**` | `runtime/bootstrap/**` | merge | DI tests pass |
+| `interfaces/**` | `runtime/interfaces/**` | move | CLI + orchestration tests pass |
+| `domain/ports/**` | `core/contracts/**` | rename | Protocol/ABC count stable |
+
+### 1.3 Вариант C — hybrid (сохранить 5 слоёв, но укрупнить feature-пакеты)
+
+| Source (`src/bioetl/...`) | Target (`src/bioetl/...`) | Change type | Done when |
+|---|---|---|---|
+| `application/pipelines/{provider}/**` | `application/features/{provider}/**` | move | provider e2e tests pass |
+| `infrastructure/adapters/{provider}/**` | `infrastructure/features/{provider}/adapters/**` | move | contract tests pass |
+| `domain/schemas/{provider}/**` | `domain/features/{provider}/schemas/**` | move | schema contract tests pass |
+| `composition/providers/**` | `composition/features/{provider}/registration/**` | split | registry tests pass |
+| `interfaces/cli/commands/**` | `interfaces/cli/features/{provider}/**` | move | CLI command tests pass |
+
+> Примечание: для каждого перемещения MUST быть временный compatibility re-export (не более 1 релизного цикла).
+
+---
+
+## 2) Обязательный стартовый набор leaf-модулей
+
+Каждый вариант консолидации MUST начинаться с листьев графа зависимостей (leaf modules), чтобы минимизировать blast radius.
+
+### Required leaf-модули (Wave 0)
+
+1. `src/bioetl/domain/value_objects/**`
+2. `src/bioetl/domain/exceptions/**`
+3. `src/bioetl/domain/contracts/gold/**`
+4. `src/bioetl/domain/schemas/common/**`
+5. `src/bioetl/infrastructure/serialization/**`
+6. `src/bioetl/infrastructure/security/**`
+7. `src/bioetl/interfaces/cli/commands/health.py`
+8. `src/bioetl/application/observability/**`
+
+**Правило запуска миграции:**
+- До перехода к Wave 1 (provider pipelines) все leaf-модули из списка выше должны быть перемещены и покрыты regression-тестами.
+
+---
+
+## 3) Rollback strategy (обязательная)
+
+Для каждого этапа миграции MUST быть:
+
+1. **Отдельная ветка:** `refactor/consolidation-stage-{N}-{slug}`
+2. **Тег до этапа:** `pre-consolidation-stage-{N}`
+3. **Тег после этапа:** `post-consolidation-stage-{N}`
+4. **Документ rollback-команд:**
+   - `git checkout pre-consolidation-stage-{N}`
+   - `git revert <stage_commit_range>`
+   - `git checkout -b rollback/stage-{N}`
+
+### Stage template
+
+| Stage | Branch | Pre-tag | Post-tag | Rollback owner |
+|---|---|---|---|---|
+| 0 (leaf modules) | `refactor/consolidation-stage-0-leaf` | `pre-consolidation-stage-0` | `post-consolidation-stage-0` | Tech Lead |
+| 1 (provider features) | `refactor/consolidation-stage-1-features` | `pre-consolidation-stage-1` | `post-consolidation-stage-1` | Module Owner |
+| 2 (bootstrap/interfaces) | `refactor/consolidation-stage-2-entrypoints` | `pre-consolidation-stage-2` | `post-consolidation-stage-2` | Release Engineer |
+
+---
+
+## 4) Метрики успеха (обязательные KPI)
+
+План MUST фиксировать baseline и target по метрикам:
+
+1. **Число слоёв** (`layer_count`)
+2. **Число интерфейсов** (`protocol_abc_count`, суммарно `typing.Protocol` + `ABC`)
+3. **Coupling между слоями** (`cross_layer_imports_count`)
+
+### Метрики и пороги
+
+| Metric | Baseline | Target | Rule |
+|---|---:|---:|---|
+| `layer_count` | current | option-specific | не увеличивать вне выбранного варианта |
+| `protocol_abc_count` | current | >= baseline | нельзя терять контракты без ADR |
+| `cross_layer_imports_count` | current | -20% minimum | снижение связанности между слоями |
+
+### Минимальные команды сбора
+
+```bash
+# Layer count (по верхнеуровневым пакетам выбранного варианта)
+find src/bioetl -maxdepth 2 -type d
+
+# Protocol + ABC count
+rg -n "class .*\(Protocol\)|class .*\(ABC\)" src/bioetl
+
+# Coupling (межслойные импорты, затем вручную классифицировать)
+rg -n "^from bioetl\.|^import bioetl\." src/bioetl
+```
+
+---
+
+## 5) Диаграммы “до/после” в Mermaid (обязательно)
+
+Для каждого варианта MUST быть две диаграммы:
+1. **AS-IS** (до)
+2. **TO-BE** (после)
+
+Минимум — dependency view на уровне слоёв/крупных пакетов.
+
+### Mermaid шаблон (AS-IS)
+
+```mermaid
+flowchart LR
+    D[domain] -->|ports| A[application]
+    A --> I[infrastructure]
+    C[composition] --> D
+    C --> A
+    C --> I
+    X[interfaces] --> C
+```
+
+### Mermaid шаблон (TO-BE, пример hybrid)
+
+```mermaid
+flowchart LR
+    DF[domain/features/*] --> AP[application/features/*]
+    AP --> IF[infrastructure/features/*]
+    CP[composition/features/*] --> DF
+    CP --> AP
+    XP[interfaces/cli/features/*] --> CP
+```
+
+---
+
+## 6) Definition of Done для RFC/ADR по консолидации
+
+RFC/ADR считается неполным, если отсутствует хотя бы один артефакт:
+- [ ] Карты перемещения модулей для всех 3 вариантов
+- [ ] Mandatory leaf-модули для Wave 0
+- [ ] Stage-based rollback strategy (branch + pre/post tags)
+- [ ] KPI baseline/target по слоям, Protocol/ABC, coupling
+- [ ] Mermaid диаграммы AS-IS/TO-BE для каждого варианта


### PR DESCRIPTION
### Motivation
- Provide a single, auditable checklist that all consolidation RFC/ADR and implementation plans MUST satisfy for any chosen consolidation option (3-layer / 2-layer / hybrid). 
- Reduce migration risk by forcing explicit move-maps, a minimal Wave‑0 of leaf modules, stage-based rollback, measurable KPIs and required before/after diagrams. 

### Description
- Add `docs/02-architecture/module-consolidation-migration-requirements.md` which defines concrete `src/bioetl/...` → target paths and change types for the three variants (`3-layer`, `2-layer`, `hybrid`). 
- Require a Wave‑0 list of leaf modules to migrate first and a rule that Wave‑1 may only start after those leaf modules are moved and regression-tested. 
- Define a stage-based rollback strategy (per-stage branch + `pre-/post-` tags + rollback commands) and a stage template with owners. 
- Introduce mandatory success metrics (`layer_count`, `protocol_abc_count`, `cross_layer_imports_count`) with collection commands and require Mermaid AS‑IS / TO‑BE diagrams and a Definition of Done checklist for RFC/ADR. 

### Testing
- This is a documentation-only change so no automated unit/integration tests were modified or required. 
- Per-change verification performed: file created and committed (`git commit` succeeded), and content inspected with `sed -n` and `nl -ba` to ensure the document was written as intended. 
- A PR was created via the repo helper after the commit and the new file is present at `docs/02-architecture/module-consolidation-migration-requirements.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698689319684832497637fb8fc0110ed)