### PR TITLE
Add pattern validation for empty/whitespace-only titles

### DIFF
--- a/configs/dq/entities/chembl/publication.yaml
+++ b/configs/dq/entities/chembl/publication.yaml
@@ -53,6 +53,13 @@ entity_field_validations:
     nullable: true
     error_message: "Title must not exceed 2000 characters"
 
+  - field: title
+    type: pattern
+    pattern: '\S'
+    nullable: true
+    severity: warn
+    error_message: "Title should not be empty or whitespace-only"
+
 # =============================================================================
 # Cross-Field Validations
 # =============================================================================

--- a/configs/dq/entities/pubmed/publication.yaml
+++ b/configs/dq/entities/pubmed/publication.yaml
@@ -25,6 +25,13 @@ entity_field_validations:
     nullable: true
     error_message: "Title must not exceed 2000 characters"
 
+  - field: title
+    type: pattern
+    pattern: '\S'
+    nullable: true
+    severity: warn
+    error_message: "Title should not be empty or whitespace-only"
+
   - field: doi
     type: pattern
     pattern: '^10\.\d{4,}/.+$'

--- a/src/bioetl/infrastructure/storage/gold_writer.py
+++ b/src/bioetl/infrastructure/storage/gold_writer.py
@@ -700,11 +700,7 @@ class GoldWriter(BaseDeltaWriter):
         for attempt in range(3):
             try:
                 await self._run_in_executor(
-                    lambda table_or_uri=table_path,
-                    data=arrow_data,
-                    mode=mode,
-                    partition_by=partition_cols,
-                    schema_mode=schema_mode: (
+                    lambda table_or_uri=table_path, data=arrow_data, mode=mode, partition_by=partition_cols, schema_mode=schema_mode: (
                         write_deltalake(
                             table_or_uri=table_or_uri,
                             data=pa.RecordBatchReader.from_batches(
@@ -794,10 +790,7 @@ class GoldWriter(BaseDeltaWriter):
                         records, column_order=column_order
                     )
                     await self._run_in_executor(
-                        lambda table_or_uri=table_path,
-                        data=arrow_data,
-                        mode="append",
-                        partition_by=partition_cols: (
+                        lambda table_or_uri=table_path, data=arrow_data, mode="append", partition_by=partition_cols: (
                             write_deltalake(
                                 table_or_uri=table_or_uri,
                                 data=pa.RecordBatchReader.from_batches(


### PR DESCRIPTION
## Summary
Add pattern-based validation rules to detect empty or whitespace-only titles in publication entities across ChEMBL and PubMed data sources.

## Changes
- Added pattern validation (`\S`) to the `title` field in both ChEMBL and PubMed publication configurations
- Validation is set to warning severity to flag suspicious data without blocking ingestion
- Pattern ensures titles contain at least one non-whitespace character
- Applied consistently across both data sources for uniform data quality standards

## Implementation Details
- Uses regex pattern `\S` to match any non-whitespace character
- Configured as nullable to respect existing null handling behavior
- Warning severity allows data quality monitoring without strict enforcement
- Error message clearly indicates the validation purpose: "Title should not be empty or whitespace-only"

https://claude.ai/code/session_019paxbY3vSwy2PHCiTYxSxk