### PR TITLE
Standardize reference count field naming to citations_made

### DIFF
--- a/configs/dq/entities/crossref/publication.yaml
+++ b/configs/dq/entities/crossref/publication.yaml
@@ -57,6 +57,12 @@ entity_field_validations:
     nullable: true
     error_message: "Citation count must be non-negative"
 
+  - field: citations_made
+    type: range
+    min: 0
+    nullable: true
+    error_message: "Reference count must be non-negative"
+
 # =============================================================================
 # Cross-Field Validations
 # =============================================================================

--- a/configs/dq/entities/openalex/publication.yaml
+++ b/configs/dq/entities/openalex/publication.yaml
@@ -78,7 +78,7 @@ entity_field_validations:
     nullable: true
     error_message: "FWCI must be non-negative"
 
-  - field: reference_count
+  - field: citations_made
     type: range
     min: 0
     nullable: true

--- a/configs/dq/entities/semanticscholar/publication.yaml
+++ b/configs/dq/entities/semanticscholar/publication.yaml
@@ -57,7 +57,7 @@ entity_field_validations:
     nullable: true
     error_message: "Citation count must be non-negative"
 
-  - field: reference_count
+  - field: citations_made
     type: range
     min: 0
     nullable: true


### PR DESCRIPTION
## Summary
This PR standardizes the field naming convention for reference counts across publication entity configurations by renaming `reference_count` to `citations_made` for consistency and clarity.

## Key Changes
- **CrossRef publication config**: Added new validation rule for `citations_made` field (range validation, min: 0, nullable)
- **OpenAlex publication config**: Renamed `reference_count` field to `citations_made` in validation rules
- **Semantic Scholar publication config**: Renamed `reference_count` field to `citations_made` in validation rules

## Implementation Details
- All three data source configurations now use the unified `citations_made` field name for tracking the number of references made by a publication
- Validation rules remain consistent across all sources: range type validation with minimum value of 0, nullable support, and appropriate error messaging
- This change improves data model consistency and makes it easier to work with reference count data across different publication sources

https://claude.ai/code/session_015kUF1R4sXR3sDA3ett7zkg