### PR TITLE
Refine DOI validation to reject whitespace in suffix

### DIFF
--- a/configs/dq/entities/chembl/publication.yaml
+++ b/configs/dq/entities/chembl/publication.yaml
@@ -43,9 +43,9 @@ entity_field_validations:
 
   - field: doi
     type: pattern
-    pattern: '^10\.\d{4,}/.+$'
+    pattern: '^10\.\d{4,}/\S+$'
     nullable: true
-    error_message: "DOI must start with 10. prefix"
+    error_message: "DOI must match format 10.XXXX/suffix (no whitespace)"
 
   - field: title
     type: max_length

--- a/configs/dq/entities/crossref/publication.yaml
+++ b/configs/dq/entities/crossref/publication.yaml
@@ -14,9 +14,9 @@ entity: publication
 entity_field_validations:
   - field: doi
     type: pattern
-    pattern: '^10\.\d{4,}/.+$'
+    pattern: '^10\.\d{4,}/\S+$'
     nullable: false
-    error_message: "DOI is required and must start with 10. prefix"
+    error_message: "DOI is required and must match format 10.XXXX/suffix (no whitespace)"
 
   - field: title
     type: max_length

--- a/configs/dq/entities/openalex/publication.yaml
+++ b/configs/dq/entities/openalex/publication.yaml
@@ -27,9 +27,9 @@ entity_field_validations:
 
   - field: doi
     type: pattern
-    pattern: '^10\.\d{4,}/.+$'
+    pattern: '^10\.\d{4,}/\S+$'
     nullable: true
-    error_message: "DOI must start with 10. prefix"
+    error_message: "DOI must match format 10.XXXX/suffix (no whitespace)"
 
   - field: title
     type: max_length

--- a/configs/dq/entities/pubmed/publication.yaml
+++ b/configs/dq/entities/pubmed/publication.yaml
@@ -27,9 +27,9 @@ entity_field_validations:
 
   - field: doi
     type: pattern
-    pattern: '^10\.\d{4,}/.+$'
+    pattern: '^10\.\d{4,}/\S+$'
     nullable: true
-    error_message: "DOI must start with 10. prefix"
+    error_message: "DOI must match format 10.XXXX/suffix (no whitespace)"
 
   - field: publication_year
     type: range

--- a/configs/dq/entities/semanticscholar/publication.yaml
+++ b/configs/dq/entities/semanticscholar/publication.yaml
@@ -27,9 +27,9 @@ entity_field_validations:
 
   - field: doi
     type: pattern
-    pattern: '^10\.\d{4,}/.+$'
+    pattern: '^10\.\d{4,}/\S+$'
     nullable: true
-    error_message: "DOI must start with 10. prefix"
+    error_message: "DOI must match format 10.XXXX/suffix (no whitespace)"
 
   - field: title
     type: max_length

--- a/configs/dq/providers/crossref.yaml
+++ b/configs/dq/providers/crossref.yaml
@@ -19,9 +19,9 @@ provider_field_validations:
   # DOI format validation (applies to all CrossRef entities)
   - field: doi
     type: pattern
-    pattern: '^10\.\d{4,}/.*$'
+    pattern: '^10\.\d{4,}/\S+$'
     nullable: true
-    error_message: "Invalid DOI format (must start with 10. prefix)"
+    error_message: "Invalid DOI format (must match 10.XXXX/suffix, no whitespace)"
 
   # Year range validation
   - field: publication_year

--- a/configs/dq/providers/openalex.yaml
+++ b/configs/dq/providers/openalex.yaml
@@ -26,9 +26,9 @@ provider_field_validations:
   # DOI format validation
   - field: doi
     type: pattern
-    pattern: '^10\.\d{4,}/.*$'
+    pattern: '^10\.\d{4,}/\S+$'
     nullable: true
-    error_message: "Invalid DOI format (must start with 10. prefix)"
+    error_message: "Invalid DOI format (must match 10.XXXX/suffix, no whitespace)"
 
   # Year range validation
   - field: publication_year

--- a/configs/dq/providers/pubmed.yaml
+++ b/configs/dq/providers/pubmed.yaml
@@ -34,9 +34,9 @@ provider_field_validations:
   # DOI format validation
   - field: doi
     type: pattern
-    pattern: '^10\.\d{4,}/.*$'
+    pattern: '^10\.\d{4,}/\S+$'
     nullable: true
-    error_message: "Invalid DOI format (must start with 10. prefix)"
+    error_message: "Invalid DOI format (must match 10.XXXX/suffix, no whitespace)"
 
   # Year range validation
   - field: publication_year

--- a/configs/dq/providers/semanticscholar.yaml
+++ b/configs/dq/providers/semanticscholar.yaml
@@ -27,9 +27,9 @@ provider_field_validations:
   # DOI format validation
   - field: doi
     type: pattern
-    pattern: '^10\.\d{4,}/.*$'
+    pattern: '^10\.\d{4,}/\S+$'
     nullable: true
-    error_message: "Invalid DOI format (must start with 10. prefix)"
+    error_message: "Invalid DOI format (must match 10.XXXX/suffix, no whitespace)"
 
   # Year range validation
   - field: publication_year

