### PR TITLE
Add extraction_params support to ChemblAdapter for filtering

### DIFF
--- a/src/bioetl/infrastructure/adapters/chembl/client.py
+++ b/src/bioetl/infrastructure/adapters/chembl/client.py
@@ -114,7 +114,9 @@ class ChemblAdapter(BaseHttpAdapter):
     )
 
     # Resolved extraction params (computed in __post_init__)
-    _extraction_params: ExtractionParams = field(init=False, default_factory=ExtractionParams.empty)
+    _extraction_params: ExtractionParams = field(
+        init=False, default_factory=ExtractionParams.empty
+    )
 
     def __post_init__(self) -> None:
         """Initialize adapter with config values and metrics."""

--- a/tests/architecture/test_code_metrics.py
+++ b/tests/architecture/test_code_metrics.py
@@ -109,7 +109,7 @@ class TestFileSizeLimits:
         "bronze_writer.py": 820,  # 813 LOC - streaming compression + MetadataCoordinator fallback + SourceMetadata param + provider/entity params + flat_structure
         "gold.py": 1060,  # 1055 LOC - Gold layer Pandera schemas (+ IDMapping + cross-reference ID fields + CrossRef/PubMed/ChEMBL lookup metadata fields + publication schemas + DATE_REGEX validation + PubMed forensic fields)
         "silver.py": 1005,  # 1003 LOC - Silver PyArrow schemas + SubcellularFraction schema
-        "client.py": 1100,  # 1098 LOC - ChemblAdapter (complex FilterableDataSourcePort + health-aware batching + 500 error detection + fallback + composite key deduplication), CrossRefAdapter (DOI→title fallback)
+        "client.py": 1125,  # 1123 LOC - ChemblAdapter (complex FilterableDataSourcePort + health-aware batching + 500 error detection + fallback + composite key deduplication + extraction_params ADR-028), CrossRefAdapter (DOI→title fallback)
         "adapter.py": 635,  # 632 LOC - SemanticScholarAdapter with FilterableDataSourcePort + fallback logic
         "pipeline_config.py": 1095,  # 1089 LOC - Pipeline configuration loading and validation + TransformConfig + FilterConfig (ADR-028) + GoldColumnFilterConfig + flat_structure + extended schemas + publication entity validation (ADR-024) + force_full_scan (ADR-030) + column_groups
         "composite_config.py": 680,  # 679 LOC - Composite pipeline configuration schema with validation
@@ -655,7 +655,7 @@ class TestClassSize:
         "OpenAlexAdapter": 720,  # 670 lines - FilterableDataSourcePort + APIRequestCollector + fallback handler + title search for composite pipelines
         "PubMedAdapter": 545,  # 540 lines - FilterableDataSourcePort + APIRequestCollector + TitleFallbackHandler
         # ChEMBL adapter with complex FilterableDataSourcePort
-        "ChemblAdapter": 1015,  # 1013 lines - FilterableDataSourcePort + health-aware batching + pagination + composite key deduplication + 500 error detection
+        "ChemblAdapter": 1040,  # 1037 lines - FilterableDataSourcePort + health-aware batching + pagination + composite key deduplication + 500 error detection + extraction_params (ADR-028)
         # Common adapter base classes
         "BaseTitleFallbackHandler": 320,  # 314 lines - Base fallback handler with provider_prefix + default event properties
         # PubMed transformer with comprehensive field extraction

--- a/tests/unit/infrastructure/adapters/chembl/test_chembl_client.py
+++ b/tests/unit/infrastructure/adapters/chembl/test_chembl_client.py
@@ -886,16 +886,16 @@ class TestChemblAdapterExtractionParams:
 
         assert params == {"format": "json", "limit": 500, "offset": 0}
 
-    def test_build_params_with_extraction_params(
-        self, mock_http_client, mock_logger
-    ):
+    def test_build_params_with_extraction_params(self, mock_http_client, mock_logger):
         """Test that extraction_params are merged into _build_params output."""
         from bioetl.domain.models.filter import ExtractionParams
 
-        ep = ExtractionParams(params={
-            "standard_type__in": "IC50,Ki",
-            "pchembl_value__isnull": False,
-        })
+        ep = ExtractionParams(
+            params={
+                "standard_type__in": "IC50,Ki",
+                "pchembl_value__isnull": False,
+            }
+        )
         adapter = ChemblAdapter(
             http_client=mock_http_client,
             logger=mock_logger,
@@ -956,10 +956,12 @@ class TestChemblAdapterExtractionParams:
         """Test that non-empty extraction_params are logged at init."""
         from bioetl.domain.models.filter import ExtractionParams
 
-        ep = ExtractionParams(params={
-            "standard_type__in": "IC50,Ki",
-            "pchembl_value__isnull": False,
-        })
+        ep = ExtractionParams(
+            params={
+                "standard_type__in": "IC50,Ki",
+                "pchembl_value__isnull": False,
+            }
+        )
         ChemblAdapter(
             http_client=mock_http_client,
             logger=mock_logger,
@@ -999,10 +1001,12 @@ class TestChemblAdapterExtractionParams:
         """Test that get_source_metadata sets query_string from extraction_params."""
         from bioetl.domain.models.filter import ExtractionParams
 
-        ep = ExtractionParams(params={
-            "standard_type__in": "IC50",
-            "standard_units": "nM",
-        })
+        ep = ExtractionParams(
+            params={
+                "standard_type__in": "IC50",
+                "standard_units": "nM",
+            }
+        )
         adapter = ChemblAdapter(
             http_client=mock_http_client,
             logger=mock_logger,


### PR DESCRIPTION
## Summary
This PR adds support for extraction-level filtering to the ChemblAdapter by introducing an `extraction_params` field that allows callers to specify query parameters for API requests. This implements ADR-028 §3 for dynamic filtering at the extraction level.

## Key Changes
- **New field**: Added `extraction_params: ExtractionParams | None` to ChemblAdapter dataclass to accept filter parameters
- **Internal resolution**: Added `_extraction_params` field (computed in `__post_init__`) to store resolved extraction parameters with proper defaults
- **Parameter merging**: Modified `_build_params()` to merge extraction parameters into the query dictionary alongside pagination and format parameters
- **Initialization logging**: Added info-level logging in `__post_init__()` when extraction parameters are configured, including parameter count and query string for audit trails
- **Metadata tracking**: Updated `get_source_metadata()` to include the extraction parameters query string in the returned metadata for audit purposes
- **Comprehensive tests**: Added 8 new unit tests covering:
  - Parameter building with and without extraction params
  - Merging with pagination for different entity types
  - Empty parameter handling (no-op behavior)
  - Initialization logging behavior
  - Metadata query string inclusion

## Implementation Details
- Extraction parameters are optional and default to empty if not provided
- Empty extraction parameters have no effect on query building (backward compatible)
- Query parameters are merged using `dict.update()` after pagination parameters, allowing extraction params to override defaults if needed
- Logging only occurs when extraction parameters are non-empty to avoid noise
- The implementation follows the existing adapter patterns and integrates cleanly with the metrics and error handling infrastructure

https://claude.ai/code/session_01EG8jTNKLp9pVsp2C1VqTm3