### PR TITLE
Add extraction_params threading and overlap validation (ADR-028 §3)

### DIFF
--- a/src/bioetl/composition/providers/registration.py
+++ b/src/bioetl/composition/providers/registration.py
@@ -26,6 +26,7 @@ from bioetl.composition.providers.provider_registry import (
     ProviderConfig,
     ProviderRegistry,
 )
+from bioetl.domain.models.filter import ExtractionParams
 
 # Import adapter classes from Infrastructure (allowed direction)
 from bioetl.infrastructure.adapters.chembl.client import ChemblAdapter
@@ -60,6 +61,40 @@ if TYPE_CHECKING:
     from bioetl.infrastructure.schemas.pipeline_config import PipelineYamlConfig
 
 
+def _validate_extraction_input_filter_overlap(
+    extraction_params: ExtractionParams,
+    input_filter: InputFilterConfig,
+    logger: LoggerPort,
+) -> None:
+    """Warn if input_filter field overlaps extraction_params keys.
+
+    Both are applied as AND in API query. Overlap means one might
+    shadow the other. Log WARNING but do not block.
+    """
+    if not input_filter.enabled or extraction_params.is_empty:
+        return
+
+    filter_field = input_filter.filter_field
+    if filter_field and filter_field in extraction_params.params:
+        logger.warning(
+            "extraction_params_input_filter_overlap",
+            overlap_field=filter_field,
+            extraction_value=str(extraction_params.params[filter_field]),
+            resolution="input_filter will override extraction_params for this field",
+        )
+
+    # Check multi-column mode
+    if input_filter.columns:
+        for col in input_filter.columns:
+            if col.filter_field in extraction_params.params:
+                logger.warning(
+                    "extraction_params_input_filter_overlap",
+                    overlap_field=col.filter_field,
+                    extraction_value=str(extraction_params.params[col.filter_field]),
+                    resolution="input_filter will override",
+                )
+
+
 def _create_chembl_data_source(
     settings: Settings,
     pipeline_config: PipelineYamlConfig,
@@ -82,12 +117,22 @@ def _create_chembl_data_source(
     # Load adapter configuration from YAML (single source of truth)
     adapter_config = _get_adapter_config("chembl", default_page_size=1000)
 
+    # Build ExtractionParams from pipeline config (ADR-028 §3)
+    extraction_params = ExtractionParams(params=pipeline_config.extraction_params)
+
+    # Validate overlap between extraction_params and input_filter
+    if filter_config is not None:
+        _validate_extraction_input_filter_overlap(
+            extraction_params, filter_config, logger
+        )
+
     base_adapter = DataSourceFactory.create(
         "chembl",
         http_client=http_client,
         logger=logger,
         adapter_config=adapter_config,
         metrics=metrics,
+        extraction_params=extraction_params,
     )
 
     # Wrap with PublicationTermDataSource for derived entity extraction

--- a/src/bioetl/infrastructure/config_loader.py
+++ b/src/bioetl/infrastructure/config_loader.py
@@ -252,7 +252,7 @@ def _merge_filter_config(
     filter_config: dict[str, Any],
     explicit_entity_config: dict[str, Any],
 ) -> None:
-    """Merge filter config (input_filter, gold_filters) into pipeline config.
+    """Merge filter config (input_filter, gold_filters, extraction_params) into pipeline config.
 
     Merge priority (highest to lowest):
     1. Explicit entity config (from pipeline YAML file)
@@ -294,6 +294,16 @@ def _merge_filter_config(
             )
 
         config["gold_filters"] = merged_gold_filters
+
+    # Merge extraction_params (ADR-028 §3)
+    if "extraction_params" in filter_config:
+        merged_extraction_params = dict(filter_config["extraction_params"])
+
+        # Pipeline-level overrides take precedence
+        if "extraction_params" in explicit_entity_config:
+            merged_extraction_params.update(explicit_entity_config["extraction_params"])
+
+        config["extraction_params"] = merged_extraction_params
 
 
 def _load_column_groups_section(

--- a/src/bioetl/infrastructure/schemas/pipeline_config.py
+++ b/src/bioetl/infrastructure/schemas/pipeline_config.py
@@ -983,6 +983,11 @@ class PipelineYamlConfig(BaseModel):
         default_factory=list,
         description="Optional column ordering groups for Silver/Gold output",
     )
+    extraction_params: dict[str, str | int | bool] = Field(
+        default_factory=dict,
+        description="Server-side API query parameters for Bronze extraction (ADR-028 §3). "
+        "Merged from filter config file. Keys are provider-specific query params.",
+    )
 
     # Pagination strategy (ADR-030)
     force_full_scan: bool = Field(

--- a/tests/architecture/test_code_metrics.py
+++ b/tests/architecture/test_code_metrics.py
@@ -97,7 +97,7 @@ class TestFileSizeLimits:
         "bootstrap.py": 450,  # 420 LOC - main DI wiring
         "composite.py": 515,  # 512 LOC - Composite pipeline bootstrap with runner factories + field group registry loading + DQ report service
         "entrypoints.py": 110,  # 102 LOC - Re-export facade (split to _pipeline_execution, _resource_management, _services)
-        "registration.py": 610,  # 604 LOC - provider registration (config helpers extracted to _config_helpers.py)
+        "registration.py": 655,  # 651 LOC - provider registration (config helpers extracted to _config_helpers.py) + extraction_params overlap validation (ADR-028 §3)
         "storage_adapter.py": 660,  # 655 LOC - storage adapter with Bronze/Silver/Gold writers + BronzeWriteResult + SilverWriteResult + SourceMetadata param + Silver lineage
         # Consolidated factory files (v5.2)
         "pipeline_factory.py": 820,  # 814 LOC - merged generic_factory + runner_assembly + entity_type helper + DQ context factory + flat_structure paths + MetadataCoordinator creation + pipeline_name propagation
@@ -111,7 +111,7 @@ class TestFileSizeLimits:
         "silver.py": 1005,  # 1003 LOC - Silver PyArrow schemas + SubcellularFraction schema
         "client.py": 1125,  # 1123 LOC - ChemblAdapter (complex FilterableDataSourcePort + health-aware batching + 500 error detection + fallback + composite key deduplication + extraction_params ADR-028), CrossRefAdapter (DOI→title fallback)
         "adapter.py": 635,  # 632 LOC - SemanticScholarAdapter with FilterableDataSourcePort + fallback logic
-        "pipeline_config.py": 1095,  # 1089 LOC - Pipeline configuration loading and validation + TransformConfig + FilterConfig (ADR-028) + GoldColumnFilterConfig + flat_structure + extended schemas + publication entity validation (ADR-024) + force_full_scan (ADR-030) + column_groups
+        "pipeline_config.py": 1100,  # 1098 LOC - Pipeline configuration loading and validation + TransformConfig + FilterConfig (ADR-028) + GoldColumnFilterConfig + flat_structure + extended schemas + publication entity validation (ADR-024) + force_full_scan (ADR-030) + column_groups + extraction_params
         "composite_config.py": 680,  # 679 LOC - Composite pipeline configuration schema with validation
         # Interfaces layer exemptions
         "cli.py": 550,  # 536 LOC - CLI commands, options, vacuum-all

--- a/tests/unit/composition/providers/test_extraction_params_registration.py
+++ b/tests/unit/composition/providers/test_extraction_params_registration.py
@@ -1,0 +1,311 @@
+"""Tests for extraction_params threading from filter config to ChemblAdapter.
+
+Verifies:
+- ExtractionParams are passed from pipeline config to ChemblAdapter
+- Overlap validation between extraction_params and input_filter
+- Other providers handle extraction_params gracefully (empty params)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bioetl.domain.filtering import FilterColumn, InputFilterConfig
+from bioetl.domain.models.filter import ExtractionParams
+from bioetl.composition.providers.registration import (
+    _validate_extraction_input_filter_overlap,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def logger() -> MagicMock:
+    """Mock LoggerPort."""
+    return MagicMock()
+
+
+@pytest.fixture()
+def active_extraction_params() -> ExtractionParams:
+    """Non-empty ExtractionParams."""
+    return ExtractionParams(
+        params={
+            "standard_type__in": "IC50,Ki",
+            "standard_units": "nM",
+            "assay_type__in": "B,F",
+        }
+    )
+
+
+@pytest.fixture()
+def empty_extraction_params() -> ExtractionParams:
+    """Empty ExtractionParams."""
+    return ExtractionParams.empty()
+
+
+@pytest.fixture()
+def enabled_input_filter() -> InputFilterConfig:
+    """Enabled single-column InputFilterConfig."""
+    return InputFilterConfig(
+        enabled=True,
+        source_path="data/input/ids.csv",
+        column_name="activity_id",
+        filter_field="activity_id",
+        batch_size=20,
+    )
+
+
+@pytest.fixture()
+def disabled_input_filter() -> InputFilterConfig:
+    """Disabled InputFilterConfig."""
+    return InputFilterConfig(enabled=False)
+
+
+@pytest.fixture()
+def overlapping_input_filter() -> InputFilterConfig:
+    """InputFilterConfig whose filter_field overlaps extraction_params."""
+    return InputFilterConfig(
+        enabled=True,
+        source_path="data/input/ids.csv",
+        column_name="type_col",
+        filter_field="standard_type__in",
+        batch_size=20,
+    )
+
+
+@pytest.fixture()
+def multi_column_overlapping_filter() -> InputFilterConfig:
+    """Multi-column InputFilterConfig with overlapping column."""
+    return InputFilterConfig(
+        enabled=True,
+        source_path="data/input/multi.csv",
+        columns=(
+            FilterColumn(column_name="type_col", filter_field="standard_type__in"),
+            FilterColumn(column_name="unit_col", filter_field="target_chembl_id"),
+        ),
+        batch_size=20,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Overlap Validation Tests
+# ---------------------------------------------------------------------------
+
+
+class TestOverlapValidation:
+    """Tests for _validate_extraction_input_filter_overlap."""
+
+    def test_overlap_validation_warns_on_conflict(
+        self,
+        active_extraction_params: ExtractionParams,
+        overlapping_input_filter: InputFilterConfig,
+        logger: MagicMock,
+    ) -> None:
+        """Warning is logged when filter_field overlaps extraction_params key."""
+        _validate_extraction_input_filter_overlap(
+            active_extraction_params, overlapping_input_filter, logger
+        )
+
+        logger.warning.assert_called_once()
+        call_args = logger.warning.call_args
+        assert call_args[0][0] == "extraction_params_input_filter_overlap"
+        assert call_args[1]["overlap_field"] == "standard_type__in"
+
+    def test_overlap_validation_silent_when_no_overlap(
+        self,
+        active_extraction_params: ExtractionParams,
+        enabled_input_filter: InputFilterConfig,
+        logger: MagicMock,
+    ) -> None:
+        """No warning when filter_field does not overlap extraction_params."""
+        _validate_extraction_input_filter_overlap(
+            active_extraction_params, enabled_input_filter, logger
+        )
+
+        logger.warning.assert_not_called()
+
+    def test_overlap_validation_skipped_when_input_filter_disabled(
+        self,
+        active_extraction_params: ExtractionParams,
+        disabled_input_filter: InputFilterConfig,
+        logger: MagicMock,
+    ) -> None:
+        """No warning when input_filter is disabled."""
+        _validate_extraction_input_filter_overlap(
+            active_extraction_params, disabled_input_filter, logger
+        )
+
+        logger.warning.assert_not_called()
+
+    def test_overlap_validation_skipped_when_extraction_empty(
+        self,
+        empty_extraction_params: ExtractionParams,
+        enabled_input_filter: InputFilterConfig,
+        logger: MagicMock,
+    ) -> None:
+        """No warning when extraction_params is empty."""
+        _validate_extraction_input_filter_overlap(
+            empty_extraction_params, enabled_input_filter, logger
+        )
+
+        logger.warning.assert_not_called()
+
+    def test_overlap_validation_multi_column_overlap(
+        self,
+        active_extraction_params: ExtractionParams,
+        multi_column_overlapping_filter: InputFilterConfig,
+        logger: MagicMock,
+    ) -> None:
+        """Warning logged for each overlapping column in multi-column mode."""
+        _validate_extraction_input_filter_overlap(
+            active_extraction_params, multi_column_overlapping_filter, logger
+        )
+
+        # Only standard_type__in overlaps, target_chembl_id does not
+        assert logger.warning.call_count == 1
+        call_args = logger.warning.call_args
+        assert call_args[1]["overlap_field"] == "standard_type__in"
+
+
+# ---------------------------------------------------------------------------
+# ChemblAdapter extraction_params passthrough
+# ---------------------------------------------------------------------------
+
+
+class TestExtractionParamsPassedToAdapter:
+    """Test that extraction_params reaches ChemblAdapter via DataSourceFactory."""
+
+    @patch(
+        "bioetl.composition.providers.registration._get_factories",
+    )
+    @patch(
+        "bioetl.composition.providers.registration._get_adapter_config",
+    )
+    def test_extraction_params_passed_to_adapter(
+        self,
+        mock_get_adapter_config: MagicMock,
+        mock_get_factories: MagicMock,
+    ) -> None:
+        """ExtractionParams from pipeline_config reaches DataSourceFactory.create."""
+        from bioetl.composition.providers.registration import (
+            _create_chembl_data_source,
+        )
+
+        # Setup mocks
+        mock_factory = MagicMock()
+        mock_http_factory = MagicMock()
+        mock_get_factories.return_value = (mock_factory, mock_http_factory)
+        mock_get_adapter_config.return_value = MagicMock()
+
+        mock_settings = MagicMock()
+        mock_logger = MagicMock()
+        mock_pipeline_config = MagicMock()
+        mock_pipeline_config.extraction_params = {
+            "standard_type__in": "IC50,Ki",
+            "standard_units": "nM",
+        }
+        mock_pipeline_config.entity_type = "activity"
+
+        _create_chembl_data_source(
+            settings=mock_settings,
+            pipeline_config=mock_pipeline_config,
+            logger=mock_logger,
+        )
+
+        # Verify DataSourceFactory.create was called with extraction_params
+        mock_factory.create.assert_called_once()
+        call_kwargs = mock_factory.create.call_args
+        extraction_params = call_kwargs[1].get("extraction_params") or call_kwargs[
+            1
+        ].get("extraction_params")
+
+        assert extraction_params is not None
+        assert isinstance(extraction_params, ExtractionParams)
+        assert extraction_params.params["standard_type__in"] == "IC50,Ki"
+        assert extraction_params.params["standard_units"] == "nM"
+
+    @patch(
+        "bioetl.composition.providers.registration._get_factories",
+    )
+    @patch(
+        "bioetl.composition.providers.registration._get_adapter_config",
+    )
+    def test_empty_extraction_params_when_not_configured(
+        self,
+        mock_get_adapter_config: MagicMock,
+        mock_get_factories: MagicMock,
+    ) -> None:
+        """Empty ExtractionParams when pipeline has no extraction_params."""
+        from bioetl.composition.providers.registration import (
+            _create_chembl_data_source,
+        )
+
+        mock_factory = MagicMock()
+        mock_http_factory = MagicMock()
+        mock_get_factories.return_value = (mock_factory, mock_http_factory)
+        mock_get_adapter_config.return_value = MagicMock()
+
+        mock_settings = MagicMock()
+        mock_logger = MagicMock()
+        mock_pipeline_config = MagicMock()
+        mock_pipeline_config.extraction_params = {}
+        mock_pipeline_config.entity_type = "activity"
+
+        _create_chembl_data_source(
+            settings=mock_settings,
+            pipeline_config=mock_pipeline_config,
+            logger=mock_logger,
+        )
+
+        call_kwargs = mock_factory.create.call_args[1]
+        extraction_params = call_kwargs["extraction_params"]
+        assert extraction_params.is_empty
+
+
+# ---------------------------------------------------------------------------
+# Other providers: unpack triple without error
+# ---------------------------------------------------------------------------
+
+
+class TestOtherProvidersUnpackTriple:
+    """Verify PipelineYamlConfig.extraction_params defaults to empty dict.
+
+    Other providers (PubChem, UniProt, etc.) do not use extraction_params
+    but must not break when the field is present in pipeline config.
+    """
+
+    def test_pipeline_config_extraction_params_defaults_empty(self) -> None:
+        """PipelineYamlConfig has extraction_params defaulting to empty dict."""
+        from bioetl.infrastructure.schemas.pipeline_config import PipelineYamlConfig
+
+        config = PipelineYamlConfig(
+            pipeline_name="pubchem_compound",
+            provider="pubchem",
+            entity_type="compound",
+            primary_keys=["compound_id"],
+            silver_table="compound",
+        )
+        assert config.extraction_params == {}
+
+    def test_pipeline_config_accepts_extraction_params(self) -> None:
+        """PipelineYamlConfig accepts extraction_params from YAML."""
+        from bioetl.infrastructure.schemas.pipeline_config import PipelineYamlConfig
+
+        config = PipelineYamlConfig(
+            pipeline_name="chembl_activity",
+            provider="chembl",
+            entity_type="activity",
+            primary_keys=["activity_id"],
+            silver_table="activity",
+            extraction_params={
+                "standard_type__in": "IC50,Ki",
+                "standard_units": "nM",
+            },
+        )
+        assert config.extraction_params["standard_type__in"] == "IC50,Ki"
+        assert config.extraction_params["standard_units"] == "nM"

--- a/tests/unit/infrastructure/config/test_filter_config_loader.py
+++ b/tests/unit/infrastructure/config/test_filter_config_loader.py
@@ -421,6 +421,81 @@ class TestFilterConfigFile:
         assert range_filter.include_max is False
 
 
+class TestFilterConfigLoaderExtractionParams:
+    """Tests for extraction_params loading via FilterConfigLoader."""
+
+    def test_extraction_params_default_empty(self, loader: FilterConfigLoader) -> None:
+        """Extraction params should be empty when not configured."""
+        _, _, extraction_params = loader.load("test_provider", "test_entity")
+        assert extraction_params.is_empty
+
+    def test_extraction_params_from_entity_config(self, tmp_path: Path) -> None:
+        """Extraction params should be loaded from entity config."""
+        filter_root = tmp_path / "filter"
+        filter_root.mkdir()
+
+        (filter_root / "_defaults.yaml").write_text(
+            """
+version: "1.0.0"
+input_filter:
+  enabled: false
+  batch_size: 100
+gold_filters:
+  required_fields: []
+"""
+        )
+
+        entities = filter_root / "entities" / "chembl"
+        entities.mkdir(parents=True)
+        (entities / "activity.yaml").write_text(
+            """
+version: "1.0.0"
+provider: chembl
+entity: activity
+extraction_params:
+  standard_type__in: "IC50,Ki"
+  standard_units: "nM"
+  potential_duplicate: 0
+  data_validity_comment__isnull: true
+"""
+        )
+
+        loader = FilterConfigLoader(tmp_path)
+        _, _, extraction_params = loader.load("chembl", "activity")
+
+        assert not extraction_params.is_empty
+        assert extraction_params.params["standard_type__in"] == "IC50,Ki"
+        assert extraction_params.params["standard_units"] == "nM"
+        assert extraction_params.params["potential_duplicate"] == 0
+        assert extraction_params.params["data_validity_comment__isnull"] is True
+
+    def test_extraction_params_inline_override(self, tmp_path: Path) -> None:
+        """Inline overrides should update extraction_params."""
+        filter_root = tmp_path / "filter"
+        filter_root.mkdir()
+
+        (filter_root / "_defaults.yaml").write_text(
+            """
+version: "1.0.0"
+input_filter:
+  enabled: false
+gold_filters:
+  required_fields: []
+extraction_params:
+  standard_type__in: "IC50"
+"""
+        )
+
+        loader = FilterConfigLoader(tmp_path)
+        _, _, extraction_params = loader.load(
+            "any",
+            "any",
+            inline_overrides={"extraction_params": {"standard_type__in": "Ki"}},
+        )
+
+        assert extraction_params.params["standard_type__in"] == "Ki"
+
+
 class TestFilterConfigLoaderIntegration:
     """Integration tests with actual filter config structure."""
 


### PR DESCRIPTION
## Summary
Implements server-side API query parameter support for Bronze extraction by threading `extraction_params` from pipeline configuration through to the ChemblAdapter, with validation to warn about overlaps with input_filter settings.

## Key Changes

- **New validation function** `_validate_extraction_input_filter_overlap()` in `registration.py` that warns (but doesn't block) when `extraction_params` keys overlap with `input_filter.filter_field`, since both are applied as AND in API queries and one could shadow the other.

- **ExtractionParams threading** in `_create_chembl_data_source()`:
  - Builds `ExtractionParams` from `pipeline_config.extraction_params`
  - Validates overlap with input_filter before passing to DataSourceFactory
  - Passes `extraction_params` to ChemblAdapter via factory

- **Config schema updates**:
  - Added `extraction_params: dict[str, str | int | bool]` field to `PipelineYamlConfig` with default empty dict
  - Updated `_merge_filter_config()` in config_loader to merge extraction_params from filter config files with pipeline-level overrides taking precedence

- **Comprehensive test coverage**:
  - Unit tests for overlap validation (single-column and multi-column modes)
  - Tests verifying extraction_params are passed through to adapter
  - Tests confirming other providers handle empty extraction_params gracefully
  - Integration tests for FilterConfigLoader extraction_params loading

- **Documentation**: Updated code metrics and docstrings to reference ADR-028 §3

## Implementation Details

- Overlap validation is non-blocking (logs WARNING only) to allow flexibility in filter composition
- Empty `ExtractionParams` are handled gracefully across all providers
- Filter config merging follows established priority: explicit entity config > defaults
- All changes maintain backward compatibility (extraction_params defaults to empty dict)

https://claude.ai/code/session_01J16z3m1346LxtGaYaWYrJf