--- a/src/bioetl/domain/schemas/crossref/author.py
+++ b/src/bioetl/domain/schemas/crossref/author.py
@@ -28,7 +28,7 @@ class AuthorSchema(ETLRecordSchema):
     # === Foreign Key ===
     doi: Series[str] = pa.Field(
         nullable=False,
-        str_matches=r"^10\.\d{4,}/.*$",
+        str_matches=r"^10\.\d{4,}/\S+$",
         description="FK to Publication.doi",
     )
 

--- a/src/bioetl/domain/schemas/crossref/funder.py
+++ b/src/bioetl/domain/schemas/crossref/funder.py
@@ -26,7 +26,7 @@ class FunderSchema(ETLRecordSchema):
     # === Foreign Key ===
     doi: Series[str] = pa.Field(
         nullable=False,
-        str_matches=r"^10\.\d{4,}/.*$",
+        str_matches=r"^10\.\d{4,}/\S+$",
         description="FK to Publication.doi",
     )
 

--- a/src/bioetl/domain/schemas/crossref/reference.py
+++ b/src/bioetl/domain/schemas/crossref/reference.py
@@ -25,7 +25,7 @@ class ReferenceSchema(ETLRecordSchema):
     # === Foreign Key ===
     source_doi: Series[str] = pa.Field(
         nullable=False,
-        str_matches=r"^10\.\d{4,}/.*$",
+        str_matches=r"^10\.\d{4,}/\S+$",
         description="DOI of citing publication (FK to Publication.doi)",
     )
 
@@ -39,7 +39,7 @@ class ReferenceSchema(ETLRecordSchema):
     # === Target Reference ===
     target_doi: Series[str] | None = pa.Field(
         nullable=True,
-        str_matches=r"^10\.\d{4,}/.*$",
+        str_matches=r"^10\.\d{4,}/\S+$",
         description="DOI of cited publication (if resolved)",
     )
     unstructured: Series[str] | None = pa.Field(

--- a/src/bioetl/domain/validation.py
+++ b/src/bioetl/domain/validation.py
@@ -345,8 +345,9 @@ def validate_non_empty_string(value: str | None) -> str | None:
 # Format: 10.XXXX/suffix where:
 #   - 10. is the fixed prefix
 #   - XXXX is registrant code (minimum 4 digits)
-#   - suffix is the identifier (minimum 1 character)
-DOI_REGEX_PATTERN: str = r"^10\.\d{4,}/.+$"
+#   - suffix is the identifier (minimum 1 non-whitespace character)
+# Aligned with DOI Value Object: \S+ forbids whitespace in DOI suffix.
+DOI_REGEX_PATTERN: str = r"^10\.\d{4,}/\S+$"
 _DOI_PATTERN = re.compile(DOI_REGEX_PATTERN)
 
 

--- a/tests/unit/domain/schemas/test_doi_validation.py
+++ b/tests/unit/domain/schemas/test_doi_validation.py
@@ -78,12 +78,14 @@ class TestDoiRegexPattern:
 
     def test_pattern_components(self) -> None:
         """Test DOI regex pattern has correct components."""
-        # Pattern should be: ^10\.\d{4,}/.+$
+        # Pattern should be: ^10\.\d{4,}/\S+$
         assert "10\\." in DOI_REGEX_PATTERN, "Pattern should start with '10.'"
         assert "\\d{4,}" in DOI_REGEX_PATTERN, (
             "Pattern should require 4+ digit registrant"
         )
-        assert "/.+" in DOI_REGEX_PATTERN, "Pattern should require non-empty suffix"
+        assert "/\\S+" in DOI_REGEX_PATTERN, (
+            "Pattern should require non-empty suffix without whitespace"
+        )
 
 
 class TestDoiRegexEdgeCases:


### PR DESCRIPTION
## Summary
Updated DOI validation patterns across all data quality configurations, schemas, and validation logic to explicitly reject whitespace characters in the DOI suffix. This ensures stricter validation of DOI format compliance.

## Key Changes
- **Regex Pattern Update**: Changed DOI pattern from `^10\.\d{4,}/.+$` to `^10\.\d{4,}/\S+$`
  - `.+` (any character) → `\S+` (non-whitespace characters)
  - Prevents DOIs with spaces, tabs, or other whitespace in the suffix
  
- **Configuration Files Updated** (8 files):
  - Entity validations: ChEMBL, CrossRef, OpenAlex, PubMed, SemanticScholar
  - Provider validations: CrossRef, OpenAlex, PubMed, SemanticScholar
  
- **Schema Validations Updated** (3 files):
  - `crossref/author.py`: FK validation for `doi` field
  - `crossref/funder.py`: FK validation for `doi` field
  - `crossref/reference.py`: FK validations for `source_doi` and `target_doi` fields
  
- **Core Validation Logic** (`src/bioetl/domain/validation.py`):
  - Updated `DOI_REGEX_PATTERN` constant with improved documentation
  - Added clarification that suffix requires non-whitespace characters
  
- **Test Updates** (`tests/unit/domain/schemas/test_doi_validation.py`):
  - Updated pattern component test to verify `/\S+` instead of `/.+`
  - Enhanced assertion message for clarity

## Implementation Details
- All error messages updated to reflect the stricter validation: "must match format 10.XXXX/suffix (no whitespace)"
- Changes are consistent across all validation layers (config, schema, and domain logic)
- Maintains backward compatibility with valid DOIs while rejecting malformed ones with embedded whitespace

https://claude.ai/code/session_01SXzZhab6NmGNiNkm6VoDc8