### PR TITLE
Standardize publication year filters across all data sources

### DIFF
--- a/configs/filter/entities/chembl/publication.yaml
+++ b/configs/filter/entities/chembl/publication.yaml
@@ -32,10 +32,10 @@ gold_filters:
 
   # Numeric range filters
   ranges:
-    # Scientific journals era cutoff (schema allows 1500..2100)
+    # Standardized publication year filter (1950..2050 inclusive)
     publication_year:
-      min: 1800
-      include_min: false
+      min: 1950
+      max: 2050
 
   # Required fields (pubmed_id and doi are optional - not all publications have them)
   required_fields:

--- a/configs/filter/entities/crossref/publication.yaml
+++ b/configs/filter/entities/crossref/publication.yaml
@@ -29,10 +29,10 @@ input_filter:
 gold_filters:
   # Numeric range filters
   ranges:
-    # Scientific journals era cutoff (schema allows 1500..2100)
+    # Standardized publication year filter (1950..2050 inclusive)
     publication_year:
-      min: 1800
-      max: 2100
+      min: 1950
+      max: 2050
 
   # Required fields
   required_fields:

--- a/configs/filter/entities/openalex/publication.yaml
+++ b/configs/filter/entities/openalex/publication.yaml
@@ -29,10 +29,10 @@ input_filter:
 gold_filters:
   # Numeric range filters
   ranges:
-    # Scientific journals era cutoff (schema allows 1500..2100)
+    # Standardized publication year filter (1950..2050 inclusive)
     publication_year:
-      min: 1800
-      max: 2100
+      min: 1950
+      max: 2050
 
   # Required fields
   required_fields:

--- a/configs/filter/entities/pubmed/publication.yaml
+++ b/configs/filter/entities/pubmed/publication.yaml
@@ -29,10 +29,10 @@ input_filter:
 gold_filters:
   # Numeric range filters
   ranges:
-    # Scientific journals era cutoff (schema allows 1500..2100)
+    # Standardized publication year filter (1950..2050 inclusive)
     publication_year:
-      min: 1800
-      max: 2100
+      min: 1950
+      max: 2050
 
   # Required fields
   required_fields:

--- a/configs/filter/entities/semanticscholar/publication.yaml
+++ b/configs/filter/entities/semanticscholar/publication.yaml
@@ -29,10 +29,10 @@ input_filter:
 gold_filters:
   # Numeric range filters
   ranges:
-    # Scientific journals era cutoff (schema allows 1500..2100)
+    # Standardized publication year filter (1950..2050 inclusive)
     publication_year:
-      min: 1800
-      max: 2100
+      min: 1950
+      max: 2050
 
   # Required fields
   required_fields:

--- a/tests/snapshots/pipeline_configs.json
+++ b/tests/snapshots/pipeline_configs.json
@@ -749,8 +749,8 @@
           "column": "publication_year",
           "include_max": true,
           "include_min": true,
-          "max_value": 2100.0,
-          "min_value": 1800.0
+          "max_value": 2050.0,
+          "min_value": 1950.0
         }
       ],
       "required_fields": [


### PR DESCRIPTION
## Summary
Updated publication year filter ranges across all data source configurations to use a consistent, standardized range of 1950–2050 (inclusive). This replaces the previous inconsistent approach where different sources used different cutoff years (1800–2100).

## Changes Made
- **ChEMBL**: Updated min year from 1800 to 1950 and removed the `include_min: false` flag; added explicit max year of 2050
- **Crossref**: Updated min year from 1800 to 1950 and max year from 2100 to 2050
- **OpenAlex**: Updated min year from 1800 to 1950 and max year from 2100 to 2050
- **PubMed**: Updated min year from 1800 to 1950 and max year from 2100 to 2050
- **Semantic Scholar**: Updated min year from 1800 to 1950 and max year from 2100 to 2050
- Updated all filter comments to reflect the new standardized range

## Rationale
This change ensures consistent publication filtering across all integrated data sources, improving data quality by:
- Excluding pre-1950 publications that may have incomplete or unreliable metadata
- Establishing a uniform cutoff that aligns with modern scientific publishing practices
- Reducing noise from historical or edge-case publications
- Providing a clear, documented standard for all downstream consumers

https://claude.ai/code/session_01XxwDEZpK6ax1sKd5w7awhg