### PR TITLE
Increase PubMed ID maximum validation limit to 10 billion

### DIFF
--- a/configs/dq/entities/chembl/publication.yaml
+++ b/configs/dq/entities/chembl/publication.yaml
@@ -37,7 +37,7 @@ entity_field_validations:
   - field: pmid
     type: range
     min: 1
-    max: 100000000
+    max: 10000000000
     nullable: true
     error_message: "PubMed ID must be a positive integer"
 

--- a/configs/dq/entities/openalex/publication.yaml
+++ b/configs/dq/entities/openalex/publication.yaml
@@ -21,7 +21,7 @@ entity_field_validations:
   - field: pmid
     type: range
     min: 1
-    max: 100000000
+    max: 10000000000
     nullable: true
     error_message: "PubMed ID must be a positive integer"
 

--- a/configs/dq/entities/pubmed/publication.yaml
+++ b/configs/dq/entities/pubmed/publication.yaml
@@ -15,7 +15,7 @@ entity_field_validations:
   - field: pmid
     type: range
     min: 1
-    max: 100000000
+    max: 10000000000
     nullable: false
     error_message: "PMID is required and must be a positive integer"
 

--- a/configs/dq/entities/semanticscholar/publication.yaml
+++ b/configs/dq/entities/semanticscholar/publication.yaml
@@ -21,7 +21,7 @@ entity_field_validations:
   - field: pmid
     type: range
     min: 1
-    max: 100000000
+    max: 10000000000
     nullable: true
     error_message: "PubMed ID must be a positive integer"
 

--- a/configs/dq/providers/pubmed.yaml
+++ b/configs/dq/providers/pubmed.yaml
@@ -20,7 +20,7 @@ provider_field_validations:
   - field: pmid
     type: range
     min: 1
-    max: 100000000
+    max: 10000000000
     nullable: true
     error_message: "PMID must be a positive integer"
 

--- a/src/bioetl/infrastructure/storage/gold_writer.py
+++ b/src/bioetl/infrastructure/storage/gold_writer.py
@@ -700,11 +700,7 @@ class GoldWriter(BaseDeltaWriter):
         for attempt in range(3):
             try:
                 await self._run_in_executor(
-                    lambda table_or_uri=table_path,
-                    data=arrow_data,
-                    mode=mode,
-                    partition_by=partition_cols,
-                    schema_mode=schema_mode: (
+                    lambda table_or_uri=table_path, data=arrow_data, mode=mode, partition_by=partition_cols, schema_mode=schema_mode: (
                         write_deltalake(
                             table_or_uri=table_or_uri,
                             data=pa.RecordBatchReader.from_batches(
@@ -794,10 +790,7 @@ class GoldWriter(BaseDeltaWriter):
                         records, column_order=column_order
                     )
                     await self._run_in_executor(
-                        lambda table_or_uri=table_path,
-                        data=arrow_data,
-                        mode="append",
-                        partition_by=partition_cols: (
+                        lambda table_or_uri=table_path, data=arrow_data, mode="append", partition_by=partition_cols: (
                             write_deltalake(
                                 table_or_uri=table_or_uri,
                                 data=pa.RecordBatchReader.from_batches(


### PR DESCRIPTION
## Summary
Updated the maximum validation limit for PubMed IDs (PMID) across all publication entity configurations and the PubMed provider from 100 million to 10 billion to accommodate the growing number of publications in PubMed.

## Changes
- Updated PMID maximum range validation from `100000000` to `10000000000` in:
  - `configs/dq/entities/chembl/publication.yaml`
  - `configs/dq/entities/openalex/publication.yaml`
  - `configs/dq/entities/pubmed/publication.yaml`
  - `configs/dq/entities/semanticscholar/publication.yaml`
  - `configs/dq/providers/pubmed.yaml`

## Details
This change increases the upper bound for PMID validation by 100x (from 10^8 to 10^10), allowing the system to accept and validate PubMed IDs that exceed the previous 100 million limit. The minimum validation threshold (1) and nullable settings remain unchanged for each configuration.

https://claude.ai/code/session_01Mem9G9aXMqnMpFkGXMgKKv