### PR TITLE
Add extraction-level filtering params for ChEMBL Activity API

### DIFF
--- a/configs/filter/entities/chembl/activity.yaml
+++ b/configs/filter/entities/chembl/activity.yaml
@@ -20,6 +20,52 @@ input_filter:
   filter_field: "activity_id"
   batch_size: 20
 
+# ---------------------------------------------------------------------------
+# Extraction-Level Filtering (ADR-028 §3)
+# ---------------------------------------------------------------------------
+# Server-side query parameters appended to every ChEMBL Activity API request.
+# Syntax: ChEMBL django-style lookups (__in, __isnull, __gt, __lt, etc.)
+# Reference: https://chembl.gitbook.io/chembl-interface-documentation/web-services/chembl-data-web-services
+#
+# These params reduce API traffic from ~20M to ~2-5M records.
+# Does NOT affect content_hash (ADR-014).
+# Logged in SourceMetadata.query_string for audit/reproducibility.
+#
+# Resulting API URL pattern:
+#   /chembl/api/data/activity?format=json&limit=1000&offset=0
+#     &standard_type__in=IC50,Ki
+#     &standard_units=nM
+#     &standard_relation==
+#     &assay_type__in=B,F
+#     &potential_duplicate=0
+#     &data_validity_comment__isnull=true
+#     &pchembl_value__isnull=false
+#     &standard_flag=1
+extraction_params:
+  # Measurement types: IC50 (inhibitor concentration) and Ki (inhibition constant)
+  standard_type__in: "IC50,Ki"
+
+  # Standardized units: nanomolar only
+  standard_units: "nM"
+
+  # Exact measurements only (exclude censored: >, <, ~)
+  standard_relation: "="
+
+  # Assay types: Binding and Functional (exclude ADMET, Toxicity, etc.)
+  assay_type__in: "B,F"
+
+  # Exclude potential duplicate records
+  potential_duplicate: 0
+
+  # Exclude records flagged with data validity issues
+  data_validity_comment__isnull: true
+
+  # Only records with standardized pChEMBL value
+  pchembl_value__isnull: false
+
+  # Only ChEMBL-standardized values (manual curation flag)
+  standard_flag: 1
+
 # -----------------------------------------------------------------------------
 # Gold Filters
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds server-side query parameters to the ChEMBL Activity API configuration to filter records at the extraction stage, reducing API traffic and improving data quality without affecting content hashing.

## Changes
- **Added `extraction_params` section** to `configs/filter/entities/chembl/activity.yaml` with 7 filtering parameters:
  - `standard_type__in`: Limits to IC50 and Ki measurement types
  - `standard_units`: Restricts to nanomolar (nM) units only
  - `standard_relation`: Includes only exact measurements (excludes censored values like >, <, ~)
  - `assay_type__in`: Filters to Binding and Functional assays only
  - `potential_duplicate`: Excludes potential duplicate records
  - `data_validity_comment__isnull`: Excludes records with data validity flags
  - `pchembl_value__isnull`: Includes only records with standardized pChEMBL values
  - `standard_flag`: Includes only ChEMBL-standardized values (manual curation)

## Implementation Details
- Uses ChEMBL django-style lookup syntax (`__in`, `__isnull`, etc.) compatible with the ChEMBL API
- Reduces API traffic from ~20M to ~2-5M records
- Does not affect content hashing (per ADR-014)
- Query parameters are logged in `SourceMetadata.query_string` for audit and reproducibility
- Includes comprehensive documentation with API URL pattern example and rationale for each parameter
- References ADR-028 §3 for architectural decision context

https://claude.ai/code/session_01Eif5sdcLF6bmmPoao5dZTo