### PR TITLE
Add citation count range validation across publication sources

### DIFF
--- a/configs/dq/entities/crossref/publication.yaml
+++ b/configs/dq/entities/crossref/publication.yaml
@@ -57,6 +57,14 @@ entity_field_validations:
     nullable: true
     error_message: "Citation count must be non-negative"
 
+  - field: citations_received
+    type: range
+    min: 0
+    max: 10000000
+    nullable: true
+    severity: warn
+    error_message: "Unusually high citation count"
+
   - field: citations_made
     type: range
     min: 0

--- a/configs/dq/entities/openalex/publication.yaml
+++ b/configs/dq/entities/openalex/publication.yaml
@@ -72,6 +72,14 @@ entity_field_validations:
     nullable: true
     error_message: "Citation count must be non-negative"
 
+  - field: citations_received
+    type: range
+    min: 0
+    max: 10000000
+    nullable: true
+    severity: warn
+    error_message: "Unusually high citation count"
+
   - field: fwci
     type: range
     min: 0

--- a/configs/dq/entities/semanticscholar/publication.yaml
+++ b/configs/dq/entities/semanticscholar/publication.yaml
@@ -57,6 +57,14 @@ entity_field_validations:
     nullable: true
     error_message: "Citation count must be non-negative"
 
+  - field: citations_received
+    type: range
+    min: 0
+    max: 10000000
+    nullable: true
+    severity: warn
+    error_message: "Unusually high citation count"
+
   - field: citations_made
     type: range
     min: 0


### PR DESCRIPTION
## Summary
Added data quality validation rules for the `citations_received` field across all publication data sources (Crossref, OpenAlex, and Semantic Scholar) to detect unusually high citation counts.

## Changes
- Added range validation for `citations_received` field in three publication configuration files:
  - `configs/dq/entities/crossref/publication.yaml`
  - `configs/dq/entities/openalex/publication.yaml`
  - `configs/dq/entities/semanticscholar/publication.yaml`

- Validation configuration:
  - **Type**: Range validation
  - **Min**: 0 (non-negative citations)
  - **Max**: 10,000,000 (upper threshold for anomaly detection)
  - **Severity**: Warning (non-blocking)
  - **Nullable**: True (allows null values)
  - **Message**: "Unusually high citation count"

## Implementation Details
The validation is configured as a warning-level check rather than an error, allowing data to pass quality checks while flagging potentially anomalous citation counts for review. The 10 million citation threshold serves as a practical upper bound for detecting data quality issues without being overly restrictive for legitimately highly-cited publications.

https://claude.ai/code/session_01FdTYT2T1o9jCEPKydqhJMx